### PR TITLE
fix(parser/pg): use GetDatabaseDefinition for catalog init [BYT-9215]

### DIFF
--- a/backend/plugin/parser/pg/completion_test.go
+++ b/backend/plugin/parser/pg/completion_test.go
@@ -133,11 +133,8 @@ func getMetadataForTest(_ context.Context, _, databaseName string) (string, *mod
 				},
 				Views: []*storepb.ViewMetadata{
 					{
-						Name: "v1",
-						Definition: `CREATE VIEW v1 AS
-						SELECT *
-						FROM t1
-						`,
+						Name:       "v1",
+						Definition: `SELECT * FROM t1`,
 					},
 				},
 				ExternalTables: []*storepb.ExternalTableMetadata{
@@ -163,10 +160,20 @@ func getMetadataForTest(_ context.Context, _, databaseName string) (string, *mod
 				},
 				Sequences: []*storepb.SequenceMetadata{
 					{
-						Name: "seq1",
+						Name:      "seq1",
+						DataType:  "bigint",
+						Start:     "1",
+						Increment: "1",
+						MinValue:  "1",
+						MaxValue:  "9223372036854775807",
 					},
 					{
-						Name: "user_id_seq",
+						Name:      "user_id_seq",
+						DataType:  "bigint",
+						Start:     "1",
+						Increment: "1",
+						MinValue:  "1",
+						MaxValue:  "9223372036854775807",
 					},
 				},
 			},
