### PR TITLE
refactor(advisor/tidb): extract index-family spine + fix TEXT regression on INDEX_TYPE_NO_BLOB (batch 8 follow-up)

### DIFF
--- a/backend/plugin/advisor/tidb/advisor_index_pk_type.go
+++ b/backend/plugin/advisor/tidb/advisor_index_pk_type.go
@@ -102,63 +102,17 @@ type pkData struct {
 }
 
 func (c *indexPkTypeChecker) checkStmt(ostmt OmniStmt) {
+	cb := indexFamilyCallbacks{
+		onColumn:       c.addNewColumn,
+		onConstraint:   c.addConstraint,
+		onChangeColumn: c.changeColumn,
+	}
 	var pkDataList []pkData
 	switch n := ostmt.Node.(type) {
 	case *ast.CreateTableStmt:
-		if n.Table == nil {
-			return
-		}
-		tableName := n.Table.Name
-		for _, column := range n.Columns {
-			if column == nil {
-				continue
-			}
-			pds := c.addNewColumn(tableName, ostmt.AbsoluteLine(column.Loc.Start), column)
-			pkDataList = append(pkDataList, pds...)
-		}
-		for _, constraint := range n.Constraints {
-			if constraint == nil {
-				continue
-			}
-			pds := c.addConstraint(tableName, ostmt.AbsoluteLine(constraint.Loc.Start), constraint)
-			pkDataList = append(pkDataList, pds...)
-		}
+		pkDataList = collectIndexFamilyCreateTable(ostmt, n, cb)
 	case *ast.AlterTableStmt:
-		if n.Table == nil {
-			return
-		}
-		tableName := n.Table.Name
-		stmtLine := ostmt.AbsoluteLine(n.Loc.Start)
-		for _, cmd := range n.Commands {
-			if cmd == nil {
-				continue
-			}
-			switch cmd.Type {
-			case ast.ATAddColumn:
-				for _, column := range addColumnTargets(cmd) {
-					pds := c.addNewColumn(tableName, stmtLine, column)
-					pkDataList = append(pkDataList, pds...)
-				}
-			case ast.ATAddConstraint:
-				if cmd.Constraint != nil {
-					pds := c.addConstraint(tableName, stmtLine, cmd.Constraint)
-					pkDataList = append(pkDataList, pds...)
-				}
-			case ast.ATChangeColumn, ast.ATModifyColumn:
-				if cmd.Column == nil {
-					continue
-				}
-				newColumnDef := cmd.Column
-				oldColumnName := newColumnDef.Name
-				if cmd.Type == ast.ATChangeColumn && cmd.Name != "" {
-					// CHANGE COLUMN: cmd.Name is the OLD column name.
-					oldColumnName = cmd.Name
-				}
-				pds := c.changeColumn(tableName, oldColumnName, stmtLine, newColumnDef)
-				pkDataList = append(pkDataList, pds...)
-			default:
-			}
-		}
+		pkDataList = collectIndexFamilyAlterTable(ostmt, n, cb)
 	default:
 		return
 	}

--- a/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
+++ b/backend/plugin/advisor/tidb/advisor_index_primary_key_type_allowlist.go
@@ -68,67 +68,17 @@ type indexPrimaryKeyTypeAllowlistChecker struct {
 }
 
 func (c *indexPrimaryKeyTypeAllowlistChecker) checkStmt(ostmt OmniStmt) {
+	cb := indexFamilyCallbacks{
+		onColumn:       c.addNewColumn,
+		onConstraint:   c.addConstraint,
+		onChangeColumn: c.changeColumn,
+	}
 	var pkDataList []pkData
 	switch n := ostmt.Node.(type) {
 	case *ast.CreateTableStmt:
-		if n.Table == nil {
-			return
-		}
-		tableName := n.Table.Name
-		for _, column := range n.Columns {
-			if column == nil {
-				continue
-			}
-			pds := c.addNewColumn(tableName, ostmt.AbsoluteLine(column.Loc.Start), column)
-			pkDataList = append(pkDataList, pds...)
-		}
-		for _, constraint := range n.Constraints {
-			if constraint == nil {
-				continue
-			}
-			pds := c.addConstraint(tableName, ostmt.AbsoluteLine(constraint.Loc.Start), constraint)
-			pkDataList = append(pkDataList, pds...)
-		}
+		pkDataList = collectIndexFamilyCreateTable(ostmt, n, cb)
 	case *ast.AlterTableStmt:
-		if n.Table == nil {
-			return
-		}
-		tableName := n.Table.Name
-		stmtLine := ostmt.AbsoluteLine(n.Loc.Start)
-		for _, cmd := range n.Commands {
-			if cmd == nil {
-				continue
-			}
-			switch cmd.Type {
-			case ast.ATAddColumn:
-				for _, column := range addColumnTargets(cmd) {
-					pds := c.addNewColumn(tableName, stmtLine, column)
-					pkDataList = append(pkDataList, pds...)
-				}
-			case ast.ATAddConstraint, ast.ATAddIndex:
-				// Empirically tidb omni emits only ATAddConstraint for
-				// `ALTER TABLE ... ADD …` forms (bare and named); ATAddIndex
-				// is reserved (not emitted). Dual arm preserved for sibling
-				// parity with the naming-convention advisors and mysql analog.
-				if cmd.Constraint != nil {
-					pds := c.addConstraint(tableName, stmtLine, cmd.Constraint)
-					pkDataList = append(pkDataList, pds...)
-				}
-			case ast.ATChangeColumn, ast.ATModifyColumn:
-				if cmd.Column == nil {
-					continue
-				}
-				newColumnDef := cmd.Column
-				oldColumnName := newColumnDef.Name
-				if cmd.Type == ast.ATChangeColumn && cmd.Name != "" {
-					// CHANGE COLUMN: cmd.Name is the OLD column name.
-					oldColumnName = cmd.Name
-				}
-				pds := c.changeColumn(tableName, oldColumnName, stmtLine, newColumnDef)
-				pkDataList = append(pkDataList, pds...)
-			default:
-			}
-		}
+		pkDataList = collectIndexFamilyAlterTable(ostmt, n, cb)
 	default:
 		return
 	}

--- a/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
+++ b/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
@@ -61,91 +61,19 @@ type indexTypeNoBlobChecker struct {
 }
 
 func (c *indexTypeNoBlobChecker) checkStmt(ostmt OmniStmt) {
+	cb := indexFamilyCallbacks{
+		onColumn:       c.addNewColumn,
+		onConstraint:   c.addConstraint,
+		onChangeColumn: c.changeColumn,
+	}
 	var pkDataList []pkData
 	switch n := ostmt.Node.(type) {
 	case *ast.CreateTableStmt:
-		if n.Table == nil {
-			return
-		}
-		tableName := n.Table.Name
-		for _, column := range n.Columns {
-			if column == nil {
-				continue
-			}
-			pds := c.addNewColumn(tableName, ostmt.AbsoluteLine(column.Loc.Start), column)
-			pkDataList = append(pkDataList, pds...)
-		}
-		for _, constraint := range n.Constraints {
-			if constraint == nil {
-				continue
-			}
-			pds := c.addConstraint(tableName, ostmt.AbsoluteLine(constraint.Loc.Start), constraint)
-			pkDataList = append(pkDataList, pds...)
-		}
+		pkDataList = collectIndexFamilyCreateTable(ostmt, n, cb)
 	case *ast.AlterTableStmt:
-		if n.Table == nil {
-			return
-		}
-		tableName := n.Table.Name
-		stmtLine := ostmt.AbsoluteLine(n.Loc.Start)
-		for _, cmd := range n.Commands {
-			if cmd == nil {
-				continue
-			}
-			switch cmd.Type {
-			case ast.ATAddColumn:
-				for _, column := range addColumnTargets(cmd) {
-					pds := c.addNewColumn(tableName, stmtLine, column)
-					pkDataList = append(pkDataList, pds...)
-				}
-			case ast.ATAddConstraint, ast.ATAddIndex:
-				// Empirically tidb omni emits only ATAddConstraint for
-				// `ALTER TABLE ... ADD …` forms (bare and named); ATAddIndex
-				// is reserved (not emitted). Dual arm preserved for sibling
-				// parity with the naming-convention advisors and mysql analog.
-				if cmd.Constraint != nil {
-					pds := c.addConstraint(tableName, stmtLine, cmd.Constraint)
-					pkDataList = append(pkDataList, pds...)
-				}
-			case ast.ATChangeColumn, ast.ATModifyColumn:
-				if cmd.Column == nil {
-					continue
-				}
-				newColumnDef := cmd.Column
-				oldColumnName := newColumnDef.Name
-				if cmd.Type == ast.ATChangeColumn && cmd.Name != "" {
-					// CHANGE COLUMN: cmd.Name is the OLD column name.
-					oldColumnName = cmd.Name
-				}
-				pds := c.changeColumn(tableName, oldColumnName, stmtLine, newColumnDef)
-				pkDataList = append(pkDataList, pds...)
-			default:
-			}
-		}
+		pkDataList = collectIndexFamilyAlterTable(ostmt, n, cb)
 	case *ast.CreateIndexStmt:
-		if n.Table == nil {
-			return
-		}
-		// Note: pingcap-typed advisor does NOT exclude FULLTEXT/SPATIAL
-		// indexes from the BLOB check, even though the mysql omni rule does.
-		// Preserve pingcap behavior; aligning to mysql's stricter exclusion
-		// is a separate intentional behavior change (cumulative #9 territory).
-		tableName := n.Table.Name
-		stmtLine := ostmt.AbsoluteLine(n.Loc.Start)
-		for _, columnName := range omniIndexColumns(n.Columns) {
-			columnType, err := c.getColumnType(tableName, columnName)
-			if err != nil {
-				continue
-			}
-			if isBlobType(columnType) {
-				pkDataList = append(pkDataList, pkData{
-					table:      tableName,
-					column:     columnName,
-					columnType: columnType,
-					line:       stmtLine,
-				})
-			}
-		}
+		pkDataList = c.collectCreateIndex(ostmt, n)
 	default:
 		return
 	}
@@ -159,6 +87,38 @@ func (c *indexTypeNoBlobChecker) checkStmt(ostmt OmniStmt) {
 			StartPosition: common.ConvertANTLRLineToPosition(pd.line),
 		})
 	}
+}
+
+// collectCreateIndex handles standalone `CREATE INDEX ... ON t (...)`
+// statements (the BLOB-only top-level type — neither pk_type nor
+// allowlist inspect this form).
+//
+// Note: pingcap-typed advisor does NOT exclude FULLTEXT/SPATIAL indexes
+// from the BLOB check, even though the mysql omni rule does. Preserve
+// pingcap behavior; aligning to mysql's stricter exclusion is a separate
+// intentional behavior change (cumulative #9 territory).
+func (c *indexTypeNoBlobChecker) collectCreateIndex(ostmt OmniStmt, n *ast.CreateIndexStmt) []pkData {
+	if n.Table == nil {
+		return nil
+	}
+	tableName := n.Table.Name
+	stmtLine := ostmt.AbsoluteLine(n.Loc.Start)
+	var pkDataList []pkData
+	for _, columnName := range omniIndexColumns(n.Columns) {
+		columnType, err := c.getColumnType(tableName, columnName)
+		if err != nil {
+			continue
+		}
+		if isBlobType(columnType) {
+			pkDataList = append(pkDataList, pkData{
+				table:      tableName,
+				column:     columnName,
+				columnType: columnType,
+				line:       stmtLine,
+			})
+		}
+	}
+	return pkDataList
 }
 
 func (c *indexTypeNoBlobChecker) addNewColumn(tableName string, line int, colDef *ast.ColumnDef) []pkData {

--- a/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
+++ b/backend/plugin/advisor/tidb/advisor_index_type_no_blob.go
@@ -210,9 +210,20 @@ func (c *indexTypeNoBlobChecker) getColumnType(tableName, columnName string) (st
 	return "", errors.Errorf(errCannotFindColumnTypeFmt, tableName, columnName)
 }
 
+// isBlobType matches the BLOB *and* TEXT type families. The rule is
+// named INDEX_TYPE_NO_BLOB and pingcap rendered everything as "blob" in
+// advice content, but pingcap-tidb's `mysql.TypeBlob` enum value covers
+// both BLOB and TEXT (TEXT is BLOB with non-binary charset), so the
+// pingcap-typed advisor flagged TEXT-in-INDEX too. Omni gives TEXT its
+// own DataType.Name (cumulative #14 territory): a mechanical port that
+// only matched the four BLOB names dropped TEXT coverage. Match both
+// families to preserve the rule's effective behavior; advice content
+// now reflects the accurate type name (e.g. "is text" rather than
+// pingcap's accidental "is blob").
 func isBlobType(columnType string) bool {
 	switch strings.ToLower(columnType) {
-	case "blob", "tinyblob", "mediumblob", "longblob":
+	case "blob", "tinyblob", "mediumblob", "longblob",
+		"text", "tinytext", "mediumtext", "longtext":
 		return true
 	default:
 		return false

--- a/backend/plugin/advisor/tidb/test/index_type_no_blob.yaml
+++ b/backend/plugin/advisor/tidb/test/index_type_no_blob.yaml
@@ -219,3 +219,50 @@
         line: 2
         column: 0
       endposition: null
+# TEXT-family parity (Codex P1 catch on batch-8 omni migration):
+# pingcap-tidb's parser unifies TEXT and BLOB under mysql.TypeBlob (TEXT
+# is BLOB with non-binary charset), so the pingcap-typed advisor flagged
+# TEXT-in-INDEX as "is blob". Omni stores TEXT as a distinct DataType.Name
+# ("TEXT", "TINYTEXT", etc.); a mechanical port that only matched
+# blob/tinyblob/mediumblob/longblob silently dropped TEXT coverage. Fixed
+# by extending isBlobType to also match the TEXT family. Advice content
+# now uses the accurate type name ("is text") rather than pingcap's
+# accidental "is blob" rendering.
+- statement: CREATE TABLE t(c TEXT, INDEX(c(10)))
+  changeType: 1
+  want:
+    - status: 2
+      code: 804
+      title: INDEX_TYPE_NO_BLOB
+      content: Columns in index must not be BLOB but `t`.`c` is text
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+- statement: CREATE TABLE t(tt TINYTEXT, mt MEDIUMTEXT, lt LONGTEXT, id INT, INDEX(tt(1), mt(2), lt(3), id))
+  changeType: 1
+  want:
+    - status: 2
+      code: 804
+      title: INDEX_TYPE_NO_BLOB
+      content: Columns in index must not be BLOB but `t`.`lt` is longtext
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+    - status: 2
+      code: 804
+      title: INDEX_TYPE_NO_BLOB
+      content: Columns in index must not be BLOB but `t`.`mt` is mediumtext
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+    - status: 2
+      code: 804
+      title: INDEX_TYPE_NO_BLOB
+      content: Columns in index must not be BLOB but `t`.`tt` is tinytext
+      startposition:
+        line: 1
+        column: 0
+      endposition: null

--- a/backend/plugin/advisor/tidb/utils.go
+++ b/backend/plugin/advisor/tidb/utils.go
@@ -284,6 +284,121 @@ func omniDataTypeNameCompact(dt *omniast.DataType) string {
 	return strings.ToLower(dt.Name)
 }
 
+// indexFamilyCallbacks parameterizes the shared CREATE TABLE / ALTER TABLE
+// walk used by the index-family advisors (advisor_index_pk_type,
+// advisor_index_type_no_blob, advisor_index_primary_key_type_allowlist).
+// The three advisors share scaffolding — same top-level type switch, same
+// AlterTable command-arm dispatch, same `pkData` accumulator — but diverge
+// at every callback site (which constraint types they care about, which
+// column-level constraint flags violations, what content the advice emits).
+// Encoding the spine here removes ~30 lines of duplication per advisor;
+// the per-rule logic stays in each advisor's callbacks.
+//
+// Each callback returns the [`pkData`] entries this command contributed,
+// so the helper concatenates results without owning advice formatting
+// (which differs per advisor and stays in-file).
+type indexFamilyCallbacks struct {
+	// onColumn fires for each column observed in CREATE TABLE columns and
+	// ALTER TABLE ADD COLUMN. Implementations typically record the column
+	// in the per-checker tracker (so ADD INDEX on a just-added column can
+	// resolve its type later) and emit a violation if the column itself
+	// declares a triggering inline constraint (e.g. PRIMARY KEY / UNIQUE).
+	onColumn func(tableName string, line int, col *omniast.ColumnDef) []pkData
+	// onConstraint fires for each top-level constraint observed: CREATE
+	// TABLE table-level constraints and ALTER TABLE ADD CONSTRAINT / ADD
+	// INDEX / ADD PRIMARY KEY / etc. Empirically tidb omni emits all
+	// `ALTER TABLE ADD ...` forms via ATAddConstraint; ATAddIndex is also
+	// dispatched here for sibling parity (cumulative #17).
+	onConstraint func(tableName string, line int, constraint *omniast.Constraint) []pkData
+	// onChangeColumn fires for ALTER TABLE CHANGE/MODIFY COLUMN. The
+	// helper resolves the OLD column name (cmd.Name for CHANGE COLUMN
+	// when set; falling back to the new column's name for MODIFY COLUMN
+	// or unnamed CHANGE) so callbacks can clean up tracker state before
+	// re-recording.
+	onChangeColumn func(tableName string, oldColumnName string, line int, newCol *omniast.ColumnDef) []pkData
+}
+
+// collectIndexFamilyCreateTable walks a CreateTableStmt's columns and
+// table-level constraints, dispatching each to the per-advisor callbacks.
+// Line positions: column line is the column's start; constraint line is
+// the constraint's start. Returns the concatenated pkData; advice
+// formatting/emission stays in the caller.
+func collectIndexFamilyCreateTable(ostmt OmniStmt, n *omniast.CreateTableStmt, cb indexFamilyCallbacks) []pkData {
+	if n == nil || n.Table == nil {
+		return nil
+	}
+	tableName := n.Table.Name
+	var result []pkData
+	for _, column := range n.Columns {
+		if column == nil {
+			continue
+		}
+		if cb.onColumn != nil {
+			result = append(result, cb.onColumn(tableName, ostmt.AbsoluteLine(column.Loc.Start), column)...)
+		}
+	}
+	for _, constraint := range n.Constraints {
+		if constraint == nil {
+			continue
+		}
+		if cb.onConstraint != nil {
+			result = append(result, cb.onConstraint(tableName, ostmt.AbsoluteLine(constraint.Loc.Start), constraint)...)
+		}
+	}
+	return result
+}
+
+// collectIndexFamilyAlterTable walks an AlterTableStmt's commands,
+// dispatching ATAddColumn / ATAddConstraint+ATAddIndex / ATChangeColumn+
+// ATModifyColumn to the per-advisor callbacks. Other command types are
+// ignored. The line for every command is the top-level statement's start
+// (matching pingcap-typed visitors that read `node.OriginTextPosition()`
+// for ALTER TABLE specs). Returns the concatenated pkData.
+func collectIndexFamilyAlterTable(ostmt OmniStmt, n *omniast.AlterTableStmt, cb indexFamilyCallbacks) []pkData {
+	if n == nil || n.Table == nil {
+		return nil
+	}
+	tableName := n.Table.Name
+	stmtLine := ostmt.AbsoluteLine(n.Loc.Start)
+	var result []pkData
+	for _, cmd := range n.Commands {
+		if cmd == nil {
+			continue
+		}
+		switch cmd.Type {
+		case omniast.ATAddColumn:
+			if cb.onColumn == nil {
+				continue
+			}
+			for _, column := range addColumnTargets(cmd) {
+				result = append(result, cb.onColumn(tableName, stmtLine, column)...)
+			}
+		case omniast.ATAddConstraint, omniast.ATAddIndex:
+			// Empirically tidb omni emits only ATAddConstraint for
+			// `ALTER TABLE ... ADD …` forms (bare and named); ATAddIndex
+			// is reserved (cumulative #17). Dual arm preserved for sibling
+			// parity with the naming-convention advisors and forward-compat
+			// against grammar evolution.
+			if cmd.Constraint != nil && cb.onConstraint != nil {
+				result = append(result, cb.onConstraint(tableName, stmtLine, cmd.Constraint)...)
+			}
+		case omniast.ATChangeColumn, omniast.ATModifyColumn:
+			if cmd.Column == nil || cb.onChangeColumn == nil {
+				continue
+			}
+			newCol := cmd.Column
+			oldColumnName := newCol.Name
+			if cmd.Type == omniast.ATChangeColumn && cmd.Name != "" {
+				// CHANGE COLUMN: cmd.Name is the OLD column name.
+				oldColumnName = cmd.Name
+			}
+			result = append(result, cb.onChangeColumn(tableName, oldColumnName, stmtLine, newCol)...)
+		default:
+		}
+	}
+	return result
+}
+
 // addColumnTargets returns the column definitions added by an ATAddColumn
 // cmd. omni populates either cmd.Columns (multi-column ADD COLUMN (...))
 // or cmd.Column (single ADD COLUMN); read both defensively.


### PR DESCRIPTION
## Summary

Two follow-up fixes to PR #20229 (batch 8 omni migration), merged before review feedback could land. Both commits standalone.

### Commit 1 — Sonar duplication fix (extraction)

PR #20229 was flagged at **36.6% duplicated lines on new code** (51% on `advisor_index_primary_key_type_allowlist.go`, 31.1% on `advisor_index_type_no_blob.go`). The flagged duplication was the CREATE TABLE column/constraint loop + ALTER TABLE command-arm dispatch, repeated 3 times across the index family (batch-2's `advisor_index_pk_type` + batch-8's blob/allowlist).

Extracts two helpers in `utils.go`:
- `collectIndexFamilyCreateTable` — walks `CreateTableStmt.Columns`/`Constraints`.
- `collectIndexFamilyAlterTable` — walks `AlterTableStmt.Commands`, dispatching `ATAddColumn` / `ATAddConstraint+ATAddIndex` / `ATChangeColumn+ATModifyColumn` and resolving `CHANGE COLUMN`'s old name.

Each advisor passes an `indexFamilyCallbacks` struct (`onColumn`, `onConstraint`, `onChangeColumn`); per-rule logic stays in callback bodies. Top-level type switch stays per-advisor (BLOB has `CreateIndexStmt`; the other two don't — asymmetric, kept in-file). Advice content + code stay per-advisor.

Side effect on batch-2 `advisor_index_pk_type.go`: case-arm coverage broadens from `case ATAddConstraint:` to `case ATAddConstraint, ATAddIndex:` (helper unifies). Empirically equivalent today per cumulative #17 — tidb omni does not emit `ATAddIndex`. Defensive against future grammar evolution.

Net: **-244 lines** of duplicated scaffolding across 3 advisors, **+115 lines** of helper. Spine exists once instead of three times.

### Commit 2 — TEXT-family regression fix (Codex P1)

Codex flagged a real false-negative on the omni migration: pingcap's `mysql.TypeBlob` enum value unified BLOB and TEXT (TEXT is BLOB with non-binary charset), so the pingcap-typed advisor flagged `CREATE TABLE t(c TEXT, INDEX(c(10)))` — rendering the type as `is blob` (accidentally accurate via type-enum unification). Omni gives TEXT its own `DataType.Name` ("TEXT", "TINYTEXT", etc.); the batch-8 mechanical port matched only the four BLOB names via `isBlobType`, **silently dropping TEXT-in-INDEX coverage**.

Cumulative #14 in the completion-plan table already documents the BLOB/TEXT split pattern — exactly the failure mode the table is meant to prevent. The plan doc now also has a dedicated cumulative #18 entry for this case and a step 2a (type-enum cross-reference) pre-batch invariant to catch the class going forward. Honest miss during the original shape audit.

**Empirical reproduction** on the merged batch-8 code:
```
CREATE TABLE t(c TEXT, INDEX(c(10)))   →   no advice (regression)
```

Fix: extend `isBlobType` to match BLOB AND TEXT families (8 names total). Pinned with three new fixture cases in `index_type_no_blob.yaml`:
- `CREATE TABLE t(c TEXT, INDEX(c(10)))` (single TEXT)
- TINYTEXT/MEDIUMTEXT/LONGTEXT in INDEX (cardinality + breadth across the TEXT family)

## Customer-visible behavior change — deferred-behavior-change framing

Advice content for TEXT-family columns in indexes changes:

| | Before this PR | After this PR |
|---|---|---|
| `CREATE TABLE t(c TEXT, INDEX(c(10)))` | (no advice — regression introduced by #20229) | `Columns in index must not be BLOB but \`t\`.\`c\` is text` |
| Pre-omni pingcap-tidb (historical baseline) | `Columns in index must not be BLOB but \`t\`.\`c\` is blob` (accidentally rendered as "blob" via TypeBlob unification) | n/a |

**Framing:** UX improvement, not regression. Pingcap rendered TEXT as `is blob` because the type-byte was shared (TypeBlob); omni renders it accurately as `is text`. Same rule fires, more accurate content. Consistent with batch 6's CHARSET/CHARACTER SET behavior preservation framing — customer-visible advice content changes during omni migration are flagged explicitly so future authors searching for "deferred behavior change" / "side-effect" patterns find them via grep.

**Customer effect:** rule still fires (no false negative restored); advice content text differs by one word ("is blob" → "is text") for TEXT-family columns; customers without TEXT-in-INDEX schemas see no difference; the prior "is blob" rendering was unobservable / accidentally accurate in the pingcap implementation.

## Out of scope

`mysql/rule_index_type_no_blob.go:206` has the same `isBlob` shape (BLOB-only). **Empirically verified during this session: this is NOT a regression — pre-omni mysql used ANTLR (not pingcap), \`columnType\` came from token text not a type-byte enum, and the rule never matched TEXT in either era.** The mysql gap is long-standing behavior, not omni-introduced. No ticket filed (no customer impact reported); the gap is documented in cumulative #18's "Pattern for cumulative-table maintainers" note.

## Test plan

- [x] `go test -count=1 -run "^TestTiDBRules$" ./backend/plugin/advisor/tidb/` — green (with new TEXT pins)
- [x] `go test -count=1 ./backend/plugin/advisor/tidb/ ./backend/plugin/advisor/mysql/` — green
- [x] `golangci-lint run --allow-parallel-runners ./backend/plugin/advisor/tidb/...` — 0 issues
- [x] `go build -ldflags "-w -s" ./backend/bin/server/main.go` — clean
- [x] Empirical pre-fix reproduction confirmed the TEXT regression existed; post-fix reproduction confirmed the fix
- [x] Empirical verification of mysql parallel: pre-omni mysql `isBlob` (via `git show 699ff60c20^:...`) had same shape — long-standing gap, not regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)