### PR TITLE
fix(project): force refresh project list on switcher open

### DIFF
--- a/frontend/src/components/Project/ProjectSwitch/ProjectSwitchPopover.vue
+++ b/frontend/src/components/Project/ProjectSwitch/ProjectSwitchPopover.vue
@@ -6,7 +6,7 @@
     scrollable
     trigger="click"
     :show-arrow="false"
-    :display-directive="'show'"
+    :display-directive="'if'"
   >
     <template #trigger>
       <NButton


### PR DESCRIPTION
Changes display-directive to 'if' to force re-mounting and data fetching.