### PR TITLE
refactor(advisor/tidb): migrate WHERE-required pair + leading-wildcard LIKE to omni AST (Phase 1.5 §1.5.3 batch 5)

### DIFF
--- a/backend/plugin/advisor/tidb/advisor_stmt_no_leading_wildcard_like.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_no_leading_wildcard_like.go
@@ -91,7 +91,24 @@ func (v *noLeadingWildcardLikeVisitor) Visit(node ast.Node) ast.Visitor {
 	}
 	// Pingcap doesn't gate on like.Not — NOT LIKE with leading wildcard
 	// triggers the same as LIKE. Mirror that behavior.
-	lit, ok := like.Pattern.(*ast.StringLit)
+	//
+	// Cumulative shape divergence #11: omni wraps `'%abc' COLLATE
+	// utf8mb4_bin` as *CollateExpr{Expr: *StringLit, Collation: "..."}.
+	// Pingcap's *SetCollationExpr restored to text as
+	// "%abc COLLATE utf8mb4_bin" (value first, COLLATE clause after), so
+	// pingcap's leading-`%` check accidentally fired on the rendered text.
+	// Without the unwrap, omni would silently skip and regress vs. pingcap.
+	// The loop handles nested COLLATE defensively (not produced by current
+	// TiDB grammar but cheap insurance).
+	pattern := like.Pattern
+	for {
+		c, ok := pattern.(*ast.CollateExpr)
+		if !ok {
+			break
+		}
+		pattern = c.Expr
+	}
+	lit, ok := pattern.(*ast.StringLit)
 	if !ok {
 		// Non-literal patterns (parameter, column ref, expression) — skip.
 		// Per pingcap parity (see Check() docstring).

--- a/backend/plugin/advisor/tidb/advisor_stmt_no_leading_wildcard_like.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_no_leading_wildcard_like.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pingcap/tidb/pkg/parser/ast"
-	"github.com/pingcap/tidb/pkg/parser/format"
+	"github.com/bytebase/omni/tidb/ast"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -14,26 +13,39 @@ import (
 )
 
 const (
-	wildcard string = "%"
+	wildcard byte = '%'
 )
 
 var (
 	_ advisor.Advisor = (*NoLeadingWildcardLikeAdvisor)(nil)
-	_ ast.Visitor     = (*noLeadingWildcardLikeChecker)(nil)
+	_ ast.Visitor     = (*noLeadingWildcardLikeVisitor)(nil)
 )
 
 func init() {
 	advisor.Register(storepb.Engine_TIDB, storepb.SQLReviewRule_STATEMENT_WHERE_NO_LEADING_WILDCARD_LIKE, &NoLeadingWildcardLikeAdvisor{})
 }
 
-// NoLeadingWildcardLikeAdvisor is the advisor checking for no leading wildcard LIKE.
+// NoLeadingWildcardLikeAdvisor checks for LIKE patterns that begin with
+// `%`, e.g. `WHERE x LIKE '%foo'`. Such patterns force a full table scan;
+// the rule warns even on NOT LIKE because the same scan cost applies.
 type NoLeadingWildcardLikeAdvisor struct {
 }
 
-// Check checks for no leading wildcard LIKE.
+// Check is Recipe B (sub-walk via omni Visitor) — LIKE expressions can
+// appear in any WHERE clause depth, including UNION arms, subqueries, and
+// CTEs.
+//
+// Per pingcap-typed advisor's behavior (preserved here):
+//   - Fires once per top-level statement, regardless of how many leading-`%`
+//     LIKE expressions it contains.
+//   - Doesn't distinguish LIKE from NOT LIKE — both trigger.
+//   - Only `%` triggers; `_` (single-character wildcard) doesn't.
+//   - ESCAPE clause doesn't affect the pattern check.
+//   - Non-string-literal patterns (parameter `?`, column refs, function
+//     calls) silently skip — pingcap's restoreNode produced text starting
+//     with `?` / column-name / function-name, none of which start with `%`.
 func (*NoLeadingWildcardLikeAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	root, err := getTiDBNodes(checkCtx)
-
+	stmts, err := getTiDBOmniNodes(checkCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -43,53 +55,51 @@ func (*NoLeadingWildcardLikeAdvisor) Check(_ context.Context, checkCtx advisor.C
 		return nil, err
 	}
 
-	checker := &noLeadingWildcardLikeChecker{level: level}
-	for _, stmtNode := range root {
-		checker.text = stmtNode.Text()
-		checker.leadingWildcardLike = false
-		(stmtNode).Accept(checker)
-
-		if checker.leadingWildcardLike {
-			checker.adviceList = append(checker.adviceList, &storepb.Advice{
-				Status:        checker.level,
-				Code:          code.StatementLeadingWildcardLike.Int32(),
-				Title:         checkCtx.Rule.Type.String(),
-				Content:       fmt.Sprintf("\"%s\" uses leading wildcard LIKE", checker.text),
-				StartPosition: common.ConvertANTLRLineToPosition(stmtNode.OriginTextPosition()),
-			})
+	title := checkCtx.Rule.Type.String()
+	var adviceList []*storepb.Advice
+	for _, ostmt := range stmts {
+		v := &noLeadingWildcardLikeVisitor{}
+		ast.Walk(v, ostmt.Node)
+		if !v.found {
+			continue
 		}
+		adviceList = append(adviceList, &storepb.Advice{
+			Status:        level,
+			Code:          code.StatementLeadingWildcardLike.Int32(),
+			Title:         title,
+			Content:       fmt.Sprintf("\"%s\" uses leading wildcard LIKE", ostmt.TrimmedText()),
+			StartPosition: common.ConvertANTLRLineToPosition(ostmt.FirstTokenLine()),
+		})
 	}
-
-	return checker.adviceList, nil
+	return adviceList, nil
 }
 
-type noLeadingWildcardLikeChecker struct {
-	adviceList          []*storepb.Advice
-	level               storepb.Advice_Status
-	text                string
-	leadingWildcardLike bool
+type noLeadingWildcardLikeVisitor struct {
+	found bool
 }
 
-// Enter implements the ast.Visitor interface.
-func (v *noLeadingWildcardLikeChecker) Enter(in ast.Node) (ast.Node, bool) {
-	if node, ok := in.(*ast.PatternLikeOrIlikeExpr); !v.leadingWildcardLike && ok {
-		pattern, err := restoreNode(node.Pattern, format.RestoreStringWithoutCharset)
-		if err != nil {
-			v.adviceList = append(v.adviceList, &storepb.Advice{
-				Status:  v.level,
-				Code:    code.Internal.Int32(),
-				Title:   "Internal error for no leading wildcard LIKE rule",
-				Content: fmt.Sprintf("\"%s\" meet internal error %q", v.text, err.Error()),
-			})
-		}
-		if len(pattern) > 0 && pattern[:1] == wildcard {
-			v.leadingWildcardLike = true
-		}
+// Visit returns v to recurse into children. Once a leading-`%` is found,
+// returns nil to skip the remaining subtree — the check is per-statement
+// boolean, no benefit to continuing.
+func (v *noLeadingWildcardLikeVisitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil || v.found {
+		return nil
 	}
-	return in, false
-}
-
-// Leave implements the ast.Visitor interface.
-func (*noLeadingWildcardLikeChecker) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+	like, ok := node.(*ast.LikeExpr)
+	if !ok {
+		return v
+	}
+	// Pingcap doesn't gate on like.Not — NOT LIKE with leading wildcard
+	// triggers the same as LIKE. Mirror that behavior.
+	lit, ok := like.Pattern.(*ast.StringLit)
+	if !ok {
+		// Non-literal patterns (parameter, column ref, expression) — skip.
+		// Per pingcap parity (see Check() docstring).
+		return v
+	}
+	if len(lit.Value) > 0 && lit.Value[0] == wildcard {
+		v.found = true
+		return nil
+	}
+	return v
 }

--- a/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_select.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_select.go
@@ -4,31 +4,40 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/omni/tidb/ast"
+
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
-
-	"github.com/pingcap/tidb/pkg/parser/ast"
 )
 
 var (
 	_ advisor.Advisor = (*WhereRequirementForSelectAdvisor)(nil)
-	_ ast.Visitor     = (*whereRequirementForSelectChecker)(nil)
+	_ ast.Visitor     = (*whereRequireSelectVisitor)(nil)
 )
 
 func init() {
 	advisor.Register(storepb.Engine_TIDB, storepb.SQLReviewRule_STATEMENT_WHERE_REQUIRE_SELECT, &WhereRequirementForSelectAdvisor{})
 }
 
-// WhereRequirementForSelectAdvisor is the advisor checking for the WHERE clause requirement for SELECT statements.
+// WhereRequirementForSelectAdvisor checks the WHERE clause requirement for
+// SELECT statements.
 type WhereRequirementForSelectAdvisor struct {
 }
 
-// Check checks for the WHERE clause requirement.
+// Check is Recipe B (sub-walk via omni Visitor) — the pingcap-typed
+// version's Visitor returns (in, false) and so recurses into sub-selects;
+// the existing fixture
+//
+//	SELECT id FROM tech_book WHERE id > (SELECT max(id) FROM tech_book)
+//
+// expects an advice on the inner SELECT (outer has a WHERE; trigger must
+// come from the inner subquery). A naive Recipe-A top-level type-switch
+// would silently regress on this case — same shape of bug as batch 3's
+// no_select_all round-1 missed-qualified-wildcard.
 func (*WhereRequirementForSelectAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	root, err := getTiDBNodes(checkCtx)
-
+	stmts, err := getTiDBOmniNodes(checkCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -37,50 +46,58 @@ func (*WhereRequirementForSelectAdvisor) Check(_ context.Context, checkCtx advis
 	if err != nil {
 		return nil, err
 	}
-	checker := &whereRequirementForSelectChecker{
-		level: level,
-		title: checkCtx.Rule.Type.String(),
-	}
-	for _, stmtNode := range root {
-		checker.text = stmtNode.Text()
-		checker.line = stmtNode.OriginTextPosition()
-		(stmtNode).Accept(checker)
-	}
 
-	return checker.adviceList, nil
-}
-
-type whereRequirementForSelectChecker struct {
-	adviceList []*storepb.Advice
-	level      storepb.Advice_Status
-	title      string
-	text       string
-	line       int
-}
-
-// Enter implements the ast.Visitor interface.
-func (v *whereRequirementForSelectChecker) Enter(in ast.Node) (ast.Node, bool) {
-	code := advisorcode.Ok
-	if node, ok := in.(*ast.SelectStmt); ok {
-		// Allow SELECT queries without a FROM clause to proceed, e.g. SELECT 1.
-		if node.Where == nil && node.From != nil {
-			code = advisorcode.StatementNoWhere
+	title := checkCtx.Rule.Type.String()
+	var adviceList []*storepb.Advice
+	for _, ostmt := range stmts {
+		// Pingcap parity: every match reports the OUTER statement's
+		// first-token line and trimmed text, not the inner SelectStmt's
+		// position — checker.text/line are set ONCE per top-level statement
+		// in the pingcap version (before Accept()).
+		v := &whereRequireSelectVisitor{
+			level:   level,
+			title:   title,
+			text:    ostmt.TrimmedText(),
+			line:    ostmt.FirstTokenLine(),
+			advices: &adviceList,
 		}
+		ast.Walk(v, ostmt.Node)
 	}
+	return adviceList, nil
+}
 
-	if code != advisorcode.Ok {
-		v.adviceList = append(v.adviceList, &storepb.Advice{
+type whereRequireSelectVisitor struct {
+	level   storepb.Advice_Status
+	title   string
+	text    string
+	line    int
+	advices *[]*storepb.Advice
+}
+
+// Visit returns v to recurse into children, including SelectStmt.Left/Right
+// (UNION arms) per omni's Walk contract.
+func (v *whereRequireSelectVisitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return nil
+	}
+	sel, ok := node.(*ast.SelectStmt)
+	if !ok {
+		return v
+	}
+	// Cumulative shape divergence #10: omni's SelectStmt.From is []TableExpr
+	// (slice), not pingcap's *TableRefsClause (pointer). len(From) > 0
+	// is the correct "has FROM" check; `From != nil` would be wrong on
+	// empty-but-non-nil slices.
+	//
+	// Allow SELECT without FROM (e.g. SELECT 1, SELECT CURDATE()).
+	if sel.Where == nil && len(sel.From) > 0 {
+		*v.advices = append(*v.advices, &storepb.Advice{
 			Status:        v.level,
-			Code:          code.Int32(),
+			Code:          advisorcode.StatementNoWhere.Int32(),
 			Title:         v.title,
 			Content:       fmt.Sprintf("\"%s\" requires WHERE clause", v.text),
 			StartPosition: common.ConvertANTLRLineToPosition(v.line),
 		})
 	}
-	return in, false
-}
-
-// Leave implements the ast.Visitor interface.
-func (*whereRequirementForSelectChecker) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+	return v
 }

--- a/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_update_delete.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_update_delete.go
@@ -4,31 +4,34 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/bytebase/omni/tidb/ast"
+
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	advisorcode "github.com/bytebase/bytebase/backend/plugin/advisor/code"
-
-	"github.com/pingcap/tidb/pkg/parser/ast"
 )
 
 var (
 	_ advisor.Advisor = (*WhereRequirementForUpdateDeleteAdvisor)(nil)
-	_ ast.Visitor     = (*whereRequirementForUpdateDeleteChecker)(nil)
 )
 
 func init() {
 	advisor.Register(storepb.Engine_TIDB, storepb.SQLReviewRule_STATEMENT_WHERE_REQUIRE_UPDATE_DELETE, &WhereRequirementForUpdateDeleteAdvisor{})
 }
 
-// WhereRequirementForUpdateDeleteAdvisor is the advisor checking for the WHERE clause requirement for UPDATE and DELETE statements.
+// WhereRequirementForUpdateDeleteAdvisor checks the WHERE clause
+// requirement for UPDATE and DELETE statements.
 type WhereRequirementForUpdateDeleteAdvisor struct {
 }
 
-// Check checks for the WHERE clause requirement.
+// Check is Recipe A (top-level type-switch) — UPDATE and DELETE cannot
+// nest other UPDATE/DELETE statements in standard SQL, so a sub-walk would
+// add no coverage over a top-level check. Subqueries inside UPDATE/DELETE
+// (in WHERE expressions or SET values) are SELECTs, which are the
+// where_required_for_select advisor's concern, not this rule's.
 func (*WhereRequirementForUpdateDeleteAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
-	root, err := getTiDBNodes(checkCtx)
-
+	stmts, err := getTiDBOmniNodes(checkCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -37,57 +40,32 @@ func (*WhereRequirementForUpdateDeleteAdvisor) Check(_ context.Context, checkCtx
 	if err != nil {
 		return nil, err
 	}
-	checker := &whereRequirementForUpdateDeleteChecker{
-		level: level,
-		title: checkCtx.Rule.Type.String(),
-	}
-	for _, stmtNode := range root {
-		checker.text = stmtNode.Text()
-		checker.line = stmtNode.OriginTextPosition()
-		(stmtNode).Accept(checker)
-	}
 
-	return checker.adviceList, nil
-}
-
-type whereRequirementForUpdateDeleteChecker struct {
-	adviceList []*storepb.Advice
-	level      storepb.Advice_Status
-	title      string
-	text       string
-	line       int
-}
-
-// Enter implements the ast.Visitor interface.
-func (v *whereRequirementForUpdateDeleteChecker) Enter(in ast.Node) (ast.Node, bool) {
-	code := advisorcode.Ok
-	switch node := in.(type) {
-	// DELETE
-	case *ast.DeleteStmt:
-		if node.Where == nil {
-			code = advisorcode.StatementNoWhere
+	title := checkCtx.Rule.Type.String()
+	var adviceList []*storepb.Advice
+	for _, ostmt := range stmts {
+		var noWhere bool
+		switch n := ostmt.Node.(type) {
+		case *ast.DeleteStmt:
+			if n.Where == nil {
+				noWhere = true
+			}
+		case *ast.UpdateStmt:
+			if n.Where == nil {
+				noWhere = true
+			}
+		default:
 		}
-	// UPDATE
-	case *ast.UpdateStmt:
-		if node.Where == nil {
-			code = advisorcode.StatementNoWhere
+		if !noWhere {
+			continue
 		}
-	default:
-	}
-
-	if code != advisorcode.Ok {
-		v.adviceList = append(v.adviceList, &storepb.Advice{
-			Status:        v.level,
-			Code:          code.Int32(),
-			Title:         v.title,
-			Content:       fmt.Sprintf("\"%s\" requires WHERE clause", v.text),
-			StartPosition: common.ConvertANTLRLineToPosition(v.line),
+		adviceList = append(adviceList, &storepb.Advice{
+			Status:        level,
+			Code:          advisorcode.StatementNoWhere.Int32(),
+			Title:         title,
+			Content:       fmt.Sprintf("\"%s\" requires WHERE clause", ostmt.TrimmedText()),
+			StartPosition: common.ConvertANTLRLineToPosition(ostmt.FirstTokenLine()),
 		})
 	}
-	return in, false
-}
-
-// Leave implements the ast.Visitor interface.
-func (*whereRequirementForUpdateDeleteChecker) Leave(in ast.Node) (ast.Node, bool) {
-	return in, true
+	return adviceList, nil
 }

--- a/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_update_delete.go
+++ b/backend/plugin/advisor/tidb/advisor_stmt_where_required_for_update_delete.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	_ advisor.Advisor = (*WhereRequirementForUpdateDeleteAdvisor)(nil)
+	_ ast.Visitor     = (*whereRequireUpdateDeleteVisitor)(nil)
 )
 
 func init() {
@@ -25,11 +26,18 @@ func init() {
 type WhereRequirementForUpdateDeleteAdvisor struct {
 }
 
-// Check is Recipe A (top-level type-switch) — UPDATE and DELETE cannot
-// nest other UPDATE/DELETE statements in standard SQL, so a sub-walk would
-// add no coverage over a top-level check. Subqueries inside UPDATE/DELETE
-// (in WHERE expressions or SET values) are SELECTs, which are the
-// where_required_for_select advisor's concern, not this rule's.
+// Check is Recipe B (sub-walk via omni Visitor). The initial batch-5
+// implementation was Recipe A on the assumption that UPDATE and DELETE
+// can't nest in standard SQL — but that missed statement-wrapper forms
+// like `EXPLAIN DELETE FROM t` and `EXPLAIN UPDATE t SET x = 1`. Both
+// pingcap and omni produce *ExplainStmt{Stmt: *DeleteStmt}, and pingcap's
+// Visitor walked into the inner DML to fire the rule. A Recipe A
+// migration silently regresses on the EXPLAIN-wrapped form.
+//
+// Per Phase 1.5 cumulative shape divergence #13 (Codex P2 round-1 catch
+// on PR #20211): wrapper statements (EXPLAIN, TRACE, DESCRIBE, ...) embed
+// DML at omni's nodes that mechanical top-level type-switch ignores.
+// Recipe B with omniast.Walk handles every wrapper kind automatically.
 func (*WhereRequirementForUpdateDeleteAdvisor) Check(_ context.Context, checkCtx advisor.Context) ([]*storepb.Advice, error) {
 	stmts, err := getTiDBOmniNodes(checkCtx)
 	if err != nil {
@@ -44,28 +52,57 @@ func (*WhereRequirementForUpdateDeleteAdvisor) Check(_ context.Context, checkCtx
 	title := checkCtx.Rule.Type.String()
 	var adviceList []*storepb.Advice
 	for _, ostmt := range stmts {
-		var noWhere bool
-		switch n := ostmt.Node.(type) {
-		case *ast.DeleteStmt:
-			if n.Where == nil {
-				noWhere = true
-			}
-		case *ast.UpdateStmt:
-			if n.Where == nil {
-				noWhere = true
-			}
-		default:
+		// Pingcap parity: every match reports the OUTER statement's
+		// trimmed text and first-token line. For EXPLAIN DELETE FROM t,
+		// the advice content is the EXPLAIN statement, not the inner
+		// DeleteStmt — same as pingcap's `checker.text/line` set once
+		// before Accept().
+		v := &whereRequireUpdateDeleteVisitor{
+			level:   level,
+			title:   title,
+			text:    ostmt.TrimmedText(),
+			line:    ostmt.FirstTokenLine(),
+			advices: &adviceList,
 		}
-		if !noWhere {
-			continue
-		}
-		adviceList = append(adviceList, &storepb.Advice{
-			Status:        level,
-			Code:          advisorcode.StatementNoWhere.Int32(),
-			Title:         title,
-			Content:       fmt.Sprintf("\"%s\" requires WHERE clause", ostmt.TrimmedText()),
-			StartPosition: common.ConvertANTLRLineToPosition(ostmt.FirstTokenLine()),
-		})
+		ast.Walk(v, ostmt.Node)
 	}
 	return adviceList, nil
+}
+
+type whereRequireUpdateDeleteVisitor struct {
+	level   storepb.Advice_Status
+	title   string
+	text    string
+	line    int
+	advices *[]*storepb.Advice
+}
+
+// Visit returns v to recurse into children, including ExplainStmt.Stmt
+// and other statement-wrapper forms.
+func (v *whereRequireUpdateDeleteVisitor) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return nil
+	}
+	var noWhere bool
+	switch n := node.(type) {
+	case *ast.DeleteStmt:
+		if n.Where == nil {
+			noWhere = true
+		}
+	case *ast.UpdateStmt:
+		if n.Where == nil {
+			noWhere = true
+		}
+	default:
+	}
+	if noWhere {
+		*v.advices = append(*v.advices, &storepb.Advice{
+			Status:        v.level,
+			Code:          advisorcode.StatementNoWhere.Int32(),
+			Title:         v.title,
+			Content:       fmt.Sprintf("\"%s\" requires WHERE clause", v.text),
+			StartPosition: common.ConvertANTLRLineToPosition(v.line),
+		})
+	}
+	return v
 }

--- a/backend/plugin/advisor/tidb/test/statement_where_no_leading_wildcard_like.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_where_no_leading_wildcard_like.yaml
@@ -44,3 +44,50 @@
         line: 1
         column: 0
       endposition: null
+# LIKE matrix pins (added with the omni Recipe B migration). Per pingcap
+# parity, NOT LIKE with leading `%` triggers (advisor doesn't gate on
+# the Not flag); ESCAPE clause doesn't affect the pattern check; only
+# `%` is the wildcard (`_` is not flagged); non-string-literal patterns
+# silently skip (parameter `?` doesn't trigger because pingcap restored
+# it as `?`, omni skips because pattern is not *StringLit). UNION arms
+# are walked by omni's Walk per the cumulative shape-divergence table
+# item #5.
+- statement: SELECT * FROM t WHERE a NOT LIKE '%abc'
+  changeType: 1
+  want:
+    - status: 2
+      code: 204
+      title: STATEMENT_WHERE_NO_LEADING_WILDCARD_LIKE
+      content: '"SELECT * FROM t WHERE a NOT LIKE ''%abc''" uses leading wildcard LIKE'
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+- statement: SELECT * FROM t WHERE a LIKE '%abc' ESCAPE '\\'
+  changeType: 1
+  want:
+    - status: 2
+      code: 204
+      title: STATEMENT_WHERE_NO_LEADING_WILDCARD_LIKE
+      content: '"SELECT * FROM t WHERE a LIKE ''%abc'' ESCAPE ''\\''" uses leading wildcard LIKE'
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+- statement: SELECT * FROM t WHERE a LIKE '_abc'
+  changeType: 1
+- statement: SELECT * FROM t WHERE a LIKE 'abc'
+  changeType: 1
+- statement: SELECT * FROM t WHERE a LIKE ?
+  changeType: 1
+- statement: SELECT * FROM t WHERE a LIKE 'foo' UNION SELECT * FROM u WHERE a LIKE '%bar'
+  changeType: 1
+  want:
+    - status: 2
+      code: 204
+      title: STATEMENT_WHERE_NO_LEADING_WILDCARD_LIKE
+      content: '"SELECT * FROM t WHERE a LIKE ''foo'' UNION SELECT * FROM u WHERE a LIKE ''%bar''" uses leading wildcard LIKE'
+      startposition:
+        line: 1
+        column: 0
+      endposition: null

--- a/backend/plugin/advisor/tidb/test/statement_where_no_leading_wildcard_like.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_where_no_leading_wildcard_like.yaml
@@ -111,3 +111,15 @@
       endposition: null
 - statement: SELECT * FROM t WHERE a LIKE 'abc' COLLATE utf8mb4_bin
   changeType: 1
+# Cumulative shape divergence #12 (peer-review preempt; empirically NOT
+# a regression). LIKE ('%abc') wraps the literal in parens. Pingcap
+# parses Pattern as *ast.ParenthesesExpr; restoreNode renders as
+# "(%abc)" (parens preserved), so pattern[0] == '(' and pingcap does
+# NOT trigger. Omni parses Pattern as *ast.ParenExpr{Expr: *StringLit};
+# the StringLit type-assert fails, silently skips. Same outcome via
+# different mechanisms — no divergence. DO NOT add ParenExpr to the
+# CollateExpr unwrap loop; doing so would make omni start triggering
+# on a case pingcap doesn't, introducing a real regression. This
+# fixture pins the non-trigger contract.
+- statement: SELECT * FROM t WHERE a LIKE ('%abc')
+  changeType: 1

--- a/backend/plugin/advisor/tidb/test/statement_where_no_leading_wildcard_like.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_where_no_leading_wildcard_like.yaml
@@ -91,3 +91,23 @@
         line: 1
         column: 0
       endposition: null
+# Cumulative shape divergence #11 (Codex P1 catch on PR #20211):
+# omni wraps `'%abc' COLLATE utf8mb4_bin` as *CollateExpr{Expr: *StringLit};
+# pingcap rendered *SetCollationExpr to text as "%abc COLLATE utf8mb4_bin"
+# (value first), so the leading-`%` check accidentally fired. The omni
+# port unwraps CollateExpr before the StringLit type-assert to preserve
+# pingcap behavior. Both fixtures pin the contract: leading-`%` with
+# COLLATE triggers; non-leading with COLLATE doesn't.
+- statement: SELECT * FROM t WHERE a LIKE '%abc' COLLATE utf8mb4_bin
+  changeType: 1
+  want:
+    - status: 2
+      code: 204
+      title: STATEMENT_WHERE_NO_LEADING_WILDCARD_LIKE
+      content: '"SELECT * FROM t WHERE a LIKE ''%abc'' COLLATE utf8mb4_bin" uses leading wildcard LIKE'
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+- statement: SELECT * FROM t WHERE a LIKE 'abc' COLLATE utf8mb4_bin
+  changeType: 1

--- a/backend/plugin/advisor/tidb/test/statement_where_require_update_delete.yaml
+++ b/backend/plugin/advisor/tidb/test/statement_where_require_update_delete.yaml
@@ -24,3 +24,36 @@
   changeType: 1
 - statement: UPDATE tech_book SET id = 1 WHERE id > 10
   changeType: 1
+# Cumulative shape divergence #13 (Codex P2 catch on PR #20211, batch 5
+# round-1). EXPLAIN/TRACE/DESCRIBE wrap DML — both pingcap and omni
+# parse `EXPLAIN DELETE FROM t` as *ExplainStmt{Stmt: *DeleteStmt}.
+# Pingcap's Visitor walked into the inner DML; the initial batch-5
+# Recipe A migration only checked the top-level type and silently
+# regressed on the EXPLAIN-wrapped form. Switched to Recipe B; these
+# fixtures pin the contract.
+- statement: EXPLAIN DELETE FROM tech_book
+  changeType: 1
+  want:
+    - status: 2
+      code: 202
+      title: STATEMENT_WHERE_REQUIRE_UPDATE_DELETE
+      content: '"EXPLAIN DELETE FROM tech_book" requires WHERE clause'
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+- statement: EXPLAIN UPDATE tech_book SET id = 1
+  changeType: 1
+  want:
+    - status: 2
+      code: 202
+      title: STATEMENT_WHERE_REQUIRE_UPDATE_DELETE
+      content: '"EXPLAIN UPDATE tech_book SET id = 1" requires WHERE clause'
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+- statement: EXPLAIN DELETE FROM tech_book WHERE id > 0
+  changeType: 1
+- statement: EXPLAIN UPDATE tech_book SET id = 1 WHERE id > 10
+  changeType: 1


### PR DESCRIPTION
## Summary

Phase 1.5 §1.5.3 batch 5 of the TiDB advisor migration to omni AST. Migrates the WHERE-required pair plus the first Recipe B (sub-walk) advisor in a single PR for family coherence — all 3 are WHERE-clause-related rules.

**Migration progress: 20 of 51 advisors on omni AST.**

This is the **first batch with Recipe B** in the migration. Per Phase 1.5 calibration framing, reviewer attention to the Visitor implementation is warranted.

## Migrated advisors

| File | Recipe | Notes |
|---|---|---|
| `advisor_stmt_where_required_for_select.go` | **B** | Walks into sub-selects; existing fixture proves this is required (see Recipe choice below) |
| `advisor_stmt_where_required_for_update_delete.go` | A | No nested UPDATE/DELETE possible in standard SQL |
| `advisor_stmt_no_leading_wildcard_like.go` | **B** | Walks WHERE expressions for `*ast.LikeExpr` at any depth |

## Recipe-A vs B determined empirically (NOT by name pattern)

Per pre-batch protocol, read each pingcap-typed Visitor body before locking the recipe choice.

**`where_required_for_select` is Recipe B, not A.** The pingcap Visitor returns `(in, false)` (continue recursion). Existing fixture proves this is required:

```yaml
- statement: SELECT id FROM tech_book WHERE id > (SELECT max(id) FROM tech_book)
  changeType: 1
  want:
    - status: 2
      content: '"SELECT id FROM tech_book WHERE id > (SELECT max(id) FROM tech_book)" requires WHERE clause'
```

The OUTER has a WHERE; the trigger comes from the INNER subquery. A naive Recipe A migration (top-level type-switch) would silently regress on this fixture — same shape of bug as batch 3's `no_select_all` round-1 fix (cumulative table item #5).

**`where_required_for_update_delete` is Recipe A.** Standard SQL doesn't allow nested UPDATE/DELETE. Subqueries inside are SELECTs (handled by the SELECT advisor).

**`no_leading_wildcard_like` is Recipe B.** Walks WHERE expressions to find `*ast.LikeExpr` nodes at any nesting depth.

## Recipe B failure-mode checklist (per plan §1.5.0)

| # | Item | `where_required_for_select` | `no_leading_wildcard_like` |
|---|---|---|---|
| 1 | `Visit(node) Visitor` signature (NOT pingcap's `Enter` returning `(Node, bool)`) | ✓ | ✓ |
| 2 | `Visit(nil)` post-order signal handled | ✓ `if node == nil { return nil }` | ✓ same |
| 3 | No built-in pre/post framing — depth tracking manual | N/A — no per-subtree state | N/A |
| 4 | Returning `nil` to skip subtree | Returns `v` always (full walk; no benefit to skipping) | Optimization: `if v.found { return nil }` after first hit |
| 5 | Mutable state across recursion | None | `found` flag — instantiated **fresh per top-level statement** in outer loop, not reused across statements (matches pingcap's `checker.leadingWildcardLike = false` reset) |

## Shape audit findings — NEW cumulative shape divergence #10

| Advisor / batch | Pingcap shape | Omni shape | Class |
|---|---|---|---|
| `where_required_for_select` (batch 5) | `node.From != nil` (`*TableRefsClause` pointer) | `n.From []TableExpr` (slice) | Latent bug if mechanically renamed: `From != nil` evaluates true for empty-but-non-nil slices, would miss "no FROM" (e.g. `SELECT 1`) and incorrectly flag it. Use `len(n.From) > 0`. |

Existing cumulative table items consulted:
- **Item #5** (UNION arm coverage): omni's `Walk` recurses into `SelectStmt.Left/Right`. Recipe B advisors automatically cover both arms — UNION fixture verifies this for `no_leading_wildcard_like`.
- **Item #6** (`FirstTokenLine` for whole-statement advice positions): used for both Recipe B advisors' StartPosition.

## LIKE matrix empirical pins

7 new fixtures in `statement_where_no_leading_wildcard_like.yaml`. Each pins a distinct LIKE-shape behavior; each was assumed-then-confirmed via the test pass.

| Input | Expected | Verifies |
|---|---|---|
| `WHERE a NOT LIKE '%abc'` | triggers | pingcap doesn't gate on `LikeExpr.Not` flag — NOT LIKE behaves same as LIKE |
| `WHERE a LIKE '%abc' ESCAPE '\\'` | triggers | ESCAPE clause is on a separate field; doesn't affect pattern check |
| `WHERE a LIKE '_abc'` | does NOT trigger | only `%` is the wildcard; `_` is not flagged (per `wildcard = '%'` constant) |
| `WHERE a LIKE 'abc'` | does NOT trigger | no wildcard, no flag |
| `WHERE a LIKE ?` | does NOT trigger | parameter marker is not `*ast.StringLit`; type-assert fails, silently skip (matches pingcap's `restoreNode` producing `?` which doesn't start with `%`) |
| `... UNION SELECT ... WHERE a LIKE '%bar'` | triggers | omni Walk recurses into `SelectStmt.Left/Right` (cumulative #5) |

## API mappings used

| Pingcap | Omni |
|---|---|
| `*ast.SelectStmt.From != nil` (`*TableRefsClause`) | `len(n.From) > 0` (`[]TableExpr`) |
| `*ast.SelectStmt.Where == nil` | same: `n.Where == nil` (`ExprNode` interface) |
| `*ast.PatternLikeOrIlikeExpr` | `*ast.LikeExpr` |
| `node.Pattern` + `restoreNode(...)` (renders to text) | `node.Pattern.(*ast.StringLit).Value` (read literal value directly) |
| `*ast.DeleteStmt`, `*ast.UpdateStmt` | same names in omni |
| `(stmtNode).Accept(checker)` | `omniast.Walk(visitor, ostmt.Node)` |
| `Enter(in) (Node, bool)` returning `(in, false)` to recurse | `Visit(node) Visitor` returning `v` to recurse, `nil` to skip |
| `node.Text()`, `node.OriginTextPosition()` (top-level) | `ostmt.TrimmedText()`, `ostmt.FirstTokenLine()` |

## What's NOT in this batch

- Any advisor outside the WHERE family. `stmt_no_leading_wildcard_like` was bundled (rather than split into a separate "first Recipe B spike" PR) because the calibration framing in the plan is about reviewer rigor, not scope isolation, and family coherence makes the Recipe A vs B comparison more legible side-by-side.
- Dispatcher flip (1.5.N+1) — unchanged.

## Test plan

- [x] `go test -count=1 -run "^TestTiDBRules$" ./backend/plugin/advisor/tidb/` — green (existing fixtures + 7 new)
- [x] `go test -count=1 ./backend/plugin/advisor/tidb/ ./backend/plugin/advisor/mysql/` — green (cross-engine non-regression)
- [x] `go test -count=1 ./backend/plugin/parser/tidb/` — green
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/advisor/tidb/...` — 0 issues
- [x] `go build -ldflags "-w -s" -p=16 -o /tmp/bb-batch5 ./backend/bin/server/main.go` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)