### PR TITLE
feat(issue-detail): migrate project issue detail page to react

### DIFF
--- a/frontend/src/react/components/monaco/MonacoEditor.tsx
+++ b/frontend/src/react/components/monaco/MonacoEditor.tsx
@@ -51,6 +51,7 @@ import type {
 } from "./types";
 import {
   buildAdviceHoverMessage,
+  configureMonacoMessages,
   extensionNameOfLanguage,
   formatEditorContent,
   trySetContentWithUndo,
@@ -137,6 +138,14 @@ export function MonacoEditor({
   const [contentHeight, setContentHeight] = useState(min);
   const [ready, setReady] = useState(false);
 
+  useEffect(() => {
+    configureMonacoMessages({
+      title: t("sql-editor.web-socket.errors.title"),
+      description: t("sql-editor.web-socket.errors.description"),
+      disconnected: t("sql-editor.web-socket.errors.disconnected"),
+    });
+  }, [t]);
+
   contentRef.current = content;
   languageRef.current = language;
   readOnlyRef.current = readOnly;
@@ -147,6 +156,11 @@ export function MonacoEditor({
   onActiveContentChangeRef.current = onActiveContentChange;
   onReadyRef.current = onReady;
 
+  const shouldEnableLSP =
+    !readOnly &&
+    (Boolean(autoCompleteContext) ||
+      enableDecorations ||
+      Boolean(onActiveContentChange));
   const connection = useSyncExternalStore(
     subscribeConnectionState,
     getConnectionStateSnapshot,
@@ -211,21 +225,19 @@ export function MonacoEditor({
     let formatAction: { dispose(): void } | null = null;
     let suggestStyle: HTMLStyleElement | null = null;
     let messageHandler: ((event: MessageEvent) => void) | null = null;
+    const host = document.createElement("div");
+    host.className = "h-full w-full";
+    containerRef.current?.replaceChildren(host);
 
     (async () => {
-      if (!containerRef.current) return;
+      if (!containerRef.current || editorRef.current) return;
 
-      const shouldEnableLSP =
-        !readOnlyRef.current &&
-        (Boolean(autoCompleteContext) ||
-          enableDecorations ||
-          Boolean(onActiveContentChangeRef.current));
       if (shouldEnableLSP) {
         void initializeLSPClient().catch(() => undefined);
       }
 
       const editor = await createMonacoEditor({
-        container: containerRef.current,
+        container: host,
         options: {
           ...optionsRef.current,
           language: languageRef.current,
@@ -303,9 +315,11 @@ export function MonacoEditor({
       }
 
       if (shouldEnableLSP) {
-        const wsPromise = getConnectionWebSocket();
+        const wsPromise =
+          getConnectionWebSocket() ??
+          initializeLSPClient().then(() => getConnectionWebSocket());
         wsPromise?.then((ws) => {
-          if (disposed) return;
+          if (!ws || disposed) return;
           messageHandler = (message: MessageEvent) => {
             processStatementRangeMessage(message, activeRangeByUriRef);
             emitSelectionSideEffects();
@@ -343,6 +357,7 @@ export function MonacoEditor({
       editorRef.current?.dispose();
       editorRef.current = null;
       modelRef.current = null;
+      host.remove();
     };
   }, [
     autoCompleteContext,
@@ -351,6 +366,8 @@ export function MonacoEditor({
     enableDecorations,
     formatContentOptions,
     generatedFilename,
+    shouldEnableLSP,
+    t,
   ]);
 
   useEffect(() => {

--- a/frontend/src/react/components/monaco/core.ts
+++ b/frontend/src/react/components/monaco/core.ts
@@ -19,8 +19,13 @@ const initializeTheme = () => {
   if (state.themeInitialized) return;
   state.themeInitialized = true;
   if (!monacoModule) return;
-  monacoModule.editor.defineTheme("bb", getBBTheme());
-  monacoModule.editor.defineTheme("bb-dark", getBBDarkTheme());
+  try {
+    monacoModule.editor.defineTheme("bb", getBBTheme());
+    monacoModule.editor.defineTheme("bb-dark", getBBDarkTheme());
+  } catch {
+    // The VSCode theme service override owns themes in some runtime modes.
+    // Fall back to the default theme instead of failing editor creation.
+  }
 };
 
 const initialize = async () => {

--- a/frontend/src/react/components/monaco/lsp-client.ts
+++ b/frontend/src/react/components/monaco/lsp-client.ts
@@ -62,6 +62,10 @@ const conn: ConnectionState = {
     timestamp: 0,
   },
 };
+let connectionSnapshot = {
+  state: conn.state,
+  heartbeat: conn.heartbeat,
+};
 
 const state = {
   client: undefined as MonacoLanguageClient | undefined,
@@ -70,11 +74,19 @@ const state = {
 
 const setConnState = (patch: Partial<ConnectionState>) => {
   Object.assign(conn, patch);
+  connectionSnapshot = {
+    state: conn.state,
+    heartbeat: conn.heartbeat,
+  };
   emit();
 };
 
 const setHeartbeat = (patch: Partial<ConnectionState["heartbeat"]>) => {
   Object.assign(conn.heartbeat, patch);
+  connectionSnapshot = {
+    state: conn.state,
+    heartbeat: conn.heartbeat,
+  };
   emit();
 };
 
@@ -295,9 +307,6 @@ export const subscribeConnectionState = (listener: () => void) => {
   };
 };
 
-export const getConnectionStateSnapshot = () => ({
-  state: conn.state,
-  heartbeat: conn.heartbeat,
-});
+export const getConnectionStateSnapshot = () => connectionSnapshot;
 
 export const getConnectionWebSocket = () => conn.ws;

--- a/frontend/src/react/components/monaco/services.ts
+++ b/frontend/src/react/components/monaco/services.ts
@@ -9,12 +9,25 @@ import "vscode/localExtensionHost";
 type WorkerLoader = () => Worker;
 
 const workerLoaders: Partial<Record<string, WorkerLoader>> = {
+  editorWorkerService: () =>
+    new Worker(
+      new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url),
+      { type: "module" }
+    ),
   TextEditorWorker: () =>
     new Worker(
       new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url),
       { type: "module" }
     ),
   TextMateWorker: () =>
+    new Worker(
+      new URL(
+        "@codingame/monaco-vscode-textmate-service-override/worker",
+        import.meta.url
+      ),
+      { type: "module" }
+    ),
+  textMateWorker: () =>
     new Worker(
       new URL(
         "@codingame/monaco-vscode-textmate-service-override/worker",

--- a/frontend/src/react/components/monaco/utils.ts
+++ b/frontend/src/react/components/monaco/utils.ts
@@ -1,5 +1,4 @@
 import { Range } from "monaco-editor";
-import { t } from "@/plugins/i18n";
 import { pushNotification } from "@/store";
 import type { Language, SQLDialect } from "@/types";
 import { callCssVariable, escapeMarkdown, minmax } from "@/utils";
@@ -15,10 +14,26 @@ export const RECONNECTION_DELAY = {
 export const WEBSOCKET_TIMEOUT = 5000;
 export const WEBSOCKET_HEARTBEAT_INTERVAL = 10 * 1000;
 
+type MonacoMessages = {
+  title: string;
+  description: string;
+  disconnected: string;
+};
+
+let monacoMessages: MonacoMessages = {
+  title: "WebSocket connection failed",
+  description: "Auto Completion might be limited or disabled.",
+  disconnected: "WebSocket disconnected",
+};
+
+export const configureMonacoMessages = (messages: MonacoMessages) => {
+  monacoMessages = messages;
+};
+
 export const messages = {
-  title: () => t("sql-editor.web-socket.errors.title"),
-  description: () => t("sql-editor.web-socket.errors.description"),
-  disconnected: () => t("sql-editor.web-socket.errors.disconnected"),
+  title: () => monacoMessages.title,
+  description: () => monacoMessages.description,
+  disconnected: () => monacoMessages.disconnected,
 };
 
 export const extensionNameOfLanguage = (lang: Language) => {

--- a/frontend/src/react/components/ui/button.tsx
+++ b/frontend/src/react/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
       },
       size: {
         default: "h-9 px-4 py-2",
-        xs: "h-7 px-2 text-xs",
+        xs: "h-6 px-1.5 text-[11px] gap-1.5",
         sm: "h-8 px-3 text-xs",
         md: "h-9 px-4 text-sm",
         lg: "h-10 px-6",

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -1,4 +1,12 @@
 {
+  "activity.sentence.canceled-issue": "closed the issue",
+  "activity.sentence.changed-description": "changed description",
+  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
+  "activity.sentence.changed-labels": "changed labels",
+  "activity.sentence.created-issue": "created issue",
+  "activity.sentence.modified-sql-of": "modified SQL of",
+  "activity.sentence.reopened-issue": "reopened issue",
+  "activity.sentence.resolved-issue": "approved the issue",
   "agent": {
     "active-only-chats": "Active only",
     "ai-not-configured": {
@@ -132,6 +140,7 @@
     "address": "Address",
     "admin": "Admin",
     "all": "All",
+    "approve": "Approve",
     "approved": "Approved",
     "archive": "Archive",
     "archive-description": "Mark \"{{name}}\" as archived and read-only.",
@@ -182,6 +191,7 @@
     "dismiss": "Dismiss",
     "download": "Download",
     "draft": "Draft",
+    "duration": "Duration",
     "edit": "Edit",
     "email": "Email",
     "email-ascii-only": "Email addresses only support ASCII characters (letters, numbers, and symbols like . _ - +).",
@@ -226,6 +236,7 @@
     "minutes": "Minutes",
     "missing-required-permission": "Missing required permissions {{permissions}}",
     "missing-required-permission-for-resource": "Missing required permissions for resource {{resource}}",
+    "more": "More",
     "n-items-selected": "{{n}} items selected",
     "n-more": "+{{n}} more",
     "name": "Name",
@@ -238,12 +249,14 @@
     "password": "Password",
     "pending": "Pending",
     "permissions": "Permissions",
+    "plan": "Plan",
     "previous": "Previous",
     "project": "Project",
     "projects": "Projects",
     "read-only": "Read-only",
     "reason": "Reason",
     "regenerate": "Regenerate",
+    "reject": "Reject",
     "rejected": "Rejected",
     "release": "Release",
     "reorder": "Reorder",
@@ -263,6 +276,7 @@
     },
     "rollback": "Rollback",
     "rows-per-page": "Rows per page",
+    "run": "Run",
     "save": "Save",
     "schema": "Schema",
     "scope": "Scope",
@@ -277,6 +291,7 @@
     "skipped": "Skipped",
     "snapshot": "Snapshot",
     "sql": "SQL",
+    "stage": "Stage",
     "state": "State",
     "statement": "Statement",
     "status": "Status",
@@ -309,6 +324,7 @@
     "write-only": "write only",
     "you": "you"
   },
+  "common.activity": "Activity",
   "common.add": "Add",
   "common.admin": "Admin",
   "common.all": "All",
@@ -318,41 +334,61 @@
   "common.cannot-undo-this-action": "You cannot undo this action",
   "common.catalog": "Catalog",
   "common.close": "Close",
+  "common.collapse": "Collapse",
+  "common.column": "Column",
+  "common.comment": "Comment",
   "common.confirm": "Confirm",
   "common.continue-anyway": "Continue anyway",
+  "common.copy": "Copy",
   "common.create": "Create",
   "common.creating": "Creating",
   "common.custom": "Custom",
   "common.database": "Database",
+  "common.database-group": "Database group",
   "common.databases": "Databases",
   "common.default": "default",
   "common.delete": "Delete",
   "common.delete-resource": "Delete {{type}}",
   "common.deleted": "Deleted",
+  "common.detail": "Detail",
   "common.detailed-guide": "detailed guide",
   "common.edit": "Edit",
+  "common.edited": "edited",
   "common.environment": "Environment",
   "common.import": "Import",
+  "common.issue": "Issue",
   "common.key": "Key",
   "common.labels": "Labels",
   "common.learn-more": "Learn more",
+  "common.line": "Line",
   "common.load-more": "Load more",
   "common.loading": "Loading",
   "common.members": "Members",
   "common.minutes": "Minutes",
+  "common.n-more": "{{n}} more",
   "common.no-data": "No data",
+  "common.only-creator-allowed-export": "Only the creator is allowed to export",
+  "common.open": "Open",
   "common.optional": "Optional",
   "common.or": "or",
   "common.overview": "Overview",
   "common.password": "Password",
   "common.project": "Project",
   "common.read-only": "Read-only",
+  "common.remaining": "remaining",
   "common.remove": "Remove",
   "common.removed": "Removed",
   "common.restore": "Restore",
+  "common.retry": "Retry",
+  "common.role.self": "Role",
   "common.rollout": "Rollout",
+  "common.save": "Save",
   "common.sensitive-placeholder": "Sensitive - write only",
   "common.show-more": "Show more",
+  "common.skip": "Skip",
+  "common.success": "Success",
+  "common.task": "Task",
+  "common.troubleshoot": "Troubleshoot",
   "common.unknown": "Unknown",
   "common.unlimited": "Unlimited",
   "common.updated": "Updated",
@@ -400,7 +436,17 @@
       }
     },
     "issue-review": {
-      "generating-approval-flow": "Generating approval flow"
+      "and-n-other-users": "{{names}} and {{count}} other users",
+      "approved-by": "Approved by",
+      "disallow-approve-reason": {
+        "some-task-checks-are-still-running": "Some task checks are still running.",
+        "some-task-checks-didnt-pass": "Some task checks didn't pass."
+      },
+      "generating-approval-flow": "Generating approval flow",
+      "re-request-review": "Re-request review",
+      "re-request-review-success": "Review re-requested successfully",
+      "rejected-by": "Rejected by",
+      "self-approval-not-allowed": "Self-approval is not allowed in this project. So you cannot approve your own issue."
     },
     "risk": {
       "description": "Risk assessment automatically evaluates database changes and assigns risk levels based on the type of operation being performed.",
@@ -437,6 +483,9 @@
     },
     "self": "Custom Approval"
   },
+  "custom-approval.issue-review.approved-issue": "approved issue",
+  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
+  "custom-approval.issue-review.rejected-issue": "rejected issue",
   "data-source": {
     "additional-node-addresses": "Additional Node Addresses",
     "connection-string-schema": "Connection String Schema",
@@ -642,6 +691,7 @@
   "export-data": {
     "password-optional": "Encrypt with password (Optional)"
   },
+  "export-data.password-optional": "Password (optional)",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "For databases sharing the same schema, a database group lets you migrate them together in one change. Define the group once and reuse it across migrations without picking individual databases every time.",
@@ -970,6 +1020,7 @@
   "instance.scan-interval.self": "Scan Interval",
   "instance.section.basic-info": "Basic Info",
   "instance.section.connection": "Connection",
+  "instance.select-database-user": "Select database user",
   "instance.sentence.aws-rds.mysql.template": "Below is an example to create user {{user}}@% and grant the user with the needed privileges.",
   "instance.sentence.aws-rds.postgresql.template": "Below is an example to create user '{{user}}' and grant the user with the needed privileges.",
   "instance.sentence.console.snowflake": "The external console URL managing this instance (e.g. AWS RDS console, your in-house DB instance console)",
@@ -1015,6 +1066,11 @@
   "instance.users": "Users",
   "instance.your-snowflake-account-locator": "Your Snowflake account locator",
   "issue": {
+    "access-grant": {
+      "details": "Access Grant Details",
+      "expired-at": "Expired at"
+    },
+    "action-anyway": "{{action}} anyway",
     "advanced-search": {
       "filter": "Filter",
       "scope": {
@@ -1059,6 +1115,9 @@
         }
       }
     },
+    "approval-flow": {
+      "self": "Approval Flow"
+    },
     "batch-transition": {
       "close": "Close",
       "closed": "closed",
@@ -1066,13 +1125,22 @@
       "reopen": "Reopen",
       "reopened": "reopened"
     },
+    "checks-manual-rollout-hint": "Approval is complete, but rollout wasn't created automatically because this plan still has failed checks. Go to Plan to continue.",
     "data-export": {
+      "download-tooltip": "Available for 24 hours",
+      "file-expired": "File Expired",
       "format": "Format",
       "limits": "Limits",
       "options": "Options"
     },
     "labels": "Issue Labels",
     "leave-a-comment": "Leave a comment...",
+    "review": {
+      "approve-description": "Submit feedback and approve this issue",
+      "comment-description": "Submit general feedback without approval",
+      "reject-description": "Submit feedback and request changes",
+      "self": "Review"
+    },
     "risk-level": {
       "filter": "Filter issues by risk level",
       "high": "High",
@@ -1081,8 +1149,10 @@
       "self": "Risk level"
     },
     "role-grant": {
-      "all-databases": "All",
+      "all-databases": "All databases",
       "all-databases-tip": "All current and future databases in this project.",
+      "details": "Role Grant Details",
+      "expired-at": "Expired at",
       "manually-select": "Manually select",
       "use-cel": "Use CEL Expression"
     },
@@ -1092,6 +1162,12 @@
       "descending": "Descending",
       "sort": "Sort",
       "updated": "Update time"
+    },
+    "status-transition": {
+      "modal": {
+        "close": "Close issue?",
+        "reopen": "Reopen issue?"
+      }
     },
     "subtitle": "Issues cover database changes, data exports, and access requests. Review and approve before execution.",
     "table": {
@@ -1111,7 +1187,26 @@
     "upload-sql": "Upload SQL",
     "waiting-approval": "Waiting for Approval"
   },
+  "issue.comment-editor.nothing-to-preview": "Nothing to preview",
+  "issue.comment-editor.preview": "Preview",
+  "issue.comment-editor.toolbar.bold": "Insert bold text",
+  "issue.comment-editor.toolbar.code": "Insert SQL code snippet",
+  "issue.comment-editor.toolbar.hashtag": "Insert hashtag",
+  "issue.comment-editor.toolbar.header": "Insert heading text",
+  "issue.comment-editor.toolbar.link": "Insert a link",
+  "issue.comment-editor.write": "Write",
+  "issue.data-export.format": "Format",
+  "issue.data-export.limits": "Limits",
+  "issue.data-export.options": "Options",
+  "issue.issue-name": "Issue name",
+  "issue.no-description-provided": "No description provided",
+  "issue.options-disabled-due-to-oversize": "Options are disabled because the SQL is oversized.",
+  "issue.overwrite-current-statement": "Overwrite current SQL statement",
+  "issue.review.self": "Review",
+  "issue.statement-from-sheet-warning": "This statement is loaded from a large sheet. Preview may be truncated.",
   "issue.task-run.logs": "Logs",
+  "issue.transaction-mode.label": "Transaction Mode",
+  "issue.upload-sql-file-max-size-exceeded": "Max file size ({size}) exceeded.",
   "label": {
     "add-label": "Add label",
     "empty-label-value": "Empty",
@@ -1142,6 +1237,9 @@
     "checks": {
       "self": "Checks"
     },
+    "editor": {
+      "save-changes-before-continuing": "Please save or cancel your changes before continuing"
+    },
     "navigator": {
       "review": "Review"
     },
@@ -1152,6 +1250,30 @@
       "title": "Targets"
     }
   },
+  "plan.checks.failed-to-run": "Failed to run plan checks",
+  "plan.checks.no-check-results": "No check results",
+  "plan.checks.no-results-match-filters": "No results match your filters",
+  "plan.checks.started": "Plan checks started",
+  "plan.go-to-plan-page": "Go to plan page",
+  "plan.isolation-level.read-committed": "Read Committed",
+  "plan.isolation-level.read-uncommitted": "Read Uncommitted",
+  "plan.isolation-level.repeatable-read": "Repeatable Read",
+  "plan.isolation-level.self": "Isolation Level",
+  "plan.isolation-level.serializable": "Serializable",
+  "plan.navigator.checks": "Checks",
+  "plan.navigator.statement-empty": "Statement is empty",
+  "plan.options.self": "Options",
+  "plan.overview.no-checks": "No checks",
+  "plan.ready-for-review": "Ready for Review",
+  "plan.run": "Run",
+  "plan.select-isolation-level": "Select isolation level",
+  "plan.spec.change": "Change",
+  "plan.spec.type.database-change": "Database Change",
+  "plan.targets.no-targets-found": "No targets found",
+  "plan.targets.non-env-warning.one": "{{count}} database will be excluded from rollout because it has no effective environment:",
+  "plan.targets.non-env-warning.other": "{{count}} databases will be excluded from rollout because they have no effective environment:",
+  "plan.targets.title": "Targets",
+  "plan.targets.view-all": "View all ({{count}})",
   "policy": {
     "environment-tier": {
       "description": "The environment will appear differently from other environments.",
@@ -1256,6 +1378,7 @@
           "self": "Enforce SQL review"
         },
         "labels": {
+          "configure-labels": "Configure labels",
           "description": "Labels can be attached in the issues for management",
           "force-issue-labels": {
             "description": "Require at least one label when creating issues.",
@@ -1333,10 +1456,23 @@
     "request-export-data": "Request Export"
   },
   "release": {
+    "and-n-more-files": "and {{count}} more files",
+    "change-tip": "This change is linked to a release artifact.",
+    "file-type": {
+      "declarative": "Declarative",
+      "unspecified": "Unspecified",
+      "versioned": "Versioned"
+    },
     "files": "Files",
+    "not-found": "Release not found",
     "releases": "Releases",
     "total-files": "Total {{}} files",
-    "usage-description": "A release is a versioned application artifact whose deployment to an environment is triggered by a GitOps workflow."
+    "usage-description": "A release is a versioned application artifact whose deployment to an environment is triggered by a GitOps workflow.",
+    "vcs-source": "VCS Source",
+    "vcs-type": {
+      "unspecified": "Unknown VCS"
+    },
+    "view-all-files": "View all files"
   },
   "remind": {
     "release": {
@@ -1390,7 +1526,8 @@
     "stage": {
       "self_one": "Stage",
       "self_other": "Stages"
-    }
+    },
+    "task-execution-errors": "Task execution errors"
   },
   "schema-editor": {
     "raw-sql": "Raw SQL"
@@ -1904,6 +2041,7 @@
   },
   "sql-editor": {
     "access-grants": "Access Grants",
+    "access-type-unmask": "See unmasked sensitive data",
     "activate-access": "Activate",
     "activate-confirm": "Are you sure you want to activate this access grant?",
     "expired": "Expired",
@@ -1912,6 +2050,7 @@
     "revoke-access": "Revoke",
     "revoke-confirm": "Are you sure you want to revoke this access grant?",
     "self": "SQL Editor",
+    "unmask-warning": "The query result may include unmasked sensitive data.",
     "view-issue": "View Issue",
     "web-socket": {
       "errors": {
@@ -2781,11 +2920,40 @@
   "subscription.usage.instance-count.runoutof": "You have run out of your {{total}} instance quota.",
   "subscription.usage.instance-count.title": "Instance count limit",
   "task": {
+    "cancel-task": "Cancel task | Cancel tasks",
     "checking": "Checking...",
+    "created": "Created",
+    "data-export-creator-only": "Only the issue creator can execute data export tasks",
+    "error": {
+      "scheduled-time-must-be-in-the-future": "Scheduled time must be in the future"
+    },
+    "execution-time": "Execution time",
+    "no-permission": "No permission to perform this action",
+    "run-immediately": {
+      "description": "Tasks will start executing as soon as you click Run. No delay or scheduling required.",
+      "self": "Run immediately"
+    },
+    "run-task": "Run task | Run tasks",
+    "schedule-for-later": {
+      "description": "Set a specific date and time for tasks to automatically start running. Useful for maintenance windows or off-peak hours.",
+      "self": "Schedule for later"
+    },
+    "select-scheduled-time": "Select scheduled time",
+    "skip-prior-backup": "Skip prior backup",
+    "skip-prior-backup-description": "Skip the automatic data backup before applying changes",
+    "skip-task": "Skip task | Skip tasks",
+    "started": "Started",
     "status": {
-      "running": "Running"
+      "canceled": "Canceled",
+      "done": "Done",
+      "failed": "Failed",
+      "not-started": "Not started",
+      "pending": "Pending",
+      "running": "Running",
+      "skipped": "Skipped"
     }
   },
+  "task-run.history": "Execution History",
   "task-run.log-detail.backing-up": "Backing up...",
   "task-run.log-detail.backup-completed": "completed ({{count}} tables)",
   "task-run.log-detail.completed": "Completed",
@@ -2806,7 +2974,18 @@
   "task-run.log-viewer.multiple-replicas-notice": "Server restart detected during execution. Logs are grouped by replica.",
   "task-run.log-viewer.replica-n": "Replica #{n}",
   "task-run.log-viewer.summary": "{sections} sections · {entries} entries",
+  "task-run.status.enqueued": "Waiting for execution.",
+  "task-run.status.enqueued-with-rollout-time": "Waiting to execute after {{time}}.",
+  "task-run.status.waiting-max-tasks-per-rollout": "Waiting for other tasks to finish. Maximum running tasks limit per rollout has been reached. Last report at {{time}}.",
   "task.affected-rows": "Affected rows",
+  "task.check-type.affected-rows.description": "Estimated by statistical information.",
+  "task.check-type.affected-rows.self": "Affected rows",
+  "task.check-type.ghost-sync": "gh-ost sync",
+  "task.check-type.sql-review.description": "Analyze the SQL statement for potential issues and provide recommendations. Includes built-in rules and your custom rules.",
+  "task.check-type.sql-review.self": "SQL review",
+  "task.check-type.summary-report": "Summary report",
+  "task.online-migration.self": "Online migration",
+  "task.prior-backup": "Prior backup",
   "two-factor": {
     "description": "Two-factor authentication provides an extra layer of security for member accounts. When signing in, you will be required to enter the security code generated by your Authenticator App.",
     "disable": {

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -1,4 +1,12 @@
 {
+  "activity.sentence.canceled-issue": "closed the issue",
+  "activity.sentence.changed-description": "changed description",
+  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
+  "activity.sentence.changed-labels": "changed labels",
+  "activity.sentence.created-issue": "created issue",
+  "activity.sentence.modified-sql-of": "modified SQL of",
+  "activity.sentence.reopened-issue": "reopened issue",
+  "activity.sentence.resolved-issue": "approved the issue",
   "agent": {
     "active-only-chats": "Solo activos",
     "ai-not-configured": {
@@ -132,6 +140,7 @@
     "address": "Dirección",
     "admin": "Admin",
     "all": "Todos",
+    "approve": "Approve",
     "approved": "Aprobado",
     "archive": "Archivo",
     "archive-description": "Mark \"{{name}}\" as archived and read-only.",
@@ -182,6 +191,7 @@
     "dismiss": "Descartar",
     "download": "Descargar",
     "draft": "Borrador",
+    "duration": "Duration",
     "edit": "Editar",
     "email": "Correo electrónico",
     "email-ascii-only": "Las direcciones de correo solo admiten caracteres ASCII (letras, números y símbolos como . _ - +).",
@@ -226,6 +236,7 @@
     "minutes": "Minutos",
     "missing-required-permission": "Faltan permisos requeridos {{permissions}}",
     "missing-required-permission-for-resource": "Faltan permisos requeridos para el recurso {{resource}}",
+    "more": "More",
     "n-items-selected": "{{n}} elementos seleccionados",
     "n-more": "+{{n}} más",
     "name": "Nombre",
@@ -238,12 +249,14 @@
     "password": "Contraseña",
     "pending": "Pendiente",
     "permissions": "Permisos",
+    "plan": "Plan",
     "previous": "Previous",
     "project": "Proyecto",
     "projects": "Proyectos",
     "read-only": "Solo lectura",
     "reason": "Reason",
     "regenerate": "Regenerar",
+    "reject": "Reject",
     "rejected": "Rechazado",
     "release": "Versión",
     "reorder": "Reordenar",
@@ -263,6 +276,7 @@
     },
     "rollback": "Retroceder",
     "rows-per-page": "Filas por página",
+    "run": "Run",
     "save": "Guardar",
     "schema": "Esquema",
     "scope": "Alcance",
@@ -277,10 +291,11 @@
     "skipped": "Omitido",
     "snapshot": "Instantánea",
     "sql": "SQL",
+    "stage": "Etapa",
     "state": "Estado",
     "statement": "Declaración",
     "status": "Estado",
-    "submit": "Enviar",
+    "submit": "Submit",
     "system": "Sistema",
     "table": "Tabla",
     "title": "Título",
@@ -309,6 +324,7 @@
     "write-only": "solo escritura",
     "you": "tu"
   },
+  "common.activity": "Actividad",
   "common.add": "Agregar",
   "common.admin": "Admin",
   "common.all": "Todos",
@@ -318,41 +334,61 @@
   "common.cannot-undo-this-action": "No se puede deshacer esta acción",
   "common.catalog": "Catálogo",
   "common.close": "Cerrar",
+  "common.collapse": "Contraer",
+  "common.column": "Columna",
+  "common.comment": "Comment",
   "common.confirm": "Confirmar",
   "common.continue-anyway": "De todas maneras, continúe",
+  "common.copy": "Copiar",
   "common.create": "Crear",
   "common.creating": "Creando...",
   "common.custom": "Personalizado",
   "common.database": "Base de datos",
+  "common.database-group": "Grupo de bases de datos",
   "common.databases": "Bases de datos",
   "common.default": "predeterminado",
   "common.delete": "Eliminar",
   "common.delete-resource": "Delete {{type}}",
   "common.deleted": "Eliminado",
+  "common.detail": "Detail",
   "common.detailed-guide": "guía detallada",
   "common.edit": "Editar",
+  "common.edited": "edited",
   "common.environment": "Entorno",
   "common.import": "Importar",
+  "common.issue": "Issue",
   "common.key": "Clave",
   "common.labels": "Etiquetas",
   "common.learn-more": "Aprender más",
+  "common.line": "Línea",
   "common.load-more": "Cargar más",
   "common.loading": "Cargando",
   "common.members": "Miembros",
   "common.minutes": "Minutos",
+  "common.n-more": "{{n}} más",
   "common.no-data": "Sin datos",
+  "common.only-creator-allowed-export": "Only the creator is allowed to export",
+  "common.open": "Abrir",
   "common.optional": "Opcional",
   "common.or": "o",
   "common.overview": "Resumen",
   "common.password": "Contraseña",
   "common.project": "Proyecto",
   "common.read-only": "Solo lectura",
+  "common.remaining": "restantes",
   "common.remove": "Eliminar",
   "common.removed": "Eliminado",
   "common.restore": "Restaurar",
+  "common.retry": "Reintentar",
+  "common.role.self": "Rol",
   "common.rollout": "Implementar",
+  "common.save": "Guardar",
   "common.sensitive-placeholder": "Sensible - solo escritura",
   "common.show-more": "Mostrar más",
+  "common.skip": "Omitir",
+  "common.success": "Éxito",
+  "common.task": "Tarea",
+  "common.troubleshoot": "Solucionar problemas",
   "common.unknown": "Desconocido",
   "common.unlimited": "Ilimitado",
   "common.updated": "Actualizado",
@@ -400,7 +436,17 @@
       }
     },
     "issue-review": {
-      "generating-approval-flow": "Generando flujo de aprobación"
+      "and-n-other-users": "{{names}} y {{count}} otros usuarios",
+      "approved-by": "Aprobado por",
+      "disallow-approve-reason": {
+        "some-task-checks-are-still-running": "Some task checks are still running.",
+        "some-task-checks-didnt-pass": "Some task checks didn't pass."
+      },
+      "generating-approval-flow": "Generando flujo de aprobación",
+      "re-request-review": "Volver a solicitar revisión",
+      "re-request-review-success": "Revisión solicitada nuevamente con éxito",
+      "rejected-by": "Rechazado por",
+      "self-approval-not-allowed": "No se permite la autoaprobación para este proyecto. No puedes aprobarlo como creador."
     },
     "risk": {
       "description": "La evaluación de riesgos evalúa automáticamente los cambios en la base de datos y asigna niveles de riesgo según el tipo de operación que se realiza.",
@@ -437,6 +483,9 @@
     },
     "self": "Aprobación personalizada"
   },
+  "custom-approval.issue-review.approved-issue": "approved issue",
+  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
+  "custom-approval.issue-review.rejected-issue": "rejected issue",
   "data-source": {
     "additional-node-addresses": "Direcciones de nodos adicionales",
     "connection-string-schema": "Esquema de cadena de conexión",
@@ -642,6 +691,7 @@
   "export-data": {
     "password-optional": "Cifrar con contraseña (opcional)"
   },
+  "export-data.password-optional": "Contraseña (opcional)",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "Para bases de datos con el mismo esquema, un grupo de bases de datos permite migrarlas juntas en un solo cambio. Defina el grupo una vez y reutilícelo en las migraciones sin tener que seleccionar bases de datos individuales cada vez.",
@@ -970,6 +1020,7 @@
   "instance.scan-interval.self": "Intervalo de escaneo",
   "instance.section.basic-info": "Información básica",
   "instance.section.connection": "Conexión",
+  "instance.select-database-user": "Seleccionar usuario de base de datos",
   "instance.sentence.aws-rds.mysql.template": "A continuación se muestra un ejemplo para crear el usuario {{user}}@% y otorgarle los privilegios necesarios.",
   "instance.sentence.aws-rds.postgresql.template": "A continuación se muestra un ejemplo para crear el usuario '{{user}}' y otorgarle los privilegios necesarios.",
   "instance.sentence.console.snowflake": "La URL de la consola externa que administra esta instancia (por ejemplo, la consola de AWS RDS, la consola de la instancia de base de datos interna)",
@@ -1015,6 +1066,11 @@
   "instance.users": "Usuarios",
   "instance.your-snowflake-account-locator": "Su localizador de cuentas Snowflake",
   "issue": {
+    "access-grant": {
+      "details": "Access Grant Details",
+      "expired-at": "Expired at"
+    },
+    "action-anyway": "{{action}} de todos modos",
     "advanced-search": {
       "filter": "Filtrar",
       "scope": {
@@ -1059,6 +1115,9 @@
         }
       }
     },
+    "approval-flow": {
+      "self": "Flujo de aprobación"
+    },
     "batch-transition": {
       "close": "Cerrar",
       "closed": "cerrado",
@@ -1066,13 +1125,22 @@
       "reopen": "Reabrir",
       "reopened": "reabierto"
     },
+    "checks-manual-rollout-hint": "La aprobación ya se completó, pero el rollout no se creó automáticamente porque este plan todavía tiene verificaciones fallidas. Ve a Plan para continuar.",
     "data-export": {
+      "download-tooltip": "Disponible por 24 horas",
+      "file-expired": "Archivo expirado",
       "format": "Formato",
       "limits": "Límites",
       "options": "Opciones de exportación"
     },
     "labels": "Etiquetas de problema",
     "leave-a-comment": "Dejar un comentario...",
+    "review": {
+      "approve-description": "Enviar comentarios y aprobar este problema",
+      "comment-description": "Enviar comentarios generales sin aprobación",
+      "reject-description": "Envíe comentarios y solicite cambios",
+      "self": "Revisar"
+    },
     "risk-level": {
       "filter": "Filtrar por nivel de riesgo",
       "high": "Alto",
@@ -1083,6 +1151,8 @@
     "role-grant": {
       "all-databases": "todas las bases de datos",
       "all-databases-tip": "Todas las bases de datos actuales y futuras de este proyecto.",
+      "details": "Role Grant Details",
+      "expired-at": "Expired at",
       "manually-select": "selección manual",
       "use-cel": "Usar expresión CEL"
     },
@@ -1092,6 +1162,12 @@
       "descending": "Descendente",
       "sort": "Ordenar",
       "updated": "Fecha de actualización"
+    },
+    "status-transition": {
+      "modal": {
+        "close": "¿Cerrar el problema?",
+        "reopen": "¿Reabrir incidencia?"
+      }
     },
     "subtitle": "Los problemas abarcan cambios en la base de datos, exportaciones de datos y solicitudes de acceso. Revisar y aprobar antes de la ejecución.",
     "table": {
@@ -1111,7 +1187,26 @@
     "upload-sql": "Upload SQL",
     "waiting-approval": "A la espera de la aprobación"
   },
+  "issue.comment-editor.nothing-to-preview": "Nothing to preview",
+  "issue.comment-editor.preview": "Preview",
+  "issue.comment-editor.toolbar.bold": "Insert bold text",
+  "issue.comment-editor.toolbar.code": "Insert SQL code snippet",
+  "issue.comment-editor.toolbar.hashtag": "Insert hashtag",
+  "issue.comment-editor.toolbar.header": "Insert heading text",
+  "issue.comment-editor.toolbar.link": "Insert a link",
+  "issue.comment-editor.write": "Write",
+  "issue.data-export.format": "Formato",
+  "issue.data-export.limits": "Límites",
+  "issue.data-export.options": "Opciones",
+  "issue.issue-name": "Issue name",
+  "issue.no-description-provided": "No description provided",
+  "issue.options-disabled-due-to-oversize": "Las opciones están deshabilitadas porque el SQL es demasiado grande.",
+  "issue.overwrite-current-statement": "Sobrescribir la declaración SQL actual",
+  "issue.review.self": "Review",
+  "issue.statement-from-sheet-warning": "This statement is loaded from a large sheet. Preview may be truncated.",
   "issue.task-run.logs": "Registros",
+  "issue.transaction-mode.label": "Modo de transacción",
+  "issue.upload-sql-file-max-size-exceeded": "Se ha excedido el tamaño máximo del archivo ({size}).",
   "label": {
     "add-label": "Agregar etiqueta",
     "empty-label-value": "Valor",
@@ -1142,6 +1237,9 @@
     "checks": {
       "self": "Verificaciones"
     },
+    "editor": {
+      "save-changes-before-continuing": "Guarde o cancele sus cambios antes de continuar."
+    },
     "navigator": {
       "review": "Revisión"
     },
@@ -1152,6 +1250,30 @@
       "title": "Objetivos"
     }
   },
+  "plan.checks.failed-to-run": "Failed to run plan checks",
+  "plan.checks.no-check-results": "No check results",
+  "plan.checks.no-results-match-filters": "No results match your filters",
+  "plan.checks.started": "Plan checks started",
+  "plan.go-to-plan-page": "Ir a la página del plan",
+  "plan.isolation-level.read-committed": "Lectura confirmada",
+  "plan.isolation-level.read-uncommitted": "Lectura no confirmada",
+  "plan.isolation-level.repeatable-read": "Lectura repetible",
+  "plan.isolation-level.self": "Nivel de Aislamiento",
+  "plan.isolation-level.serializable": "Serializable",
+  "plan.navigator.checks": "Checks",
+  "plan.navigator.statement-empty": "La sentencia está vacía",
+  "plan.options.self": "Opciones",
+  "plan.overview.no-checks": "No checks",
+  "plan.ready-for-review": "Ready for Review",
+  "plan.run": "Run",
+  "plan.select-isolation-level": "Seleccionar nivel de aislamiento",
+  "plan.spec.change": "Change",
+  "plan.spec.type.database-change": "Cambio de base de datos",
+  "plan.targets.no-targets-found": "No se encontraron objetivos",
+  "plan.targets.non-env-warning.one": "{{count}} base de datos se excluirá del despliegue porque no tiene un entorno efectivo:",
+  "plan.targets.non-env-warning.other": "{{count}} bases de datos se excluirán del despliegue porque no tienen un entorno efectivo:",
+  "plan.targets.title": "Objetivos",
+  "plan.targets.view-all": "Ver todo ({{count}})",
   "policy": {
     "environment-tier": {
       "description": "El entorno aparecerá de manera diferente a otros entornos.",
@@ -1256,6 +1378,7 @@
           "self": "Aplicar revisión SQL"
         },
         "labels": {
+          "configure-labels": "Configurar etiquetas",
           "description": "Se pueden colocar etiquetas en los problemas para su gestión.",
           "force-issue-labels": {
             "description": "Exija al menos una etiqueta al crear problemas.",
@@ -1333,10 +1456,23 @@
     "request-export-data": "Solicitar exportación"
   },
   "release": {
+    "and-n-more-files": "and {{count}} more files",
+    "change-tip": "This change is linked to a release artifact.",
+    "file-type": {
+      "declarative": "Declarative",
+      "unspecified": "Unspecified",
+      "versioned": "Versioned"
+    },
     "files": "Archivos",
+    "not-found": "Release not found",
     "releases": "Lanzamientos",
     "total-files": "Total de {{}} archivos",
-    "usage-description": "Un lanzamiento es un artefacto de aplicación versionado cuyo despliegue a un entorno es activado por un flujo de trabajo GitOps."
+    "usage-description": "Un lanzamiento es un artefacto de aplicación versionado cuyo despliegue a un entorno es activado por un flujo de trabajo GitOps.",
+    "vcs-source": "VCS Source",
+    "vcs-type": {
+      "unspecified": "Unknown VCS"
+    },
+    "view-all-files": "View all files"
   },
   "remind": {
     "release": {
@@ -1390,7 +1526,8 @@
     "stage": {
       "self_one": "Etapa",
       "self_other": "Etapas"
-    }
+    },
+    "task-execution-errors": "Errores de ejecución de tareas"
   },
   "schema-editor": {
     "raw-sql": "Raw SQL"
@@ -1904,6 +2041,7 @@
   },
   "sql-editor": {
     "access-grants": "Access Grants",
+    "access-type-unmask": "See unmasked sensitive data",
     "activate-access": "Activate",
     "activate-confirm": "Are you sure you want to activate this access grant?",
     "expired": "Expired",
@@ -1912,6 +2050,7 @@
     "revoke-access": "Revoke",
     "revoke-confirm": "Are you sure you want to revoke this access grant?",
     "self": "Editor de SQL",
+    "unmask-warning": "The query result may include unmasked sensitive data.",
     "view-issue": "View Issue",
     "web-socket": {
       "errors": {
@@ -2781,11 +2920,40 @@
   "subscription.usage.instance-count.runoutof": "Te has quedado sin tu cuota de instancias {{total}}.",
   "subscription.usage.instance-count.title": "Límite de cantidad de instancias",
   "task": {
+    "cancel-task": "Cancelar tarea | Cancelar tareas",
     "checking": "Comprobando...",
+    "created": "Creado",
+    "data-export-creator-only": "Sólo el creador del problema puede ejecutar tareas de exportación de datos",
+    "error": {
+      "scheduled-time-must-be-in-the-future": "La hora programada debe ser en el futuro"
+    },
+    "execution-time": "Tiempo de ejecución",
+    "no-permission": "No hay permiso para realizar esta acción",
+    "run-immediately": {
+      "description": "Las tareas comenzarán a ejecutarse en cuanto haga clic en \"Ejecutar\". No requiere demora ni programación.",
+      "self": "Corre inmediatamente"
+    },
+    "run-task": "Ejecutar tarea | Ejecutar tareas",
+    "schedule-for-later": {
+      "description": "Establezca una fecha y hora específicas para que las tareas comiencen a ejecutarse automáticamente. Útil para periodos de mantenimiento o horas de baja demanda.",
+      "self": "Programar para más tarde"
+    },
+    "select-scheduled-time": "Seleccionar hora programada",
+    "skip-prior-backup": "Omitir respaldo previo",
+    "skip-prior-backup-description": "Omitir la copia de seguridad automática de datos antes de aplicar cambios",
+    "skip-task": "Saltar tarea | Saltar tareas",
+    "started": "Iniciado",
     "status": {
-      "running": "Ejecutándose"
+      "canceled": "Cancelado",
+      "done": "Hecho",
+      "failed": "Fallido",
+      "not-started": "No iniciado",
+      "pending": "Pendiente",
+      "running": "Ejecutándose",
+      "skipped": "Omitido"
     }
   },
+  "task-run.history": "Historial de ejecución",
   "task-run.log-detail.backing-up": "haciendo copia de seguridad...",
   "task-run.log-detail.backup-completed": "completadas ({{count}} tablas)",
   "task-run.log-detail.completed": "Completado",
@@ -2806,7 +2974,18 @@
   "task-run.log-viewer.multiple-replicas-notice": "Se detectó un reinicio del servidor durante la ejecución. Los registros están agrupados por réplica.",
   "task-run.log-viewer.replica-n": "Réplica #{n}",
   "task-run.log-viewer.summary": "{sections} secciones · {entries} entradas",
+  "task-run.status.enqueued": "Esperando a ser ejecutada.",
+  "task-run.status.enqueued-with-rollout-time": "Esperando para ejecutar después de {{time}}.",
+  "task-run.status.waiting-max-tasks-per-rollout": "Esperando a que terminen otras tareas. Se ha alcanzado el límite máximo de tareas en ejecución por despliegue. Último informe a las {{time}}.",
   "task.affected-rows": "Filas afectadas",
+  "task.check-type.affected-rows.description": "Estimated by statistical information.",
+  "task.check-type.affected-rows.self": "Affected rows",
+  "task.check-type.ghost-sync": "gh-ost sync",
+  "task.check-type.sql-review.description": "Analyze the SQL statement for potential issues and provide recommendations. Includes built-in rules and your custom rules.",
+  "task.check-type.sql-review.self": "SQL review",
+  "task.check-type.summary-report": "Summary report",
+  "task.online-migration.self": "Migración en línea",
+  "task.prior-backup": "Respaldo previo",
   "two-factor": {
     "description": "La autenticación de dos factores proporciona una capa adicional de seguridad para las cuentas de los miembros. Al iniciar sesión, se te pedirá que ingreses el código de seguridad generado por tu aplicación de autenticación.",
     "disable": {

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -1,4 +1,12 @@
 {
+  "activity.sentence.canceled-issue": "closed the issue",
+  "activity.sentence.changed-description": "changed description",
+  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
+  "activity.sentence.changed-labels": "changed labels",
+  "activity.sentence.created-issue": "created issue",
+  "activity.sentence.modified-sql-of": "modified SQL of",
+  "activity.sentence.reopened-issue": "reopened issue",
+  "activity.sentence.resolved-issue": "approved the issue",
   "agent": {
     "active-only-chats": "アクティブのみ",
     "ai-not-configured": {
@@ -132,6 +140,7 @@
     "address": "接続先",
     "admin": "管理者",
     "all": "全て",
+    "approve": "Approve",
     "approved": "承認済み",
     "archive": "アーカイブ",
     "archive-description": "Mark \"{{name}}\" as archived and read-only.",
@@ -182,6 +191,7 @@
     "dismiss": "閉じる",
     "download": "ダウンロード",
     "draft": "下書き",
+    "duration": "Duration",
     "edit": "編集",
     "email": "メールアドレス",
     "email-ascii-only": "メールアドレスは ASCII 文字のみ使用できます（英数字および . _ - + などの記号）。",
@@ -226,6 +236,7 @@
     "minutes": "分",
     "missing-required-permission": "必要な権限がありません {{permissions}}",
     "missing-required-permission-for-resource": "リソース {{resource}} に必要な権限がありません",
+    "more": "More",
     "n-items-selected": "{{n}} 件選択済み",
     "n-more": "+{{n}} もっと",
     "name": "名前",
@@ -238,12 +249,14 @@
     "password": "パスワード",
     "pending": "保留中",
     "permissions": "権限",
+    "plan": "Plan",
     "previous": "Previous",
     "project": "プロジェクト",
     "projects": "プロジェクト",
     "read-only": "読み取り専用",
     "reason": "Reason",
     "regenerate": "再生する",
+    "reject": "Reject",
     "rejected": "却下",
     "release": "リリース",
     "reorder": "並び替え",
@@ -263,6 +276,7 @@
     },
     "rollback": "ロールバック",
     "rows-per-page": "ページあたりの行数",
+    "run": "Run",
     "save": "保存",
     "schema": "スキーマ",
     "scope": "スコープ",
@@ -277,10 +291,11 @@
     "skipped": "スキップ",
     "snapshot": "スナップショット",
     "sql": "SQL",
+    "stage": "ステージ",
     "state": "ステート",
     "statement": "ステートメント",
     "status": "ステータス",
-    "submit": "送信",
+    "submit": "Submit",
     "system": "システム",
     "table": "テーブル",
     "title": "タイトル",
@@ -309,6 +324,7 @@
     "write-only": "書き込み専用",
     "you": "あなた"
   },
+  "common.activity": "アクティビティ",
   "common.add": "追加",
   "common.admin": "管理者",
   "common.all": "全て",
@@ -318,41 +334,61 @@
   "common.cannot-undo-this-action": "この操作は元に戻せません",
   "common.catalog": "カタログ",
   "common.close": "閉じる",
+  "common.collapse": "折りたたむ",
+  "common.column": "列",
+  "common.comment": "Comment",
   "common.confirm": "確認する",
   "common.continue-anyway": "まだ続けたい",
+  "common.copy": "コピー",
   "common.create": "作成する",
   "common.creating": "作成...",
   "common.custom": "カスタマイズ",
   "common.database": "データベース",
+  "common.database-group": "データベースグループ",
   "common.databases": "データベース",
   "common.default": "デフォルト",
   "common.delete": "消去",
   "common.delete-resource": "Delete {{type}}",
   "common.deleted": "削除されました",
+  "common.detail": "Detail",
   "common.detailed-guide": "詳細ガイド",
   "common.edit": "編集",
+  "common.edited": "edited",
   "common.environment": "環境",
   "common.import": "インポート",
+  "common.issue": "Issue",
   "common.key": "キー",
   "common.labels": "ラベル",
   "common.learn-more": "もっと詳しく知る",
+  "common.line": "行",
   "common.load-more": "さらに読み込む",
   "common.loading": "読み込み中",
   "common.members": "メンバー",
   "common.minutes": "分",
+  "common.n-more": "あと {{n}} 件",
   "common.no-data": "データなし",
+  "common.only-creator-allowed-export": "Only the creator is allowed to export",
+  "common.open": "開く",
   "common.optional": "オプション",
   "common.or": "または",
   "common.overview": "概要",
   "common.password": "パスワード",
   "common.project": "プロジェクト",
   "common.read-only": "読み取り専用",
+  "common.remaining": "残り",
   "common.remove": "削除",
   "common.removed": "削除されました",
   "common.restore": "復元する",
+  "common.retry": "再試行",
+  "common.role.self": "ロール",
   "common.rollout": "リリース",
+  "common.save": "保存",
   "common.sensitive-placeholder": "機密データ - 書き込みのみ",
   "common.show-more": "もっと見る",
+  "common.skip": "スキップ",
+  "common.success": "成功",
+  "common.task": "タスク",
+  "common.troubleshoot": "トラブルシューティング",
   "common.unknown": "不明",
   "common.unlimited": "無制限",
   "common.updated": "更新しました",
@@ -400,7 +436,17 @@
       }
     },
     "issue-review": {
-      "generating-approval-flow": "承認フローが生成されています"
+      "and-n-other-users": "{{names}} と他の {{count}} 人のユーザー",
+      "approved-by": "承認者",
+      "disallow-approve-reason": {
+        "some-task-checks-are-still-running": "Some task checks are still running.",
+        "some-task-checks-didnt-pass": "Some task checks didn't pass."
+      },
+      "generating-approval-flow": "承認フローが生成されています",
+      "re-request-review": "再度承認をリクエストする",
+      "re-request-review-success": "レビューの再リクエストが完了しました",
+      "rejected-by": "拒否された",
+      "self-approval-not-allowed": "このプロジェクトでは自己承認は許可されていません。作成者として承認することはできません。"
     },
     "risk": {
       "description": "リスク評価は、データベースの変更を自動的に評価し、実行される操作の種類に基づいてリスクレベルを割り当てます。",
@@ -437,6 +483,9 @@
     },
     "self": "カスタム承認"
   },
+  "custom-approval.issue-review.approved-issue": "approved issue",
+  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
+  "custom-approval.issue-review.rejected-issue": "rejected issue",
   "data-source": {
     "additional-node-addresses": "追加のノードアドレス",
     "connection-string-schema": "接続文字列モード",
@@ -642,6 +691,7 @@
   "export-data": {
     "password-optional": "パスワード暗号化の設定 (オプション)"
   },
+  "export-data.password-optional": "パスワード（任意）",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "同じスキーマを持つデータベースには、データベースグループを使用すると一度の変更でまとめてマイグレーションできます。グループを一度定義すれば、毎回個別にデータベースを選択することなく、マイグレーション全体で再利用できます。",
@@ -970,6 +1020,7 @@
   "instance.scan-interval.self": "スキャン間隔",
   "instance.section.basic-info": "基本情報",
   "instance.section.connection": "接続",
+  "instance.select-database-user": "データベースユーザーの選択",
   "instance.sentence.aws-rds.mysql.template": "以下は、ユーザー {{user}}@% を作成し、そのユーザーに必要な権限を付与する例です。",
   "instance.sentence.aws-rds.postgresql.template": "以下は、ユーザー '{{user}}' を作成し、そのユーザーに必要な権限を付与する例です。",
   "instance.sentence.console.snowflake": "この インスタンス を管理する外部コンソール URL (AWS RDS コンソール、データベース コンソールなど)",
@@ -1015,6 +1066,11 @@
   "instance.users": "ユーザー",
   "instance.your-snowflake-account-locator": "Snowflake アカウント ロケーター",
   "issue": {
+    "access-grant": {
+      "details": "Access Grant Details",
+      "expired-at": "Expired at"
+    },
+    "action-anyway": "まだ {{action}} が必要です",
     "advanced-search": {
       "filter": "フィルター",
       "scope": {
@@ -1059,6 +1115,9 @@
         }
       }
     },
+    "approval-flow": {
+      "self": "承認フロー"
+    },
     "batch-transition": {
       "close": "閉じる",
       "closed": "閉まっている",
@@ -1066,13 +1125,22 @@
       "reopen": "再開",
       "reopened": "再開"
     },
+    "checks-manual-rollout-hint": "承認は完了しましたが、このプランにはまだチェックエラーがあるため、ロールアウトは自動作成されていません。Plan に移動して続行してください。",
     "data-export": {
+      "download-tooltip": "24 時間利用可能",
+      "file-expired": "ファイルの有効期限が切れました",
       "format": "エクスポート形式",
       "limits": "制限",
       "options": "設定項目"
     },
     "labels": "イシューラベル",
     "leave-a-comment": "コメントを残す…",
+    "review": {
+      "approve-description": "フィードバックを送信してこのイシューを承認する",
+      "comment-description": "承認なしで一般的なフィードバックを送信する",
+      "reject-description": "フィードバックを送信して変更をリクエストする",
+      "self": "レビュー"
+    },
     "risk-level": {
       "filter": "リスクレベルでフィルタリング",
       "high": "高い",
@@ -1083,6 +1151,8 @@
     "role-grant": {
       "all-databases": "すべてのデータベース",
       "all-databases-tip": "このプロジェクトに属する現在および将来のすべてのデータベース。",
+      "details": "Role Grant Details",
+      "expired-at": "Expired at",
       "manually-select": "手動選択",
       "use-cel": "CEL式を使用"
     },
@@ -1092,6 +1162,12 @@
       "descending": "降順",
       "sort": "並べ替え",
       "updated": "更新日時"
+    },
+    "status-transition": {
+      "modal": {
+        "close": "イシューを閉じますか?",
+        "reopen": "イシューを再開しますか?"
+      }
     },
     "subtitle": "イシューには、データベースの変更、データのエクスポート、アクセス要求が含まれます。実行前に確認と承認が必要です。",
     "table": {
@@ -1111,7 +1187,26 @@
     "upload-sql": "Upload SQL",
     "waiting-approval": "承認待ち"
   },
+  "issue.comment-editor.nothing-to-preview": "Nothing to preview",
+  "issue.comment-editor.preview": "Preview",
+  "issue.comment-editor.toolbar.bold": "Insert bold text",
+  "issue.comment-editor.toolbar.code": "Insert SQL code snippet",
+  "issue.comment-editor.toolbar.hashtag": "Insert hashtag",
+  "issue.comment-editor.toolbar.header": "Insert heading text",
+  "issue.comment-editor.toolbar.link": "Insert a link",
+  "issue.comment-editor.write": "Write",
+  "issue.data-export.format": "形式",
+  "issue.data-export.limits": "制限",
+  "issue.data-export.options": "オプション",
+  "issue.issue-name": "Issue name",
+  "issue.no-description-provided": "No description provided",
+  "issue.options-disabled-due-to-oversize": "SQL が大きすぎるため、オプションは無効になっています。",
+  "issue.overwrite-current-statement": "現在の SQL ステートメントを上書きする",
+  "issue.review.self": "Review",
+  "issue.statement-from-sheet-warning": "This statement is loaded from a large sheet. Preview may be truncated.",
   "issue.task-run.logs": "ログ",
+  "issue.transaction-mode.label": "トランザクションモード",
+  "issue.upload-sql-file-max-size-exceeded": "アップロード ファイルのサイズは {size} を超えることはできません。",
   "label": {
     "add-label": "タグ付けする",
     "empty-label-value": "ヌル",
@@ -1142,6 +1237,9 @@
     "checks": {
       "self": "チェック"
     },
+    "editor": {
+      "save-changes-before-continuing": "続行する前に変更を保存またはキャンセルしてください"
+    },
     "navigator": {
       "review": "レビュー"
     },
@@ -1152,6 +1250,30 @@
       "title": "ターゲット"
     }
   },
+  "plan.checks.failed-to-run": "Failed to run plan checks",
+  "plan.checks.no-check-results": "No check results",
+  "plan.checks.no-results-match-filters": "No results match your filters",
+  "plan.checks.started": "Plan checks started",
+  "plan.go-to-plan-page": "プランページへ移動",
+  "plan.isolation-level.read-committed": "コミット済み読み取り",
+  "plan.isolation-level.read-uncommitted": "未コミット読み取り",
+  "plan.isolation-level.repeatable-read": "反復可能読み取り",
+  "plan.isolation-level.self": "分離レベル",
+  "plan.isolation-level.serializable": "直列化可能",
+  "plan.navigator.checks": "Checks",
+  "plan.navigator.statement-empty": "ステートメントが空です",
+  "plan.options.self": "オプション",
+  "plan.overview.no-checks": "No checks",
+  "plan.ready-for-review": "Ready for Review",
+  "plan.run": "Run",
+  "plan.select-isolation-level": "分離レベルを選択",
+  "plan.spec.change": "Change",
+  "plan.spec.type.database-change": "データベース変更",
+  "plan.targets.no-targets-found": "対象が見つかりません",
+  "plan.targets.non-env-warning.one": "有効な環境がないため、{{count}} 件のデータベースはロールアウトから除外されます:",
+  "plan.targets.non-env-warning.other": "有効な環境がないため、{{count}} 件のデータベースはロールアウトから除外されます:",
+  "plan.targets.title": "対象",
+  "plan.targets.view-all": "すべて表示 ({{count}})",
   "policy": {
     "environment-tier": {
       "description": "この環境を他の環境とは異なって見えるようにします。",
@@ -1256,6 +1378,7 @@
           "self": "SQL レビューを強制"
         },
         "labels": {
+          "configure-labels": "ラベルを設定する",
           "description": "イシューにラベルを貼って管理できる",
           "force-issue-labels": {
             "description": "イシューを作成するときは、少なくとも 1 つのラベルが必要です。",
@@ -1333,10 +1456,23 @@
     "request-export-data": "データ出力を申請する"
   },
   "release": {
+    "and-n-more-files": "and {{count}} more files",
+    "change-tip": "This change is linked to a release artifact.",
+    "file-type": {
+      "declarative": "Declarative",
+      "unspecified": "Unspecified",
+      "versioned": "Versioned"
+    },
     "files": "ファイル",
+    "not-found": "Release not found",
     "releases": "リリース",
     "total-files": "合計 {{}} ファイル",
-    "usage-description": "リリースは、GitOpsワークフローによって環境へのデプロイがトリガーされるバージョン管理されたアプリケーションアーティファクトです。"
+    "usage-description": "リリースは、GitOpsワークフローによって環境へのデプロイがトリガーされるバージョン管理されたアプリケーションアーティファクトです。",
+    "vcs-source": "VCS Source",
+    "vcs-type": {
+      "unspecified": "Unknown VCS"
+    },
+    "view-all-files": "View all files"
   },
   "remind": {
     "release": {
@@ -1390,7 +1526,8 @@
     "stage": {
       "self_one": "ステージ",
       "self_other": "ステージ"
-    }
+    },
+    "task-execution-errors": "タスク実行エラー"
   },
   "schema-editor": {
     "raw-sql": "Raw SQL"
@@ -1904,6 +2041,7 @@
   },
   "sql-editor": {
     "access-grants": "Access Grants",
+    "access-type-unmask": "See unmasked sensitive data",
     "activate-access": "Activate",
     "activate-confirm": "Are you sure you want to activate this access grant?",
     "expired": "Expired",
@@ -1912,6 +2050,7 @@
     "revoke-access": "Revoke",
     "revoke-confirm": "Are you sure you want to revoke this access grant?",
     "self": "SQLエディタ",
+    "unmask-warning": "The query result may include unmasked sensitive data.",
     "view-issue": "View Issue",
     "web-socket": {
       "errors": {
@@ -2781,11 +2920,40 @@
   "subscription.usage.instance-count.runoutof": "すべての {{total}} インスタンス クレジットが使用されました。",
   "subscription.usage.instance-count.title": "インスタンスの制限",
   "task": {
+    "cancel-task": "タスクをキャンセルする",
     "checking": "検査中…",
+    "created": "作成日時",
+    "data-export-creator-only": "イシュー作成者のみがデータエクスポートタスクを実行できます",
+    "error": {
+      "scheduled-time-must-be-in-the-future": "スケジュール時間は将来の時間である必要があります"
+    },
+    "execution-time": "実行時間",
+    "no-permission": "この操作を実行する権限がありません",
+    "run-immediately": {
+      "description": "「実行」をクリックするとすぐにタスクの実行が開始されます。遅延やスケジュール設定は必要ありません。",
+      "self": "すぐに実行"
+    },
+    "run-task": "タスクを実行 | タスクを実行",
+    "schedule-for-later": {
+      "description": "タスクを自動的に実行開始する日時を指定します。メンテナンス期間やオフピーク時に便利です。",
+      "self": "後でスケジュールする"
+    },
+    "select-scheduled-time": "予定時刻を選択してください",
+    "skip-prior-backup": "事前バックアップをスキップ",
+    "skip-prior-backup-description": "変更適用前の自動データバックアップをスキップする",
+    "skip-task": "タスクをスキップ | タスクをスキップ",
+    "started": "開始日時",
     "status": {
-      "running": "ランニング"
+      "canceled": "キャンセル",
+      "done": "終わり",
+      "failed": "失敗",
+      "not-started": "開始されていません",
+      "pending": "保留中",
+      "running": "ランニング",
+      "skipped": "スキップ"
     }
   },
+  "task-run.history": "実行履歴",
   "task-run.log-detail.backing-up": "バックアップ中...",
   "task-run.log-detail.backup-completed": "完了しました（{{count}} テーブル）",
   "task-run.log-detail.completed": "完了しました",
@@ -2806,7 +2974,18 @@
   "task-run.log-viewer.multiple-replicas-notice": "実行中にサーバーの再起動が検出されました。ログはレプリカごとにグループ化されています。",
   "task-run.log-viewer.replica-n": "レプリカ #{n}",
   "task-run.log-viewer.summary": "{sections} セクション · {entries} エントリ",
+  "task-run.status.enqueued": "実行を待っています。",
+  "task-run.status.enqueued-with-rollout-time": "{{time}} の後に実行される予定です。",
+  "task-run.status.waiting-max-tasks-per-rollout": "他のタスクが完了するのを待っています。ロールアウトごとの最大実行タスク数制限に達しました。最後の報告は {{time}} です。",
   "task.affected-rows": "影響を受けた行数",
+  "task.check-type.affected-rows.description": "Estimated by statistical information.",
+  "task.check-type.affected-rows.self": "Affected rows",
+  "task.check-type.ghost-sync": "gh-ost sync",
+  "task.check-type.sql-review.description": "Analyze the SQL statement for potential issues and provide recommendations. Includes built-in rules and your custom rules.",
+  "task.check-type.sql-review.self": "SQL review",
+  "task.check-type.summary-report": "Summary report",
+  "task.online-migration.self": "オンラインでの大規模なテーブル変更",
+  "task.prior-backup": "影響を受けるデータの事前バックアップ",
   "two-factor": {
     "description": "2 要素認証は、システム メンバーに追加のセキュリティ層を提供します。ログインするとき、ユーザーは認証アプリケーションによって生成されたセキュリティ コードを入力する必要があります。",
     "disable": {

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -1,4 +1,12 @@
 {
+  "activity.sentence.canceled-issue": "closed the issue",
+  "activity.sentence.changed-description": "changed description",
+  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
+  "activity.sentence.changed-labels": "changed labels",
+  "activity.sentence.created-issue": "created issue",
+  "activity.sentence.modified-sql-of": "modified SQL of",
+  "activity.sentence.reopened-issue": "reopened issue",
+  "activity.sentence.resolved-issue": "approved the issue",
   "agent": {
     "active-only-chats": "Chỉ hoạt động",
     "ai-not-configured": {
@@ -132,6 +140,7 @@
     "address": "Địa chỉ",
     "admin": "Quản trị viên",
     "all": "Tất cả",
+    "approve": "Approve",
     "approved": "Đã phê duyệt",
     "archive": "Lưu trữ",
     "archive-description": "Mark \"{{name}}\" as archived and read-only.",
@@ -182,6 +191,7 @@
     "dismiss": "Loại bỏ",
     "download": "Tải xuống",
     "draft": "Bản nháp",
+    "duration": "Duration",
     "edit": "Chỉnh sửa",
     "email": "Email",
     "email-ascii-only": "Địa chỉ email chỉ hỗ trợ ký tự ASCII (chữ cái, số và ký hiệu như . _ - +).",
@@ -226,6 +236,7 @@
     "minutes": "Phút",
     "missing-required-permission": "Thiếu quyền cần thiết {{permissions}}",
     "missing-required-permission-for-resource": "Thiếu quyền cần thiết cho tài nguyên {{resource}}",
+    "more": "More",
     "n-items-selected": "Đã chọn {{n}} mục",
     "n-more": "+{{n}} nữa",
     "name": "Tên",
@@ -238,12 +249,14 @@
     "password": "Mật khẩu",
     "pending": "Đang chờ",
     "permissions": "Quyền",
+    "plan": "Plan",
     "previous": "Previous",
     "project": "Dự án",
     "projects": "Dự án",
     "read-only": "Chỉ đọc",
     "reason": "Reason",
     "regenerate": "Tạo lại",
+    "reject": "Reject",
     "rejected": "Đã từ chối",
     "release": "Phiên bản",
     "reorder": "Sắp xếp lại",
@@ -263,6 +276,7 @@
     },
     "rollback": "Hoàn tác",
     "rows-per-page": "Số dòng mỗi trang",
+    "run": "Run",
     "save": "Lưu",
     "schema": "Schema",
     "scope": "Phạm vi",
@@ -277,10 +291,11 @@
     "skipped": "Đã bỏ qua",
     "snapshot": "Ảnh chụp nhanh",
     "sql": "SQL",
+    "stage": "Giai đoạn",
     "state": "Trạng thái",
     "statement": "Câu lệnh",
     "status": "Trạng thái",
-    "submit": "Gửi",
+    "submit": "Submit",
     "system": "Hệ thống",
     "table": "Bảng",
     "title": "Tiêu đề",
@@ -309,6 +324,7 @@
     "write-only": "chỉ ghi",
     "you": "bạn"
   },
+  "common.activity": "Hoạt động",
   "common.add": "Thêm",
   "common.admin": "Quản trị viên",
   "common.all": "Tất cả",
@@ -318,41 +334,61 @@
   "common.cannot-undo-this-action": "Bạn không thể hoàn tác hành động này.",
   "common.catalog": "Danh mục",
   "common.close": "Đóng",
+  "common.collapse": "Thu gọn",
+  "common.column": "Cột",
+  "common.comment": "Comment",
   "common.confirm": "Xác nhận",
   "common.continue-anyway": "Tiếp tục",
+  "common.copy": "Sao chép",
   "common.create": "Tạo",
   "common.creating": "Đang tạo...",
   "common.custom": "Tùy chỉnh",
   "common.database": "Cơ sở dữ liệu",
+  "common.database-group": "Nhóm cơ sở dữ liệu",
   "common.databases": "Cơ sở dữ liệu",
   "common.default": "Mặc định",
   "common.delete": "Xóa",
   "common.delete-resource": "Delete {{type}}",
   "common.deleted": "Đã xóa",
+  "common.detail": "Detail",
   "common.detailed-guide": "Hướng dẫn chi tiết",
   "common.edit": "Chỉnh sửa",
+  "common.edited": "edited",
   "common.environment": "Môi trường",
   "common.import": "Nhập",
+  "common.issue": "Issue",
   "common.key": "Khóa",
   "common.labels": "Nhãn",
   "common.learn-more": "Tìm hiểu thêm",
+  "common.line": "Dòng",
   "common.load-more": "Tải thêm",
   "common.loading": "Đang tải",
   "common.members": "Thành viên",
   "common.minutes": "Phút",
+  "common.n-more": "còn {{n}}",
   "common.no-data": "Không có dữ liệu",
+  "common.only-creator-allowed-export": "Only the creator is allowed to export",
+  "common.open": "Mở",
   "common.optional": "Tùy chọn",
   "common.or": "hoặc",
   "common.overview": "Tổng quan",
   "common.password": "Mật khẩu",
   "common.project": "Dự án",
   "common.read-only": "Chỉ đọc",
+  "common.remaining": "còn lại",
   "common.remove": "Xóa",
   "common.removed": "LOẠI BỎ",
   "common.restore": "Khôi phục",
+  "common.retry": "Thử lại",
+  "common.role.self": "Vai trò",
   "common.rollout": "Triển khai",
+  "common.save": "Lưu",
   "common.sensitive-placeholder": "Nhạy cảm - Chỉ ghi",
   "common.show-more": "Hiển thị thêm",
+  "common.skip": "Bỏ qua",
+  "common.success": "Thành công",
+  "common.task": "Tác vụ",
+  "common.troubleshoot": "Khắc phục sự cố",
   "common.unknown": "Không xác định",
   "common.unlimited": "Không giới hạn",
   "common.updated": "Đã cập nhật",
@@ -400,7 +436,17 @@
       }
     },
     "issue-review": {
-      "generating-approval-flow": "Đang tạo quy trình phê duyệt"
+      "and-n-other-users": "{{names}} và {{count}} người dùng khác",
+      "approved-by": "Được chấp thuận bởi",
+      "disallow-approve-reason": {
+        "some-task-checks-are-still-running": "Some task checks are still running.",
+        "some-task-checks-didnt-pass": "Some task checks didn't pass."
+      },
+      "generating-approval-flow": "Đang tạo quy trình phê duyệt",
+      "re-request-review": "Yêu cầu xem xét lại",
+      "re-request-review-success": "Yêu cầu xem xét lại đã được thực hiện thành công.",
+      "rejected-by": "Bị từ chối bởi",
+      "self-approval-not-allowed": "Không được phép tự phê duyệt cho dự án này. Bạn không thể phê duyệt với tư cách là người sáng tạo."
     },
     "risk": {
       "description": "Đánh giá rủi ro tự động đánh giá các thay đổi cơ sở dữ liệu và phân loại mức độ rủi ro dựa trên loại thao tác được thực hiện.",
@@ -437,6 +483,9 @@
     },
     "self": "Phê duyệt tùy chỉnh"
   },
+  "custom-approval.issue-review.approved-issue": "approved issue",
+  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
+  "custom-approval.issue-review.rejected-issue": "rejected issue",
   "data-source": {
     "additional-node-addresses": "Địa chỉ nút bổ sung",
     "connection-string-schema": "Lược đồ chuỗi kết nối",
@@ -642,6 +691,7 @@
   "export-data": {
     "password-optional": "Mã hóa bằng mật khẩu (Tùy chọn)"
   },
+  "export-data.password-optional": "Mật khẩu (không bắt buộc)",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "Đối với các cơ sở dữ liệu có cùng schema, nhóm cơ sở dữ liệu cho phép bạn migration tất cả cùng lúc trong một thay đổi. Chỉ cần định nghĩa nhóm một lần và tái sử dụng trong các lần migration mà không cần chọn từng cơ sở dữ liệu mỗi lần.",
@@ -970,6 +1020,7 @@
   "instance.scan-interval.self": "Khoảng thời gian quét",
   "instance.section.basic-info": "Thông tin cơ bản",
   "instance.section.connection": "Kết nối",
+  "instance.select-database-user": "Chọn người dùng cơ sở dữ liệu",
   "instance.sentence.aws-rds.mysql.template": "Dưới đây là ví dụ để tạo người dùng {{user}}@% và cấp cho người dùng các đặc quyền cần thiết.",
   "instance.sentence.aws-rds.postgresql.template": "Dưới đây là ví dụ để tạo người dùng '{{user}}' và cấp cho người dùng các đặc quyền cần thiết.",
   "instance.sentence.console.snowflake": "URL bảng điều khiển bên ngoài quản lý phiên bản này (ví dụ: bảng điều khiển AWS RDS, bảng điều khiển phiên bản cơ sở dữ liệu nội bộ của bạn)",
@@ -1015,6 +1066,11 @@
   "instance.users": "Người dùng",
   "instance.your-snowflake-account-locator": "Định vị tài khoản Snowflake của bạn",
   "issue": {
+    "access-grant": {
+      "details": "Access Grant Details",
+      "expired-at": "Expired at"
+    },
+    "action-anyway": "{{action}} bằng mọi cách",
     "advanced-search": {
       "filter": "Bộ lọc",
       "scope": {
@@ -1059,6 +1115,9 @@
         }
       }
     },
+    "approval-flow": {
+      "self": "Quy trình phê duyệt"
+    },
     "batch-transition": {
       "close": "Đóng",
       "closed": "đã đóng",
@@ -1066,13 +1125,22 @@
       "reopen": "Mở lại",
       "reopened": "đã mở lại"
     },
+    "checks-manual-rollout-hint": "Phê duyệt đã hoàn tất, nhưng rollout không được tạo tự động vì kế hoạch này vẫn còn kiểm tra lỗi. Hãy vào Plan để tiếp tục.",
     "data-export": {
+      "download-tooltip": "Có sẵn trong 24 giờ",
+      "file-expired": "Tệp đã hết hạn",
       "format": "Định dạng",
       "limits": "Giới hạn",
       "options": "Tùy chọn"
     },
     "labels": "Nhãn vấn đề",
     "leave-a-comment": "Để lại bình luận...",
+    "review": {
+      "approve-description": "Gửi phản hồi và phê duyệt vấn đề này.",
+      "comment-description": "Gửi phản hồi chung mà không cần phê duyệt",
+      "reject-description": "Gửi phản hồi và yêu cầu thay đổi",
+      "self": "Xem xét"
+    },
     "risk-level": {
       "filter": "Lọc theo mức độ rủi ro",
       "high": "Cao",
@@ -1081,8 +1149,10 @@
       "self": "Mức độ rủi ro"
     },
     "role-grant": {
-      "all-databases": "Tất cả",
+      "all-databases": "Tất cả cơ sở dữ liệu",
       "all-databases-tip": "Tất cả cơ sở dữ liệu hiện tại và tương lai trong dự án này.",
+      "details": "Role Grant Details",
+      "expired-at": "Expired at",
       "manually-select": "Chọn thủ công",
       "use-cel": "Sử dụng biểu thức CEL"
     },
@@ -1092,6 +1162,12 @@
       "descending": "Giảm dần",
       "sort": "Sắp xếp",
       "updated": "Thời gian cập nhật"
+    },
+    "status-transition": {
+      "modal": {
+        "close": "Đóng vấn đề?",
+        "reopen": "Mở lại vấn đề?"
+      }
     },
     "subtitle": "Các vấn đề bao gồm thay đổi cơ sở dữ liệu, xuất dữ liệu và yêu cầu truy cập. Cần xem xét và phê duyệt trước khi thực hiện.",
     "table": {
@@ -1111,7 +1187,26 @@
     "upload-sql": "Upload SQL",
     "waiting-approval": "Đang chờ phê duyệt"
   },
+  "issue.comment-editor.nothing-to-preview": "Nothing to preview",
+  "issue.comment-editor.preview": "Preview",
+  "issue.comment-editor.toolbar.bold": "Insert bold text",
+  "issue.comment-editor.toolbar.code": "Insert SQL code snippet",
+  "issue.comment-editor.toolbar.hashtag": "Insert hashtag",
+  "issue.comment-editor.toolbar.header": "Insert heading text",
+  "issue.comment-editor.toolbar.link": "Insert a link",
+  "issue.comment-editor.write": "Write",
+  "issue.data-export.format": "Định dạng",
+  "issue.data-export.limits": "Giới hạn",
+  "issue.data-export.options": "Tùy chọn",
+  "issue.issue-name": "Issue name",
+  "issue.no-description-provided": "No description provided",
+  "issue.options-disabled-due-to-oversize": "Các tùy chọn bị vô hiệu hóa vì SQL quá lớn.",
+  "issue.overwrite-current-statement": "Ghi đè câu lệnh SQL hiện tại",
+  "issue.review.self": "Review",
+  "issue.statement-from-sheet-warning": "This statement is loaded from a large sheet. Preview may be truncated.",
   "issue.task-run.logs": "Nhật ký",
+  "issue.transaction-mode.label": "Chế độ giao dịch",
+  "issue.upload-sql-file-max-size-exceeded": "Vượt quá kích thước tệp tối đa ({size}).",
   "label": {
     "add-label": "Thêm nhãn",
     "empty-label-value": "Trống",
@@ -1142,6 +1237,9 @@
     "checks": {
       "self": "Kiểm tra"
     },
+    "editor": {
+      "save-changes-before-continuing": "Vui lòng lưu hoặc hủy thay đổi của bạn trước khi tiếp tục"
+    },
     "navigator": {
       "review": "Xem xét"
     },
@@ -1152,6 +1250,30 @@
       "title": "Mục tiêu"
     }
   },
+  "plan.checks.failed-to-run": "Failed to run plan checks",
+  "plan.checks.no-check-results": "No check results",
+  "plan.checks.no-results-match-filters": "No results match your filters",
+  "plan.checks.started": "Plan checks started",
+  "plan.go-to-plan-page": "Đi tới trang kế hoạch",
+  "plan.isolation-level.read-committed": "Đọc đã cam kết",
+  "plan.isolation-level.read-uncommitted": "Đọc chưa cam kết",
+  "plan.isolation-level.repeatable-read": "Đọc lặp lại",
+  "plan.isolation-level.self": "Mức Độ Cô Lập",
+  "plan.isolation-level.serializable": "Tuần tự hóa",
+  "plan.navigator.checks": "Checks",
+  "plan.navigator.statement-empty": "Câu lệnh đang trống",
+  "plan.options.self": "Tùy chọn",
+  "plan.overview.no-checks": "No checks",
+  "plan.ready-for-review": "Ready for Review",
+  "plan.run": "Run",
+  "plan.select-isolation-level": "Chọn mức độ cô lập",
+  "plan.spec.change": "Change",
+  "plan.spec.type.database-change": "Thay đổi cơ sở dữ liệu",
+  "plan.targets.no-targets-found": "Không tìm thấy mục tiêu",
+  "plan.targets.non-env-warning.one": "{{count}} cơ sở dữ liệu sẽ bị loại khỏi rollout vì không có môi trường hiệu lực:",
+  "plan.targets.non-env-warning.other": "{{count}} cơ sở dữ liệu sẽ bị loại khỏi rollout vì không có môi trường hiệu lực:",
+  "plan.targets.title": "Mục tiêu",
+  "plan.targets.view-all": "Xem tất cả ({{count}})",
   "policy": {
     "environment-tier": {
       "description": "Môi trường sẽ xuất hiện khác với các môi trường khác.",
@@ -1256,6 +1378,7 @@
           "self": "Bắt buộc đánh giá SQL"
         },
         "labels": {
+          "configure-labels": "Cấu hình nhãn",
           "description": "Có thể gắn nhãn vào các vấn đề để quản lý",
           "force-issue-labels": {
             "description": "Yêu cầu ít nhất một nhãn khi tạo vấn đề.",
@@ -1333,10 +1456,23 @@
     "request-export-data": "Yêu cầu Xuất"
   },
   "release": {
+    "and-n-more-files": "and {{count}} more files",
+    "change-tip": "This change is linked to a release artifact.",
+    "file-type": {
+      "declarative": "Declarative",
+      "unspecified": "Unspecified",
+      "versioned": "Versioned"
+    },
     "files": "Tệp",
+    "not-found": "Release not found",
     "releases": "Bản phát hành",
     "total-files": "Tổng số {{}} tệp",
-    "usage-description": "Bản phát hành là một artifact ứng dụng có phiên bản mà việc triển khai vào môi trường được kích hoạt bởi quy trình GitOps."
+    "usage-description": "Bản phát hành là một artifact ứng dụng có phiên bản mà việc triển khai vào môi trường được kích hoạt bởi quy trình GitOps.",
+    "vcs-source": "VCS Source",
+    "vcs-type": {
+      "unspecified": "Unknown VCS"
+    },
+    "view-all-files": "View all files"
   },
   "remind": {
     "release": {
@@ -1390,7 +1526,8 @@
     "stage": {
       "self_one": "Giai đoạn",
       "self_other": "Các giai đoạn"
-    }
+    },
+    "task-execution-errors": "Lỗi thực hiện tác vụ"
   },
   "schema-editor": {
     "raw-sql": "Raw SQL"
@@ -1904,6 +2041,7 @@
   },
   "sql-editor": {
     "access-grants": "Access Grants",
+    "access-type-unmask": "See unmasked sensitive data",
     "activate-access": "Activate",
     "activate-confirm": "Are you sure you want to activate this access grant?",
     "expired": "Expired",
@@ -1912,6 +2050,7 @@
     "revoke-access": "Revoke",
     "revoke-confirm": "Are you sure you want to revoke this access grant?",
     "self": "Trình soạn thảo SQL",
+    "unmask-warning": "The query result may include unmasked sensitive data.",
     "view-issue": "View Issue",
     "web-socket": {
       "errors": {
@@ -2781,11 +2920,40 @@
   "subscription.usage.instance-count.runoutof": "Bạn đã hết hạn ngạch {{total}} phiên bản của mình.",
   "subscription.usage.instance-count.title": "Giới hạn số lượng phiên bản",
   "task": {
+    "cancel-task": "Hủy tác vụ | Hủy các tác vụ",
     "checking": "Đang kiểm tra...",
+    "created": "Đã tạo",
+    "data-export-creator-only": "Chỉ người tạo sự cố mới có thể thực hiện tác vụ xuất dữ liệu",
+    "error": {
+      "scheduled-time-must-be-in-the-future": "Thời gian dự kiến phải ở trong tương lai"
+    },
+    "execution-time": "Thời gian thực thi",
+    "no-permission": "Không có quyền thực hiện hành động này",
+    "run-immediately": {
+      "description": "Các tác vụ sẽ bắt đầu thực thi ngay khi bạn nhấp vào Chạy. Không cần trì hoãn hay lên lịch.",
+      "self": "Chạy ngay lập tức"
+    },
+    "run-task": "Chạy tác vụ | Chạy tác vụ",
+    "schedule-for-later": {
+      "description": "Đặt ngày và giờ cụ thể để các tác vụ tự động bắt đầu chạy. Hữu ích cho các khung giờ bảo trì hoặc ngoài giờ cao điểm.",
+      "self": "Lên lịch cho sau"
+    },
+    "select-scheduled-time": "Chọn thời gian đã lên lịch",
+    "skip-prior-backup": "Bỏ qua sao lưu trước",
+    "skip-prior-backup-description": "Bỏ qua sao lưu dữ liệu tự động trước khi áp dụng thay đổi",
+    "skip-task": "Bỏ qua nhiệm vụ | Bỏ qua nhiệm vụ",
+    "started": "Bắt đầu",
     "status": {
-      "running": "Đang chạy"
+      "canceled": "Đã hủy",
+      "done": "Hoàn tất",
+      "failed": "Thất bại",
+      "not-started": "Chưa bắt đầu",
+      "pending": "Đang chờ",
+      "running": "Đang chạy",
+      "skipped": "Đã bỏ qua"
     }
   },
+  "task-run.history": "Lịch sử thực thi",
   "task-run.log-detail.backing-up": "đang sao lưu...",
   "task-run.log-detail.backup-completed": "đã hoàn thành ({{count}} bảng)",
   "task-run.log-detail.completed": "Đã hoàn thành",
@@ -2806,7 +2974,18 @@
   "task-run.log-viewer.multiple-replicas-notice": "Phát hiện khởi động lại máy chủ trong quá trình thực thi. Nhật ký được nhóm theo bản sao.",
   "task-run.log-viewer.replica-n": "Bản sao #{n}",
   "task-run.log-viewer.summary": "{sections} phần · {entries} mục",
+  "task-run.status.enqueued": "Đang chờ thực thi.",
+  "task-run.status.enqueued-with-rollout-time": "Đang chờ thực thi sau {{time}}.",
+  "task-run.status.waiting-max-tasks-per-rollout": "Đang chờ các tác vụ khác hoàn thành. Đã đạt đến giới hạn số lượng tác vụ đang chạy tối đa cho mỗi lần triển khai. Báo cáo gần nhất lúc {{time}}.",
   "task.affected-rows": "Hàng bị ảnh hưởng",
+  "task.check-type.affected-rows.description": "Estimated by statistical information.",
+  "task.check-type.affected-rows.self": "Affected rows",
+  "task.check-type.ghost-sync": "gh-ost sync",
+  "task.check-type.sql-review.description": "Analyze the SQL statement for potential issues and provide recommendations. Includes built-in rules and your custom rules.",
+  "task.check-type.sql-review.self": "SQL review",
+  "task.check-type.summary-report": "Summary report",
+  "task.online-migration.self": "Di chuyển trực tuyến",
+  "task.prior-backup": "Sao lưu trước",
   "two-factor": {
     "description": "Xác thực hai yếu tố cung cấp một lớp bảo mật bổ sung cho các tài khoản thành viên. Khi đăng nhập, bạn sẽ được yêu cầu nhập mã bảo mật do Ứng dụng xác thực của bạn tạo.",
     "disable": {

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -1,4 +1,12 @@
 {
+  "activity.sentence.canceled-issue": "closed the issue",
+  "activity.sentence.changed-description": "changed description",
+  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
+  "activity.sentence.changed-labels": "changed labels",
+  "activity.sentence.created-issue": "created issue",
+  "activity.sentence.modified-sql-of": "modified SQL of",
+  "activity.sentence.reopened-issue": "reopened issue",
+  "activity.sentence.resolved-issue": "approved the issue",
   "agent": {
     "active-only-chats": "仅活跃",
     "ai-not-configured": {
@@ -132,6 +140,7 @@
     "address": "地址",
     "admin": "管理员",
     "all": "全部",
+    "approve": "Approve",
     "approved": "已批准",
     "archive": "归档",
     "archive-description": "将「{{name}}」标记为已归档且只读。",
@@ -182,6 +191,7 @@
     "dismiss": "关闭",
     "download": "下载",
     "draft": "草稿",
+    "duration": "Duration",
     "edit": "编辑",
     "email": "邮箱",
     "email-ascii-only": "邮箱地址仅支持 ASCII 字符（英文字母、数字及 . _ - + 等符号）。",
@@ -226,6 +236,7 @@
     "minutes": "分钟",
     "missing-required-permission": "缺少必需的权限 {{permissions}}",
     "missing-required-permission-for-resource": "缺少资源 {{resource}} 的必需权限",
+    "more": "More",
     "n-items-selected": "已选 {{n}} 项",
     "n-more": "+{{n}} 更多",
     "name": "名称",
@@ -238,12 +249,14 @@
     "password": "密码",
     "pending": "待审批",
     "permissions": "权限",
+    "plan": "Plan",
     "previous": "上一步",
     "project": "项目",
     "projects": "项目",
     "read-only": "只读",
     "reason": "Reason",
     "regenerate": "重新生成",
+    "reject": "Reject",
     "rejected": "已拒绝",
     "release": "版本",
     "reorder": "排序",
@@ -263,6 +276,7 @@
     },
     "rollback": "回滚",
     "rows-per-page": "每页行数",
+    "run": "Run",
     "save": "保存",
     "schema": "模式",
     "scope": "范围",
@@ -277,10 +291,11 @@
     "skipped": "已跳过",
     "snapshot": "快照",
     "sql": "SQL",
+    "stage": "阶段",
     "state": "状态",
     "statement": "语句",
     "status": "状态",
-    "submit": "提交",
+    "submit": "Submit",
     "system": "系统",
     "table": "表",
     "title": "标题",
@@ -309,6 +324,7 @@
     "write-only": "仅写入",
     "you": "您"
   },
+  "common.activity": "活动",
   "common.add": "添加",
   "common.admin": "管理员",
   "common.all": "全部",
@@ -318,41 +334,61 @@
   "common.cannot-undo-this-action": "这个操作无法撤销",
   "common.catalog": "Catalog",
   "common.close": "关闭",
+  "common.collapse": "收起",
+  "common.column": "列",
+  "common.comment": "Comment",
   "common.confirm": "确认",
   "common.continue-anyway": "仍要继续",
+  "common.copy": "拷贝",
   "common.create": "创建",
   "common.creating": "创建中...",
   "common.custom": "自定义",
   "common.database": "数据库",
+  "common.database-group": "数据库组",
   "common.databases": "数据库",
   "common.default": "默认",
   "common.delete": "删除",
   "common.delete-resource": "删除{{type}}",
   "common.deleted": "已删除",
+  "common.detail": "Detail",
   "common.detailed-guide": "详细指南",
   "common.edit": "编辑",
+  "common.edited": "edited",
   "common.environment": "环境",
   "common.import": "导入",
+  "common.issue": "Issue",
   "common.key": "键",
   "common.labels": "标签",
   "common.learn-more": "了解更多",
+  "common.line": "行",
   "common.load-more": "加载更多",
   "common.loading": "加载中",
   "common.members": "成员",
   "common.minutes": "分钟",
+  "common.n-more": "还有 {{n}} 个",
   "common.no-data": "无数据",
+  "common.only-creator-allowed-export": "只有创建者可以导出",
+  "common.open": "打开",
   "common.optional": "可选",
   "common.or": "或者",
   "common.overview": "概览",
   "common.password": "密码",
   "common.project": "项目",
   "common.read-only": "只读",
+  "common.remaining": "剩余",
   "common.remove": "删除",
   "common.removed": "已移除",
   "common.restore": "恢复",
+  "common.retry": "重试",
+  "common.role.self": "角色",
   "common.rollout": "发布",
+  "common.save": "保存",
   "common.sensitive-placeholder": "敏感数据 - 仅写入",
   "common.show-more": "显示更多",
+  "common.skip": "跳过",
+  "common.success": "成功",
+  "common.task": "任务",
+  "common.troubleshoot": "排查问题",
   "common.unknown": "未知",
   "common.unlimited": "无限制",
   "common.updated": "已更新",
@@ -400,7 +436,17 @@
       }
     },
     "issue-review": {
-      "generating-approval-flow": "正在生成审批流"
+      "and-n-other-users": "{{names}} 和另外 {{count}} 位用户",
+      "approved-by": "已批准",
+      "disallow-approve-reason": {
+        "some-task-checks-are-still-running": "部分任务检查仍在运行中。",
+        "some-task-checks-didnt-pass": "部分任务检查未通过。"
+      },
+      "generating-approval-flow": "正在生成审批流",
+      "re-request-review": "请求再次审批",
+      "re-request-review-success": "已成功请求再次审批",
+      "rejected-by": "被拒绝",
+      "self-approval-not-allowed": "此项目不允许工单创建者审批。您无法以创建者身份批准。"
     },
     "risk": {
       "description": "风险评估会自动评估数据库变更，并根据操作类型分配风险等级。",
@@ -437,6 +483,9 @@
     },
     "self": "自定义审批"
   },
+  "custom-approval.issue-review.approved-issue": "approved issue",
+  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
+  "custom-approval.issue-review.rejected-issue": "rejected issue",
   "data-source": {
     "additional-node-addresses": "附加节点地址",
     "connection-string-schema": "连接串模式",
@@ -642,6 +691,7 @@
   "export-data": {
     "password-optional": "设置密码加密（可选）"
   },
+  "export-data.password-optional": "密码（可选）",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "对于具有相同 Schema 的数据库，数据库分组可以让您在一次变更中同时迁移它们。只需定义一次分组，即可在多次迁移中复用，无需每次都逐个选择数据库。",
@@ -970,6 +1020,7 @@
   "instance.scan-interval.self": "扫描间隔",
   "instance.section.basic-info": "基本信息",
   "instance.section.connection": "连接",
+  "instance.select-database-user": "选择数据库用户",
   "instance.sentence.aws-rds.mysql.template": "下面是创建用户 {{user}}@% 并授予该用户所需权限的示例。",
   "instance.sentence.aws-rds.postgresql.template": "下面是创建用户“{{user}}”并授予该用户所需权限的示例。",
   "instance.sentence.console.snowflake": "\b管理该实例的外部控制台 URL（如 AWS RDS 控制台，您的数据库控制台）",
@@ -1015,6 +1066,11 @@
   "instance.users": "用户",
   "instance.your-snowflake-account-locator": "您的 Snowflake 账户定位符",
   "issue": {
+    "access-grant": {
+      "details": "Access Grant Details",
+      "expired-at": "Expired at"
+    },
+    "action-anyway": "仍要{{action}}",
     "advanced-search": {
       "filter": "过滤",
       "scope": {
@@ -1059,6 +1115,9 @@
         }
       }
     },
+    "approval-flow": {
+      "self": "审批流"
+    },
     "batch-transition": {
       "close": "关闭",
       "closed": "关闭",
@@ -1066,13 +1125,22 @@
       "reopen": "重开",
       "reopened": "重开"
     },
+    "checks-manual-rollout-hint": "审批已完成，但由于该计划仍有未通过的检查，系统未自动创建发布。请前往变更计划页继续。",
     "data-export": {
+      "download-tooltip": "24 小时可用",
+      "file-expired": "文件已过期",
       "format": "导出格式",
       "limits": "限制",
       "options": "配置项"
     },
     "labels": "工单标签",
     "leave-a-comment": "发表一条评论…",
+    "review": {
+      "approve-description": "提交反馈并批准此工单",
+      "comment-description": "提交反馈，不进行批准操作",
+      "reject-description": "提交反馈并要求修改",
+      "self": "审批"
+    },
     "risk-level": {
       "filter": "按风险等级筛选",
       "high": "高风险",
@@ -1083,6 +1151,8 @@
     "role-grant": {
       "all-databases": "所有数据库",
       "all-databases-tip": "所有当前和未来属于这个项目的数据库。",
+      "details": "Role Grant Details",
+      "expired-at": "Expired at",
       "manually-select": "手动选择",
       "use-cel": "使用 CEL 表达式"
     },
@@ -1092,6 +1162,12 @@
       "descending": "倒序",
       "sort": "排序",
       "updated": "更新时间"
+    },
+    "status-transition": {
+      "modal": {
+        "close": "关闭工单？",
+        "reopen": "重开工单？"
+      }
     },
     "subtitle": "工单涵盖数据库变更、数据导出和权限申请。执行前需审查和审批。",
     "table": {
@@ -1111,7 +1187,26 @@
     "upload-sql": "上传 SQL",
     "waiting-approval": "等待审批"
   },
+  "issue.comment-editor.nothing-to-preview": "Nothing to preview",
+  "issue.comment-editor.preview": "Preview",
+  "issue.comment-editor.toolbar.bold": "Insert bold text",
+  "issue.comment-editor.toolbar.code": "Insert SQL code snippet",
+  "issue.comment-editor.toolbar.hashtag": "Insert hashtag",
+  "issue.comment-editor.toolbar.header": "Insert heading text",
+  "issue.comment-editor.toolbar.link": "Insert a link",
+  "issue.comment-editor.write": "Write",
+  "issue.data-export.format": "格式",
+  "issue.data-export.limits": "限制",
+  "issue.data-export.options": "选项",
+  "issue.issue-name": "Issue name",
+  "issue.no-description-provided": "No description provided",
+  "issue.options-disabled-due-to-oversize": "由于 SQL 文件过大，选项已禁用。",
+  "issue.overwrite-current-statement": "覆盖当前的 SQL 语句",
+  "issue.review.self": "评审",
+  "issue.statement-from-sheet-warning": "该 SQL 来自较大的 Sheet，预览内容可能已截断。",
   "issue.task-run.logs": "日志",
+  "issue.transaction-mode.label": "事务模式",
+  "issue.upload-sql-file-max-size-exceeded": "上传文件大小不能超过 {size}。",
   "label": {
     "add-label": "添加标签",
     "empty-label-value": "空",
@@ -1142,6 +1237,9 @@
     "checks": {
       "self": "检查"
     },
+    "editor": {
+      "save-changes-before-continuing": "请保存或取消更改，然后再继续"
+    },
     "navigator": {
       "review": "审批"
     },
@@ -1152,6 +1250,30 @@
       "title": "目标库"
     }
   },
+  "plan.checks.failed-to-run": "执行计划检查失败",
+  "plan.checks.no-check-results": "没有检查结果",
+  "plan.checks.no-results-match-filters": "没有结果匹配当前筛选条件",
+  "plan.checks.started": "计划检查已启动",
+  "plan.go-to-plan-page": "前往计划页面",
+  "plan.isolation-level.read-committed": "已提交读",
+  "plan.isolation-level.read-uncommitted": "未提交读",
+  "plan.isolation-level.repeatable-read": "可重复读",
+  "plan.isolation-level.self": "隔离级别",
+  "plan.isolation-level.serializable": "串行化",
+  "plan.navigator.checks": "检查",
+  "plan.navigator.statement-empty": "语句为空",
+  "plan.options.self": "配置项",
+  "plan.overview.no-checks": "没有检查",
+  "plan.ready-for-review": "准备提交评审",
+  "plan.run": "运行",
+  "plan.select-isolation-level": "选择隔离级别",
+  "plan.spec.change": "Change",
+  "plan.spec.type.database-change": "数据库变更",
+  "plan.targets.no-targets-found": "未找到目标",
+  "plan.targets.non-env-warning.one": "{{count}} 个数据库因为没有生效环境，将不会进入发布:",
+  "plan.targets.non-env-warning.other": "{{count}} 个数据库因为没有生效环境，将不会进入发布:",
+  "plan.targets.title": "目标",
+  "plan.targets.view-all": "查看全部 ({{count}})",
   "policy": {
     "environment-tier": {
       "description": "使该环境在显示上不同于其他环境。",
@@ -1256,6 +1378,7 @@
           "self": "强制 SQL 审核"
         },
         "labels": {
+          "configure-labels": "配置标签",
           "description": "可以在工单中附加标签以便管理",
           "force-issue-labels": {
             "description": "创建工单时必须添加至少一个标签。",
@@ -1333,10 +1456,23 @@
     "request-export-data": "申请导出数据"
   },
   "release": {
+    "and-n-more-files": "以及另外 {{count}} 个文件",
+    "change-tip": "该变更关联到了一个发布包。",
+    "file-type": {
+      "declarative": "声明式",
+      "unspecified": "未指定",
+      "versioned": "版本化"
+    },
     "files": "文件",
+    "not-found": "未找到发布包",
     "releases": "发布包",
     "total-files": "共 {{}} 个文件",
-    "usage-description": "发布包是版本化的应用制品。GitOps 工作流将发布包部署到环境。"
+    "usage-description": "发布包是版本化的应用制品。GitOps 工作流将发布包部署到环境。",
+    "vcs-source": "VCS 来源",
+    "vcs-type": {
+      "unspecified": "未知 VCS"
+    },
+    "view-all-files": "查看全部文件"
   },
   "remind": {
     "release": {
@@ -1390,7 +1526,8 @@
     "stage": {
       "self_one": "阶段",
       "self_other": "阶段"
-    }
+    },
+    "task-execution-errors": "任务执行错误"
   },
   "schema-editor": {
     "raw-sql": "SQL 语句"
@@ -1904,6 +2041,7 @@
   },
   "sql-editor": {
     "access-grants": "访问授权",
+    "access-type-unmask": "See unmasked sensitive data",
     "activate-access": "激活",
     "activate-confirm": "确定要激活此访问授权吗？",
     "expired": "已过期",
@@ -1912,6 +2050,7 @@
     "revoke-access": "撤销",
     "revoke-confirm": "确定要撤销此访问授权吗？",
     "self": "SQL 编辑器",
+    "unmask-warning": "The query result may include unmasked sensitive data.",
     "view-issue": "查看工单",
     "web-socket": {
       "errors": {
@@ -2781,11 +2920,40 @@
   "subscription.usage.instance-count.runoutof": "已用尽全部 {{total}} 个实例额度。",
   "subscription.usage.instance-count.title": "实例数量限制",
   "task": {
+    "cancel-task": "取消任务",
     "checking": "检查中…",
+    "created": "创建时间",
+    "data-export-creator-only": "只有工单创建者可以执行数据导出任务",
+    "error": {
+      "scheduled-time-must-be-in-the-future": "计划时间必须是将来的时间"
+    },
+    "execution-time": "执行时间",
+    "no-permission": "无权限执行该操作",
+    "run-immediately": {
+      "description": "点击“运行”后，任务将立即开始执行。",
+      "self": "立即运行"
+    },
+    "run-task": "运行任务 | 运行任务",
+    "schedule-for-later": {
+      "description": "设置任务自动开始运行的特定时间。",
+      "self": "定时运行"
+    },
+    "select-scheduled-time": "选择计划时间",
+    "skip-prior-backup": "跳过预备份",
+    "skip-prior-backup-description": "跳过变更前的自动数据备份",
+    "skip-task": "跳过任务 | 跳过任务",
+    "started": "开始于",
     "status": {
-      "running": "运行中"
+      "canceled": "已取消",
+      "done": "完成",
+      "failed": "失败",
+      "not-started": "未开始",
+      "pending": "待执行",
+      "running": "运行中",
+      "skipped": "已跳过"
     }
   },
+  "task-run.history": "执行历史",
   "task-run.log-detail.backing-up": "备份中...",
   "task-run.log-detail.backup-completed": "已完成（{{count}} 个表）",
   "task-run.log-detail.completed": "已完成",
@@ -2806,7 +2974,18 @@
   "task-run.log-viewer.multiple-replicas-notice": "检测到执行期间服务重启，日志按副本分组显示。",
   "task-run.log-viewer.replica-n": "副本 #{n}",
   "task-run.log-viewer.summary": "{sections} 个分组 · {entries} 条记录",
+  "task-run.status.enqueued": "等待执行。",
+  "task-run.status.enqueued-with-rollout-time": "等待执行，{{time}} 后执行。",
+  "task-run.status.waiting-max-tasks-per-rollout": "正在等待其他任务完成。已达到每次发布的最大运行任务数限制。上次报告时间：{{time}}。",
   "task.affected-rows": "影响行数",
+  "task.check-type.affected-rows.description": "根据统计信息估算。",
+  "task.check-type.affected-rows.self": "影响行数",
+  "task.check-type.ghost-sync": "gh-ost 同步",
+  "task.check-type.sql-review.description": "分析 SQL 语句中的潜在问题并提供建议，包括内置规则和自定义规则。",
+  "task.check-type.sql-review.self": "SQL 审核",
+  "task.check-type.summary-report": "摘要报告",
+  "task.online-migration.self": "在线大表变更",
+  "task.prior-backup": "预备份受影响数据",
   "two-factor": {
     "description": "双重认证为系统成员提供了一个额外的安全层。在登录时，用户需要输入由认证器应用程序生成的安全代码。",
     "disable": {

--- a/frontend/src/react/pages/project/ProjectIssueDetailPage.tsx
+++ b/frontend/src/react/pages/project/ProjectIssueDetailPage.tsx
@@ -1,0 +1,132 @@
+import { X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/react/components/ui/button";
+import { cn } from "@/react/lib/utils";
+import { IssueDetailActivity } from "./issue-detail/components/IssueDetailActivity";
+import { IssueDetailBranchContent } from "./issue-detail/components/IssueDetailBranchContent";
+import { IssueDetailHeader } from "./issue-detail/components/IssueDetailHeader";
+import { IssueDetailSidebar } from "./issue-detail/components/IssueDetailSidebar";
+import { IssueDetailProvider } from "./issue-detail/context/IssueDetailContext";
+import { useIssueDetailPage } from "./issue-detail/hooks/useIssueDetailPage";
+import type { ProjectIssueDetailPageProps } from "./issue-detail/types";
+
+export function ProjectIssueDetailPage(props: ProjectIssueDetailPageProps) {
+  const { t } = useTranslation();
+  const [
+    databaseExportExecutionHistoryExpanded,
+    setDatabaseExportExecutionHistoryExpanded,
+  ] = useState(false);
+  const [databaseExportTasksExpanded, setDatabaseExportTasksExpanded] =
+    useState(false);
+  const [pageHost, setPageHost] = useState<HTMLDivElement | null>(null);
+  const [databaseChangeSelectedSpecId, setDatabaseChangeSelectedSpecId] =
+    useState("");
+  const page = useIssueDetailPage({ ...props, pageHost });
+  const showDesktopSidebar = page.sidebarMode === "DESKTOP";
+  const showMobileSidebar = page.sidebarMode === "MOBILE";
+  const desktopSidebarStyle = useMemo(
+    () => ({
+      width: `${page.desktopSidebarWidth || 240}px`,
+    }),
+    [page.desktopSidebarWidth]
+  );
+
+  return (
+    <IssueDetailProvider value={page}>
+      <div
+        ref={setPageHost}
+        className="relative h-full overflow-x-hidden overflow-y-auto"
+      >
+        <div
+          className={`flex min-h-full flex-col ${
+            page.ready ? "" : "invisible pointer-events-none"
+          }`}
+        >
+          <IssueDetailHeader />
+          <div className="flex flex-1 items-stretch border-t">
+            <div className="flex flex-1 shrink flex-col gap-y-4 overflow-x-auto p-4">
+              <IssueDetailBranchContent
+                databaseChangeSelectedSpecId={databaseChangeSelectedSpecId}
+                databaseExportExecutionHistoryExpanded={
+                  databaseExportExecutionHistoryExpanded
+                }
+                databaseExportTasksExpanded={databaseExportTasksExpanded}
+                onDatabaseExportExecutionHistoryExpandedChange={
+                  setDatabaseExportExecutionHistoryExpanded
+                }
+                onDatabaseChangeSelectedSpecIdChange={
+                  setDatabaseChangeSelectedSpecId
+                }
+                onDatabaseExportTasksExpandedChange={
+                  setDatabaseExportTasksExpanded
+                }
+              />
+              <IssueDetailActivity />
+            </div>
+
+            {showDesktopSidebar && (
+              <div
+                className="shrink-0 border-l bg-white"
+                style={desktopSidebarStyle}
+              >
+                <div className="sticky top-0">
+                  <IssueDetailSidebar />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {!page.ready && (
+          <div className="absolute inset-0 flex flex-col items-center justify-center gap-y-3 bg-white">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-control-border border-t-accent" />
+            <div className="text-sm text-control-light">
+              {t("common.loading")}
+            </div>
+          </div>
+        )}
+
+        {showMobileSidebar && (
+          <div
+            className={cn(
+              "absolute inset-0 z-30 transition-[visibility] duration-200",
+              page.mobileSidebarOpen
+                ? "visible"
+                : "invisible pointer-events-none"
+            )}
+          >
+            <button
+              className={cn(
+                "absolute inset-0 bg-black/40 transition-opacity duration-200",
+                page.mobileSidebarOpen ? "opacity-100" : "opacity-0"
+              )}
+              onClick={() => page.setMobileSidebarOpen(false)}
+              type="button"
+            />
+            <div
+              className={cn(
+                "absolute right-0 top-0 flex h-full w-[80vw] min-w-[240px] max-w-[320px] transform flex-col border-l bg-white p-2 shadow-lg transition-transform duration-200",
+                page.mobileSidebarOpen ? "translate-x-0" : "translate-x-full"
+              )}
+            >
+              <div className="mb-2 flex justify-end">
+                <Button
+                  aria-label={t("common.close")}
+                  onClick={() => page.setMobileSidebarOpen(false)}
+                  size="icon"
+                  variant="ghost"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                <IssueDetailSidebar />
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </IssueDetailProvider>
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
@@ -1,0 +1,193 @@
+import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { EngineIconPath } from "@/react/components/instance/constants";
+import { Alert } from "@/react/components/ui/alert";
+import { useVueState } from "@/react/hooks/useVueState";
+import {
+  useAccessGrantStore,
+  useDatabaseV1Store,
+  useEnvironmentV1Store,
+  useProjectV1Store,
+} from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import { isValidDatabaseName } from "@/types";
+import type { AccessGrant } from "@/types/proto-es/v1/access_grant_service_pb";
+import { extractProjectResourceName, hasProjectPermissionV2 } from "@/utils";
+import { getAccessGrantExpirationText } from "@/utils/accessGrant";
+import { extractDatabaseResourceName } from "@/utils/v1/database";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+
+export function IssueDetailAccessGrantDetails() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const databaseStore = useDatabaseV1Store();
+  const accessGrantStore = useAccessGrantStore();
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+  const [isLoading, setIsLoading] = useState(true);
+  const [accessGrant, setAccessGrant] = useState<AccessGrant | undefined>();
+
+  useEffect(() => {
+    let canceled = false;
+
+    const run = async () => {
+      const name = page.issue?.accessGrant;
+      if (!name || !page.issue) {
+        setIsLoading(false);
+        setAccessGrant(undefined);
+        return;
+      }
+
+      setIsLoading(true);
+      try {
+        let grant: AccessGrant | undefined;
+        if (hasProjectPermissionV2(project, "bb.accessGrants.get")) {
+          grant = await accessGrantStore.getAccessGrant(name);
+        } else {
+          const parent = `projects/${extractProjectResourceName(page.issue.name)}`;
+          const response = await accessGrantStore.searchMyAccessGrants({
+            parent,
+            filter: { name },
+          });
+          grant = response.accessGrants[0];
+        }
+
+        if (canceled) {
+          return;
+        }
+
+        setAccessGrant(grant);
+        if (grant) {
+          for (const target of grant.targets) {
+            if (isValidDatabaseName(target)) {
+              void databaseStore.getOrFetchDatabaseByName(target);
+            }
+          }
+        }
+      } finally {
+        if (!canceled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void run();
+    return () => {
+      canceled = true;
+    };
+  }, [accessGrantStore, databaseStore, page.issue, project]);
+
+  const expirationInfo = accessGrant
+    ? getAccessGrantExpirationText(accessGrant)
+    : { type: "never" as const };
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <h3 className="text-base font-medium">
+        {t("issue.access-grant.details")}
+      </h3>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-8">
+          <Loader2 className="h-5 w-5 animate-spin text-control-light" />
+        </div>
+      ) : accessGrant ? (
+        <div className="flex flex-col gap-y-4 rounded-sm border p-4">
+          {accessGrant.targets.length > 0 && (
+            <div className="flex flex-col gap-y-2">
+              <span className="text-sm text-control-light">
+                {t("common.databases")}
+              </span>
+              <div className="flex flex-wrap gap-2">
+                {accessGrant.targets.map((target) => (
+                  <IssueDetailAccessGrantTarget key={target} target={target} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {accessGrant.query && (
+            <div className="flex flex-col gap-y-2">
+              <span className="text-sm text-control-light">
+                {t("common.statement")}
+              </span>
+              {accessGrant.unmask && (
+                <Alert variant="warning" showIcon={false}>
+                  {t("sql-editor.unmask-warning")}
+                </Alert>
+              )}
+              <div className="max-h-[30em] overflow-auto rounded-xs bg-gray-50 p-4">
+                <pre className="whitespace-pre-wrap font-mono text-sm">
+                  {accessGrant.query}
+                </pre>
+              </div>
+              <label className="flex items-center gap-2">
+                <input
+                  checked={accessGrant.unmask}
+                  className="h-4 w-4"
+                  disabled
+                  readOnly
+                  type="checkbox"
+                />
+                <span className="text-base">
+                  {t("sql-editor.access-type-unmask")}
+                </span>
+              </label>
+            </div>
+          )}
+
+          <div className="flex flex-col gap-y-1">
+            <span className="text-sm text-control-light">
+              {expirationInfo.type === "duration"
+                ? t("common.duration")
+                : t("issue.access-grant.expired-at")}
+            </span>
+            <div className="text-base">
+              {expirationInfo.type === "never"
+                ? t("project.members.never-expires")
+                : expirationInfo.value}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function IssueDetailAccessGrantTarget({ target }: { target: string }) {
+  const databaseStore = useDatabaseV1Store();
+  const environmentStore = useEnvironmentV1Store();
+  const database = useVueState(() => databaseStore.getDatabaseByName(target));
+  const environment = useVueState(() =>
+    environmentStore.getEnvironmentByName(
+      database.effectiveEnvironment ?? database.environment ?? ""
+    )
+  );
+  const instance = database.instanceResource;
+  const { databaseName } = extractDatabaseResourceName(target);
+  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
+
+  return (
+    <div className="inline-flex min-w-0 items-center gap-2 rounded-sm border px-2 py-1.5">
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center truncate text-sm">
+          {engineIcon && (
+            <img
+              alt=""
+              className="mr-1 inline-block h-4 w-4"
+              src={engineIcon}
+            />
+          )}
+          <span className="mr-1 truncate text-gray-400">
+            {environment.title}
+          </span>
+          <span className="truncate text-gray-600">{instance?.title}</span>
+          <span className="mx-1 shrink-0 text-gray-500">&gt;</span>
+          <span className="truncate text-gray-800">{databaseName}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantView.tsx
@@ -1,0 +1,9 @@
+import { IssueDetailAccessGrantDetails } from "./IssueDetailAccessGrantDetails";
+
+export function IssueDetailAccessGrantView() {
+  return (
+    <div className="flex w-full flex-col gap-y-4">
+      <IssueDetailAccessGrantDetails />
+    </div>
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailActionBar.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailActionBar.tsx
@@ -1,0 +1,1341 @@
+import { create } from "@bufbuild/protobuf";
+import dayjs from "dayjs";
+import DOMPurify from "dompurify";
+import { first, orderBy } from "lodash-es";
+import {
+  Bold,
+  CalendarX,
+  Check,
+  ChevronDown,
+  Code2,
+  EllipsisVertical,
+  Hash,
+  Heading1,
+  Link2,
+  Loader2,
+  MessageCircle,
+  X,
+} from "lucide-react";
+import MarkdownIt from "markdown-it";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+import {
+  issueServiceClientConnect,
+  rolloutServiceClientConnect,
+} from "@/connect";
+import { Button } from "@/react/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/react/components/ui/dialog";
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/react/components/ui/sheet";
+import { Textarea } from "@/react/components/ui/textarea";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { useClickOutside } from "@/react/hooks/useClickOutside";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import { router } from "@/router";
+import {
+  PROJECT_V1_ROUTE_ISSUE_DETAIL,
+  PROJECT_V1_ROUTE_PLAN_DETAIL,
+} from "@/router/dashboard/projectV1";
+import {
+  buildPlanDeployRouteFromPlanName,
+  buildPlanDeployRouteFromRolloutName,
+} from "@/router/dashboard/projectV1RouteHelpers";
+import {
+  pushNotification,
+  useCurrentUserV1,
+  useIssueCommentStore,
+  useProjectV1Store,
+  useSQLStore,
+} from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import {
+  ApproveIssueRequestSchema,
+  BatchUpdateIssuesStatusRequestSchema,
+  IssueStatus,
+  ListIssueCommentsRequestSchema,
+  RejectIssueRequestSchema,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { PlanCheckRun_Status } from "@/types/proto-es/v1/plan_service_pb";
+import {
+  BatchRunTasksRequestSchema,
+  CreateRolloutRequestSchema,
+  type Rollout,
+  TaskRun_ExportArchiveStatus,
+} from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  Advice_Level,
+  ExportRequestSchema,
+} from "@/types/proto-es/v1/sql_service_pb";
+import {
+  extractPlanUID,
+  extractProjectResourceName,
+  extractTaskRunUID,
+  extractTaskUID,
+} from "@/utils";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+import { useIssueDetailSpecValidation } from "../hooks/useIssueDetailSpecValidation";
+import {
+  type ActionContext,
+  type ActionDefinition,
+  buildIssueDetailActionContext,
+  createIssueDetailActions,
+  type UnifiedAction,
+} from "../utils/actionRegistry";
+import { isApprovalCompleted } from "../utils/approval";
+import { refreshIssueDetailState } from "../utils/refreshIssueDetailState";
+import { IssueDetailTaskRolloutActionPanel } from "./IssueDetailTaskRolloutActionPanel";
+
+const markdown = new MarkdownIt({
+  html: true,
+  linkify: true,
+});
+
+export function IssueDetailActionBar() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const issueCommentStore = useIssueCommentStore();
+  const sqlStore = useSQLStore();
+  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const [pendingConfirmAction, setPendingConfirmAction] =
+    useState<ActionDefinition>();
+  const [pendingReviewOpen, setPendingReviewOpen] = useState(false);
+  const [pendingRolloutAction, setPendingRolloutAction] = useState<
+    "ROLLOUT_START" | "ROLLOUT_CANCEL" | undefined
+  >();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+  const { isSpecEmpty } = useIssueDetailSpecValidation(page.plan?.specs ?? []);
+
+  useClickOutside(menuRef, menuOpen, () => setMenuOpen(false));
+
+  const context = useMemo<ActionContext | undefined>(() => {
+    if (!page.plan || !project || !currentUser) {
+      return undefined;
+    }
+    const statusCount = page.plan.planCheckRunStatusCount ?? {};
+    const planCheckStatus =
+      statusCount.ERROR > 0 || statusCount.FAILED > 0
+        ? Advice_Level.ERROR
+        : statusCount.WARNING > 0
+          ? Advice_Level.WARNING
+          : Advice_Level.SUCCESS;
+
+    return buildIssueDetailActionContext({
+      plan: page.plan,
+      issue: page.issue,
+      rollout: page.rollout,
+      project,
+      currentUser,
+      taskRuns: page.taskRuns,
+      isCreating: page.isCreating,
+      planCheckStatus,
+      hasRunningPlanChecks: (statusCount.RUNNING ?? 0) > 0,
+      isSpecEmpty,
+    });
+  }, [
+    currentUser,
+    page.isCreating,
+    page.issue,
+    page.plan,
+    page.rollout,
+    page.taskRuns,
+    project,
+    isSpecEmpty,
+  ]);
+
+  const globalDisabledReason = useMemo(() => {
+    return page.isEditing
+      ? t("plan.editor.save-changes-before-continuing")
+      : undefined;
+  }, [page.isEditing, t]);
+  const issueDetailActions = useMemo(() => createIssueDetailActions(t), [t]);
+
+  const getCategory = useCallback(
+    (action: ActionDefinition) => {
+      if (!context) {
+        return "secondary";
+      }
+      return typeof action.category === "function"
+        ? action.category(context)
+        : action.category;
+    },
+    [context]
+  );
+
+  const visibleActions = useMemo(() => {
+    if (!context || page.isCreating) {
+      return [];
+    }
+    return issueDetailActions.filter((action) => action.isVisible(context));
+  }, [context, page.isCreating]);
+
+  const primaryAction = useMemo(() => {
+    return visibleActions.find((action) => getCategory(action) === "primary");
+  }, [getCategory, visibleActions]);
+
+  const secondaryActions = useMemo(() => {
+    return visibleActions.filter(
+      (action) =>
+        getCategory(action) === "secondary" ||
+        (getCategory(action) === "primary" && action.id !== primaryAction?.id)
+    );
+  }, [getCategory, primaryAction?.id, visibleActions]);
+
+  const shouldShowPlanLink = useMemo(() => {
+    if (!page.plan || !page.issue) {
+      return false;
+    }
+    if (page.issueType !== "DATABASE_CHANGE") {
+      return false;
+    }
+    return page.plan.hasRollout || isApprovalCompleted(page.issue);
+  }, [page.issue, page.issueType, page.plan]);
+
+  const planRoute = useMemo(() => {
+    if (!page.plan) {
+      return undefined;
+    }
+    if (page.plan.hasRollout) {
+      return buildPlanDeployRouteFromPlanName(page.plan.name);
+    }
+    return {
+      name: PROJECT_V1_ROUTE_PLAN_DETAIL,
+      params: {
+        projectId: extractProjectResourceName(page.plan.name),
+        planId: extractPlanUID(page.plan.name),
+      },
+    };
+  }, [page.plan]);
+
+  const isActionDisabled = useCallback(
+    (action: ActionDefinition) => {
+      if (!context) {
+        return true;
+      }
+      return page.isEditing || action.isDisabled(context);
+    },
+    [context, page.isEditing]
+  );
+
+  const getDisabledReason = useCallback(
+    (action: ActionDefinition) => {
+      if (!context) {
+        return undefined;
+      }
+      return globalDisabledReason || action.disabledReason(context);
+    },
+    [context, globalDisabledReason]
+  );
+
+  const refreshIssueComments = useCallback(async () => {
+    if (!page.issue?.name) {
+      return;
+    }
+    await issueCommentStore.listIssueComments(
+      create(ListIssueCommentsRequestSchema, {
+        parent: page.issue.name,
+        pageSize: 1000,
+      })
+    );
+  }, [issueCommentStore, page.issue?.name]);
+
+  const handleRefreshIssueDetailState = useCallback(async () => {
+    await refreshIssueDetailState(page);
+  }, [page]);
+
+  const handleExportDownload = useCallback(async () => {
+    if (!page.rollout) {
+      return;
+    }
+    try {
+      setIsSubmitting(true);
+      const content = await sqlStore.exportData(
+        create(ExportRequestSchema, {
+          name: `${page.rollout.name}/stages/-`,
+        })
+      );
+      const buffer = content.buffer.slice(
+        content.byteOffset,
+        content.byteOffset + content.byteLength
+      ) as ArrayBuffer;
+      const blob = new Blob([buffer], {
+        type: "application/zip",
+      });
+      const url = window.URL.createObjectURL(blob);
+      const filename = `export-data-${dayjs(new Date()).format(
+        "YYYY-MM-DDTHH-mm-ss"
+      )}.zip`;
+      const link = document.createElement("a");
+      link.download = filename;
+      link.href = url;
+      link.click();
+      await handleRefreshIssueDetailState();
+    } catch (error) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.failed"),
+        description: String(error),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [handleRefreshIssueDetailState, page.rollout, sqlStore, t]);
+
+  const handleCreateRollout = useCallback(
+    async (options?: { runAllTasks?: boolean }) => {
+      if (!page.plan) {
+        return;
+      }
+      const createdRollout = await rolloutServiceClientConnect.createRollout(
+        create(CreateRolloutRequestSchema, {
+          parent: page.plan.name,
+        })
+      );
+
+      if (options?.runAllTasks) {
+        for (const stage of createdRollout.stages) {
+          await rolloutServiceClientConnect.batchRunTasks(
+            create(BatchRunTasksRequestSchema, {
+              parent: stage.name,
+              tasks: stage.tasks.map((task) => task.name),
+            })
+          );
+        }
+      }
+
+      await handleRefreshIssueDetailState();
+
+      if (createdRollout.stages.length > 0) {
+        void router.push(
+          buildPlanDeployRouteFromRolloutName(createdRollout.name)
+        );
+      }
+    },
+    [handleRefreshIssueDetailState, page.plan]
+  );
+
+  const handleIssueStatusAction = useCallback(
+    async (action: "ISSUE_STATUS_CLOSE" | "ISSUE_STATUS_REOPEN") => {
+      if (!page.issue || !project) {
+        return;
+      }
+      const nextStatus =
+        action === "ISSUE_STATUS_CLOSE"
+          ? IssueStatus.CANCELED
+          : IssueStatus.OPEN;
+      await issueServiceClientConnect.batchUpdateIssuesStatus(
+        create(BatchUpdateIssuesStatusRequestSchema, {
+          parent: project.name,
+          issues: [page.issue.name],
+          status: nextStatus,
+        })
+      );
+      await Promise.all([
+        handleRefreshIssueDetailState(),
+        refreshIssueComments(),
+      ]);
+    },
+    [handleRefreshIssueDetailState, page.issue, project, refreshIssueComments]
+  );
+
+  const confirmLabel =
+    pendingConfirmAction && context ? pendingConfirmAction.label(context) : "";
+  const confirmContent = pendingConfirmAction
+    ? pendingConfirmAction.id === "ISSUE_STATUS_CLOSE"
+      ? t("issue.status-transition.modal.close")
+      : pendingConfirmAction.id === "ISSUE_STATUS_REOPEN"
+        ? t("issue.status-transition.modal.reopen")
+        : ""
+    : "";
+  const exportExpired =
+    primaryAction?.id === "EXPORT_DOWNLOAD" &&
+    isExportExpired(page.rollout, page.taskRuns);
+
+  const executeAction = useCallback(
+    async (action: UnifiedAction) => {
+      if (!context) {
+        return;
+      }
+      if (action === "EXPORT_DOWNLOAD") {
+        await handleExportDownload();
+        return;
+      }
+      if (action === "ISSUE_REVIEW") {
+        setPendingReviewOpen(true);
+        return;
+      }
+      if (action === "ISSUE_STATUS_CLOSE" || action === "ISSUE_STATUS_REOPEN") {
+        const definition = visibleActions.find((item) => item.id === action);
+        setPendingConfirmAction(definition);
+        return;
+      }
+      if (action === "ROLLOUT_START") {
+        if (context.hasDeferredRollout && !page.rollout) {
+          try {
+            setIsSubmitting(true);
+            await handleCreateRollout({ runAllTasks: true });
+          } catch (error) {
+            pushNotification({
+              module: "bytebase",
+              style: "CRITICAL",
+              title: t("common.failed"),
+              description: String(error),
+            });
+          } finally {
+            setIsSubmitting(false);
+          }
+          return;
+        }
+        setPendingRolloutAction("ROLLOUT_START");
+        return;
+      }
+      if (action === "ROLLOUT_CANCEL") {
+        setPendingRolloutAction("ROLLOUT_CANCEL");
+      }
+    },
+    [
+      context,
+      handleCreateRollout,
+      handleExportDownload,
+      page.rollout,
+      t,
+      visibleActions,
+    ]
+  );
+
+  const confirmAction = useCallback(async () => {
+    if (!pendingConfirmAction) {
+      return;
+    }
+    try {
+      setIsSubmitting(true);
+      if (
+        pendingConfirmAction.id === "ISSUE_STATUS_CLOSE" ||
+        pendingConfirmAction.id === "ISSUE_STATUS_REOPEN"
+      ) {
+        await handleIssueStatusAction(pendingConfirmAction.id);
+      }
+      setPendingConfirmAction(undefined);
+    } catch (error) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.failed"),
+        description: String(error),
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [handleIssueStatusAction, pendingConfirmAction, t]);
+
+  if (!context || !page.plan) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-x-2">
+        {shouldShowPlanLink && planRoute && (
+          <Button
+            className="gap-x-1"
+            onClick={() => {
+              void router.push(planRoute);
+            }}
+            size="sm"
+            variant="outline"
+          >
+            <span>#{extractPlanUID(page.plan.name)}</span>
+            <span>{t("common.plan")}</span>
+          </Button>
+        )}
+
+        {primaryAction &&
+          (primaryAction.id === "ISSUE_REVIEW" ? (
+            <IssueDetailReviewTrigger
+              action={primaryAction}
+              context={context}
+              disabled={isSubmitting || isActionDisabled(primaryAction)}
+              disabledReason={getDisabledReason(primaryAction)}
+              loading={isSubmitting}
+              onExecute={executeAction}
+            >
+              <IssueDetailReviewPopover
+                context={context}
+                mobile={page.sidebarMode === "MOBILE"}
+                onOpenChange={setPendingReviewOpen}
+                onRefreshIssueComments={refreshIssueComments}
+                onRefreshState={handleRefreshIssueDetailState}
+                open={pendingReviewOpen}
+              />
+            </IssueDetailReviewTrigger>
+          ) : (
+            <IssueDetailActionButton
+              action={primaryAction}
+              context={context}
+              disabled={isSubmitting || isActionDisabled(primaryAction)}
+              disabledReason={getDisabledReason(primaryAction)}
+              exportExpired={exportExpired}
+              loading={isSubmitting && primaryAction.id === "EXPORT_DOWNLOAD"}
+              onExecute={executeAction}
+            />
+          ))}
+
+        {secondaryActions.length > 0 && (
+          <div className="relative" ref={menuRef}>
+            <Tooltip
+              content={
+                primaryAction ? getDisabledReason(primaryAction) : undefined
+              }
+            >
+              <span className="inline-flex">
+                <Button
+                  aria-label={t("common.more")}
+                  className="px-1"
+                  disabled={Boolean(
+                    primaryAction && isActionDisabled(primaryAction)
+                  )}
+                  onClick={() => setMenuOpen((open) => !open)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  <EllipsisVertical className="h-4 w-4" />
+                </Button>
+              </span>
+            </Tooltip>
+            {menuOpen && (
+              <div className="absolute right-0 top-full z-40 mt-1 min-w-44 overflow-hidden rounded-sm border border-control-border bg-white py-1 shadow-lg">
+                {secondaryActions.map((action) => {
+                  const disabled = isActionDisabled(action) || isSubmitting;
+                  return (
+                    <Tooltip
+                      key={action.id}
+                      content={disabled ? getDisabledReason(action) : undefined}
+                      side="left"
+                    >
+                      <span className="block">
+                        <button
+                          className={cn(
+                            "flex w-full items-center px-3 py-2 text-left text-sm",
+                            disabled
+                              ? "cursor-not-allowed text-control-placeholder"
+                              : "hover:bg-control-bg"
+                          )}
+                          disabled={disabled}
+                          onClick={() => {
+                            setMenuOpen(false);
+                            void executeAction(action.id);
+                          }}
+                          type="button"
+                        >
+                          {action.label(context)}
+                        </button>
+                      </span>
+                    </Tooltip>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <IssueDetailConfirmDialog
+        busy={isSubmitting}
+        content={confirmContent}
+        label={confirmLabel}
+        onConfirm={() => {
+          void confirmAction();
+        }}
+        open={Boolean(pendingConfirmAction)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingConfirmAction(undefined);
+          }
+        }}
+      />
+
+      <IssueDetailTaskRolloutActionPanel
+        action={
+          pendingRolloutAction === "ROLLOUT_START"
+            ? "RUN"
+            : pendingRolloutAction === "ROLLOUT_CANCEL"
+              ? "CANCEL"
+              : undefined
+        }
+        onConfirm={handleRefreshIssueDetailState}
+        open={Boolean(pendingRolloutAction && page.rollout)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingRolloutAction(undefined);
+          }
+        }}
+        target={{ type: "tasks", stage: page.rollout?.stages[0] }}
+      />
+    </>
+  );
+}
+
+function IssueDetailReviewTrigger({
+  action,
+  children,
+  context,
+  disabled,
+  disabledReason,
+  loading,
+  onExecute,
+}: {
+  action: ActionDefinition;
+  children: ReactNode;
+  context: ActionContext;
+  disabled: boolean;
+  disabledReason?: string;
+  loading?: boolean;
+  onExecute: (action: UnifiedAction) => Promise<void>;
+}) {
+  const button = (
+    <Button
+      className="gap-x-1.5"
+      disabled={disabled}
+      onClick={() => {
+        void onExecute(action.id);
+      }}
+      size="sm"
+      variant={action.buttonType === "default" ? "outline" : "default"}
+    >
+      {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+      <span>{action.label(context)}</span>
+      <ChevronDown className="h-4 w-4" />
+    </Button>
+  );
+
+  return (
+    <div className="relative inline-flex">
+      <Tooltip content={disabled ? disabledReason : undefined}>
+        <span className="inline-flex">{button}</span>
+      </Tooltip>
+      {children}
+    </div>
+  );
+}
+
+function IssueDetailActionButton({
+  action,
+  context,
+  disabled,
+  disabledReason,
+  exportExpired = false,
+  loading = false,
+  onExecute,
+}: {
+  action: ActionDefinition;
+  context: ActionContext;
+  disabled: boolean;
+  disabledReason?: string;
+  exportExpired?: boolean;
+  loading?: boolean;
+  onExecute: (action: UnifiedAction) => Promise<void>;
+}) {
+  const { t } = useTranslation();
+
+  if (exportExpired) {
+    return (
+      <Tooltip content={t("issue.data-export.download-tooltip")}>
+        <div className="flex items-center gap-2 text-sm textlabel leading-8">
+          <CalendarX className="h-5 w-5" />
+          {t("issue.data-export.file-expired")}
+        </div>
+      </Tooltip>
+    );
+  }
+
+  const button = (
+    <Button
+      className={cn(
+        action.buttonType === "success" &&
+          "bg-success text-white hover:bg-success/90",
+        action.id === "ISSUE_REVIEW" && "gap-x-1.5"
+      )}
+      disabled={disabled}
+      onClick={() => {
+        void onExecute(action.id);
+      }}
+      size="sm"
+      variant={action.buttonType === "default" ? "outline" : "default"}
+    >
+      {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+      <span>{action.label(context)}</span>
+      {action.id === "ISSUE_REVIEW" && <ChevronDown className="h-4 w-4" />}
+    </Button>
+  );
+
+  return (
+    <Tooltip content={disabled ? disabledReason : undefined}>
+      <span className="inline-flex">{button}</span>
+    </Tooltip>
+  );
+}
+
+function IssueDetailConfirmDialog({
+  busy,
+  content,
+  label,
+  onConfirm,
+  open,
+  onOpenChange,
+}: {
+  busy: boolean;
+  content: string;
+  label: string;
+  onConfirm: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Dialog onOpenChange={onOpenChange} open={open}>
+      <DialogContent className="max-w-md p-6">
+        {open && (
+          <>
+            <DialogTitle>{label}</DialogTitle>
+            <div className="mt-3 text-sm text-control-light">{content}</div>
+            <div className="mt-6 flex items-center justify-end gap-x-2">
+              <Button
+                onClick={() => onOpenChange(false)}
+                size="sm"
+                variant="ghost"
+              >
+                {t("common.cancel")}
+              </Button>
+              <Button disabled={busy} onClick={onConfirm} size="sm">
+                {busy && <Loader2 className="h-4 w-4 animate-spin" />}
+                {label}
+              </Button>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function IssueDetailReviewPopover({
+  context,
+  mobile,
+  onOpenChange,
+  onRefreshIssueComments,
+  onRefreshState,
+  open,
+}: {
+  context: ActionContext;
+  mobile: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRefreshIssueComments: () => Promise<void>;
+  onRefreshState: () => Promise<void>;
+  open: boolean;
+}) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const issueCommentStore = useIssueCommentStore();
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [loading, setLoading] = useState(false);
+  const [comment, setComment] = useState("");
+  const [selectedAction, setSelectedAction] = useState<
+    "COMMENT" | "APPROVE" | "REJECT"
+  >("COMMENT");
+  const [performActionAnyway, setPerformActionAnyway] = useState(false);
+  const issue = page.issue;
+  const planCheckWarnings = useMemo(() => {
+    const warnings: string[] = [];
+    for (const run of page.planCheckRuns) {
+      if (run.status === PlanCheckRun_Status.FAILED) {
+        warnings.push(
+          t(
+            "custom-approval.issue-review.disallow-approve-reason.some-task-checks-didnt-pass"
+          )
+        );
+        break;
+      }
+    }
+    for (const run of page.planCheckRuns) {
+      if (run.status === PlanCheckRun_Status.RUNNING) {
+        warnings.push(
+          t(
+            "custom-approval.issue-review.disallow-approve-reason.some-task-checks-are-still-running"
+          )
+        );
+        break;
+      }
+    }
+    return warnings;
+  }, [page.planCheckRuns, t]);
+  const confirmErrors = useMemo(() => {
+    if (
+      selectedAction === "APPROVE" &&
+      planCheckWarnings.length > 0 &&
+      !performActionAnyway
+    ) {
+      return planCheckWarnings;
+    }
+    return [];
+  }, [comment, performActionAnyway, planCheckWarnings, selectedAction, t]);
+  const submitDisabled =
+    loading ||
+    (selectedAction === "COMMENT" && comment.trim().length === 0) ||
+    (selectedAction === "APPROVE" &&
+      planCheckWarnings.length > 0 &&
+      !performActionAnyway);
+
+  useEffect(() => {
+    if (!open) {
+      setComment("");
+      setSelectedAction("COMMENT");
+      setPerformActionAnyway(false);
+    }
+  }, [open]);
+
+  useClickOutside(popoverRef, open && !mobile, () => onOpenChange(false));
+
+  const handleSubmit = useCallback(async () => {
+    if (!issue || confirmErrors.length > 0) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      if (selectedAction === "APPROVE") {
+        const response = await issueServiceClientConnect.approveIssue(
+          create(ApproveIssueRequestSchema, {
+            comment,
+            name: issue.name,
+          })
+        );
+        page.patchState({ issue: response });
+      } else if (selectedAction === "REJECT") {
+        const response = await issueServiceClientConnect.rejectIssue(
+          create(RejectIssueRequestSchema, {
+            comment,
+            name: issue.name,
+          })
+        );
+        page.patchState({ issue: response });
+      } else {
+        await issueCommentStore.createIssueComment({
+          issueName: issue.name,
+          comment,
+        });
+      }
+
+      await Promise.all([onRefreshState(), onRefreshIssueComments()]);
+      onOpenChange(false);
+
+      if (
+        selectedAction === "APPROVE" &&
+        page.plan &&
+        !page.plan.specs.some(
+          (spec) =>
+            spec.config.case === "createDatabaseConfig" ||
+            spec.config.case === "exportDataConfig"
+        ) &&
+        page.plan.hasRollout
+      ) {
+        void router.push(buildPlanDeployRouteFromPlanName(page.plan.name));
+      } else if (selectedAction !== "COMMENT" && issue) {
+        void router.push({
+          name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
+          params: {
+            issueId: page.issueId,
+            projectId: extractProjectResourceName(issue.name),
+          },
+          hash: "#issue-comment-editor",
+        });
+      }
+    } catch (error) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.failed"),
+        description: String(error),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    comment,
+    confirmErrors.length,
+    issue,
+    issueCommentStore,
+    onOpenChange,
+    onRefreshIssueComments,
+    onRefreshState,
+    page.issueId,
+    page.plan,
+    selectedAction,
+    t,
+  ]);
+
+  if (!open) {
+    return null;
+  }
+
+  const content = (
+    <div className="flex flex-col gap-y-3">
+      <IssueDetailReviewMarkdownEditor
+        content={comment}
+        onChange={setComment}
+        onSubmit={() => {
+          void handleSubmit();
+        }}
+      />
+
+      <div className="flex flex-col gap-y-2.5">
+        <IssueDetailReviewOption
+          description={t("issue.review.comment-description")}
+          icon={<MessageCircle className="mt-0.5 h-4 w-4 text-gray-600" />}
+          label={t("common.comment")}
+          onSelect={() => setSelectedAction("COMMENT")}
+          selected={selectedAction === "COMMENT"}
+        />
+        {context.permissions.isApprovalCandidate && (
+          <IssueDetailReviewOption
+            description={t("issue.review.approve-description")}
+            icon={<Check className="mt-0.5 h-4 w-4 text-green-600" />}
+            label={t("common.approve")}
+            onSelect={() => setSelectedAction("APPROVE")}
+            selected={selectedAction === "APPROVE"}
+          />
+        )}
+        {context.permissions.isApprovalCandidate && (
+          <IssueDetailReviewOption
+            description={t("issue.review.reject-description")}
+            icon={<X className="mt-0.5 h-4 w-4 text-red-600" />}
+            label={t("common.reject")}
+            onSelect={() => setSelectedAction("REJECT")}
+            selected={selectedAction === "REJECT"}
+          />
+        )}
+      </div>
+
+      {selectedAction === "APPROVE" && planCheckWarnings.length > 0 && (
+        <div className="rounded-xs border border-warning/30 bg-warning/5 px-4 py-3 text-sm text-warning">
+          <ul className="list-inside list-disc">
+            {planCheckWarnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+          <label className="mt-3 flex items-center gap-x-2 text-main">
+            <input
+              checked={performActionAnyway}
+              className="h-4 w-4 rounded border-control-border"
+              onChange={(e) => setPerformActionAnyway(e.target.checked)}
+              type="checkbox"
+            />
+            <span className="text-sm">
+              {t("issue.action-anyway", {
+                action: t("common.approve"),
+              })}
+            </span>
+          </label>
+        </div>
+      )}
+
+      <div className="flex items-center justify-start gap-x-2 pt-1">
+        <Button
+          disabled={submitDisabled}
+          onClick={() => {
+            void handleSubmit();
+          }}
+          size="sm"
+        >
+          {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+          {t("common.submit")}
+        </Button>
+        <Button onClick={() => onOpenChange(false)} size="sm" variant="ghost">
+          {t("common.cancel")}
+        </Button>
+      </div>
+    </div>
+  );
+
+  if (mobile) {
+    return (
+      <Sheet onOpenChange={onOpenChange} open={open}>
+        <SheetContent
+          className="w-[calc(100vw-2rem)] max-w-[32rem]"
+          width="standard"
+        >
+          <SheetHeader>
+            <SheetTitle>{t("issue.review.self")}</SheetTitle>
+          </SheetHeader>
+          <SheetBody className="py-4">{content}</SheetBody>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
+  return (
+    <div
+      className="absolute right-0 top-full z-40 mt-2 w-[min(34rem,calc(100vw-2rem))] rounded-sm border border-control-border bg-white px-4 py-4 shadow-lg"
+      ref={popoverRef}
+    >
+      {content}
+    </div>
+  );
+}
+
+function IssueDetailReviewOption({
+  description,
+  icon,
+  label,
+  onSelect,
+  selected,
+}: {
+  description?: string;
+  icon: ReactNode;
+  label: string;
+  onSelect: () => void;
+  selected: boolean;
+}) {
+  return (
+    <label
+      className={cn(
+        "flex cursor-pointer items-start gap-3 rounded-xs px-0 py-0.5 text-left transition-colors",
+        selected ? "text-main" : "text-control"
+      )}
+    >
+      <input
+        checked={selected}
+        className="mt-1 h-4 w-4 accent-accent"
+        onChange={onSelect}
+        type="radio"
+      />
+      <span className="mt-1 shrink-0">{icon}</span>
+      <span className="flex flex-col gap-y-0.5">
+        <span className="text-sm font-medium leading-6">{label}</span>
+        {description && (
+          <span className="text-sm leading-6 text-control-light">
+            {description}
+          </span>
+        )}
+      </span>
+    </label>
+  );
+}
+
+function IssueDetailReviewMarkdownEditor({
+  content,
+  onChange,
+  onSubmit,
+}: {
+  content: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+}) {
+  const { t } = useTranslation();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [tab, setTab] = useState<"write" | "preview">("write");
+  const previewHtml = useMemo(() => {
+    const rendered = markdown.render(content || "");
+    return DOMPurify.sanitize(rendered);
+  }, [content]);
+
+  useEffect(() => {
+    if (!textareaRef.current) {
+      return;
+    }
+    textareaRef.current.style.height = "auto";
+    textareaRef.current.style.height = `${Math.max(
+      textareaRef.current.scrollHeight,
+      112
+    )}px`;
+  }, [content, tab]);
+
+  const insertTemplate = (template: string, cursorOffset: number) => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const next = `${content.slice(0, start)}${template.slice(
+      0,
+      cursorOffset
+    )}${content.slice(start, end)}${template.slice(cursorOffset)}${content.slice(end)}`;
+    onChange(next);
+    window.requestAnimationFrame(() => {
+      if (!textareaRef.current) {
+        return;
+      }
+      const cursor = start + cursorOffset;
+      textareaRef.current.focus();
+      textareaRef.current.setSelectionRange(cursor, cursor);
+    });
+  };
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between border-b border-control-border pb-1">
+        <div className="flex gap-x-4">
+          <button
+            className={cn(
+              "relative px-1 pb-2 text-sm font-medium transition-colors",
+              tab === "write"
+                ? "text-accent after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-accent"
+                : "text-control-light hover:text-control"
+            )}
+            onClick={() => setTab("write")}
+            type="button"
+          >
+            {t("issue.comment-editor.write")}
+          </button>
+          <button
+            className={cn(
+              "relative px-1 pb-2 text-sm font-medium transition-colors",
+              tab === "preview"
+                ? "text-accent after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-accent"
+                : "text-control-light hover:text-control"
+            )}
+            onClick={() => setTab("preview")}
+            type="button"
+          >
+            {t("issue.comment-editor.preview")}
+          </button>
+        </div>
+        {tab === "write" && (
+          <div className="flex items-center gap-x-3 pb-1">
+            <IssueDetailReviewToolbarButton
+              icon={<Heading1 className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.header")}
+              onClick={() => insertTemplate("### ", 4)}
+            />
+            <IssueDetailReviewToolbarButton
+              icon={<Bold className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.bold")}
+              onClick={() => insertTemplate("****", 2)}
+            />
+            <IssueDetailReviewToolbarButton
+              icon={<Code2 className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.code")}
+              onClick={() => insertTemplate("```sql\n\n```", 7)}
+            />
+            <IssueDetailReviewToolbarButton
+              icon={<Link2 className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.link")}
+              onClick={() => insertTemplate("[](url)", 1)}
+            />
+            <IssueDetailReviewToolbarButton
+              icon={<Hash className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.hashtag")}
+              onClick={() => insertTemplate("#", 1)}
+            />
+          </div>
+        )}
+      </div>
+
+      {tab === "preview" ? (
+        <div className="markdown-body min-h-25 rounded-xs border border-control-border px-4 py-3 text-sm">
+          {previewHtml ? (
+            <div dangerouslySetInnerHTML={{ __html: previewHtml }} />
+          ) : (
+            <span className="italic text-gray-400">
+              {t("issue.comment-editor.nothing-to-preview")}
+            </span>
+          )}
+        </div>
+      ) : (
+        <Textarea
+          className="min-h-34 rounded-lg px-4 py-3 text-sm"
+          maxLength={65536}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={(e) => {
+            const listContinuation = applyMarkdownListContinuation(
+              content,
+              e.currentTarget.selectionStart,
+              e.currentTarget.selectionEnd
+            );
+            if (
+              e.key === "Enter" &&
+              !e.nativeEvent.isComposing &&
+              !e.metaKey &&
+              !e.ctrlKey &&
+              listContinuation
+            ) {
+              e.preventDefault();
+              onChange(listContinuation.content);
+              window.requestAnimationFrame(() => {
+                const target = textareaRef.current;
+                if (!target) {
+                  return;
+                }
+                target.focus();
+                target.setSelectionRange(
+                  listContinuation.cursor,
+                  listContinuation.cursor
+                );
+              });
+              return;
+            }
+            if (
+              e.key === "Enter" &&
+              !e.nativeEvent.isComposing &&
+              (e.metaKey || e.ctrlKey)
+            ) {
+              e.preventDefault();
+              onSubmit();
+            }
+          }}
+          placeholder={t("issue.leave-a-comment")}
+          ref={textareaRef}
+          rows={4}
+          value={content}
+        />
+      )}
+    </div>
+  );
+}
+
+function IssueDetailReviewToolbarButton({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      aria-label={label}
+      className="rounded-xs p-1 text-control transition-colors hover:bg-control-bg hover:text-main"
+      onClick={onClick}
+      title={label}
+      type="button"
+    >
+      {icon}
+    </button>
+  );
+}
+
+function applyMarkdownListContinuation(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number
+) {
+  if (selectionStart !== selectionEnd) {
+    return undefined;
+  }
+
+  const lines = text.split("\n");
+  const lineIndex = getActiveLineIndex(text, selectionStart);
+  const currentLine = lines[lineIndex] ?? "";
+  const lineStart = getCursorPosition(lines.slice(0, lineIndex));
+  const indexInCurrentLine = selectionStart - lineStart;
+
+  if (/^\s{0,}(\d{1,}\.|-)\s{1,}$/.test(currentLine)) {
+    lines[lineIndex] = "";
+    return {
+      content: lines.join("\n"),
+      cursor: getCursorPosition(lines.slice(0, lineIndex)),
+    };
+  }
+
+  if (!/^\s{0,}(\d{1,}\.|-)\s/.test(currentLine)) {
+    return undefined;
+  }
+
+  const indent = " ".repeat(
+    currentLine.length - currentLine.trimStart().length
+  );
+  const trailing = currentLine.slice(indexInCurrentLine);
+  lines[lineIndex] = currentLine.slice(0, indexInCurrentLine);
+
+  let nextListStart = "-";
+  if (/^\s{0,}\d{1,}\.\s/.test(currentLine)) {
+    const currentNumber = Number(currentLine.match(/\d+/)?.[0] ?? "1");
+    nextListStart = `${currentNumber + 1}.`;
+  }
+
+  lines.splice(lineIndex + 1, 0, `${indent}${nextListStart} ${trailing}`);
+  return {
+    content: lines.join("\n"),
+    cursor: getCursorPosition(lines.slice(0, lineIndex + 2)) - 1,
+  };
+}
+
+function getActiveLineIndex(content: string, cursorPosition: number): number {
+  const lines = content.split("\n");
+  let count = 0;
+  for (let i = 0; i < lines.length; i++) {
+    count += lines[i].length;
+    if (count >= cursorPosition) {
+      return i;
+    }
+    count += 1;
+  }
+  return lines.length - 1;
+}
+
+function getCursorPosition(lines: string[]): number {
+  let count = 0;
+  for (const line of lines) {
+    count += line.length;
+    count += 1;
+  }
+  return count;
+}
+
+function isExportExpired(
+  rollout: Rollout | undefined,
+  taskRuns: {
+    name: string;
+    exportArchiveStatus: TaskRun_ExportArchiveStatus;
+  }[]
+) {
+  if (!rollout) {
+    return false;
+  }
+  const exportTaskRuns =
+    rollout.stages
+      .flatMap((stage) => stage.tasks)
+      .map((task) => {
+        const taskRunsForTask = taskRuns.filter(
+          (taskRun) =>
+            extractTaskUID(taskRun.name) === extractTaskUID(task.name)
+        );
+        return first(
+          orderBy(
+            taskRunsForTask,
+            (taskRun) => Number(extractTaskRunUID(taskRun.name)),
+            "desc"
+          )
+        );
+      })
+      .filter(Boolean) ?? [];
+
+  return exportTaskRuns.every(
+    (taskRun) =>
+      !!taskRun &&
+      taskRun.exportArchiveStatus === TaskRun_ExportArchiveStatus.EXPORTED
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailActivity.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailActivity.tsx
@@ -1,0 +1,14 @@
+import { useTranslation } from "react-i18next";
+
+import { IssueDetailCommentList } from "./IssueDetailCommentList";
+
+export function IssueDetailActivity() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <h3 className="text-base font-medium">{t("common.activity")}</h3>
+      <IssueDetailCommentList />
+    </div>
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
@@ -1,0 +1,652 @@
+import { create } from "@bufbuild/protobuf";
+import {
+  Check,
+  RotateCcw,
+  ShieldAlert,
+  ShieldCheck,
+  User,
+  X,
+} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { issueServiceClientConnect } from "@/connect";
+import { FeatureBadge } from "@/react/components/FeatureBadge";
+import { getAvatarColor, getInitials } from "@/react/components/UserAvatar";
+import { Button } from "@/react/components/ui/button";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import {
+  pushNotification,
+  useCurrentUserV1,
+  useGroupStore,
+  useProjectIamPolicyStore,
+  useProjectV1Store,
+  useUserStore,
+} from "@/store";
+import { projectNamePrefix, userNamePrefix } from "@/store/modules/v1/common";
+import { RiskLevel, State } from "@/types/proto-es/v1/common_pb";
+import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
+import {
+  Issue_ApprovalStatus,
+  Issue_Approver_Status,
+  RequestIssueRequestSchema,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
+import type { User as UserMessage } from "@/types/proto-es/v1/user_service_pb";
+import {
+  AccountType,
+  getAccountTypeByEmail,
+  groupBindingPrefix,
+} from "@/types/v1/user";
+import {
+  displayRoleTitle,
+  ensureUserFullName,
+  isBindingPolicyExpired,
+  memberMapToRolesInProjectIAM,
+} from "@/utils";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+
+type ApprovalStepStatus = "approved" | "rejected" | "current" | "pending";
+
+export function IssueDetailApprovalFlow() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const issue = page.issue;
+
+  useEffect(() => {
+    void projectStore
+      .getOrFetchProjectByName(projectName)
+      .catch(() => undefined);
+    void projectIamPolicyStore
+      .getOrFetchProjectIamPolicy(projectName)
+      .catch(() => undefined);
+  }, [projectIamPolicyStore, projectName, projectStore]);
+
+  if (!issue) {
+    return null;
+  }
+
+  const approvalSteps = issue.approvalTemplate?.flow?.roles ?? [];
+  const statusTag = getStatusTag(issue, approvalSteps.length, t);
+
+  return (
+    <div>
+      <div className="flex w-full flex-row flex-wrap items-center gap-2">
+        <h3 className="textinfolabel">{t("issue.approval-flow.self")}</h3>
+        <FeatureBadge feature={PlanFeature.FEATURE_APPROVAL_WORKFLOW} />
+        <ApprovalRiskLevelIcon
+          riskLevel={issue.riskLevel}
+          title={issue.approvalTemplate?.title?.trim()}
+        />
+        <div className="grow" />
+        {statusTag && (
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full px-2 py-0.5 text-xs",
+              statusTag.className
+            )}
+          >
+            {statusTag.label}
+          </span>
+        )}
+      </div>
+
+      <div className="mt-2">
+        {issue.approvalStatus === Issue_ApprovalStatus.CHECKING ? (
+          <div className="flex items-center gap-x-2 text-sm text-control-placeholder">
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-control-border border-t-accent" />
+            <span>
+              {t("custom-approval.issue-review.generating-approval-flow")}
+            </span>
+          </div>
+        ) : approvalSteps.length > 0 ? (
+          <div className="mt-1 flex flex-col gap-y-4 pl-1">
+            {approvalSteps.map((step, index) => (
+              <ApprovalStepItem
+                key={`${step}-${index}`}
+                issue={issue}
+                readonly={page.readonly}
+                step={step}
+                stepIndex={index}
+                stepNumber={index + 1}
+                totalSteps={approvalSteps.length}
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex items-center gap-x-1 text-sm text-control-placeholder">
+            {t("custom-approval.approval-flow.skip")}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ApprovalStepItem({
+  issue,
+  readonly,
+  step,
+  stepIndex,
+  stepNumber,
+  totalSteps,
+}: {
+  issue: Issue;
+  readonly: boolean;
+  step: string;
+  stepIndex: number;
+  stepNumber: number;
+  totalSteps: number;
+}) {
+  const { t } = useTranslation();
+  const {
+    canReRequest,
+    handleReRequestReview,
+    potentialApprovers,
+    reRequesting,
+    roleName,
+    showSelfApprovalTip,
+    status,
+    stepApprover,
+  } = useApprovalStep(issue, step, stepIndex);
+
+  return (
+    <div className="relative pl-9">
+      {stepIndex < totalSteps - 1 && (
+        <div className="absolute left-[13px] top-7 bottom-[-16px] w-px bg-control-border" />
+      )}
+
+      <div
+        className={cn(
+          "absolute left-0 top-0 z-10 flex h-7 w-7 items-center justify-center rounded-full",
+          status === "approved"
+            ? "bg-success"
+            : status === "rejected"
+              ? "bg-warning"
+              : status === "current"
+                ? "bg-accent"
+                : "bg-control-bg"
+        )}
+      >
+        {status === "approved" ? (
+          <Check className="h-3.5 w-3.5 text-white" />
+        ) : status === "rejected" ? (
+          <X className="h-3.5 w-3.5 text-white" />
+        ) : status === "current" ? (
+          <User className="h-3.5 w-3.5 text-white" />
+        ) : (
+          <span className="text-xs font-medium text-control">{stepNumber}</span>
+        )}
+      </div>
+
+      <div>
+        <div className="text-sm font-medium text-main">{roleName}</div>
+        <div className="mt-1 text-sm text-control-light">
+          {status === "approved" && (
+            <div className="flex flex-row items-center gap-1">
+              <span className="text-xs">
+                {t("custom-approval.issue-review.approved-by")}
+              </span>
+              {stepApprover?.principal && (
+                <ApprovalUserText candidate={stepApprover.principal} />
+              )}
+            </div>
+          )}
+
+          {status === "rejected" && (
+            <div className="flex flex-col gap-1">
+              <div className="flex flex-row items-center gap-1">
+                <span className="text-xs">
+                  {t("custom-approval.issue-review.rejected-by")}
+                </span>
+                {stepApprover?.principal && (
+                  <ApprovalUserText candidate={stepApprover.principal} />
+                )}
+              </div>
+              {canReRequest && !readonly && (
+                <div className="mt-1">
+                  <Button
+                    className="gap-x-1.5"
+                    disabled={reRequesting}
+                    onClick={() => {
+                      void handleReRequestReview();
+                    }}
+                    size="xs"
+                    variant="outline"
+                  >
+                    <RotateCcw className="h-3 w-3" />
+                    {t("custom-approval.issue-review.re-request-review")}
+                  </Button>
+                </div>
+              )}
+            </div>
+          )}
+
+          {status === "current" && !readonly && (
+            <div className="flex flex-col gap-1">
+              <PotentialApprovers users={potentialApprovers} />
+              {showSelfApprovalTip && (
+                <div className="rounded-sm border border-warning bg-warning/10 px-1 py-0.5 text-xs text-warning">
+                  {t("custom-approval.issue-review.self-approval-not-allowed")}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ApprovalUserText({ candidate }: { candidate: string }) {
+  const userStore = useUserStore();
+  const [user, setUser] = useState<UserMessage>();
+
+  useEffect(() => {
+    let canceled = false;
+
+    const load = async () => {
+      const next = await userStore.getOrFetchUserByIdentifier({
+        identifier: candidate,
+      });
+      if (canceled || !next) {
+        return;
+      }
+      if (
+        getAccountTypeByEmail(next.email) !== AccountType.USER ||
+        next.state !== State.ACTIVE
+      ) {
+        setUser(undefined);
+        return;
+      }
+      setUser(next);
+    };
+
+    void load();
+
+    return () => {
+      canceled = true;
+    };
+  }, [candidate, userStore]);
+
+  if (!user) {
+    return null;
+  }
+
+  const displayName = user.title || user.email.split("@")[0];
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-medium text-white"
+        style={{ backgroundColor: getAvatarColor(displayName) }}
+      >
+        {getInitials(displayName)}
+      </span>
+      <span className="text-xs text-control">{displayName}</span>
+    </span>
+  );
+}
+
+function PotentialApprovers({ users }: { users: UserMessage[] }) {
+  const { t } = useTranslation();
+
+  if (users.length === 0) {
+    return null;
+  }
+
+  if (users.length <= 3) {
+    return (
+      <div className="flex flex-col items-start gap-1">
+        {users.map((user) => (
+          <ApprovalCandidateRow key={user.name} user={user} />
+        ))}
+      </div>
+    );
+  }
+
+  const visibleUsers = users.slice(0, 3);
+  const names = visibleUsers
+    .map((user) => user.title || user.email.split("@")[0])
+    .join(", ");
+  const remainingCount = users.length - visibleUsers.length;
+  const triggerText = t("custom-approval.issue-review.and-n-other-users", {
+    count: remainingCount,
+    names,
+  });
+
+  return (
+    <Tooltip
+      content={
+        <div className="flex max-w-xs flex-col gap-y-1">
+          {users.map((user) => (
+            <ApprovalCandidateRow key={user.name} showEmail user={user} />
+          ))}
+        </div>
+      }
+      side="bottom"
+    >
+      <span className="cursor-pointer text-xs text-control-light hover:text-accent">
+        {triggerText}
+      </span>
+    </Tooltip>
+  );
+}
+
+function ApprovalCandidateRow({
+  showEmail = false,
+  user,
+}: {
+  showEmail?: boolean;
+  user: UserMessage;
+}) {
+  const { t } = useTranslation();
+  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const displayName = user.title || user.email.split("@")[0];
+  const isCurrentUser = currentUser?.name === user.name;
+
+  return (
+    <div className="inline-flex items-center gap-1.5">
+      <span
+        className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-medium text-white"
+        style={{ backgroundColor: getAvatarColor(displayName) }}
+      >
+        {getInitials(displayName)}
+      </span>
+      <span className="text-xs text-control">{displayName}</span>
+      {isCurrentUser && (
+        <span className="rounded-full bg-success/10 px-1.5 py-0.5 text-[10px] text-success">
+          {t("common.you")}
+        </span>
+      )}
+      {showEmail && (
+        <span className="text-xs text-control-light">{user.email}</span>
+      )}
+    </div>
+  );
+}
+
+function ApprovalRiskLevelIcon({
+  riskLevel,
+  title,
+}: {
+  riskLevel: RiskLevel;
+  title?: string;
+}) {
+  const { t } = useTranslation();
+
+  if (riskLevel === RiskLevel.RISK_LEVEL_UNSPECIFIED) {
+    return null;
+  }
+
+  const riskLevelText =
+    riskLevel === RiskLevel.LOW
+      ? t("issue.risk-level.low")
+      : riskLevel === RiskLevel.MODERATE
+        ? t("issue.risk-level.moderate")
+        : t("issue.risk-level.high");
+
+  return (
+    <Tooltip
+      content={
+        <div className="flex flex-col gap-1">
+          <div>
+            <span>{riskLevelText}</span>
+            <span className="ml-1 opacity-60">
+              ({t("issue.risk-level.self")})
+            </span>
+          </div>
+          {title && <div className="text-sm opacity-80">{title}</div>}
+        </div>
+      }
+    >
+      {riskLevel === RiskLevel.LOW ? (
+        <ShieldCheck className="h-4 w-4 text-success" />
+      ) : riskLevel === RiskLevel.MODERATE ? (
+        <ShieldAlert className="h-4 w-4 text-warning" />
+      ) : (
+        <ShieldAlert className="h-4 w-4 text-error" />
+      )}
+    </Tooltip>
+  );
+}
+
+function getStatusTag(
+  issue: Issue,
+  approvalStepCount: number,
+  t: ReturnType<typeof useTranslation>["t"]
+) {
+  if (approvalStepCount === 0) {
+    return undefined;
+  }
+  if (issue.approvalStatus === Issue_ApprovalStatus.APPROVED) {
+    return {
+      className: "bg-success/10 text-success",
+      label: t("issue.table.approved"),
+    };
+  }
+  if (issue.approvalStatus === Issue_ApprovalStatus.REJECTED) {
+    return {
+      className: "bg-warning/10 text-warning",
+      label: t("common.rejected"),
+    };
+  }
+  if (issue.approvalStatus === Issue_ApprovalStatus.PENDING) {
+    return {
+      className: "bg-accent/10 text-accent",
+      label: t("common.under-review"),
+    };
+  }
+  return undefined;
+}
+
+function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const groupStore = useGroupStore();
+  const projectStore = useProjectV1Store();
+  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const userStore = useUserStore();
+  const [potentialApprovers, setPotentialApprovers] = useState<UserMessage[]>(
+    []
+  );
+  const [reRequesting, setReRequesting] = useState(false);
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const currentUserEmail = currentUser?.email ?? "";
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+  const stepApprover = issue.approvers[stepIndex];
+
+  const status = useMemo<ApprovalStepStatus>(() => {
+    if (stepApprover?.status === Issue_Approver_Status.APPROVED) {
+      return "approved";
+    }
+    if (stepApprover?.status === Issue_Approver_Status.REJECTED) {
+      return "rejected";
+    }
+    for (let i = 0; i < stepIndex; i++) {
+      const previousApprover = issue.approvers[i];
+      if (
+        !previousApprover ||
+        (previousApprover.status !== Issue_Approver_Status.APPROVED &&
+          previousApprover.status !== Issue_Approver_Status.REJECTED)
+      ) {
+        return "pending";
+      }
+      if (previousApprover.status === Issue_Approver_Status.REJECTED) {
+        return "pending";
+      }
+    }
+    return "current";
+  }, [issue.approvers, stepApprover, stepIndex]);
+
+  const roleName = useMemo(() => {
+    return step
+      ? displayRoleTitle(step)
+      : t("custom-approval.approval-flow.node.approver");
+  }, [step, t]);
+
+  const canReRequest = useMemo(() => {
+    return (
+      issue.creator === `${userNamePrefix}${currentUserEmail}` &&
+      stepApprover?.status === Issue_Approver_Status.REJECTED
+    );
+  }, [currentUserEmail, issue.creator, stepApprover?.status]);
+
+  const groupNamesKey = useVueState(() => {
+    const policy = projectIamPolicyStore.getProjectIamPolicy(projectName);
+    const names: string[] = [];
+    for (const binding of policy.bindings) {
+      if (binding.role !== step || isBindingPolicyExpired(binding)) {
+        continue;
+      }
+      for (const member of binding.members) {
+        if (member.startsWith(groupBindingPrefix)) {
+          names.push(member);
+        }
+      }
+    }
+    return [...new Set(names)].sort().join("\u0000");
+  });
+  const groupNames = useMemo(() => {
+    return groupNamesKey ? groupNamesKey.split("\u0000") : [];
+  }, [groupNamesKey]);
+
+  useEffect(() => {
+    void groupStore.batchGetOrFetchGroups(groupNames).catch(() => undefined);
+  }, [groupNames, groupStore]);
+
+  const candidateEmailsKey = useVueState(() => {
+    const policy = projectIamPolicyStore.getProjectIamPolicy(projectName);
+    const memberMap = memberMapToRolesInProjectIAM(policy, step);
+    const candidates: string[] = [];
+    for (const fullname of memberMap.keys()) {
+      if (fullname.startsWith(userNamePrefix)) {
+        candidates.push(fullname);
+      }
+    }
+    return [...new Set(candidates)].sort().join("\u0000");
+  });
+  const candidateEmails = useMemo(() => {
+    return candidateEmailsKey ? candidateEmailsKey.split("\u0000") : [];
+  }, [candidateEmailsKey]);
+
+  const isCurrentUserInCandidates = useMemo(() => {
+    return candidateEmails.includes(`${userNamePrefix}${currentUserEmail}`);
+  }, [candidateEmails, currentUserEmail]);
+
+  const filteredCandidateEmails = useMemo(() => {
+    if (
+      !project.allowSelfApproval &&
+      issue.creator === `${userNamePrefix}${currentUserEmail}`
+    ) {
+      return candidateEmails.filter(
+        (candidate) => candidate !== `${userNamePrefix}${currentUserEmail}`
+      );
+    }
+    return candidateEmails;
+  }, [
+    candidateEmails,
+    currentUserEmail,
+    issue.creator,
+    project.allowSelfApproval,
+  ]);
+
+  const showSelfApprovalTip = useMemo(() => {
+    return (
+      status === "current" &&
+      !project.allowSelfApproval &&
+      issue.creator === `${userNamePrefix}${currentUserEmail}` &&
+      isCurrentUserInCandidates
+    );
+  }, [
+    currentUserEmail,
+    isCurrentUserInCandidates,
+    issue.creator,
+    project.allowSelfApproval,
+    status,
+  ]);
+
+  useEffect(() => {
+    let canceled = false;
+
+    const load = async () => {
+      if (status !== "current" || filteredCandidateEmails.length === 0) {
+        setPotentialApprovers([]);
+        return;
+      }
+
+      const users = await userStore.batchGetOrFetchUsers(
+        filteredCandidateEmails.map(ensureUserFullName)
+      );
+      if (canceled) {
+        return;
+      }
+
+      const next = users
+        .filter((user) => {
+          return (
+            user &&
+            user.state === State.ACTIVE &&
+            getAccountTypeByEmail(user.email) === AccountType.USER
+          );
+        })
+        .sort((left, right) => {
+          if (left.email === currentUserEmail) return -1;
+          if (right.email === currentUserEmail) return 1;
+          return left.title.localeCompare(right.title);
+        });
+      setPotentialApprovers(next);
+    };
+
+    void load();
+
+    return () => {
+      canceled = true;
+    };
+  }, [currentUserEmail, filteredCandidateEmails, status, userStore]);
+
+  const handleReRequestReview = async () => {
+    if (reRequesting) {
+      return;
+    }
+
+    try {
+      setReRequesting(true);
+      const response = await issueServiceClientConnect.requestIssue(
+        create(RequestIssueRequestSchema, {
+          name: issue.name,
+        })
+      );
+      page.patchState({ issue: response });
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: t("custom-approval.issue-review.re-request-review-success"),
+      });
+    } catch (error) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.failed"),
+        description: String(error),
+      });
+    } finally {
+      setReRequesting(false);
+    }
+  };
+
+  return {
+    canReRequest,
+    handleReRequestReview,
+    potentialApprovers,
+    reRequesting,
+    roleName,
+    showSelfApprovalTip,
+    status,
+    stepApprover,
+  };
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailBranchContent.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailBranchContent.tsx
@@ -1,0 +1,60 @@
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+import { IssueDetailAccessGrantView } from "./IssueDetailAccessGrantView";
+import { IssueDetailDatabaseChangeView } from "./IssueDetailDatabaseChangeView";
+import { IssueDetailDatabaseCreateView } from "./IssueDetailDatabaseCreateView";
+import { IssueDetailDatabaseExportView } from "./IssueDetailDatabaseExportView";
+import { IssueDetailRoleGrantView } from "./IssueDetailRoleGrantView";
+
+export function IssueDetailBranchContent({
+  databaseChangeSelectedSpecId,
+  databaseExportExecutionHistoryExpanded,
+  databaseExportTasksExpanded,
+  onDatabaseChangeSelectedSpecIdChange,
+  onDatabaseExportExecutionHistoryExpandedChange,
+  onDatabaseExportTasksExpandedChange,
+}: {
+  databaseChangeSelectedSpecId: string;
+  databaseExportExecutionHistoryExpanded: boolean;
+  databaseExportTasksExpanded: boolean;
+  onDatabaseChangeSelectedSpecIdChange: (specId: string) => void;
+  onDatabaseExportExecutionHistoryExpandedChange: (expanded: boolean) => void;
+  onDatabaseExportTasksExpandedChange: (expanded: boolean) => void;
+}) {
+  const page = useIssueDetailContext();
+
+  if (page.issueType === "ROLE_GRANT") {
+    return <IssueDetailRoleGrantView />;
+  }
+
+  if (page.issueType === "ACCESS_GRANT") {
+    return <IssueDetailAccessGrantView />;
+  }
+
+  if (page.issueType === "CREATE_DATABASE") {
+    return <IssueDetailDatabaseCreateView />;
+  }
+
+  if (page.issueType === "EXPORT_DATA") {
+    return (
+      <IssueDetailDatabaseExportView
+        executionHistoryExpanded={databaseExportExecutionHistoryExpanded}
+        onExecutionHistoryExpandedChange={
+          onDatabaseExportExecutionHistoryExpandedChange
+        }
+        onTasksExpandedChange={onDatabaseExportTasksExpandedChange}
+        tasksExpanded={databaseExportTasksExpanded}
+      />
+    );
+  }
+
+  if (page.issueType === "DATABASE_CHANGE") {
+    return (
+      <IssueDetailDatabaseChangeView
+        onSelectedSpecIdChange={onDatabaseChangeSelectedSpecIdChange}
+        selectedSpecId={databaseChangeSelectedSpecId}
+      />
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailChecks.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailChecks.tsx
@@ -1,0 +1,853 @@
+import { create } from "@bufbuild/protobuf";
+import type { Timestamp as TimestampPb } from "@bufbuild/protobuf/wkt";
+import {
+  AlertCircle,
+  CheckCircle,
+  CircleQuestionMark,
+  FileCode,
+  Loader2,
+  Play,
+  SearchCode,
+  Shield,
+  XCircle,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { planServiceClientConnect } from "@/connect";
+import { Button } from "@/react/components/ui/button";
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/react/components/ui/sheet";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import { pushNotification, useCurrentUserV1, useProjectV1Store } from "@/store";
+import { extractUserEmail, projectNamePrefix } from "@/store/modules/v1/common";
+import {
+  getDateForPbTimestampProtoEs,
+  getRuleLocalization,
+  ruleTemplateMapV2,
+  ruleTypeToString,
+} from "@/types";
+import {
+  GetPlanCheckRunRequestSchema,
+  GetPlanRequestSchema,
+  type PlanCheckRun,
+  type PlanCheckRun_Result,
+  PlanCheckRun_Result_Type,
+  PlanCheckRun_ResultSchema,
+  PlanCheckRun_Status,
+  RunPlanChecksRequestSchema,
+} from "@/types/proto-es/v1/plan_service_pb";
+import { SQLReviewRule_Type } from "@/types/proto-es/v1/review_config_service_pb";
+import { Advice_Level } from "@/types/proto-es/v1/sql_service_pb";
+import { hasProjectPermissionV2 } from "@/utils";
+import { extractDatabaseResourceName } from "@/utils/v1/database";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+
+interface ResultGroup {
+  key: string;
+  type: PlanCheckRun_Result_Type;
+  target: string;
+  createTime?: TimestampPb;
+  results: PlanCheckRun_Result[];
+}
+
+const PAGE_SIZE = 10;
+
+export function IssueDetailChecks() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const [isRunningChecks, setIsRunningChecks] = useState(false);
+  const [selectedResultStatus, setSelectedResultStatus] = useState<
+    Advice_Level | undefined
+  >();
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+  const summary = useMemo(() => getPlanCheckSummary(page), [page]);
+  const hasAnyChecks = summary.total > 0;
+  const allowRunChecks = useMemo(() => {
+    if (!page.plan) {
+      return false;
+    }
+    if (extractUserEmail(page.plan.creator) === currentUser.email) {
+      return true;
+    }
+    return hasProjectPermissionV2(project, "bb.planCheckRuns.run");
+  }, [currentUser.email, page.plan, project]);
+
+  const refreshChecks = useCallback(async () => {
+    if (!page.plan) {
+      return [];
+    }
+    const nextPlan = await planServiceClientConnect.getPlan(
+      create(GetPlanRequestSchema, {
+        name: page.plan.name,
+      })
+    );
+
+    let nextPlanCheckRuns: PlanCheckRun[] = [];
+    try {
+      const response = await planServiceClientConnect.getPlanCheckRun(
+        create(GetPlanCheckRunRequestSchema, {
+          name: `${page.plan.name}/planCheckRun`,
+        })
+      );
+      nextPlanCheckRuns = [response];
+    } catch {
+      nextPlanCheckRuns = [];
+    }
+
+    page.patchState({
+      plan: nextPlan,
+      planCheckRuns: nextPlanCheckRuns,
+    });
+    return nextPlanCheckRuns;
+  }, [page.plan]);
+
+  const runChecks = useCallback(async () => {
+    if (!page.plan?.name) {
+      return;
+    }
+
+    try {
+      setIsRunningChecks(true);
+      await planServiceClientConnect.runPlanChecks(
+        create(RunPlanChecksRequestSchema, {
+          name: page.plan.name,
+        })
+      );
+      await refreshChecks();
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: t("plan.checks.started"),
+      });
+    } catch (error) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("plan.checks.failed-to-run"),
+        description: String(error),
+      });
+    } finally {
+      setIsRunningChecks(false);
+    }
+  }, [page.plan?.name, refreshChecks, t]);
+
+  if (!page.plan) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-y-1">
+      <div className="flex items-center justify-between">
+        <h3 className="textlabel">{t("plan.navigator.checks")}</h3>
+        {allowRunChecks && (
+          <Button
+            disabled={isRunningChecks}
+            onClick={() => {
+              void runChecks();
+            }}
+            size="xs"
+            variant="outline"
+          >
+            <Play className="h-3.5 w-3.5" />
+            {t("plan.run")}
+          </Button>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {hasAnyChecks && (
+          <IssueDetailChecksStatusCount
+            selectedStatus={selectedResultStatus}
+            summary={summary}
+            onSelectStatus={setSelectedResultStatus}
+          />
+        )}
+        {!hasAnyChecks && (
+          <span className="text-sm text-control-placeholder">
+            {t("plan.overview.no-checks")}
+          </span>
+        )}
+      </div>
+
+      <IssueDetailChecksDialog
+        onClose={() => setSelectedResultStatus(undefined)}
+        open={selectedResultStatus !== undefined}
+        planCheckRuns={page.planCheckRuns}
+        refreshChecks={refreshChecks}
+        status={selectedResultStatus}
+      />
+    </div>
+  );
+}
+
+function IssueDetailChecksStatusCount({
+  onSelectStatus,
+  selectedStatus,
+  summary,
+}: {
+  onSelectStatus: (status: Advice_Level | undefined) => void;
+  selectedStatus?: Advice_Level;
+  summary: PlanCheckSummary;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-3">
+      {summary.running > 0 && (
+        <div className="flex items-center gap-1 text-control">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span>{t("task.status.running")}</span>
+        </div>
+      )}
+      {summary.error > 0 && (
+        <button
+          className={cn(
+            "flex items-center gap-1 text-error",
+            selectedStatus === Advice_Level.ERROR
+              ? "rounded-lg bg-gray-100 px-2 py-1"
+              : selectedStatus !== undefined
+                ? "px-2 py-1"
+                : ""
+          )}
+          onClick={() =>
+            onSelectStatus(
+              selectedStatus === Advice_Level.ERROR
+                ? undefined
+                : Advice_Level.ERROR
+            )
+          }
+          type="button"
+        >
+          <XCircle className="h-5 w-5" />
+          <span>{summary.error}</span>
+        </button>
+      )}
+      {summary.warning > 0 && (
+        <button
+          className={cn(
+            "flex items-center gap-1 text-warning",
+            selectedStatus === Advice_Level.WARNING
+              ? "rounded-lg bg-gray-100 px-2 py-1"
+              : selectedStatus !== undefined
+                ? "px-2 py-1"
+                : ""
+          )}
+          onClick={() =>
+            onSelectStatus(
+              selectedStatus === Advice_Level.WARNING
+                ? undefined
+                : Advice_Level.WARNING
+            )
+          }
+          type="button"
+        >
+          <AlertCircle className="h-5 w-5" />
+          <span>{summary.warning}</span>
+        </button>
+      )}
+      {summary.success > 0 && (
+        <button
+          className={cn(
+            "flex items-center gap-1 text-success",
+            selectedStatus === Advice_Level.SUCCESS
+              ? "rounded-lg bg-gray-100 px-2 py-1"
+              : selectedStatus !== undefined
+                ? "px-2 py-1"
+                : ""
+          )}
+          onClick={() =>
+            onSelectStatus(
+              selectedStatus === Advice_Level.SUCCESS
+                ? undefined
+                : Advice_Level.SUCCESS
+            )
+          }
+          type="button"
+        >
+          <CheckCircle className="h-5 w-5" />
+          <span>{summary.success}</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function IssueDetailChecksDialog({
+  onClose,
+  open,
+  planCheckRuns,
+  refreshChecks,
+  status,
+}: {
+  onClose: () => void;
+  open: boolean;
+  planCheckRuns: PlanCheckRun[];
+  refreshChecks: () => Promise<PlanCheckRun[]>;
+  status?: Advice_Level;
+}) {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+  const [resolvedPlanCheckRuns, setResolvedPlanCheckRuns] =
+    useState<PlanCheckRun[]>(planCheckRuns);
+
+  useEffect(() => {
+    setResolvedPlanCheckRuns(planCheckRuns);
+  }, [planCheckRuns]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    let canceled = false;
+
+    const load = async () => {
+      try {
+        setIsLoading(true);
+        const runs = await refreshChecks();
+        if (!canceled) {
+          setResolvedPlanCheckRuns(runs);
+        }
+      } finally {
+        if (!canceled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      canceled = true;
+    };
+  }, [open, refreshChecks]);
+
+  return (
+    <Sheet onOpenChange={(nextOpen) => !nextOpen && onClose()} open={open}>
+      <SheetContent
+        className="w-[calc(100vw-2rem)] max-w-[calc(100vw-2rem)] sm:max-w-[40rem]"
+        width="standard"
+      >
+        <SheetHeader>
+          <SheetTitle>{t("plan.navigator.checks")}</SheetTitle>
+        </SheetHeader>
+        <SheetBody className="py-4">
+          <IssueDetailChecksView
+            defaultStatus={status}
+            isLoading={isLoading}
+            planCheckRuns={resolvedPlanCheckRuns}
+          />
+        </SheetBody>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function IssueDetailChecksView({
+  defaultStatus,
+  isLoading = false,
+  planCheckRuns,
+}: {
+  defaultStatus?: Advice_Level;
+  isLoading?: boolean;
+  planCheckRuns: PlanCheckRun[];
+}) {
+  const { t } = useTranslation();
+  const [selectedStatus, setSelectedStatus] = useState<
+    Advice_Level | undefined
+  >(defaultStatus);
+  const [displayCount, setDisplayCount] = useState(PAGE_SIZE);
+
+  useEffect(() => {
+    setSelectedStatus(defaultStatus);
+  }, [defaultStatus]);
+
+  const summary = useMemo(
+    () => computePlanCheckStatusSummary(planCheckRuns),
+    [planCheckRuns]
+  );
+  const hasAnyStatus = summary.total > 0;
+  const hasFilters = selectedStatus !== undefined;
+  const filteredResultGroups = useMemo(
+    () => buildFilteredResultGroups(planCheckRuns, selectedStatus),
+    [planCheckRuns, selectedStatus]
+  );
+  const displayedResultGroups = filteredResultGroups.slice(0, displayCount);
+  const hasMore = filteredResultGroups.length > displayCount;
+  const remainingCount = filteredResultGroups.length - displayCount;
+
+  useEffect(() => {
+    setDisplayCount(PAGE_SIZE);
+  }, [selectedStatus]);
+
+  return (
+    <div className="flex flex-1 flex-col">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          {hasAnyStatus && (
+            <div className="flex items-center gap-3">
+              {summary.error > 0 && (
+                <button
+                  className={cn(
+                    "flex items-center gap-1 text-error",
+                    selectedStatus === Advice_Level.ERROR
+                      ? "rounded-lg bg-gray-100 px-2 py-1"
+                      : "px-2 py-1"
+                  )}
+                  onClick={() =>
+                    setSelectedStatus((current) =>
+                      current === Advice_Level.ERROR
+                        ? undefined
+                        : Advice_Level.ERROR
+                    )
+                  }
+                  type="button"
+                >
+                  <XCircle className="h-5 w-5" />
+                  <span>{t("common.error")}</span>
+                  <span>{summary.error}</span>
+                </button>
+              )}
+              {summary.warning > 0 && (
+                <button
+                  className={cn(
+                    "flex items-center gap-1 text-warning",
+                    selectedStatus === Advice_Level.WARNING
+                      ? "rounded-lg bg-gray-100 px-2 py-1"
+                      : "px-2 py-1"
+                  )}
+                  onClick={() =>
+                    setSelectedStatus((current) =>
+                      current === Advice_Level.WARNING
+                        ? undefined
+                        : Advice_Level.WARNING
+                    )
+                  }
+                  type="button"
+                >
+                  <AlertCircle className="h-5 w-5" />
+                  <span>{t("common.warning")}</span>
+                  <span>{summary.warning}</span>
+                </button>
+              )}
+              {summary.success > 0 && (
+                <button
+                  className={cn(
+                    "flex items-center gap-1 text-success",
+                    selectedStatus === Advice_Level.SUCCESS
+                      ? "rounded-lg bg-gray-100 px-2 py-1"
+                      : "px-2 py-1"
+                  )}
+                  onClick={() =>
+                    setSelectedStatus((current) =>
+                      current === Advice_Level.SUCCESS
+                        ? undefined
+                        : Advice_Level.SUCCESS
+                    )
+                  }
+                  type="button"
+                >
+                  <CheckCircle className="h-5 w-5" />
+                  <span>{t("common.success")}</span>
+                  <span>{summary.success}</span>
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center py-12">
+            <Loader2 className="h-5 w-5 animate-spin text-control-light" />
+          </div>
+        ) : filteredResultGroups.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12">
+            <CheckCircle className="mb-4 h-12 w-12 text-control-light opacity-50" />
+            <div className="text-lg text-control-light">
+              {hasFilters
+                ? t("plan.checks.no-results-match-filters")
+                : t("plan.checks.no-check-results")}
+            </div>
+          </div>
+        ) : (
+          <div>
+            <div className="divide-y">
+              {displayedResultGroups.map((group) => (
+                <div key={group.key} className="px-2 py-4">
+                  <div className="mb-2 flex flex-wrap items-start justify-between gap-2">
+                    <div className="flex shrink-0 items-center gap-3">
+                      <CheckTypeIcon
+                        className="h-5 w-5 text-control-light"
+                        type={group.type}
+                      />
+                      <div className="flex flex-row items-center gap-2">
+                        <span className="text-sm font-medium">
+                          {getCheckTypeLabel(group.type, t)}
+                        </span>
+                        {getCheckTypeDescription(group.type, t) && (
+                          <Tooltip
+                            content={getCheckTypeDescription(group.type, t)}
+                          >
+                            <CircleQuestionMark className="h-4 w-4 text-control-light" />
+                          </Tooltip>
+                        )}
+                        {group.createTime && (
+                          <span className="text-sm text-control-light">
+                            {formatTimestamp(group.createTime)}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {group.target && (
+                      <div className="min-w-0 max-w-[50%] truncate text-sm text-control-light">
+                        {formatCheckTarget(group.target)}
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex flex-col gap-y-2 pl-8">
+                    {group.results.map((result, index) => (
+                      <IssueDetailCheckResultCard
+                        key={`${group.key}-${index}`}
+                        affectedRows={
+                          result.report?.case === "sqlSummaryReport"
+                            ? result.report.value.affectedRows
+                            : undefined
+                        }
+                        code={result.code}
+                        content={result.content}
+                        position={
+                          result.report?.case === "sqlReviewReport" &&
+                          result.report.value.startPosition
+                            ? result.report.value.startPosition
+                            : undefined
+                        }
+                        reportType={result.report?.case}
+                        status={getCheckResultStatus(result.status)}
+                        title={result.title}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {hasMore && (
+              <div className="flex justify-center py-4">
+                <button
+                  className="text-sm text-accent hover:underline"
+                  onClick={() =>
+                    setDisplayCount((current) => current + PAGE_SIZE)
+                  }
+                  type="button"
+                >
+                  {t("common.load-more")} ({remainingCount})
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailCheckResultCard({
+  affectedRows,
+  code,
+  content,
+  position,
+  reportType,
+  status,
+  title,
+}: {
+  affectedRows?: bigint;
+  code?: number;
+  content?: string;
+  position?: { line: number; column: number };
+  reportType?: "sqlReviewReport" | "sqlSummaryReport";
+  status: "SUCCESS" | "WARNING" | "ERROR";
+  title: string;
+}) {
+  const { t } = useTranslation();
+  const displayTitle = useMemo(
+    () => getCheckResultTitle(title, code, reportType),
+    [code, reportType, title]
+  );
+
+  return (
+    <div className="flex items-start gap-3 rounded-lg border bg-gray-50 px-3 py-2">
+      {status === "ERROR" ? (
+        <XCircle className="h-5 w-5 shrink-0 text-error" />
+      ) : status === "WARNING" ? (
+        <AlertCircle className="h-5 w-5 shrink-0 text-warning" />
+      ) : (
+        <CheckCircle className="h-5 w-5 shrink-0 text-success" />
+      )}
+
+      <div className="flex min-w-0 flex-1 flex-col gap-y-1">
+        <div className="text-sm font-medium text-main">{displayTitle}</div>
+        {content && <div className="text-sm text-control">{content}</div>}
+        {position && (position.line > 0 || position.column > 0) && (
+          <div className="mt-1 text-sm text-control-light">
+            {position.line > 0 && (
+              <span>
+                {t("common.line")} {position.line}
+              </span>
+            )}
+            {position.line > 0 && position.column > 0 && <span>, </span>}
+            {position.column > 0 && (
+              <span>
+                {t("common.column")} {position.column}
+              </span>
+            )}
+          </div>
+        )}
+        {affectedRows !== undefined && (
+          <div className="mt-1 flex items-center gap-1 text-sm">
+            <span className="inline-flex items-center rounded-full bg-white px-2 py-0.5 text-xs text-control">
+              {t("task.check-type.affected-rows.self")}
+            </span>
+            <span>{String(affectedRows)}</span>
+            <span className="text-control opacity-80">
+              ({t("task.check-type.affected-rows.description")})
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface PlanCheckSummary {
+  running: number;
+  success: number;
+  warning: number;
+  error: number;
+  total: number;
+}
+
+function getPlanCheckSummary(
+  page: ReturnType<typeof useIssueDetailContext>
+): PlanCheckSummary {
+  if (page.planCheckRuns.length > 0) {
+    return computePlanCheckStatusSummary(page.planCheckRuns);
+  }
+
+  const statusCount = page.plan?.planCheckRunStatusCount || {};
+  const running =
+    statusCount[PlanCheckRun_Status[PlanCheckRun_Status.RUNNING]] || 0;
+  const success = statusCount[Advice_Level[Advice_Level.SUCCESS]] || 0;
+  const warning = statusCount[Advice_Level[Advice_Level.WARNING]] || 0;
+  const error =
+    (statusCount[Advice_Level[Advice_Level.ERROR]] || 0) +
+    (statusCount[PlanCheckRun_Status[PlanCheckRun_Status.FAILED]] || 0);
+  const total = running + success + warning + error;
+  return { running, success, warning, error, total };
+}
+
+function computePlanCheckStatusSummary(runs: PlanCheckRun[]): PlanCheckSummary {
+  let running = 0;
+  let success = 0;
+  let warning = 0;
+  let error = 0;
+
+  for (const checkRun of runs) {
+    if (checkRun.status === PlanCheckRun_Status.RUNNING) {
+      running++;
+    }
+    if (checkRun.status === PlanCheckRun_Status.FAILED) {
+      error++;
+    }
+    for (const result of checkRun.results) {
+      if (result.status === Advice_Level.ERROR) {
+        error++;
+      } else if (result.status === Advice_Level.WARNING) {
+        warning++;
+      } else if (result.status === Advice_Level.SUCCESS) {
+        success++;
+      }
+    }
+  }
+
+  return {
+    error,
+    running,
+    success,
+    total: running + success + warning + error,
+    warning,
+  };
+}
+
+function buildFilteredResultGroups(
+  planCheckRuns: PlanCheckRun[],
+  selectedStatus?: Advice_Level
+) {
+  const groups: ResultGroup[] = [];
+  const groupMap = new Map<string, ResultGroup>();
+
+  for (const checkRun of planCheckRuns) {
+    if (
+      checkRun.status === PlanCheckRun_Status.FAILED &&
+      (selectedStatus === undefined || selectedStatus === Advice_Level.ERROR)
+    ) {
+      groups.push({
+        createTime: checkRun.createTime,
+        key: `failed-${checkRun.name}`,
+        results: [
+          create(PlanCheckRun_ResultSchema, {
+            code: 0,
+            content: checkRun.error || "Plan check run failed",
+            status: Advice_Level.ERROR,
+            title: "Check Failed",
+          }),
+        ],
+        target: "",
+        type: PlanCheckRun_Result_Type.TYPE_UNSPECIFIED,
+      });
+    }
+
+    for (const result of checkRun.results) {
+      if (selectedStatus !== undefined && result.status !== selectedStatus) {
+        continue;
+      }
+
+      const key = `${result.type}-${result.target}`;
+      const group = groupMap.get(key) ?? {
+        createTime: checkRun.createTime,
+        key,
+        results: [],
+        target: result.target,
+        type: result.type,
+      };
+      group.results.push(result);
+      if (!groupMap.has(key)) {
+        groupMap.set(key, group);
+        groups.push(group);
+      }
+    }
+  }
+
+  return groups;
+}
+
+function CheckTypeIcon({
+  className,
+  type,
+}: {
+  className?: string;
+  type: PlanCheckRun_Result_Type;
+}) {
+  const Icon =
+    type === PlanCheckRun_Result_Type.STATEMENT_ADVISE
+      ? SearchCode
+      : type === PlanCheckRun_Result_Type.STATEMENT_SUMMARY_REPORT
+        ? FileCode
+        : type === PlanCheckRun_Result_Type.GHOST_SYNC
+          ? Shield
+          : FileCode;
+  return <Icon className={className} />;
+}
+
+function getCheckTypeLabel(
+  type: PlanCheckRun_Result_Type,
+  t: ReturnType<typeof useTranslation>["t"]
+) {
+  if (type === PlanCheckRun_Result_Type.STATEMENT_ADVISE) {
+    return t("task.check-type.sql-review.self");
+  }
+  if (type === PlanCheckRun_Result_Type.STATEMENT_SUMMARY_REPORT) {
+    return t("task.check-type.summary-report");
+  }
+  if (type === PlanCheckRun_Result_Type.GHOST_SYNC) {
+    return t("task.check-type.ghost-sync");
+  }
+  return String(type);
+}
+
+function getCheckTypeDescription(
+  type: PlanCheckRun_Result_Type,
+  t: ReturnType<typeof useTranslation>["t"]
+) {
+  if (type === PlanCheckRun_Result_Type.STATEMENT_ADVISE) {
+    return t("task.check-type.sql-review.description");
+  }
+  return undefined;
+}
+
+function getCheckResultStatus(
+  status: Advice_Level
+): "SUCCESS" | "WARNING" | "ERROR" {
+  if (status === Advice_Level.ERROR) {
+    return "ERROR";
+  }
+  if (status === Advice_Level.WARNING) {
+    return "WARNING";
+  }
+  return "SUCCESS";
+}
+
+function getCheckResultTitle(
+  title: string,
+  code?: number,
+  reportType?: "sqlReviewReport" | "sqlSummaryReport"
+) {
+  const messageWithCode = (message: string) => {
+    if (code !== undefined && code !== 0) {
+      return `${message} #${code}`;
+    }
+    return message;
+  };
+
+  if (title === "OK" || title === "Syntax error") {
+    return messageWithCode(title);
+  }
+
+  if (reportType === "sqlReviewReport") {
+    if (!code) {
+      return title;
+    }
+    const typeKey = title as keyof typeof SQLReviewRule_Type;
+    const typeEnum = SQLReviewRule_Type[typeKey];
+    if (typeEnum !== undefined) {
+      for (const mapByType of ruleTemplateMapV2.values()) {
+        const rule = mapByType.get(typeEnum);
+        if (rule) {
+          return messageWithCode(
+            getRuleLocalization(ruleTypeToString(rule.type), rule.engine).title
+          );
+        }
+      }
+    } else if (title.startsWith("builtin.")) {
+      return messageWithCode(getRuleLocalization(title).title);
+    }
+  }
+
+  return messageWithCode(title);
+}
+
+function formatTimestamp(timestamp: TimestampPb) {
+  return getDateForPbTimestampProtoEs(timestamp)?.toLocaleString() ?? "";
+}
+
+function formatCheckTarget(target: string) {
+  if (!target) {
+    return "";
+  }
+  try {
+    return extractDatabaseResourceName(target).databaseName;
+  } catch {
+    return target;
+  }
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailCommentList.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailCommentList.tsx
@@ -1,0 +1,1272 @@
+import { create } from "@bufbuild/protobuf";
+import DOMPurify from "dompurify";
+import {
+  Bold,
+  Code2,
+  Hash,
+  Heading1,
+  Link2,
+  Loader2,
+  Pencil,
+  Play,
+  Plus,
+  ThumbsUp,
+} from "lucide-react";
+import MarkdownIt from "markdown-it";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { issueServiceClientConnect } from "@/connect";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
+import { ReadonlyDiffMonaco } from "@/react/components/monaco";
+import { UserAvatar } from "@/react/components/UserAvatar";
+import { Button } from "@/react/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/react/components/ui/dialog";
+import { Textarea } from "@/react/components/ui/textarea";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import { router } from "@/router";
+import { PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL } from "@/router/dashboard/projectV1";
+import {
+  extractUserEmail,
+  getIssueCommentType,
+  IssueCommentType,
+  pushNotification,
+  useCurrentUserV1,
+  useIssueCommentStore,
+  useProjectV1Store,
+  useSheetV1Store,
+  useUserStore,
+} from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import { getTimeForPbTimestampProtoEs, unknownUser } from "@/types";
+import {
+  type IssueComment,
+  IssueComment_Approval_Status,
+  IssueSchema,
+  IssueStatus,
+  ListIssueCommentsRequestSchema,
+  UpdateIssueRequestSchema,
+} from "@/types/proto-es/v1/issue_service_pb";
+import type { User } from "@/types/proto-es/v1/user_service_pb";
+import {
+  extractPlanUID,
+  extractProjectResourceName,
+  getSpecDisplayInfo,
+} from "@/utils";
+import { hasProjectPermissionV2 } from "@/utils/iam/permission";
+import { getSheetStatement } from "@/utils/v1/sheet";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+
+const markdown = new MarkdownIt({
+  html: true,
+  linkify: true,
+});
+
+export function IssueDetailCommentList() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const userStore = useUserStore();
+  const issueCommentStore = useIssueCommentStore();
+  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const routeHash = useVueState(() => router.currentRoute.value.hash);
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+  const issueName = page.issue?.name || page.plan?.issue || "";
+  const issueComments = useVueState(() =>
+    issueName ? issueCommentStore.getIssueComments(issueName) : []
+  );
+  const issueUpdateKey = `${page.issue?.updateTime?.seconds ?? ""}:${page.issue?.updateTime?.nanos ?? ""}`;
+  const [activeCommentName, setActiveCommentName] = useState<string>();
+  const [editContent, setEditContent] = useState("");
+  const [newComment, setNewComment] = useState("");
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const allowCreateComment = Boolean(
+    project && hasProjectPermissionV2(project, "bb.issueComments.create")
+  );
+  const activeComment = useMemo(
+    () => issueComments.find((comment) => comment.name === activeCommentName),
+    [activeCommentName, issueComments]
+  );
+  const allowUpdateComment = Boolean(
+    activeComment && editContent && editContent !== activeComment.comment
+  );
+
+  useEffect(() => {
+    page.setEditing("comment-row", Boolean(activeCommentName));
+    return () => {
+      page.setEditing("comment-row", false);
+    };
+  }, [activeCommentName, page]);
+
+  useEffect(() => {
+    if (!issueName) {
+      return;
+    }
+    let canceled = false;
+    const run = async () => {
+      try {
+        setIsRefreshing(true);
+        await issueCommentStore.listIssueComments(
+          create(ListIssueCommentsRequestSchema, {
+            parent: issueName,
+            pageSize: 1000,
+          })
+        );
+      } finally {
+        if (!canceled) {
+          setIsRefreshing(false);
+        }
+      }
+    };
+    void run();
+    return () => {
+      canceled = true;
+    };
+  }, [issueCommentStore, issueName, issueUpdateKey]);
+
+  useEffect(() => {
+    if (!routeHash.match(/^#activity(\d+)/)) {
+      return;
+    }
+    const elem =
+      document.querySelector(routeHash) || document.querySelector("#activity");
+    const timer = window.setTimeout(() => elem?.scrollIntoView());
+    return () => window.clearTimeout(timer);
+  }, [routeHash]);
+
+  useEffect(() => {
+    const identifiers = new Set<string>();
+    if (page.issue?.creator) {
+      identifiers.add(page.issue.creator);
+    }
+    for (const comment of issueComments) {
+      if (comment.creator) {
+        identifiers.add(comment.creator);
+      }
+    }
+    if (identifiers.size === 0) {
+      return;
+    }
+    void userStore.batchGetOrFetchUsers([...identifiers]);
+  }, [issueComments, page.issue?.creator, userStore]);
+
+  const refreshIssueComments = async () => {
+    if (!issueName) {
+      return;
+    }
+    await issueCommentStore.listIssueComments(
+      create(ListIssueCommentsRequestSchema, {
+        parent: issueName,
+        pageSize: 1000,
+      })
+    );
+  };
+
+  const allowEditComment = (comment: IssueComment): boolean => {
+    if (!project) {
+      return false;
+    }
+    const commentType = getIssueCommentType(comment);
+    const isEditable =
+      commentType === IssueCommentType.USER_COMMENT ||
+      (commentType === IssueCommentType.APPROVAL && comment.comment !== "");
+    if (!isEditable) {
+      return false;
+    }
+    if (currentUser.email === extractUserEmail(comment.creator)) {
+      return true;
+    }
+    return hasProjectPermissionV2(project, "bb.issueComments.update");
+  };
+
+  const startEditComment = (comment: IssueComment) => {
+    setActiveCommentName(comment.name);
+    setEditContent(comment.comment);
+  };
+
+  const cancelEditComment = () => {
+    setActiveCommentName(undefined);
+    setEditContent("");
+  };
+
+  const saveEditComment = async () => {
+    if (!activeComment || !allowUpdateComment) {
+      return;
+    }
+    await issueCommentStore.updateIssueComment({
+      issueCommentName: activeComment.name,
+      comment: editContent,
+    });
+    cancelEditComment();
+    await refreshIssueComments();
+  };
+
+  const createComment = async () => {
+    if (!issueName || !newComment) {
+      return;
+    }
+    await issueCommentStore.createIssueComment({
+      issueName,
+      comment: newComment,
+    });
+    setNewComment("");
+    await refreshIssueComments();
+  };
+
+  return (
+    <div className="flex flex-col">
+      <ul>
+        <IssueDescriptionCommentRow
+          issueComments={issueComments}
+          onRefresh={refreshIssueComments}
+        />
+        {issueComments.map((item, index) => {
+          const isEditing = activeCommentName === item.name;
+          return (
+            <IssueCommentRow
+              key={item.name}
+              isLast={index === issueComments.length - 1}
+              issueComment={item}
+              comment={
+                item.comment ? (
+                  <EditableMarkdownContent
+                    allowSave={allowUpdateComment}
+                    content={item.comment}
+                    editContent={editContent}
+                    isEditing={isEditing}
+                    onCancel={cancelEditComment}
+                    onChange={setEditContent}
+                    onSave={() => {
+                      void saveEditComment();
+                    }}
+                    placeholder={t("issue.no-description-provided")}
+                    projectName={project?.name}
+                  />
+                ) : null
+              }
+              subjectSuffix={
+                allowEditComment(item) && !activeCommentName ? (
+                  <Button
+                    className="text-gray-500 hover:text-gray-700"
+                    onClick={() => startEditComment(item)}
+                    size="xs"
+                    variant="ghost"
+                  >
+                    <Pencil className="h-3.5 w-3.5" />
+                  </Button>
+                ) : null
+              }
+            />
+          );
+        })}
+      </ul>
+
+      {!activeCommentName && allowCreateComment && (
+        <div className="mt-2">
+          <div className="flex gap-3">
+            <div className="shrink-0 pt-1">
+              <UserAvatar
+                size="sm"
+                title={currentUser.title || currentUser.email}
+              />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="sr-only" id="issue-comment-editor">
+                {t("common.comment")}
+              </h3>
+              <IssueDetailMarkdownEditor
+                content={newComment}
+                onChange={setNewComment}
+                onSubmit={() => {
+                  void createComment();
+                }}
+                placeholder={t("issue.leave-a-comment")}
+                projectName={project?.name}
+              />
+              <div className="mt-3 flex items-center justify-end">
+                <Button
+                  disabled={newComment.length === 0}
+                  onClick={() => {
+                    void createComment();
+                  }}
+                  size="sm"
+                  type="button"
+                >
+                  {t("common.comment")}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+      {isRefreshing && issueComments.length === 0 && (
+        <div className="mt-3 flex items-center justify-center text-sm text-control-light">
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          {t("common.loading")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IssueDescriptionCommentRow({
+  issueComments,
+  onRefresh,
+}: {
+  issueComments: IssueComment[];
+  onRefresh: () => Promise<void>;
+}) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const userStore = useUserStore();
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+  const creator = useVueState(
+    () =>
+      userStore.getUserByIdentifier(page.issue?.creator || "") ??
+      unknownUser(page.issue?.creator || "")
+  );
+  const [isEditing, setIsEditing] = useState(false);
+  const [editContent, setEditContent] = useState(page.issue?.description || "");
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setEditContent(page.issue?.description || "");
+    }
+  }, [isEditing, page.issue?.description]);
+
+  useEffect(() => {
+    page.setEditing("issue-description", isEditing);
+    return () => {
+      page.setEditing("issue-description", false);
+    };
+  }, [isEditing, page]);
+
+  const allowEdit = Boolean(
+    project && hasProjectPermissionV2(project, "bb.issues.update")
+  );
+  const allowSave = editContent !== (page.issue?.description || "");
+
+  const saveEdit = async () => {
+    if (!allowSave || !page.issue) {
+      return;
+    }
+    try {
+      setIsSaving(true);
+      const issuePatch = create(IssueSchema, {
+        name: page.issue.name,
+        description: editContent,
+      });
+      const request = create(UpdateIssueRequestSchema, {
+        issue: issuePatch,
+        updateMask: { paths: ["description"] },
+      });
+      const response = await issueServiceClientConnect.updateIssue(request);
+      page.patchState({ issue: response });
+      setIsEditing(false);
+      await onRefresh();
+    } catch (error) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.failed"),
+        description: String(error),
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <li>
+      <div className="relative pb-4">
+        {issueComments.length > 0 && (
+          <span
+            aria-hidden="true"
+            className="absolute left-4 -ml-px h-full w-0.5 bg-block-border"
+          />
+        )}
+        <div className="relative flex items-start">
+          <div className="relative">
+            <div className="bg-white pt-1.5" />
+            <UserAvatar
+              className="h-7 w-7 text-[0.8rem] font-medium"
+              size="sm"
+              title={creator.title || creator.email}
+            />
+            <div className="absolute -bottom-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full bg-control-bg ring-2 ring-white">
+              <Plus className="h-4 w-4 text-control" />
+            </div>
+          </div>
+
+          <div className="ml-3 min-w-0 flex-1">
+            <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+              <div className="bg-gray-50 px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <div className="flex min-w-0 flex-wrap items-center gap-x-2 text-sm">
+                    <CommentCreator creator={creator} />
+                    <span className="wrap-break-word min-w-0 text-gray-600">
+                      {t("activity.sentence.created-issue")}
+                    </span>
+                    {page.issue?.createTime && (
+                      <HumanizeTs
+                        className="text-gray-500"
+                        ts={
+                          getTimeForPbTimestampProtoEs(
+                            page.issue.createTime,
+                            0
+                          ) / 1000
+                        }
+                      />
+                    )}
+                  </div>
+                  {allowEdit && !isEditing && (
+                    <Button
+                      onClick={() => setIsEditing(true)}
+                      size="xs"
+                      variant="ghost"
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                  )}
+                </div>
+              </div>
+              <div className="border-t border-gray-200 px-4 py-3 text-sm text-gray-700">
+                <EditableMarkdownContent
+                  allowSave={allowSave}
+                  content={page.issue?.description || ""}
+                  editContent={editContent}
+                  isEditing={isEditing}
+                  isSaving={isSaving}
+                  onCancel={() => {
+                    setEditContent(page.issue?.description || "");
+                    setIsEditing(false);
+                  }}
+                  onChange={setEditContent}
+                  onSave={() => {
+                    void saveEdit();
+                  }}
+                  placeholder={t("issue.no-description-provided")}
+                  projectName={project?.name}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function IssueCommentRow({
+  comment,
+  isLast,
+  issueComment,
+  subjectSuffix,
+}: {
+  comment?: ReactNode;
+  isLast: boolean;
+  issueComment: IssueComment;
+  subjectSuffix?: ReactNode;
+}) {
+  return (
+    <li>
+      <div className="relative pb-4" id={issueComment.name}>
+        {!isLast && (
+          <span
+            aria-hidden="true"
+            className="absolute left-4 -ml-px h-full w-0.5 bg-gray-200"
+          />
+        )}
+        <div className="relative flex items-start">
+          <div className="pt-1.5">
+            <CommentActionIcon issueComment={issueComment} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div
+              className={cn(
+                "overflow-hidden rounded-lg border",
+                comment
+                  ? "ml-3 border-gray-200 bg-white"
+                  : "ml-1 border-transparent"
+              )}
+            >
+              <div className={cn("px-3 py-2", comment && "bg-gray-50")}>
+                <div className="flex items-center justify-between">
+                  <div className="flex min-w-0 flex-wrap items-center gap-x-2 text-sm">
+                    <CommentActionHeader issueComment={issueComment} />
+                  </div>
+                  {subjectSuffix}
+                </div>
+              </div>
+              {comment && (
+                <div className="wrap-break-word border-t border-gray-200 px-4 py-3 text-sm whitespace-pre-wrap text-gray-700">
+                  {comment}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function CommentActionHeader({ issueComment }: { issueComment: IssueComment }) {
+  const { t } = useTranslation();
+  const userStore = useUserStore();
+  const creator = useVueState(
+    () =>
+      userStore.getUserByIdentifier(issueComment.creator) ??
+      unknownUser(issueComment.creator)
+  );
+  const createdTs = getTimeForPbTimestampProtoEs(issueComment.createTime, 0);
+  const updatedTs = getTimeForPbTimestampProtoEs(issueComment.updateTime, 0);
+  const isEdited =
+    createdTs !== updatedTs &&
+    getIssueCommentType(issueComment) === IssueCommentType.USER_COMMENT;
+
+  return (
+    <>
+      <CommentCreator creator={creator} />
+      <CommentActionSentence issueComment={issueComment} />
+      {issueComment.createTime && (
+        <HumanizeTs className="text-gray-500" ts={createdTs / 1000} />
+      )}
+      {isEdited && (
+        <span className="text-xs text-gray-500">({t("common.edited")})</span>
+      )}
+    </>
+  );
+}
+
+function CommentCreator({ creator }: { creator: User }) {
+  return (
+    <span className="font-medium text-main">
+      {creator.title || creator.email}
+    </span>
+  );
+}
+
+function CommentActionSentence({
+  issueComment,
+}: {
+  issueComment: IssueComment;
+}) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const commentType = getIssueCommentType(issueComment);
+
+  if (
+    commentType === IssueCommentType.APPROVAL &&
+    issueComment.event.case === "approval"
+  ) {
+    const { status } = issueComment.event.value;
+    if (status === IssueComment_Approval_Status.APPROVED) {
+      return (
+        <span className="wrap-break-word min-w-0 text-gray-600">
+          {t("custom-approval.issue-review.approved-issue")}
+        </span>
+      );
+    }
+    if (status === IssueComment_Approval_Status.REJECTED) {
+      return (
+        <span className="wrap-break-word min-w-0 text-gray-600">
+          {t("custom-approval.issue-review.rejected-issue")}
+        </span>
+      );
+    }
+    if (status === IssueComment_Approval_Status.PENDING) {
+      return (
+        <span className="wrap-break-word min-w-0 text-gray-600">
+          {t("custom-approval.issue-review.re-requested-review")}
+        </span>
+      );
+    }
+  }
+
+  if (
+    commentType === IssueCommentType.ISSUE_UPDATE &&
+    issueComment.event.case === "issueUpdate"
+  ) {
+    const {
+      fromDescription,
+      fromLabels,
+      fromStatus,
+      fromTitle,
+      toDescription,
+      toLabels,
+      toStatus,
+      toTitle,
+    } = issueComment.event.value;
+    if (fromTitle !== undefined && toTitle !== undefined) {
+      return (
+        <span className="wrap-break-word min-w-0 text-gray-600">
+          {t("activity.sentence.changed-from-to", {
+            name: t("issue.issue-name").toLowerCase(),
+            newValue: toTitle,
+            oldValue: fromTitle,
+          })}
+        </span>
+      );
+    }
+    if (fromDescription !== undefined && toDescription !== undefined) {
+      return (
+        <span className="wrap-break-word min-w-0 text-gray-600">
+          {t("activity.sentence.changed-description")}
+        </span>
+      );
+    }
+    if (fromStatus !== undefined && toStatus !== undefined) {
+      if (toStatus === IssueStatus.DONE) {
+        return (
+          <span className="wrap-break-word min-w-0 text-gray-600">
+            {t("activity.sentence.resolved-issue")}
+          </span>
+        );
+      }
+      if (toStatus === IssueStatus.CANCELED) {
+        return (
+          <span className="wrap-break-word min-w-0 text-gray-600">
+            {t("activity.sentence.canceled-issue")}
+          </span>
+        );
+      }
+      if (toStatus === IssueStatus.OPEN) {
+        return (
+          <span className="wrap-break-word min-w-0 text-gray-600">
+            {t("activity.sentence.reopened-issue")}
+          </span>
+        );
+      }
+    }
+    if (fromLabels.length !== 0 || toLabels.length !== 0) {
+      return (
+        <span className="wrap-break-word min-w-0 text-gray-600">
+          {t("activity.sentence.changed-labels")}
+        </span>
+      );
+    }
+  }
+
+  if (
+    commentType === IssueCommentType.PLAN_SPEC_UPDATE &&
+    issueComment.event.case === "planSpecUpdate"
+  ) {
+    const { spec, fromSheet, toSheet } = issueComment.event.value;
+    if (fromSheet && toSheet && page.plan) {
+      const specs = page.plan.specs ?? [];
+      const specInfo = getSpecDisplayInfo(specs, spec);
+      const planName = page.plan.name;
+      const href = router.resolve({
+        name: PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
+        params: {
+          planId: extractPlanUID(planName),
+          projectId: extractProjectResourceName(planName),
+          specId: specInfo?.specId ?? "",
+        },
+      }).href;
+
+      return (
+        <span className="wrap-break-word min-w-0 text-gray-600">
+          {t("activity.sentence.modified-sql-of")}{" "}
+          {specInfo?.specId ? (
+            <a
+              className="inline-flex items-center gap-1 hover:underline"
+              href={href}
+            >
+              {t("plan.spec.change")}
+              <span className="rounded-full bg-control-bg px-1.5 py-0.5 text-xs text-main">
+                #{specInfo.displayIndex}
+              </span>
+            </a>
+          ) : (
+            t("plan.spec.change")
+          )}{" "}
+          <IssueDetailStatementUpdateButton
+            newSheet={toSheet}
+            oldSheet={fromSheet}
+          />
+        </span>
+      );
+    }
+  }
+
+  return <span className="wrap-break-word min-w-0 text-gray-600" />;
+}
+
+function CommentActionIcon({ issueComment }: { issueComment: IssueComment }) {
+  const userStore = useUserStore();
+  const user = useVueState(
+    () =>
+      userStore.getUserByIdentifier(issueComment.creator) ??
+      unknownUser(issueComment.creator)
+  );
+  const commentType = getIssueCommentType(issueComment);
+
+  if (
+    commentType === IssueCommentType.APPROVAL &&
+    issueComment.event.case === "approval"
+  ) {
+    const { status } = issueComment.event.value;
+    if (status === IssueComment_Approval_Status.APPROVED) {
+      return (
+        <CommentIconBadge
+          className="bg-success text-white"
+          icon={<ThumbsUp className="h-4 w-4" />}
+        />
+      );
+    }
+    if (status === IssueComment_Approval_Status.REJECTED) {
+      return (
+        <CommentIconBadge
+          className="bg-warning text-white"
+          icon={<Pencil className="h-4 w-4" />}
+        />
+      );
+    }
+    if (status === IssueComment_Approval_Status.PENDING) {
+      return (
+        <CommentIconBadge
+          className="bg-control-bg text-control"
+          icon={<Play className="ml-px h-4 w-4" strokeWidth={3} />}
+        />
+      );
+    }
+  }
+
+  if (
+    commentType === IssueCommentType.ISSUE_UPDATE &&
+    issueComment.event.case === "issueUpdate"
+  ) {
+    const { fromLabels, toDescription, toLabels, toTitle } =
+      issueComment.event.value;
+    if (
+      toTitle !== undefined ||
+      toDescription !== undefined ||
+      toLabels.length !== 0 ||
+      fromLabels.length !== 0
+    ) {
+      return (
+        <CommentIconBadge
+          className="bg-control-bg text-control"
+          icon={<Pencil className="h-4 w-4" />}
+        />
+      );
+    }
+  }
+
+  if (commentType === IssueCommentType.PLAN_SPEC_UPDATE) {
+    return (
+      <CommentIconBadge
+        className="bg-control-bg text-control"
+        icon={<Pencil className="h-4 w-4" />}
+      />
+    );
+  }
+
+  return (
+    <div className="relative pl-0.5">
+      <div className="flex h-7 w-7 items-center justify-center rounded-full bg-white ring-4 ring-white">
+        <UserAvatar
+          className="h-7 w-7 text-[0.8rem] font-medium"
+          size="sm"
+          title={user.title || user.email}
+        />
+      </div>
+    </div>
+  );
+}
+
+function CommentIconBadge({
+  className,
+  icon,
+}: {
+  className: string;
+  icon: ReactNode;
+}) {
+  return (
+    <div className="relative pl-0.5">
+      <div
+        className={cn(
+          "flex h-7 w-7 items-center justify-center rounded-full ring-4 ring-white",
+          className
+        )}
+      >
+        {icon}
+      </div>
+    </div>
+  );
+}
+
+function EditableMarkdownContent({
+  allowSave,
+  content,
+  editContent,
+  isEditing,
+  isSaving = false,
+  onCancel,
+  onChange,
+  onSave,
+  placeholder,
+  projectName,
+}: {
+  allowSave: boolean;
+  content: string;
+  editContent: string;
+  isEditing: boolean;
+  isSaving?: boolean;
+  onCancel: () => void;
+  onChange: (value: string) => void;
+  onSave: () => void;
+  placeholder: string;
+  projectName?: string;
+}) {
+  const { t } = useTranslation();
+
+  if (!isEditing && !content) {
+    return (
+      <p>
+        <i className="italic text-gray-400">{placeholder}</i>
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <IssueDetailMarkdownEditor
+        content={isEditing ? editContent : content}
+        maxHeight={Number.MAX_SAFE_INTEGER}
+        mode={isEditing ? "editor" : "preview"}
+        onChange={onChange}
+        onSubmit={onSave}
+        projectName={projectName}
+      />
+      {isEditing && (
+        <div className="mt-2 flex items-center justify-end gap-x-2">
+          <Button onClick={onCancel} size="xs" variant="ghost">
+            {t("common.cancel")}
+          </Button>
+          <Button disabled={!allowSave || isSaving} onClick={onSave} size="xs">
+            {isSaving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+            {t("common.save")}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IssueDetailMarkdownEditor({
+  content,
+  maxHeight = 192,
+  mode = "editor",
+  onChange,
+  onSubmit,
+  placeholder,
+  projectName,
+}: {
+  content: string;
+  maxHeight?: number;
+  mode?: "editor" | "preview";
+  onChange?: (value: string) => void;
+  onSubmit?: () => void;
+  placeholder?: string;
+  projectName?: string;
+}) {
+  const { t } = useTranslation();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [tab, setTab] = useState<"write" | "preview">(
+    mode === "preview" ? "preview" : "write"
+  );
+  const previewHtml = useMemo(
+    () => renderMarkdown(content, projectName, t),
+    [content, projectName, t]
+  );
+
+  useEffect(() => {
+    setTab(mode === "preview" ? "preview" : "write");
+  }, [mode]);
+
+  useEffect(() => {
+    if (tab === "write" && textareaRef.current) {
+      autoSizeTextarea(textareaRef.current);
+    }
+  }, [content, tab]);
+
+  const insertTemplate = (template: string, position: number) => {
+    const textarea = textareaRef.current;
+    if (!textarea || !onChange) {
+      return;
+    }
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const next = `${content.slice(0, start)}${template.slice(
+      0,
+      position
+    )}${content.slice(start, end)}${template.slice(position)}${content.slice(end)}`;
+    onChange(next);
+    window.requestAnimationFrame(() => {
+      const target = textareaRef.current;
+      if (!target) {
+        return;
+      }
+      const cursor = start + position;
+      target.focus();
+      target.setSelectionRange(cursor, cursor);
+      autoSizeTextarea(target);
+    });
+  };
+
+  if (mode === "preview") {
+    return (
+      <div
+        className="markdown-body min-h-6 wrap-break-word"
+        dangerouslySetInnerHTML={{
+          __html:
+            previewHtml ||
+            `<span class="text-gray-400 italic">${t(
+              "issue.comment-editor.nothing-to-preview"
+            )}</span>`,
+        }}
+      />
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between border-b border-control-border">
+        <div className="flex gap-x-4">
+          <button
+            className={cn(
+              "relative px-1 pb-2 text-sm font-medium transition-colors",
+              tab === "write"
+                ? "text-accent after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-accent"
+                : "text-control-light hover:text-control"
+            )}
+            onClick={() => setTab("write")}
+            type="button"
+          >
+            {t("issue.comment-editor.write")}
+          </button>
+          <button
+            className={cn(
+              "relative px-1 pb-2 text-sm font-medium transition-colors",
+              tab === "preview"
+                ? "text-accent after:absolute after:inset-x-0 after:-bottom-px after:h-0.5 after:bg-accent"
+                : "text-control-light hover:text-control"
+            )}
+            onClick={() => setTab("preview")}
+            type="button"
+          >
+            {t("issue.comment-editor.preview")}
+          </button>
+        </div>
+        {tab === "write" && (
+          <div className="flex items-center gap-x-1 pb-1">
+            <ToolbarButton
+              icon={<Heading1 className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.header")}
+              onClick={() => insertTemplate("### ", 4)}
+            />
+            <ToolbarButton
+              icon={<Bold className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.bold")}
+              onClick={() => insertTemplate("****", 2)}
+            />
+            <ToolbarButton
+              icon={<Code2 className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.code")}
+              onClick={() => insertTemplate("```sql\n\n```", 7)}
+            />
+            <ToolbarButton
+              icon={<Link2 className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.link")}
+              onClick={() => insertTemplate("[](url)", 1)}
+            />
+            <ToolbarButton
+              icon={<Hash className="h-4 w-4" />}
+              label={t("issue.comment-editor.toolbar.hashtag")}
+              onClick={() => insertTemplate("#", 1)}
+            />
+          </div>
+        )}
+      </div>
+
+      {tab === "preview" ? (
+        <div className="markdown-body min-h-6 wrap-break-word rounded-md">
+          {previewHtml ? (
+            <div
+              dangerouslySetInnerHTML={{
+                __html: previewHtml,
+              }}
+            />
+          ) : (
+            <span className="italic text-gray-400">
+              {t("issue.comment-editor.nothing-to-preview")}
+            </span>
+          )}
+        </div>
+      ) : (
+        <Textarea
+          className="whitespace-pre-wrap rounded-lg px-4 py-3"
+          maxLength={65536}
+          onChange={(e) => onChange?.(e.target.value)}
+          onKeyDown={(e) => {
+            const listContinuation = applyMarkdownListContinuation(
+              content,
+              e.currentTarget.selectionStart,
+              e.currentTarget.selectionEnd
+            );
+            if (
+              e.key === "Enter" &&
+              !e.nativeEvent.isComposing &&
+              !e.metaKey &&
+              !e.ctrlKey &&
+              listContinuation
+            ) {
+              e.preventDefault();
+              onChange?.(listContinuation.content);
+              window.requestAnimationFrame(() => {
+                const target = textareaRef.current;
+                if (!target) {
+                  return;
+                }
+                target.focus();
+                target.setSelectionRange(
+                  listContinuation.cursor,
+                  listContinuation.cursor
+                );
+                autoSizeTextarea(target);
+              });
+              return;
+            }
+            if (
+              e.key === "Enter" &&
+              !e.nativeEvent.isComposing &&
+              (e.metaKey || e.ctrlKey)
+            ) {
+              e.preventDefault();
+              onSubmit?.();
+            }
+          }}
+          placeholder={placeholder || t("issue.leave-a-comment")}
+          ref={textareaRef}
+          rows={4}
+          style={{ maxHeight }}
+          value={content}
+        />
+      )}
+    </div>
+  );
+}
+
+function ToolbarButton({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      aria-label={label}
+      className="rounded-xs p-1 text-control transition-colors hover:bg-control-bg hover:text-main"
+      onClick={onClick}
+      title={label}
+      type="button"
+    >
+      {icon}
+    </button>
+  );
+}
+
+function IssueDetailStatementUpdateButton({
+  newSheet,
+  oldSheet,
+}: {
+  newSheet: string;
+  oldSheet: string;
+}) {
+  const { t } = useTranslation();
+  const sheetStore = useSheetV1Store();
+  const [open, setOpen] = useState(false);
+  const [oldStatement, setOldStatement] = useState("");
+  const [newStatement, setNewStatement] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    let canceled = false;
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const [oldValue, newValue] = await Promise.all([
+          sheetStore
+            .getOrFetchSheetByName(oldSheet)
+            .then((sheet) => (sheet ? getSheetStatement(sheet) : "")),
+          sheetStore
+            .getOrFetchSheetByName(newSheet)
+            .then((sheet) => (sheet ? getSheetStatement(sheet) : "")),
+        ]);
+        if (!canceled) {
+          setOldStatement(oldValue);
+          setNewStatement(newValue);
+        }
+      } finally {
+        if (!canceled) {
+          setIsLoading(false);
+        }
+      }
+    };
+    void load();
+    return () => {
+      canceled = true;
+    };
+  }, [newSheet, oldSheet, open, sheetStore]);
+
+  return (
+    <>
+      <button
+        className="inline-flex items-center text-accent hover:underline"
+        onClick={() => setOpen(true)}
+        type="button"
+      >
+        {t("common.view-details")}
+      </button>
+      <Dialog onOpenChange={setOpen} open={open}>
+        <DialogContent className="max-w-none border-0 p-0 sm:w-[calc(100vw-9rem)] 2xl:max-w-none">
+          <div className="px-6 pt-5">
+            <DialogTitle>{t("common.detail")}</DialogTitle>
+          </div>
+          <div className="px-6 pb-6 pt-2">
+            <div className="relative h-[calc(100vh-10rem)] w-full">
+              {isLoading ? (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <Loader2 className="h-6 w-6 animate-spin text-control-light" />
+                </div>
+              ) : (
+                <ReadonlyDiffMonaco
+                  className="h-full w-full overflow-clip rounded-md border"
+                  modified={newStatement}
+                  original={oldStatement}
+                />
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function autoSizeTextarea(textarea: HTMLTextAreaElement) {
+  textarea.style.height = "auto";
+  textarea.style.height = `${Math.max(textarea.scrollHeight, 112)}px`;
+}
+
+function applyMarkdownListContinuation(
+  text: string,
+  selectionStart: number,
+  selectionEnd: number
+) {
+  if (selectionStart !== selectionEnd) {
+    return undefined;
+  }
+
+  const lines = text.split("\n");
+  const lineIndex = getActiveLineIndex(text, selectionStart);
+  const currentLine = lines[lineIndex] ?? "";
+  const lineStart = getCursorPosition(lines.slice(0, lineIndex));
+  const indexInCurrentLine = selectionStart - lineStart;
+
+  if (/^\s{0,}(\d{1,}\.|-)\s{1,}$/.test(currentLine)) {
+    lines[lineIndex] = "";
+    return {
+      content: lines.join("\n"),
+      cursor: getCursorPosition(lines.slice(0, lineIndex)),
+    };
+  }
+
+  if (!/^\s{0,}(\d{1,}\.|-)\s/.test(currentLine)) {
+    return undefined;
+  }
+
+  const indent = " ".repeat(
+    currentLine.length - currentLine.trimStart().length
+  );
+  const trailing = currentLine.slice(indexInCurrentLine);
+  lines[lineIndex] = currentLine.slice(0, indexInCurrentLine);
+
+  let nextListStart = "-";
+  if (/^\s{0,}\d{1,}\.\s/.test(currentLine)) {
+    const currentNumber = Number(currentLine.match(/\d+/)?.[0] ?? "1");
+    nextListStart = `${currentNumber + 1}.`;
+  }
+
+  lines.splice(lineIndex + 1, 0, `${indent}${nextListStart} ${trailing}`);
+  return {
+    content: lines.join("\n"),
+    cursor: getCursorPosition(lines.slice(0, lineIndex + 2)) - 1,
+  };
+}
+
+function getActiveLineIndex(content: string, cursorPosition: number): number {
+  const lines = content.split("\n");
+  let count = 0;
+  for (let i = 0; i < lines.length; i++) {
+    count += lines[i].length;
+    if (count >= cursorPosition) {
+      return i;
+    }
+    count += 1;
+  }
+  return lines.length - 1;
+}
+
+function getCursorPosition(lines: string[]): number {
+  let count = 0;
+  for (const line of lines) {
+    count += line.length;
+    count += 1;
+  }
+  return count;
+}
+
+function renderMarkdown(
+  markdownContent: string,
+  projectName: string | undefined,
+  t: (key: string) => string
+) {
+  if (!markdownContent) {
+    return "";
+  }
+  const withIssueLinks = markdownContent
+    .split(/(#\d+)\b/)
+    .map((part) => {
+      if (!part.startsWith("#")) {
+        return part;
+      }
+      const id = Number.parseInt(part.slice(1), 10);
+      if (!Number.isNaN(id) && id > 0 && projectName) {
+        const projectId = extractProjectResourceName(projectName);
+        const url = `${window.location.origin}/projects/${projectId}/issues/${id}`;
+        return `[${t("common.issue")} #${id}](${url})`;
+      }
+      return part;
+    })
+    .join("");
+  const rendered = markdown.render(withIssueLinks);
+  return DOMPurify.sanitize(rendered);
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
@@ -1,0 +1,942 @@
+import { create } from "@bufbuild/protobuf";
+import { ChevronRight, ExternalLink, FolderTree, X } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { instanceRoleServiceClientConnect } from "@/connect";
+import { EngineIconPath } from "@/react/components/instance/constants";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from "@/react/components/ui/dialog";
+import { SearchInput } from "@/react/components/ui/search-input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/react/components/ui/select";
+import { Switch } from "@/react/components/ui/switch";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import { router } from "@/router";
+import {
+  PROJECT_V1_ROUTE_DATABASE_GROUP_DETAIL,
+  PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS,
+} from "@/router/dashboard/projectV1";
+import { buildPlanDeployRouteFromPlanName } from "@/router/dashboard/projectV1RouteHelpers";
+import {
+  getProjectNameAndDatabaseGroupName,
+  useDatabaseV1Store,
+  useDBGroupStore,
+  useEnvironmentV1Store,
+  useSheetV1Store,
+} from "@/store";
+import { isValidDatabaseGroupName, isValidDatabaseName } from "@/types";
+import { Engine } from "@/types/proto-es/v1/common_pb";
+import { DatabaseGroupView } from "@/types/proto-es/v1/database_group_service_pb";
+import { ListInstanceRolesRequestSchema } from "@/types/proto-es/v1/instance_role_service_pb";
+import type { Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
+import {
+  extractDatabaseResourceName,
+  extractInstanceResourceName,
+  extractPlanUID,
+  extractProjectResourceName,
+  getDefaultTransactionMode,
+  getInstanceResource,
+} from "@/utils";
+import { getStatementSize } from "@/utils/sheet";
+import { extractDatabaseGroupName } from "@/utils/v1/databaseGroup";
+import { instanceV1SupportsTransactionMode } from "@/utils/v1/instance";
+import { sheetNameOfSpec } from "@/utils/v1/issue/plan";
+import { extractSheetUID, getSheetStatement } from "@/utils/v1/sheet";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+import { useIssueDetailSpecValidation } from "../hooks/useIssueDetailSpecValidation";
+import {
+  allowGhostForDatabase,
+  BACKUP_AVAILABLE_ENGINES,
+  getGhostConfig,
+  type IsolationLevel,
+  isDatabaseChangeSpec,
+  parseStatement,
+} from "../utils/databaseChange";
+import { getLocalSheetByName } from "../utils/localSheet";
+import { IssueDetailStatementSection } from "./IssueDetailStatementSection";
+
+const DEFAULT_VISIBLE_TARGETS = 20;
+const MAX_INLINE_DATABASES = 5;
+const EMPTY_SELECT_VALUE = "__empty__";
+
+export function IssueDetailDatabaseChangeView({
+  onSelectedSpecIdChange,
+  selectedSpecId,
+}: {
+  onSelectedSpecIdChange: (specId: string) => void;
+  selectedSpecId: string;
+}) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const { emptySpecIdSet } = useIssueDetailSpecValidation(
+    page.plan?.specs ?? []
+  );
+
+  const specs = page.plan?.specs ?? [];
+  const selectedSpec = useMemo(() => {
+    return specs.find((spec) => spec.id === selectedSpecId) ?? specs[0];
+  }, [selectedSpecId, specs]);
+  const planHref = useMemo(() => {
+    if (!page.plan) {
+      return "";
+    }
+    const route = page.plan.hasRollout
+      ? buildPlanDeployRouteFromPlanName(page.plan.name)
+      : {
+          name: PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS,
+          params: {
+            projectId: extractProjectResourceName(page.plan.name),
+            planId: extractPlanUID(page.plan.name),
+          },
+        };
+    return router.resolve(route).href;
+  }, [page.plan]);
+
+  useEffect(() => {
+    if (selectedSpec && selectedSpec.id !== selectedSpecId) {
+      onSelectedSpecIdChange(selectedSpec.id);
+    }
+  }, [onSelectedSpecIdChange, selectedSpec, selectedSpecId]);
+
+  return (
+    <div className="flex w-full flex-col">
+      <div>
+        <div className="flex items-center justify-between border-b border-control-border">
+          <div className="flex items-center">
+            {specs.map((spec, index) => {
+              const isSelected = selectedSpec?.id === spec.id;
+              return (
+                <button
+                  key={spec.id}
+                  className={cn(
+                    "relative -mb-px flex cursor-pointer items-center gap-1 rounded-t-md border px-3 py-1.5 text-sm transition-colors",
+                    isSelected
+                      ? "border-control-border border-b-white bg-white font-medium text-main"
+                      : "border-transparent bg-transparent text-control-light hover:text-control"
+                  )}
+                  onClick={() => onSelectedSpecIdChange(spec.id)}
+                  type="button"
+                >
+                  <span className="opacity-60">#{index + 1}</span>
+                  <span>{t("plan.spec.type.database-change")}</span>
+                  {emptySpecIdSet.has(spec.id) && (
+                    <Tooltip content={t("plan.navigator.statement-empty")}>
+                      <span className="text-error">*</span>
+                    </Tooltip>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {page.plan && (
+            <a
+              className="px-3 text-sm text-accent hover:underline"
+              href={planHref}
+            >
+              {t("plan.go-to-plan-page")} →
+            </a>
+          )}
+        </div>
+
+        <div className="rounded-b-lg border-x border-b border-control-border bg-white px-3 py-2">
+          {selectedSpec && (
+            <div className="flex flex-col gap-2">
+              <IssueDetailDatabaseChangeTargets selectedSpec={selectedSpec} />
+              <div className="flex flex-col">
+                <IssueDetailStatementSection
+                  forceReadonly
+                  spec={selectedSpec}
+                />
+              </div>
+              <IssueDetailDatabaseChangeOptions selectedSpec={selectedSpec} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseChangeOptions({
+  selectedSpec,
+}: {
+  selectedSpec: Plan_Spec;
+}) {
+  const { t } = useTranslation();
+  const databaseStore = useDatabaseV1Store();
+  const sheetStore = useSheetV1Store();
+  const [sheetStatement, setSheetStatement] = useState("");
+  const [isSheetOversize, setIsSheetOversize] = useState(false);
+  const [instanceRoles, setInstanceRoles] = useState<string[]>([]);
+
+  const targets = useMemo(() => {
+    if (selectedSpec.config?.case === "changeDatabaseConfig") {
+      return selectedSpec.config.value.targets ?? [];
+    }
+    return [];
+  }, [selectedSpec]);
+  const databases = useVueState(() =>
+    targets
+      .map((target) => databaseStore.getDatabaseByName(target))
+      .filter((database) => isValidDatabaseName(database.name))
+  );
+  const parsedStatement = useMemo(
+    () => parseStatement(sheetStatement),
+    [sheetStatement]
+  );
+  const selectedRole = useMemo(() => {
+    if (!parsedStatement.roleSetterBlock) {
+      return "";
+    }
+    const match = parsedStatement.roleSetterBlock.match(
+      /SET ROLE ([a-zA-Z_][a-zA-Z0-9_]{0,62});/
+    );
+    return match?.[1] ?? "";
+  }, [parsedStatement.roleSetterBlock]);
+  const selectedIsolation = parsedStatement.isolationLevel ?? "";
+  const transactionModeChecked =
+    parsedStatement.transactionMode !== undefined
+      ? parsedStatement.transactionMode === "on"
+      : getDefaultTransactionMode();
+  const ghostEnabled = getGhostConfig(sheetStatement) !== undefined;
+  const preBackupEnabled =
+    selectedSpec.config?.case === "changeDatabaseConfig"
+      ? Boolean(selectedSpec.config.value.enablePriorBackup)
+      : false;
+  const isSheetBasedDatabaseChange =
+    selectedSpec.config?.case === "changeDatabaseConfig" &&
+    !selectedSpec.config.value.release;
+  const showTransactionMode = useMemo(() => {
+    if (!isSheetBasedDatabaseChange) {
+      return false;
+    }
+    return databases.every((database) =>
+      instanceV1SupportsTransactionMode(getInstanceResource(database).engine)
+    );
+  }, [databases, isSheetBasedDatabaseChange]);
+  const showInstanceRole = useMemo(() => {
+    if (!isSheetBasedDatabaseChange) {
+      return false;
+    }
+    return databases.every(
+      (database) => getInstanceResource(database).engine === Engine.POSTGRES
+    );
+  }, [databases, isSheetBasedDatabaseChange]);
+  const showIsolationLevel = useMemo(() => {
+    if (!isSheetBasedDatabaseChange) {
+      return false;
+    }
+    return databases.every((database) =>
+      [Engine.MYSQL, Engine.MARIADB, Engine.TIDB].includes(
+        getInstanceResource(database).engine
+      )
+    );
+  }, [databases, isSheetBasedDatabaseChange]);
+  const showPreBackup = useMemo(() => {
+    if (selectedSpec.config?.case !== "changeDatabaseConfig") {
+      return false;
+    }
+    if (isDatabaseChangeSpec(selectedSpec)) {
+      return databases.every((database) =>
+        BACKUP_AVAILABLE_ENGINES.includes(getInstanceResource(database).engine)
+      );
+    }
+    return true;
+  }, [databases, selectedSpec]);
+  const showGhost = useMemo(() => {
+    if (!isSheetBasedDatabaseChange) {
+      return false;
+    }
+    return databases.every((database) => allowGhostForDatabase(database));
+  }, [databases, isSheetBasedDatabaseChange]);
+  const shouldShow =
+    showTransactionMode ||
+    showInstanceRole ||
+    showIsolationLevel ||
+    showPreBackup ||
+    showGhost;
+  const instanceRoleOptions = useMemo(() => {
+    const roles = !selectedRole
+      ? instanceRoles
+      : instanceRoles.includes(selectedRole)
+        ? instanceRoles
+        : [selectedRole, ...instanceRoles];
+    return roles.map((role) => ({ label: role, value: role }));
+  }, [instanceRoles, selectedRole]);
+  const oversizeTooltip = isSheetOversize
+    ? t("issue.options-disabled-due-to-oversize")
+    : undefined;
+  const isolationLevelOptions = useMemo(() => {
+    return [
+      {
+        label: t("plan.isolation-level.read-uncommitted"),
+        value: "READ_UNCOMMITTED",
+      },
+      {
+        label: t("plan.isolation-level.read-committed"),
+        value: "READ_COMMITTED",
+      },
+      {
+        label: t("plan.isolation-level.repeatable-read"),
+        value: "REPEATABLE_READ",
+      },
+      {
+        label: t("plan.isolation-level.serializable"),
+        value: "SERIALIZABLE",
+      },
+    ] satisfies Array<{ label: string; value: IsolationLevel }>;
+  }, [t]);
+
+  useEffect(() => {
+    let canceled = false;
+    const sheetName = sheetNameOfSpec(selectedSpec);
+    if (!sheetName) {
+      setSheetStatement("");
+      setIsSheetOversize(false);
+      return;
+    }
+
+    const loadSheet = async () => {
+      const uid = extractSheetUID(sheetName);
+      const sheet = uid.startsWith("-")
+        ? getLocalSheetByName(sheetName)
+        : await sheetStore.getOrFetchSheetByName(sheetName);
+      if (!sheet || canceled) {
+        return;
+      }
+      const statement = getSheetStatement(sheet);
+      setSheetStatement(statement);
+      setIsSheetOversize(getStatementSize(statement) < sheet.contentSize);
+    };
+
+    void loadSheet();
+
+    return () => {
+      canceled = true;
+    };
+  }, [selectedSpec, sheetStore]);
+
+  useEffect(() => {
+    let canceled = false;
+    const database = databases[0];
+    const instanceName = database
+      ? extractDatabaseResourceName(database.name).instance
+      : "";
+    if (!showInstanceRole || !instanceName) {
+      setInstanceRoles([]);
+      return;
+    }
+
+    const loadInstanceRoles = async () => {
+      try {
+        const request = create(ListInstanceRolesRequestSchema, {
+          parent: instanceName,
+        });
+        const response =
+          await instanceRoleServiceClientConnect.listInstanceRoles(request);
+        if (!canceled) {
+          setInstanceRoles(response.roles.map((role) => role.roleName));
+        }
+      } catch {
+        if (!canceled) {
+          setInstanceRoles([]);
+        }
+      }
+    };
+
+    void loadInstanceRoles();
+
+    return () => {
+      canceled = true;
+    };
+  }, [databases, showInstanceRole]);
+
+  return (
+    <div className={cn("flex flex-col gap-1", !shouldShow && "hidden")}>
+      <span className="text-base">{t("plan.options.self")}</span>
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 sm:gap-x-6">
+        <div
+          className={cn(
+            "flex items-center gap-1",
+            !showInstanceRole && "hidden"
+          )}
+        >
+          <span className="text-sm text-control-light">
+            {t("common.role.self")}
+          </span>
+          <IssueDetailReadonlySelect
+            disabledReason={oversizeTooltip}
+            options={instanceRoleOptions}
+            placeholder={t("instance.select-database-user")}
+            value={selectedRole}
+            widthClassName="w-36"
+          />
+        </div>
+        <div
+          className={cn(
+            "flex items-center gap-1",
+            !showTransactionMode && "hidden"
+          )}
+        >
+          <span className="text-sm text-control-light">
+            {t("issue.transaction-mode.label")}
+          </span>
+          <Tooltip content={oversizeTooltip}>
+            <div>
+              <Switch
+                checked={transactionModeChecked}
+                disabled
+                onCheckedChange={() => {}}
+                size="small"
+              />
+            </div>
+          </Tooltip>
+        </div>
+        <div
+          className={cn(
+            "flex items-center gap-1",
+            !showIsolationLevel && "hidden"
+          )}
+        >
+          <span className="text-sm text-control-light">
+            {t("plan.isolation-level.self")}
+          </span>
+          <IssueDetailReadonlySelect
+            disabledReason={oversizeTooltip}
+            options={isolationLevelOptions}
+            placeholder={t("plan.select-isolation-level")}
+            value={selectedIsolation}
+            widthClassName="w-36"
+          />
+        </div>
+        <div
+          className={cn("flex items-center gap-1", !showPreBackup && "hidden")}
+        >
+          <span className="text-sm text-control-light">
+            {t("task.prior-backup")}
+          </span>
+          <div>
+            <Switch
+              checked={preBackupEnabled}
+              disabled
+              onCheckedChange={() => {}}
+              size="small"
+            />
+          </div>
+        </div>
+        <div className={cn("flex items-center gap-1", !showGhost && "hidden")}>
+          <span className="text-sm text-control-light">
+            {t("task.online-migration.self")}
+          </span>
+          <Tooltip content={oversizeTooltip}>
+            <div>
+              <Switch
+                checked={ghostEnabled}
+                disabled
+                onCheckedChange={() => {}}
+                size="small"
+              />
+            </div>
+          </Tooltip>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailReadonlySelect({
+  disabledReason,
+  options,
+  placeholder,
+  value,
+  widthClassName,
+}: {
+  disabledReason?: string;
+  options: Array<{ label: string; value: string }>;
+  placeholder: string;
+  value: string;
+  widthClassName?: string;
+}) {
+  return (
+    <Tooltip content={disabledReason ?? ""}>
+      <div>
+        <Select
+          disabled
+          onValueChange={() => {}}
+          value={value || EMPTY_SELECT_VALUE}
+        >
+          <SelectTrigger className={cn("h-6 text-xs", widthClassName)}>
+            <SelectValue>
+              {options.find((option) => option.value === value)?.label ||
+                placeholder}
+            </SelectValue>
+          </SelectTrigger>
+          <SelectContent>
+            {!value && (
+              <SelectItem value={EMPTY_SELECT_VALUE}>{placeholder}</SelectItem>
+            )}
+            {options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </Tooltip>
+  );
+}
+
+function IssueDetailDatabaseChangeTargets({
+  selectedSpec,
+}: {
+  selectedSpec: Plan_Spec;
+}) {
+  const { t } = useTranslation();
+  const databaseStore = useDatabaseV1Store();
+  const dbGroupStore = useDBGroupStore();
+  const [showAllTargetsDialog, setShowAllTargetsDialog] = useState(false);
+  const [searchText, setSearchText] = useState("");
+  const [isLoadingTargets, setIsLoadingTargets] = useState(false);
+  const [isLoadingAllTargets, setIsLoadingAllTargets] = useState(false);
+
+  const targets = useMemo(() => {
+    if (selectedSpec.config?.case === "changeDatabaseConfig") {
+      return selectedSpec.config.value.targets ?? [];
+    }
+    return [];
+  }, [selectedSpec]);
+  const visibleTargets = useMemo(() => {
+    return targets.slice(0, Math.min(DEFAULT_VISIBLE_TARGETS, targets.length));
+  }, [targets]);
+  const nonEnvDatabaseNames = useVueState(() => {
+    if (isLoadingTargets) {
+      return [];
+    }
+    return targets
+      .flatMap((target) => {
+        if (!isValidDatabaseGroupName(target)) {
+          return [target];
+        }
+        return (
+          dbGroupStore
+            .getDBGroupByName(target)
+            .matchedDatabases?.map((database) => database.name) ?? []
+        );
+      })
+      .filter(
+        (name) => !databaseStore.getDatabaseByName(name).effectiveEnvironment
+      );
+  });
+  const filteredTargets = useVueState(() => {
+    if (!searchText) {
+      return targets;
+    }
+
+    const normalizedSearchText = searchText.toLowerCase();
+    return targets.filter((target) => {
+      if (isValidDatabaseName(target)) {
+        const database = databaseStore.getDatabaseByName(target);
+        return extractDatabaseResourceName(database.name)
+          .databaseName.toLowerCase()
+          .includes(normalizedSearchText);
+      }
+      return String(target).toLowerCase().includes(normalizedSearchText);
+    });
+  });
+  const nonEnvWarning =
+    nonEnvDatabaseNames.length === 1
+      ? t("plan.targets.non-env-warning.one", {
+          count: nonEnvDatabaseNames.length,
+        })
+      : t("plan.targets.non-env-warning.other", {
+          count: nonEnvDatabaseNames.length,
+        });
+
+  useEffect(() => {
+    let canceled = false;
+
+    const loadVisibleTargets = async () => {
+      if (targets.length === 0) {
+        setIsLoadingTargets(false);
+        return;
+      }
+
+      setIsLoadingTargets(true);
+      try {
+        await fetchTargets(visibleTargets, dbGroupStore, databaseStore);
+      } catch {
+        // Ignore target loading failures to match the current Vue behavior.
+      } finally {
+        if (!canceled) {
+          setIsLoadingTargets(false);
+        }
+      }
+    };
+
+    void loadVisibleTargets();
+
+    return () => {
+      canceled = true;
+    };
+  }, [databaseStore, dbGroupStore, targets, visibleTargets]);
+
+  useEffect(() => {
+    if (!showAllTargetsDialog) {
+      return;
+    }
+
+    let canceled = false;
+    setSearchText("");
+
+    const loadAllTargets = async () => {
+      setIsLoadingAllTargets(true);
+      try {
+        await fetchTargets(targets, dbGroupStore, databaseStore);
+      } catch {
+        // Ignore target loading failures to match the current Vue behavior.
+      } finally {
+        if (!canceled) {
+          setIsLoadingAllTargets(false);
+        }
+      }
+    };
+
+    void loadAllTargets();
+
+    return () => {
+      canceled = true;
+    };
+  }, [databaseStore, dbGroupStore, showAllTargetsDialog, targets]);
+
+  return (
+    <>
+      <div className="flex flex-col gap-y-1">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1">
+            <span className="textlabel uppercase">
+              {t("plan.targets.title")}
+            </span>
+            {targets.length > 1 && (
+              <span className="textlabel text-control-light">
+                ({targets.length})
+              </span>
+            )}
+          </div>
+        </div>
+
+        {!isLoadingTargets && nonEnvDatabaseNames.length > 0 && (
+          <div className="rounded-sm border border-yellow-200 bg-yellow-50 px-3 py-2 text-sm text-yellow-900">
+            <div>{nonEnvWarning}</div>
+            <div className="mt-1 flex flex-col gap-1 text-sm">
+              {nonEnvDatabaseNames.map((name) => (
+                <div key={name} className="flex items-center gap-2">
+                  <span className="h-1 w-1 shrink-0 rounded-full bg-current" />
+                  <IssueDetailDatabaseTarget target={name} />
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {isLoadingTargets ? (
+          <div className="flex items-center justify-center py-2">
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-control-border border-t-accent" />
+          </div>
+        ) : targets.length > 0 ? (
+          <div className="flex flex-wrap items-center gap-2">
+            {visibleTargets.map((target) => (
+              <div
+                key={target}
+                className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1"
+              >
+                {isValidDatabaseName(target) ? (
+                  <IssueDetailDatabaseTarget showEnvironment target={target} />
+                ) : isValidDatabaseGroupName(target) ? (
+                  <IssueDetailDatabaseGroupTarget
+                    className="py-1"
+                    target={target}
+                  />
+                ) : (
+                  <span className="text-sm text-control-placeholder">
+                    {target}
+                  </span>
+                )}
+              </div>
+            ))}
+            {targets.length > DEFAULT_VISIBLE_TARGETS && (
+              <button
+                className="h-7 cursor-pointer rounded-sm px-2 text-xs text-control transition-colors hover:bg-control-bg"
+                onClick={() => setShowAllTargetsDialog(true)}
+                type="button"
+              >
+                {t("plan.targets.view-all", { count: targets.length })}
+              </button>
+            )}
+          </div>
+        ) : (
+          <div className="py-1 text-sm text-control-light">
+            {t("plan.targets.no-targets-found")}
+          </div>
+        )}
+      </div>
+
+      <Dialog
+        open={showAllTargetsDialog}
+        onOpenChange={(open) => setShowAllTargetsDialog(open)}
+      >
+        <DialogContent className="relative max-w-[100vw] p-0 md:w-[50rem]">
+          <div className="flex h-full max-h-[calc(100vh-10rem)] flex-col gap-y-4">
+            <div className="flex items-center justify-between border-b px-4 py-4">
+              <DialogTitle>
+                {t("plan.targets.title")} ({targets.length})
+              </DialogTitle>
+              <DialogClose
+                render={
+                  <button
+                    className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm text-control transition-colors hover:bg-control-bg"
+                    type="button"
+                  />
+                }
+              >
+                <X className="h-4 w-4" />
+              </DialogClose>
+            </div>
+
+            <div className="px-4">
+              <SearchInput
+                placeholder={t("common.search")}
+                value={searchText}
+                onChange={(event) => setSearchText(event.target.value)}
+              />
+            </div>
+
+            <div className="flex-1 overflow-hidden px-4 pb-4">
+              {isLoadingAllTargets ? (
+                <div className="flex h-full items-center justify-center">
+                  <div className="h-5 w-5 animate-spin rounded-full border-2 border-control-border border-t-accent" />
+                </div>
+              ) : filteredTargets.length > 0 ? (
+                <div className="h-full overflow-y-auto">
+                  <div className="flex flex-wrap gap-2">
+                    {filteredTargets.map((target) => (
+                      <div
+                        key={target}
+                        className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1 transition-all"
+                      >
+                        {isValidDatabaseName(target) ? (
+                          <IssueDetailDatabaseTarget
+                            showEnvironment
+                            target={target}
+                          />
+                        ) : isValidDatabaseGroupName(target) ? (
+                          <IssueDetailDatabaseGroupTarget target={target} />
+                        ) : (
+                          <span className="text-sm">{target}</span>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <div className="flex h-full items-center justify-center text-control-light">
+                  {t("common.no-data")}
+                </div>
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function IssueDetailDatabaseTarget({
+  showEnvironment = false,
+  target,
+}: {
+  showEnvironment?: boolean;
+  target: string;
+}) {
+  const { t } = useTranslation();
+  const databaseStore = useDatabaseV1Store();
+  const environmentStore = useEnvironmentV1Store();
+  const database = useVueState(() => databaseStore.getDatabaseByName(target));
+  const environment = useVueState(() =>
+    environmentStore.getEnvironmentByName(
+      database.effectiveEnvironment ??
+        database.instanceResource?.environment ??
+        ""
+    )
+  );
+  const instance = database.instanceResource;
+  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
+  const { databaseName } = extractDatabaseResourceName(target);
+  const instanceTitle =
+    instance?.title ||
+    extractInstanceResourceName(target) ||
+    t("common.unknown");
+
+  return (
+    <div className="flex min-w-0 items-center truncate text-sm">
+      {engineIcon && (
+        <img alt="" className="mr-1 inline-block h-4 w-4" src={engineIcon} />
+      )}
+      {showEnvironment && (
+        <span className="mr-1 truncate text-gray-400">{environment.title}</span>
+      )}
+      <span className="truncate text-gray-600">{instanceTitle}</span>
+      <ChevronRight className="h-4 w-4 shrink-0 text-gray-500 opacity-60" />
+      <span className="truncate text-gray-800">{databaseName}</span>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseGroupTarget({
+  className,
+  target,
+}: {
+  className?: string;
+  target: string;
+}) {
+  const { t } = useTranslation();
+  const dbGroupStore = useDBGroupStore();
+  const databaseStore = useDatabaseV1Store();
+  const databaseGroup = useVueState(() =>
+    dbGroupStore.getDBGroupByName(target)
+  );
+  const databases = databaseGroup.matchedDatabases?.map((db) => db.name) ?? [];
+  const extraDatabases = databases.slice(MAX_INLINE_DATABASES);
+
+  useEffect(() => {
+    if (!isValidDatabaseGroupName(target)) {
+      return;
+    }
+    void dbGroupStore.getOrFetchDBGroupByName(target, {
+      silent: true,
+      view: DatabaseGroupView.FULL,
+    });
+  }, [dbGroupStore, target]);
+
+  useEffect(() => {
+    if (databases.length > 0) {
+      void databaseStore.batchGetOrFetchDatabases(databases);
+    }
+  }, [databaseStore, databases]);
+
+  const gotoDatabaseGroupDetailPage = () => {
+    const [projectId, databaseGroupName] =
+      getProjectNameAndDatabaseGroupName(target);
+    const url = router.resolve({
+      name: PROJECT_V1_ROUTE_DATABASE_GROUP_DETAIL,
+      params: {
+        databaseGroupName,
+        projectId,
+      },
+    }).fullPath;
+    window.open(url, "_blank");
+  };
+
+  return (
+    <div className={cn("flex w-full flex-col gap-2", className)}>
+      <div className="flex items-center gap-x-2">
+        <FolderTree className="h-5 w-5 shrink-0 text-control" />
+        <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs">
+          {t("common.database-group")}
+        </span>
+        <span className="truncate text-sm text-gray-800">
+          {extractDatabaseGroupName(databaseGroup.name || target)}
+        </span>
+        {isValidDatabaseGroupName(databaseGroup.name) && (
+          <button
+            className="flex cursor-pointer items-center opacity-60 hover:opacity-100"
+            onClick={gotoDatabaseGroupDetailPage}
+            type="button"
+          >
+            <ExternalLink className="h-4 w-auto" />
+          </button>
+        )}
+      </div>
+
+      {databases.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 pl-7">
+          {databases.slice(0, MAX_INLINE_DATABASES).map((database) => (
+            <div
+              key={database}
+              className="inline-flex cursor-default items-center gap-x-1 rounded-lg border bg-gray-50 px-2 py-1 transition-all"
+            >
+              <IssueDetailDatabaseTarget showEnvironment target={database} />
+            </div>
+          ))}
+          {extraDatabases.length > 0 && (
+            <Tooltip
+              content={
+                <div className="flex flex-col gap-y-1">
+                  {extraDatabases.map((database) => (
+                    <span key={database}>{database}</span>
+                  ))}
+                </div>
+              }
+              side="bottom"
+            >
+              <span className="cursor-pointer text-xs text-accent">
+                {t("common.n-more", {
+                  n: databases.length - MAX_INLINE_DATABASES,
+                })}
+              </span>
+            </Tooltip>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const fetchTargets = async (
+  targets: string[],
+  dbGroupStore: ReturnType<typeof useDBGroupStore>,
+  databaseStore: ReturnType<typeof useDatabaseV1Store>
+) => {
+  const databaseTargets = new Set<string>();
+
+  for (const target of targets) {
+    if (isValidDatabaseGroupName(target)) {
+      try {
+        const databaseGroup = await dbGroupStore.getOrFetchDBGroupByName(
+          target,
+          {
+            silent: true,
+            view: DatabaseGroupView.FULL,
+          }
+        );
+        for (const database of databaseGroup.matchedDatabases ?? []) {
+          databaseTargets.add(database.name);
+        }
+      } catch {
+        // Ignore target loading failures to match the current Vue behavior.
+      }
+      continue;
+    }
+    if (isValidDatabaseName(target)) {
+      databaseTargets.add(target);
+    }
+  }
+
+  if (databaseTargets.size > 0) {
+    await databaseStore.batchGetOrFetchDatabases([...databaseTargets]);
+  }
+
+  return [...databaseTargets];
+};

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
@@ -1,0 +1,377 @@
+import { Check, FastForward, Minus, Pause, X } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { EngineIconPath } from "@/react/components/instance/constants";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import { router } from "@/router";
+import { INSTANCE_ROUTE_DETAIL } from "@/router/dashboard/instance";
+import {
+  useEnvironmentV1Store,
+  useInstanceV1Store,
+  useProjectV1Store,
+  useSheetV1Store,
+} from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import {
+  formatEnvironmentName,
+  isValidEnvironmentName,
+  isValidInstanceName,
+} from "@/types";
+import type { Plan_CreateDatabaseConfig } from "@/types/proto-es/v1/plan_service_pb";
+import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  databaseV1Url,
+  extractCoreDatabaseInfoFromDatabaseCreateTask,
+  extractDatabaseResourceName,
+} from "@/utils";
+import {
+  extractInstanceResourceName,
+  instanceV1Name,
+} from "@/utils/v1/instance";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+import { IssueDetailTaskRunTable } from "./IssueDetailTaskRunTable";
+
+export function IssueDetailDatabaseCreateView() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const environmentStore = useEnvironmentV1Store();
+  const instanceStore = useInstanceV1Store();
+  const sheetStore = useSheetV1Store();
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+
+  const createDatabaseSpec = useMemo(() => {
+    return page.plan?.specs.find(
+      (spec) => spec.config?.case === "createDatabaseConfig"
+    );
+  }, [page.plan]);
+
+  const createDatabaseConfig =
+    createDatabaseSpec?.config?.case === "createDatabaseConfig"
+      ? (createDatabaseSpec.config.value as Plan_CreateDatabaseConfig)
+      : undefined;
+
+  const environmentName = createDatabaseConfig?.environment ?? "";
+  const targetInstanceName = createDatabaseConfig?.target ?? "";
+  const environment = useVueState(() =>
+    environmentStore.getEnvironmentByName(environmentName)
+  );
+  const instance = useVueState(() =>
+    instanceStore.getInstanceByName(targetInstanceName)
+  );
+
+  const createDatabaseTask = useMemo(() => {
+    if (!page.rollout || !createDatabaseSpec) {
+      return undefined;
+    }
+
+    for (const stage of page.rollout.stages) {
+      for (const task of stage.tasks) {
+        if (task.specId === createDatabaseSpec.id) {
+          return task;
+        }
+      }
+    }
+    return undefined;
+  }, [createDatabaseSpec, page.rollout]);
+
+  const taskRunsForCreateDatabase = useMemo(() => {
+    if (!createDatabaseTask) {
+      return [];
+    }
+    return page.taskRuns.filter((taskRun) =>
+      taskRun.name.startsWith(`${createDatabaseTask.name}/`)
+    );
+  }, [createDatabaseTask, page.taskRuns]);
+
+  const sheetName =
+    createDatabaseTask?.payload.case === "databaseCreate"
+      ? createDatabaseTask.payload.value.sheet
+      : "";
+
+  useEffect(() => {
+    if (sheetName) {
+      void sheetStore.getOrFetchSheetByName(sheetName);
+    }
+  }, [sheetName, sheetStore]);
+
+  useEffect(() => {
+    if (targetInstanceName) {
+      void instanceStore.getOrFetchInstanceByName(targetInstanceName);
+    }
+  }, [instanceStore, targetInstanceName]);
+
+  const isTaskDone = createDatabaseTask?.status === Task_Status.DONE;
+  const createdDatabase =
+    isTaskDone && createDatabaseTask && page.plan
+      ? extractCoreDatabaseInfoFromDatabaseCreateTask(
+          project,
+          createDatabaseTask,
+          page.plan
+        )
+      : undefined;
+  const displayInstanceName = extractInstanceResourceName(targetInstanceName);
+
+  return (
+    <div className="flex w-full flex-col gap-y-4">
+      <div className="flex flex-col gap-y-2">
+        <h3 className="text-base font-medium">{t("common.overview")}</h3>
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-600">
+              {t("common.environment")}:
+            </span>
+            <IssueDetailDatabaseCreateEnvironment
+              environmentName={environment.name}
+            >
+              {environment.title}
+            </IssueDetailDatabaseCreateEnvironment>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-600">
+              {t("common.instance")}:
+            </span>
+            {isValidInstanceName(instance.name) ? (
+              <IssueDetailDatabaseCreateInstance instanceName={instance.name}>
+                {instanceV1Name(instance)}
+              </IssueDetailDatabaseCreateInstance>
+            ) : (
+              <span className="text-gray-900">{displayInstanceName}</span>
+            )}
+          </div>
+
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-600">
+              {t("common.database")}:
+            </span>
+            {isTaskDone && createdDatabase ? (
+              <>
+                <a
+                  className="normal-link"
+                  href={databaseV1Url(createdDatabase)}
+                >
+                  {
+                    extractDatabaseResourceName(createdDatabase.name)
+                      .databaseName
+                  }
+                </a>
+                <span className="text-sm text-gray-500">
+                  ({t("common.created")})
+                </span>
+              </>
+            ) : (
+              <span className="text-gray-900">
+                {createDatabaseConfig?.database ?? ""}
+              </span>
+            )}
+          </div>
+
+          {createDatabaseTask && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-gray-600">
+                {t("common.status")}:
+              </span>
+              <IssueDetailTaskStatus status={createDatabaseTask.status} />
+            </div>
+          )}
+        </div>
+        {createDatabaseTask && taskRunsForCreateDatabase.length > 0 && (
+          <div className="mt-4">
+            <IssueDetailTaskRunTable taskRuns={taskRunsForCreateDatabase} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseCreateEnvironment({
+  children,
+  environmentName,
+}: {
+  children: string;
+  environmentName: string;
+}) {
+  const style = useMemo(() => {
+    if (!isValidEnvironmentName(environmentName)) {
+      return undefined;
+    }
+    const id = environmentName.split("/").pop();
+    if (!id) {
+      return undefined;
+    }
+    const href = `/${formatEnvironmentName(id)}`;
+    return href;
+  }, [environmentName]);
+
+  if (!style) {
+    return <span>{children}</span>;
+  }
+
+  return (
+    <a className="normal-link hover:underline" href={style}>
+      <span>{children}</span>
+    </a>
+  );
+}
+
+function IssueDetailDatabaseCreateInstance({
+  children,
+  instanceName,
+}: {
+  children: string;
+  instanceName: string;
+}) {
+  const instanceId = extractInstanceResourceName(instanceName);
+  const instanceHref = instanceId
+    ? router.resolve({
+        name: INSTANCE_ROUTE_DETAIL,
+        params: { instanceId },
+      }).href
+    : "";
+  const instanceStore = useInstanceV1Store();
+  const instance = useVueState(() =>
+    instanceStore.getInstanceByName(instanceName)
+  );
+  const engineIcon = EngineIconPath[instance.engine];
+
+  if (!instanceHref) {
+    return <span className="text-gray-900">{children}</span>;
+  }
+
+  return (
+    <a
+      className="inline-flex items-center gap-x-1 normal-link hover:underline"
+      href={instanceHref}
+      onClick={(event) => {
+        event.stopPropagation();
+      }}
+    >
+      {engineIcon && (
+        <img alt="" className="h-4 w-4 shrink-0" src={engineIcon} />
+      )}
+      <span className="truncate">{children}</span>
+    </a>
+  );
+}
+
+function IssueDetailTaskStatus({ status }: { status: Task_Status }) {
+  const { t } = useTranslation();
+  const classes = (() => {
+    const sizeClass = "h-5 w-5";
+    let statusClass = "";
+    switch (status) {
+      case Task_Status.NOT_STARTED:
+        statusClass = "bg-white border-2 border-control";
+        break;
+      case Task_Status.PENDING:
+        statusClass = "bg-white border-2 border-info text-info";
+        break;
+      case Task_Status.RUNNING:
+        statusClass = "bg-white border-2 border-info text-info";
+        break;
+      case Task_Status.SKIPPED:
+        statusClass = "bg-white border-2 border-control-light text-gray-600";
+        break;
+      case Task_Status.DONE:
+        statusClass = "bg-success text-white";
+        break;
+      case Task_Status.FAILED:
+        statusClass = "bg-error text-white";
+        break;
+      default:
+        statusClass = "";
+        break;
+    }
+    return `${sizeClass} ${statusClass}`;
+  })();
+
+  return (
+    <Tooltip content={taskStatusLabel(t, status)}>
+      <div
+        aria-label={taskStatusLabel(t, status)}
+        className={cn(
+          "relative flex shrink-0 select-none items-center justify-center overflow-hidden rounded-full",
+          classes
+        )}
+      >
+        {status === Task_Status.STATUS_UNSPECIFIED && (
+          <span className="h-full w-full rounded-full border border-dashed border-control" />
+        )}
+        {status === Task_Status.NOT_STARTED && (
+          <span
+            aria-hidden="true"
+            className="h-1/2 w-1/2 rounded-full bg-control"
+          />
+        )}
+        {status === Task_Status.PENDING && <Pause className="h-3/4 w-3/4" />}
+        {status === Task_Status.RUNNING && (
+          <div className="relative flex h-1/2 w-1/2 overflow-visible">
+            <span
+              aria-hidden="true"
+              className="absolute z-0 h-full w-full animate-ping-slow rounded-full"
+              style={{ backgroundColor: "rgba(37, 99, 235, 0.5)" }}
+            />
+            <span
+              aria-hidden="true"
+              className="z-1 h-full w-full rounded-full bg-info"
+            />
+          </div>
+        )}
+        {status === Task_Status.SKIPPED && (
+          <FastForward className="h-3/4 w-3/4" />
+        )}
+        {status === Task_Status.DONE && <Check className="h-3/4 w-3/4" />}
+        {status === Task_Status.FAILED && (
+          <span
+            aria-hidden="true"
+            className="rounded-full text-center text-base font-medium"
+          >
+            !
+          </span>
+        )}
+        {status === Task_Status.CANCELED && (
+          <Minus className="h-full w-full rounded-full border-2 border-control-light bg-white text-control-light" />
+        )}
+        {status !== Task_Status.CANCELED &&
+          status !== Task_Status.FAILED &&
+          status !== Task_Status.DONE &&
+          status !== Task_Status.SKIPPED &&
+          status !== Task_Status.RUNNING &&
+          status !== Task_Status.PENDING &&
+          status !== Task_Status.NOT_STARTED &&
+          status !== Task_Status.STATUS_UNSPECIFIED && (
+            <X className="h-3/4 w-3/4" />
+          )}
+      </div>
+    </Tooltip>
+  );
+}
+
+function taskStatusLabel(
+  t: ReturnType<typeof useTranslation>["t"],
+  status: Task_Status
+) {
+  switch (status) {
+    case Task_Status.NOT_STARTED:
+      return t("task.status.not-started");
+    case Task_Status.PENDING:
+      return t("task.status.pending");
+    case Task_Status.RUNNING:
+      return t("task.status.running");
+    case Task_Status.DONE:
+      return t("task.status.done");
+    case Task_Status.FAILED:
+      return t("task.status.failed");
+    case Task_Status.CANCELED:
+      return t("task.status.canceled");
+    case Task_Status.SKIPPED:
+      return t("task.status.skipped");
+    default:
+      return String(status);
+  }
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
@@ -1,0 +1,932 @@
+import { clone, create } from "@bufbuild/protobuf";
+import {
+  Check,
+  ChevronRight,
+  EllipsisVertical,
+  ExternalLink,
+  FastForward,
+  FolderTree,
+  Minus,
+  Pause,
+  X,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { planServiceClientConnect } from "@/connect";
+import { EngineIconPath } from "@/react/components/instance/constants";
+import { Button } from "@/react/components/ui/button";
+import { Input } from "@/react/components/ui/input";
+import { Switch } from "@/react/components/ui/switch";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { useClickOutside } from "@/react/hooks/useClickOutside";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import { router } from "@/router";
+import { PROJECT_V1_ROUTE_DATABASE_GROUP_DETAIL } from "@/router/dashboard/projectV1";
+import {
+  DEFAULT_MAX_RESULT_SIZE_IN_MB,
+  getProjectNameAndDatabaseGroupName,
+  pushNotification,
+  useDatabaseV1Store,
+  useDBGroupStore,
+  useEnvironmentV1Store,
+  useSettingV1Store,
+} from "@/store";
+import { isValidDatabaseGroupName, isValidDatabaseName } from "@/types";
+import { ExportFormat } from "@/types/proto-es/v1/common_pb";
+import { DatabaseGroupView } from "@/types/proto-es/v1/database_group_service_pb";
+import {
+  Plan_ExportDataConfigSchema,
+  PlanSchema,
+  UpdatePlanRequestSchema,
+} from "@/types/proto-es/v1/plan_service_pb";
+import { type Task, Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  extractDatabaseResourceName,
+  extractInstanceResourceName,
+  extractTaskUID,
+} from "@/utils";
+import { extractDatabaseGroupName } from "@/utils/v1/databaseGroup";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+import { refreshIssueDetailState } from "../utils/refreshIssueDetailState";
+import {
+  CANCELABLE_TASK_STATUSES,
+  RUNNABLE_TASK_STATUSES,
+} from "../utils/rollout";
+import { IssueDetailStatementSection } from "./IssueDetailStatementSection";
+import { IssueDetailTaskRolloutActionPanel } from "./IssueDetailTaskRolloutActionPanel";
+import { IssueDetailTaskRunTable } from "./IssueDetailTaskRunTable";
+
+const DEFAULT_DISPLAY_COUNT = 10;
+const MAX_INLINE_DATABASES = 5;
+const EXPORT_FORMATS = [
+  { label: "JSON", value: ExportFormat.JSON },
+  { label: "CSV", value: ExportFormat.CSV },
+  { label: "SQL", value: ExportFormat.SQL },
+  { label: "XLSX", value: ExportFormat.XLSX },
+] as const;
+
+export function IssueDetailDatabaseExportView({
+  executionHistoryExpanded,
+  onExecutionHistoryExpandedChange,
+  onTasksExpandedChange,
+  tasksExpanded,
+}: {
+  executionHistoryExpanded: boolean;
+  onExecutionHistoryExpandedChange: (expanded: boolean) => void;
+  onTasksExpandedChange: (expanded: boolean) => void;
+  tasksExpanded: boolean;
+}) {
+  const page = useIssueDetailContext();
+  const exportDataSpec = useMemo(() => {
+    return page.plan?.specs.find(
+      (spec) => spec.config?.case === "exportDataConfig"
+    );
+  }, [page.plan]);
+  const targets = useMemo(() => {
+    if (exportDataSpec?.config.case === "exportDataConfig") {
+      return exportDataSpec.config.value.targets ?? [];
+    }
+    return [];
+  }, [exportDataSpec]);
+  const tasks = useMemo(() => {
+    if (!page.rollout || !exportDataSpec) {
+      return [];
+    }
+    return page.rollout.stages
+      .flatMap((stage) => stage.tasks)
+      .filter((task) => task.specId === exportDataSpec.id);
+  }, [exportDataSpec, page.rollout]);
+  const showExecutionHistory = Boolean(
+    page.rollout && page.taskRuns.length > 0
+  );
+
+  return (
+    <div className="flex w-full flex-col gap-y-4">
+      {page.rollout ? (
+        <IssueDetailDatabaseExportTasks
+          onTasksExpandedChange={onTasksExpandedChange}
+          tasks={tasks}
+          tasksExpanded={tasksExpanded}
+        />
+      ) : (
+        <IssueDetailDatabaseExportTargets targets={targets} />
+      )}
+      {showExecutionHistory && (
+        <IssueDetailDatabaseExportExecutionHistory
+          expanded={executionHistoryExpanded}
+          onExpandedChange={onExecutionHistoryExpandedChange}
+        />
+      )}
+      <IssueDetailDatabaseExportLimits />
+      <IssueDetailDatabaseExportOptions />
+      <div className="flex flex-col">
+        {exportDataSpec && (
+          <IssueDetailStatementSection spec={exportDataSpec} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseExportOptions() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const exportDataSpec = useMemo(() => {
+    return page.plan?.specs.find(
+      (spec) => spec.config?.case === "exportDataConfig"
+    );
+  }, [page.plan]);
+  const exportDataConfig = useMemo(() => {
+    if (exportDataSpec?.config.case === "exportDataConfig") {
+      return exportDataSpec.config.value;
+    }
+    return undefined;
+  }, [exportDataSpec]);
+  const [editableConfig, setEditableConfig] = useState(() =>
+    create(Plan_ExportDataConfigSchema, {})
+  );
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    if (exportDataConfig && !isEditing) {
+      setEditableConfig(clone(Plan_ExportDataConfigSchema, exportDataConfig));
+    }
+  }, [exportDataConfig, isEditing]);
+
+  useEffect(() => {
+    page.setEditing("export-options", isEditing);
+    return () => {
+      page.setEditing("export-options", false);
+    };
+  }, [isEditing, page]);
+
+  const shouldShowEditButton = useMemo(() => {
+    if (page.readonly || page.isCreating || isEditing) {
+      return false;
+    }
+    return !page.plan?.hasRollout;
+  }, [isEditing, page.isCreating, page.plan?.hasRollout, page.readonly]);
+  const optionsEditable = page.isCreating || isEditing;
+  const encryptionEnabled = Boolean(editableConfig.password);
+  const selectedFormatLabel =
+    EXPORT_FORMATS.find((item) => item.value === editableConfig.format)
+      ?.label ?? "JSON";
+  const hasChanges = useMemo(() => {
+    if (!isEditing || !exportDataConfig) {
+      return false;
+    }
+    return (
+      editableConfig.format !== exportDataConfig.format ||
+      editableConfig.password !== exportDataConfig.password
+    );
+  }, [editableConfig, exportDataConfig, isEditing]);
+
+  const handleFormatChange = (value: string) => {
+    setEditableConfig((current) =>
+      create(Plan_ExportDataConfigSchema, {
+        ...current,
+        format: Number(value) as ExportFormat,
+      })
+    );
+  };
+
+  const handlePasswordEnabledChange = (checked: boolean) => {
+    setEditableConfig((current) =>
+      create(Plan_ExportDataConfigSchema, {
+        ...current,
+        password: checked ? current.password : "",
+      })
+    );
+  };
+
+  const handlePasswordChange = (password: string) => {
+    setEditableConfig((current) =>
+      create(Plan_ExportDataConfigSchema, {
+        ...current,
+        password,
+      })
+    );
+  };
+
+  const handleEdit = () => {
+    if (!exportDataConfig) {
+      return;
+    }
+    setEditableConfig(clone(Plan_ExportDataConfigSchema, exportDataConfig));
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    if (exportDataConfig) {
+      setEditableConfig(clone(Plan_ExportDataConfigSchema, exportDataConfig));
+    }
+  };
+
+  const handleSave = async () => {
+    if (!page.plan || !exportDataSpec || !hasChanges) {
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      const planPatch = clone(PlanSchema, page.plan);
+      const specToPatch = planPatch.specs.find(
+        (spec) => spec.id === exportDataSpec.id
+      );
+      if (!specToPatch || specToPatch.config.case !== "exportDataConfig") {
+        throw new Error("Cannot find export data spec to update");
+      }
+
+      specToPatch.config.value = clone(
+        Plan_ExportDataConfigSchema,
+        editableConfig
+      );
+
+      const request = create(UpdatePlanRequestSchema, {
+        plan: planPatch,
+        updateMask: { paths: ["specs"] },
+      });
+      const response = await planServiceClientConnect.updatePlan(request);
+      page.patchState({ plan: response });
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: t("common.updated"),
+      });
+      setIsEditing(false);
+    } catch (error) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.error"),
+        description: String(error),
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-base font-medium">
+          {t("issue.data-export.options")}
+        </h3>
+        {(shouldShowEditButton || isEditing) && (
+          <div className="flex items-center justify-end gap-x-2">
+            {!isEditing ? (
+              <Button onClick={handleEdit} size="xs" variant="outline">
+                {t("common.edit")}
+              </Button>
+            ) : (
+              <>
+                <Button
+                  disabled={!hasChanges || isSaving}
+                  onClick={handleSave}
+                  size="xs"
+                  variant="outline"
+                >
+                  {t("common.save")}
+                </Button>
+                <Button onClick={handleCancel} size="xs" variant="ghost">
+                  {t("common.cancel")}
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-y-3 rounded-sm border p-3">
+        <div className="flex items-center gap-4">
+          <span className="text-sm">{t("issue.data-export.format")}</span>
+          {optionsEditable ? (
+            <div className="flex flex-wrap items-center gap-4">
+              {EXPORT_FORMATS.map((item) => (
+                <label
+                  key={item.value}
+                  className="inline-flex cursor-pointer items-center gap-2 text-sm"
+                >
+                  <input
+                    checked={editableConfig.format === item.value}
+                    className="h-4 w-4"
+                    name="export-format"
+                    onChange={() => handleFormatChange(String(item.value))}
+                    type="radio"
+                  />
+                  <span>{item.label}</span>
+                </label>
+              ))}
+            </div>
+          ) : (
+            <span className="text-sm font-medium leading-6">
+              {selectedFormatLabel}
+            </span>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-4 md:flex-row md:items-center">
+          <div className="flex items-center gap-4">
+            <span className="text-sm">
+              {t("export-data.password-optional")}
+            </span>
+            <Switch
+              checked={encryptionEnabled}
+              disabled={!optionsEditable}
+              onCheckedChange={handlePasswordEnabledChange}
+              size="small"
+            />
+          </div>
+          {optionsEditable && encryptionEnabled && (
+            <div className="flex items-center gap-4">
+              <span className="text-sm">
+                {t("common.password")} <span className="text-red-600">*</span>
+              </span>
+              <Input
+                autoComplete="new-password"
+                className="h-8 w-auto min-w-48"
+                onChange={(event) => handlePasswordChange(event.target.value)}
+                placeholder={t("common.password")}
+                type="password"
+                value={editableConfig.password}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseExportTasks({
+  onTasksExpandedChange,
+  tasks,
+  tasksExpanded,
+}: {
+  onTasksExpandedChange: (expanded: boolean) => void;
+  tasks: Task[];
+  tasksExpanded: boolean;
+}) {
+  const { t } = useTranslation();
+  const databaseStore = useDatabaseV1Store();
+  const visibleTasks = tasksExpanded
+    ? tasks
+    : tasks.slice(0, DEFAULT_DISPLAY_COUNT);
+  const hasMore = tasks.length > DEFAULT_DISPLAY_COUNT;
+  const remainingCount = tasks.length - DEFAULT_DISPLAY_COUNT;
+
+  useEffect(() => {
+    const targets = tasks.map((task) => task.target);
+    if (targets.length > 0) {
+      void databaseStore.batchGetOrFetchDatabases(targets);
+    }
+  }, [databaseStore, tasks]);
+
+  if (tasks.length === 0) {
+    return (
+      <div className="py-8 text-center text-control-light">
+        {t("common.no-data")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <h3 className="text-base font-medium">{t("common.task")}</h3>
+      <div
+        className={cn(
+          "flex flex-wrap gap-2",
+          tasksExpanded && hasMore && "max-h-96 overflow-y-auto"
+        )}
+      >
+        {visibleTasks.map((task) => (
+          <div
+            key={task.name}
+            className="inline-flex min-w-0 items-center gap-2 rounded-sm border px-2 py-1.5"
+          >
+            <IssueDetailTaskStatus status={task.status} tiny />
+            <IssueDetailDatabaseExportDatabaseTarget target={task.target} />
+            <IssueDetailDatabaseExportTaskActions task={task} />
+          </div>
+        ))}
+        {hasMore && (
+          <button
+            className="cursor-pointer px-2 text-sm text-accent"
+            onClick={() => onTasksExpandedChange(!tasksExpanded)}
+            type="button"
+          >
+            {tasksExpanded
+              ? t("common.collapse")
+              : `${t("common.show-more")} (${remainingCount} ${t("common.remaining")})`}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseExportTaskActions({ task }: { task: Task }) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [pendingAction, setPendingAction] = useState<
+    "RUN" | "SKIP" | "CANCEL" | undefined
+  >();
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useClickOutside(menuRef, menuOpen, () => setMenuOpen(false));
+
+  const stage = useMemo(() => {
+    return page.rollout?.stages.find((candidate) =>
+      candidate.tasks.some((item) => item.name === task.name)
+    );
+  }, [page.rollout?.stages, task.name]);
+
+  const canRun = RUNNABLE_TASK_STATUSES.includes(task.status);
+  const canSkip = RUNNABLE_TASK_STATUSES.includes(task.status);
+  const canCancel = CANCELABLE_TASK_STATUSES.includes(task.status);
+  const primaryAction = canRun
+    ? task.status === Task_Status.FAILED
+      ? "RETRY"
+      : "RUN"
+    : undefined;
+
+  if (!stage || (!canRun && !canSkip && !canCancel)) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="relative flex items-center gap-x-2" ref={menuRef}>
+        {primaryAction && (
+          <Button
+            onClick={() => setPendingAction("RUN")}
+            size="xs"
+            variant="outline"
+          >
+            {primaryAction === "RETRY" ? t("common.retry") : t("common.run")}
+          </Button>
+        )}
+        {(canSkip || canCancel) && (
+          <>
+            <Button
+              aria-label={t("common.more")}
+              className="px-1"
+              onClick={() => setMenuOpen((open) => !open)}
+              size="xs"
+              variant="ghost"
+            >
+              <EllipsisVertical className="h-3.5 w-3.5" />
+            </Button>
+            {menuOpen && (
+              <div className="absolute right-0 top-full z-20 mt-1 min-w-36 overflow-hidden rounded-sm border border-control-border bg-white py-1 shadow-lg">
+                {canSkip && (
+                  <button
+                    className="flex w-full items-center px-3 py-2 text-left text-sm hover:bg-control-bg"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      setPendingAction("SKIP");
+                    }}
+                    type="button"
+                  >
+                    {t("common.skip")}
+                  </button>
+                )}
+                {canCancel && (
+                  <button
+                    className="flex w-full items-center px-3 py-2 text-left text-sm hover:bg-control-bg"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      setPendingAction("CANCEL");
+                    }}
+                    type="button"
+                  >
+                    {t("common.cancel")}
+                  </button>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <IssueDetailTaskRolloutActionPanel
+        action={pendingAction}
+        onConfirm={() => refreshIssueDetailState(page)}
+        open={Boolean(pendingAction)}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingAction(undefined);
+          }
+        }}
+        target={{ type: "tasks", tasks: [task], stage }}
+      />
+    </>
+  );
+}
+
+function IssueDetailDatabaseExportExecutionHistory({
+  expanded,
+  onExpandedChange,
+}: {
+  expanded: boolean;
+  onExpandedChange: (expanded: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const allTaskRuns = useMemo(() => {
+    const exportDataSpec = page.plan?.specs.find(
+      (spec) => spec.config?.case === "exportDataConfig"
+    );
+    if (!page.rollout || !exportDataSpec) {
+      return [];
+    }
+
+    const exportTaskUIDs = new Set(
+      page.rollout.stages
+        .flatMap((stage) => stage.tasks)
+        .filter((task) => task.specId === exportDataSpec.id)
+        .map((task) => extractTaskUID(task.name))
+    );
+
+    return page.taskRuns.filter((taskRun) =>
+      exportTaskUIDs.has(extractTaskUID(taskRun.name))
+    );
+  }, [page.plan, page.rollout, page.taskRuns]);
+
+  if (!page.rollout || allTaskRuns.length === 0) {
+    return null;
+  }
+
+  const visibleTaskRuns =
+    expanded || allTaskRuns.length <= DEFAULT_DISPLAY_COUNT
+      ? allTaskRuns
+      : allTaskRuns.slice(0, DEFAULT_DISPLAY_COUNT);
+  const hasMore = allTaskRuns.length > DEFAULT_DISPLAY_COUNT;
+  const remainingCount = allTaskRuns.length - DEFAULT_DISPLAY_COUNT;
+  const maxHeight = expanded && allTaskRuns.length > 50 ? "80vh" : undefined;
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="flex flex-col gap-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-medium">{t("task-run.history")}</h3>
+        </div>
+
+        <div>
+          <IssueDetailTaskRunTable
+            maxHeight={maxHeight}
+            showDatabaseColumn
+            taskRuns={visibleTaskRuns}
+          />
+          {hasMore && (
+            <div className="mt-2 flex justify-center">
+              <button
+                className="h-7 rounded-sm px-2 text-sm text-control transition-colors hover:bg-control-bg"
+                onClick={() => onExpandedChange(!expanded)}
+                type="button"
+              >
+                {expanded
+                  ? t("common.collapse")
+                  : `${t("common.show-more")} (${remainingCount} ${t("common.remaining")})`}
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseExportTargets({ targets }: { targets: string[] }) {
+  const { t } = useTranslation();
+  const databaseStore = useDatabaseV1Store();
+  const dbGroupStore = useDBGroupStore();
+
+  useEffect(() => {
+    for (const target of targets) {
+      if (isValidDatabaseName(target)) {
+        void databaseStore.getOrFetchDatabaseByName(target);
+      } else if (isValidDatabaseGroupName(target)) {
+        void dbGroupStore.getOrFetchDBGroupByName(target, {
+          view: DatabaseGroupView.FULL,
+        });
+      }
+    }
+  }, [databaseStore, dbGroupStore, targets]);
+
+  if (targets.length === 0) {
+    return (
+      <div className="py-8 text-center text-control-light">
+        {t("common.no-data")}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <h3 className="text-base font-medium">{t("plan.targets.title")}</h3>
+      <div className="flex flex-wrap gap-2">
+        {targets.map((target) => (
+          <div
+            key={target}
+            className="inline-flex min-w-0 items-center gap-2 rounded-sm border px-2 py-1.5"
+          >
+            {isValidDatabaseName(target) ? (
+              <IssueDetailDatabaseExportDatabaseTarget target={target} />
+            ) : isValidDatabaseGroupName(target) ? (
+              <IssueDetailDatabaseExportDatabaseGroupTarget target={target} />
+            ) : (
+              <span className="text-sm">{target}</span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseExportDatabaseTarget({
+  target,
+}: {
+  target: string;
+}) {
+  const { t } = useTranslation();
+  const databaseStore = useDatabaseV1Store();
+  const environmentStore = useEnvironmentV1Store();
+  const database = useVueState(() => databaseStore.getDatabaseByName(target));
+  const environment = useVueState(() =>
+    environmentStore.getEnvironmentByName(
+      database.effectiveEnvironment ??
+        database.instanceResource?.environment ??
+        ""
+    )
+  );
+  const instance = database.instanceResource;
+  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
+  const { databaseName } = extractDatabaseResourceName(target);
+  const instanceTitle =
+    instance?.title ||
+    extractInstanceResourceName(target) ||
+    t("common.unknown");
+
+  return (
+    <div className="flex min-w-0 items-center truncate text-sm">
+      {engineIcon && (
+        <img alt="" className="mr-1 inline-block h-4 w-4" src={engineIcon} />
+      )}
+      <span className="mr-1 truncate text-gray-400">{environment.title}</span>
+      <span className="truncate text-gray-600">{instanceTitle}</span>
+      <ChevronRight className="h-4 w-4 shrink-0 text-gray-500 opacity-60" />
+      <span className="truncate text-gray-800">{databaseName}</span>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseExportDatabaseGroupTarget({
+  target,
+}: {
+  target: string;
+}) {
+  const { t } = useTranslation();
+  const dbGroupStore = useDBGroupStore();
+  const databaseStore = useDatabaseV1Store();
+  const databaseGroup = useVueState(() =>
+    dbGroupStore.getDBGroupByName(target)
+  );
+  const databases = databaseGroup.matchedDatabases?.map((db) => db.name) ?? [];
+  const extraDatabases = databases.slice(MAX_INLINE_DATABASES);
+
+  useEffect(() => {
+    if (!isValidDatabaseGroupName(target)) {
+      return;
+    }
+    void dbGroupStore.getOrFetchDBGroupByName(target, {
+      silent: true,
+      view: DatabaseGroupView.FULL,
+    });
+  }, [dbGroupStore, target]);
+
+  useEffect(() => {
+    if (databases.length > 0) {
+      void databaseStore.batchGetOrFetchDatabases(databases);
+    }
+  }, [databaseStore, databases]);
+
+  const gotoDatabaseGroupDetailPage = () => {
+    const [projectId, databaseGroupName] =
+      getProjectNameAndDatabaseGroupName(target);
+    const url = router.resolve({
+      name: PROJECT_V1_ROUTE_DATABASE_GROUP_DETAIL,
+      params: {
+        databaseGroupName,
+        projectId,
+      },
+    }).fullPath;
+    window.open(url, "_blank");
+  };
+
+  return (
+    <div className="flex w-full flex-col gap-2 px-1 py-1">
+      <div className="flex items-center gap-x-2">
+        <FolderTree className="h-5 w-5 shrink-0 text-control" />
+        <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs">
+          {t("common.database-group")}
+        </span>
+        <span className="truncate text-sm text-gray-800">
+          {extractDatabaseGroupName(databaseGroup.name || target)}
+        </span>
+        {isValidDatabaseGroupName(databaseGroup.name) && (
+          <button
+            className="flex cursor-pointer items-center opacity-60 hover:opacity-100"
+            onClick={gotoDatabaseGroupDetailPage}
+            type="button"
+          >
+            <ExternalLink className="h-4 w-auto" />
+          </button>
+        )}
+      </div>
+
+      {databases.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 pl-7">
+          {databases.slice(0, MAX_INLINE_DATABASES).map((database) => (
+            <div
+              key={database}
+              className="inline-flex cursor-default items-center gap-x-1 rounded-lg border bg-gray-50 px-2 py-1 transition-all"
+            >
+              <IssueDetailDatabaseExportDatabaseTarget target={database} />
+            </div>
+          ))}
+          {extraDatabases.length > 0 && (
+            <Tooltip
+              content={
+                <div className="flex flex-col gap-y-1">
+                  {extraDatabases.map((database) => (
+                    <span key={database}>{database}</span>
+                  ))}
+                </div>
+              }
+              side="bottom"
+            >
+              <span className="cursor-pointer text-xs text-accent">
+                {t("common.n-more", {
+                  n: databases.length - MAX_INLINE_DATABASES,
+                })}
+              </span>
+            </Tooltip>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IssueDetailDatabaseExportLimits() {
+  const { t } = useTranslation();
+  const settingStore = useSettingV1Store();
+  const maximumResultSize = useVueState(() => {
+    let size = settingStore.workspaceProfile.sqlResultSize;
+    if (size <= 0) {
+      size = BigInt(DEFAULT_MAX_RESULT_SIZE_IN_MB * 1024 * 1024);
+    }
+    return Number(size) / 1024 / 1024;
+  });
+
+  return (
+    <div className="flex w-full flex-col gap-y-2">
+      <h3 className="text-base font-medium">{t("issue.data-export.limits")}</h3>
+      <div className="flex items-center gap-x-2">
+        <span className="text-sm">
+          {t("settings.general.workspace.maximum-sql-result.size.self")}
+        </span>
+        <span className="font-medium">{maximumResultSize} MB</span>
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailTaskStatus({
+  status,
+  tiny = false,
+}: {
+  status: Task_Status;
+  tiny?: boolean;
+}) {
+  const { t } = useTranslation();
+  const classes = (() => {
+    const sizeClass = tiny ? "h-4 w-4" : "h-5 w-5";
+    let statusClass = "";
+    switch (status) {
+      case Task_Status.NOT_STARTED:
+        statusClass = "bg-white border-2 border-control";
+        break;
+      case Task_Status.PENDING:
+        statusClass = "bg-white border-2 border-info text-info";
+        break;
+      case Task_Status.RUNNING:
+        statusClass = "bg-white border-2 border-info text-info";
+        break;
+      case Task_Status.SKIPPED:
+        statusClass = "bg-white border-2 border-control-light text-gray-600";
+        break;
+      case Task_Status.DONE:
+        statusClass = "bg-success text-white";
+        break;
+      case Task_Status.FAILED:
+        statusClass = "bg-error text-white";
+        break;
+      default:
+        statusClass = "";
+        break;
+    }
+    return `${sizeClass} ${statusClass}`;
+  })();
+
+  return (
+    <Tooltip content={taskStatusLabel(t, status)}>
+      <div
+        aria-label={taskStatusLabel(t, status)}
+        className={cn(
+          "relative flex shrink-0 select-none items-center justify-center overflow-hidden rounded-full",
+          classes
+        )}
+      >
+        {status === Task_Status.STATUS_UNSPECIFIED && (
+          <span className="h-full w-full rounded-full border border-dashed border-control" />
+        )}
+        {status === Task_Status.NOT_STARTED && (
+          <span
+            aria-hidden="true"
+            className="h-1/2 w-1/2 rounded-full bg-control"
+          />
+        )}
+        {status === Task_Status.PENDING && <Pause className="h-3/4 w-3/4" />}
+        {status === Task_Status.RUNNING && (
+          <div className="relative flex h-1/2 w-1/2 overflow-visible">
+            <span
+              aria-hidden="true"
+              className="absolute z-0 h-full w-full animate-ping-slow rounded-full"
+              style={{ backgroundColor: "rgba(37, 99, 235, 0.5)" }}
+            />
+            <span
+              aria-hidden="true"
+              className="z-1 h-full w-full rounded-full bg-info"
+            />
+          </div>
+        )}
+        {status === Task_Status.SKIPPED && (
+          <FastForward className="h-3/4 w-3/4" />
+        )}
+        {status === Task_Status.DONE && <Check className="h-3/4 w-3/4" />}
+        {status === Task_Status.FAILED && (
+          <span
+            aria-hidden="true"
+            className="rounded-full text-center text-base font-medium"
+          >
+            !
+          </span>
+        )}
+        {status === Task_Status.CANCELED && (
+          <Minus className="h-full w-full rounded-full border-2 border-control-light bg-white text-control-light" />
+        )}
+        {status !== Task_Status.CANCELED &&
+          status !== Task_Status.FAILED &&
+          status !== Task_Status.DONE &&
+          status !== Task_Status.SKIPPED &&
+          status !== Task_Status.RUNNING &&
+          status !== Task_Status.PENDING &&
+          status !== Task_Status.NOT_STARTED &&
+          status !== Task_Status.STATUS_UNSPECIFIED && (
+            <X className="h-3/4 w-3/4" />
+          )}
+      </div>
+    </Tooltip>
+  );
+}
+
+function taskStatusLabel(
+  t: ReturnType<typeof useTranslation>["t"],
+  status: Task_Status
+) {
+  switch (status) {
+    case Task_Status.NOT_STARTED:
+      return t("task.status.not-started");
+    case Task_Status.PENDING:
+      return t("task.status.pending");
+    case Task_Status.RUNNING:
+      return t("task.status.running");
+    case Task_Status.DONE:
+      return t("task.status.done");
+    case Task_Status.FAILED:
+      return t("task.status.failed");
+    case Task_Status.CANCELED:
+      return t("task.status.canceled");
+    case Task_Status.SKIPPED:
+      return t("task.status.skipped");
+    default:
+      return t("common.unknown");
+  }
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailHeader.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailHeader.tsx
@@ -1,0 +1,57 @@
+import { Ban, CheckCircle2, Menu } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Badge } from "@/react/components/ui/badge";
+import { Button } from "@/react/components/ui/button";
+import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+import { IssueDetailActionBar } from "./IssueDetailActionBar";
+import { IssueDetailTitleInput } from "./IssueDetailTitleInput";
+
+export function IssueDetailHeader() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const showClosedTag = page.issue?.status === IssueStatus.CANCELED;
+  const showDoneTag = page.issue?.status === IssueStatus.DONE;
+  const showMobileSidebarButton = page.sidebarMode === "MOBILE";
+
+  return (
+    <div className="px-2 py-2 sm:px-4">
+      <div className="flex flex-row items-center justify-between gap-2">
+        {showClosedTag && (
+          <Badge
+            className="shrink-0 gap-x-1.5 rounded-full px-3 py-1"
+            variant="default"
+          >
+            <Ban className="h-4 w-4" />
+            {t("common.closed")}
+          </Badge>
+        )}
+        {showDoneTag && !showClosedTag && (
+          <Badge
+            className="shrink-0 gap-x-1.5 rounded-full px-3 py-1"
+            variant="success"
+          >
+            <CheckCircle2 className="h-4 w-4" />
+            {t("common.approved")}
+          </Badge>
+        )}
+
+        <IssueDetailTitleInput />
+
+        <div className="flex flex-row items-center justify-end gap-x-2">
+          <IssueDetailActionBar />
+          {showMobileSidebarButton && (
+            <Button
+              aria-label={t("common.open")}
+              onClick={() => page.setMobileSidebarOpen(true)}
+              size="icon"
+              variant="ghost"
+            >
+              <Menu className="h-5 w-5" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailLabels.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailLabels.tsx
@@ -1,0 +1,241 @@
+import { create } from "@bufbuild/protobuf";
+import { ChevronDown, ExternalLink, X } from "lucide-react";
+import {
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+import { issueServiceClientConnect } from "@/connect";
+import { useClickOutside } from "@/react/hooks/useClickOutside";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import { router } from "@/router";
+import { PROJECT_V1_ROUTE_SETTINGS } from "@/router/dashboard/projectV1";
+import { pushNotification, useProjectV1Store } from "@/store";
+import { getProjectName, projectNamePrefix } from "@/store/modules/v1/common";
+import {
+  IssueStatus,
+  UpdateIssueRequestSchema,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { hasProjectPermissionV2 } from "@/utils";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+
+type IssueLabelOption = {
+  color: string;
+  value: string;
+};
+
+export function IssueDetailLabels() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+
+  useClickOutside(containerRef, open, () => setOpen(false));
+
+  const options = useMemo<IssueLabelOption[]>(() => {
+    return (project?.issueLabels ?? []).map((label) => ({
+      color: label.color,
+      value: label.value,
+    }));
+  }, [project?.issueLabels]);
+  const selected = useMemo(() => {
+    const pool = new Set(options.map((label) => label.value));
+    return (page.issue?.labels ?? []).filter((label) => pool.has(label));
+  }, [options, page.issue?.labels]);
+  const allowChange = useMemo(() => {
+    if (!project || !page.issue || page.issue.status !== IssueStatus.OPEN) {
+      return false;
+    }
+    return hasProjectPermissionV2(project, "bb.issues.update");
+  }, [page.issue, project]);
+  const settingsHref = useMemo(() => {
+    if (!project) {
+      return "";
+    }
+    return router.resolve({
+      hash: "#issue-related",
+      name: PROJECT_V1_ROUTE_SETTINGS,
+      params: {
+        projectId: getProjectName(project.name),
+      },
+    }).href;
+  }, [project]);
+
+  const updateLabels = useCallback(
+    async (labels: string[]) => {
+      if (!page.issue) {
+        return;
+      }
+      try {
+        setIsUpdating(true);
+        const request = create(UpdateIssueRequestSchema, {
+          issue: {
+            ...page.issue,
+            labels,
+          },
+          updateMask: { paths: ["labels"] },
+        });
+        const response = await issueServiceClientConnect.updateIssue(request);
+        page.patchState({ issue: response });
+        pushNotification({
+          module: "bytebase",
+          style: "SUCCESS",
+          title: t("common.updated"),
+        });
+      } catch (error) {
+        pushNotification({
+          module: "bytebase",
+          style: "CRITICAL",
+          title: t("common.failed"),
+          description: String(error),
+        });
+      } finally {
+        setIsUpdating(false);
+      }
+    },
+    [page.issue, t]
+  );
+
+  const toggleLabel = useCallback(
+    async (value: string) => {
+      const next = selected.includes(value)
+        ? selected.filter((label) => label !== value)
+        : [...selected, value];
+      await updateLabels(next);
+    },
+    [selected, updateLabels]
+  );
+
+  const removeSelectedLabel = useCallback(
+    async (value: string, e: ReactMouseEvent) => {
+      e.stopPropagation();
+      await updateLabels(selected.filter((label) => label !== value));
+    },
+    [selected, updateLabels]
+  );
+
+  return (
+    <div className="flex flex-col gap-y-1">
+      <div className="flex items-center gap-x-1 textinfolabel">
+        <span>{t("issue.labels")}</span>
+        {project?.forceIssueLabels && <span className="text-error">*</span>}
+      </div>
+      <div ref={containerRef} className="relative">
+        <button
+          className={cn(
+            "flex min-h-9 w-full items-center justify-between gap-2 rounded-sm border border-control-border bg-white px-3 py-1.5 text-left text-sm transition-colors",
+            allowChange && !isUpdating && "hover:bg-control-bg",
+            open && "border-accent shadow-[0_0_0_1px_var(--color-accent)]",
+            (!allowChange || isUpdating) && "cursor-not-allowed opacity-60"
+          )}
+          disabled={!allowChange || isUpdating}
+          onClick={() => setOpen((current) => !current)}
+          type="button"
+        >
+          <div className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+            {selected.length > 0 ? (
+              selected.map((value) => {
+                const option = options.find((item) => item.value === value);
+                return (
+                  <span
+                    key={value}
+                    className="inline-flex items-center gap-1 rounded-xs bg-control-bg px-1.5 py-0.5 text-xs"
+                  >
+                    <span
+                      className="size-2.5 shrink-0 rounded-sm"
+                      style={{ backgroundColor: option?.color }}
+                    />
+                    <span className="truncate">{value}</span>
+                    {allowChange && !isUpdating && (
+                      <button
+                        className="text-control-placeholder hover:text-control"
+                        onClick={(e) => {
+                          void removeSelectedLabel(value, e);
+                        }}
+                        type="button"
+                      >
+                        <X className="size-3" />
+                      </button>
+                    )}
+                  </span>
+                );
+              })
+            ) : (
+              <span className="text-control-placeholder">
+                {t("common.select")}
+              </span>
+            )}
+          </div>
+          <ChevronDown
+            className={cn(
+              "size-4 shrink-0 text-control-placeholder transition-transform",
+              open && "rotate-180"
+            )}
+          />
+        </button>
+
+        {open && (
+          <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-sm border border-control-border bg-white shadow-lg">
+            <div className="max-h-60 overflow-y-auto">
+              {options.length === 0 ? (
+                <div className="flex flex-col items-center gap-y-3 px-3 py-6 text-sm text-control-placeholder">
+                  <span>{t("common.no-data")}</span>
+                  {settingsHref &&
+                    project &&
+                    hasProjectPermissionV2(project, "bb.projects.update") && (
+                      <a
+                        className="flex items-center gap-x-2 textinfolabel normal-link"
+                        href={settingsHref}
+                      >
+                        <span>
+                          {t(
+                            "project.settings.issue-related.labels.configure-labels"
+                          )}
+                        </span>
+                        <ExternalLink className="h-4 w-4" />
+                      </a>
+                    )}
+                </div>
+              ) : (
+                options.map((option) => {
+                  const isSelected = selected.includes(option.value);
+                  return (
+                    <button
+                      key={option.value}
+                      className="flex w-full items-center gap-x-2 px-3 py-2 text-left text-sm transition-colors hover:bg-control-bg"
+                      disabled={isUpdating}
+                      onClick={() => {
+                        void toggleLabel(option.value);
+                      }}
+                      type="button"
+                    >
+                      <input
+                        checked={isSelected}
+                        className="accent-accent"
+                        readOnly
+                        type="checkbox"
+                      />
+                      <span
+                        className="size-4 shrink-0 rounded-sm"
+                        style={{ backgroundColor: option.color }}
+                      />
+                      <span>{option.value}</span>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx
@@ -1,0 +1,213 @@
+import dayjs from "dayjs";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
+import { useVueState } from "@/react/hooks/useVueState";
+import {
+  useDatabaseV1Store,
+  useEnvironmentV1Store,
+  useInstanceV1Store,
+  useRoleStore,
+} from "@/store";
+import type { DatabaseResource } from "@/types";
+import { displayRoleTitle } from "@/utils";
+import {
+  type ConditionExpression,
+  convertFromCELString,
+} from "@/utils/issue/cel";
+import { extractDatabaseResourceName } from "@/utils/v1/database";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+
+export function IssueDetailRoleGrantDetails() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const roleStore = useRoleStore();
+  const databaseStore = useDatabaseV1Store();
+  const issue = page.issue;
+  const requestRoleName = issue?.roleGrant?.role ?? "";
+  const requestRole = useVueState(() =>
+    roleStore.getRoleByName(requestRoleName)
+  );
+  const [condition, setCondition] = useState<ConditionExpression | undefined>();
+
+  useEffect(() => {
+    let canceled = false;
+
+    const run = async () => {
+      const expression = issue?.roleGrant?.condition?.expression ?? "";
+      if (!expression) {
+        setCondition(undefined);
+        return;
+      }
+      try {
+        const parsed = await convertFromCELString(expression);
+        if (!canceled) {
+          setCondition(parsed);
+        }
+      } catch (error) {
+        console.error("Failed to parse CEL expression:", error);
+        if (!canceled) {
+          setCondition(undefined);
+        }
+      }
+    };
+
+    void run();
+    return () => {
+      canceled = true;
+    };
+  }, [issue?.roleGrant?.condition?.expression]);
+
+  useEffect(() => {
+    const resources = condition?.databaseResources ?? [];
+    if (resources.length > 0) {
+      void databaseStore.batchGetOrFetchDatabases(
+        resources.map((resource) => resource.databaseFullName)
+      );
+    }
+  }, [condition?.databaseResources, databaseStore]);
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <h3 className="text-base font-medium">{t("issue.role-grant.details")}</h3>
+
+      <div className="flex flex-col gap-y-4 rounded-sm border p-4">
+        {requestRoleName && (
+          <div className="flex flex-col gap-y-2">
+            <span className="text-sm text-control-light">{t("role.self")}</span>
+            <div className="text-base">{displayRoleTitle(requestRoleName)}</div>
+          </div>
+        )}
+
+        {requestRole && (
+          <div className="flex flex-col gap-y-2">
+            <span className="text-sm text-control-light">
+              {t("common.permissions")} ({requestRole.permissions.length})
+            </span>
+            <div className="max-h-[10em] overflow-auto rounded-sm border p-2">
+              {requestRole.permissions.map((permission) => (
+                <p key={permission} className="text-sm leading-5">
+                  {permission}
+                </p>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {condition?.databaseResources && (
+          <div className="flex flex-col gap-y-2">
+            <span className="text-sm text-control-light">
+              {t("common.database")}
+            </span>
+            <div>
+              {condition.databaseResources.length === 0 ? (
+                <span>{t("issue.role-grant.all-databases")}</span>
+              ) : (
+                <IssueDetailDatabaseResourceTable
+                  databaseResourceList={condition.databaseResources}
+                />
+              )}
+            </div>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-y-2">
+          <span className="text-sm text-control-light">
+            {t("issue.role-grant.expired-at")}
+          </span>
+          <div className="text-base">
+            {condition?.expiredTime
+              ? dayjs(new Date(condition.expiredTime)).format("LLL")
+              : t("project.members.never-expires")}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function IssueDetailDatabaseResourceTable({
+  databaseResourceList,
+}: {
+  databaseResourceList: DatabaseResource[];
+}) {
+  const { t } = useTranslation();
+  const databaseStore = useDatabaseV1Store();
+  const environmentStore = useEnvironmentV1Store();
+  const instanceStore = useInstanceV1Store();
+  const rows = useVueState(() =>
+    databaseResourceList.map((resource) => {
+      const database = databaseStore.getDatabaseByName(
+        resource.databaseFullName
+      );
+      const { databaseName, instanceName } = extractDatabaseResourceName(
+        resource.databaseFullName
+      );
+      const instance = instanceName
+        ? instanceStore.getInstanceByName(`instances/${instanceName}`)
+        : database.instanceResource;
+      const environmentName =
+        database.effectiveEnvironment ??
+        database.instanceResource?.environment ??
+        "";
+      const environment =
+        environmentStore.getEnvironmentByName(environmentName);
+      return {
+        databaseName,
+        environmentTitle: environment.title,
+        instanceTitle: instance?.title ?? "",
+        resource,
+      };
+    })
+  );
+
+  return (
+    <div className="overflow-auto rounded-sm border">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            <TableHead className="bg-gray-50">{t("common.database")}</TableHead>
+            <TableHead className="bg-gray-50">{t("common.table")}</TableHead>
+            <TableHead className="bg-gray-50">
+              {t("common.environment")}
+            </TableHead>
+            <TableHead className="bg-gray-50">{t("common.instance")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow key={`${row.resource.databaseFullName}-${index}`}>
+              <TableCell>{row.databaseName}</TableCell>
+              <TableCell>
+                <span className="line-clamp-1">
+                  {extractTableName(row.resource)}
+                </span>
+              </TableCell>
+              <TableCell>{row.environmentTitle}</TableCell>
+              <TableCell>{row.instanceTitle}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function extractTableName(databaseResource: DatabaseResource) {
+  if (!databaseResource.schema && !databaseResource.table) {
+    return "*";
+  }
+  const names = [];
+  if (databaseResource.schema) {
+    names.push(databaseResource.schema);
+  }
+  names.push(databaseResource.table || "*");
+  return names.join(".");
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantView.tsx
@@ -1,0 +1,9 @@
+import { IssueDetailRoleGrantDetails } from "./IssueDetailRoleGrantDetails";
+
+export function IssueDetailRoleGrantView() {
+  return (
+    <div className="flex w-full flex-col gap-y-4">
+      <IssueDetailRoleGrantDetails />
+    </div>
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailSidebar.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailSidebar.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Alert } from "@/react/components/ui/alert";
+import { PlanCheckRun_Status } from "@/types/proto-es/v1/plan_service_pb";
+import { Advice_Level } from "@/types/proto-es/v1/sql_service_pb";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+import { isApprovalCompleted } from "../utils/approval";
+import { IssueDetailApprovalFlow } from "./IssueDetailApprovalFlow";
+import { IssueDetailChecks } from "./IssueDetailChecks";
+import { IssueDetailLabels } from "./IssueDetailLabels";
+
+export function IssueDetailSidebar() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const showChecks = useMemo(() => {
+    const specs = page.plan?.specs ?? [];
+    return (
+      specs.length > 0 &&
+      specs.every((spec) => spec.config?.case === "changeDatabaseConfig")
+    );
+  }, [page.plan?.specs]);
+  const showChecksManualRolloutHint = useMemo(() => {
+    if (!page.plan || !page.issue || page.plan.hasRollout) {
+      return false;
+    }
+    if (!isApprovalCompleted(page.issue)) {
+      return false;
+    }
+    const statusCount = page.plan.planCheckRunStatusCount ?? {};
+    return (
+      (statusCount.ERROR ?? 0) > 0 ||
+      (statusCount.FAILED ?? 0) > 0 ||
+      page.planCheckRuns.some(
+        (run) =>
+          run.status === PlanCheckRun_Status.FAILED ||
+          run.results.some((result) => result.status === Advice_Level.ERROR)
+      )
+    );
+  }, [page.issue, page.plan, page.planCheckRuns]);
+
+  return (
+    <div className="flex w-full flex-col gap-4 p-4">
+      {showChecks && (
+        <div className="flex flex-col gap-2">
+          {showChecksManualRolloutHint && (
+            <Alert variant="warning">
+              {t("issue.checks-manual-rollout-hint")}
+            </Alert>
+          )}
+          <IssueDetailChecks />
+        </div>
+      )}
+      <IssueDetailApprovalFlow />
+      <IssueDetailLabels />
+    </div>
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
@@ -1,0 +1,660 @@
+import { clone, create } from "@bufbuild/protobuf";
+import dayjs from "dayjs";
+import { ExternalLink, Loader2, Package, Upload } from "lucide-react";
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { planServiceClientConnect, sheetServiceClientConnect } from "@/connect";
+import { MonacoEditor, ReadonlyMonaco } from "@/react/components/monaco";
+import { Alert } from "@/react/components/ui/alert";
+import { Button } from "@/react/components/ui/button";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import {
+  projectNamePrefix,
+  pushNotification,
+  useCurrentUserV1,
+  useDatabaseV1Store,
+  useProjectV1Store,
+  useReleaseStore,
+  useSheetV1Store,
+} from "@/store";
+import { extractUserEmail } from "@/store/modules/v1/common";
+import {
+  getDateForPbTimestampProtoEs,
+  isValidDatabaseName,
+  isValidReleaseName,
+  languageOfEngineV1,
+} from "@/types";
+import { VCSType } from "@/types/proto-es/v1/common_pb";
+import {
+  type Plan,
+  type Plan_Spec,
+  PlanSchema,
+  UpdatePlanRequestSchema,
+} from "@/types/proto-es/v1/plan_service_pb";
+import {
+  type Release,
+  Release_Type,
+} from "@/types/proto-es/v1/release_service_pb";
+import { GetSheetRequestSchema } from "@/types/proto-es/v1/sheet_service_pb";
+import { extractDatabaseResourceName, hasProjectPermissionV2 } from "@/utils";
+import { getStatementSize, MAX_UPLOAD_FILE_SIZE_MB } from "@/utils/sheet";
+import { getInstanceResource } from "@/utils/v1/database";
+import { sheetNameOfSpec } from "@/utils/v1/issue/plan";
+import {
+  extractSheetUID,
+  getSheetStatement,
+  setSheetStatement,
+} from "@/utils/v1/sheet";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+import {
+  createEmptyLocalSheet,
+  getLocalSheetByName,
+} from "../utils/localSheet";
+
+const MAX_DISPLAYED_RELEASE_FILES = 4;
+
+export function IssueDetailStatementSection({
+  className,
+  forceReadonly = false,
+  spec,
+}: {
+  className?: string;
+  forceReadonly?: boolean;
+  spec: Plan_Spec;
+}) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const sheetStore = useSheetV1Store();
+  const releaseStore = useReleaseStore();
+  const projectStore = useProjectV1Store();
+  const databaseStore = useDatabaseV1Store();
+  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const project = useVueState(() =>
+    projectStore.getProjectByName(`${projectNamePrefix}${page.projectId}`)
+  );
+  const releaseName =
+    spec.config?.case === "changeDatabaseConfig"
+      ? spec.config.value.release
+      : "";
+  const sheetName = useMemo(() => sheetNameOfSpec(spec), [spec]);
+  const release = useVueState(() =>
+    isValidReleaseName(releaseName)
+      ? releaseStore.getReleaseByName(releaseName)
+      : undefined
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSheetOversize, setIsSheetOversize] = useState(false);
+  const [isDownloading, setIsDownloading] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [statement, setStatement] = useState("");
+  const [draftStatement, setDraftStatement] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const editingScope = useMemo(() => `statement:${spec.id}`, [spec.id]);
+  const targetDatabaseName = useMemo(() => {
+    if (
+      spec.config?.case !== "changeDatabaseConfig" &&
+      spec.config?.case !== "exportDataConfig"
+    ) {
+      return "";
+    }
+    return (spec.config.value.targets ?? []).find(isValidDatabaseName) ?? "";
+  }, [spec]);
+  const language = useMemo(() => {
+    if (!targetDatabaseName) {
+      return "sql";
+    }
+    const database = databaseStore.getDatabaseByName(targetDatabaseName);
+    return languageOfEngineV1(getInstanceResource(database).engine);
+  }, [databaseStore, targetDatabaseName]);
+  const autoCompleteContext = useMemo(() => {
+    if (!targetDatabaseName) {
+      return undefined;
+    }
+    return {
+      instance: extractDatabaseResourceName(targetDatabaseName).instance,
+      database: targetDatabaseName,
+      scene: "all" as const,
+    };
+  }, [targetDatabaseName]);
+  const statementTitle =
+    language === "sql" ? t("common.sql") : t("common.statement");
+  const displayedStatement = isEditing ? draftStatement : statement;
+  const isEmpty = displayedStatement.trim() === "";
+
+  useEffect(() => {
+    if (!isEditing) {
+      setDraftStatement(statement);
+    }
+  }, [isEditing, statement]);
+
+  useEffect(() => {
+    page.setEditing(editingScope, isEditing);
+    return () => {
+      page.setEditing(editingScope, false);
+    };
+  }, [editingScope, isEditing, page]);
+
+  useEffect(() => {
+    setIsEditing(false);
+    setDraftStatement("");
+  }, [spec.id]);
+
+  useEffect(() => {
+    let canceled = false;
+
+    const load = async () => {
+      if (isValidReleaseName(releaseName)) {
+        const cached = releaseStore.getReleaseByName(releaseName);
+        if (isValidReleaseName(cached.name)) {
+          return;
+        }
+        try {
+          setIsLoading(true);
+          await releaseStore.fetchReleaseByName(releaseName, true);
+        } finally {
+          if (!canceled) {
+            setIsLoading(false);
+          }
+        }
+        return;
+      }
+
+      if (!sheetName) {
+        setStatement("");
+        setIsSheetOversize(false);
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        const uid = extractSheetUID(sheetName);
+        const sheet = uid.startsWith("-")
+          ? getLocalSheetByName(sheetName)
+          : await sheetStore.getOrFetchSheetByName(sheetName);
+        if (!sheet || canceled) {
+          return;
+        }
+        const nextStatement = getSheetStatement(sheet);
+        setStatement(nextStatement);
+        setIsSheetOversize(getStatementSize(nextStatement) < sheet.contentSize);
+      } finally {
+        if (!canceled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      canceled = true;
+    };
+  }, [releaseName, releaseStore, sheetName, sheetStore]);
+
+  if (isValidReleaseName(releaseName)) {
+    return (
+      <IssueDetailReleaseStatement
+        className={className}
+        isLoading={isLoading}
+        release={release}
+        releaseName={releaseName}
+      />
+    );
+  }
+
+  const canModifyStatement = Boolean(
+    !forceReadonly &&
+      !page.readonly &&
+      !page.isCreating &&
+      !page.plan?.hasRollout &&
+      sheetName &&
+      project &&
+      (currentUser.email === extractUserEmail(page.plan?.creator || "") ||
+        hasProjectPermissionV2(project, "bb.plans.update"))
+  );
+  const canEdit = canModifyStatement && !isSheetOversize;
+  const hasChanges = isEditing && draftStatement !== statement;
+  const canSave =
+    !isSaving &&
+    !isLoading &&
+    Boolean(sheetName) &&
+    draftStatement.trim() !== "" &&
+    hasChanges;
+
+  const handleBeginEdit = () => {
+    setDraftStatement(statement);
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setDraftStatement(statement);
+    setIsEditing(false);
+  };
+
+  const downloadSheet = async () => {
+    if (!sheetName) {
+      return;
+    }
+
+    try {
+      setIsDownloading(true);
+      const uid = extractSheetUID(sheetName);
+      const content = uid.startsWith("-")
+        ? statement
+        : new TextDecoder().decode(
+            (
+              await sheetServiceClientConnect.getSheet(
+                create(GetSheetRequestSchema, {
+                  name: sheetName,
+                  raw: true,
+                })
+              )
+            ).content
+          );
+      const filename = `${sheetName.split("/").pop() || "sheet"}.sql`;
+      const blob = new Blob([content], { type: "text/plain" });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      console.error("Failed to download sheet:", error);
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.error"),
+        description: String(error),
+      });
+    } finally {
+      setIsDownloading(false);
+    }
+  };
+
+  const handleUploadClick = () => {
+    inputRef.current?.click();
+  };
+
+  const handleFileUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (!file) {
+      return;
+    }
+    if (file.size > MAX_UPLOAD_FILE_SIZE_MB * 1024 * 1024) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("issue.upload-sql-file-max-size-exceeded", {
+          size: `${MAX_UPLOAD_FILE_SIZE_MB}MB`,
+        }),
+      });
+      return;
+    }
+    const nextStatement = await file.text();
+    if (isSheetOversize && statement.trim() !== "") {
+      const confirmed = window.confirm(t("issue.overwrite-current-statement"));
+      if (!confirmed) {
+        return;
+      }
+    }
+    setDraftStatement(nextStatement);
+    setIsEditing(true);
+  };
+
+  const patchPlanStatement = (
+    plan: Plan,
+    targetSpec: Plan_Spec,
+    nextSheetName: string
+  ) => {
+    const planPatch = clone(PlanSchema, plan);
+    const specToPatch = planPatch.specs.find(
+      (candidate) => candidate.id === targetSpec.id
+    );
+    if (!specToPatch) {
+      return undefined;
+    }
+    if (
+      specToPatch.config?.case !== "changeDatabaseConfig" &&
+      specToPatch.config?.case !== "exportDataConfig"
+    ) {
+      return undefined;
+    }
+    specToPatch.config.value.sheet = nextSheetName;
+    return planPatch;
+  };
+
+  const handleSave = async () => {
+    if (!page.plan || !project || !sheetName || !canSave) {
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      const sheet = createEmptyLocalSheet();
+      setSheetStatement(sheet, draftStatement);
+      const createdSheet = await sheetStore.createSheet(project.name, sheet);
+      const nextPlan = patchPlanStatement(page.plan, spec, createdSheet.name);
+      if (!nextPlan) {
+        return;
+      }
+      const request = create(UpdatePlanRequestSchema, {
+        plan: nextPlan,
+        updateMask: {
+          paths: ["specs"],
+        },
+      });
+      const response = await planServiceClientConnect.updatePlan(request);
+      page.patchState({
+        plan: response,
+      });
+      setStatement(draftStatement);
+      setIsEditing(false);
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: t("common.updated"),
+      });
+      void page.refreshState();
+    } catch (error) {
+      console.error("Failed to update issue detail statement:", error);
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.error"),
+        description: String(error),
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className={cn("flex flex-col gap-y-2", className)}>
+      <div className="flex items-center justify-between">
+        <div
+          className={cn(
+            "flex items-center gap-x-1 text-base font-medium",
+            isEmpty && "text-red-600"
+          )}
+        >
+          <span>{statementTitle}</span>
+          {isEmpty && <span className="text-error">*</span>}
+        </div>
+        <input
+          ref={inputRef}
+          accept=".sql,.txt,application/sql,text/plain"
+          className="hidden"
+          onChange={(event) => void handleFileUpload(event)}
+          type="file"
+        />
+        <div className="flex items-center gap-x-2">
+          {(canModifyStatement || isEditing) && (
+            <div className="flex items-center gap-x-2">
+              <Button onClick={handleUploadClick} size="xs" variant="outline">
+                <Upload className="h-3.5 w-3.5" />
+                {t("issue.upload-sql")}
+              </Button>
+              {!isEditing ? (
+                canEdit ? (
+                  <Button onClick={handleBeginEdit} size="xs" variant="outline">
+                    {t("common.edit")}
+                  </Button>
+                ) : null
+              ) : (
+                <>
+                  <Button
+                    disabled={!canSave}
+                    onClick={() => void handleSave()}
+                    size="xs"
+                    variant="outline"
+                  >
+                    {isSaving && (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    )}
+                    {t("common.save")}
+                  </Button>
+                  <Button onClick={handleCancel} size="xs" variant="ghost">
+                    {t("common.cancel")}
+                  </Button>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+      {isSheetOversize && (
+        <Alert variant="warning">
+          <div className="flex items-center justify-between gap-x-4">
+            <span>{t("issue.statement-from-sheet-warning")}</span>
+            {sheetName && (
+              <Button
+                disabled={isDownloading}
+                onClick={() => void downloadSheet()}
+                size="xs"
+                variant="outline"
+              >
+                {isDownloading && (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                )}
+                {t("common.download")}
+              </Button>
+            )}
+          </div>
+        </Alert>
+      )}
+      {isLoading ? (
+        <div className="rounded-md border border-control-border bg-white px-4 py-3 text-sm text-control-light">
+          {t("common.loading")}
+        </div>
+      ) : statement || isEditing ? (
+        <div className="relative">
+          {isEditing ? (
+            <MonacoEditor
+              autoCompleteContext={autoCompleteContext}
+              className="relative h-auto max-h-[600px] min-h-[120px]"
+              content={draftStatement}
+              language={language}
+              onChange={setDraftStatement}
+            />
+          ) : (
+            <ReadonlyMonaco
+              className="relative h-auto max-h-[600px] min-h-[120px]"
+              content={statement}
+              language={language}
+            />
+          )}
+        </div>
+      ) : (
+        <div className="rounded-md border border-control-border bg-white px-4 py-3 text-sm text-control-light">
+          {t("common.no-data")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IssueDetailReleaseStatement({
+  className,
+  isLoading,
+  release,
+  releaseName,
+}: {
+  className?: string;
+  isLoading: boolean;
+  release?: Release;
+  releaseName: string;
+}) {
+  const { t } = useTranslation();
+  const releaseTitle = useMemo(() => {
+    const name = release?.name || releaseName;
+    const parts = name.split("/");
+    return parts[parts.length - 1] || name;
+  }, [release?.name, releaseName]);
+  const displayedFiles =
+    release?.files.slice(0, MAX_DISPLAYED_RELEASE_FILES) ?? [];
+  const createdTime = release?.createTime
+    ? dayjs(getDateForPbTimestampProtoEs(release.createTime)).format(
+        "YYYY-MM-DD HH:mm:ss"
+      )
+    : undefined;
+
+  return (
+    <div className={cn("flex h-full flex-col gap-y-2", className)}>
+      <Alert variant="info">{t("release.change-tip")}</Alert>
+
+      <div className="flex items-center justify-between gap-x-2">
+        <div className="flex items-center gap-x-1 text-base font-medium">
+          <Package className="h-4 w-4" />
+          <span>{releaseTitle}</span>
+        </div>
+        {isValidReleaseName(release?.name ?? "") && (
+          <a
+            className="inline-flex items-center gap-x-1 text-sm text-accent hover:underline"
+            href={`/${release?.name}`}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <span>{t("common.view")}</span>
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="rounded-md border border-control-border bg-control-bg px-4 py-3 text-sm text-control-light">
+          {t("common.loading")}
+        </div>
+      ) : release ? (
+        <div className="rounded-md border border-control-border bg-control-bg px-4 py-3">
+          <div className="flex flex-col gap-y-3">
+            <div>
+              <div className="text-sm font-medium text-main">
+                {releaseTitle}
+              </div>
+              <div className="mt-1 text-xs text-control-light">
+                {release.name}
+              </div>
+            </div>
+
+            {release.files.length > 0 && (
+              <div className="flex flex-col gap-y-2">
+                <div className="flex items-center justify-between">
+                  <div className="text-sm font-medium text-control">
+                    {t("release.files")} ({release.files.length})
+                  </div>
+                  {release.files.length > MAX_DISPLAYED_RELEASE_FILES &&
+                    isValidReleaseName(release.name) && (
+                      <a
+                        className="text-sm text-accent hover:underline"
+                        href={`/${release.name}`}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        {t("release.view-all-files")}
+                      </a>
+                    )}
+                </div>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
+                  {displayedFiles.map((file) => (
+                    <div
+                      key={file.path}
+                      className="flex items-center justify-between rounded-sm bg-white p-2 text-xs"
+                    >
+                      <div className="mr-2 min-w-0 flex-1">
+                        <div className="truncate font-medium">{file.path}</div>
+                        <div className="text-control-light">{file.version}</div>
+                      </div>
+                      <div className="shrink-0 rounded-sm bg-blue-100 px-1.5 py-0.5 text-xs text-blue-800">
+                        {getReleaseFileTypeText(release.type, t)}
+                      </div>
+                    </div>
+                  ))}
+                  {release.files.length > MAX_DISPLAYED_RELEASE_FILES && (
+                    <div className="py-1 text-center text-xs text-control-light">
+                      {t("release.and-n-more-files", {
+                        count:
+                          release.files.length - MAX_DISPLAYED_RELEASE_FILES,
+                      })}
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {release.vcsSource && (
+              <div className="flex flex-col gap-y-1">
+                <div className="text-sm font-medium text-control">
+                  {t("release.vcs-source")}
+                </div>
+                <div className="text-xs">
+                  <span className="text-control-light">
+                    {getVCSTypeText(release.vcsSource.vcsType, t)}:
+                  </span>
+                  {release.vcsSource.url && (
+                    <a
+                      className="ml-1 text-accent hover:underline"
+                      href={release.vcsSource.url}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      {release.vcsSource.url}
+                    </a>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {createdTime && (
+              <div className="text-xs text-control-light">{createdTime}</div>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-md border border-error/30 bg-error/5 px-4 py-3 text-sm text-error">
+          {t("release.not-found")}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const getReleaseFileTypeText = (
+  fileType: Release_Type,
+  t: (key: string, options?: Record<string, unknown>) => string
+) => {
+  switch (fileType) {
+    case Release_Type.VERSIONED:
+      return t("release.file-type.versioned");
+    case Release_Type.DECLARATIVE:
+      return t("release.file-type.declarative");
+    case Release_Type.TYPE_UNSPECIFIED:
+      return t("release.file-type.unspecified");
+    default:
+      return t("release.file-type.unspecified");
+  }
+};
+
+const getVCSTypeText = (
+  vcsType: VCSType,
+  t: (key: string, options?: Record<string, unknown>) => string
+) => {
+  switch (vcsType) {
+    case VCSType.GITHUB:
+      return "GitHub";
+    case VCSType.GITLAB:
+      return "GitLab";
+    case VCSType.BITBUCKET:
+      return "Bitbucket";
+    case VCSType.AZURE_DEVOPS:
+      return "Azure DevOps";
+    default:
+      return t("release.vcs-type.unspecified");
+  }
+};

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
@@ -1,0 +1,740 @@
+import { create } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
+import { Check, FastForward, Loader2, Pause, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { rolloutServiceClientConnect } from "@/connect";
+import { EngineIconPath } from "@/react/components/instance/constants";
+import { Button } from "@/react/components/ui/button";
+import { Input } from "@/react/components/ui/input";
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/react/components/ui/sheet";
+import { Textarea } from "@/react/components/ui/textarea";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import {
+  pushNotification,
+  useCurrentUserV1,
+  useDatabaseV1Store,
+  useEnvironmentV1Store,
+  useProjectV1Store,
+} from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
+import {
+  BatchCancelTaskRunsRequestSchema,
+  BatchRunTasksRequestSchema,
+  BatchSkipTasksRequestSchema,
+  ListTaskRunsRequestSchema,
+  type Stage,
+  type Task,
+  Task_Status,
+  Task_Type,
+  TaskRun_Status,
+} from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  extractDatabaseResourceName,
+  extractInstanceResourceName,
+  extractStageUID,
+} from "@/utils";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+import {
+  CANCELABLE_TASK_STATUSES,
+  canRolloutTasks,
+  preloadRolloutPermissionContext,
+  RUNNABLE_TASK_STATUSES,
+} from "../utils/rollout";
+
+const DEFAULT_RUN_DELAY_MS = 60 * 60 * 1000;
+
+export type IssueDetailTaskRolloutAction = "RUN" | "SKIP" | "CANCEL";
+
+export type IssueDetailTaskRolloutTarget = {
+  type: "tasks";
+  tasks?: Task[];
+  stage?: Stage;
+};
+
+const pluralizedLabel = (raw: string, count: number): string => {
+  const [singular, plural] = raw.split("|").map((part) => part.trim());
+  if (!plural) {
+    return singular;
+  }
+  return count === 1 ? singular : plural;
+};
+
+export function IssueDetailTaskRolloutActionPanel({
+  action,
+  onConfirm,
+  onOpenChange,
+  open,
+  target,
+}: {
+  action?: IssueDetailTaskRolloutAction;
+  onConfirm?: () => Promise<void> | void;
+  onOpenChange: (open: boolean) => void;
+  open: boolean;
+  target: IssueDetailTaskRolloutTarget;
+}) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+  const [loading, setLoading] = useState(false);
+  const [permissionLoading, setPermissionLoading] = useState(false);
+  const [canRun, setCanRun] = useState(true);
+  const [comment, setComment] = useState("");
+  const [runTimeInMS, setRunTimeInMS] = useState<number | undefined>();
+  const [skipPriorBackup, setSkipPriorBackup] = useState(false);
+
+  const allRolloutTasks = useMemo(() => {
+    return page.rollout?.stages.flatMap((stage) => stage.tasks) ?? [];
+  }, [page.rollout]);
+  const rolloutType = useMemo(() => {
+    if (
+      allRolloutTasks.every((task) => task.type === Task_Type.DATABASE_CREATE)
+    ) {
+      return "DATABASE_CREATE";
+    }
+    if (
+      allRolloutTasks.every((task) => task.type === Task_Type.DATABASE_EXPORT)
+    ) {
+      return "DATABASE_EXPORT";
+    }
+    return "DATABASE_CHANGE";
+  }, [allRolloutTasks]);
+  const isDatabaseCreateOrExport =
+    rolloutType === "DATABASE_CREATE" || rolloutType === "DATABASE_EXPORT";
+  const baseTasks = useMemo(() => {
+    if (target.tasks) {
+      return target.tasks;
+    }
+    if (isDatabaseCreateOrExport) {
+      return allRolloutTasks;
+    }
+    return target.stage?.tasks ?? [];
+  }, [allRolloutTasks, isDatabaseCreateOrExport, target.stage, target.tasks]);
+  const eligibleTasks = useMemo(() => {
+    if (action === "RUN" || action === "SKIP") {
+      return baseTasks.filter((task) =>
+        RUNNABLE_TASK_STATUSES.includes(task.status)
+      );
+    }
+    if (action === "CANCEL") {
+      return baseTasks.filter((task) =>
+        CANCELABLE_TASK_STATUSES.includes(task.status)
+      );
+    }
+    return [];
+  }, [action, baseTasks]);
+  const hasPriorBackupTasks = useMemo(() => {
+    return eligibleTasks.some((task) => {
+      const spec = page.plan?.specs.find((item) => item.id === task.specId);
+      return (
+        spec?.config.case === "changeDatabaseConfig" &&
+        spec.config.value.enablePriorBackup
+      );
+    });
+  }, [eligibleTasks, page.plan?.specs]);
+  const showStageInfo = !isDatabaseCreateOrExport;
+  const showTaskInfo = rolloutType !== "DATABASE_CREATE";
+  const taskCountSuffix = useMemo(() => {
+    if (
+      eligibleTasks.length <= 1 ||
+      !showStageInfo ||
+      !target.stage?.tasks.length
+    ) {
+      return "";
+    }
+    const total = target.stage.tasks.length;
+    return eligibleTasks.length === total
+      ? String(eligibleTasks.length)
+      : `${eligibleTasks.length} / ${total}`;
+  }, [eligibleTasks.length, showStageInfo, target.stage?.tasks.length]);
+
+  useEffect(() => {
+    if (!open) {
+      setComment("");
+      setRunTimeInMS(undefined);
+      setSkipPriorBackup(false);
+      return;
+    }
+
+    let canceled = false;
+    const prepare = async () => {
+      setPermissionLoading(true);
+      setCanRun(false);
+      await preloadRolloutPermissionContext({
+        environment: target.stage?.environment,
+        projectName: project?.name ?? "",
+        tasks: eligibleTasks,
+      });
+      if (canceled) {
+        return;
+      }
+      setCanRun(
+        project
+          ? canRolloutTasks({
+              currentUser,
+              environment: target.stage?.environment,
+              issue: page.issue,
+              project,
+              tasks: eligibleTasks,
+            })
+          : false
+      );
+      setPermissionLoading(false);
+    };
+
+    void prepare();
+
+    return () => {
+      canceled = true;
+    };
+  }, [
+    currentUser,
+    eligibleTasks,
+    open,
+    page.issue,
+    project,
+    target.stage?.environment,
+  ]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const runTimes = new Set(
+      eligibleTasks.map((task) => task.runTime).filter(Boolean)
+    );
+    if (runTimes.size !== 1) {
+      return;
+    }
+    const runTime = [...runTimes][0];
+    if (!runTime) {
+      return;
+    }
+    setRunTimeInMS(Number(runTime.seconds) * 1000 + runTime.nanos / 1000000);
+  }, [eligibleTasks, open]);
+
+  const validationErrors = useMemo(() => {
+    const errors: string[] = [];
+    if (eligibleTasks.length === 0) {
+      errors.push(t("common.no-data"));
+    }
+    if (!canRun) {
+      errors.push(
+        page.issue?.type === Issue_Type.DATABASE_EXPORT
+          ? t("task.data-export-creator-only")
+          : t("task.no-permission")
+      );
+    }
+    if (
+      action === "RUN" &&
+      runTimeInMS !== undefined &&
+      runTimeInMS <= Date.now()
+    ) {
+      errors.push(t("task.error.scheduled-time-must-be-in-the-future"));
+    }
+    return errors;
+  }, [action, canRun, eligibleTasks.length, page.issue?.type, runTimeInMS, t]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!page.rollout || !action || validationErrors.length > 0) {
+      return;
+    }
+
+    try {
+      setLoading(true);
+      if (action === "RUN") {
+        await runTasks({
+          rolloutName: page.rollout.name,
+          runTimeInMS,
+          skipPriorBackup,
+          tasks: eligibleTasks,
+        });
+      } else if (action === "SKIP") {
+        await skipTasks({
+          comment,
+          rolloutName: page.rollout.name,
+          tasks: eligibleTasks,
+        });
+      } else {
+        await cancelTasks({
+          rolloutName: page.rollout.name,
+          tasks: eligibleTasks,
+        });
+      }
+      await onConfirm?.();
+      onOpenChange(false);
+    } catch (error) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.error"),
+        description: String(error),
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [
+    action,
+    comment,
+    eligibleTasks,
+    onConfirm,
+    onOpenChange,
+    page.rollout,
+    runTimeInMS,
+    skipPriorBackup,
+    t,
+    validationErrors.length,
+  ]);
+
+  if (!action) {
+    return null;
+  }
+
+  const title =
+    action === "RUN"
+      ? pluralizedLabel(t("task.run-task"), eligibleTasks.length)
+      : action === "SKIP"
+        ? pluralizedLabel(t("task.skip-task"), eligibleTasks.length)
+        : pluralizedLabel(t("task.cancel-task"), eligibleTasks.length);
+  const confirmButtonText =
+    action === "RUN"
+      ? t("common.run")
+      : action === "SKIP"
+        ? t("common.skip")
+        : t("common.cancel");
+
+  return (
+    <Sheet onOpenChange={onOpenChange} open={open}>
+      <SheetContent width="wide">
+        <SheetHeader>
+          <SheetTitle>{title}</SheetTitle>
+        </SheetHeader>
+        <SheetBody className="relative">
+          <div className="flex h-full flex-col gap-y-4 px-1">
+            {validationErrors.length > 0 && (
+              <div className="rounded-xs border border-error/30 bg-error/5 px-4 py-3">
+                <div className="mb-1 font-medium text-error">
+                  {t("rollout.task-execution-errors")}
+                </div>
+                <ul className="flex list-inside list-disc flex-col gap-y-1 text-sm text-error">
+                  {validationErrors.map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {showStageInfo && target.stage?.environment && (
+              <div className="flex shrink-0 flex-row items-center justify-start gap-x-2 overflow-y-hidden">
+                <label className="font-medium text-control">
+                  {t("common.stage")}
+                </label>
+                <IssueDetailStageEnvironment
+                  environmentName={target.stage.environment}
+                />
+              </div>
+            )}
+
+            {showTaskInfo && (
+              <div className="flex shrink-0 flex-col gap-y-1">
+                <label className="text-control">
+                  <span className="font-medium">{t("common.task")}</span>
+                  {taskCountSuffix && (
+                    <span className="opacity-80"> ({taskCountSuffix})</span>
+                  )}
+                </label>
+                <div className="max-h-64 overflow-y-auto">
+                  <ul className="flex flex-col gap-y-2 text-sm">
+                    {eligibleTasks.map((task) => (
+                      <li
+                        className="flex h-8 items-center gap-x-2"
+                        key={task.name}
+                      >
+                        <IssueDetailTaskStatus status={task.status} />
+                        <IssueDetailTaskDatabaseName task={task} />
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            )}
+
+            {action === "RUN" && (
+              <div className="flex flex-col">
+                <h3 className="mb-1 font-medium text-control">
+                  {t("task.execution-time")}
+                </h3>
+                <div className="flex flex-col gap-2 sm:flex-row sm:gap-4">
+                  <label className="inline-flex items-center gap-x-2 text-sm">
+                    <input
+                      checked={runTimeInMS === undefined}
+                      name="run-time-mode"
+                      onChange={() => setRunTimeInMS(undefined)}
+                      type="radio"
+                    />
+                    <span>{t("task.run-immediately.self")}</span>
+                  </label>
+                  <label className="inline-flex items-center gap-x-2 text-sm">
+                    <input
+                      checked={runTimeInMS !== undefined}
+                      name="run-time-mode"
+                      onChange={() =>
+                        setRunTimeInMS(Date.now() + DEFAULT_RUN_DELAY_MS)
+                      }
+                      type="radio"
+                    />
+                    <span>{t("task.schedule-for-later.self")}</span>
+                  </label>
+                </div>
+                <div className="mt-1 text-sm text-control-light">
+                  {runTimeInMS === undefined
+                    ? t("task.run-immediately.description")
+                    : t("task.schedule-for-later.description")}
+                </div>
+                {runTimeInMS !== undefined && (
+                  <Input
+                    className="mt-2"
+                    onChange={(event) =>
+                      setRunTimeInMS(
+                        parseDatetimeLocalValue(event.target.value)
+                      )
+                    }
+                    placeholder={t("task.select-scheduled-time")}
+                    type="datetime-local"
+                    value={formatDatetimeLocalValue(runTimeInMS)}
+                  />
+                )}
+              </div>
+            )}
+
+            {action === "RUN" && hasPriorBackupTasks && (
+              <div className="flex flex-col">
+                <label className="inline-flex items-center gap-x-2 text-sm">
+                  <input
+                    checked={skipPriorBackup}
+                    className="h-4 w-4 rounded border-control-border"
+                    onChange={(event) =>
+                      setSkipPriorBackup(event.target.checked)
+                    }
+                    type="checkbox"
+                  />
+                  <span>{t("task.skip-prior-backup")}</span>
+                </label>
+                <div className="ml-6 text-sm text-control-light">
+                  {t("task.skip-prior-backup-description")}
+                </div>
+              </div>
+            )}
+
+            {action === "SKIP" && page.issue && (
+              <div className="flex shrink-0 flex-col gap-y-1">
+                <p className="font-medium text-control">{t("common.reason")}</p>
+                <Textarea
+                  className="min-h-28"
+                  maxLength={1000}
+                  onChange={(event) => setComment(event.target.value)}
+                  placeholder={t("issue.leave-a-comment")}
+                  value={comment}
+                />
+              </div>
+            )}
+          </div>
+
+          {(loading || permissionLoading) && (
+            <div className="absolute inset-0 flex items-center justify-center bg-white/50">
+              <Loader2 className="h-6 w-6 animate-spin text-control" />
+            </div>
+          )}
+        </SheetBody>
+        <SheetFooter>
+          <Button onClick={() => onOpenChange(false)} variant="ghost">
+            {t("common.close")}
+          </Button>
+          <Button
+            disabled={permissionLoading || validationErrors.length > 0}
+            onClick={() => void handleConfirm()}
+          >
+            {loading && <Loader2 className="h-4 w-4 animate-spin" />}
+            {confirmButtonText}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+async function runTasks({
+  rolloutName,
+  runTimeInMS,
+  skipPriorBackup,
+  tasks,
+}: {
+  rolloutName: string;
+  runTimeInMS?: number;
+  skipPriorBackup: boolean;
+  tasks: Task[];
+}) {
+  const tasksByStage = groupTasksByStage(tasks);
+  for (const [stageId, stageTasks] of tasksByStage) {
+    const request = create(BatchRunTasksRequestSchema, {
+      parent: `${rolloutName}/stages/${stageId}`,
+      tasks: stageTasks.map((task) => task.name),
+    });
+    if (runTimeInMS !== undefined) {
+      request.runTime = create(TimestampSchema, {
+        seconds: BigInt(Math.floor(runTimeInMS / 1000)),
+        nanos: (runTimeInMS % 1000) * 1000000,
+      });
+    }
+    request.skipPriorBackup = skipPriorBackup;
+    await rolloutServiceClientConnect.batchRunTasks(request);
+  }
+}
+
+async function skipTasks({
+  comment,
+  rolloutName,
+  tasks,
+}: {
+  comment: string;
+  rolloutName: string;
+  tasks: Task[];
+}) {
+  const tasksByStage = groupTasksByStage(tasks);
+  for (const [stageId, stageTasks] of tasksByStage) {
+    await rolloutServiceClientConnect.batchSkipTasks(
+      create(BatchSkipTasksRequestSchema, {
+        parent: `${rolloutName}/stages/${stageId}`,
+        reason: comment,
+        tasks: stageTasks.map((task) => task.name),
+      })
+    );
+  }
+}
+
+async function cancelTasks({
+  rolloutName,
+  tasks,
+}: {
+  rolloutName: string;
+  tasks: Task[];
+}) {
+  const tasksByStage = groupTasksByStage(tasks);
+  const cancelableRuns = new Map<string, string[]>();
+  for (const [stageId, stageTasks] of tasksByStage) {
+    const taskNames = new Set(stageTasks.map((task) => task.name));
+    const response = await rolloutServiceClientConnect.listTaskRuns(
+      create(ListTaskRunsRequestSchema, {
+        parent: `${rolloutName}/stages/${stageId}/tasks/-`,
+      })
+    );
+    const runs = response.taskRuns
+      .filter((run) => {
+        const taskName = run.name.split("/taskRuns/")[0];
+        return (
+          taskNames.has(taskName) &&
+          (run.status === TaskRun_Status.PENDING ||
+            run.status === TaskRun_Status.RUNNING)
+        );
+      })
+      .map((run) => run.name);
+    if (runs.length > 0) {
+      cancelableRuns.set(`${rolloutName}/stages/${stageId}`, runs);
+    }
+  }
+
+  await Promise.all(
+    [...cancelableRuns.entries()].map(([stageName, taskRuns]) =>
+      rolloutServiceClientConnect.batchCancelTaskRuns(
+        create(BatchCancelTaskRunsRequestSchema, {
+          parent: `${stageName}/tasks/-`,
+          taskRuns,
+        })
+      )
+    )
+  );
+}
+
+function groupTasksByStage(tasks: Task[]) {
+  const grouped = new Map<string, Task[]>();
+  for (const task of tasks) {
+    const stageId = extractStageUID(task.name);
+    if (!stageId) {
+      continue;
+    }
+    if (!grouped.has(stageId)) {
+      grouped.set(stageId, []);
+    }
+    grouped.get(stageId)?.push(task);
+  }
+  return grouped;
+}
+
+function IssueDetailTaskDatabaseName({ task }: { task: Task }) {
+  if (task.target) {
+    return <IssueDetailDatabaseTarget target={task.target} />;
+  }
+  return <span className="truncate">{task.name.split("/").at(-1)}</span>;
+}
+
+function IssueDetailDatabaseTarget({ target }: { target: string }) {
+  const { t } = useTranslation();
+  const databaseStore = useDatabaseV1Store();
+  const environmentStore = useEnvironmentV1Store();
+  const database = useVueState(() => databaseStore.getDatabaseByName(target));
+  const environment = useVueState(() =>
+    environmentStore.getEnvironmentByName(
+      database.effectiveEnvironment ??
+        database.instanceResource?.environment ??
+        ""
+    )
+  );
+  const instance = database.instanceResource;
+  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
+  const { databaseName } = extractDatabaseResourceName(target);
+  const instanceTitle =
+    instance?.title ||
+    extractInstanceResourceName(target) ||
+    t("common.unknown");
+
+  return (
+    <div className="flex min-w-0 items-center truncate text-sm">
+      {engineIcon && (
+        <img alt="" className="mr-1 inline-block h-4 w-4" src={engineIcon} />
+      )}
+      <span className="mr-1 truncate text-gray-400">{environment.title}</span>
+      <span className="truncate text-gray-600">{instanceTitle}</span>
+      <span className="mx-1 shrink-0 text-gray-500 opacity-60">›</span>
+      <span className="truncate text-gray-800">{databaseName}</span>
+    </div>
+  );
+}
+
+function IssueDetailStageEnvironment({
+  environmentName,
+}: {
+  environmentName: string;
+}) {
+  const environmentStore = useEnvironmentV1Store();
+  const environment = useVueState(() =>
+    environmentStore.getEnvironmentByName(environmentName)
+  );
+
+  return (
+    <span className="text-sm text-control">
+      {environment.title || environmentName.split("/").at(-1)}
+    </span>
+  );
+}
+
+function IssueDetailTaskStatus({ status }: { status: Task_Status }) {
+  const { t } = useTranslation();
+  return (
+    <Tooltip content={taskStatusLabel(t, status)}>
+      <div
+        aria-label={taskStatusLabel(t, status)}
+        className={cn(
+          "relative flex h-5 w-5 shrink-0 select-none items-center justify-center overflow-hidden rounded-full",
+          taskStatusClassName(status)
+        )}
+      >
+        {status === Task_Status.NOT_STARTED && (
+          <span className="h-1/2 w-1/2 rounded-full bg-control" />
+        )}
+        {status === Task_Status.PENDING && <Pause className="h-3/4 w-3/4" />}
+        {status === Task_Status.RUNNING && (
+          <div className="relative flex h-1/2 w-1/2 overflow-visible">
+            <span
+              className="absolute z-0 h-full w-full animate-ping-slow rounded-full"
+              style={{ backgroundColor: "rgba(37, 99, 235, 0.5)" }}
+            />
+            <span className="z-1 h-full w-full rounded-full bg-info" />
+          </div>
+        )}
+        {status === Task_Status.SKIPPED && (
+          <FastForward className="h-3/4 w-3/4" />
+        )}
+        {status === Task_Status.DONE && <Check className="h-3/4 w-3/4" />}
+        {status === Task_Status.FAILED && (
+          <span className="rounded-full text-base font-medium">!</span>
+        )}
+        {status === Task_Status.CANCELED && (
+          <span className="text-base leading-none">-</span>
+        )}
+        {status !== Task_Status.CANCELED &&
+          status !== Task_Status.FAILED &&
+          status !== Task_Status.DONE &&
+          status !== Task_Status.SKIPPED &&
+          status !== Task_Status.RUNNING &&
+          status !== Task_Status.PENDING &&
+          status !== Task_Status.NOT_STARTED && <X className="h-3/4 w-3/4" />}
+      </div>
+    </Tooltip>
+  );
+}
+
+function taskStatusClassName(status: Task_Status) {
+  switch (status) {
+    case Task_Status.NOT_STARTED:
+      return "border-2 border-control bg-white";
+    case Task_Status.PENDING:
+    case Task_Status.RUNNING:
+      return "border-2 border-info bg-white text-info";
+    case Task_Status.SKIPPED:
+      return "border-2 border-control-light bg-white text-gray-600";
+    case Task_Status.DONE:
+      return "bg-success text-white";
+    case Task_Status.FAILED:
+      return "bg-error text-white";
+    case Task_Status.CANCELED:
+      return "border-2 border-control-light bg-white text-control-light";
+    default:
+      return "border border-dashed border-control bg-white";
+  }
+}
+
+function taskStatusLabel(t: (key: string) => string, status: Task_Status) {
+  switch (status) {
+    case Task_Status.NOT_STARTED:
+      return t("task.status.not-started");
+    case Task_Status.PENDING:
+      return t("task.status.pending");
+    case Task_Status.RUNNING:
+      return t("task.status.running");
+    case Task_Status.SKIPPED:
+      return t("task.status.skipped");
+    case Task_Status.DONE:
+      return t("task.status.done");
+    case Task_Status.FAILED:
+      return t("task.status.failed");
+    case Task_Status.CANCELED:
+      return t("task.status.canceled");
+    default:
+      return t("task.status.not-started");
+  }
+}
+
+function formatDatetimeLocalValue(value?: number) {
+  if (value === undefined) {
+    return "";
+  }
+  return new Date(value).toISOString().slice(0, 16);
+}
+
+function parseDatetimeLocalValue(value: string) {
+  const parsed = new Date(value).getTime();
+  return Number.isFinite(parsed) ? parsed : undefined;
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
@@ -1,0 +1,386 @@
+import { create } from "@bufbuild/protobuf";
+import { DurationSchema } from "@bufbuild/protobuf/wkt";
+import { Check, Minus } from "lucide-react";
+import { useEffect, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { EngineIconPath } from "@/react/components/instance/constants";
+import { EllipsisText } from "@/react/components/ui/ellipsis-text";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
+import {
+  useDatabaseV1Store,
+  useEnvironmentV1Store,
+  useProjectV1Store,
+} from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import {
+  getDateForPbTimestampProtoEs,
+  getTimeForPbTimestampProtoEs,
+} from "@/types";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import {
+  type Task,
+  type TaskRun,
+  TaskRun_Status,
+} from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  databaseForTask,
+  extractDatabaseResourceName,
+  extractInstanceResourceName,
+  extractTaskUID,
+  formatAbsoluteDateTime,
+  humanizeDate,
+  humanizeDurationV1,
+} from "@/utils";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+
+export function IssueDetailTaskRunTable({
+  maxHeight,
+  showDatabaseColumn = false,
+  taskRuns,
+}: {
+  maxHeight?: string | number;
+  showDatabaseColumn?: boolean;
+  taskRuns: TaskRun[];
+}) {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const databaseStore = useDatabaseV1Store();
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+
+  const taskByUID = useMemo(() => {
+    const map = new Map<string, Task>();
+    for (const stage of page.rollout?.stages ?? []) {
+      for (const task of stage.tasks) {
+        map.set(extractTaskUID(task.name), task);
+      }
+    }
+    return map;
+  }, [page.rollout?.stages]);
+
+  const sortedTaskRuns = useMemo(() => {
+    return [...taskRuns].sort((left, right) => {
+      const leftTime = left.createTime ? Number(left.createTime.seconds) : 0;
+      const rightTime = right.createTime ? Number(right.createTime.seconds) : 0;
+      return rightTime - leftTime;
+    });
+  }, [taskRuns]);
+
+  useEffect(() => {
+    if (!showDatabaseColumn) {
+      return;
+    }
+
+    const targets = [
+      ...new Set(
+        taskRuns
+          .map((taskRun) => taskByUID.get(extractTaskUID(taskRun.name))?.target)
+          .filter((target): target is string => Boolean(target))
+      ),
+    ];
+    if (targets.length > 0) {
+      void databaseStore.batchGetOrFetchDatabases(targets);
+    }
+  }, [databaseStore, showDatabaseColumn, taskByUID, taskRuns]);
+
+  const getTaskForTaskRun = (taskRun: TaskRun) => {
+    return taskByUID.get(extractTaskUID(taskRun.name));
+  };
+
+  const getDatabaseForTaskRun = (taskRun: TaskRun) => {
+    const task = getTaskForTaskRun(taskRun);
+    return task ? databaseForTask(project, task, page.plan) : undefined;
+  };
+
+  const wrapperStyle =
+    maxHeight !== undefined
+      ? {
+          maxHeight:
+            typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight,
+        }
+      : undefined;
+
+  return (
+    <>
+      <div className="overflow-auto rounded-sm border" style={wrapperStyle}>
+        <Table className="table-fixed">
+          <TableHeader>
+            <TableRow className="hover:bg-transparent">
+              <TableHead className="sticky top-0 z-10 w-9 bg-gray-50 px-2" />
+              {showDatabaseColumn && (
+                <TableHead className="sticky top-0 z-10 w-64 bg-gray-50">
+                  {t("common.database")}
+                </TableHead>
+              )}
+              <TableHead className="sticky top-0 z-10 bg-gray-50">
+                {t("common.detail")}
+              </TableHead>
+              <TableHead className="sticky top-0 z-10 w-36 bg-gray-50">
+                {t("task.created")}
+              </TableHead>
+              <TableHead className="sticky top-0 z-10 w-36 bg-gray-50">
+                {t("task.started")}
+              </TableHead>
+              <TableHead className="sticky top-0 z-10 w-28 bg-gray-50 pr-6 whitespace-nowrap text-sm">
+                {t("task.execution-time")}
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sortedTaskRuns.map((taskRun) => {
+              const database = getDatabaseForTaskRun(taskRun);
+              return (
+                <TableRow key={taskRun.name}>
+                  <TableCell className="px-2">
+                    <IssueDetailTaskRunStatusIcon status={taskRun.status} />
+                  </TableCell>
+                  {showDatabaseColumn && (
+                    <TableCell>
+                      {database ? (
+                        <IssueDetailTaskRunDatabaseCell database={database} />
+                      ) : (
+                        <span className="text-control-light">-</span>
+                      )}
+                    </TableCell>
+                  )}
+                  <TableCell className="min-w-0 pr-2">
+                    <IssueDetailTaskRunComment taskRun={taskRun} />
+                  </TableCell>
+                  <TableCell>
+                    <IssueDetailTaskRunDateCell date={taskRun.createTime} />
+                  </TableCell>
+                  <TableCell>
+                    <IssueDetailTaskRunDateCell date={taskRun.startTime} />
+                  </TableCell>
+                  <TableCell className="pr-6 whitespace-nowrap">
+                    <span className="whitespace-nowrap text-sm text-control">
+                      {executionDurationOfTaskRun(taskRun)
+                        ? humanizeDurationV1(
+                            executionDurationOfTaskRun(taskRun)
+                          )
+                        : "-"}
+                    </span>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+    </>
+  );
+}
+
+function IssueDetailTaskRunStatusIcon({ status }: { status: TaskRun_Status }) {
+  const { t } = useTranslation();
+  const classes = (() => {
+    switch (status) {
+      case TaskRun_Status.PENDING:
+        return "bg-white border-2 border-info text-info";
+      case TaskRun_Status.RUNNING:
+        return "bg-white border-2 border-info text-info";
+      case TaskRun_Status.DONE:
+        return "bg-success text-white";
+      case TaskRun_Status.FAILED:
+        return "bg-error text-white";
+      case TaskRun_Status.CANCELED:
+        return "bg-white border-2 border-gray-400 text-gray-400";
+      default:
+        return "";
+    }
+  })();
+
+  return (
+    <Tooltip content={taskRunStatusLabel(t, status)}>
+      <div
+        className={cn(
+          "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full select-none",
+          classes
+        )}
+      >
+        {status === TaskRun_Status.PENDING && (
+          <span className="h-1.5 w-1.5 rounded-full bg-info" />
+        )}
+        {status === TaskRun_Status.RUNNING && (
+          <div className="relative flex h-2.5 w-2.5 overflow-visible">
+            <span className="absolute z-0 h-full w-full animate-ping-slow rounded-full bg-blue-600/50" />
+            <span className="z-1 h-full w-full rounded-full bg-info" />
+          </div>
+        )}
+        {status === TaskRun_Status.DONE && <Check className="h-4 w-4" />}
+        {status === TaskRun_Status.FAILED && (
+          <span className="text-base font-medium text-white">!</span>
+        )}
+        {status === TaskRun_Status.CANCELED && <Minus className="h-4 w-4" />}
+      </div>
+    </Tooltip>
+  );
+}
+
+function IssueDetailTaskRunComment({ taskRun }: { taskRun: TaskRun }) {
+  const { t } = useTranslation();
+  const earliestAllowedTime = taskRun.runTime
+    ? getTimeForPbTimestampProtoEs(taskRun.runTime)
+    : null;
+
+  const comment = (() => {
+    if (taskRun.status === TaskRun_Status.PENDING) {
+      if (earliestAllowedTime) {
+        return t("task-run.status.enqueued-with-rollout-time", {
+          time: formatAbsoluteDateTime(earliestAllowedTime),
+        });
+      }
+      return t("task-run.status.enqueued");
+    }
+    if (taskRun.status === TaskRun_Status.RUNNING && taskRun.schedulerInfo) {
+      const cause = taskRun.schedulerInfo.waitingCause;
+      if (cause?.cause?.case === "parallelTasksLimit") {
+        return t("task-run.status.waiting-max-tasks-per-rollout", {
+          time: formatAbsoluteDateTime(
+            getTimeForPbTimestampProtoEs(taskRun.schedulerInfo.reportTime)
+          ),
+        });
+      }
+    }
+    return taskRun.detail || "-";
+  })();
+
+  const commentLink =
+    taskRun.status === TaskRun_Status.FAILED && comment.includes("version")
+      ? {
+          link: "https://docs.bytebase.com/change-database/troubleshoot/?source=console#duplicate-version",
+          title: t("common.troubleshoot"),
+        }
+      : undefined;
+
+  return (
+    <div className="flex flex-col gap-y-0.5 xl:flex-row xl:items-center xl:gap-x-1">
+      <div className="min-w-0 flex-1">
+        <EllipsisText className="line-clamp-1" text={comment} />
+      </div>
+      {commentLink && (
+        <a
+          className="normal-link shrink-0"
+          href={commentLink.link}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {commentLink.title}
+        </a>
+      )}
+    </div>
+  );
+}
+
+function IssueDetailTaskRunDateCell({
+  date,
+  format = "humanized",
+}: {
+  date?: Parameters<typeof getDateForPbTimestampProtoEs>[0];
+  format?: "absolute" | "humanized";
+}) {
+  if (!date) {
+    return <span className="text-control-light">-</span>;
+  }
+
+  const parsedDate = getDateForPbTimestampProtoEs(date);
+  if (!parsedDate) {
+    return <span className="text-control-light">-</span>;
+  }
+  const text =
+    format === "absolute"
+      ? formatAbsoluteDateTime(parsedDate.getTime())
+      : humanizeDate(parsedDate);
+
+  return (
+    <Tooltip content={formatAbsoluteDateTime(parsedDate.getTime())}>
+      <span className="text-sm text-control">{text}</span>
+    </Tooltip>
+  );
+}
+
+function IssueDetailTaskRunDatabaseCell({ database }: { database: Database }) {
+  const { t } = useTranslation();
+  const environmentStore = useEnvironmentV1Store();
+  const environment = useVueState(() =>
+    environmentStore.getEnvironmentByName(
+      database.effectiveEnvironment ??
+        database.instanceResource?.environment ??
+        ""
+    )
+  );
+  const instance = database.instanceResource;
+  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
+  const { databaseName } = extractDatabaseResourceName(database.name);
+  const instanceTitle =
+    instance?.title ||
+    extractInstanceResourceName(database.name) ||
+    t("common.unknown");
+
+  return (
+    <div className="flex min-w-0 items-center truncate text-sm">
+      {engineIcon && (
+        <img alt="" className="mr-1 inline-block h-4 w-4" src={engineIcon} />
+      )}
+      <span className="mr-1 truncate text-gray-400">{environment.title}</span>
+      <span className="truncate text-gray-600">{instanceTitle}</span>
+      <span className="mx-1 shrink-0 text-gray-500 opacity-60">/</span>
+      <span className="truncate text-gray-800">{databaseName}</span>
+    </div>
+  );
+}
+
+function executionDurationOfTaskRun(taskRun: TaskRun) {
+  const { startTime, updateTime } = taskRun;
+  if (!startTime || !updateTime) {
+    return undefined;
+  }
+  if (Number(startTime.seconds) === 0) {
+    return undefined;
+  }
+  if (taskRun.status === TaskRun_Status.RUNNING) {
+    const elapsedMS = Date.now() - getTimeForPbTimestampProtoEs(startTime);
+    return create(DurationSchema, {
+      nanos: (elapsedMS % 1000) * 1e6,
+      seconds: BigInt(Math.floor(elapsedMS / 1000)),
+    });
+  }
+  const elapsedMS =
+    getTimeForPbTimestampProtoEs(updateTime) -
+    getTimeForPbTimestampProtoEs(startTime);
+  return create(DurationSchema, {
+    nanos: (elapsedMS % 1000) * 1e6,
+    seconds: BigInt(Math.floor(elapsedMS / 1000)),
+  });
+}
+
+function taskRunStatusLabel(
+  t: ReturnType<typeof useTranslation>["t"],
+  status: TaskRun_Status
+) {
+  switch (status) {
+    case TaskRun_Status.PENDING:
+      return t("task.status.pending");
+    case TaskRun_Status.RUNNING:
+      return t("task.status.running");
+    case TaskRun_Status.DONE:
+      return t("task.status.done");
+    case TaskRun_Status.FAILED:
+      return t("task.status.failed");
+    case TaskRun_Status.CANCELED:
+      return t("task.status.canceled");
+    default:
+      return String(status);
+  }
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTitleInput.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTitleInput.tsx
@@ -1,0 +1,122 @@
+import { create } from "@bufbuild/protobuf";
+import { Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { issueServiceClientConnect } from "@/connect";
+import { useVueState } from "@/react/hooks/useVueState";
+import { pushNotification, useProjectV1Store } from "@/store";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import {
+  IssueSchema,
+  UpdateIssueRequestSchema,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { hasProjectPermissionV2 } from "@/utils";
+import { useIssueDetailContext } from "../context/IssueDetailContext";
+
+export function IssueDetailTitleInput() {
+  const { t } = useTranslation();
+  const page = useIssueDetailContext();
+  const projectStore = useProjectV1Store();
+  const projectName = `${projectNamePrefix}${page.projectId}`;
+  const project = useVueState(() => projectStore.getProjectByName(projectName));
+
+  const [title, setTitle] = useState(page.issue?.title || "");
+  const [isEditing, setIsEditing] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+
+  useEffect(() => {
+    setTitle(page.issue?.title || page.plan?.title || "");
+  }, [page.issue?.title, page.plan?.title]);
+
+  useEffect(() => {
+    return () => {
+      page.setEditing("title", false);
+    };
+  }, [page]);
+
+  const allowEdit = useMemo(() => {
+    if (page.readonly || !page.issue || !project) {
+      return false;
+    }
+    return hasProjectPermissionV2(project, "bb.issues.update");
+  }, [page.issue, page.readonly, project]);
+  const isReadOnly = !allowEdit || isUpdating;
+
+  const handleBlur = async () => {
+    page.setEditing("title", false);
+    setIsEditing(false);
+    if (!page.issue || title === page.issue.title) {
+      setTitle(page.issue?.title || "");
+      return;
+    }
+
+    try {
+      setIsUpdating(true);
+      const issuePatch = create(IssueSchema, {
+        ...page.issue,
+        title,
+      });
+      const request = create(UpdateIssueRequestSchema, {
+        issue: issuePatch,
+        updateMask: { paths: ["title"] },
+      });
+      const response = await issueServiceClientConnect.updateIssue(request);
+      page.patchState({ issue: response });
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: t("common.updated"),
+      });
+    } catch (error) {
+      console.error("Failed to update issue title:", error);
+      setTitle(page.issue.title);
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.error"),
+        description: String(error),
+      });
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <div className="relative min-w-0 flex-1">
+      <input
+        className={[
+          "h-10 w-full bg-transparent text-[18px] font-bold text-main transition-colors outline-hidden",
+          "placeholder:text-control-placeholder",
+          "caret-main",
+          isReadOnly ? "cursor-default" : "cursor-text",
+          isEditing
+            ? "border border-control-border bg-transparent px-3"
+            : "border border-transparent bg-transparent px-0",
+        ].join(" ")}
+        maxLength={200}
+        onBlur={handleBlur}
+        onChange={(e) => setTitle(e.target.value)}
+        onFocus={() => {
+          if (isReadOnly) {
+            return;
+          }
+          page.setEditing("title", true);
+          setIsEditing(true);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+            e.currentTarget.blur();
+          }
+        }}
+        required
+        readOnly={isReadOnly}
+        value={title}
+      />
+      {isUpdating && (
+        <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center">
+          <Loader2 className="h-4 w-4 animate-spin text-control-light" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/react/pages/project/issue-detail/context/IssueDetailContext.tsx
+++ b/frontend/src/react/pages/project/issue-detail/context/IssueDetailContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, type ReactNode, useContext } from "react";
+import type { IssueDetailPageState } from "../hooks/useIssueDetailPage";
+
+const IssueDetailContext = createContext<IssueDetailPageState | null>(null);
+
+export const IssueDetailProvider = ({
+  value,
+  children,
+}: {
+  value: IssueDetailPageState;
+  children: ReactNode;
+}) => {
+  return (
+    <IssueDetailContext.Provider value={value}>
+      {children}
+    </IssueDetailContext.Provider>
+  );
+};
+
+export const useIssueDetailContext = () => {
+  const context = useContext(IssueDetailContext);
+  if (!context) {
+    throw new Error(
+      "useIssueDetailContext must be used within IssueDetailProvider"
+    );
+  }
+  return context;
+};

--- a/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
+++ b/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
@@ -1,0 +1,537 @@
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  issueServiceClientConnect,
+  planServiceClientConnect,
+  rolloutServiceClientConnect,
+} from "@/connect";
+import { useVueState } from "@/react/hooks/useVueState";
+import { router } from "@/router";
+import {
+  WORKSPACE_ROUTE_403,
+  WORKSPACE_ROUTE_404,
+} from "@/router/dashboard/workspaceRoutes";
+import { projectNamePrefix, useProjectV1Store } from "@/store";
+import { State } from "@/types/proto-es/v1/common_pb";
+import {
+  GetIssueRequestSchema,
+  type Issue,
+  IssueStatus,
+} from "@/types/proto-es/v1/issue_service_pb";
+import {
+  GetPlanCheckRunRequestSchema,
+  GetPlanRequestSchema,
+  type Plan,
+  type PlanCheckRun,
+} from "@/types/proto-es/v1/plan_service_pb";
+import {
+  GetRolloutRequestSchema,
+  ListTaskRunsRequestSchema,
+  type Rollout,
+  Task_Status,
+  type TaskRun,
+} from "@/types/proto-es/v1/rollout_service_pb";
+import { unknownPlan } from "@/types/v1/issue/plan";
+import { getRolloutFromPlan, minmax, setDocumentTitle } from "@/utils";
+import type { ProjectIssueDetailPageProps } from "../types";
+import {
+  type IssueDetailType,
+  resolveIssueDetailType,
+} from "./useIssueDetailType";
+
+export type IssueDetailSidebarMode = "NONE" | "DESKTOP" | "MOBILE";
+
+export interface IssueDetailPageSnapshot {
+  projectId: string;
+  issueId: string;
+  pageKey: string;
+  projectTitle: string;
+  isCreating: boolean;
+  isInitializing: boolean;
+  ready: boolean;
+  readonly: boolean;
+  issue?: Issue;
+  plan?: Plan;
+  rollout?: Rollout;
+  taskRuns: TaskRun[];
+  planCheckRuns: PlanCheckRun[];
+  issueType?: IssueDetailType;
+  sidebarMode: IssueDetailSidebarMode;
+  desktopSidebarWidth: number;
+  mobileSidebarOpen: boolean;
+}
+
+export interface IssueDetailPageState extends IssueDetailPageSnapshot {
+  isEditing: boolean;
+  patchState: (patch: Partial<IssueDetailPageSnapshot>) => void;
+  refreshState: () => Promise<void>;
+  setEditing: (scope: string, editing: boolean) => void;
+  setMobileSidebarOpen: (open: boolean) => void;
+}
+
+const POLLER_INTERVAL = {
+  min: 1000,
+  max: 30000,
+  growth: 2,
+  jitter: 250,
+} as const;
+
+const buildDefaultSnapshot = (
+  projectId: string,
+  issueId: string
+): IssueDetailPageSnapshot => ({
+  projectId,
+  issueId,
+  pageKey: `${projectId}/${issueId}`,
+  projectTitle: "",
+  isCreating: issueId.toLowerCase() === "create",
+  isInitializing: true,
+  ready: false,
+  readonly: true,
+  issue: undefined,
+  plan: undefined,
+  rollout: undefined,
+  taskRuns: [],
+  planCheckRuns: [],
+  issueType: undefined,
+  sidebarMode: "NONE",
+  desktopSidebarWidth: 0,
+  mobileSidebarOpen: false,
+});
+
+const applyDerivedState = (
+  snapshot: IssueDetailPageSnapshot
+): IssueDetailPageSnapshot => {
+  const readonly =
+    snapshot.plan?.state === State.DELETED ||
+    (snapshot.issue ? snapshot.issue.status !== IssueStatus.OPEN : false);
+  return {
+    ...snapshot,
+    issueType: resolveIssueDetailType(
+      snapshot.issue,
+      snapshot.plan ?? unknownPlan()
+    ),
+    readonly,
+    ready:
+      (Boolean(snapshot.issue) || Boolean(snapshot.plan)) &&
+      !snapshot.isInitializing,
+  };
+};
+
+const loadIssueDetailSnapshot = async (
+  projectId: string,
+  issueId: string
+): Promise<Partial<IssueDetailPageSnapshot>> => {
+  const issue = await issueServiceClientConnect.getIssue(
+    create(GetIssueRequestSchema, {
+      name: `${projectNamePrefix}${projectId}/issues/${issueId}`,
+    })
+  );
+
+  if (!issue.plan) {
+    return {
+      issue,
+      plan: unknownPlan(),
+      planCheckRuns: [],
+      rollout: undefined,
+      taskRuns: [],
+    };
+  }
+
+  const plan = await planServiceClientConnect.getPlan(
+    create(GetPlanRequestSchema, {
+      name: issue.plan,
+    })
+  );
+
+  const [planCheckRuns, rollout] = await Promise.all([
+    planServiceClientConnect
+      .getPlanCheckRun(
+        create(GetPlanCheckRunRequestSchema, {
+          name: `${plan.name}/planCheckRun`,
+        })
+      )
+      .then((run) => [run] as PlanCheckRun[])
+      .catch(() => []),
+    plan.hasRollout
+      ? rolloutServiceClientConnect
+          .getRollout(
+            create(GetRolloutRequestSchema, {
+              name: getRolloutFromPlan(plan.name),
+            })
+          )
+          .catch(() => undefined)
+      : Promise.resolve(undefined),
+  ]);
+
+  const taskRuns =
+    rollout !== undefined
+      ? await rolloutServiceClientConnect
+          .listTaskRuns(
+            create(ListTaskRunsRequestSchema, {
+              parent: `${rollout.name}/stages/-/tasks/-`,
+            })
+          )
+          .then((response) => response.taskRuns)
+          .catch(() => [])
+      : [];
+
+  return {
+    issue,
+    plan,
+    planCheckRuns,
+    rollout,
+    taskRuns,
+  };
+};
+
+const refreshIssueDetailSnapshot = async (
+  snapshot: Pick<IssueDetailPageSnapshot, "issue" | "plan">
+): Promise<Partial<IssueDetailPageSnapshot>> => {
+  if (!snapshot.plan?.name) {
+    return {};
+  }
+
+  const plan = await planServiceClientConnect.getPlan(
+    create(GetPlanRequestSchema, {
+      name: snapshot.plan.name,
+    })
+  );
+
+  const [issue, planCheckRuns, rollout] = await Promise.all([
+    snapshot.issue?.name
+      ? issueServiceClientConnect
+          .getIssue(
+            create(GetIssueRequestSchema, {
+              name: snapshot.issue.name,
+            })
+          )
+          .catch(() => undefined)
+      : Promise.resolve(undefined),
+    planServiceClientConnect
+      .getPlanCheckRun(
+        create(GetPlanCheckRunRequestSchema, {
+          name: `${plan.name}/planCheckRun`,
+        })
+      )
+      .then((run) => [run] as PlanCheckRun[])
+      .catch(() => []),
+    plan.hasRollout
+      ? rolloutServiceClientConnect
+          .getRollout(
+            create(GetRolloutRequestSchema, {
+              name: getRolloutFromPlan(plan.name),
+            })
+          )
+          .catch(() => undefined)
+      : Promise.resolve(undefined),
+  ]);
+
+  const taskRuns =
+    rollout !== undefined
+      ? await rolloutServiceClientConnect
+          .listTaskRuns(
+            create(ListTaskRunsRequestSchema, {
+              parent: `${rollout.name}/stages/-/tasks/-`,
+            })
+          )
+          .then((response) => response.taskRuns)
+          .catch(() => [])
+      : [];
+
+  return {
+    issue,
+    plan,
+    planCheckRuns,
+    rollout,
+    taskRuns,
+  };
+};
+
+export const useIssueDetailPage = ({
+  issueId,
+  pageHost,
+  projectId,
+}: ProjectIssueDetailPageProps & {
+  pageHost: HTMLDivElement | null;
+}): IssueDetailPageState => {
+  const { t } = useTranslation();
+  const projectStore = useProjectV1Store();
+  const project = useVueState(() =>
+    projectStore.getProjectByName(`${projectNamePrefix}${projectId}`)
+  );
+  const [snapshot, setSnapshot] = useState<IssueDetailPageSnapshot>(() =>
+    buildDefaultSnapshot(projectId, issueId)
+  );
+  const [editingScopes, setEditingScopes] = useState<Record<string, true>>({});
+  const latestSnapshotRef = useRef(snapshot);
+  const pollTimerRef = useRef<number | undefined>(undefined);
+  const isEditing = Object.keys(editingScopes).length > 0;
+
+  useEffect(() => {
+    latestSnapshotRef.current = snapshot;
+  }, [snapshot]);
+
+  const stopPolling = useCallback(() => {
+    if (!pollTimerRef.current) {
+      return;
+    }
+    window.clearTimeout(pollTimerRef.current);
+    pollTimerRef.current = undefined;
+  }, []);
+
+  const patchState = useCallback(
+    (patch: Partial<IssueDetailPageSnapshot>) => {
+      setSnapshot((prev) => applyDerivedState({ ...prev, ...patch }));
+    },
+    [setSnapshot]
+  );
+
+  const setMobileSidebarOpen = useCallback(
+    (open: boolean) => {
+      patchState({ mobileSidebarOpen: open });
+    },
+    [patchState]
+  );
+
+  const refreshState = useCallback(async () => {
+    const current = latestSnapshotRef.current;
+    const patch = await refreshIssueDetailSnapshot(current);
+    patchState(patch);
+  }, [patchState]);
+
+  const setEditing = useCallback((scope: string, editing: boolean) => {
+    setEditingScopes((prev) => {
+      if (editing) {
+        if (prev[scope]) {
+          return prev;
+        }
+        return {
+          ...prev,
+          [scope]: true,
+        };
+      }
+      if (!prev[scope]) {
+        return prev;
+      }
+      const next = { ...prev };
+      delete next[scope];
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    setEditingScopes({});
+    patchState({
+      issueId,
+      isCreating: issueId.toLowerCase() === "create",
+      isInitializing: true,
+      issue: undefined,
+      pageKey: `${projectId}/${issueId}`,
+      plan: undefined,
+      planCheckRuns: [],
+      projectId,
+      rollout: undefined,
+      taskRuns: [],
+    });
+
+    let canceled = false;
+
+    const load = async () => {
+      try {
+        const patch = await loadIssueDetailSnapshot(projectId, issueId);
+        if (canceled) {
+          return;
+        }
+        patchState({
+          ...patch,
+          isInitializing: false,
+        });
+      } catch (error) {
+        if (canceled) {
+          return;
+        }
+        if (error instanceof ConnectError) {
+          if (error.code === Code.NotFound) {
+            void router.push({ name: WORKSPACE_ROUTE_404 });
+          } else if (error.code === Code.PermissionDenied) {
+            void router.push({ name: WORKSPACE_ROUTE_403 });
+          }
+          patchState({ isInitializing: false });
+          return;
+        }
+
+        patchState({ isInitializing: false });
+        throw error;
+      }
+    };
+
+    void load();
+
+    return () => {
+      canceled = true;
+    };
+  }, [issueId, patchState, projectId]);
+
+  useEffect(() => {
+    patchState({
+      projectTitle: project.title,
+    });
+  }, [patchState, project.title]);
+
+  useEffect(() => {
+    const entityTitle = snapshot.issue?.title || snapshot.plan?.title;
+    if (snapshot.ready && entityTitle) {
+      setDocumentTitle(entityTitle, snapshot.projectTitle);
+    }
+  }, [
+    snapshot.issue?.title,
+    snapshot.plan?.title,
+    snapshot.projectTitle,
+    snapshot.ready,
+  ]);
+
+  useEffect(() => {
+    if (!pageHost) {
+      patchState({
+        desktopSidebarWidth: 0,
+        mobileSidebarOpen: false,
+        sidebarMode: "NONE",
+      });
+      return;
+    }
+
+    const updateSidebar = () => {
+      const containerWidth = pageHost.getBoundingClientRect().width;
+      const sidebarMode: IssueDetailSidebarMode =
+        containerWidth === 0
+          ? "NONE"
+          : containerWidth < 780
+            ? "MOBILE"
+            : "DESKTOP";
+      const desktopSidebarWidth = containerWidth < 1280 ? 240 : 336;
+      patchState({
+        desktopSidebarWidth,
+        mobileSidebarOpen:
+          sidebarMode === "MOBILE"
+            ? latestSnapshotRef.current.mobileSidebarOpen
+            : false,
+        sidebarMode,
+      });
+    };
+
+    updateSidebar();
+    const observer = new ResizeObserver(() => updateSidebar());
+    observer.observe(pageHost);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [pageHost, patchState]);
+
+  useEffect(() => {
+    if (!isEditing) {
+      return;
+    }
+
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.returnValue = t("common.leave-without-saving");
+      event.preventDefault();
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    const removeGuard = router.beforeEach((_to, _from, next) => {
+      if (window.confirm(t("common.leave-without-saving"))) {
+        next();
+      } else {
+        next(false);
+      }
+    });
+
+    return () => {
+      window.removeEventListener("beforeunload", onBeforeUnload);
+      removeGuard();
+    };
+  }, [isEditing, t]);
+
+  const isPlanDone = useMemo(() => {
+    if (!snapshot.rollout) {
+      return false;
+    }
+    const allTasks = snapshot.rollout.stages.flatMap((stage) => stage.tasks);
+    return (
+      allTasks.length > 0 &&
+      allTasks.every(
+        (task) =>
+          task.status === Task_Status.DONE ||
+          task.status === Task_Status.SKIPPED
+      )
+    );
+  }, [snapshot.rollout]);
+
+  useEffect(() => {
+    if (!snapshot.ready || snapshot.isCreating || isPlanDone) {
+      stopPolling();
+      return;
+    }
+
+    let canceled = false;
+
+    const poll = (interval: number) => {
+      stopPolling();
+      const nextInterval = minmax(
+        interval +
+          Math.floor(Math.random() * (POLLER_INTERVAL.jitter * 2 + 1)) -
+          POLLER_INTERVAL.jitter,
+        POLLER_INTERVAL.min,
+        POLLER_INTERVAL.max
+      );
+
+      pollTimerRef.current = window.setTimeout(async () => {
+        if (canceled) {
+          return;
+        }
+        await refreshState().catch(() => undefined);
+        if (canceled) {
+          return;
+        }
+        poll(
+          Math.min(nextInterval * POLLER_INTERVAL.growth, POLLER_INTERVAL.max)
+        );
+      }, nextInterval);
+    };
+
+    poll(POLLER_INTERVAL.min);
+
+    return () => {
+      canceled = true;
+      stopPolling();
+    };
+  }, [
+    isPlanDone,
+    refreshState,
+    snapshot.isCreating,
+    snapshot.ready,
+    stopPolling,
+  ]);
+
+  return useMemo(
+    () => ({
+      ...snapshot,
+      isEditing,
+      patchState,
+      refreshState,
+      setEditing,
+      setMobileSidebarOpen,
+    }),
+    [
+      isEditing,
+      patchState,
+      refreshState,
+      setEditing,
+      setMobileSidebarOpen,
+      snapshot,
+    ]
+  );
+};

--- a/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
+++ b/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
@@ -190,26 +190,34 @@ const loadIssueDetailSnapshot = async (
 const refreshIssueDetailSnapshot = async (
   snapshot: Pick<IssueDetailPageSnapshot, "issue" | "plan">
 ): Promise<Partial<IssueDetailPageSnapshot>> => {
-  if (!snapshot.plan?.name) {
-    return {};
+  const issue = snapshot.issue?.name
+    ? await issueServiceClientConnect
+        .getIssue(
+          create(GetIssueRequestSchema, {
+            name: snapshot.issue.name,
+          })
+        )
+        .catch(() => undefined)
+    : undefined;
+
+  const planName = snapshot.plan?.name || issue?.plan;
+  if (!planName) {
+    return {
+      issue,
+      plan: unknownPlan(),
+      planCheckRuns: [],
+      rollout: undefined,
+      taskRuns: [],
+    };
   }
 
   const plan = await planServiceClientConnect.getPlan(
     create(GetPlanRequestSchema, {
-      name: snapshot.plan.name,
+      name: planName,
     })
   );
 
-  const [issue, planCheckRuns, rollout] = await Promise.all([
-    snapshot.issue?.name
-      ? issueServiceClientConnect
-          .getIssue(
-            create(GetIssueRequestSchema, {
-              name: snapshot.issue.name,
-            })
-          )
-          .catch(() => undefined)
-      : Promise.resolve(undefined),
+  const [planCheckRuns, rollout] = await Promise.all([
     planServiceClientConnect
       .getPlanCheckRun(
         create(GetPlanCheckRunRequestSchema, {

--- a/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailSpecValidation.ts
+++ b/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailSpecValidation.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from "react";
+import { useSheetV1Store } from "@/store";
+import type { Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
+import { sheetNameOfSpec } from "@/utils/v1/issue/plan";
+import { extractSheetUID, getSheetStatement } from "@/utils/v1/sheet";
+import { getLocalSheetByName } from "../utils/localSheet";
+
+const checkSpecStatement = async (
+  spec: Plan_Spec,
+  sheetStore: ReturnType<typeof useSheetV1Store>
+): Promise<boolean> => {
+  if (
+    spec.config?.case !== "changeDatabaseConfig" &&
+    spec.config?.case !== "exportDataConfig"
+  ) {
+    return false;
+  }
+
+  if (
+    spec.config?.case === "changeDatabaseConfig" &&
+    spec.config.value.release
+  ) {
+    return false;
+  }
+
+  const sheetName = sheetNameOfSpec(spec);
+  if (!sheetName) {
+    return true;
+  }
+
+  try {
+    const uid = extractSheetUID(sheetName);
+    const sheet = uid.startsWith("-")
+      ? getLocalSheetByName(sheetName)
+      : await sheetStore.getOrFetchSheetByName(sheetName);
+    if (!sheet) {
+      return true;
+    }
+    return getSheetStatement(sheet).trim() === "";
+  } catch {
+    return false;
+  }
+};
+
+export function useIssueDetailSpecValidation(specs: Plan_Spec[]) {
+  const sheetStore = useSheetV1Store();
+  const [emptySpecIdSet, setEmptySpecIdSet] = useState<Set<string>>(
+    () => new Set()
+  );
+
+  useEffect(() => {
+    let canceled = false;
+
+    const validate = async () => {
+      const next = new Set<string>();
+      await Promise.all(
+        specs.map(async (spec) => {
+          if (await checkSpecStatement(spec, sheetStore)) {
+            next.add(spec.id);
+          }
+        })
+      );
+      if (!canceled) {
+        setEmptySpecIdSet(next);
+      }
+    };
+
+    void validate();
+
+    return () => {
+      canceled = true;
+    };
+  }, [sheetStore, specs]);
+
+  return {
+    emptySpecIdSet,
+    isSpecEmpty: (spec: Plan_Spec) => emptySpecIdSet.has(spec.id),
+  };
+}

--- a/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailType.ts
+++ b/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailType.ts
@@ -1,0 +1,43 @@
+import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
+import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
+import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
+
+export type IssueDetailType =
+  | "DATABASE_CHANGE"
+  | "CREATE_DATABASE"
+  | "EXPORT_DATA"
+  | "ROLE_GRANT"
+  | "ACCESS_GRANT";
+
+export const resolveIssueDetailType = (
+  issue?: Issue,
+  plan?: Plan
+): IssueDetailType | undefined => {
+  if (!issue) {
+    return undefined;
+  }
+
+  if (issue.type === Issue_Type.ROLE_GRANT) {
+    return "ROLE_GRANT";
+  }
+  if (issue.type === Issue_Type.ACCESS_GRANT) {
+    return "ACCESS_GRANT";
+  }
+
+  const specs = plan?.specs ?? [];
+  if (specs.length === 0) {
+    return undefined;
+  }
+
+  if (specs.every((spec) => spec.config.case === "createDatabaseConfig")) {
+    return "CREATE_DATABASE";
+  }
+  if (specs.every((spec) => spec.config.case === "exportDataConfig")) {
+    return "EXPORT_DATA";
+  }
+  if (specs.some((spec) => spec.config.case === "changeDatabaseConfig")) {
+    return "DATABASE_CHANGE";
+  }
+
+  return undefined;
+};

--- a/frontend/src/react/pages/project/issue-detail/types.ts
+++ b/frontend/src/react/pages/project/issue-detail/types.ts
@@ -1,0 +1,4 @@
+export interface ProjectIssueDetailPageProps {
+  projectId: string;
+  issueId: string;
+}

--- a/frontend/src/react/pages/project/issue-detail/utils/actionRegistry.ts
+++ b/frontend/src/react/pages/project/issue-detail/utils/actionRegistry.ts
@@ -1,0 +1,483 @@
+import type { TFunction } from "i18next";
+import { first, orderBy } from "lodash-es";
+import { candidatesOfApprovalStepV1, extractUserEmail } from "@/store";
+import { State } from "@/types/proto-es/v1/common_pb";
+import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
+import {
+  Issue_ApprovalStatus,
+  Issue_Approver_Status,
+  Issue_Type,
+  IssueStatus,
+} from "@/types/proto-es/v1/issue_service_pb";
+import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import type { Rollout, TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  Task_Status,
+  Task_Type,
+  TaskRun_ExportArchiveStatus,
+  TaskRun_Status,
+} from "@/types/proto-es/v1/rollout_service_pb";
+import { Advice_Level } from "@/types/proto-es/v1/sql_service_pb";
+import type { User } from "@/types/proto-es/v1/user_service_pb";
+import {
+  extractTaskRunUID,
+  extractTaskUID,
+  hasProjectPermissionV2,
+  isUserIncludedInList,
+  isValidIssueName,
+  isValidPlanName,
+} from "@/utils";
+import { isApprovalCompleted } from "./approval";
+
+export type IssueReviewAction = "ISSUE_REVIEW";
+export type IssueStatusAction = "ISSUE_STATUS_CLOSE" | "ISSUE_STATUS_REOPEN";
+export type IssueAction =
+  | IssueReviewAction
+  | IssueStatusAction
+  | "ISSUE_CREATE";
+export type RolloutAction = "ROLLOUT_START" | "ROLLOUT_CANCEL";
+export type ExportAction = "EXPORT_DOWNLOAD";
+export type UnifiedAction = IssueAction | RolloutAction | ExportAction;
+export type ExecuteType =
+  | "immediate"
+  | "popover:labels"
+  | "popover:review"
+  | "panel:issue-status"
+  | "panel:rollout";
+export type ActionCategory = "primary" | "secondary";
+
+export interface ActionPermissions {
+  updatePlan: boolean;
+  createIssue: boolean;
+  updateIssue: boolean;
+  createRollout: boolean;
+  runTasks: boolean;
+  isApprovalCandidate: boolean;
+}
+
+export interface ActionValidation {
+  hasEmptySpec: boolean;
+  planChecksRunning: boolean;
+  planChecksFailed: boolean;
+}
+
+export interface ActionContext {
+  plan: Plan;
+  issue: Issue | undefined;
+  rollout: Rollout | undefined;
+  project: Project;
+  planState: State;
+  issueStatus: IssueStatus | undefined;
+  approvalStatus: Issue_ApprovalStatus | undefined;
+  isCreating: boolean;
+  isIssueOnly: boolean;
+  isExportPlan: boolean;
+  isReleasePlan: boolean;
+  hasDeferredRollout: boolean;
+  isCreator: boolean;
+  issueApproved: boolean;
+  exportArchiveReady: boolean;
+  allTasksFinished: boolean;
+  hasDatabaseCreateOrExportTasks: boolean;
+  hasStartableTasks: boolean;
+  hasRunningTasks: boolean;
+  permissions: ActionPermissions;
+  validation: ActionValidation;
+}
+
+export interface ActionDefinition {
+  id: UnifiedAction;
+  label: (ctx: ActionContext) => string;
+  buttonType: "primary" | "success" | "default";
+  category: ActionCategory | ((ctx: ActionContext) => ActionCategory);
+  priority: number;
+  isVisible: (ctx: ActionContext) => boolean;
+  isDisabled: (ctx: ActionContext) => boolean;
+  disabledReason: (ctx: ActionContext) => string | undefined;
+  executeType: ExecuteType;
+}
+
+export interface ContextBuilderInput {
+  plan: Plan;
+  issue: Issue | undefined;
+  rollout: Rollout | undefined;
+  project: Project;
+  currentUser: User;
+  taskRuns: TaskRun[];
+  isCreating: boolean;
+  planCheckStatus: Advice_Level;
+  hasRunningPlanChecks: boolean;
+  isSpecEmpty: (spec: Plan["specs"][0]) => boolean;
+}
+
+const computeIsApprovalCandidate = (
+  issue: Issue | undefined,
+  currentUser: User,
+  project: Project
+): boolean => {
+  if (!issue) return false;
+  if (isApprovalCompleted(issue)) return false;
+
+  const { approvers, approvalTemplate } = issue;
+  const hasRejection = approvers.some(
+    (app) => app.status === Issue_Approver_Status.REJECTED
+  );
+  if (hasRejection) return false;
+
+  const roles = approvalTemplate?.flow?.roles ?? [];
+  if (roles.length === 0) return false;
+
+  const rejectedIndex = approvers.findIndex(
+    (approver) => approver.status === Issue_Approver_Status.REJECTED
+  );
+  const currentRoleIndex =
+    rejectedIndex >= 0 ? rejectedIndex : approvers.length;
+  const currentRole = roles[currentRoleIndex];
+  if (!currentRole) return false;
+
+  const candidates = candidatesOfApprovalStepV1(issue, currentRole);
+  if (!isUserIncludedInList(currentUser.email, candidates)) return false;
+
+  if (
+    !project.allowSelfApproval &&
+    currentUser.email === extractUserEmail(issue.creator)
+  ) {
+    return false;
+  }
+  return true;
+};
+
+const computeExportArchiveReady = (
+  rollout: Rollout | undefined,
+  taskRuns: TaskRun[],
+  issue: Issue | undefined,
+  currentUserEmail: string
+): boolean => {
+  if (!issue) return false;
+  if (![IssueStatus.OPEN, IssueStatus.DONE].includes(issue.status))
+    return false;
+  if (currentUserEmail !== extractUserEmail(issue.creator)) return false;
+
+  const exportTasks =
+    rollout?.stages
+      .flatMap((stage) => stage.tasks)
+      .filter((task) => task.type === Task_Type.DATABASE_EXPORT) ?? [];
+  if (exportTasks.length === 0) return false;
+  if (
+    !exportTasks.every((task) =>
+      [Task_Status.DONE, Task_Status.SKIPPED].includes(task.status)
+    )
+  ) {
+    return false;
+  }
+
+  const doneTasks = exportTasks.filter(
+    (task) => task.status === Task_Status.DONE
+  );
+  if (doneTasks.length === 0) return false;
+
+  const exportTaskRuns = doneTasks
+    .map((task) => {
+      const taskRunsForTask = taskRuns.filter(
+        (taskRun) => extractTaskUID(taskRun.name) === extractTaskUID(task.name)
+      );
+      return first(
+        orderBy(
+          taskRunsForTask,
+          (taskRun) => Number(extractTaskRunUID(taskRun.name)),
+          "desc"
+        )
+      );
+    })
+    .filter(Boolean) as TaskRun[];
+
+  if (
+    exportTaskRuns.length === 0 ||
+    exportTaskRuns.some(
+      (taskRun) =>
+        taskRun.status !== TaskRun_Status.DONE ||
+        taskRun.exportArchiveStatus ===
+          TaskRun_ExportArchiveStatus.EXPORT_ARCHIVE_STATUS_UNSPECIFIED
+    )
+  ) {
+    return false;
+  }
+
+  return true;
+};
+
+export const buildIssueDetailActionContext = (
+  input: ContextBuilderInput
+): ActionContext => {
+  const {
+    currentUser,
+    hasRunningPlanChecks,
+    isCreating,
+    isSpecEmpty,
+    issue,
+    plan,
+    planCheckStatus,
+    project,
+    rollout,
+    taskRuns,
+  } = input;
+
+  const currentUserEmail = currentUser.email;
+  const isIssueOnly =
+    !isValidPlanName(plan.name) && Boolean(isValidIssueName(issue?.name));
+  const isExportPlan = plan.specs.some(
+    (spec) => spec.config?.case === "exportDataConfig"
+  );
+  const isReleasePlan = plan.specs.some(
+    (spec) =>
+      spec.config?.case === "changeDatabaseConfig" &&
+      Boolean(spec.config.value.release)
+  );
+  const hasDeferredRollout = plan.specs.some(
+    (spec) =>
+      spec.config?.case === "exportDataConfig" ||
+      spec.config?.case === "createDatabaseConfig"
+  );
+  const isCreator =
+    currentUserEmail === extractUserEmail(plan.creator || "") ||
+    (issue ? currentUserEmail === extractUserEmail(issue.creator) : false);
+
+  const permissions: ActionPermissions = {
+    updatePlan:
+      currentUserEmail === extractUserEmail(plan.creator || "") ||
+      hasProjectPermissionV2(project, "bb.plans.update"),
+    createIssue: hasProjectPermissionV2(project, "bb.issues.create"),
+    updateIssue: hasProjectPermissionV2(project, "bb.issues.update"),
+    createRollout: hasProjectPermissionV2(project, "bb.rollouts.create"),
+    runTasks:
+      issue?.type === Issue_Type.DATABASE_EXPORT
+        ? currentUserEmail === extractUserEmail(issue.creator)
+        : hasProjectPermissionV2(project, "bb.taskRuns.create"),
+    isApprovalCandidate: computeIsApprovalCandidate(
+      issue,
+      currentUser,
+      project
+    ),
+  };
+
+  const validation: ActionValidation = {
+    hasEmptySpec: plan.specs.some((spec) => isSpecEmpty(spec)),
+    planChecksRunning: hasRunningPlanChecks,
+    planChecksFailed: planCheckStatus === Advice_Level.ERROR,
+  };
+
+  const allTasks = rollout?.stages.flatMap((stage) => stage.tasks) ?? [];
+  const allTasksFinished = allTasks.every((task) =>
+    [Task_Status.DONE, Task_Status.SKIPPED].includes(task.status)
+  );
+  const hasDatabaseCreateOrExportTasks = allTasks.some(
+    (task) =>
+      task.type === Task_Type.DATABASE_CREATE ||
+      task.type === Task_Type.DATABASE_EXPORT
+  );
+  const hasStartableTasks = allTasks.some((task) =>
+    [
+      Task_Status.NOT_STARTED,
+      Task_Status.FAILED,
+      Task_Status.CANCELED,
+    ].includes(task.status)
+  );
+  const hasRunningTasks = allTasks.some((task) =>
+    [Task_Status.PENDING, Task_Status.RUNNING].includes(task.status)
+  );
+
+  return {
+    plan,
+    issue,
+    rollout,
+    project,
+    planState: plan.state,
+    issueStatus: issue?.status,
+    approvalStatus: issue?.approvalStatus,
+    isCreating,
+    isIssueOnly,
+    isExportPlan,
+    isReleasePlan,
+    hasDeferredRollout,
+    isCreator,
+    issueApproved: isApprovalCompleted(issue),
+    exportArchiveReady: computeExportArchiveReady(
+      rollout,
+      taskRuns,
+      issue,
+      currentUserEmail
+    ),
+    allTasksFinished,
+    hasDatabaseCreateOrExportTasks,
+    hasStartableTasks,
+    hasRunningTasks,
+    permissions,
+    validation,
+  };
+};
+
+export const createIssueDetailActions = (t: TFunction): ActionDefinition[] => {
+  const issueActions: ActionDefinition[] = [
+    {
+      id: "ISSUE_CREATE",
+      label: () => t("plan.ready-for-review"),
+      buttonType: "primary",
+      category: "primary",
+      priority: 5,
+      isVisible: (ctx) =>
+        !ctx.isIssueOnly &&
+        !ctx.isReleasePlan &&
+        ctx.plan.issue === "" &&
+        !ctx.plan.hasRollout &&
+        ctx.planState === State.ACTIVE,
+      isDisabled: (ctx) =>
+        !ctx.permissions.createIssue ||
+        ctx.validation.hasEmptySpec ||
+        ctx.validation.planChecksRunning ||
+        (ctx.validation.planChecksFailed && ctx.project.enforceSqlReview),
+      disabledReason: (ctx) => {
+        if (!ctx.permissions.createIssue) {
+          return t("common.missing-required-permission", {
+            permissions: "bb.issues.create",
+          });
+        }
+        if (ctx.validation.hasEmptySpec) {
+          return t("plan.navigator.statement-empty");
+        }
+        if (ctx.validation.planChecksRunning) {
+          return t(
+            "custom-approval.issue-review.disallow-approve-reason.some-task-checks-are-still-running"
+          );
+        }
+        if (ctx.validation.planChecksFailed && ctx.project.enforceSqlReview) {
+          return t(
+            "custom-approval.issue-review.disallow-approve-reason.some-task-checks-didnt-pass"
+          );
+        }
+        return undefined;
+      },
+      executeType: "popover:labels",
+    },
+    {
+      id: "ISSUE_REVIEW",
+      label: () => t("issue.review.self"),
+      buttonType: "primary",
+      category: "primary",
+      priority: 30,
+      isVisible: (ctx) =>
+        ctx.issueStatus === IssueStatus.OPEN &&
+        ctx.approvalStatus !== Issue_ApprovalStatus.APPROVED &&
+        ctx.approvalStatus !== Issue_ApprovalStatus.SKIPPED &&
+        ctx.permissions.isApprovalCandidate,
+      isDisabled: () => false,
+      disabledReason: () => undefined,
+      executeType: "popover:review",
+    },
+    {
+      id: "ISSUE_STATUS_CLOSE",
+      label: () => t("issue.batch-transition.close"),
+      buttonType: "default",
+      category: "secondary",
+      priority: 90,
+      isVisible: (ctx) =>
+        ctx.issueStatus === IssueStatus.OPEN && !ctx.plan.hasRollout,
+      isDisabled: (ctx) => !ctx.permissions.updateIssue,
+      disabledReason: (ctx) => {
+        if (!ctx.permissions.updateIssue) {
+          return t("common.missing-required-permission", {
+            permissions: "bb.issues.update",
+          });
+        }
+        return undefined;
+      },
+      executeType: "panel:issue-status",
+    },
+    {
+      id: "ISSUE_STATUS_REOPEN",
+      label: () => t("issue.batch-transition.reopen"),
+      buttonType: "default",
+      category: "primary",
+      priority: 20,
+      isVisible: (ctx) => ctx.issueStatus === IssueStatus.CANCELED,
+      isDisabled: (ctx) => !ctx.permissions.updateIssue,
+      disabledReason: (ctx) => {
+        if (!ctx.permissions.updateIssue) {
+          return t("common.missing-required-permission", {
+            permissions: "bb.issues.update",
+          });
+        }
+        return undefined;
+      },
+      executeType: "panel:issue-status",
+    },
+  ];
+
+  const rolloutActions: ActionDefinition[] = [
+    {
+      id: "ROLLOUT_START",
+      label: (ctx) =>
+        ctx.isExportPlan ? t("common.export") : t("common.rollout"),
+      buttonType: "primary",
+      category: "primary",
+      priority: 60,
+      isVisible: (ctx) => {
+        if (!ctx.hasDeferredRollout) return false;
+        if (!ctx.issue || !ctx.issueApproved) return false;
+        if (!ctx.rollout) return true;
+        return ctx.hasStartableTasks;
+      },
+      isDisabled: (ctx) => !ctx.permissions.runTasks,
+      disabledReason: (ctx) => {
+        if (!ctx.permissions.runTasks) {
+          if (ctx.isExportPlan) {
+            return t("common.only-creator-allowed-export");
+          }
+          return t("common.missing-required-permission");
+        }
+        return undefined;
+      },
+      executeType: "panel:rollout",
+    },
+    {
+      id: "ROLLOUT_CANCEL",
+      label: () => t("common.cancel"),
+      buttonType: "default",
+      category: "secondary",
+      priority: 80,
+      isVisible: (ctx) => {
+        if (!ctx.hasDeferredRollout) return false;
+        if (!ctx.rollout) return false;
+        if (!ctx.issueApproved) return false;
+        if (!ctx.hasRunningTasks) return false;
+        return true;
+      },
+      isDisabled: (ctx) => !ctx.permissions.runTasks,
+      disabledReason: (ctx) => {
+        if (!ctx.permissions.runTasks) {
+          return t("common.missing-required-permission", {
+            permissions: "bb.taskRuns.create",
+          });
+        }
+        return undefined;
+      },
+      executeType: "panel:rollout",
+    },
+    {
+      id: "EXPORT_DOWNLOAD",
+      label: () => t("common.download"),
+      buttonType: "primary",
+      category: "primary",
+      priority: 0,
+      isVisible: (ctx) =>
+        ctx.isExportPlan && ctx.exportArchiveReady && ctx.isCreator,
+      isDisabled: () => false,
+      disabledReason: () => undefined,
+      executeType: "immediate",
+    },
+  ];
+
+  return [...issueActions, ...rolloutActions].sort(
+    (left, right) => left.priority - right.priority
+  );
+};

--- a/frontend/src/react/pages/project/issue-detail/utils/approval.ts
+++ b/frontend/src/react/pages/project/issue-detail/utils/approval.ts
@@ -1,0 +1,19 @@
+import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
+import { Issue_ApprovalStatus } from "@/types/proto-es/v1/issue_service_pb";
+
+const hasNoApprovalRequired = (issue: Issue | undefined): boolean => {
+  if (!issue) return false;
+  if (issue.approvalStatus === Issue_ApprovalStatus.CHECKING) return false;
+  const roles = issue.approvalTemplate?.flow?.roles ?? [];
+  return roles.length === 0;
+};
+
+export const isApprovalCompleted = (issue: Issue | undefined): boolean => {
+  if (!issue) return false;
+
+  return (
+    issue.approvalStatus === Issue_ApprovalStatus.APPROVED ||
+    issue.approvalStatus === Issue_ApprovalStatus.SKIPPED ||
+    hasNoApprovalRequired(issue)
+  );
+};

--- a/frontend/src/react/pages/project/issue-detail/utils/databaseChange.ts
+++ b/frontend/src/react/pages/project/issue-detail/utils/databaseChange.ts
@@ -1,0 +1,137 @@
+import { isValidDatabaseName } from "@/types";
+import { Engine } from "@/types/proto-es/v1/common_pb";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import type { Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
+import { getInstanceResource, semverCompare } from "@/utils";
+
+export const BACKUP_AVAILABLE_ENGINES = [
+  Engine.MYSQL,
+  Engine.TIDB,
+  Engine.MSSQL,
+  Engine.ORACLE,
+  Engine.POSTGRES,
+];
+
+const MIN_GHOST_SUPPORT_MYSQL_VERSION = "5.6.0";
+const MIN_GHOST_SUPPORT_MARIADB_VERSION = "10.6.0";
+
+const TXN_MODE_REGEX = /^\s*--\s*txn-mode\s*=\s*(on|off)\s*$/i;
+const TXN_ISOLATION_REGEX =
+  /^\s*--\s*txn-isolation\s*=\s*(READ\s+UNCOMMITTED|READ\s+COMMITTED|REPEATABLE\s+READ|SERIALIZABLE)\s*$/i;
+const ROLE_SETTER_REGEX =
+  /\/\*\s*=== Bytebase Role Setter\. DO NOT EDIT\. === \*\/\s*SET ROLE ([a-zA-Z_][a-zA-Z0-9_]{0,62});/;
+const GHOST_DIRECTIVE_REGEX =
+  /^\s*--\s*gh-ost\s*=\s*(\{[^}]*\})\s*(?:\/\*.*\*\/)?\s*$/i;
+
+export type IsolationLevel =
+  | "READ_UNCOMMITTED"
+  | "READ_COMMITTED"
+  | "REPEATABLE_READ"
+  | "SERIALIZABLE";
+
+interface ParsedStatement {
+  transactionMode?: "on" | "off";
+  isolationLevel?: IsolationLevel;
+  ghostConfig?: Record<string, string>;
+  roleSetterBlock?: string;
+  mainContent: string;
+}
+
+export const allowGhostForDatabase = (database: Database) => {
+  const instanceResource = getInstanceResource(database);
+  const engine = instanceResource.engine;
+  return (
+    (engine === Engine.MYSQL &&
+      semverCompare(
+        instanceResource.engineVersion,
+        MIN_GHOST_SUPPORT_MYSQL_VERSION,
+        "gte"
+      )) ||
+    (engine === Engine.MARIADB &&
+      semverCompare(
+        instanceResource.engineVersion,
+        MIN_GHOST_SUPPORT_MARIADB_VERSION,
+        "gte"
+      ))
+  );
+};
+
+export const isDatabaseChangeSpec = (spec?: Plan_Spec) => {
+  if (!spec) return false;
+  if (
+    spec.config?.case === "changeDatabaseConfig" ||
+    spec.config?.case === "exportDataConfig"
+  ) {
+    return (spec.config.value.targets ?? []).every(isValidDatabaseName);
+  }
+  return false;
+};
+
+const parseStatementInternal = (statement: string): ParsedStatement => {
+  const lines = statement.split("\n");
+  const result: ParsedStatement = {
+    mainContent: "",
+  };
+  const directiveLines = new Set<number>();
+
+  for (const [i, line] of lines.entries()) {
+    const trimmed = line.trim();
+    if (trimmed === "") {
+      continue;
+    }
+    if (!trimmed.startsWith("--")) {
+      break;
+    }
+
+    const txnModeMatch = line.match(TXN_MODE_REGEX);
+    if (txnModeMatch) {
+      result.transactionMode = txnModeMatch[1].toLowerCase() as "on" | "off";
+      directiveLines.add(i);
+      continue;
+    }
+
+    const isolationMatch = line.match(TXN_ISOLATION_REGEX);
+    if (isolationMatch) {
+      result.isolationLevel = isolationMatch[1]
+        .toUpperCase()
+        .replace(/\s+/g, "_") as IsolationLevel;
+      directiveLines.add(i);
+      continue;
+    }
+
+    const ghostMatch = line.match(GHOST_DIRECTIVE_REGEX);
+    if (ghostMatch) {
+      try {
+        result.ghostConfig = JSON.parse(ghostMatch[1]);
+      } catch {
+        // Ignore malformed ghost config in readonly issue detail.
+      }
+      directiveLines.add(i);
+      continue;
+    }
+  }
+
+  const remainingContent = lines
+    .filter((_, i) => !directiveLines.has(i))
+    .join("\n");
+  const roleSetterMatch = remainingContent.match(ROLE_SETTER_REGEX);
+
+  if (roleSetterMatch) {
+    result.roleSetterBlock = roleSetterMatch[0];
+    result.mainContent = remainingContent.replace(ROLE_SETTER_REGEX, "").trim();
+  } else {
+    result.mainContent = remainingContent.trim();
+  }
+
+  return result;
+};
+
+export const parseStatement = (statement: string) => {
+  return parseStatementInternal(statement);
+};
+
+export const getGhostConfig = (
+  statement: string
+): Record<string, string> | undefined => {
+  return parseStatementInternal(statement).ghostConfig;
+};

--- a/frontend/src/react/pages/project/issue-detail/utils/localSheet.ts
+++ b/frontend/src/react/pages/project/issue-detail/utils/localSheet.ts
@@ -1,0 +1,23 @@
+import { create } from "@bufbuild/protobuf";
+import { reactive } from "vue";
+import type { Sheet } from "@/types/proto-es/v1/sheet_service_pb";
+import { SheetSchema } from "@/types/proto-es/v1/sheet_service_pb";
+
+const localSheetsByName = reactive(new Map<string, Sheet>());
+
+export const createEmptyLocalSheet = () => {
+  return reactive(create(SheetSchema, {}));
+};
+
+export const getLocalSheetByName = (name: string): Sheet => {
+  const existing = localSheetsByName.get(name);
+  if (existing) {
+    return existing;
+  }
+  const sheet = reactive({
+    ...createEmptyLocalSheet(),
+    name,
+  });
+  localSheetsByName.set(name, sheet);
+  return sheet;
+};

--- a/frontend/src/react/pages/project/issue-detail/utils/refreshIssueDetailState.ts
+++ b/frontend/src/react/pages/project/issue-detail/utils/refreshIssueDetailState.ts
@@ -1,0 +1,81 @@
+import { create } from "@bufbuild/protobuf";
+import {
+  issueServiceClientConnect,
+  planServiceClientConnect,
+  rolloutServiceClientConnect,
+} from "@/connect";
+import { GetIssueRequestSchema } from "@/types/proto-es/v1/issue_service_pb";
+import {
+  GetPlanCheckRunRequestSchema,
+  GetPlanRequestSchema,
+  type PlanCheckRun,
+} from "@/types/proto-es/v1/plan_service_pb";
+import {
+  GetRolloutRequestSchema,
+  ListTaskRunsRequestSchema,
+} from "@/types/proto-es/v1/rollout_service_pb";
+import { getRolloutFromPlan } from "@/utils";
+import type { IssueDetailPageState } from "../hooks/useIssueDetailPage";
+
+export async function refreshIssueDetailState(
+  page: Pick<IssueDetailPageState, "issue" | "patchState" | "plan">
+) {
+  if (!page.plan?.name) {
+    return;
+  }
+
+  const nextPlan = await planServiceClientConnect.getPlan(
+    create(GetPlanRequestSchema, {
+      name: page.plan.name,
+    })
+  );
+
+  const [issueResult, planCheckRunResult, rolloutResult] = await Promise.all([
+    page.issue?.name
+      ? issueServiceClientConnect
+          .getIssue(
+            create(GetIssueRequestSchema, {
+              name: page.issue.name,
+            })
+          )
+          .catch(() => undefined)
+      : Promise.resolve(undefined),
+    planServiceClientConnect
+      .getPlanCheckRun(
+        create(GetPlanCheckRunRequestSchema, {
+          name: `${page.plan.name}/planCheckRun`,
+        })
+      )
+      .then((result) => [result] as PlanCheckRun[])
+      .catch(() => []),
+    nextPlan.hasRollout
+      ? rolloutServiceClientConnect
+          .getRollout(
+            create(GetRolloutRequestSchema, {
+              name: getRolloutFromPlan(nextPlan.name),
+            })
+          )
+          .catch(() => undefined)
+      : Promise.resolve(undefined),
+  ]);
+
+  const nextTaskRuns =
+    rolloutResult !== undefined
+      ? await rolloutServiceClientConnect
+          .listTaskRuns(
+            create(ListTaskRunsRequestSchema, {
+              parent: `${rolloutResult.name}/stages/-/tasks/-`,
+            })
+          )
+          .then((response) => response.taskRuns)
+          .catch(() => [])
+      : [];
+
+  page.patchState({
+    issue: issueResult,
+    plan: nextPlan,
+    planCheckRuns: planCheckRunResult,
+    rollout: rolloutResult,
+    taskRuns: nextTaskRuns,
+  });
+}

--- a/frontend/src/react/pages/project/issue-detail/utils/rollout.ts
+++ b/frontend/src/react/pages/project/issue-detail/utils/rollout.ts
@@ -1,0 +1,137 @@
+import { usePolicyV1Store, useProjectIamPolicyStore } from "@/store";
+import { roleNamePrefix } from "@/store/modules/v1/common";
+import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
+import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
+import { PolicyType } from "@/types/proto-es/v1/org_policy_service_pb";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import type { Task } from "@/types/proto-es/v1/rollout_service_pb";
+import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
+import type { User } from "@/types/proto-es/v1/user_service_pb";
+import {
+  hasProjectPermissionV2,
+  hasWorkspacePermissionV2,
+  memberMapToRolesInProjectIAM,
+} from "@/utils";
+
+type RolloutPolicyAccessState = "loaded" | "unavailable";
+
+const rolloutPolicyAccessStateByEnvironment = new Map<
+  string,
+  RolloutPolicyAccessState
+>();
+
+export const RUNNABLE_TASK_STATUSES: Task_Status[] = [
+  Task_Status.NOT_STARTED,
+  Task_Status.CANCELED,
+  Task_Status.FAILED,
+];
+
+export const CANCELABLE_TASK_STATUSES: Task_Status[] = [
+  Task_Status.PENDING,
+  Task_Status.RUNNING,
+];
+
+export const canRolloutTasks = ({
+  currentUser,
+  environment,
+  issue,
+  project,
+  tasks,
+}: {
+  currentUser: User;
+  environment?: string;
+  issue?: Issue;
+  project: Project;
+  tasks: Task[];
+}): boolean => {
+  if (tasks.length === 0) {
+    return false;
+  }
+
+  if (issue && issue.type === Issue_Type.DATABASE_EXPORT) {
+    return issue.creator === currentUser.name;
+  }
+
+  const hasCreatePermission =
+    hasWorkspacePermissionV2("bb.taskRuns.create") ||
+    hasProjectPermissionV2(project, "bb.taskRuns.create");
+  if (hasCreatePermission) {
+    return true;
+  }
+
+  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const policyStore = usePolicyV1Store();
+  const projectIamPolicy = projectIamPolicyStore.getProjectIamPolicy(
+    project.name
+  );
+  const memberRoles = memberMapToRolesInProjectIAM(projectIamPolicy);
+  const userRoles = memberRoles.get(currentUser.name);
+
+  return tasks.every(() => {
+    if (!environment) {
+      return false;
+    }
+
+    const rolloutPolicy = policyStore.getPolicyByParentAndType({
+      parentPath: environment,
+      policyType: PolicyType.ROLLOUT_POLICY,
+    });
+
+    if (!rolloutPolicy) {
+      return (
+        rolloutPolicyAccessStateByEnvironment.get(environment) === "unavailable"
+      );
+    }
+
+    if (
+      !rolloutPolicy.policy ||
+      rolloutPolicy.policy.case !== "rolloutPolicy"
+    ) {
+      return true;
+    }
+
+    for (const requiredRole of rolloutPolicy.policy.value.roles) {
+      if (
+        requiredRole.startsWith(roleNamePrefix) &&
+        userRoles?.has(requiredRole)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+};
+
+export const preloadRolloutPermissionContext = async ({
+  environment,
+  projectName,
+  tasks,
+}: {
+  environment?: string;
+  projectName: string;
+  tasks: Task[];
+}) => {
+  if (tasks.length === 0 || !environment) {
+    return;
+  }
+
+  const policyStore = usePolicyV1Store();
+  const projectIamPolicyStore = useProjectIamPolicyStore();
+
+  await Promise.allSettled([
+    projectIamPolicyStore.getOrFetchProjectIamPolicy(projectName),
+  ]);
+
+  const policyResults = await Promise.allSettled([
+    policyStore.getOrFetchPolicyByParentAndType({
+      parentPath: environment,
+      policyType: PolicyType.ROLLOUT_POLICY,
+    }),
+  ]);
+
+  rolloutPolicyAccessStateByEnvironment.set(
+    environment,
+    policyResults[0]?.status === "fulfilled" ? "loaded" : "unavailable"
+  );
+};

--- a/frontend/src/router/dashboard/projectV1.ts
+++ b/frontend/src/router/dashboard/projectV1.ts
@@ -79,20 +79,16 @@ const planRoutes: RouteRecordRaw[] = [
 // Issue routes — uses IssueLayout (issue-only)
 const issueRoutes: RouteRecordRaw[] = [
   {
-    path: "",
-    component: () => import("@/views/project/IssueLayout.vue"),
-    props: true,
-    children: [
-      {
-        path: "issues/:issueId(\\d+)",
-        name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
-        meta: {
-          requiredPermissionList: () => ["bb.issues.get"],
-        },
-        component: () => import("@/views/project/IssueDetailV1View.vue"),
-        props: true,
-      },
-    ],
+    path: "issues/:issueId(\\d+)",
+    name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
+    meta: {
+      requiredPermissionList: () => ["bb.issues.get"],
+    },
+    component: () => import("@/react/ReactPageMount.vue"),
+    props: (route: RouteLocationNormalized) => ({
+      page: "ProjectIssueDetailPage",
+      ...route.params,
+    }),
   },
 ];
 


### PR DESCRIPTION
## Summary
- Replace the project issue detail route with a React implementation
- Preserve the existing issue-detail workflows across database change, create, export, role grant, and access grant issues
- Bring Monaco-based statement editing and issue review interactions into the React page

## Key Changes
- Add a React issue detail page shell with header, activity feed, sidebar, and issue-type specific content blocks
- Implement React versions of issue actions, approval flow, labels, comments, checks, rollout task actions, and task run tables
- Migrate statement handling to React Monaco, including readonly/edit flows and issue-detail-specific editor behavior
- Update route wiring so the issue detail route mounts the new React page
- Align shared UI details needed by the migrated page, including button sizing and React locale entries

## Motivation
- Complete the Vue-to-React migration for the project issue detail experience
- Remove reliance on legacy issue-detail rendering paths while keeping behavior and layout close to the existing UI
- Consolidate issue-detail interactions on the React stack so follow-up work can build on one implementation

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`