### PR TITLE
feat(mysql): per-object walk-through loader with pseudo fallback

### DIFF
--- a/backend/plugin/parser/mysql/test-data/test_completion.yaml
+++ b/backend/plugin/parser/mysql/test-data/test_completion.yaml
@@ -5044,8 +5044,68 @@
       priority: 0
 - input: SELECT c1 as 'eid' FROM t1 ORDER BY |
   want:
+    - text: c1
+      type: COLUMN
+      definition: t1 | , NOT NULL
+      comment: ""
+      priority: 0
+    - text: eid
+      type: COLUMN
+      definition: ""
+      comment: ""
+      priority: 0
+    - text: db
+      type: DATABASE
+      definition: ""
+      comment: ""
+      priority: 0
+    - text: t1
+      type: TABLE
+      definition: ""
+      comment: ""
+      priority: 0
+    - text: t2
+      type: TABLE
+      definition: ""
+      comment: ""
+      priority: 0
+    - text: v1
+      type: VIEW
+      definition: ""
+      comment: ""
+      priority: 0
 - input: SELECT c1 as "xid" FROM t1 ORDER BY |
   want:
+    - text: c1
+      type: COLUMN
+      definition: t1 | , NOT NULL
+      comment: ""
+      priority: 0
+    - text: xid
+      type: COLUMN
+      definition: ""
+      comment: ""
+      priority: 0
+    - text: db
+      type: DATABASE
+      definition: ""
+      comment: ""
+      priority: 0
+    - text: t1
+      type: TABLE
+      definition: ""
+      comment: ""
+      priority: 0
+    - text: t2
+      type: TABLE
+      definition: ""
+      comment: ""
+      priority: 0
+    - text: v1
+      type: VIEW
+      definition: ""
+      comment: ""
+      priority: 0
 - input: SELECT * FROM t2 AS Foo WHERE foo.|
   want:
     - text: c1

