### PR TITLE
fix(frontend): use create(BindingSchema) instead of plain objects for IAM policy bindings

### DIFF
--- a/frontend/src/components/ProjectMember/AddProjectMember/AddProjectMembersPanel.vue
+++ b/frontend/src/components/ProjectMember/AddProjectMember/AddProjectMembersPanel.vue
@@ -148,10 +148,14 @@ const mergePolicyBinding = async () => {
   }
 
   for (const binding of bindingMap.values()) {
-    policy.bindings.push({
-      ...binding,
-      members: [...new Set(binding.members)],
-    });
+    policy.bindings.push(
+      create(BindingSchema, {
+        role: binding.role,
+        members: [...new Set(binding.members)],
+        condition: binding.condition,
+        parsedExpr: binding.parsedExpr,
+      })
+    );
   }
 
   return policy;

--- a/frontend/src/components/User/Settings/CreateServiceAccountDrawer.vue
+++ b/frontend/src/components/User/Settings/CreateServiceAccountDrawer.vue
@@ -112,7 +112,7 @@ import {
   unknownUser,
 } from "@/types";
 import { PresetRoleType } from "@/types/iam";
-import type { Binding } from "@/types/proto-es/v1/iam_policy_pb";
+import { BindingSchema } from "@/types/proto-es/v1/iam_policy_pb";
 import type { User } from "@/types/proto-es/v1/user_service_pb";
 import { UserSchema } from "@/types/proto-es/v1/user_service_pb";
 
@@ -221,12 +221,12 @@ const updateProjectIamPolicyForMember = async (
         existingBinding.members.push(member);
       }
     } else {
-      policy.bindings.push({
-        role,
-        members: [member],
-        condition: undefined,
-        parsedExpr: undefined,
-      } as Binding);
+      policy.bindings.push(
+        create(BindingSchema, {
+          role,
+          members: [member],
+        })
+      );
     }
   }
 

--- a/frontend/src/components/User/Settings/CreateWorkloadIdentityDrawer.vue
+++ b/frontend/src/components/User/Settings/CreateWorkloadIdentityDrawer.vue
@@ -351,7 +351,7 @@ import {
   unknownUser,
 } from "@/types";
 import { PresetRoleType } from "@/types/iam";
-import type { Binding } from "@/types/proto-es/v1/iam_policy_pb";
+import { BindingSchema } from "@/types/proto-es/v1/iam_policy_pb";
 import type { User } from "@/types/proto-es/v1/user_service_pb";
 import {
   UserSchema,
@@ -691,12 +691,12 @@ const updateProjectIamPolicyForMember = async (
         existingBinding.members.push(member);
       }
     } else {
-      policy.bindings.push({
-        role,
-        members: [member],
-        condition: undefined,
-        parsedExpr: undefined,
-      } as Binding);
+      policy.bindings.push(
+        create(BindingSchema, {
+          role,
+          members: [member],
+        })
+      );
     }
   }
 


### PR DESCRIPTION
Plain JS object literals lose protobuf runtime metadata, causing "cannot use field bytebase.v1.Binding.role with message undefined" serialization error when updating IAM policies.