### PR TITLE
chore: upgrade biome to 2.4.6 and enable new lint rules

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.6/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
   "files": {
     "ignoreUnknown": true,
@@ -27,29 +27,39 @@
         "noUselessTypeConstraint": "error"
       },
       "correctness": {
+        "noConstantCondition": "error",
         "noEmptyPattern": "error",
+        "noPrecisionLoss": "error",
+        "noSelfAssign": "error",
+        "noUnsafeOptionalChaining": "error",
         "noUnusedVariables": "error",
         "noVueReservedKeys": "error",
         "noVueReservedProps": "error",
-        "noVueSetupPropsReactivityLoss": "error"
+        "noVueSetupPropsReactivityLoss": "error",
+        "useIsNan": "error",
+        "useValidForDirection": "error"
       },
       "nursery": {
         "noForIn": "error",
+        "noVueArrowFuncInWatch": "error",
         "noVueVIfWithVFor": "error",
         "useArraySortCompare": "error",
         "useFind": "error",
+        "useScopedStyles": "error",
         "useSpread": "error",
         "useVueConsistentVBindStyle": "error",
         "useVueConsistentVOnStyle": "error",
         "useVueHyphenatedAttributes": "error",
         "useVueValidTemplateRoot": "error",
         "useVueValidVBind": "error",
+        "useVueValidVCloak": "error",
         "useVueValidVElse": "error",
         "useVueValidVElseIf": "error",
         "useVueValidVHtml": "error",
         "useVueValidVIf": "error",
-        "useVueValidVOnce": "error",
         "useVueValidVOn": "error",
+        "useVueValidVOnce": "error",
+        "useVueValidVPre": "error",
         "useVueValidVText": "error",
         "useVueVForKey": "error"
       },
@@ -58,19 +68,26 @@
         "noNamespace": "error",
         "useArrayLiterals": "error",
         "useAsConstAssertion": "error",
-        "useBlockStatements": "off"
+        "useBlockStatements": "off",
+        "useExportType": "error",
+        "useSelfClosingElements": "error"
       },
       "suspicious": {
+        "noAsyncPromiseExecutor": "error",
         "noConsole": {
           "level": "error",
           "options": { "allow": ["warn", "error", "debug", "assert", "log"] }
         },
         "noDebugger": "error",
         "noDeprecatedImports": "error",
+        "noDoubleEquals": "error",
+        "noDuplicateCase": "error",
         "noExplicitAny": "error",
         "noExtraNonNullAssertion": "error",
+        "noGlobalIsNan": "error",
         "noMisleadingInstantiator": "error",
         "noNonNullAssertedOptionalChain": "error",
+        "noSparseArray": "error",
         "noUnsafeDeclarationMerging": "error",
         "useNamespaceKeyword": "error"
       }
