### PR TITLE
fix(frontend): add fallback for sessionState.page in PagedTable

### DIFF
--- a/frontend/src/components/v2/Model/PagedTable.vue
+++ b/frontend/src/components/v2/Model/PagedTable.vue
@@ -132,7 +132,8 @@ const fetchData = async (refresh = false) => {
   const isFirstFetch = state.paginationToken === "";
   const expectedRowCount = isFirstFetch
     ? // Load one or more page for the first fetch to restore the session
-      pageSize.value * sessionState.value.page
+      // Use fallback of 1 for backward compatibility with versions that don't store page field
+      pageSize.value * (sessionState.value.page ?? 1)
     : // Always load one page if NOT the first fetch
       pageSize.value;
 


### PR DESCRIPTION
Close BYT-8769

## Summary
- Add nullish coalescing fallback (`?? 1`) for `sessionState.value.page` in PagedTable.vue
- Fixes NaN issue when downgrading from 3.14.0 to 3.13.1 (3.14.0 doesn't store the `page` field)

## Root Cause
| Version | SessionState stored | Code expects |
|---------|---------------------|--------------|
| 3.13.1 | `{page, updatedTs, pageSize}` | `page` field |
| 3.14.0 | `{updatedTs, pageSize}` | No `page` field |

When downgrading, `pageSize.value * sessionState.value.page` produces `NaN` because `page` is `undefined`.

## Test plan
- [ ] Clear localStorage, use 3.14.0 to set pageSize, downgrade to 3.13.1
- [ ] Verify PagedTable loads correctly without NaN errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)