### PR TITLE
fix(schema): quote CamelCase columns in PostgreSQL index/constraint DDL

### DIFF
--- a/backend/plugin/schema/pg/camelcase_index_test.go
+++ b/backend/plugin/schema/pg/camelcase_index_test.go
@@ -1,0 +1,260 @@
+package pg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+	"github.com/bytebase/bytebase/backend/store/model"
+)
+
+func TestQuoteIndexExpression(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"userId", `"userId"`},
+		{"accountName", `"accountName"`},
+		{"user_id", "user_id"},
+		{"id", "id"},
+		{`"userId"`, `"userId"`},
+		{"lower(name)", "lower(name)"},
+		{"(a + b)", "(a + b)"},
+		{"col::text", "col::text"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			require.Equal(t, tt.expected, quoteIndexExpression(tt.input))
+		})
+	}
+}
+
+// TestCamelCaseIndexColumnQuoting_SDL reproduces https://github.com/bytebase/bytebase/issues/19348
+// via the SDL diff path (AST-based).
+func TestCamelCaseIndexColumnQuoting_SDL(t *testing.T) {
+	previousSDL := ""
+
+	currentSDL := `
+CREATE TABLE "public"."ba_account" (
+    "userId" text NOT NULL,
+    "accountName" text
+);
+
+CREATE INDEX ba_account_userId_idx ON "public"."ba_account" ("userId");
+`
+
+	currentSchema := model.NewDatabaseMetadata(
+		&storepb.DatabaseSchemaMetadata{
+			Name:    "testdb",
+			Schemas: []*storepb.SchemaMetadata{},
+		}, nil, nil, storepb.Engine_POSTGRES, false)
+
+	diff, err := GetSDLDiff(currentSDL, previousSDL, currentSchema)
+	require.NoError(t, err)
+	require.NotNil(t, diff)
+
+	ddl, err := generateMigration(diff)
+	require.NoError(t, err)
+
+	t.Logf("Generated DDL:\n%s", ddl)
+
+	require.Contains(t, ddl, `("userId")`, "CamelCase column in CREATE INDEX must be quoted")
+}
+
+// TestCamelCaseIndexColumnQuoting_SyncSchema reproduces https://github.com/bytebase/bytebase/issues/19348
+// via the Sync Schema path: the source schema is exported (with proper quoting), then
+// parsed into metadata by GetDatabaseMetadata (which calls generateIndexDefinition).
+// The parsed metadata's Definition must preserve quoting for CamelCase columns.
+func TestCamelCaseIndexColumnQuoting_SyncSchema(t *testing.T) {
+	// This is the exported schema from the source database (pg_get_indexdef quotes correctly).
+	sourceSchemaSQL := `
+CREATE TABLE "public"."ba_account" (
+    "userId" text NOT NULL,
+    "accountName" text
+);
+
+CREATE INDEX "ba_account_userid_idx" ON "public"."ba_account" ("userId");
+`
+
+	// Parse the source schema into metadata (this is what getTargetDBMetadata does).
+	parsedMetadata, err := GetDatabaseMetadata(sourceSchemaSQL)
+	require.NoError(t, err)
+
+	// Verify the parsed index Definition has quoted "userId".
+	var indexDef string
+	for _, s := range parsedMetadata.Schemas {
+		for _, tbl := range s.Tables {
+			for _, idx := range tbl.Indexes {
+				if idx.Name == "ba_account_userid_idx" {
+					indexDef = idx.Definition
+				}
+			}
+		}
+	}
+	require.NotEmpty(t, indexDef, "index definition should be set")
+	t.Logf("Parsed index Definition: %s", indexDef)
+	require.Contains(t, indexDef, `"userId"`, "CamelCase column must be quoted in parsed Definition")
+
+	// Now simulate the full Sync Schema diff: target has no index, source has it.
+	oldMetadata := &storepb.DatabaseSchemaMetadata{
+		Name: "testdb",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "ba_account",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "userId", Type: "text"},
+							{Name: "accountName", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	oldSchema := model.NewDatabaseMetadata(oldMetadata, nil, nil, storepb.Engine_POSTGRES, false)
+	newSchema := model.NewDatabaseMetadata(parsedMetadata, nil, nil, storepb.Engine_POSTGRES, false)
+
+	diff, err := schema.GetDatabaseSchemaDiff(storepb.Engine_POSTGRES, oldSchema, newSchema)
+	require.NoError(t, err)
+	require.NotNil(t, diff)
+
+	ddl, err := generateMigration(diff)
+	require.NoError(t, err)
+
+	t.Logf("Generated DDL:\n%s", ddl)
+
+	require.Contains(t, ddl, `"userId"`, "CamelCase column in CREATE INDEX must be quoted")
+}
+
+// TestCamelCaseConstraintQuoting_PrimaryKey verifies that PRIMARY KEY constraints
+// on CamelCase columns are properly quoted in generated ALTER TABLE statements.
+func TestCamelCaseConstraintQuoting_PrimaryKey(t *testing.T) {
+	// Old state: table without primary key
+	oldMetadata := &storepb.DatabaseSchemaMetadata{
+		Name: "testdb",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "ba_account",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "userId", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// New state: table with primary key on CamelCase column
+	newMetadata := &storepb.DatabaseSchemaMetadata{
+		Name: "testdb",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "ba_account",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "userId", Type: "text"},
+						},
+						Indexes: []*storepb.IndexMetadata{
+							{
+								Name:         "ba_account_pkey",
+								Expressions:  []string{"userId"},
+								Type:         "btree",
+								Primary:      true,
+								Unique:       true,
+								IsConstraint: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	oldSchema := model.NewDatabaseMetadata(oldMetadata, nil, nil, storepb.Engine_POSTGRES, false)
+	newSchema := model.NewDatabaseMetadata(newMetadata, nil, nil, storepb.Engine_POSTGRES, false)
+
+	diff, err := schema.GetDatabaseSchemaDiff(storepb.Engine_POSTGRES, oldSchema, newSchema)
+	require.NoError(t, err)
+	require.NotNil(t, diff)
+
+	ddl, err := generateMigration(diff)
+	require.NoError(t, err)
+
+	t.Logf("Generated DDL:\n%s", ddl)
+
+	require.Contains(t, ddl, `PRIMARY KEY ("userId")`, "CamelCase column in PRIMARY KEY must be quoted")
+}
+
+// TestCamelCaseConstraintQuoting_Unique verifies that UNIQUE constraints
+// on CamelCase columns are properly quoted in generated ALTER TABLE statements.
+func TestCamelCaseConstraintQuoting_Unique(t *testing.T) {
+	// Old state: table without unique constraint
+	oldMetadata := &storepb.DatabaseSchemaMetadata{
+		Name: "testdb",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "ba_account",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "userId", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// New state: table with unique constraint on CamelCase column
+	newMetadata := &storepb.DatabaseSchemaMetadata{
+		Name: "testdb",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "ba_account",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "userId", Type: "text"},
+						},
+						Indexes: []*storepb.IndexMetadata{
+							{
+								Name:         "ba_account_userId_key",
+								Expressions:  []string{"userId"},
+								Type:         "btree",
+								Unique:       true,
+								IsConstraint: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	oldSchema := model.NewDatabaseMetadata(oldMetadata, nil, nil, storepb.Engine_POSTGRES, false)
+	newSchema := model.NewDatabaseMetadata(newMetadata, nil, nil, storepb.Engine_POSTGRES, false)
+
+	diff, err := schema.GetDatabaseSchemaDiff(storepb.Engine_POSTGRES, oldSchema, newSchema)
+	require.NoError(t, err)
+	require.NotNil(t, diff)
+
+	ddl, err := generateMigration(diff)
+	require.NoError(t, err)
+
+	t.Logf("Generated DDL:\n%s", ddl)
+
+	require.Contains(t, ddl, `UNIQUE ("userId")`, "CamelCase column in UNIQUE constraint must be quoted")
+}

--- a/backend/plugin/schema/pg/get_database_metadata.go
+++ b/backend/plugin/schema/pg/get_database_metadata.go
@@ -2456,11 +2456,12 @@ func (e *metadataExtractor) generateIndexDefinition(ctx *parser.IndexstmtContext
 	if len(index.Expressions) > 0 {
 		columnList := make([]string, len(index.Expressions))
 		for i, expr := range index.Expressions {
+			quoted := quoteIndexExpression(expr)
 			// Add DESC if needed
 			if i < len(index.Descending) && index.Descending[i] {
-				columnList[i] = fmt.Sprintf("%s DESC", expr)
+				columnList[i] = fmt.Sprintf("%s DESC", quoted)
 			} else {
-				columnList[i] = expr
+				columnList[i] = quoted
 			}
 		}
 		parts = append(parts, fmt.Sprintf("(%s)", strings.Join(columnList, ", ")))
@@ -2561,11 +2562,12 @@ func (*metadataExtractor) generateConstraintIndexDefinition(index *storepb.Index
 	if len(index.Expressions) > 0 {
 		columnList := make([]string, len(index.Expressions))
 		for i, expr := range index.Expressions {
+			quoted := quoteIndexExpression(expr)
 			// Add DESC if needed
 			if i < len(index.Descending) && index.Descending[i] {
-				columnList[i] = fmt.Sprintf("%s DESC", expr)
+				columnList[i] = fmt.Sprintf("%s DESC", quoted)
 			} else {
-				columnList[i] = expr
+				columnList[i] = quoted
 			}
 		}
 		parts = append(parts, fmt.Sprintf("(%s)", strings.Join(columnList, ", ")))


### PR DESCRIPTION
## Summary
- Fix missing double quotes for CamelCase column names in generated PostgreSQL `CREATE INDEX`, `PRIMARY KEY`, and `UNIQUE` constraint statements
- Add `quoteIndexExpression()` helper that quotes identifiers containing uppercase letters while leaving lowercase identifiers and complex expressions unchanged
- Apply quoting in `generateIndexDefinition`, `generateConstraintIndexDefinition` (Definition construction), and `writeMigrationPrimaryKey`, `writeMigrationUniqueKey` (direct SQL construction)

Fixes #19348

## Test plan
- [x] Unit test for `quoteIndexExpression` covering: CamelCase, lowercase, already-quoted, function expressions, cast expressions, empty string
- [x] Integration test for SDL diff path (AST-based)
- [x] Integration test for Sync Schema path (parses exported schema → generates migration DDL)
- [x] Integration test for PRIMARY KEY on CamelCase column
- [x] Integration test for UNIQUE constraint on CamelCase column
- [x] Full `go test ./backend/plugin/schema/pg/` suite passes (including testcontainer tests)
- [x] Manual verification via Bytebase UI: Sync Schema between two databases with CamelCase-indexed columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)