### PR TITLE
fix: only enforce sequential task execution for release-based migrations

### DIFF
--- a/backend/runner/taskrun/running_scheduler.go
+++ b/backend/runner/taskrun/running_scheduler.go
@@ -269,12 +269,13 @@ func checkTaskDrift(task *store.TaskMessage, database *store.DatabaseMessage, pl
 }
 
 // isSequentialTask returns whether the task should be executed sequentially.
+// Only release-based DATABASE_MIGRATE tasks are sequential to ensure ordered
+// schema changes. Non-release migrations can run concurrently on the same database.
 func isSequentialTask(task *store.TaskMessage) bool {
 	//exhaustive:enforce
 	switch task.Type {
 	case storepb.Task_DATABASE_MIGRATE:
-		// All DATABASE_MIGRATE operations (DDL/GHOST) should be sequential
-		return true
+		return task.Payload.GetRelease() != ""
 	case storepb.Task_DATABASE_CREATE,
 		storepb.Task_DATABASE_EXPORT:
 		return false


### PR DESCRIPTION
## Summary
- Only release-based `DATABASE_MIGRATE` tasks are now sequential (one at a time per database)
- Non-release migrations can run concurrently on the same database
- `isSequentialTask()` now checks `task.Payload.GetRelease() != ""` instead of always returning `true` for `DATABASE_MIGRATE`

## Breaking Changes
- Non-release database migrations will no longer be serialized per database. If concurrent migrations on the same database cause issues (e.g., schema dump inconsistencies), users should be aware of this tradeoff.

## Test plan
- [ ] Verify release-based migrations still run sequentially on the same database
- [ ] Verify non-release migrations can run in parallel on the same database
- [ ] Verify `DATABASE_CREATE` and `DATABASE_EXPORT` tasks are unaffected

Closes BYT-8974

🤖 Generated with [Claude Code](https://claude.com/claude-code)