### PR TITLE
fix(frontend): stabilize ExprEditor condition updates

### DIFF
--- a/frontend/src/react/components/ExprEditor.test.tsx
+++ b/frontend/src/react/components/ExprEditor.test.tsx
@@ -1,0 +1,237 @@
+import { act, type ReactElement, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { Factor } from "@/plugins/cel/types/factor";
+import { type ConditionGroupExpr, ExprType } from "@/plugins/cel/types/simple";
+import {
+  CEL_ATTRIBUTE_RISK_LEVEL,
+  CEL_ATTRIBUTE_STATEMENT_SQL_TYPE,
+} from "@/utils/cel-attributes";
+import { ExprEditor, type OptionConfig } from "./ExprEditor";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+class ResizeObserverStub implements ResizeObserver {
+  constructor(_callback: ResizeObserverCallback) {}
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+globalThis.ResizeObserver = ResizeObserverStub;
+
+const { MockExprType } = vi.hoisted(() => ({
+  MockExprType: {
+    RawString: "RawString",
+    Condition: "Condition",
+    ConditionGroup: "ConditionGroup",
+  } as const,
+}));
+
+vi.mock("@/plugins/cel", () => ({
+  ExprType: MockExprType,
+  LogicalOperatorList: ["_&&_", "_||_"],
+  getOperatorListByFactor: () => ["_==_", "@in"],
+  isBooleanFactor: () => false,
+  isCollectionOperator: (operator: string) =>
+    operator === "@in" || operator === "@not_in",
+  isConditionExpr: (expr: { type: string }) =>
+    expr.type === MockExprType.Condition,
+  isConditionGroupExpr: (expr: { type: string }) =>
+    expr.type === MockExprType.ConditionGroup,
+  isNumberFactor: () => false,
+  isRawStringExpr: (expr: { type: string }) =>
+    expr.type === MockExprType.RawString,
+  isStringFactor: () => true,
+  isStringOperator: (operator: string) =>
+    ["contains", "@not_contains", "matches", "startsWith", "endsWith"].includes(
+      operator
+    ),
+  isTimestampFactor: () => false,
+  operatorDisplayLabel: (operator: string) => operator,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/utils", () => ({
+  getDefaultPagination: () => ({
+    pageSize: 1000,
+    pageToken: "",
+  }),
+}));
+
+vi.mock("@/react/components/EnvironmentLabel", () => ({
+  EnvironmentLabel: ({ environmentName }: { environmentName: string }) => (
+    <span>{environmentName}</span>
+  ),
+}));
+
+vi.mock("@/store/modules/v1/common", () => ({
+  environmentNamePrefix: "environments/",
+}));
+
+const optionConfigMap = new Map<Factor, OptionConfig>([
+  [
+    CEL_ATTRIBUTE_STATEMENT_SQL_TYPE,
+    {
+      options: [
+        { value: "DDL", label: "DDL" },
+        { value: "DML", label: "DML" },
+        { value: "DCL", label: "DCL" },
+      ],
+    },
+  ],
+  [
+    CEL_ATTRIBUTE_RISK_LEVEL,
+    {
+      options: [
+        { value: "HIGH", label: "High" },
+        { value: "LOW", label: "Low" },
+      ],
+    },
+  ],
+]);
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(element);
+  });
+
+  return {
+    container,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+        container.remove();
+      }),
+  };
+};
+
+const flushEffects = async () => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe("ExprEditor", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("keeps the next condition value after deleting the first condition", async () => {
+    const initialExpr: ConditionGroupExpr = {
+      type: ExprType.ConditionGroup,
+      operator: "_&&_",
+      args: [
+        {
+          type: ExprType.Condition,
+          operator: "@in",
+          args: [CEL_ATTRIBUTE_STATEMENT_SQL_TYPE, ["DDL"]],
+        },
+        {
+          type: ExprType.Condition,
+          operator: "@in",
+          args: [CEL_ATTRIBUTE_RISK_LEVEL, ["HIGH"]],
+        },
+      ],
+    };
+    let currentExpr = initialExpr;
+
+    const Harness = () => {
+      const [expr, setExpr] = useState(initialExpr);
+      return (
+        <ExprEditor
+          expr={expr}
+          factorList={[
+            CEL_ATTRIBUTE_STATEMENT_SQL_TYPE,
+            CEL_ATTRIBUTE_RISK_LEVEL,
+          ]}
+          optionConfigMap={optionConfigMap}
+          onUpdate={(next) => {
+            currentExpr = next;
+            setExpr(next);
+          }}
+        />
+      );
+    };
+
+    const { container, unmount } = renderIntoContainer(<Harness />);
+    await flushEffects();
+
+    const deleteButtons = Array.from(
+      container.querySelectorAll('button[type="button"]')
+    ).filter((button) => button.className.includes("size-7"));
+    expect(deleteButtons).toHaveLength(2);
+
+    await act(async () => {
+      deleteButtons[0]?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true })
+      );
+    });
+    await flushEffects();
+
+    expect(currentExpr.args).toHaveLength(1);
+    expect(currentExpr.args[0]).toMatchObject({
+      type: ExprType.Condition,
+      operator: "@in",
+      args: [CEL_ATTRIBUTE_RISK_LEVEL, ["HIGH"]],
+    });
+
+    unmount();
+  });
+
+  test("static multi-select dropdown constrains overflow", async () => {
+    const initialExpr: ConditionGroupExpr = {
+      type: ExprType.ConditionGroup,
+      operator: "_&&_",
+      args: [
+        {
+          type: ExprType.Condition,
+          operator: "@in",
+          args: [CEL_ATTRIBUTE_STATEMENT_SQL_TYPE, []],
+        },
+      ],
+    };
+
+    const { container, unmount } = renderIntoContainer(
+      <ExprEditor
+        expr={initialExpr}
+        factorList={[CEL_ATTRIBUTE_STATEMENT_SQL_TYPE]}
+        optionConfigMap={optionConfigMap}
+        onUpdate={() => {}}
+      />
+    );
+    await flushEffects();
+
+    const trigger = Array.from(
+      container.querySelectorAll('button[type="button"]')
+    ).find((button) =>
+      button.textContent?.includes("cel.condition.select-value")
+    );
+    expect(trigger).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => {
+      trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const allOption = Array.from(document.body.querySelectorAll("label")).find(
+      (label) => label.textContent?.includes("common.all")
+    );
+    const dropdown = allOption?.parentElement;
+    expect(dropdown).toBeInstanceOf(HTMLDivElement);
+    expect(dropdown?.className).toContain("max-h-48");
+    expect(dropdown?.className).toContain("overflow-y-auto");
+
+    unmount();
+  });
+});

