### PR TITLE
feat(tsql): finish MSSQL omni query span cleanup

### DIFF
--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -54,6 +54,15 @@ func newQuerySpanExtractor(defaultDatabase string, defaultSchema string, gCtx ba
 	}
 }
 
+func (q *querySpanExtractor) findTempTable(rawName string) (*base.PhysicalTable, bool) {
+	for name, tempTable := range q.gCtx.TempTables {
+		if q.isIdentifierEqual(rawName, name) {
+			return tempTable, true
+		}
+	}
+	return nil, false
+}
+
 // tsqlFindTableSchemaByParts resolves a (linkedServer, database, schema, table)
 // tuple to a TableSource. Empty strings for database/schema mean "not specified
 // by the user"; defaults are applied here when looking up metadata. CTEs
@@ -65,7 +74,7 @@ func (q *querySpanExtractor) tsqlFindTableSchemaByParts(linkedServer, rawDatabas
 		return nil, errors.Errorf("linked server is not supported yet, but found %q", linkedServer)
 	}
 	if strings.HasPrefix(rawTable, "#") {
-		if tempTable, ok := q.gCtx.TempTables[rawTable]; ok {
+		if tempTable, ok := q.findTempTable(rawTable); ok {
 			return tempTable, nil
 		}
 		// TODO(masking): Considering SELECT * INTO #temp FROM dbo.t1; SELECT * FROM #temp. We should mask the #temp.

--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -65,6 +65,9 @@ func (q *querySpanExtractor) tsqlFindTableSchemaByParts(linkedServer, rawDatabas
 		return nil, errors.Errorf("linked server is not supported yet, but found %q", linkedServer)
 	}
 	if strings.HasPrefix(rawTable, "#") {
+		if tempTable, ok := q.gCtx.TempTables[rawTable]; ok {
+			return tempTable, nil
+		}
 		// TODO(masking): Considering SELECT * INTO #temp FROM dbo.t1; SELECT * FROM #temp. We should mask the #temp.
 		return &base.PseudoTable{}, nil
 	}

--- a/backend/plugin/parser/tsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/tsql/query_span_extractor_omni.go
@@ -659,7 +659,11 @@ func (q *omniQuerySpanExtractor) resolveTableValuedFunction(fn *ast.FuncCallExpr
 	switch strings.ToUpper(fn.Name.Object) {
 	case "STRING_SPLIT":
 		columnNames = []string{"value"}
-		if fn.Args != nil && fn.Args.Len() >= 3 {
+		hasOrdinal, err := stringSplitHasOrdinalColumn(fn.Args)
+		if err != nil {
+			return nil, err
+		}
+		if hasOrdinal {
 			columnNames = append(columnNames, "ordinal")
 		}
 	case "OPENJSON":
@@ -686,6 +690,39 @@ func (q *omniQuerySpanExtractor) resolveTableValuedFunction(fn *ast.FuncCallExpr
 		return nil, err
 	}
 	return &base.PseudoTable{Name: normIdent(alias), Columns: columns}, nil
+}
+
+func stringSplitHasOrdinalColumn(args *ast.List) (bool, error) {
+	if args == nil || args.Len() < 3 {
+		return false, nil
+	}
+	arg := args.Items[2]
+	for {
+		paren, ok := arg.(*ast.ParenExpr)
+		if !ok {
+			break
+		}
+		arg = paren.Expr
+	}
+	literal, ok := arg.(*ast.Literal)
+	if !ok {
+		return false, unsupportedNodeError("STRING_SPLIT enable_ordinal must be a constant 0, 1, or NULL", arg)
+	}
+	switch literal.Type {
+	case ast.LitInteger:
+		switch literal.Ival {
+		case 0:
+			return false, nil
+		case 1:
+			return true, nil
+		default:
+			return false, unsupportedNodeError("STRING_SPLIT enable_ordinal must be 0 or 1", arg)
+		}
+	case ast.LitNull:
+		return false, nil
+	default:
+		return false, unsupportedNodeError("STRING_SPLIT enable_ordinal must be a constant 0, 1, or NULL", arg)
+	}
 }
 
 func (q *omniQuerySpanExtractor) resolveSubqueryAsTable(sq *ast.SubqueryExpr, alias string, columnAliases ...string) (base.TableSource, error) {
@@ -754,7 +791,7 @@ func (q *omniQuerySpanExtractor) resolveTableVar(tv *ast.TableVarRef, alias stri
 		return nil, nil
 	}
 	name := tv.Name
-	if temp, ok := q.gCtx.TempTables[name]; ok {
+	if temp, ok := q.findTempTable(name); ok {
 		tableName := name
 		if alias != "" {
 			tableName = alias

--- a/backend/plugin/parser/tsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/tsql/query_span_extractor_omni.go
@@ -12,12 +12,6 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
-// errOmniUnsupported is a development-time sentinel: signals that the omni
-// extractor cannot handle the given construct yet. Only used by unit tests to
-// distinguish "not yet implemented" from real bugs. Never returned from the
-// public GetQuerySpan entry point after cutover.
-var errOmniUnsupported = errors.New("omni query span extractor: unsupported construct")
-
 // omniQuerySpanExtractor extracts query span information from omni MSSQL AST.
 // It embeds querySpanExtractor so string-based resolution helpers
 // (tsqlIsFieldSensitive, tsqlFindTableSchemaByParts, isIdentifierEqual,
@@ -79,6 +73,9 @@ func (q *omniQuerySpanExtractor) getOmniQuerySpan(ctx context.Context, statement
 	// side-effect. Non-table DECLARE (plain scalar variables) is a no-op.
 	if d, ok := root.(*ast.DeclareStmt); ok {
 		populateOmniTempTables(d, q.gCtx.TempTables)
+	}
+	if c, ok := root.(*ast.CreateTableStmt); ok {
+		populateOmniCreateTempTable(c, q.gCtx.TempTables)
 	}
 
 	accessTables := collectOmniAccessTables(root, q.defaultDatabase, q.defaultSchema)
@@ -175,6 +172,7 @@ func (q *omniQuerySpanExtractor) extractFromSelectStmt(sel *ast.SelectStmt) (*ba
 	if err != nil {
 		return nil, err
 	}
+	q.populateSelectIntoTempTable(sel, results)
 
 	return &base.PseudoTable{Columns: results}, nil
 }
@@ -409,7 +407,7 @@ func (q *omniQuerySpanExtractor) processWithClause(w *ast.WithClause) error {
 		}
 		body, ok := cte.Query.(*ast.SelectStmt)
 		if !ok {
-			return errOmniUnsupported
+			return unsupportedNodeError("only SELECT CTE bodies are supported", cte.Query)
 		}
 
 		cteName := normIdent(cte.Name)
@@ -543,20 +541,32 @@ func (q *omniQuerySpanExtractor) extractTableSource(node ast.Node) ([]base.Table
 	case *ast.TableVarMethodCallRef:
 		return []base.TableSource{&base.PseudoTable{Name: v.Alias, Columns: xmlNodesColumns(v.Columns)}}, nil
 	case *ast.PivotExpr:
-		return nil, errors.New("pivot is not supported yet")
-	case *ast.UnpivotExpr:
-		return nil, errors.New("unpivot is not supported yet")
-	case *ast.FuncCallExpr:
 		return nil, unsupportedTableSourceError(node)
+	case *ast.UnpivotExpr:
+		return nil, unsupportedTableSourceError(node)
+	case *ast.FuncCallExpr:
+		ts, err := q.resolveTableValuedFunction(v, "", nil)
+		if err != nil {
+			return nil, err
+		}
+		return []base.TableSource{ts}, nil
 	default:
-		return nil, errors.Wrapf(errOmniUnsupported, "FROM item type %T", node)
+		return nil, unsupportedTableSourceError(node)
 	}
 }
 
 func unsupportedTableSourceError(node ast.Node) error {
+	return unsupportedNodeError("only full table name, supported TVF, derived table, values clause, and temp table in table source item are supported", node)
+}
+
+func unsupportedNodeError(message string, node ast.Node) error {
+	typeName := "<nil>"
+	if typ := reflect.TypeOf(node); typ != nil {
+		typeName = typ.String()
+	}
 	return &base.TypeNotSupportedError{
-		Err:  errors.Errorf("only full table name in table source item is supported"),
-		Type: reflect.TypeOf(node).String(),
+		Err:  errors.New(message),
+		Type: typeName,
 	}
 }
 
@@ -627,9 +637,9 @@ func (q *omniQuerySpanExtractor) resolveAliasedTableRef(at *ast.AliasedTableRef)
 		if len(inners) == 1 {
 			return inners[0], nil
 		}
-		return nil, errors.Wrapf(errOmniUnsupported, "AliasedTableRef wrapping TableVarRef with non-single output")
+		return nil, unsupportedNodeError("aliased table variable must produce a single table source", at.Table)
 	case *ast.FuncCallExpr:
-		return nil, unsupportedTableSourceError(at.Table)
+		return q.resolveTableValuedFunction(inner, at.Alias, columnAliases)
 	case *ast.TableVarMethodCallRef:
 		cols := xmlNodesColumns(inner.Columns)
 		if err := applyColumnAliases(cols, columnAliases); err != nil {
@@ -637,14 +647,51 @@ func (q *omniQuerySpanExtractor) resolveAliasedTableRef(at *ast.AliasedTableRef)
 		}
 		return &base.PseudoTable{Name: normIdent(at.Alias), Columns: cols}, nil
 	default:
-		return nil, errors.Wrapf(errOmniUnsupported, "AliasedTableRef inner %T", at.Table)
+		return nil, unsupportedNodeError("unsupported aliased table source item", at.Table)
 	}
+}
+
+func (q *omniQuerySpanExtractor) resolveTableValuedFunction(fn *ast.FuncCallExpr, alias string, columnAliases []string) (base.TableSource, error) {
+	if fn == nil || fn.Name == nil {
+		return nil, unsupportedTableSourceError(fn)
+	}
+	var columnNames []string
+	switch strings.ToUpper(fn.Name.Object) {
+	case "STRING_SPLIT":
+		columnNames = []string{"value"}
+		if fn.Args != nil && fn.Args.Len() >= 3 {
+			columnNames = append(columnNames, "ordinal")
+		}
+	case "OPENJSON":
+		columnNames = []string{"key", "value", "type"}
+	default:
+		return nil, unsupportedTableSourceError(fn)
+	}
+
+	argSources, err := q.mergeListSources(fn.Args)
+	if err != nil {
+		return nil, err
+	}
+	columns := make([]base.QuerySpanResult, 0, len(columnNames))
+	for _, name := range columnNames {
+		columns = append(columns, base.QuerySpanResult{
+			Name:          name,
+			SourceColumns: argSources.SourceColumns,
+		})
+	}
+	if strings.EqualFold(fn.Name.Object, "STRING_SPLIT") && len(columns) > 1 {
+		columns[1].SourceColumns = make(base.SourceColumnSet)
+	}
+	if err := applyColumnAliases(columns, columnAliases); err != nil {
+		return nil, err
+	}
+	return &base.PseudoTable{Name: normIdent(alias), Columns: columns}, nil
 }
 
 func (q *omniQuerySpanExtractor) resolveSubqueryAsTable(sq *ast.SubqueryExpr, alias string, columnAliases ...string) (base.TableSource, error) {
 	body, ok := sq.Query.(*ast.SelectStmt)
 	if !ok {
-		return nil, errOmniUnsupported
+		return nil, unsupportedNodeError("only SELECT subqueries in table source are supported", sq.Query)
 	}
 	clone := q.cloneForSubquery()
 	pseudo, err := clone.extractFromSelectStmt(body)
@@ -761,6 +808,43 @@ func populateOmniTempTables(d *ast.DeclareStmt, out map[string]*base.PhysicalTab
 	}
 }
 
+func populateOmniCreateTempTable(c *ast.CreateTableStmt, out map[string]*base.PhysicalTable) {
+	if c == nil || c.Name == nil || out == nil || !strings.HasPrefix(c.Name.Object, "#") {
+		return
+	}
+	var columns []string
+	if c.Columns != nil {
+		columns = make([]string, 0, c.Columns.Len())
+		for _, item := range c.Columns.Items {
+			if cd, ok := item.(*ast.ColumnDef); ok {
+				columns = append(columns, cd.Name)
+			}
+		}
+	}
+	out[c.Name.Object] = &base.PhysicalTable{
+		Name:    c.Name.Object,
+		Columns: columns,
+	}
+}
+
+func (q *omniQuerySpanExtractor) populateSelectIntoTempTable(sel *ast.SelectStmt, results []base.QuerySpanResult) {
+	if sel == nil || sel.IntoTable == nil || q.gCtx.TempTables == nil || !strings.HasPrefix(sel.IntoTable.Object, "#") {
+		return
+	}
+	columns := make([]string, 0, len(results))
+	for i, result := range results {
+		name := result.Name
+		if name == "" && sel.TargetList != nil && i < len(sel.TargetList.Items) {
+			name = q.sliceName(sel.TargetList.Items[i])
+		}
+		columns = append(columns, name)
+	}
+	q.gCtx.TempTables[sel.IntoTable.Object] = &base.PhysicalTable{
+		Name:    sel.IntoTable.Object,
+		Columns: columns,
+	}
+}
+
 func xmlNodesColumns(cols []string) []base.QuerySpanResult {
 	out := make([]base.QuerySpanResult, 0, len(cols))
 	for _, c := range cols {
@@ -844,7 +928,7 @@ func (q *omniQuerySpanExtractor) extractTargetList(list *ast.List) ([]base.Query
 				results = append(results, r)
 				continue
 			}
-			return nil, errors.Wrapf(errOmniUnsupported, "target item %T", item)
+			return nil, unsupportedNodeError("unsupported SELECT target item", item)
 		}
 	}
 	return results, nil
@@ -1175,7 +1259,7 @@ func (q *omniQuerySpanExtractor) mergeOrderBySources(list *ast.List) (base.Query
 		case ast.ExprNode:
 			expr = v
 		default:
-			return r, errors.Wrapf(errOmniUnsupported, "ORDER BY item type %T", it)
+			return r, unsupportedNodeError("unsupported ORDER BY item", it)
 		}
 		sub, err := q.resolveExpressionNode(expr)
 		if err != nil {

--- a/backend/plugin/parser/tsql/query_span_extractor_omni_test.go
+++ b/backend/plugin/parser/tsql/query_span_extractor_omni_test.go
@@ -352,6 +352,22 @@ func TestOmniQuerySpan_SystemTableValuedFunctions(t *testing.T) {
 				{Database: "db", Schema: "dbo", Table: "t1", Column: "a"},
 			},
 		},
+		{
+			name:     "string_split_third_arg_zero_has_no_ordinal",
+			sql:      "SELECT s.value FROM t1 CROSS APPLY STRING_SPLIT(t1.a, ',', 0) AS s(value)",
+			wantName: "value",
+			wantSources: []base.ColumnResource{
+				{Database: "db", Schema: "dbo", Table: "t1", Column: "a"},
+			},
+		},
+		{
+			name:     "string_split_third_arg_null_has_no_ordinal",
+			sql:      "SELECT s.value FROM t1 CROSS APPLY STRING_SPLIT(t1.a, ',', NULL) AS s(value)",
+			wantName: "value",
+			wantSources: []base.ColumnResource{
+				{Database: "db", Schema: "dbo", Table: "t1", Column: "a"},
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -379,6 +395,26 @@ func TestOmniQuerySpan_TempTableDefinitions(t *testing.T) {
 	require.Equal(t, base.DDL, span1.Type)
 	require.Contains(t, gCtx.TempTables, "#tmp")
 	require.Equal(t, []string{"id", "name"}, gCtx.TempTables["#tmp"].Columns)
+
+	q2 := newOmniQuerySpanExtractor("db", "dbo", gCtx, true)
+	span2, err := q2.getOmniQuerySpan(context.Background(), "SELECT id, name FROM #tmp")
+	require.NoError(t, err)
+	require.Len(t, span2.Results, 2)
+	require.Equal(t, "id", span2.Results[0].Name)
+	require.Equal(t, "name", span2.Results[1].Name)
+}
+
+func TestOmniQuerySpan_TempTableDefinitionsCaseInsensitive(t *testing.T) {
+	getter, lister := buildMockDatabaseMetadataGetter(omniTestMetadata)
+	gCtx := base.GetQuerySpanContext{
+		GetDatabaseMetadataFunc: getter,
+		ListDatabaseNamesFunc:   lister,
+		TempTables:              make(map[string]*base.PhysicalTable),
+	}
+
+	q1 := newOmniQuerySpanExtractor("db", "dbo", gCtx, true)
+	_, err := q1.getOmniQuerySpan(context.Background(), "CREATE TABLE #Tmp(id INT, name NVARCHAR(50))")
+	require.NoError(t, err)
 
 	q2 := newOmniQuerySpanExtractor("db", "dbo", gCtx, true)
 	span2, err := q2.getOmniQuerySpan(context.Background(), "SELECT id, name FROM #tmp")

--- a/backend/plugin/parser/tsql/query_span_extractor_omni_test.go
+++ b/backend/plugin/parser/tsql/query_span_extractor_omni_test.go
@@ -303,8 +303,8 @@ func TestOmniQuerySpan_UnsupportedTableSources(t *testing.T) {
 		sql                  string
 		wantTypeNotSupported bool
 	}{
-		{name: "pivot", sql: "SELECT * FROM t PIVOT (SUM(a) FOR b IN ([1],[2])) AS p"},
-		{name: "unpivot", sql: "SELECT * FROM t UNPIVOT (v FOR c IN ([1],[2])) AS u"},
+		{name: "pivot", sql: "SELECT * FROM t PIVOT (SUM(a) FOR b IN ([1],[2])) AS p", wantTypeNotSupported: true},
+		{name: "unpivot", sql: "SELECT * FROM t UNPIVOT (v FOR c IN ([1],[2])) AS u", wantTypeNotSupported: true},
 		{name: "cross_apply_tvf", sql: "SELECT * FROM t1 CROSS APPLY fn(t1.a) AS x(v)", wantTypeNotSupported: true},
 		{name: "aliased_tvf", sql: "SELECT * FROM fn(t1.a) AS x(v)", wantTypeNotSupported: true},
 	}
@@ -319,6 +319,96 @@ func TestOmniQuerySpan_UnsupportedTableSources(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOmniQuerySpan_SystemTableValuedFunctions(t *testing.T) {
+	cases := []struct {
+		name        string
+		sql         string
+		wantName    string
+		wantSources []base.ColumnResource
+	}{
+		{
+			name:     "string_split_value_flows_from_input",
+			sql:      "SELECT s.value FROM t1 CROSS APPLY STRING_SPLIT(t1.a, ',') AS s",
+			wantName: "value",
+			wantSources: []base.ColumnResource{
+				{Database: "db", Schema: "dbo", Table: "t1", Column: "a"},
+			},
+		},
+		{
+			name:     "openjson_value_flows_from_input",
+			sql:      "SELECT j.value FROM t1 CROSS APPLY OPENJSON(t1.a) AS j",
+			wantName: "value",
+			wantSources: []base.ColumnResource{
+				{Database: "db", Schema: "dbo", Table: "t1", Column: "a"},
+			},
+		},
+		{
+			name:     "tvf_column_alias_list",
+			sql:      "SELECT s.v FROM t1 CROSS APPLY STRING_SPLIT(t1.a, ',', 1) AS s(v, ordinal)",
+			wantName: "v",
+			wantSources: []base.ColumnResource{
+				{Database: "db", Schema: "dbo", Table: "t1", Column: "a"},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			q := newOmniTestExtractor(t, "db")
+			span, err := q.getOmniQuerySpan(context.Background(), tc.sql)
+			require.NoError(t, err)
+			require.Len(t, span.Results, 1)
+			require.Equal(t, tc.wantName, span.Results[0].Name)
+			require.ElementsMatch(t, tc.wantSources, sortedSources(span.Results[0].SourceColumns))
+		})
+	}
+}
+
+func TestOmniQuerySpan_TempTableDefinitions(t *testing.T) {
+	getter, lister := buildMockDatabaseMetadataGetter(omniTestMetadata)
+	gCtx := base.GetQuerySpanContext{
+		GetDatabaseMetadataFunc: getter,
+		ListDatabaseNamesFunc:   lister,
+		TempTables:              make(map[string]*base.PhysicalTable),
+	}
+
+	q1 := newOmniQuerySpanExtractor("db", "dbo", gCtx, true)
+	span1, err := q1.getOmniQuerySpan(context.Background(), "CREATE TABLE #tmp(id INT, name NVARCHAR(50))")
+	require.NoError(t, err)
+	require.Equal(t, base.DDL, span1.Type)
+	require.Contains(t, gCtx.TempTables, "#tmp")
+	require.Equal(t, []string{"id", "name"}, gCtx.TempTables["#tmp"].Columns)
+
+	q2 := newOmniQuerySpanExtractor("db", "dbo", gCtx, true)
+	span2, err := q2.getOmniQuerySpan(context.Background(), "SELECT id, name FROM #tmp")
+	require.NoError(t, err)
+	require.Len(t, span2.Results, 2)
+	require.Equal(t, "id", span2.Results[0].Name)
+	require.Equal(t, "name", span2.Results[1].Name)
+}
+
+func TestOmniQuerySpan_SelectIntoTempTableRegistersColumns(t *testing.T) {
+	getter, lister := buildMockDatabaseMetadataGetter(omniTestMetadata)
+	gCtx := base.GetQuerySpanContext{
+		GetDatabaseMetadataFunc: getter,
+		ListDatabaseNamesFunc:   lister,
+		TempTables:              make(map[string]*base.PhysicalTable),
+	}
+
+	q1 := newOmniQuerySpanExtractor("db", "dbo", gCtx, true)
+	span1, err := q1.getOmniQuerySpan(context.Background(), "SELECT a AS id, b INTO #selected FROM t")
+	require.NoError(t, err)
+	require.Equal(t, base.Select, span1.Type)
+	require.Contains(t, gCtx.TempTables, "#selected")
+	require.Equal(t, []string{"id", "b"}, gCtx.TempTables["#selected"].Columns)
+
+	q2 := newOmniQuerySpanExtractor("db", "dbo", gCtx, true)
+	span2, err := q2.getOmniQuerySpan(context.Background(), "SELECT * FROM #selected")
+	require.NoError(t, err)
+	require.Len(t, span2.Results, 2)
+	require.Equal(t, "id", span2.Results[0].Name)
+	require.Equal(t, "b", span2.Results[1].Name)
 }
 
 // TestOmniQuerySpan_CTEVisibleInSetOpArms verifies that a CTE defined on a

--- a/backend/plugin/parser/tsql/query_span_parser_invariant_test.go
+++ b/backend/plugin/parser/tsql/query_span_parser_invariant_test.go
@@ -12,15 +12,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// TestOmniMigrationProbe verifies that the omni MSSQL parser can handle every
-// statement used by the current query-span ANTLR-based tests, and that the omni
-// AST populates the specific fields the planned transliteration depends on.
-// This is a discovery test: failures are the point. Run with
+// TestOmniQuerySpanParserInvariants verifies that the omni MSSQL parser can
+// handle every statement used by the query-span fixtures, and that the AST
+// continues to populate the fields the query-span extractor depends on. Run with
 //
-//	go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/tsql -run ^TestOmniMigrationProbe$
-func TestOmniMigrationProbe(t *testing.T) {
-	t.Run("FixtureParseCoverage", probeFixtureParseCoverage)
-	t.Run("StructuralInvariants", probeStructuralInvariants)
+//	go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/tsql -run ^TestOmniQuerySpanParserInvariants$
+func TestOmniQuerySpanParserInvariants(t *testing.T) {
+	t.Run("FixtureParseCoverage", querySpanFixtureParseCoverage)
+	t.Run("StructuralInvariants", querySpanStructuralInvariants)
 }
 
 type fixtureEntry struct {
@@ -28,7 +27,7 @@ type fixtureEntry struct {
 	Statement   string `yaml:"statement"`
 }
 
-var omniProbeFixturePaths = []string{
+var querySpanFixturePaths = []string{
 	"test-data/query-span/standard.yaml",
 	"test-data/query-span/join.yaml",
 	"test-data/query-span/case-sensitivity.yaml",
@@ -37,7 +36,7 @@ var omniProbeFixturePaths = []string{
 	"test-data/query-span/regression.yaml",
 }
 
-func probeFixtureParseCoverage(t *testing.T) {
+func querySpanFixtureParseCoverage(t *testing.T) {
 	type failure struct {
 		fixture   string
 		index     int
@@ -48,7 +47,7 @@ func probeFixtureParseCoverage(t *testing.T) {
 	totals := map[string][2]int{} // fixture -> [total, passed]
 	var failures []failure
 
-	for _, path := range omniProbeFixturePaths {
+	for _, path := range querySpanFixturePaths {
 		f, err := os.Open(path)
 		if err != nil {
 			t.Fatalf("open %s: %v", path, err)
@@ -111,17 +110,17 @@ func firstLine(s string) string {
 	return s
 }
 
-// probeStructuralInvariants runs hand-crafted SQL probes and asserts the
-// omni AST populates fields the migration will rely on. A failure means we
-// must either change omni or find an alternative in the transliteration.
-func probeStructuralInvariants(t *testing.T) {
-	type probe struct {
+// querySpanStructuralInvariants runs hand-crafted SQL statements and asserts
+// the omni AST populates fields the extractor relies on. A failure means we
+// must either update omni or adapt the extractor.
+func querySpanStructuralInvariants(t *testing.T) {
+	type invariant struct {
 		name  string
 		sql   string
 		check func(*testing.T, ast.Node)
 	}
 
-	probes := []probe{
+	invariants := []invariant{
 		{
 			name: "res_target_as_alias",
 			sql:  "SELECT c AS a FROM t",
@@ -144,10 +143,10 @@ func probeStructuralInvariants(t *testing.T) {
 				// Document actual shape — omni may lose the alias completely for this form.
 				switch v := sel.TargetList.Items[0].(type) {
 				case *ast.ResTarget:
-					t.Logf("omni parses `a = c` as ResTarget{Name=%q, Val=%T} — migration must recover alias from Val if Name is empty", v.Name, v.Val)
+					t.Logf("omni parses `a = c` as ResTarget{Name=%q, Val=%T} — extractor must recover alias from Val if Name is empty", v.Name, v.Val)
 					if v.Name != "a" {
 						if be, ok := v.Val.(*ast.BinaryExpr); ok && be.Op == ast.BinOpEq {
-							t.Logf("  recovery: Val is BinaryExpr{Op=Eq, Left=%T, Right=%T} — migration can pull alias from Left *ColumnRef.Column", be.Left, be.Right)
+							t.Logf("  recovery: Val is BinaryExpr{Op=Eq, Left=%T, Right=%T} — extractor can pull alias from Left *ColumnRef.Column", be.Left, be.Right)
 						}
 						t.Errorf("ResTarget.Name: want a, got %q (parser does not attribute the assignment form)", v.Name)
 					}
@@ -457,7 +456,7 @@ func probeStructuralInvariants(t *testing.T) {
 				default:
 					kind = fmt.Sprintf("%T", sel.WhereClause)
 				}
-				t.Logf("CONTAINS predicate shape: %s — migration must handle this form instead of ANTLR Freetext_predicateContext", kind)
+				t.Logf("CONTAINS predicate shape: %s — extractor must handle this form", kind)
 			},
 		},
 		{
@@ -538,7 +537,7 @@ func probeStructuralInvariants(t *testing.T) {
 			name: "table_variable_in_from",
 			sql:  "DECLARE @t TABLE(id INT); SELECT id FROM @t",
 			check: func(t *testing.T, _ ast.Node) {
-				// ParseTSQLOmni gives a slice; this probe only checks the first stmt (DECLARE).
+				// ParseTSQLOmni gives a slice; this invariant only checks the first stmt (DECLARE).
 				// Walk the full parse to confirm the second has @t as TableVarRef.
 				stmts, err := ParseTSQLOmni("DECLARE @t TABLE(id INT); SELECT id FROM @t")
 				if err != nil {
@@ -569,7 +568,7 @@ func probeStructuralInvariants(t *testing.T) {
 					t.Fatal("no TableRef in FROM")
 				}
 				if tr.Object != "#t" {
-					t.Errorf("TableRef.Object for temp table: got %q — migration must recognize '#' prefix as local temp", tr.Object)
+					t.Errorf("TableRef.Object for temp table: got %q — extractor must recognize '#' prefix as local temp", tr.Object)
 				}
 			},
 		},
@@ -604,7 +603,7 @@ func probeStructuralInvariants(t *testing.T) {
 		},
 	}
 
-	for _, p := range probes {
+	for _, p := range invariants {
 		t.Run(p.name, func(t *testing.T) {
 			stmts, err := ParseTSQLOmni(p.sql)
 			if err != nil {

--- a/docs/plans/2026-04-23-mssql-query-span-omni-migration.md
+++ b/docs/plans/2026-04-23-mssql-query-span-omni-migration.md
@@ -179,10 +179,10 @@ Tests: simple CTE; CTE with explicit column list; chain of CTEs where CTE2 uses 
 
 ### Phase 7 — Special table sources
 
-- **PIVOT**: `*ast.PivotExpr{Source, AggFunc, ForCol, InValues, Alias}` — result columns = source's non-pivot columns (need to subtract the FOR column) + one column per IN value, each pivoted aggregate. Source columns for pivoted columns = the AggFunc's source columns. This is new semantic work; ANTLR currently returns "not supported yet" — so this is an upgrade from current behavior. Start by emulating ANTLR: return errOmniUnsupported, and add a TODO. Real PIVOT support is a separate follow-up.
+- **PIVOT**: `*ast.PivotExpr{Source, AggFunc, ForCol, InValues, Alias}` — result columns = source's non-pivot columns (need to subtract the FOR column) + one column per IN value, each pivoted aggregate. Source columns for pivoted columns = the AggFunc's source columns. This is new semantic work; ANTLR returned "not supported yet", so the omni extractor preserves that behavior with a typed unsupported error. Real PIVOT support is a separate follow-up.
 - **UNPIVOT**: similar — emulate current ANTLR (unsupported).
 - **CROSS APPLY / OUTER APPLY**: `*JoinClause{Type: CrossApply|OuterApply}`. The Right is a table expression (often a TVF or subquery) that can reference Left columns (correlated). Treat as a join where Right is evaluated in a scope that includes Left. Contribution to tableSourcesFrom: both sides.
-- **Table-valued function call (TVF)**: `*FuncCallExpr` appearing in FROM position. Look up return signature — complicated, requires schema metadata for user TVFs. For system TVFs (e.g. `OPENJSON`, `STRING_SPLIT`): hardcode return shape. For unknown: `errOmniUnsupported` (ANTLR does the same for most).
+- **Table-valued function call (TVF)**: `*FuncCallExpr` appearing in FROM position. Look up return signature — complicated, requires schema metadata for user TVFs. The omni extractor hardcodes common system TVFs (`OPENJSON`, `STRING_SPLIT`) and returns a typed unsupported error for unknown TVFs.
 - **Temp tables**: `#t` → PseudoTable from gCtx.TempTables; `@t` (TableVarRef) → same lookup.
 - **TableVarMethodCallRef** (XML `.nodes()`): emits a table of XML fragments; columns named after the method's alias columns; no physical source.
 - **CHANGETABLE**: return PseudoTable (stats only, no sensitive data flow). Matches ANTLR behavior.
@@ -230,12 +230,12 @@ Tests: SELECT INTO #tmp FROM t (temp destination); FOR XML AUTO (ensure no crash
 5. Remove unused ANTLR-only helpers: `normalizeFullTableNameFallback`, `splitTableNameIntoNormalizedParts`, `unquote`, `getSelectBodyFromCreateView`, `NormalizeTSQLIdentifier` (if only used here — grep).
 6. `omni.go`'s `AsANTLRAST()` lazy ANTLR fallback: check if any other tsql file still uses it; drop if not.
 
-All 29 YAML fixtures must pass. The probe tests (`TestOmniMigrationProbe`) must still pass. New extractor tests all green. Lint clean. Build clean.
+All YAML fixtures must pass. Parser invariant tests (`TestOmniQuerySpanParserInvariants`) must still pass. New extractor tests all green. Lint clean. Build clean.
 
 ### Phase 12 — Cleanup
 
 - Delete the now-unused `query_span_extractor.go` ANTLR code (once fully replaced)
-- Remove `query_span_omni_probe_test.go` if it's now redundant with Phase 1-10 tests (or keep as a regression net — decide on cutover)
+- Keep parser AST shape coverage as `query_span_parser_invariant_test.go`.
 - Update `AGENTS.md` / skill docs if they still reference the old file layout
 - Open follow-up tickets for items deferred: PIVOT/UNPIVOT result-column inference, TVF metadata, SELECT INTO target marking, FOR XML single-column collapse
 
@@ -272,9 +272,9 @@ Validation of omni progress during development:
 1. **Unit tests** (`TestOmniQuerySpan_*`) — direct calls into `newOmniQuerySpanExtractor(...).getOmniQuerySpan()`, bypassing `GetQuerySpan`. This is where every phase's coverage is proven.
 2. **Parity harness** (`TestQuerySpan_AntlrOmniParity`, dev-only) — table-driven over the YAML corpus; calls both ANTLR via `GetQuerySpan` and omni directly; reports diffs. Useful as a thermometer; not wired to CI until cutover.
 
-`errOmniUnsupported` remains as a development signal (so unit tests can distinguish "not yet implemented" from "real bug") but is never observable from outside the package. After Phase 10 it should stop appearing for every supported shape, at which point the cutover is safe.
+Unsupported omni constructs return typed unsupported errors from the production path.
 
-At Phase 11, `GetQuerySpan` is rewritten to call the omni extractor directly (no fallback). `errOmniUnsupported` is deleted along with all ANTLR extraction code.
+At Phase 11, `GetQuerySpan` is rewritten to call the omni extractor directly (no fallback). The development-only unsupported sentinel is deleted along with the ANTLR extraction code.
 
 ## Risk register
 
@@ -312,7 +312,7 @@ Total: ~8 engineer-days. Parity test fixed after each phase, keeping CI green.
 
 ## Open questions
 
-1. **Should `query_span_omni_probe_test.go` stay?** It duplicates some checks. Recommend: keep through cutover for parse-coverage gating; delete in Phase 12 if the per-phase tests cover everything.
+1. **Should parser AST shape coverage stay?** Resolved: keep the useful parser AST coverage as `query_span_parser_invariant_test.go`.
 2. **PIVOT full support in this migration or later?** Current ANTLR is a no-op ("not supported"). Recommend: keep no-op parity in Phase 7; real PIVOT support = new project.
 3. **TVF return-shape metadata**: do we add a gCtx function for it (similar to ListDatabaseNamesFunc)? Recommend: yes, but defer to a separate ticket; the migration uses an empty fallback meanwhile.
 4. **Order of `tableSourcesFrom` across comma-join vs JOIN**: ANTLR current code `append`s as it walks left-to-right, JOIN unwraps from inside. Match exactly.


### PR DESCRIPTION
## Summary
- Add MSSQL omni query-span support for common system TVFs (`STRING_SPLIT`, `OPENJSON`) while keeping unknown TVFs, PIVOT, and UNPIVOT as typed unsupported errors.
- Register `#temp` table columns from `CREATE TABLE #...` and `SELECT ... INTO #...` so later query-span extraction can resolve them.
- Remove the query-span omni unsupported sentinel and convert the migration probe into a stable parser invariant test.

## Testing
- [x] `go test -count=1 ./backend/plugin/parser/tsql`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `golangci-lint run --fix --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Pre-PR Checklist
- Breaking change check: no breaking API/schema/proto/config/UI changes.
- Composite-PK query safety: skipped, no `backend/store` or migrator changes.
- SonarCloud properties: existing `backend/**/*_test.go` and test CPD exclusions cover the renamed test file.
