### PR TITLE
fix(frontend): restore changelog detail UI/UX parity and enhance experience

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -192,6 +192,7 @@
   },
   "changelog": {
     "current-schema-empty": "Current schema is empty",
+    "no-schema-change": "No schema change",
     "schema-snapshot-after-change": "The schema snapshot recorded after applying this change",
     "select": "Schema version is recorded each time a schema change is applied via Bytebase",
     "self": "Changelog",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -192,6 +192,7 @@
   },
   "changelog": {
     "current-schema-empty": "El esquema actual está vacío",
+    "no-schema-change": "No schema change",
     "schema-snapshot-after-change": "La instantánea de esquema registrada después de aplicar este cambio",
     "select": "La versión del esquema se registra cada vez que se aplica un cambio de esquema a través de Bytebase",
     "self": "Historial de cambios",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -192,6 +192,7 @@
   },
   "changelog": {
     "current-schema-empty": "現在のスキーマは空です",
+    "no-schema-change": "No schema change",
     "schema-snapshot-after-change": "この変更を完了した後のスキーマのスナップショット",
     "select": "スキーマのバージョンは、Bytebase を通じてスキーマの変更が実行されるたびに記録されます。",
     "self": "変更履歴",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -192,6 +192,7 @@
   },
   "changelog": {
     "current-schema-empty": "Lược đồ hiện tại trống",
+    "no-schema-change": "No schema change",
     "schema-snapshot-after-change": "Ảnh chụp nhanh lược đồ được ghi lại sau khi áp dụng thay đổi này",
     "select": "Phiên bản lược đồ được ghi lại mỗi khi thay đổi lược đồ được áp dụng qua Bytebase",
     "self": "Nhật ký thay đổi",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -192,6 +192,7 @@
   },
   "changelog": {
     "current-schema-empty": "当前 schema 为空",
+    "no-schema-change": "没有 Schema 变更",
     "schema-snapshot-after-change": "完成这次变更后的 schema 快照",
     "select": "Schema 版本是在每次通过 Bytebase 执行 Schema 变更后被记录下来的",
     "self": "变更历史",

--- a/frontend/src/react/components/monaco/ReadonlyDiffMonaco.tsx
+++ b/frontend/src/react/components/monaco/ReadonlyDiffMonaco.tsx
@@ -81,12 +81,17 @@ export function ReadonlyDiffMonaco({
       );
 
       const { editor: monacoEditor } = await import("monaco-editor");
+
+      if (disposed) {
+        return;
+      }
+
       const originalModel = monacoEditor.createModel(
-        normalizedOriginal,
+        originalRef.current.replace(/\r\n?/g, "\n"),
         languageRef.current
       );
       const modifiedModel = monacoEditor.createModel(
-        normalizedModified,
+        modifiedRef.current.replace(/\r\n?/g, "\n"),
         languageRef.current
       );
 
@@ -96,12 +101,6 @@ export function ReadonlyDiffMonaco({
       });
 
       setContentHeight(modifiedEditor.getContentHeight());
-
-      if (disposed) {
-        contentSizeSubscription?.dispose();
-        editor.dispose();
-        return;
-      }
     })();
 
     return () => {

--- a/frontend/src/react/components/monaco/ReadonlyDiffMonaco.tsx
+++ b/frontend/src/react/components/monaco/ReadonlyDiffMonaco.tsx
@@ -3,6 +3,7 @@ import {
   createMonacoDiffEditor,
   setMonacoModelLanguage,
 } from "@/components/MonacoEditor/editor";
+import { loadMonacoEditor } from "@/components/MonacoEditor/lazy-editor";
 import type { IStandaloneDiffEditor } from "@/components/MonacoEditor/types";
 import { cn } from "@/react/lib/utils";
 import type { Language } from "@/types";
@@ -80,17 +81,17 @@ export function ReadonlyDiffMonaco({
         }
       );
 
-      const { editor: monacoEditor } = await import("monaco-editor");
+      const monaco = await loadMonacoEditor();
 
       if (disposed) {
         return;
       }
 
-      const originalModel = monacoEditor.createModel(
+      const originalModel = monaco.editor.createModel(
         originalRef.current.replace(/\r\n?/g, "\n"),
         languageRef.current
       );
-      const modifiedModel = monacoEditor.createModel(
+      const modifiedModel = monaco.editor.createModel(
         modifiedRef.current.replace(/\r\n?/g, "\n"),
         languageRef.current
       );

--- a/frontend/src/react/components/monaco/ReadonlyDiffMonaco.tsx
+++ b/frontend/src/react/components/monaco/ReadonlyDiffMonaco.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  createMonacoDiffEditor,
+  setMonacoModelLanguage,
+} from "@/components/MonacoEditor/editor";
+import type { IStandaloneDiffEditor } from "@/components/MonacoEditor/types";
+import { cn } from "@/react/lib/utils";
+import type { Language } from "@/types";
+
+export interface ReadonlyDiffMonacoProps {
+  original: string;
+  modified: string;
+  language?: Language;
+  className?: string;
+  min?: number;
+  max?: number;
+}
+
+export function ReadonlyDiffMonaco({
+  original,
+  modified,
+  language = "sql",
+  className = "",
+  min = 120,
+  max = 600,
+}: ReadonlyDiffMonacoProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const editorRef = useRef<IStandaloneDiffEditor | null>(null);
+  const originalRef = useRef(original);
+  const modifiedRef = useRef(modified);
+  const languageRef = useRef(language);
+  const [contentHeight, setContentHeight] = useState(min);
+  const clampMeasuredHeight = (height: number): number => {
+    return Math.min(max, Math.max(min, height));
+  };
+
+  originalRef.current = original;
+  modifiedRef.current = modified;
+  languageRef.current = language;
+
+  const normalizedOriginal = useMemo(
+    () => original.replace(/\r\n?/g, "\n"),
+    [original]
+  );
+  const normalizedModified = useMemo(
+    () => modified.replace(/\r\n?/g, "\n"),
+    [modified]
+  );
+
+  useEffect(() => {
+    let disposed = false;
+    let contentSizeSubscription: { dispose(): void } | null = null;
+
+    (async () => {
+      if (!containerRef.current) return;
+
+      const editor = await createMonacoDiffEditor({
+        container: containerRef.current,
+        options: {
+          readOnly: true,
+          domReadOnly: true,
+          renderSideBySide: true,
+          ignoreTrimWhitespace: true,
+        },
+      });
+
+      if (disposed) {
+        editor.dispose();
+        return;
+      }
+
+      editorRef.current = editor;
+
+      // Handle height auto-grow by listening to the modified editor's size change.
+      const modifiedEditor = editor.getModifiedEditor();
+      contentSizeSubscription = modifiedEditor.onDidContentSizeChange(
+        (event) => {
+          if (!event.contentHeightChanged) return;
+          setContentHeight(event.contentHeight);
+        }
+      );
+
+      const { editor: monacoEditor } = await import("monaco-editor");
+      const originalModel = monacoEditor.createModel(
+        normalizedOriginal,
+        languageRef.current
+      );
+      const modifiedModel = monacoEditor.createModel(
+        normalizedModified,
+        languageRef.current
+      );
+
+      editor.setModel({
+        original: originalModel,
+        modified: modifiedModel,
+      });
+
+      setContentHeight(modifiedEditor.getContentHeight());
+
+      if (disposed) {
+        contentSizeSubscription?.dispose();
+        editor.dispose();
+        return;
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      contentSizeSubscription?.dispose();
+      const model = editorRef.current?.getModel();
+      model?.original?.dispose();
+      model?.modified?.dispose();
+      editorRef.current?.dispose();
+      editorRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const model = editor.getModel();
+    if (model) {
+      if (model.original.getValue() !== normalizedOriginal) {
+        model.original.setValue(normalizedOriginal);
+      }
+      if (model.modified.getValue() !== normalizedModified) {
+        model.modified.setValue(normalizedModified);
+      }
+    }
+    const modifiedEditor = editor.getModifiedEditor();
+    setContentHeight(modifiedEditor.getContentHeight());
+  }, [normalizedOriginal, normalizedModified]);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    const model = editor?.getModel();
+    if (!model) return;
+
+    (async () => {
+      await setMonacoModelLanguage(model.original, languageRef.current);
+      await setMonacoModelLanguage(model.modified, languageRef.current);
+    })();
+  }, [language]);
+
+  const height = clampMeasuredHeight(contentHeight);
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "w-full overflow-clip rounded-md border text-sm",
+        className
+      )}
+      style={{ height }}
+    />
+  );
+}
+
+export default ReadonlyDiffMonaco;

