### PR TITLE
fix(elasticsearch): handle parsing errors in GetQuerySpan

### DIFF
--- a/backend/plugin/parser/elasticsearch/query_span_test.go
+++ b/backend/plugin/parser/elasticsearch/query_span_test.go
@@ -56,3 +56,14 @@ func TestGetQuerySpan(t *testing.T) {
 		a.NoError(err)
 	}
 }
+
+func TestGetQuerySpan_Error(t *testing.T) {
+	// MongoDB style query, definitely not ElasticSearch
+	stmt := "db.users.find({})"
+	span, err := GetQuerySpan(context.Background(), base.GetQuerySpanContext{}, base.Statement{Text: stmt}, "", "", false)
+
+	// New behavior: returns error
+	require.Error(t, err)
+	require.Nil(t, span)
+	require.Contains(t, err.Error(), "Syntax error")
+}

--- a/backend/plugin/parser/elasticsearch/test-data/query_span.yaml
+++ b/backend/plugin/parser/elasticsearch/test-data/query_span.yaml
@@ -189,8 +189,3 @@
 - description: PATCH document
   statement: "PATCH /my_index/_doc/1"
   queryType: 5  # DML
-
-# Unknown method
-- description: Unknown method
-  statement: "UNKNOWN /my_index"
-  queryType: 0  # QueryTypeUnknown


### PR DESCRIPTION
Previously, GetQuerySpan ignored errors from ParseElasticsearchREST and returned QueryTypeUnknown for malformed queries (e.g. MongoDB queries). This resulted in a "permission denied" error ("disallowed query type") instead of a syntax error.

This change modifies GetQuerySpan to:
1. Propagate errors from ParseElasticsearchREST.
2. Check for syntax errors in the ParseResult and return a formatted error if any exist.

This ensures that invalid queries result in a proper syntax error message.