### PR TITLE
fix(instance): sync detail form after instance load

### DIFF
--- a/frontend/src/react/components/instance/InstanceFormBody.test.ts
+++ b/frontend/src/react/components/instance/InstanceFormBody.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+describe("InstanceFormBody", () => {
+  test("uses boolean values for inert collapsible sections", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/react/components/instance/InstanceFormBody.tsx"),
+      "utf-8"
+    );
+
+    expect(source).not.toContain(
+      'inert={isEngineSelectorCollapsed ? "" : undefined}'
+    );
+    expect(source).not.toContain(
+      'inert={isConnectionOptionsCollapsed ? "" : undefined}'
+    );
+    expect(source).toContain(
+      "inert={isEngineSelectorCollapsed ? true : undefined}"
+    );
+    expect(source).toContain(
+      "inert={isConnectionOptionsCollapsed ? true : undefined}"
+    );
+  });
+});

--- a/frontend/src/react/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/react/components/instance/InstanceFormBody.tsx
@@ -1313,8 +1313,7 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
               style={{
                 gridTemplateRows: !isEngineSelectorCollapsed ? "1fr" : "0fr",
               }}
-              // @ts-expect-error -- inert is a valid HTML attribute but not yet in React's type definitions
-              inert={isEngineSelectorCollapsed ? "" : undefined}
+              inert={isEngineSelectorCollapsed ? true : undefined}
             >
               <div className="overflow-hidden">
                 <div className="px-4 py-4">
@@ -1873,8 +1872,7 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
               style={{
                 gridTemplateRows: !isConnectionOptionsCollapsed ? "1fr" : "0fr",
               }}
-              // @ts-expect-error -- inert is a valid HTML attribute but not yet in React's type definitions
-              inert={isConnectionOptionsCollapsed ? "" : undefined}
+              inert={isConnectionOptionsCollapsed ? true : undefined}
             >
               <div className="overflow-hidden">
                 <div className="px-5 py-4">

--- a/frontend/src/react/components/instance/InstanceFormContext.test.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.test.tsx
@@ -1,0 +1,158 @@
+import { create } from "@bufbuild/protobuf";
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, test, vi } from "vitest";
+import { Engine } from "@/types/proto-es/v1/common_pb";
+import {
+  DataSourceSchema,
+  DataSourceType,
+  InstanceSchema,
+} from "@/types/proto-es/v1/instance_service_pb";
+import { unknownInstance } from "@/types/v1/instance";
+import {
+  InstanceFormProvider,
+  useInstanceFormContext,
+} from "./InstanceFormContext";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/react/i18n", () => ({
+  default: {
+    t: (key: string) => key,
+  },
+}));
+
+vi.mock("monaco-editor", () => ({}));
+
+vi.mock(
+  "@codingame/monaco-vscode-editor-api/vscode/src/vs/editor/standalone/browser/standalone-tokens.css",
+  () => ({})
+);
+
+vi.mock("@/types", () => ({
+  UNKNOWN_INSTANCE_NAME: "instances/-",
+  unknownDataSource: () => ({
+    id: "admin",
+    type: 1,
+    host: "",
+    port: "",
+    username: "",
+    password: "",
+    database: "",
+    additionalAddresses: [],
+    extraConnectionParameters: {},
+  }),
+}));
+
+vi.mock("@/store", () => ({
+  pushNotification: vi.fn(),
+  useActuatorV1Store: () => ({
+    activatedInstanceCount: 0,
+  }),
+  useEnvironmentV1Store: () => ({
+    getEnvironmentByName: (name: string) => ({ name }),
+  }),
+  useInstanceV1Store: () => ({
+    createDataSource: vi.fn(),
+    createInstance: vi.fn(),
+    updateDataSource: vi.fn(),
+  }),
+  useSubscriptionV1Store: () => ({
+    currentPlan: 1,
+    instanceLicenseCount: 1,
+    hasInstanceFeature: () => false,
+  }),
+}));
+
+vi.mock("@/utils", () => ({
+  calcUpdateMask: () => [],
+  convertKVListToLabels: (list: { key: string; value: string }[]) =>
+    Object.fromEntries(list.map(({ key, value }) => [key, value])),
+  convertLabelsToKVList: (labels: Record<string, string>) =>
+    Object.entries(labels).map(([key, value]) => ({ key, value })),
+  hasWorkspacePermissionV2: () => true,
+  instanceV1HasExtraParameters: () => false,
+  instanceV1HasSSH: () => false,
+  instanceV1HasSSL: () => false,
+  isValidSpannerHost: (host: string) => host !== "",
+}));
+
+vi.mock("@/utils/connect", () => ({
+  extractGrpcErrorMessage: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}));
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const Probe = () => {
+  const ctx = useInstanceFormContext();
+  return (
+    <div
+      data-title={ctx.basicInfo.title}
+      data-host={ctx.adminDataSource.host}
+    />
+  );
+};
+
+const renderIntoContainer = () => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  return {
+    container,
+    render: async (nextElement: ReactElement) => {
+      await act(async () => {
+        root.render(nextElement);
+      });
+    },
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+    },
+  };
+};
+
+describe("InstanceFormProvider", () => {
+  test("refreshes form state when an unknown instance is replaced by the fetched instance", async () => {
+    const fetchedInstance = create(InstanceSchema, {
+      name: "instances/prod",
+      title: "Production",
+      engine: Engine.POSTGRES,
+      environment: "environments/prod",
+      dataSources: [
+        create(DataSourceSchema, {
+          id: "admin",
+          type: DataSourceType.ADMIN,
+          host: "prod.example.com",
+          port: "5432",
+        }),
+      ],
+    });
+    const harness = renderIntoContainer();
+
+    await harness.render(
+      <InstanceFormProvider instance={unknownInstance()}>
+        <Probe />
+      </InstanceFormProvider>
+    );
+    await harness.render(
+      <InstanceFormProvider instance={fetchedInstance}>
+        <Probe />
+      </InstanceFormProvider>
+    );
+
+    const probe = harness.container.firstElementChild as HTMLElement;
+    expect(probe.dataset.title).toBe("Production");
+    expect(probe.dataset.host).toBe("prod.example.com");
+
+    harness.unmount();
+  });
+});