--- a/backend/plugin/schema/mysql/walk_through_loader.go
+++ b/backend/plugin/schema/mysql/walk_through_loader.go
@@ -572,11 +572,19 @@ func wtBuildColumnDef(col *storepb.ColumnMetadata) (*ast.ColumnDef, error) {
 	}
 
 	if !isAutoInc && col.Default != "" && col.Generation == nil {
-		if expr, err := wtParseExpr(col.Default); err == nil {
-			def.DefaultValue = expr
+		// MySQL sync fills "NULL" as the default for all nullable columns,
+		// including TEXT/BLOB/JSON/GEOMETRY — types that MySQL's grammar
+		// does NOT accept a DEFAULT clause on. Emitting `DEFAULT NULL` for
+		// these would cause DefineTable to reject the whole table and force
+		// pseudo fallback. Mirror the filter in
+		// get_database_definition.go:typeSupportsDefaultValue.
+		if !strings.EqualFold(col.Default, "NULL") || wtTypeSupportsDefault(col.Type) {
+			if expr, err := wtParseExpr(col.Default); err == nil {
+				def.DefaultValue = expr
+			}
+			// Silent drop on parse failure — a missing DEFAULT is a closer
+			// approximation of reality than a whole-column failure.
 		}
-		// Silent drop on parse failure — a missing DEFAULT is a closer
-		// approximation of reality than a whole-column failure.
 	}
 	if col.OnUpdate != "" {
 		if expr, err := wtParseExpr(col.OnUpdate); err == nil {
@@ -618,13 +626,15 @@ func wtBuildIndexConstraint(idx *storepb.IndexMetadata) *ast.Constraint {
 		c.Type = ast.ConstrIndex
 		c.IndexType = idxTypeUpper
 	}
-	// Use IndexColumns when per-part length or DESC matters; otherwise the
-	// simpler Columns field is enough. Functional indexes (expressions) are
-	// left as plain identifiers — rare in practice and omni can't validate
-	// them against the catalog anyway.
+	// Functional key parts (MySQL 8.0+) arrive as expressions in
+	// idx.Expressions — either parenthesized `(lower(name))` or
+	// function-call `lower(name)` form. Those MUST live in
+	// IndexColumns[*].Expr, not in the bare-identifier Columns slice.
+	// Per-part length or DESC also force IndexColumns.
 	needIC := false
-	for i := range idx.Expressions {
-		if (i < len(idx.KeyLength) && idx.KeyLength[i] > 0) ||
+	for i, expr := range idx.Expressions {
+		if wtIsExpressionIndexKey(expr) ||
+			(i < len(idx.KeyLength) && idx.KeyLength[i] > 0) ||
 			(i < len(idx.Descending) && idx.Descending[i]) {
 			needIC = true
 			break
@@ -632,9 +642,7 @@ func wtBuildIndexConstraint(idx *storepb.IndexMetadata) *ast.Constraint {
 	}
 	if needIC {
 		for i, expr := range idx.Expressions {
-			ic := &ast.IndexColumn{
-				Expr: &ast.ColumnRef{Column: wtUnquoteIdent(expr)},
-			}
+			ic := &ast.IndexColumn{Expr: wtIndexKeyExpr(expr)}
 			if i < len(idx.KeyLength) && idx.KeyLength[i] > 0 {
 				ic.Length = int(idx.KeyLength[i])
 			}
@@ -649,6 +657,47 @@ func wtBuildIndexConstraint(idx *storepb.IndexMetadata) *ast.Constraint {
 		}
 	}
 	return c
+}
+
+// wtIsExpressionIndexKey returns true if the key-part string looks like a
+// functional index expression rather than a bare identifier. Heuristic:
+// presence of a paren implies either a function call or a parenthesized
+// expression. Backticked identifiers don't normally contain parens.
+func wtIsExpressionIndexKey(s string) bool {
+	return strings.Contains(s, "(")
+}
+
+// wtIndexKeyExpr converts one idx.Expressions entry into an ExprNode. For
+// functional keys we parse the expression text (source is MySQL's own
+// information_schema output, not our deparse); bare identifiers become a
+// plain ColumnRef.
+func wtIndexKeyExpr(s string) ast.ExprNode {
+	if wtIsExpressionIndexKey(s) {
+		if parsed, err := wtParseExpr(s); err == nil {
+			return parsed
+		}
+		// Parse failed — best-effort: fall through to ColumnRef so at least
+		// the constraint installs with some key part instead of an empty
+		// IndexColumn.
+	}
+	return &ast.ColumnRef{Column: wtUnquoteIdent(s)}
+}
+
+// wtTypeSupportsDefault returns false for MySQL column types that disallow a
+// literal DEFAULT clause (BLOB family, JSON, GEOMETRY). Mirrors the filter
+// used by the bytebase writer — see get_database_definition.go:
+// typeSupportsDefaultValue — so the loader refuses defaults for the same
+// types the writer refuses to emit them for.
+func wtTypeSupportsDefault(typeStr string) bool {
+	head := strings.ToLower(strings.TrimSpace(typeStr))
+	if i := strings.IndexAny(head, " ("); i >= 0 {
+		head = head[:i]
+	}
+	switch head {
+	case "blob", "tinyblob", "mediumblob", "longblob", "json", "geometry":
+		return false
+	}
+	return true
 }
 
 func wtBuildFKConstraint(fk *storepb.ForeignKeyMetadata) *ast.Constraint {

--- a/backend/plugin/schema/mysql/walk_through_loader.go
+++ b/backend/plugin/schema/mysql/walk_through_loader.go
@@ -1,0 +1,846 @@
+package mysql
+
+import (
+	"cmp"
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/bytebase/omni/mysql/ast"
+	"github.com/bytebase/omni/mysql/catalog"
+	mysqlparser "github.com/bytebase/omni/mysql/parser"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+// autoIncrementSentinel matches the value that MySQL sync writes into
+// ColumnMetadata.Default when the column is AUTO_INCREMENT. See
+// get_database_definition.go:isAutoIncrement.
+const autoIncrementSentinel = "AUTO_INCREMENT"
+
+// loadWalkThroughCatalog installs every schema object from DatabaseSchemaMetadata
+// into the omni MySQL catalog with per-object isolation and pseudo fallback.
+//
+// Rationale: the prior implementation emitted a single concatenated DDL and
+// executed it as one Exec call. A single failing CREATE TABLE would leave the
+// catalog missing that table, and every downstream view / user query that
+// referenced it would also fail. This loader restricts each failure to its
+// owning object: if a table cannot be installed as-is, a pseudo table with
+// the right column names (but TEXT types, no constraints) is installed in its
+// place so that references still resolve.
+//
+// Preconditions: the caller must already have created and selected the target
+// database. This loader mutates foreign_key_checks to allow forward FK
+// references during bulk load.
+func loadWalkThroughCatalog(ctx context.Context, cat *catalog.Catalog, dbName string, meta *storepb.DatabaseSchemaMetadata) error {
+	if cat == nil {
+		return errors.New("loadWalkThroughCatalog: nil catalog")
+	}
+	if meta == nil {
+		return nil
+	}
+
+	// Disable FK checks for the duration of the bulk load. MySQL tolerates
+	// forward FK references only when this flag is off.
+	prevFKChecks := cat.ForeignKeyChecks()
+	cat.SetForeignKeyChecks(false)
+	defer cat.SetForeignKeyChecks(prevFKChecks)
+
+	cat.SetCurrentDatabase(dbName)
+
+	objects := wtCollectObjects(dbName, meta)
+	sorted := wtTopoSort(objects)
+	for _, obj := range sorted {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		wtInstallOne(cat, dbName, obj)
+	}
+	return nil
+}
+
+// wtObjectKind identifies the kind of a walk-through loader object.
+type wtObjectKind int
+
+const (
+	kindWTTable wtObjectKind = iota
+	kindWTView
+	kindWTFunction
+	kindWTProcedure
+)
+
+// wtObjectEntry is one unit of work for the walk-through loader.
+type wtObjectEntry struct {
+	kind wtObjectKind
+	name string
+
+	// Exactly one of the following is set based on kind.
+	tableMeta *storepb.TableMetadata
+	viewMeta  *storepb.ViewMetadata
+	funcMeta  *storepb.FunctionMetadata
+	procMeta  *storepb.ProcedureMetadata
+}
+
+func (e *wtObjectEntry) key() string {
+	switch e.kind {
+	case kindWTTable:
+		return "table:" + e.name
+	case kindWTView:
+		return "view:" + e.name
+	case kindWTFunction:
+		return "func:" + e.name
+	case kindWTProcedure:
+		return "proc:" + e.name
+	}
+	return "unknown:" + e.name
+}
+
+func (e *wtObjectEntry) sortKey() string {
+	return wtKindLabel(e.kind) + "\x00" + e.name
+}
+
+func wtKindLabel(k wtObjectKind) string {
+	switch k {
+	case kindWTTable:
+		return "1table"
+	case kindWTView:
+		return "2view"
+	case kindWTFunction:
+		return "3function"
+	case kindWTProcedure:
+		return "4procedure"
+	}
+	return "9unknown"
+}
+
+// wtCollectObjects flattens DatabaseSchemaMetadata into wtObjectEntry values.
+// MySQL metadata uses a single empty-named schema, so we look only at the first.
+func wtCollectObjects(_ string, meta *storepb.DatabaseSchemaMetadata) []*wtObjectEntry {
+	var out []*wtObjectEntry
+	for _, sm := range meta.Schemas {
+		for _, tbl := range sm.Tables {
+			if tbl == nil || tbl.Name == "" {
+				continue
+			}
+			out = append(out, &wtObjectEntry{
+				kind:      kindWTTable,
+				name:      tbl.Name,
+				tableMeta: tbl,
+			})
+		}
+		for _, view := range sm.Views {
+			if view == nil || view.Name == "" {
+				continue
+			}
+			out = append(out, &wtObjectEntry{
+				kind:     kindWTView,
+				name:     view.Name,
+				viewMeta: view,
+			})
+		}
+		for _, fn := range sm.Functions {
+			if fn == nil || fn.Name == "" {
+				continue
+			}
+			out = append(out, &wtObjectEntry{
+				kind:     kindWTFunction,
+				name:     fn.Name,
+				funcMeta: fn,
+			})
+		}
+		for _, proc := range sm.Procedures {
+			if proc == nil || proc.Name == "" {
+				continue
+			}
+			out = append(out, &wtObjectEntry{
+				kind:     kindWTProcedure,
+				name:     proc.Name,
+				procMeta: proc,
+			})
+		}
+	}
+	return out
+}
+
+// wtTopoSort orders objects by dependency using Tarjan SCC.
+//
+// For MySQL the dependency graph is extremely thin: tables have no cross-edges
+// (FKs are tolerated by SetForeignKeyChecks(false)), views tolerate forward
+// refs via DefineView semantics, and functions/procedures reference objects
+// only in their body text (opaque to us). So the graph reduces to a fixed
+// per-kind ordering: tables → views → functions → procedures. We still run
+// Tarjan so the shape of this file mirrors the pg walk-through loader, and so
+// the ordering remains deterministic if dependency edges are added later.
+func wtTopoSort(objects []*wtObjectEntry) []*wtObjectEntry {
+	if len(objects) == 0 {
+		return nil
+	}
+	index := make(map[string]*wtObjectEntry, len(objects))
+	for _, obj := range objects {
+		index[obj.key()] = obj
+	}
+
+	edges := wtBuildEdges(objects, index)
+	sccs := wtTarjanSCC(objects, edges)
+
+	sccOf := make(map[string]int, len(objects))
+	for i, scc := range sccs {
+		for _, obj := range scc {
+			sccOf[obj.key()] = i
+		}
+	}
+
+	condensedEdges := make([][]int, len(sccs))
+	inDegree := make([]int, len(sccs))
+	seenEdge := make(map[[2]int]bool)
+	for src, dsts := range edges {
+		srcSCC, ok := sccOf[src]
+		if !ok {
+			continue
+		}
+		for _, dst := range dsts {
+			dstSCC, ok2 := sccOf[dst]
+			if !ok2 || dstSCC == srcSCC {
+				continue
+			}
+			edge := [2]int{dstSCC, srcSCC}
+			if seenEdge[edge] {
+				continue
+			}
+			seenEdge[edge] = true
+			condensedEdges[dstSCC] = append(condensedEdges[dstSCC], srcSCC)
+			inDegree[srcSCC]++
+		}
+	}
+
+	ready := make([]int, 0)
+	for i := range sccs {
+		if inDegree[i] == 0 {
+			ready = append(ready, i)
+		}
+	}
+	wtSortSCCsByMin(ready, sccs)
+
+	var flat []*wtObjectEntry
+	for len(ready) > 0 {
+		next := ready[0]
+		ready = ready[1:]
+		flat = append(flat, wtSortedSCCMembers(sccs[next])...)
+		for _, nb := range condensedEdges[next] {
+			inDegree[nb]--
+			if inDegree[nb] == 0 {
+				ready = append(ready, nb)
+			}
+		}
+		wtSortSCCsByMin(ready, sccs)
+	}
+
+	if len(flat) != len(objects) {
+		emitted := make(map[string]bool, len(flat))
+		for _, o := range flat {
+			emitted[o.key()] = true
+		}
+		var missed []*wtObjectEntry
+		for _, o := range objects {
+			if !emitted[o.key()] {
+				missed = append(missed, o)
+			}
+		}
+		slices.SortStableFunc(missed, func(a, b *wtObjectEntry) int {
+			return cmp.Compare(a.sortKey(), b.sortKey())
+		})
+		flat = append(flat, missed...)
+	}
+	return flat
+}
+
+// wtBuildEdges is intentionally thin today. See wtTopoSort for the rationale.
+func wtBuildEdges(_ []*wtObjectEntry, _ map[string]*wtObjectEntry) map[string][]string {
+	return map[string][]string{}
+}
+
+func wtTarjanSCC(objects []*wtObjectEntry, edges map[string][]string) [][]*wtObjectEntry {
+	type state struct {
+		index, low int
+		onStack    bool
+	}
+	st := make(map[string]*state, len(objects))
+	byKey := make(map[string]*wtObjectEntry, len(objects))
+	for _, obj := range objects {
+		byKey[obj.key()] = obj
+	}
+
+	keys := make([]string, 0, len(objects))
+	for _, obj := range objects {
+		keys = append(keys, obj.key())
+	}
+	slices.Sort(keys)
+
+	var (
+		idx    int
+		stack  []string
+		result [][]*wtObjectEntry
+	)
+
+	var strongconnect func(v string)
+	strongconnect = func(v string) {
+		st[v] = &state{index: idx, low: idx, onStack: true}
+		idx++
+		stack = append(stack, v)
+		for _, w := range edges[v] {
+			if _, ok := byKey[w]; !ok {
+				continue
+			}
+			if _, seen := st[w]; !seen {
+				strongconnect(w)
+				st[v].low = min(st[v].low, st[w].low)
+			} else if st[w].onStack {
+				st[v].low = min(st[v].low, st[w].index)
+			}
+		}
+		if st[v].low == st[v].index {
+			var scc []*wtObjectEntry
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				st[w].onStack = false
+				scc = append(scc, byKey[w])
+				if w == v {
+					break
+				}
+			}
+			result = append(result, scc)
+		}
+	}
+
+	for _, k := range keys {
+		if _, seen := st[k]; !seen {
+			strongconnect(k)
+		}
+	}
+	return result
+}
+
+func wtSortedSCCMembers(scc []*wtObjectEntry) []*wtObjectEntry {
+	out := make([]*wtObjectEntry, len(scc))
+	copy(out, scc)
+	slices.SortStableFunc(out, func(a, b *wtObjectEntry) int {
+		return cmp.Compare(a.sortKey(), b.sortKey())
+	})
+	return out
+}
+
+func wtSortSCCsByMin(indices []int, sccs [][]*wtObjectEntry) {
+	slices.SortStableFunc(indices, func(a, b int) int {
+		return cmp.Compare(wtMinSortKey(sccs[a]), wtMinSortKey(sccs[b]))
+	})
+}
+
+func wtMinSortKey(scc []*wtObjectEntry) string {
+	if len(scc) == 0 {
+		return ""
+	}
+	best := scc[0].sortKey()
+	for _, o := range scc[1:] {
+		if k := o.sortKey(); k < best {
+			best = k
+		}
+	}
+	return best
+}
+
+// wtInstallOne attempts a real install and falls back to pseudo for tables/views.
+func wtInstallOne(cat *catalog.Catalog, dbName string, obj *wtObjectEntry) {
+	if err := wtInstallReal(cat, obj); err == nil {
+		return
+	}
+	switch obj.kind {
+	case kindWTTable:
+		_ = wtInstallPseudoTable(cat, dbName, obj.tableMeta)
+	case kindWTView:
+		_ = wtInstallPseudoView(cat, dbName, obj.viewMeta)
+	default:
+		// Functions, procedures: no pseudo form. Leave uninstalled.
+	}
+}
+
+// wtInstallReal builds the object's AST directly from metadata and calls the
+// corresponding catalog Define* API. This bypasses the bytebase deparser and
+// the omni parser on the critical path — both of which can have bugs that
+// would otherwise cause an object to fail real install when the metadata
+// itself is fine.
+//
+// Parser use is deliberately confined to cases where the input string comes
+// from MySQL itself (COLUMN_TYPE, VIEW_DEFINITION, SHOW CREATE output,
+// information_schema expression columns). Parsing those is parsing reality,
+// not parsing our own deparse, and that's the distinction that matters.
+func wtInstallReal(cat *catalog.Catalog, obj *wtObjectEntry) error {
+	switch obj.kind {
+	case kindWTTable:
+		stmt, err := wtBuildCreateTableStmt(obj.tableMeta)
+		if err != nil {
+			return err
+		}
+		return cat.DefineTable(stmt)
+	case kindWTView:
+		stmt, err := wtBuildCreateViewStmt(obj.viewMeta)
+		if err != nil {
+			return err
+		}
+		return cat.DefineView(stmt)
+	case kindWTFunction:
+		stmt, err := wtParseCreateRoutineStmt(obj.funcMeta.Definition, false)
+		if err != nil {
+			return err
+		}
+		return cat.DefineFunction(stmt)
+	case kindWTProcedure:
+		stmt, err := wtParseCreateRoutineStmt(obj.procMeta.Definition, true)
+		if err != nil {
+			return err
+		}
+		return cat.DefineProcedure(stmt)
+	}
+	return errors.Errorf("wtInstallReal: unknown kind %d", obj.kind)
+}
+
+// wtBuildCreateTableStmt maps TableMetadata directly onto *ast.CreateTableStmt.
+// Expression-bearing fields (DEFAULT, ON UPDATE, GENERATED, CHECK) go through
+// wtParseExpr, which tolerates parse failures by silently dropping the
+// affected feature rather than failing the whole table.
+func wtBuildCreateTableStmt(tbl *storepb.TableMetadata) (*ast.CreateTableStmt, error) {
+	if tbl == nil || tbl.Name == "" {
+		return nil, errors.New("wtBuildCreateTableStmt: empty table")
+	}
+	stmt := &ast.CreateTableStmt{
+		Table: &ast.TableRef{Name: tbl.Name},
+	}
+
+	for _, col := range tbl.Columns {
+		if col == nil || col.Name == "" {
+			continue
+		}
+		def, err := wtBuildColumnDef(col)
+		if err != nil {
+			return nil, errors.Wrapf(err, "column %q", col.Name)
+		}
+		stmt.Columns = append(stmt.Columns, def)
+	}
+
+	for _, idx := range tbl.Indexes {
+		if idx == nil || len(idx.Expressions) == 0 {
+			continue
+		}
+		if c := wtBuildIndexConstraint(idx); c != nil {
+			stmt.Constraints = append(stmt.Constraints, c)
+		}
+	}
+
+	for _, fk := range tbl.ForeignKeys {
+		if fk == nil {
+			continue
+		}
+		stmt.Constraints = append(stmt.Constraints, wtBuildFKConstraint(fk))
+	}
+
+	for _, chk := range tbl.CheckConstraints {
+		if chk == nil {
+			continue
+		}
+		if c := wtBuildCheckConstraint(chk); c != nil {
+			stmt.Constraints = append(stmt.Constraints, c)
+		}
+	}
+
+	if tbl.Engine != "" {
+		stmt.Options = append(stmt.Options, &ast.TableOption{Name: "ENGINE", Value: tbl.Engine})
+	}
+	if tbl.Charset != "" {
+		stmt.Options = append(stmt.Options, &ast.TableOption{Name: "CHARSET", Value: tbl.Charset})
+	}
+	if tbl.Collation != "" {
+		stmt.Options = append(stmt.Options, &ast.TableOption{Name: "COLLATE", Value: tbl.Collation})
+	}
+	if tbl.Comment != "" {
+		stmt.Options = append(stmt.Options, &ast.TableOption{Name: "COMMENT", Value: tbl.Comment})
+	}
+
+	// Partitions deliberately skipped: PartitionClause requires parsed
+	// expression trees that we don't have metadata for in decomposed form.
+	// Losing partition info does not affect column resolution or query shape.
+
+	return stmt, nil
+}
+
+func wtBuildColumnDef(col *storepb.ColumnMetadata) (*ast.ColumnDef, error) {
+	typeName, err := wtParseTypeName(col.Type)
+	if err != nil {
+		return nil, err
+	}
+	// Column-level charset/collation can come in via the type string or via
+	// separate metadata fields. Prefer type-embedded if present, else take
+	// the separate fields.
+	if typeName.Charset == "" && col.CharacterSet != "" {
+		typeName.Charset = col.CharacterSet
+	}
+	if typeName.Collate == "" && col.Collation != "" {
+		typeName.Collate = col.Collation
+	}
+
+	def := &ast.ColumnDef{
+		Name:     col.Name,
+		TypeName: typeName,
+		Comment:  col.Comment,
+	}
+	if !col.Nullable {
+		def.Constraints = append(def.Constraints, &ast.ColumnConstraint{Type: ast.ColConstrNotNull})
+	}
+
+	// MySQL sync encodes AUTO_INCREMENT as the literal string "AUTO_INCREMENT"
+	// in ColumnMetadata.Default. Detect it here and set AutoIncrement instead
+	// of treating it as a real default expression.
+	isAutoInc := strings.EqualFold(col.Default, autoIncrementSentinel)
+	if isAutoInc {
+		def.AutoIncrement = true
+	}
+
+	if !isAutoInc && col.Default != "" && col.Generation == nil {
+		if expr, err := wtParseExpr(col.Default); err == nil {
+			def.DefaultValue = expr
+		}
+		// Silent drop on parse failure — a missing DEFAULT is a closer
+		// approximation of reality than a whole-column failure.
+	}
+	if col.OnUpdate != "" {
+		if expr, err := wtParseExpr(col.OnUpdate); err == nil {
+			def.OnUpdate = expr
+		}
+	}
+	if col.Generation != nil && col.Generation.Expression != "" {
+		if expr, err := wtParseExpr(col.Generation.Expression); err == nil {
+			def.Generated = &ast.GeneratedColumn{
+				Expr:   expr,
+				Stored: col.Generation.Type == storepb.GenerationMetadata_TYPE_STORED,
+			}
+		}
+	}
+	return def, nil
+}
+
+func wtBuildIndexConstraint(idx *storepb.IndexMetadata) *ast.Constraint {
+	// IndexMetadata.Type mixes two axes: the constraint kind (FULLTEXT /
+	// SPATIAL) and the access method (BTREE / HASH). Pick them apart so
+	// the resulting ast.Constraint sets Type and IndexType correctly.
+	idxTypeUpper := strings.ToUpper(strings.TrimSpace(idx.Type))
+
+	c := &ast.Constraint{
+		Name: idx.Name,
+	}
+	switch {
+	case idx.Primary:
+		c.Type = ast.ConstrPrimaryKey
+		c.IndexType = idxTypeUpper
+	case idx.Unique:
+		c.Type = ast.ConstrUnique
+		c.IndexType = idxTypeUpper
+	case idxTypeUpper == "FULLTEXT":
+		c.Type = ast.ConstrFulltextIndex
+	case idxTypeUpper == "SPATIAL":
+		c.Type = ast.ConstrSpatialIndex
+	default:
+		c.Type = ast.ConstrIndex
+		c.IndexType = idxTypeUpper
+	}
+	// Use IndexColumns when per-part length or DESC matters; otherwise the
+	// simpler Columns field is enough. Functional indexes (expressions) are
+	// left as plain identifiers — rare in practice and omni can't validate
+	// them against the catalog anyway.
+	needIC := false
+	for i := range idx.Expressions {
+		if (i < len(idx.KeyLength) && idx.KeyLength[i] > 0) ||
+			(i < len(idx.Descending) && idx.Descending[i]) {
+			needIC = true
+			break
+		}
+	}
+	if needIC {
+		for i, expr := range idx.Expressions {
+			ic := &ast.IndexColumn{
+				Expr: &ast.ColumnRef{Column: wtUnquoteIdent(expr)},
+			}
+			if i < len(idx.KeyLength) && idx.KeyLength[i] > 0 {
+				ic.Length = int(idx.KeyLength[i])
+			}
+			if i < len(idx.Descending) && idx.Descending[i] {
+				ic.Desc = true
+			}
+			c.IndexColumns = append(c.IndexColumns, ic)
+		}
+	} else {
+		for _, expr := range idx.Expressions {
+			c.Columns = append(c.Columns, wtUnquoteIdent(expr))
+		}
+	}
+	return c
+}
+
+func wtBuildFKConstraint(fk *storepb.ForeignKeyMetadata) *ast.Constraint {
+	return &ast.Constraint{
+		Type:       ast.ConstrForeignKey,
+		Name:       fk.Name,
+		Columns:    fk.Columns,
+		RefTable:   &ast.TableRef{Schema: fk.ReferencedSchema, Name: fk.ReferencedTable},
+		RefColumns: fk.ReferencedColumns,
+		OnUpdate:   wtFKAction(fk.OnUpdate),
+		OnDelete:   wtFKAction(fk.OnDelete),
+		Match:      strings.ToUpper(fk.MatchType),
+	}
+}
+
+func wtFKAction(s string) ast.ReferenceAction {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "RESTRICT":
+		return ast.RefActRestrict
+	case "CASCADE":
+		return ast.RefActCascade
+	case "SET NULL":
+		return ast.RefActSetNull
+	case "SET DEFAULT":
+		return ast.RefActSetDefault
+	case "NO ACTION":
+		return ast.RefActNoAction
+	default:
+		return ast.RefActNone
+	}
+}
+
+func wtBuildCheckConstraint(chk *storepb.CheckConstraintMetadata) *ast.Constraint {
+	if chk.Expression == "" {
+		return nil
+	}
+	expr, err := wtParseExpr(chk.Expression)
+	if err != nil {
+		return nil
+	}
+	return &ast.Constraint{
+		Type: ast.ConstrCheck,
+		Name: chk.Name,
+		Expr: expr,
+	}
+}
+
+// wtBuildCreateViewStmt builds the CreateViewStmt directly; the SELECT body is
+// parsed from VIEW_DEFINITION (a MySQL-produced string, not our deparse).
+// DefineView tolerates a nil Select, so forward references, cyclic views and
+// body-parse failures are all survivable.
+func wtBuildCreateViewStmt(view *storepb.ViewMetadata) (*ast.CreateViewStmt, error) {
+	if view == nil || view.Name == "" {
+		return nil, errors.New("wtBuildCreateViewStmt: empty view")
+	}
+	stmt := &ast.CreateViewStmt{
+		OrReplace:  true,
+		Name:       &ast.TableRef{Name: view.Name},
+		SelectText: view.Definition,
+	}
+	for _, col := range view.Columns {
+		if col != nil && col.Name != "" {
+			stmt.Columns = append(stmt.Columns, col.Name)
+		}
+	}
+	if view.Definition != "" {
+		if sel, err := wtParseSelect(view.Definition); err == nil {
+			stmt.Select = sel
+		}
+	}
+	return stmt, nil
+}
+
+// wtParseCreateRoutineStmt parses the full SHOW CREATE FUNCTION / PROCEDURE
+// text that MySQL sync stored in FunctionMetadata.Definition /
+// ProcedureMetadata.Definition. The result is the AST form DefineFunction and
+// DefineProcedure consume.
+func wtParseCreateRoutineStmt(definition string, isProcedure bool) (*ast.CreateFunctionStmt, error) {
+	if strings.TrimSpace(definition) == "" {
+		return nil, errors.New("empty definition")
+	}
+	list, err := mysqlparser.Parse(definition)
+	if err != nil {
+		return nil, err
+	}
+	if list == nil {
+		return nil, errors.New("nil parse result")
+	}
+	for _, n := range list.Items {
+		if stmt, ok := n.(*ast.CreateFunctionStmt); ok {
+			stmt.IsProcedure = isProcedure
+			return stmt, nil
+		}
+	}
+	return nil, errors.New("no CreateFunctionStmt in parse result")
+}
+
+// wtParseTypeName parses a MySQL column-type string (the output of
+// information_schema.COLUMNS.COLUMN_TYPE, e.g. "varchar(255)",
+// "int unsigned", "enum('a','b')") into *ast.DataType by wrapping it in a
+// throwaway CREATE TABLE and letting the omni parser do the work.
+func wtParseTypeName(typeStr string) (*ast.DataType, error) {
+	typeStr = strings.TrimSpace(typeStr)
+	if typeStr == "" {
+		return nil, errors.New("empty type string")
+	}
+	sql := "CREATE TABLE `__bb_wt_type_probe` (`__bb_c` " + typeStr + ")"
+	list, err := mysqlparser.Parse(sql)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parse type %q", typeStr)
+	}
+	if list == nil || len(list.Items) == 0 {
+		return nil, errors.Errorf("parse type %q: empty result", typeStr)
+	}
+	ct, ok := list.Items[0].(*ast.CreateTableStmt)
+	if !ok {
+		return nil, errors.Errorf("parse type %q: expected CreateTableStmt, got %T", typeStr, list.Items[0])
+	}
+	if len(ct.Columns) == 0 || ct.Columns[0].TypeName == nil {
+		return nil, errors.Errorf("parse type %q: no type in parsed column", typeStr)
+	}
+	return ct.Columns[0].TypeName, nil
+}
+
+// wtParseExpr parses an expression string via a SELECT wrapper. Used for
+// DEFAULT, ON UPDATE, generated-column and CHECK expressions — all of which
+// originate in MySQL's information_schema or SHOW CREATE output (reality,
+// not our deparse).
+func wtParseExpr(exprStr string) (ast.ExprNode, error) {
+	exprStr = strings.TrimSpace(exprStr)
+	if exprStr == "" {
+		return nil, errors.New("empty expression")
+	}
+	sql := "SELECT (" + exprStr + ") AS `__bb_wt_expr_probe`"
+	list, err := mysqlparser.Parse(sql)
+	if err != nil {
+		return nil, errors.Wrapf(err, "parse expr %q", exprStr)
+	}
+	if list == nil || len(list.Items) == 0 {
+		return nil, errors.Errorf("parse expr %q: empty result", exprStr)
+	}
+	sel, ok := list.Items[0].(*ast.SelectStmt)
+	if !ok {
+		return nil, errors.Errorf("parse expr %q: expected SelectStmt, got %T", exprStr, list.Items[0])
+	}
+	if len(sel.TargetList) == 0 {
+		return nil, errors.Errorf("parse expr %q: empty target list", exprStr)
+	}
+	rt, ok := sel.TargetList[0].(*ast.ResTarget)
+	if !ok {
+		return nil, errors.Errorf("parse expr %q: unexpected target %T", exprStr, sel.TargetList[0])
+	}
+	return rt.Val, nil
+}
+
+// wtParseSelect parses a SELECT body (as returned by VIEW_DEFINITION) into
+// *ast.SelectStmt.
+func wtParseSelect(body string) (*ast.SelectStmt, error) {
+	list, err := mysqlparser.Parse(body)
+	if err != nil {
+		return nil, err
+	}
+	if list == nil || len(list.Items) == 0 {
+		return nil, errors.New("empty parse result")
+	}
+	sel, ok := list.Items[0].(*ast.SelectStmt)
+	if !ok {
+		return nil, errors.Errorf("expected SelectStmt, got %T", list.Items[0])
+	}
+	return sel, nil
+}
+
+func wtUnquoteIdent(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 && s[0] == '`' && s[len(s)-1] == '`' {
+		return strings.ReplaceAll(s[1:len(s)-1], "``", "`")
+	}
+	return s
+}
+
+// wtInstallPseudoTable installs a degraded table with all-TEXT columns and no
+// constraints. Built as an AST and handed to DefineTable directly — no SQL
+// string and no parser on the critical path.
+func wtInstallPseudoTable(cat *catalog.Catalog, _ string, tbl *storepb.TableMetadata) error {
+	if tbl == nil || tbl.Name == "" {
+		return errors.New("pseudo table: missing name")
+	}
+
+	stmt := &ast.CreateTableStmt{
+		Table: &ast.TableRef{Name: tbl.Name},
+	}
+
+	seen := make(map[string]bool, len(tbl.Columns))
+	for _, col := range tbl.Columns {
+		if col == nil || col.Name == "" || seen[col.Name] {
+			continue
+		}
+		seen[col.Name] = true
+		stmt.Columns = append(stmt.Columns, &ast.ColumnDef{
+			Name:     col.Name,
+			TypeName: wtPseudoTextType(),
+		})
+	}
+	if len(stmt.Columns) == 0 {
+		// MySQL requires at least one column — give it a placeholder so the
+		// object still exists and blocks future duplicate-name installs.
+		stmt.Columns = append(stmt.Columns, &ast.ColumnDef{
+			Name:     "__bb_placeholder",
+			TypeName: wtPseudoTextType(),
+		})
+	}
+	return cat.DefineTable(stmt)
+}
+
+// wtInstallPseudoView installs a degraded view whose SELECT list is a series
+// of NULL literals aliased to the original view's column names. Built in AST
+// form and installed via DefineView directly.
+func wtInstallPseudoView(cat *catalog.Catalog, _ string, view *storepb.ViewMetadata) error {
+	if view == nil || view.Name == "" {
+		return errors.New("pseudo view: missing name")
+	}
+
+	var targets []ast.ExprNode
+	seen := make(map[string]bool)
+	addTarget := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		targets = append(targets, &ast.ResTarget{
+			Name: name,
+			Val:  &ast.NullLit{},
+		})
+	}
+	for _, col := range view.Columns {
+		if col != nil {
+			addTarget(col.Name)
+		}
+	}
+	if len(targets) == 0 {
+		for _, dc := range view.DependencyColumns {
+			if dc != nil {
+				addTarget(dc.Column)
+			}
+		}
+	}
+	if len(targets) == 0 {
+		addTarget("__bb_placeholder")
+	}
+
+	return cat.DefineView(&ast.CreateViewStmt{
+		OrReplace: true,
+		Name:      &ast.TableRef{Name: view.Name},
+		Select:    &ast.SelectStmt{TargetList: targets},
+	})
+}
+
+func wtPseudoTextType() *ast.DataType {
+	return &ast.DataType{Name: "TEXT"}
+}

--- a/backend/plugin/schema/mysql/walk_through_loader.go
+++ b/backend/plugin/schema/mysql/walk_through_loader.go
@@ -69,18 +69,26 @@ const (
 	kindWTView
 	kindWTFunction
 	kindWTProcedure
+	kindWTTrigger
+	kindWTEvent
 )
 
 // wtObjectEntry is one unit of work for the walk-through loader.
 type wtObjectEntry struct {
 	kind wtObjectKind
 	name string
+	// parentTable is set for kindWTTrigger — triggers must attach to an
+	// existing table in the catalog, so we carry the owning table name
+	// separately from the trigger name.
+	parentTable string
 
 	// Exactly one of the following is set based on kind.
-	tableMeta *storepb.TableMetadata
-	viewMeta  *storepb.ViewMetadata
-	funcMeta  *storepb.FunctionMetadata
-	procMeta  *storepb.ProcedureMetadata
+	tableMeta   *storepb.TableMetadata
+	viewMeta    *storepb.ViewMetadata
+	funcMeta    *storepb.FunctionMetadata
+	procMeta    *storepb.ProcedureMetadata
+	triggerMeta *storepb.TriggerMetadata
+	eventMeta   *storepb.EventMetadata
 }
 
 func (e *wtObjectEntry) key() string {
@@ -93,12 +101,22 @@ func (e *wtObjectEntry) key() string {
 		return "func:" + e.name
 	case kindWTProcedure:
 		return "proc:" + e.name
+	case kindWTTrigger:
+		return "trigger:" + e.parentTable + "." + e.name
+	case kindWTEvent:
+		return "event:" + e.name
 	}
 	return "unknown:" + e.name
 }
 
 func (e *wtObjectEntry) sortKey() string {
-	return wtKindLabel(e.kind) + "\x00" + e.name
+	base := wtKindLabel(e.kind) + "\x00" + e.name
+	if e.kind == kindWTTrigger {
+		// Keep triggers grouped by their parent table so stable ordering
+		// within a file doesn't depend on trigger name alone.
+		base += "\x00" + e.parentTable
+	}
+	return base
 }
 
 func wtKindLabel(k wtObjectKind) string {
@@ -111,6 +129,12 @@ func wtKindLabel(k wtObjectKind) string {
 		return "3function"
 	case kindWTProcedure:
 		return "4procedure"
+	case kindWTTrigger:
+		// Triggers must install after their target table. The ordering here
+		// alone does the trick because kindWTTable sorts before kindWTTrigger.
+		return "5trigger"
+	case kindWTEvent:
+		return "6event"
 	}
 	return "9unknown"
 }
@@ -129,6 +153,17 @@ func wtCollectObjects(_ string, meta *storepb.DatabaseSchemaMetadata) []*wtObjec
 				name:      tbl.Name,
 				tableMeta: tbl,
 			})
+			for _, trg := range tbl.Triggers {
+				if trg == nil || trg.Name == "" {
+					continue
+				}
+				out = append(out, &wtObjectEntry{
+					kind:        kindWTTrigger,
+					name:        trg.Name,
+					parentTable: tbl.Name,
+					triggerMeta: trg,
+				})
+			}
 		}
 		for _, view := range sm.Views {
 			if view == nil || view.Name == "" {
@@ -158,6 +193,16 @@ func wtCollectObjects(_ string, meta *storepb.DatabaseSchemaMetadata) []*wtObjec
 				kind:     kindWTProcedure,
 				name:     proc.Name,
 				procMeta: proc,
+			})
+		}
+		for _, ev := range sm.Events {
+			if ev == nil || ev.Name == "" {
+				continue
+			}
+			out = append(out, &wtObjectEntry{
+				kind:      kindWTEvent,
+				name:      ev.Name,
+				eventMeta: ev,
 			})
 		}
 	}
