### PR TITLE
fix: stop treating DROP VIEW as DROP TABLE for risk and compatibility checks

### DIFF
--- a/backend/plugin/advisor/pg/test/schema_backward_compatibility.yaml
+++ b/backend/plugin/advisor/pg/test/schema_backward_compatibility.yaml
@@ -9,3 +9,31 @@
         line: 1
         column: 0
       endposition: null
+- statement: DROP VIEW my_view
+  want:
+- statement: DROP VIEW IF EXISTS my_view
+  want:
+- statement: DROP VIEW public.my_view
+  want:
+- statement: DROP VIEW my_view; CREATE OR REPLACE VIEW my_view AS SELECT 1
+  want:
+- statement: DROP TABLE tech_book
+  want:
+    - status: 2
+      code: 103
+      title: SCHEMA_BACKWARD_COMPATIBILITY
+      content: '"DROP TABLE tech_book" may cause incompatibility with the existing data and code'
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+- statement: DROP MATERIALIZED VIEW my_mat_view
+  want:
+    - status: 2
+      code: 103
+      title: SCHEMA_BACKWARD_COMPATIBILITY
+      content: '"DROP MATERIALIZED VIEW my_mat_view" may cause incompatibility with the existing data and code'
+      startposition:
+        line: 1
+        column: 0
+      endposition: null

--- a/backend/plugin/parser/pg/statement_type_antlr.go
+++ b/backend/plugin/parser/pg/statement_type_antlr.go
@@ -272,11 +272,11 @@ func getDropStatementType(ctx *parser.DropstmtContext) storepb.StatementType {
 			return storepb.StatementType_DROP_TABLE
 		}
 		if objType.VIEW() != nil {
-			// Legacy compatibility: PostgreSQL treats both regular views and materialized views
-			// as DROP_TABLE instead of DROP_VIEW. This matches the behavior of the legacy
-			// pg_query_go parser to maintain consistency in statement type reporting.
-			// Note: Redshift follows the same pattern.
-			return storepb.StatementType_DROP_TABLE
+			if objType.MATERIALIZED() != nil {
+				// DROP MATERIALIZED VIEW holds data — treat as DROP_TABLE for risk assessment.
+				return storepb.StatementType_DROP_TABLE
+			}
+			return storepb.StatementType_DROP_VIEW
 		}
 		if objType.INDEX() != nil {
 			return storepb.StatementType_DROP_INDEX

--- a/backend/plugin/parser/pg/test-data/test_statement_type.yaml
+++ b/backend/plugin/parser/pg/test-data/test_statement_type.yaml
@@ -42,7 +42,7 @@
     - DROP_TRIGGER
 - statement: DROP VIEW v1;
   want:
-    - DROP_TABLE
+    - DROP_VIEW
 - statement: DROP FUNCTION func1();
   want:
     - DROP_FUNCTION
@@ -123,3 +123,6 @@
 - statement: ALTER VIEW v_old RENAME TO v_new;
   want:
     - ALTER_VIEW
+- statement: DROP MATERIALIZED VIEW mv1;
+  want:
+    - DROP_TABLE

--- a/backend/plugin/parser/redshift/statement_type.go
+++ b/backend/plugin/parser/redshift/statement_type.go
@@ -311,10 +311,11 @@ func getDropStatementType(ctx *parser.DropstmtContext) storepb.StatementType {
 			return storepb.StatementType_DROP_TABLE
 		}
 		if objType.VIEW() != nil {
-			// Legacy compatibility: Redshift (like PostgreSQL) treats both regular views
-			// and materialized views as DROP_TABLE instead of DROP_VIEW to maintain
-			// consistency with the legacy parser behavior.
-			return storepb.StatementType_DROP_TABLE
+			if objType.MATERIALIZED() != nil {
+				// DROP MATERIALIZED VIEW holds data — treat as DROP_TABLE for risk assessment.
+				return storepb.StatementType_DROP_TABLE
+			}
+			return storepb.StatementType_DROP_VIEW
 		}
 		if objType.INDEX() != nil {
 			return storepb.StatementType_DROP_INDEX


### PR DESCRIPTION
## Summary
- **Root cause:** PostgreSQL and Redshift parsers mapped `DROP VIEW` to `StatementType_DROP_TABLE` for legacy compatibility with the old pg_query_go parser. This caused non-materialized views to be classified as HIGH risk, triggering approval workflows unnecessarily.
- `DROP VIEW` now correctly maps to `DROP_VIEW` — no longer HIGH risk
- `DROP MATERIALIZED VIEW` stays mapped to `DROP_TABLE` — still HIGH risk (holds data)
- `SCHEMA_BACKWARD_COMPATIBILITY` advisor no longer flags `DROP VIEW`

## Test plan
- [x] PG parser test: `DROP VIEW v1` → expects `DROP_VIEW` (was `DROP_TABLE`)
- [x] PG parser test: `DROP MATERIALIZED VIEW mv1` → expects `DROP_TABLE`
- [x] Advisor test: `DROP VIEW` variants → no advice
- [x] Advisor test: `DROP TABLE` → code 103
- [x] Advisor test: `DROP MATERIALIZED VIEW` → code 103
- [x] Linter clean on pg and redshift packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)