### PR TITLE
feat(mongodb): add telemetry for gomongo fallback events

### DIFF
--- a/backend/component/telemetry/reporter.go
+++ b/backend/component/telemetry/reporter.go
@@ -1,0 +1,155 @@
+// Package telemetry provides telemetry reporting to hub.bytebase.com.
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru/v2"
+
+	"github.com/bytebase/bytebase/backend/common"
+)
+
+const (
+	hubEventURL        = "https://hub.bytebase.com/v1/events"
+	maxStatementLength = 1000
+	cacheCapacity      = 100
+)
+
+// Reporter sends telemetry events to hub.bytebase.com with deduplication.
+type Reporter struct {
+	mu          sync.RWMutex
+	workspaceID string
+	version     string
+	gitCommit   string
+	enabled     bool
+
+	// LRU cache for deduplication: tracks reported statement hashes
+	cache *lru.Cache[string, struct{}]
+
+	httpClient *http.Client
+}
+
+var (
+	globalReporter     *Reporter
+	globalReporterOnce sync.Once
+)
+
+// InitGlobalReporter initializes the global telemetry reporter.
+// Must be called once at server startup.
+func InitGlobalReporter(workspaceID, version, gitCommit string, enabled bool) {
+	globalReporterOnce.Do(func() {
+		cache, _ := lru.New[string, struct{}](cacheCapacity)
+		globalReporter = &Reporter{
+			workspaceID: workspaceID,
+			version:     version,
+			gitCommit:   gitCommit,
+			enabled:     enabled,
+			cache:       cache,
+			httpClient: &http.Client{
+				Timeout: 10 * time.Second,
+			},
+		}
+	})
+}
+
+// gomongoFallbackPayload is the JSON payload for gomongo fallback events.
+type gomongoFallbackPayload struct {
+	WorkspaceID     string `json:"workspaceId"`
+	Version         string `json:"version"`
+	Commit          string `json:"commit"`
+	GomongoFallback struct {
+		Statement    string `json:"statement"`
+		ErrorMessage string `json:"errorMessage"`
+	} `json:"gomongoFallback"`
+}
+
+// ReportGomongoFallback reports a gomongo fallback event.
+// It deduplicates based on statement hash using an LRU cache.
+// Only reports in release versions (non-development builds).
+func ReportGomongoFallback(ctx context.Context, statement string, errorMessage string) {
+	if globalReporter == nil {
+		return
+	}
+
+	globalReporter.mu.RLock()
+	if !globalReporter.enabled || globalReporter.workspaceID == "" {
+		globalReporter.mu.RUnlock()
+		return
+	}
+	workspaceID := globalReporter.workspaceID
+	version := globalReporter.version
+	gitCommit := globalReporter.gitCommit
+	globalReporter.mu.RUnlock()
+
+	// Skip telemetry in development builds
+	if version == "development" {
+		return
+	}
+
+	// Truncate statement
+	truncatedStatement, truncated := common.TruncateString(statement, maxStatementLength)
+	if truncated {
+		truncatedStatement += "..."
+	}
+
+	// Check deduplication
+	hash := hashStatement(truncatedStatement)
+	if !globalReporter.shouldReport(hash) {
+		return
+	}
+
+	// Build payload
+	payload := gomongoFallbackPayload{
+		WorkspaceID: workspaceID,
+		Version:     version,
+		Commit:      gitCommit,
+	}
+	payload.GomongoFallback.Statement = truncatedStatement
+	payload.GomongoFallback.ErrorMessage = errorMessage
+
+	// Send async to not block query execution
+	go globalReporter.send(ctx, payload)
+}
+
+func (r *Reporter) shouldReport(hash string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.cache.Get(hash); ok {
+		return false
+	}
+
+	r.cache.Add(hash, struct{}{})
+	return true
+}
+
+func (r *Reporter) send(ctx context.Context, payload any) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, hubEventURL, bytes.NewReader(body))
+	if err != nil {
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return
+	}
+	resp.Body.Close()
+}
+
+func hashStatement(statement string) string {
+	h := sha256.Sum256([]byte(statement))
+	return hex.EncodeToString(h[:])
+}

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/bytebase/bytebase/backend/component/iam"
 	"github.com/bytebase/bytebase/backend/component/sampleinstance"
 	"github.com/bytebase/bytebase/backend/component/sheet"
+	"github.com/bytebase/bytebase/backend/component/telemetry"
 	"github.com/bytebase/bytebase/backend/component/webhook"
 	"github.com/bytebase/bytebase/backend/demo"
 	"github.com/bytebase/bytebase/backend/enterprise"
@@ -186,6 +187,15 @@ func NewServer(ctx context.Context, profile *config.Profile) (*Server, error) {
 		return nil, errors.Wrap(err, "failed to get system setting")
 	}
 	secret := systemSetting.AuthSecret
+
+	// Initialize telemetry reporter for hub.bytebase.com event reporting.
+	telemetry.InitGlobalReporter(
+		systemSetting.GetWorkspaceId(),
+		profile.Version,
+		profile.GitCommit,
+		workspaceProfile.GetEnableMetricCollection(),
+	)
+
 	s.iamManager, err = iam.NewManager(stores, s.licenseService)
 	if err := s.iamManager.ReloadCache(ctx); err != nil {
 		return nil, errors.Wrapf(err, "failed to reload iam cache")

--- a/go.mod
+++ b/go.mod
@@ -300,7 +300,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.6
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bytebase/parser v0.0.0-20260121030202-698704919f24
+	github.com/bytebase/parser v0.0.0-20260123082732-e9723d1469a0
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251022180443-0feb69152e9f // indirect
 	github.com/cockroachdb/cockroach-go/v2 v2.4.3

--- a/go.sum
+++ b/go.sum
@@ -861,8 +861,8 @@ github.com/bytebase/gomongo v0.0.0-20260123064557-5e3ae906bb2c h1:e1yWka4+s62d7r
 github.com/bytebase/gomongo v0.0.0-20260123064557-5e3ae906bb2c/go.mod h1:tmnMdRvFw6R4jYLWnPCtGMsCh2McnCXBLW4ZonyShsE=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/parser v0.0.0-20260121030202-698704919f24 h1:oonTO26orUa4bYk/hQjALiYO1zII+Kzpjg75OnC3VtU=
-github.com/bytebase/parser v0.0.0-20260121030202-698704919f24/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
+github.com/bytebase/parser v0.0.0-20260123082732-e9723d1469a0 h1:a8xGDaGm0w1AgPgZSO5eqJcuSjeut8jDMrVfyaVLyII=
+github.com/bytebase/parser v0.0.0-20260123082732-e9723d1469a0/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
## Summary
- Add telemetry reporting to hub.bytebase.com when MongoDB queries fall back to mongosh execution due to gomongo parsing/execution failures
- Helps identify unsupported MongoDB syntax patterns in the gomongo library
- Uses LRU-based deduplication (capacity 100) to avoid duplicate reports
- Truncates statements to 1000 characters and only reports in release builds

## Test plan
- [ ] Verify telemetry reporter initializes correctly on server startup
- [ ] Test that gomongo fallback events are reported when queries fall back to mongosh
- [ ] Verify deduplication works (same statement not reported twice while in LRU cache)
- [ ] Verify development builds skip telemetry reporting

🤖 Generated with [Claude Code](https://claude.com/claude-code)