### PR TITLE
feat: make builtin SQL review rule level configurable

### DIFF
--- a/backend/plugin/advisor/sql_review.go
+++ b/backend/plugin/advisor/sql_review.go
@@ -103,8 +103,16 @@ func SQLReviewCheck(
 	builtinOnly := len(ruleList) == 0
 
 	if !checkContext.NoAppendBuiltin {
-		// Append builtin rules to the rule list.
-		ruleList = append(ruleList, GetBuiltinRules(checkContext.DBType)...)
+		// Append builtin rules only if the user hasn't overridden them in their config.
+		userRuleTypes := make(map[storepb.SQLReviewRule_Type]bool, len(ruleList))
+		for _, r := range ruleList {
+			userRuleTypes[r.Type] = true
+		}
+		for _, r := range GetBuiltinRules(checkContext.DBType) {
+			if !userRuleTypes[r.Type] {
+				ruleList = append(ruleList, r)
+			}
+		}
 	}
 
 	if asts == nil || len(ruleList) == 0 {

--- a/backend/plugin/advisor/template_test.go
+++ b/backend/plugin/advisor/template_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-
-	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
 
 // TestTemplateAdvisorRegistrations validates that all SQL review rules in frontend templates
@@ -371,6 +369,6 @@ func buildRuleTypeMapping() map[string]string {
 		"SYSTEM_FUNCTION_DISALLOW_CREATE":                     "storepb.SQLReviewRule_SYSTEM_FUNCTION_DISALLOW_CREATE",
 		"SYSTEM_FUNCTION_DISALLOWED_LIST":                     "storepb.SQLReviewRule_SYSTEM_FUNCTION_DISALLOWED_LIST",
 		"ADVICE_ONLINE_MIGRATION":                             "storepb.SQLReviewRule_ADVICE_ONLINE_MIGRATION",
-		"BUILTIN_PRIOR_BACKUP_CHECK":                          storepb.SQLReviewRule_BUILTIN_PRIOR_BACKUP_CHECK.String(),
+		"BUILTIN_PRIOR_BACKUP_CHECK":                          "storepb.SQLReviewRule_BUILTIN_PRIOR_BACKUP_CHECK",
 	}
 }

--- a/frontend/src/components/SQLReview/SQLReviewCreation.vue
+++ b/frontend/src/components/SQLReview/SQLReviewCreation.vue
@@ -66,6 +66,8 @@ import {
   TEMPLATE_LIST_V2 as builtInTemplateList,
   convertRuleMapToPolicyRuleList,
   getRuleMapByEngine,
+  isBuiltinRule,
+  withBuiltinRules,
 } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import { SQLReviewRule_Type } from "@/types/proto-es/v1/review_config_service_pb";
@@ -128,7 +130,9 @@ const state = reactive<LocalState>({
   name: props.name || t("sql-review.create.basic-info.display-name-default"),
   resourceId: props.policy ? getReviewConfigId(props.policy.id) : "",
   attachedResources: props.selectedResources,
-  selectedRuleMapByEngine: getRuleMapByEngine(props.selectedRuleList),
+  selectedRuleMapByEngine: withBuiltinRules(
+    getRuleMapByEngine(props.selectedRuleList)
+  ),
   selectedTemplateId: props.policy
     ? getTemplateId(props.policy)
     : builtInTemplateList[0]?.id,
@@ -145,7 +149,9 @@ const onTemplateApply = (template: SQLReviewPolicyTemplateV2 | undefined) => {
   state.selectedTemplateId = template.id;
   state.pendingApplyTemplate = undefined;
 
-  state.selectedRuleMapByEngine = getRuleMapByEngine(template.ruleList);
+  state.selectedRuleMapByEngine = withBuiltinRules(
+    getRuleMapByEngine(template.ruleList)
+  );
 };
 
 const onCancel = (newPolicy: SQLReviewPolicy | undefined = undefined) => {
@@ -257,6 +263,9 @@ const tryApplyTemplate = (template: SQLReviewPolicyTemplateV2) => {
 };
 
 const removeRole = (rule: RuleTemplateV2) => {
+  if (isBuiltinRule(rule)) {
+    return;
+  }
   state.selectedRuleMapByEngine.get(rule.engine)?.delete(rule.type);
   if (state.selectedRuleMapByEngine.get(rule.engine)?.size === 0) {
     state.selectedRuleMapByEngine.delete(rule.engine);

--- a/frontend/src/components/SQLReview/components/SQLReviewRulesSelectPanel.vue
+++ b/frontend/src/components/SQLReview/components/SQLReviewRulesSelectPanel.vue
@@ -48,7 +48,7 @@ import { Drawer, DrawerContent } from "@/components/v2";
 import { type Engine } from "@/types/proto-es/v1/common_pb";
 import type { SQLReviewRule_Type } from "@/types/proto-es/v1/review_config_service_pb";
 import type { RuleTemplateV2 } from "@/types/sqlReview";
-import { ruleTemplateMapV2 } from "@/types/sqlReview";
+import { isBuiltinRule, ruleTemplateMapV2 } from "@/types/sqlReview";
 import SQLReviewTabsByEngine from "./SQLReviewTabsByEngine.vue";
 import SQLRuleTableWithFilter from "./SQLRuleTableWithFilter.vue";
 import { getRuleKey } from "./utils";
@@ -99,6 +99,10 @@ const onSelectedRuleKeysUpdateForEngine = (engine: Engine, keys: string[]) => {
     const [engineStr, ruleKey] = oldKey.split(":");
     const engineNum = parseInt(engineStr) as Engine;
     const ruleType = parseInt(ruleKey) as SQLReviewRule_Type;
+    const template = ruleTemplateMapV2.get(engineNum)?.get(ruleType);
+    if (template && isBuiltinRule(template)) {
+      continue;
+    }
     const rule = props.selectedRuleMap.get(engineNum)?.get(ruleType);
     if (rule) {
       emit("rule-remove", rule);

--- a/frontend/src/components/SQLReview/components/SQLRuleTable.vue
+++ b/frontend/src/components/SQLReview/components/SQLRuleTable.vue
@@ -61,7 +61,7 @@
                 @click="setActiveRule(rule)"
               />
               <NButton
-                v-if="editable"
+                v-if="editable && !isBuiltinRule(rule)"
                 secondary
                 type="error"
                 size="small"
@@ -102,7 +102,7 @@ import { NButton, NCheckbox, NDataTable, NDivider } from "naive-ui";
 import { computed, reactive } from "vue";
 import { useI18n } from "vue-i18n";
 import type { RuleTemplateV2 } from "@/types";
-import { getRuleLocalization, ruleTypeToString } from "@/types";
+import { getRuleLocalization, isBuiltinRule, ruleTypeToString } from "@/types";
 import { SQLReviewRule_Level } from "@/types/proto-es/v1/review_config_service_pb";
 import RuleConfig from "./RuleConfigComponents/RuleConfig.vue";
 import RuleLevelSwitch from "./RuleLevelSwitch.vue";
@@ -248,7 +248,7 @@ const columns = computed(() => {
             <NButton onClick={() => setActiveRule(rule)}>
               {props.editable ? t("common.edit") : t("common.view")}
             </NButton>
-            {props.editable && (
+            {props.editable && !isBuiltinRule(rule) && (
               <NButton
                 secondary
                 type="error"

--- a/frontend/src/types/sql-review-schema.yaml
+++ b/frontend/src/types/sql-review-schema.yaml
@@ -2012,3 +2012,18 @@
 - type: STATEMENT_OBJECT_OWNER_CHECK
   category: STATEMENT
   engine: POSTGRES
+- type: BUILTIN_PRIOR_BACKUP_CHECK
+  category: BUILTIN
+  engine: MYSQL
+- type: BUILTIN_PRIOR_BACKUP_CHECK
+  category: BUILTIN
+  engine: POSTGRES
+- type: BUILTIN_PRIOR_BACKUP_CHECK
+  category: BUILTIN
+  engine: TIDB
+- type: BUILTIN_PRIOR_BACKUP_CHECK
+  category: BUILTIN
+  engine: MSSQL
+- type: BUILTIN_PRIOR_BACKUP_CHECK
+  category: BUILTIN
+  engine: ORACLE

--- a/frontend/src/types/sqlReview.ts
+++ b/frontend/src/types/sqlReview.ts
@@ -119,6 +119,33 @@ export const ruleTypeToString = (type: SQLReviewRule_Type): string => {
   return SQLReviewRule_Type[type] as string;
 };
 
+const BUILTIN_CATEGORY = "BUILTIN";
+
+export const isBuiltinRule = (rule: RuleTemplateV2): boolean => {
+  return rule.category === BUILTIN_CATEGORY;
+};
+
+// Returns a new rule map with builtin rules injected for engines already present.
+// Builtin rules are always active and cannot be removed by users.
+export const withBuiltinRules = (
+  ruleMap: Map<Engine, Map<SQLReviewRule_Type, RuleTemplateV2>>
+): Map<Engine, Map<SQLReviewRule_Type, RuleTemplateV2>> => {
+  const result = new Map<Engine, Map<SQLReviewRule_Type, RuleTemplateV2>>();
+  for (const [engine, engineMap] of ruleMap) {
+    const copy = new Map(engineMap);
+    const engineTemplates = ruleTemplateMapV2.get(engine);
+    if (engineTemplates) {
+      for (const [type, template] of engineTemplates) {
+        if (template.category === BUILTIN_CATEGORY && !copy.has(type)) {
+          copy.set(type, { ...template });
+        }
+      }
+    }
+    result.set(engine, copy);
+  }
+  return result;
+};
+
 export const getRuleMapByEngine = (
   ruleList: RuleTemplateV2[]
 ): Map<Engine, Map<SQLReviewRule_Type, RuleTemplateV2>> => {

--- a/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
@@ -197,7 +197,9 @@ import type { RuleTemplateV2 } from "@/types";
 import {
   convertRuleMapToPolicyRuleList,
   getRuleMapByEngine,
+  isBuiltinRule,
   UNKNOWN_ID,
+  withBuiltinRules,
 } from "@/types";
 import type { Engine } from "@/types/proto-es/v1/common_pb";
 import { SQLReviewRule_Type } from "@/types/proto-es/v1/review_config_service_pb";
@@ -288,7 +290,7 @@ const ruleListOfPolicy = computed((): RuleTemplateV2[] => {
 watch(
   ruleListOfPolicy,
   (ruleList) => {
-    state.ruleMapByEngine = getRuleMapByEngine(ruleList);
+    state.ruleMapByEngine = withBuiltinRules(getRuleMapByEngine(ruleList));
   },
   { immediate: true }
 );
@@ -331,6 +333,9 @@ const markChange = (
 };
 
 const removeRule = (rule: RuleTemplateV2) => {
+  if (isBuiltinRule(rule)) {
+    return;
+  }
   state.ruleMapByEngine.get(rule.engine)?.delete(rule.type);
   if (state.ruleMapByEngine.get(rule.engine)?.size === 0) {
     state.ruleMapByEngine.delete(rule.engine);
@@ -339,7 +344,9 @@ const removeRule = (rule: RuleTemplateV2) => {
 };
 
 const onCancelChanges = () => {
-  state.ruleMapByEngine = getRuleMapByEngine(ruleListOfPolicy.value);
+  state.ruleMapByEngine = withBuiltinRules(
+    getRuleMapByEngine(ruleListOfPolicy.value)
+  );
   state.rulesUpdated = false;
 };
 


### PR DESCRIPTION
## Summary
- Allow users to configure the severity level (ERROR/WARNING) of builtin SQL review rules through the existing review config UI
- The builtin rule (prior backup check) is always active and cannot be disabled, but its level can now be changed per engine
- Backend skips appending builtin rules when the user has already configured them in their review config, so the user's chosen level takes precedence

## Changes

**Backend** (`backend/plugin/advisor/sql_review.go`):
- When appending builtin rules in `SQLReviewCheck`, check if the user's config already contains the rule type. If yes, skip the builtin default so the user's configured level wins.

**Frontend** (6 files):
- `sql-review-schema.yaml` — Added `BUILTIN_PRIOR_BACKUP_CHECK` for MYSQL, POSTGRES, TIDB, MSSQL, ORACLE under `BUILTIN` category
- `sqlReview.ts` — Added `isBuiltinRule()` helper and pure `withBuiltinRules()` transform that returns a new rule map with builtins injected
- `SQLRuleTable.vue` — Hide delete button for builtin rules (desktop + mobile)
- `SQLReviewRulesSelectPanel.vue` — Prevent deselecting builtin rules
- `SQLReviewCreation.vue` / `SettingWorkspaceSQLReviewDetail.vue` — Guard `removeRule` against builtin types; inject builtins via `withBuiltinRules(getRuleMapByEngine(...))`

## Test plan
- [ ] Open an existing SQL review config — verify the "Prior backup feasibility check" rule appears under the "Builtin rules" category tab for each engine
- [ ] Verify the builtin rule has no delete button
- [ ] Change the builtin rule level from WARNING to ERROR, save, and verify it persists
- [ ] Create a new review config from a template — verify builtin rules appear automatically
- [ ] Verify the builtin rule cannot be deselected in the rule selection drawer
- [ ] Run a SQL review check and confirm the configured level is used instead of the hardcoded WARNING default