### PR TITLE
fix(frontend): preserve engine icon aspect ratio

### DIFF
--- a/frontend/src/react/components/DatabaseSelect.tsx
+++ b/frontend/src/react/components/DatabaseSelect.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { Combobox } from "@/react/components/ui/combobox";
 import { useActuatorV1Store, useDatabaseV1Store } from "@/store";
@@ -100,13 +100,7 @@ export function DatabaseSelect({
         const inst = getInstanceResource(db);
         return (
           <span className="flex items-center gap-1.5 truncate">
-            {EngineIconPath[inst.engine] && (
-              <img
-                className="h-4 w-4 shrink-0"
-                src={EngineIconPath[inst.engine]}
-                alt=""
-              />
-            )}
+            <EngineIcon engine={inst.engine} className="h-4 w-4" />
             {extractDatabaseResourceName(db.name).databaseName}
           </span>
         );
@@ -122,13 +116,7 @@ export function DatabaseSelect({
               <div className="flex items-center gap-1.5">
                 {inst.title && (
                   <>
-                    {EngineIconPath[inst.engine] && (
-                      <img
-                        className="h-4 w-4 shrink-0"
-                        src={EngineIconPath[inst.engine]}
-                        alt=""
-                      />
-                    )}
+                    <EngineIcon engine={inst.engine} className="h-4 w-4" />
                     <span>{inst.title}</span>
                     <span className="text-control-placeholder">&gt;</span>
                   </>

--- a/frontend/src/react/components/EngineIcon.tsx
+++ b/frontend/src/react/components/EngineIcon.tsx
@@ -1,0 +1,33 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { cn } from "@/react/lib/utils";
+import type { Engine } from "@/types/proto-es/v1/common_pb";
+
+type EngineIconProps = Omit<ComponentPropsWithoutRef<"img">, "src"> & {
+  engine: Engine;
+};
+
+export function EngineIcon({
+  engine,
+  alt = "",
+  className,
+  ...props
+}: EngineIconProps) {
+  const src = getEngineIconSrc(engine);
+  if (!src) {
+    return null;
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className={cn("shrink-0 object-contain", className)}
+      {...props}
+    />
+  );
+}
+
+export function getEngineIconSrc(engine: Engine) {
+  return EngineIconPath[engine];
+}

--- a/frontend/src/react/components/InstanceSelect.tsx
+++ b/frontend/src/react/components/InstanceSelect.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { Combobox } from "@/react/components/ui/combobox";
 import { useInstanceV1Store } from "@/store";
@@ -84,11 +84,7 @@ export function InstanceSelect({
         if (!inst) return opt.label;
         return (
           <span className="flex items-center gap-1.5 truncate">
-            <img
-              className="h-4 w-4 shrink-0"
-              src={EngineIconPath[inst.engine]}
-              alt=""
-            />
+            <EngineIcon engine={inst.engine} className="h-4 w-4" />
             {inst.title}
           </span>
         );
@@ -106,11 +102,7 @@ export function InstanceSelect({
                   <span className="text-control-placeholder">&gt;</span>
                 </>
               )}
-              <img
-                className="h-4 w-4 shrink-0"
-                src={EngineIconPath[inst.engine]}
-                alt=""
-              />
+              <EngineIcon engine={inst.engine} className="h-4 w-4" />
               <span>{inst.title}</span>
             </div>
             <span className="text-xs text-control-placeholder">

--- a/frontend/src/react/components/database/DatabaseTable.tsx
+++ b/frontend/src/react/components/database/DatabaseTable.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle, XCircle } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { LabelsDisplay } from "@/react/components/LabelsDisplay";
 import {
@@ -312,10 +312,9 @@ export function DatabaseTable({
                       )}
                       <TableCell>
                         <div className="flex items-center gap-x-2">
-                          <img
-                            className="h-5 w-5 shrink-0"
-                            src={EngineIconPath[instanceResource.engine]}
-                            alt=""
+                          <EngineIcon
+                            engine={instanceResource.engine}
+                            className="h-5 w-5"
                           />
                           <span className="truncate">
                             {extractDatabaseResourceName(db.name).databaseName}

--- a/frontend/src/react/components/database/TransferProjectSheet.tsx
+++ b/frontend/src/react/components/database/TransferProjectSheet.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { ProjectSelect } from "@/react/components/ProjectSelect";
 import { Button } from "@/react/components/ui/button";
 import {
@@ -61,10 +61,9 @@ export function TransferProjectSheet({
                 key={db.name}
                 className="px-3 py-2 text-sm border-b last:border-b-0 flex items-center gap-x-2"
               >
-                <img
+                <EngineIcon
+                  engine={getInstanceResource(db).engine}
                   className="size-4"
-                  src={EngineIconPath[getInstanceResource(db).engine]}
-                  alt=""
                 />
                 <span>{extractDatabaseResourceName(db.name).databaseName}</span>
               </div>

--- a/frontend/src/react/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/react/components/instance/InstanceFormBody.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentSelect } from "@/react/components/EnvironmentSelect";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { LabelListEditor } from "@/react/components/LabelListEditor";
@@ -52,7 +53,6 @@ import {
 import type { EditDataSource } from "./common";
 import { hasSslConfig } from "./common";
 import {
-  EngineIconPath,
   MongoDBConnectionStringSchemaList,
   RedisConnectionType,
   SnowflakeExtraLinkPlaceHolder,
@@ -247,9 +247,7 @@ function InstanceEngineRadioGrid({
           }`}
           onClick={() => onEngineChange(eng)}
         >
-          {EngineIconPath[eng] && (
-            <img src={EngineIconPath[eng]} alt="" className="size-5 shrink-0" />
-          )}
+          <EngineIcon engine={eng} className="size-5" />
           <span className="truncate">{engineNameV1(eng)}</span>
           {isEngineBeta(eng) && (
             <span className="ml-auto shrink-0 rounded-full bg-accent/10 px-2 py-0.5 text-xs text-accent">
@@ -1283,13 +1281,7 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
                   {t("database.engine")}
                 </p>
                 <div className="mt-1 flex items-center gap-x-1.5">
-                  {EngineIconPath[basicInfo.engine] && (
-                    <img
-                      src={EngineIconPath[basicInfo.engine]}
-                      alt=""
-                      className="size-4"
-                    />
-                  )}
+                  <EngineIcon engine={basicInfo.engine} className="size-4" />
                   <span className="text-sm font-medium text-main">
                     {engineNameV1(basicInfo.engine)}
                   </span>
@@ -1351,13 +1343,7 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
                 <span className="ml-0.5 text-error">*</span>
                 {instance && (
                   <div className="ml-2 flex items-center">
-                    {EngineIconPath[instance.engine] && (
-                      <img
-                        src={EngineIconPath[instance.engine]}
-                        alt=""
-                        className="size-4"
-                      />
-                    )}
+                    <EngineIcon engine={instance.engine} className="size-4" />
                     <span className="ml-1">{instance.engineVersion}</span>
                   </div>
                 )}

--- a/frontend/src/react/components/instance/index.tsx
+++ b/frontend/src/react/components/instance/index.tsx
@@ -1,3 +1,4 @@
+export { EngineIcon } from "../EngineIcon";
 export { CreateDataSourceExample } from "./CreateDataSourceExample";
 export { CredentialSourceForm } from "./CredentialSourceForm";
 export type { BasicInfo, DataSourceEditState, EditDataSource } from "./common";

--- a/frontend/src/react/components/sql-editor/ConnectionPane/ConnectionPane.tsx
+++ b/frontend/src/react/components/sql-editor/ConnectionPane/ConnectionPane.tsx
@@ -2,13 +2,13 @@ import { cloneDeep } from "lodash-es";
 import { ChevronDown, ChevronRight, Info, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
 import {
   AdvancedSearch,
   emptySearchParams,
   type SearchParams,
 } from "@/react/components/AdvancedSearch";
 import { DatabaseGroupTable } from "@/react/components/DatabaseGroupTable";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
 import { Separator } from "@/react/components/ui/separator";
@@ -773,7 +773,6 @@ function SelectedDatabaseTag({
   const dbLabel = database
     ? extractDatabaseResourceName(database.name).databaseName
     : extractDatabaseResourceName(name).databaseName;
-  const iconPath = instance ? EngineIconPath[instance.engine] : undefined;
 
   return (
     <span
@@ -782,7 +781,7 @@ function SelectedDatabaseTag({
         disabled && "opacity-50"
       )}
     >
-      {iconPath && <img src={iconPath} alt="" className="size-4 shrink-0" />}
+      {instance && <EngineIcon engine={instance.engine} className="size-4" />}
       {instance && (
         <span className="truncate max-w-[8rem]">
           {instanceV1Name(instance)}

--- a/frontend/src/react/components/sql-editor/ConnectionPane/TreeNode/DatabaseNode.tsx
+++ b/frontend/src/react/components/sql-editor/ConnectionPane/TreeNode/DatabaseNode.tsx
@@ -1,6 +1,6 @@
 import { create } from "@bufbuild/protobuf";
 import { ChevronRight } from "lucide-react";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
 import { RequestQueryButton } from "@/react/components/sql-editor/RequestQueryButton";
 import { Tooltip } from "@/react/components/ui/tooltip";
@@ -49,7 +49,6 @@ export function DatabaseNode({
 
   const database = (node as SQLEditorTreeNode<"database">).meta.target;
   const instance = getInstanceResource(database);
-  const iconPath = EngineIconPath[instance.engine];
   const databaseName = extractDatabaseResourceName(database.name).databaseName;
   const canQuery = isDatabaseV1Queryable(database);
 
@@ -77,9 +76,7 @@ export function DatabaseNode({
         )}
       >
         <div className="flex flex-row items-center gap-x-1 min-w-0">
-          {iconPath ? (
-            <img src={iconPath} alt="" className="size-4 shrink-0" />
-          ) : null}
+          <EngineIcon engine={instance.engine} className="size-4" />
           <span className="truncate">{instanceV1Name(instance)}</span>
         </div>
         <ChevronRight className="size-3 shrink-0" />

--- a/frontend/src/react/components/sql-editor/ConnectionPane/TreeNode/InstanceNode.tsx
+++ b/frontend/src/react/components/sql-editor/ConnectionPane/TreeNode/InstanceNode.tsx
@@ -1,4 +1,4 @@
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
 import type { SQLEditorTreeNode } from "@/types";
 import { instanceV1Name } from "@/utils";
@@ -21,13 +21,10 @@ export function InstanceNode({ node, keyword }: Props) {
     ...target,
     $typeName: "bytebase.v1.InstanceResource" as const,
   };
-  const iconPath = EngineIconPath[instance.engine];
   return (
     <div className="flex items-center max-w-full overflow-hidden gap-x-1">
       <span className="inline-flex items-center gap-x-1">
-        {iconPath ? (
-          <img src={iconPath} alt="" className="size-4 shrink-0" />
-        ) : null}
+        <EngineIcon engine={instance.engine} className="size-4" />
         <span className="truncate">
           <HighlightLabelText
             text={instanceV1Name(instance)}

--- a/frontend/src/react/components/sql-editor/DatabaseChooser.tsx
+++ b/frontend/src/react/components/sql-editor/DatabaseChooser.tsx
@@ -1,6 +1,6 @@
 import { ChevronRight, Database, SquareStack } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -79,11 +79,7 @@ export function DatabaseChooser({ disabled = false }: DatabaseChooserProps) {
           <EnvironmentLabel environmentName={environment.name} />
           <ChevronRight className="size-4 shrink-0 text-control-light" />
           <div className="flex items-center gap-1">
-            <img
-              className="size-4 shrink-0"
-              src={EngineIconPath[instance.engine]}
-              alt=""
-            />
+            <EngineIcon engine={instance.engine} className="size-4" />
             <span className="truncate">{instance.title}</span>
           </div>
           <ChevronRight className="size-4 shrink-0 text-control-light" />

--- a/frontend/src/react/components/sql-editor/ReadonlyModeNotSupported.tsx
+++ b/frontend/src/react/components/sql-editor/ReadonlyModeNotSupported.tsx
@@ -1,6 +1,6 @@
 import { ShieldAlert } from "lucide-react";
 import { Trans, useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useConnectionOfCurrentSQLEditorTab } from "@/store";
 import { AdminModeButton } from "./AdminModeButton";
@@ -30,13 +30,7 @@ export function ReadonlyModeNotSupported() {
           components={{
             instance: (
               <span className="inline-flex items-center gap-x-1 font-medium text-control">
-                {EngineIconPath[instance.engine] && (
-                  <img
-                    src={EngineIconPath[instance.engine]}
-                    alt=""
-                    className="size-4"
-                  />
-                )}
+                <EngineIcon engine={instance.engine} className="size-4" />
                 <span>{instance.title}</span>
               </span>
             ),

--- a/frontend/src/react/components/sql-editor/SchemaPane/HoverPanel/TableInfo.tsx
+++ b/frontend/src/react/components/sql-editor/SchemaPane/HoverPanel/TableInfo.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useDatabaseV1Store, useDBSchemaV1Store } from "@/store";
 import { Engine } from "@/types/proto-es/v1/common_pb";
@@ -42,14 +42,13 @@ export function TableInfo({ database, schema, table }: Props) {
       ? ""
       : tableMetadata.collation;
   const comment = tableMetadata.comment;
-  const iconPath = EngineIconPath[instanceEngine];
 
   return (
     <div className="min-w-56 max-w-[18rem] gap-y-1">
       <InfoItem title={t("common.name")}>{tableMetadata.name}</InfoItem>
       <InfoItem title={t("database.engine")}>
         <span className="flex items-center gap-x-0.5">
-          {iconPath ? <img src={iconPath} alt="" className="size-4" /> : null}
+          <EngineIcon engine={instanceEngine} className="size-4" />
           {engineNameV1(instanceEngine)}
         </span>
       </InfoItem>

--- a/frontend/src/react/components/sql-editor/SchemaPane/SchemaPane.tsx
+++ b/frontend/src/react/components/sql-editor/SchemaPane/SchemaPane.tsx
@@ -9,7 +9,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { TableSchemaViewer } from "@/react/components/TableSchemaViewer";
 import {
   Dialog,
@@ -602,13 +602,10 @@ function DatabaseTitle({
   database: { name: string; project: string } & Record<string, unknown>;
 }) {
   const instance = getInstanceResource(database as never);
-  const iconPath = EngineIconPath[instance.engine];
   const databaseName = extractDatabaseResourceName(database.name).databaseName;
   return (
     <span className="inline-flex items-center gap-x-1">
-      {iconPath ? (
-        <img src={iconPath} alt="" className="size-4 shrink-0" />
-      ) : null}
+      <EngineIcon engine={instance.engine} className="size-4" />
       <span className="truncate">{instanceV1Name(instance)}</span>
       <ChevronRight className="size-3 shrink-0" />
       <span className="truncate">{databaseName}</span>

--- a/frontend/src/react/components/sql-editor/SchemaPane/TreeNode/DatabaseNode.tsx
+++ b/frontend/src/react/components/sql-editor/SchemaPane/TreeNode/DatabaseNode.tsx
@@ -1,4 +1,4 @@
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useDatabaseV1Store } from "@/store";
 import { extractDatabaseResourceName, getInstanceResource } from "@/utils";
@@ -24,14 +24,13 @@ export function DatabaseNode({ node, keyword }: Props) {
 
   const databaseName = extractDatabaseResourceName(database.name).databaseName;
   const instance = getInstanceResource(database);
-  const iconPath = EngineIconPath[instance.engine];
 
   return (
     <CommonNode
       text={databaseName}
       keyword={keyword}
       highlight={true}
-      icon={iconPath ? <img src={iconPath} alt="" className="size-4" /> : null}
+      icon={<EngineIcon engine={instance.engine} className="size-4" />}
     />
   );
 }

--- a/frontend/src/react/components/sql-editor/SheetConnectionIcon.tsx
+++ b/frontend/src/react/components/sql-editor/SheetConnectionIcon.tsx
@@ -1,5 +1,5 @@
 import { Unlink } from "lucide-react";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon, getEngineIconSrc } from "@/react/components/EngineIcon";
 import type { SQLEditorTab } from "@/types";
 import { getConnectionForSQLEditorTab, isConnectedSQLEditorTab } from "@/utils";
 
@@ -16,14 +16,8 @@ export function SheetConnectionIcon({ tab }: Props) {
   const connected = isConnectedSQLEditorTab(tab);
   const { instance } = getConnectionForSQLEditorTab(tab);
 
-  if (connected && instance && EngineIconPath[instance.engine]) {
-    return (
-      <img
-        src={EngineIconPath[instance.engine]}
-        alt=""
-        className="size-4 shrink-0"
-      />
-    );
+  if (connected && instance && getEngineIconSrc(instance.engine)) {
+    return <EngineIcon engine={instance.engine} className="size-4" />;
   }
   return <Unlink className="size-4 shrink-0" />;
 }

--- a/frontend/src/react/components/sql-review/TabsByEngine.tsx
+++ b/frontend/src/react/components/sql-review/TabsByEngine.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import {
   Tabs,
   TabsList,
@@ -69,11 +69,7 @@ export function TabsByEngine({ ruleMapByEngine, children }: TabsByEngineProps) {
         {sortedData.map(([engine, ruleMap]) => (
           <TabsTrigger key={engine} value={String(engine)}>
             <div className="flex items-center gap-x-1">
-              <img
-                src={EngineIconPath[engine]}
-                alt=""
-                className="h-4 w-auto object-contain"
-              />
+              <EngineIcon engine={engine} className="h-4 w-4" />
               <span className="text-sm">{engineParts(engine).title}</span>
               {engineParts(engine).subtitle && (
                 <span className="text-xs text-control-light">

--- a/frontend/src/react/components/useCommonSearchScopeOptions.tsx
+++ b/frontend/src/react/components/useCommonSearchScopeOptions.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
 import type {
   ScopeOption,
   ValueOption,
 } from "@/react/components/AdvancedSearch";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { useInstanceV1Store } from "@/store";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import {
@@ -45,13 +45,7 @@ export function useCommonSearchScopeOptions(
           keywords: [name, ins.title, String(ins.engine), env],
           render: () => (
             <span className="flex items-center gap-x-1">
-              {EngineIconPath[ins.engine] && (
-                <img
-                  src={EngineIconPath[ins.engine]}
-                  alt=""
-                  className="size-4 shrink-0"
-                />
-              )}
+              <EngineIcon engine={ins.engine} className="size-4" />
               <span className="truncate">{ins.title}</span>
               {env && (
                 <span className="text-control-light text-xs">({env})</span>

--- a/frontend/src/react/pages/project/ProjectAccessGrantsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectAccessGrantsPage.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
 import {
   AdvancedSearch,
   emptySearchParams,
@@ -9,6 +8,7 @@ import {
   type ValueOption,
 } from "@/react/components/AdvancedSearch";
 import { ComponentPermissionGuard } from "@/react/components/ComponentPermissionGuard";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { TimeRangePicker } from "@/react/components/TimeRangePicker";
 import { Badge } from "@/react/components/ui/badge";
@@ -103,7 +103,7 @@ function mapDatabase(db: Database) {
     dbName,
     instanceTitle: inst?.title ?? "",
     envId: envId ?? "",
-    engineIcon: inst ? (EngineIconPath[inst.engine] ?? "") : "",
+    engine: inst?.engine,
   };
 }
 
@@ -178,12 +178,8 @@ export function ProjectAccessGrantsPage({ projectId }: { projectId: string }) {
           custom: true,
           render: () => (
             <span className="inline-flex items-center gap-x-1">
-              {mapped.engineIcon && (
-                <img
-                  className="h-4 w-4 shrink-0"
-                  src={mapped.engineIcon}
-                  alt=""
-                />
+              {mapped.engine && (
+                <EngineIcon engine={mapped.engine} className="h-4 w-4" />
               )}
               <span>{mapped.instanceTitle}</span>
               <span className="text-control-placeholder">&gt;</span>

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -12,7 +12,6 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
 import { applyPlanTitleToQuery } from "@/components/Plan/logic/title";
 import {
   AdvancedSearch,
@@ -20,6 +19,7 @@ import {
   type SearchParams,
   type ValueOption,
 } from "@/react/components/AdvancedSearch";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import {
   PermissionGuard,
@@ -1113,12 +1113,8 @@ function DatabaseSelector({
                     </td>
                     <td className="py-2 pr-4">
                       <div className="flex items-center gap-x-1.5">
-                        {inst && EngineIconPath[inst.engine] && (
-                          <img
-                            className="size-4 shrink-0"
-                            src={EngineIconPath[inst.engine]}
-                            alt=""
-                          />
+                        {inst && (
+                          <EngineIcon engine={inst.engine} className="size-4" />
                         )}
                         <span>{databaseName}</span>
                       </div>

--- a/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
@@ -13,9 +13,9 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
 import { applyPlanTitleToQuery } from "@/components/Plan/logic/title";
 import { DatabaseSelect } from "@/react/components/DatabaseSelect";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentSelect } from "@/react/components/EnvironmentSelect";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import {
@@ -1105,13 +1105,7 @@ function SourceSchemaInfo({
             onClick={gotoDatabase}
           >
             <span className="opacity-60">{t("common.database")}</span>
-            {EngineIconPath[sourceEngine] && (
-              <img
-                src={EngineIconPath[sourceEngine]}
-                className="w-4 h-auto"
-                alt=""
-              />
-            )}
+            <EngineIcon engine={sourceEngine} className="w-4 h-4" />
             <span>
               {
                 extractDatabaseResourceName(databaseFromChangelog.name)
@@ -1134,13 +1128,7 @@ function SourceSchemaInfo({
           </span>
           <span className="inline-flex items-center gap-x-1 px-2.5 py-0.5 rounded-full bg-control-bg text-sm">
             <span className="opacity-60 mr-1">{t("database.engine")}</span>
-            {EngineIconPath[sourceEngine] && (
-              <img
-                src={EngineIconPath[sourceEngine]}
-                className="w-4 h-auto"
-                alt=""
-              />
-            )}
+            <EngineIcon engine={sourceEngine} className="w-4 h-4" />
             <span>{engineNameV1(sourceEngine)}</span>
           </span>
         </>
@@ -1502,13 +1490,10 @@ function SelectTargetDatabasesView({
                   )}
                   onClick={() => onSelectedDatabaseNameChange(database.name)}
                 >
-                  {EngineIconPath[getInstanceResource(database).engine] && (
-                    <img
-                      src={EngineIconPath[getInstanceResource(database).engine]}
-                      className="w-4 h-auto shrink-0"
-                      alt=""
-                    />
-                  )}
+                  <EngineIcon
+                    engine={getInstanceResource(database).engine}
+                    className="w-4 h-4"
+                  />
                   <span className="truncate ml-1">
                     <span className="mx-0.5 text-control-placeholder">
                       ({getDatabaseEnvironment(database).title})
@@ -2156,15 +2141,10 @@ function TargetDatabasesSelectPanel({
                       </td>
                       <td className="py-2 px-2">
                         <div className="flex items-center gap-x-1">
-                          {EngineIconPath[getInstanceResource(db).engine] && (
-                            <img
-                              src={
-                                EngineIconPath[getInstanceResource(db).engine]
-                              }
-                              className="w-4 h-auto"
-                              alt=""
-                            />
-                          )}
+                          <EngineIcon
+                            engine={getInstanceResource(db).engine}
+                            className="w-4 h-4"
+                          />
                           {extractDatabaseResourceName(db.name).databaseName}
                         </div>
                       </td>

--- a/frontend/src/react/pages/project/database-detail/DatabaseDetailHeader.tsx
+++ b/frontend/src/react/pages/project/database-detail/DatabaseDetailHeader.tsx
@@ -1,7 +1,7 @@
 import { Check, Copy, ShieldAlert } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { useEnvironment, usePlanFeature } from "@/react/hooks/useAppState";
 import { router } from "@/router";
 import { INSTANCE_ROUTE_DETAIL } from "@/router/dashboard/instance";
@@ -62,7 +62,6 @@ export function DatabaseDetailHeader({
   const instanceLabel = instanceV1Name(instanceResource);
   const instanceId = extractInstanceResourceName(instanceResource.name);
   const canViewInstance = hasWorkspacePermissionV2("bb.instances.get");
-  const engineIconSrc = EngineIconPath[String(instanceResource.engine)];
 
   const environment = useEnvironment(database.effectiveEnvironment ?? "");
   const hasEnvironmentTierFeature = usePlanFeature(
@@ -189,24 +188,18 @@ export function DatabaseDetailHeader({
               className="inline-flex cursor-pointer items-center gap-x-1 hover:underline"
               onClick={handleInstanceClick}
             >
-              {engineIconSrc && (
-                <img
-                  src={engineIconSrc}
-                  className="h-4 w-4 shrink-0 object-contain"
-                  alt=""
-                />
-              )}
+              <EngineIcon
+                engine={instanceResource.engine}
+                className="h-4 w-4"
+              />
               {instanceLabel}
             </a>
           ) : (
             <span className="inline-flex items-center gap-x-1">
-              {engineIconSrc && (
-                <img
-                  src={engineIconSrc}
-                  className="h-4 w-4 shrink-0 object-contain"
-                  alt=""
-                />
-              )}
+              <EngineIcon
+                engine={instanceResource.engine}
+                className="h-4 w-4"
+              />
               {instanceLabel}
             </span>
           )}

--- a/frontend/src/react/pages/project/export-center/DataExportPrepSheet.tsx
+++ b/frontend/src/react/pages/project/export-center/DataExportPrepSheet.tsx
@@ -3,7 +3,7 @@ import { Database as DatabaseIcon, FolderTree, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { IssueLabelSelect } from "@/react/components/IssueLabelSelect";
 import { Button } from "@/react/components/ui/button";
@@ -570,13 +570,7 @@ function TargetBadge({ target }: { target: string }) {
     const { databaseName } = extractDatabaseResourceName(target);
     return (
       <div className="inline-flex items-center gap-2 px-2 py-1.5 border rounded-sm min-w-0">
-        {inst && EngineIconPath[inst.engine] && (
-          <img
-            className="size-4 shrink-0"
-            src={EngineIconPath[inst.engine]}
-            alt=""
-          />
-        )}
+        {inst && <EngineIcon engine={inst.engine} className="size-4" />}
         {env && <EnvironmentLabel environmentName={env.name} />}
         <span className="text-sm truncate">{databaseName}</span>
       </div>
@@ -834,12 +828,8 @@ function DatabaseSelector({
                     </td>
                     <td className="py-2 pr-4">
                       <div className="flex items-center gap-x-1.5">
-                        {inst && EngineIconPath[inst.engine] && (
-                          <img
-                            className="size-4 shrink-0"
-                            src={EngineIconPath[inst.engine]}
-                            alt=""
-                          />
+                        {inst && (
+                          <EngineIcon engine={inst.engine} className="size-4" />
                         )}
                         <span>{databaseName}</span>
                       </div>

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/react/components/instance/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { Alert } from "@/react/components/ui/alert";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
@@ -167,17 +167,15 @@ function IssueDetailAccessGrantTarget({ target }: { target: string }) {
   );
   const instance = database.instanceResource;
   const { databaseName } = extractDatabaseResourceName(target);
-  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
 
   return (
     <div className="inline-flex min-w-0 items-center gap-2 rounded-sm border px-2 py-1.5">
       <div className="min-w-0 flex-1">
         <div className="flex min-w-0 items-center truncate text-sm">
-          {engineIcon && (
-            <img
-              alt=""
+          {instance && (
+            <EngineIcon
+              engine={instance.engine}
               className="mr-1 inline-block h-4 w-4"
-              src={engineIcon}
             />
           )}
           <span className="mr-1 truncate text-gray-400">

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
@@ -3,7 +3,7 @@ import { ChevronRight, ExternalLink, FolderTree, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { instanceRoleServiceClientConnect } from "@/connect";
-import { EngineIconPath } from "@/react/components/instance/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import {
   Dialog,
   DialogClose,
@@ -783,7 +783,6 @@ function IssueDetailDatabaseTarget({
     )
   );
   const instance = database.instanceResource;
-  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
   const { databaseName } = extractDatabaseResourceName(target);
   const instanceTitle =
     instance?.title ||
@@ -792,8 +791,11 @@ function IssueDetailDatabaseTarget({
 
   return (
     <div className="flex min-w-0 items-center truncate text-sm">
-      {engineIcon && (
-        <img alt="" className="mr-1 inline-block h-4 w-4" src={engineIcon} />
+      {instance && (
+        <EngineIcon
+          engine={instance.engine}
+          className="mr-1 inline-block h-4 w-4"
+        />
       )}
       {showEnvironment && (
         <span className="mr-1 truncate text-gray-400">{environment.title}</span>

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
@@ -1,7 +1,7 @@
 import { Check, FastForward, Minus, Pause, X } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/react/components/instance/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
@@ -237,7 +237,6 @@ function IssueDetailDatabaseCreateInstance({
   const instance = useVueState(() =>
     instanceStore.getInstanceByName(instanceName)
   );
-  const engineIcon = EngineIconPath[instance.engine];
 
   if (!instanceHref) {
     return <span className="text-gray-900">{children}</span>;
@@ -251,9 +250,7 @@ function IssueDetailDatabaseCreateInstance({
         event.stopPropagation();
       }}
     >
-      {engineIcon && (
-        <img alt="" className="h-4 w-4 shrink-0" src={engineIcon} />
-      )}
+      <EngineIcon engine={instance.engine} className="h-4 w-4" />
       <span className="truncate">{children}</span>
     </a>
   );

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
@@ -13,7 +13,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { planServiceClientConnect } from "@/connect";
-import { EngineIconPath } from "@/react/components/instance/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { Switch } from "@/react/components/ui/switch";
@@ -667,7 +667,6 @@ function IssueDetailDatabaseExportDatabaseTarget({
     )
   );
   const instance = database.instanceResource;
-  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
   const { databaseName } = extractDatabaseResourceName(target);
   const instanceTitle =
     instance?.title ||
@@ -676,8 +675,11 @@ function IssueDetailDatabaseExportDatabaseTarget({
 
   return (
     <div className="flex min-w-0 items-center truncate text-sm">
-      {engineIcon && (
-        <img alt="" className="mr-1 inline-block h-4 w-4" src={engineIcon} />
+      {instance && (
+        <EngineIcon
+          engine={instance.engine}
+          className="mr-1 inline-block h-4 w-4"
+        />
       )}
       <span className="mr-1 truncate text-gray-400">{environment.title}</span>
       <span className="truncate text-gray-600">{instanceTitle}</span>

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
@@ -4,7 +4,7 @@ import { Check, FastForward, Loader2, Pause, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
-import { EngineIconPath } from "@/react/components/instance/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import {
@@ -603,7 +603,6 @@ function IssueDetailDatabaseTarget({ target }: { target: string }) {
     )
   );
   const instance = database.instanceResource;
-  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
   const { databaseName } = extractDatabaseResourceName(target);
   const instanceTitle =
     instance?.title ||
@@ -612,8 +611,11 @@ function IssueDetailDatabaseTarget({ target }: { target: string }) {
 
   return (
     <div className="flex min-w-0 items-center truncate text-sm">
-      {engineIcon && (
-        <img alt="" className="mr-1 inline-block h-4 w-4" src={engineIcon} />
+      {instance && (
+        <EngineIcon
+          engine={instance.engine}
+          className="mr-1 inline-block h-4 w-4"
+        />
       )}
       <span className="mr-1 truncate text-gray-400">{environment.title}</span>
       <span className="truncate text-gray-600">{instanceTitle}</span>

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
@@ -3,7 +3,7 @@ import { DurationSchema } from "@bufbuild/protobuf/wkt";
 import { Check, Minus } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/react/components/instance/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
 import {
   Table,
@@ -321,7 +321,6 @@ function IssueDetailTaskRunDatabaseCell({ database }: { database: Database }) {
     )
   );
   const instance = database.instanceResource;
-  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
   const { databaseName } = extractDatabaseResourceName(database.name);
   const instanceTitle =
     instance?.title ||
@@ -330,8 +329,11 @@ function IssueDetailTaskRunDatabaseCell({ database }: { database: Database }) {
 
   return (
     <div className="flex min-w-0 items-center truncate text-sm">
-      {engineIcon && (
-        <img alt="" className="mr-1 inline-block h-4 w-4" src={engineIcon} />
+      {instance && (
+        <EngineIcon
+          engine={instance.engine}
+          className="mr-1 inline-block h-4 w-4"
+        />
       )}
       <span className="mr-1 truncate text-gray-400">{environment.title}</span>
       <span className="truncate text-gray-600">{instanceTitle}</span>

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -16,8 +16,8 @@ import {
   instanceRoleServiceClientConnect,
   planServiceClientConnect,
 } from "@/connect";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
-import { EngineIconPath } from "@/react/components/instance/constants";
 import { Alert } from "@/react/components/ui/alert";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
@@ -1486,12 +1486,8 @@ function DatabaseSelector({
                     </td>
                     <td className="py-2 pr-4">
                       <div className="flex items-center gap-x-1.5">
-                        {inst && EngineIconPath[inst.engine] && (
-                          <img
-                            className="size-4 shrink-0"
-                            src={EngineIconPath[inst.engine]}
-                            alt=""
-                          />
+                        {inst && (
+                          <EngineIcon engine={inst.engine} className="size-4" />
                         )}
                         <span>{databaseName}</span>
                       </div>
@@ -1633,11 +1629,7 @@ export function DatabaseTarget({
 
   return (
     <div className="flex min-w-0 items-center truncate text-sm">
-      <img
-        alt=""
-        className="mr-1 h-4 w-4 shrink-0"
-        src={EngineIconPath[instance.engine]}
-      />
+      <EngineIcon engine={instance.engine} className="mr-1 h-4 w-4" />
       {showEnvironment && environment?.title && (
         <span className="mr-1 truncate text-control-placeholder">
           {environment.title}

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
@@ -4,7 +4,7 @@ import { Check, FastForward, Loader2, Pause, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
-import { EngineIconPath } from "@/react/components/instance/constants";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
@@ -613,7 +613,6 @@ function PlanDetailDatabaseTarget({ target }: { target: string }) {
       ""
   );
   const instance = database.instanceResource;
-  const engineIcon = instance ? EngineIconPath[instance.engine] : "";
   const { databaseName } = extractDatabaseResourceName(target);
   const instanceTitle =
     instance?.title ||
@@ -622,8 +621,11 @@ function PlanDetailDatabaseTarget({ target }: { target: string }) {
 
   return (
     <div className="flex min-w-0 items-center truncate text-sm">
-      {engineIcon && (
-        <img alt="" className="mr-1 inline-block h-4 w-4" src={engineIcon} />
+      {instance && (
+        <EngineIcon
+          engine={instance.engine}
+          className="mr-1 inline-block h-4 w-4"
+        />
       )}
       <span className="mr-1 truncate text-gray-400">{environment.title}</span>
       <span className="truncate text-gray-600">{instanceTitle}</span>

--- a/frontend/src/react/pages/settings/DatabasesPage.tsx
+++ b/frontend/src/react/pages/settings/DatabasesPage.tsx
@@ -3,7 +3,6 @@ import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import { Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
 import {
   AdvancedSearch,
   getValueFromScopes,
@@ -19,6 +18,7 @@ import {
   TransferProjectSheet,
 } from "@/react/components/database";
 import { EditEnvironmentSheet } from "@/react/components/EditEnvironmentSheet";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { Button } from "@/react/components/ui/button";
@@ -207,11 +207,7 @@ export function DatabasesPage() {
           custom: true,
           render: () => (
             <span className="inline-flex items-center gap-x-1.5">
-              <img
-                className="h-4 w-4 shrink-0"
-                src={EngineIconPath[engine]}
-                alt=""
-              />
+              <EngineIcon engine={engine} className="h-4 w-4" />
               <span>{engineNameV1(engine)}</span>
             </span>
           ),

--- a/frontend/src/react/pages/settings/InstanceDetailPage.tsx
+++ b/frontend/src/react/pages/settings/InstanceDetailPage.tsx
@@ -8,6 +8,7 @@ import {
   type ValueOption,
 } from "@/react/components/AdvancedSearch";
 import { DatabaseTable } from "@/react/components/database";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import {
   InstanceActionDropdown,
@@ -17,7 +18,6 @@ import {
   InstanceRoleTable,
   InstanceSyncButton,
 } from "@/react/components/instance";
-import { EngineIconPath } from "@/react/components/instance/constants";
 import { Alert } from "@/react/components/ui/alert";
 import {
   Tabs,
@@ -182,8 +182,6 @@ export function InstanceDetailPage({ instanceId }: { instanceId: string }) {
     }
   }, []);
 
-  const engineIconSrc = EngineIconPath[instance.engine];
-
   return (
     <div className="p-4 flex flex-col gap-y-2">
       {/* Archive banner */}
@@ -203,9 +201,7 @@ export function InstanceDetailPage({ instanceId }: { instanceId: string }) {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-x-2">
-          {engineIconSrc && (
-            <img src={engineIconSrc} alt="" className="h-6 w-6" />
-          )}
+          <EngineIcon engine={instance.engine} className="h-6 w-6" />
           <span className="text-lg font-medium">
             {instanceV1Name(instance)}
           </span>

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -12,13 +12,13 @@ import {
 import type { RefObject } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { EngineIconPath } from "@/components/InstanceForm/constants";
 import {
   AdvancedSearch,
   getValueFromScopes,
   type ScopeOption,
   type SearchParams,
 } from "@/react/components/AdvancedSearch";
+import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { InstanceAssignmentSheet } from "@/react/components/InstanceAssignmentSheet";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
@@ -712,11 +712,7 @@ export function InstancesPage() {
           custom: true,
           render: () => (
             <span className="inline-flex items-center gap-x-1.5">
-              <img
-                className="h-4 w-4 shrink-0"
-                src={EngineIconPath[engine]}
-                alt=""
-              />
+              <EngineIcon engine={engine} className="h-4 w-4" />
               <span>{engineNameV1(engine)}</span>
             </span>
           ),
@@ -1273,10 +1269,9 @@ export function InstancesPage() {
                       </td>
                       <td className="px-4 py-2">
                         <div className="flex items-center gap-x-2 min-w-0">
-                          <img
-                            className="h-5 w-5 shrink-0"
-                            src={EngineIconPath[instance.engine]}
-                            alt=""
+                          <EngineIcon
+                            engine={instance.engine}
+                            className="h-5 w-5"
                           />
                           <EllipsisText text={instance.title} />
                         </div>


### PR DESCRIPTION
## Summary
- Add a shared React `EngineIcon` component that centralizes engine logo rendering.
- Replace scattered raw engine logo `<img>` usage so database engine icons keep their original aspect ratio.

## Key Changes
- Render engine logos through `EngineIcon`, which applies `object-contain` consistently.
- Update instance, database, SQL editor, project, issue, and settings surfaces to use the shared component.
- Preserve existing fallback behavior for missing engine icons, including the SQL editor unlink icon.

## Motivation
- Fixes BYT-9343 where non-square engine logos, especially MongoDB, were stretched by fixed square image boxes.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`