### PR TITLE
fix(frontend): unify react table zebra striping

### DIFF
--- a/frontend/src/react/components/database/DatabaseTable.tsx
+++ b/frontend/src/react/components/database/DatabaseTable.tsx
@@ -18,7 +18,6 @@ import {
   useSessionPageSize,
 } from "@/react/hooks/useSessionPageSize";
 import { useVueState } from "@/react/hooks/useVueState";
-import { cn } from "@/react/lib/utils";
 import { router } from "@/router";
 import { useActuatorV1Store, useDatabaseV1Store } from "@/store";
 import type { DatabaseFilter } from "@/store/modules/v1/database";
@@ -291,16 +290,13 @@ export function DatabaseTable({
                   </TableCell>
                 </TableRow>
               ) : (
-                databases.map((db, i) => {
+                databases.map((db) => {
                   const isSelected = selectedNames?.has(db.name) ?? false;
                   const instanceResource = getInstanceResource(db);
                   return (
                     <TableRow
                       key={db.name}
-                      className={cn(
-                        "cursor-pointer",
-                        i % 2 === 1 && "bg-gray-50/50"
-                      )}
+                      className="cursor-pointer"
                       onClick={(e) => handleRowClick(db, e)}
                     >
                       {showSelection && (

--- a/frontend/src/react/components/ui/table.test.tsx
+++ b/frontend/src/react/components/ui/table.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { TableBody, TableRow } from "./table";
+
+describe("table primitives", () => {
+  test("TableBody stripes rows by default", () => {
+    const element = TableBody({ children: null });
+
+    expect(element.props.className).toContain(
+      "[&_tr:nth-child(even)]:bg-control-bg/50"
+    );
+  });
+
+  test("TableBody can disable striping", () => {
+    const element = TableBody({ children: null, striped: false });
+
+    expect(element.props.className).not.toContain(
+      "[&_tr:nth-child(even)]:bg-control-bg/50"
+    );
+  });
+
+  test("TableRow can opt out of striping", () => {
+    const element = TableRow({ children: null, striped: false });
+
+    expect(element.props["data-striped"]).toBe("false");
+    expect(element.props.className).toContain("!bg-transparent");
+  });
+});

--- a/frontend/src/react/components/ui/table.tsx
+++ b/frontend/src/react/components/ui/table.tsx
@@ -18,17 +18,34 @@ function TableHeader({
   return <thead className={cn("[&_tr]:border-b", className)} {...props} />;
 }
 
-function TableBody({ className, ...props }: ComponentPropsWithoutRef<"tbody">) {
+interface TableBodyProps extends ComponentPropsWithoutRef<"tbody"> {
+  striped?: boolean;
+}
+
+function TableBody({ className, striped = true, ...props }: TableBodyProps) {
   return (
-    <tbody className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+    <tbody
+      className={cn(
+        "[&_tr:last-child]:border-0",
+        striped && "[&_tr:nth-child(even)]:bg-control-bg/50",
+        className
+      )}
+      {...props}
+    />
   );
 }
 
-function TableRow({ className, ...props }: ComponentPropsWithoutRef<"tr">) {
+interface TableRowProps extends ComponentPropsWithoutRef<"tr"> {
+  striped?: boolean;
+}
+
+function TableRow({ className, striped = true, ...props }: TableRowProps) {
   return (
     <tr
+      data-striped={striped ? undefined : "false"}
       className={cn(
-        "border-b border-block-border transition-colors hover:bg-control-bg/60 data-[state=selected]:bg-control-bg",
+        "border-b border-block-border transition-colors hover:bg-control-bg/60 data-[state=selected]:!bg-control-bg",
+        !striped && "!bg-transparent",
         className
       )}
       {...props}

--- a/frontend/src/react/pages/project/database-detail/changelog/DatabaseChangelogTable.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/changelog/DatabaseChangelogTable.test.tsx
@@ -1,0 +1,88 @@
+import { create } from "@bufbuild/protobuf";
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ChangelogSchema } from "@/types/proto-es/v1/database_service_pb";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/router", () => ({
+  router: {
+    push: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils/v1/changelog", () => ({
+  changelogLink: () => "/projects/p1/databases/d1/changelogs/1",
+}));
+
+vi.mock("@/types", () => ({
+  getDateForPbTimestampProtoEs: () => new Date("2026-04-15T00:00:00Z"),
+}));
+
+vi.mock("@/utils", () => ({
+  humanizeDate: () => "Apr 15, 2026",
+}));
+
+import { DatabaseChangelogTable } from "./DatabaseChangelogTable";
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  return {
+    container,
+    render: () => {
+      act(() => {
+        root.render(element);
+      });
+    },
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
+};
+
+const makeChangelog = (name: string) =>
+  create(ChangelogSchema, {
+    name,
+    planTitle: `Plan ${name}`,
+  });
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("DatabaseChangelogTable", () => {
+  test("inherits default zebra striping from shared table primitives", () => {
+    const { container, render, unmount } = renderIntoContainer(
+      <DatabaseChangelogTable
+        loading={false}
+        changelogs={[
+          makeChangelog("changelogs/1"),
+          makeChangelog("changelogs/2"),
+        ]}
+      />
+    );
+
+    render();
+
+    const tbody = container.querySelector("tbody");
+
+    expect(tbody?.className).toContain(
+      "[&_tr:nth-child(even)]:bg-control-bg/50"
+    );
+
+    unmount();
+  });
+});

--- a/frontend/src/react/pages/project/database-detail/changelog/DatabaseChangelogTable.tsx
+++ b/frontend/src/react/pages/project/database-detail/changelog/DatabaseChangelogTable.tsx
@@ -1,6 +1,14 @@
 import { Check } from "lucide-react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { router } from "@/router";
 import { getDateForPbTimestampProtoEs } from "@/types";
 import {
@@ -69,52 +77,52 @@ export function DatabaseChangelogTable({
 
   return (
     <div className="overflow-hidden rounded border border-block-border">
-      <table className="min-w-full divide-y divide-block-border">
-        <thead className="bg-control-bg">
-          <tr className="text-left text-sm text-control-light">
-            <th className="w-12 px-4 py-2" />
-            <th className="w-[180px] px-4 py-2 font-medium">
+      <Table className="min-w-full">
+        <TableHeader className="bg-control-bg">
+          <TableRow className="text-left text-sm text-control-light hover:bg-control-bg">
+            <TableHead className="w-12" />
+            <TableHead className="w-[180px]">
               {t("common.created-at")}
-            </th>
-            <th className="min-w-[200px] px-4 py-2 font-medium">
+            </TableHead>
+            <TableHead className="min-w-[200px]">
               {t("common.rollout")}
-            </th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-block-border bg-background">
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {changelogs.map((changelog) => (
-            <tr
+            <TableRow
               key={changelog.name}
               className="cursor-pointer hover:bg-control-bg"
               onClick={(e) => handleRowClick(changelog, e)}
             >
-              <td className="px-4 py-3 text-center">
+              <TableCell className="text-center">
                 <ChangelogStatusIcon status={changelog.status} />
-              </td>
-              <td className="px-4 py-3 text-sm text-main">
+              </TableCell>
+              <TableCell className="text-main">
                 {getDateForPbTimestampProtoEs(changelog.createTime)
                   ? humanizeDate(
                       getDateForPbTimestampProtoEs(changelog.createTime) as Date
                     )
                   : "-"}
-              </td>
-              <td className="truncate px-4 py-3 text-sm text-main">
+              </TableCell>
+              <TableCell className="truncate text-main">
                 {changelog.planTitle || "-"}
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           ))}
           {changelogs.length === 0 && (
-            <tr>
-              <td
-                className="px-4 py-6 text-center text-sm text-control-light"
+            <TableRow striped={false}>
+              <TableCell
+                className="py-6 text-center text-control-light"
                 colSpan={3}
               >
                 {t("common.no-data")}
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           )}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }

--- a/frontend/src/react/pages/settings/GroupsPage.tsx
+++ b/frontend/src/react/pages/settings/GroupsPage.tsx
@@ -267,7 +267,7 @@ function GroupTable({
             <TableHead className="text-right whitespace-nowrap w-16" />
           </TableRow>
         </TableHeader>
-        <TableBody>
+        <TableBody striped={false}>
           {groups.map((group, i) => {
             const isExpanded = expandedGroups.has(group.name);
             const members = memberCache.get(group.name);

--- a/frontend/src/react/pages/settings/UsersPage.tsx
+++ b/frontend/src/react/pages/settings/UsersPage.tsx
@@ -244,7 +244,7 @@ function UserTable({
           </TableRow>
         </TableHeader>
         <TableBody>
-          {users.map((user, i) => {
+          {users.map((user) => {
             const accountType = getAccountTypeByEmail(user.email);
             const isDeleted = user.state === State.DELETED;
             const isSelf = currentUser.name === user.name;
@@ -253,7 +253,6 @@ function UserTable({
               <TableRow
                 key={user.name}
                 className={cn(
-                  i % 2 === 1 && "bg-control-bg/50",
                   hasWorkspacePermissionV2(getViewPermission(accountType)) &&
                     "cursor-pointer hover:bg-control-bg focus-visible:outline-none focus-visible:bg-control-bg"
                 )}


### PR DESCRIPTION
## Summary
- default zebra striping in the shared React table primitives
- add striped opt-outs for tables or rows that should stay plain
- remove duplicate zebra styling from DatabaseTable and add regression coverage

## Test Plan
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test -- src/react/components/ui/table.test.tsx
