### PR TITLE
fix(schema-editor): append /schemaString suffix to GetSchemaString request name

### DIFF
--- a/frontend/src/components/SchemaEditorLite/Panels/PreviewPane.vue
+++ b/frontend/src/components/SchemaEditorLite/Panels/PreviewPane.vue
@@ -111,7 +111,7 @@ const fetchSchemaString = useDebounceFn(async () => {
   try {
     const { metadata } = mocked.value;
     const request = create(GetSchemaStringRequestSchema, {
-      name: props.db.name,
+      name: `${props.db.name}/schemaString`,
       metadata: metadata,
     });
     const response =

--- a/frontend/src/components/TableSchemaViewer.vue
+++ b/frontend/src/components/TableSchemaViewer.vue
@@ -62,7 +62,7 @@ const resourceName = computed(() => {
 onMounted(async () => {
   nextTick(async () => {
     const request = create(GetSchemaStringRequestSchema, {
-      name: props.database.name,
+      name: `${props.database.name}/schemaString`,
       type: props.type,
       schema: props.schema,
       object: props.object,


### PR DESCRIPTION
## Summary
- Fix Schema Editor failing with `[invalid_argument] failed to parse ... with suffix "/schemaString"` error
- The frontend `getSchemaString` calls were sending the database resource name without the required `/schemaString` suffix
- All similar endpoints (`getDatabaseSchema`, `getDatabaseSDLSchema`) correctly append their suffix (`/schema`, `/sdlSchema`), but `getSchemaString` was the only one missing it

Closes BYT-8968

## Test plan
- [ ] Open Schema Editor, select a table → "Preview schema text" should render without error
- [ ] Open TableSchemaViewer for any table → schema string should load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)