### PR TITLE
fix(frontend): stabilize SSH connection form

### DIFF
--- a/frontend/src/react/components/instance/InstanceFormContext.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.tsx
@@ -44,6 +44,7 @@ import {
   extractBasicInfo,
   extractDataSourceEditState,
 } from "./common";
+import { effectivePortForEngine } from "./constants";
 import { type InstanceSpecs, useInstanceSpecs } from "./specs";
 
 export type LocalState = {
@@ -339,6 +340,7 @@ export function InstanceFormProvider({
         ds.masterPassword = edit.updatedMasterPassword;
       if (edit.useEmptyMasterPassword) ds.masterPassword = "";
       if (edit.updatedToken) ds.authenticationPrivateKey = edit.updatedToken;
+      ds.port = effectivePortForEngine(engine, ds.port, ds.srv);
       if (!specs.showDatabase) ds.database = "";
       if (engine !== Engine.ORACLE) {
         ds.sid = "";

--- a/frontend/src/react/components/instance/SshConnectionForm.test.tsx
+++ b/frontend/src/react/components/instance/SshConnectionForm.test.tsx
@@ -1,0 +1,97 @@
+import { act, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { SshConnectionForm } from "./SshConnectionForm";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+type SshValue = {
+  sshHost: string;
+  sshPort: string;
+  sshUser: string;
+  sshPassword: string;
+  sshPrivateKey: string;
+};
+
+const emptySshValue = (): SshValue => ({
+  sshHost: "",
+  sshPort: "",
+  sshUser: "",
+  sshPassword: "",
+  sshPrivateKey: "",
+});
+
+function ControlledSshConnectionForm() {
+  const [value, setValue] = useState<SshValue>(emptySshValue);
+  return (
+    <SshConnectionForm
+      value={value}
+      onChange={(partial) => setValue((prev) => ({ ...prev, ...partial }))}
+    />
+  );
+}
+
+function mount(node: React.ReactNode) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return { container, root };
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value"
+  )?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("SshConnectionForm", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("keeps tunnel selected after editing SSH fields before port is entered", () => {
+    const { container, root } = mount(<ControlledSshConnectionForm />);
+    const tunnelRadio = container.querySelector(
+      'input[value="TUNNEL+PK"]'
+    ) as HTMLInputElement | null;
+    expect(tunnelRadio).not.toBeNull();
+
+    act(() => {
+      tunnelRadio?.click();
+    });
+
+    let userInput = container.querySelector(
+      "#sshUser"
+    ) as HTMLInputElement | null;
+    expect(userInput).not.toBeNull();
+
+    act(() => {
+      setInputValue(userInput!, "alice");
+    });
+
+    userInput = container.querySelector("#sshUser");
+    expect(userInput).not.toBeNull();
+    expect(
+      (container.querySelector('input[value="TUNNEL+PK"]') as HTMLInputElement)
+        .checked
+    ).toBe(true);
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/frontend/src/react/components/instance/SshConnectionForm.tsx
+++ b/frontend/src/react/components/instance/SshConnectionForm.tsx
@@ -22,7 +22,13 @@ interface SshConnectionFormProps {
 }
 
 function guessSshType(value: Partial<SshValue>): SshType {
-  if (value.sshPort) {
+  if (
+    value.sshHost ||
+    value.sshPort ||
+    value.sshUser ||
+    value.sshPassword ||
+    value.sshPrivateKey
+  ) {
     return "TUNNEL+PK";
   }
   return "NONE";

--- a/frontend/src/react/components/instance/constants.test.ts
+++ b/frontend/src/react/components/instance/constants.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, vi } from "vitest";
+import { Engine } from "@/types/proto-es/v1/common_pb";
+import { effectivePortForEngine } from "./constants";
+
+vi.mock("@/utils", () => ({
+  supportedEngineV1List: () => [],
+}));
+
+describe("effectivePortForEngine", () => {
+  test("uses the engine default when the editable port is blank", () => {
+    expect(effectivePortForEngine(Engine.MYSQL, "", true)).toBe("3306");
+  });
+
+  test("preserves explicit custom ports", () => {
+    expect(effectivePortForEngine(Engine.MYSQL, "3307", true)).toBe("3307");
+  });
+
+  test("uses the engine default for MongoDB non-SRV data sources", () => {
+    expect(effectivePortForEngine(Engine.MONGODB, "", false)).toBe("27017");
+  });
+
+  test("preserves blank ports for MongoDB SRV data sources", () => {
+    expect(effectivePortForEngine(Engine.MONGODB, "", true)).toBe("");
+  });
+});

--- a/frontend/src/react/components/instance/constants.ts
+++ b/frontend/src/react/components/instance/constants.ts
@@ -57,6 +57,17 @@ export const defaultPortForEngine = (engine: Engine) => {
   throw new Error("engine port unknown");
 };
 
+export const effectivePortForEngine = (
+  engine: Engine,
+  port: string,
+  srv: boolean
+) => {
+  if (port || (engine === Engine.MONGODB && srv)) {
+    return port;
+  }
+  return defaultPortForEngine(engine);
+};
+
 export const getEngineList = () => supportedEngineV1List();
 
 export const MongoDBConnectionStringSchemaList = [


### PR DESCRIPTION
## Linear Issue
close BYT-9411

## Summary
- Keep SSH tunnel selected when editing SSH fields before the SSH port is entered.
- Apply database default ports when serializing data sources with blank editable ports.
- Preserve blank ports for MongoDB SRV data sources and add regression coverage.

## Test Plan
- [x] `pnpm --dir frontend exec vitest run src/react/components/instance/constants.test.ts src/react/components/instance/SshConnectionForm.test.tsx --passWithNoTests`
- [x] `pnpm --dir frontend fix`
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`
- [ ] `pnpm --dir frontend test` (fails in existing header/localStorage tests: `DashboardHeader.test.tsx` and `VersionMenuItem.test.tsx` report `localStorage.setItem/clear is not a function`)

## Pre-PR Checklist
- Breaking change check: frontend bug fix only; no breaking label needed.
- Composite-PK query safety: skipped, no `backend/store` or migrator changes.
- SonarCloud properties: skipped, new files are tests under existing frontend test paths.