### PR TITLE
fix: restore column masking exemption resource selection

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1179,7 +1179,6 @@
     "role-grant": {
       "all-databases": "All",
       "all-databases-tip": "All current and future databases in this project.",
-      "column-scope-select-disabled": "Manually select is unavailable for column-scoped selections.",
       "details": "Request Details",
       "expired-at": "Expired at",
       "manually-select": "Manually select",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1179,7 +1179,6 @@
     "role-grant": {
       "all-databases": "todas las bases de datos",
       "all-databases-tip": "Todas las bases de datos actuales y futuras de este proyecto.",
-      "column-scope-select-disabled": "La selección manual no está disponible para selecciones con alcance de columna.",
       "details": "Detalles de la solicitud",
       "expired-at": "tiempo de caducidad",
       "manually-select": "selección manual",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1179,7 +1179,6 @@
     "role-grant": {
       "all-databases": "すべてのデータベース",
       "all-databases-tip": "このプロジェクトに属する現在および将来のすべてのデータベース。",
-      "column-scope-select-disabled": "列単位の選択では手動選択を使用できません。",
       "details": "リクエストの詳細",
       "expired-at": "有効期限",
       "manually-select": "手動選択",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1179,7 +1179,6 @@
     "role-grant": {
       "all-databases": "Tất cả",
       "all-databases-tip": "Tất cả cơ sở dữ liệu hiện tại và tương lai trong dự án này.",
-      "column-scope-select-disabled": "Không thể chọn thủ công cho phạm vi ở mức cột.",
       "details": "Yêu cầu chi tiết",
       "expired-at": "Hết hạn vào",
       "manually-select": "Chọn thủ công",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1179,7 +1179,6 @@
     "role-grant": {
       "all-databases": "所有数据库",
       "all-databases-tip": "所有当前和未来属于这个项目的数据库。",
-      "column-scope-select-disabled": "列级范围的选择不能使用手动选择。",
       "details": "请求详细",
       "expired-at": "过期时间",
       "manually-select": "手动选择",

--- a/frontend/src/plugins/i18n.test.ts
+++ b/frontend/src/plugins/i18n.test.ts
@@ -169,18 +169,6 @@ const checkKeysSorted = (
   return errors;
 };
 
-const getNestedValue = (
-  obj: Record<string, unknown>,
-  path: string
-): unknown => {
-  return path.split(".").reduce<unknown>((current, key) => {
-    if (!current || typeof current !== "object") {
-      return undefined;
-    }
-    return (current as Record<string, unknown>)[key];
-  }, obj);
-};
-
 describe("Locale keys are sorted alphabetically", () => {
   const localesDirs = [
     resolve(__dirname, "../locales"),
@@ -195,29 +183,6 @@ describe("Locale keys are sorted alphabetically", () => {
         const errors = checkKeysSorted(content, file);
         expect(errors, errors.join("\n")).toHaveLength(0);
       });
-    }
-  }
-});
-
-describe("Grant access locale coverage", () => {
-  const localesDirs = [
-    resolve(__dirname, "../locales"),
-    resolve(__dirname, "../react/locales"),
-  ];
-  const requiredKeys = ["issue.role-grant.column-scope-select-disabled"];
-
-  for (const dir of localesDirs) {
-    const files = readdirSync(dir).filter((f) => f.endsWith(".json"));
-    for (const file of files) {
-      const content = JSON.parse(readFileSync(resolve(dir, file), "utf-8"));
-      for (const key of requiredKeys) {
-        test(`${dir.includes("react") ? "react/" : ""}locales/${file} includes ${key}`, () => {
-          expect(
-            getNestedValue(content, key),
-            `${file} missing ${key}`
-          ).toBeTruthy();
-        });
-      }
     }
   }
 });

--- a/frontend/src/react/components/DatabaseResourceSelector.test.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.test.tsx
@@ -1,0 +1,383 @@
+import { act, type ReactElement, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { DatabaseResource } from "@/types";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  fetchDatabases: vi.fn(),
+  fetchInstanceList: vi.fn(),
+  getOrFetchDatabaseMetadata: vi.fn(),
+  databaseStore: undefined as
+    | { fetchDatabases: ReturnType<typeof vi.fn> }
+    | undefined,
+  instanceStore: undefined as
+    | { fetchInstanceList: ReturnType<typeof vi.fn> }
+    | undefined,
+  environmentStore: {
+    environmentList: [],
+  },
+  extractDatabaseResourceName: vi.fn((name: string) => {
+    const parts = name.split("/");
+    return {
+      instance: parts[1] ?? "",
+      instanceName: parts[1] ?? "",
+      database: name,
+      databaseName: parts[3] ?? name,
+    };
+  }),
+  extractInstanceResourceName: vi.fn((name: string) => {
+    const parts = name.split("/");
+    return parts[1] ?? name;
+  }),
+}));
+
+mocks.databaseStore = {
+  fetchDatabases: mocks.fetchDatabases,
+};
+mocks.instanceStore = {
+  fetchInstanceList: mocks.fetchInstanceList,
+};
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { count?: number }) =>
+      options?.count === undefined ? key : key,
+  }),
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  default: {
+    global: {
+      t: (key: string) => key,
+    },
+  },
+  t: (key: string) => key,
+}));
+
+vi.mock("@/store", () => ({
+  useDatabaseV1Store: () => mocks.databaseStore,
+  useEnvironmentV1Store: () => mocks.environmentStore,
+  useInstanceV1Store: () => mocks.instanceStore,
+}));
+
+vi.mock("@/react/hooks/useVueState", () => ({
+  useVueState: (getter: () => unknown) => getter(),
+}));
+
+vi.mock("@/react/components/AdvancedSearch", () => ({
+  getValueFromScopes: (
+    params: { scopes: { id: string; value: string }[] },
+    id: string
+  ) => params.scopes.find((scope) => scope.id === id)?.value ?? "",
+  AdvancedSearch: ({
+    params,
+    onParamsChange,
+  }: {
+    params: { query: string; scopes: { id: string; value: string }[] };
+    onParamsChange: (params: {
+      query: string;
+      scopes: { id: string; value: string }[];
+    }) => void;
+  }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onParamsChange({
+          query: "salary",
+          scopes: [{ id: "table", value: "employee" }],
+        })
+      }
+    >
+      <span>advanced-search:{params.query}</span>
+    </button>
+  ),
+}));
+
+vi.mock("@/store/modules/v1/dbSchema", () => ({
+  useDBSchemaV1Store: () => ({
+    getOrFetchDatabaseMetadata: mocks.getOrFetchDatabaseMetadata,
+  }),
+}));
+
+vi.mock("@/react/components/EnvironmentLabel", () => ({
+  EnvironmentLabel: ({ environmentName }: { environmentName: string }) => (
+    <span>{environmentName}</span>
+  ),
+}));
+
+vi.mock("@/utils", () => ({
+  engineNameV1: (engine: number) => `engine-${engine}`,
+  extractDatabaseResourceName: mocks.extractDatabaseResourceName,
+  extractInstanceResourceName: mocks.extractInstanceResourceName,
+  getDefaultPagination: () => 100,
+  supportedEngineV1List: () => [],
+}));
+
+let DatabaseResourceSelector: typeof import("./DatabaseResourceSelector").DatabaseResourceSelector;
+
+const databaseName = "instances/prod/databases/hr";
+const metadata = {
+  schemas: [
+    {
+      name: "public",
+      tables: [
+        {
+          name: "employee",
+          columns: [{ name: "id" }, { name: "salary" }],
+        },
+      ],
+    },
+  ],
+};
+const schemaLessMetadata = {
+  schemas: [
+    {
+      name: "",
+      tables: [
+        {
+          name: "employee",
+          columns: [{ name: "salary" }],
+        },
+      ],
+    },
+  ],
+};
+
+function Harness({
+  includeColumns,
+  initialValue = [],
+  onValueChange,
+}: {
+  includeColumns?: boolean;
+  initialValue?: DatabaseResource[];
+  onValueChange?: (value: DatabaseResource[]) => void;
+}) {
+  const [value, setValue] = useState<DatabaseResource[]>(initialValue);
+
+  return (
+    <DatabaseResourceSelector
+      projectName="projects/project"
+      value={value}
+      includeColumns={includeColumns}
+      onChange={(next) => {
+        setValue(next);
+        onValueChange?.(next);
+      }}
+    />
+  );
+}
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  document.body.appendChild(container);
+  act(() => {
+    root.render(element);
+  });
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+};
+
+const flushPromises = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+};
+
+const rowForText = (container: HTMLElement, text: string): HTMLElement => {
+  const matches = Array.from(container.querySelectorAll("span")).filter(
+    (node) => node.textContent === text
+  );
+  const match = matches[0];
+  if (!match) {
+    throw new Error(`row text not found: ${text}`);
+  }
+  const row = match.parentElement;
+  if (!row) {
+    throw new Error(`row not found: ${text}`);
+  }
+  return row;
+};
+
+const clickFirstButtonInRow = (container: HTMLElement, text: string) => {
+  const row = rowForText(container, text);
+  const button =
+    row instanceof HTMLButtonElement ? row : row.querySelector("button");
+  if (!button) {
+    throw new Error(`button not found: ${text}`);
+  }
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+};
+
+const clickCheckboxInRow = (container: HTMLElement, text: string) => {
+  const row = rowForText(container, text);
+  const checkbox = row.querySelector('[role="checkbox"]');
+  if (!checkbox) {
+    throw new Error(`checkbox not found: ${text}`);
+  }
+  act(() => {
+    checkbox.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+};
+
+const expandDatabase = async (container: HTMLElement) => {
+  await waitForText(container, "hr");
+  clickFirstButtonInRow(container, "hr");
+  await flushPromises();
+};
+
+const waitForText = async (container: HTMLElement, text: string) => {
+  for (let i = 0; i < 10; i++) {
+    if (container.textContent?.includes(text)) {
+      return;
+    }
+    await flushPromises();
+  }
+  throw new Error(`text not found: ${text}`);
+};
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mocks.fetchDatabases.mockResolvedValue({
+    databases: [
+      {
+        name: databaseName,
+        environment: "environments/prod",
+        effectiveEnvironment: "environments/prod",
+        instanceResource: { title: "Prod" },
+      },
+    ],
+    nextPageToken: "",
+  });
+  mocks.fetchInstanceList.mockResolvedValue({
+    instances: [],
+    nextPageToken: "",
+  });
+  mocks.getOrFetchDatabaseMetadata.mockResolvedValue(metadata);
+  ({ DatabaseResourceSelector } = await import("./DatabaseResourceSelector"));
+});
+
+describe("DatabaseResourceSelector", () => {
+  test("passes AdvancedSearch query and table scope to database fetch", async () => {
+    const { container, unmount } = renderIntoContainer(<Harness />);
+    await flushPromises();
+    await waitForText(container, "advanced-search:");
+
+    mocks.fetchDatabases.mockClear();
+    clickFirstButtonInRow(container, "advanced-search:");
+    await flushPromises();
+
+    expect(mocks.fetchDatabases).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        filter: expect.objectContaining({
+          query: "salary",
+          table: "employee",
+        }),
+      })
+    );
+
+    unmount();
+  });
+
+  test("does not expose column rows unless explicitly enabled", async () => {
+    const { container, unmount } = renderIntoContainer(<Harness />);
+    await flushPromises();
+    await expandDatabase(container);
+    clickFirstButtonInRow(container, "public");
+
+    expect(container.textContent).toContain("employee");
+    expect(container.textContent).not.toContain("salary");
+
+    unmount();
+  });
+
+  test("selects multiple columns as one table-scoped DatabaseResource", async () => {
+    const onValueChange = vi.fn();
+    const { container, unmount } = renderIntoContainer(
+      <Harness includeColumns onValueChange={onValueChange} />
+    );
+    await flushPromises();
+    await expandDatabase(container);
+    clickFirstButtonInRow(container, "public");
+    clickFirstButtonInRow(container, "employee");
+
+    clickCheckboxInRow(container, "id");
+    clickCheckboxInRow(container, "salary");
+
+    expect(onValueChange).toHaveBeenLastCalledWith([
+      {
+        databaseFullName: databaseName,
+        schema: "public",
+        table: "employee",
+        columns: ["id", "salary"],
+      },
+    ]);
+    expect(container.textContent).toContain("hr.public.employee: id, salary");
+
+    unmount();
+  });
+
+  test("omits empty schema segment from column resource labels", async () => {
+    mocks.getOrFetchDatabaseMetadata.mockResolvedValue(schemaLessMetadata);
+    const { container, unmount } = renderIntoContainer(
+      <Harness includeColumns />
+    );
+    await flushPromises();
+    await expandDatabase(container);
+    clickFirstButtonInRow(container, "employee");
+
+    clickCheckboxInRow(container, "salary");
+
+    expect(container.textContent).toContain("hr.employee: salary");
+    expect(container.textContent).not.toContain("hr..employee: salary");
+
+    unmount();
+  });
+
+  test("selecting a table replaces child column selections", async () => {
+    const onValueChange = vi.fn();
+    const { container, unmount } = renderIntoContainer(
+      <Harness
+        includeColumns
+        initialValue={[
+          {
+            databaseFullName: databaseName,
+            schema: "public",
+            table: "employee",
+            columns: ["salary"],
+          },
+        ]}
+        onValueChange={onValueChange}
+      />
+    );
+    await flushPromises();
+    await expandDatabase(container);
+    clickFirstButtonInRow(container, "public");
+    clickCheckboxInRow(container, "employee");
+
+    expect(onValueChange).toHaveBeenLastCalledWith([
+      {
+        databaseFullName: databaseName,
+        schema: "public",
+        table: "employee",
+      },
+    ]);
+
+    unmount();
+  });
+});

