### PR TITLE
fix(frontend): correct status filter description in issue advanced search

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
+++ b/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
@@ -113,7 +113,7 @@ export const useIssueSearchScopeOptions = (
         id: "status",
         allowMultiple: true,
         title: t("common.status"),
-        description: t("issue.advanced-search.scope.approval.description"),
+        description: t("issue.advanced-search.scope.status.description"),
         options: [
           {
             value: IssueStatus[IssueStatus.OPEN],

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1010,6 +1010,9 @@
           "title": "Current approver",
           "description": "Search by the issue current approver"
         },
+        "status": {
+          "description": "Search by the issue status"
+        },
         "approval": {
           "value": {
             "pending": "Pending approval",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1010,6 +1010,9 @@
           "title": "aprobador actual",
           "description": "Buscar por el aprobador actual del problema"
         },
+        "status": {
+          "description": "Buscar por el estado del issue"
+        },
         "approval": {
           "value": {
             "pending": "Aprobación pendiente",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1010,6 +1010,9 @@
           "title": "現在の承認者",
           "description": "イシューの現在の承認者による検索"
         },
+        "status": {
+          "description": "イシューのステータスで検索"
+        },
         "approval": {
           "value": {
             "pending": "保留中",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1010,6 +1010,9 @@
           "title": "Người phê duyệt hiện tại",
           "description": "Tìm kiếm theo người phê duyệt hiện tại"
         },
+        "status": {
+          "description": "Tìm kiếm theo trạng thái issue"
+        },
         "approval": {
           "value": {
             "pending": "Đang chờ phê duyệt",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1010,6 +1010,9 @@
           "title": "当前审批人",
           "description": "按工单的当前审批人搜索"
         },
+        "status": {
+          "description": "按工单状态搜索"
+        },
         "approval": {
           "value": {
             "pending": "待审批",


### PR DESCRIPTION
## Summary
- The status scope in the issue advanced search was incorrectly using the approval description ("Search by the issue approval status") instead of its own description
- Added a dedicated `status.description` locale key with the correct text "Search by the issue status" across all 5 locale files (en-US, zh-CN, ja-JP, es-ES, vi-VN)

## Test plan
- [ ] Open an issue list page (e.g., My Issues or Project Issues)
- [ ] Click on the search bar to open the filter dropdown
- [ ] Verify the "status" scope shows "Search by the issue status" as its description

🤖 Generated with [Claude Code](https://claude.com/claude-code)