### PR TITLE
fix(frontend): resizable columns on instance and database tables

### DIFF
--- a/frontend/src/react/components/AuditLogTable.tsx
+++ b/frontend/src/react/components/AuditLogTable.tsx
@@ -22,6 +22,7 @@ import {
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { TimeRangePicker } from "@/react/components/TimeRangePicker";
 import { Button } from "@/react/components/ui/button";
+import { ColumnResizeHandle } from "@/react/components/ui/column-resize-handle";
 import {
   Dialog,
   DialogContent,
@@ -29,6 +30,7 @@ import {
 } from "@/react/components/ui/dialog";
 import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
 import { usePlanFeature } from "@/react/hooks/useAppState";
+import { useColumnWidths } from "@/react/hooks/useColumnWidths";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
 import {
   getPageSizeOptions,
@@ -443,61 +445,6 @@ function useColumnDefs(): ColumnDef[] {
 }
 
 // ============================================================
-// useColumnWidths
-// ============================================================
-
-function useColumnWidths(columns: ColumnDef[]) {
-  const [widths, setWidths] = useState<number[]>(() =>
-    columns.map((c) => c.defaultWidth)
-  );
-  const dragRef = useRef<{
-    colIndex: number;
-    startX: number;
-    startWidth: number;
-  } | null>(null);
-
-  const onMouseDown = useCallback(
-    (colIndex: number, e: React.MouseEvent) => {
-      e.preventDefault();
-      e.stopPropagation();
-      dragRef.current = {
-        colIndex,
-        startX: e.clientX,
-        startWidth: widths[colIndex],
-      };
-
-      const onMouseMove = (ev: MouseEvent) => {
-        if (!dragRef.current) return;
-        const delta = ev.clientX - dragRef.current.startX;
-        const min = columns[dragRef.current.colIndex].minWidth ?? 40;
-        const newWidth = Math.max(min, dragRef.current.startWidth + delta);
-        setWidths((prev) => {
-          const next = [...prev];
-          next[dragRef.current!.colIndex] = newWidth;
-          return next;
-        });
-      };
-      const onMouseUp = () => {
-        dragRef.current = null;
-        document.removeEventListener("mousemove", onMouseMove);
-        document.removeEventListener("mouseup", onMouseUp);
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-      };
-      document.addEventListener("mousemove", onMouseMove);
-      document.addEventListener("mouseup", onMouseUp);
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-    },
-    [widths, columns]
-  );
-
-  const totalWidth = widths.reduce((sum, w) => sum + w, 0);
-
-  return { widths, totalWidth, onResizeStart: onMouseDown };
-}
-
-// ============================================================
 // AuditLogTable — shared component
 // ============================================================
 
@@ -813,8 +760,7 @@ export function AuditLogTable({
                         {col.sortable && renderSortIndicator(col.key)}
                       </div>
                       {col.resizable && (
-                        <div
-                          className="absolute right-0 top-1/4 h-1/2 w-[3px] cursor-col-resize rounded-full bg-control-bg-hover hover:bg-accent/60 active:bg-accent transition-colors"
+                        <ColumnResizeHandle
                           onMouseDown={(e) => onResizeStart(colIdx, e)}
                         />
                       )}

--- a/frontend/src/react/components/database/DatabaseTable.tsx
+++ b/frontend/src/react/components/database/DatabaseTable.tsx
@@ -12,12 +12,14 @@ import {
   TableHeader,
   TableRow,
 } from "@/react/components/ui/table";
+import { useColumnWidths } from "@/react/hooks/useColumnWidths";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
 import {
   getPageSizeOptions,
   useSessionPageSize,
 } from "@/react/hooks/useSessionPageSize";
 import { useVueState } from "@/react/hooks/useVueState";
+import { cn } from "@/react/lib/utils";
 import { router } from "@/router";
 import { useActuatorV1Store, useDatabaseV1Store } from "@/store";
 import type { DatabaseFilter } from "@/store/modules/v1/database";
@@ -43,6 +45,18 @@ export interface DatabaseTableProps {
   selectedNames?: Set<string>;
   onSelectedNamesChange?: (names: Set<string>) => void;
   refreshToken?: number;
+}
+
+interface DatabaseColumn {
+  key: string;
+  title: React.ReactNode;
+  defaultWidth: number;
+  minWidth?: number;
+  resizable?: boolean;
+  sortable?: boolean;
+  sortKey?: string;
+  cellClassName?: string;
+  render: (database: Database) => React.ReactNode;
 }
 
 export function DatabaseTable({
@@ -208,70 +222,181 @@ export function DatabaseTable({
   const pageSizeOptions = getPageSizeOptions();
   const showProjectColumn = mode === "ALL";
 
+  const columns: DatabaseColumn[] = [];
+  if (showSelection) {
+    columns.push({
+      key: "select",
+      title: (
+        <input
+          ref={headerCheckboxRef}
+          type="checkbox"
+          checked={allSelected}
+          onChange={toggleSelectAll}
+          className="rounded-xs border-control-border"
+        />
+      ),
+      defaultWidth: 48,
+      render: (db) => (
+        <input
+          type="checkbox"
+          checked={selectedNames?.has(db.name) ?? false}
+          onChange={() => toggleSelection(db.name)}
+          onClick={(e) => e.stopPropagation()}
+          className="rounded-xs border-control-border"
+        />
+      ),
+    });
+  }
+  columns.push({
+    key: "name",
+    title: t("common.name"),
+    defaultWidth: 280,
+    minWidth: 160,
+    resizable: true,
+    sortable: true,
+    sortKey: "name",
+    render: (db) => {
+      const instanceResource = getInstanceResource(db);
+      return (
+        <div className="flex items-center gap-x-2">
+          <EngineIcon engine={instanceResource.engine} className="h-5 w-5" />
+          <span className="truncate">
+            {extractDatabaseResourceName(db.name).databaseName}
+          </span>
+        </div>
+      );
+    },
+  });
+  columns.push({
+    key: "environment",
+    title: t("common.environment"),
+    defaultWidth: 200,
+    minWidth: 120,
+    resizable: true,
+    render: (db) => (
+      <EnvironmentLabel environmentName={getDatabaseEnvironment(db).name} />
+    ),
+  });
+  if (showProjectColumn) {
+    columns.push({
+      key: "project",
+      title: t("common.project"),
+      defaultWidth: 200,
+      minWidth: 120,
+      resizable: true,
+      sortable: true,
+      sortKey: "project",
+      render: (db) => (
+        <span className="truncate">
+          {extractProjectResourceName(getDatabaseProject(db).name)}
+        </span>
+      ),
+    });
+  } else {
+    columns.push({
+      key: "release",
+      title: t("common.release"),
+      defaultWidth: 140,
+      minWidth: 80,
+      resizable: true,
+      render: (db) => (
+        <span className="truncate">
+          {db.release ? extractReleaseUID(db.release) : "-"}
+        </span>
+      ),
+    });
+  }
+  columns.push({
+    key: "instance",
+    title: t("common.instance"),
+    defaultWidth: 240,
+    minWidth: 120,
+    resizable: true,
+    sortable: true,
+    sortKey: "instance",
+    render: (db) => (
+      <span className="block truncate">{getInstanceResource(db).title}</span>
+    ),
+  });
+  columns.push({
+    key: "address",
+    title: t("common.address"),
+    defaultWidth: 240,
+    minWidth: 150,
+    resizable: true,
+    render: (db) => (
+      <span className="truncate">
+        {hostPortOfInstanceV1(getInstanceResource(db))}
+      </span>
+    ),
+  });
+  columns.push({
+    key: "labels",
+    title: t("common.labels"),
+    defaultWidth: 240,
+    minWidth: 150,
+    resizable: true,
+    render: (db) => <LabelsDisplay labels={db.labels} />,
+  });
+  columns.push({
+    key: "status",
+    title: t("common.status"),
+    defaultWidth: 80,
+    cellClassName: "whitespace-nowrap",
+    render: (db) =>
+      db.syncStatus === SyncStatus.FAILED ? (
+        <span title={db.syncError || t("database.sync-status-failed")}>
+          <XCircle className="w-4 h-4 text-error" />
+        </span>
+      ) : (
+        <CheckCircle className="w-4 h-4 text-success" />
+      ),
+  });
+
+  const { widths, totalWidth, onResizeStart } = useColumnWidths(columns);
+
   return (
     <>
       <div className="border rounded-sm">
         <div className="overflow-x-auto">
-          <Table className="min-w-[800px]">
+          <Table className="table-fixed" style={{ width: `${totalWidth}px` }}>
+            <colgroup>
+              {widths.map((w, i) => (
+                <col key={columns[i].key} style={{ width: `${w}px` }} />
+              ))}
+            </colgroup>
             <TableHeader>
               <TableRow className="bg-gray-50">
-                {showSelection && (
-                  <TableHead className="w-12">
-                    <input
-                      ref={headerCheckboxRef}
-                      type="checkbox"
-                      checked={allSelected}
-                      onChange={toggleSelectAll}
-                      className="rounded-xs border-control-border"
-                    />
-                  </TableHead>
-                )}
-                <TableHead
-                  sortable
-                  sortActive={sortKey === "name"}
-                  sortDir={sortOrder}
-                  onSort={() => toggleSort("name")}
-                >
-                  {t("common.name")}
-                </TableHead>
-                <TableHead>{t("common.environment")}</TableHead>
-                {!showProjectColumn && (
-                  <TableHead>{t("common.release")}</TableHead>
-                )}
-                {showProjectColumn && (
+                {columns.map((col, colIdx) => (
                   <TableHead
-                    sortable
-                    sortActive={sortKey === "project"}
+                    key={col.key}
+                    sortable={col.sortable}
+                    sortActive={
+                      col.sortable && sortKey === (col.sortKey ?? col.key)
+                    }
                     sortDir={sortOrder}
-                    onSort={() => toggleSort("project")}
+                    onSort={
+                      col.sortable
+                        ? () => toggleSort(col.sortKey ?? col.key)
+                        : undefined
+                    }
+                    resizable={col.resizable}
+                    onResizeStart={
+                      col.resizable
+                        ? (e) => onResizeStart(colIdx, e)
+                        : undefined
+                    }
                   >
-                    {t("common.project")}
+                    {col.title}
                   </TableHead>
-                )}
-                <TableHead
-                  sortable
-                  sortActive={sortKey === "instance"}
-                  sortDir={sortOrder}
-                  onSort={() => toggleSort("instance")}
-                >
-                  {t("common.instance")}
-                </TableHead>
-                <TableHead className="hidden md:table-cell">
-                  {t("common.address")}
-                </TableHead>
-                <TableHead className="hidden md:table-cell">
-                  {t("common.labels")}
-                </TableHead>
-                <TableHead className="whitespace-nowrap">
-                  {t("common.status")}
-                </TableHead>
+                ))}
               </TableRow>
             </TableHeader>
             <TableBody>
               {loading && databases.length === 0 ? (
                 <TableRow>
                   <TableCell
-                    colSpan={8}
+                    colSpan={columns.length}
                     className="py-8 text-center text-control-placeholder"
                   >
                     <div className="flex items-center justify-center gap-x-2">
@@ -283,94 +408,29 @@ export function DatabaseTable({
               ) : databases.length === 0 ? (
                 <TableRow>
                   <TableCell
-                    colSpan={8}
+                    colSpan={columns.length}
                     className="py-8 text-center text-control-placeholder"
                   >
                     {t("common.no-data")}
                   </TableCell>
                 </TableRow>
               ) : (
-                databases.map((db) => {
-                  const isSelected = selectedNames?.has(db.name) ?? false;
-                  const instanceResource = getInstanceResource(db);
-                  return (
-                    <TableRow
-                      key={db.name}
-                      className="cursor-pointer"
-                      onClick={(e) => handleRowClick(db, e)}
-                    >
-                      {showSelection && (
-                        <TableCell className="w-12">
-                          <input
-                            type="checkbox"
-                            checked={isSelected}
-                            onChange={() => toggleSelection(db.name)}
-                            onClick={(e) => e.stopPropagation()}
-                            className="rounded-xs border-control-border"
-                          />
-                        </TableCell>
-                      )}
-                      <TableCell>
-                        <div className="flex items-center gap-x-2">
-                          <EngineIcon
-                            engine={instanceResource.engine}
-                            className="h-5 w-5"
-                          />
-                          <span className="truncate">
-                            {extractDatabaseResourceName(db.name).databaseName}
-                          </span>
-                        </div>
+                databases.map((db) => (
+                  <TableRow
+                    key={db.name}
+                    className="cursor-pointer"
+                    onClick={(e) => handleRowClick(db, e)}
+                  >
+                    {columns.map((col) => (
+                      <TableCell
+                        key={col.key}
+                        className={cn("overflow-hidden", col.cellClassName)}
+                      >
+                        {col.render(db)}
                       </TableCell>
-                      <TableCell>
-                        <EnvironmentLabel
-                          environmentName={getDatabaseEnvironment(db).name}
-                        />
-                      </TableCell>
-                      {!showProjectColumn && (
-                        <TableCell>
-                          <span className="truncate">
-                            {db.release ? extractReleaseUID(db.release) : "-"}
-                          </span>
-                        </TableCell>
-                      )}
-                      {showProjectColumn && (
-                        <TableCell>
-                          <span className="truncate">
-                            {extractProjectResourceName(
-                              getDatabaseProject(db).name
-                            )}
-                          </span>
-                        </TableCell>
-                      )}
-                      <TableCell className="max-w-[200px]">
-                        <span className="block truncate">
-                          {instanceResource.title}
-                        </span>
-                      </TableCell>
-                      <TableCell className="hidden md:table-cell">
-                        <span className="truncate">
-                          {hostPortOfInstanceV1(instanceResource)}
-                        </span>
-                      </TableCell>
-                      <TableCell className="hidden md:table-cell">
-                        <LabelsDisplay labels={db.labels} />
-                      </TableCell>
-                      <TableCell>
-                        {db.syncStatus === SyncStatus.FAILED ? (
-                          <span
-                            title={
-                              db.syncError || t("database.sync-status-failed")
-                            }
-                          >
-                            <XCircle className="w-4 h-4 text-error" />
-                          </span>
-                        ) : (
-                          <CheckCircle className="w-4 h-4 text-success" />
-                        )}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })
+                    ))}
+                  </TableRow>
+                ))
               )}
             </TableBody>
           </Table>

--- a/frontend/src/react/components/ui/column-resize-handle.tsx
+++ b/frontend/src/react/components/ui/column-resize-handle.tsx
@@ -1,0 +1,25 @@
+import { cn } from "@/react/lib/utils";
+
+interface ColumnResizeHandleProps {
+  onMouseDown: (e: React.MouseEvent) => void;
+  className?: string;
+}
+
+/**
+ * Drag affordance for resizing a table column. Designed to be absolutely
+ * positioned inside a `relative` `<th>`.
+ */
+export function ColumnResizeHandle({
+  onMouseDown,
+  className,
+}: ColumnResizeHandleProps) {
+  return (
+    <div
+      className={cn(
+        "absolute right-0 top-1/4 h-1/2 w-[3px] cursor-col-resize rounded-full bg-control-bg-hover hover:bg-accent/60 active:bg-accent transition-colors",
+        className
+      )}
+      onMouseDown={onMouseDown}
+    />
+  );
+}

--- a/frontend/src/react/components/ui/column-resize-handle.tsx
+++ b/frontend/src/react/components/ui/column-resize-handle.tsx
@@ -20,6 +20,7 @@ export function ColumnResizeHandle({
         className
       )}
       onMouseDown={onMouseDown}
+      onClick={(e) => e.stopPropagation()}
     />
   );
 }

--- a/frontend/src/react/components/ui/table.tsx
+++ b/frontend/src/react/components/ui/table.tsx
@@ -1,5 +1,6 @@
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import type { ComponentPropsWithoutRef } from "react";
+import { ColumnResizeHandle } from "@/react/components/ui/column-resize-handle";
 import { cn } from "@/react/lib/utils";
 
 function Table({ className, ...props }: ComponentPropsWithoutRef<"table">) {
@@ -64,6 +65,10 @@ interface TableHeadProps extends ComponentPropsWithoutRef<"th"> {
   sortDir?: TableHeadSortDirection;
   /** Called when the user clicks to toggle sort. */
   onSort?: () => void;
+  /** Render a drag-to-resize handle on the right edge. */
+  resizable?: boolean;
+  /** Called when the user starts dragging the resize handle. */
+  onResizeStart?: (e: React.MouseEvent) => void;
 }
 
 function TableHead({
@@ -73,6 +78,8 @@ function TableHead({
   sortActive,
   sortDir,
   onSort,
+  resizable,
+  onResizeStart,
   onClick,
   ...props
 }: TableHeadProps) {
@@ -81,6 +88,7 @@ function TableHead({
       className={cn(
         "h-10 px-4 py-2 text-left align-middle font-medium text-control-light",
         sortable && "cursor-pointer select-none hover:text-control",
+        resizable && "relative",
         className
       )}
       onClick={(e) => {
@@ -96,6 +104,9 @@ function TableHead({
         </span>
       ) : (
         children
+      )}
+      {resizable && onResizeStart && (
+        <ColumnResizeHandle onMouseDown={onResizeStart} />
       )}
     </th>
   );

--- a/frontend/src/react/hooks/useColumnWidths.ts
+++ b/frontend/src/react/hooks/useColumnWidths.ts
@@ -1,0 +1,64 @@
+import { useCallback, useRef, useState } from "react";
+
+export interface ColumnWithWidth {
+  defaultWidth: number;
+  minWidth?: number;
+}
+
+/**
+ * Tracks per-column widths for a `table-fixed` table and exposes a mouse
+ * handler to start a drag-to-resize gesture on a column header. State is
+ * positional: `widths[i]` corresponds to `columns[i]`.
+ *
+ * Widths are not persisted across remounts.
+ */
+export function useColumnWidths<T extends ColumnWithWidth>(columns: T[]) {
+  const [widths, setWidths] = useState<number[]>(() =>
+    columns.map((c) => c.defaultWidth)
+  );
+  const dragRef = useRef<{
+    colIndex: number;
+    startX: number;
+    startWidth: number;
+  } | null>(null);
+
+  const onResizeStart = useCallback(
+    (colIndex: number, e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dragRef.current = {
+        colIndex,
+        startX: e.clientX,
+        startWidth: widths[colIndex],
+      };
+
+      const onMouseMove = (ev: MouseEvent) => {
+        if (!dragRef.current) return;
+        const delta = ev.clientX - dragRef.current.startX;
+        const min = columns[dragRef.current.colIndex].minWidth ?? 40;
+        const newWidth = Math.max(min, dragRef.current.startWidth + delta);
+        setWidths((prev) => {
+          const next = [...prev];
+          next[dragRef.current!.colIndex] = newWidth;
+          return next;
+        });
+      };
+      const onMouseUp = () => {
+        dragRef.current = null;
+        document.removeEventListener("mousemove", onMouseMove);
+        document.removeEventListener("mouseup", onMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [widths, columns]
+  );
+
+  const totalWidth = widths.reduce((sum, w) => sum + w, 0);
+
+  return { widths, totalWidth, onResizeStart };
+}

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -34,6 +34,7 @@ import {
   AlertDialogTitle,
 } from "@/react/components/ui/alert-dialog";
 import { Button } from "@/react/components/ui/button";
+import { ColumnResizeHandle } from "@/react/components/ui/column-resize-handle";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -49,6 +50,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
+import { useColumnWidths } from "@/react/hooks/useColumnWidths";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
 import {
   getPageSizeOptions,
@@ -93,6 +95,18 @@ import {
 
 const ASSIGN_LICENSE_QUERY = "assignLicense";
 const ASSIGN_LICENSE_INSTANCES_QUERY = "instances";
+
+interface InstanceColumn {
+  key: string;
+  title: React.ReactNode;
+  defaultWidth: number;
+  minWidth?: number;
+  resizable?: boolean;
+  sortable?: boolean;
+  sortKey?: string;
+  cellClassName?: string;
+  render: (instance: Instance) => React.ReactNode;
+}
 
 // Shared hooks
 // ============================================================
@@ -1118,6 +1132,123 @@ export function InstancesPage() {
   }, [someSelected]);
   const pageSizeOptions = getPageSizeOptions();
 
+  const columns: InstanceColumn[] = [
+    {
+      key: "select",
+      title: (
+        <input
+          ref={headerCheckboxRef}
+          type="checkbox"
+          checked={allSelected}
+          onChange={toggleSelectAll}
+          className="rounded-xs border-control-border"
+        />
+      ),
+      defaultWidth: 48,
+      cellClassName: "px-4 py-2",
+      render: (instance) => (
+        <input
+          type="checkbox"
+          checked={selectedNames.has(instance.name)}
+          onChange={() => toggleSelection(instance.name)}
+          onClick={(e) => e.stopPropagation()}
+          className="rounded-xs border-control-border"
+        />
+      ),
+    },
+    {
+      key: "title",
+      title: t("common.name"),
+      defaultWidth: 280,
+      minWidth: 160,
+      resizable: true,
+      sortable: true,
+      render: (instance) => (
+        <div className="flex items-center gap-x-2 min-w-0">
+          <EngineIcon engine={instance.engine} className="h-5 w-5" />
+          <EllipsisText text={instance.title} />
+        </div>
+      ),
+    },
+    {
+      key: "environment",
+      title: t("common.environment"),
+      defaultWidth: 220,
+      minWidth: 120,
+      resizable: true,
+      sortable: true,
+      render: (instance) => (
+        <EnvironmentName environmentName={instance.environment ?? ""} />
+      ),
+    },
+    {
+      key: "address",
+      title: t("common.address"),
+      defaultWidth: 280,
+      minWidth: 150,
+      resizable: true,
+      render: (instance) => {
+        const isExpanded = expandedDataSources.has(instance.name);
+        const hasMultipleDS = instance.dataSources.length > 1;
+        return (
+          <div className="flex items-start gap-x-2">
+            <span className="truncate">
+              {isExpanded
+                ? instance.dataSources.map((ds, idx) => (
+                    <div key={idx}>{hostPortOfDataSource(ds)}</div>
+                  ))
+                : hostPortOfInstanceV1(instance)}
+            </span>
+            {hasMultipleDS && (
+              <button
+                className="p-0.5 hover:bg-control-bg rounded-xs shrink-0"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleDataSource(instance.name);
+                }}
+              >
+                {isExpanded ? (
+                  <ChevronUp className="w-4 h-4" />
+                ) : (
+                  <ChevronDown className="w-4 h-4" />
+                )}
+              </button>
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      key: "labels",
+      title: t("common.labels"),
+      defaultWidth: 240,
+      minWidth: 150,
+      resizable: true,
+      render: (instance) => <LabelsDisplay labels={instance.labels} />,
+    },
+    {
+      key: "license",
+      title: t("subscription.instance-assignment.license"),
+      defaultWidth: 100,
+      render: (instance) => (instance.activation ? "Y" : ""),
+    },
+    {
+      key: "actions",
+      title: "",
+      defaultWidth: 50,
+      render: (instance) => (
+        <div className="flex justify-end" onClick={(e) => e.stopPropagation()}>
+          <InstanceActionDropdown
+            instance={instance}
+            onAction={handleRowAction}
+          />
+        </div>
+      ),
+    },
+  ];
+
+  const { widths, totalWidth, onResizeStart } = useColumnWidths(columns);
+
   return (
     <div className="py-4 flex flex-col">
       {/* Instance count warning */}
@@ -1179,53 +1310,49 @@ export function InstancesPage() {
       {/* Table */}
       <div className="border rounded-sm">
         <div className="overflow-x-auto">
-          <table className="w-full text-sm min-w-[900px]">
+          <table
+            className="text-sm table-fixed"
+            style={{ width: `${totalWidth}px` }}
+          >
+            <colgroup>
+              {widths.map((w, i) => (
+                <col key={columns[i].key} style={{ width: `${w}px` }} />
+              ))}
+            </colgroup>
             <thead>
               <tr className="bg-control-bg border-b border-control-border">
-                <th className="w-12 px-4 py-2">
-                  <input
-                    ref={headerCheckboxRef}
-                    type="checkbox"
-                    checked={allSelected}
-                    onChange={toggleSelectAll}
-                    className="rounded-xs border-control-border"
-                  />
-                </th>
-                <th
-                  className="px-4 py-2 text-left font-medium min-w-[200px] cursor-pointer select-none"
-                  onClick={() => toggleSort("title")}
-                >
-                  <div className="flex items-center gap-x-1">
-                    {t("common.name")}
-                    {renderSortIndicator("title")}
-                  </div>
-                </th>
-                <th
-                  className="px-4 py-2 text-left font-medium min-w-[200px] cursor-pointer select-none"
-                  onClick={() => toggleSort("environment")}
-                >
-                  <div className="flex items-center gap-x-2 text-sm text-main">
-                    {t("common.environment")}
-                    {renderSortIndicator("environment")}
-                  </div>
-                </th>
-                <th className="px-4 py-2 text-left font-medium">
-                  {t("common.address")}
-                </th>
-                <th className="px-4 py-2 text-left font-medium min-w-[240px] hidden md:table-cell">
-                  {t("common.labels")}
-                </th>
-                <th className="px-4 py-2 text-left font-medium w-[100px]">
-                  {t("subscription.instance-assignment.license")}
-                </th>
-                <th className="w-[50px]" />
+                {columns.map((col, colIdx) => (
+                  <th
+                    key={col.key}
+                    className={cn(
+                      "relative px-4 py-2 text-left font-medium",
+                      col.sortable && "cursor-pointer select-none"
+                    )}
+                    onClick={
+                      col.sortable
+                        ? () => toggleSort(col.sortKey ?? col.key)
+                        : undefined
+                    }
+                  >
+                    <div className="flex items-center gap-x-1">
+                      {col.title}
+                      {col.sortable &&
+                        renderSortIndicator(col.sortKey ?? col.key)}
+                    </div>
+                    {col.resizable && (
+                      <ColumnResizeHandle
+                        onMouseDown={(e) => onResizeStart(colIdx, e)}
+                      />
+                    )}
+                  </th>
+                ))}
               </tr>
             </thead>
             <tbody>
               {loading && instances.length === 0 ? (
                 <tr>
                   <td
-                    colSpan={7}
+                    colSpan={columns.length}
                     className="px-4 py-8 text-center text-control-placeholder"
                   >
                     <div className="flex items-center justify-center gap-x-2">
@@ -1237,98 +1364,35 @@ export function InstancesPage() {
               ) : instances.length === 0 ? (
                 <tr>
                   <td
-                    colSpan={7}
+                    colSpan={columns.length}
                     className="px-4 py-8 text-center text-control-placeholder"
                   >
                     {t("common.no-data")}
                   </td>
                 </tr>
               ) : (
-                instances.map((instance, i) => {
-                  const isSelected = selectedNames.has(instance.name);
-                  const isExpanded = expandedDataSources.has(instance.name);
-                  const hasMultipleDS = instance.dataSources.length > 1;
-
-                  return (
-                    <tr
-                      key={instance.name}
-                      className={cn(
-                        "border-b last:border-b-0 cursor-pointer hover:bg-control-bg",
-                        i % 2 === 1 && "bg-control-bg/50"
-                      )}
-                      onClick={(e) => handleRowClick(instance, e)}
-                    >
-                      <td className="w-12 px-4 py-2">
-                        <input
-                          type="checkbox"
-                          checked={isSelected}
-                          onChange={() => toggleSelection(instance.name)}
-                          onClick={(e) => e.stopPropagation()}
-                          className="rounded-xs border-control-border"
-                        />
+                instances.map((instance, i) => (
+                  <tr
+                    key={instance.name}
+                    className={cn(
+                      "border-b last:border-b-0 cursor-pointer hover:bg-control-bg",
+                      i % 2 === 1 && "bg-control-bg/50"
+                    )}
+                    onClick={(e) => handleRowClick(instance, e)}
+                  >
+                    {columns.map((col) => (
+                      <td
+                        key={col.key}
+                        className={cn(
+                          "px-4 py-2 align-middle overflow-hidden",
+                          col.cellClassName
+                        )}
+                      >
+                        {col.render(instance)}
                       </td>
-                      <td className="px-4 py-2">
-                        <div className="flex items-center gap-x-2 min-w-0">
-                          <EngineIcon
-                            engine={instance.engine}
-                            className="h-5 w-5"
-                          />
-                          <EllipsisText text={instance.title} />
-                        </div>
-                      </td>
-                      <td className="px-4 py-2">
-                        <EnvironmentName
-                          environmentName={instance.environment ?? ""}
-                        />
-                      </td>
-                      <td className="px-4 py-2">
-                        <div className="flex items-start gap-x-2">
-                          <span className="truncate">
-                            {isExpanded
-                              ? instance.dataSources.map((ds, idx) => (
-                                  <div key={idx}>
-                                    {hostPortOfDataSource(ds)}
-                                  </div>
-                                ))
-                              : hostPortOfInstanceV1(instance)}
-                          </span>
-                          {hasMultipleDS && (
-                            <button
-                              className="p-0.5 hover:bg-control-bg rounded-xs shrink-0"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                toggleDataSource(instance.name);
-                              }}
-                            >
-                              {isExpanded ? (
-                                <ChevronUp className="w-4 h-4" />
-                              ) : (
-                                <ChevronDown className="w-4 h-4" />
-                              )}
-                            </button>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-4 py-2 hidden md:table-cell">
-                        <LabelsDisplay labels={instance.labels} />
-                      </td>
-                      <td className="px-4 py-2">
-                        {instance.activation ? "Y" : ""}
-                      </td>
-                      <td className="px-4 py-2">
-                        <div
-                          className="flex justify-end"
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <InstanceActionDropdown
-                            instance={instance}
-                            onAction={handleRowAction}
-                          />
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })
+                    ))}
+                  </tr>
+                ))
               )}
             </tbody>
           </table>


### PR DESCRIPTION
## Summary

Fixes [BYT-9353](https://linear.app/bytebase/issue/BYT-9353/the-long-instance-name-can-not-be-fully-displayed-in-instance-list): long instance/database names were truncated on the workspace instance and database list pages with no way for users to widen the column.

The instance and database tables now support **drag-to-resize** on content columns, matching the UX of the existing audit log table. The reporter explicitly asked for parity with that table.

## What changed

- Extracted the inline `useColumnWidths` hook from `AuditLogTable.tsx` into a shared hook at `frontend/src/react/hooks/useColumnWidths.ts`.
- Extracted the inline 3px drag-handle div into `<ColumnResizeHandle>` at `frontend/src/react/components/ui/column-resize-handle.tsx`.
- Added `resizable` + `onResizeStart` props to the shared `<TableHead>` shadcn wrapper, so any page using it can opt in.
- Refactored `InstancesPage.tsx` and `DatabaseTable.tsx` from hard-coded `<th>`/`<td>` markup to a column-defs array driven by `useColumnWidths`, with `<colgroup>` + `table-fixed`.
- `DatabaseTable.tsx` is shared by three pages (`/databases`, instance detail, project databases), so they all benefit.

NAME column default is now 280px (was a 200px min) and resizes down to 160px. Other content columns (environment, address, project, instance, labels) are also resizable.

Widths reset on reload — same as `AuditLogTable`. Persistence is a separate follow-up.

## Test plan

- [x] \`pnpm --dir frontend fix\` clean
- [x] \`pnpm --dir frontend type-check\` clean
- [x] \`pnpm --dir frontend test\` passes (174 files, 1725 tests)
- [x] \`pnpm --dir frontend check\` clean (eslint + biome + i18n + react-layering + locale-sort)
- [x] Verified locally on the workspace instance list page — drag-to-widen works on NAME and reveals long instance names
- [x] Verified locally on the workspace databases page — drag-to-widen works
- [ ] Reviewer: try resizing each content column; confirm row click navigation still works; confirm sort still works on title/environment/instance/project columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)