### PR TITLE
fix(sql-editor): export the original SQL, not the row-limit-rewritten one

### DIFF
--- a/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
+++ b/frontend/src/views/sql-editor/EditorCommon/ResultView/SingleResultViewV1.vue
@@ -90,7 +90,7 @@
               ($event) =>
                 $emit('export', {
                   ...$event,
-                  statement: result.statement,
+                  statement: params.statement,
                 })
             "
           >


### PR DESCRIPTION
## Summary

The SQL Editor's single-result export drawer was sending the *already-rewritten* statement to the export endpoint, capping every export at the editor's Result Limit dropdown (default 1000) regardless of the value chosen in the export form.

When a query is run, the backend rewrites `SELECT * FROM t` into `SELECT * FROM t LIMIT 1000` and returns that string in `result.statement`. The export drawer then sent that rewritten string as the export payload along with the form's row count (e.g. 10000). The backend's LIMIT rewriter applies `min(existing, requested)`, so the existing `LIMIT 1000` stuck and the ZIP came back with at most 1000 rows.

The fix sends `params.statement` (the original user SQL) — matching what the multi-result "export all" path in `ResultViewV1.vue:114` and the React `BatchQuerySelect.tsx:222` already do. Backend semantics are unchanged: any `LIMIT` the user actually typed is still honored via `min(user, requested)`.

This is a long-standing defect — same symptom as the closed [issue #13534](https://github.com/bytebase/bytebase/issues/13534) (reported on 2.22.2, closed 2024-08).

## Reproduction (verified locally on `main`)

Seeded a 5000-row Postgres table, then exercised `SQLService.Export` directly:

| Statement sent | Form `limit` | Result before fix |
|---|---|---|
| `SELECT * FROM export_repro LIMIT 1000` *(what the editor was sending)* | 10000 | ZIP `.sql` shows `LIMIT 1000`, CSV has 1000 rows |
| `SELECT * FROM export_repro` *(what the editor sends after this fix)* | 10000 | ZIP `.sql` shows `LIMIT 10000`, CSV has 5000 rows |
| `SELECT * FROM export_repro LIMIT 5` *(user-written LIMIT)* | 10000 | ZIP `.sql` shows `LIMIT 5`, CSV has 5 rows |

Third row confirms the backend's `min(user-written, requested)` semantics still apply correctly when the original statement is forwarded.

## Test plan
- [ ] In the SQL Editor, run a query that returns more than 1000 rows against a Postgres database.
- [ ] Open the export drawer, set Export rows to 10000, format CSV, click Confirm.
- [ ] Open the downloaded ZIP — `.sql` file shows `LIMIT 10000` (or no LIMIT if the engine doesn't auto-rewrite), CSV contains all expected rows.
- [ ] Repeat with the SQL itself containing `LIMIT 5` — exported file should still cap at 5 rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)