### PR TITLE
fix: correct Learn more link for online migration

### DIFF
--- a/frontend/src/components/Plan/components/Configuration/GhostSection/GhostSwitch.vue
+++ b/frontend/src/components/Plan/components/Configuration/GhostSection/GhostSwitch.vue
@@ -18,7 +18,7 @@
       <ErrorList v-if="errors.length > 0" :errors="errors" class="mt-2" />
       <LearnMoreLink
         v-if="databasesNotMeetingRequirements.length > 0"
-        :url="'https://docs.bytebase.com/change-database/rollback-data-changes?source=console'"
+        :url="'https://docs.bytebase.com/change-database/online-schema-migration-for-mysql?source=console'"
         color="light"
         class="mt-1 text-sm"
       />


### PR DESCRIPTION
## Summary
The "Learn more" link in the Ghost (online migration) switch component was incorrectly pointing to the data rollback documentation URL (`rollback-data-changes`). This PR corrects it to point to the online schema migration documentation.

## Changes
- Changed the URL in `GhostSwitch.vue` from `/change-database/rollback-data-changes` to `/change-database/online-schema-migration-for-mysql`

## Related Issue
Fixes: BYT-8832