### PR TITLE
fix(frontend): display "in" instead of "@in" in CEL operator dropdown

### DIFF
--- a/frontend/src/plugins/cel/types/operator.ts
+++ b/frontend/src/plugins/cel/types/operator.ts
@@ -81,6 +81,7 @@ const OPERATOR_DISPLAY: Record<string, string> = {
   ">=": "≥",
   "==": "=",
   "!=": "≠",
+  "@in": "in",
   "@not_in": "not in",
   "@not_contains": "not contains",
 };


### PR DESCRIPTION
## Summary

Fixes BYT-9317. The CEL condition operator dropdown (approval flow, risk rules, role grants, masking exemptions) rendered `@in` literally while its negative counterpart rendered as `not in`, producing an inconsistent list:

    =
    ≠
    @in          ← leading "@" leaks into UI
    not in
    contains
    not contains
    ...

## Root cause

CEL represents the `in` collection operator as `@in` in its AST (and `@not_in`, `@not_contains` for the negatives). The operator dropdown uses `operatorDisplayLabel()` in `frontend/src/plugins/cel/types/operator.ts` to translate AST tokens into human-readable labels via an `OPERATOR_DISPLAY` map.

The map had entries for `@not_in` → `not in` and `@not_contains` → `not contains`, but no entry for `@in`. So `@in` fell through the map and was rendered as-is, while `@not_in` was rewritten. That's the asymmetry.

Both the Vue picker (`components/ExprEditor/components/OperatorSelect.vue`) and the React picker (`react/components/ExprEditor.tsx`) share this helper, so the bug appeared in both.

## Fix

One-line addition to `OPERATOR_DISPLAY`:

```ts
"@in": "in",
```

- Display-layer only. The stored CEL value remains `@in`, so there's no impact on persisted conditions, backend parsing, or API payloads.
- No breaking change: behavior of existing data is unchanged; only the user-facing label for the `@in` option is corrected.

## Test plan

- [ ] Open any CEL condition editor (Custom Approval rule, risk rule, role grant, masking exemption). Verify the operator dropdown shows `in` (no leading `@`) alongside `not in`, `contains`, `not contains`, etc.
- [ ] Select `in`, save the expression, reopen — the saved expression still loads and the dropdown still shows the normalized label.
- [ ] Existing expressions using `@in` (in DB) continue to display correctly after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)