### PR TITLE
fix(plsql): parse CREATE TABLE range bounds as expressions (BYT-9302)

### DIFF
--- a/backend/plugin/parser/plsql/plsql_test.go
+++ b/backend/plugin/parser/plsql/plsql_test.go
@@ -42,6 +42,23 @@ func TestPLSQLParser(t *testing.T) {
 			statement:    "SELECT 1 FROM DUAL;\n   SELEC 5 FROM DUAL;\nSELECT 6 FROM DUAL;",
 			errorMessage: "Syntax error at line 2:10 \nrelated text: SELECT 1 FROM DUAL;\n   SELEC 5",
 		},
+		// BYT-9302: CREATE TABLE with INTERVAL partitioning and DATE literal bound.
+		{
+			statement: `CREATE TABLE GCP.LEAD_DROP_MC_NATIVE_DATA
+(
+  TXN_DATE  DATE,
+  USERID    VARCHAR2(100),
+  CUSTID    VARCHAR2(100),
+  SCREENID  VARCHAR2(500),
+  EVENTTIME DATE,
+  STATUS    NUMBER
+)
+PARTITION BY RANGE (TXN_DATE)
+INTERVAL (NUMTODSINTERVAL(1,'DAY'))
+(
+  PARTITION P0 VALUES LESS THAN (DATE '2026-01-01')
+);`,
+		},
 	}
 
 	for _, test := range tests {

--- a/go.mod
+++ b/go.mod
@@ -298,7 +298,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.8
 	github.com/aws/smithy-go v1.24.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bytebase/parser v0.0.0-20260324092042-1d52e5412f50
+	github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/cockroachdb/cockroach-go/v2 v2.4.3

--- a/go.sum
+++ b/go.sum
@@ -253,8 +253,8 @@ github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
 github.com/bytebase/omni v0.0.0-20260417040020-724d3998950a h1:jSeJxacP5ZJzvIZwddyX5N0OP9hR87SOGnht3HdX9B4=
 github.com/bytebase/omni v0.0.0-20260417040020-724d3998950a/go.mod h1:AT+iLKCu7NyxTaYaOLzETRFBVurjRaqUU3YmFron9pw=
-github.com/bytebase/parser v0.0.0-20260324092042-1d52e5412f50 h1:Kq5wlhZ586Rch39y/IQV9MnrEzHob4iiXBG6zrbvSMU=
-github.com/bytebase/parser v0.0.0-20260324092042-1d52e5412f50/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
+github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
+github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
## Summary

- Bumps `github.com/bytebase/parser` to pick up [bytebase/parser#66](https://github.com/bytebase/parser/pull/66), which closes a batch of CREATE TABLE grammar gaps against the [Oracle 19c spec](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/CREATE-TABLE.html) — `range_values_clause`/`list_values_clause` now accept full expressions, adds `IF NOT EXISTS`, multi-column/AUTOMATIC `LIST`, `CONSISTENT HASH` and `PARTITIONSET` strategies, flexible blockchain clauses, and subpartition/annotations completeness.
- Directly unblocks [BYT-9302](https://linear.app/bytebase/issue/BYT-9302): `CREATE TABLE ... PARTITION BY RANGE (...) INTERVAL (NUMTODSINTERVAL(...)) (... VALUES LESS THAN (DATE '...'))` now parses instead of failing with a syntax error.
- Adds the reported failing statement as a regression fixture in `TestPLSQLParser`.

## Test plan
- [x] `go test ./backend/plugin/parser/plsql/...` green (new BYT-9302 fixture included)
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/parser/plsql/...` — 0 issues
- [x] Verified the 11 previously-failing scenarios from the parser-side investigation (DATE/TIMESTAMP bounds, arithmetic bounds, NULL in LIST, multi-column LIST, AUTOMATIC, IF NOT EXISTS, CONSISTENT HASH, PARTITIONSET, blockchain DAYS IDLE) all parse under the bumped dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)