### PR TITLE
fix: add explicit permissions to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/backend-tests-default.yml
+++ b/.github/workflows/backend-tests-default.yml
@@ -11,6 +11,8 @@ on:
       - 'proto/**/*.go'
       - 'action/**'
 
+permissions: {}
+
 jobs:
   go-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -11,6 +11,9 @@ on:
       - 'proto/**/*.go'
       - 'action/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build-push-action-image.yml
+++ b/.github/workflows/build-push-action-image.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'release/*.*.*'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build-push-demo-image.yml
+++ b/.github/workflows/build-push-demo-image.yml
@@ -3,6 +3,9 @@ name: Build and Push Demo Image to GAR
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   GAR_LOCATION: us-central1
   GAR_REPOSITORY: bytebase

--- a/.github/workflows/demo-daily-deploy.yml
+++ b/.github/workflows/demo-daily-deploy.yml
@@ -4,6 +4,8 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   deploy:
     if: github.repository == 'bytebase/bytebase'

--- a/.github/workflows/docker-tag-latest.yml
+++ b/.github/workflows/docker-tag-latest.yml
@@ -14,6 +14,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
   draft-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-tests-default.yml
+++ b/.github/workflows/frontend-tests-default.yml
@@ -9,6 +9,8 @@ on:
     paths-ignore:
       - 'frontend/**'
 
+permissions: {}
+
 jobs:
   static-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'frontend/**'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/golangci-lint-default.yml
+++ b/.github/workflows/golangci-lint-default.yml
@@ -12,6 +12,8 @@ on:
       - 'go.mod'
       - 'proto/**/*.go'
 
+permissions: {}
+
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,6 +12,9 @@ on:
       - 'proto/**/*.go'
       - '.golangci.yaml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/proto-linter-default.yml
+++ b/.github/workflows/proto-linter-default.yml
@@ -7,6 +7,8 @@ on:
     paths-ignore:
       - 'proto/**'
 
+permissions: {}
+
 jobs:
   lint-protos:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_link.yml
+++ b/.github/workflows/test_link.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'frontend/**'
 
+permissions:
+  contents: read
+
 jobs:
   link-tests:
     runs-on: self-hosted

--- a/.github/workflows/test_link_default.yml
+++ b/.github/workflows/test_link_default.yml
@@ -8,6 +8,8 @@ on:
     paths-ignore:
       - 'frontend/**'
 
+permissions: {}
+
 jobs:
   go-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to all 14 GitHub Actions workflow files to resolve CodeQL alerts #213-#229 (`actions/missing-workflow-permissions`)
- Workflows that only echo or have no repo interaction use `permissions: {}` (no permissions)
- Workflows that checkout code use `permissions: contents: read`
- `draft-release.yml` uses `permissions: contents: write` (needed for creating GitHub releases)

## Test plan
- [ ] Verify CI workflows still pass on this PR
- [ ] Confirm CodeQL alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)