### PR TITLE
fix: use trigger slot for project label color picker

### DIFF
--- a/frontend/src/components/Project/Settings/ProjectIssueRelatedSettingPanel.vue
+++ b/frontend/src/components/Project/Settings/ProjectIssueRelatedSettingPanel.vue
@@ -263,7 +263,7 @@ import {
   NTag,
   NTooltip,
 } from "naive-ui";
-import { computed, reactive, ref } from "vue";
+import { type ComponentPublicInstance, computed, reactive, ref } from "vue";
 import { Switch } from "@/components/v2";
 import { useProjectV1Store } from "@/store";
 import type {
@@ -397,7 +397,7 @@ const renderLabel = (value: string, index: number) => {
             }: {
               value: string | null;
               onClick: () => void;
-              ref: (el: HTMLElement | null) => void;
+              ref: (el: Element | ComponentPublicInstance | null) => void;
             }) => (
               <div
                 ref={triggerRef}


### PR DESCRIPTION
## Summary
- Replace `renderLabel` prop with `#trigger` slot (via `v-slots` in JSX) for the `NColorPicker` in project issue label settings
- Follows the naive-ui recommended pattern for custom color picker triggers

## Test plan
- [ ] Go to Project Settings > Issue Related
- [ ] Verify label color swatches render as proper colored squares
- [ ] Click a color swatch and verify the picker opens
- [ ] Select a color and verify it updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)