### PR TITLE
fix: suppress SonarCloud false positive SQL injection warnings

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -4,6 +4,7 @@ sonar.sources=.
 # Exclude generated code, build artifacts, and dependencies from analysis
 sonar.exclusions=\
   backend/generated-go,\
+  backend/migrator/migration,\
   proto/gen,\
   bytebase-build,\
   frontend/node_modules

--- a/backend/store/group.go
+++ b/backend/store/group.go
@@ -130,7 +130,7 @@ func (s *Store) ListGroups(ctx context.Context, find *FindGroupMessage) ([]*Grou
 	}
 
 	var groups []*GroupMessage
-	rows, err := s.GetDB().QueryContext(ctx, query, args...)
+	rows, err := s.GetDB().QueryContext(ctx, query, args...) // NOSONAR: query is parameterized via qb.Query
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (s *Store) CreateGroup(ctx context.Context, create *GroupMessage) (*GroupMe
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&create.ID); err != nil {
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&create.ID); err != nil { // NOSONAR: query is parameterized via qb.Query
 		return nil, err
 	}
 
@@ -252,7 +252,7 @@ func (s *Store) UpdateGroup(ctx context.Context, patch *UpdateGroupMessage) (*Gr
 	var payload []byte
 	var email sql.NullString
 
-	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan( // NOSONAR: query is parameterized via qb.Query
 		&group.ID,
 		&email,
 		&group.Title,

--- a/backend/store/oauth2_authorization_code.go
+++ b/backend/store/oauth2_authorization_code.go
@@ -37,7 +37,7 @@ func (s *Store) CreateOAuth2AuthorizationCode(ctx context.Context, create *OAuth
 		return nil, err
 	}
 
-	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil { // NOSONAR: query is parameterized via qb.Query
 		return nil, errors.Wrap(err, "failed to create OAuth2 authorization code")
 	}
 	return create, nil
@@ -57,7 +57,7 @@ func (s *Store) GetOAuth2AuthorizationCode(ctx context.Context, code string) (*O
 
 	msg := &OAuth2AuthorizationCodeMessage{}
 	var configBytes []byte
-	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(
+	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan( // NOSONAR: query is parameterized via qb.Query
 		&msg.Code, &msg.ClientID, &msg.UserEmail, &configBytes, &msg.ExpiresAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -84,7 +84,7 @@ func (s *Store) DeleteOAuth2AuthorizationCode(ctx context.Context, code string) 
 		return err
 	}
 
-	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil { // NOSONAR: query is parameterized via qb.Query
 		return errors.Wrap(err, "failed to delete OAuth2 authorization code")
 	}
 	return nil

--- a/backend/store/oauth2_client.go
+++ b/backend/store/oauth2_client.go
@@ -73,7 +73,7 @@ func (s *Store) ListOAuth2Clients(ctx context.Context, find *FindOAuth2ClientMes
 		return nil, err
 	}
 
-	rows, err := s.GetDB().QueryContext(ctx, query, args...)
+	rows, err := s.GetDB().QueryContext(ctx, query, args...) // NOSONAR: query is parameterized via qb.Query
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query OAuth2 clients")
 	}
@@ -110,7 +110,7 @@ func (s *Store) UpdateOAuth2ClientLastActiveAt(ctx context.Context, clientID str
 		return err
 	}
 
-	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
+	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil { // NOSONAR: query is parameterized via qb.Query
 		return errors.Wrap(err, "failed to update OAuth2 client last active at")
 	}
 	return nil

--- a/backend/store/principal.go
+++ b/backend/store/principal.go
@@ -407,7 +407,7 @@ func listUserImpl(ctx context.Context, txn *sql.Tx, find *FindUserMessage) ([]*U
 	}
 
 	var userMessages []*UserMessage
-	rows, err := txn.QueryContext(ctx, sql, args...)
+	rows, err := txn.QueryContext(ctx, sql, args...) // NOSONAR: query is parameterized via qb.Query
 	if err != nil {
 		return nil, err
 	}
@@ -463,7 +463,7 @@ func scanPrincipalRow(ctx context.Context, tx *sql.Tx, sqlStr string, args []any
 	var mfaConfigBytes []byte
 	var profileBytes []byte
 	var typeString string
-	if err := tx.QueryRowContext(ctx, sqlStr, args...).Scan(
+	if err := tx.QueryRowContext(ctx, sqlStr, args...).Scan( // NOSONAR: query is parameterized via qb.Query
 		&user.ID,
 		&user.MemberDeleted,
 		&user.Email,
@@ -540,7 +540,7 @@ func (s *Store) CreateUser(ctx context.Context, create *UserMessage) (*UserMessa
 	}
 
 	var userID int
-	if err := tx.QueryRowContext(ctx, sql, args...).Scan(&userID, &create.CreatedAt); err != nil {
+	if err := tx.QueryRowContext(ctx, sql, args...).Scan(&userID, &create.CreatedAt); err != nil { // NOSONAR: query is parameterized via qb.Query
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- Add `// NOSONAR` comments to 11 parameterized query execution lines across 4 store files (`principal.go`, `oauth2_client.go`, `oauth2_authorization_code.go`, `group.go`) that are incorrectly flagged as SQL injection vulnerabilities. All queries use `qb.Query` which properly separates user values into `$1/$2/...` placeholders.
- Exclude `backend/migrator/migration` from SonarCloud analysis — these are schema migration SQL files, not application source code, and account for 56 of the 63 current blocker issues.

## Test plan
- [ ] Verify `golangci-lint run --allow-parallel-runners` passes with no new issues
- [ ] Confirm SonarCloud blocker count drops after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)