### PR TITLE
refactor(store): remove unnecessary single-operation transactions

### DIFF
--- a/backend/store/database.go
+++ b/backend/store/database.go
@@ -418,17 +418,7 @@ func (s *Store) BatchUpdateDatabases(ctx context.Context, databases []*DatabaseM
 		return errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return err
 	}
 

--- a/backend/store/db_schema.go
+++ b/backend/store/db_schema.go
@@ -122,22 +122,12 @@ func (s *Store) UpsertDBSchema(
 		return errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
 	var metadata, schema, config []byte
-	if err := tx.QueryRowContext(ctx, query, args...).Scan(
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(
 		&metadata,
 		&schema,
 		&config,
 	); err != nil {
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
 		return err
 	}
 
@@ -167,16 +157,7 @@ func (s *Store) UpdateDBSchema(ctx context.Context, instanceID, databaseName str
 		return errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return err
 	}
 

--- a/backend/store/export_archive.go
+++ b/backend/store/export_archive.go
@@ -124,15 +124,7 @@ func (s *Store) CreateExportArchive(ctx context.Context, create *ExportArchiveMe
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-	if err := tx.QueryRowContext(ctx, query, args...).Scan(&create.UID); err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&create.UID); err != nil {
 		return nil, err
 	}
 
@@ -147,17 +139,11 @@ func (s *Store) DeleteExportArchive(ctx context.Context, uid int) error {
 		return errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return err
 	}
 
-	return tx.Commit()
+	return nil
 }
 
 // DeleteExpiredExportArchives deletes export archives older than the specified retention period.

--- a/backend/store/release.go
+++ b/backend/store/release.go
@@ -253,18 +253,8 @@ func (s *Store) UpdateRelease(ctx context.Context, update *UpdateReleaseMessage)
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return nil, errors.Wrapf(err, "failed to query row")
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, errors.Wrapf(err, "failed to commit tx")
 	}
 
 	return s.GetRelease(ctx, &FindReleaseMessage{
@@ -283,13 +273,7 @@ func (s *Store) ListReleaseCategories(ctx context.Context, projectID string) ([]
 		ORDER BY category ASC
 	`
 
-	tx, err := s.GetDB().BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to begin tx")
-	}
-	defer tx.Rollback()
-
-	rows, err := tx.QueryContext(ctx, query, projectID)
+	rows, err := s.GetDB().QueryContext(ctx, query, projectID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to query rows")
 	}
@@ -306,10 +290,6 @@ func (s *Store) ListReleaseCategories(ctx context.Context, projectID string) ([]
 
 	if err := rows.Err(); err != nil {
 		return nil, errors.Wrapf(err, "rows err")
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, errors.Wrapf(err, "failed to commit tx")
 	}
 
 	return categories, nil

--- a/backend/store/setting.go
+++ b/backend/store/setting.go
@@ -312,16 +312,10 @@ func (s *Store) UpsertSetting(ctx context.Context, update *SettingMessage) (*Set
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to begin transaction")
-	}
-	defer tx.Rollback()
-
 	var setting SettingMessage
 	var nameString string
 	var valueString string
-	if err := tx.QueryRowContext(ctx, query, args...).Scan(
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(
 		&nameString,
 		&valueString,
 	); err != nil {
@@ -345,9 +339,6 @@ func (s *Store) UpsertSetting(ctx context.Context, update *SettingMessage) (*Set
 	}
 	setting.Value = msg
 
-	if err := tx.Commit(); err != nil {
-		return nil, errors.Wrap(err, "failed to commit transaction")
-	}
 	s.settingCache.Add(setting.Name, &setting)
 	return &setting, nil
 }
@@ -360,18 +351,8 @@ func (s *Store) DeleteSetting(ctx context.Context, name storepb.SettingName) err
 		return errors.Wrapf(err, "failed to build sql")
 	}
 
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return errors.Wrap(err, "failed to commit transaction")
 	}
 
 	s.settingCache.Remove(name)


### PR DESCRIPTION
## Summary
- Remove transaction wrappers from 18 functions that only execute single SQL statements
- Single statements are already atomic in PostgreSQL, so explicit transactions add unnecessary overhead
- Reduces code complexity and improves performance

## Files Modified

| File | Functions |
|------|-----------|
| `revision.go` | `CreateRevision`, `DeleteRevision` |
| `database.go` | `BatchUpdateDatabases` |
| `setting.go` | `UpsertSetting`, `DeleteSetting` |
| `policy.go` | `UpdatePolicy`, `DeletePolicy` |
| `review_config.go` | `CreateReviewConfig`, `DeleteReviewConfig`, `UpdateReviewConfig` |
| `db_schema.go` | `UpsertDBSchema`, `UpdateDBSchema` |
| `release.go` | `UpdateRelease`, `ListReleaseCategories` |
| `export_archive.go` | `CreateExportArchive`, `DeleteExportArchive` |
| `idp.go` | `CreateIdentityProvider`, `DeleteIdentityProvider` |

## Test plan
- [x] `golangci-lint run --allow-parallel-runners ./backend/store/...` passes (0 issues)
- [x] `go build` succeeds
- [ ] Verify no regressions in database operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)