### PR TITLE
fix(pg): support CTE in prior backup statement generation

### DIFF
--- a/backend/plugin/parser/pg/test-data/test_backup.yaml
+++ b/backend/plugin/parser/pg/test-data/test_backup.yaml
@@ -174,3 +174,48 @@
       endposition:
         line: 3
         column: 20
+- input: WITH cte AS (SELECT a FROM test2) UPDATE test SET c = 1 FROM cte WHERE test.a = cte.a;
+  result:
+    - statement: |-
+        CREATE TABLE "backupSchema"."rollback_test_public" AS
+        WITH cte AS (SELECT a FROM test2)
+          SELECT "public"."test".* FROM test, cte WHERE test.a = cte.a;
+      sourceschema: public
+      sourcetablename: test
+      targettablename: rollback_test_public
+      startposition:
+        line: 1
+        column: 0
+      endposition:
+        line: 1
+        column: 86
+- input: WITH cte AS (SELECT a FROM test2) DELETE FROM test USING cte WHERE test.a = cte.a;
+  result:
+    - statement: |-
+        CREATE TABLE "backupSchema"."rollback_test_public" AS
+        WITH cte AS (SELECT a FROM test2)
+          SELECT "public"."test".* FROM test, cte WHERE test.a = cte.a;
+      sourceschema: public
+      sourcetablename: test
+      targettablename: rollback_test_public
+      startposition:
+        line: 1
+        column: 0
+      endposition:
+        line: 1
+        column: 82
+- input: WITH cte AS (SELECT a FROM test2) UPDATE test ta SET b = 1 FROM cte WHERE cte.a = ta.a;
+  result:
+    - statement: |-
+        CREATE TABLE "backupSchema"."rollback_test_public" AS
+        WITH cte AS (SELECT a FROM test2)
+          SELECT "ta".* FROM test ta, cte WHERE cte.a = ta.a;
+      sourceschema: public
+      sourcetablename: test
+      targettablename: rollback_test_public
+      startposition:
+        line: 1
+        column: 0
+      endposition:
+        line: 1
+        column: 87


### PR DESCRIPTION
## Summary

- Fix prior backup failing with `relation "cte" does not exist` when UPDATE/DELETE statements use CTEs (WITH clause)
- Add `extractCTE` function to extract WITH clause from PostgreSQL UPDATE/DELETE parse tree and include it in the generated backup SQL
- Add test cases covering UPDATE with CTE, DELETE with CTE, and UPDATE with CTE + table alias

Fixes BYT-8867
https://linear.app/bytebase/issue/BYT-8867/failed-to-execute-backup-statement-relation-cte-does-not-exist

## Test plan

- [x] `TestBackup` passes with 3 new CTE test cases
- [x] Generated backup SQL verified parseable by PostgreSQL parser
- [x] Existing backup tests unaffected
- [ ] Manual test: run a CTE-based UPDATE through Bytebase with prior backup enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)