### PR TITLE
refactor(frontend): consolidate sentinel types and plan title generation

### DIFF
--- a/frontend/src/components/AuditLog/AuditLogDataTable.vue
+++ b/frontend/src/components/AuditLog/AuditLogDataTable.vue
@@ -33,7 +33,7 @@ import {
   projectNamePrefix,
   rolloutNamePrefix,
 } from "@/store/modules/v1/common";
-import { emptyProject, getDateForPbTimestampProtoEs } from "@/types";
+import { getDateForPbTimestampProtoEs, unknownProject } from "@/types";
 import { StatusSchema } from "@/types/proto-es/google/rpc/status_pb";
 import type { AuditLog } from "@/types/proto-es/v1/audit_log_service_pb";
 import {
@@ -113,7 +113,7 @@ const columnList = computed((): AuditDataTableColumn[] => {
             return <span>-</span>;
           }
           const mockProject = {
-            ...emptyProject(),
+            ...unknownProject(),
             name: `${projectNamePrefix}${projectResourceId}`,
             title: projectResourceId,
           };

--- a/frontend/src/components/DataExportPrepForm/DataExportPrepForm.vue
+++ b/frontend/src/components/DataExportPrepForm/DataExportPrepForm.vue
@@ -47,7 +47,7 @@ import DatabaseAndGroupSelector, {
 } from "@/components/DatabaseAndGroupSelector/";
 import { PROJECT_V1_ROUTE_PLAN_DETAIL } from "@/router/dashboard/projectV1";
 import { useProjectByName } from "@/store";
-import { extractProjectResourceName, generateIssueTitle } from "@/utils";
+import { extractProjectResourceName, generatePlanTitle } from "@/utils";
 import { DrawerContent } from "../v2";
 
 type LocalState = {
@@ -80,10 +80,10 @@ const navigateToIssuePage = async () => {
     return;
   }
 
-  const issueType = "bb.issue.database.data.export";
+  const template = "bb.plan.export-data";
   const query: LocationQueryRaw = {
-    template: issueType,
-    name: generateIssueTitle(issueType),
+    template,
+    name: generatePlanTitle(template),
   };
 
   if (state.targetSelectState.changeSource === "DATABASE") {

--- a/frontend/src/components/GrantRequestPanel/GrantRequestPanel.vue
+++ b/frontend/src/components/GrantRequestPanel/GrantRequestPanel.vue
@@ -70,7 +70,7 @@ import {
   displayRoleTitle,
   extractIssueUID,
   extractProjectResourceName,
-  generateIssueTitle,
+  formatIssueTitle,
 } from "@/utils";
 
 const props = withDefaults(
@@ -149,16 +149,15 @@ const doCreateIssue = async () => {
   const newIssue = create(IssueSchema, {
     title: project.value.enforceIssueTitle
       ? `[${t("issue.title.request-role")}] ${formRef.value?.reason}`
-      : generateIssueTitle(
-          "bb.issue.grant.request",
+      : formatIssueTitle(
+          t("issue.title.request-specific-role", {
+            role: displayRoleTitle(binding.role),
+          }),
           uniq(
             databaseResources?.map(
               (databaseResource) => databaseResource.databaseFullName
             )
-          ),
-          t("issue.title.request-specific-role", {
-            role: displayRoleTitle(binding.role),
-          })
+          )
         ),
     description: binding.condition?.description,
     type: NewIssue_Type.GRANT_REQUEST,

--- a/frontend/src/components/InstanceForm/common.ts
+++ b/frontend/src/components/InstanceForm/common.ts
@@ -1,7 +1,7 @@
 import { cloneDeep, first } from "lodash-es";
 import { t } from "@/plugins/i18n";
 import { useActuatorV1Store, useSubscriptionV1Store } from "@/store";
-import { emptyDataSource, UNKNOWN_INSTANCE_NAME } from "@/types";
+import { UNKNOWN_INSTANCE_NAME, unknownDataSource } from "@/types";
 import { Engine, State } from "@/types/proto-es/v1/common_pb";
 import type {
   DataSource,
@@ -86,7 +86,7 @@ export const extractBasicInfo = (instance: Instance | undefined): BasicInfo => {
 
 export const wrapEditDataSource = (ds: DataSource | undefined) => {
   return {
-    ...cloneDeep(ds ?? emptyDataSource()),
+    ...cloneDeep(ds ?? unknownDataSource()),
     pendingCreate: ds === undefined,
     updatedPassword: "",
     updatedMasterPassword: "",

--- a/frontend/src/components/Plan/logic/initialize/index.ts
+++ b/frontend/src/components/Plan/logic/initialize/index.ts
@@ -7,7 +7,7 @@ import {
   rolloutServiceClientConnect,
 } from "@/connect";
 import { projectNamePrefix, usePlanStore } from "@/store";
-import { EMPTY_ID, UNKNOWN_ID } from "@/types";
+import { UNKNOWN_ID } from "@/types";
 import {
   GetIssueRequestSchema,
   Issue_Type,
@@ -17,7 +17,7 @@ import type { Plan, PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import { GetRolloutRequestSchema } from "@/types/proto-es/v1/rollout_service_pb";
 import type { Rollout, TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
 import { getRolloutFromPlan, extractPlanNameFromRolloutName } from "@/utils";
-import { emptyPlan } from "@/types/v1/issue/plan";
+import { unknownPlan } from "@/types/v1/issue/plan";
 import { createPlanSkeleton } from "./create";
 import {
   WORKSPACE_ROUTE_403,
@@ -43,7 +43,7 @@ export function useInitializePlan(
     // If planId is provided, use it directly
     if (unref(planId)) {
       const id = unref(planId)!;
-      if (id.toLowerCase() === "create") return String(EMPTY_ID);
+      if (id.toLowerCase() === "create") return "create";
       const uid = Number(id);
       if (uid > 0) return String(uid);
       return String(UNKNOWN_ID);
@@ -51,14 +51,14 @@ export function useInitializePlan(
     // Otherwise, if legacyRolloutId is provided, we'll fetch the plan from the rollout
     if (unref(legacyRolloutId)) {
       const id = unref(legacyRolloutId)!;
-      if (id.toLowerCase() === "create") return String(EMPTY_ID);
+      if (id.toLowerCase() === "create") return "create";
       // For rollout-based initialization, return a special marker
       return `rollout:${id}`;
     }
     // Otherwise, if issueId is provided, we'll fetch the plan from the issue
     if (unref(issueId)) {
       const id = unref(issueId)!;
-      if (id.toLowerCase() === "create") return String(EMPTY_ID);
+      if (id.toLowerCase() === "create") return "create";
       // For issue-based initialization, return a special marker
       return `issue:${id}`;
     }
@@ -70,7 +70,7 @@ export function useInitializePlan(
   const planStore = usePlanStore();
   const isInitializing = ref(true);
 
-  const plan = ref<Plan>(emptyPlan());
+  const plan = ref<Plan>(unknownPlan());
   const planCheckRuns = ref<PlanCheckRun[]>([]);
   const issue = ref<Issue | undefined>(undefined);
   const rollout = ref<Rollout | undefined>(undefined);
@@ -81,7 +81,7 @@ export function useInitializePlan(
     let issueResult: Issue | undefined = undefined;
     let rolloutResult: Rollout | undefined = undefined;
 
-    if (uid === String(EMPTY_ID)) {
+    if (uid === "create") {
       // Creating a new plan
       planResult = await createPlanSkeleton(
         route,
@@ -142,7 +142,7 @@ export function useInitializePlan(
           );
         }
         return {
-          plan: emptyPlan(),
+          plan: unknownPlan(),
           issue: issueResult,
           rollout: undefined,
           url,

--- a/frontend/src/components/Plan/logic/issue.ts
+++ b/frontend/src/components/Plan/logic/issue.ts
@@ -11,11 +11,11 @@ import {
   extractDatabaseGroupName,
   extractDatabaseResourceName,
   extractProjectResourceName,
-  generateIssueTitle,
+  generatePlanTitle,
 } from "@/utils";
 
 export const preCreateIssue = async (project: string, targets: string[]) => {
-  const type = "bb.issue.database.update";
+  const type = "bb.plan.change-database";
   const databaseStore = useDatabaseV1Store();
   const dbGroupStore = useDBGroupStore();
   const projectStore = useProjectV1Store();
@@ -48,7 +48,7 @@ export const preCreateIssue = async (project: string, targets: string[]) => {
     query.databaseGroupName = databaseGroupName;
     // Only set title from generated if enforceIssueTitle is false.
     if (!projectEntity.enforceIssueTitle) {
-      query.name = generateIssueTitle(type, [
+      query.name = generatePlanTitle(type, [
         extractDatabaseGroupName(databaseGroupName),
       ]);
     }
@@ -56,7 +56,7 @@ export const preCreateIssue = async (project: string, targets: string[]) => {
     query.databaseList = targets.join(",");
     // Only set title from generated if enforceIssueTitle is false.
     if (!projectEntity.enforceIssueTitle) {
-      query.name = generateIssueTitle(
+      query.name = generatePlanTitle(
         type,
         targets.map((db) => {
           const { databaseName } = extractDatabaseResourceName(db);

--- a/frontend/src/components/Project/ProjectCreatePanel.vue
+++ b/frontend/src/components/Project/ProjectCreatePanel.vue
@@ -76,7 +76,7 @@ import ResourceIdField from "@/components/v2/Form/ResourceIdField.vue";
 import { pushNotification, useUIStateStore } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { useProjectV1Store } from "@/store/modules/v1/project";
-import { emptyProject } from "@/types";
+import { unknownProject } from "@/types";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
@@ -100,7 +100,7 @@ const projectV1Store = useProjectV1Store();
 
 const state = reactive<LocalState>({
   project: {
-    ...emptyProject(),
+    ...unknownProject(),
     title: "New Project",
   },
   resourceId: "",

--- a/frontend/src/components/SyncDatabaseSchemaV1/index.vue
+++ b/frontend/src/components/SyncDatabaseSchemaV1/index.vue
@@ -99,7 +99,7 @@ import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import {
   extractDatabaseResourceName,
   extractProjectResourceName,
-  generateIssueTitle,
+  generatePlanTitle,
   getInstanceResource,
 } from "@/utils";
 import {
@@ -333,7 +333,7 @@ const tryFinishSetup = async () => {
 
   const targetDatabaseList = targetDatabaseViewRef.value.targetDatabaseList;
   const query: LocationQueryRaw = {
-    template: "bb.issue.database.update",
+    template: "bb.plan.change-database",
     mode: "normal",
   };
   const sqlMap: Record<string, string> = {};
@@ -348,8 +348,8 @@ const tryFinishSetup = async () => {
   const sqlMapStorageKey = `bb.issues.sql-map.${uuidv4()}`;
   useStorageStore().put(sqlMapStorageKey, sqlMap);
   query.sqlMapStorageKey = sqlMapStorageKey;
-  query.name = generateIssueTitle(
-    "bb.issue.database.update",
+  query.name = generatePlanTitle(
+    "bb.plan.change-database",
     targetDatabaseList.map(
       (db) => extractDatabaseResourceName(db.name).databaseName
     )

--- a/frontend/src/components/User/Settings/CreateUserDrawer.vue
+++ b/frontend/src/components/User/Settings/CreateUserDrawer.vue
@@ -348,7 +348,7 @@ import {
   useUserStore,
   useWorkspaceV1Store,
 } from "@/store";
-import { emptyUser } from "@/types";
+import { unknownUser } from "@/types";
 import { PresetRoleType } from "@/types/iam";
 import type { User } from "@/types/proto-es/v1/user_service_pb";
 import {
@@ -393,7 +393,7 @@ const userPasswordRef = ref<InstanceType<typeof UserPassword>>();
 
 const state = reactive<LocalState>({
   isRequesting: false,
-  user: emptyUser(),
+  user: unknownUser(),
   roles: [PresetRoleType.WORKSPACE_MEMBER],
   passwordConfirm: "",
   wif: {

--- a/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseOperations.vue
+++ b/frontend/src/components/v2/Model/DatabaseV1Table/DatabaseOperations.vue
@@ -148,7 +148,7 @@ import {
 import {
   extractDatabaseResourceName,
   extractProjectResourceName,
-  generateIssueTitle,
+  generatePlanTitle,
   PERMISSIONS_FOR_DATABASE_CHANGE_ISSUE,
   PERMISSIONS_FOR_DATABASE_CREATE_ISSUE,
   PERMISSIONS_FOR_DATABASE_EXPORT_ISSUE,
@@ -256,7 +256,7 @@ const operations = computed(() => {
 });
 
 const generateMultiDb = async (
-  type: "bb.issue.database.update" | "bb.issue.database.data.export"
+  type: "bb.plan.change-database" | "bb.plan.export-data"
 ) => {
   // Fetch project to check enforce_issue_title setting
   const project = await projectStore.getOrFetchProjectByName(
@@ -269,7 +269,7 @@ const generateMultiDb = async (
   };
   // Only set title from generated if enforceIssueTitle is false.
   if (!project.enforceIssueTitle) {
-    query.name = generateIssueTitle(
+    query.name = generatePlanTitle(
       type,
       props.databases.map(
         (db) => extractDatabaseResourceName(db.name).databaseName
@@ -277,7 +277,7 @@ const generateMultiDb = async (
     );
   }
 
-  const isDataExport = type === "bb.issue.database.data.export";
+  const isDataExport = type === "bb.plan.export-data";
   router.push({
     name: isDataExport
       ? PROJECT_V1_ROUTE_PLAN_DETAIL
@@ -412,7 +412,7 @@ const actions = computed((): DatabaseAction[] => {
               !selectedProjectName.value ||
               props.databases.length < 1 ||
               selectedProjectNames.value.has(DEFAULT_PROJECT_NAME),
-            click: () => generateMultiDb("bb.issue.database.data.export"),
+            click: () => generateMultiDb("bb.plan.export-data"),
             requiredPermissions: [...PERMISSIONS_FOR_DATABASE_EXPORT_ISSUE],
           });
         }

--- a/frontend/src/store/modules/v1/databaseCatalog.ts
+++ b/frontend/src/store/modules/v1/databaseCatalog.ts
@@ -6,7 +6,7 @@ import { databaseCatalogServiceClientConnect } from "@/connect";
 import { silentContextKey } from "@/connect/context-key";
 import { useCache } from "@/store/cache";
 import type { MaybeRef } from "@/types";
-import { EMPTY_ID, UNKNOWN_ID, UNKNOWN_INSTANCE_NAME } from "@/types";
+import { UNKNOWN_ID, UNKNOWN_INSTANCE_NAME } from "@/types";
 import type { DatabaseCatalog } from "@/types/proto-es/v1/database_catalog_service_pb";
 import {
   ColumnCatalogSchema,
@@ -51,7 +51,7 @@ export const useDatabaseCatalogV1Store = defineStore(
       const { databaseName } = extractDatabaseResourceName(database);
       if (
         databaseName === String(UNKNOWN_ID) ||
-        databaseName === String(EMPTY_ID)
+        databaseName === String(UNKNOWN_ID)
       ) {
         return create(DatabaseCatalogSchema, {
           name: ensureDatabaseCatalogResourceName(
@@ -102,7 +102,7 @@ export const useDatabaseCatalogV1Store = defineStore(
       const { databaseName } = extractDatabaseResourceName(database);
       if (
         databaseName === String(UNKNOWN_ID) ||
-        databaseName === String(EMPTY_ID)
+        databaseName === String(UNKNOWN_ID)
       ) {
         return create(DatabaseCatalogSchema, {
           name: ensureDatabaseCatalogResourceName(
@@ -190,7 +190,7 @@ export const useDatabaseCatalog = (
     const { databaseName } = extractDatabaseResourceName(unref(database));
     if (
       databaseName === String(UNKNOWN_ID) ||
-      databaseName === String(EMPTY_ID)
+      databaseName === String(UNKNOWN_ID)
     ) {
       return;
     }

--- a/frontend/src/store/modules/v1/dbSchema.ts
+++ b/frontend/src/store/modules/v1/dbSchema.ts
@@ -7,7 +7,7 @@ import { silentContextKey } from "@/connect/context-key";
 // Removed conversion imports as part of Bold Migration Strategy
 import { useCache } from "@/store/cache";
 import type { MaybeRef } from "@/types";
-import { EMPTY_ID, UNKNOWN_ID, UNKNOWN_INSTANCE_NAME } from "@/types";
+import { UNKNOWN_ID, UNKNOWN_INSTANCE_NAME } from "@/types";
 import type { DatabaseMetadata } from "@/types/proto-es/v1/database_service_pb";
 import {
   DatabaseMetadataSchema,
@@ -128,7 +128,7 @@ export const useDBSchemaV1Store = defineStore("dbSchema_v1", () => {
     const { databaseName } = extractDatabaseResourceName(database);
     if (
       databaseName === String(UNKNOWN_ID) ||
-      databaseName === String(EMPTY_ID)
+      databaseName === String(UNKNOWN_ID)
     ) {
       return create(DatabaseMetadataSchema, {
         name: ensureDatabaseMetadataResourceName(
@@ -243,7 +243,7 @@ export const useDBSchemaV1Store = defineStore("dbSchema_v1", () => {
     const { databaseName } = extractDatabaseResourceName(database);
     if (
       databaseName === String(UNKNOWN_ID) ||
-      databaseName === String(EMPTY_ID)
+      databaseName === String(UNKNOWN_ID)
     ) {
       return create(TableMetadataSchema, {
         name: table,
@@ -424,7 +424,7 @@ export const useMetadata = (
     const { databaseName } = extractDatabaseResourceName(unref(database));
     if (
       databaseName === String(UNKNOWN_ID) ||
-      databaseName === String(EMPTY_ID)
+      databaseName === String(UNKNOWN_ID)
     ) {
       return;
     }

--- a/frontend/src/store/modules/v1/project.ts
+++ b/frontend/src/store/modules/v1/project.ts
@@ -10,8 +10,6 @@ import type { MaybeRef, ResourceId } from "@/types";
 import {
   DEFAULT_PROJECT_NAME,
   defaultProject,
-  EMPTY_PROJECT_NAME,
-  emptyProject,
   isValidProjectName,
   UNKNOWN_PROJECT_NAME,
   unknownProject,
@@ -101,7 +99,6 @@ export const useProjectV1Store = defineStore("project_v1", () => {
     );
   };
   const getProjectByName = (name: string) => {
-    if (name === EMPTY_PROJECT_NAME) return emptyProject();
     if (name === UNKNOWN_PROJECT_NAME) return unknownProject();
     if (name === DEFAULT_PROJECT_NAME) return defaultProject();
     return projectMapByName.get(name) ?? unknownProject();

--- a/frontend/src/types/const.ts
+++ b/frontend/src/types/const.ts
@@ -1,7 +1,3 @@
-// unknown represents an anomaly.
-// Returns as function to avoid caller accidentally mutate it.
-// UNKNOWN_ID means an anomaly, it expects a resource which is missing (e.g. Keyed lookup missing).
+// UNKNOWN_ID is used for placeholder/sentinel values when a resource is missing or not yet selected.
+// Returns as function to avoid caller accidentally mutating it.
 export const UNKNOWN_ID = -1;
-// EMPTY_ID means an expected behavior, it expects no resource (e.g. contains an empty value, using this technic enables
-// us to declare variable as required, which leads to cleaner code)
-export const EMPTY_ID = 0;

--- a/frontend/src/types/dbGroup.ts
+++ b/frontend/src/types/dbGroup.ts
@@ -17,6 +17,5 @@ export const unknownDatabaseGroup = (): DatabaseGroup => {
   const projectEntity = unknownProject();
   return create(DatabaseGroupSchema, {
     name: `${projectEntity.name}/databaseGroups/${UNKNOWN_ID}`,
-    title: "<<Unknown database group>>",
   });
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -10,7 +10,6 @@ export * from "./error";
 export * from "./help";
 export * from "./iam";
 export * from "./id";
-export * from "./issue";
 export * from "./member";
 export * from "./misc";
 export * from "./notification";

--- a/frontend/src/types/issue.ts
+++ b/frontend/src/types/issue.ts
@@ -1,9 +1,0 @@
-type IssueTypeDatabase =
-  | "bb.issue.database.create"
-  | "bb.issue.database.grant"
-  | "bb.issue.database.update"
-  | "bb.issue.database.data.export";
-
-type IssueTypeGrantRequest = "bb.issue.grant.request";
-
-export type IssueType = IssueTypeDatabase | IssueTypeGrantRequest;

--- a/frontend/src/types/rollout.ts
+++ b/frontend/src/types/rollout.ts
@@ -1,18 +1,11 @@
 import { create as createProto } from "@bufbuild/protobuf";
 import { getProjectNamePlanIdFromRolloutName } from "@/store/modules/v1/common";
-import { EMPTY_ID, UNKNOWN_ID } from "./const";
+import { UNKNOWN_ID } from "./const";
 import type { Rollout } from "./proto-es/v1/rollout_service_pb";
 import { RolloutSchema } from "./proto-es/v1/rollout_service_pb";
-import { EMPTY_PROJECT_NAME, UNKNOWN_PROJECT_NAME } from "./v1/project";
+import { UNKNOWN_PROJECT_NAME } from "./v1/project";
 
-export const EMPTY_ROLLOUT_NAME = `${EMPTY_PROJECT_NAME}/plans/${EMPTY_ID}/rollout`;
 export const UNKNOWN_ROLLOUT_NAME = `${UNKNOWN_PROJECT_NAME}/plans/${UNKNOWN_ID}/rollout`;
-
-export const emptyRollout = (): Rollout => {
-  return createProto(RolloutSchema, {
-    name: EMPTY_ROLLOUT_NAME,
-  });
-};
 
 export const unknownRollout = (): Rollout => {
   return createProto(RolloutSchema, {

--- a/frontend/src/types/v1/dataSource.ts
+++ b/frontend/src/types/v1/dataSource.ts
@@ -10,18 +10,11 @@ import {
 export const DATASOURCE_ADMIN_USER_NAME = "bytebase";
 export const DATASOURCE_READONLY_USER_NAME = `${DATASOURCE_ADMIN_USER_NAME}_readonly`;
 
-export const emptyDataSource = () => {
+export const unknownDataSource = () => {
   return create(DataSourceSchema, {
     type: DataSourceType.ADMIN,
     id: uuidv4(),
     authenticationType: DataSource_AuthenticationType.PASSWORD,
     username: DATASOURCE_ADMIN_USER_NAME,
   });
-};
-
-export const unknownDataSource = () => {
-  return {
-    ...emptyDataSource(),
-    title: "<<Unknown data source>>",
-  };
 };

--- a/frontend/src/types/v1/database.ts
+++ b/frontend/src/types/v1/database.ts
@@ -1,6 +1,6 @@
 import { create } from "@bufbuild/protobuf";
 import { extractDatabaseResourceName, isNullOrUndefined } from "@/utils";
-import { EMPTY_ID, UNKNOWN_ID } from "../const";
+import { UNKNOWN_ID } from "../const";
 import { State } from "../proto-es/v1/common_pb";
 import type { Database } from "../proto-es/v1/database_service_pb";
 import { DatabaseSchema$ } from "../proto-es/v1/database_service_pb";
@@ -28,7 +28,6 @@ export const isValidDatabaseName = (name: unknown): name is string => {
     !isNullOrUndefined(instanceName) &&
     !isNullOrUndefined(databaseName) &&
     instanceName !== String(UNKNOWN_ID) &&
-    instanceName !== String(EMPTY_ID) &&
     databaseName !== String(UNKNOWN_ID)
   );
 };

--- a/frontend/src/types/v1/environment.ts
+++ b/frontend/src/types/v1/environment.ts
@@ -1,12 +1,11 @@
 import { create } from "@bufbuild/protobuf";
 import { environmentNamePrefix } from "@/store";
-import { EMPTY_ID, UNKNOWN_ID } from "../const";
+import { UNKNOWN_ID } from "../const";
 import {
   type EnvironmentSetting_Environment,
   EnvironmentSetting_EnvironmentSchema,
 } from "../proto-es/v1/setting_service_pb";
 
-export const EMPTY_ENVIRONMENT_NAME = `environments/${EMPTY_ID}`;
 export const UNKNOWN_ENVIRONMENT_NAME = `environments/${UNKNOWN_ID}`;
 export const NULL_ENVIRONMENT_NAME = "environments/-";
 
@@ -19,9 +18,6 @@ export const unknownEnvironment = (): Environment => {
     ...create(EnvironmentSetting_EnvironmentSchema, {
       name: UNKNOWN_ENVIRONMENT_NAME,
       id: String(UNKNOWN_ID),
-      title: "<<Unknown environment>>",
-      tags: {},
-      color: "",
     }),
     order: 0,
   };
@@ -44,7 +40,6 @@ export const isValidEnvironmentName = (name: unknown): name is string => {
   return (
     typeof name === "string" &&
     /^environments\/.+/.test(name) &&
-    name !== EMPTY_ENVIRONMENT_NAME &&
     name !== UNKNOWN_ENVIRONMENT_NAME &&
     name !== NULL_ENVIRONMENT_NAME
   );

--- a/frontend/src/types/v1/instance.ts
+++ b/frontend/src/types/v1/instance.ts
@@ -1,5 +1,5 @@
 import { create } from "@bufbuild/protobuf";
-import { EMPTY_ID, UNKNOWN_ID } from "../const";
+import { UNKNOWN_ID } from "../const";
 import { Engine, State } from "../proto-es/v1/common_pb";
 import type {
   Instance,
@@ -10,27 +10,21 @@ import {
   InstanceSchema,
 } from "../proto-es/v1/instance_service_pb";
 
-export const EMPTY_INSTANCE_NAME = `instances/${EMPTY_ID}`;
 export const UNKNOWN_INSTANCE_NAME = `instances/${UNKNOWN_ID}`;
 
 export const unknownInstance = (): Instance => {
-  const instance = create(InstanceSchema, {
+  return create(InstanceSchema, {
     name: UNKNOWN_INSTANCE_NAME,
     state: State.ACTIVE,
-    title: "<<Unknown instance>>",
     engine: Engine.MYSQL,
   });
-  return instance;
 };
 
 export const unknownInstanceResource = (): InstanceResource => {
-  const instance = unknownInstance();
   return create(InstanceResourceSchema, {
     name: UNKNOWN_INSTANCE_NAME,
-    engine: instance.engine,
-    title: "<<Unknown instance>>",
+    engine: Engine.MYSQL,
     activation: true,
-    dataSources: [],
   });
 };
 
@@ -38,7 +32,6 @@ export const isValidInstanceName = (name: unknown): name is string => {
   return (
     typeof name === "string" &&
     name.startsWith("instances/") &&
-    name !== EMPTY_INSTANCE_NAME &&
     name !== UNKNOWN_INSTANCE_NAME
   );
 };

--- a/frontend/src/types/v1/issue/plan.ts
+++ b/frontend/src/types/v1/issue/plan.ts
@@ -1,29 +1,19 @@
 import { create as createProto } from "@bufbuild/protobuf";
-import { EMPTY_ID, UNKNOWN_ID } from "@/types/const";
+import { UNKNOWN_ID } from "@/types/const";
 import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
 import {
   Plan_SpecSchema,
   PlanSchema,
 } from "@/types/proto-es/v1/plan_service_pb";
 
-export const EMPTY_PLAN_NAME = `projects/${EMPTY_ID}/plans/${EMPTY_ID}`;
 export const UNKNOWN_PLAN_NAME = `projects/${UNKNOWN_ID}/plans/${UNKNOWN_ID}`;
-export const emptyPlan = (): Plan => {
-  return createProto(PlanSchema, {
-    name: EMPTY_PLAN_NAME,
-  });
-};
+
 export const unknownPlan = (): Plan => {
   return createProto(PlanSchema, {
     name: UNKNOWN_PLAN_NAME,
   });
 };
 
-export const emptyPlanSpec = () => {
-  return createProto(Plan_SpecSchema, {
-    id: String(EMPTY_ID),
-  });
-};
 export const unknownPlanSpec = () => {
   return createProto(Plan_SpecSchema, {
     id: String(UNKNOWN_ID),

--- a/frontend/src/types/v1/issue/rollout.ts
+++ b/frontend/src/types/v1/issue/rollout.ts
@@ -1,25 +1,15 @@
 import { create } from "@bufbuild/protobuf";
-import { EMPTY_ID, UNKNOWN_ID } from "@/types/const";
+import { UNKNOWN_ID } from "@/types/const";
 import {
   StageSchema,
   Task_Type,
   TaskSchema,
 } from "@/types/proto-es/v1/rollout_service_pb";
-import { EMPTY_ROLLOUT_NAME, UNKNOWN_ROLLOUT_NAME } from "@/types/rollout";
-import {
-  EMPTY_ENVIRONMENT_NAME,
-  UNKNOWN_ENVIRONMENT_NAME,
-} from "../environment";
+import { UNKNOWN_ROLLOUT_NAME } from "@/types/rollout";
+import { UNKNOWN_ENVIRONMENT_NAME } from "../environment";
 
-export const EMPTY_STAGE_NAME = `${EMPTY_ROLLOUT_NAME}/stages/${EMPTY_ID}`;
 export const UNKNOWN_STAGE_NAME = `${UNKNOWN_ROLLOUT_NAME}/stages/${UNKNOWN_ID}`;
 
-export const emptyStage = () => {
-  return create(StageSchema, {
-    name: EMPTY_STAGE_NAME,
-    environment: EMPTY_ENVIRONMENT_NAME,
-  });
-};
 export const unknownStage = () => {
   return create(StageSchema, {
     name: UNKNOWN_STAGE_NAME,
@@ -27,13 +17,8 @@ export const unknownStage = () => {
   });
 };
 
-export const EMPTY_TASK_NAME = `${EMPTY_STAGE_NAME}/tasks/${EMPTY_ID}`;
 export const UNKNOWN_TASK_NAME = `${UNKNOWN_STAGE_NAME}/tasks/${UNKNOWN_ID}`;
-export const emptyTask = () => {
-  return create(TaskSchema, {
-    name: EMPTY_TASK_NAME,
-  });
-};
+
 export const unknownTask = () => {
   return create(TaskSchema, {
     name: UNKNOWN_TASK_NAME,

--- a/frontend/src/types/v1/project.ts
+++ b/frontend/src/types/v1/project.ts
@@ -1,18 +1,16 @@
 import { create as createProto } from "@bufbuild/protobuf";
-import { EMPTY_ID, UNKNOWN_ID } from "../const";
+import { UNKNOWN_ID } from "../const";
 import { State } from "../proto-es/v1/common_pb";
 import type { Project } from "../proto-es/v1/project_service_pb";
 import { ProjectSchema } from "../proto-es/v1/project_service_pb";
 
 export const DEFAULT_PROJECT_UID = 1;
-export const EMPTY_PROJECT_NAME = `projects/${EMPTY_ID}`;
 export const UNKNOWN_PROJECT_NAME = `projects/${UNKNOWN_ID}`;
 export const DEFAULT_PROJECT_NAME = "projects/default";
 
-export const emptyProject = (): Project => {
+export const unknownProject = (): Project => {
   return createProto(ProjectSchema, {
-    name: EMPTY_PROJECT_NAME,
-    title: "",
+    name: UNKNOWN_PROJECT_NAME,
     state: State.ACTIVE,
     enforceIssueTitle: true,
     enforceSqlReview: true,
@@ -20,14 +18,6 @@ export const emptyProject = (): Project => {
     requirePlanCheckNoError: true,
     allowRequestRole: true,
   });
-};
-
-export const unknownProject = (): Project => {
-  return {
-    ...emptyProject(),
-    name: UNKNOWN_PROJECT_NAME,
-    title: "<<Unknown project>>",
-  };
 };
 
 export const defaultProject = (): Project => {
@@ -40,9 +30,6 @@ export const defaultProject = (): Project => {
 
 export const isValidProjectName = (name: string | undefined) => {
   return (
-    !!name &&
-    name.startsWith("projects/") &&
-    name !== EMPTY_PROJECT_NAME &&
-    name !== UNKNOWN_PROJECT_NAME
+    !!name && name.startsWith("projects/") && name !== UNKNOWN_PROJECT_NAME
   );
 };

--- a/frontend/src/types/v1/projectWebhook.ts
+++ b/frontend/src/types/v1/projectWebhook.ts
@@ -6,7 +6,7 @@ import {
   WebhookSchema,
 } from "../proto-es/v1/project_service_pb";
 
-export const emptyProjectWebhook = () => {
+export const unknownProjectWebhook = () => {
   return createProto(WebhookSchema, {
     type: WebhookType.SLACK,
     notificationTypes: [Activity_Type.ISSUE_CREATED],

--- a/frontend/src/types/v1/user.ts
+++ b/frontend/src/types/v1/user.ts
@@ -2,7 +2,7 @@ import { create } from "@bufbuild/protobuf";
 import { t } from "@/plugins/i18n";
 import { extractUserId } from "@/store/modules/v1/common";
 import { SYSTEM_BOT_EMAIL } from "../common";
-import { EMPTY_ID, UNKNOWN_ID } from "../const";
+import { UNKNOWN_ID } from "../const";
 import { State } from "../proto-es/v1/common_pb";
 import type { User } from "../proto-es/v1/user_service_pb";
 import { UserSchema, UserType } from "../proto-es/v1/user_service_pb";
@@ -10,40 +10,31 @@ import { UserSchema, UserType } from "../proto-es/v1/user_service_pb";
 export const UNKNOWN_USER_NAME = `users/${UNKNOWN_ID}`;
 export const SYSTEM_BOT_USER_NAME = `users/${SYSTEM_BOT_EMAIL}`;
 
-export const emptyUser = (): User => {
-  return create(UserSchema, {
-    name: `users/${EMPTY_ID}`,
+export const unknownUser = (name: string = ""): User => {
+  const user = create(UserSchema, {
+    name: UNKNOWN_USER_NAME,
     state: State.ACTIVE,
-    email: "",
-    title: "",
     userType: UserType.USER,
   });
-};
-
-export const unknownUser = (name: string = ""): User => {
-  const empty = emptyUser();
   if (name) {
-    empty.name = name;
+    user.name = name;
     const email = extractUserId(name);
-    empty.email = email;
-    empty.title = email;
-  } else {
-    empty.name = UNKNOWN_USER_NAME;
-    empty.title = "<<Unknown user>>";
+    user.email = email;
+    user.title = email;
   }
-  return empty;
+  return user;
 };
 
 export const ALL_USERS_USER_EMAIL = "allUsers";
 // Pseudo allUsers account.
 export const allUsersUser = (): User => {
-  return {
-    ...emptyUser(),
+  return create(UserSchema, {
     name: `users/${ALL_USERS_USER_EMAIL}`,
+    state: State.ACTIVE,
     title: t("settings.members.all-users"),
     email: ALL_USERS_USER_EMAIL,
     userType: UserType.SYSTEM_BOT,
-  };
+  });
 };
 
 export const userBindingPrefix = "user:";
@@ -65,7 +56,6 @@ export const isValidUserName = (name: string) => {
   return (
     !!name &&
     /^users\/(.+)$/.test(name) &&
-    name !== emptyUser().name &&
     name !== unknownUser().name &&
     name !== allUsersUser().name
   );

--- a/frontend/src/utils/v1/issue/plan.ts
+++ b/frontend/src/utils/v1/issue/plan.ts
@@ -1,4 +1,4 @@
-import { EMPTY_ID, UNKNOWN_ID } from "@/types";
+import { UNKNOWN_ID } from "@/types";
 import type { Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 
 export const sheetNameOfSpec = (spec: Plan_Spec): string => {
@@ -22,9 +22,7 @@ export const isValidPlanName = (name: string | undefined) => {
     return false;
   }
   const planUID = extractPlanUID(name);
-  return Boolean(
-    planUID && planUID !== String(EMPTY_ID) && planUID !== String(UNKNOWN_ID)
-  );
+  return Boolean(planUID && planUID !== String(UNKNOWN_ID));
 };
 
 export const extractPlanCheckRunUID = (name: string) => {

--- a/frontend/src/utils/v1/issue/rollout.ts
+++ b/frontend/src/utils/v1/issue/rollout.ts
@@ -3,12 +3,9 @@ import { useI18n } from "vue-i18n";
 import { TASK_STATUS_FILTERS } from "@/components/Plan/constants/task";
 import { useDatabaseV1Store } from "@/store";
 import {
-  EMPTY_ID,
-  EMPTY_TASK_NAME,
-  emptyStage,
-  emptyTask,
   isValidDatabaseName,
   UNKNOWN_ID,
+  UNKNOWN_TASK_NAME,
   unknownDatabase,
   unknownStage,
   unknownTask,
@@ -54,9 +51,7 @@ export const isValidStageName = (name: string | undefined) => {
     return false;
   }
   const stageUID = extractStageUID(name);
-  return (
-    stageUID && stageUID !== String(EMPTY_ID) && stageUID !== String(UNKNOWN_ID)
-  );
+  return stageUID && stageUID !== String(UNKNOWN_ID);
 };
 
 export const extractTaskUID = (name: string) => {
@@ -70,9 +65,7 @@ export const isValidTaskName = (name: string | undefined) => {
     return false;
   }
   const taskUID = extractTaskUID(name);
-  return (
-    taskUID && taskUID !== String(EMPTY_ID) && taskUID !== String(UNKNOWN_ID)
-  );
+  return taskUID && taskUID !== String(UNKNOWN_ID);
 };
 
 export const extractTaskRunUID = (name: string) => {
@@ -149,7 +142,7 @@ export const activeTaskInTaskList = (tasks: Task[]): Task => {
   }
 
   // fallback
-  return last(tasks) ?? emptyTask();
+  return last(tasks) ?? unknownTask();
 };
 
 export const activeTaskInStageV1 = (stage: Stage): Task => {
@@ -158,14 +151,14 @@ export const activeTaskInStageV1 = (stage: Stage): Task => {
 
 export const activeTaskInRollout = (rollout: Rollout | undefined): Task => {
   if (!rollout) {
-    return emptyTask();
+    return unknownTask();
   }
   return activeTaskInTaskList(flattenTaskV1List(rollout));
 };
 
 export const activeStageInRollout = (rollout: Rollout | undefined): Stage => {
   const activeTask = activeTaskInRollout(rollout);
-  if (activeTask.name !== EMPTY_TASK_NAME) {
+  if (activeTask.name !== UNKNOWN_TASK_NAME) {
     const stage = rollout?.stages.find((stage) =>
       stage.tasks.includes(activeTask)
     );
@@ -173,7 +166,7 @@ export const activeStageInRollout = (rollout: Rollout | undefined): Stage => {
       return stage;
     }
   }
-  return emptyStage();
+  return unknownStage();
 };
 
 export const findTaskByName = (

--- a/frontend/src/views/Setup/AdminSetup.vue
+++ b/frontend/src/views/Setup/AdminSetup.vue
@@ -112,7 +112,7 @@ import {
   useSettingV1Store,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
-import { emptyProject } from "@/types";
+import { unknownProject } from "@/types";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import { DatabaseChangeMode } from "@/types/proto-es/v1/setting_service_pb";
 import WorkspaceMode from "./WorkspaceMode.vue";
@@ -141,7 +141,7 @@ const state = reactive<LocalState>({
   data: "self-setup",
   mode: DatabaseChangeMode.PIPELINE,
   project: {
-    ...emptyProject(),
+    ...unknownProject(),
     title: "New Project",
   },
   resourceId: "",

--- a/frontend/src/views/project/ProjectPlanDashboard.vue
+++ b/frontend/src/views/project/ProjectPlanDashboard.vue
@@ -99,7 +99,7 @@ import {
   extractDatabaseGroupName,
   extractDatabaseResourceName,
   extractProjectResourceName,
-  generateIssueTitle,
+  generatePlanTitle,
   getDefaultPagination,
   type SearchParams,
   type SearchScope,
@@ -292,7 +292,7 @@ watch(
 );
 
 const handleSpecCreated = async (spec: Plan_Spec) => {
-  const template = "bb.issue.database.update";
+  const template = "bb.plan.change-database";
   const targets = targetsForSpec(spec);
   const isDatabaseGroup = targets.every((target) =>
     isValidDatabaseGroupName(target)
@@ -335,7 +335,7 @@ const handleSpecCreated = async (spec: Plan_Spec) => {
     query.databaseGroupName = databaseGroupName;
     // Only set title from generated if enforceIssueTitle is false.
     if (!project.value.enforceIssueTitle) {
-      query.name = generateIssueTitle(template, [
+      query.name = generatePlanTitle(template, [
         extractDatabaseGroupName(databaseGroupName),
       ]);
     }
@@ -343,7 +343,7 @@ const handleSpecCreated = async (spec: Plan_Spec) => {
     query.databaseList = targets.join(",");
     // Only set title from generated if enforceIssueTitle is false.
     if (!project.value.enforceIssueTitle) {
-      query.name = generateIssueTitle(
+      query.name = generatePlanTitle(
         template,
         targets.map((db) => {
           const { databaseName } = extractDatabaseResourceName(db);

--- a/frontend/src/views/project/ProjectWebhookCreate.vue
+++ b/frontend/src/views/project/ProjectWebhookCreate.vue
@@ -11,7 +11,7 @@ import { computed } from "vue";
 import ProjectWebhookForm from "@/components/ProjectWebhookForm.vue";
 import { useProjectByName } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
-import { emptyProjectWebhook } from "@/types/v1/projectWebhook";
+import { unknownProjectWebhook } from "@/types/v1/projectWebhook";
 
 const props = defineProps<{
   projectId: string;
@@ -21,5 +21,5 @@ const { project } = useProjectByName(
   computed(() => `${projectNamePrefix}${props.projectId}`)
 );
 
-const defaultNewWebhook = emptyProjectWebhook();
+const defaultNewWebhook = unknownProjectWebhook();
 </script>

--- a/frontend/src/views/project/ProjectWebhookDetail.vue
+++ b/frontend/src/views/project/ProjectWebhookDetail.vue
@@ -12,7 +12,7 @@ import { computed } from "vue";
 import ProjectWebhookForm from "@/components/ProjectWebhookForm.vue";
 import { useProjectByName, useProjectWebhookV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
-import { emptyProjectWebhook } from "@/types/v1/projectWebhook";
+import { unknownProjectWebhook } from "@/types/v1/projectWebhook";
 import { idFromSlug } from "@/utils";
 
 const props = defineProps<{
@@ -30,7 +30,7 @@ const projectWebhook = computed(() => {
   const id = idFromSlug(props.projectWebhookSlug);
   return (
     projectWebhookV1Store.getProjectWebhookFromProjectById(project.value, id) ??
-    emptyProjectWebhook()
+    unknownProjectWebhook()
   );
 });
 </script>

--- a/frontend/src/views/sql-editor/EditorCommon/ExecuteHint.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ExecuteHint.vue
@@ -138,7 +138,7 @@ const gotoCreateIssue = async () => {
   const { databaseName } = extractDatabaseResourceName(db.name);
 
   const query = {
-    template: "bb.issue.database.update",
+    template: "bb.plan.change-database",
     name: `[${databaseName}] Change from SQL Editor`,
     databaseList: db.name,
     sqlStorageKey,

--- a/frontend/src/views/sql-editor/SQLEditorHomePage.vue
+++ b/frontend/src/views/sql-editor/SQLEditorHomePage.vue
@@ -129,7 +129,7 @@ useEmitteryEventListener(
     }
     const { databaseName: dbName } = extractDatabaseResourceName(database.name);
     const query = {
-      template: "bb.issue.database.update",
+      template: "bb.plan.change-database",
       name: `[${dbName}] Edit schema`,
       databaseList: database.name,
       sql: exampleSQL.join(" "),


### PR DESCRIPTION
- Remove EMPTY_ID and emptyXxx() functions, keep only unknownXxx()
- Rename IssueType to use plan-related naming (bb.plan.change-database, bb.plan.export-data)
- Split generateIssueTitle into generatePlanTitle and formatIssueTitle
- Remove redundant empty string assignments from unknownXxx() functions
- Delete unused frontend/src/types/issue.ts