### PR TITLE
fix(frontend): add loading state and fix stale cache on profile email update

### DIFF
--- a/frontend/src/AuthContext.vue
+++ b/frontend/src/AuthContext.vue
@@ -72,27 +72,29 @@ onUnmounted(() => {
   }
 });
 
-// When current user changed, we need to redirect to the workspace root page.
+// When current user changed (e.g., another user logged in from different tab),
+// redirect to workspace root with notification.
+// Skip if this is a self email update (name changes from users/old@email to users/new@email).
 watch(
   () => authStore.currentUserName,
-  (currentUserName, prevCurrentUserName) => {
-    if (
-      currentUserName &&
-      prevCurrentUserName &&
-      currentUserName !== prevCurrentUserName
-    ) {
-      router.push({
-        name: WORKSPACE_ROOT_MODULE,
-        // to force route reload
-        query: { _r: Date.now() },
-      });
-      pushNotification({
-        module: "bytebase",
-        style: "INFO",
-        title: t("auth.login-as-another.title"),
-        description: t("auth.login-as-another.content"),
-      });
+  (curr, prev) => {
+    if (!curr || !prev || curr === prev) return;
+
+    if (authStore.isSelfEmailUpdate) {
+      authStore.isSelfEmailUpdate = false;
+      return;
     }
+
+    router.push({
+      name: WORKSPACE_ROOT_MODULE,
+      query: { _r: Date.now() },
+    });
+    pushNotification({
+      module: "bytebase",
+      style: "INFO",
+      title: t("auth.login-as-another.title"),
+      description: t("auth.login-as-another.content"),
+    });
   }
 );
 

--- a/frontend/src/store/modules/user.ts
+++ b/frontend/src/store/modules/user.ts
@@ -164,10 +164,16 @@ export const useUserStore = defineStore("user", () => {
     if (!originData) {
       throw new Error(`user with email ${oldEmail} not found`);
     }
+    const oldName = originData.name;
     const response = await userServiceClientConnect.updateEmail({
       name: `users/${oldEmail}`,
       email: newEmail,
     });
+    // Remove old cache entry since the user's name changes with email
+    if (oldName !== response.name) {
+      userMapByName.value.delete(oldName);
+      userRequestCache.delete(oldName);
+    }
     return setUser(response);
   };
 

--- a/frontend/src/store/modules/v1/auth.ts
+++ b/frontend/src/store/modules/v1/auth.ts
@@ -35,8 +35,10 @@ export const useAuthStore = defineStore("auth_v1", () => {
   const authSessionKey = ref<string>(uniqueId());
   const actuatorStore = useActuatorV1Store();
   const unauthenticatedOccurred = ref<boolean>(false);
-  // Format: users/{user}. {user} is a system-generated unique ID.
+  // Format: users/{email}. Changes when user email is updated.
   const currentUserName = ref<string | undefined>(undefined);
+  // Flag to suppress "logged in as another user" notification during self email update
+  const isSelfEmailUpdate = ref(false);
 
   const isLoggedIn = computed(() => {
     return (
@@ -213,17 +215,26 @@ export const useAuthStore = defineStore("auth_v1", () => {
     }
   };
 
+  // Update currentUserName after self email change.
+  // Sets flag to suppress "logged in as another user" notification.
+  const updateCurrentUserNameForEmailChange = (newName: string) => {
+    isSelfEmailUpdate.value = true;
+    currentUserName.value = newName;
+  };
+
   return {
     currentUserName,
     isLoggedIn,
     unauthenticatedOccurred,
     requireResetPassword,
     authSessionKey,
+    isSelfEmailUpdate,
     login,
     signup,
     logout,
     fetchCurrentUser,
     setRequireResetPassword,
+    updateCurrentUserNameForEmailChange,
   };
 });
 


### PR DESCRIPTION
- Add loading spinner to save button during slow UpdateEmail API call
- Fix stale frontend cache after email update:
  - Remove old cache entries from userMapByName and userRequestCache
  - Update authStore.currentUserName via new method that suppresses the "logged in as another user" notification
- Only show success notification when something actually changed