### PR TITLE
fix: use UTF-8 safe TruncateString for string truncation

### DIFF
--- a/backend/api/mcp/tool_search.go
+++ b/backend/api/mcp/tool_search.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/bytebase/bytebase/backend/common"
 )
 
 // SearchInput is the input for the search_api tool.
@@ -235,8 +237,8 @@ func (*Server) formatProperty(sb *strings.Builder, prop PropertyInfo) {
 		cleanDesc := strings.ReplaceAll(prop.Description, "\n", " ")
 		cleanDesc = strings.ReplaceAll(cleanDesc, "\r", "")
 		// Truncate at 100 chars
-		if len(cleanDesc) > 100 {
-			cleanDesc = cleanDesc[:97] + "..."
+		if truncated, ok := common.TruncateString(cleanDesc, 97); ok {
+			cleanDesc = truncated + "..."
 		}
 		desc = fmt.Sprintf(" // %s", cleanDesc)
 	}

--- a/backend/migrator/migrator.go
+++ b/backend/migrator/migrator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 
+	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/store"
 )
@@ -209,9 +210,9 @@ func executeMigration(ctx context.Context, conn *sql.Conn, statement string, ver
 		}
 
 		// Truncate statement for readability in error message
-		stmtPreview := statement
-		if len(stmtPreview) > 100 {
-			stmtPreview = stmtPreview[:100] + "..."
+		stmtPreview, truncated := common.TruncateString(statement, 100)
+		if truncated {
+			stmtPreview += "..."
 		}
 
 		return errors.Errorf("migration %s failed\n"+

--- a/backend/plugin/db/elasticsearch/sync.go
+++ b/backend/plugin/db/elasticsearch/sync.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/pkg/errors"
 
+	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 )
@@ -96,9 +97,9 @@ func (d *Driver) getVersion() (string, error) {
 	err = json.Unmarshal(bytes, &result)
 	if err != nil {
 		// Include response body to help debug parsing issues
-		bodyPreview := string(bytes)
-		if len(bodyPreview) > 500 {
-			bodyPreview = bodyPreview[:500] + "..."
+		bodyPreview, truncated := common.TruncateString(string(bytes), 500)
+		if truncated {
+			bodyPreview += "..."
 		}
 		return "", errors.Wrapf(err, "failed to parse version response: %s", bodyPreview)
 	}
@@ -158,9 +159,9 @@ func (d *Driver) getIndices() ([]*storepb.TableMetadata, error) {
 		var results []IndicesResult
 		if err := json.Unmarshal(bytes, &results); err != nil {
 			// Include response body to help debug parsing issues
-			bodyPreview := string(bytes)
-			if len(bodyPreview) > 500 {
-				bodyPreview = bodyPreview[:500] + "..."
+			bodyPreview, truncated := common.TruncateString(string(bytes), 500)
+			if truncated {
+				bodyPreview += "..."
 			}
 			return nil, errors.Wrapf(err, "failed to parse Elasticsearch indices response: %s", bodyPreview)
 		}
@@ -204,9 +205,9 @@ func (d *Driver) getIndices() ([]*storepb.TableMetadata, error) {
 	var results []IndicesResult
 	if err := json.Unmarshal(bytes, &results); err != nil {
 		// Include response body to help debug parsing issues
-		bodyPreview := string(bytes)
-		if len(bodyPreview) > 500 {
-			bodyPreview = bodyPreview[:500] + "..."
+		bodyPreview, truncated := common.TruncateString(string(bytes), 500)
+		if truncated {
+			bodyPreview += "..."
 		}
 		return nil, errors.Wrapf(err, "failed to parse indices response: %s", bodyPreview)
 	}


### PR DESCRIPTION
## Summary
- Replace byte-based string truncation (`str[:n]`) with `common.TruncateString` which iterates over runes
- Fixes potential invalid UTF-8 sequences when truncating strings containing multi-byte Unicode characters
- Affected files: migrator error messages, MCP tool descriptions, Elasticsearch response previews

## Test plan
- [ ] Verify `golangci-lint` passes (confirmed locally)
- [ ] Review that truncation behavior is unchanged for ASCII strings
- [ ] Manual test with Unicode content to verify no corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)