### PR TITLE
fix(query-span): guard cyclic view expansion

### DIFF
--- a/backend/plugin/parser/mysql/query_span_extractor.go
+++ b/backend/plugin/parser/mysql/query_span_extractor.go
@@ -40,6 +40,8 @@ type querySpanExtractor struct {
 	// priorTableInFrom is the table sources from the from clause before the current table source.
 	// It's used to resolve the column name in JSON_TABLE functions.
 	priorTableInFrom []base.TableSource
+
+	viewResolutionStack map[string]bool
 }
 
 // newQuerySpanExtractor creates a new query span extractor, the databaseMetadata and the ast are in the read guard.
@@ -451,11 +453,12 @@ func (q *querySpanExtractor) extractSourceColumnSetFromExpr(ctx antlr.ParserRule
 		subqueryExtractor := &querySpanExtractor{
 			ctx: q.ctx,
 			// The defaultDatabase is the same as the outer query.
-			defaultDatabase:   q.defaultDatabase,
-			gCtx:              q.gCtx,
-			ctes:              q.ctes,
-			outerTableSources: append(q.outerTableSources, q.tableSourceFrom...),
-			tableSourceFrom:   []base.TableSource{},
+			defaultDatabase:     q.defaultDatabase,
+			gCtx:                q.gCtx,
+			ctes:                q.ctes,
+			outerTableSources:   append(q.outerTableSources, q.tableSourceFrom...),
+			tableSourceFrom:     []base.TableSource{},
+			viewResolutionStack: cloneViewResolutionStack(q.viewResolutionStack),
 		}
 		tableSource, err := subqueryExtractor.extractSubquery(ctx)
 		if err != nil {
@@ -1400,7 +1403,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName, tableName string) (ba
 		viewSchema = schema.GetView(tableName)
 	}
 	if viewSchema != nil {
-		columns, err := q.getColumnsForView(viewSchema.Definition)
+		columns, err := q.getColumnsForView(dbMetadata.GetProto().GetName(), viewSchema.Name, viewSchema.Definition)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get columns for view %q", tableName)
 		}
@@ -1420,8 +1423,15 @@ func (q *querySpanExtractor) findTableSchema(databaseName, tableName string) (ba
 	}
 }
 
