### PR TITLE
cherrypick: [release/3.17.1] batch 2 — number-input fixes, mysql/sync/backup fixes

### DIFF
--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -636,6 +636,17 @@ func queryRetry(
 		if err != nil {
 			return nil, nil, duration, err
 		}
+		if d == nil {
+			// The referenced database is not tracked by Bytebase (e.g. it was
+			// dropped, excluded by sync filters, or never discovered yet).
+			// Skip the sync attempt and leave the span's NotFoundError in place
+			// so the masking policy below can reject the query cleanly instead
+			// of panicking on a nil *DatabaseMessage.
+			slog.Debug("skip metadata sync: database not tracked",
+				slog.String("instance", instance.ResourceID),
+				slog.String("database", accessDatabaseName))
+			continue
+		}
 		if err := schemaSyncer.SyncDatabaseSchema(ctx, d); err != nil {
 			return nil, nil, duration, errors.Wrapf(err, "failed to sync database schema for database %q", accessDatabaseName)
 		}

--- a/backend/plugin/parser/mysql/query_span_extractor.go
+++ b/backend/plugin/parser/mysql/query_span_extractor.go
@@ -1531,18 +1531,31 @@ func isMixedQuery(m base.SourceColumnSet, ignoreCaseSensitive bool) (bool, bool)
 	return !hasUser && hasSystem, false
 }
 
