### PR TITLE
fix(pg): guard query span recursion

### DIFF
--- a/backend/plugin/parser/pg/query_span_loader_integration_test.go
+++ b/backend/plugin/parser/pg/query_span_loader_integration_test.go
@@ -2,7 +2,13 @@ package pg
 
 import (
 	"context"
+	"os"
+	"os/exec"
+	"runtime/debug"
 	"testing"
+
+	"github.com/bytebase/omni/pg/ast"
+	"github.com/bytebase/omni/pg/catalog"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
@@ -238,6 +244,224 @@ func TestLoaderIntegration_EnumWorksWhenDeclared(t *testing.T) {
 	}
 	mustHaveExactSource(t, span.Results[0], "tasks", "id")
 	mustHaveExactSource(t, span.Results[1], "tasks", "status")
+}
+
+func TestLoaderIntegration_CorrelatedRangeFunctionSubquery(t *testing.T) {
+	meta := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name: "public",
+			Tables: []*storepb.TableMetadata{
+				{
+					Name: "compliance_case_record_audits",
+					Columns: []*storepb.ColumnMetadata{
+						{Name: "case_id", Type: "text"},
+						{Name: "entity_id", Type: "text"},
+						{Name: "reason", Type: "text"},
+						{Name: "remark", Type: "text"},
+						{Name: "case_record", Type: "jsonb"},
+						{Name: "reviewer_by", Type: "text"},
+						{Name: "deleted_at", Type: "timestamptz"},
+					},
+				},
+				{
+					Name: "compliance_cases",
+					Columns: []*storepb.ColumnMetadata{
+						{Name: "case_id", Type: "text"},
+						{Name: "case_info", Type: "jsonb"},
+						{Name: "deleted_at", Type: "timestamptz"},
+					},
+				},
+			},
+		}},
+	}
+	sql := `
+select
+  a.case_id,
+  -- c.member_id,
+  a.entity_id as uid,
+  a.reason,
+  a.remark,
+  (
+    select elem->>'matchedDateTimeValue'
+    from jsonb_array_elements(a.case_record::jsonb->'secondaryFieldResults') elem
+    where elem->>'typeId' = '******'
+    limit 1
+  ) as wc_dob,
+  (
+    select elem->>'matchedValue'
+    from jsonb_array_elements(a.case_record::jsonb->'secondaryFieldResults') elem
+    where elem->>'typeId' = '******'
+    limit 1
+  ) as wc_citizenship,
+  c.case_info->>'birth_date' as kyc_dob,
+  c.case_info->>'nationality' as kyc_citizenship,
+  a.reviewer_by as review_by
+from compliance_case_record_audits a
+inner join compliance_cases c
+  on c.case_id = a.case_id and c.deleted_at is null
+where a.reviewer_by in ('****** ', '******')
+  and a.deleted_at is null;
+`
+	span := mustGetQuerySpan(t, meta, sql)
+	if len(span.Results) != 9 {
+		t.Fatalf("got %d results, want 9", len(span.Results))
+	}
+	mustHaveExactSource(t, span.Results[4], "compliance_case_record_audits", "case_record")
+	mustHaveExactSource(t, span.Results[5], "compliance_case_record_audits", "case_record")
+	mustHaveExactSource(t, span.Results[6], "compliance_cases", "case_info")
+	mustHaveExactSource(t, span.Results[7], "compliance_cases", "case_info")
+}
+
+func TestAppendQueryDoesNotMutateSharedStack(t *testing.T) {
+	outer := &catalog.Query{}
+	parent := &catalog.Query{}
+	current := &catalog.Query{}
+	nested := &catalog.Query{}
+	queryStack := []*catalog.Query{outer, parent, current}
+
+	nextStack := appendQuery(queryStack[:2], nested)
+
+	if queryStack[2] != current {
+		t.Fatalf("appendQuery mutated caller stack: got %p, want %p", queryStack[2], current)
+	}
+	if len(nextStack) != 3 || nextStack[2] != nested {
+		t.Fatalf("appendQuery returned unexpected stack: %+v", nextStack)
+	}
+}
+
+func TestLoaderIntegration_BuiltinFunctionSelfReferenceDoesNotOverflow(t *testing.T) {
+	if os.Getenv("BYTEBASE_TEST_FUNCTION_SELF_REFERENCE") == "1" {
+		debug.SetMaxStack(1 << 20)
+		varExpr := &catalog.VarExpr{RangeIdx: 0, AttNum: 1}
+		q := &catalog.Query{
+			TargetList: []*catalog.TargetEntry{{
+				Expr: varExpr,
+			}},
+			RangeTable: []*catalog.RangeTableEntry{{
+				Kind: catalog.RTEFunction,
+				FuncExprs: []catalog.AnalyzedExpr{&catalog.FuncCallExpr{
+					Args: []catalog.AnalyzedExpr{&catalog.OpExpr{
+						Left: varExpr,
+						Right: &catalog.ConstExpr{
+							Value: "items",
+						},
+					}},
+				}},
+			}},
+		}
+		extractor := newOmniQuerySpanExtractor(loaderTestDB, []string{loaderTestSchema}, base.GetQuerySpanContext{})
+		extractor.cat = catalog.New()
+		extractor.walkExpr(q, q.TargetList[0].Expr, make(base.SourceColumnSet))
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLoaderIntegration_BuiltinFunctionSelfReferenceDoesNotOverflow$")
+	cmd.Env = append(os.Environ(), "BYTEBASE_TEST_FUNCTION_SELF_REFERENCE=1")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("walkExpr overflowed on self-referential function RTE: %v\n%s", err, output)
+	}
+}
+
+func TestLoaderIntegration_PlainColumnCycleDoesNotOverflow(t *testing.T) {
+	if os.Getenv("BYTEBASE_TEST_PLAIN_COLUMN_CYCLE") == "1" {
+		debug.SetMaxStack(1 << 20)
+		varExpr := &catalog.VarExpr{RangeIdx: 0, AttNum: 1}
+		q := &catalog.Query{
+			TargetList: []*catalog.TargetEntry{{
+				Expr: varExpr,
+			}},
+			RangeTable: []*catalog.RangeTableEntry{{
+				Kind: catalog.RTESubquery,
+			}},
+		}
+		q.RangeTable[0].Subquery = q
+		_ = isUltimatelyPlainColumn(q, varExpr)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLoaderIntegration_PlainColumnCycleDoesNotOverflow$")
+	cmd.Env = append(os.Environ(), "BYTEBASE_TEST_PLAIN_COLUMN_CYCLE=1")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("isUltimatelyPlainColumn overflowed on cyclic subquery RTE: %v\n%s", err, output)
+	}
+}
+
+func TestLoaderIntegration_PredicateQueryCycleDoesNotOverflow(t *testing.T) {
+	if os.Getenv("BYTEBASE_TEST_PREDICATE_QUERY_CYCLE") == "1" {
+		debug.SetMaxStack(1 << 20)
+		q := &catalog.Query{}
+		q.CTEList = []*catalog.CommonTableExprQ{{Query: q}}
+		extractor := newOmniQuerySpanExtractor(loaderTestDB, []string{loaderTestSchema}, base.GetQuerySpanContext{})
+		analyzer := &plpgsqlAnalyzer{
+			extractor: extractor,
+			scope:     newVariableScope(nil),
+		}
+		analyzer.collectQueryPredicateColumns(q)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLoaderIntegration_PredicateQueryCycleDoesNotOverflow$")
+	cmd.Env = append(os.Environ(), "BYTEBASE_TEST_PREDICATE_QUERY_CYCLE=1")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("collectQueryPredicateColumns overflowed on cyclic query graph: %v\n%s", err, output)
+	}
+}
+
+func TestLoaderIntegration_SetOpQueryCycleDoesNotOverflow(t *testing.T) {
+	if os.Getenv("BYTEBASE_TEST_SET_OP_QUERY_CYCLE") == "1" {
+		debug.SetMaxStack(1 << 20)
+		q := &catalog.Query{SetOp: catalog.SetOpUnion}
+		q.LArg = q
+		q.RArg = &catalog.Query{TargetList: []*catalog.TargetEntry{{
+			Expr: &catalog.ConstExpr{
+				Value: "1",
+			},
+		}}}
+		selStmt := &ast.SelectStmt{}
+		selStmt.Larg = selStmt
+		selStmt.Rarg = &ast.SelectStmt{}
+		extractor := newOmniQuerySpanExtractor(loaderTestDB, []string{loaderTestSchema}, base.GetQuerySpanContext{})
+		extractor.extractLineage(q, selStmt)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLoaderIntegration_SetOpQueryCycleDoesNotOverflow$")
+	cmd.Env = append(os.Environ(), "BYTEBASE_TEST_SET_OP_QUERY_CYCLE=1")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("extractLineage overflowed on cyclic set-op query graph: %v\n%s", err, output)
+	}
+}
+
+func TestLoaderIntegration_FallbackCTECycleDoesNotOverflow(t *testing.T) {
+	if os.Getenv("BYTEBASE_TEST_FALLBACK_CTE_CYCLE") == "1" {
+		debug.SetMaxStack(1 << 20)
+		cteSel := &ast.SelectStmt{
+			TargetList: &ast.List{Items: []ast.Node{&ast.ResTarget{
+				Name: "x",
+				Val: &ast.ColumnRef{Fields: &ast.List{Items: []ast.Node{
+					&ast.String{Str: "c"},
+					&ast.String{Str: "x"},
+				}}},
+			}}},
+			FromClause: &ast.List{Items: []ast.Node{&ast.RangeVar{Relname: "c"}}},
+		}
+		extractor := newOmniQuerySpanExtractor(loaderTestDB, []string{loaderTestSchema}, base.GetQuerySpanContext{})
+		extractor.cat = catalog.New()
+		analyzer := &plpgsqlAnalyzer{
+			extractor: extractor,
+			scope:     newVariableScope(nil),
+			cteMap:    map[string]*ast.SelectStmt{"c": cteSel},
+		}
+		analyzer.resolveThroughCTE(cteSel, "x", nil, make(base.SourceColumnSet))
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestLoaderIntegration_FallbackCTECycleDoesNotOverflow$")
+	cmd.Env = append(os.Environ(), "BYTEBASE_TEST_FALLBACK_CTE_CYCLE=1")
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("resolveThroughCTE overflowed on cyclic fallback CTE: %v\n%s", err, output)
+	}
 }
 
 // ---------- helpers ----------

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -311,9 +311,22 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 // selStmt is the original parse tree, used to determine IsPlainField
 // (which is true only for columns that came from * expansion).
 func (e *omniQuerySpanExtractor) extractLineage(q *catalog.Query, selStmt *ast.SelectStmt) []base.QuerySpanResult {
+	return e.extractLineageWithVisited(q, selStmt, make(map[*catalog.Query]bool))
+}
+
+func (e *omniQuerySpanExtractor) extractLineageWithVisited(q *catalog.Query, selStmt *ast.SelectStmt, visited map[*catalog.Query]bool) []base.QuerySpanResult {
+	if q == nil {
+		return nil
+	}
+	if visited[q] {
+		return nil
+	}
+	visited[q] = true
+	defer delete(visited, q)
+
 	// Handle set operations (UNION/INTERSECT/EXCEPT).
 	if q.SetOp != catalog.SetOpNone {
-		return e.extractSetOpLineage(q, selStmt)
+		return e.extractSetOpLineageWithVisited(q, selStmt, visited)
 	}
 
 	// Build a plain-field mask from the parse tree's target list.
@@ -380,9 +393,24 @@ func (e *omniQuerySpanExtractor) extractLineage(q *catalog.Query, selStmt *ast.S
 // CTEs and subqueries, is a simple column reference (VarExpr pointing to a
 // physical table). Aggregates, functions, and other expressions return false.
 func isUltimatelyPlainColumn(q *catalog.Query, expr catalog.AnalyzedExpr) bool {
+	return isUltimatelyPlainColumnWithVisited(q, expr, make(map[queryExprKey]bool))
+}
+
+type queryExprKey struct {
+	query *catalog.Query
+	expr  catalog.AnalyzedExpr
+}
+
+func isUltimatelyPlainColumnWithVisited(q *catalog.Query, expr catalog.AnalyzedExpr, visited map[queryExprKey]bool) bool {
 	if expr == nil {
 		return false
 	}
+	key := queryExprKey{query: q, expr: expr}
+	if visited[key] {
+		return false
+	}
+	visited[key] = true
+
 	v, ok := expr.(*catalog.VarExpr)
 	if !ok {
 		return false
@@ -398,13 +426,13 @@ func isUltimatelyPlainColumn(q *catalog.Query, expr catalog.AnalyzedExpr) bool {
 		return true
 	case catalog.RTESubquery:
 		if rte.Subquery != nil && colIdx >= 0 && colIdx < len(rte.Subquery.TargetList) {
-			return isUltimatelyPlainColumn(rte.Subquery, rte.Subquery.TargetList[colIdx].Expr)
+			return isUltimatelyPlainColumnWithVisited(rte.Subquery, rte.Subquery.TargetList[colIdx].Expr, visited)
 		}
 	case catalog.RTECTE:
 		if rte.CTEIndex >= 0 && rte.CTEIndex < len(q.CTEList) {
 			cte := q.CTEList[rte.CTEIndex]
 			if cte.Query != nil && colIdx >= 0 && colIdx < len(cte.Query.TargetList) {
-				return isUltimatelyPlainColumn(cte.Query, cte.Query.TargetList[colIdx].Expr)
+				return isUltimatelyPlainColumnWithVisited(cte.Query, cte.Query.TargetList[colIdx].Expr, visited)
 			}
 		}
 	default:
@@ -557,13 +585,17 @@ func countStarColumnsFromRTE(q *catalog.Query, targets []*catalog.TargetEntry, s
 	return count
 }
 
-// extractSetOpLineage handles UNION/INTERSECT/EXCEPT by merging lineage from both branches.
-func (e *omniQuerySpanExtractor) extractSetOpLineage(q *catalog.Query, selStmt *ast.SelectStmt) []base.QuerySpanResult {
+func (e *omniQuerySpanExtractor) extractSetOpLineageWithVisited(q *catalog.Query, selStmt *ast.SelectStmt, visited map[*catalog.Query]bool) []base.QuerySpanResult {
 	if q.LArg == nil || q.RArg == nil {
 		return nil
 	}
-	lResults := e.extractLineage(q.LArg, selStmt.Larg)
-	rResults := e.extractLineage(q.RArg, selStmt.Rarg)
+	var lSelStmt, rSelStmt *ast.SelectStmt
+	if selStmt != nil {
+		lSelStmt = selStmt.Larg
+		rSelStmt = selStmt.Rarg
+	}
+	lResults := e.extractLineageWithVisited(q.LArg, lSelStmt, visited)
+	rResults := e.extractLineageWithVisited(q.RArg, rSelStmt, visited)
 
 	// For EXCEPT, output rows come only from the left branch — do not
 	// merge right-side lineage into the result columns.
@@ -592,16 +624,30 @@ func (e *omniQuerySpanExtractor) extractSetOpLineage(q *catalog.Query, selStmt *
 // walkExpr recursively walks an analyzed expression tree and collects all
 // source column references into the result set.
 func (e *omniQuerySpanExtractor) walkExpr(q *catalog.Query, expr catalog.AnalyzedExpr, result base.SourceColumnSet) {
+	e.walkExprWithVisited([]*catalog.Query{q}, expr, result, make(map[queryExprKey]bool))
+}
+
+func (e *omniQuerySpanExtractor) walkExprWithVisited(queryStack []*catalog.Query, expr catalog.AnalyzedExpr, result base.SourceColumnSet, visited map[queryExprKey]bool) {
 	if expr == nil {
 		return
 	}
+	q := currentQuery(queryStack)
+	if q == nil {
+		return
+	}
+	key := queryExprKey{query: q, expr: expr}
+	if visited[key] {
+		return
+	}
+	visited[key] = true
+
 	switch v := expr.(type) {
 	case *catalog.VarExpr:
-		e.resolveVar(q, v, result)
+		e.resolveVar(queryStack, v, result, visited)
 	case *catalog.FuncCallExpr:
 		// Walk arguments first — they contribute to access tables.
 		for _, arg := range v.Args {
-			e.walkExpr(q, arg, result)
+			e.walkExprWithVisited(queryStack, arg, result, visited)
 		}
 		// Trace lineage through user-defined function body.
 		if proc := e.cat.GetUserProcByOID(v.FuncOID); proc != nil {
@@ -614,81 +660,111 @@ func (e *omniQuerySpanExtractor) walkExpr(q *catalog.Query, expr catalog.Analyze
 		}
 	case *catalog.AggExpr:
 		for _, arg := range v.Args {
-			e.walkExpr(q, arg, result)
+			e.walkExprWithVisited(queryStack, arg, result, visited)
 		}
 	case *catalog.OpExpr:
-		e.walkExpr(q, v.Left, result)
-		e.walkExpr(q, v.Right, result)
+		e.walkExprWithVisited(queryStack, v.Left, result, visited)
+		e.walkExprWithVisited(queryStack, v.Right, result, visited)
 	case *catalog.BoolExprQ:
 		for _, arg := range v.Args {
-			e.walkExpr(q, arg, result)
+			e.walkExprWithVisited(queryStack, arg, result, visited)
 		}
 	case *catalog.CaseExprQ:
-		e.walkExpr(q, v.Arg, result)
+		e.walkExprWithVisited(queryStack, v.Arg, result, visited)
 		for _, w := range v.When {
-			e.walkExpr(q, w.Condition, result)
-			e.walkExpr(q, w.Result, result)
+			e.walkExprWithVisited(queryStack, w.Condition, result, visited)
+			e.walkExprWithVisited(queryStack, w.Result, result, visited)
 		}
-		e.walkExpr(q, v.Default, result)
+		e.walkExprWithVisited(queryStack, v.Default, result, visited)
 	case *catalog.CoalesceExprQ:
 		for _, arg := range v.Args {
-			e.walkExpr(q, arg, result)
+			e.walkExprWithVisited(queryStack, arg, result, visited)
 		}
 	case *catalog.SubLinkExpr:
-		e.walkExpr(q, v.TestExpr, result)
+		e.walkExprWithVisited(queryStack, v.TestExpr, result, visited)
 		if v.SubQuery != nil {
+			subQueryStack := appendQuery(queryStack, v.SubQuery)
 			for _, te := range v.SubQuery.TargetList {
 				if !te.ResJunk {
-					e.walkExpr(v.SubQuery, te.Expr, result)
+					e.walkExprWithVisited(subQueryStack, te.Expr, result, visited)
 				}
 			}
 		}
 	case *catalog.RelabelExpr:
-		e.walkExpr(q, v.Arg, result)
+		e.walkExprWithVisited(queryStack, v.Arg, result, visited)
 	case *catalog.CoerceViaIOExpr:
-		e.walkExpr(q, v.Arg, result)
+		e.walkExprWithVisited(queryStack, v.Arg, result, visited)
 	case *catalog.RowExprQ:
 		for _, arg := range v.Args {
-			e.walkExpr(q, arg, result)
+			e.walkExprWithVisited(queryStack, arg, result, visited)
 		}
 	case *catalog.WindowFuncExpr:
 		for _, arg := range v.Args {
-			e.walkExpr(q, arg, result)
+			e.walkExprWithVisited(queryStack, arg, result, visited)
 		}
-		e.walkExpr(q, v.AggFilter, result)
+		e.walkExprWithVisited(queryStack, v.AggFilter, result, visited)
 	case *catalog.NullIfExprQ:
 		for _, arg := range v.Args {
-			e.walkExpr(q, arg, result)
+			e.walkExprWithVisited(queryStack, arg, result, visited)
 		}
 	case *catalog.MinMaxExprQ:
 		for _, arg := range v.Args {
-			e.walkExpr(q, arg, result)
+			e.walkExprWithVisited(queryStack, arg, result, visited)
 		}
 	case *catalog.ArrayExprQ:
 		for _, elem := range v.Elements {
-			e.walkExpr(q, elem, result)
+			e.walkExprWithVisited(queryStack, elem, result, visited)
 		}
 	case *catalog.ScalarArrayOpExpr:
-		e.walkExpr(q, v.Left, result)
-		e.walkExpr(q, v.Right, result)
+		e.walkExprWithVisited(queryStack, v.Left, result, visited)
+		e.walkExprWithVisited(queryStack, v.Right, result, visited)
 	case *catalog.CollateExprQ:
-		e.walkExpr(q, v.Arg, result)
+		e.walkExprWithVisited(queryStack, v.Arg, result, visited)
 	case *catalog.NullTestExpr:
-		e.walkExpr(q, v.Arg, result)
+		e.walkExprWithVisited(queryStack, v.Arg, result, visited)
 	case *catalog.BooleanTestExpr:
-		e.walkExpr(q, v.Arg, result)
+		e.walkExprWithVisited(queryStack, v.Arg, result, visited)
 	case *catalog.DistinctExprQ:
-		e.walkExpr(q, v.Left, result)
-		e.walkExpr(q, v.Right, result)
+		e.walkExprWithVisited(queryStack, v.Left, result, visited)
+		e.walkExprWithVisited(queryStack, v.Right, result, visited)
 	case *catalog.FieldSelectExprQ:
-		e.walkExpr(q, v.Arg, result)
+		e.walkExprWithVisited(queryStack, v.Arg, result, visited)
 	// ConstExpr, SQLValueFuncExpr, CoerceToDomainValueExpr — no column refs.
 	default:
 	}
 }
 
+func currentQuery(queryStack []*catalog.Query) *catalog.Query {
+	if len(queryStack) == 0 {
+		return nil
+	}
+	return queryStack[len(queryStack)-1]
+}
+
+func appendQuery(queryStack []*catalog.Query, q *catalog.Query) []*catalog.Query {
+	nextStack := make([]*catalog.Query, 0, len(queryStack)+1)
+	nextStack = append(nextStack, queryStack...)
+	if q == nil {
+		return nextStack
+	}
+	return append(nextStack, q)
+}
+
 // resolveVar resolves a VarExpr to its ultimate source column(s).
-func (e *omniQuerySpanExtractor) resolveVar(q *catalog.Query, v *catalog.VarExpr, result base.SourceColumnSet) {
+func (e *omniQuerySpanExtractor) resolveVar(queryStack []*catalog.Query, v *catalog.VarExpr, result base.SourceColumnSet, visited map[queryExprKey]bool) {
+	q := currentQuery(queryStack)
+	effectiveStack := queryStack
+	if v.LevelsUp > 0 {
+		ancestorIdx := len(queryStack) - 1 - v.LevelsUp
+		if ancestorIdx < 0 {
+			return
+		}
+		q = queryStack[ancestorIdx]
+		effectiveStack = queryStack[:ancestorIdx+1]
+	}
+	if q == nil {
+		return
+	}
 	if v.RangeIdx < 0 || v.RangeIdx >= len(q.RangeTable) {
 		return
 	}
@@ -718,7 +794,7 @@ func (e *omniQuerySpanExtractor) resolveVar(q *catalog.Query, v *catalog.VarExpr
 		}
 		if colIdx >= 0 && colIdx < len(rte.Subquery.TargetList) {
 			te := rte.Subquery.TargetList[colIdx]
-			e.walkExpr(rte.Subquery, te.Expr, result)
+			e.walkExprWithVisited(appendQuery(effectiveStack, rte.Subquery), te.Expr, result, visited)
 		}
 
 	case catalog.RTECTE:
@@ -726,7 +802,7 @@ func (e *omniQuerySpanExtractor) resolveVar(q *catalog.Query, v *catalog.VarExpr
 			cte := q.CTEList[rte.CTEIndex]
 			if cte.Query != nil && colIdx >= 0 && colIdx < len(cte.Query.TargetList) {
 				te := cte.Query.TargetList[colIdx]
-				e.walkExpr(cte.Query, te.Expr, result)
+				e.walkExprWithVisited(appendQuery(effectiveStack, cte.Query), te.Expr, result, visited)
 			}
 		}
 
@@ -748,7 +824,7 @@ func (e *omniQuerySpanExtractor) resolveVar(q *catalog.Query, v *catalog.VarExpr
 					// Built-in function (no user proc) — trace lineage through
 					// the function's arguments. E.g., jsonb_each(a) depends on column a.
 					for _, arg := range fc.Args {
-						e.walkExpr(q, arg, result)
+						e.walkExprWithVisited(effectiveStack, arg, result, visited)
 					}
 				}
 			}

--- a/backend/plugin/parser/pg/query_span_omni_plpgsql.go
+++ b/backend/plugin/parser/pg/query_span_omni_plpgsql.go
@@ -185,7 +185,13 @@ type plpgsqlAnalyzer struct {
 	// returnResults collects per-column source sets from all RETURN QUERY paths.
 	returnResults [][]base.SourceColumnSet
 	// cteMap holds CTE definitions for resolving column refs through CTEs.
-	cteMap map[string]*ast.SelectStmt
+	cteMap       map[string]*ast.SelectStmt
+	resolvingCTE map[cteResolveKey]bool
+}
+
+type cteResolveKey struct {
+	sel *ast.SelectStmt
+	col string
 }
 
 func (e *omniQuerySpanExtractor) analyzePLpgSQLBody(proc *catalog.UserProc, body string) ([]base.SourceColumnSet, error) {
@@ -621,14 +627,22 @@ func (a *plpgsqlAnalyzer) collectAccessTablesFromSQL(sql string) {
 // Note: funcSourceColumns only stores table-level access (via collectAccessTablesFromSQL),
 // so we don't add column-level entries to it here.
 func (a *plpgsqlAnalyzer) collectQueryPredicateColumns(q *catalog.Query) {
+	a.collectQueryPredicateColumnsWithVisited(q, make(map[*catalog.Query]bool))
+}
+
+func (a *plpgsqlAnalyzer) collectQueryPredicateColumnsWithVisited(q *catalog.Query, visited map[*catalog.Query]bool) {
 	if q == nil {
 		return
 	}
+	if visited[q] {
+		return
+	}
+	visited[q] = true
 
 	// Handle set operations recursively.
 	if q.SetOp != catalog.SetOpNone {
-		a.collectQueryPredicateColumns(q.LArg)
-		a.collectQueryPredicateColumns(q.RArg)
+		a.collectQueryPredicateColumnsWithVisited(q.LArg, visited)
+		a.collectQueryPredicateColumnsWithVisited(q.RArg, visited)
 		return
 	}
 
@@ -645,14 +659,14 @@ func (a *plpgsqlAnalyzer) collectQueryPredicateColumns(q *catalog.Query) {
 	// Recurse into CTEs.
 	for _, cte := range q.CTEList {
 		if cte.Query != nil {
-			a.collectQueryPredicateColumns(cte.Query)
+			a.collectQueryPredicateColumnsWithVisited(cte.Query, visited)
 		}
 	}
 
 	// Recurse into subqueries in FROM clause.
 	for _, rte := range q.RangeTable {
 		if rte.Kind == catalog.RTESubquery && rte.Subquery != nil {
-			a.collectQueryPredicateColumns(rte.Subquery)
+			a.collectQueryPredicateColumnsWithVisited(rte.Subquery, visited)
 		}
 	}
 }
@@ -987,6 +1001,18 @@ func (a *plpgsqlAnalyzer) resolveThroughCTE(cteSel *ast.SelectStmt, colName stri
 	if cteSel == nil || cteSel.TargetList == nil {
 		return
 	}
+	key := cteResolveKey{
+		sel: cteSel,
+		col: strings.ToLower(colName),
+	}
+	if a.resolvingCTE == nil {
+		a.resolvingCTE = make(map[cteResolveKey]bool)
+	}
+	if a.resolvingCTE[key] {
+		return
+	}
+	a.resolvingCTE[key] = true
+	defer delete(a.resolvingCTE, key)
 
 	// Build FROM tables for the CTE's query.
 	cteTables := a.collectFromTables(cteSel)


### PR DESCRIPTION
## Summary
- Resolve correlated subquery `VarExpr.LevelsUp` before walking query span lineage, fixing the `jsonb_array_elements(a.case_record...)` stack overflow path seen in 3.17.1.
- Add visited guards for query span recursion across analyzed expressions, set-op lineage, plain-column checks, PL/pgSQL predicate query walks, and fallback CTE resolution.
- Add regression coverage for the customer SQL shape plus synthetic cyclic analyzed/fallback graphs.

## Investigation
- Reproduced the reported SQL on Bytebase 3.17.1 in a temporary worktree; it overflows via `resolveVar -> walkExpr(OpExpr) -> resolveVar`.
- The SQL uses correlated scalar subqueries over `jsonb_array_elements`; omni marks `a.case_record` with `LevelsUp=1`, but old query span resolved it against the inner query's `RTEFunction`.

## Test Plan
- [x] `go test -v -count=1 ./backend/plugin/parser/pg -run '^(TestLoaderIntegration.*|TestGetQuerySpan)$' -timeout 60s`
- [x] `go test -count=1 ./backend/plugin/parser/pg -timeout 120s`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `golangci-lint run --fix --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Pre-PR Checklist
- Breaking change check: not breaking; bug fix in PG query span only.
- Composite-PK query safety: skipped; no `backend/store` or migrator changes.
- SonarCloud properties: skipped; no new files/directories.

close BYT-9369
