### PR TITLE
fix: add SET ROLE permission hint to bbdataarchive setup instructions

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1226,7 +1226,7 @@
       "some-databases-not-meeting-requirements": "Some databases ({databases}) don't meet requirements",
       "some-databases-have-issues": "{count} database has issues | {count} databases have issues",
       "configuration-has-issues": "Configuration has {count} issue | Configuration has {count} issues",
-      "missing-backup-schema-postgres": "Create schema 'bbdataarchive' in database '{database}', then sync the database",
+      "missing-backup-schema-postgres": "Create schema 'bbdataarchive' in database '{database}'. If using SET ROLE, grant USAGE and CREATE on the schema to that role. Then sync the database",
       "missing-backup-database": "Create database 'bbdataarchive' on instance '{instance}', then sync the instance and database",
       "missing-backup-database-oracle": "Create database 'BBDATAARCHIVE' on instance '{instance}', then sync the instance and database"
     },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1226,7 +1226,7 @@
       "some-databases-not-meeting-requirements": "Algunas bases de datos ({databases}) no cumplen los requisitos",
       "some-databases-have-issues": "{count} la base de datos tiene problemas | {count} las bases de datos tienen problemas",
       "configuration-has-issues": "La configuración tiene {count} problemas | La configuración tiene {count} problemas",
-      "missing-backup-schema-postgres": "Cree el esquema 'bbdataarchive' en la base de datos '{database}', luego sincronice la base de datos",
+      "missing-backup-schema-postgres": "Cree el esquema 'bbdataarchive' en la base de datos '{database}'. Si usa SET ROLE, otorgue USAGE y CREATE en el esquema a ese rol. Luego sincronice la base de datos",
       "missing-backup-database": "Cree la base de datos 'bbdataarchive' en la instancia '{instance}', luego sincronice la instancia y la base de datos",
       "missing-backup-database-oracle": "Cree la base de datos 'BBDATAARCHIVE' en la instancia '{instance}', luego sincronice la instancia y la base de datos"
     },

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1226,7 +1226,7 @@
       "some-databases-not-meeting-requirements": "一部のデータベース ({databases}) は要件を満たしていません",
       "some-databases-have-issues": "{count} データベースに問題があります | {count} データベースに問題があります",
       "configuration-has-issues": "構成に {count} 個の問題があります | 構成に {count} 個の問題があります",
-      "missing-backup-schema-postgres": "データベース '{database}' にスキーマ 'bbdataarchive' を作成し、データベースを同期してください",
+      "missing-backup-schema-postgres": "データベース '{database}' にスキーマ 'bbdataarchive' を作成してください。SET ROLE を使用している場合は、そのロールにスキーマの USAGE と CREATE 権限を付与してください。その後、データベースを同期してください",
       "missing-backup-database": "インスタンス '{instance}' にデータベース 'bbdataarchive' を作成し、インスタンスとデータベースを同期してください",
       "missing-backup-database-oracle": "インスタンス '{instance}' にデータベース 'BBDATAARCHIVE' を作成し、インスタンスとデータベースを同期してください"
     },

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1226,7 +1226,7 @@
       "some-databases-not-meeting-requirements": "Một số cơ sở dữ liệu ({databases}) không đáp ứng được yêu cầu",
       "some-databases-have-issues": "{count} cơ sở dữ liệu có vấn đề | {count} cơ sở dữ liệu có vấn đề",
       "configuration-has-issues": "Cấu hình có vấn đề {count} | Cấu hình có vấn đề {count}",
-      "missing-backup-schema-postgres": "Tạo schema 'bbdataarchive' trong cơ sở dữ liệu '{database}', sau đó đồng bộ cơ sở dữ liệu",
+      "missing-backup-schema-postgres": "Tạo schema 'bbdataarchive' trong cơ sở dữ liệu '{database}'. Nếu sử dụng SET ROLE, hãy cấp quyền USAGE và CREATE trên schema cho role đó. Sau đó đồng bộ cơ sở dữ liệu",
       "missing-backup-database": "Tạo cơ sở dữ liệu 'bbdataarchive' trên instance '{instance}', sau đó đồng bộ instance và cơ sở dữ liệu",
       "missing-backup-database-oracle": "Tạo cơ sở dữ liệu 'BBDATAARCHIVE' trên instance '{instance}', sau đó đồng bộ instance và cơ sở dữ liệu"
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1226,7 +1226,7 @@
       "some-databases-not-meeting-requirements": "部分数据库（{databases}）不符合要求",
       "some-databases-have-issues": "{count} 个数据库有问题 | {count} 个数据库有问题",
       "configuration-has-issues": "配置存在 {count} 个问题 | 配置存在 {count} 个问题",
-      "missing-backup-schema-postgres": "在数据库 '{database}' 中创建 schema 'bbdataarchive'，然后同步数据库",
+      "missing-backup-schema-postgres": "在数据库 '{database}' 中创建 schema 'bbdataarchive'。如果使用了 SET ROLE，请将该 schema 的 USAGE 和 CREATE 权限授予对应角色。然后同步数据库",
       "missing-backup-database": "在实例 '{instance}' 上创建数据库 'bbdataarchive'，然后同步实例和数据库",
       "missing-backup-database-oracle": "在实例 '{instance}' 上创建数据库 'BBDATAARCHIVE'，然后同步实例和数据库"
     },


### PR DESCRIPTION
## Summary
- Updated the PostgreSQL pre-backup setup message to mention granting `USAGE` and `CREATE` on the `bbdataarchive` schema when using `SET ROLE`, which otherwise causes permission denied errors
- Updated all 5 locale files (en-US, zh-CN, ja-JP, es-ES, vi-VN)

Closes BYT-8813

## Test plan
- [ ] Verify the updated message renders correctly in the pre-backup configuration UI for PostgreSQL databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)