### PR TITLE
fix: show detailed reasons in batch issue close/reopen tooltips

### DIFF
--- a/frontend/src/components/IssueV1/components/BatchIssueActionsV1.vue
+++ b/frontend/src/components/IssueV1/components/BatchIssueActionsV1.vue
@@ -15,6 +15,7 @@
           })
         }}
       </div>
+      <ErrorList :errors="closeErrors" :bullets="'always'" />
     </template>
   </TooltipButton>
 
@@ -32,6 +33,7 @@
           })
         }}
       </div>
+      <ErrorList :errors="reopenErrors" :bullets="'always'" />
     </template>
   </TooltipButton>
 
@@ -47,9 +49,12 @@
 <script lang="ts" setup>
 import type { PropType } from "vue";
 import { computed, reactive, ref } from "vue";
+import { useI18n } from "vue-i18n";
+import ErrorList from "@/components/misc/ErrorList.vue";
 import { TooltipButton } from "@/components/v2";
 import { refreshIssueList } from "@/store";
 import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
+import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import { BatchIssueStatusActionPanel } from "./Panel";
 import type { IssueStatusAction } from "./Panel/issueStatusAction";
 import {
@@ -89,6 +94,40 @@ const isActionApplicableForAllIssues = (action: IssueStatusAction): boolean => {
     return actions.includes(action);
   });
 };
+
+const { t } = useI18n();
+
+const issueStatuses = computed(() => {
+  const statuses = new Set<IssueStatus>();
+  for (const issue of props.issueList) {
+    statuses.add(issue.status);
+  }
+  return statuses;
+});
+
+const closeErrors = computed(() => {
+  const errors: string[] = [];
+  const statuses = issueStatuses.value;
+  if (statuses.has(IssueStatus.DONE)) {
+    errors.push(t("issue.batch-transition.done-cannot-close"));
+  }
+  if (statuses.has(IssueStatus.CANCELED)) {
+    errors.push(t("issue.batch-transition.canceled-cannot-close"));
+  }
+  return errors;
+});
+
+const reopenErrors = computed(() => {
+  const errors: string[] = [];
+  const statuses = issueStatuses.value;
+  if (statuses.has(IssueStatus.OPEN)) {
+    errors.push(t("issue.batch-transition.open-cannot-reopen"));
+  }
+  if (statuses.has(IssueStatus.DONE)) {
+    errors.push(t("issue.batch-transition.done-cannot-reopen"));
+  }
+  return errors;
+});
 
 const handleUpdated = () => {
   state.isRequesting = false;

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1089,6 +1089,10 @@
     },
     "batch-transition": {
       "not-allowed-tips": "Some of selected issues cannot be {operation}",
+      "open-cannot-reopen": "Open issues cannot be reopened",
+      "done-cannot-reopen": "Done issues cannot be reopened",
+      "done-cannot-close": "Done issues cannot be closed",
+      "canceled-cannot-close": "Canceled issues cannot be closed",
       "reopen": "Reopen",
       "reopened": "reopened",
       "action-n-issues": "{action} {n} issue | {action} {n} issues",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1089,6 +1089,10 @@
     },
     "batch-transition": {
       "not-allowed-tips": "Algunos de las incidencias seleccionadas no se pueden {operation}",
+      "open-cannot-reopen": "Open issues cannot be reopened",
+      "done-cannot-reopen": "Done issues cannot be reopened",
+      "done-cannot-close": "Done issues cannot be closed",
+      "canceled-cannot-close": "Canceled issues cannot be closed",
       "reopen": "Reabrir",
       "reopened": "reabierto",
       "action-n-issues": "{action} {n} incidencia | {action} {n} incidencias",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1089,6 +1089,10 @@
     },
     "batch-transition": {
       "not-allowed-tips": "選択したイシューの一部を {operation} にすることはできません",
+      "open-cannot-reopen": "Open issues cannot be reopened",
+      "done-cannot-reopen": "Done issues cannot be reopened",
+      "done-cannot-close": "Done issues cannot be closed",
+      "canceled-cannot-close": "Canceled issues cannot be closed",
       "reopen": "再開",
       "reopened": "再開",
       "action-n-issues": "{action} {n} 個のイシュー",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1089,6 +1089,10 @@
     },
     "batch-transition": {
       "not-allowed-tips": "Một số vấn đề đã chọn không thể {operation}",
+      "open-cannot-reopen": "Open issues cannot be reopened",
+      "done-cannot-reopen": "Done issues cannot be reopened",
+      "done-cannot-close": "Done issues cannot be closed",
+      "canceled-cannot-close": "Canceled issues cannot be closed",
       "reopen": "Mở lại",
       "reopened": "đã mở lại",
       "action-n-issues": "{action} {n} vấn đề | {action} {n} vấn đề",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1089,6 +1089,10 @@
     },
     "batch-transition": {
       "not-allowed-tips": "部分选中的工单无法被{operation}",
+      "open-cannot-reopen": "打开中的工单无法重开",
+      "done-cannot-reopen": "已完成的工单无法重开",
+      "done-cannot-close": "已完成的工单无法关闭",
+      "canceled-cannot-close": "已取消的工单无法关闭",
       "reopen": "重开",
       "reopened": "重开",
       "action-n-issues": "{action} {n} 个工单",


### PR DESCRIPTION
## Summary
- Show specific disabled reasons (e.g. "Done issues cannot be reopened") in batch close/reopen button tooltips, in addition to the generic message
- Uses `ErrorList` component for consistent error display with bullet points
- Collects issue statuses in a single pass via a shared computed for efficiency

Resolves BYT-8997

## Test plan
- [ ] Select a mix of Open + Done issues → verify Reopen tooltip shows both "Open issues cannot be reopened" and "Done issues cannot be reopened"
- [ ] Select Done issues → verify Close tooltip shows "Done issues cannot be closed"
- [ ] Select Canceled issues → verify Close tooltip shows "Canceled issues cannot be closed"
- [ ] Select only Canceled issues → verify Reopen button is enabled with no tooltip

<img width="838" height="354" alt="image" src="https://github.com/user-attachments/assets/468120f5-1d42-4293-a5f5-e9421c470f15" />
