### PR TITLE
fix(frontend): hide git commit hash and external URL for cloud

### DIFF
--- a/frontend/src/components/misc/Version.vue
+++ b/frontend/src/components/misc/Version.vue
@@ -44,8 +44,10 @@
           <div v-if="canUpgrade" class="whitespace-nowrap">
             {{ $t("remind.release.new-version-available") }}
           </div>
-          <div>BE Git hash: {{ gitCommitBE }}</div>
-          <div>FE Git hash: {{ gitCommitFE }}</div>
+          <template v-if="!isSaaSMode">
+            <div>BE Git hash: {{ gitCommitBE }}</div>
+            <div>FE Git hash: {{ gitCommitFE }}</div>
+          </template>
         </div>
       </template>
     </NTooltip>
@@ -88,7 +90,7 @@ const state = reactive<LocalState>({
   showReleaseModal: false,
 });
 
-const { isDemo } = storeToRefs(actuatorStore);
+const { isDemo, isSaaSMode } = storeToRefs(actuatorStore);
 const canUpgrade = computed(() => {
   return actuatorStore.hasNewRelease;
 });

--- a/frontend/src/react/pages/settings/general/GeneralSection.tsx
+++ b/frontend/src/react/pages/settings/general/GeneralSection.tsx
@@ -195,40 +195,42 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
               </div>
             </div>
 
-            {/* External URL */}
-            <div>
-              <label className="flex items-center gap-x-2">
-                <span className="text-base font-semibold">
-                  {t("settings.general.workspace.external-url.self")}
-                </span>
-              </label>
-              <div className="mb-3 text-sm text-gray-400">
-                {t("settings.general.workspace.external-url.description")}{" "}
-                <a
-                  href="https://docs.bytebase.com/get-started/self-host/external-url?source=console"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-accent hover:underline"
-                >
-                  {t("common.learn-more")}
-                </a>
+            {/* External URL — hidden in SaaS/cloud mode */}
+            {!isSaaSMode && (
+              <div>
+                <label className="flex items-center gap-x-2">
+                  <span className="text-base font-semibold">
+                    {t("settings.general.workspace.external-url.self")}
+                  </span>
+                </label>
+                <div className="mb-3 text-sm text-gray-400">
+                  {t("settings.general.workspace.external-url.description")}{" "}
+                  <a
+                    href="https://docs.bytebase.com/get-started/self-host/external-url?source=console"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-accent hover:underline"
+                  >
+                    {t("common.learn-more")}
+                  </a>
+                </div>
+                {externalUrlFromFlag && (
+                  <Alert variant="info" className="mb-3">
+                    {t(
+                      "settings.general.workspace.external-url.cannot-edit-flag"
+                    )}
+                  </Alert>
+                )}
+                <Input
+                  value={state.externalUrl}
+                  className="w-full"
+                  disabled={!canEdit || externalUrlFromFlag}
+                  onChange={(e) =>
+                    setState((s) => ({ ...s, externalUrl: e.target.value }))
+                  }
+                />
               </div>
-              {externalUrlFromFlag && !isSaaSMode && (
-                <Alert variant="info" className="mb-3">
-                  {t(
-                    "settings.general.workspace.external-url.cannot-edit-flag"
-                  )}
-                </Alert>
-              )}
-              <Input
-                value={state.externalUrl}
-                className="w-full"
-                disabled={!canEdit || isSaaSMode || externalUrlFromFlag}
-                onChange={(e) =>
-                  setState((s) => ({ ...s, externalUrl: e.target.value }))
-                }
-              />
-            </div>
+            )}
           </div>
         </PermissionGuard>
 


### PR DESCRIPTION
## Summary
- Hide FE/BE git commit hash tooltip in the profile dropdown when in cloud/SaaS mode (always latest, not useful)
- Hide the External URL setting on the General settings page when in cloud/SaaS mode (fixed URL, not configurable)

## Test plan
- [ ] Verify git hash tooltip no longer shows in cloud mode profile dropdown
- [ ] Verify External URL section is hidden on General settings page in cloud mode
- [ ] Verify both still appear in self-hosted mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)