@@ -351,7 +396,9 @@ func wtMinSortKey(scc []*wtObjectEntry) string {
 	return best
 }
 
-// wtInstallOne attempts a real install and falls back to pseudo for tables/views.
+// wtInstallOne attempts a real install and falls back to pseudo for objects
+// that have a pseudo form. For objects without one (functions, procedures)
+// failure silently drops the object from the catalog.
 func wtInstallOne(cat *catalog.Catalog, dbName string, obj *wtObjectEntry) {
 	if err := wtInstallReal(cat, obj); err == nil {
 		return
@@ -361,6 +408,10 @@ func wtInstallOne(cat *catalog.Catalog, dbName string, obj *wtObjectEntry) {
 		_ = wtInstallPseudoTable(cat, dbName, obj.tableMeta)
 	case kindWTView:
 		_ = wtInstallPseudoView(cat, dbName, obj.viewMeta)
+	case kindWTTrigger:
+		_ = wtInstallPseudoTrigger(cat, obj.triggerMeta, obj.parentTable)
+	case kindWTEvent:
+		_ = wtInstallPseudoEvent(cat, obj.eventMeta)
 	default:
 		// Functions, procedures: no pseudo form. Leave uninstalled.
 	}
@@ -402,6 +453,20 @@ func wtInstallReal(cat *catalog.Catalog, obj *wtObjectEntry) error {
 			return err
 		}
 		return cat.DefineProcedure(stmt)
+	case kindWTTrigger:
+		tm := obj.triggerMeta
+		if tm == nil || tm.Timing == "" || tm.Event == "" {
+			// Missing routing metadata — let pseudo fallback synthesize
+			// defaults rather than storing a semantically broken trigger.
+			return errors.New("trigger: missing Timing or Event")
+		}
+		return cat.DefineTrigger(wtBuildCreateTriggerStmt(tm, obj.parentTable))
+	case kindWTEvent:
+		stmt, err := wtParseCreateEventStmt(obj.eventMeta.Definition)
+		if err != nil {
+			return err
+		}
+		return cat.DefineEvent(stmt)
 	}
 	return errors.Errorf("wtInstallReal: unknown kind %d", obj.kind)
 }
