### PR TITLE
fix(backup): skip schema sync when no backup statements [BYT-9301]

### DIFF
--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -809,6 +809,9 @@ func (exec *DatabaseMigrateExecutor) backupData(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to transform DML to select")
 	}
+	if len(statements) == 0 {
+		return &storepb.PriorBackupDetail{}, nil
+	}
 
 	prependStatements, err := getPrependStatements(database.Engine, originStatement)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `backupData` unconditionally called `SyncDatabaseSchema` after the backup loop, even when `TransformDMLToSelect` produced zero statements (e.g., INSERT-only input). The resulting schema introspection + store write added 20+ seconds to the Prior Backup step for INSERT statements, despite no backup tables being created.
- Fix: early-return with an empty `PriorBackupDetail` when there are no backup statements, skipping both the no-op loop and the unnecessary sync.

Fixes BYT-9301.

## Test plan

- [ ] Enable Prior Backup, run an INSERT-only issue, confirm the Prior Backup step completes near-instantly instead of ~22s.
- [ ] Run an UPDATE/DELETE issue with Prior Backup enabled, confirm backup tables are still created and the downstream sync still runs.
- [ ] Verify `bbdataarchive` schema absence no longer matters for INSERT (prior behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)