### PR TITLE
fix: normalize revision payload file path between API and store layers

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -15890,7 +15890,8 @@ components:
           type: string
           title: file
           description: |-
-            Format: projects/{project}/releases/{release}/files/{id}
+            Format: projects/{project}/releases/{release}/files/{file_path}
+             The file_path segment is URL-encoded since file paths may contain "/".
              Can be empty.
         version:
           type: string

--- a/backend/api/v1/revision_service.go
+++ b/backend/api/v1/revision_service.go
@@ -303,6 +303,10 @@ func convertToRevisions(parent string, projectID string, revisions []*store.Revi
 
 func convertToRevision(parent string, projectID string, revision *store.RevisionMessage) *v1pb.Revision {
 	taskRunName := revision.Payload.TaskRun
+	file := revision.Payload.File
+	if file != "" && revision.Payload.Release != "" {
+		file = common.FormatReleaseFile(revision.Payload.Release, file)
+	}
 	r := &v1pb.Revision{
 		Name:        fmt.Sprintf("%s/%s%s", parent, common.RevisionNamePrefix, revision.ResourceID),
 		Release:     revision.Payload.Release,
@@ -310,7 +314,7 @@ func convertToRevision(parent string, projectID string, revision *store.Revision
 		Sheet:       common.FormatSheet(projectID, revision.Payload.SheetSha256),
 		SheetSha256: revision.Payload.SheetSha256,
 		Version:     revision.Version,
-		File:        revision.Payload.File,
+		File:        file,
 		TaskRun:     taskRunName,
 		Type:        convertToRevisionType(revision.Payload.Type),
 	}
@@ -340,13 +344,20 @@ func convertToRevisionType(t storepb.SchemaChangeType) v1pb.Revision_Type {
 }
 
 func convertRevision(revision *v1pb.Revision, database *store.DatabaseMessage, sheetSha256 string) *store.RevisionMessage {
+	file := revision.File
+	if file != "" {
+		_, _, fileID, err := common.GetProjectReleaseIDFile(file)
+		if err == nil {
+			file = fileID
+		}
+	}
 	r := &store.RevisionMessage{
 		InstanceID:   database.InstanceID,
 		DatabaseName: database.DatabaseName,
 		Version:      revision.Version,
 		Payload: &storepb.RevisionPayload{
 			Release:     revision.Release,
-			File:        revision.File,
+			File:        file,
 			SheetSha256: sheetSha256,
 			TaskRun:     revision.TaskRun,
 			Type:        convertRevisionType(revision.Type),

--- a/backend/common/resource_name.go
+++ b/backend/common/resource_name.go
@@ -3,6 +3,7 @@ package common
 
 import (
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -467,11 +468,23 @@ func GetProjectReleaseID(name string) (string, string, error) {
 }
 
 func GetProjectReleaseIDFile(name string) (string, string, string, error) {
-	tokens, err := GetNameParentTokens(name, ProjectNamePrefix, ReleaseNamePrefix, FileNamePrefix)
-	if err != nil {
-		return "", "", "", err
+	// Find the "files/" segment - everything after it is the encoded file path
+	parentPart, encodedFileID, found := strings.Cut(name, "/"+FileNamePrefix)
+	if !found {
+		return "", "", "", errors.Errorf("invalid release file name %q: missing files/ segment", name)
 	}
-	return tokens[0], tokens[1], tokens[2], nil
+
+	tokens, err := GetNameParentTokens(parentPart, ProjectNamePrefix, ReleaseNamePrefix)
+	if err != nil {
+		return "", "", "", errors.Errorf("invalid release file name %q", name)
+	}
+
+	fileID, err := url.PathUnescape(encodedFileID)
+	if err != nil {
+		return "", "", "", errors.Errorf("invalid release file name %q: failed to decode file ID", name)
+	}
+
+	return tokens[0], tokens[1], fileID, nil
 }
 
 // GetGroupEmail returns the group email.
@@ -612,7 +625,7 @@ func FormatReleaseName(projectID string, releaseID string) string {
 }
 
 func FormatReleaseFile(release string, fileID string) string {
-	return fmt.Sprintf("%s/%s%s", release, FileNamePrefix, fileID)
+	return fmt.Sprintf("%s/%s%s", release, FileNamePrefix, url.PathEscape(fileID))
 }
 
 func FormatRevision(instanceID, databaseID string, revisionID string) string {

--- a/backend/generated-go/store/revision.pb.go
+++ b/backend/generated-go/store/revision.pb.go
@@ -27,7 +27,7 @@ type RevisionPayload struct {
 	// Format: projects/{project}/releases/{release}
 	// Can be empty.
 	Release string `protobuf:"bytes,1,opt,name=release,proto3" json:"release,omitempty"`
-	// Format: projects/{project}/releases/{release}/files/{id}
+	// The file filepath.
 	// Can be empty.
 	File string `protobuf:"bytes,2,opt,name=file,proto3" json:"file,omitempty"`
 	// The SHA256 hash of the sheet content (hex-encoded).

--- a/backend/generated-go/v1/revision_service.pb.go
+++ b/backend/generated-go/v1/revision_service.pb.go
@@ -471,7 +471,8 @@ type Revision struct {
 	Deleter string `protobuf:"bytes,4,opt,name=deleter,proto3" json:"deleter,omitempty"`
 	// Can be empty.
 	DeleteTime *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=delete_time,json=deleteTime,proto3" json:"delete_time,omitempty"`
-	// Format: projects/{project}/releases/{release}/files/{id}
+	// Format: projects/{project}/releases/{release}/files/{file_path}
+	// The file_path segment is URL-encoded since file paths may contain "/".
 	// Can be empty.
 	File string `protobuf:"bytes,6,opt,name=file,proto3" json:"file,omitempty"`
 	// The schema version string for this revision.

--- a/backend/migrator/migration/3.17/0016##revision_file_path_normalize.sql
+++ b/backend/migrator/migration/3.17/0016##revision_file_path_normalize.sql
@@ -1,0 +1,18 @@
+-- Strip the resource name prefix from revision.payload.file, leaving only the plain file path.
+-- Old format: projects/{project}/releases/{release}/files/{path}
+-- New format: {path}
+-- The regexp_replace extracts everything after "files/" as the plain path.
+-- Note: Old data was never URL-encoded, so no decoding is needed.
+UPDATE revision
+SET payload = jsonb_set(
+    payload,
+    '{file}',
+    to_jsonb(
+        regexp_replace(
+            payload->>'file',
+            '^projects/[^/]+/releases/[^/]+/files/',
+            ''
+        )
+    )
+)
+WHERE payload->>'file' LIKE 'projects/%/releases/%/files/%';

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -15,8 +15,8 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.17.15"), *files[len(files)-1].version)
-	require.Equal(t, "migration/3.17/0015##dedupe_read_only_data_sources.sql", files[len(files)-1].path)
+	require.Equal(t, semver.MustParse("3.17.16"), *files[len(files)-1].version)
+	require.Equal(t, "migration/3.17/0016##revision_file_path_normalize.sql", files[len(files)-1].path)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/frontend/src/components/Revision/CreateRevisionDrawer.vue
+++ b/frontend/src/components/Revision/CreateRevisionDrawer.vue
@@ -833,7 +833,7 @@ const handleConfirm = async () => {
           revision: {
             release: selectedRelease.value!.name,
             version: file.version,
-            file: `${selectedRelease.value!.name}/files/${file.path}`,
+            file: `${selectedRelease.value!.name}/files/${encodeURIComponent(file.path)}`,
             sheet: file.sheet,
             type: mapReleaseTypeToRevisionType(selectedRelease.value!.type),
           },

--- a/frontend/src/types/proto-es/v1/revision_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/revision_service_pb.d.ts
@@ -231,7 +231,8 @@ export declare type Revision = Message<"bytebase.v1.Revision"> & {
   deleteTime?: Timestamp;
 
   /**
-   * Format: projects/{project}/releases/{release}/files/{id}
+   * Format: projects/{project}/releases/{release}/files/{file_path}
+   * The file_path segment is URL-encoded since file paths may contain "/".
    * Can be empty.
    *
    * @generated from field: string file = 6;

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -25176,7 +25176,8 @@ components:
           type: string
           title: file
           description: |-
-            Format: projects/{project}/releases/{release}/files/{id}
+            Format: projects/{project}/releases/{release}/files/{file_path}
+             The file_path segment is URL-encoded since file paths may contain "/".
              Can be empty.
         version:
           type: string

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -3933,7 +3933,7 @@ The severity level for SQL review rules.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | release | [string](#string) |  | Format: projects/{project}/releases/{release} Can be empty. |
-| file | [string](#string) |  | Format: projects/{project}/releases/{release}/files/{id} Can be empty. |
+| file | [string](#string) |  | The file filepath. Can be empty. |
 | sheet_sha256 | [string](#string) |  | The SHA256 hash of the sheet content (hex-encoded). |
 | task_run | [string](#string) |  | The task run associated with the revision. Can be empty. Format: projects/{project}/plans/{plan}/rollout/stages/{stage}/tasks/{task}/taskRuns/{taskRun} |
 | type | [SchemaChangeType](#bytebase-store-SchemaChangeType) |  | The type of the revision. |

--- a/proto/gen/grpc-doc/store/index.html
+++ b/proto/gen/grpc-doc/store/index.html
@@ -11141,7 +11141,7 @@ Can be empty. </p></td>
                   <td>file</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Format: projects/{project}/releases/{release}/files/{id}
+                  <td><p>The file filepath.
 Can be empty. </p></td>
                 </tr>
               

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -10374,7 +10374,7 @@ When paginating, all other parameters provided to `ListRevisions` must match the
 | create_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  |  |
 | deleter | [string](#string) |  | Format: users/hello@world.com Can be empty. |
 | delete_time | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | Can be empty. |
-| file | [string](#string) |  | Format: projects/{project}/releases/{release}/files/{id} Can be empty. |
+| file | [string](#string) |  | Format: projects/{project}/releases/{release}/files/{file_path} The file_path segment is URL-encoded since file paths may contain &#34;/&#34;. Can be empty. |
 | version | [string](#string) |  | The schema version string for this revision. |
 | sheet | [string](#string) |  | The sheet that holds the content. Format: projects/{project}/sheets/{sheet} |
 | sheet_sha256 | [string](#string) |  | The SHA256 hash value of the sheet. |

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -29297,7 +29297,8 @@ Can be empty. </p></td>
                   <td>file</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Format: projects/{project}/releases/{release}/files/{id}
+                  <td><p>Format: projects/{project}/releases/{release}/files/{file_path}
+The file_path segment is URL-encoded since file paths may contain &#34;/&#34;.
 Can be empty. </p></td>
                 </tr>
               

--- a/proto/store/store/revision.proto
+++ b/proto/store/store/revision.proto
@@ -12,7 +12,7 @@ message RevisionPayload {
   // Can be empty.
   string release = 1 [(google.api.resource_reference) = {type: "bytebase.com/Release"}];
 
-  // Format: projects/{project}/releases/{release}/files/{id}
+  // The file filepath.
   // Can be empty.
   string file = 2;
 

--- a/proto/v1/v1/revision_service.proto
+++ b/proto/v1/v1/revision_service.proto
@@ -155,7 +155,8 @@ message Revision {
   // Can be empty.
   google.protobuf.Timestamp delete_time = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-  // Format: projects/{project}/releases/{release}/files/{id}
+  // Format: projects/{project}/releases/{release}/files/{file_path}
+  // The file_path segment is URL-encoded since file paths may contain "/".
   // Can be empty.
   string file = 6;
 


### PR DESCRIPTION
## Summary

- Normalize `revision.payload.file` so the store layer always stores plain file paths (e.g. `2.2/V0001.sql`), while the API layer converts between plain paths and resource names (`projects/{project}/releases/{release}/files/{encoded_path}`)
- URL-encode the file path segment in API resource names to handle `/` in paths (e.g. `2.2%2FV0001.sql`)
- Add DB migration to strip old `projects/{project}/releases/{release}/files/` prefix from existing revision data

### Background

The `revision.payload.file` field had two writers producing different formats:
- **Executor** stored plain `file.Path` (e.g. `2.2/V0001.sql`)
- **API** stored the full resource name `projects/{project}/releases/{release}/files/{path}` as-is

Additionally, file paths containing `/` broke `GetNameParentTokens` which splits on `/` and expects a fixed segment count.

### Changes

- `GetProjectReleaseIDFile`: Custom parser using `strings.Cut` to find `/files/` segment, URL-decodes the file path
- `FormatReleaseFile`: URL-encodes file path with `url.PathEscape`
- `convertRevision` (API→store): Extracts plain file path from resource name before storing
- `convertToRevision` (store→API): Reconstructs full resource name from release + file
- Frontend `CreateRevisionDrawer`: Encodes file path with `encodeURIComponent`
- Migration: Strips `projects/{project}/releases/{release}/files/` prefix from existing data
- Proto comments updated to document URL-encoding

## Test plan

- [x] `golangci-lint run --allow-parallel-runners` — 0 issues
- [x] `go build` — passes
- [x] `TestLatestVersion` — passes
- [x] `buf format -w proto && buf lint proto` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Close BYT-9217 BYT-9219