### PR TITLE
fix(issue): clarify done activity wording

### DIFF
--- a/frontend/src/components/Plan/components/HeaderSection/HeaderSection.vue
+++ b/frontend/src/components/Plan/components/HeaderSection/HeaderSection.vue
@@ -13,11 +13,11 @@
         </template>
         {{ $t("common.draft") }}
       </NTag>
-      <NTag v-else-if="showDoneTag" round type="success">
+      <NTag v-else-if="showDoneTag" round :type="doneTagType">
         <template #icon>
           <CheckCircle2Icon class="w-4 h-4" />
         </template>
-        {{ $t("common.approved") }}
+        {{ doneTagLabel }}
       </NTag>
       <TitleInput />
       <div class="flex flex-row items-center justify-end">
@@ -47,6 +47,7 @@ import {
 } from "lucide-vue-next";
 import { NButton, NTag } from "naive-ui";
 import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { useRoute } from "vue-router";
 import {
   PROJECT_V1_ROUTE_ISSUE_DETAIL,
@@ -55,7 +56,10 @@ import {
   PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS,
 } from "@/router/dashboard/projectV1";
 import { State } from "@/types/proto-es/v1/common_pb";
-import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
+import {
+  Issue_ApprovalStatus,
+  IssueStatus,
+} from "@/types/proto-es/v1/issue_service_pb";
 import { isValidPlanName } from "@/utils";
 import { usePlanContext } from "../../logic";
 import { useSidebarContext } from "../../logic/sidebar";
@@ -64,6 +68,7 @@ import DescriptionSection from "./DescriptionSection.vue";
 import TitleInput from "./TitleInput.vue";
 
 const route = useRoute();
+const { t } = useI18n();
 const { isCreating, plan, issue } = usePlanContext();
 
 const isPlanDetailPage = computed(() => {
@@ -119,6 +124,18 @@ const showDoneTag = computed(() => {
   // Only show done tag on issue detail page
   if (!isIssueDetailPage.value) return false;
   return issue.value?.status === IssueStatus.DONE;
+});
+
+const doneTagLabel = computed(() => {
+  return issue.value?.approvalStatus === Issue_ApprovalStatus.APPROVED
+    ? t("common.approved")
+    : t("common.skipped");
+});
+
+const doneTagType = computed(() => {
+  return issue.value?.approvalStatus === Issue_ApprovalStatus.APPROVED
+    ? "success"
+    : "default";
 });
 
 const showDescriptionSection = computed(() => {

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionIcon.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionIcon.vue
@@ -38,10 +38,12 @@ import {
 import type { Component } from "vue";
 import { computed } from "vue";
 import { SkipIcon } from "@/components/Icon";
+import { usePlanContext } from "@/components/Plan/logic";
 import UserAvatar from "@/components/User/UserAvatar.vue";
 import { getIssueCommentType, IssueCommentType, useUserStore } from "@/store";
 import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
 import { IssueComment_Approval_Status } from "@/types/proto-es/v1/issue_service_pb";
+import { isDatabaseChangeDoneRolloutComment } from "./utils";
 
 type ActionIconType =
   | "avatar"
@@ -149,6 +151,7 @@ const props = defineProps<{
 }>();
 
 const userStore = useUserStore();
+const { issue, plan } = usePlanContext();
 
 const user = computedAsync(() => {
   return userStore.getOrFetchUserByIdentifier({
@@ -181,6 +184,11 @@ const iconType = computed((): ActionIconType => {
   ) {
     const { toTitle, toDescription, toLabels, fromLabels } =
       issueComment.event.value;
+    if (
+      isDatabaseChangeDoneRolloutComment(issue.value, plan.value, issueComment)
+    ) {
+      return "complete";
+    }
     if (
       toTitle !== undefined ||
       toDescription !== undefined ||

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionSentence.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionSentence.vue
@@ -5,11 +5,14 @@
 <script lang="tsx" setup>
 import { defineComponent } from "vue";
 import { Translation, useI18n } from "vue-i18n";
+import { RouterLink } from "vue-router";
 import { usePlanContext } from "@/components/Plan/logic";
 import { SpecLink } from "@/components/v2";
+import { buildPlanDeployRouteFromPlanName } from "@/router/dashboard/projectV1RouteHelpers";
 import { getIssueCommentType, IssueCommentType } from "@/store";
 import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
 import {
+  Issue_ApprovalStatus,
   IssueComment_Approval_Status,
   IssueStatus,
 } from "@/types/proto-es/v1/issue_service_pb";
@@ -19,13 +22,14 @@ import {
   getSpecDisplayInfo,
 } from "@/utils";
 import StatementUpdate from "./StatementUpdate.vue";
+import { isDatabaseChangeDoneRolloutComment } from "./utils";
 
 const props = defineProps<{
   issueComment: IssueComment;
 }>();
 
 const { t } = useI18n();
-const { plan } = usePlanContext();
+const { issue, plan } = usePlanContext();
 
 const renderActionSentence = () => {
   const { issueComment } = props;
@@ -70,6 +74,43 @@ const renderActionSentence = () => {
       return t("activity.sentence.changed-description");
     } else if (fromStatus !== undefined && toStatus !== undefined) {
       if (toStatus === IssueStatus.DONE) {
+        if (
+          isDatabaseChangeDoneRolloutComment(
+            issue.value,
+            plan.value,
+            issueComment
+          )
+        ) {
+          const planUID = extractPlanUID(plan.value.name);
+          const planLink = () => (
+            <RouterLink
+              to={buildPlanDeployRouteFromPlanName(plan.value.name)}
+              class="font-medium text-accent hover:underline"
+            >
+              #{planUID}
+            </RouterLink>
+          );
+          if (issue.value?.approvalStatus === Issue_ApprovalStatus.APPROVED) {
+            if (planUID) {
+              return (
+                <>
+                  {t("activity.sentence.review-done-rollout-created-for-plan")}{" "}
+                  {planLink()}
+                </>
+              );
+            }
+            return t("activity.sentence.review-done-rollout-created");
+          }
+          if (planUID) {
+            return (
+              <>
+                {t("activity.sentence.review-skipped-rollout-created-for-plan")}{" "}
+                {planLink()}
+              </>
+            );
+          }
+          return t("activity.sentence.review-skipped-rollout-created");
+        }
         return t("activity.sentence.resolved-issue");
       } else if (toStatus === IssueStatus.CANCELED) {
         return t("activity.sentence.canceled-issue");

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueCommentAction.vue
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/IssueCommentAction.vue
@@ -11,7 +11,10 @@
       <div class="px-3 py-2" :class="$slots.comment ? 'bg-gray-50' : ''">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-x-2 text-sm min-w-0 flex-wrap">
-            <ActionCreator :creator="issueComment.creator" />
+            <ActionCreator
+              v-if="!shouldHideCreator(issueComment)"
+              :creator="issueComment.creator"
+            />
 
             <ActionSentence
               :issue-comment="issueComment"
@@ -53,13 +56,25 @@
 
 <script lang="ts" setup>
 import HumanizeTs from "@/components/misc/HumanizeTs.vue";
+import { usePlanContext } from "@/components/Plan/logic";
 import { getIssueCommentType, IssueCommentType } from "@/store";
 import { getTimeForPbTimestampProtoEs } from "@/types";
 import type { IssueComment } from "@/types/proto-es/v1/issue_service_pb";
 import ActionCreator from "./ActionCreator.vue";
 import ActionSentence from "./ActionSentence.vue";
+import { isDatabaseChangeDoneRolloutComment } from "./utils";
 
 defineProps<{
   issueComment: IssueComment;
 }>();
+
+const { issue, plan } = usePlanContext();
+
+const shouldHideCreator = (issueComment: IssueComment) => {
+  return isDatabaseChangeDoneRolloutComment(
+    issue.value,
+    plan.value,
+    issueComment
+  );
+};
 </script>

--- a/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/utils.ts
+++ b/frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/utils.ts
@@ -1,0 +1,18 @@
+import { getIssueCommentType, IssueCommentType } from "@/store";
+import type { Issue, IssueComment } from "@/types/proto-es/v1/issue_service_pb";
+import { Issue_Type, IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
+import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
+
+export const isDatabaseChangeDoneRolloutComment = (
+  issue: Issue | undefined,
+  plan: Plan,
+  issueComment: IssueComment
+) => {
+  return (
+    issue?.type === Issue_Type.DATABASE_CHANGE &&
+    plan.hasRollout &&
+    getIssueCommentType(issueComment) === IssueCommentType.ISSUE_UPDATE &&
+    issueComment.event.case === "issueUpdate" &&
+    issueComment.event.value.toStatus === IssueStatus.DONE
+  );
+};

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -7,7 +7,11 @@
       "changed-labels": "changed labels",
       "created-issue": "created issue",
       "reopened-issue": "reopened issue",
-      "resolved-issue": "approved the issue"
+      "resolved-issue": "marked the issue as Done",
+      "review-done-rollout-created": "Review done, rollout created",
+      "review-done-rollout-created-for-plan": "Review done, rollout created for plan",
+      "review-skipped-rollout-created": "Review skipped, rollout created",
+      "review-skipped-rollout-created-for-plan": "Review skipped, rollout created for plan"
     }
   },
   "agent": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -7,7 +7,11 @@
       "changed-labels": "etiquetas cambiadas",
       "created-issue": "incidencia creado",
       "reopened-issue": "incidencia reabierta",
-      "resolved-issue": "aprobó la incidencia"
+      "resolved-issue": "marcó la incidencia como completada",
+      "review-done-rollout-created": "Revisión completada, rollout creado",
+      "review-done-rollout-created-for-plan": "Revisión completada, rollout creado para el plan",
+      "review-skipped-rollout-created": "Revisión omitida, rollout creado",
+      "review-skipped-rollout-created-for-plan": "Revisión omitida, rollout creado para el plan"
     }
   },
   "agent": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -7,7 +7,11 @@
       "changed-labels": "ラベルを変更しました",
       "created-issue": "イシューを作成する",
       "reopened-issue": "イシューを再開する",
-      "resolved-issue": "イシューを承認した"
+      "resolved-issue": "イシューを完了としてマークしました",
+      "review-done-rollout-created": "レビューが完了し、ロールアウトが作成されました",
+      "review-done-rollout-created-for-plan": "レビューが完了し、プランのロールアウトが作成されました",
+      "review-skipped-rollout-created": "レビューがスキップされ、ロールアウトが作成されました",
+      "review-skipped-rollout-created-for-plan": "レビューがスキップされ、プランのロールアウトが作成されました"
     }
   },
   "agent": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -7,7 +7,11 @@
       "changed-labels": "đã thay đổi nhãn",
       "created-issue": "đã tạo vấn đề",
       "reopened-issue": "đã mở lại vấn đề",
-      "resolved-issue": "đã phê duyệt vấn đề"
+      "resolved-issue": "đã đánh dấu vấn đề là Hoàn tất",
+      "review-done-rollout-created": "Đánh giá đã hoàn tất, rollout đã được tạo",
+      "review-done-rollout-created-for-plan": "Đánh giá đã hoàn tất, rollout đã được tạo cho kế hoạch",
+      "review-skipped-rollout-created": "Đánh giá đã được bỏ qua, rollout đã được tạo",
+      "review-skipped-rollout-created-for-plan": "Đánh giá đã được bỏ qua, rollout đã được tạo cho kế hoạch"
     }
   },
   "agent": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -7,7 +7,11 @@
       "changed-labels": "改变标签",
       "created-issue": "创建工单",
       "reopened-issue": "重开工单",
-      "resolved-issue": "批准工单"
+      "resolved-issue": "将工单标记为已完成",
+      "review-done-rollout-created": "审批完成，已创建发布",
+      "review-done-rollout-created-for-plan": "审批完成，已为计划创建发布",
+      "review-skipped-rollout-created": "已跳过审批，已创建发布",
+      "review-skipped-rollout-created-for-plan": "已跳过审批，已为计划创建发布"
     }
   },
   "agent": {


### PR DESCRIPTION
## Summary
- Clarify legacy Vue issue DONE status and activity wording so automatic rollout creation is not presented as a user approval.

## Key Changes
- Show DONE issue header status as `Approved` only when the review status is approved; otherwise show `Skipped`.
- Render database-change auto-DONE activity as review completion/skipping with a linked plan reference.
- Hide the comment actor and use the completed icon only for database-change DONE activity created after rollout exists.
- Update Vue locale strings across supported locales.

## Motivation
- The activity log previously rendered status changes to DONE as approval activity, which could make the issue creator appear to have approved the issue even when rollout creation was automatic.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`