### PR TITLE
fix: improve database table responsiveness on mobile

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueTableV1.vue
+++ b/frontend/src/components/IssueV1/components/IssueTableV1.vue
@@ -58,6 +58,7 @@ import {
   getIssueRoute,
   humanizeTs,
   projectOfIssue,
+  TailwindBreakpoints,
 } from "@/utils";
 import IssueLabelSelector, {
   getValidIssueLabels,
@@ -98,7 +99,7 @@ const tableRef = ref<HTMLDivElement>();
 const isTableInViewport = useElementVisibilityInScrollParent(tableRef);
 const { width: tableWidth } = useElementSize(tableRef);
 const showExtendedColumns = computed(() => {
-  return tableWidth.value > 800;
+  return tableWidth.value > TailwindBreakpoints.md;
 });
 
 const sortedIssueList = computed(() => {

--- a/frontend/src/utils/css.ts
+++ b/frontend/src/utils/css.ts
@@ -3,6 +3,16 @@ import { computed, type Raw, ref, unref, watchEffect } from "vue";
 import type { MaybeRef } from "@/types";
 import type { VueClass } from "./types";
 
+// Tailwind CSS default breakpoints
+// https://tailwindcss.com/docs/responsive-design
+export const TailwindBreakpoints = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  "2xl": 1536,
+} as const;
+
 export const rgbToHex = (r: number, g: number, b: number) => {
   const hex = [r, g, b]
     .map((decimal) => decimal.toString(16).padStart(2, "0"))


### PR DESCRIPTION
Part of BYT-8782

Hide secondary columns (Release, Project, Address, Labels) when container width is below the md breakpoint, and add scroll-x with minWidth on remaining columns to prevent header text wrapping.

Also extract TailwindBreakpoints constant in utils/css.ts and migrate IssueTableV1's hardcoded 800 to use it.