### PR TITLE
chore(plsql): add omni parser entrypoint

### DIFF
--- a/backend/plugin/parser/plsql/omni.go
+++ b/backend/plugin/parser/plsql/omni.go
@@ -1,0 +1,72 @@
+package plsql
+
+import (
+	"unicode/utf8"
+
+	"github.com/bytebase/omni/oracle/ast"
+	oracleparser "github.com/bytebase/omni/oracle/parser"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// OmniAST wraps an omni AST node and implements the base.AST interface.
+type OmniAST struct {
+	// Node is the omni AST node (e.g. *ast.SelectStmt, *ast.CreateTableStmt).
+	Node ast.Node
+	// Text is the original SQL text of this statement.
+	Text string
+	// StartPosition is the 1-based position where this statement starts.
+	StartPosition *storepb.Position
+}
+
+// ASTStartPosition implements base.AST.
+func (a *OmniAST) ASTStartPosition() *storepb.Position {
+	return a.StartPosition
+}
+
+// ParsePLSQLOmni parses SQL using omni's parser and returns an ast.List.
+// This is the recommended entry point for new Oracle code that needs omni AST nodes.
+func ParsePLSQLOmni(sql string) (*ast.List, error) {
+	return oracleparser.Parse(sql)
+}
+
+// GetOmniNode extracts the omni AST node from a base.AST interface.
+// Returns the node and true if it is an OmniAST, nil and false otherwise.
+func GetOmniNode(a base.AST) (ast.Node, bool) {
+	if a == nil {
+		return nil, false
+	}
+	omniAST, ok := a.(*OmniAST)
+	if !ok {
+		return nil, false
+	}
+	return omniAST.Node, true
+}
+
+// ByteOffsetToRunePosition converts a byte offset in sql to a 1-based line:column
+// where column is measured in Unicode code points (runes), matching storepb.Position semantics.
+func ByteOffsetToRunePosition(sql string, byteOffset int) *storepb.Position {
+	if byteOffset > len(sql) {
+		byteOffset = len(sql)
+	}
+
+	line := int32(1)
+	runeCol := int32(0) // 0-based rune count on current line
+	i := 0
+	for i < byteOffset {
+		r, size := utf8.DecodeRuneInString(sql[i:])
+		if r == '\n' {
+			line++
+			runeCol = 0
+		} else {
+			runeCol++
+		}
+		i += size
+	}
+
+	return &storepb.Position{
+		Line:   line,
+		Column: runeCol + 1, // convert to 1-based
+	}
+}

--- a/backend/plugin/parser/plsql/omni_test.go
+++ b/backend/plugin/parser/plsql/omni_test.go
@@ -1,0 +1,59 @@
+package plsql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/omni/oracle/ast"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestParsePLSQLOmni(t *testing.T) {
+	list, err := ParsePLSQLOmni("SELECT * FROM T; INSERT INTO T VALUES (1);")
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	require.Len(t, list.Items, 2)
+
+	first, ok := list.Items[0].(*ast.RawStmt)
+	require.True(t, ok)
+	require.IsType(t, &ast.SelectStmt{}, first.Stmt)
+
+	second, ok := list.Items[1].(*ast.RawStmt)
+	require.True(t, ok)
+	require.IsType(t, &ast.InsertStmt{}, second.Stmt)
+}
+
+func TestParsePLSQLOmniReturnsParseError(t *testing.T) {
+	_, err := ParsePLSQLOmni("SELECT * FROM")
+	require.Error(t, err)
+}
+
+func TestOracleOmniASTWrapper(t *testing.T) {
+	node := &ast.SelectStmt{}
+	start := &storepb.Position{Line: 2, Column: 3}
+	omniAST := &OmniAST{
+		Node:          node,
+		Text:          "SELECT 1 FROM DUAL",
+		StartPosition: start,
+	}
+
+	var parsed base.AST = omniAST
+	require.Equal(t, start, parsed.ASTStartPosition())
+
+	got, ok := GetOmniNode(parsed)
+	require.True(t, ok)
+	require.Same(t, node, got)
+
+	got, ok = GetOmniNode(nil)
+	require.False(t, ok)
+	require.Nil(t, got)
+}
+
+func TestOracleByteOffsetToRunePosition(t *testing.T) {
+	position := ByteOffsetToRunePosition("SELECT\n日本 FROM DUAL", len("SELECT\n日"))
+	require.Equal(t, int32(2), position.Line)
+	require.Equal(t, int32(2), position.Column)
+}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260508022716-902da6c9bd2a
+	github.com/bytebase/omni v0.0.0-20260509021101-01140a7b9722
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,8 @@ github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888 h1:E8tz8maxpih/vt
 github.com/bytebase/gomongo v0.0.0-20260403033636-f6c50d4ab888/go.mod h1:IgLUOjyiHehdE0G3C92IjGYu9lJQgkPwf2mdNSvPWq8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260508022716-902da6c9bd2a h1:YeNioujsdgU53DZONC8Zoi7Hx2CVht0F0hbn8PeAAu4=
-github.com/bytebase/omni v0.0.0-20260508022716-902da6c9bd2a/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260509021101-01140a7b9722 h1:zeMIExVxJVNoU3DZfrKrMMrdZTmUJ264bihZ3fDNcqo=
+github.com/bytebase/omni v0.0.0-20260509021101-01140a7b9722/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Add Oracle `OmniAST` wrapper plus `ParsePLSQLOmni`, `GetOmniNode`, and byte-offset position helper.
- Add focused tests for Oracle omni parsing, wrapper extraction, parse errors, and Unicode offset conversion.
- Upgrade `github.com/bytebase/omni` to `v0.0.0-20260509021101-01140a7b9722`.

## Test Plan
- [x] `go test ./backend/plugin/parser/plsql -count=1`
- [x] `golangci-lint run --fix --allow-parallel-runners`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Pre-PR Checklist
- Breaking change check: no API/schema/proto/config/UI workflow changes.
- Composite-PK query safety: skipped, no `backend/store` or migrator changes.
- SonarCloud properties: no update needed; new Go source and test files are under existing included patterns.