--- a/frontend/src/react/components/ExprEditor.tsx
+++ b/frontend/src/react/components/ExprEditor.tsx
@@ -90,7 +90,11 @@ function getOperatorListByFactor(
   return overrideMap?.get(factor) ?? getRawOperatorListByFactor(factor);
 }
 
-function getDefaultValue(factor: Factor): string | number | boolean | Date {
+function getDefaultValue(
+  factor: Factor,
+  operator?: ConditionOperator
+): string | number | boolean | Date | string[] | number[] {
+  if (operator && isCollectionOperator(operator)) return [];
   if (isNumberFactor(factor)) return 0;
   if (isBooleanFactor(factor)) return true;
   if (isStringFactor(factor)) return "";
@@ -798,7 +802,7 @@ function MultiCheckSelect({
           anchorRef={triggerRef}
           dropdownRef={dropdownRef}
           matchAnchorWidth
-          className="bg-background border border-control-border rounded-sm shadow-md py-1"
+          className="bg-background border border-control-border rounded-sm shadow-md py-1 max-h-48 overflow-y-auto"
         >
           <label className="flex items-center gap-2 px-3 py-1.5 text-sm cursor-pointer border-b border-control-border hover:bg-control-bg">
             <Checkbox
@@ -860,7 +864,13 @@ function FactorSelect({
     if (!factorList.includes(factor)) {
       doUpdate((group) => {
         const cond = group.args[operandIndex] as ConditionExpr;
-        (cond.args as unknown[])[0] = factorList[0];
+        const newFactor = factorList[0];
+        (cond.args as unknown[])[0] = newFactor;
+        const operators = getOperatorListByFactor(newFactor, overrideMap);
+        if (operators.length > 0 && !operators.includes(cond.operator)) {
+          cond.operator = operators[0] as ConditionOperator;
+        }
+        (cond.args as unknown[])[1] = getDefaultValue(newFactor, cond.operator);
       });
     }
   }, [factor, factorList]);
@@ -879,6 +889,10 @@ function FactorSelect({
           if (operators.length > 0 && !operators.includes(cond.operator)) {
             cond.operator = operators[0] as ConditionOperator;
           }
+          (cond.args as unknown[])[1] = getDefaultValue(
+            newFactor,
+            cond.operator
+          );
         });
       }}
     >
@@ -929,6 +943,10 @@ function OperatorSelect({
       doUpdate((group) => {
         const cond = group.args[operandIndex] as ConditionExpr;
         cond.operator = operators[0] as ConditionOperator;
+        (cond.args as unknown[])[1] = getDefaultValue(
+          cond.args[0] as Factor,
+          cond.operator
+        );
       });
     }
   }, [operators, expr.operator]);
@@ -941,6 +959,10 @@ function OperatorSelect({
         doUpdate((group) => {
           const cond = group.args[operandIndex] as ConditionExpr;
           cond.operator = val as ConditionOperator;
+          (cond.args as unknown[])[1] = getDefaultValue(
+            cond.args[0] as Factor,
+            cond.operator
+          );
         });
       }}
     >
@@ -1026,30 +1048,6 @@ function ValueInput({
       (cond.args as unknown[])[1] = v;
     });
   };
