### PR TITLE
chore: migration drop sheet table

### DIFF
--- a/backend/migrator/migration/3.15/0007##drop_sheet_table.sql
+++ b/backend/migrator/migration/3.15/0007##drop_sheet_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE sheet;

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -183,22 +183,6 @@ CREATE TABLE sheet_blob (
 	content text NOT NULL
 );
 
--- sheet table stores general statements.
-CREATE TABLE sheet (
-    id serial PRIMARY KEY,
-    creator text NOT NULL REFERENCES principal(email) ON UPDATE CASCADE,
-    created_at timestamptz NOT NULL DEFAULT now(),
-    project text NOT NULL REFERENCES project(resource_id),
-    name text NOT NULL,
-    sha256 bytea NOT NULL,
-    -- Stored as SheetPayload (proto/store/store/sheet.proto)
-    payload jsonb NOT NULL DEFAULT '{}'
-);
-
-CREATE INDEX idx_sheet_project ON sheet(project);
-
-ALTER SEQUENCE sheet_id_seq RESTART WITH 101;
-
 -- plan table stores the plan for a project
 CREATE TABLE plan (
     id bigserial PRIMARY KEY,

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -12,8 +12,8 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.15.6"), *files[len(files)-1].version)
-	require.Equal(t, "migration/3.15/0006##remove_system_bot.sql", files[len(files)-1].path)
+	require.Equal(t, semver.MustParse("3.15.7"), *files[len(files)-1].version)
+	require.Equal(t, "migration/3.15/0007##drop_sheet_table.sql", files[len(files)-1].path)
 }
 
 func TestVersionUnique(t *testing.T) {


### PR DESCRIPTION
Release 3.15.7 migration: drops the unused sheet table.