### PR TITLE
fix(frontend): register audit log protobuf details

### DIFF
--- a/frontend/src/connect/index.ts
+++ b/frontend/src/connect/index.ts
@@ -1,13 +1,9 @@
 import { createClient } from "@connectrpc/connect";
 import { createConnectTransport } from "@connectrpc/connect-web";
-import { createRegistry } from "@bufbuild/protobuf";
 import { AIService } from "@/types/proto-es/v1/ai_service_pb";
 import { AccessGrantService } from "@/types/proto-es/v1/access_grant_service_pb";
 import { ActuatorService } from "@/types/proto-es/v1/actuator_service_pb";
-import {
-  AuditDataSchema,
-  AuditLogService,
-} from "@/types/proto-es/v1/audit_log_service_pb";
+import { AuditLogService } from "@/types/proto-es/v1/audit_log_service_pb";
 import { AuthService } from "@/types/proto-es/v1/auth_service_pb";
 import { CelService } from "@/types/proto-es/v1/cel_service_pb";
 import { DatabaseCatalogService } from "@/types/proto-es/v1/database_catalog_service_pb";
@@ -26,10 +22,7 @@ import { ReviewConfigService } from "@/types/proto-es/v1/review_config_service_p
 import { RevisionService } from "@/types/proto-es/v1/revision_service_pb";
 import { RoleService } from "@/types/proto-es/v1/role_service_pb";
 import { RolloutService } from "@/types/proto-es/v1/rollout_service_pb";
-import {
-  SettingSchema,
-  SettingService,
-} from "@/types/proto-es/v1/setting_service_pb";
+import { SettingService } from "@/types/proto-es/v1/setting_service_pb";
 import { SheetService } from "@/types/proto-es/v1/sheet_service_pb";
 import { SQLService } from "@/types/proto-es/v1/sql_service_pb";
 import { SubscriptionService } from "@/types/proto-es/v1/subscription_service_pb";
@@ -43,13 +36,12 @@ import {
   errorNotificationInterceptor,
   activeInterceptor,
 } from "./middlewares";
+import { protobufJsonRegistry } from "@/types/protobufJsonRegistry";
 import { isDev } from "@/utils";
 
 const address = import.meta.env.BB_GRPC_LOCAL || window.location.origin;
 
 // Registry for decoding google.protobuf.Any fields in JSON responses
