### PR TITLE
fix(frontend): stabilize paged table loading

### DIFF
--- a/frontend/src/react/hooks/usePagedData.test.tsx
+++ b/frontend/src/react/hooks/usePagedData.test.tsx
@@ -1,0 +1,91 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { usePagedData } from "./usePagedData";
+
+vi.mock("@/react/hooks/useSessionPageSize", () => ({
+  getPageSizeOptions: () => [50, 100],
+  useSessionPageSize: () => [50, vi.fn()],
+}));
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type Item = {
+  name: string;
+};
+
+type FetchList = (params: {
+  pageSize: number;
+  pageToken: string;
+}) => Promise<{ list: Item[]; nextPageToken?: string }>;
+
+function Harness({ fetchList }: { fetchList: FetchList }) {
+  const paged = usePagedData<Item>({
+    sessionKey: "test-use-paged-data",
+    fetchList,
+  });
+
+  if (paged.isLoading) {
+    return <div data-state="loading">loading</div>;
+  }
+  if (paged.dataList.length === 0) {
+    return <div data-state="empty">empty</div>;
+  }
+  return <div data-state="data">{paged.dataList[0].name}</div>;
+}
+
+describe("usePagedData", () => {
+  let root: Root | undefined;
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    sessionStorage.clear();
+    act(() => {
+      root?.unmount();
+    });
+    root = undefined;
+    container = undefined;
+    document.body.innerHTML = "";
+  });
+
+  test("keeps loading while a debounced refresh is pending", async () => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    const emptyFetch = vi.fn<FetchList>(async () => ({ list: [] }));
+    const dataFetch = vi.fn<FetchList>(async () => ({
+      list: [{ name: "items/1" }],
+    }));
+
+    await act(async () => {
+      root!.render(<Harness fetchList={emptyFetch} />);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-state]")?.textContent).toBe("empty");
+
+    await act(async () => {
+      root!.render(<Harness fetchList={dataFetch} />);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-state]")?.textContent).toBe(
+      "loading"
+    );
+    expect(dataFetch).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector("[data-state]")?.textContent).toBe(
+      "items/1"
+    );
+  });
+});

