### PR TITLE
fix: harden instance TLS path validation

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -252,6 +252,12 @@ func (s *InstanceService) CreateInstance(ctx context.Context, req *connect.Reque
 	return connect.NewResponse(result), nil
 }
 
+func instanceWithMetadata(instance *store.InstanceMessage, metadata *storepb.Instance) *store.InstanceMessage {
+	candidate := *instance
+	candidate.Metadata = metadata
+	return &candidate
+}
+
 func (s *InstanceService) checkInstanceDataSources(ctx context.Context, instance *store.InstanceMessage, dataSources []*storepb.DataSource) error {
 	for _, ds := range dataSources {
 		if err := s.checkDataSource(ctx, instance, ds); err != nil {
@@ -786,6 +792,10 @@ func (s *InstanceService) AddDataSource(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 
+	if err := s.licenseService.IsFeatureEnabledForInstance(ctx, common.GetWorkspaceIDFromContext(ctx), v1pb.PlanFeature_FEATURE_INSTANCE_READ_ONLY_CONNECTION, instance); err != nil {
+		return nil, connect.NewError(connect.CodePermissionDenied, err)
+	}
+
 	// Test connection.
 	if req.Msg.ValidateOnly {
 		err := func() error {
@@ -807,15 +817,12 @@ func (s *InstanceService) AddDataSource(ctx context.Context, req *connect.Reques
 		if err != nil {
 			return nil, err
 		}
-		result := convertToV1Instance(instance)
+		result := convertToV1Instance(instanceWithMetadata(instance, metadata))
 		return connect.NewResponse(result), nil
 	}
 
 	if dataSource.GetType() != storepb.DataSourceType_READ_ONLY {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("only read-only data source can be added"))
-	}
-	if err := s.licenseService.IsFeatureEnabledForInstance(ctx, common.GetWorkspaceIDFromContext(ctx), v1pb.PlanFeature_FEATURE_INSTANCE_READ_ONLY_CONNECTION, instance); err != nil {
-		return nil, connect.NewError(connect.CodePermissionDenied, err)
 	}
 
 	instance, err = s.store.UpdateInstance(ctx, &store.UpdateInstanceMessage{
@@ -858,8 +865,9 @@ func (s *InstanceService) UpdateDataSource(ctx context.Context, req *connect.Req
 	if dataSource == nil {
 		if req.Msg.AllowMissing {
 			return s.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
-				Name:       req.Msg.Name,
-				DataSource: req.Msg.DataSource,
+				Name:         req.Msg.Name,
+				DataSource:   req.Msg.DataSource,
+				ValidateOnly: req.Msg.ValidateOnly,
 			}))
 		}
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf(`cannot found data source "%s"`, req.Msg.DataSource.Id))
@@ -1027,7 +1035,7 @@ func (s *InstanceService) UpdateDataSource(ctx context.Context, req *connect.Req
 		if err != nil {
 			return nil, err
 		}
-		result := convertToV1Instance(instance)
+		result := convertToV1Instance(instanceWithMetadata(instance, metadata))
 		return connect.NewResponse(result), nil
 	}
 

--- a/backend/plugin/db/util/ssl.go
+++ b/backend/plugin/db/util/ssl.go
@@ -4,6 +4,7 @@ package util
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -12,6 +13,8 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
+
+const maxTLSMaterialFileSize int64 = 10 << 20
 
 func HasTLSPath(ds *storepb.DataSource) bool {
 	if ds == nil {
@@ -61,12 +64,35 @@ func readTLSPathFile(label, path string) (string, error) {
 	if !filepath.IsAbs(path) {
 		return "", errors.Errorf("%s path must be absolute", label)
 	}
-	content, err := os.ReadFile(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", errors.Errorf("failed to read %s file", label)
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.Errorf("%s path must point to a regular file", label)
+	}
+	if info.Size() == 0 {
+		return "", errors.Errorf("%s file is empty", label)
+	}
+	if info.Size() > maxTLSMaterialFileSize {
+		return "", errors.Errorf("%s file is too large", label)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", errors.Errorf("failed to read %s file", label)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxTLSMaterialFileSize+1))
 	if err != nil {
 		return "", errors.Errorf("failed to read %s file", label)
 	}
 	if len(content) == 0 {
 		return "", errors.Errorf("%s file is empty", label)
+	}
+	if int64(len(content)) > maxTLSMaterialFileSize {
+		return "", errors.Errorf("%s file is too large", label)
 	}
 	return string(content), nil
 }

--- a/backend/plugin/db/util/ssl_test.go
+++ b/backend/plugin/db/util/ssl_test.go
@@ -92,6 +92,31 @@ func TestResolveTLSMaterialRedactsReadErrors(t *testing.T) {
 	require.NotContains(t, err.Error(), "no such file")
 }
 
+func TestResolveTLSMaterialRejectsNonRegularPath(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := ResolveTLSMaterial(&storepb.DataSource{
+		UseSsl:    true,
+		SslCaPath: dir,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CA certificate path must point to a regular file")
+	require.NotContains(t, err.Error(), dir)
+}
+
+func TestResolveTLSMaterialRejectsOversizedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(path, make([]byte, maxTLSMaterialFileSize+1), 0o600))
+
+	_, err := ResolveTLSMaterial(&storepb.DataSource{
+		UseSsl:    true,
+		SslCaPath: path,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CA certificate file is too large")
+	require.NotContains(t, err.Error(), path)
+}
+
 func TestGetTLSConfigRequiresResolvedTLSMaterial(t *testing.T) {
 	_, err := GetTLSConfig(&storepb.DataSource{
 		UseSsl:    true,

--- a/backend/tests/data_source_test.go
+++ b/backend/tests/data_source_test.go
@@ -42,6 +42,17 @@ func TestDataSource(t *testing.T) {
 	_, err = ctl.instanceServiceClient.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
 		Name: instance.Name,
 		DataSource: &v1pb.DataSource{
+			Id:   "readonly-validate-only",
+			Type: v1pb.DataSourceType_READ_ONLY,
+			Host: instanceDir,
+		},
+		ValidateOnly: true,
+	}))
+	a.ErrorContains(err, "TEAM feature, please upgrade to access it")
+
+	_, err = ctl.instanceServiceClient.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
 			Id:       "readonly",
 			Type:     v1pb.DataSourceType_READ_ONLY,
 			Username: "ro_ds",
@@ -152,4 +163,111 @@ func TestDataSource(t *testing.T) {
 		DataSource: &v1pb.DataSource{Id: "readonly"},
 	}))
 	a.NoError(err)
+}
+
+func TestDataSourceValidateOnly(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	instanceRootDir := t.TempDir()
+	instanceName := "testInstanceValidateOnly"
+	instanceDir, err := ctl.provisionSQLiteInstance(instanceRootDir, instanceName)
+	a.NoError(err)
+
+	instanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       "test",
+			Engine:      v1pb.Engine_SQLITE,
+			Environment: new("environments/prod"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{Type: v1pb.DataSourceType_ADMIN, Id: "admin-ds", Host: instanceDir}},
+		},
+	}))
+	a.NoError(err)
+	instance := instanceResp.Msg
+
+	err = ctl.setLicense(ctx)
+	a.NoError(err)
+
+	addResp, err := ctl.instanceServiceClient.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
+			Id:   "readonly-validate-only",
+			Type: v1pb.DataSourceType_READ_ONLY,
+			Host: instanceDir,
+		},
+		ValidateOnly: true,
+	}))
+	a.NoError(err)
+	a.Len(addResp.Msg.DataSources, 2)
+	a.NotNil(findDataSource(addResp.Msg.DataSources, "readonly-validate-only"))
+
+	instanceResp, err = ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	a.Len(instanceResp.Msg.DataSources, 1)
+	a.Nil(findDataSource(instanceResp.Msg.DataSources, "readonly-validate-only"))
+
+	updateResp, err := ctl.instanceServiceClient.UpdateDataSource(ctx, connect.NewRequest(&v1pb.UpdateDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
+			Id:   "readonly-allow-missing",
+			Type: v1pb.DataSourceType_READ_ONLY,
+			Host: instanceDir,
+		},
+		UpdateMask:   &fieldmaskpb.FieldMask{Paths: []string{"host"}},
+		ValidateOnly: true,
+		AllowMissing: true,
+	}))
+	a.NoError(err)
+	a.Len(updateResp.Msg.DataSources, 2)
+	a.NotNil(findDataSource(updateResp.Msg.DataSources, "readonly-allow-missing"))
+
+	instanceResp, err = ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	a.Len(instanceResp.Msg.DataSources, 1)
+	a.Nil(findDataSource(instanceResp.Msg.DataSources, "readonly-allow-missing"))
+
+	_, err = ctl.instanceServiceClient.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
+			Id:   "readonly",
+			Type: v1pb.DataSourceType_READ_ONLY,
+			Host: instanceDir,
+		},
+	}))
+	a.NoError(err)
+
+	updateResp, err = ctl.instanceServiceClient.UpdateDataSource(ctx, connect.NewRequest(&v1pb.UpdateDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
+			Id:       "readonly",
+			Username: "updated-user",
+		},
+		UpdateMask:   &fieldmaskpb.FieldMask{Paths: []string{"username"}},
+		ValidateOnly: true,
+	}))
+	a.NoError(err)
+	updated := findDataSource(updateResp.Msg.DataSources, "readonly")
+	a.NotNil(updated)
+	a.Equal("updated-user", updated.Username)
+
+	instanceResp, err = ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	persisted := findDataSource(instanceResp.Msg.DataSources, "readonly")
+	a.NotNil(persisted)
+	a.Equal("", persisted.Username)
+}
+
+func findDataSource(dataSources []*v1pb.DataSource, id string) *v1pb.DataSource {
+	for _, dataSource := range dataSources {
+		if dataSource.Id == id {
+			return dataSource
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- Harden instance TLS path-backed material loading so configured paths must point to regular files and TLS material reads are capped at 10 MiB with a bounded reader.
- Fix datasource `validate_only` semantics so `UpdateDataSource` with `allow_missing` no longer persists data, and validate-only responses return the candidate datasource state without mutating cached instances.
- Move read-only datasource license gating before validate-only connection tests so unlicensed callers cannot exercise that connection path.

## Problems
- TLS path settings only required absolute paths before runtime resolution. A user with instance update permission could point `ssl_*_path` at a directory, device, FIFO, or very large file, and `os.ReadFile` would attempt to read it during driver creation.
- `UpdateDataSource(allow_missing=true, validate_only=true)` delegated to `AddDataSource` without forwarding `validate_only`, so a dry-run request could persist a new datasource.
- `AddDataSource(validate_only=true)` tested the connection before checking the read-only datasource feature gate.
- Datasource validate-only responses were converted from the original instance, so clients could not inspect the candidate datasource state that was validated.

## Solution
- Add `os.Stat` checks in TLS path resolution, reject non-regular files, reject empty and oversized files, and read through `io.LimitReader`.
- Forward `ValidateOnly` in the `allow_missing` delegation path.
- Check the read-only datasource feature gate before validate-only connection testing.
- Return candidate instances for datasource validate-only responses using a shallow instance copy, avoiding mutation of cached `InstanceMessage` objects.

## Test Plan
- [x] `go test -v -count=1 ./backend/plugin/db/util`
- [x] `go test -v -count=1 ./backend/api/v1 -run '^TestValidateAndSanitizeDataSourceTLS' -timeout 5m`
- [x] `go test -v -count=1 ./backend/tests -run '^(TestDataSource|TestDataSourceValidateOnly)$' -timeout 5m`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
