### PR TITLE
chore: configure SonarCloud to exclude test files and generated code

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,32 @@
+# Path to sources
+sonar.sources=.
+
+# Exclude generated code, build artifacts, and dependencies from analysis
+sonar.exclusions=\
+  backend/generated-go,\
+  proto/gen,\
+  bytebase-build,\
+  frontend/node_modules
+
+# Path to tests — identify test files so they are analyzed as tests, not source
+sonar.test.inclusions=\
+  backend/**/*_test.go,\
+  backend/**/testdata/**,\
+  backend/**/test-data/**,\
+  frontend/src/**/*.test.ts,\
+  frontend/src/**/*.test.tsx,\
+  frontend/src/**/*.spec.ts,\
+  frontend/src/**/*.spec.tsx
+
+# Source encoding
+sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+sonar.cpd.exclusions=\
+  backend/**/*_test.go,\
+  backend/**/testdata/**,\
+  backend/**/test-data/**,\
+  backend/generated-go,\
+  frontend/src/**/*.test.ts,\
+  frontend/src/**/*.test.tsx,\
+  proto/gen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ psql -U bbdev bbdev
   - Configuration breaking changes (removed flags, changed behavior)
 - **Description** — Clearly describe what the PR changes and why
 - **Testing** — Include information about how the changes were tested
+- **SonarCloud** — When creating or updating a PR, update `.sonarcloud.properties` to reflect the latest file structure. Use `sonar.exclusions` for generated code, build artifacts, and dependencies (directory paths only). Use `sonar.test.inclusions` for test file patterns (wildcards like `**/*_test.go`). Use `sonar.cpd.exclusions` to skip copy-paste detection on test files
 
 ## Common Go Lint Rules
 


### PR DESCRIPTION
## Summary
- Add `.sonarcloud.properties` to fix SonarQube false positives on test files (fixes duplicate code and security hotspot issues seen in #19310)
- `sonar.exclusions`: generated code (`backend/generated-go`, `proto/gen`), build artifacts (`bytebase-build`), and dependencies (`frontend/node_modules`)
- `sonar.test.inclusions`: classify test files (`**/*_test.go`, `**/testdata/**`, `**/*.test.ts`) as tests so they don't count as source
- `sonar.cpd.exclusions`: skip copy-paste detection on test files and generated code
- Update `CLAUDE.md` with PR guidelines for keeping `.sonarcloud.properties` up to date

Resolves BYT-8874

## Test plan
- [ ] Verify SonarCloud analysis passes on this PR without duplicate code or security hotspot false positives from test files
- [ ] Confirm the properties file is picked up by SonarCloud automatic analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)