### PR TITLE
fix: add migration to fix open issues with hasRollout set to true

### DIFF
--- a/backend/migrator/migration/3.14/0034##fix_open_issue_with_has_rollout.sql
+++ b/backend/migrator/migration/3.14/0034##fix_open_issue_with_has_rollout.sql
@@ -1,0 +1,21 @@
+-- Fix legacy data where issue is not DONE but plan.hasRollout is true.
+-- This inconsistency was caused by a race condition in auto rollout creation (BYT-8790).
+--
+-- When a rollout is created, the expected sequence is:
+--   1. Create tasks for the plan
+--   2. Set plan.config.hasRollout = true
+--   3. Set issue.status = DONE
+-- Due to a race condition, step 3 could be skipped.
+
+-- hasRollout is true, tasks exist, but issue is OPEN
+-- → The rollout was created, so mark the issue as DONE.
+UPDATE issue
+SET status = 'DONE'
+WHERE status = 'OPEN'
+  AND type = 'DATABASE_CHANGE'
+  AND plan_id IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM plan
+    WHERE plan.id = issue.plan_id
+      AND plan.config->>'hasRollout' = 'true'
+  );


### PR DESCRIPTION
Due to a race condition in auto rollout creation (BYT-8790), some issues remain OPEN even though their plan has hasRollout=true and the rollout was successfully created. This migration marks those DATABASE_CHANGE issues as DONE.