### PR TITLE
fix(store): remove unnecessary transactions and fix resource leaks

### DIFF
--- a/backend/store/stats.go
+++ b/backend/store/stats.go
@@ -18,17 +18,8 @@ func (s *Store) CountActiveInstances(ctx context.Context) (int, error) {
 		return 0, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return 0, err
-	}
-	defer tx.Rollback()
-
 	var count int
-	if err := tx.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
-		return 0, err
-	}
-	if err := tx.Commit(); err != nil {
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count, nil
@@ -36,12 +27,6 @@ func (s *Store) CountActiveInstances(ctx context.Context) (int, error) {
 
 // CountActiveEndUsers counts the number of endusers.
 func (s *Store) CountActiveEndUsers(ctx context.Context) (int, error) {
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return 0, err
-	}
-	defer tx.Rollback()
-
 	q := qb.Q().Space("SELECT count(DISTINCT principal.id) FROM principal WHERE principal.deleted = ? AND principal.type = ?", false, storepb.PrincipalType_END_USER.String())
 	query, args, err := q.ToSQL()
 	if err != nil {
@@ -49,10 +34,7 @@ func (s *Store) CountActiveEndUsers(ctx context.Context) (int, error) {
 	}
 
 	var count int
-	if err := tx.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
-		return 0, err
-	}
-	if err := tx.Commit(); err != nil {
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count, nil


### PR DESCRIPTION
## Summary
- Remove unnecessary transactions from `CreateProjectWebhook`, `UpdateProjectWebhook`, `DeleteProjectWebhook` (single operations that don't need atomicity)
- Inline `PatchWorkSheet` logic and remove unused `patchWorkSheetImpl` function
- Remove unnecessary transactions from `CountActiveInstances`, `CountActiveEndUsers` (single SELECT queries)

These functions were also missing `defer tx.Rollback()` which could cause connection pool exhaustion on errors.

## Test plan
- [ ] Verify webhook CRUD operations still work
- [ ] Verify worksheet patching still works
- [ ] Verify stats counting still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)