### PR TITLE
chore: group @codingame packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,9 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "monthly"
+    groups:
+      codingame:
+        patterns:
+          - "@codingame/*"
 
 version: 2


### PR DESCRIPTION
## Summary
- Add a dependabot group for `@codingame/*` packages so they are updated together in a single PR

## Test plan
- [ ] Verify dependabot creates grouped PRs for @codingame packages on next schedule