### PR TITLE
fix: resolve incorrect integer type conversions

### DIFF
--- a/backend/common/position.go
+++ b/backend/common/position.go
@@ -2,8 +2,20 @@
 package common
 
 import (
+	"math"
+
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
+
+func safeIntToInt32(v int) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if v < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(v)
+}
 
 // ANTLRPosition is a position in a text expressed as one-based line and
 // zero-based column character (code point) offset integrated with ANTLR4.
@@ -54,28 +66,16 @@ func ConvertANTLRPositionToPosition(a *ANTLRPosition, text string) *storepb.Posi
 func ConvertANTLRLineToPosition(line int) *storepb.Position {
 	// ANTLR line numbers are 1-based, and Position uses 1-based line numbering.
 	// Just pass through the value, handling the 0 case for safety.
-	positionLine := line
-	if line < 1 {
-		positionLine = 1
-	}
+	positionLine := max(line, 1)
 	return &storepb.Position{
-		Line: int32(positionLine),
+		Line: safeIntToInt32(positionLine),
 	}
 }
 
-func ConvertTiDBParserErrorPositionToPosition(line, column int) *storepb.Position {
-	if line < 1 {
-		line = 1
-	}
-	if column < 1 {
-		column = 1
-	}
-
-	// TiDB parser provides 1-based line and column
-	// Store them as 1-based in Position
+func ConvertTiDBParserErrorPositionToPosition(line, column int32) *storepb.Position {
 	return &storepb.Position{
-		Line:   int32(line),
-		Column: int32(column),
+		Line:   max(line, 1),
+		Column: max(column, 1),
 	}
 }
 

--- a/backend/common/position_test.go
+++ b/backend/common/position_test.go
@@ -47,8 +47,8 @@ func TestConvertANTLRPositionToPosition(t *testing.T) {
 func TestConvertTiDBParserErrorPositionToPosition(t *testing.T) {
 	testCases := []struct {
 		name         string
-		line         int
-		column       int
+		line         int32
+		column       int32
 		expectedLine int32
 		expectedCol  int32
 	}{

--- a/backend/plugin/db/mysql/sync.go
+++ b/backend/plugin/db/mysql/sync.go
@@ -64,14 +64,16 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 		return nil, err
 	}
 
-	lowerCaseTableNames := 0
+	var lowerCaseTableNames int32
 	lowerCaseTableNamesText, err := d.getServerVariable(ctx, "lower_case_table_names")
 	if err != nil {
 		slog.Debug("failed to get lower_case_table_names variable", log.BBError(err))
 	} else {
-		lowerCaseTableNames, err = strconv.Atoi(lowerCaseTableNamesText)
+		v, err := strconv.ParseInt(lowerCaseTableNamesText, 10, 32)
 		if err != nil {
 			slog.Debug("failed to parse lower_case_table_names variable", log.BBError(err))
+		} else {
+			lowerCaseTableNames = int32(v)
 		}
 	}
 
@@ -115,7 +117,7 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 		Version:   version,
 		Databases: databases,
 		Metadata: &storepb.Instance{
-			MysqlLowerCaseTableNames: int32(lowerCaseTableNames),
+			MysqlLowerCaseTableNames: lowerCaseTableNames,
 			Roles:                    instanceRoles,
 		},
 	}, nil

--- a/backend/plugin/db/starrocks/sync.go
+++ b/backend/plugin/db/starrocks/sync.go
@@ -43,14 +43,16 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 		return nil, err
 	}
 
-	lowerCaseTableNames := 0
+	var lowerCaseTableNames int32
 	lowerCaseTableNamesText, err := d.getServerVariable(ctx, "lower_case_table_names")
 	if err != nil {
 		slog.Debug("failed to get lower_case_table_names variable", log.BBError(err))
 	} else {
-		lowerCaseTableNames, err = strconv.Atoi(lowerCaseTableNamesText)
+		v, err := strconv.ParseInt(lowerCaseTableNamesText, 10, 32)
 		if err != nil {
 			slog.Debug("failed to parse lower_case_table_names variable", log.BBError(err))
+		} else {
+			lowerCaseTableNames = int32(v)
 		}
 	}
 
@@ -93,7 +95,7 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 		Version:   version,
 		Databases: databases,
 		Metadata: &storepb.Instance{
-			MysqlLowerCaseTableNames: int32(lowerCaseTableNames),
+			MysqlLowerCaseTableNames: lowerCaseTableNames,
 		},
 	}, nil
 }

