### PR TITLE
fix: compute access grant expire_time at activation time for TTL-based grants

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -7030,7 +7030,7 @@ components:
                   title: ttl
                   description: |-
                     Input only. The time-to-live duration for the access grant.
-                     The server computes `expire_time` from this value at creation time.
+                     The server computes `expire_time` from this value at activation time.
                   $ref: '#/components/schemas/google.protobuf.Duration'
               title: ttl
               required:

--- a/backend/generated-go/store/access_grant.pb.go
+++ b/backend/generated-go/store/access_grant.pb.go
@@ -9,6 +9,7 @@ package store
 import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	durationpb "google.golang.org/protobuf/types/known/durationpb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -119,10 +120,14 @@ type AccessGrantPayload struct {
 	// The query permission granted.
 	Query string `protobuf:"bytes,3,opt,name=query,proto3" json:"query,omitempty"`
 	// Whether the grant allows unmasking sensitive data.
-	Unmask        bool   `protobuf:"varint,4,opt,name=unmask,proto3" json:"unmask,omitempty"`
-	Reason        string `protobuf:"bytes,5,opt,name=reason,proto3" json:"reason,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Unmask bool   `protobuf:"varint,4,opt,name=unmask,proto3" json:"unmask,omitempty"`
+	Reason string `protobuf:"bytes,5,opt,name=reason,proto3" json:"reason,omitempty"`
+	// The requested duration for the access grant.
+	// Stored when the user provides a TTL instead of an absolute expire_time.
+	// The server computes expire_time from this value at activation time.
+	RequestedDuration *durationpb.Duration `protobuf:"bytes,6,opt,name=requested_duration,json=requestedDuration,proto3" json:"requested_duration,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *AccessGrantPayload) Reset() {
@@ -190,24 +195,32 @@ func (x *AccessGrantPayload) GetReason() string {
 	return ""
 }
 
+func (x *AccessGrantPayload) GetRequestedDuration() *durationpb.Duration {
+	if x != nil {
+		return x.RequestedDuration
+	}
+	return nil
+}
+
 var File_store_access_grant_proto protoreflect.FileDescriptor
 
 const file_store_access_grant_proto_rawDesc = "" +
 	"\n" +
-	"\x18store/access_grant.proto\x12\x0ebytebase.store\"U\n" +
+	"\x18store/access_grant.proto\x12\x0ebytebase.store\x1a\x1egoogle/protobuf/duration.proto\"U\n" +
 	"\vAccessGrant\"F\n" +
 	"\x06Status\x12\x16\n" +
 	"\x12STATUS_UNSPECIFIED\x10\x00\x12\v\n" +
 	"\aPENDING\x10\x01\x12\n" +
 	"\n" +
 	"\x06ACTIVE\x10\x02\x12\v\n" +
-	"\aREVOKED\x10\x03\"\x8f\x01\n" +
+	"\aREVOKED\x10\x03\"\xd9\x01\n" +
 	"\x12AccessGrantPayload\x12\x19\n" +
 	"\bissue_id\x18\x01 \x01(\x03R\aissueId\x12\x18\n" +
 	"\atargets\x18\x02 \x03(\tR\atargets\x12\x14\n" +
 	"\x05query\x18\x03 \x01(\tR\x05query\x12\x16\n" +
 	"\x06unmask\x18\x04 \x01(\bR\x06unmask\x12\x16\n" +
