### PR TITLE
cherrypick: [release/3.17.1] fix(databricks): bind connected catalog to SQL warehouse session (#20188)

### DIFF
--- a/backend/plugin/db/databricks/databricks.go
+++ b/backend/plugin/db/databricks/databricks.go
@@ -159,9 +159,13 @@ func (d *Driver) Execute(ctx context.Context, statement string, _ db.ExecuteOpti
 
 // Execute SQL statement synchronously and return row data or error.
 func (d *Driver) execStatementSync(ctx context.Context, statement string) ([][]string, []dbsql.ColumnInfo, error) {
+	// Bind the connected Bytebase database (= Unity Catalog) to the
+	// session, so unqualified `schema.table` references resolve like in
+	// other RDBMSes. Equivalent to issuing `USE CATALOG <name>` first.
 	resp, err := d.Client.StatementExecution.ExecuteAndWait(ctx, dbsql.ExecuteStatementRequest{
 		Statement:   statement,
 		WarehouseId: d.WarehouseID,
+		Catalog:     d.curCatalog,
 	})
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

Cherry-pick of #20188 onto release/3.17.1.

Fixes the SQL Editor double-click failure on non-default Databricks catalogs (e.g. Delta Sharing). Refs [BYT-9379](https://linear.app/bytebase/issue/BYT-9379/databricks-sql-editor-support).

## Test plan

- [x] Cherry-pick applied cleanly with no conflicts
- [ ] Manual: connect to a Databricks instance against a non-default catalog, double-click a table in the SQL Editor, confirm the result grid renders rows