### PR TITLE
fix: use stable localStorage key for revision table page size

### DIFF
--- a/frontend/src/components/Database/DatabaseRevisionPanel.vue
+++ b/frontend/src/components/Database/DatabaseRevisionPanel.vue
@@ -7,8 +7,8 @@
       </NButton>
     </div>
     <PagedTable
-      :key="pagedRevisionTableSessionKey"
-      :session-key="pagedRevisionTableSessionKey"
+      ref="revisionPagedTable"
+      :session-key="`bb.paged-revision-table.${database.name}`"
       :fetch-list="fetchRevisionList"
     >
       <template #table="{ list, loading }">
@@ -35,19 +35,20 @@
 import { create } from "@bufbuild/protobuf";
 import { NButton } from "naive-ui";
 import { ref } from "vue";
+import type { ComponentExposed } from "vue-component-type-helpers";
 import { RevisionDataTable } from "@/components/Revision";
 import CreateRevisionDrawer from "@/components/Revision/CreateRevisionDrawer.vue";
 import PagedTable from "@/components/v2/Model/PagedTable.vue";
 import { revisionServiceClientConnect } from "@/connect";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
 import { ListRevisionsRequestSchema } from "@/types/proto-es/v1/revision_service_pb";
-import { useDatabaseDetailContext } from "./context";
 
 const props = defineProps<{
   database: Database;
 }>();
 
-const { pagedRevisionTableSessionKey } = useDatabaseDetailContext();
+const revisionPagedTable = ref<ComponentExposed<typeof PagedTable<Revision>>>();
 const showCreateRevisionDrawer = ref(false);
 
 const fetchRevisionList = async ({
@@ -72,10 +73,10 @@ const fetchRevisionList = async ({
 
 const handleRevisionCreated = () => {
   showCreateRevisionDrawer.value = false;
-  refreshList();
+  revisionPagedTable.value?.refresh();
 };
 
 const refreshList = () => {
-  pagedRevisionTableSessionKey.value = `bb.paged-revision-table.${Date.now()}`;
+  revisionPagedTable.value?.refresh();
 };
 </script>

--- a/frontend/src/components/Database/context.ts
+++ b/frontend/src/components/Database/context.ts
@@ -1,5 +1,5 @@
 import type { InjectionKey, Ref } from "vue";
-import { computed, inject, provide, ref } from "vue";
+import { computed, inject, provide } from "vue";
 import { useDatabaseV1ByName } from "@/store";
 import {
   databaseNamePrefix,
@@ -11,7 +11,6 @@ import { getInstanceResource, instanceV1HasAlterSchema } from "@/utils";
 
 export type DatabaseDetailContext = {
   database: Ref<Database>;
-  pagedRevisionTableSessionKey: Ref<string>;
   allowAlterSchema: Ref<boolean>;
   isDefaultProject: Ref<boolean>;
 };
@@ -35,10 +34,6 @@ export const provideDatabaseDetailContext = (
     )
   );
 
-  const pagedRevisionTableSessionKey = ref(
-    `bb.paged-revision-table.${Date.now()}`
-  );
-
   const isDefaultProject = computed(
     () => database.value.project === DEFAULT_PROJECT_NAME
   );
@@ -49,7 +44,6 @@ export const provideDatabaseDetailContext = (
 
   const context: DatabaseDetailContext = {
     database,
-    pagedRevisionTableSessionKey,
     allowAlterSchema,
     isDefaultProject,
   };


### PR DESCRIPTION
Part of BYT-8770

The revision table used `bb.paged-revision-table.${Date.now()}` as its PagedTable session key, creating a new localStorage entry on every page visit that was never cleaned up. Replace with a stable key `bb.paged-revision-table.${database.name}` and use a template ref to call refresh() directly, matching the pattern used by the changelog panel and all other PagedTable consumers.