### PR TITLE
test: bound testcontainer migration subtest concurrency for oracle/mssql

### DIFF
--- a/backend/plugin/schema/mssql/generate_migration_testcontainer_test.go
+++ b/backend/plugin/schema/mssql/generate_migration_testcontainer_test.go
@@ -2346,9 +2346,18 @@ GO
 		},
 	}
 
+	// MSSQL Express in CI gets significantly slower when too many schema-heavy
+	// subtests run at once against the same container. Keep bounded parallelism.
+	const maxConcurrentSubtests = 4
+	parallelGate := make(chan struct{}, maxConcurrentSubtests)
+
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
+			parallelGate <- struct{}{}
+			defer func() {
+				<-parallelGate
+			}()
 
 			// Create test database with unique name
 			testDB := fmt.Sprintf("test_%s", strings.ReplaceAll(uuid.New().String(), "-", "_"))

--- a/backend/plugin/schema/oracle/generate_migration_testcontainer_test.go
+++ b/backend/plugin/schema/oracle/generate_migration_testcontainer_test.go
@@ -1711,10 +1711,19 @@ COMMENT ON TABLE SPECIAL_DATA IS '';
 		},
 	}
 
+	// Oracle Free in CI slows down heavily when too many schema-heavy
+	// subtests execute concurrently against the same container.
+	const maxConcurrentSubtests = 4
+	parallelGate := make(chan struct{}, maxConcurrentSubtests)
+
 	for _, tc := range testCases {
 		tc := tc // Capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+			parallelGate <- struct{}{}
+			defer func() {
+				<-parallelGate
+			}()
 
 			// Create unique Oracle user for this test (Oracle users are schemas)
 			// Use UUID to ensure uniqueness and avoid name collisions


### PR DESCRIPTION
## Summary
- bound subtest concurrency in MSSQL `TestGenerateMigrationWithTestcontainer`
- bound subtest concurrency in Oracle `TestGenerateMigrationWithTestcontainer`
- avoid DB/container contention from unbounded `t.Parallel()` fan-out

## Why
CI raw logs showed high per-subtest durations in Oracle migration testcontainer suite and overall package hotspot in `backend/plugin/schema/oracle`.

## Local benchmark (Oracle)
`TestGenerateMigrationWithTestcontainer` on same machine, image pre-pulled:
- bounded (`maxConcurrentSubtests=4`): `real 95.36s` (`ok ... 88.686s`)
- effectively unbounded (`maxConcurrentSubtests=1000`): `real 130.48s` (`ok ... 122.786s`)

Bounded concurrency improved wall time by ~35.12s (~26.9%).

## Notes
- kept limit at `4` in both Oracle and MSSQL tests
- no functional behavior change; test orchestration only
