### PR TITLE
fix(pg): insert query limit after outer order by

### DIFF
--- a/backend/plugin/db/pg/query.go
+++ b/backend/plugin/db/pg/query.go
@@ -260,7 +260,12 @@ func findLimitInsertPosition(sel *ast.SelectStmt) (int, bool) {
 	}
 
 	// Otherwise insert at SelectStmt.Loc.End (after everything, including outer parens).
+	// For CTE queries, omni may report SelectStmt.Loc.End before the outer ORDER BY,
+	// so account for the sort clause explicitly.
 	end := sel.Loc.End
+	if span := ast.ListSpan(sel.SortClause); span.End > end {
+		end = span.End
+	}
 	if end <= 0 {
 		return 0, false
 	}

--- a/backend/plugin/db/pg/query_limit_test.go
+++ b/backend/plugin/db/pg/query_limit_test.go
@@ -2,10 +2,13 @@ package pg
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pgparser "github.com/bytebase/bytebase/backend/plugin/parser/pg"
 )
 
 func TestGetStatementWithResultLimit(t *testing.T) {
@@ -213,6 +216,60 @@ func TestGetStatementWithResultLimitInline(t *testing.T) {
 			limit:     5,
 			wantErr:   true,
 		},
+		{
+			name: "CTE with lateral and ORDER BY",
+			statement: `WITH params AS (
+  SELECT 'resource.environment_id in []'::text AS env_condition
+), affected AS (
+  SELECT
+    p.resource,
+    binding,
+    COALESCE(binding->'condition'->>'expression', '') AS old_expression
+  FROM policy p,
+  LATERAL jsonb_array_elements(p.payload->'bindings') AS binding
+  WHERE p.type = 'IAM'
+    AND p.resource_type = 'PROJECT'
+    AND binding->>'role' = 'roles/projectOwner'
+    AND COALESCE(binding->'condition'->>'expression', '') NOT LIKE '%resource.environment_id%'
+)
+SELECT
+  resource,
+  binding->'members' AS members,
+  binding->'condition' AS old_condition,
+  CASE
+    WHEN old_expression = '' THEN params.env_condition
+    ELSE '(' || old_expression || ') && ' || params.env_condition
+  END AS new_expression
+FROM affected
+CROSS JOIN params
+ORDER BY resource`,
+			limit: 1000,
+			want: `WITH params AS (
+  SELECT 'resource.environment_id in []'::text AS env_condition
+), affected AS (
+  SELECT
+    p.resource,
+    binding,
+    COALESCE(binding->'condition'->>'expression', '') AS old_expression
+  FROM policy p,
+  LATERAL jsonb_array_elements(p.payload->'bindings') AS binding
+  WHERE p.type = 'IAM'
+    AND p.resource_type = 'PROJECT'
+    AND binding->>'role' = 'roles/projectOwner'
+    AND COALESCE(binding->'condition'->>'expression', '') NOT LIKE '%resource.environment_id%'
+)
+SELECT
+  resource,
+  binding->'members' AS members,
+  binding->'condition' AS old_condition,
+  CASE
+    WHEN old_expression = '' THEN params.env_condition
+    ELSE '(' || old_expression || ') && ' || params.env_condition
+  END AS new_expression
+FROM affected
+CROSS JOIN params
+ORDER BY resource LIMIT 1000`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -228,5 +285,108 @@ func TestGetStatementWithResultLimitInline(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestGetStatementWithResultLimitInlineClauseOrder(t *testing.T) {
+	tests := []struct {
+		name           string
+		statement      string
+		limit          int
+		want           string
+		clausesInOrder []string
+	}{
+		{
+			name:           "ORDER BY",
+			statement:      "SELECT * FROM users ORDER BY created_at DESC",
+			limit:          10,
+			want:           "SELECT * FROM users ORDER BY created_at DESC LIMIT 10",
+			clausesInOrder: []string{"ORDER BY", "LIMIT 10"},
+		},
+		{
+			name:           "OFFSET without LIMIT",
+			statement:      "SELECT * FROM users OFFSET 20",
+			limit:          10,
+			clausesInOrder: []string{"OFFSET 20", "LIMIT 10"},
+		},
+		{
+			name:           "ORDER BY with OFFSET without LIMIT",
+			statement:      "SELECT * FROM users ORDER BY created_at DESC OFFSET 20",
+			limit:          10,
+			clausesInOrder: []string{"ORDER BY", "OFFSET 20", "LIMIT 10"},
+		},
+		{
+			name:           "ORDER BY with FOR UPDATE",
+			statement:      "SELECT * FROM users ORDER BY id FOR UPDATE",
+			limit:          10,
+			want:           "SELECT * FROM users ORDER BY id LIMIT 10 FOR UPDATE",
+			clausesInOrder: []string{"ORDER BY", "LIMIT 10", "FOR UPDATE"},
+		},
+		{
+			name:           "ORDER BY with OFFSET and FOR UPDATE",
+			statement:      "SELECT * FROM users ORDER BY id OFFSET 20 FOR UPDATE",
+			limit:          10,
+			clausesInOrder: []string{"ORDER BY", "OFFSET 20", "LIMIT 10", "FOR UPDATE"},
+		},
+		{
+			name:           "GROUP BY HAVING WINDOW ORDER BY",
+			statement:      "SELECT department, count(*) AS n, rank() OVER w FROM users GROUP BY department HAVING count(*) > 1 WINDOW w AS (ORDER BY department) ORDER BY n DESC",
+			limit:          10,
+			want:           "SELECT department, count(*) AS n, rank() OVER w FROM users GROUP BY department HAVING count(*) > 1 WINDOW w AS (ORDER BY department) ORDER BY n DESC LIMIT 10",
+			clausesInOrder: []string{"GROUP BY", "HAVING", "WINDOW", "ORDER BY n", "LIMIT 10"},
+		},
+		{
+			name:           "UNION with outer ORDER BY",
+			statement:      "SELECT id FROM users UNION ALL SELECT id FROM admins ORDER BY id",
+			limit:          10,
+			want:           "SELECT id FROM users UNION ALL SELECT id FROM admins ORDER BY id LIMIT 10",
+			clausesInOrder: []string{"UNION ALL", "ORDER BY", "LIMIT 10"},
+		},
+		{
+			name:           "ORDER BY inside window only",
+			statement:      "SELECT row_number() OVER (ORDER BY created_at) FROM users",
+			limit:          10,
+			want:           "SELECT row_number() OVER (ORDER BY created_at) FROM users LIMIT 10",
+			clausesInOrder: []string{"FROM users", "LIMIT 10"},
+		},
+		{
+			name:           "ORDER BY inside subquery only",
+			statement:      "SELECT * FROM (SELECT * FROM users ORDER BY created_at) AS ordered_users",
+			limit:          10,
+			want:           "SELECT * FROM (SELECT * FROM users ORDER BY created_at) AS ordered_users LIMIT 10",
+			clausesInOrder: []string{"AS ordered_users", "LIMIT 10"},
+		},
+		{
+			name:           "WITH query with outer ORDER BY",
+			statement:      "WITH active_users AS (SELECT * FROM users WHERE active = true) SELECT * FROM active_users ORDER BY created_at",
+			limit:          10,
+			want:           "WITH active_users AS (SELECT * FROM users WHERE active = true) SELECT * FROM active_users ORDER BY created_at LIMIT 10",
+			clausesInOrder: []string{"WITH", "ORDER BY", "LIMIT 10"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getStatementWithResultLimitInline(tt.statement, tt.limit)
+			require.NoError(t, err)
+			if tt.want != "" {
+				assert.Equal(t, tt.want, got)
+			}
+			assertSubstringsInOrder(t, got, tt.clausesInOrder)
+
+			_, err = pgparser.ParsePg(got)
+			require.NoError(t, err, "rewritten SQL should remain parseable: %s", got)
+		})
+	}
+}
+
+func assertSubstringsInOrder(t *testing.T, s string, substrings []string) {
+	t.Helper()
+
+	start := 0
+	for _, substring := range substrings {
+		index := strings.Index(s[start:], substring)
+		require.NotEqualf(t, -1, index, "expected %q after offset %d in %q", substring, start, s)
+		start += index + len(substring)
 	}
 }


### PR DESCRIPTION
## Summary
- Fix Postgres SQL Editor result-limit rewriting so injected `LIMIT` is placed after the outer `ORDER BY` for CTE queries.
- Add regression coverage for the reported `WITH ... LATERAL ... CROSS JOIN ... ORDER BY` query.
- Add clause-order tests for `ORDER BY`, `OFFSET`, locking clauses, set operations, CTEs, subqueries, and window functions; rewritten SQL is parsed again to catch invalid output.

## Test Plan
- `go test ./backend/plugin/db/pg -count=1`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Pre-PR Checklist
- Breaking change check: not breaking; bug fix in Postgres query-limit rewrite.
- Composite-PK query safety: skipped; diff does not touch `backend/store/` or `backend/migrator/`.
- SonarCloud properties: skipped; no new files or directories.
