### PR TITLE
fix(databricks): bind connected catalog to SQL warehouse session

### DIFF
--- a/backend/plugin/db/databricks/databricks.go
+++ b/backend/plugin/db/databricks/databricks.go
@@ -159,9 +159,13 @@ func (d *Driver) Execute(ctx context.Context, statement string, _ db.ExecuteOpti
 
 // Execute SQL statement synchronously and return row data or error.
 func (d *Driver) execStatementSync(ctx context.Context, statement string) ([][]string, []dbsql.ColumnInfo, error) {
+	// Bind the connected Bytebase database (= Unity Catalog) to the
+	// session, so unqualified `schema.table` references resolve like in
+	// other RDBMSes. Equivalent to issuing `USE CATALOG <name>` first.
 	resp, err := d.Client.StatementExecution.ExecuteAndWait(ctx, dbsql.ExecuteStatementRequest{
 		Statement:   statement,
 		WarehouseId: d.WarehouseID,
+		Catalog:     d.curCatalog,
 	})
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

- The Databricks driver captured the connected database as `d.curCatalog` in `Open()` but never forwarded it to `ExecuteStatementRequest`, so every query fell back to the workspace default catalog (typically `main` / `hive_metastore`).
- Effect: tables outside that default — Delta Sharing catalogs, any non-default catalog — failed unqualified `schema.table` lookups with `TABLE_OR_VIEW_NOT_FOUND`. The SQL Editor's double-click-to-preview action was the most visible casualty.
- Fix: pass `Catalog: d.curCatalog` on every `ExecuteStatementRequest`, equivalent to `USE CATALOG <name>`. Databricks now behaves like other RDBMSes in Bytebase: connecting to a database binds the session to it, and 2-level identifiers resolve as expected. The SDK field is `omitempty`, so instance-level operations (where `curCatalog` is empty) keep their previous behavior.

Refs [BYT-9379](https://linear.app/bytebase/issue/BYT-9379/databricks-sql-editor-support).

## Test plan

- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/db/databricks/...` — 0 issues
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- [x] Manual: connect to a Databricks instance with a non-default catalog (e.g. `samples` or a Delta Sharing catalog), open the SQL Editor against a database in that catalog, double-click a table → result grid renders rows instead of `TABLE_OR_VIEW_NOT_FOUND`
- [x] Manual: bare `SELECT * FROM <schema>.<table>` (no catalog prefix) inside the editor also resolves against the connected catalog
- [x] Regression: instance-level sync (no bound database) still lists all catalogs