@@ -843,4 +908,115 @@ func wtInstallPseudoView(cat *catalog.Catalog, _ string, view *storepb.ViewMetad
 
 func wtPseudoTextType() *ast.DataType {
 	return &ast.DataType{Name: "TEXT"}
+}
+
+// wtBuildCreateTriggerStmt hand-constructs *ast.CreateTriggerStmt from
+// TriggerMetadata. Sync fills only the body (information_schema
+// TRIGGERS.ACTION_STATEMENT) without the CREATE TRIGGER header, so we wire
+// Name/Timing/Event/Table/BodyText directly. Body is a parsed sp_proc_stmt —
+// best-effort only; on parse failure we still hand DefineTrigger a usable
+// stmt with BodyText populated.
+func wtBuildCreateTriggerStmt(tm *storepb.TriggerMetadata, tableName string) *ast.CreateTriggerStmt {
+	stmt := &ast.CreateTriggerStmt{
+		Name:     tm.Name,
+		Timing:   tm.Timing,
+		Event:    tm.Event,
+		Table:    &ast.TableRef{Name: tableName},
+		BodyText: tm.Body,
+	}
+	if body := wtParseTriggerBody(tableName, tm.Timing, tm.Event, tm.Body); body != nil {
+		stmt.Body = body
+	}
+	return stmt
+}
+
+// wtParseTriggerBody wraps the raw trigger body in a known-good CREATE TRIGGER
+// template so the omni parser can produce a Body node. Source is MySQL's
+// information_schema output, not our own deparse.
+func wtParseTriggerBody(tableName, timing, event, body string) ast.Node {
+	if strings.TrimSpace(body) == "" {
+		return nil
+	}
+	if tableName == "" {
+		tableName = "__bb_probe_table"
+	}
+	if timing == "" {
+		timing = "BEFORE"
+	}
+	if event == "" {
+		event = "INSERT"
+	}
+	sql := "CREATE TRIGGER `__bb_probe_trigger` " + timing + " " + event +
+		" ON `" + tableName + "` FOR EACH ROW " + body
+	list, err := mysqlparser.Parse(sql)
+	if err != nil || list == nil {
+		return nil
+	}
+	for _, n := range list.Items {
+		if ct, ok := n.(*ast.CreateTriggerStmt); ok {
+			return ct.Body
+		}
+	}
+	return nil
+}
+
+// wtInstallPseudoTrigger installs a trigger stub when the real install path
+// fails (e.g. body node construction tripped up DefineTrigger, or the parent
+// table name was empty in metadata). The stub preserves Name and routing
+// (Timing/Event/Table) so references still resolve; Body collapses to the
+// trivial no-op "BEGIN END".
+func wtInstallPseudoTrigger(cat *catalog.Catalog, tm *storepb.TriggerMetadata, tableName string) error {
+	if tm == nil || tm.Name == "" {
+		return errors.New("pseudo trigger: missing name")
+	}
+	timing := tm.Timing
+	if timing == "" {
+		timing = "BEFORE"
+	}
+	event := tm.Event
+	if event == "" {
+		event = "INSERT"
+	}
+	if tableName == "" {
+		tableName = "__bb_placeholder"
+	}
+	return cat.DefineTrigger(&ast.CreateTriggerStmt{
+		Name:     tm.Name,
+		Timing:   timing,
+		Event:    event,
+		Table:    &ast.TableRef{Name: tableName},
+		BodyText: "BEGIN END",
+	})
+}
+
+// wtParseCreateEventStmt parses the full SHOW CREATE EVENT text that sync
+// stored in EventMetadata.Definition into *ast.CreateEventStmt.
+func wtParseCreateEventStmt(definition string) (*ast.CreateEventStmt, error) {
+	if strings.TrimSpace(definition) == "" {
+		return nil, errors.New("empty event definition")
+	}
+	list, err := mysqlparser.Parse(definition)
+	if err != nil {
+		return nil, err
+	}
+	if list == nil {
+		return nil, errors.New("nil parse result")
+	}
+	for _, n := range list.Items {
+		if ev, ok := n.(*ast.CreateEventStmt); ok {
+			return ev, nil
+		}
+	}
+	return nil, errors.New("no CreateEventStmt in parse result")
+}
+
+// wtInstallPseudoEvent installs a bare name-only event when the real install
+// path fails (Definition was empty, malformed, or rejected by DefineEvent).
+func wtInstallPseudoEvent(cat *catalog.Catalog, em *storepb.EventMetadata) error {
+	if em == nil || em.Name == "" {
+		return errors.New("pseudo event: missing name")
+	}
+	return cat.DefineEvent(&ast.CreateEventStmt{
+		Name: em.Name,
+	})
 }

--- a/backend/plugin/schema/mysql/walk_through_loader_test.go
+++ b/backend/plugin/schema/mysql/walk_through_loader_test.go
@@ -1,0 +1,612 @@
+package mysql
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/mysql/catalog"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+// These tests exercise loadWalkThroughCatalog against synthetic metadata.
+// Nothing here touches bb_export or any external fixture — every input is a
+// storepb.*Metadata constructed in memory.
+
+const testDBName = "testdb"
+
+// newLoaderTestCatalog returns a catalog with the test database created and
+// selected, matching the setup WalkThroughOmni performs before the loader runs.
+func newLoaderTestCatalog(t *testing.T) *catalog.Catalog {
+	t.Helper()
+	c := catalog.New()
+	if _, err := c.Exec(
+		"SET foreign_key_checks = 0;\nCREATE DATABASE IF NOT EXISTS `"+testDBName+"`;\nUSE `"+testDBName+"`;",
+		&catalog.ExecOptions{ContinueOnError: true},
+	); err != nil {
+		t.Fatalf("init catalog: %v", err)
+	}
+	return c
+}
+
+func runLoader(t *testing.T, c *catalog.Catalog, meta *storepb.DatabaseSchemaMetadata) {
+	t.Helper()
+	if err := loadWalkThroughCatalog(context.Background(), c, testDBName, meta); err != nil {
+		t.Fatalf("loadWalkThroughCatalog: %v", err)
+	}
+}
+
+func mustGetTable(t *testing.T, c *catalog.Catalog, name string) *catalog.Table {
+	t.Helper()
+	db := c.GetDatabase(testDBName)
+	if db == nil {
+		t.Fatalf("database %q not in catalog", testDBName)
+	}
+	tbl := db.Tables[strings.ToLower(name)]
+	if tbl == nil {
+		t.Fatalf("table %q not in catalog", name)
+	}
+	return tbl
+}
+
+func mustGetView(t *testing.T, c *catalog.Catalog, name string) *catalog.View {
+	t.Helper()
+	db := c.GetDatabase(testDBName)
+	if db == nil {
+		t.Fatalf("database %q not in catalog", testDBName)
+	}
+	v := db.Views[strings.ToLower(name)]
+	if v == nil {
+		t.Fatalf("view %q not in catalog", name)
+	}
+	return v
+}
+
+// ----------------------------------------------------------------------
+// wtParseTypeName — covers a representative cross-section of MySQL types.
+// ----------------------------------------------------------------------
+
+func TestWtParseTypeName(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantName string
+	}{
+		{"int", "INT"},
+		{"int unsigned", "INT"},
+		{"bigint(20) unsigned zerofill", "BIGINT"},
+		{"varchar(255)", "VARCHAR"},
+		{"char(1)", "CHAR"},
+		{"text", "TEXT"},
+		{"decimal(10,2)", "DECIMAL"},
+		{"datetime(6)", "DATETIME"},
+		{"timestamp", "TIMESTAMP"},
+		{"tinyint(1)", "TINYINT"},
+		{"blob", "BLOB"},
+		{"json", "JSON"},
+		{"enum('a','b','c')", "ENUM"},
+		{"set('x','y')", "SET"},
+		{"geometry", "GEOMETRY"},
+		{"bit(1)", "BIT"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			dt, err := wtParseTypeName(tc.in)
+			if err != nil {
+				t.Fatalf("wtParseTypeName(%q): %v", tc.in, err)
+			}
+			if !strings.EqualFold(dt.Name, tc.wantName) {
+				t.Errorf("wtParseTypeName(%q).Name = %q, want %q", tc.in, dt.Name, tc.wantName)
+			}
+		})
+	}
+}
+
+func TestWtParseTypeName_Failures(t *testing.T) {
+	for _, in := range []string{"", "not a real type (((", "int UNSIGNED ZEROFILL NOT_A_THING"} {
+		if _, err := wtParseTypeName(in); err == nil {
+			t.Errorf("wtParseTypeName(%q): expected error, got nil", in)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// wtParseExpr — default/ON UPDATE/generated/check expressions.
+// ----------------------------------------------------------------------
+
+func TestWtParseExpr(t *testing.T) {
+	for _, in := range []string{
+		`'hello'`,
+		`CURRENT_TIMESTAMP`,
+		`NULL`,
+		`0`,
+		`a + b`,
+		`CONCAT('x', 'y')`,
+		`DATE_FORMAT(NOW(), '%Y-%m-%d')`,
+	} {
+		if _, err := wtParseExpr(in); err != nil {
+			t.Errorf("wtParseExpr(%q) unexpectedly failed: %v", in, err)
+		}
+	}
+}
+
+func TestWtParseExpr_Failures(t *testing.T) {
+	// "SELECT 1" is intentionally NOT in this list: wrapped in our SELECT
+	// probe it parses as a scalar subquery expression, which is valid.
+	for _, in := range []string{"", "(((", "this is not sql at all ###"} {
+		if _, err := wtParseExpr(in); err == nil {
+			t.Errorf("wtParseExpr(%q): expected error, got nil", in)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// Real table install — exercises the full column + constraint + option path.
+// ----------------------------------------------------------------------
+
+func TestLoader_TableBasic(t *testing.T) {
+	meta := schemaWithTables(&storepb.TableMetadata{
+		Name:      "users",
+		Engine:    "InnoDB",
+		Charset:   "utf8mb4",
+		Collation: "utf8mb4_0900_ai_ci",
+		Comment:   "users table",
+		Columns: []*storepb.ColumnMetadata{
+			{
+				Name:     "id",
+				Type:     "bigint unsigned",
+				Nullable: false,
+				Default:  autoIncrementSentinel,
+			},
+			{
+				Name:         "email",
+				Type:         "varchar(255)",
+				Nullable:     false,
+				CharacterSet: "utf8mb4",
+				Collation:    "utf8mb4_0900_ai_ci",
+			},
+			{
+				Name:     "created_at",
+				Type:     "timestamp",
+				Nullable: false,
+				Default:  "CURRENT_TIMESTAMP",
+				OnUpdate: "CURRENT_TIMESTAMP",
+			},
+			{
+				Name:     "bio",
+				Type:     "text",
+				Nullable: true,
+				Comment:  "free form text",
+			},
+		},
+		Indexes: []*storepb.IndexMetadata{
+			{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+			{Name: "uniq_email", Type: "BTREE", Unique: true, Expressions: []string{"email"}},
+		},
+	})
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	tbl := mustGetTable(t, c, "users")
+	if got := len(tbl.Columns); got != 4 {
+		t.Fatalf("Columns: want 4, got %d", got)
+	}
+	if got := tbl.Engine; got != "InnoDB" {
+		t.Errorf("Engine: %q", got)
+	}
+	if got := tbl.Charset; got != "utf8mb4" {
+		t.Errorf("Charset: %q", got)
+	}
+	if got := tbl.Comment; got != "users table" {
+		t.Errorf("Comment: %q", got)
+	}
+
+	// Column properties.
+	idCol := tbl.GetColumn("id")
+	if idCol == nil {
+		t.Fatal("id column missing")
+	}
+	if !idCol.AutoIncrement {
+		t.Error("id should be AUTO_INCREMENT (sentinel detection)")
+	}
+	if idCol.Nullable {
+		t.Error("id should be NOT NULL")
+	}
+	if strings.ToLower(idCol.DataType) != "bigint" {
+		t.Errorf("id.DataType = %q", idCol.DataType)
+	}
+
+	emailCol := tbl.GetColumn("email")
+	if emailCol == nil || emailCol.Charset != "utf8mb4" {
+		t.Errorf("email.Charset: %q", emailCol.Charset)
+	}
+
+	createdCol := tbl.GetColumn("created_at")
+	// Omni's catalog canonicalizes CURRENT_TIMESTAMP to now() when deparsing
+	// the parsed expression; both forms are equivalent so assert presence of
+	// a default and ON UPDATE rather than a specific string.
+	if createdCol == nil || createdCol.Default == nil || *createdCol.Default == "" {
+		t.Errorf("created_at default missing: %+v", createdCol)
+	}
+	if createdCol == nil || createdCol.OnUpdate == "" {
+		t.Error("created_at OnUpdate missing")
+	}
+
+	bioCol := tbl.GetColumn("bio")
+	if bioCol == nil || bioCol.Comment != "free form text" {
+		t.Errorf("bio.Comment: %q", bioCol.Comment)
+	}
+
+	// Primary key must be present as a constraint.
+	var hasPK, hasUnique bool
+	for _, con := range tbl.Constraints {
+		switch con.Type {
+		case catalog.ConPrimaryKey:
+			hasPK = true
+		case catalog.ConUniqueKey:
+			if con.Name == "uniq_email" {
+				hasUnique = true
+			}
+		default:
+		}
+	}
+	if !hasPK {
+		t.Error("missing PRIMARY KEY constraint")
+	}
+	if !hasUnique {
+		t.Error("missing uniq_email unique constraint")
+	}
+}
+
+// ----------------------------------------------------------------------
+// Fulltext / Spatial index fix — the regression we're covering in this PR.
+// ----------------------------------------------------------------------
+
+func TestLoader_FulltextAndSpatialIndex(t *testing.T) {
+	meta := schemaWithTables(&storepb.TableMetadata{
+		Name: "t",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "id", Type: "bigint unsigned", Nullable: false, Default: autoIncrementSentinel},
+			{Name: "body", Type: "text", Nullable: true},
+			{Name: "location", Type: "geometry", Nullable: true},
+		},
+		Indexes: []*storepb.IndexMetadata{
+			{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+			{Name: "ft_body", Type: "FULLTEXT", Expressions: []string{"body"}},
+			{Name: "sp_location", Type: "SPATIAL", Expressions: []string{"location"}},
+		},
+	})
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	tbl := mustGetTable(t, c, "t")
+	var gotFulltext, gotSpatial bool
+	for _, idx := range tbl.Indexes {
+		switch idx.Name {
+		case "ft_body":
+			gotFulltext = idx.Fulltext
+			if !idx.Fulltext {
+				t.Errorf("ft_body installed but not marked as Fulltext; IndexType=%q", idx.IndexType)
+			}
+		case "sp_location":
+			gotSpatial = idx.Spatial
+			if !idx.Spatial {
+				t.Errorf("sp_location installed but not marked as Spatial; IndexType=%q", idx.IndexType)
+			}
+		default:
+			// Other indexes (e.g. PRIMARY) are irrelevant here.
+		}
+	}
+	if !gotFulltext {
+		t.Error("fulltext index not found on table")
+	}
+	if !gotSpatial {
+		t.Error("spatial index not found on table")
+	}
+}
+
+// ----------------------------------------------------------------------
+// FK install — foreign_key_checks off, the constraint is recorded unchecked.
+// ----------------------------------------------------------------------
+
+func TestLoader_ForeignKeyAcrossTables(t *testing.T) {
+	meta := schemaWithTables(
+		&storepb.TableMetadata{
+			Name: "parent",
+			Columns: []*storepb.ColumnMetadata{
+				{Name: "id", Type: "bigint unsigned", Nullable: false, Default: autoIncrementSentinel},
+			},
+			Indexes: []*storepb.IndexMetadata{
+				{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+			},
+		},
+		&storepb.TableMetadata{
+			Name: "child",
+			Columns: []*storepb.ColumnMetadata{
+				{Name: "id", Type: "bigint unsigned", Nullable: false, Default: autoIncrementSentinel},
+				{Name: "parent_id", Type: "bigint unsigned", Nullable: false},
+			},
+			Indexes: []*storepb.IndexMetadata{
+				{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+				{Name: "idx_parent_id", Type: "BTREE", Expressions: []string{"parent_id"}},
+			},
+			ForeignKeys: []*storepb.ForeignKeyMetadata{
+				{
+					Name:              "fk_child_parent",
+					Columns:           []string{"parent_id"},
+					ReferencedTable:   "parent",
+					ReferencedColumns: []string{"id"},
+					OnDelete:          "CASCADE",
+					OnUpdate:          "RESTRICT",
+				},
+			},
+		},
+	)
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	child := mustGetTable(t, c, "child")
+	var fk *catalog.Constraint
+	for _, con := range child.Constraints {
+		if con.Type == catalog.ConForeignKey && con.Name == "fk_child_parent" {
+			fk = con
+			break
+		}
+	}
+	if fk == nil {
+		t.Fatal("fk_child_parent constraint missing")
+	}
+	if strings.ToUpper(fk.OnDelete) != "CASCADE" {
+		t.Errorf("OnDelete = %q, want CASCADE", fk.OnDelete)
+	}
+	if strings.ToUpper(fk.OnUpdate) != "RESTRICT" {
+		t.Errorf("OnUpdate = %q, want RESTRICT", fk.OnUpdate)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Generated columns.
+// ----------------------------------------------------------------------
+
+func TestLoader_GeneratedColumn(t *testing.T) {
+	meta := schemaWithTables(&storepb.TableMetadata{
+		Name: "t",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "a", Type: "int", Nullable: true},
+			{Name: "b", Type: "int", Nullable: true},
+			{
+				Name:     "c",
+				Type:     "int",
+				Nullable: true,
+				Generation: &storepb.GenerationMetadata{
+					Type:       storepb.GenerationMetadata_TYPE_STORED,
+					Expression: "a + b",
+				},
+			},
+		},
+	})
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	tbl := mustGetTable(t, c, "t")
+	col := tbl.GetColumn("c")
+	if col == nil || col.Generated == nil {
+		t.Fatalf("generated column not recorded: %+v", col)
+	}
+	if !col.Generated.Stored {
+		t.Error("expected STORED, got VIRTUAL")
+	}
+	if !strings.Contains(col.Generated.Expr, "a") || !strings.Contains(col.Generated.Expr, "b") {
+		t.Errorf("Generated.Expr = %q", col.Generated.Expr)
+	}
+}
+
+// ----------------------------------------------------------------------
+// View real install.
+// ----------------------------------------------------------------------
+
+func TestLoader_ViewReal(t *testing.T) {
+	meta := &storepb.DatabaseSchemaMetadata{
+		Name: testDBName,
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "users",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "bigint unsigned", Nullable: false, Default: autoIncrementSentinel},
+							{Name: "name", Type: "varchar(255)", Nullable: true},
+						},
+						Indexes: []*storepb.IndexMetadata{
+							{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+						},
+					},
+				},
+				Views: []*storepb.ViewMetadata{
+					{
+						Name:       "v_users",
+						Definition: "SELECT id, name FROM users",
+					},
+				},
+			},
+		},
+	}
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	v := mustGetView(t, c, "v_users")
+	if !strings.Contains(strings.ToUpper(v.Definition), "SELECT") {
+		t.Errorf("view Definition not preserved: %q", v.Definition)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Pseudo fallbacks. We exercise them directly by calling the helpers because
+// the AST-direct real path is permissive enough that natural failures are
+// rare; going through the helper means we really test the Define* + ast
+// construction that the fallback relies on.
+// ----------------------------------------------------------------------
+
+func TestLoader_PseudoTable(t *testing.T) {
+	c := newLoaderTestCatalog(t)
+	// Minimal metadata — just column names.
+	tblMeta := &storepb.TableMetadata{
+		Name: "pt",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
+		},
+	}
+	if err := wtInstallPseudoTable(c, testDBName, tblMeta); err != nil {
+		t.Fatalf("wtInstallPseudoTable: %v", err)
+	}
+	tbl := mustGetTable(t, c, "pt")
+	if len(tbl.Columns) != 3 {
+		t.Fatalf("pseudo columns: got %d want 3", len(tbl.Columns))
+	}
+	for _, col := range tbl.Columns {
+		if !strings.EqualFold(col.DataType, "text") {
+			t.Errorf("pseudo column %q: DataType=%q, want text", col.Name, col.DataType)
+		}
+	}
+}
+
+func TestLoader_PseudoTable_EmptyColumns(t *testing.T) {
+	c := newLoaderTestCatalog(t)
+	if err := wtInstallPseudoTable(c, testDBName, &storepb.TableMetadata{Name: "empty"}); err != nil {
+		t.Fatalf("wtInstallPseudoTable(no columns): %v", err)
+	}
+	tbl := mustGetTable(t, c, "empty")
+	if len(tbl.Columns) != 1 {
+		t.Fatalf("placeholder columns: got %d want 1", len(tbl.Columns))
+	}
+	if tbl.Columns[0].Name != "__bb_placeholder" {
+		t.Errorf("placeholder column name: %q", tbl.Columns[0].Name)
+	}
+}
+
+func TestLoader_PseudoView(t *testing.T) {
+	c := newLoaderTestCatalog(t)
+	if err := wtInstallPseudoView(c, testDBName, &storepb.ViewMetadata{
+		Name: "pv",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "x"},
+			{Name: "y"},
+		},
+	}); err != nil {
+		t.Fatalf("wtInstallPseudoView: %v", err)
+	}
+	v := mustGetView(t, c, "pv")
+	if len(v.Columns) != 2 {
+		t.Fatalf("pseudo view columns: got %d want 2", len(v.Columns))
+	}
+}
+
+// ----------------------------------------------------------------------
+// Fallback chain — real install fails, pseudo kicks in.
+// Simulate by giving a column an unparseable type string.
+// ----------------------------------------------------------------------
+
+func TestLoader_RealFailsFallsBackToPseudo(t *testing.T) {
+	meta := schemaWithTables(&storepb.TableMetadata{
+		Name: "broken",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "good", Type: "int"},
+			// Type with unbalanced parens — wtParseTypeName returns an error
+			// for this, so wtBuildCreateTableStmt propagates and install_real
+			// fails, triggering pseudo install.
+			{Name: "bad", Type: "varchar((("},
+		},
+	})
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	tbl := mustGetTable(t, c, "broken")
+	if len(tbl.Columns) != 2 {
+		t.Fatalf("pseudo columns: got %d want 2", len(tbl.Columns))
+	}
+	// Pseudo collapses everything to TEXT.
+	for _, col := range tbl.Columns {
+		if !strings.EqualFold(col.DataType, "text") {
+			t.Errorf("pseudo fallback should collapse columns to TEXT; %q.DataType=%q", col.Name, col.DataType)
+		}
+	}
+}
+
+// ----------------------------------------------------------------------
+// Topological ordering — FK forward references work with FK checks off.
+// ----------------------------------------------------------------------
+
+func TestLoader_ForwardFKInstallsViaFKChecksOff(t *testing.T) {
+	// Child declared first in the metadata, referencing parent that appears
+	// after. Because the loader flips foreign_key_checks off during bulk
+	// install, this must succeed.
+	meta := schemaWithTables(
+		&storepb.TableMetadata{
+			Name: "child",
+			Columns: []*storepb.ColumnMetadata{
+				{Name: "id", Type: "bigint unsigned", Nullable: false, Default: autoIncrementSentinel},
+				{Name: "parent_id", Type: "bigint unsigned", Nullable: false},
+			},
+			Indexes: []*storepb.IndexMetadata{
+				{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+				{Name: "idx_pid", Type: "BTREE", Expressions: []string{"parent_id"}},
+			},
+			ForeignKeys: []*storepb.ForeignKeyMetadata{
+				{
+					Name:              "fk_fwd",
+					Columns:           []string{"parent_id"},
+					ReferencedTable:   "parent",
+					ReferencedColumns: []string{"id"},
+				},
+			},
+		},
+		&storepb.TableMetadata{
+			Name: "parent",
+			Columns: []*storepb.ColumnMetadata{
+				{Name: "id", Type: "bigint unsigned", Nullable: false, Default: autoIncrementSentinel},
+			},
+			Indexes: []*storepb.IndexMetadata{
+				{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+			},
+		},
+	)
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	// Both tables present, child's FK is recorded.
+	mustGetTable(t, c, "parent")
+	child := mustGetTable(t, c, "child")
+	var found bool
+	for _, con := range child.Constraints {
+		if con.Type == catalog.ConForeignKey && con.Name == "fk_fwd" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("fk_fwd not recorded on child; forward-FK install failed")
+	}
+}
+
+// schemaWithTables wraps tables into a DatabaseSchemaMetadata with the
+// expected single empty-named schema that MySQL uses.
+func schemaWithTables(tables ...*storepb.TableMetadata) *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: testDBName,
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name:   "",
+				Tables: tables,
+			},
+		},
+	}
+}

