### PR TITLE
feat(action): support access-token auth for workload identity

### DIFF
--- a/action/command/rollout.go
+++ b/action/command/rollout.go
@@ -55,7 +55,7 @@ func runRollout(w *world.World) func(command *cobra.Command, _ []string) error {
 		}()
 		w.IsRollout = true
 		ctx := command.Context()
-		client, err := NewClient(w.URL, w.ServiceAccount, w.ServiceAccountSecret)
+		client, err := NewClientFromWorld(w)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create client")
 		}

--- a/action/command/root.go
+++ b/action/command/root.go
@@ -25,6 +25,7 @@ func NewRootCommand(w *world.World) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&w.URL, "url", "https://demo.bytebase.com", "Bytebase URL")
 	cmd.PersistentFlags().StringVar(&w.ServiceAccount, "service-account", "", "Bytebase Service account")
 	cmd.PersistentFlags().StringVar(&w.ServiceAccountSecret, "service-account-secret", "", "Bytebase Service account secret")
+	cmd.PersistentFlags().StringVar(&w.AccessToken, "access-token", "", "Bytebase access token (alternative to service account auth, e.g. from workload identity exchange)")
 	cmd.PersistentFlags().StringVar(&w.Project, "project", "projects/hr", "Bytebase project")
 	cmd.PersistentFlags().StringSliceVar(&w.Targets, "targets", []string{"instances/test-sample-instance/databases/hr_test", "instances/prod-sample-instance/databases/hr_prod"}, "Bytebase targets. Either one or more databases or a single databaseGroup")
 	cmd.PersistentFlags().StringVar(&w.FilePattern, "file-pattern", "", "File pattern to glob migration files")
@@ -51,6 +52,14 @@ func rootPreRun(w *world.World) func(cmd *cobra.Command, args []string) error {
 
 		return nil
 	}
+}
+
+// NewClientFromWorld creates a Client using the authentication method configured in World.
+func NewClientFromWorld(w *world.World) (*Client, error) {
+	if w.AccessToken != "" {
+		return NewClientWithAccessToken(w.URL, w.AccessToken)
+	}
+	return NewClient(w.URL, w.ServiceAccount, w.ServiceAccountSecret)
 }
 
 func CheckVersionCompatibility(w *world.World, client *Client, cliVersion string) {

--- a/action/world/world.go
+++ b/action/world/world.go
@@ -21,6 +21,7 @@ type World struct {
 	URL                  string
 	ServiceAccount       string
 	ServiceAccountSecret string
+	AccessToken          string // Alternative to service account auth, e.g. from workload identity exchange
 	Project              string // projects/{project}
 	Targets              []string
 	FilePattern          string


### PR DESCRIPTION
## Summary
- Add `--access-token` flag to `bytebase-action` CLI as an alternative to service account auth
- Enables OIDC/workload identity federation flow: CI/CD platforms exchange their OIDC token via `POST /v1/auth:exchangeToken` for a Bytebase access token, then pass it to bytebase-action
- Unify client creation via `NewClientFromWorld()` for both check and rollout commands

## Changes
- `action/world/world.go` — Add `AccessToken` field to World struct
- `action/command/root.go` — Add `--access-token` persistent flag and `NewClientFromWorld()` helper
- `action/command/api.go` — Add `NewClientWithAccessToken()` and refactor into `createClient()` with token refresher logic
- `action/command/rollout.go` — Use `NewClientFromWorld()` instead of `NewClient()`

## Test plan
- [ ] Verify `bytebase-action check --access-token=<token>` authenticates correctly
- [ ] Verify `bytebase-action rollout --access-token=<token>` authenticates correctly
- [ ] Verify existing service account auth (`--service-account` + `--service-account-secret`) still works
- [ ] Verify `--access-token` takes precedence when both are provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)