### PR TITLE
feat(react): hide expired role chips in members table

### DIFF
--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -1680,12 +1680,13 @@ export function MembersPage({ projectId }: { projectId?: string }) {
     })
   );
 
+  // Derived from the unfiltered IAM policy, not memberBindings (which is
+  // already filtered by the search box). Otherwise the toggle would vanish
+  // whenever a search happens to exclude members with expired bindings.
   const hasExpiredProjectRoles = useMemo(() => {
-    if (!projectName) return false;
-    return memberBindings.some((mb) =>
-      mb.projectRoleBindings.some((b) => isBindingPolicyExpired(b))
-    );
-  }, [memberBindings, projectName]);
+    if (!projectName || !projectIamPolicy) return false;
+    return projectIamPolicy.bindings.some((b) => isBindingPolicyExpired(b));
+  }, [projectIamPolicy, projectName]);
 
   const canSetIamPolicy = project
     ? !isDefaultProject(project.name) &&

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -130,6 +130,7 @@ function MemberTable({
   onUpdateBinding,
   onRevokeBinding,
   scope,
+  showExpiredRoles,
 }: {
   bindings: MemberBinding[];
   allowEdit: boolean;
@@ -138,6 +139,7 @@ function MemberTable({
   onUpdateBinding: (binding: MemberBinding) => void;
   onRevokeBinding: (binding: MemberBinding) => void;
   scope: "workspace" | "project";
+  showExpiredRoles: boolean;
 }) {
   const { t } = useTranslation();
   const currentUser = useVueState(() => useCurrentUserV1().value);
@@ -183,9 +185,16 @@ function MemberTable({
   };
 
   const renderProjectRoleSummary = (bindings: Binding[]) => {
-    return groupProjectRoleBindings(bindings).map((group) => {
+    const visible = showExpiredRoles
+      ? bindings
+      : bindings.filter((b) => !isBindingPolicyExpired(b));
+    return groupProjectRoleBindings(visible).map((group) => {
+      const allExpired = group.bindings.every((b) => isBindingPolicyExpired(b));
       return (
-        <Badge key={group.role} className="text-xs gap-x-1">
+        <Badge
+          key={group.role}
+          className={cn("text-xs gap-x-1", allExpired && "line-through")}
+        >
           {displayRoleTitle(group.role)}
           {group.bindings.length > 1 && (
             <span className="text-control-light">
@@ -370,12 +379,14 @@ function MemberTableByRole({
   onUpdateBinding,
   onRevokeBinding,
   scope,
+  showExpiredRoles,
 }: {
   bindings: MemberBinding[];
   allowEdit: boolean;
   onUpdateBinding: (binding: MemberBinding) => void;
   onRevokeBinding: (binding: MemberBinding) => void;
   scope: "workspace" | "project";
+  showExpiredRoles: boolean;
 }) {
   const { t } = useTranslation();
   const currentUser = useVueState(() => useCurrentUserV1().value);
@@ -387,9 +398,12 @@ function MemberTableByRole({
   const roleToBindings = useMemo(() => {
     const map = new Map<string, MemberBinding[]>();
     for (const mb of bindings) {
+      const projectBindings = showExpiredRoles
+        ? mb.projectRoleBindings
+        : mb.projectRoleBindings.filter((b) => !isBindingPolicyExpired(b));
       const roles =
         scope === "project"
-          ? getProjectRoleSet(mb.projectRoleBindings)
+          ? getProjectRoleSet(projectBindings)
           : [...mb.workspaceLevelRoles];
       for (const role of roles) {
         if (!map.has(role)) map.set(role, []);
@@ -401,7 +415,7 @@ function MemberTableByRole({
       role,
       members: map.get(role) ?? [],
     }));
-  }, [bindings, scope]);
+  }, [bindings, scope, showExpiredRoles]);
 
   // Expand all roles by default on first load
   useEffect(() => {
@@ -1631,6 +1645,7 @@ export function MembersPage({ projectId }: { projectId?: string }) {
     MemberBinding | undefined
   >();
   const [showRequestRoleDialog, setShowRequestRoleDialog] = useState(false);
+  const [showExpiredRoles, setShowExpiredRoles] = useState(false);
 
   const hasRequestRoleFeature = useVueState(() =>
     subscriptionStore.hasFeature(PlanFeature.FEATURE_REQUEST_ROLE_WORKFLOW)
@@ -1664,6 +1679,13 @@ export function MembersPage({ projectId }: { projectId?: string }) {
       ignoreRoles: EMPTY_ROLE_SET,
     })
   );
+
+  const hasExpiredProjectRoles = useMemo(() => {
+    if (!projectName) return false;
+    return memberBindings.some((mb) =>
+      mb.projectRoleBindings.some((b) => isBindingPolicyExpired(b))
+    );
+  }, [memberBindings, projectName]);
 
   const canSetIamPolicy = project
     ? !isDefaultProject(project.name) &&
@@ -1898,14 +1920,26 @@ export function MembersPage({ projectId }: { projectId?: string }) {
         value={memberViewTab}
         onValueChange={(v) => setMemberViewTab(v as "MEMBERS" | "ROLES")}
       >
-        <TabsList>
-          <TabsTrigger value="MEMBERS">
-            {t("settings.members.view-by-members")}
-          </TabsTrigger>
-          <TabsTrigger value="ROLES">
-            {t("settings.members.view-by-roles")}
-          </TabsTrigger>
-        </TabsList>
+        <div className="flex items-center justify-between gap-x-4 border-b border-control-border">
+          <TabsList className="border-b-0">
+            <TabsTrigger value="MEMBERS">
+              {t("settings.members.view-by-members")}
+            </TabsTrigger>
+            <TabsTrigger value="ROLES">
+              {t("settings.members.view-by-roles")}
+            </TabsTrigger>
+          </TabsList>
+          {hasExpiredProjectRoles && (
+            <label className="flex items-center gap-x-2 text-sm cursor-pointer pb-2">
+              <input
+                type="checkbox"
+                checked={showExpiredRoles}
+                onChange={(e) => setShowExpiredRoles(e.target.checked)}
+              />
+              {t("project.members.show-expired-roles")}
+            </label>
+          )}
+        </div>
         <TabsPanel value="MEMBERS">
           <div className="py-4">
             <MemberTable
@@ -1916,6 +1950,7 @@ export function MembersPage({ projectId }: { projectId?: string }) {
               onUpdateBinding={handleMemberUpdateBinding}
               onRevokeBinding={handleMemberRevokeBinding}
               scope={scope}
+              showExpiredRoles={showExpiredRoles}
             />
           </div>
         </TabsPanel>
@@ -1927,6 +1962,7 @@ export function MembersPage({ projectId }: { projectId?: string }) {
               onUpdateBinding={handleMemberUpdateBinding}
               onRevokeBinding={handleMemberRevokeBinding}
               scope={scope}
+              showExpiredRoles={showExpiredRoles}
             />
           </div>
         </TabsPanel>


### PR DESCRIPTION
## Summary
Follow-up to [#20174](https://github.com/bytebase/bytebase/pull/20174). The role chips on the project members table still showed expired bindings counted alongside active ones (e.g. `Project Owner (2)` even when one of those bindings had expired). This PR applies the same expired-roles toggle to the table so the displayed role state matches the detail panel.

- `View by members`: role chips filter out expired bindings; counts reflect active bindings only. If a chip's group becomes entirely expired (only visible after toggle), it renders with strikethrough.
- `View by roles`: groupings exclude members whose only binding for that role is expired.
- A `Show expired roles` checkbox is added above the tabs (project scope), only rendered when the project actually has at least one expired binding. Default unchecked.

## Test plan
- [ ] `pnpm --dir frontend type-check` passes
- [ ] `pnpm --dir frontend fix` is clean
- [ ] In a project where a member has both active and expired bindings for the same role, the `Project Owner (N)` chip shows the active count by default; toggling `Show expired roles` includes the expired bindings (with strikethrough on a fully-expired chip)
- [ ] In `View by roles`, members appear under a role only if they have an active binding for it; toggling on includes members with expired-only bindings for that role
- [ ] When no expired bindings exist in the project, the checkbox is hidden
- [ ] Workspace scope (no project) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)