### PR TITLE
fix(frontend): use viewport-based agent window defaults

### DIFF
--- a/frontend/src/react/plugins/agent/components/AgentWindow.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentWindow.tsx
@@ -20,6 +20,13 @@ import {
   selectOrderedChats,
   useAgentStore,
 } from "../store/agent";
+import {
+  MIN_HEIGHT,
+  MIN_MAIN_PANEL_WIDTH,
+  MIN_SIDEBAR_WIDTH,
+  MIN_WIDTH,
+  WINDOW_MARGIN,
+} from "../window";
 import { AgentChat } from "./AgentChat";
 import { AgentInput } from "./AgentInput";
 import {
@@ -32,19 +39,6 @@ import {
   resizeWindowBounds,
 } from "./window-resize";
 
-const MIN_SIDEBAR_WIDTH = 180;
-const MIN_MAIN_PANEL_WIDTH = 240;
-// Budget for the sidebar resize handle, borders, and a small breathing
-// room so the main panel actually reaches its minimum width without the
-// input row collapsing.
-const WINDOW_CHROME_BUDGET = 40;
-// Keep the total window wide enough so both the sidebar and the main panel
-// can render at their minimums side by side; otherwise the input row gets
-// squeezed and the placeholder wraps onto multiple lines.
-const MIN_WIDTH =
-  MIN_SIDEBAR_WIDTH + MIN_MAIN_PANEL_WIDTH + WINDOW_CHROME_BUDGET;
-const MIN_HEIGHT = 400;
-const WINDOW_MARGIN = 16;
 const resizeZoneClasses: Record<ResizeDirection, string> = {
   n: "left-[12px] top-[-6px] h-[6px] w-[calc(100%-24px)] cursor-n-resize",
   s: "bottom-[-6px] left-[12px] h-[6px] w-[calc(100%-24px)] cursor-s-resize",

--- a/frontend/src/react/plugins/agent/store/agent.test.ts
+++ b/frontend/src/react/plugins/agent/store/agent.test.ts
@@ -33,11 +33,25 @@ function createMockStorage(): Storage {
   };
 }
 
+function setViewportSize(width: number, height: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: width,
+  });
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: height,
+  });
+}
+
 let mockStorage: Storage;
 
 beforeEach(() => {
   mockStorage = createMockStorage();
   vi.stubGlobal("localStorage", mockStorage);
+  setViewportSize(1280, 800);
 });
 
 afterEach(() => {
@@ -54,6 +68,25 @@ describe("useAgentStore (Zustand)", () => {
     expect(s(store).currentChatId).toBe(s(store).chats[0].id);
     expect(s(store).getMessages(s(store).currentChatId)).toEqual([]);
     expect(s(store).chats[0].totalTokensUsed).toBe(0);
+  });
+
+  test("uses viewport-relative medium window defaults when no saved window state exists", () => {
+    setViewportSize(1440, 900);
+
+    const store = createAgentStore();
+
+    expect(s(store).size).toEqual({ width: 788, height: 625 });
+    expect(s(store).position).toEqual({ x: 326, y: 138 });
+    expect(s(store).sidebarWidth).toBe(200);
+  });
+
+  test("keeps the default window inside narrow viewports", () => {
+    setViewportSize(430, 450);
+
+    const store = createAgentStore();
+
+    expect(s(store).size).toEqual({ width: 398, height: 400 });
+    expect(s(store).position).toEqual({ x: 16, y: 25 });
   });
 
   test("loads persisted window state", () => {
@@ -77,6 +110,20 @@ describe("useAgentStore (Zustand)", () => {
       '"sidebarWidth":280'
     );
     expect(localStorage.getItem(AGENT_STATE_KEY)).not.toBeNull();
+  });
+
+  test("centers the window when opening the agent", () => {
+    setViewportSize(1440, 900);
+    const store = createAgentStore();
+
+    s(store).setSize(788, 625);
+    s(store).setPosition(700, 500);
+
+    s(store).toggle();
+
+    expect(s(store).visible).toBe(true);
+    expect(s(store).position).toEqual({ x: 326, y: 138 });
+    expect(s(store).size).toEqual({ width: 788, height: 625 });
   });
 
   test("normalizes stale running chats on load", () => {

--- a/frontend/src/react/plugins/agent/store/agent.test.ts
+++ b/frontend/src/react/plugins/agent/store/agent.test.ts
@@ -126,6 +126,19 @@ describe("useAgentStore (Zustand)", () => {
     expect(s(store).size).toEqual({ width: 788, height: 625 });
   });
 
+  test("centers reopening using the rendered minimum size on wider viewports", () => {
+    setViewportSize(1440, 900);
+    const store = createAgentStore();
+
+    s(store).setSize(398, 388);
+    s(store).setPosition(700, 500);
+
+    s(store).toggle();
+
+    expect(s(store).visible).toBe(true);
+    expect(s(store).position).toEqual({ x: 490, y: 250 });
+  });
+
   test("normalizes stale running chats on load", () => {
     localStorage.setItem(
       AGENT_STATE_KEY,

--- a/frontend/src/react/plugins/agent/store/agent.ts
+++ b/frontend/src/react/plugins/agent/store/agent.ts
@@ -11,6 +11,10 @@ import type {
   Message,
   ToolCall,
 } from "../logic/types";
+import {
+  getCenteredAgentWindowPosition,
+  getDefaultAgentWindowState,
+} from "../window";
 
 export const AGENT_STATE_KEY = "bb-agent-state-v2";
 export const AGENT_WINDOW_KEY = "bb-agent-window";
@@ -496,6 +500,18 @@ const getSafeStorage = (): Storage | null => {
   return storage as Storage;
 };
 
+const getInitialWindowState = () => {
+  if (typeof window === "undefined") {
+    return {
+      position: { x: 0, y: 0 },
+      size: { width: 480, height: 540 },
+      sidebarWidth: 200,
+    };
+  }
+
+  return getDefaultAgentWindowState(window.innerWidth, window.innerHeight);
+};
+
 const loadInitialState = (): {
   chats: AgentChat[];
   messagesByChatId: Record<string, AgentMessage[]>;
@@ -540,6 +556,7 @@ const loadInitialState = (): {
 
 export const createAgentStore = () => {
   const initial = loadInitialState();
+  const initialWindowState = getInitialWindowState();
 
   const store = create<AgentState>()(
     immer((set, get) => {
@@ -565,12 +582,9 @@ export const createAgentStore = () => {
       return {
         // Window state
         visible: false,
-        position: {
-          x: typeof window !== "undefined" ? window.innerWidth - 500 : 0,
-          y: typeof window !== "undefined" ? window.innerHeight - 560 : 0,
-        },
-        size: { width: 480, height: 540 },
-        sidebarWidth: 200,
+        position: initialWindowState.position,
+        size: initialWindowState.size,
+        sidebarWidth: initialWindowState.sidebarWidth,
         minimized: false,
 
         // Chat state (from persisted/initial)
@@ -586,6 +600,14 @@ export const createAgentStore = () => {
             state.visible = !state.visible;
             if (state.visible) {
               state.minimized = false;
+              if (typeof window !== "undefined") {
+                state.position = getCenteredAgentWindowPosition(
+                  window.innerWidth,
+                  window.innerHeight,
+                  state.size.width,
+                  state.size.height
+                );
+              }
             }
           }),
         minimize: () =>

--- a/frontend/src/react/plugins/agent/window.ts
+++ b/frontend/src/react/plugins/agent/window.ts
@@ -1,0 +1,81 @@
+export const MIN_SIDEBAR_WIDTH = 180;
+export const MIN_MAIN_PANEL_WIDTH = 240;
+export const WINDOW_CHROME_BUDGET = 40;
+export const MIN_WIDTH =
+  MIN_SIDEBAR_WIDTH + MIN_MAIN_PANEL_WIDTH + WINDOW_CHROME_BUDGET;
+export const MIN_HEIGHT = 400;
+export const WINDOW_MARGIN = 16;
+export const DEFAULT_SIDEBAR_WIDTH = 200;
+
+const DEFAULT_WIDTH_RATIO = 0.56;
+const DEFAULT_HEIGHT_RATIO = 0.72;
+const MAX_DEFAULT_WIDTH = 960;
+const MAX_DEFAULT_HEIGHT = 820;
+
+const clampDefaultDimension = (
+  preferred: number,
+  preferredMin: number,
+  viewportMax: number,
+  preferredMax: number
+) => {
+  const max = Math.max(1, viewportMax - WINDOW_MARGIN * 2);
+  const min = Math.min(preferredMin, max);
+  return Math.min(
+    Math.min(preferredMax, max),
+    Math.max(min, Math.round(preferred))
+  );
+};
+
+const clampDisplayDimension = (size: number, viewportSize: number) => {
+  const max = Math.max(1, viewportSize - WINDOW_MARGIN * 2);
+  return Math.min(max, Math.max(1, Math.round(size)));
+};
+
+export const getCenteredAgentWindowPosition = (
+  viewportWidth: number,
+  viewportHeight: number,
+  windowWidth: number,
+  windowHeight: number
+) => {
+  const width = clampDisplayDimension(windowWidth, viewportWidth);
+  const height = clampDisplayDimension(windowHeight, viewportHeight);
+
+  return {
+    x: Math.max(WINDOW_MARGIN, Math.round((viewportWidth - width) / 2)),
+    y: Math.max(WINDOW_MARGIN, Math.round((viewportHeight - height) / 2)),
+  };
+};
+
+export const getDefaultAgentWindowState = (
+  viewportWidth: number,
+  viewportHeight: number
+) => {
+  const availableWidth = Math.max(1, viewportWidth - WINDOW_MARGIN * 2);
+  const availableHeight = Math.max(1, viewportHeight - WINDOW_MARGIN * 2);
+  const width = clampDefaultDimension(
+    availableWidth * DEFAULT_WIDTH_RATIO,
+    MIN_WIDTH,
+    viewportWidth,
+    MAX_DEFAULT_WIDTH
+  );
+  const height = clampDefaultDimension(
+    availableHeight * DEFAULT_HEIGHT_RATIO,
+    MIN_HEIGHT,
+    viewportHeight,
+    MAX_DEFAULT_HEIGHT
+  );
+
+  return {
+    position: getCenteredAgentWindowPosition(
+      viewportWidth,
+      viewportHeight,
+      width,
+      height
+    ),
+    size: {
+      width,
+      height,
+    },
+    sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
+  };
+};

--- a/frontend/src/react/plugins/agent/window.ts
+++ b/frontend/src/react/plugins/agent/window.ts
@@ -26,9 +26,14 @@ const clampDefaultDimension = (
   );
 };
 
-const clampDisplayDimension = (size: number, viewportSize: number) => {
+const clampDisplayDimension = (
+  size: number,
+  viewportSize: number,
+  preferredMin: number
+) => {
   const max = Math.max(1, viewportSize - WINDOW_MARGIN * 2);
-  return Math.min(max, Math.max(1, Math.round(size)));
+  const min = Math.min(preferredMin, max);
+  return Math.min(max, Math.max(min, Math.round(size)));
 };
 
 export const getCenteredAgentWindowPosition = (
@@ -37,8 +42,12 @@ export const getCenteredAgentWindowPosition = (
   windowWidth: number,
   windowHeight: number
 ) => {
-  const width = clampDisplayDimension(windowWidth, viewportWidth);
-  const height = clampDisplayDimension(windowHeight, viewportHeight);
+  const width = clampDisplayDimension(windowWidth, viewportWidth, MIN_WIDTH);
+  const height = clampDisplayDimension(
+    windowHeight,
+    viewportHeight,
+    MIN_HEIGHT
+  );
 
   return {
     x: Math.max(WINDOW_MARGIN, Math.round((viewportWidth - width) / 2)),


### PR DESCRIPTION
## Summary
- size the page agent window from the current viewport instead of a small fixed default
- center the agent window when it opens while preserving the current window size
- cover default sizing and open-position behavior with agent store tests

## Test Plan
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test