### PR TITLE
fix(react): hide version info in cloud/SaaS mode

### DIFF
--- a/frontend/src/react/components/header/VersionMenuItem.test.tsx
+++ b/frontend/src/react/components/header/VersionMenuItem.test.tsx
@@ -192,4 +192,24 @@ describe("VersionMenuItem", () => {
     );
     unmount();
   });
+
+  test("hides version info in SaaS/cloud mode", () => {
+    mocks.serverInfo = {
+      version: "1.0.0",
+      gitCommit: "backend123",
+      saas: true,
+      demo: false,
+    };
+    const { container, render, unmount } = renderIntoContainer(
+      <VersionMenuItem onCloseMenu={mocks.closeMenu} />
+    );
+    render();
+
+    expect(container.textContent).not.toContain("v1.0.0");
+    expect(container.textContent).not.toContain("BE Git hash");
+    expect(container.textContent).not.toContain("FE Git hash");
+    // The plan label should still be visible.
+    expect(container.textContent).toContain("Team");
+    unmount();
+  });
 });

--- a/frontend/src/react/components/header/VersionMenuItem.tsx
+++ b/frontend/src/react/components/header/VersionMenuItem.tsx
@@ -113,29 +113,31 @@ export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
           )}
         </div>
 
-        <button
-          type="button"
-          className="flex w-full items-center justify-between gap-x-2 rounded-sm px-0 py-1 text-left text-sm text-control hover:text-accent"
-          onClick={() => {
-            if (hasNewRelease) {
-              onCloseMenu();
-              setDialogOpen(true);
-            }
-          }}
-        >
-          <span className="flex items-center gap-x-2">
-            {hasNewRelease ? (
-              <Volume2 className="h-4 w-4 text-success" />
-            ) : null}
-            {formattedVersion}
-          </span>
-        </button>
-
         {!serverInfo?.saas ? (
-          <div className="mt-1 text-xs text-control-light">
-            <div>BE Git hash: {gitCommitBE.slice(0, 7)}</div>
-            <div>FE Git hash: {gitCommitFE.slice(0, 7)}</div>
-          </div>
+          <>
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-x-2 rounded-sm px-0 py-1 text-left text-sm text-control hover:text-accent"
+              onClick={() => {
+                if (hasNewRelease) {
+                  onCloseMenu();
+                  setDialogOpen(true);
+                }
+              }}
+            >
+              <span className="flex items-center gap-x-2">
+                {hasNewRelease ? (
+                  <Volume2 className="h-4 w-4 text-success" />
+                ) : null}
+                {formattedVersion}
+              </span>
+            </button>
+
+            <div className="mt-1 text-xs text-control-light">
+              <div>BE Git hash: {gitCommitBE.slice(0, 7)}</div>
+              <div>FE Git hash: {gitCommitFE.slice(0, 7)}</div>
+            </div>
+          </>
         ) : null}
       </div>
 


### PR DESCRIPTION
## Summary
- In SaaS/cloud mode, the profile menu's version section is no longer relevant — the cloud is managed centrally and users can't act on a "new version available" prompt
- Wrap the version button + BE/FE git hashes in the existing `!serverInfo?.saas` gate so only the plan label remains visible in cloud
- Self-host behavior is unchanged

Linear: [BYT-9404](https://linear.app/bytebase/issue/BYT-9404/remove-version-info-on-cloud-ui)

## Test plan
- [x] \`pnpm --dir frontend type-check\` passes
- [x] \`pnpm --dir frontend fix\` clean
- [x] Added unit test \`hides version info in SaaS/cloud mode\` in \`VersionMenuItem.test.tsx\`
- [ ] Manual: open profile menu in self-host — version, BE/FE git hash still visible
- [ ] Manual: open profile menu in cloud — only plan label visible, no version, no git hashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)