### PR TITLE
fix: enforce WHATWG email validation to prevent Unicode homoglyph attacks

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -355,7 +355,7 @@ func (s *AuthService) getOrCreateUserWithIDP(ctx context.Context, request *v1pb.
 	}
 	// The userinfo's email comes from identity provider, it has to be converted to lower-case.
 	email := strings.ToLower(userInfo.Identifier)
-	if err := validateEmail(email); err != nil {
+	if err := common.ValidateEmail(email); err != nil {
 		// If the email is invalid, we will try to use the domain and identifier to construct the email.
 		domain := extractDomain(idp.Domain)
 		if domain != "" {

--- a/backend/api/v1/user_service.go
+++ b/backend/api/v1/user_service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/mail"
 	"regexp"
 	"strings"
 	"time"
@@ -830,7 +829,7 @@ func validateEmailWithDomains(ctx context.Context, licenseService *enterprise.Li
 	if licenseService.IsFeatureEnabled(v1pb.PlanFeature_FEATURE_USER_EMAIL_DOMAIN_RESTRICTION) != nil {
 		// nolint:nilerr
 		// feature not enabled, only validate email and skip domain restriction.
-		if err := validateEmail(email); err != nil {
+		if err := common.ValidateEmail(email); err != nil {
 			return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("invalid email: %v", err.Error()))
 		}
 		return nil
@@ -846,7 +845,7 @@ func validateEmailWithDomains(ctx context.Context, licenseService *enterprise.Li
 	}
 
 	// Check if the email is valid.
-	if err := validateEmail(email); err != nil {
+	if err := common.ValidateEmail(email); err != nil {
 		return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("invalid email: %v", err.Error()))
 	}
 	// Domain restrictions are not applied to service account.
@@ -865,16 +864,6 @@ func validateEmailWithDomains(ctx context.Context, licenseService *enterprise.Li
 		if !ok {
 			return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("email %q does not belong to domains %v", email, allowedDomains))
 		}
-	}
-	return nil
-}
-
-func validateEmail(email string) error {
-	if email != strings.ToLower(email) {
-		return errors.New("email should be lowercase")
-	}
-	if _, err := mail.ParseAddress(email); err != nil {
-		return err
 	}
 	return nil
 }

--- a/backend/common/util.go
+++ b/backend/common/util.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -160,6 +161,25 @@ func ValidatePhone(phone string) error {
 		return errors.New("invalid phone number")
 	}
 	return nil
+}
+
+// emailRegex is based on the WHATWG HTML spec for valid email addresses.
+// https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+// Modified to only allow lowercase letters since Bytebase requires lowercase emails.
+var emailRegex = regexp.MustCompile(`^[a-z0-9.!#$%&'*+/=?^_` + "`" + `{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$`)
+
+// ValidateEmail validates the email address using WHATWG HTML spec.
+// Only lowercase ASCII letters, digits, and standard email symbols are allowed.
+func ValidateEmail(email string) error {
+	if !emailRegex.MatchString(email) {
+		return errors.New("invalid email address")
+	}
+	return nil
+}
+
+// IsValidEmail returns true if the email is valid per WHATWG HTML spec.
+func IsValidEmail(email string) bool {
+	return emailRegex.MatchString(email)
 }
 
 // SanitizeUTF8String returns a copy of the string s with each run of invalid or unprintable UTF-8 byte sequences

--- a/docs/plans/2026-01-19-unicode-email-normalization-design.md
+++ b/docs/plans/2026-01-19-unicode-email-normalization-design.md
@@ -1,0 +1,103 @@
+# Unicode Email Normalization Fix
+
+**Issue**: [#18943](https://github.com/bytebase/bytebase/issues/18943)
+**Date**: 2026-01-19
+
+## Problem
+
+Users can create accounts with visually identical but technically distinct email addresses using Unicode homoglyphs. For example:
+- `testo@gmail.com` (ASCII 'o')
+- `testо@gmail.com` (Cyrillic 'о', U+043E)
+
+This creates security risks: account confusion, privilege mis-assignment, audit ambiguity, and password reset/SSO mismatch.
+
+## Solution
+
+Enforce ASCII-only characters in email addresses for all new account creation and email updates.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Validation scope | Full email (not just local part) | Simpler, eliminates all homoglyph vectors |
+| Migration strategy | Reject new only | Non-breaking, existing accounts unchanged |
+| Validation placement | Frontend + Backend | Immediate UX feedback + authoritative security |
+| Domain handling | ASCII-only (IDN rejected) | Stricter security, simpler implementation |
+
+## Implementation
+
+### Backend
+
+**File**: `backend/api/v1/user_service.go`
+
+Update `validateEmail()`:
+
+```go
+func validateEmail(email string) error {
+    if email != strings.ToLower(email) {
+        return errors.New("email should be lowercase")
+    }
+
+    // Validate entire email contains only ASCII characters
+    for _, r := range email {
+        if r > 127 {
+            return errors.New("email must contain only ASCII characters")
+        }
+    }
+
+    if _, err := mail.ParseAddress(email); err != nil {
+        return err
+    }
+    return nil
+}
+```
+
+**File**: `backend/api/directory-sync/webhook.go`
+
+Add ASCII validation after `normalizeEmail()` calls to reject non-ASCII emails from SCIM providers.
+
+### Frontend
+
+**File**: `frontend/src/components/EmailInput.vue`
+
+Add validation helper:
+
+```typescript
+const isAsciiEmail = (email: string): boolean => {
+  return /^[\x00-\x7F]*$/.test(email);
+};
+```
+
+**File**: `frontend/src/locales/en-US.json`
+
+```json
+{
+  "common": {
+    "email-ascii-only": "Email addresses with special Unicode characters are not supported. Please use standard characters (a-z, 0-9, and common symbols)."
+  }
+}
+```
+
+Add translations to other locale files as needed.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `backend/api/v1/user_service.go` | Add ASCII check in `validateEmail()` |
+| `backend/api/directory-sync/webhook.go` | Add ASCII validation after `normalizeEmail()` |
+| `frontend/src/components/EmailInput.vue` | Add `isAsciiEmail()` validation |
+| `frontend/src/locales/en-US.json` | Add `common.email-ascii-only` message |
+| `frontend/src/locales/zh-CN.json` | Add Chinese translation |
+
+## Testing
+
+- Unit test for `validateEmail()` with ASCII and non-ASCII inputs
+- Frontend test for `EmailInput.vue` validation
+- Manual test: attempt signup with `testо@gmail.com` (Cyrillic о)
+
+## Security Considerations
+
+- Existing accounts with non-ASCII emails remain functional (grandfathered)
+- New validation applies only to create/update operations
+- Backend is the authoritative validation layer; frontend is for UX only

--- a/frontend/src/components/EmailInput.vue
+++ b/frontend/src/components/EmailInput.vue
@@ -1,30 +1,49 @@
 <template>
-  <NInputGroup v-if="enforceDomain && !readonly">
+  <div class="flex flex-col">
+    <NInputGroup v-if="enforceDomain && !readonly">
+      <NInput
+        v-model:value="state.shortValue"
+        :size="size"
+        :disabled="readonly"
+        :status="hasEmailError ? 'error' : undefined"
+      />
+      <NInputGroupLabel :size="size"> @ </NInputGroupLabel>
+      <NSelect
+        :size="size"
+        v-model:value="state.domain"
+        :options="domainSelectOptions"
+        :disabled="readonly"
+      />
+    </NInputGroup>
     <NInput
-      v-model:value="state.shortValue"
+      v-else
+      v-model:value="state.value"
       :size="size"
       :disabled="readonly"
+      :status="hasEmailError ? 'error' : undefined"
     />
-    <NInputGroupLabel :size="size"> @ </NInputGroupLabel>
-    <NSelect
-      :size="size"
-      v-model:value="state.domain"
-      :options="domainSelectOptions"
-      :disabled="readonly"
-    />
-  </NInputGroup>
-  <NInput
-    v-else
-    v-model:value="state.value"
-    :size="size"
-    :disabled="readonly"
-  />
+    <span v-if="hasEmailError" class="text-error text-sm mt-1">
+      {{ t("common.email-ascii-only") }}
+    </span>
+  </div>
 </template>
 
 <script lang="ts" setup>
 import { NInput, NInputGroup, NInputGroupLabel, NSelect } from "naive-ui";
 import { computed, reactive, watch, watchEffect } from "vue";
+import { useI18n } from "vue-i18n";
 import { useSettingV1Store } from "@/store";
+
+const { t } = useI18n();
+
+// WHATWG HTML spec email validation (lowercase only).
+// https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+const emailRegex =
+  /^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/;
+
+const isValidEmail = (email: string): boolean => {
+  return emailRegex.test(email);
+};
 
 interface LocalState {
   // The full email value.
@@ -86,6 +105,16 @@ const domainSelectOptions = computed(() => {
       value,
     };
   });
+});
+
+const hasEmailError = computed(() => {
+  const email = enforceDomain.value
+    ? `${state.shortValue}@${state.domain}`
+    : state.value;
+  if (!email || !email.includes("@")) {
+    return false;
+  }
+  return !isValidEmail(email);
 });
 
 watchEffect(() => {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -20,6 +20,7 @@
     "sign-in-as-admin": "Sign in as administrator",
     "sign-up": "Sign up",
     "email": "Email",
+    "email-ascii-only": "Email addresses only support ASCII characters (letters, numbers, and symbols like . _ - +).",
     "username": "Username",
     "password": "Password",
     "save": "Save",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -20,6 +20,7 @@
     "sign-in-as-admin": "Iniciar sesión como administrador",
     "sign-up": "Registrarse",
     "email": "Correo electrónico",
+    "email-ascii-only": "Las direcciones de correo solo admiten caracteres ASCII (letras, números y símbolos como . _ - +).",
     "username": "Nombre de usuario",
     "password": "Contraseña",
     "save": "Guardar",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -20,6 +20,7 @@
     "sign-in-as-admin": "管理者としてサインイン",
     "sign-up": "登録する",
     "email": "メールアドレス",
+    "email-ascii-only": "メールアドレスは ASCII 文字のみ使用できます（英数字および . _ - + などの記号）。",
     "username": "ユーザー名",
     "password": "パスワード",
     "save": "保存",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -20,6 +20,7 @@
     "sign-in-as-admin": "Đăng nhập với tư cách quản trị viên",
     "sign-up": "Đăng ký",
     "email": "Email",
+    "email-ascii-only": "Địa chỉ email chỉ hỗ trợ ký tự ASCII (chữ cái, số và ký hiệu như . _ - +).",
     "username": "Tên người dùng",
     "password": "Mật khẩu",
     "save": "Lưu",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -20,6 +20,7 @@
     "sign-in-as-admin": "以管理员身份登录",
     "sign-up": "注册",
     "email": "邮箱",
+    "email-ascii-only": "邮箱地址仅支持 ASCII 字符（英文字母、数字及 . _ - + 等符号）。",
     "username": "用户名",
     "password": "密码",
     "save": "保存",


### PR DESCRIPTION
Close BYT-8726

## Summary

- Enforce WHATWG HTML spec email validation to prevent homoglyph attacks
- Only allow lowercase ASCII letters, digits, and standard email symbols
- Reject all non-ASCII characters, control characters, and invisible characters
- Add client-side validation in EmailInput.vue for immediate feedback
- Add i18n error messages for all locales (en-US, zh-CN, es-ES, ja-JP, vi-VN)

## Security Issue

Users could create accounts with visually identical but technically distinct emails using Unicode homoglyphs (e.g., ASCII 'o' vs Cyrillic 'о' U+043E). This creates risks including account confusion, privilege mis-assignment, and audit ambiguity.

## Solution

Use the [WHATWG HTML spec email regex](https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address), modified to only allow lowercase:

```regex
^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$
```

## Test plan

- [ ] Attempt signup with `testо@gmail.com` (Cyrillic о) → should be rejected
- [ ] Attempt signup with `test@gmail.com` → should succeed
- [ ] Verify error message displays in all supported locales

Fixes #18943

🤖 Generated with [Claude Code](https://claude.com/claude-code)