### PR TITLE
fix(frontend): prevent IME composition from triggering unintended actions

### DIFF
--- a/frontend/src/components/InstanceForm/SyncDatabases.vue
+++ b/frontend/src/components/InstanceForm/SyncDatabases.vue
@@ -170,6 +170,7 @@ watch(
 );
 
 const handleKeyDown = (e: KeyboardEvent) => {
+  if (e.isComposing) return;
   const inputDatabase = state.inputDatabase.trim();
   if (!inputDatabase) {
     return;

--- a/frontend/src/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor/MarkdownEditor.vue
@@ -233,6 +233,7 @@ onMounted(() => {
 });
 
 const keyboardHandler = (e: KeyboardEvent) => {
+  if (e.isComposing) return;
   if (!contentTextArea.value) {
     return;
   }

--- a/frontend/src/components/Plan/components/HeaderSection/TitleInput.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/TitleInput.vue
@@ -11,7 +11,7 @@
       class="bb-plan-title-input"
       @focus="state.isEditing = true"
       @blur="onBlur"
-      @keyup.enter="onEnter"
+      @keydown.enter="onEnter"
       @update:value="onUpdateValue"
     />
   </div>
@@ -196,7 +196,8 @@ const onBlur = async () => {
   }
 };
 
-const onEnter = (e: Event) => {
+const onEnter = (e: KeyboardEvent) => {
+  if (e.isComposing) return;
   const input = e.target as HTMLInputElement;
   input.blur();
 };

--- a/frontend/src/views/ProfileDashboard.vue
+++ b/frontend/src/views/ProfileDashboard.vue
@@ -329,6 +329,7 @@ const passwordRestrictionSetting = computed(
 );
 
 const keyboardHandler = (e: KeyboardEvent) => {
+  if (e.isComposing) return;
   if (state.editing) {
     if (e.code === "Escape") {
       cancelEdit();

--- a/frontend/src/views/sql-editor/TabList/TabItem/Label.vue
+++ b/frontend/src/views/sql-editor/TabList/TabItem/Label.vue
@@ -19,8 +19,8 @@
       type="text"
       class="edit"
       @blur="confirmEdit"
-      @keyup.enter="(e) => (e.target as HTMLInputElement).blur()"
-      @keyup.esc="cancelEdit"
+      @keydown.enter="onEnter"
+      @keydown.esc="onEsc"
     />
   </div>
 </template>
@@ -101,6 +101,16 @@ const confirmEdit = () => {
   }
 
   state.editing = false;
+};
+
+const onEnter = (e: KeyboardEvent) => {
+  if (e.isComposing) return;
+  (e.target as HTMLInputElement).blur();
+};
+
+const onEsc = (e: KeyboardEvent) => {
+  if (e.isComposing) return;
+  cancelEdit();
 };
 
 const cancelEdit = () => {


### PR DESCRIPTION
## Summary

- Switch `@keyup.enter` to `@keydown.enter` with `isComposing` guard to prevent IME confirmation from triggering blur (TitleInput, Label)
- Add `isComposing` guard to `keydown` handlers using `e.code` matching (ProfileDashboard, SyncDatabases) and MarkdownEditor's keyboard handler

## Test plan

- [x] Plan/Issue title: Type CJK text with IME, press Enter to confirm composition -- input should stay focused
- [x] SQL Editor tab rename: Double-click tab name, type CJK text, press Enter to confirm -- rename should not complete until a second Enter
- [x] SQL Editor tab rename: Press Esc during IME composition -- rename should not be cancelled
- [x] Profile settings: Edit name with IME, press Cmd+Enter during composition -- name should not be saved with partial text
- [x] Markdown editor: Type `- テスト` with IME, press Enter to confirm -- autoComplete should not trigger
- [x] Instance sync databases: Type database name with IME, press Enter to confirm -- database should not be added prematurely
- [x] Verify all above inputs work correctly without IME (regular Enter behavior unchanged)

## Related Issues or PRs

Fixes #19548 