### PR TITLE
fix(frontend): use ESNext target for React tsconfig

### DIFF
--- a/frontend/tsconfig.react.json
+++ b/frontend/tsconfig.react.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2025",
+    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2025", "DOM", "DOM.Iterable"],


### PR DESCRIPTION
## Summary
- change `frontend/tsconfig.react.json` target from `ES2025` to `ESNext`
- keep `lib` on `ES2025` so available type definitions stay unchanged
- stop Vite/esbuild from warning about the unsupported `ES2025` target for React TS sources

## Test Plan
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend test`
