### PR TITLE
fix: GitOps dashboard code block overflow on small screens

### DIFF
--- a/frontend/src/views/project/ProjectGitOpsDashboard.vue
+++ b/frontend/src/views/project/ProjectGitOpsDashboard.vue
@@ -244,13 +244,18 @@
                 </i18n-t>
               </NButton>
             </div>
-            <div v-show="showSqlReviewYaml" class="relative rounded-xs p-4 bg-gray-50">
+            <div
+              v-show="showSqlReviewYaml"
+              class="relative rounded-xs p-4 bg-gray-50"
+            >
               <div class="absolute top-2 right-2 p-2">
                 <CopyButton size="medium" :content="githubSqlReviewYaml" />
               </div>
-              <NConfigProvider :hljs="hljs">
-                <NCode language="yaml" :code="githubSqlReviewYaml" />
-              </NConfigProvider>
+              <div class="overflow-x-auto pr-12">
+                <NConfigProvider :hljs="hljs">
+                  <NCode language="yaml" :code="githubSqlReviewYaml" />
+                </NConfigProvider>
+              </div>
             </div>
           </div>
           <!-- release.yml -->
@@ -278,13 +283,18 @@
                 </i18n-t>
               </NButton>
             </div>
-            <div v-show="showReleaseYaml" class="relative rounded-xs p-4 bg-gray-50">
+            <div
+              v-show="showReleaseYaml"
+              class="relative rounded-xs p-4 bg-gray-50"
+            >
               <div class="absolute top-2 right-2 p-2">
                 <CopyButton size="medium" :content="githubReleaseYaml" />
               </div>
-              <NConfigProvider :hljs="hljs">
-                <NCode language="yaml" :code="githubReleaseYaml" />
-              </NConfigProvider>
+              <div class="overflow-x-auto pr-12">
+                <NConfigProvider :hljs="hljs">
+                  <NCode language="yaml" :code="githubReleaseYaml" />
+                </NConfigProvider>
+              </div>
             </div>
           </div>
         </NTabPane>
@@ -316,13 +326,18 @@
                 </i18n-t>
               </NButton>
             </div>
-            <div v-show="showGitlabCiYaml" class="relative rounded-xs p-4 bg-gray-50">
+            <div
+              v-show="showGitlabCiYaml"
+              class="relative rounded-xs p-4 bg-gray-50"
+            >
               <div class="absolute top-2 right-2 p-2">
                 <CopyButton size="medium" :content="gitlabCiYaml" />
               </div>
-              <NConfigProvider :hljs="hljs">
-                <NCode language="yaml" :code="gitlabCiYaml" />
-              </NConfigProvider>
+              <div class="overflow-x-auto pr-12">
+                <NConfigProvider :hljs="hljs">
+                  <NCode language="yaml" :code="gitlabCiYaml" />
+                </NConfigProvider>
+              </div>
             </div>
           </div>
         </NTabPane>
@@ -354,9 +369,11 @@
           <div class="absolute top-2 right-2 p-2">
             <CopyButton size="medium" :content="sampleSql" />
           </div>
-          <NConfigProvider :hljs="hljs">
-            <NCode language="sql" :code="sampleSql" />
-          </NConfigProvider>
+          <div class="overflow-x-auto pr-12">
+            <NConfigProvider :hljs="hljs">
+              <NCode language="sql" :code="sampleSql" />
+            </NConfigProvider>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Make GitOps workflow and sample SQL code blocks horizontally scrollable on narrow screens
- Keep the copy button fixed instead of scrolling with the code content

## Key Changes
- Wrap each `NCode` block in a dedicated horizontal scroll container
- Preserve the existing card layout while isolating scrolling to the code area
- Add right padding in the scrollable area so content does not render under the copy button

## Motivation
- Long YAML and SQL lines were clipped on small screens, making the examples hard to read
- The copy button previously moved with horizontal scrolling, which made the interaction awkward

## Impact
- Improves mobile and narrow-window usability in the GitOps dashboard
- No backend, API, or data model changes

## Testing
- Not run (not requested)
- Reviewers should verify horizontal scrolling and copy button positioning across all four code examples

## Risks / Rollback
- Low risk and limited to GitOps dashboard presentation
- Roll back by removing the inner scroll wrappers around the code blocks

## Checklist
- [ ] Tests added/updated (if applicable)
- [x] No breaking changes OR documented
- [ ] Docs updated (if needed)