### PR TITLE
fix: use mail.ParseAddress for email validation in directory sync

### DIFF
--- a/backend/api/directory-sync/webhook.go
+++ b/backend/api/directory-sync/webhook.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/mail"
 	"net/url"
 	"slices"
 	"strconv"
@@ -217,7 +218,7 @@ func (s *Service) RegisterDirectorySyncRoutes(g *echo.Group) {
 			}
 			// Normalize email to lowercase for consistent lookup
 			normalizedEmail := normalizeEmail(expr.Value)
-			if !common.IsValidEmail(normalizedEmail) {
+			if _, err := mail.ParseAddress(normalizedEmail); err != nil {
 				// Azure sends UUID as userName for connectivity health checks, expecting empty response.
 				// This is expected behavior, so we just log at debug level and return empty.
 				slog.Debug("skipping filter with invalid email format", slog.String("key", expr.Key), slog.String("value", expr.Value))


### PR DESCRIPTION
## Summary
Fixed build error caused by undefined `common.IsValidEmail` function in directory sync webhook handler.

## Changes
- Added `net/mail` import to `backend/api/directory-sync/webhook.go`
- Replaced `common.IsValidEmail(normalizedEmail)` with `mail.ParseAddress(normalizedEmail)` following the existing pattern used in `backend/api/v1/user_service.go:876`

## Test plan
- [x] Build succeeds without errors
- [x] Email validation logic follows existing codebase patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)