### PR TITLE
fix: use drawer for issue review on mobile and add max-width to drawers

### DIFF
--- a/frontend/src/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor/MarkdownEditor.vue
@@ -10,7 +10,7 @@
     >
       <NTab name="write" :tab="$t('issue.comment-editor.write')" />
       <NTab name="preview" :tab="$t('issue.comment-editor.preview')" />
-      <template v-if="state.activeTab === 'write'" #suffix>
+      <template v-if="!compact && state.activeTab === 'write'" #suffix>
         <div class="flex items-center justify-end">
           <NTooltip
             v-for="(toolbar, i) in toolbarItems"
@@ -129,6 +129,7 @@ const props = withDefaults(
     autofocus?: boolean;
     maxlength?: number;
     maxHeight?: number;
+    compact?: boolean;
   }>(),
   {
     maxHeight: 192,

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/components/IssueReviewForm.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/components/IssueReviewForm.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="flex flex-col gap-y-4">
+    <MarkdownEditor
+      mode="editor"
+      :content="comment"
+      :project="project"
+      :compact="compact"
+      :maxlength="65536"
+      @change="(val: string) => (comment = val)"
+    />
+
+    <NRadioGroup
+      v-model:value="selectedAction"
+      :disabled="loading"
+      class="flex! flex-col gap-y-2"
+    >
+      <NRadio value="COMMENT">
+        <div class="flex items-start gap-2">
+          <MessageCircleIcon class="w-4 h-4 mt-0.5 text-gray-600 shrink-0" />
+          <div class="flex flex-col">
+            <span class="font-medium">{{ $t("common.comment") }}</span>
+            <span class="text-control-light text-xs">
+              {{ $t("issue.review.comment-description") }}
+            </span>
+          </div>
+        </div>
+      </NRadio>
+
+      <NRadio v-if="canApprove" value="APPROVE">
+        <div class="flex items-start gap-2">
+          <CheckIcon class="w-4 h-4 mt-0.5 text-green-600 shrink-0" />
+          <div class="flex flex-col">
+            <span class="font-medium">{{ $t("common.approve") }}</span>
+            <span class="text-control-light text-xs">
+              {{ $t("issue.review.approve-description") }}
+            </span>
+          </div>
+        </div>
+      </NRadio>
+
+      <NRadio v-if="canReject" value="REJECT">
+        <div class="flex items-start gap-2">
+          <XIcon class="w-4 h-4 mt-0.5 text-red-600 shrink-0" />
+          <div class="flex flex-col">
+            <span class="font-medium">{{ $t("common.reject") }}</span>
+            <span class="text-control-light text-xs">
+              {{ $t("issue.review.reject-description") }}
+            </span>
+          </div>
+        </div>
+      </NRadio>
+    </NRadioGroup>
+
+    <NAlert
+      v-if="selectedAction === 'APPROVE' && planCheckWarnings.length > 0"
+      type="warning"
+      size="small"
+    >
+      <ul class="text-sm">
+        <li
+          v-for="(warning, index) in planCheckWarnings"
+          :key="index"
+          class="list-disc list-inside"
+        >
+          {{ warning }}
+        </li>
+      </ul>
+      <NCheckbox
+        v-model:checked="performActionAnyway"
+        class="mt-2"
+        size="small"
+      >
+        {{
+          $t("issue.action-anyway", {
+            action: $t("common.approve"),
+          })
+        }}
+      </NCheckbox>
+    </NAlert>
+
+    <div class="flex justify-end gap-x-2">
+      <NButton quaternary @click="$emit('cancel')">
+        {{ $t("common.cancel") }}
+      </NButton>
+      <NTooltip :disabled="confirmErrors.length === 0" placement="top">
+        <template #trigger>
+          <NButton
+            type="primary"
+            :disabled="confirmErrors.length > 0 || loading"
+            :loading="loading"
+            @click="
+              $emit('submit', {
+                action: selectedAction,
+                comment,
+              })
+            "
+          >
+            {{ $t("common.submit") }}
+          </NButton>
+        </template>
+        <template #default>
+          <ErrorList :errors="confirmErrors" />
+        </template>
+      </NTooltip>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { CheckIcon, MessageCircleIcon, XIcon } from "lucide-vue-next";
+import {
+  NAlert,
+  NButton,
+  NCheckbox,
+  NRadio,
+  NRadioGroup,
+  NTooltip,
+} from "naive-ui";
+import { computed, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import MarkdownEditor from "@/components/MarkdownEditor";
+import { ErrorList } from "@/components/Plan/components/common";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+
+export type ReviewAction = "APPROVE" | "REJECT" | "COMMENT";
+
+const props = defineProps<{
+  canApprove: boolean;
+  canReject: boolean;
+  loading: boolean;
+  compact?: boolean;
+  planCheckWarnings: string[];
+  project: Project;
+}>();
+
+defineEmits<{
+  (event: "submit", payload: { action: ReviewAction; comment: string }): void;
+  (event: "cancel"): void;
+}>();
+
+const { t } = useI18n();
+
+const comment = ref("");
+const selectedAction = ref<ReviewAction>("COMMENT");
+const performActionAnyway = ref(false);
+
+const confirmErrors = computed(() => {
+  const list: string[] = [];
+  if (selectedAction.value === "COMMENT" && !comment.value.trim()) {
+    list.push(
+      t(
+        "custom-approval.issue-review.disallow-approve-reason.x-field-is-required",
+        { field: t("common.comment") }
+      )
+    );
+  }
+  if (
+    selectedAction.value === "APPROVE" &&
+    props.planCheckWarnings.length > 0 &&
+    !performActionAnyway.value
+  ) {
+    list.push(...props.planCheckWarnings);
+  }
+  return list;
+});
+</script>

--- a/frontend/src/components/Plan/components/SpecDetailView/FailedTaskRunsSection.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/FailedTaskRunsSection.vue
@@ -36,7 +36,7 @@
     <Drawer v-model:show="taskRunDetailContext.show">
       <DrawerContent
         :title="$t('common.detail')"
-        style="width: calc(100vw - 14rem)"
+        class="max-w-[calc(100vw-2rem)]"
       >
         <TaskRunDetail
           v-if="taskRunDetailContext.taskRun && selectedDatabase"

--- a/frontend/src/components/RolloutV1/components/CommonDrawer.vue
+++ b/frontend/src/components/RolloutV1/components/CommonDrawer.vue
@@ -2,7 +2,7 @@
   <Drawer :show="show" :mask-closable="true" @close="$emit('close')">
     <DrawerContent
       :title="title"
-      class="relative overflow-hidden w-128 max-w-[100vw]"
+      class="relative overflow-hidden w-128 max-w-[calc(100vw-2rem)]"
     >
       <template #default>
         <slot />

--- a/frontend/src/components/RolloutV1/components/StageTimeline.vue
+++ b/frontend/src/components/RolloutV1/components/StageTimeline.vue
@@ -116,7 +116,7 @@
   <Drawer v-model:show="taskRunDetailContext.show">
     <DrawerContent
       :title="$t('common.detail')"
-      style="width: calc(100vw - 14rem)"
+      class="max-w-[calc(100vw-2rem)]"
     >
       <TaskRunDetail
         v-if="taskRunDetailContext.taskRun"

--- a/frontend/src/components/RolloutV1/components/TaskRolloutActionPanel.vue
+++ b/frontend/src/components/RolloutV1/components/TaskRolloutActionPanel.vue
@@ -93,7 +93,7 @@
           <NRadioGroup
             :size="'large'"
             :value="runTimeInMS === undefined ? 'immediate' : 'scheduled'"
-            class="flex! flex-row gap-x-4"
+            class="flex! flex-col sm:flex-row gap-2 sm:gap-4"
             @update:value="handleExecutionModeChange"
           >
             <NRadio value="immediate">

--- a/frontend/src/components/RolloutV1/components/TaskRunRollbackDrawer.vue
+++ b/frontend/src/components/RolloutV1/components/TaskRunRollbackDrawer.vue
@@ -1,6 +1,10 @@
 <template>
   <Drawer v-model:show="show" :width="720" placement="right">
-    <DrawerContent :title="$t('common.rollback')" :closable="!state.loading">
+    <DrawerContent
+      :title="$t('common.rollback')"
+      :closable="!state.loading"
+      class="max-w-[calc(100vw-2rem)]"
+    >
       <div class="flex flex-col gap-y-4">
         <!-- Steps indicator -->
         <NSteps :current="currentStep" size="small">

--- a/frontend/src/components/RolloutV1/components/TaskRunTable.vue
+++ b/frontend/src/components/RolloutV1/components/TaskRunTable.vue
@@ -11,7 +11,7 @@
   <Drawer v-model:show="taskRunDetailContext.show">
     <DrawerContent
       :title="$t('common.detail')"
-      style="width: calc(100vw - 14rem)"
+      class="max-w-[calc(100vw-2rem)]"
     >
       <TaskRunDetail
         v-if="taskRunDetailContext.taskRun"


### PR DESCRIPTION
Part of BYT-8782

* IssueReviewButton now renders NPopover on desktop and Drawer on mobile, preventing viewport overflow. 
* Extract self-contained IssueReviewForm component that owns its own state and validation. 
* Add compact prop to MarkdownEditor to hide toolbar on mobile. 
* Apply consistent max-w-[calc(100vw-2rem)] to drawer content across Plan and RolloutV1.