### PR TITLE
feat(table): add checks column and simplify column sizing

### DIFF
--- a/frontend/src/components/Plan/components/PlanDataTable/PlanDataTable.vue
+++ b/frontend/src/components/Plan/components/PlanDataTable/PlanDataTable.vue
@@ -34,7 +34,7 @@ import {
   extractProjectResourceName,
   TailwindBreakpoints,
 } from "@/utils";
-import PlanCheckRunStatusIcon from "../PlanCheckRunStatusIcon.vue";
+import PlanCheckStatusCount from "../PlanCheckStatusCount.vue";
 
 withDefaults(
   defineProps<{
@@ -58,9 +58,7 @@ const columnList = computed((): DataTableColumn<Plan>[] => {
     {
       key: "title",
       title: t("issue.table.name"),
-      minWidth: 200,
       ellipsis: true,
-      resizable: true,
       render: (plan) => {
         const showDraftTag = plan.issue === "" && !plan.hasRollout;
         const isDeleted = plan.state === State.DELETED;
@@ -85,7 +83,6 @@ const columnList = computed((): DataTableColumn<Plan>[] => {
             ) : (
               <span class="opacity-60 italic">{t("common.untitled")}</span>
             )}
-            <PlanCheckRunStatusIcon plan={plan} size="small" />
             {isDeleted && (
               <NTag type="warning" round size="small">
                 {t("common.closed")}
@@ -101,19 +98,24 @@ const columnList = computed((): DataTableColumn<Plan>[] => {
       },
     },
     {
+      key: "checks",
+      title: t("plan.checks.self"),
+      width: 200,
+      hide: !showExtendedColumns.value,
+      render: (plan) => <PlanCheckStatusCount plan={plan} size="small" />,
+    },
+    {
       key: "updateTime",
       title: t("issue.table.updated"),
-      minWidth: 128,
+      width: 150,
       hide: !showExtendedColumns.value,
       render: (plan) => <Timestamp timestamp={plan.updateTime} />,
     },
     {
       key: "creator",
       title: t("issue.table.creator"),
-      minWidth: 200,
+      width: 150,
       hide: !showExtendedColumns.value,
-      resizable: true,
-      ellipsis: true,
       render: (plan) => {
         const creator =
           userStore.getUserByIdentifier(plan.creator) ||
@@ -135,9 +137,7 @@ const columnList = computed((): DataTableColumn<Plan>[] => {
 });
 
 const scrollX = computed(() => {
-  return columnList.value.reduce((sum, col) => {
-    return sum + ((col as { minWidth?: number }).minWidth ?? 100);
-  }, 0);
+  return 700;
 });
 
 const rowProps = (plan: Plan) => {


### PR DESCRIPTION
- Replace PlanCheckRunStatusIcon with a compact PlanCheckStatusCount component in the table to surface check counts when extended columns are visible.
- Add a dedicated "checks" column (width 200) that conditionally shows PlanCheckStatusCount when showExtendedColumns is enabled.
- Remove per-column minWidth/resizable/ellipsis settings and replace several minWidth values with fixed widths (updateTime/creator) to simplify layout.
- Remove the inline status icon from the title cell to avoid duplication with the new checks column.
- Replace dynamic scrollX calculation with a fixed value (700) to simplify horizontal sizing logic.

These changes make the table layout simpler and introduce a focused, dedicated checks column to improve visibility of plan check status.

<img width="2206" height="930" alt="image" src="https://github.com/user-attachments/assets/0fb0a1d1-8fdf-4f57-99ef-be4f8b5e08bf" />

Close BYT-8882