### PR TITLE
fix(frontend): persist page agent window position

### DIFF
--- a/frontend/src/react/plugins/agent/store/agent.test.ts
+++ b/frontend/src/react/plugins/agent/store/agent.test.ts
@@ -112,21 +112,40 @@ describe("useAgentStore (Zustand)", () => {
     expect(localStorage.getItem(AGENT_STATE_KEY)).not.toBeNull();
   });
 
-  test("centers the window when opening the agent", () => {
+  test("keeps persisted position when opening the agent", () => {
     setViewportSize(1440, 900);
-    const store = createAgentStore();
+    localStorage.setItem(
+      AGENT_WINDOW_KEY,
+      JSON.stringify({
+        position: { x: 120, y: 140 },
+        size: { width: 480, height: 540 },
+        sidebarWidth: 200,
+      })
+    );
 
-    s(store).setSize(788, 625);
-    s(store).setPosition(700, 500);
+    const store = createAgentStore();
 
     s(store).toggle();
 
     expect(s(store).visible).toBe(true);
-    expect(s(store).position).toEqual({ x: 326, y: 138 });
+    expect(s(store).position).toEqual({ x: 120, y: 140 });
+  });
+
+  test("keeps current position when opening the agent", () => {
+    setViewportSize(1440, 900);
+    const store = createAgentStore();
+
+    s(store).setSize(788, 625);
+    s(store).setPosition(320, 180);
+
+    s(store).toggle();
+
+    expect(s(store).visible).toBe(true);
+    expect(s(store).position).toEqual({ x: 320, y: 180 });
     expect(s(store).size).toEqual({ width: 788, height: 625 });
   });
 
-  test("centers reopening using the rendered minimum size on wider viewports", () => {
+  test("clamps opening position using the rendered minimum size on wider viewports", () => {
     setViewportSize(1440, 900);
     const store = createAgentStore();
 
@@ -136,7 +155,7 @@ describe("useAgentStore (Zustand)", () => {
     s(store).toggle();
 
     expect(s(store).visible).toBe(true);
-    expect(s(store).position).toEqual({ x: 490, y: 250 });
+    expect(s(store).position).toEqual({ x: 700, y: 484 });
   });
 
   test("normalizes stale running chats on load", () => {

--- a/frontend/src/react/plugins/agent/store/agent.ts
+++ b/frontend/src/react/plugins/agent/store/agent.ts
@@ -12,7 +12,7 @@ import type {
   ToolCall,
 } from "../logic/types";
 import {
-  getCenteredAgentWindowPosition,
+  clampAgentWindowPosition,
   getDefaultAgentWindowState,
 } from "../window";
 
@@ -616,11 +616,12 @@ export const createAgentStore = () => {
             if (state.visible) {
               state.minimized = false;
               if (typeof window !== "undefined") {
-                state.position = getCenteredAgentWindowPosition(
+                state.position = clampAgentWindowPosition(
                   window.innerWidth,
                   window.innerHeight,
                   state.size.width,
-                  state.size.height
+                  state.size.height,
+                  state.position
                 );
               }
             }

--- a/frontend/src/react/plugins/agent/window.ts
+++ b/frontend/src/react/plugins/agent/window.ts
@@ -55,6 +55,28 @@ export const getCenteredAgentWindowPosition = (
   };
 };
 
+export const clampAgentWindowPosition = (
+  viewportWidth: number,
+  viewportHeight: number,
+  windowWidth: number,
+  windowHeight: number,
+  position: { x: number; y: number }
+) => {
+  const width = clampDisplayDimension(windowWidth, viewportWidth, MIN_WIDTH);
+  const height = clampDisplayDimension(
+    windowHeight,
+    viewportHeight,
+    MIN_HEIGHT
+  );
+  const maxX = Math.max(WINDOW_MARGIN, viewportWidth - width - WINDOW_MARGIN);
+  const maxY = Math.max(WINDOW_MARGIN, viewportHeight - height - WINDOW_MARGIN);
+
+  return {
+    x: Math.min(maxX, Math.max(WINDOW_MARGIN, Math.round(position.x))),
+    y: Math.min(maxY, Math.max(WINDOW_MARGIN, Math.round(position.y))),
+  };
+};
+
 export const getDefaultAgentWindowState = (
   viewportWidth: number,
   viewportHeight: number


### PR DESCRIPTION
## Summary
- Restore the persisted/current page agent window position when opening the agent.
- Clamp restored positions to the viewport so stale coordinates do not reopen off-screen.
- Add regression coverage for persisted position, current position, and clamping behavior.

## Test Plan
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test src/react/plugins/agent/store/agent.test.ts

## Pre-PR Checklist
- Breaking change check: not breaking; this restores expected window persistence behavior.
- Composite-PK query safety: skipped, no backend store or migrator changes.
- SonarCloud properties: skipped, no new files or directories.
