### PR TITLE
refactor(frontend): migrate revision table to shadcn with batch delete

### DIFF
--- a/frontend/src/react/components/ui/alert-dialog.tsx
+++ b/frontend/src/react/components/ui/alert-dialog.tsx
@@ -1,0 +1,96 @@
+import { AlertDialog as BaseAlertDialog } from "@base-ui/react/alert-dialog";
+import type { ComponentProps } from "react";
+import { cn } from "@/react/lib/utils";
+
+const AlertDialog = BaseAlertDialog.Root;
+
+const AlertDialogTrigger = BaseAlertDialog.Trigger;
+
+function AlertDialogOverlay({
+  className,
+  ref,
+  ...props
+}: ComponentProps<typeof BaseAlertDialog.Backdrop>) {
+  return (
+    <BaseAlertDialog.Backdrop
+      ref={ref}
+      className={cn("fixed inset-0 z-50 bg-overlay/50", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  children,
+  ref,
+  ...props
+}: ComponentProps<typeof BaseAlertDialog.Popup>) {
+  return (
+    <BaseAlertDialog.Portal>
+      <AlertDialogOverlay />
+      <BaseAlertDialog.Popup
+        ref={ref}
+        className={cn(
+          "fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2",
+          "w-full max-w-md",
+          "rounded-sm bg-background p-6 shadow-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </BaseAlertDialog.Popup>
+    </BaseAlertDialog.Portal>
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ref,
+  ...props
+}: ComponentProps<typeof BaseAlertDialog.Title>) {
+  return (
+    <BaseAlertDialog.Title
+      ref={ref}
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ref,
+  ...props
+}: ComponentProps<typeof BaseAlertDialog.Description>) {
+  return (
+    <BaseAlertDialog.Description
+      ref={ref}
+      className={cn("mt-2 text-sm text-control-light", className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn("mt-4 flex justify-end gap-x-2", className)}
+      {...props}
+    />
+  );
+}
+
+const AlertDialogClose = BaseAlertDialog.Close;
+
+export {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogOverlay,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+};

--- a/frontend/src/react/pages/project/database-detail/panels/DatabaseRevisionPanel.tsx
+++ b/frontend/src/react/pages/project/database-detail/panels/DatabaseRevisionPanel.tsx
@@ -9,6 +9,13 @@ import CreateRevisionDrawer from "@/components/Revision/CreateRevisionDrawer.vue
 import { revisionServiceClientConnect } from "@/connect";
 import i18n from "@/plugins/i18n";
 import NaiveUI from "@/plugins/naive-ui";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from "@/react/components/ui/alert-dialog";
 import { Button } from "@/react/components/ui/button";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { router } from "@/router";
@@ -95,6 +102,7 @@ export function DatabaseRevisionPanel({ database }: { database: Database }) {
   const [showCreateRevisionDrawer, setShowCreateRevisionDrawer] =
     useState(false);
   const [drawerEverOpened, setDrawerEverOpened] = useState(false);
+  const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
   const fetchRevisionList = useCallback(
     async ({
       pageToken,
@@ -134,16 +142,24 @@ export function DatabaseRevisionPanel({ database }: { database: Database }) {
     refreshRef.current();
   }, []);
 
-  const handleDelete = useCallback(
-    async (name: string) => {
-      if (!window.confirm(t("database.revision.delete-confirm-dialog"))) {
-        return;
-      }
-      await revisionStore.deleteRevision(name);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const handleDeleteSelected = useCallback(async () => {
+    try {
+      await Promise.allSettled(
+        [...selectedNames].map((name) => revisionStore.deleteRevision(name))
+      );
+    } finally {
+      setSelectedNames(new Set());
+      setShowDeleteConfirm(false);
       handleRevisionDeleted();
-    },
-    [handleRevisionDeleted, revisionStore, t]
-  );
+    }
+  }, [selectedNames, handleRevisionDeleted, revisionStore]);
+
+  // Clear selection on page size change or database switch, but not on loadMore.
+  useEffect(() => {
+    setSelectedNames(new Set());
+  }, [paged.pageSize, database.name]);
 
   return (
     <>
@@ -162,9 +178,20 @@ export function DatabaseRevisionPanel({ database }: { database: Database }) {
         <DatabaseRevisionTable
           revisions={paged.dataList}
           loading={paged.isLoading}
-          onDelete={handleDelete}
+          selectedNames={selectedNames}
+          onSelectedNamesChange={setSelectedNames}
         />
-        <div className="mt-2">
+        <div className="mt-2 flex items-center justify-between">
+          {selectedNames.size > 0 ? (
+            <Button
+              variant="destructive"
+              onClick={() => setShowDeleteConfirm(true)}
+            >
+              {t("common.delete")} ({selectedNames.size})
+            </Button>
+          ) : (
+            <div />
+          )}
           <PagedTableFooter
             pageSize={paged.pageSize}
             pageSizeOptions={paged.pageSizeOptions}
@@ -175,6 +202,34 @@ export function DatabaseRevisionPanel({ database }: { database: Database }) {
           />
         </div>
       </div>
+
+      <AlertDialog
+        open={showDeleteConfirm}
+        onOpenChange={(open) => {
+          if (!open) setShowDeleteConfirm(false);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogTitle>
+            {t("database.revision.delete-confirm-dialog")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("common.cannot-undo-this-action")}
+          </AlertDialogDescription>
+          <AlertDialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteConfirm(false)}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteSelected}>
+              {t("common.delete")}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       {drawerEverOpened && (
         <VueCreateRevisionDrawerMount
           databaseName={database.name}

--- a/frontend/src/react/pages/project/database-detail/revision/DatabaseRevisionTable.tsx
+++ b/frontend/src/react/pages/project/database-detail/revision/DatabaseRevisionTable.tsx
@@ -1,5 +1,13 @@
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/react/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { router } from "@/router";
 import { getDateForPbTimestampProtoEs } from "@/types";
 import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
@@ -9,13 +17,44 @@ import { getRevisionType, revisionLink } from "@/utils/v1/revision";
 export function DatabaseRevisionTable({
   loading,
   revisions,
-  onDelete,
+  selectedNames,
+  onSelectedNamesChange,
 }: {
   loading: boolean;
   revisions: Revision[];
-  onDelete: (name: string) => void | Promise<void>;
+  selectedNames: Set<string>;
+  onSelectedNamesChange: (names: Set<string>) => void;
 }) {
   const { t } = useTranslation();
+
+  const allSelected =
+    revisions.length > 0 && selectedNames.size === revisions.length;
+  const someSelected =
+    selectedNames.size > 0 && selectedNames.size < revisions.length;
+  const headerCheckboxRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (headerCheckboxRef.current) {
+      headerCheckboxRef.current.indeterminate = someSelected;
+    }
+  }, [someSelected]);
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      onSelectedNamesChange(new Set());
+    } else {
+      onSelectedNamesChange(new Set(revisions.map((r) => r.name)));
+    }
+  };
+
+  const toggleSelection = (name: string) => {
+    const next = new Set(selectedNames);
+    if (next.has(name)) {
+      next.delete(name);
+    } else {
+      next.add(name);
+    }
+    onSelectedNamesChange(next);
+  };
 
   if (loading) {
     return (
@@ -24,63 +63,66 @@ export function DatabaseRevisionTable({
   }
 
   return (
-    <div className="overflow-hidden rounded border border-block-border">
-      <table className="min-w-full divide-y divide-block-border">
-        <thead className="bg-control-bg">
-          <tr className="text-left text-sm text-control-light">
-            <th className="px-4 py-2 font-medium">{t("common.version")}</th>
-            <th className="px-4 py-2 font-medium">{t("common.type")}</th>
-            <th className="px-4 py-2 font-medium">{t("common.created-at")}</th>
-            <th className="px-4 py-2 font-medium">{t("common.operations")}</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-block-border bg-background">
-          {revisions.map((revision) => (
-            <tr key={revision.name}>
-              <td className="px-4 py-3 text-sm text-main">
-                <button
-                  className="cursor-pointer text-left hover:text-accent"
-                  type="button"
-                  onClick={() => void router.push(revisionLink(revision))}
-                >
-                  {revision.version || revision.name}
-                </button>
-              </td>
-              <td className="px-4 py-3 text-sm text-control">
-                {getRevisionType(revision.type)}
-              </td>
-              <td className="px-4 py-3 text-sm text-control">
-                {getDateForPbTimestampProtoEs(revision.createTime)
-                  ? humanizeDate(
-                      getDateForPbTimestampProtoEs(revision.createTime) as Date
-                    )
-                  : "-"}
-              </td>
-              <td className="px-4 py-3 text-sm text-control">
-                <Button
-                  data-name={revision.name}
-                  size="sm"
-                  type="button"
-                  variant="ghost"
-                  onClick={() => void onDelete(revision.name)}
-                >
-                  {t("common.delete")}
-                </Button>
-              </td>
-            </tr>
-          ))}
-          {revisions.length === 0 && (
-            <tr>
-              <td
-                className="px-4 py-6 text-center text-sm text-control-light"
-                colSpan={4}
-              >
-                {t("common.no-data")}
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
-    </div>
+    <Table>
+      <TableHeader className="bg-control-bg">
+        <TableRow>
+          <TableHead className="w-12">
+            <input
+              ref={headerCheckboxRef}
+              type="checkbox"
+              checked={allSelected}
+              onChange={toggleSelectAll}
+              className="rounded-xs border-control-border"
+            />
+          </TableHead>
+          <TableHead>{t("common.version")}</TableHead>
+          <TableHead>{t("common.type")}</TableHead>
+          <TableHead>{t("common.created-at")}</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {revisions.map((revision) => (
+          <TableRow
+            key={revision.name}
+            className="cursor-pointer"
+            data-state={
+              selectedNames.has(revision.name) ? "selected" : undefined
+            }
+            onClick={() => void router.push(revisionLink(revision))}
+          >
+            <TableCell className="w-12">
+              <input
+                type="checkbox"
+                checked={selectedNames.has(revision.name)}
+                onChange={() => toggleSelection(revision.name)}
+                onClick={(e) => e.stopPropagation()}
+                className="rounded-xs border-control-border"
+              />
+            </TableCell>
+            <TableCell className="text-main">
+              {revision.version || revision.name}
+            </TableCell>
+            <TableCell>{getRevisionType(revision.type)}</TableCell>
+            <TableCell>
+              {getDateForPbTimestampProtoEs(revision.createTime)
+                ? humanizeDate(
+                    getDateForPbTimestampProtoEs(revision.createTime) as Date
+                  )
+                : "-"}
+            </TableCell>
+          </TableRow>
+        ))}
+        {revisions.length === 0 && (
+          <TableRow>
+            <TableCell
+              className="py-6 text-center text-control-light"
+              colSpan={4}
+            >
+              {t("common.no-data")}
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
   );
 }


### PR DESCRIPTION
## Summary
- Migrate database revision table from raw HTML to shadcn `Table` components
- Replace per-row delete buttons with checkbox row selection and batch delete
- Make entire table rows clickable to navigate to revision detail page
- Add new `AlertDialog` UI component (wrapping Base UI `AlertDialog` primitive) for delete confirmation

## Test plan
- [ ] Navigate to project database detail page, revision tab
- [ ] Verify table renders with checkboxes, version, type, and created-at columns
- [ ] Click a row to verify it navigates to revision detail page
- [ ] Select rows via checkboxes, verify "Delete (N)" button appears at bottom
- [ ] Click delete button, verify AlertDialog confirmation appears with proper styling
- [ ] Confirm deletion removes selected revisions and refreshes the list
- [ ] Verify select-all checkbox works (including indeterminate state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)