### PR TITLE
cherrypick: [release/3.17.1] redesign instance TLS settings + harden path validation

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -252,6 +252,12 @@ func (s *InstanceService) CreateInstance(ctx context.Context, req *connect.Reque
 	return connect.NewResponse(result), nil
 }
 
+func instanceWithMetadata(instance *store.InstanceMessage, metadata *storepb.Instance) *store.InstanceMessage {
+	candidate := *instance
+	candidate.Metadata = metadata
+	return &candidate
+}
+
 func (s *InstanceService) checkInstanceDataSources(ctx context.Context, instance *store.InstanceMessage, dataSources []*storepb.DataSource) error {
 	for _, ds := range dataSources {
 		if err := s.checkDataSource(ctx, instance, ds); err != nil {
@@ -786,6 +792,10 @@ func (s *InstanceService) AddDataSource(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 
+	if err := s.licenseService.IsFeatureEnabledForInstance(ctx, common.GetWorkspaceIDFromContext(ctx), v1pb.PlanFeature_FEATURE_INSTANCE_READ_ONLY_CONNECTION, instance); err != nil {
+		return nil, connect.NewError(connect.CodePermissionDenied, err)
+	}
+
 	// Test connection.
 	if req.Msg.ValidateOnly {
 		err := func() error {
@@ -807,15 +817,12 @@ func (s *InstanceService) AddDataSource(ctx context.Context, req *connect.Reques
 		if err != nil {
 			return nil, err
 		}
-		result := convertToV1Instance(instance)
+		result := convertToV1Instance(instanceWithMetadata(instance, metadata))
 		return connect.NewResponse(result), nil
 	}
 
 	if dataSource.GetType() != storepb.DataSourceType_READ_ONLY {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("only read-only data source can be added"))
-	}
-	if err := s.licenseService.IsFeatureEnabledForInstance(ctx, common.GetWorkspaceIDFromContext(ctx), v1pb.PlanFeature_FEATURE_INSTANCE_READ_ONLY_CONNECTION, instance); err != nil {
-		return nil, connect.NewError(connect.CodePermissionDenied, err)
 	}
 
 	instance, err = s.store.UpdateInstance(ctx, &store.UpdateInstanceMessage{
@@ -858,8 +865,9 @@ func (s *InstanceService) UpdateDataSource(ctx context.Context, req *connect.Req
 	if dataSource == nil {
 		if req.Msg.AllowMissing {
 			return s.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
-				Name:       req.Msg.Name,
-				DataSource: req.Msg.DataSource,
+				Name:         req.Msg.Name,
+				DataSource:   req.Msg.DataSource,
+				ValidateOnly: req.Msg.ValidateOnly,
 			}))
 		}
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf(`cannot found data source "%s"`, req.Msg.DataSource.Id))
@@ -1027,7 +1035,7 @@ func (s *InstanceService) UpdateDataSource(ctx context.Context, req *connect.Req
 		if err != nil {
 			return nil, err
 		}
-		result := convertToV1Instance(instance)
+		result := convertToV1Instance(instanceWithMetadata(instance, metadata))
 		return connect.NewResponse(result), nil
 	}
 

--- a/backend/plugin/db/util/ssl.go
+++ b/backend/plugin/db/util/ssl.go
@@ -4,6 +4,7 @@ package util
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -12,6 +13,8 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
+
+const maxTLSMaterialFileSize int64 = 10 << 20
 
 func HasTLSPath(ds *storepb.DataSource) bool {
 	if ds == nil {
@@ -61,12 +64,35 @@ func readTLSPathFile(label, path string) (string, error) {
 	if !filepath.IsAbs(path) {
 		return "", errors.Errorf("%s path must be absolute", label)
 	}
-	content, err := os.ReadFile(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", errors.Errorf("failed to read %s file", label)
+	}
+	if !info.Mode().IsRegular() {
+		return "", errors.Errorf("%s path must point to a regular file", label)
+	}
+	if info.Size() == 0 {
+		return "", errors.Errorf("%s file is empty", label)
+	}
+	if info.Size() > maxTLSMaterialFileSize {
+		return "", errors.Errorf("%s file is too large", label)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return "", errors.Errorf("failed to read %s file", label)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxTLSMaterialFileSize+1))
 	if err != nil {
 		return "", errors.Errorf("failed to read %s file", label)
 	}
 	if len(content) == 0 {
 		return "", errors.Errorf("%s file is empty", label)
+	}
+	if int64(len(content)) > maxTLSMaterialFileSize {
+		return "", errors.Errorf("%s file is too large", label)
 	}
 	return string(content), nil
 }

--- a/backend/plugin/db/util/ssl_test.go
+++ b/backend/plugin/db/util/ssl_test.go
@@ -92,6 +92,31 @@ func TestResolveTLSMaterialRedactsReadErrors(t *testing.T) {
 	require.NotContains(t, err.Error(), "no such file")
 }
 
+func TestResolveTLSMaterialRejectsNonRegularPath(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := ResolveTLSMaterial(&storepb.DataSource{
+		UseSsl:    true,
+		SslCaPath: dir,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CA certificate path must point to a regular file")
+	require.NotContains(t, err.Error(), dir)
+}
+
+func TestResolveTLSMaterialRejectsOversizedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ca.pem")
+	require.NoError(t, os.WriteFile(path, make([]byte, maxTLSMaterialFileSize+1), 0o600))
+
+	_, err := ResolveTLSMaterial(&storepb.DataSource{
+		UseSsl:    true,
+		SslCaPath: path,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "CA certificate file is too large")
+	require.NotContains(t, err.Error(), path)
+}
+
 func TestGetTLSConfigRequiresResolvedTLSMaterial(t *testing.T) {
 	_, err := GetTLSConfig(&storepb.DataSource{
 		UseSsl:    true,

--- a/backend/tests/data_source_test.go
+++ b/backend/tests/data_source_test.go
@@ -42,6 +42,17 @@ func TestDataSource(t *testing.T) {
 	_, err = ctl.instanceServiceClient.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
 		Name: instance.Name,
 		DataSource: &v1pb.DataSource{
+			Id:   "readonly-validate-only",
+			Type: v1pb.DataSourceType_READ_ONLY,
+			Host: instanceDir,
+		},
+		ValidateOnly: true,
+	}))
+	a.ErrorContains(err, "TEAM feature, please upgrade to access it")
+
+	_, err = ctl.instanceServiceClient.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
 			Id:       "readonly",
 			Type:     v1pb.DataSourceType_READ_ONLY,
 			Username: "ro_ds",
@@ -152,4 +163,111 @@ func TestDataSource(t *testing.T) {
 		DataSource: &v1pb.DataSource{Id: "readonly"},
 	}))
 	a.NoError(err)
+}
+
+func TestDataSourceValidateOnly(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	instanceRootDir := t.TempDir()
+	instanceName := "testInstanceValidateOnly"
+	instanceDir, err := ctl.provisionSQLiteInstance(instanceRootDir, instanceName)
+	a.NoError(err)
+
+	instanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       "test",
+			Engine:      v1pb.Engine_SQLITE,
+			Environment: new("environments/prod"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{Type: v1pb.DataSourceType_ADMIN, Id: "admin-ds", Host: instanceDir}},
+		},
+	}))
+	a.NoError(err)
+	instance := instanceResp.Msg
+
+	err = ctl.setLicense(ctx)
+	a.NoError(err)
+
+	addResp, err := ctl.instanceServiceClient.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
+			Id:   "readonly-validate-only",
+			Type: v1pb.DataSourceType_READ_ONLY,
+			Host: instanceDir,
+		},
+		ValidateOnly: true,
+	}))
+	a.NoError(err)
+	a.Len(addResp.Msg.DataSources, 2)
+	a.NotNil(findDataSource(addResp.Msg.DataSources, "readonly-validate-only"))
+
+	instanceResp, err = ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	a.Len(instanceResp.Msg.DataSources, 1)
+	a.Nil(findDataSource(instanceResp.Msg.DataSources, "readonly-validate-only"))
+
+	updateResp, err := ctl.instanceServiceClient.UpdateDataSource(ctx, connect.NewRequest(&v1pb.UpdateDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
+			Id:   "readonly-allow-missing",
+			Type: v1pb.DataSourceType_READ_ONLY,
+			Host: instanceDir,
+		},
+		UpdateMask:   &fieldmaskpb.FieldMask{Paths: []string{"host"}},
+		ValidateOnly: true,
+		AllowMissing: true,
+	}))
+	a.NoError(err)
+	a.Len(updateResp.Msg.DataSources, 2)
+	a.NotNil(findDataSource(updateResp.Msg.DataSources, "readonly-allow-missing"))
+
+	instanceResp, err = ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	a.Len(instanceResp.Msg.DataSources, 1)
+	a.Nil(findDataSource(instanceResp.Msg.DataSources, "readonly-allow-missing"))
+
+	_, err = ctl.instanceServiceClient.AddDataSource(ctx, connect.NewRequest(&v1pb.AddDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
+			Id:   "readonly",
+			Type: v1pb.DataSourceType_READ_ONLY,
+			Host: instanceDir,
+		},
+	}))
+	a.NoError(err)
+
+	updateResp, err = ctl.instanceServiceClient.UpdateDataSource(ctx, connect.NewRequest(&v1pb.UpdateDataSourceRequest{
+		Name: instance.Name,
+		DataSource: &v1pb.DataSource{
+			Id:       "readonly",
+			Username: "updated-user",
+		},
+		UpdateMask:   &fieldmaskpb.FieldMask{Paths: []string{"username"}},
+		ValidateOnly: true,
+	}))
+	a.NoError(err)
+	updated := findDataSource(updateResp.Msg.DataSources, "readonly")
+	a.NotNil(updated)
+	a.Equal("updated-user", updated.Username)
+
+	instanceResp, err = ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	persisted := findDataSource(instanceResp.Msg.DataSources, "readonly")
+	a.NotNil(persisted)
+	a.Equal("", persisted.Username)
+}
+
+func findDataSource(dataSources []*v1pb.DataSource, id string) *v1pb.DataSource {
+	for _, dataSource := range dataSources {
+		if dataSource.Id == id {
+			return dataSource
+		}
+	}
+	return nil
 }

