### PR TITLE
chore: align Go precheck version

### DIFF
--- a/scripts/build_init.sh
+++ b/scripts/build_init.sh
@@ -30,7 +30,7 @@ mkdir_output() {
 }
 
 # Go and node version checks.
-TARGET_GO_VERSION="1.24.4"
+TARGET_GO_VERSION="1.26.0"
 GO_VERSION=`go version | { read _ _ v _; echo ${v#go}; }`
 if [ "$(version ${GO_VERSION})" -lt "$(version $TARGET_GO_VERSION)" ];
 then


### PR DESCRIPTION
## Summary
- Align `scripts/build_init.sh` Go precheck with the repo's Go 1.26.0 target.
- Keep the existing Node precheck unchanged.

## Testing
- `sh -n scripts/build_init.sh`
- `sh scripts/build_init.sh`
- `git diff --check`

## Pre-PR checklist
- Breaking change check: no breaking changes; this only tightens a local build precheck to match existing repo toolchain pins.
- Composite-PK query safety: skipped; no backend store or migrator changes.
- SonarCloud properties: skipped; no new files or directories.
