### PR TITLE
fix(backend): update issue status to DONE when manually creating rollout (#19151)

### DIFF
--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -272,7 +272,6 @@ func (s *RolloutService) CreateRollout(ctx context.Context, req *connect.Request
 		}
 	}
 
-
 	tasks, err := GetPipelineCreate(ctx, s.store, plan.Config.GetSpecs(), project.ResourceID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to get pipeline create"))


### PR DESCRIPTION
Cherry-pick of #19151 to release/3.14.0 branch.

Previously, when calling CreateRollout API, the issue parameter was passed as nil to CreateRolloutAndPendingTasks, which meant the issue status was never updated to DONE.

This fix fetches the issue and passes it to CreateRolloutAndPendingTasks, ensuring the issue status is properly updated when a rollout is created manually (not via auto-rollout).