### PR TITLE
fix: service account login broken after principal store split

### DIFF
--- a/backend/store/principal.go
+++ b/backend/store/principal.go
@@ -105,6 +105,7 @@ func (s *Store) GetPrincipalByEmail(ctx context.Context, email string) (*UserMes
 			ID:            sa.ID,
 			Email:         sa.Email,
 			Name:          sa.Name,
+			PasswordHash:  sa.PasswordHash,
 			Type:          storepb.PrincipalType_SERVICE_ACCOUNT,
 			MemberDeleted: sa.MemberDeleted,
 			MFAConfig:     &storepb.MFAConfig{},

--- a/frontend/src/components/User/Settings/ServiceAccountPanel.vue
+++ b/frontend/src/components/User/Settings/ServiceAccountPanel.vue
@@ -82,7 +82,7 @@
   <CreateServiceAccountDrawer
     v-if="state.showCreateDrawer"
     :service-account="state.editingServiceAccount"
-    :project="project.name"
+    :project="projectId ? project.name : undefined"
     @close="
       () => {
         state.showCreateDrawer = false;


### PR DESCRIPTION
## Summary
- The principal store refactor (#19072) omitted `password_hash` from `ServiceAccountMessage` struct, its SELECT query, and RETURNING clauses — causing all service account logins (e.g. via Terraform provider) to fail with "invalid email or password"
- Fix workspace-level service account creation showing `-1.service.bytebase.com` domain in the email dropdown by not passing the default project name when no `projectId` is set

## Test plan
- [x] Verified `bcrypt.CompareHashAndPassword` matches the stored hash against the service key
- [x] Confirmed service account login succeeds via Connect RPC after the fix
- [x] Confirmed Terraform provider can authenticate and create/update instances after the fix
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)