### PR TITLE
fix(parser/cassandra): propagate request context in query span extraction

### DIFF
--- a/backend/plugin/parser/cassandra/query_span.go
+++ b/backend/plugin/parser/cassandra/query_span.go
@@ -15,7 +15,7 @@ func init() {
 }
 
 // GetQuerySpan extracts the query span from a CQL statement.
-func GetQuerySpan(_ context.Context, gCtx base.GetQuerySpanContext, stmt base.Statement, database, _ string, _ bool) (*base.QuerySpan, error) {
+func GetQuerySpan(ctx context.Context, gCtx base.GetQuerySpanContext, stmt base.Statement, database, _ string, _ bool) (*base.QuerySpan, error) {
 	parseResults, err := ParseCassandraSQL(stmt.Text)
 	if err != nil {
 		return nil, err
@@ -33,7 +33,7 @@ func GetQuerySpan(_ context.Context, gCtx base.GetQuerySpanContext, stmt base.St
 	tree := parseResults[0].Tree
 
 	// Create extractor and walk the tree
-	extractor := newQuerySpanExtractor(database, gCtx)
+	extractor := newQuerySpanExtractor(ctx, database, gCtx)
 	antlr.ParseTreeWalkerDefault.Walk(extractor, tree)
 
 	if extractor.err != nil {

--- a/backend/plugin/parser/cassandra/query_span_extractor.go
+++ b/backend/plugin/parser/cassandra/query_span_extractor.go
@@ -15,6 +15,7 @@ type querySpanExtractor struct {
 	*cql.BaseCqlParserListener
 
 	// Context
+	ctx             context.Context
 	defaultKeyspace string
 	gCtx            base.GetQuerySpanContext
 
@@ -33,9 +34,10 @@ func unquoteIdentifier(identifier string) string {
 	return identifier
 }
 
-func newQuerySpanExtractor(defaultKeyspace string, gCtx base.GetQuerySpanContext) *querySpanExtractor {
+func newQuerySpanExtractor(ctx context.Context, defaultKeyspace string, gCtx base.GetQuerySpanContext) *querySpanExtractor {
 	return &querySpanExtractor{
 		BaseCqlParserListener: &cql.BaseCqlParserListener{},
+		ctx:                   ctx,
 		defaultKeyspace:       defaultKeyspace,
 		gCtx:                  gCtx,
 		querySpan: &base.QuerySpan{
@@ -180,8 +182,7 @@ func (e *querySpanExtractor) expandSelectAsterisk(keyspace, table string) []base
 		}}
 	}
 
-	ctx := context.Background()
-	_, metadata, err := e.gCtx.GetDatabaseMetadataFunc(ctx, e.gCtx.InstanceID, keyspace)
+	_, metadata, err := e.gCtx.GetDatabaseMetadataFunc(e.ctx, e.gCtx.InstanceID, keyspace)
 	if err != nil || metadata == nil {
 		// If we can't get metadata, fall back to SelectAsterisk flag
 		// This matches behavior of other engines like TSQL


### PR DESCRIPTION
## Summary

- Fix nil pointer dereference when running `SELECT *` queries in the Cassandra SQL editor
- Cassandra's `GetQuerySpan` discarded the request context (`_ context.Context`), forcing `expandSelectAsterisk` to use `context.Background()` which has no workspace ID
- When the instance cache was cold, `GetInstance` queried with empty workspace (`WHERE workspace = ''`), returned nil, and crashed at `convertMetadataAndConfig`

**Root cause**: asymmetry between `GetDBSchema` (skips workspace filter when empty → finds the row) and `ListInstances` (always filters by workspace → zero rows → nil)

## Test plan

- [x] Set up local Cassandra instance, ran `SELECT * FROM employees LIMIT 50;`
- [x] Reproduced the crash by evicting instance cache before `GetInstance` call
- [x] Verified fix resolves the crash with cache eviction still in place
- [x] Build and lint pass with zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)