### PR TITLE
fix: increase NSplit resize trigger size for better usability

### DIFF
--- a/frontend/src/components/SchemaEditorLite/SchemaEditorLite.vue
+++ b/frontend/src/components/SchemaEditorLite/SchemaEditorLite.vue
@@ -8,7 +8,7 @@
       :min="0.15"
       :max="0.4"
       :default-size="0.25"
-      :resize-trigger-size="1"
+      :resize-trigger-size="3"
     >
       <template #1>
         <Aside

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TriggersTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TriggersTable.vue
@@ -2,7 +2,7 @@
   <NSplit
     :disabled="!detail"
     :size="detail ? 0.6 : 1"
-    :resize-trigger-size="1"
+    :resize-trigger-size="3"
   >
     <template #1>
       <div class="h-full flex-1 overflow-y-hidden">

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DefinitionViewer.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DefinitionViewer.vue
@@ -4,7 +4,7 @@
     :size="editorPanelSize.size"
     :min="editorPanelSize.min"
     :max="editorPanelSize.max"
-    :resize-trigger-size="1"
+    :resize-trigger-size="3"
     @update:size="handleEditorPanelResize"
   >
     <template #1>

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
@@ -31,7 +31,7 @@
     :size="editorPanelSize.size"
     :min="editorPanelSize.min"
     :max="editorPanelSize.max"
-    :resize-trigger-size="1"
+    :resize-trigger-size="3"
     @update:size="handleEditorPanelResize"
   >
     <template #1>

--- a/frontend/src/views/sql-editor/EditorPanel/StandardPanel/StandardPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/StandardPanel/StandardPanel.vue
@@ -3,7 +3,7 @@
     v-if="!tab || tab.mode === 'WORKSHEET'"
     direction="vertical"
     :max="0.8"
-    :resize-trigger-size="1"
+    :resize-trigger-size="3"
   >
     <template #1>
       <div class="h-full flex flex-col overflow-hidden justify-start items-stretch">
@@ -16,7 +16,7 @@
             :size="editorPanelSize.size"
             :min="editorPanelSize.min"
             :max="editorPanelSize.max"
-            :resize-trigger-size="1"
+            :resize-trigger-size="3"
             @update:size="handleEditorPanelResize"
           >
             <template #1>

--- a/frontend/src/views/sql-editor/SQLEditorHomePage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorHomePage.vue
@@ -32,7 +32,7 @@
       :size="hideSidebar ? 0 : state.sizebarSize"
       :min="0.1"
       :max="0.4"
-      :resize-trigger-size="1"
+      :resize-trigger-size="3"
       @update:size="size => state.sizebarSize = size"
     >
       <template #1>


### PR DESCRIPTION
## Summary

Fixes #BYT-8733

Increases `resize-trigger-size` from 1px to 3px across all NSplit components to improve resize handle usability.

## Root Cause

The migration from `splitpanes` library to Naive UI's `NSplit` component in v3.14.0 introduced 1px resize triggers that were too difficult to grab and drag.

## Changes

Changed `resize-trigger-size` from `1` to `3` pixels in:
- `SQLEditorHomePage.vue` - Main sidebar/worksheet panel
- `StandardPanel.vue` - SQL editor ↔ results panel (vertical) + AI panel (horizontal)
- `SchemaEditorLite.vue` - Schema editor sidebar
- `CodeViewer.vue` - Code viewer AI panel
- `TriggersTable.vue` - Triggers detail panel
- `DefinitionViewer.vue` - Definition viewer AI panel

## Test Plan

- [x] Manual testing: Verified resize handles are easier to grab
- [x] ESLint and Biome checks pass
- [ ] UI testing: Test all affected panels resize smoothly

🤖 Generated with [Claude Code](https://claude.com/claude-code)