### PR TITLE
fix(frontend): localize React header labels

### DIFF
--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -69,7 +69,7 @@
     "unarchive-all-chats": "Desarchivar todos los chats",
     "unarchive-chat": "Desarchivar chat"
   },
-  "agent.self": "Agent",
+  "agent.self": "Asistente",
   "audit-log": {
     "advanced-search": {
       "scope": {
@@ -480,7 +480,7 @@
   "common.password": "Contraseña",
   "common.project": "Proyecto",
   "common.read-only": "Solo lectura",
-  "common.recent": "Recent",
+  "common.recent": "Recientes",
   "common.remaining": "restantes",
   "common.remove": "Eliminar",
   "common.removed": "Eliminado",
@@ -1446,9 +1446,9 @@
   "issue.data-export.format": "Formato",
   "issue.data-export.limits": "Límites",
   "issue.data-export.options": "Opciones",
-  "issue.issue-name": "Issue name",
-  "issue.my-issues": "My Issues",
-  "issue.no-description-provided": "No description provided",
+  "issue.issue-name": "Nombre de la incidencia",
+  "issue.my-issues": "Mis issues",
+  "issue.no-description-provided": "No se proporcionó ninguna descripción",
   "issue.options-disabled-due-to-oversize": "Las opciones están deshabilitadas porque el SQL es demasiado grande.",
   "issue.overwrite-current-statement": "Sobrescribir la declaración SQL actual",
   "issue.review.self": "Review",
@@ -1804,7 +1804,7 @@
       "webhook-url": "URL del webhook"
     }
   },
-  "project.select": "Select project",
+  "project.select": "Seleccionar proyecto",
   "quick-action": {
     "create-db": "Crear base de datos",
     "new-project": "Nuevo Proyecto",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -69,7 +69,7 @@
     "unarchive-all-chats": "すべてのチャットのアーカイブを解除",
     "unarchive-chat": "アーカイブ解除"
   },
-  "agent.self": "Agent",
+  "agent.self": "エージェント",
   "audit-log": {
     "advanced-search": {
       "scope": {
@@ -480,7 +480,7 @@
   "common.password": "パスワード",
   "common.project": "プロジェクト",
   "common.read-only": "読み取り専用",
-  "common.recent": "Recent",
+  "common.recent": "最近",
   "common.remaining": "残り",
   "common.remove": "削除",
   "common.removed": "削除されました",
@@ -1446,9 +1446,9 @@
   "issue.data-export.format": "形式",
   "issue.data-export.limits": "制限",
   "issue.data-export.options": "オプション",
-  "issue.issue-name": "Issue name",
-  "issue.my-issues": "My Issues",
-  "issue.no-description-provided": "No description provided",
+  "issue.issue-name": "イシュー名",
+  "issue.my-issues": "自分の Issue",
+  "issue.no-description-provided": "説明なし",
   "issue.options-disabled-due-to-oversize": "SQL が大きすぎるため、オプションは無効になっています。",
   "issue.overwrite-current-statement": "現在の SQL ステートメントを上書きする",
   "issue.review.self": "Review",
@@ -1804,7 +1804,7 @@
       "webhook-url": "Webhook URL"
     }
   },
-  "project.select": "Select project",
+  "project.select": "プロジェクトを選択",
   "quick-action": {
     "create-db": "データベースの作成",
     "new-project": "作成するプロジェクト",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -69,7 +69,7 @@
     "unarchive-all-chats": "Bỏ lưu trữ tất cả cuộc trò chuyện",
     "unarchive-chat": "Bỏ lưu trữ"
   },
-  "agent.self": "Agent",
+  "agent.self": "Trợ lý",
   "audit-log": {
     "advanced-search": {
       "scope": {
@@ -480,7 +480,7 @@
   "common.password": "Mật khẩu",
   "common.project": "Dự án",
   "common.read-only": "Chỉ đọc",
-  "common.recent": "Recent",
+  "common.recent": "Gần đây",
   "common.remaining": "còn lại",
   "common.remove": "Xóa",
   "common.removed": "LOẠI BỎ",
@@ -1446,9 +1446,9 @@
   "issue.data-export.format": "Định dạng",
   "issue.data-export.limits": "Giới hạn",
   "issue.data-export.options": "Tùy chọn",
-  "issue.issue-name": "Issue name",
-  "issue.my-issues": "My Issues",
-  "issue.no-description-provided": "No description provided",
+  "issue.issue-name": "Tên vấn đề",
+  "issue.my-issues": "Issue của tôi",
+  "issue.no-description-provided": "Không có mô tả nào được cung cấp",
   "issue.options-disabled-due-to-oversize": "Các tùy chọn bị vô hiệu hóa vì SQL quá lớn.",
   "issue.overwrite-current-statement": "Ghi đè câu lệnh SQL hiện tại",
   "issue.review.self": "Review",
@@ -1804,7 +1804,7 @@
       "webhook-url": "URL Webhook"
     }
   },
-  "project.select": "Select project",
+  "project.select": "Chọn dự án",
   "quick-action": {
     "create-db": "Tạo cơ sở dữ liệu",
     "new-project": "Mới Dự án",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -69,7 +69,7 @@
     "unarchive-all-chats": "取消归档所有对话",
     "unarchive-chat": "取消归档"
   },
-  "agent.self": "Agent",
+  "agent.self": "助手",
   "audit-log": {
     "advanced-search": {
       "scope": {
@@ -480,7 +480,7 @@
   "common.password": "密码",
   "common.project": "项目",
   "common.read-only": "只读",
-  "common.recent": "Recent",
+  "common.recent": "最近访问",
   "common.remaining": "剩余",
   "common.remove": "删除",
   "common.removed": "已移除",
@@ -1446,9 +1446,9 @@
   "issue.data-export.format": "格式",
   "issue.data-export.limits": "限制",
   "issue.data-export.options": "选项",
-  "issue.issue-name": "Issue name",
-  "issue.my-issues": "My Issues",
-  "issue.no-description-provided": "No description provided",
+  "issue.issue-name": "工单名称",
+  "issue.my-issues": "我的工单",
+  "issue.no-description-provided": "未提供描述",
   "issue.options-disabled-due-to-oversize": "由于 SQL 文件过大，选项已禁用。",
   "issue.overwrite-current-statement": "覆盖当前的 SQL 语句",
   "issue.review.self": "评审",
@@ -1804,7 +1804,7 @@
       "webhook-url": "Webhook URL"
     }
   },
-  "project.select": "Select project",
+  "project.select": "选择项目",
   "quick-action": {
     "create-db": "创建数据库",
     "new-project": "创建项目",


### PR DESCRIPTION
## Summary
- Localize React header/project switch labels that were introduced as English placeholders during the dashboard header migration.
- Restore zh-CN issue label strings from the legacy locale equivalents.

## Test Plan
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check