### PR TITLE
fix: resolve incorrect integer type conversions flagged by code scanning

### DIFF
--- a/backend/plugin/parser/elasticsearch/parser.go
+++ b/backend/plugin/parser/elasticsearch/parser.go
@@ -858,7 +858,7 @@ func (p *parser) array() ([]any, error) {
 
 func (p *parser) string() (string, error) {
 	s := ""
-	uffff := 0
+	var uffff int32
 	if p.ch == '"' {
 		if p.peek(0) == '"' && p.peek(1) == '"' {
 			// literal
@@ -899,7 +899,7 @@ func (p *parser) string() (string, error) {
 						if err != nil {
 							break
 						}
-						uffff = (uffff << 4) + int(uint32(hex))
+						uffff = (uffff << 4) | int32(hex&0xF)
 					}
 					// Treat uffff as UTF-16 encoded rune.
 					s += string(rune(uffff))

--- a/backend/resources/postgres/postgres.go
+++ b/backend/resources/postgres/postgres.go
@@ -4,6 +4,7 @@ package postgres
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"os/exec"
 	"os/user"
@@ -113,6 +114,9 @@ func initDB(pgDataDir, pgUser string) error {
 		return err
 	}
 	if !sameUser {
+		if uid > math.MaxInt32 || gid > math.MaxInt32 {
+			return errors.Errorf("uid %d or gid %d exceeds maximum safe value", uid, gid)
+		}
 		slog.Info(fmt.Sprintf("Recursively change owner of data directory %q to bytebase...", pgDataDir))
 		for _, dir := range dirListToChown {
 			slog.Info(fmt.Sprintf("Change owner of %q to bytebase", dir))


### PR DESCRIPTION
## Summary
- Fix all 3 open CodeQL alerts for `go/incorrect-integer-conversion`
- Replace unsafe `int()` casts from `strconv.ParseUint` / `strconv.Atoi` results with properly bounded conversions:
  - **mysql/starrocks/tidb sync.go**: Use `strconv.ParseInt` with bitSize 32 for `lower_case_table_names`
  - **mssql get_database_metadata.go**: Use `strconv.ParseInt` with bitSize 32 for spatial index options
  - **tidb parser**: Use `strconv.ParseInt` with bitSize 32 for error position line/column
  - **common/position.go**: Add `safeIntToInt32` helper with bounds clamping; change `ConvertTiDBParserErrorPositionToPosition` to accept `int32`
  - **elasticsearch/parser.go**: Change `uffff` to `int32` and use bitmask `int32(hex&0xF)` to bound values
  - **postgres.go**: Return `uint32` from `shouldSwitchUser()` for direct use in `syscall.Credential`; add `math.MaxInt32` bounds check before `int()` cast at `os.Chown`

## Test plan
- [x] Full project build passes (`go build`)
- [x] `golangci-lint` shows no new issues (pre-existing issues only)
- [x] `go vet` passes on all changed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)