### PR TITLE
fix: validate semantic types in database catalog updates

### DIFF
--- a/backend/api/v1/database_catalog_service.go
+++ b/backend/api/v1/database_catalog_service.go
@@ -101,7 +101,15 @@ func (s *DatabaseCatalogService) UpdateDatabaseCatalog(ctx context.Context, req 
 
 	databaseConfig := convertDatabaseCatalog(req.Msg.GetCatalog())
 
+	semanticTypesSetting, err := s.store.GetSemanticTypesSetting(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get semantic types setting"))
+	}
+
 	if err := validateCatalogSchemaNames(databaseConfig, dbMetadata.GetProto()); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	if err := validateCatalogSemanticTypeIDs(databaseConfig, semanticTypesSetting); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
 
@@ -218,6 +226,79 @@ func validateCatalogSchemaNames(config *storepb.DatabaseConfig, metadata *storep
 		return nil
 	}
 	return errors.Errorf("schema name must not be empty for database %v", strings.TrimSuffix(config.Name, common.CatalogSuffix))
+}
+
+func validateCatalogSemanticTypeIDs(config *storepb.DatabaseConfig, setting *storepb.SemanticTypeSetting) error {
+	if config == nil {
+		return nil
+	}
+
+	validSemanticTypeIDs := make(map[string]bool)
+	for _, semanticType := range setting.GetTypes() {
+		validSemanticTypeIDs[semanticType.Id] = true
+	}
+
+	for _, schema := range config.GetSchemas() {
+		for _, table := range schema.GetTables() {
+			if err := validateTableCatalogSemanticTypeIDs(table, validSemanticTypeIDs); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateTableCatalogSemanticTypeIDs(table *storepb.TableCatalog, validSemanticTypeIDs map[string]bool) error {
+	if table == nil {
+		return nil
+	}
+	for _, column := range table.GetColumns() {
+		if err := validateColumnCatalogSemanticTypeIDs(column, validSemanticTypeIDs); err != nil {
+			return err
+		}
+	}
+	return validateObjectSchemaSemanticTypeIDs(table.GetObjectSchema(), validSemanticTypeIDs)
+}
+
+func validateColumnCatalogSemanticTypeIDs(column *storepb.ColumnCatalog, validSemanticTypeIDs map[string]bool) error {
+	if column == nil {
+		return nil
+	}
+	if err := validateSemanticTypeID(column.SemanticType, validSemanticTypeIDs); err != nil {
+		return errors.Wrapf(err, "invalid semantic type for column %q", column.Name)
+	}
+	if err := validateObjectSchemaSemanticTypeIDs(column.GetObjectSchema(), validSemanticTypeIDs); err != nil {
+		return errors.Wrapf(err, "invalid object schema for column %q", column.Name)
+	}
+	return nil
+}
+
+func validateObjectSchemaSemanticTypeIDs(objectSchema *storepb.ObjectSchema, validSemanticTypeIDs map[string]bool) error {
+	if objectSchema == nil {
+		return nil
+	}
+	if err := validateSemanticTypeID(objectSchema.SemanticType, validSemanticTypeIDs); err != nil {
+		return err
+	}
+	for name, property := range objectSchema.GetStructKind().GetProperties() {
+		if err := validateObjectSchemaSemanticTypeIDs(property, validSemanticTypeIDs); err != nil {
+			return errors.Wrapf(err, "invalid semantic type for object property %q", name)
+		}
+	}
+	if err := validateObjectSchemaSemanticTypeIDs(objectSchema.GetArrayKind().GetKind(), validSemanticTypeIDs); err != nil {
+		return errors.Wrap(err, "invalid semantic type for array element")
+	}
+	return nil
+}
+
+func validateSemanticTypeID(semanticTypeID string, validSemanticTypeIDs map[string]bool) error {
+	if semanticTypeID == "" {
+		return nil
+	}
+	if validSemanticTypeIDs[semanticTypeID] {
+		return nil
+	}
+	return errors.Errorf("semantic type id %q not found", semanticTypeID)
 }
 
 func hasEmptySchemaName[T interface{ GetName() string }](schemas []T) bool {

--- a/backend/api/v1/database_catalog_service_test.go
+++ b/backend/api/v1/database_catalog_service_test.go
@@ -70,3 +70,96 @@ func TestValidateCatalogSchemaNames(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateCatalogSemanticTypeIDs(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *storepb.DatabaseConfig
+		setting *storepb.SemanticTypeSetting
+		wantErr string
+	}{
+		{
+			name: "empty semantic type allowed",
+			config: &storepb.DatabaseConfig{
+				Schemas: []*storepb.SchemaCatalog{{
+					Name: "public",
+					Tables: []*storepb.TableCatalog{{
+						Name:    "users",
+						Columns: []*storepb.ColumnCatalog{{Name: "email"}},
+					}},
+				}},
+			},
+			setting: &storepb.SemanticTypeSetting{},
+		},
+		{
+			name: "known column semantic type passes",
+			config: &storepb.DatabaseConfig{
+				Schemas: []*storepb.SchemaCatalog{{
+					Name: "public",
+					Tables: []*storepb.TableCatalog{{
+						Name:    "users",
+						Columns: []*storepb.ColumnCatalog{{Name: "email", SemanticType: "email"}},
+					}},
+				}},
+			},
+			setting: &storepb.SemanticTypeSetting{
+				Types: []*storepb.SemanticTypeSetting_SemanticType{{Id: "email"}},
+			},
+		},
+		{
+			name: "unknown column semantic type rejected",
+			config: &storepb.DatabaseConfig{
+				Schemas: []*storepb.SchemaCatalog{{
+					Name: "public",
+					Tables: []*storepb.TableCatalog{{
+						Name:    "users",
+						Columns: []*storepb.ColumnCatalog{{Name: "email", SemanticType: "missing"}},
+					}},
+				}},
+			},
+			setting: &storepb.SemanticTypeSetting{
+				Types: []*storepb.SemanticTypeSetting_SemanticType{{Id: "email"}},
+			},
+			wantErr: "invalid semantic type for column \"email\": semantic type id \"missing\" not found",
+		},
+		{
+			name: "nested object semantic type rejected",
+			config: &storepb.DatabaseConfig{
+				Schemas: []*storepb.SchemaCatalog{{
+					Name: "public",
+					Tables: []*storepb.TableCatalog{{
+						Name: "events",
+						Columns: []*storepb.ColumnCatalog{{
+							Name: "payload",
+							ObjectSchema: &storepb.ObjectSchema{
+								Type: storepb.ObjectSchema_OBJECT,
+								Kind: &storepb.ObjectSchema_StructKind_{
+									StructKind: &storepb.ObjectSchema_StructKind{
+										Properties: map[string]*storepb.ObjectSchema{
+											"email": {Type: storepb.ObjectSchema_STRING, SemanticType: "missing"},
+										},
+									},
+								},
+							},
+						}},
+					}},
+				}},
+			},
+			setting: &storepb.SemanticTypeSetting{
+				Types: []*storepb.SemanticTypeSetting_SemanticType{{Id: "email"}},
+			},
+			wantErr: "invalid object schema for column \"payload\": invalid semantic type for object property \"email\": semantic type id \"missing\" not found",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCatalogSemanticTypeIDs(tc.config, tc.setting)
+			if tc.wantErr != "" {
+				require.EqualError(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- validate semantic type IDs in `UpdateDatabaseCatalog` before saving catalog metadata
- reject unknown semantic types on columns, table object schemas, and nested object schema members
- add unit tests covering accepted and rejected semantic type references

## Testing
- go test -count=1 ./backend/api/v1 -run '^(TestValidateCatalogSchemaNames|TestValidateCatalogSemanticTypeIDs)$'
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- go test -count=1 ./backend/api/v1
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
