### PR TITLE
feat(frontend): show issue approval status for PENDING access grants

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -52,6 +52,7 @@
     "latest": "Latest",
     "error": "Error",
     "canceled": "Canceled",
+    "rejected": "Rejected",
     "approve": "Approve",
     "done": "Done",
     "create": "Create",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -52,6 +52,7 @@
     "latest": "Último",
     "error": "Error",
     "canceled": "Cancelado",
+    "rejected": "Rechazado",
     "approve": "Aprobar",
     "done": "Hecho",
     "create": "Crear",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -52,6 +52,7 @@
     "latest": "最新の",
     "error": "間違い",
     "canceled": "キャンセル",
+    "rejected": "却下",
     "approve": "承認する",
     "done": "仕上げる",
     "create": "作成する",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -52,6 +52,7 @@
     "latest": "Mới nhất",
     "error": "Lỗi",
     "canceled": "Đã hủy",
+    "rejected": "Đã từ chối",
     "approve": "Phê duyệt",
     "done": "Hoàn tất",
     "create": "Tạo",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -52,6 +52,7 @@
     "latest": "最新",
     "error": "错误",
     "canceled": "已取消",
+    "rejected": "已拒绝",
     "approve": "批准",
     "done": "完成",
     "create": "创建",


### PR DESCRIPTION
## Summary
<img width="1098" height="908" alt="Microsoft Edge 2026-02-26 14 55 04" src="https://github.com/user-attachments/assets/95f1ad5f-8f9a-4b9b-8d58-c4efa5a3b7db" />
close BYT-8918
- When an access grant is PENDING and has an associated issue, fetch the issue to display a more meaningful status (**Rejected** / **Canceled**) instead of always showing "Pending"
- Add `REJECTED` and `CANCELED` display statuses with appropriate tag colors (error/default) and line-through styling
- Add i18n `common.rejected` key for all 5 locales (en-US, zh-CN, es-ES, ja-JP, vi-VN)

## Test plan
- [ ] Open SQL Editor → Access Grants panel
- [ ] Verify PENDING grants with rejected issues show "Rejected" (red tag)
- [ ] Verify PENDING grants with canceled issues show "Canceled" (gray tag)
- [ ] Verify normal PENDING grants still show "Pending" (yellow tag)
- [ ] Verify rejected/canceled grants have line-through styling on the query text
- [ ] Verify "View Issue" link still works for all states

🤖 Generated with [Claude Code](https://claude.com/claude-code)