### PR TITLE
fix(db): improve error message when pg_table_size returns NULL due to insufficient permissions

### DIFF
--- a/backend/plugin/db/pg/sync.go
+++ b/backend/plugin/db/pg/sync.go
@@ -581,10 +581,16 @@ func getTables(
 		table := &storepb.TableMetadata{}
 		var oid int
 		var schemaName string
+		var dataSize, indexSize sql.NullInt64
 		var comment sql.NullString
-		if err := rows.Scan(&oid, &schemaName, &table.Name, &table.DataSize, &table.IndexSize, &table.RowCount, &comment, &table.Owner); err != nil {
+		if err := rows.Scan(&oid, &schemaName, &table.Name, &dataSize, &indexSize, &table.RowCount, &comment, &table.Owner); err != nil {
 			return nil, nil, nil, err
 		}
+		if !dataSize.Valid || !indexSize.Valid {
+			return nil, nil, nil, errors.Errorf("pg_table_size or pg_indexes_size returned NULL for table %q.%q — this typically means the database user lacks permission; grant the pg_read_all_stats role to fix this", schemaName, table.Name)
+		}
+		table.DataSize = dataSize.Int64
+		table.IndexSize = indexSize.Int64
 		if pgparser.IsSystemTable(table.Name) {
 			continue
 		}


### PR DESCRIPTION
## Summary

- On PostgreSQL 16+, `pg_table_size()` and `pg_indexes_size()` return NULL instead of raising an error when the connected user lacks permission on a table. This caused a cryptic scan error: `converting NULL to int64 is unsupported`.
- Scan into `sql.NullInt64` and return an actionable error message that identifies the specific table and tells the user to grant `pg_read_all_stats`.

**Before:**
```
failed to get tables from database "db": sql: Scan error on column index 3, name "pg_table_size": converting NULL to int64 is unsupported
```

**After:**
```
failed to get tables from database "db": pg_table_size or pg_indexes_size returned NULL for table "schema"."table" — this typically means the database user lacks permission; grant the pg_read_all_stats role to fix this
```

## Test plan

- [ ] Connect to a PostgreSQL 16+ database with a user that does NOT have `pg_read_all_stats` and verify the new error message appears
- [ ] Connect with a user that has `pg_read_all_stats` and verify sync works normally