### PR TITLE
fix: validate database ownership in UpdateWorksheet to prevent cross-project binding

### DIFF
--- a/backend/api/v1/worksheet_service.go
+++ b/backend/api/v1/worksheet_service.go
@@ -262,6 +262,10 @@ func (s *WorksheetService) UpdateWorksheet(
 				if database == nil {
 					return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %v not found", request.Worksheet.Database))
 				}
+				// Verify the database belongs to the worksheet's project.
+				if database.ProjectID != worksheet.ProjectID {
+					return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found in project %q", request.Worksheet.Database, worksheet.ProjectID))
+				}
 				worksheetPatch.InstanceID, worksheetPatch.DatabaseName = &database.InstanceID, &database.DatabaseName
 			} else {
 				emptyStr := ""


### PR DESCRIPTION
## Summary
- Add missing project ownership validation when updating a worksheet's `database` field
- `UpdateWorksheet` now verifies that the target database belongs to the worksheet's project before allowing the binding, matching the existing check in `CreateWorksheet`
- Without this fix, an authenticated user could bind their worksheet to a database from another project, bypassing project-level access control

Closes BYT-8964

## Test plan
- [ ] Create a worksheet in Project A
- [ ] Attempt to update the worksheet's database to one belonging to Project B
- [ ] Verify the request is rejected with a `NOT_FOUND` error
- [ ] Verify updating to a database within Project A still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)