### PR TITLE
fix(tidb): honor IF [NOT] EXISTS in walk-through DDL simulation

### DIFF
--- a/backend/plugin/schema/tidb/testdata/walk_through.yaml
+++ b/backend/plugin/schema/tidb/testdata/walk_through.yaml
@@ -465,3 +465,180 @@
     \     \"visible\": true\n            }\n          ]\n        }\n      ]\n    }\n\
     \  ]\n}"
   advice: null
+- statement: |
+    CREATE TABLE t(a int);
+    ALTER TABLE t ADD COLUMN IF NOT EXISTS a int;
+  ignore_case_sensitive: false
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int(11)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  advice: null
+- statement: |
+    CREATE TABLE t(a int);
+    ALTER TABLE t ADD COLUMN a int;
+  ignore_case_sensitive: false
+  want: ''
+  advice:
+    status: 1
+    code: 412
+    title: Column `a` already exists in table `t`
+    content: Column `a` already exists in table `t`
+    startPosition:
+      line: 0
+- statement: |
+    CREATE TABLE t(a int);
+    ALTER TABLE t DROP COLUMN IF EXISTS b;
+  ignore_case_sensitive: false
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int(11)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  advice: null
+- statement: |
+    CREATE TABLE t(a int);
+    ALTER TABLE t DROP INDEX IF EXISTS idx_nonexistent;
+  ignore_case_sensitive: false
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int(11)"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  advice: null
+- statement: |
+    CREATE TABLE t(a int);
+    CREATE INDEX idx_a ON t(a);
+    CREATE INDEX IF NOT EXISTS idx_a ON t(a);
+  ignore_case_sensitive: false
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int(11)"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "idx_a",
+                  "expressions": [
+                    "a"
+                  ],
+                  "type": "BTREE",
+                  "visible": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  advice: null
+- statement: |
+    CREATE TABLE t(a int);
+    CREATE INDEX idx_a ON t(a);
+    CREATE INDEX idx_a ON t(a);
+  ignore_case_sensitive: false
+  want: ''
+  advice:
+    status: 1
+    code: 805
+    title: Index `idx_a` already exists in table `t`
+    content: Index `idx_a` already exists in table `t`
+    startPosition:
+      line: 0
+- statement: |
+    CREATE TABLE t(a int);
+    CREATE INDEX idx_a ON t(a);
+    ALTER TABLE t ADD INDEX IF NOT EXISTS idx_a (a);
+  ignore_case_sensitive: false
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int(11)"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "idx_a",
+                  "expressions": [
+                    "a"
+                  ],
+                  "type": "BTREE",
+                  "visible": true
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  advice: null

--- a/backend/plugin/schema/tidb/walk_through.go
+++ b/backend/plugin/schema/tidb/walk_through.go
@@ -319,6 +319,10 @@ func tidbHandleCreateIndex(d *model.DatabaseMetadata, node *tidbast.CreateIndexS
 		return err
 	}
 
+	if node.IfNotExists && node.IndexName != "" && table.GetIndex(node.IndexName) != nil {
+		return nil
+	}
+
 	unique := false
 	tp := tidbast.IndexTypeBtree.String()
 	isSpatial := false
@@ -367,6 +371,9 @@ func tidbAlterTable(d *model.DatabaseMetadata, node *tidbast.AlterTableStmt) *st
 			}
 		case tidbast.AlterTableAddColumns:
 			for _, column := range spec.NewColumns {
+				if spec.IfNotExists && table.GetColumn(column.Name.Name.L) != nil {
+					continue
+				}
 				var pos *tidbast.ColumnPosition
 				if len(spec.NewColumns) == 1 {
 					pos = spec.Position
@@ -396,6 +403,9 @@ func tidbAlterTable(d *model.DatabaseMetadata, node *tidbast.AlterTableStmt) *st
 				col.Position = int32(i + 1)
 			}
 		case tidbast.AlterTableAddConstraint:
+			if spec.Constraint != nil && spec.Constraint.IfNotExists && spec.Constraint.Name != "" && table.GetIndex(spec.Constraint.Name) != nil {
+				continue
+			}
 			if err := tidbCreateConstraint(table, spec.Constraint); err != nil {
 				return err
 			}
@@ -403,6 +413,9 @@ func tidbAlterTable(d *model.DatabaseMetadata, node *tidbast.AlterTableStmt) *st
 			columnName := spec.OldColumnName.Name.O
 			// Validate column exists
 			if table.GetColumn(columnName) == nil {
+				if spec.IfExists {
+					continue
+				}
 				content := fmt.Sprintf("Column `%s` does not exist in table `%s`", columnName, table.GetProto().Name)
 				return &storepb.Advice{
 					Status:        storepb.Advice_ERROR,
@@ -433,6 +446,9 @@ func tidbAlterTable(d *model.DatabaseMetadata, node *tidbast.AlterTableStmt) *st
 				}
 			}
 		case tidbast.AlterTableDropIndex:
+			if spec.IfExists && table.GetIndex(spec.Name) == nil {
+				continue
+			}
 			if err := table.DropIndex(spec.Name); err != nil {
 				return &storepb.Advice{
 					Status:        storepb.Advice_ERROR,

--- a/backend/plugin/schema/tidb/walk_through_test.go
+++ b/backend/plugin/schema/tidb/walk_through_test.go
@@ -56,9 +56,9 @@ func TestWalkThrough(t *testing.T) {
 		asts := base.ExtractASTs(stmts)
 		advice := WalkThrough(state, asts)
 		if advice != nil {
-			// Compare the advice fields
-			require.Equal(t, test.Advice.Code, advice.Code)
-			require.Equal(t, test.Advice.Content, advice.Content)
+			require.NotNil(t, test.Advice, "unexpected advice for statement %q: %+v", test.Statement, advice)
+			require.Equal(t, test.Advice.Code, advice.Code, "statement %q", test.Statement)
+			require.Equal(t, test.Advice.Content, advice.Content, "statement %q", test.Statement)
 			continue
 		}
 


### PR DESCRIPTION
## Summary

- Idempotent DDL such as `CREATE INDEX IF NOT EXISTS`, `ALTER TABLE ADD COLUMN IF NOT EXISTS`, `ALTER TABLE DROP COLUMN IF EXISTS`, `ALTER TABLE DROP INDEX IF EXISTS`, and `ALTER TABLE ADD INDEX IF NOT EXISTS` previously produced "already exists" / "does not exist" errors during pre-check even though the user opted into idempotent semantics.
- The TiDB walk-through now consults `IfExists` / `IfNotExists` on the relevant AST nodes and treats the statement as a no-op when the target object's existence already matches the clause.
- Other engines (MySQL/MariaDB/OceanBase via the omni MySQL catalog, PostgreSQL via the omni PG catalog) will be addressed in follow-up PRs — fixing engine by engine.

Linear: [BYT-9352](https://linear.app/bytebase/issue/BYT-9352)

## Test plan

- [x] Added 7 YAML cases covering each idempotent form (positive + regression where applicable) in `backend/plugin/schema/tidb/testdata/walk_through.yaml`
- [x] `go test -count=1 ./backend/plugin/schema/tidb/...` passes
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/schema/tidb/...` clean
- [x] Build passes: `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)