### PR TITLE
refactor(frontend): move workspace state to react store

### DIFF
--- a/frontend/src/react/components/AuditLogTable.test.tsx
+++ b/frontend/src/react/components/AuditLogTable.test.tsx
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
   exportAuditLogs: vi.fn(),
   useTranslation: vi.fn(() => ({ t: (key: string) => key })),
   pushNotification: vi.fn(),
-  useSubscriptionV1Store: vi.fn(() => ({ hasFeature: () => true })),
+  usePlanFeature: vi.fn(() => true),
   useUserStore: vi.fn(() => ({ fetchUserList: vi.fn() })),
 }));
 
@@ -37,8 +37,11 @@ vi.mock("@/connect", () => ({
 
 vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
-  useSubscriptionV1Store: mocks.useSubscriptionV1Store,
   useUserStore: mocks.useUserStore,
+}));
+
+vi.mock("@/react/hooks/useAppState", () => ({
+  usePlanFeature: mocks.usePlanFeature,
 }));
 
 vi.mock("@/store/modules/v1/common", () => ({
@@ -72,10 +75,6 @@ vi.mock("@/react/hooks/usePagedData", () => ({
 vi.mock("@/react/hooks/useSessionPageSize", () => ({
   getPageSizeOptions: () => [10],
   useSessionPageSize: () => [10, vi.fn()],
-}));
-
-vi.mock("@/react/hooks/useVueState", () => ({
-  useVueState: (getter: () => unknown) => getter(),
 }));
 
 vi.mock("@/connect/methods", () => ({

--- a/frontend/src/react/components/AuditLogTable.tsx
+++ b/frontend/src/react/components/AuditLogTable.tsx
@@ -28,18 +28,14 @@ import {
   DialogTitle,
 } from "@/react/components/ui/dialog";
 import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
+import { usePlanFeature } from "@/react/hooks/useAppState";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
 import {
   getPageSizeOptions,
   useSessionPageSize,
 } from "@/react/hooks/useSessionPageSize";
-import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
-import {
-  pushNotification,
-  useSubscriptionV1Store,
-  useUserStore,
-} from "@/store";
+import { pushNotification, useUserStore } from "@/store";
 import {
   extractUserEmail,
   getProjectIdPlanUidStageUidFromRolloutName,
@@ -520,10 +516,7 @@ export function AuditLogTable({
   readonlyScopes,
 }: AuditLogTableProps) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
-  const hasAuditLogFeature = useVueState(() =>
-    subscriptionStore.hasFeature(PlanFeature.FEATURE_AUDIT_LOG)
-  );
+  const hasAuditLogFeature = usePlanFeature(PlanFeature.FEATURE_AUDIT_LOG);
   const columns = useColumnDefs();
   const { widths, totalWidth, onResizeStart } = useColumnWidths(columns);
 

--- a/frontend/src/react/components/EditEnvironmentSheet.tsx
+++ b/frontend/src/react/components/EditEnvironmentSheet.tsx
@@ -10,9 +10,8 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useEnvironmentList } from "@/react/hooks/useAppState";
 import { cn } from "@/react/lib/utils";
-import { useEnvironmentV1Store } from "@/store";
 
 export function EditEnvironmentSheet({
   open,
@@ -24,10 +23,7 @@ export function EditEnvironmentSheet({
   onUpdate: (environment: string) => Promise<void>;
 }) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
-  const environments = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environments = useEnvironmentList();
   const [selected, setSelected] = useState("");
   const [updating, setUpdating] = useState(false);
 

--- a/frontend/src/react/components/EnvironmentLabel.tsx
+++ b/frontend/src/react/components/EnvironmentLabel.tsx
@@ -1,8 +1,7 @@
 import { ShieldAlert } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useEnvironment, usePlanFeature } from "@/react/hooks/useAppState";
 import { cn } from "@/react/lib/utils";
-import { featureToRef, useEnvironmentV1Store } from "@/store";
 import type { Environment } from "@/types";
 import { NULL_ENVIRONMENT_NAME, UNKNOWN_ENVIRONMENT_NAME } from "@/types";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
@@ -26,14 +25,9 @@ export function EnvironmentLabel({
   className?: string;
 }) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
 
   // Always called (rules of hooks); result ignored when envProp is provided.
-  const envFromStore = useVueState(() =>
-    environmentStore.getEnvironmentByName(
-      environmentName || NULL_ENVIRONMENT_NAME
-    )
-  );
+  const envFromStore = useEnvironment(environmentName || NULL_ENVIRONMENT_NAME);
 
   const environment = envProp ?? envFromStore;
 
@@ -41,8 +35,8 @@ export function EnvironmentLabel({
     environment.name === UNKNOWN_ENVIRONMENT_NAME ||
     environment.name === NULL_ENVIRONMENT_NAME;
 
-  const hasEnvTierFeature = useVueState(
-    () => featureToRef(PlanFeature.FEATURE_ENVIRONMENT_TIERS).value
+  const hasEnvTierFeature = usePlanFeature(
+    PlanFeature.FEATURE_ENVIRONMENT_TIERS
   );
   const isProtected =
     hasEnvTierFeature && environment.tags?.protected === "protected";

--- a/frontend/src/react/components/EnvironmentMultiSelect.tsx
+++ b/frontend/src/react/components/EnvironmentMultiSelect.tsx
@@ -7,9 +7,8 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/react/components/ui/popover";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useEnvironmentList } from "@/react/hooks/useAppState";
 import { cn } from "@/react/lib/utils";
-import { useEnvironmentV1Store } from "@/store";
 
 export function EnvironmentMultiSelect({
   value,
@@ -19,10 +18,7 @@ export function EnvironmentMultiSelect({
   onChange: (envs: string[]) => void;
 }>) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
-  const environmentList = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environmentList = useEnvironmentList();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/frontend/src/react/components/EnvironmentSelect.tsx
+++ b/frontend/src/react/components/EnvironmentSelect.tsx
@@ -2,8 +2,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { Combobox } from "@/react/components/ui/combobox";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useEnvironmentV1Store } from "@/store";
+import { useEnvironmentList } from "@/react/hooks/useAppState";
 import { formatEnvironmentName } from "@/types";
 import type { Environment } from "@/types/v1/environment";
 
@@ -27,11 +26,7 @@ export function EnvironmentSelect({
   renderSuffix,
 }: EnvironmentSelectProps) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
-
-  const environments = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environments = useEnvironmentList();
 
   const options = useMemo(
     () =>

--- a/frontend/src/react/components/FeatureAttention.test.tsx
+++ b/frontend/src/react/components/FeatureAttention.test.tsx
@@ -16,9 +16,9 @@ const mocks = vi.hoisted(() => ({
   useTranslation: vi.fn(() => ({
     t: (key: string) => key,
   })),
-  useVueState: vi.fn((getter: () => unknown) => getter()),
-  useSubscriptionV1Store: vi.fn(),
-  useActuatorV1Store: vi.fn(),
+  useSubscriptionState: vi.fn(),
+  useServerState: vi.fn(),
+  useAppStore: vi.fn(),
   hasWorkspacePermissionV2: vi.fn(() => true),
   autoSubscriptionRoute: vi.fn(() => "/subscription"),
   routerPush: vi.fn(),
@@ -30,8 +30,9 @@ vi.mock("react-i18next", () => ({
   useTranslation: mocks.useTranslation,
 }));
 
-vi.mock("@/react/hooks/useVueState", () => ({
-  useVueState: mocks.useVueState,
+vi.mock("@/react/hooks/useAppState", () => ({
+  useSubscriptionState: mocks.useSubscriptionState,
+  useServerState: mocks.useServerState,
 }));
 
 vi.mock("@/react/components/InstanceAssignmentSheet", () => ({
@@ -44,9 +45,8 @@ vi.mock("@/router", () => ({
   },
 }));
 
-vi.mock("@/store", () => ({
-  useSubscriptionV1Store: mocks.useSubscriptionV1Store,
-  useActuatorV1Store: mocks.useActuatorV1Store,
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: mocks.useAppStore,
 }));
 
 vi.mock("@/types", () => ({
@@ -82,21 +82,26 @@ beforeEach(async () => {
   mocks.useTranslation.mockReturnValue({
     t: (key: string) => key,
   });
-  mocks.useVueState.mockReset();
-  mocks.useVueState.mockImplementation((getter: () => unknown) => getter());
-  mocks.useSubscriptionV1Store.mockReset();
-  mocks.useSubscriptionV1Store.mockReturnValue({
-    hasInstanceFeature: vi.fn(() => false),
-    instanceMissingLicense: vi.fn(() => false),
+  mocks.useSubscriptionState.mockReset();
+  mocks.useSubscriptionState.mockReturnValue({
     isTrialing: false,
     trialingDays: 14,
-    getMinimumRequiredPlan: vi.fn(() => PlanType.TEAM),
   });
-  mocks.useActuatorV1Store.mockReset();
-  mocks.useActuatorV1Store.mockReturnValue({
+  mocks.useServerState.mockReset();
+  mocks.useServerState.mockReturnValue({
     totalInstanceCount: 0,
     activatedInstanceCount: 0,
   });
+  mocks.useAppStore.mockReset();
+  mocks.useAppStore.mockImplementation(
+    (selector: (state: Record<string, unknown>) => unknown) =>
+      selector({
+        hasInstanceFeature: () => false,
+        instanceMissingLicense: () => false,
+        getMinimumRequiredPlan: () => PlanType.TEAM,
+        hasFeature: () => false,
+      })
+  );
   mocks.hasWorkspacePermissionV2.mockReset();
   mocks.hasWorkspacePermissionV2.mockReturnValue(true);
   mocks.autoSubscriptionRoute.mockReset();

--- a/frontend/src/react/components/FeatureAttention.tsx
+++ b/frontend/src/react/components/FeatureAttention.tsx
@@ -7,8 +7,12 @@ import {
   AlertTitle,
 } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import {
+  useServerState,
+  useSubscriptionState,
+} from "@/react/hooks/useAppState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import { useActuatorV1Store, useSubscriptionV1Store } from "@/store";
 import { ENTERPRISE_INQUIRE_LINK, instanceLimitFeature } from "@/types";
 import type {
   Instance,
@@ -19,7 +23,6 @@ import {
   PlanType,
 } from "@/types/proto-es/v1/subscription_service_pb";
 import { autoSubscriptionRoute, hasWorkspacePermissionV2 } from "@/utils";
-import { useVueState } from "../hooks/useVueState";
 import { InstanceAssignmentSheet } from "./InstanceAssignmentSheet";
 
 export function FeatureAttention({
@@ -32,21 +35,23 @@ export function FeatureAttention({
   instance?: Instance | InstanceResource;
 }) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
-  const actuatorStore = useActuatorV1Store();
+  const { trialingDays, isTrialing } = useSubscriptionState();
+  const { totalInstanceCount, activatedInstanceCount } = useServerState();
   const [showInstanceAssignment, setShowInstanceAssignment] = useState(false);
 
-  const hasFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(feature)
+  const hasFeature = useAppStore((state) => state.hasInstanceFeature(feature));
+  const instanceMissingLicense = useAppStore((state) =>
+    state.instanceMissingLicense(feature, instance)
   );
-  const instanceMissingLicense = useVueState(() =>
-    subscriptionStore.instanceMissingLicense(feature, instance)
+  const requiredPlan = useAppStore((state) =>
+    state.getMinimumRequiredPlan(feature)
   );
-  const existInstanceWithoutLicense = useVueState(
-    () =>
-      actuatorStore.totalInstanceCount > actuatorStore.activatedInstanceCount &&
-      instanceLimitFeature.has(feature)
+  const featureIncludedInPlan = useAppStore((state) =>
+    state.hasFeature(feature)
   );
+  const existInstanceWithoutLicense =
+    totalInstanceCount > activatedInstanceCount &&
+    instanceLimitFeature.has(feature);
 
   const show =
     !hasFeature ||
@@ -64,16 +69,12 @@ export function FeatureAttention({
 
   let descriptionText: string;
   if (!hasFeature) {
-    const startTrial = subscriptionStore.isTrialing
+    const startTrial = isTrialing
       ? ""
       : t("subscription.trial-for-days", {
-          days: subscriptionStore.trialingDays,
+          days: trialingDays,
         });
-    const requiredPlan = subscriptionStore.getMinimumRequiredPlan(feature);
-    if (
-      requiredPlan === PlanType.FREE &&
-      subscriptionStore.hasFeature(feature)
-    ) {
+    if (requiredPlan === PlanType.FREE && featureIncludedInPlan) {
       descriptionText = `${featureDesc}\n${startTrial}`;
     } else {
       const trialText = t("subscription.required-plan-with-trial", {
@@ -97,7 +98,7 @@ export function FeatureAttention({
   if (hasPermission) {
     if (!hasFeature) {
       actionText = t("subscription.request-n-days-trial", {
-        days: subscriptionStore.trialingDays,
+        days: trialingDays,
       });
     } else if (hasWorkspacePermissionV2("bb.instances.update")) {
       actionText = t("subscription.instance-assignment.assign-license");

--- a/frontend/src/react/components/FeatureBadge.tsx
+++ b/frontend/src/react/components/FeatureBadge.tsx
@@ -1,8 +1,8 @@
 import { Lock, Sparkles } from "lucide-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useSubscriptionV1Store } from "@/store";
+import { useSubscriptionState } from "@/react/hooks/useAppState";
+import { useAppStore } from "@/react/stores/app";
 import type {
   Instance,
   InstanceResource,
@@ -48,16 +48,16 @@ export function FeatureBadge({
   fallback = null,
 }: FeatureBadgeProps) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
+  useSubscriptionState();
 
-  const hasFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(feature, instance)
+  const hasFeature = useAppStore((state) =>
+    state.hasInstanceFeature(feature, instance)
   );
-  const instanceMissingLicense = useVueState(() =>
-    subscriptionStore.instanceMissingLicense(feature, instance)
+  const instanceMissingLicense = useAppStore((state) =>
+    state.instanceMissingLicense(feature, instance)
   );
-  const minimumPlan = useVueState(() =>
-    subscriptionStore.getMinimumRequiredPlan(feature)
+  const minimumPlan = useAppStore((state) =>
+    state.getMinimumRequiredPlan(feature)
   );
 
   if (instanceMissingLicense) {

--- a/frontend/src/react/components/InstanceAssignmentSheet.tsx
+++ b/frontend/src/react/components/InstanceAssignmentSheet.tsx
@@ -15,14 +15,16 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
+import {
+  useServerState,
+  useSubscriptionState,
+} from "@/react/hooks/useAppState";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import {
   pushNotification,
-  useActuatorV1Store,
   useDatabaseV1Store,
   useInstanceV1Store,
-  useSubscriptionV1Store,
 } from "@/store";
 import { isValidInstanceName } from "@/types";
 import type {
@@ -51,19 +53,10 @@ export function InstanceAssignmentSheet({
   const { t } = useTranslation();
   const instanceStore = useInstanceV1Store();
   const databaseStore = useDatabaseV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
-  const actuatorStore = useActuatorV1Store();
+  const refreshServerInfo = useAppStore((state) => state.refreshServerInfo);
 
-  const instanceLicenseCount = useVueState(
-    () => subscriptionStore.instanceLicenseCount
-  );
-  const currentPlan = useVueState(() => subscriptionStore.currentPlan);
-  const activatedInstanceCount = useVueState(
-    () => actuatorStore.activatedInstanceCount
-  );
-  const workspaceResourceName = useVueState(
-    () => actuatorStore.workspaceResourceName
-  );
+  const { instanceLicenseCount, currentPlan } = useSubscriptionState();
+  const { activatedInstanceCount } = useServerState();
 
   const [instances, setInstances] = useState<Instance[]>([]);
   const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
@@ -202,7 +195,7 @@ export function InstanceAssignmentSheet({
       for (const instance of updated) {
         databaseStore.updateDatabaseInstance(instance);
       }
-      await actuatorStore.fetchServerInfo(workspaceResourceName);
+      await refreshServerInfo();
       pushNotification({
         module: "bytebase",
         style: "SUCCESS",
@@ -214,7 +207,6 @@ export function InstanceAssignmentSheet({
       setProcessing(false);
     }
   }, [
-    actuatorStore,
     canManageSubscription,
     databaseStore,
     instanceStore,
@@ -224,7 +216,7 @@ export function InstanceAssignmentSheet({
     processing,
     selectedNames,
     t,
-    workspaceResourceName,
+    refreshServerInfo,
   ]);
 
   const confirmDisabled =

--- a/frontend/src/react/components/instance/CredentialSourceForm.tsx
+++ b/frontend/src/react/components/instance/CredentialSourceForm.tsx
@@ -9,8 +9,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { Input } from "@/react/components/ui/input";
 import { Textarea } from "@/react/components/ui/textarea";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useActuatorV1Store } from "@/store";
+import { useServerState } from "@/react/hooks/useAppState";
 import {
   DataSource_AuthenticationType,
   DataSource_AWSCredentialSchema,
@@ -33,8 +32,7 @@ function CredentialSourceForm({
   onDataSourceChange,
 }: CredentialSourceFormProps) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const { isSaaSMode } = useServerState();
 
   const isIAMAuthentication =
     dataSource.authenticationType ===

--- a/frontend/src/react/components/ui/feature-modal.test.tsx
+++ b/frontend/src/react/components/ui/feature-modal.test.tsx
@@ -7,7 +7,8 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const mocks = vi.hoisted(() => ({
-  useVueState: vi.fn<(getter: () => unknown) => unknown>(),
+  useSubscriptionState: vi.fn(),
+  useAppStore: vi.fn(),
   instanceMissingLicense: false,
   requiredPlan: 1, // TEAM
   showTrial: false,
@@ -19,17 +20,12 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock("@/react/hooks/useVueState", () => ({
-  useVueState: mocks.useVueState,
+vi.mock("@/react/hooks/useAppState", () => ({
+  useSubscriptionState: mocks.useSubscriptionState,
 }));
 
-vi.mock("@/store", () => ({
-  useSubscriptionV1Store: () => ({
-    instanceMissingLicense: () => mocks.instanceMissingLicense,
-    getMinimumRequiredPlan: () => mocks.requiredPlan,
-    showTrial: mocks.showTrial,
-    trialingDays: mocks.trialingDays,
-  }),
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: mocks.useAppStore,
 }));
 
 vi.mock("@/router", () => ({
@@ -142,11 +138,21 @@ const renderIntoContainer = (element: ReactElement) => {
 
 beforeEach(async () => {
   vi.clearAllMocks();
-  mocks.useVueState.mockImplementation((getter) => getter());
   mocks.instanceMissingLicense = false;
   mocks.requiredPlan = 1;
   mocks.showTrial = false;
   mocks.trialingDays = 14;
+  mocks.useSubscriptionState.mockReturnValue({
+    showTrial: mocks.showTrial,
+    trialingDays: mocks.trialingDays,
+  });
+  mocks.useAppStore.mockImplementation(
+    (selector: (state: Record<string, unknown>) => unknown) =>
+      selector({
+        instanceMissingLicense: () => mocks.instanceMissingLicense,
+        getMinimumRequiredPlan: () => mocks.requiredPlan,
+      })
+  );
   mocks.hasWorkspacePermissionV2.mockReturnValue(true);
   ({ FeatureModal } = await import("./feature-modal"));
 });

--- a/frontend/src/react/components/ui/feature-modal.tsx
+++ b/frontend/src/react/components/ui/feature-modal.tsx
@@ -7,10 +7,10 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/react/components/ui/dialog";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useSubscriptionState } from "@/react/hooks/useAppState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { INSTANCE_ROUTE_DASHBOARD } from "@/router/dashboard/workspaceRoutes";
-import { useSubscriptionV1Store } from "@/store";
 import { ENTERPRISE_INQUIRE_LINK } from "@/types";
 import type {
   Instance,
@@ -45,18 +45,16 @@ const planLabel: Record<number, string> = {
  */
 export function FeatureModal({ open, feature, instance, onOpenChange }: Props) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
+  const { showTrial, trialingDays } = useSubscriptionState();
   const hasPermission = hasWorkspacePermissionV2("bb.settings.set");
 
   const resolvedFeature = feature ?? PlanFeature.FEATURE_UNSPECIFIED;
-  const instanceMissingLicense = useVueState(() =>
-    subscriptionStore.instanceMissingLicense(resolvedFeature, instance)
+  const instanceMissingLicense = useAppStore((state) =>
+    state.instanceMissingLicense(resolvedFeature, instance)
   );
-  const requiredPlan = useVueState(() =>
-    subscriptionStore.getMinimumRequiredPlan(resolvedFeature)
+  const requiredPlan = useAppStore((state) =>
+    state.getMinimumRequiredPlan(resolvedFeature)
   );
-  const showTrial = useVueState(() => subscriptionStore.showTrial);
-  const trialingDays = useVueState(() => subscriptionStore.trialingDays);
 
   if (!feature) {
     return null;

--- a/frontend/src/react/hooks/useAppState.ts
+++ b/frontend/src/react/hooks/useAppState.ts
@@ -8,6 +8,13 @@ import {
 import type { AppFeatures } from "@/types/appProfile";
 import type { Permission } from "@/types/iam/permission";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import type { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
+import {
+  isValidEnvironmentName,
+  NULL_ENVIRONMENT_NAME,
+  nullEnvironment,
+  unknownEnvironment,
+} from "@/types/v1/environment";
 import { storageKeyRecentProjects } from "@/utils/storage-keys";
 
 export { isConnectAlreadyExists };
@@ -40,6 +47,43 @@ export function useSubscription() {
   return { subscription, uploadLicense };
 }
 
+export function useSubscriptionState() {
+  const subscription = useAppStore((state) => state.subscription);
+  const loadSubscription = useAppStore((state) => state.loadSubscription);
+  const uploadLicense = useAppStore((state) => state.uploadLicense);
+  const currentPlan = useAppStore((state) => state.currentPlan());
+  const isFreePlan = useAppStore((state) => state.isFreePlan());
+  const isTrialing = useAppStore((state) => state.isTrialing());
+  const isExpired = useAppStore((state) => state.isExpired());
+  const daysBeforeExpire = useAppStore((state) => state.daysBeforeExpire());
+  const trialingDays = useAppStore((state) => state.trialingDays());
+  const showTrial = useAppStore((state) => state.showTrial());
+  const expireAt = useAppStore((state) => state.expireAt());
+  const instanceCountLimit = useAppStore((state) => state.instanceCountLimit());
+  const userCountLimit = useAppStore((state) => state.userCountLimit());
+  const instanceLicenseCount = useAppStore((state) =>
+    state.instanceLicenseCount()
+  );
+  useEffect(() => {
+    void loadSubscription();
+  }, [loadSubscription]);
+  return {
+    subscription,
+    uploadLicense,
+    currentPlan,
+    isFreePlan,
+    isTrialing,
+    isExpired,
+    daysBeforeExpire,
+    trialingDays,
+    showTrial,
+    expireAt,
+    instanceCountLimit,
+    userCountLimit,
+    instanceLicenseCount,
+  };
+}
+
 export function useServerInfo() {
   const serverInfo = useAppStore((state) => state.serverInfo);
   const loadServerInfo = useAppStore((state) => state.loadServerInfo);
@@ -47,6 +91,45 @@ export function useServerInfo() {
     void loadServerInfo();
   }, [loadServerInfo]);
   return serverInfo;
+}
+
+export function useServerState() {
+  const serverInfo = useAppStore((state) => state.serverInfo);
+  const loadServerInfo = useAppStore((state) => state.loadServerInfo);
+  const isSaaSMode = useAppStore((state) => state.isSaaSMode());
+  const workspaceResourceName = useAppStore((state) =>
+    state.workspaceResourceName()
+  );
+  const externalUrl = useAppStore((state) => state.externalUrl());
+  const needConfigureExternalUrl = useAppStore((state) =>
+    state.needConfigureExternalUrl()
+  );
+  const version = useAppStore((state) => state.version());
+  const changelogURL = useAppStore((state) => state.changelogURL());
+  const activatedInstanceCount = useAppStore((state) =>
+    state.activatedInstanceCount()
+  );
+  const totalInstanceCount = useAppStore((state) => state.totalInstanceCount());
+  const userCountInIam = useAppStore((state) => state.userCountInIam());
+  useEffect(() => {
+    void loadServerInfo();
+  }, [loadServerInfo]);
+  return {
+    serverInfo,
+    isSaaSMode,
+    workspaceResourceName,
+    externalUrl,
+    needConfigureExternalUrl,
+    version,
+    changelogURL,
+    activatedInstanceCount,
+    totalInstanceCount,
+    userCountInIam,
+  };
+}
+
+export function useWorkspaceResourceName() {
+  return useServerState().workspaceResourceName;
 }
 
 export function useIsSaaSMode() {
@@ -62,6 +145,58 @@ export function useAppFeature<T extends keyof AppFeatures>(feature: T) {
     void loadWorkspaceProfile();
   }, [loadWorkspaceProfile]);
   return value;
+}
+
+export function useWorkspaceProfile() {
+  const workspaceProfile = useAppStore((state) => state.workspaceProfile);
+  const loadWorkspaceProfile = useAppStore(
+    (state) => state.loadWorkspaceProfile
+  );
+  useEffect(() => {
+    void loadWorkspaceProfile();
+  }, [loadWorkspaceProfile]);
+  return workspaceProfile;
+}
+
+export function useEnvironmentList() {
+  const environmentList = useAppStore((state) => state.environmentList);
+  const loadEnvironmentList = useAppStore((state) => state.loadEnvironmentList);
+  useEffect(() => {
+    void loadEnvironmentList();
+  }, [loadEnvironmentList]);
+  return environmentList;
+}
+
+export function useEnvironment(name: string | undefined) {
+  const environmentList = useEnvironmentList();
+  return useMemo(() => {
+    if (!name || name === NULL_ENVIRONMENT_NAME) {
+      return nullEnvironment();
+    }
+    const environment = environmentList.find((env) => env.name === name);
+    if (environment) {
+      return environment;
+    }
+    if (!isValidEnvironmentName(name)) {
+      return unknownEnvironment();
+    }
+    const id = name.replace(/^environments\//, "");
+    return {
+      ...unknownEnvironment(),
+      id,
+      name,
+      title: id,
+    };
+  }, [environmentList, name]);
+}
+
+export function usePlanFeature(feature: PlanFeature) {
+  const loadSubscription = useAppStore((state) => state.loadSubscription);
+  const hasFeature = useAppStore((state) => state.hasFeature(feature));
+  useEffect(() => {
+    void loadSubscription();
+  }, [loadSubscription]);
+  return hasFeature;
 }
 
 export function useWorkspacePermission(permission: Permission) {

--- a/frontend/src/react/pages/project/database-detail/DatabaseDetailHeader.tsx
+++ b/frontend/src/react/pages/project/database-detail/DatabaseDetailHeader.tsx
@@ -2,10 +2,9 @@ import { Check, Copy, ShieldAlert } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EngineIconPath } from "@/components/InstanceForm/constants";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useEnvironment, usePlanFeature } from "@/react/hooks/useAppState";
 import { router } from "@/router";
 import { INSTANCE_ROUTE_DETAIL } from "@/router/dashboard/instance";
-import { featureToRef, useEnvironmentV1Store } from "@/store";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import {
@@ -54,7 +53,6 @@ export function DatabaseDetailHeader({
 }) {
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
-  const environmentStore = useEnvironmentV1Store();
   const { databaseName } = useMemo(
     () => extractDatabaseParts(database.name),
     [database.name]
@@ -66,12 +64,9 @@ export function DatabaseDetailHeader({
   const canViewInstance = hasWorkspacePermissionV2("bb.instances.get");
   const engineIconSrc = EngineIconPath[String(instanceResource.engine)];
 
-  const environment = useVueState(() =>
-    environmentStore.getEnvironmentByName(database.effectiveEnvironment ?? "")
-  );
-
-  const hasEnvironmentTierFeature = useVueState(
-    () => featureToRef(PlanFeature.FEATURE_ENVIRONMENT_TIERS).value
+  const environment = useEnvironment(database.effectiveEnvironment ?? "");
+  const hasEnvironmentTierFeature = usePlanFeature(
+    PlanFeature.FEATURE_ENVIRONMENT_TIERS
   );
 
   const isValidEnv =

--- a/frontend/src/react/pages/settings/EnvironmentsPage.tsx
+++ b/frontend/src/react/pages/settings/EnvironmentsPage.tsx
@@ -56,6 +56,7 @@ import {
 } from "@/react/components/ui/tabs";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import {
   WORKSPACE_ROUTE_SQL_REVIEW_CREATE,
@@ -639,6 +640,9 @@ function EnvironmentDetail({
   const environmentStore = useEnvironmentV1Store();
   const policyStore = usePolicyV1Store();
   const subscriptionStore = useSubscriptionV1Store();
+  const refreshEnvironmentList = useAppStore(
+    (state) => state.refreshEnvironmentList
+  );
 
   const canEdit = hasWorkspacePermissionV2("bb.settings.setEnvironment");
   const canGetPolicy = hasWorkspacePermissionV2("bb.policies.get");
@@ -789,6 +793,7 @@ function EnvironmentDetail({
       setEditTitle(updated.title);
       setEditColor(updated.color || "#4f46e5");
       setEditProtected(updated.tags?.protected === "protected");
+      await refreshEnvironmentList();
     }
 
     // Update rollout policy if changed
@@ -1437,6 +1442,9 @@ export function EnvironmentsPage() {
   const environmentStore = useEnvironmentV1Store();
   const policyStore = usePolicyV1Store();
   const uiStateStore = useUIStateStore();
+  const refreshEnvironmentList = useAppStore(
+    (state) => state.refreshEnvironmentList
+  );
 
   const environmentList = useVueState(() => [
     ...environmentStore.environmentList,
@@ -1560,6 +1568,7 @@ export function EnvironmentsPage() {
     }
 
     setShowCreate(false);
+    await refreshEnvironmentList();
     selectTab(createdEnvironment.id);
   };
 
@@ -1572,6 +1581,7 @@ export function EnvironmentsPage() {
       style: "SUCCESS",
       title: t("common.deleted"),
     });
+    await refreshEnvironmentList();
     // Select first remaining environment
     const remaining = environmentStore.environmentList;
     if (remaining.length > 0) {
@@ -1581,6 +1591,7 @@ export function EnvironmentsPage() {
 
   const handleReorder = async (reordered: Environment[]) => {
     await environmentStore.reorderEnvironmentList(reordered);
+    await refreshEnvironmentList();
     setShowReorder(false);
     pushNotification({
       module: "bytebase",

--- a/frontend/src/react/pages/settings/LandingPage.tsx
+++ b/frontend/src/react/pages/settings/LandingPage.tsx
@@ -30,6 +30,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
+import { useCurrentUser, useServerState } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
 import {
@@ -59,11 +60,7 @@ import {
   SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
 } from "@/router/dashboard/workspaceSetting";
 import { useRecentVisit } from "@/router/useRecentVisit";
-import {
-  useActuatorV1Store,
-  useCurrentUserV1,
-  useProjectV1Store,
-} from "@/store";
+import { useActuatorV1Store, useProjectV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { UNKNOWN_PROJECT_NAME } from "@/types";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
@@ -86,7 +83,7 @@ interface QuickLinkDef {
 
 function useFullQuickLinkList(): QuickLinkDef[] {
   const { t } = useTranslation();
-  const isSaaSMode = useVueState(() => useActuatorV1Store().isSaaSMode);
+  const { isSaaSMode } = useServerState();
 
   return useMemo(() => {
     // Two special items always first
@@ -436,9 +433,8 @@ export function LandingPage(_: Record<string, never> = {}) {
   const [showConfigDrawer, setShowConfigDrawer] = useState(false);
   const [showProjectSwitchDialog, setShowProjectSwitchDialog] = useState(false);
 
-  const email = useVueState(() => useCurrentUserV1().value.email);
-  const version = useVueState(() => useActuatorV1Store().version);
-  const changelogURL = useVueState(() => useActuatorV1Store().changelogURL);
+  const email = useCurrentUser()?.email ?? "";
+  const { version, changelogURL } = useServerState();
   const hasNewRelease = useVueState(() => useActuatorV1Store().hasNewRelease);
   const releaseLatest = useVueState(
     () => useActuatorV1Store().releaseInfo.latest

--- a/frontend/src/react/pages/settings/MCPPage.tsx
+++ b/frontend/src/react/pages/settings/MCPPage.tsx
@@ -15,22 +15,14 @@ import {
   TabsTrigger,
 } from "@/react/components/ui/tabs";
 import { Textarea } from "@/react/components/ui/textarea";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useServerState } from "@/react/hooks/useAppState";
 import { router } from "@/router";
 import { SETTING_ROUTE_WORKSPACE_GENERAL } from "@/router/dashboard/workspaceSetting";
-import { useActuatorV1Store } from "@/store";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
 export function MCPPage() {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
-
-  const externalUrl = useVueState(
-    () => actuatorStore.serverInfo?.externalUrl ?? ""
-  );
-  const needConfigureExternalUrl = useVueState(
-    () => actuatorStore.needConfigureExternalUrl
-  );
+  const { externalUrl, needConfigureExternalUrl } = useServerState();
   const canConfigureExternalUrl = hasWorkspacePermissionV2(
     "bb.settings.setWorkspaceProfile"
   );

--- a/frontend/src/react/pages/settings/PurchaseSection.tsx
+++ b/frontend/src/react/pages/settings/PurchaseSection.tsx
@@ -3,7 +3,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import { useSubscriptionState } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { pushNotification, useSubscriptionV1Store } from "@/store";
 import type { PurchasePlanAdditional } from "@/types/proto-es/v1/subscription_service_pb";
 import {
@@ -82,11 +84,10 @@ const planPrefix: Record<number, string> = {
 export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
   const { t } = useTranslation();
   const subscriptionStore = useSubscriptionV1Store();
+  const refreshSubscription = useAppStore((state) => state.refreshSubscription);
 
-  const currentPlan = useVueState(() => subscriptionStore.currentPlan);
-  const isFreePlan = useVueState(() => subscriptionStore.isFreePlan);
-  const isExpired = useVueState(() => subscriptionStore.isExpired);
-  const subscription = useVueState(() => subscriptionStore.subscription);
+  const { currentPlan, isFreePlan, isExpired, subscription } =
+    useSubscriptionState();
   const paymentInfo = useVueState(() => subscriptionStore.paymentInfo);
   const purchasePlans = useVueState(() => subscriptionStore.purchasePlans);
 
@@ -129,6 +130,7 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
           { signal: controller.signal }
         );
         if (!controller.signal.aborted) {
+          await refreshSubscription();
           setPendingPayment(false);
         }
       } catch (e) {
@@ -141,14 +143,14 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
     return () => {
       controller.abort();
     };
-  }, []);
+  }, [allowManage, refreshSubscription, subscriptionStore]);
 
   // Fetch payment info for active subscriptions.
   useEffect(() => {
     if (!isFreePlan && !isExpired) {
       subscriptionStore.fetchPaymentInfo();
     }
-  }, [isFreePlan, isExpired]);
+  }, [isFreePlan, isExpired, subscriptionStore]);
 
   const isCurrentPlan = useCallback(
     (plan: PlanType) => currentPlan === plan && !isExpired,
@@ -305,6 +307,7 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
         await subscriptionStore.pollSubscriptionUntil(
           (sub) => sub.plan !== PlanType.FREE && sub.seats === seats
         );
+        await refreshSubscription();
         setPendingPayment(false);
       }
     } catch (e) {
@@ -324,6 +327,7 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
       await subscriptionStore.pollSubscriptionUntil(
         (sub) => sub.plan === PlanType.FREE
       );
+      await refreshSubscription();
       pushNotification({
         module: "bytebase",
         style: "SUCCESS",

--- a/frontend/src/react/pages/settings/SubscriptionPage.tsx
+++ b/frontend/src/react/pages/settings/SubscriptionPage.tsx
@@ -6,13 +6,12 @@ import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { Textarea } from "@/react/components/ui/textarea";
-import { useVueState } from "@/react/hooks/useVueState";
 import {
-  getWorkspaceId,
-  pushNotification,
-  useActuatorV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+  useNotify,
+  useServerState,
+  useSubscriptionState,
+} from "@/react/hooks/useAppState";
+import { getResourceId, workspaceNamePrefix } from "@/react/lib/resourceName";
 import { ENTERPRISE_INQUIRE_LINK } from "@/types";
 import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
@@ -28,39 +27,34 @@ export function SubscriptionPage({
   onManageInstanceLicenses: onManageInstanceLicensesProp,
 }: SubscriptionPageProps) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
-  const actuatorStore = useActuatorV1Store();
+  const notify = useNotify();
 
   const allowManage = hasWorkspacePermissionV2("bb.subscription.manage");
   const allowManageInstanceLicenses =
     allowManage && hasWorkspacePermissionV2("bb.instances.list");
 
-  // Subscribe to Vue reactive state
-  const currentPlan = useVueState(() => subscriptionStore.currentPlan);
-  const isFreePlan = useVueState(() => subscriptionStore.isFreePlan);
-  const isTrialing = useVueState(() => subscriptionStore.isTrialing);
-  const isExpired = useVueState(() => subscriptionStore.isExpired);
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
-  const isSelfHostLicense = useVueState(
-    () => subscriptionStore.isSelfHostLicense
-  );
-  const showTrial = useVueState(() => subscriptionStore.showTrial);
-  const trialingDays = useVueState(() => subscriptionStore.trialingDays);
-  const expireAt = useVueState(() => subscriptionStore.expireAt);
-  const instanceCountLimit = useVueState(
-    () => subscriptionStore.instanceCountLimit
-  );
-  const instanceLicenseCount = useVueState(
-    () => subscriptionStore.instanceLicenseCount
-  );
-  const userCountLimit = useVueState(() => subscriptionStore.userCountLimit);
-  const userCountInIam = useVueState(() => actuatorStore.userCountInIam);
-  const activatedInstanceCount = useVueState(
-    () => actuatorStore.activatedInstanceCount
-  );
-  const workspaceId = useVueState(() =>
-    getWorkspaceId(actuatorStore.workspaceResourceName)
-  );
+  const {
+    uploadLicense,
+    currentPlan,
+    isFreePlan,
+    isTrialing,
+    isExpired,
+    showTrial,
+    trialingDays,
+    expireAt,
+    instanceCountLimit,
+    instanceLicenseCount,
+    userCountLimit,
+  } = useSubscriptionState();
+  const {
+    isSaaSMode,
+    userCountInIam,
+    activatedInstanceCount,
+    workspaceResourceName,
+  } = useServerState();
+  const isSelfHostLicense =
+    import.meta.env.MODE.toLowerCase() !== "release-aws";
+  const workspaceId = getResourceId(workspaceResourceName, workspaceNamePrefix);
 
   const [license, setLicense] = useState("");
   const [loading, setLoading] = useState(false);
@@ -100,8 +94,8 @@ export function SubscriptionPage({
     if (disabled) return;
     setLoading(true);
     try {
-      await subscriptionStore.uploadLicense(license);
-      pushNotification({
+      await uploadLicense(license);
+      notify({
         module: "bytebase",
         style: "SUCCESS",
         title: t("subscription.update.success.title"),
@@ -109,7 +103,7 @@ export function SubscriptionPage({
       });
       setLicense("");
     } catch {
-      pushNotification({
+      notify({
         module: "bytebase",
         style: "CRITICAL",
         title: t("subscription.update.failure.title"),

--- a/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
+++ b/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
@@ -14,8 +14,8 @@ import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { Alert } from "@/react/components/ui/alert";
 import { Input } from "@/react/components/ui/input";
+import { useServerState } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
-import { useActuatorV1Store } from "@/store";
 import { useSettingV1Store } from "@/store/modules";
 import {
   AISetting_Provider,
@@ -86,8 +86,7 @@ export const AIAugmentationSection = forwardRef<
   const settingV1Store = useSettingV1Store();
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const actuatorStore = useActuatorV1Store();
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const { isSaaSMode } = useServerState();
   const canEdit = hasWorkspacePermissionV2("bb.settings.set") && !isSaaSMode;
 
   const aiSetting = useVueState(() => {

--- a/frontend/src/react/pages/settings/general/AccountSection.tsx
+++ b/frontend/src/react/pages/settings/general/AccountSection.tsx
@@ -19,12 +19,9 @@ import {
 } from "@/react/components/PermissionGuard";
 import { Input } from "@/react/components/ui/input";
 import { NumberInput } from "@/react/components/ui/number-input";
+import { usePlanFeature, useServerState } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
-import {
-  useActuatorV1Store,
-  useIdentityProviderStore,
-  useSubscriptionV1Store,
-} from "@/store";
+import { useIdentityProviderStore } from "@/store";
 import { useSettingV1Store } from "@/store/modules/v1/setting";
 import {
   defaultAccessTokenDurationInHours,
@@ -101,29 +98,19 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
     const settingV1Store = useSettingV1Store();
     const idpStore = useIdentityProviderStore();
 
-    const isSaaSMode = useVueState(() => useActuatorV1Store().isSaaSMode);
-    const hasDisallowSignupFeature = useVueState(() =>
-      useSubscriptionV1Store().hasFeature(
-        PlanFeature.FEATURE_DISALLOW_SELF_SERVICE_SIGNUP
-      )
+    const { isSaaSMode, workspaceResourceName } = useServerState();
+    const hasDisallowSignupFeature = usePlanFeature(
+      PlanFeature.FEATURE_DISALLOW_SELF_SERVICE_SIGNUP
     );
-    const has2FAFeature = useVueState(() =>
-      useSubscriptionV1Store().hasFeature(PlanFeature.FEATURE_TWO_FA)
+    const has2FAFeature = usePlanFeature(PlanFeature.FEATURE_TWO_FA);
+    const hasDisallowPasswordSigninFeature = usePlanFeature(
+      PlanFeature.FEATURE_DISALLOW_PASSWORD_SIGNIN
     );
-    const hasDisallowPasswordSigninFeature = useVueState(() =>
-      useSubscriptionV1Store().hasFeature(
-        PlanFeature.FEATURE_DISALLOW_PASSWORD_SIGNIN
-      )
+    const hasPasswordFeature = usePlanFeature(
+      PlanFeature.FEATURE_PASSWORD_RESTRICTIONS
     );
-    const hasPasswordFeature = useVueState(() =>
-      useSubscriptionV1Store().hasFeature(
-        PlanFeature.FEATURE_PASSWORD_RESTRICTIONS
-      )
-    );
-    const hasSecureTokenFeature = useVueState(() =>
-      useSubscriptionV1Store().hasFeature(
-        PlanFeature.FEATURE_TOKEN_DURATION_CONTROL
-      )
+    const hasSecureTokenFeature = usePlanFeature(
+      PlanFeature.FEATURE_TOKEN_DURATION_CONTROL
     );
 
     const [allowEdit] = usePermissionCheck(["bb.settings.setWorkspaceProfile"]);
@@ -138,15 +125,19 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       () => !!settingV1Store.getSettingByName(Setting_SettingName.EMAIL)
     );
 
-    // Fetch identity providers and EMAIL setting on mount.
+    // Fetch identity providers after the workspace resource name is ready.
     useEffect(() => {
-      idpStore.fetchIdentityProviderList(
-        useActuatorV1Store().workspaceResourceName
-      );
+      if (workspaceResourceName) {
+        idpStore.fetchIdentityProviderList(workspaceResourceName);
+      }
+    }, [idpStore, workspaceResourceName]);
+
+    // Fetch EMAIL setting on mount.
+    useEffect(() => {
       // Populate the EMAIL setting into the store cache; useVueState above
       // picks up the change reactively.
       settingV1Store.getOrFetchSettingByName(Setting_SettingName.EMAIL, true);
-    }, []);
+    }, [settingV1Store]);
 
     // --- Toggle state ---
     const getInitialToggleState = useCallback((): ToggleState => {

--- a/frontend/src/react/pages/settings/general/AnnouncementSection.tsx
+++ b/frontend/src/react/pages/settings/general/AnnouncementSection.tsx
@@ -15,8 +15,7 @@ import {
   usePermissionCheck,
 } from "@/react/components/PermissionGuard";
 import { Input } from "@/react/components/ui/input";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useSubscriptionV1Store } from "@/store";
+import { usePlanFeature } from "@/react/hooks/useAppState";
 import { useSettingV1Store } from "@/store/modules/v1/setting";
 import {
   Announcement_AlertLevel,
@@ -48,11 +47,8 @@ export const AnnouncementSection = forwardRef<
 >(function AnnouncementSection({ title, onDirtyChange }, ref) {
   const { t } = useTranslation();
   const settingV1Store = useSettingV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
 
-  const hasFeature = useVueState(() =>
-    subscriptionStore.hasFeature(PlanFeature.FEATURE_DASHBOARD_ANNOUNCEMENT)
-  );
+  const hasFeature = usePlanFeature(PlanFeature.FEATURE_DASHBOARD_ANNOUNCEMENT);
 
   const [canEdit] = usePermissionCheck(["bb.settings.setWorkspaceProfile"]);
 

--- a/frontend/src/react/pages/settings/general/AuditLogSection.tsx
+++ b/frontend/src/react/pages/settings/general/AuditLogSection.tsx
@@ -10,8 +10,8 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useSettingV1Store, useSubscriptionV1Store } from "@/store";
+import { usePlanFeature } from "@/react/hooks/useAppState";
+import { useSettingV1Store } from "@/store";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import type { SectionHandle } from "./useSettingSection";
 
@@ -29,11 +29,8 @@ export const AuditLogSection = forwardRef<SectionHandle, AuditLogSectionProps>(
   function AuditLogSection({ allowEdit, onDirtyChange }, ref) {
     const { t } = useTranslation();
     const settingV1Store = useSettingV1Store();
-    const subscriptionV1Store = useSubscriptionV1Store();
 
-    const hasAuditLogFeature = useVueState(() =>
-      subscriptionV1Store.hasFeature(PlanFeature.FEATURE_AUDIT_LOG)
-    );
+    const hasAuditLogFeature = usePlanFeature(PlanFeature.FEATURE_AUDIT_LOG);
 
     const getInitialState = useCallback(
       (): State => ({

--- a/frontend/src/react/pages/settings/general/BrandingSection.tsx
+++ b/frontend/src/react/pages/settings/general/BrandingSection.tsx
@@ -17,12 +17,9 @@ import {
 } from "@/react/components/PermissionGuard";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
+import { usePlanFeature } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
-import {
-  pushNotification,
-  useSubscriptionV1Store,
-  useWorkspaceV1Store,
-} from "@/store";
+import { pushNotification, useWorkspaceV1Store } from "@/store";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import { WorkspaceSchema } from "@/types/proto-es/v1/workspace_service_pb";
 import type { SectionHandle } from "./useSettingSection";
@@ -49,9 +46,7 @@ export const BrandingSection = forwardRef<SectionHandle, BrandingSectionProps>(
     const workspaceStore = useWorkspaceV1Store();
 
     const workspace = useVueState(() => workspaceStore.currentWorkspace);
-    const hasBrandingFeature = useVueState(() =>
-      useSubscriptionV1Store().hasFeature(PlanFeature.FEATURE_CUSTOM_LOGO)
-    );
+    const hasBrandingFeature = usePlanFeature(PlanFeature.FEATURE_CUSTOM_LOGO);
 
     const [canEdit] = usePermissionCheck(["bb.workspaces.update"]);
 

--- a/frontend/src/react/pages/settings/general/GeneralPage.tsx
+++ b/frontend/src/react/pages/settings/general/GeneralPage.tsx
@@ -2,9 +2,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { Button } from "@/react/components/ui/button";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useServerState } from "@/react/hooks/useAppState";
 import { router } from "@/router";
-import { pushNotification, useActuatorV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { hasWorkspacePermissionV2 } from "@/utils";
 import { AccountSection } from "./AccountSection";
 import { AIAugmentationSection } from "./AIAugmentationSection";
@@ -19,8 +19,7 @@ import type { SectionHandle } from "./useSettingSection";
 
 export function GeneralPage() {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const { isSaaSMode } = useServerState();
   const canEditProfile = hasWorkspacePermissionV2(
     "bb.settings.setWorkspaceProfile"
   );

--- a/frontend/src/react/pages/settings/general/GeneralSection.tsx
+++ b/frontend/src/react/pages/settings/general/GeneralSection.tsx
@@ -22,10 +22,11 @@ import {
   DialogTitle,
 } from "@/react/components/ui/dialog";
 import { Input } from "@/react/components/ui/input";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useServerState } from "@/react/hooks/useAppState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { SQL_EDITOR_HOME_MODULE } from "@/router/sqlEditor";
-import { useActuatorV1Store, useSettingV1Store } from "@/store";
+import { useSettingV1Store } from "@/store";
 import { DatabaseChangeMode } from "@/types/proto-es/v1/setting_service_pb";
 import type { SectionHandle } from "./useSettingSection";
 
@@ -43,12 +44,10 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
   function GeneralSection({ title, onDirtyChange }, ref) {
     const { t } = useTranslation();
     const settingV1Store = useSettingV1Store();
-    const actuatorV1Store = useActuatorV1Store();
+    const refreshServerInfo = useAppStore((state) => state.refreshServerInfo);
 
-    const isSaaSMode = useVueState(() => actuatorV1Store.isSaaSMode);
-    const externalUrlFromFlag = useVueState(
-      () => actuatorV1Store.serverInfo?.externalUrlFromFlag ?? false
-    );
+    const { isSaaSMode, externalUrl, serverInfo } = useServerState();
+    const externalUrlFromFlag = serverInfo?.externalUrlFromFlag ?? false;
 
     const [canEdit] = usePermissionCheck(["bb.settings.setWorkspaceProfile"]);
 
@@ -60,9 +59,9 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
           mode === DatabaseChangeMode.EDITOR
             ? mode
             : DatabaseChangeMode.PIPELINE,
-        externalUrl: actuatorV1Store.serverInfo?.externalUrl ?? "",
+        externalUrl,
       };
-    }, [settingV1Store, actuatorV1Store]);
+    }, [settingV1Store, externalUrl]);
 
     const [state, setState] = useState<LocalState>(getInitialState);
     const [showModal, setShowModal] = useState(false);
@@ -87,6 +86,7 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
             paths: ["value.workspace_profile.external_url"],
           }),
         });
+        await refreshServerInfo();
       }
       if (state.databaseChangeMode !== initState.databaseChangeMode) {
         await settingV1Store.updateWorkspaceProfile({
@@ -101,7 +101,7 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
           setShowModal(true);
         }
       }
-    }, [state, getInitialState, settingV1Store]);
+    }, [state, getInitialState, settingV1Store, refreshServerInfo]);
 
     useImperativeHandle(
       ref,

--- a/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
+++ b/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
@@ -13,13 +13,12 @@ import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { NumberInput } from "@/react/components/ui/number-input";
-import { useVueState } from "@/react/hooks/useVueState";
 import {
-  DEFAULT_MAX_RESULT_SIZE_IN_MB,
-  useActuatorV1Store,
-  usePolicyV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+  usePlanFeature,
+  useWorkspaceResourceName,
+} from "@/react/hooks/useAppState";
+import { useVueState } from "@/react/hooks/useVueState";
+import { DEFAULT_MAX_RESULT_SIZE_IN_MB, usePolicyV1Store } from "@/store";
 import { useSettingV1Store } from "@/store/modules/v1/setting";
 import {
   PolicyResourceType,
@@ -51,18 +50,15 @@ export const SQLEditorSection = forwardRef<
   SQLEditorSectionProps
 >(function SQLEditorSection({ title, onDirtyChange }, ref) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
   const policyV1Store = usePolicyV1Store();
   const settingV1Store = useSettingV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
 
-  const resource = useVueState(() => actuatorStore.workspaceResourceName);
-
-  const hasQueryPolicyFeature = useVueState(() =>
-    subscriptionStore.hasFeature(PlanFeature.FEATURE_QUERY_POLICY)
+  const resource = useWorkspaceResourceName();
+  const hasQueryPolicyFeature = usePlanFeature(
+    PlanFeature.FEATURE_QUERY_POLICY
   );
-  const hasRestrictCopyingDataFeature = useVueState(() =>
-    subscriptionStore.hasFeature(PlanFeature.FEATURE_RESTRICT_COPYING_DATA)
+  const hasRestrictCopyingDataFeature = usePlanFeature(
+    PlanFeature.FEATURE_RESTRICT_COPYING_DATA
   );
 
   const canUpdatePolicy = hasWorkspacePermissionV2("bb.policies.update");

--- a/frontend/src/react/pages/settings/general/SecuritySection.tsx
+++ b/frontend/src/react/pages/settings/general/SecuritySection.tsx
@@ -17,8 +17,7 @@ import {
   usePermissionCheck,
 } from "@/react/components/PermissionGuard";
 import { Input } from "@/react/components/ui/input";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useSubscriptionV1Store } from "@/store";
+import { usePlanFeature } from "@/react/hooks/useAppState";
 import { useSettingV1Store } from "@/store/modules/v1/setting";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import type { SectionHandle } from "./useSettingSection";
@@ -42,15 +41,10 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
   function SecuritySection({ title, onDirtyChange }, ref) {
     const { t } = useTranslation();
     const settingV1Store = useSettingV1Store();
-    const subscriptionStore = useSubscriptionV1Store();
 
-    const hasWatermarkFeature = useVueState(() =>
-      subscriptionStore.hasFeature(PlanFeature.FEATURE_WATERMARK)
-    );
-    const hasDomainRestrictionFeature = useVueState(() =>
-      subscriptionStore.hasFeature(
-        PlanFeature.FEATURE_USER_EMAIL_DOMAIN_RESTRICTION
-      )
+    const hasWatermarkFeature = usePlanFeature(PlanFeature.FEATURE_WATERMARK);
+    const hasDomainRestrictionFeature = usePlanFeature(
+      PlanFeature.FEATURE_USER_EMAIL_DOMAIN_RESTRICTION
     );
     const [canEdit] = usePermissionCheck(["bb.settings.setWorkspaceProfile"]);
 

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -2,6 +2,7 @@ import { create as createProto } from "@bufbuild/protobuf";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ReactShellBridgeEvent } from "@/react/shell-bridge";
 import { ExprSchema } from "@/types/proto-es/google/type/expr_pb";
+import { ActuatorInfoSchema } from "@/types/proto-es/v1/actuator_service_pb";
 import { State } from "@/types/proto-es/v1/common_pb";
 import {
   BindingSchema,
@@ -12,10 +13,17 @@ import { ProjectSchema } from "@/types/proto-es/v1/project_service_pb";
 import { RoleSchema } from "@/types/proto-es/v1/role_service_pb";
 import {
   DatabaseChangeMode,
+  EnvironmentSetting_EnvironmentSchema,
+  EnvironmentSettingSchema,
   SettingSchema,
   SettingValueSchema,
   WorkspaceProfileSettingSchema,
 } from "@/types/proto-es/v1/setting_service_pb";
+import {
+  PlanFeature,
+  PlanType,
+  SubscriptionSchema,
+} from "@/types/proto-es/v1/subscription_service_pb";
 import { UserSchema } from "@/types/proto-es/v1/user_service_pb";
 import {
   storageKeyIntroState,
@@ -25,6 +33,19 @@ import {
 import { createAppStore } from ".";
 
 const mocks = vi.hoisted(() => ({
+  localStorage: (() => {
+    const storage = new Map<string, string>();
+    const localStorage = {
+      clear: vi.fn(() => storage.clear()),
+      getItem: vi.fn((key: string) => storage.get(key) ?? null),
+      removeItem: vi.fn((key: string) => storage.delete(key)),
+      setItem: vi.fn((key: string, value: string) => {
+        storage.set(key, value);
+      }),
+    };
+    vi.stubGlobal("localStorage", localStorage);
+    return localStorage;
+  })(),
   getCurrentUser: vi.fn(),
   logout: vi.fn(),
   getActuatorInfo: vi.fn(),
@@ -95,6 +116,11 @@ const projectB = createProto(ProjectSchema, {
   name: "projects/b",
   title: "B",
   state: State.ACTIVE,
+});
+
+const timestampSeconds = (seconds: number) => ({
+  seconds: BigInt(seconds),
+  nanos: 0,
 });
 
 beforeEach(() => {
@@ -255,6 +281,201 @@ describe("useAppStore", () => {
       false
     );
     expect(store.getState().appFeatures["bb.feature.hide-trial"]).toBe(false);
+  });
+
+  test("derives actuator state for React consumers", () => {
+    const store = createAppStore();
+    store.setState({
+      serverInfo: createProto(ActuatorInfoSchema, {
+        workspace: "workspaces/default",
+        version: "3.10.2",
+        externalUrl: "",
+        saas: true,
+        activatedInstanceCount: 2,
+        totalInstanceCount: 3,
+        userCountInIam: 7,
+      }),
+    });
+
+    expect(store.getState().isSaaSMode()).toBe(true);
+    expect(store.getState().workspaceResourceName()).toBe("workspaces/default");
+    expect(store.getState().needConfigureExternalUrl()).toBe(true);
+    expect(store.getState().changelogURL()).toBe(
+      "https://docs.bytebase.com/changelog/bytebase-3-10-2/"
+    );
+    expect(store.getState().activatedInstanceCount()).toBe(2);
+    expect(store.getState().totalInstanceCount()).toBe(3);
+    expect(store.getState().userCountInIam()).toBe(7);
+  });
+
+  test("derives subscription limits and feature state", () => {
+    const store = createAppStore();
+    store.setState({
+      subscription: createProto(SubscriptionSchema, {
+        plan: PlanType.ENTERPRISE,
+        seats: -1,
+        instances: -1,
+        activeInstances: -1,
+        expiresTime: timestampSeconds(
+          Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30
+        ),
+      }),
+    });
+
+    expect(store.getState().currentPlan()).toBe(PlanType.ENTERPRISE);
+    expect(store.getState().isFreePlan()).toBe(false);
+    expect(store.getState().isExpired()).toBe(false);
+    expect(store.getState().showTrial()).toBe(false);
+    expect(store.getState().instanceCountLimit()).toBe(Number.MAX_VALUE);
+    expect(store.getState().userCountLimit()).toBe(Number.MAX_VALUE);
+    expect(store.getState().instanceLicenseCount()).toBe(Number.MAX_VALUE);
+    expect(store.getState().hasFeature(PlanFeature.FEATURE_DATA_MASKING)).toBe(
+      true
+    );
+    expect(
+      store.getState().hasInstanceFeature(
+        PlanFeature.FEATURE_DATA_MASKING,
+        createProto(InstanceSchema, {
+          name: "instances/prod",
+          activation: false,
+        })
+      )
+    ).toBe(false);
+    expect(
+      store.getState().instanceMissingLicense(
+        PlanFeature.FEATURE_DATA_MASKING,
+        createProto(InstanceSchema, {
+          name: "instances/prod",
+          activation: false,
+        })
+      )
+    ).toBe(true);
+  });
+
+  test("treats expired subscriptions as feature unavailable", () => {
+    const store = createAppStore();
+    store.setState({
+      subscription: createProto(SubscriptionSchema, {
+        plan: PlanType.ENTERPRISE,
+        expiresTime: timestampSeconds(
+          Math.floor(Date.now() / 1000) - 60 * 60 * 24
+        ),
+      }),
+    });
+
+    expect(store.getState().isExpired()).toBe(true);
+    expect(store.getState().hasFeature(PlanFeature.FEATURE_DATA_MASKING)).toBe(
+      false
+    );
+  });
+
+  test("refreshes subscription state after external mutations", async () => {
+    mocks.getSubscription.mockResolvedValue(
+      createProto(SubscriptionSchema, {
+        plan: PlanType.TEAM,
+        seats: 12,
+      })
+    );
+    const store = createAppStore();
+    store.setState({
+      subscription: createProto(SubscriptionSchema, {
+        plan: PlanType.FREE,
+        seats: 0,
+      }),
+    });
+
+    const subscription = await store.getState().refreshSubscription();
+
+    expect(subscription?.plan).toBe(PlanType.TEAM);
+    expect(store.getState().currentPlan()).toBe(PlanType.TEAM);
+    expect(store.getState().userCountLimit()).toBe(12);
+  });
+
+  test("loads environment settings into React state", async () => {
+    mocks.getSetting.mockResolvedValue(
+      createProto(SettingSchema, {
+        value: createProto(SettingValueSchema, {
+          value: {
+            case: "environment",
+            value: createProto(EnvironmentSettingSchema, {
+              environments: [
+                createProto(EnvironmentSetting_EnvironmentSchema, {
+                  id: "dev",
+                  title: "Development",
+                  color: "#00aa00",
+                }),
+                createProto(EnvironmentSetting_EnvironmentSchema, {
+                  id: "prod",
+                  title: "Production",
+                  tags: { protected: "protected" },
+                }),
+              ],
+            }),
+          },
+        }),
+      })
+    );
+    const store = createAppStore();
+
+    const environments = await store.getState().loadEnvironmentList();
+
+    expect(environments.map((env) => env.name)).toEqual([
+      "environments/dev",
+      "environments/prod",
+    ]);
+    expect(store.getState().environmentList[1]).toMatchObject({
+      id: "prod",
+      order: 1,
+      tags: { protected: "protected" },
+    });
+  });
+
+  test("refreshes environment settings after cache warm-up", async () => {
+    mocks.getSetting
+      .mockResolvedValueOnce(
+        createProto(SettingSchema, {
+          value: createProto(SettingValueSchema, {
+            value: {
+              case: "environment",
+              value: createProto(EnvironmentSettingSchema, {
+                environments: [
+                  createProto(EnvironmentSetting_EnvironmentSchema, {
+                    id: "dev",
+                    title: "Development",
+                  }),
+                ],
+              }),
+            },
+          }),
+        })
+      )
+      .mockResolvedValueOnce(
+        createProto(SettingSchema, {
+          value: createProto(SettingValueSchema, {
+            value: {
+              case: "environment",
+              value: createProto(EnvironmentSettingSchema, {
+                environments: [
+                  createProto(EnvironmentSetting_EnvironmentSchema, {
+                    id: "prod",
+                    title: "Production",
+                  }),
+                ],
+              }),
+            },
+          }),
+        })
+      );
+    const store = createAppStore();
+
+    await store.getState().loadEnvironmentList();
+    await store.getState().loadEnvironmentList();
+    expect(mocks.getSetting).toHaveBeenCalledTimes(1);
+
+    const environments = await store.getState().refreshEnvironmentList();
+
+    expect(mocks.getSetting).toHaveBeenCalledTimes(2);
+    expect(environments.map((env) => env.name)).toEqual(["environments/prod"]);
   });
 
   test("loads project IAM policy and checks project permissions", async () => {

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -4,13 +4,21 @@ import type { Permission } from "@/types/iam/permission";
 import type { NotificationCreate } from "@/types/notification";
 import type { ActuatorInfo } from "@/types/proto-es/v1/actuator_service_pb";
 import type { IamPolicy } from "@/types/proto-es/v1/iam_policy_pb";
-import type { Instance } from "@/types/proto-es/v1/instance_service_pb";
+import type {
+  Instance,
+  InstanceResource,
+} from "@/types/proto-es/v1/instance_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import type { Role } from "@/types/proto-es/v1/role_service_pb";
 import type { WorkspaceProfileSetting } from "@/types/proto-es/v1/setting_service_pb";
-import type { Subscription } from "@/types/proto-es/v1/subscription_service_pb";
+import type {
+  PlanFeature,
+  PlanType,
+  Subscription,
+} from "@/types/proto-es/v1/subscription_service_pb";
 import type { User } from "@/types/proto-es/v1/user_service_pb";
 import type { Workspace } from "@/types/proto-es/v1/workspace_service_pb";
+import type { Environment } from "@/types/v1/environment";
 
 export type ProjectListParams = {
   pageSize: number;
@@ -33,6 +41,8 @@ export type WorkspaceSlice = {
   workspaceRequest?: Promise<Workspace | undefined>;
   workspaceProfile?: WorkspaceProfileSetting;
   workspaceProfileRequest?: Promise<WorkspaceProfileSetting | undefined>;
+  environmentList: Environment[];
+  environmentRequest?: Promise<Environment[]>;
   appFeatures: AppFeatures;
   subscription?: Subscription;
   subscriptionRequest?: Promise<Subscription | undefined>;
@@ -40,8 +50,41 @@ export type WorkspaceSlice = {
   refreshServerInfo: () => Promise<ActuatorInfo | undefined>;
   loadWorkspace: () => Promise<Workspace | undefined>;
   loadWorkspaceProfile: () => Promise<WorkspaceProfileSetting | undefined>;
+  loadEnvironmentList: (force?: boolean) => Promise<Environment[]>;
+  refreshEnvironmentList: () => Promise<Environment[]>;
   loadSubscription: () => Promise<Subscription | undefined>;
+  refreshSubscription: () => Promise<Subscription | undefined>;
   uploadLicense: (license: string) => Promise<Subscription | undefined>;
+  currentPlan: () => PlanType;
+  isFreePlan: () => boolean;
+  isTrialing: () => boolean;
+  isExpired: () => boolean;
+  daysBeforeExpire: () => number;
+  trialingDays: () => number;
+  showTrial: () => boolean;
+  expireAt: () => string;
+  instanceCountLimit: () => number;
+  userCountLimit: () => number;
+  instanceLicenseCount: () => number;
+  hasFeature: (feature: PlanFeature) => boolean;
+  hasInstanceFeature: (
+    feature: PlanFeature,
+    instance?: Instance | InstanceResource
+  ) => boolean;
+  instanceMissingLicense: (
+    feature: PlanFeature,
+    instance?: Instance | InstanceResource
+  ) => boolean;
+  getMinimumRequiredPlan: (feature: PlanFeature) => PlanType;
+  isSaaSMode: () => boolean;
+  workspaceResourceName: () => string;
+  externalUrl: () => string;
+  needConfigureExternalUrl: () => boolean;
+  version: () => string;
+  changelogURL: () => string;
+  activatedInstanceCount: () => number;
+  totalInstanceCount: () => number;
+  userCountInIam: () => number;
 };
 
 export type IamSlice = {

--- a/frontend/src/react/stores/app/workspace.ts
+++ b/frontend/src/react/stores/app/workspace.ts
@@ -1,4 +1,6 @@
 import { create as createProto } from "@bufbuild/protobuf";
+import dayjs from "dayjs";
+import semver from "semver";
 import {
   actuatorServiceClientConnect,
   settingServiceClientConnect,
@@ -11,20 +13,42 @@ import {
 } from "@/react/lib/resourceName";
 import { defaultAppProfile } from "@/types/appProfile";
 import {
+  hasFeature as checkFeature,
+  hasInstanceFeature as checkInstanceFeature,
+  getMinimumRequiredPlan,
+  instanceLimitFeature,
+  PLANS,
+} from "@/types/plan";
+import {
   DatabaseChangeMode,
+  type EnvironmentSetting_Environment,
+  EnvironmentSetting_EnvironmentSchema,
   GetSettingRequestSchema,
   Setting_SettingName,
   WorkspaceProfileSettingSchema,
 } from "@/types/proto-es/v1/setting_service_pb";
 import {
   GetSubscriptionRequestSchema,
+  PlanType,
   UploadLicenseRequestSchema,
 } from "@/types/proto-es/v1/subscription_service_pb";
+import {
+  getDateForPbTimestampProtoEs,
+  getTimeForPbTimestampProtoEs,
+} from "@/types/timestamp";
+import type { Environment } from "@/types/v1/environment";
+import { formatAbsoluteDateTime } from "@/utils/datetime";
 import type { AppSliceCreator, WorkspaceSlice } from "./types";
 
 const workspaceProfileSettingName = `${settingNamePrefix}${
   Setting_SettingName[Setting_SettingName.WORKSPACE_PROFILE]
 }`;
+const environmentSettingName = `${settingNamePrefix}${
+  Setting_SettingName[Setting_SettingName.ENVIRONMENT]
+}`;
+const externalUrlPlaceholder =
+  "https://docs.bytebase.com/get-started/self-host/external-url";
+const trialingDays = 14;
 
 function appFeaturesFromDatabaseChangeMode(mode: DatabaseChangeMode) {
   const appFeatures = defaultAppProfile().features;
@@ -41,11 +65,35 @@ function appFeaturesFromDatabaseChangeMode(mode: DatabaseChangeMode) {
   return appFeatures;
 }
 
+function environmentNameFromId(id: string) {
+  return `environments/${id}`;
+}
+
+function convertEnvironmentList(
+  environments: EnvironmentSetting_Environment[]
+): Environment[] {
+  return environments.map<Environment>((env, i) => ({
+    ...createProto(EnvironmentSetting_EnvironmentSchema, {
+      name: environmentNameFromId(env.id),
+      id: env.id,
+      title: env.title,
+      color: env.color,
+      tags: env.tags,
+    }),
+    order: i,
+  }));
+}
+
+function isSelfHostLicense() {
+  return import.meta.env.MODE.toLowerCase() !== "release-aws";
+}
+
 export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
   set,
   get
 ) => ({
   serverInfoTs: 0,
+  environmentList: [],
   appFeatures: defaultAppProfile().features,
 
   loadServerInfo: async () => {
@@ -137,11 +185,56 @@ export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
     return request;
   },
 
+  loadEnvironmentList: async (force = false) => {
+    const existing = get().environmentList;
+    if (!force && existing.length > 0) return existing;
+    const pending = get().environmentRequest;
+    if (pending) return pending;
+    const request = settingServiceClientConnect
+      .getSetting(
+        createProto(GetSettingRequestSchema, {
+          name: environmentSettingName,
+        })
+      )
+      .then((setting) => {
+        const settingValue = setting.value?.value;
+        const environments =
+          settingValue?.case === "environment"
+            ? convertEnvironmentList(settingValue.value.environments)
+            : [];
+        set({ environmentList: environments, environmentRequest: undefined });
+        return environments;
+      })
+      .catch(() => {
+        set({ environmentRequest: undefined });
+        return [];
+      });
+    set({ environmentRequest: request });
+    return request;
+  },
+
+  refreshEnvironmentList: async () => get().loadEnvironmentList(true),
+
   loadSubscription: async () => {
     const existing = get().subscription;
     if (existing) return existing;
     const pending = get().subscriptionRequest;
     if (pending) return pending;
+    const request = subscriptionServiceClientConnect
+      .getSubscription(createProto(GetSubscriptionRequestSchema, {}))
+      .then((subscription) => {
+        set({ subscription, subscriptionRequest: undefined });
+        return subscription;
+      })
+      .catch(() => {
+        set({ subscriptionRequest: undefined });
+        return undefined;
+      });
+    set({ subscriptionRequest: request });
+    return request;
+  },
+
+  refreshSubscription: async () => {
     const request = subscriptionServiceClientConnect
       .getSubscription(createProto(GetSubscriptionRequestSchema, {}))
       .then((subscription) => {
@@ -163,4 +256,148 @@ export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
     set({ subscription });
     return subscription;
   },
+
+  currentPlan: () => {
+    return get().subscription?.plan ?? PlanType.FREE;
+  },
+
+  isFreePlan: () => get().currentPlan() === PlanType.FREE,
+
+  isTrialing: () => Boolean(get().subscription?.trialing),
+
+  isExpired: () => {
+    const subscription = get().subscription;
+    if (!subscription?.expiresTime || get().isFreePlan()) {
+      return false;
+    }
+    return dayjs(
+      getDateForPbTimestampProtoEs(subscription.expiresTime)
+    ).isBefore(new Date());
+  },
+
+  daysBeforeExpire: () => {
+    const subscription = get().subscription;
+    if (!subscription?.expiresTime || get().isFreePlan()) {
+      return -1;
+    }
+    return Math.max(
+      dayjs(getDateForPbTimestampProtoEs(subscription.expiresTime)).diff(
+        new Date(),
+        "day"
+      ),
+      0
+    );
+  },
+
+  trialingDays: () => trialingDays,
+
+  showTrial: () => {
+    if (!isSelfHostLicense()) {
+      return false;
+    }
+    return !get().subscription || get().isFreePlan();
+  },
+
+  expireAt: () => {
+    const subscription = get().subscription;
+    if (!subscription?.expiresTime || get().isFreePlan()) {
+      return "";
+    }
+    return formatAbsoluteDateTime(
+      getTimeForPbTimestampProtoEs(subscription.expiresTime)
+    );
+  },
+
+  instanceCountLimit: () => {
+    const subscription = get().subscription;
+    const licenseLimit = subscription?.instances ?? 0;
+    if (licenseLimit > 0) {
+      return licenseLimit;
+    }
+    const planLimit =
+      PLANS.find((plan) => plan.type === get().currentPlan())
+        ?.maximumInstanceCount ?? 0;
+    if (planLimit < 0) {
+      return licenseLimit > 0 ? licenseLimit : Number.MAX_VALUE;
+    }
+    return planLimit;
+  },
+
+  userCountLimit: () => {
+    let limit =
+      PLANS.find((plan) => plan.type === get().currentPlan())
+        ?.maximumSeatCount ?? 0;
+    if (limit < 0) {
+      limit = Number.MAX_VALUE;
+    }
+    const seats = get().subscription?.seats ?? 0;
+    if (seats < 0) {
+      return Number.MAX_VALUE;
+    }
+    if (seats === 0) {
+      return limit;
+    }
+    return seats;
+  },
+
+  instanceLicenseCount: () => {
+    const count = get().subscription?.activeInstances ?? 0;
+    return count < 0 ? Number.MAX_VALUE : count;
+  },
+
+  hasFeature: (feature) => {
+    if (get().isExpired()) {
+      return false;
+    }
+    return checkFeature(get().currentPlan(), feature);
+  },
+
+  hasInstanceFeature: (feature, instance) => {
+    const plan = get().currentPlan();
+    if (plan === PlanType.FREE) {
+      return get().hasFeature(feature);
+    }
+    if (!instance || !instanceLimitFeature.has(feature)) {
+      return get().hasFeature(feature);
+    }
+    return checkInstanceFeature(plan, feature, instance.activation);
+  },
+
+  instanceMissingLicense: (feature, instance) => {
+    if (!instanceLimitFeature.has(feature) || !instance) {
+      return false;
+    }
+    return get().hasFeature(feature) && !instance.activation;
+  },
+
+  getMinimumRequiredPlan,
+
+  isSaaSMode: () => get().serverInfo?.saas ?? false,
+
+  workspaceResourceName: () => get().serverInfo?.workspace ?? "",
+
+  externalUrl: () => get().serverInfo?.externalUrl ?? "",
+
+  needConfigureExternalUrl: () => {
+    const serverInfo = get().serverInfo;
+    if (!serverInfo) return false;
+    const url = serverInfo.externalUrl ?? "";
+    return url === "" || url === externalUrlPlaceholder;
+  },
+
+  version: () => get().serverInfo?.version ?? "",
+
+  changelogURL: () => {
+    const version = semver.valid(get().serverInfo?.version);
+    if (!version) return "";
+    return `https://docs.bytebase.com/changelog/bytebase-${version
+      .split(".")
+      .join("-")}/`;
+  },
+
+  activatedInstanceCount: () => get().serverInfo?.activatedInstanceCount ?? 0,
+
+  totalInstanceCount: () => get().serverInfo?.totalInstanceCount ?? 0,
+
+  userCountInIam: () => get().serverInfo?.userCountInIam ?? 0,
 });


### PR DESCRIPTION
## Summary
- Move React console workspace foundation reads from Vue/Pinia stores into the React app store.
- Add React hooks for server, subscription, workspace profile, and environment state.
- Update selected high-frequency React consumers to use the new hooks instead of `useVueState()` for foundation state.

## Key Changes
- Extend `react/stores/app` with environment loading, subscription helpers, and actuator/server derived helpers.
- Add `useSubscriptionState`, `useServerState`, `useEnvironmentList`, `useEnvironment`, and `usePlanFeature`.
- Migrate subscription, feature badge/modal, instance assignment, MCP, landing, environment selectors/labels, database header, and settings general foundation reads.
- Add app store tests for subscription derivation, server derivation, and environment conversion.

## Motivation
- Reduce React page coupling to Vue reactive state as a first step toward removing the Vue app shell boundary.
- Keep this slice focused on workspace foundation state while leaving project/database/sql-editor and mutation-heavy settings flows in their existing stores.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend check`
- `pnpm --dir frontend exec vitest run src/react/stores/app/index.test.ts src/react/components/FeatureAttention.test.tsx src/react/components/ui/feature-modal.test.tsx src/react/components/AuditLogTable.test.tsx src/react/pages/project/ProjectDatabaseDetailPage.test.tsx --passWithNoTests`
- `pnpm --dir frontend test` currently still fails on existing header/localStorage test environment issues in `DashboardHeader.test.tsx` and `VersionMenuItem.test.tsx`; touched tests pass.