### PR TITLE
fix: delete project resources

### DIFF
--- a/backend/store/project.go
+++ b/backend/store/project.go
@@ -489,14 +489,54 @@ func (s *Store) DeleteProject(ctx context.Context, resourceID string) error {
 		return errors.Wrapf(err, "failed to delete project_webhook for project %s", resourceID)
 	}
 
-	// Unlink principals (service accounts) from this project
-	q = qb.Q().Space("UPDATE principal SET project = NULL WHERE project = ?", resourceID)
+	// Delete resources referencing project principals (service accounts) before deleting principals.
+	// Note: oauth2_authorization_code, oauth2_refresh_token, and web_refresh_token are skipped
+	// because project-scoped principals can only be SERVICE_ACCOUNT or WORKLOAD_IDENTITY
+	// (enforced by principal_project_type_check constraint), and only END_USER can create
+	// OAuth2/web session tokens.
+
+	// Delete worksheet_organizer entries where the principal is a project service account
+	q = qb.Q().Space("DELETE FROM worksheet_organizer")
+	q.Space("WHERE principal IN (SELECT email FROM principal WHERE project = ?)", resourceID)
 	sql, args, err = q.ToSQL()
 	if err != nil {
-		return errors.Wrap(err, "failed to build principal update query")
+		return errors.Wrap(err, "failed to build worksheet_organizer delete query")
 	}
 	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
-		return errors.Wrapf(err, "failed to unlink principals from project %s", resourceID)
+		return errors.Wrapf(err, "failed to delete worksheet_organizer for project %s", resourceID)
+	}
+
+	// Delete worksheets created by project service accounts
+	// (worksheet.creator is NOT NULL, so we must delete rather than nullify)
+	q = qb.Q().Space("DELETE FROM worksheet")
+	q.Space("WHERE creator IN (SELECT email FROM principal WHERE project = ?)", resourceID)
+	sql, args, err = q.ToSQL()
+	if err != nil {
+		return errors.Wrap(err, "failed to build worksheet delete query for principals")
+	}
+	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
+		return errors.Wrapf(err, "failed to delete worksheets for project principals %s", resourceID)
+	}
+
+	// Nullify revision.deleter references to project service accounts
+	q = qb.Q().Space("UPDATE revision SET deleter = NULL")
+	q.Space("WHERE deleter IN (SELECT email FROM principal WHERE project = ?)", resourceID)
+	sql, args, err = q.ToSQL()
+	if err != nil {
+		return errors.Wrap(err, "failed to build revision update query")
+	}
+	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
+		return errors.Wrapf(err, "failed to nullify revision.deleter for project %s", resourceID)
+	}
+
+	// Delete project principals (service accounts)
+	q = qb.Q().Space("DELETE FROM principal WHERE project = ?", resourceID)
+	sql, args, err = q.ToSQL()
+	if err != nil {
+		return errors.Wrap(err, "failed to build principal delete query")
+	}
+	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
+		return errors.Wrapf(err, "failed to delete principals for project %s", resourceID)
 	}
 
 	// Finally, delete the project itself (only if it's marked as deleted)


### PR DESCRIPTION
- Missing delete the `plan_webhook_delivery`
- Wrong order for delete `plan`
- Table `sheet` has been deprecated
- Missing delete the `access_grants` 
- Delete principals and other related resources