### PR TITLE
refactor(frontend): remove overrideMainContainerClass mechanism

### DIFF
--- a/frontend/src/components/AuditLog/AuditLogDataTable.vue
+++ b/frontend/src/components/AuditLog/AuditLogDataTable.vue
@@ -3,6 +3,7 @@
     size="small"
     :columns="columnList"
     :data="auditLogList"
+    :bordered="false"
     :striped="true"
     :loading="loading"
     :row-key="(data: AuditLog) => data.name"

--- a/frontend/src/components/AuditLog/PagedAuditLogDataTable.vue
+++ b/frontend/src/components/AuditLog/PagedAuditLogDataTable.vue
@@ -2,6 +2,7 @@
   <PagedTable
     ref="auditPagedTable"
     :session-key="`bb.page-audit-log-table.settings-audit-log-v1-table.${parent}`"
+    :footer-class="'mx-4'"
     :fetch-list="fetchAuditLog"
     :order-keys="['create_time']"
   >

--- a/frontend/src/components/DatabaseGroup/DatabaseGroupDataTable.vue
+++ b/frontend/src/components/DatabaseGroup/DatabaseGroupDataTable.vue
@@ -47,7 +47,7 @@ const props = withDefaults(
     selectedDatabaseGroupNames?: string[];
   }>(),
   {
-    bordered: true,
+    bordered: false,
     pageSize: 20,
     selectedDatabaseGroupNames: () => [],
   }

--- a/frontend/src/components/Plan/components/PlanDataTable/PlanDataTable.vue
+++ b/frontend/src/components/Plan/components/PlanDataTable/PlanDataTable.vue
@@ -6,7 +6,7 @@
       :columns="columnList"
       :data="planList"
       :striped="true"
-      :bordered="true"
+      :bordered="false"
       :loading="loading"
       :scroll-x="scrollX"
       :row-key="(plan: Plan) => plan.name"

--- a/frontend/src/components/Project/ProjectIssuesPanel.vue
+++ b/frontend/src/components/Project/ProjectIssuesPanel.vue
@@ -1,34 +1,34 @@
 <template>
-  <div class="flex flex-col gap-y-2">
-    <NAlert
-      v-if="!hideHint"
-      type="info"
-      closable
-      @close="dismissHint"
-    >
-      {{ $t("issue.subtitle") }}
-    </NAlert>
-    <IssueSearch
-      v-model:params="state.params"
-      :components="['searchbox', 'time-range', 'presets', 'status']"
-    />
-
-    <div class="relative min-h-80">
-      <PagedTable
-        ref="issuePagedTable"
-        session-key="bb.issue-table.project-issues"
-        :fetch-list="fetchIssueList"
+  <div class="flex flex-col">
+    <div class="px-4 flex flex-col gap-y-2 pb-2">
+      <NAlert
+        v-if="!hideHint"
+        type="info"
+        closable
+        @close="dismissHint"
       >
-        <template #table="{ list, loading }">
-          <IssueTableV1
-            :bordered="true"
-            :loading="loading"
-            :issue-list="list"
-            :highlight-text="state.params.query"
-          />
-        </template>
-      </PagedTable>
+        {{ $t("issue.subtitle") }}
+      </NAlert>
+      <IssueSearch
+        v-model:params="state.params"
+        :components="['searchbox', 'time-range', 'presets', 'status']"
+      />
     </div>
+    <PagedTable
+      ref="issuePagedTable"
+      session-key="bb.issue-table.project-issues"
+      :footer-class="'mx-4'"
+      :fetch-list="fetchIssueList"
+    >
+      <template #table="{ list, loading }">
+        <IssueTableV1
+          class="border-x-0"
+          :loading="loading"
+          :issue-list="list"
+          :highlight-text="state.params.query"
+        />
+      </template>
+    </PagedTable>
   </div>
 </template>
 

--- a/frontend/src/components/Project/ProjectReleasesPanel.vue
+++ b/frontend/src/components/Project/ProjectReleasesPanel.vue
@@ -1,40 +1,41 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4">
-    <NAlert type="info">
-      <span>{{ $t("release.usage-description") }}</span>
-      <LearnMoreLink
-        url="https://docs.bytebase.com/gitops/migration-based-workflow/release/?source=console"
-        class="ml-1"
-      />
-    </NAlert>
-
-    <!-- Category Filter -->
-    <div class="flex items-center gap-x-4">
-      <NSelect
-        v-model:value="selectedCategory"
-        :options="categoryOptions"
-        :placeholder="$t('release.filter-by-category')"
-        :loading="categoriesLoading"
-        clearable
-        class="w-64"
-      />
-      <NButton
-        v-if="selectedCategory"
-        @click="clearFilters"
-        quaternary
-      >
-        {{ $t('common.clear-filters') }}
-      </NButton>
+  <div class="w-full flex flex-col">
+    <div class="px-4 flex flex-col gap-y-2 pb-2">
+      <NAlert type="info">
+        <span>{{ $t("release.usage-description") }}</span>
+        <LearnMoreLink
+          url="https://docs.bytebase.com/gitops/migration-based-workflow/release/?source=console"
+          class="ml-1"
+        />
+      </NAlert>
+      <!-- Category Filter -->
+      <div class="flex items-center gap-x-4">
+        <NSelect
+          v-model:value="selectedCategory"
+          :options="categoryOptions"
+          :placeholder="$t('release.filter-by-category')"
+          :loading="categoriesLoading"
+          clearable
+          class="w-64"
+        />
+        <NButton
+          v-if="selectedCategory"
+          @click="clearFilters"
+          quaternary
+        >
+          {{ $t('common.clear-filters') }}
+        </NButton>
+      </div>
     </div>
-
     <PagedTable
       :key="`${project.name}-${selectedCategory || 'all'}`"
       :session-key="`project-${project.name}-releases`"
+      :footer-class="'mx-4'"
       :fetch-list="fetchReleaseList"
     >
       <template #table="{ list, loading }">
         <ReleaseDataTable
-          :bordered="true"
+          :bordered="false"
           :loading="loading"
           :release-list="list"
         />

--- a/frontend/src/components/ProjectDatabasesPanel.vue
+++ b/frontend/src/components/ProjectDatabasesPanel.vue
@@ -1,34 +1,36 @@
 <template>
-  <div class="flex flex-col gap-y-2">
-    <div
-      class="w-full flex flex-col sm:flex-row items-start sm:items-end justify-between gap-2"
-    >
-      <AdvancedSearch
-        v-model:params="state.params"
-        class="flex-1"
-        :autofocus="false"
-        :placeholder="$t('database.filter-database')"
-        :scope-options="scopeOptions"
-      />
-      <PermissionGuardWrapper
-        v-slot="slotProps"
-        :project="project"
-        :permissions="[
-          'bb.instances.list',
-          ...PERMISSIONS_FOR_DATABASE_CREATE_ISSUE,
-        ]"
+  <div class="py-4 flex flex-col">
+    <div class="px-4 flex flex-col gap-y-2 pb-2">
+      <div
+        class="w-full flex flex-col sm:flex-row items-start sm:items-end justify-between gap-2"
       >
-        <NButton
-          type="primary"
-          :disabled="slotProps.disabled"
-          @click="state.showCreateDrawer = true"
+        <AdvancedSearch
+          v-model:params="state.params"
+          class="flex-1"
+          :autofocus="false"
+          :placeholder="$t('database.filter-database')"
+          :scope-options="scopeOptions"
+        />
+        <PermissionGuardWrapper
+          v-slot="slotProps"
+          :project="project"
+          :permissions="[
+            'bb.instances.list',
+            ...PERMISSIONS_FOR_DATABASE_CREATE_ISSUE,
+          ]"
         >