-
-  // Reset value when factor or operator changes
-  const prevRef = useRef({ factor, operator });
-  useEffect(() => {
-    const prev = prevRef.current;
-    const changed = prev.factor !== factor || prev.operator !== operator;
-    prevRef.current = { factor, operator };
-    if (!changed) return;
-
-    doUpdate((group) => {
-      const cond = group.args[operandIndex] as ConditionExpr;
-      if (isNumberFactor(cond.args[0] as Factor)) {
-        (cond.args as unknown[])[1] = isCollectionOperator(cond.operator)
-          ? []
-          : 0;
-      } else if (isBooleanFactor(cond.args[0] as Factor)) {
-        (cond.args as unknown[])[1] = true;
-      } else if (isStringFactor(cond.args[0] as Factor)) {
-        (cond.args as unknown[])[1] = isCollectionOperator(cond.operator)
-          ? []
-          : "";
-      }
-    });
-  }, [factor, operator]);
 
   const getStringValue = () => {
     const v = expr.args[1];
@@ -1361,13 +1359,13 @@ function ConditionGroup({
     const factor = factorList[0];
     if (!factor) return;
     const operators = getOperatorListByFactor(factor, overrideMap);
-    const op = operators[0];
+    const op = operators[0] as ConditionOperator | undefined;
     if (!op) return;
     doUpdate((group) => {
       group.args.push({
         type: ExprType.Condition,
         operator: op,
-        args: [factor, getDefaultValue(factor)],
+        args: [factor, getDefaultValue(factor, op)],
       } as ConditionExpr);
     });
   };


### PR DESCRIPTION

<img width="1786" height="746" alt="Microsoft Edge 2026-05-09 17 53 07" src="https://github.com/user-attachments/assets/3ac5f3d0-861f-4d21-aa82-8958c8f79096" />
<img width="1780" height="380" alt="Microsoft Edge 2026-05-09 17 53 22" src="https://github.com/user-attachments/assets/3be35fc2-e668-4105-86d9-07265c6bb7b9" />

## Summary
- Make static ExprEditor multi-select dropdowns scroll when many options are available.
- Move ExprEditor value resets to explicit factor/operator changes so deleting a condition does not clear the next condition's value.
- Add regression coverage for condition deletion and static multi-select overflow.

## Test Plan
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend test`

## Pre-PR Checklist
- Breaking changes: none. This is a UI bug fix.
- Composite-PK query safety: skipped, no backend store or migration changes.
- SonarCloud properties: existing `frontend/src/**/*.test.tsx` inclusion covers the new test file.

Closes BYT-9431
