### PR TITLE
chore: add shadcn skill reminder to frontend AGENTS.md

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -15,6 +15,10 @@ This file provides additional guidance to AI coding assistants working under `./
 - All new UI code should be written in React unless an existing Vue surface must be preserved temporarily for compatibility.
 - Do not delete Vue counterparts until you verify they have no remaining live callers.
 
+## shadcn Skill
+
+When working on React UI, invoke the `shadcn` skill before writing or modifying components. The skill provides component selection guidance, critical rules, and best practices. Always check the skill when unsure which component to use.
+
 ## shadcn Component Guidelines
 
 React UI components live in `src/react/components/ui/` and follow shadcn-style patterns: Base UI primitives wrapped with `cva` variants and `cn()` for class merging.


### PR DESCRIPTION
## Summary
- Add a note to `frontend/AGENTS.md` reminding AI agents to invoke the `shadcn` skill before writing or modifying React UI components
- Helps agents pick the right component (e.g., `AlertDialog` for confirmations)

## Test plan
- [ ] Verify `frontend/AGENTS.md` renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)