### PR TITLE
chore: expand MSSQL completion Omni coverage

### DIFF
--- a/backend/plugin/parser/tsql/completion.go
+++ b/backend/plugin/parser/tsql/completion.go
@@ -11,6 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/antlr4-go/antlr/v4"
+	omnimssql "github.com/bytebase/omni/mssql"
 	mssqlparser "github.com/bytebase/omni/mssql/parser"
 	tsqlparser "github.com/bytebase/parser/tsql"
 
@@ -24,8 +25,6 @@ func init() {
 }
 
 var (
-	// Check tableRefListener is implementing the TSqlParserListener interface.
-	_ tsqlparser.TSqlParserListener = &tableRefListener{}
 	_ tsqlparser.TSqlParserListener = &cteExtractor{}
 
 	tsqlDataTypes = []string{
@@ -454,17 +453,14 @@ type Completer struct {
 	metadataGetter      base.GetDatabaseMetadataFunc
 	databaseNamesLister base.ListDatabaseNamesFunc
 
-	cteCache map[int][]*base.VirtualTableReference
-	// referencesStack is a hierarchical stack of table references.
-	// We'll update the stack when we encounter a new FROM clauses.
-	referencesStack [][]base.TableReference
 	// references is the flattened table references.
 	// It's helpful to look up the table reference.
-	references          []base.TableReference
-	referenceMap        map[string]bool
-	cteTables           []*base.VirtualTableReference
-	caretTokenIsQuoted  quotedType
-	noSeparatorRequired map[int]bool
+	references         []base.TableReference
+	referenceMap       map[string]bool
+	cteTables          []*base.VirtualTableReference
+	caretTokenIsQuoted quotedType
+	completionPrefix   string
+	completionIntent   *omnimssql.CompletionIntent
 }
 
 func Completion(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) ([]base.Candidate, error) {
@@ -514,7 +510,6 @@ func newCompleter(ctx context.Context, cCtx base.CompletionContext, parser *tsql
 		defaultSchema:       "dbo",
 		metadataGetter:      cCtx.Metadata,
 		databaseNamesLister: cCtx.ListDatabaseNames,
-		cteCache:            nil,
 	}
 }
 
@@ -644,48 +639,104 @@ func (c *Completer) complete() ([]base.Candidate, error) {
 		}
 	}
 
-	caretIndex := c.scanner.GetIndex()
-	if caretIndex > 0 && !c.noSeparatorRequired[c.scanner.GetPreviousTokenType(true)] {
-		caretIndex--
+	completionContext := omnimssql.CollectCompletion(c.sql, c.cursorByteOffset)
+	if completionContext != nil {
+		c.completionPrefix = completionContext.Prefix
+		c.completionIntent = completionContext.Intent
+		c.collectCompletionScopeReferences(completionContext)
+		c.collectCompletionCTEs(completionContext)
 	}
-	c.referencesStack = append([][]base.TableReference{{}}, c.referencesStack...)
+	candidates := (*mssqlparser.CandidateSet)(nil)
+	if completionContext != nil {
+		candidates = completionContext.Candidates
+	}
+	if candidates == nil {
+		candidates = mssqlparser.Collect(c.sql, c.cursorByteOffset)
+	}
 
-	completionOffset := c.cursorByteOffset
-	candidates := mssqlparser.Collect(c.sql, completionOffset)
-	if len(candidates.Rules) == 0 {
-		if prefixTok, ok := c.prefixToken(); ok {
-			completionOffset = prefixTok.Loc
-			candidates = mssqlparser.Collect(c.sql, completionOffset)
-		}
-	}
-
-	for _, rc := range candidates.Rules {
-		if rc.Rule == "columnref" {
-			c.collectLeadingTableReferences(caretIndex)
-			c.takeReferencesSnapshot()
-			c.collectRemainingTableReferences()
-			c.takeReferencesSnapshot()
-			break
-		}
-	}
 	return c.convertCandidates(candidates)
 }
 
-func (c *Completer) prefixToken() (mssqlparser.Token, bool) {
-	idx := c.caretTokenIndex
-	if idx < len(c.tokens) {
-		tok := c.tokens[idx]
-		if tok.Loc < c.cursorByteOffset && c.cursorByteOffset <= tok.End && mssqlparser.IsIdentTokenType(tok.Type) {
-			return tok, true
+func (c *Completer) determineObjectNameContext() []*objectRefContext {
+	if c.completionIntent == nil {
+		return c.determineFullTableNameContext()
+	}
+	context := newObjectRefContext()
+	qualifier := c.completionIntent.Qualifier
+	if qualifier.Server != "" {
+		context.setLinkedServer(qualifier.Server)
+	}
+	if qualifier.Database != "" {
+		context.setDatabase(qualifier.Database)
+	}
+	if qualifier.Schema != "" {
+		context.setSchema(qualifier.Schema)
+		if qualifier.Database == "" {
+			context.flags &^= objectFlagShowDatabase
 		}
 	}
-	if idx > 0 {
-		tok := c.tokens[idx-1]
-		if tok.End == c.cursorByteOffset && mssqlparser.IsIdentTokenType(tok.Type) {
-			return tok, true
+	if qualifier.Object != "" {
+		context.setObject(qualifier.Object)
+	}
+	return []*objectRefContext{context}
+}
+
+func (c *Completer) determineColumnNameContext() []*objectRefContext {
+	if c.completionIntent == nil || !completionIntentHasObjectKind(c.completionIntent, omnimssql.ObjectKindColumn) {
+		return c.determineFullColumnName()
+	}
+	context := newObjectRefContext(withColumn())
+	qualifier := c.completionIntent.Qualifier
+	if qualifier.Database == "" && qualifier.Schema != "" && qualifier.Object == "" &&
+		(strings.EqualFold(qualifier.Schema, "INSERTED") || strings.EqualFold(qualifier.Schema, "DELETED")) {
+		return []*objectRefContext{context}
+	}
+	if qualifier.Object != "" {
+		if qualifier.Server != "" {
+			context.setLinkedServer(qualifier.Server)
+		}
+		if qualifier.Database != "" {
+			context.setDatabase(qualifier.Database)
+		}
+		if qualifier.Schema != "" {
+			context.setSchema(qualifier.Schema)
+		}
+		context.setObject(qualifier.Object)
+		context.flags &^= objectFlagShowDatabase | objectFlagShowSchema
+		return []*objectRefContext{context}
+	}
+	if qualifier.Server != "" && qualifier.Database != "" && qualifier.Schema != "" {
+		context.setDatabase(qualifier.Server)
+		context.setSchema(qualifier.Database)
+		context.setObject(qualifier.Schema)
+		context.flags &^= objectFlagShowDatabase | objectFlagShowSchema
+		return []*objectRefContext{context}
+	}
+	if qualifier.Schema != "" {
+		if qualifier.Database != "" {
+			context.setSchema(qualifier.Database)
+		}
+		context.setObject(qualifier.Schema)
+		context.flags &^= objectFlagShowDatabase | objectFlagShowSchema
+		return []*objectRefContext{context}
+	}
+	if qualifier.Database != "" {
+		context.setObject(qualifier.Database)
+		context.flags &^= objectFlagShowDatabase | objectFlagShowSchema
+	}
+	return []*objectRefContext{context}
+}
+
+func completionIntentHasObjectKind(intent *omnimssql.CompletionIntent, kind omnimssql.ObjectKind) bool {
+	if intent == nil {
+		return false
+	}
+	for _, objectKind := range intent.ObjectKinds {
+		if objectKind == kind {
+			return true
 		}
 	}
-	return mssqlparser.Token{}, false
+	return false
 }
 
 func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]base.Candidate, error) {
@@ -710,6 +761,8 @@ func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]b
 		})
 	}
 
+	c.insertCompletionIntentCandidates(keywordEntries, functionEntries, databaseEntries, schemaEntries, tableEntries, viewEntries, sequenceEntries, routineEntries)
+
 	for _, ruleCandidate := range candidates.Rules {
 		c.scanner.PopAndRestore()
 		c.scanner.Push()
@@ -721,14 +774,14 @@ func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]b
 			databaseEntries.insertMetadataDatabases(c, "")
 		case "schema_ref":
 			schemaEntries.insertMetadataSchemas(c, "", "")
-		case "proc_ref":
-			for _, context := range c.determineFullTableNameContext() {
+		case "proc_ref", "proc_name":
+			for _, context := range c.determineObjectNameContext() {
 				if context.flags&objectFlagShowObject != 0 {
 					routineEntries.insertMetadataProcedures(c, context.linkedServer, context.database, context.schema)
 				}
 			}
 		case "sequence_ref":
-			for _, context := range c.determineFullTableNameContext() {
+			for _, context := range c.determineObjectNameContext() {
 				if context.flags&objectFlagShowObject != 0 {
 					sequenceEntries.insertMetadataSequences(c, context.linkedServer, context.database, context.schema)
 				}
@@ -741,9 +794,15 @@ func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]b
 				})
 			}
 		case "table_ref":
