### PR TITLE
fix(frontend): add missing flex classes to Groups tab on Users page

### DIFF
--- a/frontend/src/views/SettingWorkspaceUsers.vue
+++ b/frontend/src/views/SettingWorkspaceUsers.vue
@@ -44,7 +44,7 @@
 
       <NTabPane name="GROUPS">
         <template #tab>
-          <div>
+          <div class="flex-1 flex gap-x-2">
             <p class="text-base font-medium leading-7 text-main">
               <span>{{ $t("settings.members.groups.self") }}</span>
             </p>


### PR DESCRIPTION
## Summary
The "Groups" tab label on the Users & Groups settings page displays with vertically stacked characters instead of horizontally.

## Root Cause
In `SettingWorkspaceUsers.vue`, the GROUPS tab's wrapper `<div>` had no CSS classes, while the USERS tab had `class="flex-1 flex gap-x-2"`. Without flex properties, the div gets squeezed to near-zero width in NTabs' flex container, causing per-character wrapping.

## Fix
Added `class="flex-1 flex gap-x-2"` to the GROUPS tab wrapper div — matching the USERS tab.

## Testing
- ESLint passes on changed file
- Visual: Groups tab now displays horizontally like the Users tab