### PR TITLE
fix(test): satisfy staticcheck nil guards

### DIFF
--- a/backend/plugin/parser/tsql/query_span_parser_invariant_test.go
+++ b/backend/plugin/parser/tsql/query_span_parser_invariant_test.go
@@ -188,6 +188,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				star := findFirst[*ast.StarExpr](sel)
 				if star == nil {
 					t.Fatal("no StarExpr")
+					return
 				}
 				if star.Qualifier != "" {
 					t.Errorf("want Qualifier empty, got %q", star.Qualifier)
@@ -202,6 +203,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				star := findFirst[*ast.StarExpr](sel)
 				if star == nil {
 					t.Fatal("no StarExpr")
+					return
 				}
 				if star.Qualifier != "t1" {
 					t.Errorf("want Qualifier=t1, got %q", star.Qualifier)
@@ -216,6 +218,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				at := findFirst[*ast.AliasedTableRef](sel.FromClause)
 				if at == nil {
 					t.Fatal("no AliasedTableRef")
+					return
 				}
 				if at.Alias != "x" {
 					t.Errorf("Alias: want x, got %q", at.Alias)
@@ -230,6 +233,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				at := findFirst[*ast.AliasedTableRef](sel.FromClause)
 				if at == nil {
 					t.Fatal("no AliasedTableRef in FROM")
+					return
 				}
 				if at.Alias != "x" {
 					t.Errorf("Alias: want x, got %q", at.Alias)
@@ -379,6 +383,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				j := findFirst[*ast.JoinClause](sel.FromClause)
 				if j == nil {
 					t.Fatal("no JoinClause")
+					return
 				}
 				if j.Type != ast.JoinCrossApply {
 					t.Errorf("JoinType: want CrossApply, got %v", j.Type)
@@ -393,6 +398,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				j := findFirst[*ast.JoinClause](sel.FromClause)
 				if j == nil {
 					t.Fatal("no JoinClause in FROM")
+					return
 				}
 				if j.Type != ast.JoinCrossApply {
 					t.Errorf("JoinType: want CrossApply, got %v", j.Type)
@@ -478,6 +484,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				col := findFirst[*ast.ColumnRef](sel)
 				if col == nil {
 					t.Fatal("no ColumnRef")
+					return
 				}
 				if col.Column != "col name" {
 					t.Errorf("Column: want \"col name\" (unquoted), got %q", col.Column)
@@ -485,6 +492,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				tr := findFirst[*ast.TableRef](sel)
 				if tr == nil {
 					t.Fatal("no TableRef")
+					return
 				}
 				if tr.Object != "my table" {
 					t.Errorf("TableRef.Object: want \"my table\", got %q", tr.Object)
@@ -499,6 +507,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				col := findFirst[*ast.ColumnRef](sel)
 				if col == nil {
 					t.Fatal("no ColumnRef")
+					return
 				}
 				if col.Column != "col name" {
 					t.Errorf("Column: want \"col name\" (unquoted), got %q", col.Column)
@@ -513,6 +522,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				tr := findFirst[*ast.TableRef](sel.FromClause)
 				if tr == nil {
 					t.Fatal("no TableRef in FROM")
+					return
 				}
 				if tr.Database != "db1" || tr.Schema != "dbo" || tr.Object != "t" {
 					t.Errorf("TableRef: got db=%q schema=%q obj=%q", tr.Database, tr.Schema, tr.Object)
@@ -527,6 +537,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				tr := findFirst[*ast.TableRef](sel.FromClause)
 				if tr == nil {
 					t.Fatal("no TableRef in FROM")
+					return
 				}
 				if tr.Server != "srv1" || tr.Database != "db1" || tr.Schema != "dbo" || tr.Object != "t" {
 					t.Errorf("TableRef: got srv=%q db=%q schema=%q obj=%q", tr.Server, tr.Database, tr.Schema, tr.Object)
@@ -566,6 +577,7 @@ func querySpanStructuralInvariants(t *testing.T) {
 				tr := findFirst[*ast.TableRef](sel.FromClause)
 				if tr == nil {
 					t.Fatal("no TableRef in FROM")
+					return
 				}
 				if tr.Object != "#t" {
 					t.Errorf("TableRef.Object for temp table: got %q — extractor must recognize '#' prefix as local temp", tr.Object)

--- a/backend/plugin/schema/mysql/walk_through_loader_test.go
+++ b/backend/plugin/schema/mysql/walk_through_loader_test.go
@@ -42,6 +42,7 @@ func mustGetTable(t *testing.T, c *catalog.Catalog, name string) *catalog.Table 
 	db := c.GetDatabase(testDBName)
 	if db == nil {
 		t.Fatalf("database %q not in catalog", testDBName)
+		return nil
 	}
 	tbl := db.Tables[strings.ToLower(name)]
 	if tbl == nil {
@@ -55,6 +56,7 @@ func mustGetView(t *testing.T, c *catalog.Catalog, name string) *catalog.View {
 	db := c.GetDatabase(testDBName)
 	if db == nil {
 		t.Fatalf("database %q not in catalog", testDBName)
+		return nil
 	}
 	v := db.Views[strings.ToLower(name)]
 	if v == nil {
@@ -68,6 +70,7 @@ func mustGetTrigger(t *testing.T, c *catalog.Catalog, name string) *catalog.Trig
 	db := c.GetDatabase(testDBName)
 	if db == nil {
 		t.Fatalf("database %q not in catalog", testDBName)
+		return nil
 	}
 	trg := db.Triggers[strings.ToLower(name)]
 	if trg == nil {
@@ -81,6 +84,7 @@ func mustGetEvent(t *testing.T, c *catalog.Catalog, name string) *catalog.Event 
 	db := c.GetDatabase(testDBName)
 	if db == nil {
 		t.Fatalf("database %q not in catalog", testDBName)
+		return nil
 	}
 	ev := db.Events[strings.ToLower(name)]
 	if ev == nil {
@@ -232,6 +236,7 @@ func TestLoader_TableBasic(t *testing.T) {
 	idCol := tbl.GetColumn("id")
 	if idCol == nil {
 		t.Fatal("id column missing")
+		return
 	}
 	if !idCol.AutoIncrement {
 		t.Error("id should be AUTO_INCREMENT (sentinel detection)")
@@ -384,6 +389,7 @@ func TestLoader_ForeignKeyAcrossTables(t *testing.T) {
 	}
 	if fk == nil {
 		t.Fatal("fk_child_parent constraint missing")
+		return
 	}
 	if strings.ToUpper(fk.OnDelete) != "CASCADE" {
 		t.Errorf("OnDelete = %q, want CASCADE", fk.OnDelete)

--- a/backend/tests/sql_export_data_source_test.go
+++ b/backend/tests/sql_export_data_source_test.go
@@ -119,6 +119,7 @@ func TestSQLExportDataSourceResolution(t *testing.T) {
 	}
 	if readOnly == nil {
 		t.Fatal("expected read-only data source")
+		return
 	}
 	readOnly.Id = "readonly-legacy"
 	metadata.DataSources = append(metadata.DataSources, readOnly)

--- a/backend/tests/sql_query_data_source_test.go
+++ b/backend/tests/sql_query_data_source_test.go
@@ -119,6 +119,7 @@ func TestSQLQueryDataSourceResolution(t *testing.T) {
 	}
 	if readOnly == nil {
 		t.Fatal("expected read-only data source")
+		return
 	}
 	readOnly.Id = "readonly-legacy"
 	metadata.DataSources = append(metadata.DataSources, readOnly)


### PR DESCRIPTION
## Summary
- Add explicit returns after fatal test guards so staticcheck can prove nil values are not dereferenced.
- Keep this separate from the metadata DB auth refactor because these are unrelated existing lint issues.

## Testing
- golangci-lint run --allow-parallel-runners
- go test -v -count=1 ./backend/plugin/parser/tsql -run ^TestOmniQuerySpanParserInvariants$
- go test -v -count=1 ./backend/plugin/schema/mysql -run ^(TestLoader_TableBasic|TestLoader_ForeignKeyAcrossTables)$
- go test -v -count=1 ./backend/tests -run ^(TestSQLExportDataSourceResolution|TestSQLQueryDataSourceResolution)$ -timeout 5m