### PR TITLE
cherrypick: [release/3.17.1] fix(frontend): show database group title in plan selectors (#20171)

### DIFF
--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -1236,7 +1236,7 @@ function DatabaseGroupSelector({
               <td className="py-2 pr-4">
                 <div className="flex items-center gap-x-1.5">
                   <FolderTree className="size-4 text-control-light shrink-0" />
-                  <span>{extractDatabaseGroupName(group.name)}</span>
+                  <span>{group.title}</span>
                 </div>
               </td>
             </tr>


### PR DESCRIPTION
## Summary

Cherry-picks [#20171](https://github.com/bytebase/bytebase/pull/20171) onto `release/3.17.1`. Fixes BYT-9375 — the create-plan database group selector was rendering the resource ID (e.g. `dypef`) instead of the human-readable `group.title`.

### Conflicts

- `frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx`: modify/delete conflict — this React file does not exist on `release/3.17.1` (it landed in [#20154](https://github.com/bytebase/bytebase/pull/20154) on `main` after the release branch was cut). Resolved by dropping that hunk; only `ProjectPlanDashboardPage.tsx` is patched here.
- The corresponding Vue selector on `release/3.17.1` (`frontend/src/components/DatabaseGroup/DatabaseGroupDataTable.vue`) already renders `data.title` correctly, so no Vue patch is needed.

## Test plan

- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)