### PR TITLE
fix(frontend): align shadcn react patterns

### DIFF
--- a/frontend/src/react/components/FeatureAttention.test.tsx
+++ b/frontend/src/react/components/FeatureAttention.test.tsx
@@ -116,6 +116,7 @@ describe("FeatureAttention", () => {
 
     const alert = container.querySelector('[role="alert"]');
     expect(alert).toBeTruthy();
+    expect(alert?.querySelectorAll("svg")).toHaveLength(1);
 
     const actionButton = [...container.querySelectorAll("button")].find(
       (button) =>

--- a/frontend/src/react/components/FeatureAttention.test.tsx
+++ b/frontend/src/react/components/FeatureAttention.test.tsx
@@ -1,0 +1,137 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ENTERPRISE_INQUIRE_LINK } from "@/types/common";
+import {
+  PlanFeature,
+  PlanType,
+} from "@/types/proto-es/v1/subscription_service_pb";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  useTranslation: vi.fn(() => ({
+    t: (key: string) => key,
+  })),
+  useVueState: vi.fn((getter: () => unknown) => getter()),
+  useSubscriptionV1Store: vi.fn(),
+  useActuatorV1Store: vi.fn(),
+  hasWorkspacePermissionV2: vi.fn(() => true),
+  autoSubscriptionRoute: vi.fn(() => "/subscription"),
+  routerPush: vi.fn(),
+}));
+
+let FeatureAttention: typeof import("./FeatureAttention").FeatureAttention;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: mocks.useTranslation,
+}));
+
+vi.mock("@/react/hooks/useVueState", () => ({
+  useVueState: mocks.useVueState,
+}));
+
+vi.mock("@/react/components/InstanceAssignmentBridge", () => ({
+  InstanceAssignmentBridge: () => null,
+}));
+
+vi.mock("@/router", () => ({
+  router: {
+    push: mocks.routerPush,
+  },
+}));
+
+vi.mock("@/store", () => ({
+  useSubscriptionV1Store: mocks.useSubscriptionV1Store,
+  useActuatorV1Store: mocks.useActuatorV1Store,
+}));
+
+vi.mock("@/types", () => ({
+  ENTERPRISE_INQUIRE_LINK,
+  instanceLimitFeature: new Set<PlanFeature>(),
+}));
+
+vi.mock("@/utils", () => ({
+  autoSubscriptionRoute: mocks.autoSubscriptionRoute,
+  hasWorkspacePermissionV2: mocks.hasWorkspacePermissionV2,
+}));
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  return {
+    container,
+    render: () => {
+      act(() => {
+        root.render(element);
+      });
+    },
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
+};
+
+beforeEach(async () => {
+  mocks.useTranslation.mockReset();
+  mocks.useTranslation.mockReturnValue({
+    t: (key: string) => key,
+  });
+  mocks.useVueState.mockReset();
+  mocks.useVueState.mockImplementation((getter: () => unknown) => getter());
+  mocks.useSubscriptionV1Store.mockReset();
+  mocks.useSubscriptionV1Store.mockReturnValue({
+    hasInstanceFeature: vi.fn(() => false),
+    instanceMissingLicense: vi.fn(() => false),
+    isTrialing: false,
+    trialingDays: 14,
+    getMinimumRequiredPlan: vi.fn(() => PlanType.TEAM),
+  });
+  mocks.useActuatorV1Store.mockReset();
+  mocks.useActuatorV1Store.mockReturnValue({
+    totalInstanceCount: 0,
+    activatedInstanceCount: 0,
+  });
+  mocks.hasWorkspacePermissionV2.mockReset();
+  mocks.hasWorkspacePermissionV2.mockReturnValue(true);
+  mocks.autoSubscriptionRoute.mockReset();
+  mocks.autoSubscriptionRoute.mockReturnValue("/subscription");
+  mocks.routerPush.mockReset();
+  ({ FeatureAttention } = await import("./FeatureAttention"));
+});
+
+describe("FeatureAttention", () => {
+  test("renders warning state as an alert and opens the inquiry link", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    const { container, render, unmount } = renderIntoContainer(
+      <FeatureAttention feature={PlanFeature.FEATURE_AUDIT_LOG} />
+    );
+
+    render();
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+
+    const actionButton = [...container.querySelectorAll("button")].find(
+      (button) =>
+        button.textContent?.includes("subscription.request-n-days-trial")
+    );
+    expect(actionButton).toBeTruthy();
+
+    act(() => {
+      actionButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(openSpy).toHaveBeenCalledWith(ENTERPRISE_INQUIRE_LINK, "_blank");
+
+    openSpy.mockRestore();
+    unmount();
+  });
+});

--- a/frontend/src/react/components/FeatureAttention.tsx
+++ b/frontend/src/react/components/FeatureAttention.tsx
@@ -1,6 +1,11 @@
 import { CircleAlert, Info } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { router } from "@/router";
 import { useActuatorV1Store, useSubscriptionV1Store } from "@/store";
@@ -115,34 +120,14 @@ export function FeatureAttention({
 
   return (
     <>
-      <div
-        className={`flex items-start gap-3 rounded-xs border px-4 py-3 ${
-          isWarning
-            ? "border-yellow-300 bg-yellow-50"
-            : "border-blue-200 bg-blue-50"
-        }`}
-      >
-        <Icon
-          className={`w-5 h-5 mt-0.5 shrink-0 ${
-            isWarning ? "text-yellow-600" : "text-blue-600"
-          }`}
-        />
+      <Alert variant={isWarning ? "warning" : "info"}>
+        <Icon className="size-5 mt-0.5 shrink-0" />
         <div className="flex-1 flex flex-col gap-3">
-          <div>
-            <p
-              className={`font-medium text-sm ${
-                isWarning ? "text-yellow-800" : "text-blue-800"
-              }`}
-            >
-              {title}
-            </p>
-            <p
-              className={`text-sm whitespace-pre-line mt-1 ${
-                isWarning ? "text-yellow-700" : "text-blue-700"
-              }`}
-            >
+          <div className="flex flex-col gap-1">
+            <AlertTitle>{title}</AlertTitle>
+            <AlertDescription className="mt-0 whitespace-pre-line">
               {descriptionText}
-            </p>
+            </AlertDescription>
           </div>
           {actionText && (
             <div className="flex justify-end">
@@ -157,7 +142,7 @@ export function FeatureAttention({
             </div>
           )}
         </div>
-      </div>
+      </Alert>
       <InstanceAssignmentBridge
         open={showInstanceAssignment}
         selectedInstanceList={instance ? [instance.name] : []}

--- a/frontend/src/react/components/FeatureAttention.tsx
+++ b/frontend/src/react/components/FeatureAttention.tsx
@@ -120,7 +120,7 @@ export function FeatureAttention({
 
   return (
     <>
-      <Alert variant={isWarning ? "warning" : "info"}>
+      <Alert variant={isWarning ? "warning" : "info"} showIcon={false}>
         <Icon className="size-5 mt-0.5 shrink-0" />
         <div className="flex-1 flex flex-col gap-3">
           <div className="flex flex-col gap-1">

--- a/frontend/src/react/components/sql-review/TemplateSelector.test.tsx
+++ b/frontend/src/react/components/sql-review/TemplateSelector.test.tsx
@@ -1,0 +1,132 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { SQLReviewPolicyTemplateV2 } from "@/types/sqlReview";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const reviewTemplate: SQLReviewPolicyTemplateV2 & {
+  review: { name: string; resources: string[] };
+} = {
+  id: "reviews/example",
+  ruleList: [],
+  review: {
+    name: "Existing policy",
+    resources: ["environments/test"],
+  },
+};
+
+const mocks = vi.hoisted(() => ({
+  useTranslation: vi.fn(() => ({
+    t: (key: string) => key,
+  })),
+  useVueState: vi.fn((getter: () => unknown) => getter()),
+  rulesToTemplate: vi.fn(() => reviewTemplate),
+  useProjectV1Store: vi.fn(),
+  useSQLReviewStore: vi.fn(),
+}));
+
+let TemplateSelector: typeof import("./TemplateSelector").TemplateSelector;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: mocks.useTranslation,
+}));
+
+vi.mock("@/react/hooks/useVueState", () => ({
+  useVueState: mocks.useVueState,
+}));
+
+vi.mock("@/components/SQLReview/components/utils", () => ({
+  rulesToTemplate: mocks.rulesToTemplate,
+}));
+
+vi.mock("@/react/components/EnvironmentLabel", () => ({
+  EnvironmentLabel: ({ environmentName }: { environmentName: string }) => (
+    <span>{environmentName}</span>
+  ),
+}));
+
+vi.mock("@/types", () => ({
+  TEMPLATE_LIST_V2: [
+    {
+      id: "builtin/default",
+      ruleList: [],
+    },
+  ],
+}));
+
+vi.mock("@/store", () => ({
+  useProjectV1Store: mocks.useProjectV1Store,
+  useSQLReviewStore: mocks.useSQLReviewStore,
+}));
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  return {
+    container,
+    render: () => {
+      act(() => {
+        root.render(element);
+      });
+    },
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
+};
+
+beforeEach(async () => {
+  mocks.useTranslation.mockReset();
+  mocks.useTranslation.mockReturnValue({
+    t: (key: string) => key,
+  });
+  mocks.useVueState.mockReset();
+  mocks.useVueState.mockImplementation((getter: () => unknown) => getter());
+  mocks.rulesToTemplate.mockReset();
+  mocks.rulesToTemplate.mockReturnValue(reviewTemplate);
+  mocks.useProjectV1Store.mockReset();
+  mocks.useProjectV1Store.mockReturnValue({
+    getOrFetchProjectByName: vi.fn(),
+    getProjectByName: vi.fn(() => undefined),
+  });
+  mocks.useSQLReviewStore.mockReset();
+  mocks.useSQLReviewStore.mockReturnValue({
+    reviewPolicyList: [{ id: "policy-1" }],
+    fetchReviewPolicyList: vi.fn(),
+  });
+  ({ TemplateSelector } = await import("./TemplateSelector"));
+});
+
+describe("TemplateSelector", () => {
+  test("renders review templates as semantic buttons", () => {
+    const onSelectTemplate = vi.fn();
+    const { container, render, unmount } = renderIntoContainer(
+      <TemplateSelector onSelectTemplate={onSelectTemplate} />
+    );
+
+    render();
+
+    const buttons = [...container.querySelectorAll("button")];
+    const reviewButton = buttons.find((button) =>
+      button.textContent?.includes("Existing policy")
+    );
+
+    expect(reviewButton).toBeTruthy();
+
+    act(() => {
+      reviewButton?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onSelectTemplate).toHaveBeenCalledWith(reviewTemplate);
+
+    unmount();
+  });
+});

--- a/frontend/src/react/components/sql-review/TemplateSelector.tsx
+++ b/frontend/src/react/components/sql-review/TemplateSelector.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from "react-i18next";
 import { rulesToTemplate } from "@/components/SQLReview/components/utils";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { Badge } from "@/react/components/ui/badge";
+import { Separator } from "@/react/components/ui/separator";
 import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
 import { useProjectV1Store, useSQLReviewStore } from "@/store";
 import {
   environmentNamePrefix,
@@ -91,18 +93,22 @@ export function TemplateSelector({
     <div className="flex flex-col gap-y-2">
       <p className="textlabel">
         {t("sql-review.create.basic-info.choose-template")}
-        {required && <span className="text-red-500"> *</span>}
+        {required && <span className="text-error"> *</span>}
       </p>
 
       {reviewPolicyTemplateList.length > 0 && (
         <>
           <div className="flex flex-wrap gap-4">
             {reviewPolicyTemplateList.map((template) => (
-              <div
+              <button
+                type="button"
                 key={template.id}
-                className={`relative border border-gray-300 hover:bg-gray-100 rounded-sm px-6 py-4 transition-all cursor-pointer w-full sm:max-w-xs ${
-                  isSelected(template) ? "bg-gray-100" : "bg-transparent"
-                }`}
+                aria-pressed={isSelected(template)}
+                className={cn(
+                  "relative flex w-full cursor-pointer flex-col rounded-sm border border-control-border px-6 py-4 text-left transition-colors sm:max-w-xs",
+                  "hover:bg-control-bg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
+                  isSelected(template) && "bg-control-bg"
+                )}
                 onClick={() => onSelectTemplate(template)}
               >
                 <div className="text-left flex flex-col gap-y-2">
@@ -122,30 +128,34 @@ export function TemplateSelector({
                   </p>
                 </div>
                 {isSelected(template) && (
-                  <CheckCircle className="w-7 h-7 text-accent absolute top-3 right-3" />
+                  <CheckCircle className="absolute right-3 top-3 size-7 text-accent" />
                 )}
-              </div>
+              </button>
             ))}
           </div>
 
-          <hr className="border-gray-200 my-2" />
+          <Separator className="my-2" />
         </>
       )}
 
       <div className="flex flex-wrap gap-4">
         {builtInTemplateList.map((template) => (
-          <div
+          <button
+            type="button"
             key={template.id}
-            className={`relative border border-gray-300 hover:bg-gray-100 rounded-sm px-6 py-4 transition-all cursor-pointer w-full sm:max-w-xs ${
-              isSelected(template) ? "bg-gray-100" : "bg-transparent"
-            }`}
+            aria-pressed={isSelected(template)}
+            className={cn(
+              "relative flex w-full cursor-pointer flex-col rounded-sm border border-control-border px-6 py-4 text-left transition-colors sm:max-w-xs",
+              "hover:bg-control-bg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
+              isSelected(template) && "bg-control-bg"
+            )}
             onClick={() => onSelectTemplate(template)}
           >
             <div className="text-left flex flex-col gap-y-2">
               <span className="text-base font-medium">
                 {t(`sql-review.template.${template.id.split(".").join("-")}`)}
               </span>
-              <p className="text-sm text-gray-500">
+              <p className="text-sm text-control-light">
                 {t(
                   `sql-review.template.${template.id.split(".").join("-")}-desc`
                 )}
@@ -156,9 +166,9 @@ export function TemplateSelector({
               </p>
             </div>
             {isSelected(template) && (
-              <CheckCircle className="w-7 h-7 text-accent absolute top-3 right-3" />
+              <CheckCircle className="absolute right-3 top-3 size-7 text-accent" />
             )}
-          </div>
+          </button>
         ))}
       </div>
     </div>

--- a/frontend/src/react/components/ui/select.tsx
+++ b/frontend/src/react/components/ui/select.tsx
@@ -44,7 +44,7 @@ function SelectContent({
 }: ComponentProps<typeof BaseSelect.Popup>) {
   return (
     <BaseSelect.Portal>
-      <BaseSelect.Positioner sideOffset={4} className="z-[100]">
+      <BaseSelect.Positioner sideOffset={4}>
         <BaseSelect.Popup
           ref={ref}
           className={cn(

--- a/frontend/src/react/components/ui/separator.tsx
+++ b/frontend/src/react/components/ui/separator.tsx
@@ -1,0 +1,27 @@
+import type { ComponentProps } from "react";
+import { cn } from "@/react/lib/utils";
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: ComponentProps<"div"> & {
+  orientation?: "horizontal" | "vertical";
+  decorative?: boolean;
+}) {
+  return (
+    <div
+      role={decorative ? "none" : "separator"}
+      aria-orientation={orientation}
+      className={cn(
+        "shrink-0 bg-block-border",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Separator };

--- a/frontend/src/react/components/ui/tooltip.tsx
+++ b/frontend/src/react/components/ui/tooltip.tsx
@@ -26,9 +26,9 @@ export function Tooltip({
         </BaseTooltip.Trigger>
         <BaseTooltip.Portal>
           <BaseTooltip.Positioner side={side} sideOffset={4}>
-            <BaseTooltip.Popup className="z-50 rounded-sm bg-gray-900 px-2.5 py-1.5 text-xs text-white shadow-md max-w-56">
+            <BaseTooltip.Popup className="max-w-56 rounded-sm bg-main px-2.5 py-1.5 text-xs text-main-text shadow-md">
               {content}
-              <BaseTooltip.Arrow className="fill-gray-900" />
+              <BaseTooltip.Arrow className="fill-main" />
             </BaseTooltip.Popup>
           </BaseTooltip.Positioner>
         </BaseTooltip.Portal>
@@ -60,9 +60,9 @@ export function BlockTooltip({
         </BaseTooltip.Trigger>
         <BaseTooltip.Portal>
           <BaseTooltip.Positioner side={side} sideOffset={4}>
-            <BaseTooltip.Popup className="z-50 rounded-sm bg-gray-900 px-2.5 py-1.5 text-xs text-white shadow-md max-w-56">
+            <BaseTooltip.Popup className="max-w-56 rounded-sm bg-main px-2.5 py-1.5 text-xs text-main-text shadow-md">
               {content}
-              <BaseTooltip.Arrow className="fill-gray-900" />
+              <BaseTooltip.Arrow className="fill-main" />
             </BaseTooltip.Popup>
           </BaseTooltip.Positioner>
         </BaseTooltip.Portal>


### PR DESCRIPTION
## Summary
- align `FeatureAttention` and `TemplateSelector` with the shared shadcn-style React UI primitives
- add a shared `Separator` primitive and clean up `Select`/`Tooltip` to use semantic tokens and avoid manual overlay stacking
- add regression tests for alert semantics and template selection buttons

## Test Plan
- [x] pnpm --dir frontend fix
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test