--- a/backend/plugin/schema/mysql/walk_through_loader_test.go
+++ b/backend/plugin/schema/mysql/walk_through_loader_test.go
@@ -63,6 +63,32 @@ func mustGetView(t *testing.T, c *catalog.Catalog, name string) *catalog.View {
 	return v
 }
 
+func mustGetTrigger(t *testing.T, c *catalog.Catalog, name string) *catalog.Trigger {
+	t.Helper()
+	db := c.GetDatabase(testDBName)
+	if db == nil {
+		t.Fatalf("database %q not in catalog", testDBName)
+	}
+	trg := db.Triggers[strings.ToLower(name)]
+	if trg == nil {
+		t.Fatalf("trigger %q not in catalog", name)
+	}
+	return trg
+}
+
+func mustGetEvent(t *testing.T, c *catalog.Catalog, name string) *catalog.Event {
+	t.Helper()
+	db := c.GetDatabase(testDBName)
+	if db == nil {
+		t.Fatalf("database %q not in catalog", testDBName)
+	}
+	ev := db.Events[strings.ToLower(name)]
+	if ev == nil {
+		t.Fatalf("event %q not in catalog", name)
+	}
+	return ev
+}
+
 // ----------------------------------------------------------------------
 // wtParseTypeName — covers a representative cross-section of MySQL types.
 // ----------------------------------------------------------------------
