### PR TITLE
refactor(react): unify list tables onto Table component

### DIFF
--- a/docs/superpowers/plans/2026-05-06-unify-react-tables.md
+++ b/docs/superpowers/plans/2026-05-06-unify-react-tables.md
@@ -1,0 +1,846 @@
+# Unify React list-page tables — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace four raw `<table>` callsites in React list pages with the unified `Table` component at `frontend/src/react/components/ui/table.tsx`, normalizing visuals to the unified component's defaults.
+
+**Architecture:** Pure markup migration. Each callsite swaps raw `<table>` / `<thead>` / `<tbody>` / `<tr>` / `<th>` / `<td>` for the unified `Table` / `TableHeader` / `TableHead` / `TableBody` / `TableRow` / `TableCell`. Sortable headers and column resize use props the unified `Table` already exposes (`sortable`, `sortActive`, `sortDir`, `onSort`, `resizable`, `onResizeStart`). No new APIs are added to the unified `Table`. One PR per page, smallest first.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS v4, Base UI, `class-variance-authority`. Lint via `pnpm --dir frontend fix` / `check`. Type check via `pnpm --dir frontend type-check`. Manual visual verification in `pnpm --dir frontend dev`.
+
+**Spec:** `docs/superpowers/specs/2026-05-06-unify-react-tables-design.md`
+
+**Note on testing:** These are visual UI markup migrations. There are no existing unit tests for these table renderings, and the spec's validation strategy is type-check + lint + manual visual diff rather than TDD. Each task ends with the validation commands and a manual check pass.
+
+**Reference — unified Table API surface (from `frontend/src/react/components/ui/table.tsx`):**
+
+- `Table` — `<table>` wrapper, `w-full caption-bottom text-sm`. Accepts arbitrary children (e.g. `<colgroup>`) and `style` (inline `width` overrides `w-full`).
+- `TableHeader` — `<thead>` wrapper, adds `[&_tr]:border-b`.
+- `TableBody` — `<tbody>` wrapper. `striped?: boolean` (default `true`) toggles `[&_tr:nth-child(even)]:bg-control-bg/50`.
+- `TableRow` — `<tr>` wrapper with hover and selected styles. `striped?: boolean` (default `true`); `striped={false}` adds `!bg-transparent`.
+- `TableHead` — `<th>` wrapper, `h-10 px-4 py-2 text-left align-middle font-medium text-control-light`. Props: `sortable`, `sortActive`, `sortDir` (`"asc" | "desc"`), `onSort`, `resizable`, `onResizeStart`. When `sortable` it renders the children inside an inline-flex span with the unified `ArrowUp`/`ArrowDown`/`ArrowUpDown` indicator. When `resizable && onResizeStart`, it renders the shared `ColumnResizeHandle`.
+- `TableCell` — `<td>` wrapper, `px-4 py-3 align-middle text-sm text-control`.
+
+`TableHeadSortDirection` is exported from the same module.
+
+---
+
+## Task 1: Migrate inline ReleaseTable in ProjectReleaseDashboardPage
+
+**Files:**
+- Modify: `frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx` (the inline `ReleaseTable` and `ReleaseRow` functions; currently lines 186–281)
+
+This is the smallest case: no sort, no resize, no selection, no pagination logic in the table itself. The page already uses `cn` from `@/react/lib/utils`, so no new imports needed besides the unified `Table` parts.
+
+- [ ] **Step 1: Add the unified Table imports**
+
+In the import block at the top of `ProjectReleaseDashboardPage.tsx`, add a new line in alphabetical order (between `Button` and `PagedTableFooter`):
+
+```tsx
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
+```
+
+- [ ] **Step 2: Replace the `ReleaseTable` function body**
+
+Replace the function body (currently lines 186–209) with:
+
+```tsx
+function ReleaseTable({ releases }: { releases: Release[] }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-75">{t("common.name")}</TableHead>
+            <TableHead>{t("release.files")}</TableHead>
+            <TableHead className="w-32">{t("common.created-at")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {releases.map((release) => (
+            <ReleaseRow key={release.name} release={release} />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Replace the `ReleaseRow` function's JSX**
+
+In `ReleaseRow` (currently lines 215–281), replace the `<tr>...</tr>` block (currently lines 242–280) with:
+
+```tsx
+return (
+  <TableRow className="cursor-pointer" onClick={onRowClick}>
+    <TableCell>
+      <span
+        className={cn(
+          "truncate",
+          isDeleted && "text-control-light line-through"
+        )}
+      >
+        {releaseName}
+      </span>
+    </TableCell>
+    <TableCell>
+      <div className="flex flex-col items-start gap-1">
+        {showFiles.map((file, idx) => (
+          <p key={idx} className="w-full truncate">
+            {file.version && (
+              <span className="mr-2 inline-flex items-center rounded-full bg-control-bg px-2 py-0.5 text-xs">
+                {file.version}
+              </span>
+            )}
+            {file.path}
+          </p>
+        ))}
+        {release.files.length > MAX_SHOW_FILES_COUNT && (
+          <p className="text-control-placeholder text-xs italic">
+            {t("release.total-files", { count: release.files.length })}
+          </p>
+        )}
+      </div>
+    </TableCell>
+    <TableCell>
+      <HumanizeTs ts={createTimeTs} />
+    </TableCell>
+  </TableRow>
+);
+```
+
+Notes on what changed:
+- The custom `border-b cursor-pointer hover:bg-control-bg` becomes just `cursor-pointer` — `TableRow` already provides `border-b border-block-border` and `hover:bg-control-bg/60`. Per the spec, accept the unified hover (`/60` instead of solid).
+- The custom `py-2 px-4` cell padding becomes the unified `px-4 py-3`.
+- The header row's custom `border-b text-left text-control-light` is dropped — `TableHeader` adds the bottom border and `TableHead` has `text-control-light` and `text-left` baked in.
+
+- [ ] **Step 4: Run the frontend fixer**
+
+```bash
+pnpm --dir frontend fix
+```
+
+Expected: imports get sorted; no errors.
+
+- [ ] **Step 5: Type check**
+
+```bash
+pnpm --dir frontend type-check
+```
+
+Expected: PASS, no errors related to this file.
+
+- [ ] **Step 6: Lint check**
+
+```bash
+pnpm --dir frontend check
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Manual visual verification**
+
+Start the dev server (`pnpm --dir frontend dev`) and open a project that has at least one release. Navigate to `/projects/<id>/releases`. Verify:
+
+- The table renders with three columns (Name, Files, Created at).
+- Rows are clickable and navigate to the release detail.
+- The filter bar above still works (selecting a category filters the list).
+- Striped rows alternate (this is new — ReleaseTable used to have no striping; the unified Table adds it by default).
+
+Confirm visually that nothing looks broken. If you decide striping is undesirable here, pass `striped={false}` to `<TableBody>` and re-check; otherwise keep the default.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx
+git commit -m "$(cat <<'EOF'
+refactor(react): migrate ReleaseTable to unified Table component
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Migrate ProjectTable
+
+**Files:**
+- Modify: `frontend/src/react/components/ProjectTable.tsx`
+
+This is a focused component file. The migration drops the local `SortIndicator` (rotating ChevronDown) in favor of the unified Table's `ArrowUp`/`ArrowDown`/`ArrowUpDown`, drops the `bg-control-bg` header background, and uses `TableHead`'s `sortable` / `sortActive` / `sortDir` / `onSort` props.
+
+- [ ] **Step 1: Update the imports**
+
+Replace the existing import block (currently lines 1–10) with:
+
+```tsx
+import { Check } from "lucide-react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { HighlightLabelText } from "@/react/components/HighlightLabelText";
+import { Badge } from "@/react/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { getProjectName } from "@/react/lib/resourceName";
+import { cn } from "@/react/lib/utils";
+import { State } from "@/types/proto-es/v1/common_pb";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+```
+
+`ChevronDown` is removed because the unified `TableHead` provides its own sort indicator.
+
+- [ ] **Step 2: Update the file-level doc comment on `ProjectTable`**
+
+Replace the JSDoc above the `ProjectTable` function (currently lines 68–87) with:
+
+```tsx
+/**
+ * React port of `frontend/src/components/v2/Model/ProjectV1Table.vue`.
+ *
+ * Renders the standard project listing — id / title / labels columns,
+ * with optional leading current-project check, leading selection
+ * checkboxes, and trailing action-dropdown slot. Matches the prop
+ * shape of the Vue component so call sites read the same way.
+ *
+ * Two surfaces consume this today:
+ *   - `ProjectsPage` (settings) — `showSelection` + `showActions` +
+ *     server-side sort by title.
+ *   - `ProjectSwitchPanel` (header popover) — `showLabels=false` +
+ *     `currentProject` set to the active project.
+ */
+```
+
+The note about "uses plain HTML table elements to preserve … bg-control-bg header / px-4 py-2 padding / rotating ChevronDown" is no longer accurate after this migration.
+
+- [ ] **Step 3: Replace the `<table>` body with the unified primitives**
+
+Replace the JSX returned by `ProjectTable` (currently lines 137–278) with:
+
+```tsx
+return (
+  <Table className={className}>
+    <TableHeader>
+      <TableRow>
+        {showSelection ? (
+          <TableHead className="w-12">
+            <input
+              type="checkbox"
+              aria-label={t("common.select-all")}
+              checked={allSelected}
+              onChange={handleSelectAll}
+              className="rounded-xs border-control-border"
+            />
+          </TableHead>
+        ) : showLeadingCheck ? (
+          <TableHead className="w-8 px-2" />
+        ) : null}
+        <TableHead className="min-w-[128px]">{t("common.id")}</TableHead>
+        <TableHead
+          className="min-w-[200px]"
+          sortable={!!onSortChange}
+          sortActive={sortKey === "title"}
+          sortDir={sortOrder}
+          onSort={() => onSortChange?.("title")}
+        >
+          {t("project.table.name")}
+        </TableHead>
+        {showLabels ? (
+          <TableHead className="min-w-[240px] hidden md:table-cell">
+            {t("common.labels")}
+          </TableHead>
+        ) : null}
+        {showActions ? <TableHead className="w-[50px]" /> : null}
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {loading && projectList.length === 0 ? (
+        <TableRow>
+          <TableCell
+            colSpan={totalColumns}
+            className="px-4 py-8 text-center text-control-placeholder"
+          >
+            <div className="flex items-center justify-center gap-x-2">
+              <div className="animate-spin size-4 border-2 border-accent border-t-transparent rounded-full" />
+              {t("common.loading")}
+            </div>
+          </TableCell>
+        </TableRow>
+      ) : projectList.length === 0 ? (
+        <TableRow>
+          <TableCell
+            colSpan={totalColumns}
+            className="px-4 py-8 text-center text-control-placeholder"
+          >
+            {emptyContent ?? t("common.no-data")}
+          </TableCell>
+        </TableRow>
+      ) : (
+        projectList.map((project) => {
+          const resourceId = getProjectName(project.name);
+          const isDefault = resourceId === "default";
+          const isCurrent = currentProject?.name === project.name;
+          const isSelected = selectedProjectNames.includes(project.name);
+          return (
+            <TableRow
+              key={project.name}
+              className={cn(onRowClick && "cursor-pointer")}
+              onClick={(event) => onRowClick?.(project, event)}
+            >
+              {showSelection ? (
+                <TableCell
+                  className="w-12"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <input
+                    type="checkbox"
+                    aria-label={t("common.select")}
+                    checked={isSelected}
+                    disabled={isDefault}
+                    onChange={() => handleToggleRow(project.name)}
+                    className="rounded-xs border-control-border disabled:opacity-50"
+                  />
+                </TableCell>
+              ) : showLeadingCheck ? (
+                <TableCell className="w-8 px-2">
+                  {isCurrent ? (
+                    <Check className="size-4 text-accent" />
+                  ) : null}
+                </TableCell>
+              ) : null}
+              <TableCell>
+                <HighlightLabelText text={resourceId} keyword={keyword} />
+              </TableCell>
+              <TableCell>
+                <div className="flex items-center gap-x-2">
+                  <HighlightLabelText
+                    text={project.title || resourceId}
+                    keyword={keyword}
+                  />
+                  {project.state === State.DELETED ? (
+                    <Badge variant="warning" className="text-xs">
+                      {t("common.archived")}
+                    </Badge>
+                  ) : null}
+                </div>
+              </TableCell>
+              {showLabels ? (
+                <TableCell className="hidden md:table-cell">
+                  <LabelsCell labels={project.labels ?? {}} />
+                </TableCell>
+              ) : null}
+              {showActions ? (
+                <TableCell
+                  className="w-[50px]"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="flex justify-end">
+                    {renderActions?.(project)}
+                  </div>
+                </TableCell>
+              ) : null}
+            </TableRow>
+          );
+        })
+      )}
+    </TableBody>
+  </Table>
+);
+```
+
+Notes on what changed:
+- The header `bg-control-bg` background is dropped (per spec — normalize to unified defaults).
+- The local `SortIndicator` is no longer used; the unified `TableHead`'s `sortable` API renders the standard indicator.
+- The custom `i % 2 === 1 && "bg-control-bg/50"` striping is dropped because `TableBody` provides striping by default. The current visual (every-other row tinted) stays.
+- `onRowClick && "cursor-pointer hover:bg-control-bg"` becomes `onRowClick && "cursor-pointer"` because `TableRow` already provides hover (`hover:bg-control-bg/60`).
+- Cell padding shifts from `px-4 py-2` to the unified `px-4 py-3`.
+
+- [ ] **Step 4: Delete the now-unused local `SortIndicator`**
+
+Remove the entire `SortIndicator` function (currently lines 281–305) including its JSDoc. Also remove the `ProjectTableSortDirection` type alias usage check — it remains used via the `sortOrder` prop type, so keep the `ProjectTableSortDirection` export. Only `SortIndicator` is deleted.
+
+- [ ] **Step 5: Run the frontend fixer**
+
+```bash
+pnpm --dir frontend fix
+```
+
+Expected: imports get sorted; no errors.
+
+- [ ] **Step 6: Type check**
+
+```bash
+pnpm --dir frontend type-check
+```
+
+Expected: PASS, no errors related to this file. The `sortDir` prop on `TableHead` accepts `"asc" | "desc" | undefined` and `ProjectTableSortDirection` is `"asc" | "desc"`, so passing `sortOrder` directly is type-safe.
+
+- [ ] **Step 7: Lint check**
+
+```bash
+pnpm --dir frontend check
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Manual visual verification**
+
+Start the dev server (or keep it running). Verify both consumers of `ProjectTable`:
+
+1. **Settings → Projects** (`/projects` settings list): table should render with the unified header style (no `bg-control-bg` background), unified arrow sort indicator on the Name column. Click the Name header to toggle sort. Selection checkboxes still work; bulk action bar still appears. Pagination still works.
+2. **Project switcher** (header popover with `currentProject` set): leading column shows the check icon for the current project. No labels column. Clicking a row navigates.
+
+Confirm both look right. The visual diff is intentional per the spec (Question 3, option A).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/react/components/ProjectTable.tsx
+git commit -m "$(cat <<'EOF'
+refactor(react): migrate ProjectTable to unified Table component
+
+Drop the local SortIndicator and bg-control-bg header background in
+favor of the unified Table's defaults.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Migrate AuditLogTable
+
+**Files:**
+- Modify: `frontend/src/react/components/AuditLogTable.tsx`
+
+The page uses `useColumnWidths` + a `<colgroup>` for explicit per-column widths and `style={{ width: totalWidth }}` + `table-fixed` for layout. The unified `Table` accepts arbitrary children (so `<colgroup>` works) and forwards `style`/`className`. Sort indicators move from the local `renderSortIndicator` (rotating ChevronDown) to `TableHead`'s built-in indicator. Resize wires through `TableHead`'s `resizable` + `onResizeStart` props.
+
+- [ ] **Step 1: Update the imports**
+
+Replace the existing imports for `ChevronDown` (line 6) and the `ColumnResizeHandle` import (line 25). Specifically:
+
+In the `lucide-react` import (currently line 5–11), drop `ChevronDown`:
+
+```tsx
+import { Download, ExternalLink, Maximize2, X } from "lucide-react";
+```
+
+Drop the `ColumnResizeHandle` import line (currently line 25) — `TableHead` renders the handle internally now.
+
+Add the unified `Table` imports. In the alphabetical block of `@/react/components/ui/*` imports, add (between `LAYER_SURFACE_CLASS` and the next block — adjust insertion point so the file passes `pnpm --dir frontend fix`):
+
+```tsx
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
+```
+
+- [ ] **Step 2: Delete the local `renderSortIndicator`**
+
+Inside `AuditLogTable`, delete the `renderSortIndicator` constant (currently lines 692–703):
+
+```tsx
+const renderSortIndicator = (columnKey: string) => {
+  if (sortKey !== columnKey)
+    return <ChevronDown className="h-4 w-4 text-control-light" />;
+  return (
+    <ChevronDown
+      className={cn(
+        "h-4 w-4 text-accent transition-transform",
+        sortOrder === "asc" && "rotate-180"
+      )}
+    />
+  );
+};
+```
+
+Sort indication will be handled by `TableHead`'s `sortable` API.
+
+- [ ] **Step 3: Replace the `<table>` body with the unified primitives**
+
+Replace the table block (currently lines 736–811) with:
+
+```tsx
+<Table
+  className="border-t border-block-border table-fixed"
+  style={{ width: `${totalWidth}px` }}
+>
+  <colgroup>
+    {widths.map((w, i) => (
+      <col key={columns[i].key} style={{ width: `${w}px` }} />
+    ))}
+  </colgroup>
+  <TableHeader>
+    <TableRow>
+      {columns.map((col, colIdx) => (
+        <TableHead
+          key={col.key}
+          className="text-sm text-main whitespace-nowrap"
+          sortable={col.sortable}
+          sortActive={col.sortable && sortKey === col.key}
+          sortDir={sortOrder}
+          onSort={
+            col.sortable ? () => toggleSort(col.key) : undefined
+          }
+          resizable={col.resizable}
+          onResizeStart={
+            col.resizable ? (e) => onResizeStart(colIdx, e) : undefined
+          }
+        >
+          {col.title}
+        </TableHead>
+      ))}
+    </TableRow>
+  </TableHeader>
+  <TableBody striped={false}>
+    {loading && auditLogs.length === 0 ? (
+      <TableRow>
+        <TableCell
+          colSpan={columns.length}
+          className="text-center py-8 text-control-placeholder"
+        >
+          {t("common.loading")}
+        </TableCell>
+      </TableRow>
+    ) : auditLogs.length === 0 ? (
+      <TableRow>
+        <TableCell
+          colSpan={columns.length}
+          className="text-center py-8 text-control-placeholder"
+        >
+          {t("common.no-data")}
+        </TableCell>
+      </TableRow>
+    ) : (
+      auditLogs.map((log, idx) => (
+        <TableRow key={log.name || idx}>
+          {columns.map((col) => (
+            <TableCell
+              key={col.key}
+              className="align-top overflow-hidden"
+            >
+              {col.render(log)}
+            </TableCell>
+          ))}
+        </TableRow>
+      ))
+    )}
+  </TableBody>
+</Table>
+```
+
+Notes on what changed:
+- `<table className="text-sm border-t border-block-border table-fixed">` becomes `<Table className="border-t border-block-border table-fixed">` (the unified `Table` already sets `text-sm`).
+- `<colgroup>` is passed as a direct child of `<Table>` — the unified component spreads `...props` onto `<table>` and renders any children.
+- The custom `text-main` and `whitespace-nowrap` per-header are kept via the `className` prop on `TableHead` (this is page-specific styling, not a deviation from the spec — the spec said header dropdown filters and arbitrary header content keep working).
+- The page previously used manual `idx % 2 === 1 && "bg-control-bg/50"` striping. The unified `TableBody` provides the same effect by default — the snippet above does **not** pass `striped={false}`. The loading and empty states are also `<TableRow>` children of `<TableBody>` so striping parity is computed including them, but those states are short-lived; the visual diff is acceptable.
+- `align-top` on cells is preserved (audit log rows can be tall). `overflow-hidden` is preserved.
+
+- [ ] **Step 4: Run the frontend fixer**
+
+```bash
+pnpm --dir frontend fix
+```
+
+Expected: imports get sorted; no errors.
+
+- [ ] **Step 5: Type check**
+
+```bash
+pnpm --dir frontend type-check
+```
+
+Expected: PASS, no errors related to this file. `sortDir` accepts `"asc" | "desc" | undefined`; `sortOrder` here is `"asc" | "desc"`. When `sortKey !== col.key`, `sortActive` is `false` so `sortDir` is ignored by the indicator.
+
+- [ ] **Step 6: Lint check**
+
+```bash
+pnpm --dir frontend check
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Manual visual verification**
+
+Open the workspace audit log page (`/audit-log`) and the project audit log page (a project detail's audit log tab) — both consume `AuditLogTable`.
+
+Verify:
+
+- Columns render with their initial widths.
+- Drag the resize handle on a resizable column header — it resizes.
+- Click the **Created at** column header — sort toggles asc → desc → off, with the unified arrow indicator switching state.
+- The export dropdown still opens and exports.
+- The advanced search and time range picker still filter results.
+- Pagination footer still works.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/react/components/AuditLogTable.tsx
+git commit -m "$(cat <<'EOF'
+refactor(react): migrate AuditLogTable to unified Table component
+
+Wire column resize and sort through the unified TableHead props
+instead of the local renderSortIndicator and ColumnResizeHandle
+imports.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Migrate InstancesPage
+
+**Files:**
+- Modify: `frontend/src/react/pages/settings/InstancesPage.tsx`
+
+This is the largest case but mechanically the same as AuditLogTable: `useColumnWidths` + `<colgroup>` + `style={{ width: totalWidth }}` + `table-fixed` pass through to the unified `Table`. Sort indicator and column resize move to `TableHead` props. Data source expansion stays in-cell (as in the existing code) — no special handling.
+
+- [ ] **Step 1: Update the imports**
+
+In the `lucide-react` import block (currently lines 3–11), drop `ChevronDown` if it is **only** used by the local `renderSortIndicator` and the `SyncDropdown` toggle and the in-cell data source toggle. Check those:
+
+- `SyncDropdown` (line 559) uses `<ChevronDown className="h-3 w-3 ml-1" />` — keep.
+- The address cell (line 1213) uses `<ChevronDown className="w-4 h-4" />` — keep.
+- The local `renderSortIndicator` uses it — this gets deleted.
+
+So **keep** `ChevronDown` in the import. Same for `ChevronUp` (used for the data source toggle).
+
+Drop the `ColumnResizeHandle` import (currently line 37) — `TableHead` renders the handle internally.
+
+Add the unified `Table` imports. After the existing `Sheet` imports block, add:
+
+```tsx
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
+```
+
+- [ ] **Step 2: Delete the local `renderSortIndicator`**
+
+Delete this constant inside `InstancesPage` (currently lines 1109–1121):
+
+```tsx
+const renderSortIndicator = (columnKey: string) => {
+  if (sortKey !== columnKey) {
+    return <ChevronDown className="size-3 text-control-border" />;
+  }
+  return (
+    <ChevronDown
+      className={cn(
+        "h-3 w-3 text-accent transition-transform",
+        sortOrder === "asc" && "rotate-180"
+      )}
+    />
+  );
+};
+```
+
+- [ ] **Step 3: Replace the `<table>` block with the unified primitives**
+
+Replace the table block (currently lines 1314–1403, beginning with `<div className="border rounded-sm">` and ending with the closing `</div>` of that wrapper) with:
+
+```tsx
+{/* Table */}
+<div className="border rounded-sm">
+  <div className="overflow-x-auto">
+    <Table
+      className="table-fixed"
+      style={{ width: `${totalWidth}px` }}
+    >
+      <colgroup>
+        {widths.map((w, i) => (
+          <col key={columns[i].key} style={{ width: `${w}px` }} />
+        ))}
+      </colgroup>
+      <TableHeader>
+        <TableRow>
+          {columns.map((col, colIdx) => (
+            <TableHead
+              key={col.key}
+              sortable={col.sortable}
+              sortActive={col.sortable && sortKey === (col.sortKey ?? col.key)}
+              sortDir={sortOrder}
+              onSort={
+                col.sortable
+                  ? () => toggleSort(col.sortKey ?? col.key)
+                  : undefined
+              }
+              resizable={col.resizable}
+              onResizeStart={
+                col.resizable ? (e) => onResizeStart(colIdx, e) : undefined
+              }
+            >
+              {col.title}
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {loading && instances.length === 0 ? (
+          <TableRow>
+            <TableCell
+              colSpan={columns.length}
+              className="px-4 py-8 text-center text-control-placeholder"
+            >
+              <div className="flex items-center justify-center gap-x-2">
+                <div className="animate-spin size-4 border-2 border-accent border-t-transparent rounded-full" />
+                {t("common.loading")}
+              </div>
+            </TableCell>
+          </TableRow>
+        ) : instances.length === 0 ? (
+          <TableRow>
+            <TableCell
+              colSpan={columns.length}
+              className="px-4 py-8 text-center text-control-placeholder"
+            >
+              {t("common.no-data")}
+            </TableCell>
+          </TableRow>
+        ) : (
+          instances.map((instance) => (
+            <TableRow
+              key={instance.name}
+              className="cursor-pointer"
+              onClick={(e) => handleRowClick(instance, e)}
+            >
+              {columns.map((col) => (
+                <TableCell
+                  key={col.key}
+                  className={cn("overflow-hidden", col.cellClassName)}
+                >
+                  {col.render(instance)}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))
+        )}
+      </TableBody>
+    </Table>
+  </div>
+</div>
+```
+
+Notes on what changed:
+- `<table className="text-sm table-fixed">` becomes `<Table className="table-fixed">` (the unified `Table` already sets `text-sm`).
+- The header row's custom `bg-control-bg border-b border-control-border` is dropped — the unified `TableHeader` adds the bottom border, and per the spec we drop the custom header background.
+- The local `renderSortIndicator` calls are replaced by `TableHead`'s built-in indicator via the `sortable` / `sortActive` / `sortDir` / `onSort` props.
+- `<ColumnResizeHandle ... />` calls inside each `<th>` are removed; they are now rendered by `TableHead` itself when `resizable` is true.
+- Per-row striping (`i % 2 === 1 && "bg-control-bg/50"`) is dropped because `TableBody` provides striping by default. Pass `cursor-pointer` to `TableRow` (hover is already provided by the unified component).
+- Cells keep their `cellClassName` override pattern (used for the select column to set tighter padding). `align-middle` is dropped because `TableCell` already sets it. `overflow-hidden` is preserved.
+
+- [ ] **Step 4: Run the frontend fixer**
+
+```bash
+pnpm --dir frontend fix
+```
+
+Expected: imports get sorted; no errors.
+
+- [ ] **Step 5: Type check**
+
+```bash
+pnpm --dir frontend type-check
+```
+
+Expected: PASS, no errors related to this file. The `InstanceColumn` type's `title: React.ReactNode` is compatible with `TableHead`'s children. `sortable`, `sortActive`, `sortDir`, `onSort`, `resizable`, `onResizeStart` are all optional on `TableHead`.
+
+- [ ] **Step 6: Lint check**
+
+```bash
+pnpm --dir frontend check
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Manual visual verification — InstancesPage**
+
+Open `/instance` (the workspace instances list). Verify:
+
+- Header renders with no background fill (intentional — visual normalization).
+- Sort indicators on Name and Environment use the unified `ArrowUp`/`ArrowDown`/`ArrowUpDown` icons. Clicking toggles asc → desc → off.
+- Drag a resize handle on Name, Environment, Address, or Labels — column resizes.
+- Click a row — navigates to instance detail.
+- Click the row's checkbox without navigating — selection updates and the batch operations bar appears.
+- Find an instance with multiple data sources (or temporarily add one). Click the chevron in the address cell. The cell expands vertically to show all data source `host:port` entries. Collapse — back to a single line.
+- Sort while a row is expanded — the row stays in its position relative to the sort, with its expansion preserved (expansion state is keyed on `instance.name`).
+- Pagination footer still works.
+- Trigger an empty result (e.g. search for a string that matches nothing) — the empty placeholder spans all columns.
+- Trigger the loading state (refresh) — the loading spinner spans all columns.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/react/pages/settings/InstancesPage.tsx
+git commit -m "$(cat <<'EOF'
+refactor(react): migrate InstancesPage table to unified Table component
+
+Wire column resize and sort through the unified TableHead props.
+Data source expansion stays in-cell — no Table API change needed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final wrap-up
+
+After all four tasks are committed:
+
+- [ ] **Final step: Whole-frontend check**
+
+Run the full frontend pipeline once more to catch any cross-file issues:
+
+```bash
+pnpm --dir frontend fix
+pnpm --dir frontend check
+pnpm --dir frontend type-check
+pnpm --dir frontend test
+```
+
+Expected: all PASS. If `test` surfaces failures in unrelated areas, document them but do not attempt to fix them as part of this work.
+
+- [ ] **Final step: Confirm no stragglers**
+
+Run a quick grep to confirm there are no remaining raw `<table>` callsites under `frontend/src/react/`:
+
+```bash
+grep -rn '<table' frontend/src/react/ --include='*.tsx' | grep -v 'src/react/components/ui/table.tsx'
+```
+
+Expected: no results (other than possibly comments or string literals — eyeball them).
+
+If new raw `<table>` callsites appear that were not in the original audit, do **not** silently expand the scope. Stop and report them; the spec covers exactly the four files above.

--- a/docs/superpowers/specs/2026-05-06-unify-react-tables-design.md
+++ b/docs/superpowers/specs/2026-05-06-unify-react-tables-design.md
@@ -79,12 +79,16 @@ Smallest case: no sort, no resize, no selection.
 Largest case.
 
 - Same markup swap with `sortable` / `resizable` props wired to existing state.
-- Expandable data sources stay as page-level logic: when an instance row is
-  expanded, render an extra `<TableRow>` directly after it whose single
-  `<TableCell colSpan=...>` holds the data source list. The unified `Table`
-  does not need to know about expansion.
-- Striping: likely pass `striped={false}` so the expanded follow-up row does
-  not produce odd alternating bands. Confirm during implementation.
+- Expandable data sources stay as in-cell rendering: the address cell shows
+  either the single `hostPortOfInstanceV1(instance)` line or a vertical list
+  of `hostPortOfDataSource(ds)` lines based on `expandedDataSources` state.
+  Page-level logic only — no Table API change.
+- The page builds column widths via `useColumnWidths` + `<colgroup>` and sets
+  `style={{ width: totalWidth }}` + `table-fixed` on the table element.
+  Pass these through to the unified `Table` (it spreads `...props` and
+  accepts arbitrary children including `<colgroup>`).
+- Striping default-on is fine; in-cell expansion does not interact with
+  alternating row bands.
 
 ## Validation
 
@@ -97,8 +101,8 @@ For each migrated page:
 - Manual visual check via `pnpm --dir frontend dev`: load the page, verify
   sort, resize, expand, and row-click behavior; eyeball the visual diff against
   the current build.
-- For `InstancesPage` specifically: expand a row, sort while expanded, resize a
-  column, collapse and re-expand.
+- For `InstancesPage` specifically: expand a row's data sources, sort while
+  expanded, resize a column, collapse and re-expand.
 
 ## PR strategy
 

--- a/docs/superpowers/specs/2026-05-06-unify-react-tables-design.md
+++ b/docs/superpowers/specs/2026-05-06-unify-react-tables-design.md
@@ -1,0 +1,113 @@
+# Unify React list-page tables on the shared `Table` component
+
+**Date:** 2026-05-06
+**Status:** Approved
+
+## Goal
+
+Replace the remaining raw `<table>` callsites in React list pages with the
+unified `Table` component at
+`frontend/src/react/components/ui/table.tsx`, normalizing visual appearance to
+the unified component's defaults.
+
+The unified `Table` already provides striping, sortable headers (with
+`ArrowUp/Down/UpDown` indicators), and column resizing via the
+`ColumnResizeHandle`. Most React list surfaces already use it. A handful still
+ship raw HTML — those are the targets.
+
+## Scope
+
+### In scope (4 callsites)
+
+1. `frontend/src/react/components/ProjectTable.tsx` — used by `ProjectsPage`.
+2. `frontend/src/react/components/AuditLogTable.tsx`.
+3. `frontend/src/react/pages/settings/InstancesPage.tsx`.
+4. The inline `ReleaseTable` in
+   `frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx`
+   (currently around lines 186–280).
+
+### Out of scope
+
+- Pages that already use the unified `Table` (changelog, revisions, groups, SQL
+  review rules, instance roles, release files, approval steps,
+  `DatabaseTableView`, etc.). They are fine as-is.
+- Vue list pages. They will pick up the unified `Table` when they are migrated
+  to React on their own schedules.
+- Building a `DataTable` wrapper or adopting `@tanstack/react-table`. Premature
+  given there are only four callsites left.
+- Adding new APIs to the unified `Table` itself (no expansion API, no sticky
+  header API). All four migrations should be possible with the current API.
+  If implementation hits an unavoidable gap, stop and flag it rather than
+  silently extending the component.
+
+## Per-page changes
+
+### 1. `ReleaseTable` (in `ProjectReleaseDashboardPage.tsx`)
+
+Smallest case: no sort, no resize, no selection.
+
+- Swap raw `<table>` / `<thead>` / `<tbody>` / `<tr>` / `<th>` / `<td>` for
+  `Table` / `TableHeader` / `TableHead` / `TableBody` / `TableRow` / `TableCell`.
+- Drop the custom `py-2 px-4` and accept the unified `px-4 py-3`.
+- Row click handler stays on `<TableRow onClick=...>`.
+- Default striping is fine.
+
+### 2. `ProjectTable.tsx`
+
+- Same markup swap.
+- Drop the `bg-control-bg` header row and the rotating `ChevronDown`. The
+  unified `ArrowUp/Down/UpDown` sort indicators take over via
+  `sortable` / `sortActive` / `sortDir` / `onSort` props on `<TableHead>`.
+- Current-project highlight (check icon) stays as a name-cell concern. No
+  Table API change.
+- Optional checkbox column stays as a leading `<TableHead>` / `<TableCell>`
+  slot.
+
+### 3. `AuditLogTable.tsx`
+
+- Replace raw HTML.
+- Column resize wires the existing width state through
+  `<TableHead resizable onResizeStart=...>` (already supported by the unified
+  `Table`).
+- Header dropdown filters keep working — `<TableHead>` accepts arbitrary
+  children.
+- If a sticky header is currently in use, keep it as a wrapper-level CSS class
+  on the surrounding scroll container. No Table API change.
+
+### 4. `InstancesPage.tsx`
+
+Largest case.
+
+- Same markup swap with `sortable` / `resizable` props wired to existing state.
+- Expandable data sources stay as page-level logic: when an instance row is
+  expanded, render an extra `<TableRow>` directly after it whose single
+  `<TableCell colSpan=...>` holds the data source list. The unified `Table`
+  does not need to know about expansion.
+- Striping: likely pass `striped={false}` so the expanded follow-up row does
+  not produce odd alternating bands. Confirm during implementation.
+
+## Validation
+
+For each migrated page:
+
+- `pnpm --dir frontend fix`
+- `pnpm --dir frontend check`
+- `pnpm --dir frontend type-check`
+- `pnpm --dir frontend test` for any tests touching the surface.
+- Manual visual check via `pnpm --dir frontend dev`: load the page, verify
+  sort, resize, expand, and row-click behavior; eyeball the visual diff against
+  the current build.
+- For `InstancesPage` specifically: expand a row, sort while expanded, resize a
+  column, collapse and re-expand.
+
+## PR strategy
+
+One PR per page, smallest and safest first:
+
+1. `ReleaseTable` — trivial swap, low blast radius.
+2. `ProjectTable` — visual normalization, used by `ProjectsPage`.
+3. `AuditLogTable` — column-resize wiring.
+4. `InstancesPage` — column-resize plus expandable rows; most risk.
+
+This keeps each diff small and reviewable, and a regression in one does not
+block the others.

--- a/frontend/src/react/components/AuditLogTable.tsx
+++ b/frontend/src/react/components/AuditLogTable.tsx
@@ -2,13 +2,7 @@ import { create, toJsonString } from "@bufbuild/protobuf";
 import { AnySchema } from "@bufbuild/protobuf/wkt";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import {
-  ChevronDown,
-  Download,
-  ExternalLink,
-  Maximize2,
-  X,
-} from "lucide-react";
+import { Download, ExternalLink, Maximize2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { auditLogServiceClientConnect } from "@/connect";
@@ -22,13 +16,20 @@ import {
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { TimeRangePicker } from "@/react/components/TimeRangePicker";
 import { Button } from "@/react/components/ui/button";
-import { ColumnResizeHandle } from "@/react/components/ui/column-resize-handle";
 import {
   Dialog,
   DialogContent,
   DialogTitle,
 } from "@/react/components/ui/dialog";
 import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { usePlanFeature } from "@/react/hooks/useAppState";
 import { useColumnWidths } from "@/react/hooks/useColumnWidths";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
@@ -689,19 +690,6 @@ export function AuditLogTable({
     ];
   }, [t, searchUsers]);
 
-  const renderSortIndicator = (columnKey: string) => {
-    if (sortKey !== columnKey)
-      return <ChevronDown className="h-4 w-4 text-control-light" />;
-    return (
-      <ChevronDown
-        className={cn(
-          "h-4 w-4 text-accent transition-transform",
-          sortOrder === "asc" && "rotate-180"
-        )}
-      />
-    );
-  };
-
   const pageSizeOptions = getPageSizeOptions();
 
   return (
@@ -733,8 +721,8 @@ export function AuditLogTable({
       {hasAuditLogFeature ? (
         <div>
           <div className="overflow-x-auto">
-            <table
-              className="text-sm border-t border-block-border table-fixed"
+            <Table
+              className="border-t border-block-border table-fixed"
               style={{ width: `${totalWidth}px` }}
             >
               <colgroup>
@@ -742,73 +730,65 @@ export function AuditLogTable({
                   <col key={columns[i].key} style={{ width: `${w}px` }} />
                 ))}
               </colgroup>
-              <thead>
-                <tr className="border-b border-block-border">
+              <TableHeader>
+                <TableRow>
                   {columns.map((col, colIdx) => (
-                    <th
+                    <TableHead
                       key={col.key}
-                      className={cn(
-                        "relative px-4 py-3 text-left text-sm font-medium text-main whitespace-nowrap",
-                        col.sortable && "cursor-pointer select-none"
-                      )}
-                      onClick={
+                      className="text-sm text-main whitespace-nowrap"
+                      sortable={col.sortable}
+                      sortActive={col.sortable && sortKey === col.key}
+                      sortDir={sortOrder}
+                      onSort={
                         col.sortable ? () => toggleSort(col.key) : undefined
                       }
+                      resizable={col.resizable}
+                      onResizeStart={
+                        col.resizable
+                          ? (e) => onResizeStart(colIdx, e)
+                          : undefined
+                      }
                     >
-                      <div className="flex items-center gap-x-1">
-                        {col.title}
-                        {col.sortable && renderSortIndicator(col.key)}
-                      </div>
-                      {col.resizable && (
-                        <ColumnResizeHandle
-                          onMouseDown={(e) => onResizeStart(colIdx, e)}
-                        />
-                      )}
-                    </th>
+                      {col.title}
+                    </TableHead>
                   ))}
-                </tr>
-              </thead>
-              <tbody>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {loading && auditLogs.length === 0 ? (
-                  <tr>
-                    <td
+                  <TableRow>
+                    <TableCell
                       colSpan={columns.length}
                       className="text-center py-8 text-control-placeholder"
                     >
                       {t("common.loading")}
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ) : auditLogs.length === 0 ? (
-                  <tr>
-                    <td
+                  <TableRow>
+                    <TableCell
                       colSpan={columns.length}
                       className="text-center py-8 text-control-placeholder"
                     >
                       {t("common.no-data")}
-                    </td>
-                  </tr>
+                    </TableCell>
+                  </TableRow>
                 ) : (
                   auditLogs.map((log, idx) => (
-                    <tr
-                      key={log.name || idx}
-                      className={cn(
-                        "border-b border-block-border",
-                        idx % 2 === 1 && "bg-control-bg/50"
-                      )}
-                    >
+                    <TableRow key={log.name || idx}>
                       {columns.map((col) => (
-                        <td
+                        <TableCell
                           key={col.key}
-                          className="px-4 py-3 text-sm align-top overflow-hidden"
+                          className="align-top overflow-hidden"
                         >
                           {col.render(log)}
-                        </td>
+                        </TableCell>
                       ))}
-                    </tr>
+                    </TableRow>
                   ))
                 )}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </div>
 
           {/* Pagination footer */}

--- a/frontend/src/react/components/AuditLogTable.tsx
+++ b/frontend/src/react/components/AuditLogTable.tsx
@@ -723,7 +723,7 @@ export function AuditLogTable({
           <div className="overflow-x-auto">
             <Table
               className="border-t border-block-border table-fixed"
-              style={{ width: `${totalWidth}px` }}
+              style={{ minWidth: `${totalWidth}px` }}
             >
               <colgroup>
                 {widths.map((w, i) => (

--- a/frontend/src/react/components/ProjectTable.tsx
+++ b/frontend/src/react/components/ProjectTable.tsx
@@ -1,8 +1,16 @@
-import { Check, ChevronDown } from "lucide-react";
+import { Check } from "lucide-react";
 import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
 import { Badge } from "@/react/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { getProjectName } from "@/react/lib/resourceName";
 import { cn } from "@/react/lib/utils";
@@ -78,12 +86,6 @@ export interface ProjectTableProps {
  *     server-side sort by title.
  *   - `ProjectSwitchPanel` (header popover) — `showLabels=false` +
  *     `currentProject` set to the active project.
- *
- * Uses plain HTML table elements (not the shadcn `Table` primitives)
- * to preserve the visual styling that ProjectsPage shipped with —
- * specifically: `bg-control-bg` header row, `px-4 py-2` cell padding,
- * and a rotating `ChevronDown` sort indicator. Switching to the
- * shadcn primitives would change all of those at once.
  */
 export function ProjectTable({
   projectList,
@@ -135,11 +137,11 @@ export function ProjectTable({
   };
 
   return (
-    <table className={cn("w-full text-sm", className)}>
-      <thead>
-        <tr className="bg-control-bg border-b border-control-border">
+    <Table className={className}>
+      <TableHeader>
+        <TableRow>
           {showSelection ? (
-            <th className="w-12 px-4 py-2">
+            <TableHead className="w-12">
               <input
                 type="checkbox"
                 aria-label={t("common.select-all")}
@@ -147,42 +149,32 @@ export function ProjectTable({
                 onChange={handleSelectAll}
                 className="rounded-xs border-control-border"
               />
-            </th>
+            </TableHead>
           ) : showLeadingCheck ? (
-            <th className="w-8 px-2 py-2" />
+            <TableHead className="w-8 px-2" />
           ) : null}
-          <th className="px-4 py-2 text-left font-medium min-w-[128px]">
-            {t("common.id")}
-          </th>
-          <th
-            className={cn(
-              "px-4 py-2 text-left font-medium min-w-[200px]",
-              onSortChange && "cursor-pointer select-none"
-            )}
-            onClick={() => onSortChange?.("title")}
+          <TableHead className="min-w-[128px]">{t("common.id")}</TableHead>
+          <TableHead
+            className="min-w-[200px]"
+            sortable={!!onSortChange}
+            sortActive={sortKey === "title"}
+            sortDir={sortOrder}
+            onSort={() => onSortChange?.("title")}
           >
-            <div className="flex items-center gap-x-1">
-              {t("project.table.name")}
-              {onSortChange ? (
-                <SortIndicator
-                  active={sortKey === "title"}
-                  direction={sortOrder}
-                />
-              ) : null}
-            </div>
-          </th>
+            {t("project.table.name")}
+          </TableHead>
           {showLabels ? (
-            <th className="px-4 py-2 text-left font-medium min-w-[240px] hidden md:table-cell">
+            <TableHead className="min-w-[240px] hidden md:table-cell">
               {t("common.labels")}
-            </th>
+            </TableHead>
           ) : null}
-          {showActions ? <th className="w-[50px]" /> : null}
-        </tr>
-      </thead>
-      <tbody>
+          {showActions ? <TableHead className="w-[50px]" /> : null}
+        </TableRow>
+      </TableHeader>
+      <TableBody>
         {loading && projectList.length === 0 ? (
-          <tr>
-            <td
+          <TableRow>
+            <TableCell
               colSpan={totalColumns}
               className="px-4 py-8 text-center text-control-placeholder"
             >
@@ -190,36 +182,32 @@ export function ProjectTable({
                 <div className="animate-spin size-4 border-2 border-accent border-t-transparent rounded-full" />
                 {t("common.loading")}
               </div>
-            </td>
-          </tr>
+            </TableCell>
+          </TableRow>
         ) : projectList.length === 0 ? (
-          <tr>
-            <td
+          <TableRow>
+            <TableCell
               colSpan={totalColumns}
               className="px-4 py-8 text-center text-control-placeholder"
             >
               {emptyContent ?? t("common.no-data")}
-            </td>
-          </tr>
+            </TableCell>
+          </TableRow>
         ) : (
-          projectList.map((project, i) => {
+          projectList.map((project) => {
             const resourceId = getProjectName(project.name);
             const isDefault = resourceId === "default";
             const isCurrent = currentProject?.name === project.name;
             const isSelected = selectedProjectNames.includes(project.name);
             return (
-              <tr
+              <TableRow
                 key={project.name}
-                className={cn(
-                  "border-b last:border-b-0",
-                  onRowClick && "cursor-pointer hover:bg-control-bg",
-                  i % 2 === 1 && "bg-control-bg/50"
-                )}
+                className={cn(onRowClick && "cursor-pointer")}
                 onClick={(event) => onRowClick?.(project, event)}
               >
                 {showSelection ? (
-                  <td
-                    className="w-12 px-4 py-2"
+                  <TableCell
+                    className="w-12"
                     onClick={(e) => e.stopPropagation()}
                   >
                     <input
@@ -230,18 +218,18 @@ export function ProjectTable({
                       onChange={() => handleToggleRow(project.name)}
                       className="rounded-xs border-control-border disabled:opacity-50"
                     />
-                  </td>
+                  </TableCell>
                 ) : showLeadingCheck ? (
-                  <td className="w-8 px-2 py-2">
+                  <TableCell className="w-8 px-2">
                     {isCurrent ? (
                       <Check className="size-4 text-accent" />
                     ) : null}
-                  </td>
+                  </TableCell>
                 ) : null}
-                <td className="px-4 py-2">
+                <TableCell>
                   <HighlightLabelText text={resourceId} keyword={keyword} />
-                </td>
-                <td className="px-4 py-2">
+                </TableCell>
+                <TableCell>
                   <div className="flex items-center gap-x-2">
                     <HighlightLabelText
                       text={project.title || resourceId}
@@ -253,54 +241,28 @@ export function ProjectTable({
                       </Badge>
                     ) : null}
                   </div>
-                </td>
+                </TableCell>
                 {showLabels ? (
-                  <td className="px-4 py-2 hidden md:table-cell">
+                  <TableCell className="hidden md:table-cell">
                     <LabelsCell labels={project.labels ?? {}} />
-                  </td>
+                  </TableCell>
                 ) : null}
                 {showActions ? (
-                  <td
-                    className="w-[50px] px-4 py-2"
+                  <TableCell
+                    className="w-[50px]"
                     onClick={(e) => e.stopPropagation()}
                   >
                     <div className="flex justify-end">
                       {renderActions?.(project)}
                     </div>
-                  </td>
+                  </TableCell>
                 ) : null}
-              </tr>
+              </TableRow>
             );
           })
         )}
-      </tbody>
-    </table>
-  );
-}
-
-/**
- * ProjectsPage's original sort indicator: a single ChevronDown that
- * rotates 180° when the column is sorted ascending. Inactive state
- * shows the chevron in `text-control-border` so it reads as "you
- * could click this". Matches the pre-extraction look.
- */
-function SortIndicator({
-  active,
-  direction,
-}: {
-  active: boolean;
-  direction?: ProjectTableSortDirection;
-}) {
-  if (!active) {
-    return <ChevronDown className="size-3 text-control-border" />;
-  }
-  return (
-    <ChevronDown
-      className={cn(
-        "size-3 text-accent transition-transform",
-        direction === "asc" && "rotate-180"
-      )}
-    />
+      </TableBody>
+    </Table>
   );
 }
 

--- a/frontend/src/react/components/database/DatabaseTableView.tsx
+++ b/frontend/src/react/components/database/DatabaseTableView.tsx
@@ -283,88 +283,84 @@ export function DatabaseTableView({
   const { widths, totalWidth, onResizeStart } = useColumnWidths(columns);
 
   return (
-    <div className="border rounded-sm">
-      <div className="overflow-x-auto">
-        <Table className="table-fixed" style={{ minWidth: `${totalWidth}px` }}>
-          <colgroup>
-            {widths.map((w, i) => (
-              <col key={columns[i].key} style={{ width: `${w}px` }} />
-            ))}
-          </colgroup>
-          <TableHeader>
+    <div className="overflow-x-auto border-y border-block-border">
+      <Table className="table-fixed" style={{ minWidth: `${totalWidth}px` }}>
+        <colgroup>
+          {widths.map((w, i) => (
+            <col key={columns[i].key} style={{ width: `${w}px` }} />
+          ))}
+        </colgroup>
+        <TableHeader>
+          <TableRow>
+            {columns.map((col, colIdx) => {
+              const colSortKey = col.sortKey;
+              const sortActive = Boolean(
+                col.sortable && colSortKey && sort?.key === colSortKey
+              );
+              return (
+                <TableHead
+                  key={col.key}
+                  sortable={col.sortable && sortable}
+                  sortActive={sortActive}
+                  sortDir={sort?.order ?? "asc"}
+                  onSort={
+                    col.sortable && sortable && colSortKey
+                      ? () => toggleSort(colSortKey)
+                      : undefined
+                  }
+                  resizable={col.resizable}
+                  onResizeStart={
+                    col.resizable ? (e) => onResizeStart(colIdx, e) : undefined
+                  }
+                >
+                  {col.title}
+                </TableHead>
+              );
+            })}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {loading && databases.length === 0 ? (
             <TableRow>
-              {columns.map((col, colIdx) => {
-                const colSortKey = col.sortKey;
-                const sortActive = Boolean(
-                  col.sortable && colSortKey && sort?.key === colSortKey
-                );
-                return (
-                  <TableHead
-                    key={col.key}
-                    sortable={col.sortable && sortable}
-                    sortActive={sortActive}
-                    sortDir={sort?.order ?? "asc"}
-                    onSort={
-                      col.sortable && sortable && colSortKey
-                        ? () => toggleSort(colSortKey)
-                        : undefined
-                    }
-                    resizable={col.resizable}
-                    onResizeStart={
-                      col.resizable
-                        ? (e) => onResizeStart(colIdx, e)
-                        : undefined
-                    }
-                  >
-                    {col.title}
-                  </TableHead>
-                );
-              })}
+              <TableCell
+                colSpan={columns.length}
+                className="py-8 text-center text-control-placeholder"
+              >
+                <div className="flex items-center justify-center gap-x-2">
+                  <div className="animate-spin h-4 w-4 border-2 border-accent border-t-transparent rounded-full" />
+                  {t("common.loading")}
+                </div>
+              </TableCell>
             </TableRow>
-          </TableHeader>
-          <TableBody>
-            {loading && databases.length === 0 ? (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="py-8 text-center text-control-placeholder"
-                >
-                  <div className="flex items-center justify-center gap-x-2">
-                    <div className="animate-spin h-4 w-4 border-2 border-accent border-t-transparent rounded-full" />
-                    {t("common.loading")}
-                  </div>
-                </TableCell>
+          ) : databases.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={columns.length}
+                className="py-8 text-center text-control-placeholder"
+              >
+                {t("common.no-data")}
+              </TableCell>
+            </TableRow>
+          ) : (
+            databases.map((db) => (
+              <TableRow
+                key={db.name}
+                className={onRowClick ? "cursor-pointer" : undefined}
+                onClick={onRowClick ? (e) => onRowClick(db, e) : undefined}
+              >
+                {columns.map((col) => (
+                  <TableCell
+                    key={col.key}
+                    className={cn("overflow-hidden", col.cellClassName)}
+                  >
+                    {col.render(db)}
+                  </TableCell>
+                ))}
               </TableRow>
-            ) : databases.length === 0 ? (
-              <TableRow>
-                <TableCell
-                  colSpan={columns.length}
-                  className="py-8 text-center text-control-placeholder"
-                >
-                  {t("common.no-data")}
-                </TableCell>
-              </TableRow>
-            ) : (
-              databases.map((db) => (
-                <TableRow
-                  key={db.name}
-                  className={onRowClick ? "cursor-pointer" : undefined}
-                  onClick={onRowClick ? (e) => onRowClick(db, e) : undefined}
-                >
-                  {columns.map((col) => (
-                    <TableCell
-                      key={col.key}
-                      className={cn("overflow-hidden", col.cellClassName)}
-                    >
-                      {col.render(db)}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
+            ))
+          )}
+        </TableBody>
+      </Table>
     </div>
   );
 }

--- a/frontend/src/react/components/database/DatabaseTableView.tsx
+++ b/frontend/src/react/components/database/DatabaseTableView.tsx
@@ -285,14 +285,14 @@ export function DatabaseTableView({
   return (
     <div className="border rounded-sm">
       <div className="overflow-x-auto">
-        <Table className="table-fixed" style={{ width: `${totalWidth}px` }}>
+        <Table className="table-fixed" style={{ minWidth: `${totalWidth}px` }}>
           <colgroup>
             {widths.map((w, i) => (
               <col key={columns[i].key} style={{ width: `${w}px` }} />
             ))}
           </colgroup>
           <TableHeader>
-            <TableRow className="bg-gray-50">
+            <TableRow>
               {columns.map((col, colIdx) => {
                 const colSortKey = col.sortKey;
                 const sortActive = Boolean(

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
@@ -33,6 +33,14 @@ import {
   DialogTitle,
 } from "@/react/components/ui/dialog";
 import { FeatureModal } from "@/react/components/ui/feature-modal";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { Tabs, TabsList, TabsTrigger } from "@/react/components/ui/tabs";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
@@ -1214,43 +1222,40 @@ function ExemptionResourceTable({
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-block-border">
-            <th className="textinfolabel font-medium text-xs py-2 px-2 text-left whitespace-nowrap">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="whitespace-nowrap">
               {t("common.instance")}
-            </th>
-            <th className="textinfolabel font-medium text-xs py-2 px-2 text-left whitespace-nowrap">
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
               {t("common.database")}
-            </th>
-            <th className="textinfolabel font-medium text-xs py-2 px-2 text-left whitespace-nowrap">
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
               {t("common.schema")}
-            </th>
-            <th className="textinfolabel font-medium text-xs py-2 px-2 text-left whitespace-nowrap">
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
               {t("common.table")}
-            </th>
-            <th className="textinfolabel font-medium text-xs py-2 px-2 text-left whitespace-nowrap">
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
               {t("database.columns")}
-            </th>
-            <th className="textinfolabel font-medium text-xs py-2 px-2 text-left whitespace-nowrap">
+            </TableHead>
+            <TableHead className="whitespace-nowrap">
               {t("common.classification-level")}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody striped={false}>
           {databaseResources.map((resource, idx) => {
             const { instanceName, databaseName } = extractDatabaseResourceName(
               resource.databaseFullName
             );
             return (
-              <tr
-                key={idx}
-                className="border-b border-block-border last:border-b-0"
-              >
-                <td className="py-2 px-2 text-control-light whitespace-nowrap">
+              <TableRow key={idx}>
+                <TableCell className="text-control-light whitespace-nowrap">
                   {isSentinel(instanceName) ? t("database.all") : instanceName}
-                </td>
-                <td className="py-2 px-2 whitespace-nowrap">
+                </TableCell>
+                <TableCell className="whitespace-nowrap">
                   {isSentinel(databaseName) ? (
                     <span className="text-control-placeholder">
                       {t("database.all")}
@@ -1265,30 +1270,30 @@ function ExemptionResourceTable({
                   ) : (
                     <span className="text-control-light">{databaseName}</span>
                   )}
-                </td>
-                <td className="py-2 px-2 text-control-light whitespace-nowrap">
+                </TableCell>
+                <TableCell className="text-control-light whitespace-nowrap">
                   {resource.schema || "-"}
-                </td>
-                <td className="py-2 px-2 text-control-light whitespace-nowrap">
+                </TableCell>
+                <TableCell className="text-control-light whitespace-nowrap">
                   {resource.table || "-"}
-                </td>
-                <td className="py-2 px-2">
+                </TableCell>
+                <TableCell>
                   {resource.columns && resource.columns.length > 0
                     ? resource.columns.join(", ")
                     : "-"}
-                </td>
-                <td className="py-2 px-2">
+                </TableCell>
+                <TableCell>
                   <LevelBadge
                     level={classificationLevel?.value}
                     operator={classificationLevel?.operator}
                     noLimit={!classificationLevel}
                   />
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             );
           })}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }

--- a/frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx
@@ -7,6 +7,14 @@ import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { cn } from "@/react/lib/utils";
 import { router } from "@/router";
@@ -188,22 +196,20 @@ function ReleaseTable({ releases }: { releases: Release[] }) {
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b text-left text-control-light">
-            <th className="py-2 px-4 font-medium w-75">{t("common.name")}</th>
-            <th className="py-2 px-4 font-medium">{t("release.files")}</th>
-            <th className="py-2 px-4 font-medium w-32">
-              {t("common.created-at")}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-75">{t("common.name")}</TableHead>
+            <TableHead>{t("release.files")}</TableHead>
+            <TableHead className="w-32">{t("common.created-at")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {releases.map((release) => (
             <ReleaseRow key={release.name} release={release} />
           ))}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }
@@ -240,11 +246,8 @@ function ReleaseRow({ release }: { release: Release }) {
   );
 
   return (
-    <tr
-      className="border-b cursor-pointer hover:bg-control-bg"
-      onClick={onRowClick}
-    >
-      <td className="py-2 px-4">
+    <TableRow className="cursor-pointer" onClick={onRowClick}>
+      <TableCell>
         <span
           className={cn(
             "truncate",
@@ -253,8 +256,8 @@ function ReleaseRow({ release }: { release: Release }) {
         >
           {releaseName}
         </span>
-      </td>
-      <td className="py-2 px-4">
+      </TableCell>
+      <TableCell>
         <div className="flex flex-col items-start gap-1">
           {showFiles.map((file, idx) => (
             <p key={idx} className="w-full truncate">
@@ -272,10 +275,10 @@ function ReleaseRow({ release }: { release: Release }) {
             </p>
           )}
         </div>
-      </td>
-      <td className="py-2 px-4">
+      </TableCell>
+      <TableCell>
         <HumanizeTs ts={createTimeTs} />
-      </td>
-    </tr>
+      </TableCell>
+    </TableRow>
   );
 }

--- a/frontend/src/react/pages/project/ProjectWebhooksPage.tsx
+++ b/frontend/src/react/pages/project/ProjectWebhooksPage.tsx
@@ -14,6 +14,14 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/react/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { WebhookTypeIcon } from "@/react/components/WebhookTypeIcon";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
@@ -163,27 +171,25 @@ function WebhookTable({
 
   return (
     <div className="px-4">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b text-left text-control-light">
-            <th className="py-2 pr-4 font-medium w-60">{t("common.name")}</th>
-            <th className="py-2 pr-4 font-medium">URL</th>
-            <th className="py-2 pr-4 font-medium">
-              {t("project.webhook.triggering-activity")}
-            </th>
-            {allowEdit && <th className="py-2 font-medium w-12" />}
-          </tr>
-        </thead>
-        <tbody>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="w-60">{t("common.name")}</TableHead>
+            <TableHead>URL</TableHead>
+            <TableHead>{t("project.webhook.triggering-activity")}</TableHead>
+            {allowEdit && <TableHead className="w-12" />}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {webhooks.length === 0 ? (
-            <tr>
-              <td
+            <TableRow>
+              <TableCell
                 colSpan={allowEdit ? 4 : 3}
                 className="py-8 text-center text-control-light"
               >
                 {t("common.no-data")}
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           ) : (
             webhooks.map((webhook) => {
               const activityTitles = webhook.notificationTypes.map(
@@ -198,21 +204,21 @@ function WebhookTable({
               );
 
               return (
-                <tr
+                <TableRow
                   key={webhook.name}
-                  className="border-b cursor-pointer hover:bg-control-bg"
+                  className="cursor-pointer"
                   onClick={(e) => onRowClick(e, webhook)}
                 >
-                  <td className="py-2 pr-4">
+                  <TableCell>
                     <div className="flex items-center gap-x-2">
                       <WebhookTypeIcon type={webhook.type} className="size-5" />
                       {webhook.title}
                     </div>
-                  </td>
-                  <td className="py-2 pr-4 truncate max-w-xs text-control-light">
+                  </TableCell>
+                  <TableCell className="truncate max-w-xs text-control-light">
                     {webhook.url}
-                  </td>
-                  <td className="py-2 pr-4">
+                  </TableCell>
+                  <TableCell>
                     <div className="flex flex-wrap gap-2">
                       {activityTitles.map((title) => (
                         <span
@@ -223,18 +229,18 @@ function WebhookTable({
                         </span>
                       ))}
                     </div>
-                  </td>
+                  </TableCell>
                   {allowEdit && (
-                    <td className="py-2">
+                    <TableCell>
                       <ActionDropdown webhook={webhook} onDelete={onDelete} />
-                    </td>
+                    </TableCell>
                   )}
-                </tr>
+                </TableRow>
               );
             })
           )}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -1306,7 +1306,10 @@ export function InstancesPage() {
       {/* Table */}
       <div className="border rounded-sm">
         <div className="overflow-x-auto">
-          <Table className="table-fixed" style={{ width: `${totalWidth}px` }}>
+          <Table
+            className="table-fixed"
+            style={{ minWidth: `${totalWidth}px` }}
+          >
             <colgroup>
               {widths.map((w, i) => (
                 <col key={columns[i].key} style={{ width: `${w}px` }} />

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -34,7 +34,6 @@ import {
   AlertDialogTitle,
 } from "@/react/components/ui/alert-dialog";
 import { Button } from "@/react/components/ui/button";
-import { ColumnResizeHandle } from "@/react/components/ui/column-resize-handle";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -50,6 +49,14 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { useColumnWidths } from "@/react/hooks/useColumnWidths";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
 import {
@@ -1106,20 +1113,6 @@ export function InstancesPage() {
     []
   );
 
-  const renderSortIndicator = (columnKey: string) => {
-    if (sortKey !== columnKey) {
-      return <ChevronDown className="size-3 text-control-border" />;
-    }
-    return (
-      <ChevronDown
-        className={cn(
-          "h-3 w-3 text-accent transition-transform",
-          sortOrder === "asc" && "rotate-180"
-        )}
-      />
-    );
-  };
-
   const canCreate = hasWorkspacePermissionV2("bb.instances.create");
   const allSelected =
     instances.length > 0 && selectedNames.size === instances.length;
@@ -1313,48 +1306,43 @@ export function InstancesPage() {
       {/* Table */}
       <div className="border rounded-sm">
         <div className="overflow-x-auto">
-          <table
-            className="text-sm table-fixed"
-            style={{ width: `${totalWidth}px` }}
-          >
+          <Table className="table-fixed" style={{ width: `${totalWidth}px` }}>
             <colgroup>
               {widths.map((w, i) => (
                 <col key={columns[i].key} style={{ width: `${w}px` }} />
               ))}
             </colgroup>
-            <thead>
-              <tr className="bg-control-bg border-b border-control-border">
+            <TableHeader>
+              <TableRow>
                 {columns.map((col, colIdx) => (
-                  <th
+                  <TableHead
                     key={col.key}
-                    className={cn(
-                      "relative px-4 py-2 text-left font-medium",
-                      col.sortable && "cursor-pointer select-none"
-                    )}
-                    onClick={
+                    sortable={col.sortable}
+                    sortActive={
+                      col.sortable && sortKey === (col.sortKey ?? col.key)
+                    }
+                    sortDir={sortOrder}
+                    onSort={
                       col.sortable
                         ? () => toggleSort(col.sortKey ?? col.key)
                         : undefined
                     }
+                    resizable={col.resizable}
+                    onResizeStart={
+                      col.resizable
+                        ? (e) => onResizeStart(colIdx, e)
+                        : undefined
+                    }
                   >
-                    <div className="flex items-center gap-x-1">
-                      {col.title}
-                      {col.sortable &&
-                        renderSortIndicator(col.sortKey ?? col.key)}
-                    </div>
-                    {col.resizable && (
-                      <ColumnResizeHandle
-                        onMouseDown={(e) => onResizeStart(colIdx, e)}
-                      />
-                    )}
-                  </th>
+                    {col.title}
+                  </TableHead>
                 ))}
-              </tr>
-            </thead>
-            <tbody>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
               {loading && instances.length === 0 ? (
-                <tr>
-                  <td
+                <TableRow>
+                  <TableCell
                     colSpan={columns.length}
                     className="px-4 py-8 text-center text-control-placeholder"
                   >
@@ -1362,43 +1350,37 @@ export function InstancesPage() {
                       <div className="animate-spin size-4 border-2 border-accent border-t-transparent rounded-full" />
                       {t("common.loading")}
                     </div>
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               ) : instances.length === 0 ? (
-                <tr>
-                  <td
+                <TableRow>
+                  <TableCell
                     colSpan={columns.length}
                     className="px-4 py-8 text-center text-control-placeholder"
                   >
                     {t("common.no-data")}
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               ) : (
-                instances.map((instance, i) => (
-                  <tr
+                instances.map((instance) => (
+                  <TableRow
                     key={instance.name}
-                    className={cn(
-                      "border-b last:border-b-0 cursor-pointer hover:bg-control-bg",
-                      i % 2 === 1 && "bg-control-bg/50"
-                    )}
+                    className="cursor-pointer"
                     onClick={(e) => handleRowClick(instance, e)}
                   >
                     {columns.map((col) => (
-                      <td
+                      <TableCell
                         key={col.key}
-                        className={cn(
-                          "px-4 py-2 align-middle overflow-hidden",
-                          col.cellClassName
-                        )}
+                        className={cn("overflow-hidden", col.cellClassName)}
                       >
                         {col.render(instance)}
-                      </td>
+                      </TableCell>
                     ))}
-                  </tr>
+                  </TableRow>
                 ))
               )}
-            </tbody>
-          </table>
+            </TableBody>
+          </Table>
         </div>
       </div>
 

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -1304,87 +1304,80 @@ export function InstancesPage() {
       )}
 
       {/* Table */}
-      <div className="border rounded-sm">
-        <div className="overflow-x-auto">
-          <Table
-            className="table-fixed"
-            style={{ minWidth: `${totalWidth}px` }}
-          >
-            <colgroup>
-              {widths.map((w, i) => (
-                <col key={columns[i].key} style={{ width: `${w}px` }} />
+      <div className="overflow-x-auto border-y border-block-border">
+        <Table className="table-fixed" style={{ minWidth: `${totalWidth}px` }}>
+          <colgroup>
+            {widths.map((w, i) => (
+              <col key={columns[i].key} style={{ width: `${w}px` }} />
+            ))}
+          </colgroup>
+          <TableHeader>
+            <TableRow>
+              {columns.map((col, colIdx) => (
+                <TableHead
+                  key={col.key}
+                  sortable={col.sortable}
+                  sortActive={
+                    col.sortable && sortKey === (col.sortKey ?? col.key)
+                  }
+                  sortDir={sortOrder}
+                  onSort={
+                    col.sortable
+                      ? () => toggleSort(col.sortKey ?? col.key)
+                      : undefined
+                  }
+                  resizable={col.resizable}
+                  onResizeStart={
+                    col.resizable ? (e) => onResizeStart(colIdx, e) : undefined
+                  }
+                >
+                  {col.title}
+                </TableHead>
               ))}
-            </colgroup>
-            <TableHeader>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {loading && instances.length === 0 ? (
               <TableRow>
-                {columns.map((col, colIdx) => (
-                  <TableHead
-                    key={col.key}
-                    sortable={col.sortable}
-                    sortActive={
-                      col.sortable && sortKey === (col.sortKey ?? col.key)
-                    }
-                    sortDir={sortOrder}
-                    onSort={
-                      col.sortable
-                        ? () => toggleSort(col.sortKey ?? col.key)
-                        : undefined
-                    }
-                    resizable={col.resizable}
-                    onResizeStart={
-                      col.resizable
-                        ? (e) => onResizeStart(colIdx, e)
-                        : undefined
-                    }
-                  >
-                    {col.title}
-                  </TableHead>
-                ))}
+                <TableCell
+                  colSpan={columns.length}
+                  className="px-4 py-8 text-center text-control-placeholder"
+                >
+                  <div className="flex items-center justify-center gap-x-2">
+                    <div className="animate-spin size-4 border-2 border-accent border-t-transparent rounded-full" />
+                    {t("common.loading")}
+                  </div>
+                </TableCell>
               </TableRow>
-            </TableHeader>
-            <TableBody>
-              {loading && instances.length === 0 ? (
-                <TableRow>
-                  <TableCell
-                    colSpan={columns.length}
-                    className="px-4 py-8 text-center text-control-placeholder"
-                  >
-                    <div className="flex items-center justify-center gap-x-2">
-                      <div className="animate-spin size-4 border-2 border-accent border-t-transparent rounded-full" />
-                      {t("common.loading")}
-                    </div>
-                  </TableCell>
+            ) : instances.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="px-4 py-8 text-center text-control-placeholder"
+                >
+                  {t("common.no-data")}
+                </TableCell>
+              </TableRow>
+            ) : (
+              instances.map((instance) => (
+                <TableRow
+                  key={instance.name}
+                  className="cursor-pointer"
+                  onClick={(e) => handleRowClick(instance, e)}
+                >
+                  {columns.map((col) => (
+                    <TableCell
+                      key={col.key}
+                      className={cn("overflow-hidden", col.cellClassName)}
+                    >
+                      {col.render(instance)}
+                    </TableCell>
+                  ))}
                 </TableRow>
-              ) : instances.length === 0 ? (
-                <TableRow>
-                  <TableCell
-                    colSpan={columns.length}
-                    className="px-4 py-8 text-center text-control-placeholder"
-                  >
-                    {t("common.no-data")}
-                  </TableCell>
-                </TableRow>
-              ) : (
-                instances.map((instance) => (
-                  <TableRow
-                    key={instance.name}
-                    className="cursor-pointer"
-                    onClick={(e) => handleRowClick(instance, e)}
-                  >
-                    {columns.map((col) => (
-                      <TableCell
-                        key={col.key}
-                        className={cn("overflow-hidden", col.cellClassName)}
-                      >
-                        {col.render(instance)}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </div>
+              ))
+            )}
+          </TableBody>
+        </Table>
       </div>
 
       {/* Pagination footer */}

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -53,6 +53,14 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
+import {
   Tabs,
   TabsList,
   TabsPanel,
@@ -224,46 +232,37 @@ function MemberTable({
 
   return (
     <div className="border rounded-sm overflow-hidden">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="bg-control-bg border-b">
+      <Table>
+        <TableHeader>
+          <TableRow>
             {allowEdit && (
-              <th className="w-10 px-3 py-2">
+              <TableHead className="w-10">
                 <input
                   type="checkbox"
                   checked={allSelected}
                   onChange={toggleAll}
                 />
-              </th>
+              </TableHead>
             )}
-            <th className="px-4 py-2 text-left font-medium text-control-light">
-              {t("settings.members.table.account")}
-            </th>
-            <th className="px-4 py-2 text-left font-medium text-control-light">
-              {t("settings.members.table.roles")}
-            </th>
-            <th className="w-24 px-4 py-2 text-left font-medium text-control-light">
-              {t("common.operations")}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
+            <TableHead>{t("settings.members.table.account")}</TableHead>
+            <TableHead>{t("settings.members.table.roles")}</TableHead>
+            <TableHead className="w-24">{t("common.operations")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {bindings.map((mb) => (
-            <tr
-              key={mb.binding}
-              className="border-b last:border-b-0 hover:bg-control-bg"
-            >
+            <TableRow key={mb.binding}>
               {allowEdit && (
-                <td className="px-3 py-2">
+                <TableCell>
                   <input
                     type="checkbox"
                     checked={selectedBindings.includes(mb.binding)}
                     disabled={isSelectDisabled(mb)}
                     onChange={() => toggleOne(mb.binding)}
                   />
-                </td>
+                </TableCell>
               )}
-              <td className="px-4 py-2">
+              <TableCell>
                 <div className="flex items-center gap-x-3">
                   {mb.type === "users" ? (
                     <UserAvatar title={mb.title || mb.user?.email || "?"} />
@@ -324,8 +323,8 @@ function MemberTable({
                     </span>
                   </div>
                 </div>
-              </td>
-              <td className="px-4 py-2">
+              </TableCell>
+              <TableCell>
                 <div className="flex flex-wrap gap-1">
                   {scope === "project"
                     ? renderProjectRoleSummary(mb.projectRoleBindings)
@@ -336,8 +335,8 @@ function MemberTable({
                         </Badge>
                       ))}
                 </div>
-              </td>
-              <td className="px-4 py-2">
+              </TableCell>
+              <TableCell>
                 <div className="flex items-center gap-x-1">
                   {allowEdit && canEdit(mb) && (
                     <Button
@@ -366,21 +365,21 @@ function MemberTable({
                     </Button>
                   )}
                 </div>
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           ))}
           {bindings.length === 0 && (
-            <tr>
-              <td
+            <TableRow>
+              <TableCell
                 colSpan={allowEdit ? 4 : 3}
                 className="px-4 py-8 text-center text-control-light"
               >
                 {t("common.no-data")}
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           )}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }
@@ -474,17 +473,17 @@ function MemberTableByRole({
 
   return (
     <div className="border rounded-sm overflow-hidden">
-      <table className="w-full text-sm">
-        <tbody>
+      <Table>
+        <TableBody striped={false}>
           {roleToBindings.map(({ role, members }) => {
             const expanded = expandedRoles.has(role);
             return (
               <React.Fragment key={role}>
-                <tr
-                  className="bg-control-bg border-b cursor-pointer hover:bg-control-bg"
+                <TableRow
+                  className="bg-control-bg cursor-pointer"
                   onClick={() => toggleRole(role)}
                 >
-                  <td colSpan={3} className="px-4 py-2">
+                  <TableCell colSpan={3}>
                     <div className="flex items-center gap-x-2">
                       {expanded ? (
                         <ChevronDown className="h-4 w-4" />
@@ -501,18 +500,15 @@ function MemberTableByRole({
                         ({members.length})
                       </span>
                     </div>
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
                 {expanded &&
                   members.map(({ member: mb, allExpired }) => (
-                    <tr
+                    <TableRow
                       key={`${role}-${mb.binding}`}
-                      className={cn(
-                        "border-b last:border-b-0 hover:bg-control-bg",
-                        allExpired && "opacity-60"
-                      )}
+                      className={cn(allExpired && "opacity-60")}
                     >
-                      <td className="px-4 py-2 pl-10">
+                      <TableCell className="pl-10">
                         <div className="flex items-center gap-x-3">
                           {mb.type === "users" ? (
                             <UserAvatar
@@ -593,9 +589,9 @@ function MemberTableByRole({
                             </span>
                           </div>
                         </div>
-                      </td>
-                      <td className="px-4 py-2" />
-                      <td className="w-24 px-4 py-2">
+                      </TableCell>
+                      <TableCell />
+                      <TableCell className="w-24">
                         <div className="flex items-center gap-x-1">
                           {allowEdit && canEdit(mb) && (
                             <Button
@@ -624,24 +620,24 @@ function MemberTableByRole({
                             </Button>
                           )}
                         </div>
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   ))}
               </React.Fragment>
             );
           })}
           {roleToBindings.length === 0 && (
-            <tr>
-              <td
+            <TableRow>
+              <TableCell
                 colSpan={3}
                 className="px-4 py-8 text-center text-control-light"
               >
                 {t("common.no-data")}
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           )}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }
@@ -1460,50 +1456,39 @@ function EditMemberRoleDrawer({
 
                       {/* Database resources table */}
                       <div className="p-4">
-                        <table className="w-full text-sm">
-                          <thead>
-                            <tr className="border-b">
-                              <th className="px-2 py-1.5 text-left font-medium text-control-light">
-                                {t("common.database")}
-                              </th>
-                              <th className="px-2 py-1.5 text-left font-medium text-control-light">
-                                {t("common.schema")}
-                              </th>
-                              <th className="px-2 py-1.5 text-left font-medium text-control-light">
-                                {t("common.table")}
-                              </th>
-                              <th className="px-2 py-1.5 text-left font-medium text-control-light">
-                                {t("common.expiration")}
-                              </th>
-                            </tr>
-                          </thead>
-                          <tbody>
+                        <Table>
+                          <TableHeader>
+                            <TableRow>
+                              <TableHead>{t("common.database")}</TableHead>
+                              <TableHead>{t("common.schema")}</TableHead>
+                              <TableHead>{t("common.table")}</TableHead>
+                              <TableHead>{t("common.expiration")}</TableHead>
+                            </TableRow>
+                          </TableHeader>
+                          <TableBody>
                             {rows.map((row, rowIdx) => (
-                              <tr
-                                key={rowIdx}
-                                className="border-b last:border-b-0"
-                              >
-                                <td className="px-2 py-1.5 text-sm">
+                              <TableRow key={rowIdx}>
+                                <TableCell>
                                   {row.databaseResource?.databaseFullName ??
                                     "*"}
-                                </td>
-                                <td className="px-2 py-1.5 text-sm">
+                                </TableCell>
+                                <TableCell>
                                   {row.databaseResource?.schema ?? "*"}
-                                </td>
-                                <td className="px-2 py-1.5 text-sm">
+                                </TableCell>
+                                <TableCell>
                                   {row.databaseResource?.table ?? "*"}
-                                </td>
-                                <td className="px-2 py-1.5 text-sm">
+                                </TableCell>
+                                <TableCell>
                                   {row.expiration
                                     ? formatAbsoluteDateTime(
                                         row.expiration.getTime()
                                       )
                                     : t("project.members.never-expires")}
-                                </td>
-                              </tr>
+                                </TableCell>
+                              </TableRow>
                             ))}
-                          </tbody>
-                        </table>
+                          </TableBody>
+                        </Table>
                       </div>
                     </div>
                   );

--- a/frontend/src/react/pages/settings/ProjectsPage.tsx
+++ b/frontend/src/react/pages/settings/ProjectsPage.tsx
@@ -733,7 +733,7 @@ export function ProjectsPage() {
       )}
 
       {/* Table */}
-      <div className="border rounded-sm overflow-x-auto">
+      <div className="overflow-x-auto border-y border-block-border">
         <ProjectTable
           className="min-w-[700px]"
           projectList={projects}

--- a/frontend/src/react/pages/settings/SemanticTypesPage.tsx
+++ b/frontend/src/react/pages/settings/SemanticTypesPage.tsx
@@ -15,6 +15,14 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
@@ -374,34 +382,34 @@ export function SemanticTypesPage() {
       </p>
 
       <div className="border border-control-border rounded-sm">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="bg-control-bg border-b border-control-border">
-              <th className="px-3 py-2 font-medium w-20 text-center">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-20 text-center">
                 {t("settings.sensitive-data.semantic-types.table.icon")}
-              </th>
-              <th className="px-3 py-2 text-left font-medium w-36">ID</th>
-              <th className="px-3 py-2 text-left font-medium">
+              </TableHead>
+              <TableHead className="w-36">ID</TableHead>
+              <TableHead>
                 {t(
                   "settings.sensitive-data.semantic-types.table.semantic-type"
                 )}
-              </th>
-              <th className="px-3 py-2 text-left font-medium w-48">
+              </TableHead>
+              <TableHead className="w-48">
                 {t("settings.sensitive-data.semantic-types.table.description")}
-              </th>
-              <th className="px-3 py-2 text-left font-medium">
+              </TableHead>
+              <TableHead>
                 {t(
                   "settings.sensitive-data.semantic-types.table.masking-algorithm"
                 )}
-              </th>
+              </TableHead>
               {!isReadonly && (
-                <th className="px-3 py-2 text-right font-medium w-28">
+                <TableHead className="w-28 text-right">
                   {t("common.edit")}
-                </th>
+                </TableHead>
               )}
-            </tr>
-          </thead>
-          <tbody>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {items.map((row, index) => (
               <SemanticTypeRow
                 key={row.item.id}
@@ -418,17 +426,17 @@ export function SemanticTypesPage() {
               />
             ))}
             {items.length === 0 && (
-              <tr>
-                <td
+              <TableRow>
+                <TableCell
                   colSpan={isReadonly ? 5 : 6}
                   className="px-3 py-8 text-center text-control-placeholder"
                 >
                   {t("common.no-data")}
-                </td>
-              </tr>
+                </TableCell>
+              </TableRow>
             )}
-          </tbody>
-        </table>
+          </TableBody>
+        </Table>
       </div>
 
       {showTemplateDrawer && (
@@ -998,40 +1006,40 @@ function SemanticTemplateDrawer({
             {t("settings.sensitive-data.semantic-types.template.description")}
           </p>
           <div className="border border-control-border rounded-sm overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="bg-control-bg border-b border-control-border">
-                  <th className="px-3 py-2 text-left font-medium">ID</th>
-                  <th className="px-3 py-2 text-left font-medium">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>ID</TableHead>
+                  <TableHead>
                     {t(
                       "settings.sensitive-data.semantic-types.table.semantic-type"
                     )}
-                  </th>
-                  <th className="px-3 py-2 text-left font-medium">
+                  </TableHead>
+                  <TableHead>
                     {t(
                       "settings.sensitive-data.semantic-types.table.description"
                     )}
-                  </th>
-                  <th className="px-3 py-2 text-left font-medium">
+                  </TableHead>
+                  <TableHead>
                     {t(
                       "settings.sensitive-data.semantic-types.table.masking-algorithm"
                     )}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
                 {templates.map((template) => {
                   const key = template.id.split(".").join("-");
                   return (
-                    <tr
+                    <TableRow
                       key={template.id}
-                      className="border-b border-control-border last:border-b-0 hover:bg-control-bg cursor-pointer"
+                      className="cursor-pointer"
                       onClick={() => onApply(template)}
                     >
-                      <td className="px-3 py-2">{template.id}</td>
-                      <td className="px-3 py-2">{template.title}</td>
-                      <td className="px-3 py-2">{template.description}</td>
-                      <td className="px-3 py-2">
+                      <TableCell>{template.id}</TableCell>
+                      <TableCell>{template.title}</TableCell>
+                      <TableCell>{template.description}</TableCell>
+                      <TableCell>
                         <div className="flex items-center gap-x-1">
                           <span>
                             {t(
@@ -1047,12 +1055,12 @@ function SemanticTemplateDrawer({
                             <Info className="w-4 h-4" />
                           </span>
                         </div>
-                      </td>
-                    </tr>
+                      </TableCell>
+                    </TableRow>
                   );
                 })}
-              </tbody>
-            </table>
+              </TableBody>
+            </Table>
           </div>
         </SheetBody>
         <SheetFooter>
@@ -1104,8 +1112,8 @@ function SemanticTypeRow({
   const isEditing = row.mode !== "NORMAL";
 
   return (
-    <tr className="border-b border-control-border last:border-b-0 even:bg-control-bg/50">
-      <td className="px-3 py-2 text-center">
+    <TableRow>
+      <TableCell className="text-center">
         {isEditing && !isItemReadonly ? (
           <IconPicker
             value={row.item.icon ?? ""}
@@ -1122,11 +1130,11 @@ function SemanticTypeRow({
         ) : (
           <span className="text-control-placeholder">-</span>
         )}
-      </td>
-      <td className="px-3 py-2 truncate max-w-36" title={row.item.id}>
+      </TableCell>
+      <TableCell className="truncate max-w-36" title={row.item.id}>
         {row.item.id}
-      </td>
-      <td className="px-3 py-2">
+      </TableCell>
+      <TableCell>
         {isEditing ? (
           <Input
             value={row.item.title}
@@ -1141,8 +1149,8 @@ function SemanticTypeRow({
         ) : (
           <span className="truncate">{row.item.title}</span>
         )}
-      </td>
-      <td className="px-3 py-2">
+      </TableCell>
+      <TableCell>
         {isEditing ? (
           <Input
             value={row.item.description}
@@ -1160,8 +1168,8 @@ function SemanticTypeRow({
         ) : (
           <span className="truncate">{row.item.description}</span>
         )}
-      </td>
-      <td className="px-3 py-2">
+      </TableCell>
+      <TableCell>
         <div className="flex items-center gap-x-1">
           {isBuiltin ? (
             <>
@@ -1207,9 +1215,9 @@ function SemanticTypeRow({
             </button>
           )}
         </div>
-      </td>
+      </TableCell>
       {!readonly && (
-        <td className="px-3 py-2">
+        <TableCell>
           <div className="flex items-center justify-end gap-x-1">
             {isBuiltin ? (
               <DeleteConfirmButton
@@ -1260,9 +1268,9 @@ function SemanticTypeRow({
               </>
             )}
           </div>
-        </td>
+        </TableCell>
       )}
-    </tr>
+    </TableRow>
   );
 }
 

--- a/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
+++ b/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
@@ -17,6 +17,14 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/react/components/ui/table";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -173,29 +181,29 @@ function ServiceAccountTable({
 
   return (
     <div className="border rounded-sm overflow-hidden">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b bg-control-bg">
-            <th className="px-4 py-2 text-left font-medium whitespace-nowrap">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="whitespace-nowrap">
               {t("settings.members.table.account")}
-            </th>
-            <th className="px-4 py-2 text-right font-medium whitespace-nowrap">
+            </TableHead>
+            <TableHead className="text-right whitespace-nowrap">
               {t("common.operations")}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
           {users.length === 0 ? (
-            <tr>
-              <td
+            <TableRow>
+              <TableCell
                 colSpan={2}
                 className="py-8 text-center text-control-light text-sm"
               >
                 {t("common.no-data")}
-              </td>
-            </tr>
+              </TableCell>
+            </TableRow>
           ) : (
-            users.map((user, i) => {
+            users.map((user) => {
               const isDeleted = user.state === State.DELETED;
               const canOpenDetail =
                 !!onUserSelected &&
@@ -204,13 +212,11 @@ function ServiceAccountTable({
                   : hasWorkspacePermissionV2("bb.serviceAccounts.get"));
 
               return (
-                <tr
+                <TableRow
                   key={user.name}
                   className={cn(
-                    "border-b last:border-b-0",
-                    i % 2 === 1 && "bg-control-bg/50",
                     canOpenDetail &&
-                      "cursor-pointer hover:bg-control-bg focus-visible:outline-none focus-visible:bg-control-bg"
+                      "cursor-pointer focus-visible:outline-none focus-visible:bg-control-bg"
                   )}
                   tabIndex={canOpenDetail ? 0 : undefined}
                   role={canOpenDetail ? "button" : undefined}
@@ -232,7 +238,7 @@ function ServiceAccountTable({
                   }
                 >
                   {/* Account column */}
-                  <td className="px-4 py-2">
+                  <TableCell>
                     <div className="flex items-center gap-x-3">
                       <UserAvatar title={user.title || user.email} />
                       <div className="flex flex-col min-w-0">
@@ -314,11 +320,11 @@ function ServiceAccountTable({
                         </div>
                       )}
                     </div>
-                  </td>
+                  </TableCell>
 
                   {/* Operations column — destructive/secondary actions only.
                       The row itself is clickable to open the detail sheet. */}
-                  <td className="px-4 py-2">
+                  <TableCell>
                     <div className="flex justify-end gap-x-1">
                       {!isDeleted &&
                         (project
@@ -375,13 +381,13 @@ function ServiceAccountTable({
                           </Tooltip>
                         )}
                     </div>
-                  </td>
-                </tr>
+                  </TableCell>
+                </TableRow>
               );
             })
           )}
-        </tbody>
-      </table>
+        </TableBody>
+      </Table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Migrates 9 list tables (Release, Project, AuditLog, Instances, ServiceAccount, SemanticTypes, Members, Webhook, ExemptionResource) onto the unified Table component.
- Makes resizable list tables fill viewport width.
- Replaces rounded boxes with top/bottom borders on full-width list tables.

## Test plan
- [ ] Visit each migrated page and verify the table renders, sorts, paginates, and resizes correctly: Releases, Projects, Audit Log, Instances, Service Accounts, Semantic Types, Members, Webhooks, Masking Exemptions.
- [ ] Confirm full-width tables show top/bottom borders (no rounded box) and fill viewport width when resizable.
- [ ] Row actions, selection, and empty states still work on each migrated table.
- [ ] `pnpm --dir frontend check` and `pnpm --dir frontend type-check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)