### PR TITLE
chore: remove dead loop in BatchUpdateIssuesStatus

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -1031,19 +1031,6 @@ func (s *IssueService) BatchUpdateIssuesStatus(ctx context.Context, req *connect
 		slog.Error("failed to batch create issue comments", log.BBError(err))
 	}
 
-	// Create webhooks for each updated issue.
-	for _, issueUID := range issueUIDs {
-		updatedIssue, err := s.store.GetIssue(ctx, &store.FindIssueMessage{UID: &issueUID, ProjectID: &projectID})
-		if err != nil {
-			slog.Error("failed to get updated issue", "issueUID", issueUID, log.BBError(err))
-			continue
-		}
-		if updatedIssue == nil {
-			slog.Error("updated issue not found", "issueUID", issueUID)
-			continue
-		}
-	}
-
 	return connect.NewResponse(&v1pb.BatchUpdateIssuesStatusResponse{}), nil
 }
 


### PR DESCRIPTION
## Summary

- Remove a dead `for` loop in `BatchUpdateIssuesStatus` that fetched each issue from the store but never used the result
- The loop was commented "Create webhooks for each updated issue" but no webhook creation code was ever implemented — the fetched `updatedIssue` was discarded after nil/error checks
- This also eliminates N unnecessary `GetIssue` database queries per batch status update call

## Test plan

- [ ] Verify `BatchUpdateIssuesStatus` still works correctly (status updates and issue comments are unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)