### PR TITLE
fix: classify CALL/EXEC stored procedure statements as DML across all engines

### DIFF
--- a/backend/plugin/parser/bigquery/query_type.go
+++ b/backend/plugin/parser/bigquery/query_type.go
@@ -39,7 +39,7 @@ func (l *queryTypeListener) getQueryTypeForUnterminatedSQLStatement(u parser.IUn
 		body.Create_schema_statement() != nil, body.Create_external_schema_statement() != nil, body.Create_snapshot_statement() != nil, body.Create_table_function_statement() != nil, body.Create_table_statement() != nil,
 		body.Create_view_statement() != nil, body.Create_entity_statement() != nil, body.Rename_statement() != nil, body.Drop_all_row_access_policies_statement() != nil, body.Drop_statement() != nil, body.Undrop_statement() != nil:
 		return base.DDL
-	case body.Dml_statement() != nil, body.Merge_statement() != nil:
+	case body.Dml_statement() != nil, body.Merge_statement() != nil, body.Call_statement() != nil:
 		return base.DML
 	case body.Explain_statement() != nil:
 		return base.Explain

--- a/backend/plugin/parser/doris/query_type.go
+++ b/backend/plugin/parser/doris/query_type.go
@@ -169,6 +169,11 @@ func (l *queryTypeListener) EnterSupportedOtherStatementAlias(_ *parser.Supporte
 	l.result = base.DDL
 }
 
+// EnterCallProcedure is called for CALL stored procedure statements.
+func (l *queryTypeListener) EnterCallProcedure(_ *parser.CallProcedureContext) {
+	l.result = base.DML
+}
+
 // EnterSupportedStatsStatementAlias is called for stats statements.
 func (l *queryTypeListener) EnterSupportedStatsStatementAlias(_ *parser.SupportedStatsStatementAliasContext) {
 	l.result = base.DDL

--- a/backend/plugin/parser/pg/query_type.go
+++ b/backend/plugin/parser/pg/query_type.go
@@ -200,6 +200,11 @@ func (q *queryTypeListener) getStatementType(stmt pgparser.IStmtContext) base.Qu
 		return base.DML
 	}
 
+	// CALL stored procedure is DML
+	if stmt.Callstmt() != nil {
+		return base.DML
+	}
+
 	// Default to unknown for any unhandled statement types
 	return base.QueryTypeUnknown
 }

--- a/backend/plugin/parser/pg/test-data/query_type.yaml
+++ b/backend/plugin/parser/pg/test-data/query_type.yaml
@@ -559,3 +559,15 @@
     results: []
     sourcecolumns: []
     predicatecolumns: []
+- description: CALL stored procedure
+  statement: CALL my_procedure(1, 'test');
+  defaultDatabase: db
+  metadata: |-
+    {
+      "name":  "db"
+    }
+  querySpan:
+    type: 5
+    results: []
+    sourcecolumns: []
+    predicatecolumns: []

--- a/backend/plugin/parser/plsql/query_type.go
+++ b/backend/plugin/parser/plsql/query_type.go
@@ -149,6 +149,8 @@ func (l *queryTypeListener) EnterUnit_statement(ctx *plsql.Unit_statementContext
 			return
 		}
 		l.result = base.DML
+	case ctx.Sql_call_statement() != nil:
+		l.result = base.DML
 	default:
 		// Other statement types
 	}

--- a/backend/plugin/parser/redshift/query_type.go
+++ b/backend/plugin/parser/redshift/query_type.go
@@ -199,6 +199,11 @@ func (q *queryTypeListener) getStatementType(stmt parser.IStmtContext) base.Quer
 		return base.DML
 	}
 
+	// CALL stored procedure is DML
+	if stmt.Callstmt() != nil {
+		return base.DML
+	}
+
 	// Default to unknown for any unhandled statement types
 	return base.QueryTypeUnknown
 }

--- a/backend/plugin/parser/snowflake/query_type.go
+++ b/backend/plugin/parser/snowflake/query_type.go
@@ -66,6 +66,12 @@ func (*queryTypeListener) getQueryTypeForOtherCommand(otherCommand parser.IOther
 		return base.DDL, nil
 	case otherCommand.Set() != nil:
 		return base.Select, nil
+	case otherCommand.Call() != nil:
+		return base.DML, nil
+	case otherCommand.Execute_immediate() != nil:
+		return base.DML, nil
+	case otherCommand.Execute_task() != nil:
+		return base.DML, nil
 	default:
 		return base.QueryTypeUnknown, nil
 	}

