### PR TITLE
fix: use email format for user ID in localStorage keys

### DIFF
--- a/frontend/src/components/AuditLog/AuditLogDataTable.vue
+++ b/frontend/src/components/AuditLog/AuditLogDataTable.vue
@@ -28,7 +28,7 @@ import { ProjectV1Name } from "@/components/v2";
 import { UserLink } from "@/components/v2/Model/cells";
 import { mapSorterStatus } from "@/components/v2/Model/utils";
 import {
-  extractUserId,
+  extractUserEmail,
   getProjectIdPlanUidStageUidFromRolloutName,
   planNamePrefix,
   projectNamePrefix,
@@ -136,7 +136,7 @@ const columnList = computed((): AuditDataTableColumn[] => {
           if (!auditLog.user) {
             return <span>-</span>;
           }
-          const email = extractUserId(auditLog.user);
+          const email = extractUserEmail(auditLog.user);
           return <UserLink title={email} email={email} />;
         },
       },

--- a/frontend/src/components/Member/MembersBindingSelect.vue
+++ b/frontend/src/components/Member/MembersBindingSelect.vue
@@ -48,7 +48,7 @@ import { AccountSelect } from "@/components/v2";
 import {
   extractGroupEmail,
   extractServiceAccountId,
-  extractUserId,
+  extractUserEmail,
   extractWorkloadIdentityId,
   groupNamePrefix,
   serviceAccountNamePrefix,
@@ -104,7 +104,7 @@ const convertFullnameToMember = (fullname: string) => {
     const email = extractWorkloadIdentityId(fullname);
     return getWorkloadIdentityNameInBinding(email);
   } else {
-    const email = extractUserId(fullname);
+    const email = extractUserEmail(fullname);
     return getUserEmailInBinding(email);
   }
 };

--- a/frontend/src/components/Member/utils.ts
+++ b/frontend/src/components/Member/utils.ts
@@ -10,7 +10,7 @@ import {
   workloadIdentityToUser,
 } from "@/store";
 import {
-  extractUserId,
+  extractUserEmail,
   groupNamePrefix,
   serviceAccountNamePrefix,
   workloadIdentityNamePrefix,
@@ -79,7 +79,7 @@ const getMemberBinding = (
     } else {
       user = userStore.getUserByIdentifier(member);
       if (!user) {
-        const email = extractUserId(member);
+        const email = extractUserEmail(member);
         user = create(UserSchema, {
           title: email,
           name: fullname,
@@ -155,7 +155,7 @@ export const getMemberBindings = ({
       (binding) => (binding.group ? 0 : 1),
       (binding) => {
         if (binding.user) {
-          return extractUserId(binding.user.name);
+          return extractUserEmail(binding.user.name);
         }
         if (binding.group) {
           return extractGroupEmail(binding.group.name);

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/registry/context.ts
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/registry/context.ts
@@ -1,5 +1,5 @@
 import { first, orderBy } from "lodash-es";
-import { candidatesOfApprovalStepV1, extractUserId } from "@/store";
+import { candidatesOfApprovalStepV1, extractUserEmail } from "@/store";
 import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
 import {
   Issue_ApprovalStatus,
@@ -83,7 +83,7 @@ function computeIsApprovalCandidate(
   // Block self-approval even when matched via ALL_USERS
   if (
     !project.allowSelfApproval &&
-    currentUser.email === extractUserId(issue.creator)
+    currentUser.email === extractUserEmail(issue.creator)
   ) {
     return false;
   }
@@ -99,7 +99,7 @@ function computeExportArchiveReady(
   if (!issue) return false;
   if (![IssueStatus.OPEN, IssueStatus.DONE].includes(issue.status))
     return false;
-  if (currentUserEmail !== extractUserId(issue.creator)) return false;
+  if (currentUserEmail !== extractUserEmail(issue.creator)) return false;
 
   const exportTasks =
     rollout?.stages
@@ -190,8 +190,8 @@ export function buildActionContext(input: ContextBuilderInput): ActionContext {
       spec.config?.case === "createDatabaseConfig"
   );
   const isCreator =
-    currentUserEmail === extractUserId(plan.creator || "") ||
-    (issue ? currentUserEmail === extractUserId(issue.creator) : false);
+    currentUserEmail === extractUserEmail(plan.creator || "") ||
+    (issue ? currentUserEmail === extractUserEmail(issue.creator) : false);
 
   // Compute permissions
   const isApprovalCandidate = computeIsApprovalCandidate(
@@ -201,7 +201,7 @@ export function buildActionContext(input: ContextBuilderInput): ActionContext {
   );
   const permissions: ActionPermissions = {
     updatePlan:
-      currentUserEmail === extractUserId(plan.creator || "") ||
+      currentUserEmail === extractUserEmail(plan.creator || "") ||
       hasProjectPermissionV2(project, "bb.plans.update"),
     createIssue: hasProjectPermissionV2(project, "bb.issues.create"),
     updateIssue: hasProjectPermissionV2(project, "bb.issues.update"),
@@ -209,7 +209,7 @@ export function buildActionContext(input: ContextBuilderInput): ActionContext {
     createRollout: hasProjectPermissionV2(project, "bb.rollouts.create"),
     runTasks:
       issue?.type === Issue_Type.DATABASE_EXPORT
-        ? currentUserEmail === extractUserId(issue.creator)
+        ? currentUserEmail === extractUserEmail(issue.creator)
         : hasProjectPermissionV2(project, "bb.taskRuns.create"),
     isApprovalCandidate,
   };

--- a/frontend/src/components/Plan/components/HeaderSection/TitleInput.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/TitleInput.vue
@@ -25,7 +25,7 @@ import { computed, reactive, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { issueServiceClientConnect, planServiceClientConnect } from "@/connect";
 import {
-  extractUserId,
+  extractUserEmail,
   pushNotification,
   useCurrentProjectV1,
   useCurrentUserV1,
@@ -106,7 +106,7 @@ const allowEdit = computed(() => {
   // If issue exists, check issue permissions
   if (issue.value) {
     // Allowed if current user is the creator.
-    if (extractUserId(issue.value.creator) === currentUser.value.email) {
+    if (extractUserEmail(issue.value.creator) === currentUser.value.email) {
       return true;
     }
     // Allowed if current user has related permission.

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/useCommentEdit.ts
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/useCommentEdit.ts
@@ -2,7 +2,7 @@ import type { ComputedRef, Ref } from "vue";
 import { computed, reactive } from "vue";
 import { usePlanContext } from "@/components/Plan/logic";
 import {
-  extractUserId,
+  extractUserEmail,
   getIssueCommentType,
   IssueCommentType,
   useCurrentUserV1,
@@ -46,7 +46,7 @@ export function useCommentEdit(project: Ref<Project> | ComputedRef<Project>) {
     if (!isEditable) {
       return false;
     }
-    if (currentUser.value.email === extractUserId(comment.creator)) {
+    if (currentUser.value.email === extractUserEmail(comment.creator)) {
       return true;
     }
     return hasProjectPermissionV2(project.value, "bb.issueComments.update");

--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ChecksSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ChecksSection.vue
@@ -43,7 +43,7 @@ import { NButton } from "naive-ui";
 import { computed, ref } from "vue";
 import { planServiceClientConnect } from "@/connect";
 import {
-  extractUserId,
+  extractUserEmail,
   pushNotification,
   useCurrentProjectV1,
   useCurrentUserV1,
@@ -67,7 +67,7 @@ const selectedResultStatus = ref<Advice_Level | undefined>(undefined);
 
 const allowRunChecks = computed(() => {
   const me = currentUser.value;
-  if (extractUserId(plan.value.creator) === me.email) {
+  if (extractUserEmail(plan.value.creator) === me.email) {
     return true;
   }
   return hasProjectPermissionV2(project.value, "bb.planCheckRuns.run");

--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/Sidebar.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/Sidebar.vue
@@ -27,7 +27,7 @@ import IssueLabels from "@/components/IssueV1/components/Sidebar/IssueLabels.vue
 import { useResourcePoller } from "@/components/Plan/logic/poller";
 import { issueServiceClientConnect } from "@/connect";
 import {
-  extractUserId,
+  extractUserEmail,
   pushNotification,
   useCurrentProjectV1,
   useCurrentUserV1,
@@ -58,7 +58,7 @@ const allowChange = computed(() => {
   }
 
   // Allowed if current user is the creator.
-  if (extractUserId(issue.value.creator) === currentUser.value.email) {
+  if (extractUserEmail(issue.value.creator) === currentUser.value.email) {
     return true;
   }
 

--- a/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
+++ b/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
@@ -74,7 +74,7 @@ import { computed, ref, watch } from "vue";
 import { STATEMENT_SKIP_CHECK_THRESHOLD } from "@/components/SQLCheck/common";
 import { planServiceClientConnect } from "@/connect";
 import {
-  extractUserId,
+  extractUserEmail,
   pushNotification,
   useCurrentProjectV1,
   useCurrentUserV1,
@@ -112,7 +112,7 @@ const shouldShow = computed(() => {
 
 const allowRunChecks = computed(() => {
   const me = currentUser.value;
-  if (extractUserId(plan.value.creator) === me.email) {
+  if (extractUserEmail(plan.value.creator) === me.email) {
     return true;
   }
   return hasProjectPermissionV2(project.value, "bb.planCheckRuns.run");

--- a/frontend/src/components/ProjectMember/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMember/ProjectMemberPanel.vue
@@ -132,7 +132,7 @@ import type { MemberBinding } from "@/components/Member/types";
 import { getMemberBindings } from "@/components/Member/utils";
 import PermissionGuardWrapper from "@/components/Permission/PermissionGuardWrapper.vue";
 import {
-  extractUserId,
+  extractUserEmail,
   pushNotification,
   useCurrentUserV1,
   usePermissionStore,
@@ -293,7 +293,7 @@ const revokeMember = async (binding: MemberBinding) => {
 const selectedUserEmails = computed(() => {
   return state.selectedMembers
     .filter((member) => !member.startsWith(groupBindingPrefix))
-    .map(extractUserId);
+    .map(extractUserEmail);
 });
 
 const handleRevokeSelectedMembers = () => {

--- a/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
+++ b/frontend/src/components/ProjectMember/ProjectMemberRolePanel/index.vue
@@ -140,7 +140,7 @@ import {
 } from "@/components/v2";
 import {
   extractGroupEmail,
-  extractUserId,
+  extractUserEmail,
   pushNotification,
   useDatabaseV1Store,
   useProjectIamPolicy,
@@ -212,7 +212,7 @@ const editingBinding = ref<Binding | null>(null);
 const panelTitle = computed(() => {
   let email = props.binding.binding;
   if (props.binding.type === "users") {
-    email = extractUserId(email);
+    email = extractUserEmail(email);
   } else {
     email = extractGroupEmail(email);
   }

--- a/frontend/src/components/SensitiveData/MaskingExceptionUserTable.vue
+++ b/frontend/src/components/SensitiveData/MaskingExceptionUserTable.vue
@@ -27,7 +27,7 @@ import { MiniActionButton } from "@/components/v2";
 import { UserLink } from "@/components/v2/Model/cells";
 import {
   composePolicyBindings,
-  extractUserId,
+  extractUserEmail,
   pushNotification,
   useGroupStore,
   usePolicyByParentAndType,
@@ -242,7 +242,7 @@ const accessTableColumns = computed(
               return <GroupNameCell group={group} />;
             }
           } else {
-            const email = extractUserId(item.member);
+            const email = extractUserEmail(item.member);
             return <UserLink title={email} email={email} />;
           }
           return <span>{item.member}</span>;

--- a/frontend/src/components/User/Settings/CreateGroupDrawer.vue
+++ b/frontend/src/components/User/Settings/CreateGroupDrawer.vue
@@ -151,7 +151,7 @@ import EmailInput from "@/components/EmailInput.vue";
 import RequiredStar from "@/components/RequiredStar.vue";
 import { Drawer, DrawerContent, UserSelect } from "@/components/v2";
 import { pushNotification, useCurrentUserV1, useGroupStore } from "@/store";
-import { extractUserId, groupNamePrefix } from "@/store/modules/v1/common";
+import { extractUserEmail, groupNamePrefix } from "@/store/modules/v1/common";
 import type { Group, GroupMember } from "@/types/proto-es/v1/group_service_pb";
 import {
   GroupMember_Role,
@@ -205,7 +205,7 @@ const state = reactive<LocalState>({
 });
 
 const userFilter = (user: User, member: string) => {
-  if (extractUserId(member) === user.email) {
+  if (extractUserEmail(member) === user.email) {
     return true;
   }
   return !state.group.members.find((member) => member.member === user.name);
@@ -216,7 +216,7 @@ const isCreating = computed(() => !props.group);
 const isGroupOwner = computed(() => {
   return (
     props.group?.members.find(
-      (member) => extractUserId(member.member) === currentUserV1.value.email
+      (member) => extractUserEmail(member.member) === currentUserV1.value.email
     )?.role === GroupMember_Role.OWNER
   );
 });

--- a/frontend/src/components/User/Settings/RemoveGroupButton.vue
+++ b/frontend/src/components/User/Settings/RemoveGroupButton.vue
@@ -28,7 +28,7 @@ import { useI18n } from "vue-i18n";
 import { MiniActionButton } from "@/components/v2";
 import ResourceOccupiedModal from "@/components/v2/ResourceOccupiedModal/ResourceOccupiedModal.vue";
 import { pushNotification, useCurrentUserV1, useGroupStore } from "@/store";
-import { extractUserId } from "@/store/modules/v1/common";
+import { extractUserEmail } from "@/store/modules/v1/common";
 import {
   type Group,
   GroupMember_Role,
@@ -51,7 +51,7 @@ const resourceOccupiedModalRef =
 
 const selfMemberInGroup = computed(() => {
   return props.group?.members.find(
-    (member) => extractUserId(member.member) === currentUserV1.value.email
+    (member) => extractUserEmail(member.member) === currentUserV1.value.email
   );
 });
 

--- a/frontend/src/components/User/Settings/UserDataTableByGroup/cells/GroupNameCell.vue
+++ b/frontend/src/components/User/Settings/UserDataTableByGroup/cells/GroupNameCell.vue
@@ -66,7 +66,7 @@ import UserRolesCell from "@/components/Member/MemberDataTable/cells/UserRolesCe
 import type { MemberRole } from "@/components/Member/types";
 import { HighlightLabelText } from "@/components/v2";
 import { WORKSPACE_ROUTE_USERS } from "@/router/dashboard/workspaceRoutes";
-import { extractUserId, useCurrentUserV1 } from "@/store";
+import { extractUserEmail, useCurrentUserV1 } from "@/store";
 import type { Group } from "@/types/proto-es/v1/group_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
@@ -96,7 +96,7 @@ const currentUser = useCurrentUserV1();
 const allowGetGroup = computed(() => {
   if (
     props.group.members.find(
-      (member) => extractUserId(member.member) === currentUser.value.name
+      (member) => extractUserEmail(member.member) === currentUser.value.name
     )
   ) {
     return true;

--- a/frontend/src/components/User/Settings/UserDataTableByGroup/cells/GroupOperationsCell.vue
+++ b/frontend/src/components/User/Settings/UserDataTableByGroup/cells/GroupOperationsCell.vue
@@ -18,7 +18,7 @@ import { PencilIcon, Trash2Icon } from "lucide-vue-next";
 import { computed } from "vue";
 import { MiniActionButton } from "@/components/v2";
 import { useCurrentUserV1 } from "@/store";
-import { extractUserId } from "@/store/modules/v1/common";
+import { extractUserEmail } from "@/store/modules/v1/common";
 import type { Group } from "@/types/proto-es/v1/group_service_pb";
 import { GroupMember_Role } from "@/types/proto-es/v1/group_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
@@ -38,7 +38,7 @@ const currentUser = useCurrentUserV1();
 const isGroupOwner = computed(() => {
   return (
     props.group.members.find(
-      (m) => extractUserId(m.member) === currentUser.value.email
+      (m) => extractUserEmail(m.member) === currentUser.value.email
     )?.role === GroupMember_Role.OWNER
   );
 });

--- a/frontend/src/components/misc/Watermark.vue
+++ b/frontend/src/components/misc/Watermark.vue
@@ -36,7 +36,7 @@
 import { NWatermark } from "naive-ui";
 import { computed } from "vue";
 import {
-  extractUserId,
+  extractUserEmail,
   featureToRef,
   useActuatorV1Store,
   useCurrentUserV1,
@@ -59,7 +59,7 @@ const hasWatermarkFeature = featureToRef(PlanFeature.FEATURE_WATERMARK);
 
 const lines = computed(() => {
   const user = currentUserV1.value;
-  const uid = extractUserId(user.name);
+  const uid = extractUserEmail(user.name);
   if (user.name === UNKNOWN_USER_NAME) return [];
   if (!hasWatermarkFeature.value) return [];
   if (!settingV1Store.workspaceProfile.watermark) return [];

--- a/frontend/src/router/useRecentVisit.ts
+++ b/frontend/src/router/useRecentVisit.ts
@@ -10,7 +10,7 @@ export function useRecentVisit() {
   const currentUser = useCurrentUserV1();
 
   const recentVisit = useDynamicLocalStorage<string[]>(
-    computed(() => `${STORAGE_KEY}.${currentUser.value.name}`),
+    computed(() => `${STORAGE_KEY}.${currentUser.value.email}`),
     []
   );
 

--- a/frontend/src/store/modules/sqlEditor/legacy/migration.ts
+++ b/frontend/src/store/modules/sqlEditor/legacy/migration.ts
@@ -13,7 +13,7 @@ import {
   useDynamicLocalStorage,
   WebStorageHelper,
 } from "@/utils";
-import { extractUserId, useWorkSheetStore } from "../../v1";
+import { extractUserEmail, useWorkSheetStore } from "../../v1";
 import { useCurrentUserV1 } from "../../v1/auth";
 import { EXTENDED_TAB_FIELDS, useExtendedTabStore } from "./extendedTab";
 
@@ -28,7 +28,7 @@ type LegacyStoredTab = PersistentTab & { statement?: string };
 
 export const migrateLegacyCache = async () => {
   const me = useCurrentUserV1();
-  const userUID = computed(() => extractUserId(me.value.name));
+  const userUID = computed(() => extractUserEmail(me.value.name));
 
   const keyNamespace = computed(
     () => `${LOCAL_STORAGE_KEY_PREFIX}.${userUID.value}`
@@ -113,7 +113,7 @@ export const migrateLegacyCache = async () => {
 
 export const migrateDraftsFromCache = async (project: string) => {
   const me = useCurrentUserV1();
-  const userUID = computed(() => extractUserId(me.value.name));
+  const userUID = computed(() => extractUserEmail(me.value.name));
   const worksheetStore = useWorkSheetStore();
 
   const viewStateByTab = useDynamicLocalStorage<
@@ -169,7 +169,7 @@ export const migrateDraftsFromCache = async (project: string) => {
 
 export const migrateTabViewState = (project: string) => {
   const me = useCurrentUserV1();
-  const userUID = computed(() => extractUserId(me.value.name));
+  const userUID = computed(() => extractUserEmail(me.value.name));
 
   const keyNamespace = computed(
     () => `${LOCAL_STORAGE_KEY_PREFIX}.${project}.${userUID.value}`

--- a/frontend/src/store/modules/sqlEditor/tab.ts
+++ b/frontend/src/store/modules/sqlEditor/tab.ts
@@ -22,7 +22,6 @@ import {
   useDynamicLocalStorage,
 } from "@/utils";
 import {
-  extractUserId,
   hasFeature,
   useDatabaseV1ByName,
   useDatabaseV1Store,
@@ -56,9 +55,8 @@ export const useSQLEditorTabStore = defineStore("sqlEditorTab", () => {
   const worksheetStore = useWorkSheetStore();
 
   const me = useCurrentUserV1();
-  const userUID = computed(() => extractUserId(me.value.name));
   const keyNamespace = computed(
-    () => `${LOCAL_STORAGE_KEY_PREFIX}.${project.value}.${userUID.value}`
+    () => `${LOCAL_STORAGE_KEY_PREFIX}.${project.value}.${me.value.email}`
   );
 
   const openTmpTabList = useDynamicLocalStorage<PersistentTab[]>(

--- a/frontend/src/store/modules/uistate.ts
+++ b/frontend/src/store/modules/uistate.ts
@@ -16,9 +16,11 @@ export const useUIStateStore = defineStore("uistate", () => {
   const currentUser = useCurrentUserV1();
 
   const COLLAPSE_MODULE_KEY = computed(
-    () => `ui.list.collapse.${currentUser.value.name}`
+    () => `ui.list.collapse.${currentUser.value.email}`
   );
-  const INTRO_MODULE_KEY = computed(() => `ui.intro.${currentUser.value.name}`);
+  const INTRO_MODULE_KEY = computed(
+    () => `ui.intro.${currentUser.value.email}`
+  );
 
   const getIntroStateByKey = (key: string): boolean => {
     return stateByKey(state.introStateByKey, INTRO_MODULE_KEY.value, key);

--- a/frontend/src/store/modules/user.ts
+++ b/frontend/src/store/modules/user.ts
@@ -29,7 +29,7 @@ import {
 } from "@/types/proto-es/v1/user_service_pb";
 import { ensureUserFullName, hasWorkspacePermissionV2 } from "@/utils";
 import { useActuatorV1Store } from "./v1/actuator";
-import { extractUserId, userNamePrefix } from "./v1/common";
+import { extractUserEmail, userNamePrefix } from "./v1/common";
 import { usePermissionStore } from "./v1/permission";
 
 export interface UserFilter {
@@ -278,7 +278,7 @@ export const useUserStore = defineStore("user", () => {
     if (!identifier) {
       return;
     }
-    const id = extractUserId(identifier);
+    const id = extractUserEmail(identifier);
     if (Number.isNaN(Number(id))) {
       return [...userMapByName.value.values()].find(
         (user) => user.email === id

--- a/frontend/src/store/modules/v1/auth.ts
+++ b/frontend/src/store/modules/v1/auth.ts
@@ -27,6 +27,7 @@ import {
   UserSchema,
   UserType,
 } from "@/types/proto-es/v1/user_service_pb";
+import { extractUserEmail } from "./common";
 
 export const useAuthStore = defineStore("auth_v1", () => {
   const userStore = useUserStore();
@@ -43,12 +44,16 @@ export const useAuthStore = defineStore("auth_v1", () => {
     );
   });
 
+  const currentUserEmail = computed(() =>
+    extractUserEmail(currentUserName.value || "")
+  );
+
   const requireResetPassword = computed(() => {
     if (!isLoggedIn.value) {
       return false;
     }
     return useLocalStorage<boolean>(
-      `${currentUserName.value}.require_reset_password`,
+      `${currentUserEmail.value}.require_reset_password`,
       false
     ).value;
   });
@@ -58,7 +63,7 @@ export const useAuthStore = defineStore("auth_v1", () => {
       return false;
     }
     const needResetPasswordCache = useLocalStorage<boolean>(
-      `${currentUserName.value}.require_reset_password`,
+      `${currentUserEmail.value}.require_reset_password`,
       false
     );
     needResetPasswordCache.value = requireResetPassword;

--- a/frontend/src/store/modules/v1/common.ts
+++ b/frontend/src/store/modules/v1/common.ts
@@ -182,7 +182,7 @@ export const extractGroupEmail = (emailResource: string) => {
   return matches?.[1] ?? emailResource;
 };
 
-export const extractUserId = (identifier: string) => {
+export const extractUserEmail = (identifier: string) => {
   const matches = identifier.match(/^(?:user:|users\/)(.+)$/);
   return matches?.[1] ?? identifier;
 };

--- a/frontend/src/store/modules/v1/worksheet.ts
+++ b/frontend/src/store/modules/v1/worksheet.ts
@@ -30,7 +30,7 @@ import {
 import { useSQLEditorTabStore } from "../sqlEditor";
 import { useUserStore } from "../user";
 import { useCurrentUserV1 } from "./auth";
-import { extractUserId } from "./common";
+import { extractUserEmail } from "./common";
 import { useDatabaseV1Store } from "./database";
 import { useProjectV1Store } from "./project";
 
@@ -317,7 +317,7 @@ export const useWorkSheetAndTabStore = defineStore("worksheet_and_tab", () => {
   const isCreator = computed(() => {
     const worksheet = currentWorksheet.value;
     if (!worksheet) return false;
-    return extractUserId(worksheet.creator) === me.value.email;
+    return extractUserEmail(worksheet.creator) === me.value.email;
   });
 
   const isReadOnly = computed(() => {

--- a/frontend/src/types/v1/user.ts
+++ b/frontend/src/types/v1/user.ts
@@ -1,6 +1,6 @@
 import { create } from "@bufbuild/protobuf";
 import { t } from "@/plugins/i18n";
-import { extractUserId } from "@/store/modules/v1/common";
+import { extractUserEmail } from "@/store/modules/v1/common";
 import { UNKNOWN_ID } from "../const";
 import { State } from "../proto-es/v1/common_pb";
 import type { User } from "../proto-es/v1/user_service_pb";
@@ -17,7 +17,7 @@ export const unknownUser = (name: string = ""): User => {
   });
   if (name) {
     user.name = name;
-    const email = extractUserId(name);
+    const email = extractUserEmail(name);
     user.email = email;
     user.title = email.split("@")[0];
   }

--- a/frontend/src/utils/v1/user.ts
+++ b/frontend/src/utils/v1/user.ts
@@ -1,8 +1,8 @@
-import { extractUserId, userNamePrefix } from "@/store/modules/v1/common";
+import { extractUserEmail, userNamePrefix } from "@/store/modules/v1/common";
 import { ALL_USERS_USER_EMAIL } from "@/types";
 
 export const ensureUserFullName = (identifier: string) => {
-  const id = extractUserId(identifier);
+  const id = extractUserEmail(identifier);
   return `${userNamePrefix}${id}`;
 };
 

--- a/frontend/src/utils/v1/worksheet.ts
+++ b/frontend/src/utils/v1/worksheet.ts
@@ -4,7 +4,7 @@ import {
   useDatabaseV1Store,
   useProjectV1Store,
 } from "@/store";
-import { extractUserId } from "@/store/modules/v1/common";
+import { extractUserEmail } from "@/store/modules/v1/common";
 import { type SQLEditorConnection, UNKNOWN_PROJECT_NAME } from "@/types";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { DataSourceType } from "@/types/proto-es/v1/instance_service_pb";
@@ -32,7 +32,7 @@ export const extractWorksheetUID = (name: string) => {
 export const isWorksheetReadableV1 = (sheet: Worksheet) => {
   const currentUser = useCurrentUserV1();
 
-  if (extractUserId(sheet.creator) === currentUser.value.email) {
+  if (extractUserEmail(sheet.creator) === currentUser.value.email) {
     // Always readable to the creator
     return true;
   }
@@ -63,7 +63,7 @@ export const isWorksheetReadableV1 = (sheet: Worksheet) => {
 export const isWorksheetWritableV1 = (sheet: Worksheet) => {
   const currentUser = useCurrentUserV1();
 
-  if (extractUserId(sheet.creator) === currentUser.value.email) {
+  if (extractUserEmail(sheet.creator) === currentUser.value.email) {
     // Always writable to the creator
     return true;
   }

--- a/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/tree.ts
+++ b/frontend/src/views/sql-editor/ConnectionPanel/ConnectionPane/tree.ts
@@ -68,7 +68,7 @@ export const useSQLEditorTreeByEnvironment = (
   }>(
     computed(
       () =>
-        `bb.sql-editor.connection-pane.expanded_${environment}.${currentUser.value.name}`
+        `bb.sql-editor.connection-pane.expanded_${environment}.${currentUser.value.email}`
     ),
     {
       initialized: false,


### PR DESCRIPTION
Standardize all localStorage keys to use the user's email directly instead of the resource name (users/{email}), fixing user ID format inconsistency where old numeric IDs coexisted with new email-based IDs.

Also rename extractUserId to extractUserEmail for clarity since the user identifier in the resource name is the email.