### PR TITLE
fix: filter out non-user types from approval candidates

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/useApprovalStep.ts
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ApprovalFlowSection/useApprovalStep.ts
@@ -14,6 +14,7 @@ import {
   useProjectIamPolicyStore,
   useUserStore,
 } from "@/store";
+import { userNamePrefix } from "@/store/modules/v1/common";
 import { groupBindingPrefix } from "@/types";
 import { State } from "@/types/proto-es/v1/common_pb";
 import type {
@@ -151,7 +152,7 @@ export function useApprovalStep(
     await groupStore.batchGetOrFetchGroups(groupNames);
   });
 
-  // Get candidates for this approval step
+  // Get candidates for this approval step (only regular users, not service accounts or workload identities)
   const candidateEmails = computed(() => {
     const candidates: string[] = [];
     for (const role of stepRoles.value) {
@@ -159,7 +160,11 @@ export function useApprovalStep(
         project.value.name
       );
       const memberMap = memberMapToRolesInProjectIAM(policy, role);
-      candidates.push(...memberMap.keys());
+      for (const fullname of memberMap.keys()) {
+        if (fullname.startsWith(userNamePrefix)) {
+          candidates.push(fullname);
+        }
+      }
     }
     return uniq(candidates);
   });

--- a/frontend/src/store/modules/v1/issue.ts
+++ b/frontend/src/store/modules/v1/issue.ts
@@ -22,7 +22,7 @@ import {
   memberMapToRolesInProjectIAM,
 } from "@/utils";
 import { useUserStore } from "../user";
-import { projectNamePrefix } from "./common";
+import { projectNamePrefix, userNamePrefix } from "./common";
 import { useProjectV1Store } from "./project";
 import { useProjectIamPolicyStore } from "./projectIamPolicy";
 
@@ -138,7 +138,9 @@ export const candidatesOfApprovalStepV1 = (issue: Issue, role: string) => {
     const projectIamPolicyStore = useProjectIamPolicyStore();
     const iamPolicy = projectIamPolicyStore.getProjectIamPolicy(project.name);
     const memberMap = memberMapToRolesInProjectIAM(iamPolicy, role);
-    return [...memberMap.keys()];
+    return [...memberMap.keys()].filter((name) =>
+      name.startsWith(userNamePrefix)
+    );
   };
   const candidates = role ? candidatesForRoles(role) : [];
 


### PR DESCRIPTION
## Summary
- Filter `useApprovalStep` (`candidateEmails`) to only include regular users (`users/` prefix), excluding service accounts and workload identities from appearing as potential approvers
- Apply the same fix to `candidatesOfApprovalStepV1` in the issue store, which is used to determine if the current user is an approval candidate in the plan header actions

## Test plan
- [ ] Assign a project role (e.g. `roles/projectOwner`) to a workload identity or service account
- [ ] Create an issue that requires approval from that role
- [ ] Verify the workload identity / service account does NOT appear in the potential approvers list
- [ ] Verify regular users with the same role still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)