-var systemDatabases = map[string]bool{
+// reservedSystemDatabases are schema names MySQL itself reserves regardless of
+// lower_case_table_names. A user cannot create a schema whose lowercase name
+// collides with any of these, so matching is always case-insensitive.
+var reservedSystemDatabases = map[string]bool{
 	"information_schema": true,
 	"performance_schema": true,
-	"mysql":              true,
+}
+
+// onDiskSystemDatabases are system schemas stored on disk. On case-sensitive
+// instances (lower_case_table_names=0), users can legitimately create a distinct
+// schema whose name differs from these only by case, so we only match them
+// case-insensitively when the instance is case-insensitive.
+var onDiskSystemDatabases = map[string]bool{
+	"mysql": true,
 }
 
 func isSystemResource(resource base.ColumnResource, ignoreCaseSensitive bool) bool {
+	if reservedSystemDatabases[strings.ToLower(resource.Database)] {
+		return true
+	}
 	database := resource.Database
 	if ignoreCaseSensitive {
 		database = strings.ToLower(database)
 	}
-	return systemDatabases[database]
+	return onDiskSystemDatabases[database]
 }
 
 func mysqlExtractColumnsClause(ctx parser.IColumnsClauseContext) []string {

--- a/backend/plugin/parser/mysql/system_resource_test.go
+++ b/backend/plugin/parser/mysql/system_resource_test.go
@@ -1,0 +1,63 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestIsSystemResource(t *testing.T) {
+	cases := []struct {
+		name                string
+		database            string
+		ignoreCaseSensitive bool
+		want                bool
+	}{
+		// information_schema — reserved by MySQL server, always case-insensitive.
+		{"info_schema lowercase, case-sensitive instance", "information_schema", false, true},
+		{"info_schema uppercase, case-sensitive instance", "INFORMATION_SCHEMA", false, true},
+		{"info_schema mixed case, case-sensitive instance", "Information_Schema", false, true},
+		{"info_schema uppercase, case-insensitive instance", "INFORMATION_SCHEMA", true, true},
+
+		// performance_schema — reserved by MySQL server, always case-insensitive.
+		{"perf_schema lowercase, case-sensitive instance", "performance_schema", false, true},
+		{"perf_schema uppercase, case-sensitive instance", "PERFORMANCE_SCHEMA", false, true},
+
+		// mysql — on-disk schema, only case-insensitive when the instance is
+		// (lower_case_table_names != 0). Case-sensitive instances can host a
+		// separate user schema named e.g. `MySQL`, which must NOT be treated
+		// as a system schema.
+		{"mysql lowercase, case-sensitive instance", "mysql", false, true},
+		{"mysql uppercase, case-sensitive instance (user schema)", "MYSQL", false, false},
+		{"mysql mixed case, case-sensitive instance (user schema)", "MySQL", false, false},
+		{"mysql uppercase, case-insensitive instance", "MYSQL", true, true},
+		{"mysql mixed case, case-insensitive instance", "MySQL", true, true},
+
+		// Arbitrary user schemas are never system.
+		{"user schema lowercase", "byt9309_db", false, false},
+		{"user schema uppercase", "BYT9309_DB", false, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isSystemResource(base.ColumnResource{Database: tc.database}, tc.ignoreCaseSensitive)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestIsSystemResourceBYT9309 pins the specific regression: uppercase
+// `INFORMATION_SCHEMA` on a case-sensitive instance must be recognized as
+// a system schema, so `isMixedQuery` can short-circuit and prevent the
+// span extractor from flagging it as a not-found user database — which
+// previously cascaded into a nil-pointer panic in the schema syncer.
+func TestIsSystemResourceBYT9309(t *testing.T) {
+	set := base.SourceColumnSet{
+		{Database: "INFORMATION_SCHEMA", Table: "PROCESSLIST"}: true,
+	}
+	allSystem, mixed := isMixedQuery(set, false /* case-sensitive instance */)
+	require.True(t, allSystem, "INFORMATION_SCHEMA.PROCESSLIST should be treated as system on a case-sensitive instance")
+	require.False(t, mixed)
+}

--- a/backend/runner/schemasync/syncer.go
+++ b/backend/runner/schemasync/syncer.go
@@ -371,6 +371,9 @@ func (s *Syncer) SyncInstance(ctx context.Context, instance *store.InstanceMessa
 
 // doSyncDatabaseSchema is the core implementation that syncs the schema for a database and optionally creates a sync history record.
 func (s *Syncer) doSyncDatabaseSchema(ctx context.Context, database *store.DatabaseMessage, createSyncHistory bool) (syncHistoryResourceID string, retErr error) {
+	if database == nil {
+		return "", errors.New("cannot sync nil database")
+	}
 	instance, err := s.store.GetInstanceByResourceID(ctx, database.InstanceID)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get instance %q", database.InstanceID)

--- a/backend/runner/schemasync/syncer_test.go
+++ b/backend/runner/schemasync/syncer_test.go
@@ -1,0 +1,29 @@
+package schemasync
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSyncDatabaseSchemaNilDatabase pins the guard that prevents a nil
+// *store.DatabaseMessage from panicking the syncer. Callers may receive
+// (nil, nil) from store.GetDatabase when the referenced database is not
+// tracked by Bytebase; the syncer must return a descriptive error instead
+// of dereferencing the nil pointer. Regression test for BYT-9309.
+func TestSyncDatabaseSchemaNilDatabase(t *testing.T) {
+	s := &Syncer{}
+
+	_, err := s.doSyncDatabaseSchema(context.Background(), nil, false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil database")
+
+	err = s.SyncDatabaseSchema(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil database")
+
+	_, err = s.SyncDatabaseSchemaToHistory(context.Background(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil database")
+}

--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -809,6 +809,9 @@ func (exec *DatabaseMigrateExecutor) backupData(
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to transform DML to select")
 	}
+	if len(statements) == 0 {
+		return &storepb.PriorBackupDetail{}, nil
+	}
 
 	prependStatements, err := getPrependStatements(database.Engine, originStatement)
 	if err != nil {

--- a/frontend/src/react/components/ui/number-input.test.tsx
+++ b/frontend/src/react/components/ui/number-input.test.tsx
@@ -1,0 +1,72 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test } from "vitest";
+import { NumberInput } from "./number-input";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+function mount(node: React.ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return { container, root };
+}
+
+describe("NumberInput", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("renders empty when value is null", () => {
+    const { container } = mount(
+      <NumberInput value={null} onValueChange={() => {}} />
+    );
+    const input = container.querySelector("input") as HTMLInputElement | null;
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    expect(input?.value).toBe("");
+  });
+
+  test("displays the controlled numeric value as a formatted string", () => {
+    const { container } = mount(
+      <NumberInput value={42} onValueChange={() => {}} />
+    );
+    const input = container.querySelector("input") as HTMLInputElement | null;
+    expect(input?.value).toBe("42");
+  });
+
+  test("renders the suffix content alongside the input", () => {
+    const { container } = mount(
+      <NumberInput value={10} onValueChange={() => {}} suffix="rows" />
+    );
+    expect(container.textContent).toContain("rows");
+    expect(container.querySelector("input")).toBeInstanceOf(HTMLInputElement);
+  });
+
+  test("applies className to the outer wrapper and size variant to the input", () => {
+    const { container } = mount(
+      <NumberInput
+        value={null}
+        onValueChange={() => {}}
+        className="w-60"
+        size="sm"
+      />
+    );
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    const input = container.querySelector("input");
+    expect(wrapper?.className).toContain("w-60");
+    expect(input?.className).toContain("h-8");
+  });
+
+  test("forwards the disabled prop to the underlying input", () => {
+    const { container } = mount(
+      <NumberInput value={1} onValueChange={() => {}} disabled />
+    );
+    const input = container.querySelector("input") as HTMLInputElement | null;
+    expect(input?.disabled).toBe(true);
+  });
+});

--- a/frontend/src/react/components/ui/number-input.tsx
+++ b/frontend/src/react/components/ui/number-input.tsx
@@ -1,0 +1,95 @@
+import { NumberField } from "@base-ui/react/number-field";
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { cn } from "@/react/lib/utils";
+
+// Mirrors the sizing/appearance of ./input.tsx so NumberInput visually matches
+// the regular Input at every size.
+const numberInputClasses = cva(
+  cn(
+    "flex w-full rounded-xs border border-control-border bg-transparent text-main transition-colors",
+    "placeholder:text-control-placeholder",
+    "focus:outline-hidden",
+    "disabled:cursor-not-allowed disabled:bg-control-bg disabled:opacity-50",
+    "read-only:cursor-default read-only:bg-control-bg read-only:focus:ring-0 read-only:focus:border-control-border"
+  ),
+  {
+    variants: {
+      size: {
+        xs: "h-6 px-2 text-xs leading-4",
+        sm: "h-8 px-3 text-xs leading-4",
+        md: "h-9 px-3 text-sm leading-5",
+        lg: "h-10 px-3 text-sm leading-5",
+      },
+    },
+    defaultVariants: {
+      size: "md",
+    },
+  }
+);
+
+type NumberFieldRootProps = ComponentPropsWithoutRef<typeof NumberField.Root>;
+
+interface NumberInputProps
+  extends Omit<
+      NumberFieldRootProps,
+      "className" | "render" | "size" | "prefix"
+    >,
+    VariantProps<typeof numberInputClasses> {
+  /** Applied to the outer wrapper; use for layout/width classes (e.g. "w-60"). */
+  className?: string;
+  /** Applied to the underlying input element for extra input-specific styling. */
+  inputClassName?: string;
+  placeholder?: string;
+  /** Content rendered inside the field to the right of the input (e.g. unit). */
+  suffix?: ReactNode;
+  /** Content rendered inside the field to the left of the input. */
+  prefix?: ReactNode;
+}
+
+function NumberInput({
+  className,
+  inputClassName,
+  size,
+  suffix,
+  prefix,
+  placeholder,
+  ...rootProps
+}: NumberInputProps) {
+  const hasAffix = Boolean(prefix || suffix);
+  const inputClasses = cn(
+    numberInputClasses({ size }),
+    prefix && "pl-10",
+    suffix && "pr-12",
+    inputClassName
+  );
+
+  if (!hasAffix) {
+    return (
+      <NumberField.Root {...rootProps} className={className}>
+        <NumberField.Input placeholder={placeholder} className={inputClasses} />
+      </NumberField.Root>
+    );
+  }
+
+  return (
+    <NumberField.Root {...rootProps} className={className}>
+      <NumberField.Group className="relative inline-flex w-full items-center">
+        {prefix && (
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-control-light">
+            {prefix}
+          </span>
+        )}
+        <NumberField.Input placeholder={placeholder} className={inputClasses} />
+        {suffix && (
+          <span className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm text-control-light">
+            {suffix}
+          </span>
+        )}
+      </NumberField.Group>
+    </NumberField.Root>
+  );
+}
+
+export { NumberInput };
+export type { NumberInputProps };

--- a/frontend/src/react/pages/project/ProjectSettingsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSettingsPage.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from "@/react/components/ui/dialog";
 import { Input } from "@/react/components/ui/input";
+import { NumberInput } from "@/react/components/ui/number-input";
 import { Switch } from "@/react/components/ui/switch";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -186,7 +187,11 @@ export function ProjectSettingsPage() {
     const rows = Number(queryDataPolicy?.maximumResultRows ?? 0);
     return rows < 0 ? 0 : rows;
   }, [queryDataPolicy]);
-  const [maxRows, setMaxRows] = useState(() => getInitialMaxRows());
+  // `null` represents a transiently empty input while the user is typing;
+  // coerced to 0 on save.
+  const [maxRows, setMaxRows] = useState<number | null>(() =>
+    getInitialMaxRows()
+  );
 
   const [allowRequestRole, setAllowRequestRole] = useState(
     project?.allowRequestRole ?? false
@@ -226,15 +231,15 @@ export function ProjectSettingsPage() {
   const [postgresDatabaseTenantMode, setPostgresDatabaseTenantMode] = useState(
     project?.postgresDatabaseTenantMode ?? false
   );
-  const [maxRetries, setMaxRetries] = useState(
+  const [maxRetries, setMaxRetries] = useState<number | null>(
     project?.executionRetryPolicy?.maximumRetries ?? 0
   );
-  const [ciSamplingSize, setCiSamplingSize] = useState(
+  const [ciSamplingSize, setCiSamplingSize] = useState<number | null>(
     project?.ciSamplingSize ?? 0
   );
-  const [parallelTasksPerRollout, setParallelTasksPerRollout] = useState(
-    project?.parallelTasksPerRollout ?? 1
-  );
+  const [parallelTasksPerRollout, setParallelTasksPerRollout] = useState<
+    number | null
+  >(project?.parallelTasksPerRollout ?? 1);
 
   // New issue label input
   const [newLabelValue, setNewLabelValue] = useState("");
@@ -291,7 +296,7 @@ export function ProjectSettingsPage() {
     )
       return true;
     // Max rows
-    if (maxRows !== getInitialMaxRows()) return true;
+    if ((maxRows ?? 0) !== getInitialMaxRows()) return true;
     // Project toggles
     if (allowRequestRole !== project.allowRequestRole) return true;
     if (allowJustInTimeAccess !== project.allowJustInTimeAccess) return true;
@@ -306,10 +311,14 @@ export function ProjectSettingsPage() {
       return true;
     if (postgresDatabaseTenantMode !== project.postgresDatabaseTenantMode)
       return true;
-    if (maxRetries !== (project.executionRetryPolicy?.maximumRetries ?? 0))
+    if (
+      (maxRetries ?? 0) !== (project.executionRetryPolicy?.maximumRetries ?? 0)
+    )
       return true;
-    if (ciSamplingSize !== (project.ciSamplingSize ?? 0)) return true;
-    if (parallelTasksPerRollout !== (project.parallelTasksPerRollout ?? 0))
+    if ((ciSamplingSize ?? 0) !== (project.ciSamplingSize ?? 0)) return true;
+    if (
+      (parallelTasksPerRollout ?? 0) !== (project.parallelTasksPerRollout ?? 0)
+    )
       return true;
     return false;
   }, [
@@ -419,7 +428,8 @@ export function ProjectSettingsPage() {
       }
 
       // 2. Max rows policy (separate API)
-      if (maxRows !== getInitialMaxRows()) {
+      const maxRowsValue = maxRows ?? 0;
+      if (maxRowsValue !== getInitialMaxRows()) {
         await policyStore.upsertPolicy({
           parentPath: projectName,
           policy: {
@@ -429,7 +439,7 @@ export function ProjectSettingsPage() {
               case: "queryDataPolicy",
               value: create(QueryDataPolicySchema, {
                 ...queryDataPolicy,
-                maximumResultRows: maxRows,
+                maximumResultRows: maxRowsValue,
               }),
             },
           },
@@ -488,19 +498,26 @@ export function ProjectSettingsPage() {
         projectPatch.postgresDatabaseTenantMode = postgresDatabaseTenantMode;
         updateMask.push("postgres_database_tenant_mode");
       }
-      if (maxRetries !== (project.executionRetryPolicy?.maximumRetries ?? 0)) {
+      const maxRetriesValue = maxRetries ?? 0;
+      if (
+        maxRetriesValue !== (project.executionRetryPolicy?.maximumRetries ?? 0)
+      ) {
         projectPatch.executionRetryPolicy = create(
           Project_ExecutionRetryPolicySchema,
-          { maximumRetries: maxRetries }
+          { maximumRetries: maxRetriesValue }
         );
         updateMask.push("execution_retry_policy");
       }
-      if (ciSamplingSize !== (project.ciSamplingSize ?? 0)) {
-        projectPatch.ciSamplingSize = ciSamplingSize;
+      const ciSamplingSizeValue = ciSamplingSize ?? 0;
+      if (ciSamplingSizeValue !== (project.ciSamplingSize ?? 0)) {
+        projectPatch.ciSamplingSize = ciSamplingSizeValue;
         updateMask.push("ci_sampling_size");
       }
-      if (parallelTasksPerRollout !== (project.parallelTasksPerRollout ?? 0)) {
-        projectPatch.parallelTasksPerRollout = parallelTasksPerRollout;
+      const parallelTasksPerRolloutValue = parallelTasksPerRollout ?? 0;
+      if (
+        parallelTasksPerRolloutValue !== (project.parallelTasksPerRollout ?? 0)
+      ) {
+        projectPatch.parallelTasksPerRollout = parallelTasksPerRolloutValue;
         updateMask.push("parallel_tasks_per_rollout");
       }
       if (updateMask.length > 0) {
@@ -786,15 +803,11 @@ export function ProjectSettingsPage() {
                       </span>
                     </p>
                     <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-                      <Input
-                        type="number"
+                      <NumberInput
                         className="w-60"
                         min={0}
-                        value={String(maxRows)}
-                        onChange={(e) => {
-                          const v = parseInt(e.target.value, 10);
-                          if (!Number.isNaN(v) && v >= 0) setMaxRows(v);
-                        }}
+                        value={maxRows}
+                        onValueChange={setMaxRows}
                         disabled={!hasQueryPolicyFeature || !canUpdatePolicies}
                       />
                       <span className="text-sm text-control-light">
@@ -1313,8 +1326,8 @@ function NumericRow({
 }: {
   label: string;
   description: string;
-  value: number;
-  onChange: (v: number) => void;
+  value: number | null;
+  onChange: (v: number | null) => void;
   disabled: boolean;
   suffix?: string;
 }) {
@@ -1323,15 +1336,11 @@ function NumericRow({
       <p className="text-sm font-medium">{label}</p>
       <p className="mb-3 text-sm text-control-placeholder">{description}</p>
       <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-        <Input
-          type="number"
+        <NumberInput
           className="w-60"
           min={0}
-          value={String(value)}
-          onChange={(e) => {
-            const v = parseInt(e.target.value, 10);
-            if (!Number.isNaN(v) && v >= 0) onChange(v);
-          }}
+          value={value}
+          onValueChange={onChange}
           disabled={disabled}
         />
         {suffix && <span className="text-sm text-control-light">{suffix}</span>}

--- a/frontend/src/react/pages/settings/SemanticTypesPage.tsx
+++ b/frontend/src/react/pages/settings/SemanticTypesPage.tsx
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
+import { NumberInput } from "@/react/components/ui/number-input";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
@@ -505,12 +506,14 @@ function MaskingAlgorithmDrawer({
       ? algorithm.mask.value.type
       : Algorithm_InnerOuterMask_MaskType.INNER
   );
-  const [innerOuterPrefix, setInnerOuterPrefix] = useState(
+  // `number | null`: `null` represents an empty input while the user is
+  // typing; coerced to `0` on save.
+  const [innerOuterPrefix, setInnerOuterPrefix] = useState<number | null>(
     algorithm?.mask?.case === "innerOuterMask"
       ? algorithm.mask.value.prefixLen
       : 0
   );
-  const [innerOuterSuffix, setInnerOuterSuffix] = useState(
+  const [innerOuterSuffix, setInnerOuterSuffix] = useState<number | null>(
     algorithm?.mask?.case === "innerOuterMask"
       ? algorithm.mask.value.suffixLen
       : 0
@@ -659,8 +662,9 @@ function MaskingAlgorithmDrawer({
             case: "innerOuterMask",
             value: create(Algorithm_InnerOuterMaskSchema, {
               type: innerOuterType,
-              prefixLen: innerOuterPrefix,
-              suffixLen: innerOuterSuffix,
+              // Proto field is int32 — floor any fractional input defensively.
+              prefixLen: Math.floor(innerOuterPrefix ?? 0),
+              suffixLen: Math.floor(innerOuterSuffix ?? 0),
               substitution: innerOuterSubstitution,
             }),
           },
@@ -924,15 +928,12 @@ function MaskingAlgorithmDrawer({
                       )}
                       <span className="text-error ml-0.5">*</span>
                     </label>
-                    <Input
-                      type="number"
+                    <NumberInput
                       value={innerOuterPrefix}
                       className="w-24"
-                      onChange={(e) => {
-                        const val = Number(e.target.value);
-                        if (!Number.isNaN(val) && val >= 0)
-                          setInnerOuterPrefix(val);
-                      }}
+                      min={0}
+                      step={1}
+                      onValueChange={setInnerOuterPrefix}
                     />
                   </div>
                   <div className="flex flex-col gap-y-1">
@@ -942,15 +943,12 @@ function MaskingAlgorithmDrawer({
                       )}
                       <span className="text-error ml-0.5">*</span>
                     </label>
-                    <Input
-                      type="number"
+                    <NumberInput
                       value={innerOuterSuffix}
                       className="w-24"
-                      onChange={(e) => {
-                        const val = Number(e.target.value);
-                        if (!Number.isNaN(val) && val >= 0)
-                          setInnerOuterSuffix(val);
-                      }}
+                      min={0}
+                      step={1}
+                      onValueChange={setInnerOuterSuffix}
                     />
                   </div>
                   <div className="flex-1 flex flex-col gap-y-1">

--- a/frontend/src/react/pages/settings/general/AccountSection.tsx
+++ b/frontend/src/react/pages/settings/general/AccountSection.tsx
@@ -18,6 +18,7 @@ import {
   usePermissionCheck,
 } from "@/react/components/PermissionGuard";
 import { Input } from "@/react/components/ui/input";
+import { NumberInput } from "@/react/components/ui/number-input";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
   useActuatorV1Store,
@@ -43,11 +44,41 @@ interface ToggleState {
 }
 
 interface TokenState {
-  accessTokenDuration: number;
+  // `null` represents an empty input while the user is typing; coerced to
+  // sensible defaults (1 for durations, -1 for inactiveTimeout = "no limit")
+  // on save and dirty comparison.
+  accessTokenDuration: number | null;
   accessTokenTimeFormat: "MINUTES" | "HOURS";
-  refreshTokenDuration: number;
+  refreshTokenDuration: number | null;
   refreshTokenTimeFormat: "HOURS" | "DAYS";
-  inactiveTimeout: number;
+  inactiveTimeout: number | null;
+}
+
+// Defaults used when the user leaves a duration field empty.
+const EMPTY_TOKEN_DURATION_DEFAULT = 1;
+const EMPTY_INACTIVE_TIMEOUT_DEFAULT = -1;
+
+// Canonicalizes TokenState for both isDirty comparison and save: coerces
+// transient `null` inputs to defaults and floors any fractional values (paste
+// of "1.5" etc.) so the two paths always agree on what counts as a change.
+function normalizeTokenState(state: TokenState): TokenState {
+  const floorOr = (v: number | null, fallback: number): number =>
+    Math.floor(v ?? fallback);
+  return {
+    ...state,
+    accessTokenDuration: floorOr(
+      state.accessTokenDuration,
+      EMPTY_TOKEN_DURATION_DEFAULT
+    ),
+    refreshTokenDuration: floorOr(
+      state.refreshTokenDuration,
+      EMPTY_TOKEN_DURATION_DEFAULT
+    ),
+    inactiveTimeout: floorOr(
+      state.inactiveTimeout,
+      EMPTY_INACTIVE_TIMEOUT_DEFAULT
+    ),
+  };
 }
 
 interface AccountSectionProps {
@@ -189,6 +220,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       if (
         prevAccessFormat.current !== tokenState.accessTokenTimeFormat &&
         tokenState.accessTokenTimeFormat === "MINUTES" &&
+        tokenState.accessTokenDuration !== null &&
         tokenState.accessTokenDuration > 59
       ) {
         setTokenState((s) => ({ ...s, accessTokenDuration: 59 }));
@@ -202,6 +234,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       if (
         prevRefreshFormat.current !== tokenState.refreshTokenTimeFormat &&
         tokenState.refreshTokenTimeFormat === "HOURS" &&
+        tokenState.refreshTokenDuration !== null &&
         tokenState.refreshTokenDuration > 23
       ) {
         setTokenState((s) => ({ ...s, refreshTokenDuration: 23 }));
@@ -215,7 +248,12 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       passwordState,
       getInitialPasswordRestriction()
     );
-    const isTokenDirty = !isEqual(tokenState, getInitialTokenState());
+    // Normalize transient empty inputs (`null`) before comparing so a
+    // cleared-then-saved field doesn't leave the section permanently dirty.
+    const isTokenDirty = !isEqual(
+      normalizeTokenState(tokenState),
+      getInitialTokenState()
+    );
     const isDirty = isToggleDirty || isPasswordDirty || isTokenDirty;
 
     // --- Update ---
@@ -235,16 +273,23 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
         });
       }
 
-      // Token durations
+      // Token durations — `normalizeTokenState` coerces transient `null`
+      // inputs to defaults and floors fractional values, so the resolved
+      // shape matches what isDirty compared against.
       const initToken = getInitialTokenState();
+      const resolvedToken = normalizeTokenState(tokenState);
+      const accessTokenDuration = resolvedToken.accessTokenDuration as number;
+      const refreshTokenDuration = resolvedToken.refreshTokenDuration as number;
+      const inactiveTimeout = resolvedToken.inactiveTimeout as number;
+
       if (
-        initToken.accessTokenDuration !== tokenState.accessTokenDuration ||
+        initToken.accessTokenDuration !== accessTokenDuration ||
         initToken.accessTokenTimeFormat !== tokenState.accessTokenTimeFormat
       ) {
         const seconds =
           tokenState.accessTokenTimeFormat === "MINUTES"
-            ? tokenState.accessTokenDuration * 60
-            : tokenState.accessTokenDuration * 60 * 60;
+            ? accessTokenDuration * 60
+            : accessTokenDuration * 60 * 60;
         await settingV1Store.updateWorkspaceProfile({
           payload: {
             accessTokenDuration: create(DurationSchema, {
@@ -259,13 +304,13 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       }
 
       if (
-        initToken.refreshTokenDuration !== tokenState.refreshTokenDuration ||
+        initToken.refreshTokenDuration !== refreshTokenDuration ||
         initToken.refreshTokenTimeFormat !== tokenState.refreshTokenTimeFormat
       ) {
         const seconds =
           tokenState.refreshTokenTimeFormat === "HOURS"
-            ? tokenState.refreshTokenDuration * 60 * 60
-            : tokenState.refreshTokenDuration * 24 * 60 * 60;
+            ? refreshTokenDuration * 60 * 60
+            : refreshTokenDuration * 24 * 60 * 60;
         await settingV1Store.updateWorkspaceProfile({
           payload: {
             refreshTokenDuration: create(DurationSchema, {
@@ -279,11 +324,11 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
         });
       }
 
-      if (initToken.inactiveTimeout !== tokenState.inactiveTimeout) {
+      if (initToken.inactiveTimeout !== inactiveTimeout) {
         await settingV1Store.updateWorkspaceProfile({
           payload: {
             inactiveSessionTimeout: create(DurationSchema, {
-              seconds: BigInt(tokenState.inactiveTimeout * 60 * 60),
+              seconds: BigInt(inactiveTimeout * 60 * 60),
               nanos: 0,
             }),
           },
@@ -676,26 +721,16 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                 )}
               </p>
               <div className="mt-3 flex flex-row justify-start items-center gap-x-4">
-                <Input
-                  type="number"
+                <NumberInput
                   className="w-24"
                   value={tokenState.accessTokenDuration}
                   min={1}
                   max={tokenState.accessTokenTimeFormat === "MINUTES" ? 59 : 23}
+                  step={1}
                   disabled={disabled || !hasSecureTokenFeature}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(val)) {
-                      const max =
-                        tokenState.accessTokenTimeFormat === "MINUTES"
-                          ? 59
-                          : 23;
-                      setTokenState((s) => ({
-                        ...s,
-                        accessTokenDuration: Math.max(1, Math.min(val, max)),
-                      }));
-                    }
-                  }}
+                  onValueChange={(v) =>
+                    setTokenState((s) => ({ ...s, accessTokenDuration: v }))
+                  }
                 />
                 <label className="flex items-center gap-x-1">
                   <input
@@ -750,8 +785,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                 )}
               </p>
               <div className="mt-3 flex flex-row justify-start items-center gap-x-4">
-                <Input
-                  type="number"
+                <NumberInput
                   className="w-24"
                   value={tokenState.refreshTokenDuration}
                   min={1}
@@ -760,23 +794,11 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                       ? 23
                       : undefined
                   }
+                  step={1}
                   disabled={disabled || !hasSecureTokenFeature}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(val)) {
-                      const max =
-                        tokenState.refreshTokenTimeFormat === "HOURS"
-                          ? 23
-                          : undefined;
-                      setTokenState((s) => ({
-                        ...s,
-                        refreshTokenDuration: Math.max(
-                          1,
-                          max ? Math.min(val, max) : val
-                        ),
-                      }));
-                    }
-                  }}
+                  onValueChange={(v) =>
+                    setTokenState((s) => ({ ...s, refreshTokenDuration: v }))
+                  }
                 />
                 <label className="flex items-center gap-x-1">
                   <input
@@ -834,21 +856,15 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                 </span>
               </p>
               <div className="mt-3 flex flex-row justify-start items-center gap-x-4">
-                <Input
-                  type="number"
+                <NumberInput
                   className="w-24"
                   value={tokenState.inactiveTimeout}
                   min={-1}
+                  step={1}
                   disabled={disabled || !hasSecureTokenFeature}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(val)) {
-                      setTokenState((s) => ({
-                        ...s,
-                        inactiveTimeout: Math.max(-1, val),
-                      }));
-                    }
-                  }}
+                  onValueChange={(v) =>
+                    setTokenState((s) => ({ ...s, inactiveTimeout: v }))
+                  }
                 />
                 <span className="text-sm text-gray-500">
                   {t(

--- a/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
+++ b/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
@@ -2,7 +2,6 @@ import { create } from "@bufbuild/protobuf";
 import { DurationSchema, FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import { isEqual } from "lodash-es";
 import {
-  type ChangeEvent,
   forwardRef,
   useCallback,
   useEffect,
@@ -13,7 +12,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
-import { Input } from "@/react/components/ui/input";
+import { NumberInput } from "@/react/components/ui/number-input";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
   DEFAULT_MAX_RESULT_SIZE_IN_MB,
@@ -40,9 +39,11 @@ interface LocalState {
   disableExport: boolean;
   disableCopyData: boolean;
   allowAdminDataSource: boolean;
-  maximumResultSize: number;
-  maximumResultRows: number;
-  maxQueryTimeInSeconds: number;
+  // `null` represents an empty input while the user is typing; coerced to a
+  // number on save.
+  maximumResultSize: number | null;
+  maximumResultRows: number | null;
+  maxQueryTimeInSeconds: number | null;
 }
 
 export const SQLEditorSection = forwardRef<
@@ -122,9 +123,22 @@ export const SQLEditorSection = forwardRef<
     }
   }, [getInitialState]);
 
+  // Normalize `null` (transiently empty inputs) to the same defaults used by
+  // `update()` so that a cleared-then-saved field doesn't leave the section
+  // permanently dirty.
+  const normalizeForCompare = useCallback(
+    (s: LocalState): LocalState => ({
+      ...s,
+      maximumResultSize: s.maximumResultSize ?? DEFAULT_MAX_RESULT_SIZE_IN_MB,
+      maximumResultRows: s.maximumResultRows ?? 0,
+      maxQueryTimeInSeconds: s.maxQueryTimeInSeconds ?? 0,
+    }),
+    []
+  );
+
   const isDirty = useCallback(
-    () => !isEqual(state, getInitialState()),
-    [state, getInitialState]
+    () => !isEqual(normalizeForCompare(state), getInitialState()),
+    [state, getInitialState, normalizeForCompare]
   );
 
   const revert = useCallback(() => {
@@ -134,12 +148,17 @@ export const SQLEditorSection = forwardRef<
   const update = useCallback(async () => {
     const init = getInitialState();
 
+    const maxQueryTimeInSeconds = state.maxQueryTimeInSeconds ?? 0;
+    const maximumResultSize =
+      state.maximumResultSize ?? DEFAULT_MAX_RESULT_SIZE_IN_MB;
+    const maximumResultRows = state.maximumResultRows ?? 0;
+
     // Update query timeout if changed
-    if (init.maxQueryTimeInSeconds !== state.maxQueryTimeInSeconds) {
+    if (init.maxQueryTimeInSeconds !== maxQueryTimeInSeconds) {
       await settingV1Store.updateWorkspaceProfile({
         payload: {
           queryTimeout: create(DurationSchema, {
-            seconds: BigInt(state.maxQueryTimeInSeconds),
+            seconds: BigInt(maxQueryTimeInSeconds),
           }),
         },
         updateMask: create(FieldMaskSchema, {
@@ -149,10 +168,10 @@ export const SQLEditorSection = forwardRef<
     }
 
     // Update result size if changed
-    if (init.maximumResultSize !== state.maximumResultSize) {
+    if (init.maximumResultSize !== maximumResultSize) {
       await settingV1Store.updateWorkspaceProfile({
         payload: {
-          sqlResultSize: BigInt(state.maximumResultSize * 1024 * 1024),
+          sqlResultSize: BigInt(maximumResultSize * 1024 * 1024),
         },
         updateMask: create(FieldMaskSchema, {
           paths: ["value.workspace_profile.sql_result_size"],
@@ -173,7 +192,7 @@ export const SQLEditorSection = forwardRef<
             disableExport: state.disableExport,
             disableCopyData: state.disableCopyData,
             allowAdminDataSource: state.allowAdminDataSource,
-            maximumResultRows: state.maximumResultRows,
+            maximumResultRows,
           }),
         },
       },
@@ -203,11 +222,9 @@ export const SQLEditorSection = forwardRef<
 
   const handleNumberInput = (
     field: "maximumResultSize" | "maximumResultRows" | "maxQueryTimeInSeconds",
-    e: ChangeEvent<HTMLInputElement>
+    value: number | null
   ) => {
-    const val = parseInt(e.target.value, 10);
-    if (Number.isNaN(val)) return;
-    setState((prev) => ({ ...prev, [field]: val }));
+    setState((prev) => ({ ...prev, [field]: value }));
   };
 
   return (
@@ -303,19 +320,16 @@ export const SQLEditorSection = forwardRef<
                 </span>
               </p>
               <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-                <div className="relative w-60">
-                  <Input
-                    type="number"
-                    value={state.maximumResultSize}
-                    min={1}
-                    disabled={!hasQueryPolicyFeature || !canSetWorkspaceProfile}
-                    onChange={(e) => handleNumberInput("maximumResultSize", e)}
-                    className="pr-12"
-                  />
-                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
-                    MB
-                  </span>
-                </div>
+                <NumberInput
+                  className="w-60"
+                  value={state.maximumResultSize}
+                  min={1}
+                  disabled={!hasQueryPolicyFeature || !canSetWorkspaceProfile}
+                  onValueChange={(v) =>
+                    handleNumberInput("maximumResultSize", v)
+                  }
+                  suffix="MB"
+                />
               </div>
             </div>
           </PermissionGuard>
@@ -339,19 +353,17 @@ export const SQLEditorSection = forwardRef<
               </span>
             </p>
             <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-              <div className="relative w-60">
-                <Input
-                  type="number"
-                  value={state.maximumResultRows}
-                  min={0}
-                  disabled={!hasQueryPolicyFeature || !canUpdatePolicy}
-                  onChange={(e) => handleNumberInput("maximumResultRows", e)}
-                  className="pr-16"
-                />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
-                  {t("settings.general.workspace.maximum-sql-result.rows.rows")}
-                </span>
-              </div>
+              <NumberInput
+                className="w-60"
+                value={state.maximumResultRows}
+                min={0}
+                disabled={!hasQueryPolicyFeature || !canUpdatePolicy}
+                onValueChange={(v) => handleNumberInput("maximumResultRows", v)}
+                inputClassName="pr-16"
+                suffix={t(
+                  "settings.general.workspace.maximum-sql-result.rows.rows"
+                )}
+              />
             </div>
           </div>
         </PermissionGuard>
@@ -377,21 +389,19 @@ export const SQLEditorSection = forwardRef<
               </span>
             </p>
             <div className="mt-3 w-full flex flex-row justify-start items-center gap-4">
-              <div className="relative w-60">
-                <Input
-                  type="number"
-                  value={state.maxQueryTimeInSeconds}
-                  min={0}
-                  disabled={!hasQueryPolicyFeature || !canSetWorkspaceProfile}
-                  onChange={(e) =>
-                    handleNumberInput("maxQueryTimeInSeconds", e)
-                  }
-                  className="pr-20"
-                />
-                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-gray-500">
-                  {t("settings.general.workspace.query-data-policy.seconds")}
-                </span>
-              </div>
+              <NumberInput
+                className="w-60"
+                value={state.maxQueryTimeInSeconds}
+                min={0}
+                disabled={!hasQueryPolicyFeature || !canSetWorkspaceProfile}
+                onValueChange={(v) =>
+                  handleNumberInput("maxQueryTimeInSeconds", v)
+                }
+                inputClassName="pr-20"
+                suffix={t(
+                  "settings.general.workspace.query-data-policy.seconds"
+                )}
+              />
             </div>
           </div>
         </PermissionGuard>

--- a/frontend/src/store/modules/v1/policy.ts
+++ b/frontend/src/store/modules/v1/policy.ts
@@ -42,6 +42,13 @@ export const replacePolicyTypeNameToLowerCase = (name: string) => {
   return replaced;
 };
 
+// Shared default returned when no DATA_QUERY policy exists for a parent.
+// Must be a stable singleton so subscribers (e.g. React useVueState) don't
+// see a new reference on every call and thrash their effects.
+const EMPTY_QUERY_DATA_POLICY: QueryDataPolicy = create(QueryDataPolicySchema, {
+  maximumResultRows: -1,
+});
+
 export const usePolicyV1Store = defineStore("policy_v1", () => {
   const state = reactive<PolicyState>({
     policyMapByName: new Map(),
@@ -54,9 +61,7 @@ export const usePolicyV1Store = defineStore("policy_v1", () => {
     });
     return policy?.policy?.case === "queryDataPolicy"
       ? policy.policy.value
-      : create(QueryDataPolicySchema, {
-          maximumResultRows: -1,
-        });
+      : EMPTY_QUERY_DATA_POLICY;
   };
 
   const getOrFetchPolicyByParentAndType = async ({


### PR DESCRIPTION
## Summary

Cherry-picks from `main` onto `release/3.17.1`:

- [#20064](https://github.com/bytebase/bytebase/pull/20064) — fix(BYT-9319): stabilize default QueryDataPolicy reference
- [#20065](https://github.com/bytebase/bytebase/pull/20065) — fix(BYT-9319): allow clearing number inputs in settings
- [#20068](https://github.com/bytebase/bytebase/pull/20068) — chore(mysql): lookup system schema in lowercase always
- [#20071](https://github.com/bytebase/bytebase/pull/20071) — fix(sync): guard against nil database in schema syncer [BYT-9309]
- [#20073](https://github.com/bytebase/bytebase/pull/20073) — fix(backup): skip schema sync when no backup statements [BYT-9301]
- [#20066](https://github.com/bytebase/bytebase/pull/20066) — fix(BYT-9319): migrate remaining snap-back number inputs to NumberInput

### Conflicts

- **#20066** `frontend/src/react/pages/settings/general/AccountSection.tsx`: release/3.17.1's `handleUpdate` uses per-field `await settingV1Store.updateWorkspaceProfile` calls rather than the batched payload+updateMaskPaths pattern introduced on main. Resolved by preserving the per-field call structure and substituting the normalized `accessTokenDuration` / `refreshTokenDuration` / `inactiveTimeout` values from `normalizeTokenState(tokenState)` into the comparisons and second multiplications. The NumberInput migration and `normalizeTokenState` helper still land as intended.

## Test plan

- [x] Backend build
- [x] `go test` for `backend/plugin/parser/mysql/...`, `backend/runner/schemasync/...`, `backend/api/v1/...`, `backend/runner/taskrun/...`, `backend/store/...`
- [x] `golangci-lint` clean on touched Go packages
- [x] Frontend `type-check`
- [x] Frontend `check` (eslint + biome + i18n checks)
- [x] Frontend `test` (1158 passing)