### PR TITLE
chore: update biome schema version to 2.4.5

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,


### PR DESCRIPTION
## Summary
- Update biome JSON schema version from 2.4.4 to 2.4.5 to match the installed biome version

## Test plan
- [x] `pnpm --dir frontend check` passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)