### PR TITLE
fix(frontend): stabilize environment page selection effects

### DIFF
--- a/frontend/src/react/pages/settings/EnvironmentsPage.tsx
+++ b/frontend/src/react/pages/settings/EnvironmentsPage.tsx
@@ -96,6 +96,10 @@ import {
   hexToRgb,
   sqlReviewPolicySlug,
 } from "@/utils";
+import {
+  getEnvironmentListKey,
+  resolveSelectedEnvironmentId,
+} from "./environmentSelection";
 
 // ============================================================
 // EnvironmentName - displays env name with color badge
@@ -1419,6 +1423,7 @@ export function EnvironmentsPage() {
   const environmentList = useVueState(() => [
     ...environmentStore.environmentList,
   ]);
+  const environmentListKey = getEnvironmentListKey(environmentList);
 
   const [selectedId, setSelectedId] = useState("");
   const [showCreate, setShowCreate] = useState(false);
@@ -1443,19 +1448,14 @@ export function EnvironmentsPage() {
   // Select from hash or default to first
   useEffect(() => {
     const hash = window.location.hash.slice(1);
-    if (environmentList.length > 0) {
-      const found = environmentList.find((e) => e.id === hash);
-      if (found) {
-        setSelectedId(found.id);
-      } else {
-        setSelectedId((prev) =>
-          prev && environmentList.find((e) => e.id === prev)
-            ? prev
-            : environmentList[0].id
-        );
-      }
-    }
-  }, [environmentList]);
+    setSelectedId((currentId) =>
+      resolveSelectedEnvironmentId({
+        currentId,
+        environmentList,
+        hash,
+      })
+    );
+  }, [environmentListKey]);
 
   // Listen for hash changes
   useEffect(() => {
@@ -1473,7 +1473,7 @@ export function EnvironmentsPage() {
     };
     window.addEventListener("hashchange", onHashChange);
     return () => window.removeEventListener("hashchange", onHashChange);
-  }, [environmentList, t]);
+  }, [environmentListKey, t]);
 
   // Guard browser refresh/close
   useEffect(() => {

--- a/frontend/src/react/pages/settings/environmentSelection.test.tsx
+++ b/frontend/src/react/pages/settings/environmentSelection.test.tsx
@@ -1,0 +1,121 @@
+import { act, useEffect, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  type EnvironmentSelectionItem,
+  getEnvironmentListKey,
+  resolveSelectedEnvironmentId,
+} from "./environmentSelection";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const createEnvironment = (id: string): EnvironmentSelectionItem => ({
+  id,
+});
+
+function Harness({
+  environments,
+  hash,
+}: {
+  environments: EnvironmentSelectionItem[];
+  hash: string;
+}) {
+  const [selectedId, setSelectedId] = useState("");
+  const environmentListKey = getEnvironmentListKey(environments);
+
+  useEffect(() => {
+    setSelectedId((currentId) =>
+      resolveSelectedEnvironmentId({
+        currentId,
+        environmentList: environments,
+        hash,
+      })
+    );
+  }, [environmentListKey, hash]);
+
+  return <div data-selected-id={selectedId}>{selectedId}</div>;
+}
+
+describe("environmentSelection", () => {
+  let container: HTMLDivElement | undefined;
+  let root: Root | undefined;
+
+  afterEach(() => {
+    if (root) {
+      act(() => {
+        root?.unmount();
+      });
+    }
+    container?.remove();
+    container = undefined;
+    root = undefined;
+  });
+
+  test("returns the same key for equivalent environment ids", () => {
+    expect(getEnvironmentListKey([createEnvironment("prod")])).toEqual(
+      getEnvironmentListKey([createEnvironment("prod")])
+    );
+    expect(
+      getEnvironmentListKey([
+        createEnvironment("prod"),
+        createEnvironment("dev"),
+      ])
+    ).not.toEqual(
+      getEnvironmentListKey([
+        createEnvironment("dev"),
+        createEnvironment("prod"),
+      ])
+    );
+  });
+
+  test("keeps the current selection when the hash is missing", () => {
+    expect(
+      resolveSelectedEnvironmentId({
+        currentId: "prod",
+        environmentList: [createEnvironment("dev"), createEnvironment("prod")],
+        hash: "",
+      })
+    ).toBe("prod");
+  });
+
+  test("prefers a valid hash and falls back to the first environment", () => {
+    expect(
+      resolveSelectedEnvironmentId({
+        currentId: "",
+        environmentList: [createEnvironment("dev"), createEnvironment("prod")],
+        hash: "prod",
+      })
+    ).toBe("prod");
+
+    expect(
+      resolveSelectedEnvironmentId({
+        currentId: "missing",
+        environmentList: [createEnvironment("dev"), createEnvironment("prod")],
+        hash: "unknown",
+      })
+    ).toBe("dev");
+  });
+
+  test("stabilizes selection when the list identity changes without id changes", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    expect(() => {
+      act(() => {
+        root?.render(
+          <Harness environments={[createEnvironment("prod")]} hash="" />
+        );
+      });
+      act(() => {
+        root?.render(
+          <Harness environments={[createEnvironment("prod")]} hash="" />
+        );
+      });
+    }).not.toThrow();
+
+    expect(container.textContent).toBe("prod");
+  });
+});

--- a/frontend/src/react/pages/settings/environmentSelection.ts
+++ b/frontend/src/react/pages/settings/environmentSelection.ts
@@ -1,0 +1,37 @@
+export type EnvironmentSelectionItem = {
+  id: string;
+};
+
+export const getEnvironmentListKey = (
+  environmentList: EnvironmentSelectionItem[]
+): string => environmentList.map((environment) => environment.id).join("\0");
+
+export const resolveSelectedEnvironmentId = ({
+  currentId,
+  environmentList,
+  hash,
+}: {
+  currentId: string;
+  environmentList: EnvironmentSelectionItem[];
+  hash: string;
+}): string => {
+  if (environmentList.length === 0) {
+    return "";
+  }
+
+  const hashMatch = hash
+    ? environmentList.find((environment) => environment.id === hash)
+    : undefined;
+  if (hashMatch) {
+    return hashMatch.id;
+  }
+
+  if (
+    currentId &&
+    environmentList.some((environment) => environment.id === currentId)
+  ) {
+    return currentId;
+  }
+
+  return environmentList[0].id;
+};


### PR DESCRIPTION
## Summary
- stabilize environment selection on the React environments settings page by keying selection effects off environment ids instead of array identity
- extract the tab selection fallback logic into a small helper so hash-based selection and fallback behavior stay consistent
- add a regression test that covers equivalent list identities and the hash/current-selection fallback cases

## Test Plan
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test
