### PR TITLE
chore: support multiple-select keyboard shortcut

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/TableCell.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/TableCell.vue
@@ -93,8 +93,8 @@ const { getBinaryFormat, setBinaryFormat } = useBinaryFormatContext();
 const {
   state: selectionState,
   disabled: selectionDisabled,
-  selectCell,
-  selectRow,
+  toggleSelectCell,
+  toggleSelectRow,
 } = useSelectionContext();
 const wrapperRef = ref<HTMLDivElement>();
 const cellRef = ref<HTMLDivElement>();
@@ -228,9 +228,9 @@ const handleClick = (e: MouseEvent) => {
   }
   // If the user is holding the ctrl/cmd key, select the row.
   if (e.ctrlKey || e.metaKey) {
-    selectRow(props.rowIndex);
+    toggleSelectRow(props.rowIndex);
   } else {
-    selectCell(props.rowIndex, props.colIndex);
+    toggleSelectCell(props.rowIndex, props.colIndex);
   }
   e.stopPropagation();
 };


### PR DESCRIPTION
- Cmd/Ctrl + click to select a bunch of rows/columns

![CleanShot 2026-01-27 at 17 50 20](https://github.com/user-attachments/assets/3cf89dfc-b03b-4651-8a97-0faf78feedaa)


- Include column names in the copied data

<img width="1968" height="362" alt="CleanShot 2026-01-27 at 17 53 18@2x" src="https://github.com/user-attachments/assets/d2de30aa-28f3-42df-b226-47ab73ed6d6f" />