-func (q *querySpanExtractor) getColumnsForView(definition string) ([]base.QuerySpanResult, error) {
+func (q *querySpanExtractor) getColumnsForView(databaseName, viewName, definition string) ([]base.QuerySpanResult, error) {
+	key := mysqlViewResolutionKey(databaseName, viewName)
+	if q.viewResolutionStack[key] {
+		return nil, errors.Errorf("cyclic view reference detected while resolving %q", viewName)
+	}
+
 	newQ := newQuerySpanExtractor(q.defaultDatabase, q.gCtx, q.ignoreCaseSensitive)
+	newQ.viewResolutionStack = cloneViewResolutionStack(q.viewResolutionStack)
+	newQ.viewResolutionStack[key] = true
 	span, err := newQ.getQuerySpan(q.ctx, definition)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get query span for view")
@@ -1430,6 +1440,18 @@ func (q *querySpanExtractor) getColumnsForView(definition string) ([]base.QueryS
 		return nil, span.NotFoundError
 	}
 	return span.Results, nil
+}
+
+func mysqlViewResolutionKey(databaseName, viewName string) string {
+	return databaseName + "\x00" + viewName
+}
+
+func cloneViewResolutionStack(in map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // selectOnlyListener is the listener to listen the top level select statement only.

--- a/backend/plugin/parser/mysql/query_span_test.go
+++ b/backend/plugin/parser/mysql/query_span_test.go
@@ -104,6 +104,30 @@ func buildMockDatabaseMetadataGetter(databaseMetadata []*storepb.DatabaseSchemaM
 		}
 }
 
+func TestGetQuerySpanCyclicViewReference(t *testing.T) {
+	metadata := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "",
+				Views: []*storepb.ViewMetadata{
+					{Name: "v1", Definition: "SELECT * FROM v2"},
+					{Name: "v2", Definition: "SELECT * FROM v1"},
+				},
+			},
+		},
+	}
+	getter, lister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{metadata})
+
+	_, err := GetQuerySpan(context.Background(), base.GetQuerySpanContext{
+		GetDatabaseMetadataFunc: getter,
+		ListDatabaseNamesFunc:   lister,
+		Engine:                  storepb.Engine_MYSQL,
+	}, base.Statement{Text: "SELECT * FROM v1"}, "db", "", false)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cyclic view reference")
+}
+
 func TestExtractTableRefs(t *testing.T) {
 	tests := []struct {
 		statement string

--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -37,6 +37,8 @@ type querySpanExtractor struct {
 	tableSourcesFrom []base.TableSource
 
 	predicateColumns base.SourceColumnSet
+
+	viewResolutionStack map[string]bool
 }
 
 func newQuerySpanExtractor(defaultDatabase string, defaultSchema string, gCtx base.GetQuerySpanContext, ignoreCaseSensitive bool) *querySpanExtractor {
@@ -127,7 +129,7 @@ func (q *querySpanExtractor) tsqlFindTableSchemaByParts(linkedServer, rawDatabas
 					continue
 				}
 				view := schemaSchema.GetView(viewName)
-				viewColumns, err := q.getColumnsFromCreateView(view.Definition, databaseName, schemaName)
+				viewColumns, err := q.getColumnsFromCreateView(view.Definition, databaseName, schemaName, viewName)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to get columns for view %s.%s.%s", databaseName, schemaName, viewName)
 				}
@@ -149,7 +151,12 @@ func (q *querySpanExtractor) tsqlFindTableSchemaByParts(linkedServer, rawDatabas
 
 // getColumnsFromCreateView parses a CREATE VIEW definition with omni, extracts
 // the body's result columns, and applies the optional column alias list.
-func (q *querySpanExtractor) getColumnsFromCreateView(definition string, viewDatabaseName string, viewSchemaName string) ([]base.QuerySpanResult, error) {
+func (q *querySpanExtractor) getColumnsFromCreateView(definition string, viewDatabaseName string, viewSchemaName string, viewName string) ([]base.QuerySpanResult, error) {
+	key := tsqlViewResolutionKey(viewDatabaseName, viewSchemaName, viewName)
+	if q.viewResolutionStack[key] {
+		return nil, errors.Errorf("cyclic view reference detected while resolving %q", viewName)
+	}
+
 	stmts, err := ParseTSQLOmni(definition)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse CREATE VIEW definition")
@@ -180,6 +187,8 @@ func (q *querySpanExtractor) getColumnsFromCreateView(definition string, viewDat
 	newQ := newOmniQuerySpanExtractor(viewDatabaseName, viewSchemaName, q.gCtx, q.ignoreCaseSensitive)
 	newQ.ctx = q.ctx
 	newQ.source = definition
+	newQ.viewResolutionStack = cloneViewResolutionStack(q.viewResolutionStack)
+	newQ.viewResolutionStack[key] = true
 	pseudo, err := newQ.extractFromSelectStmt(body)
 	if err != nil {
 		var resourceNotFound *base.ResourceNotFoundError
@@ -196,6 +205,18 @@ func (q *querySpanExtractor) getColumnsFromCreateView(definition string, viewDat
 		}
 	}
 	return results, nil
+}
+
+func tsqlViewResolutionKey(databaseName, schemaName, viewName string) string {
+	return databaseName + "\x00" + schemaName + "\x00" + viewName
+}
+
+func cloneViewResolutionStack(in map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 // tsqlGetAllFieldsOfTableInFromOrOuterCTE expands `table.*` to the column set

--- a/backend/plugin/parser/tsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/tsql/query_span_extractor_omni.go
@@ -448,6 +448,7 @@ func (q *omniQuerySpanExtractor) extractCTEBody(cteName string, body *ast.Select
 				ctes:                append([]*base.PseudoTable{}, q.ctes...),
 				outerTableSources:   nil,
 				predicateColumns:    make(base.SourceColumnSet),
+				viewResolutionStack: cloneViewResolutionStack(q.viewResolutionStack),
 			},
 			source: q.source,
 		}
@@ -793,6 +794,7 @@ func (q *omniQuerySpanExtractor) cloneForSubquery() *omniQuerySpanExtractor {
 			ctes:                append([]*base.PseudoTable{}, q.ctes...),
 			outerTableSources:   append(append([]base.TableSource{}, q.outerTableSources...), q.tableSourcesFrom...),
 			predicateColumns:    make(base.SourceColumnSet),
+			viewResolutionStack: cloneViewResolutionStack(q.viewResolutionStack),
 		},
 		source: q.source,
 	}

--- a/backend/plugin/parser/tsql/query_span_test.go
+++ b/backend/plugin/parser/tsql/query_span_test.go
@@ -100,3 +100,27 @@ func buildMockDatabaseMetadataGetter(databaseMetadata []*storepb.DatabaseSchemaM
 			return names, nil
 		}
 }
+
+func TestGetQuerySpanCyclicViewReference(t *testing.T) {
+	metadata := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "dbo",
+				Views: []*storepb.ViewMetadata{
+					{Name: "v1", Definition: "CREATE VIEW [dbo].[v1] AS SELECT * FROM v2"},
+					{Name: "v2", Definition: "CREATE VIEW [dbo].[v2] AS SELECT * FROM v1"},
+				},
+			},
+		},
+	}
+	getter, lister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{metadata})
+
+	_, err := GetQuerySpan(context.Background(), base.GetQuerySpanContext{
+		GetDatabaseMetadataFunc: getter,
+		ListDatabaseNamesFunc:   lister,
+		TempTables:              make(map[string]*base.PhysicalTable),
+	}, base.Statement{Text: "SELECT * FROM v1"}, "db", "dbo", true)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cyclic view reference")
+}


### PR DESCRIPTION
## Summary
- Add cyclic view expansion guards for MySQL query span view resolution.
- Add the same guard for MSSQL omni query span view resolution, including subquery/CTE extractor clones.
- Add MySQL and MSSQL regression tests for mutually recursive views.

## Test Plan
- go test -count=1 ./backend/plugin/parser/mysql -timeout 120s
- go test -count=1 ./backend/plugin/parser/tsql -timeout 120s
- go test -count=1 ./backend/plugin/parser/pg -run '^TestLoader_CycleBreaking$' -timeout 60s
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go

## Notes
- This does not require the `breaking` label: the behavior change is limited to converting cyclic metadata view expansion from stack overflow to an explicit query-span error.
- Composite-PK checks are skipped because this PR does not touch `backend/store/` or `backend/migrator/`.
