### PR TITLE
fix(frontend): make OtpInput compatible with 2FA autofill extensions

### DIFF
--- a/frontend/src/react/components/ui/otp-input.tsx
+++ b/frontend/src/react/components/ui/otp-input.tsx
@@ -19,16 +19,25 @@ export function OtpInput({
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
 
   const handleChange = useCallback(
-    (index: number, digit: string) => {
-      if (digit && !/^\d$/.test(digit)) return;
+    (index: number, raw: string) => {
+      const digits = raw.replace(/\D/g, "");
       const next = [...value];
       while (next.length < length) next.push("");
-      next[index] = digit;
-      onChange(next);
-      if (digit && index < length - 1) {
-        inputRefs.current[index + 1]?.focus();
+      if (!digits) {
+        next[index] = "";
+        onChange(next);
+        return;
       }
-      if (digit && next.filter((v) => v).length === length) {
+      // Accept multi-digit input here so 2FA autofill extensions that set
+      // `input.value = "123456"` on the first cell get distributed across
+      // cells instead of rejected.
+      for (let i = 0; i < digits.length && index + i < length; i++) {
+        next[index + i] = digits[i];
+      }
+      onChange(next);
+      const focusIndex = Math.min(index + digits.length, length - 1);
+      inputRefs.current[focusIndex]?.focus();
+      if (next.filter((v) => v).length === length) {
         onFinish?.(next);
       }
     },
@@ -77,7 +86,8 @@ export function OtpInput({
           }}
           type="text"
           inputMode="numeric"
-          maxLength={1}
+          name={i === 0 ? "otp" : undefined}
+          maxLength={i === 0 ? length : 1}
           value={value[i] || ""}
           onChange={(e) => handleChange(i, e.target.value)}
           onKeyDown={(e) => handleKeyDown(i, e)}


### PR DESCRIPTION
## Summary
- Name the first OTP cell `otp` so autofill extensions that match on `name`/`id` (2fa/otp/code/totp/…) lock onto cell 0 instead of falling through.
- Raise the first cell's `maxLength` from `1` to `length` so a full code injected via `input.value = "123456"` isn't truncated before `onChange` sees it.
- Rewrite `handleChange` to strip non-digits and distribute the remaining digits across cells starting at `index`. Single keystrokes still land in one cell and advance focus; an injected 6-digit value fills all six cells and triggers `onFinish`.

## Test plan
- [ ] Type digits manually — each cell accepts one digit and focus advances.
- [ ] Backspace on an empty cell moves focus back.
- [ ] Paste a 6-digit code into any cell — fills all cells, triggers `onFinish`.
- [ ] With a 2FA autofill extension (e.g. Authenticator), autofill fills all six cells and submits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)