-	"\x06reason\x18\x05 \x01(\tR\x06reasonB\x93\x01\n" +
+	"\x06reason\x18\x05 \x01(\tR\x06reason\x12H\n" +
+	"\x12requested_duration\x18\x06 \x01(\v2\x19.google.protobuf.DurationR\x11requestedDurationB\x93\x01\n" +
 	"\x12com.bytebase.storeB\x10AccessGrantProtoP\x01Z\x12generated-go/store\xa2\x02\x03BSX\xaa\x02\x0eBytebase.Store\xca\x02\x0eBytebase\\Store\xe2\x02\x1aBytebase\\Store\\GPBMetadata\xea\x02\x0fBytebase::Storeb\x06proto3"
 
 var (
@@ -225,16 +238,18 @@ func file_store_access_grant_proto_rawDescGZIP() []byte {
 var file_store_access_grant_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_store_access_grant_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
 var file_store_access_grant_proto_goTypes = []any{
-	(AccessGrant_Status)(0),    // 0: bytebase.store.AccessGrant.Status
-	(*AccessGrant)(nil),        // 1: bytebase.store.AccessGrant
-	(*AccessGrantPayload)(nil), // 2: bytebase.store.AccessGrantPayload
+	(AccessGrant_Status)(0),     // 0: bytebase.store.AccessGrant.Status
+	(*AccessGrant)(nil),         // 1: bytebase.store.AccessGrant
+	(*AccessGrantPayload)(nil),  // 2: bytebase.store.AccessGrantPayload
+	(*durationpb.Duration)(nil), // 3: google.protobuf.Duration
 }
 var file_store_access_grant_proto_depIdxs = []int32{
-	0, // [0:0] is the sub-list for method output_type
-	0, // [0:0] is the sub-list for method input_type
-	0, // [0:0] is the sub-list for extension type_name
-	0, // [0:0] is the sub-list for extension extendee
-	0, // [0:0] is the sub-list for field type_name
+	3, // 0: bytebase.store.AccessGrantPayload.requested_duration:type_name -> google.protobuf.Duration
+	1, // [1:1] is the sub-list for method output_type
+	1, // [1:1] is the sub-list for method input_type
+	1, // [1:1] is the sub-list for extension type_name
+	1, // [1:1] is the sub-list for extension extendee
+	0, // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_store_access_grant_proto_init() }

--- a/backend/generated-go/store/access_grant_equal.pb.go
+++ b/backend/generated-go/store/access_grant_equal.pb.go
@@ -40,5 +40,8 @@ func (x *AccessGrantPayload) Equal(y *AccessGrantPayload) bool {
 	if x.Reason != y.Reason {
 		return false
 	}
+	if p, q := x.RequestedDuration, y.RequestedDuration; (p == nil && q != nil) || (p != nil && (q == nil || p.Seconds != q.Seconds || p.Nanos != q.Nanos)) {
+		return false
+	}
 	return true
 }

--- a/backend/generated-go/v1/access_grant_service.pb.go
+++ b/backend/generated-go/v1/access_grant_service.pb.go
@@ -258,7 +258,7 @@ type AccessGrant_ExpireTime struct {
 
 type AccessGrant_Ttl struct {
 	// Input only. The time-to-live duration for the access grant.
-	// The server computes `expire_time` from this value at creation time.
+	// The server computes `expire_time` from this value at activation time.
 	Ttl *durationpb.Duration `protobuf:"bytes,11,opt,name=ttl,proto3,oneof"`
 }
 

--- a/backend/migrator/migration/3.15/0010##create_access_grant_table.sql
+++ b/backend/migrator/migration/3.15/0010##create_access_grant_table.sql
@@ -3,7 +3,7 @@ CREATE TABLE access_grant (
     project text NOT NULL REFERENCES project(resource_id),
     creator text NOT NULL REFERENCES principal(email) ON UPDATE CASCADE,
     status text NOT NULL DEFAULT 'PENDING',
-    expire_time timestamptz NOT NULL,
+    expire_time timestamptz,
     -- Stored as AccessGrantPayload (proto/store/store/access_grant.proto)
     payload jsonb NOT NULL DEFAULT '{}',
     created_at timestamptz NOT NULL DEFAULT now(),

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -580,7 +580,7 @@ CREATE TABLE access_grant (
     project text NOT NULL REFERENCES project(resource_id),
     creator text NOT NULL REFERENCES principal(email) ON UPDATE CASCADE,
     status text NOT NULL DEFAULT 'PENDING',
-    expire_time timestamptz NOT NULL,
+    expire_time timestamptz,
     -- Stored as AccessGrantPayload (proto/store/store/access_grant.proto)
     payload jsonb NOT NULL DEFAULT '{}',
     created_at timestamptz NOT NULL DEFAULT now(),

--- a/backend/store/access_grant.go
+++ b/backend/store/access_grant.go
@@ -23,7 +23,7 @@ type AccessGrantMessage struct {
 	ProjectID  string
 	Creator    string
 	Status     storepb.AccessGrant_Status
-	ExpireTime time.Time
+	ExpireTime *time.Time
 	Payload    *storepb.AccessGrantPayload
 	// Reason is used as the issue description during creation.
 	Reason string
@@ -47,8 +47,9 @@ type FindAccessGrantMessage struct {
 
 // UpdateAccessGrantMessage is the message for updating an access grant.
 type UpdateAccessGrantMessage struct {
-	Status  *storepb.AccessGrant_Status
-	Payload *storepb.AccessGrantPayload
+	Status     *storepb.AccessGrant_Status
+	ExpireTime *time.Time
+	Payload    *storepb.AccessGrantPayload
 }
 
 // CreateAccessGrant creates a new access grant.
@@ -188,6 +189,9 @@ func (s *Store) UpdateAccessGrant(ctx context.Context, id string, update *Update
 
 	if v := update.Status; v != nil {
 		set.Comma("status = ?", v.String())
+	}
+	if v := update.ExpireTime; v != nil {
+		set.Comma("expire_time = ?", *v)
 	}
 	if v := update.Payload; v != nil {
 		p, err := protojson.Marshal(v)

--- a/frontend/src/types/proto-es/v1/access_grant_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/access_grant_service_pb.d.ts
@@ -60,7 +60,7 @@ export declare type AccessGrant = Message<"bytebase.v1.AccessGrant"> & {
   } | {
     /**
      * Input only. The time-to-live duration for the access grant.
-     * The server computes `expire_time` from this value at creation time.
+     * The server computes `expire_time` from this value at activation time.
      *
      * @generated from field: google.protobuf.Duration ttl = 11;
      */

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -15947,7 +15947,7 @@ components:
                   title: ttl
                   description: |-
                     Input only. The time-to-live duration for the access grant.
-                     The server computes `expire_time` from this value at creation time.
+                     The server computes `expire_time` from this value at activation time.
                   writeOnly: true
                   $ref: '#/components/schemas/google.protobuf.Duration'
               title: ttl

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -362,6 +362,7 @@
 | query | [string](#string) |  | The query permission granted. |
 | unmask | [bool](#bool) |  | Whether the grant allows unmasking sensitive data. |
 | reason | [string](#string) |  |  |
+| requested_duration | [google.protobuf.Duration](#google-protobuf-Duration) |  | The requested duration for the access grant. Stored when the user provides a TTL instead of an absolute expire_time. The server computes expire_time from this value at activation time. |
 
 
 

--- a/proto/gen/grpc-doc/store/index.html
+++ b/proto/gen/grpc-doc/store/index.html
@@ -1551,6 +1551,15 @@ Format: instances/{instance}/databases/{database} </p></td>
                   <td><p> </p></td>
                 </tr>
               
+                <tr>
+                  <td>requested_duration</td>
+                  <td><a href="#google.protobuf.Duration">google.protobuf.Duration</a></td>
+                  <td></td>
+                  <td><p>The requested duration for the access grant.
+Stored when the user provides a TTL instead of an absolute expire_time.
+The server computes expire_time from this value at activation time. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -766,7 +766,7 @@ Authorization method for RPC calls.
 | creator | [string](#string) |  | The creator of the access grant. Format: users/{email} |
 | status | [AccessGrant.Status](#bytebase-v1-AccessGrant-Status) |  | The status of the access grant. An ACTIVE grant with `expire_time` in the past is effectively expired and no longer authorizes access. Use `expire_time` to determine whether an ACTIVE grant has expired. |
 | expire_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | The expiration time of the access grant. |
-| ttl | [google.protobuf.Duration](#google-protobuf-Duration) |  | Input only. The time-to-live duration for the access grant. The server computes `expire_time` from this value at creation time. |
+| ttl | [google.protobuf.Duration](#google-protobuf-Duration) |  | Input only. The time-to-live duration for the access grant. The server computes `expire_time` from this value at activation time. |
 | issue | [string](#string) |  | The issue associated with the access grant. Can be empty. Format: projects/{project}/issues/{issue} |
 | targets | [string](#string) | repeated | The target databases for this access grant. Format: instances/{instance}/databases/{database} |
 | query | [string](#string) |  | The query permission granted. |

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -3002,7 +3002,7 @@ whether an ACTIVE grant has expired. </p></td>
                   <td><a href="#google.protobuf.Duration">google.protobuf.Duration</a></td>
                   <td></td>
                   <td><p>Input only. The time-to-live duration for the access grant.
-The server computes `expire_time` from this value at creation time. </p></td>
+The server computes `expire_time` from this value at activation time. </p></td>
                 </tr>
               
                 <tr>

--- a/proto/store/store/access_grant.proto
+++ b/proto/store/store/access_grant.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package bytebase.store;
 
+import "google/protobuf/duration.proto";
+
 option go_package = "generated-go/store";
 
 message AccessGrant {
@@ -28,4 +30,9 @@ message AccessGrantPayload {
   bool unmask = 4;
 
   string reason = 5;
+
+  // The requested duration for the access grant.
+  // Stored when the user provides a TTL instead of an absolute expire_time.
+  // The server computes expire_time from this value at activation time.
+  google.protobuf.Duration requested_duration = 6;
 }

--- a/proto/v1/v1/access_grant_service.proto
+++ b/proto/v1/v1/access_grant_service.proto
@@ -106,7 +106,7 @@ message AccessGrant {
     google.protobuf.Timestamp expire_time = 4;
 
     // Input only. The time-to-live duration for the access grant.
-    // The server computes `expire_time` from this value at creation time.
+    // The server computes `expire_time` from this value at activation time.
     google.protobuf.Duration ttl = 11 [(google.api.field_behavior) = INPUT_ONLY];
   }
 


### PR DESCRIPTION
## Summary
- Following GCP PAM's design, TTL-based access grants now store the requested duration in the payload and compute `expire_time` when activated (PENDING → ACTIVE), rather than at creation time
- Made `expire_time` nullable so TTL-based grants don't carry a misleading preliminary value during PENDING status
- Added `requested_duration` field to `AccessGrantPayload` to persist the user's requested TTL

## Test plan
- [ ] Create an access grant with TTL — verify `expire_time` is NULL while PENDING
- [ ] Activate the grant — verify `expire_time` is computed as `now() + requested_duration`
- [ ] Create an access grant with explicit `expire_time` — verify it is stored as-is and unchanged on activation
- [ ] Filter access grants by `expire_time` — verify TTL-based PENDING grants (NULL expire_time) are excluded from time-based filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)