### PR TITLE
fix(export): add task actions and fix skip/download for export data issues

### DIFF
--- a/backend/api/v1/rollout_service_converter.go
+++ b/backend/api/v1/rollout_service_converter.go
@@ -312,12 +312,13 @@ func convertToTaskFromDatabaseDataExport(project *store.ProjectMessage, task *st
 	}
 	stageID := common.FormatStageID(task.Environment)
 	v1pbTask := &v1pb.Task{
-		Name:    common.FormatTask(project.ResourceID, task.PlanID, stageID, task.ID),
-		SpecId:  task.Payload.GetSpecId(),
-		Type:    convertToTaskType(task),
-		Status:  convertToTaskStatus(task.LatestTaskRunStatus, false),
-		Target:  targetDatabaseName,
-		Payload: &v1pbTaskPayload,
+		Name:          common.FormatTask(project.ResourceID, task.PlanID, stageID, task.ID),
+		SpecId:        task.Payload.GetSpecId(),
+		Type:          convertToTaskType(task),
+		Status:        convertToTaskStatus(task.LatestTaskRunStatus, task.Payload.GetSkipped()),
+		SkippedReason: task.Payload.GetSkippedReason(),
+		Target:        targetDatabaseName,
+		Payload:       &v1pbTaskPayload,
 	}
 	if task.UpdatedAt != nil {
 		v1pbTask.UpdateTime = timestamppb.New(*task.UpdatedAt)

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -918,6 +918,11 @@ func (s *SQLService) doExportFromIssue(ctx context.Context, requestName string) 
 	targetTaskRunStatus := []storepb.TaskRun_Status{storepb.TaskRun_DONE}
 
 	for _, task := range tasks {
+		// Skip tasks that are marked as skipped (they don't have archives)
+		if task.Payload.GetSkipped() {
+			continue
+		}
+
 		taskRuns, err := s.store.ListTaskRuns(ctx, &store.FindTaskRunMessage{
 			TaskUID: &task.ID,
 			Status:  &targetTaskRunStatus,

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/context.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/context.ts
@@ -106,7 +106,17 @@ function computeExportArchiveReady(
     return false;
   }
 
-  const exportTaskRuns = exportTasks
+  // Only consider DONE tasks for archive readiness (skipped tasks don't have archives)
+  const doneTasks = exportTasks.filter(
+    (task) => task.status === Task_Status.DONE
+  );
+
+  // Need at least one DONE task to have an archive to download
+  if (doneTasks.length === 0) {
+    return false;
+  }
+
+  const exportTaskRuns = doneTasks
     .map((task) => {
       const taskRunsForTask = taskRuns.filter(
         (taskRun) => extractTaskUID(taskRun.name) === extractTaskUID(task.name)

--- a/frontend/src/components/RolloutV1/components/TaskStatusActions.vue
+++ b/frontend/src/components/RolloutV1/components/TaskStatusActions.vue
@@ -4,7 +4,7 @@
       v-if="!readonly && (primaryAction || dropdownOptions.length > 0)"
       class="flex flex-row justify-end items-center gap-x-2"
     >
-      <NButton v-if="primaryAction" size="small" @click="handlePrimaryAction">
+      <NButton v-if="primaryAction" :size="size" @click="handlePrimaryAction">
         {{ actionDisplayTitle(primaryAction) }}
       </NButton>
       <NDropdown
@@ -13,7 +13,7 @@
         :options="dropdownOptions"
         @select="handleDropdownSelect"
       >
-        <NButton size="small" class="px-1!" quaternary>
+        <NButton :size="size" class="px-1!" quaternary>
           <template #icon>
             <EllipsisVerticalIcon class="w-4 h-4" />
           </template>
@@ -63,11 +63,17 @@ type TaskStatusAction =
   // * -> SKIPPED
   | "SKIP";
 
-const props = defineProps<{
-  task: Task;
-  taskRuns: TaskRun[];
-  rollout?: Rollout;
-}>();
+const props = withDefaults(
+  defineProps<{
+    task: Task;
+    taskRuns: TaskRun[];
+    rollout?: Rollout;
+    size?: "tiny" | "small" | "medium" | "large";
+  }>(),
+  {
+    size: "small",
+  }
+);
 
 const emit = defineEmits<{
   "action-confirmed": [];


### PR DESCRIPTION
Close BYT-8752

- Add Run/Retry, Skip, Cancel buttons to export data TasksSection
- Fix backend not recognizing skipped status for export tasks (was hardcoded to false in convertToTaskFromDatabaseDataExport)
- Fix download button not showing when some tasks are skipped (now only considers DONE tasks for archive readiness)
- Fix export download API failing when some tasks are skipped (now skips tasks marked as skipped when collecting archives)

<img width="1784" height="1164" alt="image" src="https://github.com/user-attachments/assets/4c453b49-9275-405f-aa54-7fea0937f622" />
