### PR TITLE
fix(tidb): respect IF EXISTS clause in DROP INDEX walk-through

### DIFF
--- a/backend/plugin/schema/tidb/testdata/walk_through.yaml
+++ b/backend/plugin/schema/tidb/testdata/walk_through.yaml
@@ -420,6 +420,36 @@
     : true\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
   advice: null
 - statement: "CREATE TABLE t(\n  a int PRIMARY KEY DEFAULT 1,\n  b varchar(200) CHARACTER\
+    \ SET utf8mb4 NOT NULL UNIQUE\n);\nDROP INDEX IF EXISTS nonexistent on t;"
+  ignore_case_sensitive: false
+  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
+    \        {\n          \"name\": \"t\",\n          \"columns\": [\n           \
+    \ {\n              \"name\": \"a\",\n              \"position\": 1,\n        \
+    \      \"default\": \"1\",\n              \"type\": \"int(11)\"\n            },\n\
+    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
+    \              \"type\": \"varchar(200)\",\n              \"characterSet\": \"\
+    utf8mb4\"\n            }\n          ],\n          \"indexes\": [\n           \
+    \ {\n              \"name\": \"PRIMARY\",\n              \"expressions\": [\n\
+    \                \"a\"\n              ],\n              \"type\": \"BTREE\",\n\
+    \              \"unique\": true,\n              \"primary\": true,\n         \
+    \     \"visible\": true\n            },\n            {\n              \"name\"\
+    : \"b\",\n              \"expressions\": [\n                \"b\"\n          \
+    \    ],\n              \"type\": \"BTREE\",\n              \"unique\": true,\n\
+    \              \"visible\": true\n            }\n          ]\n        }\n     \
+    \ ]\n    }\n  ]\n}"
+  advice: null
+- statement: "CREATE TABLE t(\n  a int PRIMARY KEY DEFAULT 1,\n  b varchar(200) CHARACTER\
+    \ SET utf8mb4 NOT NULL UNIQUE\n);\nDROP INDEX nonexistent on t;"
+  ignore_case_sensitive: false
+  want: ''
+  advice:
+    status: 1
+    code: 809
+    title: index "nonexistent" does not exist in table "t"
+    content: index "nonexistent" does not exist in table "t"
+    startPosition:
+      line: 0
+- statement: "CREATE TABLE t(\n  a int PRIMARY KEY DEFAULT 1,\n  b varchar(200) CHARACTER\
     \ SET utf8mb4 NOT NULL UNIQUE\n);\nDROP INDEX b on t;"
   ignore_case_sensitive: false
   want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\

--- a/backend/plugin/schema/tidb/walk_through.go
+++ b/backend/plugin/schema/tidb/walk_through.go
@@ -299,6 +299,9 @@ func tidbDropIndex(d *model.DatabaseMetadata, node *tidbast.DropIndexStmt) *stor
 	}
 
 	if err := table.DropIndex(node.IndexName); err != nil {
+		if node.IfExists {
+			return nil
+		}
 		return &storepb.Advice{
 			Status:        storepb.Advice_ERROR,
 			Code:          code.IndexNotExists.Int32(),


### PR DESCRIPTION
## Summary

- Fix TiDB SQL review falsely raising `IndexNotExists` (code 809) for `DROP INDEX IF EXISTS` when the index doesn't exist
- The `IF EXISTS` clause is specifically meant to handle missing indexes gracefully, but the walk-through ignored it
- Add test cases for both `DROP INDEX IF EXISTS` (no error) and `DROP INDEX` without `IF EXISTS` (error 809)

Fixes: customer report on Bytebase 3.14.1 where `ALTER TABLE ... DROP INDEX IF EXISTS` raised a review error

## Test plan

- [x] `TestWalkThrough` passes with new test cases
- [ ] Verify in staging with TiDB: `ALTER TABLE t DROP INDEX IF EXISTS nonexistent;` should not raise review error
- [ ] Verify `DROP INDEX nonexistent ON t;` (without IF EXISTS) still raises error 809

🤖 Generated with [Claude Code](https://claude.com/claude-code)