### PR TITLE
fix(frontend): SQL Editor should default to a project with databases

### DIFF
--- a/frontend/src/components/ProvideSQLEditorContext.vue
+++ b/frontend/src/components/ProvideSQLEditorContext.vue
@@ -105,6 +105,23 @@ useRouteChangeGuard(
 );
 
 const fallbackToFirstProject = async () => {
+  // First, try to find a project that actually has databases.
+  // This avoids the confusing UX of landing on a project with "0 databases".
+  try {
+    const { databases } = await databaseStore.fetchDatabases({
+      parent: "workspaces/-",
+      pageSize: 1,
+    });
+    if (databases.length > 0) {
+      const projectName = databases[0].project;
+      if (isValidProjectName(projectName)) {
+        return projectName;
+      }
+    }
+  } catch {
+    // Ignore errors and fall back to project list
+  }
+
   const { projects } = await projectStore.fetchProjectList({
     pageSize: getDefaultPagination(),
     filter: {


### PR DESCRIPTION
## Summary
When clicking "SQL Editor" from the top nav, it picks the first project alphabetically — often one with no databases. The user sees "0 databases" and can't figure out why.

## Fix
Modified `ProvideSQLEditorContext.vue`'s `fallbackToFirstProject()` to:
1. First query `workspaces/-` for any database (pageSize=1)
2. Use that database's project as the default
3. Fall back to the first project only if no databases exist

## Testing
- ESLint + Biome pass
- Type-check has a pre-existing unrelated error (not introduced by this change)