### PR TITLE
fix: include line number in MSSQL error messages

### DIFF
--- a/backend/plugin/db/mssql/mssql.go
+++ b/backend/plugin/db/mssql/mssql.go
@@ -348,17 +348,27 @@ func execute(ctx context.Context, txn *sql.Tx, statement string) (int64, error) 
 	return rowsAffected, nil
 }
 
+func formatMSSQLError(e gomssqldb.Error) string {
+	b := new(strings.Builder)
+	if len(e.ProcName) > 0 {
+		fmt.Fprintf(b, "Msg %d, Level %d, State %d, Server %s, Procedure %s, Line %d\n", e.Number, e.Class, e.State, e.ServerName, e.ProcName, e.LineNo)
+	} else {
+		fmt.Fprintf(b, "Msg %d, Level %d, State %d, Server %s, Line %d\n", e.Number, e.Class, e.State, e.ServerName, e.LineNo)
+	}
+	b.WriteString(e.Message)
+	return b.String()
+}
+
 func unpackGoMSSQLDBError(err gomssqldb.Error) error {
 	if len(err.All) == 0 || len(err.All) == 1 {
-		return errors.Errorf("%s", err.Message)
+		return errors.Errorf("%s", formatMSSQLError(err))
 	}
 	var msgs []string
 	for _, e := range err.All {
-		cerr := unpackGoMSSQLDBError(e)
-		if cerr == nil {
+		if e.Message == "" {
 			continue
 		}
-		msgs = append(msgs, cerr.Error())
+		msgs = append(msgs, formatMSSQLError(e))
 	}
 	return errors.Errorf("%s", strings.Join(msgs, "\n"))
 }


### PR DESCRIPTION
## Summary
- Enrich MSSQL error messages with line number, error code, severity, state, and server name following sqlcmd's format
- Previously, errors only showed the message text (e.g., `Invalid column name 'idd'`), making it impossible to identify which statement failed when executing multiple statements
- Now errors display: `Msg 207, Level 16, State 1, Server MYSERVER, Line 6\nInvalid column name 'idd'.`

Part of BYT-8646.

## Test plan
- [x] Verified against local MSSQL 2019 Docker instance that `gomssqldb.Error.LineNo` is correctly populated
- [x] Deploy and test rollout with multiple MSSQL statements where one fails — confirm line number is visible in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)