### PR TITLE
fix(BYT-9319): stabilize default QueryDataPolicy reference

### DIFF
--- a/frontend/src/store/modules/v1/policy.ts
+++ b/frontend/src/store/modules/v1/policy.ts
@@ -42,6 +42,13 @@ export const replacePolicyTypeNameToLowerCase = (name: string) => {
   return replaced;
 };
 
+// Shared default returned when no DATA_QUERY policy exists for a parent.
+// Must be a stable singleton so subscribers (e.g. React useVueState) don't
+// see a new reference on every call and thrash their effects.
+const EMPTY_QUERY_DATA_POLICY: QueryDataPolicy = create(QueryDataPolicySchema, {
+  maximumResultRows: -1,
+});
+
 export const usePolicyV1Store = defineStore("policy_v1", () => {
   const state = reactive<PolicyState>({
     policyMapByName: new Map(),
@@ -54,9 +61,7 @@ export const usePolicyV1Store = defineStore("policy_v1", () => {
     });
     return policy?.policy?.case === "queryDataPolicy"
       ? policy.policy.value
-      : create(QueryDataPolicySchema, {
-          maximumResultRows: -1,
-        });
+      : EMPTY_QUERY_DATA_POLICY;
   };
 
   const getOrFetchPolicyByParentAndType = async ({


### PR DESCRIPTION
## Summary

- Fixes the project settings **Maximum SQL Result rows** input silently reverting typed values to `0` on projects that don't yet have a `DATA_QUERY` policy stored (reproducible on fresh projects; masked once any policy is saved).
- Root cause: `getQueryDataPolicyByParent` returned `create(QueryDataPolicySchema, { maximumResultRows: -1 })` as its empty-policy fallback, constructing a new object on every call. `ProjectSettingsPage.tsx` subscribes via `useVueState`, which tracks by reference — the churning reference flipped `getInitialMaxRows`' `useCallback` identity, which refired the reset `useEffect`, which overwrote the user's typed value on the next render.
- Fix: hoist the fallback to a module-level singleton so the reference stays stable across calls. All call sites either read fields or spread the returned object, so sharing a frozen default is safe.
- `SQLEditorSection.tsx` (workspace settings) was already immune because it guards its reset with `isEqual(prev, next)`; no page-level changes needed.

## Test plan

- [ ] On a fresh project with no `DATA_QUERY` policy, open project settings and change `Maximum SQL Result rows` — typed value should persist, and Save should update the policy.
- [ ] Revisit an existing project with an already-saved `DATA_QUERY` policy — no regression; updating `Maximum SQL Result rows` still works.
- [ ] Workspace settings `Maximum SQL Result rows` (backed by `SQLEditorSection`) continues to work.
- [ ] SQL Editor copy-data / export gating (`ResultViewV1.vue`, `policy.ts:253-268`) reads `.disableCopyData`, `.disableExport`, etc. on the shared default — values are unchanged, so no behavioral difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)