@@ -609,4 +635,334 @@ func schemaWithTables(tables ...*storepb.TableMetadata) *storepb.DatabaseSchemaM
 			},
 		},
 	}
+}
+
+// schemaWithEvents wraps events into a DatabaseSchemaMetadata.
+func schemaWithEvents(events ...*storepb.EventMetadata) *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: testDBName,
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "", Events: events},
+		},
+	}
+}
+
+// ----------------------------------------------------------------------
+// Trigger — happy paths.
+//
+// Examples match MySQL 8.0 documentation §25.3.1 (Trigger Syntax and
+// Examples). Each trigger is attached to a real table so the loader exercises
+// the actual kindWTTable → kindWTTrigger ordering.
+// ----------------------------------------------------------------------
+
+// accountTableForTriggers builds the `account` table used by the canonical
+// trigger examples in the MySQL docs.
+func accountTableForTriggers() *storepb.TableMetadata {
+	return &storepb.TableMetadata{
+		Name:   "account",
+		Engine: "InnoDB",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "acct_num", Type: "int", Nullable: true},
+			{Name: "amount", Type: "decimal(10,2)", Nullable: true},
+		},
+	}
+}
+
+func TestLoader_Trigger_SimpleSetSum(t *testing.T) {
+	// MySQL docs §25.3.1 Example 1:
+	//
+	//   CREATE TRIGGER ins_sum BEFORE INSERT ON account
+	//     FOR EACH ROW SET @sum = @sum + NEW.amount;
+	meta := schemaWithTables(withTriggers(accountTableForTriggers(), &storepb.TriggerMetadata{
+		Name:   "ins_sum",
+		Timing: "BEFORE",
+		Event:  "INSERT",
+		Body:   "SET @sum = @sum + NEW.amount",
+	}))
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	trg := mustGetTrigger(t, c, "ins_sum")
+	if !strings.EqualFold(trg.Timing, "BEFORE") {
+		t.Errorf("Timing=%q, want BEFORE", trg.Timing)
+	}
+	if !strings.EqualFold(trg.Event, "INSERT") {
+		t.Errorf("Event=%q, want INSERT", trg.Event)
+	}
+	if !strings.EqualFold(trg.Table, "account") {
+		t.Errorf("Table=%q, want account", trg.Table)
+	}
+	if !strings.Contains(trg.Body, "@sum") {
+		t.Errorf("Body lost raw text: %q", trg.Body)
+	}
+}
+
+func TestLoader_Trigger_BeginEndWithIfElse(t *testing.T) {
+	// MySQL docs §25.3.1 Example 2 (BEGIN … END with IF/ELSEIF/END IF):
+	//
+	//   CREATE TRIGGER upd_check BEFORE UPDATE ON account
+	//     FOR EACH ROW
+	//     BEGIN
+	//       IF NEW.amount < 0 THEN
+	//         SET NEW.amount = 0;
+	//       ELSEIF NEW.amount > 100 THEN
+	//         SET NEW.amount = 100;
+	//       END IF;
+	//     END;
+	body := `BEGIN
+        IF NEW.amount < 0 THEN
+            SET NEW.amount = 0;
+        ELSEIF NEW.amount > 100 THEN
+            SET NEW.amount = 100;
+        END IF;
+    END`
+	meta := schemaWithTables(withTriggers(accountTableForTriggers(), &storepb.TriggerMetadata{
+		Name:   "upd_check",
+		Timing: "BEFORE",
+		Event:  "UPDATE",
+		Body:   body,
+	}))
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	trg := mustGetTrigger(t, c, "upd_check")
+	if !strings.Contains(strings.ToUpper(trg.Body), "IF NEW.AMOUNT") {
+		t.Errorf("Body lost IF/THEN content: %q", trg.Body)
+	}
+}
+
+func TestLoader_Trigger_AfterUpdateWithSignal(t *testing.T) {
+	// MySQL docs §15.6.7.1 (SIGNAL inside a trigger):
+	//
+	//   CREATE TRIGGER validate_amount AFTER UPDATE ON account
+	//     FOR EACH ROW
+	//     BEGIN
+	//       IF NEW.amount < 0 THEN
+	//         SIGNAL SQLSTATE '45000'
+	//           SET MESSAGE_TEXT = 'Negative amount not allowed';
+	//       END IF;
+	//     END;
+	body := `BEGIN
+        IF NEW.amount < 0 THEN
+            SIGNAL SQLSTATE '45000'
+                SET MESSAGE_TEXT = 'Negative amount not allowed';
+        END IF;
+    END`
+	meta := schemaWithTables(withTriggers(accountTableForTriggers(), &storepb.TriggerMetadata{
+		Name:   "validate_amount",
+		Timing: "AFTER",
+		Event:  "UPDATE",
+		Body:   body,
+	}))
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	trg := mustGetTrigger(t, c, "validate_amount")
+	if !strings.EqualFold(trg.Timing, "AFTER") {
+		t.Errorf("Timing=%q", trg.Timing)
+	}
+	if !strings.Contains(strings.ToUpper(trg.Body), "SIGNAL") {
+		t.Errorf("Body lost SIGNAL: %q", trg.Body)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Trigger — pseudo fallback.
+// ----------------------------------------------------------------------
+
+func TestLoader_Trigger_PseudoOnMissingFields(t *testing.T) {
+	// metadata has only Name (+ Body) — Timing and Event empty. Real install
+	// should fail (DefineTrigger rejects empty Timing/Event / empty Body
+	// couldn't parse). Pseudo fills defaults.
+	meta := schemaWithTables(withTriggers(accountTableForTriggers(), &storepb.TriggerMetadata{
+		Name: "trg_needs_defaults",
+		// Timing / Event / Body intentionally empty.
+	}))
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	trg := mustGetTrigger(t, c, "trg_needs_defaults")
+	if trg.Timing == "" {
+		t.Error("pseudo trigger Timing should be filled")
+	}
+	if trg.Event == "" {
+		t.Error("pseudo trigger Event should be filled")
+	}
+	if !strings.EqualFold(trg.Table, "account") {
+		t.Errorf("pseudo trigger Table=%q, want account", trg.Table)
+	}
+}
+
+func TestLoader_Trigger_PseudoOnUnparseableBody(t *testing.T) {
+	// A body the parser can't chew up — real install still succeeds with
+	// Body=nil + BodyText populated (DefineTrigger tolerates nil Body), or
+	// falls back to pseudo with body "BEGIN END". Either way the trigger
+	// must exist in the catalog.
+	meta := schemaWithTables(withTriggers(accountTableForTriggers(), &storepb.TriggerMetadata{
+		Name:   "trg_bad_body",
+		Timing: "BEFORE",
+		Event:  "INSERT",
+		Body:   "this is not sql $$$",
+	}))
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	trg := mustGetTrigger(t, c, "trg_bad_body")
+	if !strings.EqualFold(trg.Timing, "BEFORE") {
+		t.Errorf("Timing=%q", trg.Timing)
+	}
+}
+
+func TestLoader_Trigger_OnPseudoParentTable(t *testing.T) {
+	// Parent table has a bad column type → real install fails, pseudo
+	// installs TEXT-column table. The trigger must still attach.
+	parent := &storepb.TableMetadata{
+		Name: "account",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "id", Type: "int"},
+			{Name: "bad", Type: "varchar((("}, // forces real install to fail
+		},
+	}
+	meta := schemaWithTables(withTriggers(parent, &storepb.TriggerMetadata{
+		Name:   "ins_stub",
+		Timing: "BEFORE",
+		Event:  "INSERT",
+		Body:   "SET @x = NEW.id",
+	}))
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	// Parent was pseudo-installed.
+	tbl := mustGetTable(t, c, "account")
+	if !strings.EqualFold(tbl.Columns[0].DataType, "text") {
+		t.Fatalf("expected pseudo parent table; columns=%+v", tbl.Columns)
+	}
+	// Trigger attached anyway.
+	mustGetTrigger(t, c, "ins_stub")
+}
+
+// ----------------------------------------------------------------------
+// Event — happy paths.
+//
+// Examples match MySQL 8.0 documentation §15.1.12 (CREATE EVENT). The
+// Definition string is exactly what SHOW CREATE EVENT would produce — our
+// loader parses it to AST via wtParseCreateEventStmt.
+// ----------------------------------------------------------------------
+
+func TestLoader_Event_OneShotAT(t *testing.T) {
+	// MySQL docs §15.1.12 Example 1 (one-shot):
+	//
+	//   CREATE EVENT myevent
+	//     ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 HOUR
+	//     DO UPDATE mytable SET mycol = mycol + 1;
+	def := "CREATE EVENT `myevent` " +
+		"ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 HOUR " +
+		"DO UPDATE mytable SET mycol = mycol + 1"
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, schemaWithEvents(&storepb.EventMetadata{
+		Name:       "myevent",
+		Definition: def,
+	}))
+
+	ev := mustGetEvent(t, c, "myevent")
+	if !strings.Contains(strings.ToUpper(ev.Schedule), "CURRENT_TIMESTAMP") &&
+		!strings.Contains(strings.ToUpper(ev.Schedule), "INTERVAL") {
+		t.Errorf("schedule lost: %q", ev.Schedule)
+	}
+}
+
+func TestLoader_Event_RecurringEveryWithComment(t *testing.T) {
+	// MySQL docs §15.1.12 Example 2 (recurring + comment):
+	//
+	//   CREATE EVENT e_hourly
+	//     ON SCHEDULE EVERY 1 HOUR
+	//     COMMENT 'Clears out sessions table each hour.'
+	//     DO DELETE FROM site_activity.sessions;
+	def := "CREATE EVENT `e_hourly` " +
+		"ON SCHEDULE EVERY 1 HOUR " +
+		"COMMENT 'Clears out sessions table each hour.' " +
+		"DO DELETE FROM site_activity.sessions"
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, schemaWithEvents(&storepb.EventMetadata{
+		Name:       "e_hourly",
+		Definition: def,
+	}))
+
+	ev := mustGetEvent(t, c, "e_hourly")
+	if !strings.Contains(strings.ToUpper(ev.Schedule), "EVERY") ||
+		!strings.Contains(strings.ToUpper(ev.Schedule), "HOUR") {
+		t.Errorf("schedule lost: %q", ev.Schedule)
+	}
+	if !strings.Contains(ev.Comment, "sessions") {
+		t.Errorf("comment lost: %q", ev.Comment)
+	}
+}
+
+func TestLoader_Event_DailyBeginEndBody(t *testing.T) {
+	// MySQL docs §15.1.12 Example 3 (EVERY + STARTS + compound body):
+	//
+	//   CREATE EVENT e_daily
+	//     ON SCHEDULE
+	//       EVERY 1 DAY
+	//       STARTS CURRENT_TIMESTAMP + INTERVAL 5 HOUR
+	//     COMMENT '...'
+	//     DO
+	//     BEGIN
+	//       INSERT INTO totals (time, total) SELECT NOW(), COUNT(*) FROM sessions;
+	//       DELETE FROM sessions;
+	//     END;
+	def := "CREATE EVENT `e_daily` " +
+		"ON SCHEDULE EVERY 1 DAY STARTS CURRENT_TIMESTAMP + INTERVAL 5 HOUR " +
+		"COMMENT 'Saves total then clears each day' " +
+		"DO BEGIN " +
+		"  INSERT INTO totals (time, total) SELECT NOW(), COUNT(*) FROM sessions; " +
+		"  DELETE FROM sessions; " +
+		"END"
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, schemaWithEvents(&storepb.EventMetadata{
+		Name:       "e_daily",
+		Definition: def,
+	}))
+
+	ev := mustGetEvent(t, c, "e_daily")
+	if !strings.Contains(strings.ToUpper(ev.Schedule), "STARTS") {
+		t.Errorf("schedule lost STARTS: %q", ev.Schedule)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Event — pseudo fallback.
+// ----------------------------------------------------------------------
+
+func TestLoader_Event_PseudoOnEmptyDefinition(t *testing.T) {
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, schemaWithEvents(&storepb.EventMetadata{
+		Name: "e_empty",
+		// Definition intentionally empty — real install fails, pseudo kicks in.
+	}))
+	mustGetEvent(t, c, "e_empty")
+}
+
+func TestLoader_Event_PseudoOnGarbageDefinition(t *testing.T) {
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, schemaWithEvents(&storepb.EventMetadata{
+		Name:       "e_broken",
+		Definition: "this is definitely not a CREATE EVENT statement $$",
+	}))
+	mustGetEvent(t, c, "e_broken")
+}
+
+// withTriggers is a tiny builder that attaches triggers to a given table.
+func withTriggers(tbl *storepb.TableMetadata, triggers ...*storepb.TriggerMetadata) *storepb.TableMetadata {
+	tbl.Triggers = append(tbl.Triggers, triggers...)
+	return tbl
 }