--- a/backend/plugin/parser/spanner/query_type.go
+++ b/backend/plugin/parser/spanner/query_type.go
@@ -39,7 +39,7 @@ func (l *queryTypeListener) getQueryTypeForUnterminatedSQLStatement(u parser.IUn
 		body.Create_schema_statement() != nil, body.Create_external_schema_statement() != nil, body.Create_snapshot_statement() != nil, body.Create_table_function_statement() != nil, body.Create_table_statement() != nil,
 		body.Create_view_statement() != nil, body.Create_entity_statement() != nil, body.Rename_statement() != nil, body.Drop_all_row_access_policies_statement() != nil, body.Drop_statement() != nil, body.Undrop_statement() != nil:
 		return base.DDL
-	case body.Dml_statement() != nil, body.Merge_statement() != nil:
+	case body.Dml_statement() != nil, body.Merge_statement() != nil, body.Call_statement() != nil:
 		return base.DML
 	case body.Explain_statement() != nil:
 		return base.Explain

--- a/backend/plugin/parser/trino/query_type.go
+++ b/backend/plugin/parser/trino/query_type.go
@@ -116,6 +116,11 @@ func (l *queryTypeListener) EnterMerge(_ *parser.MergeContext) {
 	l.result = base.DML
 }
 
+// EnterCall is called when entering a CallContext rule (CALL stored procedure).
+func (l *queryTypeListener) EnterCall(_ *parser.CallContext) {
+	l.result = base.DML
+}
+
 // EnterCreateTable is called when entering a CreateTableContext rule.
 func (l *queryTypeListener) EnterCreateTable(_ *parser.CreateTableContext) {
 	l.result = base.DDL

--- a/backend/plugin/parser/tsql/query_type.go
+++ b/backend/plugin/parser/tsql/query_type.go
@@ -64,6 +64,10 @@ func (l *queryTypeListener) getQueryTypeForSQLClause(clause parser.ISql_clausesC
 		if clause.Another_statement().Set_statement() != nil || clause.Another_statement().Setuser_statement() != nil || clause.Another_statement().Declare_statement() != nil {
 			return base.Select, nil
 		}
+		// EXECUTE stored procedure is DML.
+		if clause.Another_statement().Execute_statement() != nil {
+			return base.DML, nil
+		}
 		return base.QueryTypeUnknown, nil
 	case clause.Cfl_statement() != nil, clause.Dbcc_clause() != nil, clause.Backup_statement() != nil:
 		return base.QueryTypeUnknown, nil
@@ -77,6 +81,6 @@ func (*queryTypeListener) getQueryTypeForBatchLevelStatement(parser.IBatch_level
 }
 
 func (*queryTypeListener) getQueryTypeForExecuteBodyBatch(parser.IExecute_body_batchContext) (base.QueryType, error) {
-	// Call stored procedure or function. Do not detect the type for now.
-	return base.QueryTypeUnknown, nil
+	// Call stored procedure or function.
+	return base.DML, nil
 }


### PR DESCRIPTION
## Summary

- CALL/EXEC statements were classified as `QueryTypeUnknown` in most database engines, causing the SQL editor to reject them with "disallowed query type"
- Classified CALL/EXEC as DML in all engines that support stored procedures: PostgreSQL, MSSQL, Oracle, Snowflake, Redshift, BigQuery, Spanner, Trino, Doris/StarRocks
- Users can now execute stored procedures in the SQL editor with `bb.sql.dml` permission

## Engines changed

| Engine | Parser node | 
|--------|------------|
| PostgreSQL (+ CockroachDB) | `Callstmt` |
| MSSQL | `Execute_body_batch`, `Execute_statement` |
| Oracle | `Sql_call_statement` |
| Snowflake | `Call`, `Execute_immediate`, `Execute_task` |
| Redshift | `Callstmt` |
| BigQuery | `Call_statement` |
| Spanner | `Call_statement` |
| Trino | `CallContext` |
| Doris (+ StarRocks) | `CallProcedureContext` |

Already correct (no changes): MySQL, MariaDB, OceanBase, TiDB

N/A (no stored procs): ClickHouse, SQLite, Hive, Cassandra, MongoDB, Elasticsearch, Redis, DynamoDB, CosmosDB, Databricks

## Test plan

- [x] Added CALL test case to PG `query_type.yaml`
- [x] All parser tests pass
- [x] Build passes
- [x] Lint passes

Closes BYT-8541

🤖 Generated with [Claude Code](https://claude.com/claude-code)