### PR TITLE
fix(react): align inquire enterprise plan button (BYT-9372)

### DIFF
--- a/frontend/src/react/pages/settings/SubscriptionPage.tsx
+++ b/frontend/src/react/pages/settings/SubscriptionPage.tsx
@@ -178,7 +178,7 @@ export function SubscriptionPage({
             <div className="text-main">
               {t("subscription.inquire-enterprise-plan")}
             </div>
-            <div className="mt-1 ml-auto">
+            <div className="mt-1">
               <Button className="text-lg" onClick={onRequireEnterprise}>
                 {t("subscription.contact-us")}
               </Button>


### PR DESCRIPTION
## Summary

The Contact Us button under "Inquire Enterprise Plan" on the Subscription page had `ml-auto` on its container, pushing it to the right edge of its grid cell. That misaligned it with the label above and with the buttons in sibling cells (Free trial, User count) which all left-align their controls. Drop `ml-auto` so the block matches its siblings.

Linear: [BYT-9372](https://linear.app/bytebase/issue/BYT-9372/align-of-inquire-enterprise-plan-label-and-button)

## Test plan

- [ ] Open Settings → Subscription on a workspace currently trialing the Enterprise plan and confirm the "Contact us" button is left-aligned in its grid cell, matching the "Free trial" cell to its left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)