### PR TITLE
refactor(react): use shared checkbox component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,14 @@ The frontend is migrating from Vue to React. **All new UI code should be written
 - Use `useTranslation()` from `react-i18next` for i18n
 - Use CSS custom properties (`--color-accent`, `--color-error`, `--color-control-border`, etc.) for theme tokens shared with the Vue layer
 
+**Shared UI primitives**:
+- For React UI code, prefer shared components from `./frontend/src/react/components/ui/` over native HTML controls or ad hoc styled elements
+- Before adding or modifying an interactive UI element, first check whether a matching component already exists in `./frontend/src/react/components/ui/`
+- Use shared UI components for common controls such as buttons, inputs, selects, dialogs, dropdowns, tooltips, tabs, checkboxes, radios, switches, tables, and form controls when available
+- Do not hand-roll native controls with Tailwind classes when a shared component exists
+- Native HTML controls are allowed only when the shared component does not support the required browser behavior, accessibility behavior, or integration pattern
+- When touching existing React UI, opportunistically replace nearby native or ad hoc controls with shared UI components if behavior remains equivalent and the scope stays reasonable
+
 **Tailwind CSS v4**:
 - CSS-first config in `./frontend/src/assets/css/tailwind.css` — no JS config file
 - Custom utilities use `@utility`, design tokens use `@theme`