--- a/backend/plugin/schema/mysql/walk_through_loader_test.go
+++ b/backend/plugin/schema/mysql/walk_through_loader_test.go
@@ -966,3 +966,174 @@ func withTriggers(tbl *storepb.TableMetadata, triggers ...*storepb.TriggerMetada
 	tbl.Triggers = append(tbl.Triggers, triggers...)
 	return tbl
 }
+
+// ----------------------------------------------------------------------
+// Regression: MySQL sync populates `Default="NULL"` for every nullable
+// column — including BLOB / JSON / GEOMETRY types whose grammar rejects a
+// DEFAULT clause. The loader must skip DefaultValue for those types so
+// DefineTable doesn't reject the whole table and force pseudo fallback.
+// ----------------------------------------------------------------------
+
+func TestLoader_DefaultNull_OnBlobJsonGeometry_StaysReal(t *testing.T) {
+	meta := schemaWithTables(&storepb.TableMetadata{
+		Name: "t",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "id", Type: "int", Nullable: false, Default: autoIncrementSentinel},
+			// All three of these are nullable — sync fills Default="NULL"
+			// for them. MySQL grammar does NOT accept DEFAULT on these
+			// types, so the loader must drop the default silently.
+			{Name: "payload_json", Type: "json", Nullable: true, Default: "NULL"},
+			{Name: "blob_body", Type: "blob", Nullable: true, Default: "NULL"},
+			{Name: "location", Type: "geometry", Nullable: true, Default: "NULL"},
+			// For a type that DOES support DEFAULT, Default="NULL" should
+			// still be applied.
+			{Name: "name", Type: "varchar(255)", Nullable: true, Default: "NULL"},
+		},
+	})
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	tbl := mustGetTable(t, c, "t")
+	// Real install path keeps real column types — verify by checking a
+	// non-TEXT DataType on the JSON / BLOB / GEOMETRY columns.
+	for _, want := range []struct{ name, dt string }{
+		{"payload_json", "json"},
+		{"blob_body", "blob"},
+		{"location", "geometry"},
+	} {
+		got := tbl.GetColumn(want.name)
+		if got == nil {
+			t.Errorf("column %q missing", want.name)
+			continue
+		}
+		if !strings.EqualFold(got.DataType, want.dt) {
+			t.Errorf("column %q: DataType=%q, want %q (pseudo fallback leaked?)", want.name, got.DataType, want.dt)
+		}
+		// The DEFAULT must have been suppressed — BLOB/JSON/GEOMETRY must
+		// NOT carry a stored default.
+		if got.Default != nil {
+			t.Errorf("column %q: Default=%v, want nil for unsupported-default type", want.name, *got.Default)
+		}
+	}
+	// Regular varchar still carries DEFAULT NULL.
+	if name := tbl.GetColumn("name"); name == nil || name.Default == nil {
+		t.Error("varchar column lost its DEFAULT NULL")
+	}
+}
+
+// ----------------------------------------------------------------------
+// Regression: MySQL 8.0 functional indexes store key parts as expressions
+// like `(lower(name))` or `lower(name)`. Dumping them into Constraint.Columns
+// (bare identifier slice) makes DefineTable reject the table. Expression
+// keys must land in IndexColumns[*].Expr instead.
+// ----------------------------------------------------------------------
+
+func TestLoader_FunctionalIndex_ParenthesizedExpression(t *testing.T) {
+	// MySQL docs §10.3.10 Functional Key Parts:
+	//
+	//   CREATE TABLE t1 (
+	//     col1 INT, col2 INT,
+	//     INDEX func_index ((ABS(col1)))
+	//   );
+	meta := schemaWithTables(&storepb.TableMetadata{
+		Name: "t1",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "col1", Type: "int", Nullable: true},
+			{Name: "col2", Type: "int", Nullable: true},
+		},
+		Indexes: []*storepb.IndexMetadata{
+			{
+				Name:        "func_index",
+				Type:        "BTREE",
+				Expressions: []string{"(abs(col1))"},
+			},
+		},
+	})
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	tbl := mustGetTable(t, c, "t1")
+	if strings.EqualFold(tbl.Columns[0].DataType, "text") {
+		t.Fatal("table degraded to pseudo (all columns TEXT) — functional index broke real install")
+	}
+	// Index must exist.
+	var found bool
+	for _, idx := range tbl.Indexes {
+		if idx.Name == "func_index" {
+			found = true
+			// Catalog stores the key-part expression in IndexColumn.Expr.
+			if len(idx.Columns) != 1 {
+				t.Fatalf("func_index: expected 1 key part, got %d", len(idx.Columns))
+			}
+		}
+	}
+	if !found {
+		t.Error("func_index not installed on table")
+	}
+}
+
+func TestLoader_FunctionalIndex_FunctionCallForm(t *testing.T) {
+	// Same thing but key part is stored as bare function-call text
+	// (lower(name) without outer parens) — another shape the proto comment
+	// explicitly calls out.
+	meta := schemaWithTables(&storepb.TableMetadata{
+		Name: "t",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "id", Type: "int", Nullable: false, Default: autoIncrementSentinel},
+			{Name: "name", Type: "varchar(255)", Nullable: true},
+		},
+		Indexes: []*storepb.IndexMetadata{
+			{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+			{Name: "idx_lower_name", Type: "BTREE", Expressions: []string{"lower(`name`)"}},
+		},
+	})
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	tbl := mustGetTable(t, c, "t")
+	if strings.EqualFold(tbl.Columns[0].DataType, "text") {
+		t.Fatal("table degraded to pseudo — function-call index broke real install")
+	}
+	var found bool
+	for _, idx := range tbl.Indexes {
+		if idx.Name == "idx_lower_name" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("idx_lower_name not installed")
+	}
+}
+
+// TestLoader_FunctionalIndex_MixedWithBareColumns is a negative-regression
+// test: when one key part is an expression and another is a bare column, the
+// whole index must still install — all parts route through IndexColumns.
+func TestLoader_FunctionalIndex_MixedWithBareColumns(t *testing.T) {
+	meta := schemaWithTables(&storepb.TableMetadata{
+		Name: "t",
+		Columns: []*storepb.ColumnMetadata{
+			{Name: "id", Type: "int", Nullable: false, Default: autoIncrementSentinel},
+			{Name: "tag", Type: "varchar(64)", Nullable: true},
+			{Name: "name", Type: "varchar(255)", Nullable: true},
+		},
+		Indexes: []*storepb.IndexMetadata{
+			{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},
+			{
+				Name:        "idx_mixed",
+				Type:        "BTREE",
+				Expressions: []string{"tag", "(lower(`name`))"},
+			},
+		},
+	})
+
+	c := newLoaderTestCatalog(t)
+	runLoader(t, c, meta)
+
+	tbl := mustGetTable(t, c, "t")
+	if strings.EqualFold(tbl.Columns[0].DataType, "text") {
+		t.Fatal("table degraded to pseudo — mixed index broke real install")
+	}
+}

