### PR TITLE
fix(backend): suggest correct field names in API unknown field errors

### DIFF
--- a/backend/server/grpc_routes.go
+++ b/backend/server/grpc_routes.go
@@ -55,11 +55,11 @@ func configureGrpcRouters(
 	// Note: the gateway response modifier takes the token duration on server startup. If the value is changed,
 	// the user has to restart the server to take the latest value.
 	mux := grpcruntime.NewServeMux(
-		grpcruntime.WithMarshalerOption(grpcruntime.MIMEWildcard, &grpcruntime.JSONPb{
+		grpcruntime.WithMarshalerOption(grpcruntime.MIMEWildcard, newSuggestingMarshaler(&grpcruntime.JSONPb{
 			MarshalOptions: protojson.MarshalOptions{},
 			//nolint:forbidigo
 			UnmarshalOptions: protojson.UnmarshalOptions{},
-		}),
+		})),
 		// pass through request headers that need to be used by connect rpc handlers.
 		grpcruntime.WithIncomingHeaderMatcher(func(key string) (string, bool) {
 			switch strings.ToLower(key) {

--- a/backend/server/marshaler.go
+++ b/backend/server/marshaler.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	grpcruntime "github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/protobuf/proto"
+)
+
+// suggestingMarshaler wraps a grpc-gateway Marshaler and enhances "unknown field"
+// errors with suggestions for similar valid field names.
+type suggestingMarshaler struct {
+	grpcruntime.Marshaler
+}
+
+func newSuggestingMarshaler(inner grpcruntime.Marshaler) *suggestingMarshaler {
+	return &suggestingMarshaler{Marshaler: inner}
+}
+
+func (m *suggestingMarshaler) NewDecoder(r io.Reader) grpcruntime.Decoder {
+	return &suggestingDecoder{
+		inner: m.Marshaler.NewDecoder(r),
+	}
+}
+
+// suggestingDecoder wraps a Decoder and enhances unknown field errors.
+type suggestingDecoder struct {
+	inner grpcruntime.Decoder
+}
+
+// unknownFieldRe matches protojson errors like:
+//
+//	unknown field "target"
+var unknownFieldRe = regexp.MustCompile(`unknown field "([^"]+)"`)
+
+func (d *suggestingDecoder) Decode(v any) error {
+	err := d.inner.Decode(v)
+	if err == nil {
+		return nil
+	}
+
+	match := unknownFieldRe.FindStringSubmatch(err.Error())
+	if match == nil {
+		return err
+	}
+	unknownField := match[1]
+
+	msg, ok := v.(proto.Message)
+	if !ok {
+		return err
+	}
+
+	fields := msg.ProtoReflect().Descriptor().Fields()
+	var candidates []string
+	for i := 0; i < fields.Len(); i++ {
+		// protojson uses camelCase JSON names.
+		candidates = append(candidates, fields.Get(i).JSONName())
+	}
+
+	suggestions := findSimilar(unknownField, candidates, 3)
+	if len(suggestions) == 0 {
+		return fmt.Errorf("%w. Valid fields: %s", err, strings.Join(candidates, ", "))
+	}
+	return fmt.Errorf("%w. Did you mean: %s?", err, strings.Join(suggestions, ", "))
+}
+
+// findSimilar returns up to maxResults field names sorted by edit distance.
+// Only fields within a reasonable distance threshold are included.
+func findSimilar(input string, candidates []string, maxResults int) []string {
+	type scored struct {
+		name string
+		dist int
+	}
+	input = strings.ToLower(input)
+	var results []scored
+	for _, c := range candidates {
+		d := levenshtein(input, strings.ToLower(c))
+		// Threshold: at most half the length of the longer string + 1.
+		maxLen := len(input)
+		if len(c) > maxLen {
+			maxLen = len(c)
+		}
+		if d <= maxLen/2+1 {
+			results = append(results, scored{name: c, dist: d})
+		}
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].dist < results[j].dist
+	})
+	var out []string
+	for i := 0; i < len(results) && i < maxResults; i++ {
+		out = append(out, fmt.Sprintf("%q", results[i].name))
+	}
+	return out
+}
+
+// levenshtein computes the edit distance between two strings.
+func levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	curr := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(curr[j-1]+1, min(prev[j]+1, prev[j-1]+cost))
+		}
+		prev, curr = curr, prev
+	}
+	return prev[lb]
+}

--- a/backend/server/marshaler_test.go
+++ b/backend/server/marshaler_test.go
@@ -1,0 +1,36 @@
+package server
+
+import (
+	"testing"
+)
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"target", "targets", 1},
+		{"target", "target", 0},
+		{"kitten", "sitting", 3},
+	}
+	for _, tt := range tests {
+		if got := levenshtein(tt.a, tt.b); got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestFindSimilar(t *testing.T) {
+	candidates := []string{"targets", "title", "description", "changeDatabaseConfig"}
+
+	results := findSimilar("target", candidates, 3)
+	if len(results) == 0 {
+		t.Fatal("expected at least one suggestion")
+	}
+	if results[0] != `"targets"` {
+		t.Errorf("expected first suggestion to be \"targets\", got %s", results[0])
+	}
+}


### PR DESCRIPTION
## Summary
When sending an API request with a wrong field name (e.g., `"target"` instead of `"targets"` in `changeDatabaseConfig`), the error says `unknown field "target"` but doesn't hint at the correct field.

## Fix
Created a `suggestingMarshaler` that wraps the grpc-gateway JSONPb marshaler. When protojson returns "unknown field" errors, it:
1. Extracts the bad field name
2. Finds similar valid fields via Levenshtein distance
3. Appends suggestions to the error message

**Before:** `unknown field "target"`
**After:** `unknown field "target". Did you mean: "targets"?`

## Files Changed
- `backend/server/marshaler.go` — new suggesting marshaler with Levenshtein matching
- `backend/server/marshaler_test.go` — unit tests
- `backend/server/grpc_routes.go` — use new marshaler

## Testing
- Unit tests included
- Note: Go toolchain not available in dev environment — needs CI validation