--- a/frontend/src/react/components/IAMRemindDialog.tsx
+++ b/frontend/src/react/components/IAMRemindDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -112,11 +113,9 @@ export function IAMRemindDialog({ project }: IAMRemindDialogProps) {
           </ul>
         </div>
         <label className="mt-6 flex items-center gap-x-2 text-sm text-control-light">
-          <input
-            type="checkbox"
-            className="size-4 rounded-xs border-control-border"
+          <Checkbox
             checked={checked}
-            onChange={(event) => setChecked(event.target.checked)}
+            onCheckedChange={(checked) => setChecked(checked)}
           />
           {t("remind.role-expire.checkbox")}
         </label>

--- a/frontend/src/react/components/InstanceAssignmentSheet.tsx
+++ b/frontend/src/react/components/InstanceAssignmentSheet.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
 import {
   Sheet,
@@ -293,11 +294,11 @@ export function InstanceAssignmentSheet({
                       >
                         {canManageSubscription && (
                           <td className="px-4 py-2">
-                            <input
-                              type="checkbox"
+                            <Checkbox
                               checked={checked}
-                              onChange={() => toggleSelection(instance.name)}
-                              className="rounded-xs border-control-border"
+                              onCheckedChange={() =>
+                                toggleSelection(instance.name)
+                              }
                             />
                           </td>
                         )}

--- a/frontend/src/react/components/IssueLabelSelect.tsx
+++ b/frontend/src/react/components/IssueLabelSelect.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, X } from "lucide-react";
 import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
 import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { cn } from "@/react/lib/utils";
@@ -119,12 +120,7 @@ export function IssueLabelSelect({
                       className="w-full text-left px-3 py-2 text-sm flex items-center gap-2 hover:bg-control-bg transition-colors"
                       onClick={() => toggleLabel(label.value)}
                     >
-                      <input
-                        type="checkbox"
-                        checked={isSelected}
-                        readOnly
-                        className="rounded-xs border-control-border accent-accent"
-                      />
+                      <Checkbox checked={isSelected} />
                       <span
                         className="size-4 rounded-sm shrink-0"
                         style={{ backgroundColor: label.color }}

--- a/frontend/src/react/components/ProjectTable.tsx
+++ b/frontend/src/react/components/ProjectTable.tsx
@@ -3,6 +3,7 @@ import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
 import { Badge } from "@/react/components/ui/badge";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -142,12 +143,10 @@ export function ProjectTable({
         <TableRow>
           {showSelection ? (
             <TableHead className="w-12">
-              <input
-                type="checkbox"
-                aria-label={t("common.select-all")}
+              <Checkbox
                 checked={allSelected}
-                onChange={handleSelectAll}
-                className="rounded-xs border-control-border"
+                aria-label={t("common.select-all")}
+                onCheckedChange={handleSelectAll}
               />
             </TableHead>
           ) : showLeadingCheck ? (
@@ -210,13 +209,12 @@ export function ProjectTable({
                     className="w-12"
                     onClick={(e) => e.stopPropagation()}
                   >
-                    <input
-                      type="checkbox"
-                      aria-label={t("common.select")}
+                    <Checkbox
                       checked={isSelected}
+                      aria-label={t("common.select")}
                       disabled={isDefault}
-                      onChange={() => handleToggleRow(project.name)}
-                      className="rounded-xs border-control-border disabled:opacity-50"
+                      onCheckedChange={() => handleToggleRow(project.name)}
+                      className="disabled:opacity-50"
                     />
                   </TableCell>
                 ) : showLeadingCheck ? (

--- a/frontend/src/react/components/SchemaEditorLite/Panels/IndexesEditor/IndexesEditor.tsx
+++ b/frontend/src/react/components/SchemaEditorLite/Panels/IndexesEditor/IndexesEditor.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash2 } from "lucide-react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Combobox } from "@/react/components/ui/combobox";
 import { Input } from "@/react/components/ui/input";
 import {
@@ -147,18 +148,17 @@ export function IndexesEditor({
                 />
               </TableCell>
               <TableCell className="text-center">
-                <input
-                  type="checkbox"
+                <Checkbox
                   checked={index.unique}
                   disabled={isReadonly || index.primary}
-                  onChange={(e) => {
-                    index.unique = e.target.checked;
+                  onCheckedChange={(checked) => {
+                    index.unique = checked;
                     handleIndexChange();
                   }}
                 />
               </TableCell>
               <TableCell className="text-center">
-                <input type="checkbox" checked={index.primary} disabled />
+                <Checkbox checked={index.primary} disabled />
               </TableCell>
               {!isReadonly && (
                 <TableCell className="text-right">

--- a/frontend/src/react/components/SchemaEditorLite/Panels/TableColumnEditor/TableColumnEditor.tsx
+++ b/frontend/src/react/components/SchemaEditorLite/Panels/TableColumnEditor/TableColumnEditor.tsx
@@ -2,6 +2,7 @@ import { RotateCcw, Trash2 } from "lucide-react";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import {
   Table,
@@ -289,22 +290,20 @@ export function TableColumnEditor({
                   />
                 </TableCell>
                 <TableCell className={cn(cellClass, "text-center")}>
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={!column.nullable}
                     disabled={disabled || isPK}
-                    onChange={(e) =>
-                      handleNullableChange(column, !e.target.checked)
+                    onCheckedChange={(checked) =>
+                      handleNullableChange(column, !checked)
                     }
                   />
                 </TableCell>
                 <TableCell className={cn(cellClass, "text-center")}>
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={isPK}
                     disabled={disabled || !allowChangePrimaryKeys}
-                    onChange={(e) =>
-                      handlePrimaryKeyChange(column, e.target.checked)
+                    onCheckedChange={(checked) =>
+                      handlePrimaryKeyChange(column, checked)
                     }
                   />
                 </TableCell>

--- a/frontend/src/react/components/database/DatabaseTableView.tsx
+++ b/frontend/src/react/components/database/DatabaseTableView.tsx
@@ -1,9 +1,10 @@
 import { CheckCircle, XCircle } from "lucide-react";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { LabelsDisplay } from "@/react/components/LabelsDisplay";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -126,35 +127,23 @@ export function DatabaseTableView({
   const someSelected =
     (selectedNames?.size ?? 0) > 0 &&
     (selectedNames?.size ?? 0) < databases.length;
-  const headerCheckboxRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    if (headerCheckboxRef.current) {
-      headerCheckboxRef.current.indeterminate = someSelected;
-    }
-  }, [someSelected]);
-
   const columns = useMemo<DatabaseColumn[]>(() => {
     const cols: DatabaseColumn[] = [];
     if (showSelection) {
       cols.push({
         key: "select",
         title: (
-          <input
-            ref={headerCheckboxRef}
-            type="checkbox"
-            checked={allSelected}
-            onChange={toggleSelectAll}
-            className="rounded-xs border-control-border"
+          <Checkbox
+            checked={someSelected ? "indeterminate" : allSelected}
+            onCheckedChange={toggleSelectAll}
           />
         ),
         defaultWidth: 48,
         render: (db) => (
-          <input
-            type="checkbox"
+          <Checkbox
             checked={selectedNames?.has(db.name) ?? false}
-            onChange={() => toggleSelection(db.name)}
+            onCheckedChange={() => toggleSelection(db.name)}
             onClick={(e) => e.stopPropagation()}
-            className="rounded-xs border-control-border"
           />
         ),
       });

--- a/frontend/src/react/components/instance/DataSourceForm.tsx
+++ b/frontend/src/react/components/instance/DataSourceForm.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useActuatorV1Store, useSubscriptionV1Store } from "@/store";
@@ -914,12 +915,11 @@ export function DataSourceForm({
                         <div className="mt-2">
                           {!isCreating && allowUsingEmptyPassword && (
                             <label className="flex items-center gap-x-1.5 mb-2 text-sm cursor-pointer">
-                              <input
-                                type="checkbox"
+                              <Checkbox
                                 checked={dataSource.useEmptyPassword ?? false}
                                 disabled={!allowEdit}
-                                onChange={(e) =>
-                                  toggleUseEmptyPassword(e.target.checked)
+                                onCheckedChange={(checked) =>
+                                  toggleUseEmptyPassword(checked)
                                 }
                               />
                               {t("instance.no-password")}
@@ -1441,17 +1441,15 @@ export function DataSourceForm({
                             <div className="mt-2">
                               {!isCreating && allowUsingEmptyPassword && (
                                 <label className="flex items-center gap-x-1.5 mb-2 text-sm cursor-pointer">
-                                  <input
-                                    type="checkbox"
+                                  <Checkbox
                                     checked={
                                       dataSource.useEmptyMasterPassword ?? false
                                     }
                                     disabled={!allowEdit}
-                                    onChange={(e) => {
+                                    onCheckedChange={(checked) => {
                                       update({
-                                        useEmptyMasterPassword:
-                                          e.target.checked,
-                                        updatedMasterPassword: e.target.checked
+                                        useEmptyMasterPassword: checked,
+                                        updatedMasterPassword: checked
                                           ? ""
                                           : dataSource.updatedMasterPassword,
                                       });

--- a/frontend/src/react/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/react/components/instance/InstanceFormBody.tsx
@@ -17,6 +17,7 @@ import { LabelListEditor } from "@/react/components/LabelListEditor";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
@@ -740,11 +741,10 @@ function SyncDatabases({
       </div>
       <div className="flex flex-col gap-y-2">
         <label className="flex items-center gap-x-2 cursor-pointer">
-          <input
-            type="checkbox"
+          <Checkbox
             checked={syncAll}
             disabled={!allowEdit}
-            onChange={(e) => setSyncAll(e.target.checked)}
+            onCheckedChange={(checked) => setSyncAll(checked)}
           />
           {t("instance.sync-databases.sync-all")}
         </label>
@@ -768,11 +768,10 @@ function SyncDatabases({
                       key={db}
                       className="flex items-center gap-x-2 cursor-pointer text-sm"
                     >
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={selectedSet.has(db)}
                         disabled={!allowEdit}
-                        onChange={() => toggleDatabase(db)}
+                        onCheckedChange={() => toggleDatabase(db)}
                       />
                       <span>{db}</span>
                     </label>
@@ -1806,13 +1805,12 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
               adminDataSource.additionalAddresses.length === 0 && (
                 <div className="sm:col-span-4 sm:col-start-1">
                   <label className="flex items-center gap-x-2 cursor-pointer">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={adminDataSource.directConnection}
                       disabled={!allowEdit}
-                      onChange={(e) =>
+                      onCheckedChange={(checked) =>
                         updateAdminDS({
-                          directConnection: e.target.checked,
+                          directConnection: checked,
                         })
                       }
                     />

--- a/frontend/src/react/components/release/ReleaseFileTable.tsx
+++ b/frontend/src/react/components/release/ReleaseFileTable.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -119,11 +120,10 @@ export function ReleaseFileTable({
                   className="w-10"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={checked}
-                    onChange={(e) =>
-                      handleCheckboxChange(file, e.target.checked)
+                    onCheckedChange={(checked) =>
+                      handleCheckboxChange(file, checked)
                     }
                   />
                 </TableCell>

--- a/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
+++ b/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
@@ -7,6 +7,7 @@ import { accessGrantServiceClientConnect } from "@/connect";
 import { MonacoEditor } from "@/react/components/monaco/MonacoEditor";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Combobox } from "@/react/components/ui/combobox";
 import { ExpirationPicker } from "@/react/components/ui/expiration-picker";
 import {
@@ -270,11 +271,9 @@ function AccessGrantRequestDrawerInner({
               {t("sql-editor.grant-type-unmask")}
             </div>
             <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="checkbox"
+              <Checkbox
                 checked={unmask}
-                onChange={(e) => setUnmask(e.target.checked)}
-                className="accent-accent"
+                onCheckedChange={(checked) => setUnmask(checked)}
               />
               <span>{t("sql-editor.access-type-unmask")}</span>
             </label>

--- a/frontend/src/react/components/sql-editor/ConnectionPane/ConnectionPane.tsx
+++ b/frontend/src/react/components/sql-editor/ConnectionPane/ConnectionPane.tsx
@@ -10,6 +10,7 @@ import {
 import { DatabaseGroupTable } from "@/react/components/DatabaseGroupTable";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
 import { Separator } from "@/react/components/ui/separator";
 import {
@@ -592,12 +593,10 @@ function ConnectionPaneInner({ show, onMissingFeature }: Props) {
             {treeStoreState === "READY" && (
               <div className="flex flex-col gap-y-2 text-sm select-none pt-1">
                 <label className="inline-flex items-center gap-x-2">
-                  <input
-                    type="checkbox"
-                    className="rounded-xs border-control-border"
+                  <Checkbox
                     checked={showMissingQueryDatabases}
-                    onChange={(e) =>
-                      setShowMissingQueryDatabases(e.target.checked)
+                    onCheckedChange={(checked) =>
+                      setShowMissingQueryDatabases(checked)
                     }
                   />
                   {t("sql-editor.show-databases-without-query-permission")}

--- a/frontend/src/react/components/sql-editor/ConnectionPane/TreeNode/DatabaseNode.tsx
+++ b/frontend/src/react/components/sql-editor/ConnectionPane/TreeNode/DatabaseNode.tsx
@@ -3,6 +3,7 @@ import { ChevronRight } from "lucide-react";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
 import { RequestQueryButton } from "@/react/components/sql-editor/RequestQueryButton";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
@@ -54,13 +55,12 @@ export function DatabaseNode({
 
   const checkbox = supportBatchMode ? (
     <Tooltip content={checkTooltip ?? ""}>
-      <input
-        type="checkbox"
-        className="mr-2 size-3.5"
+      <Checkbox
         checked={!!checked}
+        className="mr-2"
         disabled={checkDisabled}
         onClick={(e) => e.stopPropagation()}
-        onChange={(e) => onCheckedChange?.(e.target.checked)}
+        onCheckedChange={(checked) => onCheckedChange?.(checked)}
       />
     </Tooltip>
   ) : null;

--- a/frontend/src/react/components/sql-editor/Panels/SequencesPanel/SequencesTable.tsx
+++ b/frontend/src/react/components/sql-editor/Panels/SequencesPanel/SequencesTable.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -108,12 +109,7 @@ export function SequencesTable({
                 </TableCell>
                 <TableCell>{sequence.increment}</TableCell>
                 <TableCell>
-                  <input
-                    type="checkbox"
-                    checked={sequence.cycle}
-                    disabled
-                    className="accent-accent"
-                  />
+                  <Checkbox checked={sequence.cycle} disabled />
                 </TableCell>
                 <TableCell>{sequence.cacheSize}</TableCell>
                 <TableCell>

--- a/frontend/src/react/components/sql-editor/Panels/ViewsPanel/ViewDetail.tsx
+++ b/frontend/src/react/components/sql-editor/Panels/ViewsPanel/ViewDetail.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft, Code, Columns, Eye, FileSymlink } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Tabs,
   TabsList,
@@ -115,11 +116,9 @@ export function ViewDetail({ db, database, schema, view }: ViewDetailProps) {
         {mode === "DEFINITION" ? (
           <div className="flex items-center gap-2">
             <label className="flex items-center gap-x-1 text-sm text-control cursor-pointer select-none">
-              <input
-                type="checkbox"
+              <Checkbox
                 checked={format}
-                onChange={(event) => setFormat(event.target.checked)}
-                className="accent-accent"
+                onCheckedChange={(checked) => setFormat(checked)}
               />
               {t("sql-editor.format")}
             </label>

--- a/frontend/src/react/components/sql-editor/Panels/common/CodeViewer.tsx
+++ b/frontend/src/react/components/sql-editor/Panels/common/CodeViewer.tsx
@@ -15,6 +15,7 @@ import * as promptUtils from "@/plugins/ai/logic/prompt";
 import type { ChatAction } from "@/plugins/ai/types";
 import { ReadonlyMonaco } from "@/react/components/monaco/ReadonlyMonaco";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { cn } from "@/react/lib/utils";
 import { useSQLEditorUIStore } from "@/store";
 import { dialectOfEngineV1 } from "@/types";
@@ -180,11 +181,9 @@ export function CodeViewer({
         </div>
         <div className="flex justify-end items-center gap-x-3">
           <label className="flex items-center gap-x-1 text-sm text-control cursor-pointer select-none">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={format}
-              onChange={(event) => setFormat(event.target.checked)}
-              className="accent-accent"
+              onCheckedChange={(checked) => setFormat(checked)}
             />
             {t("sql-editor.format")}
           </label>

--- a/frontend/src/react/components/sql-editor/Panels/common/tables/ColumnsTable.tsx
+++ b/frontend/src/react/components/sql-editor/Panels/common/tables/ColumnsTable.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
 import { engineSupportsMultiSchema } from "@/react/components/SchemaEditorLite/core/spec";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -138,20 +139,13 @@ export function ColumnsTable({
                 <EllipsisCell content={column.comment} />
               </TableCell>
               <TableCell className="w-20">
-                <input
-                  type="checkbox"
-                  checked={!column.nullable}
-                  disabled
-                  className="accent-accent"
-                />
+                <Checkbox checked={!column.nullable} disabled />
               </TableCell>
               {showPrimary ? (
                 <TableCell className="w-20">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={!!primaryKey?.expressions.includes(column.name)}
                     disabled
-                    className="accent-accent"
                   />
                 </TableCell>
               ) : null}

--- a/frontend/src/react/components/sql-editor/Panels/common/tables/IndexesTable.tsx
+++ b/frontend/src/react/components/sql-editor/Panels/common/tables/IndexesTable.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -83,20 +84,10 @@ export function IndexesTable({ table, keyword }: IndexesTableProps) {
                 <EllipsisCell content={index.comment} />
               </TableCell>
               <TableCell className="w-20">
-                <input
-                  type="checkbox"
-                  checked={index.primary}
-                  disabled
-                  className="accent-accent"
-                />
+                <Checkbox checked={index.primary} disabled />
               </TableCell>
               <TableCell className="w-20">
-                <input
-                  type="checkbox"
-                  checked={index.unique}
-                  disabled
-                  className="accent-accent"
-                />
+                <Checkbox checked={index.unique} disabled />
               </TableCell>
             </TableRow>
           ))}

--- a/frontend/src/react/components/sql-editor/SheetTree.tsx
+++ b/frontend/src/react/components/sql-editor/SheetTree.tsx
@@ -37,6 +37,7 @@ import {
   AlertDialogTitle,
 } from "@/react/components/ui/alert-dialog";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -961,18 +962,17 @@ export function SheetTree({
         >
           {/* Multi-select checkbox */}
           {multiSelectMode && (
-            <input
-              type="checkbox"
-              className="size-3.5 shrink-0 cursor-pointer"
+            <Checkbox
               checked={isChecked}
-              onChange={(e) => {
-                e.stopPropagation();
+              className="shrink-0 cursor-pointer"
+              onClick={(e) => e.stopPropagation()}
+              onCheckedChange={(checked) => {
                 // Checking a folder recursively includes all descendants so
                 // users don't have to tick each child individually.
                 const affected = folderNode.worksheet
                   ? [folderNode]
                   : revealNodes(folderNode, (n) => n);
-                if (e.target.checked) {
+                if (checked) {
                   const existing = new Set(checkedNodes.map((n) => n.key));
                   onCheckedNodesChange?.([
                     ...checkedNodes,
@@ -985,7 +985,6 @@ export function SheetTree({
                   );
                 }
               }}
-              onClick={(e) => e.stopPropagation()}
             />
           )}
 

--- a/frontend/src/react/components/sql-review/Panels.tsx
+++ b/frontend/src/react/components/sql-review/Panels.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { getRuleKey } from "@/components/SQLReview/components/utils";
 import { Alert, AlertDescription } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Sheet,
   SheetBody,
@@ -281,11 +282,9 @@ export function AttachResourcesPanel({
                       key={name}
                       className="flex items-center gap-x-2 cursor-pointer"
                     >
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={checked}
-                        onChange={() => toggleResource(name)}
-                        className="accent-accent"
+                        onCheckedChange={() => toggleResource(name)}
                       />
                       <span>{env.title || name}</span>
                       {attachedConfig && (
@@ -321,11 +320,9 @@ export function AttachResourcesPanel({
                       key={name}
                       className="flex items-center gap-x-2 cursor-pointer"
                     >
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={checked}
-                        onChange={() => toggleResource(name)}
-                        className="accent-accent"
+                        onCheckedChange={() => toggleResource(name)}
                       />
                       <span>{proj.title || name}</span>
                       {attachedConfig && (

--- a/frontend/src/react/components/sql-review/RuleComponents.tsx
+++ b/frontend/src/react/components/sql-review/RuleComponents.tsx
@@ -6,6 +6,7 @@ import { getRulePayload } from "@/components/SQLReview/components/RuleConfigComp
 import { payloadValueListToComponentList } from "@/components/SQLReview/components/utils";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -210,11 +211,10 @@ export function RuleConfig({
 
           {config.payload.type === "BOOLEAN" && (
             <label className="flex items-center gap-x-2">
-              <input
-                type="checkbox"
+              <Checkbox
                 checked={(payload[index] as boolean) ?? false}
                 disabled={disabled}
-                onChange={(e) => updatePayload(index, e.target.checked)}
+                onCheckedChange={(checked) => updatePayload(index, checked)}
               />
               <span>{configTitle(rule, config)}</span>
               {configTooltip(rule, config) && (
@@ -473,10 +473,9 @@ export function RuleLevelFilter({
             key={level}
             className="flex items-center gap-x-2 cursor-pointer"
           >
-            <input
-              type="checkbox"
+            <Checkbox
               checked={isCheckedLevel(level)}
-              onChange={() => onToggleCheckedLevel(level)}
+              onCheckedChange={() => onToggleCheckedLevel(level)}
             />
             <RuleLevelBadge level={level} suffix={`(${count})`} />
           </label>

--- a/frontend/src/react/components/ui/checkbox.tsx
+++ b/frontend/src/react/components/ui/checkbox.tsx
@@ -15,41 +15,34 @@ const ICON_SIZE: Record<CheckboxSize, string> = {
   md: "size-3",
 };
 
-interface CheckboxProps {
+interface CheckboxProps
+  extends Omit<
+    React.ComponentProps<typeof BaseCheckbox.Root>,
+    "checked" | "onCheckedChange" | "className" | "children"
+  > {
   checked: boolean | "indeterminate";
   onCheckedChange?: (checked: boolean) => void;
-  onClick?: React.MouseEventHandler<HTMLElement>;
-  disabled?: boolean;
   size?: CheckboxSize;
   className?: string;
-  id?: string;
-  name?: string;
-  "aria-label"?: string;
 }
 
 function Checkbox({
   checked,
   onCheckedChange,
   onClick,
-  disabled,
   size = "md",
   className,
-  id,
-  name,
-  "aria-label": ariaLabel,
+  ...rootProps
 }: CheckboxProps) {
   const baseChecked = checked === "indeterminate" ? false : checked;
   const indeterminate = checked === "indeterminate";
 
   const root = (
     <BaseCheckbox.Root
+      {...rootProps}
       checked={baseChecked}
       indeterminate={indeterminate}
       onCheckedChange={(value) => onCheckedChange?.(value)}
-      disabled={disabled}
-      id={id}
-      name={name}
-      aria-label={ariaLabel}
       className={cn(
         "inline-flex shrink-0 items-center justify-center align-middle rounded-sm border bg-background transition-colors",
         ROOT_SIZE[size],

--- a/frontend/src/react/components/ui/checkbox.tsx
+++ b/frontend/src/react/components/ui/checkbox.tsx
@@ -41,25 +41,24 @@ function Checkbox({
   const baseChecked = checked === "indeterminate" ? false : checked;
   const indeterminate = checked === "indeterminate";
 
-  return (
+  const root = (
     <BaseCheckbox.Root
       checked={baseChecked}
       indeterminate={indeterminate}
       onCheckedChange={(value) => onCheckedChange?.(value)}
-      onClick={onClick}
       disabled={disabled}
       id={id}
       name={name}
       aria-label={ariaLabel}
       className={cn(
-        "inline-flex shrink-0 items-center justify-center rounded-sm border bg-background transition-colors",
+        "inline-flex shrink-0 items-center justify-center align-middle rounded-sm border bg-background transition-colors",
         ROOT_SIZE[size],
         "border-control-border hover:border-accent/60",
         "data-[checked]:bg-accent data-[checked]:border-accent",
         "data-[indeterminate]:bg-accent data-[indeterminate]:border-accent",
         "focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
         "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-control-border",
-        className
+        !onClick && className
       )}
     >
       <BaseCheckbox.Indicator className="flex items-center justify-center text-background">
@@ -70,6 +69,17 @@ function Checkbox({
         )}
       </BaseCheckbox.Indicator>
     </BaseCheckbox.Root>
+  );
+
+  if (!onClick) return root;
+
+  return (
+    <span
+      className={cn("inline-flex align-middle", className)}
+      onClick={onClick}
+    >
+      {root}
+    </span>
   );
 }
 

--- a/frontend/src/react/pages/auth/SignupPage.tsx
+++ b/frontend/src/react/pages/auth/SignupPage.tsx
@@ -5,6 +5,7 @@ import { UserPasswordFields } from "@/react/components/auth/UserPasswordFields";
 import { computePasswordValidation } from "@/react/components/auth/userPasswordValidation";
 import { BytebaseLogo } from "@/react/components/BytebaseLogo";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
@@ -168,11 +169,12 @@ export function SignupPage() {
 
             {needAdminSetup && (
               <div className="w-full flex flex-row justify-start items-start gap-x-2">
-                <input
-                  id="accept-terms"
-                  type="checkbox"
+                <Checkbox
                   checked={acceptTermsAndPolicy}
-                  onChange={(e) => setAcceptTermsAndPolicy(e.target.checked)}
+                  id="accept-terms"
+                  onCheckedChange={(checked) =>
+                    setAcceptTermsAndPolicy(checked)
+                  }
                 />
                 <label
                   htmlFor="accept-terms"

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -26,6 +26,7 @@ import {
   usePermissionCheck,
 } from "@/react/components/PermissionGuard";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
   Sheet,
@@ -1064,14 +1065,9 @@ function DatabaseSelector({
             <thead>
               <tr className="border-b text-left text-control-light">
                 <th className="py-2 pr-2 w-8">
-                  <input
-                    type="checkbox"
-                    checked={allSelected}
-                    ref={(el) => {
-                      if (el) el.indeterminate = someSelected;
-                    }}
-                    onChange={toggleAll}
-                    className="accent-accent"
+                  <Checkbox
+                    checked={someSelected ? "indeterminate" : allSelected}
+                    onCheckedChange={toggleAll}
                   />
                 </th>
                 <th className="py-2 pr-4 font-medium">
@@ -1104,12 +1100,7 @@ function DatabaseSelector({
                     onClick={() => toggleDatabase(db.name)}
                   >
                     <td className="py-2 pr-2">
-                      <input
-                        type="checkbox"
-                        checked={isSelected}
-                        readOnly
-                        className="accent-accent"
-                      />
+                      <Checkbox checked={isSelected} />
                     </td>
                     <td className="py-2 pr-4">
                       <div className="flex items-center gap-x-1.5">

--- a/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
@@ -25,6 +25,7 @@ import {
   setMonacoModelLanguage,
 } from "@/react/components/monaco/core";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Combobox, type ComboboxOption } from "@/react/components/ui/combobox";
 import {
   Dialog,
@@ -2102,13 +2103,12 @@ function TargetDatabasesSelectPanel({
                 <thead>
                   <tr className="border-b">
                     <th className="py-2 px-2 w-8 text-left">
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={
                           filteredDatabases.length > 0 &&
                           filteredDatabases.every((db) => selected.has(db.name))
                         }
-                        onChange={toggleAll}
+                        onCheckedChange={toggleAll}
                       />
                     </th>
                     <th className="py-2 px-2 text-left font-medium">
@@ -2133,10 +2133,9 @@ function TargetDatabasesSelectPanel({
                         className="py-2 px-2"
                         onClick={(e) => e.stopPropagation()}
                       >
-                        <input
-                          type="checkbox"
+                        <Checkbox
                           checked={selected.has(db.name)}
-                          onChange={() => toggleDatabase(db.name)}
+                          onCheckedChange={() => toggleDatabase(db.name)}
                         />
                       </td>
                       <td className="py-2 px-2">

--- a/frontend/src/react/pages/project/ProjectWebhookForm.tsx
+++ b/frontend/src/react/pages/project/ProjectWebhookForm.tsx
@@ -4,6 +4,7 @@ import { EllipsisVertical, Info } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -466,11 +467,10 @@ export function ProjectWebhookForm({
                 <div key={item.activity}>
                   <div className="flex items-center gap-x-1">
                     <label className="flex items-center gap-x-2 cursor-pointer">
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={isEventOn(item.activity)}
-                        onChange={(e) =>
-                          toggleEvent(item.activity, e.target.checked)
+                        onCheckedChange={(checked) =>
+                          toggleEvent(item.activity, checked)
                         }
                       />
                       <span className="text-sm">{item.title}</span>
@@ -529,12 +529,11 @@ export function ProjectWebhookForm({
               </span>
               <div className="flex items-center mt-2">
                 <label className="flex items-center gap-x-2 cursor-pointer">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={state.directMessage}
                     disabled={!activitySupportDirectMessage}
-                    onChange={(e) =>
-                      updateField("directMessage", e.target.checked)
+                    onCheckedChange={(checked) =>
+                      updateField("directMessage", checked)
                     }
                   />
                   <span className="text-sm">

--- a/frontend/src/react/pages/project/database-detail/catalog/SensitiveColumnTable.tsx
+++ b/frontend/src/react/pages/project/database-detail/catalog/SensitiveColumnTable.tsx
@@ -1,8 +1,9 @@
 import { Trash2 } from "lucide-react";
-import { useEffect, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { MaskData } from "@/components/SensitiveData/types";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -114,7 +115,6 @@ export function SensitiveColumnTable({
   onDelete: (item: MaskData) => void;
 }) {
   const { t } = useTranslation();
-  const headerCheckboxRef = useRef<HTMLInputElement>(null);
   const checkedKeySet = useMemo(
     () => new Set(checkedColumnList.map(itemKey)),
     [checkedColumnList]
@@ -128,15 +128,6 @@ export function SensitiveColumnTable({
     columnList.length > 0 && visibleSelectedCount === columnList.length;
   const someSelected =
     visibleSelectedCount > 0 && visibleSelectedCount < columnList.length;
-
-  useEffect(() => {
-    if (headerCheckboxRef.current) {
-      headerCheckboxRef.current.indeterminate = someSelected;
-      if (!someSelected) {
-        headerCheckboxRef.current.indeterminate = false;
-      }
-    }
-  }, [someSelected]);
 
   const toggleSelection = (item: MaskData) => {
     const key = itemKey(item);
@@ -175,13 +166,10 @@ export function SensitiveColumnTable({
           <TableRow className="hover:bg-control-bg">
             {showSelectionColumn && (
               <TableHead className="w-12">
-                <input
-                  ref={headerCheckboxRef}
-                  type="checkbox"
-                  checked={allSelected}
-                  onChange={toggleSelectAll}
+                <Checkbox
+                  checked={someSelected ? "indeterminate" : allSelected}
+                  onCheckedChange={toggleSelectAll}
                   onClick={(event) => event.stopPropagation()}
-                  className="rounded-xs border-control-border"
                 />
               </TableHead>
             )}
@@ -224,12 +212,10 @@ export function SensitiveColumnTable({
                 >
                   {showSelectionColumn && (
                     <TableCell className="w-12">
-                      <input
-                        type="checkbox"
+                      <Checkbox
                         checked={isChecked}
-                        onChange={() => toggleSelection(item)}
+                        onCheckedChange={() => toggleSelection(item)}
                         onClick={(event) => event.stopPropagation()}
-                        className="rounded-xs border-control-border"
                       />
                     </TableCell>
                   )}

--- a/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ColumnDataTable/utils";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -1195,12 +1196,7 @@ export function TableDetailDialog({
                         {column.defaultValue}
                       </td>
                       <td className="px-4 py-3 text-sm text-control">
-                        <input
-                          checked={column.nullable}
-                          disabled
-                          readOnly
-                          type="checkbox"
-                        />
+                        <Checkbox checked={column.nullable} disabled />
                       </td>
                       {showCharacterSetColumn && (
                         <td className="px-4 py-3 text-sm text-control">

--- a/frontend/src/react/pages/project/database-detail/revision/DatabaseRevisionTable.tsx
+++ b/frontend/src/react/pages/project/database-detail/revision/DatabaseRevisionTable.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -31,13 +31,6 @@ export function DatabaseRevisionTable({
     revisions.length > 0 && selectedNames.size === revisions.length;
   const someSelected =
     selectedNames.size > 0 && selectedNames.size < revisions.length;
-  const headerCheckboxRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    if (headerCheckboxRef.current) {
-      headerCheckboxRef.current.indeterminate = someSelected;
-    }
-  }, [someSelected]);
-
   const toggleSelectAll = () => {
     if (allSelected) {
       onSelectedNamesChange(new Set());
@@ -67,12 +60,9 @@ export function DatabaseRevisionTable({
       <TableHeader className="bg-control-bg">
         <TableRow>
           <TableHead className="w-12">
-            <input
-              ref={headerCheckboxRef}
-              type="checkbox"
-              checked={allSelected}
-              onChange={toggleSelectAll}
-              className="rounded-xs border-control-border"
+            <Checkbox
+              checked={someSelected ? "indeterminate" : allSelected}
+              onCheckedChange={toggleSelectAll}
             />
           </TableHead>
           <TableHead>{t("common.version")}</TableHead>
@@ -91,12 +81,10 @@ export function DatabaseRevisionTable({
             onClick={() => void router.push(revisionLink(revision))}
           >
             <TableCell className="w-12">
-              <input
-                type="checkbox"
+              <Checkbox
                 checked={selectedNames.has(revision.name)}
-                onChange={() => toggleSelection(revision.name)}
+                onCheckedChange={() => toggleSelection(revision.name)}
                 onClick={(e) => e.stopPropagation()}
-                className="rounded-xs border-control-border"
               />
             </TableCell>
             <TableCell className="text-main">

--- a/frontend/src/react/pages/project/export-center/DataExportPrepSheet.tsx
+++ b/frontend/src/react/pages/project/export-center/DataExportPrepSheet.tsx
@@ -7,6 +7,7 @@ import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { IssueLabelSelect } from "@/react/components/IssueLabelSelect";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
@@ -785,14 +786,9 @@ function DatabaseSelector({
             <thead>
               <tr className="border-b text-left text-control-light">
                 <th className="py-2 pr-2 w-8">
-                  <input
-                    type="checkbox"
-                    checked={allSelected}
-                    ref={(el) => {
-                      if (el) el.indeterminate = someSelected;
-                    }}
-                    onChange={toggleAll}
-                    className="accent-accent"
+                  <Checkbox
+                    checked={someSelected ? "indeterminate" : allSelected}
+                    onCheckedChange={toggleAll}
                   />
                 </th>
                 <th className="py-2 pr-4 font-medium">
@@ -819,12 +815,7 @@ function DatabaseSelector({
                     onClick={() => toggleDatabase(db.name)}
                   >
                     <td className="py-2 pr-2">
-                      <input
-                        type="checkbox"
-                        checked={isSelected}
-                        readOnly
-                        className="accent-accent"
-                      />
+                      <Checkbox checked={isSelected} />
                     </td>
                     <td className="py-2 pr-4">
                       <div className="flex items-center gap-x-1.5">

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { Alert } from "@/react/components/ui/alert";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
   useAccessGrantStore,
@@ -124,13 +125,7 @@ export function IssueDetailAccessGrantDetails() {
                 </pre>
               </div>
               <label className="flex items-center gap-2">
-                <input
-                  checked={accessGrant.unmask}
-                  className="h-4 w-4"
-                  disabled
-                  readOnly
-                  type="checkbox"
-                />
+                <Checkbox checked={accessGrant.unmask} disabled />
                 <span className="text-base">
                   {t("sql-editor.access-type-unmask")}
                 </span>

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailLabels.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailLabels.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { issueServiceClientConnect } from "@/connect";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
 import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -225,12 +226,7 @@ export function IssueDetailLabels() {
                       }}
                       type="button"
                     >
-                      <input
-                        checked={isSelected}
-                        className="accent-accent"
-                        readOnly
-                        type="checkbox"
-                      />
+                      <Checkbox checked={isSelected} />
                       <span
                         className="size-4 shrink-0 rounded-sm"
                         style={{ backgroundColor: option.color }}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import {
   Sheet,
@@ -423,13 +424,9 @@ export function IssueDetailTaskRolloutActionPanel({
             {action === "RUN" && hasPriorBackupTasks && (
               <div className="flex flex-col">
                 <label className="inline-flex items-center gap-x-2 text-sm">
-                  <input
+                  <Checkbox
                     checked={skipPriorBackup}
-                    className="h-4 w-4 rounded border-control-border"
-                    onChange={(event) =>
-                      setSkipPriorBackup(event.target.checked)
-                    }
-                    type="checkbox"
+                    onCheckedChange={(checked) => setSkipPriorBackup(checked)}
                   />
                   <span>{t("task.skip-prior-backup")}</span>
                 </label>

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -21,6 +21,7 @@ import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { Alert } from "@/react/components/ui/alert";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -1472,20 +1473,15 @@ function DatabaseSelector({
             <thead>
               <tr className="border-b text-left text-control-light">
                 <th className="w-8 py-2 pr-2">
-                  <input
-                    type="checkbox"
-                    checked={allSelected}
-                    ref={(el) => {
-                      if (el) el.indeterminate = someSelected;
-                    }}
-                    onChange={() =>
+                  <Checkbox
+                    checked={someSelected ? "indeterminate" : allSelected}
+                    onCheckedChange={() =>
                       onSelectedNamesChange(
                         allSelected
                           ? new Set()
                           : new Set(databases.map((db) => db.name))
                       )
                     }
-                    className="accent-accent"
                   />
                 </th>
                 <th className="py-2 pr-4 font-medium">
@@ -1518,12 +1514,7 @@ function DatabaseSelector({
                     onClick={() => toggleDatabase(db.name)}
                   >
                     <td className="py-2 pr-2">
-                      <input
-                        type="checkbox"
-                        checked={isSelected}
-                        readOnly
-                        className="accent-accent"
-                      />
+                      <Checkbox checked={isSelected} />
                     </td>
                     <td className="py-2 pr-4">
                       <div className="flex items-center gap-x-1.5">

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailDeployFuture.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailDeployFuture.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
 import { Alert, AlertTitle } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Sheet,
   SheetBody,
@@ -360,12 +361,10 @@ export function PlanDetailDeployFuture() {
           <SheetFooter className="justify-between">
             {warningMessages.length > 0 && errorMessages.length === 0 ? (
               <label className="flex items-center gap-x-2 text-sm text-control">
-                <input
+                <Checkbox
                   checked={bypassWarnings}
-                  className="accent-accent"
                   disabled={creatingRollout}
-                  onChange={(event) => setBypassWarnings(event.target.checked)}
-                  type="checkbox"
+                  onCheckedChange={(checked) => setBypassWarnings(checked)}
                 />
                 <span>{t("rollout.bypass-stage-requirements")}</span>
               </label>

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/react/components/IssueLabelSelect";
 import { MarkdownEditor } from "@/react/components/MarkdownEditor";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Popover,
   PopoverContent,
@@ -713,13 +714,11 @@ function ReadyForReviewPopoverContent({
       />
       {showChecksWarning && (
         <label className="flex items-center gap-x-2 text-sm text-control">
-          <input
+          <Checkbox
             checked={checksWarningAcknowledged}
-            className="accent-accent"
-            onChange={(event) =>
-              onChecksWarningAcknowledgedChange(event.target.checked)
+            onCheckedChange={(checked) =>
+              onChecksWarningAcknowledgedChange(checked)
             }
-            type="checkbox"
           />
           <span>
             {t("issue.action-anyway", {

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailMetadataSidebar.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailMetadataSidebar.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { issueServiceClientConnect } from "@/connect";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Popover,
   PopoverContent,
@@ -367,12 +368,7 @@ function IssueLabelsSection({
                     onClick={() => void toggleLabel(option.value)}
                     type="button"
                   >
-                    <input
-                      checked={isSelected}
-                      className="accent-accent"
-                      readOnly
-                      type="checkbox"
-                    />
+                    <Checkbox checked={isSelected} />
                     <span
                       className="size-4 shrink-0 rounded-sm"
                       style={{ backgroundColor: option.color }}

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.tsx
@@ -13,6 +13,7 @@ import { ReadonlyMonaco } from "@/react/components/monaco";
 import { Alert } from "@/react/components/ui/alert";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Sheet,
   SheetBody,
@@ -182,12 +183,11 @@ export function PlanDetailRollbackSheet({
                       key={item.taskRun.name}
                       className="flex cursor-pointer items-center gap-3 border-b border-control-border px-3 py-2 last:border-b-0 hover:bg-gray-50"
                     >
-                      <input
+                      <Checkbox
                         checked={checked}
-                        className="accent-accent"
-                        onChange={(event) => {
+                        onCheckedChange={(checked) => {
                           setSelectedTaskRunNames((prev) => {
-                            if (event.target.checked) {
+                            if (checked) {
                               return [...prev, item.taskRun.name];
                             }
                             return prev.filter(
@@ -195,7 +195,6 @@ export function PlanDetailRollbackSheet({
                             );
                           });
                         }}
-                        type="checkbox"
                       />
                       <div className="min-w-0 space-y-1">
                         <div className="min-w-0 text-sm font-medium text-main">

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
 import {
@@ -408,13 +409,9 @@ export function PlanDetailTaskRolloutActionPanel({
             {action === "RUN" && hasPriorBackupTasks && (
               <div className="flex flex-col">
                 <label className="inline-flex items-center gap-x-2 text-sm">
-                  <input
+                  <Checkbox
                     checked={skipPriorBackup}
-                    className="h-4 w-4 rounded border-control-border"
-                    onChange={(event) =>
-                      setSkipPriorBackup(event.target.checked)
-                    }
-                    type="checkbox"
+                    onCheckedChange={(checked) => setSkipPriorBackup(checked)}
                   />
                   <span>{t("task.skip-prior-backup")}</span>
                 </label>

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
@@ -11,6 +11,7 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ReadonlyMonaco } from "@/react/components/monaco";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { cn } from "@/react/lib/utils";
 import { router } from "@/router";
 import { getTimeForPbTimestampProtoEs } from "@/types";
@@ -152,13 +153,12 @@ export function DeployTaskItem({
         >
           <div className="flex items-center justify-between gap-x-3">
             <div className="flex min-w-0 flex-1 items-center gap-x-2">
-              <input
+              <Checkbox
                 checked={isSelected}
-                className="shrink-0 accent-accent"
+                className="shrink-0"
                 disabled={!isSelectable}
-                onChange={() => onToggleSelect()}
+                onCheckedChange={() => onToggleSelect()}
                 onClick={(event) => event.stopPropagation()}
-                type="checkbox"
               />
               <DeployTaskStatus
                 size={isExpanded ? "large" : "small"}

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskToolbar.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskToolbar.tsx
@@ -1,7 +1,8 @@
 import { Play, SkipForward, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
 import type { Stage, Task } from "@/types/proto-es/v1/rollout_service_pb";
@@ -42,8 +43,6 @@ export function DeployTaskToolbar({
     PlanDetailTaskRolloutAction | undefined
   >(undefined);
   const [permissionReady, setPermissionReady] = useState(false);
-  const checkboxRef = useRef<HTMLInputElement | null>(null);
-
   useEffect(() => {
     let canceled = false;
     const load = async () => {
@@ -106,14 +105,6 @@ export function DeployTaskToolbar({
     count: selectedTasks.length,
   });
 
-  useEffect(() => {
-    if (checkboxRef.current) {
-      checkboxRef.current.indeterminate =
-        selectedTasks.length > 0 &&
-        selectedTasks.length < selectableTasks.length;
-    }
-  }, [selectableTasks.length, selectedTasks.length]);
-
   return (
     <>
       <div className="sticky top-0 z-10 px-4">
@@ -127,19 +118,19 @@ export function DeployTaskToolbar({
               }
             >
               <div>
-                <input
+                <Checkbox
                   checked={
                     selectedTasks.length > 0 &&
-                    selectedTasks.length === selectableTasks.length
+                    selectedTasks.length < selectableTasks.length
+                      ? "indeterminate"
+                      : selectedTasks.length > 0 &&
+                        selectedTasks.length === selectableTasks.length
                   }
-                  className="accent-accent"
                   disabled={selectableTasks.length === 0}
-                  ref={checkboxRef}
-                  onChange={(event) => {
-                    if (event.target.checked) onSelectAll();
+                  onCheckedChange={(checked) => {
+                    if (checked) onSelectAll();
                     else onClearSelection();
                   }}
-                  type="checkbox"
                 />
               </div>
             </Tooltip>

--- a/frontend/src/react/pages/settings/EnvironmentsPage.tsx
+++ b/frontend/src/react/pages/settings/EnvironmentsPage.tsx
@@ -33,6 +33,7 @@ import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { ResourceIdField } from "@/react/components/ResourceIdField";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -890,12 +891,10 @@ function EnvironmentDetail({
               </p>
             </div>
             <label className="inline-flex items-center gap-x-2 cursor-pointer">
-              <input
-                type="checkbox"
+              <Checkbox
                 checked={editProtected}
                 disabled={!canEdit}
-                onChange={(e) => setEditProtected(e.target.checked)}
-                className="rounded-xs border-gray-300"
+                onCheckedChange={(checked) => setEditProtected(checked)}
               />
               <span className="text-sm">
                 {t("policy.environment-tier.mark-env-as-production")}
@@ -992,11 +991,10 @@ function EnvironmentDetail({
             <div className="mt-3">
               {existRelatedResource && (
                 <label className="flex items-start gap-x-2 mb-2">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={confirmDelete}
-                    onChange={(e) => setConfirmDelete(e.target.checked)}
-                    className="mt-0.5 rounded-xs border-gray-300"
+                    onCheckedChange={(checked) => setConfirmDelete(checked)}
+                    className="mt-0.5"
                   />
                   <span className="text-sm text-gray-600">
                     {t("environment.delete-description")}
@@ -1188,11 +1186,9 @@ function CreateSheet({
                 {t("policy.environment-tier.description", { newline: "\n" })}
               </p>
               <label className="inline-flex items-center gap-x-2 cursor-pointer">
-                <input
-                  type="checkbox"
+                <Checkbox
                   checked={isProtected}
-                  onChange={(e) => setIsProtected(e.target.checked)}
-                  className="rounded-xs border-gray-300"
+                  onCheckedChange={(checked) => setIsProtected(checked)}
                 />
                 <span className="text-sm">
                   {t("policy.environment-tier.mark-env-as-production")}

--- a/frontend/src/react/pages/settings/IDPDetailPage.tsx
+++ b/frontend/src/react/pages/settings/IDPDetailPage.tsx
@@ -15,6 +15,7 @@ import {
   AlertDialogTitle,
 } from "@/react/components/ui/alert-dialog";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -547,13 +548,12 @@ function ProviderConfigForm({
             {t("settings.sso.form.security-options")}
           </label>
           <label className="flex items-center gap-x-2 cursor-pointer">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={configForOAuth2.skipTlsVerify}
-              onChange={(e) =>
+              onCheckedChange={(checked) =>
                 onUpdateOAuth2({
                   ...configForOAuth2,
-                  skipTlsVerify: e.target.checked,
+                  skipTlsVerify: checked,
                 })
               }
             />
@@ -695,13 +695,12 @@ function ProviderConfigForm({
             {t("settings.sso.form.security-options")}
           </label>
           <label className="flex items-center gap-x-2 cursor-pointer">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={configForOIDC.skipTlsVerify}
-              onChange={(e) =>
+              onCheckedChange={(checked) =>
                 onUpdateOIDC({
                   ...configForOIDC,
-                  skipTlsVerify: e.target.checked,
+                  skipTlsVerify: checked,
                 })
               }
             />
@@ -914,13 +913,12 @@ function ProviderConfigForm({
             {t("settings.sso.form.security-options")}
           </label>
           <label className="flex items-center gap-x-2 cursor-pointer">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={configForLDAP.skipTlsVerify}
-              onChange={(e) =>
+              onCheckedChange={(checked) =>
                 onUpdateLDAP({
                   ...configForLDAP,
-                  skipTlsVerify: e.target.checked,
+                  skipTlsVerify: checked,
                 })
               }
             />

--- a/frontend/src/react/pages/settings/IDPsPage.tsx
+++ b/frontend/src/react/pages/settings/IDPsPage.tsx
@@ -24,6 +24,7 @@ import {
   type ResourceIdFieldRef,
 } from "@/react/components/ResourceIdField";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -653,13 +654,12 @@ function ProviderConfigForm({
             {t("settings.sso.form.security-options")}
           </label>
           <label className="flex items-center gap-x-2 cursor-pointer">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={configForOAuth2.skipTlsVerify}
-              onChange={(e) =>
+              onCheckedChange={(checked) =>
                 onUpdateOAuth2({
                   ...configForOAuth2,
-                  skipTlsVerify: e.target.checked,
+                  skipTlsVerify: checked,
                 })
               }
             />
@@ -796,13 +796,12 @@ function ProviderConfigForm({
             {t("settings.sso.form.security-options")}
           </label>
           <label className="flex items-center gap-x-2 cursor-pointer">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={configForOIDC.skipTlsVerify}
-              onChange={(e) =>
+              onCheckedChange={(checked) =>
                 onUpdateOIDC({
                   ...configForOIDC,
-                  skipTlsVerify: e.target.checked,
+                  skipTlsVerify: checked,
                 })
               }
             />
@@ -1011,13 +1010,12 @@ function ProviderConfigForm({
             {t("settings.sso.form.security-options")}
           </label>
           <label className="flex items-center gap-x-2 cursor-pointer">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={configForLDAP.skipTlsVerify}
-              onChange={(e) =>
+              onCheckedChange={(checked) =>
                 onUpdateLDAP({
                   ...configForLDAP,
-                  skipTlsVerify: e.target.checked,
+                  skipTlsVerify: checked,
                 })
               }
             />

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -34,6 +34,7 @@ import {
   AlertDialogTitle,
 } from "@/react/components/ui/alert-dialog";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -404,11 +405,9 @@ function InstanceActionDropdown({
         }}
       >
         <label className="flex items-center gap-x-2 text-sm text-control-light mt-2">
-          <input
-            type="checkbox"
+          <Checkbox
             checked={forceArchive}
-            onChange={(e) => setForceArchive(e.target.checked)}
-            className="rounded-xs border-control-border"
+            onCheckedChange={(checked) => setForceArchive(checked)}
           />
           {t("instance.force-archive-description")}
         </label>
@@ -1118,35 +1117,24 @@ export function InstancesPage() {
     instances.length > 0 && selectedNames.size === instances.length;
   const someSelected =
     selectedNames.size > 0 && selectedNames.size < instances.length;
-  const headerCheckboxRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    if (headerCheckboxRef.current) {
-      headerCheckboxRef.current.indeterminate = someSelected;
-    }
-  }, [someSelected]);
   const pageSizeOptions = getPageSizeOptions();
 
   const columns: InstanceColumn[] = [
     {
       key: "select",
       title: (
-        <input
-          ref={headerCheckboxRef}
-          type="checkbox"
-          checked={allSelected}
-          onChange={toggleSelectAll}
-          className="rounded-xs border-control-border"
+        <Checkbox
+          checked={someSelected ? "indeterminate" : allSelected}
+          onCheckedChange={toggleSelectAll}
         />
       ),
       defaultWidth: 48,
       cellClassName: "px-4 py-2",
       render: (instance) => (
-        <input
-          type="checkbox"
+        <Checkbox
           checked={selectedNames.has(instance.name)}
-          onChange={() => toggleSelection(instance.name)}
+          onCheckedChange={() => toggleSelection(instance.name)}
           onClick={(e) => e.stopPropagation()}
-          className="rounded-xs border-control-border"
         />
       ),
     },

--- a/frontend/src/react/pages/settings/LandingPage.tsx
+++ b/frontend/src/react/pages/settings/LandingPage.tsx
@@ -23,6 +23,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { ProjectSwitchDialog } from "@/react/components/header/ProjectSwitchDialog";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Sheet,
   SheetBody,
@@ -392,11 +393,10 @@ function ConfigSheet({
               className="flex items-center justify-between p-2 hover:bg-gray-100 rounded-sm cursor-grab"
             >
               <div className="flex items-center gap-x-2">
-                <input
-                  type="checkbox"
-                  checked
+                <Checkbox
+                  checked={true}
                   disabled={selected.length <= 1}
-                  onChange={() => uncheck(item.id)}
+                  onCheckedChange={() => uncheck(item.id)}
                 />
                 <item.icon className="w-5 h-5 text-gray-500" />
                 {item.title}
@@ -413,7 +413,7 @@ function ConfigSheet({
               className="flex items-center gap-x-2 p-2 hover:bg-gray-100 rounded-sm cursor-pointer"
               onClick={() => check(item.id)}
             >
-              <input type="checkbox" checked={false} readOnly />
+              <Checkbox checked={false} />
               <item.icon className="w-5 h-5 text-gray-500" />
               {item.title}
             </div>

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/react/components/ui/alert";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
@@ -237,11 +238,7 @@ function MemberTable({
           <TableRow>
             {allowEdit && (
               <TableHead className="w-10">
-                <input
-                  type="checkbox"
-                  checked={allSelected}
-                  onChange={toggleAll}
-                />
+                <Checkbox checked={allSelected} onCheckedChange={toggleAll} />
               </TableHead>
             )}
             <TableHead>{t("settings.members.table.account")}</TableHead>
@@ -254,11 +251,10 @@ function MemberTable({
             <TableRow key={mb.binding}>
               {allowEdit && (
                 <TableCell>
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={selectedBindings.includes(mb.binding)}
                     disabled={isSelectDisabled(mb)}
-                    onChange={() => toggleOne(mb.binding)}
+                    onCheckedChange={() => toggleOne(mb.binding)}
                   />
                 </TableCell>
               )}

--- a/frontend/src/react/pages/settings/PurchaseSection.tsx
+++ b/frontend/src/react/pages/settings/PurchaseSection.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { useSubscriptionState } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
@@ -508,10 +509,11 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
                     ) : card.selfServicePurchase ? (
                       <>
                         <label className="mt-3 flex items-start gap-x-2 text-sm text-control-placeholder cursor-pointer">
-                          <input
-                            type="checkbox"
+                          <Checkbox
                             checked={checkPolicy}
-                            onChange={(e) => setCheckPolicy(e.target.checked)}
+                            onCheckedChange={(checked) =>
+                              setCheckPolicy(checked)
+                            }
                             className="mt-0.5"
                           />
                           <span>

--- a/frontend/src/react/pages/settings/SQLReviewPage.tsx
+++ b/frontend/src/react/pages/settings/SQLReviewPage.tsx
@@ -6,6 +6,7 @@ import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { ResourceLink } from "@/react/components/sql-review/ResourceLink";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
   Table,
@@ -116,11 +117,11 @@ function PolicyTable({
                 <TableCell>{policy.ruleList.length}</TableCell>
                 <TableCell>
                   {hasUpdatePermission ? (
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={policy.enforce}
-                      onChange={(e) => toggleEnabled(policy, e.target.checked)}
-                      className="h-4 w-4 rounded-xs border-control-border accent-accent"
+                      onCheckedChange={(checked) =>
+                        toggleEnabled(policy, checked)
+                      }
                     />
                   ) : policy.enforce ? (
                     <Check className="w-4 h-4 text-control-light" />

--- a/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
+++ b/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
@@ -8,6 +8,7 @@ import { RoleSelect } from "@/react/components/RoleSelect";
 import { UserAvatar } from "@/react/components/UserAvatar";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import {
   Sheet,
@@ -827,10 +828,9 @@ export function ServiceAccountsPage({ projectId }: { projectId?: string }) {
 
         {/* Inactive toggle */}
         <label className="flex items-center gap-x-2 text-sm cursor-pointer">
-          <input
-            type="checkbox"
+          <Checkbox
             checked={showInactive}
-            onChange={(e) => setShowInactive(e.target.checked)}
+            onCheckedChange={(checked) => setShowInactive(checked)}
           />
           <span className="textinfolabel">
             {t("settings.members.show-inactive")}

--- a/frontend/src/react/pages/settings/UsersPage.tsx
+++ b/frontend/src/react/pages/settings/UsersPage.tsx
@@ -19,6 +19,7 @@ import { RoleSelect } from "@/react/components/RoleSelect";
 import { UserAvatar } from "@/react/components/UserAvatar";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
@@ -1062,10 +1063,9 @@ export function UsersPage() {
         {/* Inactive users toggle (only shown with list permission) */}
         {hasUserListPermission && (
           <label className="flex items-center gap-x-2 text-sm cursor-pointer">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={showInactiveUsers}
-              onChange={(e) => setShowInactiveUsers(e.target.checked)}
+              onCheckedChange={(checked) => setShowInactiveUsers(checked)}
             />
             {t("settings.members.show-inactive")}
           </label>

--- a/frontend/src/react/pages/settings/WorkloadIdentitiesPage.tsx
+++ b/frontend/src/react/pages/settings/WorkloadIdentitiesPage.tsx
@@ -5,6 +5,7 @@ import { CreateWorkloadIdentitySheet } from "@/react/components/CreateWorkloadId
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { UserAvatar } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -404,10 +405,9 @@ export function WorkloadIdentitiesPage({ projectId }: { projectId?: string }) {
 
         {/* Show inactive toggle */}
         <label className="flex items-center gap-x-2 text-sm cursor-pointer">
-          <input
-            type="checkbox"
+          <Checkbox
             checked={showInactive}
-            onChange={(e) => setShowInactive(e.target.checked)}
+            onCheckedChange={(checked) => setShowInactive(checked)}
           />
           <span className="textinfolabel">
             {t("settings.members.show-inactive")}

--- a/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
+++ b/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
@@ -13,6 +13,7 @@ import { ComponentPermissionGuard } from "@/react/components/ComponentPermission
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { Alert } from "@/react/components/ui/alert";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { useServerState } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -232,11 +233,10 @@ export const AIAugmentationSection = forwardRef<
                 {/* Enable toggle */}
                 <div>
                   <div className="flex items-center gap-x-2">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={state.enabled}
                       disabled={!canEdit}
-                      onChange={(e) => toggleEnabled(e.target.checked)}
+                      onCheckedChange={(checked) => toggleEnabled(checked)}
                     />
                     <span className="text-base font-semibold">
                       {t(

--- a/frontend/src/react/pages/settings/general/AccountSection.tsx
+++ b/frontend/src/react/pages/settings/general/AccountSection.tsx
@@ -17,6 +17,7 @@ import {
   PermissionGuard,
   usePermissionCheck,
 } from "@/react/components/PermissionGuard";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { NumberInput } from "@/react/components/ui/number-input";
 import { usePlanFeature, useServerState } from "@/react/hooks/useAppState";
@@ -427,14 +428,13 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
               <>
                 <div className="mt-4 lg:mt-0">
                   <div className="flex items-center gap-x-2">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={toggleState.disallowSignup}
                       disabled={disabled || !hasDisallowSignupFeature}
-                      onChange={(e) =>
+                      onCheckedChange={(checked) =>
                         setToggleState((s) => ({
                           ...s,
-                          disallowSignup: e.target.checked,
+                          disallowSignup: checked,
                         }))
                       }
                     />
@@ -491,13 +491,12 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                   </span>
                 </div>
                 <label className="flex items-center gap-x-2">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={passwordState.requireNumber}
                     disabled={disabled || !hasPasswordFeature}
-                    onChange={(e) =>
+                    onCheckedChange={(checked) =>
                       updatePasswordField({
-                        requireNumber: e.target.checked,
+                        requireNumber: checked,
                       })
                     }
                   />
@@ -506,13 +505,12 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                   )}
                 </label>
                 <label className="flex items-center gap-x-2">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={passwordState.requireLetter}
                     disabled={disabled || !hasPasswordFeature}
-                    onChange={(e) =>
+                    onCheckedChange={(checked) =>
                       updatePasswordField({
-                        requireLetter: e.target.checked,
+                        requireLetter: checked,
                       })
                     }
                   />
@@ -521,13 +519,12 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                   )}
                 </label>
                 <label className="flex items-center gap-x-2">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={passwordState.requireUppercaseLetter}
                     disabled={disabled || !hasPasswordFeature}
-                    onChange={(e) =>
+                    onCheckedChange={(checked) =>
                       updatePasswordField({
-                        requireUppercaseLetter: e.target.checked,
+                        requireUppercaseLetter: checked,
                       })
                     }
                   />
@@ -536,13 +533,12 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                   )}
                 </label>
                 <label className="flex items-center gap-x-2">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={passwordState.requireSpecialCharacter}
                     disabled={disabled || !hasPasswordFeature}
-                    onChange={(e) =>
+                    onCheckedChange={(checked) =>
                       updatePasswordField({
-                        requireSpecialCharacter: e.target.checked,
+                        requireSpecialCharacter: checked,
                       })
                     }
                   />
@@ -551,13 +547,12 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                   )}
                 </label>
                 <label className="flex items-center gap-x-2">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={passwordState.requireResetPasswordForFirstLogin}
                     disabled={disabled || !hasPasswordFeature}
-                    onChange={(e) =>
+                    onCheckedChange={(checked) =>
                       updatePasswordField({
-                        requireResetPasswordForFirstLogin: e.target.checked,
+                        requireResetPasswordForFirstLogin: checked,
                       })
                     }
                   />
@@ -566,12 +561,11 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                   )}
                 </label>
                 <label className="flex items-center gap-x-2">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={!!passwordState.passwordRotation}
                     disabled={disabled || !hasPasswordFeature}
-                    onChange={(e) => {
-                      if (e.target.checked) {
+                    onCheckedChange={(checked) => {
+                      if (checked) {
                         updatePasswordField({
                           passwordRotation: create(DurationSchema, {
                             seconds: BigInt(7 * 24 * 60 * 60),
@@ -634,14 +628,13 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
             <div className="flex flex-col gap-y-7">
               <div className="mt-4 lg:mt-0">
                 <div className="flex items-center gap-x-2">
-                  <input
-                    type="checkbox"
+                  <Checkbox
                     checked={toggleState.requireMfa}
                     disabled={disabled || !has2FAFeature}
-                    onChange={(e) =>
+                    onCheckedChange={(checked) =>
                       setToggleState((s) => ({
                         ...s,
-                        requireMfa: e.target.checked,
+                        requireMfa: checked,
                       }))
                     }
                   />
@@ -659,8 +652,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
               {!isSaaSMode && (
                 <div className="lg:mt-0">
                   <div className="flex items-center gap-x-2">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={toggleState.disallowPasswordSignin}
                       disabled={
                         disabled ||
@@ -668,10 +660,10 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
                         (!toggleState.disallowPasswordSignin &&
                           !existActiveIdentityProvider)
                       }
-                      onChange={(e) =>
+                      onCheckedChange={(checked) =>
                         setToggleState((s) => ({
                           ...s,
-                          disallowPasswordSignin: e.target.checked,
+                          disallowPasswordSignin: checked,
                         }))
                       }
                     />
@@ -708,17 +700,16 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
               {!isSaaSMode && isDev() && (
                 <div className="lg:mt-0">
                   <div className="flex items-center gap-x-2">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={toggleState.allowEmailCodeSignin}
                       disabled={
                         disabled ||
                         (!toggleState.allowEmailCodeSignin && !hasEmailSetting)
                       }
-                      onChange={(e) =>
+                      onCheckedChange={(checked) =>
                         setToggleState((s) => ({
                           ...s,
-                          allowEmailCodeSignin: e.target.checked,
+                          allowEmailCodeSignin: checked,
                         }))
                       }
                     />

--- a/frontend/src/react/pages/settings/general/AuditLogSection.tsx
+++ b/frontend/src/react/pages/settings/general/AuditLogSection.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { usePlanFeature } from "@/react/hooks/useAppState";
 import { useSettingV1Store } from "@/store";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
@@ -86,15 +87,14 @@ export const AuditLogSection = forwardRef<SectionHandle, AuditLogSectionProps>(
         <div className="flex-1 lg:px-4 flex flex-col gap-y-6">
           {/* Audit log stdout toggle */}
           <label className="flex items-start gap-x-3 cursor-pointer">
-            <input
-              type="checkbox"
+            <Checkbox
+              checked={state.enableAuditLogStdout}
               className="mt-1"
               disabled={!allowEdit || !hasAuditLogFeature}
-              checked={state.enableAuditLogStdout}
-              onChange={(e) =>
+              onCheckedChange={(checked) =>
                 setState((s) => ({
                   ...s,
-                  enableAuditLogStdout: e.target.checked,
+                  enableAuditLogStdout: checked,
                 }))
               }
             />
@@ -110,15 +110,14 @@ export const AuditLogSection = forwardRef<SectionHandle, AuditLogSectionProps>(
 
           {/* Debug mode toggle */}
           <label className="flex items-start gap-x-3 cursor-pointer">
-            <input
-              type="checkbox"
+            <Checkbox
+              checked={state.enableDebug}
               className="mt-1"
               disabled={!allowEdit}
-              checked={state.enableDebug}
-              onChange={(e) =>
+              onCheckedChange={(checked) =>
                 setState((s) => ({
                   ...s,
-                  enableDebug: e.target.checked,
+                  enableDebug: checked,
                 }))
               }
             />

--- a/frontend/src/react/pages/settings/general/ProductImprovementSection.tsx
+++ b/frontend/src/react/pages/settings/general/ProductImprovementSection.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { useSettingV1Store } from "@/store";
 import type { SectionHandle } from "./useSettingSection";
 
@@ -73,15 +74,14 @@ export const ProductImprovementSection = forwardRef<
       </div>
       <div className="flex-1 lg:px-4">
         <label className="flex items-start gap-x-3 cursor-pointer">
-          <input
-            type="checkbox"
+          <Checkbox
+            checked={state.enableMetricCollection}
             className="mt-1"
             disabled={!allowEdit}
-            checked={state.enableMetricCollection}
-            onChange={(e) =>
+            onCheckedChange={(checked) =>
               setState((s) => ({
                 ...s,
-                enableMetricCollection: e.target.checked,
+                enableMetricCollection: checked,
               }))
             }
           />

--- a/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
+++ b/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { NumberInput } from "@/react/components/ui/number-input";
 import {
   usePlanFeature,
@@ -232,12 +233,12 @@ export const SQLEditorSection = forwardRef<
         {/* Data Export toggle */}
         <PermissionGuard permissions={["bb.policies.update"]} display="block">
           <div className="w-full inline-flex items-center gap-x-2">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={!state.disableExport}
               disabled={!canUpdatePolicy || !hasQueryPolicyFeature}
-              onChange={(e) => handleToggle("disableExport", !e.target.checked)}
-              className="h-4 w-4"
+              onCheckedChange={(checked) =>
+                handleToggle("disableExport", !checked)
+              }
             />
             <span className="text-base font-semibold">
               {t("settings.general.workspace.data-export")}
@@ -249,14 +250,12 @@ export const SQLEditorSection = forwardRef<
         {/* Data Copy toggle */}
         <PermissionGuard permissions={["bb.policies.update"]} display="block">
           <div className="w-full inline-flex items-center gap-x-2">
-            <input
-              type="checkbox"
+            <Checkbox
               checked={!state.disableCopyData}
               disabled={!canUpdatePolicy || !hasRestrictCopyingDataFeature}
-              onChange={(e) =>
-                handleToggle("disableCopyData", !e.target.checked)
+              onCheckedChange={(checked) =>
+                handleToggle("disableCopyData", !checked)
               }
-              className="h-4 w-4"
             />
             <span className="text-base font-semibold">
               {t("settings.general.workspace.data-copy")}
@@ -269,14 +268,12 @@ export const SQLEditorSection = forwardRef<
         <PermissionGuard permissions={["bb.policies.update"]} display="block">
           <div>
             <div className="w-full inline-flex items-center gap-x-2">
-              <input
-                type="checkbox"
+              <Checkbox
                 checked={state.allowAdminDataSource}
                 disabled={!canUpdatePolicy || !hasQueryPolicyFeature}
-                onChange={(e) =>
-                  handleToggle("allowAdminDataSource", e.target.checked)
+                onCheckedChange={(checked) =>
+                  handleToggle("allowAdminDataSource", checked)
                 }
-                className="h-4 w-4"
               />
               <span className="text-base font-semibold">
                 {t("settings.general.workspace.allow-admin-data-source.self")}

--- a/frontend/src/react/pages/settings/general/SecuritySection.tsx
+++ b/frontend/src/react/pages/settings/general/SecuritySection.tsx
@@ -16,6 +16,7 @@ import {
   PermissionGuard,
   usePermissionCheck,
 } from "@/react/components/PermissionGuard";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { usePlanFeature } from "@/react/hooks/useAppState";
 import { useSettingV1Store } from "@/store/modules/v1/setting";
@@ -214,14 +215,13 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
             {/* Watermark */}
             <div>
               <div className="flex items-center gap-x-2">
-                <input
-                  type="checkbox"
+                <Checkbox
                   checked={state.enableWatermark}
                   disabled={!canEdit || !hasWatermarkFeature}
-                  onChange={(e) =>
+                  onCheckedChange={(checked) =>
                     setState((prev) => ({
                       ...prev,
-                      enableWatermark: e.target.checked,
+                      enableWatermark: checked,
                     }))
                   }
                 />
@@ -274,14 +274,13 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
                     </span>
                   </div>
                   <label className="flex items-center gap-x-2">
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       checked={state.neverExpire}
                       disabled={!canEdit}
-                      onChange={(e) =>
+                      onCheckedChange={(checked) =>
                         setState((prev) => ({
                           ...prev,
-                          neverExpire: e.target.checked,
+                          neverExpire: checked,
                         }))
                       }
                     />
@@ -344,19 +343,18 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
                 {/* Enforce restriction checkbox */}
                 <div className="w-full flex flex-row justify-between items-center">
                   <label className="flex items-start gap-x-2">
-                    <input
-                      type="checkbox"
-                      className="mt-1"
+                    <Checkbox
                       checked={state.enableRestriction}
+                      className="mt-1"
                       disabled={
                         !canEdit ||
                         validDomains.length === 0 ||
                         !hasDomainRestrictionFeature
                       }
-                      onChange={(e) =>
+                      onCheckedChange={(checked) =>
                         setState((prev) => ({
                           ...prev,
-                          enableRestriction: e.target.checked,
+                          enableRestriction: checked,
                         }))
                       }
                     />


### PR DESCRIPTION
## Summary
- Replace visible React `input type="checkbox"` usages with the shared `Checkbox` UI component.
- Preserve declarative checked, disabled, click-stopping, and indeterminate selection behavior.
- Broaden `Checkbox` props to pass through Base UI root attributes used by migrated call sites.
- Document the React shared UI primitive preference in `AGENTS.md` so future UI work checks `frontend/src/react/components/ui/` before using native or ad hoc controls.

## Test plan
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
- `git diff --check`