### PR TITLE
fix(react): indicate expired roles in member detail panel (BYT-9374)

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -280,6 +280,7 @@
     "environments": "Environments",
     "error": "Error",
     "expiration": "Expiration",
+    "expired": "Expired",
     "export": "Export",
     "failed": "Failed",
     "feishu": "Feishu",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -280,6 +280,7 @@
     "environments": "Entornos",
     "error": "Error",
     "expiration": "Expiración",
+    "expired": "Expirado",
     "export": "Exportar",
     "failed": "Falló",
     "feishu": "Feishu",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -280,6 +280,7 @@
     "environments": "環境",
     "error": "間違い",
     "expiration": "有効期限",
+    "expired": "期限切れ",
     "export": "出力",
     "failed": "失敗",
     "feishu": "Feishu",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -280,6 +280,7 @@
     "environments": "Môi trường",
     "error": "Lỗi",
     "expiration": "Hết hạn",
+    "expired": "Đã hết hạn",
     "export": "Xuất",
     "failed": "Thất bại",
     "feishu": "Feishu",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -280,6 +280,7 @@
     "environments": "环境",
     "error": "错误",
     "expiration": "过期时间",
+    "expired": "已过期",
     "export": "导出",
     "failed": "失败",
     "feishu": "飞书",

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -280,6 +280,7 @@
     "environments": "Environments",
     "error": "Error",
     "expiration": "Expiration",
+    "expired": "Expired",
     "export": "Export",
     "failed": "Failed",
     "file-selector": {

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -1724,7 +1724,8 @@
         },
         "max-expiration-hint": "Maximum allowed by workspace policy: {{days}} day(s)."
       },
-      "revoke-role-from-member": "Revoke '{{role}}' from '{{member}}'?"
+      "revoke-role-from-member": "Revoke '{{role}}' from '{{member}}'?",
+      "show-expired-roles": "Show expired roles"
     },
     "overview": {
       "info-slot-content": "Bytebase periodically syncs the instance schema. Newly synced databases are first placed here. User should transfer them to the proper application project."

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -277,6 +277,7 @@
     "environments": "Entornos",
     "error": "Error",
     "expiration": "Expiración",
+    "expired": "Expirado",
     "export": "Exportar",
     "failed": "Error",
     "file-selector": {

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -1716,7 +1716,8 @@
         },
         "max-expiration-hint": "Máximo permitido por la política del espacio de trabajo: {{days}} día(s)."
       },
-      "revoke-role-from-member": "¿Revocar '{{role}}' de '{{member}}'?"
+      "revoke-role-from-member": "¿Revocar '{{role}}' de '{{member}}'?",
+      "show-expired-roles": "Mostrar roles expirados"
     },
     "overview": {
       "info-slot-content": "Bytebase sincroniza periódicamente el esquema de la instancia. Las bases de datos recién sincronizadas se colocan aquí primero. El usuario debe transferirlas al proyecto de aplicación adecuado."

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -1716,7 +1716,8 @@
         },
         "max-expiration-hint": "ワークスペースポリシーで許可される最大値：{{days}} 日。"
       },
-      "revoke-role-from-member": "'{{member}}' から '{{role}}' を取り消しますか？"
+      "revoke-role-from-member": "'{{member}}' から '{{role}}' を取り消しますか？",
+      "show-expired-roles": "期限切れのロールを表示"
     },
     "overview": {
       "info-slot-content": "Bytebase はインスタンスのスキーマを定期的に同期します。新しく同期されたデータベースは最初にここに配置され、その後、それらを適切なプロジェクトに転送できます。"

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -277,6 +277,7 @@
     "environments": "環境",
     "error": "間違い",
     "expiration": "有効期限",
+    "expired": "期限切れ",
     "export": "エクスポート",
     "failed": "失敗",
     "file-selector": {

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -1716,7 +1716,8 @@
         },
         "max-expiration-hint": "Tối đa được phép theo chính sách không gian làm việc: {{days}} ngày."
       },
