### PR TITLE
chore: update omni dependency

### DIFF
--- a/backend/plugin/schema/mysql/walk_through_loader_test.go
+++ b/backend/plugin/schema/mysql/walk_through_loader_test.go
@@ -295,7 +295,7 @@ func TestLoader_FulltextAndSpatialIndex(t *testing.T) {
 		Columns: []*storepb.ColumnMetadata{
 			{Name: "id", Type: "bigint unsigned", Nullable: false, Default: autoIncrementSentinel},
 			{Name: "body", Type: "text", Nullable: true},
-			{Name: "location", Type: "geometry", Nullable: true},
+			{Name: "location", Type: "geometry", Nullable: false},
 		},
 		Indexes: []*storepb.IndexMetadata{
 			{Name: "PRIMARY", Type: "BTREE", Primary: true, Unique: true, Expressions: []string{"id"}},

--- a/backend/tests/test-data/sql_review_mysql.yaml
+++ b/backend/tests/test-data/sql_review_mysql.yaml
@@ -30,9 +30,26 @@
   result:
     - |-
       {
+        "status":  "WARNING",
+        "title":  "BLOB/TEXT column used in key specification without a key length",
+        "content":  "BLOB/TEXT column used in key specification without a key length",
+        "code":  260,
+        "target":  "instances/instance-96a5f914-2/databases/testsqlreview",
+        "type":  "STATEMENT_ADVISE",
+        "sqlReviewReport":  {
+          "startPosition":  {
+            "line":  1
+          }
+        }
+      }
+  run: false
+- statement: CREATE TABLE userTable(id INT NOT NULL,name VARCHAR(255) CHARSET ascii,roomId INT,time_created TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',time_updated TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',content BLOB NOT NULL COMMENT 'comment',json_content JSON NOT NULL COMMENT 'comment',INDEX idx1(name),UNIQUE KEY uk1(id, name),FOREIGN KEY fk1(roomId) REFERENCES room(id),INDEX idx_userTable_content(content(10))) ENGINE = MyISAM COLLATE latin1_bin
+  result:
+    - |-
+      {
         "status":  "ERROR",
         "title":  "ENGINE_MYSQL_USE_INNODB",
-        "content":  "\"CREATE TABLE userTable(id INT NOT NULL,name VARCHAR(255) CHARSET ascii,roomId INT,time_created TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',time_updated TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',content BLOB NOT NULL COMMENT 'comment',json_content JSON NOT NULL COMMENT 'comment',INDEX idx1(name),UNIQUE KEY uk1(id, name),FOREIGN KEY fk1(roomId) REFERENCES room(id),INDEX idx_userTable_content(content)) ENGINE = CSV COLLATE latin1_bin;\" doesn't use InnoDB engine",
+        "content":  "\"CREATE TABLE userTable(id INT NOT NULL,name VARCHAR(255) CHARSET ascii,roomId INT,time_created TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',time_updated TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',content BLOB NOT NULL COMMENT 'comment',json_content JSON NOT NULL COMMENT 'comment',INDEX idx1(name),UNIQUE KEY uk1(id, name),FOREIGN KEY fk1(roomId) REFERENCES room(id),INDEX idx_userTable_content(content(10))) ENGINE = MyISAM COLLATE latin1_bin;\" doesn't use InnoDB engine",
         "code":  501,
         "target":  "instances/instance-96a5f914-2/databases/testsqlreview",
         "type":  "STATEMENT_ADVISE",
@@ -270,7 +287,7 @@
       {
         "status":  "WARNING",
         "title":  "COLUMN_DISALLOW_SET_CHARSET",
-        "content":  "Disallow set column charset but \"CREATE TABLE userTable(id INT NOT NULL,name VARCHAR(255) CHARSET ascii,roomId INT,time_created TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',time_updated TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',content BLOB NOT NULL COMMENT 'comment',json_content JSON NOT NULL COMMENT 'comment',INDEX idx1(name),UNIQUE KEY uk1(id, name),FOREIGN KEY fk1(roomId) REFERENCES room(id),INDEX idx_userTable_content(content)) ENGINE = CSV COLLATE latin1_bin\" does",
+        "content":  "Disallow set column charset but \"CREATE TABLE userTable(id INT NOT NULL,name VARCHAR(255) CHARSET ascii,roomId INT,time_created TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',time_updated TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',content BLOB NOT NULL COMMENT 'comment',json_content JSON NOT NULL COMMENT 'comment',INDEX idx1(name),UNIQUE KEY uk1(id, name),FOREIGN KEY fk1(roomId) REFERENCES room(id),INDEX idx_userTable_content(content(10))) ENGINE = MyISAM COLLATE latin1_bin\" does",
         "code":  414,
         "target":  "instances/instance-96a5f914-2/databases/testsqlreview",
         "type":  "STATEMENT_ADVISE",
@@ -354,7 +371,7 @@
       {
         "status":  "WARNING",
         "title":  "SYSTEM_CHARSET_ALLOWLIST",
-        "content":  "\"CREATE TABLE userTable(id INT NOT NULL,name VARCHAR(255) CHARSET ascii,roomId INT,time_created TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',time_updated TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',content BLOB NOT NULL COMMENT 'comment',json_content JSON NOT NULL COMMENT 'comment',INDEX idx1(name),UNIQUE KEY uk1(id, name),FOREIGN KEY fk1(roomId) REFERENCES room(id),INDEX idx_userTable_content(content)) ENGINE = CSV COLLATE latin1_bin\" used disabled charset 'ascii'",
+        "content":  "\"CREATE TABLE userTable(id INT NOT NULL,name VARCHAR(255) CHARSET ascii,roomId INT,time_created TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',time_updated TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',content BLOB NOT NULL COMMENT 'comment',json_content JSON NOT NULL COMMENT 'comment',INDEX idx1(name),UNIQUE KEY uk1(id, name),FOREIGN KEY fk1(roomId) REFERENCES room(id),INDEX idx_userTable_content(content(10))) ENGINE = MyISAM COLLATE latin1_bin\" used disabled charset 'ascii'",
         "code":  1001,
         "target":  "instances/instance-96a5f914-2/databases/testsqlreview",
         "type":  "STATEMENT_ADVISE",
@@ -368,7 +385,7 @@
       {
         "status":  "WARNING",
         "title":  "SYSTEM_COLLATION_ALLOWLIST",
-        "content":  "\"CREATE TABLE userTable(id INT NOT NULL,name VARCHAR(255) CHARSET ascii,roomId INT,time_created TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',time_updated TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',content BLOB NOT NULL COMMENT 'comment',json_content JSON NOT NULL COMMENT 'comment',INDEX idx1(name),UNIQUE KEY uk1(id, name),FOREIGN KEY fk1(roomId) REFERENCES room(id),INDEX idx_userTable_content(content)) ENGINE = CSV COLLATE latin1_bin\" used disabled collation 'latin1_bin'",
+        "content":  "\"CREATE TABLE userTable(id INT NOT NULL,name VARCHAR(255) CHARSET ascii,roomId INT,time_created TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',time_updated TIMESTAMP NOT NULL DEFAULT NOW() ON UPDATE NOW() COMMENT 'comment',content BLOB NOT NULL COMMENT 'comment',json_content JSON NOT NULL COMMENT 'comment',INDEX idx1(name),UNIQUE KEY uk1(id, name),FOREIGN KEY fk1(roomId) REFERENCES room(id),INDEX idx_userTable_content(content(10))) ENGINE = MyISAM COLLATE latin1_bin\" used disabled collation 'latin1_bin'",
         "code":  1201,
         "target":  "instances/instance-96a5f914-2/databases/testsqlreview",
         "type":  "STATEMENT_ADVISE",

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260424061300-8a4a735f63a5
+	github.com/bytebase/omni v0.0.0-20260427081057-916c11de76f6
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888 h1:E8tz8maxpih/vt
 github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888/go.mod h1:IgLUOjyiHehdE0G3C92IjGYu9lJQgkPwf2mdNSvPWq8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260424061300-8a4a735f63a5 h1:drOwmZHyohwDoTkRAm+hkx5C/sZL8KTHOBSUaAppr4Y=
-github.com/bytebase/omni v0.0.0-20260424061300-8a4a735f63a5/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260427081057-916c11de76f6 h1:VsMeuad1/WnGcqUCsZbkTiW2DXsbsU+dv1AZcmFdNJs=
+github.com/bytebase/omni v0.0.0-20260427081057-916c11de76f6/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Update `github.com/bytebase/omni` to `916c11d` (`v0.0.0-20260427081057-916c11de76f6`).
- Align the MySQL SPATIAL index loader fixture with real MySQL behavior by requiring the indexed geometry column to be NOT NULL.
- Split the MySQL SQL review fixture so one case verifies walkthrough failure for a BLOB index without key length, while another case passes walkthrough and still reports the broader advisor set.

## Validation
- Verified against MySQL 8.0.33 that SPATIAL indexes require NOT NULL columns, and that BLOB indexes require key length unless FULLTEXT.
- `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/schema/mysql -run ^TestLoader_FulltextAndSpatialIndex$`
- `go test -v -count=1 ./backend/tests -run ^TestSQLReviewForMySQL$`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `golangci-lint run --allow-parallel-runners`

## Notes
- Full `go test ./...` was not clean in this local environment before these targeted fixes due to unrelated local/environment failures (`mongosh` missing for MongoDB tests and the migrator invalid UTF-8 test behavior under local Postgres 16 container).
