### PR TITLE
fix: revoke pending access grant when ACCESS_GRANT issue is rejected or cancelled

### DIFF
--- a/backend/api/v1/access_grant_service.go
+++ b/backend/api/v1/access_grant_service.go
@@ -310,6 +310,21 @@ func activateAccessGrant(ctx context.Context, stores *store.Store, accessGrantNa
 	return updated, nil
 }
 
+func revokeAccessGrantByName(ctx context.Context, stores *store.Store, accessGrantName string) (*store.AccessGrantMessage, error) {
+	_, accessGrantID, err := common.GetProjectIDAccessGrantID(accessGrantName)
+	if err != nil {
+		return nil, err
+	}
+	status := storepb.AccessGrant_REVOKED
+	updated, err := stores.UpdateAccessGrant(ctx, accessGrantID, &store.UpdateAccessGrantMessage{
+		Status: &status,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to revoke access grant")
+	}
+	return updated, nil
+}
+
 // RevokeAccessGrant revokes an active access grant.
 func (s *AccessGrantService) RevokeAccessGrant(ctx context.Context, request *connect.Request[v1pb.RevokeAccessGrantRequest]) (*connect.Response[v1pb.AccessGrant], error) {
 	if err := s.licenseService.IsFeatureEnabled(v1pb.PlanFeature_FEATURE_JIT); err != nil {

--- a/backend/api/v1/issue_hook.go
+++ b/backend/api/v1/issue_hook.go
@@ -131,3 +131,18 @@ func completeAccessRequestIssue(ctx context.Context, stores *store.Store, userEm
 
 	return updatedIssue, nil
 }
+
+// rejectAccessRequestIssue revokes the access grant when an ACCESS_GRANT issue is rejected or cancelled.
+func rejectAccessRequestIssue(ctx context.Context, stores *store.Store, issue *store.IssueMessage) error {
+	if issue.Type != storepb.Issue_ACCESS_GRANT {
+		return nil
+	}
+	if issue.Payload.AccessGrantId == "" {
+		return nil
+	}
+	accessGrantName := common.FormatAccessGrant(issue.ProjectID, issue.Payload.AccessGrantId)
+	if _, err := revokeAccessGrantByName(ctx, stores, accessGrantName); err != nil {
+		return errors.Wrapf(err, "failed to revoke access grant %v", accessGrantName)
+	}
+	return nil
+}

--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -684,6 +684,10 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
 	}
 
+	if err := rejectAccessRequestIssue(ctx, s.store, issue); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
 	if _, err := s.store.CreateIssueComments(ctx, user.Email, &store.IssueCommentMessage{
 		IssueUID: issue.UID,
 		Payload: &storepb.IssueCommentPayload{
@@ -1020,6 +1024,11 @@ func (s *IssueService) BatchUpdateIssuesStatus(ctx context.Context, req *connect
 		if updatedIssue == nil {
 			slog.Error("updated issue not found", "issueUID", issueUID)
 			continue
+		}
+		if newStatus == storepb.Issue_CANCELED {
+			if err := rejectAccessRequestIssue(ctx, s.store, updatedIssue); err != nil {
+				slog.Error("failed to revoke access grant for cancelled issue", "issueUID", issueUID, log.BBError(err))
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- When an `ACCESS_GRANT` issue is rejected or cancelled, the associated access grant was left in `PENDING` status forever
- Added `revokeAccessGrantByName()` helper (mirrors existing `activateAccessGrant()`) and `rejectAccessRequestIssue()` orchestration
- Called in `RejectIssue()` and `BatchUpdateIssuesStatus()` (for `CANCELED` status)

## Test plan
- [ ] Reject an ACCESS_GRANT issue and verify the access grant status changes to REVOKED
- [ ] Cancel an ACCESS_GRANT issue via batch update and verify the access grant status changes to REVOKED
- [ ] Approve an ACCESS_GRANT issue and verify the existing activate flow still works
- [ ] Reject/cancel a non-ACCESS_GRANT issue and verify no errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)