### PR TITLE
fix(plan): emit spec update issue comments

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -295,6 +295,7 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 
 	var planCheckRunsTrigger bool
 	var databaseGroup *v1pb.DatabaseGroup
+	var issueCommentCreates []*store.IssueCommentMessage
 
 	for _, path := range req.UpdateMask.Paths {
 		switch path {
@@ -333,6 +334,7 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 				return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get issue: %v", err))
 			}
 			if issue != nil {
+				issueCommentCreates = append(issueCommentCreates, buildPlanSpecUpdateIssueComments(issue.ProjectID, issue.UID, oldPlan.UID, oldPlan.Config.GetSpecs(), allSpecs)...)
 				// Reset approval finding status
 				updatedIssue, err := s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
 					PayloadUpsert: &storepb.Issue{
@@ -366,6 +368,12 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 	updatedPlan, err := s.store.UpdatePlan(ctx, planUpdate)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan %q: %v", req.Plan.Name, err))
+	}
+
+	if len(issueCommentCreates) > 0 {
+		if _, err := s.store.CreateIssueComments(ctx, user.Email, issueCommentCreates...); err != nil {
+			slog.Warn("failed to create plan spec update issue comments", log.BBError(err))
+		}
 	}
 
 	if planCheckRunsTrigger {
@@ -1093,6 +1101,57 @@ func convertPlanSpec(spec *v1pb.Plan_Spec) *storepb.PlanConfig_Spec {
 	default:
 	}
 	return storeSpec
+}
+
+func getPlanSpecSheetSha256(spec *storepb.PlanConfig_Spec) string {
+	if spec == nil {
+		return ""
+	}
+	if config := spec.GetChangeDatabaseConfig(); config != nil {
+		return config.GetSheetSha256()
+	}
+	if config := spec.GetExportDataConfig(); config != nil {
+		return config.GetSheetSha256()
+	}
+	return ""
+}
+
+func buildPlanSpecUpdateIssueComments(projectID string, issueUID int64, planUID int64, oldSpecs, newSpecs []*storepb.PlanConfig_Spec) []*store.IssueCommentMessage {
+	oldSpecByID := make(map[string]*storepb.PlanConfig_Spec, len(oldSpecs))
+	for _, spec := range oldSpecs {
+		if spec.GetId() == "" {
+			continue
+		}
+		oldSpecByID[spec.GetId()] = spec
+	}
+
+	var issueCommentCreates []*store.IssueCommentMessage
+	for _, spec := range newSpecs {
+		specID := spec.GetId()
+		oldSpec, ok := oldSpecByID[specID]
+		if !ok {
+			continue
+		}
+		fromSheetSha256 := getPlanSpecSheetSha256(oldSpec)
+		toSheetSha256 := getPlanSpecSheetSha256(spec)
+		if fromSheetSha256 == "" || toSheetSha256 == "" || fromSheetSha256 == toSheetSha256 {
+			continue
+		}
+		issueCommentCreates = append(issueCommentCreates, &store.IssueCommentMessage{
+			ProjectID: projectID,
+			IssueUID:  issueUID,
+			Payload: &storepb.IssueCommentPayload{
+				Event: &storepb.IssueCommentPayload_PlanSpecUpdate_{
+					PlanSpecUpdate: &storepb.IssueCommentPayload_PlanSpecUpdate{
+						Spec:            common.FormatSpec(projectID, planUID, specID),
+						FromSheetSha256: &fromSheetSha256,
+						ToSheetSha256:   &toSheetSha256,
+					},
+				},
+			},
+		})
+	}
+	return issueCommentCreates
 }
 
 func convertPlanSpecCreateDatabaseConfig(config *v1pb.Plan_Spec_CreateDatabaseConfig) *storepb.PlanConfig_Spec_CreateDatabaseConfig {

--- a/backend/tests/plan_update_test.go
+++ b/backend/tests/plan_update_test.go
@@ -1,0 +1,137 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+)
+
+func TestUpdatePlanCreatesPlanSpecUpdateIssueComment(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	instanceRootDir := t.TempDir()
+	instanceName := "testPlanUpdateInstance"
+	instanceDir, err := ctl.provisionSQLiteInstance(instanceRootDir, instanceName)
+	a.NoError(err)
+
+	instanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       instanceName,
+			Engine:      v1pb.Engine_SQLITE,
+			Environment: new("environments/prod"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{Type: v1pb.DataSourceType_ADMIN, Host: instanceDir, Id: "admin"}},
+		},
+	}))
+	a.NoError(err)
+	instance := instanceResp.Msg
+
+	databaseName := "testPlanUpdateDb"
+	err = ctl.createDatabase(ctx, ctl.project, instance, nil, databaseName, "")
+	a.NoError(err)
+
+	databaseResp, err := ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{
+		Name: fmt.Sprintf("%s/databases/%s", instance.Name, databaseName),
+	}))
+	a.NoError(err)
+	database := databaseResp.Msg
+
+	sheet1Resp, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet: &v1pb.Sheet{
+			Content: []byte("CREATE TABLE plan_update_test_1 (id INTEGER PRIMARY KEY);"),
+		},
+	}))
+	a.NoError(err)
+	sheet1 := sheet1Resp.Msg
+
+	sheet2Resp, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet: &v1pb.Sheet{
+			Content: []byte("CREATE TABLE plan_update_test_2 (id INTEGER PRIMARY KEY);"),
+		},
+	}))
+	a.NoError(err)
+	sheet2 := sheet2Resp.Msg
+
+	specID := uuid.NewString()
+	planResp, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan: &v1pb.Plan{
+			Specs: []*v1pb.Plan_Spec{
+				{
+					Id: specID,
+					Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+							Targets: []string{database.Name},
+							Sheet:   sheet1.Name,
+						},
+					},
+				},
+			},
+		},
+	}))
+	a.NoError(err)
+	plan := planResp.Msg
+
+	issueResp, err := ctl.issueServiceClient.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+		Parent: ctl.project.Name,
+		Issue: &v1pb.Issue{
+			Type:        v1pb.Issue_DATABASE_CHANGE,
+			Title:       fmt.Sprintf("change database %s", database.Name),
+			Description: fmt.Sprintf("change database %s", database.Name),
+			Plan:        plan.Name,
+		},
+	}))
+	a.NoError(err)
+	issue := issueResp.Msg
+
+	_, err = ctl.planServiceClient.UpdatePlan(ctx, connect.NewRequest(&v1pb.UpdatePlanRequest{
+		Plan: &v1pb.Plan{
+			Name: plan.Name,
+			Specs: []*v1pb.Plan_Spec{
+				{
+					Id: specID,
+					Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+							Targets: []string{database.Name},
+							Sheet:   sheet2.Name,
+						},
+					},
+				},
+			},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"specs"}},
+	}))
+	a.NoError(err)
+
+	commentsResp, err := ctl.issueServiceClient.ListIssueComments(ctx, connect.NewRequest(&v1pb.ListIssueCommentsRequest{
+		Parent: issue.Name,
+	}))
+	a.NoError(err)
+
+	var planSpecUpdates []*v1pb.IssueComment_PlanSpecUpdate
+	for _, comment := range commentsResp.Msg.IssueComments {
+		if planSpecUpdate := comment.GetPlanSpecUpdate(); planSpecUpdate != nil {
+			planSpecUpdates = append(planSpecUpdates, planSpecUpdate)
+		}
+	}
+	a.Len(planSpecUpdates, 1)
+	a.Equal(fmt.Sprintf("%s/specs/%s", plan.Name, specID), planSpecUpdates[0].Spec)
+	a.Equal(sheet1.Name, planSpecUpdates[0].GetFromSheet())
+	a.Equal(sheet2.Name, planSpecUpdates[0].GetToSheet())
+}

