### PR TITLE
fix(frontend): guard against NaN pageSize from corrupted localStorage

### DIFF
--- a/frontend/src/components/v2/Model/PagedTable.vue
+++ b/frontend/src/components/v2/Model/PagedTable.vue
@@ -153,7 +153,11 @@ const sessionState = useDynamicLocalStorage<SessionState>(
 
 const pageSize = computed(() => {
   const sizeInSession = sessionState.value.pageSize ?? 0;
-  if (!options.value.find((o) => o.value === sizeInSession)) {
+  // Guard against NaN/invalid values from corrupted localStorage data
+  if (
+    !Number.isFinite(sizeInSession) ||
+    !options.value.find((o) => o.value === sizeInSession)
+  ) {
     return options.value[0].value;
   }
   return Math.max(options.value[0].value, sizeInSession);


### PR DESCRIPTION
Close BYT-8769

## Summary
- Add `Number.isFinite()` check in `PagedTable.vue` to guard against NaN/invalid pageSize values from corrupted localStorage data
- Falls back to default page size when localStorage contains invalid values from previous Bytebase versions

## Problem
When upgrading Bytebase (e.g., 3.13.1 → 3.14.0), localStorage may contain incompatible pagination data that causes `NaN` to be computed for `pageSize`. This `NaN` value then causes a proto serialization error:

```
ConnectError: [internal] serialize binary: cannot encode field bytebase.v1.ListDatabasesRequest.page_size to binary: invalid int32: NaN
```

The error persists even after page refresh because localStorage survives browser refresh. Users would need to manually clear localStorage to fix it.

## Test plan
- [ ] Verify existing pagination functionality works normally
- [ ] Simulate corrupted localStorage with `localStorage.setItem('some-key.users/user', JSON.stringify({pageSize: NaN}))` and verify fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)