### PR TITLE
fix(frontend): move GitOps to last position in CI/CD sidebar

### DIFF
--- a/frontend/src/components/Project/useProjectSidebar.ts
+++ b/frontend/src/components/Project/useProjectSidebar.ts
@@ -56,11 +56,6 @@ export const useProjectSidebar = (project: MaybeRef<Project>) => {
         hide: isDefaultProject.value,
         children: [
           {
-            title: t("gitops.self"),
-            path: PROJECT_V1_ROUTE_GITOPS,
-            type: "div",
-          },
-          {
             title: t("plan.plans"),
             path: PROJECT_V1_ROUTE_PLANS,
             type: "div",
@@ -73,6 +68,11 @@ export const useProjectSidebar = (project: MaybeRef<Project>) => {
           {
             title: t("release.releases"),
             path: PROJECT_V1_ROUTE_RELEASES,
+            type: "div",
+          },
+          {
+            title: t("gitops.self"),
+            path: PROJECT_V1_ROUTE_GITOPS,
             type: "div",
           },
         ],


### PR DESCRIPTION
## Summary
- Move GitOps from the first to the last position in the CI/CD sidebar section, placing it after Releases

Fixes BYT-8957

## Test plan
- [ ] Verify the CI/CD sidebar shows items in order: Plans, Rollouts, Releases, GitOps

🤖 Generated with [Claude Code](https://claude.com/claude-code)