-      "revoke-role-from-member": "Thu hồi '{{role}}' từ '{{member}}'?"
+      "revoke-role-from-member": "Thu hồi '{{role}}' từ '{{member}}'?",
+      "show-expired-roles": "Hiển thị vai trò đã hết hạn"
     },
     "overview": {
       "info-slot-content": "Bytebase định kỳ đồng bộ hóa lược đồ phiên bản. Các cơ sở dữ liệu mới được đồng bộ hóa trước tiên được đặt ở đây. Người dùng nên chuyển chúng đến dự án ứng dụng thích hợp."

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -277,6 +277,7 @@
     "environments": "Môi trường",
     "error": "Lỗi",
     "expiration": "Hết hạn",
+    "expired": "Đã hết hạn",
     "export": "Xuất",
     "failed": "Thất bại",
     "file-selector": {

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -1716,7 +1716,8 @@
         },
         "max-expiration-hint": "工作空间策略允许的最大值：{{days}} 天。"
       },
-      "revoke-role-from-member": "从 '{{member}}' 撤销 '{{role}}' 角色？"
+      "revoke-role-from-member": "从 '{{member}}' 撤销 '{{role}}' 角色？",
+      "show-expired-roles": "显示已过期角色"
     },
     "overview": {
       "info-slot-content": "Bytebase 会定时同步实例的 schema，新同步的数据库会首先被置于这里，之后您可以再将他们转移到适当的项目中。"

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -277,6 +277,7 @@
     "environments": "环境",
     "error": "错误",
     "expiration": "过期时间",
+    "expired": "已过期",
     "export": "导出",
     "failed": "失败",
     "file-selector": {

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -91,6 +91,7 @@ import {
   formatAbsoluteDateTime,
   hasProjectPermissionV2,
   hasWorkspacePermissionV2,
+  isBindingPolicyExpired,
   sortRoles,
 } from "@/utils";
 import {
@@ -1300,16 +1301,32 @@ function EditMemberRoleDrawer({
                   const rows = getSingleBindingRows(binding);
                   const envLimitation =
                     getProjectRoleBindingEnvironmentLimitationState(binding);
+                  const isExpired = isBindingPolicyExpired(binding);
                   return (
                     <div
                       key={`${binding.role}-${idx}`}
-                      className="border rounded-sm"
+                      className={cn(
+                        "border rounded-sm",
+                        isExpired && "opacity-60"
+                      )}
                     >
                       {/* Role header */}
                       <div className="flex items-center justify-between px-4 py-3 bg-control-bg border-b">
-                        <span className="font-medium text-sm">
-                          {displayRoleTitle(binding.role)}
-                        </span>
+                        <div className="flex items-center gap-x-2">
+                          <span
+                            className={cn(
+                              "font-medium text-sm",
+                              isExpired && "line-through"
+                            )}
+                          >
+                            {displayRoleTitle(binding.role)}
+                          </span>
+                          {isExpired && (
+                            <Badge variant="destructive" className="text-xs">
+                              {t("common.expired")}
+                            </Badge>
+                          )}
+                        </div>
                         <div className="flex items-center gap-x-1">
                           <Button
                             variant="ghost"

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -967,6 +967,20 @@ function EditMemberRoleDrawer({
   });
   const [isRequesting, setIsRequesting] = useState(false);
   const [showNestedGrant, setShowNestedGrant] = useState(false);
+  const [showExpiredRoles, setShowExpiredRoles] = useState(false);
+
+  const hasExpiredRoles = useMemo(
+    () => liveProjectRoleBindings.some((b) => isBindingPolicyExpired(b)),
+    [liveProjectRoleBindings]
+  );
+
+  const visibleProjectRoleBindings = useMemo(
+    () =>
+      showExpiredRoles
+        ? liveProjectRoleBindings
+        : liveProjectRoleBindings.filter((b) => !isBindingPolicyExpired(b)),
+    [liveProjectRoleBindings, showExpiredRoles]
+  );
 
   const [form, setForm] = useState<RoleBindingFormState>(() => ({
     id: crypto.randomUUID(),
@@ -1300,12 +1314,22 @@ function EditMemberRoleDrawer({
             {/* Body — Role Bindings */}
             <SheetBody className="px-6 py-6">
               <div className="flex flex-col gap-y-6">
-                {liveProjectRoleBindings.length === 0 && (
+                {hasExpiredRoles && (
+                  <label className="flex items-center gap-x-2 text-sm cursor-pointer self-start">
+                    <input
+                      type="checkbox"
+                      checked={showExpiredRoles}
+                      onChange={(e) => setShowExpiredRoles(e.target.checked)}
+                    />
+                    {t("project.members.show-expired-roles")}
+                  </label>
+                )}
+                {visibleProjectRoleBindings.length === 0 && (
                   <div className="text-center text-control-light py-8">
                     {t("common.no-data")}
                   </div>
                 )}
-                {liveProjectRoleBindings.map((binding, idx) => {
+                {visibleProjectRoleBindings.map((binding, idx) => {
                   const rows = getSingleBindingRows(binding);
                   const envLimitation =
                     getProjectRoleBindingEnvironmentLimitationState(binding);

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -942,11 +942,19 @@ function EditMemberRoleDrawer({
   const isProjectCreateMode = !!projectName && !isEditMode;
   const isProjectEditMode = !!projectName && isEditMode;
 
-  // Live project role bindings for the member (reactively updated when IAM policy changes)
+  // Live project role bindings for the member (reactively updated when IAM policy changes).
+  // Active bindings come first, expired ones last; original order is preserved within each group.
   const liveProjectRoleBindings = useVueState(() => {
     if (!isProjectEditMode || !member || !projectName) return [];
     const policy = projectIamPolicyStore.getProjectIamPolicy(projectName);
-    return policy.bindings.filter((b) => b.members.includes(member.binding));
+    const matching = policy.bindings.filter((b) =>
+      b.members.includes(member.binding)
+    );
+    return [...matching].sort((a, b) => {
+      const aExpired = isBindingPolicyExpired(a) ? 1 : 0;
+      const bExpired = isBindingPolicyExpired(b) ? 1 : 0;
+      return aExpired - bExpired;
+    });
   });
 
   const [selectedBindings, setSelectedBindings] = useState<string[]>(


### PR DESCRIPTION
## Summary
The project member detail panel rendered expired role bindings identically to active ones, so admins couldn't tell at a glance which roles had lapsed (BYT-9374).

This PR makes expiration visible and keeps the panel uncluttered:

- **Visual indicator on expired bindings** — the binding card gets reduced opacity, the role title gets strikethrough, and a destructive `Expired` badge is rendered next to the title (mirrors the existing Vue `RoleCell` strikethrough convention).
- **Sorted list** — active bindings render first, expired ones last; original ordering is preserved within each group.
- **Hidden by default** — expired bindings are filtered out unless the admin checks `Show expired roles`. The checkbox only appears when the member actually has at least one expired binding.
- **i18n** — `common.expired` and `project.members.show-expired-roles` added to all five React locales (en-US, es-ES, ja-JP, vi-VN, zh-CN).

## Test plan
- [ ] `pnpm --dir frontend type-check` passes
- [ ] `pnpm --dir frontend fix` is clean
- [ ] In a project, grant a member two roles — one with a past expiration and one active. Open the member detail panel:
  - [ ] Only the active role is visible by default
  - [ ] A `Show expired roles` checkbox is rendered above the list
  - [ ] After checking it, the expired role appears below the active one with strikethrough title + `Expired` badge + reduced opacity
- [ ] For a member with no expired roles, the checkbox is not rendered
- [ ] For a member with only never-expiring or active roles, behavior is unchanged

Fixes [BYT-9374](https://linear.app/bytebase/issue/BYT-9374/expired-member-role-is-not-visually-indicated-in-the-member-detail).


<img width="2404" height="1624" alt="CleanShot 2026-04-29 at 17 28 11@2x" src="https://github.com/user-attachments/assets/20ba62cb-86ea-4111-aa1c-59fe69cc4f9b" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)