### PR TITLE
fix(frontend): show database group title in plan selectors

### DIFF
--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -1239,7 +1239,7 @@ function DatabaseGroupSelector({
               <td className="py-2 pr-4">
                 <div className="flex items-center gap-x-1.5">
                   <FolderTree className="size-4 text-control-light shrink-0" />
-                  <span>{extractDatabaseGroupName(group.name)}</span>
+                  <span>{group.title}</span>
                 </div>
               </td>
             </tr>

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -1599,7 +1599,7 @@ function DatabaseGroupSelector({
               <td className="py-2 pr-4">
                 <div className="flex items-center gap-x-1.5">
                   <FolderTree className="size-4 shrink-0 text-control-light" />
-                  <span>{extractDatabaseGroupName(group.name)}</span>
+                  <span>{group.title}</span>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
## Summary

- The `DatabaseGroupSelector` in the create-plan and plan-detail flows was rendering `extractDatabaseGroupName(group.name)` — i.e. the resource ID parsed from `projects/{p}/databaseGroups/{id}` (e.g. `dypef`, `dypefnokk`) — instead of the human-readable `group.title`.
- Now displays `group.title` in both selectors, matching the expectation from BYT-9375.

Closes BYT-9375.

## Test plan

- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend check` (eslint, biome, react-i18n, react-layering, locale sort)
- [ ] Manually verify the create-plan drawer's "Database Groups" tab now shows titles
- [ ] Manually verify the plan-detail change-branch flow's database-group selector shows titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)