### PR TITLE
fix(frontend): restore request role availability on project members

### DIFF
--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -1335,6 +1335,11 @@
       "edit-member": "Edit member - {{member}}",
       "never-expires": "Never",
       "request-role": {
+        "disabled-reason": {
+          "allow-request-role-disabled": "Allow request role is disabled for this project.",
+          "can-grant-access-directly": "You already have {{permission}}, so you can grant access directly.",
+          "feature-unavailable": "Request role workflow is unavailable on the current plan."
+        },
         "expiration-exceeds-max": "Expiration cannot exceed the workspace limit of {{days}} day(s).",
         "expiration-must-be-future": "Expiration must be in the future.",
         "failed-to-build-expression": "Failed to build CEL expression. Please try again.",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -1335,6 +1335,11 @@
       "edit-member": "Editar miembro - {{member}}",
       "never-expires": "Never",
       "request-role": {
+        "disabled-reason": {
+          "allow-request-role-disabled": "La solicitud de roles está deshabilitada para este proyecto.",
+          "can-grant-access-directly": "Ya tienes {{permission}}, así que puedes conceder acceso directamente.",
+          "feature-unavailable": "El flujo de solicitud de roles no está disponible en el plan actual."
+        },
         "expiration-exceeds-max": "La expiración no puede exceder el límite del espacio de trabajo de {{days}} día(s).",
         "expiration-must-be-future": "La expiración debe ser una fecha futura.",
         "failed-to-build-expression": "Error al construir la expresión CEL. Inténtalo de nuevo.",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -1335,6 +1335,11 @@
       "edit-member": "メンバー編集 - {{member}}",
       "never-expires": "Never",
       "request-role": {
+        "disabled-reason": {
+          "allow-request-role-disabled": "このプロジェクトではロール申請が無効になっています。",
+          "can-grant-access-directly": "すでに {{permission}} を持っているため、直接アクセスを付与できます。",
+          "feature-unavailable": "現在のプランではロール申請ワークフローを利用できません。"
+        },
         "expiration-exceeds-max": "有効期限はワークスペースの上限 {{days}} 日を超えることはできません。",
         "expiration-must-be-future": "有効期限は将来の時刻を指定してください。",
         "failed-to-build-expression": "CEL 式の構築に失敗しました。もう一度お試しください。",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -1335,6 +1335,11 @@
       "edit-member": "Chỉnh sửa thành viên - {{member}}",
       "never-expires": "Never",
       "request-role": {
+        "disabled-reason": {
+          "allow-request-role-disabled": "Dự án này đã tắt tính năng yêu cầu vai trò.",
+          "can-grant-access-directly": "Bạn đã có {{permission}}, nên có thể cấp quyền truy cập trực tiếp.",
+          "feature-unavailable": "Quy trình yêu cầu vai trò không khả dụng trong gói hiện tại."
+        },
         "expiration-exceeds-max": "Thời gian hết hạn không được vượt quá giới hạn {{days}} ngày của không gian làm việc.",
         "expiration-must-be-future": "Thời gian hết hạn phải ở tương lai.",
         "failed-to-build-expression": "Không thể xây dựng biểu thức CEL. Vui lòng thử lại.",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -1335,6 +1335,11 @@
       "edit-member": "编辑成员 - {{member}}",
       "never-expires": "Never",
       "request-role": {
+        "disabled-reason": {
+          "allow-request-role-disabled": "此项目未启用申请角色。",
+          "can-grant-access-directly": "您已拥有 {{permission}}，可以直接授予访问权限。",
+          "feature-unavailable": "当前套餐不支持申请角色工作流。"
+        },
         "expiration-exceeds-max": "过期时间不能超过工作空间上限 {{days}} 天。",
         "expiration-must-be-future": "过期时间必须是将来的时间。",
         "failed-to-build-expression": "构建 CEL 表达式失败，请重试。",

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -72,6 +72,7 @@ import {
   TabsTrigger,
 } from "@/react/components/ui/tabs";
 import { Textarea } from "@/react/components/ui/textarea";
+import { Tooltip } from "@/react/components/ui/tooltip";
 import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { useEscapeKey } from "@/react/hooks/useEscapeKey";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -132,8 +133,17 @@ import {
   convertFromExpr,
   stringifyConditionExpression,
 } from "@/utils/issue/cel";
+import { getSetIamPolicyPermissionGuardConfig } from "./membersPageActions";
+import {
+  getRequestRoleButtonState,
+  REQUEST_ROLE_REQUIRED_PERMISSIONS,
+} from "./requestRoleButton";
 
 const EMPTY_ROLE_SET = new Set<string>();
+
+const assertNever = (value: never): never => {
+  throw new Error(`Unexpected value: ${String(value)}`);
+};
 
 // ============================================================
 // MemberTable (view by members)
@@ -2268,19 +2278,49 @@ export function MembersPage({ projectId }: { projectId?: string }) {
 
   const scope = projectName ? "project" : "workspace";
 
-  // A project member without `bb.projects.setIamPolicy` cannot grant access
-  // to themselves, so they need to request it instead. The old Vue
-  // ProjectMemberPanel showed a "Request Role" button in this case; we
-  // restore the same behavior here.
-  const canRequestRole = useMemo(() => {
-    if (!project || !projectName) return false;
-    if (!project.allowRequestRole) return false;
-    if (canSetIamPolicy) return false;
-    return (
-      hasProjectPermissionV2(project, "bb.issues.create") &&
-      hasProjectPermissionV2(project, "bb.roles.list")
-    );
-  }, [project, projectName, canSetIamPolicy]);
+  const requestRoleButtonState = useMemo(
+    () =>
+      getRequestRoleButtonState({
+        projectName,
+        projectReady: !!project,
+        allowRequestRole: project?.allowRequestRole ?? false,
+        canSetIamPolicy,
+        hasRequestRoleFeature,
+      }),
+    [projectName, project, canSetIamPolicy, hasRequestRoleFeature]
+  );
+
+  const requestRoleDisabledReason = useMemo(() => {
+    const reason = requestRoleButtonState.disabledReason;
+    if (!reason) return undefined;
+
+    switch (reason.kind) {
+      case "loading":
+        return t("common.loading");
+      case "allow-request-role-disabled":
+        return t(
+          "project.members.request-role.disabled-reason.allow-request-role-disabled"
+        );
+      case "can-grant-access-directly":
+        return t(
+          "project.members.request-role.disabled-reason.can-grant-access-directly",
+          {
+            permission: reason.permission,
+          }
+        );
+      case "feature-unavailable":
+        return t(
+          "project.members.request-role.disabled-reason.feature-unavailable"
+        );
+      default:
+        return assertNever(reason);
+    }
+  }, [requestRoleButtonState.disabledReason, t]);
+
+  const setIamPolicyPermissionGuard = useMemo(
+    () => getSetIamPolicyPermissionGuardConfig(project),
+    [project]
+  );
 
   return (
     <div className="w-full px-4 overflow-x-hidden flex flex-col pt-2 pb-4">
@@ -2317,46 +2357,72 @@ export function MembersPage({ projectId }: { projectId?: string }) {
           onChange={(e) => setMemberSearchText(e.target.value)}
         />
         <div className="flex items-center gap-x-2">
-          <PermissionGuard permissions={["bb.workspaces.setIamPolicy"]}>
-            <div className="flex items-center gap-x-2">
-              {memberViewTab === "MEMBERS" && (
+          <PermissionGuard {...setIamPolicyPermissionGuard}>
+            {({ disabled }) => (
+              <div className="flex items-center gap-x-2">
+                {memberViewTab === "MEMBERS" && (
+                  <Button
+                    variant="outline"
+                    disabled={
+                      disabled ||
+                      !canSetIamPolicy ||
+                      selectedMembers.length === 0
+                    }
+                    onClick={handleRevokeSelected}
+                  >
+                    {t("settings.members.revoke-access")}
+                  </Button>
+                )}
                 <Button
-                  variant="outline"
-                  disabled={!canSetIamPolicy || selectedMembers.length === 0}
-                  onClick={handleRevokeSelected}
+                  disabled={disabled || !canSetIamPolicy}
+                  onClick={() => {
+                    setEditingMember(undefined);
+                    setShowEditMemberDrawer(true);
+                  }}
                 >
-                  {t("settings.members.revoke-access")}
+                  <Plus className="h-4 w-4 mr-1" />
+                  {t("settings.members.grant-access")}
                 </Button>
-              )}
-              <Button
-                disabled={!canSetIamPolicy}
-                onClick={() => {
-                  setEditingMember(undefined);
-                  setShowEditMemberDrawer(true);
-                }}
-              >
-                <Plus className="h-4 w-4 mr-1" />
-                {t("settings.members.grant-access")}
-              </Button>
-            </div>
+              </div>
+            )}
           </PermissionGuard>
-          {canRequestRole && (
-            <Button
-              disabled={!hasRequestRoleFeature}
-              onClick={() => setShowRequestRoleDialog(true)}
-            >
-              {hasRequestRoleFeature ? (
-                <ShieldUser className="size-4 mr-1" />
-              ) : (
-                <FeatureBadge
-                  feature={PlanFeature.FEATURE_REQUEST_ROLE_WORKFLOW}
-                  clickable={false}
-                  className="mr-1"
-                />
-              )}
-              {t("issue.title.request-role")}
-            </Button>
-          )}
+          {requestRoleButtonState.visible &&
+            (requestRoleDisabledReason ? (
+              <Tooltip content={requestRoleDisabledReason}>
+                <span className="inline-flex">
+                  <Button
+                    disabled
+                    onClick={() => setShowRequestRoleDialog(true)}
+                  >
+                    {hasRequestRoleFeature ? (
+                      <ShieldUser className="size-4 mr-1" />
+                    ) : (
+                      <FeatureBadge
+                        feature={PlanFeature.FEATURE_REQUEST_ROLE_WORKFLOW}
+                        clickable={false}
+                        className="mr-1"
+                      />
+                    )}
+                    {t("issue.title.request-role")}
+                  </Button>
+                </span>
+              </Tooltip>
+            ) : (
+              <PermissionGuard
+                permissions={[...REQUEST_ROLE_REQUIRED_PERMISSIONS]}
+                project={project}
+              >
+                {({ disabled }) => (
+                  <Button
+                    disabled={disabled}
+                    onClick={() => setShowRequestRoleDialog(true)}
+                  >
+                    <ShieldUser className="size-4 mr-1" />
+                    {t("issue.title.request-role")}
+                  </Button>
+                )}
+              </PermissionGuard>
+            ))}
         </div>
       </div>
 

--- a/frontend/src/react/pages/settings/membersPageActions.test.ts
+++ b/frontend/src/react/pages/settings/membersPageActions.test.ts
@@ -1,0 +1,24 @@
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, test } from "vitest";
+import { ProjectSchema } from "@/types/proto-es/v1/project_service_pb";
+import { getSetIamPolicyPermissionGuardConfig } from "./membersPageActions";
+
+describe("getSetIamPolicyPermissionGuardConfig", () => {
+  test("uses workspace IAM permission in workspace scope", () => {
+    expect(getSetIamPolicyPermissionGuardConfig()).toEqual({
+      permissions: ["bb.workspaces.setIamPolicy"],
+    });
+  });
+
+  test("uses project IAM permission in project scope", () => {
+    const project = create(ProjectSchema, {
+      name: "projects/demo",
+      title: "Demo",
+    });
+
+    expect(getSetIamPolicyPermissionGuardConfig(project)).toEqual({
+      permissions: ["bb.projects.setIamPolicy"],
+      project,
+    });
+  });
+});

--- a/frontend/src/react/pages/settings/membersPageActions.ts
+++ b/frontend/src/react/pages/settings/membersPageActions.ts
@@ -1,0 +1,22 @@
+import type { Permission } from "@/types";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+
+interface PermissionGuardConfig {
+  readonly permissions: Permission[];
+  readonly project?: Project;
+}
+
+export const getSetIamPolicyPermissionGuardConfig = (
+  project?: Project
+): PermissionGuardConfig => {
+  if (project) {
+    return {
+      permissions: ["bb.projects.setIamPolicy"],
+      project,
+    };
+  }
+
+  return {
+    permissions: ["bb.workspaces.setIamPolicy"],
+  };
+};

--- a/frontend/src/react/pages/settings/requestRoleButton.test.ts
+++ b/frontend/src/react/pages/settings/requestRoleButton.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { getRequestRoleButtonState } from "./requestRoleButton";
+
+describe("getRequestRoleButtonState", () => {
+  const base = {
+    projectName: "projects/demo",
+    projectReady: true,
+    allowRequestRole: true,
+    canSetIamPolicy: false,
+    hasRequestRoleFeature: true,
+  } as const;
+
+  test("hides the button outside project scope", () => {
+    expect(
+      getRequestRoleButtonState({
+        ...base,
+        projectName: undefined,
+      })
+    ).toEqual({
+      visible: false,
+    });
+  });
+
+  test("shows a loading-disabled button while project state is unavailable", () => {
+    expect(
+      getRequestRoleButtonState({
+        ...base,
+        projectReady: false,
+      })
+    ).toEqual({
+      visible: true,
+      disabledReason: {
+        kind: "loading",
+      },
+    });
+  });
+
+  test("shows a disabled button when request role is turned off for the project", () => {
+    expect(
+      getRequestRoleButtonState({
+        ...base,
+        allowRequestRole: false,
+      })
+    ).toEqual({
+      visible: true,
+      disabledReason: {
+        kind: "allow-request-role-disabled",
+      },
+    });
+  });
+
+  test("shows a disabled button when the user can grant access directly", () => {
+    expect(
+      getRequestRoleButtonState({
+        ...base,
+        canSetIamPolicy: true,
+      })
+    ).toEqual({
+      visible: true,
+      disabledReason: {
+        kind: "can-grant-access-directly",
+        permission: "bb.projects.setIamPolicy",
+      },
+    });
+  });
+
+  test("leaves permission-related disabling to the permission guard", () => {
+    expect(
+      getRequestRoleButtonState({
+        ...base,
+      })
+    ).toEqual({
+      visible: true,
+    });
+  });
+
+  test("shows a disabled button when the workflow feature is unavailable", () => {
+    expect(
+      getRequestRoleButtonState({
+        ...base,
+        hasRequestRoleFeature: false,
+      })
+    ).toEqual({
+      visible: true,
+      disabledReason: {
+        kind: "feature-unavailable",
+      },
+    });
+  });
+
+  test("enables the button when every prerequisite is satisfied", () => {
+    expect(getRequestRoleButtonState(base)).toEqual({
+      visible: true,
+    });
+  });
+});

--- a/frontend/src/react/pages/settings/requestRoleButton.ts
+++ b/frontend/src/react/pages/settings/requestRoleButton.ts
@@ -1,0 +1,89 @@
+import type { Permission } from "@/types";
+
+export const REQUEST_ROLE_REQUIRED_PERMISSIONS = [
+  "bb.issues.create",
+  "bb.roles.list",
+] as const satisfies readonly Permission[];
+
+export type RequestRoleButtonDisabledReason =
+  | {
+      kind: "loading";
+    }
+  | {
+      kind: "allow-request-role-disabled";
+    }
+  | {
+      kind: "can-grant-access-directly";
+      permission: Permission;
+    }
+  | {
+      kind: "feature-unavailable";
+    };
+
+interface RequestRoleButtonStateArgs {
+  readonly projectName?: string;
+  readonly projectReady: boolean;
+  readonly allowRequestRole: boolean;
+  readonly canSetIamPolicy: boolean;
+  readonly hasRequestRoleFeature: boolean;
+}
+
+interface RequestRoleButtonState {
+  readonly visible: boolean;
+  readonly disabledReason?: RequestRoleButtonDisabledReason;
+}
+
+export const getRequestRoleButtonState = ({
+  projectName,
+  projectReady,
+  allowRequestRole,
+  canSetIamPolicy,
+  hasRequestRoleFeature,
+}: RequestRoleButtonStateArgs): RequestRoleButtonState => {
+  if (!projectName) {
+    return {
+      visible: false,
+    };
+  }
+
+  if (!projectReady) {
+    return {
+      visible: true,
+      disabledReason: {
+        kind: "loading",
+      },
+    };
+  }
+
+  if (!allowRequestRole) {
+    return {
+      visible: true,
+      disabledReason: {
+        kind: "allow-request-role-disabled",
+      },
+    };
+  }
+
+  if (canSetIamPolicy) {
+    return {
+      visible: true,
+      disabledReason: {
+        kind: "can-grant-access-directly",
+        permission: "bb.projects.setIamPolicy",
+      },
+    };
+  }
+
+  if (!hasRequestRoleFeature) {
+    return {
+      visible: true,
+      disabledReason: {
+        kind: "feature-unavailable",
+      },
+    };
+  }
+
+  return {
+    visible: true,
+  };
+};


### PR DESCRIPTION
## Summary
- keep the project members `Request Role` action visible and show disabled-state reasons instead of hiding it
- route permission-based disabled states through `PermissionGuard` so missing permissions display with the existing list-style tooltip
- align project/workspace IAM guard handling for the members page action cluster and add focused tests for the new helpers

## Test Plan
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend exec vitest run src/react/pages/settings/membersPageActions.test.ts src/react/pages/settings/requestRoleButton.test.ts
