### PR TITLE
fix: handle invalid SQL timestamps in query results

### DIFF
--- a/backend/plugin/db/mysql/query.go
+++ b/backend/plugin/db/mysql/query.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
-	"time"
 
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bytebase/parser/mysql"
 
@@ -44,27 +42,7 @@ func convertValue(typeName string, columnType *sql.ColumnType, value any) *v1pb.
 		if raw.Valid {
 			_, scale, _ := columnType.DecimalSize()
 			if typeName == "TIMESTAMP" || typeName == "DATETIME" {
-				// Special case for MySQL zero date which is not a valid Go time
-				if raw.String == "0000-00-00 00:00:00" {
-					return &v1pb.RowValue{
-						Kind: &v1pb.RowValue_StringValue{
-							StringValue: raw.String,
-						},
-					}
-				}
-				t, err := time.Parse(time.DateTime, raw.String)
-				if err != nil {
-					slog.Error("failed to parse time value", log.BBError(err))
-					return util.NullRowValue
-				}
-				return &v1pb.RowValue{
-					Kind: &v1pb.RowValue_TimestampValue{
-						TimestampValue: &v1pb.RowValue_Timestamp{
-							GoogleTimestamp: timestamppb.New(t),
-							Accuracy:        int32(scale),
-						},
-					},
-				}
+				return util.BuildTimestampOrStringRowValue(raw.String, scale)
 			}
 			return &v1pb.RowValue{
 				Kind: &v1pb.RowValue_StringValue{

--- a/backend/plugin/db/starrocks/query.go
+++ b/backend/plugin/db/starrocks/query.go
@@ -6,11 +6,9 @@ import (
 	"log/slog"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bytebase/parser/mysql"
 
@@ -43,19 +41,7 @@ func convertValue(typeName string, columnType *sql.ColumnType, value any) *v1pb.
 		if raw.Valid {
 			if typeName == "TIMESTAMP" || typeName == "DATETIME" {
 				_, scale, _ := columnType.DecimalSize()
-				t, err := time.Parse(time.DateTime, raw.String)
-				if err != nil {
-					slog.Error("failed to parse time value", log.BBError(err))
-					return util.NullRowValue
-				}
-				return &v1pb.RowValue{
-					Kind: &v1pb.RowValue_TimestampValue{
-						TimestampValue: &v1pb.RowValue_Timestamp{
-							GoogleTimestamp: timestamppb.New(t),
-							Accuracy:        int32(scale),
-						},
-					},
-				}
+				return util.BuildTimestampOrStringRowValue(raw.String, scale)
 			}
 			return &v1pb.RowValue{
 				Kind: &v1pb.RowValue_StringValue{

--- a/backend/plugin/db/tidb/query.go
+++ b/backend/plugin/db/tidb/query.go
@@ -5,10 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	tidbast "github.com/pingcap/tidb/pkg/parser/ast"
 	"github.com/pingcap/tidb/pkg/parser/format"
@@ -43,19 +41,7 @@ func convertValue(typeName string, columnType *sql.ColumnType, value any) *v1pb.
 		if raw.Valid {
 			_, scale, _ := columnType.DecimalSize()
 			if typeName == "TIMESTAMP" || typeName == "DATETIME" {
-				t, err := time.Parse(time.DateTime, raw.String)
-				if err != nil {
-					slog.Error("failed to parse time value", log.BBError(err))
-					return util.NullRowValue
-				}
-				return &v1pb.RowValue{
-					Kind: &v1pb.RowValue_TimestampValue{
-						TimestampValue: &v1pb.RowValue_Timestamp{
-							GoogleTimestamp: timestamppb.New(t),
-							Accuracy:        int32(scale),
-						},
-					},
-				}
+				return util.BuildTimestampOrStringRowValue(raw.String, scale)
 			}
 			return &v1pb.RowValue{
 				Kind: &v1pb.RowValue_StringValue{

--- a/backend/plugin/db/util/driverutil.go
+++ b/backend/plugin/db/util/driverutil.go
@@ -7,11 +7,13 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bytebase/bytebase/backend/common"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
@@ -46,6 +48,42 @@ var NullRowValue = &v1pb.RowValue{
 	Kind: &v1pb.RowValue_NullValue{
 		NullValue: structpb.NullValue_NULL_VALUE,
 	},
+}
+
+func BuildStringRowValue(value string) *v1pb.RowValue {
+	return &v1pb.RowValue{
+		Kind: &v1pb.RowValue_StringValue{
+			StringValue: value,
+		},
+	}
+}
+
+func BuildTimestampOrStringRowValue(value string, scale int64) *v1pb.RowValue {
+	t, err := parseSQLTimestamp(value)
+	if err != nil {
+		return BuildStringRowValue(value)
+	}
+
+	ts := timestamppb.New(t)
+	if err := ts.CheckValid(); err != nil {
+		return BuildStringRowValue(value)
+	}
+
+	return &v1pb.RowValue{
+		Kind: &v1pb.RowValue_TimestampValue{
+			TimestampValue: &v1pb.RowValue_Timestamp{
+				GoogleTimestamp: ts,
+				Accuracy:        int32(scale),
+			},
+		},
+	}
+}
+
+func parseSQLTimestamp(value string) (time.Time, error) {
+	if strings.Contains(value, ".") {
+		return time.Parse("2006-01-02 15:04:05.999999999", value)
+	}
+	return time.Parse(time.DateTime, value)
 }
 
 func RowsToQueryResult(rows *sql.Rows, valueMaker func(string, *sql.ColumnType) any, rowValueConverter func(string, *sql.ColumnType, any) *v1pb.RowValue, limit int64) (*v1pb.QueryResult, error) {

--- a/backend/plugin/db/util/driverutil_test.go
+++ b/backend/plugin/db/util/driverutil_test.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestBuildTimestampOrStringRowValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      string
+		wantString bool
+	}{
+		{
+			name:       "valid timestamp",
+			value:      "2026-05-11 12:34:56.007",
+			wantString: false,
+		},
+		{
+			name:       "zero year timestamp",
+			value:      "0000-01-01 00:00:00.007",
+			wantString: true,
+		},
+		{
+			name:       "zero date timestamp",
+			value:      "0000-00-00 00:00:00",
+			wantString: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BuildTimestampOrStringRowValue(tc.value, 3)
+			_, err := protojson.Marshal(got)
+			require.NoError(t, err)
+
+			if tc.wantString {
+				require.Equal(t, tc.value, got.GetStringValue())
+				return
+			}
+
+			require.NotNil(t, got.GetTimestampValue())
+			require.EqualValues(t, 3, got.GetTimestampValue().GetAccuracy())
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Backport #20285 to release/3.17.1.
- Preserve invalid SQL timestamp/datetime values as strings instead of encoding them as protobuf Timestamp values.
- Share timestamp conversion across MySQL, TiDB, and StarRocks query result handling.

Closes BYT-9438

## Test Plan
- [x] go test ./backend/plugin/db/util ./backend/plugin/db/tidb ./backend/plugin/db/mysql ./backend/plugin/db/starrocks
- [x] golangci-lint run --allow-parallel-runners
- [x] go build -ldflags \"-w -s\" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go