### PR TITLE
fix(fe): show engine-specific error messages when ghost toggle is disabled

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1204,7 +1204,8 @@
       "only-some-databases-checked": "Only some databases are checked",
       "some-databases-not-meeting-requirements": "Some databases ({databases}) don't meet requirements",
       "some-databases-have-issues": "{count} database has issues | {count} databases have issues",
-      "configuration-has-issues": "Configuration has {count} issue | Configuration has {count} issues"
+      "configuration-has-issues": "Configuration has {count} issue | Configuration has {count} issues",
+      "missing-backup-database": "Create database 'bbdataarchive' on instance '{instance}', then sync the instance and database"
     },
     "refresh-indicator": {
       "last-refresh": "Last refresh: {time}"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1204,7 +1204,8 @@
       "only-some-databases-checked": "Sólo se comprueban algunas bases de datos",
       "some-databases-not-meeting-requirements": "Algunas bases de datos ({databases}) no cumplen los requisitos",
       "some-databases-have-issues": "{count} la base de datos tiene problemas | {count} las bases de datos tienen problemas",
-      "configuration-has-issues": "La configuración tiene {count} problemas | La configuración tiene {count} problemas"
+      "configuration-has-issues": "La configuración tiene {count} problemas | La configuración tiene {count} problemas",
+      "missing-backup-database": "Cree la base de datos 'bbdataarchive' en la instancia '{instance}', luego sincronice la instancia y la base de datos"
     },
     "refresh-indicator": {
       "last-refresh": "Última actualización: {time}"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1204,7 +1204,8 @@
       "only-some-databases-checked": "一部のデータベースのみがチェックされます",
       "some-databases-not-meeting-requirements": "一部のデータベース ({databases}) は要件を満たしていません",
       "some-databases-have-issues": "{count} データベースに問題があります | {count} データベースに問題があります",
-      "configuration-has-issues": "構成に {count} 個の問題があります | 構成に {count} 個の問題があります"
+      "configuration-has-issues": "構成に {count} 個の問題があります | 構成に {count} 個の問題があります",
+      "missing-backup-database": "インスタンス '{instance}' にデータベース 'bbdataarchive' を作成し、インスタンスとデータベースを同期してください"
     },
     "refresh-indicator": {
       "last-refresh": "最終更新: {time}"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1204,7 +1204,8 @@
       "only-some-databases-checked": "Chỉ một số cơ sở dữ liệu được kiểm tra",
       "some-databases-not-meeting-requirements": "Một số cơ sở dữ liệu ({databases}) không đáp ứng được yêu cầu",
       "some-databases-have-issues": "{count} cơ sở dữ liệu có vấn đề | {count} cơ sở dữ liệu có vấn đề",
-      "configuration-has-issues": "Cấu hình có vấn đề {count} | Cấu hình có vấn đề {count}"
+      "configuration-has-issues": "Cấu hình có vấn đề {count} | Cấu hình có vấn đề {count}",
+      "missing-backup-database": "Tạo cơ sở dữ liệu 'bbdataarchive' trên phiên bản '{instance}', sau đó đồng bộ phiên bản và cơ sở dữ liệu"
     },
     "refresh-indicator": {
       "last-refresh": "Làm mới lần cuối: {time}"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1204,7 +1204,8 @@
       "only-some-databases-checked": "仅检查部分数据库",
       "some-databases-not-meeting-requirements": "部分数据库（{databases}）不符合要求",
       "some-databases-have-issues": "{count} 个数据库有问题 | {count} 个数据库有问题",
-      "configuration-has-issues": "配置存在 {count} 个问题 | 配置存在 {count} 个问题"
+      "configuration-has-issues": "配置存在 {count} 个问题 | 配置存在 {count} 个问题",
+      "missing-backup-database": "请在实例 '{instance}' 上创建数据库 'bbdataarchive'，然后同步实例和数据库"
     },
     "refresh-indicator": {
       "last-refresh": "上次刷新：{time}"


### PR DESCRIPTION
Consistent with #18888 which added detailed error messages for the prior backup toggle. When the ghost toggle is disabled due to missing bbdataarchive database, users previously saw only a generic tooltip with no actionable guidance. Now shows the same detailed error message: "Create database 'bbdataarchive' on instance '{instance}', then sync the instance and database."