@@ -202,7 +209,12 @@ func getMetadataForTest(_ context.Context, _, databaseName string) (string, *mod
 				},
 				Sequences: []*storepb.SequenceMetadata{
 					{
-						Name: "order_id_seq",
+						Name:      "order_id_seq",
+						DataType:  "bigint",
+						Start:     "1",
+						Increment: "1",
+						MinValue:  "1",
+						MaxValue:  "9223372036854775807",
 					},
 				},
 			},

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -2,8 +2,7 @@ package pg
 
 import (
 	"context"
-
-	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -12,8 +11,10 @@ import (
 	"github.com/bytebase/omni/pg/catalog"
 	omniparser "github.com/bytebase/omni/pg/parser"
 
+	"github.com/bytebase/bytebase/backend/common/log"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
 	"github.com/bytebase/bytebase/backend/store/model"
 )
 
@@ -79,9 +80,9 @@ func (e *omniQuerySpanExtractor) getDatabaseMetadata(database string) (*model.Da
 }
 
 // initCatalog initializes the omni catalog from the database metadata.
-// It generates minimal DDL from the metadata proto and loads it into the catalog.
-// We generate DDL directly here instead of using schema.GetDatabaseDefinition
-// to avoid circular imports (schema/pg imports parser/pg).
+// It uses schemapg.GetDatabaseDefinition to produce complete DDL (including
+// CREATE TYPE, CREATE SEQUENCE, dependency ordering, etc.), the same
+// approach used by WalkThroughOmni.
 func (e *omniQuerySpanExtractor) initCatalog() error {
 	meta, err := e.getDatabaseMetadata(e.defaultDatabase)
 	if err != nil {
@@ -95,9 +96,21 @@ func (e *omniQuerySpanExtractor) initCatalog() error {
 		return nil
 	}
 
-	ddl := buildMinimalDDL(meta.GetProto())
+	ddl, err := schema.GetDatabaseDefinition(
+		storepb.Engine_POSTGRES,
+		schema.GetDefinitionContext{},
+		meta.GetProto(),
+	)
+	if err != nil {
+		return errors.Wrapf(err, "failed to generate schema DDL for catalog init")
+	}
 	if ddl != "" {
 		if _, err := e.cat.Exec(ddl, &catalog.ExecOptions{ContinueOnError: true}); err != nil {
+			slog.Error("failed to parse schema DDL for catalog init",
+				slog.String("database", e.defaultDatabase),
+				log.BBError(err),
+				slog.String("context", ddlErrorContext(ddl, err)),
+			)
 			return errors.Wrapf(err, "failed to load schema DDL into catalog")
 		}
 	}
@@ -117,77 +130,27 @@ func (e *omniQuerySpanExtractor) initCatalog() error {
 	return nil
 }
 
-// buildMinimalDDL generates CREATE SCHEMA / CREATE TABLE / CREATE VIEW / CREATE FUNCTION
-// statements from metadata, sufficient for omni's AnalyzeSelectStmt to resolve columns.
-func buildMinimalDDL(meta *storepb.DatabaseSchemaMetadata) string {
-	if meta == nil {
-		return ""
+// ddlErrorContext extracts a snippet around the error position from the DDL.
+// If err is a *omniparser.ParseError with a position, it shows ~200 bytes
+// around that position. Otherwise returns the first 500 bytes.
+func ddlErrorContext(ddl string, err error) string {
+	var parseErr *omniparser.ParseError
+	if errors.As(err, &parseErr) && parseErr.Position > 0 {
+		pos := parseErr.Position
+		start := pos - 100
+		if start < 0 {
+			start = 0
+		}
+		end := pos + 100
+		if end > len(ddl) {
+			end = len(ddl)
+		}
+		return ddl[start:end]
 	}
-	var b strings.Builder
-	for _, s := range meta.Schemas {
-		schemaName := s.Name
-		if schemaName != "public" && schemaName != "pg_catalog" {
-			fmt.Fprintf(&b, "CREATE SCHEMA IF NOT EXISTS %s;\n", quoteIdentifier(schemaName))
-		}
-		for _, t := range s.Tables {
-			buildCreateTable(&b, schemaName, t)
-		}
-		for _, v := range s.Views {
-			buildCreateView(&b, schemaName, v)
-		}
-		for _, v := range s.MaterializedViews {
-			buildCreateMaterializedView(&b, schemaName, v)
-		}
-		for _, f := range s.Functions {
-			if f.Definition != "" {
-				// Load the function with a stubbed body to avoid type validation
-				// failures. The catalog needs the function signature (name, params,
-				// return type) to resolve SELECT * FROM func(), but the actual body
-				// is analyzed separately via analyzeFunctionBody. Stubbing the body
-				// avoids errors when table column types default to text but the
-				// function declares int parameters.
-				stubbed := stubFunctionBody(f.Definition)
-				fmt.Fprintf(&b, "%s;\n", strings.TrimSuffix(strings.TrimSpace(stubbed), ";"))
-			}
-		}
+	if len(ddl) > 500 {
+		return ddl[:500] + "...(truncated)"
 	}
-	return b.String()
-}
-
-func buildCreateTable(b *strings.Builder, schema string, t *storepb.TableMetadata) {
-	fmt.Fprintf(b, "CREATE TABLE %s.%s (\n", quoteIdentifier(schema), quoteIdentifier(t.Name))
-	for i, c := range t.Columns {
-		colType := c.Type
-		if colType == "" {
-			colType = "text"
-		}
-		fmt.Fprintf(b, "  %s %s", quoteIdentifier(c.Name), colType)
-		if i < len(t.Columns)-1 {
-			b.WriteString(",")
-		}
-		b.WriteString("\n")
-	}
-	b.WriteString(");\n")
-}
-
-func buildCreateView(b *strings.Builder, schema string, v *storepb.ViewMetadata) {
-	if v.Definition == "" {
-		return
-	}
-	def := strings.TrimSuffix(strings.TrimSpace(v.Definition), ";")
-	fmt.Fprintf(b, "CREATE VIEW %s.%s AS %s;\n", quoteIdentifier(schema), quoteIdentifier(v.Name), def)
-}
-
-func buildCreateMaterializedView(b *strings.Builder, schema string, v *storepb.MaterializedViewMetadata) {
-	if v.Definition == "" {
-		return
-	}
-	def := strings.TrimSuffix(strings.TrimSpace(v.Definition), ";")
-	fmt.Fprintf(b, "CREATE MATERIALIZED VIEW %s.%s AS %s;\n", quoteIdentifier(schema), quoteIdentifier(v.Name), def)
-}
-
-func quoteIdentifier(name string) string {
-	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+	return ddl
 }
 
 // extractFuncBodyFromDef extracts the dollar-quoted function body from a
@@ -226,39 +189,6 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 		}
 	}
 	return "", 0, 0
-}
-
-// stubFunctionBody replaces the body of a CREATE FUNCTION statement with a
-// minimal stub. This avoids catalog type validation failures when table column
-// types are unknown (defaulting to text) while the function declares specific
-// return types. The function signature is preserved so the catalog can resolve
-// function calls.
-func stubFunctionBody(definition string) string {
-	tag, bodyStart, bodyEnd := findDollarQuotedBody(definition)
-	if tag == "" {
-		return definition
-	}
-
-	// Determine language for appropriate stub body.
-	upper := strings.ToUpper(definition)
-	lang := ""
-	if langIdx := strings.Index(upper, "LANGUAGE"); langIdx >= 0 {
-		rest := strings.TrimSpace(definition[langIdx+8:])
-		parts := strings.Fields(rest)
-		if len(parts) > 0 {
-			lang = strings.ToLower(strings.TrimRight(parts[0], ";"))
-		}
-	}
-
-	var stubBody string
-	switch lang {
-	case "plpgsql":
-		stubBody = " BEGIN RETURN; END; "
-	default:
-		stubBody = " SELECT NULL "
-	}
-
-	return definition[:bodyStart] + stubBody + definition[bodyEnd-len(tag):]
 }
 
 // getQuerySpan extracts the query span for the given SQL statement.

--- a/backend/plugin/parser/pg/schema_init_test.go
+++ b/backend/plugin/parser/pg/schema_init_test.go
@@ -1,0 +1,6 @@
+package pg
+
+import (
+	// Register PG schema definition generator for tests.
+	_ "github.com/bytebase/bytebase/backend/plugin/schema/pg"
+)

--- a/backend/plugin/parser/pg/test-data/query_span.yaml
+++ b/backend/plugin/parser/pg/test-data/query_span.yaml
@@ -119,13 +119,16 @@
               "name":  "t1",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name": "c"
+                  "name": "c",
+                  "type": "text"
                 }
               ]
             },
