### PR TITLE
chore(proto): align ConnectRPC generator version

### DIFF
--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -15,7 +15,7 @@ plugins:
   - remote: buf.build/grpc/go
     out: ../backend/generated-go
     opt: paths=source_relative
-  - remote: buf.build/connectrpc/go:v1.18.1
+  - remote: buf.build/connectrpc/go:v1.19.1
     out: ../backend/generated-go
     opt:
       - paths=source_relative


### PR DESCRIPTION
## Summary
- Update the ConnectRPC Go remote generator pin from v1.18.1 to v1.19.1.
- Keep the generator version aligned with `connectrpc.com/connect v1.19.1` in `go.mod`.

## Testing
- `buf format -w proto`
- `buf lint proto`
- `PATH="$(go env GOPATH)/bin:$PATH" buf generate`
- `git diff --check`

## Breaking Change Check
- Reviewed `git diff main...HEAD` and `git diff origin/main...HEAD`; this only updates a proto generation plugin version pin and produces no generated-code diff.
