### PR TITLE
fix(store): remove unnecessary transactions from single-operation functions

### DIFF
--- a/backend/store/database.go
+++ b/backend/store/database.go
@@ -234,27 +234,6 @@ func (s *Store) ListDatabases(ctx context.Context, find *FindDatabaseMessage) ([
 
 // CreateDatabaseDefault creates a new database in the default project.
 func (s *Store) CreateDatabaseDefault(ctx context.Context, create *DatabaseMessage) (*DatabaseMessage, error) {
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	if _, err := s.createDatabaseDefaultImpl(ctx, tx, create.ProjectID, create.InstanceID, create); err != nil {
-		return nil, err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, err
-	}
-
-	// Invalidate an update the cache.
-	s.databaseCache.Remove(getDatabaseCacheKey(create.InstanceID, create.DatabaseName))
-	return s.GetDatabase(ctx, &FindDatabaseMessage{InstanceID: &create.InstanceID, DatabaseName: &create.DatabaseName, ShowDeleted: true})
-}
-
-// createDatabaseDefault only creates a default database with charset, collation only in the default project.
-func (*Store) createDatabaseDefaultImpl(ctx context.Context, txn *sql.Tx, projectID, instanceID string, create *DatabaseMessage) (int, error) {
 	q := qb.Q().Space(`
 		INSERT INTO db (
 			instance,
@@ -266,22 +245,25 @@ func (*Store) createDatabaseDefaultImpl(ctx context.Context, txn *sql.Tx, projec
 		ON CONFLICT (instance, name) DO UPDATE SET
 			deleted = EXCLUDED.deleted
 		RETURNING id`,
-		instanceID,
-		projectID,
+		create.InstanceID,
+		create.ProjectID,
 		create.DatabaseName,
 		false,
 	)
 
 	query, args, err := q.ToSQL()
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed to build sql")
+		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
 	var databaseUID int
-	if err := txn.QueryRowContext(ctx, query, args...).Scan(&databaseUID); err != nil {
-		return 0, err
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&databaseUID); err != nil {
+		return nil, err
 	}
-	return databaseUID, nil
+
+	// Invalidate and update the cache.
+	s.databaseCache.Remove(getDatabaseCacheKey(create.InstanceID, create.DatabaseName))
+	return s.GetDatabase(ctx, &FindDatabaseMessage{InstanceID: &create.InstanceID, DatabaseName: &create.DatabaseName, ShowDeleted: true})
 }
 
 // UpsertDatabase upserts a database.
@@ -290,12 +272,6 @@ func (s *Store) UpsertDatabase(ctx context.Context, create *DatabaseMessage) (*D
 	if err != nil {
 		return nil, err
 	}
-
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
 
 	var environment *string
 	if create.EnvironmentID != nil && *create.EnvironmentID != "" {
@@ -332,10 +308,7 @@ func (s *Store) UpsertDatabase(ctx context.Context, create *DatabaseMessage) (*D
 	}
 
 	var databaseUID int
-	if err := tx.QueryRowContext(ctx, query, args...).Scan(&databaseUID); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&databaseUID); err != nil {
 		return nil, err
 	}
 
@@ -391,17 +364,8 @@ func (s *Store) UpdateDatabase(ctx context.Context, patch *UpdateDatabaseMessage
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
 	var databaseUID int
-	if err := tx.QueryRowContext(ctx, query, args...).Scan(&databaseUID); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&databaseUID); err != nil {
 		return nil, err
 	}
 

--- a/backend/store/database_group.go
+++ b/backend/store/database_group.go
@@ -39,16 +39,8 @@ func (s *Store) DeleteDatabaseGroup(ctx context.Context, projectID, resourceID s
 		return errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return errors.Wrapf(err, "failed to begin transaction")
-	}
-	defer tx.Rollback()
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return errors.Wrapf(err, "failed to execute")
-	}
-	if err := tx.Commit(); err != nil {
-		return errors.Wrapf(err, "failed to commit transaction")
 	}
 	return nil
 }
@@ -193,17 +185,8 @@ func (s *Store) CreateDatabaseGroup(ctx context.Context, create *DatabaseGroupMe
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to begin transaction")
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-		return nil, errors.Wrapf(err, "failed to scan")
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, errors.Wrapf(err, "failed to commit transaction")
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
+		return nil, errors.Wrapf(err, "failed to execute")
 	}
 
 	return create, nil

--- a/backend/store/instance.go
+++ b/backend/store/instance.go
@@ -186,12 +186,6 @@ func (s *Store) CreateInstance(ctx context.Context, instanceCreate *InstanceMess
 		environment = instanceCreate.EnvironmentID
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
 	q := qb.Q().Space(`
 			INSERT INTO instance (
 				resource_id,
@@ -203,11 +197,7 @@ func (s *Store) CreateInstance(ctx context.Context, instanceCreate *InstanceMess
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-		return nil, err
-	}
-
-	if err := tx.Commit(); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return nil, err
 	}
 
@@ -271,17 +261,7 @@ func (s *Store) UpdateInstance(ctx context.Context, patch *UpdateInstanceMessage
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-		return nil, err
-	}
-
-	if err := tx.Commit(); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
Remove transaction wrappers from functions that only perform single database operations. Single SQL statements are already atomic in PostgreSQL, so these transactions added overhead without benefit.

**Files modified:**
- `issue.go`: CreateIssue, UpdateIssue, ListIssues
- `plan.go`: CreatePlan, UpdatePlan, ListPlans  
- `database.go`: CreateDatabaseDefault, UpsertDatabase, UpdateDatabase
- `instance.go`: CreateInstance, UpdateInstance
- `group.go`: CreateGroup, UpdateGroup, DeleteGroup
- `changelog.go`: CreateChangelog, UpdateChangelog
- `database_group.go`: DeleteDatabaseGroup, CreateDatabaseGroup
- `project.go`: CreateProject (fixed to include policy creation in same tx)

**Note:** `CreateProject` was kept as a transaction but fixed - it now properly includes both the project INSERT and IAM policy creation in the same transaction for proper atomicity (previously the policy was created in a separate transaction).

**Stats:** -217 lines, +33 lines

## Test plan
- [ ] Verify CRUD operations work for issues, plans, databases, instances, groups, changelogs, database groups, projects
- [ ] Verify project creation properly creates IAM policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)