--- a/frontend/src/react/components/monaco/index.ts
+++ b/frontend/src/react/components/monaco/index.ts
@@ -1,2 +1,2 @@
-export { ReadonlyMonaco } from "./ReadonlyMonaco";
-export { clampEditorHeight } from "./height";
+export * from "./ReadonlyMonaco";
+export * from "./ReadonlyDiffMonaco";

--- a/frontend/src/react/components/ui/switch.tsx
+++ b/frontend/src/react/components/ui/switch.tsx
@@ -6,6 +6,7 @@ interface SwitchProps {
   onCheckedChange: (checked: boolean) => void;
   disabled?: boolean;
   className?: string;
+  size?: "default" | "small";
 }
 
 function Switch({
@@ -13,14 +14,18 @@ function Switch({
   onCheckedChange,
   disabled,
   className,
+  size = "default",
 }: SwitchProps) {
+  const isSmall = size === "small";
+
   return (
     <BaseSwitch.Root
       checked={checked}
       onCheckedChange={onCheckedChange}
       disabled={disabled}
       className={cn(
-        "relative inline-flex h-5 w-9 cursor-pointer items-center rounded-full transition-colors",
+        "relative inline-flex cursor-pointer items-center rounded-full transition-colors",
+        isSmall ? "h-4 w-7" : "h-5 w-9",
         "bg-gray-300 data-[checked]:bg-blue-600",
         "focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
         "disabled:cursor-not-allowed disabled:opacity-50",
@@ -29,8 +34,10 @@ function Switch({
     >
       <BaseSwitch.Thumb
         className={cn(
-          "block h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-          "translate-x-0.5 data-[checked]:translate-x-[18px]"
+          "block rounded-full bg-white shadow-sm transition-transform",
+          isSmall
+            ? "h-3 w-3 translate-x-0.5 data-[checked]:translate-x-[12px]"
+            : "h-4 w-4 translate-x-0.5 data-[checked]:translate-x-[18px]"
         )}
       />
     </BaseSwitch.Root>

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -118,6 +118,7 @@
   },
   "changelog": {
     "current-schema-empty": "Current schema is empty",
+    "no-schema-change": "No schema change",
     "schema-snapshot-after-change": "The schema snapshot recorded after applying this change",
     "select": "Schema version is recorded each time a schema change is applied via Bytebase",
     "self": "Changelog",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -118,6 +118,7 @@
   },
   "changelog": {
     "current-schema-empty": "El esquema actual está vacío",
+    "no-schema-change": "No schema change",
     "schema-snapshot-after-change": "La instantánea de esquema registrada después de aplicar este cambio",
     "select": "Schema version is recorded each time a schema change is applied via Bytebase",
     "self": "Changelog",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -118,6 +118,7 @@
   },
   "changelog": {
     "current-schema-empty": "現在のスキーマは空です",
+    "no-schema-change": "No schema change",
     "schema-snapshot-after-change": "この変更を完了した後のスキーマのスナップショット",
     "select": "Schema version is recorded each time a schema change is applied via Bytebase",
     "self": "Changelog",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -118,6 +118,7 @@
   },
   "changelog": {
     "current-schema-empty": "Lược đồ hiện tại trống",
+    "no-schema-change": "No schema change",
     "schema-snapshot-after-change": "Ảnh chụp nhanh lược đồ được ghi lại sau khi áp dụng thay đổi này",
     "select": "Schema version is recorded each time a schema change is applied via Bytebase",
     "self": "Changelog",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -118,6 +118,7 @@
   },
   "changelog": {
     "current-schema-empty": "当前 schema 为空",
+    "no-schema-change": "没有 Schema 变更",
     "schema-snapshot-after-change": "完成这次变更后的 schema 快照",
     "select": "Schema 版本是在每次通过 Bytebase 执行 Schema 变更后被记录下来的",
     "self": "变更历史",

--- a/frontend/src/react/pages/project/DatabaseChangelogDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/DatabaseChangelogDetailPage.test.tsx
@@ -53,6 +53,24 @@ const mocks = vi.hoisted(() => {
         );
       }
     ),
+    ReadonlyDiffMonaco: vi.fn(
+      ({
+        original,
+        modified,
+        className,
+      }: {
+        original: string;
+        modified: string;
+        className?: string;
+      }) => {
+        return (
+          <div data-testid="readonly-diff-monaco" className={className}>
+            <div data-testid="diff-original">{original}</div>
+            <div data-testid="diff-modified">{modified}</div>
+          </div>
+        );
+      }
+    ),
     TaskRunLogViewer: vi.fn(({ taskRunName }: { taskRunName: string }) => {
       return <div data-testid="task-run-log">{taskRunName}</div>;
     }),
@@ -78,9 +96,7 @@ const mocks = vi.hoisted(() => {
     ),
     LoaderCircle: vi.fn(() => <div data-testid="spinner" />),
     ArrowUpRight: vi.fn(() => <div data-testid="arrow-up-right" />),
-    CheckCircle2: vi.fn(() => <div data-testid="check-circle-2" />),
-    CircleAlert: vi.fn(() => <div data-testid="circle-alert" />),
-    CircleDot: vi.fn(() => <div data-testid="circle-dot" />),
+    Check: vi.fn(() => <div data-testid="check" />),
     Copy: vi.fn(() => <div data-testid="copy-icon" />),
     useTranslation: vi.fn(() => ({
       t: (key: string) => key,
@@ -103,9 +119,7 @@ let DatabaseChangelogDetailPage: DatabaseChangelogDetailPageComponent;
 vi.mock("lucide-react", () => ({
   LoaderCircle: mocks.LoaderCircle,
   ArrowUpRight: mocks.ArrowUpRight,
-  CheckCircle2: mocks.CheckCircle2,
-  CircleAlert: mocks.CircleAlert,
-  CircleDot: mocks.CircleDot,
+  Check: mocks.Check,
   Copy: mocks.Copy,
 }));
 
@@ -139,6 +153,7 @@ vi.mock("@/react/components/ui/switch", () => ({
 
 vi.mock("@/react/components/monaco", () => ({
   ReadonlyMonaco: mocks.ReadonlyMonaco,
+  ReadonlyDiffMonaco: mocks.ReadonlyDiffMonaco,
 }));
 
 vi.mock("@/react/components/task-run-log", () => ({
@@ -226,13 +241,12 @@ beforeEach(() => {
   mocks.pushNotification.mockReset();
   mocks.useVueState.mockImplementation((getter: () => unknown) => getter());
   mocks.ReadonlyMonaco.mockClear();
+  mocks.ReadonlyDiffMonaco.mockClear();
   mocks.TaskRunLogViewer.mockClear();
   mocks.Switch.mockClear();
   mocks.LoaderCircle.mockClear();
   mocks.ArrowUpRight.mockClear();
-  mocks.CheckCircle2.mockClear();
-  mocks.CircleAlert.mockClear();
-  mocks.CircleDot.mockClear();
+  mocks.Check.mockClear();
   mocks.Copy.mockClear();
   mocks.clipboardWriteText.mockReset();
   Object.defineProperty(globalThis.navigator, "clipboard", {
@@ -450,6 +464,11 @@ describe("DatabaseChangelogDetailPage", () => {
     expect(container.textContent).toContain("common.schema");
     expect(container.textContent).toContain("common.snapshot");
     expect(container.textContent).toContain("31 B");
+    // Should render ReadonlyDiffMonaco by default if there's a diff.
+    expect(
+      container.querySelector('[data-testid="readonly-diff-monaco"]')
+    ).not.toBeNull();
+
     const copyButton = container.querySelector(
       '[aria-label="common.copy"]'
     ) as HTMLButtonElement | null;
@@ -519,7 +538,61 @@ describe("DatabaseChangelogDetailPage", () => {
     expect(container.textContent).toContain("changelog.current-schema-empty");
     expect(
       container.querySelectorAll('[data-testid="readonly-monaco"]').length
-    ).toBe(0);
+    ).toBe(0); // Should be 0 because it renders the empty text div
+
+    unmount();
+  });
+
+  test("renders the diff viewer by default when the schema has changed", async () => {
+    const changelog = {
+      ...mocks.currentChangelog,
+      schema: "new schema",
+    };
+    const previousChangelog = {
+      ...mocks.previousChangelog,
+      schema: "old schema",
+    };
+    mocks.useProjectDatabaseDetail.mockReturnValue({
+      database: {
+        name: "instances/inst1/databases/db1",
+        project: "projects/proj1",
+        instanceResource: { engine: "MYSQL" },
+      },
+      databaseName: "instances/inst1/databases/db1",
+      loading: false,
+      ready: true,
+      allowAlterSchema: true,
+      isDefaultProject: false,
+    });
+    mocks.getOrFetchChangelogByName.mockResolvedValue(changelog);
+    mocks.fetchPreviousChangelog.mockResolvedValue(previousChangelog);
+    mocks.getChangelogByName.mockReturnValue(undefined);
+
+    const { container, render, unmount } = renderIntoContainer(
+      createElement(DatabaseChangelogDetailPage, {
+        project: "projects/proj1",
+        instance: "instances/inst1",
+        database: "instances/inst1/databases/db1",
+        changelogId: "7",
+      })
+    );
+
+    render();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-testid="readonly-diff-monaco"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="diff-original"]')?.textContent
+    ).toBe("old schema");
+    expect(
+      container.querySelector('[data-testid="diff-modified"]')?.textContent
+    ).toBe("new schema");
 
     unmount();
   });

--- a/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
+++ b/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
@@ -1,14 +1,7 @@
-import {
-  ArrowUpRight,
-  CheckCircle2,
-  CircleAlert,
-  CircleDot,
-  Copy,
-  LoaderCircle,
-} from "lucide-react";
+import { ArrowUpRight, Check, Copy, LoaderCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ReadonlyMonaco } from "@/react/components/monaco";
+import { ReadonlyDiffMonaco, ReadonlyMonaco } from "@/react/components/monaco";
 import { TaskRunLogViewer } from "@/react/components/task-run-log";
 import { Button } from "@/react/components/ui/button";
 import { Switch } from "@/react/components/ui/switch";
@@ -86,7 +79,12 @@ function ChangelogStatusIndicator({ status }: { status: Changelog_Status }) {
           aria-label={t("common.status")}
           className="flex h-5 w-5 items-center justify-center rounded-full border-2 border-info bg-white text-info"
         >
-          <CircleDot className="h-3 w-3" />
+          <span
+            className="h-2 w-2 rounded-full bg-info"
+            style={{
+              animation: "pulse 2.5s cubic-bezier(0.4, 0, 0.6, 1) infinite",
+            }}
+          />
         </span>
       );
     case Changelog_Status.DONE:
@@ -95,7 +93,7 @@ function ChangelogStatusIndicator({ status }: { status: Changelog_Status }) {
           aria-label={t("common.status")}
           className="flex h-5 w-5 items-center justify-center rounded-full bg-success text-white"
         >
-          <CheckCircle2 className="h-4 w-4" />
+          <Check className="h-4 w-4" />
         </span>
       );
     case Changelog_Status.FAILED:
@@ -104,7 +102,7 @@ function ChangelogStatusIndicator({ status }: { status: Changelog_Status }) {
           aria-label={t("common.status")}
           className="flex h-5 w-5 items-center justify-center rounded-full bg-error text-white"
         >
-          <CircleAlert className="h-4 w-4" />
+          <span className="pb-0.5 text-base font-normal">!</span>
         </span>
       );
     default:
@@ -212,6 +210,10 @@ export function DatabaseChangelogDetailPage({
         }
         setResolvedChangelog(current);
         setPreviousChangelog(previous);
+
+        // Show diff by default only if there is a schema change.
+        const hasDiff = (previous?.schema ?? "") !== (current?.schema ?? "");
+        setShowDiff(hasDiff);
       })
       .catch((error) => {
         console.error("Failed to fetch changelog details", error);
@@ -244,11 +246,21 @@ export function DatabaseChangelogDetailPage({
     );
   }, [resolvedChangelog]);
 
+  const hasSchemaDiff = useMemo(() => {
+    if (!resolvedChangelog) {
+      return false;
+    }
+    return (
+      (previousChangelog?.schema ?? "") !== (resolvedChangelog.schema ?? "")
+    );
+  }, [resolvedChangelog, previousChangelog]);
+
   const allowRollback = useMemo(() => {
     if (
       !detail.database ||
       detail.isDefaultProject ||
-      !detail.allowAlterSchema
+      !detail.allowAlterSchema ||
+      !hasSchemaDiff
     ) {
       return false;
     }
@@ -266,6 +278,7 @@ export function DatabaseChangelogDetailPage({
     detail.database,
     detail.isDefaultProject,
     resolvedChangelog,
+    hasSchemaDiff,
   ]);
 
   const databaseDisplayName =
@@ -431,24 +444,6 @@ export function DatabaseChangelogDetailPage({
         ) : null}
 
         <div className="flex flex-col gap-y-2">
-          <div className="flex items-center justify-between gap-x-2">
-            <div className="flex items-center gap-x-2">
-              <Switch checked={showDiff} onCheckedChange={setShowDiff} />
-              <span className="text-sm font-semibold">
-                {t("changelog.show-diff")}
-              </span>
-            </div>
-            {allowRollback ? (
-              <Button size="sm" onClick={handleRollback}>
-                {t("common.rollback")}
-              </Button>
-            ) : null}
-          </div>
-
-          <div className="textinfolabel">
-            {t("changelog.schema-snapshot-after-change")}
-          </div>
-
           <p className="flex items-center gap-x-2 text-lg text-main">
             <span>
               {t("common.schema")} {t("common.snapshot")}
@@ -461,21 +456,44 @@ export function DatabaseChangelogDetailPage({
             <CopyButton content={resolvedChangelog.schema} />
           </p>
 
-          {showDiff ? (
-            <div className="grid gap-4 lg:grid-cols-2">
-              <ReadonlyMonaco
-                content={previousChangelog?.schema ?? ""}
-                className="relative h-auto max-h-[600px] min-h-[120px]"
-              />
-              <ReadonlyMonaco
-                content={resolvedChangelog.schema}
-                className="relative h-auto max-h-[600px] min-h-[120px]"
-              />
+          <div className="flex items-center justify-between gap-x-2">
+            <div className="flex items-center gap-x-2">
+              <div className="flex items-center gap-x-1">
+                <Switch
+                  checked={showDiff}
+                  onCheckedChange={setShowDiff}
+                  size="small"
+                />
+                <span className="text-sm font-semibold">
+                  {t("changelog.show-diff")}
+                </span>
+              </div>
+              <div className="textinfolabel">
+                {t("changelog.schema-snapshot-after-change")}
+              </div>
+              {!hasSchemaDiff && (
+                <div className="text-sm font-normal text-accent">
+                  ({t("changelog.no-schema-change")})
+                </div>
+              )}
             </div>
+            {allowRollback ? (
+              <Button size="sm" onClick={handleRollback}>
+                {t("common.rollback")}
+              </Button>
+            ) : null}
+          </div>
+
+          {showDiff ? (
+            <ReadonlyDiffMonaco
+              original={previousChangelog?.schema ?? ""}
+              modified={resolvedChangelog.schema}
+              className="relative h-auto max-h-[600px] min-h-[120px]"
+            />
           ) : resolvedChangelog.schema ? (
             <ReadonlyMonaco
               content={resolvedChangelog.schema}
-              className="relative h-auto min-h-[120px] max-h-[600px]"
+              className="relative h-auto max-h-[600px] min-h-[120px]"
             />
           ) : (
             <div className="text-sm text-control-light">


### PR DESCRIPTION
## Summary

This PR restores full UI/UX parity for the database changelog detail page following its recent migration from Vue to React. It also introduces several experience improvements to make schema comparisons more intuitive.

## Changes

- **Restored Professional Diff**: Added `ReadonlyDiffMonaco` component using the Monaco `DiffEditor` engine to provide a true side-by-side comparison with synchronized scrolling and highlighting.
- **Visual Parity**: Updated `ChangelogStatusIndicator` to match the original design (pulsing Pending dot, exclamation character for Failed).
- **Layout Refinement**: Corrected the `Schema Snapshot` section hierarchy to place the title and file size at the top, with controls (Diff switch, Rollback button) in a dedicated row below.
- **Smart Experience Logic**: 
    - `Show Diff` now defaults to `true` only when a schema change exists.
    - `Rollback` button is hidden when there is no schema diff to revert.
    - Added a clear `(No schema change)` hint for identical snapshots.
- **Component Polish**: Added `size="small"` support to the React `Switch` component and added missing i18n keys for `no-schema-change`.

## Testing

- Verified that the diff view displays correctly for changelogs with changes.
- Verified that the snapshot view defaults to a single pane when no changes are present.
- Checked that status icons match the provided design screenshots.
- Ran `pnpm check` and `pnpm type-check` to ensure codebase health.

## Breaking Changes

None. Verified against the migration checklist.