### PR TITLE
fix(frontend): disable directive controls on oversized SQL sheets

### DIFF
--- a/frontend/src/components/Plan/components/Configuration/GhostSection/GhostFlagsPanel.vue
+++ b/frontend/src/components/Plan/components/Configuration/GhostSection/GhostFlagsPanel.vue
@@ -66,7 +66,8 @@ const emits = defineEmits<{
 const { t } = useI18n();
 const { isCreating, allowChange, plan, events } = useGhostSettingContext();
 const { selectedSpec } = useSelectedSpec();
-const { sheet, sheetStatement, sheetReady } = useSpecSheet(selectedSpec);
+const { sheet, sheetStatement, sheetReady, isSheetOversize } =
+  useSpecSheet(selectedSpec);
 
 const title = computed(() => {
   return t("task.online-migration.configure-ghost-parameters");
@@ -94,7 +95,7 @@ const errors = computed(() => {
 
 const readonly = computed(() => {
   if (isCreating.value) return false;
-  return !allowChange.value;
+  return !allowChange.value || isSheetOversize.value;
 });
 
 const close = () => {

--- a/frontend/src/components/Plan/components/Configuration/GhostSection/GhostSwitch.vue
+++ b/frontend/src/components/Plan/components/Configuration/GhostSection/GhostSwitch.vue
@@ -6,6 +6,7 @@
         :value="enabled"
         :disabled="
           !allowChange ||
+          isSheetOversize ||
           (!enabled &&
             (databasesNotMeetingRequirements.length > 0 || errors.length > 0))
         "
@@ -53,7 +54,8 @@ const { t } = useI18n();
 const { isCreating, plan, allowChange, events, databases } =
   useGhostSettingContext();
 const { selectedSpec } = useSelectedSpec();
-const { sheet, sheetStatement, sheetReady } = useSpecSheet(selectedSpec);
+const { sheet, sheetStatement, sheetReady, isSheetOversize } =
+  useSpecSheet(selectedSpec);
 
 const enabled = computed(() => {
   if (!sheetReady.value) return false;
@@ -103,6 +105,11 @@ const databasesNotMeetingRequirements = computed(() => {
 });
 
 const tooltipMessage = computed(() => {
+  // Check if sheet is oversized
+  if (isSheetOversize.value) {
+    return t("issue.options-disabled-due-to-oversize");
+  }
+
   // Check if only some databases are checked
   if (
     checkedDatabasesCount.value < totalDatabasesCount.value &&

--- a/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/InstanceRoleSelect.vue
+++ b/frontend/src/components/Plan/components/Configuration/InstanceRoleSection/InstanceRoleSelect.vue
@@ -1,23 +1,28 @@
 <template>
-  <NSelect
-    v-model:value="selectedRole"
-    class="w-36!"
-    size="small"
-    :options="options"
-    :placeholder="$t('instance.select-database-user')"
-    :filterable="true"
-    :virtual-scroll="true"
-    :fallback-option="false"
-    :consistent-menu-width="false"
-    :clearable="true"
-    :disabled="!allowChange"
-    :loading="loading"
-  />
+  <NTooltip :disabled="!isSheetOversize">
+    <template #trigger>
+      <NSelect
+        v-model:value="selectedRole"
+        class="w-36!"
+        size="small"
+        :options="options"
+        :placeholder="$t('instance.select-database-user')"
+        :filterable="true"
+        :virtual-scroll="true"
+        :fallback-option="false"
+        :consistent-menu-width="false"
+        :clearable="true"
+        :disabled="!allowChange || isSheetOversize"
+        :loading="loading"
+      />
+    </template>
+    {{ $t("issue.options-disabled-due-to-oversize") }}
+  </NTooltip>
 </template>
 
 <script setup lang="tsx">
 import { create } from "@bufbuild/protobuf";
-import { NSelect, type SelectOption } from "naive-ui";
+import { NSelect, NTooltip, type SelectOption } from "naive-ui";
 import { computed, nextTick, ref, watch } from "vue";
 import {
   updateSpecSheetWithStatement,
@@ -42,7 +47,8 @@ const {
   events,
 } = useInstanceRoleSettingContext();
 const { selectedSpec } = useSelectedSpec();
-const { sheetStatement, sheet, sheetReady } = useSpecSheet(selectedSpec);
+const { sheetStatement, sheet, sheetReady, isSheetOversize } =
+  useSpecSheet(selectedSpec);
 const { plan, isCreating } = usePlanContext();
 
 // Flag to prevent circular updates

--- a/frontend/src/components/Plan/components/Configuration/IsolationLevelSection/IsolationLevelSelect.vue
+++ b/frontend/src/components/Plan/components/Configuration/IsolationLevelSection/IsolationLevelSelect.vue
@@ -1,21 +1,26 @@
 <template>
-  <NSelect
-    v-model:value="selectedIsolation"
-    class="w-36!"
-    size="small"
-    :options="options"
-    :placeholder="$t('plan.select-isolation-level')"
-    :filterable="true"
-    :virtual-scroll="true"
-    :fallback-option="false"
-    :consistent-menu-width="false"
-    :clearable="true"
-    :disabled="!allowChange"
-  />
+  <NTooltip :disabled="!isSheetOversize">
+    <template #trigger>
+      <NSelect
+        v-model:value="selectedIsolation"
+        class="w-36!"
+        size="small"
+        :options="options"
+        :placeholder="$t('plan.select-isolation-level')"
+        :filterable="true"
+        :virtual-scroll="true"
+        :fallback-option="false"
+        :consistent-menu-width="false"
+        :clearable="true"
+        :disabled="!allowChange || isSheetOversize"
+      />
+    </template>
+    {{ $t("issue.options-disabled-due-to-oversize") }}
+  </NTooltip>
 </template>
 
 <script setup lang="tsx">
-import { NSelect, type SelectOption } from "naive-ui";
+import { NSelect, NTooltip, type SelectOption } from "naive-ui";
 import { computed, nextTick, ref, watch } from "vue";
 import {
   updateSpecSheetWithStatement,
@@ -38,7 +43,8 @@ const {
 } = useIsolationLevelSettingContext();
 
 const { selectedSpec } = useSelectedSpec();
-const { sheetStatement, sheet, sheetReady } = useSpecSheet(selectedSpec);
+const { sheetStatement, sheet, sheetReady, isSheetOversize } =
+  useSpecSheet(selectedSpec);
 const { plan, isCreating } = usePlanContext();
 
 // Flag to prevent circular updates

--- a/frontend/src/components/Plan/components/Configuration/TransactionModeSection/TransactionModeSwitch.vue
+++ b/frontend/src/components/Plan/components/Configuration/TransactionModeSection/TransactionModeSwitch.vue
@@ -1,13 +1,18 @@
 <template>
-  <NSwitch
-    v-model:value="isTransactionOn"
-    size="small"
-    :disabled="!allowChange"
-  />
+  <NTooltip :disabled="!isSheetOversize">
+    <template #trigger>
+      <NSwitch
+        v-model:value="isTransactionOn"
+        size="small"
+        :disabled="!allowChange || isSheetOversize"
+      />
+    </template>
+    {{ $t("issue.options-disabled-due-to-oversize") }}
+  </NTooltip>
 </template>
 
 <script setup lang="tsx">
-import { NSwitch } from "naive-ui";
+import { NSwitch, NTooltip } from "naive-ui";
 import { computed, nextTick, ref, watch } from "vue";
 import {
   updateSpecSheetWithStatement,
@@ -25,7 +30,8 @@ import { useTransactionModeSettingContext } from "./context";
 const { allowChange, transactionMode, events } =
   useTransactionModeSettingContext();
 const { selectedSpec } = useSelectedSpec();
-const { sheetStatement, sheet, sheetReady } = useSpecSheet(selectedSpec);
+const { sheetStatement, sheet, sheetReady, isSheetOversize } =
+  useSpecSheet(selectedSpec);
 const { plan, isCreating } = usePlanContext();
 
 // Flag to prevent circular updates

--- a/frontend/src/components/Plan/components/StatementSection/EditorView/EditorView.vue
+++ b/frontend/src/components/Plan/components/StatementSection/EditorView/EditorView.vue
@@ -224,8 +224,6 @@ import { SheetSchema } from "@/types/proto-es/v1/sheet_service_pb";
 import {
   extractDatabaseResourceName,
   getInstanceResource,
-  getSheetStatement,
-  getStatementSize,
   setSheetStatement,
   useInstanceV1EditorLanguage,
 } from "@/utils";
@@ -300,17 +298,21 @@ const isEditorReadonly = computed(() => {
   return !editorState.isEditing.value || isSheetOversize.value || false;
 });
 
-const { sheet, sheetName, sheetReady, sheetStatement } =
-  useSpecSheet(selectedSpec);
+const {
+  sheet,
+  sheetName,
+  sheetReady,
+  sheetStatement,
+  isSheetOversize: isSheetOversizeRaw,
+} = useSpecSheet(selectedSpec);
 
+// Wrap the raw oversized check with UI-specific conditions:
+// - When creating, sheets are local and never truncated in practice
+// - When editing, the user has already entered edit mode (only possible for non-oversized sheets)
 const isSheetOversize = computed(() => {
   if (isCreating.value) return false;
   if (editorState.isEditing.value) return false;
-  if (!sheetReady.value) return false;
-  if (!sheet.value) return false;
-  return (
-    getStatementSize(getSheetStatement(sheet.value)) < sheet.value.contentSize
-  );
+  return isSheetOversizeRaw.value;
 });
 
 const denyEditStatementReasons = computed(() => {

--- a/frontend/src/components/Plan/components/StatementSection/useSpecSheet.ts
+++ b/frontend/src/components/Plan/components/StatementSection/useSpecSheet.ts
@@ -6,6 +6,7 @@ import type { Sheet } from "@/types/proto-es/v1/sheet_service_pb";
 import {
   extractSheetUID,
   getSheetStatement,
+  getStatementSize,
   setSheetStatement,
   sheetNameOfSpec,
 } from "@/utils";
@@ -51,11 +52,23 @@ export const useSpecSheet = (spec: ComputedRef<Plan_Spec>) => {
     sheetStatement.value = statement;
   };
 
+  // Check if the sheet content is truncated (oversized).
+  // When contentSize > actual fetched statement size, the sheet was truncated
+  // during fetch. Modifying directives on truncated sheets would cause data loss.
+  const isSheetOversize = computed(() => {
+    if (!sheetReady.value) return false;
+    if (!sheet.value) return false;
+    return (
+      getStatementSize(getSheetStatement(sheet.value)) < sheet.value.contentSize
+    );
+  });
+
   return {
     sheet,
     sheetName,
     sheetReady,
     sheetStatement,
     updateSheetStatement,
+    isSheetOversize,
   };
 };

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1030,6 +1030,7 @@
     },
     "upload-sql": "Upload SQL",
     "statement-from-sheet-warning": "Due to the SQL being oversized, it has been truncated to display, and editing is disabled. You can upload a new SQL file to overwrite it.",
+    "options-disabled-due-to-oversize": "Options are disabled because the SQL is oversized.",
     "overwrite-current-statement": "Overwrite current SQL statement",
     "upload-sql-file-max-size-exceeded": "Max file size ({size}) exceeded.",
     "transaction-mode": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1030,6 +1030,7 @@
     },
     "upload-sql": "Cargar SQL",
     "statement-from-sheet-warning": "Debido a que el SQL es demasiado grande, se ha truncado para mostrarlo y la edición está deshabilitada. Puede cargar un nuevo archivo SQL para sobrescribirlo.",
+    "options-disabled-due-to-oversize": "Las opciones están deshabilitadas porque el SQL es demasiado grande.",
     "overwrite-current-statement": "Sobrescribir la declaración SQL actual",
     "upload-sql-file-max-size-exceeded": "Se ha excedido el tamaño máximo del archivo ({size}).",
     "transaction-mode": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1030,6 +1030,7 @@
     },
     "upload-sql": "SQLのアップロード",
     "statement-from-sheet-warning": "SQL が大きすぎるため、表示時に切り捨てられ、編集が無効になっています。新しい SQL ファイルをアップロードして上書きすることができます。",
+    "options-disabled-due-to-oversize": "SQL が大きすぎるため、オプションは無効になっています。",
     "overwrite-current-statement": "現在の SQL ステートメントを上書きする",
     "upload-sql-file-max-size-exceeded": "アップロード ファイルのサイズは {size} を超えることはできません。",
     "transaction-mode": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1030,6 +1030,7 @@
     },
     "upload-sql": "Tải lên SQL",
     "statement-from-sheet-warning": "Do kích thước SQL vượt quá, nó đã bị cắt bớt để hiển thị và chỉnh sửa bị vô hiệu hóa. Bạn có thể tải lên một tệp SQL mới để ghi đè nó.",
+    "options-disabled-due-to-oversize": "Các tùy chọn bị vô hiệu hóa vì SQL quá lớn.",
     "overwrite-current-statement": "Ghi đè câu lệnh SQL hiện tại",
     "upload-sql-file-max-size-exceeded": "Vượt quá kích thước tệp tối đa ({size}).",
     "transaction-mode": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1030,6 +1030,7 @@
     },
     "upload-sql": "上传 SQL",
     "statement-from-sheet-warning": "由于 SQL 文件过大，因此被截断以便显示，并且编辑功能已禁用。你可以上传新的 SQL 文件以将其覆盖。",
+    "options-disabled-due-to-oversize": "由于 SQL 文件过大，选项已禁用。",
     "overwrite-current-statement": "覆盖当前的 SQL 语句",
     "upload-sql-file-max-size-exceeded": "上传文件大小不能超过 {size}。",
     "transaction-mode": {


### PR DESCRIPTION
When a SQL sheet is oversized (>2MB), the frontend receives truncated content. Previously, directive controls (Transaction Mode, Isolation Level, Ghost, Instance Role) remained active, and modifying them would save the truncated content back, causing data loss.

This change:
- Adds isSheetOversize check to useSpecSheet composable
- Disables all directive controls when sheet is oversized
- Shows tooltip explaining why controls are disabled

Fixes BYT-8745