### PR TITLE
fix(parser/mssql): apply CREATE VIEW column alias list in query span extraction

### DIFF
--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -761,8 +761,11 @@ func (q *querySpanExtractor) tsqlFindTableSchema(fullTableName parser.IFull_tabl
 }
 
 func (q *querySpanExtractor) getColumnsFromCreateView(definition string, viewDatabaseName string, viewSchemaName string) ([]base.QuerySpanResult, error) {
-	// Extract the SELECT body from CREATE VIEW statement
-	selectBody, err := getSelectBodyFromCreateView(definition)
+	// Extract the SELECT body and optional column alias list from CREATE VIEW statement.
+	// e.g. CREATE VIEW vw (F1, F2) AS SELECT col_a, col_b FROM tbl
+	//   selectBody = "SELECT col_a, col_b FROM tbl"
+	//   columnAliases = ["F1", "F2"]
+	selectBody, columnAliases, err := getSelectBodyFromCreateView(definition)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to extract SELECT body from CREATE VIEW")
 	}
@@ -780,6 +783,15 @@ func (q *querySpanExtractor) getColumnsFromCreateView(definition string, viewDat
 	if span.NotFoundError != nil {
 		return nil, span.NotFoundError
 	}
+
+	// Apply column aliases from the CREATE VIEW header if present.
+	// The alias list renames the SELECT body columns positionally.
+	if len(columnAliases) > 0 && len(columnAliases) == len(span.Results) {
+		for i, alias := range columnAliases {
+			span.Results[i].Name = alias
+		}
+	}
+
 	return span.Results, nil
 }
 
@@ -3673,35 +3685,36 @@ func unquote(name string) string {
 	return name
 }
 
-func getSelectBodyFromCreateView(createView string) (string, error) {
+func getSelectBodyFromCreateView(createView string) (string, []string, error) {
 	antlrASTs, err := ParseTSQL(createView)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	if len(antlrASTs) != 1 {
-		return "", errors.Errorf("expected exactly 1 statement, got %d", len(antlrASTs))
+		return "", nil, errors.Errorf("expected exactly 1 statement, got %d", len(antlrASTs))
 	}
 
 	ast := antlrASTs[0]
 	tree := ast.Tree
 	if tree == nil {
-		return "", errors.Errorf("parse tree is nil")
+		return "", nil, errors.Errorf("parse tree is nil")
 	}
 
 	extractor := &selectBodyExtractor{}
 	antlr.ParseTreeWalkerDefault.Walk(extractor, tree)
 
 	if extractor.selectBody == "" {
-		return "", errors.Errorf("no SELECT statement found in CREATE VIEW")
+		return "", nil, errors.Errorf("no SELECT statement found in CREATE VIEW")
 	}
 
-	return extractor.selectBody, nil
+	return extractor.selectBody, extractor.columnAliases, nil
 }
 
 type selectBodyExtractor struct {
 	*parser.BaseTSqlParserListener
-	selectBody string
+	selectBody    string
+	columnAliases []string
 }
 
 func (e *selectBodyExtractor) EnterCreate_view(ctx *parser.Create_viewContext) {
@@ -3713,5 +3726,13 @@ func (e *selectBodyExtractor) EnterCreate_view(ctx *parser.Create_viewContext) {
 		input := selectStatement.GetStart().GetInputStream()
 		interval := antlr.NewInterval(start, stop)
 		e.selectBody = input.GetTextFromInterval(interval)
+	}
+
+	// Extract the optional column alias list: CREATE VIEW vw (F1, F2) AS SELECT ...
+	if columnNameList := ctx.Column_name_list(); columnNameList != nil {
+		for _, id := range columnNameList.AllId_() {
+			_, normalizedName := NormalizeTSQLIdentifier(id)
+			e.columnAliases = append(e.columnAliases, normalizedName)
+		}
 	}
 }

--- a/backend/plugin/parser/tsql/test-data/query-span/regression.yaml
+++ b/backend/plugin/parser/tsql/test-data/query-span/regression.yaml
@@ -157,6 +157,84 @@
         table: TableB
         column: IDB
 
+- description: "BYT-9235: WHERE clause on view column fails when CREATE VIEW has column alias list"
+  statement: |-
+    SELECT top 10 * FROM [bhs].[dbo].[vwTest] a WHERE a.F1 LIKE 'MT%'
+  defaultDatabase: bhs
+  ignoreCaseSensitive: true
+  metadata:
+    - |-
+      {
+        "name": "bhs",
+        "schemas": [
+          {
+            "name": "dbo",
+            "views": [
+              {
+                "name": "vwTest",
+                "definition": "CREATE VIEW [dbo].[vwTest] (F1, F2) AS SELECT col_a, col_b FROM tbl",
+                "columns": [
+                  {
+                    "name": "F1"
+                  },
+                  {
+                    "name": "F2"
+                  }
+                ]
+              }
+            ],
+            "tables": [
+              {
+                "name": "tbl",
+                "columns": [
+                  {
+                    "name": "col_a"
+                  },
+                  {
+                    "name": "col_b"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+  querySpan:
+    type: 1
+    results:
+      - name: f1
+        sourcecolumns:
+          - server: ""
+            database: bhs
+            schema: dbo
+            table: tbl
+            column: col_a
+        isplainfield: true
+        sourcefieldpaths: []
+        selectasterisk: false
+      - name: f2
+        sourcecolumns:
+          - server: ""
+            database: bhs
+            schema: dbo
+            table: tbl
+            column: col_b
+        isplainfield: true
+        sourcefieldpaths: []
+        selectasterisk: false
+    sourcecolumns:
+      - server: ""
+        database: bhs
+        schema: dbo
+        table: vwTest
+        column: ""
+    predicatecolumns:
+      - server: ""
+        database: bhs
+        schema: dbo
+        table: tbl
+        column: col_a
+
 - description: Test simple correlated subquery - fix for outer table sources
   statement: |-
     SELECT HMNum FROM TableA WHERE HMNum = 'test'


### PR DESCRIPTION
## Summary
- Fix MSSQL query span extractor ignoring the column alias list in `CREATE VIEW vw (F1, F2) AS SELECT col_a, col_b FROM tbl`
- The SELECT body was parsed correctly, but the column aliases from the header were not applied, causing WHERE clauses referencing aliased column names to fail with "no matching column"
- Extract the column alias list from the CREATE VIEW header and apply it positionally to rename parsed columns

## Root Cause
`getSelectBodyFromCreateView` only extracted the SELECT body from `CREATE VIEW`, completely ignoring the optional column alias list between the view name and `AS`. When a view defined `CREATE VIEW vw (F1, F2) AS SELECT col_a, col_b FROM tbl`, the resolved columns were named `col_a`/`col_b` instead of `F1`/`F2`. `SELECT *` worked (no name matching needed), but `WHERE a.F1 = ...` failed because `f1` wasn't in the column list.

## Test plan
- [x] Added regression test case for BYT-9235 in `backend/plugin/parser/tsql/test-data/query-span/regression.yaml`
- [x] All existing TSQL query span tests pass
- [x] Lint passes

Closes BYT-9235

🤖 Generated with [Claude Code](https://claude.com/claude-code)