### PR TITLE
fix(mssql): skip prior backup for DMLs targeting temp tables (BYT-9359)

### DIFF
--- a/backend/plugin/parser/tsql/backup.go
+++ b/backend/plugin/parser/tsql/backup.go
@@ -519,10 +519,7 @@ func sourceFromLoc(source string, loc ast.Loc) string {
 	if loc.Start < 0 || loc.End < 0 || loc.Start >= len(source) {
 		return ""
 	}
-	end := loc.End
-	if end > len(source) {
-		end = len(source)
-	}
+	end := min(loc.End, len(source))
 	return strings.TrimSpace(source[loc.Start:end])
 }
 

--- a/backend/plugin/parser/tsql/backup.go
+++ b/backend/plugin/parser/tsql/backup.go
@@ -3,6 +3,7 @@ package tsql
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"slices"
 	"strings"
 
@@ -219,6 +220,12 @@ func prepareTransformation(databaseName, statement string) ([]statementInfo, err
 		}
 		if table == nil {
 			return nil, errors.Errorf("failed to resolve DML target table")
+		}
+		if strings.HasPrefix(table.Table, "#") {
+			slog.Info("prior backup: skipping DML targeting temp table",
+				"table", table.Table,
+				"statementType", statementType)
+			continue
 		}
 		table.StatementType = statementType
 		loc := dmlNodeLoc(node)

--- a/backend/plugin/parser/tsql/backup_test.go
+++ b/backend/plugin/parser/tsql/backup_test.go
@@ -243,3 +243,54 @@ func TestBackupWithQuotedStrings(t *testing.T) {
 	// The WHERE clause should be present
 	a.Contains(stmt2, "WHERE id = 1")
 }
+
+// TestBackupSkipsTempTableTargets validates BYT-9359: prior backup must skip
+// any UPDATE/DELETE whose target table is a temp table (#name local, ##name
+// global). Temp tables are session-scoped, so a backup query running in a
+// separate session would fail with "Invalid object name". Skipping is the
+// only sane outcome — the rows can't be reconstructed across sessions and
+// have no rollback semantics anyway.
+func TestBackupSkipsTempTableTargets(t *testing.T) {
+	tests := []struct {
+		name            string
+		input           string
+		wantLen         int
+		wantTargetTable string // only checked when wantLen == 1
+	}{
+		{
+			name:    "update local temp table only",
+			input:   "UPDATE #tmp SET c1 = 1 WHERE c2 = 2;",
+			wantLen: 0,
+		},
+		{
+			name:    "delete from local temp table only",
+			input:   "DELETE FROM #tmp WHERE c1 = 1;",
+			wantLen: 0,
+		},
+		{
+			name:    "update global temp table only",
+			input:   "UPDATE ##gtmp SET c1 = 1 WHERE c2 = 2;",
+			wantLen: 0,
+		},
+		{
+			name: "mixed temp and real targets",
+			input: strings.Join([]string{
+				"UPDATE #tmp SET c1 = 1 WHERE c2 = 2;",
+				"UPDATE test SET c1 = 2 WHERE c1 = 1;",
+			}, "\n"),
+			wantLen:         1,
+			wantTargetTable: "rollback_test_db",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := TransformDMLToSelect(context.Background(), base.TransformContext{}, tc.input, "db", "backupDB", "rollback")
+			require.NoError(t, err)
+			require.Len(t, result, tc.wantLen)
+			if tc.wantLen == 1 {
+				require.Equal(t, tc.wantTargetTable, result[0].TargetTableName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Customer (medcoenergi) reported that running a stored procedure whose body issues `UPDATE #tmpList SET ...` aborts the migration when Prior Backup is enabled. The generator emits `SELECT * INTO [bbdataarchive].[dbo].[..._#tmpList_...] FROM (SELECT [t].* FROM #tmpList t ...)`, which then fails with `Msg 208 ... Invalid object name '#tmpList'` because the backup runs in a separate session from the one that created the temp table.

This PR adds a single check in `prepareTransformation` (`backend/plugin/parser/tsql/backup.go`): when `resolveDMLTargetTable` returns a `*TableReference` whose `Table` starts with `#`, the DML is skipped (no backup statement emitted) and an `slog.Info` line is logged. `#` covers both local (`#name`) and global (`##name`) temp tables; T-SQL reserves the prefix.

The non-goal is deliberate: `UPDATE real ... FROM real JOIN #tmp ...` (target real, JOIN driver temp) is left to fail explicitly at execute time. Silently skipping the backup there would leave a real table un-backed-up without warning — a worse failure mode than the current explicit MSSQL error.

Also includes a small ride-along: `sourceFromLoc` switched to Go 1.21+ `min()` (gopls minmax suggestion, no behavior change). Bundled to avoid same-file merge conflicts.

## What changed

- `backend/plugin/parser/tsql/backup.go` — added `log/slog` import, 5-line skip block in `prepareTransformation`, `min()` in `sourceFromLoc`.
- `backend/plugin/parser/tsql/backup_test.go` — `TestBackupSkipsTempTableTargets` covers local-temp, global-temp, delete-from-temp, and mixed temp+real targets.
- `docs/superpowers/specs/2026-04-29-mssql-prior-backup-temp-table-design.md` — design rationale.
- `docs/superpowers/plans/2026-04-29-mssql-prior-backup-temp-table.md` — implementation plan.

## Behavior matrix

| Migration shape | Before | After |
|---|---|---|
| `UPDATE #tmp ...` / `DELETE FROM #tmp ...` | Backup emitted → MSSQL `Invalid object name`, migration aborts | **Skipped, no backup, migration proceeds** |
| `UPDATE real ... FROM real JOIN #tmp ...` | Fails at execute | Unchanged — still fails (intentional) |
| `UPDATE real ... [no temp]` | Backup emitted | Unchanged |
| Mixed temp + real targets | All-or-nothing failure | Real-target DML gets a backup; temp-target DML silently skipped |

## Test plan

- [x] `go test -v -count=1 ./backend/plugin/parser/tsql/...` — all green, including new 4-case `TestBackupSkipsTempTableTargets`
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/parser/tsql/...` — 0 issues
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go` — clean build
- [ ] Reviewer to confirm: customer's exact failing query (`UPDATE #tmpList SET ... OUTER APPLY ... OUTER APPLY ...`) is covered — minimal `UPDATE #tmp SET c1 = 1 WHERE c2 = 2` exercises the same code path because the skip happens **before** `extractSuffixSelectStatement` is invoked, so the OUTER APPLY body never enters

Linear: BYT-9359