### PR TITLE
refactor: improve instance creation page with responsive engine selector and docked info panel

### DIFF
--- a/frontend/src/components/InstanceForm/DataSourceSection/DataSourceForm.vue
+++ b/frontend/src/components/InstanceForm/DataSourceSection/DataSourceForm.vue
@@ -213,7 +213,7 @@
       thus we make it REQUIRED here.-->
           <NInput
             v-model:value="dataSource.username"
-            class="mt-2 w-full"
+            class="mt-2 w-full max-w-[48rem]"
             :disabled="!allowEdit"
             :placeholder="
               basicInfo.engine === Engine.CLICKHOUSE ? $t('common.default') : ''
@@ -337,7 +337,7 @@
               <NInput
                 type="password"
                 show-password-on="click"
-                class="w-full"
+                class="w-full max-w-[48rem]"
                 :input-props="{ autocomplete: 'off' }"
                 :placeholder="
                   dataSource.useEmptyPassword

--- a/frontend/src/components/InstanceForm/Form.vue
+++ b/frontend/src/components/InstanceForm/Form.vue
@@ -1,25 +1,74 @@
 <template>
   <div class="flex flex-col gap-y-6 pb-2">
-    <InstanceEngineRadioGrid
-      v-if="isCreating"
-      :engine="basicInfo.engine"
-      :engine-list="supportedEngineV1List()"
-      class="w-full grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 gap-2"
-      @update:engine="(newEngine: Engine) => changeInstanceEngine(newEngine)"
-    >
-      <template #suffix="{ engine }">
-        <NTag
-          v-if="isEngineBeta(engine as Engine)"
-          round
-          size="small"
-          type="info"
+    <div class="w-full flex flex-col gap-y-6">
+      <div
+        v-if="isCreating"
+        class="rounded-lg border border-block-border bg-white"
+      >
+        <button
+          type="button"
+          class="w-full flex items-center justify-between gap-x-3 px-4 py-3 text-left transition-colors hover:bg-gray-50"
+          @click="toggleEngineSelector"
         >
-          Beta
-        </NTag>
-      </template>
-    </InstanceEngineRadioGrid>
+          <div class="min-w-0">
+            <p
+              class="text-[11px] font-medium uppercase tracking-[0.14em] text-control-light"
+            >
+              {{ $t("database.engine") }}
+            </p>
+            <div class="mt-1 flex items-center gap-x-1.5">
+              <RichEngineName
+                :engine="basicInfo.engine"
+                class="text-sm font-medium text-main"
+              />
+              <NTag
+                v-if="isEngineBeta(basicInfo.engine)"
+                round
+                size="small"
+                type="info"
+              >
+                Beta
+              </NTag>
+            </div>
+          </div>
+          <div class="shrink-0 flex items-center gap-x-2 text-control-light">
+            <span class="text-sm">{{ $t("common.edit") }}</span>
+            <ChevronDownIcon
+              v-if="!isEngineSelectorCollapsed"
+              class="w-4 h-4"
+            />
+            <ChevronRightIcon v-else class="w-4 h-4" />
+          </div>
+        </button>
 
-    <div class="max-w-212.5 flex flex-col gap-y-6">
+        <Transition name="engine-selector">
+          <div
+            v-show="!isEngineSelectorCollapsed"
+            class="border-t border-block-border px-4 py-4"
+          >
+            <InstanceEngineRadioGrid
+              :engine="basicInfo.engine"
+              :engine-list="supportedEngineV1List()"
+              class="w-full grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-2"
+              @update:engine="
+                (newEngine: Engine) => handleSelectInstanceEngine(newEngine)
+              "
+            >
+              <template #suffix="{ engine }">
+                <NTag
+                  v-if="isEngineBeta(engine as Engine)"
+                  round
+                  size="small"
+                  type="info"
+                >
+                  Beta
+                </NTag>
+              </template>
+            </InstanceEngineRadioGrid>
+          </div>
+        </Transition>
+      </div>
+
       <!-- Basic Info Card -->
       <div class="border border-block-border rounded-lg p-5">
         <h3 class="text-base font-medium text-main">
@@ -39,7 +88,7 @@
             <NInput
               v-model:value="basicInfo.title"
               required
-              class="mt-1 w-full"
+              class="mt-1 w-full max-w-[40rem]"
               :disabled="!allowEdit"
               :maxlength="200"
             />
@@ -98,7 +147,7 @@
               {{ $t("common.environment") }}
             </label>
             <EnvironmentSelect
