### PR TITLE
fix(parser/mssql): scope join-anchor pushes to query specification (BYT-9235)

### DIFF
--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -379,16 +379,21 @@ func (q *querySpanExtractor) extractTSqlSensitiveFieldsFromQuerySpecification(ct
 
 	var compoundFrom []base.TableSource
 	if from := ctx.From_table_sources(); from != nil {
+		// Capture the boundary BEFORE extracting table sources: the extraction
+		// pushes intermediate join anchors onto q.tableSourcesFrom (see
+		// extractTSqlSensitiveFieldsFromTableSource), and those pushes must be
+		// scoped to this query specification so they don't leak into the
+		// enclosing scope — especially when alias names collide.
+		originalFromFieldList := len(q.tableSourcesFrom)
+		defer func() {
+			q.tableSourcesFrom = q.tableSourcesFrom[:originalFromFieldList]
+		}()
 		fromFieldList, err := q.extractTSqlSensitiveFieldsFromTableSources(from.GetFrom())
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to extract sensitive fields from `table_sources` in `query_specification`")
 		}
-		originalFromFieldList := len(q.tableSourcesFrom)
 		q.tableSourcesFrom = append(q.tableSourcesFrom, fromFieldList...)
 		compoundFrom = fromFieldList
-		defer func() {
-			q.tableSourcesFrom = q.tableSourcesFrom[:originalFromFieldList]
-		}()
 	}
 
 	result := &base.PseudoTable{}

