### PR TITLE
feat(frontend): show hint when failed checks block auto-rollout

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/Sidebar.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/Sidebar.vue
@@ -3,13 +3,21 @@
     <!-- 1. Stages - Progress indicator -->
     <StagesSection v-if="isDatabaseChangePlan" />
 
-    <!-- 2. Checks - Health status -->
+    <!-- 2. Checks rollout hint -->
+    <NAlert v-if="showChecksBlockRolloutHint" type="error">
+      {{ $t("issue.checks-block-rollout-hint") }}
+    </NAlert>
+    <NAlert v-else-if="showForceRolloutHint" type="warning">
+      {{ $t("issue.force-rollout-hint") }}
+    </NAlert>
+
+    <!-- 3. Checks - Health status -->
     <ChecksSection v-if="isDatabaseChangePlan" />
 
-    <!-- 3. Approval Flow - Reviewers -->
+    <!-- 4. Approval Flow - Reviewers -->
     <ApprovalFlowSection :issue="issue" />
 
-    <!-- 4. Labels - Metadata -->
+    <!-- 5. Labels - Metadata -->
     <IssueLabels
       :project="project"
       :value="issue.labels || []"
@@ -21,17 +29,21 @@
 
 <script setup lang="ts">
 import { create } from "@bufbuild/protobuf";
+import { NAlert } from "naive-ui";
 import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import IssueLabels from "@/components/IssueV1/components/Sidebar/IssueLabels.vue";
 import { useResourcePoller } from "@/components/Plan/logic/poller";
 import { issueServiceClientConnect } from "@/connect";
 import { pushNotification, useCurrentProjectV1 } from "@/store";
+import { State } from "@/types/proto-es/v1/common_pb";
 import {
+  Issue_ApprovalStatus,
   IssueStatus,
   UpdateIssueRequestSchema,
 } from "@/types/proto-es/v1/issue_service_pb";
 import { hasProjectPermissionV2 } from "@/utils";
+import { usePlanCheckStatus } from "../../../logic";
 import { usePlanContextWithIssue } from "../../../logic/context";
 import ApprovalFlowSection from "./ApprovalFlowSection/ApprovalFlowSection.vue";
 import ChecksSection from "./ChecksSection.vue";
@@ -39,12 +51,45 @@ import StagesSection from "./StagesSection.vue";
 
 const { t } = useI18n();
 const { plan, issue } = usePlanContextWithIssue();
+const { project } = useCurrentProjectV1();
+const { refreshResources } = useResourcePoller();
+const { hasErrors: checksHaveErrors, hasRunning: checksRunning } =
+  usePlanCheckStatus(plan);
 
 const isDatabaseChangePlan = computed(() =>
   plan.value.specs.some((spec) => spec.config?.case === "changeDatabaseConfig")
 );
-const { project } = useCurrentProjectV1();
-const { refreshResources } = useResourcePoller();
+
+const isApproved = computed(() => {
+  const status = issue.value.approvalStatus;
+  if (status === Issue_ApprovalStatus.CHECKING) return false;
+  const roles = issue.value.approvalTemplate?.flow?.roles ?? [];
+  return (
+    status === Issue_ApprovalStatus.APPROVED ||
+    status === Issue_ApprovalStatus.SKIPPED ||
+    roles.length === 0
+  );
+});
+
+const showChecksHint = computed(() => {
+  return (
+    issue.value.status === IssueStatus.OPEN &&
+    plan.value.state === State.ACTIVE &&
+    isDatabaseChangePlan.value &&
+    isApproved.value &&
+    checksHaveErrors.value &&
+    !checksRunning.value &&
+    !plan.value.hasRollout
+  );
+});
+
+const showChecksBlockRolloutHint = computed(() => {
+  return showChecksHint.value && project.value.requirePlanCheckNoError;
+});
+
+const showForceRolloutHint = computed(() => {
+  return showChecksHint.value && !project.value.requirePlanCheckNoError;
+});
 
 const allowChange = computed(() => {
   if (issue.value.status !== IssueStatus.OPEN) {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1072,6 +1072,8 @@
     "approval-flow": {
       "self": "Approval flow"
     },
+    "force-rollout-hint": "Proceed with manual rollout to override failed checks.",
+    "checks-block-rollout-hint": "Failed checks are preventing rollout creation. Fix the errors to proceed.",
     "risk-level": {
       "self": "Risk level",
       "low": "Low",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1072,6 +1072,8 @@
     "approval-flow": {
       "self": "Flujo de aprobación"
     },
+    "force-rollout-hint": "Proceda con el despliegue manual para anular las verificaciones fallidas.",
+    "checks-block-rollout-hint": "Las verificaciones fallidas impiden la creación del despliegue. Corrija los errores para continuar.",
     "risk-level": {
       "self": "Nivel de riesgo",
       "low": "Bajo",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1072,6 +1072,8 @@
     "approval-flow": {
       "self": "承認の流れ"
     },
+    "force-rollout-hint": "手動でロールアウトを作成して、失敗したチェックをオーバーライドしてください。",
+    "checks-block-rollout-hint": "チェックの失敗によりロールアウトを作成できません。エラーを修正してから続行してください。",
     "risk-level": {
       "self": "リスクレベル",
       "low": "低い",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1072,6 +1072,8 @@
     "approval-flow": {
       "self": "Quy trình phê duyệt"
     },
+    "force-rollout-hint": "Tiến hành triển khai thủ công để bỏ qua các kiểm tra thất bại.",
+    "checks-block-rollout-hint": "Kiểm tra thất bại đang ngăn việc tạo triển khai. Hãy sửa lỗi để tiếp tục.",
     "risk-level": {
       "self": "Mức độ rủi ro",
       "low": "Thấp",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1072,6 +1072,8 @@
     "approval-flow": {
       "self": "审批流"
     },
+    "force-rollout-hint": "手动创建发布以跳过失败的 SQL 检查。",
+    "checks-block-rollout-hint": "SQL 检查失败导致无法创建发布。请修复错误后再继续。",
     "risk-level": {
       "self": "风险等级",
       "low": "低风险",


### PR DESCRIPTION
## Summary
- When an approved issue has failing checks, auto-rollout creation is silently blocked. This adds NAlert warnings in the issue sidebar (above Checks section) to explain why:
  - **Error alert** (`requirePlanCheckNoError` enabled): "Failed checks are preventing rollout creation. Fix the errors to proceed."
  - **Warning alert** (bypassable): "Proceed with manual rollout to override failed checks."
- Guards: only shown on OPEN issues with ACTIVE plans, when approved, checks have errors, checks aren't still running, and no rollout exists yet.

## Test plan
- [ ] Create issue with failing SQL checks → approve → verify warning alert appears above Checks section
- [ ] Enable `requirePlanCheckNoError` on project → verify error alert appears instead
- [ ] After creating rollout manually → verify hint disappears
- [ ] On canceled/done issues → verify hint does not appear
- [ ] While checks are still running → verify hint does not appear

<img width="800" height="436" alt="image" src="https://github.com/user-attachments/assets/85e3b071-c73c-4897-a78c-cdc781e439c5" />
