### PR TITLE
fix(frontend): clear approval filters when switching issue status tabs

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueSearch/Status.vue
+++ b/frontend/src/components/IssueV1/components/IssueSearch/Status.vue
@@ -90,10 +90,15 @@ const updateStatus = (value: IssueStatus) => {
     allowMultiple = true;
   }
 
+  // Clear status-incompatible filters (e.g. approval, current-approver)
+  // when switching tabs, to avoid "No Data" from conflicting filters.
+  const incompatibleScopeIds = new Set(["status", "approval", "current-approver"]);
   const updated = upsertScope({
     params: {
       ...props.params,
-      scopes: props.params.scopes.filter((scope) => scope.id !== "status"),
+      scopes: props.params.scopes.filter(
+        (scope) => !incompatibleScopeIds.has(scope.id)
+      ),
     },
     scopes,
     allowMultiple,


### PR DESCRIPTION
## Summary
On the Issues page, switching between status tabs (Open/Closed/All) carries over incompatible filters, resulting in empty results.

## Steps to Reproduce
1. Click "Waiting for Approval" preset (sets approval + current-approver filters)
2. Click "Closed" tab
3. See "No Data" even when closed issues exist — approval filters persist

## Root Cause
`Status.vue`'s `updateStatus` function only filtered out `status` scopes before upserting new ones, but left `approval` and `current-approver` scopes intact.

## Fix
Extended the scope filter to also clear `approval` and `current-approver` scopes when switching status tabs. 6-line change in one file.

## Testing
- ESLint + vue-tsc pass on changed file