-          <template #icon>
-            <PlusIcon class="h-4 w-4" />
-          </template>
-          {{ $t("quick-action.new-db") }}
-        </NButton>
-      </PermissionGuardWrapper>
+          <NButton
+            type="primary"
+            :disabled="slotProps.disabled"
+            @click="state.showCreateDrawer = true"
+          >
+            <template #icon>
+              <PlusIcon class="h-4 w-4" />
+            </template>
+            {{ $t("quick-action.new-db") }}
+          </NButton>
+        </PermissionGuardWrapper>
+      </div>
     </div>
     <DatabaseOperations
       :project-name="project.name"
@@ -39,8 +41,10 @@
     <PagedDatabaseTable
       ref="pagedDatabaseTableRef"
       mode="PROJECT"
+      :bordered="false"
       :show-selection="true"
       :filter="filter"
+      :footer-class="'mx-4'"
       :parent="project.name"
       v-model:selected-database-names="state.selectedDatabaseNames"
     />

--- a/frontend/src/components/ProjectMember/ProjectMemberPanel.vue
+++ b/frontend/src/components/ProjectMember/ProjectMemberPanel.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="w-full mx-auto flex flex-col gap-y-4">
-    <div class="textinfolabel">
+    <div class="textinfolabel px-4 pt-4">
       {{ $t("project.members.description") }}
       <LearnMoreLink
         url="https://docs.bytebase.com/administration/roles/?source=console#project-roles"
       />
     </div>
 
-    <NTabs v-model:value="state.selectedTab" type="bar" animated>
+    <NTabs v-model:value="state.selectedTab" type="bar" :tabs-padding="16" animated>
       <template #suffix>
-        <div class="flex justify-end gap-x-2">
+        <div class="flex justify-end gap-x-2 pr-4">
           <SearchBox
             v-model:value="state.searchText"
             :placeholder="$t('settings.members.search-member')"

--- a/frontend/src/components/ProjectSettingPanel.vue
+++ b/frontend/src/components/ProjectSettingPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-0 pt-4">
+  <div class="w-full flex flex-col gap-y-0 pt-4 px-4">
     <div class="divide-y divide-block-border">
       <!-- General Settings Section -->
       <div class="pb-6 lg:flex">

--- a/frontend/src/components/ProjectWebhookForm.vue
+++ b/frontend/src/components/ProjectWebhookForm.vue
@@ -262,7 +262,6 @@ import { BBAttention } from "@/bbkit";
 import RequiredStar from "@/components/RequiredStar.vue";
 import { MissingExternalURLAttention } from "@/components/v2/Form";
 import FormLayout from "@/components/v2/Form/FormLayout.vue";
-import { useBodyLayoutContext } from "@/layouts/common";
 import {
   PROJECT_V1_ROUTE_WEBHOOK_DETAIL,
   PROJECT_V1_ROUTE_WEBHOOKS,
@@ -311,10 +310,6 @@ const dialog = useDialog();
 const settingStore = useSettingV1Store();
 const projectStore = useProjectV1Store();
 const projectWebhookV1Store = useProjectWebhookV1Store();
-const { overrideMainContainerClass } = useBodyLayoutContext();
-
-overrideMainContainerClass("!pb-0");
-
 onMounted(async () => {
   await settingStore.getOrFetchSettingByName(Setting_SettingName.APP_IM);
 });

--- a/frontend/src/components/SensitiveData/MaskingExceptionUserTable.vue
+++ b/frontend/src/components/SensitiveData/MaskingExceptionUserTable.vue
@@ -4,7 +4,7 @@
     :columns="accessTableColumns"
     :data="filteredList"
     :row-key="(row: AccessUser) => row.key"
-    :bordered="true"
+    :bordered="false"
     :striped="true"
     :loading="!ready || state.loading"
     :max-height="'calc(100vh - 15rem)'"

--- a/frontend/src/components/SyncDatabaseSchemaV1/index.vue
+++ b/frontend/src/components/SyncDatabaseSchemaV1/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full overflow-hidden flex flex-col">
+  <div class="w-full h-full overflow-hidden flex flex-col px-4">
     <p class="text-sm text-gray-500">
       {{ $t("database.sync-schema.description") }}
       <LearnMoreLink

--- a/frontend/src/components/User/Settings/ServiceAccountPanel.vue
+++ b/frontend/src/components/User/Settings/ServiceAccountPanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="w-full overflow-x-hidden flex flex-col gap-y-4 pb-4">
-    <div class="flex justify-between items-center">
+  <div class="w-full overflow-x-hidden flex flex-col py-4">
+    <div class="flex justify-between items-center px-4 pb-2">
       <div class="flex items-center gap-x-2">
         <p class="text-lg font-medium leading-7 text-main">
           <span>{{ $t("settings.members.service-accounts") }}</span>
@@ -33,6 +33,7 @@
       ref="serviceAccountPagedTable"
       :session-key="sessionKey"
       :fetch-list="fetchServiceAccountList"
+      :footer-class="'mx-4'"
     >
       <template #table="{ list, loading }">
         <UserDataTable
@@ -46,37 +47,38 @@
       </template>
     </PagedTable>
 
-    <div>
+    <div class="px-4">
       <NCheckbox v-model:checked="state.showInactiveList">
         <span class="textinfolabel">
           {{ $t("settings.members.show-inactive") }}
         </span>
       </NCheckbox>
-
-      <template v-if="state.showInactiveList">
-        <div class="flex justify-between items-center mt-2 mb-4">
-          <p class="text-lg font-medium leading-7">
-            <span>{{ $t("settings.members.inactive-service-accounts") }}</span>
-          </p>
-        </div>
-
-        <PagedTable
-          ref="deletedServiceAccountPagedTable"
-          :session-key="deletedSessionKey"
-          :fetch-list="fetchInactiveServiceAccountList"
-        >
-          <template #table="{ list, loading }">
-            <UserDataTable
-              :loading="loading"
-              :show-roles="false"
-              :show-groups="false"
-              :user-list="list"
-              @user-updated="handleServiceAccountRestore"
-            />
-          </template>
-        </PagedTable>
-      </template>
     </div>
+
+    <template v-if="state.showInactiveList">
+      <div class="flex justify-between items-center mt-2 px-4 pb-2">
+        <p class="text-lg font-medium leading-7">
+          <span>{{ $t("settings.members.inactive-service-accounts") }}</span>
+        </p>
+      </div>
+
+      <PagedTable
+        ref="deletedServiceAccountPagedTable"
+        :session-key="deletedSessionKey"
+        :fetch-list="fetchInactiveServiceAccountList"
+        :footer-class="'mx-4'"
+      >
+        <template #table="{ list, loading }">
+          <UserDataTable
+            :loading="loading"
+            :show-roles="false"
+            :show-groups="false"
+            :user-list="list"
+            @user-updated="handleServiceAccountRestore"
+          />
+        </template>
+      </PagedTable>
+    </template>
   </div>
 
   <CreateServiceAccountDrawer

--- a/frontend/src/components/User/Settings/WorkloadIdentityPanel.vue
+++ b/frontend/src/components/User/Settings/WorkloadIdentityPanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="w-full overflow-x-hidden flex flex-col gap-y-4 pb-4">
-    <div class="flex justify-between items-center">
+  <div class="w-full overflow-x-hidden flex flex-col py-4">
+    <div class="flex justify-between items-center px-4 pb-2">
       <div class="flex items-center gap-x-2">
         <p class="text-lg font-medium leading-7 text-main">
           <span>{{ $t("settings.members.workload-identities") }}</span>
@@ -33,6 +33,7 @@
       ref="workloadIdentityPagedTable"
       :session-key="sessionKey"
       :fetch-list="fetchWorkloadIdentityList"
+      :footer-class="'mx-4'"
     >
       <template #table="{ list, loading }">
         <UserDataTable
@@ -46,39 +47,40 @@
       </template>
     </PagedTable>
 
-    <div>
+    <div class="px-4">
       <NCheckbox v-model:checked="state.showInactiveList">
         <span class="textinfolabel">
           {{ $t("settings.members.show-inactive") }}
         </span>
       </NCheckbox>
-
-      <template v-if="state.showInactiveList">
-        <div class="flex justify-between items-center mt-2 mb-4">
-          <p class="text-lg font-medium leading-7">
-            <span>{{
-              $t("settings.members.inactive-workload-identities")
-            }}</span>
-          </p>
-        </div>
-
-        <PagedTable
-          ref="deletedWorkloadIdentityPagedTable"
-          :session-key="deletedSessionKey"
-          :fetch-list="fetchInactiveWorkloadIdentityList"
-        >
-          <template #table="{ list, loading }">
-            <UserDataTable
-              :loading="loading"
-              :show-roles="false"
-              :show-groups="false"
-              :user-list="list"
-              @user-updated="handleWorkloadIdentityRestore"
-            />
-          </template>
-        </PagedTable>
-      </template>
     </div>
+
+    <template v-if="state.showInactiveList">
+      <div class="flex justify-between items-center mt-2 px-4 pb-2">
+        <p class="text-lg font-medium leading-7">
+          <span>{{
+            $t("settings.members.inactive-workload-identities")
+          }}</span>
+        </p>
+      </div>
+
+      <PagedTable
+        ref="deletedWorkloadIdentityPagedTable"
+        :session-key="deletedSessionKey"
+        :fetch-list="fetchInactiveWorkloadIdentityList"
+        :footer-class="'mx-4'"
+      >
+        <template #table="{ list, loading }">
+          <UserDataTable
+            :loading="loading"
+            :show-roles="false"
+            :show-groups="false"
+            :user-list="list"
+            @user-updated="handleWorkloadIdentityRestore"
+          />
+        </template>
+      </PagedTable>
+    </template>
   </div>
 
   <CreateWorkloadIdentityDrawer

--- a/frontend/src/layouts/BodyLayout.vue
+++ b/frontend/src/layouts/BodyLayout.vue
@@ -52,11 +52,9 @@
         <div
           id="bb-layout-main"
           ref="mainContainerRef"
-          class="md:min-w-0 flex-1 overflow-y-auto py-4"
-          :class="mainContainerClasses"
+          class="md:min-w-0 flex-1 overflow-y-auto"
         >
           <RoutePermissionGuard
-            class="mx-4"
             :routes="[
               ...workspaceRoutes,
               ...workspaceSettingRoutes,
@@ -189,7 +187,7 @@ onUnmounted(() => {
   }
 });
 
