### PR TITLE
fix(ci): upgrade golangci-lint to v2.10.1 for Go 1.26 support

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,6 +32,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.5.0
+          version: v2.10.1
           args: --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners
           skip-cache: true


### PR DESCRIPTION
## Summary

- Upgrade golangci-lint from v2.5.0 to v2.10.1 in CI workflow
- v2.5.0 was built with Go 1.25 and panics when analyzing code requiring Go 1.26
- Go 1.26 support was added in golangci-lint v2.9.0

## Test plan

- [ ] CI golangci-lint job passes without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)