### PR TITLE
fix: drop legacy worksheet organizer FK during 3.17.3 migration

### DIFF
--- a/backend/migrator/migration/3.17/0003##worksheet_composite_pk.sql
+++ b/backend/migrator/migration/3.17/0003##worksheet_composite_pk.sql
@@ -1,7 +1,9 @@
 -- Phase A: Drop old FKs and PKs
+ALTER TABLE worksheet_organizer DROP CONSTRAINT IF EXISTS sheet_organizer_sheet_id_fkey;
 ALTER TABLE worksheet_organizer DROP CONSTRAINT IF EXISTS worksheet_organizer_worksheet_id_fkey;
 ALTER TABLE worksheet_organizer DROP CONSTRAINT IF EXISTS worksheet_organizer_worksheet_fkey;
 ALTER TABLE worksheet_organizer DROP CONSTRAINT IF EXISTS worksheet_organizer_pkey;
+ALTER TABLE worksheet_organizer DROP CONSTRAINT IF EXISTS sheet_organizer_pkey;
 DROP INDEX IF EXISTS idx_worksheet_unique_resource_id;
 
 -- Phase B: Change worksheet PK to resource_id


### PR DESCRIPTION
## Summary
- drop the legacy `sheet_organizer_sheet_id_fkey` before switching `worksheet` primary key to `resource_id`
- keep the existing drops for `worksheet_organizer_*` and `sheet_organizer_pkey`

## Validation
- ran `backend/migrator/migration/3.17/0003##worksheet_composite_pk.sql` against `postgresql://bbdev@127.0.0.1:5983/bbdev` inside a transaction
- confirmed the migration no longer fails on the legacy `sheet_organizer_sheet_id_fkey` dependency