### PR TITLE
refactor(store): remove unnecessary single-operation transactions

### DIFF
--- a/backend/store/query_history.go
+++ b/backend/store/query_history.go
@@ -93,20 +93,11 @@ func (s *Store) CreateQueryHistory(ctx context.Context, create *QueryHistoryMess
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	if err := tx.QueryRowContext(ctx, sql, args...).Scan(
+	if err := s.GetDB().QueryRowContext(ctx, sql, args...).Scan(
 		&create.UID,
 		&create.CreatedAt,
 	); err != nil {
 		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, errors.Wrapf(err, "failed to commit transaction")
 	}
 
 	return create, nil

--- a/backend/store/sheet.go
+++ b/backend/store/sheet.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"crypto/sha256"
-	"database/sql"
 	"encoding/hex"
 	"fmt"
 
@@ -76,13 +75,7 @@ func (s *Store) getSheet(ctx context.Context, sha256Hex string, loadFull bool) (
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	rows, err := tx.QueryContext(ctx, query, args...)
+	rows, err := s.GetDB().QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -102,9 +95,6 @@ func (s *Store) getSheet(ctx context.Context, sha256Hex string, loadFull bool) (
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 

--- a/backend/store/sync_history.go
+++ b/backend/store/sync_history.go
@@ -86,18 +86,9 @@ func (s *Store) CreateSyncHistory(ctx context.Context, instanceID, databaseName 
 		return 0, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed to begin tx")
-	}
-	defer tx.Rollback()
-
 	var id int64
-	if err := tx.QueryRowContext(ctx, query, args...).Scan(&id); err != nil {
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&id); err != nil {
 		return 0, errors.Wrapf(err, "failed to insert")
-	}
-	if err := tx.Commit(); err != nil {
-		return 0, errors.Wrapf(err, "failed to commit")
 	}
 
 	return id, nil


### PR DESCRIPTION
## Summary
- Remove transaction wrappers from 5 store functions that only perform single database operations
- Affected functions: `getSheet`, `CreateWorkSheet`, `UpsertWorksheetOrganizer`, `CreateQueryHistory`, `CreateSyncHistory`
- Transactions add overhead and are only needed when multiple operations must be atomic

## Test plan
- [ ] Verify linter passes (`golangci-lint run --allow-parallel-runners ./backend/store/...`)
- [ ] Run existing tests for affected functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)