### PR TITLE
fix: respect verify_tls_certificate in elasticsearch TLS fallback

### DIFF
--- a/backend/plugin/db/elasticsearch/elasticsearch.go
+++ b/backend/plugin/db/elasticsearch/elasticsearch.go
@@ -144,11 +144,14 @@ func openWithBasicAuth(_ context.Context, config db.ConnectionConfig, address st
 		return nil, errors.Wrap(err, "failed to get TLS config")
 	}
 
-	// Default to insecure if no SSL is configured
+	// Build TLS config if no SSL is configured
 	if tlsConfig == nil {
 		tlsConfig = &tls.Config{
 			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: true, //nolint:gosec // We use custom verification when verify_tls_certificate is set
+		}
+		if config.DataSource.GetVerifyTlsCertificate() {
+			tlsConfig.VerifyPeerCertificate = util.CreateCertificateVerifier(nil, config.DataSource.Host)
 		}
 	} else {
 		// Ensure minimum TLS version
@@ -212,11 +215,14 @@ func openWithOpenSearchClient(ctx context.Context, config db.ConnectionConfig, a
 		return nil, errors.Wrap(err, "failed to get TLS config")
 	}
 
-	// Default to insecure if no SSL is configured
+	// Build TLS config if no SSL is configured
 	if tlsConfig == nil {
 		tlsConfig = &tls.Config{
 			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: true,
+			InsecureSkipVerify: true, //nolint:gosec // We use custom verification when verify_tls_certificate is set
+		}
+		if config.DataSource.GetVerifyTlsCertificate() {
+			tlsConfig.VerifyPeerCertificate = util.CreateCertificateVerifier(nil, config.DataSource.Host)
 		}
 	} else {
 		// Ensure minimum TLS version


### PR DESCRIPTION
## Summary
- When no SSL is explicitly configured, the elasticsearch driver was using `InsecureSkipVerify: true` without respecting the `verify_tls_certificate` setting (CodeQL alerts #249, #250)
- Follow the same pattern as `mysql.go` and `ssl.go`: use custom `VerifyPeerCertificate` with system CA pool when verification is enabled
- Also dismissed 6 stale CodeQL alerts (#127, #165, #182, #183, #197, #210) from an old analysis category that referenced changed code

## Test plan
- [ ] Verify elasticsearch/OpenSearch connections work with SSL disabled
- [ ] Verify connections work with `verify_tls_certificate` enabled against valid certs
- [ ] Verify connections work with `verify_tls_certificate` disabled against self-signed certs
- [ ] Confirm CodeQL alerts #249 and #250 close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)