### PR TITLE
fix: remove duplicate Slack webhook title

### DIFF
--- a/backend/plugin/webhook/slack/app.go
+++ b/backend/plugin/webhook/slack/app.go
@@ -206,7 +206,9 @@ func (p *provider) chatPostMessage(ctx context.Context, channelID string, webhoo
 
 	data := url.Values{}
 	data.Set("channel", channelID)
-	data.Set("text", msg.Text)
+	if msg.Text != "" {
+		data.Set("text", msg.Text)
+	}
 	data.Set("attachments", string(attachmentsJSON))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://slack.com/api/chat.postMessage", strings.NewReader(data.Encode()))

--- a/backend/plugin/webhook/slack/slack.go
+++ b/backend/plugin/webhook/slack/slack.go
@@ -68,7 +68,7 @@ type Attachment struct {
 
 // MessagePayload is the API message for Slack webhook.
 type MessagePayload struct {
-	Text        string       `json:"text"`
+	Text        string       `json:"text,omitempty"`
 	BlockList   []Block      `json:"blocks,omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 }
@@ -195,7 +195,6 @@ func BuildMessage(ctx webhook.Context) MessagePayload {
 	}
 
 	return MessagePayload{
-		Text: ctx.Title,
 		Attachments: []Attachment{{
 			Color:     levelColor(ctx.Level),
 			BlockList: blocks,

--- a/backend/plugin/webhook/slack/slack_test.go
+++ b/backend/plugin/webhook/slack/slack_test.go
@@ -29,7 +29,7 @@ func TestBuildMessage_IssueApproved(t *testing.T) {
 
 	msg := BuildMessage(ctx)
 
-	a.Equal("Issue approved", msg.Text)
+	a.Empty(msg.Text)
 	a.Len(msg.Attachments, 1)
 	a.Equal("#2EB67D", msg.Attachments[0].Color)
 
@@ -156,7 +156,7 @@ func TestBuildMessage_JSONStructure(t *testing.T) {
 	// Verify the JSON is valid and has expected top-level structure
 	var parsed map[string]any
 	a.NoError(json.Unmarshal(b, &parsed))
-	a.Equal("Issue approved", parsed["text"])
+	a.NotContains(parsed, "text")
 	a.NotNil(parsed["attachments"])
 
 	attachments, ok := parsed["attachments"].([]any)
@@ -167,6 +167,25 @@ func TestBuildMessage_JSONStructure(t *testing.T) {
 	a.True(ok)
 	a.Equal("#2EB67D", att["color"])
 	a.NotNil(att["blocks"])
+}
+
+func TestBuildMessage_OmitsTopLevelText(t *testing.T) {
+	a := require.New(t)
+
+	ctx := webhook.Context{
+		Level: webhook.WebhookWarn,
+		Title: "Approval required",
+		Link:  "https://bb.example.com/projects/proj-1/issues/42",
+	}
+
+	msg := BuildMessage(ctx)
+	b, err := json.Marshal(msg)
+	a.NoError(err)
+
+	var parsed map[string]any
+	a.NoError(json.Unmarshal(b, &parsed))
+	a.NotContains(parsed, "text")
+	a.Contains(msg.Attachments[0].BlockList[0].Text.Text, "Approval required")
 }
 
 func TestEscapeMrkdwn(t *testing.T) {

--- a/backend/tests/webhook_test.go
+++ b/backend/tests/webhook_test.go
@@ -239,29 +239,25 @@ func TestWebhookIntegration(t *testing.T) {
 		requests := collector.getRequests()
 		require.GreaterOrEqual(t, len(requests), 1, "Expected at least 1 webhook")
 
-		// Find and verify the issue creation webhook
+		// Find and verify the issue creation webhook. Slack incoming webhook
+		// payloads intentionally omit top-level text to avoid rendering a
+		// duplicate message above the attachment card.
 		var foundCorrectWebhook bool
 		for _, req := range requests {
 			require.Equal(t, "POST", req.Method)
 			require.Contains(t, req.Headers.Get("Content-Type"), "application/json")
 
-			var payload map[string]any
-			require.NoError(t, json.Unmarshal(req.Body, &payload))
+			title, desc, err := parseSlackWebhook(req.Body)
+			require.NoError(t, err)
 
-			// Check if this is an issue creation webhook
-			if text, ok := payload["text"].(string); ok && text == "Issue created" {
-				title, desc, err := parseSlackWebhook(req.Body)
-				require.NoError(t, err)
-
-				// The webhook should use plan's description (title support is incomplete)
-				if desc == planDesc {
-					foundCorrectWebhook = true
-					t.Logf("✓ Webhook uses plan's description: %q", desc)
-					if title == "" {
-						t.Logf("⚠️  Issue title is empty (expected: %q)", planTitle)
-					}
-					break
+			// The webhook should use plan's description (title support is incomplete)
+			if desc == planDesc {
+				foundCorrectWebhook = true
+				t.Logf("✓ Webhook uses plan's description: %q", desc)
+				if title == "" {
+					t.Logf("⚠️  Issue title is empty (expected: %q)", planTitle)
 				}
+				break
 			}
 		}
 


### PR DESCRIPTION
## Summary
- Omit the top-level Slack webhook text so Slack only renders the attachment/card title.
- Preserve the card title and attachment payload for incoming webhooks.
- Avoid sending an empty text field when posting Slack app direct messages.

## Test Plan
- go test -v -count=1 ./backend/plugin/webhook/slack
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go