### PR TITLE
feat(lsp): add MongoDB LSP support for statement ranges and diagnostics

### DIFF
--- a/backend/plugin/parser/mongodb/diagnose.go
+++ b/backend/plugin/parser/mongodb/diagnose.go
@@ -1,0 +1,30 @@
+package mongodb
+
+import (
+	"context"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func init() {
+	base.RegisterDiagnoseFunc(storepb.Engine_MONGODB, Diagnose)
+}
+
+// Diagnose performs syntax checking on a MongoDB shell script.
+func Diagnose(_ context.Context, _ base.DiagnoseContext, statement string) ([]base.Diagnostic, error) {
+	diagnostics := []base.Diagnostic{}
+
+	parseResult := ParseMongoShell(statement)
+	if parseResult == nil {
+		return diagnostics, nil
+	}
+
+	for _, err := range parseResult.Errors {
+		if err != nil {
+			diagnostics = append(diagnostics, base.ConvertSyntaxErrorToDiagnostic(err, statement))
+		}
+	}
+
+	return diagnostics, nil
+}

--- a/backend/plugin/parser/mongodb/mongodb.go
+++ b/backend/plugin/parser/mongodb/mongodb.go
@@ -1,0 +1,88 @@
+// Package mongodb provides MongoDB shell parser functionality for LSP features.
+package mongodb
+
+import (
+	"github.com/antlr4-go/antlr/v4"
+
+	"github.com/bytebase/parser/mongodb"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// ParseResult contains the result of parsing a MongoDB shell script.
+type ParseResult struct {
+	Tree       mongodb.IProgramContext
+	Statements []StatementInfo
+	Errors     []*base.SyntaxError
+}
+
+// StatementInfo contains information about a parsed statement.
+type StatementInfo struct {
+	StartOffset int
+	EndOffset   int
+	StartLine   int
+	StartColumn int
+	EndLine     int
+	EndColumn   int
+}
+
+// ParseMongoShell parses a MongoDB shell script and returns the parse result.
+func ParseMongoShell(statement string) *ParseResult {
+	inputStream := antlr.NewInputStream(statement)
+	lexer := mongodb.NewMongoShellLexer(inputStream)
+	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	parser := mongodb.NewMongoShellParser(stream)
+
+	// Set up error listener
+	lexer.RemoveErrorListeners()
+	parser.RemoveErrorListeners()
+	errorListener := mongodb.NewMongoShellErrorListener()
+	lexer.AddErrorListener(errorListener)
+	parser.AddErrorListener(errorListener)
+
+	// Parse the input
+	tree := parser.Program()
+
+	result := &ParseResult{
+		Tree: tree,
+	}
+
+	// Convert errors
+	for _, err := range errorListener.Errors {
+		result.Errors = append(result.Errors, &base.SyntaxError{
+			Position: &storepb.Position{
+				Line:   int32(err.Line),
+				Column: int32(err.Column + 1), // Convert to 1-based column
+			},
+			RawMessage: err.Message,
+			Message:    err.Message,
+		})
+	}
+
+	// Extract statement information
+	if tree != nil {
+		for _, stmt := range tree.AllStatement() {
+			if stmt == nil {
+				continue
+			}
+			start := stmt.GetStart()
+			stop := stmt.GetStop()
+			if start == nil || stop == nil {
+				continue
+			}
+
+			info := StatementInfo{
+				StartOffset: start.GetStart(),
+				EndOffset:   stop.GetStop() + 1, // End is exclusive
+				StartLine:   start.GetLine(),
+				StartColumn: start.GetColumn(),
+				EndLine:     stop.GetLine(),
+				EndColumn:   stop.GetColumn() + len(stop.GetText()),
+			}
+			result.Statements = append(result.Statements, info)
+		}
+	}
+
+	return result
+}

--- a/backend/plugin/parser/mongodb/mongodb_test.go
+++ b/backend/plugin/parser/mongodb/mongodb_test.go
@@ -1,0 +1,217 @@
+package mongodb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestParseMongoShell(t *testing.T) {
+	testCases := []struct {
+		description     string
+		statement       string
+		wantStatements  int
+		wantHasErrors   bool
+		wantStartOffset int
+		wantEndOffset   int
+	}{
+		{
+			description:     "single find statement",
+			statement:       `db.collection.find({})`,
+			wantStatements:  1,
+			wantHasErrors:   false,
+			wantStartOffset: 0,
+			wantEndOffset:   22,
+		},
+		{
+			description:     "single find with filter",
+			statement:       `db.users.find({ name: "John" })`,
+			wantStatements:  1,
+			wantHasErrors:   false,
+			wantStartOffset: 0,
+			wantEndOffset:   31,
+		},
+		{
+			description:    "multiple statements",
+			statement:      "db.users.find({});\ndb.products.insertOne({ name: \"test\" })",
+			wantStatements: 2,
+			wantHasErrors:  false,
+		},
+		{
+			description:    "show databases command",
+			statement:      "show dbs",
+			wantStatements: 1,
+			wantHasErrors:  false,
+		},
+		{
+			description:    "show collections command",
+			statement:      "show collections",
+			wantStatements: 1,
+			wantHasErrors:  false,
+		},
+		{
+			description:    "aggregation pipeline",
+			statement:      `db.orders.aggregate([{ $match: { status: "A" } }, { $group: { _id: "$cust_id", total: { $sum: "$amount" } } }])`,
+			wantStatements: 1,
+			wantHasErrors:  false,
+		},
+		{
+			description:    "bracket notation for collection",
+			statement:      `db["my-collection"].find({})`,
+			wantStatements: 1,
+			wantHasErrors:  false,
+		},
+		{
+			description:    "method chaining",
+			statement:      `db.users.find({}).sort({ name: 1 }).limit(10)`,
+			wantStatements: 1,
+			wantHasErrors:  false,
+		},
+		{
+			description:   "syntax error - missing closing paren",
+			statement:     `db.collection.find({`,
+			wantHasErrors: true,
+		},
+		{
+			description:    "empty input",
+			statement:      "",
+			wantStatements: 0,
+			wantHasErrors:  false,
+		},
+		{
+			description:    "whitespace only",
+			statement:      "   \n\t  ",
+			wantStatements: 0,
+			wantHasErrors:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result := ParseMongoShell(tc.statement)
+			require.NotNil(t, result)
+
+			if !tc.wantHasErrors {
+				require.Len(t, result.Statements, tc.wantStatements, "statement count mismatch")
+				require.Empty(t, result.Errors, "expected no errors")
+			} else {
+				require.NotEmpty(t, result.Errors, "expected errors")
+			}
+
+			if tc.wantStatements > 0 && tc.wantStartOffset != 0 && tc.wantEndOffset != 0 {
+				require.Equal(t, tc.wantStartOffset, result.Statements[0].StartOffset)
+				require.Equal(t, tc.wantEndOffset, result.Statements[0].EndOffset)
+			}
+		})
+	}
+}
+
+func TestGetStatementRanges(t *testing.T) {
+	testCases := []struct {
+		description string
+		statement   string
+		wantRanges  int
+	}{
+		{
+			description: "single statement",
+			statement:   `db.collection.find({})`,
+			wantRanges:  1,
+		},
+		{
+			description: "multiple statements on separate lines",
+			statement:   "db.users.find({});\ndb.products.find({})",
+			wantRanges:  2,
+		},
+		{
+			description: "multiline statement",
+			statement: `db.users.aggregate([
+  { $match: { status: "A" } },
+  { $group: { _id: "$cust_id" } }
+])`,
+			wantRanges: 1,
+		},
+		{
+			description: "empty input",
+			statement:   "",
+			wantRanges:  0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			ranges, err := GetStatementRanges(context.Background(), base.StatementRangeContext{}, tc.statement)
+			require.NoError(t, err)
+			require.Len(t, ranges, tc.wantRanges)
+		})
+	}
+}
+
+func TestGetStatementRangesWithHindiCharacters(t *testing.T) {
+	// Test with Hindi characters - ANTLR returns character (rune) offsets, not byte offsets
+	// The Hindi collection name "मिलन-भेंट" has 9 runes but 25 bytes
+	statement := "db[\"मिलन-भेंट\"].find()\ndb.coll.find()"
+
+	ranges, err := GetStatementRanges(context.Background(), base.StatementRangeContext{}, statement)
+	require.NoError(t, err)
+	require.Len(t, ranges, 2)
+
+	// First statement: db["मिलन-भेंट"].find()
+	// Starts at line 0, char 0
+	// Ends at line 0, char 22 (after the closing paren)
+	require.Equal(t, uint32(0), ranges[0].Start.Line)
+	require.Equal(t, uint32(0), ranges[0].Start.Character)
+	require.Equal(t, uint32(0), ranges[0].End.Line)
+	require.Equal(t, uint32(22), ranges[0].End.Character)
+
+	// Second statement: db.coll.find()
+	// Starts at line 1, char 0
+	// Ends at line 1, char 14
+	require.Equal(t, uint32(1), ranges[1].Start.Line)
+	require.Equal(t, uint32(0), ranges[1].Start.Character)
+	require.Equal(t, uint32(1), ranges[1].End.Line)
+	require.Equal(t, uint32(14), ranges[1].End.Character)
+}
+
+func TestDiagnose(t *testing.T) {
+	testCases := []struct {
+		description        string
+		statement          string
+		wantHasDiagnostics bool
+	}{
+		{
+			description:        "valid statement",
+			statement:          `db.collection.find({})`,
+			wantHasDiagnostics: false,
+		},
+		{
+			description:        "syntax error - unclosed brace",
+			statement:          `db.collection.find({`,
+			wantHasDiagnostics: true,
+		},
+		{
+			description:        "syntax error - invalid token",
+			statement:          `db.collection.find(@@@@)`,
+			wantHasDiagnostics: true,
+		},
+		{
+			description:        "empty input",
+			statement:          "",
+			wantHasDiagnostics: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			diagnostics, err := Diagnose(context.Background(), base.DiagnoseContext{}, tc.statement)
+			require.NoError(t, err)
+			if tc.wantHasDiagnostics {
+				require.NotEmpty(t, diagnostics, "expected diagnostics")
+			} else {
+				require.Empty(t, diagnostics, "expected no diagnostics")
+			}
+		})
+	}
+}

