### PR TITLE
refactor(react): simplify alert content API

### DIFF
--- a/frontend/src/react/components/CustomApproval/RuleEditSheet.tsx
+++ b/frontend/src/react/components/CustomApproval/RuleEditSheet.tsx
@@ -175,9 +175,12 @@ export function RuleEditSheet({
         <SheetBody className="gap-y-4">
           {/* Fallback hint */}
           {isFallback && (
-            <Alert variant="warning">
-              {t("custom-approval.approval-flow.fallback-rules-hint")}
-            </Alert>
+            <Alert
+              variant="warning"
+              description={t(
+                "custom-approval.approval-flow.fallback-rules-hint"
+              )}
+            />
           )}
 
           {/* Template presets (create mode only) */}

--- a/frontend/src/react/components/FeatureAttention.tsx
+++ b/frontend/src/react/components/FeatureAttention.tsx
@@ -1,11 +1,6 @@
-import { CircleAlert, Info } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import {
   useServerState,
@@ -124,32 +119,27 @@ export function FeatureAttention({
     router.push(autoSubscriptionRoute());
   };
 
-  const Icon = isWarning ? CircleAlert : Info;
-
   return (
     <>
-      <Alert variant={isWarning ? "warning" : "info"} showIcon={false}>
-        <Icon className="size-5 mt-0.5 shrink-0" />
-        <div className="flex-1 flex flex-col gap-3">
-          <div className="flex flex-col gap-1">
-            <AlertTitle>{title}</AlertTitle>
-            <AlertDescription className="mt-0 whitespace-pre-line">
-              {descriptionText}
-            </AlertDescription>
+      <Alert
+        variant={isWarning ? "warning" : "info"}
+        title={title}
+        description={
+          <span className="whitespace-pre-line">{descriptionText}</span>
+        }
+      >
+        {actionText && (
+          <div className="mt-3 flex justify-end">
+            <Button
+              variant="outline"
+              size="sm"
+              className="shrink-0 whitespace-nowrap"
+              onClick={onAction}
+            >
+              {actionText}
+            </Button>
           </div>
-          {actionText && (
-            <div className="flex justify-end">
-              <Button
-                variant="outline"
-                size="sm"
-                className="shrink-0 whitespace-nowrap"
-                onClick={onAction}
-              >
-                {actionText}
-              </Button>
-            </div>
-          )}
-        </div>
+        )}
       </Alert>
       {!hasUnifiedInstanceLicense && (
         <InstanceAssignmentSheet

--- a/frontend/src/react/components/ProjectRouteShell.tsx
+++ b/frontend/src/react/components/ProjectRouteShell.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { IAMRemindDialog } from "@/react/components/IAMRemindDialog";
 import { RoutePermissionGuardShell } from "@/react/components/RoutePermissionGuardShell";
-import { Alert, AlertDescription } from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import type { ReactRouteShellTargets } from "@/react/dashboard-shell";
 import { useNotify } from "@/react/hooks/useAppState";
 import {
@@ -148,11 +148,11 @@ export function ProjectRouteShell({
           <h1 className="mb-4 text-xl font-bold leading-6 text-main truncate">
             {t("database.unassigned-databases")}
           </h1>
-          <Alert variant="info" className="mb-4">
-            <AlertDescription>
-              {t("project.overview.info-slot-content")}
-            </AlertDescription>
-          </Alert>
+          <Alert
+            variant="info"
+            className="mb-4"
+            description={t("project.overview.info-slot-content")}
+          />
         </div>
       )}
       <RoutePermissionGuardShell

--- a/frontend/src/react/components/database/LabelEditorSheet.tsx
+++ b/frontend/src/react/components/database/LabelEditorSheet.tsx
@@ -82,9 +82,11 @@ export function LabelEditorSheet({
         </SheetHeader>
         <SheetBody>
           {hasMixedValues && (
-            <Alert variant="warning" className="mb-4">
-              {t("database.mixed-label-values-warning")}
-            </Alert>
+            <Alert
+              variant="warning"
+              className="mb-4"
+              description={t("database.mixed-label-values-warning")}
+            />
           )}
           <div className="flex items-center gap-x-2 mb-4">
             <Input

--- a/frontend/src/react/components/instance/CreateDataSourceExample.tsx
+++ b/frontend/src/react/components/instance/CreateDataSourceExample.tsx
@@ -381,9 +381,13 @@ function EngineSpecificDescription({
   if (engine === Engine.POSTGRES) {
     return (
       <>
-        <Alert variant="warning" className="my-2">
-          {t("instance.sentence.create-user-example.postgresql.warn")}
-        </Alert>
+        <Alert
+          variant="warning"
+          className="my-2"
+          description={t(
+            "instance.sentence.create-user-example.postgresql.warn"
+          )}
+        />
         {authenticationType ===
         DataSource_AuthenticationType.GOOGLE_CLOUD_SQL_IAM ? (
           <p>

--- a/frontend/src/react/components/instance/DataSourceSection.tsx
+++ b/frontend/src/react/components/instance/DataSourceSection.tsx
@@ -113,18 +113,22 @@ export function DataSourceSection({
   return (
     <>
       {showROTips && (
-        <Alert variant="warning" className="my-4">
-          <div className="flex items-center justify-between gap-x-2">
-            <span>{t("data-source.no-read-only-data-source")}</span>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleCreateRODataSource}
-            >
-              {t("common.create")}
-            </Button>
-          </div>
-        </Alert>
+        <Alert
+          variant="warning"
+          className="my-4"
+          description={
+            <div className="flex items-center justify-between gap-x-2">
+              <span>{t("data-source.no-read-only-data-source")}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleCreateRODataSource}
+              >
+                {t("common.create")}
+              </Button>
+            </div>
+          }
+        />
       )}
 
       <div className="mt-2 gap-y-2 gap-x-4 border-none">

--- a/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.test.tsx
+++ b/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.test.tsx
@@ -119,8 +119,20 @@ vi.mock("@/react/components/ui/sheet", () => ({
 }));
 
 vi.mock("@/react/components/ui/alert", () => ({
-  Alert: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="alert">{children}</div>
+  Alert: ({
+    children,
+    title,
+    description,
+  }: {
+    children?: React.ReactNode;
+    title?: React.ReactNode;
+    description?: React.ReactNode;
+  }) => (
+    <div data-testid="alert">
+      {title}
+      {description}
+      {children}
+    </div>
   ),
 }));
 

--- a/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
+++ b/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
@@ -254,7 +254,10 @@ function AccessGrantRequestDrawerInner({
               {t("common.statement")}
               <span className="text-error ml-0.5">*</span>
             </div>
-            <Alert variant="info">{t("sql-editor.only-select-allowed")}</Alert>
+            <Alert
+              variant="info"
+              description={t("sql-editor.only-select-allowed")}
+            />
             <MonacoEditor
               className="border rounded-[3px] h-40"
               content={query}

--- a/frontend/src/react/components/sql-editor/ExecuteHint.tsx
+++ b/frontend/src/react/components/sql-editor/ExecuteHint.tsx
@@ -95,24 +95,27 @@ export function ExecuteHint({ database, onClose }: Props) {
 
   return (
     <div className="w-[28rem]">
-      <Alert variant="info">
-        <section className="flex flex-col gap-y-2">
-          <p>{t("sql-editor.only-select-allowed")}</p>
-          {database && environment && (
-            <p>
-              <Trans
-                t={t}
-                i18nKey="sql-editor.ddl-dml-requires-data-change-plan"
-                components={{
-                  environment: (
-                    <span className="font-medium">{environment.title}</span>
-                  ),
-                }}
-              />
-            </p>
-          )}
-        </section>
-      </Alert>
+      <Alert
+        variant="info"
+        description={
+          <section className="flex flex-col gap-y-2">
+            <p>{t("sql-editor.only-select-allowed")}</p>
+            {database && environment && (
+              <p>
+                <Trans
+                  t={t}
+                  i18nKey="sql-editor.ddl-dml-requires-data-change-plan"
+                  components={{
+                    environment: (
+                      <span className="font-medium">{environment.title}</span>
+                    ),
+                  }}
+                />
+              </p>
+            )}
+          </section>
+        }
+      />
 
       <div className="mt-4 flex justify-between">
         {allowAdmin && (

--- a/frontend/src/react/components/sql-review/Panels.tsx
+++ b/frontend/src/react/components/sql-review/Panels.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getRuleKey } from "@/components/SQLReview/components/utils";
-import { Alert, AlertDescription } from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import {
   Sheet,
@@ -343,20 +343,23 @@ export function AttachResourcesPanel({
 
         {showOverrideConfirm && conflictingResources.length > 0 && (
           <div className="px-4 py-3 border-t">
-            <Alert variant="warning">
-              <AlertDescription>
-                <p className="mb-2">
-                  {t("sql-review.attach-resource.override-warning", {
-                    button: t("common.confirm"),
-                  })}
-                </p>
-                <ul className="list-disc list-inside text-sm">
-                  {conflictingResources.map((r) => (
-                    <li key={r}>{r}</li>
-                  ))}
-                </ul>
-              </AlertDescription>
-            </Alert>
+            <Alert
+              variant="warning"
+              description={
+                <>
+                  <p className="mb-2">
+                    {t("sql-review.attach-resource.override-warning", {
+                      button: t("common.confirm"),
+                    })}
+                  </p>
+                  <ul className="list-disc list-inside text-sm">
+                    {conflictingResources.map((r) => (
+                      <li key={r}>{r}</li>
+                    ))}
+                  </ul>
+                </>
+              }
+            />
           </div>
         )}
 

--- a/frontend/src/react/components/ui/alert.test.tsx
+++ b/frontend/src/react/components/ui/alert.test.tsx
@@ -1,0 +1,53 @@
+import { act, createElement, type ReactElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test } from "vitest";
+import * as alertModule from "./alert";
+import { Alert } from "./alert";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(element);
+  });
+  return {
+    container,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+        container.remove();
+      }),
+  };
+};
+
+describe("Alert", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("renders title and description props as structured content", () => {
+    const { container, unmount } = renderIntoContainer(
+      createElement(Alert, {
+        title: "Update available",
+        description: "A new version is ready to install.",
+      })
+    );
+
+    expect(container.textContent).toContain("Update available");
+    expect(container.textContent).toContain(
+      "A new version is ready to install."
+    );
+
+    unmount();
+  });
+
+  test("only exports the alert primitive", () => {
+    expect("AlertTitle" in alertModule).toBe(false);
+    expect("AlertDescription" in alertModule).toBe(false);
+  });
+});

--- a/frontend/src/react/components/ui/alert.tsx
+++ b/frontend/src/react/components/ui/alert.tsx
@@ -5,17 +5,17 @@ import {
   Info,
   type LucideIcon,
 } from "lucide-react";
-import type { ComponentProps } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { cn } from "@/react/lib/utils";
 
 const alertVariants = cva(
-  "relative rounded-xs border px-4 py-3 text-sm flex gap-x-3 items-start",
+  "relative flex w-full items-start gap-x-3 rounded-xs border px-4 py-3 text-sm leading-5 text-control shadow-xs",
   {
     variants: {
       variant: {
-        info: "border-accent/30 bg-accent/5 text-accent",
-        warning: "border-warning/30 bg-warning/5 text-warning",
-        error: "border-error/30 bg-error/5 text-error",
+        info: "border-info/40 bg-info/10",
+        warning: "border-warning/40 bg-warning/10",
+        error: "border-error/40 bg-error/10",
       },
     },
     defaultVariants: {
@@ -24,14 +24,29 @@ const alertVariants = cva(
   }
 );
 
+const alertIconVariants = cva("mt-0.5 size-5 shrink-0", {
+  variants: {
+    variant: {
+      info: "text-info",
+      warning: "text-warning",
+      error: "text-error",
+    },
+  },
+  defaultVariants: {
+    variant: "info",
+  },
+});
+
 const iconMap: Record<string, LucideIcon> = {
   info: Info,
   warning: AlertTriangle,
   error: AlertCircle,
 };
 
-type AlertProps = ComponentProps<"div"> &
+type AlertProps = Omit<ComponentProps<"div">, "title"> &
   VariantProps<typeof alertVariants> & {
+    title?: ReactNode;
+    description?: ReactNode;
     showIcon?: boolean;
   };
 
@@ -39,33 +54,46 @@ function Alert({
   className,
   variant = "info",
   showIcon = true,
+  title,
+  description,
   children,
   ...props
 }: AlertProps) {
   const Icon = iconMap[variant ?? "info"];
+  const hasStructuredContent = title !== undefined || description !== undefined;
+
   return (
     <div
       role="alert"
       className={cn(alertVariants({ variant, className }))}
       {...props}
     >
-      {showIcon && <Icon className="size-5 shrink-0 mt-0.5" />}
-      <div>{children}</div>
+      {showIcon && <Icon className={alertIconVariants({ variant })} />}
+      <div className="min-w-0 flex-1">
+        {hasStructuredContent ? (
+          <>
+            {title !== undefined && (
+              <h5 className="font-medium leading-6">{title}</h5>
+            )}
+            {description !== undefined && (
+              <div
+                className={cn(
+                  "text-sm text-control-light leading-6",
+                  title !== undefined && "mt-1"
+                )}
+              >
+                {description}
+              </div>
+            )}
+            {children}
+          </>
+        ) : (
+          children
+        )}
+      </div>
     </div>
   );
 }
 
-function AlertTitle({ className, ...props }: ComponentProps<"h5">) {
-  return (
-    <h5 className={cn("font-medium leading-tight", className)} {...props} />
-  );
-}
-
-function AlertDescription({ className, ...props }: ComponentProps<"div">) {
-  return (
-    <div className={cn("mt-1 text-sm opacity-90", className)} {...props} />
-  );
-}
-
-export { Alert, AlertTitle, AlertDescription, alertVariants };
+export { Alert, alertVariants };
 export type { AlertProps };

--- a/frontend/src/react/pages/auth/PasswordForgotPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordForgotPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import logoFull from "@/assets/logo-full.svg";
 import { authServiceClientConnect } from "@/connect";
-import { Alert, AlertTitle } from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -80,9 +80,10 @@ export function PasswordForgotPage() {
       <div className="mt-8">
         <div className="mt-6 flex flex-col gap-y-4">
           {!passwordResetEnabled ? (
-            <Alert variant="warning">
-              <AlertTitle>{t("auth.password-forget.selfhost")}</AlertTitle>
-            </Alert>
+            <Alert
+              variant="warning"
+              title={t("auth.password-forget.selfhost")}
+            />
           ) : (
             <>
               <div>

--- a/frontend/src/react/pages/auth/SigninPage.tsx
+++ b/frontend/src/react/pages/auth/SigninPage.tsx
@@ -5,7 +5,7 @@ import { DemoSigninForm } from "@/react/components/auth/DemoSigninForm";
 import { EmailCodeSigninForm } from "@/react/components/auth/EmailCodeSigninForm";
 import { PasswordSigninForm } from "@/react/components/auth/PasswordSigninForm";
 import { BytebaseLogo } from "@/react/components/BytebaseLogo";
-import { Alert, AlertTitle } from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import {
   Tabs,
@@ -176,11 +176,11 @@ export function SigninPage(props: SigninPageProps) {
         <BytebaseLogo className="mx-auto mb-8" />
 
         {invitedEmail && (
-          <Alert variant="info" className="mb-4 mt-4">
-            <AlertTitle>
-              {t("auth.sign-in.invited-email", { email: invitedEmail })}
-            </AlertTitle>
-          </Alert>
+          <Alert
+            variant="info"
+            className="mb-4 mt-4"
+            title={t("auth.sign-in.invited-email", { email: invitedEmail })}
+          />
         )}
 
         {showSignInForm && (

--- a/frontend/src/react/pages/auth/TwoFactorRequiredPage.tsx
+++ b/frontend/src/react/pages/auth/TwoFactorRequiredPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from "react-i18next";
-import { Alert, AlertDescription } from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { TwoFactorSetupPage } from "@/react/pages/settings/two-factor/TwoFactorSetupPage";
 import { useAuthStore } from "@/store";
 
@@ -7,11 +7,10 @@ export function TwoFactorRequiredPage() {
   const { t } = useTranslation();
   return (
     <div className="w-full">
-      <Alert variant="warning">
-        <AlertDescription>
-          {t("two-factor.messages.2fa-required")}
-        </AlertDescription>
-      </Alert>
+      <Alert
+        variant="warning"
+        description={t("two-factor.messages.2fa-required")}
+      />
       <div className="w-full p-2 sm:p-8 sm:px-16">
         <TwoFactorSetupPage cancelAction={() => useAuthStore().logout()} />
       </div>

--- a/frontend/src/react/pages/project/ProjectDatabaseDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/ProjectDatabaseDetailPage.test.tsx
@@ -339,9 +339,23 @@ vi.mock("./database-detail/panels/DatabaseSettingsPanel", () => ({
 }));
 
 vi.mock("@/react/components/ui/alert", () => ({
-  Alert: vi.fn(({ children }: { children: ReactNode }) => (
-    <div data-testid="alert">{children}</div>
-  )),
+  Alert: vi.fn(
+    ({
+      children,
+      title,
+      description,
+    }: {
+      children?: ReactNode;
+      title?: ReactNode;
+      description?: ReactNode;
+    }) => (
+      <div data-testid="alert">
+        {title}
+        {description}
+        {children}
+      </div>
+    )
+  ),
 }));
 
 vi.mock("@/react/components/ui/button", () => ({

--- a/frontend/src/react/pages/project/ProjectDatabaseDetailPage.tsx
+++ b/frontend/src/react/pages/project/ProjectDatabaseDetailPage.tsx
@@ -191,14 +191,17 @@ export function ProjectDatabaseDetailPage({
   return (
     <div className="flex min-h-full flex-col gap-y-4 p-4">
       {!detail.database.effectiveEnvironment && (
-        <Alert variant="warning">
-          <div className="flex flex-row items-center justify-between gap-x-2">
-            <div>{t("instance.no-environment")}</div>
-            <Button variant="link" size="sm" onClick={handleSetEnvironment}>
-              {t("database.edit-environment")}
-            </Button>
-          </div>
-        </Alert>
+        <Alert
+          variant="warning"
+          description={
+            <div className="flex flex-row items-center justify-between gap-x-2">
+              <div>{t("instance.no-environment")}</div>
+              <Button variant="link" size="sm" onClick={handleSetEnvironment}>
+                {t("database.edit-environment")}
+              </Button>
+            </div>
+          }
+        />
       )}
 
       <div className="flex flex-col items-start gap-y-2 xl:flex-row xl:items-center xl:justify-between xl:gap-x-2">

--- a/frontend/src/react/pages/project/ProjectGitOpsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectGitOpsPage.tsx
@@ -336,29 +336,32 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
       <div className="border border-gray-200 rounded-sm p-6 flex flex-col gap-y-3">
         <h2 className="text-lg font-medium">{t("gitops.checklist.title")}</h2>
 
-        <Alert variant="info">
-          <span>
-            {t("gitops.checklist.wif-notice-text")}{" "}
-            <a
-              href="https://docs.bytebase.com/tutorials/gitops-bitbucket-workflow?source=console"
-              target="_blank"
-              rel="noreferrer"
-              className="text-accent hover:underline"
-            >
-              Bitbucket
-            </a>{" "}
-            /{" "}
-            <a
-              href="https://docs.bytebase.com/tutorials/gitops-azure-devops-workflow?source=console"
-              target="_blank"
-              rel="noreferrer"
-              className="text-accent hover:underline"
-            >
-              Azure DevOps
-            </a>{" "}
-            {t("gitops.checklist.wif-notice-suffix")}
-          </span>
-        </Alert>
+        <Alert
+          variant="info"
+          description={
+            <span>
+              {t("gitops.checklist.wif-notice-text")}{" "}
+              <a
+                href="https://docs.bytebase.com/tutorials/gitops-bitbucket-workflow?source=console"
+                target="_blank"
+                rel="noreferrer"
+                className="text-accent hover:underline"
+              >
+                Bitbucket
+              </a>{" "}
+              /{" "}
+              <a
+                href="https://docs.bytebase.com/tutorials/gitops-azure-devops-workflow?source=console"
+                target="_blank"
+                rel="noreferrer"
+                className="text-accent hover:underline"
+              >
+                Azure DevOps
+              </a>{" "}
+              {t("gitops.checklist.wif-notice-suffix")}
+            </span>
+          }
+        />
 
         {/* Check 1: External URL */}
         <div className="flex items-start gap-x-3 py-3">
@@ -499,13 +502,15 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
 
           <TabsPanel value="github">
             {providerMismatchGithub && (
-              <Alert variant="error" className="mb-3">
-                {t("gitops.workflow.provider-not-match", {
+              <Alert
+                variant="error"
+                className="mb-3"
+                description={t("gitops.workflow.provider-not-match", {
                   provider: getWorkloadIdentityProviderText(
                     selectedConfig!.providerType
                   ),
                 })}
-              </Alert>
+              />
             )}
             <div className="flex items-center gap-x-2 my-3">
               <span className="text-sm">
@@ -545,13 +550,15 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
 
           <TabsPanel value="gitlab">
             {providerMismatchGitlab && (
-              <Alert variant="error" className="mb-3">
-                {t("gitops.workflow.provider-not-match", {
+              <Alert
+                variant="error"
+                className="mb-3"
+                description={t("gitops.workflow.provider-not-match", {
                   provider: getWorkloadIdentityProviderText(
                     selectedConfig!.providerType
                   ),
                 })}
-              </Alert>
+              />
             )}
             <CollapsibleCode
               label={
@@ -666,22 +673,25 @@ function MissingExternalURLAttention() {
   );
 
   return (
-    <Alert variant="error" className="mt-1">
-      <div className="flex flex-col gap-y-1">
-        <span className="font-medium">{t("banner.external-url")}</span>
-        <span>{t("settings.general.workspace.external-url.description")}</span>
-        {canConfigure && (
+    <Alert
+      variant="error"
+      className="mt-1"
+      title={t("banner.external-url")}
+      description={t("settings.general.workspace.external-url.description")}
+    >
+      {canConfigure && (
+        <div className="mt-1">
           <Button
             size="sm"
-            className="w-fit mt-1"
+            className="w-fit"
             onClick={() =>
               router.push({ name: SETTING_ROUTE_WORKSPACE_GENERAL })
             }
           >
             {t("common.configure-now")}
           </Button>
-        )}
-      </div>
+        </div>
+      )}
     </Alert>
   );
 }

--- a/frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx
@@ -96,13 +96,18 @@ export function ProjectReleaseDashboardPage({
   return (
     <div className="py-4 w-full flex flex-col">
       <div className="px-4 flex flex-col gap-y-2 pb-2">
-        <Alert variant="info">
-          <span>{t("release.usage-description")}</span>
-          <LearnMoreLink
-            href="https://docs.bytebase.com/gitops/migration-based-workflow/release/?source=console"
-            className="ml-1"
-          />
-        </Alert>
+        <Alert
+          variant="info"
+          description={
+            <>
+              <span>{t("release.usage-description")}</span>
+              <LearnMoreLink
+                href="https://docs.bytebase.com/gitops/migration-based-workflow/release/?source=console"
+                className="ml-1"
+              />
+            </>
+          }
+        />
 
         {/* Category filter */}
         <div className="flex items-center gap-x-4">

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
@@ -114,9 +114,11 @@ export function IssueDetailAccessGrantDetails() {
                 {t("common.statement")}
               </span>
               {accessGrant.unmask && (
-                <Alert variant="warning" showIcon={false}>
-                  {t("sql-editor.unmask-warning")}
-                </Alert>
+                <Alert
+                  variant="warning"
+                  showIcon={false}
+                  description={t("sql-editor.unmask-warning")}
+                />
               )}
               <div className="max-h-[30em] overflow-auto rounded-xs bg-gray-50 p-4">
                 <pre className="whitespace-pre-wrap font-mono text-sm">

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailSidebar.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailSidebar.tsx
@@ -43,9 +43,10 @@ export function IssueDetailSidebar() {
       {showChecks && (
         <div className="flex flex-col gap-2">
           {showChecksManualRolloutHint && (
-            <Alert variant="warning">
-              {t("issue.checks-manual-rollout-hint")}
-            </Alert>
+            <Alert
+              variant="warning"
+              description={t("issue.checks-manual-rollout-hint")}
+            />
           )}
           <IssueDetailChecks />
         </div>

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
@@ -439,24 +439,27 @@ export function IssueDetailStatementSection({
         </div>
       </div>
       {isSheetOversize && (
-        <Alert variant="warning">
-          <div className="flex items-center justify-between gap-x-4">
-            <span>{t("issue.statement-from-sheet-warning")}</span>
-            {sheetName && (
-              <Button
-                disabled={isDownloading}
-                onClick={() => void downloadSheet()}
-                size="xs"
-                variant="outline"
-              >
-                {isDownloading && (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                )}
-                {t("common.download")}
-              </Button>
-            )}
-          </div>
-        </Alert>
+        <Alert
+          variant="warning"
+          description={
+            <div className="flex items-center justify-between gap-x-4">
+              <span>{t("issue.statement-from-sheet-warning")}</span>
+              {sheetName && (
+                <Button
+                  disabled={isDownloading}
+                  onClick={() => void downloadSheet()}
+                  size="xs"
+                  variant="outline"
+                >
+                  {isDownloading && (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  )}
+                  {t("common.download")}
+                </Button>
+              )}
+            </div>
+          }
+        />
       )}
       {isLoading ? (
         <div className="rounded-md border border-control-border bg-white px-4 py-3 text-sm text-control-light">
@@ -516,7 +519,7 @@ function IssueDetailReleaseStatement({
 
   return (
     <div className={cn("flex h-full flex-col gap-y-2", className)}>
-      <Alert variant="info">{t("release.change-tip")}</Alert>
+      <Alert variant="info" description={t("release.change-tip")} />
 
       <div className="flex items-center justify-between gap-x-2">
         <div className="flex items-center gap-x-1 text-base font-medium">

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -1101,17 +1101,23 @@ function TargetsSection({
           )}
         </div>
         {!isLoadingTargets && nonEnvDatabaseNames.length > 0 && (
-          <Alert className="px-3 py-2" variant="warning">
-            <div>{nonEnvWarning}</div>
-            <div className="mt-1 flex flex-col gap-1 text-sm">
-              {nonEnvDatabaseNames.map((name) => (
-                <div key={name} className="flex items-center gap-2">
-                  <span className="h-1 w-1 shrink-0 rounded-full bg-current" />
-                  <DatabaseTarget target={name} />
+          <Alert
+            className="px-3 py-2"
+            variant="warning"
+            description={
+              <>
+                <div>{nonEnvWarning}</div>
+                <div className="mt-1 flex flex-col gap-1 text-sm">
+                  {nonEnvDatabaseNames.map((name) => (
+                    <div key={name} className="flex items-center gap-2">
+                      <span className="h-1 w-1 shrink-0 rounded-full bg-current" />
+                      <DatabaseTarget target={name} />
+                    </div>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </Alert>
+              </>
+            }
+          />
         )}
         {isLoadingTargets ? (
           <div className="flex items-center justify-center py-2">

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailDeployFuture.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailDeployFuture.tsx
@@ -9,7 +9,7 @@ import {
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
-import { Alert, AlertTitle } from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import {
   Sheet,
@@ -320,23 +320,29 @@ export function PlanDetailDeployFuture() {
           </SheetHeader>
           <SheetBody className="gap-y-4">
             {errorMessages.length > 0 ? (
-              <Alert variant="error">
-                <AlertTitle>{t("common.error")}</AlertTitle>
-                <ul className="mt-2 list-inside list-disc text-sm">
-                  {errorMessages.map((message) => (
-                    <li key={message}>{message}</li>
-                  ))}
-                </ul>
-              </Alert>
+              <Alert
+                variant="error"
+                title={t("common.error")}
+                description={
+                  <ul className="list-inside list-disc text-sm">
+                    {errorMessages.map((message) => (
+                      <li key={message}>{message}</li>
+                    ))}
+                  </ul>
+                }
+              />
             ) : warningMessages.length > 0 ? (
-              <Alert variant="warning">
-                <AlertTitle>{t("common.warning")}</AlertTitle>
-                <ul className="mt-2 list-inside list-disc text-sm">
-                  {warningMessages.map((message) => (
-                    <li key={message}>{message}</li>
-                  ))}
-                </ul>
-              </Alert>
+              <Alert
+                variant="warning"
+                title={t("common.warning")}
+                description={
+                  <ul className="list-inside list-disc text-sm">
+                    {warningMessages.map((message) => (
+                      <li key={message}>{message}</li>
+                    ))}
+                  </ul>
+                }
+              />
             ) : null}
 
             {page.issue && (

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.tsx
@@ -215,9 +215,12 @@ export function PlanDetailRollbackSheet({
             </div>
           ) : (
             <div className="space-y-4">
-              <Alert variant="info">
-                {t("task-run.rollback.preview-statement.description")}
-              </Alert>
+              <Alert
+                variant="info"
+                description={t(
+                  "task-run.rollback.preview-statement.description"
+                )}
+              />
               {loading ? (
                 <div className="flex items-center justify-center py-8 text-control-light">
                   <Loader2 className="h-5 w-5 animate-spin" />

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailStatementSection.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailStatementSection.tsx
@@ -477,24 +477,27 @@ export function PlanDetailStatementSection({
         </div>
       </div>
       {isSheetOversize && (
-        <Alert variant="warning">
-          <div className="flex items-center justify-between gap-x-4">
-            <span>{t("issue.statement-from-sheet-warning")}</span>
-            {sheetName && (
-              <Button
-                disabled={isDownloading}
-                onClick={() => void downloadSheet()}
-                size="xs"
-                variant="outline"
-              >
-                {isDownloading && (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                )}
-                {t("common.download")}
-              </Button>
-            )}
-          </div>
-        </Alert>
+        <Alert
+          variant="warning"
+          description={
+            <div className="flex items-center justify-between gap-x-4">
+              <span>{t("issue.statement-from-sheet-warning")}</span>
+              {sheetName && (
+                <Button
+                  disabled={isDownloading}
+                  onClick={() => void downloadSheet()}
+                  size="xs"
+                  variant="outline"
+                >
+                  {isDownloading && (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  )}
+                  {t("common.download")}
+                </Button>
+              )}
+            </div>
+          }
+        />
       )}
       {isLoading ? (
         <div className="rounded-md border border-control-border bg-white px-4 py-3 text-sm text-control-light">
@@ -571,9 +574,11 @@ function PlanDetailReleaseStatement({
 
   return (
     <div className={cn("flex h-full flex-col gap-y-2", className)}>
-      <Alert className="border-0" variant="info">
-        {t("release.change-tip")}
-      </Alert>
+      <Alert
+        className="border-0"
+        variant="info"
+        description={t("release.change-tip")}
+      />
       <div className="flex items-center justify-between gap-x-2">
         <div className="flex items-center gap-x-1 text-base font-medium">
           <Package className="h-4 w-4" />

--- a/frontend/src/react/pages/settings/GlobalMaskingPage.tsx
+++ b/frontend/src/react/pages/settings/GlobalMaskingPage.tsx
@@ -557,9 +557,10 @@ export function GlobalMaskingPage() {
     <div className="w-full px-4 py-4 flex flex-col gap-y-4">
       <FeatureAttention feature={PlanFeature.FEATURE_DATA_MASKING} />
       {hasSensitiveDataFeature && (
-        <Alert variant="info">
-          {t("custom-approval.rule.first-match-wins")}
-        </Alert>
+        <Alert
+          variant="info"
+          description={t("custom-approval.rule.first-match-wins")}
+        />
       )}
 
       {/* Toolbar */}

--- a/frontend/src/react/pages/settings/GroupsPage.tsx
+++ b/frontend/src/react/pages/settings/GroupsPage.tsx
@@ -14,7 +14,7 @@ import { ComponentPermissionGuard } from "@/react/components/ComponentPermission
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
 import { UserSelect } from "@/react/components/UserSelect";
-import { Alert, AlertDescription } from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
@@ -717,11 +717,10 @@ function GroupForm({
       <SheetBody>
         <div className="flex flex-col gap-y-6">
           {isExternalGroup && (
-            <Alert variant="info">
-              <AlertDescription>
-                {t("settings.members.groups.external-readonly")}
-              </AlertDescription>
-            </Alert>
+            <Alert
+              variant="info"
+              description={t("settings.members.groups.external-readonly")}
+            />
           )}
 
           {/* Email */}

--- a/frontend/src/react/pages/settings/InstanceDetailPage.tsx
+++ b/frontend/src/react/pages/settings/InstanceDetailPage.tsx
@@ -374,9 +374,11 @@ export function InstanceDetailPage({ instanceId }: { instanceId: string }) {
 
       {/* No environment warning */}
       {!instance.environment && (
-        <Alert variant="warning" className="mb-4">
-          {t("instance.no-environment")}
-        </Alert>
+        <Alert
+          variant="warning"
+          className="mb-4"
+          description={t("instance.no-environment")}
+        />
       )}
 
       {/* Header */}

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -22,11 +22,7 @@ import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { InstanceAssignmentSheet } from "@/react/components/InstanceAssignmentSheet";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -1247,16 +1243,14 @@ export function InstancesPage() {
     <div className="py-4 flex flex-col">
       {/* Instance count warning */}
       {quotaExhausted && (
-        <Alert variant="warning" className="mx-4 mb-4">
-          <AlertTitle>
-            {t("subscription.usage.instance-count.title")}
-          </AlertTitle>
-          <AlertDescription>
-            {t("subscription.usage.instance-count.runoutof", {
-              total: instanceCountLimit,
-            })}
-          </AlertDescription>
-        </Alert>
+        <Alert
+          variant="warning"
+          className="mx-4 mb-4"
+          title={t("subscription.usage.instance-count.title")}
+          description={t("subscription.usage.instance-count.runoutof", {
+            total: instanceCountLimit,
+          })}
+        />
       )}
 
       {/* Header: Search + Create */}

--- a/frontend/src/react/pages/settings/MCPPage.tsx
+++ b/frontend/src/react/pages/settings/MCPPage.tsx
@@ -1,11 +1,7 @@
 import { Check, Copy } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import {
@@ -93,35 +89,37 @@ export function MCPPage() {
 
       {/* Warning if external URL not configured */}
       {needConfigureExternalUrl && (
-        <Alert variant="error">
-          <AlertTitle>{t("banner.external-url")}</AlertTitle>
-          <AlertDescription>
-            <span>
-              {t("settings.general.workspace.external-url.description")}
-            </span>
-            {canConfigureExternalUrl && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="ml-3"
-                onClick={() =>
-                  router.push({ name: SETTING_ROUTE_WORKSPACE_GENERAL })
-                }
-              >
-                {t("common.configure-now")}
-              </Button>
-            )}
-          </AlertDescription>
-        </Alert>
+        <Alert
+          variant="error"
+          title={t("banner.external-url")}
+          description={
+            <>
+              <span>
+                {t("settings.general.workspace.external-url.description")}
+              </span>
+              {canConfigureExternalUrl && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="ml-3"
+                  onClick={() =>
+                    router.push({ name: SETTING_ROUTE_WORKSPACE_GENERAL })
+                  }
+                >
+                  {t("common.configure-now")}
+                </Button>
+              )}
+            </>
+          }
+        />
       )}
 
       {/* Authentication Notice */}
-      <Alert variant="info">
-        <AlertTitle>{t("settings.mcp.auth.title")}</AlertTitle>
-        <AlertDescription>
-          {t("settings.mcp.auth.description")}
-        </AlertDescription>
-      </Alert>
+      <Alert
+        variant="info"
+        title={t("settings.mcp.auth.title")}
+        description={t("settings.mcp.auth.description")}
+      />
 
       {/* Section 1: General Config */}
       <div className="flex flex-col gap-y-3">

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -35,11 +35,7 @@ import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { RoleSelect } from "@/react/components/RoleSelect";
 import { UserAvatar } from "@/react/components/UserAvatar";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
@@ -1540,11 +1536,10 @@ function EditMemberRoleDrawer({
         <SheetBody className="px-6 py-6">
           <div className="flex flex-col gap-y-6">
             {!isEditMode && !projectName && hasEmailSetting && (
-              <Alert variant="info">
-                <AlertDescription>
-                  {t("settings.members.invite-email-hint")}
-                </AlertDescription>
-              </Alert>
+              <Alert
+                variant="info"
+                description={t("settings.members.invite-email-hint")}
+              />
             )}
             {/* Member input */}
             <div className="flex flex-col gap-y-2">
@@ -1816,20 +1811,24 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   return (
     <div className="w-full px-4 overflow-x-hidden flex flex-col pt-2 pb-4">
       {!projectName && remainingUserCount <= 3 && (
-        <Alert variant="warning" className="mb-2">
-          <AlertTitle>{t("subscription.usage.user-count.title")}</AlertTitle>
-          <AlertDescription>
-            {remainingUserCount > 0
-              ? t("subscription.usage.user-count.remaining", {
-                  total: userCountLimit,
-                  count: remainingUserCount,
-                })
-              : t("subscription.usage.user-count.runoutof", {
-                  total: userCountLimit,
-                })}{" "}
-            {t("subscription.usage.user-count.upgrade")}
-          </AlertDescription>
-        </Alert>
+        <Alert
+          variant="warning"
+          className="mb-2"
+          title={t("subscription.usage.user-count.title")}
+          description={
+            <>
+              {remainingUserCount > 0
+                ? t("subscription.usage.user-count.remaining", {
+                    total: userCountLimit,
+                    count: remainingUserCount,
+                  })
+                : t("subscription.usage.user-count.runoutof", {
+                    total: userCountLimit,
+                  })}{" "}
+              {t("subscription.usage.user-count.upgrade")}
+            </>
+          }
+        />
       )}
       {projectName && (
         <div className="textinfolabel mb-4">

--- a/frontend/src/react/pages/settings/PurchaseSection.tsx
+++ b/frontend/src/react/pages/settings/PurchaseSection.tsx
@@ -399,11 +399,13 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
             </div>
           )}
           {paymentInfo?.cancelAtPeriodEnd ? (
-            <Alert variant="warning" className="my-2">
-              {t("subscription.purchase.cancel-pending", {
+            <Alert
+              variant="warning"
+              className="my-2"
+              description={t("subscription.purchase.cancel-pending", {
                 date: paymentInfo.periodEnd,
               })}
-            </Alert>
+            />
           ) : (
             allowManage && (
               <div className="mt-4">

--- a/frontend/src/react/pages/settings/RequestRoleSheet.test.tsx
+++ b/frontend/src/react/pages/settings/RequestRoleSheet.test.tsx
@@ -67,12 +67,15 @@ vi.mock("@/react/components/ui/expiration-picker", () => ({
 }));
 
 vi.mock("@/react/components/ui/alert", () => ({
-  Alert: ({ children }: { children: ReactNode }) =>
-    createElement("div", {}, children),
-  AlertTitle: ({ children }: { children: ReactNode }) =>
-    createElement("div", {}, children),
-  AlertDescription: ({ children }: { children: ReactNode }) =>
-    createElement("div", {}, children),
+  Alert: ({
+    children,
+    title,
+    description,
+  }: {
+    children?: ReactNode;
+    title?: ReactNode;
+    description?: ReactNode;
+  }) => createElement("div", {}, title, description, children),
 }));
 
 vi.mock("@/react/components/IssueLabelSelect", () => ({

--- a/frontend/src/react/pages/settings/RequestRoleSheet.tsx
+++ b/frontend/src/react/pages/settings/RequestRoleSheet.tsx
@@ -21,11 +21,7 @@ import type { OptionConfig } from "@/react/components/ExprEditor";
 import { ExprEditor } from "@/react/components/ExprEditor";
 import { IssueLabelSelect } from "@/react/components/IssueLabelSelect";
 import { RoleSelect } from "@/react/components/RoleSelect";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { ExpirationPicker } from "@/react/components/ui/expiration-picker";
 import {
@@ -424,28 +420,27 @@ function RequestRoleForm({
       <SheetBody>
         <div className="flex flex-col gap-y-4">
           {labelsMisconfigured && (
-            <Alert variant="warning">
-              <AlertTitle>
-                {t("project.members.request-role.labels-misconfigured.title")}
-              </AlertTitle>
-              <AlertDescription>
-                {t(
-                  "project.members.request-role.labels-misconfigured.description"
-                )}
-              </AlertDescription>
-            </Alert>
+            <Alert
+              variant="warning"
+              title={t(
+                "project.members.request-role.labels-misconfigured.title"
+              )}
+              description={t(
+                "project.members.request-role.labels-misconfigured.description"
+              )}
+            />
           )}
           {requiredPermissionList.length > 0 && (
-            <Alert>
-              <AlertTitle>{t("common.required-permission")}</AlertTitle>
-              <AlertDescription>
+            <Alert
+              title={t("common.required-permission")}
+              description={
                 <ul className="list-disc pl-4">
                   {requiredPermissionList.map((permission) => (
                     <li key={permission}>{permission}</li>
                   ))}
                 </ul>
-              </AlertDescription>
-            </Alert>
+              }
+            />
           )}
           <div className="flex flex-col gap-y-1">
             <label className="text-sm font-medium">

--- a/frontend/src/react/pages/settings/RolesPage.tsx
+++ b/frontend/src/react/pages/settings/RolesPage.tsx
@@ -13,11 +13,7 @@ import {
   type ResourceIdFieldRef,
 } from "@/react/components/ResourceIdField";
 import { RoleSelect } from "@/react/components/RoleSelect";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -307,21 +303,24 @@ function DeleteConfirmModal({
 
         {occupiedResources.length > 0 ? (
           <div className="mt-4">
-            <Alert variant="warning">
-              <AlertDescription>
-                <p className="mb-2">
-                  {t("resource.delete-warning-with-resources", {
-                    name: displayRoleTitle(roleName),
-                  })}
-                </p>
-                <ul className="list-disc pl-4 text-sm">
-                  {occupiedResources.map((r) => (
-                    <li key={r}>{r}</li>
-                  ))}
-                </ul>
-                <p className="mt-2">{t("resource.delete-warning-retry")}</p>
-              </AlertDescription>
-            </Alert>
+            <Alert
+              variant="warning"
+              description={
+                <>
+                  <p className="mb-2">
+                    {t("resource.delete-warning-with-resources", {
+                      name: displayRoleTitle(roleName),
+                    })}
+                  </p>
+                  <ul className="list-disc pl-4 text-sm">
+                    {occupiedResources.map((r) => (
+                      <li key={r}>{r}</li>
+                    ))}
+                  </ul>
+                  <p className="mt-2">{t("resource.delete-warning-retry")}</p>
+                </>
+              }
+            />
           </div>
         ) : (
           <AlertDialogDescription className="mt-2">
@@ -607,24 +606,25 @@ function RoleSheet({
               </div>
 
               {missedBasicPermissions.length > 0 && !isBuiltin && (
-                <Alert variant="error">
-                  <AlertTitle>
-                    {t("common.missing-required-permission")}
-                  </AlertTitle>
-                  <AlertDescription>
-                    <p>{t("common.required-workspace-permission")}</p>
-                    <ul className="list-disc pl-4 mt-1">
-                      {missedBasicPermissions.map((p) => (
-                        <li key={p}>{p}</li>
-                      ))}
-                    </ul>
-                    <div className="mt-2">
-                      <Button size="sm" onClick={addMissingPermissions}>
-                        {t("common.add-permissions")}
-                      </Button>
-                    </div>
-                  </AlertDescription>
-                </Alert>
+                <Alert
+                  variant="error"
+                  title={t("common.missing-required-permission")}
+                  description={
+                    <>
+                      <p>{t("common.required-workspace-permission")}</p>
+                      <ul className="list-disc pl-4 mt-1">
+                        {missedBasicPermissions.map((p) => (
+                          <li key={p}>{p}</li>
+                        ))}
+                      </ul>
+                      <div className="mt-2">
+                        <Button size="sm" onClick={addMissingPermissions}>
+                          {t("common.add-permissions")}
+                        </Button>
+                      </div>
+                    </>
+                  }
+                />
               )}
 
               <PermissionTransfer

--- a/frontend/src/react/pages/settings/SQLReviewDetailPage.tsx
+++ b/frontend/src/react/pages/settings/SQLReviewDetailPage.tsx
@@ -8,7 +8,7 @@ import { ResourceLink } from "@/react/components/sql-review/ResourceLink";
 import { ReviewCreation } from "@/react/components/sql-review/ReviewCreation";
 import { RuleTableWithFilter } from "@/react/components/sql-review/RuleTable";
 import { TabsByEngine } from "@/react/components/sql-review/TabsByEngine";
-import { Alert, AlertDescription } from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
 import {
@@ -228,9 +228,11 @@ export function SQLReviewDetailPage({
     <div className="px-4 py-4">
       {/* Disabled warning */}
       {!reviewPolicy.enforce && (
-        <Alert variant="warning" className="mb-4">
-          <AlertDescription>{t("sql-review.disabled")}</AlertDescription>
-        </Alert>
+        <Alert
+          variant="warning"
+          className="mb-4"
+          description={t("sql-review.disabled")}
+        />
       )}
 
       {/* Header: title + actions */}
@@ -301,8 +303,9 @@ export function SQLReviewDetailPage({
       {/* Attached resources */}
       <div className="mt-4 flex flex-col gap-y-4">
         {reviewPolicy.resources.length === 0 && (
-          <Alert variant="warning">
-            <AlertDescription>
+          <Alert
+            variant="warning"
+            description={
               <div className="flex items-center justify-between">
                 <div>
                   <p className="font-medium">
@@ -320,8 +323,8 @@ export function SQLReviewDetailPage({
                   {t("sql-review.attach-resource.self")}
                 </Button>
               </div>
-            </AlertDescription>
-          </Alert>
+            }
+          />
         )}
         <div className="flex flex-wrap gap-y-2 gap-x-2">
           {reviewPolicy.resources.map((resource) => (

--- a/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
+++ b/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
@@ -224,9 +224,12 @@ export const AIAugmentationSection = forwardRef<
         <PermissionGuard permissions={["bb.settings.set"]} display="block">
           <div className="flex-1 lg:px-4">
             {isSaaSMode ? (
-              <Alert variant="info">
-                {t("settings.general.workspace.ai-assistant.enabled-in-saas")}
-              </Alert>
+              <Alert
+                variant="info"
+                description={t(
+                  "settings.general.workspace.ai-assistant.enabled-in-saas"
+                )}
+              />
             ) : (
               <div className="mt-4 lg:mt-0 flex flex-col gap-y-4">
                 {/* Enable toggle */}

--- a/frontend/src/react/pages/settings/general/GeneralSection.tsx
+++ b/frontend/src/react/pages/settings/general/GeneralSection.tsx
@@ -217,11 +217,13 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
                   />
                 </div>
                 {externalUrlFromFlag && (
-                  <Alert variant="info" className="mb-3">
-                    {t(
+                  <Alert
+                    variant="info"
+                    className="mb-3"
+                    description={t(
                       "settings.general.workspace.external-url.cannot-edit-flag"
                     )}
-                  </Alert>
+                  />
                 )}
                 <Input
                   value={state.externalUrl}

--- a/frontend/src/react/pages/settings/shared/AADSyncSheet.tsx
+++ b/frontend/src/react/pages/settings/shared/AADSyncSheet.tsx
@@ -3,7 +3,7 @@ import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import { Copy } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
-import { Alert, AlertDescription } from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import {
@@ -124,9 +124,7 @@ export function AADSyncSheet({
 
             {/* Missing external URL warning */}
             {!externalUrl && (
-              <Alert variant="warning">
-                <AlertDescription>{t("banner.external-url")}</AlertDescription>
-              </Alert>
+              <Alert variant="warning" description={t("banner.external-url")} />
             )}
 
             {/* SCIM Endpoint URL */}

--- a/frontend/src/react/pages/settings/two-factor/RecoveryCodesView.tsx
+++ b/frontend/src/react/pages/settings/two-factor/RecoveryCodesView.tsx
@@ -1,11 +1,7 @@
 import { Download } from "lucide-react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/react/components/ui/alert";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 
 interface RecoveryCodesViewProps {
@@ -34,19 +30,22 @@ export function RecoveryCodesView({
 
   return (
     <div className="w-full flex flex-col gap-y-4 my-8">
-      <Alert variant="info">
-        <AlertTitle>
-          {t("two-factor.setup-steps.download-recovery-codes.keep-safe.self")}
-        </AlertTitle>
-        <AlertDescription>
-          <p>{t("two-factor.setup-steps.download-recovery-codes.tips")}</p>
-          <p>
-            {t(
-              "two-factor.setup-steps.download-recovery-codes.keep-safe.description"
-            )}
-          </p>
-        </AlertDescription>
-      </Alert>
+      <Alert
+        variant="info"
+        title={t(
+          "two-factor.setup-steps.download-recovery-codes.keep-safe.self"
+        )}
+        description={
+          <>
+            <p>{t("two-factor.setup-steps.download-recovery-codes.tips")}</p>
+            <p>
+              {t(
+                "two-factor.setup-steps.download-recovery-codes.keep-safe.description"
+              )}
+            </p>
+          </>
+        }
+      />
       <div className="w-full mx-auto flex flex-col justify-start items-start">
         <ul className="w-full grid grid-cols-2 list-disc list-inside mx-auto gap-4 gap-x-24 p-8 px-12 border rounded-xs bg-gray-50">
           {recoveryCodes.map((code) => (


### PR DESCRIPTION
## Summary
- Simplify the React Alert component to accept title and description props directly.
- Remove the AlertTitle and AlertDescription subcomponent API.
- Migrate existing React alert usages to the prop-based API.

## Key Changes
- Refresh alert styling with semantic borders, backgrounds, icon colors, and neutral content text.
- Preserve child content support for custom inline content after title/description.
- Add Alert tests and update affected component tests.

## Motivation
- Keeps alert usage concise and consistent across React UI components without over-designing the component API.

## Testing
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test