### PR TITLE
fix: support gh-ost in versioned release workflow

### DIFF
--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -288,25 +288,14 @@ func (exec *DatabaseMigrateExecutor) runStandardMigration(ctx context.Context, d
 	}, nil
 }
 
-func (exec *DatabaseMigrateExecutor) runGhostMigration(ctx context.Context, driverCtx context.Context, task *store.TaskMessage, taskRunUID int64, sheet *store.SheetMessage, instance *store.InstanceMessage, database *store.DatabaseMessage, project *store.ProjectMessage) (*storepb.TaskRunResult, error) {
-	// Parse ghost flags from sheet directive
+func executeGhostMigration(ctx context.Context, driverCtx context.Context, task *store.TaskMessage, sheet *store.SheetMessage, instance *store.InstanceMessage, database *store.DatabaseMessage, driver db.Driver) error {
 	flags, err := ghost.ParseGhostDirective(sheet.Statement)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse ghost directive")
+		return errors.Wrapf(err, "failed to parse ghost directive")
 	}
 	if flags == nil {
 		flags = make(map[string]string)
 	}
-
-	// Get database driver
-	driver, err := exec.dbFactory.GetAdminDatabaseDriver(ctx, instance, database, db.ConnectionContext{
-		TenantMode: project.Setting.GetPostgresDatabaseTenantMode(),
-		TaskRunUID: &taskRunUID,
-	})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get driver connection for instance %q", instance.ResourceID)
-	}
-	defer driver.Close(ctx)
 
 	slog.Debug("Start migration...",
 		slog.String("instance", database.InstanceID),
@@ -315,35 +304,24 @@ func (exec *DatabaseMigrateExecutor) runGhostMigration(ctx context.Context, driv
 		slog.String("sheetSha256", sheet.Sha256),
 	)
 
-	// Set up execute options
-	opts := db.ExecuteOptions{}
-	if project != nil && project.Setting != nil {
-		opts.MaximumRetries = int(project.Setting.GetExecutionRetryPolicy().GetMaximumRetries())
-	}
-	opts.CreateTaskRunLog = func(t time.Time, e *storepb.TaskRunLog) error {
-		return exec.store.CreateTaskRunLog(ctx, database.ProjectID, taskRunUID, t.UTC(), exec.profile.ReplicaID, e)
-	}
-
-	// Prepare gh-ost migration context before beginning migration
-	// Remove all Bytebase directives from statement before passing to gh-ost
+	// Remove all Bytebase directives from statement before passing to gh-ost.
 	cleanedStatement := parserbase.CleanDirectives(sheet.Statement)
 	statement := strings.TrimSpace(cleanedStatement)
-	// Trim trailing semicolons.
 	statement = strings.TrimRight(statement, ";")
 
 	tableName, err := ghost.GetTableNameFromStatement(statement)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	adminDataSource := utils.DataSourceFromInstanceWithType(instance, storepb.DataSourceType_ADMIN)
 	if adminDataSource == nil {
-		return nil, common.Errorf(common.Internal, "admin data source not found for instance %s", instance.ResourceID)
+		return common.Errorf(common.Internal, "admin data source not found for instance %s", instance.ResourceID)
 	}
 
 	migrationContext, err := ghost.NewMigrationContext(ctx, task.ID, database, adminDataSource, tableName, fmt.Sprintf("_%d", time.Now().Unix()), cleanedStatement, false, flags, 10000000)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to init migrationContext for gh-ost")
+		return errors.Wrap(err, "failed to init migrationContext for gh-ost")
 	}
 	defer func() {
 		// Use migrationContext.Uuid as the tls_config_key by convention.
@@ -352,25 +330,8 @@ func (exec *DatabaseMigrateExecutor) runGhostMigration(ctx context.Context, driv
 		gomysql.DeregisterTLSConfig(migrationContext.Uuid)
 	}()
 
-	// Begin migration - create pending changelog
-	changelogID, err := exec.store.CreateChangelog(ctx, &store.ChangelogMessage{
-		InstanceID:   database.InstanceID,
-		DatabaseName: database.DatabaseName,
-		Status:       store.ChangelogStatusPending,
-		SyncHistory:  nil,
-		Payload: &storepb.ChangelogPayload{
-			TaskRun:   common.FormatTaskRun(database.ProjectID, task.PlanID, task.Environment, task.ID, taskRunUID),
-			GitCommit: exec.profile.GitCommit,
-		},
-	})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create changelog")
-	}
-
-	// Execute gh-ost migration
 	// set buffer size to 1 to unblock the sender because there is no listener if the task is canceled.
 	migrationError := make(chan error, 1)
