### PR TITLE
fix(pg): three schema→DDL generator bugs breaking omni LoadSQL

### DIFF
--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -1214,12 +1214,16 @@ func writeRules(out io.Writer, _ string, _ string, rules []*storepb.RuleMetadata
 	return nil
 }
 
+// objectIDSeparator joins schema + object into a map/graph key. NUL cannot
+// legally appear in a PostgreSQL identifier, so this avoids ambiguity when
+// either half itself contains a dot (e.g. a table literally named "a.b").
+const objectIDSeparator = "\x00"
+
 func getSchemaNameFromID(id string) string {
-	parts := strings.Split(id, ".")
-	if len(parts) != 2 {
-		return ""
+	if schema, _, ok := strings.Cut(id, objectIDSeparator); ok {
+		return schema
 	}
-	return parts[0]
+	return ""
 }
 
 func writeColumnIdentityGeneration(out io.Writer, schema string, generationTypes storepb.ColumnMetadata_IdentityGeneration, sequence *storepb.SequenceMetadata) error {
@@ -1453,7 +1457,7 @@ func funcIdentity(f *storepb.FunctionMetadata) string {
 func getObjectID(schema string, object string) string {
 	var buf strings.Builder
 	_, _ = buf.WriteString(schema)
-	_, _ = buf.WriteString(".")
+	_, _ = buf.WriteString(objectIDSeparator)
 	_, _ = buf.WriteString(object)
 	return buf.String()
 }
@@ -1541,14 +1545,22 @@ func writeCreateTable(out io.Writer, schema string, tableName string, columns []
 		return err
 	}
 
-	for i, column := range columns {
-		if i > 0 {
-			if _, err := io.WriteString(out, ","); err != nil {
-				return err
-			}
+	// first tracks whether we've written any element inside the parens yet so
+	// the leading comma on constraints is suppressed when there are no columns
+	// (e.g. tables that only carry CHECK constraints).
+	first := true
+	writeItemSep := func() error {
+		if first {
+			first = false
+			_, err := io.WriteString(out, "\n    ")
+			return err
 		}
+		_, err := io.WriteString(out, ",\n    ")
+		return err
+	}
 
-		if _, err := io.WriteString(out, "\n    "); err != nil {
+	for _, column := range columns {
+		if err := writeItemSep(); err != nil {
 			return err
 		}
 
@@ -1586,7 +1598,9 @@ func writeCreateTable(out io.Writer, schema string, tableName string, columns []
 	}
 
 	for _, check := range checks {
-		_, _ = io.WriteString(out, ",\n    ")
+		if err := writeItemSep(); err != nil {
+			return err
+		}
 		_, _ = io.WriteString(out, `CONSTRAINT "`)
 		_, _ = io.WriteString(out, check.Name)
 		_, _ = io.WriteString(out, `" CHECK `)
@@ -1594,7 +1608,9 @@ func writeCreateTable(out io.Writer, schema string, tableName string, columns []
 	}
 
 	for _, exclude := range excludes {
-		_, _ = io.WriteString(out, ",\n    ")
+		if err := writeItemSep(); err != nil {
+			return err
+		}
 		_, _ = io.WriteString(out, `CONSTRAINT "`)
 		_, _ = io.WriteString(out, exclude.Name)
 		_, _ = io.WriteString(out, `" `)
@@ -2017,7 +2033,7 @@ func writeIndexComment(out io.Writer, schema string, index *storepb.IndexMetadat
 		return err
 	}
 
-	_, err := io.WriteString(out, `';\n\n`)
+	_, err := io.WriteString(out, "';\n\n")
 	return err
 }
 
@@ -3138,26 +3154,31 @@ func writeCreateTableSDL(out io.Writer, schemaName string, table *storepb.TableM
 		return err
 	}
 
-	// Write columns
-	for i, column := range table.Columns {
-		if i > 0 {
-			if _, err := io.WriteString(out, ","); err != nil {
-				return err
-			}
-		}
-
-		if _, err := io.WriteString(out, "\n    "); err != nil {
+	// first tracks whether any element has been written inside the parens so
+	// the separator on constraints is suppressed when there are no columns.
+	first := true
+	writeItemSep := func() error {
+		if first {
+			first = false
+			_, err := io.WriteString(out, "\n    ")
 			return err
 		}
+		_, err := io.WriteString(out, ",\n    ")
+		return err
+	}
 
-		// Use the extracted writeColumnSDL function
+	// Write columns
+	for _, column := range table.Columns {
+		if err := writeItemSep(); err != nil {
+			return err
+		}
 		if err := writeColumnSDL(out, column, table.Name, sequences); err != nil {
 			return err
 		}
 	}
 
 	// Write table constraints
-	if err := writeTableConstraintsSDL(out, table); err != nil {
+	if err := writeTableConstraintsSDL(out, table, writeItemSep); err != nil {
 		return err
 	}
 
@@ -3165,11 +3186,11 @@ func writeCreateTableSDL(out io.Writer, schemaName string, table *storepb.TableM
 	return err
 }
 
-func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata) error {
+func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata, writeSep func() error) error {
 	// Write primary key constraint
 	for _, index := range table.Indexes {
 		if index.Primary {
-			if _, err := io.WriteString(out, ",\n    "); err != nil {
+			if err := writeSep(); err != nil {
 				return err
 			}
 			if err := writePrimaryKeyConstraintSDL(out, index); err != nil {
@@ -3181,7 +3202,7 @@ func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata) error
 	// Write unique constraints
 	for _, index := range table.Indexes {
 		if index.Unique && !index.Primary && index.IsConstraint {
-			if _, err := io.WriteString(out, ",\n    "); err != nil {
+			if err := writeSep(); err != nil {
 				return err
 			}
 			if err := writeUniqueKeyConstraintSDL(out, index); err != nil {
@@ -3192,7 +3213,7 @@ func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata) error
 
 	// Write check constraints
 	for _, check := range table.CheckConstraints {
-		if _, err := io.WriteString(out, ",\n    "); err != nil {
+		if err := writeSep(); err != nil {
 			return err
 		}
 		if err := writeCheckConstraintSDL(out, check); err != nil {
@@ -3202,7 +3223,7 @@ func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata) error
 
 	// Write EXCLUDE constraints
 	for _, exclude := range table.ExcludeConstraints {
-		if _, err := io.WriteString(out, ",\n    "); err != nil {
+		if err := writeSep(); err != nil {
 			return err
 		}
 		if err := writeExcludeConstraintSDL(out, exclude); err != nil {
@@ -3212,7 +3233,7 @@ func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata) error
 
 	// Write foreign key constraints
 	for _, fk := range table.ForeignKeys {
-		if _, err := io.WriteString(out, ",\n    "); err != nil {
+		if err := writeSep(); err != nil {
 			return err
 		}
 		if err := writeForeignKeyConstraintSDL(out, fk); err != nil {

--- a/backend/plugin/schema/pg/get_database_definition_regressions_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_regressions_test.go
@@ -1,0 +1,125 @@
+package pg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bytebase/omni/pg/catalog"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+)
+
+// TestGetDatabaseDefinition_IndexCommentUsesRealNewline reproduces the A1
+// bug where writeIndexComment used a Go raw string literal with `\n\n`,
+// producing four literal characters `\`, `n`, `\`, `n` instead of two line
+// feeds. The regression surfaced as omni pgparser choking on the backslash
+// right after `COMMENT ON INDEX ... IS '...';`.
+func TestGetDatabaseDefinition_IndexCommentUsesRealNewline(t *testing.T) {
+	meta := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name: "public",
+			Tables: []*storepb.TableMetadata{{
+				Name: "t",
+				Columns: []*storepb.ColumnMetadata{
+					{Name: "id", Type: "integer", Nullable: false},
+				},
+				Indexes: []*storepb.IndexMetadata{{
+					Name:        "idx_t_id",
+					Type:        "btree",
+					Expressions: []string{"id"},
+					Descending:  []bool{false},
+					Definition:  "CREATE INDEX idx_t_id ON public.t USING btree (id);",
+					Comment:     "sample comment",
+				}},
+			}},
+		}},
+	}
+
+	ddl, err := GetDatabaseDefinition(schema.GetDefinitionContext{}, meta)
+	if err != nil {
+		t.Fatalf("GetDatabaseDefinition: %v", err)
+	}
+
+	if strings.Contains(ddl, `\n`) {
+		t.Errorf("DDL contains literal backslash-n escape; got:\n%s", ddl)
+	}
+	if !strings.Contains(ddl, `COMMENT ON INDEX "public"."idx_t_id" IS 'sample comment';`) {
+		t.Errorf("expected COMMENT ON INDEX statement, got:\n%s", ddl)
+	}
+
+	cat := catalog.New()
+	if _, execErr := cat.Exec(ddl, &catalog.ExecOptions{ContinueOnError: true}); execErr != nil {
+		t.Errorf("omni catalog parse error: %v\nDDL:\n%s", execErr, ddl)
+	}
+}
+
+// TestGetDatabaseDefinition_TableWithOnlyCheckConstraints reproduces the A2
+// bug where a table with zero columns but with CHECK constraints produced
+// `CREATE TABLE "..."."..." (,` — an invalid leading comma. We force the
+// case by declaring a CHECK constraint on a table with no regular columns.
+func TestGetDatabaseDefinition_TableWithOnlyCheckConstraints(t *testing.T) {
+	meta := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name: "public",
+			Tables: []*storepb.TableMetadata{{
+				Name: "cons_only",
+				CheckConstraints: []*storepb.CheckConstraintMetadata{{
+					Name:       "cons_only_dummy",
+					Expression: "(1 = 1)",
+				}},
+			}},
+		}},
+	}
+
+	ddl, err := GetDatabaseDefinition(schema.GetDefinitionContext{}, meta)
+	if err != nil {
+		t.Fatalf("GetDatabaseDefinition: %v", err)
+	}
+	if strings.Contains(ddl, "(,") {
+		t.Errorf("DDL still has `(,` leading comma; got:\n%s", ddl)
+	}
+	if !strings.Contains(ddl, `CREATE TABLE "public"."cons_only" (`) {
+		t.Errorf("expected CREATE TABLE for cons_only, got:\n%s", ddl)
+	}
+	// Omni will reject a table with zero columns semantically, but it must
+	// at least parse cleanly; the test asserts the parse-level contract.
+	if _, parseErr := catalog.New().Exec(ddl, &catalog.ExecOptions{ContinueOnError: true}); parseErr != nil {
+		t.Errorf("omni catalog parse error: %v\nDDL:\n%s", parseErr, ddl)
+	}
+}
+
+// TestGetDatabaseDefinition_TableNameContainingDot reproduces A3: a table
+// whose name literally contains a period was writing out as `"".".."` —
+// because the schema + "." + object object-ID was split back on the first
+// dot and produced an empty schema. The fix uses a NUL separator.
+func TestGetDatabaseDefinition_TableNameContainingDot(t *testing.T) {
+	meta := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name: "public",
+			Tables: []*storepb.TableMetadata{{
+				Name: "weird.name",
+				Columns: []*storepb.ColumnMetadata{
+					{Name: "c", Type: "text", Nullable: true},
+				},
+			}},
+		}},
+	}
+
+	ddl, err := GetDatabaseDefinition(schema.GetDefinitionContext{}, meta)
+	if err != nil {
+		t.Fatalf("GetDatabaseDefinition: %v", err)
+	}
+	if strings.Contains(ddl, `""."`) {
+		t.Errorf("DDL contains empty schema `\"\".\"` prefix; got:\n%s", ddl)
+	}
+	if !strings.Contains(ddl, `CREATE TABLE "public"."weird.name"`) {
+		t.Errorf("expected schema to be public, got:\n%s", ddl)
+	}
+	if _, parseErr := catalog.New().Exec(ddl, &catalog.ExecOptions{ContinueOnError: true}); parseErr != nil {
+		t.Errorf("omni catalog parse error: %v\nDDL:\n%s", parseErr, ddl)
+	}
+}


### PR DESCRIPTION
## Summary

Three generator-side bugs in `GetDatabaseDefinition` that produced DDL omni's `catalog.LoadSQL` could not parse:

- **`COMMENT ON INDEX ...` terminator written as literal `\n\n`.** `writeIndexComment` used a Go raw-string literal `` `';\n\n` ``, so the separator after the statement landed in the output as four characters (`\ n \ n`) instead of two line feeds. The next `CREATE TABLE/INDEX` attached to that same line and the parser failed at the backslash.
- **`CREATE TABLE (,` for tables with zero columns and only table-level constraints.** Both `writeCreateTable` and `writeCreateTableSDL` / `writeTableConstraintsSDL` unconditionally prefixed constraint lines with `,\n    `. When a table had no regular columns (e.g. only CHECK constraints), the first constraint produced a leading comma. Replaced with a closure that tracks whether anything has been emitted inside the parens and only emits the comma from the second item onward.
- **Table names that literally contain `.` collapsed to an empty schema.** `getObjectID` joined schema and object with `.` and `getSchemaNameFromID` split back on `.` requiring exactly two segments. A table named `xref.radian_virtual_association_code` made the id have three segments, the split failed, schema returned empty, and the DDL emitted `""."xref.radian_virtual_association_code"`. Switched the internal separator to NUL (`\x00`), which is illegal in PostgreSQL identifiers.

Discovered by running 373 real PG metadata snapshots through `GetDatabaseDefinition` and then `omni catalog.Exec`. These three bugs accounted for ~20 files' top-level parse failures.

## Test plan

- [x] New regression tests in `backend/plugin/schema/pg/get_database_definition_regressions_test.go` — one per bug — build synthetic metadata, call `GetDatabaseDefinition`, assert the output has no literal `\n`, no `(,`, no `""."..."`, and that omni `catalog.Exec` parses it without error.
- [x] `go test ./backend/plugin/schema/pg/...` — passes (8.3s).
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/schema/pg/...` — 0 issues.
- [x] Full server build: `go build ./backend/bin/server/main.go` — succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)