@@ -133,13 +136,16 @@
               "name":  "t2",
               "columns":  [
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 },
                 {
-                  "name":  "e"
+                  "name":  "e",
+                  "type": "text"
                 }
               ]
             }
@@ -227,10 +233,12 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 }
               ]
             },
@@ -238,10 +246,12 @@
               "name":  "t2",
               "columns":  [
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -309,10 +319,12 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 }
               ]
             },
@@ -320,10 +332,12 @@
               "name":  "t2",
               "columns":  [
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -870,10 +884,12 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 }
               ]
             }
@@ -931,7 +947,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -973,7 +990,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1015,7 +1033,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1057,7 +1076,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1109,7 +1129,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1151,7 +1172,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1193,7 +1215,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1230,7 +1253,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1262,7 +1286,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1294,7 +1319,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1326,7 +1352,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1378,7 +1405,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             },
@@ -1386,7 +1414,8 @@
               "name":  "t2",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1444,7 +1473,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1492,7 +1522,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1544,7 +1575,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1592,7 +1624,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1619,7 +1652,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -1651,16 +1685,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -1742,16 +1780,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -1823,16 +1865,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -1904,16 +1950,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -1975,16 +2025,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -2021,10 +2075,12 @@
               "name":  "galleries",
               "columns":  [
                 {
-                  "name":  "id"
+                  "name":  "id",
+                  "type": "text"
                 },
                 {
-                  "name":  "city"
+                  "name":  "city",
+                  "type": "text"
                 }
               ]
             },
@@ -2032,16 +2088,20 @@
               "name":  "paintings",
               "columns":  [
                 {
-                  "name":  "gallery_id"
+                  "name":  "gallery_id",
+                  "type": "text"
                 },
                 {
-                  "name":  "artist_id"
+                  "name":  "artist_id",
+                  "type": "text"
                 },
                 {
-                  "name":  "title"
+                  "name":  "title",
+                  "type": "text"
                 },
                 {
-                  "name":  "price"
+                  "name":  "price",
+                  "type": "text"
                 }
               ]
             }
@@ -2103,16 +2163,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -2224,10 +2288,12 @@
               "name":  "t1",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 }
               ]
             },
@@ -2235,10 +2301,12 @@
               "name":  "t2",
               "columns":  [
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -2310,16 +2378,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -2421,16 +2493,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -2502,16 +2578,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -2553,16 +2633,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -2634,16 +2718,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -2730,16 +2818,20 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 }
               ]
             }
@@ -2811,7 +2903,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -2837,17 +2930,17 @@
             {
               "name": "users",
               "columns": [
-                {"name": "id"},
-                {"name": "name"},
-                {"name": "email"}
+                {"name": "id", "type": "text"},
+                {"name": "name", "type": "text"},
+                {"name": "email", "type": "text"}
               ]
             },
             {
               "name": "payments",
               "columns": [
-                {"name": "id"},
-                {"name": "user_id"},
-                {"name": "amount"}
+                {"name": "id", "type": "text"},
+                {"name": "user_id", "type": "text"},
+                {"name": "amount", "type": "text"}
               ]
             }
           ]
@@ -2943,7 +3036,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -2995,7 +3089,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -3047,7 +3142,8 @@
               "name":  "t",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 }
               ]
             }