--- a/frontend/src/react/components/instance/InstanceFormContext.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.tsx
@@ -156,6 +156,26 @@ export function InstanceFormProvider({
   const [labelErrors, setLabelErrors] = useState<string[]>([]);
   const [showConnectionOptionsEvent, setShowConnectionOptionsEvent] =
     useState(0);
+  const syncedInstanceNameRef = useRef(instance?.name);
+
+  useEffect(() => {
+    if (syncedInstanceNameRef.current === instance?.name) {
+      return;
+    }
+
+    syncedInstanceNameRef.current = instance?.name;
+    const nextBasicInfo = extractBasicInfo(instance);
+    const nextDataSourceEditState = extractDataSourceEditState(instance);
+    setBasicInfo(nextBasicInfo);
+    setLabelKVList(convertLabelsToKVList(nextBasicInfo.labels, true));
+    setDataSourceEditState(nextDataSourceEditState);
+    setState((prev) => ({
+      ...prev,
+      editingDataSourceId: nextDataSourceEditState.editingDataSourceId,
+    }));
+    setLabelErrors([]);
+    setMissingFeature(undefined);
+  }, [instance]);
 
   const emitShowConnectionOptions = useCallback(() => {
     setShowConnectionOptionsEvent((prev) => prev + 1);


### PR DESCRIPTION
## Summary
- Refresh instance form state when fetched instance data replaces the placeholder instance on the detail page.
- Use boolean `inert` values for collapsed instance form sections to avoid React warnings.

## Key Changes
- Sync `InstanceFormProvider` local state when the active instance name changes.
- Add regression coverage for placeholder-to-fetched instance hydration.
- Add regression coverage for boolean `inert` attributes in collapsible sections.

## Motivation
- Prevent the overview tab from showing blank instance form fields on first entry until the user switches tabs.

## Testing
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend exec vitest run src/react/components/instance/InstanceFormContext.test.tsx src/react/components/instance/InstanceFormBody.test.ts`
