### PR TITLE
fix(frontend): replace proto object spreads with clone() to preserve $typeName metadata

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/Actions.vue
@@ -62,7 +62,7 @@
 </template>
 
 <script setup lang="ts">
-import { create } from "@bufbuild/protobuf";
+import { clone, create } from "@bufbuild/protobuf";
 import { useDialog } from "naive-ui";
 import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
@@ -82,6 +82,7 @@ import {
   BatchUpdateIssuesStatusRequestSchema,
   IssueStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
+import { PlanSchema } from "@/types/proto-es/v1/plan_service_pb";
 import {
   BatchRunTasksRequestSchema,
   CreateRolloutRequestSchema,
@@ -234,9 +235,9 @@ const handlePlanStateChange = async (action: "PLAN_CLOSE" | "PLAN_REOPEN") => {
     onPositiveClick: async () => {
       d.loading = true;
       try {
-        await planStore.updatePlan({ ...plan.value, state: newState }, [
-          "state",
-        ]);
+        const planPatch = clone(PlanSchema, plan.value);
+        planPatch.state = newState;
+        await planStore.updatePlan(planPatch, ["state"]);
         await resourcePoller.refreshResources();
       } catch (error) {
         pushNotification({

--- a/frontend/src/store/modules/idp.ts
+++ b/frontend/src/store/modules/idp.ts
@@ -1,4 +1,4 @@
-import { create } from "@bufbuild/protobuf";
+import { clone, create } from "@bufbuild/protobuf";
 import { createContextValues } from "@connectrpc/connect";
 import { isEqual, isUndefined } from "lodash-es";
 import { defineStore } from "pinia";
@@ -10,6 +10,7 @@ import {
   CreateIdentityProviderRequestSchema,
   DeleteIdentityProviderRequestSchema,
   GetIdentityProviderRequestSchema,
+  IdentityProviderSchema,
   ListIdentityProvidersRequestSchema,
   UpdateIdentityProviderRequestSchema,
 } from "@/types/proto-es/v1/idp_service_pb";
@@ -82,7 +83,11 @@ export const useIdentityProviderStore = defineStore("idp", () => {
       throw new Error(`identity provider with name ${update.name} not found`);
     }
 
-    const fullProvider = { ...originData, ...update } as IdentityProvider;
+    const fullProvider = clone(IdentityProviderSchema, originData);
+    if (update.title !== undefined) fullProvider.title = update.title;
+    if (update.domain !== undefined) fullProvider.domain = update.domain;
+    if (update.type !== undefined) fullProvider.type = update.type;
+    if (update.config !== undefined) fullProvider.config = update.config;
     const request = create(UpdateIdentityProviderRequestSchema, {
       identityProvider: fullProvider,
       updateMask: {

--- a/frontend/src/store/modules/v1/worksheet.ts
+++ b/frontend/src/store/modules/v1/worksheet.ts
@@ -1,4 +1,4 @@
-import { create } from "@bufbuild/protobuf";
+import { clone, create } from "@bufbuild/protobuf";
 import { createContextValues } from "@connectrpc/connect";
 import { uniqBy } from "lodash-es";
 import { defineStore } from "pinia";
@@ -20,6 +20,7 @@ import {
   UpdateWorksheetOrganizerRequestSchema,
   UpdateWorksheetRequestSchema,
   WorksheetOrganizerSchema,
+  WorksheetSchema,
 } from "@/types/proto-es/v1/worksheet_service_pb";
 import {
   extractWorksheetUID,
@@ -109,7 +110,7 @@ export const useWorkSheetStore = defineStore("worksheet_v1", () => {
   const createWorksheet = async (worksheet: Worksheet) => {
     const fullWorksheet = worksheet.name
       ? worksheet
-      : { ...worksheet, name: "" };
+      : clone(WorksheetSchema, worksheet);
     const request = create(CreateWorksheetRequestSchema, {
       worksheet: fullWorksheet,
     });


### PR DESCRIPTION
Object spread on protobuf messages can strip nested $typeName metadata, causing binary serialization failures. Use clone() from @bufbuild/protobuf which properly deep-clones proto messages with all metadata intact.