### PR TITLE
fix(monaco): share services init between Vue and React wrappers

### DIFF
--- a/frontend/src/components/MonacoEditor/services.ts
+++ b/frontend/src/components/MonacoEditor/services.ts
@@ -6,9 +6,21 @@ import "@codingame/monaco-vscode-theme-defaults-default-extension";
 import getThemeServiceOverride from "@codingame/monaco-vscode-theme-service-override";
 import "vscode/localExtensionHost";
 
+// Vue and React both ship their own Monaco wrappers during the React migration.
+// Without the guards below, whichever module evaluates second would clobber
+// `window.MonacoEnvironment` (losing worker labels the other side needs) and
+// re-trigger `@codingame/monaco-vscode-api` `initialize`, which is a *global*
+// one-shot — the second call rejects and leaves the editor spinner stuck
+// forever until a hard refresh. See BYT-9242.
+
 type WorkerLoader = () => Worker;
 
 const workerLoaders: Partial<Record<string, WorkerLoader>> = {
+  editorWorkerService: () =>
+    new Worker(
+      new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url),
+      { type: "module" }
+    ),
   TextEditorWorker: () =>
     new Worker(
       new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url),
@@ -22,20 +34,40 @@ const workerLoaders: Partial<Record<string, WorkerLoader>> = {
       ),
       { type: "module" }
     ),
+  textMateWorker: () =>
+    new Worker(
+      new URL(
+        "@codingame/monaco-vscode-textmate-service-override/worker",
+        import.meta.url
+      ),
+      { type: "module" }
+    ),
 };
 