--- a/docs/superpowers/plans/2026-04-21-instance-tls-ui-posture.md
+++ b/docs/superpowers/plans/2026-04-21-instance-tls-ui-posture.md
@@ -1,0 +1,1230 @@
+# Instance TLS UI Posture Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the instance data source TLS UI with a posture-first `Connection security` design while preserving the existing backend/API/storage model.
+
+**Architecture:** Add local TLS posture helpers in `frontend/src/react/components/instance/tls.ts`, add a small segmented-control primitive for the posture/source controls, and update `SslCertificateForm` plus `DataSourceForm` to map the UI posture onto existing `useSsl`, CA, and client certificate/key fields. Vault TLS keeps the existing legacy path because it does not pass posture props.
+
+**Tech Stack:** React, Base UI-compatible local UI primitives, Tailwind CSS v4 classes, Vitest, `react-i18next`, Pinia state bridged with `useVueState`.
+
+---
+
+## File Structure
+
+- Modify `frontend/src/react/components/instance/tls.ts`: add posture constants/types and helper functions for posture inference, posture application, and client identity support.
+- Modify `frontend/src/react/components/instance/common.test.ts`: add tests for posture inference and clearing behavior.
+- Create `frontend/src/react/components/ui/segmented-control.tsx`: reusable segmented control with selected, disabled, and tooltip-capable options.
+- Modify `frontend/src/react/components/instance/SslCertificateForm.tsx`: replace instance-mode switch/radio source UI with posture and segmented source controls; keep legacy rendering for Vault callers.
+- Modify `frontend/src/react/components/instance/SslCertificateForm.test.tsx`: update existing tests and add component tests for posture, SaaS file path disabling, verification explanation, and unsupported mTLS.
+- Modify `frontend/src/react/components/instance/DataSourceForm.tsx`: infer and sync local posture state, pass SaaS mode, and map posture changes to existing data source fields.
+- Modify locale files under `frontend/src/react/locales/`: add the new display strings to every React locale file.
+
+---
+
+### Task 1: Add TLS Posture Helpers
+
+**Files:**
+- Modify: `frontend/src/react/components/instance/tls.ts`
+- Test: `frontend/src/react/components/instance/common.test.ts`
+
+- [ ] **Step 1: Write failing posture helper tests**
+
+Add these imports in `frontend/src/react/components/instance/common.test.ts`:
+
+```ts
+import { Engine } from "@/types/proto-es/v1/common_pb";
+```
+
+Extend the existing TLS imports:
+
+```ts
+import {
+  applyLocalTlsCaSource,
+  applyLocalTlsClientCertSource,
+  applyLocalTlsPosture,
+  getLocalTlsCaSource,
+  getLocalTlsClientCertSource,
+  getLocalTlsPosture,
+  isLocalTlsClientIdentitySupported,
+  SSL_UPDATE_MASK_FIELDS,
+} from "./tls";
+```
+
+Append these tests to `frontend/src/react/components/instance/common.test.ts`:
+
+```ts
+describe("TLS posture helpers", () => {
+  test("infers disabled posture when SSL is off", () => {
+    expect(getLocalTlsPosture({ useSsl: false })).toBe("DISABLED");
+  });
+
+  test("infers TLS posture when SSL is on without client identity", () => {
+    expect(
+      getLocalTlsPosture({
+        useSsl: true,
+        sslCaPathSet: true,
+      } as never)
+    ).toBe("TLS");
+  });
+
+  test("infers mutual TLS posture from inline client material", () => {
+    expect(
+      getLocalTlsPosture({
+        useSsl: true,
+        sslCertSet: true,
+        sslKeySet: true,
+      } as never)
+    ).toBe("MUTUAL_TLS");
+  });
+
+  test("infers mutual TLS posture from file path client material", () => {
+    expect(
+      getLocalTlsPosture({
+        useSsl: true,
+        sslCertPathSet: true,
+        sslKeyPathSet: true,
+      } as never)
+    ).toBe("MUTUAL_TLS");
+  });
+
+  test("switching posture to TLS clears only client identity fields", () => {
+    const next = applyLocalTlsPosture(
+      {
+        useSsl: true,
+        sslCaPath: "/tmp/ca.pem",
+        sslCaPathSet: true,
+        sslCert: "inline-cert",
+        sslKey: "inline-key",
+        sslCertPath: "/tmp/cert.pem",
+        sslKeyPath: "/tmp/key.pem",
+        sslCertSet: true,
+        sslKeySet: true,
+        sslCertPathSet: true,
+        sslKeyPathSet: true,
+      } as never,
+      "TLS"
+    );
+
+    expect(next.useSsl).toBe(true);
+    expect(next.sslCaPath).toBe("/tmp/ca.pem");
+    expect(next.sslCaPathSet).toBe(true);
+    expect(next.sslCert).toBe("");
+    expect(next.sslKey).toBe("");
+    expect(next.sslCertPath).toBe("");
+    expect(next.sslKeyPath).toBe("");
+    expect(next.sslCertSet).toBe(false);
+    expect(next.sslKeySet).toBe(false);
+    expect(next.sslCertPathSet).toBe(false);
+    expect(next.sslKeyPathSet).toBe(false);
+  });
+
+  test("switching posture to disabled clears all TLS material", () => {
+    const next = applyLocalTlsPosture(
+      {
+        useSsl: true,
+        sslCa: "inline-ca",
+        sslCaPath: "/tmp/ca.pem",
+        sslCert: "inline-cert",
+        sslKey: "inline-key",
+      } as never,
+      "DISABLED"
+    );
+
+    expect(next.useSsl).toBe(false);
+    expect(next.sslCa).toBe("");
+    expect(next.sslCaPath).toBe("");
+    expect(next.sslCert).toBe("");
+    expect(next.sslKey).toBe("");
+  });
+
+  test("MSSQL does not support client identity in this form", () => {
+    expect(isLocalTlsClientIdentitySupported(Engine.MSSQL)).toBe(false);
+    expect(isLocalTlsClientIdentitySupported(Engine.POSTGRES)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir frontend test -- SslCertificateForm common
+```
+
+Expected: FAIL because `applyLocalTlsPosture`, `getLocalTlsPosture`, and `isLocalTlsClientIdentitySupported` are not exported yet.
+
+- [ ] **Step 3: Implement posture helpers**
+
+In `frontend/src/react/components/instance/tls.ts`, add the engine import near the top:
+
+```ts
+import { Engine } from "@/types/proto-es/v1/common_pb";
+```
+
+Add posture constants and type after the existing local TLS source constants:
+
+```ts
+export const LOCAL_TLS_POSTURE_DISABLED = "DISABLED" as const;
+export const LOCAL_TLS_POSTURE_TLS = "TLS" as const;
+export const LOCAL_TLS_POSTURE_MUTUAL_TLS = "MUTUAL_TLS" as const;
+
+export type LocalTlsPosture =
+  | typeof LOCAL_TLS_POSTURE_DISABLED
+  | typeof LOCAL_TLS_POSTURE_TLS
+  | typeof LOCAL_TLS_POSTURE_MUTUAL_TLS;
+```
+
+Add these helpers after `getLocalTlsClientCertSource`:
+
+```ts
+export const getLocalTlsPosture = (
+  ds: LocalTlsDataSource | undefined
+): LocalTlsPosture => {
+  if (!ds?.useSsl) {
+    return LOCAL_TLS_POSTURE_DISABLED;
+  }
+  return getLocalTlsClientCertSource(ds) === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
+    ? LOCAL_TLS_POSTURE_TLS
+    : LOCAL_TLS_POSTURE_MUTUAL_TLS;
+};
+
+export const isLocalTlsClientIdentitySupported = (engine: Engine): boolean => {
+  return engine !== Engine.MSSQL;
+};
+```
+
+Add this helper after `applyLocalTlsClientCertSource`:
+
+```ts
+export const applyLocalTlsPosture = (
+  ds: DataSource,
+  posture: LocalTlsPosture
+): DataSource => {
+  const next = cloneDeep(ds);
+  switch (posture) {
+    case LOCAL_TLS_POSTURE_DISABLED:
+      return disableLocalTls(next);
+    case LOCAL_TLS_POSTURE_TLS:
+      next.useSsl = true;
+      clearLocalTlsClientCertFields(next);
+      return next;
+    case LOCAL_TLS_POSTURE_MUTUAL_TLS:
+      next.useSsl = true;
+      return next;
+  }
+};
+```
+
+- [ ] **Step 4: Run helper tests**
+
+Run:
+
+```bash
+pnpm --dir frontend test -- common
+```
+
+Expected: PASS for `common.test.ts`.
+
+- [ ] **Step 5: Commit helper changes**
+
+Run:
+
+```bash
+git add frontend/src/react/components/instance/tls.ts frontend/src/react/components/instance/common.test.ts
+git commit -m "feat: add local TLS posture helpers"
+```
+
+---
+
+### Task 2: Add a Segmented Control Primitive
+
+**Files:**
+- Create: `frontend/src/react/components/ui/segmented-control.tsx`
+- Test indirectly in: `frontend/src/react/components/instance/SslCertificateForm.test.tsx`
+
+- [ ] **Step 1: Create the segmented control**
+
+Create `frontend/src/react/components/ui/segmented-control.tsx`:
+
+```tsx
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { cn } from "@/react/lib/utils";
+
+export interface SegmentedControlOption<T extends string> {
+  value: T;
+  label: React.ReactNode;
+  disabled?: boolean;
+  tooltip?: React.ReactNode;
+}
+
+interface SegmentedControlProps<T extends string> {
+  value: T;
+  options: SegmentedControlOption<T>[];
+  onValueChange: (value: T) => void;
+  ariaLabel: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function SegmentedControl<T extends string>({
+  value,
+  options,
+  onValueChange,
+  ariaLabel,
+  disabled = false,
+  className,
+}: SegmentedControlProps<T>) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex max-w-full flex-wrap rounded-xs border border-control-border bg-background",
+        className
+      )}
+    >
+      {options.map((option, index) => {
+        const selected = option.value === value;
+        const optionDisabled = disabled || option.disabled;
+        const button = (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            aria-disabled={optionDisabled || undefined}
+            data-state={selected ? "checked" : "unchecked"}
+            data-disabled={optionDisabled || undefined}
+            className={cn(
+              "min-h-8 px-3 text-sm transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
+              index > 0 && "border-l border-control-border",
+              selected
+                ? "bg-accent text-accent-text"
+                : "bg-background text-control hover:bg-control-bg",
+              optionDisabled && "cursor-not-allowed opacity-50 hover:bg-background"
+            )}
+            onClick={() => {
+              if (!optionDisabled) {
+                onValueChange(option.value);
+              }
+            }}
+          >
+            {option.label}
+          </button>
+        );
+
+        if (!option.tooltip) {
+          return button;
+        }
+        return (
+          <Tooltip key={option.value} content={option.tooltip}>
+            {button}
+          </Tooltip>
+        );
+      })}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Run frontend type check for the new component**
+
+Run:
+
+```bash
+pnpm --dir frontend type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit segmented control**
+
+Run:
+
+```bash
+git add frontend/src/react/components/ui/segmented-control.tsx
+git commit -m "feat: add React segmented control"
+```
+
+---
+
+### Task 3: Update Locale Strings
+
+**Files:**
+- Modify: `frontend/src/react/locales/en-US.json`
+- Modify: `frontend/src/react/locales/zh-CN.json`
+- Modify: `frontend/src/react/locales/ja-JP.json`
+- Modify: `frontend/src/react/locales/es-ES.json`
+- Modify: `frontend/src/react/locales/vi-VN.json`
+
+- [ ] **Step 1: Update the English locale**
+
+In `frontend/src/react/locales/en-US.json`, update the `data-source.ssl` object:
+
+```json
+{
+  "ca-empty-uses-system-trust": "Uses the system trust store to verify the server certificate.",
+  "ca-source": {
+    "file-path": "File path",
+    "file-path-unavailable-saas": "File paths are unavailable in Bytebase Cloud.",
+    "inline-pem": "Paste PEM",
+    "self": "CA certificate source",
+    "system-trust": "System trust"
+  },
+  "client-cert": "Certificate",
+  "client-cert-path": "Certificate path",
+  "client-cert-source": {
+    "file-path": "File path",
+    "file-path-unavailable-saas": "File paths are unavailable in Bytebase Cloud.",
+    "inline-pem": "Paste PEM",
+    "none": "None",
+    "self": "Client identity source"
+  },
+  "client-identity": "Client identity",
+  "client-key": "Private key",
+  "client-key-path": "Private key path",
+  "connection-security": "Connection security",
+  "mutual-tls-unavailable-engine": "Mutual TLS is not available for this engine.",
+  "posture": {
+    "disabled": "Disabled",
+    "mutual-tls": "Mutual TLS",
+    "self": "Security posture",
+    "tls": "TLS"
+  },
+  "server-identity": "Server identity",
+  "verification-disabled-description": "Verification is disabled. The connection is encrypted, but the server identity is not verified; CA settings are ignored."
+}
+```
+
+Preserve existing keys not shown in this snippet, such as placeholders and `configured`.
+
+- [ ] **Step 2: Update non-English React locale files**
+
+Apply the same key structure to:
+
+```bash
+frontend/src/react/locales/zh-CN.json
+frontend/src/react/locales/ja-JP.json
+frontend/src/react/locales/es-ES.json
+frontend/src/react/locales/vi-VN.json
+```
+
+Use the English strings as fallback values if a proper translation is not available. Do not add empty objects.
+
+- [ ] **Step 3: Validate locale JSON**
+
+Run:
+
+```bash
+pnpm --dir frontend check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit locale changes**
+
+Run:
+
+```bash
+git add frontend/src/react/locales/en-US.json frontend/src/react/locales/zh-CN.json frontend/src/react/locales/ja-JP.json frontend/src/react/locales/es-ES.json frontend/src/react/locales/vi-VN.json
+git commit -m "chore: add TLS posture locale strings"
+```
+
+---
+
+### Task 4: Redesign `SslCertificateForm`
+
+**Files:**
+- Modify: `frontend/src/react/components/instance/SslCertificateForm.tsx`
+- Test: `frontend/src/react/components/instance/SslCertificateForm.test.tsx`
+
+- [ ] **Step 1: Write failing component tests**
+
+Replace the current explicit-source test in `frontend/src/react/components/instance/SslCertificateForm.test.tsx` with tests that describe the new UI. Keep the existing `marks write-only TLS material as configured` test and update expected labels as needed.
+
+Add these tests:
+
+```tsx
+import type { ReactNode } from "react";
+
+vi.mock("@/react/components/ui/tooltip", () => ({
+  Tooltip: ({
+    content,
+    children,
+  }: {
+    content: ReactNode;
+    children: ReactNode;
+  }) => (
+    <span data-tooltip={typeof content === "string" ? content : undefined}>
+      {children}
+      {content}
+    </span>
+  ),
+}));
+
+test("renders posture-first connection security controls", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <SslCertificateForm
+        posture="TLS"
+        onPostureChange={() => {}}
+        caSource="SYSTEM_TRUST"
+        onCaSourceChange={() => {}}
+        clientCertSource="NONE"
+        onClientCertSourceChange={() => {}}
+        useSsl={true}
+        verify={true}
+        onVerifyChange={() => {}}
+        engineType={Engine.POSTGRES}
+      />
+    );
+  });
+
+  expect(container.textContent).toContain("data-source.ssl.connection-security");
+  expect(container.textContent).toContain("data-source.ssl.posture.disabled");
+  expect(container.textContent).toContain("data-source.ssl.posture.tls");
+  expect(container.textContent).toContain("data-source.ssl.posture.mutual-tls");
+  expect(container.textContent).toContain("data-source.ssl.server-identity");
+  expect(container.textContent).toContain(
+    "data-source.ssl.ca-empty-uses-system-trust"
+  );
+  expect(container.textContent).not.toContain("data-source.ssl.client-identity");
+
+  act(() => {
+    root.unmount();
+  });
+});
+
+test("renders client identity for mutual TLS without a None source option", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <SslCertificateForm
+        posture="MUTUAL_TLS"
+        onPostureChange={() => {}}
+        caSource="SYSTEM_TRUST"
+        onCaSourceChange={() => {}}
+        clientCertSource="INLINE_PEM"
+        onClientCertSourceChange={() => {}}
+        useSsl={true}
+        verify={true}
+        onVerifyChange={() => {}}
+        showKeyAndCert
+        engineType={Engine.POSTGRES}
+      />
+    );
+  });
+
+  expect(container.textContent).toContain("data-source.ssl.client-identity");
+  expect(container.textContent).toContain(
+    "data-source.ssl.client-cert-source.inline-pem"
+  );
+  expect(container.textContent).toContain(
+    "data-source.ssl.client-cert-source.file-path"
+  );
+  expect(container.textContent).not.toContain(
+    "data-source.ssl.client-cert-source.none"
+  );
+
+  act(() => {
+    root.unmount();
+  });
+});
+
+test("keeps CA controls visible when verification is disabled", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <SslCertificateForm
+        posture="TLS"
+        onPostureChange={() => {}}
+        caSource="INLINE_PEM"
+        onCaSourceChange={() => {}}
+        clientCertSource="NONE"
+        onClientCertSourceChange={() => {}}
+        useSsl={true}
+        verify={false}
+        onVerifyChange={() => {}}
+        engineType={Engine.POSTGRES}
+      />
+    );
+  });
+
+  expect(container.textContent).toContain(
+    "data-source.ssl.verification-disabled-description"
+  );
+  expect(container.textContent).toContain("data-source.ssl.ca-source.self");
+
+  act(() => {
+    root.unmount();
+  });
+});
+
+test("disables file path source options in SaaS mode", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <SslCertificateForm
+        posture="MUTUAL_TLS"
+        onPostureChange={() => {}}
+        caSource="FILE_PATH"
+        onCaSourceChange={() => {}}
+        clientCertSource="FILE_PATH"
+        onClientCertSourceChange={() => {}}
+        useSsl={true}
+        verify={true}
+        onVerifyChange={() => {}}
+        isSaaSMode
+        showKeyAndCert
+        engineType={Engine.POSTGRES}
+      />
+    );
+  });
+
+  expect(
+    container.querySelector('[aria-label="data-source.ssl.ca-source.self"] [aria-disabled="true"][aria-checked="true"]')
+  ).not.toBeNull();
+  expect(container.textContent).toContain(
+    "data-source.ssl.ca-source.file-path-unavailable-saas"
+  );
+
+  act(() => {
+    root.unmount();
+  });
+});
+
+test("shows disabled mutual TLS for unsupported engines", () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <SslCertificateForm
+        posture="TLS"
+        onPostureChange={() => {}}
+        caSource="SYSTEM_TRUST"
+        onCaSourceChange={() => {}}
+        clientCertSource="NONE"
+        onClientCertSourceChange={() => {}}
+        useSsl={true}
+        verify={true}
+        onVerifyChange={() => {}}
+        engineType={Engine.MSSQL}
+      />
+    );
+  });
+
+  expect(container.textContent).toContain(
+    "data-source.ssl.mutual-tls-unavailable-engine"
+  );
+  expect(
+    container.querySelector('[aria-disabled="true"]')
+  ).not.toBeNull();
+
+  act(() => {
+    root.unmount();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pnpm --dir frontend test -- SslCertificateForm
+```
+
+Expected: FAIL because `SslCertificateForm` does not yet accept posture or SaaS props and still renders radio source selectors.
+
+- [ ] **Step 3: Update imports and props**
+
+In `frontend/src/react/components/instance/SslCertificateForm.tsx`, remove the radio group import:
+
+```ts
+-import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
+```
+
+Add:
+
+```ts
+import { SegmentedControl } from "@/react/components/ui/segmented-control";
+```
+
+Extend the TLS imports:
+
+```ts
+import {
+  getLocalTlsCaSource,
+  getLocalTlsClientCertSource,
+  isLocalTlsClientIdentitySupported,
+  LOCAL_TLS_CA_SOURCE_FILE_PATH,
+  LOCAL_TLS_CA_SOURCE_INLINE_PEM,
+  LOCAL_TLS_CA_SOURCE_SYSTEM_TRUST,
+  LOCAL_TLS_CLIENT_CERT_SOURCE_FILE_PATH,
+  LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM,
+  LOCAL_TLS_CLIENT_CERT_SOURCE_NONE,
+  LOCAL_TLS_POSTURE_DISABLED,
+  LOCAL_TLS_POSTURE_MUTUAL_TLS,
+  LOCAL_TLS_POSTURE_TLS,
+  type LocalTlsCaSource,
+  type LocalTlsClientCertSource,
+  type LocalTlsPosture,
+} from "./tls";
+```
+
+Add props to `SslCertificateFormProps`:
+
+```ts
+  posture?: LocalTlsPosture;
+  onPostureChange?: (val: LocalTlsPosture) => void;
+  isSaaSMode?: boolean;
+```
+
+Destructure them in `SslCertificateForm`:
+
+```ts
+  posture,
+  onPostureChange,
+  isSaaSMode = false,
+```
+
+- [ ] **Step 4: Replace source selector helpers with segmented controls**
+
+Replace `CaSourceSelector` with:
+
+```tsx
+function CaSourceSelector({
+  value,
+  onChange,
+  disabled = false,
+  isSaaSMode = false,
+}: {
+  value: LocalTlsCaSource;
+  onChange: (value: LocalTlsCaSource) => void;
+  disabled?: boolean;
+  isSaaSMode?: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <SegmentedControl
+      value={value}
+      onValueChange={onChange}
+      ariaLabel={t("data-source.ssl.ca-source.self")}
+      disabled={disabled}
+      options={[
+        {
+          value: LOCAL_TLS_CA_SOURCE_SYSTEM_TRUST,
+          label: t("data-source.ssl.ca-source.system-trust"),
+        },
+        {
+          value: LOCAL_TLS_CA_SOURCE_INLINE_PEM,
+          label: t("data-source.ssl.ca-source.inline-pem"),
+        },
+        {
+          value: LOCAL_TLS_CA_SOURCE_FILE_PATH,
+          label: t("data-source.ssl.ca-source.file-path"),
+          disabled: isSaaSMode,
+          tooltip: isSaaSMode
+            ? t("data-source.ssl.ca-source.file-path-unavailable-saas")
+            : undefined,
+        },
+      ]}
+    />
+  );
+}
+```
+
+Replace `ClientCertSourceSelector` with:
+
+```tsx
+function ClientCertSourceSelector({
+  value,
+  onChange,
+  disabled = false,
+  isSaaSMode = false,
+}: {
+  value: LocalTlsClientCertSource;
+  onChange: (value: LocalTlsClientCertSource) => void;
+  disabled?: boolean;
+  isSaaSMode?: boolean;
+}) {
+  const { t } = useTranslation();
+  return (
+    <SegmentedControl
+      value={value}
+      onValueChange={onChange}
+      ariaLabel={t("data-source.ssl.client-cert-source.self")}
+      disabled={disabled}
+      options={[
+        {
+          value: LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM,
+          label: t("data-source.ssl.client-cert-source.inline-pem"),
+        },
+        {
+          value: LOCAL_TLS_CLIENT_CERT_SOURCE_FILE_PATH,
+          label: t("data-source.ssl.client-cert-source.file-path"),
+          disabled: isSaaSMode,
+          tooltip: isSaaSMode
+            ? t("data-source.ssl.client-cert-source.file-path-unavailable-saas")
+            : undefined,
+        },
+      ]}
+    />
+  );
+}
+```
+
+- [ ] **Step 5: Add posture rendering**
+
+Inside `SslCertificateForm`, compute posture state:
+
+```ts
+  const showPostureUi = posture !== undefined && !!onPostureChange;
+  const resolvedPosture =
+    posture ??
+    (resolvedUseSsl
+      ? resolvedClientCertSource === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
+        ? LOCAL_TLS_POSTURE_TLS
+        : LOCAL_TLS_POSTURE_MUTUAL_TLS
+      : LOCAL_TLS_POSTURE_DISABLED);
+  const supportsClientIdentity =
+    showKeyAndCertFields && isLocalTlsClientIdentitySupported(engineType);
+  const savedClientIdentity =
+    resolvedClientCertSource !== LOCAL_TLS_CLIENT_CERT_SOURCE_NONE;
+  const canSelectMutualTls = supportsClientIdentity || savedClientIdentity;
+```
+
+Add this JSX helper before the `return`:
+
+```tsx
+  const renderPostureControl = () => {
+    if (!showPostureUi) {
+      return null;
+    }
+    return (
+      <div className="flex flex-col gap-y-1">
+        <label className="textlabel block">
+          {t("data-source.ssl.posture.self")}
+        </label>
+        <SegmentedControl
+          value={resolvedPosture}
+          onValueChange={onPostureChange}
+          ariaLabel={t("data-source.ssl.posture.self")}
+          disabled={disabled}
+          options={[
+            {
+              value: LOCAL_TLS_POSTURE_DISABLED,
+              label: t("data-source.ssl.posture.disabled"),
+            },
+            {
+              value: LOCAL_TLS_POSTURE_TLS,
+              label: t("data-source.ssl.posture.tls"),
+            },
+            {
+              value: LOCAL_TLS_POSTURE_MUTUAL_TLS,
+              label: t("data-source.ssl.posture.mutual-tls"),
+              disabled: !canSelectMutualTls,
+              tooltip: !canSelectMutualTls
+                ? t("data-source.ssl.mutual-tls-unavailable-engine")
+                : undefined,
+            },
+          ]}
+        />
+      </div>
+    );
+  };
+```
+
+In the main return, render the new section title and posture control when `showPostureUi` is true:
+
+```tsx
+    <div className="mt-2 flex flex-col gap-y-3">
+      {showPostureUi && (
+        <label className="textlabel block">
+          {t("data-source.ssl.connection-security")}
+        </label>
+      )}
+      {renderPostureControl()}
+      {!showPostureUi && showUseSslSwitch && (
+        // existing switch block
+      )}
+```
+
+Keep the legacy `showUseSslSwitch` branch only when `!showPostureUi`.
+
+- [ ] **Step 6: Render server and client identity groups**
+
+In the posture branch, replace the flat per-group source UI with grouped sections:
+
+```tsx
+              {showPostureUi ? (
+                <>
+                  {resolvedPosture !== LOCAL_TLS_POSTURE_DISABLED && (
+                    <fieldset className="rounded-xs border border-control-border p-3">
+                      <legend className="px-1 text-xs font-medium text-control-light">
+                        {t("data-source.ssl.server-identity")}
+                      </legend>
+                      <div className="flex flex-col gap-y-3">
+                        {showVerify && (
+                          <div className="flex flex-row items-center gap-x-1">
+                            <Switch
+                              checked={verify}
+                              onCheckedChange={(val) => onVerifyChange?.(val)}
+                              disabled={disabled}
+                            />
+                            <label className="textlabel block">
+                              {resolvedVerifyLabel}
+                            </label>
+                            {showTooltip && (
+                              <Tooltip
+                                content={t(
+                                  "data-source.ssl.verify-certificate-tooltip"
+                                )}
+                                side="right"
+                              >
+                                <Info className="size-4 text-warning" />
+                              </Tooltip>
+                            )}
+                          </div>
+                        )}
+                        {!verify && (
+                          <p className="text-xs text-warning">
+                            {t(
+                              "data-source.ssl.verification-disabled-description"
+                            )}
+                          </p>
+                        )}
+                        {showCaSourceUi && (
+                          <div className="flex flex-col gap-y-1">
+                            <label className="textlabel block">
+                              {t("data-source.ssl.ca-source.self")}
+                            </label>
+                            <CaSourceSelector
+                              value={resolvedCaSource}
+                              onChange={onCaSourceChange}
+                              disabled={disabled}
+                              isSaaSMode={isSaaSMode}
+                            />
+                          </div>
+                        )}
+                        {renderCaMaterial()}
+                      </div>
+                    </fieldset>
+                  )}
+
+                  {resolvedPosture === LOCAL_TLS_POSTURE_MUTUAL_TLS && (
+                    <fieldset className="rounded-xs border border-control-border p-3">
+                      <legend className="px-1 text-xs font-medium text-control-light">
+                        {t("data-source.ssl.client-identity")}
+                      </legend>
+                      <div className="flex flex-col gap-y-3">
+                        {showClientCertSourceUi && (
+                          <div className="flex flex-col gap-y-1">
+                            <label className="textlabel block">
+                              {t("data-source.ssl.client-cert-source.self")}
+                            </label>
+                            <ClientCertSourceSelector
+                              value={
+                                resolvedClientCertSource ===
+                                LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
+                                  ? LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM
+                                  : resolvedClientCertSource
+                              }
+                              onChange={onClientCertSourceChange}
+                              disabled={disabled || !canSelectMutualTls}
+                              isSaaSMode={isSaaSMode}
+                            />
+                          </div>
+                        )}
+                        {renderClientCertMaterial()}
+                      </div>
+                    </fieldset>
+                  )}
+                </>
+              ) : (
+                // existing non-posture branch
+              )}
+```
+
+Update `renderCaMaterial` so file path inputs are disabled in SaaS mode:
+
+```tsx
+            disabled={disabled || isSaaSMode}
+```
+
+Update `renderClientCertMaterial` so file path inputs are disabled in SaaS mode:
+
+```tsx
+              disabled={disabled || isSaaSMode}
+```
+
+- [ ] **Step 7: Preserve legacy Vault behavior**
+
+Make sure the `!showPerGroupSourceUi ? renderLegacyMaterial() : ...` branch remains available when `showPostureUi` is false. Vault calls `SslCertificateForm` without `useSsl`, `posture`, or source props; it should keep rendering its existing tabs/textareas.
+
+- [ ] **Step 8: Run component tests**
+
+Run:
+
+```bash
+pnpm --dir frontend test -- SslCertificateForm
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit form redesign**
+
+Run:
+
+```bash
+git add frontend/src/react/components/instance/SslCertificateForm.tsx frontend/src/react/components/instance/SslCertificateForm.test.tsx
+git commit -m "feat: redesign TLS certificate form around posture"
+```
+
+---
+
+### Task 5: Wire Posture and SaaS Mode in Data Source Form
+
+**Files:**
+- Modify: `frontend/src/react/components/instance/DataSourceForm.tsx`
+
+- [ ] **Step 1: Update imports**
+
+In `frontend/src/react/components/instance/DataSourceForm.tsx`, change:
+
+```ts
+import { useSubscriptionV1Store } from "@/store";
+```
+
+to:
+
+```ts
+import { useActuatorV1Store, useSubscriptionV1Store } from "@/store";
+```
+
+Extend the TLS imports:
+
+```ts
+import {
+  applyLocalTlsCaSource,
+  applyLocalTlsClientCertSource,
+  applyLocalTlsPosture,
+  disableLocalTls,
+  getLocalTlsCaSource,
+  getLocalTlsClientCertSource,
+  getLocalTlsPosture,
+  LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM,
+  LOCAL_TLS_CLIENT_CERT_SOURCE_NONE,
+  LOCAL_TLS_POSTURE_DISABLED,
+  LOCAL_TLS_POSTURE_MUTUAL_TLS,
+  LOCAL_TLS_POSTURE_TLS,
+  type LocalTlsPosture,
+} from "./tls";
+```
+
+- [ ] **Step 2: Add SaaS and posture state**
+
+After the subscription store line:
+
+```ts
+  const actuatorStore = useActuatorV1Store();
+  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+```
+
+After `localTlsClientCertSource` state:
+
+```ts
+  const [localTlsPosture, setLocalTlsPosture] = useState(
+    getLocalTlsPosture(dataSource)
+  );
+```
+
+In the TLS sync effect, set posture when the data source changes or when `updateSsl` is not set:
+
+```ts
+      setLocalTlsPosture(getLocalTlsPosture(dataSource));
+```
+
+Add these dependencies to the effect only if not already present:
+
+```ts
+    dataSource.sslCertPathSet,
+    dataSource.sslKeyPathSet,
+```
+
+- [ ] **Step 3: Add posture change handler**
+
+Before the JSX return, add:
+
+```ts
+  const onLocalTlsPostureChange = useCallback(
+    (posture: LocalTlsPosture) => {
+      setLocalTlsPosture(posture);
+      if (posture === LOCAL_TLS_POSTURE_DISABLED) {
+        setLocalTlsCaSource("SYSTEM_TRUST");
+        setLocalTlsClientCertSource(LOCAL_TLS_CLIENT_CERT_SOURCE_NONE);
+        update({ ...disableLocalTls(dataSource), updateSsl: true });
+        return;
+      }
+
+      const next = applyLocalTlsPosture(dataSource, posture);
+      const enablingTls = !dataSource.useSsl;
+      if (posture === LOCAL_TLS_POSTURE_TLS) {
+        setLocalTlsClientCertSource(LOCAL_TLS_CLIENT_CERT_SOURCE_NONE);
+      }
+      if (
+        posture === LOCAL_TLS_POSTURE_MUTUAL_TLS &&
+        localTlsClientCertSource === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
+      ) {
+        setLocalTlsClientCertSource(LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM);
+      }
+
+      update({
+        ...next,
+        verifyTlsCertificate: enablingTls
+          ? true
+          : dataSource.verifyTlsCertificate,
+        updateSsl: mergeTlsUpdateState(dataSource.updateSsl, {
+          useSsl: true,
+          clientCert: posture === LOCAL_TLS_POSTURE_TLS,
+        }),
+      });
+    },
+    [dataSource, localTlsClientCertSource, update]
+  );
+```
+
+- [ ] **Step 4: Replace the old SSL section label and props**
+
+In the SSL section, replace the visible label text:
+
+```tsx
+{t("data-source.ssl-connection")}
+```
+
+with:
+
+```tsx
+{t("data-source.ssl.connection-security")}
+```
+
+In the `SslCertificateForm` call, add:
+
+```tsx
+                posture={localTlsPosture}
+                onPostureChange={onLocalTlsPostureChange}
+                isSaaSMode={isSaaSMode}
+```
+
+Keep `useSsl` and `onUseSslChange` for compatibility during the transition, but `SslCertificateForm` should hide the switch when posture props are present.
+
+- [ ] **Step 5: Preserve source change behavior**
+
+When CA source changes, keep the existing handler.
+
+When client source changes, keep the existing handler, but make sure SaaS disabled controls prevent choosing `FILE_PATH` before this handler runs. The handler should still tolerate existing `FILE_PATH` state because saved file-path rows must render truthfully.
+
+- [ ] **Step 6: Run targeted tests**
+
+Run:
+
+```bash
+pnpm --dir frontend test -- SslCertificateForm common
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit DataSourceForm wiring**
+
+Run:
+
+```bash
+git add frontend/src/react/components/instance/DataSourceForm.tsx
+git commit -m "feat: wire TLS posture into data source form"
+```
+
+---
+
+### Task 6: Polish, Type Check, and Final Verification
+
+**Files:**
+- Modify only files touched in earlier tasks if verification finds issues.
+
+- [ ] **Step 1: Run frontend fixer**
+
+Run:
+
+```bash
+pnpm --dir frontend fix
+```
+
+Expected: command completes and may modify formatting/import ordering.
+
+- [ ] **Step 2: Run frontend checks**
+
+Run:
+
+```bash
+pnpm --dir frontend check
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run React type check**
+
+Run:
+
+```bash
+pnpm --dir frontend type-check
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run frontend tests**
+
+Run:
+
+```bash
+pnpm --dir frontend test
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Review final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD
+git diff HEAD -- frontend/src/react/components/instance frontend/src/react/components/ui frontend/src/react/locales
+```
+
+Expected: diff only contains the planned TLS posture UI, helper, segmented control, tests, and locale changes.
+
+- [ ] **Step 6: Commit verification fixes**
+
+If `pnpm --dir frontend fix` or manual verification fixes changed files, commit them:
+
+```bash
+git add frontend/src/react/components/instance frontend/src/react/components/ui frontend/src/react/locales
+git commit -m "chore: polish TLS posture UI"
+```
+
+If there are no changes, skip this commit.

--- a/docs/superpowers/specs/2026-04-21-instance-tls-ui-posture-design.md
+++ b/docs/superpowers/specs/2026-04-21-instance-tls-ui-posture-design.md
@@ -1,0 +1,164 @@
+# Instance TLS UI Posture Design
+
+## Goal
+
+Redesign the instance data source TLS UI as a pure presentation change over the existing TLS fields. The UI should make the connection security posture explicit without adding templates, telemetry, proto fields, API fields, or backend behavior.
+
+This design applies only to instance data source connection security. Vault TLS configuration stays on the existing UI.
+
+## Non-Goals
+
+- No "Start from template" flow.
+- No telemetry changes.
+- No proto, API, database, or backend behavior changes.
+- No persisted TLS mode enum.
+- No Vault TLS redesign.
+- No raw engine-specific labels such as `sslmode` in the user-facing UI.
+
+## Approaches Considered
+
+### Replace the SSL switch with posture
+
+Use one segmented posture control under a `Connection security` section:
+
+`Disabled | TLS | Mutual TLS`
+
+This is the chosen design. It gives one visible control for the user's primary decision and maps cleanly onto existing fields.
+
+### Keep the SSL switch and add posture below it
+
+This keeps the current `SSL Connection` switch and adds another control after it. It was rejected because it creates two controls for the same state: off versus disabled, and TLS versus mTLS.
+
+### Keep the current source-first UI
+
+This keeps the current CA/client certificate source controls without a posture picker. It was rejected because it makes mTLS an implied side effect of choosing client certificate material instead of a first-class security posture.
+
+## Section Structure
+
+The section title is `Connection security`.
+
+The first control is a segmented posture picker:
+
+`Disabled | TLS | Mutual TLS`
+
+For new instance data sources, the default posture is `Disabled`.
+
+For existing data sources, infer posture from saved fields:
+
+- `useSsl=false` means `Disabled`.
+- `useSsl=true` with no client certificate/key means `TLS`.
+- `useSsl=true` with client certificate/key means `Mutual TLS`.
+
+## Disabled Posture
+
+When `Disabled` is selected:
+
+- Hide server identity fields.
+- Hide client identity fields.
+- Clear TLS material in the local form state before save.
+
+This avoids hidden TLS configuration under a visibly disabled posture.
+
+## TLS Posture
+
+When `TLS` is selected, show the `Server identity` group.
+
+The group contains:
+
+- `Verify server certificate` toggle.
+- CA certificate source segmented control: `System trust | Paste PEM | File path`.
+- CA material input only when the selected source needs input.
+
+When `Verify server certificate` is on and CA source is `System trust`, show helper text:
+
+`Uses the system trust store to verify the server certificate.`
+
+When `Verify server certificate` is off, keep CA source and CA inputs enabled, but show this explanation:
+
+`Verification is disabled. The connection is encrypted, but the server identity is not verified; CA settings are ignored.`
+
+Do not clear CA material merely because verification is turned off. Users may turn verification off temporarily and should not lose the CA configuration unless they switch the entire posture to `Disabled` or change the CA source.
+
+## Mutual TLS Posture
+
+When `Mutual TLS` is selected, show both `Server identity` and `Client identity`.
+
+`Server identity` behaves the same as in the `TLS` posture. `System trust` remains available because mTLS does not require a private CA for the server certificate.
+
+`Client identity` contains:
+
+- Client material source segmented control: `Paste PEM | File path`.
+- `Certificate` input.
+- `Private key` input.
+
+Do not show a `None` option inside `Client identity`. If users do not want client identity, they should choose the `TLS` posture.
+
+Do not add helper copy saying certificate and private key are required together. The backend already validates the pair. The fields should still be visually grouped in one `Client identity` block.
+
+## Source Labels
+
+Use user-facing labels:
+
+- `Paste PEM`, not `Inline PEM`.
+- `File path`, not engine-specific or field-specific source labels.
+
+Use specific input labels:
+
+- `CA certificate path`.
+- `Certificate path`.
+- `Private key path`.
+- `Certificate`.
+- `Private key`.
+
+Keep existing drag-and-drop behavior for PEM textareas even though the source option says `Paste PEM`.
+
+## SaaS Mode
+
+Bytebase SaaS mode should disable file-path source options because local Bytebase server paths are unavailable in Bytebase Cloud.
+
+Use the existing frontend SaaS signal: `actuatorStore.isSaaSMode`, read from React via `useVueState`.
+
+When SaaS mode is active:
+
+- Disable `File path` in the CA source control.
+- Disable `File path` in the Client identity source control.
+- Show a hover tooltip on disabled file-path options:
+
+`File paths are unavailable in Bytebase Cloud.`
+
+If an existing data source already has file-path TLS material, show the file-path source as selected but disabled. The UI must represent saved state truthfully instead of silently switching to `System trust` or `Paste PEM`.
+
+## Engine Support
+
+For engines where the form does not support client certificate/key material, keep the `Mutual TLS` posture option visible but disabled.
+
+Show a hover tooltip on the disabled `Mutual TLS` option:
+
+`Mutual TLS is not available for this engine.`
+
+If an existing saved data source has client certificate/key material, show `Mutual TLS` as selected even if the normal creation path would disable selecting it. Saved state should be represented truthfully.
+
+## State Changes
+
+Switching from `Mutual TLS` to `TLS` clears client certificate/key fields immediately.
+
+Switching from `TLS` or `Mutual TLS` to `Disabled` clears CA material and client certificate/key material immediately.
+
+Switching CA source clears inactive CA fields only. It must not clear client certificate/key fields.
+
+Switching client identity source clears inactive client certificate/key fields only. It must not clear CA fields.
+
+## Testing
+
+Frontend tests should cover:
+
+- New data sources default to `Disabled`.
+- Existing data sources infer `Disabled`, `TLS`, and `Mutual TLS` from existing fields.
+- Switching `Mutual TLS` to `TLS` clears client certificate/key material.
+- Switching to `Disabled` clears TLS material.
+- Turning verification off keeps CA controls enabled and keeps CA material.
+- SaaS mode disables file-path source options and shows the SaaS tooltip.
+- Existing file-path saved state remains visibly selected but disabled in SaaS mode.
+- Unsupported engines show disabled `Mutual TLS` with the unsupported-engine tooltip.
+- Existing client certificate/key saved state renders as `Mutual TLS` even for engines that normally cannot select it.
+- Labels use `Connection security`, `TLS`, `Mutual TLS`, `Server identity`, `Client identity`, `Paste PEM`, `Certificate`, and `Private key`.

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -600,7 +600,6 @@
     },
     "ssl": {
       "ca-cert": "CA Certificate",
-      "ca-empty-uses-system-trust": "Leave empty to use the system trust store",
       "ca-path": "CA Certificate Path",
       "ca-placeholder": "Input or drag and drop YOUR_CA_CERTIFICATE",
       "ca-source": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -600,7 +600,6 @@
     },
     "ssl": {
       "ca-cert": "Certificado de CA",
-      "ca-empty-uses-system-trust": "Dejar vacío para usar la tienda de confianza del sistema",
       "ca-path": "Ruta del certificado de CA",
       "ca-placeholder": "Ingrese o arrastre y suelte YOUR_CA_CERTIFICATE",
       "ca-source": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -600,7 +600,6 @@
     },
     "ssl": {
       "ca-cert": "CA証明書",
-      "ca-empty-uses-system-trust": "空欄のままにすると、システムの信頼ストアを使用します",
       "ca-path": "CA証明書のパス",
       "ca-placeholder": "YOUR_CA_CERTIFICATEを入力またはドラッグ＆ドロップ",
       "ca-source": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -600,7 +600,6 @@
     },
     "ssl": {
       "ca-cert": "Chứng chỉ CA",
-      "ca-empty-uses-system-trust": "Để trống để dùng kho tin cậy của hệ thống",
       "ca-path": "Đường dẫn chứng chỉ CA",
       "ca-placeholder": "Nhập hoặc kéo thả YOUR_CA_CERTIFICATE",
       "ca-source": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -600,7 +600,6 @@
     },
     "ssl": {
       "ca-cert": "CA 证书",
-      "ca-empty-uses-system-trust": "留空以使用系统信任存储",
       "ca-path": "CA 证书路径",
       "ca-placeholder": "输入或拖放 YOUR_CA_CERTIFICATE",
       "ca-source": {

--- a/frontend/src/react/components/instance/DataSourceForm.tsx
+++ b/frontend/src/react/components/instance/DataSourceForm.tsx
@@ -6,7 +6,7 @@ import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { useVueState } from "@/react/hooks/useVueState";
-import { useSubscriptionV1Store } from "@/store";
+import { useActuatorV1Store, useSubscriptionV1Store } from "@/store";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import {
   DataSource_AuthenticationType,
@@ -35,9 +35,17 @@ import { SslCertificateForm } from "./SslCertificateForm";
 import {
   applyLocalTlsCaSource,
   applyLocalTlsClientCertSource,
+  applyLocalTlsPosture,
   disableLocalTls,
   getLocalTlsCaSource,
   getLocalTlsClientCertSource,
+  getLocalTlsPosture,
+  LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM,
+  LOCAL_TLS_CLIENT_CERT_SOURCE_NONE,
+  LOCAL_TLS_POSTURE_DISABLED,
+  LOCAL_TLS_POSTURE_MUTUAL_TLS,
+  LOCAL_TLS_POSTURE_TLS,
+  type LocalTlsPosture,
 } from "./tls";
 
 interface DataSourceFormProps {
@@ -81,6 +89,8 @@ export function DataSourceForm({
   const { t } = useTranslation();
   const subscriptionStore = useSubscriptionV1Store();
   const currentPlan = useVueState(() => subscriptionStore.currentPlan);
+  const actuatorStore = useActuatorV1Store();
+  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
   const ctx = useInstanceFormContext();
   const {
     instance,
@@ -117,6 +127,9 @@ export function DataSourceForm({
   const [localTlsClientCertSource, setLocalTlsClientCertSource] = useState(
     getLocalTlsClientCertSource(dataSource)
   );
+  const [localTlsPosture, setLocalTlsPosture] = useState(
+    getLocalTlsPosture(dataSource)
+  );
   const previousDataSourceIdRef = useRef(dataSource.id);
 
   // Sync passwordType when externalSecret changes
@@ -135,11 +148,13 @@ export function DataSourceForm({
       previousDataSourceIdRef.current = dataSource.id;
       setLocalTlsCaSource(getLocalTlsCaSource(dataSource));
       setLocalTlsClientCertSource(getLocalTlsClientCertSource(dataSource));
+      setLocalTlsPosture(getLocalTlsPosture(dataSource));
       return;
     }
     if (!dataSource.updateSsl) {
       setLocalTlsCaSource(getLocalTlsCaSource(dataSource));
       setLocalTlsClientCertSource(getLocalTlsClientCertSource(dataSource));
+      setLocalTlsPosture(getLocalTlsPosture(dataSource));
     }
   }, [
     dataSource.id,
@@ -489,6 +504,42 @@ export function DataSourceForm({
     };
     reader.readAsArrayBuffer(file);
   };
+
+  const onLocalTlsPostureChange = useCallback(
+    (posture: LocalTlsPosture) => {
+      setLocalTlsPosture(posture);
+      if (posture === LOCAL_TLS_POSTURE_DISABLED) {
+        setLocalTlsCaSource("SYSTEM_TRUST");
+        setLocalTlsClientCertSource(LOCAL_TLS_CLIENT_CERT_SOURCE_NONE);
+        update({ ...disableLocalTls(dataSource), updateSsl: true });
+        return;
+      }
+
+      const next = applyLocalTlsPosture(dataSource, posture);
+      const enablingTls = !dataSource.useSsl;
+      if (posture === LOCAL_TLS_POSTURE_TLS) {
+        setLocalTlsClientCertSource(LOCAL_TLS_CLIENT_CERT_SOURCE_NONE);
+      }
+      if (
+        posture === LOCAL_TLS_POSTURE_MUTUAL_TLS &&
+        localTlsClientCertSource === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
+      ) {
+        setLocalTlsClientCertSource(LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM);
+      }
+
+      update({
+        ...next,
+        verifyTlsCertificate: enablingTls
+          ? true
+          : dataSource.verifyTlsCertificate,
+        updateSsl: mergeTlsUpdateState(dataSource.updateSsl, {
+          useSsl: true,
+          clientCert: posture === LOCAL_TLS_POSTURE_TLS,
+        }),
+      });
+    },
+    [dataSource, localTlsClientCertSource, update]
+  );
 
   return (
     <div className="grid grid-cols-1 gap-y-4 gap-x-4 border-none sm:grid-cols-3">
@@ -1647,7 +1698,7 @@ export function DataSourceForm({
           {showSSL && isPasswordAuth && (
             <div className="sm:col-span-3 sm:col-start-1">
               <div className="flex items-center justify-start gap-x-2 textlabel">
-                {t("data-source.ssl-connection")}
+                {t("data-source.ssl.connection-security")}
                 {isCreating && onOpenInfoPanel && hasSslInfo && (
                   <button
                     type="button"
@@ -1674,6 +1725,9 @@ export function DataSourceForm({
                   setLocalTlsClientCertSource("NONE");
                   update({ ...disableLocalTls(dataSource), updateSsl: true });
                 }}
+                posture={localTlsPosture}
+                onPostureChange={onLocalTlsPostureChange}
+                isSaaSMode={isSaaSMode}
                 caSource={localTlsCaSource}
                 onCaSourceChange={(source) => {
                   setLocalTlsCaSource(source);

--- a/frontend/src/react/components/instance/InstanceFormBody.i18n.test.ts
+++ b/frontend/src/react/components/instance/InstanceFormBody.i18n.test.ts
@@ -1,0 +1,39 @@
+import i18next from "i18next";
+import { describe, expect, test } from "vitest";
+import enUS from "@/react/locales/en-US.json";
+import esES from "@/react/locales/es-ES.json";
+import jaJP from "@/react/locales/ja-JP.json";
+import viVN from "@/react/locales/vi-VN.json";
+import zhCN from "@/react/locales/zh-CN.json";
+
+const LOCALES = {
+  "en-US": enUS,
+  "zh-CN": zhCN,
+  "es-ES": esES,
+  "ja-JP": jaJP,
+  "vi-VN": viVN,
+} as const;
+
+describe("Instance form locale interpolation", () => {
+  test.each(
+    Object.entries(LOCALES)
+  )("renders host and proxy placeholders literally in %s", (locale, translation) => {
+    const i18n = i18next.createInstance();
+
+    void i18n.init({
+      resources: {
+        [locale]: { translation },
+      },
+      lng: locale,
+      interpolation: {
+        escapeValue: false,
+      },
+      initImmediate: false,
+    });
+
+    expect(i18n.t("instance.sentence.host.none-snowflake")).toContain(" | ");
+    expect(i18n.t("instance.sentence.host.none-snowflake")).not.toContain("{");
+    expect(i18n.t("instance.sentence.proxy.snowflake")).toContain("@");
+    expect(i18n.t("instance.sentence.proxy.snowflake")).not.toContain("{");
+  });
+});

--- a/frontend/src/react/components/instance/SslCertificateForm.test.tsx
+++ b/frontend/src/react/components/instance/SslCertificateForm.test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, test, vi } from "vitest";
@@ -14,12 +15,27 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
+vi.mock("@/react/components/ui/tooltip", () => ({
+  Tooltip: ({
+    content,
+    children,
+  }: {
+    content: ReactNode;
+    children: ReactNode;
+  }) => (
+    <span data-tooltip={typeof content === "string" ? content : undefined}>
+      {children}
+      {content}
+    </span>
+  ),
+}));
+
 describe("SslCertificateForm", () => {
   afterEach(() => {
     document.body.innerHTML = "";
   });
 
-  test("renders the CA trust hint for inline PEM input", () => {
+  test("does not render the CA trust hint", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -35,7 +51,7 @@ describe("SslCertificateForm", () => {
       );
     });
 
-    expect(container.textContent).toContain(
+    expect(container.textContent).not.toContain(
       "data-source.ssl.ca-empty-uses-system-trust"
     );
 
@@ -44,7 +60,7 @@ describe("SslCertificateForm", () => {
     });
   });
 
-  test("renders explicit CA and client certificate source controls", () => {
+  test("renders posture-first connection security controls", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);
     const root = createRoot(container);
@@ -52,26 +68,380 @@ describe("SslCertificateForm", () => {
     act(() => {
       root.render(
         <SslCertificateForm
-          useSsl={true}
+          posture="TLS"
+          onPostureChange={() => {}}
           caSource="SYSTEM_TRUST"
           onCaSourceChange={() => {}}
-          clientCertSource="FILE_PATH"
+          clientCertSource="NONE"
           onClientCertSourceChange={() => {}}
-          showKeyAndCert={true}
+          useSsl={true}
+          verify={true}
+          onVerifyChange={() => {}}
+          engineType={Engine.POSTGRES}
         />
       );
     });
 
-    expect(container.textContent).toContain("data-source.ssl.ca-source.self");
-    expect(container.textContent).toContain(
-      "data-source.ssl.ca-source.system-trust"
+    expect(container.textContent).not.toContain(
+      "data-source.ssl.connection-security"
     );
+    expect(container.textContent).toContain("data-source.ssl.posture.disabled");
+    expect(container.textContent).toContain("data-source.ssl.posture.tls");
     expect(container.textContent).toContain(
-      "data-source.ssl.client-cert-source.self"
+      "data-source.ssl.posture.mutual-tls"
+    );
+    expect(container.textContent).not.toContain("data-source.ssl.posture.self");
+    expect(
+      container.querySelector('[aria-label="data-source.ssl.posture.self"]')
+    ).not.toBeNull();
+    expect(
+      container
+        .querySelector('[aria-label="data-source.ssl.posture.self"]')
+        ?.classList.contains("self-start")
+    ).toBe(true);
+    const selectedPostureInput = container.querySelector(
+      '[aria-label="data-source.ssl.posture.self"] [aria-checked="true"]'
+    );
+    const selectedPostureLabel = selectedPostureInput?.closest("label");
+    expect(
+      Array.from(selectedPostureLabel?.classList ?? []).some((className) =>
+        /^z-\d+$/.test(className)
+      )
+    ).toBe(false);
+    expect(
+      selectedPostureLabel?.classList.contains("focus-within:ring-inset")
+    ).toBe(true);
+    expect(
+      selectedPostureLabel?.nextElementSibling?.classList.contains("border-l")
+    ).toBe(false);
+    expect(container.textContent).toContain("data-source.ssl.server-identity");
+    expect(container.textContent).not.toContain(
+      "data-source.ssl.ca-empty-uses-system-trust"
+    );
+    expect(container.textContent).not.toContain(
+      "data-source.ssl.client-identity"
+    );
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  test("renders client identity for mutual TLS without a None source option", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SslCertificateForm
+          posture="MUTUAL_TLS"
+          onPostureChange={() => {}}
+          caSource="SYSTEM_TRUST"
+          onCaSourceChange={() => {}}
+          clientCertSource="INLINE_PEM"
+          onClientCertSourceChange={() => {}}
+          useSsl={true}
+          verify={true}
+          onVerifyChange={() => {}}
+          showKeyAndCert
+          engineType={Engine.POSTGRES}
+        />
+      );
+    });
+
+    expect(container.textContent).toContain("data-source.ssl.client-identity");
+    expect(container.textContent).toContain(
+      "data-source.ssl.client-cert-source.inline-pem"
     );
     expect(container.textContent).toContain(
       "data-source.ssl.client-cert-source.file-path"
     );
+    expect(container.textContent).not.toContain(
+      "data-source.ssl.client-cert-source.none"
+    );
+    expect(
+      Array.from(container.querySelectorAll("textarea")).map((textarea) =>
+        textarea.getAttribute("placeholder")
+      )
+    ).toEqual([
+      "data-source.ssl.client-cert-placeholder",
+      "data-source.ssl.client-key-placeholder",
+    ]);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  test("keeps CA controls visible when verification is disabled", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SslCertificateForm
+          posture="TLS"
+          onPostureChange={() => {}}
+          caSource="INLINE_PEM"
+          onCaSourceChange={() => {}}
+          clientCertSource="NONE"
+          onClientCertSourceChange={() => {}}
+          useSsl={true}
+          verify={false}
+          onVerifyChange={() => {}}
+          engineType={Engine.POSTGRES}
+        />
+      );
+    });
+
+    expect(container.textContent).toContain(
+      "data-source.ssl.verification-disabled-description"
+    );
+    expect(container.textContent).toContain("data-source.ssl.ca-source.self");
+    expect(container.textContent).not.toContain(
+      "data-source.ssl.ca-empty-uses-system-trust"
+    );
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  test("falls back to legacy UI when posture source props are incomplete", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SslCertificateForm
+          posture="TLS"
+          onPostureChange={() => {}}
+          useSsl={true}
+          onUseSslChange={() => {}}
+          verify={true}
+          onVerifyChange={() => {}}
+          engineType={Engine.POSTGRES}
+        />
+      );
+    });
+
+    expect(container.textContent).not.toContain(
+      "data-source.ssl.connection-security"
+    );
+    expect(container.textContent).toContain("data-source.ssl-connection");
+    expect(container.textContent).not.toContain(
+      "data-source.ssl.ca-empty-uses-system-trust"
+    );
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  test("disables file path source options in SaaS mode", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SslCertificateForm
+          posture="MUTUAL_TLS"
+          onPostureChange={() => {}}
+          caSource="FILE_PATH"
+          onCaSourceChange={() => {}}
+          clientCertSource="FILE_PATH"
+          onClientCertSourceChange={() => {}}
+          useSsl={true}
+          verify={true}
+          onVerifyChange={() => {}}
+          isSaaSMode
+          showKeyAndCert
+          engineType={Engine.POSTGRES}
+        />
+      );
+    });
+
+    expect(
+      container.querySelector(
+        '[aria-label="data-source.ssl.ca-source.self"] [aria-disabled="true"][aria-checked="true"]'
+      )
+    ).not.toBeNull();
+    expect(
+      container.querySelector(
+        '[aria-label="data-source.ssl.client-cert-source.self"] [aria-disabled="true"][aria-checked="true"]'
+      )
+    ).not.toBeNull();
+    expect(
+      container.querySelector<HTMLInputElement>(
+        '[data-testid="tls-ca-path-input"]'
+      )?.disabled
+    ).toBe(true);
+    expect(
+      container.querySelector<HTMLInputElement>(
+        '[data-testid="tls-cert-path-input"]'
+      )?.disabled
+    ).toBe(true);
+    expect(
+      container.querySelector<HTMLInputElement>(
+        '[data-testid="tls-key-path-input"]'
+      )?.disabled
+    ).toBe(true);
+    expect(container.textContent).toContain(
+      "data-source.ssl.ca-source.file-path-unavailable-saas"
+    );
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  test("shows disabled mutual TLS for unsupported engines", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SslCertificateForm
+          posture="TLS"
+          onPostureChange={() => {}}
+          caSource="SYSTEM_TRUST"
+          onCaSourceChange={() => {}}
+          clientCertSource="NONE"
+          onClientCertSourceChange={() => {}}
+          useSsl={true}
+          verify={true}
+          onVerifyChange={() => {}}
+          engineType={Engine.MSSQL}
+        />
+      );
+    });
+
+    expect(container.textContent).toContain(
+      "data-source.ssl.mutual-tls-unavailable-engine"
+    );
+    expect(container.querySelector('[aria-disabled="true"]')).not.toBeNull();
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  test("falls back from mutual TLS for unsupported engines without saved client identity", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SslCertificateForm
+          posture="MUTUAL_TLS"
+          onPostureChange={() => {}}
+          caSource="SYSTEM_TRUST"
+          onCaSourceChange={() => {}}
+          clientCertSource="NONE"
+          onClientCertSourceChange={() => {}}
+          useSsl={true}
+          verify={true}
+          onVerifyChange={() => {}}
+          engineType={Engine.MSSQL}
+        />
+      );
+    });
+
+    expect(container.textContent).toContain(
+      "data-source.ssl.mutual-tls-unavailable-engine"
+    );
+    expect(container.querySelector('[aria-disabled="true"]')).not.toBeNull();
+    expect(
+      container.querySelector(
+        '[aria-label="data-source.ssl.posture.self"] [aria-disabled="true"][aria-checked="true"]'
+      )
+    ).toBeNull();
+    expect(container.textContent).not.toContain(
+      "data-source.ssl.client-identity"
+    );
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  test("does not treat non-none source as saved client identity for unsupported engines", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SslCertificateForm
+          posture="MUTUAL_TLS"
+          onPostureChange={() => {}}
+          caSource="SYSTEM_TRUST"
+          onCaSourceChange={() => {}}
+          clientCertSource="FILE_PATH"
+          onClientCertSourceChange={() => {}}
+          useSsl={true}
+          verify={true}
+          onVerifyChange={() => {}}
+          engineType={Engine.MSSQL}
+        />
+      );
+    });
+
+    expect(container.textContent).toContain(
+      "data-source.ssl.mutual-tls-unavailable-engine"
+    );
+    expect(
+      container.querySelector(
+        '[aria-label="data-source.ssl.posture.self"] [aria-disabled="true"][aria-checked="true"]'
+      )
+    ).toBeNull();
+    expect(container.textContent).not.toContain(
+      "data-source.ssl.client-identity"
+    );
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  test("renders saved mutual TLS identity for unsupported engines", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <SslCertificateForm
+          posture="MUTUAL_TLS"
+          onPostureChange={() => {}}
+          caSource="SYSTEM_TRUST"
+          onCaSourceChange={() => {}}
+          clientCertSource="INLINE_PEM"
+          onClientCertSourceChange={() => {}}
+          useSsl={true}
+          verify={true}
+          onVerifyChange={() => {}}
+          hasCert={true}
+          hasKey={true}
+          engineType={Engine.MSSQL}
+        />
+      );
+    });
+
+    expect(container.textContent).toContain("data-source.ssl.client-identity");
+    expect(container.textContent).toContain("data-source.ssl.client-cert");
+    expect(container.textContent).toContain("data-source.ssl.client-key");
+    expect(
+      container.querySelector(
+        '[aria-label="data-source.ssl.posture.self"] [aria-checked="true"][aria-disabled="true"]'
+      )
+    ).not.toBeNull();
 
     act(() => {
       root.unmount();

--- a/frontend/src/react/components/instance/SslCertificateForm.tsx
+++ b/frontend/src/react/components/instance/SslCertificateForm.tsx
@@ -3,7 +3,10 @@ import { type DragEvent, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Badge } from "@/react/components/ui/badge";
 import { Input } from "@/react/components/ui/input";
-import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
+import {
+  SegmentedControl,
+  type SegmentedControlOption,
+} from "@/react/components/ui/segmented-control";
 import { Switch } from "@/react/components/ui/switch";
 import {
   Tabs,
@@ -16,14 +19,19 @@ import { Engine } from "@/types/proto-es/v1/common_pb";
 import {
   getLocalTlsCaSource,
   getLocalTlsClientCertSource,
+  isLocalTlsClientIdentitySupported,
   LOCAL_TLS_CA_SOURCE_FILE_PATH,
   LOCAL_TLS_CA_SOURCE_INLINE_PEM,
   LOCAL_TLS_CA_SOURCE_SYSTEM_TRUST,
   LOCAL_TLS_CLIENT_CERT_SOURCE_FILE_PATH,
   LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM,
   LOCAL_TLS_CLIENT_CERT_SOURCE_NONE,
+  LOCAL_TLS_POSTURE_DISABLED,
+  LOCAL_TLS_POSTURE_MUTUAL_TLS,
+  LOCAL_TLS_POSTURE_TLS,
   type LocalTlsCaSource,
   type LocalTlsClientCertSource,
+  type LocalTlsPosture,
 } from "./tls";
 
 interface SslCertificateFormProps {
@@ -33,6 +41,9 @@ interface SslCertificateFormProps {
   onCaSourceChange?: (val: LocalTlsCaSource) => void;
   clientCertSource?: LocalTlsClientCertSource;
   onClientCertSourceChange?: (val: LocalTlsClientCertSource) => void;
+  posture?: LocalTlsPosture;
+  onPostureChange?: (val: LocalTlsPosture) => void;
+  isSaaSMode?: boolean;
   ca?: string;
   hasCa?: boolean;
   onCaChange?: (val: string) => void;
@@ -112,13 +123,15 @@ function CaSourceSelector({
   value,
   onChange,
   disabled = false,
+  isSaaSMode = false,
 }: {
   value: LocalTlsCaSource;
   onChange: (value: LocalTlsCaSource) => void;
   disabled?: boolean;
+  isSaaSMode?: boolean;
 }) {
   const { t } = useTranslation();
-  const options: { value: LocalTlsCaSource; label: string }[] = [
+  const options: SegmentedControlOption<LocalTlsCaSource>[] = [
     {
       value: LOCAL_TLS_CA_SOURCE_SYSTEM_TRUST,
       label: t("data-source.ssl.ca-source.system-trust"),
@@ -130,26 +143,22 @@ function CaSourceSelector({
     {
       value: LOCAL_TLS_CA_SOURCE_FILE_PATH,
       label: t("data-source.ssl.ca-source.file-path"),
+      disabled: isSaaSMode,
+      tooltip: isSaaSMode
+        ? t("data-source.ssl.ca-source.file-path-unavailable-saas")
+        : undefined,
     },
   ];
 
   return (
-    <RadioGroup
+    <SegmentedControl
       value={value}
-      onValueChange={(next) => onChange(next as LocalTlsCaSource)}
-      aria-label={t("data-source.ssl.ca-source.self")}
-      className="mt-2 gap-x-4"
-    >
-      {options.map((option) => (
-        <RadioGroupItem
-          key={option.value}
-          value={option.value}
-          disabled={disabled}
-        >
-          {option.label}
-        </RadioGroupItem>
-      ))}
-    </RadioGroup>
+      onValueChange={onChange}
+      ariaLabel={t("data-source.ssl.ca-source.self")}
+      options={options}
+      disabled={disabled}
+      className="mt-2"
+    />
   );
 }
 
@@ -157,17 +166,25 @@ function ClientCertSourceSelector({
   value,
   onChange,
   disabled = false,
+  isSaaSMode = false,
+  allowNone = false,
 }: {
   value: LocalTlsClientCertSource;
   onChange: (value: LocalTlsClientCertSource) => void;
   disabled?: boolean;
+  isSaaSMode?: boolean;
+  allowNone?: boolean;
 }) {
   const { t } = useTranslation();
-  const options: { value: LocalTlsClientCertSource; label: string }[] = [
-    {
-      value: LOCAL_TLS_CLIENT_CERT_SOURCE_NONE,
-      label: t("data-source.ssl.client-cert-source.none"),
-    },
+  const options: SegmentedControlOption<LocalTlsClientCertSource>[] = [
+    ...(allowNone
+      ? [
+          {
+            value: LOCAL_TLS_CLIENT_CERT_SOURCE_NONE,
+            label: t("data-source.ssl.client-cert-source.none"),
+          },
+        ]
+      : []),
     {
       value: LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM,
       label: t("data-source.ssl.client-cert-source.inline-pem"),
@@ -175,26 +192,22 @@ function ClientCertSourceSelector({
     {
       value: LOCAL_TLS_CLIENT_CERT_SOURCE_FILE_PATH,
       label: t("data-source.ssl.client-cert-source.file-path"),
+      disabled: isSaaSMode,
+      tooltip: isSaaSMode
+        ? t("data-source.ssl.client-cert-source.file-path-unavailable-saas")
+        : undefined,
     },
   ];
 
   return (
-    <RadioGroup
+    <SegmentedControl
       value={value}
-      onValueChange={(next) => onChange(next as LocalTlsClientCertSource)}
-      aria-label={t("data-source.ssl.client-cert-source.self")}
-      className="mt-2 gap-x-4"
-    >
-      {options.map((option) => (
-        <RadioGroupItem
-          key={option.value}
-          value={option.value}
-          disabled={disabled}
-        >
-          {option.label}
-        </RadioGroupItem>
-      ))}
-    </RadioGroup>
+      onValueChange={(next) => onChange(next)}
+      ariaLabel={t("data-source.ssl.client-cert-source.self")}
+      options={options}
+      disabled={disabled}
+      className="mt-2"
+    />
   );
 }
 
@@ -205,6 +218,9 @@ export function SslCertificateForm({
   onCaSourceChange,
   clientCertSource,
   onClientCertSourceChange,
+  posture,
+  onPostureChange,
+  isSaaSMode = false,
   ca = "",
   hasCa = false,
   onCaChange,
@@ -246,7 +262,6 @@ export function SslCertificateForm({
   const resolvedCertPathLabel = t("data-source.ssl.client-cert-path");
   const resolvedKeyPathLabel = t("data-source.ssl.client-key-path");
   const resolvedConfiguredLabel = t("data-source.ssl.configured");
-  const resolvedCaHint = t("data-source.ssl.ca-empty-uses-system-trust");
   const resolvedCaPlaceholder = t("data-source.ssl.ca-placeholder");
   const resolvedCertPlaceholder = t("data-source.ssl.client-cert-placeholder");
   const resolvedKeyPlaceholder = t("data-source.ssl.client-key-placeholder");
@@ -255,10 +270,27 @@ export function SslCertificateForm({
   const showCaSourceUi = caSource !== undefined && !!onCaSourceChange;
   const showClientCertSourceUi =
     clientCertSource !== undefined && !!onClientCertSourceChange;
+  const showPostureUi =
+    posture !== undefined &&
+    !!onPostureChange &&
+    showCaSourceUi &&
+    showClientCertSourceUi;
   const showPerGroupSourceUi = showCaSourceUi || showClientCertSourceUi;
 
+  const hasClientIdentityMaterial = !!(
+    cert ||
+    sslKey ||
+    certPath ||
+    keyPath ||
+    hasCert ||
+    hasKey ||
+    hasCertPath ||
+    hasKeyPath
+  );
   const showKeyAndCertFields =
-    showKeyAndCert || ![Engine.MSSQL].includes(engineType);
+    showKeyAndCert ||
+    ![Engine.MSSQL].includes(engineType) ||
+    hasClientIdentityMaterial;
 
   const inferredCaSource = getLocalTlsCaSource({
     useSsl: true,
@@ -300,6 +332,21 @@ export function SslCertificateForm({
     : inferredClientCertSource === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
       ? LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM
       : inferredClientCertSource;
+  const inferredPosture = resolvedUseSsl
+    ? resolvedClientCertSource === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
+      ? LOCAL_TLS_POSTURE_TLS
+      : LOCAL_TLS_POSTURE_MUTUAL_TLS
+    : LOCAL_TLS_POSTURE_DISABLED;
+  const requestedPosture =
+    showPostureUi && posture !== undefined ? posture : inferredPosture;
+  const supportsClientIdentity =
+    showKeyAndCertFields && isLocalTlsClientIdentitySupported(engineType);
+  const canShowMutualTls = supportsClientIdentity || hasClientIdentityMaterial;
+  const canSelectMutualTls = supportsClientIdentity;
+  const resolvedPosture =
+    requestedPosture === LOCAL_TLS_POSTURE_MUTUAL_TLS && !canShowMutualTls
+      ? LOCAL_TLS_POSTURE_TLS
+      : requestedPosture;
   const showConfiguredBadge = (hasStoredValue: boolean, visibleValue: string) =>
     hasStoredValue && !visibleValue;
   const renderLabel = (
@@ -316,10 +363,42 @@ export function SslCertificateForm({
       )}
     </div>
   );
+  const renderPostureControl = () => {
+    const options: SegmentedControlOption<LocalTlsPosture>[] = [
+      {
+        value: LOCAL_TLS_POSTURE_DISABLED,
+        label: t("data-source.ssl.posture.disabled"),
+      },
+      {
+        value: LOCAL_TLS_POSTURE_TLS,
+        label: t("data-source.ssl.posture.tls"),
+      },
+      {
+        value: LOCAL_TLS_POSTURE_MUTUAL_TLS,
+        label: t("data-source.ssl.posture.mutual-tls"),
+        disabled: !canSelectMutualTls,
+        tooltip: !canSelectMutualTls
+          ? t("data-source.ssl.mutual-tls-unavailable-engine")
+          : undefined,
+      },
+    ];
+
+    return (
+      <div className="flex flex-col gap-y-1">
+        <SegmentedControl
+          value={resolvedPosture}
+          onValueChange={(next) => onPostureChange?.(next)}
+          ariaLabel={t("data-source.ssl.posture.self")}
+          options={options}
+          disabled={disabled}
+        />
+      </div>
+    );
+  };
 
   const renderCaMaterial = () => {
     if (resolvedCaSource === LOCAL_TLS_CA_SOURCE_SYSTEM_TRUST) {
-      return <p className="mt-1 text-xs textinfolabel">{resolvedCaHint}</p>;
+      return null;
     }
 
     if (resolvedCaSource === LOCAL_TLS_CA_SOURCE_FILE_PATH) {
@@ -327,9 +406,10 @@ export function SslCertificateForm({
         <div className="flex flex-col gap-y-1">
           {renderLabel(resolvedCaPathLabel, hasCaPath, caPath)}
           <Input
+            data-testid="tls-ca-path-input"
             value={caPath}
             onChange={(e) => onCaPathChange?.(e.target.value)}
-            disabled={disabled}
+            disabled={disabled || isSaaSMode}
             placeholder={resolvedCaPathLabel}
           />
         </div>
@@ -345,37 +425,37 @@ export function SslCertificateForm({
           disabled={disabled}
           placeholder={resolvedCaPlaceholder}
         />
-        <p className="text-xs textinfolabel">{resolvedCaHint}</p>
       </div>
     );
   };
 
-  const renderClientCertMaterial = () => {
-    if (
-      !showKeyAndCertFields ||
-      resolvedClientCertSource === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
-    ) {
+  const renderClientCertMaterial = (
+    source: LocalTlsClientCertSource = resolvedClientCertSource
+  ) => {
+    if (!showKeyAndCertFields || source === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE) {
       return null;
     }
 
-    if (resolvedClientCertSource === LOCAL_TLS_CLIENT_CERT_SOURCE_FILE_PATH) {
+    if (source === LOCAL_TLS_CLIENT_CERT_SOURCE_FILE_PATH) {
       return (
         <div className="flex flex-col gap-y-2">
           <div className="flex flex-col gap-y-1">
             {renderLabel(resolvedCertPathLabel, hasCertPath, certPath)}
             <Input
+              data-testid="tls-cert-path-input"
               value={certPath}
               onChange={(e) => onCertPathChange?.(e.target.value)}
-              disabled={disabled}
+              disabled={disabled || isSaaSMode}
               placeholder={resolvedCertPathLabel}
             />
           </div>
           <div className="flex flex-col gap-y-1">
             {renderLabel(resolvedKeyPathLabel, hasKeyPath, keyPath)}
             <Input
+              data-testid="tls-key-path-input"
               value={keyPath}
               onChange={(e) => onKeyPathChange?.(e.target.value)}
-              disabled={disabled}
+              disabled={disabled || isSaaSMode}
               placeholder={resolvedKeyPathLabel}
             />
           </div>
@@ -386,21 +466,21 @@ export function SslCertificateForm({
     return (
       <div className="flex flex-col gap-y-2">
         <div className="flex flex-col gap-y-1">
-          {renderLabel(resolvedKeyLabel, hasKey, sslKey)}
-          <DroppableTextarea
-            value={sslKey}
-            onChange={(val) => onKeyChange?.(val)}
-            disabled={disabled}
-            placeholder={resolvedKeyPlaceholder}
-          />
-        </div>
-        <div className="flex flex-col gap-y-1">
           {renderLabel(resolvedCertLabel, hasCert, cert)}
           <DroppableTextarea
             value={cert}
             onChange={(val) => onCertChange?.(val)}
             disabled={disabled}
             placeholder={resolvedCertPlaceholder}
+          />
+        </div>
+        <div className="flex flex-col gap-y-1">
+          {renderLabel(resolvedKeyLabel, hasKey, sslKey)}
+          <DroppableTextarea
+            value={sslKey}
+            onChange={(val) => onKeyChange?.(val)}
+            disabled={disabled}
+            placeholder={resolvedKeyPlaceholder}
           />
         </div>
       </div>
@@ -414,9 +494,10 @@ export function SslCertificateForm({
           <div className="flex flex-col gap-y-1">
             {renderLabel(resolvedCaPathLabel, hasCaPath, caPath)}
             <Input
+              data-testid="tls-ca-path-input"
               value={caPath}
               onChange={(e) => onCaPathChange?.(e.target.value)}
-              disabled={disabled}
+              disabled={disabled || isSaaSMode}
               placeholder={resolvedCaPathLabel}
             />
           </div>
@@ -424,9 +505,10 @@ export function SslCertificateForm({
             <div className="flex flex-col gap-y-1">
               {renderLabel(resolvedCertPathLabel, hasCertPath, certPath)}
               <Input
+                data-testid="tls-cert-path-input"
                 value={certPath}
                 onChange={(e) => onCertPathChange?.(e.target.value)}
-                disabled={disabled}
+                disabled={disabled || isSaaSMode}
                 placeholder={resolvedCertPathLabel}
               />
             </div>
@@ -435,9 +517,10 @@ export function SslCertificateForm({
             <div className="flex flex-col gap-y-1">
               {renderLabel(resolvedKeyPathLabel, hasKeyPath, keyPath)}
               <Input
+                data-testid="tls-key-path-input"
                 value={keyPath}
                 onChange={(e) => onKeyPathChange?.(e.target.value)}
-                disabled={disabled}
+                disabled={disabled || isSaaSMode}
                 placeholder={resolvedKeyPathLabel}
               />
             </div>
@@ -491,7 +574,6 @@ export function SslCertificateForm({
             disabled={disabled}
             placeholder={resolvedCaPlaceholder}
           />
-          <p className="mt-1 text-xs textinfolabel">{resolvedCaHint}</p>
         </TabsPanel>
         {showKeyAndCertFields && (
           <TabsPanel value="KEY" className="pt-1">
@@ -517,9 +599,108 @@ export function SslCertificateForm({
     );
   };
 
+  const renderVerifyControl = () => {
+    if (!showVerify) {
+      return null;
+    }
+
+    return (
+      <div className="flex flex-row items-center gap-x-1">
+        <Switch
+          checked={verify}
+          onCheckedChange={(val) => onVerifyChange?.(val)}
+          disabled={disabled}
+        />
+        <label className="textlabel block">{resolvedVerifyLabel}</label>
+        {showTooltip && (
+          <Tooltip
+            content={t("data-source.ssl.verify-certificate-tooltip")}
+            side="right"
+          >
+            <Info className="size-4 text-warning" />
+          </Tooltip>
+        )}
+      </div>
+    );
+  };
+
+  const renderPostureMaterial = () => {
+    if (resolvedPosture === LOCAL_TLS_POSTURE_DISABLED) {
+      return null;
+    }
+
+    const clientIdentitySource =
+      resolvedClientCertSource === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
+        ? LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM
+        : resolvedClientCertSource;
+
+    return (
+      <>
+        <fieldset className="flex flex-col gap-y-2 rounded-xs border border-control-border px-3 py-2">
+          <legend className="px-1 textlabel">
+            {t("data-source.ssl.server-identity")}
+          </legend>
+          {renderVerifyControl()}
+          {!verify && (
+            <p className="text-xs textinfolabel">
+              {t("data-source.ssl.verification-disabled-description")}
+            </p>
+          )}
+          <div className="flex flex-col gap-y-2">
+            {showCaSourceUi && (
+              <div className="flex flex-col gap-y-1">
+                <label className="textlabel block">
+                  {t("data-source.ssl.ca-source.self")}
+                </label>
+                <CaSourceSelector
+                  value={resolvedCaSource}
+                  onChange={onCaSourceChange!}
+                  disabled={disabled}
+                  isSaaSMode={isSaaSMode}
+                />
+              </div>
+            )}
+            {renderCaMaterial()}
+          </div>
+        </fieldset>
+
+        {resolvedPosture === LOCAL_TLS_POSTURE_MUTUAL_TLS && (
+          <fieldset className="flex flex-col gap-y-2 rounded-xs border border-control-border px-3 py-2">
+            <legend className="px-1 textlabel">
+              {t("data-source.ssl.client-identity")}
+            </legend>
+            <div className="flex flex-col gap-y-2">
+              {showClientCertSourceUi && (
+                <div className="flex flex-col gap-y-1">
+                  <label className="textlabel block">
+                    {t("data-source.ssl.client-cert-source.self")}
+                  </label>
+                  <ClientCertSourceSelector
+                    value={clientIdentitySource}
+                    onChange={onClientCertSourceChange!}
+                    disabled={disabled}
+                    isSaaSMode={isSaaSMode}
+                  />
+                </div>
+              )}
+              {renderClientCertMaterial(clientIdentitySource)}
+            </div>
+          </fieldset>
+        )}
+      </>
+    );
+  };
+
   return (
-    <div className="mt-2 flex flex-col gap-y-2">
-      {showUseSslSwitch && (
+    <div className="mt-2 flex flex-col gap-y-3">
+      {showPostureUi && (
+        <>
+          {renderPostureControl()}
+          {renderPostureMaterial()}
+        </>
+      )}
+
+      {!showPostureUi && showUseSslSwitch && (
         <div className="flex flex-row items-center gap-x-1">
           <Switch
             checked={resolvedUseSsl}
@@ -532,26 +713,9 @@ export function SslCertificateForm({
         </div>
       )}
 
-      {resolvedUseSsl && (
+      {!showPostureUi && resolvedUseSsl && (
         <>
-          {showVerify && (
-            <div className="flex flex-row items-center gap-x-1">
-              <Switch
-                checked={verify}
-                onCheckedChange={(val) => onVerifyChange?.(val)}
-                disabled={disabled}
-              />
-              <label className="textlabel block">{resolvedVerifyLabel}</label>
-              {showTooltip && (
-                <Tooltip
-                  content={t("data-source.ssl.verify-certificate-tooltip")}
-                  side="right"
-                >
-                  <Info className="size-4 text-warning" />
-                </Tooltip>
-              )}
-            </div>
-          )}
+          {renderVerifyControl()}
 
           {!showPerGroupSourceUi ? (
             renderLegacyMaterial()
@@ -565,8 +729,9 @@ export function SslCertificateForm({
                     </label>
                     <CaSourceSelector
                       value={resolvedCaSource}
-                      onChange={onCaSourceChange}
+                      onChange={onCaSourceChange!}
                       disabled={disabled}
+                      isSaaSMode={isSaaSMode}
                     />
                   </div>
                 )}
@@ -582,8 +747,10 @@ export function SslCertificateForm({
                       </label>
                       <ClientCertSourceSelector
                         value={resolvedClientCertSource}
-                        onChange={onClientCertSourceChange}
+                        onChange={onClientCertSourceChange!}
                         disabled={disabled}
+                        isSaaSMode={isSaaSMode}
+                        allowNone
                       />
                     </div>
                   )}

--- a/frontend/src/react/components/instance/common.test.ts
+++ b/frontend/src/react/components/instance/common.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "vitest";
+import { Engine } from "@/types/proto-es/v1/common_pb";
 import {
   applyLocalTlsCaSource,
   applyLocalTlsClientCertSource,
+  applyLocalTlsPosture,
   getLocalTlsCaSource,
   getLocalTlsClientCertSource,
+  getLocalTlsPosture,
+  isLocalTlsClientIdentitySupported,
   SSL_UPDATE_MASK_FIELDS,
 } from "./tls";
 
@@ -93,5 +97,95 @@ describe("TLS local source helpers", () => {
         sslCaSet: true,
       } as never)
     ).toBe("INLINE_PEM");
+  });
+});
+
+describe("TLS posture helpers", () => {
+  test("infers disabled posture when SSL is off", () => {
+    expect(getLocalTlsPosture({ useSsl: false })).toBe("DISABLED");
+  });
+
+  test("infers TLS posture when SSL is on without client identity", () => {
+    expect(
+      getLocalTlsPosture({
+        useSsl: true,
+        sslCaPathSet: true,
+      } as never)
+    ).toBe("TLS");
+  });
+
+  test("infers mutual TLS posture from inline client material", () => {
+    expect(
+      getLocalTlsPosture({
+        useSsl: true,
+        sslCertSet: true,
+        sslKeySet: true,
+      } as never)
+    ).toBe("MUTUAL_TLS");
+  });
+
+  test("infers mutual TLS posture from file path client material", () => {
+    expect(
+      getLocalTlsPosture({
+        useSsl: true,
+        sslCertPathSet: true,
+        sslKeyPathSet: true,
+      } as never)
+    ).toBe("MUTUAL_TLS");
+  });
+
+  test("switching posture to TLS clears only client identity fields", () => {
+    const next = applyLocalTlsPosture(
+      {
+        useSsl: true,
+        sslCaPath: "/tmp/ca.pem",
+        sslCaPathSet: true,
+        sslCert: "inline-cert",
+        sslKey: "inline-key",
+        sslCertPath: "/tmp/cert.pem",
+        sslKeyPath: "/tmp/key.pem",
+        sslCertSet: true,
+        sslKeySet: true,
+        sslCertPathSet: true,
+        sslKeyPathSet: true,
+      } as never,
+      "TLS"
+    );
+
+    expect(next.useSsl).toBe(true);
+    expect(next.sslCaPath).toBe("/tmp/ca.pem");
+    expect(next.sslCaPathSet).toBe(true);
+    expect(next.sslCert).toBe("");
+    expect(next.sslKey).toBe("");
+    expect(next.sslCertPath).toBe("");
+    expect(next.sslKeyPath).toBe("");
+    expect(next.sslCertSet).toBe(false);
+    expect(next.sslKeySet).toBe(false);
+    expect(next.sslCertPathSet).toBe(false);
+    expect(next.sslKeyPathSet).toBe(false);
+  });
+
+  test("switching posture to disabled clears all TLS material", () => {
+    const next = applyLocalTlsPosture(
+      {
+        useSsl: true,
+        sslCa: "inline-ca",
+        sslCaPath: "/tmp/ca.pem",
+        sslCert: "inline-cert",
+        sslKey: "inline-key",
+      } as never,
+      "DISABLED"
+    );
+
+    expect(next.useSsl).toBe(false);
+    expect(next.sslCa).toBe("");
+    expect(next.sslCaPath).toBe("");
+    expect(next.sslCert).toBe("");
+    expect(next.sslKey).toBe("");
+  });
+
+  test("MSSQL does not support client identity in this form", () => {
+    expect(isLocalTlsClientIdentitySupported(Engine.MSSQL)).toBe(false);
+    expect(isLocalTlsClientIdentitySupported(Engine.POSTGRES)).toBe(true);
   });
 });

--- a/frontend/src/react/components/instance/tls.ts
+++ b/frontend/src/react/components/instance/tls.ts
@@ -1,4 +1,5 @@
 import { cloneDeep } from "lodash-es";
+import { Engine } from "@/types/proto-es/v1/common_pb";
 import type { DataSource } from "@/types/proto-es/v1/instance_service_pb";
 
 export const LOCAL_TLS_SOURCE_DISABLED = "DISABLED" as const;
@@ -27,6 +28,15 @@ export type LocalTlsClientCertSource =
   | typeof LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
   | typeof LOCAL_TLS_CLIENT_CERT_SOURCE_INLINE_PEM
   | typeof LOCAL_TLS_CLIENT_CERT_SOURCE_FILE_PATH;
+
+export const LOCAL_TLS_POSTURE_DISABLED = "DISABLED" as const;
+export const LOCAL_TLS_POSTURE_TLS = "TLS" as const;
+export const LOCAL_TLS_POSTURE_MUTUAL_TLS = "MUTUAL_TLS" as const;
+
+export type LocalTlsPosture =
+  | typeof LOCAL_TLS_POSTURE_DISABLED
+  | typeof LOCAL_TLS_POSTURE_TLS
+  | typeof LOCAL_TLS_POSTURE_MUTUAL_TLS;
 
 export const SSL_UPDATE_MASK_FIELDS = [
   "use_ssl",
@@ -125,6 +135,21 @@ export const getLocalTlsClientCertSource = (
   return LOCAL_TLS_CLIENT_CERT_SOURCE_NONE;
 };
 
+export const getLocalTlsPosture = (
+  ds: LocalTlsDataSource | undefined
+): LocalTlsPosture => {
+  if (!ds?.useSsl) {
+    return LOCAL_TLS_POSTURE_DISABLED;
+  }
+  return getLocalTlsClientCertSource(ds) === LOCAL_TLS_CLIENT_CERT_SOURCE_NONE
+    ? LOCAL_TLS_POSTURE_TLS
+    : LOCAL_TLS_POSTURE_MUTUAL_TLS;
+};
+
+export const isLocalTlsClientIdentitySupported = (engine: Engine): boolean => {
+  return engine !== Engine.MSSQL;
+};
+
 export const applyLocalTlsCaSource = (
   ds: DataSource,
   source: LocalTlsCaSource
@@ -175,6 +200,24 @@ export const applyLocalTlsClientCertSource = (
       break;
   }
   return next;
+};
+
+export const applyLocalTlsPosture = (
+  ds: DataSource,
+  posture: LocalTlsPosture
+): DataSource => {
+  const next = cloneDeep(ds);
+  switch (posture) {
+    case LOCAL_TLS_POSTURE_DISABLED:
+      return disableLocalTls(next);
+    case LOCAL_TLS_POSTURE_TLS:
+      next.useSsl = true;
+      clearLocalTlsClientCertFields(next);
+      return next;
+    case LOCAL_TLS_POSTURE_MUTUAL_TLS:
+      next.useSsl = true;
+      return next;
+  }
 };
 
 export const disableLocalTls = (ds: DataSource): DataSource => {

--- a/frontend/src/react/components/ui/segmented-control.tsx
+++ b/frontend/src/react/components/ui/segmented-control.tsx
@@ -1,0 +1,96 @@
+import { Radio } from "@base-ui/react/radio";
+import { RadioGroup as BaseRadioGroup } from "@base-ui/react/radio-group";
+import type { ReactNode } from "react";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { cn } from "@/react/lib/utils";
+
+export interface SegmentedControlOption<T extends string> {
+  value: T;
+  label: ReactNode;
+  disabled?: boolean;
+  tooltip?: ReactNode;
+}
+
+interface SegmentedControlProps<T extends string> {
+  value: T;
+  options: SegmentedControlOption<T>[];
+  onValueChange: (value: T) => void;
+  ariaLabel: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function SegmentedControl<T extends string>({
+  value,
+  options,
+  onValueChange,
+  ariaLabel,
+  disabled = false,
+  className,
+}: SegmentedControlProps<T>) {
+  return (
+    <BaseRadioGroup
+      value={value}
+      onValueChange={(nextValue) => {
+        onValueChange(nextValue as T);
+      }}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      className={cn(
+        "inline-flex max-w-full flex-wrap self-start rounded-xs border border-control-border bg-background",
+        className
+      )}
+    >
+      {options.map((option, index) => {
+        const selected = option.value === value;
+        const previousSelected =
+          index > 0 && options[index - 1]?.value === value;
+        const optionDisabled = disabled || option.disabled;
+        const segment = (
+          <label
+            key={option.value}
+            className={cn(
+              "relative inline-flex min-h-8 items-center justify-center px-3 text-sm transition-colors focus-within:outline-hidden focus-within:ring-2 focus-within:ring-accent focus-within:ring-inset",
+              index > 0 &&
+                !previousSelected &&
+                "border-l border-control-border",
+              selected
+                ? "bg-accent text-accent-text"
+                : "bg-background text-control hover:bg-control-bg",
+              optionDisabled &&
+                "cursor-not-allowed opacity-50 hover:bg-background"
+            )}
+          >
+            <Radio.Root
+              value={option.value}
+              disabled={optionDisabled}
+              aria-checked={selected}
+              aria-disabled={optionDisabled || undefined}
+              data-state={selected ? "checked" : "unchecked"}
+              data-disabled={optionDisabled || undefined}
+              className="sr-only"
+            />
+            <span
+              className={cn(
+                "pointer-events-none select-none",
+                optionDisabled && "cursor-not-allowed"
+              )}
+            >
+              {option.label}
+            </span>
+          </label>
+        );
+
+        if (!option.tooltip) {
+          return segment;
+        }
+
+        return (
+          <Tooltip key={option.value} content={option.tooltip}>
+            {segment}
+          </Tooltip>
+        );
+      })}
+    </BaseRadioGroup>
+  );
+}

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -529,29 +529,41 @@
     },
     "ssl": {
       "ca-cert": "CA Certificate",
-      "ca-empty-uses-system-trust": "Leave empty to use the system trust store",
       "ca-path": "CA Certificate Path",
       "ca-placeholder": "Input or drag and drop YOUR_CA_CERTIFICATE",
       "ca-source": {
-        "file-path": "File Path",
-        "inline-pem": "Inline PEM",
-        "self": "CA Certificate Source",
-        "system-trust": "System Trust"
+        "file-path": "File path",
+        "file-path-unavailable-saas": "File paths are unavailable in Bytebase Cloud.",
+        "inline-pem": "Paste PEM",
+        "self": "CA certificate source",
+        "system-trust": "System trust"
       },
-      "client-cert": "Client Certificate",
-      "client-cert-path": "Client Certificate Path",
+      "client-cert": "Certificate",
+      "client-cert-path": "Certificate path",
       "client-cert-placeholder": "Input or drag and drop YOUR_CLIENT_CERT",
       "client-cert-source": {
-        "file-path": "File Path",
-        "inline-pem": "Inline PEM",
+        "file-path": "File path",
+        "file-path-unavailable-saas": "File paths are unavailable in Bytebase Cloud.",
+        "inline-pem": "Paste PEM",
         "none": "None",
-        "self": "Client Certificate Source"
+        "self": "Client identity source"
       },
-      "client-key": "Client Key",
-      "client-key-path": "Client Key Path",
+      "client-identity": "Client identity",
+      "client-key": "Private key",
+      "client-key-path": "Private key path",
       "client-key-placeholder": "Input or drag and drop YOUR_CLIENT_KEY",
       "configured": "Configured",
-      "verify-certificate": "Verify TLS certificate",
+      "connection-security": "Connection security",
+      "mutual-tls-unavailable-engine": "Mutual TLS is not available for this engine.",
+      "posture": {
+        "disabled": "Disabled",
+        "mutual-tls": "Mutual TLS",
+        "self": "TLS mode",
+        "tls": "TLS"
+      },
+      "server-identity": "Server identity",
+      "verification-disabled-description": "Verification is disabled. The connection is encrypted, but the server identity is not verified; CA settings are ignored.",
+      "verify-certificate": "Verify server certificate",
       "verify-certificate-tooltip": "Enable TLS certificate verification for secure connections. Disable only for development or when certificates cannot be properly validated (e.g., self-signed certs, VPN environments). Warning: Disabling verification is insecure"
     },
     "ssl-connection": "SSL Connection"
@@ -582,7 +594,6 @@
   "data-source.ssh.user": "User",
   "data-source.ssl-connection": "SSL Connection",
   "data-source.ssl.ca-cert": "CA Certificate",
-  "data-source.ssl.ca-empty-uses-system-trust": "Leave empty to use the system trust store",
   "data-source.ssl.ca-path": "CA Certificate Path",
   "data-source.ssl.client-cert": "Client Certificate",
   "data-source.ssl.client-cert-path": "Client Certificate Path",
@@ -943,10 +954,10 @@
         }
       },
       "host": {
-        "none-snowflake": "e.g. host.docker.internal {{'|'}} host ip {{'|'}} local socket"
+        "none-snowflake": "e.g. host.docker.internal | host ip | local socket"
       },
       "proxy": {
-        "snowflake": "For proxy server, append {{'@'}}PROXY_HOST and specify PROXY_PORT in the port"
+        "snowflake": "For proxy server, append @PROXY_HOST and specify PROXY_PORT in the port"
       }
     },
     "show-how-to-create": "Show how to create",
@@ -1075,8 +1086,8 @@
   "instance.sentence.google-cloud-sql.instance-name-tips": "The instance connection name should like {{instance}}.",
   "instance.sentence.google-cloud-sql.mysql.template": "Create a service account named {{user}}, then add it in your Google Cloud SQL as IAM user {{user}}@'%'. Grant this user with the needed privileges.",
   "instance.sentence.google-cloud-sql.postgresql.template": "Create a service account named {{user}}, then add it in your Google Cloud SQL as IAM user {{user}}@project-id.iam. Grant the user with the needed privileges.",
-  "instance.sentence.host.none-snowflake": "e.g. host.docker.internal {'|'} host ip {'|'} local socket",
-  "instance.sentence.proxy.snowflake": "For proxy server, append {'@'}PROXY_HOST and specify PROXY_PORT in the port",
+  "instance.sentence.host.none-snowflake": "e.g. host.docker.internal | host ip | local socket",
+  "instance.sentence.proxy.snowflake": "For proxy server, append @PROXY_HOST and specify PROXY_PORT in the port",
   "instance.show-how-to-create": "Show how to create",
   "instance.snowflake-web-console": "Snowflake Web Console",
   "instance.successfully-archived-instance": "Successfully archived the instance '{{0}}'.",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -529,29 +529,41 @@
     },
     "ssl": {
       "ca-cert": "Certificado de CA",
-      "ca-empty-uses-system-trust": "Dejar vacío para usar la tienda de confianza del sistema",
       "ca-path": "Ruta del certificado de CA",
       "ca-placeholder": "Ingrese o arrastre y suelte YOUR_CA_CERTIFICATE",
       "ca-source": {
         "file-path": "Ruta de archivo",
-        "inline-pem": "PEM en línea",
+        "file-path-unavailable-saas": "Las rutas de archivo no están disponibles en Bytebase Cloud.",
+        "inline-pem": "Pegar PEM",
         "self": "Origen del certificado de CA",
         "system-trust": "Confianza del sistema"
       },
-      "client-cert": "Certificado del cliente",
-      "client-cert-path": "Ruta del certificado del cliente",
+      "client-cert": "Certificado",
+      "client-cert-path": "Ruta del certificado",
       "client-cert-placeholder": "Ingrese o arrastre y suelte YOUR_CLIENT_CERT",
       "client-cert-source": {
         "file-path": "Ruta de archivo",
-        "inline-pem": "PEM en línea",
+        "file-path-unavailable-saas": "Las rutas de archivo no están disponibles en Bytebase Cloud.",
+        "inline-pem": "Pegar PEM",
         "none": "Ninguno",
-        "self": "Origen del certificado del cliente"
+        "self": "Origen de la identidad del cliente"
       },
-      "client-key": "Clave del cliente",
-      "client-key-path": "Ruta de la clave del cliente",
+      "client-identity": "Identidad del cliente",
+      "client-key": "Clave privada",
+      "client-key-path": "Ruta de la clave privada",
       "client-key-placeholder": "Ingrese o arrastre y suelte YOUR_CLIENT_KEY",
       "configured": "Configurado",
-      "verify-certificate": "Verificar certificado TLS",
+      "connection-security": "Seguridad de la conexión",
+      "mutual-tls-unavailable-engine": "El TLS mutuo no está disponible para este motor.",
+      "posture": {
+        "disabled": "Deshabilitado",
+        "mutual-tls": "TLS mutuo",
+        "self": "Modo TLS",
+        "tls": "TLS"
+      },
+      "server-identity": "Identidad del servidor",
+      "verification-disabled-description": "La verificación está deshabilitada. La conexión está cifrada, pero la identidad del servidor no se verifica; la configuración de CA se ignora.",
+      "verify-certificate": "Verificar certificado del servidor",
       "verify-certificate-tooltip": "Habilitar la verificación del certificado TLS para conexiones seguras. Deshabilitar solo para desarrollo o cuando los certificados no se pueden validar correctamente (por ejemplo, certificados autofirmados, entornos VPN). Advertencia: Deshabilitar la verificación es inseguro"
     },
     "ssl-connection": "Conexión SSL"
@@ -582,7 +594,6 @@
   "data-source.ssh.user": "Nombre de usuario",
   "data-source.ssl-connection": "Conexión SSL",
   "data-source.ssl.ca-cert": "Certificado de CA",
-  "data-source.ssl.ca-empty-uses-system-trust": "Dejar vacío para usar la tienda de confianza del sistema",
   "data-source.ssl.ca-path": "Ruta del certificado de CA",
   "data-source.ssl.client-cert": "Certificado del cliente",
   "data-source.ssl.client-cert-path": "Ruta del certificado del cliente",
@@ -943,10 +954,10 @@
         }
       },
       "host": {
-        "none-snowflake": "por ejemplo, host.docker.internal {{'|'}} host ip {{'|'}} local socket"
+        "none-snowflake": "por ejemplo, host.docker.internal | host ip | local socket"
       },
       "proxy": {
-        "snowflake": "Para el servidor proxy, agregue {{'@'}}PROXY_HOST y especifique PROXY_PORT en el puerto"
+        "snowflake": "Para el servidor proxy, agregue @PROXY_HOST y especifique PROXY_PORT en el puerto"
       }
     },
     "show-how-to-create": "Mostrar cómo crear",
@@ -1075,8 +1086,8 @@
   "instance.sentence.google-cloud-sql.instance-name-tips": "El nombre de la conexión de la instancia debería ser {{instance}}.",
   "instance.sentence.google-cloud-sql.mysql.template": "Cree una cuenta de servicio llamada {{user}} y luego agréguela en su Google Cloud SQL como usuario de IAM {{user}}@'%'. Otorgue a este usuario los privilegios necesarios.",
   "instance.sentence.google-cloud-sql.postgresql.template": "Cree una cuenta de servicio llamada {{user}} y luego agréguela en su Google Cloud SQL como usuario de IAM {{user}}@project-id.iam. Otorgue al usuario los privilegios necesarios.",
-  "instance.sentence.host.none-snowflake": "por ejemplo, host.docker.internal {'|'} host ip {'|'} local socket",
-  "instance.sentence.proxy.snowflake": "Para el servidor proxy, agregue {'@'}PROXY_HOST y especifique PROXY_PORT en el puerto",
+  "instance.sentence.host.none-snowflake": "por ejemplo, host.docker.internal | host ip | local socket",
+  "instance.sentence.proxy.snowflake": "Para el servidor proxy, agregue @PROXY_HOST y especifique PROXY_PORT en el puerto",
   "instance.show-how-to-create": "Mostrar cómo crear",
   "instance.snowflake-web-console": "Consola web de Snowflake",
   "instance.successfully-archived-instance": "Se archivó exitosamente la instancia '{{0}}'.",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -529,29 +529,41 @@
     },
     "ssl": {
       "ca-cert": "CA証明書",
-      "ca-empty-uses-system-trust": "空欄のままにすると、システムの信頼ストアを使用します",
       "ca-path": "CA証明書のパス",
       "ca-placeholder": "YOUR_CA_CERTIFICATEを入力またはドラッグ＆ドロップ",
       "ca-source": {
         "file-path": "ファイルパス",
-        "inline-pem": "インラインPEM",
-        "self": "CA証明書のソース",
+        "file-path-unavailable-saas": "Bytebase Cloud ではファイルパスは利用できません。",
+        "inline-pem": "PEM を貼り付け",
+        "self": "CA 証明書のソース",
         "system-trust": "システム信頼"
       },
-      "client-cert": "クライアント証明書",
-      "client-cert-path": "クライアント証明書のパス",
+      "client-cert": "証明書",
+      "client-cert-path": "証明書のパス",
       "client-cert-placeholder": "YOUR_CLIENT_CERTを入力またはドラッグ＆ドロップ",
       "client-cert-source": {
         "file-path": "ファイルパス",
-        "inline-pem": "インラインPEM",
+        "file-path-unavailable-saas": "Bytebase Cloud ではファイルパスは利用できません。",
+        "inline-pem": "PEM を貼り付け",
         "none": "なし",
-        "self": "クライアント証明書のソース"
+        "self": "クライアント ID のソース"
       },
-      "client-key": "クライアントキー",
-      "client-key-path": "クライアントキーのパス",
+      "client-identity": "クライアント ID",
+      "client-key": "秘密鍵",
+      "client-key-path": "秘密鍵のパス",
       "client-key-placeholder": "YOUR_CLIENT_KEYを入力またはドラッグ＆ドロップ",
       "configured": "設定済み",
-      "verify-certificate": "TLS証明書を検証",
+      "connection-security": "接続セキュリティ",
+      "mutual-tls-unavailable-engine": "このエンジンでは相互 TLS は利用できません。",
+      "posture": {
+        "disabled": "無効",
+        "mutual-tls": "相互 TLS",
+        "self": "TLS モード",
+        "tls": "TLS"
+      },
+      "server-identity": "サーバー ID",
+      "verification-disabled-description": "検証は無効です。接続は暗号化されていますが、サーバーの ID は検証されず、CA 設定は無視されます。",
+      "verify-certificate": "サーバー証明書を検証",
       "verify-certificate-tooltip": "安全な接続のためにTLS証明書の検証を有効にします。開発環境や証明書が適切に検証できない場合（自己署名証明書、VPN環境など）にのみ無効にしてください。警告：検証を無効にすることは安全ではありません"
     },
     "ssl-connection": "SSL接続"
@@ -582,7 +594,6 @@
   "data-source.ssh.user": "ユーザー名",
   "data-source.ssl-connection": "SSL接続",
   "data-source.ssl.ca-cert": "CA証明書",
-  "data-source.ssl.ca-empty-uses-system-trust": "空欄のままにすると、システムの信頼ストアを使用します",
   "data-source.ssl.ca-path": "CA証明書のパス",
   "data-source.ssl.client-cert": "クライアント証明書",
   "data-source.ssl.client-cert-path": "クライアント証明書のパス",
@@ -943,10 +954,10 @@
         }
       },
       "host": {
-        "none-snowflake": "たとえば、host.docker.internal {{'|'}} host ip {{'|'}} local socket"
+        "none-snowflake": "たとえば、host.docker.internal | host ip | local socket"
       },
       "proxy": {
-        "snowflake": "プロキシ サーバーの場合は、{{'@'}}PROXY_HOST を追加し、ポートに PROXY_PORT を指定します。"
+        "snowflake": "プロキシ サーバーの場合は、@PROXY_HOST を追加し、ポートに PROXY_PORT を指定します。"
       }
     },
     "show-how-to-create": "作成方法",
@@ -1075,8 +1086,8 @@
   "instance.sentence.google-cloud-sql.instance-name-tips": "インスタンス接続名は {{instance}} である必要があります。",
   "instance.sentence.google-cloud-sql.mysql.template": "{{user}} という名前のサービス アカウントを作成し、IAM ユーザー {{user}}@'%' として Google Cloud SQL に追加します。このユーザーに必要な権限を付与します。",
   "instance.sentence.google-cloud-sql.postgresql.template": "{{user}} という名前のサービス アカウントを作成し、IAM ユーザー {{user}}@project-id.iam として Google Cloud SQL に追加します。ユーザーに必要な権限を付与します。",
-  "instance.sentence.host.none-snowflake": "たとえば、host.docker.internal {'|'} host ip {'|'} local socket",
-  "instance.sentence.proxy.snowflake": "プロキシ サーバーの場合は、{'@'}PROXY_HOST を追加し、ポートに PROXY_PORT を指定します。",
+  "instance.sentence.host.none-snowflake": "たとえば、host.docker.internal | host ip | local socket",
+  "instance.sentence.proxy.snowflake": "プロキシ サーバーの場合は、@PROXY_HOST を追加し、ポートに PROXY_PORT を指定します。",
   "instance.show-how-to-create": "作成方法",
   "instance.snowflake-web-console": "スノーフレークウェブコンソール",
   "instance.successfully-archived-instance": "インスタンス '{{0}}' を正常にアーカイブしました。",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -529,29 +529,41 @@
     },
     "ssl": {
       "ca-cert": "Chứng chỉ CA",
-      "ca-empty-uses-system-trust": "Để trống để dùng kho tin cậy của hệ thống",
       "ca-path": "Đường dẫn chứng chỉ CA",
       "ca-placeholder": "Nhập hoặc kéo thả YOUR_CA_CERTIFICATE",
       "ca-source": {
         "file-path": "Đường dẫn tệp",
-        "inline-pem": "PEM nội tuyến",
+        "file-path-unavailable-saas": "Bytebase Cloud không hỗ trợ đường dẫn tệp.",
+        "inline-pem": "Dán PEM",
         "self": "Nguồn chứng chỉ CA",
         "system-trust": "Tin cậy hệ thống"
       },
-      "client-cert": "Chứng chỉ máy khách",
-      "client-cert-path": "Đường dẫn chứng chỉ máy khách",
+      "client-cert": "Chứng chỉ",
+      "client-cert-path": "Đường dẫn chứng chỉ",
       "client-cert-placeholder": "Nhập hoặc kéo thả YOUR_CLIENT_CERT",
       "client-cert-source": {
         "file-path": "Đường dẫn tệp",
-        "inline-pem": "PEM nội tuyến",
+        "file-path-unavailable-saas": "Bytebase Cloud không hỗ trợ đường dẫn tệp.",
+        "inline-pem": "Dán PEM",
         "none": "Không có",
-        "self": "Nguồn chứng chỉ máy khách"
+        "self": "Nguồn danh tính máy khách"
       },
-      "client-key": "Khóa máy khách",
-      "client-key-path": "Đường dẫn khóa máy khách",
+      "client-identity": "Danh tính máy khách",
+      "client-key": "Khóa riêng",
+      "client-key-path": "Đường dẫn khóa riêng",
       "client-key-placeholder": "Nhập hoặc kéo thả YOUR_CLIENT_KEY",
       "configured": "Đã cấu hình",
-      "verify-certificate": "Xác minh chứng chỉ TLS",
+      "connection-security": "Bảo mật kết nối",
+      "mutual-tls-unavailable-engine": "TLS lẫn nhau không khả dụng cho engine này.",
+      "posture": {
+        "disabled": "Đã tắt",
+        "mutual-tls": "TLS lẫn nhau",
+        "self": "Chế độ TLS",
+        "tls": "TLS"
+      },
+      "server-identity": "Danh tính máy chủ",
+      "verification-disabled-description": "Đã tắt xác minh. Kết nối được mã hóa, nhưng danh tính máy chủ không được xác minh; cài đặt CA sẽ bị bỏ qua.",
+      "verify-certificate": "Xác minh chứng chỉ máy chủ",
       "verify-certificate-tooltip": "Bật xác minh chứng chỉ TLS để kết nối an toàn. Chỉ tắt cho môi trường phát triển hoặc khi không thể xác thực chứng chỉ đúng cách (ví dụ: chứng chỉ tự ký, môi trường VPN). Cảnh báo: Tắt xác minh là không an toàn"
     },
     "ssl-connection": "Kết nối SSL"
@@ -582,7 +594,6 @@
   "data-source.ssh.user": "Người dùng",
   "data-source.ssl-connection": "Kết nối SSL",
   "data-source.ssl.ca-cert": "Chứng chỉ CA",
-  "data-source.ssl.ca-empty-uses-system-trust": "Để trống để dùng kho tin cậy của hệ thống",
   "data-source.ssl.ca-path": "Đường dẫn chứng chỉ CA",
   "data-source.ssl.client-cert": "Chứng chỉ máy khách",
   "data-source.ssl.client-cert-path": "Đường dẫn chứng chỉ máy khách",
@@ -943,10 +954,10 @@
         }
       },
       "host": {
-        "none-snowflake": "ví dụ: host.docker.internal {{'|'}} địa chỉ IP máy chủ {{'|'}} local socket"
+        "none-snowflake": "ví dụ: host.docker.internal | địa chỉ IP máy chủ | local socket"
       },
       "proxy": {
-        "snowflake": "Đối với máy chủ proxy, thêm {{'@'}}PROXY_HOST và chỉ định PROXY_PORT trong cổng"
+        "snowflake": "Đối với máy chủ proxy, thêm @PROXY_HOST và chỉ định PROXY_PORT trong cổng"
       }
     },
     "show-how-to-create": "Hiển thị cách tạo",
@@ -1075,8 +1086,8 @@
   "instance.sentence.google-cloud-sql.instance-name-tips": "Tên kết nối phiên bản phải giống như {{instance}}.",
   "instance.sentence.google-cloud-sql.mysql.template": "Tạo một tài khoản dịch vụ có tên {{user}}, sau đó thêm nó vào Google Cloud SQL của bạn với tư cách là người dùng IAM {{user}}@'%'. Cấp cho người dùng này các đặc quyền cần thiết.",
   "instance.sentence.google-cloud-sql.postgresql.template": "Tạo một tài khoản dịch vụ có tên {{user}}, sau đó thêm nó vào Google Cloud SQL của bạn với tư cách là người dùng IAM {{user}}@project-id.iam. Cấp cho người dùng các đặc quyền cần thiết.",
-  "instance.sentence.host.none-snowflake": "ví dụ: host.docker.internal {'|'} địa chỉ IP máy chủ {'|'} local socket",
-  "instance.sentence.proxy.snowflake": "Đối với máy chủ proxy, thêm {'@'}PROXY_HOST và chỉ định PROXY_PORT trong cổng",
+  "instance.sentence.host.none-snowflake": "ví dụ: host.docker.internal | địa chỉ IP máy chủ | local socket",
+  "instance.sentence.proxy.snowflake": "Đối với máy chủ proxy, thêm @PROXY_HOST và chỉ định PROXY_PORT trong cổng",
   "instance.show-how-to-create": "Hiển thị cách tạo",
   "instance.snowflake-web-console": "Bảng điều khiển web Snowflake",
   "instance.successfully-archived-instance": "Đã lưu trữ thành công phiên bản '{{0}}'.",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -529,29 +529,41 @@
     },
     "ssl": {
       "ca-cert": "CA 证书",
-      "ca-empty-uses-system-trust": "留空以使用系统信任存储",
       "ca-path": "CA 证书路径",
       "ca-placeholder": "输入或拖放 YOUR_CA_CERTIFICATE",
       "ca-source": {
         "file-path": "文件路径",
-        "inline-pem": "内联 PEM",
+        "file-path-unavailable-saas": "Bytebase Cloud 中不可使用文件路径。",
+        "inline-pem": "粘贴 PEM",
         "self": "CA 证书来源",
         "system-trust": "系统信任"
       },
-      "client-cert": "客户端证书",
-      "client-cert-path": "客户端证书路径",
+      "client-cert": "证书",
+      "client-cert-path": "证书路径",
       "client-cert-placeholder": "输入或拖放 YOUR_CLIENT_CERT",
       "client-cert-source": {
         "file-path": "文件路径",
-        "inline-pem": "内联 PEM",
+        "file-path-unavailable-saas": "Bytebase Cloud 中不可使用文件路径。",
+        "inline-pem": "粘贴 PEM",
         "none": "无",
-        "self": "客户端证书来源"
+        "self": "客户端身份来源"
       },
-      "client-key": "客户端密钥",
-      "client-key-path": "客户端密钥路径",
+      "client-identity": "客户端身份",
+      "client-key": "私钥",
+      "client-key-path": "私钥路径",
       "client-key-placeholder": "输入或拖放 YOUR_CLIENT_KEY",
       "configured": "已配置",
-      "verify-certificate": "验证 TLS 证书",
+      "connection-security": "连接安全性",
+      "mutual-tls-unavailable-engine": "此引擎不支持双向 TLS。",
+      "posture": {
+        "disabled": "已禁用",
+        "mutual-tls": "双向 TLS",
+        "self": "TLS 模式",
+        "tls": "TLS"
+      },
+      "server-identity": "服务器身份",
+      "verification-disabled-description": "已禁用验证。连接已加密，但未验证服务器身份；CA 设置将被忽略。",
+      "verify-certificate": "验证服务器证书",
       "verify-certificate-tooltip": "启用 TLS 证书验证以确保安全连接。仅在开发环境或证书无法正确验证的情况下禁用（例如自签名证书、VPN 环境）。警告：禁用验证是不安全的"
     },
     "ssl-connection": "SSL 连接"
@@ -582,7 +594,6 @@
   "data-source.ssh.user": "用户名",
   "data-source.ssl-connection": "SSL 连接",
   "data-source.ssl.ca-cert": "CA 证书",
-  "data-source.ssl.ca-empty-uses-system-trust": "留空以使用系统信任存储",
   "data-source.ssl.ca-path": "CA 证书路径",
   "data-source.ssl.client-cert": "客户端证书",
   "data-source.ssl.client-cert-path": "客户端证书路径",
@@ -943,10 +954,10 @@
         }
       },
       "host": {
-        "none-snowflake": "例如 host.docker.internal {{'|'}} ip {{'|'}} local socket"
+        "none-snowflake": "例如 host.docker.internal | ip | local socket"
       },
       "proxy": {
-        "snowflake": "对于代理服务器，加上 {{'@'}}PROXY_HOST，并在端口里指定 PROXY_PORT"
+        "snowflake": "对于代理服务器，加上 @PROXY_HOST，并在端口里指定 PROXY_PORT"
       }
     },
     "show-how-to-create": "如何创建",
@@ -1075,8 +1086,8 @@
   "instance.sentence.google-cloud-sql.instance-name-tips": "实例连接名称应为 {{instance}}。",
   "instance.sentence.google-cloud-sql.mysql.template": "创建一个名为 {{user}} 的服务帐户，然后将其作为 IAM 用户 {{user}}@'%' 添加到您的 Google Cloud SQL 中。授予此用户所需的权限。",
   "instance.sentence.google-cloud-sql.postgresql.template": "创建一个名为 {{user}} 的服务帐户，然后将其作为 IAM 用户 {{user}}@project-id.iam 添加到您的 Google Cloud SQL 中。授予用户所需的权限。",
-  "instance.sentence.host.none-snowflake": "例如 host.docker.internal {'|'} ip {'|'} local socket",
-  "instance.sentence.proxy.snowflake": "对于代理服务器，加上 {'@'}PROXY_HOST，并在端口里指定 PROXY_PORT",
+  "instance.sentence.host.none-snowflake": "例如 host.docker.internal | ip | local socket",
+  "instance.sentence.proxy.snowflake": "对于代理服务器，加上 @PROXY_HOST，并在端口里指定 PROXY_PORT",
   "instance.show-how-to-create": "如何创建",
   "instance.snowflake-web-console": "Snowflake Web 控制台",
   "instance.successfully-archived-instance": "成功归档实例'{{0}}'。",


### PR DESCRIPTION
## Summary

Cherry-picks from `main` onto `release/3.17.1`:

- [#20082](https://github.com/bytebase/bytebase/pull/20082) — feat: redesign instance TLS settings
- [#20084](https://github.com/bytebase/bytebase/pull/20084) — fix: harden instance TLS path validation

Both applied cleanly with `-x` (no conflicts).

Note: the auto-backport bot already opened [#20087](https://github.com/bytebase/bytebase/pull/20087) and [#20088](https://github.com/bytebase/bytebase/pull/20088) for the same two commits individually — pick whichever is preferred; the other(s) can be closed.

## Test plan

- [x] Backend build
- [x] `go test ./backend/api/v1/... ./backend/plugin/db/util/...`
- [x] `golangci-lint` clean on touched Go packages
- [x] Frontend `type-check`
- [x] Frontend `check` (eslint + biome + i18n)
- [x] Frontend `test` (1188 passing)