### PR TITLE
fix(frontend): flip portal combobox near viewport edge

### DIFF
--- a/frontend/src/react/components/ui/combobox-position.test.ts
+++ b/frontend/src/react/components/ui/combobox-position.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { getPortalDropdownStyle } from "./combobox-position";
+
+describe("getPortalDropdownStyle", () => {
+  test("opens upward when there is not enough room below", () => {
+    expect(
+      getPortalDropdownStyle(
+        {
+          top: 700,
+          left: 80,
+          width: 220,
+          bottom: 736,
+        },
+        240,
+        800
+      )
+    ).toEqual({
+      position: "fixed",
+      left: 80,
+      width: 220,
+      bottom: 104,
+    });
+  });
+
+  test("keeps the dropdown below when there is enough room", () => {
+    expect(
+      getPortalDropdownStyle(
+        {
+          top: 120,
+          left: 24,
+          width: 180,
+          bottom: 156,
+        },
+        240,
+        800
+      )
+    ).toEqual({
+      position: "fixed",
+      left: 24,
+      width: 180,
+      top: 160,
+    });
+  });
+});

--- a/frontend/src/react/components/ui/combobox-position.test.ts
+++ b/frontend/src/react/components/ui/combobox-position.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { getPortalDropdownStyle } from "./combobox-position";
+import {
+  getPortalDropdownStyle,
+  isPortalDropdownStyleEqual,
+  shouldIgnorePortalDropdownScroll,
+} from "./combobox-position";
 
 describe("getPortalDropdownStyle", () => {
   test("opens upward when there is not enough room below", () => {
@@ -40,5 +44,54 @@ describe("getPortalDropdownStyle", () => {
       width: 180,
       top: 160,
     });
+  });
+
+  test("ignores scroll events that originate from the dropdown itself", () => {
+    const dropdown = document.createElement("div");
+    const optionList = document.createElement("div");
+    dropdown.appendChild(optionList);
+
+    expect(shouldIgnorePortalDropdownScroll(optionList, dropdown)).toBe(true);
+    expect(shouldIgnorePortalDropdownScroll(dropdown, dropdown)).toBe(true);
+    expect(
+      shouldIgnorePortalDropdownScroll(document.createElement("div"), dropdown)
+    ).toBe(false);
+    expect(shouldIgnorePortalDropdownScroll(null, dropdown)).toBe(false);
+  });
+
+  test("treats equivalent portal dropdown styles as unchanged", () => {
+    expect(
+      isPortalDropdownStyleEqual(
+        {
+          position: "fixed",
+          left: 24,
+          width: 180,
+          top: 160,
+        },
+        {
+          position: "fixed",
+          left: 24,
+          width: 180,
+          top: 160,
+        }
+      )
+    ).toBe(true);
+
+    expect(
+      isPortalDropdownStyleEqual(
+        {
+          position: "fixed",
+          left: 24,
+          width: 180,
+          top: 160,
+        },
+        {
+          position: "fixed",
+          left: 24,
+          width: 180,
+          bottom: 104,
+        }
+      )
+    ).toBe(false);
   });
 });

--- a/frontend/src/react/components/ui/combobox-position.ts
+++ b/frontend/src/react/components/ui/combobox-position.ts
@@ -1,0 +1,23 @@
+const DROPDOWN_OFFSET = 4;
+
+function getPortalDropdownStyle(
+  triggerRect: Pick<DOMRect, "top" | "left" | "width" | "bottom">,
+  dropdownHeight: number,
+  viewportHeight: number
+): React.CSSProperties {
+  const availableBelow = viewportHeight - triggerRect.bottom - DROPDOWN_OFFSET;
+  const availableAbove = triggerRect.top - DROPDOWN_OFFSET;
+  const shouldOpenUpward =
+    availableBelow < dropdownHeight && availableAbove > availableBelow;
+
+  return {
+    position: "fixed",
+    left: triggerRect.left,
+    width: triggerRect.width,
+    ...(shouldOpenUpward
+      ? { bottom: viewportHeight - triggerRect.top + DROPDOWN_OFFSET }
+      : { top: triggerRect.bottom + DROPDOWN_OFFSET }),
+  };
+}
+
+export { DROPDOWN_OFFSET, getPortalDropdownStyle };

--- a/frontend/src/react/components/ui/combobox-position.ts
+++ b/frontend/src/react/components/ui/combobox-position.ts
@@ -1,5 +1,12 @@
 const DROPDOWN_OFFSET = 4;
 
+function shouldIgnorePortalDropdownScroll(
+  target: EventTarget | null,
+  dropdownElement: HTMLElement | null
+): boolean {
+  return target instanceof Node && dropdownElement?.contains(target) === true;
+}
+
 function getPortalDropdownStyle(
   triggerRect: Pick<DOMRect, "top" | "left" | "width" | "bottom">,
   dropdownHeight: number,
@@ -20,4 +27,22 @@ function getPortalDropdownStyle(
   };
 }
 
