### PR TITLE
fix: exclude PolarDB pg_bitmapindex schema from pg dumps

### DIFF
--- a/backend/plugin/parser/pg/system_objects.go
+++ b/backend/plugin/parser/pg/system_objects.go
@@ -745,6 +745,7 @@ var (
 		"information_schema":       true,
 		"pg_catalog":               true,
 		"pg_toast":                 true,
+		"pg_bitmapindex":           true,
 		"rw_catalog":               true,
 		"timescaledb_information":  true,
 		"timescaledb_experimental": true,

--- a/backend/plugin/parser/pg/system_objects_test.go
+++ b/backend/plugin/parser/pg/system_objects_test.go
@@ -1,0 +1,13 @@
+package pg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolarDBSystemSchema(t *testing.T) {
+	require.True(t, IsSystemSchema("pg_bitmapindex"))
+	require.Contains(t, strings.Split(SystemSchemaWhereClause, ","), "'pg_bitmapindex'")
+}


### PR DESCRIPTION
Close BYT-9045

## Summary
- treat PolarDB's `pg_bitmapindex` as a PostgreSQL system schema
- exclude it from Bytebase's PostgreSQL dump/sync path via the shared system schema list
- add a regression test covering the PolarDB schema classification

## Testing
- go test ./backend/plugin/parser/pg -run '^TestPolarDBSystemSchema$'
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go

## Breaking Changes
- None. Reviewed `git diff main...HEAD`; local `main` is behind `origin/main`, so I also verified the actual PR delta against `origin/main...HEAD`. The effective change is limited to PostgreSQL system-schema filtering and a regression test.
