### PR TITLE
chore: bump omni for completion scope

### DIFF
--- a/backend/plugin/parser/pg/completion.go
+++ b/backend/plugin/parser/pg/completion.go
@@ -202,7 +202,8 @@ func (c *Completer) completion() ([]base.Candidate, error) {
 	c.referencesStack = append([][]base.TableReference{{}}, c.referencesStack...)
 
 	// Use omni parser to collect grammar candidates instead of C3.
-	candidates := pgparser.Collect(c.sql, c.cursorByteOffset)
+	completionOffset := c.cursorByteOffset
+	candidates := pgparser.Collect(c.sql, completionOffset)
 
 	// If Collect returned no rule candidates and the cursor is at the end of a
 	// partial identifier token (prefix), retry Collect at the start of that
@@ -211,16 +212,19 @@ func (c *Completer) completion() ([]base.Candidate, error) {
 	// rule to suggest.
 	if len(candidates.Rules) == 0 {
 		if prefixTok, ok := c.prefixToken(); ok {
-			candidates = pgparser.Collect(c.sql, prefixTok.Loc)
+			completionOffset = prefixTok.Loc
+			candidates = pgparser.Collect(c.sql, completionOffset)
 		}
 	}
 
 	for _, rc := range candidates.Rules {
 		if rc.Rule == "columnref" {
+			completionContext := pgparser.CollectCompletion(c.sql, completionOffset)
 			c.collectLeadingTableReferences(caretIndex)
 			c.takeReferencesSnapshot()
 			c.collectRemainingTableReferences()
 			c.takeReferencesSnapshot()
+			c.collectCompletionScopeReferences(completionContext)
 			break
 		}
 	}
@@ -1067,6 +1071,155 @@ func (c *Completer) takeReferencesSnapshot() {
 	for _, references := range c.referencesStack {
 		c.references = append(c.references, references...)
 	}
+}
+
+func (c *Completer) collectCompletionScopeReferences(completionContext *pgparser.CompletionContext) {
+	if completionContext == nil || completionContext.Scope == nil {
+		return
+	}
+	for _, reference := range completionContext.Scope.References {
+		tableReference := c.convertCompletionScopeReference(reference)
+		if tableReference != nil {
+			c.appendReferenceIfMissing(tableReference)
+		}
+	}
+}
+
+func (c *Completer) appendReferenceIfMissing(reference base.TableReference) {
+	key := tableReferenceKey(reference)
+	for _, existing := range c.references {
+		if tableReferenceKey(existing) == key {
+			return
+		}
+	}
+	c.references = append(c.references, reference)
+}
+
+func tableReferenceKey(reference base.TableReference) string {
+	switch reference := reference.(type) {
+	case *base.PhysicalTableReference:
+		return strings.Join([]string{"physical", reference.Database, reference.Schema, reference.Table, reference.Alias}, "\x00")
+	case *base.VirtualTableReference:
+		return strings.Join([]string{"virtual", reference.Table}, "\x00")
+	default:
+		return fmt.Sprintf("%T", reference)
+	}
+}
+
+func (c *Completer) convertCompletionScopeReference(reference pgparser.RangeReference) base.TableReference {
+	switch reference.Kind {
+	case pgparser.RangeReferenceRelation:
+		if len(reference.AliasColumns) > 0 {
+			return &base.VirtualTableReference{
+				Table:   completionReferenceName(reference),
+				Columns: reference.AliasColumns,
+			}
+		}
+		return &base.PhysicalTableReference{
+			Database: reference.Catalog,
+			Schema:   reference.Schema,
+			Table:    reference.Name,
+			Alias:    reference.Alias,
+		}
+	case pgparser.RangeReferenceCTE:
+		return c.convertCompletionCTEReference(reference)
+	case pgparser.RangeReferenceSubquery:
+		return c.convertCompletionSubqueryReference(reference)
+	case pgparser.RangeReferenceFunction:
+		if reference.Alias == "" || len(reference.AliasColumns) == 0 {
+			return nil
+		}
+		return &base.VirtualTableReference{
+			Table:   reference.Alias,
+			Columns: reference.AliasColumns,
+		}
+	case pgparser.RangeReferenceJoinAlias:
+		if reference.Alias == "" {
+			return nil
+		}
+		return &base.VirtualTableReference{
+			Table:   reference.Alias,
+			Columns: reference.AliasColumns,
+		}
+	default:
+		return nil
+	}
+}
+
+func completionReferenceName(reference pgparser.RangeReference) string {
+	if reference.Alias != "" {
+		return reference.Alias
+	}
+	return reference.Name
+}
+
+func (c *Completer) convertCompletionCTEReference(reference pgparser.RangeReference) base.TableReference {
+	virtualReference := &base.VirtualTableReference{
+		Table:   completionReferenceName(reference),
+		Columns: reference.AliasColumns,
+	}
+	if len(virtualReference.Columns) > 0 {
+		return virtualReference
+	}
+	if reference.BodyLoc.Start < 0 || reference.BodyLoc.End <= reference.BodyLoc.Start || reference.BodyLoc.End > len(c.sql) {
+		return virtualReference
+	}
+	queryText := c.sql[reference.BodyLoc.Start:reference.BodyLoc.End]
+	span, err := GetQuerySpan(
+		c.ctx,
+		base.GetQuerySpanContext{
+			InstanceID:              c.instanceID,
+			GetDatabaseMetadataFunc: c.getMetadata,
+			ListDatabaseNamesFunc:   c.listDatabaseNames,
+		},
+		base.Statement{Text: queryText},
+		c.defaultDatabase,
+		"",
+		false,
+	)
+	if err != nil || span.NotFoundError != nil {
+		return virtualReference
+	}
+	for _, column := range span.Results {
+		virtualReference.Columns = append(virtualReference.Columns, column.Name)
+	}
+	return virtualReference
+}
+
+func (c *Completer) convertCompletionSubqueryReference(reference pgparser.RangeReference) base.TableReference {
+	if reference.Alias == "" {
+		return nil
+	}
+	virtualReference := &base.VirtualTableReference{
+		Table:   reference.Alias,
+		Columns: reference.AliasColumns,
+	}
+	if len(virtualReference.Columns) > 0 {
+		return virtualReference
+	}
+	if reference.BodyLoc.Start < 0 || reference.BodyLoc.End <= reference.BodyLoc.Start || reference.BodyLoc.End > len(c.sql) {
+		return virtualReference
+	}
+	subqueryText := c.sql[reference.BodyLoc.Start:reference.BodyLoc.End]
+	span, err := GetQuerySpan(
+		c.ctx,
+		base.GetQuerySpanContext{
+			InstanceID:              c.instanceID,
+			GetDatabaseMetadataFunc: c.getMetadata,
+			ListDatabaseNamesFunc:   c.listDatabaseNames,
+		},
+		base.Statement{Text: fmt.Sprintf("SELECT * FROM (%s) AS %s;", subqueryText, reference.Alias)},
+		c.defaultDatabase,
+		"",
+		false,
+	)
+	if err != nil || span.NotFoundError != nil {
+		return virtualReference
+	}
+	for _, column := range span.Results {
+		virtualReference.Columns = append(virtualReference.Columns, column.Name)
+	}
+	return virtualReference
 }
 
 func (c *Completer) collectRemainingTableReferences() {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260421084205-9688c5c4c22e
+	github.com/bytebase/omni v0.0.0-20260424061300-8a4a735f63a5
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888 h1:E8tz8maxpih/vt
 github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888/go.mod h1:IgLUOjyiHehdE0G3C92IjGYu9lJQgkPwf2mdNSvPWq8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260421084205-9688c5c4c22e h1:uP7i1fob0XGJEddN/Ota9oA+gGiuTY7Bti77YckoFwQ=
-github.com/bytebase/omni v0.0.0-20260421084205-9688c5c4c22e/go.mod h1:AT+iLKCu7NyxTaYaOLzETRFBVurjRaqUU3YmFron9pw=
+github.com/bytebase/omni v0.0.0-20260424061300-8a4a735f63a5 h1:drOwmZHyohwDoTkRAm+hkx5C/sZL8KTHOBSUaAppr4Y=
+github.com/bytebase/omni v0.0.0-20260424061300-8a4a735f63a5/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Bump github.com/bytebase/omni to 8a4a735 to include completion-safe paren lookahead and parser completion scope support.
- Use omni CollectCompletion scope to supplement PostgreSQL completion references for incomplete JOIN contexts.
- Preserve existing ByteBase reference recovery so historical completion behavior such as UNION/CTE/nested subquery cases does not regress.

## Test Plan
- go test -count=1 ./backend/plugin/parser/pg -run '^TestCompletion$'
- go test -count=1 ./backend/plugin/parser/pg
- go test -count=1 ./backend/plugin/parser/...
- go test -count=1 ./backend/plugin/advisor/...
- go test -count=1 ./backend/plugin/schema/...
- go test -count=1 ./backend/plugin/db/pg ./backend/plugin/db/mssql
- go test -count=1 github.com/bytebase/omni/pg/parser
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go

## Pre-PR Checklist
- Breaking change check: not applicable; this is a parser completion dependency bump and adapter change.
- Composite-PK query safety: skipped; no backend/store or migration changes.
- SonarCloud properties: skipped; no new files or directories.