### PR TITLE
fix(sync): guard against nil database in schema syncer [BYT-9309]

### DIFF
--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -636,6 +636,17 @@ func queryRetry(
 		if err != nil {
 			return nil, nil, duration, err
 		}
+		if d == nil {
+			// The referenced database is not tracked by Bytebase (e.g. it was
+			// dropped, excluded by sync filters, or never discovered yet).
+			// Skip the sync attempt and leave the span's NotFoundError in place
+			// so the masking policy below can reject the query cleanly instead
+			// of panicking on a nil *DatabaseMessage.
+			slog.Debug("skip metadata sync: database not tracked",
+				slog.String("instance", instance.ResourceID),
+				slog.String("database", accessDatabaseName))
+			continue
+		}
 		if err := schemaSyncer.SyncDatabaseSchema(ctx, d); err != nil {
 			return nil, nil, duration, errors.Wrapf(err, "failed to sync database schema for database %q", accessDatabaseName)
 		}

--- a/backend/runner/schemasync/syncer.go
+++ b/backend/runner/schemasync/syncer.go
@@ -371,6 +371,9 @@ func (s *Syncer) SyncInstance(ctx context.Context, instance *store.InstanceMessa
 
 // doSyncDatabaseSchema is the core implementation that syncs the schema for a database and optionally creates a sync history record.
 func (s *Syncer) doSyncDatabaseSchema(ctx context.Context, database *store.DatabaseMessage, createSyncHistory bool) (syncHistoryResourceID string, retErr error) {
+	if database == nil {
+		return "", errors.New("cannot sync nil database")
+	}
 	instance, err := s.store.GetInstanceByResourceID(ctx, database.InstanceID)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get instance %q", database.InstanceID)

--- a/backend/runner/schemasync/syncer_test.go
+++ b/backend/runner/schemasync/syncer_test.go
@@ -1,0 +1,29 @@
+package schemasync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncDatabaseSchemaNilDatabase pins the guard that prevents a nil
+// *store.DatabaseMessage from panicking the syncer. Callers may receive
+// (nil, nil) from store.GetDatabase when the referenced database is not
+// tracked by Bytebase; the syncer must return a descriptive error instead
+// of dereferencing the nil pointer. Regression test for BYT-9309.
+func TestSyncDatabaseSchemaNilDatabase(t *testing.T) {
+	s := &Syncer{}
+
+	_, err := s.doSyncDatabaseSchema(context.Background(), nil, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil database")
+
+	err = s.SyncDatabaseSchema(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil database")
+
+	_, err = s.SyncDatabaseSchemaToHistory(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil database")
+}


### PR DESCRIPTION
## Summary

- Fix a nil-pointer panic in the schema syncer when the SQL editor triggers a metadata sync for a database Bytebase doesn't track (dropped, excluded by sync filters, never discovered, or — pre-#20068 — a case-mismatched system schema).
- \`store.GetDatabase\` signals "not found" as \`(nil, nil)\`. \`queryRetry\` was forwarding that nil straight into \`SyncDatabaseSchema\`, which dereferenced it on the first line of \`doSyncDatabaseSchema\`.
- Add two complementary guards: caller-side skip when \`GetDatabase\` returns nil, and callee-side error return on nil \`*DatabaseMessage\`.

## Behavior

For a cross-database query like \`SELECT * FROM otherdb.tbl\` where \`otherdb\` is not tracked by Bytebase:

- **Before**: panic, query fails with \`[internal] error: runtime error: invalid memory address or nil pointer dereference\`.
- **After**: sync is skipped, the span's \`NotFoundError\` flows through, and the existing masking policy at the end of \`queryRetry\` either rejects the query with a clean \`failed to mask data: ...\` error (masking enabled) or lets the results through (masking disabled or unmask grant).

No new instance-wide sync is triggered from the query path — that would be a latency footgun.

## Test plan

- [x] Added \`TestSyncDatabaseSchemaNilDatabase\` — pins the callee-side guard against regression.
- [x] \`go test ./backend/runner/schemasync/\` passes.
- [x] \`go build ./backend/...\` passes.
- [x] \`golangci-lint run\` clean for affected packages.
- [ ] Manual verification: run \`SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST\` on a case-sensitive MySQL instance where Bytebase's system-schema detection previously missed.

Relates to #20068 (system-schema case-sensitivity fix). These two PRs are independent — this one is the defense-in-depth for any future caller that forwards a nil from \`GetDatabase\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)