@@ -225,6 +242,7 @@
         "rules": {
           "complexity": { "noArguments": "error" },
           "correctness": {
+            "noUnusedImports": "error",
             "noConstAssign": "off",
             "noGlobalObjectCalls": "off",
             "noInvalidBuiltinInstantiation": "off",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,7 +78,7 @@
     "vueuc": "0.4.65"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.4.5",
+    "@biomejs/biome": "2.4.6",
     "@codingame/esbuild-import-meta-url-plugin": "^1.0.3",
     "@iconify/json": "2.2.446",
     "@intlify/eslint-plugin-vue-i18n": "^4.0.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -194,8 +194,8 @@ importers:
         version: 0.4.65(vue@3.5.29(typescript@5.9.3))
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.4.5
-        version: 2.4.5
+        specifier: 2.4.6
+        version: 2.4.6
       '@codingame/esbuild-import-meta-url-plugin':
         specifier: ^1.0.3
         version: 1.0.3
@@ -910,55 +910,55 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.4.5':
-    resolution: {integrity: sha512-OWNCyMS0Q011R6YifXNOg6qsOg64IVc7XX6SqGsrGszPbkVCoaO7Sr/lISFnXZ9hjQhDewwZ40789QmrG0GYgQ==}
+  '@biomejs/biome@2.4.6':
+    resolution: {integrity: sha512-QnHe81PMslpy3mnpL8DnO2M4S4ZnYPkjlGCLWBZT/3R9M6b5daArWMMtEfP52/n174RKnwRIf3oT8+wc9ihSfQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.5':
-    resolution: {integrity: sha512-lGS4Nd5O3KQJ6TeWv10mElnx1phERhBxqGP/IKq0SvZl78kcWDFMaTtVK+w3v3lusRFxJY78n07PbKplirsU5g==}
+  '@biomejs/cli-darwin-arm64@2.4.6':
+    resolution: {integrity: sha512-NW18GSyxr+8sJIqgoGwVp5Zqm4SALH4b4gftIA0n62PTuBs6G2tHlwNAOj0Vq0KKSs7Sf88VjjmHh0O36EnzrQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.5':
-    resolution: {integrity: sha512-6MoH4tyISIBNkZ2Q5T1R7dLd5BsITb2yhhhrU9jHZxnNSNMWl+s2Mxu7NBF8Y3a7JJcqq9nsk8i637z4gqkJxQ==}
+  '@biomejs/cli-darwin-x64@2.4.6':
+    resolution: {integrity: sha512-4uiE/9tuI7cnjtY9b07RgS7gGyYOAfIAGeVJWEfeCnAarOAS7qVmuRyX6d7JTKw28/mt+rUzMasYeZ+0R/U1Mw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.5':
-    resolution: {integrity: sha512-iqLDgpzobG7gpBF0fwEVS/LT8kmN7+S0E2YKFDtqliJfzNLnAiV2Nnyb+ehCDCJgAZBASkYHR2o60VQWikpqIg==}
+  '@biomejs/cli-linux-arm64-musl@2.4.6':
+    resolution: {integrity: sha512-F/JdB7eN22txiTqHM5KhIVt0jVkzZwVYrdTR1O3Y4auBOQcXxHK4dxULf4z43QyZI5tsnQJrRBHZy7wwtL+B3A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-arm64@2.4.5':
-    resolution: {integrity: sha512-U1GAG6FTjhAO04MyH4xn23wRNBkT6H7NentHh+8UxD6ShXKBm5SY4RedKJzkUThANxb9rUKIPc7B8ew9Xo/cWg==}
+  '@biomejs/cli-linux-arm64@2.4.6':
+    resolution: {integrity: sha512-kMLaI7OF5GN1Q8Doymjro1P8rVEoy7BKQALNz6fiR8IC1WKduoNyteBtJlHT7ASIL0Cx2jR6VUOBIbcB1B8pew==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64-musl@2.4.5':
-    resolution: {integrity: sha512-NlKa7GpbQmNhZf9kakQeddqZyT7itN7jjWdakELeXyTU3pg/83fTysRRDPJD0akTfKDl6vZYNT9Zqn4MYZVBOA==}
+  '@biomejs/cli-linux-x64-musl@2.4.6':
+    resolution: {integrity: sha512-C9s98IPDu7DYarjlZNuzJKTjVHN03RUnmHV5htvqsx6vEUXCDSJ59DNwjKVD5XYoSS4N+BYhq3RTBAL8X6svEg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-linux-x64@2.4.5':
-    resolution: {integrity: sha512-NdODlSugMzTlENPTa4z0xB82dTUlCpsrOxc43///aNkTLblIYH4XpYflBbf5ySlQuP8AA4AZd1qXhV07IdrHdQ==}
+  '@biomejs/cli-linux-x64@2.4.6':
+    resolution: {integrity: sha512-oHXmUFEoH8Lql1xfc3QkFLiC1hGR7qedv5eKNlC185or+o4/4HiaU7vYODAH3peRCfsuLr1g6v2fK9dFFOYdyw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
 
-  '@biomejs/cli-win32-arm64@2.4.5':
-    resolution: {integrity: sha512-EBfrTqRIWOFSd7CQb/0ttjHMR88zm3hGravnDwUA9wHAaCAYsULKDebWcN5RmrEo1KBtl/gDVJMrFjNR0pdGUw==}
+  '@biomejs/cli-win32-arm64@2.4.6':
+    resolution: {integrity: sha512-xzThn87Pf3YrOGTEODFGONmqXpTwUNxovQb72iaUOdcw8sBSY3+3WD8Hm9IhMYLnPi0n32s3L3NWU6+eSjfqFg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.5':
-    resolution: {integrity: sha512-Pmhv9zT95YzECfjEHNl3mN9Vhusw9VA5KHY0ZvlGsxsjwS5cb7vpRnHzJIv0vG7jB0JI7xEaMH9ddfZm/RozBw==}
+  '@biomejs/cli-win32-x64@2.4.6':
+    resolution: {integrity: sha512-7++XhnsPlr1HDbor5amovPjOH6vsrFOCdp93iKXhFn6bcMUI6soodj3WWKfgEO6JosKU1W5n3uky3WW9RlRjTg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -5609,39 +5609,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@biomejs/biome@2.4.5':
+  '@biomejs/biome@2.4.6':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.5
-      '@biomejs/cli-darwin-x64': 2.4.5
-      '@biomejs/cli-linux-arm64': 2.4.5
-      '@biomejs/cli-linux-arm64-musl': 2.4.5
-      '@biomejs/cli-linux-x64': 2.4.5
-      '@biomejs/cli-linux-x64-musl': 2.4.5
-      '@biomejs/cli-win32-arm64': 2.4.5
-      '@biomejs/cli-win32-x64': 2.4.5
+      '@biomejs/cli-darwin-arm64': 2.4.6
+      '@biomejs/cli-darwin-x64': 2.4.6
+      '@biomejs/cli-linux-arm64': 2.4.6
+      '@biomejs/cli-linux-arm64-musl': 2.4.6
+      '@biomejs/cli-linux-x64': 2.4.6
+      '@biomejs/cli-linux-x64-musl': 2.4.6
+      '@biomejs/cli-win32-arm64': 2.4.6
+      '@biomejs/cli-win32-x64': 2.4.6
 
-  '@biomejs/cli-darwin-arm64@2.4.5':
+  '@biomejs/cli-darwin-arm64@2.4.6':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.5':
+  '@biomejs/cli-darwin-x64@2.4.6':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.5':
+  '@biomejs/cli-linux-arm64-musl@2.4.6':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.5':
+  '@biomejs/cli-linux-arm64@2.4.6':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.5':
+  '@biomejs/cli-linux-x64-musl@2.4.6':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.5':
+  '@biomejs/cli-linux-x64@2.4.6':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.5':
+  '@biomejs/cli-win32-arm64@2.4.6':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.5':
+  '@biomejs/cli-win32-x64@2.4.6':
     optional: true
 
   '@buf/googleapis_googleapis.bufbuild_es@2.10.2-20251126203132-004180b77378.1(@bufbuild/protobuf@2.11.0)':

--- a/frontend/src/bbkit/BBAvatar.vue
+++ b/frontend/src/bbkit/BBAvatar.vue
@@ -77,7 +77,7 @@ const props = withDefaults(
 );
 
 const initials = computed(() => {
-  if (props.username == "?") {
+  if (props.username === "?") {
     return "?";
   }
 

--- a/frontend/src/components/AuditLog/AuditLogSearch/AuditLogSearch.vue
+++ b/frontend/src/components/AuditLog/AuditLogSearch/AuditLogSearch.vue
@@ -151,7 +151,7 @@ const scopeOptions = computed((): ScopeOption[] => {
       title: t("audit-log.advanced-search.scope.level.title"),
       description: t("audit-log.advanced-search.scope.level.description"),
       options: Object.keys(AuditLog_Severity)
-        .filter((v) => isNaN(Number(v)))
+        .filter((v) => Number.isNaN(Number(v)))
         .map((severity) => {
           return {
             value: severity,

--- a/frontend/src/components/EnvironmentForm/Form.vue
+++ b/frontend/src/components/EnvironmentForm/Form.vue
@@ -305,7 +305,7 @@ const renderColorPicker = () => {
           style={{
             backgroundColor: state.value.environment.color || "#4f46e5",
           }}
-        ></div>
+        />
       )}
       onComplete={(color: string) => {
         if (color.toUpperCase() === "#FFFFFF") {

--- a/frontend/src/components/IndexTable.vue
+++ b/frontend/src/components/IndexTable.vue
@@ -84,7 +84,7 @@ const sectionList = computed(() => {
   const sections: { title: string; list: IndexMetadata[] }[] = [];
 
   for (const index of props.indexList) {
-    const item = sections.find((item) => item.title == index.name);
+    const item = sections.find((item) => item.title === index.name);
     if (item) {
       item.list.push(index);
     } else {

--- a/frontend/src/components/InstanceForm/DataSourceSection/DataSourceForm.vue
+++ b/frontend/src/components/InstanceForm/DataSourceSection/DataSourceForm.vue
@@ -1365,7 +1365,7 @@ const secretNameLabel = computed(() => {
 });
 
 const secretKeyLabel = computed(() => {
-  if (state.passwordType == DataSourceExternalSecret_SecretType.VAULT_KV_V2) {
+  if (state.passwordType === DataSourceExternalSecret_SecretType.VAULT_KV_V2) {
     return t("instance.external-secret-vault.vault-secret-key");
   }
   return t("instance.external-secret.key-name");

--- a/frontend/src/components/Member/MemberDataTable/index.vue
+++ b/frontend/src/components/Member/MemberDataTable/index.vue
@@ -111,7 +111,7 @@ const columns = computed(
         hide: !props.allowEdit,
         disabled: (rowData: BindingRowData | UserRoleData) => {
           return (
-            rowData.type == "user" ||
+            rowData.type === "user" ||
             props.selectDisabled((rowData as BindingRowData).data)
           );
         },

--- a/frontend/src/components/Project/Settings/ProjectIssueRelatedSettingPanel.vue
+++ b/frontend/src/components/Project/Settings/ProjectIssueRelatedSettingPanel.vue
@@ -394,7 +394,7 @@ const renderLabel = (value: string, index: number) => {
               <div
                 class="w-4 h-4 rounded-sm cursor-pointer relative"
                 style={{ backgroundColor: label.color }}
-              ></div>
+              />
             )}
             onUpdateValue={(color: string) => (label.color = color)}
           />

--- a/frontend/src/components/ProjectWebhookForm.vue
+++ b/frontend/src/components/ProjectWebhookForm.vue
@@ -476,7 +476,7 @@ const createWebhook = () => {
     const createdWebhook = updatedProject.webhooks.find((wh) => {
       return (
         wh.title === webhook.title &&
-        wh.type == webhook.type &&
+        wh.type === webhook.type &&
         wh.url === webhook.url
       );
     });

--- a/frontend/src/components/SQLReview/components/SQLReviewPolicyDataTable.vue
+++ b/frontend/src/components/SQLReview/components/SQLReviewPolicyDataTable.vue
@@ -55,7 +55,7 @@ const columns = computed(
         width: 200,
         resizable: true,
         render: (review: SQLReviewPolicy) => {
-          return <div innerHTML={highlight(review.name)}></div>;
+          return <div innerHTML={highlight(review.name)} />;
         },
       },
       {

--- a/frontend/src/components/misc/Version.vue
+++ b/frontend/src/components/misc/Version.vue
@@ -118,7 +118,7 @@ const readableCurrentPlan = computed((): string => {
 
 const version = computed(() => {
   const v = actuatorStore.version;
-  if (v.split(".").length == 3) {
+  if (v.split(".").length === 3) {
     return `v${v}`;
   }
   return v;

--- a/frontend/src/components/v2/Form/ResourceIdField.vue
+++ b/frontend/src/components/v2/Form/ResourceIdField.vue
@@ -243,7 +243,7 @@ const escape = (str: string) => {
     .toLowerCase()
     .split("")
     .map((char) => {
-      if (char == " ") return "-";
+      if (char === " ") return "-";
       if (char.match(/\s/)) return "";
       if (characters.includes(char)) return char;
       return randomCharacter(char);

--- a/frontend/src/plugins/cel/logic/resolve.ts
+++ b/frontend/src/plugins/cel/logic/resolve.ts
@@ -206,7 +206,7 @@ const resolveStringExpr = (
   if (!callExpr)
     throw new Error(`Expected callExpr but got ${expr.exprKind?.case}`);
   let operator = callExpr.function as StringOperator;
-  if (negative && operator == "contains") {
+  if (negative && operator === "contains") {
     operator = "@not_contains";
   }
   const factor = getFactorName(callExpr.target!);
@@ -227,7 +227,7 @@ const resolveCollectionExpr = (
   if (!callExpr)
     throw new Error(`Expected callExpr but got ${expr.exprKind?.case}`);
   let operator = callExpr.function as CollectionOperator;
-  if (negative && operator == "@in") {
+  if (negative && operator === "@in") {
     operator = "@not_in";
   }
   const [factorExpr, valuesExpr] = callExpr.args;

--- a/frontend/src/store/modules/notification.ts
+++ b/frontend/src/store/modules/notification.ts
@@ -57,7 +57,7 @@ function findNotification(
   const list = state.notificationByModule.get(filter.module);
   if (list && list.length > 0) {
     if (filter.id) {
-      return list.find((item) => item.id == filter.id);
+      return list.find((item) => item.id === filter.id);
     }
     return list[0];
   }

--- a/frontend/src/store/modules/v1/common.ts
+++ b/frontend/src/store/modules/v1/common.ts
@@ -177,7 +177,7 @@ export const getInstanceAndDatabaseId = (name: string): string[] => {
     databaseNamePrefix,
   ]);
 
-  if (tokens.length != 2) {
+  if (tokens.length !== 2) {
     return ["", ""];
   }
 

--- a/frontend/src/types/v1/instance.ts
+++ b/frontend/src/types/v1/instance.ts
@@ -119,8 +119,8 @@ export const defaultCollationOfEngineV1 = (engine: Engine): string => {
 
 export function isPostgresFamily(type: Engine): boolean {
   return (
-    type == Engine.POSTGRES ||
-    type == Engine.REDSHIFT ||
-    type == Engine.COCKROACHDB
+    type === Engine.POSTGRES ||
+    type === Engine.REDSHIFT ||
+    type === Engine.COCKROACHDB
   );
 }

--- a/frontend/src/utils/idp.ts
+++ b/frontend/src/utils/idp.ts
@@ -8,7 +8,7 @@ export const identityProviderTypeToString = (
     return "OAuth 2.0";
   } else if (type === IdentityProviderType.OIDC) {
     return "OIDC";
-  } else if (type == IdentityProviderType.LDAP) {
+  } else if (type === IdentityProviderType.LDAP) {
     return "LDAP";
   } else {
     throw new Error(`identity provider type ${type} not found`);

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -98,7 +98,7 @@ export function bytesToString(size: number): string {
 
 export function urlfy(str: string): string {
   let result = str.trim();
-  if (result.search(/^http[s]?:\/\//) == -1) {
+  if (result.search(/^http[s]?:\/\//) === -1) {
     result = "http://" + result;
   }
   return result;

--- a/frontend/src/views/EnvironmentDashboard.vue
+++ b/frontend/src/views/EnvironmentDashboard.vue
@@ -284,7 +284,7 @@ const stopReorder = () => {
 
 const orderChanged = computed(() => {
   for (let i = 0; i < state.reorderedEnvironmentList.length; i++) {
-    if (state.reorderedEnvironmentList[i].id != environmentList.value[i].id) {
+    if (state.reorderedEnvironmentList[i].id !== environmentList.value[i].id) {
       return true;
     }
   }

--- a/frontend/src/views/sql-editor/AsidePanel/WorksheetPane/SheetList/SheetTree.vue
+++ b/frontend/src/views/sql-editor/AsidePanel/WorksheetPane/SheetList/SheetTree.vue
@@ -781,7 +781,7 @@ const handleDrop = async ({ node, dragNode }: TreeDropInfo) => {
   if (!oldParentNode) {
     return;
   }
-  if (oldParentNode.key == parentNode.key) {
+  if (oldParentNode.key === parentNode.key) {
     // parent folder not change
     return;
   }

--- a/frontend/src/views/sql-editor/Sheet/folder.ts
+++ b/frontend/src/views/sql-editor/Sheet/folder.ts
@@ -78,7 +78,7 @@ export const useFolderByView = (
       [...localCache.value].filter(
         (value) =>
           !(
-            value == path ||
+            value === path ||
             isSubFolder({ parent: path, path: value, dig: true })
           )
       )


### PR DESCRIPTION
## Summary

- Upgrade `@biomejs/biome` from 2.4.5 to 2.4.6 (bug fixes only)
- Enable 16 new lint rules across correctness, suspicious, style, and nursery categories
- Enable `noUnusedImports` for `.ts`/`.tsx` files only (excluded from `.vue` where Biome can't detect template imports)
- Auto-fixed 19 violations: `==` → `===`, `isNaN` → `Number.isNaN`, and self-closing elements

### New rules

| Category | Rules |
|----------|-------|
| Correctness | `noConstantCondition`, `noSelfAssign`, `noPrecisionLoss`, `noUnsafeOptionalChaining`, `useIsNan`, `useValidForDirection` |
| Suspicious | `noAsyncPromiseExecutor`, `noDoubleEquals`, `noDuplicateCase`, `noGlobalIsNan`, `noSparseArray` |
| Style | `useExportType`, `useSelfClosingElements` |
| Nursery | `noVueArrowFuncInWatch`, `useScopedStyles`, `useVueValidVCloak`, `useVueValidVPre` |
| TS-only | `noUnusedImports` |

## Test plan

- [x] `pnpm --dir frontend check` — clean
- [x] `pnpm --dir frontend type-check` — clean
- [x] `pnpm --dir frontend test` — 789 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)