### PR TITLE
fix(frontend): correct sticky bottom offset and padding for action bars

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueListV1.vue
+++ b/frontend/src/components/IssueV1/components/IssueListV1.vue
@@ -162,7 +162,7 @@
 
   <div
     v-if="isListInViewport && selectedIssueList.length > 0"
-    class="sticky -bottom-4 w-full bg-white flex items-center gap-x-2 px-3 sm:px-4 py-2 border-y"
+    class="sticky bottom-0 w-full bg-white flex items-center gap-x-2 px-3 sm:px-4 py-2 border-y"
     :class="bordered && 'border-x'"
   >
     <BatchIssueActionsV1 :issue-list="selectedIssueList" />

--- a/frontend/src/views/EnvironmentDetail.vue
+++ b/frontend/src/views/EnvironmentDetail.vue
@@ -11,7 +11,7 @@
     <div class="flex flex-col h-full w-full">
       <EnvironmentFormBody :features="features" class="w-full flex-1 px-4" />
       <EnvironmentFormButtons
-        class="sticky -bottom-4 bg-white py-4 px-2 border-t border-block-border"
+        class="sticky bottom-0 bg-white py-2 px-2 border-t border-block-border"
         :class="buttonsClass"
       />
     </div>

--- a/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
+++ b/frontend/src/views/SettingWorkspaceSQLReviewDetail.vue
@@ -125,7 +125,7 @@
     />
     <div
       v-if="state.rulesUpdated"
-      class="w-full mt-4 py-4 border-t border-block-border flex justify-between bg-white sticky -bottom-4 z-10"
+      class="w-full mt-4 py-2 border-t border-block-border flex justify-between bg-white sticky bottom-0 z-10"
     >
       <NButton @click.prevent="onCancelChanges">
         <span> {{ $t("common.cancel") }}</span>


### PR DESCRIPTION
Change sticky positioning from -bottom-4 to bottom-0 and reduce vertical padding for consistent alignment of sticky action bars.