### PR TITLE
feat(tidb): statement ranges for SQL editor LSP

### DIFF
--- a/backend/plugin/parser/tidb/statement_ranges.go
+++ b/backend/plugin/parser/tidb/statement_ranges.go
@@ -77,6 +77,11 @@ func buildBytePositionMap(sql string) []lsp.Position {
 	return positions
 }
 
+// positionAt returns the LSP Position at a rune-aligned byte offset. Offsets
+// that land inside a multi-byte UTF-8 sequence silently return the zero
+// Position (because buildBytePositionMap only populates entries at rune
+// boundaries), so callers must pass boundaries produced by Split or other
+// rune-aware tokenizers. Out-of-bounds offsets return ok=false.
 func positionAt(positions []lsp.Position, byteOffset int) (lsp.Position, bool) {
 	if byteOffset < 0 || byteOffset >= len(positions) {
 		return lsp.Position{}, false
@@ -110,7 +115,11 @@ func leadingWhitespaceBytes(sql string, start, end int) int {
 // the last segment without a trailing delimiter it is 0. Custom DELIMITER
 // directives are not fully tracked here — the range will simply stop at the
 // start of the custom delimiter in that case, which is sufficient for cursor-
-// contained-in-range checks used by BYT-9157.
+// contained-in-range checks used by BYT-9157. UX consequence: a cursor placed
+// directly on the bytes of a custom delimiter (e.g. between the two '$' of
+// '$$') won't match any range, and the editor falls back to its out-of-range
+// behavior for Ctrl+Enter. Cursors inside the statement body — the common
+// case — are unaffected.
 func delimLenAt(sql string, byteEnd int) int {
 	if byteEnd < 0 || byteEnd >= len(sql) {
 		return 0

--- a/backend/plugin/parser/tidb/statement_ranges.go
+++ b/backend/plugin/parser/tidb/statement_ranges.go
@@ -1,0 +1,122 @@
+package tidb
+
+import (
+	"context"
+	"unicode"
+	"unicode/utf8"
+
+	omnitidbparser "github.com/bytebase/omni/tidb/parser"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+
+	lsp "github.com/bytebase/lsp-protocol"
+)
+
+func init() {
+	base.RegisterStatementRangesFunc(storepb.Engine_TIDB, GetStatementRanges)
+}
+
+// GetStatementRanges returns LSP-compatible ranges (0-based line, UTF-16 character)
+// for each top-level SQL statement in statement.
+//
+// Implementation note: this uses omni/tidb's Split, which is a pure lexical
+// scanner and works on both valid and invalid SQL. This is required for LSP
+// use cases — the caller (e.g. SQL editor Ctrl+Enter) asks for ranges while the
+// user is mid-edit, so any grammar-level Parse would fail-fast and drop ranges
+// for statements preceding a syntax error. Split is soft-fail by construction.
+func GetStatementRanges(_ context.Context, _ base.StatementRangeContext, statement string) ([]base.Range, error) {
+	segments := omnitidbparser.Split(statement)
+	if len(segments) == 0 {
+		return nil, nil
+	}
+
+	positions := buildBytePositionMap(statement)
+
+	ranges := make([]base.Range, 0, len(segments))
+	for _, seg := range segments {
+		startOffset := min(seg.ByteStart+leadingWhitespaceBytes(statement, seg.ByteStart, seg.ByteEnd), seg.ByteEnd)
+
+		endOffset := seg.ByteEnd + delimLenAt(statement, seg.ByteEnd)
+
+		start, ok := positionAt(positions, startOffset)
+		if !ok {
+			continue
+		}
+		end, ok := positionAt(positions, endOffset)
+		if !ok {
+			continue
+		}
+		ranges = append(ranges, base.Range{Start: start, End: end})
+	}
+	return ranges, nil
+}
+
+// buildBytePositionMap maps every byte offset in sql (0..len(sql) inclusive) to
+// its LSP position (0-based line, 0-based UTF-16 character offset on that line).
+// Surrogate pairs beyond the BMP count as two UTF-16 code units, matching LSP
+// semantics.
+func buildBytePositionMap(sql string) []lsp.Position {
+	positions := make([]lsp.Position, len(sql)+1)
+	var line, character uint32
+	i := 0
+	for i < len(sql) {
+		positions[i] = lsp.Position{Line: line, Character: character}
+		r, size := utf8.DecodeRuneInString(sql[i:])
+		if r == '\n' {
+			line++
+			character = 0
+		} else if r > 0xFFFF {
+			character += 2
+		} else {
+			character++
+		}
+		i += size
+	}
+	positions[i] = lsp.Position{Line: line, Character: character}
+	return positions
+}
+
+func positionAt(positions []lsp.Position, byteOffset int) (lsp.Position, bool) {
+	if byteOffset < 0 || byteOffset >= len(positions) {
+		return lsp.Position{}, false
+	}
+	return positions[byteOffset], true
+}
+
+// leadingWhitespaceBytes returns the number of leading Unicode whitespace bytes
+// within sql[start:end]. Mirrors the whitespace trim performed by the ANTLR-based
+// statement-range helper so TiDB ranges line up with snowflake/doris/pg behavior.
+func leadingWhitespaceBytes(sql string, start, end int) int {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(sql) {
+		end = len(sql)
+	}
+	i := start
+	for i < end {
+		r, size := utf8.DecodeRuneInString(sql[i:])
+		if !unicode.IsSpace(r) {
+			break
+		}
+		i += size
+	}
+	return i - start
+}
+
+// delimLenAt returns the length of the statement delimiter that sits at
+// sql[byteEnd:], if any. For the common default delimiter (';') this is 1; for
+// the last segment without a trailing delimiter it is 0. Custom DELIMITER
+// directives are not fully tracked here — the range will simply stop at the
+// start of the custom delimiter in that case, which is sufficient for cursor-
+// contained-in-range checks used by BYT-9157.
+func delimLenAt(sql string, byteEnd int) int {
+	if byteEnd < 0 || byteEnd >= len(sql) {
+		return 0
+	}
+	if sql[byteEnd] == ';' {
+		return 1
+	}
+	return 0
+}

--- a/backend/plugin/parser/tidb/statement_ranges_test.go
+++ b/backend/plugin/parser/tidb/statement_ranges_test.go
@@ -1,0 +1,72 @@
+package tidb
+
+import (
+	"context"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/bytebase/bytebase/backend/common/yamltest"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestGetStatementRanges(t *testing.T) {
+	type testCase struct {
+		Statement string       `yaml:"statement,omitempty"`
+		Expected  []base.Range `yaml:"ranges,omitempty"`
+	}
+
+	const (
+		record      = false
+		testDataDir = "test-data/statement-ranges"
+	)
+	a := require.New(t)
+
+	entries, err := os.ReadDir(testDataDir)
+	a.NoError(err)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		filepath := path.Join(testDataDir, entry.Name())
+		yamlFile, err := os.Open(filepath)
+		a.NoError(err)
+		var testCases []testCase
+		byteValue, err := io.ReadAll(yamlFile)
+		a.NoError(err)
+		a.NoError(yamlFile.Close())
+		a.NoError(yaml.Unmarshal(byteValue, &testCases))
+		for i, tc := range testCases {
+			if tc.Statement == "" {
+				continue
+			}
+			ranges, err := GetStatementRanges(context.TODO(), base.StatementRangeContext{}, tc.Statement)
+			a.NoError(err)
+			if record {
+				testCases[i].Expected = ranges
+			} else {
+				a.Equal(tc.Expected, ranges, "statement: %s", tc.Statement)
+			}
+		}
+
+		if record {
+			yamltest.Record(t, filepath, testCases)
+		}
+	}
+}
+
+// TestGetStatementRangesEmpty asserts that empty / whitespace-only input
+// returns no ranges (distinct from the YAML-driven fixtures which skip
+// blank statements).
+func TestGetStatementRangesEmpty(t *testing.T) {
+	a := require.New(t)
+	for _, s := range []string{"", "   ", "\n\n", "-- just a comment\n", "/* block */"} {
+		ranges, err := GetStatementRanges(context.TODO(), base.StatementRangeContext{}, s)
+		a.NoError(err, "input %q", s)
+		a.Empty(ranges, "input %q", s)
+	}
+}

--- a/backend/plugin/parser/tidb/test-data/statement-ranges/standard.yaml
+++ b/backend/plugin/parser/tidb/test-data/statement-ranges/standard.yaml
@@ -1,0 +1,167 @@
+- statement: SELECT 1;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 9
+- statement: SELECT 1; SELECT 2;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 9
+    - start:
+        line: 0
+        character: 10
+      end:
+        line: 0
+        character: 19
+- statement: SELECT 1
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 8
+- statement: |-
+    SELECT 1;
+      SELECT 2
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 9
+    - start:
+        line: 1
+        character: 2
+      end:
+        line: 1
+        character: 10
+- statement: SELECT FROM; CREATE TABLE t (id INT);
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 12
+    - start:
+        line: 0
+        character: 13
+      end:
+        line: 0
+        character: 37
+- statement: "SELECT 1; -- \U0001F600\nSELECT 2;"
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 9
+    - start:
+        line: 0
+        character: 10
+      end:
+        line: 1
+        character: 9
+- statement: SELECT 1;SELECT 2;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 9
+    - start:
+        line: 0
+        character: 9
+      end:
+        line: 0
+        character: 18
+- statement: |-
+    SELECT 1;
+    /* note */ SELECT 2;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 9
+    - start:
+        line: 1
+        character: 0
+      end:
+        line: 1
+        character: 20
+- statement: |-
+    DELIMITER //
+    SELECT 1//
+    DELIMITER ;
+    SELECT 2;
+  ranges:
+    - start:
+        line: 1
+        character: 0
+      end:
+        line: 1
+        character: 8
+    - start:
+        line: 3
+        character: 0
+      end:
+        line: 3
+        character: 9
+- statement: |-
+    DELIMITER $$
+    CREATE PROCEDURE p()
+    BEGIN
+      SELECT 1;
+      SELECT 2;
+    END$$
+    DELIMITER ;
+  ranges:
+    - start:
+        line: 1
+        character: 0
+      end:
+        line: 5
+        character: 3
+- statement: SELECT 'a;b' AS x; SELECT 1;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 18
+    - start:
+        line: 0
+        character: 19
+      end:
+        line: 0
+        character: 28
+- statement: |-
+    SELECT /* inner; */ 1;
+    SELECT 2;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 22
+    - start:
+        line: 1
+        character: 0
+      end:
+        line: 1
+        character: 9


### PR DESCRIPTION
## Summary

- Adds `backend/plugin/parser/tidb/statement_ranges.go`, wiring `omni/tidb.Split` into `base.RegisterStatementRangesFunc(storepb.Engine_TIDB, …)` so the SQL editor's `Ctrl+Enter` can resolve the cursor statement for TiDB connections.
- Closes the TiDB half of [BYT-9157](https://linear.app/bytebase/issue/BYT-9157/add-lsp-statement-ranges-for-mysql-tidb). MySQL half is tracked under BYT-9011.
- Part of [BYT-9141 (omni: tidb)](https://linear.app/bytebase/issue/BYT-9141/omni-tidb), Phase 0 of [plans/2026-04-23-omni-tidb-completion-plan.md](https://github.com/bytebase/bytebase/blob/main/plans/2026-04-23-omni-tidb-completion-plan.md) — this is the first omni/tidb → bytebase integration; the pattern established here will be reused in Phase 1 (completion/normalize/restore/omni shim/tidb.go registration).

## Design note: `Split` (not `Parse`)

The implementation uses `omni/tidb/parser.Split` — a pure lexical scanner — rather than `Parse`. LSP callers request ranges while the user is mid-edit; a grammar-level parse would fail-fast on the first syntax error and drop ranges for every statement, including valid ones earlier in the buffer. `Split` is soft-fail by construction: it identifies statement boundaries at top-level `;` (and DELIMITER-aware custom delimiters) without grammar validation. A dedicated test case asserts this: `SELECT FROM; CREATE TABLE t (id INT);` returns two ranges even though the first statement is syntactically invalid.

## Test coverage

`backend/plugin/parser/tidb/test-data/statement-ranges/standard.yaml` exercises 12 cases:

- Single / multiple statements, with and without trailing `;`
- Leading/trailing whitespace across multiple lines
- Soft-fail on syntactically invalid input
- Multi-byte (emoji) SQL — asserts UTF-16 code-unit offsets on surrogate pairs
- Adjacent statements with no whitespace between `;` and next statement
- Leading block comment attached to the next statement
- Custom `DELIMITER //` + revert
- Compound `BEGIN…END` block under `DELIMITER $$` with inner `;`s that must NOT split
- String literal containing `;`
- Block comment containing `;`

Plus `TestGetStatementRangesEmpty` for blank / whitespace-only / comment-only inputs.

Verification:

```
$ go test -count=1 ./backend/plugin/parser/tidb/...
ok  	github.com/bytebase/bytebase/backend/plugin/parser/tidb	2.542s
$ golangci-lint run --allow-parallel-runners ./backend/plugin/parser/tidb/...
0 issues.
```

## Known Phase-0 simplification

For segments terminated by a *custom* `DELIMITER` (e.g. `//` or `$$`), the returned range end stops at the start of the custom delim, not after it. Default `;` is exact. This is documented inline in `delimLenAt`. Rationale: BYT-9157's cursor-contained-in-range check is unaffected (cursors live inside statement bodies, not on delimiters). If stored-procedure editing surfaces a UX complaint, we extend — small follow-up, not a blocker.

## Behavior change for reviewers to sanity-check

Before this PR, the TiDB engine had no `StatementRangeFunc` registered, so `base.GetStatementRanges` returned an empty slice and LSP's performance optimizer fell back to "execute whole tab" on `Ctrl+Enter`. After this PR, TiDB returns proper ranges and `Ctrl+Enter` without a selection runs the cursor statement — matching the existing MySQL/PG/Snowflake/Doris behavior. The plan's Open Question #2 flagged this as "probably fine (strictly a UX improvement) but worth confirming" — flagging here for Peter / Danny.

## Test plan

- [x] `go test -count=1 ./backend/plugin/parser/tidb/...` — green
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/parser/tidb/...` — 0 issues
- [x] `gofmt -l` on modified files — clean
- [x] `go test -count=1 ./backend/plugin/parser/mysql/...` — no cross-engine regression
- [ ] Manual dev-mode check: TiDB connection, paste `SELECT 1; SELECT 2;` into SQL editor, cursor on second, `Ctrl+Enter` runs only the second statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)