### PR TITLE
fix(fe): gate changelog schema snapshot on sync log

### DIFF
--- a/frontend/src/react/pages/project/DatabaseChangelogDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/DatabaseChangelogDetailPage.test.tsx
@@ -41,6 +41,7 @@ const mocks = vi.hoisted(() => {
     fetchPreviousChangelog: vi.fn(),
     getChangelogByName: vi.fn(),
     useChangelogStore: vi.fn(),
+    getTaskRunLog: vi.fn(),
     useVueState: vi.fn((getter: () => unknown) => getter()),
     clipboardWriteText,
     pushNotification: vi.fn(),
@@ -169,6 +170,12 @@ vi.mock("@/store", () => ({
   useChangelogStore: mocks.useChangelogStore,
 }));
 
+vi.mock("@/connect", () => ({
+  rolloutServiceClientConnect: {
+    getTaskRunLog: mocks.getTaskRunLog,
+  },
+}));
+
 vi.mock("./database-detail/useProjectDatabaseDetail", () => ({
   useProjectDatabaseDetail: mocks.useProjectDatabaseDetail,
 }));
@@ -238,6 +245,7 @@ beforeEach(() => {
   mocks.fetchPreviousChangelog.mockReset();
   mocks.getChangelogByName.mockReset();
   mocks.useChangelogStore.mockReset();
+  mocks.getTaskRunLog.mockReset();
   mocks.pushNotification.mockReset();
   mocks.useVueState.mockImplementation((getter: () => unknown) => getter());
   mocks.ReadonlyMonaco.mockClear();
@@ -289,6 +297,18 @@ beforeEach(() => {
     getOrFetchChangelogByName: mocks.getOrFetchChangelogByName,
     fetchPreviousChangelog: mocks.fetchPreviousChangelog,
     getChangelogByName: mocks.getChangelogByName,
+  });
+  mocks.getTaskRunLog.mockResolvedValue({
+    entries: [
+      {
+        type: 3,
+        databaseSync: {
+          startTime: { seconds: BigInt(1710000001), nanos: 0 },
+          endTime: { seconds: BigInt(1710000002), nanos: 0 },
+          error: "",
+        },
+      },
+    ],
   });
 });
 
@@ -539,6 +559,322 @@ describe("DatabaseChangelogDetailPage", () => {
     expect(
       container.querySelectorAll('[data-testid="readonly-monaco"]').length
     ).toBe(0); // Should be 0 because it renders the empty text div
+
+    unmount();
+  });
+
+  test("shows a diff when database sync exists and current schema is empty", async () => {
+    const changelog = {
+      ...mocks.currentChangelog,
+      schema: "",
+      schemaSize: BigInt(0),
+    };
+    mocks.useProjectDatabaseDetail.mockReturnValue({
+      database: {
+        name: "instances/inst1/databases/db1",
+        project: "projects/proj1",
+        instanceResource: { engine: "POSTGRES" },
+      },
+      databaseName: "instances/inst1/databases/db1",
+      loading: false,
+      ready: true,
+      allowAlterSchema: true,
+      isDefaultProject: false,
+    });
+    mocks.getOrFetchChangelogByName.mockResolvedValue(changelog);
+    mocks.fetchPreviousChangelog.mockResolvedValue(mocks.previousChangelog);
+    mocks.getChangelogByName.mockReturnValue(undefined);
+
+    const { container, render, unmount } = renderIntoContainer(
+      createElement(DatabaseChangelogDetailPage, {
+        project: "projects/proj1",
+        instance: "instances/inst1",
+        database: "instances/inst1/databases/db1",
+        changelogId: "7",
+      })
+    );
+
+    render();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector('[data-testid="readonly-diff-monaco"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="diff-original"]')?.textContent
+    ).toBe("previous schema");
+    expect(
+      container.querySelector('[data-testid="diff-modified"]')?.textContent
+    ).toBe("");
+
+    unmount();
+  });
+
+  test("hides the schema snapshot for task-run changelogs without database sync", async () => {
+    const changelog = {
+      ...mocks.currentChangelog,
+      schema: "",
+      schemaSize: BigInt(0),
+    };
+    mocks.useProjectDatabaseDetail.mockReturnValue({
+      database: {
+        name: "instances/inst1/databases/db1",
+        project: "projects/proj1",
+        instanceResource: { engine: "POSTGRES" },
+      },
+      databaseName: "instances/inst1/databases/db1",
+      loading: false,
+      ready: true,
+      allowAlterSchema: true,
+      isDefaultProject: false,
+    });
+    mocks.getOrFetchChangelogByName.mockResolvedValue(changelog);
+    mocks.fetchPreviousChangelog.mockResolvedValue(mocks.previousChangelog);
+    mocks.getTaskRunLog.mockResolvedValue({
+      entries: [
+        {
+          type: 2,
+          commandExecute: {
+            statement: "DELETE FROM t WHERE id = 1",
+          },
+        },
+      ],
+    });
+    mocks.getChangelogByName.mockReturnValue(undefined);
+
+    const { container, render, unmount } = renderIntoContainer(
+      createElement(DatabaseChangelogDetailPage, {
+        project: "projects/proj1",
+        instance: "instances/inst1",
+        database: "instances/inst1/databases/db1",
+        changelogId: "7",
+      })
+    );
+
+    render();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.getTaskRunLog).toHaveBeenCalledWith(
+      expect.objectContaining({ parent: changelog.taskRun })
+    );
+    expect(
+      container.querySelector('[data-testid="readonly-diff-monaco"]')
+    ).toBeNull();
+    expect(container.textContent).not.toContain("common.schema");
+    expect(container.textContent).not.toContain("common.snapshot");
+    expect(container.textContent).not.toContain("changelog.no-schema-change");
+    expect(container.textContent).not.toContain(
+      "changelog.current-schema-empty"
+    );
+    expect(container.textContent).not.toContain("common.rollback");
+
+    unmount();
+  });
+
+  test("recomputes schema snapshot visibility when the active changelog updates", async () => {
+    let activeChangelog = {
+      ...mocks.currentChangelog,
+      status: 1,
+      schema: "",
+      schemaSize: BigInt(0),
+    };
+    mocks.useProjectDatabaseDetail.mockReturnValue({
+      database: {
+        name: "instances/inst1/databases/db1",
+        project: "projects/proj1",
+        instanceResource: { engine: "POSTGRES" },
+      },
+      databaseName: "instances/inst1/databases/db1",
+      loading: false,
+      ready: true,
+      allowAlterSchema: true,
+      isDefaultProject: false,
+    });
+    mocks.getOrFetchChangelogByName.mockResolvedValue(activeChangelog);
+    mocks.fetchPreviousChangelog.mockResolvedValue(mocks.previousChangelog);
+    mocks.getChangelogByName.mockImplementation(() => activeChangelog);
+    mocks.getTaskRunLog
+      .mockResolvedValueOnce({
+        entries: [
+          {
+            type: 2,
+            commandExecute: {
+              statement: "DELETE FROM t WHERE id = 1",
+            },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        entries: [
+          {
+            type: 3,
+            databaseSync: {
+              startTime: { seconds: BigInt(1710000001), nanos: 0 },
+              endTime: { seconds: BigInt(1710000002), nanos: 0 },
+              error: "",
+            },
+          },
+        ],
+      });
+
+    const createPage = () =>
+      createElement(DatabaseChangelogDetailPage, {
+        project: "projects/proj1",
+        instance: "instances/inst1",
+        database: "instances/inst1/databases/db1",
+        changelogId: "7",
+      });
+    const { container, render, unmount } = renderIntoContainer(createPage());
+
+    render();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain("common.schema");
+    expect(container.textContent).not.toContain("common.snapshot");
+
+    activeChangelog = {
+      ...activeChangelog,
+      status: 2,
+    };
+    render(createPage());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.getTaskRunLog).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain("common.schema");
+    expect(container.textContent).toContain("common.snapshot");
+    expect(
+      container.querySelector('[data-testid="readonly-diff-monaco"]')
+    ).not.toBeNull();
+
+    unmount();
+  });
+
+  test("shows the schema snapshot when task-run-log fetch fails", async () => {
+    const changelog = {
+      ...mocks.currentChangelog,
+      schema: "",
+      schemaSize: BigInt(0),
+    };
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.useProjectDatabaseDetail.mockReturnValue({
+      database: {
+        name: "instances/inst1/databases/db1",
+        project: "projects/proj1",
+        instanceResource: { engine: "POSTGRES" },
+      },
+      databaseName: "instances/inst1/databases/db1",
+      loading: false,
+      ready: true,
+      allowAlterSchema: true,
+      isDefaultProject: false,
+    });
+    mocks.getOrFetchChangelogByName.mockResolvedValue(changelog);
+    mocks.fetchPreviousChangelog.mockResolvedValue(mocks.previousChangelog);
+    mocks.getTaskRunLog.mockRejectedValue(new Error("forbidden"));
+    mocks.getChangelogByName.mockReturnValue(undefined);
+
+    const { container, render, unmount } = renderIntoContainer(
+      createElement(DatabaseChangelogDetailPage, {
+        project: "projects/proj1",
+        instance: "instances/inst1",
+        database: "instances/inst1/databases/db1",
+        changelogId: "7",
+      })
+    );
+
+    render();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.getTaskRunLog).toHaveBeenCalledWith(
+      expect.objectContaining({ parent: changelog.taskRun })
+    );
+    expect(container.textContent).toContain("common.schema");
+    expect(container.textContent).toContain("common.snapshot");
+    expect(
+      container.querySelector('[data-testid="readonly-diff-monaco"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="diff-original"]')?.textContent
+    ).toBe("previous schema");
+    expect(
+      container.querySelector('[data-testid="diff-modified"]')?.textContent
+    ).toBe("");
+
+    unmount();
+    consoleError.mockRestore();
+  });
+
+  test("allows diff for changelogs without task run", async () => {
+    const changelog = {
+      ...mocks.currentChangelog,
+      taskRun: "",
+      schema: "",
+      schemaSize: BigInt(0),
+    };
+    mocks.useProjectDatabaseDetail.mockReturnValue({
+      database: {
+        name: "instances/inst1/databases/db1",
+        project: "projects/proj1",
+        instanceResource: { engine: "POSTGRES" },
+      },
+      databaseName: "instances/inst1/databases/db1",
+      loading: false,
+      ready: true,
+      allowAlterSchema: true,
+      isDefaultProject: false,
+    });
+    mocks.getOrFetchChangelogByName.mockResolvedValue(changelog);
+    mocks.fetchPreviousChangelog.mockResolvedValue(mocks.previousChangelog);
+    mocks.getChangelogByName.mockReturnValue(undefined);
+
+    const { container, render, unmount } = renderIntoContainer(
+      createElement(DatabaseChangelogDetailPage, {
+        project: "projects/proj1",
+        instance: "instances/inst1",
+        database: "instances/inst1/databases/db1",
+        changelogId: "7",
+      })
+    );
+
+    render();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.getTaskRunLog).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="readonly-diff-monaco"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="diff-original"]')?.textContent
+    ).toBe("previous schema");
+    expect(
+      container.querySelector('[data-testid="diff-modified"]')?.textContent
+    ).toBe("");
 
     unmount();
   });