-
 	migrator := logic.NewMigrator(migrationContext, "bb")
 
 	defer func() {
@@ -399,14 +360,51 @@ func (exec *DatabaseMigrateExecutor) runGhostMigration(ctx context.Context, driv
 		migrationError <- nil
 	}()
 
-	var migrationErr error
 	select {
 	case err := <-migrationError:
-		migrationErr = err
+		return err
 	case <-driverCtx.Done():
 		migrationContext.PanicAbort <- errors.New("task canceled")
-		migrationErr = errors.New("task canceled")
+		return errors.New("task canceled")
 	}
+}
+
+func (exec *DatabaseMigrateExecutor) runGhostMigration(ctx context.Context, driverCtx context.Context, task *store.TaskMessage, taskRunUID int64, sheet *store.SheetMessage, instance *store.InstanceMessage, database *store.DatabaseMessage, project *store.ProjectMessage) (*storepb.TaskRunResult, error) {
+	// Get database driver
+	driver, err := exec.dbFactory.GetAdminDatabaseDriver(ctx, instance, database, db.ConnectionContext{
+		TenantMode: project.Setting.GetPostgresDatabaseTenantMode(),
+		TaskRunUID: &taskRunUID,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get driver connection for instance %q", instance.ResourceID)
+	}
+	defer driver.Close(ctx)
+
+	// Set up execute options
+	opts := db.ExecuteOptions{}
+	if project != nil && project.Setting != nil {
+		opts.MaximumRetries = int(project.Setting.GetExecutionRetryPolicy().GetMaximumRetries())
+	}
+	opts.CreateTaskRunLog = func(t time.Time, e *storepb.TaskRunLog) error {
+		return exec.store.CreateTaskRunLog(ctx, database.ProjectID, taskRunUID, t.UTC(), exec.profile.ReplicaID, e)
+	}
+
+	// Begin migration - create pending changelog
+	changelogID, err := exec.store.CreateChangelog(ctx, &store.ChangelogMessage{
+		InstanceID:   database.InstanceID,
+		DatabaseName: database.DatabaseName,
+		Status:       store.ChangelogStatusPending,
+		SyncHistory:  nil,
+		Payload: &storepb.ChangelogPayload{
+			TaskRun:   common.FormatTaskRun(database.ProjectID, task.PlanID, task.Environment, task.ID, taskRunUID),
+			GitCommit: exec.profile.GitCommit,
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create changelog")
+	}
+
+	migrationErr := executeGhostMigration(ctx, driverCtx, task, sheet, instance, database, driver)
 
 	// Dump after migration and update changelog
 	update := &store.UpdateChangelogMessage{
@@ -527,14 +525,17 @@ func (exec *DatabaseMigrateExecutor) runVersionedRelease(ctx context.Context, dr
 			},
 		})
 
-		slog.Debug("Start migration...",
-			slog.String("instance", database.InstanceID),
-			slog.String("database", database.DatabaseName),
-			slog.String("type", task.Type.String()),
-		)
-
-		// Execute the SQL
-		_, err = driver.Execute(driverCtx, sheet.Statement, opts)
+		// Execute the SQL.
+		if ghost.IsGhostEnabled(sheet.Statement) {
+			err = executeGhostMigration(ctx, driverCtx, task, sheet, instance, database, driver)
+		} else {
+			slog.Debug("Start migration...",
+				slog.String("instance", database.InstanceID),
+				slog.String("database", database.DatabaseName),
+				slog.String("type", task.Type.String()),
+			)
+			_, err = driver.Execute(driverCtx, sheet.Statement, opts)
+		}
 		if err != nil {
 			migrationErr = errors.Wrapf(err, "failed to execute release file %s (version %s)", file.Path, file.Version)
 			break

--- a/backend/tests/gitops_test.go
+++ b/backend/tests/gitops_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bytebase/bytebase/backend/common"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
@@ -308,6 +309,144 @@ func TestGitOpsRollout(t *testing.T) {
 	a.NoError(err)
 	a.NotNil(rolloutResp2)
 	a.Equal(rollout.Name, rolloutResp2.Msg.Name)
+}
+
+func TestGitOpsRolloutGhostDirective(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	mysqlContainer, err := getMySQLContainer(ctx)
+	a.NoError(err)
+	defer func() {
+		mysqlContainer.Close(ctx)
+	}()
+
+	const databaseName = "gitops_rollout_ghost_db"
+	mysqlDB := mysqlContainer.db
+	_, err = mysqlDB.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %v", databaseName))
+	a.NoError(err)
+	_, err = mysqlDB.Exec("DROP USER IF EXISTS bytebase")
+	a.NoError(err)
+	_, err = mysqlDB.Exec("CREATE USER 'bytebase' IDENTIFIED WITH mysql_native_password BY 'bytebase'")
+	a.NoError(err)
+	_, err = mysqlDB.Exec("GRANT ALTER, ALTER ROUTINE, CREATE, CREATE ROUTINE, CREATE VIEW, DELETE, DROP, EVENT, EXECUTE, INDEX, INSERT, PROCESS, REFERENCES, SELECT, SHOW DATABASES, SHOW VIEW, TRIGGER, UPDATE, USAGE, REPLICATION CLIENT, REPLICATION SLAVE, LOCK TABLES, RELOAD ON *.* to bytebase")
+	a.NoError(err)
+
+	projectID := generateRandomString("gitops-rollout-ghost")
+	projectResp, err := ctl.projectServiceClient.CreateProject(ctx, connect.NewRequest(&v1pb.CreateProjectRequest{
+		Project: &v1pb.Project{
+			Name:              fmt.Sprintf("projects/%s", projectID),
+			Title:             projectID,
+			AllowSelfApproval: true,
+		},
+		ProjectId: projectID,
+	}))
+	a.NoError(err)
+	project := projectResp.Msg
+
+	instanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       "gitops-rollout-ghost",
+			Engine:      v1pb.Engine_MYSQL,
+			Environment: stringPtr("environments/test"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{Type: v1pb.DataSourceType_ADMIN, Host: mysqlContainer.host, Port: mysqlContainer.port, Username: "bytebase", Password: "bytebase", Id: "admin"}},
+		},
+	}))
+	a.NoError(err)
+	instance := instanceResp.Msg
+
+	backupDBName := common.BackupDatabaseNameOfEngine(storepb.Engine_MYSQL)
+	err = ctl.createDatabase(ctx, project, instance, nil, backupDBName, "")
+	a.NoError(err)
+	err = ctl.createDatabase(ctx, project, instance, nil, databaseName, "")
+	a.NoError(err)
+
+	createReleaseResp, err := ctl.releaseServiceClient.CreateRelease(ctx, connect.NewRequest(&v1pb.CreateReleaseRequest{
+		Parent: project.Name,
+		Release: &v1pb.Release{
+			Type: v1pb.Release_VERSIONED,
+			Files: []*v1pb.Release_File{
+				{
+					Path:      "migrations/001__create_book.sql",
+					Version:   "001",
+					Statement: []byte(mysqlMigrationStatement),
+				},
+				{
+					Path:    "migrations/002__add_author.sql",
+					Version: "002",
+					Statement: []byte(`-- gh-ost = {}
+ALTER TABLE book ADD author VARCHAR(54);`),
+				},
+			},
+		},
+	}))
+	a.NoError(err)
+
+	planResp, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: project.Name,
+		Plan: &v1pb.Plan{
+			Title:       "GitOps gh-ost deployment",
+			Description: "Deploy release with gh-ost directive",
+			Specs: []*v1pb.Plan_Spec{
+				{
+					Id: uuid.NewString(),
+					Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+							Release: createReleaseResp.Msg.Name,
+							Targets: []string{
+								fmt.Sprintf("%s/databases/%s", instance.Name, databaseName),
+							},
+						},
+					},
+				},
+			},
+		},
+	}))
+	a.NoError(err)
+	plan := planResp.Msg
+
+	rolloutResp, err := ctl.rolloutServiceClient.CreateRollout(ctx, connect.NewRequest(&v1pb.CreateRolloutRequest{
+		Parent: plan.Name,
+	}))
+	a.NoError(err)
+	rollout := rolloutResp.Msg
+
+	issueResp, err := ctl.issueServiceClient.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+		Parent: project.Name,
+		Issue: &v1pb.Issue{
+			Title:       "GitOps gh-ost rollout",
+			Description: "Deploy release via versioned release workflow with gh-ost",
+			Type:        v1pb.Issue_DATABASE_CHANGE,
+			Plan:        plan.Name,
+		},
+	}))
+	a.NoError(err)
+	issue := issueResp.Msg
+
+	err = ctl.waitRollout(ctx, issue.Name, rollout.Name)
+	a.NoError(err)
+
+	dbSchemaResp, err := ctl.databaseServiceClient.GetDatabaseSchema(ctx, connect.NewRequest(&v1pb.GetDatabaseSchemaRequest{
+		Name: fmt.Sprintf("%s/databases/%s/schema", instance.Name, databaseName),
+	}))
+	a.NoError(err)
+	a.Equal(wantDBSchema2, dbSchemaResp.Msg.Schema)
+
+	revisionsResp, err := ctl.revisionServiceClient.ListRevisions(ctx, connect.NewRequest(&v1pb.ListRevisionsRequest{
+		Parent: fmt.Sprintf("%s/databases/%s", instance.Name, databaseName),
+	}))
+	a.NoError(err)
+	a.Len(revisionsResp.Msg.Revisions, 2)
+	for _, revision := range revisionsResp.Msg.Revisions {
+		a.Equal(createReleaseResp.Msg.Name, revision.Release)
+	}
 }
 
 // TestGitOpsRolloutMultiTarget tests a more complex GitOps scenario:


### PR DESCRIPTION
## Summary
- route versioned release files with gh-ost directives through the existing gh-ost execution flow instead of always using plain driver execution
- refactor the gh-ost executor path so the manual and versioned release workflows share the same migration logic
- add a MySQL GitOps regression test covering a versioned release rollout with a gh-ost directive

## Why
Versioned Release / GitOps rollouts ignored `-- gh-ost = ...` directives even though the same SQL worked through the manual plan workflow. This change brings parity between the two execution paths.

Fixes #19452
Close BYT-9006

## Testing
- `go test ./backend/runner/taskrun ./backend/tests -run '^(TestGhostSchemaUpdate|TestGitOpsRollout|TestGitOpsRolloutGhostDirective)$' -count=1`
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags '-w -s' -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Breaking Changes
- None.
