### PR TITLE
fix: default SQL Editor query role to least privilege

### DIFF
--- a/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   useTranslation: vi.fn(() => ({ t: (key: string) => key })),
   useVueState: vi.fn<(getter: () => unknown) => unknown>(),
   useProjectV1Store: vi.fn(),
+  useRoleStore: vi.fn(),
   useSQLEditorStore: vi.fn(),
   hasFeature: vi.fn(() => true),
   parseStringToResource: vi.fn((s: string) => ({
@@ -29,6 +30,7 @@ vi.mock("@/react/hooks/useVueState", () => ({
 
 vi.mock("@/store", () => ({
   useProjectV1Store: mocks.useProjectV1Store,
+  useRoleStore: mocks.useRoleStore,
   useSQLEditorStore: mocks.useSQLEditorStore,
   hasFeature: mocks.hasFeature,
 }));
@@ -38,7 +40,10 @@ vi.mock("@/components/RoleGrantPanel/DatabaseResourceForm/common", () => ({
 }));
 
 vi.mock("@/types", () => ({
-  PresetRoleType: { SQL_EDITOR_USER: "roles/sqlEditorUser" },
+  PresetRoleType: {
+    SQL_EDITOR_READ_USER: "roles/sqlEditorReadUser",
+    SQL_EDITOR_USER: "roles/sqlEditorUser",
+  },
 }));
 
 vi.mock("@/types/proto-es/v1/subscription_service_pb", () => ({
@@ -79,8 +84,14 @@ vi.mock("@/react/components/ui/button", () => ({
 }));
 
 vi.mock("./RoleGrantPanel", () => ({
-  RoleGrantPanel: ({ onClose }: { onClose: () => void }) => (
-    <div data-testid="role-grant-panel">
+  RoleGrantPanel: ({
+    onClose,
+    role,
+  }: {
+    onClose: () => void;
+    role: string;
+  }) => (
+    <div data-testid="role-grant-panel" data-role={role}>
       <button data-close-btn onClick={onClose}>
         Close
       </button>
@@ -145,6 +156,18 @@ const setupDefaultMocks = (allowJIT = false, allowRequestRole = true) => {
       allowJustInTimeAccess: allowJIT,
       allowRequestRole,
     })),
+  });
+  mocks.useRoleStore.mockReturnValue({
+    roleList: [
+      {
+        name: "roles/sqlEditorUser",
+        permissions: ["bb.sql.select", "bb.sql.explain"],
+      },
+      {
+        name: "roles/sqlEditorReadUser",
+        permissions: ["bb.sql.select"],
+      },
+    ],
   });
   mocks.useSQLEditorStore.mockReturnValue({ project: "projects/proj1" });
   mocks.hasFeature.mockReturnValue(true);
@@ -230,6 +253,31 @@ describe("RequestQueryButton", () => {
     expect(
       container.querySelector("[data-testid='role-grant-panel']")
     ).not.toBeNull();
+    unmount();
+  });
+
+  test("non-JIT role request defaults to least-permission SQL select role", async () => {
+    setupDefaultMocks(false, true);
+    const { container, render, unmount } = renderIntoContainer(
+      <RequestQueryButton
+        text={false}
+        permissionDeniedDetail={makePermissionDeniedDetail({
+          requiredPermissions: ["bb.sql.select", "bb.issues.create"],
+        })}
+      />
+    );
+    render();
+
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    expect(
+      container
+        .querySelector("[data-testid='role-grant-panel']")
+        ?.getAttribute("data-role")
+    ).toBe("roles/sqlEditorReadUser");
     unmount();
   });
 

--- a/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
@@ -161,7 +161,7 @@ const setupDefaultMocks = (allowJIT = false, allowRequestRole = true) => {
     roleList: [
       {
         name: "roles/sqlEditorUser",
-        permissions: ["bb.sql.select", "bb.sql.explain"],
+        permissions: ["bb.sql.select", "bb.sql.dml", "bb.sql.explain"],
       },
       {
         name: "roles/sqlEditorReadUser",
@@ -205,7 +205,7 @@ describe("RequestQueryButton", () => {
       <RequestQueryButton
         text={false}
         permissionDeniedDetail={makePermissionDeniedDetail({
-          requiredPermissions: ["bb.sql.select", "bb.issues.create"],
+          requiredPermissions: ["bb.sql.select"],
         })}
       />
     );
@@ -262,7 +262,7 @@ describe("RequestQueryButton", () => {
       <RequestQueryButton
         text={false}
         permissionDeniedDetail={makePermissionDeniedDetail({
-          requiredPermissions: ["bb.sql.select", "bb.issues.create"],
+          requiredPermissions: ["bb.sql.select"],
         })}
       />
     );
@@ -278,6 +278,31 @@ describe("RequestQueryButton", () => {
         .querySelector("[data-testid='role-grant-panel']")
         ?.getAttribute("data-role")
     ).toBe("roles/sqlEditorReadUser");
+    unmount();
+  });
+
+  test("non-JIT role request defaults to role covering denied permission", async () => {
+    setupDefaultMocks(false, true);
+    const { container, render, unmount } = renderIntoContainer(
+      <RequestQueryButton
+        text={false}
+        permissionDeniedDetail={makePermissionDeniedDetail({
+          requiredPermissions: ["bb.sql.dml"],
+        })}
+      />
+    );
+    render();
+
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    expect(
+      container
+        .querySelector("[data-testid='role-grant-panel']")
+        ?.getAttribute("data-role")
+    ).toBe("roles/sqlEditorUser");
     unmount();
   });
 

--- a/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   useProjectV1Store: vi.fn(),
   useRoleStore: vi.fn(),
   useSQLEditorStore: vi.fn(),
+  useSubscriptionV1Store: vi.fn(),
   hasFeature: vi.fn(() => true),
   parseStringToResource: vi.fn((s: string) => ({
     databaseFullName: s,
@@ -32,6 +33,7 @@ vi.mock("@/store", () => ({
   useProjectV1Store: mocks.useProjectV1Store,
   useRoleStore: mocks.useRoleStore,
   useSQLEditorStore: mocks.useSQLEditorStore,
+  useSubscriptionV1Store: mocks.useSubscriptionV1Store,
   hasFeature: mocks.hasFeature,
 }));
 
@@ -40,6 +42,7 @@ vi.mock("@/components/RoleGrantPanel/DatabaseResourceForm/common", () => ({
 }));
 
 vi.mock("@/types", () => ({
+  PRESET_ROLES: ["roles/sqlEditorReadUser", "roles/sqlEditorUser"],
   PresetRoleType: {
     SQL_EDITOR_READ_USER: "roles/sqlEditorReadUser",
     SQL_EDITOR_USER: "roles/sqlEditorUser",
@@ -48,6 +51,7 @@ vi.mock("@/types", () => ({
 
 vi.mock("@/types/proto-es/v1/subscription_service_pb", () => ({
   PlanFeature: {
+    FEATURE_CUSTOM_ROLES: 47,
     FEATURE_JIT: 5,
     FEATURE_REQUEST_ROLE_WORKFLOW: 6,
   },
@@ -164,12 +168,19 @@ const setupDefaultMocks = (allowJIT = false, allowRequestRole = true) => {
         permissions: ["bb.sql.select", "bb.sql.dml", "bb.sql.explain"],
       },
       {
-        name: "roles/sqlEditorReadUser",
+        name: "roles/queryOnly",
         permissions: ["bb.sql.select"],
+      },
+      {
+        name: "roles/sqlEditorReadUser",
+        permissions: ["bb.sql.select", "bb.sql.explain"],
       },
     ],
   });
   mocks.useSQLEditorStore.mockReturnValue({ project: "projects/proj1" });
+  mocks.useSubscriptionV1Store.mockReturnValue({
+    hasInstanceFeature: vi.fn(() => false),
+  });
   mocks.hasFeature.mockReturnValue(true);
   mocks.useVueState.mockImplementation((getter: () => unknown) => getter());
 };
@@ -303,6 +314,59 @@ describe("RequestQueryButton", () => {
         .querySelector("[data-testid='role-grant-panel']")
         ?.getAttribute("data-role")
     ).toBe("roles/sqlEditorUser");
+    unmount();
+  });
+
+  test("non-JIT role request ignores custom roles when feature is disabled", async () => {
+    setupDefaultMocks(false, true);
+    const { container, render, unmount } = renderIntoContainer(
+      <RequestQueryButton
+        text={false}
+        permissionDeniedDetail={makePermissionDeniedDetail({
+          requiredPermissions: ["bb.sql.select"],
+        })}
+      />
+    );
+    render();
+
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    expect(
+      container
+        .querySelector("[data-testid='role-grant-panel']")
+        ?.getAttribute("data-role")
+    ).toBe("roles/sqlEditorReadUser");
+    unmount();
+  });
+
+  test("non-JIT role request can default to custom role when feature is enabled", async () => {
+    setupDefaultMocks(false, true);
+    mocks.useSubscriptionV1Store.mockReturnValue({
+      hasInstanceFeature: vi.fn(() => true),
+    });
+    const { container, render, unmount } = renderIntoContainer(
+      <RequestQueryButton
+        text={false}
+        permissionDeniedDetail={makePermissionDeniedDetail({
+          requiredPermissions: ["bb.sql.select"],
+        })}
+      />
+    );
+    render();
+
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+
+    expect(
+      container
+        .querySelector("[data-testid='role-grant-panel']")
+        ?.getAttribute("data-role")
+    ).toBe("roles/queryOnly");
     unmount();
   });
 

--- a/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
@@ -306,6 +306,46 @@ describe("RequestQueryButton", () => {
     unmount();
   });
 
+  test("non-JIT role request works without Array.prototype.toSorted", async () => {
+    setupDefaultMocks(false, true);
+    const descriptor = Object.getOwnPropertyDescriptor(
+      Array.prototype,
+      "toSorted"
+    );
+    Object.defineProperty(Array.prototype, "toSorted", {
+      configurable: true,
+      value: undefined,
+    });
+
+    try {
+      const { container, render, unmount } = renderIntoContainer(
+        <RequestQueryButton
+          text={false}
+          permissionDeniedDetail={makePermissionDeniedDetail({
+            requiredPermissions: ["bb.sql.select"],
+          })}
+        />
+      );
+      render();
+
+      const btn = container.querySelector("button") as HTMLButtonElement;
+      await act(async () => {
+        btn.click();
+      });
+
+      expect(
+        container
+          .querySelector("[data-testid='role-grant-panel']")
+          ?.getAttribute("data-role")
+      ).toBe("roles/sqlEditorReadUser");
+      unmount();
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(Array.prototype, "toSorted", descriptor);
+      }
+    }
+  });
+
   test("click in JIT mode opens AccessGrantRequestDrawer", async () => {
     setupDefaultMocks(true, true);
     const { container, render, unmount } = renderIntoContainer(

--- a/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
@@ -11,9 +11,10 @@ import {
   useProjectV1Store,
   useRoleStore,
   useSQLEditorStore,
+  useSubscriptionV1Store,
 } from "@/store";
 import type { DatabaseResource, Permission } from "@/types";
-import { PresetRoleType } from "@/types";
+import { PRESET_ROLES, PresetRoleType } from "@/types";
 import type { PermissionDeniedDetail } from "@/types/proto-es/v1/common_pb";
 import type { Role } from "@/types/proto-es/v1/role_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
@@ -24,13 +25,15 @@ const SQL_SELECT_PERMISSION = "bb.sql.select";
 
 const getDefaultQueryRole = (
   roles: readonly Pick<Role, "name" | "permissions">[],
-  requiredPermissions: readonly string[]
+  requiredPermissions: readonly string[],
+  hasCustomRoleFeature: boolean
 ) => {
   const permissions =
     requiredPermissions.length > 0
       ? requiredPermissions
       : [SQL_SELECT_PERMISSION];
   const candidates = [...roles]
+    .filter((role) => hasCustomRoleFeature || PRESET_ROLES.includes(role.name))
     .filter((role) =>
       permissions.every((permission) => role.permissions.includes(permission))
     )
@@ -72,13 +75,18 @@ export function RequestQueryButton({
   const projectStore = useProjectV1Store();
   const editorStore = useSQLEditorStore();
   const roleStore = useRoleStore();
+  const subscriptionStore = useSubscriptionV1Store();
 
   const projectName = useVueState(() => editorStore.project);
   const project = useVueState(() => projectStore.getProjectByName(projectName));
+  const hasCustomRoleFeature = useVueState(() =>
+    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_CUSTOM_ROLES)
+  );
   const defaultQueryRole = useVueState(() =>
     getDefaultQueryRole(
       roleStore.roleList,
-      permissionDeniedDetail.requiredPermissions
+      permissionDeniedDetail.requiredPermissions,
+      hasCustomRoleFeature
     )
   );
 

--- a/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
@@ -6,13 +6,43 @@ import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { Button } from "@/react/components/ui/button";
 import { useVueState } from "@/react/hooks/useVueState";
-import { hasFeature, useProjectV1Store, useSQLEditorStore } from "@/store";
+import {
+  hasFeature,
+  useProjectV1Store,
+  useRoleStore,
+  useSQLEditorStore,
+} from "@/store";
 import type { DatabaseResource, Permission } from "@/types";
 import { PresetRoleType } from "@/types";
 import type { PermissionDeniedDetail } from "@/types/proto-es/v1/common_pb";
+import type { Role } from "@/types/proto-es/v1/role_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import { AccessGrantRequestDrawer } from "./AccessGrantRequestDrawer";
 import { RoleGrantPanel } from "./RoleGrantPanel";
+
+const SQL_SELECT_PERMISSION = "bb.sql.select";
+
+const getDefaultQueryRole = (
+  roles: readonly Pick<Role, "name" | "permissions">[]
+) => {
+  const candidates = roles
+    .filter((role) => role.permissions.includes(SQL_SELECT_PERMISSION))
+    .toSorted((a, b) => {
+      const permissionCountDelta = a.permissions.length - b.permissions.length;
+      if (permissionCountDelta !== 0) {
+        return permissionCountDelta;
+      }
+      if (a.name === PresetRoleType.SQL_EDITOR_READ_USER) {
+        return -1;
+      }
+      if (b.name === PresetRoleType.SQL_EDITOR_READ_USER) {
+        return 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+  return candidates[0]?.name ?? PresetRoleType.SQL_EDITOR_READ_USER;
+};
 
 interface Props {
   readonly size?: "sm" | "default";
@@ -34,9 +64,13 @@ export function RequestQueryButton({
 
   const projectStore = useProjectV1Store();
   const editorStore = useSQLEditorStore();
+  const roleStore = useRoleStore();
 
   const projectName = useVueState(() => editorStore.project);
   const project = useVueState(() => projectStore.getProjectByName(projectName));
+  const defaultQueryRole = useVueState(() =>
+    getDefaultQueryRole(roleStore.roleList)
+  );
 
   const useJIT = useMemo(
     () =>
@@ -110,7 +144,7 @@ export function RequestQueryButton({
         <RoleGrantPanel
           projectName={projectName}
           databaseResources={missingResources}
-          role={PresetRoleType.SQL_EDITOR_USER}
+          role={defaultQueryRole}
           requiredPermissions={permissionDeniedDetail.requiredPermissions}
           onClose={() => setShowPanel(false)}
         />

--- a/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
@@ -23,10 +23,17 @@ import { RoleGrantPanel } from "./RoleGrantPanel";
 const SQL_SELECT_PERMISSION = "bb.sql.select";
 
 const getDefaultQueryRole = (
-  roles: readonly Pick<Role, "name" | "permissions">[]
+  roles: readonly Pick<Role, "name" | "permissions">[],
+  requiredPermissions: readonly string[]
 ) => {
+  const permissions =
+    requiredPermissions.length > 0
+      ? requiredPermissions
+      : [SQL_SELECT_PERMISSION];
   const candidates = roles
-    .filter((role) => role.permissions.includes(SQL_SELECT_PERMISSION))
+    .filter((role) =>
+      permissions.every((permission) => role.permissions.includes(permission))
+    )
     .toSorted((a, b) => {
       const permissionCountDelta = a.permissions.length - b.permissions.length;
       if (permissionCountDelta !== 0) {
@@ -41,7 +48,7 @@ const getDefaultQueryRole = (
       return a.name.localeCompare(b.name);
     });
 
-  return candidates[0]?.name ?? PresetRoleType.SQL_EDITOR_READ_USER;
+  return candidates[0]?.name ?? PresetRoleType.SQL_EDITOR_USER;
 };
 
 interface Props {
@@ -69,7 +76,10 @@ export function RequestQueryButton({
   const projectName = useVueState(() => editorStore.project);
   const project = useVueState(() => projectStore.getProjectByName(projectName));
   const defaultQueryRole = useVueState(() =>
-    getDefaultQueryRole(roleStore.roleList)
+    getDefaultQueryRole(
+      roleStore.roleList,
+      permissionDeniedDetail.requiredPermissions
+    )
   );
 
   const useJIT = useMemo(

--- a/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
@@ -30,11 +30,11 @@ const getDefaultQueryRole = (
     requiredPermissions.length > 0
       ? requiredPermissions
       : [SQL_SELECT_PERMISSION];
-  const candidates = roles
+  const candidates = [...roles]
     .filter((role) =>
       permissions.every((permission) => role.permissions.includes(permission))
     )
-    .toSorted((a, b) => {
+    .sort((a, b) => {
       const permissionCountDelta = a.permissions.length - b.permissions.length;
       if (permissionCountDelta !== 0) {
         return permissionCountDelta;


### PR DESCRIPTION
## Summary
- Default SQL Editor non-JIT query role requests to the least-permission role that includes `bb.sql.select`.
- Prefer `roles/sqlEditorReadUser` as the deterministic fallback/tie-breaker.
- Add coverage for the non-JIT request role default.

## Test Plan
- [x] `pnpm --dir frontend fix`
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend test RequestQueryButton.test.tsx`
- [ ] `pnpm --dir frontend test` - unrelated existing failures in `DashboardHeader.test.tsx` and `VersionMenuItem.test.tsx` because `localStorage.setItem`/`localStorage.clear` are unavailable in those tests; `RequestQueryButton.test.tsx` passed in the full run.
