### PR TITLE
fix(frontend): restore NoSQL catalog editing in React table detail

### DIFF
--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -361,6 +361,7 @@
   "common.username": "Username",
   "common.value": "Value",
   "common.version": "Version",
+  "common.view-doc": "View doc",
   "common.warning": "Warning",
   "common.write-only": "write only",
   "create-db": {
@@ -622,6 +623,7 @@
     "triggers": "Triggers",
     "views": "Views"
   },
+  "db.catalog.description": "Edit and upload the table catalog.",
   "db.failed-to-sync-schema": "Failed to sync schema",
   "db.failed-to-sync-schema-for-database-database-value-name": "Failed to sync schema for database '{{0}}'.",
   "db.n-databases-had-sync-errors": "{{0}} database(s) had sync errors",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -361,6 +361,7 @@
   "common.username": "Nombre de usuario",
   "common.value": "Valor",
   "common.version": "Versión",
+  "common.view-doc": "Ver doc",
   "common.warning": "Advertencia",
   "common.write-only": "solo escritura",
   "create-db": {
@@ -622,6 +623,7 @@
     "triggers": "Desencadenantes",
     "views": "Vistas"
   },
+  "db.catalog.description": "Editar y cargar el catálogo de tablas.",
   "db.failed-to-sync-schema": "No se pudo sincronizar el esquema",
   "db.failed-to-sync-schema-for-database-database-value-name": "Error al sincronizar el esquema para la base de datos '{{0}}'.",
   "db.n-databases-had-sync-errors": "{{0}} base(s) de datos tuvieron errores de sincronización",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -361,6 +361,7 @@
   "common.username": "ユーザー名",
   "common.value": "値",
   "common.version": "バージョン",
+  "common.view-doc": "ドキュメントを見る",
   "common.warning": "警告する",
   "common.write-only": "書き込み専用",
   "create-db": {
@@ -622,6 +623,7 @@
     "triggers": "トリガー",
     "views": "ビュー"
   },
+  "db.catalog.description": "テーブルカタログを編集してアップロードします。",
   "db.failed-to-sync-schema": "スキーマの同期に失敗しました",
   "db.failed-to-sync-schema-for-database-database-value-name": "データベース '{{0}}' のスキーマを同期できませんでした。",
   "db.n-databases-had-sync-errors": "{{0}} 個のデータベースで同期エラーが発生しました",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -361,6 +361,7 @@
   "common.username": "Tên người dùng",
   "common.value": "Giá trị",
   "common.version": "Phiên bản",
+  "common.view-doc": "Xem tài liệu",
   "common.warning": "Cảnh báo",
   "common.write-only": "chỉ ghi",
   "create-db": {
@@ -622,6 +623,7 @@
     "triggers": "Trình kích hoạt",
     "views": "Khung nhìn"
   },
+  "db.catalog.description": "Chỉnh sửa và tải lên danh mục bảng.",
   "db.failed-to-sync-schema": "Không đồng bộ hóa được lược đồ",
   "db.failed-to-sync-schema-for-database-database-value-name": "Không đồng bộ hóa được lược đồ cho cơ sở dữ liệu '{{0}}'.",
   "db.n-databases-had-sync-errors": "{{0}} cơ sở dữ liệu gặp lỗi đồng bộ",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -361,6 +361,7 @@
   "common.username": "用户名",
   "common.value": "值",
   "common.version": "版本",
+  "common.view-doc": "查看文档",
   "common.warning": "警告",
   "common.write-only": "仅写入",
   "create-db": {
@@ -622,6 +623,7 @@
     "triggers": "触发器",
     "views": "视图"
   },
+  "db.catalog.description": "编辑并上传表的 Catalog",
   "db.failed-to-sync-schema": "同步 schema 失败",
   "db.failed-to-sync-schema-for-database-database-value-name": "为数据库 '{{0}}' 同步 schema 失败。",
   "db.n-databases-had-sync-errors": "{{0}} 个数据库同步出错",