-const registry = createRegistry(AuditDataSchema, SettingSchema);
-
 const transport = createConnectTransport({
   baseUrl: address,
   useBinaryFormat: isDev() ? false : true,
@@ -60,7 +52,7 @@ const transport = createConnectTransport({
   ],
   fetch: (input, init) => fetch(input, { ...init, credentials: "include" }),
   jsonOptions: {
-    registry,
+    registry: protobufJsonRegistry,
   },
 });
 

--- a/frontend/src/react/components/AuditLogTable.test.tsx
+++ b/frontend/src/react/components/AuditLogTable.test.tsx
@@ -1,0 +1,170 @@
+import { create } from "@bufbuild/protobuf";
+import { anyPack } from "@bufbuild/protobuf/wkt";
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { StatusSchema } from "@/types/proto-es/google/rpc/status_pb";
+import {
+  AuditLog_Severity,
+  AuditLogSchema,
+} from "@/types/proto-es/v1/audit_log_service_pb";
+import { PermissionDeniedDetailSchema } from "@/types/proto-es/v1/common_pb";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  searchAuditLogs: vi.fn(),
+  exportAuditLogs: vi.fn(),
+  useTranslation: vi.fn(() => ({ t: (key: string) => key })),
+  pushNotification: vi.fn(),
+  useSubscriptionV1Store: vi.fn(() => ({ hasFeature: () => true })),
+  useUserStore: vi.fn(() => ({ fetchUserList: vi.fn() })),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: mocks.useTranslation,
+}));
+
+vi.mock("@/connect", () => ({
+  auditLogServiceClientConnect: {
+    searchAuditLogs: mocks.searchAuditLogs,
+    exportAuditLogs: mocks.exportAuditLogs,
+  },
+}));
+
+vi.mock("@/store", () => ({
+  pushNotification: mocks.pushNotification,
+  useSubscriptionV1Store: mocks.useSubscriptionV1Store,
+  useUserStore: mocks.useUserStore,
+}));
+
+vi.mock("@/store/modules/v1/common", () => ({
+  extractUserEmail: (name: string) => name.replace("users/", ""),
+  getProjectIdPlanUidStageUidFromRolloutName: () => [
+    "project",
+    "plan",
+    "stage",
+  ],
+  planNamePrefix: "plans/",
+  projectNamePrefix: "projects/",
+  userNamePrefix: "users/",
+}));
+
+vi.mock("@/react/components/AdvancedSearch", () => ({
+  AdvancedSearch: () => <div data-testid="advanced-search" />,
+}));
+
+vi.mock("@/react/components/TimeRangePicker", () => ({
+  TimeRangePicker: () => <div data-testid="time-range-picker" />,
+}));
+
+vi.mock("@/react/components/FeatureAttention", () => ({
+  FeatureAttention: () => null,
+}));
+
+vi.mock("@/react/hooks/usePagedData", () => ({
+  PagedTableFooter: () => <div data-testid="paged-table-footer" />,
+}));
+
+vi.mock("@/react/hooks/useSessionPageSize", () => ({
+  getPageSizeOptions: () => [10],
+  useSessionPageSize: () => [10, vi.fn()],
+}));
+
+vi.mock("@/react/hooks/useVueState", () => ({
+  useVueState: (getter: () => unknown) => getter(),
+}));
+
+vi.mock("@/connect/methods", () => ({
+  ALL_METHODS_WITH_AUDIT: [],
+}));
+
+vi.mock("@/utils", () => ({
+  formatAbsoluteDateTime: () => "2026-04-27 00:00:00",
+  getDefaultPagination: () => 1000,
+  humanizeDurationV1: () => "0ms",
+}));
+
+vi.mock("@/types", () => ({
+  getDateForPbTimestampProtoEs: () => new Date("2026-04-27T00:00:00Z"),
+}));
+
+globalThis.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+let AuditLogTable: typeof import("./AuditLogTable").AuditLogTable;
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  document.body.appendChild(container);
+  return {
+    container,
+    render: async () => {
+      await act(async () => {
+        root.render(element);
+      });
+    },
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ AuditLogTable } = await import("./AuditLogTable"));
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("AuditLogTable", () => {
+  test("renders status details with PermissionDeniedDetail", async () => {
+    const permissionDeniedDetail = create(PermissionDeniedDetailSchema, {
+      method: "/bytebase.v1.SQLService/Query",
+      requiredPermissions: ["bb.sql.select"],
+      resources: ["instances/prod/databases/app"],
+    });
+    const status = create(StatusSchema, {
+      code: 7,
+      message: "permission denied",
+      details: [anyPack(PermissionDeniedDetailSchema, permissionDeniedDetail)],
+    });
+    const auditLog = create(AuditLogSchema, {
+      name: "auditLogs/1",
+      severity: AuditLog_Severity.ERROR,
+      method: "/bytebase.v1.SQLService/Query",
+      user: "users/user@example.com",
+      status,
+    });
+    mocks.searchAuditLogs.mockResolvedValue({
+      auditLogs: [auditLog],
+      nextPageToken: "",
+    });
+
+    const { container, render, unmount } = renderIntoContainer(
+      <AuditLogTable parent="projects/-" canExport={false} />
+    );
+
+    await render();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("PermissionDeniedDetail");
+    expect(container.textContent).toContain("bb.sql.select");
+
+    unmount();
+  });
+});

--- a/frontend/src/react/components/AuditLogTable.tsx
+++ b/frontend/src/react/components/AuditLogTable.tsx
@@ -1,5 +1,4 @@
-import { file_google_rpc_error_details } from "@buf/googleapis_googleapis.bufbuild_es/google/rpc/error_details_pb";
-import { create, createRegistry, toJsonString } from "@bufbuild/protobuf";
+import { create, toJsonString } from "@bufbuild/protobuf";
 import { AnySchema } from "@bufbuild/protobuf/wkt";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
