### PR TITLE
fix(frontend): force 2-column engine selector grid on mobile

### DIFF
--- a/frontend/src/components/InstanceForm/Form.vue
+++ b/frontend/src/components/InstanceForm/Form.vue
@@ -48,7 +48,7 @@
             <InstanceEngineRadioGrid
               :engine="basicInfo.engine"
               :engine-list="supportedEngineV1List()"
-              class="w-full grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-2"
+              class="w-full grid-cols-2 sm:grid-cols-[repeat(auto-fit,minmax(170px,1fr))] gap-2"
               @update:engine="
                 (newEngine: Engine) => handleSelectInstanceEngine(newEngine)
               "


### PR DESCRIPTION
## Summary
- On narrow viewports (<640px), the engine selector's `auto-fit minmax(170px)` grid collapsed to a single column, making the 24-engine list excessively long on mobile
- Forces `grid-cols-2` as the mobile default, preserving the existing `auto-fit` behavior on `sm` (640px+) screens

## Before / After (iPhone 12 Pro, 390px)
**Before**: 1 engine per row — excessively long vertical list  
**After**: 2 engines per row — compact, scannable grid

## Test plan
- [ ] Open `/instances/new` on a mobile viewport (390px width)
- [ ] Verify engine selector shows 2 columns
- [ ] Verify longer names (e.g. "OceanBase (MySQL)") truncate gracefully
- [ ] Verify desktop/tablet viewports are unchanged (auto-fit still applies at 640px+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)