--- a/backend/plugin/parser/tsql/test-data/query-span/regression.yaml
+++ b/backend/plugin/parser/tsql/test-data/query-span/regression.yaml
@@ -250,12 +250,7 @@
             "views": [
               {
                 "name": "vwBHSDetailBPM3",
-                "definition": "CREATE VIEW [dbo].[vwBHSDetailBPM3] AS SELECT DISTINCT a.* FROM (SELECT a.Id, b.F1, b.F2 FROM tableA a INNER JOIN tableB b ON a.Id = b.mainid WHERE a.condition = 'A' UNION SELECT a.Id, b.F1, b.F2 FROM tableA a INNER JOIN tableB b ON a.Id = b.mainid WHERE a.condition = 'B') a",
-                "columns": [
-                  {"name": "Id"},
-                  {"name": "F1"},
-                  {"name": "F2"}
-                ]
+                "definition": "CREATE VIEW [dbo].[vwBHSDetailBPM3] AS SELECT DISTINCT a.* FROM (SELECT a.Id, b.F1, b.F2 FROM tableA a INNER JOIN tableB b ON a.Id = b.mainid WHERE a.condition = 'A' UNION SELECT a.Id, b.F1, b.F2 FROM tableA a INNER JOIN tableB b ON a.Id = b.mainid WHERE a.condition = 'B') a"
               }
             ],
             "tables": [

--- a/backend/plugin/parser/tsql/test-data/query-span/regression.yaml
+++ b/backend/plugin/parser/tsql/test-data/query-span/regression.yaml
@@ -235,6 +235,95 @@
         table: tbl
         column: col_a
 
+- description: "BYT-9235: alias shadowing between inner JOIN tables and outer derived table in view body. The view uses `SELECT DISTINCT a.* FROM (SELECT a.Id, b.F1, b.F2 FROM tableA a INNER JOIN tableB b ... UNION ...) a` — same alias `a` at inner and outer levels. Before the fix, join-anchor pushes leaked out of nested query specifications, so `a.*` resolved to the inner tableA instead of the outer derived table."
+  statement: |-
+    SELECT TOP 10 * FROM [bhs].[dbo].[vwBHSDetailBPM3] a WHERE a.F1 LIKE 'MT%'
+  defaultDatabase: bhs
+  ignoreCaseSensitive: true
+  metadata:
+    - |-
+      {
+        "name": "bhs",
+        "schemas": [
+          {
+            "name": "dbo",
+            "views": [
+              {
+                "name": "vwBHSDetailBPM3",
+                "definition": "CREATE VIEW [dbo].[vwBHSDetailBPM3] AS SELECT DISTINCT a.* FROM (SELECT a.Id, b.F1, b.F2 FROM tableA a INNER JOIN tableB b ON a.Id = b.mainid WHERE a.condition = 'A' UNION SELECT a.Id, b.F1, b.F2 FROM tableA a INNER JOIN tableB b ON a.Id = b.mainid WHERE a.condition = 'B') a",
+                "columns": [
+                  {"name": "Id"},
+                  {"name": "F1"},
+                  {"name": "F2"}
+                ]
+              }
+            ],
+            "tables": [
+              {
+                "name": "tableA",
+                "columns": [
+                  {"name": "Id"},
+                  {"name": "condition"}
+                ]
+              },
+              {
+                "name": "tableB",
+                "columns": [
+                  {"name": "mainid"},
+                  {"name": "F1"},
+                  {"name": "F2"}
+                ]
+              }
+            ]
+          }
+        ]
+      }
+  querySpan:
+    type: 1
+    results:
+      - name: Id
+        sourcecolumns:
+          - server: ""
+            database: bhs
+            schema: dbo
+            table: tableA
+            column: Id
+        isplainfield: true
+        sourcefieldpaths: []
+        selectasterisk: false
+      - name: F1
+        sourcecolumns:
+          - server: ""
+            database: bhs
+            schema: dbo
+            table: tableB
+            column: F1
+        isplainfield: true
+        sourcefieldpaths: []
+        selectasterisk: false
+      - name: F2
+        sourcecolumns:
+          - server: ""
+            database: bhs
+            schema: dbo
+            table: tableB
+            column: F2
+        isplainfield: true
+        sourcefieldpaths: []
+        selectasterisk: false
+    sourcecolumns:
+      - server: ""
+        database: bhs
+        schema: dbo
+        table: vwBHSDetailBPM3
+        column: ""
+    predicatecolumns:
+      - server: ""
+        database: bhs
+        schema: dbo
+        table: tableB
+        column: F1
+
 - description: Test simple correlated subquery - fix for outer table sources
   statement: |-
     SELECT HMNum FROM TableA WHERE HMNum = 'test'


### PR DESCRIPTION
## Summary

- Fixes BYT-9235: a MSSQL view whose body shadows a table alias across nested query specifications (e.g. `SELECT DISTINCT a.* FROM (SELECT a.Id, b.F1 FROM tableA a JOIN tableB b ... UNION ...) a`) caused `WHERE a.F1 LIKE '…'` on that view to fail with `no matching column ""."".”a"."f1"`.
- `extractTSqlSensitiveFieldsFromQuerySpecification` captured `originalFromFieldList` **after** calling `extractTSqlSensitiveFieldsFromTableSources`, which pushes intermediate join anchors onto `q.tableSourcesFrom`. The deferred truncation therefore restored to the post-push length and those anchors leaked out of the query's scope. When an alias (`a`) was reused at inner and outer levels, the leaked inner `PseudoTable(a)` shadowed the outer derived-table alias in sequential resolution, so `SELECT a.*` pulled inner-table columns instead of the derived table's.
- The earlier fix in #19984 addressed a related-but-different case (explicit `CREATE VIEW vw (F1, F2) AS …` column alias list) and did not cover this scope-leak.

### Fix

Capture `originalFromFieldList` and install the `defer` **before** the table-sources extraction runs so per-join pushes are cleaned up with the rest of the query scope.

## Test plan

- [x] New regression test in `backend/plugin/parser/tsql/test-data/query-span/regression.yaml` mirroring the user's actual view shape (UNION derived table + shadowed `a` alias).
- [x] `go test ./backend/plugin/parser/tsql/...` passes.
- [x] `go build ./backend/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)