### PR TITLE
feat(api): add release filter to ListRollouts API

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -12416,10 +12416,12 @@ components:
              Supported filters:
              - update_time: rollout update time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
              - task_type: the task type, support "in" operator, check the Task.Type enum for the values.
+             - release: the release resource name in "projects/{project}/releases/{release}" format, support "==" operator. Filters rollouts that reference the specified release.
 
              For example:
              update_time >= "2025-01-02T15:04:05Z07:00"
              task_type in ["DATABASE_MIGRATE", "DATABASE_EXPORT"]
+             release == "projects/myproject/releases/123"
       title: ListRolloutsRequest
       additionalProperties: false
     bytebase.v1.ListRolloutsResponse:

--- a/backend/generated-go/v1/rollout_service.pb.go
+++ b/backend/generated-go/v1/rollout_service.pb.go
@@ -778,10 +778,12 @@ type ListRolloutsRequest struct {
 	// Supported filters:
 	// - update_time: rollout update time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
 	// - task_type: the task type, support "in" operator, check the Task.Type enum for the values.
+	// - release: the release resource name in "projects/{project}/releases/{release}" format, support "==" operator. Filters rollouts that reference the specified release.
 	//
 	// For example:
 	// update_time >= "2025-01-02T15:04:05Z07:00"
 	// task_type in ["DATABASE_MIGRATE", "DATABASE_EXPORT"]
+	// release == "projects/myproject/releases/123"
 	Filter        string `protobuf:"bytes,4,opt,name=filter,proto3" json:"filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/backend/store/rollout_filter.go
+++ b/backend/store/rollout_filter.go
@@ -45,6 +45,18 @@ func GetListRolloutFilter(filter string) (*qb.Query, error) {
 					q.And("?", qq)
 				}
 				return qb.Q().Space("(?)", q), nil
+			case celoperators.Equals:
+				variable, value := getVariableAndValueFromExpr(expr)
+				switch variable {
+				case "release":
+					releaseName, ok := value.(string)
+					if !ok {
+						return nil, errors.Errorf("release value must be a string")
+					}
+					return qb.Q().Space("EXISTS (SELECT 1 FROM jsonb_array_elements(plan.config->'specs') AS spec WHERE spec->'changeDatabaseConfig'->>'release' = ?)", releaseName), nil
+				default:
+					return nil, errors.Errorf("unsupported variable %q for == operator", variable)
+				}
 			case celoperators.In:
 				variable, value := getVariableAndValueFromExpr(expr)
 				switch variable {

--- a/frontend/src/types/proto-es/v1/rollout_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/rollout_service_pb.d.ts
@@ -205,10 +205,12 @@ export declare type ListRolloutsRequest = Message<"bytebase.v1.ListRolloutsReque
    * Supported filters:
    * - update_time: rollout update time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
    * - task_type: the task type, support "in" operator, check the Task.Type enum for the values.
+   * - release: the release resource name in "projects/{project}/releases/{release}" format, support "==" operator. Filters rollouts that reference the specified release.
    *
    * For example:
    * update_time >= "2025-01-02T15:04:05Z07:00"
    * task_type in ["DATABASE_MIGRATE", "DATABASE_EXPORT"]
+   * release == "projects/myproject/releases/123"
    *
    * @generated from field: string filter = 4;
    */

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -7942,10 +7942,12 @@ paths:
              Supported filters:
              - update_time: rollout update time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
              - task_type: the task type, support "in" operator, check the Task.Type enum for the values.
+             - release: the release resource name in "projects/{project}/releases/{release}" format, support "==" operator. Filters rollouts that reference the specified release.
 
              For example:
              update_time >= "2025-01-02T15:04:05Z07:00"
              task_type in ["DATABASE_MIGRATE", "DATABASE_EXPORT"]
+             release == "projects/myproject/releases/123"
           schema:
             type: string
             title: filter
@@ -7956,10 +7958,12 @@ paths:
                Supported filters:
                - update_time: rollout update time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
                - task_type: the task type, support "in" operator, check the Task.Type enum for the values.
+               - release: the release resource name in "projects/{project}/releases/{release}" format, support "==" operator. Filters rollouts that reference the specified release.
 
                For example:
                update_time >= "2025-01-02T15:04:05Z07:00"
                task_type in ["DATABASE_MIGRATE", "DATABASE_EXPORT"]
+               release == "projects/myproject/releases/123"
       responses:
         "200":
           description: Success
@@ -16693,10 +16697,12 @@ components:
              Supported filters:
              - update_time: rollout update time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
              - task_type: the task type, support "in" operator, check the Task.Type enum for the values.
+             - release: the release resource name in "projects/{project}/releases/{release}" format, support "==" operator. Filters rollouts that reference the specified release.
 
              For example:
              update_time >= "2025-01-02T15:04:05Z07:00"
              task_type in ["DATABASE_MIGRATE", "DATABASE_EXPORT"]
+             release == "projects/myproject/releases/123"
       title: ListRolloutsRequest
       required:
         - parent

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -9495,9 +9495,9 @@ RoleService manages workspace roles and permissions.
 When paginating, all other parameters provided to `ListRollouts` must match the call that provided the page token. |
 | filter | [string](#string) |  | Filter is used to filter rollouts returned in the list. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
 
-Supported filters: - update_time: rollout update time in &#34;2006-01-02T15:04:05Z07:00&#34; format, support &#34;&gt;=&#34; or &#34;&lt;=&#34; operator. - task_type: the task type, support &#34;in&#34; operator, check the Task.Type enum for the values.
+Supported filters: - update_time: rollout update time in &#34;2006-01-02T15:04:05Z07:00&#34; format, support &#34;&gt;=&#34; or &#34;&lt;=&#34; operator. - task_type: the task type, support &#34;in&#34; operator, check the Task.Type enum for the values. - release: the release resource name in &#34;projects/{project}/releases/{release}&#34; format, support &#34;==&#34; operator. Filters rollouts that reference the specified release.
 
-For example: update_time &gt;= &#34;2025-01-02T15:04:05Z07:00&#34; task_type in [&#34;DATABASE_MIGRATE&#34;, &#34;DATABASE_EXPORT&#34;] |
+For example: update_time &gt;= &#34;2025-01-02T15:04:05Z07:00&#34; task_type in [&#34;DATABASE_MIGRATE&#34;, &#34;DATABASE_EXPORT&#34;] release == &#34;projects/myproject/releases/123&#34; |
 
 
 

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -26807,10 +26807,12 @@ The syntax and semantics of CEL are documented at https://github.com/google/cel-
 Supported filters:
 - update_time: rollout update time in &#34;2006-01-02T15:04:05Z07:00&#34; format, support &#34;&gt;=&#34; or &#34;&lt;=&#34; operator.
 - task_type: the task type, support &#34;in&#34; operator, check the Task.Type enum for the values.
+- release: the release resource name in &#34;projects/{project}/releases/{release}&#34; format, support &#34;==&#34; operator. Filters rollouts that reference the specified release.
 
 For example:
 update_time &gt;= &#34;2025-01-02T15:04:05Z07:00&#34;
-task_type in [&#34;DATABASE_MIGRATE&#34;, &#34;DATABASE_EXPORT&#34;] </p></td>
+task_type in [&#34;DATABASE_MIGRATE&#34;, &#34;DATABASE_EXPORT&#34;]
+release == &#34;projects/myproject/releases/123&#34; </p></td>
                 </tr>
               
             </tbody>

--- a/proto/v1/v1/rollout_service.proto
+++ b/proto/v1/v1/rollout_service.proto
@@ -217,10 +217,12 @@ message ListRolloutsRequest {
   // Supported filters:
   // - update_time: rollout update time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
   // - task_type: the task type, support "in" operator, check the Task.Type enum for the values.
+  // - release: the release resource name in "projects/{project}/releases/{release}" format, support "==" operator. Filters rollouts that reference the specified release.
   //
   // For example:
   // update_time >= "2025-01-02T15:04:05Z07:00"
   // task_type in ["DATABASE_MIGRATE", "DATABASE_EXPORT"]
+  // release == "projects/myproject/releases/123"
   string filter = 4;
 }
 


### PR DESCRIPTION
Part of BYT-6680. Add support for filtering rollouts by release reference in the ListRollouts API. This enables finding all rollouts associated with a specific release, which is needed for the release detail page. Usage: `release == "projects/{project}/releases/{release}"`