--- a/backend/plugin/db/tidb/sync.go
+++ b/backend/plugin/db/tidb/sync.go
@@ -57,14 +57,16 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 		return nil, err
 	}
 
-	lowerCaseTableNames := 0
+	var lowerCaseTableNames int32
 	lowerCaseTableNamesText, err := d.getServerVariable(ctx, "lower_case_table_names")
 	if err != nil {
 		slog.Debug("failed to get lower_case_table_names variable", log.BBError(err))
 	} else {
-		lowerCaseTableNames, err = strconv.Atoi(lowerCaseTableNamesText)
+		v, err := strconv.ParseInt(lowerCaseTableNamesText, 10, 32)
 		if err != nil {
 			slog.Debug("failed to parse lower_case_table_names variable", log.BBError(err))
+		} else {
+			lowerCaseTableNames = int32(v)
 		}
 	}
 
@@ -108,7 +110,7 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 		Version:   version,
 		Databases: databases,
 		Metadata: &storepb.Instance{
-			MysqlLowerCaseTableNames: int32(lowerCaseTableNames),
+			MysqlLowerCaseTableNames: lowerCaseTableNames,
 			Roles:                    instanceRoles,
 		},
 	}, nil

--- a/backend/plugin/parser/elasticsearch/parser.go
+++ b/backend/plugin/parser/elasticsearch/parser.go
@@ -899,7 +899,7 @@ func (p *parser) string() (string, error) {
 						if err != nil {
 							break
 						}
-						uffff = (uffff << 4) + int(hex)
+						uffff = (uffff << 4) + int(uint32(hex))
 					}
 					// Treat uffff as UTF-16 encoded rune.
 					s += string(rune(uffff))

--- a/backend/plugin/parser/tidb/tidb.go
+++ b/backend/plugin/parser/tidb/tidb.go
@@ -159,16 +159,16 @@ func convertParserError(parserErr error) error {
 	if len(res[0]) != 3 {
 		return parserErr
 	}
-	line, err := strconv.Atoi(res[0][1])
+	line, err := strconv.ParseInt(res[0][1], 10, 32)
 	if err != nil {
 		return parserErr
 	}
-	column, err := strconv.Atoi(res[0][2])
+	column, err := strconv.ParseInt(res[0][2], 10, 32)
 	if err != nil {
 		return parserErr
 	}
 	return &base.SyntaxError{
-		Position: common.ConvertTiDBParserErrorPositionToPosition(line, column),
+		Position: common.ConvertTiDBParserErrorPositionToPosition(int32(line), int32(column)),
 		Message:  parserErr.Error(),
 	}
 }

