### PR TITLE
fix(react): skip plan refresh for access/role grant issues

### DIFF
--- a/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
+++ b/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
@@ -33,7 +33,7 @@ import {
   Task_Status,
   type TaskRun,
 } from "@/types/proto-es/v1/rollout_service_pb";
-import { unknownPlan } from "@/types/v1/issue/plan";
+import { UNKNOWN_PLAN_NAME, unknownPlan } from "@/types/v1/issue/plan";
 import { getRolloutFromPlan, minmax, setDocumentTitle } from "@/utils";
 import type { ProjectIssueDetailPageProps } from "../types";
 import {
@@ -209,7 +209,13 @@ const refreshIssueDetailSnapshot = async (
         .catch(() => undefined)
     : undefined;
 
-  const planName = snapshot.plan?.name || issue?.plan;
+  // Prefer the authoritative `issue.plan`; fall back to the snapshot only when
+  // it holds a real plan (not the UNKNOWN placeholder used for access/role grants).
+  const snapshotPlanName =
+    snapshot.plan?.name && snapshot.plan.name !== UNKNOWN_PLAN_NAME
+      ? snapshot.plan.name
+      : undefined;
+  const planName = issue?.plan || snapshotPlanName;
   if (!planName) {
     return {
       issue,

--- a/frontend/src/react/pages/project/issue-detail/utils/refreshIssueDetailState.ts
+++ b/frontend/src/react/pages/project/issue-detail/utils/refreshIssueDetailState.ts
@@ -14,13 +14,27 @@ import {
   GetRolloutRequestSchema,
   ListTaskRunsRequestSchema,
 } from "@/types/proto-es/v1/rollout_service_pb";
+import { UNKNOWN_PLAN_NAME } from "@/types/v1/issue/plan";
 import { getRolloutFromPlan } from "@/utils";
 import type { IssueDetailPageState } from "../hooks/useIssueDetailPage";
 
 export async function refreshIssueDetailState(
   page: Pick<IssueDetailPageState, "issue" | "patchState" | "plan">
 ) {
-  if (!page.plan?.name) {
+  // Issues without a plan (e.g., access/role grants) use an UNKNOWN placeholder.
+  // Fetching it would hit "project -1 not found" — refresh only the issue instead.
+  if (!page.plan?.name || page.plan.name === UNKNOWN_PLAN_NAME) {
+    if (!page.issue?.name) {
+      return;
+    }
+    const issueResult = await issueServiceClientConnect
+      .getIssue(
+        create(GetIssueRequestSchema, {
+          name: page.issue.name,
+        })
+      )
+      .catch(() => undefined);
+    page.patchState({ issue: issueResult });
     return;
   }
 


### PR DESCRIPTION
## Summary

- Fixes BYT-9295: approving a JIT access request (ACCESS_GRANT issue) surfaces a `ConnectError: [not_found] project "-1" not found` toast even though the approval itself succeeds.
- Root cause: access/role grant issues have no plan, so the issue detail page uses an `unknownPlan()` placeholder whose name is `projects/-1/plans/-1`. The refresh helpers in `refreshIssueDetailState.ts` and `useIssueDetailPage.ts` treated that as a real plan name and called `getPlan("projects/-1/plans/-1")` after approve/reject, which the ACL layer rejected.
- Fix: treat `UNKNOWN_PLAN_NAME` as "no plan" in both refresh paths. Only refresh the issue when there's no plan, and prefer the authoritative `issue.plan` over the snapshot's placeholder when recomputing.

## Test plan

- [ ] As a dev user, create a JIT access request on a project
- [ ] As a project admin (or workspace admin), approve the request
- [ ] Confirm the issue transitions to "Done" and **no** "Failed" toast appears
- [ ] Reject flow also completes without a toast error
- [ ] Database-change issues (which do have a plan) still refresh plan + rollout correctly after approve/reject
- [ ] `pnpm --dir frontend fix` and `pnpm --dir frontend type-check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)