### PR TITLE
chore: add custom tag input to build-push-action-image workflow

### DIFF
--- a/.github/workflows/build-push-action-image.yml
+++ b/.github/workflows/build-push-action-image.yml
@@ -2,6 +2,11 @@ name: Build push action image
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag (e.g., latest, 1.0.0)'
+        required: false
+        default: ''
   push:
     branches:
       - 'release/*.*.*'
@@ -21,7 +26,9 @@ jobs:
       - name: Extract build args
         id: extract_build_args
         run: |
-          if [[ "${{ github.ref_name }}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            VERSION="${{ inputs.tag }}"
+          elif [[ "${{ github.ref_name }}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             VERSION=$(echo "${{ github.ref_name }}" | sed 's/release\///')
           else
             VERSION="latest"
@@ -56,7 +63,9 @@ jobs:
       - name: Extract build args
         id: extract_build_args
         run: |
-          if [[ "${{ github.ref_name }}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            VERSION="${{ inputs.tag }}"
+          elif [[ "${{ github.ref_name }}" =~ ^release/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             VERSION=$(echo "${{ github.ref_name }}" | sed 's/release\///')
           else
             VERSION="latest"


### PR DESCRIPTION
## Summary
- Add `tag` input to `workflow_dispatch` trigger in the action image build workflow
- When manually triggering, users can now specify a custom image tag (e.g., `ksl`, `1.0.0`)
- Falls back to version from branch name or `latest` if no tag is provided

## Test plan
- [ ] Trigger workflow manually with a custom tag and verify the image is pushed with that tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)