### PR TITLE
chore: add display limit with expand/collapse to DatabaseExportView

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/ExecutionHistorySection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/ExecutionHistorySection.vue
@@ -10,7 +10,23 @@
 
       <!-- Task Runs Table -->
       <div v-if="allTaskRuns.length > 0">
-        <TaskRunTable :task-runs="allTaskRuns" :show-database-column="true" />
+        <TaskRunTable
+          :task-runs="visibleTaskRuns"
+          :show-database-column="true"
+          :virtual-scroll="expanded && allTaskRuns.length > VIRTUAL_SCROLL_THRESHOLD"
+          :max-height="expanded && allTaskRuns.length > VIRTUAL_SCROLL_THRESHOLD ? '80vh' : undefined"
+        />
+        <div v-if="hasMore" class="flex justify-center mt-2">
+          <NButton quaternary size="small" @click="expanded = !expanded">
+            <template v-if="expanded">
+              {{ $t("common.collapse") }}
+            </template>
+            <template v-else>
+              {{ $t("common.show-more") }}
+              ({{ remainingCount }} {{ $t("common.remaining") }})
+            </template>
+          </NButton>
+        </div>
       </div>
 
       <!-- No task runs message -->
@@ -22,11 +38,13 @@
 </template>
 
 <script lang="ts" setup>
+import { NButton } from "naive-ui";
 import { computed } from "vue";
 import TaskRunTable from "@/components/RolloutV1/components/TaskRunTable.vue";
 import type { TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
 import { extractTaskUID } from "@/utils";
 import { usePlanContext } from "../../../logic";
+import { useExpandableList, VIRTUAL_SCROLL_THRESHOLD } from ".";
 
 const { plan, rollout, taskRuns } = usePlanContext();
 
@@ -64,4 +82,11 @@ const allTaskRuns = computed((): TaskRun[] => {
     exportTaskUIDs.has(extractTaskUID(taskRun.name))
   );
 });
+
+const {
+  expanded,
+  hasMore,
+  visibleItems: visibleTaskRuns,
+  remainingCount,
+} = useExpandableList(allTaskRuns);
 </script>

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/TasksSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/TasksSection.vue
@@ -4,9 +4,12 @@
       <h3 class="text-base font-medium">
         {{ $t("common.task", tasks.length) }}
       </h3>
-      <div class="flex flex-wrap gap-2">
+      <div
+        class="flex flex-wrap gap-2"
+        :class="expanded && hasMore ? 'max-h-96 overflow-y-auto' : ''"
+      >
         <div
-          v-for="task in tasks"
+          v-for="task in visibleTasks"
           :key="task.name"
           class="inline-flex items-center gap-2 px-2 py-1.5 border rounded-sm min-w-0"
         >
@@ -25,6 +28,19 @@
             @action-confirmed="handleActionConfirmed"
           />
         </div>
+        <button
+          v-if="hasMore"
+          class="text-sm px-2 text-accent cursor-pointer"
+          @click="expanded = !expanded"
+        >
+          <template v-if="expanded">
+            {{ $t("common.collapse") }}
+          </template>
+          <template v-else>
+            {{ $t("common.show-more") }}
+            ({{ remainingCount }} {{ $t("common.remaining") }})
+          </template>
+        </button>
       </div>
     </template>
     <div v-else class="text-center text-control-light py-8">
@@ -41,6 +57,7 @@ import TaskStatusActions from "@/components/RolloutV1/components/TaskStatusActio
 import { taskRunNamePrefix, useDatabaseV1Store } from "@/store";
 import type { Task } from "@/types/proto-es/v1/rollout_service_pb";
 import { usePlanContextWithRollout } from "../../../logic";
+import { useExpandableList } from ".";
 
 const { plan, rollout, taskRuns, events } = usePlanContextWithRollout();
 const dbStore = useDatabaseV1Store();
@@ -55,6 +72,13 @@ const tasks = computed(() => {
     .flatMap((stage) => stage.tasks)
     .filter((task) => task.specId === exportDataSpec.id);
 });
+
+const {
+  expanded,
+  hasMore,
+  visibleItems: visibleTasks,
+  remainingCount,
+} = useExpandableList(tasks);
 
 // Get task runs for a specific task
 const getTaskRunsForTask = (task: Task) => {

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/index.ts
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView/index.ts
@@ -1,3 +1,21 @@
+import { type Ref, computed, ref } from "vue";
+
+const DEFAULT_DISPLAY_COUNT = 10;
+export const VIRTUAL_SCROLL_THRESHOLD = 50;
+
+export function useExpandableList<T>(items: Ref<T[]>) {
+  const expanded = ref(false);
+  const hasMore = computed(() => items.value.length > DEFAULT_DISPLAY_COUNT);
+  const visibleItems = computed(() => {
+    if (expanded.value || !hasMore.value) return items.value;
+    return items.value.slice(0, DEFAULT_DISPLAY_COUNT);
+  });
+  const remainingCount = computed(
+    () => items.value.length - DEFAULT_DISPLAY_COUNT
+  );
+  return { expanded, hasMore, visibleItems, remainingCount };
+}
+
 export { default as ExecutionHistorySection } from "./ExecutionHistorySection.vue";
 export { default as LimitsSection } from "./LimitsSection.vue";
 export { default as OptionsSection } from "./OptionsSection.vue";

--- a/frontend/src/components/RolloutV1/components/TaskRunTable.vue
+++ b/frontend/src/components/RolloutV1/components/TaskRunTable.vue
@@ -6,6 +6,8 @@
     :data="sortedTaskRuns"
     :striped="true"
     :bordered="true"
+    :virtual-scroll="virtualScroll"
+    :max-height="maxHeight"
   />
 
   <Drawer v-model:show="taskRunDetailContext.show">
@@ -50,6 +52,8 @@ import TaskRunStatusIcon from "./TaskRunStatusIcon.vue";
 const props = defineProps<{
   taskRuns: TaskRun[];
   showDatabaseColumn?: boolean; // Whether to show database column
+  virtualScroll?: boolean;
+  maxHeight?: string | number;
 }>();
 
 // Sort task runs by creation time descending (newest first)


### PR DESCRIPTION
Close BYT-8828. Show only the first 10 tasks and task runs by default with a "Show more" button to expand. Tasks button is inline with task cards; execution history uses virtual scroll for large datasets (>50 items).