### PR TITLE
fix(oracle): sanitize UTF-8 in all comment fields during schema sync

### DIFF
--- a/backend/plugin/db/oracle/sync.go
+++ b/backend/plugin/db/oracle/sync.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/db/util"
@@ -385,7 +386,7 @@ func getTableComments(txn *sql.Tx, schemaName string) (map[db.TableKey]string, e
 			return nil, err
 		}
 		key := db.TableKey{Schema: schemaName, Table: tableName}
-		tableCommentMap[key] = comment
+		tableCommentMap[key] = common.SanitizeUTF8String(comment)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, util.FormatErrorWithQuery(err, query)
@@ -426,7 +427,7 @@ func getTableColumnComments(txn *sql.Tx, schemaName string) (map[db.ColumnKey]st
 			return nil, err
 		}
 		key := db.ColumnKey{Schema: schemaName, Table: tableName, Column: columnName}
-		columnCommentsMap[key] = comment
+		columnCommentsMap[key] = common.SanitizeUTF8String(comment)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, util.FormatErrorWithQuery(err, query)
@@ -1370,7 +1371,7 @@ func getViewComments(txn *sql.Tx, schemaName string) (map[db.TableKey]string, er
 			return nil, err
 		}
 		key := db.TableKey{Schema: schemaName, Table: viewName}
-		viewCommentMap[key] = comment
+		viewCommentMap[key] = common.SanitizeUTF8String(comment)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, util.FormatErrorWithQuery(err, query)
@@ -1420,7 +1421,7 @@ func getSequenceComments(txn *sql.Tx, schemaName string) (map[db.TableKey]string
 			return nil, err
 		}
 		key := db.TableKey{Schema: schemaName, Table: sequenceName}
-		sequenceCommentMap[key] = comment
+		sequenceCommentMap[key] = common.SanitizeUTF8String(comment)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, util.FormatErrorWithQuery(err, query)
@@ -1471,7 +1472,7 @@ func getFunctionComments(txn *sql.Tx, schemaName string) (map[db.TableKey]string
 			return nil, err
 		}
 		key := db.TableKey{Schema: schemaName, Table: functionName}
-		functionCommentMap[key] = comment
+		functionCommentMap[key] = common.SanitizeUTF8String(comment)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, util.FormatErrorWithQuery(err, query)
@@ -1529,7 +1530,7 @@ func getMaterializedViewComments(txn *sql.Tx, schemaName string) (map[db.TableKe
 			return nil, err
 		}
 		key := db.TableKey{Schema: schemaName, Table: mvName}
-		materializedViewCommentMap[key] = comment
+		materializedViewCommentMap[key] = common.SanitizeUTF8String(comment)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, util.FormatErrorWithQuery(err, query)
@@ -1580,7 +1581,7 @@ func getTriggerComments(txn *sql.Tx, schemaName string) (map[db.TableKey]string,
 			return nil, err
 		}
 		key := db.TableKey{Schema: schemaName, Table: triggerName}
-		triggerCommentMap[key] = comment
+		triggerCommentMap[key] = common.SanitizeUTF8String(comment)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, util.FormatErrorWithQuery(err, query)

--- a/backend/plugin/db/oracle/sync_utf8_test.go
+++ b/backend/plugin/db/oracle/sync_utf8_test.go
@@ -1,7 +1,6 @@
 package oracle
 
 import (
-	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -83,7 +82,7 @@ func TestOracleCommentSanitizedUTF8MarshalSuccess(t *testing.T) {
 
 	require.True(t, utf8.ValidString(sanitized),
 		"sanitized string must be valid UTF-8")
-	require.True(t, strings.Contains(sanitized, "\\xe1"),
+	require.Contains(t, sanitized, "\\xe1",
 		"sanitized string should preserve original bytes as hex")
 
 	metadata := &storepb.DatabaseSchemaMetadata{


### PR DESCRIPTION
## Summary

- **Bug**: Customer on Bytebase 3.15.0 reports Oracle schema sync fails with `proto: field bytebase store.ColumnMetadata.comment contains invalid UTF-8`. Root cause: Oracle databases configured as AL32UTF8 can contain invalid UTF-8 bytes when data was inserted via clients with incorrect NLS_LANG settings. go-ora's UTF-8 decode path (`BytesToString`) passes raw bytes through without validation, and `protojson.Marshal` rejects them.
- **Fix**: Apply `common.SanitizeUTF8String()` at all 7 Oracle comment ingestion points in `sync.go`. Invalid bytes are preserved as `\xHH` hex for forensic visibility (e.g., `Tr\xe1ng` instead of crash).
- **Scope**: Table, column, view, materialized view, sequence, function, and trigger comments. `getIndexComments` is a stub (returns empty map), so no change needed there.

## Root cause analysis

1. Oracle database declares AL32UTF8 charset
2. Some data was inserted by clients with wrong NLS_LANG (e.g., Windows-1258 bytes stored as-is)
3. go-ora charset 873 (AL32UTF8) decode does raw byte cast — no UTF-8 validation
4. Invalid bytes flow into protobuf `string` fields (`ColumnMetadata.comment`, etc.)
5. `protojson.Marshal()` at `db_schema.go:81` rejects with "invalid UTF-8"

Reproduced and confirmed with a standalone test using go-ora's actual `StringConverter.Decode()`.

## Test plan

- [x] `TestOracleCommentInvalidUTF8MarshalFailure` — proves the bug (invalid UTF-8 → marshal error)
- [x] `TestOracleCommentSanitizedUTF8MarshalSuccess` — proves the fix (sanitized → marshal success, hex preserved)
- [x] `go test -run TestOracleComment ./backend/plugin/db/oracle` — 2/2 PASS
- [x] `golangci-lint run ./backend/plugin/db/oracle/...` — 0 issues
- [x] Full build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)