### PR TITLE
fix(frontend): use project-scoped suffix for service account email

### DIFF
--- a/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
+++ b/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
@@ -45,6 +45,34 @@ import type { ServiceAccount } from "@/types/proto-es/v1/service_account_service
 import type { User } from "@/types/proto-es/v1/user_service_pb";
 import { hasProjectPermissionV2, hasWorkspacePermissionV2 } from "@/utils";
 
+function execCommandCopy(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  if (navigator.clipboard) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // fall through to execCommand fallback
+    }
+  }
+  return execCommandCopy(text);
+}
+
 // ============================================================
 // ServiceAccountTable
 // ============================================================
@@ -120,8 +148,7 @@ function ServiceAccountTable({
       );
       const updated = serviceAccountToUser(sa);
       onUserUpdated(updated);
-      if (updated.serviceKey) {
-        await navigator.clipboard.writeText(updated.serviceKey);
+      if (updated.serviceKey && (await copyToClipboard(updated.serviceKey))) {
         setCopiedKeys((prev) => new Set(prev).add(updated.name));
         pushNotification({
           module: "bytebase",
@@ -135,7 +162,7 @@ function ServiceAccountTable({
   };
 
   const handleCopyKey = async (user: User) => {
-    await navigator.clipboard.writeText(user.serviceKey);
+    if (!(await copyToClipboard(user.serviceKey))) return;
     setCopiedKeys((prev) => new Set(prev).add(user.name));
     pushNotification({
       module: "bytebase",
@@ -420,7 +447,10 @@ function ServiceAccountForm({
   );
 
   const isEditMode = !!serviceAccount && !!serviceAccount.email;
-  const emailSuffix = getServiceAccountSuffix();
+  const emailSuffix = useMemo(() => {
+    const pid = project ? project.replace(/^projects\//, "") : "";
+    return getServiceAccountSuffix(pid || undefined);
+  }, [project]);
 
   // Capture initial values on mount — parent keys by serviceAccount so
   // these reflect the latest props.


### PR DESCRIPTION
## Summary

- The Service Account create form (`ServiceAccountsPage.tsx`) always rendered `@service.bytebase.com` as the email suffix, even when opened from a project — it should show `@<project-id>.service.bytebase.com` to match `WorkloadIdentitiesPage` and the actual server-assigned email. Caused by `getServiceAccountSuffix()` being called with no argument; now derives the project ID from the `project` prop the same way `CreateWorkloadIdentitySheet` does.
- Saved emails were already correct (the create RPC passes `parent`), so this is a display-only fix — but the misleading preview is what's shown in the screenshot.
- Drive-by: add a `document.execCommand('copy')` fallback so reset/copy service key still works when `navigator.clipboard` is unavailable (non-secure contexts).

## Test plan

- [ ] Open a project's Service Accounts page → New service account → email suffix shows `@<project-id>.service.bytebase.com`
- [ ] Workspace Service Accounts page still shows `@service.bytebase.com`
- [ ] Created accounts list correctly with the project-scoped email
- [ ] Reset/copy service key still copies to clipboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)