### PR TITLE
fix(frontend): handle 404 errors in recent projects cache

### DIFF
--- a/frontend/src/components/Project/useRecentProjects.ts
+++ b/frontend/src/components/Project/useRecentProjects.ts
@@ -36,7 +36,13 @@ export const useRecentProjects = () => {
     const projects = [];
     const invalidProjects: string[] = [];
 
-    await projectV1Store.batchGetOrFetchProjects(recentViewProjectNames.value);
+    try {
+      await projectV1Store.batchGetOrFetchProjects(
+        recentViewProjectNames.value
+      );
+    } catch {
+      // Some projects may have failed to fetch (e.g., 404), continue to check individually
+    }
 
     for (const projectName of recentViewProjectNames.value) {
       try {


### PR DESCRIPTION
Wrap batchGetOrFetchProjects in try-catch so that deleted projects (returning 404) don't break the recent projects list. Invalid projects are still detected and removed from the cache individually.