### PR TITLE
fix: hide readonly scope tags from AdvancedSearch UI

### DIFF
--- a/frontend/src/components/AdvancedSearch/ScopeTags.vue
+++ b/frontend/src/components/AdvancedSearch/ScopeTags.vue
@@ -1,20 +1,19 @@
 <template>
   <NTag
-    v-for="(scope, i) in params.scopes"
-    :key="`${i}-${scope.id}`"
-    :closable="!scope.readonly"
-    :disabled="scope.readonly"
+    v-for="({ scope, originalIndex }, visibleIndex) in visibleScopes"
+    :key="`${originalIndex}-${scope.id}`"
+    closable
     :data-search-scope-id="scope.id"
     :bordered="false"
     size="small"
     style="--n-icon-size: 12px"
-    v-bind="tagProps(i)"
-    @close="$emit('remove-scope', i)"
-    @click.stop.prevent="handleClick(scope)"
+    v-bind="tagProps(visibleIndex)"
+    @close="$emit('remove-scope', originalIndex)"
+    @click.stop.prevent="$emit('select-scope', scope)"
   >
     <div class="flex items-center gap-1">
       <span class="text-control">{{ scope.id }}:</span>
-      <component :is="() => renderValue(scope, i)" />
+      <component :is="() => renderValue(scope)" />
     </div>
   </NTag>
 </template>
@@ -23,6 +22,7 @@
 import dayjs from "dayjs";
 import type { TagProps } from "naive-ui";
 import { NTag } from "naive-ui";
+import { computed } from "vue";
 import { useI18n } from "vue-i18n";
 import { UNKNOWN_ID } from "@/types";
 import type { SearchParams, SearchScope } from "@/utils";
@@ -35,12 +35,18 @@ const props = defineProps<{
   focusedTagIndex?: number;
 }>();
 
-const emit = defineEmits<{
+defineEmits<{
   (event: "remove-scope", index: number): void;
   (event: "select-scope", scope: SearchScope): void;
 }>();
 
 const { t } = useI18n();
+
+const visibleScopes = computed(() => {
+  return props.params.scopes
+    .map((scope, originalIndex) => ({ scope, originalIndex }))
+    .filter(({ scope }) => !scope.readonly);
+});
 
 const tagProps = (index: number): TagProps => {
   if (props.focusedTagIndex !== index) {
@@ -54,7 +60,7 @@ const tagProps = (index: number): TagProps => {
   };
 };
 
-const renderValue = (scope: SearchScope, _index: number) => {
+const renderValue = (scope: SearchScope) => {
   const scopeOption = props.scopeOptions
     .find((option) => option.id === scope.id)
     ?.options?.find((option) => option.value === scope.value);
@@ -72,13 +78,5 @@ const renderValue = (scope: SearchScope, _index: number) => {
     return <span>{t("common.all").toLocaleLowerCase()}</span>;
   }
   return <span>{scope.value}</span>;
-};
-
-const handleClick = (scope: SearchScope) => {
-  if (scope.readonly) {
-    return;
-  }
-
-  emit("select-scope", scope);
 };
 </script>


### PR DESCRIPTION
## Summary
- Hide readonly scope tags (e.g., `project:xxx`) from the AdvancedSearch filter bar since they are redundant when the user is already in that context
- Reduces horizontal space usage, partially addressing BYT-8967 (horizontal overflow on small screens)
- Readonly scopes are preserved in `params.scopes` for filtering, caching, and clear behavior — only hidden from the UI

Resolves: https://linear.app/bytebase/issue/BYT-8967

## Test plan
- [ ] Open a project's issue list page — verify the readonly `project:xxx` tag no longer appears in the search bar
- [ ] Verify search filters still work correctly within the project scope
- [ ] Add/remove editable scope tags — verify indices and removal work correctly
- [ ] Clear the search bar — verify readonly scopes are preserved (filtering still scoped to project)
- [ ] Check instance detail page — verify the readonly `instance:xxx` tag is also hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)