### PR TITLE
refactor(frontend): remove ComposedDatabase and use base Database type

### DIFF
--- a/frontend/src/components/Changelog/ChangelogDetail.vue
+++ b/frontend/src/components/Changelog/ChangelogDetail.vue
@@ -138,6 +138,7 @@ import {
 import {
   bytesToString,
   extractProjectResourceName,
+  getInstanceResource,
   wrapRefAsPromise,
 } from "@/utils";
 import { instanceV1SupportsSchemaRollback } from "@/utils/v1/instance";
@@ -240,7 +241,9 @@ const allowRollback = computed((): boolean => {
   }
   // Check if engine supports schema diff rollback (GenerateMigration in backend)
   if (
-    !instanceV1SupportsSchemaRollback(database.value.instanceResource.engine)
+    !instanceV1SupportsSchemaRollback(
+      getInstanceResource(database.value).engine
+    )
   ) {
     return false;
   }

--- a/frontend/src/components/ColumnDataTable/SemanticTypeCell.vue
+++ b/frontend/src/components/ColumnDataTable/SemanticTypeCell.vue
@@ -25,7 +25,7 @@
 
   <FeatureModal
     :feature="PlanFeature.FEATURE_DATA_MASKING"
-    :instance="database.instanceResource"
+    :instance="getInstanceResource(database)"
     :open="state.showFeatureModal"
     @cancel="state.showFeatureModal = false"
   />
@@ -46,8 +46,9 @@ import { computed, reactive } from "vue";
 import { useSemanticType } from "@/components/SensitiveData/useSemanticType";
 import { MiniActionButton } from "@/components/v2";
 import { useSubscriptionV1Store } from "@/store";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
+import { getInstanceResource } from "@/utils";
 import FeatureModal from "../FeatureGuard/FeatureModal.vue";
 import SemanticTypesDrawer from "../SensitiveData/components/SemanticTypesDrawer.vue";
 
@@ -58,7 +59,7 @@ type LocalState = {
 
 const props = defineProps<{
   semanticTypeId: string;
-  database: ComposedDatabase;
+  database: Database;
   readonly?: boolean;
 }>();
 
@@ -82,7 +83,7 @@ const hasSensitiveDataFeature = computed(() => {
 const instanceMissingLicense = computed(() => {
   return subscriptionV1Store.instanceMissingLicense(
     PlanFeature.FEATURE_DATA_MASKING,
-    props.database.instanceResource
+    getInstanceResource(props.database)
   );
 });
 

--- a/frontend/src/components/ColumnDataTable/index.vue
+++ b/frontend/src/components/ColumnDataTable/index.vue
@@ -21,15 +21,19 @@ import {
   useDatabaseCatalog,
   useSubscriptionV1Store,
 } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
   ColumnMetadata,
+  Database,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
 import type { DataClassificationSetting_DataClassificationConfig } from "@/types/proto-es/v1/setting_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
-import { hasProjectPermissionV2 } from "@/utils";
+import {
+  getDatabaseProject,
+  getInstanceResource,
+  hasProjectPermissionV2,
+} from "@/utils";
 import ClassificationCell from "./ClassificationCell.vue";
 import LabelsCell from "./LabelsCell.vue";
 import SemanticTypeCell from "./SemanticTypeCell.vue";
@@ -41,7 +45,7 @@ defineOptions({
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     schema: string;
     table: TableMetadata;
     columnList: ColumnMetadata[];
@@ -58,7 +62,7 @@ const props = withDefaults(
 
 const { t } = useI18n();
 const engine = computed(() => {
-  return props.database.instanceResource.engine;
+  return getInstanceResource(props.database).engine;
 });
 const subscriptionV1Store = useSubscriptionV1Store();
 
@@ -100,7 +104,7 @@ const showCollationColumn = computed(() => {
 
 const hasDatabaseCatalogPermission = computed(() => {
   return hasProjectPermissionV2(
-    props.database.projectEntity,
+    getDatabaseProject(props.database),
     "bb.databaseCatalogs.update"
   );
 });

--- a/frontend/src/components/Database/DatabaseChangelogPanel.vue
+++ b/frontend/src/components/Database/DatabaseChangelogPanel.vue
@@ -23,11 +23,13 @@ import type { ComponentExposed } from "vue-component-type-helpers";
 import { ChangelogDataTable } from "@/components/Changelog";
 import PagedTable from "@/components/v2/Model/PagedTable.vue";
 import { useChangelogStore } from "@/store";
-import type { ComposedDatabase } from "@/types";
-import type { Changelog } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Changelog,
+  Database,
+} from "@/types/proto-es/v1/database_service_pb";
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
 }>();
 
 const changelogStore = useChangelogStore();

--- a/frontend/src/components/Database/DatabaseOverviewInfo.vue
+++ b/frontend/src/components/Database/DatabaseOverviewInfo.vue
@@ -58,16 +58,20 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useDBSchemaV1Store } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { Engine, State } from "@/types/proto-es/v1/common_pb";
-import { humanizeDate, instanceV1HasCollationAndCharacterSet } from "@/utils";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import {
+  getDatabaseEngine,
+  humanizeDate,
+  instanceV1HasCollationAndCharacterSet,
+} from "@/utils";
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
 }>();
 
 const databaseEngine = computed(() => {
-  return props.database.instanceResource.engine;
+  return getDatabaseEngine(props.database);
 });
 
 const databaseSchemaMetadata = computed(() => {

--- a/frontend/src/components/Database/DatabaseOverviewPanel.vue
+++ b/frontend/src/components/Database/DatabaseOverviewPanel.vue
@@ -4,7 +4,7 @@
     <DatabaseOverviewInfo :database="database" class="pb-6" />
 
     <ComponentPermissionGuard
-      :project="database.projectEntity"
+      :project="getDatabaseProject(database)"
       :permissions="['bb.databases.getSchema']"
     >
       <div class="border-t border-block-border pt-6">
@@ -174,9 +174,11 @@ import TableDataTable from "@/components/TableDataTable.vue";
 import TaskTable from "@/components/TaskTable.vue";
 import ViewDataTable from "@/components/ViewDataTable.vue";
 import { useDBSchemaV1Store } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
+  getDatabaseEngine,
+  getDatabaseProject,
   hasSchemaProperty,
   instanceV1SupportsPackage,
   instanceV1SupportsSequence,
@@ -194,7 +196,7 @@ interface LocalState {
 }
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
 }>();
 
 const { t } = useI18n();
@@ -210,7 +212,7 @@ const state = reactive<LocalState>({
 const dbSchemaStore = useDBSchemaV1Store();
 
 const databaseEngine = computed(() => {
-  return props.database.instanceResource.engine;
+  return getDatabaseEngine(props.database);
 });
 
 const hasSchemaPropertyV1 = computed(() => {

--- a/frontend/src/components/Database/DatabaseRevisionPanel.vue
+++ b/frontend/src/components/Database/DatabaseRevisionPanel.vue
@@ -39,12 +39,12 @@ import { RevisionDataTable } from "@/components/Revision";
 import CreateRevisionDrawer from "@/components/Revision/CreateRevisionDrawer.vue";
 import PagedTable from "@/components/v2/Model/PagedTable.vue";
 import { revisionServiceClientConnect } from "@/connect";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { ListRevisionsRequestSchema } from "@/types/proto-es/v1/revision_service_pb";
 import { useDatabaseDetailContext } from "./context";
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
 }>();
 
 const { pagedRevisionTableSessionKey } = useDatabaseDetailContext();

--- a/frontend/src/components/Database/DatabaseSensitiveDataPanel.vue
+++ b/frontend/src/components/Database/DatabaseSensitiveDataPanel.vue
@@ -2,7 +2,7 @@
   <div class="w-full flex flex-col gap-y-4">
     <FeatureAttention
       :feature="PlanFeature.FEATURE_DATA_MASKING"
-      :instance="database.instanceResource"
+      :instance="getInstanceResource(database)"
     />
     <div
       class="flex flex-col gap-x-2 lg:flex-row gap-y-4 justify-between items-end lg:items-center"
@@ -11,7 +11,7 @@
       <PermissionGuardWrapper
         v-if="!isMaskingForNoSQL"
         v-slot="slotProps"
-        :project="database.projectEntity"
+        :project="getDatabaseProject(database)"
         :permissions="[
           'bb.policies.createMaskingExemptionPolicy',
           'bb.policies.updateMaskingExemptionPolicy',
@@ -32,7 +32,7 @@
               v-else
               :feature="PlanFeature.FEATURE_DATA_MASKING"
               class="text-white"
-              :instance="database.instanceResource"
+              :instance="getInstanceResource(database)"
             />
           </template>
           {{ $t("settings.sensitive-data.grant-access") }}
@@ -54,7 +54,7 @@
   <FeatureModal
     :feature="PlanFeature.FEATURE_DATA_MASKING"
     :open="state.showFeatureModal"
-    :instance="database.instanceResource"
+    :instance="getInstanceResource(database)"
     @cancel="state.showFeatureModal = false"
   />
 
@@ -95,20 +95,25 @@ import type { MaskData } from "@/components/SensitiveData/types";
 import { isCurrentColumnException } from "@/components/SensitiveData/utils";
 import { SearchBox } from "@/components/v2";
 import { featureToRef, useDatabaseCatalog, usePolicyV1Store } from "@/store";
-import { type ComposedDatabase } from "@/types";
 import {
   type ObjectSchema,
   ObjectSchema_Type,
 } from "@/types/proto-es/v1/database_catalog_service_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   MaskingExemptionPolicySchema,
   PolicyType,
 } from "@/types/proto-es/v1/org_policy_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
-import { hasProjectPermissionV2, instanceV1MaskingForNoSQL } from "@/utils";
+import {
+  getDatabaseProject,
+  getInstanceResource,
+  hasProjectPermissionV2,
+  instanceV1MaskingForNoSQL,
+} from "@/utils";
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
 }>();
 
 interface LocalState {
@@ -130,12 +135,12 @@ const state = reactive<LocalState>({
 });
 
 const isMaskingForNoSQL = computed(() =>
-  instanceV1MaskingForNoSQL(props.database.instanceResource)
+  instanceV1MaskingForNoSQL(getInstanceResource(props.database))
 );
 
 const hasUpdateCatalogPermission = computed(() => {
   return hasProjectPermissionV2(
-    props.database.projectEntity,
+    getDatabaseProject(props.database),
     "bb.databaseCatalogs.update"
   );
 });

--- a/frontend/src/components/Database/context.ts
+++ b/frontend/src/components/Database/context.ts
@@ -5,12 +5,12 @@ import {
   databaseNamePrefix,
   instanceNamePrefix,
 } from "@/store/modules/v1/common";
-import type { ComposedDatabase } from "@/types";
 import { DEFAULT_PROJECT_NAME } from "@/types";
-import { instanceV1HasAlterSchema } from "@/utils";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { getInstanceResource, instanceV1HasAlterSchema } from "@/utils";
 
 export type DatabaseDetailContext = {
-  database: Ref<ComposedDatabase>;
+  database: Ref<Database>;
   pagedRevisionTableSessionKey: Ref<string>;
   allowAlterSchema: Ref<boolean>;
   isDefaultProject: Ref<boolean>;
@@ -44,7 +44,7 @@ export const provideDatabaseDetailContext = (
   );
 
   const allowAlterSchema = computed(() => {
-    return instanceV1HasAlterSchema(database.value.instanceResource);
+    return instanceV1HasAlterSchema(getInstanceResource(database.value));
   });
 
   const context: DatabaseDetailContext = {

--- a/frontend/src/components/DatabaseDetail/SQLEditorButtonV1.vue
+++ b/frontend/src/components/DatabaseDetail/SQLEditorButtonV1.vue
@@ -23,10 +23,11 @@ import { NTooltip } from "naive-ui";
 import { computed } from "vue";
 import { useRouter } from "vue-router";
 import { SQL_EDITOR_DATABASE_MODULE } from "@/router/sqlEditor";
-import type { ComposedDatabase } from "@/types";
 import { DEFAULT_PROJECT_NAME, defaultProject } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { VueClass } from "@/utils";
 import {
+  extractDatabaseResourceName,
   extractInstanceResourceName,
   extractProjectResourceName,
   hasProjectPermissionV2,
@@ -35,7 +36,7 @@ import {
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     table?: string;
     schema?: string;
     label?: boolean;
@@ -54,7 +55,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (name: "failed", database: ComposedDatabase): void;
+  (name: "failed", database: Database): void;
 }>();
 
 const router = useRouter();
@@ -90,12 +91,13 @@ const gotoSQLEditor = () => {
     }
   }
 
+  const { instance, databaseName } = extractDatabaseResourceName(database.name);
   const route = router.resolve({
     name: SQL_EDITOR_DATABASE_MODULE,
     params: {
       project: extractProjectResourceName(database.project),
-      instance: extractInstanceResourceName(database.instance),
-      database: database.databaseName,
+      instance: extractInstanceResourceName(instance),
+      database: databaseName,
     },
     query: {
       table: props.table ? props.table : undefined,

--- a/frontend/src/components/DatabaseDetail/SchemaDiagramButton.vue
+++ b/frontend/src/components/DatabaseDetail/SchemaDiagramButton.vue
@@ -30,10 +30,10 @@ import { ref } from "vue";
 import { BBModal } from "@/bbkit";
 import { SchemaDiagram, SchemaDiagramIcon } from "@/components/SchemaDiagram";
 import { useDBSchemaV1Store } from "@/store";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
 }>();
 
 const open = ref<boolean>(false);

--- a/frontend/src/components/DatabaseDetail/Settings/DatabaseSettingsPanel.vue
+++ b/frontend/src/components/DatabaseDetail/Settings/DatabaseSettingsPanel.vue
@@ -9,10 +9,10 @@
           class="mt-1 max-w-md"
           :value="`${environmentNamePrefix}${environment.id}`"
           :disabled="!allowUpdateDatabase"
-          :clearable="!database.instanceResource.environment"
+          :clearable="!getInstanceResource(database).environment"
           :render-suffix="
             (env: Environment) =>
-              database.instanceResource.environment === env.name
+              getInstanceResource(database).environment === env.name
                 ? `(${$t('common.default')})`
                 : ''
           "
@@ -41,14 +41,18 @@ import {
   useDatabaseV1Store,
   useEnvironmentV1Store,
 } from "@/store";
-import { type ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { UpdateDatabaseRequestSchema } from "@/types/proto-es/v1/database_service_pb";
 import type { Environment } from "@/types/v1/environment";
-import { hasProjectPermissionV2 } from "@/utils";
+import {
+  getDatabaseProject,
+  getInstanceResource,
+  hasProjectPermissionV2,
+} from "@/utils";
 import Labels from "./components/Labels.vue";
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
 }>();
 
 const databaseStore = useDatabaseV1Store();
@@ -62,7 +66,10 @@ const environment = computed(() => {
 });
 
 const allowUpdateDatabase = computed(() =>
-  hasProjectPermissionV2(props.database.projectEntity, "bb.databases.update")
+  hasProjectPermissionV2(
+    getDatabaseProject(props.database),
+    "bb.databases.update"
+  )
 );
 
 const handleSelectEnvironment = async (name: string | undefined) => {

--- a/frontend/src/components/DatabaseDetail/Settings/components/Labels.vue
+++ b/frontend/src/components/DatabaseDetail/Settings/components/Labels.vue
@@ -42,7 +42,7 @@ import { computed, reactive, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { LabelListEditor } from "@/components/Label/";
 import { pushNotification, useDatabaseV1Store } from "@/store";
-import { type ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { UpdateDatabaseRequestSchema } from "@/types/proto-es/v1/database_service_pb";
 import { convertKVListToLabels, convertLabelsToKVList } from "@/utils";
 
@@ -52,7 +52,7 @@ type LocalState = {
 };
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   allowEdit: boolean;
 }>();
 

--- a/frontend/src/components/DatabaseDetail/SyncDatabaseButton.vue
+++ b/frontend/src/components/DatabaseDetail/SyncDatabaseButton.vue
@@ -2,7 +2,7 @@
   <PermissionGuardWrapper
     v-if="available"
     v-slot="slotProps"
-    :project="database.projectEntity"
+    :project="getDatabaseProject(database)"
     :permissions="['bb.databases.sync']"
   >
     <NButton
@@ -28,13 +28,14 @@ import {
   useDatabaseV1Store,
   useDBSchemaV1Store,
 } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { isValidDatabaseName } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { extractDatabaseResourceName, getDatabaseProject } from "@/utils";
 
 const props = defineProps<{
   text: boolean;
   type: "default" | "primary";
-  database: ComposedDatabase;
+  database: Database;
 }>();
 
 const emit = defineEmits<{
@@ -60,21 +61,23 @@ const syncDatabaseSchema = async () => {
       database: props.database.name,
       skipCache: true,
     });
+    const { databaseName } = extractDatabaseResourceName(props.database.name);
     pushNotification({
       module: "bytebase",
       style: "SUCCESS",
       title: t(
         "db.successfully-synced-schema-for-database-database-value-name",
-        [props.database.databaseName]
+        [databaseName]
       ),
     });
     emit("finish");
   } catch (error) {
+    const { databaseName } = extractDatabaseResourceName(props.database.name);
     pushNotification({
       module: "bytebase",
       style: "CRITICAL",
       title: t("db.failed-to-sync-schema-for-database-database-value-name", [
-        props.database.databaseName,
+        databaseName,
       ]),
       description: (error as ConnectError).message,
     });

--- a/frontend/src/components/DatabaseGroup/MatchedDatabaseView.vue
+++ b/frontend/src/components/DatabaseGroup/MatchedDatabaseView.vue
@@ -33,12 +33,12 @@
             <DatabaseV1Name :database="database" />
             <div class="flex-1 flex flex-row justify-end items-center shrink-0">
               <InstanceV1Name
-                :instance="database.instanceResource"
+                :instance="getInstanceResource(database)"
                 :link="false"
               />
               <EnvironmentV1Name
                 class="ml-1 text-sm text-gray-400 max-w-[124px]"
-                :environment="database.effectiveEnvironmentEntity"
+                :environment="getDatabaseEnvironment(database)"
                 :link="false"
               />
             </div>
@@ -73,22 +73,23 @@ import {
 import type { ConditionGroupExpr } from "@/plugins/cel";
 import { validateSimpleExpr } from "@/plugins/cel";
 import { useDatabaseV1Store, useDBGroupStore } from "@/store";
+import { DEBOUNCE_SEARCH_DELAY, isValidDatabaseName } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
-  type ComposedDatabase,
-  DEBOUNCE_SEARCH_DELAY,
-  isValidDatabaseName,
-} from "@/types";
-import { getDefaultPagination } from "@/utils";
+  getDatabaseEnvironment,
+  getDefaultPagination,
+  getInstanceResource,
+} from "@/utils";
 
 interface DatabaseMatchList<T> {
   token: T;
   loading: boolean;
   getTotal?: () => number;
-  databaseList: ComposedDatabase[];
+  databaseList: Database[];
   name: "matched" | "unmatched";
   title: string;
   hasNext: (token: T) => boolean;
-  loadMore: (token: T) => Promise<{ databases: ComposedDatabase[]; token: T }>;
+  loadMore: (token: T) => Promise<{ databases: Database[]; token: T }>;
 }
 
 type AnyDatabaseMatchList =
@@ -133,7 +134,7 @@ const loadMoreMatched = async (index: number) => {
 };
 
 const loadMoreUnmatched = async (token: string) => {
-  let unmatched: ComposedDatabase[] = [];
+  let unmatched: Database[] = [];
   let pageToken = token;
   while (true) {
     const { databases, nextPageToken } = await databaseStore.fetchDatabases({

--- a/frontend/src/components/DatabaseInfo.vue
+++ b/frontend/src/components/DatabaseInfo.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="flex items-center flex-wrap gap-1">
     <InstanceV1Name
-      :instance="database.instanceResource"
+      :instance="instanceResource"
       :plain="true"
       :link="link"
       :text-class="link ? 'hover:underline' : ''"
     >
       <template
         v-if="
-          database.instanceResource.environment !==
+          instanceResource.environment !==
           database.effectiveEnvironment
         "
         #prefix
@@ -31,7 +31,7 @@
 
       <template v-if="database">
         <EnvironmentV1Name
-          :environment="database.effectiveEnvironmentEntity"
+          :environment="effectiveEnvironment"
           :plain="true"
           :show-icon="false"
           :link="link"
@@ -58,11 +58,12 @@ import {
   InstanceV1Name,
 } from "@/components/v2";
 import { useEnvironmentV1Store } from "@/store";
-import { type ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { getDatabaseEnvironment, getInstanceResource } from "@/utils";
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     link?: boolean;
   }>(),
   {
@@ -70,9 +71,14 @@ const props = withDefaults(
   }
 );
 
+const instanceResource = computed(() => getInstanceResource(props.database));
+const effectiveEnvironment = computed(() =>
+  getDatabaseEnvironment(props.database)
+);
+
 const instanceEnvironment = computed(() => {
   return useEnvironmentV1Store().getEnvironmentByName(
-    props.database.instanceResource.environment ?? ""
+    instanceResource.value.environment ?? ""
   );
 });
 </script>

--- a/frontend/src/components/ExternalTableDataTable.vue
+++ b/frontend/src/components/ExternalTableDataTable.vue
@@ -28,8 +28,10 @@ import { NDataTable } from "naive-ui";
 import { computed, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import { HighlightLabelText } from "@/components/v2";
-import type { ComposedDatabase } from "@/types";
-import type { ExternalTableMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  ExternalTableMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 import ExternalTableDetailDrawer from "./ExternalTableDetailDrawer.vue";
 
 type LocalState = {
@@ -38,7 +40,7 @@ type LocalState = {
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     schemaName?: string;
     externalTableList: ExternalTableMetadata[];
     search?: string;

--- a/frontend/src/components/ExternalTableDetailDrawer.vue
+++ b/frontend/src/components/ExternalTableDetailDrawer.vue
@@ -33,7 +33,7 @@
                     >{{ $t("common.environment") }}&nbsp;-&nbsp;</span
                   >
                   <EnvironmentV1Name
-                    :environment="database.effectiveEnvironmentEntity"
+                    :environment="effectiveEnvironment"
                     icon-class="textinfolabel"
                   />
                 </dd>
@@ -42,7 +42,7 @@
                   <span class="ml-1 textlabel"
                     >{{ $t("common.instance") }}&nbsp;-&nbsp;</span
                   >
-                  <InstanceV1Name :instance="database.instanceResource" />
+                  <InstanceV1Name :instance="instanceResource" />
                 </dd>
                 <dt class="sr-only">{{ $t("common.project") }}</dt>
                 <dd class="flex items-center text-sm md:mr-4">
@@ -50,7 +50,7 @@
                     >{{ $t("common.project") }}&nbsp;-&nbsp;</span
                   >
                   <ProjectV1Name
-                    :project="database.projectEntity"
+                    :project="projectEntity"
                     hash="#databases"
                   />
                 </dd>
@@ -142,6 +142,9 @@ import { useDatabaseV1Store, useDBSchemaV1Store } from "@/store";
 import { DEFAULT_PROJECT_NAME, defaultProject } from "@/types";
 import { TableMetadataSchema } from "@/types/proto-es/v1/database_service_pb";
 import {
+  getDatabaseEnvironment,
+  getDatabaseProject,
+  getInstanceResource,
   hasProjectPermissionV2,
   hasSchemaProperty,
   isDatabaseV1Queryable,
@@ -194,8 +197,20 @@ const database = computed(() => {
   return databaseV1Store.getDatabaseByName(props.databaseName);
 });
 
+const instanceResource = computed(() => {
+  return getInstanceResource(database.value);
+});
+
+const projectEntity = computed(() => {
+  return getDatabaseProject(database.value);
+});
+
+const effectiveEnvironment = computed(() => {
+  return getDatabaseEnvironment(database.value);
+});
+
 const instanceEngine = computed(() => {
-  return database.value.instanceResource.engine;
+  return instanceResource.value.engine;
 });
 
 const allowQuery = computed(() => {

--- a/frontend/src/components/FunctionDataTable.vue
+++ b/frontend/src/components/FunctionDataTable.vue
@@ -16,14 +16,16 @@ import type { DataTableColumn } from "naive-ui";
 import { NDataTable } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
-import type { FunctionMetadata } from "@/types/proto-es/v1/database_service_pb";
-import { hasSchemaProperty } from "@/utils";
+import type {
+  Database,
+  FunctionMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
+import { getInstanceResource, hasSchemaProperty } from "@/utils";
 import EllipsisSQLView from "./EllipsisSQLView.vue";
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     schemaName?: string;
     functionList: FunctionMetadata[];
     loading?: boolean;
@@ -36,7 +38,7 @@ const props = withDefaults(
 
 const { t } = useI18n();
 
-const engine = computed(() => props.database.instanceResource.engine);
+const engine = computed(() => getInstanceResource(props.database).engine);
 
 const columns = computed(() => {
   const columns: (DataTableColumn<FunctionMetadata> & { hide?: boolean })[] = [

--- a/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/DatabaseResourceSelector.vue
+++ b/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/DatabaseResourceSelector.vue
@@ -44,12 +44,9 @@ import {
   environmentNamePrefix,
   instanceNamePrefix,
 } from "@/store/modules/v1/common";
-import {
-  type ComposedDatabase,
-  type DatabaseResource,
-  DEBOUNCE_SEARCH_DELAY,
-} from "@/types";
+import { type DatabaseResource, DEBOUNCE_SEARCH_DELAY } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   CommonFilterScopeIdList,
   extractProjectResourceName,
@@ -149,7 +146,7 @@ const selectedValueList = ref<string[]>([]);
 const expandedKeys = ref<string[]>([]);
 const indeterminateKeys = ref<string[]>([]);
 const initializeStatus = ref<"PENDING" | "PROCESSING" | "DONE">("PENDING");
-const databaseList = ref<ComposedDatabase[]>([]);
+const databaseList = ref<Database[]>([]);
 const fetchDataState = ref<{
   nextPageToken?: string;
   loading: boolean;

--- a/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/Label.vue
+++ b/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/Label.vue
@@ -8,7 +8,7 @@
     <span v-html="optionName" />
     <span v-if="database" class="ml-1 text-gray-500 flex flex-row items-center">
       (<InstanceV1Name
-        :instance="database.instanceResource"
+        :instance="getInstanceResource(database)"
         :link="false"
         class="whitespace-nowrap"
       />)
@@ -22,7 +22,11 @@ import { escape } from "lodash-es";
 import { computed, h } from "vue";
 import { EnvironmentV1Name, InstanceV1Name } from "@/components/v2";
 import { useDatabaseV1Store } from "@/store";
-import { getHighlightHTMLByRegExp } from "@/utils";
+import {
+  getDatabaseEnvironment,
+  getHighlightHTMLByRegExp,
+  getInstanceResource,
+} from "@/utils";
 import DatabaseIcon from "~icons/heroicons-outline/circle-stack";
 import TableIcon from "~icons/heroicons-outline/table-cells";
 import SchemaIcon from "~icons/heroicons-outline/view-columns";
@@ -44,7 +48,8 @@ const database = computedAsync(() => {
 const environment = computed(() => {
   const { option } = props;
   if (option.level !== "databases") return undefined;
-  return database.value?.effectiveEnvironmentEntity;
+  if (!database.value) return undefined;
+  return getDatabaseEnvironment(database.value);
 });
 
 const Prefix = () => {

--- a/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/common.ts
+++ b/frontend/src/components/GrantRequestPanel/DatabaseResourceForm/common.ts
@@ -5,10 +5,17 @@ import {
   databaseNamePrefix,
   instanceNamePrefix,
 } from "@/store/modules/v1/common";
-import type { ComposedDatabase, DatabaseResource } from "@/types";
+import type { DatabaseResource } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
-import type { TableMetadata } from "@/types/proto-es/v1/database_service_pb";
-import { hasSchemaProperty } from "@/utils";
+import type {
+  Database,
+  TableMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
+import {
+  extractDatabaseResourceName,
+  getInstanceResource,
+  hasSchemaProperty,
+} from "@/utils";
 
 export type DatabaseResourceType =
   | "databases"
@@ -30,7 +37,7 @@ export const mapTreeOptions = ({
   filterValueList,
   includeCloumn,
 }: {
-  databaseList: ComposedDatabase[];
+  databaseList: Database[];
   filterValueList?: string[];
   includeCloumn: boolean;
 }) => {
@@ -46,7 +53,7 @@ export const mapTreeOptions = ({
     const databaseNode: DatabaseTreeOption<"databases"> = {
       level: "databases",
       value: database.name,
-      label: database.databaseName,
+      label: extractDatabaseResourceName(database.name).databaseName,
       isLeaf: false,
       children: getSchemaOrTableTreeOptions({
         database,
@@ -115,11 +122,11 @@ export const getSchemaOrTableTreeOptions = ({
   filterValueList,
   includeCloumn,
 }: {
-  database: ComposedDatabase;
+  database: Database;
   filterValueList?: string[];
   includeCloumn: boolean;
 }) => {
-  if (database.instanceResource.engine === Engine.MONGODB) {
+  if (getInstanceResource(database).engine === Engine.MONGODB) {
     // do not support table level select for MongoDB.
     return [];
   }
@@ -130,7 +137,7 @@ export const getSchemaOrTableTreeOptions = ({
   if (!databaseMetadata) {
     return undefined;
   }
-  if (hasSchemaProperty(database.instanceResource.engine)) {
+  if (hasSchemaProperty(getInstanceResource(database).engine)) {
     const schemaNodes = databaseMetadata.schemas.map(
       (schema): DatabaseTreeOption<"schemas"> => {
         const value = `${database.name}/schemas/${schema.name}`;

--- a/frontend/src/components/IndexTable.vue
+++ b/frontend/src/components/IndexTable.vue
@@ -19,14 +19,17 @@ import { NDataTable } from "naive-ui";
 import type { PropType } from "vue";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
-import type { IndexMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  IndexMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
+import { getInstanceResource } from "@/utils";
 
 const props = defineProps({
   database: {
     required: true,
-    type: Object as PropType<ComposedDatabase>,
+    type: Object as PropType<Database>,
   },
   indexList: {
     required: true,
@@ -36,11 +39,11 @@ const props = defineProps({
 
 const { t } = useI18n();
 const showVisibleColumn = computed(() => {
-  const engine = props.database.instanceResource.engine;
+  const engine = getInstanceResource(props.database).engine;
   return engine !== Engine.POSTGRES && engine !== Engine.MONGODB;
 });
 const showCommentColumn = computed(() => {
-  const engine = props.database.instanceResource.engine;
+  const engine = getInstanceResource(props.database).engine;
   return engine !== Engine.MONGODB;
 });
 const columns = computed((): DataTableColumn<IndexMetadata>[] => {

--- a/frontend/src/components/IssueV1/components/GrantRequest/DatabaseResourceTable.vue
+++ b/frontend/src/components/IssueV1/components/GrantRequest/DatabaseResourceTable.vue
@@ -17,6 +17,11 @@ import { EnvironmentV1Name, InstanceV1Name } from "@/components/v2";
 import { useDatabaseV1Store } from "@/store";
 import type { DatabaseResource } from "@/types";
 import type { DatabaseGroup } from "@/types/proto-es/v1/database_group_service_pb";
+import {
+  extractDatabaseResourceName,
+  getDatabaseEnvironment,
+  getInstanceResource,
+} from "@/utils";
 
 const props = defineProps<{
   databaseResourceList: DatabaseResource[];
@@ -29,11 +34,11 @@ defineEmits<{
 const { t } = useI18n();
 const databaseStore = useDatabaseV1Store();
 
-const extractDatabaseName = (databaseResource: DatabaseResource) => {
+const getDatabaseName = (databaseResource: DatabaseResource) => {
   const database = databaseStore.getDatabaseByName(
     databaseResource.databaseFullName
   );
-  return database.databaseName;
+  return extractDatabaseResourceName(database.name).databaseName;
 };
 
 const extractTableName = (databaseResource: DatabaseResource) => {
@@ -48,7 +53,7 @@ const extractTableName = (databaseResource: DatabaseResource) => {
   return names.join(".");
 };
 
-const extractComposedDatabase = (databaseResource: DatabaseResource) => {
+const getDatabase = (databaseResource: DatabaseResource) => {
   const database = databaseStore.getDatabaseByName(
     databaseResource.databaseFullName
   );
@@ -74,7 +79,7 @@ const columns = computed((): DataTableColumn<DatabaseResource>[] => {
     {
       title: t("common.database"),
       key: "database",
-      render: (row) => extractDatabaseName(row),
+      render: (row) => getDatabaseName(row),
     },
     {
       title: t("common.table"),
@@ -88,7 +93,7 @@ const columns = computed((): DataTableColumn<DatabaseResource>[] => {
       key: "environment",
       render: (row) => (
         <EnvironmentV1Name
-          environment={extractComposedDatabase(row).effectiveEnvironmentEntity}
+          environment={getDatabaseEnvironment(getDatabase(row))}
         />
       ),
     },
@@ -96,9 +101,7 @@ const columns = computed((): DataTableColumn<DatabaseResource>[] => {
       title: t("common.instance"),
       key: "instance",
       render: (row) => (
-        <InstanceV1Name
-          instance={extractComposedDatabase(row).instanceResource}
-        />
+        <InstanceV1Name instance={getInstanceResource(getDatabase(row))} />
       ),
     },
   ];

--- a/frontend/src/components/PackageDataTable.vue
+++ b/frontend/src/components/PackageDataTable.vue
@@ -16,14 +16,16 @@ import type { DataTableColumn } from "naive-ui";
 import { NDataTable } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
-import type { PackageMetadata } from "@/types/proto-es/v1/database_service_pb";
-import { hasSchemaProperty } from "@/utils";
+import type {
+  Database,
+  PackageMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
+import { getInstanceResource, hasSchemaProperty } from "@/utils";
 import EllipsisSQLView from "./EllipsisSQLView.vue";
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     schemaName?: string;
     packageList: PackageMetadata[];
     loading?: boolean;
@@ -36,7 +38,7 @@ const props = withDefaults(
 
 const { t } = useI18n();
 
-const engine = computed(() => props.database.instanceResource.engine);
+const engine = computed(() => getInstanceResource(props.database).engine);
 
 const columns = computed(() => {
   const columns: (DataTableColumn<PackageMetadata> & { hide?: boolean })[] = [

--- a/frontend/src/components/Plan/components/AddSpecDrawer.vue
+++ b/frontend/src/components/Plan/components/AddSpecDrawer.vue
@@ -57,7 +57,7 @@ import {
   useCurrentProjectV1,
   useDatabaseV1Store,
 } from "@/store";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   Plan_ChangeDatabaseConfigSchema,
   type Plan_Spec,
@@ -66,7 +66,7 @@ import {
 
 const props = defineProps<{
   title?: string;
-  preSelectedDatabases?: ComposedDatabase[];
+  preSelectedDatabases?: Database[];
   preSelectedDatabaseGroup?: string;
 }>();
 

--- a/frontend/src/components/Plan/components/Configuration/GhostSection/GhostSwitch.vue
+++ b/frontend/src/components/Plan/components/Configuration/GhostSection/GhostSwitch.vue
@@ -38,6 +38,7 @@ import { targetsForSpec } from "@/components/Plan/logic";
 import { planServiceClientConnect } from "@/connect";
 import { pushNotification } from "@/store";
 import { UpdatePlanRequestSchema } from "@/types/proto-es/v1/plan_service_pb";
+import { extractDatabaseResourceName } from "@/utils";
 import { allowGhostForDatabase } from "./common";
 import { useGhostSettingContext } from "./context";
 
@@ -63,7 +64,7 @@ const errors = computed(() => {
         "task.online-migration.error.not-applicable.database-doesnt-meet-ghost-requirement",
         {
           database: unsupportedDatabases
-            .map((db) => db.databaseName)
+            .map((db) => extractDatabaseResourceName(db.name).databaseName)
             .join(", "),
         }
       )
@@ -113,7 +114,7 @@ const tooltipMessage = computed(() => {
     }
     // Otherwise show the databases that don't meet requirements
     const dbNames = databasesNotMeetingRequirements.value
-      .map((db) => db.databaseName)
+      .map((db) => extractDatabaseResourceName(db.name).databaseName)
       .join(", ");
     return t("plan.ghost.some-databases-not-meeting-requirements", {
       databases: dbNames,

--- a/frontend/src/components/Plan/components/Configuration/GhostSection/common.ts
+++ b/frontend/src/components/Plan/components/Configuration/GhostSection/common.ts
@@ -1,8 +1,8 @@
 import { isDBGroupChangeSpec } from "@/components/Plan/logic";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { type Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
-import { semverCompare } from "@/utils";
+import { getInstanceResource, semverCompare } from "@/utils";
 
 export const GHOST_AVAILABLE_ENGINES = [Engine.MYSQL, Engine.MARIADB];
 
@@ -10,18 +10,19 @@ export const MIN_GHOST_SUPPORT_MYSQL_VERSION = "5.6.0";
 
 export const MIN_GHOST_SUPPORT_MARIADB_VERSION = "10.6.0";
 
-export const allowGhostForDatabase = (database: ComposedDatabase) => {
-  const engine = database.instanceResource.engine;
+export const allowGhostForDatabase = (database: Database) => {
+  const instanceResource = getInstanceResource(database);
+  const engine = instanceResource.engine;
   return (
     (engine === Engine.MYSQL &&
       semverCompare(
-        database.instanceResource.engineVersion,
+        instanceResource.engineVersion,
         MIN_GHOST_SUPPORT_MYSQL_VERSION,
         "gte"
       )) ||
     (engine === Engine.MARIADB &&
       semverCompare(
-        database.instanceResource.engineVersion,
+        instanceResource.engineVersion,
         MIN_GHOST_SUPPORT_MARIADB_VERSION,
         "gte"
       ))

--- a/frontend/src/components/Plan/components/Configuration/GhostSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/GhostSection/context.ts
@@ -5,7 +5,7 @@ import { targetsForSpec } from "@/components/Plan/logic";
 import { useDatabaseV1Store } from "@/store";
 import { isValidDatabaseName } from "@/types";
 import type { Plan, Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
-import { isNullOrUndefined } from "@/utils";
+import { getInstanceResource, isNullOrUndefined } from "@/utils";
 import { GHOST_AVAILABLE_ENGINES, getGhostEnabledForSpec } from "./common";
 
 export const KEY = Symbol(
@@ -43,7 +43,7 @@ export const provideGhostSettingContext = (refs: {
     return (
       selectedSpec.value &&
       databases.value.every((db) =>
-        GHOST_AVAILABLE_ENGINES.includes(db.instanceResource.engine)
+        GHOST_AVAILABLE_ENGINES.includes(getInstanceResource(db).engine)
       ) &&
       !isNullOrUndefined(getGhostEnabledForSpec(selectedSpec.value))
     );

--- a/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/InstanceRoleSelect.vue
+++ b/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/InstanceRoleSelect.vue
@@ -26,7 +26,7 @@ import {
 import { instanceRoleServiceClientConnect } from "@/connect";
 import type { InstanceRole } from "@/types/proto-es/v1/instance_role_service_pb";
 import { ListInstanceRolesRequestSchema } from "@/types/proto-es/v1/instance_role_service_pb";
-import { setSheetStatement } from "@/utils";
+import { extractDatabaseResourceName, setSheetStatement } from "@/utils";
 import { useSelectedSpec } from "../../SpecDetailView/context";
 import {
   parseStatement,
@@ -70,15 +70,20 @@ const database = computed(() => {
   return databases.value[0];
 });
 
+const instanceName = computed(() => {
+  if (!database.value) return undefined;
+  return extractDatabaseResourceName(database.value.name).instance;
+});
+
 watch(
-  () => database.value?.instance,
+  instanceName,
   async () => {
-    if (!database.value) return;
+    if (!database.value || !instanceName.value) return;
 
     loading.value = true;
     try {
       const request = create(ListInstanceRolesRequestSchema, {
-        parent: database.value.instance,
+        parent: instanceName.value,
       });
       const response =
         await instanceRoleServiceClientConnect.listInstanceRoles(request);

--- a/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/context.ts
@@ -7,6 +7,7 @@ import { isValidDatabaseName } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import { type Plan, type Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import { getInstanceResource } from "@/utils";
 
 export const KEY = Symbol(
   "bb.plan.setting.instance-role"
@@ -47,7 +48,7 @@ export const provideInstanceRoleSettingContext = (refs: {
 
     // Only show for PostgreSQL databases
     const allDatabasesArePostgres = databases.value.every(
-      (db) => db.instanceResource.engine === Engine.POSTGRES
+      (db) => getInstanceResource(db).engine === Engine.POSTGRES
     );
     if (!allDatabasesArePostgres) return false;
 

--- a/frontend/src/components/Plan/components/Configuration/IsolationLevelSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/IsolationLevelSection/context.ts
@@ -7,6 +7,7 @@ import { isValidDatabaseName } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import { type Plan, type Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import { getInstanceResource } from "@/utils";
 import type { IsolationLevel } from "../../StatementSection/directiveUtils";
 
 export const KEY = Symbol(
@@ -53,7 +54,7 @@ export const provideIsolationLevelSettingContext = (refs: {
     // Only show for MySQL/MariaDB/TiDB for now
     const supportedEngines = [Engine.MYSQL, Engine.MARIADB, Engine.TIDB];
     const allDatabasesSupported = databases.value.every((db) =>
-      supportedEngines.includes(db.instanceResource.engine)
+      supportedEngines.includes(getInstanceResource(db).engine)
     );
     if (!allDatabasesSupported) return false;
 

--- a/frontend/src/components/Plan/components/Configuration/PreBackupSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/PreBackupSection/context.ts
@@ -20,6 +20,7 @@ import {
   UpdatePlanRequestSchema,
 } from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import { getInstanceResource } from "@/utils";
 import { BACKUP_AVAILABLE_ENGINES } from "./common";
 
 const KEY = Symbol(
@@ -64,7 +65,7 @@ export const providePreBackupSettingContext = (refs: {
       // If any of the databases in the spec is not supported, do not show.
       if (
         !databases.value.every((db) =>
-          BACKUP_AVAILABLE_ENGINES.includes(db.instanceResource.engine)
+          BACKUP_AVAILABLE_ENGINES.includes(getInstanceResource(db).engine)
         )
       ) {
         return false;

--- a/frontend/src/components/Plan/components/Configuration/TransactionModeSection/context.ts
+++ b/frontend/src/components/Plan/components/Configuration/TransactionModeSection/context.ts
@@ -6,7 +6,10 @@ import { useDatabaseV1Store } from "@/store";
 import { isValidDatabaseName } from "@/types";
 import { type Plan, type Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
-import { instanceV1SupportsTransactionMode } from "@/utils";
+import {
+  getInstanceResource,
+  instanceV1SupportsTransactionMode,
+} from "@/utils";
 
 export const KEY = Symbol(
   "bb.plan.setting.transaction-mode"
@@ -47,7 +50,7 @@ export const provideTransactionModeSettingContext = (refs: {
 
     // Check if all databases support transaction mode
     const allDatabasesSupportTransactionMode = databases.value.every((db) =>
-      instanceV1SupportsTransactionMode(db.instanceResource.engine)
+      instanceV1SupportsTransactionMode(getInstanceResource(db).engine)
     );
     if (!allDatabasesSupportTransactionMode) return false;
 

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/TaskName.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/TaskName.vue
@@ -4,7 +4,7 @@
     exact-active-class=""
     class="font-medium text-main hover:border-b hover:border-b-main"
   >
-    <span>{{ databaseForTask(project, task).databaseName }}</span>
+    <span>{{ databaseName }}</span>
     <span class="ml-1 text-control-placeholder">#{{ taskUID }}</span>
   </router-link>
 </template>
@@ -17,6 +17,7 @@ import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
 import type { Task } from "@/types/proto-es/v1/rollout_service_pb";
 import {
   databaseForTask,
+  extractDatabaseResourceName,
   extractProjectResourceName,
   extractTaskUID,
 } from "@/utils";
@@ -30,6 +31,11 @@ const project = computed(() => {
   return useProjectV1Store().getProjectByName(
     `${projectNamePrefix}${extractProjectResourceName(props.plan.name)}`
   );
+});
+
+const databaseName = computed(() => {
+  const db = databaseForTask(project.value, props.task);
+  return extractDatabaseResourceName(db.name).databaseName;
 });
 
 const taskUID = computed(() => {

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseCreateView.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseCreateView.vue
@@ -32,7 +32,12 @@
             >{{ $t("common.database") }}:</span
           >
           <template v-if="isTaskDone && createdDatabase">
-            <DatabaseV1Name :database="createdDatabase" :link="true" />
+            <router-link
+              :to="databaseV1Url(createdDatabase)"
+              class="normal-link"
+            >
+              {{ extractDatabaseResourceName(createdDatabase.name).databaseName }}
+            </router-link>
             <span class="text-sm text-gray-500"
               >({{ $t("common.created") }})</span
             >
@@ -69,11 +74,7 @@
 import { computed, watchEffect } from "vue";
 import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";
 import TaskRunTable from "@/components/RolloutV1/components/TaskRunTable.vue";
-import {
-  DatabaseV1Name,
-  EnvironmentV1Name,
-  InstanceV1Name,
-} from "@/components/v2";
+import { EnvironmentV1Name, InstanceV1Name } from "@/components/v2";
 import {
   useCurrentProjectV1,
   useEnvironmentV1Store,
@@ -83,7 +84,11 @@ import {
 import type { Plan_CreateDatabaseConfig } from "@/types/proto-es/v1/plan_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { isValidInstanceName } from "@/types/v1/instance";
-import { extractCoreDatabaseInfoFromDatabaseCreateTask } from "@/utils";
+import {
+  databaseV1Url,
+  extractCoreDatabaseInfoFromDatabaseCreateTask,
+  extractDatabaseResourceName,
+} from "@/utils";
 import { extractInstanceResourceName } from "@/utils/v1/instance";
 import { usePlanContext } from "../..";
 

--- a/frontend/src/components/Plan/components/SQLCheckSection/SQLCheckBadge.vue
+++ b/frontend/src/components/Plan/components/SQLCheckSection/SQLCheckBadge.vue
@@ -25,7 +25,7 @@
   <SQLCheckPanel
     v-if="showDetailPanel"
     :project="project.name"
-    :database="database"
+    :database="database as Database"
     :advices="advices"
     @close="showDetailPanel = false"
   />
@@ -37,6 +37,7 @@ import { NTag } from "naive-ui";
 import { computed, ref } from "vue";
 import TaskSpinner from "@/components/misc/TaskSpinner.vue";
 import { SQLCheckPanel } from "@/components/SQLCheck";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Advice } from "@/types/proto-es/v1/sql_service_pb";
 import { Advice_Level } from "@/types/proto-es/v1/sql_service_pb";
 import { usePlanSQLCheckContext } from "./context";

--- a/frontend/src/components/Plan/components/SQLCheckSection/SQLCheckButton.vue
+++ b/frontend/src/components/Plan/components/SQLCheckSection/SQLCheckButton.vue
@@ -31,7 +31,7 @@
   <SQLCheckPanel
     v-if="checkResult && advices && showDetailPanel"
     :project="project.name"
-    :database="database"
+    :database="database as Database"
     :advices="advices"
     :affected-rows="checkResult.affectedRows"
     :risk-level="checkResult.riskLevel"
@@ -58,6 +58,7 @@ import ErrorList from "@/components/misc/ErrorList.vue";
 import { SQLCheckPanel } from "@/components/SQLCheck";
 import { STATEMENT_SKIP_CHECK_THRESHOLD } from "@/components/SQLCheck/common";
 import { releaseServiceClientConnect } from "@/connect";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { CheckReleaseResponse } from "@/types/proto-es/v1/release_service_pb";
 import {
   CheckReleaseRequestSchema,

--- a/frontend/src/components/Plan/components/SpecDetailView/AllTargetsDrawer.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/AllTargetsDrawer.vue
@@ -65,6 +65,7 @@ import { BBSpin } from "@/bbkit";
 import { Drawer, DrawerContent, SearchBox } from "@/components/v2";
 import { useDatabaseV1Store, useDBGroupStore } from "@/store";
 import { isValidDatabaseGroupName, isValidDatabaseName } from "@/types";
+import { extractDatabaseResourceName } from "@/utils";
 import DatabaseDisplay from "../common/DatabaseDisplay.vue";
 import { useSelectedSpec } from "./context";
 import DatabaseGroupTargetDisplay from "./DatabaseGroupTargetDisplay.vue";
@@ -102,7 +103,9 @@ const filteredTargets = computed(() => {
   return props.targets.filter((target: string) => {
     if (isValidDatabaseName(target)) {
       const db = databaseStore.getDatabaseByName(target);
-      return db.databaseName.toLowerCase().includes(searchText);
+      return extractDatabaseResourceName(db.name)
+        .databaseName.toLowerCase()
+        .includes(searchText);
     }
     return (target as string).toLocaleLowerCase().includes(searchText);
   });

--- a/frontend/src/components/Plan/components/StatementSection/EditorView/EditorView.vue
+++ b/frontend/src/components/Plan/components/StatementSection/EditorView/EditorView.vue
@@ -122,7 +122,7 @@
         :dialect="dialect"
         :advices="isEditorReadonly || isCreating ? markers : []"
         :auto-complete-context="{
-          instance: database.instance,
+          instance: extractDatabaseResourceName(database.name).instance,
           database: database.name,
           scene: 'all',
         }"
@@ -170,7 +170,7 @@
         :dialect="dialect"
         :advices="isEditorReadonly || isCreating ? markers : []"
         :auto-complete-context="{
-          instance: database.instance,
+          instance: extractDatabaseResourceName(database.name).instance,
           database: database.name,
           scene: 'all',
         }"
@@ -222,6 +222,8 @@ import { dialectOfEngineV1, isValidDatabaseGroupName } from "@/types";
 import { UpdatePlanRequestSchema } from "@/types/proto-es/v1/plan_service_pb";
 import { SheetSchema } from "@/types/proto-es/v1/sheet_service_pb";
 import {
+  extractDatabaseResourceName,
+  getInstanceResource,
   getSheetStatement,
   getStatementSize,
   setSheetStatement,
@@ -259,17 +261,16 @@ const database = computed(() => {
   return databaseForSpec(project.value, selectedSpec.value);
 });
 
-const language = useInstanceV1EditorLanguage(
-  computed(() => database.value.instanceResource)
-);
+const instanceResource = computed(() => getInstanceResource(database.value));
+
+const language = useInstanceV1EditorLanguage(instanceResource);
 const filename = computed(() => {
   const name = uuidv1();
   const ext = extensionNameOfLanguage(language.value);
   return `${name}.${ext}`;
 });
 const dialect = computed((): SQLDialect => {
-  const db = database.value;
-  return dialectOfEngineV1(db.instanceResource.engine);
+  return dialectOfEngineV1(instanceResource.value.engine);
 });
 const statementTitle = computed(() => {
   return language.value === "sql" ? t("common.sql") : t("common.statement");
@@ -387,7 +388,7 @@ const shouldShowSchemaEditorButton = computed(() => {
       return false;
     }
     const db = databaseStore.getDatabaseByName(targetName);
-    return engineSupportsSchemaEditor(db.instanceResource.engine);
+    return engineSupportsSchemaEditor(getInstanceResource(db).engine);
   });
 });
 

--- a/frontend/src/components/Plan/components/StatementSection/SchemaEditorDrawer.vue
+++ b/frontend/src/components/Plan/components/StatementSection/SchemaEditorDrawer.vue
@@ -71,6 +71,7 @@ import { Drawer, DrawerContent } from "@/components/v2";
 import { useDatabaseV1Store, useDBSchemaV1Store } from "@/store";
 import { DEBOUNCE_SEARCH_DELAY } from "@/types";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import { extractDatabaseResourceName, getInstanceResource } from "@/utils";
 import { engineSupportsSchemaEditor } from "@/utils/schemaEditor";
 import { DEFAULT_VISIBLE_TARGETS } from "../SpecDetailView/context";
 
@@ -137,10 +138,11 @@ const databaseOptions = computed(() => {
     .slice(0, DEFAULT_VISIBLE_TARGETS * (pageIndex + 1))
     .map((dbName) => {
       const db = databaseStore.getDatabaseByName(dbName);
+      const instanceResource = getInstanceResource(db);
       return {
-        label: `${db.databaseName} (${db.instanceResource.title})`,
+        label: `${extractDatabaseResourceName(db.name).databaseName} (${instanceResource.title})`,
         value: db.name,
-        disabled: !engineSupportsSchemaEditor(db.instanceResource.engine),
+        disabled: !engineSupportsSchemaEditor(instanceResource.engine),
       };
     });
 });

--- a/frontend/src/components/Plan/logic/issue.ts
+++ b/frontend/src/components/Plan/logic/issue.ts
@@ -27,7 +27,7 @@ export const preCreateIssue = async (project: string, targets: string[]) => {
       databaseNames.push(dbGroup.title);
     } else if (isValidDatabaseName(target)) {
       const db = databaseStore.getDatabaseByName(target);
-      databaseNames.push(db.databaseName);
+      databaseNames.push(extractDatabaseResourceName(db.name).databaseName);
     }
   }
 

--- a/frontend/src/components/Plan/logic/plan.ts
+++ b/frontend/src/components/Plan/logic/plan.ts
@@ -9,7 +9,7 @@ import { Engine } from "@/types/proto-es/v1/common_pb";
 import { DatabaseGroupView } from "@/types/proto-es/v1/database_group_service_pb";
 import type { Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
-import { mockDatabase } from "@/utils";
+import { getInstanceResource, mockDatabase } from "@/utils";
 
 export const databaseForSpec = (project: Project, spec: Plan_Spec) => {
   const targets = targetsForSpec(spec);
@@ -57,7 +57,7 @@ export const databaseEngineForSpec = async (
       target,
       true /* silent */
     );
-    return db.instanceResource.engine;
+    return getInstanceResource(db).engine;
   }
   if (isValidDatabaseGroupName(target)) {
     const dbGroupStore = useDBGroupStore();
@@ -72,7 +72,7 @@ export const databaseEngineForSpec = async (
         /* silent */ true
       );
       if (isValidDatabaseName(db.name)) {
-        return db.instanceResource.engine;
+        return getInstanceResource(db).engine;
       }
     }
   }

--- a/frontend/src/components/PlanCheckRun/PlanCheckRunBar.vue
+++ b/frontend/src/components/PlanCheckRun/PlanCheckRunBar.vue
@@ -36,7 +36,7 @@
 import { create } from "@bufbuild/protobuf";
 import { ref } from "vue";
 import { planServiceClientConnect } from "@/connect";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import {
   PlanCheckRun_Result_Type,
@@ -54,7 +54,7 @@ const props = withDefaults(
     labelClass?: VueClass;
     planName: string;
     planCheckRunList?: PlanCheckRun[];
-    database: ComposedDatabase;
+    database: Database;
   }>(),
   {
     allowRunChecks: true,

--- a/frontend/src/components/PlanCheckRun/PlanCheckRunDetail.vue
+++ b/frontend/src/components/PlanCheckRun/PlanCheckRunDetail.vue
@@ -243,7 +243,7 @@ import { SQLRuleEditDialog } from "@/components/SQLReview/components";
 import { planServiceClientConnect } from "@/connect";
 import { WORKSPACE_ROUTE_SQL_REVIEW } from "@/router/dashboard/workspaceRoutes";
 import { useReviewPolicyForDatabase } from "@/store";
-import type { ComposedDatabase, RuleTemplateV2 } from "@/types";
+import type { RuleTemplateV2 } from "@/types";
 import {
   convertPolicyRuleToRuleTemplate,
   GeneralErrorCode,
@@ -252,6 +252,7 @@ import {
   ruleTypeToString,
   SQLReviewPolicyErrorCode,
 } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type {
   PlanCheckRun,
   PlanCheckRun_Result,
@@ -290,7 +291,7 @@ type LocalState = {
 const props = defineProps<{
   planCheckRun: PlanCheckRun;
   showCodeLocation?: boolean;
-  database?: ComposedDatabase;
+  database?: Database;
 }>();
 
 const { t } = useI18n();
@@ -347,7 +348,7 @@ const getRuleTemplateByType = (type: string) => {
     return;
   }
 
-  if (props.database) {
+  if (props.database?.instanceResource) {
     return ruleTemplateMapV2
       .get(props.database.instanceResource.engine)
       ?.get(typeEnum);
@@ -508,7 +509,7 @@ const reviewPolicy = useReviewPolicyForDatabase(
 );
 
 const getActiveRule = (type: string): RuleTemplateV2 | undefined => {
-  const engine = props.database?.instanceResource.engine;
+  const engine = props.database?.instanceResource?.engine;
   if (isBuiltinRule(type) && engine) {
     const typeEnum = builtinRuleType(type);
     if (!typeEnum) {

--- a/frontend/src/components/PlanCheckRun/PlanCheckRunModal.vue
+++ b/frontend/src/components/PlanCheckRun/PlanCheckRunModal.vue
@@ -17,7 +17,7 @@
 
 <script setup lang="ts">
 import { BBModal } from "@/bbkit";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import { PlanCheckRun_Result_Type } from "@/types/proto-es/v1/plan_service_pb";
 import PlanCheckRunPanel from "./PlanCheckRunPanel.vue";
@@ -25,7 +25,7 @@ import PlanCheckRunPanel from "./PlanCheckRunPanel.vue";
 defineProps<{
   planCheckRunList: PlanCheckRun[];
   selectedType: PlanCheckRun_Result_Type;
-  database: ComposedDatabase;
+  database: Database;
 }>();
 
 defineEmits<{

--- a/frontend/src/components/PlanCheckRun/PlanCheckRunPanel.vue
+++ b/frontend/src/components/PlanCheckRun/PlanCheckRunPanel.vue
@@ -28,7 +28,8 @@ import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import type { TabFilterItem } from "@/components/v2";
 import { TabFilter } from "@/components/v2";
-import { type ComposedDatabase, getDateForPbTimestampProtoEs } from "@/types";
+import { getDateForPbTimestampProtoEs } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   type PlanCheckRun,
   PlanCheckRun_Result_Type,
@@ -41,7 +42,7 @@ import PlanCheckRunDetail from "./PlanCheckRunDetail.vue";
 
 const props = defineProps<{
   planCheckRunList: PlanCheckRun[];
-  database: ComposedDatabase;
+  database: Database;
   selectedType?: PlanCheckRun_Result_Type;
 }>();
 

--- a/frontend/src/components/ProjectDatabasesPanel.vue
+++ b/frontend/src/components/ProjectDatabasesPanel.vue
@@ -68,8 +68,9 @@ import {
   environmentNamePrefix,
   instanceNamePrefix,
 } from "@/store/modules/v1/common";
-import { type ComposedDatabase, isValidDatabaseName } from "@/types";
+import { isValidDatabaseName } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import type { SearchParams, SearchScope } from "@/utils";
 import {
@@ -170,7 +171,7 @@ const filter = computed(() => ({
   drifted: selectedDriftedValue.value,
 }));
 
-const selectedDatabases = computed((): ComposedDatabase[] => {
+const selectedDatabases = computed((): Database[] => {
   return state.selectedDatabaseNames
     .map((databaseName) => databaseStore.getDatabaseByName(databaseName))
     .filter((database) => isValidDatabaseName(database.name));

--- a/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
+++ b/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
@@ -160,6 +160,8 @@ import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import {
   checkRoleContainsAnyPermission,
   displayRoleTitle,
+  extractDatabaseResourceName,
+  getInstanceResource,
   hasProjectPermissionV2,
 } from "@/utils";
 import { buildConditionExpr, convertFromExpr } from "@/utils/issue/cel";
@@ -263,7 +265,7 @@ const getDataTableColumns = (
             return (
               <div class="flex items-center gap-x-1">
                 <InstanceV1Name
-                  instance={database.instanceResource}
+                  instance={getInstanceResource(database)}
                   link={false}
                 />
                 <span>/</span>
@@ -491,7 +493,8 @@ const extractDatabaseName = (databaseResource?: DatabaseResource) => {
     return "*";
   }
   const database = extractDatabase(databaseResource);
-  return database.databaseName;
+  const { databaseName } = extractDatabaseResourceName(database.name);
+  return databaseName;
 };
 
 const extractSchemaName = (databaseResource?: DatabaseResource) => {

--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -59,6 +59,7 @@ import {
 } from "@/types";
 import {
   emptySQLEditorConnection,
+  extractDatabaseResourceName,
   extractInstanceResourceName,
   extractProjectResourceName,
   extractWorksheetConnection,
@@ -225,8 +226,9 @@ const prepareConnectionParams = async () => {
     return false;
   }
   // connected to db
+  const { instance } = extractDatabaseResourceName(database.name);
   const connection = {
-    instance: database.instance,
+    instance,
     database: database.name,
   };
   tabStore.addTab({
@@ -327,12 +329,13 @@ const syncURLWithConnection = () => {
           query.table = table;
           query.schema = schema ?? "";
         }
+        const dbResource = extractDatabaseResourceName(database.name);
         router.replace({
           name: SQL_EDITOR_DATABASE_MODULE,
           params: {
             project: extractProjectResourceName(database.project),
-            instance: extractInstanceResourceName(database.instance),
-            database: database.databaseName,
+            instance: extractInstanceResourceName(dbResource.instance),
+            database: dbResource.databaseName,
           },
           query,
         });

--- a/frontend/src/components/Revision/RevisionDetailPanel.vue
+++ b/frontend/src/components/Revision/RevisionDetailPanel.vue
@@ -76,8 +76,8 @@ import { TaskRunLogViewer } from "@/components/RolloutV1/components/TaskRunLogVi
 import { CopyButton } from "@/components/v2";
 import { sheetServiceClientConnect } from "@/connect";
 import { useRevisionStore } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { getDateForPbTimestampProtoEs } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
 import { bytesToString } from "@/utils";
 import { extractTaskLink, getRevisionType } from "@/utils/v1/revision";
@@ -88,7 +88,7 @@ interface LocalState {
 }
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   revisionName: string;
 }>();
 

--- a/frontend/src/components/SQLCheck/SQLCheckButton.vue
+++ b/frontend/src/components/SQLCheck/SQLCheckButton.vue
@@ -74,8 +74,10 @@ import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { BBSpin } from "@/bbkit";
 import { releaseServiceClientConnect } from "@/connect";
-import type { ComposedDatabase } from "@/types";
-import type { DatabaseMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  DatabaseMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 import type { CheckReleaseResponse } from "@/types/proto-es/v1/release_service_pb";
 import {
   CheckReleaseRequestSchema,
@@ -98,7 +100,7 @@ const props = withDefaults(
       errors: string[];
       statement: string;
     }>;
-    database: ComposedDatabase;
+    database: Database;
     databaseMetadata?: DatabaseMetadata;
     buttonProps?: ButtonProps;
     buttonStyle?: VueStyle;

--- a/frontend/src/components/SQLCheck/SQLCheckPanel.vue
+++ b/frontend/src/components/SQLCheck/SQLCheckPanel.vue
@@ -61,8 +61,8 @@ import { useI18n } from "vue-i18n";
 import { BBModal } from "@/bbkit";
 import PlanCheckRunDetail from "@/components/PlanCheckRun/PlanCheckRunDetail.vue";
 import { useProjectV1Store } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { RiskLevel } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import {
   PlanCheckRun_Result_SqlReviewReportSchema,
@@ -77,7 +77,7 @@ const props = withDefaults(
   defineProps<{
     project: string;
     advices: Advice[];
-    database?: ComposedDatabase;
+    database?: Database;
     affectedRows?: bigint;
     riskLevel?: RiskLevel;
     overrideTitle?: string;

--- a/frontend/src/components/SQLCheck/SQLCheckSummary.vue
+++ b/frontend/src/components/SQLCheck/SQLCheckSummary.vue
@@ -15,7 +15,7 @@
 <script setup lang="ts">
 import { NButton } from "naive-ui";
 import { computed } from "vue";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Advice } from "@/types/proto-es/v1/sql_service_pb";
 import { Advice_Level } from "@/types/proto-es/v1/sql_service_pb";
 
@@ -26,7 +26,7 @@ type Summary = {
 };
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   advices: Advice[];
 }>();
 

--- a/frontend/src/components/SchemaDiagram/Canvas/Canvas.vue
+++ b/frontend/src/components/SchemaDiagram/Canvas/Canvas.vue
@@ -55,6 +55,7 @@
 <script lang="ts" setup>
 import { NButton, NButtonGroup, NTooltip } from "naive-ui";
 import { ref, useSlots } from "vue";
+import { extractDatabaseResourceName } from "@/utils";
 import Square2x2 from "~icons/heroicons-outline/squares-2x2";
 import { useSchemaDiagramContext } from "../common";
 import { ZOOM_RANGE } from "../common/const";
@@ -81,7 +82,8 @@ const renderDummy = () => {
 const handleScreenshot = async () => {
   busy.value = true;
   try {
-    await dummy.value?.capture(`${database.value.databaseName}.png`);
+    const { databaseName } = extractDatabaseResourceName(database.value.name);
+    await dummy.value?.capture(`${databaseName}.png`);
   } catch (err) {
     console.error("Screenshot request failed", err);
   } finally {

--- a/frontend/src/components/SchemaDiagram/Navigator/Navigator.vue
+++ b/frontend/src/components/SchemaDiagram/Navigator/Navigator.vue
@@ -6,7 +6,7 @@
     >
       <div class="p-1 flex flex-col gap-y-2">
         <SchemaSelector
-          v-if="hasSchemaProperty(database.instanceResource.engine)"
+          v-if="hasSchemaProperty(instanceEngine)"
           :schemas="databaseMetadata.schemas"
           v-model:value="selectedSchemaNames"
         />
@@ -40,8 +40,8 @@
 
 <script lang="ts" setup>
 import { NInput } from "naive-ui";
-import { reactive } from "vue";
-import { hasSchemaProperty } from "@/utils";
+import { computed, reactive } from "vue";
+import { getInstanceResource, hasSchemaProperty } from "@/utils";
 import { useSchemaDiagramContext } from "../common";
 import SchemaSelector from "./SchemaSelector.vue";
 import Tree from "./Tree.vue";
@@ -58,4 +58,8 @@ const state = reactive<LocalState>({
 
 const { databaseMetadata, selectedSchemaNames, database } =
   useSchemaDiagramContext();
+
+const instanceEngine = computed(
+  () => getInstanceResource(database.value).engine
+);
 </script>

--- a/frontend/src/components/SchemaDiagram/Navigator/Tree.vue
+++ b/frontend/src/components/SchemaDiagram/Navigator/Tree.vue
@@ -19,7 +19,11 @@
 <script lang="ts" setup>
 import { NTree, type TreeOption } from "naive-ui";
 import { computed, h } from "vue";
-import { hasSchemaProperty, isDescendantOf } from "@/utils";
+import {
+  getInstanceResource,
+  hasSchemaProperty,
+  isDescendantOf,
+} from "@/utils";
 import { useSchemaDiagramContext } from "../common";
 import { DEFAULT_PADDINGS } from "../common/const";
 import { Label, Prefix, Suffix } from "./TreeNode";
@@ -39,7 +43,7 @@ const context = useSchemaDiagramContext();
 const { selectedSchemas, events, database } = context;
 
 const isFlatTree = computed(() => {
-  return hasSchemaProperty(database.value.instanceResource.engine);
+  return hasSchemaProperty(getInstanceResource(database.value).engine);
 });
 
 const treeData = computed(() => {

--- a/frontend/src/components/SchemaDiagram/SchemaDiagram.vue
+++ b/frontend/src/components/SchemaDiagram/SchemaDiagram.vue
@@ -34,9 +34,9 @@ import Emittery from "emittery";
 import { uniqueId } from "lodash-es";
 import { computed, nextTick, ref, toRef, watch } from "vue";
 import { BBSpin } from "@/bbkit";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -58,7 +58,7 @@ import type {
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     databaseMetadata: DatabaseMetadata;
     editable?: boolean;
     schemaStatus?: (schema: SchemaMetadata) => EditStatus;

--- a/frontend/src/components/SchemaDiagram/types/context.ts
+++ b/frontend/src/components/SchemaDiagram/types/context.ts
@@ -1,8 +1,8 @@
 import type Emittery from "emittery";
 import type { Ref } from "vue";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -16,7 +16,7 @@ import type { ForeignKey } from "./schema";
 // and used in its descendants.
 export type SchemaDiagramContext = {
   // Props
-  database: Ref<ComposedDatabase>;
+  database: Ref<Database>;
   databaseMetadata: Ref<DatabaseMetadata>;
   editable: Ref<boolean>;
 

--- a/frontend/src/components/SchemaEditorLite/Aside/NodePrefix.vue
+++ b/frontend/src/components/SchemaEditorLite/Aside/NodePrefix.vue
@@ -11,7 +11,7 @@
     <template v-if="node.type === 'database'">
       <DatabaseIcon class="w-4 h-auto text-gray-400" />
       <span class="text-gray-500">
-        {{ node.db.effectiveEnvironmentEntity.title }}
+        {{ getDatabaseEnvironment(node.db).title }}
       </span>
     </template>
 
@@ -70,6 +70,7 @@ import {
 } from "@/components/Icon";
 import { InstanceV1EngineIcon } from "@/components/v2";
 import { useEnvironmentV1Store } from "@/store";
+import { getDatabaseEnvironment } from "@/utils";
 import { useSchemaEditorContext } from "../context";
 import type { TreeNode, TreeNodeForInstance } from "./common";
 import NodeCheckbox from "./NodeCheckbox";

--- a/frontend/src/components/SchemaEditorLite/Aside/Tree.vue
+++ b/frontend/src/components/SchemaEditorLite/Aside/Tree.vue
@@ -114,8 +114,8 @@ import { useI18n } from "vue-i18n";
 import { SearchBox } from "@/components/v2";
 import { useEmitteryEventListener } from "@/composables/useEmitteryEventListener";
 import { useDBSchemaV1Store } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   FunctionMetadata,
   ProcedureMetadata,
@@ -124,6 +124,7 @@ import type {
   ViewMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
 import {
+  getDatabaseEngine,
   getFixedPrimaryKey,
   getHighlightHTMLByKeyWords,
   isDescendantOf,
@@ -150,30 +151,30 @@ import NodePrefix from "./NodePrefix.vue";
 interface LocalState {
   shouldRelocateTreeNode: boolean;
   schemaNameModalContext?: {
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     schema?: SchemaMetadata;
   };
   tableNameModalContext?: {
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     schema: SchemaMetadata;
     table?: TableMetadata;
   };
   procedureNameModalContext?: {
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     schema: SchemaMetadata;
     procedure?: ProcedureMetadata;
   };
   viewNameModalContext?: {
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     schema: SchemaMetadata;
     view?: ViewMetadata;
   };
   functionNameModalContext?: {
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     schema: SchemaMetadata;
     function?: FunctionMetadata;
@@ -588,7 +589,7 @@ const renderSuffix = ({ option }: { option: TreeOption }) => {
     },
   });
   if (node.type === "database") {
-    const { engine } = node.db.instanceResource;
+    const engine = getDatabaseEngine(node.db);
     if (engineSupportsMultiSchema(engine)) {
       icons.push(menuIcon);
     }
@@ -625,7 +626,7 @@ const renderSuffix = ({ option }: { option: TreeOption }) => {
 
 const handleDuplicateTable = (treeNode: TreeNodeForTable) => {
   const { db } = treeNode;
-  const engine = db.instanceResource.engine;
+  const engine = getDatabaseEngine(db);
   const { schema, table } = treeNode.metadata;
   const flattenTableList = treeNode.metadata.database.schemas.flatMap(
     (schema) => schema.tables

--- a/frontend/src/components/SchemaEditorLite/Aside/context-menu.ts
+++ b/frontend/src/components/SchemaEditorLite/Aside/context-menu.ts
@@ -2,9 +2,9 @@ import Emittery from "emittery";
 import type { DropdownOption } from "naive-ui";
 import { computed, type Ref, reactive } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
-import { isDescendantOf } from "@/utils";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { getDatabaseEngine, isDescendantOf } from "@/utils";
 import { useSchemaEditorContext } from "../context";
 import { engineSupportsMultiSchema } from "../spec";
 import type {
@@ -80,7 +80,7 @@ export const useContextMenu = (): ContextMenuContext => {
     if (!node) return [];
     if (typeof node.db === "undefined") return [];
 
-    const { engine } = (node.db as ComposedDatabase).instanceResource;
+    const engine = getDatabaseEngine(node.db as Database);
     if (node.type === "database") {
       if (engineSupportsMultiSchema(engine)) {
         return [

--- a/frontend/src/components/SchemaEditorLite/Modals/EditColumnForeignKeyModal.vue
+++ b/frontend/src/components/SchemaEditorLite/Modals/EditColumnForeignKeyModal.vue
@@ -83,16 +83,16 @@ import type { SelectOption } from "naive-ui";
 import { NButton, NInput, NInputGroup, NSelect } from "naive-ui";
 import { computed, onMounted, reactive } from "vue";
 import { BBModal } from "@/bbkit";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   ForeignKeyMetadata,
   SchemaMetadata,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
 import { ForeignKeyMetadataSchema } from "@/types/proto-es/v1/database_service_pb";
-import { hasSchemaProperty } from "@/utils";
+import { getDatabaseEngine, hasSchemaProperty } from "@/utils";
 import { useSchemaEditorContext } from "../context";
 import {
   removeColumnFromForeignKey,
@@ -119,7 +119,7 @@ type ColumnSelectOption = TableSelectOption & {
 };
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   metadata: DatabaseMetadata;
   schema: SchemaMetadata;
   table: TableMetadata;
@@ -139,7 +139,7 @@ const state = reactive<LocalState>({
   foreignKeyName: "",
 });
 const engine = computed(() => {
-  return props.database.instanceResource.engine;
+  return getDatabaseEngine(props.database);
 });
 
 const referencedSchema = computed(() => {

--- a/frontend/src/components/SchemaEditorLite/Modals/FunctionNameModal.vue
+++ b/frontend/src/components/SchemaEditorLite/Modals/FunctionNameModal.vue
@@ -36,8 +36,8 @@ import { computed, onMounted, reactive, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { BBModal } from "@/bbkit";
 import { useNotificationStore } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   FunctionMetadata,
   SchemaMetadata,
@@ -53,7 +53,7 @@ interface LocalState {
 }
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   metadata: DatabaseMetadata;
   schema: SchemaMetadata;
   func?: FunctionMetadata;

--- a/frontend/src/components/SchemaEditorLite/Modals/ProcedureNameModal.vue
+++ b/frontend/src/components/SchemaEditorLite/Modals/ProcedureNameModal.vue
@@ -36,8 +36,8 @@ import { computed, onMounted, reactive, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { BBModal } from "@/bbkit";
 import { useNotificationStore } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   ProcedureMetadata,
   SchemaMetadata,
@@ -53,7 +53,7 @@ interface LocalState {
 }
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   metadata: DatabaseMetadata;
   schema: SchemaMetadata;
   procedure?: ProcedureMetadata;

--- a/frontend/src/components/SchemaEditorLite/Modals/SchemaNameModal.vue
+++ b/frontend/src/components/SchemaEditorLite/Modals/SchemaNameModal.vue
@@ -31,8 +31,10 @@ import { reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import { BBModal } from "@/bbkit";
 import { useNotificationStore } from "@/store";
-import type { ComposedDatabase } from "@/types";
-import type { DatabaseMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  DatabaseMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 import { SchemaMetadataSchema } from "@/types/proto-es/v1/database_service_pb";
 import { useSchemaEditorContext } from "../context";
 
@@ -43,7 +45,7 @@ interface LocalState {
 }
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   metadata: DatabaseMetadata;
 }>();
 

--- a/frontend/src/components/SchemaEditorLite/Modals/TableNameModal.vue
+++ b/frontend/src/components/SchemaEditorLite/Modals/TableNameModal.vue
@@ -36,9 +36,9 @@ import { computed, onMounted, reactive, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { BBModal } from "@/bbkit";
 import { useNotificationStore } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -47,6 +47,7 @@ import {
   ColumnMetadataSchema,
   TableMetadataSchema,
 } from "@/types/proto-es/v1/database_service_pb";
+import { getDatabaseEngine } from "@/utils";
 import { useSchemaEditorContext } from "../context";
 import { upsertColumnPrimaryKey } from "../edit";
 
@@ -58,7 +59,7 @@ interface LocalState {
 }
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   metadata: DatabaseMetadata;
   schema: SchemaMetadata;
   table?: TableMetadata;
@@ -119,7 +120,7 @@ const handleConfirmButtonClick = async () => {
 
     const column = create(ColumnMetadataSchema, {});
     column.name = "id";
-    const engine = props.database.instanceResource.engine;
+    const engine = getDatabaseEngine(props.database);
     column.type = engine === Engine.POSTGRES ? "integer" : "int";
     column.comment = "";
     table.columns.push(column);

--- a/frontend/src/components/SchemaEditorLite/Modals/ViewNameModal.vue
+++ b/frontend/src/components/SchemaEditorLite/Modals/ViewNameModal.vue
@@ -36,8 +36,8 @@ import { computed, onMounted, reactive, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { BBModal } from "@/bbkit";
 import { useNotificationStore } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   ViewMetadata,
@@ -53,7 +53,7 @@ interface LocalState {
 }
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   metadata: DatabaseMetadata;
   schema: SchemaMetadata;
   view?: ViewMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/ColumnSelectionSummary.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/ColumnSelectionSummary.vue
@@ -7,15 +7,15 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useSchemaEditorContext } from "@/components/SchemaEditorLite/context";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   metadata: {
     database: DatabaseMetadata;
     schema: SchemaMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/CommonCodeEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/CommonCodeEditor.vue
@@ -8,7 +8,7 @@
         :content="state.code"
         :readonly="!editable"
         :auto-complete-context="{
-          instance: db.instance,
+          instance: extractDatabaseResourceName(db.name).instance,
           database: db.name,
           scene: 'all',
         }"
@@ -23,7 +23,8 @@
 <script setup lang="ts">
 import { computed, reactive, watch } from "vue";
 import { MonacoEditor } from "@/components/MonacoEditor";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { extractDatabaseResourceName } from "@/utils";
 import type { EditStatus } from "..";
 
 type LocalState = {
@@ -31,7 +32,7 @@ type LocalState = {
 };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   code: string;
   readonly: boolean;
   status: EditStatus;

--- a/frontend/src/components/SchemaEditorLite/Panels/DatabaseEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/DatabaseEditor.vue
@@ -122,14 +122,15 @@ import { PlusIcon } from "lucide-vue-next";
 import { NButton, NSelect, NTooltip } from "naive-ui";
 import { computed, nextTick, reactive, watch } from "vue";
 import SchemaDiagram, { SchemaDiagramIcon } from "@/components/SchemaDiagram";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
+import { getDatabaseEngine } from "@/utils";
 import { useSchemaEditorContext } from "../context";
 import TableNameModal from "../Modals/TableNameModal.vue";
 import TableList from "./TableList";
@@ -141,7 +142,7 @@ defineOptions({
 
 const props = withDefaults(
   defineProps<{
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     selectedSchemaName: string | undefined;
     searchPattern?: string;
@@ -172,7 +173,7 @@ const state = reactive<LocalState>({
   showFeatureModal: false,
 });
 const engine = computed(() => {
-  return props.db.instanceResource.engine;
+  return getDatabaseEngine(props.db);
 });
 const selectedSchema = computed(() => {
   return props.database.schemas.find(

--- a/frontend/src/components/SchemaEditorLite/Panels/FunctionEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/FunctionEditor.vue
@@ -10,8 +10,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   FunctionMetadata,
   SchemaMetadata,
@@ -21,7 +21,7 @@ import type { EditStatus } from "../types";
 import CommonCodeEditor from "./CommonCodeEditor.vue";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   func: FunctionMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/IndexesEditor/IndexesEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/IndexesEditor/IndexesEditor.vue
@@ -32,14 +32,15 @@ import { NCheckbox, NDataTable } from "naive-ui";
 import { computed, h, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { InlineInput } from "@/components/v2";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
+  Database,
   DatabaseMetadata,
   IndexMetadata,
   SchemaMetadata,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
+import { getDatabaseEngine } from "@/utils";
 import { markUUID } from "../common";
 import { ColumnsCell, OperationCell } from "./components";
 
@@ -47,7 +48,7 @@ const props = withDefaults(
   defineProps<{
     show?: boolean;
     readonly?: boolean;
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     schema: SchemaMetadata;
     table: TableMetadata;
@@ -173,7 +174,7 @@ const columns = computed(() => {
       render: (index) => {
         const allowTurnOnOrOffPrimary = () => {
           // Do not allow to edit primary key for TiDB.
-          if (props.db.instanceResource.engine === Engine.TIDB) {
+          if (getDatabaseEngine(props.db) === Engine.TIDB) {
             return false;
           }
 

--- a/frontend/src/components/SchemaEditorLite/Panels/IndexesEditor/components/ColumnsCell.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/IndexesEditor/components/ColumnsCell.vue
@@ -24,9 +24,9 @@ import type { SelectOption } from "naive-ui";
 import { NSelect, NTag } from "naive-ui";
 import type { CSSProperties } from "vue";
 import { computed, h, ref } from "vue";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   IndexMetadata,
   SchemaMetadata,
@@ -41,7 +41,7 @@ type ColumnOption = SelectOption & {
 
 const props = defineProps<{
   readonly?: boolean;
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   table: TableMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/PartitionsEditor/PartitionsEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/PartitionsEditor/PartitionsEditor.vue
@@ -33,8 +33,8 @@ import { ChevronDownIcon } from "lucide-vue-next";
 import { type DataTableColumn, NDataTable } from "naive-ui";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -64,7 +64,7 @@ const props = withDefaults(
   defineProps<{
     show?: boolean;
     readonly?: boolean;
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     schema: SchemaMetadata;
     table: TableMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/PreviewPane.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/PreviewPane.vue
@@ -56,8 +56,8 @@ import { MonacoEditor } from "@/components/MonacoEditor";
 import MaskSpinner from "@/components/misc/MaskSpinner.vue";
 import { useEmitteryEventListener } from "@/composables/useEmitteryEventListener";
 import { databaseServiceClientConnect } from "@/connect";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
@@ -67,7 +67,7 @@ import { extractGrpcErrorMessage } from "@/utils/connect";
 import { useSchemaEditorContext } from "../context";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   title: string;

--- a/frontend/src/components/SchemaEditorLite/Panels/ProcedureEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/ProcedureEditor.vue
@@ -10,8 +10,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   ProcedureMetadata,
   SchemaMetadata,
@@ -21,7 +21,7 @@ import type { EditStatus } from "../types";
 import CommonCodeEditor from "./CommonCodeEditor.vue";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   procedure: ProcedureMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/TableColumnEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/TableColumnEditor.vue
@@ -40,10 +40,10 @@ import {
 } from "@/components/SchemaEditorLite";
 import { InlineInput } from "@/components/v2";
 import { pushNotification } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   ForeignKeyMetadata,
   SchemaMetadata,
@@ -68,7 +68,7 @@ const props = withDefaults(
     show?: boolean;
     readonly: boolean;
     showForeignKey?: boolean;
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     schema: SchemaMetadata;
     table: TableMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/ForeignKeyCell.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/ForeignKeyCell.vue
@@ -36,18 +36,19 @@
 import { PenSquareIcon } from "lucide-vue-next";
 import { computed } from "vue";
 import { MiniActionButton } from "@/components/v2";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   ForeignKeyMetadata,
   SchemaMetadata,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
+import { getDatabaseEngine } from "@/utils";
 import { engineSupportsMultiSchema } from "../../../spec";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   table: TableMetadata;
@@ -90,7 +91,7 @@ const referencedNameForFk = (fk: ForeignKeyMetadata) => {
     (column) => column.name === fk.referencedColumns[position]
   );
 
-  if (engineSupportsMultiSchema(props.db.instanceResource.engine)) {
+  if (engineSupportsMultiSchema(getDatabaseEngine(props.db))) {
     return `${referencedSchema.name}.${referencedTable.name}(${referencedColumn?.name})`;
   } else {
     return `${referencedTable.name}(${referencedColumn?.name})`;

--- a/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/SelectionCell.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableColumnEditor/components/SelectionCell.vue
@@ -10,16 +10,16 @@
 import { NCheckbox } from "naive-ui";
 import { computed } from "vue";
 import { useSchemaEditorContext } from "@/components/SchemaEditorLite/context";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   metadata: {
     database: DatabaseMetadata;
     schema: SchemaMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/TableEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableEditor.vue
@@ -161,10 +161,10 @@ import { ArrowLeftIcon, PlusIcon } from "lucide-vue-next";
 import { NButton } from "naive-ui";
 import { computed, reactive, ref } from "vue";
 import { IndexIcon, TablePartitionIcon } from "@/components/Icon";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   ForeignKeyMetadata,
   SchemaMetadata,
@@ -177,7 +177,11 @@ import {
   TablePartitionMetadata_Type,
   TablePartitionMetadataSchema,
 } from "@/types/proto-es/v1/database_service_pb";
-import { instanceV1AllowsReorderColumns, randomString } from "@/utils";
+import {
+  getDatabaseEngine,
+  instanceV1AllowsReorderColumns,
+  randomString,
+} from "@/utils";
 import { useSchemaEditorContext } from "../context";
 import EditColumnForeignKeyModal from "../Modals/EditColumnForeignKeyModal.vue";
 import {
@@ -195,7 +199,7 @@ type EditMode = "COLUMNS" | "INDEXES" | "PARTITIONS";
 
 const props = withDefaults(
   defineProps<{
-    db: ComposedDatabase;
+    db: Database;
     database: DatabaseMetadata;
     schema: SchemaMetadata;
     table: TableMetadata;
@@ -226,7 +230,7 @@ const {
 } = useSchemaEditorContext();
 
 const engine = computed((): Engine => {
-  return props.db.instanceResource.engine;
+  return getDatabaseEngine(props.db);
 });
 const state = reactive<LocalState>({
   mode: "COLUMNS",

--- a/frontend/src/components/SchemaEditorLite/Panels/TableList/TableList.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableList/TableList.vue
@@ -32,8 +32,8 @@ import { NCheckbox, NDataTable } from "naive-ui";
 import { computed, h, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { InlineInput } from "@/components/v2";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -43,7 +43,7 @@ import { markUUID } from "../common";
 import { NameCell, OperationCell, SelectionCell } from "./components";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   tables: TableMetadata[];

--- a/frontend/src/components/SchemaEditorLite/Panels/TableList/components/SelectionCell.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableList/components/SelectionCell.vue
@@ -10,15 +10,15 @@
 import { NCheckbox } from "naive-ui";
 import { computed } from "vue";
 import { useSchemaEditorContext } from "@/components/SchemaEditorLite/context";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   metadata: {
     database: DatabaseMetadata;
     schema: SchemaMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/TableSelectionSummary.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/TableSelectionSummary.vue
@@ -6,15 +6,15 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
 import { useSchemaEditorContext } from "../context";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   metadata: {
     database: DatabaseMetadata;
     schema: SchemaMetadata;

--- a/frontend/src/components/SchemaEditorLite/Panels/ViewEditor.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/ViewEditor.vue
@@ -22,8 +22,8 @@
 import { create } from "@bufbuild/protobuf";
 import { cloneDeep } from "lodash-es";
 import { computed } from "vue";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   ViewMetadata,
@@ -35,7 +35,7 @@ import CommonCodeEditor from "./CommonCodeEditor.vue";
 import PreviewPane from "./PreviewPane.vue";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   view: ViewMetadata;

--- a/frontend/src/components/SchemaEditorLite/TabsContainer.vue
+++ b/frontend/src/components/SchemaEditorLite/TabsContainer.vue
@@ -64,6 +64,7 @@ import { XIcon } from "lucide-vue-next";
 import { NEllipsis } from "naive-ui";
 import scrollIntoView from "scroll-into-view-if-needed";
 import { nextTick, ref, watch } from "vue";
+import { extractDatabaseResourceName } from "@/utils";
 import {
   DatabaseIcon,
   FunctionIcon,
@@ -122,7 +123,7 @@ const getTabComputedClassList = (tab: TabContext) => {
 const getTabName = (tab: TabContext) => {
   if (tab.type === "database") {
     const { database } = tab;
-    return database.databaseName;
+    return extractDatabaseResourceName(database.name).databaseName;
   }
   if (tab.type === "table") {
     const {

--- a/frontend/src/components/SchemaEditorLite/algorithm/apply.ts
+++ b/frontend/src/components/SchemaEditorLite/algorithm/apply.ts
@@ -1,6 +1,8 @@
 import { cloneDeep } from "lodash-es";
-import type { ComposedDatabase } from "@/types";
-import type { DatabaseMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  DatabaseMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 import type { SchemaEditorContext } from "../context";
 
 export const useApplyMetadataEdit = (context: SchemaEditorContext) => {
@@ -14,7 +16,7 @@ export const useApplyMetadataEdit = (context: SchemaEditorContext) => {
   } = context;
 
   const applyMetadataEdit = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: DatabaseMetadata
   ) => {
     const response = cloneDeep(metadata);

--- a/frontend/src/components/SchemaEditorLite/algorithm/diff-merge.ts
+++ b/frontend/src/components/SchemaEditorLite/algorithm/diff-merge.ts
@@ -1,18 +1,16 @@
 import { cloneDeep, isEqual, pick } from "lodash-es";
-import type { ComposedDatabase } from "@/types";
 import type {
+  ColumnMetadata,
+  Database,
+  DatabaseMetadata,
+  ForeignKeyMetadata,
   FunctionMetadata,
+  IndexMetadata,
   ProcedureMetadata,
+  SchemaMetadata,
+  TableMetadata,
   TablePartitionMetadata,
   ViewMetadata,
-} from "@/types/proto-es/v1/database_service_pb";
-import {
-  type ColumnMetadata,
-  type DatabaseMetadata,
-  type ForeignKeyMetadata,
-  type IndexMetadata,
-  type SchemaMetadata,
-  type TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
 import {
   ComparableColumnFields,
@@ -39,7 +37,7 @@ type RichColumnMetadata = RichTableMetadata & {
 
 export class DiffMerge {
   context: SchemaEditorContext;
-  database: ComposedDatabase;
+  database: Database;
   sourceMetadata: DatabaseMetadata;
   targetMetadata: DatabaseMetadata;
   sourceSchemaMap = new Map<string, SchemaMetadata>();
@@ -72,7 +70,7 @@ export class DiffMerge {
     targetMetadata,
   }: {
     context: SchemaEditorContext;
-    database: ComposedDatabase;
+    database: Database;
     sourceMetadata: DatabaseMetadata;
     targetMetadata: DatabaseMetadata;
   }) {
@@ -684,7 +682,7 @@ export class DiffMerge {
 
 // database schema
 const mapSchemas = (
-  database: ComposedDatabase,
+  database: Database,
   schemas: SchemaMetadata[],
   map: Map<string, SchemaMetadata>
 ) => {
@@ -697,7 +695,7 @@ const mapSchemas = (
   });
 };
 const mapTables = (
-  database: ComposedDatabase,
+  database: Database,
   schema: SchemaMetadata,
   tables: TableMetadata[],
   map: Map<string, TableMetadata>
@@ -712,7 +710,7 @@ const mapTables = (
   });
 };
 const mapColumns = (
-  database: ComposedDatabase,
+  database: Database,
   schema: SchemaMetadata,
   table: TableMetadata,
   columns: ColumnMetadata[],
@@ -729,7 +727,7 @@ const mapColumns = (
   });
 };
 const mapTablePartitions = (
-  database: ComposedDatabase,
+  database: Database,
   schema: SchemaMetadata,
   table: TableMetadata,
   partitions: TablePartitionMetadata[],
@@ -746,7 +744,7 @@ const mapTablePartitions = (
   });
 };
 const mapViews = (
-  database: ComposedDatabase,
+  database: Database,
   schema: SchemaMetadata,
   views: ViewMetadata[],
   map: Map<string, ViewMetadata>
@@ -761,7 +759,7 @@ const mapViews = (
   });
 };
 const mapProcedures = (
-  database: ComposedDatabase,
+  database: Database,
   schema: SchemaMetadata,
   procedures: ProcedureMetadata[],
   map: Map<string, ProcedureMetadata>
@@ -776,7 +774,7 @@ const mapProcedures = (
   });
 };
 const mapFunctions = (
-  database: ComposedDatabase,
+  database: Database,
   schema: SchemaMetadata,
   functions: FunctionMetadata[],
   map: Map<string, FunctionMetadata>

--- a/frontend/src/components/SchemaEditorLite/common.ts
+++ b/frontend/src/components/SchemaEditorLite/common.ts
@@ -4,9 +4,12 @@ import { isEqual } from "lodash-es";
 import { sqlServiceClientConnect } from "@/connect";
 import { silentContextKey } from "@/connect/context-key";
 import { t } from "@/plugins/i18n";
-import type { ComposedDatabase } from "@/types";
-import type { DatabaseMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  DatabaseMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 import { DiffMetadataRequestSchema } from "@/types/proto-es/v1/sql_service_pb";
+import { getDatabaseEngine } from "@/utils";
 import { extractGrpcErrorMessage } from "@/utils/connect";
 import { validateDatabaseMetadata } from "./utils";
 
@@ -20,7 +23,7 @@ export const generateDiffDDL = async ({
   sourceMetadata,
   targetMetadata,
 }: {
-  database: ComposedDatabase;
+  database: Database;
   sourceMetadata: DatabaseMetadata;
   targetMetadata: DatabaseMetadata;
 }): Promise<GenerateDiffDDLResult> => {
@@ -46,7 +49,7 @@ export const generateDiffDDL = async ({
     const newRequest = create(DiffMetadataRequestSchema, {
       sourceMetadata: sourceMetadata,
       targetMetadata: targetMetadata,
-      engine: database.instanceResource.engine,
+      engine: getDatabaseEngine(database),
     });
     const diffResponse = await sqlServiceClientConnect.diffMetadata(
       newRequest,

--- a/frontend/src/components/SchemaEditorLite/context/common.ts
+++ b/frontend/src/components/SchemaEditorLite/context/common.ts
@@ -1,6 +1,6 @@
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   FunctionMetadata,
   ProcedureMetadata,
   SchemaMetadata,
@@ -10,7 +10,7 @@ import type {
 } from "@/types/proto-es/v1/database_service_pb";
 
 export const keyForResource = (
-  database: ComposedDatabase,
+  database: Database,
   metadata: {
     schema?: SchemaMetadata;
     table?: TableMetadata;

--- a/frontend/src/components/SchemaEditorLite/context/edit.ts
+++ b/frontend/src/components/SchemaEditorLite/context/edit.ts
@@ -1,7 +1,7 @@
 import { computed, ref } from "vue";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   FunctionMetadata,
   ProcedureMetadata,
   SchemaMetadata,
@@ -19,7 +19,7 @@ export const useEditStatus = () => {
   });
 
   const markEditStatus = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
       table?: TableMetadata;
@@ -44,7 +44,7 @@ export const useEditStatus = () => {
   };
 
   const removeEditStatus = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
       table?: TableMetadata;
@@ -67,7 +67,7 @@ export const useEditStatus = () => {
   };
 
   const getSchemaStatus = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
     }
@@ -83,7 +83,7 @@ export const useEditStatus = () => {
   };
 
   const getTableStatus = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
       table: TableMetadata;
@@ -100,7 +100,7 @@ export const useEditStatus = () => {
   };
 
   const replaceTableName = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
       table: TableMetadata;
@@ -135,7 +135,7 @@ export const useEditStatus = () => {
   };
 
   const getColumnStatus = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
       table: TableMetadata;
@@ -153,7 +153,7 @@ export const useEditStatus = () => {
   };
 
   const getPartitionStatus = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
       table: TableMetadata;
@@ -171,7 +171,7 @@ export const useEditStatus = () => {
   };
 
   const getProcedureStatus = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
       procedure: ProcedureMetadata;
@@ -185,7 +185,7 @@ export const useEditStatus = () => {
   };
 
   const getFunctionStatus = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
       function: FunctionMetadata;
@@ -199,7 +199,7 @@ export const useEditStatus = () => {
   };
 
   const getViewStatus = (
-    database: ComposedDatabase,
+    database: Database,
     metadata: {
       schema: SchemaMetadata;
       view: ViewMetadata;

--- a/frontend/src/components/SchemaEditorLite/context/scroll.ts
+++ b/frontend/src/components/SchemaEditorLite/context/scroll.ts
@@ -1,9 +1,9 @@
 import { useMounted } from "@vueuse/core";
 import type { Ref } from "vue";
 import { computed, ref, watch } from "vue";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -21,7 +21,7 @@ type RichColumnMetadata = RichTableMetadata & {
   // field?: "name" | "type"; // TODO
 };
 type RichMetadataWithDB<T> = {
-  db: ComposedDatabase;
+  db: Database;
   metadata: T;
 };
 

--- a/frontend/src/components/SchemaEditorLite/context/selection.ts
+++ b/frontend/src/components/SchemaEditorLite/context/selection.ts
@@ -1,9 +1,9 @@
 import { pick } from "lodash-es";
 import type { Ref } from "vue";
 import { computed } from "vue";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   FunctionMetadata,
   ProcedureMetadata,
@@ -34,7 +34,7 @@ export const useSelection = (
 
   const updateTableSelectionImpl = (
     map: Map<string, RolloutObject>,
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -65,7 +65,7 @@ export const useSelection = (
   };
   const updateColumnSelectionImpl = (
     map: Map<string, RolloutObject>,
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -93,7 +93,7 @@ export const useSelection = (
   };
   const updateViewSelectionImpl = (
     map: Map<string, RolloutObject>,
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -115,7 +115,7 @@ export const useSelection = (
   };
   const updateProcedureSelectionImpl = (
     map: Map<string, RolloutObject>,
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -137,7 +137,7 @@ export const useSelection = (
   };
   const updateFunctionSelectionImpl = (
     map: Map<string, RolloutObject>,
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -162,7 +162,7 @@ export const useSelection = (
   };
 
   const getTableSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -206,7 +206,7 @@ export const useSelection = (
     return state;
   };
   const updateTableSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -220,7 +220,7 @@ export const useSelection = (
     emit(updatedMap);
   };
   const getAllTablesSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -245,7 +245,7 @@ export const useSelection = (
     };
   };
   const updateAllTablesSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -269,7 +269,7 @@ export const useSelection = (
     emit(updatedMap);
   };
   const getColumnSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -287,7 +287,7 @@ export const useSelection = (
     return { checked, indeterminate: false };
   };
   const updateColumnSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -302,7 +302,7 @@ export const useSelection = (
     emit(updatedMap);
   };
   const getAllColumnsSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -328,7 +328,7 @@ export const useSelection = (
     };
   };
   const updateAllColumnsSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -354,7 +354,7 @@ export const useSelection = (
   };
 
   const getViewSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -374,7 +374,7 @@ export const useSelection = (
     };
   };
   const updateViewSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -388,7 +388,7 @@ export const useSelection = (
     emit(updatedMap);
   };
   const getAllViewsSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -412,7 +412,7 @@ export const useSelection = (
     };
   };
   const updateAllViewsSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -437,7 +437,7 @@ export const useSelection = (
   };
 
   const getProcedureSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -457,7 +457,7 @@ export const useSelection = (
     };
   };
   const updateProcedureSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -471,7 +471,7 @@ export const useSelection = (
     emit(updatedMap);
   };
   const getAllProceduresSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -495,7 +495,7 @@ export const useSelection = (
     };
   };
   const updateAllProceduresSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -520,7 +520,7 @@ export const useSelection = (
   };
 
   const getFunctionSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -540,7 +540,7 @@ export const useSelection = (
     };
   };
   const updateFunctionSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -554,7 +554,7 @@ export const useSelection = (
     emit(updatedMap);
   };
   const getAllFunctionsSelectionState = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;
@@ -578,7 +578,7 @@ export const useSelection = (
     };
   };
   const updateAllFunctionsSelection = (
-    db: ComposedDatabase,
+    db: Database,
     metadata: {
       database: DatabaseMetadata;
       schema: SchemaMetadata;

--- a/frontend/src/components/SchemaEditorLite/types.ts
+++ b/frontend/src/components/SchemaEditorLite/types.ts
@@ -1,6 +1,6 @@
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   FunctionMetadata,
   ProcedureMetadata,
@@ -10,7 +10,7 @@ import type {
 } from "@/types/proto-es/v1/database_service_pb";
 
 export type EditTarget = {
-  database: ComposedDatabase;
+  database: Database;
   metadata: DatabaseMetadata;
   baselineMetadata: DatabaseMetadata;
 };
@@ -25,7 +25,7 @@ export type CommonTabContext = {
 // Tab context for editing database.
 export type DatabaseTabContext = CommonTabContext & {
   type: "database";
-  database: ComposedDatabase;
+  database: Database;
   metadata: {
     database: DatabaseMetadata;
   };
@@ -35,7 +35,7 @@ export type DatabaseTabContext = CommonTabContext & {
 // Tab context for editing table.
 export type TableTabContext = CommonTabContext & {
   type: "table";
-  database: ComposedDatabase;
+  database: Database;
   metadata: {
     database: DatabaseMetadata;
     schema: SchemaMetadata;
@@ -45,7 +45,7 @@ export type TableTabContext = CommonTabContext & {
 
 export type ViewTabContext = CommonTabContext & {
   type: "view";
-  database: ComposedDatabase;
+  database: Database;
   metadata: {
     database: DatabaseMetadata;
     schema: SchemaMetadata;
@@ -55,7 +55,7 @@ export type ViewTabContext = CommonTabContext & {
 
 export type ProcedureTabContext = CommonTabContext & {
   type: "procedure";
-  database: ComposedDatabase;
+  database: Database;
   metadata: {
     database: DatabaseMetadata;
     schema: SchemaMetadata;
@@ -65,7 +65,7 @@ export type ProcedureTabContext = CommonTabContext & {
 
 export type FunctionTabContext = CommonTabContext & {
   type: "function";
-  database: ComposedDatabase;
+  database: Database;
   metadata: {
     database: DatabaseMetadata;
     schema: SchemaMetadata;
@@ -93,7 +93,7 @@ export type EditStatus = "normal" | "created" | "dropped" | "updated";
  * Only tables are selectable rollout objects by now
  */
 export type RolloutObject = {
-  db: ComposedDatabase;
+  db: Database;
   metadata: {
     database: DatabaseMetadata;
     schema: SchemaMetadata;

--- a/frontend/src/components/SensitiveData/MaskingExceptionUserTable.vue
+++ b/frontend/src/components/SensitiveData/MaskingExceptionUserTable.vue
@@ -46,7 +46,7 @@ import {
   PolicyType,
 } from "@/types/proto-es/v1/org_policy_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
-import { autoDatabaseRoute } from "@/utils";
+import { autoDatabaseRoute, getInstanceResource } from "@/utils";
 import {
   batchConvertFromCELString,
   type ConditionExpression,
@@ -114,7 +114,7 @@ const getDatabaseAccessResource = (access: AccessUser): VNodeChild => {
       {validDatabase && (
         <div class="flex flex-col xl:flex-row xl:items-center gap-x-1 text-sm textinfo">
           <span class="font-medium">{`${t("common.instance")}:`}</span>
-          <InstanceV1Name instance={database.instanceResource} />
+          <InstanceV1Name instance={getInstanceResource(database)} />
         </div>
       )}
       <div class="flex flex-col xl:flex-row xl:items-center gap-x-1 text-sm textinfo">

--- a/frontend/src/components/SensitiveData/components/SensitiveColumnTable.vue
+++ b/frontend/src/components/SensitiveData/components/SensitiveColumnTable.vue
@@ -30,17 +30,21 @@ import {
   useDatabaseCatalogV1Store,
   useSettingV1Store,
 } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnCatalog,
   ObjectSchema,
   TableCatalog,
 } from "@/types/proto-es/v1/database_catalog_service_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { DataClassificationSetting_DataClassificationConfigSchema } from "@/types/proto-es/v1/setting_service_pb";
-import { autoDatabaseRoute } from "@/utils";
+import {
+  autoDatabaseRoute,
+  getDatabaseProject,
+  getInstanceResource,
+} from "@/utils";
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   showOperation: boolean;
   rowClickable: boolean;
   rowSelectable: boolean;
@@ -73,7 +77,7 @@ const databaseCatalog = useDatabaseCatalog(props.database.name, false);
 const classificationConfig = computed(() => {
   return (
     settingStore.getProjectClassification(
-      props.database.projectEntity.dataClassificationConfigId
+      getDatabaseProject(props.database).dataClassificationConfigId
     ) ?? create(DataClassificationSetting_DataClassificationConfigSchema, {})
   );
 });
@@ -145,7 +149,7 @@ const dataTableColumns = computed(() => {
           <ClassificationCell
             classification={item.classificationId}
             classificationConfig={classificationConfig.value}
-            engine={props.database.instanceResource.engine}
+            engine={getInstanceResource(props.database).engine}
             readonly={!props.showOperation || item.disableClassification}
             onApply={(id: string) => onClassificationIdApply(item, id)}
           />

--- a/frontend/src/components/SensitiveData/types.ts
+++ b/frontend/src/components/SensitiveData/types.ts
@@ -1,9 +1,10 @@
-import type { ComposedDatabase, DatabaseResource } from "@/types";
+import type { DatabaseResource } from "@/types";
 import type {
   ColumnCatalog,
   ObjectSchema,
   TableCatalog,
 } from "@/types/proto-es/v1/database_catalog_service_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 
 export type MaskDataTarget = TableCatalog | ColumnCatalog | ObjectSchema;
 
@@ -19,7 +20,7 @@ export interface MaskData {
 }
 
 export interface SensitiveColumn {
-  database: ComposedDatabase;
+  database: Database;
   maskData: MaskData;
 }
 

--- a/frontend/src/components/SequenceDataTable.vue
+++ b/frontend/src/components/SequenceDataTable.vue
@@ -18,12 +18,14 @@ import type { DataTableColumn } from "naive-ui";
 import { NCheckbox, NDataTable, NPerformantEllipsis } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
-import type { SequenceMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  SequenceMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 
 withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     schemaName?: string;
     sequenceList: SequenceMetadata[];
     loading?: boolean;

--- a/frontend/src/components/StreamTable.vue
+++ b/frontend/src/components/StreamTable.vue
@@ -15,8 +15,10 @@ import { NDataTable } from "naive-ui";
 import { computed, h } from "vue";
 import { useI18n } from "vue-i18n";
 import DefinitionView from "@/components/DefinitionView.vue";
-import type { ComposedDatabase } from "@/types";
-import type { StreamMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  StreamMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 import {
   StreamMetadata_Mode,
   StreamMetadata_Type,
@@ -24,7 +26,7 @@ import {
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     schemaName?: string;
     streamList: StreamMetadata[];
     loading?: boolean;

--- a/frontend/src/components/SyncDatabaseSchemaV1/SourceSchemaInfo.vue
+++ b/frontend/src/components/SyncDatabaseSchemaV1/SourceSchemaInfo.vue
@@ -9,7 +9,7 @@
       <NTag round @click="gotoDatabase">
         <span class="opacity-60 mr-1">{{ t("common.database") }}</span>
         <EngineIcon custom-class="inline-flex w-4 h-auto" :engine="engine" />
-        <span>{{ databaseFromChangelog.databaseName }}</span>
+        <span>{{ extractDatabaseResourceName(databaseFromChangelog.name).databaseName }}</span>
       </NTag>
       <NTag round @click="gotoChangelog">
         <span class="opacity-60 mr-1">{{ t("common.changelog") }}</span>
@@ -41,6 +41,7 @@ import {
   databaseV1Url,
   engineNameV1,
   extractChangelogUID,
+  extractDatabaseResourceName,
   isValidChangelogName,
 } from "@/utils";
 import { EngineIcon } from "../Icon";

--- a/frontend/src/components/SyncDatabaseSchemaV1/TargetDatabasesSelectPanel.vue
+++ b/frontend/src/components/SyncDatabaseSchemaV1/TargetDatabasesSelectPanel.vue
@@ -44,7 +44,7 @@
             <div class="mx-2">
               <ul class="list-disc">
                 <li v-for="db in selectedDatabaseList" :key="db.name">
-                  {{ db.databaseName }}
+                  {{ extractDatabaseResourceName(db.name).databaseName }}
                 </li>
               </ul>
             </div>
@@ -78,6 +78,7 @@ import type { Engine } from "@/types/proto-es/v1/common_pb";
 import type { SearchParams, SearchScope } from "@/utils";
 import {
   CommonFilterScopeIdList,
+  extractDatabaseResourceName,
   extractProjectResourceName,
   getValueFromSearchParams,
 } from "@/utils";

--- a/frontend/src/components/SyncDatabaseSchemaV1/index.vue
+++ b/frontend/src/components/SyncDatabaseSchemaV1/index.vue
@@ -96,7 +96,12 @@ import { isValidDatabaseName, isValidEnvironmentName } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import { ChangelogView } from "@/types/proto-es/v1/database_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
-import { extractProjectResourceName, generateIssueTitle } from "@/utils";
+import {
+  extractDatabaseResourceName,
+  extractProjectResourceName,
+  generateIssueTitle,
+  getInstanceResource,
+} from "@/utils";
 import {
   extractDatabaseNameAndChangelogUID,
   isValidChangelogName,
@@ -185,7 +190,7 @@ const sourceEngine = computed(() => {
     const database = databaseStore.getDatabaseByName(
       changelogSourceSchemaState.databaseName
     );
-    return database.instanceResource.engine;
+    return getInstanceResource(database).engine;
   } else {
     return rawSQLState.engine;
   }
@@ -345,7 +350,9 @@ const tryFinishSetup = async () => {
   query.sqlMapStorageKey = sqlMapStorageKey;
   query.name = generateIssueTitle(
     "bb.issue.database.update",
-    targetDatabaseList.map((db) => db.databaseName)
+    targetDatabaseList.map(
+      (db) => extractDatabaseResourceName(db.name).databaseName
+    )
   );
 
   router.push({

--- a/frontend/src/components/TableDataTable.vue
+++ b/frontend/src/components/TableDataTable.vue
@@ -41,11 +41,18 @@ import {
   useDatabaseCatalog,
   useSettingV1Store,
 } from "@/store/modules";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
-import type { TableMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  TableMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
-import { bytesToString, hasSchemaProperty } from "@/utils";
+import {
+  bytesToString,
+  getDatabaseProject,
+  getInstanceResource,
+  hasSchemaProperty,
+} from "@/utils";
 import TableDetailDrawer from "./TableDetailDrawer.vue";
 
 type LocalState = {
@@ -54,7 +61,7 @@ type LocalState = {
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     schemaName?: string;
     tableList: TableMetadata[];
     search?: string;
@@ -94,13 +101,13 @@ watch(
 
 const classificationConfig = computed(() => {
   return settingStore.getProjectClassification(
-    props.database.projectEntity.dataClassificationConfigId
+    getDatabaseProject(props.database).dataClassificationConfigId
   );
 });
 
 const hasSensitiveDataFeature = featureToRef(PlanFeature.FEATURE_DATA_MASKING);
 
-const engine = computed(() => props.database.instanceResource.engine);
+const engine = computed(() => getInstanceResource(props.database).engine);
 
 const isPostgres = computed(() => engine.value === Engine.POSTGRES);
 

--- a/frontend/src/components/TableDetailDrawer.vue
+++ b/frontend/src/components/TableDetailDrawer.vue
@@ -35,7 +35,7 @@
                     >{{ $t("common.environment") }}&nbsp;-&nbsp;</span
                   >
                   <EnvironmentV1Name
-                    :environment="database.effectiveEnvironmentEntity"
+                    :environment="effectiveEnvironment"
                     icon-class="textinfolabel"
                   />
                 </dd>
@@ -44,7 +44,7 @@
                   <span class="ml-1 textlabel"
                     >{{ $t("common.instance") }}&nbsp;-&nbsp;</span
                   >
-                  <InstanceV1Name :instance="database.instanceResource" />
+                  <InstanceV1Name :instance="instanceResource" />
                 </dd>
                 <dt class="sr-only">{{ $t("common.project") }}</dt>
                 <dd class="flex items-center text-sm md:mr-4">
@@ -52,7 +52,7 @@
                     >{{ $t("common.project") }}&nbsp;-&nbsp;</span
                   >
                   <ProjectV1Name
-                    :project="database.projectEntity"
+                    :project="projectEntity"
                     hash="#databases"
                   />
                 </dd>
@@ -339,6 +339,9 @@ import { GetSchemaStringRequest_ObjectType } from "@/types/proto-es/v1/database_
 import type { DataClassificationSetting_DataClassificationConfig } from "@/types/proto-es/v1/setting_service_pb";
 import {
   bytesToString,
+  getDatabaseEnvironment,
+  getDatabaseProject,
+  getInstanceResource,
   hasIndexSizeProperty,
   hasProjectPermissionV2,
   hasSchemaProperty,
@@ -432,9 +435,21 @@ const table = computedAsync(
   }
 );
 
+const instanceResource = computed(() => {
+  return getInstanceResource(database.value);
+});
+
+const projectEntity = computed(() => {
+  return getDatabaseProject(database.value);
+});
+
+const effectiveEnvironment = computed(() => {
+  return getDatabaseEnvironment(database.value);
+});
+
 const hasDatabaseCatalogPermission = computed(() => {
   return hasProjectPermissionV2(
-    database.value.projectEntity,
+    projectEntity.value,
     "bb.databaseCatalogs.update"
   );
 });
@@ -499,7 +514,7 @@ const database = computed(() => {
 });
 
 const instanceEngine = computed(() => {
-  return database.value.instanceResource.engine;
+  return instanceResource.value.engine;
 });
 
 const instanceEngineNew = computed(() => {
@@ -516,7 +531,7 @@ const allowQuery = computed(() => {
 const hasPartitionTables = computed(() => {
   return (
     // Only show partition tables for PostgreSQL.
-    database.value.instanceResource.engine === Engine.POSTGRES &&
+    instanceResource.value.engine === Engine.POSTGRES &&
     table.value &&
     table.value.partitions.length > 0
   );

--- a/frontend/src/components/TableSchemaViewer.vue
+++ b/frontend/src/components/TableSchemaViewer.vue
@@ -25,13 +25,15 @@ import { computed, nextTick, onMounted, ref } from "vue";
 import { MonacoEditor } from "@/components/MonacoEditor";
 import { CopyButton } from "@/components/v2";
 import { databaseServiceClientConnect } from "@/connect";
-import type { ComposedDatabase } from "@/types";
-import type { GetSchemaStringRequest_ObjectType } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  GetSchemaStringRequest_ObjectType,
+} from "@/types/proto-es/v1/database_service_pb";
 import { GetSchemaStringRequestSchema } from "@/types/proto-es/v1/database_service_pb";
-import { hasSchemaProperty } from "@/utils";
+import { getInstanceResource, hasSchemaProperty } from "@/utils";
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   schema?: string;
   object?: string;
   type?: GetSchemaStringRequest_ObjectType;
@@ -40,7 +42,7 @@ const props = defineProps<{
 const schemaString = ref<string | null>(null);
 
 const engine = computed(() => {
-  return props.database.instanceResource.engine;
+  return getInstanceResource(props.database).engine;
 });
 
 const resourceName = computed(() => {

--- a/frontend/src/components/TaskTable.vue
+++ b/frontend/src/components/TaskTable.vue
@@ -15,13 +15,15 @@ import { NDataTable } from "naive-ui";
 import { computed, h } from "vue";
 import { useI18n } from "vue-i18n";
 import DefinitionView from "@/components/DefinitionView.vue";
-import type { ComposedDatabase } from "@/types";
-import type { TaskMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  TaskMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 import { TaskMetadata_State } from "@/types/proto-es/v1/database_service_pb";
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     schemaName?: string;
     taskList: TaskMetadata[];
     loading?: boolean;

--- a/frontend/src/components/TransferDatabaseForm/TransferDatabaseForm.vue
+++ b/frontend/src/components/TransferDatabaseForm/TransferDatabaseForm.vue
@@ -52,7 +52,7 @@
           <div class="mx-2">
             <ul class="list-disc">
               <li v-for="db in selectedDatabaseList" :key="db.name">
-                {{ db.databaseName }}
+                {{ extractDatabaseResourceName(db.name).databaseName }}
               </li>
             </ul>
           </div>
@@ -85,11 +85,11 @@ import {
   useProjectByName,
 } from "@/store";
 import {
-  type ComposedDatabase,
   DEFAULT_PROJECT_NAME,
   formatEnvironmentName,
   isValidProjectName,
 } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   BatchUpdateDatabasesRequestSchema,
   DatabaseSchema$,
@@ -98,7 +98,7 @@ import {
 import type { InstanceResource } from "@/types/proto-es/v1/instance_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import type { Environment } from "@/types/v1/environment";
-import { hasWorkspacePermissionV2 } from "@/utils";
+import { extractDatabaseResourceName, hasWorkspacePermissionV2 } from "@/utils";
 import { DrawerContent, ProjectSelect } from "../v2";
 import { PagedDatabaseTable } from "../v2/Model/DatabaseV1Table";
 import TransferSourceSelector from "./TransferSourceSelector.vue";
@@ -117,10 +117,10 @@ interface LocalState {
 const props = withDefaults(
   defineProps<{
     projectName: string;
-    onSuccess?: (databases: ComposedDatabase[]) => void;
+    onSuccess?: (databases: Database[]) => void;
   }>(),
   {
-    onSuccess: (_: ComposedDatabase[]) => {},
+    onSuccess: (_: Database[]) => {},
   }
 );
 
@@ -216,7 +216,7 @@ const transferDatabase = async () => {
     const displayDatabaseName =
       selectedDatabaseList.value.length > 1
         ? `${selectedDatabaseList.value.length} databases`
-        : `'${selectedDatabaseList.value[0].databaseName}'`;
+        : `'${extractDatabaseResourceName(selectedDatabaseList.value[0].name).databaseName}'`;
 
     props.onSuccess(updated);
     emit("dismiss");

--- a/frontend/src/components/TransferOutDatabaseForm/TransferOutDatabaseForm.vue
+++ b/frontend/src/components/TransferOutDatabaseForm/TransferOutDatabaseForm.vue
@@ -78,25 +78,25 @@ import {
   useDatabaseV1Store,
   useProjectV1Store,
 } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { DEFAULT_PROJECT_NAME, isValidProjectName } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   BatchUpdateDatabasesRequestSchema,
   DatabaseSchema$,
   UpdateDatabaseRequestSchema,
 } from "@/types/proto-es/v1/database_service_pb";
-import { autoProjectRoute } from "@/utils";
+import { autoProjectRoute, extractDatabaseResourceName } from "@/utils";
 import DatabaseV1Table from "../v2/Model/DatabaseV1Table/DatabaseV1Table.vue";
 
 const props = withDefaults(
   defineProps<{
-    databaseList: ComposedDatabase[];
+    databaseList: Database[];
     selectedDatabaseNames?: string[];
-    onSuccess?: (databases: ComposedDatabase[]) => void;
+    onSuccess?: (databases: Database[]) => void;
   }>(),
   {
     selectedDatabaseNames: () => [],
-    onSuccess: (_: ComposedDatabase[]) => {},
+    onSuccess: (_: Database[]) => {},
   }
 );
 
@@ -198,7 +198,7 @@ const doTransfer = async () => {
       const displayDatabaseName =
         databaseList.length > 1
           ? `${databaseList.length} databases`
-          : `'${databaseList[0].databaseName}'`;
+          : `'${extractDatabaseResourceName(databaseList[0].name).databaseName}'`;
 
       pushNotification({
         module: "bytebase",

--- a/frontend/src/components/TriggerDataTable.vue
+++ b/frontend/src/components/TriggerDataTable.vue
@@ -16,14 +16,16 @@ import { NDataTable, NPerformantEllipsis } from "naive-ui";
 import type { PropType } from "vue";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
-import type { TriggerMetadata } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Database,
+  TriggerMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
 import EllipsisSQLView from "./EllipsisSQLView.vue";
 
 defineProps({
   database: {
     required: true,
-    type: Object as PropType<ComposedDatabase>,
+    type: Object as PropType<Database>,
   },
   schemaName: {
     type: String,

--- a/frontend/src/components/ViewDataTable.vue
+++ b/frontend/src/components/ViewDataTable.vue
@@ -16,14 +16,16 @@ import type { DataTableColumn } from "naive-ui";
 import { NDataTable } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
-import type { ViewMetadata } from "@/types/proto-es/v1/database_service_pb";
-import { hasSchemaProperty } from "@/utils";
+import type {
+  Database,
+  ViewMetadata,
+} from "@/types/proto-es/v1/database_service_pb";
+import { getInstanceResource, hasSchemaProperty } from "@/utils";
 import EllipsisSQLView from "./EllipsisSQLView.vue";
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     schemaName?: string;
     viewList: ViewMetadata[];
     loading?: boolean;
@@ -36,7 +38,7 @@ const props = withDefaults(
 
 const { t } = useI18n();
 
-const engine = computed(() => props.database.instanceResource.engine);
+const engine = computed(() => getInstanceResource(props.database).engine);
 
 const columns = computed(() => {
   const columns: (DataTableColumn<ViewMetadata> & { hide?: boolean })[] = [

--- a/frontend/src/components/v2/Model/DatabaseV1Name.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Name.vue
@@ -8,7 +8,7 @@
       shouldShowLink && 'hover:underline',
     ]"
   >
-    <HighlightLabelText :text="database.databaseName" :keyword="keyword" />
+    <HighlightLabelText :text="extractDatabaseResourceName(database.name).databaseName" :keyword="keyword" />
     <span
       v-if="showNotFound && database.state === State.DELETED"
       class="text-control-placeholder"
@@ -22,14 +22,14 @@
 import { NEllipsis } from "naive-ui";
 import { computed } from "vue";
 import { useRouter } from "vue-router";
-import type { ComposedDatabase } from "@/types";
 import { State } from "@/types/proto-es/v1/common_pb";
-import { autoDatabaseRoute } from "@/utils";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { autoDatabaseRoute, extractDatabaseResourceName } from "@/utils";
 import HighlightLabelText from "./HighlightLabelText.vue";
 
 const props = withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     link?: boolean;
     plain?: boolean;
     showNotFound?: boolean;

--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseOperations.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseOperations.vue
@@ -137,14 +137,16 @@ import {
   useGracefulRequest,
   useProjectV1Store,
 } from "@/store";
-import type { ComposedDatabase, Permission } from "@/types";
+import type { Permission } from "@/types";
 import { DEFAULT_PROJECT_NAME, isValidProjectName } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   BatchUpdateDatabasesRequestSchema,
   DatabaseSchema$,
   UpdateDatabaseRequestSchema,
 } from "@/types/proto-es/v1/database_service_pb";
 import {
+  extractDatabaseResourceName,
   extractProjectResourceName,
   generateIssueTitle,
   PERMISSIONS_FOR_DATABASE_CHANGE_ISSUE,
@@ -170,7 +172,7 @@ interface LocalState {
 
 const props = withDefaults(
   defineProps<{
-    databases: ComposedDatabase[];
+    databases: Database[];
     projectName?: string;
     instanceName?: string;
     onCreateDatabase?: () => void;
@@ -188,7 +190,7 @@ const state = reactive<LocalState>({
 
 const emit = defineEmits<{
   (event: "refresh"): void;
-  (event: "update", databases: ComposedDatabase[]): void;
+  (event: "update", databases: Database[]): void;
 }>();
 
 const { t } = useI18n();
@@ -269,7 +271,9 @@ const generateMultiDb = async (
   if (!project.enforceIssueTitle) {
     query.name = generateIssueTitle(
       type,
-      props.databases.map((db) => db.databaseName)
+      props.databases.map(
+        (db) => extractDatabaseResourceName(db.name).databaseName
+      )
     );
   }
 

--- a/frontend/src/components/v2/Model/DatabaseV1Table/PagedDatabaseTable.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/PagedDatabaseTable.vue
@@ -28,7 +28,7 @@ import type { ComponentExposed } from "vue-component-type-helpers";
 import { useRouter } from "vue-router";
 import PagedTable from "@/components/v2/Model/PagedTable.vue";
 import { type DatabaseFilter, useDatabaseV1Store } from "@/store";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { autoDatabaseRoute } from "@/utils";
 import DatabaseV1Table from "./DatabaseV1Table.vue";
 
@@ -49,14 +49,13 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-  (event: "row-click", e: MouseEvent, val: ComposedDatabase): void;
+  (event: "row-click", e: MouseEvent, val: Database): void;
 }>();
 
 const databaseStore = useDatabaseV1Store();
 const router = useRouter();
 
-const databasePagedTable =
-  ref<ComponentExposed<typeof PagedTable<ComposedDatabase>>>();
+const databasePagedTable = ref<ComponentExposed<typeof PagedTable<Database>>>();
 
 const fetchDatabases = async ({
   pageToken,
@@ -90,7 +89,7 @@ watch(
   { deep: true }
 );
 
-const handleDatabaseClick = (event: MouseEvent, database: ComposedDatabase) => {
+const handleDatabaseClick = (event: MouseEvent, database: Database) => {
   if (props.customClick) {
     emit("row-click", event, database);
   } else {
@@ -104,7 +103,7 @@ const handleDatabaseClick = (event: MouseEvent, database: ComposedDatabase) => {
 };
 
 defineExpose({
-  updateCache: (databases: ComposedDatabase[]) => {
+  updateCache: (databases: Database[]) => {
     databasePagedTable.value?.updateCache(databases);
   },
   refresh: () => databasePagedTable.value?.refresh(),

--- a/frontend/src/components/v2/Model/DatabaseView.vue
+++ b/frontend/src/components/v2/Model/DatabaseView.vue
@@ -3,12 +3,12 @@
     <FeatureBadge
       :feature="PlanFeature.FEATURE_DATABASE_GROUPS"
       class="mr-2"
-      :instance="database.instanceResource"
+      :instance="getInstanceResource(database)"
     />
-    <InstanceV1EngineIcon :instance="database.instanceResource" />
+    <InstanceV1EngineIcon :instance="getInstanceResource(database)" />
     <EnvironmentV1Name
       text-class="text-control-light"
-      :environment="database.effectiveEnvironmentEntity"
+      :environment="getDatabaseEnvironment(database)"
       :plain="true"
       :show-icon="false"
       :link="false"
@@ -27,6 +27,7 @@ import { FeatureBadge } from "@/components/FeatureGuard";
 import { DatabaseV1Name, EnvironmentV1Name } from "@/components/v2";
 import { useDatabaseV1ByName } from "@/store";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
+import { getDatabaseEnvironment, getInstanceResource } from "@/utils";
 import { InstanceV1EngineIcon } from "./Instance";
 
 const props = defineProps<{

--- a/frontend/src/components/v2/Model/RichDatabaseName.vue
+++ b/frontend/src/components/v2/Model/RichDatabaseName.vue
@@ -4,7 +4,7 @@
       <div class="flex flex-row justify-start items-center gap-x-1">
         <ProjectV1Name
           v-if="showProject"
-          :project="database.projectEntity"
+          :project="getDatabaseProject(database)"
           :link="false"
         />
 
@@ -19,11 +19,11 @@
         >
           <InstanceV1EngineIcon
             v-if="showEngineIcon"
-            :instance="database.instanceResource"
+            :instance="getInstanceResource(database)"
           />
           <InstanceV1Name
             v-if="showInstance"
-            :instance="database.instanceResource"
+            :instance="getInstanceResource(database)"
             :icon="false"
             :link="false"
           />
@@ -37,7 +37,7 @@
         <div class="flex flex-row items-center gap-x-1">
           <EnvironmentV1Name
             v-if="showEnvironment"
-            :environment="database.effectiveEnvironmentEntity"
+            :environment="getDatabaseEnvironment(database)"
             :link="false"
             :show-icon="showProductionEnvironmentIcon"
             text-class="text-control-light"
@@ -54,7 +54,7 @@
     <template #default>
       <InstanceV1Name
         v-if="tooltip === 'instance'"
-        :instance="database.instanceResource"
+        :instance="getInstanceResource(database)"
         :link="false"
       />
     </template>
@@ -64,7 +64,12 @@
 <script setup lang="ts">
 import { ChevronRightIcon } from "lucide-vue-next";
 import { NPopover } from "naive-ui";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import {
+  getDatabaseEnvironment,
+  getDatabaseProject,
+  getInstanceResource,
+} from "@/utils";
 import DatabaseV1Name from "./DatabaseV1Name.vue";
 import EnvironmentV1Name from "./EnvironmentV1Name.vue";
 import { InstanceV1EngineIcon, InstanceV1Name } from "./Instance";
@@ -72,7 +77,7 @@ import ProjectV1Name from "./ProjectV1Name.vue";
 
 withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     showProject?: boolean;
     showEngineIcon?: boolean;
     showInstance?: boolean;

--- a/frontend/src/components/v2/Model/cells/DatabaseNameCell.vue
+++ b/frontend/src/components/v2/Model/cells/DatabaseNameCell.vue
@@ -9,11 +9,11 @@
 
 <script setup lang="ts">
 import { DatabaseV1Name } from "@/components/v2";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 
 withDefaults(
   defineProps<{
-    database: ComposedDatabase;
+    database: Database;
     keyword?: string;
   }>(),
   {

--- a/frontend/src/components/v2/Select/DatabaseSelect.vue
+++ b/frontend/src/components/v2/Select/DatabaseSelect.vue
@@ -21,8 +21,9 @@ import { computed } from "vue";
 import { RichDatabaseName } from "@/components/v2";
 import { useDatabaseV1Store } from "@/store";
 import { workspaceNamePrefix } from "@/store/modules/v1/common";
-import type { ComposedDatabase } from "@/types";
 import { type Engine } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { extractDatabaseResourceName } from "@/utils";
 import RemoteResourceSelector from "./RemoteResourceSelector/index.vue";
 import type {
   ResourceSelectOption,
@@ -39,7 +40,7 @@ const props = withDefaults(
     environmentName?: string;
     projectName?: string;
     allowedEngineTypeList?: Engine[];
-    filter?: (database: ComposedDatabase) => boolean;
+    filter?: (database: Database) => boolean;
     multiple?: boolean;
     disabled?: boolean;
     size?: SelectSize;
@@ -58,16 +59,16 @@ defineEmits<{
 
 const databaseStore = useDatabaseV1Store();
 
-const getOption = (db: ComposedDatabase) => {
+const getOption = (db: Database) => {
   return {
     resource: db,
     value: db.name,
-    label: db.databaseName,
+    label: extractDatabaseResourceName(db.name).databaseName,
   };
 };
 
 const additionalOptions = computedAsync(async () => {
-  const options: ResourceSelectOption<ComposedDatabase>[] = [];
+  const options: ResourceSelectOption<Database>[] = [];
 
   let databaseNames: string[] = [];
   if (Array.isArray(props.value)) {
@@ -104,7 +105,7 @@ const handleSearch = async (params: {
   };
 };
 
-const customLabel = (database: ComposedDatabase, keyword: string) => {
+const customLabel = (database: Database, keyword: string) => {
   return (
     <RichDatabaseName
       database={database}

--- a/frontend/src/composables/usePriorBackupTelemetry.ts
+++ b/frontend/src/composables/usePriorBackupTelemetry.ts
@@ -10,7 +10,7 @@ import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import type { Task } from "@/types/proto-es/v1/rollout_service_pb";
 import { isValidDatabaseName } from "@/types/v1/database";
-import { isDev } from "@/utils";
+import { getInstanceResource, isDev } from "@/utils";
 
 interface PriorBackupTelemetryPayload {
   enabled: boolean;
@@ -35,7 +35,7 @@ async function getEngineFromTaskTarget(target: string): Promise<Engine> {
       target,
       true /* silent */
     );
-    return db.instanceResource.engine;
+    return getInstanceResource(db).engine;
   } catch {
     return Engine.ENGINE_UNSPECIFIED;
   }

--- a/frontend/src/store/modules/sqlEditor/editor.ts
+++ b/frontend/src/store/modules/sqlEditor/editor.ts
@@ -2,7 +2,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { includes } from "lodash-es";
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
-import { type ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { QueryOption_RedisRunCommandsOn } from "@/types/proto-es/v1/sql_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
@@ -53,7 +53,7 @@ export const useSQLEditorStore = defineStore("sqlEditor", () => {
   };
 
   const isShowExecutingHint = ref(false);
-  const executingHintDatabase = ref<ComposedDatabase | undefined>();
+  const executingHintDatabase = ref<Database | undefined>();
 
   return {
     resultRowsLimit,

--- a/frontend/src/store/modules/sqlEditor/tab.ts
+++ b/frontend/src/store/modules/sqlEditor/tab.ts
@@ -15,6 +15,8 @@ import {
   defaultSQLEditorTab,
   emptySQLEditorConnection,
   extractWorksheetConnection,
+  getDatabaseEnvironment,
+  getInstanceResource,
   getSheetStatement,
   isConnectedSQLEditorTab,
   suggestedTabTitleForSQLEditorConnection,
@@ -447,12 +449,12 @@ export const useSQLEditorConnectionDetail = (
   );
 
   const instance = computed(() => {
-    return database.value.instanceResource;
+    return getInstanceResource(database.value);
   });
 
   const environment = computed(() => {
     if (isValidDatabaseName(database.value.name)) {
-      return database.value.effectiveEnvironmentEntity;
+      return getDatabaseEnvironment(database.value);
     }
 
     return useEnvironmentV1Store().getEnvironmentByName(

--- a/frontend/src/store/modules/sqlReview.ts
+++ b/frontend/src/store/modules/sqlReview.ts
@@ -6,12 +6,8 @@ import { computed, unref, watchEffect } from "vue";
 import { reviewConfigServiceClientConnect } from "@/connect";
 import { silentContextKey } from "@/connect/context-key";
 import { policyNamePrefix } from "@/store/modules/v1/common";
-import type {
-  ComposedDatabase,
-  MaybeRef,
-  SchemaPolicyRule,
-  SQLReviewPolicy,
-} from "@/types";
+import type { MaybeRef, SchemaPolicyRule, SQLReviewPolicy } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   PolicyType,
   TagPolicySchema,
@@ -326,7 +322,7 @@ export const useReviewPolicyByResource = (
 };
 
 export const useReviewPolicyForDatabase = (
-  database: MaybeRef<ComposedDatabase | undefined>
+  database: MaybeRef<Database | undefined>
 ) => {
   const store = useSQLReviewStore();
 

--- a/frontend/src/store/modules/v1/databaseCatalog.ts
+++ b/frontend/src/store/modules/v1/databaseCatalog.ts
@@ -16,7 +16,11 @@ import {
   TableCatalogSchema,
   UpdateDatabaseCatalogRequestSchema,
 } from "@/types/proto-es/v1/database_catalog_service_pb";
-import { extractDatabaseResourceName, hasProjectPermissionV2 } from "@/utils";
+import {
+  extractDatabaseResourceName,
+  getDatabaseProject,
+  hasProjectPermissionV2,
+} from "@/utils";
 import { useDatabaseV1Store } from "./database";
 
 type DatabaseCatalogCacheKey = [string /* database catalog resource name */];
@@ -191,7 +195,9 @@ export const useDatabaseCatalog = (
       return;
     }
     const db = await databaseStore.getOrFetchDatabaseByName(unref(database));
-    if (hasProjectPermissionV2(db.projectEntity, "bb.databaseCatalogs.get")) {
+    if (
+      hasProjectPermissionV2(getDatabaseProject(db), "bb.databaseCatalogs.get")
+    ) {
       await store.getOrFetchDatabaseCatalog({
         database: unref(database),
         skipCache: unref(skipCache),

--- a/frontend/src/store/modules/v1/instanceResource.ts
+++ b/frontend/src/store/modules/v1/instanceResource.ts
@@ -2,6 +2,7 @@ import { uniqBy } from "lodash-es";
 import { computed, type MaybeRef, ref, unref, watchEffect } from "vue";
 import { isValidInstanceName } from "@/types";
 import type { InstanceResource } from "@/types/proto-es/v1/instance_service_pb";
+import { getInstanceResource } from "@/utils";
 import { useDatabaseV1Store } from "./database";
 import { useInstanceV1Store } from "./instance";
 
@@ -16,7 +17,7 @@ export const useInstanceResourceByName = (
 
   const instanceList = computed(() => {
     return uniqBy(
-      databaseStore.databaseList.map((db) => db.instanceResource),
+      databaseStore.databaseList.map((db) => getInstanceResource(db)),
       (i) => i.name
     ) as InstanceResource[];
   });

--- a/frontend/src/store/modules/v1/policy.ts
+++ b/frontend/src/store/modules/v1/policy.ts
@@ -6,8 +6,9 @@ import { computed, reactive, ref, unref, watchEffect } from "vue";
 import { orgPolicyServiceClientConnect } from "@/connect";
 import { silentContextKey } from "@/connect/context-key";
 import { policyNamePrefix } from "@/store/modules/v1/common";
-import type { ComposedDatabase, MaybeRef } from "@/types";
+import type { MaybeRef } from "@/types";
 import { UNKNOWN_USER_NAME } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type {
   Policy,
   QueryDataPolicy,
@@ -254,7 +255,7 @@ export const usePolicyByParentAndType = (
 };
 
 export const useDataSourceRestrictionPolicy = (
-  database: MaybeRef<ComposedDatabase>
+  database: MaybeRef<Database>
 ) => {
   const store = usePolicyV1Store();
   const ready = ref(false);

--- a/frontend/src/store/modules/v1/projectIamPolicy.ts
+++ b/frontend/src/store/modules/v1/projectIamPolicy.ts
@@ -5,13 +5,13 @@ import { computed, ref, shallowReactive, unref, watch } from "vue";
 import { projectServiceClientConnect } from "@/connect";
 import {
   ALL_USERS_USER_EMAIL,
-  type ComposedDatabase,
   groupBindingPrefix,
   type MaybeRef,
   type QueryPermission,
   QueryPermissionQueryAny,
 } from "@/types";
 import type { Expr } from "@/types/proto-es/google/api/expr/v1alpha1/syntax_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { IamPolicy } from "@/types/proto-es/v1/iam_policy_pb";
 import {
   GetIamPolicyRequestSchema,
@@ -20,7 +20,7 @@ import {
 } from "@/types/proto-es/v1/iam_policy_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import type { User } from "@/types/proto-es/v1/user_service_pb";
-import { getUserEmailListInBinding } from "@/utils";
+import { getDatabaseProject, getUserEmailListInBinding } from "@/utils";
 import { convertFromExpr } from "@/utils/issue/cel";
 import { useRoleStore } from "../role";
 import { useUserStore } from "../user";
@@ -174,14 +174,14 @@ const checkProjectIAMPolicyWithExpr = (
 };
 
 export const checkQuerierPermission = (
-  database: ComposedDatabase,
+  database: Database,
   permissions: QueryPermission[] = QueryPermissionQueryAny,
   schema?: string,
   table?: string
 ) => {
   return checkProjectIAMPolicyWithExpr(
     useCurrentUserV1().value,
-    database.projectEntity,
+    getDatabaseProject(database),
     permissions,
     (expr?: Expr): boolean => {
       // If no condition is set, then return true.

--- a/frontend/src/types/sqlEditor/tree.ts
+++ b/frontend/src/types/sqlEditor/tree.ts
@@ -1,7 +1,7 @@
 import type { TreeOption } from "naive-ui";
 import { t } from "@/plugins/i18n";
+import type { Database } from "../proto-es/v1/database_service_pb";
 import type { InstanceResource } from "../proto-es/v1/instance_service_pb";
-import type { ComposedDatabase } from "../v1";
 import type { Environment } from "../v1/environment";
 
 export type SQLEditorTreeFactor =
@@ -34,7 +34,7 @@ export type SQLEditorTreeNodeTarget<
   : T extends "environment"
     ? Environment
     : T extends "database"
-      ? ComposedDatabase
+      ? Database
       : T extends "label"
         ? LabelTarget
         : never;
@@ -110,7 +110,7 @@ export const instanceOfSQLEditorTreeNode = (node: SQLEditorTreeNode) => {
     return target as InstanceResource;
   }
   if (type === "database") {
-    return (target as ComposedDatabase).instanceResource;
+    return (target as Database).instanceResource;
   }
   return undefined;
 };

--- a/frontend/src/types/v1/database.ts
+++ b/frontend/src/types/v1/database.ts
@@ -4,46 +4,21 @@ import { EMPTY_ID, UNKNOWN_ID } from "../const";
 import { State } from "../proto-es/v1/common_pb";
 import type { Database } from "../proto-es/v1/database_service_pb";
 import { DatabaseSchema$ } from "../proto-es/v1/database_service_pb";
-import type { InstanceResource } from "../proto-es/v1/instance_service_pb";
-import type { Project } from "../proto-es/v1/project_service_pb";
-import type { Environment } from "../v1/environment";
 import { formatEnvironmentName, unknownEnvironment } from "./environment";
 import { unknownInstance, unknownInstanceResource } from "./instance";
 import { unknownProject } from "./project";
 
-export interface ComposedDatabase extends Database {
-  /** related project entity */
-  projectEntity: Project;
-  /** extracted database name */
-  databaseName: string;
-  /** instance name. Format: instances/{instance} */
-  instance: string;
-  /** related environment entity composed by effectedEnvironment  */
-  effectiveEnvironmentEntity: Environment;
-  /** non-empty instanceResource field, should be filled by unknownInstanceResource() if needed */
-  instanceResource: InstanceResource;
-}
-
 export const UNKNOWN_DATABASE_NAME = `${unknownInstance().name}/databases/${UNKNOWN_ID}`;
 
-export const unknownDatabase = (): ComposedDatabase => {
-  const projectEntity = unknownProject();
+export const unknownDatabase = (): Database => {
   const instanceResource = unknownInstanceResource();
-  const effectiveEnvironmentEntity = unknownEnvironment();
-  const database = create(DatabaseSchema$, {
+  return create(DatabaseSchema$, {
     name: `${instanceResource.name}/databases/${UNKNOWN_ID}`,
     state: State.ACTIVE,
-    project: projectEntity.name,
-    effectiveEnvironment: formatEnvironmentName(effectiveEnvironmentEntity.id),
-  });
-  return {
-    ...database,
-    databaseName: "<<Unknown database>>",
-    instance: instanceResource.name,
+    project: unknownProject().name,
+    effectiveEnvironment: formatEnvironmentName(unknownEnvironment().id),
     instanceResource,
-    projectEntity,
-    effectiveEnvironmentEntity,
-  };
+  });
 };
 
 export const isValidDatabaseName = (name: unknown): name is string => {

--- a/frontend/src/types/v1/schemaEditor/state.ts
+++ b/frontend/src/types/v1/schemaEditor/state.ts
@@ -1,4 +1,4 @@
-import type { ComposedDatabase } from "..";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Schema } from "./atomType";
 
 export enum SchemaEditorTabType {
@@ -30,7 +30,7 @@ export type TabContext = {
 } & (DatabaseTabContext | TableTabContext);
 
 export interface DatabaseSchema {
-  database: ComposedDatabase;
+  database: Database;
   schemaList: Schema[];
   originSchemaList: Schema[];
 }

--- a/frontend/src/utils/expr.ts
+++ b/frontend/src/utils/expr.ts
@@ -16,10 +16,12 @@ import {
   useInstanceV1Store,
   useProjectV1Store,
 } from "@/store";
-import { type ComposedDatabase, isValidInstanceName } from "@/types";
+import { isValidInstanceName } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Instance } from "@/types/proto-es/v1/instance_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import {
+  extractDatabaseResourceName,
   extractInstanceResourceName,
   extractProjectResourceName,
 } from "@/utils";
@@ -78,7 +80,7 @@ const getProjectIdOption = (proj: Project) => {
   };
 };
 
-const getDatabasFullNameOption = (database: ComposedDatabase) => {
+const getDatabasFullNameOption = (database: Database) => {
   return {
     label: database.name,
     value: database.name,
@@ -112,11 +114,12 @@ const getInstanceIdOption = (ins: Instance) => {
   };
 };
 
-const getDatabaseIdOptions = (databases: ComposedDatabase[]) => {
+const getDatabaseIdOptions = (databases: Database[]) => {
   return databases.map<ResourceSelectOption<unknown>>((database) => {
+    const { databaseName } = extractDatabaseResourceName(database.name);
     return {
-      label: database.databaseName,
-      value: database.databaseName,
+      label: databaseName,
+      value: databaseName,
       render: getRenderOptionFunc({
         name: database.name,
         title: () =>

--- a/frontend/src/utils/label.ts
+++ b/frontend/src/utils/label.ts
@@ -1,5 +1,5 @@
 import { orderBy } from "lodash-es";
-import type { ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { extractEnvironmentResourceName } from "./v1";
 
 export const MAX_LABEL_VALUE_LENGTH = 63;
@@ -32,7 +32,7 @@ export const convertKVListToLabels = (
   return labels;
 };
 
-export const getSemanticLabelValue = (db: ComposedDatabase, key: string) => {
+export const getSemanticLabelValue = (db: Database, key: string) => {
   if (key === "environment") {
     return extractEnvironmentResourceName(db.effectiveEnvironment ?? "");
   }

--- a/frontend/src/utils/v1/changelog.ts
+++ b/frontend/src/utils/v1/changelog.ts
@@ -1,8 +1,10 @@
 import { create } from "@bufbuild/protobuf";
 import { useDatabaseV1Store } from "@/store";
-import type { ComposedDatabase } from "@/types";
 import { UNKNOWN_ID } from "@/types";
-import type { Changelog } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Changelog,
+  Database,
+} from "@/types/proto-es/v1/database_service_pb";
 import { ChangelogSchema } from "@/types/proto-es/v1/database_service_pb";
 import { databaseV1Url, extractDatabaseResourceName } from "./database";
 
@@ -41,7 +43,7 @@ export const changelogLink = (changelog: Changelog): string => {
 };
 
 export const mockLatestChangelog = (
-  database: ComposedDatabase,
+  database: Database,
   schema: string = ""
 ) => {
   return create(ChangelogSchema, {

--- a/frontend/src/views/DatabaseDashboard.vue
+++ b/frontend/src/views/DatabaseDashboard.vue
@@ -77,9 +77,9 @@ import {
   instanceNamePrefix,
   projectNamePrefix,
 } from "@/store/modules/v1/common";
-import type { ComposedDatabase } from "@/types";
 import { DEFAULT_PROJECT_NAME, isValidDatabaseName } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { SearchParams } from "@/utils";
 import {
   CommonFilterScopeIdList,
@@ -96,7 +96,7 @@ interface LocalState {
 }
 
 defineProps<{
-  onClickDatabase?: (event: MouseEvent, db: ComposedDatabase) => void;
+  onClickDatabase?: (event: MouseEvent, db: Database) => void;
 }>();
 
 const uiStateStore = useUIStateStore();
@@ -175,7 +175,7 @@ onMounted(() => {
   }
 });
 
-const selectedDatabases = computed((): ComposedDatabase[] => {
+const selectedDatabases = computed((): Database[] => {
   return state.selectedDatabaseNameList
     .filter((databaseName) => isValidDatabaseName(databaseName))
     .map((databaseName) => databaseStore.getDatabaseByName(databaseName));

--- a/frontend/src/views/DatabaseDetail/ChangelogDetail.vue
+++ b/frontend/src/views/DatabaseDetail/ChangelogDetail.vue
@@ -4,7 +4,7 @@
       {{ $t("common.databases") }}
     </NBreadcrumbItem>
     <NBreadcrumbItem @click="router.push(databaseV1Url(database))">
-      {{ database.databaseName }}
+      {{ extractDatabaseResourceName(database.name).databaseName }}
     </NBreadcrumbItem>
     <NBreadcrumbItem
       @click="router.push(`${databaseV1Url(database)}#changelog`)"
@@ -32,7 +32,7 @@ import { useRouter } from "vue-router";
 import { BBSpin } from "@/bbkit";
 import { ChangelogDetail as ChangelogDetailView } from "@/components/Changelog";
 import { useDatabaseV1ByName } from "@/store";
-import { databaseV1Url } from "@/utils";
+import { databaseV1Url, extractDatabaseResourceName } from "@/utils";
 
 const props = defineProps<{
   project: string;

--- a/frontend/src/views/DatabaseDetail/DatabaseDetail.vue
+++ b/frontend/src/views/DatabaseDetail/DatabaseDetail.vue
@@ -28,7 +28,7 @@
             <div
               class="text-xl box-content font-bold text-main truncate flex items-center gap-x-2"
             >
-              {{ database.databaseName }}
+              {{ extractDatabaseResourceName(database.name).databaseName }}
 
               <ProductionEnvironmentV1Icon
                 :environment="environment"
@@ -64,7 +64,7 @@
               <span class="ml-1 textlabel"
                 >{{ $t("common.instance") }}&nbsp;-&nbsp;</span
               >
-              <InstanceV1Name :instance="database.instanceResource" />
+              <InstanceV1Name :instance="getInstanceResource(database)" />
             </dd>
             <dt v-if="database.release" class="sr-only">
               {{ $t("common.release") }}
@@ -105,7 +105,7 @@
           <PermissionGuardWrapper
             v-if="!isDefaultProject"
             v-slot="slotProps"
-            :project="database.projectEntity"
+            :project="getDatabaseProject(database)"
             :permissions="['bb.databases.update']"
           >
             <NButton
@@ -122,7 +122,7 @@
           <PermissionGuardWrapper
             v-if="!isDefaultProject"
             v-slot="slotProps"
-            :project="database.projectEntity"
+            :project="getDatabaseProject(database)"
             :permissions="[
               ...PERMISSIONS_FOR_DATABASE_CHANGE_ISSUE
             ]"
@@ -249,13 +249,17 @@ import {
   ProductionEnvironmentV1Icon,
 } from "@/components/v2";
 import { PROJECT_V1_ROUTE_DATABASE_DETAIL } from "@/router/dashboard/projectV1";
-import { useDatabaseV1ByName, useEnvironmentV1Store } from "@/store";
+import { useDatabaseV1ByName } from "@/store";
 import {
   databaseNamePrefix,
   instanceNamePrefix,
 } from "@/store/modules/v1/common";
 import {
+  extractDatabaseResourceName,
   extractProjectResourceName,
+  getDatabaseEnvironment,
+  getDatabaseProject,
+  getInstanceResource,
   instanceV1HasAlterSchema,
   isDatabaseV1Queryable,
   PERMISSIONS_FOR_DATABASE_CHANGE_ISSUE,
@@ -326,7 +330,7 @@ const { database, ready } = useDatabaseV1ByName(
   )
 );
 
-const project = computed(() => database.value.projectEntity);
+const project = computed(() => getDatabaseProject(database.value));
 
 watchEffect(() => {
   if (!ready.value) {
@@ -348,7 +352,7 @@ watchEffect(() => {
 });
 
 const hasSchemaDiagramFeature = computed((): boolean => {
-  return instanceV1HasAlterSchema(database.value.instanceResource);
+  return instanceV1HasAlterSchema(getInstanceResource(database.value));
 });
 
 const allowQuery = computed(() => {
@@ -364,10 +368,10 @@ const handleGotoSQLEditorFailed = () => {
 };
 
 const environment = computed(() => {
-  return useEnvironmentV1Store().getEnvironmentByName(
-    database.value.effectiveEnvironment ?? ""
-  );
+  return getDatabaseEnvironment(database.value);
 });
 
-useTitle(computed(() => database.value.databaseName));
+useTitle(
+  computed(() => extractDatabaseResourceName(database.value.name).databaseName)
+);
 </script>

--- a/frontend/src/views/DatabaseDetail/RevisionDetail.vue
+++ b/frontend/src/views/DatabaseDetail/RevisionDetail.vue
@@ -4,7 +4,7 @@
       {{ $t("common.databases") }}
     </NBreadcrumbItem>
     <NBreadcrumbItem @click="router.push(databaseV1Url(database))">
-      {{ database.databaseName }}
+      {{ extractDatabaseResourceName(database.name).databaseName }}
     </NBreadcrumbItem>
     <NBreadcrumbItem
       @click="router.push(`${databaseV1Url(database)}#revision`)"
@@ -31,7 +31,7 @@ import { useRouter } from "vue-router";
 import { BBSpin } from "@/bbkit";
 import { RevisionDetailPanel as RevisionDetailView } from "@/components/Revision";
 import { useDatabaseV1ByName } from "@/store";
-import { databaseV1Url } from "@/utils";
+import { databaseV1Url, extractDatabaseResourceName } from "@/utils";
 
 const props = defineProps<{
   project: string;

--- a/frontend/src/views/InstanceDetail.vue
+++ b/frontend/src/views/InstanceDetail.vue
@@ -114,12 +114,9 @@ import {
   instanceNamePrefix,
   projectNamePrefix,
 } from "@/store/modules/v1/common";
-import {
-  type ComposedDatabase,
-  formatEnvironmentName,
-  isValidDatabaseName,
-} from "@/types";
+import { formatEnvironmentName, isValidDatabaseName } from "@/types";
 import { State } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { SearchParams, SearchScope } from "@/utils";
 import {
   CommonFilterScopeIdList,
@@ -281,7 +278,7 @@ const createDatabase = () => {
 
 useTitle(computed(() => instance.value.title));
 
-const selectedDatabases = computed((): ComposedDatabase[] => {
+const selectedDatabases = computed((): Database[] => {
   return state.selectedDatabaseNameList
     .map((databaseName) => databaseStore.getDatabaseByName(databaseName))
     .filter((database) => isValidDatabaseName(database.name));

--- a/frontend/src/views/sql-editor/AsidePanel/ActionBar/TabItem.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/ActionBar/TabItem.vue
@@ -23,6 +23,7 @@ import type { VNodeChild } from "vue";
 import { computed, toRef } from "vue";
 import { useConnectionOfCurrentSQLEditorTab } from "@/store";
 import type { EditorPanelView } from "@/types";
+import { extractDatabaseResourceName } from "@/utils";
 import { useActions } from "../../AsidePanel/SchemaPane/actions";
 import { useCurrentTabViewStateContext } from "../../EditorPanel/context/viewState.tsx";
 import { useButton } from "./common";
@@ -59,7 +60,7 @@ const { openNewTab } = useActions();
 
 const handleClick = () => {
   openNewTab({
-    title: `[${database.value.databaseName}] ${props.action.title}`,
+    title: `[${extractDatabaseResourceName(database.value.name).databaseName}] ${props.action.title}`,
     view: props.action.view,
   });
 };

--- a/frontend/src/views/sql-editor/AsidePanel/HistoryPane/HistoryConnectionIcon.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/HistoryPane/HistoryConnectionIcon.vue
@@ -13,7 +13,7 @@ import { InstanceV1EngineIcon } from "@/components/v2";
 import { useDatabaseV1Store } from "@/store";
 import { isValidInstanceName, unknownInstanceResource } from "@/types";
 import type { QueryHistory } from "@/types/proto-es/v1/sql_service_pb";
-import { extractDatabaseResourceName } from "@/utils";
+import { extractDatabaseResourceName, getInstanceResource } from "@/utils";
 
 const props = defineProps<{
   queryHistory: QueryHistory;
@@ -22,6 +22,6 @@ const props = defineProps<{
 const instance = computedAsync(async () => {
   const { database } = extractDatabaseResourceName(props.queryHistory.database);
   const d = await useDatabaseV1Store().getOrFetchDatabaseByName(database);
-  return d.instanceResource;
+  return getInstanceResource(d);
 }, unknownInstanceResource());
 </script>

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/HoverPanel/ColumnInfo.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/HoverPanel/ColumnInfo.vue
@@ -35,6 +35,7 @@ import { getColumnDefaultValuePlaceholder } from "@/components/SchemaEditorLite"
 import { useDatabaseV1Store, useDBSchemaV1Store } from "@/store";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import { ColumnMetadataSchema } from "@/types/proto-es/v1/database_service_pb";
+import { getInstanceResource } from "@/utils";
 import InfoItem from "./InfoItem.vue";
 
 const props = defineProps<{
@@ -60,7 +61,8 @@ const columnMetadata = computed(
 );
 
 const instanceEngine = computed(
-  () => databaseStore.getDatabaseByName(props.database).instanceResource.engine
+  () =>
+    getInstanceResource(databaseStore.getDatabaseByName(props.database)).engine
 );
 
 const characterSet = computed(() => {

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/HoverPanel/TableInfo.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/HoverPanel/TableInfo.vue
@@ -29,7 +29,7 @@ import { computed } from "vue";
 import { RichEngineName } from "@/components/v2";
 import { useDatabaseV1Store, useDBSchemaV1Store } from "@/store";
 import { Engine } from "@/types/proto-es/v1/common_pb";
-import { bytesToString } from "@/utils";
+import { bytesToString, getInstanceResource } from "@/utils";
 import InfoItem from "./InfoItem.vue";
 
 const props = defineProps<{
@@ -42,7 +42,8 @@ const dbSchema = useDBSchemaV1Store();
 const databaseStore = useDatabaseV1Store();
 
 const instanceEngine = computed(
-  () => databaseStore.getDatabaseByName(props.database).instanceResource.engine
+  () =>
+    getInstanceResource(databaseStore.getDatabaseByName(props.database)).engine
 );
 
 const tableMetadata = computed(() =>

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/DatabaseNode.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/TreeNode/DatabaseNode.vue
@@ -1,11 +1,11 @@
 <template>
   <CommonNode
-    :text="database.databaseName"
+    :text="databaseName"
     :keyword="keyword"
     :highlight="true"
   >
     <template #icon>
-      <InstanceV1EngineIcon :instance="database.instanceResource" />
+      <InstanceV1EngineIcon :instance="instanceResource" />
     </template>
   </CommonNode>
 </template>
@@ -14,6 +14,7 @@
 import { computed } from "vue";
 import { InstanceV1EngineIcon } from "@/components/v2";
 import { useDatabaseV1Store } from "@/store";
+import { extractDatabaseResourceName, getInstanceResource } from "@/utils";
 import type { TreeNode } from "../tree";
 import CommonNode from "./CommonNode.vue";
 
@@ -29,4 +30,10 @@ const database = computed(() =>
     (props.node as TreeNode<"database">).meta.target.database
   )
 );
+
+const databaseName = computed(
+  () => extractDatabaseResourceName(database.value.name).databaseName
+);
+
+const instanceResource = computed(() => getInstanceResource(database.value));
 </script>

--- a/frontend/src/views/sql-editor/AsidePanel/SchemaPane/tree.ts
+++ b/frontend/src/views/sql-editor/AsidePanel/SchemaPane/tree.ts
@@ -1,10 +1,10 @@
 import type { TreeOption } from "naive-ui";
 import { type RenderFunction } from "vue";
 import { t } from "@/plugins/i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
   CheckConstraintMetadata,
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   DependencyColumn,
   ForeignKeyMetadata,
@@ -822,7 +822,7 @@ const buildSchemaNodeChildren = (
 };
 
 export const buildDatabaseSchemaTree = (
-  database: ComposedDatabase,
+  database: Database,
   metadata: DatabaseMetadata
 ) => {
   const dummyRoot = mapTreeNodeByType("database", {

--- a/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/ConnectionPane.vue
+++ b/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/ConnectionPane.vue
@@ -235,7 +235,6 @@ import {
 import { instanceNamePrefix } from "@/store/modules/v1/common";
 import type {
   BatchQueryContext,
-  ComposedDatabase,
   QueryDataSourceType,
   SQLEditorTreeNode,
 } from "@/types";
@@ -248,6 +247,7 @@ import {
   unknownEnvironment,
 } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { DataSourceType } from "@/types/proto-es/v1/instance_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import type { SearchParams } from "@/utils";
@@ -603,7 +603,7 @@ const connect = (node: SQLEditorTreeNode) => {
   if (node.disabled || node.meta.type !== "database") {
     return;
   }
-  const database = node.meta.target as ComposedDatabase;
+  const database = node.meta.target as Database;
   if (!isDatabaseV1Queryable(database)) {
     return;
   }

--- a/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/DatabaseHoverPanel/DatabaseHoverPanel.vue
+++ b/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/DatabaseHoverPanel/DatabaseHoverPanel.vue
@@ -21,7 +21,7 @@
           </div>
           <div class="text-main text-right">
             <EnvironmentV1Name
-              :environment="database.effectiveEnvironmentEntity"
+              :environment="environment!"
               :link="false"
             />
           </div>
@@ -32,17 +32,17 @@
           </div>
           <div class="text-main text-right">
             <InstanceV1Name
-              :instance="database.instanceResource"
+              :instance="instanceResource!"
               :link="false"
             />
           </div>
         </div>
-        <div v-if="!hasProjectContext" class="contents">
+        <div v-if="!hasProjectContext && project" class="contents">
           <div class="text-gray-500 font-medium">
             {{ $t("common.project") }}
           </div>
           <div class="text-main text-right">
-            <ProjectV1Name :project="database.projectEntity" :link="false" />
+            <ProjectV1Name :project="project" :link="false" />
           </div>
         </div>
         <div class="contents">
@@ -77,7 +77,12 @@ import {
 } from "@/components/v2";
 import { useSQLEditorStore } from "@/store";
 import type { Position, SQLEditorTreeNodeTarget } from "@/types";
-import { minmax } from "@/utils";
+import {
+  getDatabaseEnvironment,
+  getDatabaseProject,
+  getInstanceResource,
+  minmax,
+} from "@/utils";
 import { useHoverStateContext } from "./hover-state";
 
 const props = defineProps<{
@@ -112,6 +117,21 @@ const database = computed(() => {
   const { type, target } = state.value.node.meta;
   if (type !== "database") return undefined;
   return target as SQLEditorTreeNodeTarget<"database">;
+});
+
+const environment = computed(() => {
+  if (!database.value) return undefined;
+  return getDatabaseEnvironment(database.value);
+});
+
+const instanceResource = computed(() => {
+  if (!database.value) return undefined;
+  return getInstanceResource(database.value);
+});
+
+const project = computed(() => {
+  if (!database.value) return undefined;
+  return getDatabaseProject(database.value);
 });
 
 const hasProjectContext = computed(() => {

--- a/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/tree.ts
+++ b/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/tree.ts
@@ -14,11 +14,11 @@ import {
   useSQLEditorStore,
 } from "@/store";
 import type {
-  ComposedDatabase,
   StatefulSQLEditorTreeFactor as StatefulFactor,
   SQLEditorTreeNode as TreeNode,
 } from "@/types";
 import { DEBOUNCE_SEARCH_DELAY } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   getDefaultPagination,
   isDatabaseV1Queryable,
@@ -56,7 +56,7 @@ export const useSQLEditorTreeByEnvironment = (
 
   const tree = ref<TreeNode[]>([]);
   const showMissingQueryDatabases = ref<boolean>(false);
-  const databaseList = ref<ComposedDatabase[]>([]);
+  const databaseList = ref<Database[]>([]);
   const fetchDataState = ref<{
     loading: boolean;
     nextPageToken?: string;

--- a/frontend/src/views/sql-editor/EditorCommon/DatabaseChooser.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/DatabaseChooser.vue
@@ -30,7 +30,7 @@
         </template>
       </NPopover>
       <EnvironmentV1Name
-        :environment="database.effectiveEnvironmentEntity"
+        :environment="environment"
         :link="false"
       />
       <ChevronRightIcon class="shrink-0 h-4 w-4 text-control-light" />
@@ -45,7 +45,7 @@
       <ChevronRightIcon class="shrink-0 h-4 w-4 text-control-light" />
       <div class="flex items-center gap-1">
         <DatabaseIcon class="shrink-0" />
-        <span>{{ database.databaseName }}</span>
+        <span>{{ databaseName }}</span>
       </div>
     </div>
     <template v-else>
@@ -58,6 +58,7 @@
 import { ChevronRightIcon, SquareStackIcon } from "lucide-vue-next";
 import { NButton, NPopover } from "naive-ui";
 import { storeToRefs } from "pinia";
+import { computed } from "vue";
 import { DatabaseIcon } from "@/components/Icon";
 import { EnvironmentV1Name, InstanceV1EngineIcon } from "@/components/v2";
 import {
@@ -66,13 +67,24 @@ import {
   useSQLEditorTabStore,
 } from "@/store";
 import { isValidDatabaseName, isValidInstanceName } from "@/types";
+import {
+  extractDatabaseResourceName,
+  getDatabaseEnvironment,
+  getInstanceResource,
+} from "@/utils";
 import { useSQLEditorContext } from "../context";
 
 const { currentTab, isInBatchMode } = storeToRefs(useSQLEditorTabStore());
 const { showConnectionPanel } = useSQLEditorContext();
 const { projectContextReady } = storeToRefs(useSQLEditorStore());
 
-const { instance, database } = useConnectionOfCurrentSQLEditorTab();
+const { database } = useConnectionOfCurrentSQLEditorTab();
+
+const instance = computed(() => getInstanceResource(database.value));
+const environment = computed(() => getDatabaseEnvironment(database.value));
+const databaseName = computed(
+  () => extractDatabaseResourceName(database.value.name).databaseName
+);
 
 const changeConnection = () => {
   showConnectionPanel.value = true;

--- a/frontend/src/views/sql-editor/EditorCommon/ExecuteHint.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ExecuteHint.vue
@@ -9,7 +9,7 @@
           <i18n-t keypath="sql-editor.enable-ddl-for-environment">
             <template #environment>
               <EnvironmentV1Name
-                :environment="database.effectiveEnvironmentEntity"
+                :environment="getDatabaseEnvironment(database)"
               />
             </template>
           </i18n-t>
@@ -53,13 +53,18 @@ import {
   useSQLEditorTabStore,
   useStorageStore,
 } from "@/store";
-import type { ComposedDatabase } from "@/types";
-import { extractProjectResourceName, hasWorkspacePermissionV2 } from "@/utils";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import {
+  extractDatabaseResourceName,
+  extractProjectResourceName,
+  getDatabaseEnvironment,
+  hasWorkspacePermissionV2,
+} from "@/utils";
 import AdminModeButton from "./AdminModeButton.vue";
 
 withDefaults(
   defineProps<{
-    database?: ComposedDatabase | undefined;
+    database?: Database | undefined;
   }>(),
   { database: undefined }
 );
@@ -130,10 +135,11 @@ const gotoCreateIssue = async () => {
   const db = await useDatabaseV1Store().getOrFetchDatabaseByName(database);
   const sqlStorageKey = `bb.issues.sql.${uuidv4()}`;
   useStorageStore().put(sqlStorageKey, statement.value);
+  const { databaseName } = extractDatabaseResourceName(db.name);
 
   const query = {
     template: "bb.issue.database.update",
-    name: `[${db.databaseName}] Change from SQL Editor`,
+    name: `[${databaseName}] Change from SQL Editor`,
     databaseList: db.name,
     sqlStorageKey,
   };

--- a/frontend/src/views/sql-editor/EditorCommon/QueryContextSettingPopover.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/QueryContextSettingPopover.vue
@@ -122,7 +122,11 @@ import {
 } from "@/types/proto-es/v1/instance_service_pb";
 import { QueryDataPolicy_Restriction } from "@/types/proto-es/v1/org_policy_service_pb";
 import { QueryOption_RedisRunCommandsOn } from "@/types/proto-es/v1/sql_service_pb";
-import { getValidDataSourceByPolicy, readableDataSourceType } from "@/utils";
+import {
+  getInstanceResource,
+  getValidDataSourceByPolicy,
+  readableDataSourceType,
+} from "@/utils";
 
 defineProps<{
   disabled?: boolean;
@@ -153,7 +157,7 @@ const showRedisConfig = computed(() => {
   if (!database.value) {
     return false;
   }
-  const instance = database.value.instanceResource;
+  const instance = getInstanceResource(database.value);
   return instance.engine === Engine.REDIS;
 });
 
@@ -162,14 +166,14 @@ const selectedDataSourceId = computed(() => {
 });
 
 const selectedDataSource = computed(() => {
-  const instance = database.value.instanceResource;
+  const instance = getInstanceResource(database.value);
   return instance.dataSources.find(
     (ds) => ds.id === selectedDataSourceId.value
   );
 });
 
 const dataSources = computed(() => {
-  return orderBy(database.value.instanceResource.dataSources, "type");
+  return orderBy(getInstanceResource(database.value).dataSources, "type");
 });
 
 const dataSourceUnaccessibleReason = (

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/TableCell.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/TableCell.vue
@@ -58,10 +58,14 @@ import { ExpandIcon } from "lucide-vue-next";
 import { NButton } from "naive-ui";
 import { twMerge } from "tailwind-merge";
 import { computed, ref } from "vue";
-import { type ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { RowValue } from "@/types/proto-es/v1/sql_service_pb";
-import { getHighlightHTMLByRegExp, type SearchScope } from "@/utils";
+import {
+  getHighlightHTMLByRegExp,
+  getInstanceResource,
+  type SearchScope,
+} from "@/utils";
 import { useSQLResultViewContext } from "../context";
 import BinaryFormatButton from "./common/BinaryFormatButton.vue";
 import {
@@ -78,7 +82,7 @@ const props = defineProps<{
   colIndex: number;
   allowSelect?: boolean;
   columnType: string; // Column type from QueryResult
-  database: ComposedDatabase;
+  database: Database;
   scope?: SearchScope;
   keyword: string;
 }>();
@@ -133,7 +137,7 @@ useResizeObserver(cellRef, () => {
 
 const clickable = computed(() => {
   if (truncated.value) return true;
-  if (props.database.instanceResource.engine === Engine.MONGODB) {
+  if (getInstanceResource(props.database).engine === Engine.MONGODB) {
     // A cheap way to check JSON string without paying the parsing cost.
     const maybeJSON = String(props.value).trim();
     return (

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/VirtualDataTable.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/VirtualDataTable.vue
@@ -213,7 +213,8 @@
 import { useWindowSize, watchDebounced } from "@vueuse/core";
 import { NPerformantEllipsis, NVirtualList } from "naive-ui";
 import { nextTick, onMounted, onUnmounted, ref } from "vue";
-import { type ComposedDatabase, DEBOUNCE_SEARCH_DELAY } from "@/types";
+import { DEBOUNCE_SEARCH_DELAY } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { MaskingReason } from "@/types/proto-es/v1/sql_service_pb";
 import { type QueryRow } from "@/types/proto-es/v1/sql_service_pb";
 import { type SearchParams } from "@/utils";
@@ -244,7 +245,7 @@ const props = defineProps<{
   activeRowIndex: number;
   isSensitiveColumn: (index: number) => boolean;
   getMaskingReason?: (index: number) => MaskingReason | undefined;
-  database: ComposedDatabase;
+  database: Database;
   sortState?: SortState;
   search: SearchParams;
 }>();

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue
@@ -25,7 +25,7 @@ import {
   isValidDatabaseName,
   PresetRoleType,
 } from "@/types";
-import { hasProjectPermissionV2 } from "@/utils";
+import { getDatabaseProject, hasProjectPermissionV2 } from "@/utils";
 
 const props = withDefaults(
   defineProps<{
@@ -56,9 +56,10 @@ const available = computed(() => {
     return false;
   }
 
+  const project = getDatabaseProject(database.value);
   return (
-    database.value.projectEntity.allowRequestRole &&
-    hasProjectPermissionV2(database.value.projectEntity, "bb.issues.create")
+    project.allowRequestRole &&
+    hasProjectPermissionV2(project, "bb.issues.create")
   );
 });
 

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/ResultViewV1.vue
@@ -193,14 +193,15 @@ import {
   usePolicyV1Store,
 } from "@/store/modules/v1/policy";
 import type {
-  ComposedDatabase,
   DatabaseResource,
   SQLEditorQueryParams,
   SQLResultSetV1,
 } from "@/types";
 import { ExportFormat } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { PolicyType } from "@/types/proto-es/v1/org_policy_service_pb";
 import { ExportRequestSchema } from "@/types/proto-es/v1/sql_service_pb";
+import { extractDatabaseResourceName } from "@/utils";
 import type { SQLResultViewContext } from "./context";
 import { provideSQLResultViewContext } from "./context";
 import { provideBinaryFormatContext } from "./DataTable/common/binary-format-store";
@@ -215,7 +216,7 @@ type ViewMode = "SINGLE-RESULT" | "MULTI-RESULT" | "EMPTY" | "ERROR";
 const props = withDefaults(
   defineProps<{
     executeParams: SQLEditorQueryParams;
-    database: ComposedDatabase;
+    database: Database;
     resultSet?: SQLResultSetV1;
     loading?: boolean;
     dark?: boolean;
@@ -378,7 +379,7 @@ const handleExportBtnClick = async ({
       {
         content,
         // the download file is always zip file.
-        filename: `${props.database.databaseName}.${dayjs(new Date()).format("YYYY-MM-DDTHH-mm-ss")}.zip`,
+        filename: `${extractDatabaseResourceName(props.database.name).databaseName}.${dayjs(new Date()).format("YYYY-MM-DDTHH-mm-ss")}.zip`,
       },
     ]);
   } catch (e) {

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
@@ -258,11 +258,11 @@ import { useExecuteSQL } from "@/composables/useExecuteSQL";
 import { DISMISS_PLACEHOLDER } from "@/plugins/ai/components/state";
 import { useSQLEditorStore, useSQLEditorTabStore } from "@/store";
 import type {
-  ComposedDatabase,
   SQLEditorDatabaseQueryContext,
   SQLEditorQueryParams,
 } from "@/types";
 import { Engine, ExportFormat } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   QueryOption_MSSQLExplainFormat,
   QueryOptionSchema,
@@ -273,6 +273,7 @@ import {
   compareQueryRowValues,
   createExplainToken,
   extractSQLRowValuePlain,
+  getInstanceResource,
   isNullOrUndefined,
   type SearchParams,
 } from "@/utils";
@@ -301,7 +302,7 @@ type ViewMode = "RESULT" | "EMPTY" | "AFFECTED-ROWS" | "ERROR";
 
 const props = defineProps<{
   params: SQLEditorQueryParams;
-  database: ComposedDatabase;
+  database: Database;
   result: QueryResult;
   setIndex: number;
   showExport: boolean;
@@ -607,7 +608,7 @@ provideSelectionContext({
   rows: rows,
 });
 
-const engine = computed(() => props.database.instanceResource.engine);
+const engine = computed(() => getInstanceResource(props.database).engine);
 
 const showVisualizeButton = computed((): boolean => {
   return (

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
@@ -73,7 +73,7 @@
 import { NVirtualList } from "naive-ui";
 import { computed, ref } from "vue";
 import { CopyButton } from "@/components/v2";
-import { type ComposedDatabase } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type {
   MaskingReason,
   QueryRow,
@@ -96,7 +96,7 @@ const props = defineProps<{
   activeRowIndex: number;
   isSensitiveColumn: (index: number) => boolean;
   getMaskingReason?: (index: number) => MaskingReason | undefined;
-  database: ComposedDatabase;
+  database: Database;
   search: SearchParams;
 }>();
 

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTableColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTableColumnsTable.vue
@@ -23,19 +23,23 @@ import { NCheckbox, NDataTable } from "naive-ui";
 import { computed, h, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { DefaultValueCell } from "@/components/SchemaEditorLite/Panels/TableColumnEditor/components";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   ExternalTableMetadata,
   SchemaMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
-import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
+import {
+  getHighlightHTMLByRegExp,
+  getInstanceResource,
+  useAutoHeightDataTable,
+} from "@/utils";
 import { EllipsisCell } from "../../common";
 import { useCurrentTabViewStateContext } from "../../context/viewState";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   externalTable: ExternalTableMetadata;
@@ -59,7 +63,7 @@ const filteredColumns = computed(() => {
 });
 
 const columns = computed(() => {
-  const engine = props.db.instanceResource.engine;
+  const engine = getInstanceResource(props.db).engine;
   const downGrade = filteredColumns.value.length > 50;
   const columns: (DataTableColumn<ColumnMetadata> & { hide?: boolean })[] = [
     {

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTablesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ExternalTablesPanel/ExternalTablesTable.vue
@@ -22,8 +22,8 @@
 import { type DataTableColumn, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   ExternalTableMetadata,
   SchemaMetadata,
@@ -32,7 +32,7 @@ import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
 import { useCurrentTabViewStateContext } from "../../context/viewState";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   externalTables: ExternalTableMetadata[];

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/FunctionsPanel/FunctionsTable.vue
@@ -22,8 +22,8 @@
 import { type DataTableColumn, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   FunctionMetadata,
   SchemaMetadata,
@@ -35,7 +35,7 @@ import { useCurrentTabViewStateContext } from "../../context/viewState";
 type FunctionWithPosition = { func: FunctionMetadata; position: number };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   funcs: FunctionMetadata[];

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/InfoPanel/InfoPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/InfoPanel/InfoPanel.vue
@@ -111,7 +111,7 @@
       </div>
 
       <div
-        v-if="instanceV1SupportsSequence(database.instanceResource)"
+        v-if="instanceV1SupportsSequence(getInstanceResource(database))"
         class="flex flex-col gap-2"
       >
         <div class="flex items-center justify-between">
@@ -143,7 +143,7 @@
       </div>
 
       <div
-        v-if="instanceV1SupportsExternalTable(database.instanceResource)"
+        v-if="instanceV1SupportsExternalTable(getInstanceResource(database))"
         class="flex flex-col gap-2"
       >
         <div class="flex items-center justify-between">
@@ -172,7 +172,7 @@
       </div>
 
       <div
-        v-if="instanceV1SupportsPackage(database.instanceResource)"
+        v-if="instanceV1SupportsPackage(getInstanceResource(database))"
         class="flex flex-col gap-2"
       >
         <div class="flex items-center justify-between">
@@ -215,6 +215,7 @@ import {
   useDBSchemaV1Store,
 } from "@/store";
 import {
+  getInstanceResource,
   instanceV1SupportsExternalTable,
   instanceV1SupportsPackage,
   instanceV1SupportsSequence,

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/PackagesPanel/PackagesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/PackagesPanel/PackagesTable.vue
@@ -24,8 +24,8 @@
 import { type DataTableColumn, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   PackageMetadata,
   SchemaMetadata,
@@ -40,7 +40,7 @@ type PackageWithPosition = {
 };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   packages: PackageMetadata[];

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/Panels.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/Panels.vue
@@ -67,6 +67,7 @@ import { isValidDatabaseName } from "@/types";
 import type { DatabaseMetadata } from "@/types/proto-es/v1/database_service_pb";
 import {
   extractDatabaseResourceName,
+  getInstanceResource,
   nextAnimationFrame,
   type VueClass,
 } from "@/utils";
@@ -140,7 +141,7 @@ useEmitteryEventListener(AIEvents, "run-statement", async ({ statement }) => {
   execute({
     connection,
     statement,
-    engine: database.instanceResource.engine,
+    engine: getInstanceResource(database).engine,
     explain: false,
     selection: tab.value.editorState.selection,
   });

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ProceduresPanel/ProceduresTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ProceduresPanel/ProceduresTable.vue
@@ -24,8 +24,8 @@
 import { type DataTableColumn, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   ProcedureMetadata,
   SchemaMetadata,
@@ -40,7 +40,7 @@ type ProcedureWithPosition = {
 };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   procedures: ProcedureMetadata[];

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/SequencesPanel/SequencesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/SequencesPanel/SequencesTable.vue
@@ -24,8 +24,8 @@
 import { type DataTableColumn, NCheckbox, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   SequenceMetadata,
@@ -38,7 +38,7 @@ import { useCurrentTabViewStateContext } from "../../context/viewState";
 type SequenceWithPosition = { sequence: SequenceMetadata; position: number };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   sequences: SequenceMetadata[];

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ColumnsTable.vue
@@ -26,20 +26,24 @@ import {
   DefaultValueCell,
   ForeignKeyCell,
 } from "@/components/SchemaEditorLite/Panels/TableColumnEditor/components";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
-import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
+import {
+  getHighlightHTMLByRegExp,
+  getInstanceResource,
+  useAutoHeightDataTable,
+} from "@/utils";
 import { EllipsisCell } from "../../common";
 import { useCurrentTabViewStateContext } from "../../context/viewState";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   table: TableMetadata;
@@ -67,7 +71,7 @@ const primaryKey = computed(() => {
 });
 
 const columns = computed(() => {
-  const engine = props.db.instanceResource.engine;
+  const engine = getInstanceResource(props.db).engine;
   const downGrade = filteredColumns.value.length > 50;
   const columns: (DataTableColumn<ColumnMetadata> & { hide?: boolean })[] = [
     {

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ForeignKeysTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/ForeignKeysTable.vue
@@ -22,19 +22,23 @@ import type { DataTableColumn, DataTableInst } from "naive-ui";
 import { NDataTable } from "naive-ui";
 import { computed, h, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
+  Database,
   DatabaseMetadata,
   ForeignKeyMetadata,
   SchemaMetadata,
   TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
-import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
+import {
+  getHighlightHTMLByRegExp,
+  getInstanceResource,
+  useAutoHeightDataTable,
+} from "@/utils";
 import { useCurrentTabViewStateContext } from "../../context/viewState";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   table: TableMetadata;
@@ -133,7 +137,7 @@ const columns = computed(() => {
         title: "Match type",
         resizable: true,
         minWidth: 140,
-        hide: props.db.instanceResource.engine !== Engine.POSTGRES,
+        hide: getInstanceResource(props.db).engine !== Engine.POSTGRES,
       },
     ];
   return columns.filter((header) => !header.hide);

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/IndexesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/IndexesTable.vue
@@ -22,8 +22,8 @@ import type { DataTableColumn } from "naive-ui";
 import { NCheckbox, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   IndexMetadata,
   SchemaMetadata,
@@ -34,7 +34,7 @@ import { EllipsisCell } from "../../common";
 import { useCurrentTabViewStateContext } from "../../context/viewState";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   table: TableMetadata;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/PartitionsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/PartitionsTable.vue
@@ -22,8 +22,8 @@ import { ChevronDownIcon } from "lucide-vue-next";
 import { type DataTableColumn, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -38,7 +38,7 @@ type FlattenTablePartitionMetadata = {
 };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   table: TableMetadata;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TableDetail.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TableDetail.vue
@@ -98,8 +98,8 @@ import {
   TriggerIcon,
 } from "@/components/Icon";
 import { SearchBox } from "@/components/v2";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -119,7 +119,7 @@ type LocalState = {
 };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   table: TableMetadata;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TablesTable.vue
@@ -22,8 +22,8 @@
 import { type DataTableColumn, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -31,6 +31,7 @@ import type {
 import {
   bytesToString,
   getHighlightHTMLByRegExp,
+  getInstanceResource,
   hasIndexSizeProperty,
   hasTableEngineProperty,
   instanceV1HasCollationAndCharacterSet,
@@ -40,7 +41,7 @@ import { EllipsisCell } from "../../common";
 import { useCurrentTabViewStateContext } from "../../context/viewState";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   tables: TableMetadata[];
@@ -62,7 +63,7 @@ const emit = defineEmits<{
 const { viewState } = useCurrentTabViewStateContext();
 const { t } = useI18n();
 const instanceResource = computed(() => {
-  return props.db.instanceResource;
+  return getInstanceResource(props.db);
 });
 
 const filteredTables = computed(() => {

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TriggersTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TablesPanel/TriggersTable.vue
@@ -54,8 +54,8 @@ import { type DataTableColumn, NButton, NDataTable, NSplit } from "naive-ui";
 import { computed, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { TriggerIcon } from "@/components/Icon";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -76,7 +76,7 @@ type TriggerWithPosition = {
 };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   table: TableMetadata;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/TriggersPanel/TriggersTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/TriggersPanel/TriggersTable.vue
@@ -24,8 +24,8 @@
 import { type DataTableColumn, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   TableMetadata,
@@ -41,7 +41,7 @@ type TriggerWithPosition = {
 };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   table?: TableMetadata;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ColumnsTable.vue
@@ -23,19 +23,23 @@ import { NCheckbox, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { DefaultValueCell } from "@/components/SchemaEditorLite/Panels/TableColumnEditor/components";
-import type { ComposedDatabase } from "@/types";
 import type {
   ColumnMetadata,
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   ViewMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
-import { getHighlightHTMLByRegExp, useAutoHeightDataTable } from "@/utils";
+import {
+  getHighlightHTMLByRegExp,
+  getInstanceResource,
+  useAutoHeightDataTable,
+} from "@/utils";
 import { EllipsisCell } from "../../common";
 import { useCurrentTabViewStateContext } from "../../context/viewState";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   view: ViewMetadata;
@@ -63,7 +67,7 @@ const filteredColumns = computed(() => {
 });
 
 const columns = computed(() => {
-  const engine = props.db.instanceResource.engine;
+  const engine = getInstanceResource(props.db).engine;
   const downGrade = filteredColumns.value.length > 50;
   const columns: (DataTableColumn<ColumnMetadata> & { hide?: boolean })[] = [
     {

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DefinitionViewer.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DefinitionViewer.vue
@@ -47,13 +47,13 @@ import formatSQL from "@/components/MonacoEditor/sqlFormatter";
 import { AIChatToSQL, useAIActions } from "@/plugins/ai";
 import { useAIContext } from "@/plugins/ai/logic";
 import * as promptUtils from "@/plugins/ai/logic/prompt";
-import type { ComposedDatabase } from "@/types";
 import { dialectOfEngineV1 } from "@/types";
-import { nextAnimationFrame } from "@/utils";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { getInstanceResource, nextAnimationFrame } from "@/utils";
 import { useSQLEditorContext } from "@/views/sql-editor/context";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   code: string;
   format?: boolean;
 }>();
@@ -65,7 +65,7 @@ const emit = defineEmits<{
 
 const { showAIPanel, editorPanelSize, handleEditorPanelResize } =
   useSQLEditorContext();
-const instanceEngine = computed(() => props.db.instanceResource.engine);
+const instanceEngine = computed(() => getInstanceResource(props.db).engine);
 const AIContext = useAIContext();
 const selectedStatement = ref("");
 
@@ -121,7 +121,7 @@ const handleEditorReady = (
       AIContext.events.emit("send-chat", {
         content: promptUtils.explainCode(
           statement,
-          props.db.instanceResource.engine
+          getInstanceResource(props.db).engine
         ),
         newChat,
       });

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DependencyColumnsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/DependencyColumnsTable.vue
@@ -23,8 +23,8 @@ import type { DataTableColumn } from "naive-ui";
 import { NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   DependencyColumn,
   SchemaMetadata,
@@ -32,6 +32,7 @@ import type {
 } from "@/types/proto-es/v1/database_service_pb";
 import {
   getHighlightHTMLByRegExp,
+  getInstanceResource,
   hasSchemaProperty,
   keyForDependencyColumn,
   useAutoHeightDataTable,
@@ -39,7 +40,7 @@ import {
 import { useCurrentTabViewStateContext } from "../../context/viewState";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   view: ViewMetadata;
@@ -70,7 +71,7 @@ const filteredDependencyColumns = computed(() => {
 });
 
 const columns = computed(() => {
-  const engine = props.db.instanceResource.engine;
+  const engine = getInstanceResource(props.db).engine;
   const columns: (DataTableColumn<DependencyColumn> & { hide?: boolean })[] = [
     {
       key: "schema",

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewDetail.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewDetail.vue
@@ -81,8 +81,8 @@ import { computed, h, reactive, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { ColumnIcon, ViewIcon } from "@/components/Icon";
 import { SearchBox } from "@/components/v2";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   ViewMetadata,
@@ -100,7 +100,7 @@ type LocalState = {
 };
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   view: ViewMetadata;

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewsTable.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/ViewsPanel/ViewsTable.vue
@@ -22,8 +22,8 @@
 import { type DataTableColumn, NDataTable } from "naive-ui";
 import { computed, h, watch } from "vue";
 import { useI18n } from "vue-i18n";
-import type { ComposedDatabase } from "@/types";
 import type {
+  Database,
   DatabaseMetadata,
   SchemaMetadata,
   ViewMetadata,
@@ -33,7 +33,7 @@ import { EllipsisCell } from "../../common";
 import { useCurrentTabViewStateContext } from "../../context/viewState";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   database: DatabaseMetadata;
   schema: SchemaMetadata;
   views: ViewMetadata[];

--- a/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/Panels/common/CodeViewer.vue
@@ -84,14 +84,18 @@ import formatSQL from "@/components/MonacoEditor/sqlFormatter";
 import { AIChatToSQL, useAIActions } from "@/plugins/ai";
 import { useAIContext } from "@/plugins/ai/logic";
 import * as promptUtils from "@/plugins/ai/logic/prompt";
-import type { ComposedDatabase } from "@/types";
 import { dialectOfEngineV1 } from "@/types";
-import { nextAnimationFrame, type VueClass } from "@/utils";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import {
+  getInstanceResource,
+  nextAnimationFrame,
+  type VueClass,
+} from "@/utils";
 import { useSQLEditorContext } from "@/views/sql-editor/context";
 import { OpenAIButton } from "@/views/sql-editor/EditorCommon";
 
 const props = defineProps<{
-  db: ComposedDatabase;
+  db: Database;
   title: string;
   code: string;
   headerClass?: VueClass;
@@ -108,7 +112,7 @@ const format = useLocalStorage<boolean>(
   "bb.sql-editor.editor-panel.code-viewer.format",
   false
 );
-const instanceEngine = computed(() => props.db.instanceResource.engine);
+const instanceEngine = computed(() => getInstanceResource(props.db).engine);
 const selectedStatement = ref("");
 
 const formatted = computedAsync(
@@ -163,7 +167,7 @@ const handleEditorReady = (
       AIContext.events.emit("send-chat", {
         content: promptUtils.explainCode(
           statement,
-          props.db.instanceResource.engine
+          getInstanceResource(props.db).engine
         ),
         newChat,
       });

--- a/frontend/src/views/sql-editor/EditorPanel/ResultPanel/BatchQuerySelect.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/ResultPanel/BatchQuerySelect.vue
@@ -131,26 +131,31 @@ import {
   useSQLStore,
 } from "@/store";
 import { useEffectiveQueryDataPolicyForProject } from "@/store/modules/v1/policy";
-import type { ComposedDatabase, SQLEditorDatabaseQueryContext } from "@/types";
+import type { SQLEditorDatabaseQueryContext } from "@/types";
 import { ExportFormat } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { ExportRequestSchema } from "@/types/proto-es/v1/sql_service_pb";
-import { hexToRgb } from "@/utils";
+import {
+  extractDatabaseResourceName,
+  getDatabaseEnvironment,
+  hexToRgb,
+} from "@/utils";
 import ContextMenu from "./ContextMenu.vue";
 import { provideResultTabListContext } from "./context";
 
 const MAX_EXPORT = 20;
 
 type BatchQueryItem = {
-  database: ComposedDatabase;
+  database: Database;
   context: SQLEditorDatabaseQueryContext | undefined;
 };
 
 const props = defineProps<{
-  selectedDatabase: ComposedDatabase | undefined;
+  selectedDatabase: Database | undefined;
 }>();
 
 const emit = defineEmits<{
-  (event: "update:selected-database", db: ComposedDatabase | undefined): void;
+  (event: "update:selected-database", db: Database | undefined): void;
 }>();
 
 const tabStore = useSQLEditorTabStore();
@@ -257,9 +262,9 @@ watch(
   }
 );
 
-const getBackgroundColorRgb = (database: ComposedDatabase) => {
+const getBackgroundColorRgb = (database: Database) => {
   const color = hexToRgb(
-    database.effectiveEnvironmentEntity.color || "#4f46e5"
+    getDatabaseEnvironment(database).color || "#4f46e5"
   ).join(", ");
   return {
     backgroundColor: `rgba(${color}, 0.1)`,
@@ -301,7 +306,7 @@ const handleExportBtnClick = async ({
       contents.push({
         content,
         // the download file is always zip file.
-        filename: `${database.databaseName}.${dayjs(new Date()).format("YYYY-MM-DDTHH-mm-ss")}.zip`,
+        filename: `${extractDatabaseResourceName(database.name).databaseName}.${dayjs(new Date()).format("YYYY-MM-DDTHH-mm-ss")}.zip`,
       });
     } catch (e) {
       pushNotification({

--- a/frontend/src/views/sql-editor/EditorPanel/ResultPanel/DatabaseQueryContext.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/ResultPanel/DatabaseQueryContext.vue
@@ -45,14 +45,14 @@ import { useCurrentTimestamp } from "@/composables/useCurrentTimestamp";
 import { useExecuteSQL } from "@/composables/useExecuteSQL";
 import { useSQLEditorTabStore } from "@/store";
 import type {
-  ComposedDatabase,
   SQLEditorDatabaseQueryContext,
   SQLEditorQueryParams,
 } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { ResultViewV1 } from "../../EditorCommon/";
 
 const props = defineProps<{
-  database: ComposedDatabase;
+  database: Database;
   context: SQLEditorDatabaseQueryContext;
 }>();
 

--- a/frontend/src/views/sql-editor/EditorPanel/ResultPanel/ResultPanel.vue
+++ b/frontend/src/views/sql-editor/EditorPanel/ResultPanel/ResultPanel.vue
@@ -96,12 +96,14 @@ import { computed, nextTick, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { BBAttention, BBSpin } from "@/bbkit";
 import { useSQLEditorTabStore } from "@/store";
-import type { ComposedDatabase, SQLEditorDatabaseQueryContext } from "@/types";
+import type { SQLEditorDatabaseQueryContext } from "@/types";
 import { getDataSourceTypeI18n } from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { getInstanceResource } from "@/utils";
 import BatchQuerySelect from "./BatchQuerySelect.vue";
 import DatabaseQueryContext from "./DatabaseQueryContext.vue";
 
-const selectedDatabase = ref<ComposedDatabase>();
+const selectedDatabase = ref<Database>();
 const tabStore = useSQLEditorTabStore();
 const selectedTab = ref<string>();
 const { t } = useI18n();
@@ -243,12 +245,14 @@ const tabName = (context: SQLEditorDatabaseQueryContext) => {
 
 // Cache data sources for better performance
 const dataSourcesMap = computed(() => {
-  if (!selectedDatabase.value?.instanceResource.dataSources) {
+  if (!selectedDatabase.value) {
     return new Map();
   }
-  return new Map(
-    selectedDatabase.value.instanceResource.dataSources.map((ds) => [ds.id, ds])
-  );
+  const instance = getInstanceResource(selectedDatabase.value);
+  if (!instance.dataSources) {
+    return new Map();
+  }
+  return new Map(instance.dataSources.map((ds) => [ds.id, ds]));
 });
 
 const dataSourceInContext = (context: SQLEditorDatabaseQueryContext) => {

--- a/frontend/src/views/sql-editor/SQLEditorHomePage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorHomePage.vue
@@ -76,7 +76,10 @@ import {
   useSQLEditorStore,
   useSQLEditorTabStore,
 } from "@/store";
-import { extractProjectResourceName } from "@/utils";
+import {
+  extractDatabaseResourceName,
+  extractProjectResourceName,
+} from "@/utils";
 import AsidePanel from "./AsidePanel";
 import ConnectionPanel from "./ConnectionPanel";
 import { useSQLEditorContext } from "./context";
@@ -124,9 +127,10 @@ useEmitteryEventListener(
         exampleSQL.push(`${table}`);
       }
     }
+    const { databaseName: dbName } = extractDatabaseResourceName(database.name);
     const query = {
       template: "bb.issue.database.update",
-      name: `[${database.databaseName}] Edit schema`,
+      name: `[${dbName}] Edit schema`,
       databaseList: database.name,
       sql: exampleSQL.join(" "),
     };

--- a/frontend/src/views/sql-editor/TabList/TabItem/AdminLabel.vue
+++ b/frontend/src/views/sql-editor/TabList/TabItem/AdminLabel.vue
@@ -2,7 +2,7 @@
   <label class="flex items-center text-sm h-5 ml-0.5 whitespace-nowrap">
     <template v-if="!hideEnvironment">
       <EnvironmentV1Name
-        :environment="database.effectiveEnvironmentEntity"
+        :environment="environment"
         :link="false"
       />
       <ChevronRightIcon class="shrink-0 h-4 w-4 opacity-70" />
@@ -12,7 +12,7 @@
       <ChevronRightIcon class="shrink-0 h-4 w-4 opacity-70" />
     </template>
     <template v-if="isValidDatabaseName(database.name)">
-      <span>{{ database.databaseName }}</span>
+      <span>{{ databaseName }}</span>
     </template>
   </label>
 </template>
@@ -28,6 +28,11 @@ import {
   type SQLEditorTab,
   UNKNOWN_ID,
 } from "@/types";
+import {
+  extractDatabaseResourceName,
+  getDatabaseEnvironment,
+  getInstanceResource,
+} from "@/utils";
 
 const props = defineProps<{
   tab: SQLEditorTab;
@@ -40,10 +45,18 @@ const { database } = useDatabaseV1ByName(
 );
 
 const instance = computed(() => {
-  return database.value.instanceResource;
+  return getInstanceResource(database.value);
+});
+
+const environment = computed(() => {
+  return getDatabaseEnvironment(database.value);
+});
+
+const databaseName = computed(() => {
+  return extractDatabaseResourceName(database.value.name).databaseName;
 });
 
 const hideEnvironment = computed(() => {
-  return database.value.effectiveEnvironmentEntity?.id === String(UNKNOWN_ID);
+  return environment.value?.id === String(UNKNOWN_ID);
 });
 </script>

--- a/frontend/src/views/sql-editor/TabList/TabItem/TabItem.vue
+++ b/frontend/src/views/sql-editor/TabList/TabItem/TabItem.vue
@@ -36,7 +36,11 @@
 import { computed, reactive } from "vue";
 import { useSQLEditorTabStore } from "@/store";
 import { type SQLEditorTab, UNKNOWN_ID } from "@/types";
-import { getConnectionForSQLEditorTab, hexToRgb } from "@/utils";
+import {
+  getConnectionForSQLEditorTab,
+  getDatabaseEnvironment,
+  hexToRgb,
+} from "@/utils";
 import AdminLabel from "./AdminLabel.vue";
 import Label from "./Label.vue";
 import Prefix from "./Prefix.vue";
@@ -66,9 +70,12 @@ const isCurrentTab = computed(() => props.tab.id === tabStore.currentTabId);
 
 const environment = computed(() => {
   const { database } = getConnectionForSQLEditorTab(props.tab);
-  const environment = database?.effectiveEnvironmentEntity;
+  if (!database) {
+    return undefined;
+  }
+  const environment = getDatabaseEnvironment(database);
   if (environment?.id === String(UNKNOWN_ID)) {
-    return;
+    return undefined;
   }
   return environment;
 });


### PR DESCRIPTION
Part of BYT-8300. Remove the ComposedDatabase interface and use the base Database proto type directly. This follows the pattern established in the ComposedIssue removal (PR #19039).

Changes:
- Add helper functions to frontend/src/utils/v1/database.ts:
  - getInstanceResource() - returns InstanceResource with fallback
  - getDatabaseEngine() - returns Engine from instance resource
  - getDatabaseProject() - returns Project from store (sync)
  - getDatabaseEnvironment() - returns Environment from store
- Update unknownDatabase() to return Database instead of ComposedDatabase
- Simplify batchComposeDatabase() to only ensure instanceResource fallback
- Update ~150 files to use Database type and helper functions
- Remove ComposedDatabase interface