-export { DROPDOWN_OFFSET, getPortalDropdownStyle };
+function isPortalDropdownStyleEqual(
+  previous: React.CSSProperties,
+  next: React.CSSProperties
+): boolean {
+  return (
+    previous.position === next.position &&
+    previous.left === next.left &&
+    previous.width === next.width &&
+    previous.top === next.top &&
+    previous.bottom === next.bottom
+  );
+}
+
+export {
+  DROPDOWN_OFFSET,
+  getPortalDropdownStyle,
+  isPortalDropdownStyleEqual,
+  shouldIgnorePortalDropdownScroll,
+};

--- a/frontend/src/react/components/ui/combobox.tsx
+++ b/frontend/src/react/components/ui/combobox.tsx
@@ -10,6 +10,7 @@ import {
 import { createPortal } from "react-dom";
 import { cn } from "@/react/lib/utils";
 import { HighlightLabelText } from "../HighlightLabelText";
+import { getPortalDropdownStyle } from "./combobox-position";
 import { getLayerRoot, LAYER_SURFACE_CLASS } from "./layer";
 import { SearchInput } from "./search-input";
 
@@ -112,19 +113,6 @@ export function Combobox(props: ComboboxProps) {
     [allOptions, selectedValues]
   );
 
-  // Position dropdown for portal mode — useLayoutEffect prevents a
-  // one-frame flash at a stale/empty position before the browser paints.
-  useLayoutEffect(() => {
-    if (!open || !portal || !containerRef.current) return;
-    const rect = containerRef.current.getBoundingClientRect();
-    setDropdownStyle({
-      position: "fixed",
-      top: rect.bottom + 4,
-      left: rect.left,
-      width: rect.width,
-    });
-  }, [open, portal]);
-
   // Debounced server-side search
   useEffect(() => {
     if (!onSearch || !open) return;
@@ -153,6 +141,30 @@ export function Combobox(props: ComboboxProps) {
       }))
       .filter((g) => g.options.length > 0);
   }, [options, search, onSearch]);
+
+  // Position dropdown for portal mode — useLayoutEffect prevents a
+  // one-frame flash at a stale/empty position before the browser paints.
+  useLayoutEffect(() => {
+    if (!open || !portal || !containerRef.current) return;
+
+    const updateDropdownPosition = () => {
+      if (!containerRef.current) return;
+      const rect = containerRef.current.getBoundingClientRect();
+      const dropdownHeight = dropdownRef.current?.offsetHeight ?? 0;
+      setDropdownStyle(
+        getPortalDropdownStyle(rect, dropdownHeight, window.innerHeight)
+      );
+    };
+
+    updateDropdownPosition();
+    window.addEventListener("resize", updateDropdownPosition);
+    window.addEventListener("scroll", updateDropdownPosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updateDropdownPosition);
+      window.removeEventListener("scroll", updateDropdownPosition, true);
+    };
+  }, [open, portal, filteredGroups]);
 
   // Click outside (handles both container and portal dropdown)
   useEffect(() => {

--- a/frontend/src/react/components/ui/combobox.tsx
+++ b/frontend/src/react/components/ui/combobox.tsx
@@ -10,7 +10,11 @@ import {
 import { createPortal } from "react-dom";
 import { cn } from "@/react/lib/utils";
 import { HighlightLabelText } from "../HighlightLabelText";
-import { getPortalDropdownStyle } from "./combobox-position";
+import {
+  getPortalDropdownStyle,
+  isPortalDropdownStyleEqual,
+  shouldIgnorePortalDropdownScroll,
+} from "./combobox-position";
 import { getLayerRoot, LAYER_SURFACE_CLASS } from "./layer";
 import { SearchInput } from "./search-input";
 
@@ -151,18 +155,32 @@ export function Combobox(props: ComboboxProps) {
       if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       const dropdownHeight = dropdownRef.current?.offsetHeight ?? 0;
-      setDropdownStyle(
-        getPortalDropdownStyle(rect, dropdownHeight, window.innerHeight)
+      const nextStyle = getPortalDropdownStyle(
+        rect,
+        dropdownHeight,
+        window.innerHeight
       );
+      setDropdownStyle((previousStyle) =>
+        isPortalDropdownStyleEqual(previousStyle, nextStyle)
+          ? previousStyle
+          : nextStyle
+      );
+    };
+
+    const handleScroll = (event: Event) => {
+      if (shouldIgnorePortalDropdownScroll(event.target, dropdownRef.current)) {
+        return;
+      }
+      updateDropdownPosition();
     };
 
     updateDropdownPosition();
     window.addEventListener("resize", updateDropdownPosition);
-    window.addEventListener("scroll", updateDropdownPosition, true);
+    window.addEventListener("scroll", handleScroll, true);
 
     return () => {
       window.removeEventListener("resize", updateDropdownPosition);
-      window.removeEventListener("scroll", updateDropdownPosition, true);
+      window.removeEventListener("scroll", handleScroll, true);
     };
   }, [open, portal, filteredGroups]);
 


### PR DESCRIPTION
## Summary
- flip shared portal combobox dropdowns upward when there is not enough viewport space below the trigger
- keep the combobox aligned with the overlay layer root used by the latest React overlay changes
- add focused placement tests for above/below positioning behavior

## Test Plan
- [x] pnpm --dir frontend test src/react/components/ui/combobox-position.test.ts
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check