### PR TITLE
fix(frontend): use consistent SQL Editor icon on database detail

### DIFF
--- a/frontend/src/react/pages/project/database-detail/DatabaseSQLEditorButton.tsx
+++ b/frontend/src/react/pages/project/database-detail/DatabaseSQLEditorButton.tsx
@@ -1,4 +1,4 @@
-import { Terminal } from "lucide-react";
+import { SquareTerminal } from "lucide-react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { router } from "@/router";
@@ -74,7 +74,7 @@ export function DatabaseSQLEditorButton({
       className="flex cursor-pointer items-center text-sm textlabel hover:text-accent md:mr-4"
       onClick={handleClick}
     >
-      <Terminal className="mr-1 h-4 w-4" />
+      <SquareTerminal className="mr-1 size-4" />
       {t("sql-editor.self")}
     </dd>
   );


### PR DESCRIPTION
## Summary
- The inline "SQL Editor" link in the database detail header used the plain `Terminal` lucide icon, while the top-right SQL Editor button in `DashboardHeader.vue` uses `SquareTerminal`. The mismatch looked off next to the environment badge and instance icon.
- Swapped `Terminal` → `SquareTerminal` in `DatabaseSQLEditorButton.tsx` so both entry points render the same icon.
- Also switched `h-4 w-4` → `size-4` per the shadcn guidelines in `frontend/AGENTS.md`.

## Test plan
- [ ] Visit a database detail page and confirm the inline "SQL Editor" link icon matches the top-right header button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)