### PR TITLE
refactor(parser/mssql): migrate query validation and type classification to omni AST

### DIFF
--- a/backend/plugin/db/mssql/stmt_type.go
+++ b/backend/plugin/db/mssql/stmt_type.go
@@ -1,8 +1,7 @@
 package mssql
 
 import (
-	"github.com/antlr4-go/antlr/v4"
-	rawparser "github.com/bytebase/parser/tsql"
+	"github.com/bytebase/omni/mssql/ast"
 	"github.com/pkg/errors"
 
 	parser "github.com/bytebase/bytebase/backend/plugin/parser/tsql"
@@ -16,70 +15,51 @@ const (
 	stmtTypeRowCountGenerating
 )
 
-type stmtTypeListener struct {
-	*rawparser.BaseTSqlParserListener
-	stmtType stmtType
-	err      error
-}
-
 func getStmtType(stmt string) (stmtType, error) {
-	parseResults, err := parser.ParseTSQL(stmt)
+	stmts, err := parser.ParseTSQLOmni(stmt)
 	if err != nil {
 		return stmtTypeUnknown, err
 	}
 
-	if len(parseResults) != 1 {
-		return stmtTypeUnknown, errors.Errorf("expected exactly 1 statement, got %d", len(parseResults))
-	}
-
-	l := &stmtTypeListener{}
-	antlr.ParseTreeWalkerDefault.Walk(l, parseResults[0].Tree)
-	if l.err != nil {
-		return stmtTypeUnknown, l.err
-	}
-	return l.stmtType, nil
-}
-
-func (l *stmtTypeListener) EnterBatch_without_go(ctx *rawparser.Batch_without_goContext) {
-	switch {
-	case len(ctx.AllSql_clauses()) > 0:
-		if len(ctx.AllSql_clauses()) > 1 {
-			l.err = errors.Errorf("unexpected multiple SQL clauses")
+	var nodes []ast.Node
+	for _, s := range stmts {
+		if s.Empty() {
+			continue
 		}
-		l.stmtType, l.err = getStmtTypeFromSQLClauses(ctx.AllSql_clauses()[0])
-	case ctx.Batch_level_statement() != nil:
-		l.stmtType = stmtTypeUnknown
-	case ctx.Execute_body_batch() != nil:
-		l.err = errors.Errorf("unsupported execute func proc")
+		nodes = append(nodes, s.AST)
+	}
+
+	switch len(nodes) {
+	case 0:
+		return stmtTypeUnknown, nil
+	case 1:
+		return classifyStmtType(nodes[0])
 	default:
-		// For any other unhandled cases, set the statement type to unknown
-		l.stmtType = stmtTypeUnknown
+		return stmtTypeUnknown, errors.Errorf("expected exactly 1 statement, got %d", len(nodes))
 	}
 }
 
-func getStmtTypeFromSQLClauses(ctx rawparser.ISql_clausesContext) (stmtType, error) {
-	switch {
-	case ctx.Dml_clause() != nil:
-		if v := ctx.Dml_clause().Select_statement_standalone(); v != nil {
-			if v.Select_statement().Query_expression().Query_specification() != nil && v.Select_statement().Query_expression().Query_specification().INTO() != nil {
-				// SELECT INTO will generate the row count only.
-				return stmtTypeRowCountGenerating, nil
-			}
-			return stmtTypeResultSetGenerating | stmtTypeRowCountGenerating, nil
+func classifyStmtType(node ast.Node) (stmtType, error) {
+	switch n := node.(type) {
+	case *ast.SelectStmt:
+		if parser.HasSelectInto(n) {
+			// SELECT ... INTO materialises a new table — no result set, only row count.
+			return stmtTypeRowCountGenerating, nil
 		}
+		return stmtTypeResultSetGenerating | stmtTypeRowCountGenerating, nil
+
+	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt, *ast.MergeStmt,
+		*ast.BulkInsertStmt, *ast.InsertBulkStmt, *ast.CopyIntoStmt,
+		*ast.ReadtextStmt, *ast.WritetextStmt, *ast.UpdatetextStmt,
+		*ast.ReceiveStmt, *ast.PredictStmt:
 		return stmtTypeRowCountGenerating, nil
-	case ctx.Cfl_statement() != nil:
+
+	case *ast.IfStmt, *ast.WhileStmt, *ast.BeginEndStmt, *ast.TryCatchStmt,
+		*ast.ReturnStmt, *ast.BreakStmt, *ast.ContinueStmt, *ast.GotoStmt,
+		*ast.LabelStmt, *ast.WaitForStmt:
 		return stmtTypeUnknown, errors.Errorf("unsupported control flow statement")
-	case ctx.Another_statement() != nil:
-		return stmtTypeUnknown, nil
-	case ctx.Ddl_clause() != nil:
-		return stmtTypeUnknown, nil
-	case ctx.Dbcc_clause() != nil:
-		return stmtTypeUnknown, nil
-	case ctx.Backup_statement() != nil:
-		return stmtTypeUnknown, nil
+
 	default:
-		// For any unhandled SQL clause types, return unknown
 		return stmtTypeUnknown, nil
 	}
 }

--- a/backend/plugin/parser/tsql/query.go
+++ b/backend/plugin/parser/tsql/query.go
@@ -1,8 +1,7 @@
 package tsql
 
 import (
-	"github.com/antlr4-go/antlr/v4"
-	parser "github.com/bytebase/parser/tsql"
+	"github.com/bytebase/omni/mssql/ast"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
@@ -12,99 +11,54 @@ func init() {
 	base.RegisterQueryValidator(storepb.Engine_MSSQL, ValidateSQLForEditor)
 }
 
+// ValidateSQLForEditor validates that every statement in the SQL is a read-only
+// SELECT (no SELECT INTO). Returns (valid, allAlike, err). For MSSQL the two
+// booleans move together — we reject on the first non-SELECT.
 func ValidateSQLForEditor(statement string) (bool, bool, error) {
-	antlrASTs, err := ParseTSQL(statement)
+	stmts, err := ParseTSQLOmni(statement)
 	if err != nil {
 		return false, false, err
 	}
-	if len(antlrASTs) == 0 {
+	if len(stmts) == 0 {
 		return false, false, nil
 	}
 
-	l := &queryValidateListener{
-		valid: true,
-	}
-
-	for _, ast := range antlrASTs {
-		antlr.ParseTreeWalkerDefault.Walk(l, ast.Tree)
-		if !l.valid {
-			break
+	for _, s := range stmts {
+		if s.Empty() {
+			continue
+		}
+		if !isReadOnlySelect(s.AST) {
+			return false, false, nil
 		}
 	}
-
-	return l.valid, l.valid, nil
+	return true, true, nil
 }
 
-type queryValidateListener struct {
-	*parser.BaseTSqlParserListener
-
-	valid bool
-}
-
-func (q *queryValidateListener) EnterBatch_without_go(ctx *parser.Batch_without_goContext) {
-	if !q.valid {
-		return
-	}
-	if ctx.Batch_level_statement() != nil {
-		q.valid = false
-		return
-	}
-}
-
-func (q *queryValidateListener) EnterSql_clauses(ctx *parser.Sql_clausesContext) {
-	if !q.valid {
-		return
-	}
-	if ctx.Dml_clause() == nil {
-		q.valid = false
-		return
-	}
-}
-
-func (q *queryValidateListener) EnterDml_clause(ctx *parser.Dml_clauseContext) {
-	if !q.valid {
-		return
-	}
-	_, ok := ctx.GetParent().(*parser.Sql_clausesContext)
+// isReadOnlySelect returns true for SELECT statements without an INTO target.
+// Non-SELECT nodes and SELECT ... INTO are rejected — INTO materialises a new
+// table which is a DDL-like side effect.
+func isReadOnlySelect(node ast.Node) bool {
+	sel, ok := node.(*ast.SelectStmt)
 	if !ok {
-		return
+		return false
 	}
-	if ctx.Select_statement_standalone() == nil {
-		q.valid = false
-		return
-	}
+	return !HasSelectInto(sel)
 }
 
-func (q *queryValidateListener) EnterSelect_statement_standalone(ctx *parser.Select_statement_standaloneContext) {
-	if !q.valid {
-		return
+// HasSelectInto reports whether sel (or any branch of its set operations)
+// carries an INTO clause.
+func HasSelectInto(sel *ast.SelectStmt) bool {
+	if sel == nil {
+		return false
 	}
-	_, ok := ctx.GetParent().(*parser.Dml_clauseContext)
-	if !ok {
-		return
+	if sel.IntoTable != nil {
+		return true
 	}
-	if ctx.Select_statement() == nil {
-		q.valid = false
-		return
+	if sel.Larg != nil && HasSelectInto(sel.Larg) {
+		return true
 	}
-}
-
-func (q *queryValidateListener) EnterQuery_specification(ctx *parser.Query_specificationContext) {
-	if !q.valid {
-		return
+	if sel.Rarg != nil && HasSelectInto(sel.Rarg) {
+		return true
 	}
-	if ctx.INTO() != nil {
-		// For Into clause, we only select into temporary table, likes "SELECT ... INTO #temp FROM ...".
-		isValid := false
-		// NOTE: normal mode is not in single session mode, so temporary table is meaningless.
-		// if tableName := ctx.Table_name(); tableName != nil {
-		// 	if allID := tableName.AllId_(); len(allID) == 1 {
-		// 		if id := allID[0].TEMP_ID(); id != nil {
-		// 			isValid = true
-		// 		}
-		// 	}
-		// }
-		q.valid = isValid
-		return
-	}
+	return false
 }

--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -90,17 +90,17 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 		return nil, base.MixUserSystemTablesError
 	}
 
-	queryTypeListener := &queryTypeListener{
-		allSystems: allSystems,
-		result:     base.QueryTypeUnknown,
+	omniStmts, omniErr := ParseTSQLOmni(statement)
+	if omniErr != nil {
+		return nil, omniErr
 	}
-	antlr.ParseTreeWalkerDefault.Walk(queryTypeListener, tree)
-	if queryTypeListener.err != nil {
-		return nil, queryTypeListener.err
+	queryType := base.Select
+	if len(omniStmts) > 0 {
+		queryType = classifyQueryType(omniStmts[0].AST, allSystems)
 	}
-	if queryTypeListener.result != base.Select {
+	if queryType != base.Select {
 		return &base.QuerySpan{
-			Type:          queryTypeListener.result,
+			Type:          queryType,
 			SourceColumns: base.SourceColumnSet{},
 			Results:       []base.QuerySpanResult{},
 		}, nil
@@ -124,7 +124,7 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 		var resourceNotFound *base.ResourceNotFoundError
 		if errors.As(err, &resourceNotFound) {
 			return &base.QuerySpan{
-				Type:          queryTypeListener.result,
+				Type:          queryType,
 				SourceColumns: accessTables,
 				Results:       []base.QuerySpanResult{},
 				NotFoundError: resourceNotFound,
@@ -135,7 +135,7 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 	}
 
 	return &base.QuerySpan{
-		Type:             queryTypeListener.result,
+		Type:             queryType,
 		SourceColumns:    accessTables,
 		Results:          listener.result,
 		PredicateColumns: q.predicateColumns,

--- a/backend/plugin/parser/tsql/query_type.go
+++ b/backend/plugin/parser/tsql/query_type.go
@@ -1,86 +1,74 @@
 package tsql
 
 import (
-	parser "github.com/bytebase/parser/tsql"
+	"github.com/bytebase/omni/mssql/ast"
 
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
-type queryTypeListener struct {
-	*parser.BaseTSqlParserListener
-
-	allSystems bool
-	result     base.QueryType
-	err        error
-}
-
-func (l *queryTypeListener) EnterTsql_file(ctx *parser.Tsql_fileContext) {
-	if l.err != nil {
-		return
+// classifyQueryType classifies an omni AST node into a QueryType.
+// allSystems indicates whether all referenced tables are system/info_schema tables.
+func classifyQueryType(node ast.Node, allSystems bool) base.QueryType {
+	if node == nil {
+		return base.QueryTypeUnknown
 	}
 
-	l.result, l.err = l.getQueryTypeForTSqlFile(ctx)
-}
+	switch node.(type) {
+	case *ast.SelectStmt:
+		if allSystems {
+			return base.SelectInfoSchema
+		}
+		return base.Select
 
-func (l *queryTypeListener) getQueryTypeForTSqlFile(file parser.ITsql_fileContext) (base.QueryType, error) {
-	if len(file.AllBatch_without_go()) == 0 {
-		// Multiple go statement only.
-		return base.Select, nil
-	}
+	// Safe read-only statements treated as Select (parity with the pre-omni
+	// Another_statement → SET/SETUSER/DECLARE branch).
+	case *ast.SetStmt, *ast.SetOptionStmt, *ast.DeclareStmt:
+		return base.Select
 
-	// TODO(zp): Make sure the splitter had handled the GO statement.
-	return l.getQueryTypeForBatchWithoutGo(file.Batch_without_go(0))
-}
+	// DML statements.
+	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt, *ast.MergeStmt,
+		*ast.BulkInsertStmt, *ast.InsertBulkStmt, *ast.CopyIntoStmt,
+		*ast.ReadtextStmt, *ast.WritetextStmt, *ast.UpdatetextStmt,
+		*ast.ExecStmt, *ast.ReceiveStmt, *ast.PredictStmt:
+		return base.DML
 
-func (l *queryTypeListener) getQueryTypeForBatchWithoutGo(batch parser.IBatch_without_goContext) (base.QueryType, error) {
-	// TODO(zp): Make sure the splitter had handled the SEMICOLON.
-	switch {
-	case len(batch.AllSql_clauses()) != 0 && batch.Execute_body_batch() == nil:
-		return l.getQueryTypeForSQLClause(batch.Sql_clauses(0))
-	case batch.Batch_level_statement() != nil:
-		return l.getQueryTypeForBatchLevelStatement(batch.Batch_level_statement())
-	case batch.Execute_body_batch() != nil:
-		return l.getQueryTypeForExecuteBodyBatch(batch.Execute_body_batch())
+	// DDL statements.
+	case *ast.CreateTableStmt, *ast.AlterTableStmt, *ast.DropStmt,
+		*ast.TruncateStmt, *ast.RenameStmt,
+		*ast.CreateIndexStmt, *ast.AlterIndexStmt,
+		*ast.CreateViewStmt,
+		*ast.CreateTriggerStmt, *ast.EnableDisableTriggerStmt,
+		*ast.CreateFunctionStmt, *ast.CreateProcedureStmt,
+		*ast.CreateDatabaseStmt, *ast.AlterDatabaseStmt,
+		*ast.CreateSchemaStmt, *ast.AlterSchemaStmt,
+		*ast.CreateTypeStmt,
+		*ast.CreateSequenceStmt, *ast.AlterSequenceStmt,
+		*ast.CreateSynonymStmt,
+		*ast.GrantStmt, *ast.SecurityStmt, *ast.SecurityKeyStmt, *ast.SecurityPolicyStmt,
+		*ast.SensitivityClassificationStmt, *ast.SignatureStmt,
+		*ast.CreateStatisticsStmt, *ast.UpdateStatisticsStmt, *ast.DropStatisticsStmt,
+		*ast.CreatePartitionFunctionStmt, *ast.AlterPartitionFunctionStmt,
+		*ast.CreatePartitionSchemeStmt, *ast.AlterPartitionSchemeStmt,
+		*ast.CreateFulltextIndexStmt, *ast.AlterFulltextIndexStmt,
+		*ast.CreateFulltextCatalogStmt, *ast.AlterFulltextCatalogStmt,
+		*ast.CreateFulltextStoplistStmt, *ast.AlterFulltextStoplistStmt, *ast.DropFulltextStoplistStmt,
+		*ast.CreateSearchPropertyListStmt, *ast.AlterSearchPropertyListStmt, *ast.DropSearchPropertyListStmt,
+		*ast.CreateXmlSchemaCollectionStmt, *ast.AlterXmlSchemaCollectionStmt,
+		*ast.CreateXmlIndexStmt, *ast.CreateSelectiveXmlIndexStmt,
+		*ast.CreateSpatialIndexStmt, *ast.CreateJsonIndexStmt, *ast.CreateVectorIndexStmt,
+		*ast.CreateAggregateStmt, *ast.DropAggregateStmt,
+		*ast.CreateAssemblyStmt, *ast.AlterAssemblyStmt,
+		*ast.CreateMaterializedViewStmt, *ast.AlterMaterializedViewStmt,
+		*ast.CreateExternalTableAsSelectStmt, *ast.CreateTableCloneStmt,
+		*ast.CreateTableAsSelectStmt, *ast.CreateRemoteTableAsSelectStmt,
+		*ast.CreateFederationStmt, *ast.AlterFederationStmt, *ast.DropFederationStmt, *ast.UseFederationStmt,
+		*ast.AlterServerConfigurationStmt:
+		return base.DDL
+
 	default:
-		return base.QueryTypeUnknown, nil
+		// Flow control (IF/WHILE/BEGIN-END/TRY-CATCH/RETURN/BREAK/CONTINUE/GOTO/LABEL/WAITFOR),
+		// PRINT/RAISERROR/THROW, DBCC, BACKUP/RESTORE, transactions, cursors, and other
+		// statements we do not classify — report as Unknown to match the pre-omni behavior.
+		return base.QueryTypeUnknown
 	}
-}
-
-func (l *queryTypeListener) getQueryTypeForSQLClause(clause parser.ISql_clausesContext) (base.QueryType, error) {
-	// We only care about the first clause.
-	switch {
-	case clause.Dml_clause() != nil:
-		if clause.Dml_clause().Select_statement_standalone() != nil {
-			if l.allSystems {
-				return base.SelectInfoSchema, nil
-			}
-			return base.Select, nil
-		}
-		return base.DML, nil
-	case clause.Ddl_clause() != nil:
-		return base.DDL, nil
-	case clause.Another_statement() != nil:
-		// Treat SAFE SET as select statement.
-		if clause.Another_statement().Set_statement() != nil || clause.Another_statement().Setuser_statement() != nil || clause.Another_statement().Declare_statement() != nil {
-			return base.Select, nil
-		}
-		// EXECUTE stored procedure is DML.
-		if clause.Another_statement().Execute_statement() != nil {
-			return base.DML, nil
-		}
-		return base.QueryTypeUnknown, nil
-	case clause.Cfl_statement() != nil, clause.Dbcc_clause() != nil, clause.Backup_statement() != nil:
-		return base.QueryTypeUnknown, nil
-	default:
-		return base.QueryTypeUnknown, nil
-	}
-}
-
-func (*queryTypeListener) getQueryTypeForBatchLevelStatement(parser.IBatch_level_statementContext) (base.QueryType, error) {
-	return base.DDL, nil
-}
-
-func (*queryTypeListener) getQueryTypeForExecuteBodyBatch(parser.IExecute_body_batchContext) (base.QueryType, error) {
-	// Call stored procedure or function.
-	return base.DML, nil
 }


### PR DESCRIPTION
## Summary

Replaces ANTLR listeners in four MSSQL query-path files with omni AST type-switches, continuing the broader MSSQL omni migration.

- `parser/tsql/query_type.go` — `classifyQueryType` operates on omni nodes (SelectStmt / DML / DDL / safe-SET-DECLARE / Unknown), parallel to the PG pattern in `parser/pg/query_type.go`.
- `parser/tsql/query.go` — `ValidateSQLForEditor` rejects non-SELECT and SELECT ... INTO, with recursive INTO detection across UNION branches via `HasSelectInto`.
- `parser/tsql/query_span_extractor.go` — early-exit query type classification now goes through `ParseTSQLOmni` + `classifyQueryType`. The rest of the span walk is still ANTLR, pending a larger follow-up migration.
- `db/mssql/stmt_type.go` — `classifyStmtType` distinguishes result-set vs row-count generation via omni nodes; reuses `HasSelectInto` for SELECT INTO detection.

Net: -209 / +131 lines.

## Test plan

- [x] `go build ./backend/plugin/parser/tsql/... ./backend/plugin/db/mssql/...`
- [x] `golangci-lint run ./backend/plugin/parser/tsql/... ./backend/plugin/db/mssql/...`
- [x] `go test ./backend/plugin/parser/tsql/... ./backend/plugin/db/mssql/... ./backend/plugin/advisor/mssql/... ./backend/plugin/schema/mssql/...`
- [x] Codex review pass — feedback addressed (recursive SELECT INTO detection, ExecStmt behavior parity, UseStmt parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)