### PR TITLE
feat(frontend): add Sheet primitive, migrate Custom Approval Rule to drawer

### DIFF
--- a/frontend/src/react/components/CustomApproval/RuleEditSheet.tsx
+++ b/frontend/src/react/components/CustomApproval/RuleEditSheet.tsx
@@ -13,12 +13,15 @@ import {
 import { ExprEditor } from "@/react/components/ExprEditor";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-} from "@/react/components/ui/dialog";
 import { Input } from "@/react/components/ui/input";
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/react/components/ui/sheet";
 import { Switch } from "@/react/components/ui/switch";
 import { Textarea } from "@/react/components/ui/textarea";
 import type { LocalApprovalRule } from "@/types";
@@ -37,7 +40,7 @@ import {
   getApprovalOptionConfigMap,
 } from "./utils";
 
-interface RuleEditDialogProps {
+interface RuleEditSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   mode: "create" | "edit";
@@ -50,7 +53,7 @@ interface RuleEditDialogProps {
   onSave: (rule: Omit<LocalApprovalRule, "uid"> & { uid?: string }) => void;
 }
 
-export function RuleEditDialog({
+export function RuleEditSheet({
   open,
   onOpenChange,
   mode,
@@ -61,7 +64,7 @@ export function RuleEditDialog({
   hasFeature,
   onShowFeatureModal,
   onSave,
-}: RuleEditDialogProps) {
+}: RuleEditSheetProps) {
   const { t } = useTranslation();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -163,17 +166,13 @@ export function RuleEditDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex flex-col overflow-hidden lg:max-w-[75vw] 2xl:max-w-[55vw]">
-        {/* Header */}
-        <div className="border-b px-6 py-4">
-          <DialogTitle className="text-lg font-medium text-control">
-            {t("custom-approval.rule.self")}
-          </DialogTitle>
-        </div>
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent width="wide">
+        <SheetHeader>
+          <SheetTitle>{t("custom-approval.rule.self")}</SheetTitle>
+        </SheetHeader>
 
-        {/* Body */}
-        <div className="flex flex-1 flex-col gap-y-4 overflow-y-auto px-6 py-4">
+        <SheetBody className="gap-y-4">
           {/* Fallback hint */}
           {isFallback && (
             <Alert variant="warning">
@@ -281,18 +280,17 @@ export function RuleEditDialog({
               </>
             )}
           </div>
-        </div>
+        </SheetBody>
 
-        {/* Footer */}
-        <footer className="flex items-center justify-end gap-x-2 border-t px-6 py-4">
+        <SheetFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             {t("common.cancel")}
           </Button>
           <Button disabled={!allowSave || !allowAdmin} onClick={handleSave}>
             {mode === "create" ? t("common.create") : t("common.update")}
           </Button>
-        </footer>
-      </DialogContent>
-    </Dialog>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/frontend/src/react/components/CustomApproval/RulesSection.tsx
+++ b/frontend/src/react/components/CustomApproval/RulesSection.tsx
@@ -28,7 +28,7 @@ import { pushNotification, useWorkspaceApprovalSettingStore } from "@/store";
 import type { LocalApprovalRule } from "@/types";
 import type { WorkspaceApprovalSetting_Rule_Source } from "@/types/proto-es/v1/setting_service_pb";
 import { WorkspaceApprovalSetting_Rule_Source as RuleSource } from "@/types/proto-es/v1/setting_service_pb";
-import { RuleEditDialog } from "./RuleEditDialog";
+import { RuleEditSheet } from "./RuleEditSheet";
 import { approvalSourceText, formatApprovalFlow } from "./utils";
 
 interface RulesSectionProps {
@@ -365,7 +365,7 @@ export function RulesSection({
         )}
       </div>
 
-      <RuleEditDialog
+      <RuleEditSheet
         open={dialogOpen}
         onOpenChange={setDialogOpen}
         mode={dialogMode}

--- a/frontend/src/react/components/ui/sheet.tsx
+++ b/frontend/src/react/components/ui/sheet.tsx
@@ -1,0 +1,183 @@
+import { Dialog as BaseDialog } from "@base-ui/react/dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
+import { cn } from "@/react/lib/utils";
+
+// ---- Root ----
+// A side sheet is a Dialog whose Popup is pinned to the right edge of the
+// viewport. We reuse Base UI's Dialog primitive for focus trap, Escape key,
+// outside-click dismissal, and ARIA wiring — a sheet is semantically a dialog,
+// just with a different layout.
+const Sheet = BaseDialog.Root;
+
+// ---- Trigger ----
+const SheetTrigger = BaseDialog.Trigger;
+
+// ---- Close ----
+const SheetClose = BaseDialog.Close;
+
+// ---- Backdrop ----
+// Dialog, Select, Tooltip, AlertDialog, DropdownMenu all share `z-50`. Within
+// that layer, stacking falls back to DOM portal mount order — later mounts
+// win — which correctly places a Select/Tooltip opened *inside* a Sheet on
+// top of the sheet backdrop. Do not bump Sheet above z-50 (or other overlays
+// below) without updating all siblings together. See BYT-9226 / PR #19824.
+function SheetOverlay({
+  className,
+  ref,
+  ...props
+}: ComponentProps<typeof BaseDialog.Backdrop>) {
+  return (
+    <BaseDialog.Backdrop
+      ref={ref}
+      className={cn(
+        "fixed inset-0 z-50 bg-overlay/50",
+        "data-[starting-style]:opacity-0 data-[ending-style]:opacity-0",
+        "transition-opacity duration-200",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+// ---- Content (Portal + Overlay + Popup) ----
+// Width tiers codify our resource-edit drawer conventions:
+//   narrow   (384px) — single-field pickers, short forms
+//   standard (704px) — 3-6 field forms, permission transfer lists
+//   wide     (832px) — forms with CEL builders, nested tables, multi-tab layouts
+// Do not inline ad-hoc widths on SheetContent — add a tier here if a new
+// legitimate size is needed so all consumers stay aligned.
+const sheetContentVariants = cva(
+  cn(
+    "fixed inset-y-0 right-0 z-50 flex h-full flex-col bg-background shadow-lg",
+    "max-w-[100vw] outline-hidden",
+    "data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full",
+    "transition-transform duration-200 ease-out"
+  ),
+  {
+    variants: {
+      width: {
+        narrow: "w-[24rem]",
+        standard: "w-[44rem]",
+        wide: "w-[52rem]",
+      },
+    },
+    defaultVariants: {
+      width: "standard",
+    },
+  }
+);
+
+interface SheetContentProps
+  extends ComponentProps<typeof BaseDialog.Popup>,
+    VariantProps<typeof sheetContentVariants> {}
+
+function SheetContent({
+  className,
+  children,
+  width,
+  ref,
+  ...props
+}: SheetContentProps) {
+  return (
+    <BaseDialog.Portal>
+      <SheetOverlay />
+      <BaseDialog.Popup
+        ref={ref}
+        className={cn(sheetContentVariants({ width }), className)}
+        {...props}
+      >
+        {children}
+      </BaseDialog.Popup>
+    </BaseDialog.Portal>
+  );
+}
+
+// ---- Header ----
+// Sticky top region with a bottom border. Typically contains SheetTitle and
+// an optional SheetDescription.
+function SheetHeader({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-y-1 border-b border-control-border px-6 py-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+// ---- Body ----
+// Scrollable middle region between header and footer. Uses flex-1 so it
+// absorbs remaining vertical space.
+function SheetBody({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex flex-1 flex-col overflow-y-auto px-6 py-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+// ---- Footer ----
+// Sticky bottom region with a top border. Use `gap-x-2` for button groups,
+// matching the BUTTON_SPACING_STANDARDIZATION convention.
+function SheetFooter({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-end gap-x-2 border-t border-control-border px-6 py-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+// ---- Title ----
+function SheetTitle({
+  className,
+  ref,
+  ...props
+}: ComponentProps<typeof BaseDialog.Title>) {
+  return (
+    <BaseDialog.Title
+      ref={ref}
+      className={cn("text-lg font-semibold text-control", className)}
+      {...props}
+    />
+  );
+}
+
+// ---- Description ----
+function SheetDescription({
+  className,
+  ref,
+  ...props
+}: ComponentProps<typeof BaseDialog.Description>) {
+  return (
+    <BaseDialog.Description
+      ref={ref}
+      className={cn("text-sm text-control-light", className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetBody,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetOverlay,
+  SheetTitle,
+  SheetTrigger,
+};


### PR DESCRIPTION
## Summary

The frontend has no `Sheet` / `Drawer` primitive in shadcn `ui/` — every existing "drawer" (`RoleDrawer`, `EditEnvironmentDrawer`) is hand-rolled with `fixed inset-0 z-50` + a manual backdrop, manual Escape handling, and an inlined one-off width. That's the same missing-primitive pattern we just fixed for `DropdownMenu` in #19960 — different call sites, same drift.

Meanwhile, multiple complex resource-edit forms are still centered dialogs where a right-side drawer fits far better. **Custom Approval Rule** is the clearest example, with presets + title + description + a CEL expression builder + a draggable approval-nodes table all crammed into a modal that was already sized `lg:max-w-[75vw] 2xl:max-w-[55vw]` just to fit the content.

This PR builds the missing primitive and uses Custom Approval Rule as the reference implementation that proves it works end-to-end. Follow-up PRs can migrate SQL Review `RuleEditDialog`, `RoleDrawer`, and `EditEnvironmentDrawer` onto the same primitive for consistency.

## Changes

### New primitive: `frontend/src/react/components/ui/sheet.tsx`

- Wraps Base UI's `Dialog` (same `@base-ui/react/dialog` powering `dialog.tsx`) with a right-side layout. Focus trap, Escape, outside-click, ARIA, and portal all come free from Base UI — no more hand-rolled hooks.
- **Width tiers** via ` cva` on `SheetContent` — new consumers pick a tier, no more ad-hoc widths:
  | tier | width | when to use |
  |---|---|---|
  | `narrow` | `w-[24rem]` (384px) | single-field pickers, short forms |
  | `standard` | `w-[44rem]` (704px) | 3–6 field forms, permission transfer |
  | `wide` | `w-[52rem]` (832px) | CEL builders, nested tables, multi-tab layouts |
- **Overlay-stacking rule** from `frontend/AGENTS.md`: backdrop and popup both at `z-50` to match `Dialog`/`Select`/`Tooltip`/`DropdownMenu`, so later-mounted portals (e.g. a `Select` opened *inside* a `Sheet`) correctly render on top. See BYT-9226 / PR #19824.
- **Slide-in transition** keyed off Base UI's `data-starting-style` / `data-ending-style` data attributes.
- Exports: `Sheet`, `SheetTrigger`, `SheetContent`, `SheetHeader`, `SheetBody`, `SheetFooter`, `SheetTitle`, `SheetDescription`, `SheetClose`, `SheetOverlay`.

### Migration: Custom Approval Rule

- Rename `frontend/src/react/components/CustomApproval/RuleEditDialog.tsx` → `RuleEditSheet.tsx` and component `RuleEditDialog` → `RuleEditSheet`. Git tracked it as a rename (91% similarity).
- Replace `Dialog` / `DialogContent` / `DialogTitle` with `Sheet` / `SheetContent width=\"wide\"` / `SheetHeader` / `SheetBody` / `SheetFooter` / `SheetTitle`.
- Drop hand-rolled `flex flex-col overflow-hidden lg:max-w-[75vw] 2xl:max-w-[55vw]` and the header/body/footer div chrome — that's now the primitive's job.
- Update the single importer in `RulesSection.tsx`.

## UX Change (not a breaking change per AGENTS.md §Breaking Change Check, but worth calling out)

The **Custom Approval Rule editor** (Settings → Custom Approval → Create/Edit rule) now opens as a **right-side drawer** instead of a centered dialog. Same fields, same buttons, same validation, same save flow — users perform the task identically, but the form shape is visually different and the rules list behind it stays visible. This matches the rule we're codifying: *creating/editing a resource → drawer*.

## Test plan

- [x] `pnpm --dir frontend type-check` passes
- [x] `pnpm --dir frontend check` (ESLint + Biome + i18n + locale sort) passes
- [x] `pnpm --dir frontend test` — all 1031 tests pass
- [x] `pnpm --dir frontend dev` compiles cleanly; root serves HTTP 200
- [ ] **Visual QA:** Settings → Custom Approval → click **Create** on a rule group — the editor opens as a right-side drawer that slides in
- [ ] **Visual QA:** the rules list behind the drawer remains visible (backdrop dims but doesn't hide)
- [ ] **Visual QA:** edit an existing rule — title/description/condition/approval nodes all pre-populate correctly
- [ ] **Visual QA:** try a template preset in create mode — title + condition + flow roles populate
- [ ] **Visual QA:** toggle "no approval required" — approval nodes table hides, Save button re-enables
- [ ] **Visual QA:** drawer dismisses via Escape key, outside click, and the Cancel button
- [ ] **Visual QA:** at a narrow viewport (<832px) the drawer clamps to `max-w-[100vw]` rather than overflowing
- [ ] **Visual QA:** focus trap works — Tab/Shift+Tab cycles within the drawer
- [ ] **Visual QA:** opening a `Select` inside the drawer (e.g. approver role picker in the nodes table) renders on top of the drawer's backdrop, not behind it
- [ ] **Visual QA:** the fallback-rule hint Alert still renders for fallback rules

## Follow-ups (intentionally out of scope)

The same primitive should replace these in a subsequent PR:

- **SQL Review `RuleEditDialog`** (`frontend/src/react/components/sql-review/RuleComponents.tsx:359`) — per-rule config with dynamic payload fields. Target: `<Sheet width=\"standard\">`.
- **`EditEnvironmentDrawer`** (`frontend/src/react/pages/settings/InstancesPage.tsx:503`) — already conceptually correct, just hand-rolled. Target: `<Sheet width=\"narrow\">`.
- **`RoleDrawer`** (`frontend/src/react/pages/settings/RolesPage.tsx:374`) — also hand-rolled. Target: `<Sheet width=\"standard\">`.

Also: a short `frontend/.claude/DIALOG_VS_SHEET.md` guideline doc (mirrors `BUTTON_SPACING_STANDARDIZATION.md`) codifying *"create/edit a resource → Sheet; yes/no confirmation or single-field prompt → Dialog"* and the width tiers. Deliberately deferred until the primitive has at least one consumer, which this PR provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)