### PR TITLE
refactor(advisor/tidb): migrate naming-table/column/drop rules to omni AST (Phase 1.5 §1.5.3 batch 1)

### DIFF
--- a/backend/plugin/advisor/tidb/advisor_naming_column.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_column.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/bytebase/omni/tidb/ast"
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -16,7 +16,6 @@ import (
 
 var (
 	_ advisor.Advisor = (*NamingColumnConventionAdvisor)(nil)
-	_ ast.Visitor     = (*namingColumnConventionChecker)(nil)
 )
 
 func init() {
@@ -29,8 +28,7 @@ type NamingColumnConventionAdvisor struct {
 
 // Check checks for column naming convention.
 func (*NamingColumnConventionAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	root, err := getTiDBNodes(checkCtx)
-
+	stmts, err := getTiDBOmniNodes(checkCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -60,8 +58,8 @@ func (*NamingColumnConventionAdvisor) Check(_ context.Context, checkCtx advisor.
 		maxLength: maxLength,
 	}
 
-	for _, stmtNode := range root {
-		(stmtNode).Accept(checker)
+	for _, ostmt := range stmts {
+		checker.checkStmt(ostmt)
 	}
 
 	return checker.adviceList, nil
@@ -75,81 +73,102 @@ type namingColumnConventionChecker struct {
 	maxLength  int
 }
 
-// Enter implements the ast.Visitor interface.
-func (v *namingColumnConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
-	type columnData struct {
-		name string
-		line int
-	}
-	var columnList []columnData
+type columnDataNamingColumn struct {
+	name string
+	line int
+}
+
+func (c *namingColumnConventionChecker) checkStmt(ostmt OmniStmt) {
+	var columnList []columnDataNamingColumn
 	var tableName string
-	switch node := in.(type) {
-	// CREATE TABLE
+	switch n := ostmt.Node.(type) {
 	case *ast.CreateTableStmt:
-		tableName = node.Table.Name.O
-		for _, column := range node.Cols {
-			columnList = append(columnList, columnData{
-				name: column.Name.Name.O,
-				line: column.OriginTextPosition(),
+		if n.Table == nil {
+			return
+		}
+		tableName = n.Table.Name
+		for _, col := range n.Columns {
+			if col == nil {
+				continue
+			}
+			columnList = append(columnList, columnDataNamingColumn{
+				name: col.Name,
+				line: ostmt.AbsoluteLine(col.Loc.Start),
 			})
 		}
-	// ALTER TABLE
 	case *ast.AlterTableStmt:
-		tableName = node.Table.Name.O
-		for _, spec := range node.Specs {
-			switch spec.Tp {
-			// RENAME COLUMN
-			case ast.AlterTableRenameColumn:
-				columnList = append(columnList, columnData{
-					name: spec.NewColumnName.Name.O,
-					line: in.OriginTextPosition(),
-				})
-			// ADD COLUMNS
-			case ast.AlterTableAddColumns:
-				for _, column := range spec.NewColumns {
-					columnList = append(columnList, columnData{
-						name: column.Name.Name.O,
-						line: in.OriginTextPosition(),
+		if n.Table == nil {
+			return
+		}
+		tableName = n.Table.Name
+		// Use the ALTER statement's line for all column references — pingcap parity.
+		stmtLine := ostmt.AbsoluteLine(n.Loc.Start)
+		for _, cmd := range n.Commands {
+			if cmd == nil {
+				continue
+			}
+			switch cmd.Type {
+			case ast.ATRenameColumn:
+				if cmd.NewName != "" {
+					columnList = append(columnList, columnDataNamingColumn{
+						name: cmd.NewName,
+						line: stmtLine,
 					})
 				}
-			// CHANGE COLUMN
-			case ast.AlterTableChangeColumn:
-				columnList = append(columnList, columnData{
-					name: spec.NewColumns[0].Name.Name.O,
-					line: in.OriginTextPosition(),
-				})
+			case ast.ATAddColumn:
+				// omni populates either Columns (multi-form) or Column (single).
+				// Mutually exclusive in practice but not enforced by the type.
+				if len(cmd.Columns) > 0 {
+					for _, col := range cmd.Columns {
+						if col != nil {
+							columnList = append(columnList, columnDataNamingColumn{
+								name: col.Name,
+								line: stmtLine,
+							})
+						}
+					}
+				} else if cmd.Column != nil {
+					columnList = append(columnList, columnDataNamingColumn{
+						name: cmd.Column.Name,
+						line: stmtLine,
+					})
+				}
+			case ast.ATChangeColumn:
+				// Only the new column name matters here.
+				if cmd.Column != nil {
+					columnList = append(columnList, columnDataNamingColumn{
+						name: cmd.Column.Name,
+						line: stmtLine,
+					})
+				}
 			default:
-				// Skip other alter table specification types
+				// MODIFY COLUMN (ATModifyColumn) and other forms intentionally
+				// not handled — pre-existing inheritance from the pingcap-AST
+				// version of this advisor.
 			}
 		}
 	default:
+		return
 	}
 
 	for _, column := range columnList {
-		if !v.format.MatchString(column.name) {
-			v.adviceList = append(v.adviceList, &storepb.Advice{
-				Status:        v.level,
+		if !c.format.MatchString(column.name) {
+			c.adviceList = append(c.adviceList, &storepb.Advice{
+				Status:        c.level,
 				Code:          code.NamingColumnConventionMismatch.Int32(),
-				Title:         v.title,
-				Content:       fmt.Sprintf("`%s`.`%s` mismatches column naming convention, naming format should be %q", tableName, column.name, v.format),
+				Title:         c.title,
+				Content:       fmt.Sprintf("`%s`.`%s` mismatches column naming convention, naming format should be %q", tableName, column.name, c.format),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),
 			})
 		}
-		if v.maxLength > 0 && len(column.name) > v.maxLength {
-			v.adviceList = append(v.adviceList, &storepb.Advice{
-				Status:        v.level,
+		if c.maxLength > 0 && len(column.name) > c.maxLength {
+			c.adviceList = append(c.adviceList, &storepb.Advice{
+				Status:        c.level,
 				Code:          code.NamingColumnConventionMismatch.Int32(),
-				Title:         v.title,
-				Content:       fmt.Sprintf("`%s`.`%s` mismatches column naming convention, its length should be within %d characters", tableName, column.name, v.maxLength),
+				Title:         c.title,
+				Content:       fmt.Sprintf("`%s`.`%s` mismatches column naming convention, its length should be within %d characters", tableName, column.name, c.maxLength),
 				StartPosition: common.ConvertANTLRLineToPosition(column.line),
 			})
 		}
 	}
-
-	return in, false
-}
-
-// Leave implements the ast.Visitor interface.
-func (*namingColumnConventionChecker) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
 }

--- a/backend/plugin/advisor/tidb/advisor_naming_table.go
+++ b/backend/plugin/advisor/tidb/advisor_naming_table.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/bytebase/omni/tidb/ast"
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -16,7 +16,6 @@ import (
 
 var (
 	_ advisor.Advisor = (*NamingTableConventionAdvisor)(nil)
-	_ ast.Visitor     = (*namingTableConventionChecker)(nil)
 )
 
 func init() {
@@ -29,8 +28,7 @@ type NamingTableConventionAdvisor struct {
 
 // Check checks for table naming convention.
 func (*NamingTableConventionAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	root, err := getTiDBNodes(checkCtx)
-
+	stmts, err := getTiDBOmniNodes(checkCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +57,9 @@ func (*NamingTableConventionAdvisor) Check(_ context.Context, checkCtx advisor.C
 		format:    format,
 		maxLength: maxLength,
 	}
-	for _, stmtNode := range root {
-		(stmtNode).Accept(checker)
+
+	for _, ostmt := range stmts {
+		checker.checkStmt(ostmt)
 	}
 
 	return checker.adviceList, nil
@@ -74,54 +73,56 @@ type namingTableConventionChecker struct {
 	maxLength  int
 }
 
-// Enter implements the ast.Visitor interface.
-func (v *namingTableConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
+func (c *namingTableConventionChecker) checkStmt(ostmt OmniStmt) {
 	var tableNames []string
-	switch node := in.(type) {
-	// CREATE TABLE
+	var line int
+	switch n := ostmt.Node.(type) {
 	case *ast.CreateTableStmt:
-		// Original string
-		tableNames = append(tableNames, node.Table.Name.O)
-	// ALTER TABLE
+		if n.Table == nil {
+			return
+		}
+		tableNames = append(tableNames, n.Table.Name)
+		line = ostmt.AbsoluteLine(n.Loc.Start)
 	case *ast.AlterTableStmt:
-		for _, spec := range node.Specs {
-			// RENAME TABLE
-			if spec.Tp == ast.AlterTableRenameTable {
-				tableNames = append(tableNames, spec.NewTable.Name.O)
+		for _, cmd := range n.Commands {
+			if cmd == nil {
+				continue
+			}
+			if cmd.Type == ast.ATRenameTable && cmd.NewName != "" {
+				tableNames = append(tableNames, cmd.NewName)
 			}
 		}
-	// RENAME TABLE
+		line = ostmt.AbsoluteLine(n.Loc.Start)
 	case *ast.RenameTableStmt:
-		for _, table2Table := range node.TableToTables {
-			tableNames = append(tableNames, table2Table.NewTable.Name.O)
+		for _, pair := range n.Pairs {
+			if pair == nil || pair.New == nil {
+				continue
+			}
+			tableNames = append(tableNames, pair.New.Name)
 		}
+		line = ostmt.AbsoluteLine(n.Loc.Start)
 	default:
+		return
 	}
 
 	for _, tableName := range tableNames {
-		if !v.format.MatchString(tableName) {
-			v.adviceList = append(v.adviceList, &storepb.Advice{
-				Status:        v.level,
+		if !c.format.MatchString(tableName) {
+			c.adviceList = append(c.adviceList, &storepb.Advice{
+				Status:        c.level,
 				Code:          code.NamingTableConventionMismatch.Int32(),
-				Title:         v.title,
-				Content:       fmt.Sprintf("`%s` mismatches table naming convention, naming format should be %q", tableName, v.format),
-				StartPosition: common.ConvertANTLRLineToPosition(in.OriginTextPosition()),
+				Title:         c.title,
+				Content:       fmt.Sprintf("`%s` mismatches table naming convention, naming format should be %q", tableName, c.format),
+				StartPosition: common.ConvertANTLRLineToPosition(line),
 			})
 		}
-		if v.maxLength > 0 && len(tableName) > v.maxLength {
-			v.adviceList = append(v.adviceList, &storepb.Advice{
-				Status:        v.level,
+		if c.maxLength > 0 && len(tableName) > c.maxLength {
+			c.adviceList = append(c.adviceList, &storepb.Advice{
+				Status:        c.level,
 				Code:          code.NamingTableConventionMismatch.Int32(),
-				Title:         v.title,
-				Content:       fmt.Sprintf("`%s` mismatches table naming convention, its length should be within %d characters", tableName, v.maxLength),
-				StartPosition: common.ConvertANTLRLineToPosition(in.OriginTextPosition()),
+				Title:         c.title,
+				Content:       fmt.Sprintf("`%s` mismatches table naming convention, its length should be within %d characters", tableName, c.maxLength),
+				StartPosition: common.ConvertANTLRLineToPosition(line),
 			})
 		}
 	}
-	return in, false
-}
-
-// Leave implements the ast.Visitor interface.
-func (*namingTableConventionChecker) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
 }

--- a/backend/plugin/advisor/tidb/advisor_table_drop_naming_convention.go
+++ b/backend/plugin/advisor/tidb/advisor_table_drop_naming_convention.go
@@ -5,19 +5,17 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
-
-	"github.com/pingcap/tidb/pkg/parser/ast"
+	"github.com/bytebase/omni/tidb/ast"
 	"github.com/pkg/errors"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 )
 
 var (
 	_ advisor.Advisor = (*TableDropNamingConventionAdvisor)(nil)
-	_ ast.Visitor     = (*namingDropTableConventionChecker)(nil)
 )
 
 func init() {
@@ -30,8 +28,7 @@ type TableDropNamingConventionAdvisor struct {
 
 // Check checks for drop table naming convention.
 func (*TableDropNamingConventionAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	root, err := getTiDBNodes(checkCtx)
-
+	stmts, err := getTiDBOmniNodes(checkCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -55,8 +52,9 @@ func (*TableDropNamingConventionAdvisor) Check(_ context.Context, checkCtx advis
 		title:  checkCtx.Rule.Type.String(),
 		format: format,
 	}
-	for _, stmtNode := range root {
-		(stmtNode).Accept(checker)
+
+	for _, ostmt := range stmts {
+		checker.checkStmt(ostmt)
 	}
 
 	return checker.adviceList, nil
@@ -69,26 +67,24 @@ type namingDropTableConventionChecker struct {
 	format     *regexp.Regexp
 }
 
-// Enter implements the ast.Visitor interface.
-func (v *namingDropTableConventionChecker) Enter(in ast.Node) (ast.Node, bool) {
-	if node, ok := in.(*ast.DropTableStmt); ok {
-		for _, table := range node.Tables {
-			if !v.format.MatchString(table.Name.O) {
-				v.adviceList = append(v.adviceList, &storepb.Advice{
-					Status:        v.level,
-					Code:          code.TableDropNamingConventionMismatch.Int32(),
-					Title:         v.title,
-					Content:       fmt.Sprintf("`%s` mismatches drop table naming convention, naming format should be %q", table.Name.O, v.format),
-					StartPosition: common.ConvertANTLRLineToPosition(node.OriginTextPosition()),
-				})
-			}
+func (c *namingDropTableConventionChecker) checkStmt(ostmt OmniStmt) {
+	node, ok := ostmt.Node.(*ast.DropTableStmt)
+	if !ok {
+		return
+	}
+	line := ostmt.AbsoluteLine(node.Loc.Start)
+	for _, table := range node.Tables {
+		if table == nil {
+			continue
+		}
+		if !c.format.MatchString(table.Name) {
+			c.adviceList = append(c.adviceList, &storepb.Advice{
+				Status:        c.level,
+				Code:          code.TableDropNamingConventionMismatch.Int32(),
+				Title:         c.title,
+				Content:       fmt.Sprintf("`%s` mismatches drop table naming convention, naming format should be %q", table.Name, c.format),
+				StartPosition: common.ConvertANTLRLineToPosition(line),
+			})
 		}
 	}
-
-	return in, false
-}
-
-// Leave implements the ast.Visitor interface.
-func (*namingDropTableConventionChecker) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
 }


### PR DESCRIPTION
## Summary

First Class I advisor batch in Phase 1.5. Migrates three TiDB SQL review rules from the legacy pingcap parser to omni AST, following the pilot recipe established in PR #20140.

| Rule | Class | Approach |
|---|---|---|
| `NAMING_TABLE` (`advisor_naming_table.go`) | I | Recipe A — top-level type switch on CreateTableStmt / AlterTableStmt / RenameTableStmt |
| `NAMING_COLUMN` (`advisor_naming_column.go`) | I | Recipe A — same set of types, plus per-column iteration |
| `TABLE_DROP_NAMING_CONVENTION` (`advisor_table_drop_naming_convention.go`) | I | Recipe A — top-level switch on DropTableStmt |

**Migration progress:** 5 of 51 advisors on omni AST (2 from §1.5.1 pilot + 3 from this batch).

## Pre-batch checklist

Per plan §1.5.0, mandatory steps:

1. **Coupling scan.** No unexported helpers shared cross-file in this batch beyond `getTiDBOmniNodes` (already in utils.go). One unrelated coupling — `getTemplateRegexp` shared between index/unique/foreign-key naming rules — was identified but those rules are NOT in this batch (they're Class IIa due to `in.Text()` usage in their internal-error path; queued for batch 2).
2. **Shape audit.** Compared each migration against the analogous `mysql/rule_*.go` omni rule. Branch structure matches one-to-one — no pingcap-vs-omni desugaring divergence found in this batch.
3. **Yaml fixture coverage.** `TestTiDBRules` green for all three rules.
4. **Pingcap-import quarantine.** No remaining `github.com/pingcap/tidb/pkg` references in the migrated files.

## API mappings used

Verified against plan §1.5.0 "Verified API mapping" table:

| Pingcap | Omni |
|---|---|
| `node.Table.Name.O` | `node.Table.Name` |
| `column.Name.Name.O` | `col.Name` |
| `column.OriginTextPosition()` | `ostmt.AbsoluteLine(col.Loc.Start)` |
| `node.Cols` | `n.Columns` |
| `node.Specs[].Tp` | `n.Commands[].Type` |
| `ast.AlterTableRenameTable` | `ast.ATRenameTable` |
| `ast.AlterTableRenameColumn` | `ast.ATRenameColumn` |
| `ast.AlterTableAddColumns` | `ast.ATAddColumn` |
| `ast.AlterTableChangeColumn` | `ast.ATChangeColumn` |
| `spec.NewTable.Name.O` | `cmd.NewName` (string) |
| `spec.NewColumnName.Name.O` | `cmd.NewName` (string) |
| `spec.NewColumns` / `NewColumns[0]` | `cmd.Columns` (multi-form) **or** `cmd.Column` (single-form) — defensive read |
| `node.TableToTables` | `n.Pairs` (`[]*RenameTablePair`) |
| `table2Table.NewTable.Name.O` | `pair.New.Name` |

## Defensive reads applied

`naming_column`'s ATAddColumn handler reads both `cmd.Columns` and `cmd.Column` (mutually exclusive in practice but not enforced by the type) — same pattern as the pilot's `column_no_null`. Without the defensive split, omni populating both fields simultaneously would double-count column names.

## What's NOT in this batch (intentional)

- `advisor_naming_index_convention.go`, `advisor_naming_unique_key_convention.go`, `advisor_naming_foreign_key_convention.go` — these are Class IIa (use `in.Text()` for internal-error advice content) and share the `getTemplateRegexp` helper. Queued for batch 2; will likely move `getTemplateRegexp` to `utils.go` as a coupling-scan prep at that point.
- All other ~46 advisors — future batches per the plan's track structure.

## Validation

```bash
go test -count=1 ./backend/plugin/advisor/tidb/...   # green (TestTiDBRules covers all 3 rules)
go test -count=1 ./backend/plugin/advisor/mysql/...  # green (cross-engine regression)
go test -count=1 ./backend/plugin/parser/tidb/...    # green
go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go  # green
golangci-lint run --allow-parallel-runners ./backend/plugin/advisor/tidb/...  # 0 issues
```

YAML fixtures (`naming_table.yaml`, `naming_column.yaml`, `table_drop_naming_convention.yaml`): all advice content + line numbers identical to pre-migration.

## References

- Plan: `plans/2026-04-23-omni-tidb-completion-plan.md` Phase 1.5 §1.5.3 (advisor batches), §1.5.0 invariants 1, 2, 6, 7.
- Pilot recipe: PR #20140 (column_no_null, insert_must_specify_column).
- Bridge: PR #20179 (`AsPingCapAST`, line-tracking helper).
- Parent: [BYT-9141 omni: tidb](https://linear.app/bytebase/issue/BYT-9141).

## Test plan

- [x] `TestTiDBRules` passes for NAMING_TABLE, NAMING_COLUMN, TABLE_DROP_NAMING_CONVENTION
- [x] mysql cross-engine regression passes
- [x] golangci-lint clean
- [x] Build succeeds
- [ ] Reviewer verifies the migrations match the pilot recipe and the plan's API mapping table
- [ ] Reviewer confirms naming_column's ATAddColumn defensive read is consistent with the pilot's column_no_null

🤖 Generated with [Claude Code](https://claude.com/claude-code)