### PR TITLE
fix(frontend): preserve distinct project role bindings

### DIFF
--- a/frontend/src/components/Member/MemberDataTable/cells/UserRolesCell.vue
+++ b/frontend/src/components/Member/MemberDataTable/cells/UserRolesCell.vue
@@ -20,10 +20,10 @@
 
 <script lang="ts" setup>
 import { create } from "@bufbuild/protobuf";
-import { orderBy } from "lodash-es";
 import { computed } from "vue";
-import { type Binding, BindingSchema } from "@/types/proto-es/v1/iam_policy_pb";
-import { isBindingPolicyExpired, sortRoles } from "@/utils";
+import { BindingSchema } from "@/types/proto-es/v1/iam_policy_pb";
+import { sortRoles } from "@/utils";
+import { getUniqueProjectRoleBindings } from "../../projectRoleBindings";
 import type { MemberRole } from "../../types";
 import RoleCell from "./RoleCell.vue";
 
@@ -36,23 +36,6 @@ const workspaceLevelRoles = computed(() => {
 });
 
 const projectRoleBindings = computed(() => {
-  const roleMap = new Map<string, { expired: boolean; binding: Binding }>();
-  for (const binding of props.role.projectRoleBindings) {
-    const isExpired = isBindingPolicyExpired(binding);
-    if (
-      !roleMap.has(binding.role) ||
-      (roleMap.get(binding.role)?.expired && !isExpired)
-    ) {
-      roleMap.set(binding.role, {
-        expired: isExpired,
-        binding,
-      });
-    }
-  }
-
-  return orderBy(
-    [...roleMap.values()].map((item) => item.binding),
-    ["role"]
-  );
+  return getUniqueProjectRoleBindings(props.role.projectRoleBindings);
 });
 </script>

--- a/frontend/src/components/Member/MemberDataTable/cells/UserRolesCell.vue
+++ b/frontend/src/components/Member/MemberDataTable/cells/UserRolesCell.vue
@@ -10,8 +10,8 @@
       :scope="'workspace'"
     />
     <RoleCell
-      v-for="binding in projectRoleBindings"
-      :key="binding.role"
+      v-for="(binding, index) in projectRoleBindings"
+      :key="getProjectRoleBindingKey(binding, index)"
       :bordered="true"
       :binding="binding" :scope="'project'"
     />
@@ -23,7 +23,7 @@ import { create } from "@bufbuild/protobuf";
 import { computed } from "vue";
 import { BindingSchema } from "@/types/proto-es/v1/iam_policy_pb";
 import { sortRoles } from "@/utils";
-import { getUniqueProjectRoleBindings } from "../../projectRoleBindings";
+import { getProjectRoleBindingKey } from "../../projectRoleBindings";
 import type { MemberRole } from "../../types";
 import RoleCell from "./RoleCell.vue";
 
@@ -35,7 +35,5 @@ const workspaceLevelRoles = computed(() => {
   return sortRoles([...props.role.workspaceLevelRoles]);
 });
 
-const projectRoleBindings = computed(() => {
-  return getUniqueProjectRoleBindings(props.role.projectRoleBindings);
-});
+const projectRoleBindings = computed(() => props.role.projectRoleBindings);
 </script>

--- a/frontend/src/components/Member/projectRoleBindings.ts
+++ b/frontend/src/components/Member/projectRoleBindings.ts
@@ -1,48 +1,48 @@
-import { orderBy } from "lodash-es";
+import { PRESET_ROLES } from "@/types/iam/role";
 import type { Binding } from "@/types/proto-es/v1/iam_policy_pb";
 
