### PR TITLE
fix(BYT-9319): allow clearing number inputs in settings

### DIFF
--- a/frontend/src/react/components/ui/number-input.test.tsx
+++ b/frontend/src/react/components/ui/number-input.test.tsx
@@ -1,0 +1,72 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test } from "vitest";
+import { NumberInput } from "./number-input";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function mount(node: React.ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return { container, root };
+}
+
+describe("NumberInput", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("renders empty when value is null", () => {
+    const { container } = mount(
+      <NumberInput value={null} onValueChange={() => {}} />
+    );
+    const input = container.querySelector("input") as HTMLInputElement | null;
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    expect(input?.value).toBe("");
+  });
+
+  test("displays the controlled numeric value as a formatted string", () => {
+    const { container } = mount(
+      <NumberInput value={42} onValueChange={() => {}} />
+    );
+    const input = container.querySelector("input") as HTMLInputElement | null;
+    expect(input?.value).toBe("42");
+  });
+
+  test("renders the suffix content alongside the input", () => {
+    const { container } = mount(
+      <NumberInput value={10} onValueChange={() => {}} suffix="rows" />
+    );
+    expect(container.textContent).toContain("rows");
+    expect(container.querySelector("input")).toBeInstanceOf(HTMLInputElement);
+  });
+
+  test("applies className to the outer wrapper and size variant to the input", () => {
+    const { container } = mount(
+      <NumberInput
+        value={null}
+        onValueChange={() => {}}
+        className="w-60"
+        size="sm"
+      />
+    );
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    const input = container.querySelector("input");
+    expect(wrapper?.className).toContain("w-60");
+    expect(input?.className).toContain("h-8");
+  });
+
+  test("forwards the disabled prop to the underlying input", () => {
+    const { container } = mount(
+      <NumberInput value={1} onValueChange={() => {}} disabled />
+    );
+    const input = container.querySelector("input") as HTMLInputElement | null;
+    expect(input?.disabled).toBe(true);
+  });
+});