--- a/backend/plugin/parser/mongodb/statement_ranges.go
+++ b/backend/plugin/parser/mongodb/statement_ranges.go
@@ -1,0 +1,96 @@
+package mongodb
+
+import (
+	"context"
+
+	lsp "github.com/bytebase/lsp-protocol"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func init() {
+	base.RegisterStatementRangesFunc(storepb.Engine_MONGODB, GetStatementRanges)
+}
+
+// GetStatementRanges returns the ranges of statements in the MongoDB shell script.
+func GetStatementRanges(_ context.Context, _ base.StatementRangeContext, statement string) ([]base.Range, error) {
+	parseResult := ParseMongoShell(statement)
+	if parseResult == nil {
+		return []base.Range{}, nil
+	}
+
+	// Build a mapping from character (rune) offset to LSP position.
+	// ANTLR returns character offsets, not byte offsets.
+	runePositions := buildRunePositionMap(statement)
+
+	var ranges []base.Range
+
+	for _, stmt := range parseResult.Statements {
+		if stmt.EndOffset <= stmt.StartOffset {
+			continue
+		}
+
+		startPosition := getPositionByRuneOffset(stmt.StartOffset, runePositions)
+		endPosition := getPositionByRuneOffset(stmt.EndOffset, runePositions)
+		if startPosition == nil || endPosition == nil {
+			continue
+		}
+
+		ranges = append(ranges, base.Range{
+			Start: *startPosition,
+			End:   *endPosition,
+		})
+	}
+
+	return ranges, nil
+}
+
+// runePosition stores the LSP position for a given rune offset.
+type runePosition struct {
+	line      uint32
+	character uint32 // UTF-16 code units
+}
+
+// buildRunePositionMap creates a mapping from rune offset to LSP position.
+func buildRunePositionMap(statement string) []runePosition {
+	runes := []rune(statement)
+	positions := make([]runePosition, len(runes)+1) // +1 for end position
+
+	var line uint32
+	var character uint32
+
+	for i, r := range runes {
+		positions[i] = runePosition{line: line, character: character}
+
+		if r == '\n' {
+			line++
+			character = 0
+		} else {
+			// Count UTF-16 code units
+			if r > 0xFFFF {
+				// Surrogate pair needed
+				character += 2
+			} else {
+				character++
+			}
+		}
+	}
+
+	// Position after the last character
+	positions[len(runes)] = runePosition{line: line, character: character}
+
+	return positions
+}
+
+// getPositionByRuneOffset converts a rune (character) offset to an LSP Position.
+func getPositionByRuneOffset(runeOffset int, positions []runePosition) *lsp.Position {
+	if runeOffset < 0 || runeOffset >= len(positions) {
+		return nil
+	}
+	pos := positions[runeOffset]
+	return &lsp.Position{
+		Line:      pos.line,
+		Character: pos.character,
+	}
+}

--- a/backend/server/ultimate.go
+++ b/backend/server/ultimate.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/cosmosdb"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/doris"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/elasticsearch"
+	_ "github.com/bytebase/bytebase/backend/plugin/parser/mongodb"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/partiql"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/pg"

--- a/frontend/src/components/MonacoEditor/lsp-client.ts
+++ b/frontend/src/components/MonacoEditor/lsp-client.ts
@@ -133,7 +133,8 @@ const createLanguageClient = async (): Promise<MonacoLanguageClient> => {
     name: "Bytebase Language Client",
     clientOptions: {
       // use a language id as a document selector
-      documentSelector: ["sql"],
+      // "sql" for SQL-based engines, "javascript" for MongoDB
+      documentSelector: ["sql", "javascript"],
       // Optimize initialization options
       initializationOptions: {
         // Request server to batch/throttle expensive operations


### PR DESCRIPTION
## Summary
- Add LSP features for MongoDB shell syntax including statement range detection and syntax diagnostics
- Register MongoDB parser in server imports using `github.com/bytebase/parser/mongodb`
- Add "javascript" to LSP client document selector since MongoDB uses JavaScript language ID
- Fix diagnostics to send empty array instead of null for proper marker clearing

## Test plan
- [x] Run `go test ./backend/plugin/parser/mongodb/...` - all tests pass
- [x] Run `golangci-lint` - no issues
- [x] Run `pnpm --dir frontend check` - passes
- [x] Manual testing with MongoDB instance in SQL editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)