### PR TITLE
fix(frontend): correct zh-CN translation for under-review status

### DIFF
--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2658,7 +2658,7 @@
       "risk-level-moderate": "中风险操作包括标准 DDL 变更，如添加列或索引。",
       "risk-level-high": "高风险操作包括破坏性变更，如 DROP TABLE、TRUNCATE 或大规模数据修改。",
       "integration": "与审批流集成",
-      "integration-description": "风险等级与自定义审批系统集成。您可以配置审批流，根据变更的风险等级要求不同级别的审核。"
+      "integration-description": "风险等级与自定义审批系统集成。您可以配置审批流，根据变更的风险等级要求不同级别的审批。"
     },
     "rule": {
       "first-match-wins": "规则按顺序评估，第一个匹配的规则将被应用。"


### PR DESCRIPTION
## Summary
- Fix zh-CN translation for `common.under-review`: 审核中 → 审批中
- 审核 refers to SQL review/lint, while 审批 refers to approval review

## Test plan
- [ ] Verify zh-CN locale shows "审批中" for pending approval status badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)