### PR TITLE
chore: remove dead instance limit check

### DIFF
--- a/backend/enterprise/license.go
+++ b/backend/enterprise/license.go
@@ -350,9 +350,6 @@ func (s *LicenseService) GetInstanceLimit(ctx context.Context, workspaceID strin
 	limit := instanceLimitValues[subscription.Plan]
 	if limit == -1 {
 		// Enterprise license.
-		if subscription.Instances > 0 {
-			return int(subscription.Instances)
-		}
 		limit = math.MaxInt
 	}
 	return limit


### PR DESCRIPTION
## Summary
- Remove an unreachable `subscription.Instances > 0` check from `GetInstanceLimit`.
- Keep the enterprise plan fallback behavior unchanged by returning `math.MaxInt` when the plan limit is unlimited.

## Pre-PR Checklist
- Breaking change check: not breaking; removes dead code without changing reachable behavior.
- Composite-PK query safety: skipped; no `backend/store/` or `backend/migrator/` changes.
- SonarCloud properties: skipped; no new files or directories.

## Test Plan
- `gofmt -w backend/enterprise/license.go`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- `go test -v -count=1 ./backend/enterprise`
- `git diff --check`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