+const previousEnvironment = window.MonacoEnvironment;
+const previousGetWorker = previousEnvironment?.getWorker;
+
 window.MonacoEnvironment = {
-  getWorker: function (_moduleId, label) {
+  ...previousEnvironment,
+  getWorker: function (moduleId, label) {
     const workerFactory = workerLoaders[label];
-    if (workerFactory != null) {
+    if (workerFactory) {
       return workerFactory();
+    }
+    if (previousGetWorker) {
+      return previousGetWorker(moduleId, label);
     }
     throw new Error(`Worker ${label} not found`);
   },
 };
 
-const state = {
-  servicesInitialized: undefined as Promise<void> | undefined,
+// Share the init promise across both Vue and React Monaco wrappers. The
+// underlying `@codingame/monaco-vscode-api` `initialize` is a global one-shot,
+// so both sides must await the same promise rather than each caching its own.
+const GLOBAL_INIT_KEY = "__bytebaseMonacoServicesInitPromise__";
+
+type GlobalWithMonacoInit = typeof globalThis & {
+  [GLOBAL_INIT_KEY]?: Promise<void>;
 };
 
 const initializeRunner = async () => {
@@ -49,12 +81,19 @@ const initializeRunner = async () => {
   });
 };
 
-export const initializeMonacoServices = async () => {
-  if (state.servicesInitialized) {
-    return state.servicesInitialized;
+export const initializeMonacoServices = async (): Promise<void> => {
+  const g = globalThis as GlobalWithMonacoInit;
+  if (g[GLOBAL_INIT_KEY]) {
+    return g[GLOBAL_INIT_KEY];
   }
 
-  const job = initializeRunner();
-  state.servicesInitialized = job;
+  const job = initializeRunner().catch((err) => {
+    // Allow a retry on the next call instead of caching a rejected promise.
+    if (g[GLOBAL_INIT_KEY] === job) {
+      g[GLOBAL_INIT_KEY] = undefined;
+    }
+    throw err;
+  });
+  g[GLOBAL_INIT_KEY] = job;
   return job;
 };

--- a/frontend/src/react/components/monaco/services.ts
+++ b/frontend/src/react/components/monaco/services.ts
@@ -6,6 +6,13 @@ import "@codingame/monaco-vscode-theme-defaults-default-extension";
 import getThemeServiceOverride from "@codingame/monaco-vscode-theme-service-override";
 import "vscode/localExtensionHost";
 
+// Vue and React both ship their own Monaco wrappers during the React migration.
+// Without the guards below, whichever module evaluates second would clobber
+// `window.MonacoEnvironment` (losing worker labels the other side needs) and
+// re-trigger `@codingame/monaco-vscode-api` `initialize`, which is a *global*
+// one-shot — the second call rejects and leaves the editor spinner stuck
+// forever until a hard refresh. See BYT-9242.
+
 type WorkerLoader = () => Worker;
 
 const workerLoaders: Partial<Record<string, WorkerLoader>> = {
@@ -37,18 +44,30 @@ const workerLoaders: Partial<Record<string, WorkerLoader>> = {
     ),
 };
 
+const previousEnvironment = window.MonacoEnvironment;
+const previousGetWorker = previousEnvironment?.getWorker;
+
 window.MonacoEnvironment = {
-  getWorker: function (_moduleId, label) {
+  ...previousEnvironment,
+  getWorker: function (moduleId, label) {
     const workerFactory = workerLoaders[label];
-    if (workerFactory != null) {
+    if (workerFactory) {
       return workerFactory();
+    }
+    if (previousGetWorker) {
+      return previousGetWorker(moduleId, label);
     }
     throw new Error(`Worker ${label} not found`);
   },
 };
 
-const state = {
-  servicesInitialized: undefined as Promise<void> | undefined,
+// Share the init promise across both Vue and React Monaco wrappers. The
+// underlying `@codingame/monaco-vscode-api` `initialize` is a global one-shot,
+// so both sides must await the same promise rather than each caching its own.
+const GLOBAL_INIT_KEY = "__bytebaseMonacoServicesInitPromise__";
+
+type GlobalWithMonacoInit = typeof globalThis & {
+  [GLOBAL_INIT_KEY]?: Promise<void>;
 };
 
 const initializeRunner = async () => {
@@ -62,12 +81,19 @@ const initializeRunner = async () => {
   });
 };
 
-export const initializeMonacoServices = async () => {
-  if (state.servicesInitialized) {
-    return state.servicesInitialized;
+export const initializeMonacoServices = async (): Promise<void> => {
+  const g = globalThis as GlobalWithMonacoInit;
+  if (g[GLOBAL_INIT_KEY]) {
+    return g[GLOBAL_INIT_KEY];
   }
 
-  const job = initializeRunner();
-  state.servicesInitialized = job;
+  const job = initializeRunner().catch((err) => {
+    // Allow a retry on the next call instead of caching a rejected promise.
+    if (g[GLOBAL_INIT_KEY] === job) {
+      g[GLOBAL_INIT_KEY] = undefined;
+    }
+    throw err;
+  });
+  g[GLOBAL_INIT_KEY] = job;
   return job;
 };


### PR DESCRIPTION
Fixes BYT-9242.

## Summary
- Vue and React Monaco wrappers each set `window.MonacoEnvironment` and called `@codingame/monaco-vscode-api` `initialize` independently. Whichever module evaluated second clobbered the worker-label map and re-called the *global one-shot* init, which rejected.
- The rejected promise was cached in the losing module's per-file singleton, so every subsequent Monaco instance failed silently (caught in `MonacoTextModelEditor.vue`) and the editor spinner stayed on forever until a hard refresh.
- Chain `window.MonacoEnvironment.getWorker` so maps compose instead of clobber, and move the init promise onto `globalThis` so both wrappers share one lifecycle. Clear the slot on failure to allow retries.

## Test plan
- [ ] Open an issue detail page (React) and let Monaco load; navigate to the plan detail page (Vue) without refreshing — SQL editor should render, not spin.
- [ ] Do the reverse navigation (plan → issue) — React editor should render, not spin.
- [ ] Console should have no `Worker editorWorkerService not found` or `[MonacoEditor] initialize failed` errors.
- [ ] Hard-refresh each page — both still work (no regression on cold load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)