### PR TITLE
chore(migrator): improve member prefix migration to use principal table

### DIFF
--- a/backend/migrator/migration/3.15/0005##migrate_iam_binding_member_prefix.sql
+++ b/backend/migrator/migration/3.15/0005##migrate_iam_binding_member_prefix.sql
@@ -1,8 +1,11 @@
--- Migrate IAM binding members from legacy "users/" prefix to proper prefixes:
--- - Service accounts: "users/xxx@service.bytebase.com" -> "serviceAccounts/xxx@service.bytebase.com"
--- - Workload identities: "users/xxx@workload.bytebase.com" -> "workloadIdentities/xxx@workload.bytebase.com"
+-- Migrate policy members from legacy "users/" prefix to proper prefixes:
+-- - Service accounts: "users/xxx@..." -> "serviceAccounts/xxx@..."
+-- - Workload identities: "users/xxx@..." -> "workloadIdentities/xxx@..."
+-- Uses principal table to determine the actual type.
+-- Only processes members with "users/" prefix; already-migrated data is unchanged.
 
 -- Update IAM policies in the policy table
+-- IAM policy structure: { bindings: [{ members: [...], role: "..." }] }
 UPDATE policy
 SET payload = (
     SELECT jsonb_set(
@@ -16,23 +19,19 @@ SET payload = (
                     (
                         SELECT jsonb_agg(
                             CASE
-                                -- Service account: workspace-level (ends with @service.bytebase.com)
-                                WHEN member_text LIKE 'users/%@service.bytebase.com'
-                                THEN to_jsonb(regexp_replace(member_text, '^users/', 'serviceAccounts/'))
-                                -- Service account: project-level (contains .service.bytebase.com)
-                                WHEN member_text LIKE 'users/%@%.service.bytebase.com'
-                                THEN to_jsonb(regexp_replace(member_text, '^users/', 'serviceAccounts/'))
-                                -- Workload identity: workspace-level (ends with @workload.bytebase.com)
-                                WHEN member_text LIKE 'users/%@workload.bytebase.com'
-                                THEN to_jsonb(regexp_replace(member_text, '^users/', 'workloadIdentities/'))
-                                -- Workload identity: project-level (contains .workload.bytebase.com)
-                                WHEN member_text LIKE 'users/%@%.workload.bytebase.com'
-                                THEN to_jsonb(regexp_replace(member_text, '^users/', 'workloadIdentities/'))
+                                WHEN member_text NOT LIKE 'users/%'
+                                THEN member
+                                WHEN p.type = 'SERVICE_ACCOUNT'
+                                THEN to_jsonb('serviceAccounts/' || email_extracted.email)
+                                WHEN p.type = 'WORKLOAD_IDENTITY'
+                                THEN to_jsonb('workloadIdentities/' || email_extracted.email)
                                 ELSE member
                             END
                         )
                         FROM jsonb_array_elements(binding->'members') AS member,
-                             LATERAL (SELECT member #>> '{}' AS member_text) AS extracted
+                             LATERAL (SELECT member #>> '{}' AS member_text) AS extracted,
+                             LATERAL (SELECT substring(member_text FROM 7) AS email) AS email_extracted
+                        LEFT JOIN principal p ON p.email = email_extracted.email
                     )
                 )
             )
@@ -42,3 +41,41 @@ SET payload = (
 )
 WHERE type = 'IAM'
   AND payload->'bindings' IS NOT NULL;
+
+-- Update Masking Exemption policies in the policy table
+-- Masking Exemption policy structure: { exemptions: [{ members: [...], condition: {...} }] }
+UPDATE policy
+SET payload = (
+    SELECT jsonb_set(
+        payload,
+        '{exemptions}',
+        (
+            SELECT jsonb_agg(
+                jsonb_set(
+                    exemption,
+                    '{members}',
+                    (
+                        SELECT jsonb_agg(
+                            CASE
+                                WHEN member_text NOT LIKE 'users/%'
+                                THEN member
+                                WHEN p.type = 'SERVICE_ACCOUNT'
+                                THEN to_jsonb('serviceAccounts/' || email_extracted.email)
+                                WHEN p.type = 'WORKLOAD_IDENTITY'
+                                THEN to_jsonb('workloadIdentities/' || email_extracted.email)
+                                ELSE member
+                            END
+                        )
+                        FROM jsonb_array_elements(exemption->'members') AS member,
+                             LATERAL (SELECT member #>> '{}' AS member_text) AS extracted,
+                             LATERAL (SELECT substring(member_text FROM 7) AS email) AS email_extracted
+                        LEFT JOIN principal p ON p.email = email_extracted.email
+                    )
+                )
+            )
+            FROM jsonb_array_elements(payload->'exemptions') AS exemption
+        )
+    )
+)
+WHERE type = 'MASKING_EXEMPTION'
+  AND payload->'exemptions' IS NOT NULL;


### PR DESCRIPTION
## Summary
close BYT-8852
- Join `principal` table to determine actual principal type instead of relying on email suffix pattern matching
- Handle both `IAM` and `MASKING_EXCEPTION` policy types
- Skip already-migrated members (those not starting with `users/`)
- Use clearer string operations (`substring` + concat vs `regexp_replace`)

## Test plan
- [ ] Verify migration script runs successfully on test database
- [ ] Confirm service accounts are migrated to `serviceAccounts/` prefix
- [ ] Confirm workload identities are migrated to `workloadIdentities/` prefix
- [ ] Confirm already-migrated data is unchanged
- [ ] Confirm regular users remain as `users/` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)