### PR TITLE
fix(frontend): stop row action menus getting clipped by overflow-x-auto

### DIFF
--- a/frontend/src/react/components/instance/InstanceActionDropdown.tsx
+++ b/frontend/src/react/components/instance/InstanceActionDropdown.tsx
@@ -1,7 +1,12 @@
 import { EllipsisVertical } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/react/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { router } from "@/router";
 import { INSTANCE_ROUTE_DASHBOARD } from "@/router/dashboard/workspaceRoutes";
 import { pushNotification, useInstanceV1Store } from "@/store";
@@ -20,8 +25,6 @@ export function InstanceActionDropdown({
 }: InstanceActionDropdownProps) {
   const { t } = useTranslation();
   const instanceStore = useInstanceV1Store();
-  const [open, setOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const canArchive = hasWorkspacePermissionV2("bb.instances.delete");
   const canRestore = hasWorkspacePermissionV2("bb.instances.undelete");
@@ -87,64 +90,34 @@ export function InstanceActionDropdown({
     });
   }, [instance, instanceStore, t, onDeleted]);
 
-  const options: { key: string; label: string; handler: () => void }[] = [];
+  const showArchive = instance.state === State.ACTIVE && canArchive;
+  const showRestore = instance.state === State.DELETED && canRestore;
+  const showDelete = canArchive || canRestore;
 