-			completionContexts := c.determineFullTableNameContext()
+			completionContexts := c.determineObjectNameContext()
 			for _, context := range completionContexts {
 				c.insertObjectCandidates(context, databaseEntries, schemaEntries, tableEntries, viewEntries, sequenceEntries)
+			}
+		case "view_name", "view_ref":
+			for _, context := range c.determineObjectNameContext() {
+				if context.flags&objectFlagShowObject != 0 {
+					viewEntries.insertMetadataViews(c, context.linkedServer, context.database, context.schema)
+				}
 			}
 		case "asterisk":
 			completionContexts := c.determineAsteriskContext()
@@ -751,7 +810,7 @@ func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]b
 				c.insertObjectCandidates(context, databaseEntries, schemaEntries, tableEntries, viewEntries, sequenceEntries)
 			}
 		case "columnref":
-			completionContexts := c.determineFullColumnName()
+			completionContexts := c.determineColumnNameContext()
 			for _, context := range completionContexts {
 				c.insertObjectCandidates(context, databaseEntries, schemaEntries, tableEntries, viewEntries, sequenceEntries)
 				if context.flags&objectFlagShowObject != 0 {
@@ -793,10 +852,17 @@ func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]b
 							})
 						}
 					}
-					columnEntries.insertMetadataColumns(c, context.linkedServer, context.database, context.schema, context.object)
+					if !context.empty() || len(c.references) == 0 {
+						columnEntries.insertMetadataColumns(c, context.linkedServer, context.database, context.schema, context.object)
+					}
 					for _, reference := range c.references {
+						matchedQualifiedReference := false
 						switch reference := reference.(type) {
 						case *base.PhysicalTableReference:
+							if context.empty() {
+								columnEntries.insertMetadataColumns(c, "", reference.Database, reference.Schema, reference.Table)
+								continue
+							}
 							inputLinkedServer := context.linkedServer
 							inputDatabaseName := context.database
 							if inputDatabaseName == "" {
@@ -817,19 +883,26 @@ func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]b
 								referenceSchemaName = c.defaultSchema
 							}
 							referenceTableName := reference.Table
+							referenceTableIsAlias := false
 							if reference.Alias != "" {
 								referenceTableName = reference.Alias
+								referenceTableIsAlias = true
 							}
 
-							if inputLinkedServer == "" && strings.EqualFold(referenceDatabaseName, inputDatabaseName) &&
-								strings.EqualFold(referenceSchemaName, inputSchemaName) &&
-								strings.EqualFold(referenceTableName, inputTableName) {
+							if inputLinkedServer == "" && strings.EqualFold(referenceTableName, inputTableName) &&
+								(referenceTableIsAlias ||
+									(strings.EqualFold(referenceDatabaseName, inputDatabaseName) &&
+										strings.EqualFold(referenceSchemaName, inputSchemaName))) {
 								columnEntries.insertMetadataColumns(c, "", reference.Database, reference.Schema, reference.Table)
+								matchedQualifiedReference = referenceTableIsAlias && context.database == "" && context.schema == ""
 							}
 						case *base.VirtualTableReference:
 							// Reference could be a physical table reference or a virtual table reference, if the reference is a virtual table reference,
 							// and users do not specify the server, database and schema, we should also insert the columns.
 							if context.linkedServer == "" && context.database == "" && context.schema == "" {
+								if context.object != "" && !strings.EqualFold(reference.Table, context.object) {
+									continue
+								}
 								for _, column := range reference.Columns {
 									if _, ok := columnEntries[column]; !ok {
 										columnEntries[column] = base.Candidate{
@@ -838,8 +911,12 @@ func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]b
 										}
 									}
 								}
+								matchedQualifiedReference = context.object != ""
 							}
 						default:
+						}
+						if matchedQualifiedReference {
+							break
 						}
 					}
 					if context.linkedServer == "" && context.database == "" && context.schema == "" {
@@ -856,7 +933,7 @@ func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]b
 							}
 						}
 					}
-					if context.empty() {
+					if context.empty() && len(c.references) == 0 {
 						columnEntries.insertAllColumns(c)
 					}
 				}
