### PR TITLE
fix(frontend): replace raw radio inputs with Base UI RadioGroup in sync schema page

### DIFF
--- a/frontend/src/react/components/ui/radio-group.tsx
+++ b/frontend/src/react/components/ui/radio-group.tsx
@@ -1,0 +1,42 @@
+import { Radio } from "@base-ui/react/radio";
+import { RadioGroup as BaseRadioGroup } from "@base-ui/react/radio-group";
+import { cn } from "@/react/lib/utils";
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof BaseRadioGroup>) {
+  return (
+    <BaseRadioGroup
+      className={cn("flex items-center gap-x-6", className)}
+      {...props}
+    />
+  );
+}
+
+function RadioGroupItem({
+  children,
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof Radio.Root> & { children?: React.ReactNode }) {
+  return (
+    <label
+      className={cn("flex items-center gap-x-2 cursor-pointer", className)}
+    >
+      <Radio.Root
+        value={value}
+        className={cn(
+          "flex size-4 items-center justify-center rounded-full border border-control-border",
+          "data-[checked]:border-accent data-[checked]:border-[5px]",
+          "focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
+          "disabled:cursor-not-allowed disabled:opacity-50"
+        )}
+        {...props}
+      />
+      {children && <span className="text-sm">{children}</span>}
+    </label>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
@@ -30,6 +30,7 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/react/components/ui/dialog";
+import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
 import { SearchInput } from "@/react/components/ui/search-input";
 import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { useEscapeKey } from "@/react/hooks/useEscapeKey";
@@ -583,38 +584,21 @@ function SourceSchemaStep({
   return (
     <>
       <div className="mb-4">
-        <div className="flex items-center gap-x-6">
-          <label className="flex items-center gap-x-2 cursor-pointer">
-            <input
-              type="radio"
-              name="source-schema-type"
-              checked={
-                sourceSchemaType === SourceSchemaType.SCHEMA_HISTORY_VERSION
-              }
-              onChange={() =>
-                onSourceSchemaTypeChange(
-                  SourceSchemaType.SCHEMA_HISTORY_VERSION
-                )
-              }
-              className="accent-accent"
-            />
-            <span className="text-sm">{t("common.changelog")}</span>
-          </label>
-          <label className="flex items-center gap-x-2 cursor-pointer">
-            <input
-              type="radio"
-              name="source-schema-type"
-              checked={sourceSchemaType === SourceSchemaType.RAW_SQL}
-              onChange={() =>
-                onSourceSchemaTypeChange(SourceSchemaType.RAW_SQL)
-              }
-              className="accent-accent"
-            />
-            <span className="text-sm">
-              {t("database.sync-schema.copy-schema")}
-            </span>
-          </label>
-        </div>
+        <RadioGroup
+          value={String(sourceSchemaType)}
+          onValueChange={(value) =>
+            onSourceSchemaTypeChange(Number(value) as SourceSchemaType)
+          }
+        >
+          <RadioGroupItem
+            value={String(SourceSchemaType.SCHEMA_HISTORY_VERSION)}
+          >
+            {t("common.changelog")}
+          </RadioGroupItem>
+          <RadioGroupItem value={String(SourceSchemaType.RAW_SQL)}>
+            {t("database.sync-schema.copy-schema")}
+          </RadioGroupItem>
+        </RadioGroup>
       </div>
       {sourceSchemaType === SourceSchemaType.SCHEMA_HISTORY_VERSION && (
         <DatabaseSchemaSelector


### PR DESCRIPTION
## Summary
- Add a reusable `RadioGroup` / `RadioGroupItem` UI component wrapping Base UI's `Radio` primitive, styled with semantic tokens and following the same shadcn pattern as `Switch` and other UI components
- Replace raw `<input type="radio">` elements in the sync schema page with the new component, fixing inconsistent radio button styling (BYT-9184)

## Test plan
- [ ] Navigate to a project's Sync Schema page
- [ ] Verify the Changelog / Copy schema radio buttons render with proper styled circular indicators
- [ ] Verify selecting each radio option still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)