### PR TITLE
fix: enable SQL review plan check for MariaDB engine

### DIFF
--- a/backend/common/engine.go
+++ b/backend/common/engine.go
@@ -173,7 +173,8 @@ func EngineSupportStatementAdvise(e storepb.Engine) bool {
 		storepb.Engine_MSSQL,
 		storepb.Engine_DYNAMODB,
 		storepb.Engine_COCKROACHDB,
-		storepb.Engine_REDSHIFT:
+		storepb.Engine_REDSHIFT,
+		storepb.Engine_MARIADB:
 		return true
 	case
 		storepb.Engine_ENGINE_UNSPECIFIED,
@@ -184,7 +185,6 @@ func EngineSupportStatementAdvise(e storepb.Engine) bool {
 		storepb.Engine_CLICKHOUSE,
 		storepb.Engine_SPANNER,
 		storepb.Engine_BIGQUERY,
-		storepb.Engine_MARIADB,
 		storepb.Engine_STARROCKS,
 		storepb.Engine_HIVE,
 		storepb.Engine_DORIS,


### PR DESCRIPTION
## Summary

- MariaDB was missing from `EngineSupportStatementAdvise()` in `backend/common/engine.go`, causing the plan check runner (`StatementAdviseExecutor`) to skip SQL review entirely for MariaDB databases — returning early with SUCCESS without executing any rules
- The editor pre-check worked correctly because it uses `CheckRelease` API which gates on `EngineSupportSQLReview()`, where MariaDB was already included
- This meant `requirePlanCheckNoError` and `enforceSqlReview` project settings did not prevent rollout of SQL that violated ERROR-level review rules on MariaDB

Fix: move `Engine_MARIADB` from the `false` branch to the `true` branch of `EngineSupportStatementAdvise()`.

## Test plan

- [ ] Verify MariaDB instance with SQL review config at ERROR level (e.g. `STATEMENT_WHERE_REQUIRE_UPDATE_DELETE`) correctly produces FAILED plan check on `DELETE FROM table;`
- [ ] Verify `requirePlanCheckNoError: true` blocks rollout when plan check fails
- [ ] Verify editor SQL review continues to work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)