### PR TITLE
fix(react): keep labels next to truncated title in issue/project rows

### DIFF
--- a/frontend/src/react/components/IssueTable.tsx
+++ b/frontend/src/react/components/IssueTable.tsx
@@ -653,7 +653,7 @@ export function IssueListItem({
             {issue.title ? (
               <a
                 href={issueUrl}
-                className="font-medium text-main text-base hover:underline min-w-0 flex-1 block"
+                className="font-medium text-main text-base hover:underline min-w-0 block"
                 onClick={(e) => e.stopPropagation()}
               >
                 <EllipsisText text={issue.title}>

--- a/frontend/src/react/components/ProjectTable.tsx
+++ b/frontend/src/react/components/ProjectTable.tsx
@@ -246,7 +246,7 @@ export function ProjectTable({
                   <div className="flex items-center gap-x-2 min-w-0">
                     <EllipsisText
                       text={project.title || resourceId}
-                      className="min-w-0 flex-1"
+                      className="min-w-0"
                     >
                       <HighlightLabelText
                         text={project.title || resourceId}


### PR DESCRIPTION
## Summary

- Follow-up to #20284. After adopting `EllipsisText` on the My Issues row and the Projects table, the title element kept its `min-w-0 flex-1`, so it consumed all available width and pushed sibling labels / the archived badge to the far right edge of the row.
- Drops `flex-1` from both call sites. The title now sizes to its content (labels sit next to it) and still shrinks + truncates when the row overflows, because `min-w-0` is preserved on a flex item that already defaults to `flex-shrink: 1`.

## Test plan

- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend check` (lint + Biome + i18n + layering + locale sort)
- [ ] Manual: My Issues — short title → labels render right next to title; long title → title truncates with hover tooltip, labels still adjacent
- [ ] Manual: Projects table — archived project → "Archived" badge sits next to the project name instead of at the column's right edge; long name still truncates

🤖 Generated with [Claude Code](https://claude.com/claude-code)