### PR TITLE
feat(frontend): add "Under review" status badge to approval flow sidebar

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/ApprovalFlowSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/ApprovalFlowSection.vue
@@ -95,6 +95,12 @@ const statusTag = computed((): StatusTag | undefined => {
       type: "warning",
     };
   }
+  if (status === Issue_ApprovalStatus.PENDING) {
+    return {
+      label: t("common.under-review"),
+      type: "info",
+    };
+  }
   return undefined;
 });
 </script>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -53,6 +53,7 @@
     "error": "Error",
     "canceled": "Canceled",
     "rejected": "Rejected",
+    "under-review": "Under review",
     "approve": "Approve",
     "done": "Done",
     "create": "Create",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -53,6 +53,7 @@
     "error": "Error",
     "canceled": "Cancelado",
     "rejected": "Rechazado",
+    "under-review": "En revisión",
     "approve": "Aprobar",
     "done": "Hecho",
     "create": "Crear",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -53,6 +53,7 @@
     "error": "間違い",
     "canceled": "キャンセル",
     "rejected": "却下",
+    "under-review": "レビュー中",
     "approve": "承認する",
     "done": "仕上げる",
     "create": "作成する",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -53,6 +53,7 @@
     "error": "Lỗi",
     "canceled": "Đã hủy",
     "rejected": "Đã từ chối",
+    "under-review": "Đang xem xét",
     "approve": "Phê duyệt",
     "done": "Hoàn tất",
     "create": "Tạo",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -53,6 +53,7 @@
     "error": "错误",
     "canceled": "已取消",
     "rejected": "已拒绝",
+    "under-review": "审核中",
     "approve": "批准",
     "done": "完成",
     "create": "创建",


### PR DESCRIPTION
## Summary
- Add "Under review" (blue/info) badge to the approval flow sidebar when approval is pending, complementing the existing Approved (green) and Rejected (orange) badges from #19438
- Add `common.under-review` i18n key across all 5 locale files (en-US, zh-CN, ja-JP, es-ES, vi-VN)

## Test plan
- [ ] Verify pending approval issue shows blue "Under review" badge next to "Approval flow" title
- [ ] Verify Approved and Rejected badges still display correctly
- [ ] Verify badge text renders correctly in all locales

<img width="700" height="562" alt="image" src="https://github.com/user-attachments/assets/c933425e-6998-431a-a45d-5449f1710d11" />
