### PR TITLE
docs: remove demo link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,10 +163,3 @@ alias y="pnpm --dir frontend i && pnpm --dir frontend dev"
    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=bytebase/bytebase%2Cliquibase/liquibase%2Cflyway/flyway%2Cdbeaver/cloudbeaver&type=date&legend=top-left" />
  </picture>
 </a>
-
----
-
-<p align="center">
-  <b>Join us in revolutionizing database management!</b><br>
-  <a href="https://cal.com/bytebase/product-walkthrough">Book a demo</a>
-</p>


### PR DESCRIPTION
Removed the 'Book a demo' section from the end of README.md as requested.