--- a/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.test.tsx
@@ -1,3 +1,4 @@
+import { create, toJsonString } from "@bufbuild/protobuf";
 import type {
   ButtonHTMLAttributes,
   ElementType,
@@ -8,6 +9,7 @@ import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { Engine } from "@/types/proto-es/v1/common_pb";
+import { TableCatalogSchema } from "@/types/proto-es/v1/database_catalog_service_pb";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { DataClassificationSetting_DataClassificationConfig } from "@/types/proto-es/v1/setting_service_pb";
 import { Setting_SettingName } from "@/types/proto-es/v1/setting_service_pb";
@@ -24,6 +26,10 @@ const mocks = vi.hoisted(() => ({
   useVueState: vi.fn(),
   useSettingV1Store: vi.fn(),
   useSubscriptionV1Store: vi.fn(),
+  useDatabaseCatalog: vi.fn(),
+  useDatabaseCatalogV1Store: vi.fn(),
+  getTableCatalog: vi.fn(),
+  pushNotification: vi.fn(),
   getOrFetchSettingByName: vi.fn(),
   getSettingByName: vi.fn(),
   getProjectClassification: vi.fn(),
@@ -31,6 +37,7 @@ const mocks = vi.hoisted(() => ({
   updateTableCatalog: vi.fn(),
   getDatabaseProject: vi.fn(),
   getInstanceResource: vi.fn(),
+  instanceV1MaskingForNoSQL: vi.fn(),
   hasProjectPermissionV2: vi.fn(),
   hasWorkspacePermissionV2: vi.fn(),
 }));
@@ -118,6 +125,10 @@ vi.mock("@/react/components/FeatureAttention", () => ({
 }));
 
 vi.mock("@/store", () => ({
+  getTableCatalog: mocks.getTableCatalog,
+  pushNotification: mocks.pushNotification,
+  useDatabaseCatalog: mocks.useDatabaseCatalog,
+  useDatabaseCatalogV1Store: mocks.useDatabaseCatalogV1Store,
   useSettingV1Store: mocks.useSettingV1Store,
   useSubscriptionV1Store: mocks.useSubscriptionV1Store,
 }));
@@ -125,6 +136,7 @@ vi.mock("@/store", () => ({
 vi.mock("@/utils", () => ({
   getDatabaseProject: mocks.getDatabaseProject,
   getInstanceResource: mocks.getInstanceResource,
+  instanceV1MaskingForNoSQL: mocks.instanceV1MaskingForNoSQL,
   hasProjectPermissionV2: mocks.hasProjectPermissionV2,
   hasWorkspacePermissionV2: mocks.hasWorkspacePermissionV2,
 }));
@@ -178,13 +190,28 @@ const press = (element: HTMLElement) => {
   });
 };
 
-const makeDatabase = (): Database =>
+const changeValue = (
+  element: HTMLInputElement | HTMLTextAreaElement,
+  value: string
+) => {
+  act(() => {
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(element),
+      "value"
+    );
+    descriptor?.set?.call(element, value);
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    element.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+};
+
+const makeDatabase = (engine = Engine.POSTGRES): Database =>
   ({
     name: "instances/inst1/databases/db",
     project: "projects/proj1",
     instanceResource: {
       name: "instances/inst1",
-      engine: Engine.POSTGRES,
+      engine,
     },
   }) as Database;
 
@@ -246,6 +273,32 @@ beforeEach(async () => {
     hasFeature: vi.fn(() => true),
     instanceMissingLicense: vi.fn(() => false),
   });
+  mocks.useDatabaseCatalog.mockReset();
+  mocks.useDatabaseCatalog.mockReturnValue({
+    value: {
+      name: "instances/inst1/databases/db/catalog",
+      schemas: [],
+    },
+  });
+  mocks.useDatabaseCatalogV1Store.mockReset();
+  mocks.useDatabaseCatalogV1Store.mockReturnValue({
+    updateDatabaseCatalog: vi.fn().mockResolvedValue(undefined),
+  });
+  mocks.getTableCatalog.mockReset();
+  mocks.getTableCatalog.mockImplementation(
+    (
+      catalog: {
+        schemas?: Array<{ name: string; tables: Array<{ name?: string }> }>;
+      },
+      schema: string,
+      tableName: string
+    ) =>
+      catalog.schemas
+        ?.find((schemaCatalog) => schemaCatalog.name === schema)
+        ?.tables.find((tableCatalog) => tableCatalog.name === tableName) ??
+      create(TableCatalogSchema, { name: tableName })
+  );
+  mocks.pushNotification.mockReset();
   mocks.updateColumnCatalog.mockReset();
   mocks.updateColumnCatalog.mockResolvedValue(undefined);
   mocks.updateTableCatalog.mockReset();
@@ -256,10 +309,20 @@ beforeEach(async () => {
     dataClassificationConfigId: "classification-config",
   });
   mocks.getInstanceResource.mockReset();
-  mocks.getInstanceResource.mockReturnValue({
-    name: "instances/inst1",
-    engine: Engine.POSTGRES,
-  });
+  mocks.getInstanceResource.mockImplementation(
+    (database?: { instanceResource?: { name: string; engine: Engine } }) =>
+      database?.instanceResource ?? {
+        name: "instances/inst1",
+        engine: Engine.POSTGRES,
+      }
+  );
+  mocks.instanceV1MaskingForNoSQL.mockReset();
+  mocks.instanceV1MaskingForNoSQL.mockImplementation(
+    (instanceOrEngine: Engine | { engine: Engine }) =>
+      (typeof instanceOrEngine === "number"
+        ? instanceOrEngine
+        : instanceOrEngine.engine) === Engine.MONGODB
+  );
   mocks.hasProjectPermissionV2.mockReset();
   mocks.hasProjectPermissionV2.mockReturnValue(true);
   mocks.hasWorkspacePermissionV2.mockReset();
@@ -640,6 +703,109 @@ describe("TableDetailDialog", () => {
     expect(container.textContent).toContain("db.triggers");
     expect(container.textContent).toContain("audit_before_insert");
     expect(container.textContent).toContain("EXECUTE FUNCTION audit_insert()");
+
+    unmount();
+  });
+
+  test("restores the legacy NoSQL catalog editor and upload flow", async () => {
+    const updateDatabaseCatalog = vi.fn().mockResolvedValue(undefined);
+    mocks.useDatabaseCatalog.mockReturnValue({
+      value: {
+        name: "instances/inst1/databases/db/catalog",
+        schemas: [
+          {
+            name: "",
+            tables: [
+              create(TableCatalogSchema, {
+                name: "orders",
+                classification: "PII",
+              }),
+            ],
+          },
+        ],
+      },
+    });
+    mocks.useDatabaseCatalogV1Store.mockReturnValue({
+      updateDatabaseCatalog,
+    });
+
+    const { container, render, unmount } = renderIntoContainer(
+      createElement(TableDetailDialog as unknown as ElementType, {
+        open: true,
+        onOpenChange: vi.fn(),
+        table: {
+          database: makeDatabase(Engine.MONGODB),
+          editable: true,
+          name: "orders",
+          schema: "",
+          tableName: "orders",
+          columns: [],
+          rowCount: "0",
+          dataSize: "8 KB",
+          indexSize: "0 KB",
+          indexes: [],
+          showIndexes: false,
+        },
+      })
+    );
+
+    render();
+    await flush();
+
+    expect(container.textContent).toContain("common.catalog");
+    expect(container.textContent).toContain("db.catalog.description");
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    expect((textarea as HTMLTextAreaElement).value).toContain(
+      '"name": "orders"'
+    );
+    expect((textarea as HTMLTextAreaElement).value).toContain(
+      '"classification": "PII"'
+    );
+
+    changeValue(
+      textarea as HTMLTextAreaElement,
+      toJsonString(
+        TableCatalogSchema,
+        create(TableCatalogSchema, {
+          name: "orders",
+          classification: "PUBLIC",
+        }),
+        { prettySpaces: 2 }
+      )
+    );
+    await flush();
+
+    const uploadButton = container.querySelector(
+      '[data-testid="nosql-catalog-upload"]'
+    );
+    expect(uploadButton).not.toBeNull();
+
+    click(uploadButton as HTMLButtonElement);
+    await flush();
+
+    expect(updateDatabaseCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        schemas: expect.arrayContaining([
+          expect.objectContaining({
+            name: "",
+            tables: expect.arrayContaining([
+              expect.objectContaining({
+                name: "orders",
+                classification: "PUBLIC",
+              }),
+            ]),
+          }),
+        ]),
+      })
+    );
+    expect(mocks.pushNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        style: "SUCCESS",
+        title: "common.updated",
+      })
+    );
 
     unmount();
   });

--- a/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.tsx
@@ -1,3 +1,5 @@
+import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
+import { cloneDeep } from "lodash-es";
 import { Pencil, X } from "lucide-react";
 import type { MouseEvent, ReactNode } from "react";
 import { useEffect, useMemo, useState } from "react";
@@ -23,8 +25,20 @@ import {
   TableHeader,
   TableRow,
 } from "@/react/components/ui/table";
+import { Textarea } from "@/react/components/ui/textarea";
 import { useVueState } from "@/react/hooks/useVueState";
-import { useSettingV1Store, useSubscriptionV1Store } from "@/store";
+import {
+  getTableCatalog,
+  pushNotification,
+  useDatabaseCatalog,
+  useDatabaseCatalogV1Store,
+  useSettingV1Store,
+  useSubscriptionV1Store,
+} from "@/store";
+import {
+  SchemaCatalogSchema,
+  TableCatalogSchema,
+} from "@/types/proto-es/v1/database_catalog_service_pb";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type {
   DataClassificationSetting_DataClassificationConfig,
@@ -36,6 +50,7 @@ import {
   getDatabaseProject,
   getInstanceResource,
   hasWorkspacePermissionV2,
+  instanceV1MaskingForNoSQL,
 } from "@/utils";
 
 interface TableColumnDetail {
@@ -354,6 +369,123 @@ function DetailSection({
       <div className="text-sm font-medium text-control-light">{title}</div>
       {children}
     </div>
+  );
+}
+
+function NoSQLCatalogEditor({
+  database,
+  readonly,
+  schema,
+  tableName,
+}: {
+  database: Database;
+  readonly: boolean;
+  schema: string;
+  tableName: string;
+}) {
+  const { t } = useTranslation();
+  const databaseCatalogStore = useDatabaseCatalogV1Store();
+  const databaseCatalog = useDatabaseCatalog(database.name, false);
+  const catalog = useVueState(() => databaseCatalog.value);
+  const [catalogText, setCatalogText] = useState("{}");
+  const [isUploading, setIsUploading] = useState(false);
+
+  const initialCatalogText = useMemo(() => {
+    return toJsonString(
+      TableCatalogSchema,
+      getTableCatalog(catalog, schema, tableName) ??
+        create(TableCatalogSchema, {
+          name: tableName,
+        }),
+      {
+        prettySpaces: 2,
+      }
+    );
+  }, [catalog, schema, tableName]);
+
+  useEffect(() => {
+    setCatalogText(initialCatalogText);
+  }, [initialCatalogText]);
+
+  const hasChanges = catalogText !== initialCatalogText;
+
+  const handleUpload = async () => {
+    const nextTableCatalog = fromJsonString(TableCatalogSchema, catalogText);
+    if (nextTableCatalog.name !== tableName) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.error"),
+        description: `catalog name must be ${tableName}`,
+      });
+      return;
+    }
+
+    setIsUploading(true);
+    try {
+      const pendingCatalog = cloneDeep(catalog);
+      const schemaCatalog = pendingCatalog.schemas.find(
+        (schemaCatalog) => schemaCatalog.name === schema
+      );
+      if (schemaCatalog) {
+        const tableIndex = schemaCatalog.tables.findIndex(
+          (tableCatalog) => tableCatalog.name === tableName
+        );
+        if (tableIndex >= 0) {
+          schemaCatalog.tables[tableIndex] = nextTableCatalog;
+        } else {
+          schemaCatalog.tables.push(nextTableCatalog);
+        }
+      } else {
+        pendingCatalog.schemas.push(
+          create(SchemaCatalogSchema, {
+            name: schema,
+            tables: [nextTableCatalog],
+          })
+        );
+      }
+
+      await databaseCatalogStore.updateDatabaseCatalog(pendingCatalog);
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: t("common.updated"),
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <DetailSection title={t("common.catalog")}>
+      <div className="text-sm text-control-light">
+        {t("db.catalog.description")}{" "}
+        <a
+          className="normal-link"
+          href="https://api.bytebase.com/#tag/databasecatalogservice/PATCH/v1/instances/{instance}/databases/{database}/catalog"
+          rel="noreferrer"
+          target="_blank"
+        >
+          {t("common.view-doc")}
+        </a>
+      </div>
+      <Textarea
+        data-testid="nosql-catalog-editor"
+        className="min-h-80 font-mono"
+        disabled={readonly}
+        value={catalogText}
+        onChange={(event) => setCatalogText(event.target.value)}
+      />
+      <div className="flex justify-end gap-x-2">
+        <Button
+          data-testid="nosql-catalog-upload"
+          disabled={readonly || !hasChanges || isUploading}
+          onClick={() => void handleUpload()}
+        >
+          {isUploading ? t("common.updating") : t("common.upload")}
+        </Button>
+      </div>
+    </DetailSection>
   );
 }
 
@@ -801,6 +933,9 @@ export function TableDetailDialog({
   const showColumnClassification = table.showColumnClassification;
   const showColumnCollation = table.showColumnCollation;
   const showColumns = table.showColumns ?? true;
+  const showNoSQLCatalog =
+    !!table.database &&
+    instanceV1MaskingForNoSQL(getInstanceResource(table.database));
   const showIndexCommentColumn = table.showIndexComment;
   const showIndexVisibleColumn = table.showIndexVisible;
   const showPartitionTables =
@@ -1190,6 +1325,15 @@ export function TableDetailDialog({
               </Table>
             </div>
           </DetailSection>
+        )}
+
+        {showNoSQLCatalog && table.database && table.tableName && (
+          <NoSQLCatalogEditor
+            database={table.database}
+            readonly={readonly}
+            schema={table.schema ?? ""}
+            tableName={table.tableName}
+          />
         )}
       </DialogContent>
     </Dialog>

--- a/frontend/src/react/pages/project/database-detail/overview/TableMetadataTable.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/TableMetadataTable.test.tsx
@@ -35,6 +35,7 @@ const mocks = vi.hoisted(() => ({
     name: "instances/inst1",
     engine: Engine.POSTGRES,
   })),
+  instanceV1MaskingForNoSQL: vi.fn(() => false),
   hasProjectPermissionV2: vi.fn(() => true),
   hasSchemaProperty: vi.fn(() => true),
   hasWorkspacePermissionV2: vi.fn(() => true),
@@ -65,6 +66,7 @@ vi.mock("@/utils", () => ({
   getDatabaseEngine: mocks.getDatabaseEngine,
   getDatabaseProject: mocks.getDatabaseProject,
   getInstanceResource: mocks.getInstanceResource,
+  instanceV1MaskingForNoSQL: mocks.instanceV1MaskingForNoSQL,
   hasProjectPermissionV2: mocks.hasProjectPermissionV2,
   hasSchemaProperty: mocks.hasSchemaProperty,
   hasWorkspacePermissionV2: mocks.hasWorkspacePermissionV2,
@@ -247,6 +249,8 @@ beforeEach(async () => {
     name: "instances/inst1",
     engine: Engine.POSTGRES,
   });
+  mocks.instanceV1MaskingForNoSQL.mockReset();
+  mocks.instanceV1MaskingForNoSQL.mockReturnValue(false);
   mocks.hasProjectPermissionV2.mockReset();
   mocks.hasProjectPermissionV2.mockReturnValue(true);
   mocks.hasSchemaProperty.mockReset();

--- a/frontend/src/react/pages/project/database-detail/panels/DatabaseOverviewPanel.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/panels/DatabaseOverviewPanel.test.tsx
@@ -58,6 +58,7 @@ const mocks = vi.hoisted(() => {
     hasSchemaProperty: vi.fn(() => true),
     hasTableEngineProperty: vi.fn(() => false),
     instanceV1HasCollationAndCharacterSet: vi.fn(() => true),
+    instanceV1MaskingForNoSQL: vi.fn(() => false),
     instanceV1SupportsColumn: vi.fn(() => true),
     instanceV1SupportsIndex: vi.fn(() => true),
     instanceV1SupportsPackage: vi.fn(() => false),
@@ -110,6 +111,7 @@ vi.mock("@/utils", () => ({
   hasTableEngineProperty: mocks.hasTableEngineProperty,
   instanceV1HasCollationAndCharacterSet:
     mocks.instanceV1HasCollationAndCharacterSet,
+  instanceV1MaskingForNoSQL: mocks.instanceV1MaskingForNoSQL,
   instanceV1SupportsColumn: mocks.instanceV1SupportsColumn,
   instanceV1SupportsIndex: mocks.instanceV1SupportsIndex,
   instanceV1SupportsPackage: mocks.instanceV1SupportsPackage,
@@ -258,6 +260,8 @@ beforeEach(async () => {
   mocks.getDatabaseEngine.mockReturnValue(Engine.POSTGRES);
   mocks.isDev.mockReset();
   mocks.isDev.mockReturnValue(false);
+  mocks.instanceV1MaskingForNoSQL.mockReset();
+  mocks.instanceV1MaskingForNoSQL.mockReturnValue(false);
   mocks.hasSchemaProperty.mockReset();
   mocks.hasSchemaProperty.mockReturnValue(true);
   mocks.instanceV1HasCollationAndCharacterSet.mockReset();


### PR DESCRIPTION
## Summary
- restore the NoSQL table catalog editor in the React table detail dialog for MongoDB, CosmosDB, and Elasticsearch
- wire the editor back to the existing database catalog store with legacy JSON upload behavior and validation
- add regression coverage and React locale keys for the restored catalog UI

## Test Plan
- [x] pnpm --dir frontend fix
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test
