### PR TITLE
fix(store): remove N+1 queries from batch update functions

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -447,7 +447,7 @@ func (s *InstanceService) DeleteInstance(ctx context.Context, req *connect.Reque
 	if req.Msg.Force {
 		if len(databases) > 0 {
 			defaultProjectID := common.DefaultProjectID
-			if _, err := s.store.BatchUpdateDatabases(ctx, databases, &store.BatchUpdateDatabases{ProjectID: &defaultProjectID}); err != nil {
+			if err := s.store.BatchUpdateDatabases(ctx, databases, &store.BatchUpdateDatabases{ProjectID: &defaultProjectID}); err != nil {
 				return nil, connect.NewError(connect.CodeInternal, err)
 			}
 		}

--- a/backend/api/v1/setting_service.go
+++ b/backend/api/v1/setting_service.go
@@ -546,7 +546,7 @@ func (s *SettingService) UpdateSetting(ctx context.Context, request *connect.Req
 				}); err != nil {
 					return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to unset environment %v for instances", env.Id))
 				}
-				if _, err := s.store.BatchUpdateDatabases(ctx, nil, &store.BatchUpdateDatabases{
+				if err := s.store.BatchUpdateDatabases(ctx, nil, &store.BatchUpdateDatabases{
 					EnvironmentID:       &emptyStr,
 					FindByEnvironmentID: &env.Id,
 				}); err != nil {
@@ -609,7 +609,7 @@ func (s *SettingService) UpdateSetting(ctx context.Context, request *connect.Req
 				Setting:    setting,
 			})
 		}
-		if _, err = s.store.UpdateProjects(ctx, batchUpdate...); err != nil {
+		if err = s.store.UpdateProjects(ctx, batchUpdate...); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to patch project classification with error: %v", err))
 		}
 	}

--- a/backend/store/project.go
+++ b/backend/store/project.go
@@ -243,9 +243,9 @@ func (s *Store) CreateProject(ctx context.Context, create *ProjectMessage, creat
 }
 
 // UpdateProjects updates projects in a single transaction.
-func (s *Store) UpdateProjects(ctx context.Context, patches ...*UpdateProjectMessage) ([]*ProjectMessage, error) {
+func (s *Store) UpdateProjects(ctx context.Context, patches ...*UpdateProjectMessage) error {
 	if len(patches) == 0 {
-		return nil, nil
+		return nil
 	}
 
 	// Remove all projects from cache first
@@ -266,7 +266,7 @@ func (s *Store) UpdateProjects(ctx context.Context, patches ...*UpdateProjectMes
 		if patch.Setting != nil {
 			payload, err := protojson.Marshal(patch.Setting)
 			if err != nil {
-				return nil, err
+				return err
 			}
 			s := string(payload)
 			settings[i] = &s
@@ -285,24 +285,14 @@ func (s *Store) UpdateProjects(ctx context.Context, patches ...*UpdateProjectMes
 
 	query, args, err := q.ToSQL()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
-		return nil, err
+		return err
 	}
 
-	// Fetch and return all updated projects
-	var updatedProjects []*ProjectMessage
-	for _, patch := range patches {
-		project, err := s.GetProject(ctx, &FindProjectMessage{ResourceID: &patch.ResourceID})
-		if err != nil {
-			return nil, err
-		}
-		updatedProjects = append(updatedProjects, project)
-	}
-
-	return updatedProjects, nil
+	return nil
 }
 
 func (s *Store) storeProjectCache(project *ProjectMessage) {


### PR DESCRIPTION
## Summary
- `UpdateProjects` and `BatchUpdateDatabases` were fetching each updated record individually after batch updates, causing N+1 query problems
- Changed both functions to return `error` only instead of returning updated records
- Callers that need updated data now call `GetProject`/`GetDatabase` separately
- `BatchUpdateDatabases` now invalidates cache entries instead of updating them with N+1 `GetInstance` calls

## Test plan
- [ ] Build passes
- [ ] Lint passes
- [ ] Existing tests pass (no new tests needed - behavior unchanged, just return values removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)