-const getBindingExpirationTimestamp = (
-  binding: Binding
-): number | undefined => {
-  const expression = binding.condition?.expression;
-  if (!expression) {
-    return undefined;
-  }
+export interface ProjectRoleBindingGroup {
+  role: string;
+  bindings: Binding[];
+}
 
-  const match = expression.match(/request\.time\s*<\s*timestamp\("([^"]+)"\)/);
-  if (!match) {
-    return undefined;
-  }
-
-  const timestamp = Date.parse(match[1]);
-  return Number.isNaN(timestamp) ? undefined : timestamp;
+export const getProjectRoleBindingKey = (
+  binding: Binding,
+  index: number
+): string => {
+  return [
+    binding.role,
+    binding.condition?.expression ?? "",
+    binding.condition?.description ?? "",
+    index,
+  ].join("::");
 };
 
-const isBindingExpired = (binding: Binding): boolean => {
-  const expiration = getBindingExpirationTimestamp(binding);
-  return expiration !== undefined && expiration < Date.now();
-};
-
-export const getUniqueProjectRoleBindings = (
+export const groupProjectRoleBindings = (
   bindings: Binding[]
-): Binding[] => {
-  const roleMap = new Map<string, { expired: boolean; binding: Binding }>();
+): ProjectRoleBindingGroup[] => {
+  const roleMap = new Map<string, Binding[]>();
 
   for (const binding of bindings) {
-    const expired = isBindingExpired(binding);
-    if (
-      !roleMap.has(binding.role) ||
-      (roleMap.get(binding.role)?.expired && !expired)
-    ) {
-      roleMap.set(binding.role, {
-        expired,
-        binding,
-      });
+    if (!roleMap.has(binding.role)) {
+      roleMap.set(binding.role, []);
     }
+    roleMap.get(binding.role)?.push(binding);
   }
 
-  return orderBy(
-    [...roleMap.values()].map((item) => item.binding),
-    ["role"]
-  );
+  return [...roleMap.keys()]
+    .sort((a, b) => {
+      const priority = (role: string) => {
+        const presetRoleIndex = PRESET_ROLES.indexOf(role);
+        if (presetRoleIndex !== -1) {
+          return presetRoleIndex;
+        }
+        return PRESET_ROLES.length;
+      };
+      return priority(a) - priority(b);
+    })
+    .map((role) => ({
+      role,
+      bindings: roleMap.get(role) ?? [],
+    }));
 };

--- a/frontend/src/components/Member/projectRoleBindings.ts
+++ b/frontend/src/components/Member/projectRoleBindings.ts
@@ -1,0 +1,48 @@
+import { orderBy } from "lodash-es";
+import type { Binding } from "@/types/proto-es/v1/iam_policy_pb";
+
+const getBindingExpirationTimestamp = (
+  binding: Binding
+): number | undefined => {
+  const expression = binding.condition?.expression;
+  if (!expression) {
+    return undefined;
+  }
+
+  const match = expression.match(/request\.time\s*<\s*timestamp\("([^"]+)"\)/);
+  if (!match) {
+    return undefined;
+  }
+
+  const timestamp = Date.parse(match[1]);
+  return Number.isNaN(timestamp) ? undefined : timestamp;
+};
+
+const isBindingExpired = (binding: Binding): boolean => {
+  const expiration = getBindingExpirationTimestamp(binding);
+  return expiration !== undefined && expiration < Date.now();
+};
+
+export const getUniqueProjectRoleBindings = (
+  bindings: Binding[]
+): Binding[] => {
+  const roleMap = new Map<string, { expired: boolean; binding: Binding }>();
+
+  for (const binding of bindings) {
+    const expired = isBindingExpired(binding);
+    if (
+      !roleMap.has(binding.role) ||
+      (roleMap.get(binding.role)?.expired && !expired)
+    ) {
+      roleMap.set(binding.role, {
+        expired,
+        binding,
+      });
+    }
+  }
+
+  return orderBy(
+    [...roleMap.values()].map((item) => item.binding),
+    ["role"]
+  );
+};

--- a/frontend/src/components/Member/utils.test.ts
+++ b/frontend/src/components/Member/utils.test.ts
@@ -1,0 +1,37 @@
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, test } from "vitest";
+import { ExprSchema as ConditionExprSchema } from "@/types/proto-es/google/type/expr_pb";
+import { BindingSchema } from "@/types/proto-es/v1/iam_policy_pb";
+import { getUniqueProjectRoleBindings } from "./projectRoleBindings";
+
+describe("getUniqueProjectRoleBindings", () => {
+  test("dedupes repeated roles and prefers non-expired bindings", () => {
+    const activeProjectDeveloper = create(BindingSchema, {
+      role: "roles/projectDeveloper",
+      members: ["user:test@example.com"],
+    });
+    const expiredProjectDeveloper = create(BindingSchema, {
+      role: "roles/projectDeveloper",
+      members: ["user:test@example.com"],
+      condition: create(ConditionExprSchema, {
+        expression: 'request.time < timestamp("2000-01-01T00:00:00Z")',
+      }),
+    });
+    const sqlEditorUser = create(BindingSchema, {
+      role: "roles/sqlEditorUser",
+      members: ["user:test@example.com"],
+    });
+
+    const result = getUniqueProjectRoleBindings([
+      expiredProjectDeveloper,
+      activeProjectDeveloper,
+      sqlEditorUser,
+    ]);
+
+    expect(result.map((binding) => binding.role)).toEqual([
+      "roles/projectDeveloper",
+      "roles/sqlEditorUser",
+    ]);
+    expect(result[0].condition?.expression).toBeUndefined();
+  });
+});

--- a/frontend/src/components/Member/utils.test.ts
+++ b/frontend/src/components/Member/utils.test.ts
@@ -2,10 +2,13 @@ import { create } from "@bufbuild/protobuf";
 import { describe, expect, test } from "vitest";
 import { ExprSchema as ConditionExprSchema } from "@/types/proto-es/google/type/expr_pb";
 import { BindingSchema } from "@/types/proto-es/v1/iam_policy_pb";
-import { getUniqueProjectRoleBindings } from "./projectRoleBindings";
+import {
+  getProjectRoleBindingKey,
+  groupProjectRoleBindings,
+} from "./projectRoleBindings";
 
-describe("getUniqueProjectRoleBindings", () => {
-  test("dedupes repeated roles and prefers non-expired bindings", () => {
+describe("groupProjectRoleBindings", () => {
+  test("groups repeated roles without dropping distinct bindings", () => {
     const activeProjectDeveloper = create(BindingSchema, {
       role: "roles/projectDeveloper",
       members: ["user:test@example.com"],
@@ -22,16 +25,32 @@ describe("getUniqueProjectRoleBindings", () => {
       members: ["user:test@example.com"],
     });
 
-    const result = getUniqueProjectRoleBindings([
+    const result = groupProjectRoleBindings([
       expiredProjectDeveloper,
       activeProjectDeveloper,
       sqlEditorUser,
     ]);
 
-    expect(result.map((binding) => binding.role)).toEqual([
+    expect(result.map((group) => group.role)).toEqual([
       "roles/projectDeveloper",
       "roles/sqlEditorUser",
     ]);
-    expect(result[0].condition?.expression).toBeUndefined();
+    expect(result[0].bindings).toEqual([
+      expiredProjectDeveloper,
+      activeProjectDeveloper,
+    ]);
+  });
+});
+
+describe("getProjectRoleBindingKey", () => {
+  test("keeps repeated same-role bindings unique", () => {
+    const binding = create(BindingSchema, {
+      role: "roles/projectDeveloper",
+      members: ["user:test@example.com"],
+    });
+
+    expect(getProjectRoleBindingKey(binding, 0)).not.toEqual(
+      getProjectRoleBindingKey(binding, 1)
+    );
   });
 });

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -22,6 +22,7 @@ import React, {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { getUniqueProjectRoleBindings } from "@/components/Member/projectRoleBindings";
 import type { MemberBinding } from "@/components/Member/types";
 import { getMemberBindings } from "@/components/Member/utils";
 import {
@@ -308,10 +309,10 @@ function MemberTable({
               <td className="px-4 py-2">
                 <div className="flex flex-wrap gap-1">
                   {scope === "project"
-                    ? sortRoles(mb.projectRoleBindings.map((b) => b.role)).map(
-                        (role) => (
-                          <Badge key={role} className="text-xs gap-x-1">
-                            {displayRoleTitle(role)}
+                    ? getUniqueProjectRoleBindings(mb.projectRoleBindings).map(
+                        (binding) => (
+                          <Badge key={binding.role} className="text-xs gap-x-1">
+                            {displayRoleTitle(binding.role)}
                           </Badge>
                         )
                       )
@@ -398,7 +399,9 @@ function MemberTableByRole({
     for (const mb of bindings) {
       const roles =
         scope === "project"
-          ? mb.projectRoleBindings.map((b) => b.role)
+          ? getUniqueProjectRoleBindings(mb.projectRoleBindings).map(
+              (b) => b.role
+            )
           : [...mb.workspaceLevelRoles];
       for (const role of roles) {
         if (!map.has(role)) map.set(role, []);

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -22,7 +22,7 @@ import React, {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { getUniqueProjectRoleBindings } from "@/components/Member/projectRoleBindings";
+import { groupProjectRoleBindings } from "@/components/Member/projectRoleBindings";
 import type { MemberBinding } from "@/components/Member/types";
 import { getMemberBindings } from "@/components/Member/utils";
 import {
@@ -146,6 +146,10 @@ const assertNever = (value: never): never => {
   throw new Error(`Unexpected value: ${String(value)}`);
 };
 
+const getProjectRoleSet = (bindings: Binding[]): string[] => {
+  return [...new Set(bindings.map((binding) => binding.role))];
+};
+
 // ============================================================
 // MemberTable (view by members)
 // ============================================================
@@ -206,6 +210,21 @@ function MemberTable({
 
   const isSelectDisabled = (mb: MemberBinding) => {
     return scope === "project" && mb.projectRoleBindings.length === 0;
+  };
+
+  const renderProjectRoleSummary = (bindings: Binding[]) => {
+    return groupProjectRoleBindings(bindings).map((group) => {
+      return (
+        <Badge key={group.role} className="text-xs gap-x-1">
+          {displayRoleTitle(group.role)}
+          {group.bindings.length > 1 && (
+            <span className="text-control-light">
+              ({group.bindings.length})
+            </span>
+          )}
+        </Badge>
+      );
+    });
   };
 
   return (
@@ -309,13 +328,7 @@ function MemberTable({
               <td className="px-4 py-2">
                 <div className="flex flex-wrap gap-1">
                   {scope === "project"
-                    ? getUniqueProjectRoleBindings(mb.projectRoleBindings).map(
-                        (binding) => (
-                          <Badge key={binding.role} className="text-xs gap-x-1">
-                            {displayRoleTitle(binding.role)}
-                          </Badge>
-                        )
-                      )
+                    ? renderProjectRoleSummary(mb.projectRoleBindings)
                     : sortRoles([...mb.workspaceLevelRoles]).map((role) => (
                         <Badge key={role} className="text-xs gap-x-1">
                           <Building2 className="h-3 w-3" />
@@ -399,9 +412,7 @@ function MemberTableByRole({
     for (const mb of bindings) {
       const roles =
         scope === "project"
-          ? getUniqueProjectRoleBindings(mb.projectRoleBindings).map(
-              (b) => b.role
-            )
+          ? getProjectRoleSet(mb.projectRoleBindings)
           : [...mb.workspaceLevelRoles];
       for (const role of roles) {
         if (!map.has(role)) map.set(role, []);


### PR DESCRIPTION
## Summary
- preserve distinct project role bindings instead of collapsing bindings that share the same role name
- render repeated project-role bindings as a single role badge with a count in the React members table
- use stable per-binding keys in the Vue member role cell and add regression coverage for grouped rendering and key generation

## Test Plan
- [x] pnpm --dir frontend fix
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test
- [x] verify on http://localhost:3001/projects/db333/members that duplicate-key warnings are gone while repeated bindings are still represented