--- a/docs/plans/2026-04-16-plan-spec-update-comments/definition.md
+++ b/docs/plans/2026-04-16-plan-spec-update-comments/definition.md
@@ -1,0 +1,45 @@
+## Background & Context
+
+The reported approval workflow visibility issue occurs when SQL changes during an active approval flow and downstream approvers do not see an in-issue activity entry showing the SQL change. A follow-up proposal narrowed this work to the audit visibility gap: `PlanSpecUpdate` issue comment payloads and frontend rendering remain present, but `UpdatePlan` stopped emitting those events after GitHub PR [#18589](https://github.com/bytebase/bytebase/pull/18589) simplified plan update handling. That PR was merged on 2025-12-23 and its `backend/api/v1/plan_service.go` patch removed prior `PlanSpecUpdate` issue comment creation from the `specs` update branch.
+
+## Issue Statement
+
+When `PlanService.UpdatePlan` processes a `specs` update for a plan attached to an issue, the plan and approval state are updated without an issue activity entry that records the changed statement sheet, even though the issue comment payload, API conversion, and frontend rendering paths still handle `PlanSpecUpdate` events; downstream approvers see the latest SQL and approval activity without in-issue history of the SQL change.
+
+## Current State
+
+- `backend/api/v1/plan_service.go:225` defines `PlanService.UpdatePlan`.
+- `backend/api/v1/plan_service.go:307` handles the `specs` update mask path.
+- `backend/api/v1/plan_service.go:321` converts and stores the new specs in a cloned plan config.
+- `backend/api/v1/plan_service.go:330` looks up the linked issue for the plan.
+- `backend/api/v1/plan_service.go:335` through `backend/api/v1/plan_service.go:360` reset approval finding state and, for export issues, reapply the approval template.
+- `backend/api/v1/plan_service.go:366` persists the plan update after the spec update branch completes.
+- `backend/api/v1/plan_service.go:371` through `backend/api/v1/plan_service.go:383` create and schedule plan check runs after spec changes.
+- `backend/store/issue_comment.go:129` defines `CreateIssueComments`, which inserts issue comments with a caller-provided creator and JSON payload.
+- `proto/store/store/issue_comment.proto:13` through `proto/store/store/issue_comment.proto:17` define `IssueCommentPayload.event` and include `plan_spec_update`.
+- `proto/store/store/issue_comment.proto:35` through `proto/store/store/issue_comment.proto:42` define `PlanSpecUpdate` with spec, previous sheet SHA256, and new sheet SHA256 fields.
+- `backend/api/v1/issue_service_converter.go:308` through `backend/api/v1/issue_service_converter.go:310` convert stored `PlanSpecUpdate` payloads to v1 issue comment events.
+- `backend/api/v1/issue_service_converter.go:375` through `backend/api/v1/issue_service_converter.go:389` resolve stored sheet SHA256 values to v1 sheet resource names.
+- `frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionSentence.vue:83` through `frontend/src/components/Plan/components/IssueReviewView/ActivitySection/IssueCommentView/ActionSentence.vue:111` render `PLAN_SPEC_UPDATE` comments with a spec link and statement diff when both old and new sheets are present.
+- A repository search found current `PlanSpecUpdate` handling in payload, conversion, and frontend rendering paths, but no current `PlanSpecUpdate` issue comment creation path in `PlanService.UpdatePlan`.
+
+## Non-Goals
+
+- Changing proto definitions for issue comments, plans, sheets, or approvals.
+- Changing frontend issue activity rendering or the statement diff component.
+- Redesigning issue comments, plan comments, or activity timeline storage.
+- Changing plan update permissions or the `bb.plans.update` role mapping.
+- Changing self-approval eligibility, including tracking or validating the last plan SQL editor.
+- Changing rollout execution, task update, or plan check scheduling behavior.
+- Recording SQL changes for plans with no linked issue.
+
+## Open Questions
+
+- Should this work cover self-approval eligibility for users who edited plan SQL? (default: no, keep it separate from this audit visibility proposal)
+- Should activity entries be limited to statement sheet changes with both previous and new sheet SHA256 values? (default: yes, match the existing `PlanSpecUpdate` payload and frontend diff rendering)
+- Should additions or removals of specs be represented separately when no statement sheet diff exists? (default: no, keep the event limited to changed specs whose statement sheets can be compared)
+- Should a failed issue comment insert fail the `UpdatePlan` request? (default: no, preserve the existing pattern of treating activity creation as non-fatal where possible)
+
+## Scope
+
+**S** - The current state localizes the visibility gap to the `specs` branch of `backend/api/v1/plan_service.go`, while the existing issue comment payload, converter, storage API, and frontend renderer already support `PlanSpecUpdate` events.

--- a/docs/plans/2026-04-16-plan-spec-update-comments/design.md
+++ b/docs/plans/2026-04-16-plan-spec-update-comments/design.md
@@ -1,0 +1,56 @@
+## References
+
+- [GitHub Docs: Reviewing proposed changes in a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/reviewing-proposed-changes-in-a-pull-request?tool=codespaces) - verified. GitHub places review decisions next to file diffs, commit context, and stale-review behavior.
+- [GitLab Docs: Merge requests](https://docs.gitlab.com/user/project/merge_requests/) - verified. GitLab merge requests present code changes, inline reviews, comments, CI state, mergeability, and commit lists together.
+- [GitLab Docs: Merge request commits](https://docs.gitlab.com/user/project/merge_requests/commits/) - verified. GitLab keeps a per-merge-request commit history and supports viewing diffs between commits.
+- [OWASP Logging Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html) - verified. OWASP describes audit logs as chronological, attributable records and recommends enough event data to reconstruct who did what, when, and to which object.
+- [Bytebase PR #18589: refactor: remove deployment snapshot and simplify plan updates](https://github.com/bytebase/bytebase/pull/18589) - verified. The `backend/api/v1/plan_service.go` patch simplified `UpdatePlan` and removed the previous `PlanSpecUpdate` issue comment creation path.
+
+## Industry Baseline
+
+Code review systems keep content changes visible inside the review workflow. GitHub documents pull request review around changed files, diffs, commits, approvals, and stale-review behavior in one review surface. GitLab merge requests similarly combine code changes, inline reviews, comments, pipelines, mergeability, and commits, and provide commit history plus diff comparison when reviewers need change progression.
+
+Audit guidance favors chronological, attributable, scoped event records instead of separate ad hoc channels. The OWASP Logging Cheat Sheet describes audit records as a trail that supports reconstruction and review, and recommends recording enough information to identify the event time, actor, action, and object without over-logging.
+
+For this codebase, the baseline maps to issue activity rather than a new plan activity subsystem. `IssueCommentPayload.PlanSpecUpdate` already stores the changed spec and previous/new sheet SHA256 values, `issue_comment` already stores creator and timestamps, and the frontend already renders the event as a statement diff.
+
+## Research Summary
+
+The relevant pattern across GitHub and GitLab is to surface changes to review content in the same workflow where approvals happen. Reviewers can inspect what changed without switching to an unrelated audit channel.
+
+OWASP's logging guidance supports a small, purpose-built activity event: the existing issue comment row supplies when and who; the `PlanSpecUpdate` payload supplies what changed and the affected object; the frontend diff view supplies reviewable context. That matches the current Bytebase model without expanding proto contracts or logging raw SQL into an additional structure.
+
+The prior `UpdatePlan` implementation removed in PR #18589 already followed this direction by creating `PlanSpecUpdate` comments for sheet changes. The current code still has the downstream payload conversion and frontend rendering, so the main design question is how to reconstruct changed sheet pairs in the simplified `UpdatePlan` flow.
+
+## Design Goals
+
+- Emit one issue activity entry for each updated plan spec whose statement sheet changes while the plan is attached to an issue; this is verifiable by updating a plan spec and listing issue comments.
+- Preserve existing API and frontend contracts; this is verifiable by no proto changes and no frontend source changes.
+- Keep issue activity scoped to reviewable statement diffs; this is verifiable by `PlanSpecUpdate` comments containing both previous and new sheet references.
+- Preserve existing plan update behavior for validation, approval reset, and plan check scheduling; this is verifiable by existing plan update tests plus a focused regression test around issue comments.
+
+## Non-Goals
+
+- Changing proto definitions for issue comments, plans, sheets, or approvals.
+- Changing frontend issue activity rendering or the statement diff component.
+- Redesigning issue comments, plan comments, or activity timeline storage.
+- Changing plan update permissions or the `bb.plans.update` role mapping.
+- Changing self-approval eligibility, including tracking or validating the last plan SQL editor.
+- Changing rollout execution, task update, or plan check scheduling behavior.
+- Recording SQL changes for plans with no linked issue.
+
+## Proposed Design
+
+Keep `PlanService.UpdatePlan` as the emission point for plan spec update activity. This follows the GitHub and GitLab pattern of keeping content-change history in the same review object where reviewers make approval decisions, and it avoids a separate plan activity system because `issue_comment` already backs issue activity.
+
+Detect changed statement sheets inside the existing `specs` update branch in `backend/api/v1/plan_service.go`. Compare the old stored specs from `oldPlan.Config.Specs` with the new stored specs produced from the request, keyed by spec ID. For each spec present in both old and new versions, read the old and new sheet SHA256 from supported sheet-backed configs. Create an activity entry only when both SHA256 values are non-empty and different. This keeps the event aligned with the current `PlanSpecUpdate` payload and frontend renderer, which both expect before/after sheet references.
+
+Use the existing `IssueCommentPayload_PlanSpecUpdate` event. Set `Spec` with `common.FormatSpec(issue.ProjectID, oldPlan.UID, specID)`, `FromSheetSha256` with the old sheet SHA256, and `ToSheetSha256` with the new sheet SHA256. `issue_comment.creator` and row timestamps provide the actor and time fields recommended by OWASP, while the payload identifies the action object and before/after sheet state.
+
+Create comments only when an issue is found for the plan. That matches the current visibility problem, which is specifically about downstream issue approvers, and respects the non-goal of recording SQL changes for standalone plans. If multiple specs change in one request, create one comment per changed spec so each timeline entry can link to the affected spec and statement diff independently.
+
+Create the comments after the plan update succeeds, using `store.CreateIssueComments` with the requesting user's email and the accumulated comment payloads. Treat comment insertion failure as non-fatal and log it, matching the pre-simplification behavior removed in PR #18589. This keeps the plan update behavior stable while restoring the review-visible audit entry.
+
+Do not change `proto/store/store/issue_comment.proto`, `backend/api/v1/issue_service_converter.go`, or the frontend activity components. The existing converter resolves stored SHA256 values back to sheet resource names, and the existing frontend renders the linked spec and statement diff when both sheets are present.
+
+Add a focused backend regression test for a plan attached to an issue: update a sheet-backed spec to reference a different sheet, assert the plan update succeeds, then assert an issue comment exists with a `PlanSpecUpdate` payload containing the expected spec resource and old/new sheet SHA256 values. A companion negative case should cover unchanged sheet SHA or no linked issue, where no `PlanSpecUpdate` comment is created.

--- a/docs/plans/2026-04-16-plan-spec-update-comments/plan.md
+++ b/docs/plans/2026-04-16-plan-spec-update-comments/plan.md
@@ -1,0 +1,45 @@
+## Task List
+
+Task Index: T1: Emit plan spec update issue comments [M]
+
+### T1: Emit plan spec update issue comments [M]
+
+**Objective**: Restore issue activity entries for updated plan specs whose statement sheet changes while the plan is attached to an issue, preserving the existing `PlanSpecUpdate` payload and frontend diff path.
+
+**Size**: M (2 files, moderate comparison and regression test logic)
+
+**Files**:
+- Modify: `backend/api/v1/plan_service.go`
+- Create: `backend/tests/plan_update_test.go`
+
+**Implementation**:
+1. In `backend/api/v1/plan_service.go`, in `PlanService.UpdatePlan()` around the existing local variables near line 296, add a slice for pending `*store.IssueCommentMessage` values.
+2. In the `specs` update branch around lines 321-335, after converting the request specs into the cloned plan config and after finding the linked issue, collect `PlanSpecUpdate` issue comment payloads when both old and new specs contain the same spec ID and the sheet SHA256 changes.
+3. In `backend/api/v1/plan_service.go`, add small unexported helpers near the plan conversion/helper functions:
+   - one helper to extract a sheet SHA256 from sheet-backed store plan spec configs (`ChangeDatabaseConfig` and `ExportDataConfig`);
+   - one helper to compare old/new specs by ID and return `IssueCommentPayload_PlanSpecUpdate` comments using `common.FormatSpec(projectID, planUID, specID)`.
+4. In `PlanService.UpdatePlan()` around line 366, after `s.store.UpdatePlan()` succeeds and before returning the converted plan, call `s.store.CreateIssueComments(ctx, user.Email, pendingComments...)` when comments were collected. Log insertion errors as non-fatal with `slog.Warn`.
+5. In `backend/tests/plan_update_test.go`, add `TestUpdatePlanCreatesPlanSpecUpdateIssueComment`: start the existing test controller, create a SQLite instance/database, create two sheets, create a sheet-backed database change plan and issue, update the plan spec to point at the second sheet, list issue comments, and assert exactly one `PlanSpecUpdate` event contains the expected spec resource plus old and new sheet resource names.
+
+**Boundaries**: Do not change proto files, generated files, frontend files, plan permissions, approval eligibility rules, rollout/task behavior, or issue comment storage schema.
+
+**Dependencies**: None
+
+**Expected Outcome**: Updating a sheet-backed plan spec attached to an issue creates a review-visible `PlanSpecUpdate` issue comment with old/new sheet references; existing plan update behavior remains unchanged.
+
+**Validation**:
+- `gofmt -w backend/api/v1/plan_service.go backend/tests/plan_update_test.go` - modified Go files are formatted.
+- `golangci-lint run --allow-parallel-runners` - lint completes with no issues.
+- `golangci-lint run --fix --allow-parallel-runners` - auto-fix completes without introducing required follow-up changes.
+- `golangci-lint run --allow-parallel-runners` - repeated lint completes with no issues.
+- `go test -v -count=1 github.com/bytebase/bytebase/backend/tests -run ^TestUpdatePlanCreatesPlanSpecUpdateIssueComment$` - focused regression test passes.
+- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go` - backend build succeeds.
+
+## Out-of-Scope Tasks
+
+- Tracking who last edited plan SQL for approval eligibility.
+- Blocking self-approval based on plan SQL edits.
+- Adding new issue comment event types or proto fields.
+- Changing the frontend activity timeline or statement diff renderer.
+- Recording plan spec changes for plans without linked issues.
+- Reworking rollout, task, or plan check scheduling semantics.


### PR DESCRIPTION
## Summary
- Restore issue timeline entries when an attached plan spec changes its statement sheet.
- Keep the existing `PlanSpecUpdate` payload, API conversion, and frontend diff rendering contracts unchanged.
- Add a focused backend regression test for updating a sheet-backed plan spec.

## Key Changes
- Compare old and new plan specs during `UpdatePlan` and collect `PlanSpecUpdate` comments for changed sheet SHA256 values.
- Create collected issue comments after the plan update succeeds, treating comment creation failures as non-fatal logs.
- Cover the public API flow for plan update, issue comment listing, and old/new sheet references.

## Motivation
- Downstream approvers need in-issue visibility when SQL changes during an approval flow.
- The payload and frontend rendering path already exist; the backend emission path was missing after plan update simplification.

## Testing
- `gofmt -w backend/api/v1/plan_service.go backend/tests/plan_update_test.go`
- `go test -v -count=1 github.com/bytebase/bytebase/backend/tests -run ^TestUpdatePlanCreatesPlanSpecUpdateIssueComment$`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `golangci-lint run --allow-parallel-runners` currently fails on pre-existing unrelated `revive` `unhandled-error` findings outside this PR's files.

## Breaking Change Check
- Reviewed `git diff main...HEAD`; no API, database schema, proto, configuration, behavior, webhook/event, permission, or UI workflow breaking changes found.