### PR TITLE
fix(react): display database names in member role editor

### DIFF
--- a/frontend/src/react/pages/settings/MemberDatabaseResourceName.test.tsx
+++ b/frontend/src/react/pages/settings/MemberDatabaseResourceName.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { DatabaseResource } from "@/types";
+import { MemberDatabaseResourceName } from "./MemberDatabaseResourceName";
+
+const mocks = vi.hoisted(() => ({
+  getDatabaseByName: vi.fn(),
+  getInstanceByName: vi.fn(),
+}));
+
+vi.mock("@/react/hooks/useVueState", () => ({
+  useVueState: <T,>(getter: () => T) => getter(),
+}));
+
+vi.mock("@/store", () => ({
+  useDatabaseV1Store: () => ({
+    getDatabaseByName: mocks.getDatabaseByName,
+  }),
+  useInstanceV1Store: () => ({
+    getInstanceByName: mocks.getInstanceByName,
+  }),
+}));
+
+vi.mock("@/react/components/EngineIcon", () => ({
+  EngineIcon: ({ engine }: { engine: string }) => (
+    <span data-testid="engine-icon">{engine}</span>
+  ),
+}));
+
+vi.mock("@/utils", () => ({
+  extractDatabaseResourceName: (name: string) => {
+    const parts = name.split("/");
+    return {
+      databaseName: parts[3] ?? name,
+      instanceName: parts[1] ?? "",
+    };
+  },
+  extractInstanceResourceName: (name: string) => name.split("/")[1] ?? name,
+  getInstanceResource: (database: { instanceResource?: unknown }) =>
+    database.instanceResource,
+}));
+
+const resource: DatabaseResource = {
+  databaseFullName: "instances/prod/databases/hr",
+};
+
+describe("MemberDatabaseResourceName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getDatabaseByName.mockReturnValue({
+      name: "instances/prod/databases/hr",
+      instanceResource: {
+        name: "instances/prod",
+        title: "Production",
+        engine: "POSTGRES",
+      },
+    });
+    mocks.getInstanceByName.mockReturnValue({
+      name: "instances/prod",
+      title: "Production",
+      engine: "POSTGRES",
+    });
+  });
+
+  test("renders instance title and database name instead of raw resource path", () => {
+    render(<MemberDatabaseResourceName resource={resource} />);
+
+    expect(screen.getByTestId("engine-icon")).toHaveTextContent("POSTGRES");
+    expect(screen.getByText("Production")).toBeInTheDocument();
+    expect(screen.getByText("hr")).toBeInTheDocument();
+    expect(
+      screen.queryByText(resource.databaseFullName)
+    ).not.toBeInTheDocument();
+  });
+
+  test("falls back to instance id without showing unknown instance engine", () => {
+    mocks.getDatabaseByName.mockReturnValue({
+      name: "instances/prod/databases/hr",
+    });
+    mocks.getInstanceByName.mockReturnValue({
+      name: "instances/-",
+      title: "",
+      engine: "MYSQL",
+    });
+
+    render(<MemberDatabaseResourceName resource={resource} />);
+
+    expect(screen.queryByTestId("engine-icon")).not.toBeInTheDocument();
+    expect(screen.getByText("prod")).toBeInTheDocument();
+    expect(screen.getByText("hr")).toBeInTheDocument();
+  });
+
+  test("renders wildcard for unscoped resources", () => {
+    render(<MemberDatabaseResourceName />);
+
+    expect(screen.getByText("*")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/react/pages/settings/MemberDatabaseResourceName.tsx
+++ b/frontend/src/react/pages/settings/MemberDatabaseResourceName.tsx
@@ -1,0 +1,64 @@
+import { ChevronRight } from "lucide-react";
+import { EngineIcon } from "@/react/components/EngineIcon";
+import { useVueState } from "@/react/hooks/useVueState";
+import { useDatabaseV1Store, useInstanceV1Store } from "@/store";
+import type { DatabaseResource } from "@/types";
+import {
+  extractDatabaseResourceName,
+  extractInstanceResourceName,
+} from "@/utils";
+
+export function MemberDatabaseResourceName({
+  resource,
+}: {
+  resource?: DatabaseResource;
+}) {
+  const databaseStore = useDatabaseV1Store();
+  const instanceStore = useInstanceV1Store();
+
+  const display = useVueState(() => {
+    if (!resource) {
+      return undefined;
+    }
+
+    const { databaseName, instanceName } = extractDatabaseResourceName(
+      resource.databaseFullName
+    );
+    const database = databaseStore.getDatabaseByName(resource.databaseFullName);
+    const expectedInstanceName = `instances/${instanceName}`;
+    const instance = instanceName
+      ? instanceStore.getInstanceByName(expectedInstanceName)
+      : undefined;
+    const validInstance =
+      instance?.name === expectedInstanceName ? instance : undefined;
+    const instanceResource =
+      database.instanceResource?.name === expectedInstanceName
+        ? database.instanceResource
+        : undefined;
+    const instanceTitle =
+      validInstance?.title ||
+      instanceResource?.title ||
+      extractInstanceResourceName(resource.databaseFullName);
+
+    return {
+      databaseName,
+      engine: instanceResource?.engine || validInstance?.engine,
+      instanceTitle,
+    };
+  });
+
+  if (!display) {
+    return <span>*</span>;
+  }
+
+  return (
+    <div className="flex min-w-0 items-center text-sm">
+      {display.engine !== undefined && (
+        <EngineIcon engine={display.engine} className="mr-1 h-4 w-4" />
+      )}
+      <span className="truncate text-gray-600">{display.instanceTitle}</span>
+      <ChevronRight className="h-4 w-4 shrink-0 text-gray-500 opacity-60" />
+      <span className="truncate text-gray-800">{display.databaseName}</span>
+    </div>
+  );
+}

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -104,6 +104,7 @@ import {
   stringifyConditionExpression,
 } from "@/utils/issue/cel";
 import { MemberBindingEnvironmentBanner } from "./MemberBindingEnvironmentBanner";
+import { MemberDatabaseResourceName } from "./MemberDatabaseResourceName";
 import { getSetIamPolicyPermissionGuardConfig } from "./membersPageActions";
 import { getProjectRoleBindingEnvironmentLimitationState } from "./membersPageEnvironment";
 import { RequestRoleSheet } from "./RequestRoleSheet";
@@ -1432,8 +1433,9 @@ function EditMemberRoleDrawer({
                             {rows.map((row, rowIdx) => (
                               <TableRow key={rowIdx}>
                                 <TableCell>
-                                  {row.databaseResource?.databaseFullName ??
-                                    "*"}
+                                  <MemberDatabaseResourceName
+                                    resource={row.databaseResource}
+                                  />
                                 </TableCell>
                                 <TableCell>
                                   {row.databaseResource?.schema ?? "*"}


### PR DESCRIPTION

<img width="1364" height="782" alt="Microsoft Edge 2026-05-09 17 17 04" src="https://github.com/user-attachments/assets/51738095-260b-421e-972a-8c54a157f1b9" />

## Summary
- Show project member role database scopes as instance name plus database name instead of raw resource paths.
- Add a reusable React renderer with engine icon support and safe fallback behavior for uncached instances.
- Cover display and fallback cases with tests.

## Test Plan
- pnpm --dir frontend test src/react/pages/settings/MemberDatabaseResourceName.test.tsx
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test

Closes BYT-9415