### PR TITLE
chore(frontend): add shadcn cli config

### DIFF
--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "base-nova",
+  "rsc": false,
+  "tsx": true,
+  "iconLibrary": "lucide",
+  "tailwind": {
+    "config": "",
+    "css": "src/assets/css/tailwind.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/react/components",
+    "ui": "@/react/components/ui",
+    "utils": "@/react/lib/utils",
+    "lib": "@/react/lib",
+    "hooks": "@/react/hooks"
+  }
+}

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -18,6 +18,8 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "lib": ["ES2025", "DOM", "DOM.Iterable"],
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "paths": {
       "@/*": ["./src/*"]
     },

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,4 +1,11 @@
 {
+  "compilerOptions": {
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
   "files": [],
   "references": [
     {

--- a/frontend/tsconfig.react.json
+++ b/frontend/tsconfig.react.json
@@ -3,6 +3,8 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2025", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
     "jsxImportSource": "react",


### PR DESCRIPTION
## Summary
- add a minimal `frontend/components.json` so shadcn CLI can detect the existing React UI layer
- add the frontend `@/*` alias at the root tsconfig level so shadcn CLI resolves paths from `frontend/`
- add `baseUrl` and `ignoreDeprecations: "6.0"` to the frontend app/react tsconfigs so TypeScript 6 accepts the alias config

## Test Plan
- [x] pnpm --dir frontend fix
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test