-  if (instance.state === State.ACTIVE && canArchive) {
-    options.push({
-      key: "archive",
-      label: t("common.archive"),
-      handler: handleArchive,
-    });
-  } else if (instance.state === State.DELETED && canRestore) {
-    options.push({
-      key: "restore",
-      label: t("common.restore"),
-      handler: handleRestore,
-    });
-  }
-
-  if (canArchive || canRestore) {
-    options.push({
-      key: "delete",
-      label: t("common.delete"),
-      handler: handleDelete,
-    });
-  }
-
-  if (options.length === 0) return null;
+  if (!showArchive && !showRestore && !showDelete) return null;
 
   return (
-    <div className="relative" ref={dropdownRef}>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="size-8"
-        onClick={() => setOpen(!open)}
-      >
+    <DropdownMenu>
+      <DropdownMenuTrigger className="inline-flex items-center justify-center size-8 rounded-xs text-control hover:bg-control-bg cursor-pointer outline-hidden focus-visible:ring-2 focus-visible:ring-accent">
         <EllipsisVertical className="size-4" />
-      </Button>
-      {open && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <div className="absolute right-0 top-full mt-1 z-50 min-w-[120px] rounded-sm border bg-background shadow-md py-1">
-            {options.map((opt) => (
-              <button
-                key={opt.key}
-                type="button"
-                className={`w-full text-left px-3 py-1.5 text-sm hover:bg-control-bg ${
-                  opt.key === "delete" ? "text-error" : ""
-                }`}
-                onClick={() => {
-                  setOpen(false);
-                  opt.handler();
-                }}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </>
-      )}
-    </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        {showArchive && (
+          <DropdownMenuItem onClick={handleArchive}>
+            {t("common.archive")}
+          </DropdownMenuItem>
+        )}
+        {showRestore && (
+          <DropdownMenuItem onClick={handleRestore}>
+            {t("common.restore")}
+          </DropdownMenuItem>
+        )}
+        {showDelete && (
+          <DropdownMenuItem className="text-error" onClick={handleDelete}>
+            {t("common.delete")}
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/src/react/components/ui/dropdown-menu.tsx
+++ b/frontend/src/react/components/ui/dropdown-menu.tsx
@@ -1,0 +1,108 @@
+import { Menu as BaseMenu } from "@base-ui/react/menu";
+import type { ComponentProps } from "react";
+import { cn } from "@/react/lib/utils";
+
+// ---- Root ----
+// Default to non-modal: row action menus should let users click through to
+// other elements and dismiss by clicking outside, without locking page scroll.
+// Callers that need modal behavior (rare) can pass `modal` explicitly.
+function DropdownMenu({
+  modal = false,
+  ...props
+}: ComponentProps<typeof BaseMenu.Root>) {
+  return <BaseMenu.Root modal={modal} {...props} />;
+}
+
+// ---- Trigger ----
+// Re-exported as-is so callers pass their own className/children. Base UI
+// renders it as a <button> element by default.
+const DropdownMenuTrigger = BaseMenu.Trigger;
+
+// ---- Portal + Positioner + Popup ----
+// The `z-50` on the Positioner matches the z-index used by Dialog/Select/Tooltip
+// (see ui/dialog.tsx, ui/select.tsx, ui/tooltip.tsx). It must not be removed —
+// Dialog's backdrop/popup are hardcoded at z-50, so a DropdownMenu without an
+// explicit z-index renders *behind* any open Dialog regardless of DOM portal
+// order (z-auto loses to z-50). Within the same z-layer, stacking falls back to
+// DOM order, which correctly puts later-mounted portals on top.
+// See BYT-9226 and PR #19824 for the original regression.
+function DropdownMenuContent({
+  className,
+  children,
+  sideOffset = 4,
+  align = "end",
+  ref,
+  ...props
+}: ComponentProps<typeof BaseMenu.Popup> & {
+  sideOffset?: ComponentProps<typeof BaseMenu.Positioner>["sideOffset"];
+  align?: ComponentProps<typeof BaseMenu.Positioner>["align"];
+}) {
+  return (
+    <BaseMenu.Portal>
+      <BaseMenu.Positioner
+        sideOffset={sideOffset}
+        align={align}
+        className="z-50"
+      >
+        <BaseMenu.Popup
+          ref={ref}
+          className={cn(
+            "min-w-[10rem] overflow-hidden rounded-sm border border-control-border bg-background py-1 shadow-md",
+            "focus:outline-hidden",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </BaseMenu.Popup>
+      </BaseMenu.Positioner>
+    </BaseMenu.Portal>
+  );
+}
+
+// ---- Item ----
+function DropdownMenuItem({
+  className,
+  children,
+  ref,
+  ...props
+}: ComponentProps<typeof BaseMenu.Item>) {
+  return (
+    <BaseMenu.Item
+      ref={ref}
+      className={cn(
+        "relative flex items-center gap-x-2 px-3 py-2 text-sm cursor-pointer select-none",
+        "hover:bg-control-bg focus:bg-control-bg outline-hidden",
+        "data-highlighted:bg-control-bg",
+        "data-disabled:pointer-events-none data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </BaseMenu.Item>
+  );
+}
+
+// ---- Separator ----
+function DropdownMenuSeparator({
+  className,
+  ref,
+  ...props
+}: ComponentProps<typeof BaseMenu.Separator>) {
+  return (
+    <BaseMenu.Separator
+      ref={ref}
+      className={cn("-mx-1 my-1 h-px bg-control-border", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+};

--- a/frontend/src/react/pages/project/ProjectDatabaseGroupDetailPage.tsx
+++ b/frontend/src/react/pages/project/ProjectDatabaseGroupDetailPage.tsx
@@ -11,6 +11,12 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/react/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_DATABASE_GROUPS } from "@/router/dashboard/projectV1";
@@ -49,7 +55,6 @@ export function ProjectDatabaseGroupDetailPage({
 
   const [editing, setEditing] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [showDropdown, setShowDropdown] = useState(false);
 
   // Fetch the database group on mount
   useEffect(() => {
@@ -138,36 +143,19 @@ export function ProjectDatabaseGroupDetailPage({
           </PermissionGuard>
 
           {canDelete && (
-            <div className="relative">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="px-1!"
-                onClick={() => setShowDropdown((v) => !v)}
-              >
+            <DropdownMenu>
+              <DropdownMenuTrigger className="inline-flex items-center justify-center h-8 px-1 rounded-xs text-sm text-control hover:bg-control-bg cursor-pointer outline-hidden focus-visible:ring-2 focus-visible:ring-accent">
                 <EllipsisVertical className="size-4" />
-              </Button>
-              {showDropdown && (
-                <>
-                  <div
-                    className="fixed inset-0 z-10"
-                    onClick={() => setShowDropdown(false)}
-                  />
-                  <div className="absolute right-0 top-full z-20 mt-1 bg-background border rounded-sm shadow-md min-w-[100px]">
-                    <button
-                      type="button"
-                      className="w-full text-left px-3 py-1.5 text-sm hover:bg-control-bg text-error"
-                      onClick={() => {
-                        setShowDropdown(false);
-                        setShowDeleteDialog(true);
-                      }}
-                    >
-                      {t("common.delete")}
-                    </button>
-                  </div>
-                </>
-              )}
-            </div>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent>
+                <DropdownMenuItem
+                  className="text-error"
+                  onClick={() => setShowDeleteDialog(true)}
+                >
+                  {t("common.delete")}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
         </div>
       )}

--- a/frontend/src/react/pages/project/ProjectDatabaseGroupsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectDatabaseGroupsPage.tsx
@@ -9,6 +9,12 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/react/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { Input } from "@/react/components/ui/input";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
@@ -290,39 +296,28 @@ function ActionDropdown({
   onDelete: (group: DatabaseGroup) => void;
 }) {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
 
   return (
-    <div className="relative flex justify-end">
-      <button
-        type="button"
-        className="p-1 rounded-xs hover:bg-control-bg"
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpen((v) => !v);
-        }}
-      >
-        <EllipsisVertical className="size-4" />
-      </button>
-      {open && (
-        <>
-          {/* backdrop */}
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <div className="absolute right-0 top-full z-20 mt-1 bg-background border rounded-sm shadow-md min-w-[100px]">
-            <button
-              type="button"
-              className="w-full text-left px-3 py-1.5 text-sm hover:bg-control-bg text-error"
-              onClick={(e) => {
-                e.stopPropagation();
-                setOpen(false);
-                onDelete(group);
-              }}
-            >
-              {t("common.delete")}
-            </button>
-          </div>
-        </>
-      )}
+    <div className="flex justify-end">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="p-1 rounded-xs hover:bg-control-bg outline-hidden"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <EllipsisVertical className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem
+            className="text-error"
+            onClick={(e) => {
+              e.stopPropagation();
+              onDelete(group);
+            }}
+          >
+            {t("common.delete")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/frontend/src/react/pages/project/ProjectWebhookForm.tsx
+++ b/frontend/src/react/pages/project/ProjectWebhookForm.tsx
@@ -9,6 +9,12 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/react/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { Input } from "@/react/components/ui/input";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { WebhookTypeIcon } from "@/react/components/WebhookTypeIcon";
@@ -626,35 +632,21 @@ function DetailDropdown({
   onDelete: () => void;
 }) {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
 
   return (
-    <div className="relative">
-      <button
-        type="button"
-        className="p-1 rounded-xs hover:bg-control-bg"
-        onClick={() => setOpen((v) => !v)}
-      >
+    <DropdownMenu>
+      <DropdownMenuTrigger className="p-1 rounded-xs hover:bg-control-bg outline-hidden">
         <EllipsisVertical className="size-4" />
-      </button>
-      {open && (
-        <>
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <div className="absolute right-0 top-full z-20 mt-1 bg-background border rounded-sm shadow-md min-w-[100px]">
-            <button
-              type="button"
-              className="w-full text-left px-3 py-1.5 text-sm hover:bg-control-bg text-error"
-              disabled={loading}
-              onClick={() => {
-                setOpen(false);
-                onDelete();
-              }}
-            >
-              {t("common.delete")}
-            </button>
-          </div>
-        </>
-      )}
-    </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuItem
+          className="text-error"
+          disabled={loading}
+          onClick={onDelete}
+        >
+          {t("common.delete")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/src/react/pages/project/ProjectWebhooksPage.tsx
+++ b/frontend/src/react/pages/project/ProjectWebhooksPage.tsx
@@ -8,6 +8,12 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/react/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { WebhookTypeIcon } from "@/react/components/WebhookTypeIcon";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
@@ -241,44 +247,28 @@ function ActionDropdown({
   onDelete: (webhook: Webhook) => void;
 }) {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
 
   return (
-    <div className="relative flex justify-end">
-      <button
-        type="button"
-        className="p-1 rounded-xs hover:bg-control-bg"
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpen((v) => !v);
-        }}
-      >
-        <EllipsisVertical className="size-4" />
-      </button>
-      {open && (
-        <>
-          <div
-            className="fixed inset-0 z-10"
+    <div className="flex justify-end">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="p-1 rounded-xs hover:bg-control-bg outline-hidden"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <EllipsisVertical className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem
+            className="text-error"
             onClick={(e) => {
               e.stopPropagation();
-              setOpen(false);
+              onDelete(webhook);
             }}
-          />
-          <div className="absolute right-0 top-full z-20 mt-1 bg-background border rounded-sm shadow-md min-w-[100px]">
-            <button
-              type="button"
-              className="w-full text-left px-3 py-1.5 text-sm hover:bg-control-bg text-error"
-              onClick={(e) => {
-                e.stopPropagation();
-                setOpen(false);
-                onDelete(webhook);
-              }}
-            >
-              {t("common.delete")}
-            </button>
-          </div>
-        </>
-      )}
+          >
+            {t("common.delete")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -28,6 +28,12 @@ import {
   AlertTitle,
 } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -296,16 +302,12 @@ function InstanceActionDropdown({
 }) {
   const { t } = useTranslation();
   const instanceStore = useInstanceV1Store();
-  const [open, setOpen] = useState(false);
   const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [forceArchive, setForceArchive] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const canArchive = hasWorkspacePermissionV2("bb.instances.delete");
   const canRestore = hasWorkspacePermissionV2("bb.instances.undelete");
-  const closeDropdown = useCallback(() => setOpen(false), []);
-  useClickOutside(dropdownRef, open, closeDropdown);
 
   const handleArchive = useCallback(async () => {
     try {
@@ -331,7 +333,6 @@ function InstanceActionDropdown({
   }, [instance, instanceStore, forceArchive, t, onAction]);
 
   const handleRestore = useCallback(async () => {
-    setOpen(false);
     try {
       await instanceStore.restoreInstance(instance);
       pushNotification({
@@ -378,56 +379,47 @@ function InstanceActionDropdown({
 
   return (
     <>
-      <div ref={dropdownRef} className="relative">
-        <button
-          className="p-1 hover:bg-control-bg rounded-xs"
-          onClick={(e) => {
-            e.stopPropagation();
-            setOpen(!open);
-          }}
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="p-1 rounded-xs hover:bg-control-bg outline-hidden"
+          onClick={(e) => e.stopPropagation()}
         >
           <EllipsisVertical className="h-4 w-4" />
-        </button>
-        {open && (
-          <div className="absolute right-0 top-full mt-1 bg-background border border-control-border rounded-sm shadow-lg z-10 min-w-[120px]">
-            {isActive && canArchive && (
-              <button
-                className="w-full text-left px-3 py-2 text-sm hover:bg-control-bg flex items-center gap-x-2"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setOpen(false);
-                  setShowArchiveConfirm(true);
-                }}
-              >
-                {t("common.archive")}
-              </button>
-            )}
-            {!isActive && canRestore && (
-              <button
-                className="w-full text-left px-3 py-2 text-sm hover:bg-control-bg flex items-center gap-x-2"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleRestore();
-                }}
-              >
-                {t("common.restore")}
-              </button>
-            )}
-            {(canArchive || canRestore) && (
-              <button
-                className="w-full text-left px-3 py-2 text-sm hover:bg-control-bg flex items-center gap-x-2 text-error"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setOpen(false);
-                  setShowDeleteConfirm(true);
-                }}
-              >
-                {t("common.delete")}
-              </button>
-            )}
-          </div>
-        )}
-      </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          {isActive && canArchive && (
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowArchiveConfirm(true);
+              }}
+            >
+              {t("common.archive")}
+            </DropdownMenuItem>
+          )}
+          {!isActive && canRestore && (
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                handleRestore();
+              }}
+            >
+              {t("common.restore")}
+            </DropdownMenuItem>
+          )}
+          {(canArchive || canRestore) && (
+            <DropdownMenuItem
+              className="text-error"
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowDeleteConfirm(true);
+              }}
+            >
+              {t("common.delete")}
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
 
       <ConfirmDialog
         open={showArchiveConfirm}

--- a/frontend/src/react/pages/settings/ProjectsPage.tsx
+++ b/frontend/src/react/pages/settings/ProjectsPage.tsx
@@ -24,6 +24,12 @@ import {
 } from "@/react/components/ResourceIdField";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { Input } from "@/react/components/ui/input";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -601,28 +607,11 @@ function ProjectActionDropdown({
 }) {
   const { t } = useTranslation();
   const projectStore = useProjectV1Store();
-  const [open, setOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
 
   const canDelete = hasProjectPermissionV2(project, "bb.projects.delete");
   const canUndelete = hasProjectPermissionV2(project, "bb.projects.undelete");
 
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      ) {
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [open]);
-
   const handleArchive = useCallback(async () => {
-    setOpen(false);
     if (
       !window.confirm(
         t("project.settings.confirm-archive-project", {
@@ -642,7 +631,6 @@ function ProjectActionDropdown({
   }, [project, projectStore, t, onAction]);
 
   const handleRestore = useCallback(async () => {
-    setOpen(false);
     await projectStore.restoreProject(project);
     pushNotification({
       module: "bytebase",
@@ -657,44 +645,37 @@ function ProjectActionDropdown({
   const isActive = project.state === State.ACTIVE;
 
   return (
-    <div ref={dropdownRef} className="relative">
-      <button
-        className="p-1 hover:bg-control-bg rounded-xs"
-        onClick={(e) => {
-          e.stopPropagation();
-          setOpen(!open);
-        }}
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="p-1 rounded-xs hover:bg-control-bg outline-hidden"
+        onClick={(e) => e.stopPropagation()}
       >
         <EllipsisVertical className="h-4 w-4" />
-      </button>
-      {open && (
-        <div className="absolute right-0 top-full mt-1 bg-background border border-control-border rounded-sm shadow-lg z-10 min-w-[120px]">
-          {isActive && canDelete && (
-            <button
-              className="w-full text-left px-3 py-2 text-sm hover:bg-control-bg flex items-center gap-x-2"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleArchive();
-              }}
-            >
-              <Archive className="h-4 w-4" />
-              {t("common.archive")}
-            </button>
-          )}
-          {!isActive && canUndelete && (
-            <button
-              className="w-full text-left px-3 py-2 text-sm hover:bg-control-bg flex items-center gap-x-2"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleRestore();
-              }}
-            >
-              {t("common.restore")}
-            </button>
-          )}
-        </div>
-      )}
-    </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        {isActive && canDelete && (
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation();
+              handleArchive();
+            }}
+          >
+            <Archive className="h-4 w-4" />
+            {t("common.archive")}
+          </DropdownMenuItem>
+        )}
+        {!isActive && canUndelete && (
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation();
+              handleRestore();
+            }}
+          >
+            {t("common.restore")}
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 


### PR DESCRIPTION
## Summary

Every row "⋮" menu in the React resource-list pages was hand-rolled with `absolute right-0 top-full` positioning inside a `<div className="overflow-x-auto">` table wrapper. Because absolute-positioned children can't escape an ancestor clipping context, the menus got sliced off the right edge of the table — users saw the **Archive** option rendering outside the card frame on Instances and Projects, and the same bug existed on Webhooks and Database Groups.

**Root cause:** we never built a shadcn `DropdownMenu` primitive, so each page reimplemented the same broken pattern. `z-index` doesn't help here — z-index only re-stacks within the same clipping context; it doesn't escape an overflow clip.

## Changes

- **New primitive:** `frontend/src/react/components/ui/dropdown-menu.tsx` wrapping Base UI's `Menu`. Portals to `document.body` (escapes any overflow clip), pins the Positioner at `z-50` to match `Dialog`/`Select`/`Tooltip` per the overlay rule in `frontend/AGENTS.md`, and defaults to `modal={false}` so row menus don't lock page scroll or block outside pointer events.
- **Refactored 7 sites** to replace hand-rolled `useState` / `useRef` / `useClickOutside` / `absolute right-0 top-full` markup with the new primitive:
  - `frontend/src/react/pages/settings/InstancesPage.tsx` (Instance row menu — screenshot case)
  - `frontend/src/react/pages/settings/ProjectsPage.tsx` (Project row menu — screenshot case)
  - `frontend/src/react/pages/project/ProjectWebhooksPage.tsx`
  - `frontend/src/react/pages/project/ProjectDatabaseGroupsPage.tsx`
  - `frontend/src/react/pages/project/ProjectDatabaseGroupDetailPage.tsx`
  - `frontend/src/react/pages/project/ProjectWebhookForm.tsx`
  - `frontend/src/react/components/instance/InstanceActionDropdown.tsx` (reusable, used by `InstanceDetailPage`)

Net diff: +306 / -287 lines across 8 files — the primitive adds ~100 lines but removes ~15–25 lines of boilerplate per site.

## Test plan

- [x] `pnpm --dir frontend type-check` passes
- [x] `pnpm --dir frontend check` (ESLint + Biome + i18n) passes
- [x] `pnpm --dir frontend test` — all 1031 tests pass
- [x] `pnpm --dir frontend dev` compiles cleanly (HTTP 200 on root)
- [ ] **Visual QA:** at a viewport where the Instances / Projects tables horizontally scroll, click the "⋮" on a row and confirm the menu renders above the table edge (portaled to body) instead of getting sliced
- [ ] **Visual QA:** confirm outside-click and Escape both still dismiss the menu
- [ ] **Visual QA:** confirm clicking "⋮" on a row does NOT also trigger row navigation (stopPropagation preserved on trigger and items)
- [ ] **Visual QA:** confirm the same fix applies on Project Webhooks, Project Database Groups, and the Database Group detail toolbar menu
- [ ] **Visual QA:** confirm Instance Detail page's `⋮` menu (the reusable `InstanceActionDropdown`) still works — archive / restore / delete via `window.confirm`

## Follow-ups (intentionally out of scope)

Similar hand-rolled dropdowns that aren't row action menus and aren't clipping — worth migrating to `DropdownMenu` in a cleanup PR once this lands:

- `InstancesPage.tsx` → `SyncDropdown` (batch-bar toolbar)
- `IssueTable.tsx` → sort-order toolbar button
- `DatabaseExportSchemaButton.tsx` → export options toolbar
- `SemanticTypesPage.tsx` → color picker popover

The original consistency-audit findings (convert Custom Approval Rule and SQL Review `RuleEditDialog` from Dialog to Drawer) are also still pending as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)