### PR TITLE
chore: extract workload identity selector

### DIFF
--- a/frontend/src/components/v2/Select/WorkloadIdentitySelect.vue
+++ b/frontend/src/components/v2/Select/WorkloadIdentitySelect.vue
@@ -1,0 +1,150 @@
+<template>
+  <RemoteResourceSelector
+    v-bind="$attrs"
+    :multiple="multiple"
+    :disabled="disabled"
+    :size="size"
+    :value="value"
+    :tag="!hasPermission"
+    :remote="hasPermission"
+    :additional-options="additionalOptions"
+    :render-label="renderLabel"
+    :render-tag="renderTag"
+    :search="handleSearch"
+    :filter="filter"
+    @update:value="(val) => $emit('update:value', val)"
+  />
+</template>
+
+<script lang="tsx" setup>
+import { computedAsync } from "@vueuse/core";
+import { computed } from "vue";
+import { HighlightLabelText } from "@/components/v2";
+import { UserNameCell } from "@/components/v2/Model/cells";
+import {
+  useWorkloadIdentityStore,
+  workloadIdentityNamePrefix,
+  workloadIdentityToUser,
+} from "@/store";
+import type { WorkloadIdentity } from "@/types/proto-es/v1/workload_identity_service_pb";
+import { hasWorkspacePermissionV2 } from "@/utils";
+import RemoteResourceSelector from "./RemoteResourceSelector/index.vue";
+import type {
+  ResourceSelectOption,
+  SelectSize,
+} from "./RemoteResourceSelector/types";
+import {
+  getRenderLabelFunc,
+  getRenderTagFunc,
+} from "./RemoteResourceSelector/utils";
+
+const props = defineProps<{
+  multiple?: boolean;
+  disabled?: boolean;
+  size?: SelectSize;
+  value?: string | string[] | undefined; // workloadIdentity fullname
+  parent?: string; // e.g. "projects/{project}" for project-scoped identities
+  filter?: (wi: WorkloadIdentity) => boolean;
+}>();
+
+defineEmits<{
+  // the value is workloadIdentity fullname
+  (event: "update:value", value: string[] | string | undefined): void;
+}>();
+
+const workloadIdentityStore = useWorkloadIdentityStore();
+
+const hasPermission = computed(() =>
+  hasWorkspacePermissionV2("bb.workloadIdentities.list")
+);
+
+const getOption = (
+  wi: WorkloadIdentity
+): ResourceSelectOption<WorkloadIdentity> => ({
+  resource: wi,
+  value: `${workloadIdentityNamePrefix}${wi.email}`,
+  label: wi.title,
+});
+
+const additionalOptions = computedAsync(async () => {
+  const options: ResourceSelectOption<WorkloadIdentity>[] = [];
+
+  let names: string[] = [];
+  if (Array.isArray(props.value)) {
+    names = props.value;
+  } else if (props.value) {
+    names = [props.value];
+  }
+
+  for (const name of names) {
+    const wi = await workloadIdentityStore.getOrFetchWorkloadIdentity(
+      name,
+      true
+    );
+    options.push(getOption(wi));
+  }
+
+  return options;
+}, []);
+
+const handleSearch = async (params: {
+  search: string;
+  pageToken: string;
+  pageSize: number;
+}) => {
+  const { workloadIdentities, nextPageToken } =
+    await workloadIdentityStore.listWorkloadIdentities({
+      parent: props.parent,
+      filter: { query: params.search },
+      pageToken: params.pageToken,
+      pageSize: params.pageSize,
+      showDeleted: false,
+    });
+  return {
+    nextPageToken,
+    options: workloadIdentities.map(getOption),
+  };
+};
+
+const customLabel = (wi: WorkloadIdentity, keyword: string) => {
+  const user = workloadIdentityToUser(wi);
+  return (
+    <UserNameCell
+      user={user}
+      allowEdit={false}
+      showMfaEnabled={false}
+      showSource={false}
+      showEmail={false}
+      link={false}
+      size="small"
+      keyword={keyword}
+      onClickUser={() => {}}
+    >
+      {{
+        suffix: () => (
+          <span class="textinfolabel truncate">
+            (<HighlightLabelText keyword={keyword} text={wi.email} />)
+          </span>
+        ),
+      }}
+    </UserNameCell>
+  );
+};
+
+const renderLabel = computed(() => {
+  return getRenderLabelFunc({
+    multiple: props.multiple,
+    customLabel,
+    showResourceName: false,
+  });
+});
+
+const renderTag = computed(() => {
+  return getRenderTagFunc({
+    multiple: props.multiple,
+    disabled: props.disabled,
+    size: props.size,
+    customLabel,
+  });
+});
+</script>