--- a/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
+++ b/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
@@ -1,6 +1,8 @@
+import { create } from "@bufbuild/protobuf";
 import { ArrowUpRight, Check, Copy, LoaderCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { rolloutServiceClientConnect } from "@/connect";
 import { ReadonlyDiffMonaco, ReadonlyMonaco } from "@/react/components/monaco";
 import { TaskRunLogViewer } from "@/react/components/task-run-log";
 import { Button } from "@/react/components/ui/button";
@@ -20,6 +22,11 @@ import {
   Changelog_Status,
   ChangelogView,
 } from "@/types/proto-es/v1/database_service_pb";
+import {
+  GetTaskRunLogRequestSchema,
+  type TaskRunLogEntry,
+  TaskRunLogEntry_Type,
+} from "@/types/proto-es/v1/rollout_service_pb";
 import {
   bytesToString,
   extractDatabaseResourceName,
@@ -110,6 +117,44 @@ function ChangelogStatusIndicator({ status }: { status: Changelog_Status }) {
   }
 }
 
+function hasSuccessfulDatabaseSync(entries: TaskRunLogEntry[]): boolean {
+  return entries.some((entry) => {
+    if (entry.type !== TaskRunLogEntry_Type.DATABASE_SYNC) {
+      return false;
+    }
+    return Boolean(entry.databaseSync?.endTime && !entry.databaseSync.error);
+  });
+}
+
+function canShowSchemaSnapshot(
+  changelog: Changelog | undefined,
+  hasTaskRunDatabaseSync: boolean | undefined
+): boolean {
+  if (!changelog) {
+    return false;
+  }
+  if (!changelog.taskRun) {
+    return true;
+  }
+  return hasTaskRunDatabaseSync !== false;
+}
+
+async function fetchHasSuccessfulDatabaseSync(
+  taskRun: string
+): Promise<boolean | undefined> {
+  try {
+    const response = await rolloutServiceClientConnect.getTaskRunLog(
+      create(GetTaskRunLogRequestSchema, {
+        parent: taskRun,
+      })
+    );
+    return hasSuccessfulDatabaseSync(response.entries);
+  } catch (error) {
+    console.error(`Failed to fetch task run log for ${taskRun}:`, error);
+    return undefined;
+  }
+}
+
 function CopyButton({ content }: { content: string }) {
   const { t } = useTranslation();
 
@@ -160,6 +205,9 @@ export function DatabaseChangelogDetailPage({
   const [showDiff, setShowDiff] = useState(true);
   const [resolvedChangelog, setResolvedChangelog] = useState<Changelog>();
   const [previousChangelog, setPreviousChangelog] = useState<Changelog>();
+  const [hasTaskRunDatabaseSync, setHasTaskRunDatabaseSync] = useState<
+    boolean | undefined
+  >(undefined);
 
   const projectId = extractProjectResourceName(project);
   const instanceId = extractInstanceResourceName(instance);
@@ -196,6 +244,7 @@ export function DatabaseChangelogDetailPage({
     setShowDiff(true);
     setResolvedChangelog(undefined);
     setPreviousChangelog(undefined);
+    setHasTaskRunDatabaseSync(undefined);
 
     void Promise.all([
       changelogStore.getOrFetchChangelogByName(
@@ -208,11 +257,13 @@ export function DatabaseChangelogDetailPage({
         if (cancelled) {
           return;
         }
+
         setResolvedChangelog(current);
         setPreviousChangelog(previous);
 
         // Show diff by default only if there is a schema change.
-        const hasDiff = (previous?.schema ?? "") !== (current?.schema ?? "");
+        const currentSchema = current?.schema ?? "";
+        const hasDiff = (previous?.schema ?? "") !== currentSchema;
         setShowDiff(hasDiff);
       })
       .catch((error) => {
@@ -228,6 +279,30 @@ export function DatabaseChangelogDetailPage({
       cancelled = true;
     };
   }, [changelogName, changelogStore, detail.ready]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!resolvedChangelog?.taskRun) {
+      setHasTaskRunDatabaseSync(undefined);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setHasTaskRunDatabaseSync(undefined);
+    void fetchHasSuccessfulDatabaseSync(resolvedChangelog.taskRun).then(
+      (nextHasTaskRunDatabaseSync) => {
+        if (!cancelled) {
+          setHasTaskRunDatabaseSync(nextHasTaskRunDatabaseSync);
+        }
+      }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [resolvedChangelog?.taskRun, resolvedChangelog?.status]);
 
   const taskFullLink = useMemo(() => {
     if (!resolvedChangelog?.taskRun) {
@@ -254,6 +329,11 @@ export function DatabaseChangelogDetailPage({
       (previousChangelog?.schema ?? "") !== (resolvedChangelog.schema ?? "")
     );
   }, [resolvedChangelog, previousChangelog]);
+
+  const showSchemaSnapshot = useMemo(
+    () => canShowSchemaSnapshot(resolvedChangelog, hasTaskRunDatabaseSync),
+    [hasTaskRunDatabaseSync, resolvedChangelog]
+  );
 
   const allowRollback = useMemo(() => {
     if (
@@ -443,68 +523,70 @@ export function DatabaseChangelogDetailPage({
           </div>
         ) : null}
 
-        <div className="flex flex-col gap-y-2">
-          <p className="flex items-center gap-x-2 text-lg text-main">
-            <span>
-              {t("common.schema")} {t("common.snapshot")}
-            </span>
-            {formattedSchemaSize ? (
-              <span className="text-sm font-normal text-control-light">
-                ({formattedSchemaSize})
+        {showSchemaSnapshot ? (
+          <div className="flex flex-col gap-y-2">
+            <p className="flex items-center gap-x-2 text-lg text-main">
+              <span>
+                {t("common.schema")} {t("common.snapshot")}
               </span>
-            ) : null}
-            <CopyButton content={resolvedChangelog.schema} />
-          </p>
-
-          <div className="flex items-center justify-between gap-x-2">
-            <div className="flex items-center gap-x-2">
-              <div className="flex items-center gap-x-1">
-                <Switch
-                  checked={showDiff}
-                  onCheckedChange={setShowDiff}
-                  size="sm"
-                />
-                <span className="text-sm font-semibold">
-                  {t("changelog.show-diff")}
+              {formattedSchemaSize ? (
+                <span className="text-sm font-normal text-control-light">
+                  ({formattedSchemaSize})
                 </span>
-              </div>
-              <div className="textinfolabel">
-                {t("changelog.schema-snapshot-after-change")}
-              </div>
-              {!hasSchemaDiff && (
-                <div className="text-sm font-normal text-accent">
-                  ({t("changelog.no-schema-change")})
-                </div>
-              )}
-            </div>
-            {allowRollback ? (
-              <Button size="sm" onClick={handleRollback}>
-                {t("common.rollback")}
-              </Button>
-            ) : null}
-          </div>
+              ) : null}
+              <CopyButton content={resolvedChangelog.schema} />
+            </p>
 
-          {showDiff ? (
-            <div className="overflow-hidden rounded-sm border border-control-border bg-white">
-              <ReadonlyDiffMonaco
-                original={previousChangelog?.schema ?? ""}
-                modified={resolvedChangelog.schema}
-                className="relative h-auto max-h-[600px] min-h-[120px]"
-              />
+            <div className="flex items-center justify-between gap-x-2">
+              <div className="flex items-center gap-x-2">
+                <div className="flex items-center gap-x-1">
+                  <Switch
+                    checked={showDiff}
+                    onCheckedChange={setShowDiff}
+                    size="sm"
+                  />
+                  <span className="text-sm font-semibold">
+                    {t("changelog.show-diff")}
+                  </span>
+                </div>
+                <div className="textinfolabel">
+                  {t("changelog.schema-snapshot-after-change")}
+                </div>
+                {!hasSchemaDiff && (
+                  <div className="text-sm font-normal text-accent">
+                    ({t("changelog.no-schema-change")})
+                  </div>
+                )}
+              </div>
+              {allowRollback ? (
+                <Button size="sm" onClick={handleRollback}>
+                  {t("common.rollback")}
+                </Button>
+              ) : null}
             </div>
-          ) : resolvedChangelog.schema ? (
-            <div className="overflow-hidden rounded-sm border border-control-border bg-white">
-              <ReadonlyMonaco
-                content={resolvedChangelog.schema}
-                className="relative h-auto max-h-[600px] min-h-[120px]"
-              />
-            </div>
-          ) : (
-            <div className="text-sm text-control-light">
-              {t("changelog.current-schema-empty")}
-            </div>
-          )}
-        </div>
+
+            {showDiff ? (
+              <div className="overflow-hidden rounded-sm border border-control-border bg-white">
+                <ReadonlyDiffMonaco
+                  original={previousChangelog?.schema ?? ""}
+                  modified={resolvedChangelog.schema}
+                  className="relative h-auto max-h-[600px] min-h-[120px]"
+                />
+              </div>
+            ) : resolvedChangelog.schema ? (
+              <div className="overflow-hidden rounded-sm border border-control-border bg-white">
+                <ReadonlyMonaco
+                  content={resolvedChangelog.schema}
+                  className="relative h-auto max-h-[600px] min-h-[120px]"
+                />
+              </div>
+            ) : (
+              <div className="text-sm text-control-light">
+                {t("changelog.current-schema-empty")}
+              </div>
+            )}
+          </div>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Hide the changelog Schema Snapshot section only when a task-run log is successfully fetched and has no successful Database Sync entry.
- Keep Schema Snapshot visible by default for changelogs without task runs and for task-run-log fetch failures.
- Add regression coverage for sync, no-sync, no-task-run, and fetch-failure cases.

## Test Plan
- pnpm --dir frontend test DatabaseChangelogDetailPage.test.tsx
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- git diff --check
- pnpm --dir frontend test (fails on existing header/localStorage issues: VersionMenuItem localStorage.clear, DashboardHeader localStorage.setItem/route assertion)

Close BYT-9393