### PR TITLE
fix(clickhouse): translate AggregateFunction decode errors into actionable guidance

### DIFF
--- a/backend/plugin/db/clickhouse/query.go
+++ b/backend/plugin/db/clickhouse/query.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/paulmach/orb"
 	"github.com/paulmach/orb/encoding/wkt"
+	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -26,6 +27,8 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	"github.com/bytebase/bytebase/backend/plugin/parser/standard"
 )
+
+const aggregateFunctionErrMarker = `unsupported column type "AggregateFunction(`
 
 // QueryConn queries a SQL statement in a given connection.
 func (*Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement string, queryContext db.QueryContext) ([]*v1pb.QueryResult, error) {
@@ -81,6 +84,7 @@ func (*Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement string, 
 		}()
 		stop := false
 		if err != nil {
+			err = translateAggregateFunctionError(err)
 			queryResult = &v1pb.QueryResult{
 				Error: err.Error(),
 			}
@@ -100,6 +104,20 @@ func (*Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement string, 
 
 func getStatementWithResultLimit(statement string, limit int) string {
 	return fmt.Sprintf("WITH result AS (%s) SELECT * FROM result LIMIT %d;", util.TrimStatement(statement), limit)
+}
+
+// translateAggregateFunctionError rewrites the clickhouse-go driver's opaque
+// "unsupported column type \"AggregateFunction(...)\"" error into actionable
+// guidance pointing the user at -Merge combinators or finalizeAggregation(),
+// since the driver cannot decode AggregateFunction intermediate state directly.
+func translateAggregateFunctionError(err error) error {
+	if err == nil || !strings.Contains(err.Error(), aggregateFunctionErrMarker) {
+		return err
+	}
+	return errors.Wrap(err,
+		"this query selects an AggregateFunction column, which stores aggregator intermediate state and cannot be decoded directly. "+
+			"Wrap each AggregateFunction column with its -Merge combinator under GROUP BY (for example, maxMerge(col)), or with "+
+			"finalizeAggregation(col) for per-row finalization")
 }
 
 func makeValueByTypeName(typeName string, columnType *sql.ColumnType) any {

--- a/backend/plugin/db/clickhouse/query_test.go
+++ b/backend/plugin/db/clickhouse/query_test.go
@@ -1,0 +1,37 @@
+package clickhouse
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTranslateAggregateFunctionError(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		require.NoError(t, translateAggregateFunctionError(nil))
+	})
+
+	t.Run("non aggregate function error", func(t *testing.T) {
+		err := errors.New("some other clickhouse error")
+		require.Same(t, err, translateAggregateFunctionError(err))
+	})
+
+	t.Run("simple aggregate function error is not rewritten", func(t *testing.T) {
+		// Defensive: SimpleAggregateFunction is supported by the driver, but if a
+		// future driver bug ever surfaces an "unsupported column type" error for
+		// it, our marker must not match (because SimpleAggregateFunction errors
+		// do not need the -Merge / finalizeAggregation guidance).
+		err := errors.New(`clickhouse: unsupported column type "SimpleAggregateFunction(sum, UInt64)"`)
+		require.Same(t, err, translateAggregateFunctionError(err))
+	})
+
+	t.Run("aggregate function error", func(t *testing.T) {
+		err := errors.New(`read data: failed to decode block from 127.0.0.1:9000 (conn_id=26, compression=none): clickhouse: unsupported column type "AggregateFunction(argMin, Decimal(20, 6), DateTime64(3, 'UTC'))"`)
+		got := translateAggregateFunctionError(err)
+		require.Error(t, got)
+		require.Contains(t, got.Error(), "cannot be decoded directly")
+		require.Contains(t, got.Error(), "finalizeAggregation(col)")
+		require.Contains(t, got.Error(), err.Error())
+	})
+}


### PR DESCRIPTION
## Summary

- Reported in #20043: `SELECT *` over a ClickHouse table with `AggregateFunction(...)` columns surfaces an opaque `read data: failed to decode block ... clickhouse: unsupported column type "AggregateFunction(...)"` error in the SQL Editor.
- Root cause is upstream: clickhouse-go v2.43.0 implements `SimpleAggregateFunction` but has no decoder for `AggregateFunction(...)` (`lib/column/column_gen.go`). `AggregateFunction(func, T...)` columns store opaque per-aggregator binary state (HLL sketches, t-digests, argMin's value+key pair, etc.), so a generic decoder is impossible — the correct ClickHouse pattern is to apply a `-Merge` combinator with `GROUP BY`, or wrap with `finalizeAggregation()`.
- Detect the marker in the `QueryConn` error path and rewrite the driver error into actionable guidance. Schema sync is unaffected: AggregateFunction column types are already captured correctly via `information_schema.columns.column_type`.

Resolves #20043 (UX side; the underlying driver gap is upstream).

## Test plan

- [x] Unit tests: `TestTranslateAggregateFunctionError` covers nil, non-matching, the exact reported error string, and a defensive negative case for `SimpleAggregateFunction` (whose error must NOT be rewritten — guards against weakening of the substring marker).
- [x] `go test -v -count=1 ./backend/plugin/db/clickhouse/ -run TestTranslateAggregateFunctionError` — all four subtests pass.
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/db/clickhouse/...` — 0 issues.
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go` succeeds.
- [x] Reproduced the original failure end-to-end against ClickHouse 23.8.16 with the exact schema from #20043; confirmed `finalizeAggregation()` workaround returns clean column headers, validating that the new error message points users to a working path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)