### PR TITLE
refactor(frontend): decouple react header state

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -31,7 +31,13 @@ import {
   NDialogProvider,
   NNotificationProvider,
 } from "naive-ui";
-import { onErrorCaptured, watch, watchEffect } from "vue";
+import {
+  onErrorCaptured,
+  onMounted,
+  onUnmounted,
+  watch,
+  watchEffect,
+} from "vue";
 import { useRoute, useRouter } from "vue-router";
 import Watermark from "@/components/misc/Watermark.vue";
 import { dateLang, generalLang, themeOverrides } from "../naive-ui.config";
@@ -39,9 +45,9 @@ import AuthContext from "./AuthContext.vue";
 import OverlayStackManager from "./components/misc/OverlayStackManager.vue";
 import { overrideAppProfile } from "./customAppProfile";
 import NotificationContext from "./NotificationContext.vue";
-import { t } from "./plugins/i18n";
+import { locale, t } from "./plugins/i18n";
 import { useNotificationStore } from "./store";
-import { isDev } from "./utils";
+import { isDev, setDocumentTitle } from "./utils";
 
 // Show at most 3 notifications to prevent excessive notification when shit hits the fan.
 const MAX_NOTIFICATION_DISPLAY_COUNT = 3;
@@ -49,6 +55,24 @@ const MAX_NOTIFICATION_DISPLAY_COUNT = 3;
 const route = useRoute();
 const router = useRouter();
 const notificationStore = useNotificationStore();
