### PR TITLE
fix: instrument backup schema sync logs

### DIFF
--- a/backend/api/v1/rollout_service_converter.go
+++ b/backend/api/v1/rollout_service_converter.go
@@ -475,16 +475,16 @@ func convertToTaskRunLogEntries(logs []*store.TaskRunLog) []*v1pb.TaskRunLogEntr
 			})
 
 		case storepb.TaskRunLog_PRIOR_BACKUP_END:
-			if len(entries) == 0 {
-				continue
+			for i := len(entries) - 1; i >= 0; i-- {
+				prev := entries[i]
+				if prev == nil || prev.Type != v1pb.TaskRunLogEntry_PRIOR_BACKUP || prev.PriorBackup.GetEndTime() != nil {
+					continue
+				}
+				prev.PriorBackup.EndTime = timestamppb.New(l.T)
+				prev.PriorBackup.Error = l.Payload.PriorBackupEnd.Error
+				prev.PriorBackup.PriorBackupDetail = convertToTaskRunLogPriorBackupDetail(l.Payload.PriorBackupEnd.PriorBackupDetail)
+				break
 			}
-			prev := entries[len(entries)-1]
-			if prev == nil || prev.Type != v1pb.TaskRunLogEntry_PRIOR_BACKUP {
-				continue
-			}
-			prev.PriorBackup.EndTime = timestamppb.New(l.T)
-			prev.PriorBackup.Error = l.Payload.PriorBackupEnd.Error
-			prev.PriorBackup.PriorBackupDetail = convertToTaskRunLogPriorBackupDetail(l.Payload.PriorBackupEnd.PriorBackupDetail)
 
 		case storepb.TaskRunLog_COMPUTE_DIFF_START:
 			entries = append(entries, &v1pb.TaskRunLogEntry{

--- a/backend/api/v1/rollout_service_converter_test.go
+++ b/backend/api/v1/rollout_service_converter_test.go
@@ -1,0 +1,74 @@
+package v1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestConvertToTaskRunLogEntries_PriorBackupWithDatabaseSync(t *testing.T) {
+	baseTime := time.Date(2026, 4, 22, 10, 0, 0, 0, time.UTC)
+	logs := []*store.TaskRunLog{
+		{
+			T: baseTime,
+			Payload: &storepb.TaskRunLog{
+				Type:             storepb.TaskRunLog_PRIOR_BACKUP_START,
+				PriorBackupStart: &storepb.TaskRunLog_PriorBackupStart{},
+			},
+		},
+		{
+			T: baseTime.Add(time.Second),
+			Payload: &storepb.TaskRunLog{
+				Type:              storepb.TaskRunLog_DATABASE_SYNC_START,
+				DatabaseSyncStart: &storepb.TaskRunLog_DatabaseSyncStart{},
+			},
+		},
+		{
+			T: baseTime.Add(2 * time.Second),
+			Payload: &storepb.TaskRunLog{
+				Type: storepb.TaskRunLog_DATABASE_SYNC_END,
+				DatabaseSyncEnd: &storepb.TaskRunLog_DatabaseSyncEnd{
+					Error: "sync failed",
+				},
+			},
+		},
+		{
+			T: baseTime.Add(3 * time.Second),
+			Payload: &storepb.TaskRunLog{
+				Type: storepb.TaskRunLog_PRIOR_BACKUP_END,
+				PriorBackupEnd: &storepb.TaskRunLog_PriorBackupEnd{
+					PriorBackupDetail: &storepb.PriorBackupDetail{
+						Items: []*storepb.PriorBackupDetail_Item{
+							{
+								SourceTable: &storepb.PriorBackupDetail_Item_Table{
+									Database: "instances/prod/databases/app",
+									Schema:   "public",
+									Table:    "users",
+								},
+								TargetTable: &storepb.PriorBackupDetail_Item_Table{
+									Database: "instances/prod/databases/backup",
+									Table:    "users_backup",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	entries := convertToTaskRunLogEntries(logs)
+
+	require.Len(t, entries, 2)
+	require.Equal(t, v1pb.TaskRunLogEntry_PRIOR_BACKUP, entries[0].Type)
+	require.Equal(t, baseTime, entries[0].GetPriorBackup().GetStartTime().AsTime())
+	require.Equal(t, baseTime.Add(3*time.Second), entries[0].GetPriorBackup().GetEndTime().AsTime())
+	require.Len(t, entries[0].GetPriorBackup().GetPriorBackupDetail().GetItems(), 1)
+	require.Equal(t, v1pb.TaskRunLogEntry_DATABASE_SYNC, entries[1].Type)
+	require.Equal(t, "sync failed", entries[1].GetDatabaseSync().GetError())
+}

--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -887,28 +887,21 @@ func (exec *DatabaseMigrateExecutor) backupData(
 		priorBackupDetail.Items = append(priorBackupDetail.Items, item)
 	}
 
+	syncDatabase := database
+	syncDatabaseName := fmt.Sprintf("/instances/%s/databases/%s", instance.ResourceID, database.DatabaseName)
 	if database.Engine != storepb.Engine_POSTGRES {
-		opts.LogDatabaseSyncStart()
-		if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, backupDatabase); err != nil {
-			opts.LogDatabaseSyncEnd(err.Error())
-			slog.Error("failed to sync backup database schema",
-				slog.String("database", targetDatabaseName),
-				log.BBError(err),
-			)
-		} else {
-			opts.LogDatabaseSyncEnd("")
-		}
+		syncDatabase = backupDatabase
+		syncDatabaseName = targetDatabaseName
+	}
+	opts.LogDatabaseSyncStart()
+	if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, syncDatabase); err != nil {
+		opts.LogDatabaseSyncEnd(err.Error())
+		slog.Error("failed to sync backup database schema",
+			slog.String("database", syncDatabaseName),
+			log.BBError(err),
+		)
 	} else {
-		opts.LogDatabaseSyncStart()
-		if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, database); err != nil {
-			opts.LogDatabaseSyncEnd(err.Error())
-			slog.Error("failed to sync backup database schema",
-				slog.String("database", fmt.Sprintf("/instances/%s/databases/%s", instance.ResourceID, database.DatabaseName)),
-				log.BBError(err),
-			)
-		} else {
-			opts.LogDatabaseSyncEnd("")
-		}
+		opts.LogDatabaseSyncEnd("")
 	}
 
 	return priorBackupDetail, nil

--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -162,6 +162,15 @@ func (exec *DatabaseMigrateExecutor) ensureBaselineChangelog(ctx context.Context
 }
 
 func (exec *DatabaseMigrateExecutor) runStandardMigration(ctx context.Context, driverCtx context.Context, task *store.TaskMessage, taskRunUID int64, sheet *store.SheetMessage, instance *store.InstanceMessage, database *store.DatabaseMessage, project *store.ProjectMessage) (*storepb.TaskRunResult, error) {
+	// Set up execute options
+	opts := db.ExecuteOptions{}
+	if project != nil && project.Setting != nil {
+		opts.MaximumRetries = int(project.Setting.GetExecutionRetryPolicy().GetMaximumRetries())
+	}
+	opts.CreateTaskRunLog = func(t time.Time, e *storepb.TaskRunLog) error {
+		return exec.store.CreateTaskRunLog(ctx, database.ProjectID, taskRunUID, t.UTC(), exec.profile.ReplicaID, e)
+	}
+
 	// Handle prior backup if enabled.
 	// TransformDMLToSelect will automatically filter out DDL statements,
 	// so this works correctly for mixed DDL+DML statements.
@@ -189,7 +198,7 @@ func (exec *DatabaseMigrateExecutor) runStandardMigration(ctx context.Context, d
 			// Check if we should skip backup or not.
 			if common.EngineSupportPriorBackup(database.Engine) {
 				var backupErr error
-				priorBackupDetail, backupErr = exec.backupData(ctx, driverCtx, sheet.Statement, task.Payload, task, instance, database)
+				priorBackupDetail, backupErr = exec.backupData(ctx, driverCtx, sheet.Statement, task.Payload, task, instance, database, &opts)
 				if backupErr != nil {
 					exec.store.CreateTaskRunLogS(ctx, database.ProjectID, taskRunUID, time.Now(), exec.profile.ReplicaID, &storepb.TaskRunLog{
 						Type: storepb.TaskRunLog_PRIOR_BACKUP_END,
@@ -229,15 +238,6 @@ func (exec *DatabaseMigrateExecutor) runStandardMigration(ctx context.Context, d
 		slog.String("type", task.Type.String()),
 		slog.String("sheetSha256", sheet.Sha256),
 	)
-
-	// Set up execute options
-	opts := db.ExecuteOptions{}
-	if project != nil && project.Setting != nil {
-		opts.MaximumRetries = int(project.Setting.GetExecutionRetryPolicy().GetMaximumRetries())
-	}
-	opts.CreateTaskRunLog = func(t time.Time, e *storepb.TaskRunLog) error {
-		return exec.store.CreateTaskRunLog(ctx, database.ProjectID, taskRunUID, t.UTC(), exec.profile.ReplicaID, e)
-	}
 
 	// Begin migration - create pending changelog
 	changelogID, err := exec.store.CreateChangelog(ctx, &store.ChangelogMessage{
@@ -740,6 +740,7 @@ func (exec *DatabaseMigrateExecutor) backupData(
 	task *store.TaskMessage,
 	instance *store.InstanceMessage,
 	database *store.DatabaseMessage,
+	opts *db.ExecuteOptions,
 ) (*storepb.PriorBackupDetail, error) {
 	if !payload.GetEnablePriorBackup() {
 		return nil, nil
@@ -887,18 +888,26 @@ func (exec *DatabaseMigrateExecutor) backupData(
 	}
 
 	if database.Engine != storepb.Engine_POSTGRES {
+		opts.LogDatabaseSyncStart()
 		if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, backupDatabase); err != nil {
+			opts.LogDatabaseSyncEnd(err.Error())
 			slog.Error("failed to sync backup database schema",
 				slog.String("database", targetDatabaseName),
 				log.BBError(err),
 			)
+		} else {
+			opts.LogDatabaseSyncEnd("")
 		}
 	} else {
+		opts.LogDatabaseSyncStart()
 		if err := exec.schemaSyncer.SyncDatabaseSchema(ctx, database); err != nil {
+			opts.LogDatabaseSyncEnd(err.Error())
 			slog.Error("failed to sync backup database schema",
 				slog.String("database", fmt.Sprintf("/instances/%s/databases/%s", instance.ResourceID, database.DatabaseName)),
 				log.BBError(err),
 			)
+		} else {
+			opts.LogDatabaseSyncEnd("")
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Wrap backup-phase schema sync with database sync task run log start/end events.
- Reuse the migration execute options task-run-log callback so the sync appears as a timed sub-step under prior backup.
- Preserve prior-backup log conversion when database-sync entries appear between prior-backup start/end logs.

Closes BYT-9329

## Test Plan
- go test -v -count=1 ./backend/api/v1
- go test -v -count=1 ./backend/runner/taskrun
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- golangci-lint run --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
