### PR TITLE
fix(pg): add ORDER BY to getTriggers() for deterministic schema dump output

### DIFF
--- a/backend/plugin/db/pg/sync.go
+++ b/backend/plugin/db/pg/sync.go
@@ -1411,7 +1411,8 @@ func getTriggers(txn *sql.Tx, extensionDepend map[int]bool) (map[db.TableKey][]*
 	FROM pg_trigger as pt
 		LEFT JOIN pg_class as pc ON pc.oid = pt.tgrelid
 		LEFT JOIN pg_namespace as pn ON pn.oid = pc.relnamespace
-	WHERE pn.nspname NOT IN (%s) AND pt.tgisinternal = false;`
+	WHERE pn.nspname NOT IN (%s) AND pt.tgisinternal = false
+	ORDER BY pn.nspname, pc.relname, pt.tgname;`
 	rows, err := txn.Query(fmt.Sprintf(query, pgparser.SystemSchemaWhereClause))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

The `getTriggers()` SQL query in `backend/plugin/db/pg/sync.go` was missing an `ORDER BY` clause, unlike every other metadata-fetching query in the file. This caused non-deterministic ordering of `CREATE TRIGGER` statements in schema dumps, leading to spurious diffs between runs.

## Changes

Add `ORDER BY pn.nspname, pc.relname, pt.tgname` to the trigger query, matching the pattern used by other queries in the same file:
- Constraints: `ORDER BY nsp.nspname, rel.relname, con.conname`
- Indexes: `ORDER BY n.nspname, t.relname, i.relname`
- Rules: `ORDER BY schema_name, table_name, rule_name`
- Event triggers: `ORDER BY et.evtname`

## Testing

- `golangci-lint run --allow-parallel-runners` — 0 issues

Close BYT-8998