### PR TITLE
feat(frontend): prominent approval status in issue detail sidebar

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueApprovalStatus.vue
+++ b/frontend/src/components/IssueV1/components/IssueApprovalStatus.vue
@@ -95,7 +95,7 @@ const statusTag = computed((): StatusTag | undefined => {
   }
   if (status === Issue_ApprovalStatus.REJECTED) {
     return {
-      label: t("custom-approval.approval-flow.issue-review.sent-back"),
+      label: t("common.rejected"),
       type: "warning",
       subtitle: progressText.value,
     };

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/RolloutReadyLink.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/RolloutReadyLink.vue
@@ -1,8 +1,8 @@
 <template>
   <RouterLink :to="rolloutRoute">
-    <NButton icon-placement="right" quaternary>
-      <TaskStatus :status="rolloutStatus" size="tiny" />
-      <span class="mx-1">{{ $t("common.rollout") }}</span>
+    <NButton icon-placement="right" secondary strong>
+      <TaskStatus :status="rolloutStatus" size="small" />
+      <span class="ml-2 mr-1">{{ $t("common.rollout") }}</span>
       <span>#{{ planID }}</span>
       <template #icon>
         <ArrowUpRightIcon class="opacity-60" />

--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/ApprovalFlowSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/ApprovalFlowSection.vue
@@ -1,12 +1,16 @@
 <template>
   <div>
-    <div class="w-full flex flex-row items-center gap-2">
+    <div class="w-full flex flex-row items-center gap-2 flex-wrap">
       <h3 class="textlabel">{{ $t("issue.approval-flow.self") }}</h3>
       <FeatureBadge :feature="PlanFeature.FEATURE_APPROVAL_WORKFLOW" />
       <RiskLevelIcon
         :risk-level="issue.riskLevel"
         :title="approvalTemplate?.title?.trim()"
       />
+      <div class="grow" />
+      <NTag class="truncate" v-if="statusTag" size="small" round :type="statusTag.type">
+        {{ statusTag.label }}
+      </NTag>
     </div>
 
     <div class="mt-2">
@@ -44,8 +48,10 @@
 </template>
 
 <script setup lang="ts">
-import { NTimeline } from "naive-ui";
+import type { TagProps } from "naive-ui";
+import { NTag, NTimeline } from "naive-ui";
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { BBSpin } from "@/bbkit";
 import FeatureBadge from "@/components/FeatureGuard/FeatureBadge.vue";
 import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
@@ -54,9 +60,16 @@ import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import ApprovalStepItem from "./ApprovalStepItem.vue";
 import RiskLevelIcon from "./RiskLevelIcon.vue";
 
+interface StatusTag {
+  label: string;
+  type?: TagProps["type"];
+}
+
 const props = defineProps<{
   issue: Issue;
 }>();
+
+const { t } = useI18n();
 
 const approvalTemplate = computed(() => {
   return props.issue.approvalTemplate;
@@ -64,5 +77,24 @@ const approvalTemplate = computed(() => {
 
 const approvalSteps = computed(() => {
   return approvalTemplate.value?.flow?.roles || [];
+});
+
+const statusTag = computed((): StatusTag | undefined => {
+  const status = props.issue.approvalStatus;
+  if (approvalSteps.value.length === 0) return undefined;
+
+  if (status === Issue_ApprovalStatus.APPROVED) {
+    return {
+      label: t("issue.table.approved"),
+      type: "success",
+    };
+  }
+  if (status === Issue_ApprovalStatus.REJECTED) {
+    return {
+      label: t("common.rejected"),
+      type: "warning",
+    };
+  }
+  return undefined;
 });
 </script>

--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/ApprovalStepItem.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/ApprovalStepItem.vue
@@ -45,6 +45,9 @@
           <div v-if="canReRequest && !readonly" class="mt-1">
             <NButton
               size="tiny"
+              strong
+              secondary
+              type="info"
               :loading="reRequesting"
               @click="handleReRequestReview"
             >

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2629,9 +2629,6 @@
         "delete": "Delete approval node"
       },
       "skip": "No approval required",
-      "issue-review": {
-        "sent-back": "Sent back"
-      },
       "add-rule": "Add rule",
       "edit-rule": "Edit rule",
       "fallback-rules": "Fallback Rules",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2629,9 +2629,6 @@
         "delete": "Eliminar nodo de aprobación"
       },
       "skip": "No se requiere aprobación",
-      "issue-review": {
-        "sent-back": "Devuelto"
-      },
       "add-rule": "Agregar regla",
       "edit-rule": "Editar regla",
       "fallback-rules": "Reglas de respaldo",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2629,9 +2629,6 @@
         "delete": "承認ノードの削除"
       },
       "skip": "承認不要",
-      "issue-review": {
-        "sent-back": "戻ってきた"
-      },
       "add-rule": "ルールを追加",
       "edit-rule": "ルールを編集",
       "fallback-rules": "フォールバックルール",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2629,9 +2629,6 @@
         "delete": "Xóa nút phê duyệt"
       },
       "skip": "Không cần phê duyệt",
-      "issue-review": {
-        "sent-back": "Đã gửi lại"
-      },
       "add-rule": "Thêm quy tắc",
       "edit-rule": "Chỉnh sửa quy tắc",
       "fallback-rules": "Quy tắc dự phòng",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2629,9 +2629,6 @@
         "delete": "删除审批节点"
       },
       "skip": "无需审批",
-      "issue-review": {
-        "sent-back": "被退回"
-      },
       "add-rule": "添加规则",
       "edit-rule": "编辑规则",
       "fallback-rules": "兜底规则",


### PR DESCRIPTION
## Summary
- Add color-coded status badge (Approved/Rejected) next to the "Approval flow" title in the issue detail sidebar for quick visibility
- Unify approval rejection terminology from "Sent back" to "Rejected" across all UI status badges, consistent with buttons, timeline, and step details
- Remove unused `issue-review.sent-back` locale keys from all 5 locale files
- Improve styling for rollout link button and re-request review button

## Test plan
- [ ] Verify Approved issue shows green "Approved" badge next to "Approval flow" title
- [ ] Verify Rejected issue shows warning "Rejected" badge next to "Approval flow" title
- [ ] Verify Pending issue shows no badge (only timeline steps)
- [ ] Verify issue list badges now show "Rejected" instead of "Sent back"
- [ ] Verify badge wraps properly on small screens
- [ ] Verify rollout link and re-request review button styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)