@@ -879,7 +956,71 @@ func (c *Completer) convertCandidates(candidates *mssqlparser.CandidateSet) ([]b
 	result = append(result, viewEntries.toSlice()...)
 	result = append(result, sequenceEntries.toSlice()...)
 	result = append(result, routineEntries.toSlice()...)
-	return result, nil
+	return c.filterCandidatesByPrefix(result), nil
+}
+
+func (c *Completer) insertCompletionIntentCandidates(keywordEntries, functionEntries, databaseEntries, schemaEntries, tableEntries, viewEntries, sequenceEntries, routineEntries CompletionMap) {
+	if c.completionIntent == nil {
+		return
+	}
+	contexts := c.determineObjectNameContext()
+	for _, kind := range c.completionIntent.ObjectKinds {
+		for _, context := range contexts {
+			switch kind {
+			case omnimssql.ObjectKindDatabase:
+				databaseEntries.insertMetadataDatabases(c, context.linkedServer)
+			case omnimssql.ObjectKindSchema:
+				schemaEntries.insertMetadataSchemas(c, context.linkedServer, context.database)
+			case omnimssql.ObjectKindTable:
+				if context.flags&objectFlagShowObject != 0 {
+					tableEntries.insertMetadataTables(c, context.linkedServer, context.database, context.schema)
+				}
+			case omnimssql.ObjectKindView:
+				if context.flags&objectFlagShowObject != 0 {
+					viewEntries.insertMetadataViews(c, context.linkedServer, context.database, context.schema)
+				}
+			case omnimssql.ObjectKindSequence:
+				if context.flags&objectFlagShowObject != 0 {
+					sequenceEntries.insertMetadataSequences(c, context.linkedServer, context.database, context.schema)
+				}
+			case omnimssql.ObjectKindProcedure:
+				if context.flags&objectFlagShowObject != 0 {
+					routineEntries.insertMetadataProcedures(c, context.linkedServer, context.database, context.schema)
+				}
+			case omnimssql.ObjectKindFunction:
+				functionEntries.insertBuiltinFunctions()
+			case omnimssql.ObjectKindType:
+				for _, typ := range tsqlDataTypes {
+					keywordEntries.Insert(base.Candidate{
+						Type: base.CandidateTypeKeyword,
+						Text: typ,
+					})
+				}
+			default:
+			}
+		}
+	}
+}
+
+func (c *Completer) filterCandidatesByPrefix(candidates []base.Candidate) []base.Candidate {
+	prefix := c.completionPrefix
+	if prefix == "" {
+		return candidates
+	}
+	_, normalizedPrefix := NormalizeTSQLIdentifierText(prefix)
+	if normalizedPrefix == "" {
+		return candidates
+	}
+	filtered := make([]base.Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		text := strings.TrimSuffix(candidate.Text, "()")
+		text = unquoteDoubleQuoted(text)
+		_, normalizedText := NormalizeTSQLIdentifierText(text)
+		if strings.HasPrefix(normalizedText, normalizedPrefix) {
+			filtered = append(filtered, candidate)
+		}
+	}
+	return filtered
 }
 
 func (c *Completer) insertObjectCandidates(context *objectRefContext, databaseEntries, schemaEntries, tableEntries, viewEntries, sequenceEntries CompletionMap) {
@@ -1258,7 +1399,7 @@ func isDerivedTableOpen(upperSQL string, idx int) bool {
 		return false
 	}
 	before := strings.TrimRight(upperSQL[:idx], asciiWhitespace)
-	for _, keyword := range []string{"FROM", "JOIN", "APPLY"} {
+	for _, keyword := range []string{"FROM", "JOIN", "APPLY", "USING"} {
 		if strings.HasSuffix(before, keyword) {
 			return true
 		}
@@ -1762,11 +1903,167 @@ func hasMultipleNonEmptyStatements(statements []base.Statement) bool {
 	return false
 }
 
-func (c *Completer) takeReferencesSnapshot() {
-	c.ensureReferenceMap()
-	for _, references := range c.referencesStack {
-		c.rememberReferences(references)
+func (c *Completer) collectCompletionScopeReferences(completionContext *omnimssql.CompletionContext) {
+	if completionContext == nil || completionContext.Scope == nil {
+		return
 	}
+	var references []base.TableReference
+	appendReference := func(reference omnimssql.RangeReference) {
+		if converted := c.convertCompletionScopeReference(reference); converted != nil {
+			references = append(references, converted)
+		}
+	}
+	if completionContext.Scope.DMLTarget != nil {
+		appendReference(*completionContext.Scope.DMLTarget)
+	}
+	if completionContext.Scope.MergeTarget != nil {
+		appendReference(*completionContext.Scope.MergeTarget)
+	}
+	if completionContext.Scope.MergeSource != nil {
+		appendReference(*completionContext.Scope.MergeSource)
+	}
+	for _, reference := range completionContext.Scope.LocalReferences {
+		appendReference(reference)
+	}
+	for _, level := range completionContext.Scope.OuterReferences {
+		for _, reference := range level {
+			appendReference(reference)
+		}
+	}
+	c.rememberReferencesIfMissing(references)
+}
+
+func (c *Completer) collectCompletionCTEs(completionContext *omnimssql.CompletionContext) {
+	if completionContext == nil {
+		return
+	}
+	for _, reference := range completionContext.CTEs {
+		virtual := c.convertCompletionVirtualReference(reference)
+		if virtual == nil {
+			continue
+		}
+		c.appendCTEIfMissing(virtual)
+	}
+}
+
+func (c *Completer) appendCTEIfMissing(reference *base.VirtualTableReference) {
+	for _, existing := range c.cteTables {
+		if strings.EqualFold(existing.Table, reference.Table) {
+			if len(existing.Columns) == 0 && len(reference.Columns) > 0 {
+				existing.Columns = reference.Columns
+			}
+			return
+		}
+	}
+	c.cteTables = append(c.cteTables, reference)
+}
+
+func (c *Completer) rememberReferencesIfMissing(references []base.TableReference) {
+	c.ensureReferenceMap()
+	for _, reference := range references {
+		if c.hasReference(reference) {
+			continue
+		}
+		c.rememberReferences([]base.TableReference{reference})
+	}
+}
+
+func (c *Completer) hasReference(reference base.TableReference) bool {
+	key := completionTableReferenceKey(reference)
+	for _, existing := range c.references {
+		if completionTableReferenceKey(existing) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func completionTableReferenceKey(reference base.TableReference) string {
+	switch reference := reference.(type) {
+	case *base.PhysicalTableReference:
+		return strings.Join([]string{"physical", reference.Database, reference.Schema, reference.Table, reference.Alias}, "\x00")
+	case *base.VirtualTableReference:
+		return strings.Join([]string{"virtual", reference.Table}, "\x00")
+	default:
+		return fmt.Sprintf("%T", reference)
+	}
+}
+
+func (c *Completer) convertCompletionScopeReference(reference omnimssql.RangeReference) base.TableReference {
+	switch reference.Kind {
+	case omnimssql.RangeReferenceRelation, omnimssql.RangeReferenceDMLTarget, omnimssql.RangeReferenceMergeTarget, omnimssql.RangeReferenceMergeSource:
+		alias := normalizeCompletionIdentifier(reference.Alias)
+		if reference.Kind == omnimssql.RangeReferenceMergeSource {
+			table := normalizeCompletionIdentifier(reference.Object)
+			if columns := c.lookupCTEColumns(table); len(columns) > 0 {
+				if alias != "" {
+					table = alias
+				}
+				return &base.VirtualTableReference{
+					Table:   table,
+					Columns: columns,
+				}
+			}
+		}
+		return &base.PhysicalTableReference{
+			Database: normalizeCompletionIdentifier(reference.Database),
+			Schema:   normalizeCompletionIdentifier(reference.Schema),
+			Table:    normalizeCompletionIdentifier(reference.Object),
+			Alias:    alias,
+		}
+	case omnimssql.RangeReferenceCTE, omnimssql.RangeReferenceValues, omnimssql.RangeReferenceSubquery, omnimssql.RangeReferenceTableVariable, omnimssql.RangeReferenceJoinAlias, omnimssql.RangeReferenceFunction:
+		return c.convertCompletionVirtualReference(reference)
+	default:
+		return nil
+	}
+}
+
+func (c *Completer) convertCompletionVirtualReference(reference omnimssql.RangeReference) *base.VirtualTableReference {
+	table := completionReferenceName(reference)
+	if table == "" {
+		return nil
+	}
+	columns := completionReferenceColumns(reference)
+	if len(columns) == 0 && reference.Kind == omnimssql.RangeReferenceCTE {
+		columns = c.lookupCTEColumns(table)
+	}
+	return &base.VirtualTableReference{
+		Table:   table,
+		Columns: columns,
+	}
+}
+
+func completionReferenceName(reference omnimssql.RangeReference) string {
+	if reference.Alias != "" {
+		return normalizeCompletionIdentifier(reference.Alias)
+	}
+	return normalizeCompletionIdentifier(reference.Object)
+}
+
+func completionReferenceColumns(reference omnimssql.RangeReference) []string {
+	columns := reference.Columns
+	if len(columns) == 0 {
+		columns = reference.AliasColumns
+	}
+	result := make([]string, 0, len(columns))
+	for _, column := range columns {
+		result = append(result, normalizeCompletionIdentifier(column))
+	}
+	return result
+}
+
+func normalizeCompletionIdentifier(identifier string) string {
+	original, _ := NormalizeTSQLIdentifierText(unquoteDoubleQuoted(identifier))
+	return original
+}
+
+func (c *Completer) lookupCTEColumns(table string) []string {
+	for _, cte := range c.cteTables {
+		if strings.EqualFold(cte.Table, table) {
+			return cte.Columns
+		}
+	}
+	return nil
 }
 
 func (c *Completer) ensureReferenceMap() {
@@ -1796,271 +2093,6 @@ func (c *Completer) physicalReferenceKey(reference *base.PhysicalTableReference)
 		schema = c.defaultSchema
 	}
 	return fmt.Sprintf("%s.%s.%s", database, schema, reference.Table)
-}
-
-func (c *Completer) collectLeadingTableReferences(caretIndex int) {
-	c.scanner.Push()
-
-	c.scanner.SeekIndex(0)
-
-	level := 0
-	for {
-		found := c.scanner.GetTokenType() == tsqlparser.TSqlLexerFROM
-		for !found {
-			if !c.scanner.Forward(false) || c.scanner.GetIndex() >= caretIndex {
-				break
-			}
-
-			switch c.scanner.GetTokenType() {
-			case tsqlparser.TSqlLexerLR_BRACKET:
-				level++
-				c.referencesStack = append([][]base.TableReference{{}}, c.referencesStack...)
-			case tsqlparser.TSqlLexerRR_BRACKET:
-				if level == 0 {
-					c.scanner.PopAndRestore()
-					return // We cannot go above the initial nesting level.
-				}
-			case tsqlparser.TSqlLexerFROM:
-				found = true
-			default:
-				// Other tokens, continue scanning
-			}
-		}
-		if !found {
-			c.scanner.PopAndRestore()
-			return // No FROM clause found.
-		}
-		c.parseTableReferences(c.scanner.GetFollowingText())
-		if c.scanner.GetTokenType() == tsqlparser.TSqlLexerFROM {
-			c.scanner.Forward(false /* skipHidden */)
-		}
-	}
-}
-
-func (c *Completer) collectRemainingTableReferences() {
-	c.scanner.Push()
-
-	level := 0
-	for {
-		found := c.scanner.GetTokenType() == tsqlparser.TSqlLexerFROM
-		for !found {
-			if !c.scanner.Forward(false /* skipHidden */) {
-				break
-			}
-
-			switch c.scanner.GetTokenType() {
-			case tsqlparser.TSqlLexerLR_BRACKET:
-				level++
-				c.referencesStack = append([][]base.TableReference{{}}, c.referencesStack...)
-			case tsqlparser.TSqlLexerRR_BRACKET:
-				if level > 0 {
-					level--
-				}
-
-			case tsqlparser.TSqlLexerFROM:
-				if level == 0 {
-					found = true
-				}
-			default:
-				// Other tokens, continue scanning
-			}
-		}
-
-		if !found {
-			c.scanner.PopAndRestore()
-			return // No more FROM clause found.
-		}
-
-		c.parseTableReferences(c.scanner.GetFollowingText())
-		if c.scanner.GetTokenType() == tsqlparser.TSqlLexerFROM {
-			c.scanner.Forward(false /* skipHidden */)
-		}
-	}
-}
-
-func (c *Completer) parseTableReferences(fromClause string) {
-	input := antlr.NewInputStream(fromClause)
-	lexer := tsqlparser.NewTSqlLexer(input)
-	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	parser := tsqlparser.NewTSqlParser(tokens)
-
-	parser.BuildParseTrees = true
-	parser.RemoveErrorListeners()
-	tree := parser.From_table_sources()
-	listener := &tableRefListener{
-		context:        c,
-		fromClauseMode: true,
-	}
-	antlr.ParseTreeWalkerDefault.Walk(listener, tree)
-}
-
-type tableRefListener struct {
-	*tsqlparser.BaseTSqlParserListener
-
-	context        *Completer
-	fromClauseMode bool
-	done           bool
-	level          int
-}
-
-func (l *tableRefListener) ExitAs_table_alias(ctx *tsqlparser.As_table_aliasContext) {
-	if l.done {
-		return
-	}
-	if l.level == 0 && len(l.context.referencesStack) != 0 && len(l.context.referencesStack[0]) != 0 {
-		if physicalTable, ok := l.context.referencesStack[0][len(l.context.referencesStack[0])-1].(*base.PhysicalTableReference); ok {
-			physicalTable.Alias = unquote(ctx.Table_alias().GetText())
-			return
-		}
-		if virtualTable, ok := l.context.referencesStack[0][len(l.context.referencesStack[0])-1].(*base.VirtualTableReference); ok {
-			virtualTable.Table = unquote(ctx.Table_alias().GetText())
-		}
-	}
-}
-
-func (l *tableRefListener) ExitColumn_alias_list(ctx *tsqlparser.Column_alias_listContext) {
-	if l.done {
-		return
-	}
-
-	if l.level == 0 && len(l.context.referencesStack) != 0 && len(l.context.referencesStack[0]) != 0 {
-		if virtualTable, ok := l.context.referencesStack[0][len(l.context.referencesStack[0])-1].(*base.VirtualTableReference); ok {
-			var newColumns []string
-			for _, column := range ctx.AllColumn_alias() {
-				newColumns = append(newColumns, unquote(column.GetText()))
-			}
-			virtualTable.Columns = newColumns
-		}
-	}
-}
-
-func (l *tableRefListener) ExitFull_table_name(ctx *tsqlparser.Full_table_nameContext) {
-	if l.done {
-		return
-	}
-
-	if !l.fromClauseMode || l.level == 0 {
-		reference := &base.PhysicalTableReference{}
-		_ /* Linked Server */, database, schema, table := normalizeFullTableNameFallback(ctx, "", "")
-		reference.Database = database
-		reference.Schema = schema
-		reference.Table = table
-		l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-	}
-}
-
-func (l *tableRefListener) ExitRowset_function(*tsqlparser.Rowset_functionContext) {
-	if l.done {
-		return
-	}
-
-	if !l.fromClauseMode || l.level == 0 {
-		reference := &base.VirtualTableReference{}
-
-		l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-	}
-}
-
-func (l *tableRefListener) ExitDerivedTable(ctx *tsqlparser.Derived_tableContext) {
-	if l.done {
-		return
-	}
-
-	pCtx, ok := ctx.GetParent().(*tsqlparser.Table_source_itemContext)
-	if !ok {
-		return
-	}
-
-	derivedTableName := unquote(pCtx.As_table_alias().Table_alias().GetText())
-	reference := &base.VirtualTableReference{
-		Table: derivedTableName,
-	}
-
-	if pCtx.Column_alias_list() == nil {
-		// User do not specify the column alias, we should use query span to get the column alias.
-		if span, err := GetQuerySpan(
-			l.context.ctx,
-			base.GetQuerySpanContext{
-				InstanceID:              l.context.instanceID,
-				GetDatabaseMetadataFunc: l.context.metadataGetter,
-				ListDatabaseNamesFunc:   l.context.databaseNamesLister,
-			},
-			base.Statement{Text: fmt.Sprintf("SELECT * FROM (%s);", ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx))},
-			l.context.defaultDatabase,
-			l.context.defaultSchema,
-			true,
-		); err == nil && span.NotFoundError == nil {
-			for _, column := range span.Results {
-				reference.Columns = append(reference.Columns, column.Name)
-			}
-		}
-	}
-	l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-}
-
-func (l *tableRefListener) ExitChange_table(*tsqlparser.Change_tableContext) {
-	if l.done {
-		return
-	}
-
-	if !l.fromClauseMode || l.level == 0 {
-		reference := &base.VirtualTableReference{}
-		l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-	}
-}
-
-func (l *tableRefListener) ExitNodes_method(*tsqlparser.Nodes_methodContext) {
-	if l.done {
-		return
-	}
-
-	if !l.fromClauseMode || l.level == 0 {
-		reference := &base.VirtualTableReference{}
-		l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-	}
-}
-
-func (l *tableRefListener) EnterTable_source_item(ctx *tsqlparser.Table_source_itemContext) {
-	if l.done {
-		return
-	}
-
-	if !l.fromClauseMode || l.level == 0 {
-		if ctx.GetLoc_id() != nil {
-			reference := &base.VirtualTableReference{}
-			l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-		} else if ctx.GetLoc_id_call() != nil {
-			reference := &base.VirtualTableReference{}
-			l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-		} else if ctx.GetOldstyle_fcall() != nil {
-			reference := &base.VirtualTableReference{}
-			l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-		}
-	}
-}
-
-func (l *tableRefListener) EnterSubquery(*tsqlparser.SubqueryContext) {
-	if l.done {
-		return
-	}
-
-	if l.fromClauseMode {
-		l.level++
-	} else {
-		l.context.referencesStack = append([][]base.TableReference{{}}, l.context.referencesStack...)
-	}
-}
-
-func (l *tableRefListener) ExitSubquery(*tsqlparser.SubqueryContext) {
-	if l.done {
-		return
-	}
-
-	if l.fromClauseMode {
-		l.level--
-	} else {
-		l.context.referencesStack = l.context.referencesStack[1:]
-	}
 }
 
 func (c *Completer) fetchCommonTableExpression(statement string) {

--- a/backend/plugin/parser/tsql/completion_matrix_test.go
+++ b/backend/plugin/parser/tsql/completion_matrix_test.go
@@ -52,6 +52,14 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("Name"),
 		},
 		{
+			name: "cross database qualified column reference",
+			sql:  "SELECT School.dbo.Student.|",
+			want: columns("Id", "ParentName"),
+			notWant: columns(
+				"Name",
+			),
+		},
+		{
 			name: "where clause uses current table columns",
 			sql:  "SELECT * FROM Employees WHERE |",
 			want: columns("Id", "Name"),
@@ -99,8 +107,63 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("Id", "Name"),
 		},
 		{
+			name: "in expression after comma uses current table columns",
+			sql:  "SELECT * FROM Employees WHERE Id IN (1, |)",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "or predicate uses current table columns",
+			sql:  "SELECT * FROM Employees WHERE Id = 1 OR |",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "and predicate after is null uses current table columns",
+			sql:  "SELECT * FROM Employees WHERE Id IS NULL AND |",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "not predicate uses current table columns",
+			sql:  "SELECT * FROM Employees WHERE NOT |",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "comparison expression uses current table columns",
+			sql:  "SELECT * FROM Employees WHERE Id > |",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "qualified comparison expression uses alias columns",
+			sql:  "SELECT * FROM Employees e WHERE e.Id = |",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "arithmetic expression uses current table columns",
+			sql:  "SELECT * FROM Employees WHERE Id + | > 0",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "between upper bound uses current table columns",
+			sql:  "SELECT * FROM Employees WHERE Id BETWEEN 1 AND |",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "parenthesized predicate uses current table columns",
+			sql:  "SELECT * FROM Employees WHERE (|)",
+			want: columns("Id", "Name"),
+		},
+		{
 			name: "case predicate uses current table columns",
 			sql:  "SELECT CASE WHEN | THEN 1 ELSE 0 END FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "case then expression uses current table columns",
+			sql:  "SELECT CASE WHEN Id > 0 THEN | ELSE 0 END FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "case else expression uses current table columns",
+			sql:  "SELECT CASE WHEN Id > 0 THEN 1 ELSE | END FROM Employees",
 			want: columns("Id", "Name"),
 		},
 		{
@@ -114,6 +177,41 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("Id", "Name"),
 		},
 		{
+			name: "nested function argument uses current table columns",
+			sql:  "SELECT ABS(ROUND(|, 0)) FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "isnull argument uses current table columns",
+			sql:  "SELECT ISNULL(|, 0) FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "coalesce argument uses current table columns",
+			sql:  "SELECT COALESCE(NULL, |) FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "nullif argument uses current table columns",
+			sql:  "SELECT NULLIF(|, 0) FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "cast argument uses current table columns",
+			sql:  "SELECT CAST(| AS INT) FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "convert argument uses current table columns",
+			sql:  "SELECT CONVERT(INT, |) FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "iif predicate uses current table columns",
+			sql:  "SELECT IIF(|, 1, 0) FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
 			name: "order by includes select alias",
 			sql:  "SELECT Id AS IdAlias, Name FROM Employees ORDER BY |",
 			want: append(columns("Id", "Name"), column("IdAlias")),
@@ -122,6 +220,16 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			name: "order by includes tsql equals alias",
 			sql:  "SELECT IdAlias = Id, Name FROM Employees ORDER BY |",
 			want: append(columns("Id", "Name"), column("IdAlias")),
+		},
+		{
+			name: "order by alias prefix keeps select alias available",
+			sql:  "SELECT Id AS IdAlias, Name FROM Employees ORDER BY IdA|",
+			want: columns("IdAlias"),
+		},
+		{
+			name: "order by column prefix keeps matching column available",
+			sql:  "SELECT * FROM Employees ORDER BY Na|",
+			want: columns("Name"),
 		},
 		{
 			name: "top select list uses columns",
@@ -139,8 +247,18 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("Id", "Name"),
 		},
 		{
+			name: "window partition by uses qualified alias columns",
+			sql:  "SELECT ROW_NUMBER() OVER (PARTITION BY e.| ORDER BY e.Id) FROM Employees e",
+			want: columns("Id", "Name"),
+		},
+		{
 			name: "window order by uses columns",
 			sql:  "SELECT ROW_NUMBER() OVER (ORDER BY |) FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "window order by uses qualified alias columns",
+			sql:  "SELECT ROW_NUMBER() OVER (PARTITION BY e.Id ORDER BY e.|) FROM Employees e",
 			want: columns("Id", "Name"),
 		},
 		{
@@ -168,6 +286,11 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 		{
 			name: "order by alias columns before offset",
 			sql:  "SELECT * FROM Employees e ORDER BY e.| OFFSET 10 ROWS",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "offset fetch order by keeps alias columns",
+			sql:  "SELECT * FROM Employees e ORDER BY e.| OFFSET 10 ROWS FETCH NEXT 5 ROWS ONLY",
 			want: columns("Id", "Name"),
 		},
 		{
@@ -237,6 +360,29 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("Id", "Name", "EmployeeId", "Street", "SalaryUpBound"),
 		},
 		{
+			name: "cross join where uses right alias columns",
+			sql:  "SELECT * FROM Employees e CROSS JOIN Address a WHERE a.|",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
+			name: "schema qualified join on uses right alias columns",
+			sql:  "SELECT * FROM Employees e LEFT JOIN MySchema.SalaryLevel s ON s.|",
+			want: columns("Id", "SalaryUpBound"),
+		},
+		{
+			name: "joined order by uses right alias columns",
+			sql:  "SELECT * FROM Employees e JOIN Address a ON e.Id = a.EmployeeId ORDER BY a.|",
+			want: columns("EmployeeId", "Street"),
+			notWant: columns(
+				"Name",
+			),
+		},
+		{
+			name: "joined group by uses right alias columns",
+			sql:  "SELECT a.EmployeeId, COUNT(*) FROM Employees e JOIN Address a ON e.Id = a.EmployeeId GROUP BY a.|",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
 			name: "default schema table reference",
 			sql:  "SELECT * FROM |",
 			want: append(append(tables("Address", "Employees"), schemas("dbo", "MySchema")...), sequences("EmployeeIdSeq", "OrderSeq")...),
@@ -268,9 +414,24 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			),
 		},
 		{
+			name: "database qualified dbo table reference",
+			sql:  "SELECT * FROM Company.dbo.|",
+			want: tables("Address", "Employees"),
+		},
+		{
+			name: "database qualified alternate schema table reference",
+			sql:  "SELECT * FROM Company.MySchema.|",
+			want: tables("SalaryLevel"),
+		},
+		{
 			name: "bracket quoted schema table reference",
 			sql:  "SELECT * FROM [dbo].|",
 			want: tables("Address", "Employees"),
+		},
+		{
+			name: "bracket quoted table alias columns",
+			sql:  "SELECT * FROM [dbo].[Employees] AS [emp] WHERE [emp].|",
+			want: columns("Id", "Name"),
 		},
 		{
 			name: "schema qualified table prefix keeps matching table available",
@@ -316,6 +477,21 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("Id", "Name"),
 		},
 		{
+			name: "cte qualified projected columns are available",
+			sql:  "WITH cte AS (SELECT Id, Name FROM Employees) SELECT cte.| FROM cte",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "cte where uses projected columns",
+			sql:  "WITH cte AS (SELECT Id, Name FROM Employees) SELECT * FROM cte WHERE |",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "cte insert select uses projected columns",
+			sql:  "WITH cte AS (SELECT Id, Name FROM Employees) INSERT INTO Employees SELECT | FROM cte",
+			want: columns("Id", "Name"),
+		},
+		{
 			name: "chained cte table is available",
 			sql:  "WITH a AS (SELECT Id FROM Employees), b AS (SELECT Id FROM a) SELECT * FROM |",
 			want: tables("a", "b"),
@@ -326,9 +502,44 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("EmployeeId", "Street"),
 		},
 		{
+			name: "subquery where uses inner table columns",
+			sql:  "SELECT * FROM Employees WHERE EXISTS (SELECT 1 FROM Address WHERE |)",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
+			name: "in subquery select list uses inner table columns",
+			sql:  "SELECT * FROM Employees WHERE Id IN (SELECT | FROM Address)",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
+			name: "apply subquery select list uses inner table columns",
+			sql:  "SELECT * FROM Employees e CROSS APPLY (SELECT | FROM Address) x",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
+			name: "scalar subquery select list uses inner table columns",
+			sql:  "SELECT (SELECT | FROM Employees) FROM Address",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "aggregate scalar subquery uses inner table columns",
+			sql:  "SELECT * FROM Employees WHERE Id = (SELECT MAX(|) FROM Address)",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
 			name: "derived table alias columns",
 			sql:  "SELECT d.| FROM (SELECT Id, Name FROM Employees) d",
 			want: columns("Id", "Name"),
+		},
+		{
+			name: "nested derived table alias columns",
+			sql:  "SELECT x.| FROM (SELECT d.Id FROM (SELECT Id FROM Employees) d) x",
+			want: columns("Id"),
+		},
+		{
+			name: "values derived table alias columns",
+			sql:  "SELECT v.| FROM (VALUES (1, 'a')) AS v(Id, ValueLabel)",
+			want: columns("Id", "ValueLabel"),
 		},
 		{
 			name: "correlated subquery can complete outer alias",
@@ -336,9 +547,46 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("Id", "Name"),
 		},
 		{
+			name: "correlated subquery can complete inner alias",
+			sql:  "SELECT * FROM Employees e WHERE EXISTS (SELECT 1 FROM Address a WHERE a.| = e.Id)",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
+			name: "inner alias shadows outer alias",
+			sql:  "SELECT * FROM Employees o WHERE EXISTS (SELECT 1 FROM Address o WHERE o.| = 1)",
+			want: columns("EmployeeId", "Street"),
+			notWant: columns(
+				"Name",
+			),
+		},
+		{
+			name: "any subquery select list uses inner table columns",
+			sql:  "SELECT * FROM Employees WHERE Id = ANY (SELECT | FROM Address)",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
+			name: "all subquery select list uses inner table columns",
+			sql:  "SELECT * FROM Employees WHERE Id > ALL (SELECT | FROM Address)",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
 			name: "union right arm uses right table columns",
 			sql:  "SELECT Id FROM Employees UNION SELECT | FROM Address",
 			want: columns("EmployeeId", "Street"),
+		},
+		{
+			name: "union all right arm uses right table columns",
+			sql:  "SELECT Id FROM Employees UNION ALL SELECT | FROM Address",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
+			name: "chained union final arm uses final table columns",
+			sql:  "SELECT Id FROM Employees UNION SELECT EmployeeId FROM Address UNION SELECT | FROM MySchema.SalaryLevel",
+			want: columns("Id", "SalaryUpBound"),
+			notWant: columns(
+				"EmployeeId",
+				"Street",
+			),
 		},
 		{
 			name: "except right arm uses right table columns",
@@ -361,9 +609,32 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: tables("Address", "Employees"),
 		},
 		{
+			name: "insert target cross database table reference",
+			sql:  "INSERT INTO School.dbo.|",
+			want: tables("Student"),
+			notWant: tables(
+				"Employees",
+			),
+		},
+		{
+			name: "insert target alternate schema table reference",
+			sql:  "INSERT INTO MySchema.|",
+			want: tables("SalaryLevel"),
+		},
+		{
 			name: "insert column list uses target columns",
 			sql:  "INSERT INTO Employees(|) VALUES (1)",
 			want: columns("Id", "Name"),
+		},
+		{
+			name: "insert schema qualified column list uses target columns",
+			sql:  "INSERT INTO dbo.Employees(|) VALUES (1)",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "insert cross database column list uses target columns",
+			sql:  "INSERT INTO School.dbo.Student(|) VALUES (1)",
+			want: columns("Id", "ParentName"),
 		},
 		{
 			name: "insert column list after comma uses remaining target columns",
@@ -397,9 +668,19 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: tables("Address", "Employees"),
 		},
 		{
+			name: "update target cross database table reference",
+			sql:  "UPDATE School.dbo.| SET ParentName = 'a'",
+			want: tables("Student"),
+		},
+		{
 			name: "update set column uses target columns",
 			sql:  "UPDATE Employees SET |",
 			want: columns("Id", "Name"),
+		},
+		{
+			name: "update cross database set column uses target columns",
+			sql:  "UPDATE School.dbo.Student SET |",
+			want: columns("Id", "ParentName"),
 		},
 		{
 			name: "update where uses target columns",
@@ -410,6 +691,26 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			name: "update set value uses target columns",
 			sql:  "UPDATE Employees SET Name = |",
 			want: columns("Id", "Name"),
+		},
+		{
+			name: "update top target table reference",
+			sql:  "UPDATE TOP (10) | SET Name = 'a'",
+			want: tables("Address", "Employees"),
+		},
+		{
+			name: "update alias set column uses target columns",
+			sql:  "UPDATE e SET | FROM Employees e",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "update alias set value uses target columns",
+			sql:  "UPDATE e SET Name = | FROM Employees e",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "update joined set value uses joined alias columns",
+			sql:  "UPDATE e SET Name = a.| FROM Employees e JOIN Address a ON e.Id = a.EmployeeId",
+			want: columns("EmployeeId", "Street"),
 		},
 		{
 			name: "update from joined alias columns",
@@ -437,14 +738,34 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: tables("Address", "Employees"),
 		},
 		{
+			name: "delete target cross database table reference",
+			sql:  "DELETE FROM School.dbo.|",
+			want: tables("Student"),
+		},
+		{
+			name: "delete top target table reference",
+			sql:  "DELETE TOP (10) FROM |",
+			want: tables("Address", "Employees"),
+		},
+		{
 			name: "delete where uses target columns",
 			sql:  "DELETE FROM Employees WHERE |",
 			want: columns("Id", "Name"),
 		},
 		{
+			name: "delete cross database where uses target columns",
+			sql:  "DELETE FROM School.dbo.Student WHERE |",
+			want: columns("Id", "ParentName"),
+		},
+		{
 			name: "delete alias where uses target columns",
 			sql:  "DELETE e FROM Employees e WHERE e.|",
 			want: columns("Id", "Name"),
+		},
+		{
+			name: "delete joined alias where uses joined columns",
+			sql:  "DELETE e FROM Employees e JOIN Address a ON e.Id = a.EmployeeId WHERE a.|",
+			want: columns("EmployeeId", "Street"),
 		},
 		{
 			name: "delete output deleted columns",
@@ -454,6 +775,11 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 		{
 			name: "create index target table reference",
 			sql:  "CREATE INDEX ix ON |",
+			want: tables("Address", "Employees"),
+		},
+		{
+			name: "create index target schema table reference",
+			sql:  "CREATE INDEX ix ON dbo.|",
 			want: tables("Address", "Employees"),
 		},
 		{
@@ -467,8 +793,28 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			),
 		},
 		{
+			name: "create index schema qualified column list uses target columns",
+			sql:  "CREATE INDEX ix ON dbo.Employees(|)",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "create unique clustered index column list uses target columns",
+			sql:  "CREATE UNIQUE CLUSTERED INDEX ix ON Employees(|)",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "create index include column list uses target columns",
+			sql:  "CREATE INDEX ix ON Employees(Id) INCLUDE (|)",
+			want: columns("Id", "Name"),
+		},
+		{
 			name: "create view body select uses source columns",
 			sql:  "CREATE VIEW v AS SELECT | FROM Employees",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "create view with schema body select uses source columns",
+			sql:  "CREATE VIEW MySchema.v AS SELECT | FROM Employees",
 			want: columns("Id", "Name"),
 		},
 		{
@@ -477,9 +823,22 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("Id", "Name"),
 		},
 		{
+			name: "create procedure parameter type name",
+			sql:  "CREATE PROCEDURE p @Name | AS SELECT 1",
+			want: keywords("INT", "NVARCHAR"),
+		},
+		{
 			name: "create table references table",
 			sql:  "CREATE TABLE NewTable (EmployeeId INT REFERENCES |)",
 			want: tables("Address", "Employees"),
+		},
+		{
+			name: "create table references cross database table",
+			sql:  "CREATE TABLE NewTable (StudentId INT REFERENCES School.dbo.|)",
+			want: tables("Student"),
+			notWant: tables(
+				"Employees",
+			),
 		},
 		{
 			name: "create table foreign key source column list",
@@ -492,6 +851,11 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			),
 		},
 		{
+			name: "create table named foreign key source column list",
+			sql:  "CREATE TABLE NewTable (EmployeeId INT, CONSTRAINT fk FOREIGN KEY (|) REFERENCES Employees(Id))",
+			want: columns("EmployeeId"),
+		},
+		{
 			name: "create table references column list",
 			sql:  "CREATE TABLE NewTable (EmployeeId INT REFERENCES Employees(|))",
 			want: columns("Id", "Name"),
@@ -502,8 +866,31 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			),
 		},
 		{
+			name: "create table schema qualified references column list",
+			sql:  "CREATE TABLE NewTable (EmployeeId INT REFERENCES dbo.Employees(|))",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "create table cross database references column list",
+			sql:  "CREATE TABLE NewTable (StudentId INT REFERENCES School.dbo.Student(|))",
+			want: columns("Id", "ParentName"),
+			notWant: columns(
+				"Name",
+			),
+		},
+		{
 			name: "create table type name",
 			sql:  "CREATE TABLE NewTable (Name |)",
+			want: keywords("INT", "NVARCHAR"),
+		},
+		{
+			name: "create table type name after comma",
+			sql:  "CREATE TABLE NewTable (Id INT, Name |)",
+			want: keywords("INT", "NVARCHAR"),
+		},
+		{
+			name: "declare variable type name",
+			sql:  "DECLARE @Name |",
 			want: keywords("INT", "NVARCHAR"),
 		},
 		{
@@ -522,9 +909,32 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: tables("Student"),
 		},
 		{
+			name: "alter table add column type name",
+			sql:  "ALTER TABLE Employees ADD Name |",
+			want: keywords("INT", "NVARCHAR"),
+		},
+		{
+			name: "alter table references table",
+			sql:  "ALTER TABLE Employees ADD CONSTRAINT fk FOREIGN KEY (Id) REFERENCES |",
+			want: tables("Address", "Employees"),
+		},
+		{
+			name: "alter table references column list",
+			sql:  "ALTER TABLE Employees ADD CONSTRAINT fk FOREIGN KEY (Id) REFERENCES Address(|)",
+			want: columns("EmployeeId", "Street"),
+			notWant: columns(
+				"Name",
+			),
+		},
+		{
 			name: "drop table reference",
 			sql:  "DROP TABLE |",
 			want: tables("Address", "Employees"),
+		},
+		{
+			name: "drop table prefix keeps matching table available",
+			sql:  "DROP TABLE Emp|",
+			want: tables("Employees"),
 		},
 		{
 			name: "drop table if exists reference",
@@ -542,9 +952,39 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: tables("Student"),
 		},
 		{
+			name: "drop view schema reference",
+			sql:  "DROP VIEW MySchema.|",
+			want: views("SalaryView"),
+		},
+		{
+			name: "drop procedure schema reference",
+			sql:  "DROP PROCEDURE dbo.|",
+			want: routines("SyncEmployees"),
+		},
+		{
+			name: "drop procedure prefix keeps matching routine available",
+			sql:  "DROP PROCEDURE Sync|",
+			want: routines("SyncEmployees"),
+		},
+		{
+			name: "drop sequence schema reference",
+			sql:  "DROP SEQUENCE dbo.|",
+			want: sequences("EmployeeIdSeq", "OrderSeq"),
+		},
+		{
+			name: "drop sequence prefix keeps matching sequence available",
+			sql:  "DROP SEQUENCE Employee|",
+			want: sequences("EmployeeIdSeq"),
+		},
+		{
 			name: "drop database reference",
 			sql:  "DROP DATABASE |",
 			want: databases("Company", "School"),
+		},
+		{
+			name: "drop database prefix keeps matching database available",
+			sql:  "DROP DATABASE Comp|",
+			want: databases("Company"),
 		},
 		{
 			name: "use database reference",
@@ -552,9 +992,22 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: databases("Company", "School"),
 		},
 		{
+			name: "use database prefix keeps matching database available",
+			sql:  "USE Sch|",
+			want: databases("School"),
+		},
+		{
 			name: "next value for sequence reference",
 			sql:  "SELECT NEXT VALUE FOR |",
 			want: sequences("EmployeeIdSeq", "OrderSeq"),
+		},
+		{
+			name: "next value for sequence prefix",
+			sql:  "SELECT NEXT VALUE FOR Employee|",
+			want: sequences("EmployeeIdSeq"),
+			notWant: sequences(
+				"OrderSeq",
+			),
 		},
 		{
 			name: "schema qualified next value for sequence reference",
@@ -583,6 +1036,11 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: tables("Address", "Employees"),
 		},
 		{
+			name: "truncate cross database table reference",
+			sql:  "TRUNCATE TABLE School.dbo.|",
+			want: tables("Student"),
+		},
+		{
 			name: "merge target table reference",
 			sql:  "MERGE INTO |",
 			want: tables("Address", "Employees"),
@@ -598,9 +1056,50 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: columns("Id", "Name", "EmployeeId", "Street"),
 		},
 		{
+			name: "merge on uses aliased target and source columns",
+			sql:  "MERGE INTO Employees AS target USING Address AS source ON source.|",
+			want: columns("EmployeeId", "Street"),
+			notWant: columns(
+				"Name",
+			),
+		},
+		{
+			name: "merge on uses cte source columns",
+			sql:  "WITH source AS (SELECT EmployeeId, Street FROM Address) MERGE INTO Employees AS target USING source ON |",
+			want: columns("Id", "Name", "EmployeeId", "Street"),
+		},
+		{
+			name: "merge on uses subquery source columns",
+			sql:  "MERGE INTO Employees AS target USING (SELECT EmployeeId, Street FROM Address) AS source ON source.|",
+			want: columns("EmployeeId", "Street"),
+			notWant: columns(
+				"Name",
+			),
+		},
+		{
 			name: "merge when keyword",
 			sql:  "MERGE INTO Employees USING Address ON Employees.Id = Address.EmployeeId WHEN |",
 			want: keywords("MATCHED", "NOT"),
+		},
+		{
+			name: "merge matched update set uses target columns",
+			sql:  "MERGE INTO Employees USING Address ON Employees.Id = Address.EmployeeId WHEN MATCHED THEN UPDATE SET |",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "merge matched update value uses source columns",
+			sql:  "MERGE INTO Employees USING Address ON Employees.Id = Address.EmployeeId WHEN MATCHED THEN UPDATE SET Name = Address.|",
+			want: columns("EmployeeId", "Street"),
+		},
+		{
+			name: "merge output inserted columns",
+			sql:  "MERGE INTO Employees USING Address ON Employees.Id = Address.EmployeeId WHEN MATCHED THEN UPDATE SET Name = Address.Street OUTPUT INSERTED.|",
+			want: columns("Id", "Name"),
+		},
+		{
+			name: "merge output deleted columns",
+			sql:  "MERGE INTO Employees USING Address ON Employees.Id = Address.EmployeeId WHEN MATCHED THEN UPDATE SET Name = Address.Street OUTPUT DELETED.|",
+			want: columns("Id", "Name"),
 		},
 		{
 			name: "table hint keyword",
@@ -625,7 +1124,7 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 		{
 			name: "for xml mode",
 			sql:  "SELECT * FROM Employees FOR XML |",
-			want: keywords("PATH", "AUTO"),
+			want: keywords("PATH", "RAW", "AUTO", "EXPLICIT"),
 		},
 		{
 			name: "for json mode",
@@ -638,13 +1137,28 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want: keywords("INT", "NVARCHAR"),
 		},
 		{
+			name: "openjson with second column type name",
+			sql:  "SELECT * FROM OPENJSON(@json) WITH (Name NVARCHAR(100), Age |)",
+			want: keywords("INT", "NVARCHAR"),
+		},
+		{
 			name: "pivot in list uses source columns",
 			sql:  "SELECT * FROM Employees PIVOT (COUNT(Id) FOR Name IN (|)) p",
 			want: columns("Id", "Name"),
 		},
 		{
+			name: "unpivot in list uses source columns",
+			sql:  "SELECT * FROM Employees UNPIVOT (Value FOR Field IN (|)) u",
+			want: columns("Id", "Name"),
+		},
+		{
 			name: "execute procedure reference",
 			sql:  "EXEC |",
+			want: routines("SyncEmployees"),
+		},
+		{
+			name: "execute procedure prefix",
+			sql:  "EXEC Sync|",
 			want: routines("SyncEmployees"),
 		},
 		{

--- a/backend/plugin/parser/tsql/query_span_extractor.go
+++ b/backend/plugin/parser/tsql/query_span_extractor.go
@@ -2,12 +2,10 @@ package tsql
 
 import (
 	"context"
-	"log/slog"
 	"strings"
 	"unicode"
 
 	"github.com/bytebase/omni/mssql/ast"
-	parser "github.com/bytebase/parser/tsql"
 
 	"github.com/pkg/errors"
 
@@ -424,38 +422,6 @@ func isSystemResource(resource base.ColumnResource, ignoreCaseSensitive bool) bo
 		return true
 	}
 	return false
-}
-
-// normalizeFullTableNameFallback normalizes the parts of an ANTLR full_table_name
-// context. Retained for non-query-span tsql callers (completion, backup).
-func normalizeFullTableNameFallback(fullTableName parser.IFull_table_nameContext, normalizedFallbackDatabaseName, normalizedFallbackSchemaName string) (string, string, string, string) {
-	if fullTableName == nil {
-		return "", "", "", ""
-	}
-	// TODO(zp): unify here and the related code in sql_service.go
-	name, err := NormalizeFullTableName(fullTableName)
-	if err != nil {
-		slog.Debug("Failed to normalize full table name", "error", err)
-	}
-	linkedServer := ""
-	if name.LinkedServer != "" {
-		linkedServer = name.LinkedServer
-	}
-
-	database := normalizedFallbackDatabaseName
-	if name.Database != "" {
-		database = name.Database
-	}
-	schema := normalizedFallbackSchemaName
-	if name.Schema != "" {
-		schema = name.Schema
-	}
-
-	var table string
-	if name.Table != "" {
-		table = name.Table
-	}
-	return linkedServer, database, schema, table
 }
 
 // unquote strips surrounding brackets or `N'...'` from an identifier literal.

--- a/backend/plugin/parser/tsql/test-data/test_completion.yaml
+++ b/backend/plugin/parser/tsql/test-data/test_completion.yaml
@@ -46,16 +46,6 @@
 - description: Column alias can be used in order by clause
   input: SELECT Id AS IdAlias, Name FROM Employees ORDER BY |;
   want:
-    - text: EmployeeId
-      type: COLUMN
-      definition: Company.dbo.Address | int, NOT NULL
-      comment: ""
-      priority: 1
-    - text: Id
-      type: COLUMN
-      definition: Company.MySchema.SalaryLevel | int, NOT NULL
-      comment: ""
-      priority: 1
     - text: Id
       type: COLUMN
       definition: Company.dbo.Employees | int, NOT NULL
@@ -71,16 +61,6 @@
       definition: Company.dbo.Employees | varchar, NOT NULL
       comment: ""
       priority: 0
-    - text: SalaryUpBound
-      type: COLUMN
-      definition: Company.MySchema.SalaryLevel | int, NOT NULL
-      comment: ""
-      priority: 1
-    - text: Street
-      type: COLUMN
-      definition: Company.dbo.Address | varchar, NOT NULL
-      comment: ""
-      priority: 1
     - text: Company
       type: DATABASE
       definition: ""
@@ -150,16 +130,6 @@
 - description: Full column name
   input: SELECT | FROM Employees;
   want:
-    - text: EmployeeId
-      type: COLUMN
-      definition: Company.dbo.Address | int, NOT NULL
-      comment: ""
-      priority: 1
-    - text: Id
-      type: COLUMN
-      definition: Company.MySchema.SalaryLevel | int, NOT NULL
-      comment: ""
-      priority: 1
     - text: Id
       type: COLUMN
       definition: Company.dbo.Employees | int, NOT NULL
@@ -170,16 +140,6 @@
       definition: Company.dbo.Employees | varchar, NOT NULL
       comment: ""
       priority: 0
-    - text: SalaryUpBound
-      type: COLUMN
-      definition: Company.MySchema.SalaryLevel | int, NOT NULL
-      comment: ""
-      priority: 1
-    - text: Street
-      type: COLUMN
-      definition: Company.dbo.Address | varchar, NOT NULL
-      comment: ""
-      priority: 1
     - text: Company
       type: DATABASE
       definition: ""
@@ -230,24 +190,14 @@
       priority: 0
     - text: Id
       type: COLUMN
-      definition: Company.MySchema.SalaryLevel | int, NOT NULL
-      comment: ""
-      priority: 1
-    - text: Id
-      type: COLUMN
-      definition: Company.dbo.Employees | int, NOT NULL
+      definition: ""
       comment: ""
       priority: 0
     - text: Name
       type: COLUMN
-      definition: Company.dbo.Employees | varchar, NOT NULL
+      definition: ""
       comment: ""
       priority: 0
-    - text: SalaryUpBound
-      type: COLUMN
-      definition: Company.MySchema.SalaryLevel | int, NOT NULL
-      comment: ""
-      priority: 1
     - text: Street
       type: COLUMN
       definition: Company.dbo.Address | varchar, NOT NULL

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260429081533-45e43fdcdd31
+	github.com/bytebase/omni v0.0.0-20260430035605-5f442197a248
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888 h1:E8tz8maxpih/vt
 github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888/go.mod h1:IgLUOjyiHehdE0G3C92IjGYu9lJQgkPwf2mdNSvPWq8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260429081533-45e43fdcdd31 h1:K5u/0cIhf/aGngRKPe2byis3X9g8ZVUQWfaiPubzk68=
-github.com/bytebase/omni v0.0.0-20260429081533-45e43fdcdd31/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260430035605-5f442197a248 h1:qrCbq05Wcm2qcKa+f+8MEyXeCRo33HVEVZn8DtH2rmU=
+github.com/bytebase/omni v0.0.0-20260430035605-5f442197a248/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Upgrade Omni to `5f44219` and keep MSSQL completion on the Omni-backed candidates/scope path.
- Expand MSSQL completion coverage to cover expression scopes, DML/DDL/object completion, prefix filtering, set-op isolation, and MERGE source variants.
- Remove obsolete ANTLR table-reference completion scope code and refresh completion goldens for Omni-scoped behavior.

## Test Plan
- `go test -v -count=1 ./backend/plugin/parser/tsql -run '^TestCompletionCoverageMatrix$/merge'`
- `go test -count=1 ./backend/plugin/parser/tsql`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
