### PR TITLE
fix(3.13.1): handle UTF-8 characters in NormalizeStatement

### DIFF
--- a/backend/plugin/advisor/utils.go
+++ b/backend/plugin/advisor/utils.go
@@ -16,8 +16,9 @@ import (
 // NormalizeStatement limit the max length of the statements.
 func NormalizeStatement(statement string) string {
 	maxLength := 1000
-	if len(statement) > maxLength {
-		return statement[:maxLength] + "..."
+	runes := []rune(statement)
+	if len(runes) > maxLength {
+		return string(runes[:maxLength]) + "..."
 	}
 	return statement
 }


### PR DESCRIPTION
## Summary
- Fix `NormalizeStatement` function to properly handle multi-byte UTF-8 characters
- Use rune slice instead of byte slice to avoid cutting characters mid-sequence

## Test plan
- [x] Verified linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)