### PR TITLE
fix: populate database group matched databases for SQL checks

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -436,7 +436,7 @@ func (s *PlanService) RunPlanChecks(ctx context.Context, request *connect.Reques
 		if c, ok := spec.Config.(*storepb.PlanConfig_Spec_ChangeDatabaseConfig); ok {
 			if len(c.ChangeDatabaseConfig.Targets) == 1 {
 				if _, _, err := common.GetProjectIDDatabaseGroupID(c.ChangeDatabaseConfig.Targets[0]); err == nil {
-					dg, err := getDatabaseGroupByName(ctx, s.store, c.ChangeDatabaseConfig.Targets[0], v1pb.DatabaseGroupView_DATABASE_GROUP_VIEW_BASIC)
+					dg, err := getDatabaseGroupByName(ctx, s.store, c.ChangeDatabaseConfig.Targets[0], v1pb.DatabaseGroupView_DATABASE_GROUP_VIEW_FULL)
 					if err != nil {
 						return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get database group %q: %v", c.ChangeDatabaseConfig.Targets[0], err))
 					}
@@ -648,7 +648,7 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database group %q (project %q) does not belong to plan project %q", name, groupProjectID, projectID))
 		}
 
-		dg, err := getDatabaseGroupByName(ctx, s, name, v1pb.DatabaseGroupView_DATABASE_GROUP_VIEW_BASIC)
+		dg, err := getDatabaseGroupByName(ctx, s, name, v1pb.DatabaseGroupView_DATABASE_GROUP_VIEW_FULL)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get database group %q: %v", name, err))
 		}


### PR DESCRIPTION
## Summary

Fixes issues created through database groups bypassing SQL checks.

## Root Cause

When creating or updating plans with database group targets, the code was fetching database groups using `DATABASE_GROUP_VIEW_BASIC`, which does not populate the `MatchedDatabases` field. When `DeriveCheckTargets` attempted to expand the database group into individual databases for SQL review checks, it found an empty `MatchedDatabases` list, resulting in zero check targets and bypassed SQL checks.

## Changes

Changed two calls to `getDatabaseGroupByName` in `backend/api/v1/plan_service.go`:

1. **Line 439** (in `RunPlanChecks`): `DATABASE_GROUP_VIEW_BASIC` → `DATABASE_GROUP_VIEW_FULL`
2. **Line 651** (in `validateSpecs`): `DATABASE_GROUP_VIEW_BASIC` → `DATABASE_GROUP_VIEW_FULL`

This ensures matched databases are properly populated when database groups are used in plans, allowing SQL checks to run on all databases in the group.

## Pattern

This fix aligns with the existing pattern in `rollout_service_task.go:250`, which correctly uses `DATABASE_GROUP_VIEW_FULL` when fetching database groups for rollout execution.

## Test Plan

- ✅ Code compiles successfully
- ✅ Linter passes (golangci-lint)
- Manual testing: Create a plan with database group targets and verify SQL checks run

Closes: BYT-8756

🤖 Generated with [Claude Code](https://claude.com/claude-code)