### PR TITLE
feat: support TiDB extra connection parameters

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -429,7 +429,7 @@ func (s *InstanceService) checkDataSource(ctx context.Context, instance *store.I
 		return nil
 	}
 
-	// Validate extra connection parameters for MySQL-based engines
+	// Validate extra connection parameters for MySQL-compatible engines
 	if err := validateExtraConnectionParameters(instance.Metadata.GetEngine(), dataSource.GetExtraConnectionParameters()); err != nil {
 		return connect.NewError(connect.CodeInvalidArgument, err)
 	}
@@ -1164,9 +1164,9 @@ func (s *InstanceService) instanceCountGuard(ctx context.Context) error {
 
 // validateExtraConnectionParameters validates extra connection parameters for security risks.
 func validateExtraConnectionParameters(engine storepb.Engine, params map[string]string) error {
-	// Validate MySQL-based engines
+	// Validate MySQL-compatible engines
 	switch engine {
-	case storepb.Engine_MYSQL, storepb.Engine_MARIADB, storepb.Engine_OCEANBASE:
+	case storepb.Engine_MYSQL, storepb.Engine_MARIADB, storepb.Engine_OCEANBASE, storepb.Engine_TIDB:
 		for key := range params {
 			normalizedKey := strings.ToLower(strings.TrimSpace(key))
 			if normalizedKey == "allowallfiles" {

--- a/backend/api/v1/instance_service_test.go
+++ b/backend/api/v1/instance_service_test.go
@@ -1,0 +1,17 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+func TestValidateExtraConnectionParametersRejectsTiDBAllowAllFiles(t *testing.T) {
+	err := validateExtraConnectionParameters(storepb.Engine_TIDB, map[string]string{
+		"allowAllFiles": "true",
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "allowAllFiles")
+}

--- a/backend/plugin/db/tidb/tidb.go
+++ b/backend/plugin/db/tidb/tidb.go
@@ -56,7 +56,18 @@ func newDriver() db.Driver {
 	return &Driver{}
 }
 
-// Open opens a MySQL driver.
+// validateTiDBExtraConnectionParameters validates that no dangerous parameters are present.
+func validateTiDBExtraConnectionParameters(params map[string]string) error {
+	for key := range params {
+		normalizedKey := strings.ToLower(strings.TrimSpace(key))
+		if normalizedKey == "allowallfiles" {
+			return errors.Errorf("connection parameter %q is not allowed for security reasons", key)
+		}
+	}
+	return nil
+}
+
+// Open opens a TiDB driver.
 func (d *Driver) Open(_ context.Context, dbType storepb.Engine, connCfg db.ConnectionConfig) (db.Driver, error) {
 	defer func() {
 		for _, f := range d.openCleanUp {
@@ -64,40 +75,10 @@ func (d *Driver) Open(_ context.Context, dbType storepb.Engine, connCfg db.Conne
 		}
 	}()
 
-	protocol := "tcp"
-	if strings.HasPrefix(connCfg.DataSource.Host, "/") {
-		protocol = "unix"
-	}
-	params := []string{"multiStatements=true", "maxAllowedPacket=0"}
-	if connCfg.DataSource.GetSshHost() != "" {
-		sshClient, err := util.GetSSHClient(connCfg.DataSource)
-		if err != nil {
-			return nil, err
-		}
-		d.sshClient = sshClient
-		// Now we register the dialer with the ssh connection as a parameter.
-		protocol = "mysql-tcp-" + uuid.NewString()[:8]
-		// Now we register the dialer with the ssh connection as a parameter.
-		mysql.RegisterDialContext(protocol, func(_ context.Context, addr string) (net.Conn, error) {
-			return sshClient.Dial("tcp", addr)
-		})
-	}
-
-	tlscfg, err := util.GetTLSConfig(connCfg.DataSource)
+	dsn, err := d.getTiDBConnection(connCfg)
 	if err != nil {
-		return nil, errors.Wrap(err, "sql: tls config error")
+		return nil, err
 	}
-	tlsKey := uuid.NewString()
-	if tlscfg != nil {
-		if err := mysql.RegisterTLSConfig(tlsKey, tlscfg); err != nil {
-			return nil, errors.Wrap(err, "sql: failed to register tls config")
-		}
-		// TLS config is only used during sql.Open, so should be safe to deregister afterwards.
-		d.openCleanUp = append(d.openCleanUp, func() { mysql.DeregisterTLSConfig(tlsKey) })
-		params = append(params, fmt.Sprintf("tls=%s", tlsKey))
-	}
-
-	dsn := fmt.Sprintf("%s:%s@%s(%s:%s)/%s?%s", connCfg.DataSource.Username, connCfg.Password, protocol, connCfg.DataSource.Host, connCfg.DataSource.Port, connCfg.ConnectionContext.DatabaseName, strings.Join(params, "&"))
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return nil, err
@@ -110,6 +91,49 @@ func (d *Driver) Open(_ context.Context, dbType storepb.Engine, connCfg db.Conne
 	db.SetMaxIdleConns(15)
 	d.databaseName = connCfg.ConnectionContext.DatabaseName
 	return d, nil
+}
+
+func (d *Driver) getTiDBConnection(connCfg db.ConnectionConfig) (string, error) {
+	protocol := "tcp"
+	if strings.HasPrefix(connCfg.DataSource.Host, "/") {
+		protocol = "unix"
+	}
+	params := []string{"multiStatements=true", "maxAllowedPacket=0"}
+	if err := validateTiDBExtraConnectionParameters(connCfg.DataSource.GetExtraConnectionParameters()); err != nil {
+		return "", err
+	}
+	for key, value := range connCfg.DataSource.GetExtraConnectionParameters() {
+		params = append(params, fmt.Sprintf("%s=%s", key, value))
+	}
+	if connCfg.DataSource.GetSshHost() != "" {
+		sshClient, err := util.GetSSHClient(connCfg.DataSource)
+		if err != nil {
+			return "", err
+		}
+		d.sshClient = sshClient
+		// Now we register the dialer with the ssh connection as a parameter.
+		protocol = "mysql-tcp-" + uuid.NewString()[:8]
+		// Now we register the dialer with the ssh connection as a parameter.
+		mysql.RegisterDialContext(protocol, func(_ context.Context, addr string) (net.Conn, error) {
+			return sshClient.Dial("tcp", addr)
+		})
+	}
+
+	tlscfg, err := util.GetTLSConfig(connCfg.DataSource)
+	if err != nil {
+		return "", errors.Wrap(err, "sql: tls config error")
+	}
+	tlsKey := uuid.NewString()
+	if tlscfg != nil {
+		if err := mysql.RegisterTLSConfig(tlsKey, tlscfg); err != nil {
+			return "", errors.Wrap(err, "sql: failed to register tls config")
+		}
+		// TLS config is only used during sql.Open, so should be safe to deregister afterwards.
+		d.openCleanUp = append(d.openCleanUp, func() { mysql.DeregisterTLSConfig(tlsKey) })
+		params = append(params, fmt.Sprintf("tls=%s", tlsKey))
+	}
+
+	return fmt.Sprintf("%s:%s@%s(%s:%s)/%s?%s", connCfg.DataSource.Username, connCfg.Password, protocol, connCfg.DataSource.Host, connCfg.DataSource.Port, connCfg.ConnectionContext.DatabaseName, strings.Join(params, "&")), nil
 }
 
 // Close closes the driver.

--- a/backend/plugin/db/tidb/tidb_test.go
+++ b/backend/plugin/db/tidb/tidb_test.go
@@ -4,7 +4,52 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/db"
 )
+
+func TestGetTiDBConnectionUsesExtraConnectionParameters(t *testing.T) {
+	d := &Driver{}
+	dsn, err := d.getTiDBConnection(db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Host:     "127.0.0.1",
+			Port:     "4000",
+			Username: "root",
+			ExtraConnectionParameters: map[string]string{
+				"readTimeout":  "30s",
+				"writeTimeout": "45s",
+			},
+		},
+		Password: "secret",
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: "test",
+		},
+	})
+	require.NoError(t, err)
+	require.Contains(t, dsn, "readTimeout=30s")
+	require.Contains(t, dsn, "writeTimeout=45s")
+}
+
+func TestGetTiDBConnectionRejectsAllowAllFiles(t *testing.T) {
+	d := &Driver{}
+	_, err := d.getTiDBConnection(db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Host:     "127.0.0.1",
+			Port:     "4000",
+			Username: "root",
+			ExtraConnectionParameters: map[string]string{
+				"allowAllFiles": "true",
+			},
+		},
+		Password: "secret",
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: "test",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "allowAllFiles")
+}
 
 func TestParseVersion(t *testing.T) {
 	tests := []struct {

--- a/frontend/src/utils/v1/instance.test.ts
+++ b/frontend/src/utils/v1/instance.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Engine } from "@/types/proto-es/v1/common_pb";
+
+vi.mock("@/plugins/i18n", () => ({
+  t: (key: string) => key,
+}));
+
+vi.mock("@/store", () => ({
+  useSubscriptionV1Store: () => ({ currentPlan: 0 }),
+}));
+
+vi.mock("@/types", () => ({
+  isValidInstanceName: () => true,
+  languageOfEngineV1: () => "sql",
+  unknownInstance: () => ({ title: "Unknown" }),
+}));
+
+describe("instanceV1HasExtraParameters", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it("supports TiDB extra connection parameters", async () => {
+    const { instanceV1HasExtraParameters } = await import("./instance");
+    expect(instanceV1HasExtraParameters(Engine.TIDB)).toBe(true);
+  });
+});

--- a/frontend/src/utils/v1/instance.ts
+++ b/frontend/src/utils/v1/instance.ts
@@ -185,6 +185,7 @@ export const instanceV1HasExtraParameters = (
   const engine = engineOfInstanceV1(instanceOrEngine);
   return [
     Engine.MYSQL,
+    Engine.TIDB,
     Engine.MARIADB,
     Engine.OCEANBASE,
     Engine.POSTGRES,


### PR DESCRIPTION
## Summary
- Enable TiDB instances to pass DataSource extra connection parameters into the MySQL DSN.
- Expose the extra connection parameter UI for TiDB.
- Apply the existing `allowAllFiles` security guard to TiDB and add regression coverage.

Close BYT-9378

## Test Plan
- `gofmt -w backend/plugin/db/tidb/tidb.go backend/plugin/db/tidb/tidb_test.go backend/api/v1/instance_service.go backend/api/v1/instance_service_test.go`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- `go test -v -count=1 ./backend/plugin/db/tidb -run '^TestGetTiDBConnection'`
- `go test -v -count=1 ./backend/api/v1 -run '^TestValidateExtraConnectionParametersRejectsTiDBAllowAllFiles$'`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `NODE_OPTIONS=--no-experimental-webstorage pnpm --dir frontend test`
