### PR TITLE
chore: bump gomongo to implement remaining M3 admin commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/beltran/gohive/v2 v2.0.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
-	github.com/bytebase/gomongo v0.0.0-20260130091827-042518342705
+	github.com/bytebase/gomongo v0.0.0-20260211083148-d2ea344b4b65
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/cenkalti/backoff/v5 v5.0.3

--- a/go.sum
+++ b/go.sum
@@ -857,8 +857,8 @@ github.com/bytebase/gh-ost2 v1.1.7-0.20251002210738-35e5dddaad7c h1:scJ4ycKuUAaA
 github.com/bytebase/gh-ost2 v1.1.7-0.20251002210738-35e5dddaad7c/go.mod h1:X0CGYwIZUnjfrv02/nBlftxqSBMm4mYJzFwiyn2D4d8=
 github.com/bytebase/go-mssqldb v0.0.0-20240801091126-3ff3ca07d898 h1:0ggqA9XL4yvtePPvRDRYMed3jtdNk4s0o8AMW8uJPSA=
 github.com/bytebase/go-mssqldb v0.0.0-20240801091126-3ff3ca07d898/go.mod h1:2KhUz4GSLcdJGXSJMXAf2BjmakcgoOkNyPpHdGAxRpY=
-github.com/bytebase/gomongo v0.0.0-20260130091827-042518342705 h1:rGhKFO4BLZVJl98QXPf/wkkBAqbVOkq+SktXh459wB4=
-github.com/bytebase/gomongo v0.0.0-20260130091827-042518342705/go.mod h1:4dDI0RO2BK9/BD4VE+YqvlCj/qoVMquZ99QZdRlT8Wg=
+github.com/bytebase/gomongo v0.0.0-20260211083148-d2ea344b4b65 h1:RvViQx0e24DeDJ0iENOl2wP9q7bVbFFaIyOo0whZCK4=
+github.com/bytebase/gomongo v0.0.0-20260211083148-d2ea344b4b65/go.mod h1:4dDI0RO2BK9/BD4VE+YqvlCj/qoVMquZ99QZdRlT8Wg=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
 github.com/bytebase/parser v0.0.0-20260130090605-effef73942d9 h1:q5MnVPWlV/p3MPe60SysVoUaEnyeS6+OOOk0F3DLLK8=


### PR DESCRIPTION
## Summary
- Bump gomongo to [d2ea344](https://github.com/bytebase/gomongo/commit/d2ea344b4b65) (PR [#24](https://github.com/bytebase/gomongo/pull/24)) which completes the M3 milestone by implementing all 15 remaining administrative commands natively via Go driver APIs, eliminating mongosh fallback for all M3 operations

## Test plan
- [x] `go build` passes
- [x] gomongo PR CI passed (lint, unit tests, integration tests on MongoDB 4, 8, and DocumentDB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)