### PR TITLE
fix(ci): prevent Go/golangci-lint version mismatch

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -29,9 +29,25 @@ jobs:
         with:
           go-version: '1.26.0'
           cache: false # Caching is slow.
-      - name: golangci-lint
+      - name: Install golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
+          # renovate: datasource=github-releases depName=golangci/golangci-lint
           version: v2.10.1
-          args: --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners
+          install-only: true
           skip-cache: true
+      - name: Verify Go version compatibility
+        run: |
+          GO_MAJOR_MINOR=$(go env GOVERSION | sed 's/go//' | cut -d. -f1-2)
+          LINT_GO=$(golangci-lint version --json 2>/dev/null | jq -r '.go // empty' || true)
+          if [ -z "$LINT_GO" ]; then
+            echo "Skipping compatibility check: unable to read golangci-lint Go version"
+            exit 0
+          fi
+          LINT_MAJOR_MINOR=$(echo "$LINT_GO" | sed 's/go//' | cut -d. -f1-2)
+          if [ "$GO_MAJOR_MINOR" != "$LINT_MAJOR_MINOR" ]; then
+            echo "::error::Go version mismatch: setup-go provides go${GO_MAJOR_MINOR} but golangci-lint was built with go${LINT_MAJOR_MINOR}. Update golangci-lint to a version built with go${GO_MAJOR_MINOR}."
+            exit 1
+          fi
+      - name: golangci-lint
+        run: golangci-lint run --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,11 @@
     {
       "groupName": "google.golang.org/genproto",
       "matchPackagePatterns": ["^google.golang.org/genproto"]
+    },
+    {
+      "groupName": "go-toolchain",
+      "description": "Group Go version and golangci-lint to avoid version mismatch",
+      "matchPackageNames": ["go", "golangci/golangci-lint"]
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
## Summary

- Add a **compatibility guard** step in the golangci-lint workflow that checks Go and golangci-lint major.minor versions match before running lint. Fails fast with a clear `::error::` instead of a cryptic panic.
- Add a **Renovate tracking comment** (`# renovate: datasource=github-releases depName=golangci/golangci-lint`) so Renovate can detect and auto-bump the `version:` input
- Add a **Renovate grouping rule** (`go-toolchain`) that groups `go` and `golangci/golangci-lint` updates into a single PR

This prevents the issue from #19474 where Go was bumped to 1.26.0 by Renovate but golangci-lint stayed at v2.5.0 (built with Go 1.25), causing a panic in CI.

## Test plan

- [ ] CI golangci-lint job passes (install → verify → run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)