-const { mainContainerClasses } = provideBodyLayoutContext({
+provideBodyLayoutContext({
   mainContainerRef,
 });
 </script>

--- a/frontend/src/layouts/IssuesLayout.vue
+++ b/frontend/src/layouts/IssuesLayout.vue
@@ -18,8 +18,7 @@
         <div
           id="bb-layout-main"
           ref="mainContainerRef"
-          class="md:min-w-0 flex-1 overflow-y-auto py-4"
-          :class="mainContainerClasses"
+          class="md:min-w-0 flex-1 overflow-y-auto"
         >
           <!-- Start main area-->
           <router-view name="content" />
@@ -40,7 +39,7 @@ import { provideBodyLayoutContext } from "./common";
 
 const mainContainerRef = ref<HTMLDivElement>();
 
-const { mainContainerClasses } = provideBodyLayoutContext({
+provideBodyLayoutContext({
   mainContainerRef,
 });
 </script>

--- a/frontend/src/layouts/ProjectV1Layout.vue
+++ b/frontend/src/layouts/ProjectV1Layout.vue
@@ -56,7 +56,6 @@ import { projectNamePrefix } from "@/store/modules/v1/common";
 import { DEFAULT_PROJECT_NAME, UNKNOWN_PROJECT_NAME } from "@/types";
 import { State } from "@/types/proto-es/v1/common_pb";
 import { hasProjectPermissionV2 } from "@/utils";
-import { useBodyLayoutContext } from "./common";
 
 const props = defineProps<{
   projectId: string;
@@ -117,8 +116,4 @@ const allowEdit = computed(() => {
 
   return hasProjectPermissionV2(project.value, "bb.projects.update");
 });
-
-const { overrideMainContainerClass } = useBodyLayoutContext();
-
-overrideMainContainerClass("px-4");
 </script>

--- a/frontend/src/layouts/SettingLayout.vue
+++ b/frontend/src/layouts/SettingLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="px-4 min-h-full">
+  <div class="min-h-full">
     <router-view :allow-edit="allowEdit" v-bind="$attrs" />
   </div>
 </template>

--- a/frontend/src/layouts/common.ts
+++ b/frontend/src/layouts/common.ts
@@ -1,5 +1,4 @@
 import { type InjectionKey, inject, provide, type Ref } from "vue";
-import { useClassStack } from "@/utils";
 
 export type BodyLayoutContext = ReturnType<typeof provideBodyLayoutContext>;
 
@@ -10,15 +9,8 @@ const BODY_LAYOUT_CONTEXT_KEY = Symbol(
 export const provideBodyLayoutContext = (params: {
   mainContainerRef: Ref<HTMLDivElement | undefined>;
 }) => {
-  const {
-    classes: mainContainerClasses,
-    override: overrideMainContainerClass,
-  } = useClassStack();
-
   const context = {
     ...params,
-    overrideMainContainerClass,
-    mainContainerClasses,
   };
   provide(BODY_LAYOUT_CONTEXT_KEY, context);
 

--- a/frontend/src/utils/css.ts
+++ b/frontend/src/utils/css.ts
@@ -1,8 +1,3 @@
-import { pullAt } from "lodash-es";
-import { computed, type Raw, ref, unref, watchEffect } from "vue";
-import type { MaybeRef } from "@/types";
-import type { VueClass } from "./types";
-
 // Tailwind CSS default breakpoints
 // https://tailwindcss.com/docs/responsive-design
 export const TailwindBreakpoints = {
@@ -60,37 +55,4 @@ export const callCssVariable = (
   }
 
   return value;
-};
-
-export const useClassStack = () => {
-  type StackItem = {
-    id: number;
-    classes: VueClass;
-  };
-  const context = {
-    serial: 0,
-  };
-  const stack = ref<Raw<StackItem>[]>([]);
-  const override = (classes: MaybeRef<VueClass>) => {
-    watchEffect((cleanup) => {
-      const id = context.serial++;
-      stack.value.push({
-        id,
-        classes: unref(classes),
-      });
-
-      cleanup(() => {
-        const index = stack.value.findIndex((item) => item.id === id);
-        if (index >= 0) {
-          pullAt(stack.value, index);
-        }
-      });
-    });
-  };
-
-  const classes = computed(() => {
-    return stack.value.map((item) => item.classes);
-  });
-
-  return { override, classes };
 };

--- a/frontend/src/views/DashboardLanding.vue
+++ b/frontend/src/views/DashboardLanding.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="px-4 flex flex-col h-full items-center relative">
+  <div class="py-4 px-4 flex flex-col h-full items-center relative">
     <div class="flex-1" />
     <div class="flex-[60%] flex flex-col gap-y-6">
       <div class="flex items-baseline gap-x-4">

--- a/frontend/src/views/DatabaseDashboard.vue
+++ b/frontend/src/views/DatabaseDashboard.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="flex flex-col relative gap-y-4">
+  <div class="py-4 flex flex-col relative">
     <div
-      class="w-full px-4 flex flex-col sm:flex-row items-start sm:items-end justify-between gap-2"
+      class="w-full px-4 pb-2 flex flex-col sm:flex-row items-start sm:items-end justify-between gap-2"
     >
       <AdvancedSearch
         v-model:params="state.params"

--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full h-full flex flex-col gap-4">
+  <div class="py-4 w-full h-full flex flex-col gap-4">
     <NTabs
       type="line"
       :bar-width="200"

--- a/frontend/src/views/ExportCenter/index.vue
+++ b/frontend/src/views/ExportCenter/index.vue
@@ -1,53 +1,54 @@
 <template>
-  <div class="w-full">
-    <div
-      class="w-full flex flex-col lg:flex-row items-start lg:items-center justify-between gap-2"
-    >
-      <div class="flex flex-1 max-w-full items-center gap-x-2">
-        <IssueSearch
-          v-model:params="state.params"
-          class="flex-1"
-          :override-scope-id-list="overrideSearchScopeIdList"
-        >
-          <template #searchbox-suffix>
-            <PermissionGuardWrapper
-              v-slot="slotProps"
-              :project="specificProject"
-              :permissions="[
-                ...PERMISSIONS_FOR_DATABASE_EXPORT_ISSUE
-              ]"
-            >
-              <NButton
-                type="primary"
-                :disabled="slotProps.disabled"
-                @click="state.showRequestExportPanel = true"
+  <div class="py-4 w-full flex flex-col">
+    <div class="px-4 pb-2">
+      <div
+        class="w-full flex flex-col lg:flex-row items-start lg:items-center justify-between gap-2"
+      >
+        <div class="flex flex-1 max-w-full items-center gap-x-2">
+          <IssueSearch
+            v-model:params="state.params"
+            class="flex-1"
+            :override-scope-id-list="overrideSearchScopeIdList"
+          >
+            <template #searchbox-suffix>
+              <PermissionGuardWrapper
+                v-slot="slotProps"
+                :project="specificProject"
+                :permissions="[
+                  ...PERMISSIONS_FOR_DATABASE_EXPORT_ISSUE
+                ]"
               >
-                <template #icon>
-                  <DownloadIcon class="h-4 w-4" />
-                </template>
-                {{ $t("quick-action.request-export-data") }}
-              </NButton>
-            </PermissionGuardWrapper>
-          </template>
-        </IssueSearch>
+                <NButton
+                  type="primary"
+                  :disabled="slotProps.disabled"
+                  @click="state.showRequestExportPanel = true"
+                >
+                  <template #icon>
+                    <DownloadIcon class="h-4 w-4" />
+                  </template>
+                  {{ $t("quick-action.request-export-data") }}
+                </NButton>
+              </PermissionGuardWrapper>
+            </template>
+          </IssueSearch>
+        </div>
       </div>
     </div>
-
-    <div class="relative w-full mt-4 min-h-80">
-      <PagedTable
-        ref="issuePagedTable"
-        :session-key="'export-center'"
-        :fetch-list="fetchIssueList"
-      >
-        <template #table="{ list, loading }">
-          <IssueTableV1
-            :loading="loading"
-            :issue-list="list"
-            :highlight-text="state.params.query"
-          />
-        </template>
-      </PagedTable>
-    </div>
+    <PagedTable
+      ref="issuePagedTable"
+      :session-key="'export-center'"
+      :footer-class="'mx-4'"
+      :fetch-list="fetchIssueList"
+    >
+      <template #table="{ list, loading }">
+        <IssueTableV1
+          class="border-x-0"
+          :loading="loading"
+          :issue-list="list"
+          :highlight-text="state.params.query"
+        />
+      </template>
+    </PagedTable>
   </div>
 
   <Drawer

--- a/frontend/src/views/InstanceDashboard.vue
+++ b/frontend/src/views/InstanceDashboard.vue
@@ -1,33 +1,35 @@
 <template>
-  <div class="flex flex-col gap-y-4">
-    <BBAttention
-      v-if="remainingInstanceCount <= 3"
-      :type="'warning'"
-      :title="$t('subscription.usage.instance-count.title')"
-      :description="instanceCountAttention"
-    />
-    <div class="px-4 flex items-center gap-x-2">
-      <AdvancedSearch
-        v-model:params="state.params"
-        :autofocus="false"
-        :placeholder="$t('instance.filter-instance-name')"
-        :scope-options="scopeOptions"
+  <div class="py-4 flex flex-col">
+    <div class="px-4 flex flex-col gap-y-2 pb-2">
+      <BBAttention
+        v-if="remainingInstanceCount <= 3"
+        :type="'warning'"
+        :title="$t('subscription.usage.instance-count.title')"
+        :description="instanceCountAttention"
       />
-      <PermissionGuardWrapper
-        v-slot="slotProps"
-        :permissions="['bb.instances.create']"
-      >
-        <NButton
-          type="primary"
-          :disabled="slotProps.disabled"
-          @click="showCreateInstanceDrawer"
+      <div class="flex items-center gap-x-2">
+        <AdvancedSearch
+          v-model:params="state.params"
+          :autofocus="false"
+          :placeholder="$t('instance.filter-instance-name')"
+          :scope-options="scopeOptions"
+        />
+        <PermissionGuardWrapper
+          v-slot="slotProps"
+          :permissions="['bb.instances.create']"
         >
-          <template #icon>
-            <PlusIcon class="h-4 w-4" />
-          </template>
-          {{ $t("quick-action.add-instance") }}
-        </NButton>
-      </PermissionGuardWrapper>
+          <NButton
+            type="primary"
+            :disabled="slotProps.disabled"
+            @click="showCreateInstanceDrawer"
+          >
+            <template #icon>
+              <PlusIcon class="h-4 w-4" />
+            </template>
+            {{ $t("quick-action.add-instance") }}
+          </NButton>
+        </PermissionGuardWrapper>
+      </div>
     </div>
     <div>
       <InstanceOperations

--- a/frontend/src/views/InstanceDetail.vue
+++ b/frontend/src/views/InstanceDetail.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col gap-y-2 px-6" v-bind="$attrs">
+  <div class="pt-4 flex flex-col gap-y-2 px-6" v-bind="$attrs">
     <ArchiveBanner v-if="instance.state === State.DELETED" />
     <BBAttention
       v-if="!instance.environment"
@@ -104,7 +104,6 @@ import {
   PagedDatabaseTable,
 } from "@/components/v2/Model/DatabaseV1Table";
 import { useRouteChangeGuard } from "@/composables/useRouteChangeGuard";
-import { useBodyLayoutContext } from "@/layouts/common";
 import {
   useDatabaseV1Store,
   useEnvironmentV1Store,
@@ -147,9 +146,6 @@ const props = defineProps<{
 defineOptions({
   inheritAttrs: false,
 });
-
-const { overrideMainContainerClass } = useBodyLayoutContext();
-overrideMainContainerClass("pb-0!");
 
 const { t } = useI18n();
 const router = useRouter();

--- a/frontend/src/views/MyIssues.vue
+++ b/frontend/src/views/MyIssues.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :key="viewId" class="flex flex-col">
+  <div :key="viewId" class="py-4 flex flex-col">
     <IssueSearch
       v-model:params="state.params"
       :components="['searchbox', 'time-range', 'presets', 'status']"
@@ -7,23 +7,22 @@
       class="px-4 pb-2"
     />
 
-    <div class="relative min-h-80">
-      <PagedTable
-        ref="issuePagedTable"
-        session-key="bb.issue-table.my-issues"
-        :fetch-list="fetchIssueList"
-      >
-        <template #table="{ list, loading }">
-          <IssueTableV1
-            class="border-x-0"
-            :loading="loading"
-            :issue-list="list"
-            :highlight-text="state.params.query"
-            :show-project="true"
-          />
-        </template>
-      </PagedTable>
-    </div>
+    <PagedTable
+      ref="issuePagedTable"
+      session-key="bb.issue-table.my-issues"
+      :footer-class="'mx-4'"
+      :fetch-list="fetchIssueList"
+    >
+      <template #table="{ list, loading }">
+        <IssueTableV1
+          class="border-x-0"
+          :loading="loading"
+          :issue-list="list"
+          :highlight-text="state.params.query"
+          :show-project="true"
+        />
+      </template>
+    </PagedTable>
   </div>
 </template>
 

--- a/frontend/src/views/ProfileDashboard.vue
+++ b/frontend/src/views/ProfileDashboard.vue
@@ -1,6 +1,6 @@
 <template>
   <main
-    class="flex-1 h-full relative pb-8 focus:outline-hidden xl:order-last"
+    class="px-4 pt-4 flex-1 h-full relative pb-8 focus:outline-hidden xl:order-last"
     tabindex="0"
   >
     <NoPermissionPlaceholder

--- a/frontend/src/views/ProjectDashboard.vue
+++ b/frontend/src/views/ProjectDashboard.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-col gap-y-4">
-    <div class="flex items-center justify-between px-4 gap-x-2">
+  <div class="py-4 flex flex-col">
+    <div class="flex items-center justify-between px-4 pb-2 gap-x-2">
       <AdvancedSearch
         v-model:params="state.params"
         :scope-options="scopeOptions"

--- a/frontend/src/views/SettingWorkspaceAuditLog.vue
+++ b/frontend/src/views/SettingWorkspaceAuditLog.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4 pb-6">
+  <div class="px-4 py-4">
     <FeatureAttention :feature="PlanFeature.FEATURE_AUDIT_LOG" />
     <AuditLogSearch v-model:params="state.params">
       <template #searchbox-suffix>
@@ -18,15 +18,14 @@
         />
       </template>
     </AuditLogSearch>
-
-    <PagedAuditLogDataTable
-      v-if="hasAuditLogFeature"
-      ref="pagedAuditLogDataTableRef"
-      :parent="parent"
-      :filter="searchAuditLogs"
-    />
-    <NEmpty class="py-12 border rounded-sm" v-else />
   </div>
+  <PagedAuditLogDataTable
+    v-if="hasAuditLogFeature"
+    ref="pagedAuditLogDataTableRef"
+    :parent="parent"
+    :filter="searchAuditLogs"
+  />
+  <NEmpty class="mx-4 py-12 border rounded-sm" v-else />
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/views/SettingWorkspaceCustomApproval.vue
+++ b/frontend/src/views/SettingWorkspaceCustomApproval.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4 text-sm">
+  <div class="w-full px-4 py-4 flex flex-col gap-y-4 text-sm">
     <FeatureAttention :feature="PlanFeature.FEATURE_APPROVAL_WORKFLOW" />
     <BBAttention v-if="hasCustomApprovalFeature" type="info" :description="$t('custom-approval.rule.first-match-wins')" />
 

--- a/frontend/src/views/SettingWorkspaceDataClassification.vue
+++ b/frontend/src/views/SettingWorkspaceDataClassification.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4">
+  <div class="w-full px-4 py-4 flex flex-col gap-y-4">
     <FeatureAttention
       v-if="!hasSensitiveDataFeature"
       :feature="PlanFeature.FEATURE_DATA_CLASSIFICATION"

--- a/frontend/src/views/SettingWorkspaceDataMasking.vue
+++ b/frontend/src/views/SettingWorkspaceDataMasking.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4">
+  <div class="w-full px-4 py-4 flex flex-col gap-y-4">
     <FeatureAttention
       :feature="PlanFeature.FEATURE_DATA_MASKING"
     />

--- a/frontend/src/views/SettingWorkspaceGeneral.vue
+++ b/frontend/src/views/SettingWorkspaceGeneral.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="divide-y divide-block-border pt-2">
+  <div class="px-4 divide-y divide-block-border py-4">
     <GeneralSetting
       ref="generalSettingRef"
       :title="$t('common.general')"
@@ -51,7 +51,7 @@
       />
     </PermissionGuardWrapper>
 
-    <div v-if="isDirty" class="sticky bottom-0 z-10">
+    <div v-if="isDirty" class="sticky bottom-0 z-10 -mb-4">
       <div
         class="flex justify-between w-full py-4 border-t border-block-border bg-white"
       >
@@ -84,7 +84,6 @@ import {
 } from "@/components/GeneralSetting";
 import PermissionGuardWrapper from "@/components/Permission/PermissionGuardWrapper.vue";
 import { useRouteChangeGuard } from "@/composables/useRouteChangeGuard";
-import { useBodyLayoutContext } from "@/layouts/common";
 import { pushNotification } from "@/store";
 
 const route = useRoute();
@@ -116,10 +115,6 @@ const settingRefList = computed(() => {
     auditLogStdoutSettingRef,
   ];
 });
-
-const { overrideMainContainerClass } = useBodyLayoutContext();
-
-overrideMainContainerClass("!pb-0");
 
 onMounted(async () => {
   // If the route has a hash, try to scroll to the element with the value.

--- a/frontend/src/views/SettingWorkspaceIM.vue
+++ b/frontend/src/views/SettingWorkspaceIM.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4 pb-4">
+  <div class="w-full px-4 flex flex-col gap-y-4 py-4">
     <div class="textinfolabel">
       {{ $t("settings.im-integration.description") }}
       <LearnMoreLink

--- a/frontend/src/views/SettingWorkspaceMCP.vue
+++ b/frontend/src/views/SettingWorkspaceMCP.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-6 pb-4">
+  <div class="w-full px-4 flex flex-col gap-y-6 py-4">
     <!-- Header -->
     <div>
       <h2 class="text-lg font-medium">{{ $t("settings.mcp.title") }}</h2>

--- a/frontend/src/views/SettingWorkspaceMembers.vue
+++ b/frontend/src/views/SettingWorkspaceMembers.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full mx-auto flex flex-col gap-y-4 pb-4">
+  <div class="w-full px-4 mx-auto flex flex-col py-4">
     <NTabs v-model:value="state.selectedTab" type="line" animated>
       <NTabPane name="MEMBERS">
         <template #tab>

--- a/frontend/src/views/SettingWorkspaceRiskCenter.vue
+++ b/frontend/src/views/SettingWorkspaceRiskCenter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-6 text-sm">
+  <div class="w-full px-4 py-4 flex flex-col gap-y-6 text-sm">
     <FeatureAttention
       :feature="PlanFeature.FEATURE_RISK_ASSESSMENT"
       class="mb-2"

--- a/frontend/src/views/SettingWorkspaceRole.vue
+++ b/frontend/src/views/SettingWorkspaceRole.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4 text-sm">
+  <div class="w-full px-4 py-4 flex flex-col gap-y-4 text-sm">
     <RoleSetting />
   </div>
 </template>

--- a/frontend/src/views/SettingWorkspaceSQLReview.vue
+++ b/frontend/src/views/SettingWorkspaceSQLReview.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mx-auto flex flex-col gap-y-4">
+  <div class="px-4 py-4 mx-auto flex flex-col gap-y-4">
     <div class="textinfolabel">
       {{ $t("sql-review.description") }}
       <LearnMoreLink

--- a/frontend/src/views/SettingWorkspaceSQLReviewCreate.vue
+++ b/frontend/src/views/SettingWorkspaceSQLReviewCreate.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="gap-y-4 h-full flex flex-col">
+  <div class="px-4 py-4 gap-y-4 h-full flex flex-col">
     <SQLReviewCreation
       class="flex-1"
       :selected-rule-list="[]"

--- a/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
@@ -1,4 +1,5 @@
 <template>
+  <div class="px-4 py-4">
   <SQLReviewCreation
     v-if="state.editMode"
     key="sql-review-creation"
@@ -168,6 +169,7 @@
     :review="reviewPolicy"
     @close="state.showResourcePanel = false"
   />
+  </div>
 </template>
 
 <script lang="tsx" setup>

--- a/frontend/src/views/SettingWorkspaceSSO.vue
+++ b/frontend/src/views/SettingWorkspaceSSO.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4">
+  <div class="w-full px-4 py-4 flex flex-col gap-y-4">
     <div class="textinfolabel">
       {{ $t("settings.sso.description") }}
       <LearnMoreLink

--- a/frontend/src/views/SettingWorkspaceSSODetail.vue
+++ b/frontend/src/views/SettingWorkspaceSSODetail.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-6">
+  <div class="w-full px-4 py-4 flex flex-col gap-y-6">
     <div class="w-full flex flex-row justify-between items-center">
       <div class="textinfolabel mr-4">
         {{ $t("settings.sso.description") }}

--- a/frontend/src/views/SettingWorkspaceSemanticTypes.vue
+++ b/frontend/src/views/SettingWorkspaceSemanticTypes.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4">
+  <div class="w-full px-4 py-4 flex flex-col gap-y-4">
     <FeatureAttention :feature="PlanFeature.FEATURE_DATA_MASKING" />
     <SemanticTypesView />
   </div>

--- a/frontend/src/views/SettingWorkspaceSubscription.vue
+++ b/frontend/src/views/SettingWorkspaceSubscription.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="w-full mx-auto">
+  <div class="w-full px-4 py-4 mx-auto">
     <div
       class="w-full grid grid-cols-2 gap-6 lg:grid-cols-3 3xl:grid-cols-4 my-4"
     >

--- a/frontend/src/views/SettingWorkspaceUsers.vue
+++ b/frontend/src/views/SettingWorkspaceUsers.vue
@@ -1,7 +1,8 @@
 <template>
-  <div class="w-full overflow-x-hidden flex flex-col gap-y-4 pb-4">
+  <div class="w-full px-4 overflow-x-hidden flex flex-col py-4">
     <BBAttention
       v-if="remainingUserCount <= 3"
+      class="mb-2"
       :type="'warning'"
       :title="$t('subscription.usage.user-count.title')"
       :description="userCountAttention"

--- a/frontend/src/views/TwoFactorSetup.vue
+++ b/frontend/src/views/TwoFactorSetup.vue
@@ -1,4 +1,5 @@
 <template>
+  <div class="px-4 py-4">
   <p class="text-sm text-gray-500 mb-4">
     {{ $t("two-factor.description") }}
     <LearnMoreLink
@@ -107,6 +108,7 @@
     :secret="currentUser.tempOtpSecret"
     @close="state.showSecretModal = false"
   />
+  </div>
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/views/project/IssueLayout.vue
+++ b/frontend/src/views/project/IssueLayout.vue
@@ -36,7 +36,6 @@ import { HeaderSection } from "@/components/Plan/components";
 import { provideSidebarContext } from "@/components/Plan/logic/sidebar";
 import { useNavigationGuard } from "@/components/Plan/logic/useNavigationGuard";
 import PollerProvider from "@/components/Plan/PollerProvider.vue";
-import { useBodyLayoutContext } from "@/layouts/common";
 
 const props = defineProps<{
   projectId: string;
@@ -83,10 +82,6 @@ providePlanContext({
 });
 
 provideSidebarContext(containerRef);
-
-const { overrideMainContainerClass } = useBodyLayoutContext();
-
-overrideMainContainerClass("py-0! px-0!");
 
 const documentTitle = computed(() => {
   if (isCreating.value) {

--- a/frontend/src/views/project/ProjectAccessGrantDashboard.vue
+++ b/frontend/src/views/project/ProjectAccessGrantDashboard.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4">
-    <FeatureAttention :feature="PlanFeature.FEATURE_JIT" />
+  <div class="py-4 w-full flex flex-col">
+    <FeatureAttention class="mx-4 mb-2" :feature="PlanFeature.FEATURE_JIT" />
 
     <ComponentPermissionGuard
       :project="project"
       :permissions="['bb.accessGrants.list']"
     >
-      <div class="flex items-center gap-x-2">
+      <div class="px-4 pb-2 flex items-center gap-x-2">
         <AdvancedSearch
           class="flex-1"
           :params="searchParams"
@@ -22,6 +22,7 @@
         ref="pagedTableRef"
         :key="projectName"
         :session-key="`project-${projectName}-access-grants`"
+        :footer-class="'mx-4'"
         :fetch-list="fetchList"
         :order-keys="ORDER_KEYS"
       >
@@ -30,7 +31,7 @@
             v-if="hasJITFeature"
             :columns="getSortedColumns(sorters)"
             :data="list"
-            :bordered="true"
+            :bordered="false"
             :striped="true"
             :loading="loading"
             :row-key="(row: AccessGrant) => row.name"
@@ -41,7 +42,7 @@
       </PagedTable>
     </ComponentPermissionGuard>
 
-    <NAlert v-if="!canList" type="info">
+    <NAlert v-if="!canList" type="info" class="mx-4 mt-2">
       <i18n-t keypath="sql-editor.access-grants-redirect-hint" tag="span">
         <template #link>
           <router-link

--- a/frontend/src/views/project/ProjectAuditLogDashboard.vue
+++ b/frontend/src/views/project/ProjectAuditLogDashboard.vue
@@ -1,31 +1,32 @@
 <template>
-  <div class="w-full flex flex-col gap-y-4">
-    <FeatureAttention :feature="PlanFeature.FEATURE_AUDIT_LOG" />
-    <AuditLogSearch v-model:params="state.params">
-      <template #searchbox-suffix>
-        <DataExportButton
-          v-if="hasProjectPermissionV2(project, 'bb.auditLogs.export')"
-          size="medium"
-          :support-formats="[
-            ExportFormat.CSV,
-            ExportFormat.JSON,
-            ExportFormat.XLSX,
-          ]"
-          :tooltip="disableExportTip"
-          :view-mode="'DROPDOWN'"
-          :disabled="!hasAuditLogFeature || !!disableExportTip"
-          @export="(params) => pagedAuditLogDataTableRef?.handleExport(params)"
-        />
-      </template>
-    </AuditLogSearch>
-
+  <div class="py-4 w-full flex flex-col">
+    <div class="px-4 flex flex-col gap-y-2 pb-2">
+      <FeatureAttention :feature="PlanFeature.FEATURE_AUDIT_LOG" />
+      <AuditLogSearch v-model:params="state.params">
+        <template #searchbox-suffix>
+          <DataExportButton
+            v-if="hasProjectPermissionV2(project, 'bb.auditLogs.export')"
+            size="medium"
+            :support-formats="[
+              ExportFormat.CSV,
+              ExportFormat.JSON,
+              ExportFormat.XLSX,
+            ]"
+            :tooltip="disableExportTip"
+            :view-mode="'DROPDOWN'"
+            :disabled="!hasAuditLogFeature || !!disableExportTip"
+            @export="(params) => pagedAuditLogDataTableRef?.handleExport(params)"
+          />
+        </template>
+      </AuditLogSearch>
+    </div>
     <PagedAuditLogDataTable
       v-if="hasAuditLogFeature"
       ref="pagedAuditLogDataTableRef"
       :parent="projectName"
       :filter="searchAuditLogs"
     />
-    <NEmpty class="py-12 border rounded-sm" v-else />
+    <NEmpty v-else class="mx-4 py-12 border rounded-sm" />
   </div>
 </template>
 

--- a/frontend/src/views/project/ProjectDatabaseDashboard.vue
+++ b/frontend/src/views/project/ProjectDatabaseDashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProjectDatabasesPanel :project="project" />
+  <ProjectDatabasesPanel class="py-4" :project="project" />
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/views/project/ProjectDatabaseGroupCreate.vue
+++ b/frontend/src/views/project/ProjectDatabaseGroupCreate.vue
@@ -1,6 +1,6 @@
 <template>
   <DatabaseGroupForm
-    class="h-full"
+    class="py-4 h-full"
     :readonly="false"
     :project="project"
     @dismiss="() => router.back()"

--- a/frontend/src/views/project/ProjectDatabaseGroupDashboard.vue
+++ b/frontend/src/views/project/ProjectDatabaseGroupDashboard.vue
@@ -1,43 +1,44 @@
 <template>
-  <div class="flex flex-col gap-y-4">
-    <FeatureAttention :feature="PlanFeature.FEATURE_DATABASE_GROUPS" />
-
-    <div class="flex flex-row items-center justify-end gap-x-2">
-      <SearchBox
-        v-model:value="state.searchText"
-        style="max-width: 100%"
-        :placeholder="$t('common.filter-by-name')"
-      />
-      <PermissionGuardWrapper
-        v-slot="slotProps"
-        :project="project"
-        :permissions="['bb.databaseGroups.create']"
-      >
-        <NButton
-          type="primary"
-          :disabled="slotProps.disabled"
-          @click="
-            () => {
-              if (!hasDBGroupFeature) {
-                state.showFeatureModal = true;
-                return;
-              }
-              router.push({
-                name: PROJECT_V1_ROUTE_DATABASE_GROUPS_CREATE,
-              });
-            }
-          "
+  <div class="py-4 flex flex-col">
+    <div class="px-4 flex flex-col gap-y-2 pb-2">
+      <FeatureAttention :feature="PlanFeature.FEATURE_DATABASE_GROUPS" />
+      <div class="flex flex-row items-center justify-end gap-x-2">
+        <SearchBox
+          v-model:value="state.searchText"
+          style="max-width: 100%"
+          :placeholder="$t('common.filter-by-name')"
+        />
+        <PermissionGuardWrapper
+          v-slot="slotProps"
+          :project="project"
+          :permissions="['bb.databaseGroups.create']"
         >
-          <template #icon>
-            <PlusIcon class="w-4" />
-            <FeatureBadge
-              :feature="PlanFeature.FEATURE_DATABASE_GROUPS"
-              class="text-white"
-            />
-          </template>
-          {{ $t("database-group.create") }}
-        </NButton>
-      </PermissionGuardWrapper>
+          <NButton
+            type="primary"
+            :disabled="slotProps.disabled"
+            @click="
+              () => {
+                if (!hasDBGroupFeature) {
+                  state.showFeatureModal = true;
+                  return;
+                }
+                router.push({
+                  name: PROJECT_V1_ROUTE_DATABASE_GROUPS_CREATE,
+                });
+              }
+            "
+          >
+            <template #icon>
+              <PlusIcon class="w-4" />
+              <FeatureBadge
+                :feature="PlanFeature.FEATURE_DATABASE_GROUPS"
+                class="text-white"
+              />
+            </template>
+            {{ $t("database-group.create") }}
+          </NButton>
+        </PermissionGuardWrapper>
+      </div>
     </div>
     <ProjectDatabaseGroupPanel :project="project" :filter="state.searchText" />
   </div>

--- a/frontend/src/views/project/ProjectDatabaseGroupDetail.vue
+++ b/frontend/src/views/project/ProjectDatabaseGroupDetail.vue
@@ -86,7 +86,6 @@ import DatabaseGroupForm from "@/components/DatabaseGroup/DatabaseGroupForm.vue"
 import FeatureAttention from "@/components/FeatureGuard/FeatureAttention.vue";
 import PermissionGuardWrapper from "@/components/Permission/PermissionGuardWrapper.vue";
 import { preCreateIssue } from "@/components/Plan/logic/issue";
-import { useBodyLayoutContext } from "@/layouts/common";
 import { PROJECT_V1_ROUTE_DATABASE_GROUPS } from "@/router/dashboard/projectV1";
 import {
   featureToRef,
@@ -187,8 +186,4 @@ watchEffect(async () => {
     view: DatabaseGroupView.FULL,
   });
 });
-
-const { overrideMainContainerClass } = useBodyLayoutContext();
-
-overrideMainContainerClass("py-0!");
 </script>

--- a/frontend/src/views/project/ProjectIssueDashboard.vue
+++ b/frontend/src/views/project/ProjectIssueDashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProjectIssuesPanel v-if="ready" :project="project" />
+  <ProjectIssuesPanel v-if="ready" class="py-4" :project="project" />
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/views/project/ProjectMaskingExemption.vue
+++ b/frontend/src/views/project/ProjectMaskingExemption.vue
@@ -1,8 +1,9 @@
 <template>
-  <div class="flex flex-col gap-y-4">
-    <div
-      class="flex flex-row justify-between items-center gap-x-2"
-    >
+  <div class="py-4 flex flex-col">
+    <div class="px-4 pb-2">
+      <div
+        class="flex flex-row justify-between items-center gap-x-2"
+      >
       <DatabaseSelect
         class="hidden sm:block"
         style="max-width: max-content"
@@ -55,6 +56,7 @@
           </NButton>
         </PermissionGuardWrapper>
       </div>
+    </div>
     </div>
     <MaskingExceptionUserTable
       size="medium"

--- a/frontend/src/views/project/ProjectMaskingExemptionCreate.vue
+++ b/frontend/src/views/project/ProjectMaskingExemptionCreate.vue
@@ -1,5 +1,6 @@
 <template>
   <GrantAccessForm
+    class="pt-4"
     :title="$t('project.masking-exemption.grant-exemption')"
     :column-list="[]"
     :project-name="project.name"
@@ -11,7 +12,6 @@
 import { computed } from "vue";
 import { useRouter } from "vue-router";
 import GrantAccessForm from "@/components/SensitiveData/GrantAccessForm.vue";
-import { useBodyLayoutContext } from "@/layouts/common";
 import { useProjectByName } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 
@@ -23,8 +23,4 @@ const { project } = useProjectByName(
   computed(() => `${projectNamePrefix}${props.projectId}`)
 );
 const router = useRouter();
-
-const { overrideMainContainerClass } = useBodyLayoutContext();
-
-overrideMainContainerClass("!pb-0");
 </script>

--- a/frontend/src/views/project/ProjectMemberDashboard.vue
+++ b/frontend/src/views/project/ProjectMemberDashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProjectMemberPanel :project="project" :allow-edit="allowEdit" />
+  <ProjectMemberPanel class="py-4" :project="project" :allow-edit="allowEdit" />
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/views/project/ProjectPlanDashboard.vue
+++ b/frontend/src/views/project/ProjectPlanDashboard.vue
@@ -1,53 +1,52 @@
 <template>
-  <div v-if="ready" class="w-full">
-    <NAlert
-      v-if="!hideHint"
-      type="info"
-      closable
-      class="mb-4"
-      @close="dismissHint"
-    >
-      {{ $t("plan.subtitle") }}
-    </NAlert>
-    <div
-      class="w-full flex flex-col lg:flex-row items-start lg:items-center justify-between gap-2"
-    >
-      <div class="w-full flex flex-1 items-center justify-between gap-x-2">
-        <AdvancedSearch
-          v-model:params="state.params"
-          class="flex-1"
-          :scope-options="scopeOptions"
-        />
-        <PermissionGuardWrapper
-          v-slot="slotProps"
-          :project="project"
-          :permissions="['bb.plans.create']"
-        >
-          <NButton
-            type="primary"
-            :disabled="slotProps.disabled"
-            @click="showAddSpecDrawer = true"
+  <div v-if="ready" class="py-4 w-full flex flex-col">
+    <div class="px-4 flex flex-col gap-y-2 pb-2">
+      <NAlert
+        v-if="!hideHint"
+        type="info"
+        closable
+        @close="dismissHint"
+      >
+        {{ $t("plan.subtitle") }}
+      </NAlert>
+      <div
+        class="w-full flex flex-col lg:flex-row items-start lg:items-center justify-between gap-2"
+      >
+        <div class="w-full flex flex-1 items-center justify-between gap-x-2">
+          <AdvancedSearch
+            v-model:params="state.params"
+            class="flex-1"
+            :scope-options="scopeOptions"
+          />
+          <PermissionGuardWrapper
+            v-slot="slotProps"
+            :project="project"
+            :permissions="['bb.plans.create']"
           >
-            <template #icon>
-              <PlusIcon class="w-4 h-4" />
-            </template>
-            {{ $t("plan.new-plan") }}
-          </NButton>
-        </PermissionGuardWrapper>
+            <NButton
+              type="primary"
+              :disabled="slotProps.disabled"
+              @click="showAddSpecDrawer = true"
+            >
+              <template #icon>
+                <PlusIcon class="w-4 h-4" />
+              </template>
+              {{ $t("plan.new-plan") }}
+            </NButton>
+          </PermissionGuardWrapper>
+        </div>
       </div>
     </div>
-
-    <div class="relative w-full mt-4 min-h-80">
-      <PagedTable
-        ref="planPagedTable"
-        :session-key="`bb.${project.name}.plan-table`"
-        :fetch-list="fetchPlanList"
-      >
-        <template #table="{ list, loading }">
-          <PlanDataTable :loading="loading" :plan-list="list" />
-        </template>
-      </PagedTable>
-    </div>
+    <PagedTable
+      ref="planPagedTable"
+      :session-key="`bb.${project.name}.plan-table`"
+      :footer-class="'mx-4'"
+      :fetch-list="fetchPlanList"
+    >
+      <template #table="{ list, loading }">
+        <PlanDataTable :loading="loading" :plan-list="list" />
+      </template>
+    </PagedTable>
   </div>
 
   <AddSpecDrawer

--- a/frontend/src/views/project/ProjectReleaseDashboard.vue
+++ b/frontend/src/views/project/ProjectReleaseDashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProjectReleasesPanel :project="project" />
+  <ProjectReleasesPanel class="py-4" :project="project" />
 </template>
 
 <script lang="ts" setup>

--- a/frontend/src/views/project/ProjectRolloutDashboard.vue
+++ b/frontend/src/views/project/ProjectRolloutDashboard.vue
@@ -1,37 +1,37 @@
 <template>
-  <div class="w-full">
-    <div
-      class="w-full flex flex-col lg:flex-row items-start lg:items-center justify-between gap-2"
-    >
-      <div class="w-full flex flex-1 items-center justify-between gap-x-2">
-        <AdvancedSearch
-          v-model:params="state.params"
-          class="flex-1"
-          :scope-options="scopeOptions"
-        />
-        <UpdatedTimeRange
-          :params="state.params"
-          @update:params="state.params = $event"
-        />
+  <div class="py-4 w-full flex flex-col">
+    <div class="px-4 pb-2">
+      <div
+        class="w-full flex flex-col lg:flex-row items-start lg:items-center justify-between gap-2"
+      >
+        <div class="w-full flex flex-1 items-center justify-between gap-x-2">
+          <AdvancedSearch
+            v-model:params="state.params"
+            class="flex-1"
+            :scope-options="scopeOptions"
+          />
+          <UpdatedTimeRange
+            :params="state.params"
+            @update:params="state.params = $event"
+          />
+        </div>
       </div>
     </div>
-
-    <div class="relative w-full mt-4 min-h-80">
-      <PagedTable
-        ref="rolloutPagedTable"
-        :key="project.name"
-        :session-key="`project-${project.name}-rollouts`"
-        :fetch-list="fetchRolloutList"
-      >
-        <template #table="{ list, loading }">
-          <RolloutDataTable
-            :bordered="true"
-            :loading="loading"
-            :rollout-list="list"
-          />
-        </template>
-      </PagedTable>
-    </div>
+    <PagedTable
+      ref="rolloutPagedTable"
+      :key="project.name"
+      :session-key="`project-${project.name}-rollouts`"
+      :footer-class="'mx-4'"
+      :fetch-list="fetchRolloutList"
+    >
+      <template #table="{ list, loading }">
+        <RolloutDataTable
+          :bordered="false"
+          :loading="loading"
+          :rollout-list="list"
+        />
+      </template>
+    </PagedTable>
   </div>
 </template>
 

--- a/frontend/src/views/project/ProjectSettingPanel.vue
+++ b/frontend/src/views/project/ProjectSettingPanel.vue
@@ -5,7 +5,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import ProjectSettingPanel from "@/components/ProjectSettingPanel.vue";
-import { useBodyLayoutContext } from "@/layouts/common";
 import { useProjectByName } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 
@@ -17,8 +16,4 @@ const props = defineProps<{
 const { project } = useProjectByName(
   computed(() => `${projectNamePrefix}${props.projectId}`)
 );
-
-const { overrideMainContainerClass } = useBodyLayoutContext();
-
-overrideMainContainerClass("py-0!");
 </script>

--- a/frontend/src/views/project/ProjectSyncDatabasePanelV1.vue
+++ b/frontend/src/views/project/ProjectSyncDatabasePanelV1.vue
@@ -1,5 +1,5 @@
 <template>
-  <SyncDatabaseSchema :key="project.name" :project="project" />
+  <SyncDatabaseSchema class="py-4" :key="project.name" :project="project" />
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/views/project/ProjectWebhookCreate.vue
+++ b/frontend/src/views/project/ProjectWebhookCreate.vue
@@ -1,5 +1,6 @@
 <template>
   <ProjectWebhookForm
+    class="pt-4"
     :create="true"
     :project="project"
     :webhook="defaultNewWebhook"

--- a/frontend/src/views/project/ProjectWebhookDashboard.vue
+++ b/frontend/src/views/project/ProjectWebhookDashboard.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="flex flex-col gap-y-4">
-    <div class="flex items-center justify-end">
+  <div class="py-4 flex flex-col">
+    <div class="px-4 pb-2 flex items-center justify-end">
       <PermissionGuardWrapper
         v-slot="slotProps"
         :project="project"
@@ -23,7 +23,7 @@
       :columns="columnList"
       :striped="true"
       :row-key="(webhook: Webhook) => webhook.name"
-      :bordered="true"
+      :bordered="false"
       :row-props="rowProps"
     />
   </div>

--- a/frontend/src/views/project/ProjectWebhookDetail.vue
+++ b/frontend/src/views/project/ProjectWebhookDetail.vue
@@ -1,5 +1,6 @@
 <template>
   <ProjectWebhookForm
+    class="pt-4"
     :allow-edit="allowEdit"
     :create="false"
     :project="project"

--- a/frontend/src/views/project/RolloutLayout.vue
+++ b/frontend/src/views/project/RolloutLayout.vue
@@ -40,7 +40,6 @@ import RefreshIndicator from "@/components/Plan/components/RefreshIndicator.vue"
 import { provideSidebarContext } from "@/components/Plan/logic/sidebar";
 import PollerProvider from "@/components/Plan/PollerProvider.vue";
 import RolloutBreadcrumb from "@/components/RolloutV1/components/Rollout/RolloutBreadcrumb.vue";
-import { useBodyLayoutContext } from "@/layouts/common";
 import { usePolicyV1Store } from "@/store";
 import { PolicyType } from "@/types/proto-es/v1/org_policy_service_pb";
 
@@ -96,8 +95,6 @@ providePlanContext({
 });
 
 provideSidebarContext(containerRef);
-
-useBodyLayoutContext().overrideMainContainerClass("py-0! px-0!");
 
 useTitle(
   computed(() => {


### PR DESCRIPTION
Remove the child-to-parent CSS class injection via provide/inject where 9 components mutated ancestor layout container classes using !important overrides. Each page now owns its own padding (py-4, px-4) instead of relying on container padding or fighting it.

- Remove useClassStack from css.ts and overrideMainContainerClass from layout context
- Remove py-4 from BodyLayout/IssuesLayout containers and px-4/py-4 from SettingLayout
- Add page-level padding to all workspace and project pages
- Keep the page styles consistent at the workspace level and project level
- Standardize table pages: inset wrapper (px-4) for search/alerts, edge-to-edge tables with bordered=false and footer-class mx-4