### PR TITLE
fix: rename query_history project column before adding project FK

### DIFF
--- a/backend/migrator/migration/3.17/0007##fix_project_fk_references.sql
+++ b/backend/migrator/migration/3.17/0007##fix_project_fk_references.sql
@@ -5,17 +5,18 @@ DO $$
 DECLARE
     t text;
 BEGIN
-    -- Add direct project FK to tables that only had composite FKs.
-    FOREACH t IN ARRAY ARRAY['plan_check_run', 'plan_webhook_delivery', 'task_run', 'task_run_log', 'issue_comment', 'query_history'] LOOP
-        IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = t || '_project_fkey') THEN
-            EXECUTE format('ALTER TABLE %I ADD CONSTRAINT %I FOREIGN KEY (project) REFERENCES project(resource_id)', t, t || '_project_fkey');
-        END IF;
-    END LOOP;
-
-    -- Rename query_history.project_id to project.
+    -- Rename query_history.project_id to project before adding the FK.
     IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'query_history' AND column_name = 'project_id') THEN
         ALTER TABLE query_history RENAME COLUMN project_id TO project;
     END IF;
+
+    -- Add direct project FK to tables that only had composite FKs.
+    FOREACH t IN ARRAY ARRAY['plan_check_run', 'plan_webhook_delivery', 'task_run', 'task_run_log', 'issue_comment', 'query_history'] LOOP
+        IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = t AND column_name = 'project')
+           AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = t || '_project_fkey') THEN
+            EXECUTE format('ALTER TABLE %I ADD CONSTRAINT %I FOREIGN KEY (project) REFERENCES project(resource_id)', t, t || '_project_fkey');
+        END IF;
+    END LOOP;
 END $$;
 
 -- Recreate the index with the new column name.


### PR DESCRIPTION
## Summary
- rename `query_history.project_id` to `project` before adding the direct project FK in 3.17.7
- only add the FK for tables that actually have a `project` column in the current schema state

## Validation
- ran `backend/migrator/migration/3.17/0007##fix_project_fk_references.sql` against `postgresql://bbdev@127.0.0.1:5983/bbdev` inside a transaction
- confirmed the migration completes cleanly on the legacy schema where `query_history` still has `project_id`