-              class="mt-1 w-full"
+              class="mt-1 w-full max-w-[40rem]"
               required="true"
               :value="
                 isValidEnvironmentName(
@@ -515,7 +564,7 @@
 <script setup lang="ts">
 import { create } from "@bufbuild/protobuf";
 import type { Duration } from "@bufbuild/protobuf/wkt";
-import { TrashIcon } from "lucide-vue-next";
+import { ChevronDownIcon, ChevronRightIcon, TrashIcon } from "lucide-vue-next";
 import {
   NButton,
   NCheckbox,
@@ -535,6 +584,7 @@ import {
   InstanceEngineRadioGrid,
   InstanceV1EngineIcon,
   MiniActionButton,
+  RichEngineName,
 } from "@/components/v2";
 import ResourceIdField from "@/components/v2/Form/ResourceIdField.vue";
 import {
@@ -623,6 +673,7 @@ const instanceV1Store = useInstanceV1Store();
 const actuatorStore = useActuatorV1Store();
 const subscriptionStore = useSubscriptionV1Store();
 const scanIntervalInputRef = ref<InstanceType<typeof ScanIntervalInput>>();
+const isEngineSelectorCollapsed = ref(false);
 
 const availableLicenseCount = computed(() => {
   return Math.max(
@@ -731,6 +782,15 @@ const changeInstanceEngine = (engine: Engine) => {
   basicInfo.value.engine = engine;
 };
 
+const handleSelectInstanceEngine = (engine: Engine) => {
+  changeInstanceEngine(engine);
+  isEngineSelectorCollapsed.value = true;
+};
+
+const toggleEngineSelector = () => {
+  isEngineSelectorCollapsed.value = !isEngineSelectorCollapsed.value;
+};
+
 const handleChangeSyncDatabases = (databases: string[]) => {
   basicInfo.value.syncDatabases = [...databases];
 };
@@ -825,8 +885,23 @@ const handleSelectEnvironment = (name: string | undefined) => {
 </script>
 
 <style lang="postcss" scoped>
-.instance-engine-button :deep(.n-button__content) {
-  width: 100%;
-  justify-content: flex-start;
+.engine-selector-enter-active,
+.engine-selector-leave-active {
+  overflow: hidden;
+  transition: max-height 0.2s ease, opacity 0.2s ease, transform 0.2s ease;
+}
+
+.engine-selector-enter-from,
+.engine-selector-leave-to {
+  max-height: 0;
+  opacity: 0;
+  transform: translateY(-0.25rem);
+}
+
+.engine-selector-enter-to,
+.engine-selector-leave-from {
+  max-height: 32rem;
+  opacity: 1;
+  transform: translateY(0);
 }
 </style>

--- a/frontend/src/components/InstanceForm/InfoPanel.vue
+++ b/frontend/src/components/InstanceForm/InfoPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <Teleport to="body">
+  <Teleport v-if="mode === 'overlay'" to="body">
     <Transition name="info-panel">
       <div
         v-if="visible"
@@ -9,7 +9,6 @@
         <div
           class="w-80 bg-white border-l border-block-border shadow-lg flex flex-col h-full"
         >
-          <!-- Sticky header -->
           <div
             class="sticky top-0 z-10 flex items-center justify-between px-4 py-3 border-b border-block-border bg-white"
           >
@@ -23,7 +22,6 @@
               <XIcon class="w-4 h-4" />
             </button>
           </div>
-          <!-- Scrollable content -->
           <div class="flex-1 overflow-y-auto px-4 py-4">
             <slot />
           </div>
@@ -31,18 +29,58 @@
       </div>
     </Transition>
   </Teleport>
+
+  <Transition
+    v-else
+    name="info-rail"
+    @before-leave="$emit('before-leave')"
+    @after-leave="$emit('after-leave')"
+  >
+    <aside
+      v-if="visible"
+      data-info-panel-docked="true"
+      class="h-full w-full min-w-0 overflow-hidden border-l border-block-border bg-white"
+    >
+      <div class="flex h-full flex-col">
+        <div
+          class="sticky top-0 z-10 flex items-center justify-between border-b border-block-border bg-white px-5 py-3"
+        >
+          <h3 class="min-w-0 truncate text-sm font-semibold text-main">
+            {{ title }}
+          </h3>
+          <button
+            class="text-control-light hover:text-main p-0.5 rounded"
+            @click="$emit('close')"
+          >
+            <XIcon class="w-4 h-4" />
+          </button>
+        </div>
+        <div class="flex-1 overflow-y-auto px-5 py-5">
+          <slot />
+        </div>
+      </div>
+    </aside>
+  </Transition>
 </template>
 
 <script lang="ts" setup>
 import { XIcon } from "lucide-vue-next";
 
-defineProps<{
-  visible: boolean;
-  title: string;
-}>();
+withDefaults(
+  defineProps<{
+    visible: boolean;
+    title: string;
+    mode?: "overlay" | "docked";
+  }>(),
+  {
+    mode: "overlay",
+  }
+);
 
 defineEmits<{
   close: [];
+  "before-leave": [];
+  "after-leave": [];
 }>();
 </script>
 
@@ -58,5 +96,20 @@ defineEmits<{
 .info-panel-enter-from > div,
 .info-panel-leave-to > div {
   transform: translateX(100%);
+}
+
+.info-rail-enter-active,
+.info-rail-leave-active {
+  transition: opacity 0.14s ease, transform 0.14s ease;
+}
+
+.info-rail-enter-from {
+  opacity: 0;
+  transform: translateX(0.75rem);
+}
+
+.info-rail-leave-to {
+  opacity: 0;
+  transform: translateX(0);
 }
 </style>

--- a/frontend/src/components/v2/Form/RadioGrid.vue
+++ b/frontend/src/components/v2/Form/RadioGrid.vue
@@ -11,7 +11,7 @@
       v-bind="buttonProps ? buttonProps(option.value, index) : undefined"
       @click="$emit('update:value', option.value)"
     >
-      <div class="flex flex-row items-center gap-x-2">
+      <div class="flex flex-row items-center gap-x-2 min-w-0">
         <NRadio
           :checked="value === option.value"
           :disabled="disabled"

--- a/frontend/src/components/v2/Model/Instance/InstanceEngineRadioGrid.vue
+++ b/frontend/src/components/v2/Model/Instance/InstanceEngineRadioGrid.vue
@@ -5,11 +5,11 @@
     @update:value="$emit('update:engine', $event as Engine)"
   >
     <template #item="{ option }">
-      <div class="flex flex-row items-center gap-x-1">
+      <div class="flex flex-row items-center gap-x-1 min-w-0" :title="option.label">
         <RichEngineName
           :engine="option.value as Engine"
           tag="p"
-          class="text-center text-sm text-main!"
+          class="text-center text-sm text-main! min-w-0 truncate"
         />
         <slot name="suffix" :engine="option.value" />
       </div>

--- a/frontend/src/views/CreateInstancePage.vue
+++ b/frontend/src/views/CreateInstancePage.vue
@@ -1,28 +1,53 @@
 <template>
-  <div class="flex flex-col h-full">
-    <InstanceForm @dismiss="goBack">
-      <!-- Header -->
-      <div
-        class="sticky top-0 z-10 bg-white border-b border-block-border px-6 py-4"
+  <div class="h-full overflow-hidden px-4 sm:px-6">
+    <div
+      ref="createInstanceLayoutRef"
+      class="grid h-full w-full min-h-0 min-w-0"
+      :style="createInstanceLayoutStyle"
+      @click.capture="handleDockedInfoPanelOutsideClick"
+    >
+      <div class="min-w-0 min-h-0 flex-1 flex flex-col">
+        <InstanceForm @dismiss="goBack">
+          <!-- Header -->
+          <div
+            class="sticky top-0 z-10 bg-white border-b border-block-border py-4"
+          >
+            <h1 class="text-lg font-medium">
+              {{ $t("quick-action.add-instance") }}
+            </h1>
+          </div>
+
+          <!-- Body -->
+          <div class="flex-1 min-h-0 overflow-auto py-4">
+            <InstanceFormBody />
+          </div>
+
+          <!-- Sticky footer -->
+          <div class="sticky bottom-0 z-10 bg-white">
+            <InstanceFormButtons />
+          </div>
+        </InstanceForm>
+      </div>
+
+      <InfoPanel
+        :visible="showDockedInfoPanel"
+        mode="docked"
+        :title="infoPanelTitle"
+        @before-leave="handleDockedInfoPanelBeforeLeave"
+        @after-leave="handleDockedInfoPanelAfterLeave"
+        @close="activeInfoSection = undefined"
       >
-        <h1 class="text-lg font-medium">
-          {{ $t("quick-action.add-instance") }}
-        </h1>
-      </div>
-
-      <!-- Body -->
-      <div class="flex-1 overflow-auto px-6 py-4">
-        <InstanceFormBody />
-      </div>
-
-      <!-- Sticky footer -->
-      <div class="sticky bottom-0 z-10 bg-white px-6">
-        <InstanceFormButtons />
-      </div>
-    </InstanceForm>
+        <InfoPanelContent
+          v-if="activeInfoSection"
+          :engine="currentEngine"
+          :section="activeInfoSection"
+        />
+      </InfoPanel>
+    </div>
 
     <InfoPanel
-      :visible="!!activeInfoSection"
+      :visible="showOverlayInfoPanel"
+      mode="overlay"
       :title="infoPanelTitle"
       @close="activeInfoSection = undefined"
     >
@@ -36,6 +61,7 @@
 </template>
 
 <script lang="ts" setup>
+import { useElementSize } from "@vueuse/core";
 import { computed, onMounted, provide, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
@@ -60,8 +86,69 @@ const router = useRouter();
 const subscriptionStore = useSubscriptionV1Store();
 const actuatorStore = useActuatorV1Store();
 
+const MIN_DOCKED_MAIN_WIDTH = 700;
+const DOCKED_INFO_RAIL_WIDTH = 320;
+const DOCKED_INFO_RAIL_GAP = 16;
+const MIN_DOCKED_LAYOUT_WIDTH =
+  MIN_DOCKED_MAIN_WIDTH + DOCKED_INFO_RAIL_WIDTH + DOCKED_INFO_RAIL_GAP;
+
 const activeInfoSection = ref<InfoSection | undefined>();
 const currentEngine = ref<Engine>(Engine.MYSQL);
+const isDockedInfoPanelLeaving = ref(false);
+const createInstanceLayoutRef = ref<HTMLElement>();
+const { width: createInstanceLayoutWidth } = useElementSize(
+  createInstanceLayoutRef
+);
+const canUseDockedInfoLayout = computed(
+  () => createInstanceLayoutWidth.value >= MIN_DOCKED_LAYOUT_WIDTH
+);
+const showDockedInfoPanel = computed(
+  () => !!activeInfoSection.value && canUseDockedInfoLayout.value
+);
+const showOverlayInfoPanel = computed(
+  () => !!activeInfoSection.value && !canUseDockedInfoLayout.value
+);
+const keepDockedLayout = computed(
+  () => showDockedInfoPanel.value || isDockedInfoPanelLeaving.value
+);
+const createInstanceLayoutStyle = computed(() => {
+  if (!canUseDockedInfoLayout.value || !keepDockedLayout.value) {
+    return {
+      gridTemplateColumns: "minmax(0, 1fr)",
+      columnGap: "0rem",
+    };
+  }
+
+  return {
+    gridTemplateColumns: `minmax(${MIN_DOCKED_MAIN_WIDTH}px, 1fr) ${DOCKED_INFO_RAIL_WIDTH}px`,
+    columnGap: `${DOCKED_INFO_RAIL_GAP}px`,
+  };
+});
+
+const handleDockedInfoPanelBeforeLeave = () => {
+  isDockedInfoPanelLeaving.value = true;
+};
+
+const handleDockedInfoPanelAfterLeave = () => {
+  isDockedInfoPanelLeaving.value = false;
+};
+
+const handleDockedInfoPanelOutsideClick = (event: MouseEvent) => {
+  if (!showDockedInfoPanel.value) {
+    return;
+  }
+
+  const target = event.target;
+  if (!(target instanceof Element)) {
+    return;
+  }
+
+  if (target.closest("[data-info-panel-docked='true']")) {
+    return;
+  }
+
+  activeInfoSection.value = undefined;
+};
 
 const infoPanelTitle = computed(() => {
   if (!activeInfoSection.value) return "";


### PR DESCRIPTION
## Summary

- Replace viewport-based grid breakpoints with `auto-fit` + `minmax(170px, 1fr)` so the engine selector adapts to actual container width instead of viewport width — fixes overflow when sidebar reduces available space
- Add collapsible engine selector panel that auto-collapses on selection, with animated transitions
- Add docked info panel mode on wide screens (container-width-based), falling back to overlay on narrower screens
- Cap form field widths (`max-w-[40rem]` for name/environment, `max-w-[48rem]` for credentials) to prevent stretching on wide displays
- Add `min-w-0` + local `truncate` on engine labels for graceful overflow handling with title tooltip fallback

## Test plan

- [ ] Navigate to Instances > Add Instance
- [ ] Resize browser window narrower/wider — engine grid should reflow columns without horizontal overflow
- [ ] Select an engine — panel should collapse with animation, showing selected engine in header
- [ ] Click header to re-expand engine selector
- [ ] On wide screen (>1036px container), click an info trigger (e.g. connection info) — info panel should dock to the right
- [ ] On narrower screen, info trigger should show overlay panel instead
- [ ] Verify form fields (Instance Name, Environment, username, password) don't stretch excessively on wide screens
- [ ] Verify long engine names like "OceanBase (MySQL Mode)" truncate with ellipsis and show full name on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)