### PR TITLE
fix: allow repeated database group plan targets

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -551,6 +551,7 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 	var releaseString string
 	var instanceIDs []string
 	var databaseGroups []string
+	seenDatabaseGroups := map[string]bool{}
 	var databaseNames []string
 	var databaseGroup *v1pb.DatabaseGroup
 
@@ -583,7 +584,10 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 					databaseNames = append(databaseNames, target)
 				} else if _, _, err := common.GetProjectIDDatabaseGroupID(target); err == nil {
 					databaseGroupTarget++
-					databaseGroups = append(databaseGroups, target)
+					if !seenDatabaseGroups[target] {
+						databaseGroups = append(databaseGroups, target)
+						seenDatabaseGroups[target] = true
+					}
 				} else {
 					return nil, errors.Errorf("invalid target %v", target)
 				}
@@ -609,7 +613,10 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 				if _, _, err := common.GetInstanceDatabaseID(target); err == nil {
 					databaseNames = append(databaseNames, target)
 				} else if _, _, err := common.GetProjectIDDatabaseGroupID(target); err == nil {
-					databaseGroups = append(databaseGroups, target)
+					if !seenDatabaseGroups[target] {
+						databaseGroups = append(databaseGroups, target)
+						seenDatabaseGroups[target] = true
+					}
 				} else {
 					return nil, errors.Errorf("invalid target %v", target)
 				}

--- a/backend/tests/tenant_test.go
+++ b/backend/tests/tenant_test.go
@@ -389,9 +389,10 @@ func TestCreatePlanWithRepeatedDatabaseGroupTarget(t *testing.T) {
 				Name: fmt.Sprintf("%s/planCheckRun", plan.Msg.Name),
 			}))
 			a.NoError(err)
-			if resp.Msg.Status == v1pb.PlanCheckRun_DONE || resp.Msg.Status == v1pb.PlanCheckRun_FAILED {
+			if resp.Msg.Status == v1pb.PlanCheckRun_DONE {
 				return
 			}
+			a.NotEqual(v1pb.PlanCheckRun_FAILED, resp.Msg.Status, resp.Msg.Error)
 		case <-timeout:
 			t.Fatal("timed out waiting for plan check run")
 		}

--- a/backend/tests/tenant_test.go
+++ b/backend/tests/tenant_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -299,6 +300,100 @@ func TestTenantBackfill(t *testing.T) {
 	for _, stage := range completedRollout.Msg.Stages {
 		for _, task := range stage.Tasks {
 			a.Equal(v1pb.Task_DONE, task.Status)
+		}
+	}
+}
+
+func TestCreatePlanWithRepeatedDatabaseGroupTarget(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	instanceDir, err := ctl.provisionSQLiteInstance(t.TempDir(), t.Name())
+	a.NoError(err)
+	instance, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       "prod-instance",
+			Engine:      v1pb.Engine_SQLITE,
+			Environment: new("environments/prod"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{Type: v1pb.DataSourceType_ADMIN, Host: instanceDir, Id: "admin"}},
+		},
+	}))
+	a.NoError(err)
+
+	err = ctl.createDatabase(ctx, ctl.project, instance.Msg, nil, "tenant_01", "")
+	a.NoError(err)
+
+	databaseGroup, err := ctl.databaseGroupServiceClient.CreateDatabaseGroup(ctx, connect.NewRequest(&v1pb.CreateDatabaseGroupRequest{
+		Parent:          ctl.project.Name,
+		DatabaseGroupId: "tenants",
+		DatabaseGroup: &v1pb.DatabaseGroup{
+			Title:        "All Tenants",
+			DatabaseExpr: &expr.Expr{Expression: "true"},
+		},
+	}))
+	a.NoError(err)
+
+	sheet1, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet:  &v1pb.Sheet{Content: []byte(`CREATE TABLE book(id INTEGER PRIMARY KEY);`)},
+	}))
+	a.NoError(err)
+	sheet2, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet:  &v1pb.Sheet{Content: []byte(`CREATE TABLE author(id INTEGER PRIMARY KEY);`)},
+	}))
+	a.NoError(err)
+
+	plan, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan: &v1pb.Plan{
+			Title: "Apply multiple changes to tenants",
+			Specs: []*v1pb.Plan_Spec{
+				{
+					Id: uuid.NewString(),
+					Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+							Targets: []string{databaseGroup.Msg.Name},
+							Sheet:   sheet1.Msg.Name,
+						},
+					},
+				},
+				{
+					Id: uuid.NewString(),
+					Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+							Targets: []string{databaseGroup.Msg.Name},
+							Sheet:   sheet2.Msg.Name,
+						},
+					},
+				},
+			},
+		},
+	}))
+	a.NoError(err)
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	timeout := time.After(30 * time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			resp, err := ctl.planServiceClient.GetPlanCheckRun(ctx, connect.NewRequest(&v1pb.GetPlanCheckRunRequest{
+				Name: fmt.Sprintf("%s/planCheckRun", plan.Msg.Name),
+			}))
+			a.NoError(err)
+			if resp.Msg.Status == v1pb.PlanCheckRun_DONE || resp.Msg.Status == v1pb.PlanCheckRun_FAILED {
+				return
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for plan check run")
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fix BYT-9399 by deduplicating database group targets during plan spec validation.
- Preserve the existing validation that rejects multiple distinct database groups and mixed database/database-group targets.
- Add a regression test for multi-change plans where multiple specs target the same database group.

## Test Plan
- [x] gofmt -w backend/api/v1/plan_service.go backend/tests/tenant_test.go
- [x] golangci-lint run --allow-parallel-runners
- [x] golangci-lint run --fix --allow-parallel-runners
- [x] go test -v -count=1 ./backend/tests/ -run ^TestCreatePlanWithRepeatedDatabaseGroupTarget$ -timeout 5m
- [x] go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go

## Checklist
- [x] Reviewed docs/pre-pr-checklist.md
- [x] No breaking changes
- [x] Composite-PK query safety skipped: no backend/store or backend/migrator changes
- [x] SonarCloud properties skipped: no new files or directories

Fixes BYT-9399.
