### PR TITLE
feat(partiql): 1/4 replace ANTLR-based SQL splitter with hand-written scanner

### DIFF
--- a/backend/plugin/parser/partiql/split.go
+++ b/backend/plugin/parser/partiql/split.go
@@ -1,8 +1,9 @@
 package partiql
 
 import (
-	"github.com/antlr4-go/antlr/v4"
-	parser "github.com/bytebase/parser/partiql"
+	"unicode/utf8"
+
+	"github.com/bytebase/omni/partiql"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
@@ -12,11 +13,66 @@ func init() {
 	base.RegisterSplitterFunc(storepb.Engine_DYNAMODB, SplitSQL)
 }
 
-// SplitSQL splits the input into multiple SQL statements using semicolon as delimiter.
+// SplitSQL splits the input into multiple SQL statements using the omni
+// splitter, then converts each Segment into a base.Statement with the
+// position fields that bytebase expects.
+//
+// Positions are computed in a single O(n) pass over the input, not by
+// rescanning from byte 0 for each segment.
 func SplitSQL(statement string) ([]base.Statement, error) {
-	lexer := parser.NewPartiQLLexer(antlr.NewInputStream(statement))
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	stream.Fill()
+	segs := partiql.Split(statement)
+	if len(segs) == 0 {
+		return nil, nil
+	}
 
-	return base.SplitSQLByLexer(stream, parser.PartiQLLexerCOLON_SEMI)
+	// Collect all boundary offsets we need positions for.
+	type pos struct{ line, col int }
+	positions := make(map[int]pos, len(segs)*2)
+	for _, seg := range segs {
+		positions[seg.ByteStart] = pos{}
+		positions[seg.ByteEnd] = pos{}
+	}
+
+	// Single O(n) scan: track line/col and record at each boundary offset.
+	line, col := 1, 1
+	for i := 0; i <= len(statement); {
+		if _, need := positions[i]; need {
+			positions[i] = pos{line, col}
+		}
+		if i == len(statement) {
+			break
+		}
+		r, size := utf8.DecodeRuneInString(statement[i:])
+		if r == '\n' {
+			line++
+			col = 1
+		} else {
+			col++
+		}
+		i += size
+	}
+
+	// Build result from pre-computed positions.
+	stmts := make([]base.Statement, 0, len(segs))
+	for _, seg := range segs {
+		sp := positions[seg.ByteStart]
+		ep := positions[seg.ByteEnd]
+		stmts = append(stmts, base.Statement{
+			Text:  seg.Text,
+			Empty: seg.Empty(),
+			Start: &storepb.Position{
+				Line:   int32(sp.line),
+				Column: int32(sp.col),
+			},
+			End: &storepb.Position{
+				Line:   int32(ep.line),
+				Column: int32(ep.col),
+			},
+			Range: &storepb.Range{
+				Start: int32(seg.ByteStart),
+				End:   int32(seg.ByteEnd),
+			},
+		})
+	}
+	return stmts, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260413035929-09d38c776926
+	github.com/bytebase/omni v0.0.0-20260413080102-b7768760e83e
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888 h1:E8tz8maxpih/vt
 github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888/go.mod h1:IgLUOjyiHehdE0G3C92IjGYu9lJQgkPwf2mdNSvPWq8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260413035929-09d38c776926 h1:VeWXS00qYgw5ZsU0syf/Dor6VyqUjtvDqrAoHvT9p80=
-github.com/bytebase/omni v0.0.0-20260413035929-09d38c776926/go.mod h1:AT+iLKCu7NyxTaYaOLzETRFBVurjRaqUU3YmFron9pw=
+github.com/bytebase/omni v0.0.0-20260413080102-b7768760e83e h1:6DY/L/lS+QPxSFCEd7m64C8iq1MXXTYEXwTZRiJ8fdo=
+github.com/bytebase/omni v0.0.0-20260413080102-b7768760e83e/go.mod h1:AT+iLKCu7NyxTaYaOLzETRFBVurjRaqUU3YmFron9pw=
 github.com/bytebase/parser v0.0.0-20260324092042-1d52e5412f50 h1:Kq5wlhZ586Rch39y/IQV9MnrEzHob4iiXBG6zrbvSMU=
 github.com/bytebase/parser v0.0.0-20260324092042-1d52e5412f50/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
Part 1 of 4 of the PartiQL ANTLR → omni migration.

Rewrites `SplitSQL` to use a hand-written semicolon splitter instead of the ANTLR lexer. Respects single-quoted strings, double-quoted identifiers, backtick ion literals, line/block comments.

**Merge order:** This PR is independent — merge first or in parallel with PR 2 and 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)