### PR TITLE
fix: resolve workspace ID before test-connection on instance create

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -165,6 +165,11 @@ func (s *InstanceService) CreateInstance(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
 	}
+	// Set the workspace ID early so that workspace-scoped license checks
+	// (e.g. EXTERNAL_SECRET_MANAGER) work during the ValidateOnly test
+	// connection below, before the instance is persisted.
+	workspaceID := common.GetWorkspaceIDFromContext(ctx)
+	instanceMessage.Workspace = workspaceID
 	if err := s.checkInstanceDataSources(ctx, instanceMessage, instanceMessage.Metadata.GetDataSources()); err != nil {
 		return nil, err
 	}
@@ -197,7 +202,6 @@ func (s *InstanceService) CreateInstance(ctx context.Context, req *connect.Reque
 		return connect.NewResponse(result), nil
 	}
 
-	workspaceID := common.GetWorkspaceIDFromContext(ctx)
 	activatedInstanceLimit := s.licenseService.GetActivatedInstanceLimit(ctx, workspaceID)
 	if instanceMessage.Metadata.GetActivation() {
 		count, err := s.store.GetActivatedInstanceCount(ctx, workspaceID)
@@ -209,7 +213,6 @@ func (s *InstanceService) CreateInstance(ctx context.Context, req *connect.Reque
 		}
 	}
 
-	instanceMessage.Workspace = workspaceID
 	instance, err := s.store.CreateInstance(ctx, instanceMessage)
 	if err != nil {
 		if strings.Contains(err.Error(), "duplicate key") {


### PR DESCRIPTION
## Summary

Fixes [BYT-9278](https://linear.app/bytebase/issue/BYT-9278/adding-instance-using-aws-secrets-manager-not-working) — Test Connection during instance create silently dropped the password resolved from AWS Secrets Manager (and the other external secret backends), producing `Error 1045 (28000): Access denied for user '...' (using password: NO)`.

`CreateInstance` was assigning `instanceMessage.Workspace` only after the `ValidateOnly` test-connection block. With an empty `Workspace`, the workspace-scoped license check inside `dbFactory.GetDataSourceDriver` fell back to the FREE plan via `defaultFreeSubscription`, `IsFeatureEnabledForInstance(EXTERNAL_SECRET_MANAGER, ...)` returned an error, and `secretlib.ReplaceExternalSecret` was skipped — so the connection went out with an empty password.

This regression was introduced by #19657, which added the workspace-ID parameter to `IsFeatureEnabledForInstance`. Existing instances were unaffected because their `Workspace` field is populated by the store load.

The fix sets `instanceMessage.Workspace` from the request context immediately after `convertToStoreInstance`, so the license check sees the real plan during Test Connection. Downstream activation/limit logic reuses the same `workspaceID` variable, so behavior outside the test-connection path is unchanged.

## Test plan

- [x] `gofmt -w` clean
- [x] `golangci-lint run --allow-parallel-runners ./backend/api/v1/...` — 0 issues
- [x] `go build` succeeds
- [ ] Manual: create an instance with an AWS Secrets Manager password source on a paid plan and click Test Connection — should succeed
- [ ] Manual: create an instance with a direct password — should still succeed (regression check)
- [ ] Manual: add a read-only data source to an existing instance with an external secret — should still succeed (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)