### PR TITLE
fix(frontend): stop wiping user-scoped localStorage on logout

### DIFF
--- a/docs/superpowers/plans/2026-05-09-byt-9432-logout-localstorage-wipe.md
+++ b/docs/superpowers/plans/2026-05-09-byt-9432-logout-localstorage-wipe.md
@@ -1,0 +1,286 @@
+# BYT-9432 — Stop wiping user-scoped localStorage on logout (Implementation Plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the broad `*.<email>`-suffix `localStorage` cleanup from both the Vue and React logout flows so SQL Editor tabs and other user-scoped UI state survive a logout/login cycle.
+
+**Architecture:** Pure deletion. The Vue store has a private `cleanupUserStorage(email)` helper called from `logout()`'s `finally` block; we delete both. The React store inlines the same loop in its own `logout()`'s `finally`; we delete the loop and the now-unused `email` capture and import. No other files change. The fix is two surgical edits in two files, validated by manual logout/login round-trip plus the standard frontend lint/check/type-check/test gates.
+
+**Tech Stack:** TypeScript, Vue 3 (Pinia), React, frontend monorepo gated by `pnpm --dir frontend {fix,check,type-check,test}`.
+
+**Spec:** [`docs/superpowers/specs/2026-05-09-byt-9432-logout-localstorage-wipe-design.md`](../specs/2026-05-09-byt-9432-logout-localstorage-wipe-design.md)
+
+---
+
+## File Map
+
+- **Modify:** `frontend/src/store/modules/v1/auth.ts` — delete the `cleanupUserStorage` helper (~lines 186–196) and remove its call site inside `logout()`'s `finally` block (~line 204).
+- **Modify:** `frontend/src/react/stores/app/auth.ts` — delete the inlined cleanup loop inside `logout()`'s `finally`, drop the unused `email` capture, and drop the now-unused `getCurrentUserEmail` import.
+
+No files created. No tests added (pure deletion of behavior; per the spec, a "logout doesn't touch localStorage" test would be a low-value negative-behavior pin).
+
+---
+
+## Task 1: Remove cleanup from the Vue auth store
+
+**Files:**
+- Modify: `frontend/src/store/modules/v1/auth.ts`
+
+- [ ] **Step 1: Delete the `cleanupUserStorage` helper definition**
+
+In `frontend/src/store/modules/v1/auth.ts`, remove the entire helper (and its trailing blank line) so it's gone from the file. The block to delete:
+
+```ts
+  const cleanupUserStorage = (email: string) => {
+    if (!email) return;
+    const keysToRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key?.endsWith(`.${email}`)) {
+        keysToRemove.push(key);
+      }
+    }
+    keysToRemove.forEach((key) => localStorage.removeItem(key));
+  };
+
+```
+
+Verify: `grep -n "cleanupUserStorage" frontend/src/store/modules/v1/auth.ts` returns no matches after the delete in this step is paired with Step 2 (the call site).
+
+- [ ] **Step 2: Remove the call site inside `logout()`'s `finally` block**
+
+Inside the `logout` function in the same file, the `finally` block currently reads:
+
+```ts
+    } finally {
+      cleanupUserStorage(currentUserEmail.value);
+      unauthenticatedOccurred.value = false;
+      const pathname = location.pathname;
+      // Replace and reload the page to clear frontend state directly.
+      window.location.href = router.resolve({
+        name: AUTH_SIGNIN_MODULE,
+        query: {
+          redirect:
+            getRedirectQuery() ||
+            (pathname.startsWith("/auth") ? undefined : pathname),
+        },
+      }).fullPath;
+    }
+```
+
+Edit it to drop the `cleanupUserStorage(currentUserEmail.value);` line, leaving:
+
+```ts
+    } finally {
+      unauthenticatedOccurred.value = false;
+      const pathname = location.pathname;
+      // Replace and reload the page to clear frontend state directly.
+      window.location.href = router.resolve({
+        name: AUTH_SIGNIN_MODULE,
+        query: {
+          redirect:
+            getRedirectQuery() ||
+            (pathname.startsWith("/auth") ? undefined : pathname),
+        },
+      }).fullPath;
+    }
+```
+
+- [ ] **Step 3: Verify no stale references remain**
+
+Run: `grep -n "cleanupUserStorage" frontend/src/store/modules/v1/auth.ts frontend/src/react/stores/app/auth.ts`
+Expected: no output.
+
+Run also: `grep -rn "cleanupUserStorage" frontend/src`
+Expected: no output (helper was only referenced by name in this one file).
+
+---
+
+## Task 2: Remove cleanup from the React auth store
+
+**Files:**
+- Modify: `frontend/src/react/stores/app/auth.ts`
+
+- [ ] **Step 1: Delete the inlined cleanup block and the unused `email` capture**
+
+Open `frontend/src/react/stores/app/auth.ts`. The current `logout` reads:
+
+```ts
+  logout: async (signinUrl) => {
+    const email = getCurrentUserEmail(get);
+    try {
+      await authServiceClientConnect.logout({});
+    } catch {
+      // Ignore logout errors and clear the local session by redirecting anyway.
+    } finally {
+      if (email) {
+        const keysToRemove: string[] = [];
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i);
+          if (key?.endsWith(`.${email}`)) {
+            keysToRemove.push(key);
+          }
+        }
+        keysToRemove.forEach((key) => localStorage.removeItem(key));
+      }
+      window.location.href = signinUrl;
+    }
+  },
+```
+
+Replace the entire function with:
+
+```ts
+  logout: async (signinUrl) => {
+    try {
+      await authServiceClientConnect.logout({});
+    } catch {
+      // Ignore logout errors and clear the local session by redirecting anyway.
+    } finally {
+      window.location.href = signinUrl;
+    }
+  },
+```
+
+(The `const email = getCurrentUserEmail(get);` line and the entire `if (email) { ... }` block are gone.)
+
+- [ ] **Step 2: Drop the now-unused `getCurrentUserEmail` import**
+
+At the top of the same file, the imports currently read:
+
+```ts
+import { authServiceClientConnect, userServiceClientConnect } from "@/connect";
+import type { AppSliceCreator, AuthSlice } from "./types";
+import { getCurrentUserEmail } from "./utils";
+```
+
+`getCurrentUserEmail` was only referenced inside the deleted `logout` body. Remove the import line so the imports become:
+
+```ts
+import { authServiceClientConnect, userServiceClientConnect } from "@/connect";
+import type { AppSliceCreator, AuthSlice } from "./types";
+```
+
+If, for any reason, `getCurrentUserEmail` turns out to still be referenced elsewhere in this file (it should not be), keep the import. Verify with: `grep -n "getCurrentUserEmail" frontend/src/react/stores/app/auth.ts` — expected: no output after the edit.
+
+- [ ] **Step 3: Verify no stale references remain in this file**
+
+Run: `grep -n "localStorage\|cleanupUserStorage\|getCurrentUserEmail" frontend/src/react/stores/app/auth.ts`
+Expected: no output.
+
+---
+
+## Task 3: Run frontend validation gates
+
+**Files:** none (validation only)
+
+- [ ] **Step 1: Auto-fix formatter / linter / import order**
+
+Run: `pnpm --dir frontend fix`
+Expected: completes without error. May produce no diff, or only trivial formatting changes — review any diff.
+
+- [ ] **Step 2: CI-equivalent check**
+
+Run: `pnpm --dir frontend check`
+Expected: passes with no errors.
+
+- [ ] **Step 3: Type check**
+
+Run: `pnpm --dir frontend type-check`
+Expected: passes. If the `getCurrentUserEmail` import was correctly removed in Task 2 / Step 2, there should be no "unused import" or "cannot find name" errors.
+
+- [ ] **Step 4: Unit tests**
+
+Run: `pnpm --dir frontend test`
+Expected: existing tests pass. There are no new tests in this plan.
+
+---
+
+## Task 4: Manual browser verification
+
+**Files:** none (runtime verification)
+
+- [ ] **Step 1: Start the backend and frontend dev servers**
+
+In one terminal:
+`PG_URL=postgresql://bbdev@localhost/bbdev go run ./backend/bin/server/main.go --port 8080 --data . --debug`
+
+In another:
+`pnpm --dir frontend dev`
+
+- [ ] **Step 2: Sign in and create SQL Editor state**
+
+1. Open the app in a browser and sign in as a real user.
+2. Navigate to SQL Editor.
+3. Create 2–3 tabs in any project, type a different SQL statement into each (do not save them as worksheets — leave them as unsaved tab content).
+
+- [ ] **Step 3: Snapshot the user-scoped localStorage keys**
+
+Open DevTools → Application → Local Storage → the dev-server origin.
+
+Note the presence of keys whose name ends with `.<your-email>`, especially:
+- `bb.sql-editor.tabs.<project>.<your-email>`
+- `bb.sql-editor.current-tab.<project>.<your-email>`
+
+- [ ] **Step 4: Sign out and confirm keys persist**
+
+1. Click sign out from the app menu.
+2. After the redirect to the signin page, refresh the DevTools Local Storage view for the same origin.
+3. Confirm the `*.<your-email>` keys from Step 3 are **still present**.
+
+If any of those keys are missing after logout, the cleanup deletion is incomplete — go back and re-check Tasks 1 and 2.
+
+- [ ] **Step 5: Sign back in and confirm tabs restore**
+
+1. Sign back in as the same user.
+2. Navigate to SQL Editor.
+3. Confirm the tabs from Step 2 are restored, including the unsaved SQL text in each tab.
+4. Confirm the previously-active tab is still active (driven by `bb.sql-editor.current-tab.<project>.<email>`).
+
+---
+
+## Task 5: Commit
+
+**Files:** the two modified files from Tasks 1 and 2.
+
+- [ ] **Step 1: Stage and commit**
+
+Run:
+
+```bash
+git add frontend/src/store/modules/v1/auth.ts frontend/src/react/stores/app/auth.ts
+git commit -m "$(cat <<'EOF'
+fix(frontend): stop wiping user-scoped localStorage on logout
+
+Both the Vue and React logout flows scanned localStorage and removed
+every key ending in `.<email>`. That wiped SQL Editor tabs, recent
+visits, and other user-scoped UI state — productivity state users
+expect to persist across sessions on the same browser.
+
+Keys are already user-scoped, so cross-user contamination was not a
+concern. Drop the cleanup so same-email re-login restores the prior
+SQL Editor tabs and other UI state.
+
+Fixes BYT-9432
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds. If a pre-commit hook fails, fix the underlying issue and create a new commit (do not `--amend`).
+
+- [ ] **Step 2: Verify the commit**
+
+Run: `git log -1 --stat`
+Expected: shows two files modified (`frontend/src/store/modules/v1/auth.ts`, `frontend/src/react/stores/app/auth.ts`) with a small net-negative line count.
+
+---
+
+## Done criteria
+
+- `cleanupUserStorage` no longer exists in the codebase (`grep -rn "cleanupUserStorage" frontend/src` returns nothing).
+- Neither auth store calls `localStorage.removeItem` from `logout()`.
+- Frontend lint, check, type-check, and test gates pass.
+- Manual round-trip (Task 4) confirms SQL Editor tabs survive a logout/login cycle on the same email.
+- Single commit on the branch with both file changes and a descriptive message linking BYT-9432.

--- a/docs/superpowers/specs/2026-05-09-byt-9432-logout-localstorage-wipe-design.md
+++ b/docs/superpowers/specs/2026-05-09-byt-9432-logout-localstorage-wipe-design.md
@@ -1,0 +1,81 @@
+# BYT-9432 — Stop wiping user-scoped localStorage on logout
+
+- **Status:** Approved (design)
+- **Linear:** [BYT-9432](https://linear.app/bytebase/issue/BYT-9432/logout-wipes-user-scoped-localstorage-including-sql-editor)
+- **Date:** 2026-05-09
+
+## Problem
+
+On logout, both the Vue store (`frontend/src/store/modules/v1/auth.ts`) and the React store (`frontend/src/react/stores/app/auth.ts`) scan `localStorage` and remove every key whose suffix matches `.${currentUserEmail}`. This wipes SQL Editor tabs/current-tab pointers, worksheet UI state, recent visits, quick access, and other productivity state that users rely on persisting across sessions.
+
+Keys are already user-scoped by email, so different users on the same browser cannot read each other's data — there is no cross-user contamination problem to solve by wiping. Closing the browser does not wipe `localStorage`; logout being more destructive than that is surprising. The wipe was introduced in PR #19218 alongside the storage-key registry refactor without an explicit rationale.
+
+## Goal
+
+Remove the broad `*.<email>` cleanup from both logout paths so user-scoped state survives a logout/login round-trip on the same browser.
+
+## Non-goals
+
+- No changes to `storage-keys.ts` or `storage-migrate.ts`. The keys themselves are correct.
+- No new "Sign out and clear local data" opt-in action. If shared-machine privacy becomes a real ask, that's a separate spec.
+- No new tests pinning negative behavior (logout-must-not-touch-localStorage). Manual verification only.
+
+## Changes
+
+### 1. `frontend/src/store/modules/v1/auth.ts` (Vue store)
+
+- Delete the `cleanupUserStorage` helper (defined ~line 186, 11 lines). It has no other callers in the codebase (verified by grep).
+- Delete its invocation inside `logout()`'s `finally` block (~line 204).
+- Preserve the rest of `finally` unchanged: `unauthenticatedOccurred.value = false` and the redirect to the signin route via `window.location.href`.
+
+### 2. `frontend/src/react/stores/app/auth.ts` (React store)
+
+- Delete the inlined cleanup block in `logout()` (the loop populating `keysToRemove` and the subsequent `forEach(localStorage.removeItem)`).
+- Drop the `email` capture on line 29 since it becomes unused.
+- Drop the `getCurrentUserEmail` import from `./utils` if it has no remaining uses in this file.
+- Keep the `try`/`catch` around `authServiceClientConnect.logout({})` and the `window.location.href = signinUrl` redirect.
+
+### What stays untouched
+
+- `frontend/src/utils/storage-keys.ts` — unchanged.
+- `frontend/src/utils/storage-migrate.ts` — unchanged.
+- All callers and key builders — unchanged.
+
+## Behavior after fix
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Logout, log back in as same email | User-scoped keys wiped; SQL Editor tabs gone | Keys persist; tabs and unsaved statements restore |
+| Logout, log in as different email on same browser | Previous user's keys wiped | Previous user's keys remain in storage, inaccessible to the new email (different suffix). Consistent with how every other browser-persisted UI state already behaves. |
+| Closing browser without logout | Keys persist (already true) | Keys persist (unchanged) |
+
+## Risk
+
+Low. Two small deletions in two files. No API, proto, or schema changes. The only observable behavior change is that user-scoped keys persist across logout — the change being asked for.
+
+The minor consideration is that ephemeral auth-flow nudges keyed by email (e.g., `bb.iam-remind.<email>`, `bb.reset-password.<email>`) will also persist. On a single-user browser this is harmless: the same email re-login should see the same nudge state. If this turns out to be a problem in practice, those specific keys can be cleared at the points where they're produced/consumed rather than via a blanket logout sweep.
+
+## Testing
+
+### Manual
+
+1. Sign in to the app.
+2. Open SQL Editor, create 2–3 tabs with unsaved SQL.
+3. Open DevTools → Application → Local Storage; note keys with the `.<email>` suffix (`bb.sql-editor.tabs.<project>.<email>`, `bb.sql-editor.current-tab.<project>.<email>`, etc.).
+4. Sign out via the app menu.
+5. Confirm those keys are still present in Local Storage after the redirect to the signin page.
+6. Sign back in as the same user.
+7. Confirm SQL Editor tabs, current tab, and the unsaved SQL within them all restore.
+
+### Automated gates
+
+- `pnpm --dir frontend fix`
+- `pnpm --dir frontend check`
+- `pnpm --dir frontend type-check`
+- `pnpm --dir frontend test`
+
+No new unit tests planned — the change is a pure deletion, and there is no covering test today. A test asserting "logout does not call `localStorage.removeItem`" would be a low-value negative-behavior pin.
+
+## Rollout
+
+Standard frontend deploy. No feature flag needed — the behavior change is small and clearly an improvement.

--- a/frontend/src/react/stores/app/auth.ts
+++ b/frontend/src/react/stores/app/auth.ts
@@ -1,6 +1,5 @@
 import { authServiceClientConnect, userServiceClientConnect } from "@/connect";
 import type { AppSliceCreator, AuthSlice } from "./types";
-import { getCurrentUserEmail } from "./utils";
 
 export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
   loadCurrentUser: async () => {
@@ -26,22 +25,11 @@ export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
   },
 
   logout: async (signinUrl) => {
-    const email = getCurrentUserEmail(get);
     try {
       await authServiceClientConnect.logout({});
     } catch {
       // Ignore logout errors and clear the local session by redirecting anyway.
     } finally {
-      if (email) {
-        const keysToRemove: string[] = [];
-        for (let i = 0; i < localStorage.length; i++) {
-          const key = localStorage.key(i);
-          if (key?.endsWith(`.${email}`)) {
-            keysToRemove.push(key);
-          }
-        }
-        keysToRemove.forEach((key) => localStorage.removeItem(key));
-      }
       window.location.href = signinUrl;
     }
   },

--- a/frontend/src/store/modules/v1/auth.ts
+++ b/frontend/src/store/modules/v1/auth.ts
@@ -183,25 +183,12 @@ export const useAuthStore = defineStore("auth_v1", () => {
     router.replace(nextPage);
   };
 
-  const cleanupUserStorage = (email: string) => {
-    if (!email) return;
-    const keysToRemove: string[] = [];
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i);
-      if (key?.endsWith(`.${email}`)) {
-        keysToRemove.push(key);
-      }
-    }
-    keysToRemove.forEach((key) => localStorage.removeItem(key));
-  };
-
   const logout = async () => {
     try {
       await authServiceClientConnect.logout({});
     } catch {
       // nothing
     } finally {
-      cleanupUserStorage(currentUserEmail.value);
       unauthenticatedOccurred.value = false;
       const pathname = location.pathname;
       // Replace and reload the page to clear frontend state directly.


### PR DESCRIPTION
## Summary

- Removes the `*.<email>`-suffix `localStorage` cleanup from both the Vue (`frontend/src/store/modules/v1/auth.ts`) and React (`frontend/src/react/stores/app/auth.ts`) logout flows.
- Keys are already user-scoped, so cross-user contamination was not a concern. The wipe was a regression introduced alongside the storage-key registry refactor (#19218) and clobbered SQL Editor tabs, recent visits, and other productivity state on every logout.
- Same-email re-login now restores SQL Editor tabs and other user-scoped UI state, matching the close-tab persistence users already expect.

Fixes [BYT-9432](https://linear.app/bytebase/issue/BYT-9432/logout-wipes-user-scoped-localstorage-including-sql-editor).

## Test plan

- [x] `pnpm --dir frontend fix` (no diff)
- [x] `pnpm --dir frontend check` passes
- [x] `pnpm --dir frontend type-check` passes
- [x] `pnpm --dir frontend test` (1850/1850 passing)
- [x] Manual: open SQL Editor, create unsaved tabs, sign out → user-scoped keys persist in DevTools Local Storage; sign back in same email → tabs and unsaved SQL restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)