### PR TITLE
fix: preserve SET ROLE statements across parsed statements in PG advisors

### DIFF
--- a/backend/plugin/advisor/pg/advisor_insert_row_limit.go
+++ b/backend/plugin/advisor/pg/advisor_insert_row_limit.go
@@ -47,6 +47,7 @@ func (*InsertRowLimitAdvisor) Check(ctx context.Context, checkCtx advisor.Contex
 	}
 
 	var adviceList []*storepb.Advice
+	var setRoles []string
 	for _, stmtInfo := range checkCtx.ParsedStatements {
 		if stmtInfo.AST == nil {
 			continue
@@ -64,6 +65,7 @@ func (*InsertRowLimitAdvisor) Check(ctx context.Context, checkCtx advisor.Contex
 			driver:     checkCtx.Driver,
 			ctx:        ctx,
 			tokens:     antlrAST.Tokens,
+			setRoles:   setRoles,
 			TenantMode: checkCtx.TenantMode,
 		}
 		rule.SetBaseLine(stmtInfo.BaseLine())
@@ -71,6 +73,7 @@ func (*InsertRowLimitAdvisor) Check(ctx context.Context, checkCtx advisor.Contex
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 		adviceList = append(adviceList, checker.GetAdviceList()...)
+		setRoles = rule.setRoles
 	}
 
 	return adviceList, nil

--- a/backend/plugin/advisor/pg/advisor_statement_affected_row_limit.go
+++ b/backend/plugin/advisor/pg/advisor_statement_affected_row_limit.go
@@ -47,6 +47,7 @@ func (*StatementAffectedRowLimitAdvisor) Check(ctx context.Context, checkCtx adv
 	}
 
 	var adviceList []*storepb.Advice
+	var setRoles []string
 	for _, stmtInfo := range checkCtx.ParsedStatements {
 		if stmtInfo.AST == nil {
 			continue
@@ -64,6 +65,7 @@ func (*StatementAffectedRowLimitAdvisor) Check(ctx context.Context, checkCtx adv
 			ctx:        ctx,
 			driver:     checkCtx.Driver,
 			tenantMode: checkCtx.TenantMode,
+			setRoles:   setRoles,
 			tokens:     antlrAST.Tokens,
 		}
 		rule.SetBaseLine(stmtInfo.BaseLine())
@@ -71,6 +73,7 @@ func (*StatementAffectedRowLimitAdvisor) Check(ctx context.Context, checkCtx adv
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 		adviceList = append(adviceList, checker.GetAdviceList()...)
+		setRoles = rule.setRoles
 	}
 
 	return adviceList, nil

--- a/backend/plugin/advisor/pg/advisor_statement_dml_dry_run.go
+++ b/backend/plugin/advisor/pg/advisor_statement_dml_dry_run.go
@@ -40,6 +40,7 @@ func (*StatementDMLDryRunAdvisor) Check(ctx context.Context, checkCtx advisor.Co
 	}
 
 	var adviceList []*storepb.Advice
+	var setRoles []string
 	for _, stmtInfo := range checkCtx.ParsedStatements {
 		if stmtInfo.AST == nil {
 			continue
@@ -56,6 +57,7 @@ func (*StatementDMLDryRunAdvisor) Check(ctx context.Context, checkCtx advisor.Co
 			ctx:        ctx,
 			driver:     checkCtx.Driver,
 			tenantMode: checkCtx.TenantMode,
+			setRoles:   setRoles,
 			tokens:     antlrAST.Tokens,
 		}
 		rule.SetBaseLine(stmtInfo.BaseLine())
@@ -63,6 +65,7 @@ func (*StatementDMLDryRunAdvisor) Check(ctx context.Context, checkCtx advisor.Co
 		checker := NewGenericChecker([]Rule{rule})
 		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
 		adviceList = append(adviceList, checker.GetAdviceList()...)
+		setRoles = rule.setRoles
 	}
 
 	return adviceList, nil


### PR DESCRIPTION
## Summary
- Fix bug where `SET ROLE` statements in SQL were not applied during DML dry run checks
- The issue: each `ParsedStatement` was processed with a fresh rule instance, discarding collected `setRoles` from previous statements
- The fix: hoist `setRoles` outside the per-statement loop and carry it across iterations

## Affected Files
- `backend/plugin/advisor/pg/advisor_statement_dml_dry_run.go`
- `backend/plugin/advisor/pg/advisor_insert_row_limit.go`
- `backend/plugin/advisor/pg/advisor_statement_affected_row_limit.go`

## Test plan
- [ ] Test with SQL containing `SET ROLE admin; INSERT INTO ...` and verify the SET ROLE is applied during dry run
- [ ] Verify existing advisor tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)