--- a/frontend/src/react/hooks/usePagedData.tsx
+++ b/frontend/src/react/hooks/usePagedData.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
 import {
@@ -24,6 +24,83 @@ export type PagedDataResult<T> = {
   onPageSizeChange: (size: number) => void;
 };
 
+type FetchMode = "refresh" | "append";
+
+type PagedDataState<T> = {
+  dataList: T[];
+  status: "idle" | "loading" | "ready" | "loadingMore";
+  hasMore: boolean;
+};
+
+type PagedDataAction<T> =
+  | { type: "fetch-start"; mode: FetchMode }
+  | {
+      type: "fetch-success";
+      mode: FetchMode;
+      list: T[];
+      hasMore: boolean;
+    }
+  | { type: "fetch-error" }
+  | { type: "update-cache"; items: T[] }
+  | { type: "remove-cache"; item: T };
+
+const initialPagedDataState = <
+  T extends { name: string },
+>(): PagedDataState<T> => ({
+  dataList: [],
+  status: "idle",
+  hasMore: false,
+});
+
+const pagedDataReducer = <T extends { name: string }>(
+  state: PagedDataState<T>,
+  action: PagedDataAction<T>
+): PagedDataState<T> => {
+  switch (action.type) {
+    case "fetch-start":
+      return {
+        ...state,
+        status: action.mode === "refresh" ? "loading" : "loadingMore",
+      };
+    case "fetch-success":
+      return {
+        dataList:
+          action.mode === "refresh"
+            ? action.list
+            : [...state.dataList, ...action.list],
+        status: "ready",
+        hasMore: action.hasMore,
+      };
+    case "fetch-error":
+      return {
+        ...state,
+        status: "ready",
+      };
+    case "update-cache": {
+      const dataList = [...state.dataList];
+      for (const item of action.items) {
+        const index = dataList.findIndex((data) => data.name === item.name);
+        if (index >= 0) {
+          dataList[index] = item;
+        } else {
+          dataList.push(item);
+        }
+      }
+      return {
+        ...state,
+        dataList,
+      };
+    }
+    case "remove-cache":
+      return {
+        ...state,
+        dataList: state.dataList.filter(
+          (data) => data.name !== action.item.name
+        ),
+      };
+  }
+};
+
 export function usePagedData<T extends { name: string }>({
   sessionKey,
   fetchList,
@@ -39,11 +116,11 @@ export function usePagedData<T extends { name: string }>({
   const [pageSize, setPageSize] = useSessionPageSize(sessionKey);
   const pageSizeOptions = getPageSizeOptions();
 
-  const [dataList, setDataList] = useState<T[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [isFetchingMore, setIsFetchingMore] = useState(false);
-  const [hasFetched, setHasFetched] = useState(false);
-  const [hasMore, setHasMore] = useState(false);
+  const [state, dispatch] = useReducer(
+    pagedDataReducer<T>,
+    undefined,
+    initialPagedDataState<T>
+  );
 
   const abortRef = useRef<AbortController | null>(null);
   const fetchIdRef = useRef(0);
@@ -56,30 +133,26 @@ export function usePagedData<T extends { name: string }>({
       const controller = new AbortController();
       abortRef.current = controller;
 
-      if (isRefresh) {
-        setIsLoading(true);
-      } else {
-        setIsFetchingMore(true);
-      }
+      const mode: FetchMode = isRefresh ? "refresh" : "append";
+      dispatch({ type: "fetch-start", mode });
 
       try {
         const token = isRefresh ? "" : nextPageTokenRef.current;
         const result = await fetchList({ pageSize, pageToken: token });
         if (controller.signal.aborted || currentFetchId !== fetchIdRef.current)
           return;
-        setDataList((prev) =>
-          isRefresh ? result.list : [...prev, ...result.list]
-        );
         nextPageTokenRef.current = result.nextPageToken ?? "";
-        setHasMore(Boolean(result.nextPageToken));
+        dispatch({
+          type: "fetch-success",
+          mode,
+          list: result.list,
+          hasMore: Boolean(result.nextPageToken),
+        });
       } catch (e) {
         if (e instanceof Error && e.name === "AbortError") return;
         console.error(e);
-      } finally {
         if (currentFetchId === fetchIdRef.current) {
-          setIsLoading(false);
-          setIsFetchingMore(false);
-          setHasFetched(true);
+          dispatch({ type: "fetch-error" });
         }
       }
     },
@@ -87,32 +160,21 @@ export function usePagedData<T extends { name: string }>({
   );
 
   const loadMore = useCallback(() => {
-    if (hasMore && !isFetchingMore) {
+    if (state.hasMore && state.status === "ready") {
       doFetch(false);
     }
-  }, [hasMore, isFetchingMore, doFetch]);
+  }, [doFetch, state.hasMore, state.status]);
 
   const refresh = useCallback(() => {
     doFetch(true);
   }, [doFetch]);
 
   const updateCache = useCallback((items: T[]) => {
-    setDataList((prev) => {
-      const next = [...prev];
-      for (const item of items) {
-        const idx = next.findIndex((d) => d.name === item.name);
-        if (idx >= 0) {
-          next[idx] = item;
-        } else {
-          next.push(item);
-        }
-      }
-      return next;
-    });
+    dispatch({ type: "update-cache", items });
   }, []);
 
   const removeCache = useCallback((item: T) => {
-    setDataList((prev) => prev.filter((d) => d.name !== item.name));
+    dispatch({ type: "remove-cache", item });
   }, []);
 
   // Fetch on mount and when fetchList/pageSize changes (handles search text reactivity)
@@ -124,6 +186,9 @@ export function usePagedData<T extends { name: string }>({
       doFetch(true);
       return;
     }
+    fetchIdRef.current++;
+    abortRef.current?.abort();
+    dispatch({ type: "fetch-start", mode: "refresh" });
     const timer = setTimeout(() => doFetch(true), 300);
     return () => clearTimeout(timer);
   }, [doFetch, enabled]);
@@ -135,10 +200,11 @@ export function usePagedData<T extends { name: string }>({
   }, []);
 
   return {
-    dataList,
-    isLoading: enabled && (isLoading || !hasFetched),
-    isFetchingMore,
-    hasMore,
+    dataList: state.dataList,
+    isLoading:
+      enabled && (state.status === "idle" || state.status === "loading"),
+    isFetchingMore: state.status === "loadingMore",
+    hasMore: state.hasMore,
     loadMore,
     refresh,
     updateCache,

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -134,9 +134,14 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
   const [searchParams, setSearchParams] =
     useState<SearchParams>(defaultSearchParams);
 
+  const didMountRef = useRef(false);
   useEffect(() => {
+    if (!didMountRef.current) {
+      didMountRef.current = true;
+      return;
+    }
     setSearchParams(defaultSearchParams());
-  }, [projectId]);
+  }, [defaultSearchParams, projectId]);
 
   // Scope options
   const scopeOptions: ScopeOption[] = useMemo(
@@ -232,7 +237,7 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
 
   // Handle spec created from AddSpecDrawer
   const handleSpecCreated = useCallback(
-    (spec: Plan_Spec) => {
+    async (spec: Plan_Spec) => {
       if (!project) return;
 
       const template = "bb.plan.change-database";
@@ -276,7 +281,7 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
         }
       }
 
-      router.push({
+      await router.push({
         name: PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
         params: {
           projectId,
@@ -752,7 +757,7 @@ function AddSpecDrawer({
   open: boolean;
   onClose: () => void;
   projectName: string;
-  onCreated: (spec: Plan_Spec) => void;
+  onCreated: (spec: Plan_Spec) => void | Promise<void>;
   title: string;
 }) {
   const { t } = useTranslation();
@@ -809,7 +814,7 @@ function AddSpecDrawer({
         },
       });
 
-      onCreated(spec);
+      await onCreated(spec);
       onClose();
     } catch (error) {
       pushNotification({


### PR DESCRIPTION
## Summary
- Stabilize React paged table loading state so empty tables do not flash `No data` before a pending refresh starts.
- Keep the create-plan drawer open until the navigation to the plan creation route completes.

## Key Changes
- Refactor `usePagedData` internals to a reducer-backed state machine with explicit `idle`, `loading`, `ready`, and `loadingMore` states.
- Mark debounced refreshes as loading immediately and invalidate in-flight fetches before the delayed request starts.
- Skip the redundant initial plan dashboard search reset and await create-plan navigation before closing the drawer.
- Add coverage for the debounced refresh loading state.

## Motivation
BYT-9294 reported a transient broken view when creating a plan. While investigating, React paged tables also showed an initial `No data -> loading -> data` sequence because refresh state was not explicit during debounced fetches.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
