### PR TITLE
fix(elasticsearch): flatten multi-line JSON bodies for NDJSON endpoints

### DIFF
--- a/backend/plugin/db/elasticsearch/elasticsearch.go
+++ b/backend/plugin/db/elasticsearch/elasticsearch.go
@@ -408,9 +408,12 @@ func (d *Driver) QueryConn(_ context.Context, _ *sql.Conn, statement string, _ d
 		if err := func() error {
 			startTime := time.Now()
 			// send HTTP request.
+			// For NDJSON endpoints (_msearch, _bulk, etc.), each JSON object must
+			// be on a single line. Remove embedded newlines from each data item
+			// before joining with newline separators.
 			var data []byte
 			for _, item := range request.Data {
-				data = append(data, []byte(item)...)
+				data = append(data, []byte(strings.ReplaceAll(item, "\n", ""))...)
 				data = append(data, '\n')
 			}
 			var resp *http.Response


### PR DESCRIPTION
## Summary
- ElasticSearch NDJSON endpoints (`_msearch`, `_bulk`, etc.) require each JSON object on a single line
- Multi-line pretty-printed JSON bodies were sent as-is, causing ES to parse line-by-line and fail with `x_content_e_o_f_exception` when encountering partial fragments like `{` on its own line
- Strip embedded newlines from each data item before joining with NDJSON line separators, matching Kibana's `sendRequest()` behavior

## Test plan
- [x] Existing elasticsearch plugin tests pass
- [x] Existing elasticsearch parser tests pass
- [x] Lint clean
- [x] Build succeeds
- [x] Manual test: run `_msearch` query with multi-line JSON bodies against a live ES instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)