### PR TITLE
style(react): polish plan/issue title size and status badge wrap

### DIFF
--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -695,7 +695,7 @@ function StatusTag({
   return (
     <span
       className={cn(
-        "inline-flex items-center rounded-full px-2 py-0.5 text-xs",
+        "inline-flex items-center whitespace-nowrap rounded-full px-2 py-0.5 text-xs",
         variantClasses[variant]
       )}
     >

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTitleInput.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTitleInput.tsx
@@ -86,7 +86,7 @@ export function IssueDetailTitleInput() {
     <div className="relative min-w-0 flex-1">
       <input
         className={[
-          "h-10 w-full bg-transparent text-[18px] font-bold text-main transition-colors outline-hidden",
+          "h-10 w-full bg-transparent text-xl! font-bold text-main transition-colors outline-hidden",
           "placeholder:text-control-placeholder",
           "caret-main",
           isReadOnly ? "cursor-default" : "cursor-text",

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
@@ -440,7 +440,7 @@ export function PlanDetailHeader() {
         <div className="min-w-0 flex-1">
           <input
             className={cn(
-              "h-9 w-full bg-transparent text-[18px] font-bold text-main outline-hidden",
+              "h-9 w-full bg-transparent text-xl! font-bold text-main outline-hidden",
               editingTitle
                 ? "border border-control-border px-3"
                 : "border border-transparent px-0",


### PR DESCRIPTION
## Summary
- Plan and issue title inputs: `text-[18px]` → `text-xl!` (matches the rest of the React type scale).
- Plan dashboard `StatusTag`: adds `whitespace-nowrap` so short status labels don't wrap inside the pill.

## Test plan
- [x] `pnpm --dir frontend type-check`
- [ ] Visually verify plan-detail and issue-detail title sizes, and the status pills on the plan dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)