@@ -3105,9 +3201,9 @@
             {
               "name":  "t1",
               "columns":  [
-                {"name":  "id"},
-                {"name":  "scores"},
-                {"name":  "finished_at"}
+                {"name": "id", "type": "text"},
+                {"name": "scores", "type": "text"},
+                {"name": "finished_at", "type": "text"}
               ]
             }
           ]

--- a/backend/plugin/parser/pg/test-data/query_type.yaml
+++ b/backend/plugin/parser/pg/test-data/query_type.yaml
@@ -24,13 +24,16 @@
               "name":  "t1",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name": "c"
+                  "name": "c",
+                  "type": "text"
                 }
               ]
             },
@@ -38,13 +41,16 @@
               "name":  "t2",
               "columns":  [
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 },
                 {
-                  "name":  "e"
+                  "name":  "e",
+                  "type": "text"
                 }
               ]
             }
@@ -77,13 +83,16 @@
               "name":  "t1",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name": "c"
+                  "name": "c",
+                  "type": "text"
                 }
               ]
             },
@@ -91,13 +100,16 @@
               "name":  "t2",
               "columns":  [
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 },
                 {
-                  "name":  "e"
+                  "name":  "e",
+                  "type": "text"
                 }
               ]
             }
@@ -130,13 +142,16 @@
               "name":  "t1",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name": "c"
+                  "name": "c",
+                  "type": "text"
                 }
               ]
             },
@@ -144,13 +159,16 @@
               "name":  "t2",
               "columns":  [
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 },
                 {
-                  "name":  "e"
+                  "name":  "e",
+                  "type": "text"
                 }
               ]
             }
@@ -183,13 +201,16 @@
               "name":  "t1",
               "columns":  [
                 {
-                  "name":  "a"
+                  "name":  "a",
+                  "type": "text"
                 },
                 {
-                  "name":  "b"
+                  "name":  "b",
+                  "type": "text"
                 },
                 {
-                  "name": "c"
+                  "name": "c",
+                  "type": "text"
                 }
               ]
             },
@@ -197,13 +218,16 @@
               "name":  "t2",
               "columns":  [
                 {
-                  "name":  "c"
+                  "name":  "c",
+                  "type": "text"
                 },
                 {
-                  "name":  "d"
+                  "name":  "d",
+                  "type": "text"
                 },
                 {
-                  "name":  "e"
+                  "name":  "e",
+                  "type": "text"
                 }
               ]
             }
@@ -240,8 +264,8 @@
             {
               "name":  "t",
               "columns":  [
-                {"name":  "a"},
-                {"name":  "b"}
+                {"name": "a", "type": "text"},
+                {"name": "b", "type": "text"}
               ]
             }
           ]
@@ -266,7 +290,7 @@
             {
               "name":  "t",
               "columns":  [
-                {"name":  "id"}
+                {"name": "id", "type": "text"}
               ]
             }
           ]

--- a/backend/plugin/schema/pg/get_database_definition_sdl_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_sdl_test.go
@@ -7,8 +7,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	omnipg "github.com/bytebase/omni/pg"
+
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
 
@@ -1314,7 +1315,7 @@ CREATE TABLE "test"."table1" (
 			}
 
 			// Validate that the generated SQL can be parsed without errors using ANTLR parser
-			_, err = pgparser.ParsePg(result)
+			_, err = omnipg.Parse(result)
 			require.NoError(t, err, "Generated SQL should be parseable by PostgreSQL parser")
 		})
 	}
@@ -1370,7 +1371,7 @@ func TestCheckConstraintNotValidFormatNormalMode(t *testing.T) {
 	assert.Contains(t, result, ") NOT VALID", "NOT VALID should be after CHECK expression parenthesis")
 
 	// Validate that the generated SQL can be parsed without errors using ANTLR parser
-	_, err = pgparser.ParsePg(result)
+	_, err = omnipg.Parse(result)
 	require.NoError(t, err, "Generated SQL should be parseable by PostgreSQL parser")
 }
 
@@ -1479,7 +1480,7 @@ func TestGetDatabaseDefinitionSDLFormat_WithComments(t *testing.T) {
 	assert.Contains(t, result, `COMMENT ON INDEX "test_schema"."idx_users_email" IS 'Index on email column';`)
 
 	// Validate that the generated SQL can be parsed without errors using ANTLR parser
-	_, err = pgparser.ParsePg(result)
+	_, err = omnipg.Parse(result)
 	require.NoError(t, err, "Generated SQL should be parseable by PostgreSQL parser")
 }
 
