### PR TITLE
fix(plan-checks): reword Run button and block re-run after rollout

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -440,6 +440,12 @@ func (s *PlanService) RunPlanChecks(ctx context.Context, request *connect.Reques
 	if storePlanConfigHasRelease(plan.Config) {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("cannot run plan checks because plan %q has release", plan.Name))
 	}
+	// Once a rollout exists the plan is frozen; re-running checks produces the
+	// same result and is misleading. Match the frontend gate in
+	// PlanCheckSection.vue / ChecksSection.vue / IssueDetailChecks.tsx.
+	if plan.Config.GetHasRollout() {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.Errorf("cannot run plan checks because plan %q already has a rollout", plan.Name))
+	}
 	var databaseGroup *v1pb.DatabaseGroup
 	for _, spec := range plan.Config.GetSpecs() {
 		if c, ok := spec.Config.(*storepb.PlanConfig_Spec_ChangeDatabaseConfig); ok {

--- a/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ChecksSection.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/Sidebar/ChecksSection.vue
@@ -66,6 +66,9 @@ const isRunningChecks = ref(false);
 const selectedResultStatus = ref<Advice_Level | undefined>(undefined);
 
 const allowRunChecks = computed(() => {
+  // Once a rollout exists, the plan is frozen — re-running checks produces
+  // the same result and is misleading for the user.
+  if (plan.value.hasRollout) return false;
   const me = currentUser.value;
   if (extractUserEmail(plan.value.creator) === me.email) {
     return true;

--- a/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
+++ b/frontend/src/components/Plan/components/PlanCheckSection/PlanCheckSection.vue
@@ -120,6 +120,9 @@ const shouldShow = computed(() => {
 const allowRunChecks = computed(() => {
   if (plan.value.state === State.DELETED) return false;
   if (issue.value && issue.value.status !== IssueStatus.OPEN) return false;
+  // Once a rollout exists, the plan is frozen — re-running checks produces
+  // the same result and is misleading for the user.
+  if (plan.value.hasRollout) return false;
   const me = currentUser.value;
   if (extractUserEmail(plan.value.creator) === me.email) {
     return true;

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1429,7 +1429,7 @@
     "refresh-indicator": {
       "last-refresh": "Last refresh: {time}"
     },
-    "run": "Run check",
+    "run": "Run checks",
     "select-isolation-level": "Select isolation level",
     "select-targets": "Select Targets",
     "sidebar": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1429,7 +1429,7 @@
     "refresh-indicator": {
       "last-refresh": "Última actualización: {time}"
     },
-    "run": "Ejecutar verificación",
+    "run": "Volver a verificar",
     "select-isolation-level": "Seleccionar nivel de aislamiento",
     "select-targets": "Seleccionar objetivos",
     "sidebar": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1429,7 +1429,7 @@
     "refresh-indicator": {
       "last-refresh": "最終更新: {time}"
     },
-    "run": "チェックを実行",
+    "run": "再チェック",
     "select-isolation-level": "分離レベルを選択",
     "select-targets": "ターゲットを選択",
     "sidebar": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1429,7 +1429,7 @@
     "refresh-indicator": {
       "last-refresh": "Làm mới lần cuối: {time}"
     },
-    "run": "Chạy kiểm tra",
+    "run": "Kiểm tra lại",
     "select-isolation-level": "Chọn mức độ cô lập",
     "select-targets": "Chọn mục tiêu",
     "sidebar": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1429,7 +1429,7 @@
     "refresh-indicator": {
       "last-refresh": "上次刷新：{time}"
     },
-    "run": "运行检查",
+    "run": "重新检查",
     "select-isolation-level": "选择隔离级别",
     "select-targets": "选择目标库",
     "sidebar": {

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -1299,7 +1299,7 @@
   "plan.options.self": "Options",
   "plan.overview.no-checks": "No checks",
   "plan.ready-for-review": "Ready for Review",
-  "plan.run": "Run",
+  "plan.run": "Run checks",
   "plan.select-isolation-level": "Select isolation level",
   "plan.spec.change": "Change",
   "plan.spec.type.database-change": "Database Change",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -1299,7 +1299,7 @@
   "plan.options.self": "Opciones",
   "plan.overview.no-checks": "No checks",
   "plan.ready-for-review": "Ready for Review",
-  "plan.run": "Run",
+  "plan.run": "Volver a verificar",
   "plan.select-isolation-level": "Seleccionar nivel de aislamiento",
   "plan.spec.change": "Change",
   "plan.spec.type.database-change": "Cambio de base de datos",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -1299,7 +1299,7 @@
   "plan.options.self": "オプション",
   "plan.overview.no-checks": "No checks",
   "plan.ready-for-review": "Ready for Review",
-  "plan.run": "Run",
+  "plan.run": "再チェック",
   "plan.select-isolation-level": "分離レベルを選択",
   "plan.spec.change": "Change",
   "plan.spec.type.database-change": "データベース変更",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -1299,7 +1299,7 @@
   "plan.options.self": "Tùy chọn",
   "plan.overview.no-checks": "No checks",
   "plan.ready-for-review": "Ready for Review",
-  "plan.run": "Run",
+  "plan.run": "Kiểm tra lại",
   "plan.select-isolation-level": "Chọn mức độ cô lập",
   "plan.spec.change": "Change",
   "plan.spec.type.database-change": "Thay đổi cơ sở dữ liệu",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -1299,7 +1299,7 @@
   "plan.options.self": "配置项",
   "plan.overview.no-checks": "没有检查",
   "plan.ready-for-review": "准备提交评审",
-  "plan.run": "运行",
+  "plan.run": "重新检查",
   "plan.select-isolation-level": "选择隔离级别",
   "plan.spec.change": "Change",
   "plan.spec.type.database-change": "数据库变更",

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailChecks.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailChecks.tsx
@@ -76,6 +76,11 @@ export function IssueDetailChecks() {
     if (!page.plan) {
       return false;
     }
+    // Once a rollout exists, the plan is frozen — re-running checks produces
+    // the same result and is misleading for the user.
+    if (page.plan.hasRollout) {
+      return false;
+    }
     if (extractUserEmail(page.plan.creator) === currentUser.email) {
       return true;
     }


### PR DESCRIPTION
## Summary

- Rename the plan-checks **Run** button across all 10 locales to clearly mean *re-run checks* rather than *execute SQL* — fixes BYT-8819 follow-up, and closes the gap in `frontend/src/react/locales/` where the prior fix (PR #19200) never made it.
- Hide the button in both Vue (`PlanCheckSection.vue`, `ChecksSection.vue`) and React (`IssueDetailChecks.tsx`) once the plan has a rollout; re-running checks is a no-op when the plan is frozen and misleads users.
- Enforce the same rule on the backend: `PlanService.RunPlanChecks` now returns `FailedPrecondition` when `plan.Config.HasRollout`, so scripted or stale clients can't bypass the UI guard.

Wording (key `plan.run`):

| Locale | Before (Vue / React) | After |
|---|---|---|
| en-US | `Run check` / `Run` | `Run checks` |
| zh-CN | `运行检查` / `运行` | `重新检查` |
| ja-JP | `チェックを実行` / `Run` | `再チェック` |
| es-ES | `Ejecutar verificación` / `Run` | `Volver a verificar` |
| vi-VN | `Chạy kiểm tra` / `Run` | `Kiểm tra lại` |

## Breaking Changes

- `PlanService.RunPlanChecks` previously succeeded for plans that had a rollout; it now returns `FailedPrecondition` with message `cannot run plan checks because plan %q already has a rollout`. Any external client or script that depended on re-running plan checks after the rollout was created will need to remove that call (the previous call was effectively a no-op for gating decisions — the plan is frozen).

## Test plan

- [x] `pnpm --dir frontend check` — Biome, ESLint, React i18n cross-locale consistency, locale key sort all pass
- [x] `pnpm --dir frontend type-check` — `vue-tsc` and `tsc --project tsconfig.react.json` clean
- [x] `gofmt -w` and `golangci-lint run --allow-parallel-runners ./backend/api/v1/...` — 0 issues
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go` — clean build
- [ ] Manual: open a plan before deploy, verify button reads the new wording in each locale and triggers plan checks
- [ ] Manual: deploy the plan (creates rollout), verify the button disappears in plan detail sidebar, issue review sidebar, and React issue-detail view
- [ ] Manual: with a rollout present, call `RunPlanChecks` via the API and confirm `FailedPrecondition` is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)