### PR TITLE
fix(e2e): update radio locator to match new i18n label

### DIFF
--- a/frontend/tests/e2e/masking-exemption/masking-exemption.page.ts
+++ b/frontend/tests/e2e/masking-exemption/masking-exemption.page.ts
@@ -66,7 +66,7 @@ export class GrantExemptionPage {
   constructor(page: Page, baseURL = "") {
     this.page = page;
     this.baseURL = baseURL;
-    this.allRadio = page.getByRole("radio", { name: "All", exact: true });
+    this.allRadio = page.getByRole("radio", { name: "All databases", exact: true });
     this.reasonInput = page.getByPlaceholder(/description/i);
     this.accountSelect = page.getByText("Select accounts", { exact: true });
     this.confirmButton = page.getByRole("button", { name: "Confirm" });


### PR DESCRIPTION
## Summary
- The React locale changed `issue.role-grant.all-databases` from `"All"` to `"All databases"`, which broke the grant exemption e2e test's radio button locator (`getByRole('radio', { name: 'All', exact: true })`)
- Updated the `GrantExemptionPage` page object to use `{ name: "All databases", exact: true }`

## Test plan
- [x] All 15 masking-exemption e2e tests pass (was 8 failures before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)