### PR TITLE
fix(schema): preserve overloaded PostgreSQL functions in schema dump

### DIFF
--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -117,7 +117,7 @@ func GetDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *storepb.Da
 			if function.SkipDump {
 				continue
 			}
-			funcID := getObjectID(schema.Name, function.Name)
+			funcID := getObjectID(schema.Name, funcIdentity(function))
 			functionMap[funcID] = function
 			graph.AddNode(funcID)
 			for _, dependency := range function.DependencyTables {
@@ -405,7 +405,7 @@ func GetSchemaDefinition(schema *storepb.SchemaMetadata) (string, error) {
 		if function.SkipDump {
 			continue
 		}
-		funcID := getObjectID(schema.Name, function.Name)
+		funcID := getObjectID(schema.Name, funcIdentity(function))
 		functionMap[funcID] = function
 		graph.AddNode(funcID)
 		for _, dependency := range function.DependencyTables {
@@ -1353,6 +1353,15 @@ func writeAlterSequenceOwnedBy(out io.Writer, schema string, sequence *storepb.S
 	}
 	_, err := io.WriteString(out, "\";\n\n")
 	return err
+}
+
+// funcIdentity returns the unique identity for a function, preferring
+// the full signature (name + parameter types) to support overloaded functions.
+func funcIdentity(f *storepb.FunctionMetadata) string {
+	if f.Signature != "" {
+		return f.Signature
+	}
+	return f.Name
 }
 
 func getObjectID(schema string, object string) string {


### PR DESCRIPTION
## Summary
- PostgreSQL supports function overloading (same name, different parameter signatures)
- The schema dump code used `function.Name` as the map key when building the function dependency graph, causing key collisions for overloaded functions — only the last overload survived per name
- Changed to use `function.Signature` (e.g., `camel_to_snake(character varying, character varying)`) which is the canonical PostgreSQL function identity
- Fixes both `GetDatabaseDefinition` and `GetSchemaDefinition` code paths

## Root Cause
In `get_database_definition.go`, two locations built a `functionMap` keyed by `getObjectID(schema.Name, function.Name)`. For overloaded functions like:
- `camel_to_snake(varchar)` 
- `camel_to_snake(varchar, varchar)`

Both mapped to `public.camel_to_snake`, so the second entry overwrote the first. Which overload survived depended on PostgreSQL's OID (creation) order, causing:
1. **Phantom diffs** in schema compare between identical databases (different creation order → different survivor)
2. **Lost function definitions** in schema dumps (one overload silently dropped)
3. **Confusing sync results** where DDL was generated for identical schemas

## Test plan
- [x] Created two databases with identical overloaded functions in different creation order
- [x] Verified schema sync now shows "No diff" (previously showed phantom differences)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)