### PR TITLE
fix(parser/mssql): propagate outer scope to correlated subquery in WHERE predicates (BYT-9298)

### DIFF
--- a/backend/plugin/parser/tsql/query_span_predicate.go
+++ b/backend/plugin/parser/tsql/query_span_predicate.go
@@ -134,18 +134,27 @@ func (q *querySpanExtractor) extractPredicateColumnFromSubquery(
 		return nil
 	}
 
-	subquery := ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx)
-
-	// TODO: outer table reference.
-	newQ := newQuerySpanExtractor(q.defaultDatabase, q.defaultSchema, q.gCtx, q.ignoreCaseSensitive)
-	newQ.ctes = q.ctes
-	span, err := newQ.getQuerySpan(q.ctx, subquery)
+	// Clone the extractor so the subquery sees the enclosing FROM clause as
+	// outer table sources. Without this, correlated subqueries like
+	// `WHERE EXISTS (SELECT 1 FROM t e WHERE e.col = outer.col)` cannot
+	// resolve the `outer` alias and fail with "no matching column".
+	cloneExtractor := &querySpanExtractor{
+		ctx:                 q.ctx,
+		defaultDatabase:     q.defaultDatabase,
+		defaultSchema:       q.defaultSchema,
+		ignoreCaseSensitive: q.ignoreCaseSensitive,
+		gCtx:                q.gCtx,
+		ctes:                q.ctes,
+		outerTableSources:   append(q.outerTableSources, q.tableSourcesFrom...),
+		predicateColumns:    make(base.SourceColumnSet),
+	}
+	tableSource, err := cloneExtractor.extractTSqlSensitiveFieldsFromSubquery(ctx)
 	if err != nil {
-		return errors.Wrapf(err, "failed to get query span for subquery: %s", subquery)
+		return errors.Wrapf(err, "failed to get query span for subquery")
 	}
 
-	q.predicateColumns, _ = base.MergeSourceColumnSet(q.predicateColumns, span.PredicateColumns)
-	for _, r := range span.Results {
+	q.predicateColumns, _ = base.MergeSourceColumnSet(q.predicateColumns, cloneExtractor.predicateColumns)
+	for _, r := range tableSource.GetQuerySpanResult() {
 		q.predicateColumns, _ = base.MergeSourceColumnSet(q.predicateColumns, r.SourceColumns)
 	}
 

--- a/backend/plugin/parser/tsql/query_span_test.go
+++ b/backend/plugin/parser/tsql/query_span_test.go
@@ -1,6 +1,7 @@
 package tsql
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"os"
@@ -74,10 +75,12 @@ func TestGetQuerySpan(t *testing.T) {
 		}
 
 		if record {
-			byteValue, err := yaml.Marshal(testCases)
-			a.NoError(err)
-			err = os.WriteFile(testDataPath, byteValue, 0644)
-			a.NoError(err)
+			var buf bytes.Buffer
+			enc := yaml.NewEncoder(&buf)
+			enc.SetIndent(2)
+			a.NoError(enc.Encode(testCases))
+			a.NoError(enc.Close())
+			a.NoError(os.WriteFile(testDataPath, buf.Bytes(), 0644))
 		}
 	}
 }

--- a/backend/plugin/parser/tsql/test-data/query-span/regression.yaml
+++ b/backend/plugin/parser/tsql/test-data/query-span/regression.yaml
@@ -369,3 +369,68 @@
         schema: dbo
         table: TableA
         column: HMNum
