### PR TITLE
chore: update default AI models to modern versions

### DIFF
--- a/frontend/src/components/GeneralSetting/AIAugmentationSetting.vue
+++ b/frontend/src/components/GeneralSetting/AIAugmentationSetting.vue
@@ -296,7 +296,7 @@ const providerDefault = computed(() => {
         apiKey: "",
         apiKeyDoc: "https://platform.openai.com/account/api-keys",
         endpoint: "https://api.openai.com/v1/chat/completions",
-        model: "gpt-3.5-turbo",
+        model: "gpt-4o",
       };
     case AISetting_Provider.AZURE_OPENAI:
       return {
@@ -311,14 +311,14 @@ const providerDefault = computed(() => {
         apiKey: "",
         apiKeyDoc: "https://ai.google.dev/gemini-api/docs",
         endpoint: "https://generativelanguage.googleapis.com/v1beta",
-        model: "gemini-2.0-flash",
+        model: "gemini-2.5-flash",
       };
     case AISetting_Provider.CLAUDE:
       return {
         apiKey: "",
         apiKeyDoc: "https://docs.anthropic.com/en/api/getting-started",
         endpoint: "https://api.anthropic.com/v1/messages",
-        model: "claude-3-opus-20240229",
+        model: "claude-sonnet-4-20250514",
       };
     default:
       return {


### PR DESCRIPTION
## Summary

Update the default AI model placeholders in the settings UI to current-generation models:

| Provider | Before | After |
|---|---|---|
| **OpenAI** | `gpt-3.5-turbo` | `gpt-4o` |
| **Gemini** | `gemini-2.0-flash` | `gemini-2.5-flash` |
| **Claude** | `claude-3-opus-20240229` | `claude-sonnet-4-20250514` |
| Azure OpenAI | `gpt-4o` | *(already current)* |

These are the default values shown as placeholders when a user first enables AI or switches providers. Existing user configurations stored in the database are unaffected.

## Why

- `gpt-3.5-turbo` is outdated; `gpt-4o` is the current recommended default from OpenAI
- `gemini-2.0-flash` is being retired on June 1, 2026; `gemini-2.5-flash` is the latest stable GA model
- `claude-3-opus` is a legacy model; `claude-sonnet-4` is the latest Anthropic model

## Testing

- `pnpm --dir frontend check` — passed
- `pnpm --dir frontend type-check` — passed
