### PR TITLE
refactor: remove project owner requirement for IAM policy

### DIFF
--- a/backend/api/v1/workspace_service.go
+++ b/backend/api/v1/workspace_service.go
@@ -56,7 +56,7 @@ func (s *WorkspaceService) SetIamPolicy(ctx context.Context, req *connect.Reques
 		return nil, connect.NewError(connect.CodeAborted, errors.New("there is concurrent update to the workspace iam policy, please refresh and try again"))
 	}
 
-	if _, err := validateIAMPolicy(ctx, s.store, request.Policy, policyMessage); err != nil {
+	if err := validateIAMPolicy(ctx, s.store, request.Policy, policyMessage); err != nil {
 		return nil, err
 	}
 

--- a/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
+++ b/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
@@ -55,25 +55,13 @@
               class="w-full px-2 py-2 flex flex-row justify-start items-center gap-x-1"
             >
               <span class="textlabel">{{ displayRoleTitle(role.role) }}</span>
-              <NTooltip
-                :disabled="
-                  allowRemoveRole(role.role) ||
-                  role.role !== PresetRoleType.PROJECT_OWNER
-                "
+              <MiniActionButton
+                type="error"
+                :disabled="!allowRemoveRole(role.role)"
+                @click.prevent="handleDeleteRole(role.role)"
               >
-                <template #trigger>
-                  <MiniActionButton
-                    type="error"
-                    :disabled="!allowRemoveRole(role.role)"
-                    @click.prevent="handleDeleteRole(role.role)"
-                  >
-                    <TrashIcon class="w-4 h-4" />
-                  </MiniActionButton>
-                </template>
-                <div>
-                  {{ $t("project.members.cannot-remove-last-owner") }}
-                </div>
-              </NTooltip>
+                <TrashIcon class="w-4 h-4" />
+              </MiniActionButton>
             </div>
             <NDataTable
               size="small"
@@ -173,7 +161,6 @@ import {
   checkRoleContainsAnyPermission,
   displayRoleTitle,
   hasProjectPermissionV2,
-  memberMapToRolesInProjectIAM,
 } from "@/utils";
 import { buildConditionExpr, convertFromExpr } from "@/utils/issue/cel";
 import AddProjectMembersPanel from "../AddProjectMember/AddProjectMembersPanel.vue";
@@ -341,30 +328,21 @@ const getDataTableColumns = (
           </MiniActionButton>
           {(roleList.value.find((r) => r.role === role)?.singleBindingList
             ?.length ?? 0) > 1 && (
-            <NTooltip
-              disabled={allowDeleteCondition(singleBinding)}
-              v-slots={{
-                trigger: () => (
-                  <MiniActionButton
-                    type="error"
-                    disabled={!allowDeleteCondition(singleBinding)}
-                    onClick={() => {
-                      const item = roleList.value.find((r) => r.role === role);
-                      if (item) {
-                        const index =
-                          item.singleBindingList.indexOf(singleBinding);
-                        if (index >= 0) {
-                          handleDeleteCondition(item, index);
-                        }
-                      }
-                    }}
-                  >
-                    <TrashIcon class="w-4 h-4" />
-                  </MiniActionButton>
-                ),
-                default: () => t("project.members.cannot-remove-last-owner"),
+            <MiniActionButton
+              type="error"
+              disabled={!allowDeleteCondition(singleBinding)}
+              onClick={() => {
+                const item = roleList.value.find((r) => r.role === role);
+                if (item) {
+                  const index = item.singleBindingList.indexOf(singleBinding);
+                  if (index >= 0) {
+                    handleDeleteCondition(item, index);
+                  }
+                }
               }}
-            />
+            >
+              <TrashIcon class="w-4 h-4" />
+            </MiniActionButton>
           )}
         </div>
       ),
@@ -374,23 +352,12 @@ const getDataTableColumns = (
   return columns;
 };
 
-// To prevent user accidentally removing roles and lock the project permanently, we take following measures:
-// 1. Disallow removing the last OWNER.
-// 2. Allow workspace roles who can manage project. This helps when the project OWNER is no longer available.
-const allowRemoveRole = (role: string) => {
+const allowRemoveRole = (_role: string) => {
   if (props.project.state === State.DELETED) {
     return false;
   }
   if (props.binding.type === "groups") {
     return true;
-  }
-
-  if (role === PresetRoleType.PROJECT_OWNER) {
-    const memberMap = memberMapToRolesInProjectIAM(iamPolicy.value, role);
-    // If there is only one owner, disallow removing.
-    if (memberMap.size <= 1) {
-      return false;
-    }
   }
 
   return true;

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1940,7 +1940,6 @@
       "edit": "Edit member - {member}",
       "view-by-members": "View by members",
       "view-by-roles": "View by roles",
-      "cannot-remove-last-owner": "Cannot remove the last owner of a project",
       "revoke-role-from-user": "Revoke '{role}' from '{user}'",
       "never-expires": "Never",
       "role-description": "Role description",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1940,7 +1940,6 @@
       "edit": "Editar miembro - {member}",
       "view-by-members": "Ver por miembros",
       "view-by-roles": "Ver por roles",
-      "cannot-remove-last-owner": "No se puede eliminar el último propietario de un proyecto",
       "revoke-role-from-user": "Revocar '{role}' de '{user}'",
       "never-expires": "Nunca caduca",
       "role-description": "El rol de un miembro determina qué puede hacer en el proyecto.",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1940,7 +1940,6 @@
       "edit": "メンバーの編集 - {member}",
       "view-by-members": "メンバー別に見る",
       "view-by-roles": "役割ごとに表示",
-      "cannot-remove-last-owner": "プロジェクトの最後の所有者を削除できません",
       "revoke-role-from-user": "「{user}」{role} のロールを削除します",
       "never-expires": "有効期限が切れることはありません",
       "role-description": "役割の説明",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1940,7 +1940,6 @@
       "edit": "Chỉnh sửa thành viên - {member}",
       "view-by-members": "Xem theo thành viên",
       "view-by-roles": "Xem theo vai trò",
-      "cannot-remove-last-owner": "Không thể xóa chủ sở hữu cuối cùng của một dự án",
       "revoke-role-from-user": "Thu hồi '{role}' từ '{user}'",
       "never-expires": "Không bao giờ",
       "role-description": "Mô tả vai trò",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1940,7 +1940,6 @@
       "edit": "编辑成员 - {member}",
       "view-by-members": "按成员查看",
       "view-by-roles": "按角色查看",
-      "cannot-remove-last-owner": "无法移除项目的最后一个所有者",
       "revoke-role-from-user": "删除'{user}'{role}的角色",
       "never-expires": "永不过期",
       "role-description": "角色描述",


### PR DESCRIPTION
## Summary
- Remove the constraint requiring at least one project owner in project IAM policies
- Projects can now have zero owners while workspace admins can still manage them
- Workspace-level admin requirement remains unchanged to prevent complete lockout

## Reasoning
Similar to Google Cloud Platform (GCP), where projects within an organization don't technically require users with primitive `roles/owner` role, Bytebase projects should also support this model. When working within an organizational structure, workspace-level permissions (Workspace Admin, DBA) provide sufficient oversight and management capabilities for projects, even without dedicated project owners.

This change provides:
- **Flexibility**: Projects don't require dedicated owners when workspace admins provide oversight
- **Organizational model**: Workspace admins can manage all projects from the workspace level
- **No lockout risk**: Workspace must still have at least one admin, preventing total access loss

## Changes
### Backend
- Updated `validateIAMPolicy` to remove project owner count check
- Simplified function signature from `(bool, error)` to `error`
- Workspace admin requirement remains intact

### Frontend
- Removed UI validation preventing removal of last project owner
- Removed tooltips showing "cannot remove last owner" message
- Cleaned up unused imports and locale strings

## Test plan
- [ ] Verify project IAM policy can be updated to have zero owners
- [ ] Verify workspace admins can still manage projects without owners
- [ ] Verify workspace IAM policy still requires at least one admin
- [ ] Verify UI allows removing the last project owner
- [ ] Verify no tooltip appears when removing project owners

🤖 Generated with [Claude Code](https://claude.com/claude-code)