### PR TITLE
fix(sidebar): restore native link behavior for brand logo

### DIFF
--- a/frontend/src/react/components/DashboardSidebar.tsx
+++ b/frontend/src/react/components/DashboardSidebar.tsx
@@ -313,6 +313,8 @@ export function DashboardSidebar() {
   const recordVisitRef = useRef<((path: string) => void) | null>(null);
 
   useEffect(() => {
+    // TODO(steven): Replace this Vue composable bridge with a shared framework-agnostic
+    // recent-visit helper so React components don't need a Vue effect scope.
     const scope = effectScope();
     scope.run(() => {
       const { record } = useRecentVisit();

--- a/frontend/src/react/components/DashboardSidebar.tsx
+++ b/frontend/src/react/components/DashboardSidebar.tsx
@@ -15,6 +15,7 @@ import {
 import type { ElementType } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { effectScope } from "vue";
 import logoFull from "@/assets/logo-full.svg";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
@@ -47,6 +48,7 @@ import {
   SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
 } from "@/router/dashboard/workspaceSetting";
 import { SQL_EDITOR_HOME_MODULE } from "@/router/sqlEditor";
+import { useRecentVisit } from "@/router/useRecentVisit";
 import {
   useActuatorV1Store,
   useAppFeature,
@@ -308,6 +310,16 @@ export function DashboardSidebar() {
   const customLogo = useVueState(
     () => useWorkspaceV1Store().currentWorkspace?.logo ?? ""
   );
+  const recordVisitRef = useRef<((path: string) => void) | null>(null);
+
+  useEffect(() => {
+    const scope = effectScope();
+    scope.run(() => {
+      const { record } = useRecentVisit();
+      recordVisitRef.current = record;
+    });
+    return () => scope.stop();
+  }, []);
 
   // -- Expand / collapse state -----------------------------------------------
   const [expandedSet, setExpandedSet] = useState<Set<string>>(new Set());
@@ -368,12 +380,12 @@ export function DashboardSidebar() {
 
   // -- Navigation ------------------------------------------------------------
 
-  const navigateToHome = useCallback(() => {
+  const resolveHomeRoute = useCallback(() => {
     const target =
       databaseChangeMode === DatabaseChangeMode.EDITOR
         ? SQL_EDITOR_HOME_MODULE
         : WORKSPACE_ROUTE_LANDING;
-    router.push({ name: target });
+    return router.resolve({ name: target });
   }, [databaseChangeMode]);
 
   const onGroupClick = useCallback((item: SidebarItem, key: string) => {
@@ -404,9 +416,23 @@ export function DashboardSidebar() {
     router.push({ name });
   }, []);
 
+  const handleHomeClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      const route = resolveHomeRoute();
+      recordVisitRef.current?.(route.fullPath);
+      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return;
+      }
+      e.preventDefault();
+      router.push(route);
+    },
+    [resolveHomeRoute]
+  );
+
   // -- Logo ------------------------------------------------------------------
 
   const logoSrc = customLogo || logoFull;
+  const homeHref = resolveHomeRoute().fullPath;
 
   // -- Render ----------------------------------------------------------------
 
@@ -505,12 +531,13 @@ export function DashboardSidebar() {
 
   return (
     <nav className="flex-1 flex flex-col overflow-y-hidden border-r border-block-border">
-      <div
+      <a
+        href={homeHref}
         className="p-2 shrink-0 m-auto cursor-pointer"
-        onClick={navigateToHome}
+        onClick={handleHomeClick}
       >
         <img src={logoSrc} alt="Bytebase" className="max-w-44" />
-      </div>
+      </a>
       <WorkspaceSwitcher />
       <div className="flex-1 overflow-y-auto px-2.5 pb-4 flex flex-col gap-y-1">
         {filteredItems.map((item, i) => renderItem(item, i))}

--- a/frontend/src/react/components/ProjectSidebar.tsx
+++ b/frontend/src/react/components/ProjectSidebar.tsx
@@ -341,13 +341,6 @@ export function ProjectSidebar() {
 
   // -- Navigation ------------------------------------------------------------
 
-  const navigateToHome = useCallback(() => {
-    router.push({
-      name: PROJECT_V1_ROUTE_DETAIL,
-      params: { projectId },
-    });
-  }, [projectId]);
-
   const onGroupClick = useCallback((item: SidebarItem, key: string) => {
     if (item.children && item.children.length > 0) {
       manualToggledRef.current.add(key);
@@ -390,9 +383,30 @@ export function ProjectSidebar() {
     [project.name]
   );
 
+  const resolveHomeRoute = useCallback(() => {
+    return router.resolve({
+      name: PROJECT_V1_ROUTE_DETAIL,
+      params: { projectId: getProjectName(project.name) },
+    });
+  }, [project.name]);
+
+  const handleHomeClick = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement>) => {
+      const route = resolveHomeRoute();
+      recordVisitRef.current?.(route.fullPath);
+      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
+        return;
+      }
+      e.preventDefault();
+      router.push(route);
+    },
+    [resolveHomeRoute]
+  );
+
   // -- Logo ------------------------------------------------------------------
 
   const logoSrc = customLogo || logoFull;
+  const homeHref = resolveHomeRoute().fullPath;
 
   // -- Render ----------------------------------------------------------------
 
@@ -468,12 +482,13 @@ export function ProjectSidebar() {
 
   return (
     <nav className="flex-1 flex flex-col overflow-y-hidden border-r border-block-border">
-      <div
+      <a
+        href={homeHref}
         className="p-2 shrink-0 m-auto cursor-pointer"
-        onClick={navigateToHome}
+        onClick={handleHomeClick}
       >
         <img src={logoSrc} alt="Bytebase" className="max-w-44" />
-      </div>
+      </a>
       <div className="flex-1 overflow-y-auto px-2.5 pb-4 flex flex-col gap-y-1">
         {filteredItems.map((item, i) => renderItem(item, i))}
       </div>

--- a/frontend/src/react/components/ProjectSidebar.tsx
+++ b/frontend/src/react/components/ProjectSidebar.tsx
@@ -260,6 +260,8 @@ export function ProjectSidebar() {
   // Create a Vue effectScope so we can call the Vue composable useRecentVisit.
   const recordVisitRef = useRef<((path: string) => void) | null>(null);
   useEffect(() => {
+    // TODO(steven): Replace this Vue composable bridge with a shared framework-agnostic
+    // recent-visit helper so React components don't need a Vue effect scope.
     const scope = effectScope();
     scope.run(() => {
       const { record } = useRecentVisit();

--- a/frontend/src/react/components/ProjectSidebar.tsx
+++ b/frontend/src/react/components/ProjectSidebar.tsx
@@ -40,7 +40,7 @@ import {
   useProjectV1Store,
   useWorkspaceV1Store,
 } from "@/store";
-import { getProjectName, projectNamePrefix } from "@/store/modules/v1/common";
+import { projectNamePrefix } from "@/store/modules/v1/common";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -281,13 +281,6 @@ export function ProjectSidebar() {
     }
   }, [projectId, projectStore]);
 
-  const project = useVueState(() => {
-    const pid =
-      (router.currentRoute.value.params.projectId as string | undefined) ?? "";
-    const projectName = pid ? `${projectNamePrefix}${pid}` : "";
-    return projectStore.getProjectByName(projectName);
-  });
-
   // -- Expand / collapse state -----------------------------------------------
   const [expandedSet, setExpandedSet] = useState<Set<string>>(new Set());
   const manualToggledRef = useRef<Set<string>>(new Set());
@@ -363,16 +356,16 @@ export function ProjectSidebar() {
     (path: string) =>
       router.resolve({
         name: path,
-        params: { projectId: getProjectName(project.name) },
+        params: { projectId },
       }).fullPath,
-    [project.name]
+    [projectId]
   );
 
   const handleItemClick = useCallback(
     (e: React.MouseEvent, path: string) => {
       const route = router.resolve({
         name: path,
-        params: { projectId: getProjectName(project.name) },
+        params: { projectId },
       });
       recordVisitRef.current?.(route.fullPath);
       if (e.ctrlKey || e.metaKey) {
@@ -382,15 +375,15 @@ export function ProjectSidebar() {
       e.preventDefault();
       router.push(route);
     },
-    [project.name]
+    [projectId]
   );
 
   const resolveHomeRoute = useCallback(() => {
     return router.resolve({
       name: PROJECT_V1_ROUTE_DETAIL,
-      params: { projectId: getProjectName(project.name) },
+      params: { projectId },
     });
-  }, [project.name]);
+  }, [projectId]);
 
   const handleHomeClick = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement>) => {


### PR DESCRIPTION
## Summary
- replace the React sidebar brand logo click wrappers with real links so browser-native open-in-new-tab behavior works again
- preserve SPA navigation and recent-visit tracking for normal left-click navigation
- add a TODO noting that the React-to-Vue recent-visit bridge should be replaced with a framework-agnostic helper

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend test` (fails in existing unrelated frontend tests/timeouts)