### PR TITLE
fix: strip /schemaString suffix in GetSchemaString REST gateway handler

### DIFF
--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -987,7 +987,7 @@ type metadataFilter struct {
 }
 
 func (s *DatabaseService) GetSchemaString(ctx context.Context, req *connect.Request[v1pb.GetSchemaStringRequest]) (*connect.Response[v1pb.GetSchemaStringResponse], error) {
-	instanceID, databaseName, err := common.GetInstanceDatabaseID(req.Msg.Name)
+	instanceID, databaseName, err := common.TrimSuffixAndGetInstanceDatabaseID(req.Msg.Name, common.SchemaStringSuffix)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to parse %q", req.Msg.Name))
 	}

--- a/backend/common/resource_name.go
+++ b/backend/common/resource_name.go
@@ -54,10 +54,11 @@ const (
 	ServiceAccountNamePrefix   = "serviceAccounts/"
 	WorkloadIdentityNamePrefix = "workloadIdentities/"
 
-	SchemaSuffix    = "/schema"
-	SDLSchemaSuffix = "/sdlSchema"
-	MetadataSuffix  = "/metadata"
-	CatalogSuffix   = "/catalog"
+	SchemaSuffix       = "/schema"
+	SDLSchemaSuffix    = "/sdlSchema"
+	SchemaStringSuffix = "/schemaString"
+	MetadataSuffix     = "/metadata"
+	CatalogSuffix      = "/catalog"
 
 	UserBindingPrefix             = "user:"
 	GroupBindingPrefix            = "group:"


### PR DESCRIPTION
## Summary
- The REST gateway route `GET /v1/{name=instances/*/databases/*/schemaString}` captures the full path including `/schemaString` into the `name` field
- `GetSchemaString` passed `name` directly to `GetInstanceDatabaseID()`, which expects exactly 4 path segments (`instances/{id}/databases/{id}`), causing parse failure on the 5-segment input
- Fixed by using `TrimSuffixAndGetInstanceDatabaseID` with a new `SchemaStringSuffix` constant, matching the pattern used by `GetDatabaseSDLSchema` and other sibling endpoints

## Test plan
- [ ] `GET /v1/instances/{instance}/databases/{database}/schemaString` returns schema instead of parse error
- [ ] ConnectRPC endpoint `GetSchemaString` continues to work (name field won't have suffix, `TrimSuffix` validates and errors cleanly)
- [ ] `go build ./backend/api/v1/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)