### PR TITLE
fix(migrator): handle scalar taskUpdate.tasks in migration 3.7.20

### DIFF
--- a/backend/migrator/migration/3.7/0020##add_and_migrate_task_environment_change_stage_uid_to_envid_remove_stage.sql
+++ b/backend/migrator/migration/3.7/0020##add_and_migrate_task_environment_change_stage_uid_to_envid_remove_stage.sql
@@ -70,8 +70,10 @@ SET payload = jsonb_set(
     )
 )
 WHERE payload->'taskUpdate' IS NOT NULL
-  AND payload->'taskUpdate'->'tasks' IS NOT NULL
-  AND jsonb_array_length(payload->'taskUpdate'->'tasks') > 0;
+  AND jsonb_typeof(payload->'taskUpdate'->'tasks') = 'array'
+  AND CASE WHEN jsonb_typeof(payload->'taskUpdate'->'tasks') = 'array'
+           THEN jsonb_array_length(payload->'taskUpdate'->'tasks') > 0
+           ELSE false END;
 
 -- Update all issue_comment entries with task references in taskPriorBackup
 UPDATE issue_comment

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -1,11 +1,14 @@
 package migrator
 
 import (
+	"context"
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
 )
 
@@ -29,4 +32,97 @@ func TestVersionUnique(t *testing.T) {
 		}
 		versions[file.version.String()] = struct{}{}
 	}
+}
+
+// TestMigration3_7_20_ScalarTaskUpdateTasks verifies that the migration 3.7.20
+// UPDATE on issue_comment handles scalar (non-array) taskUpdate.tasks values
+// without error. Regression test for "cannot get array length of a scalar".
+func TestMigration3_7_20_ScalarTaskUpdateTasks(t *testing.T) {
+	ctx := context.Background()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+
+	// Create minimal schema.
+	setup := `
+		CREATE TABLE stage (
+			id INT PRIMARY KEY,
+			environment TEXT NOT NULL
+		);
+		INSERT INTO stage (id, environment) VALUES (101, 'environments/prod');
+
+		CREATE OR REPLACE FUNCTION update_stage_reference(resource_path text) RETURNS text AS $$
+		DECLARE
+			stage_match text;
+			stage_id int;
+			environment_id text;
+		BEGIN
+			IF resource_path !~ '/stages/[0-9]+' THEN
+				RETURN resource_path;
+			END IF;
+			stage_match := substring(resource_path from '/stages/([0-9]+)');
+			IF stage_match IS NULL THEN
+				RETURN resource_path;
+			END IF;
+			stage_id := stage_match::int;
+			SELECT s.environment INTO environment_id FROM stage s WHERE s.id = stage_id;
+			IF environment_id IS NULL THEN
+				RETURN resource_path;
+			END IF;
+			RETURN regexp_replace(resource_path, '/stages/' || stage_id, '/stages/' || environment_id);
+		END;
+		$$ LANGUAGE plpgsql;
+
+		CREATE TABLE issue_comment (
+			id SERIAL PRIMARY KEY,
+			payload JSONB NOT NULL
+		);
+
+		INSERT INTO issue_comment (payload) VALUES
+			('{"taskUpdate":{"tasks":["projects/p1/rollouts/1/stages/101/tasks/1"]}}'),
+			('{"taskUpdate":{"tasks":"projects/p1/rollouts/1/stages/101/tasks/1"}}'),
+			('{"taskUpdate":{"tasks":null}}');
+	`
+	_, err := db.ExecContext(ctx, setup)
+	require.NoError(t, err)
+
+	// Run the exact UPDATE from migration 3.7.20 with the fixed WHERE clause.
+	migrate := `
+		UPDATE issue_comment
+		SET payload = jsonb_set(
+			payload,
+			'{taskUpdate,tasks}',
+			(
+				SELECT jsonb_agg(update_stage_reference(task_ref))
+				FROM jsonb_array_elements_text(payload->'taskUpdate'->'tasks') AS task_ref
+			)
+		)
+		WHERE payload->'taskUpdate' IS NOT NULL
+		  AND jsonb_typeof(payload->'taskUpdate'->'tasks') = 'array'
+		  AND CASE WHEN jsonb_typeof(payload->'taskUpdate'->'tasks') = 'array'
+		           THEN jsonb_array_length(payload->'taskUpdate'->'tasks') > 0
+		           ELSE false END;
+	`
+	_, err = db.ExecContext(ctx, migrate)
+	require.NoError(t, err, "migration UPDATE must not fail on scalar tasks values")
+
+	// Verify: valid array row was rewritten with environment ID.
+	var arrayPayload string
+	err = db.QueryRowContext(ctx, `SELECT payload::text FROM issue_comment WHERE id = 1`).Scan(&arrayPayload)
+	require.NoError(t, err)
+	assert.Contains(t, arrayPayload, "environments/prod", "array row should have rewritten stage reference")
+	assert.NotContains(t, arrayPayload, "stages/101", "array row should no longer have numeric stage ID")
+
+	// Verify: scalar row was NOT modified.
+	var scalarPayload string
+	err = db.QueryRowContext(ctx, `SELECT payload::text FROM issue_comment WHERE id = 2`).Scan(&scalarPayload)
+	require.NoError(t, err)
+	assert.Contains(t, scalarPayload, "stages/101", "scalar row should be unchanged")
+
+	// Verify: null row was NOT modified.
+	var nullPayload string
+	err = db.QueryRowContext(ctx, `SELECT payload::text FROM issue_comment WHERE id = 3`).Scan(&nullPayload)
+	require.NoError(t, err)
+	assert.Contains(t, nullPayload, "null", "null row should be unchanged")
 }


### PR DESCRIPTION
## Summary
- Migration 3.7.20 calls `jsonb_array_length(payload->'taskUpdate'->'tasks')` which crashes with "cannot get array length of a scalar" when `tasks` is a scalar string instead of a JSON array
- Replace `IS NOT NULL` guard with `jsonb_typeof(...) = 'array'` and wrap `jsonb_array_length` in a `CASE` expression (PostgreSQL doesn't guarantee short-circuit AND evaluation)
- Affects customers upgrading from ~3.4.0 to 3.10.0+ where some `issue_comment` rows have scalar `tasks` values

## Test plan
- [x] `TestMigration3_7_20_ScalarTaskUpdateTasks` — testcontainer-based regression test that inserts array, scalar, and null `tasks` values, runs the fixed UPDATE, and verifies: no SQL error, array row rewritten, scalar/null rows untouched
- [x] `TestLatestVersion` — existing test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)