--- a/backend/plugin/schema/mysql/walk_through_omni.go
+++ b/backend/plugin/schema/mysql/walk_through_omni.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -20,10 +21,12 @@ func init() {
 	schema.RegisterWalkThroughWithContext(storepb.Engine_OCEANBASE, WalkThroughOmni)
 }
 
-// WalkThroughOmni performs DDL simulation using omni catalog.Exec().
+// WalkThroughOmni performs DDL simulation using the omni MySQL catalog.
 // Flow:
-//  1. GetDatabaseDefinition(metadata) → schemaDDL
-//  2. catalog.Exec(schemaDDL) → load existing schema state
+//  1. Create the catalog and select the target database.
+//  2. loadWalkThroughCatalog: install each object individually with per-object
+//     pseudo fallback, so one broken CREATE TABLE can't disable the whole
+//     simulation.
 //  3. catalog.Exec(userSQL) → execute user DDL
 //  4. Map errors → *storepb.Advice
 //  5. Convert updated catalog → DatabaseMetadata (for downstream rules)
@@ -34,35 +37,27 @@ func WalkThroughOmni(ctx schema.WalkThroughContext, d *model.DatabaseMetadata, _
 
 	dbName := d.GetProto().GetName()
 
-	// Step 1: Generate DDL from current schema state.
-	schemaDDL, err := schema.GetDatabaseDefinition(
-		storepb.Engine_MYSQL,
-		schema.GetDefinitionContext{},
-		d.GetProto(),
-	)
-	if err != nil {
+	// Step 1: Create the catalog and the target database.
+	c := catalog.New()
+	initSQL := fmt.Sprintf("SET foreign_key_checks = 0;\nCREATE DATABASE IF NOT EXISTS `%s`;\nUSE `%s`;", dbName, dbName)
+	if _, err := c.Exec(initSQL, &catalog.ExecOptions{ContinueOnError: true}); err != nil {
 		return &storepb.Advice{
 			Status:        storepb.Advice_ERROR,
 			Code:          code.DDLSimulationFailed.Int32(),
-			Title:         "Failed to generate schema DDL",
+			Title:         "Failed to initialize catalog",
 			Content:       err.Error(),
 			StartPosition: &storepb.Position{Line: 0},
 		}
 	}
 
-	// Step 2: Create catalog, create database, and load existing schema.
-	c := catalog.New()
-	// Disable FK checks so that tables can reference not-yet-loaded tables,
-	// matching standard MySQL behavior for schema loading.
-	initSQL := fmt.Sprintf("SET foreign_key_checks = 0;\nCREATE DATABASE IF NOT EXISTS `%s`;\nUSE `%s`;", dbName, dbName)
-	if schemaDDL != "" {
-		initSQL += "\n" + schemaDDL
-	}
-	if _, err := c.Exec(initSQL, &catalog.ExecOptions{ContinueOnError: true}); err != nil {
+	// Step 2: Install every schema object individually with pseudo fallback.
+	// TODO: thread a real context.Context through WalkThroughContext; for now the
+	// loader only uses it for early cancellation during catalog bulk-load.
+	if err := loadWalkThroughCatalog(context.Background(), c, dbName, d.GetProto()); err != nil {
 		return &storepb.Advice{
 			Status:        storepb.Advice_ERROR,
 			Code:          code.DDLSimulationFailed.Int32(),
-			Title:         "Failed to load schema DDL",
+			Title:         "Failed to load schema",
 			Content:       err.Error(),
 			StartPosition: &storepb.Position{Line: 0},
 		}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260420093538-51d40fb25301
+	github.com/bytebase/omni v0.0.0-20260421084205-9688c5c4c22e
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888 h1:E8tz8maxpih/vt
 github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888/go.mod h1:IgLUOjyiHehdE0G3C92IjGYu9lJQgkPwf2mdNSvPWq8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260420093538-51d40fb25301 h1:uEoT91OLtXfTdTV2B/iGfr4cDGDRpoAk7eIXl4HhWZk=
-github.com/bytebase/omni v0.0.0-20260420093538-51d40fb25301/go.mod h1:AT+iLKCu7NyxTaYaOLzETRFBVurjRaqUU3YmFron9pw=
+github.com/bytebase/omni v0.0.0-20260421084205-9688c5c4c22e h1:uP7i1fob0XGJEddN/Ota9oA+gGiuTY7Bti77YckoFwQ=
+github.com/bytebase/omni v0.0.0-20260421084205-9688c5c4c22e/go.mod h1:AT+iLKCu7NyxTaYaOLzETRFBVurjRaqUU3YmFron9pw=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary

- Replace the one-shot `GetDatabaseDefinition` + `catalog.Exec` pre-load in `WalkThroughOmni` with a per-object loader (`loadWalkThroughCatalog`) that builds `Define*` ASTs directly from `storepb.*Metadata` — a bad table/view degrades to a TEXT-column pseudo instead of crashing the entire simulation.
- Parser use is limited to parsing MySQL's own output (`COLUMN_TYPE`, `VIEW_DEFINITION`, `SHOW CREATE`), never our own deparse. This eliminates the whole class of "our emitter produces DDL that omni can't parse back" failures.
- Fix `FULLTEXT` / `SPATIAL` index mapping: previously stuffed into `IndexType` (which expects `BTREE`/`HASH`), now routed to `ConstrFulltextIndex` / `ConstrSpatialIndex`.
- Bump omni to `9688c5c` for the new `catalog.Define*` APIs plus routine-body fixes (`END IF`, `IF(cond) THEN`, single-quoted alias, `SET` bare sysvar). Update `test_completion.yaml` now that the quoted-alias forms parse cleanly.

## How it works

| Path | Before | After |
|---|---|---|
| Schema load | `catalog.Exec(GetDatabaseDefinition(meta))` — all-or-nothing | `loadWalkThroughCatalog`: for each object build AST from metadata → `cat.DefineTable/View/Function/Procedure`; on failure install a pseudo placeholder |
| Parser coupling | bytebase deparse → omni parse → catalog (two potential bug sources) | metadata → AST → catalog (parser only on MySQL-sourced strings) |
| Fulltext/Spatial | silently downgraded to plain index | installed with correct constraint kind |

## Test plan

- [x] `go test ./backend/plugin/schema/mysql/...` — 13 new self-contained unit tests in `walk_through_loader_test.go` cover: `wtParseTypeName` across 16 MySQL types, `wtParseExpr`, real table install (columns / PK / unique / FK / fulltext / spatial / generated), view real install, pseudo table & pseudo view, real-fails→pseudo fallback, forward-FK with FK checks off.
- [x] `go test ./backend/plugin/parser/mysql/...` — updated `test_completion.yaml` for two stale-expectation cases (quoted aliases now parse).
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/schema/mysql/... ./backend/plugin/parser/mysql/...` → 0 issues.
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go` → OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)