### PR TITLE
fix: delete all SYSTEM_BOT principals in migration

### DIFF
--- a/backend/migrator/migration/3.15/0006##remove_system_bot.sql
+++ b/backend/migrator/migration/3.15/0006##remove_system_bot.sql
@@ -38,8 +38,8 @@ BEGIN
   UPDATE release SET creator = fallback_user WHERE creator = 'support@bytebase.com';
 END $$;
 
--- Delete the SystemBot principal row
-DELETE FROM principal WHERE id = 1 AND email = 'support@bytebase.com';
+-- Delete all SYSTEM_BOT principal rows (support@bytebase.com and allUsers)
+DELETE FROM principal WHERE type = 'SYSTEM_BOT';
 
 -- Remove SYSTEM_BOT from principal type constraint
 ALTER TABLE principal DROP CONSTRAINT principal_type_check;


### PR DESCRIPTION
The migration only deleted the principal with id=1 and email='support@bytebase.com', but databases seeded by older versions also have an 'allUsers' principal with type='SYSTEM_BOT'. This surviving row violates the new principal_type_check constraint.

Failed logs: 

```
time=2026-02-02T10:21:12.398+08:00 level=ERROR source=cmd/root.go:232 msg="Cannot new server" error="migration 3.15.6 failed\nStatement: -- Make task_run.creator nullable (for system-generated task runs)\nALTER TABLE task_run ALTER COLUMN...\nUser: postgres\nDatabase: bbdev\nError: ERROR: check constraint \"principal_type_check\" of relation \"principal\" is violated by some row (SQLSTATE 23514)\nSQLSTATE: \ngithub.com/bytebase/bytebase/backend/migrator.executeMigration\n\t/Users/steven/Projects/bytebase/bb/backend/migrator/migrator.go:218\ngithub.com/bytebase/bytebase/backend/migrator.MigrateSchema\n\t/Users/steven/Projects/bytebase/bb/backend/migrator/migrator.go:120\ngithub.com/bytebase/bytebase/backend/server.NewServer\n\t/Users/steven/Projects/bytebase/bb/backend/server/server.go:150\ngithub.com/bytebase/bytebase/backend/bin/server/cmd.start\n\t/Users/steven/Projects/bytebase/bb/backend/bin/server/cmd/root.go:225\ngithub.com/bytebase/bytebase/backend/bin/server/cmd.init.func1\n\t/Users/steven/Projects/bytebase/bb/backend/bin/server/cmd/root.go:79\ngithub.com/spf13/cobra.(*Command).execute\n\t/Users/steven/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1019\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/Users/steven/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148\ngithub.com/spf13/cobra.(*Command).Execute\n\t/Users/steven/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071\ngithub.com/bytebase/bytebase/backend/bin/server/cmd.Execute\n\t/Users/steven/Projects/bytebase/bb/backend/bin/server/cmd/root.go:88\nmain.main\n\t/Users/steven/Projects/bytebase/bb/backend/bin/server/main.go:11\nruntime.main\n\t/opt/homebrew/Cellar/go/1.25.6/libexec/src/runtime/proc.go:285\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.25.6/libexec/src/runtime/asm_arm64.s:1268\nfailed to migrate schema\ngithub.com/bytebase/bytebase/backend/server.NewServer\n\t/Users/steven/Projects/bytebase/bb/backend/server/server.go:152\ngithub.com/bytebase/bytebase/backend/bin/server/cmd.start\n\t/Users/steven/Projects/bytebase/bb/backend/bin/server/cmd/root.go:225\ngithub.com/bytebase/bytebase/backend/bin/server/cmd.init.func1\n\t/Users/steven/Projects/bytebase/bb/backend/bin/server/cmd/root.go:79\ngithub.com/spf13/cobra.(*Command).execute\n\t/Users/steven/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1019\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/Users/steven/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148\ngithub.com/spf13/cobra.(*Command).Execute\n\t/Users/steven/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071\ngithub.com/bytebase/bytebase/backend/bin/server/cmd.Execute\n\t/Users/steven/Projects/bytebase/bb/backend/bin/server/cmd/root.go:88\nmain.main\n\t/Users/steven/Projects/bytebase/bb/backend/bin/server/main.go:11\nruntime.main\n\t/opt/homebrew/Cellar/go/1.25.6/libexec/src/runtime/proc.go:285\nruntime.goexit\n\t/opt/homebrew/Cellar/go/1.25.6/libexec/src/runtime/asm_arm64.s:1268"

```