### PR TITLE
fix(e2e): address codex review + harden masking exemption tests

### DIFF
--- a/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
@@ -919,6 +919,7 @@ function ExemptionMemberItem({
 
   return (
     <div
+      data-testid="exemption-member-item"
       className={cn(
         "flex items-center gap-x-3 px-3 py-2.5 cursor-pointer rounded-xs transition-colors",
         selected ? "bg-accent/5" : "hover:bg-control-bg"
@@ -1057,6 +1058,7 @@ function ExemptionDetailPanel({
         {member.grants.map((grant, idx) => (
           <div
             key={grant.id}
+            data-testid="exemption-grant-card"
             className="border border-block-border rounded-sm overflow-hidden"
           >
             <ExemptionGrantSection
@@ -1115,6 +1117,7 @@ function ExemptionGrantSection({
     <div>
       {/* Header */}
       <div
+        data-testid="exemption-grant-header"
         className="flex items-center justify-between px-4 py-2 cursor-pointer select-none"
         onClick={() => setExpanded(!expanded)}
       >

--- a/frontend/tests/e2e/framework/api-client.ts
+++ b/frontend/tests/e2e/framework/api-client.ts
@@ -41,8 +41,19 @@ export class BytebaseApiClient {
   }
 
   // Auth
+  // NOTE: login() intentionally bypasses request() to avoid recursive re-login
+  // on 401: request() retries via login() on 401, which would loop forever if
+  // credentials were invalid.
   async login(email: string, password: string): Promise<string> {
-    const { token } = await this.request<{ token: string }>("POST", "/v1/auth/login", { email, password });
+    const resp = await fetch(`${this.baseURL}/v1/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+    if (!resp.ok) {
+      throw new Error(`API POST /v1/auth/login failed (${resp.status}): ${await resp.text()}`);
+    }
+    const { token } = (await resp.json()) as { token: string };
     this.token = token;
     this.credentials = { email, password };
     return token;

--- a/frontend/tests/e2e/framework/mode-start-new-bytebase.ts
+++ b/frontend/tests/e2e/framework/mode-start-new-bytebase.ts
@@ -16,15 +16,34 @@ const ADMIN_PASSWORD = "12345678"; // NOSONAR: fixed demo account password
 let serverProcess: child_process.ChildProcess | undefined;
 let tempDir: string | undefined;
 
+// Verify a PID belongs to a bytebase process before sending signals.
+// Prevents us from killing an unrelated process if the OS has recycled the PID
+// since the last e2e run (e.g. server crashed, PID got reused by another app).
+function isBytebaseProcess(pid: number): boolean {
+  try {
+    const out = child_process
+      .execFileSync("ps", ["-p", String(pid), "-o", "command="], {
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "ignore"],
+      })
+      .trim();
+    return out.includes("bytebase");
+  } catch {
+    return false; // ps exits non-zero if pid doesn't exist
+  }
+}
+
 export function cleanupOrphans(): void {
   if (!fs.existsSync(PID_FILE)) return;
   const content = fs.readFileSync(PID_FILE, "utf-8").trim().split("\n");
   const pid = parseInt(content[0], 10);
   const dir = content[1];
-  try {
-    process.kill(-pid, "SIGTERM"); // Kill process group
-  } catch {
-    /* already dead */
+  if (Number.isFinite(pid) && pid > 0 && isBytebaseProcess(pid)) {
+    try {
+      process.kill(-pid, "SIGTERM"); // Kill process group
+    } catch {
+      /* already dead */
+    }
   }
   if (dir && fs.existsSync(dir)) {
     fs.rmSync(dir, { recursive: true, force: true });

--- a/frontend/tests/e2e/masking-exemption/masking-exemption.page.ts
+++ b/frontend/tests/e2e/masking-exemption/masking-exemption.page.ts
@@ -4,26 +4,10 @@ export class MaskingExemptionPage {
   readonly page: Page;
   private baseURL: string;
 
-  // Navigation
   readonly grantExemptionButton: Locator;
-
-  // Tabs
   readonly activeTab: Locator;
   readonly expiredTab: Locator;
   readonly allTab: Locator;
-
-  // Search
-  readonly searchBar: Locator;
-
-  // Member list
-  readonly memberList: Locator;
-
-  // Detail panel
-  readonly detailPanel: Locator;
-
-  // Revoke dialog
-  readonly revokeConfirmButton: Locator;
-  readonly revokeCancelButton: Locator;
 
   constructor(page: Page, baseURL = "") {
     this.page = page;
@@ -31,18 +15,9 @@ export class MaskingExemptionPage {
     this.grantExemptionButton = page.getByRole("button", {
       name: /grant exemption/i,
     });
-    this.activeTab = page.getByRole("button", { name: "Active" });
-    this.expiredTab = page.getByRole("button", { name: "Expired" });
-    this.allTab = page.getByRole("button", { name: "All" });
-    this.searchBar = page.getByPlaceholder(/filter/i);
-    this.memberList = page.locator("[class*='divide-y']").first();
-    this.detailPanel = page.locator("[class*='flex-1 min-w-0']").first();
-    this.revokeConfirmButton = page
-      .getByRole("dialog")
-      .getByRole("button", { name: "Confirm" });
-    this.revokeCancelButton = page
-      .getByRole("dialog")
-      .getByRole("button", { name: "Cancel" });
+    this.activeTab = page.getByRole("tab", { name: "Active" });
+    this.expiredTab = page.getByRole("tab", { name: "Expired" });
+    this.allTab = page.getByRole("tab", { name: "All" });
   }
 
   async goto(projectId: string) {
@@ -59,43 +34,23 @@ export class MaskingExemptionPage {
       .waitFor({ timeout: 10000 });
   }
 
+  // Select a member by email. Uses data-testid for a stable locator,
+  // filtered by the visible email text.
   getMemberItem(email: string): Locator {
-    return this.page.locator(`[class*="cursor-pointer"]`).filter({
-      hasText: email,
-    });
+    return this.page
+      .getByTestId("exemption-member-item")
+      .filter({ hasText: email });
   }
 
   async selectMember(email: string) {
-    await this.getMemberItem(email).click();
-  }
-
-  getGrantCard(title: string): Locator {
-    return this.page.locator("[class*='border border-gray']").filter({
-      hasText: title,
-    });
-  }
-
-  getRevokeButton(grantTitle: string): Locator {
-    return this.getGrantCard(grantTitle).getByRole("button", {
-      name: "Revoke",
-    });
-  }
-
-  async revokeGrant(grantTitle: string) {
-    await this.getRevokeButton(grantTitle).click();
-    await this.revokeConfirmButton.click();
-    // Wait for optimistic update
-    await this.page.waitForTimeout(500);
-  }
-
-  async getMemberCount(): Promise<number> {
-    return this.page.locator("[class*='cursor-pointer']").filter({
-      has: this.page.locator("[class*='rounded-full']"),
-    }).count();
-  }
-
-  getExpiryLabel(grantTitle: string): Locator {
-    return this.getGrantCard(grantTitle).locator("[class*='text-xs']").first();
+    // Fail fast (10s) with a descriptive error if the member item is missing,
+    // instead of letting the surrounding test timeout drag out to 120s.
+    const item = this.getMemberItem(email).first();
+    await expect(
+      item,
+      `member item for "${email}" (data-testid="exemption-member-item") not found`
+    ).toBeVisible({ timeout: 10000 });
+    await item.click();
   }
 }
 
@@ -104,29 +59,17 @@ export class GrantExemptionPage {
   private baseURL: string;
 
   readonly allRadio: Locator;
-  readonly expressionRadio: Locator;
-  readonly selectRadio: Locator;
   readonly reasonInput: Locator;
-  readonly expirationInput: Locator;
   readonly accountSelect: Locator;
   readonly confirmButton: Locator;
-  readonly cancelButton: Locator;
 
   constructor(page: Page, baseURL = "") {
     this.page = page;
     this.baseURL = baseURL;
     this.allRadio = page.getByRole("radio", { name: "All", exact: true });
-    this.expressionRadio = page.getByRole("radio", {
-      name: /use cel/i,
-    });
-    this.selectRadio = page.getByRole("radio", {
-      name: /manually select/i,
-    });
     this.reasonInput = page.getByPlaceholder(/description/i);
-    this.expirationInput = page.getByRole("textbox").nth(1);
     this.accountSelect = page.getByText("Select accounts", { exact: true });
     this.confirmButton = page.getByRole("button", { name: "Confirm" });
-    this.cancelButton = page.getByRole("button", { name: "Cancel" });
   }
 
   async goto(projectId: string) {
@@ -195,11 +138,6 @@ export class SqlEditorPage {
     // Wait for results to load (look for "N rows" or "N row" indicator)
     await this.page.getByText(/\d+ rows?/).first().waitFor({ timeout: 15000 }).catch(() => {});
     await this.page.waitForTimeout(500);
-  }
-
-  async hasResultsTable(): Promise<boolean> {
-    // Check for the "rows" indicator that appears after query execution
-    return (await this.page.getByText(/\d+ rows?/).count()) > 0;
   }
 
   async resultContainsText(text: string, timeout = 15000): Promise<boolean> {

--- a/frontend/tests/e2e/masking-exemption/masking-exemption.spec.ts
+++ b/frontend/tests/e2e/masking-exemption/masking-exemption.spec.ts
@@ -271,14 +271,26 @@ test.describe("Exemption List Page", () => {
     await exemptionPage.selectMember(env.adminEmail);
     await page.waitForTimeout(500);
 
-    const grantCard = page.locator("[class*='border border-gray']").first();
+    // Use a stable data-testid locator (not CSS class substrings, which break
+    // on theme refactors). Fail loudly if the card isn't found rather than
+    // silently passing — the previous version of this test was a false
+    // positive because its class selector matched nothing.
+    const grantCard = page.getByTestId("exemption-grant-card").first();
+    await expect(grantCard).toBeVisible();
+
     const cardBox = await grantCard.boundingBox();
-    const header = grantCard.locator("> div").first();
+    const header = grantCard.getByTestId("exemption-grant-header").first();
+    await expect(header).toBeVisible();
     const headerBox = await header.boundingBox();
-    if (cardBox && headerBox) {
-      const topGap = headerBox.y - cardBox.y;
-      expect(topGap).toBeLessThanOrEqual(12);
-    }
+    expect(cardBox, "grant card boundingBox should be measurable").toBeTruthy();
+    expect(headerBox, "grant card header boundingBox should be measurable").toBeTruthy();
+
+    // Expected layout: 1px top border + header's own py-2 (8px) = ~9px gap.
+    // The original bug added pt-4 (16px) on the wrapper, pushing the gap to ~25px.
+    // Allow 0-14px range: tolerates border + minor padding, rejects pt-4 regression.
+    const topGap = headerBox!.y - cardBox!.y;
+    expect(topGap, `header should sit near top of card (got ${topGap}px)`).toBeGreaterThanOrEqual(0);
+    expect(topGap, `header should sit near top of card (got ${topGap}px)`).toBeLessThanOrEqual(14);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-ups to #19945 that missed the merge window. Addresses the outstanding codex review findings plus a few robustness fixes uncovered while re-running the suite on the rebased branch.

## Changes

- **`api-client.ts`** — `login()` now issues an inline `fetch` instead of going through `request()`. The old code triggered a recursive 401 retry loop because `request()` calls `login()` on 401, which itself called `request()`.
- **`mode-start-new-bytebase.ts`** — `cleanupOrphans()` verifies the stashed PID belongs to a bytebase process (via `ps -p … -o command=`) before `SIGTERM`'ing it. Prevents us from killing an unrelated process if the OS has recycled the PID since the last run.
- **`ProjectMaskingExemptionPage.tsx`** — Adds three `data-testid` attributes (`exemption-member-item`, `exemption-grant-card`, `exemption-grant-header`) so e2e tests can use stable locators instead of brittle CSS class substrings.
- **`masking-exemption.page.ts`** —
  - Tab locators switched from `role="button"` to `role="tab"` to match the ARIA tablist refactor already in `main`. The old selectors matched nothing and hung until the test timeout.
  - `selectMember` now fails fast (10s) with a descriptive error instead of dragging the surrounding 120s test timeout.
- **`masking-exemption.spec.ts`** — Grant-card padding test uses the new `data-testid` locators with a loud failure + pixel range assertion. Replaces the class-substring selector that was a silent false positive (it matched nothing, so the `if (cardBox && headerBox)` guard skipped the assertion entirely).

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm exec biome check` on changed files
- [x] Full e2e suite: 15 passed (1.9m)

🤖 Generated with [Claude Code](https://claude.com/claude-code)