### PR TITLE
fix(frontend): restore z-50 on Select/Tooltip so dropdowns render above Dialog

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -32,7 +32,7 @@ React UI components live in `src/react/components/ui/` and follow shadcn-style p
 - **Use `truncate` shorthand** — not `overflow-hidden text-ellipsis whitespace-nowrap`
 - **Use `cn()` for conditional classes** — import from `@/react/lib/utils`, don't write manual template literal ternaries
 - **No manual `dark:` overrides** — use semantic tokens that handle theming
-- **No manual `z-index` on overlays** — Dialog, Sheet, Popover handle their own stacking
+- **No manual `z-index` on overlay *consumers*** — callers of `Dialog`, `Sheet`, `Popover`, `Select`, `Tooltip` must not set their own `z-index`. The primitives in `src/react/components/ui/` already coordinate stacking (all overlays use `z-50`; within that layer, later-mounted portals win by DOM order). Do **not** strip `z-50` from `select.tsx`, `tooltip.tsx`, `dialog.tsx`, or `alert-dialog.tsx` — removing it makes Select/Tooltip render behind Dialog (BYT-9226, PR #19824)
 
 ### Component Patterns
 

--- a/frontend/src/react/components/ui/dialog.tsx
+++ b/frontend/src/react/components/ui/dialog.tsx
@@ -9,6 +9,11 @@ const Dialog = BaseDialog.Root;
 const DialogTrigger = BaseDialog.Trigger;
 
 // ---- Overlay / Backdrop ----
+// Dialog, Select, Tooltip, and AlertDialog all use `z-50`. Within that shared
+// z-layer, stacking falls back to DOM portal mount order — later mounts win —
+// which correctly places a Select/Tooltip opened *inside* a Dialog on top of
+// the dialog backdrop. Do not bump Dialog above z-50 (or other overlays below)
+// without updating all four components together. See BYT-9226 / PR #19824.
 function DialogOverlay({
   className,
   ref,

--- a/frontend/src/react/components/ui/select.tsx
+++ b/frontend/src/react/components/ui/select.tsx
@@ -36,6 +36,13 @@ function SelectTrigger({
 const SelectValue = BaseSelect.Value;
 
 // ---- Portal + Positioner + Popup  ----
+// The `z-50` on the Positioner matches the z-index used by Dialog/AlertDialog
+// (see ui/dialog.tsx). It must not be removed — Dialog's backdrop/popup are
+// hardcoded at z-50, so a Select without an explicit z-index renders *behind*
+// any open Dialog regardless of DOM portal order (z-auto loses to z-50).
+// Within the same z-layer, stacking falls back to DOM order, which correctly
+// puts later-mounted portals (e.g. a Select opened inside a Dialog) on top.
+// See BYT-9226 and PR #19824 for the original regression.
 function SelectContent({
   className,
   children,
@@ -44,7 +51,7 @@ function SelectContent({
 }: ComponentProps<typeof BaseSelect.Popup>) {
   return (
     <BaseSelect.Portal>
-      <BaseSelect.Positioner sideOffset={4}>
+      <BaseSelect.Positioner sideOffset={4} className="z-50">
         <BaseSelect.Popup
           ref={ref}
           className={cn(

--- a/frontend/src/react/components/ui/tooltip.tsx
+++ b/frontend/src/react/components/ui/tooltip.tsx
@@ -26,7 +26,7 @@ export function Tooltip({
         </BaseTooltip.Trigger>
         <BaseTooltip.Portal>
           <BaseTooltip.Positioner side={side} sideOffset={4}>
-            <BaseTooltip.Popup className="max-w-56 rounded-sm bg-main px-2.5 py-1.5 text-xs text-main-text shadow-md">
+            <BaseTooltip.Popup className="z-50 max-w-56 rounded-sm bg-main px-2.5 py-1.5 text-xs text-main-text shadow-md">
               {content}
               <BaseTooltip.Arrow className="fill-main" />
             </BaseTooltip.Popup>
@@ -60,7 +60,7 @@ export function BlockTooltip({
         </BaseTooltip.Trigger>
         <BaseTooltip.Portal>
           <BaseTooltip.Positioner side={side} sideOffset={4}>
-            <BaseTooltip.Popup className="max-w-56 rounded-sm bg-main px-2.5 py-1.5 text-xs text-main-text shadow-md">
+            <BaseTooltip.Popup className="z-50 max-w-56 rounded-sm bg-main px-2.5 py-1.5 text-xs text-main-text shadow-md">
               {content}
               <BaseTooltip.Arrow className="fill-main" />
             </BaseTooltip.Popup>


### PR DESCRIPTION
## Summary

Fixes [BYT-9226](https://linear.app/bytebase/issue/BYT-9226/dropdown-condition-is-behind-the-dialog-window) — the CEL factor/operator dropdowns in the Custom Approval Rule dialog once again render behind the dialog backdrop. This is the exact regression already fixed in #19824.

**Root cause:** #19949 (`fix(frontend): align shadcn react patterns`, commit `86639d28d8`) stripped `z-[100]` off `BaseSelect.Positioner` in `ui/select.tsx` and `z-50` off `BaseTooltip.Popup` in `ui/tooltip.tsx`, interpreting the AGENTS.md rule "No manual z-index on overlays" as "remove any z-index you see". But `ui/dialog.tsx:20` and `:39` still hardcode `z-50` on both backdrop and popup, and in CSS stacking an explicit `z-50` always beats `z-auto` — so a Select/Tooltip rendered inside an open Dialog ends up behind the backdrop regardless of portal mount order. The `PortaledDropdown` used by `SearchableSelect` in `ExprEditor.tsx` still has an inline `zIndex: 100`, which is why only the factor/operator pickers (which route through `ui/select.tsx`) showed the bug.

## Fix

- `ui/select.tsx` — restore `className="z-50"` on `BaseSelect.Positioner`. Using `z-50` (shadcn's canonical overlay layer) instead of #19824's `z-[100]` so all overlays share the same layer; DOM portal mount order (later = on top) then correctly stacks a Select opened inside a Dialog.
- `ui/tooltip.tsx` — restore `z-50` on both `BaseTooltip.Popup` (Tooltip + BlockTooltip). Tooltips inside dialogs were broken by the same commit.
- `ui/dialog.tsx` — add a comment documenting the shared `z-50` layering contract between Dialog / Select / Tooltip / AlertDialog, citing BYT-9226 / #19824 so the next reviewer understands the coupling.
- `ui/select.tsx` — add the matching comment at the Select callsite.

## Systematic prevention

- **In-code anchors** in `dialog.tsx` and `select.tsx` call out that these four overlays must stay on the same z-layer and cite both past tickets — the next "clean this up" refactor will run straight into the explanation.
- **`frontend/AGENTS.md`** — the old rule ("No manual \`z-index\` on overlays — Dialog, Sheet, Popover handle their own stacking") is what invited the regression; it read as "strip any z-index you see". Rewrote it to clarify:
  - The rule applies to *consumers* of overlay primitives, not the primitive definitions themselves.
  - The primitives in \`src/react/components/ui/\` coordinate stacking via a shared \`z-50\` layer plus DOM portal mount order.
  - Explicitly: **do not** strip \`z-50\` from \`select.tsx\` / \`tooltip.tsx\` / \`dialog.tsx\` / \`alert-dialog.tsx\`, with ticket numbers.

## Test plan

- [ ] Settings → Custom Approval → click "+ Add rule" → Custom Approval Rule dialog opens
- [ ] Click the factor dropdown (e.g. \`resource.environment_id\`) → options render **above** the dialog backdrop, not behind it
- [ ] Click the operator dropdown (\`==\`, \`!=\`, etc.) → options render above the dialog
- [ ] Select a factor with searchable values → \`SearchableSelect\` dropdown still renders correctly (was already fine via \`PortaledDropdown\`)
- [ ] Hover any element with a Tooltip inside a Dialog → tooltip renders above the dialog backdrop
- [ ] \`pnpm --dir frontend check\` passes
- [ ] \`pnpm --dir frontend type-check\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)