--- a/backend/plugin/schema/mssql/get_database_metadata.go
+++ b/backend/plugin/schema/mssql/get_database_metadata.go
@@ -365,15 +365,15 @@ func parseSpatialIndexOption(optionCtx parser.ISpatial_index_optionContext, inde
 				densityPart := strings.TrimSpace(parts[1])
 
 				// Extract level number from "LEVEL_1", "LEVEL_2", etc.
-				levelNum := 0
+				var levelNum int32
 				if strings.HasPrefix(strings.ToUpper(levelPart), "LEVEL_") {
-					if num, err := strconv.Atoi(levelPart[6:]); err == nil {
-						levelNum = num
+					if num, err := strconv.ParseInt(levelPart[6:], 10, 32); err == nil {
+						levelNum = int32(num)
 					}
 				}
 
 				gridLevels = append(gridLevels, &storepb.GridLevel{
-					Level:   int32(levelNum),
+					Level:   levelNum,
 					Density: strings.ToUpper(densityPart),
 				})
 			}
@@ -385,7 +385,7 @@ func parseSpatialIndexOption(optionCtx parser.ISpatial_index_optionContext, inde
 	// Handle CELLS_PER_OBJECT
 	if optionCtx.CELLS_PER_OBJECT() != nil {
 		if decimalCtx := optionCtx.DECIMAL(); decimalCtx != nil {
-			if cellsPerObject, err := strconv.Atoi(decimalCtx.GetText()); err == nil {
+			if cellsPerObject, err := strconv.ParseInt(decimalCtx.GetText(), 10, 32); err == nil {
 				index.SpatialConfig.Tessellation.CellsPerObject = int32(cellsPerObject)
 			}
 		}
@@ -408,7 +408,7 @@ func parseRebuildIndexOption(rebuildCtx parser.IRebuild_index_optionContext, ind
 	// Handle FILLFACTOR
 	if rebuildCtx.FILLFACTOR() != nil {
 		if decimalCtx := rebuildCtx.DECIMAL(); decimalCtx != nil {
-			if fillFactor, err := strconv.Atoi(decimalCtx.GetText()); err == nil {
+			if fillFactor, err := strconv.ParseInt(decimalCtx.GetText(), 10, 32); err == nil {
 				index.SpatialConfig.Storage.Fillfactor = int32(fillFactor)
 			}
 		}
@@ -445,7 +445,7 @@ func parseRebuildIndexOption(rebuildCtx parser.IRebuild_index_optionContext, ind
 	// Handle MAXDOP
 	if rebuildCtx.MAXDOP() != nil {
 		if decimalCtx := rebuildCtx.DECIMAL(); decimalCtx != nil {
-			if maxdop, err := strconv.Atoi(decimalCtx.GetText()); err == nil {
+			if maxdop, err := strconv.ParseInt(decimalCtx.GetText(), 10, 32); err == nil {
 				index.SpatialConfig.Storage.Maxdop = int32(maxdop)
 			}
 		}

--- a/backend/resources/postgres/postgres.go
+++ b/backend/resources/postgres/postgres.go
@@ -33,7 +33,7 @@ func start(port int, dataDir string, serverLog bool) (err error) {
 	if !sameUser {
 		p.SysProcAttr = &syscall.SysProcAttr{
 			Setpgid:    true,
-			Credential: &syscall.Credential{Uid: uint32(uid)},
+			Credential: &syscall.Credential{Uid: uid},
 		}
 	}
 
@@ -59,7 +59,7 @@ func stop(pgDataDir string) error {
 	if !sameUser {
 		p.SysProcAttr = &syscall.SysProcAttr{
 			Setpgid:    true,
-			Credential: &syscall.Credential{Uid: uint32(uid)},
+			Credential: &syscall.Credential{Uid: uid},
 		}
 	}
 
@@ -134,7 +134,7 @@ func initDB(pgDataDir, pgUser string) error {
 	if !sameUser {
 		p.SysProcAttr = &syscall.SysProcAttr{
 			Setpgid:    true,
-			Credential: &syscall.Credential{Uid: uint32(uid)},
+			Credential: &syscall.Credential{Uid: uid},
 		}
 	}
 	// Suppress log spam
@@ -149,7 +149,7 @@ func initDB(pgDataDir, pgUser string) error {
 	return nil
 }
 
-func shouldSwitchUser() (int, int, bool, error) {
+func shouldSwitchUser() (uint32, uint32, bool, error) {
 	sameUser := true
 	bytebaseUser, err := user.Current()
 	if err != nil {
@@ -173,5 +173,5 @@ func shouldSwitchUser() (int, int, bool, error) {
 	if err != nil {
 		return 0, 0, false, err
 	}
-	return int(uid), int(gid), sameUser, nil
+	return uint32(uid), uint32(gid), sameUser, nil
 }


### PR DESCRIPTION
## Summary
- Fix all open "Incorrect conversion between integer types" code scanning alerts (go/incorrect-integer-conversion)
- Replace `strconv.Atoi` → `strconv.ParseInt(s, 10, 32)` for values destined for `int32` fields (mssql metadata, mysql/tidb/starrocks sync, tidb parser)
- Change `shouldSwitchUser()` return type from `(int, int, bool, error)` to `(uint32, uint32, bool, error)` to match `syscall.Credential.Uid` type directly, eliminating redundant conversions at all call sites
- Change `ConvertTiDBParserErrorPositionToPosition` signature from `(int, int)` to `(int32, int32)` to avoid narrowing conversion
- Add `safeIntToInt32` bounds-checked helper for `ConvertANTLRLineToPosition` where callers pass `int`
- Cast `ParseUint(..., 32)` result through `uint32` in elasticsearch parser

## Test plan
- [x] `go build` passes
- [x] `go test ./backend/common/... -run TestConvert` passes
- [x] Existing golangci-lint issues unchanged (no new warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)