### PR TITLE
fix(frontend): wrap long inline markdown code

### DIFF
--- a/frontend/src/assets/css/github-markdown-style.css
+++ b/frontend/src/assets/css/github-markdown-style.css
@@ -823,6 +823,8 @@
   padding: 0.2em 0.4em;
   margin: 0;
   font-size: 85%;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   background-color: rgba(175, 184, 193, 0.2);
   border-radius: 6px;
 }
@@ -843,6 +845,7 @@
 .markdown-body pre > code {
   padding: 0;
   margin: 0;
+  overflow-wrap: normal;
   word-break: normal;
   white-space: pre;
   background: transparent;

--- a/frontend/src/react/plugins/agent/components/AgentChat.test.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentChat.test.tsx
@@ -1,0 +1,121 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createAgentStore, useAgentStore } from "../store/agent";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  useTranslation: vi.fn(() => ({
+    t: (key: string) => key,
+  })),
+  hasWorkspacePermissionV2: vi.fn(() => true),
+}));
+
+let AgentChat: typeof import("./AgentChat").AgentChat;
+
+function createMockStorage(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    key(index: number) {
+      return Object.keys(store)[index] ?? null;
+    },
+    getItem(key: string) {
+      return store[key] ?? null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = String(value);
+    },
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    },
+  };
+}
+
+vi.mock("react-i18next", () => ({
+  useTranslation: mocks.useTranslation,
+}));
+
+vi.mock("@/router", () => ({
+  router: {
+    push: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils", () => ({
+  hasWorkspacePermissionV2: mocks.hasWorkspacePermissionV2,
+}));
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  return {
+    container,
+    render: () => {
+      act(() => {
+        root.render(element);
+      });
+    },
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
+};
+
+beforeEach(async () => {
+  vi.stubGlobal("localStorage", createMockStorage());
+  const initialState = createAgentStore().getState();
+  useAgentStore.setState({
+    visible: initialState.visible,
+    position: initialState.position,
+    size: initialState.size,
+    sidebarWidth: initialState.sidebarWidth,
+    minimized: initialState.minimized,
+    chats: initialState.chats,
+    messagesByChatId: initialState.messagesByChatId,
+    pendingAskByChatId: initialState.pendingAskByChatId,
+    currentChatId: initialState.currentChatId,
+    abortControllersByChatId: {},
+  });
+
+  mocks.useTranslation.mockReset();
+  mocks.useTranslation.mockReturnValue({
+    t: (key: string) => key,
+  });
+  mocks.hasWorkspacePermissionV2.mockReset();
+  mocks.hasWorkspacePermissionV2.mockReturnValue(true);
+
+  ({ AgentChat } = await import("./AgentChat"));
+});
+
+describe("AgentChat", () => {
+  test("renders inline code with wrap-safe styling", () => {
+    useAgentStore.getState().addMessage({
+      role: "assistant",
+      content:
+        "Result: `354b7196c9ba5fb4b21cf615bb6ec4cd5c3c0c26c8f296b0f42b0f8a1d4e9abc`",
+    });
+
+    const { container, render, unmount } = renderIntoContainer(<AgentChat />);
+
+    render();
+
+    const code = container.querySelector("code");
+    expect(code).toBeInstanceOf(HTMLElement);
+    expect(code?.textContent).toContain("354b7196");
+    expect(code?.className).toContain("break-all");
+
+    unmount();
+  });
+});

--- a/frontend/src/react/plugins/agent/components/AgentChat.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentChat.tsx
@@ -117,7 +117,7 @@ export function AgentChat({ className }: AgentChatProps) {
                       </pre>
                     ),
                     code: ({ children }) => (
-                      <code className="rounded bg-control-bg-hover px-1 text-xs">
+                      <code className="break-all rounded bg-control-bg-hover px-1 text-xs">
                         {children}
                       </code>
                     ),


### PR DESCRIPTION
## Summary
- wrap long inline markdown code in the page agent chat bubble
- allow shared markdown inline code to wrap without changing fenced code block behavior
- add a regression test for long inline code rendering in `AgentChat`

## Test Plan
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend test`
- [x] `pnpm --dir frontend test src/react/plugins/agent/components/AgentChat.test.tsx`