### PR TITLE
chore: migrate MSSQL diagnose to omni parser

### DIFF
--- a/backend/plugin/parser/tsql/diagnose.go
+++ b/backend/plugin/parser/tsql/diagnose.go
@@ -2,11 +2,11 @@ package tsql
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"unicode"
 
-	"github.com/antlr4-go/antlr/v4"
-	parser "github.com/bytebase/parser/tsql"
+	mssqlomniparser "github.com/bytebase/omni/mssql/parser"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
@@ -33,36 +33,24 @@ func parseTSQLStatement(statement string) *base.SyntaxError {
 		// for the last statement in the script.
 		statement += ";"
 	}
-	inputStream := antlr.NewInputStream(statement)
-	lexer := parser.NewTSqlLexer(inputStream)
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
 
-	p := parser.NewTSqlParser(stream)
-	startPosition := &storepb.Position{Line: 1}
-	lexerErrorListener := &base.ParseErrorListener{
-		Statement:     statement,
-		StartPosition: startPosition,
-	}
-	lexer.RemoveErrorListeners()
-	lexer.AddErrorListener(lexerErrorListener)
-
-	parserErrorListener := &base.ParseErrorListener{
-		Statement:     statement,
-		StartPosition: startPosition,
-	}
-	p.RemoveErrorListeners()
-	p.AddErrorListener(parserErrorListener)
-
-	p.BuildParseTrees = false
-
-	_ = p.Tsql_file()
-
-	if lexerErrorListener.Err != nil {
-		return lexerErrorListener.Err
+	_, err := ParseTSQLOmni(statement)
+	if err == nil {
+		return nil
 	}
 
-	if parserErrorListener.Err != nil {
-		return parserErrorListener.Err
+	var parseErr *mssqlomniparser.ParseError
+	if !errors.As(err, &parseErr) {
+		return &base.SyntaxError{
+			Position: &storepb.Position{Line: 1, Column: 1},
+			Message:  err.Error(),
+		}
 	}
-	return nil
+
+	message := parseErr.Error()
+	return &base.SyntaxError{
+		Position:   ByteOffsetToRunePosition(statement, parseErr.Position),
+		Message:    message,
+		RawMessage: message,
+	}
 }

--- a/backend/plugin/parser/tsql/diagnose_test.go
+++ b/backend/plugin/parser/tsql/diagnose_test.go
@@ -1,0 +1,53 @@
+package tsql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestDiagnoseUsesOmniParseError(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		message   string
+		line      uint32
+		character uint32
+	}{
+		{
+			name:      "single line",
+			statement: "SELECT FROM",
+			message:   `syntax error at or near "FROM"`,
+			line:      0,
+			character: 7,
+		},
+		{
+			name:      "second line",
+			statement: "SELECT 1;\nSELECT FROM",
+			message:   `syntax error at or near "FROM"`,
+			line:      1,
+			character: 7,
+		},
+		{
+			name:      "line after non-ascii",
+			statement: "SELECT N'你好';\nSELECT FROM",
+			message:   `syntax error at or near "FROM"`,
+			line:      1,
+			character: 7,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diagnostics, err := Diagnose(context.Background(), base.DiagnoseContext{}, tt.statement)
+			require.NoError(t, err)
+			require.Len(t, diagnostics, 1)
+			require.Equal(t, tt.message, diagnostics[0].Message)
+			require.Equal(t, tt.line, diagnostics[0].Range.Start.Line)
+			require.Equal(t, tt.character, diagnostics[0].Range.Start.Character)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Migrate MSSQL diagnose syntax checking from ANTLR to the omni T-SQL parser.
- Convert omni parse errors into existing Bytebase diagnostics with line and character positions.
- Add regression coverage for single-line, multi-line, and non-ASCII preceding-line parse error locations.

## Test Plan
- [x] go test -count=1 ./backend/plugin/parser/tsql
- [x] golangci-lint run --allow-parallel-runners
- [x] golangci-lint run --fix --allow-parallel-runners
- [x] go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go