### PR TITLE
fix: use interpolated params for Doris

### DIFF
--- a/backend/plugin/db/starrocks/starrocks.go
+++ b/backend/plugin/db/starrocks/starrocks.go
@@ -69,6 +69,9 @@ func (d *Driver) Open(_ context.Context, dbType storepb.Engine, connCfg db.Conne
 		protocol = "unix"
 	}
 	params := []string{"multiStatements=true", "maxAllowedPacket=0"}
+	if dbType == storepb.Engine_DORIS {
+		params = append(params, "interpolateParams=true")
+	}
 	if connCfg.DataSource.GetSshHost() != "" {
 		sshClient, err := util.GetSSHClient(connCfg.DataSource)
 		if err != nil {


### PR DESCRIPTION
## Summary
- Add `interpolateParams=true` to Doris MySQL-wire connection params.
- Avoid server-side prepared statements when Doris schema dump queries use placeholders.
- Fixes BYT-9105.

## Test Plan
- `go test -v -count=1 ./backend/plugin/db/starrocks`
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`