### PR TITLE
fix: bump omni for BYT-9403 record-returning function views

### DIFF
--- a/backend/plugin/schema/pg/sdl_migration_omni_test.go
+++ b/backend/plugin/schema/pg/sdl_migration_omni_test.go
@@ -122,6 +122,23 @@ func TestOmniSDLMigration_DropView(t *testing.T) {
 	require.Contains(t, sql, "active_users")
 }
 
+func TestOmniSDLMigration_RecordReturningFunctionView(t *testing.T) {
+	sdl := `
+CREATE FUNCTION public.record_pair(OUT id integer, OUT name text)
+RETURNS record
+LANGUAGE sql
+AS $$
+	SELECT 1::integer, 'alice'::text;
+$$;
+
+CREATE VIEW public.record_pair_view AS
+SELECT *
+FROM public.record_pair();
+`
+	sql := omniSDLMigration(t, sdl, sdl)
+	require.Empty(t, sql)
+}
+
 func TestOmniSDLMigration_CreateFunction(t *testing.T) {
 	sql := omniSDLMigration(t, "", `
 		CREATE FUNCTION add_numbers(a INTEGER, b INTEGER) RETURNS INTEGER

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260430035605-5f442197a248
+	github.com/bytebase/omni v0.0.0-20260507034522-964293f6eb9c
 	github.com/caarlos0/env/v11 v11.4.0
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888 h1:E8tz8maxpih/vt
 github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888/go.mod h1:IgLUOjyiHehdE0G3C92IjGYu9lJQgkPwf2mdNSvPWq8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260430035605-5f442197a248 h1:qrCbq05Wcm2qcKa+f+8MEyXeCRo33HVEVZn8DtH2rmU=
-github.com/bytebase/omni v0.0.0-20260430035605-5f442197a248/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260507034522-964293f6eb9c h1:UOKS5HxqTgiIkJHQO8+sp6zGpAoUCSyVtO4o7IgarBw=
+github.com/bytebase/omni v0.0.0-20260507034522-964293f6eb9c/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Bump `github.com/bytebase/omni` to `v0.0.0-20260507034522-964293f6eb9c`.
- Add a PG SDL migration regression test for a view selecting from an OUT-parameter function declared as `RETURNS record`.
- Covers BYT-9403 where the LoadSQL/SDL path failed with `function returning record requires column definition list`.

## Test Plan
- `go test -v -count=1 ./backend/plugin/schema/pg -run TestOmniSDLMigration_RecordReturningFunctionView` (failed before the bump, passes after)
- `go test -count=1 ./backend/plugin/schema/pg`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
