### PR TITLE
cherrypick: [release/3.17.1] fix(databricks): apply user-selected row limit to SQL Editor queries (#20190)

### DIFF
--- a/backend/plugin/db/databricks/databricks.go
+++ b/backend/plugin/db/databricks/databricks.go
@@ -78,7 +78,7 @@ func (*Driver) GetDB() *sql.DB {
 	return nil
 }
 
-func (d *Driver) QueryConn(ctx context.Context, _ *sql.Conn, statement string, _ db.QueryContext) ([]*v1pb.QueryResult, error) {
+func (d *Driver) QueryConn(ctx context.Context, _ *sql.Conn, statement string, queryContext db.QueryContext) ([]*v1pb.QueryResult, error) {
 	var results []*v1pb.QueryResult
 	stmts, err := base.SplitMultiSQL(storepb.Engine_DATABRICKS, statement)
 	if err != nil {
@@ -88,7 +88,7 @@ func (d *Driver) QueryConn(ctx context.Context, _ *sql.Conn, statement string, _
 	for _, stmt := range stmts {
 		result := &v1pb.QueryResult{}
 		startTime := time.Now()
-		dataArr, colInfo, err := d.execStatementSync(ctx, stmt.Text)
+		dataArr, colInfo, err := d.execStatementSync(ctx, stmt.Text, int64(queryContext.Limit))
 		if err != nil {
 			return nil, err
 		}
@@ -158,15 +158,25 @@ func (d *Driver) Execute(ctx context.Context, statement string, _ db.ExecuteOpti
 }
 
 // Execute SQL statement synchronously and return row data or error.
-func (d *Driver) execStatementSync(ctx context.Context, statement string) ([][]string, []dbsql.ColumnInfo, error) {
+// rowLimit caps the result set when > 0; 0 means no limit (used by sync
+// and dump paths). DDL/DML callers should pass 0.
+func (d *Driver) execStatementSync(ctx context.Context, statement string, rowLimit int64) ([][]string, []dbsql.ColumnInfo, error) {
 	// Bind the connected Bytebase database (= Unity Catalog) to the
 	// session, so unqualified `schema.table` references resolve like in
 	// other RDBMSes. Equivalent to issuing `USE CATALOG <name>` first.
-	resp, err := d.Client.StatementExecution.ExecuteAndWait(ctx, dbsql.ExecuteStatementRequest{
+	req := dbsql.ExecuteStatementRequest{
 		Statement:   statement,
 		WarehouseId: d.WarehouseID,
 		Catalog:     d.curCatalog,
-	})
+	}
+	// Honor the user-selected row limit (default 1000 from the SQL Editor).
+	// Without it, INLINE results above ~25 MiB are aborted server-side
+	// with no result available — see DispositionExternalLinks for the
+	// large-result path.
+	if rowLimit > 0 {
+		req.RowLimit = rowLimit
+	}
+	resp, err := d.Client.StatementExecution.ExecuteAndWait(ctx, req)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/plugin/db/databricks/dump.go
+++ b/backend/plugin/db/databricks/dump.go
@@ -129,7 +129,7 @@ func (d *Driver) Dump(ctx context.Context, writer io.Writer, _ *storepb.Database
 }
 
 func (d *Driver) showCreateTable(ctx context.Context, qualifiedTblName string) (string, error) {
-	rows, colInfo, err := d.execStatementSync(ctx, fmt.Sprintf("SHOW CREATE TABLE %s", qualifiedTblName))
+	rows, colInfo, err := d.execStatementSync(ctx, fmt.Sprintf("SHOW CREATE TABLE %s", qualifiedTblName), 0)
 	if err != nil {
 		return "", err
 	}
@@ -170,7 +170,7 @@ func (d *Driver) descTbl(ctx context.Context, tblName string) (*tableAdditionalI
 	tblAddInfo := &tableAdditionalInfo{
 		tblProps: make(map[string]string),
 	}
-	rows, _, err := d.execStatementSync(ctx, fmt.Sprintf("DESC FORMATTED %s", tblName))
+	rows, _, err := d.execStatementSync(ctx, fmt.Sprintf("DESC FORMATTED %s", tblName), 0)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugin/db/databricks/sync.go
+++ b/backend/plugin/db/databricks/sync.go
@@ -54,7 +54,7 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 	instanceMetadata := &db.InstanceMetadata{}
 
 	// fetch version.
-	versionData, _, err := d.execStatementSync(ctx, "SELECT VERSION()")
+	versionData, _, err := d.execStatementSync(ctx, "SELECT VERSION()", 0)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Cherry-pick of #20190 onto `release/3.17.1`. Replaces #20194 (closed): now that #20192 has landed and brought the `Catalog: d.curCatalog` binding to the release branch, this commit applies cleanly with no manual conflict resolution.

Refs [BYT-9379](https://linear.app/bytebase/issue/BYT-9379/databricks-sql-editor-support).

## Test plan

- [x] Cherry-pick applied cleanly with `cherry-pick -x 4af45e510f` after #20192 landed
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/db/databricks/...` — 0 issues
- [x] `go build -ldflags "-w -s" -p=16` succeeded
- [ ] Manual on a Databricks instance: run a wide `SELECT *` with the default 1000-row limit and confirm the INLINE-size error is gone