### PR TITLE
fix(db): add WithIAMAuthN for Google Cloud SQL IAM authentication

### DIFF
--- a/backend/plugin/db/util/connection.go
+++ b/backend/plugin/db/util/connection.go
@@ -37,9 +37,11 @@ func GetAWSConnectionConfig(ctx context.Context, connCfg db.ConnectionConfig) (a
 }
 
 func GetGCPConnectionConfig(ctx context.Context, connCfg db.ConnectionConfig) (*cloudsqlconn.Dialer, error) {
-	if gcpCredential := connCfg.DataSource.GetGcpCredential(); gcpCredential != nil {
+	if gcpCredential := connCfg.DataSource.GetGcpCredential(); gcpCredential != nil && len(gcpCredential.Content) > 0 {
+		// Need BOTH: WithCredentialsJSON for API access AND WithIAMAuthN for IAM database authentication
 		return cloudsqlconn.NewDialer(ctx,
 			cloudsqlconn.WithCredentialsJSON([]byte(gcpCredential.Content)),
+			cloudsqlconn.WithIAMAuthN(),
 		)
 	}
 	return cloudsqlconn.NewDialer(ctx, cloudsqlconn.WithIAMAuthN())


### PR DESCRIPTION
## Summary

- Fixes Google Cloud SQL IAM authentication by adding `WithIAMAuthN()` option to the cloudsqlconn dialer
- The cloudsqlconn library requires BOTH options for IAM auth to work:
  - `WithCredentialsJSON`: provides credentials for Cloud SQL Admin API calls
  - `WithIAMAuthN`: enables IAM database authentication (generates OAuth tokens)
- Previously only `WithCredentialsJSON` was passed, causing "empty password returned by client" errors

## Root Cause

Without `WithIAMAuthN()`, the library:
1. ✅ Uses credentials to call Cloud SQL Admin API (get instance metadata)
2. ✅ Establishes connection to Cloud SQL proxy
3. ❌ Does NOT generate OAuth token for database authentication
4. ❌ Sends empty password → PostgreSQL rejects with SQLSTATE 28P01

## Test plan

- [x] Tested locally with Google Cloud SQL instance using IAM authentication
- [x] Verified connection succeeds with service account JSON key
- [x] Build passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)