### PR TITLE
fix: do not lowercase for search value

### DIFF
--- a/frontend/src/components/v2/Select/RemoteResourceSelector/index.vue
+++ b/frontend/src/components/v2/Select/RemoteResourceSelector/index.vue
@@ -166,7 +166,7 @@ const onSelectorOpen = async () => {
 
 const handleSearch = useDebounceFn(
   async (search: string, openOptions: boolean = true) => {
-    searchText.value = search.trim().toLowerCase();
+    searchText.value = search.trim();
     pageToken.value = "";
     await onNextPage(openOptions);
   },


### PR DESCRIPTION
- The frontend needs the original input value
- The backend will handle the `lowercase` based on the operator `==` or `matches`