### PR TITLE
fix(frontend): enable bulk skip for failed and canceled tasks

### DIFF
--- a/frontend/src/components/RolloutV1/components/StageContentView.vue
+++ b/frontend/src/components/RolloutV1/components/StageContentView.vue
@@ -85,6 +85,7 @@ import { PlayIcon, PlusIcon } from "lucide-vue-next";
 import { NButton, NPopconfirm } from "naive-ui";
 import { computed, ref } from "vue";
 import { usePlanContextWithRollout } from "@/components/Plan/logic";
+import { RUNNABLE_TASK_STATUSES } from "@/components/RolloutV1/constants/task";
 import type { Rollout, Stage } from "@/types/proto-es/v1/rollout_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import StageContentSidebar from "./StageContentSidebar.vue";
@@ -114,13 +115,8 @@ const canRunStage = computed(() => {
   if (!props.selectedStage || !props.isStageCreated(props.selectedStage)) {
     return false;
   }
-  // Can run if there are NOT_STARTED, FAILED, or CANCELED tasks
-  // PENDING tasks cannot be run (only canceled)
-  return props.selectedStage.tasks.some(
-    (task) =>
-      task.status === Task_Status.NOT_STARTED ||
-      task.status === Task_Status.FAILED ||
-      task.status === Task_Status.CANCELED
+  return props.selectedStage.tasks.some((task) =>
+    RUNNABLE_TASK_STATUSES.includes(task.status)
   );
 });
 

--- a/frontend/src/components/RolloutV1/components/TaskRolloutActionPanel.vue
+++ b/frontend/src/components/RolloutV1/components/TaskRolloutActionPanel.vue
@@ -188,6 +188,10 @@ import { useI18n } from "vue-i18n";
 import { usePlanContextWithRollout } from "@/components/Plan/logic";
 import { projectOfPlan } from "@/components/Plan/logic/utils";
 import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";
+import {
+  CANCELABLE_TASK_STATUSES,
+  RUNNABLE_TASK_STATUSES,
+} from "@/components/RolloutV1/constants/task";
 import { EnvironmentV1Name } from "@/components/v2";
 import { trackPriorBackupOnTaskRun } from "@/composables/usePriorBackupTelemetry";
 import { rolloutServiceClientConnect } from "@/connect";
@@ -208,7 +212,6 @@ import {
   BatchRunTasksRequestSchema,
   BatchSkipTasksRequestSchema,
   ListTaskRunsRequestSchema,
-  Task_Status,
   Task_Type,
   TaskRun_Status,
 } from "@/types/proto-es/v1/rollout_service_pb";
@@ -246,13 +249,10 @@ const runTimeInMS = ref<number | undefined>(undefined);
 const canRolloutPermission = ref(true);
 
 // Task status filters
-const isRunnable = (task: Task) =>
-  task.status === Task_Status.NOT_STARTED ||
-  task.status === Task_Status.FAILED ||
-  task.status === Task_Status.CANCELED;
+const isRunnable = (task: Task) => RUNNABLE_TASK_STATUSES.includes(task.status);
 
 const isCancellable = (task: Task) =>
-  task.status === Task_Status.PENDING || task.status === Task_Status.RUNNING;
+  CANCELABLE_TASK_STATUSES.includes(task.status);
 
 // Rollout type detection
 const allRolloutTasks = computed(() =>

--- a/frontend/src/components/RolloutV1/components/TaskStatusActions.vue
+++ b/frontend/src/components/RolloutV1/components/TaskStatusActions.vue
@@ -39,6 +39,10 @@ import { NButton, NDropdown } from "naive-ui";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { usePlanContextWithRollout } from "@/components/Plan/logic";
+import {
+  CANCELABLE_TASK_STATUSES,
+  RUNNABLE_TASK_STATUSES,
+} from "@/components/RolloutV1/constants/task";
 import type {
   Rollout,
   Stage,
@@ -153,17 +157,9 @@ const dropdownActions = computed((): TaskStatusAction[] => {
     return [];
   }
 
-  if (
-    [
-      Task_Status.NOT_STARTED,
-      Task_Status.FAILED,
-      Task_Status.CANCELED,
-    ].includes(props.task.status)
-  ) {
+  if (RUNNABLE_TASK_STATUSES.includes(props.task.status)) {
     return ["SKIP"];
-  } else if (
-    [Task_Status.PENDING, Task_Status.RUNNING].includes(props.task.status)
-  ) {
+  } else if (CANCELABLE_TASK_STATUSES.includes(props.task.status)) {
     return ["CANCEL"];
   } else {
     return [];

--- a/frontend/src/components/RolloutV1/components/TaskToolbar.vue
+++ b/frontend/src/components/RolloutV1/components/TaskToolbar.vue
@@ -104,11 +104,14 @@ import { NButton, NCheckbox, NTooltip } from "naive-ui";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { usePlanContext } from "@/components/Plan/logic";
+import {
+  CANCELABLE_TASK_STATUSES,
+  RUNNABLE_TASK_STATUSES,
+} from "@/components/RolloutV1/constants/task";
 import { useCurrentUserV1 } from "@/store";
 import { userNamePrefix } from "@/store/modules/v1/common";
 import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
 import type { Stage, Task } from "@/types/proto-es/v1/rollout_service_pb";
-import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import TaskRolloutActionPanel from "./TaskRolloutActionPanel.vue";
 import { canRolloutTasks } from "./taskPermissions";
 import type { TaskAction } from "./types";
@@ -175,24 +178,20 @@ const canPerformTaskActions = computed(() => {
 });
 
 const hasRunnableTasks = computed(() => {
-  return props.selectedTasks.some(
-    (task) =>
-      task.status === Task_Status.NOT_STARTED ||
-      task.status === Task_Status.FAILED ||
-      task.status === Task_Status.CANCELED
+  return props.selectedTasks.some((task) =>
+    RUNNABLE_TASK_STATUSES.includes(task.status)
   );
 });
 
 const hasSkippableTasks = computed(() => {
-  return props.selectedTasks.some(
-    (task) => task.status === Task_Status.NOT_STARTED
+  return props.selectedTasks.some((task) =>
+    RUNNABLE_TASK_STATUSES.includes(task.status)
   );
 });
 
 const hasCancellableTasks = computed(() => {
-  return props.selectedTasks.some(
-    (task) =>
-      task.status === Task_Status.PENDING || task.status === Task_Status.RUNNING
+  return props.selectedTasks.some((task) =>
+    CANCELABLE_TASK_STATUSES.includes(task.status)
   );
 });
 

--- a/frontend/src/components/RolloutV1/components/composables/useTaskActions.ts
+++ b/frontend/src/components/RolloutV1/components/composables/useTaskActions.ts
@@ -1,7 +1,10 @@
 import type { ComputedRef, Ref } from "vue";
 import { computed, ref, watch } from "vue";
+import {
+  CANCELABLE_TASK_STATUSES,
+  RUNNABLE_TASK_STATUSES,
+} from "@/components/RolloutV1/constants/task";
 import type { Stage, Task } from "@/types/proto-es/v1/rollout_service_pb";
-import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { canRolloutTasks } from "../taskPermissions";
 
 export type TaskAction = "RUN" | "SKIP" | "CANCEL";
@@ -26,16 +29,6 @@ export interface UseTaskActionsReturn {
   closeActionPanel: () => void;
 }
 
-// Statuses that allow run/skip actions
-const RUNNABLE_STATUSES = [
-  Task_Status.NOT_STARTED,
-  Task_Status.CANCELED,
-  Task_Status.FAILED,
-];
-
-// Statuses that allow cancel action
-const CANCELABLE_STATUSES = [Task_Status.PENDING, Task_Status.RUNNING];
-
 export const useTaskActions = (
   task: () => Task,
   stage: () => Stage | undefined
@@ -59,17 +52,20 @@ export const useTaskActions = (
 
   const canRun = computed(
     () =>
-      canPerformActions.value && RUNNABLE_STATUSES.includes(taskStatus.value)
+      canPerformActions.value &&
+      RUNNABLE_TASK_STATUSES.includes(taskStatus.value)
   );
 
   const canSkip = computed(
     () =>
-      canPerformActions.value && RUNNABLE_STATUSES.includes(taskStatus.value)
+      canPerformActions.value &&
+      RUNNABLE_TASK_STATUSES.includes(taskStatus.value)
   );
 
   const canCancel = computed(
     () =>
-      canPerformActions.value && CANCELABLE_STATUSES.includes(taskStatus.value)
+      canPerformActions.value &&
+      CANCELABLE_TASK_STATUSES.includes(taskStatus.value)
   );
 
   const hasActions = computed(

--- a/frontend/src/components/RolloutV1/constants/task.ts
+++ b/frontend/src/components/RolloutV1/constants/task.ts
@@ -9,3 +9,22 @@ export const TASK_STATUS_FILTERS: Task_Status[] = [
   Task_Status.DONE,
   Task_Status.SKIPPED,
 ];
+
+/**
+ * Task statuses that allow run/skip actions.
+ * Tasks in these states can be started, restarted, or skipped.
+ */
+export const RUNNABLE_TASK_STATUSES: Task_Status[] = [
+  Task_Status.NOT_STARTED,
+  Task_Status.CANCELED,
+  Task_Status.FAILED,
+];
+
+/**
+ * Task statuses that allow cancel action.
+ * Tasks in these states are currently executing or queued.
+ */
+export const CANCELABLE_TASK_STATUSES: Task_Status[] = [
+  Task_Status.PENDING,
+  Task_Status.RUNNING,
+];


### PR DESCRIPTION
The bulk skip button was disabled for failed/canceled tasks because hasSkippableTasks only checked for NOT_STARTED status, while individual task skip allowed NOT_STARTED, FAILED, and CANCELED.

Centralized task status constants (RUNNABLE_TASK_STATUSES and CANCELABLE_TASK_STATUSES) in constants/task.ts and updated all components to use them, ensuring consistent behavior between bulk and individual task actions.