### PR TITLE
fix(BYT-9319): migrate remaining snap-back number inputs to NumberInput

### DIFF
--- a/frontend/src/react/pages/settings/SemanticTypesPage.tsx
+++ b/frontend/src/react/pages/settings/SemanticTypesPage.tsx
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
+import { NumberInput } from "@/react/components/ui/number-input";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
@@ -505,12 +506,14 @@ function MaskingAlgorithmDrawer({
       ? algorithm.mask.value.type
       : Algorithm_InnerOuterMask_MaskType.INNER
   );
-  const [innerOuterPrefix, setInnerOuterPrefix] = useState(
+  // `number | null`: `null` represents an empty input while the user is
+  // typing; coerced to `0` on save.
+  const [innerOuterPrefix, setInnerOuterPrefix] = useState<number | null>(
     algorithm?.mask?.case === "innerOuterMask"
       ? algorithm.mask.value.prefixLen
       : 0
   );
-  const [innerOuterSuffix, setInnerOuterSuffix] = useState(
+  const [innerOuterSuffix, setInnerOuterSuffix] = useState<number | null>(
     algorithm?.mask?.case === "innerOuterMask"
       ? algorithm.mask.value.suffixLen
       : 0
@@ -659,8 +662,8 @@ function MaskingAlgorithmDrawer({
             case: "innerOuterMask",
             value: create(Algorithm_InnerOuterMaskSchema, {
               type: innerOuterType,
-              prefixLen: innerOuterPrefix,
-              suffixLen: innerOuterSuffix,
+              prefixLen: innerOuterPrefix ?? 0,
+              suffixLen: innerOuterSuffix ?? 0,
               substitution: innerOuterSubstitution,
             }),
           },
@@ -924,15 +927,11 @@ function MaskingAlgorithmDrawer({
                       )}
                       <span className="text-error ml-0.5">*</span>
                     </label>
-                    <Input
-                      type="number"
+                    <NumberInput
                       value={innerOuterPrefix}
                       className="w-24"
-                      onChange={(e) => {
-                        const val = Number(e.target.value);
-                        if (!Number.isNaN(val) && val >= 0)
-                          setInnerOuterPrefix(val);
-                      }}
+                      min={0}
+                      onValueChange={setInnerOuterPrefix}
                     />
                   </div>
                   <div className="flex flex-col gap-y-1">
@@ -942,15 +941,11 @@ function MaskingAlgorithmDrawer({
                       )}
                       <span className="text-error ml-0.5">*</span>
                     </label>
-                    <Input
-                      type="number"
+                    <NumberInput
                       value={innerOuterSuffix}
                       className="w-24"
-                      onChange={(e) => {
-                        const val = Number(e.target.value);
-                        if (!Number.isNaN(val) && val >= 0)
-                          setInnerOuterSuffix(val);
-                      }}
+                      min={0}
+                      onValueChange={setInnerOuterSuffix}
                     />
                   </div>
                   <div className="flex-1 flex flex-col gap-y-1">

--- a/frontend/src/react/pages/settings/SemanticTypesPage.tsx
+++ b/frontend/src/react/pages/settings/SemanticTypesPage.tsx
@@ -662,8 +662,9 @@ function MaskingAlgorithmDrawer({
             case: "innerOuterMask",
             value: create(Algorithm_InnerOuterMaskSchema, {
               type: innerOuterType,
-              prefixLen: innerOuterPrefix ?? 0,
-              suffixLen: innerOuterSuffix ?? 0,
+              // Proto field is int32 — floor any fractional input defensively.
+              prefixLen: Math.floor(innerOuterPrefix ?? 0),
+              suffixLen: Math.floor(innerOuterSuffix ?? 0),
               substitution: innerOuterSubstitution,
             }),
           },
@@ -931,6 +932,7 @@ function MaskingAlgorithmDrawer({
                       value={innerOuterPrefix}
                       className="w-24"
                       min={0}
+                      step={1}
                       onValueChange={setInnerOuterPrefix}
                     />
                   </div>
@@ -945,6 +947,7 @@ function MaskingAlgorithmDrawer({
                       value={innerOuterSuffix}
                       className="w-24"
                       min={0}
+                      step={1}
                       onValueChange={setInnerOuterSuffix}
                     />
                   </div>

--- a/frontend/src/react/pages/settings/general/AccountSection.tsx
+++ b/frontend/src/react/pages/settings/general/AccountSection.tsx
@@ -66,14 +66,26 @@ interface TokenState {
 const EMPTY_TOKEN_DURATION_DEFAULT = 1;
 const EMPTY_INACTIVE_TIMEOUT_DEFAULT = -1;
 
+// Canonicalizes TokenState for both isDirty comparison and save: coerces
+// transient `null` inputs to defaults and floors any fractional values (paste
+// of "1.5" etc.) so the two paths always agree on what counts as a change.
 function normalizeTokenState(state: TokenState): TokenState {
+  const floorOr = (v: number | null, fallback: number): number =>
+    Math.floor(v ?? fallback);
   return {
     ...state,
-    accessTokenDuration:
-      state.accessTokenDuration ?? EMPTY_TOKEN_DURATION_DEFAULT,
-    refreshTokenDuration:
-      state.refreshTokenDuration ?? EMPTY_TOKEN_DURATION_DEFAULT,
-    inactiveTimeout: state.inactiveTimeout ?? EMPTY_INACTIVE_TIMEOUT_DEFAULT,
+    accessTokenDuration: floorOr(
+      state.accessTokenDuration,
+      EMPTY_TOKEN_DURATION_DEFAULT
+    ),
+    refreshTokenDuration: floorOr(
+      state.refreshTokenDuration,
+      EMPTY_TOKEN_DURATION_DEFAULT
+    ),
+    inactiveTimeout: floorOr(
+      state.inactiveTimeout,
+      EMPTY_INACTIVE_TIMEOUT_DEFAULT
+    ),
   };
 }
 
@@ -277,20 +289,14 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
         updateMaskPaths.push("value.workspace_profile.password_restriction");
       }
 
-      // Token durations (coerce transient `null` inputs to defaults before
-      // save, then floor to integers — the proto fields convert to BigInt
-      // seconds, which rejects fractional values).
+      // Token durations — `normalizeTokenState` coerces transient `null`
+      // inputs to defaults and floors fractional values, so the resolved
+      // shape matches what isDirty compared against.
       const initToken = getInitialTokenState();
       const resolvedToken = normalizeTokenState(tokenState);
-      const accessTokenDuration = Math.floor(
-        resolvedToken.accessTokenDuration as number
-      );
-      const refreshTokenDuration = Math.floor(
-        resolvedToken.refreshTokenDuration as number
-      );
-      const inactiveTimeout = Math.floor(
-        resolvedToken.inactiveTimeout as number
-      );
+      const accessTokenDuration = resolvedToken.accessTokenDuration as number;
+      const refreshTokenDuration = resolvedToken.refreshTokenDuration as number;
+      const inactiveTimeout = resolvedToken.inactiveTimeout as number;
 
       if (
         initToken.accessTokenDuration !== accessTokenDuration ||

--- a/frontend/src/react/pages/settings/general/AccountSection.tsx
+++ b/frontend/src/react/pages/settings/general/AccountSection.tsx
@@ -18,6 +18,7 @@ import {
   usePermissionCheck,
 } from "@/react/components/PermissionGuard";
 import { Input } from "@/react/components/ui/input";
+import { NumberInput } from "@/react/components/ui/number-input";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
   useActuatorV1Store,
@@ -51,11 +52,29 @@ interface ToggleState {
 }
 
 interface TokenState {
-  accessTokenDuration: number;
+  // `null` represents an empty input while the user is typing; coerced to
+  // sensible defaults (1 for durations, -1 for inactiveTimeout = "no limit")
+  // on save and dirty comparison.
+  accessTokenDuration: number | null;
   accessTokenTimeFormat: "MINUTES" | "HOURS";
-  refreshTokenDuration: number;
+  refreshTokenDuration: number | null;
   refreshTokenTimeFormat: "HOURS" | "DAYS";
-  inactiveTimeout: number;
+  inactiveTimeout: number | null;
+}
+
+// Defaults used when the user leaves a duration field empty.
+const EMPTY_TOKEN_DURATION_DEFAULT = 1;
+const EMPTY_INACTIVE_TIMEOUT_DEFAULT = -1;
+
+function normalizeTokenState(state: TokenState): TokenState {
+  return {
+    ...state,
+    accessTokenDuration:
+      state.accessTokenDuration ?? EMPTY_TOKEN_DURATION_DEFAULT,
+    refreshTokenDuration:
+      state.refreshTokenDuration ?? EMPTY_TOKEN_DURATION_DEFAULT,
+    inactiveTimeout: state.inactiveTimeout ?? EMPTY_INACTIVE_TIMEOUT_DEFAULT,
+  };
 }
 
 interface AccountSectionProps {
@@ -208,6 +227,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       if (
         prevAccessFormat.current !== tokenState.accessTokenTimeFormat &&
         tokenState.accessTokenTimeFormat === "MINUTES" &&
+        tokenState.accessTokenDuration !== null &&
         tokenState.accessTokenDuration > 59
       ) {
         setTokenState((s) => ({ ...s, accessTokenDuration: 59 }));
@@ -221,6 +241,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       if (
         prevRefreshFormat.current !== tokenState.refreshTokenTimeFormat &&
         tokenState.refreshTokenTimeFormat === "HOURS" &&
+        tokenState.refreshTokenDuration !== null &&
         tokenState.refreshTokenDuration > 23
       ) {
         setTokenState((s) => ({ ...s, refreshTokenDuration: 23 }));
@@ -234,7 +255,12 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       passwordState,
       getInitialPasswordRestriction()
     );
-    const isTokenDirty = !isEqual(tokenState, getInitialTokenState());
+    // Normalize transient empty inputs (`null`) before comparing so a
+    // cleared-then-saved field doesn't leave the section permanently dirty.
+    const isTokenDirty = !isEqual(
+      normalizeTokenState(tokenState),
+      getInitialTokenState()
+    );
     const isDirty = isToggleDirty || isPasswordDirty || isTokenDirty;
 
     // --- Update ---
@@ -251,16 +277,21 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
         updateMaskPaths.push("value.workspace_profile.password_restriction");
       }
 
-      // Token durations
+      // Token durations (coerce transient `null` inputs to defaults before save).
       const initToken = getInitialTokenState();
+      const resolvedToken = normalizeTokenState(tokenState);
+      const accessTokenDuration = resolvedToken.accessTokenDuration as number;
+      const refreshTokenDuration = resolvedToken.refreshTokenDuration as number;
+      const inactiveTimeout = resolvedToken.inactiveTimeout as number;
+
       if (
-        initToken.accessTokenDuration !== tokenState.accessTokenDuration ||
+        initToken.accessTokenDuration !== accessTokenDuration ||
         initToken.accessTokenTimeFormat !== tokenState.accessTokenTimeFormat
       ) {
         const seconds =
           tokenState.accessTokenTimeFormat === "MINUTES"
-            ? tokenState.accessTokenDuration * 60
-            : tokenState.accessTokenDuration * 60 * 60;
+            ? accessTokenDuration * 60
+            : accessTokenDuration * 60 * 60;
         payload.accessTokenDuration = create(DurationSchema, {
           seconds: BigInt(seconds),
           nanos: 0,
@@ -269,13 +300,13 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       }
 
       if (
-        initToken.refreshTokenDuration !== tokenState.refreshTokenDuration ||
+        initToken.refreshTokenDuration !== refreshTokenDuration ||
         initToken.refreshTokenTimeFormat !== tokenState.refreshTokenTimeFormat
       ) {
         const seconds =
           tokenState.refreshTokenTimeFormat === "HOURS"
-            ? tokenState.refreshTokenDuration * 60 * 60
-            : tokenState.refreshTokenDuration * 24 * 60 * 60;
+            ? refreshTokenDuration * 60 * 60
+            : refreshTokenDuration * 24 * 60 * 60;
         payload.refreshTokenDuration = create(DurationSchema, {
           seconds: BigInt(seconds),
           nanos: 0,
@@ -283,9 +314,9 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
         updateMaskPaths.push("value.workspace_profile.refresh_token_duration");
       }
 
-      if (initToken.inactiveTimeout !== tokenState.inactiveTimeout) {
+      if (initToken.inactiveTimeout !== inactiveTimeout) {
         payload.inactiveSessionTimeout = create(DurationSchema, {
-          seconds: BigInt(tokenState.inactiveTimeout * 60 * 60),
+          seconds: BigInt(inactiveTimeout * 60 * 60),
           nanos: 0,
         });
         updateMaskPaths.push(
@@ -730,26 +761,15 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                 )}
               </p>
               <div className="mt-3 flex flex-row justify-start items-center gap-x-4">
-                <Input
-                  type="number"
+                <NumberInput
                   className="w-24"
                   value={tokenState.accessTokenDuration}
                   min={1}
                   max={tokenState.accessTokenTimeFormat === "MINUTES" ? 59 : 23}
                   disabled={disabled || !hasSecureTokenFeature}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(val)) {
-                      const max =
-                        tokenState.accessTokenTimeFormat === "MINUTES"
-                          ? 59
-                          : 23;
-                      setTokenState((s) => ({
-                        ...s,
-                        accessTokenDuration: Math.max(1, Math.min(val, max)),
-                      }));
-                    }
-                  }}
+                  onValueChange={(v) =>
+                    setTokenState((s) => ({ ...s, accessTokenDuration: v }))
+                  }
                 />
                 <label className="flex items-center gap-x-1">
                   <input
@@ -804,8 +824,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                 )}
               </p>
               <div className="mt-3 flex flex-row justify-start items-center gap-x-4">
-                <Input
-                  type="number"
+                <NumberInput
                   className="w-24"
                   value={tokenState.refreshTokenDuration}
                   min={1}
@@ -815,22 +834,9 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                       : undefined
                   }
                   disabled={disabled || !hasSecureTokenFeature}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(val)) {
-                      const max =
-                        tokenState.refreshTokenTimeFormat === "HOURS"
-                          ? 23
-                          : undefined;
-                      setTokenState((s) => ({
-                        ...s,
-                        refreshTokenDuration: Math.max(
-                          1,
-                          max ? Math.min(val, max) : val
-                        ),
-                      }));
-                    }
-                  }}
+                  onValueChange={(v) =>
+                    setTokenState((s) => ({ ...s, refreshTokenDuration: v }))
+                  }
                 />
                 <label className="flex items-center gap-x-1">
                   <input
@@ -888,21 +894,14 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                 </span>
               </p>
               <div className="mt-3 flex flex-row justify-start items-center gap-x-4">
-                <Input
-                  type="number"
+                <NumberInput
                   className="w-24"
                   value={tokenState.inactiveTimeout}
                   min={-1}
                   disabled={disabled || !hasSecureTokenFeature}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(val)) {
-                      setTokenState((s) => ({
-                        ...s,
-                        inactiveTimeout: Math.max(-1, val),
-                      }));
-                    }
-                  }}
+                  onValueChange={(v) =>
+                    setTokenState((s) => ({ ...s, inactiveTimeout: v }))
+                  }
                 />
                 <span className="text-sm text-gray-500">
                   {t(

--- a/frontend/src/react/pages/settings/general/AccountSection.tsx
+++ b/frontend/src/react/pages/settings/general/AccountSection.tsx
@@ -277,12 +277,20 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
         updateMaskPaths.push("value.workspace_profile.password_restriction");
       }
 
-      // Token durations (coerce transient `null` inputs to defaults before save).
+      // Token durations (coerce transient `null` inputs to defaults before
+      // save, then floor to integers — the proto fields convert to BigInt
+      // seconds, which rejects fractional values).
       const initToken = getInitialTokenState();
       const resolvedToken = normalizeTokenState(tokenState);
-      const accessTokenDuration = resolvedToken.accessTokenDuration as number;
-      const refreshTokenDuration = resolvedToken.refreshTokenDuration as number;
-      const inactiveTimeout = resolvedToken.inactiveTimeout as number;
+      const accessTokenDuration = Math.floor(
+        resolvedToken.accessTokenDuration as number
+      );
+      const refreshTokenDuration = Math.floor(
+        resolvedToken.refreshTokenDuration as number
+      );
+      const inactiveTimeout = Math.floor(
+        resolvedToken.inactiveTimeout as number
+      );
 
       if (
         initToken.accessTokenDuration !== accessTokenDuration ||
@@ -766,6 +774,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                   value={tokenState.accessTokenDuration}
                   min={1}
                   max={tokenState.accessTokenTimeFormat === "MINUTES" ? 59 : 23}
+                  step={1}
                   disabled={disabled || !hasSecureTokenFeature}
                   onValueChange={(v) =>
                     setTokenState((s) => ({ ...s, accessTokenDuration: v }))
@@ -833,6 +842,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                       ? 23
                       : undefined
                   }
+                  step={1}
                   disabled={disabled || !hasSecureTokenFeature}
                   onValueChange={(v) =>
                     setTokenState((s) => ({ ...s, refreshTokenDuration: v }))
@@ -898,6 +908,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                   className="w-24"
                   value={tokenState.inactiveTimeout}
                   min={-1}
+                  step={1}
                   disabled={disabled || !hasSecureTokenFeature}
                   onValueChange={(v) =>
                     setTokenState((s) => ({ ...s, inactiveTimeout: v }))


### PR DESCRIPTION
## Summary

Follow-up sweep after #20065. The same backspace snap-back bug (`parseInt + NaN-rejection + controlled value` → user can't clear the last digit) still lived in five other settings number inputs. Migrates all of them to `<NumberInput>`.

### Affected fields

| File | Field |
|---|---|
| `AccountSection.tsx` | Access token duration |
| `AccountSection.tsx` | Refresh token duration |
| `AccountSection.tsx` | Inactive session timeout |
| `SemanticTypesPage.tsx` | Inner/Outer mask — prefix length |
| `SemanticTypesPage.tsx` | Inner/Outer mask — suffix length |

### State shape changes

- `AccountSection.tsx`: `TokenState.{accessTokenDuration, refreshTokenDuration, inactiveTimeout}` widened to `number | null`. New `normalizeTokenState` helper coerces to sensible defaults (`1` for token durations = the field's min; `-1` for inactive timeout = "no limit"). Used both in `isTokenDirty` (so a cleared-and-saved field doesn't leave the section permanently dirty — same class of fix as [PR #20065's fea46be](https://github.com/bytebase/bytebase/pull/20065/commits/fea46be4295678925146b16698d50ee4cf135de7)) and in the save path.
- `SemanticTypesPage.tsx`: `innerOuterPrefix` / `innerOuterSuffix` widened to `number | null`. `buildAlgorithm` coerces with `?? 0` when constructing the proto.

### Behavior preserved

- Base UI's `NumberField` clamps on user interaction when `allowOutOfRange` is false (the default), so the existing `min`/`max` constraints for access/refresh token durations (1..59 MINUTES, 1..23 HOURS, 1..23 DAYS) still apply during typing and blur.
- Two `useEffect`s clamp access-token and refresh-token durations when their time format changes (MINUTES↔HOURS, HOURS↔DAYS). Those now guard `duration !== null` before the size comparison to avoid JS's `null > 23` coercion quirk (which would always evaluate false anyway, but being explicit makes the intent clear).
- Password `minLength`, `passwordRotationDays`, and the other "snap-to-default" number inputs across the codebase are **not** touched in this PR — they snap to a default rather than snapping back the last digit, and fall into a broader UX-consistency sweep worth a separate ticket.

## Test plan

- [x] `pnpm type-check`, `pnpm fix`, `pnpm check`, `pnpm test --run` all green (1222 tests).
- [ ] Workspace Settings → Account & Session: backspace-to-empty on each of the three fields above; confirm the field stays empty, then retype a valid value and save.
- [ ] Same for Inactive timeout — includes `min={-1}`, confirm `-1` is still accepted.
- [ ] Workspace Settings → Sensitive Data → Semantic Types → edit/create a masking algorithm → pick "Inner/Outer mask": backspace-to-empty on prefix/suffix length, retype, Apply. Confirm the saved algorithm preserves the typed lengths.
- [ ] Switch access token format between MINUTES↔HOURS with a partially-typed duration — clamp effect still triggers when the value is out of the new range.

## Breaking changes

None. API, proto, schema, config, webhooks, UI workflow all unchanged. Same native-spinner-removed UX tradeoff documented in #20065.

🤖 Generated with [Claude Code](https://claude.com/claude-code)