--- a/frontend/src/react/components/ui/number-input.tsx
+++ b/frontend/src/react/components/ui/number-input.tsx
@@ -1,0 +1,95 @@
+import { NumberField } from "@base-ui/react/number-field";
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { cn } from "@/react/lib/utils";
+
+// Mirrors the sizing/appearance of ./input.tsx so NumberInput visually matches
+// the regular Input at every size.
+const numberInputClasses = cva(
+  cn(
+    "flex w-full rounded-xs border border-control-border bg-transparent text-main transition-colors",
+    "placeholder:text-control-placeholder",
+    "focus:outline-hidden",
+    "disabled:cursor-not-allowed disabled:bg-control-bg disabled:opacity-50",
+    "read-only:cursor-default read-only:bg-control-bg read-only:focus:ring-0 read-only:focus:border-control-border"
+  ),
+  {
+    variants: {
+      size: {
+        xs: "h-6 px-2 text-xs leading-4",
+        sm: "h-8 px-3 text-xs leading-4",
+        md: "h-9 px-3 text-sm leading-5",
+        lg: "h-10 px-3 text-sm leading-5",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  }
+);
+
+type NumberFieldRootProps = ComponentPropsWithoutRef<typeof NumberField.Root>;
+
+interface NumberInputProps
+  extends Omit<
+      NumberFieldRootProps,
+      "className" | "render" | "size" | "prefix"
+    >,
+    VariantProps<typeof numberInputClasses> {
+  /** Applied to the outer wrapper; use for layout/width classes (e.g. "w-60"). */
+  className?: string;
+  /** Applied to the underlying input element for extra input-specific styling. */
+  inputClassName?: string;
+  placeholder?: string;
+  /** Content rendered inside the field to the right of the input (e.g. unit). */
+  suffix?: ReactNode;
+  /** Content rendered inside the field to the left of the input. */
+  prefix?: ReactNode;
+}
+
+function NumberInput({
+  className,
+  inputClassName,
+  size,
+  suffix,
+  prefix,
+  placeholder,
+  ...rootProps
+}: NumberInputProps) {
+  const hasAffix = Boolean(prefix || suffix);
+  const inputClasses = cn(
+    numberInputClasses({ size }),
+    prefix && "pl-10",
+    suffix && "pr-12",
+    inputClassName
+  );
+
+  if (!hasAffix) {
+    return (
+      <NumberField.Root {...rootProps} className={className}>
+        <NumberField.Input placeholder={placeholder} className={inputClasses} />
+      </NumberField.Root>
+    );
+  }
+
+  return (
+    <NumberField.Root {...rootProps} className={className}>
+      <NumberField.Group className="relative inline-flex w-full items-center">
+        {prefix && (
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-control-light">
+            {prefix}
+          </span>
+        )}
+        <NumberField.Input placeholder={placeholder} className={inputClasses} />
+        {suffix && (
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-control-light">
+            {suffix}
+          </span>
+        )}
+      </NumberField.Group>
+    </NumberField.Root>
+  );
+}
+
+export { NumberInput };
+export type { NumberInputProps };

--- a/frontend/src/react/pages/project/ProjectSettingsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSettingsPage.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/react/components/ui/dialog";
 import { Input } from "@/react/components/ui/input";
+import { NumberInput } from "@/react/components/ui/number-input";
 import { Switch } from "@/react/components/ui/switch";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -186,7 +187,11 @@ export function ProjectSettingsPage() {
     const rows = Number(queryDataPolicy?.maximumResultRows ?? 0);
     return rows < 0 ? 0 : rows;
   }, [queryDataPolicy]);
-  const [maxRows, setMaxRows] = useState(() => getInitialMaxRows());
+  // `null` represents a transiently empty input while the user is typing;
+  // coerced to 0 on save.
+  const [maxRows, setMaxRows] = useState<number | null>(() =>
+    getInitialMaxRows()
+  );
 
   const [allowRequestRole, setAllowRequestRole] = useState(
     project?.allowRequestRole ?? false
@@ -226,15 +231,15 @@ export function ProjectSettingsPage() {
   const [postgresDatabaseTenantMode, setPostgresDatabaseTenantMode] = useState(
     project?.postgresDatabaseTenantMode ?? false
   );
-  const [maxRetries, setMaxRetries] = useState(
+  const [maxRetries, setMaxRetries] = useState<number | null>(
     project?.executionRetryPolicy?.maximumRetries ?? 0
   );
-  const [ciSamplingSize, setCiSamplingSize] = useState(
+  const [ciSamplingSize, setCiSamplingSize] = useState<number | null>(
     project?.ciSamplingSize ?? 0
   );
-  const [parallelTasksPerRollout, setParallelTasksPerRollout] = useState(
-    project?.parallelTasksPerRollout ?? 1
-  );
+  const [parallelTasksPerRollout, setParallelTasksPerRollout] = useState<
+    number | null
+  >(project?.parallelTasksPerRollout ?? 1);
 
   // New issue label input
   const [newLabelValue, setNewLabelValue] = useState("");
@@ -291,7 +296,7 @@ export function ProjectSettingsPage() {
     )
       return true;
     // Max rows
-    if (maxRows !== getInitialMaxRows()) return true;
+    if ((maxRows ?? 0) !== getInitialMaxRows()) return true;
     // Project toggles
     if (allowRequestRole !== project.allowRequestRole) return true;
     if (allowJustInTimeAccess !== project.allowJustInTimeAccess) return true;
@@ -306,10 +311,14 @@ export function ProjectSettingsPage() {
       return true;
     if (postgresDatabaseTenantMode !== project.postgresDatabaseTenantMode)
       return true;
-    if (maxRetries !== (project.executionRetryPolicy?.maximumRetries ?? 0))
+    if (
+      (maxRetries ?? 0) !== (project.executionRetryPolicy?.maximumRetries ?? 0)
+    )
       return true;
-    if (ciSamplingSize !== (project.ciSamplingSize ?? 0)) return true;
-    if (parallelTasksPerRollout !== (project.parallelTasksPerRollout ?? 0))
+    if ((ciSamplingSize ?? 0) !== (project.ciSamplingSize ?? 0)) return true;
+    if (
+      (parallelTasksPerRollout ?? 0) !== (project.parallelTasksPerRollout ?? 0)
+    )
       return true;
     return false;
   }, [
@@ -419,7 +428,8 @@ export function ProjectSettingsPage() {
       }
 
       // 2. Max rows policy (separate API)
-      if (maxRows !== getInitialMaxRows()) {
+      const maxRowsValue = maxRows ?? 0;
+      if (maxRowsValue !== getInitialMaxRows()) {
         await policyStore.upsertPolicy({
           parentPath: projectName,
           policy: {
@@ -429,7 +439,7 @@ export function ProjectSettingsPage() {
               case: "queryDataPolicy",
               value: create(QueryDataPolicySchema, {
                 ...queryDataPolicy,
-                maximumResultRows: maxRows,
+                maximumResultRows: maxRowsValue,
               }),
             },
           },
@@ -488,19 +498,26 @@ export function ProjectSettingsPage() {
         projectPatch.postgresDatabaseTenantMode = postgresDatabaseTenantMode;
         updateMask.push("postgres_database_tenant_mode");
       }
-      if (maxRetries !== (project.executionRetryPolicy?.maximumRetries ?? 0)) {
+      const maxRetriesValue = maxRetries ?? 0;
+      if (
+        maxRetriesValue !== (project.executionRetryPolicy?.maximumRetries ?? 0)
+      ) {
         projectPatch.executionRetryPolicy = create(
           Project_ExecutionRetryPolicySchema,
-          { maximumRetries: maxRetries }
+          { maximumRetries: maxRetriesValue }
         );
         updateMask.push("execution_retry_policy");
       }
-      if (ciSamplingSize !== (project.ciSamplingSize ?? 0)) {
-        projectPatch.ciSamplingSize = ciSamplingSize;
+      const ciSamplingSizeValue = ciSamplingSize ?? 0;
+      if (ciSamplingSizeValue !== (project.ciSamplingSize ?? 0)) {
+        projectPatch.ciSamplingSize = ciSamplingSizeValue;
         updateMask.push("ci_sampling_size");
       }
-      if (parallelTasksPerRollout !== (project.parallelTasksPerRollout ?? 0)) {
-        projectPatch.parallelTasksPerRollout = parallelTasksPerRollout;
+      const parallelTasksPerRolloutValue = parallelTasksPerRollout ?? 0;
+      if (
+        parallelTasksPerRolloutValue !== (project.parallelTasksPerRollout ?? 0)
+      ) {
+        projectPatch.parallelTasksPerRollout = parallelTasksPerRolloutValue;
         updateMask.push("parallel_tasks_per_rollout");
       }
       if (updateMask.length > 0) {
@@ -786,15 +803,11 @@ export function ProjectSettingsPage() {
                       </span>
                     </p>
                     <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-                      <Input
-                        type="number"
+                      <NumberInput
                         className="w-60"
                         min={0}
-                        value={String(maxRows)}
-                        onChange={(e) => {
-                          const v = parseInt(e.target.value, 10);
-                          if (!Number.isNaN(v) && v >= 0) setMaxRows(v);
-                        }}
+                        value={maxRows}
+                        onValueChange={setMaxRows}
                         disabled={!hasQueryPolicyFeature || !canUpdatePolicies}
                       />
                       <span className="text-sm text-control-light">
@@ -1313,8 +1326,8 @@ function NumericRow({
 }: {
   label: string;
   description: string;
-  value: number;
-  onChange: (v: number) => void;
+  value: number | null;
+  onChange: (v: number | null) => void;
   disabled: boolean;
   suffix?: string;
 }) {
@@ -1323,15 +1336,11 @@ function NumericRow({
       <p className="text-sm font-medium">{label}</p>
       <p className="mb-3 text-sm text-control-placeholder">{description}</p>
       <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-        <Input
-          type="number"
+        <NumberInput
           className="w-60"
           min={0}
-          value={String(value)}
-          onChange={(e) => {
-            const v = parseInt(e.target.value, 10);
-            if (!Number.isNaN(v) && v >= 0) onChange(v);
-          }}
+          value={value}
+          onValueChange={onChange}
           disabled={disabled}
         />
         {suffix && <span className="text-sm text-control-light">{suffix}</span>}

--- a/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
+++ b/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
@@ -123,9 +123,22 @@ export const SQLEditorSection = forwardRef<
     }
   }, [getInitialState]);
 
+  // Normalize `null` (transiently empty inputs) to the same defaults used by
+  // `update()` so that a cleared-then-saved field doesn't leave the section
+  // permanently dirty.
+  const normalizeForCompare = useCallback(
+    (s: LocalState): LocalState => ({
+      ...s,
+      maximumResultSize: s.maximumResultSize ?? DEFAULT_MAX_RESULT_SIZE_IN_MB,
+      maximumResultRows: s.maximumResultRows ?? 0,
+      maxQueryTimeInSeconds: s.maxQueryTimeInSeconds ?? 0,
+    }),
+    []
+  );
+
   const isDirty = useCallback(
-    () => !isEqual(state, getInitialState()),
-    [state, getInitialState]
+    () => !isEqual(normalizeForCompare(state), getInitialState()),
+    [state, getInitialState, normalizeForCompare]
   );
 
   const revert = useCallback(() => {

--- a/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
+++ b/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
@@ -2,7 +2,6 @@ import { create } from "@bufbuild/protobuf";
 import { DurationSchema, FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import { isEqual } from "lodash-es";
 import {
-  type ChangeEvent,
   forwardRef,
   useCallback,
   useEffect,
@@ -13,7 +12,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
-import { Input } from "@/react/components/ui/input";
+import { NumberInput } from "@/react/components/ui/number-input";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
   DEFAULT_MAX_RESULT_SIZE_IN_MB,
@@ -40,9 +39,11 @@ interface LocalState {
   disableExport: boolean;
   disableCopyData: boolean;
   allowAdminDataSource: boolean;
-  maximumResultSize: number;
-  maximumResultRows: number;
-  maxQueryTimeInSeconds: number;
+  // `null` represents an empty input while the user is typing; coerced to a
+  // number on save.
+  maximumResultSize: number | null;
+  maximumResultRows: number | null;
+  maxQueryTimeInSeconds: number | null;
 }
 
 export const SQLEditorSection = forwardRef<
@@ -134,12 +135,17 @@ export const SQLEditorSection = forwardRef<
   const update = useCallback(async () => {
     const init = getInitialState();
 
+    const maxQueryTimeInSeconds = state.maxQueryTimeInSeconds ?? 0;
+    const maximumResultSize =
+      state.maximumResultSize ?? DEFAULT_MAX_RESULT_SIZE_IN_MB;
+    const maximumResultRows = state.maximumResultRows ?? 0;
+
     // Update query timeout if changed
-    if (init.maxQueryTimeInSeconds !== state.maxQueryTimeInSeconds) {
+    if (init.maxQueryTimeInSeconds !== maxQueryTimeInSeconds) {
       await settingV1Store.updateWorkspaceProfile({
         payload: {
           queryTimeout: create(DurationSchema, {
-            seconds: BigInt(state.maxQueryTimeInSeconds),
+            seconds: BigInt(maxQueryTimeInSeconds),
           }),
         },
         updateMask: create(FieldMaskSchema, {
@@ -149,10 +155,10 @@ export const SQLEditorSection = forwardRef<
     }
 
     // Update result size if changed
-    if (init.maximumResultSize !== state.maximumResultSize) {
+    if (init.maximumResultSize !== maximumResultSize) {
       await settingV1Store.updateWorkspaceProfile({
         payload: {
-          sqlResultSize: BigInt(state.maximumResultSize * 1024 * 1024),
+          sqlResultSize: BigInt(maximumResultSize * 1024 * 1024),
         },
         updateMask: create(FieldMaskSchema, {
           paths: ["value.workspace_profile.sql_result_size"],
@@ -173,7 +179,7 @@ export const SQLEditorSection = forwardRef<
             disableExport: state.disableExport,
             disableCopyData: state.disableCopyData,
             allowAdminDataSource: state.allowAdminDataSource,
-            maximumResultRows: state.maximumResultRows,
+            maximumResultRows,
           }),
         },
       },
@@ -203,11 +209,9 @@ export const SQLEditorSection = forwardRef<
 
   const handleNumberInput = (
     field: "maximumResultSize" | "maximumResultRows" | "maxQueryTimeInSeconds",
-    e: ChangeEvent<HTMLInputElement>
+    value: number | null
   ) => {
-    const val = parseInt(e.target.value, 10);
-    if (Number.isNaN(val)) return;
-    setState((prev) => ({ ...prev, [field]: val }));
+    setState((prev) => ({ ...prev, [field]: value }));
   };
 
   return (
@@ -303,19 +307,16 @@ export const SQLEditorSection = forwardRef<
                 </span>
               </p>
               <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-                <div className="relative w-60">
-                  <Input
-                    type="number"
-                    value={state.maximumResultSize}
-                    min={1}
-                    disabled={!hasQueryPolicyFeature || !canSetWorkspaceProfile}
-                    onChange={(e) => handleNumberInput("maximumResultSize", e)}
-                    className="pr-12"
-                  />
-                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
-                    MB
-                  </span>
-                </div>
+                <NumberInput
+                  className="w-60"
+                  value={state.maximumResultSize}
+                  min={1}
+                  disabled={!hasQueryPolicyFeature || !canSetWorkspaceProfile}
+                  onValueChange={(v) =>
+                    handleNumberInput("maximumResultSize", v)
+                  }
+                  suffix="MB"
+                />
               </div>
             </div>
           </PermissionGuard>
@@ -339,19 +340,17 @@ export const SQLEditorSection = forwardRef<
               </span>
             </p>
             <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-              <div className="relative w-60">
-                <Input
-                  type="number"
-                  value={state.maximumResultRows}
-                  min={0}
-                  disabled={!hasQueryPolicyFeature || !canUpdatePolicy}
-                  onChange={(e) => handleNumberInput("maximumResultRows", e)}
-                  className="pr-16"
-                />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
-                  {t("settings.general.workspace.maximum-sql-result.rows.rows")}
-                </span>
-              </div>
+              <NumberInput
+                className="w-60"
+                value={state.maximumResultRows}
+                min={0}
+                disabled={!hasQueryPolicyFeature || !canUpdatePolicy}
+                onValueChange={(v) => handleNumberInput("maximumResultRows", v)}
+                inputClassName="pr-16"
+                suffix={t(
+                  "settings.general.workspace.maximum-sql-result.rows.rows"
+                )}
+              />
             </div>
           </div>
         </PermissionGuard>
@@ -377,21 +376,19 @@ export const SQLEditorSection = forwardRef<
               </span>
             </p>
             <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-              <div className="relative w-60">
-                <Input
-                  type="number"
-                  value={state.maxQueryTimeInSeconds}
-                  min={0}
-                  disabled={!hasQueryPolicyFeature || !canSetWorkspaceProfile}
-                  onChange={(e) =>
-                    handleNumberInput("maxQueryTimeInSeconds", e)
-                  }
-                  className="pr-20"
-                />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
-                  {t("settings.general.workspace.query-data-policy.seconds")}
-                </span>
-              </div>
+              <NumberInput
+                className="w-60"
+                value={state.maxQueryTimeInSeconds}
+                min={0}
+                disabled={!hasQueryPolicyFeature || !canSetWorkspaceProfile}
+                onValueChange={(v) =>
+                  handleNumberInput("maxQueryTimeInSeconds", v)
+                }
+                inputClassName="pr-20"
+                suffix={t(
+                  "settings.general.workspace.query-data-policy.seconds"
+                )}
+              />
             </div>
           </div>
         </PermissionGuard>


### PR DESCRIPTION
## Summary

- Fixes the second half of BYT-9319: in workspace and project settings, backspacing the last digit of a number input (Maximum SQL Result rows, Query Timeout, CI Sampling Size, etc.) was a no-op — the digit would snap back and the field could not be cleared to retype.
- Root cause: `onChange` handlers parsed `e.target.value` via `parseInt`, silently rejected `NaN`, and left state unchanged. When the field became empty, `parseInt("") === NaN` → state unchanged → React immediately re-asserted the old number through the controlled `value={String(n)}`.
- Fix: introduce `<NumberInput>` in `src/react/components/ui/number-input.tsx`, wrapping Base UI's `NumberField` primitive. It already buffers string input internally and exposes a clean `value: number | null` contract. Consumers' state types for the affected fields are widened to `number | null`; save paths coerce null to a sensible default (0 for counts/seconds, `DEFAULT_MAX_RESULT_SIZE_IN_MB` for MB).
- Three surfaces migrated: workspace `SQLEditorSection` (result size MB, result rows, query timeout) and project `ProjectSettingsPage` (max result rows + the shared `NumericRow` used for max retries, CI sampling size, parallel tasks per rollout).

## UX note — native spinner removed

Base UI's `NumberField.Input` renders `<input type=\"text\" inputMode=\"decimal\">` internally rather than `type=\"number\"`. That deliberately drops the browser's native up/down spinner buttons on the right edge of the input (Chrome/Firefox/Safari). Rationale for accepting this tradeoff:

- The spinner is removed on purpose — it's the same choice Chakra, Mantine, Ant Design, and React Aria's NumberField all make, because `type=\"number\"` has well-documented quirks (accidental wheel-scroll changing values, locale parsing issues, `e.target.value` lossy for intermediate states — exactly the bug we're fixing).
- Keyboard stepping still works: ArrowUp / ArrowDown step by 1, Shift+Arrow by 10 (`largeStep`), Meta+Arrow by 0.1 (`smallStep`). Base UI handles this natively with `role=\"spinbutton\"` so screen readers also see it as a number field.
- Mouse-wheel stepping is opt-in via `allowWheelScrub` (disabled by default; not enabled here).
- If a future call site wants visible +/− buttons, we can add them by composing `NumberField.Increment` / `NumberField.Decrement` inside the wrapper.

## Component API

```tsx
<NumberInput
  value={maxRows}                 // number | null
  onValueChange={setMaxRows}      // (v: number | null) => void
  min={0}
  size=\"md\"                       // xs | sm | md | lg (matches <Input>)
  suffix={t(\"...rows.rows\")}      // optional affix rendered inside the field
  className=\"w-60\"
  disabled={!canUpdatePolicy}
/>
```

`size` variants match `<Input>`'s so the two look identical at every size. `prefix`/`suffix` render inside `NumberField.Group` with absolute positioning; `inputClassName` is available as an escape hatch for adjusting the right-padding when suffixes are long.

## Test plan

- [x] `pnpm type-check`, `pnpm fix`, `pnpm check`, `pnpm test --run` all green (1222 tests, 5 new for NumberInput).
- [x] Workspace Settings → General → SQL Editor: backspace \"1000\" → \"100\" → \"10\" → \"1\" → \"\". Confirm the field stays empty, no snap-back. Retype \"500\", save — confirm persistence.
- [ ] Repeat for Query Timeout (seconds) and Maximum Result Size (MB) in the same panel.
- [ ] Project Settings → Security & Policy → Maximum SQL Result rows: same backspace-to-empty flow; save; reopen; confirm the saved value renders.
- [ ] Project Settings → Issue-Related → Max retries, CI sampling size, Parallel tasks per rollout: same flow via the shared `NumericRow`.
- [ ] Keyboard: focus a number input, press ArrowUp / ArrowDown — confirm value increments/decrements.

## Breaking changes

None (API, proto, schema, config, webhooks, workflow all unchanged). The native browser spinner removal is a UX change to cosmetic controls that are being replaced by keyboard + future opt-in custom steppers — documented above for visibility rather than flagged as breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)