### PR TITLE
fix(frontend): simplify rollout link visibility to match stages section

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/Actions/RolloutReadyLink.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/RolloutReadyLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <RouterLink v-if="rollout" :to="rolloutRoute">
+  <RouterLink :to="rolloutRoute">
     <NButton icon-placement="right" quaternary>
       <TaskStatus :status="rolloutStatus" size="tiny" />
       <span class="mx-1">{{ $t("common.rollout") }}</span>
@@ -20,7 +20,7 @@ import TaskStatus from "@/components/Rollout/kits/TaskStatus.vue";
 import { PROJECT_V1_ROUTE_PLAN_ROLLOUT } from "@/router/dashboard/projectV1";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import {
-  extractPlanUIDFromRolloutName,
+  extractPlanUID,
   extractProjectResourceName,
   getRolloutStatus,
 } from "@/utils";
@@ -32,16 +32,13 @@ const rolloutStatus = computed(() => {
   return getRolloutStatus(rollout.value);
 });
 
-const planID = computed(() => {
-  if (!rollout.value?.name) return "";
-  return extractPlanUIDFromRolloutName(rollout.value.name);
-});
+const planID = computed(() => extractPlanUID(plan.value.name));
 
 const rolloutRoute = computed(() => ({
   name: PROJECT_V1_ROUTE_PLAN_ROLLOUT,
   params: {
     projectId: extractProjectResourceName(plan.value.name),
-    planId: extractPlanUIDFromRolloutName(rollout.value?.name ?? ""),
+    planId: planID.value,
   },
 }));
 </script>

--- a/frontend/src/components/Plan/logic/useRolloutReadyLink.ts
+++ b/frontend/src/components/Plan/logic/useRolloutReadyLink.ts
@@ -1,44 +1,18 @@
 import { computed } from "vue";
-import { useRoute } from "vue-router";
-import {
-  PROJECT_V1_ROUTE_PLAN_ROLLOUT,
-  PROJECT_V1_ROUTE_PLAN_ROLLOUT_STAGE,
-  PROJECT_V1_ROUTE_PLAN_ROLLOUT_TASK,
-} from "@/router/dashboard/projectV1";
 import { Task_Type } from "@/types/proto-es/v1/rollout_service_pb";
 import { usePlanContext } from "./context";
 
 /**
  * Composable that determines whether the "Rollout" link should be shown.
  * This link appears when:
- * - User is not already on the rollout tab
- * - Plan has a rollout (plan.hasRollout is true)
+ * - Rollout has been fetched (rollout ref is defined)
  * - Rollout does not contain database creation/export tasks
  */
 export const useRolloutReadyLink = () => {
-  const route = useRoute();
-  const { plan, rollout } = usePlanContext();
-
-  // Defined inside the function to avoid circular dependency issues
-  // when the module is imported before the router is initialized
-  const ROLLOUT_ROUTES = new Set([
-    PROJECT_V1_ROUTE_PLAN_ROLLOUT,
-    PROJECT_V1_ROUTE_PLAN_ROLLOUT_STAGE,
-    PROJECT_V1_ROUTE_PLAN_ROLLOUT_TASK,
-  ]);
-
-  const isOnRolloutTab = computed(() => {
-    return ROLLOUT_ROUTES.has(route.name as string);
-  });
+  const { rollout } = usePlanContext();
 
   const shouldShow = computed(() => {
-    // Hide if on rollout tab
-    if (isOnRolloutTab.value) {
-      return false;
-    }
-
-    // Show if plan has rollout
-    if (!plan.value.hasRollout || !rollout.value) {
+    if (!rollout.value) {
       return false;
     }
 


### PR DESCRIPTION
Remove redundant checks from useRolloutReadyLink:
- Remove plan.hasRollout check (redundant with rollout.value check)
- Remove isOnRolloutTab check (dead code, rollout routes use RolloutLayout)
- Remove redundant v-if="rollout" in RolloutReadyLink component