### PR TITLE
feat(react): redesign SelectionActionBar — sticky-in-main + responsive overflow

### DIFF
--- a/docs/superpowers/plans/2026-05-11-selection-action-bar-redesign.md
+++ b/docs/superpowers/plans/2026-05-11-selection-action-bar-redesign.md
@@ -1,0 +1,906 @@
+# SelectionActionBar Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the SelectionActionBar bleeding into the sidebar (BYT-9445), make it usable on mobile (BYT-9446) — by changing it from viewport-fixed to sticky-in-main, adding a responsive "More" overflow dropdown, and shortening the label to a generic "N selected".
+
+**Architecture:** Three coordinated changes inside one component plus six call-site label swaps and one new i18n key. The bar gains a `useSelectionMaxVisible` hook (1 / 3 / 5 inline buttons by Tailwind breakpoint) and splits its `actions` into inline + overflow; overflow goes into a single `MoreHorizontal` `DropdownMenu`. Positioning moves from `fixed bottom-6 left-1/2 -translate-x-1/2` to `sticky bottom-6 mx-auto w-fit` inside the page's main scroll container.
+
+**Tech Stack:** React, `@base-ui/react` (DropdownMenu primitive), Tailwind CSS v4, `react-i18next`, vitest. Linear: [BYT-9445](https://linear.app/bytebase/issue/BYT-9445), [BYT-9446](https://linear.app/bytebase/issue/BYT-9446). Design doc: `docs/superpowers/specs/2026-05-11-selection-action-bar-redesign-design.md`.
+
+**Testing note:** The overflow logic is unit-testable; positioning and responsive breakpoints are CSS/media-query behaviors best verified by browser QA. Task 4 covers the unit tests; Task 6 covers the cross-surface manual QA.
+
+---
+
+## File Structure
+
+Files created or modified, by responsibility:
+
+- `frontend/src/react/components/SelectionActionBar.tsx` — bar component. Add `useSelectionMaxVisible` hook, `maxVisibleActions` prop, overflow split + More dropdown, sticky positioning.
+- `frontend/src/react/components/SelectionActionBar.test.tsx` — extend with overflow + destructive-in-menu coverage.
+- `frontend/src/locales/en-US.json`, `es-ES.json`, `ja-JP.json`, `vi-VN.json`, `zh-CN.json` — new `common.n-selected` key.
+- `frontend/src/react/components/database/DatabaseBatchOperationsBar.tsx` — label swap.
+- `frontend/src/react/components/database/TransferProjectSheet.tsx` — label swap (read-only display).
+- `frontend/src/react/components/IssueTable.tsx` — label swap.
+- `frontend/src/react/pages/settings/InstancesPage.tsx` — label swap.
+- `frontend/src/react/pages/settings/ProjectsPage.tsx` — label swap.
+- `frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx` — label swap (read-only).
+
+Not modified: `dropdown-menu.tsx` (no variant addition needed — destructive styling is applied via `className` on the consumer).
+
+---
+
+### Task 1: Add the `common.n-selected` i18n key in all locales
+
+**Files:**
+- Modify: `frontend/src/locales/en-US.json`
+- Modify: `frontend/src/locales/es-ES.json`
+- Modify: `frontend/src/locales/ja-JP.json`
+- Modify: `frontend/src/locales/vi-VN.json`
+- Modify: `frontend/src/locales/zh-CN.json`
+
+- [ ] **Step 1: Add the key to each locale**
+
+The key must live alphabetically inside the existing `"common": { ... }` object so the locale sorter doesn't have to reorder. Insert near `"n-items-selected"`.
+
+For each file, find the `"common"` object and add this line in sorted position (after `"n-items-selected"` if present):
+
+`en-US.json`:
+```json
+    "n-selected": "{n} selected",
+```
+
+`zh-CN.json`:
+```json
+    "n-selected": "已选择 {n} 项",
+```
+
+`ja-JP.json`:
+```json
+    "n-selected": "{n} 件選択中",
+```
+
+`es-ES.json`:
+```json
+    "n-selected": "{n} seleccionados",
+```
+
+`vi-VN.json`:
+```json
+    "n-selected": "Đã chọn {n}",
+```
+
+If `n-items-selected` is not present in a locale, insert `n-selected` in alphabetical order — the locale sorter will normalize.
+
+- [ ] **Step 2: Run the locale sorter and check**
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend run sort:i18n
+```
+
+Expected: "Locale sorter: no changes (30 file(s) checked)." If it reports changes, re-stage the formatted files.
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend check
+```
+
+Expected: passes (including the React-i18n cross-locale consistency check, which verifies the key exists in every locale).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/locales/en-US.json frontend/src/locales/es-ES.json frontend/src/locales/ja-JP.json frontend/src/locales/vi-VN.json frontend/src/locales/zh-CN.json
+git commit -m "$(cat <<'EOF'
+i18n: add common.n-selected for generic selection label
+
+Used by SelectionActionBar after BYT-9446 — drops entity-specific
+wording in favor of a uniform "N selected".
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Add `useSelectionMaxVisible` hook and overflow split in SelectionActionBar
+
+**Files:**
+- Modify: `frontend/src/react/components/SelectionActionBar.tsx`
+
+- [ ] **Step 1: Add imports**
+
+At the top of `frontend/src/react/components/SelectionActionBar.tsx`, replace the existing imports with the expanded list:
+
+```tsx
+import { MoreHorizontal, type LucideIcon } from "lucide-react";
+import { useSyncExternalStore, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
+import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
+import { Separator } from "@/react/components/ui/separator";
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { cn } from "@/react/lib/utils";
+```
+
+- [ ] **Step 2: Add the `useSelectionMaxVisible` hook**
+
+Add this hook above the existing `DESTRUCTIVE_TONE_CLASS` constant (i.e. just before `const DESTRUCTIVE_TONE_CLASS = ...`):
+
+```tsx
+const MQ_SM = "(min-width: 640px)";
+const MQ_LG = "(min-width: 1024px)";
+
+function subscribeMatchMedia(query: string) {
+  return (cb: () => void) => {
+    if (typeof window === "undefined") return () => {};
+    const mql = window.matchMedia(query);
+    mql.addEventListener("change", cb);
+    return () => mql.removeEventListener("change", cb);
+  };
+}
+
+function matchesMediaQuery(query: string): boolean {
+  if (typeof window === "undefined") return true; // SSR: assume widest tier
+  return window.matchMedia(query).matches;
+}
+
+/**
+ * Returns the number of inline action buttons the bar should show before
+ * collapsing the rest into a "More" dropdown:
+ *   <  sm (<640px):   1
+ *   sm — md (640–1024px): 3
+ *   ≥ lg (≥1024px):   5
+ *
+ * SSR-safe: returns the largest tier on the first render, then resolves
+ * to the actual viewport after hydration.
+ */
+function useSelectionMaxVisible(): number {
+  const isLg = useSyncExternalStore(
+    subscribeMatchMedia(MQ_LG),
+    () => matchesMediaQuery(MQ_LG),
+    () => true
+  );
+  const isSm = useSyncExternalStore(
+    subscribeMatchMedia(MQ_SM),
+    () => matchesMediaQuery(MQ_SM),
+    () => true
+  );
+  if (isLg) return 5;
+  if (isSm) return 3;
+  return 1;
+}
+```
+
+`useSyncExternalStore` is from `react` (already imported). The two `getServerSnapshot` callbacks return `true` so SSR renders at the widest tier (5 inline) — avoids a layout flash on hydration where actions briefly collapse into a More menu.
+
+- [ ] **Step 3: Add `maxVisibleActions` prop**
+
+In the `SelectionActionBarProps` interface, add the new prop right before `children`:
+
+```tsx
+export interface SelectionActionBarProps {
+  count: number;
+  label: string;
+  allSelected: boolean;
+  onToggleSelectAll: () => void;
+  actions?: SelectionAction[];
+  /**
+   * Override the default responsive cap (1 / 3 / 5 by viewport).
+   * Useful when a call site has only 1–2 actions and never wants a
+   * More menu — set this to a high number like 99.
+   */
+  maxVisibleActions?: number;
+  children?: ReactNode;
+}
+```
+
+- [ ] **Step 4: Destructure the new prop and `useTranslation` in the function body**
+
+Replace the `SelectionActionBar` function signature and the leading variable declarations with:
+
+```tsx
+export function SelectionActionBar({
+  count,
+  label,
+  allSelected,
+  onToggleSelectAll,
+  actions,
+  maxVisibleActions,
+  children,
+}: SelectionActionBarProps) {
+  const { t } = useTranslation();
+  const defaultMaxVisible = useSelectionMaxVisible();
+  const maxVisible = maxVisibleActions ?? defaultMaxVisible;
+
+  if (count <= 0) return null;
+
+  const visibleActions = (actions ?? []).filter((a) => !a.hidden);
+  const inlineActions = visibleActions.slice(0, maxVisible);
+  const overflowActions = visibleActions.slice(maxVisible);
+  // ...rest of the function (return ...) follows
+}
+```
+
+The order matters: `useTranslation` and `useSelectionMaxVisible` must be called before the `count <= 0` early-return — React hooks rules. The split uses `slice()` so we don't mutate the input array.
+
+- [ ] **Step 5: Render the inline + overflow split**
+
+Replace the existing actions render block (the `<div className="flex items-center gap-x-3 min-w-0 overflow-x-auto">` and its children, plus the surrounding separator condition) with this. Keep the leading checkbox + label + separator above it unchanged.
+
+```tsx
+      {(inlineActions.length > 0 || overflowActions.length > 0 || children) && (
+        <Separator orientation="vertical" className="h-5 shrink-0" />
+      )}
+      {/* Actions cluster — inline buttons + optional More dropdown.
+          `min-w-0` lets flex shrink the container so any leftover overflow
+          (e.g. very long custom children) can still scroll. */}
+      <div className="flex items-center gap-x-3 min-w-0 overflow-x-auto">
+        {inlineActions.map((action) => {
+          const Icon = action.icon;
+          const button = (
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={action.disabled}
+              onClick={action.onClick}
+              className={cn(
+                "rounded-full",
+                action.tone === "destructive" && DESTRUCTIVE_TONE_CLASS
+              )}
+            >
+              {Icon && <Icon className="size-4" aria-hidden />}
+              {action.label}
+            </Button>
+          );
+          if (action.disabled && action.disabledReason) {
+            return (
+              <Tooltip key={action.key} content={action.disabledReason}>
+                {button}
+              </Tooltip>
+            );
+          }
+          return <div key={action.key}>{button}</div>;
+        })}
+        {overflowActions.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="rounded-full"
+                  aria-label={t("common.more")}
+                >
+                  <MoreHorizontal className="size-4" aria-hidden />
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="end">
+              {overflowActions.map((action) => {
+                const Icon = action.icon;
+                const item = (
+                  <DropdownMenuItem
+                    key={action.key}
+                    disabled={action.disabled}
+                    onClick={action.onClick}
+                    className={cn(
+                      action.tone === "destructive" &&
+                        "text-error data-highlighted:bg-error/10 data-highlighted:text-error"
+                    )}
+                  >
+                    {Icon && <Icon className="size-4" aria-hidden />}
+                    {action.label}
+                  </DropdownMenuItem>
+                );
+                if (action.disabled && action.disabledReason) {
+                  return (
+                    <Tooltip key={action.key} content={action.disabledReason}>
+                      <div>{item}</div>
+                    </Tooltip>
+                  );
+                }
+                return item;
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+        {children}
+      </div>
+```
+
+Notes on the rewrite:
+- The Separator now shows whenever there's any cluster to the right (inline actions, More menu, or custom `children`) — previously it only checked `visibleActions.length > 0`.
+- The More trigger uses `render={<Button ... />}` pattern, which is the Base UI / shadcn-style way to compose `DropdownMenuTrigger` with our styled Button. Confirm the existing `DropdownMenuTrigger` from `@/react/components/ui/dropdown-menu` supports `render` — if it instead expects `asChild` or wraps children directly, adapt. Check by reading the trigger function's signature at `frontend/src/react/components/ui/dropdown-menu.tsx`.
+- Destructive in the menu uses `text-error` + a faint-red highlight on focus/hover (`data-highlighted` is the Base UI attribute the existing item already styles). The override matches the inline `DESTRUCTIVE_TONE_CLASS` semantically without re-using its exact classes (those target outline-button styling).
+- Tooltip wrapping a `DropdownMenuItem` requires a wrapper `<div>` so the tooltip has a host element — `DropdownMenuItem` itself uses Base UI's `Menu.Item` which doesn't forward refs predictably for the Tooltip's positioning.
+
+- [ ] **Step 6: Verify `common.more` exists in locales (or add it)**
+
+```bash
+grep -n "\"more\":" /Users/steven/Projects/bytebase/bb/frontend/src/locales/en-US.json
+```
+
+If `common.more` doesn't already exist, add it in the same way as `n-selected` (Task 1, Step 1). Suggested values:
+- en-US: `"more": "More"`
+- zh-CN: `"more": "更多"`
+- ja-JP: `"more": "その他"`
+- es-ES: `"more": "Más"`
+- vi-VN: `"more": "Thêm"`
+
+If you add `common.more`, include those locale files in the Task 2 commit.
+
+- [ ] **Step 7: Run fix + type-check**
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend fix
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend type-check
+```
+
+Expected: both pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/react/components/SelectionActionBar.tsx
+# Include any locale files touched in Step 6:
+# git add frontend/src/locales/*.json
+git commit -m "$(cat <<'EOF'
+feat(react-selection-bar): collapse overflow actions into More dropdown
+
+Adds a responsive maxVisible ladder (1/3/5 at sm/md/lg) and a trailing
+MoreHorizontal dropdown for any actions beyond the cap. Disabled-with-
+reason and destructive tone are preserved inside the menu.
+
+Part of BYT-9446 (mobile experience).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Switch positioning from fixed to sticky-inside-main
+
+**Files:**
+- Modify: `frontend/src/react/components/SelectionActionBar.tsx`
+
+- [ ] **Step 1: Replace the bar's positioning classes**
+
+In the outer `<div>` of `SelectionActionBar`, change:
+
+```tsx
+    <div
+      className={cn(
+        "fixed bottom-6 left-1/2 -translate-x-1/2 max-w-[90vw]",
+        "flex items-center gap-x-3 rounded-full bg-background border border-control-border shadow-lg",
+        "px-4 py-2",
+        LAYER_SURFACE_CLASS
+      )}
+    >
+```
+
+to:
+
+```tsx
+    <div
+      className={cn(
+        "sticky bottom-6 mx-auto w-fit max-w-full",
+        "flex items-center gap-x-3 rounded-full bg-background border border-control-border shadow-lg",
+        "px-4 py-2",
+        LAYER_SURFACE_CLASS
+      )}
+    >
+```
+
+Key changes:
+- `fixed → sticky`: the bar joins the document flow; it sticks to `bottom-6` of the nearest scroll container.
+- `left-1/2 -translate-x-1/2 → mx-auto w-fit`: horizontal centering now lives within the parent (the page's main column), not the viewport.
+- `max-w-[90vw] → max-w-full`: parent (main column) drives the width cap; on extreme cases the bar still won't blow out its parent.
+
+The `LAYER_SURFACE_CLASS` (z-index) stays — sticky elements still need to stack above table content.
+
+- [ ] **Step 2: Verify sticky works against the real layout**
+
+The bar's scroll container should be `#bb-layout-main` (see `frontend/src/react/components/DashboardBodyShell.tsx:141-150`: `flex-1 overflow-y-auto`). Open `frontend/src/react/pages/settings/DatabasesPage.tsx` and trace the JSX from `<DatabaseBatchOperationsBar>` upward: confirm no ancestor between the bar and `#bb-layout-main` has `overflow: hidden` (or any of `overflow-x-clip`, `overflow-y-clip`, `overflow-hidden`).
+
+Read the page outer wrapper (line ~430+ in DatabasesPage.tsx — wherever the page-level `<div>` opens). If any ancestor has `overflow: hidden` on the vertical axis, sticky positioning will break and the bar will scroll away with the content.
+
+- [ ] **Step 3: Run fix + type-check**
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend fix
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend type-check
+```
+
+Expected: both pass. (CSS-only change, type-check unaffected, fix only formats.)
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend dev
+```
+
+Open `/setting/database`. Select a database. The bar should appear pinned ~24px above the bottom of the visible content area, **horizontally centered in the area to the right of the sidebar** (not in the viewport midpoint).
+
+Then open `/project/<any-project>/databases`. The bar should center between the project sidebar's right edge and the viewport right edge.
+
+If the bar instead scrolls off-screen with the table, the sticky-ancestor check (Step 2) missed an `overflow: hidden`. Apply the fallback in Step 5 below; do not commit Step 1 alone.
+
+- [ ] **Step 5 (fallback, only if Step 4 fails): CSS variable approach**
+
+If sticky positioning doesn't work because of an `overflow: hidden` ancestor that can't be removed without breaking other layout, fall back to:
+
+(a) Add `--main-content-left: 0px;` to `:root` in `frontend/src/assets/css/tailwind.css` (search for the existing `:root { ... }` block; insert the variable inside it).
+
+(b) In `frontend/src/react/components/DashboardBodyShell.tsx`, find the outer container and set the variable on it via inline style:
+
+```tsx
+<div
+  className="flex h-full flex-col overflow-hidden"
+  style={{ "--main-content-left": isDesktop ? "208px" : "0px" } as React.CSSProperties}
+>
+```
+
+(`208px` matches the existing `w-52` sidebar.)
+
+(c) Revert Task 3 Step 1 to keep `fixed bottom-6 ... max-w-[90vw]`, but replace `left-1/2 -translate-x-1/2` with:
+
+```tsx
+"fixed bottom-6 max-w-[90vw]",
+"-translate-x-1/2",
+```
+
+and set the `left` via inline style on the outer `<div>`:
+
+```tsx
+style={{ left: "calc(var(--main-content-left, 0px) + (100vw - var(--main-content-left, 0px)) / 2)" }}
+```
+
+Project pages that add their own sidebar (e.g. `ProjectSidebar`) would need to override the variable similarly — search `frontend/src/react/components/ProjectSidebar.tsx` for the parent layout and add an inline `style={{ "--main-content-left": "..." }}` if BYT-9445 still reproduces on project pages.
+
+This fallback path is taken **only** if sticky truly can't work after Step 4 verification — don't pre-emptively adopt it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/react/components/SelectionActionBar.tsx
+git commit -m "$(cat <<'EOF'
+fix(react-selection-bar): position sticky inside main content
+
+Changes the bar from viewport-fixed centering to sticky-in-main-column
+centering so it no longer bleeds into the dashboard or project sidebar.
+
+BYT-9445
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If you took the fallback path in Step 5, expand the commit to include the additional files (`tailwind.css`, `DashboardBodyShell.tsx`, possibly `ProjectSidebar.tsx`).
+
+---
+
+### Task 4: Extend SelectionActionBar tests for overflow + destructive-in-menu
+
+**Files:**
+- Modify: `frontend/src/react/components/SelectionActionBar.test.tsx`
+
+The existing tests cover render-on-count and basic action rendering. Add cases for the new overflow logic. The overflow split depends on the responsive hook, which reads `window.matchMedia`. In the test, mock `matchMedia` to force a known tier.
+
+- [ ] **Step 1: Add a `matchMedia` mock helper at the top of the test file**
+
+After the existing IS_REACT_ACT_ENVIRONMENT assignment (around line 9), add:
+
+```tsx
+function mockMatchMedia(matches: (query: string) => boolean) {
+  window.matchMedia = ((query: string) => ({
+    matches: matches(query),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => true,
+  })) as unknown as typeof window.matchMedia;
+}
+```
+
+- [ ] **Step 2: Add a new describe block with three tests**
+
+After the existing tests inside `describe("SelectionActionBar", ...)`, before the closing `});`, add:
+
+```tsx
+  test("at lg breakpoint, shows first 5 actions inline and rest in More menu", async () => {
+    mockMatchMedia(() => true); // both sm and lg match
+    await act(async () => {
+      root.render(
+        <SelectionActionBar
+          count={1}
+          label="1 selected"
+          allSelected={false}
+          onToggleSelectAll={() => {}}
+          actions={[
+            { key: "a1", label: "Action 1", icon: Archive, onClick: () => {} },
+            { key: "a2", label: "Action 2", icon: Archive, onClick: () => {} },
+            { key: "a3", label: "Action 3", icon: Archive, onClick: () => {} },
+            { key: "a4", label: "Action 4", icon: Archive, onClick: () => {} },
+            { key: "a5", label: "Action 5", icon: Archive, onClick: () => {} },
+            { key: "a6", label: "Action 6", icon: Archive, onClick: () => {} },
+            { key: "a7", label: "Action 7", icon: Archive, onClick: () => {} },
+          ]}
+        />
+      );
+    });
+    const inlineLabels = ["Action 1", "Action 2", "Action 3", "Action 4", "Action 5"];
+    for (const label of inlineLabels) {
+      expect(container.textContent ?? "").toContain(label);
+    }
+    // Actions 6 and 7 should not be in the rendered DOM (they're in a closed dropdown).
+    expect(container.textContent ?? "").not.toContain("Action 6");
+    expect(container.textContent ?? "").not.toContain("Action 7");
+    // A More trigger button should exist.
+    const moreButton = container.querySelector("button[aria-label]");
+    expect(moreButton).not.toBeNull();
+  });
+
+  test("at < sm breakpoint, shows only 1 action inline and rest in More menu", async () => {
+    mockMatchMedia(() => false); // neither sm nor lg matches
+    await act(async () => {
+      root.render(
+        <SelectionActionBar
+          count={2}
+          label="2 selected"
+          allSelected={false}
+          onToggleSelectAll={() => {}}
+          actions={[
+            { key: "a1", label: "Inline Only", icon: Archive, onClick: () => {} },
+            { key: "a2", label: "Overflow 1", icon: Archive, onClick: () => {} },
+            { key: "a3", label: "Overflow 2", icon: Archive, onClick: () => {} },
+          ]}
+        />
+      );
+    });
+    expect(container.textContent ?? "").toContain("Inline Only");
+    expect(container.textContent ?? "").not.toContain("Overflow 1");
+    expect(container.textContent ?? "").not.toContain("Overflow 2");
+  });
+
+  test("hidden actions don't count toward maxVisible", async () => {
+    mockMatchMedia(() => false); // < sm — maxVisible = 1
+    await act(async () => {
+      root.render(
+        <SelectionActionBar
+          count={1}
+          label="1 selected"
+          allSelected={false}
+          onToggleSelectAll={() => {}}
+          actions={[
+            { key: "h", label: "Hidden", icon: Archive, onClick: () => {}, hidden: true },
+            { key: "v", label: "Visible", icon: Archive, onClick: () => {} },
+          ]}
+        />
+      );
+    });
+    // Hidden action is filtered out, so Visible is the only "first" action and shows inline.
+    expect(container.textContent ?? "").toContain("Visible");
+    expect(container.textContent ?? "").not.toContain("Hidden");
+    // No More menu because nothing overflows (only 1 visible action).
+    const moreButton = container.querySelector("button[aria-label]");
+    // The leading checkbox isn't aria-labeled in the bar, so any aria-label here = More trigger.
+    expect(moreButton).toBeNull();
+  });
+
+  test("maxVisibleActions override skips the More menu entirely", async () => {
+    mockMatchMedia(() => false); // < sm — would normally collapse to 1
+    await act(async () => {
+      root.render(
+        <SelectionActionBar
+          count={1}
+          label="1 selected"
+          allSelected={false}
+          onToggleSelectAll={() => {}}
+          maxVisibleActions={99}
+          actions={[
+            { key: "a1", label: "Action 1", icon: Archive, onClick: () => {} },
+            { key: "a2", label: "Action 2", icon: Archive, onClick: () => {} },
+            { key: "a3", label: "Action 3", icon: Archive, onClick: () => {} },
+          ]}
+        />
+      );
+    });
+    expect(container.textContent ?? "").toContain("Action 1");
+    expect(container.textContent ?? "").toContain("Action 2");
+    expect(container.textContent ?? "").toContain("Action 3");
+    const moreButton = container.querySelector("button[aria-label]");
+    expect(moreButton).toBeNull();
+  });
+```
+
+If the existing test file already imports `Archive` from lucide-react (it does in `SelectionActionBar.test.tsx`), the import is reusable; otherwise add it to the imports at the top.
+
+- [ ] **Step 3: Verify the existing `useTranslation` mock still works**
+
+The test file likely already mocks `react-i18next`. Confirm by grepping:
+
+```bash
+grep -n "react-i18next\|useTranslation" /Users/steven/Projects/bytebase/bb/frontend/src/react/components/SelectionActionBar.test.tsx
+```
+
+If the mock is missing, add at the top of the test file (after `import` block, before `describe`):
+
+```tsx
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+```
+
+With this mock, `t("common.more")` returns the literal `"common.more"`, which is what the `aria-label` check above expects (any non-empty `aria-label` qualifies for the `querySelector("button[aria-label]")` assertion).
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend test -- SelectionActionBar
+```
+
+Expected: all SelectionActionBar tests pass (existing + 4 new).
+
+If a test fails because `DropdownMenuContent` is portaled (Base UI portals can mount outside `container` in tests), update the relevant assertions to query against `document.body` instead of `container` — the test for "at lg breakpoint" checks for `Action 6/7` NOT present, which works regardless of portal. The "More button exists" check uses `container.querySelector(...)`; if the trigger ends up portaled, switch to `document.body.querySelector(...)`. In practice Base UI's DropdownMenu trigger stays in-place; only the content is portaled.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/react/components/SelectionActionBar.test.tsx
+git commit -m "$(cat <<'EOF'
+test(react-selection-bar): cover responsive overflow + maxVisible override
+
+Adds unit cases for the 1/3/5 ladder, hidden-action filtering, and the
+maxVisibleActions=99 escape hatch.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Swap entity-specific labels to `common.n-selected` in all call sites
+
+**Files:**
+- Modify: `frontend/src/react/components/database/DatabaseBatchOperationsBar.tsx`
+- Modify: `frontend/src/react/components/database/TransferProjectSheet.tsx`
+- Modify: `frontend/src/react/components/IssueTable.tsx`
+- Modify: `frontend/src/react/pages/settings/InstancesPage.tsx`
+- Modify: `frontend/src/react/pages/settings/ProjectsPage.tsx`
+- Modify: `frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx`
+
+The translation function signature is `t(key, params)` and the existing keys use `{n}` or `{count}`. The new key uses `{n}` — adjust the param object accordingly.
+
+- [ ] **Step 1: DatabaseBatchOperationsBar**
+
+In `frontend/src/react/components/database/DatabaseBatchOperationsBar.tsx`, find:
+
+```tsx
+      label={t("database.selected-n-databases", { n: databases.length })}
+```
+
+Replace with:
+
+```tsx
+      label={t("common.n-selected", { n: databases.length })}
+```
+
+- [ ] **Step 2: TransferProjectSheet**
+
+In `frontend/src/react/components/database/TransferProjectSheet.tsx`, find:
+
+```tsx
+            {t("database.selected-n-databases", { n: databases.length })}
+```
+
+Replace with:
+
+```tsx
+            {t("common.n-selected", { n: databases.length })}
+```
+
+- [ ] **Step 3: IssueTable**
+
+In `frontend/src/react/components/IssueTable.tsx`, find:
+
+```tsx
+      label={`${issues.length} ${t("common.selected")}`}
+```
+
+Replace with:
+
+```tsx
+      label={t("common.n-selected", { n: issues.length })}
+```
+
+(`common.selected` was a non-existent key and was falling back to the literal — this is a quiet bug fix.)
+
+- [ ] **Step 4: InstancesPage**
+
+In `frontend/src/react/pages/settings/InstancesPage.tsx`, find:
+
+```tsx
+            label={t("instance.selected-n-instances", {
+```
+
+The wrapped call spans 2–3 lines; replace the whole call (typically `t("instance.selected-n-instances", { n: selectedNames.size })`) with:
+
+```tsx
+            label={t("common.n-selected", { n: selectedNames.size })}
+```
+
+- [ ] **Step 5: ProjectsPage**
+
+In `frontend/src/react/pages/settings/ProjectsPage.tsx`, find:
+
+```tsx
+          label={t("project.batch.selected", {
+            count: selectedProjectList.length,
+          })}
+```
+
+Replace with:
+
+```tsx
+          label={t("common.n-selected", { n: selectedProjectList.length })}
+```
+
+(Note the param key change: `count` → `n`.)
+
+- [ ] **Step 6: ProjectSyncSchemaPage**
+
+In `frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx`, find:
+
+```tsx
+            {t("database.selected-n-databases", { n: selected.size })}
+```
+
+Replace with:
+
+```tsx
+            {t("common.n-selected", { n: selected.size })}
+```
+
+- [ ] **Step 7: Run fix + type-check + tests**
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend fix
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend type-check
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend test
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/react/components/database/DatabaseBatchOperationsBar.tsx \
+        frontend/src/react/components/database/TransferProjectSheet.tsx \
+        frontend/src/react/components/IssueTable.tsx \
+        frontend/src/react/pages/settings/InstancesPage.tsx \
+        frontend/src/react/pages/settings/ProjectsPage.tsx \
+        frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+git commit -m "$(cat <<'EOF'
+refactor(react): unify selection labels as "N selected" via common.n-selected
+
+Six call sites (databases bar, instances page, projects page, issues table,
+transfer-project sheet, sync-schema page) drop their entity-specific
+selection labels in favor of the generic key. Frees ~60px of horizontal
+space on mobile — see BYT-9446.
+
+Also incidentally fixes a missing key reference in IssueTable
+(t("common.selected") never resolved).
+
+BYT-9446
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Final validation + cross-surface manual QA
+
+- [ ] **Step 1: Run the full frontend gate**
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend check
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend type-check
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend test
+```
+
+Expected: all pass — including the cross-locale i18n check (verifies `common.n-selected` and any `common.more` you added exist in every locale).
+
+- [ ] **Step 2: Dev server + cross-surface QA**
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend dev
+```
+
+Sign in, then visit each surface and select 1+ rows to surface the bar. Verify:
+
+| Surface | URL | Expected |
+|---|---|---|
+| Workspace Databases | `/setting/database` | Bar centers in main column (right of sidebar). |
+| Workspace Instances | `/setting/instance` | Bar centers in main column. |
+| Workspace Projects | `/setting/project` | Bar centers in main column. |
+| Project Databases | `/project/<id>/databases` | Bar centers between project sidebar + dashboard sidebar and viewport right. |
+| My Issues | `/my-issues` | Bar centers in main column; label reads "N selected". |
+| Project Issues | `/project/<id>/issues` | Bar centers between project sidebar and viewport right; label "N selected". |
+
+For each surface:
+- Bar label reads "N selected" (English) or "已选择 N 项" (Chinese — verify with `/setting/general` language switch if needed).
+- Selecting more than `maxVisible` actions: extra actions appear in the More dropdown trigger. Click the trigger to confirm the menu opens, items click through, disabled items show their tooltip, destructive items render red.
+- Resize browser to ≤640px: only 1 inline action; rest in More menu.
+- Resize browser to ~800px: 3 inline actions; rest in More menu.
+- Resize browser to ≥1024px: up to 5 inline actions.
+
+- [ ] **Step 3: Verify no leftover entity-specific selection keys are referenced**
+
+```bash
+grep -rn "selected-n-databases\|selected-n-instances\|project.batch.selected" /Users/steven/Projects/bytebase/bb/frontend/src --include="*.ts" --include="*.tsx"
+```
+
+Expected: no results. If any remain, they were missed in Task 5 — add a follow-up commit or amend.
+
+The locale JSON entries (`database.selected-n-databases` etc.) are intentionally *not* removed in this PR — they may have non-bar callers and the i18n checker will flag them separately if they're truly unused. Don't grep the locale files; only source files.
+
+- [ ] **Step 4: Verify the cross-locale i18n check is clean**
+
+```bash
+pnpm --dir /Users/steven/Projects/bytebase/bb/frontend check 2>&1 | grep -i "i18n\|locale"
+```
+
+Expected: `React i18n: all checks passed (missing keys, unused keys, cross-locale consistency).` and `Locale sorter: all 30 file(s) are normalized.`
+
+- [ ] **Step 5: No commit unless QA found a polish issue**
+
+If Steps 1–4 are clean and the manual QA pass surfaced no issues, no commit is needed — the work is on the branch ready for PR. Otherwise, commit polish fixes separately:
+
+```bash
+git status
+git add <fixed-files>
+git commit -m "fix(react-selection-bar): post-QA polish
+
+BYT-9445 BYT-9446"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+
+- Spec §1 "Position — sticky inside main content" → Task 3 (including the sticky-fallback CSS-variable path as Task 3 Step 5). ✓
+- Spec §2 "Responsive `maxVisible` + More dropdown" → Task 2 (hook + render split). ✓
+- Spec §3 "Generic 'N selected' label" → Task 1 (new key) + Task 5 (call sites). ✓
+- Spec §4 "Component API summary" — `maxVisibleActions` prop → Task 2 Step 3. ✓
+- Spec "Testing" section → Task 4 (unit) + Task 6 (manual QA). ✓
+- Spec "File-level change summary" — all 9 files mapped to tasks. ✓
+
+**Placeholder scan:** No "TBD" / "TODO" / "implement later" anywhere. Every code change has the complete code block. Task 3 Step 5 is conditional but spelled out fully, not a placeholder.
+
+**Type consistency:** `maxVisibleActions: number` used identically in Task 2 (definition) and Task 4 (test invocation). `useSelectionMaxVisible(): number` matches. `SelectionAction` keys (`key`, `label`, `icon`, `onClick`, `disabled`, `disabledReason`, `tone`, `hidden`) match the existing interface — nothing renamed.
+
+**Known unknowns to verify on-the-fly:**
+
+- Task 2 Step 5 uses `DropdownMenuTrigger render={...}` — if the local primitive uses `asChild` instead, adapt. The plan tells the implementer to check `dropdown-menu.tsx`. The other parts of the code block don't depend on which prop is used.
+- Task 2 Step 6 checks `common.more` existence — adds it if missing, includes the file in the commit. No guesswork.
+- Task 3 verifies sticky against the real layout; Step 5 has the full fallback if sticky fails.
+- Task 4 Step 4 notes the portaling edge case for `DropdownMenuContent` and how to adapt the assertion.

--- a/docs/superpowers/specs/2026-05-11-selection-action-bar-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-11-selection-action-bar-redesign-design.md
@@ -1,0 +1,168 @@
+# SelectionActionBar redesign: in-main positioning + responsive action overflow
+
+- **Status:** Approved
+- **Date:** 2026-05-11
+- **Linear:** [BYT-9445](https://linear.app/bytebase/issue/BYT-9445/selection-bar-should-be-centered-in-main-page-not-extending-to-side), [BYT-9446](https://linear.app/bytebase/issue/BYT-9446/selection-bar-mobile-experience-needs-update)
+
+## Problem
+
+The `SelectionActionBar` (the floating pill that appears when one or more rows are selected) has two visual bugs:
+
+1. **BYT-9445 — sidebar bleed.** The bar is `position: fixed bottom-6 left-1/2 -translate-x-1/2`, so it centers in the *viewport*. On pages with a sidebar (workspace pages have the 208px dashboard sidebar; project pages add a project sidebar on top), the visible main-content midpoint is right of viewport-midpoint, so the bar visibly extends into / under the sidebar at wider widths.
+2. **BYT-9446 — mobile crush.** The leading cluster (checkbox + label like "3 databases selected") is `shrink-0` and consumes ~140px on its own. On narrow viewports, the first action button gets clipped or truncated, and `overflow-x-auto` on the actions cluster means hidden actions require horizontal scrolling — undiscoverable.
+
+Both issues share a root cause: the bar is too wide for the space it has, in a way that the current layout can't accommodate.
+
+## Affected files
+
+- `frontend/src/react/components/SelectionActionBar.tsx` — the bar.
+- Call sites that pass the `label`:
+  - `frontend/src/react/components/database/DatabaseBatchOperationsBar.tsx` — `database.selected-n-databases`
+  - `frontend/src/react/components/database/TransferProjectSheet.tsx` — `database.selected-n-databases` (read-only display, also worth updating for consistency)
+  - `frontend/src/react/pages/settings/InstancesPage.tsx` — `instance.selected-n-instances`
+  - `frontend/src/react/pages/settings/ProjectsPage.tsx` — `project.batch.selected`
+  - `frontend/src/react/components/IssueTable.tsx` — uses `${n} ${t("common.selected")}` (and the `common.selected` key currently doesn't exist — falls back to the literal key)
+  - `frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx` — `database.selected-n-databases` (read-only)
+- New i18n key in `frontend/src/locales/*.json`.
+
+## Design
+
+Three coordinated changes — one component, several call sites, one new i18n key.
+
+### 1. Position — `sticky` inside the main content scroll container
+
+Change the bar's outer `<div>` classes from:
+
+```
+fixed bottom-6 left-1/2 -translate-x-1/2 max-w-[90vw]
+```
+
+to:
+
+```
+sticky bottom-6 mx-auto w-fit max-w-full
+```
+
+- The bar's existing JSX-parent is the page (e.g. `DatabasesPage.tsx`), which mounts inside `#bb-layout-main` (`flex-1 overflow-y-auto`, the page's scroll container — see `DashboardBodyShell.tsx:141-150`). `position: sticky bottom-6` makes the bar stick to the bottom of that scroll viewport, naturally constrained to the main content column's width.
+- `mx-auto w-fit` centers the bar horizontally within its parent (the main content column), so it never extends into the sidebar.
+- `max-w-full` keeps the safety belt — on extremely narrow viewports the bar can't blow out its parent.
+- Keep `LAYER_SURFACE_CLASS` for the existing z-index policy.
+
+**Edge case — short pages:** Sticky requires content tall enough for the bar's natural position to be below the scroll viewport. On a page with a near-empty table, the bar appears at the natural end of the content rather than pinned. This is acceptable: empty / near-empty selection bars are uncommon (the bar only renders when items are selected, which typically means a populated table) and the inline placement is visually reasonable.
+
+**Implementation verification step:** If sticky breaks because of an `overflow: hidden` ancestor between the bar and `#bb-layout-main`, fall back to a CSS-variable approach:
+- Introduce `--main-content-left: 0px` on `:root`.
+- `DashboardBodyShell.tsx` updates it to `208px` on desktop (matching `w-52`). Project-sidebar pages add their sidebar width.
+- The bar uses `position: fixed; left: calc(var(--main-content-left) + (100vw - var(--main-content-left)) / 2); transform: translate-x(-50%); bottom: 24px`.
+
+This fallback is only adopted if the primary `sticky` approach fails verification — it is not the default.
+
+### 2. Responsive `maxVisible` + "More" dropdown
+
+Inside `SelectionActionBar`, compute a `maxVisible` count based on viewport breakpoints, then split `visibleActions` into "inline" (first `maxVisible`) and "overflow" (remainder). Render inline as today; render overflow inside a single trailing "More" `DropdownMenu`.
+
+Breakpoint ladder (Tailwind defaults):
+
+| Viewport | `maxVisible` |
+|---|---|
+| `< sm` (≤640px) | **1** |
+| `sm` ≤ width < `lg` (640–1024px) | **3** |
+| `≥ lg` (≥1024px) | **5** |
+
+- Implementation: a small hook `useSelectionMaxVisible()` using `window.matchMedia` with `useSyncExternalStore`. No ResizeObserver. SSR-safe initial value is the largest tier (5) — initial paint shows everything inline, then the hook resolves on hydrate.
+- Optional caller override:
+  ```ts
+  interface SelectionActionBarProps {
+    // ...existing...
+    /** Override the default responsive cap. Useful when a call site has
+     *  only 1–2 actions and never wants a More menu. */
+    maxVisibleActions?: number;
+  }
+  ```
+- Counting: `hidden: true` actions are filtered out *before* the cap is applied — they don't count toward `maxVisible`.
+- The "More" dropdown is rendered only when `overflow.length > 0`. The trigger is a `Button variant="outline" size="sm" className="rounded-full"` containing a `MoreHorizontal` icon (lucide), no label (icon-only, accessible label via `aria-label={t("common.more")}`).
+- The dropdown menu reuses `DropdownMenu` from `@/react/components/ui/dropdown-menu`. Each overflow `SelectionAction` becomes a `DropdownMenuItem`:
+  - Icon (if present) at left.
+  - Label.
+  - `disabled` applied; if `disabledReason` set, wrap item in a tooltip — same UX as the inline disabled button.
+  - `tone: "destructive"` applies the same red text/border, restyled to fit the menu item — see "Destructive in dropdown" below.
+- Custom `children` rendered by call sites (e.g. InstancesPage's split-dropdown Sync) stay at the end of the inline cluster and are never collapsed into the More menu — they're outside the `actions` array and the bar can't introspect them. Call sites that want their custom child to participate in the overflow rule should pass it through the `actions` array as a regular SelectionAction.
+
+**Destructive in dropdown:** `DropdownMenuItem` exposes a `variant` prop in shadcn/Base UI's default config (`default | destructive`). If our local `dropdown-menu.tsx` already supports a destructive variant, use it. Otherwise, apply a className override mirroring the existing `DESTRUCTIVE_TONE_CLASS` translated to menu-item context (red text, red focus background). Verify during implementation; if neither path works cleanly, the planning step adds a small variant to our `dropdown-menu.tsx`.
+
+### 3. Generic "N selected" label
+
+Drop the entity name from the bar label everywhere. Add a single i18n key:
+
+- **New key:** `common.n-selected` → `"{n} selected"` (English) / `"已选择 {n} 项"` (Chinese) / equivalents for other locales.
+- Each call site replaces its current key:
+  - `database.selected-n-databases` → `common.n-selected` (DatabaseBatchOperationsBar.tsx, TransferProjectSheet.tsx, ProjectSyncSchemaPage.tsx)
+  - `instance.selected-n-instances` → `common.n-selected` (InstancesPage.tsx)
+  - `project.batch.selected` → `common.n-selected` (ProjectsPage.tsx)
+  - The `${n} ${t("common.selected")}` pattern in IssueTable.tsx → `t("common.n-selected", { n })`
+- Old per-entity keys are *not* removed in this PR — they may have non-bar usages (e.g. read-only summaries in sheets / wizards). The i18n unused-key checker will flag truly unused keys; we'll prune them separately if it does.
+
+The leading cluster on the bar drops from ~140px → ~80px on mobile, freeing enough space for one full-label action button beside the More dropdown.
+
+## Component API summary
+
+`SelectionActionBar` props after this change:
+
+```ts
+interface SelectionActionBarProps {
+  count: number;
+  label: string;
+  allSelected: boolean;
+  onToggleSelectAll: () => void;
+  actions?: SelectionAction[];
+  /** Optional cap override. Defaults to responsive 1 / 3 / 5 ladder. */
+  maxVisibleActions?: number;
+  children?: ReactNode;
+}
+```
+
+`SelectionAction` is unchanged.
+
+## Testing
+
+**Unit (`SelectionActionBar.test.tsx`):**
+
+- With 7 visible actions and viewport `lg`, only 5 render inline; the 6th and 7th appear in the "More" dropdown menu.
+- With 7 actions and viewport `< sm`, only 1 renders inline; remaining 6 appear in the menu.
+- `hidden: true` actions are not counted toward `maxVisible` and never appear in the menu.
+- `disabled` + `disabledReason` on an overflow action renders the menu item disabled with a tooltip.
+- `tone: "destructive"` on an overflow action renders the menu item with destructive styling.
+- `maxVisibleActions={99}` override: no More menu, all actions inline.
+- `count={0}`: bar renders nothing (unchanged behavior).
+
+**Manual QA:**
+
+- Workspace pages — Databases, Instances, Projects, My Issues. Bar centers in main content; doesn't bleed into the dashboard sidebar.
+- Project pages — Project Databases, Project Issues. Bar centers between the project sidebar + dashboard sidebar and the right edge.
+- Resize from desktop → tablet → mobile:
+  - Desktop (`≥lg`): up to 5 inline + More if more.
+  - Tablet (`sm`–`md`): 3 inline + More if more.
+  - Mobile (`<sm`): 1 inline + More if more.
+- Label reads "X selected" everywhere (English + Chinese sanity check).
+- More menu: disabled items show tooltip on hover; destructive items render red; clicking a menu item fires the same `onClick` as the inline counterpart.
+- Sticky behavior: on a page with many rows, bar stays pinned ~24px above bottom while scrolling. On a near-empty selection, bar renders in document flow (acceptable per Edge case note above).
+
+## Out of scope
+
+- Icon-only mode for inline buttons (the More menu obviates this; if button labels still overflow on tablet at `sm` with 3 actions, we'll address in a follow-up).
+- Per-action "pinned" / "always-overflow" flags. Call-site action order is the priority — earlier = stays inline longer.
+- Removing the deprecated `database.selected-n-databases` / `instance.selected-n-instances` / `project.batch.selected` keys. They may have non-bar callers; a separate cleanup PR after the i18n unused-key checker flags them.
+- Visual restyling of the bar (color, shadow, border).
+- Centralizing sidebar widths as CSS variables. Only adopted as a fallback if sticky positioning doesn't work cleanly.
+
+## File-level change summary
+
+- `frontend/src/react/components/SelectionActionBar.tsx` — sticky positioning, responsive `maxVisible`, More dropdown, `maxVisibleActions` prop.
+- `frontend/src/react/components/SelectionActionBar.test.tsx` — overflow + destructive + disabled coverage.
+- `frontend/src/react/components/database/DatabaseBatchOperationsBar.tsx` — label key swap.
+- `frontend/src/react/components/database/TransferProjectSheet.tsx` — label key swap (read-only display).
+- `frontend/src/react/components/IssueTable.tsx` — label key swap.
+- `frontend/src/react/pages/settings/InstancesPage.tsx` — label key swap.
+- `frontend/src/react/pages/settings/ProjectsPage.tsx` — label key swap.
+- `frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx` — label key swap (read-only).
+- `frontend/src/locales/*.json` — add `common.n-selected` in every locale file.

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -330,6 +330,7 @@
     "minutes": "Minutes",
     "missing-required-permission": "Missing required permissions {permissions}",
     "missing-required-permission-for-resource": "Missing required permissions for resource {resource}",
+    "more": "More",
     "n-items-selected": "{n} items selected",
     "n-more": "+{n} more",
     "n-selected": "{n} selected",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -332,6 +332,7 @@
     "missing-required-permission-for-resource": "Missing required permissions for resource {resource}",
     "n-items-selected": "{n} items selected",
     "n-more": "+{n} more",
+    "n-selected": "{n} selected",
     "name": "Name",
     "next": "Next",
     "no-data": "No data",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -685,7 +685,6 @@
       "unspecified": "Unspecified"
     },
     "select": "Select database",
-    "selected-n-databases": "{n} database selected | {n} databases selected",
     "successfully-exported-schema": "Successfully exported schema",
     "successfully-transferred-databases": "Successfully transferred databases",
     "sync-complete-for-instance": "Sync complete for instance '{0}'",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -685,7 +685,6 @@
       "unspecified": "No especificado"
     },
     "select": "Seleccionar base de datos",
-    "selected-n-databases": "{n} base de datos seleccionada | {n} bases de datos seleccionadas",
     "successfully-exported-schema": "Esquema exportado con éxito",
     "successfully-transferred-databases": "Bases de datos transferidas exitosamente",
     "sync-complete-for-instance": "Sincronización completada para la instancia '{0}'",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -332,6 +332,7 @@
     "missing-required-permission-for-resource": "Faltan permisos requeridos para el recurso {resource}",
     "n-items-selected": "{n} elementos seleccionados",
     "n-more": "+{n} más",
+    "n-selected": "{n} seleccionados",
     "name": "Nombre",
     "next": "Siguiente",
     "no-data": "Sin datos",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -330,6 +330,7 @@
     "minutes": "Minutos",
     "missing-required-permission": "Faltan permisos requeridos {permissions}",
     "missing-required-permission-for-resource": "Faltan permisos requeridos para el recurso {resource}",
+    "more": "Más",
     "n-items-selected": "{n} elementos seleccionados",
     "n-more": "+{n} más",
     "n-selected": "{n} seleccionados",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -332,6 +332,7 @@
     "missing-required-permission-for-resource": "リソース {resource} に必要な権限がありません",
     "n-items-selected": "{n} 件選択済み",
     "n-more": "+{n} もっと",
+    "n-selected": "{n} 件選択中",
     "name": "名前",
     "next": "次のステップ",
     "no-data": "データなし",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -685,7 +685,6 @@
       "unspecified": "不特定"
     },
     "select": "データベースの選択",
-    "selected-n-databases": "{n} 個のデータベースが選択されました",
     "successfully-exported-schema": "スキーマのエクスポートに成功しました",
     "successfully-transferred-databases": "データベースの移行が完了しました",
     "sync-complete-for-instance": "インスタンス '{0}' の同期が完了しました",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -330,6 +330,7 @@
     "minutes": "分",
     "missing-required-permission": "必要な権限がありません {permissions}",
     "missing-required-permission-for-resource": "リソース {resource} に必要な権限がありません",
+    "more": "その他",
     "n-items-selected": "{n} 件選択済み",
     "n-more": "+{n} もっと",
     "n-selected": "{n} 件選択中",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -330,6 +330,7 @@
     "minutes": "Phút",
     "missing-required-permission": "Thiếu quyền cần thiết {permissions}",
     "missing-required-permission-for-resource": "Thiếu quyền cần thiết cho tài nguyên {resource}",
+    "more": "Thêm",
     "n-items-selected": "Đã chọn {n} mục",
     "n-more": "+{n} nữa",
     "n-selected": "Đã chọn {n}",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -685,7 +685,6 @@
       "unspecified": "Không xác định"
     },
     "select": "Chọn cơ sở dữ liệu",
-    "selected-n-databases": "Đã chọn {n} cơ sở dữ liệu | Đã chọn {n} cơ sở dữ liệu",
     "successfully-exported-schema": "Đã xuất schema thành công",
     "successfully-transferred-databases": "Đã chuyển thành công cơ sở dữ liệu",
     "sync-complete-for-instance": "Đồng bộ hoàn tất cho instance '{0}'",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -332,6 +332,7 @@
     "missing-required-permission-for-resource": "Thiếu quyền cần thiết cho tài nguyên {resource}",
     "n-items-selected": "Đã chọn {n} mục",
     "n-more": "+{n} nữa",
+    "n-selected": "Đã chọn {n}",
     "name": "Tên",
     "next": "Tiếp theo",
     "no-data": "Không có dữ liệu",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -685,7 +685,6 @@
       "unspecified": "未指定"
     },
     "select": "选择数据库",
-    "selected-n-databases": "已选择 {n} 个数据库",
     "successfully-exported-schema": "成功导出 Schema",
     "successfully-transferred-databases": "数据库转移完成",
     "sync-complete-for-instance": "实例 '{0}' 同步完成",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -330,6 +330,7 @@
     "minutes": "分钟",
     "missing-required-permission": "缺少必需的权限 {permissions}",
     "missing-required-permission-for-resource": "缺少资源 {resource} 的必需权限",
+    "more": "更多",
     "n-items-selected": "已选 {n} 项",
     "n-more": "+{n} 更多",
     "n-selected": "已选择 {n} 项",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -332,6 +332,7 @@
     "missing-required-permission-for-resource": "缺少资源 {resource} 的必需权限",
     "n-items-selected": "已选 {n} 项",
     "n-more": "+{n} 更多",
+    "n-selected": "已选择 {n} 项",
     "name": "名称",
     "next": "下一步",
     "no-data": "无数据",

--- a/frontend/src/react/components/IssueTable.tsx
+++ b/frontend/src/react/components/IssueTable.tsx
@@ -928,7 +928,7 @@ export function BatchActionBar({
   return (
     <SelectionActionBar
       count={issues.length}
-      label={`${issues.length} ${t("common.selected")}`}
+      label={t("common.n-selected", { n: issues.length })}
       allSelected={allSelected}
       onToggleSelectAll={onToggleSelectAll}
       actions={[

--- a/frontend/src/react/components/SelectionActionBar.test.tsx
+++ b/frontend/src/react/components/SelectionActionBar.test.tsx
@@ -8,11 +8,30 @@ import { SelectionActionBar } from "./SelectionActionBar";
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+function mockMatchMedia(matches: (query: string) => boolean) {
+  window.matchMedia = ((query: string) => ({
+    matches: matches(query),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => true,
+  })) as unknown as typeof window.matchMedia;
+}
+
 describe("SelectionActionBar", () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
+    // Default to the widest tier so existing tests see all actions inline.
+    mockMatchMedia(() => true);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -188,6 +207,105 @@ describe("SelectionActionBar", () => {
       container.querySelector('[data-testid="custom-slot"]')
     ).not.toBeNull();
     expect(container.textContent).toContain("CustomSlot");
+  });
+
+  test("at lg breakpoint, shows first 5 actions inline and rest in More menu", async () => {
+    mockMatchMedia(() => true);
+    await act(async () => {
+      root.render(
+        <SelectionActionBar
+          count={1}
+          label="1 selected"
+          allSelected={false}
+          onToggleSelectAll={() => {}}
+          actions={[
+            { key: "a1", label: "Action1", icon: Archive, onClick: () => {} },
+            { key: "a2", label: "Action2", icon: Archive, onClick: () => {} },
+            { key: "a3", label: "Action3", icon: Archive, onClick: () => {} },
+            { key: "a4", label: "Action4", icon: Archive, onClick: () => {} },
+            { key: "a5", label: "Action5", icon: Archive, onClick: () => {} },
+            { key: "a6", label: "Action6", icon: Archive, onClick: () => {} },
+            { key: "a7", label: "Action7", icon: Archive, onClick: () => {} },
+          ]}
+        />
+      );
+    });
+    for (const label of ["Action1", "Action2", "Action3", "Action4", "Action5"]) {
+      expect(container.textContent ?? "").toContain(label);
+    }
+    expect(container.textContent ?? "").not.toContain("Action6");
+    expect(container.textContent ?? "").not.toContain("Action7");
+    const moreButton = container.querySelector("button[aria-label]");
+    expect(moreButton).not.toBeNull();
+  });
+
+  test("at < sm breakpoint, shows only 1 action inline and rest in More menu", async () => {
+    mockMatchMedia(() => false);
+    await act(async () => {
+      root.render(
+        <SelectionActionBar
+          count={2}
+          label="2 selected"
+          allSelected={false}
+          onToggleSelectAll={() => {}}
+          actions={[
+            { key: "a1", label: "InlineOnly", icon: Archive, onClick: () => {} },
+            { key: "a2", label: "Overflow1", icon: Archive, onClick: () => {} },
+            { key: "a3", label: "Overflow2", icon: Archive, onClick: () => {} },
+          ]}
+        />
+      );
+    });
+    expect(container.textContent ?? "").toContain("InlineOnly");
+    expect(container.textContent ?? "").not.toContain("Overflow1");
+    expect(container.textContent ?? "").not.toContain("Overflow2");
+  });
+
+  test("hidden actions don't count toward maxVisible", async () => {
+    mockMatchMedia(() => false); // < sm → maxVisible = 1
+    await act(async () => {
+      root.render(
+        <SelectionActionBar
+          count={1}
+          label="1 selected"
+          allSelected={false}
+          onToggleSelectAll={() => {}}
+          actions={[
+            { key: "h", label: "HiddenA", icon: Archive, onClick: () => {}, hidden: true },
+            { key: "v", label: "VisibleA", icon: Archive, onClick: () => {} },
+          ]}
+        />
+      );
+    });
+    expect(container.textContent ?? "").toContain("VisibleA");
+    expect(container.textContent ?? "").not.toContain("HiddenA");
+    const moreButton = container.querySelector("button[aria-label]");
+    expect(moreButton).toBeNull();
+  });
+
+  test("maxVisibleActions override skips the More menu entirely", async () => {
+    mockMatchMedia(() => false);
+    await act(async () => {
+      root.render(
+        <SelectionActionBar
+          count={1}
+          label="1 selected"
+          allSelected={false}
+          onToggleSelectAll={() => {}}
+          maxVisibleActions={99}
+          actions={[
+            { key: "a1", label: "ActionAlpha", icon: Archive, onClick: () => {} },
+            { key: "a2", label: "ActionBeta", icon: Archive, onClick: () => {} },
+            { key: "a3", label: "ActionGamma", icon: Archive, onClick: () => {} },
+          ]}
+        />
+      );
+    });
+    expect(container.textContent ?? "").toContain("ActionAlpha");
+    expect(container.textContent ?? "").toContain("ActionBeta");
+    expect(container.textContent ?? "").toContain("ActionGamma");
+    const moreButton = container.querySelector("button[aria-label]");
+    expect(moreButton).toBeNull();
   });
 
   test("disabled action with disabledReason is wrapped in a tooltip-capable element", async () => {

--- a/frontend/src/react/components/SelectionActionBar.test.tsx
+++ b/frontend/src/react/components/SelectionActionBar.test.tsx
@@ -189,26 +189,6 @@ describe("SelectionActionBar", () => {
     expect(btn.className).toContain("text-error");
   });
 
-  test("children render after declarative actions", async () => {
-    await act(async () => {
-      root.render(
-        <SelectionActionBar
-          count={1}
-          label="1 selected"
-          allSelected={true}
-          onToggleSelectAll={() => {}}
-          actions={[{ key: "a", label: "InlineAction", onClick: () => {} }]}
-        >
-          <span data-testid="custom-slot">CustomSlot</span>
-        </SelectionActionBar>
-      );
-    });
-    expect(
-      container.querySelector('[data-testid="custom-slot"]')
-    ).not.toBeNull();
-    expect(container.textContent).toContain("CustomSlot");
-  });
-
   test("at lg breakpoint, shows first 5 actions inline and rest in More menu", async () => {
     mockMatchMedia(() => true);
     await act(async () => {
@@ -230,7 +210,13 @@ describe("SelectionActionBar", () => {
         />
       );
     });
-    for (const label of ["Action1", "Action2", "Action3", "Action4", "Action5"]) {
+    for (const label of [
+      "Action1",
+      "Action2",
+      "Action3",
+      "Action4",
+      "Action5",
+    ]) {
       expect(container.textContent ?? "").toContain(label);
     }
     expect(container.textContent ?? "").not.toContain("Action6");
@@ -249,7 +235,12 @@ describe("SelectionActionBar", () => {
           allSelected={false}
           onToggleSelectAll={() => {}}
           actions={[
-            { key: "a1", label: "InlineOnly", icon: Archive, onClick: () => {} },
+            {
+              key: "a1",
+              label: "InlineOnly",
+              icon: Archive,
+              onClick: () => {},
+            },
             { key: "a2", label: "Overflow1", icon: Archive, onClick: () => {} },
             { key: "a3", label: "Overflow2", icon: Archive, onClick: () => {} },
           ]}
@@ -271,7 +262,13 @@ describe("SelectionActionBar", () => {
           allSelected={false}
           onToggleSelectAll={() => {}}
           actions={[
-            { key: "h", label: "HiddenA", icon: Archive, onClick: () => {}, hidden: true },
+            {
+              key: "h",
+              label: "HiddenA",
+              icon: Archive,
+              onClick: () => {},
+              hidden: true,
+            },
             { key: "v", label: "VisibleA", icon: Archive, onClick: () => {} },
           ]}
         />
@@ -294,9 +291,24 @@ describe("SelectionActionBar", () => {
           onToggleSelectAll={() => {}}
           maxVisibleActions={99}
           actions={[
-            { key: "a1", label: "ActionAlpha", icon: Archive, onClick: () => {} },
-            { key: "a2", label: "ActionBeta", icon: Archive, onClick: () => {} },
-            { key: "a3", label: "ActionGamma", icon: Archive, onClick: () => {} },
+            {
+              key: "a1",
+              label: "ActionAlpha",
+              icon: Archive,
+              onClick: () => {},
+            },
+            {
+              key: "a2",
+              label: "ActionBeta",
+              icon: Archive,
+              onClick: () => {},
+            },
+            {
+              key: "a3",
+              label: "ActionGamma",
+              icon: Archive,
+              onClick: () => {},
+            },
           ]}
         />
       );

--- a/frontend/src/react/components/SelectionActionBar.tsx
+++ b/frontend/src/react/components/SelectionActionBar.tsx
@@ -1,7 +1,14 @@
-import type { LucideIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import { MoreHorizontal, type LucideIcon } from "lucide-react";
+import { useSyncExternalStore, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
 import { Separator } from "@/react/components/ui/separator";
 import { Tooltip } from "@/react/components/ui/tooltip";
@@ -57,7 +64,46 @@ export interface SelectionActionBarProps {
    * use `rounded-full` (or a wrapper Button with `className="rounded-full"`)
    * to stay visually consistent.
    */
+  /**
+   * Override the default responsive cap (1 / 3 / 5 by viewport).
+   * Useful when a call site has only 1–2 actions and never wants a
+   * More menu — set this to a high number like 99.
+   */
+  maxVisibleActions?: number;
   children?: ReactNode;
+}
+
+const MQ_SM = "(min-width: 640px)";
+const MQ_LG = "(min-width: 1024px)";
+
+function subscribeMatchMedia(query: string) {
+  return (cb: () => void) => {
+    if (typeof window === "undefined") return () => {};
+    const mql = window.matchMedia(query);
+    mql.addEventListener("change", cb);
+    return () => mql.removeEventListener("change", cb);
+  };
+}
+
+function matchesMediaQuery(query: string): boolean {
+  if (typeof window === "undefined") return true;
+  return window.matchMedia(query).matches;
+}
+
+function useSelectionMaxVisible(): number {
+  const isLg = useSyncExternalStore(
+    subscribeMatchMedia(MQ_LG),
+    () => matchesMediaQuery(MQ_LG),
+    () => true
+  );
+  const isSm = useSyncExternalStore(
+    subscribeMatchMedia(MQ_SM),
+    () => matchesMediaQuery(MQ_SM),
+    () => true
+  );
+  if (isLg) return 5;
+  if (isSm) return 3;
+  return 1;
 }
 
 const DESTRUCTIVE_TONE_CLASS =
@@ -69,11 +115,18 @@ export function SelectionActionBar({
   allSelected,
   onToggleSelectAll,
   actions,
+  maxVisibleActions,
   children,
 }: SelectionActionBarProps) {
+  const { t } = useTranslation();
+  const defaultMaxVisible = useSelectionMaxVisible();
+  const maxVisible = maxVisibleActions ?? defaultMaxVisible;
+
   if (count <= 0) return null;
 
   const visibleActions = (actions ?? []).filter((a) => !a.hidden);
+  const inlineActions = visibleActions.slice(0, maxVisible);
+  const overflowActions = visibleActions.slice(maxVisible);
 
   return (
     <div
@@ -93,13 +146,16 @@ export function SelectionActionBar({
       <span className="shrink-0 text-sm font-medium text-control whitespace-nowrap">
         {label}
       </span>
-      {visibleActions.length > 0 && (
+      {(inlineActions.length > 0 ||
+        overflowActions.length > 0 ||
+        children) && (
         <Separator orientation="vertical" className="h-5 shrink-0" />
       )}
-      {/* Actions cluster — `min-w-0` lets flex shrink the container so
-          `overflow-x-auto` can actually scroll within the pill's max-width. */}
+      {/* Actions cluster — inline buttons + optional More dropdown.
+          `min-w-0` lets flex shrink the container so any leftover overflow
+          (e.g. very long custom children) can still scroll. */}
       <div className="flex items-center gap-x-3 min-w-0 overflow-x-auto">
-        {visibleActions.map((action) => {
+        {inlineActions.map((action) => {
           const Icon = action.icon;
           const button = (
             <Button
@@ -125,6 +181,49 @@ export function SelectionActionBar({
           }
           return <div key={action.key}>{button}</div>;
         })}
+        {overflowActions.length > 0 && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="rounded-full"
+                  aria-label={t("common.more")}
+                >
+                  <MoreHorizontal className="size-4" aria-hidden />
+                </Button>
+              }
+            />
+            <DropdownMenuContent align="end">
+              {overflowActions.map((action) => {
+                const Icon = action.icon;
+                const item = (
+                  <DropdownMenuItem
+                    key={action.key}
+                    disabled={action.disabled}
+                    onClick={action.onClick}
+                    className={cn(
+                      action.tone === "destructive" &&
+                        "text-error data-highlighted:bg-error/10 data-highlighted:text-error"
+                    )}
+                  >
+                    {Icon && <Icon className="size-4" aria-hidden />}
+                    {action.label}
+                  </DropdownMenuItem>
+                );
+                if (action.disabled && action.disabledReason) {
+                  return (
+                    <Tooltip key={action.key} content={action.disabledReason}>
+                      <div>{item}</div>
+                    </Tooltip>
+                  );
+                }
+                return item;
+              })}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
         {children}
       </div>
     </div>

--- a/frontend/src/react/components/SelectionActionBar.tsx
+++ b/frontend/src/react/components/SelectionActionBar.tsx
@@ -1,5 +1,5 @@
-import { MoreHorizontal, type LucideIcon } from "lucide-react";
-import { useSyncExternalStore, type ReactNode } from "react";
+import { type LucideIcon, MoreHorizontal } from "lucide-react";
+import { useSyncExternalStore } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
@@ -56,21 +56,11 @@ export interface SelectionActionBarProps {
   /** Declarative actions. Rendered in order. Hidden actions are omitted. */
   actions?: SelectionAction[];
   /**
-   * Custom action nodes rendered after `actions`. Used for actions that
-   * require richer UI (e.g. InstancesPage's split-dropdown Sync).
-   *
-   * Style note: declarative `actions` get `rounded-full` automatically so
-   * they match the pill surface. Custom buttons rendered here should also
-   * use `rounded-full` (or a wrapper Button with `className="rounded-full"`)
-   * to stay visually consistent.
-   */
-  /**
    * Override the default responsive cap (1 / 3 / 5 by viewport).
    * Useful when a call site has only 1–2 actions and never wants a
    * More menu — set this to a high number like 99.
    */
   maxVisibleActions?: number;
-  children?: ReactNode;
 }
 
 const MQ_SM = "(min-width: 640px)";
@@ -116,7 +106,6 @@ export function SelectionActionBar({
   onToggleSelectAll,
   actions,
   maxVisibleActions,
-  children,
 }: SelectionActionBarProps) {
   const { t } = useTranslation();
   const defaultMaxVisible = useSelectionMaxVisible();
@@ -146,15 +135,11 @@ export function SelectionActionBar({
       <span className="shrink-0 text-sm font-medium text-control whitespace-nowrap">
         {label}
       </span>
-      {(inlineActions.length > 0 ||
-        overflowActions.length > 0 ||
-        children) && (
+      {(inlineActions.length > 0 || overflowActions.length > 0) && (
         <Separator orientation="vertical" className="h-5 shrink-0" />
       )}
-      {/* Actions cluster — inline buttons + optional More dropdown.
-          `min-w-0` lets flex shrink the container so any leftover overflow
-          (e.g. very long custom children) can still scroll. */}
-      <div className="flex items-center gap-x-3 min-w-0 overflow-x-auto">
+      {/* Actions cluster — inline buttons + optional trailing More dropdown. */}
+      <div className="flex items-center gap-x-3 shrink-0">
         {inlineActions.map((action) => {
           const Icon = action.icon;
           const button = (
@@ -224,7 +209,6 @@ export function SelectionActionBar({
             </DropdownMenuContent>
           </DropdownMenu>
         )}
-        {children}
       </div>
     </div>
   );

--- a/frontend/src/react/components/SelectionActionBar.tsx
+++ b/frontend/src/react/components/SelectionActionBar.tsx
@@ -131,7 +131,7 @@ export function SelectionActionBar({
   return (
     <div
       className={cn(
-        "fixed bottom-6 left-1/2 -translate-x-1/2 max-w-[90vw]",
+        "sticky bottom-6 mx-auto w-fit max-w-full",
         "flex items-center gap-x-3 rounded-full bg-background border border-control-border shadow-lg",
         "px-4 py-2",
         LAYER_SURFACE_CLASS

--- a/frontend/src/react/components/database/DatabaseBatchOperationsBar.tsx
+++ b/frontend/src/react/components/database/DatabaseBatchOperationsBar.tsx
@@ -135,7 +135,7 @@ export function DatabaseBatchOperationsBar({
   return (
     <SelectionActionBar
       count={databases.length}
-      label={t("database.selected-n-databases", { n: databases.length })}
+      label={t("common.n-selected", { n: databases.length })}
       allSelected={allSelected}
       onToggleSelectAll={onToggleSelectAll}
       actions={actions}

--- a/frontend/src/react/components/database/TransferProjectSheet.tsx
+++ b/frontend/src/react/components/database/TransferProjectSheet.tsx
@@ -51,7 +51,7 @@ export function TransferProjectSheet({
         </SheetHeader>
         <SheetBody className="gap-y-4 overflow-hidden">
           <p className="shrink-0 text-sm text-control-light">
-            {t("database.selected-n-databases", { n: databases.length })}
+            {t("common.n-selected", { n: databases.length })}
           </p>
 
           {/* Table is naturally sized — short lists stay short. When the

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -331,6 +331,7 @@
     "more": "More",
     "n-items-selected": "{{n}} items selected",
     "n-more": "+{{n}} more",
+    "n-selected": "{{n}} selected",
     "name": "Name",
     "next": "Next",
     "no-data": "No data",
@@ -800,7 +801,6 @@
       "unspecified": "Unspecified"
     },
     "select": "Select database",
-    "selected-n-databases": "{{n}} database(s) selected",
     "successfully-transferred-databases": "Successfully transferred databases",
     "sync-complete-for-instance": "Sync complete for instance '{{0}}'",
     "sync-database": "Sync Database",
@@ -1699,9 +1699,7 @@
         "title_one": "Delete {{count}} Project?",
         "title_other": "Delete {{count}} Projects?",
         "warning": "This action cannot be undone. All project data including issues, configurations, and history will be permanently removed."
-      },
-      "selected_one": "{{count}} project selected",
-      "selected_other": "{{count}} projects selected"
+      }
     },
     "create-modal": {
       "project-name": "Project Name",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -326,6 +326,7 @@
     "more": "Más",
     "n-items-selected": "{{n}} elementos seleccionados",
     "n-more": "+{{n}} más",
+    "n-selected": "{{n}} seleccionados",
     "name": "Nombre",
     "next": "Siguiente",
     "no-data": "Sin datos",
@@ -793,7 +794,6 @@
       "unspecified": "No especificado"
     },
     "select": "Seleccionar base de datos",
-    "selected-n-databases": "{{n}} base(s) de datos seleccionada(s)",
     "successfully-transferred-databases": "Bases de datos transferidas exitosamente",
     "sync-complete-for-instance": "Sincronización completada para la instancia '{{0}}'",
     "sync-database": "Sincronizar base de datos",
@@ -1691,9 +1691,7 @@
         "title_one": "¿Eliminar {{count}} Proyecto?",
         "title_other": "¿Eliminar {{count}} Proyectos?",
         "warning": "Esta acción no se puede deshacer. Todos los datos del proyecto, incluidos problemas, configuraciones e historial, se eliminarán permanentemente."
-      },
-      "selected_one": "{{count}} proyecto seleccionado",
-      "selected_other": "{{count}} proyectos seleccionados"
+      }
     },
     "create-modal": {
       "project-name": "Proyecto Nombre",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -326,6 +326,7 @@
     "more": "その他",
     "n-items-selected": "{{n}} 件選択済み",
     "n-more": "+{{n}} もっと",
+    "n-selected": "{{n}} 件選択中",
     "name": "名前",
     "next": "次のステップ",
     "no-data": "データなし",
@@ -793,7 +794,6 @@
       "unspecified": "不特定"
     },
     "select": "データベースの選択",
-    "selected-n-databases": "{{n}} 個のデータベースが選択されました",
     "successfully-transferred-databases": "データベースの転送に成功しました",
     "sync-complete-for-instance": "インスタンス '{{0}}' の同期が完了しました",
     "sync-database": "データベース同期",
@@ -1691,9 +1691,7 @@
         "title_one": "{{count}} 件のプロジェクトを削除しますか?",
         "title_other": "{{count}} 件のプロジェクトを削除しますか?",
         "warning": "この操作は元に戻せません。イシュー、設定、履歴を含むすべてのプロジェクトデータが完全に削除されます。"
-      },
-      "selected_one": "{{count}} 件のプロジェクトが選択されました",
-      "selected_other": "{{count}} 件のプロジェクトが選択されました"
+      }
     },
     "create-modal": {
       "project-name": "プロジェクト名前",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -326,6 +326,7 @@
     "more": "Thêm",
     "n-items-selected": "Đã chọn {{n}} mục",
     "n-more": "+{{n}} nữa",
+    "n-selected": "Đã chọn {{n}}",
     "name": "Tên",
     "next": "Tiếp theo",
     "no-data": "Không có dữ liệu",
@@ -793,7 +794,6 @@
       "unspecified": "Không xác định"
     },
     "select": "Chọn cơ sở dữ liệu",
-    "selected-n-databases": "Đã chọn {{n}} cơ sở dữ liệu",
     "successfully-transferred-databases": "Chuyển cơ sở dữ liệu thành công",
     "sync-complete-for-instance": "Đồng bộ hoàn tất cho instance '{{0}}'",
     "sync-database": "Đồng bộ cơ sở dữ liệu",
@@ -1691,9 +1691,7 @@
         "title_one": "Xóa {{count}} Dự án?",
         "title_other": "Xóa {{count}} Dự án?",
         "warning": "Hành động này không thể hoàn tác. Tất cả dữ liệu dự án bao gồm vấn đề, cấu hình và lịch sử sẽ bị xóa vĩnh viễn."
-      },
-      "selected_one": "{{count}} dự án đã chọn",
-      "selected_other": "{{count}} dự án đã chọn"
+      }
     },
     "create-modal": {
       "project-name": "Dự án Tên",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -326,6 +326,7 @@
     "more": "更多",
     "n-items-selected": "已选 {{n}} 项",
     "n-more": "+{{n}} 更多",
+    "n-selected": "已选择 {{n}} 项",
     "name": "名称",
     "next": "下一步",
     "no-data": "无数据",
@@ -793,7 +794,6 @@
       "unspecified": "未指定"
     },
     "select": "选择数据库",
-    "selected-n-databases": "已选择 {{n}} 个数据库",
     "successfully-transferred-databases": "成功转移数据库",
     "sync-complete-for-instance": "实例 '{{0}}' 同步完成",
     "sync-database": "同步数据库",
@@ -1691,9 +1691,7 @@
         "title_one": "删除 {{count}} 个项目？",
         "title_other": "删除 {{count}} 个项目？",
         "warning": "此操作无法撤消。包括工单、配置和历史记录在内的所有项目数据将被永久删除。"
-      },
-      "selected_one": "已选择 {{count}} 个项目",
-      "selected_other": "已选择 {{count}} 个项目"
+      }
     },
     "create-modal": {
       "project-name": "项目名称",

--- a/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
@@ -2178,7 +2178,7 @@ function TargetDatabasesSelectPanel({
         {/* Footer */}
         <SheetFooter className="justify-between">
           <div className="textinfolabel">
-            {t("database.selected-n-databases", { n: selected.size })}
+            {t("common.n-selected", { n: selected.size })}
           </div>
           <div className="flex items-center justify-end gap-x-2">
             <Button variant="outline" onClick={onClose}>

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -1313,9 +1313,7 @@ export function InstancesPage() {
         return (
           <SelectionActionBar
             count={selectedInstanceList.length}
-            label={t("instance.selected-n-instances", {
-              count: selectedInstanceList.length,
-            })}
+            label={t("common.n-selected", { n: selectedInstanceList.length })}
             allSelected={allSelected}
             onToggleSelectAll={() => {
               if (allSelected) setSelectedNames(new Set());

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -517,50 +517,6 @@ function EditEnvironmentSheet({
 }
 
 // ============================================================
-// SyncDropdown
-// ============================================================
-
-function SyncDropdown({
-  disabled,
-  onSync,
-}: {
-  disabled: boolean;
-  onSync: (enableFullSync: boolean) => void;
-}) {
-  const { t } = useTranslation();
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <Button
-            variant="outline"
-            size="sm"
-            className="rounded-full"
-            disabled={disabled}
-          >
-            <RefreshCw className={cn("size-4", disabled && "animate-spin")} />
-            {disabled ? t("instance.syncing") : t("instance.sync.self")}
-            <ChevronDown className="size-3" />
-          </Button>
-        }
-      />
-      <DropdownMenuContent align="start" className="min-w-[200px]">
-        <DropdownMenuItem
-          title={t("instance.sync.sync-all-tip")}
-          onClick={() => onSync(true)}
-        >
-          {t("instance.sync.sync-all")}
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => onSync(false)}>
-          {t("instance.sync.sync-new")}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-// ============================================================
 // InstancesPage (main)
 // ============================================================
 
@@ -1287,7 +1243,24 @@ export function InstancesPage() {
       {(() => {
         const canSync = hasWorkspacePermissionV2("bb.instances.sync");
         const canUpdate = hasWorkspacePermissionV2("bb.instances.update");
+        const syncDisabled = !canSync || syncing;
         const instanceActions: SelectionAction[] = [
+          {
+            key: "sync-new",
+            label: syncing
+              ? t("instance.syncing")
+              : t("instance.sync.sync-new"),
+            icon: RefreshCw,
+            onClick: () => handleSync(false),
+            disabled: syncDisabled,
+          },
+          {
+            key: "sync-all",
+            label: t("instance.sync.sync-all"),
+            icon: RefreshCw,
+            onClick: () => handleSync(true),
+            disabled: syncDisabled,
+          },
           {
             key: "edit-env",
             label: t("database.edit-environment"),
@@ -1320,9 +1293,7 @@ export function InstancesPage() {
               else setSelectedNames(new Set(instances.map((i) => i.name)));
             }}
             actions={instanceActions}
-          >
-            <SyncDropdown disabled={!canSync || syncing} onSync={handleSync} />
-          </SelectionActionBar>
+          />
         );
       })()}
 

--- a/frontend/src/react/pages/settings/ProjectsPage.tsx
+++ b/frontend/src/react/pages/settings/ProjectsPage.tsx
@@ -675,9 +675,7 @@ export function ProjectsPage() {
       {canDelete && (
         <SelectionActionBar
           count={selectedProjectList.length}
-          label={t("project.batch.selected", {
-            count: selectedProjectList.length,
-          })}
+          label={t("common.n-selected", { n: selectedProjectList.length })}
           allSelected={
             projects.length > 0 &&
             projects.every((p) => selectedNames.has(p.name))


### PR DESCRIPTION
## Summary

Fixes two UX bugs in the React selection action bar at once:

- **BYT-9445** — Bar no longer bleeds into the dashboard or project sidebar. Switched from viewport-fixed centering (`fixed bottom-6 left-1/2 -translate-x-1/2`) to sticky-in-main (`sticky bottom-6 mx-auto w-fit`), so it centers within the main content column whatever sidebars are present.
- **BYT-9446** — Mobile experience: actions beyond a viewport-dependent cap collapse into a single "More" dropdown (1 / 3 / 5 inline at `<sm` / `sm-md` / `≥lg`). Removed the per-entity selection labels in favor of a uniform `common.n-selected` ("N selected" / "已选择 N 项"). Dropped the `children` slot from the bar's API — InstancesPage's `SyncDropdown` is now two regular `SelectionAction`s ("Sync new schemas", "Sync all schemas") so it participates in overflow logic; nothing renders to the right of More.

Design doc: \`docs/superpowers/specs/2026-05-11-selection-action-bar-redesign-design.md\`
Plan: \`docs/superpowers/plans/2026-05-11-selection-action-bar-redesign.md\`

## Test Plan

- [x] \`pnpm --dir frontend check\` (lint + biome + react-i18n + layering + sort)
- [x] \`pnpm --dir frontend type-check\`
- [x] \`pnpm --dir frontend test\` (1856 tests passing; 4 new tests in SelectionActionBar.test.tsx cover the responsive ladder, hidden-action filtering, and \`maxVisibleActions\` override)
- [ ] Manual QA per surface:
  - [ ] Workspace Databases / Instances / Projects / My Issues — bar centers in main column, no sidebar overlap.
  - [ ] Project Databases / Project Issues — bar centers between project sidebar and viewport right.
  - [ ] Resize to mobile width: only 1 inline action + More menu; "N selected" stays readable.
  - [ ] Resize to tablet (\`sm\`–\`md\`): 3 inline + More.
  - [ ] Resize to desktop (\`≥lg\`): up to 5 inline.
  - [ ] More menu: disabled-with-reason items show tooltip; destructive items render red; clicking fires the same handler as the inline counterpart.
  - [ ] Nothing renders to the right of the More button at any viewport width (including InstancesPage which previously had a custom SyncDropdown there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)