+
+- description: Test VIEW with correlated subquery referencing outer table - fix for BYT-9298
+  statement: |-
+    SELECT WanGrNumber FROM dbo.vw_gr_wan_number WHERE WanGrNumber = '123'
+  defaultDatabase: Invoice
+  ignoreCaseSensitive: true
+  metadata:
+    - |-
+      {
+        "name": "Invoice",
+        "schemas": [
+          {
+            "name": "dbo",
+            "views": [
+              {
+                "name": "vw_gr_wan_number",
+                "definition": "CREATE VIEW [dbo].[vw_gr_wan_number] AS SELECT gr.SAP_NO AS WanGrNumber FROM dbo.gr_table gr WHERE NOT EXISTS (SELECT 1 FROM dbo.existing_gr_number e WHERE e.wan_gr_number = gr.SAP_NO)"
+              }
+            ],
+            "tables": [
+              {
+                "name": "gr_table",
+                "columns": [
+                  {
+                    "name": "SAP_NO"
+                  }
+                ]
+              },
+              {
+                "name": "existing_gr_number",
+                "columns": [
+                  {
+                    "name": "wan_gr_number"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+  querySpan:
+    type: 1
+    results:
+      - name: wangrnumber
+        sourcecolumns:
+          - server: ""
+            database: Invoice
+            schema: dbo
+            table: gr_table
+            column: SAP_NO
+        isplainfield: true
+        sourcefieldpaths: []
+        selectasterisk: false
+    sourcecolumns:
+      - server: ""
+        database: Invoice
+        schema: dbo
+        table: vw_gr_wan_number
+        column: ""
+    predicatecolumns:
+      - server: ""
+        database: Invoice
+        schema: dbo
+        table: gr_table
+        column: SAP_NO


### PR DESCRIPTION
## Summary

- Fixes [BYT-9298](https://linear.app/bytebase/issue/BYT-9298/mssql-query-span-extraction-failed): a follow-up to #20006. Loading the MSSQL view `[Invoice].[dbo].[vw_gr_wan_number]` for query span extraction failed with `no matching column "".".""."gr"."sap_no"` because the view body contained a correlated subquery of the form `WHERE NOT EXISTS (SELECT 1 FROM existing_gr_number e WHERE e.wan_gr_number = gr.SAP_NO)`.
- `extractPredicateColumnFromSubquery` ([query_span_predicate.go:130](https://github.com/bytebase/bytebase/blob/main/backend/plugin/parser/tsql/query_span_predicate.go#L130)) extracted columns from subqueries in WHERE/EXISTS by re-parsing the subquery text with a brand-new extractor (only `ctes` was copied over). The fresh extractor had no `outerTableSources` and no `tableSourcesFrom`, so the outer alias `gr` was unresolvable.

## Fix

Clone the current extractor instead, propagating `outerTableSources + tableSourcesFrom`, `ctes`, and `gCtx`, and call `extractTSqlSensitiveFieldsFromSubquery` directly on the AST node. This mirrors the existing pattern used for subqueries in expression position ([query_span_extractor.go:1202](https://github.com/bytebase/bytebase/blob/main/backend/plugin/parser/tsql/query_span_extractor.go#L1202)).

## Notes

- **Predicate columns from inside view bodies are still dropped at the view boundary** — this is a pre-existing limitation shared by every legacy ANTLR-based parser (mysql, plsql, redshift, tidb, tsql), where `getColumnsForView` returns only `span.Results` and discards `span.PredicateColumns`. Out of scope for this PR.
- **Top-level `sourcecolumns` shows the view, not its underlying tables** — also intended cross-engine convention; per-column lineage to physical tables lives in `results[].sourcecolumns`.
- Switched the regression-test recorder from `yaml.Marshal` to a `yaml.Encoder` with `SetIndent(2)` so future re-records preserve the 2-space sequence indent instead of rewriting every list item with 4-space indent.

## Test plan

- [x] New regression test in [`backend/plugin/parser/tsql/test-data/query-span/regression.yaml`](https://github.com/bytebase/bytebase/blob/main/backend/plugin/parser/tsql/test-data/query-span/regression.yaml) modeling the BYT-9298 view shape (correlated subquery via `NOT EXISTS`).
- [x] Verified the regression test fails on pre-fix code and passes after the fix.
- [x] `go test ./backend/plugin/parser/tsql/...` passes.
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/parser/tsql/...` clean.
- [x] Full backend `go build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)