### PR TITLE
fix(sql-editor): show correct row data in detail panel when results are sorted

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/TableCell.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/TableCell.vue
@@ -79,6 +79,7 @@ const props = defineProps<{
   value: RowValue;
   setIndex: number;
   rowIndex: number;
+  originalRowIndex: number;
   colIndex: number;
   allowSelect?: boolean;
   columnType: string; // Column type from QueryResult
@@ -238,7 +239,7 @@ const handleClick = (e: MouseEvent) => {
 const showDetail = () => {
   detail.value = {
     set: props.setIndex,
-    row: props.rowIndex,
+    row: props.originalRowIndex,
     col: props.colIndex,
   };
 };

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/VirtualDataTable.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/DataTable/VirtualDataTable.vue
@@ -115,7 +115,7 @@
         minWidth: `${tableResize.effectiveWidth.value}px`,
       }"
     >
-      <template #default="{ item: row, index: rowIndex }: { item: { item: QueryRow; }; index: number; }">
+      <template #default="{ item: row, index: rowIndex }: { item: { key: number; item: QueryRow; }; index: number; }">
         <div
           :key="`${setIndex}-${rowIndex}`"
           class="flex group"
@@ -190,6 +190,7 @@
                 :scope="search.scopes.find(scope => scope.id === columns[columnIndex]?.id)"
                 :set-index="setIndex"
                 :row-index="rowIndex"
+                :original-row-index="row.key"
                 :col-index="columnIndex"
                 :allow-select="true"
                 :column-type="getColumnTypeByIndex(columnIndex)"

--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/VirtualDataBlock.vue
@@ -5,7 +5,7 @@
     :items="rows"
     :item-size="estimateRowHeight"
   >
-    <template #default="{ item: row, index: rowIndex }: { item: { item: QueryRow; }; index: number; }">
+    <template #default="{ item: row, index: rowIndex }: { item: { key: number; item: QueryRow; }; index: number; }">
       <div
         :key="`row-${rowIndex}`"
         class="font-mono mb-2 mx-2"
@@ -56,6 +56,7 @@
                 :scope="search.scopes.find(scope => scope.id === columns[columnIndex]?.id)"
                 :set-index="setIndex"
                 :row-index="rowIndex"
+                :original-row-index="row.key"
                 :col-index="columnIndex"
                 :column-type="column.columnType"
                 :allow-select="true"


### PR DESCRIPTION
## Summary
- Fix detail panel showing wrong row data when query results are sorted
- Add `originalRowIndex` prop to TableCell to track the original row index separately from display position
- Update VirtualDataTable and VirtualDataBlock to pass `row.key` as the original index

## Problem
When query results are sorted by clicking a column header, double-clicking a cell to view details showed data from the wrong row. The detail panel was using the display position index to look up data in the original unsorted result array.

## Test plan
- [ ] Run a query that returns multiple rows
- [ ] Sort by any column (click column header)
- [ ] Double-click a cell to open detail panel
- [ ] Verify detail panel shows correct data for the clicked row
- [ ] Test in both table view and block view modes
- [ ] Verify row selection still works correctly


🤖 Generated with [Claude Code](https://claude.com/claude-code)