### PR TITLE
fix(runner): fix race condition in auto rollout creation

### DIFF
--- a/backend/runner/plancheck/scheduler.go
+++ b/backend/runner/plancheck/scheduler.go
@@ -164,7 +164,8 @@ func (s *Scheduler) markPlanCheckRunDone(ctx context.Context, uid int, planUID i
 		return
 	}
 
-	// Auto-create rollout if plan checks pass
+	// Trigger approval finding after plan checks complete.
+	// The approval runner will trigger rollout creation after it finishes.
 	issue, err := s.store.GetIssue(ctx, &store.FindIssueMessage{PlanUID: &planUID})
 	if err != nil {
 		slog.Error("failed to get issue for approval check after plan check",
@@ -173,10 +174,8 @@ func (s *Scheduler) markPlanCheckRunDone(ctx context.Context, uid int, planUID i
 		return
 	}
 	if issue != nil && issue.PlanUID != nil {
-		// Trigger approval finding
+		// Trigger approval finding.
 		s.bus.ApprovalCheckChan <- int64(issue.UID)
-		// Trigger rollout creation (existing behavior)
-		s.bus.RolloutCreationChan <- planUID
 	}
 }
 


### PR DESCRIPTION
When plan checks completed, both ApprovalCheckChan and RolloutCreationChan were triggered simultaneously. This caused a race condition where the Rollout Creator would check if the issue was approved before the Approval Runner had finished setting ApprovalFindingDone=true, resulting in rollout creation being skipped.

Fix by having the Approval Runner trigger rollout creation after it completes approval finding, instead of triggering both channels in parallel from the plan check scheduler.

Fixes BYT-8790