@@ -52,21 +51,17 @@ import { getDateForPbTimestampProtoEs } from "@/types";
 import { StatusSchema } from "@/types/proto-es/google/rpc/status_pb";
 import type { AuditLog } from "@/types/proto-es/v1/audit_log_service_pb";
 import {
-  AuditDataSchema,
   AuditLog_Severity,
   ExportAuditLogsRequestSchema,
   SearchAuditLogsRequestSchema,
 } from "@/types/proto-es/v1/audit_log_service_pb";
 import { ExportFormat } from "@/types/proto-es/v1/common_pb";
 import { IssueService } from "@/types/proto-es/v1/issue_service_pb";
-import {
-  file_v1_plan_service,
-  PlanService,
-} from "@/types/proto-es/v1/plan_service_pb";
+import { PlanService } from "@/types/proto-es/v1/plan_service_pb";
 import { RolloutService } from "@/types/proto-es/v1/rollout_service_pb";
-import { SettingSchema } from "@/types/proto-es/v1/setting_service_pb";
 import { SQLService } from "@/types/proto-es/v1/sql_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
+import { protobufJsonRegistry } from "@/types/protobufJsonRegistry";
 import {
   formatAbsoluteDateTime,
   getDefaultPagination,
@@ -74,13 +69,6 @@ import {
 } from "@/utils";
 
 dayjs.extend(utc);
-
-const registry = createRegistry(
-  file_google_rpc_error_details,
-  file_v1_plan_service,
-  AuditDataSchema,
-  SettingSchema
-);
 
 // ============================================================
 // Filter helpers
@@ -402,7 +390,7 @@ function useColumnDefs(): ColumnDef[] {
           log.status ? (
             <JSONStringView
               jsonString={toJsonString(StatusSchema, log.status, {
-                registry,
+                registry: protobufJsonRegistry,
               })}
             />
           ) : (
@@ -431,7 +419,7 @@ function useColumnDefs(): ColumnDef[] {
           log.serviceData ? (
             <JSONStringView
               jsonString={toJsonString(AnySchema, log.serviceData, {
-                registry,
+                registry: protobufJsonRegistry,
               })}
             />
           ) : (

--- a/frontend/src/types/protobufJsonRegistry.ts
+++ b/frontend/src/types/protobufJsonRegistry.ts
@@ -1,0 +1,14 @@
+import { file_google_rpc_error_details } from "@buf/googleapis_googleapis.bufbuild_es/google/rpc/error_details_pb";
+import { createRegistry } from "@bufbuild/protobuf";
+import { AuditDataSchema } from "@/types/proto-es/v1/audit_log_service_pb";
+import { PermissionDeniedDetailSchema } from "@/types/proto-es/v1/common_pb";
+import { file_v1_plan_service } from "@/types/proto-es/v1/plan_service_pb";
+import { SettingSchema } from "@/types/proto-es/v1/setting_service_pb";
+
+export const protobufJsonRegistry = createRegistry(
+  file_google_rpc_error_details,
+  file_v1_plan_service,
+  AuditDataSchema,
+  PermissionDeniedDetailSchema,
+  SettingSchema
+);


### PR DESCRIPTION
## Summary
- Add a shared protobuf JSON registry for frontend `Any` decoding/stringifying.
- Register `PermissionDeniedDetailSchema` so audit log `google.rpc.Status.details` renders without crashing.
- Add a React audit log regression test with a packed `PermissionDeniedDetail`.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check` (passes with existing unrelated Biome warning in `frontend/src/react/components/sql-editor/TabItem/Label.tsx:117`)
- `pnpm --dir frontend type-check`
- `PATH=/Users/p0ny/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --dir frontend test src/react/components/AuditLogTable.test.tsx`
- `PATH=/Users/p0ny/.nvm/versions/node/v24.15.0/bin:$PATH pnpm --dir frontend test` (fails on existing unrelated `src/react/pages/auth/SetupPage.test.tsx` hook timeout; audit log test passes in the full run)

## Pre-PR Checklist
- Breaking change check: no API, proto, database, configuration, or workflow-breaking changes.
- Composite-PK query safety: skipped; no backend store or migrator changes.
- SonarCloud properties: no update needed; added frontend source/test files under existing included paths.