### PR TITLE
fix: add max-width to NTooltip components to prevent text overflow

### DIFF
--- a/frontend/src/components/InstanceForm/DataSourceSection/SslCertificateFormV1.vue
+++ b/frontend/src/components/InstanceForm/DataSourceSection/SslCertificateFormV1.vue
@@ -9,7 +9,7 @@
       <label class="textlabel block">
         {{ verifyLabel }}
       </label>
-      <NTooltip v-if="showTooltip">
+      <NTooltip v-if="showTooltip" style="max-width: 20rem">
         <template #trigger>
           <Info class="w-4 h-4 text-yellow-600" />
         </template>

--- a/frontend/src/components/Member/MembersBindingSelect.vue
+++ b/frontend/src/components/Member/MembersBindingSelect.vue
@@ -16,7 +16,7 @@
       <div class="flex text-main items-center gap-x-1">
         {{ $t("settings.members.select-account", 2 /* multiply*/) }}
         <RequiredStar v-if="required" />
-        <NTooltip>
+        <NTooltip style="max-width: 20rem">
           <template #trigger>
             <CircleHelpIcon class="w-4 textinfolabel" />
           </template>

--- a/frontend/src/components/Plan/components/ChecksView/ChecksView.vue
+++ b/frontend/src/components/Plan/components/ChecksView/ChecksView.vue
@@ -79,7 +79,10 @@
                 <span class="text-sm font-medium">
                   {{ getCheckTypeLabel(group.type) }}
                 </span>
-                <NTooltip v-if="getCheckTypeDescription(group.type)">
+                <NTooltip
+                  v-if="getCheckTypeDescription(group.type)"
+                  style="max-width: 20rem"
+                >
                   <template #trigger>
                     <CircleQuestionMarkIcon
                       class="w-4 h-4 text-control-light"

--- a/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
+++ b/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
@@ -4,7 +4,7 @@
     <div class="flex items-center justify-between gap-2">
       <div class="flex flex-row items-center gap-2">
         <h3 class="text-base">{{ $t("plan.checks.self") }}</h3>
-        <NTooltip v-if="isStatementOversized">
+        <NTooltip v-if="isStatementOversized" style="max-width: 20rem">
           <template #trigger>
             <NTag type="warning" round size="tiny">
               <template #icon>
@@ -38,7 +38,10 @@
         @click="openChecksDrawer($event)"
       />
 
-      <NTooltip v-if="checksOfSelectedSpec.length > 0 && affectedRows > 0">
+      <NTooltip
+        v-if="checksOfSelectedSpec.length > 0 && affectedRows > 0"
+        style="max-width: 20rem"
+      >
         <template #trigger>
           <NTag round :bordered="false">
             <div class="flex items-center gap-1">

--- a/frontend/src/components/Plan/components/SQLCheckSection/SQLCheckSection.vue
+++ b/frontend/src/components/Plan/components/SQLCheckSection/SQLCheckSection.vue
@@ -12,7 +12,10 @@
       </span>
       <div v-else class="flex flex-row justify-start items-center gap-2">
         <SQLCheckBadge :advices="checkResult.advices" />
-        <NTooltip v-if="checkResult.affectedRows > 0">
+        <NTooltip
+          v-if="checkResult.affectedRows > 0"
+          style="max-width: 20rem"
+        >
           <template #trigger>
             <NTag round>
               <span class="opacity-80"

--- a/frontend/src/components/Plan/components/SQLCheckV1Section/SQLCheckV1Section.vue
+++ b/frontend/src/components/Plan/components/SQLCheckV1Section/SQLCheckV1Section.vue
@@ -50,7 +50,10 @@
         <span class="text-success">{{ $t("common.success") }}</span>
       </span>
 
-      <NTooltip v-if="checkResults && affectedRows > 0">
+      <NTooltip
+        v-if="checkResults && affectedRows > 0"
+        style="max-width: 20rem"
+      >
         <template #trigger>
           <NTag round :bordered="false">
             <div class="flex items-center gap-1">


### PR DESCRIPTION
## Summary
- Add `style="max-width: 20rem"` to NTooltip components that display long translated text, preventing tooltip content from overflowing off-screen
- Affected components: `SslCertificateFormV1`, `MembersBindingSelect`, `ChecksView`, `PlanCheckSection`, `SQLCheckSection`, `SQLCheckV1Section`

## Test plan
- [ ] Verify "Verify TLS certificate" tooltip wraps on instance edit page
- [ ] Verify member select account hint tooltip wraps
- [ ] Verify plan check section tooltips wrap (affected rows, statement too large)
- [ ] Verify checks view SQL review description tooltip wraps

🤖 Generated with [Claude Code](https://claude.com/claude-code)