### PR TITLE
feat(frontend): support all approval status options in issue search

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
+++ b/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
@@ -138,6 +138,14 @@ export const useIssueSearchScopeOptions = (
         description: t("issue.advanced-search.scope.approval.description"),
         options: [
           {
+            value: Issue_ApprovalStatus[Issue_ApprovalStatus.CHECKING],
+            keywords: ["checking"],
+            render: () =>
+              renderSpan(
+                t("issue.advanced-search.scope.approval.value.checking")
+              ),
+          },
+          {
             value: Issue_ApprovalStatus[Issue_ApprovalStatus.PENDING],
             keywords: ["pending"],
             render: () =>
@@ -151,6 +159,22 @@ export const useIssueSearchScopeOptions = (
             render: () =>
               renderSpan(
                 t("issue.advanced-search.scope.approval.value.approved")
+              ),
+          },
+          {
+            value: Issue_ApprovalStatus[Issue_ApprovalStatus.REJECTED],
+            keywords: ["rejected"],
+            render: () =>
+              renderSpan(
+                t("issue.advanced-search.scope.approval.value.rejected")
+              ),
+          },
+          {
+            value: Issue_ApprovalStatus[Issue_ApprovalStatus.SKIPPED],
+            keywords: ["skipped"],
+            render: () =>
+              renderSpan(
+                t("issue.advanced-search.scope.approval.value.skipped")
               ),
           },
         ],

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1015,8 +1015,11 @@
         },
         "approval": {
           "value": {
+            "checking": "Checking",
             "pending": "Pending approval",
-            "approved": "Approved"
+            "approved": "Approved",
+            "rejected": "Rejected",
+            "skipped": "Skipped"
           },
           "description": "Search by the issue approval status",
           "title": "Approval Status"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1015,8 +1015,11 @@
         },
         "approval": {
           "value": {
+            "checking": "Verificando",
             "pending": "Aprobación pendiente",
-            "approved": "Aprobado"
+            "approved": "Aprobado",
+            "rejected": "Rechazado",
+            "skipped": "Omitido"
           },
           "description": "Buscar por estado de revisión del problema",
           "title": "Estado de aprobación"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1015,8 +1015,11 @@
         },
         "approval": {
           "value": {
+            "checking": "確認中",
             "pending": "保留中",
-            "approved": "承認された"
+            "approved": "承認された",
+            "rejected": "却下",
+            "skipped": "スキップ"
           },
           "description": "イシューの承認ステータスで検索する",
           "title": "承認状況"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1015,8 +1015,11 @@
         },
         "approval": {
           "value": {
+            "checking": "Đang kiểm tra",
             "pending": "Đang chờ phê duyệt",
-            "approved": "Đã phê duyệt"
+            "approved": "Đã phê duyệt",
+            "rejected": "Đã từ chối",
+            "skipped": "Đã bỏ qua"
           },
           "description": "Tìm kiếm theo trạng thái phê duyệt của vấn đề",
           "title": "Trạng thái phê duyệt"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1015,8 +1015,11 @@
         },
         "approval": {
           "value": {
+            "checking": "检查中",
             "pending": "待审批",
-            "approved": "审批通过"
+            "approved": "审批通过",
+            "rejected": "已拒绝",
+            "skipped": "已跳过"
           },
           "description": "按工单的审批状态搜索",
           "title": "审批状态"


### PR DESCRIPTION
## Summary
- Add CHECKING, REJECTED, and SKIPPED options to the approval status filter in issue advanced search
- Previously only PENDING and APPROVED were exposed, despite the backend supporting all 5 `Issue.ApprovalStatus` enum values
- Added locale keys for all 5 languages (en-US, zh-CN, ja-JP, es-ES, vi-VN)

Resolves BYT-8961

## Test plan
- [ ] Open an issue list page and click the search bar
- [ ] Select the "Approval Status" filter
- [ ] Verify all 5 options appear: Checking, Pending approval, Approved, Rejected, Skipped
- [ ] Select each option and confirm the filter applies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)