@@ -1518,7 +1519,7 @@ func TestGetDatabaseDefinitionSDLFormat_WithCommentsEscaping(t *testing.T) {
 	assert.Contains(t, result, `COMMENT ON COLUMN "public"."test_table"."id" IS 'Column with ''quoted'' text';`)
 
 	// Validate that the generated SQL can be parsed without errors using ANTLR parser
-	_, err = pgparser.ParsePg(result)
+	_, err = omnipg.Parse(result)
 	require.NoError(t, err, "Generated SQL should be parseable by PostgreSQL parser")
 }
 
@@ -1645,7 +1646,7 @@ func TestGetMultiFileDatabaseDefinition_WithComments(t *testing.T) {
 
 	// Validate that each file's SQL can be parsed
 	for fileName, content := range fileMap {
-		_, err := pgparser.ParsePg(content)
+		_, err := omnipg.Parse(content)
 		require.NoError(t, err, "SQL in file %s should be parseable by PostgreSQL parser", fileName)
 	}
 }
@@ -1945,7 +1946,7 @@ ALTER SEQUENCE "public"."test_sequence2" OWNED BY "public"."test_table"."id";
 		"Column should use serial type because it references test_table_id_seq which is owned by it")
 
 	// Validate that the generated SQL can be parsed
-	_, err = pgparser.ParsePg(result)
+	_, err = omnipg.Parse(result)
 	require.NoError(t, err, "Generated SQL should be parseable by PostgreSQL parser")
 }
 
@@ -2006,7 +2007,7 @@ $$`,
 		"Procedure comment should NOT use COMMENT ON FUNCTION")
 
 	// Validate that the generated SQL can be parsed
-	_, err = pgparser.ParsePg(result)
+	_, err = omnipg.Parse(result)
 	require.NoError(t, err, "Generated SQL should be parseable by PostgreSQL parser")
 }
 
@@ -2103,7 +2104,7 @@ $$`,
 
 	// Validate that each file's SQL can be parsed
 	for fileName, content := range fileMap {
-		_, err := pgparser.ParsePg(content)
+		_, err := omnipg.Parse(content)
 		require.NoError(t, err, "SQL in file %s should be parseable by PostgreSQL parser", fileName)
 	}
 }

--- a/backend/plugin/schema/pg/walk_through_omni.go
+++ b/backend/plugin/schema/pg/walk_through_omni.go
@@ -11,7 +11,6 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
-	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 	"github.com/bytebase/bytebase/backend/store/model"
 )
@@ -483,7 +482,7 @@ func extractViewDependencies(schemaMetadata *storepb.DatabaseSchemaMetadata) {
 
 func getViewDependencies(viewDef string, schemaName string, fullSchemaMetadata *storepb.DatabaseSchemaMetadata) []*storepb.DependencyColumn {
 	queryStatement := strings.TrimSpace(viewDef)
-	span, err := pgparser.GetQuerySpan(
+	spans, err := base.GetQuerySpan(
 		context.Background(),
 		base.GetQuerySpanContext{
 			GetDatabaseMetadataFunc: func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
@@ -494,14 +493,16 @@ func getViewDependencies(viewDef string, schemaName string, fullSchemaMetadata *
 				return []string{}, nil
 			},
 		},
-		base.Statement{Text: queryStatement},
+		storepb.Engine_POSTGRES,
+		[]base.Statement{{Text: queryStatement}},
 		"",
 		schemaName,
 		false,
 	)
-	if err != nil {
+	if err != nil || len(spans) == 0 {
 		return []*storepb.DependencyColumn{}
 	}
+	span := spans[0]
 
 	dependencyMap := make(map[string]*storepb.DependencyColumn)
 	for sourceColumn := range span.SourceColumns {


### PR DESCRIPTION
## Summary

- Replace hand-rolled `buildMinimalDDL` with `schema.GetDatabaseDefinition` for initializing the omni catalog in `GetQuerySpan`. `buildMinimalDDL` generated incomplete DDL (missing `CREATE TYPE`, `CREATE SEQUENCE`, dependency ordering) which could cause parse failures on customer databases with complex schemas.
- Break the circular dependency (`parser/pg` → `schema/pg` → `parser/pg`) properly by changing `walk_through_omni.go` to use `base.GetQuerySpan` (registry-based) instead of directly importing `parser/pg`.
- Add error logging with DDL context snippet (±100 bytes around error position) when catalog init fails, for easier debugging.

## Test plan

- [x] All existing `parser/pg` tests pass (`TestGetQuerySpan`, `TestCompletion`, etc.)
- [x] All existing `schema/pg` tests pass (`TestWalkThrough`, etc.)
- [x] Build succeeds with no circular import errors
- [ ] Verify on a real PG database with enums, views with `::` casts, and functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)