### PR TITLE
fix(frontend): add consistent horizontal padding to database group detail page

### DIFF
--- a/frontend/src/views/project/ProjectDatabaseGroupDetail.vue
+++ b/frontend/src/views/project/ProjectDatabaseGroupDetail.vue
@@ -2,7 +2,7 @@
   <div
     v-if="databaseGroup"
     v-bind="$attrs"
-    class="min-h-full flex-1 relative flex flex-col gap-y-4 pt-4"
+    class="min-h-full flex-1 relative flex flex-col gap-y-4 px-4 pt-4"
   >
     <FeatureAttention
       :feature="PlanFeature.FEATURE_DATABASE_GROUPS"


### PR DESCRIPTION
The page was missing px-4 that sibling project pages use for consistent horizontal spacing within the ProjectV1Layout margin.