### PR TITLE
refactor(frontend): remove legacy issueSlug route and related code

### DIFF
--- a/frontend/src/components/Project/ProjectSidebarV1.vue
+++ b/frontend/src/components/Project/ProjectSidebarV1.vue
@@ -23,7 +23,6 @@ defineProps<{
   instanceId?: string;
   databaseName?: string;
   changelogId?: string;
-  issueSlug?: string;
 }>();
 
 const router = useRouter();

--- a/frontend/src/components/Quickstart.vue
+++ b/frontend/src/components/Quickstart.vue
@@ -184,7 +184,7 @@ const introList = computed(() => {
           projectId: extractProjectResourceName(
             sampleProject.value?.name ?? UNKNOWN_PROJECT_NAME
           ),
-          issueSlug: SAMPLE_ISSUE_ID,
+          issueId: SAMPLE_ISSUE_ID,
         },
       },
       done: computed(() => uiStateStore.getIntroStateByKey("issue.visit")),

--- a/frontend/src/router/dashboard/projectV1.ts
+++ b/frontend/src/router/dashboard/projectV1.ts
@@ -240,21 +240,6 @@ const projectV1Routes: RouteRecordRaw[] = [
         component: () => import("@/views/project/ProjectIssueDashboard.vue"),
         props: true,
       },
-      // Redirect legacy issue slug format (e.g., "my-issue-123") to new numeric format
-      {
-        path: "issues/:issueSlug",
-        redirect: (to) => {
-          const { issueSlug, projectId } = to.params;
-          // Extract issue ID from slug (last part after the final hyphen)
-          const match = String(issueSlug).match(/-(\d+)$/);
-          const issueId = match ? match[1] : issueSlug;
-          return {
-            name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
-            params: { projectId, issueId },
-            query: to.query,
-          };
-        },
-      },
       {
         path: "plans",
         name: PROJECT_V1_ROUTE_PLANS,

--- a/frontend/src/views/DashboardHeader.vue
+++ b/frontend/src/views/DashboardHeader.vue
@@ -128,7 +128,6 @@ const state = reactive<LocalState>({
 const params = computed(() => {
   return {
     projectId: route.params.projectId as string | undefined,
-    issueSlug: route.params.issueSlug as string | undefined,
     instanceId: route.params.instanceId as string | undefined,
     databaseName: route.params.databaseName as string | undefined,
     changelogId: route.params.changelogId as string | undefined,


### PR DESCRIPTION
The issue route now only uses numeric issueId format. Remove the legacy issueSlug redirect route and all references to issueSlug in components.