### PR TITLE
fix(mongodb): skip system collections during schema sync

### DIFF
--- a/backend/plugin/db/mongodb/mongodb_test.go
+++ b/backend/plugin/db/mongodb/mongodb_test.go
@@ -143,6 +143,36 @@ func TestGetMongoDBConnectionURL(t *testing.T) {
 	}
 }
 
+func TestIsSystemCollection(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{
+			name: "users",
+			want: false,
+		},
+		{
+			name: "system.namespaces",
+			want: true,
+		},
+		{
+			name: "system.users",
+			want: true,
+		},
+		{
+			name: "system.buckets.events",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isSystemCollection(tt.name))
+		})
+	}
+}
+
 func TestIsMongoStatement(t *testing.T) {
 	tests := []struct {
 		statement string

--- a/backend/plugin/db/mongodb/sync.go
+++ b/backend/plugin/db/mongodb/sync.go
@@ -16,14 +16,6 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/db"
 )
 
-var systemCollection = map[string]bool{
-	"system.namespaces": true,
-	"system.indexes":    true,
-	"system.profile":    true,
-	"system.js":         true,
-	"system.views":      true,
-}
-
 var systemDatabase = map[string]bool{
 	"admin":    true,
 	"config":   true,
@@ -142,7 +134,7 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 	slices.Sort(viewNames)
 
 	for _, collectionName := range collectionNames {
-		if systemCollection[collectionName] {
+		if isSystemCollection(collectionName) {
 			continue
 		}
 
@@ -258,6 +250,10 @@ func getIndexes(ctx context.Context, collection *mongo.Collection) ([]*storepb.I
 		indexes = append(indexes, indexMap[name])
 	}
 	return indexes, nil
+}
+
+func isSystemCollection(collectionName string) bool {
+	return strings.HasPrefix(collectionName, "system.")
 }
 
 // getVersion returns the version of mongod or mongos instance.


### PR DESCRIPTION
## Summary
- Skip all MongoDB collections with the `system.` prefix during schema sync instead of relying on a fixed allowlist.
- Add coverage for `system.users` and `system.buckets.*` collection names.

Closes BYT-9442

## Test Plan
- `go test -v -count=1 ./backend/plugin/db/mongodb -run '^TestIsSystemCollection$'`
- `go test -short -v -count=1 ./backend/plugin/db/mongodb`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

Note: non-short MongoDB package tests require `mongosh`; this local environment does not have `mongosh` installed.