### PR TITLE
cherrypick: [release/3.17.1] fix(react): treat Databricks token as write-only on instance edit (#20186)

### DIFF
--- a/frontend/src/react/components/instance/DataSourceForm.tsx
+++ b/frontend/src/react/components/instance/DataSourceForm.tsx
@@ -1605,12 +1605,18 @@ export function DataSourceForm({
                   Token <span className="text-error">*</span>
                 </div>
                 <Input
-                  value={dataSource.authenticationPrivateKey ?? ""}
+                  type="password"
+                  value={dataSource.updatedToken}
                   className="mt-2 w-full"
+                  autoComplete="off"
                   disabled={!allowEdit}
-                  placeholder="personal access token"
+                  placeholder={
+                    isCreating
+                      ? "personal access token"
+                      : t("instance.token-write-only")
+                  }
                   onChange={(e) =>
-                    update({ authenticationPrivateKey: e.target.value })
+                    update({ updatedToken: e.target.value.trim() })
                   }
                 />
               </div>

--- a/frontend/src/react/components/instance/InstanceFormContext.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.tsx
@@ -87,7 +87,7 @@ export interface InstanceFormContextValue {
   setResourceIdValidated: React.Dispatch<React.SetStateAction<boolean>>;
   labelErrors: string[];
   setLabelErrors: React.Dispatch<React.SetStateAction<string[]>>;
-  checkDataSource: (dataSources: DataSource[]) => boolean;
+  checkDataSource: (dataSources: EditDataSource[]) => boolean;
   resetDataSource: () => void;
   extractDataSourceFromEdit: (
     engine: Engine,
@@ -208,7 +208,7 @@ export function InstanceFormProvider({
   );
 
   const checkDataSource = useCallback(
-    (dataSources: DataSource[]) => {
+    (dataSources: EditDataSource[]) => {
       return dataSources.every((ds) => {
         if (
           ds.authenticationType ===
@@ -224,7 +224,10 @@ export function InstanceFormProvider({
         if (basicInfo.engine === Engine.ORACLE) {
           if (!ds.sid && !ds.serviceName) return false;
         } else if (basicInfo.engine === Engine.DATABRICKS) {
-          if (!ds.warehouseId || !ds.authenticationPrivateKey) return false;
+          if (!ds.warehouseId) return false;
+          // Token is INPUT_ONLY: backend never returns it. Require it only on
+          // create; on edit, an empty updatedToken means "keep existing token".
+          if (ds.pendingCreate && !ds.updatedToken) return false;
         }
         if (ds.saslConfig?.mechanism?.case === "krbConfig") {
           const krbConfig = ds.saslConfig.mechanism.value;
@@ -326,6 +329,7 @@ export function InstanceFormProvider({
           "useEmptyPassword",
           "updatedMasterPassword",
           "useEmptyMasterPassword",
+          "updatedToken",
           "updateSsl"
         )
       );
@@ -334,6 +338,7 @@ export function InstanceFormProvider({
       if (edit.updatedMasterPassword)
         ds.masterPassword = edit.updatedMasterPassword;
       if (edit.useEmptyMasterPassword) ds.masterPassword = "";
+      if (edit.updatedToken) ds.authenticationPrivateKey = edit.updatedToken;
       if (!specs.showDatabase) ds.database = "";
       if (engine !== Engine.ORACLE) {
         ds.sid = "";

--- a/frontend/src/react/components/instance/common.ts
+++ b/frontend/src/react/components/instance/common.ts
@@ -42,6 +42,7 @@ export type EditDataSource = DataSource & {
   pendingCreate: boolean;
   updatedPassword: string;
   updatedMasterPassword: string;
+  updatedToken: string;
   useEmptyPassword?: boolean;
   useEmptyMasterPassword?: boolean;
   updateSsl?: TlsUpdateState;
@@ -109,6 +110,7 @@ export const wrapEditDataSource = (ds: DataSource | undefined) => {
     pendingCreate: ds === undefined,
     updatedPassword: "",
     updatedMasterPassword: "",
+    updatedToken: "",
     useEmptyPassword: false,
     useEmptyMasterPassword: false,
   };

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -983,6 +983,7 @@
     "syncing": "Syncing ...",
     "test-connection": "Test Connection",
     "testing-connection": "Testing Connection...",
+    "token-write-only": "YOUR_TOKEN - write only",
     "type-or-paste-credentials-write-only": "Type or paste CREDENTIALS - write only",
     "unable-to-connect": "Bytebase is unable to connect the instance. We recommend you to review the connection info again. But it's OK to ignore this warning for now. You can still fix the connection info from the instance detail page after creation.\n\nError detail: {{0}}",
     "users": "Users",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -983,6 +983,7 @@
     "syncing": "Sincronizando...",
     "test-connection": "Probar conexión",
     "testing-connection": "Probando conexión...",
+    "token-write-only": "TU_TOKEN - solo escritura",
     "type-or-paste-credentials-write-only": "Escriba o pegue las CREDENCIALES - solo escritura",
     "unable-to-connect": "Bytebase no puede conectar la instancia. Le recomendamos que revise la información de conexión nuevamente. Pero está bien ignorar esta advertencia por ahora. Aún puede solucionar la información de conexión desde la página de detalles de la instancia después de la creación.\n\nDetalle del error: {{0}}",
     "users": "Usuarios",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -983,6 +983,7 @@
     "syncing": "同期中 ...",
     "test-connection": "テスト接続",
     "testing-connection": "接続テスト中...",
+    "token-write-only": "YOUR_TOKEN - 書き込み専用",
     "type-or-paste-credentials-write-only": "資格情報を入力または貼り付けます - 書き込みのみ",
     "unable-to-connect": "Bytebase はインスタンスに接続できません。接続情報を再度確認することをお勧めします。ただし、今のところこの警告は無視してかまいません。作成後もインスタンスの詳細ページで接続情報を修正できます。\n\nエラーの詳細:{{0}}",
     "users": "ユーザー",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -983,6 +983,7 @@
     "syncing": "Đang đồng bộ hóa ...",
     "test-connection": "Kiểm tra kết nối",
     "testing-connection": "Đang kiểm tra kết nối...",
+    "token-write-only": "YOUR_TOKEN - chỉ ghi",
     "type-or-paste-credentials-write-only": "Nhập hoặc dán THÔNG TIN XÁC THỰC - chỉ ghi",
     "unable-to-connect": "Bytebase không thể kết nối với phiên bản. Chúng tôi khuyên bạn nên xem xét lại thông tin kết nối. Nhưng bạn có thể bỏ qua cảnh báo này ngay bây giờ. Bạn vẫn có thể sửa thông tin kết nối từ trang chi tiết phiên bản sau khi tạo.\n\nChi tiết lỗi: {{0}}",
     "users": "Người dùng",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -983,6 +983,7 @@
     "syncing": "同步中 ...",
     "test-connection": "测试连接",
     "testing-connection": "测试连接中...",
+    "token-write-only": "YOUR_TOKEN - 仅写入",
     "type-or-paste-credentials-write-only": "输入或粘贴 CREDENTIALS - 仅写入",
     "unable-to-connect": "Bytebase 无法连接到实例。我们推荐您再检查一遍连接信息。但也可以暂时忽略此警告。您在创建后仍能在实例详细页里修复连接信息。\n\n错误详情:{{0}}",
     "users": "用户",


### PR DESCRIPTION
## Summary

Cherry-pick of #20186 onto release/3.17.1.

## Test plan

- [x] Cherry-pick applied cleanly with no conflicts
- [ ] Manual verification on the release branch build