### PR TITLE
feat(frontend): support issue type filter in advanced search

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueSearch/IssueSearch.vue
+++ b/frontend/src/components/IssueV1/components/IssueSearch/IssueSearch.vue
@@ -84,6 +84,7 @@ const allowedScopes = computed((): SearchScopeId[] => {
     "current-approver",
     "approval",
     "status",
+    "issue-type",
     "issue-label",
     "project",
     "risk-level",

--- a/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
+++ b/frontend/src/components/IssueV1/components/IssueSearch/useIssueSearchScopeOptions.ts
@@ -14,6 +14,7 @@ import { isValidProjectName } from "@/types";
 import { RiskLevel } from "@/types/proto-es/v1/common_pb";
 import {
   Issue_ApprovalStatus,
+  Issue_Type,
   IssueStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
 import { type Label } from "@/types/proto-es/v1/project_service_pb";
@@ -175,6 +176,50 @@ export const useIssueSearchScopeOptions = (
             render: () =>
               renderSpan(
                 t("issue.advanced-search.scope.approval.value.skipped")
+              ),
+          },
+        ],
+      },
+      {
+        id: "issue-type",
+        title: t("issue.advanced-search.scope.issue-type.title"),
+        description: t("issue.advanced-search.scope.issue-type.description"),
+        allowMultiple: true,
+        options: [
+          {
+            value: Issue_Type[Issue_Type.DATABASE_CHANGE],
+            keywords: ["database", "change"],
+            render: () =>
+              renderSpan(
+                t(
+                  "issue.advanced-search.scope.issue-type.value.database-change"
+                )
+              ),
+          },
+          {
+            value: Issue_Type[Issue_Type.GRANT_REQUEST],
+            keywords: ["grant", "request"],
+            render: () =>
+              renderSpan(
+                t("issue.advanced-search.scope.issue-type.value.grant-request")
+              ),
+          },
+          {
+            value: Issue_Type[Issue_Type.DATABASE_EXPORT],
+            keywords: ["database", "export"],
+            render: () =>
+              renderSpan(
+                t(
+                  "issue.advanced-search.scope.issue-type.value.database-export"
+                )
+              ),
+          },
+          {
+            value: Issue_Type[Issue_Type.ACCESS_GRANT],
+            keywords: ["access", "grant"],
+            render: () =>
+              renderSpan(
+                t("issue.advanced-search.scope.issue-type.value.access-grant")
               ),
           },
         ],

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1028,6 +1028,16 @@
           "title": "Issue label",
           "description": "Filter by issue label"
         },
+        "issue-type": {
+          "title": "Type",
+          "description": "Filter by issue type",
+          "value": {
+            "database-change": "Database Change",
+            "grant-request": "Grant Request",
+            "database-export": "Database Export",
+            "access-grant": "Access Grant"
+          }
+        },
         "table": {
           "title": "Table",
           "description": "Input the value then press Enter"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1028,6 +1028,16 @@
           "title": "Etiqueta de emisión",
           "description": "Filtrar por etiqueta de problema"
         },
+        "issue-type": {
+          "title": "Type",
+          "description": "Filter by issue type",
+          "value": {
+            "database-change": "Database Change",
+            "grant-request": "Grant Request",
+            "database-export": "Database Export",
+            "access-grant": "Access Grant"
+          }
+        },
         "table": {
           "title": "Tabla",
           "description": "Ingrese el valor y luego presione Enter"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1028,6 +1028,16 @@
           "title": "イシューラベル",
           "description": "イシューラベルでフィルタリング"
         },
+        "issue-type": {
+          "title": "Type",
+          "description": "Filter by issue type",
+          "value": {
+            "database-change": "Database Change",
+            "grant-request": "Grant Request",
+            "database-export": "Database Export",
+            "access-grant": "Access Grant"
+          }
+        },
         "table": {
           "title": "テーブル",
           "description": "値を入力してEnterを押します"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1028,6 +1028,16 @@
           "title": "Nhãn vấn đề",
           "description": "Lọc theo nhãn vấn đề"
         },
+        "issue-type": {
+          "title": "Type",
+          "description": "Filter by issue type",
+          "value": {
+            "database-change": "Database Change",
+            "grant-request": "Grant Request",
+            "database-export": "Database Export",
+            "access-grant": "Access Grant"
+          }
+        },
         "table": {
           "title": "Bảng",
           "description": "Nhập giá trị sau đó nhấn Enter"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1028,6 +1028,16 @@
           "title": "工单标签",
           "description": "按工单标签过滤"
         },
+        "issue-type": {
+          "title": "类型",
+          "description": "按工单类型过滤",
+          "value": {
+            "database-change": "数据库变更",
+            "grant-request": "权限申请",
+            "database-export": "数据导出",
+            "access-grant": "访问授权"
+          }
+        },
         "table": {
           "title": "表",
           "description": "输入值然后按 Enter"

--- a/frontend/src/store/modules/v1/issue.ts
+++ b/frontend/src/store/modules/v1/issue.ts
@@ -65,8 +65,10 @@ export const buildIssueFilter = (find: IssueFilter): string => {
       `create_time <= "${dayjs(find.createdTsBefore).utc().format()}"`
     );
   }
-  if (find.type) {
-    filter.push(`type == "${Issue_Type[find.type]}"`);
+  if (find.typeList && find.typeList.length > 0) {
+    filter.push(
+      `type in [${find.typeList.map((t) => `"${Issue_Type[t]}"`).join(",")}]`
+    );
   }
   if (find.labels && find.labels.length > 0) {
     filter.push(`labels in [${find.labels.map((l) => `"${l}"`).join(",")}]`);

--- a/frontend/src/types/v1/issue/issue.ts
+++ b/frontend/src/types/v1/issue/issue.ts
@@ -12,8 +12,8 @@ export interface IssueFilter {
   riskLevelList?: RiskLevel[];
   createdTsAfter?: number;
   createdTsBefore?: number;
-  // type is the issue type, for example: GRANT_REQUEST, DATABASE_EXPORT
-  type?: Issue_Type;
+  // typeList is the issue types to filter by, for example: GRANT_REQUEST, DATABASE_EXPORT
+  typeList?: Issue_Type[];
   // filter by labels, for example: labels = "feature & bug"
   labels?: string[];
   // order by, for example: "create_time desc", "update_time asc"

--- a/frontend/src/utils/v1/advanced-search/common.ts
+++ b/frontend/src/utils/v1/advanced-search/common.ts
@@ -21,6 +21,7 @@ export const AllSearchScopeIdList = [
   "table",
   // issue related search scopes.
   "issue-label",
+  "issue-type",
   "taskType",
   "current-approver",
   "approval",

--- a/frontend/src/utils/v1/advanced-search/issue/utils.ts
+++ b/frontend/src/utils/v1/advanced-search/issue/utils.ts
@@ -3,6 +3,7 @@ import type { IssueFilter } from "@/types";
 import { RiskLevel } from "@/types/proto-es/v1/common_pb";
 import {
   Issue_ApprovalStatus,
+  Issue_Type,
   IssueStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
 import type { SearchParams } from "../common";
@@ -45,6 +46,9 @@ export const buildIssueFilterBySearchParams = (
     ),
     riskLevelList: getValuesFromSearchParams(params, "risk-level").map(
       (risk) => RiskLevel[risk as keyof typeof RiskLevel]
+    ),
+    typeList: getValuesFromSearchParams(params, "issue-type").map(
+      (type) => Issue_Type[type as keyof typeof Issue_Type]
     ),
     labels,
   };

--- a/frontend/src/views/ExportCenter/index.vue
+++ b/frontend/src/views/ExportCenter/index.vue
@@ -168,7 +168,7 @@ const overrideSearchScopeIdList = computed(() => {
 
 const mergedIssueFilter = computed(() => {
   return buildIssueFilterBySearchParams(dataExportIssueSearchParams.value, {
-    type: Issue_Type.DATABASE_EXPORT,
+    typeList: [Issue_Type.DATABASE_EXPORT],
   });
 });
 


### PR DESCRIPTION
The backend already supports filtering issues by type via CEL expressions, but the frontend UI did not expose this capability. Add an "issue-type" multi-select filter scope to the issue advanced search, allowing users to filter by DATABASE_CHANGE, GRANT_REQUEST, DATABASE_EXPORT, and ACCESS_GRANT.