### PR TITLE
fix(frontend): use allowRequestRole instead of allowSelfApproval for request role button

### DIFF
--- a/frontend/src/components/ProjectMember/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMember/ProjectMemberPanel.vue
@@ -198,7 +198,7 @@ const hasRequestRoleFeature = computed(() =>
 
 const shouldShowRequestRoleButton = computed(() => {
   return (
-    props.project.allowSelfApproval && hasWorkspacePermissionV2("bb.roles.list")
+    props.project.allowRequestRole && hasWorkspacePermissionV2("bb.roles.list")
   );
 });
 


### PR DESCRIPTION
## Summary
- Fixed incorrect field check in `shouldShowRequestRoleButton` computed property
- Changed from `project.allowSelfApproval` to `project.allowRequestRole`

## Problem
The "Request Role" button in `ProjectMemberPanel.vue` was checking the wrong project setting:
- **Before**: Checked `allowSelfApproval` (controls whether issue creators can self-approve their own issues)
- **After**: Checks `allowRequestRole` (controls whether users can request roles for the project)

This caused the button visibility to be controlled by the wrong setting.

## Root Cause
This bug was introduced in commit 333acc1eed (PR #19055) earlier today, though the incorrect usage of `allowSelfApproval` existed even before that refactor.

## Reference Implementation
Other components correctly use `allowRequestRole`:
- `frontend/src/components/Permission/ComponentPermissionGuard.vue:54`
- `frontend/src/views/sql-editor/EditorCommon/ResultView/RequestQueryButton.vue:61`

## Test Plan
- [x] Verify button appears when `project.allowRequestRole` is true
- [x] Verify button is hidden when `project.allowRequestRole` is false
- [x] Verify button respects `bb.roles.list` permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)