### PR TITLE
fix(frontend): align agent input composer controls

### DIFF
--- a/frontend/src/react/plugins/agent/components/AgentInput.test.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentInput.test.tsx
@@ -1,0 +1,210 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createAgentStore, useAgentStore } from "../store/agent";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  useTranslation: vi.fn(() => ({
+    t: (key: string) => key,
+  })),
+  routerPush: vi.fn(),
+  lazyExtractDomRefSuggestions: vi.fn(async () => []),
+  runAgentLoop: vi.fn(),
+  isAgentAIConfigurationError: vi.fn(() => false),
+  buildOutboundHistory: vi.fn(() => []),
+  buildSystemPrompt: vi.fn(() => "system"),
+  createToolExecutor: vi.fn(() => ({})),
+  getToolDefinitions: vi.fn(() => []),
+}));
+
+let AgentInput: typeof import("./AgentInput").AgentInput;
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    key(index: number) {
+      return Object.keys(store)[index] ?? null;
+    },
+    getItem(key: string) {
+      return store[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    },
+  };
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: mocks.useTranslation,
+}));
+
+vi.mock("@/router", () => ({
+  router: {
+    currentRoute: {
+      value: {
+        fullPath: "/demo",
+      },
+    },
+    push: mocks.routerPush,
+  },
+}));
+
+vi.mock("../dom", () => ({
+  lazyExtractDomRefSuggestions: mocks.lazyExtractDomRefSuggestions,
+}));
+
+vi.mock("../logic/agentLoop", () => ({
+  runAgentLoop: mocks.runAgentLoop,
+}));
+
+vi.mock("../logic/aiConfiguration", () => ({
+  isAgentAIConfigurationError: mocks.isAgentAIConfigurationError,
+}));
+
+vi.mock("../logic/outboundHistory", () => ({
+  buildOutboundHistory: mocks.buildOutboundHistory,
+}));
+
+vi.mock("../logic/prompt", () => ({
+  buildSystemPrompt: mocks.buildSystemPrompt,
+}));
+
+vi.mock("../logic/tools", () => ({
+  createToolExecutor: mocks.createToolExecutor,
+  getToolDefinitions: mocks.getToolDefinitions,
+}));
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  return {
+    container,
+    render: () => {
+      act(() => {
+        root.render(element);
+      });
+    },
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
+};
+
+const setTextareaValue = (textarea: HTMLTextAreaElement, value: string) => {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value"
+  );
+  descriptor?.set?.call(textarea, value);
+};
+
+beforeEach(async () => {
+  vi.stubGlobal("localStorage", createMockStorage());
+  useAgentStore.setState(createAgentStore().getState(), true);
+
+  mocks.useTranslation.mockReset();
+  mocks.useTranslation.mockReturnValue({
+    t: (key: string) => key,
+  });
+  mocks.routerPush.mockReset();
+  mocks.lazyExtractDomRefSuggestions.mockReset();
+  mocks.lazyExtractDomRefSuggestions.mockResolvedValue([]);
+  mocks.runAgentLoop.mockReset();
+  mocks.isAgentAIConfigurationError.mockReset();
+  mocks.isAgentAIConfigurationError.mockReturnValue(false);
+  mocks.buildOutboundHistory.mockReset();
+  mocks.buildOutboundHistory.mockReturnValue([]);
+  mocks.buildSystemPrompt.mockReset();
+  mocks.buildSystemPrompt.mockReturnValue("system");
+  mocks.createToolExecutor.mockReset();
+  mocks.createToolExecutor.mockReturnValue({});
+  mocks.getToolDefinitions.mockReset();
+  mocks.getToolDefinitions.mockReturnValue([]);
+
+  ({ AgentInput } = await import("./AgentInput"));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("AgentInput", () => {
+  test("uses the same single-line height for the textarea and send button", () => {
+    const { container, render, unmount } = renderIntoContainer(<AgentInput />);
+
+    render();
+
+    const row = container.querySelector("[data-agent-input-row]");
+    expect(row?.className).toContain("items-end");
+    expect(container.querySelector("textarea")?.className).toContain(
+      "min-h-[34px]"
+    );
+    expect(container.querySelector("textarea")?.className).toContain("block");
+    expect(container.querySelector("button")?.className).toContain("h-[34px]");
+
+    unmount();
+  });
+
+  test("adds border-box height correctly and enables scrolling only at max height", () => {
+    const { container, render, unmount } = renderIntoContainer(<AgentInput />);
+
+    render();
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
+
+    const element = textarea as HTMLTextAreaElement;
+    let scrollHeight = 32;
+    Object.defineProperty(element, "scrollHeight", {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    const getComputedStyleSpy = vi
+      .spyOn(window, "getComputedStyle")
+      .mockReturnValue({
+        lineHeight: "20px",
+        paddingTop: "6px",
+        paddingBottom: "6px",
+        borderTopWidth: "1px",
+        borderBottomWidth: "1px",
+        boxSizing: "border-box",
+      } as CSSStyleDeclaration);
+
+    act(() => {
+      setTextareaValue(element, "hello");
+      element.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(element.style.height).toBe("34px");
+    expect(element.style.overflowY).toBe("hidden");
+
+    scrollHeight = 200;
+
+    act(() => {
+      setTextareaValue(element, "a\nb\nc\nd\ne\nf\ng");
+      element.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(element.style.height).toBe("134px");
+    expect(element.style.overflowY).toBe("auto");
+
+    getComputedStyleSpy.mockRestore();
+    unmount();
+  });
+});

--- a/frontend/src/react/plugins/agent/components/AgentInput.test.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentInput.test.tsx
@@ -155,13 +155,16 @@ describe("AgentInput", () => {
     expect(container.querySelector("textarea")?.className).toContain(
       "min-h-[34px]"
     );
+    expect(container.querySelector("textarea")?.className).toContain(
+      "max-h-[134px]"
+    );
     expect(container.querySelector("textarea")?.className).toContain("block");
     expect(container.querySelector("button")?.className).toContain("h-[34px]");
 
     unmount();
   });
 
-  test("adds border-box height correctly and enables scrolling only at max height", () => {
+  test("sizes from CSS min/max heights and enables scrolling only at max height", () => {
     const { container, render, unmount } = renderIntoContainer(<AgentInput />);
 
     render();
@@ -175,15 +178,19 @@ describe("AgentInput", () => {
       configurable: true,
       get: () => scrollHeight,
     });
+    Object.defineProperty(element, "offsetHeight", {
+      configurable: true,
+      get: () => 34,
+    });
+    Object.defineProperty(element, "clientHeight", {
+      configurable: true,
+      get: () => 32,
+    });
     const getComputedStyleSpy = vi
       .spyOn(window, "getComputedStyle")
       .mockReturnValue({
-        lineHeight: "20px",
-        paddingTop: "6px",
-        paddingBottom: "6px",
-        borderTopWidth: "1px",
-        borderBottomWidth: "1px",
-        boxSizing: "border-box",
+        minHeight: "34px",
+        maxHeight: "134px",
       } as CSSStyleDeclaration);
 
     act(() => {

--- a/frontend/src/react/plugins/agent/components/AgentInput.test.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentInput.test.tsx
@@ -145,6 +145,33 @@ afterEach(() => {
 });
 
 describe("AgentInput", () => {
+  test("shows a single-line overlay placeholder and hides it when typing", () => {
+    const { container, render, unmount } = renderIntoContainer(<AgentInput />);
+
+    render();
+
+    const placeholder = container.querySelector(
+      "[data-agent-input-placeholder]"
+    );
+    expect(placeholder?.textContent).toBe("agent.input-placeholder");
+    expect(placeholder?.className).toContain("truncate");
+    expect(placeholder?.className).toContain("pointer-events-none");
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
+
+    act(() => {
+      setTextareaValue(textarea as HTMLTextAreaElement, "hello");
+      textarea?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(
+      container.querySelector("[data-agent-input-placeholder]")
+    ).toBeNull();
+
+    unmount();
+  });
+
   test("uses the same single-line height for the textarea and send button", () => {
     const { container, render, unmount } = renderIntoContainer(<AgentInput />);
 

--- a/frontend/src/react/plugins/agent/components/AgentInput.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentInput.tsx
@@ -215,29 +215,19 @@ export function AgentInput() {
     const el = textareaRef.current;
     if (!el) return;
 
-    const computedStyle = window.getComputedStyle(el);
-    const lineHeight = Number.parseFloat(computedStyle.lineHeight) || 20;
-    const paddingTop = Number.parseFloat(computedStyle.paddingTop) || 0;
-    const paddingBottom = Number.parseFloat(computedStyle.paddingBottom) || 0;
-    const paddingHeight = paddingTop + paddingBottom;
-    const borderTop = Number.parseFloat(computedStyle.borderTopWidth) || 0;
-    const borderBottom =
-      Number.parseFloat(computedStyle.borderBottomWidth) || 0;
-    const borderHeight =
-      computedStyle.boxSizing === "border-box" ? borderTop + borderBottom : 0;
-    const minHeight = lineHeight + paddingHeight + borderHeight;
-
     el.style.height = "auto";
-    const maxRows = 6;
-    const maxHeight = lineHeight * maxRows + paddingHeight + borderHeight;
-    const nextHeight = Math.max(
-      minHeight,
-      Math.min(el.scrollHeight + borderHeight, maxHeight)
-    );
+
+    const styles = window.getComputedStyle(el);
+    const minHeight =
+      Number.parseFloat(styles.minHeight) || el.getBoundingClientRect().height;
+    const maxHeight =
+      Number.parseFloat(styles.maxHeight) || Number.POSITIVE_INFINITY;
+    const borderHeight = el.offsetHeight - el.clientHeight;
+    const contentHeight = el.scrollHeight + borderHeight;
+    const nextHeight = Math.max(minHeight, Math.min(contentHeight, maxHeight));
 
     el.style.height = `${nextHeight}px`;
-    el.style.overflowY =
-      el.scrollHeight + borderHeight > maxHeight ? "auto" : "hidden";
+    el.style.overflowY = contentHeight > maxHeight ? "auto" : "hidden";
   }, []);
 
   useEffect(() => {
@@ -700,7 +690,7 @@ export function AgentInput() {
               ref={textareaRef}
               value={input}
               rows={1}
-              className="block min-h-[34px] w-full resize-none overflow-y-hidden rounded-xs border px-3 py-1.5 text-sm leading-5 outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
+              className="block min-h-[34px] max-h-[134px] w-full resize-none overflow-y-hidden rounded-xs border px-3 py-1.5 text-sm leading-5 outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
               placeholder={inputPlaceholder}
               disabled={isCurrentChatRunning || isAIConfigurationBlocked}
               onChange={(e) => {

--- a/frontend/src/react/plugins/agent/components/AgentInput.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentInput.tsx
@@ -214,11 +214,30 @@ export function AgentInput() {
   const autoResize = useCallback(() => {
     const el = textareaRef.current;
     if (!el) return;
+
+    const computedStyle = window.getComputedStyle(el);
+    const lineHeight = Number.parseFloat(computedStyle.lineHeight) || 20;
+    const paddingTop = Number.parseFloat(computedStyle.paddingTop) || 0;
+    const paddingBottom = Number.parseFloat(computedStyle.paddingBottom) || 0;
+    const paddingHeight = paddingTop + paddingBottom;
+    const borderTop = Number.parseFloat(computedStyle.borderTopWidth) || 0;
+    const borderBottom =
+      Number.parseFloat(computedStyle.borderBottomWidth) || 0;
+    const borderHeight =
+      computedStyle.boxSizing === "border-box" ? borderTop + borderBottom : 0;
+    const minHeight = lineHeight + paddingHeight + borderHeight;
+
     el.style.height = "auto";
     const maxRows = 6;
-    const lineHeight = 20;
-    const maxHeight = lineHeight * maxRows;
-    el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+    const maxHeight = lineHeight * maxRows + paddingHeight + borderHeight;
+    const nextHeight = Math.max(
+      minHeight,
+      Math.min(el.scrollHeight + borderHeight, maxHeight)
+    );
+
+    el.style.height = `${nextHeight}px`;
+    el.style.overflowY =
+      el.scrollHeight + borderHeight > maxHeight ? "auto" : "hidden";
   }, []);
 
   useEffect(() => {
@@ -675,17 +694,13 @@ export function AgentInput() {
         </div>
       ) : (
         /* Input row with @-mention autocomplete */
-        <div
-          className="relative flex items-center gap-x-2"
-          data-agent-input-row
-        >
+        <div className="relative flex items-end gap-x-2" data-agent-input-row>
           <div className="relative w-full">
             <textarea
               ref={textareaRef}
               value={input}
               rows={1}
-              className="w-full resize-none rounded-xs border px-3 py-1.5 text-sm outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
-              style={{ maxHeight: 120 }}
+              className="block min-h-[34px] w-full resize-none overflow-y-hidden rounded-xs border px-3 py-1.5 text-sm leading-5 outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
               placeholder={inputPlaceholder}
               disabled={isCurrentChatRunning || isAIConfigurationBlocked}
               onChange={(e) => {
@@ -747,7 +762,7 @@ export function AgentInput() {
             <Button
               variant="destructive"
               size="sm"
-              className="whitespace-nowrap"
+              className="h-[34px] shrink-0 self-end whitespace-nowrap"
               onClick={() => useAgentStore.getState().cancel(currentChat?.id)}
             >
               {t("agent.stop")}
@@ -755,7 +770,7 @@ export function AgentInput() {
           ) : (
             <Button
               size="sm"
-              className="whitespace-nowrap"
+              className="h-[34px] shrink-0 self-end whitespace-nowrap"
               disabled={isSendDisabled}
               onClick={() => void send()}
             >

--- a/frontend/src/react/plugins/agent/components/AgentInput.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentInput.tsx
@@ -686,12 +686,20 @@ export function AgentInput() {
         /* Input row with @-mention autocomplete */
         <div className="relative flex items-end gap-x-2" data-agent-input-row>
           <div className="relative w-full">
+            {!input && (
+              <div
+                className="pointer-events-none absolute inset-x-3 top-1.5 z-10 truncate text-sm leading-5 text-control-light"
+                data-agent-input-placeholder
+              >
+                {inputPlaceholder}
+              </div>
+            )}
             <textarea
               ref={textareaRef}
               value={input}
               rows={1}
               className="block min-h-[34px] max-h-[134px] w-full resize-none overflow-y-hidden rounded-xs border px-3 py-1.5 text-sm leading-5 outline-none focus:ring-1 focus:ring-accent disabled:opacity-50"
-              placeholder={inputPlaceholder}
+              aria-label={inputPlaceholder}
               disabled={isCurrentChatRunning || isAIConfigurationBlocked}
               onChange={(e) => {
                 setInput(e.target.value);


### PR DESCRIPTION
Close BYT-9223

## Summary
- fix the agent composer so the textarea and send button align in the live UI
- remove the textarea baseline gap by rendering it as a block element and keep autosize based on computed box metrics
- add a focused regression test for the composer sizing behavior

## Test Plan
- [x] `pnpm --dir frontend exec vitest run src/react/plugins/agent/components/AgentInput.test.tsx`
- [x] `pnpm --dir frontend fix`
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend test`
- [x] Verified against the live app at `http://localhost:3001` after signing in and opening the assistant window
