### PR TITLE
fix(frontend): use useLayoutEffect for combobox portal positioning

### DIFF
--- a/frontend/src/react/components/ui/combobox.tsx
+++ b/frontend/src/react/components/ui/combobox.tsx
@@ -1,5 +1,12 @@
 import { Check, ChevronDown, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/react/lib/utils";
 import { SearchInput } from "./search-input";
@@ -103,8 +110,9 @@ export function Combobox(props: ComboboxProps) {
     [allOptions, selectedValues]
   );
 
-  // Position dropdown for portal mode
-  useEffect(() => {
+  // Position dropdown for portal mode — useLayoutEffect prevents a
+  // one-frame flash at a stale/empty position before the browser paints.
+  useLayoutEffect(() => {
     if (!open || !portal || !containerRef.current) return;
     const rect = containerRef.current.getBoundingClientRect();
     setDropdownStyle({


### PR DESCRIPTION
## Summary
- Fix role dropdown not attaching to its trigger field when adding a user (BYT-9225)
- The `Combobox` portal dropdown used `useEffect` to calculate its fixed position, which runs **after** the browser paints — causing a one-frame flash where the dropdown appears at a stale/empty position before jumping to the correct location
- Switching to `useLayoutEffect` ensures positioning is calculated synchronously before the browser paints, eliminating the visual flash

## Test plan
- [ ] Open Users page → Create → click the Roles dropdown: dropdown appears immediately attached to the field
- [ ] Open Members page → Grant Access → click the Select roles dropdown: same behavior
- [ ] Open a project Members page → Grant Access → click Assign role: same behavior
- [ ] Scroll the sheet body, then open the dropdown: dropdown correctly positions below the trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)