### PR TITLE
feat(frontend): separate tabs for Users, Service Accounts, Workload Identities in Workspace Members

### DIFF
--- a/frontend/src/components/User/Settings/CreateUserDrawer.vue
+++ b/frontend/src/components/User/Settings/CreateUserDrawer.vue
@@ -463,6 +463,7 @@ interface LocalState {
 
 const props = defineProps<{
   user?: User;
+  initialUserType?: UserType;
 }>();
 
 const emit = defineEmits<{
@@ -582,6 +583,10 @@ watch(
   () => props.user,
   (user) => {
     if (!user) {
+      // Apply initialUserType when creating a new user
+      if (props.initialUserType) {
+        state.user.userType = props.initialUserType;
+      }
       return;
     }
     state.user = create(UserSchema, user);

--- a/frontend/src/components/v2/Model/PagedTable.vue
+++ b/frontend/src/components/v2/Model/PagedTable.vue
@@ -153,7 +153,11 @@ const sessionState = useDynamicLocalStorage<SessionState>(
 
 const pageSize = computed(() => {
   const sizeInSession = sessionState.value.pageSize ?? 0;
-  if (!options.value.find((o) => o.value === sizeInSession)) {
+  // Guard against NaN/invalid values from corrupted localStorage data
+  if (
+    !Number.isFinite(sizeInSession) ||
+    !options.value.find((o) => o.value === sizeInSession)
+  ) {
     return options.value[0].value;
   }
   return Math.max(options.value[0].value, sizeInSession);

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -452,7 +452,13 @@
       "subscription": "(Upgrade to enable role management)"
     },
     "members": {
+      "service-accounts": "Service Accounts",
+      "add-service-account": "Add Service Account",
+      "workload-identities": "Workload Identities",
+      "add-workload-identity": "Add Workload Identity",
       "inactive-users": "Inactive users",
+      "inactive-service-accounts": "Inactive service accounts",
+      "inactive-workload-identities": "Inactive workload identities",
       "table": {
         "account": "Account",
         "role": "Role",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -452,7 +452,13 @@
       "subscription": "(Actualice para habilitar la gestión de roles)"
     },
     "members": {
+      "service-accounts": "Cuentas de Servicio",
+      "add-service-account": "Añadir Cuenta de Servicio",
+      "workload-identities": "Identidades de Carga de Trabajo",
+      "add-workload-identity": "Añadir Identidad de Carga de Trabajo",
       "inactive-users": "Usuarios inactivos",
+      "inactive-service-accounts": "Cuentas de servicio inactivas",
+      "inactive-workload-identities": "Identidades de carga de trabajo inactivas",
       "table": {
         "account": "Cuenta",
         "role": "Rol",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -452,7 +452,13 @@
       "subscription": "(有料プランにアップグレードするとキャラクター管理が可能になります)"
     },
     "members": {
+      "service-accounts": "サービスアカウント",
+      "add-service-account": "サービスアカウントを追加",
+      "workload-identities": "ワークロードID",
+      "add-workload-identity": "ワークロードIDを追加",
       "inactive-users": "非アクティブユーザー",
+      "inactive-service-accounts": "非アクティブサービスアカウント",
+      "inactive-workload-identities": "非アクティブワークロードID",
       "table": {
         "account": "アカウント",
         "role": "役割",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -452,7 +452,13 @@
       "subscription": "(Nâng cấp để kích hoạt quản lý vai trò)"
     },
     "members": {
+      "service-accounts": "Tài khoản dịch vụ",
+      "add-service-account": "Thêm tài khoản dịch vụ",
+      "workload-identities": "Danh tính Workload",
+      "add-workload-identity": "Thêm danh tính Workload",
       "inactive-users": "Người dùng không hoạt động",
+      "inactive-service-accounts": "Tài khoản dịch vụ không hoạt động",
+      "inactive-workload-identities": "Danh tính Workload không hoạt động",
       "table": {
         "account": "Tài khoản",
         "role": "Vai trò",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -452,7 +452,13 @@
       "subscription": "（升级到付费方案来解锁角色管理）"
     },
     "members": {
+      "service-accounts": "服务账号",
+      "add-service-account": "添加服务账号",
+      "workload-identities": "工作负载身份",
+      "add-workload-identity": "添加工作负载身份",
       "inactive-users": "未激活用户",
+      "inactive-service-accounts": "未激活服务账号",
+      "inactive-workload-identities": "未激活工作负载身份",
       "table": {
         "account": "账户",
         "role": "角色",

--- a/frontend/src/store/modules/v1/actuator.ts
+++ b/frontend/src/store/modules/v1/actuator.ts
@@ -111,7 +111,59 @@ export const useActuatorV1Store = defineStore("actuator_v1", () => {
 
   const inactiveUserCount = computed(() => {
     return (serverInfo.value?.userStats ?? []).reduce((count, stat) => {
-      if (stat.state === State.DELETED) {
+      if (
+        stat.state === State.DELETED &&
+        stat.userType !== UserType.SERVICE_ACCOUNT &&
+        stat.userType !== UserType.WORKLOAD_IDENTITY
+      ) {
+        count += stat.count;
+      }
+      return count;
+    }, 0);
+  });
+
+  const serviceAccountCount = computed(() => {
+    return (serverInfo.value?.userStats ?? []).reduce((count, stat) => {
+      if (
+        stat.state === State.ACTIVE &&
+        stat.userType === UserType.SERVICE_ACCOUNT
+      ) {
+        count += stat.count;
+      }
+      return count;
+    }, 0);
+  });
+
+  const workloadIdentityCount = computed(() => {
+    return (serverInfo.value?.userStats ?? []).reduce((count, stat) => {
+      if (
+        stat.state === State.ACTIVE &&
+        stat.userType === UserType.WORKLOAD_IDENTITY
+      ) {
+        count += stat.count;
+      }
+      return count;
+    }, 0);
+  });
+
+  const inactiveServiceAccountCount = computed(() => {
+    return (serverInfo.value?.userStats ?? []).reduce((count, stat) => {
+      if (
+        stat.state === State.DELETED &&
+        stat.userType === UserType.SERVICE_ACCOUNT
+      ) {
+        count += stat.count;
+      }
+      return count;
+    }, 0);
+  });
+
+  const inactiveWorkloadIdentityCount = computed(() => {
+    return (serverInfo.value?.userStats ?? []).reduce((count, stat) => {
+      if (
+        stat.state === State.DELETED &&
+        stat.userType === UserType.WORKLOAD_IDENTITY
+      ) {
         count += stat.count;
       }
       return count;
@@ -275,6 +327,10 @@ export const useActuatorV1Store = defineStore("actuator_v1", () => {
     totalInstanceCount,
     replicaCount,
     inactiveUserCount,
+    serviceAccountCount,
+    workloadIdentityCount,
+    inactiveServiceAccountCount,
+    inactiveWorkloadIdentityCount,
     quickStartEnabled,
     // Actions
     getActiveUserCount,


### PR DESCRIPTION

![CleanShot 2026-01-23 at 15 58 04](https://github.com/user-attachments/assets/91d30a25-b932-4e4d-baaa-eb553ec4d3d5)

## Summary

close BYT-8760

- Split Workspace Members page into four distinct tabs: Users, Service Accounts, Workload Identities, and Groups
- Users tab now only shows regular users (`UserType.USER`) and system bots (`UserType.SYSTEM_BOT`)
- Each tab has its own data fetching, count display, and inactive list with toggle
- Add `initialUserType` prop to `CreateUserDrawer` for type preselection when clicking "Add" buttons

## Changes

- `SettingWorkspaceUsers.vue`: Add SERVICE_ACCOUNTS and WORKLOAD_IDENTITIES tabs with separate fetch functions
- `actuator.ts`: Add count computed properties for service accounts and workload identities (active/inactive)
- `CreateUserDrawer.vue`: Support `initialUserType` prop for preselecting user type
- Locales (en-US, zh-CN, ja-JP, es-ES, vi-VN): Add i18n keys for new tabs and buttons

## Test plan

- [ ] Navigate to Settings → Members and verify four tabs are displayed
- [ ] Verify Users tab only shows regular users (no service accounts or workload identities)
- [ ] Verify Service Accounts tab shows only service accounts
- [ ] Verify Workload Identities tab shows only workload identities
- [ ] Verify "Show inactive" checkbox works for each tab
- [ ] Verify "Add" buttons open the drawer with correct type preselected

🤖 Generated with [Claude Code](https://claude.com/claude-code)