--- a/frontend/src/react/components/DatabaseResourceSelector.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.tsx
@@ -1,6 +1,7 @@
 import {
   ChevronDown,
   ChevronRight,
+  Columns3,
   Database as DatabaseIcon,
   Layers,
   Table2,
@@ -8,47 +9,227 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  AdvancedSearch,
+  getValueFromScopes,
+  type ScopeOption,
+  type SearchParams,
+  type ValueOption,
+} from "@/react/components/AdvancedSearch";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { Checkbox } from "@/react/components/ui/checkbox";
-import { SearchInput } from "@/react/components/ui/search-input";
-import { useDatabaseV1Store } from "@/store";
+import { useVueState } from "@/react/hooks/useVueState";
+import {
+  useDatabaseV1Store,
+  useEnvironmentV1Store,
+  useInstanceV1Store,
+} from "@/store";
 import { useDBSchemaV1Store } from "@/store/modules/v1/dbSchema";
 import type { DatabaseResource } from "@/types";
+import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
+  ColumnMetadata,
   Database,
   DatabaseMetadata,
+  TableMetadata,
 } from "@/types/proto-es/v1/database_service_pb";
-import { extractDatabaseResourceName } from "@/utils";
+import {
+  extractDatabaseResourceName,
+  extractInstanceResourceName,
+  supportedEngineV1List,
+} from "@/utils";
+
+interface TableSelection {
+  wholeTableSelected: boolean;
+  columns: Set<string>;
+}
+
+interface SchemaSelection {
+  wholeSchemaSelected: boolean;
+  tables: Map<string, TableSelection>;
+}
+
+interface DatabaseSelection {
+  wholeDatabaseSelected: boolean;
+  schemas: Map<string, SchemaSelection>;
+}
+
+const emptyTableSelection = (): TableSelection => ({
+  wholeTableSelected: false,
+  columns: new Set(),
+});
+
+const emptySchemaSelection = (): SchemaSelection => ({
+  wholeSchemaSelected: false,
+  tables: new Map(),
+});
+
+const tableKey = (dbName: string, schemaName: string, tableName: string) =>
+  `${dbName}/schemas/${schemaName}/tables/${tableName}`;
+
+const environmentNamePrefix = "environments/";
+const instanceNamePrefix = "instances/";
+const UNKNOWN_ENVIRONMENT_ID = "-1";
+const UNKNOWN_ENVIRONMENT_NAME = `${environmentNamePrefix}${UNKNOWN_ENVIRONMENT_ID}`;
+
+interface DatabaseFilter {
+  instance?: string;
+  environment?: string;
+  query?: string;
+  labels?: string[];
+  engines?: Engine[];
+  table?: string;
+}
+
+const sameResource = (a: DatabaseResource, b: DatabaseResource) =>
+  a.databaseFullName === b.databaseFullName &&
+  a.schema === b.schema &&
+  a.table === b.table &&
+  (a.columns ?? []).join("\0") === (b.columns ?? []).join("\0");
 
 export function DatabaseResourceSelector({
   projectName,
   value,
   onChange,
+  includeColumns = false,
 }: {
   projectName: string;
   value: DatabaseResource[];
   onChange: (resources: DatabaseResource[]) => void;
+  includeColumns?: boolean;
 }) {
   const { t } = useTranslation();
   const databaseStore = useDatabaseV1Store();
   const dbSchemaStore = useDBSchemaV1Store();
+  const environmentStore = useEnvironmentV1Store();
+  const instanceStore = useInstanceV1Store();
 
   const [databases, setDatabases] = useState<Database[]>([]);
-  const [filter, setFilter] = useState("");
+  const [searchParams, setSearchParams] = useState<SearchParams>({
+    query: "",
+    scopes: [],
+  });
   const [expandedDatabases, setExpandedDatabases] = useState<Set<string>>(
     new Set()
   );
   const [expandedSchemas, setExpandedSchemas] = useState<Set<string>>(
     new Set()
   );
+  const [expandedTables, setExpandedTables] = useState<Set<string>>(new Set());
   const [metadataMap, setMetadataMap] = useState<Map<string, DatabaseMetadata>>(
     new Map()
   );
   const [loadingMetadata, setLoadingMetadata] = useState<Set<string>>(
     new Set()
   );
+  const environments = useVueState(
+    () => environmentStore.environmentList ?? []
+  );
 
-  // Fetch databases on mount
+  const searchInstances = useCallback(
+    async (keyword: string): Promise<ValueOption[]> => {
+      const result = await instanceStore.fetchInstanceList({
+        pageSize: 1000,
+        filter: keyword.trim() ? { query: keyword } : undefined,
+        silent: true,
+      });
+      return result.instances.map((instance) => {
+        const id = extractInstanceResourceName(instance.name);
+        return {
+          value: id,
+          keywords: [id, instance.title],
+        };
+      });
+    },
+    [instanceStore]
+  );
+
+  const scopeOptions: ScopeOption[] = useMemo(
+    () => [
+      {
+        id: "environment",
+        title: t("issue.advanced-search.scope.environment.title"),
+        description: t("issue.advanced-search.scope.environment.description"),
+        options: [
+          {
+            id: UNKNOWN_ENVIRONMENT_ID,
+            name: UNKNOWN_ENVIRONMENT_NAME,
+            title: "",
+          },
+          ...environments,
+        ].map((env) => {
+          const isUnknown = env.name === UNKNOWN_ENVIRONMENT_NAME;
+          return {
+            value: env.id,
+            keywords: isUnknown
+              ? ["unassigned", "none", env.id]
+              : [`${environmentNamePrefix}${env.id}`, env.title],
+            render: isUnknown
+              ? () => (
+                  <span className="italic text-control-light">
+                    {t("common.unassigned")}
+                  </span>
+                )
+              : undefined,
+            custom: isUnknown,
+          };
+        }),
+      },
+      {
+        id: "instance",
+        title: t("issue.advanced-search.scope.instance.title"),
+        description: t("issue.advanced-search.scope.instance.description"),
+        onSearch: searchInstances,
+      },
+      {
+        id: "label",
+        title: t("common.labels"),
+        description: t("issue.advanced-search.scope.label.description"),
+        allowMultiple: true,
+      },
+      {
+        id: "engine",
+        title: t("issue.advanced-search.scope.engine.title"),
+        description: t("issue.advanced-search.scope.engine.description"),
+        allowMultiple: true,
+        options: supportedEngineV1List().map((engine) => ({
+          value: Engine[engine],
+          keywords: [Engine[engine].toLowerCase()],
+        })),
+      },
+      {
+        id: "table",
+        title: t("issue.advanced-search.scope.table.title"),
+        description: t("issue.advanced-search.scope.table.description"),
+      },
+    ],
+    [environments, searchInstances, t]
+  );
+
+  const databaseFilter: DatabaseFilter = useMemo(() => {
+    const environmentId = getValueFromScopes(searchParams, "environment");
+    const instanceId = getValueFromScopes(searchParams, "instance");
+    const labels = searchParams.scopes
+      .filter((scope) => scope.id === "label")
+      .map((scope) => scope.value);
+    const engines = searchParams.scopes
+      .filter((scope) => scope.id === "engine")
+      .map((scope) => Engine[scope.value as keyof typeof Engine])
+      .filter((engine): engine is Engine => engine !== undefined);
+    const table = getValueFromScopes(searchParams, "table");
+
+    return {
+      query: searchParams.query,
+      environment: environmentId
+        ? `${environmentNamePrefix}${environmentId}`
+        : undefined,
+      instance: instanceId ? `${instanceNamePrefix}${instanceId}` : undefined,
+      labels: labels.length > 0 ? labels : undefined,
+      engines: engines.length > 0 ? engines : undefined,
+      table: table || undefined,
+    };
+  }, [searchParams]);
+
   useEffect(() => {
     let cancelled = false;
     const fetchAll = async () => {
@@ -59,6 +240,7 @@ export function DatabaseResourceSelector({
           parent: projectName,
           pageSize: 1000,
           pageToken,
+          filter: databaseFilter,
         });
         allDatabases = [...allDatabases, ...result.databases];
         pageToken = result.nextPageToken;
@@ -69,39 +251,49 @@ export function DatabaseResourceSelector({
     return () => {
       cancelled = true;
     };
-  }, [projectName, databaseStore]);
+  }, [projectName, databaseStore, databaseFilter]);
 
-  const filteredDatabases = useMemo(() => {
-    if (!filter.trim()) return databases;
-    const keyword = filter.trim().toLowerCase();
-    return databases.filter((db) => {
-      const { databaseName } = extractDatabaseResourceName(db.name);
-      return databaseName.toLowerCase().includes(keyword);
-    });
-  }, [databases, filter]);
-
-  // Build a set of selected database full names for quick lookup
   const selectedResourceMap = useMemo(() => {
-    const map = new Map<
-      string,
-      { schemas: Map<string, Set<string>>; wholeDatabaseSelected: boolean }
-    >();
-    for (const r of value) {
-      const dbName = r.databaseFullName;
+    const map = new Map<string, DatabaseSelection>();
+    for (const resource of value) {
+      const dbName = resource.databaseFullName;
       if (!map.has(dbName)) {
-        map.set(dbName, { schemas: new Map(), wholeDatabaseSelected: false });
+        map.set(dbName, {
+          schemas: new Map(),
+          wholeDatabaseSelected: false,
+        });
       }
-      const entry = map.get(dbName)!;
-      if (!r.schema && !r.table) {
-        entry.wholeDatabaseSelected = true;
-      } else if (r.schema && !r.table) {
-        // Schema-level selection
-        entry.schemas.set(r.schema, new Set());
-      } else if (r.schema !== undefined && r.table) {
-        if (!entry.schemas.has(r.schema)) {
-          entry.schemas.set(r.schema, new Set());
+
+      const dbEntry = map.get(dbName)!;
+      if (resource.schema === undefined && !resource.table) {
+        dbEntry.wholeDatabaseSelected = true;
+        continue;
+      }
+
+      if (resource.schema === undefined) {
+        continue;
+      }
+
+      if (!dbEntry.schemas.has(resource.schema)) {
+        dbEntry.schemas.set(resource.schema, emptySchemaSelection());
+      }
+      const schemaEntry = dbEntry.schemas.get(resource.schema)!;
+
+      if (!resource.table) {
+        schemaEntry.wholeSchemaSelected = true;
+        continue;
+      }
+
+      if (!schemaEntry.tables.has(resource.table)) {
+        schemaEntry.tables.set(resource.table, emptyTableSelection());
+      }
+      const tableEntry = schemaEntry.tables.get(resource.table)!;
+      if (resource.columns !== undefined && resource.columns.length > 0) {
+        for (const column of resource.columns) {
+          tableEntry.columns.add(column);
         }
-        entry.schemas.get(r.schema)!.add(r.table);
+      } else {
+        tableEntry.wholeTableSelected = true;
       }
     }
     return map;
@@ -130,9 +322,7 @@ export function DatabaseResourceSelector({
       const entry = selectedResourceMap.get(dbName);
       if (!entry) return false;
       if (entry.wholeDatabaseSelected) return true;
-      const schemaEntry = entry.schemas.get(schemaName);
-      if (!schemaEntry) return false;
-      return schemaEntry.size === 0; // Empty set means whole schema selected
+      return entry.schemas.get(schemaName)?.wholeSchemaSelected === true;
     },
     [selectedResourceMap]
   );
@@ -140,11 +330,10 @@ export function DatabaseResourceSelector({
   const isSchemaIndeterminate = useCallback(
     (dbName: string, schemaName: string): boolean => {
       const entry = selectedResourceMap.get(dbName);
-      if (!entry) return false;
-      if (entry.wholeDatabaseSelected) return false;
+      if (!entry || entry.wholeDatabaseSelected) return false;
       const schemaEntry = entry.schemas.get(schemaName);
-      if (!schemaEntry) return false;
-      return schemaEntry.size > 0; // Has specific tables selected
+      if (!schemaEntry || schemaEntry.wholeSchemaSelected) return false;
+      return schemaEntry.tables.size > 0;
     },
     [selectedResourceMap]
   );
@@ -156,20 +345,82 @@ export function DatabaseResourceSelector({
       if (entry.wholeDatabaseSelected) return true;
       const schemaEntry = entry.schemas.get(schemaName);
       if (!schemaEntry) return false;
-      if (schemaEntry.size === 0) return true; // Whole schema selected
-      return schemaEntry.has(tableName);
+      if (schemaEntry.wholeSchemaSelected) return true;
+      return schemaEntry.tables.get(tableName)?.wholeTableSelected === true;
     },
     [selectedResourceMap]
+  );
+
+  const isTableIndeterminate = useCallback(
+    (dbName: string, schemaName: string, tableName: string): boolean => {
+      const entry = selectedResourceMap.get(dbName);
+      if (!entry || entry.wholeDatabaseSelected) return false;
+      const schemaEntry = entry.schemas.get(schemaName);
+      if (!schemaEntry || schemaEntry.wholeSchemaSelected) return false;
+      const tableEntry = schemaEntry.tables.get(tableName);
+      if (!tableEntry || tableEntry.wholeTableSelected) return false;
+      return tableEntry.columns.size > 0;
+    },
+    [selectedResourceMap]
+  );
+
+  const isColumnChecked = useCallback(
+    (
+      dbName: string,
+      schemaName: string,
+      tableName: string,
+      columnName: string
+    ): boolean => {
+      const entry = selectedResourceMap.get(dbName);
+      if (!entry) return false;
+      if (entry.wholeDatabaseSelected) return true;
+      const schemaEntry = entry.schemas.get(schemaName);
+      if (!schemaEntry) return false;
+      if (schemaEntry.wholeSchemaSelected) return true;
+      const tableEntry = schemaEntry.tables.get(tableName);
+      if (!tableEntry) return false;
+      if (tableEntry.wholeTableSelected) return true;
+      return tableEntry.columns.has(columnName);
+    },
+    [selectedResourceMap]
+  );
+
+  const addColumnsExcept = useCallback(
+    (
+      resources: DatabaseResource[],
+      dbName: string,
+      schemaName: string,
+      tableName: string,
+      columns: ColumnMetadata[],
+      columnName: string
+    ) => {
+      const remainingColumns = columns
+        .map((column) => column.name)
+        .filter((name) => name !== columnName);
+      if (remainingColumns.length === columns.length) {
+        resources.push({
+          databaseFullName: dbName,
+          schema: schemaName,
+          table: tableName,
+        });
+      } else if (remainingColumns.length > 0) {
+        resources.push({
+          databaseFullName: dbName,
+          schema: schemaName,
+          table: tableName,
+          columns: remainingColumns,
+        });
+      }
+    },
+    []
   );
 
   const toggleDatabase = useCallback(
     (db: Database) => {
       const dbName = db.name;
       if (isDatabaseChecked(dbName)) {
-        // Remove all resources for this database
         onChange(value.filter((r) => r.databaseFullName !== dbName));
       } else {
-        // Remove any partial selections and add whole database
         const filtered = value.filter((r) => r.databaseFullName !== dbName);
         onChange([...filtered, { databaseFullName: dbName }]);
       }
@@ -182,8 +433,6 @@ export function DatabaseResourceSelector({
       if (isSchemaChecked(dbName, schemaName)) {
         const entry = selectedResourceMap.get(dbName);
         if (entry?.wholeDatabaseSelected) {
-          // Whole database was selected: convert to individual schema selections
-          // for all schemas EXCEPT the unchecked one
           const metadata = metadataMap.get(dbName);
           if (metadata) {
             const filtered = value.filter((r) => r.databaseFullName !== dbName);
@@ -194,15 +443,17 @@ export function DatabaseResourceSelector({
             return;
           }
         }
-        // Remove this schema and all its tables
         const filtered = value.filter(
           (r) =>
             !(r.databaseFullName === dbName && r.schema === schemaName) &&
-            !(r.databaseFullName === dbName && !r.schema && !r.table)
+            !(
+              r.databaseFullName === dbName &&
+              r.schema === undefined &&
+              !r.table
+            )
         );
         onChange(filtered);
       } else {
-        // Remove any table-level selections for this schema, add schema-level
         const filtered = value.filter(
           (r) => !(r.databaseFullName === dbName && r.schema === schemaName)
         );
@@ -218,23 +469,21 @@ export function DatabaseResourceSelector({
   const toggleTable = useCallback(
     (dbName: string, schemaName: string, tableName: string) => {
       if (isTableChecked(dbName, schemaName, tableName)) {
-        // If whole schema was selected, we need to deselect this table
-        // by selecting all other tables individually
         const entry = selectedResourceMap.get(dbName);
         if (entry?.wholeDatabaseSelected) {
-          // Whole database was selected: need to expand into per-schema selections minus this table
           const metadata = metadataMap.get(dbName);
           if (!metadata) return;
           const newResources = value.filter(
             (r) => r.databaseFullName !== dbName
           );
           for (const schema of metadata.schemas) {
-            const sName = schema.name;
             for (const table of schema.tables) {
-              if (sName === schemaName && table.name === tableName) continue;
+              if (schema.name === schemaName && table.name === tableName) {
+                continue;
+              }
               newResources.push({
                 databaseFullName: dbName,
-                schema: sName,
+                schema: schema.name,
                 table: table.name,
               });
             }
@@ -242,9 +491,9 @@ export function DatabaseResourceSelector({
           onChange(newResources);
           return;
         }
+
         const schemaEntry = entry?.schemas.get(schemaName);
-        if (schemaEntry && schemaEntry.size === 0) {
-          // Whole schema was selected: expand into individual tables minus this one
+        if (schemaEntry?.wholeSchemaSelected) {
           const metadata = metadataMap.get(dbName);
           if (!metadata) return;
           const schema = metadata.schemas.find((s) => s.name === schemaName);
@@ -263,7 +512,7 @@ export function DatabaseResourceSelector({
           onChange(newResources);
           return;
         }
-        // Individual table was selected: just remove it
+
         onChange(
           value.filter(
             (r) =>
@@ -275,13 +524,164 @@ export function DatabaseResourceSelector({
           )
         );
       } else {
+        const filtered = value.filter(
+          (r) =>
+            !(
+              r.databaseFullName === dbName &&
+              r.schema === schemaName &&
+              r.table === tableName
+            )
+        );
         onChange([
-          ...value,
+          ...filtered,
           { databaseFullName: dbName, schema: schemaName, table: tableName },
         ]);
       }
     },
     [value, onChange, isTableChecked, selectedResourceMap, metadataMap]
+  );
+
+  const toggleColumn = useCallback(
+    (
+      dbName: string,
+      schemaName: string,
+      tableName: string,
+      columnName: string
+    ) => {
+      const metadata = metadataMap.get(dbName);
+      const schema = metadata?.schemas.find((s) => s.name === schemaName);
+      const table = schema?.tables.find((t) => t.name === tableName);
+      const entry = selectedResourceMap.get(dbName);
+      const checked = isColumnChecked(
+        dbName,
+        schemaName,
+        tableName,
+        columnName
+      );
+
+      if (checked) {
+        const newResources = value.filter((r) => r.databaseFullName !== dbName);
+        if (entry?.wholeDatabaseSelected && metadata && table) {
+          for (const s of metadata.schemas) {
+            for (const t of s.tables) {
+              if (s.name === schemaName && t.name === tableName) {
+                addColumnsExcept(
+                  newResources,
+                  dbName,
+                  s.name,
+                  t.name,
+                  t.columns,
+                  columnName
+                );
+              } else {
+                newResources.push({
+                  databaseFullName: dbName,
+                  schema: s.name,
+                  table: t.name,
+                });
+              }
+            }
+          }
+          onChange(newResources);
+          return;
+        }
+
+        const schemaEntry = entry?.schemas.get(schemaName);
+        if (schemaEntry?.wholeSchemaSelected && schema && table) {
+          for (const t of schema.tables) {
+            if (t.name === tableName) {
+              addColumnsExcept(
+                newResources,
+                dbName,
+                schemaName,
+                t.name,
+                t.columns,
+                columnName
+              );
+            } else {
+              newResources.push({
+                databaseFullName: dbName,
+                schema: schemaName,
+                table: t.name,
+              });
+            }
+          }
+          onChange(newResources);
+          return;
+        }
+
+        const tableEntry = schemaEntry?.tables.get(tableName);
+        const otherResources = value.filter(
+          (r) =>
+            !(
+              r.databaseFullName === dbName &&
+              r.schema === schemaName &&
+              r.table === tableName
+            )
+        );
+        if (tableEntry?.wholeTableSelected && table) {
+          const nextResources = [...otherResources];
+          addColumnsExcept(
+            nextResources,
+            dbName,
+            schemaName,
+            tableName,
+            table.columns,
+            columnName
+          );
+          onChange(nextResources);
+          return;
+        }
+
+        const remainingColumns = [
+          ...(tableEntry?.columns ?? new Set<string>()),
+        ].filter((column) => column !== columnName);
+        if (remainingColumns.length === 0) {
+          onChange(otherResources);
+          return;
+        }
+        onChange([
+          ...otherResources,
+          {
+            databaseFullName: dbName,
+            schema: schemaName,
+            table: tableName,
+            columns: remainingColumns,
+          },
+        ]);
+        return;
+      }
+
+      const tableEntry = entry?.schemas.get(schemaName)?.tables.get(tableName);
+      const nextColumns = [
+        ...new Set([...(tableEntry?.columns ?? new Set<string>()), columnName]),
+      ];
+      const otherResources = value.filter(
+        (r) =>
+          !(
+            r.databaseFullName === dbName &&
+            r.schema === schemaName &&
+            r.table === tableName
+          )
+      );
+      onChange([
+        ...otherResources,
+        {
+          databaseFullName: dbName,
+          schema: schemaName,
+          table: tableName,
+          columns: nextColumns,
+        },
+      ]);
+    },
+    [
+      addColumnsExcept,
+      isColumnChecked,
+      metadataMap,
+      onChange,
+      selectedResourceMap,
+      value,
+    ]
   );
 
   const toggleExpandDatabase = useCallback(
@@ -291,7 +691,6 @@ export function DatabaseResourceSelector({
         next.delete(dbName);
       } else {
         next.add(dbName);
-        // Lazy load metadata
         if (!metadataMap.has(dbName) && !loadingMetadata.has(dbName)) {
           setLoadingMetadata((prev) => new Set(prev).add(dbName));
           try {
@@ -303,9 +702,9 @@ export function DatabaseResourceSelector({
             // error shown by store
           } finally {
             setLoadingMetadata((prev) => {
-              const next = new Set(prev);
-              next.delete(dbName);
-              return next;
+              const nextLoading = new Set(prev);
+              nextLoading.delete(dbName);
+              return nextLoading;
             });
           }
         }
@@ -328,78 +727,107 @@ export function DatabaseResourceSelector({
     [expandedSchemas]
   );
 
+  const toggleExpandTable = useCallback(
+    (key: string) => {
+      const next = new Set(expandedTables);
+      if (next.has(key)) {
+        next.delete(key);
+      } else {
+        next.add(key);
+      }
+      setExpandedTables(next);
+    },
+    [expandedTables]
+  );
+
   const isAllSelected = useMemo(() => {
-    if (filteredDatabases.length === 0) return false;
-    return filteredDatabases.every((db) => isDatabaseChecked(db.name));
-  }, [filteredDatabases, isDatabaseChecked]);
+    if (databases.length === 0) return false;
+    return databases.every((db) => isDatabaseChecked(db.name));
+  }, [databases, isDatabaseChecked]);
 
   const toggleSelectAll = useCallback(() => {
     if (isAllSelected) {
-      // Remove all filtered databases
-      const filteredNames = new Set(filteredDatabases.map((db) => db.name));
+      const filteredNames = new Set(databases.map((db) => db.name));
       onChange(value.filter((r) => !filteredNames.has(r.databaseFullName)));
     } else {
-      // Add all filtered databases that aren't already selected
       const existing = new Set(
         value
-          .filter((r) => !r.schema && !r.table)
+          .filter((r) => r.schema === undefined && !r.table)
           .map((r) => r.databaseFullName)
       );
-      const filteredNames = new Set(filteredDatabases.map((db) => db.name));
-      // Remove partial selections for filtered databases, then add whole-db selections
+      const filteredNames = new Set(databases.map((db) => db.name));
       const kept = value.filter((r) => !filteredNames.has(r.databaseFullName));
-      const toAdd = filteredDatabases
+      const toAdd = databases
         .filter((db) => !existing.has(db.name))
         .map((db) => ({ databaseFullName: db.name }));
       onChange([...kept, ...toAdd]);
     }
-  }, [isAllSelected, filteredDatabases, value, onChange]);
+  }, [isAllSelected, databases, value, onChange]);
 
   const removeResource = useCallback(
     (resource: DatabaseResource) => {
-      onChange(
-        value.filter(
-          (r) =>
-            !(
-              r.databaseFullName === resource.databaseFullName &&
-              r.schema === resource.schema &&
-              r.table === resource.table
-            )
-        )
-      );
+      onChange(value.filter((r) => !sameResource(r, resource)));
     },
     [value, onChange]
   );
 
   const resourceLabel = (r: DatabaseResource): string => {
     const { databaseName } = extractDatabaseResourceName(r.databaseFullName);
-    if (r.table) return `${databaseName}.${r.schema}.${r.table}`;
+    const path = [databaseName, r.schema, r.table].filter(Boolean).join(".");
+    const columns = r.columns ?? [];
+    if (r.table && columns.length > 0) {
+      return `${path}: ${columns.join(", ")}`;
+    }
+    if (r.table) return path;
     if (r.schema) return `${databaseName}.${r.schema}`;
     return databaseName;
   };
 
   const hasSchemas = (metadata: DatabaseMetadata): boolean => {
-    // If there's only one schema with empty name, it's a MySQL-style DB (no schema concept)
     if (metadata.schemas.length === 1 && metadata.schemas[0].name === "") {
       return false;
     }
     return metadata.schemas.length > 0;
   };
 
+  const renderTable = (
+    dbName: string,
+    schemaName: string,
+    table: TableMetadata
+  ) => {
+    const key = tableKey(dbName, schemaName, table.name);
+    return (
+      <TableNode
+        key={table.name}
+        tableName={table.name}
+        columns={table.columns}
+        includeColumns={includeColumns}
+        checked={isTableChecked(dbName, schemaName, table.name)}
+        indeterminate={isTableIndeterminate(dbName, schemaName, table.name)}
+        expanded={expandedTables.has(key)}
+        onToggleExpand={() => toggleExpandTable(key)}
+        onChange={() => toggleTable(dbName, schemaName, table.name)}
+        isColumnChecked={(column) =>
+          isColumnChecked(dbName, schemaName, table.name, column)
+        }
+        onColumnChange={(column) =>
+          toggleColumn(dbName, schemaName, table.name, column)
+        }
+      />
+    );
+  };
+
   return (
     <div className="border border-control-border rounded-sm overflow-hidden">
-      {/* Filter */}
       <div className="bg-gray-50 border-b border-control-border px-2 py-1.5">
-        <SearchInput
+        <AdvancedSearch
           placeholder={t("common.filter")}
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          className="h-7"
+          params={searchParams}
+          onParamsChange={setSearchParams}
+          scopeOptions={scopeOptions}
         />
       </div>
-      {/* Body */}
       <div className="flex" style={{ height: "min(24rem, 60vh)" }}>
-        {/* Left panel */}
         <div className="flex-1 flex flex-col border-r border-control-border min-w-0">
           <div className="flex items-center justify-between px-3 py-1.5 bg-gray-50 border-b border-control-border text-xs text-control-light">
             <button
@@ -412,12 +840,12 @@ export function DatabaseResourceSelector({
                 : t("common.select-all")}
             </button>
             <span>
-              {t("common.total")} {filteredDatabases.length}{" "}
-              {t("common.items", { count: filteredDatabases.length })}
+              {t("common.total")} {databases.length}{" "}
+              {t("common.items", { count: databases.length })}
             </span>
           </div>
           <div className="flex-1 overflow-y-auto">
-            {filteredDatabases.map((db) => {
+            {databases.map((db) => {
               const { databaseName } = extractDatabaseResourceName(db.name);
               const envName = db.effectiveEnvironment ?? db.environment;
               const instanceTitle = db.instanceResource?.title ?? "";
@@ -426,10 +854,10 @@ export function DatabaseResourceSelector({
               const isLoading = loadingMetadata.has(db.name);
               const dbChecked = isDatabaseChecked(db.name);
               const dbIndeterminate = isDatabaseIndeterminate(db.name);
+              const firstSchema = metadata?.schemas[0];
 
               return (
                 <div key={db.name}>
-                  {/* Database row */}
                   <div className="flex items-center gap-x-1 px-2 py-1 hover:bg-gray-50 group">
                     <button
                       type="button"
@@ -462,13 +890,11 @@ export function DatabaseResourceSelector({
                     <DatabaseIcon className="w-3.5 h-3.5 text-control-light shrink-0" />
                     <span className="text-sm truncate">{databaseName}</span>
                   </div>
-                  {/* Instance name subtitle */}
                   {instanceTitle && (
                     <div className="pl-10 text-xs text-control-light pb-0.5">
                       ({instanceTitle})
                     </div>
                   )}
-                  {/* Expanded content */}
                   {isExpanded && (
                     <div className="pl-6">
                       {isLoading && (
@@ -476,31 +902,14 @@ export function DatabaseResourceSelector({
                           {t("common.loading")}...
                         </div>
                       )}
-                      {metadata && !hasSchemas(metadata) && (
-                        // MySQL-style: show tables directly under database
+                      {metadata && !hasSchemas(metadata) && firstSchema && (
                         <>
-                          {metadata.schemas[0]?.tables.map((table) => (
-                            <TableRow
-                              key={table.name}
-                              tableName={table.name}
-                              checked={isTableChecked(
-                                db.name,
-                                metadata.schemas[0].name,
-                                table.name
-                              )}
-                              onChange={() =>
-                                toggleTable(
-                                  db.name,
-                                  metadata.schemas[0].name,
-                                  table.name
-                                )
-                              }
-                            />
-                          ))}
+                          {firstSchema.tables.map((table) =>
+                            renderTable(db.name, firstSchema.name, table)
+                          )}
                         </>
                       )}
                       {metadata && hasSchemas(metadata) && (
-                        // Postgres-style: show schemas then tables
                         <>
                           {metadata.schemas.map((schema) => {
                             const schemaKey = `${db.name}/${schema.name}`;
@@ -551,24 +960,9 @@ export function DatabaseResourceSelector({
                                 </div>
                                 {schemaExpanded && (
                                   <div className="pl-6">
-                                    {schema.tables.map((table) => (
-                                      <TableRow
-                                        key={table.name}
-                                        tableName={table.name}
-                                        checked={isTableChecked(
-                                          db.name,
-                                          schema.name,
-                                          table.name
-                                        )}
-                                        onChange={() =>
-                                          toggleTable(
-                                            db.name,
-                                            schema.name,
-                                            table.name
-                                          )
-                                        }
-                                      />
-                                    ))}
+                                    {schema.tables.map((table) =>
+                                      renderTable(db.name, schema.name, table)
+                                    )}
                                   </div>
                                 )}
                               </div>
@@ -583,7 +977,6 @@ export function DatabaseResourceSelector({
             })}
           </div>
         </div>
-        {/* Right panel */}
         <div className="flex-1 flex flex-col min-w-0">
           <div className="flex items-center px-3 py-1.5 bg-gray-50 border-b border-control-border text-xs text-control-light">
             <span>
@@ -600,7 +993,7 @@ export function DatabaseResourceSelector({
               <div className="p-1">
                 {value.map((r) => (
                   <div
-                    key={`${r.databaseFullName}/${r.schema ?? ""}/${r.table ?? ""}`}
+                    key={`${r.databaseFullName}/${r.schema ?? ""}/${r.table ?? ""}/${(r.columns ?? []).join("\0")}`}
                     className="flex items-center gap-x-1 px-2 py-1 text-sm hover:bg-gray-50 group rounded-sm"
                   >
                     <span className="flex-1 truncate">{resourceLabel(r)}</span>
@@ -622,25 +1015,74 @@ export function DatabaseResourceSelector({
   );
 }
 
-function TableRow({
+function TableNode({
   tableName,
+  columns,
+  includeColumns,
   checked,
+  indeterminate,
+  expanded,
+  onToggleExpand,
   onChange,
+  isColumnChecked,
+  onColumnChange,
 }: {
   tableName: string;
+  columns: ColumnMetadata[];
+  includeColumns: boolean;
   checked: boolean;
+  indeterminate: boolean;
+  expanded: boolean;
+  onToggleExpand: () => void;
   onChange: () => void;
+  isColumnChecked: (column: string) => boolean;
+  onColumnChange: (column: string) => void;
 }) {
   return (
-    <div className="flex items-center gap-x-1 px-2 py-1 hover:bg-gray-50">
-      <span className="shrink-0 w-4" />
-      <Checkbox
-        className="shrink-0"
-        checked={checked}
-        onCheckedChange={() => onChange()}
-      />
-      <Table2 className="w-3.5 h-3.5 text-control-light shrink-0" />
-      <span className="text-sm truncate">{tableName}</span>
+    <div>
+      <div className="flex items-center gap-x-1 px-2 py-1 hover:bg-gray-50">
+        {includeColumns && columns.length > 0 ? (
+          <button
+            type="button"
+            className="shrink-0 w-4 h-4 flex items-center justify-center text-control-light hover:text-control cursor-pointer"
+            onClick={onToggleExpand}
+          >
+            {expanded ? (
+              <ChevronDown className="w-3.5 h-3.5" />
+            ) : (
+              <ChevronRight className="w-3.5 h-3.5" />
+            )}
+          </button>
+        ) : (
+          <span className="shrink-0 w-4" />
+        )}
+        <Checkbox
+          className="shrink-0"
+          checked={checked ? true : indeterminate ? "indeterminate" : false}
+          onCheckedChange={() => onChange()}
+        />
+        <Table2 className="w-3.5 h-3.5 text-control-light shrink-0" />
+        <span className="text-sm truncate">{tableName}</span>
+      </div>
+      {includeColumns && expanded && columns.length > 0 && (
+        <div className="pl-6">
+          {columns.map((column) => (
+            <div
+              key={column.name}
+              className="flex items-center gap-x-1 px-2 py-1 hover:bg-gray-50"
+            >
+              <span className="shrink-0 w-4" />
+              <Checkbox
+                className="shrink-0"
+                checked={isColumnChecked(column.name)}
+                onCheckedChange={() => onColumnChange(column.name)}
+              />
+              <Columns3 className="w-3.5 h-3.5 text-control-light shrink-0" />
+              <span className="text-sm truncate">{column.name}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -1350,7 +1350,8 @@
           "title": "Engine"
         },
         "environment": {
-          "description": "Filter by environment"
+          "description": "Filter by environment",
+          "title": "Environment"
         },
         "instance": {
           "description": "Filter by instance",
@@ -1381,6 +1382,10 @@
         },
         "status": {
           "description": "Search by the issue status"
+        },
+        "table": {
+          "description": "Input the value then press Enter",
+          "title": "Table"
         },
         "user": {
           "description": "Filter by user"
@@ -1424,7 +1429,6 @@
     "role-grant": {
       "all-databases": "All databases",
       "all-databases-tip": "All current and future databases in this project.",
-      "column-scope-select-disabled": "Manually select is unavailable for column-scoped selections.",
       "details": "Role Grant Details",
       "expired-at": "Expired at",
       "manually-select": "Manually select",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -1343,7 +1343,8 @@
           "title": "Motor"
         },
         "environment": {
-          "description": "Filtrar por entorno"
+          "description": "Filtrar por entorno",
+          "title": "Ambiente"
         },
         "instance": {
           "description": "Filtrar por instancia",
@@ -1374,6 +1375,10 @@
         },
         "status": {
           "description": "Buscar por el estado del issue"
+        },
+        "table": {
+          "description": "Ingrese el valor y luego presione Enter",
+          "title": "Tabla"
         },
         "user": {
           "description": "Filtrar por usuario"
@@ -1416,7 +1421,6 @@
     "role-grant": {
       "all-databases": "todas las bases de datos",
       "all-databases-tip": "Todas las bases de datos actuales y futuras de este proyecto.",
-      "column-scope-select-disabled": "La selección manual no está disponible para selecciones con alcance de columna.",
       "details": "Role Grant Details",
       "expired-at": "Expired at",
       "manually-select": "selección manual",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -1343,7 +1343,8 @@
           "title": "エンジン"
         },
         "environment": {
-          "description": "環境に基づいてフィルタリングする"
+          "description": "環境に基づいてフィルタリングする",
+          "title": "環境"
         },
         "instance": {
           "description": "インスタンスによるフィルター",
@@ -1374,6 +1375,10 @@
         },
         "status": {
           "description": "イシューのステータスで検索"
+        },
+        "table": {
+          "description": "値を入力してEnterを押します",
+          "title": "テーブル"
         },
         "user": {
           "description": "ユーザーでフィルター"
@@ -1416,7 +1421,6 @@
     "role-grant": {
       "all-databases": "すべてのデータベース",
       "all-databases-tip": "このプロジェクトに属する現在および将来のすべてのデータベース。",
-      "column-scope-select-disabled": "列単位の選択では手動選択を使用できません。",
       "details": "Role Grant Details",
       "expired-at": "Expired at",
       "manually-select": "手動選択",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -1343,7 +1343,8 @@
           "title": "Engine"
         },
         "environment": {
-          "description": "Lọc theo môi trường"
+          "description": "Lọc theo môi trường",
+          "title": "Môi trường"
         },
         "instance": {
           "description": "Lọc theo phiên bản",
@@ -1374,6 +1375,10 @@
         },
         "status": {
           "description": "Tìm kiếm theo trạng thái issue"
+        },
+        "table": {
+          "description": "Nhập giá trị sau đó nhấn Enter",
+          "title": "Bảng"
         },
         "user": {
           "description": "Lọc theo người dùng"
@@ -1416,7 +1421,6 @@
     "role-grant": {
       "all-databases": "Tất cả cơ sở dữ liệu",
       "all-databases-tip": "Tất cả cơ sở dữ liệu hiện tại và tương lai trong dự án này.",
-      "column-scope-select-disabled": "Không thể chọn thủ công cho phạm vi ở mức cột.",
       "details": "Role Grant Details",
       "expired-at": "Expired at",
       "manually-select": "Chọn thủ công",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -1343,7 +1343,8 @@
           "title": "引擎"
         },
         "environment": {
-          "description": "根据环境过滤"
+          "description": "根据环境过滤",
+          "title": "环境"
         },
         "instance": {
           "description": "根据实例过滤",
@@ -1374,6 +1375,10 @@
         },
         "status": {
           "description": "按工单状态搜索"
+        },
+        "table": {
+          "description": "输入值后按下回车",
+          "title": "表"
         },
         "user": {
           "description": "按用户筛选"
@@ -1416,7 +1421,6 @@
     "role-grant": {
       "all-databases": "所有数据库",
       "all-databases-tip": "所有当前和未来属于这个项目的数据库。",
-      "column-scope-select-disabled": "列级范围的选择不能使用手动选择。",
       "details": "Role Grant Details",
       "expired-at": "Expired at",
       "manually-select": "手动选择",

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionCreatePage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionCreatePage.tsx
@@ -368,6 +368,7 @@ export function ProjectMaskingExemptionCreatePage({
               <DatabaseResourceSelector
                 projectName={projectName}
                 value={databaseResources}
+                includeColumns
                 onChange={setDatabaseResources}
               />
             )}

--- a/frontend/src/react/pages/project/database-detail/catalog/GrantAccessDialog.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/catalog/GrantAccessDialog.test.tsx
@@ -102,8 +102,19 @@ vi.mock("@/react/components/AccountMultiSelect", () => ({
 }));
 
 vi.mock("@/react/components/DatabaseResourceSelector", () => ({
-  DatabaseResourceSelector: ({ value }: { value: unknown }) => (
-    <div data-testid="database-resource-selector">{JSON.stringify(value)}</div>
+  DatabaseResourceSelector: ({
+    value,
+    includeColumns,
+  }: {
+    value: unknown;
+    includeColumns?: boolean;
+  }) => (
+    <div
+      data-include-columns={String(includeColumns)}
+      data-testid="database-resource-selector"
+    >
+      {JSON.stringify(value)}
+    </div>
   ),
 }));
 
@@ -367,7 +378,7 @@ describe("GrantAccessDialog", () => {
       container.querySelectorAll<HTMLInputElement>('input[type="radio"]')
     );
     expect(radioList[1]?.checked).toBe(true);
-    expect(radioList[2]?.disabled).toBe(true);
+    expect(radioList[2]?.disabled).toBe(false);
 
     const exprEditor = container.querySelector('[data-testid="expr-editor"]');
     expect(exprEditor?.textContent).toContain("serialized-selection");
@@ -375,7 +386,7 @@ describe("GrantAccessDialog", () => {
     unmount();
   });
 
-  test("disables select mode after CEL scope becomes column-scoped", async () => {
+  test("allows select mode after CEL scope becomes column-scoped", async () => {
     const { container, unmount } = renderGrantAccessDialog();
     await flush();
 
@@ -396,15 +407,19 @@ describe("GrantAccessDialog", () => {
       container.querySelectorAll<HTMLInputElement>('input[type="radio"]')
     );
     expect(radioList[1]?.checked).toBe(true);
-    expect(radioList[2]?.disabled).toBe(true);
+    expect(radioList[2]?.disabled).toBe(false);
 
     await click(radioList[2]!);
 
     radioList = Array.from(
       container.querySelectorAll<HTMLInputElement>('input[type="radio"]')
     );
-    expect(radioList[1]?.checked).toBe(true);
-    expect(container.querySelector('[data-testid="expr-editor"]')).toBeTruthy();
+    expect(radioList[2]?.checked).toBe(true);
+    expect(
+      container
+        .querySelector('[data-testid="database-resource-selector"]')
+        ?.getAttribute("data-include-columns")
+    ).toBe("true");
 
     unmount();
   });

--- a/frontend/src/react/pages/project/database-detail/catalog/GrantAccessDialog.tsx
+++ b/frontend/src/react/pages/project/database-detail/catalog/GrantAccessDialog.tsx
@@ -11,19 +11,11 @@ import {
   convertSensitiveColumnToDatabaseResource,
   getExpressionsForDatabaseResource as getResourceExpressions,
 } from "@/components/SensitiveData/utils";
-import type {
-  ConditionGroupExpr,
-  Factor,
-  Operator,
-  SimpleExpr,
-} from "@/plugins/cel";
+import type { ConditionGroupExpr, Factor, Operator } from "@/plugins/cel";
 import {
   buildCELExpr,
   ExprType,
   emptySimpleExpr,
-  isConditionExpr,
-  isConditionGroupExpr,
-  isRawStringExpr,
   resolveCELExpr,
   validateSimpleExpr,
   wrapAsGroup,
@@ -87,19 +79,6 @@ interface GrantAccessDialogProps {
 
 const hasColumnScopedResources = (resources: DatabaseResource[]): boolean => {
   return resources.some((resource) => (resource.columns?.length ?? 0) > 0);
-};
-
-const hasColumnScopedExpr = (expr: SimpleExpr): boolean => {
-  if (isConditionGroupExpr(expr)) {
-    return expr.args.some((arg) => hasColumnScopedExpr(arg));
-  }
-  if (isConditionExpr(expr)) {
-    return expr.args[0] === CEL_ATTRIBUTE_RESOURCE_COLUMN_NAME;
-  }
-  if (isRawStringExpr(expr)) {
-    return expr.content.includes(CEL_ATTRIBUTE_RESOURCE_COLUMN_NAME);
-  }
-  return false;
 };
 
 export function GrantAccessDialog({
@@ -261,17 +240,6 @@ export function GrantAccessDialog({
     setModeChangeProcessing(false);
   }, [open]);
 
-  const exprHasColumnScope = useMemo(() => hasColumnScopedExpr(expr), [expr]);
-  const selectModeDisabled = useMemo(() => {
-    if (hasColumnScopedResource) {
-      return true;
-    }
-    if (radioValue === "EXPRESSION") {
-      return exprHasColumnScope;
-    }
-    return false;
-  }, [hasColumnScopedResource, radioValue, exprHasColumnScope]);
-
   const isValid = useMemo(() => {
     switch (radioValue) {
       case "SELECT":
@@ -351,10 +319,6 @@ export function GrantAccessDialog({
         setShowFeatureModal(true);
         return;
       }
-      if (value === "SELECT" && selectModeDisabled) {
-        return;
-      }
-
       const requestId = modeChangeRequestIdRef.current + 1;
       modeChangeRequestIdRef.current = requestId;
 
@@ -400,7 +364,6 @@ export function GrantAccessDialog({
     },
     [
       hasRequiredFeature,
-      selectModeDisabled,
       radioValue,
       convertToConditionGroupExpr,
       databaseResources,
@@ -584,40 +547,22 @@ export function GrantAccessDialog({
                     </div>
                   </label>
 
-                  <label
-                    className={`flex items-center gap-x-2 ${
-                      selectModeDisabled
-                        ? "cursor-not-allowed"
-                        : "cursor-pointer"
-                    }`}
-                  >
+                  <label className="flex items-center gap-x-2 cursor-pointer">
                     <input
                       type="radio"
                       name="resource-mode"
                       checked={radioValue === "SELECT"}
                       onChange={() => onRadioChange("SELECT")}
-                      disabled={selectModeDisabled || modeChangeProcessing}
+                      disabled={modeChangeProcessing}
                       className="accent-accent"
                     />
-                    <Tooltip
-                      content={
-                        selectModeDisabled
-                          ? t("issue.role-grant.column-scope-select-disabled")
-                          : ""
-                      }
-                    >
-                      <div
-                        className={`flex items-center gap-x-1 ${
-                          selectModeDisabled ? "cursor-not-allowed" : ""
-                        }`}
-                      >
-                        <FeatureBadge
-                          feature={PlanFeature.FEATURE_DATA_MASKING}
-                          instance={instance}
-                        />
-                        <span>{t("issue.role-grant.manually-select")}</span>
-                      </div>
-                    </Tooltip>
+                    <div className="flex items-center gap-x-1">
+                      <FeatureBadge
+                        feature={PlanFeature.FEATURE_DATA_MASKING}
+                        instance={instance}
+                      />
+                      <span>{t("issue.role-grant.manually-select")}</span>
+                    </div>
                   </label>
                 </div>
               </div>
@@ -626,6 +571,7 @@ export function GrantAccessDialog({
                 <DatabaseResourceSelector
                   projectName={projectName}
                   value={databaseResources}
+                  includeColumns
                   onChange={setDatabaseResources}
                 />
               )}


### PR DESCRIPTION
Linear: close BYT-9389

<img width="3420" height="2130" alt="CleanShot 2026-05-08 at 18 56 45@2x" src="https://github.com/user-attachments/assets/665cf6e4-0c97-4824-a8fb-fed0ed579036" />


## Summary

- restore column-level resource selection in the React database resource selector
- wire column selection into project masking exemption creation and catalog grant access flows
- restore Vue-era database selector filters for environment, instance, label, engine, and table
- remove the obsolete column-scoped SELECT-disabled locale and coverage check

## Testing

- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- cd frontend && pnpm exec vitest run src/react/components/DatabaseResourceSelector.test.tsx src/react/pages/project/database-detail/catalog/GrantAccessDialog.test.tsx src/plugins/i18n.test.ts

Note: full `pnpm --dir frontend test` was attempted locally, but the run is currently blocked by existing Vitest localStorage environment failures in unrelated header tests (`localStorage.clear/setItem is not a function`). The targeted tests above pass.