### PR TITLE
fix(plan): simplify SQL editor layout to avoid checks overlap

### DIFF
--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseChangeView/DatabaseChangeView.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseChangeView/DatabaseChangeView.vue
@@ -4,9 +4,7 @@
     <SpecTabs v-model:selected-spec-id="selectedSpecId">
       <div v-if="selectedSpec" class="flex flex-col gap-2">
         <TargetListSection />
-        <div class="flex flex-col" :class="isReleaseView ? '' : 'h-72'">
-          <StatementSection header-variant="section" />
-        </div>
+        <StatementSection header-variant="section" />
         <OptionsSection />
       </div>
     </SpecTabs>
@@ -36,13 +34,6 @@ const selectedSpecId = ref<string>(plan.value.specs[0]?.id ?? "");
 
 const selectedSpec = computed(() => {
   return plan.value.specs.find((spec) => spec.id === selectedSpecId.value);
-});
-
-const isReleaseView = computed(() => {
-  return (
-    selectedSpec.value?.config?.case === "changeDatabaseConfig" &&
-    !!selectedSpec.value.config.value.release
-  );
 });
 
 provideSelectedSpec(

--- a/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/DatabaseExportView.vue
@@ -10,9 +10,7 @@
     <LimitsSection />
     <OptionsSection />
 
-    <div class="h-72 flex flex-col">
-      <StatementSection header-variant="section" />
-    </div>
+    <StatementSection header-variant="section" />
   </div>
 </template>
 

--- a/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
+++ b/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="shouldShow" class="flex flex-col gap-y-2 overflow-hidden">
+  <div v-if="shouldShow" class="flex flex-col gap-y-2">
     <!-- Row 1: Title + Run button -->
     <div class="flex items-center justify-between gap-2">
       <div class="flex flex-row items-center gap-2">

--- a/frontend/src/components/Plan/components/SQLCheckV1Section/SQLCheckV1Section.vue
+++ b/frontend/src/components/Plan/components/SQLCheckV1Section/SQLCheckV1Section.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="show" class="flex flex-col gap-y-2 overflow-hidden">
+  <div v-if="show" class="flex flex-col gap-y-2">
     <!-- Row 1: Title + Run button -->
     <div class="flex items-center justify-between gap-2">
       <div class="flex flex-row items-center gap-2">

--- a/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
+++ b/frontend/src/components/Plan/components/SpecDetailView/SpecDetailView.vue
@@ -5,9 +5,7 @@
       <TargetListSection />
 
       <!-- Statement -->
-      <div :class="[plan.hasRollout ? 'h-[192px]' : 'h-[256px]', 'flex flex-col']">
-        <StatementSection />
-      </div>
+      <StatementSection />
 
       <!-- Checks + Configuration -->
       <template v-if="!specHasRelease">

--- a/frontend/src/components/Plan/components/StatementSection/EditorView/EditorView.vue
+++ b/frontend/src/components/Plan/components/StatementSection/EditorView/EditorView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full flex flex-col gap-y-1">
+  <div class="flex flex-col gap-y-1">
     <div class="flex items-center justify-between">
       <div class="flex items-center gap-x-1">
         <span
@@ -110,7 +110,7 @@
       </template>
     </BBAttention>
 
-    <div class="relative flex-1">
+    <div class="relative h-64">
       <MonacoEditor
         class="w-full h-full border rounded-sm overflow-hidden"
         :filename="filename"

--- a/frontend/src/components/Plan/components/StatementSection/ReleaseView/ReleaseView.vue
+++ b/frontend/src/components/Plan/components/StatementSection/ReleaseView/ReleaseView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="h-full flex flex-col gap-y-2">
+  <div class="flex flex-col gap-y-2">
     <NAlert type="info" :bordered="false">
       <template #icon>
         <heroicons-outline:information-circle class="w-5 h-5" />

--- a/frontend/src/components/Plan/components/StatementSection/StatementSection.vue
+++ b/frontend/src/components/Plan/components/StatementSection/StatementSection.vue
@@ -1,7 +1,9 @@
 <template>
-  <div v-if="viewMode === 'EDITOR'" class="flex-1">
-    <EditorView :key="editorViewKey" :header-variant="headerVariant" />
-  </div>
+  <EditorView
+    v-if="viewMode === 'EDITOR'"
+    :key="editorViewKey"
+    :header-variant="headerVariant"
+  />
   <ReleaseView v-else-if="viewMode === 'RELEASE'" />
 </template>
 


### PR DESCRIPTION
Fixes BYT-9237.

## Summary
- `SpecDetailView` and `DatabaseChangeView` wrapped the statement editor in fixed-height divs (`plan.hasRollout ? h-[192px] : h-[256px]` and `h-72`) so Monaco's `h-full` had a concrete height. For short statements this left big empty space inside the editor and crammed `PlanCheckSection`'s status dots + `Affected rows` pill right up against its border — the "SQL overlap the checks" symptom.
- Drop the conditional wrappers and give the Monaco container a single direct `h-64`. EditorView/StatementSection no longer need `h-full` + `flex-1` plumbing.
- Remove `overflow-hidden` from `PlanCheckSection` / `SQLCheckV1Section` which could clip the Checks heading row under tight flex constraints.

## Test plan
- [ ] Plan Detail page with a short SQL + `hasRollout=true`: editor takes a stable 256px, Checks heading + status dots + `Affected rows` pill render cleanly below with no visual overlap.
- [ ] Plan Detail page with a long SQL: editor stays at 256px; long content scrolls inside Monaco.
- [ ] Issue Review page (Vue `DatabaseChangeView`): editor renders at the new height, release-view path still renders when spec has a release.
- [ ] Narrow viewports: page layout remains usable; no horizontal clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)