--- a/frontend/src/components/v2/Select/index.ts
+++ b/frontend/src/components/v2/Select/index.ts
@@ -7,6 +7,7 @@ import ProjectSelect from "./ProjectSelect.vue";
 import RoleSelect from "./RoleSelect.vue";
 import UserSelect from "./UserSelect.vue";
 import AccountSelect from "./AccountSelect.vue";
+import WorkloadIdentitySelect from "./WorkloadIdentitySelect.vue";
 
 export {
   AnnouncementLevelSelect,
@@ -18,4 +19,5 @@ export {
   AccountSelect,
   GroupSelect,
   RoleSelect,
+  WorkloadIdentitySelect,
 };

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -2856,8 +2856,7 @@
       "target-databases": "Target Databases"
     },
     "workload-identity": {
-      "select-placeholder": "Select a workload identity",
-      "no-identity": "No workload identity found. Create one to get started."
+      "select-placeholder": "Select a workload identity"
     },
     "workflow": {
       "title": "Workflow file generation",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -2856,8 +2856,7 @@
       "target-databases": "Bases de datos de destino"
     },
     "workload-identity": {
-      "select-placeholder": "Seleccionar una identidad de carga de trabajo",
-      "no-identity": "No se encontró ninguna identidad de carga de trabajo. Cree una para comenzar."
+      "select-placeholder": "Seleccionar una identidad de carga de trabajo"
     },
     "workflow": {
       "title": "Generación de archivo de flujo de trabajo",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -2856,8 +2856,7 @@
       "target-databases": "ターゲットデータベース"
     },
     "workload-identity": {
-      "select-placeholder": "ワークロードアイデンティティを選択",
-      "no-identity": "ワークロードアイデンティティが見つかりません。作成して始めましょう。"
+      "select-placeholder": "ワークロードアイデンティティを選択"
     },
     "workflow": {
       "title": "ワークフローファイル生成",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -2856,8 +2856,7 @@
       "target-databases": "Cơ sở dữ liệu đích"
     },
     "workload-identity": {
-      "select-placeholder": "Chọn một workload identity",
-      "no-identity": "Không tìm thấy workload identity. Tạo một cái để bắt đầu."
+      "select-placeholder": "Chọn một workload identity"
     },
     "workflow": {
       "title": "Tạo tệp workflow",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -2856,8 +2856,7 @@
       "target-databases": "目标数据库"
     },
     "workload-identity": {
-      "select-placeholder": "选择工作负载身份",
-      "no-identity": "未找到工作负载身份，请创建一个以开始使用。"
+      "select-placeholder": "选择工作负载身份"
     },
     "workflow": {
       "title": "工作流文件生成",

--- a/frontend/src/router/dashboard/projectV1.ts
+++ b/frontend/src/router/dashboard/projectV1.ts
@@ -470,7 +470,6 @@ const projectV1Routes: RouteRecordRaw[] = [
         meta: {
           title: () => t("gitops.self"),
           requiredPermissionList: () => [
-            "bb.settings.get",
             "bb.workloadIdentities.list",
             "bb.databases.list",
           ],

--- a/frontend/src/views/project/ProjectGitOpsDashboard.vue
+++ b/frontend/src/views/project/ProjectGitOpsDashboard.vue
@@ -61,7 +61,7 @@
       <!-- Check 2: Workload Identity -->
       <div class="flex items-start gap-x-3 py-3">
         <CheckIcon
-          v-if="selectedIdentityEmail"
+          v-if="selectedIdentityName"
           class="w-5 h-5 text-success shrink-0"
         />
         <XCircleIcon
@@ -73,9 +73,9 @@
             $t("gitops.checklist.workload-identity")
           }}</span>
           <div class="flex items-center gap-x-3">
-            <NSelect
-              v-model:value="selectedIdentityEmail"
-              :options="identityOptions"
+            <WorkloadIdentitySelect
+              v-model:value="selectedIdentityName"
+              :parent="projectName"
               :placeholder="
                 $t('gitops.workload-identity.select-placeholder')
               "
@@ -94,12 +94,6 @@
               </NButton>
             </PermissionGuardWrapper>
           </div>
-          <p
-            v-if="identityOptions.length === 0 && !isLoading"
-            class="text-sm text-control-light"
-          >
-            {{ $t("gitops.workload-identity.no-identity") }}
-          </p>
           <a
             v-if="repoUrl"
             :href="repoUrl"
@@ -337,19 +331,27 @@ import {
   ChevronRightIcon,
   XCircleIcon,
 } from "lucide-vue-next";
-import { NButton, NInput, NSelect, NSwitch, NTabPane, NTabs } from "naive-ui";
-import { computed, onMounted, ref, watch } from "vue";
+import { NButton, NInput, NSwitch, NTabPane, NTabs } from "naive-ui";
+import { computed, ref, watch } from "vue";
 import gitopsWorkflowImage from "@/assets/gitops-workflow.svg";
 import PermissionGuardWrapper from "@/components/Permission/PermissionGuardWrapper.vue";
 import CreateWorkloadIdentityDrawer from "@/components/User/Settings/CreateWorkloadIdentityDrawer.vue";
-import { CopyButton, DatabaseSelect } from "@/components/v2";
+import {
+  CopyButton,
+  DatabaseSelect,
+  WorkloadIdentitySelect,
+} from "@/components/v2";
 import { MissingExternalURLAttention } from "@/components/v2/Form";
-import { useActuatorV1Store, useProjectByName } from "@/store";
+import {
+  extractWorkloadIdentityId,
+  useActuatorV1Store,
+  useProjectByName,
+  useWorkloadIdentityStore,
+  workloadIdentityNamePrefix,
+} from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
-import { useWorkloadIdentityStore } from "@/store/modules/workloadIdentity";
 import type { User } from "@/types/proto-es/v1/user_service_pb";
 import { WorkloadIdentityConfig_ProviderType } from "@/types/proto-es/v1/user_service_pb";
-import type { WorkloadIdentity } from "@/types/proto-es/v1/workload_identity_service_pb";
 
 const props = defineProps<{
   projectId: string;
@@ -362,11 +364,8 @@ const projectName = computed(() => `${projectNamePrefix}${props.projectId}`);
 const { project } = useProjectByName(projectName);
 
 const showCreateDrawer = ref(false);
-const selectedIdentityEmail = ref<string | null>(null);
+const selectedIdentityName = ref<string | undefined>(undefined);
 const selectedDatabaseNames = ref<string[]>([]);
-const isLoading = ref(false);
-const identityOptions = ref<{ label: string; value: string }[]>([]);
-const identityMap = ref<Map<string, WorkloadIdentity>>(new Map());
 const activeTab = ref("github-actions");
 const useSelfhostRunner = ref(false);
 const showSqlReviewYaml = ref(false);
@@ -374,8 +373,8 @@ const showReleaseYaml = ref(false);
 const showGitlabCiYaml = ref(false);
 
 const selectedIdentity = computed(() => {
-  if (!selectedIdentityEmail.value) return undefined;
-  return identityMap.value.get(selectedIdentityEmail.value);
+  if (!selectedIdentityName.value) return undefined;
+  return workloadIdentityStore.getWorkloadIdentity(selectedIdentityName.value);
 });
 
 const selectedConfig = computed(
@@ -458,10 +457,10 @@ const bytebaseUrl = computed(() => {
 });
 
 const workloadIdentityEmail = computed(() => {
-  if (!selectedIdentityEmail.value) {
+  if (!selectedIdentityName.value) {
     return "{WORKLOAD_IDENTITY_EMAIL}";
   }
-  return selectedIdentityEmail.value;
+  return extractWorkloadIdentityId(selectedIdentityName.value);
 });
 
 const targetsString = computed(() => {
@@ -704,37 +703,7 @@ ${gitlabExchangeScript}
     - bytebase-action rollout --url=$BYTEBASE_URL --access-token=$BYTEBASE_ACCESS_TOKEN --project=$BYTEBASE_PROJECT --target-stage=environments/prod --plan=$PLAN`;
 });
 
-const fetchWorkloadIdentities = async () => {
-  isLoading.value = true;
-  try {
-    const response = await workloadIdentityStore.listWorkloadIdentities({
-      parent: projectName.value,
-      pageSize: 100,
-      pageToken: undefined,
-      showDeleted: false,
-    });
-    const map = new Map<string, WorkloadIdentity>();
-    const options: { label: string; value: string }[] = [];
-    for (const wi of response.workloadIdentities) {
-      map.set(wi.email, wi);
-      options.push({
-        label: `${wi.title} (${wi.email})`,
-        value: wi.email,
-      });
-    }
-    identityMap.value = map;
-    identityOptions.value = options;
-  } finally {
-    isLoading.value = false;
-  }
+const handleWorkloadIdentityCreated = (user: User) => {
+  selectedIdentityName.value = `${workloadIdentityNamePrefix}${user.email}`;
 };
-
-const handleWorkloadIdentityCreated = async (user: User) => {
-  await fetchWorkloadIdentities();
-  selectedIdentityEmail.value = user.email;
-};
-
-onMounted(() => {
-  fetchWorkloadIdentities();
-});
 </script>


### PR DESCRIPTION
- Fix: don't need the `bb.settings.set` permission for GitOps, we will get the external URL from the actuator
- Extract the workload identity selector to support the "load more" and filter

<img width="1330" height="430" alt="CleanShot 2026-03-05 at 15 13 37@2x" src="https://github.com/user-attachments/assets/db95b4c9-4c81-46f0-8ff1-3251632e0ab9" />