+
+const handleReactLocaleChange = (event: Event) => {
+  const lang = (event as CustomEvent<unknown>).detail;
+  if (typeof lang === "string") {
+    locale.value = lang;
+    if (route.meta.title) {
+      setDocumentTitle(route.meta.title(route));
+    }
+  }
+};
+
+onMounted(() => {
+  window.addEventListener("bb.react-locale-change", handleReactLocaleChange);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("bb.react-locale-change", handleReactLocaleChange);
+});
 
 watchEffect(async () => {
   // Override app profile.

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -46,7 +46,7 @@ import OverlayStackManager from "./components/misc/OverlayStackManager.vue";
 import { overrideAppProfile } from "./customAppProfile";
 import NotificationContext from "./NotificationContext.vue";
 import { locale, t } from "./plugins/i18n";
-import { useNotificationStore } from "./store";
+import { useNotificationStore, useUIStateStore } from "./store";
 import { isDev, setDocumentTitle } from "./utils";
 
 // Show at most 3 notifications to prevent excessive notification when shit hits the fan.
@@ -55,6 +55,7 @@ const MAX_NOTIFICATION_DISPLAY_COUNT = 3;
 const route = useRoute();
 const router = useRouter();
 const notificationStore = useNotificationStore();
+const uiStateStore = useUIStateStore();
 
 const handleReactLocaleChange = (event: Event) => {
   const lang = (event as CustomEvent<unknown>).detail;
@@ -66,12 +67,37 @@ const handleReactLocaleChange = (event: Event) => {
   }
 };
 
+const handleReactQuickstartReset = (event: Event) => {
+  const keys = (event as CustomEvent<{ keys?: unknown }>).detail?.keys;
+  if (!Array.isArray(keys)) {
+    return;
+  }
+  void Promise.all(
+    keys
+      .filter((key): key is string => typeof key === "string")
+      .map((key) =>
+        uiStateStore.saveIntroStateByKey({
+          key,
+          newState: false,
+        })
+      )
+  );
+};
+
 onMounted(() => {
   window.addEventListener("bb.react-locale-change", handleReactLocaleChange);
+  window.addEventListener(
+    "bb.react-quickstart-reset",
+    handleReactQuickstartReset
+  );
 });
 
 onUnmounted(() => {
   window.removeEventListener("bb.react-locale-change", handleReactLocaleChange);
+  window.removeEventListener(
+    "bb.react-quickstart-reset",
+    handleReactQuickstartReset
+  );
 });
 
 watchEffect(async () => {

--- a/frontend/src/NotificationContext.vue
+++ b/frontend/src/NotificationContext.vue
@@ -4,9 +4,9 @@
 
 <script setup lang="ts">
 import { useNotification } from "naive-ui";
-import { h, watchEffect } from "vue";
+import { h, onMounted, onUnmounted, watchEffect } from "vue";
 import { useNotificationStore } from "@/store";
-import type { BBNotificationStyle } from "@/types";
+import type { BBNotificationStyle, NotificationCreate } from "@/types";
 
 const NOTIFICATION_DURATION = 6000;
 const CRITICAL_NOTIFICATION_DURATION = 10000;
@@ -27,10 +27,7 @@ const getNotificationType = (style: BBNotificationStyle) => {
   }
 };
 
-const watchNotification = () => {
-  const item = notificationStore.tryPopNotification({
-    module: "bytebase",
-  });
+const showNotification = (item: NotificationCreate) => {
   if (!item) {
     return;
   }
@@ -81,5 +78,27 @@ const watchNotification = () => {
   });
 };
 
+const watchNotification = () => {
+  const item = notificationStore.tryPopNotification({
+    module: "bytebase",
+  });
+  if (item) {
+    showNotification(item);
+  }
+};
+
+const handleReactNotification = (event: Event) => {
+  const item = (event as CustomEvent<NotificationCreate>).detail;
+  if (item?.module === "bytebase") {
+    showNotification(item);
+  }
+};
+
 watchEffect(watchNotification);
+onMounted(() => {
+  window.addEventListener("bb.react-notification", handleReactNotification);
+});
+onUnmounted(() => {
+  window.removeEventListener("bb.react-notification", handleReactNotification);
+});
 </script>

--- a/frontend/src/plugins/i18n.ts
+++ b/frontend/src/plugins/i18n.ts
@@ -6,6 +6,18 @@ import { mergedLocalMessage } from "./i18n-messages";
 
 const validLocaleList = ["en-US", "zh-CN", "es-ES", "ja-JP", "vi-VN"];
 
+const normalizeStoredLocale = (stored: string): string => {
+  if (validLocaleList.includes(stored)) {
+    return stored;
+  }
+  try {
+    const parsed = JSON.parse(stored);
+    return typeof parsed === "string" ? parsed : "";
+  } catch {
+    return "";
+  }
+};
+
 const getValidLocale = () => {
   const storage = useLocalStorage<string>(STORAGE_KEY_LANGUAGE, "");
 
@@ -15,7 +27,7 @@ const getValidLocale = () => {
     storage.value = locale;
   }
 
-  locale = storage.value || "";
+  locale = normalizeStoredLocale(storage.value || "");
   if (validLocaleList.includes(locale)) {
     return locale;
   }

--- a/frontend/src/react/components/BytebaseLogo.test.tsx
+++ b/frontend/src/react/components/BytebaseLogo.test.tsx
@@ -8,14 +8,10 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const mocks = vi.hoisted(() => ({
-  useVueState: vi.fn<(getter: () => unknown) => unknown>(),
+  workspaceLogo: "",
   record: vi.fn(),
   push: vi.fn(),
   resolve: vi.fn(() => ({ fullPath: "/landing" })),
-}));
-
-vi.mock("@/react/hooks/useVueState", () => ({
-  useVueState: mocks.useVueState,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -27,20 +23,19 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
-vi.mock("@/store", () => ({
-  useWorkspaceV1Store: vi.fn(),
-}));
-
-vi.mock("@/router", () => ({
-  router: {
-    push: mocks.push,
-    resolve: mocks.resolve,
-  },
-}));
-
-vi.mock("@/router/useRecentVisit", () => ({
+vi.mock("@/react/hooks/useAppState", () => ({
+  useWorkspace: () => ({
+    logo: mocks.workspaceLogo,
+  }),
   useRecentVisit: () => ({
     record: mocks.record,
+  }),
+}));
+
+vi.mock("@/react/router", () => ({
+  useNavigate: () => ({
+    push: mocks.push,
+    resolve: mocks.resolve,
   }),
 }));
 
@@ -74,7 +69,7 @@ beforeEach(async () => {
 
 describe("BytebaseLogo", () => {
   test("renders custom workspace logo when present", () => {
-    mocks.useVueState.mockReturnValue("https://example.com/logo.png");
+    mocks.workspaceLogo = "https://example.com/logo.png";
     const { container, render, unmount } = renderIntoContainer(
       <BytebaseLogo />
     );
@@ -87,7 +82,7 @@ describe("BytebaseLogo", () => {
   });
 
   test("renders fallback Bytebase SVG when workspace has no custom logo", () => {
-    mocks.useVueState.mockReturnValue("");
+    mocks.workspaceLogo = "";
     const { container, render, unmount } = renderIntoContainer(
       <BytebaseLogo />
     );
@@ -100,7 +95,7 @@ describe("BytebaseLogo", () => {
   });
 
   test("records and navigates when a redirect is provided", () => {
-    mocks.useVueState.mockReturnValue("");
+    mocks.workspaceLogo = "";
     const { container, render, unmount } = renderIntoContainer(
       <BytebaseLogo redirect="workspace.landing" />
     );

--- a/frontend/src/react/components/BytebaseLogo.tsx
+++ b/frontend/src/react/components/BytebaseLogo.tsx
@@ -1,10 +1,8 @@
 import { useTranslation } from "react-i18next";
 import logoFull from "@/assets/logo-full.svg";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useRecentVisit, useWorkspace } from "@/react/hooks/useAppState";
 import { cn } from "@/react/lib/utils";
-import { router } from "@/router";
-import { useRecentVisit } from "@/router/useRecentVisit";
-import { useWorkspaceV1Store } from "@/store";
+import { useNavigate } from "@/react/router";
 
 type Props = {
   /** Optional route name — when set, the logo is wrapped in a link that records the visit. */
@@ -19,11 +17,10 @@ type Props = {
  */
 export function BytebaseLogo({ className, redirect }: Props) {
   const { t } = useTranslation();
-  const workspaceStore = useWorkspaceV1Store();
+  const workspace = useWorkspace();
   const { record } = useRecentVisit();
-  const customLogo = useVueState(
-    () => workspaceStore.currentWorkspace?.logo ?? ""
-  );
+  const navigate = useNavigate();
+  const customLogo = workspace?.logo ?? "";
 
   const content = (
     <span className="h-full w-full select-none flex flex-row justify-center items-center">
@@ -55,9 +52,9 @@ export function BytebaseLogo({ className, redirect }: Props) {
           type="button"
           className="h-full w-full cursor-pointer"
           onClick={() => {
-            const route = router.resolve({ name: redirect });
+            const route = navigate.resolve({ name: redirect });
             record(route.fullPath);
-            void router.push(route);
+            void navigate.push({ name: redirect });
           }}
         >
           {content}

--- a/frontend/src/react/components/header/DashboardHeader.test.tsx
+++ b/frontend/src/react/components/header/DashboardHeader.test.tsx
@@ -2,8 +2,10 @@ import type { ReactElement } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { WORKSPACE_ROUTE_MY_ISSUES } from "@/router/dashboard/workspaceRoutes";
-import { SQL_EDITOR_DATABASE_MODULE } from "@/router/sqlEditor";
+import {
+  SQL_EDITOR_DATABASE_MODULE,
+  WORKSPACE_ROUTE_MY_ISSUES,
+} from "@/react/router";
 import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
 
 (
@@ -20,13 +22,14 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   currentPlan: 0,
   currentRoute: {
-    value: {
-      params: {
-        projectId: "sample-project",
-        instanceId: "prod",
-        databaseName: "db",
-      },
+    name: "workspace.project.database.detail",
+    fullPath: "/projects/sample-project",
+    params: {
+      projectId: "sample-project",
+      instanceId: "prod",
+      databaseName: "db",
     },
+    query: {},
   },
 }));
 
@@ -42,8 +45,15 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
-vi.mock("@/react/hooks/useVueState", () => ({
-  useVueState: (getter: () => unknown) => getter(),
+vi.mock("@/react/hooks/useAppState", () => ({
+  useRecentVisit: () => ({
+    record: mocks.record,
+  }),
+  useSubscription: () => ({
+    subscription: {
+      plan: mocks.currentPlan,
+    },
+  }),
 }));
 
 vi.mock("@/react/components/BytebaseLogo", () => ({
@@ -60,39 +70,21 @@ vi.mock("@/react/components/header/ProfileMenuTrigger", () => ({
   ProfileMenuTrigger: () => <div data-testid="profile-menu-trigger" />,
 }));
 
-vi.mock("@/router", () => ({
-  router: {
-    currentRoute: mocks.currentRoute,
+vi.mock("@/react/router", () => ({
+  useCurrentRoute: () => mocks.currentRoute,
+  useNavigate: () => ({
     resolve: mocks.resolve,
     push: mocks.push,
-  },
-}));
-
-vi.mock("@/router/dashboard/workspaceRoutes", () => ({
+  }),
   WORKSPACE_ROUTE_LANDING: "workspace.landing",
   WORKSPACE_ROUTE_MY_ISSUES: "workspace.my-issues",
-}));
-
-vi.mock("@/router/sqlEditor", () => ({
   SQL_EDITOR_HOME_MODULE: "sql-editor.home",
   SQL_EDITOR_PROJECT_MODULE: "sql-editor.project",
   SQL_EDITOR_DATABASE_MODULE: "sql-editor.database",
 }));
 
-vi.mock("@/router/useRecentVisit", () => ({
-  useRecentVisit: () => ({
-    record: mocks.record,
-  }),
-}));
-
-vi.mock("@/utils", () => ({
+vi.mock("@/utils/storage-keys", () => ({
   STORAGE_KEY_MY_ISSUES_TAB: "bb.components.MY_ISSUES.id",
-}));
-
-vi.mock("@/store", () => ({
-  useSubscriptionV1Store: () => ({
-    currentPlan: mocks.currentPlan,
-  }),
 }));
 
 vi.mock("@/react/plugins/agent/store/agent", () => ({
@@ -133,12 +125,15 @@ beforeEach(async () => {
   });
   window.open = vi.fn();
   mocks.currentPlan = PlanType.FREE;
-  mocks.currentRoute.value = {
+  mocks.currentRoute = {
+    name: "workspace.project.database.detail",
+    fullPath: "/projects/sample-project",
     params: {
       projectId: "sample-project",
       instanceId: "prod",
       databaseName: "db",
     },
+    query: {},
   };
   ({ DashboardHeader } = await import("./DashboardHeader"));
 });

--- a/frontend/src/react/components/header/DashboardHeader.tsx
+++ b/frontend/src/react/components/header/DashboardHeader.tsx
@@ -10,21 +10,18 @@ import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
 import { BytebaseLogo } from "@/react/components/BytebaseLogo";
 import { Button } from "@/react/components/ui/button";
-import { useVueState } from "@/react/hooks/useVueState";
-import { router } from "@/router";
-import {
-  WORKSPACE_ROUTE_LANDING,
-  WORKSPACE_ROUTE_MY_ISSUES,
-} from "@/router/dashboard/workspaceRoutes";
+import { useRecentVisit, useSubscription } from "@/react/hooks/useAppState";
 import {
   SQL_EDITOR_DATABASE_MODULE,
   SQL_EDITOR_HOME_MODULE,
   SQL_EDITOR_PROJECT_MODULE,
-} from "@/router/sqlEditor";
-import { useRecentVisit } from "@/router/useRecentVisit";
-import { useSubscriptionV1Store } from "@/store";
+  useCurrentRoute,
+  useNavigate,
+  WORKSPACE_ROUTE_LANDING,
+  WORKSPACE_ROUTE_MY_ISSUES,
+} from "@/react/router";
 import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
-import { STORAGE_KEY_MY_ISSUES_TAB } from "@/utils";
+import { STORAGE_KEY_MY_ISSUES_TAB } from "@/utils/storage-keys";
 import { ProfileMenuTrigger } from "./ProfileMenuTrigger";
 import { ProjectSwitchPopover } from "./ProjectSwitchPopover";
 
@@ -50,10 +47,10 @@ export function DashboardHeader({
 }: DashboardHeaderProps) {
   const { t } = useTranslation();
   const { record } = useRecentVisit();
-  const subscriptionStore = useSubscriptionV1Store();
-
-  const currentPlan = useVueState(() => subscriptionStore.currentPlan);
-  const route = useVueState(() => router.currentRoute.value);
+  const { subscription } = useSubscription();
+  const route = useCurrentRoute();
+  const navigate = useNavigate();
+  const currentPlan = subscription?.plan ?? PlanType.FREE;
   const windowWidth = useSyncExternalStore(
     subscribeToViewport,
     getWindowWidth,
@@ -69,7 +66,7 @@ export function DashboardHeader({
 
     if (projectId) {
       if (instanceId && databaseName) {
-        return router.resolve({
+        return navigate.resolve({
           name: SQL_EDITOR_DATABASE_MODULE,
           params: {
             project: projectId,
@@ -78,7 +75,7 @@ export function DashboardHeader({
           },
         }).href;
       }
-      return router.resolve({
+      return navigate.resolve({
         name: SQL_EDITOR_PROJECT_MODULE,
         params: {
           project: projectId,
@@ -86,10 +83,11 @@ export function DashboardHeader({
       }).href;
     }
 
-    return router.resolve({
+    return navigate.resolve({
       name: SQL_EDITOR_HOME_MODULE,
     }).href;
   }, [
+    navigate,
     route.params.databaseName,
     route.params.instanceId,
     route.params.projectId,
@@ -97,10 +95,10 @@ export function DashboardHeader({
 
   const myIssueHref = useMemo(
     () =>
-      router.resolve({
+      navigate.resolve({
         name: WORKSPACE_ROUTE_MY_ISSUES,
       }).href,
-    []
+    [navigate]
   );
 
   return (
@@ -173,7 +171,7 @@ export function DashboardHeader({
           onClick={() => {
             record(myIssueHref);
             localStorage.setItem(STORAGE_KEY_MY_ISSUES_TAB, uuidv4());
-            void router.push({ name: WORKSPACE_ROUTE_MY_ISSUES });
+            void navigate.push({ name: WORKSPACE_ROUTE_MY_ISSUES });
           }}
         >
           <CircleDot className="h-4 w-4" />

--- a/frontend/src/react/components/header/ProfileMenuTrigger.test.tsx
+++ b/frontend/src/react/components/header/ProfileMenuTrigger.test.tsx
@@ -2,7 +2,8 @@ import type { ReactElement } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { WORKSPACE_ROUTE_LANDING } from "@/router/dashboard/workspaceRoutes";
+import { WORKSPACE_ROUTE_LANDING } from "@/react/router";
+import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -15,14 +16,20 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   resolve: vi.fn(({ name }: { name: string }) => ({ fullPath: `/${name}` })),
   currentRoute: {
-    value: {
-      name: "sql-editor.home",
-    },
+    name: "sql-editor.home",
+    fullPath: "/sql-editor",
+    params: {},
+    query: {},
   },
+  resetQuickstart: vi.fn(),
+  hideQuickStart: false,
 }));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
+    i18n: {
+      language: "en-US",
+    },
     t: (key: string) =>
       ({
         "common.language": "Language",
@@ -38,20 +45,6 @@ vi.mock("react-i18next", () => ({
         "subscription.plan.enterprise.title": "Enterprise",
       })[key] ?? key,
   }),
-}));
-
-vi.mock("@/plugins/i18n", () => ({
-  default: {
-    global: {
-      locale: {
-        value: "en-US",
-      },
-    },
-  },
-}));
-
-vi.mock("@/react/hooks/useVueState", () => ({
-  useVueState: (getter: () => unknown) => getter(),
 }));
 
 vi.mock("@/react/components/UserAvatar", () => ({
@@ -95,61 +88,52 @@ vi.mock("@/react/components/header/VersionMenuItem", () => ({
 
 vi.mock("./common", () => ({
   HEADER_LANGUAGE_OPTIONS: [{ label: "English", value: "en-US" }],
-  resetQuickstartProgress: vi.fn(),
   setAppLocale: mocks.emitStorageChangedEvent,
 }));
 
-vi.mock("@/router", () => ({
-  router: {
-    currentRoute: mocks.currentRoute,
+vi.mock("@/react/router", () => ({
+  useCurrentRoute: () => mocks.currentRoute,
+  useNavigate: () => ({
     push: mocks.push,
     resolve: mocks.resolve,
-  },
-}));
-
-vi.mock("@/router/dashboard/workspaceRoutes", () => ({
+  }),
+  isSqlEditorRouteName: (name?: string) => name?.startsWith("sql-editor"),
+  AUTH_SIGNIN_MODULE: "auth.signin",
   WORKSPACE_ROUTE_LANDING: "workspace.landing",
-  WORKSPACE_ROUTE_MY_ISSUES: "workspace.my-issues",
-}));
-
-vi.mock("@/router/dashboard/workspaceSetting", () => ({
   SETTING_ROUTE_PROFILE: "setting.profile",
-}));
-
-vi.mock("@/router/sqlEditor", () => ({
   SQL_EDITOR_HOME_MODULE: "sql-editor.home",
 }));
 
-vi.mock("@/store", () => ({
-  useActuatorV1Store: () => ({
-    quickStartEnabled: true,
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => ({
+    title: "Alice",
+    email: "alice@example.com",
   }),
-  useAuthStore: () => ({
-    logout: mocks.logout,
+  useServerInfo: () => ({
+    enableSample: true,
+    activatedUserCount: 1,
   }),
-  useCurrentUserV1: () => ({
-    value: {
-      title: "Alice",
-      email: "alice@example.com",
-    },
-  }),
-  useSubscriptionV1Store: () => ({
-    currentPlan: 0,
+  useSubscription: () => ({
+    subscription: { plan: PlanType.FREE },
     uploadLicense: mocks.uploadLicense,
   }),
-  useUIStateStore: () => ({
-    saveIntroStateByKey: vi.fn(),
+  useWorkspace: () => ({
+    logo: "",
   }),
-  useWorkspaceV1Store: () => ({
-    currentWorkspace: {
-      logo: "",
-    },
-  }),
+  useAppFeature: () => mocks.hideQuickStart,
+  useQuickstartReset: () => mocks.resetQuickstart,
 }));
 
-vi.mock("@/utils", () => ({
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: {
+    getState: () => ({
+      logout: mocks.logout,
+    }),
+  },
+}));
+
+vi.mock("@/utils/util", () => ({
   isDev: () => false,
-  isSQLEditorRoute: () => true,
 }));
 
 let ProfileMenuTrigger: typeof import("./ProfileMenuTrigger").ProfileMenuTrigger;
@@ -175,6 +159,7 @@ const renderIntoContainer = (element: ReactElement) => {
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  mocks.hideQuickStart = false;
   window.open = vi.fn();
   ({ ProfileMenuTrigger } = await import("./ProfileMenuTrigger"));
 });
@@ -215,6 +200,18 @@ describe("ProfileMenuTrigger", () => {
     });
     expect(mocks.logout).toHaveBeenCalled();
 
+    unmount();
+  });
+
+  test("hides quick start when the app feature disables it", () => {
+    mocks.hideQuickStart = true;
+    const { container, render, unmount } = renderIntoContainer(
+      <ProfileMenuTrigger size="medium" link />
+    );
+
+    render();
+
+    expect(container.textContent).not.toContain("Quick Start");
     unmount();
   });
 });

--- a/frontend/src/react/components/header/ProfileMenuTrigger.tsx
+++ b/frontend/src/react/components/header/ProfileMenuTrigger.tsx
@@ -1,7 +1,6 @@
 import { ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import i18n from "@/plugins/i18n";
 import { UserAvatar } from "@/react/components/UserAvatar";
 import {
   DropdownMenu,
@@ -13,26 +12,27 @@ import {
   DropdownMenuSubmenuTrigger,
   DropdownMenuTrigger,
 } from "@/react/components/ui/dropdown-menu";
-import { useVueState } from "@/react/hooks/useVueState";
-import { router } from "@/router";
-import { WORKSPACE_ROUTE_LANDING } from "@/router/dashboard/workspaceRoutes";
-import { SETTING_ROUTE_PROFILE } from "@/router/dashboard/workspaceSetting";
-import { SQL_EDITOR_HOME_MODULE } from "@/router/sqlEditor";
 import {
-  useActuatorV1Store,
-  useAuthStore,
-  useCurrentUserV1,
-  useSubscriptionV1Store,
-  useUIStateStore,
-  useWorkspaceV1Store,
-} from "@/store";
+  useAppFeature,
+  useCurrentUser,
+  useQuickstartReset,
+  useServerInfo,
+  useSubscription,
+  useWorkspace,
+} from "@/react/hooks/useAppState";
+import {
+  AUTH_SIGNIN_MODULE,
+  isSqlEditorRouteName,
+  SETTING_ROUTE_PROFILE,
+  SQL_EDITOR_HOME_MODULE,
+  useCurrentRoute,
+  useNavigate,
+  WORKSPACE_ROUTE_LANDING,
+} from "@/react/router";
+import { useAppStore } from "@/react/stores/app";
 import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
-import { isDev, isSQLEditorRoute } from "@/utils";
-import {
-  HEADER_LANGUAGE_OPTIONS,
-  resetQuickstartProgress,
-  setAppLocale,
-} from "./common";
+import { isDev } from "@/utils/util";
+import { HEADER_LANGUAGE_OPTIONS, setAppLocale } from "./common";
 import { VersionMenuItem } from "./VersionMenuItem";
 
 export interface ProfileMenuProps {
@@ -44,23 +44,21 @@ export function ProfileMenuTrigger({
   size = "medium",
   link = true,
 }: ProfileMenuProps) {
-  const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
-  const authStore = useAuthStore();
-  const subscriptionStore = useSubscriptionV1Store();
-  const uiStateStore = useUIStateStore();
-  const workspaceStore = useWorkspaceV1Store();
-
-  const currentUser = useVueState(() => useCurrentUserV1().value);
-  const currentLocale = useVueState(() => i18n.global.locale.value as string);
-  const currentRouteName = useVueState(
-    () => router.currentRoute.value.name?.toString() ?? ""
-  );
-  const currentPlan = useVueState(() => subscriptionStore.currentPlan);
-  const quickStartEnabled = useVueState(() => actuatorStore.quickStartEnabled);
-  const customLogo = useVueState(
-    () => workspaceStore.currentWorkspace?.logo ?? ""
-  );
+  const { t, i18n } = useTranslation();
+  const currentUser = useCurrentUser();
+  const serverInfo = useServerInfo();
+  const { subscription, uploadLicense } = useSubscription();
+  const workspace = useWorkspace();
+  const route = useCurrentRoute();
+  const navigate = useNavigate();
+  const resetQuickstartProgress = useQuickstartReset();
+  const hideQuickStart = useAppFeature("bb.feature.hide-quick-start");
+  const currentPlan = subscription?.plan ?? PlanType.FREE;
+  const quickStartEnabled =
+    !hideQuickStart &&
+    Boolean(serverInfo?.enableSample) &&
+    (serverInfo?.activatedUserCount ?? 0) <= 1;
+  const customLogo = workspace?.logo ?? "";
   const [open, setOpen] = useState(false);
 
   const wrapperClass = useMemo(() => {
@@ -74,19 +72,19 @@ export function ProfileMenuTrigger({
 
   const logoClass = size === "small" ? "mr-2" : "mr-4";
 
-  const sqlEditorMenuLabel = currentRouteName.startsWith("sql-editor")
+  const sqlEditorMenuLabel = isSqlEditorRouteName(route.name)
     ? t("settings.general.workspace.default-landing-page.go-to-workspace")
     : t("settings.general.workspace.default-landing-page.go-to-sql-editor");
 
   const handleProfileNavigate = () => {
     if (!link) return;
     setOpen(false);
-    void router.push({ name: SETTING_ROUTE_PROFILE });
+    void navigate.push({ name: SETTING_ROUTE_PROFILE });
   };
 
   const handleWorkspaceToggle = () => {
-    const target = router.resolve({
-      name: isSQLEditorRoute(router)
+    const target = navigate.resolve({
+      name: isSqlEditorRouteName(route.name)
         ? WORKSPACE_ROUTE_LANDING
         : SQL_EDITOR_HOME_MODULE,
     });
@@ -95,7 +93,7 @@ export function ProfileMenuTrigger({
   };
 
   const switchPlan = (license: string) => {
-    void subscriptionStore.uploadLicense(license);
+    void uploadLicense(license);
     setOpen(false);
   };
 
@@ -118,7 +116,7 @@ export function ProfileMenuTrigger({
           <UserAvatar
             size="sm"
             className="cursor-pointer"
-            title={currentUser.title || currentUser.email}
+            title={currentUser?.title || currentUser?.email || ""}
           />
         </DropdownMenuTrigger>
 
@@ -130,11 +128,11 @@ export function ProfileMenuTrigger({
             <div className="text-left">
               <p className="flex justify-between gap-x-2 text-sm">
                 <span className="truncate font-medium text-main">
-                  {currentUser.title}
+                  {currentUser?.title}
                 </span>
               </p>
               <p className="truncate text-sm text-control">
-                {currentUser.email}
+                {currentUser?.email}
               </p>
             </div>
           </DropdownMenuItem>
@@ -151,7 +149,7 @@ export function ProfileMenuTrigger({
                 <DropdownMenuItem
                   key={item.value}
                   className={
-                    item.value === currentLocale ? "bg-control-bg" : ""
+                    item.value === i18n.language ? "bg-control-bg" : ""
                   }
                   onClick={() => {
                     setAppLocale(item.value);
@@ -162,7 +160,7 @@ export function ProfileMenuTrigger({
                     <input
                       type="radio"
                       readOnly
-                      checked={item.value === currentLocale}
+                      checked={item.value === i18n.language}
                     />
                   </span>
                   {item.label}
@@ -217,7 +215,7 @@ export function ProfileMenuTrigger({
           {quickStartEnabled ? (
             <DropdownMenuItem
               onClick={() => {
-                resetQuickstartProgress(uiStateStore);
+                resetQuickstartProgress();
                 setOpen(false);
               }}
             >
@@ -238,7 +236,15 @@ export function ProfileMenuTrigger({
           <DropdownMenuItem
             onClick={() => {
               setOpen(false);
-              authStore.logout();
+              const redirect =
+                route.fullPath.startsWith("/auth") || !route.fullPath
+                  ? undefined
+                  : route.fullPath;
+              const signinUrl = navigate.resolve({
+                name: AUTH_SIGNIN_MODULE,
+                query: { redirect },
+              }).fullPath;
+              void useAppStore.getState().logout(signinUrl);
             }}
           >
             {t("common.logout")}

--- a/frontend/src/react/components/header/ProjectCreateDialog.tsx
+++ b/frontend/src/react/components/header/ProjectCreateDialog.tsx
@@ -15,12 +15,16 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
-import { router } from "@/router";
-import { pushNotification, useProjectV1Store, useUIStateStore } from "@/store";
-import { projectNamePrefix } from "@/store/modules/v1/common";
-import { unknownProject } from "@/types";
+import {
+  isConnectAlreadyExists,
+  useCreateProject,
+  useNotify,
+  useWorkspacePermission,
+} from "@/react/hooks/useAppState";
+import { projectNamePrefix } from "@/react/lib/resourceName";
+import { useNavigate } from "@/react/router";
+import { useAppStore } from "@/react/stores/app";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
-import { hasWorkspacePermissionV2 } from "@/utils";
 
 export interface ProjectCreateDialogProps {
   open: boolean;
@@ -34,8 +38,10 @@ export function ProjectCreateDialog({
   onCreated,
 }: ProjectCreateDialogProps) {
   const { t } = useTranslation();
-  const projectStore = useProjectV1Store();
-  const uiStateStore = useUIStateStore();
+  const navigate = useNavigate();
+  const { createProject, setRecentProject } = useCreateProject();
+  const notify = useNotify();
+  const hasCreatePermission = useWorkspacePermission("bb.projects.create");
   const defaultProjectTitle = t("quick-action.new-project");
   const [title, setTitle] = useState(defaultProjectTitle);
   const [resourceId, setResourceId] = useState("");
@@ -54,17 +60,19 @@ export function ProjectCreateDialog({
   const allowCreate = useMemo(() => {
     if (!title.trim()) return false;
     if (!isResourceIdValid) return false;
-    if (!hasWorkspacePermissionV2("bb.projects.create")) return false;
+    if (!hasCreatePermission) return false;
     return true;
-  }, [isResourceIdValid, title]);
+  }, [hasCreatePermission, isResourceIdValid, title]);
 
   const validate = useCallback(
     async (id: string) => {
       try {
-        await projectStore.getOrFetchProjectByName(
-          `${projectNamePrefix}${id}`,
-          true
-        );
+        const existing = await useAppStore
+          .getState()
+          .fetchProject(`${projectNamePrefix}${id}`);
+        if (!existing) {
+          return [];
+        }
         return [
           {
             type: "error" as const,
@@ -77,7 +85,7 @@ export function ProjectCreateDialog({
         return [];
       }
     },
-    [projectStore, t]
+    [t]
   );
 
   const handleCreate = useCallback(async () => {
@@ -85,12 +93,9 @@ export function ProjectCreateDialog({
 
     try {
       setIsCreating(true);
-      const createdProject = await projectStore.createProject(
-        { ...unknownProject(), title },
-        resourceId
-      );
+      const createdProject = await createProject(title, resourceId);
 
-      pushNotification({
+      notify({
         module: "bytebase",
         style: "SUCCESS",
         title: t("project.create-modal.success-prompt", {
@@ -101,16 +106,16 @@ export function ProjectCreateDialog({
       if (onCreated) {
         onCreated(createdProject);
       } else {
-        void uiStateStore.saveIntroStateByKey({
-          key: "project.visit",
-          newState: true,
-        });
-        void router.push({ path: `/${createdProject.name}` });
+        setRecentProject(createdProject.name);
+        void navigate.push({ path: `/${createdProject.name}` });
       }
 
       onClose();
     } catch (error) {
-      if (error instanceof ConnectError && error.code === Code.AlreadyExists) {
+      if (
+        isConnectAlreadyExists(error) ||
+        (error instanceof ConnectError && error.code === Code.AlreadyExists)
+      ) {
         resourceIdFieldRef.current?.addValidationError(error.message);
       } else {
         throw error;
@@ -121,13 +126,15 @@ export function ProjectCreateDialog({
   }, [
     allowCreate,
     isCreating,
+    createProject,
+    navigate,
+    notify,
     onClose,
     onCreated,
-    projectStore,
     resourceId,
+    setRecentProject,
     t,
     title,
-    uiStateStore,
   ]);
 
   return (

--- a/frontend/src/react/components/header/ProjectSwitchPanel.test.tsx
+++ b/frontend/src/react/components/header/ProjectSwitchPanel.test.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { PROJECT_V1_ROUTE_DETAIL } from "@/router/dashboard/projectV1";
+import { PROJECT_V1_ROUTE_DETAIL } from "@/react/router";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -27,11 +27,12 @@ const mocks = vi.hoisted(() => ({
     fullPath: `/projects/${params.projectId}`,
   })),
   currentRoute: {
-    value: {
-      params: {
-        projectId: "recent-project",
-      },
+    name: "workspace.project.detail",
+    fullPath: "/projects/recent-project",
+    params: {
+      projectId: "recent-project",
     },
+    query: {},
   },
   requestCreate: vi.fn(),
   close: vi.fn(),
@@ -50,23 +51,21 @@ vi.mock("react-i18next", () => ({
         "common.loading": "Loading",
         "common.rows-per-page": "Rows per page",
         "common.load-more": "Load more",
+        "quick-action.new-project": "New Project",
       })[key] ?? key,
   }),
 }));
 
-vi.mock("@/react/hooks/useVueState", () => ({
-  useVueState: (getter: () => unknown) => getter(),
-}));
-
-vi.mock("@/components/Project/useRecentProjects", () => ({
-  useRecentProjects: () => ({
-    recentViewProjects: { value: [recentProject] },
+vi.mock("@/react/hooks/useAppState", () => ({
+  useRecentVisit: () => ({
+    record: mocks.record,
   }),
-}));
-
-vi.mock("@/react/hooks/usePagedData", () => ({
-  usePagedData: () => ({
-    dataList: [allProject],
+  useProject: () => recentProject,
+  useRecentProjects: () => ({
+    projects: [recentProject],
+  }),
+  useProjectList: () => ({
+    projects: [allProject],
     isLoading: false,
     isFetchingMore: false,
     hasMore: false,
@@ -75,45 +74,19 @@ vi.mock("@/react/hooks/usePagedData", () => ({
     pageSizeOptions: [50],
     onPageSizeChange: vi.fn(),
   }),
-  PagedTableFooter: () => <div data-testid="paged-footer" />,
+  useWorkspacePermission: () => true,
+  projectMatchesKeyword: (project: typeof recentProject, keyword: string) =>
+    project.title.toLowerCase().includes(keyword.toLowerCase()),
 }));
 
-vi.mock("@/router", () => ({
-  router: {
-    currentRoute: mocks.currentRoute,
+vi.mock("@/react/router", () => ({
+  useCurrentRoute: () => mocks.currentRoute,
+  useNavigate: () => ({
     resolve: mocks.resolve,
     push: mocks.push,
-  },
-}));
-
-vi.mock("@/router/useRecentVisit", () => ({
-  useRecentVisit: () => ({
-    record: mocks.record,
   }),
-}));
-
-vi.mock("@/store", () => ({
-  useProjectV1Store: () => ({
-    getProjectByName: (name: string) =>
-      name === "projects/recent-project" ? recentProject : allProject,
-  }),
-}));
-
-vi.mock("@/types", () => ({
-  isDefaultProject: () => false,
-  isValidProjectName: () => true,
-}));
-
-vi.mock("@/utils", () => ({
-  filterProjectV1ListByKeyword: (
-    list: (typeof recentProject)[],
-    keyword: string
-  ) =>
-    list.filter((project) =>
-      project.title.toLowerCase().includes(keyword.toLowerCase())
-    ),
-  hasWorkspacePermissionV2: () => true,
-  isDev: () => false,
+  PROJECT_V1_ROUTE_DETAIL: "workspace.project.detail",
+  WORKSPACE_ROUTE_LANDING: "workspace.landing",
 }));
 
 vi.mock("@/react/components/ui/tabs", () => ({
@@ -204,8 +177,8 @@ describe("ProjectSwitchPanel", () => {
 
     render();
 
-    const createButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent === ""
+    const createButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="New Project"]'
     );
     expect(createButton).not.toBeUndefined();
     act(() => {

--- a/frontend/src/react/components/header/ProjectSwitchPanel.tsx
+++ b/frontend/src/react/components/header/ProjectSwitchPanel.tsx
@@ -7,30 +7,41 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { useRecentProjects } from "@/components/Project/useRecentProjects";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/react/components/ui/select";
 import {
   Tabs,
   TabsList,
   TabsPanel,
   TabsTrigger,
 } from "@/react/components/ui/tabs";
-import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
-import { useVueState } from "@/react/hooks/useVueState";
-import { router } from "@/router";
-import { PROJECT_V1_ROUTE_DETAIL } from "@/router/dashboard/projectV1";
-import { WORKSPACE_ROUTE_LANDING } from "@/router/dashboard/workspaceRoutes";
-import { useRecentVisit } from "@/router/useRecentVisit";
-import { useProjectV1Store } from "@/store";
-import { getProjectName, projectNamePrefix } from "@/store/modules/v1/common";
-import { isDefaultProject, isValidProjectName } from "@/types";
-import { State } from "@/types/proto-es/v1/common_pb";
-import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import {
-  filterProjectV1ListByKeyword,
-  hasWorkspacePermissionV2,
-} from "@/utils";
+  projectMatchesKeyword,
+  useProject,
+  useProjectList,
+  useRecentProjects,
+  useRecentVisit,
+  useWorkspacePermission,
+} from "@/react/hooks/useAppState";
+import {
+  getProjectName,
+  isValidProjectName,
+  projectNamePrefix,
+} from "@/react/lib/resourceName";
+import {
+  PROJECT_V1_ROUTE_DETAIL,
+  useCurrentRoute,
+  useNavigate,
+  WORKSPACE_ROUTE_LANDING,
+} from "@/react/router";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
 
 export interface ProjectSwitchPanelProps {
   onClose: () => void;
@@ -38,6 +49,54 @@ export interface ProjectSwitchPanelProps {
 }
 
 type ProjectSwitchTab = "recent" | "all";
+
+function ProjectSwitchFooter({
+  pageSize,
+  pageSizeOptions,
+  hasMore,
+  isFetchingMore,
+  onPageSizeChange,
+  onLoadMore,
+}: {
+  pageSize: number;
+  pageSizeOptions: number[];
+  hasMore: boolean;
+  isFetchingMore: boolean;
+  onPageSizeChange: (size: number) => void;
+  onLoadMore: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center justify-end gap-x-3 text-sm text-control-light">
+      <span className="whitespace-nowrap">{t("common.rows-per-page")}</span>
+      <Select
+        value={String(pageSize)}
+        onValueChange={(value) => onPageSizeChange(Number(value))}
+      >
+        <SelectTrigger size="sm" className="w-20 text-control">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {pageSizeOptions.map((option) => (
+            <SelectItem key={option} value={String(option)}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {hasMore ? (
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={isFetchingMore}
+          onClick={onLoadMore}
+        >
+          {isFetchingMore ? t("common.loading") : t("common.load-more")}
+        </Button>
+      ) : null}
+    </div>
+  );
+}
 
 function ProjectRow({
   project,
@@ -100,22 +159,18 @@ export function ProjectSwitchPanel({
   onRequestCreate,
 }: ProjectSwitchPanelProps) {
   const { t } = useTranslation();
-  const projectStore = useProjectV1Store();
   const { record } = useRecentVisit();
-  const { recentViewProjects } = useRecentProjects();
+  const navigate = useNavigate();
+  const route = useCurrentRoute();
+  const { projects: recentProjectList } = useRecentProjects();
   const [searchText, setSearchText] = useState("");
   const [selectedTab, setSelectedTab] = useState<ProjectSwitchTab>("all");
-  const currentProjectName = useVueState(() => {
-    const projectId = router.currentRoute.value.params.projectId as
-      | string
-      | undefined;
-    return projectId ? `${projectNamePrefix}${projectId}` : "";
-  });
-  const currentProject = useVueState(() =>
-    projectStore.getProjectByName(currentProjectName)
-  );
-  const recentProjectList = useVueState(() => recentViewProjects.value ?? []);
-  const allowToCreateProject = hasWorkspacePermissionV2("bb.projects.create");
+  const projectId = route.params.projectId as string | undefined;
+  const currentProjectName = projectId
+    ? `${projectNamePrefix}${projectId}`
+    : "";
+  const currentProject = useProject(currentProjectName);
+  const allowToCreateProject = useWorkspacePermission("bb.projects.create");
 
   useEffect(() => {
     if (recentProjectList.length > 0) {
@@ -124,9 +179,8 @@ export function ProjectSwitchPanel({
   }, [recentProjectList.length]);
 
   const filteredRecentProjectList = useMemo(() => {
-    return filterProjectV1ListByKeyword(
-      recentProjectList.filter((project) => !isDefaultProject(project.name)),
-      searchText
+    return recentProjectList.filter((project) =>
+      projectMatchesKeyword(project, searchText)
     );
   }, [recentProjectList, searchText]);
 
@@ -142,7 +196,7 @@ export function ProjectSwitchPanel({
   }, [filteredRecentProjectList.length, searchText, selectedTab]);
 
   const {
-    dataList: allProjects,
+    projects: allProjects,
     isLoading,
     isFetchingMore,
     hasMore,
@@ -150,35 +204,11 @@ export function ProjectSwitchPanel({
     pageSize,
     pageSizeOptions,
     onPageSizeChange,
-  } = usePagedData<Project>({
-    sessionKey: "bb.project-switch",
-    fetchList: useCallback(
-      async ({ pageSize, pageToken }) => {
-        const { projects, nextPageToken } = await projectStore.fetchProjectList(
-          {
-            pageSize,
-            pageToken,
-            filter: {
-              query: searchText,
-              excludeDefault: true,
-              state: State.ACTIVE,
-            },
-            orderBy: "title",
-            cache: true,
-          }
-        );
-        return {
-          list: projects,
-          nextPageToken,
-        };
-      },
-      [projectStore, searchText]
-    ),
-  });
+  } = useProjectList(searchText);
 
   const handleProjectSelect = useCallback(
     (project: Project, event: ReactMouseEvent<HTMLButtonElement>) => {
-      const route = router.resolve({
+      const route = navigate.resolve({
         name: PROJECT_V1_ROUTE_DETAIL,
         params: {
           projectId: getProjectName(project.name),
@@ -189,17 +219,22 @@ export function ProjectSwitchPanel({
       if (event.ctrlKey || event.metaKey) {
         window.open(route.fullPath, "_blank");
       } else {
-        void router.push(route);
+        void navigate.push({
+          name: PROJECT_V1_ROUTE_DETAIL,
+          params: {
+            projectId: getProjectName(project.name),
+          },
+        });
       }
 
       onClose();
     },
-    [onClose, record]
+    [navigate, onClose, record]
   );
 
   const handleGotoWorkspace = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
-      const route = router.resolve({
+      const route = navigate.resolve({
         name: WORKSPACE_ROUTE_LANDING,
       });
       record(route.fullPath);
@@ -207,17 +242,17 @@ export function ProjectSwitchPanel({
       if (event.ctrlKey || event.metaKey) {
         window.open(route.fullPath, "_blank");
       } else {
-        void router.push(route.fullPath);
+        void navigate.push({ name: WORKSPACE_ROUTE_LANDING });
       }
 
       onClose();
     },
-    [onClose, record]
+    [navigate, onClose, record]
   );
 
   return (
     <div className="flex w-full max-h-[calc(100vh-10rem)] flex-col">
-      {isValidProjectName(currentProject.name) ? (
+      {isValidProjectName(currentProject?.name) ? (
         <Button
           variant="ghost"
           size="sm"
@@ -311,7 +346,7 @@ export function ProjectSwitchPanel({
           </div>
 
           <div className="mt-2 border-t border-control-border pt-2">
-            <PagedTableFooter
+            <ProjectSwitchFooter
               pageSize={pageSize}
               pageSizeOptions={pageSizeOptions}
               onPageSizeChange={onPageSizeChange}

--- a/frontend/src/react/components/header/ProjectSwitchPopover.tsx
+++ b/frontend/src/react/components/header/ProjectSwitchPopover.tsx
@@ -6,31 +6,29 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/react/components/ui/popover";
-import { useVueState } from "@/react/hooks/useVueState";
-import { router } from "@/router";
-import { useProjectV1Store } from "@/store";
-import { projectNamePrefix } from "@/store/modules/v1/common";
-import { isValidProjectName } from "@/types";
+import { useProject } from "@/react/hooks/useAppState";
+import {
+  isValidProjectName,
+  projectNamePrefix,
+} from "@/react/lib/resourceName";
+import { useCurrentRoute } from "@/react/router";
 import { ProjectCreateDialog } from "./ProjectCreateDialog";
 import { ProjectSwitchPanel } from "./ProjectSwitchPanel";
 
 export function ProjectSwitchPopover() {
   const { t } = useTranslation();
-  const projectStore = useProjectV1Store();
   const [open, setOpen] = useState(false);
   const [createOpen, setCreateOpen] = useState(false);
-  const routeKey = useVueState(() => router.currentRoute.value.fullPath);
-  const currentProject = useVueState(() => {
-    const projectId = router.currentRoute.value.params.projectId as
-      | string
-      | undefined;
-    const projectName = projectId ? `${projectNamePrefix}${projectId}` : "";
-    return projectStore.getProjectByName(projectName);
-  });
+  const route = useCurrentRoute();
+  const projectId = route.params.projectId as string | undefined;
+  const currentProjectName = projectId
+    ? `${projectNamePrefix}${projectId}`
+    : "";
+  const currentProject = useProject(currentProjectName);
 
   useEffect(() => {
     setOpen(false);
-  }, [routeKey]);
+  }, [route.fullPath]);
 
   return (
     <>
@@ -44,7 +42,7 @@ export function ProjectSwitchPopover() {
           }
         >
           <div className="min-w-32 text-left">
-            {isValidProjectName(currentProject.name) ? (
+            {isValidProjectName(currentProject?.name) ? (
               <span className="block truncate text-sm font-medium text-control">
                 {currentProject.title}
               </span>

--- a/frontend/src/react/components/header/VersionMenuItem.tsx
+++ b/frontend/src/react/components/header/VersionMenuItem.tsx
@@ -1,6 +1,7 @@
 import { Volume2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import semver from "semver";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
 import {
@@ -9,33 +10,59 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/react/components/ui/dialog";
-import { useVueState } from "@/react/hooks/useVueState";
-import { router } from "@/router";
-import { SETTING_ROUTE_WORKSPACE_SUBSCRIPTION } from "@/router/dashboard/workspaceSetting";
-import { useActuatorV1Store, useSubscriptionV1Store } from "@/store";
+import {
+  useServerInfo,
+  useSubscription,
+  useWorkspacePermission,
+} from "@/react/hooks/useAppState";
+import {
+  SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
+  useNavigate,
+} from "@/react/router";
+import type { ReleaseInfo } from "@/types/actuator";
 import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
-import { hasWorkspacePermissionV2 } from "@/utils";
+import { STORAGE_KEY_RELEASE } from "@/utils/storage-keys";
+
+function readReleaseInfo(): ReleaseInfo {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_RELEASE);
+    return raw
+      ? (JSON.parse(raw) as ReleaseInfo)
+      : {
+          ignoreRemindModalTillNextRelease: false,
+          nextCheckTs: 0,
+        };
+  } catch {
+    return {
+      ignoreRemindModalTillNextRelease: false,
+      nextCheckTs: 0,
+    };
+  }
+}
+
+function hasNewerRelease(latest: string | undefined, current: string) {
+  if (!latest) return false;
+  if (current === "development") return true;
+  const latestVersion = semver.coerce(latest);
+  const currentVersion = semver.coerce(current);
+  if (!latestVersion || !currentVersion) return false;
+  return semver.gt(latestVersion, currentVersion);
+}
 
 export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
+  const serverInfo = useServerInfo();
+  const { subscription } = useSubscription();
+  const canManageSettings = useWorkspacePermission("bb.settings.set");
+  const navigate = useNavigate();
   const [dialogOpen, setDialogOpen] = useState(false);
+  const releaseInfo = useMemo(readReleaseInfo, []);
 
-  const isDemo = useVueState(() => actuatorStore.isDemo);
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
-  const version = useVueState(() => actuatorStore.version);
-  const gitCommitBE = useVueState(() => actuatorStore.gitCommitBE);
-  const gitCommitFE = useVueState(() => actuatorStore.gitCommitFE);
-  const hasNewRelease = useVueState(() => actuatorStore.hasNewRelease);
-  const releaseLatest = useVueState(() => actuatorStore.releaseInfo.latest);
-  const currentPlan = useVueState(() => subscriptionStore.currentPlan);
-  const purchaseLicenseUrl = useVueState(
-    () => subscriptionStore.purchaseLicenseUrl
-  );
-  const isSelfHostLicense = useVueState(
-    () => subscriptionStore.isSelfHostLicense
-  );
+  const version = serverInfo?.version ?? "";
+  const gitCommitBE = serverInfo?.gitCommit || "unknown";
+  const gitCommitFE = import.meta.env.GIT_COMMIT || "unknown";
+  const currentPlan = subscription?.plan ?? PlanType.FREE;
+  const hasNewRelease = hasNewerRelease(releaseInfo.latest?.tag_name, version);
 
   const planLabel = useMemo(() => {
     switch (currentPlan) {
@@ -55,6 +82,9 @@ export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
     return version || "unknown";
   }, [version]);
 
+  const isSelfHostLicense =
+    import.meta.env.MODE.toLowerCase() !== "release-aws";
+  const purchaseLicenseUrl = import.meta.env.BB_PURCHASE_LICENSE_URL as string;
   const releaseLink = isSelfHostLicense
     ? "https://docs.bytebase.com/get-started/self-host-vs-cloud"
     : purchaseLicenseUrl;
@@ -63,14 +93,14 @@ export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
     <>
       <div className="px-3 py-2">
         <div className="mb-2 flex items-center gap-x-2">
-          {isDemo ? (
+          {serverInfo?.demo ? (
             <Badge variant="secondary">{t("common.demo-mode")}</Badge>
-          ) : hasWorkspacePermissionV2("bb.settings.set") ? (
+          ) : canManageSettings ? (
             <button
               type="button"
               className="cursor-pointer text-sm text-accent hover:underline"
               onClick={() => {
-                void router.push({
+                void navigate.push({
                   name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
                 });
                 onCloseMenu();
@@ -101,7 +131,7 @@ export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
           </span>
         </button>
 
-        {!isSaaSMode ? (
+        {!serverInfo?.saas ? (
           <div className="mt-1 text-xs text-control-light">
             <div>BE Git hash: {gitCommitBE.slice(0, 7)}</div>
             <div>FE Git hash: {gitCommitFE.slice(0, 7)}</div>
@@ -109,20 +139,15 @@ export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
         ) : null}
       </div>
 
-      <Dialog
-        open={dialogOpen}
-        onOpenChange={(next) => {
-          setDialogOpen(next);
-        }}
-      >
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
         <DialogContent className="max-w-lg p-6">
           <DialogTitle>
             {t("remind.release.new-version-available-with-tag", {
-              tag: releaseLatest?.tag_name ?? "",
+              tag: releaseInfo.latest?.tag_name ?? "",
             })}
           </DialogTitle>
           <DialogDescription className="mt-2">
-            {releaseLatest?.html_url ?? releaseLink}
+            {releaseInfo.latest?.html_url ?? releaseLink}
           </DialogDescription>
           <div className="mt-6 flex justify-end gap-x-2">
             <Button variant="ghost" onClick={() => setDialogOpen(false)}>
@@ -130,7 +155,10 @@ export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
             </Button>
             <Button
               onClick={() => {
-                window.open(releaseLatest?.html_url ?? releaseLink, "_blank");
+                window.open(
+                  releaseInfo.latest?.html_url ?? releaseLink,
+                  "_blank"
+                );
                 setDialogOpen(false);
               }}
             >

--- a/frontend/src/react/components/header/common.ts
+++ b/frontend/src/react/components/header/common.ts
@@ -1,8 +1,6 @@
-import i18n from "@/plugins/i18n";
-import { router } from "@/router";
-import type { useUIStateStore } from "@/store";
-import { emitStorageChangedEvent, setDocumentTitle } from "@/utils";
+import i18n from "@/react/i18n";
 import { STORAGE_KEY_LANGUAGE } from "@/utils/storage-keys";
+import { emitStorageChangedEvent } from "@/utils/util";
 
 export type HeaderLocaleOption = {
   label: string;
@@ -18,34 +16,10 @@ export const HEADER_LANGUAGE_OPTIONS: HeaderLocaleOption[] = [
 ];
 
 export function setAppLocale(lang: string) {
-  i18n.global.locale.value = lang;
-  localStorage.setItem(STORAGE_KEY_LANGUAGE, JSON.stringify(lang));
+  void i18n.changeLanguage(lang);
+  localStorage.setItem(STORAGE_KEY_LANGUAGE, lang);
   emitStorageChangedEvent();
-
-  const route = router.currentRoute.value;
-  if (route.meta.title) {
-    setDocumentTitle(route.meta.title(route));
-  }
-}
-
-export function resetQuickstartProgress(
-  uiStateStore: ReturnType<typeof useUIStateStore>
-) {
-  const keys = [
-    "hidden",
-    "issue.visit",
-    "project.visit",
-    "environment.visit",
-    "instance.visit",
-    "database.visit",
-    "member.visit",
-    "data.query",
-  ];
-
-  for (const key of keys) {
-    void uiStateStore.saveIntroStateByKey({
-      key,
-      newState: false,
-    });
-  }
+  window.dispatchEvent(
+    new CustomEvent("bb.react-locale-change", { detail: lang })
+  );
 }

--- a/frontend/src/react/components/header/no-vue-deps.test.ts
+++ b/frontend/src/react/components/header/no-vue-deps.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+
+const sources = import.meta.glob(["./*.{ts,tsx}", "../BytebaseLogo.tsx"], {
+  query: "?raw",
+  import: "default",
+  eager: true,
+}) as Record<string, string>;
+
+const appStateSources = import.meta.glob(
+  ["../../hooks/useAppState.ts", "../../stores/app/**/*.ts"],
+  {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }
+) as Record<string, string>;
+
+const forbidden = [
+  "useVueState",
+  "@/store",
+  "@/components/Project/useRecentProjects",
+  "hasWorkspacePermissionV2",
+  "hasProjectPermissionV2",
+  "@/router",
+];
+
+describe("React dashboard header dependencies", () => {
+  test("does not directly depend on Vue, Pinia, or Vue Router", () => {
+    const violations = [];
+    for (const [file, source] of Object.entries(sources)) {
+      if (file.endsWith(".test.ts") || file.endsWith(".test.tsx")) {
+        continue;
+      }
+      for (const token of forbidden) {
+        if (source.includes(token)) {
+          violations.push(`${file}: ${token}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  test("does not keep header-specific app state names", () => {
+    const violations = [];
+    for (const [file, source] of Object.entries(appStateSources)) {
+      for (const token of [
+        "HeaderAppState",
+        "useHeaderAppStore",
+        "useHeaderApp",
+      ]) {
+        if (source.includes(token)) {
+          violations.push(`${file}: ${token}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});

--- a/frontend/src/react/hooks/useAppState.ts
+++ b/frontend/src/react/hooks/useAppState.ts
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  getProjectResourceId,
+  isConnectAlreadyExists,
+  isDefaultProjectName,
+  useAppStore,
+} from "@/react/stores/app";
+import type { AppFeatures } from "@/types/appProfile";
+import type { Permission } from "@/types/iam/permission";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import { storageKeyRecentProjects } from "@/utils/storage-keys";
+
+export { isConnectAlreadyExists };
+
+export function useCurrentUser() {
+  const user = useAppStore((state) => state.currentUser);
+  const loadCurrentUser = useAppStore((state) => state.loadCurrentUser);
+  useEffect(() => {
+    void loadCurrentUser();
+  }, [loadCurrentUser]);
+  return user;
+}
+
+export function useWorkspace() {
+  const workspace = useAppStore((state) => state.workspace);
+  const loadWorkspace = useAppStore((state) => state.loadWorkspace);
+  useEffect(() => {
+    void loadWorkspace();
+  }, [loadWorkspace]);
+  return workspace;
+}
+
+export function useSubscription() {
+  const subscription = useAppStore((state) => state.subscription);
+  const loadSubscription = useAppStore((state) => state.loadSubscription);
+  const uploadLicense = useAppStore((state) => state.uploadLicense);
+  useEffect(() => {
+    void loadSubscription();
+  }, [loadSubscription]);
+  return { subscription, uploadLicense };
+}
+
+export function useServerInfo() {
+  const serverInfo = useAppStore((state) => state.serverInfo);
+  const loadServerInfo = useAppStore((state) => state.loadServerInfo);
+  useEffect(() => {
+    void loadServerInfo();
+  }, [loadServerInfo]);
+  return serverInfo;
+}
+
+export function useAppFeature<T extends keyof AppFeatures>(feature: T) {
+  const value = useAppStore((state) => state.appFeatures[feature]);
+  const loadWorkspaceProfile = useAppStore(
+    (state) => state.loadWorkspaceProfile
+  );
+  useEffect(() => {
+    void loadWorkspaceProfile();
+  }, [loadWorkspaceProfile]);
+  return value;
+}
+
+export function useWorkspacePermission(permission: Permission) {
+  const allowed = useAppStore((state) =>
+    state.hasWorkspacePermission(permission)
+  );
+  const loadWorkspacePermissionState = useAppStore(
+    (state) => state.loadWorkspacePermissionState
+  );
+  useEffect(() => {
+    void loadWorkspacePermissionState();
+  }, [loadWorkspacePermissionState]);
+  return allowed;
+}
+
+export function useProject(name: string | undefined) {
+  const project = useAppStore((state) =>
+    name ? state.projectsByName[name] : undefined
+  );
+  const fetchProject = useAppStore((state) => state.fetchProject);
+  useEffect(() => {
+    if (name) {
+      void fetchProject(name);
+    }
+  }, [fetchProject, name]);
+  return project;
+}
+
+export function useProjectList(query: string) {
+  const searchProjects = useAppStore((state) => state.searchProjects);
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [pageToken, setPageToken] = useState("");
+  const pageTokenRef = useRef("");
+  const [isLoading, setIsLoading] = useState(true);
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+  const requestIdRef = useRef(0);
+  const [pageSize, setPageSize] = useState(() => {
+    const value = Number(localStorage.getItem("bb.project-switch.page-size"));
+    return [50, 100, 200, 500].includes(value) ? value : 50;
+  });
+
+  const fetchPage = useCallback(
+    async (mode: "refresh" | "append") => {
+      if (mode === "refresh") {
+        setIsLoading(true);
+      } else {
+        setIsFetchingMore(true);
+      }
+      const requestId = ++requestIdRef.current;
+      try {
+        const response = await searchProjects({
+          pageSize,
+          pageToken: mode === "refresh" ? "" : pageTokenRef.current,
+          query,
+        });
+        if (requestId !== requestIdRef.current) {
+          return;
+        }
+        pageTokenRef.current = response.nextPageToken ?? "";
+        setPageToken(response.nextPageToken ?? "");
+        setProjects((previous) =>
+          mode === "refresh"
+            ? response.projects
+            : [...previous, ...response.projects]
+        );
+      } finally {
+        if (requestId === requestIdRef.current) {
+          if (mode === "refresh") {
+            setIsLoading(false);
+          } else {
+            setIsFetchingMore(false);
+          }
+        }
+      }
+    },
+    [pageSize, query, searchProjects]
+  );
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      void fetchPage("refresh");
+    }, 200);
+    return () => window.clearTimeout(timer);
+  }, [fetchPage]);
+
+  const onPageSizeChange = useCallback((next: number) => {
+    localStorage.setItem("bb.project-switch.page-size", String(next));
+    setPageSize(next);
+  }, []);
+
+  return {
+    projects,
+    isLoading,
+    isFetchingMore,
+    hasMore: Boolean(pageToken),
+    loadMore: () => void fetchPage("append"),
+    pageSize,
+    pageSizeOptions: [50, 100, 200, 500],
+    onPageSizeChange,
+  };
+}
+
+function readRecentProjectNames(email: string) {
+  if (!email) return [];
+  try {
+    const raw = localStorage.getItem(storageKeyRecentProjects(email));
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed)
+      ? parsed.filter((name): name is string => typeof name === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function useRecentProjects() {
+  const currentUser = useCurrentUser();
+  const batchFetchProjects = useAppStore((state) => state.batchFetchProjects);
+  const projectsByName = useAppStore((state) => state.projectsByName);
+  const [projectNames, setProjectNames] = useState<string[]>([]);
+
+  const refreshNames = useCallback(() => {
+    setProjectNames(readRecentProjectNames(currentUser?.email ?? ""));
+  }, [currentUser?.email]);
+
+  useEffect(() => {
+    refreshNames();
+  }, [refreshNames]);
+
+  useEffect(() => {
+    if (projectNames.length > 0) {
+      void batchFetchProjects(projectNames);
+    }
+  }, [batchFetchProjects, projectNames]);
+
+  const projects = useMemo(() => {
+    return projectNames
+      .map((name) => projectsByName[name])
+      .filter((project): project is Project => Boolean(project))
+      .filter((project) => !isDefaultProjectName(project.name));
+  }, [projectNames, projectsByName]);
+
+  return { projects, refresh: refreshNames };
+}
+
+export function useRecentVisit() {
+  useCurrentUser();
+  const recordRecentVisit = useAppStore((state) => state.recordRecentVisit);
+  return {
+    record: recordRecentVisit,
+  };
+}
+
+export function useNotify() {
+  return useAppStore((state) => state.notify);
+}
+
+export function useQuickstartReset() {
+  return useAppStore((state) => state.resetQuickstartProgress);
+}
+
+export function useCreateProject() {
+  const createProject = useAppStore((state) => state.createProject);
+  const setRecentProject = useAppStore((state) => state.setRecentProject);
+  return {
+    createProject,
+    setRecentProject,
+  };
+}
+
+export function projectMatchesKeyword(project: Project, keyword: string) {
+  const normalized = keyword.trim().toLowerCase();
+  if (!normalized) return true;
+  return (
+    project.title.toLowerCase().includes(normalized) ||
+    project.name.toLowerCase().includes(normalized) ||
+    getProjectResourceId(project).toLowerCase().includes(normalized)
+  );
+}

--- a/frontend/src/react/lib/resourceName.ts
+++ b/frontend/src/react/lib/resourceName.ts
@@ -1,0 +1,23 @@
+export const workspaceNamePrefix = "workspaces/";
+export const userNamePrefix = "users/";
+export const projectNamePrefix = "projects/";
+export const settingNamePrefix = "settings/";
+
+export function getResourceId(name: string, prefix: string): string {
+  if (!name.startsWith(prefix)) {
+    return "";
+  }
+  return name.slice(prefix.length);
+}
+
+export function getProjectName(name: string): string {
+  return getResourceId(name, projectNamePrefix);
+}
+
+export function getUserName(email: string): string {
+  return `${userNamePrefix}${email}`;
+}
+
+export function isValidProjectName(name: string | undefined): name is string {
+  return Boolean(name?.startsWith(projectNamePrefix));
+}

--- a/frontend/src/react/router/index.ts
+++ b/frontend/src/react/router/index.ts
@@ -1,0 +1,90 @@
+import { useSyncExternalStore } from "react";
+import type { RouteLocationRaw } from "vue-router";
+import { router } from "@/router";
+import { AUTH_SIGNIN_MODULE } from "@/router/auth";
+import {
+  PROJECT_V1_ROUTE_DATABASE_DETAIL,
+  PROJECT_V1_ROUTE_DETAIL,
+} from "@/router/dashboard/projectV1";
+import {
+  WORKSPACE_ROUTE_LANDING,
+  WORKSPACE_ROUTE_MY_ISSUES,
+} from "@/router/dashboard/workspaceRoutes";
+import {
+  SETTING_ROUTE_PROFILE,
+  SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
+} from "@/router/dashboard/workspaceSetting";
+import {
+  SQL_EDITOR_DATABASE_MODULE,
+  SQL_EDITOR_HOME_MODULE,
+  SQL_EDITOR_PROJECT_MODULE,
+} from "@/router/sqlEditor";
+
+export {
+  AUTH_SIGNIN_MODULE,
+  PROJECT_V1_ROUTE_DATABASE_DETAIL,
+  PROJECT_V1_ROUTE_DETAIL,
+  SETTING_ROUTE_PROFILE,
+  SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
+  SQL_EDITOR_DATABASE_MODULE,
+  SQL_EDITOR_HOME_MODULE,
+  SQL_EDITOR_PROJECT_MODULE,
+  WORKSPACE_ROUTE_LANDING,
+  WORKSPACE_ROUTE_MY_ISSUES,
+};
+
+export type ReactRoute = {
+  name?: string;
+  fullPath: string;
+  params: Record<string, string | string[] | undefined>;
+  query: Record<string, unknown>;
+};
+
+export type ReactResolvedRoute = {
+  href: string;
+  fullPath: string;
+};
+
+let cachedRoute: ReactRoute | undefined;
+
+function snapshotRoute(): ReactRoute {
+  const route = router.currentRoute.value;
+  if (cachedRoute?.fullPath === route.fullPath) {
+    return cachedRoute;
+  }
+  cachedRoute = {
+    name: route.name?.toString(),
+    fullPath: route.fullPath,
+    params: route.params as Record<string, string | string[] | undefined>,
+    query: route.query as Record<string, unknown>,
+  };
+  return cachedRoute;
+}
+
+function subscribeRoute(onStoreChange: () => void) {
+  return router.afterEach(() => onStoreChange());
+}
+
+export function useCurrentRoute(): ReactRoute {
+  return useSyncExternalStore(subscribeRoute, snapshotRoute, snapshotRoute);
+}
+
+export function resolveRoute(to: RouteLocationRaw): ReactResolvedRoute {
+  const route = router.resolve(to);
+  return {
+    href: route.href,
+    fullPath: route.fullPath,
+  };
+}
+
+export function useNavigate() {
+  return {
+    push: (to: RouteLocationRaw) => router.push(to),
+    replace: (to: RouteLocationRaw) => router.replace(to),
+    resolve: resolveRoute,
+  };
+}
+
+export function isSqlEditorRouteName(name: string | undefined): boolean {
+  return name?.startsWith("sql-editor") ?? false;
+}

--- a/frontend/src/react/stores/app/auth.ts
+++ b/frontend/src/react/stores/app/auth.ts
@@ -1,0 +1,45 @@
+import { authServiceClientConnect, userServiceClientConnect } from "@/connect";
+import type { AppSliceCreator, AuthSlice } from "./types";
+import { getCurrentUserEmail } from "./utils";
+
+export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
+  loadCurrentUser: async () => {
+    const existing = get().currentUser;
+    if (existing) return existing;
+    const pending = get().currentUserRequest;
+    if (pending) return pending;
+    const request = userServiceClientConnect
+      .getCurrentUser({})
+      .then((user) => {
+        set({ currentUser: user, currentUserRequest: undefined });
+        return user;
+      })
+      .catch(() => {
+        set({ currentUserRequest: undefined });
+        return undefined;
+      });
+    set({ currentUserRequest: request });
+    return request;
+  },
+
+  logout: async (signinUrl) => {
+    const email = getCurrentUserEmail(get);
+    try {
+      await authServiceClientConnect.logout({});
+    } catch {
+      // Ignore logout errors and clear the local session by redirecting anyway.
+    } finally {
+      if (email) {
+        const keysToRemove: string[] = [];
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i);
+          if (key?.endsWith(`.${email}`)) {
+            keysToRemove.push(key);
+          }
+        }
+        keysToRemove.forEach((key) => localStorage.removeItem(key));
+      }
+      window.location.href = signinUrl;
+    }
+  },
+});

--- a/frontend/src/react/stores/app/iam.ts
+++ b/frontend/src/react/stores/app/iam.ts
@@ -1,0 +1,71 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import {
+  roleServiceClientConnect,
+  workspaceServiceClientConnect,
+} from "@/connect";
+import { workspaceNamePrefix } from "@/react/lib/resourceName";
+import { GetIamPolicyRequestSchema } from "@/types/proto-es/v1/iam_policy_pb";
+import { ListRolesRequestSchema } from "@/types/proto-es/v1/role_service_pb";
+import type { AppSliceCreator, IamSlice } from "./types";
+import { bindingMatchesUser } from "./utils";
+
+export const createIamSlice: AppSliceCreator<IamSlice> = (set, get) => ({
+  roles: [],
+
+  loadWorkspacePermissionState: async () => {
+    await Promise.all([
+      get().loadCurrentUser(),
+      get().loadServerInfo(),
+      get().loadWorkspace(),
+    ]);
+
+    const rolesRequest =
+      get().rolesRequest ??
+      roleServiceClientConnect
+        .listRoles(createProto(ListRolesRequestSchema, {}))
+        .then((response) => {
+          set({ roles: response.roles, rolesRequest: undefined });
+          return response.roles;
+        })
+        .catch(() => {
+          set({ rolesRequest: undefined });
+          return [];
+        });
+    set({ rolesRequest });
+
+    const policyResource =
+      get().serverInfo?.workspace ||
+      get().workspace?.name ||
+      get().currentUser?.workspace ||
+      `${workspaceNamePrefix}-`;
+    const policyRequest =
+      get().workspacePolicyRequest ??
+      workspaceServiceClientConnect
+        .getIamPolicy(
+          createProto(GetIamPolicyRequestSchema, { resource: policyResource })
+        )
+        .then((workspacePolicy) => {
+          set({ workspacePolicy, workspacePolicyRequest: undefined });
+          return workspacePolicy;
+        })
+        .catch(() => {
+          set({ workspacePolicyRequest: undefined });
+          return undefined;
+        });
+    set({ workspacePolicyRequest: policyRequest });
+
+    await Promise.all([rolesRequest, policyRequest]);
+  },
+
+  hasWorkspacePermission: (permission) => {
+    const user = get().currentUser;
+    if (!user) return false;
+    const roleByName = new Map(get().roles.map((role) => [role.name, role]));
+    const roleNames = bindingMatchesUser(get().workspacePolicy, user).map(
+      (binding) => binding.role
+    );
+    return roleNames.some((roleName) =>
+      roleByName.get(roleName)?.permissions.includes(permission)
+    );
+  },
+});

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -253,7 +253,9 @@ describe("useAppStore", () => {
 
   test("keeps user-scoped preferences in localStorage", () => {
     const store = createAppStore();
+    const listener = vi.fn();
     store.setState({ currentUser: user });
+    window.addEventListener("bb.react-quickstart-reset", listener);
 
     store.getState().setRecentProject(projectA.name);
     store.getState().setRecentProject(projectB.name);
@@ -274,5 +276,13 @@ describe("useAppStore", () => {
       "project.visit": false,
       "data.query": false,
     });
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          keys: expect.arrayContaining(["hidden", "data.query"]),
+        }),
+      })
+    );
+    window.removeEventListener("bb.react-quickstart-reset", listener);
   });
 });

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -1,0 +1,278 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ExprSchema } from "@/types/proto-es/google/type/expr_pb";
+import { State } from "@/types/proto-es/v1/common_pb";
+import {
+  BindingSchema,
+  IamPolicySchema,
+} from "@/types/proto-es/v1/iam_policy_pb";
+import { ProjectSchema } from "@/types/proto-es/v1/project_service_pb";
+import { RoleSchema } from "@/types/proto-es/v1/role_service_pb";
+import {
+  DatabaseChangeMode,
+  SettingSchema,
+  SettingValueSchema,
+  WorkspaceProfileSettingSchema,
+} from "@/types/proto-es/v1/setting_service_pb";
+import { UserSchema } from "@/types/proto-es/v1/user_service_pb";
+import {
+  storageKeyIntroState,
+  storageKeyRecentProjects,
+  storageKeyRecentVisit,
+} from "@/utils/storage-keys";
+import { createAppStore } from ".";
+
+const mocks = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  logout: vi.fn(),
+  getActuatorInfo: vi.fn(),
+  getWorkspace: vi.fn(),
+  getIamPolicy: vi.fn(),
+  listRoles: vi.fn(),
+  getSubscription: vi.fn(),
+  uploadLicense: vi.fn(),
+  getSetting: vi.fn(),
+  getProject: vi.fn(),
+  batchGetProjects: vi.fn(),
+  searchProjects: vi.fn(),
+  createProject: vi.fn(),
+}));
+
+vi.mock("@/connect", () => ({
+  actuatorServiceClientConnect: {
+    getActuatorInfo: mocks.getActuatorInfo,
+  },
+  authServiceClientConnect: {
+    logout: mocks.logout,
+  },
+  projectServiceClientConnect: {
+    getProject: mocks.getProject,
+    batchGetProjects: mocks.batchGetProjects,
+    searchProjects: mocks.searchProjects,
+    createProject: mocks.createProject,
+  },
+  roleServiceClientConnect: {
+    listRoles: mocks.listRoles,
+  },
+  settingServiceClientConnect: {
+    getSetting: mocks.getSetting,
+  },
+  subscriptionServiceClientConnect: {
+    getSubscription: mocks.getSubscription,
+    uploadLicense: mocks.uploadLicense,
+  },
+  userServiceClientConnect: {
+    getCurrentUser: mocks.getCurrentUser,
+  },
+  workspaceServiceClientConnect: {
+    getWorkspace: mocks.getWorkspace,
+    getIamPolicy: mocks.getIamPolicy,
+  },
+}));
+
+const user = createProto(UserSchema, {
+  name: "users/alice@example.com",
+  email: "alice@example.com",
+  groups: ["groups/dba"],
+  workspace: "workspaces/default",
+});
+
+const projectA = createProto(ProjectSchema, {
+  name: "projects/a",
+  title: "A",
+  state: State.ACTIVE,
+});
+
+const projectB = createProto(ProjectSchema, {
+  name: "projects/b",
+  title: "B",
+  state: State.ACTIVE,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe("useAppStore", () => {
+  test("combines app state slices behind one bounded store", () => {
+    const store = createAppStore();
+    const state = store.getState();
+
+    expect(state.loadCurrentUser).toBeTypeOf("function");
+    expect(state.loadWorkspace).toBeTypeOf("function");
+    expect(state.hasWorkspacePermission).toBeTypeOf("function");
+    expect(state.fetchProject).toBeTypeOf("function");
+    expect(state.notify).toBeTypeOf("function");
+    expect(state.recordRecentVisit).toBeTypeOf("function");
+  });
+
+  test("deduplicates project fetches and caches the result", async () => {
+    mocks.getProject.mockResolvedValue(projectA);
+    const store = createAppStore();
+
+    const [first, second] = await Promise.all([
+      store.getState().fetchProject(projectA.name),
+      store.getState().fetchProject(projectA.name),
+    ]);
+
+    expect(first).toBe(projectA);
+    expect(second).toBe(projectA);
+    expect(mocks.getProject).toHaveBeenCalledTimes(1);
+    expect(store.getState().projectsByName[projectA.name]).toBe(projectA);
+  });
+
+  test("falls back to individual project fetches when batch fetch fails", async () => {
+    mocks.batchGetProjects.mockRejectedValue(new Error("batch failed"));
+    mocks.getProject.mockImplementation(({ name }: { name: string }) => {
+      return Promise.resolve(name === projectA.name ? projectA : projectB);
+    });
+    const store = createAppStore();
+
+    const projects = await store
+      .getState()
+      .batchFetchProjects([projectA.name, projectB.name]);
+
+    expect(projects).toEqual([projectA, projectB]);
+    expect(mocks.batchGetProjects).toHaveBeenCalledTimes(1);
+    expect(mocks.getProject).toHaveBeenCalledTimes(2);
+  });
+
+  test("writes created projects into the entity cache", async () => {
+    mocks.createProject.mockResolvedValue(projectA);
+    const store = createAppStore();
+
+    const created = await store.getState().createProject("A", "a");
+
+    expect(created).toBe(projectA);
+    expect(store.getState().projectsByName[projectA.name]).toBe(projectA);
+  });
+
+  test("checks workspace permission through user, groups, and roles", () => {
+    const store = createAppStore();
+    store.setState({
+      currentUser: user,
+      roles: [
+        createProto(RoleSchema, {
+          name: "roles/admin",
+          permissions: ["bb.projects.create"],
+        }),
+        createProto(RoleSchema, {
+          name: "roles/viewer",
+          permissions: ["bb.projects.get"],
+        }),
+      ],
+      workspacePolicy: createProto(IamPolicySchema, {
+        bindings: [
+          createProto(BindingSchema, {
+            role: "roles/admin",
+            members: ["group:dba"],
+          }),
+          createProto(BindingSchema, {
+            role: "roles/viewer",
+            members: ["user:allUsers"],
+          }),
+        ],
+      }),
+    });
+
+    expect(store.getState().hasWorkspacePermission("bb.projects.create")).toBe(
+      true
+    );
+    expect(store.getState().hasWorkspacePermission("bb.settings.set")).toBe(
+      false
+    );
+  });
+
+  test("ignores expired IAM bindings when checking workspace permission", () => {
+    const store = createAppStore();
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    store.setState({
+      currentUser: user,
+      roles: [
+        createProto(RoleSchema, {
+          name: "roles/admin",
+          permissions: ["bb.projects.create"],
+        }),
+      ],
+      workspacePolicy: createProto(IamPolicySchema, {
+        bindings: [
+          createProto(BindingSchema, {
+            role: "roles/admin",
+            members: ["group:dba"],
+            condition: createProto(ExprSchema, {
+              expression: `request.time < timestamp("${yesterday}")`,
+            }),
+          }),
+        ],
+      }),
+    });
+
+    expect(store.getState().hasWorkspacePermission("bb.projects.create")).toBe(
+      false
+    );
+  });
+
+  test("derives app features from the workspace profile setting", async () => {
+    mocks.getSetting.mockResolvedValue(
+      createProto(SettingSchema, {
+        value: createProto(SettingValueSchema, {
+          value: {
+            case: "workspaceProfile",
+            value: createProto(WorkspaceProfileSettingSchema, {
+              databaseChangeMode: DatabaseChangeMode.EDITOR,
+            }),
+          },
+        }),
+      })
+    );
+    const store = createAppStore();
+
+    await store.getState().loadWorkspaceProfile();
+
+    expect(store.getState().appFeatures["bb.feature.hide-quick-start"]).toBe(
+      true
+    );
+  });
+
+  test("dispatches notification events for the Vue shell bridge", () => {
+    const store = createAppStore();
+    const listener = vi.fn();
+    window.addEventListener("bb.react-notification", listener);
+
+    store.getState().notify({
+      module: "bytebase",
+      style: "SUCCESS",
+      title: "Saved",
+    });
+
+    expect(store.getState().notifications).toHaveLength(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+    window.removeEventListener("bb.react-notification", listener);
+  });
+
+  test("keeps user-scoped preferences in localStorage", () => {
+    const store = createAppStore();
+    store.setState({ currentUser: user });
+
+    store.getState().setRecentProject(projectA.name);
+    store.getState().setRecentProject(projectB.name);
+    store.getState().recordRecentVisit("/projects/a?tab=1");
+    store.getState().recordRecentVisit("/projects/a?tab=2");
+    store.getState().resetQuickstartProgress();
+
+    expect(
+      JSON.parse(localStorage.getItem(storageKeyRecentProjects(user.email))!)
+    ).toEqual([projectB.name, projectA.name]);
+    expect(
+      JSON.parse(localStorage.getItem(storageKeyRecentVisit(user.email))!)
+    ).toEqual(["/projects/a?tab=2"]);
+    expect(
+      JSON.parse(localStorage.getItem(storageKeyIntroState(user.email))!)
+    ).toMatchObject({
+      hidden: false,
+      "project.visit": false,
+      "data.query": false,
+    });
+  });
+});

--- a/frontend/src/react/stores/app/index.ts
+++ b/frontend/src/react/stores/app/index.ts
@@ -1,0 +1,32 @@
+import { create } from "zustand";
+import { createAuthSlice } from "./auth";
+import { createIamSlice } from "./iam";
+import { createNotificationSlice } from "./notification";
+import { createPreferencesSlice } from "./preferences";
+import { createProjectSlice } from "./project";
+import { createWorkspaceSlice } from "./workspace";
+
+export type { AppStoreState } from "./types";
+export {
+  getProjectResourceId,
+  isConnectAlreadyExists,
+  projectResourceNameFromId,
+} from "./utils";
+export type { ProjectListParams } from "./types";
+import type { AppStoreState } from "./types";
+
+export const createAppStore = () =>
+  create<AppStoreState>()((...args) => ({
+    ...createAuthSlice(...args),
+    ...createWorkspaceSlice(...args),
+    ...createIamSlice(...args),
+    ...createProjectSlice(...args),
+    ...createNotificationSlice(...args),
+    ...createPreferencesSlice(...args),
+  }));
+
+export const useAppStore = createAppStore();
+
+export function isDefaultProjectName(name: string) {
+  return name === useAppStore.getState().serverInfo?.defaultProject;
+}

--- a/frontend/src/react/stores/app/notification.ts
+++ b/frontend/src/react/stores/app/notification.ts
@@ -1,0 +1,16 @@
+import type { AppSliceCreator, NotificationSlice } from "./types";
+
+export const createNotificationSlice: AppSliceCreator<NotificationSlice> = (
+  set
+) => ({
+  notifications: [],
+
+  notify: (notification) => {
+    set((state) => ({
+      notifications: [...state.notifications, notification],
+    }));
+    window.dispatchEvent(
+      new CustomEvent("bb.react-notification", { detail: notification })
+    );
+  },
+});

--- a/frontend/src/react/stores/app/preferences.ts
+++ b/frontend/src/react/stores/app/preferences.ts
@@ -1,0 +1,64 @@
+import {
+  storageKeyIntroState,
+  storageKeyRecentProjects,
+  storageKeyRecentVisit,
+} from "@/utils/storage-keys";
+import type { AppSliceCreator, PreferencesSlice } from "./types";
+import {
+  getCurrentUserEmail,
+  MAX_RECENT_PROJECT,
+  MAX_RECENT_VISIT,
+  readJson,
+  writeJson,
+} from "./utils";
+
+export const createPreferencesSlice: AppSliceCreator<PreferencesSlice> = (
+  _set,
+  get
+) => ({
+  setRecentProject: (name) => {
+    const email = getCurrentUserEmail(get);
+    if (!email || !name) return;
+    const key = storageKeyRecentProjects(email);
+    const previous = readJson<string[]>(key, []);
+    writeJson(
+      key,
+      [name, ...previous.filter((projectName) => projectName !== name)].slice(
+        0,
+        MAX_RECENT_PROJECT
+      )
+    );
+  },
+
+  recordRecentVisit: (path) => {
+    const email = getCurrentUserEmail(get);
+    if (!email) return;
+    const key = storageKeyRecentVisit(email);
+    const previous = readJson<string[]>(key, []);
+    const pathOnly = path.replace(/[?#].*$/, "");
+    const next = [
+      path,
+      ...previous.filter((item) => item.replace(/[?#].*$/, "") !== pathOnly),
+    ].slice(0, MAX_RECENT_VISIT + 1);
+    writeJson(key, next);
+  },
+
+  resetQuickstartProgress: () => {
+    const email = getCurrentUserEmail(get);
+    if (!email) return;
+    const key = storageKeyIntroState(email);
+    const previous = readJson<Record<string, boolean>>(key, {});
+    const next = {
+      ...previous,
+      hidden: false,
+      "issue.visit": false,
+      "project.visit": false,
+      "environment.visit": false,
+      "instance.visit": false,
+      "database.visit": false,
+      "member.visit": false,
+      "data.query": false,
+    };
+    writeJson(key, next);
+  },
+});

--- a/frontend/src/react/stores/app/preferences.ts
+++ b/frontend/src/react/stores/app/preferences.ts
@@ -12,6 +12,17 @@ import {
   writeJson,
 } from "./utils";
 
+const QUICKSTART_RESET_KEYS = [
+  "hidden",
+  "issue.visit",
+  "project.visit",
+  "environment.visit",
+  "instance.visit",
+  "database.visit",
+  "member.visit",
+  "data.query",
+];
+
 export const createPreferencesSlice: AppSliceCreator<PreferencesSlice> = (
   _set,
   get
@@ -50,15 +61,13 @@ export const createPreferencesSlice: AppSliceCreator<PreferencesSlice> = (
     const previous = readJson<Record<string, boolean>>(key, {});
     const next = {
       ...previous,
-      hidden: false,
-      "issue.visit": false,
-      "project.visit": false,
-      "environment.visit": false,
-      "instance.visit": false,
-      "database.visit": false,
-      "member.visit": false,
-      "data.query": false,
+      ...Object.fromEntries(QUICKSTART_RESET_KEYS.map((key) => [key, false])),
     };
     writeJson(key, next);
+    window.dispatchEvent(
+      new CustomEvent("bb.react-quickstart-reset", {
+        detail: { keys: QUICKSTART_RESET_KEYS },
+      })
+    );
   },
 });

--- a/frontend/src/react/stores/app/project.ts
+++ b/frontend/src/react/stores/app/project.ts
@@ -1,0 +1,141 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import { projectServiceClientConnect } from "@/connect";
+import { isValidProjectName } from "@/react/lib/resourceName";
+import { State } from "@/types/proto-es/v1/common_pb";
+import {
+  BatchGetProjectsRequestSchema,
+  CreateProjectRequestSchema,
+  GetProjectRequestSchema,
+  ProjectSchema,
+  SearchProjectsRequestSchema,
+} from "@/types/proto-es/v1/project_service_pb";
+import type { AppSliceCreator, ProjectSlice } from "./types";
+import { buildProjectFilter, defaultProjectName } from "./utils";
+
+export const createProjectSlice: AppSliceCreator<ProjectSlice> = (
+  set,
+  get
+) => ({
+  projectsByName: {},
+  projectRequests: {},
+
+  fetchProject: async (name) => {
+    if (!isValidProjectName(name) || name === defaultProjectName(get)) {
+      return undefined;
+    }
+    const existing = get().projectsByName[name];
+    if (existing) return existing;
+    const pending = get().projectRequests[name];
+    if (pending) return pending;
+
+    const request = projectServiceClientConnect
+      .getProject(createProto(GetProjectRequestSchema, { name }))
+      .then((project) => {
+        set((state) => {
+          const { [name]: _, ...projectRequests } = state.projectRequests;
+          return {
+            projectsByName: {
+              ...state.projectsByName,
+              [project.name]: project,
+            },
+            projectRequests,
+          };
+        });
+        return project;
+      })
+      .catch(() => {
+        set((state) => {
+          const { [name]: _, ...projectRequests } = state.projectRequests;
+          return { projectRequests };
+        });
+        return undefined;
+      });
+
+    set((state) => ({
+      projectRequests: { ...state.projectRequests, [name]: request },
+    }));
+    return request;
+  },
+
+  batchFetchProjects: async (names) => {
+    const validNames = [...new Set(names)].filter(
+      (name) => isValidProjectName(name) && name !== defaultProjectName(get)
+    );
+    if (validNames.length === 0) return [];
+
+    try {
+      const response = await projectServiceClientConnect.batchGetProjects(
+        createProto(BatchGetProjectsRequestSchema, { names: validNames })
+      );
+      set((state) => ({
+        projectsByName: {
+          ...state.projectsByName,
+          ...Object.fromEntries(
+            response.projects.map((project) => [project.name, project])
+          ),
+        },
+      }));
+      return response.projects;
+    } catch {
+      const projects = await Promise.all(
+        validNames.map((name) => get().fetchProject(name))
+      );
+      return projects.filter(
+        (project): project is NonNullable<typeof project> => Boolean(project)
+      );
+    }
+  },
+
+  searchProjects: async ({ pageSize, pageToken, query }) => {
+    const response = await projectServiceClientConnect.searchProjects(
+      createProto(SearchProjectsRequestSchema, {
+        pageSize,
+        pageToken,
+        filter: buildProjectFilter(query),
+        orderBy: "title",
+        showDeleted: false,
+      })
+    );
+    set((state) => ({
+      projectsByName: {
+        ...state.projectsByName,
+        ...Object.fromEntries(
+          response.projects.map((project) => [project.name, project])
+        ),
+      },
+    }));
+    return {
+      projects: response.projects.filter(
+        (project) =>
+          project.state === State.ACTIVE &&
+          project.name !== defaultProjectName(get)
+      ),
+      nextPageToken: response.nextPageToken,
+    };
+  },
+
+  createProject: async (title, resourceId) => {
+    const project = createProto(ProjectSchema, {
+      title,
+      state: State.ACTIVE,
+      enforceIssueTitle: true,
+      enforceSqlReview: true,
+      requireIssueApproval: true,
+      requirePlanCheckNoError: true,
+      allowRequestRole: true,
+    });
+    const created = await projectServiceClientConnect.createProject(
+      createProto(CreateProjectRequestSchema, {
+        project,
+        projectId: resourceId,
+      })
+    );
+    set((state) => ({
+      projectsByName: {
+        ...state.projectsByName,
+        [created.name]: created,
+      },
+    }));
+    return created;
+  },
+});

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -1,0 +1,83 @@
+import type { StateCreator } from "zustand";
+import type { AppFeatures } from "@/types/appProfile";
+import type { Permission } from "@/types/iam/permission";
+import type { NotificationCreate } from "@/types/notification";
+import type { ActuatorInfo } from "@/types/proto-es/v1/actuator_service_pb";
+import type { IamPolicy } from "@/types/proto-es/v1/iam_policy_pb";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import type { Role } from "@/types/proto-es/v1/role_service_pb";
+import type { WorkspaceProfileSetting } from "@/types/proto-es/v1/setting_service_pb";
+import type { Subscription } from "@/types/proto-es/v1/subscription_service_pb";
+import type { User } from "@/types/proto-es/v1/user_service_pb";
+import type { Workspace } from "@/types/proto-es/v1/workspace_service_pb";
+
+export type ProjectListParams = {
+  pageSize: number;
+  pageToken: string;
+  query?: string;
+};
+
+export type AuthSlice = {
+  currentUser?: User;
+  currentUserRequest?: Promise<User | undefined>;
+  loadCurrentUser: () => Promise<User | undefined>;
+  logout: (signinUrl: string) => Promise<void>;
+};
+
+export type WorkspaceSlice = {
+  serverInfo?: ActuatorInfo;
+  serverInfoRequest?: Promise<ActuatorInfo | undefined>;
+  workspace?: Workspace;
+  workspaceRequest?: Promise<Workspace | undefined>;
+  workspaceProfile?: WorkspaceProfileSetting;
+  workspaceProfileRequest?: Promise<WorkspaceProfileSetting | undefined>;
+  appFeatures: AppFeatures;
+  subscription?: Subscription;
+  subscriptionRequest?: Promise<Subscription | undefined>;
+  loadServerInfo: () => Promise<ActuatorInfo | undefined>;
+  loadWorkspace: () => Promise<Workspace | undefined>;
+  loadWorkspaceProfile: () => Promise<WorkspaceProfileSetting | undefined>;
+  loadSubscription: () => Promise<Subscription | undefined>;
+  uploadLicense: (license: string) => Promise<Subscription | undefined>;
+};
+
+export type IamSlice = {
+  workspacePolicy?: IamPolicy;
+  workspacePolicyRequest?: Promise<IamPolicy | undefined>;
+  roles: Role[];
+  rolesRequest?: Promise<Role[]>;
+  loadWorkspacePermissionState: () => Promise<void>;
+  hasWorkspacePermission: (permission: Permission) => boolean;
+};
+
+export type ProjectSlice = {
+  projectsByName: Record<string, Project>;
+  projectRequests: Record<string, Promise<Project | undefined>>;
+  fetchProject: (name: string) => Promise<Project | undefined>;
+  batchFetchProjects: (names: string[]) => Promise<Project[]>;
+  searchProjects: (params: ProjectListParams) => Promise<{
+    projects: Project[];
+    nextPageToken?: string;
+  }>;
+  createProject: (title: string, resourceId: string) => Promise<Project>;
+};
+
+export type NotificationSlice = {
+  notifications: NotificationCreate[];
+  notify: (notification: NotificationCreate) => void;
+};
+
+export type PreferencesSlice = {
+  setRecentProject: (name: string) => void;
+  recordRecentVisit: (path: string) => void;
+  resetQuickstartProgress: () => void;
+};
+
+export type AppStoreState = AuthSlice &
+  WorkspaceSlice &
+  IamSlice &
+  ProjectSlice &
+  NotificationSlice &
+  PreferencesSlice;
+
+export type AppSliceCreator<Slice> = StateCreator<AppStoreState, [], [], Slice>;

--- a/frontend/src/react/stores/app/utils.ts
+++ b/frontend/src/react/stores/app/utils.ts
@@ -1,0 +1,144 @@
+import { Code, ConnectError } from "@connectrpc/connect";
+import { resolveCELExpr } from "@/plugins/cel/logic/resolve";
+import type { SimpleExpr } from "@/plugins/cel/types";
+import { ExprType } from "@/plugins/cel/types";
+import {
+  getProjectName,
+  getUserName,
+  projectNamePrefix,
+  userNamePrefix,
+} from "@/react/lib/resourceName";
+import type { Binding } from "@/types/proto-es/v1/iam_policy_pb";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import type { User } from "@/types/proto-es/v1/user_service_pb";
+import { CEL_ATTRIBUTE_REQUEST_TIME } from "@/utils/cel-attributes";
+import type { AppStoreState } from "./types";
+
+export const MAX_RECENT_PROJECT = 5;
+export const MAX_RECENT_VISIT = 10;
+
+const ALL_USERS_NAME = `${userNamePrefix}allUsers`;
+
+export function getCurrentUserEmail(get: () => AppStoreState): string {
+  return get().currentUser?.email ?? "";
+}
+
+export function readJson<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeJson<T>(key: string, value: T) {
+  localStorage.setItem(key, JSON.stringify(value));
+}
+
+export function buildProjectFilter(query: string | undefined) {
+  const filters = ["exclude_default == true"];
+  const search = query?.trim().toLowerCase();
+  if (search) {
+    filters.push(
+      `(name.contains("${search}") || resource_id.contains("${search}"))`
+    );
+  }
+  return filters.join(" && ");
+}
+
+function bindingMemberToNames(member: string): string[] {
+  if (member === "allUsers" || member === "user:allUsers") {
+    return [ALL_USERS_NAME];
+  }
+  if (member.startsWith("user:")) {
+    return [getUserName(member.slice("user:".length))];
+  }
+  if (member.startsWith("group:")) {
+    return [`groups/${member.slice("group:".length)}`];
+  }
+  if (member.startsWith(userNamePrefix) || member.startsWith("groups/")) {
+    return [member];
+  }
+  return [getUserName(member)];
+}
+
+function findExpirationDate(expr: SimpleExpr): Date | undefined {
+  if (expr.type === ExprType.ConditionGroup) {
+    for (const arg of expr.args) {
+      const date = findExpirationDate(arg);
+      if (date) return date;
+    }
+  }
+  if (expr.type !== ExprType.Condition) {
+    return undefined;
+  }
+  const [left, right] = expr.args;
+  if (
+    expr.operator === "_<_" &&
+    left === CEL_ATTRIBUTE_REQUEST_TIME &&
+    right instanceof Date
+  ) {
+    return right;
+  }
+  return undefined;
+}
+
+function getBindingExpirationDate(binding: Binding): Date | undefined {
+  const expression = binding.condition?.expression;
+  const match = expression?.match(/request\.time\s*<\s*timestamp\("([^"]+)"\)/);
+  if (match) {
+    return new Date(match[1]);
+  }
+  if (!binding.parsedExpr) {
+    return undefined;
+  }
+  const date = findExpirationDate(resolveCELExpr(binding.parsedExpr));
+  return date && !Number.isNaN(date.getTime()) ? date : undefined;
+}
+
+function isBindingExpired(binding: Binding): boolean {
+  const expiration = getBindingExpirationDate(binding);
+  return Boolean(expiration && expiration < new Date());
+}
+
+export function bindingMatchesUser(
+  policy: AppStoreState["workspacePolicy"],
+  user: User
+) {
+  if (!policy || !user.name) {
+    return [];
+  }
+  const userGroups = new Set(user.groups);
+  return policy.bindings.filter((binding) => {
+    if (isBindingExpired(binding)) {
+      return false;
+    }
+    return binding.members.some((member) => {
+      const names = bindingMemberToNames(member);
+      return names.some(
+        (name) =>
+          name === user.name ||
+          name === ALL_USERS_NAME ||
+          (name.startsWith("groups/") && userGroups.has(name))
+      );
+    });
+  });
+}
+
+export function defaultProjectName(get: () => AppStoreState) {
+  return get().serverInfo?.defaultProject ?? "";
+}
+
+export function isConnectAlreadyExists(error: unknown): error is ConnectError {
+  return error instanceof ConnectError && error.code === Code.AlreadyExists;
+}
+
+export function projectResourceNameFromId(projectId: string | undefined) {
+  return projectId ? `${projectNamePrefix}${projectId}` : "";
+}
+
+export function getProjectResourceId(project: Project) {
+  return getProjectName(project.name);
+}

--- a/frontend/src/react/stores/app/workspace.ts
+++ b/frontend/src/react/stores/app/workspace.ts
@@ -1,0 +1,153 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import {
+  actuatorServiceClientConnect,
+  settingServiceClientConnect,
+  subscriptionServiceClientConnect,
+  workspaceServiceClientConnect,
+} from "@/connect";
+import {
+  settingNamePrefix,
+  workspaceNamePrefix,
+} from "@/react/lib/resourceName";
+import { defaultAppProfile } from "@/types/appProfile";
+import {
+  DatabaseChangeMode,
+  GetSettingRequestSchema,
+  Setting_SettingName,
+  WorkspaceProfileSettingSchema,
+} from "@/types/proto-es/v1/setting_service_pb";
+import {
+  GetSubscriptionRequestSchema,
+  UploadLicenseRequestSchema,
+} from "@/types/proto-es/v1/subscription_service_pb";
+import type { AppSliceCreator, WorkspaceSlice } from "./types";
+
+const workspaceProfileSettingName = `${settingNamePrefix}${
+  Setting_SettingName[Setting_SettingName.WORKSPACE_PROFILE]
+}`;
+
+function appFeaturesFromDatabaseChangeMode(mode: DatabaseChangeMode) {
+  const appFeatures = defaultAppProfile().features;
+  appFeatures["bb.feature.database-change-mode"] =
+    mode === DatabaseChangeMode.EDITOR
+      ? DatabaseChangeMode.EDITOR
+      : DatabaseChangeMode.PIPELINE;
+  if (
+    appFeatures["bb.feature.database-change-mode"] === DatabaseChangeMode.EDITOR
+  ) {
+    appFeatures["bb.feature.hide-quick-start"] = true;
+    appFeatures["bb.feature.hide-trial"] = true;
+  }
+  return appFeatures;
+}
+
+export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
+  set,
+  get
+) => ({
+  appFeatures: defaultAppProfile().features,
+
+  loadServerInfo: async () => {
+    const existing = get().serverInfo;
+    if (existing) return existing;
+    const pending = get().serverInfoRequest;
+    if (pending) return pending;
+    const request = actuatorServiceClientConnect
+      .getActuatorInfo({ name: get().currentUser?.workspace ?? "" })
+      .then((info) => {
+        set({ serverInfo: info, serverInfoRequest: undefined });
+        return info;
+      })
+      .catch(() => {
+        set({ serverInfoRequest: undefined });
+        return undefined;
+      });
+    set({ serverInfoRequest: request });
+    return request;
+  },
+
+  loadWorkspace: async () => {
+    const existing = get().workspace;
+    if (existing) return existing;
+    const pending = get().workspaceRequest;
+    if (pending) return pending;
+    await Promise.all([get().loadCurrentUser(), get().loadServerInfo()]);
+    const name =
+      get().serverInfo?.workspace ||
+      get().currentUser?.workspace ||
+      `${workspaceNamePrefix}-`;
+    const request = workspaceServiceClientConnect
+      .getWorkspace({ name })
+      .then((workspace) => {
+        set({ workspace, workspaceRequest: undefined });
+        return workspace;
+      })
+      .catch(() => {
+        set({ workspaceRequest: undefined });
+        return undefined;
+      });
+    set({ workspaceRequest: request });
+    return request;
+  },
+
+  loadWorkspaceProfile: async () => {
+    const existing = get().workspaceProfile;
+    if (existing) return existing;
+    const pending = get().workspaceProfileRequest;
+    if (pending) return pending;
+    const request = settingServiceClientConnect
+      .getSetting(
+        createProto(GetSettingRequestSchema, {
+          name: workspaceProfileSettingName,
+        })
+      )
+      .then((setting) => {
+        const settingValue = setting.value?.value;
+        const profile =
+          settingValue?.case === "workspaceProfile"
+            ? settingValue.value
+            : createProto(WorkspaceProfileSettingSchema, {});
+        set({
+          workspaceProfile: profile,
+          workspaceProfileRequest: undefined,
+          appFeatures: appFeaturesFromDatabaseChangeMode(
+            profile.databaseChangeMode
+          ),
+        });
+        return profile;
+      })
+      .catch(() => {
+        set({ workspaceProfileRequest: undefined });
+        return undefined;
+      });
+    set({ workspaceProfileRequest: request });
+    return request;
+  },
+
+  loadSubscription: async () => {
+    const existing = get().subscription;
+    if (existing) return existing;
+    const pending = get().subscriptionRequest;
+    if (pending) return pending;
+    const request = subscriptionServiceClientConnect
+      .getSubscription(createProto(GetSubscriptionRequestSchema, {}))
+      .then((subscription) => {
+        set({ subscription, subscriptionRequest: undefined });
+        return subscription;
+      })
+      .catch(() => {
+        set({ subscriptionRequest: undefined });
+        return undefined;
+      });
+    set({ subscriptionRequest: request });
+    return request;
+  },
+
+  uploadLicense: async (license) => {
+    const subscription = await subscriptionServiceClientConnect.uploadLicense(
+      createProto(UploadLicenseRequestSchema, { license })
+    );
+    set({ subscription });
+    return subscription;
+  },
+});

--- a/frontend/src/utils/storage-migrate.test.ts
+++ b/frontend/src/utils/storage-migrate.test.ts
@@ -123,7 +123,7 @@ describe("language migration", () => {
       JSON.stringify({ appearance: { language: "zh-CN" } })
     );
     migrateStorageKeys();
-    expect(localStorage.getItem(STORAGE_KEY_LANGUAGE)).toBe('"zh-CN"');
+    expect(localStorage.getItem(STORAGE_KEY_LANGUAGE)).toBe("zh-CN");
     expect(localStorage.getItem("bytebase_options")).toBeNull();
   });
 
@@ -142,9 +142,9 @@ describe("language migration", () => {
       "bytebase_options",
       JSON.stringify({ appearance: { language: "zh-CN" } })
     );
-    localStorage.setItem(STORAGE_KEY_LANGUAGE, '"en-US"');
+    localStorage.setItem(STORAGE_KEY_LANGUAGE, "en-US");
     migrateStorageKeys();
-    expect(localStorage.getItem(STORAGE_KEY_LANGUAGE)).toBe('"en-US"');
+    expect(localStorage.getItem(STORAGE_KEY_LANGUAGE)).toBe("en-US");
     expect(localStorage.getItem("bytebase_options")).toBeNull();
   });
 
@@ -503,7 +503,7 @@ describe("full migration scenario", () => {
 
     // Verify all migrated
     expect(localStorage.getItem(STORAGE_KEY_BACK_PATH)).toBe("/dashboard");
-    expect(localStorage.getItem(STORAGE_KEY_LANGUAGE)).toBe('"ja-JP"');
+    expect(localStorage.getItem(STORAGE_KEY_LANGUAGE)).toBe("ja-JP");
     expect(localStorage.getItem(STORAGE_KEY_SQL_EDITOR_RESULT_LIMIT)).toBe(
       "100"
     );

--- a/frontend/src/utils/storage-migrate.ts
+++ b/frontend/src/utils/storage-migrate.ts
@@ -44,7 +44,7 @@ function moveKey(oldKey: string, newKey: string) {
 
 function migrateLanguage() {
   // Old format: key "bytebase_options", value {"appearance":{"language":"zh-CN"}}
-  // New format: key "bb.language", value "zh-CN" (plain string, JSON-serialized)
+  // New format: key "bb.language", value zh-CN (plain string)
   const old = localStorage.getItem("bytebase_options");
   if (!old) return;
 
@@ -55,8 +55,7 @@ function migrateLanguage() {
       };
       const lang = parsed?.appearance?.language;
       if (lang) {
-        // useLocalStorage with string type stores as JSON-serialized string
-        localStorage.setItem(STORAGE_KEY_LANGUAGE, JSON.stringify(lang));
+        localStorage.setItem(STORAGE_KEY_LANGUAGE, lang);
       }
     } catch {
       // ignore malformed


### PR DESCRIPTION
## Summary
- Decouple the React dashboard header chain from direct Vue/Pinia/router usage.
- Add a bounded React app store with auth, workspace, IAM, project, notification, and preference slices.
- Fix locale persistence/title refresh, quick-start feature gating, expired IAM binding checks, and project switch footer styling.

## Key Changes
- Move header/project switch/profile/version data access to React hooks backed by Connect RPC and Zustand.
- Add a React route adapter and static guard test to prevent Vue/Pinia/router imports in the header chain.
- Bridge React notification and locale changes through Vue shell events while keeping React components framework-local.
- Preserve project switch Recent/All tabs, create-project flow, profile menu actions, and SQL Editor profile entry reuse.

## Motivation
- The header React migration should not keep depending on Vue/Pinia internals.
- Shared app state should use reusable domain slices instead of header-specific state naming.
- Review feedback identified missing expired-binding filtering, quick-start hide flag handling, and stale title updates after locale changes.

## Testing
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test

## Pre-PR Checklist
- Breaking change check: not applicable; frontend implementation refactor with preserved workflows.
- Composite-PK query safety: skipped; no backend/store/migrator changes.
- SonarCloud properties: reviewed; new files are normal frontend source/test files already covered by existing patterns.
