### PR TITLE
fix(frontend): prevent popover dismiss when interacting with label selector

### DIFF
--- a/frontend/src/components/IssueV1/components/IssueLabelSelector.vue
+++ b/frontend/src/components/IssueV1/components/IssueLabelSelector.vue
@@ -4,6 +4,7 @@
     :options="options"
     :disabled="disabled"
     :size="size"
+    :to="renderMenuInsideParent ? false : undefined"
     :consistent-menu-width="true"
     :max-tag-count="maxTagCount"
     :render-label="renderLabel"
@@ -67,10 +68,12 @@ const props = withDefaults(
     project: Project;
     size?: "small" | "medium" | "large";
     maxTagCount?: number | "responsive";
+    renderMenuInsideParent?: boolean;
   }>(),
   {
     size: "medium",
     maxTagCount: "responsive",
+    renderMenuInsideParent: false,
   }
 );
 

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/create/CreateButton.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/create/CreateButton.vue
@@ -37,11 +37,12 @@
             :selected="selectedLabels"
             :project="project"
             :size="'medium'"
+            :render-menu-inside-parent="true"
             @update:selected="selectedLabels = $event"
           />
         </div>
         <div class="flex justify-end gap-x-2">
-          <NButton size="small" quaternary @click="showPopover = false">
+          <NButton size="small" quaternary @click="handleCancel">
             {{ $t("common.cancel") }}
           </NButton>
           <NTooltip :disabled="confirmErrors.length === 0" placement="top">
@@ -69,7 +70,7 @@
 <script setup lang="ts">
 import { create } from "@bufbuild/protobuf";
 import { NButton, NPopover, NTooltip } from "naive-ui";
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import IssueLabelSelector from "@/components/IssueV1/components/IssueLabelSelector.vue";
@@ -120,12 +121,14 @@ const loading = ref(false);
 const showPopover = ref(false);
 const selectedLabels = ref<string[]>([]);
 
-// Reset labels when popover opens
-watch(showPopover, (show) => {
-  if (show) {
-    selectedLabels.value = [];
-  }
-});
+const resetDraft = () => {
+  selectedLabels.value = [];
+};
+
+const handleCancel = () => {
+  resetDraft();
+  showPopover.value = false;
+};
 
 // Use the validation hook for all specs
 const { isSpecEmpty } = useSpecsValidation(computed(() => plan.value.specs));
@@ -252,6 +255,8 @@ const doCreateDataExportIssue = async () => {
   });
   const createdIssue =
     await issueServiceClientConnect.createIssue(issueRequest);
+
+  resetDraft();
 
   // Redirect to issue detail page
   nextTick(() => {

--- a/frontend/src/components/Plan/components/HeaderSection/Actions/create/CreateIssueButton.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/Actions/create/CreateIssueButton.vue
@@ -39,6 +39,7 @@
             :selected="selectedLabels"
             :project="project"
             :size="'medium'"
+            :render-menu-inside-parent="true"
             @update:selected="selectedLabels = $event"
           />
         </div>
@@ -55,7 +56,7 @@
             }}
           </NCheckbox>
           <div class="grow" />
-          <NButton size="small" quaternary @click="showPopover = false">
+          <NButton size="small" quaternary @click="handleCancel">
             {{ $t("common.cancel") }}
           </NButton>
           <NTooltip :disabled="confirmErrors.length === 0" placement="top">
@@ -83,7 +84,7 @@
 <script setup lang="ts">
 import { create } from "@bufbuild/protobuf";
 import { NAlert, NButton, NCheckbox, NPopover, NTooltip } from "naive-ui";
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { useRouter } from "vue-router";
 import IssueLabelSelector from "@/components/IssueV1/components/IssueLabelSelector.vue";
@@ -136,13 +137,15 @@ const {
 
 const checksWarningAcknowledged = ref(false);
 
-// Reset state when popover opens
-watch(showPopover, (show) => {
-  if (show) {
-    selectedLabels.value = [];
-    checksWarningAcknowledged.value = false;
-  }
-});
+const resetDraft = () => {
+  selectedLabels.value = [];
+  checksWarningAcknowledged.value = false;
+};
+
+const handleCancel = () => {
+  resetDraft();
+  showPopover.value = false;
+};
 
 // Errors that disable the main button
 const errors = computed(() => {
@@ -244,6 +247,7 @@ const doCreateIssue = async () => {
 
     events.emit("status-changed", { eager: true });
 
+    resetDraft();
     showPopover.value = false;
 
     nextTick(() => {


### PR DESCRIPTION
## Summary
- Render the `NSelect` dropdown menu inside the popover DOM (`:to="false"`) via a new `renderMenuInsideParent` prop on `IssueLabelSelector`, so clicking dropdown options no longer triggers the popover's click-outside dismiss
- Replace `watch(showPopover)` state reset with explicit `resetDraft()` on cancel and after successful creation

## Test plan
- [ ] Open a plan, click "Ready for Review" button, open the label selector dropdown — verify the popover stays open
- [ ] Select labels, then click outside the popover — verify it closes
- [ ] Open the popover, select labels, click Cancel — verify labels are cleared
- [ ] For data export plans, click "Create" button, open label selector — verify same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)