### PR TITLE
fix(parser): classify truncate statements

### DIFF
--- a/backend/plugin/parser/pg/statement_type_antlr.go
+++ b/backend/plugin/parser/pg/statement_type_antlr.go
@@ -41,6 +41,8 @@ func classifyStatementType(node ast.Node) storepb.StatementType {
 		return getDropStatementTypeFromOmni(n)
 	case *ast.DropdbStmt:
 		return storepb.StatementType_DROP_DATABASE
+	case *ast.TruncateStmt:
+		return storepb.StatementType_TRUNCATE
 
 	// DDL - ALTER
 	case *ast.AlterTableStmt:

--- a/backend/plugin/parser/pg/test-data/test_statement_type.yaml
+++ b/backend/plugin/parser/pg/test-data/test_statement_type.yaml
@@ -88,6 +88,9 @@
 - statement: DELETE FROM t1 WHERE id = 1;
   want:
     - DELETE
+- statement: TRUNCATE TABLE t1;
+  want:
+    - TRUNCATE
 - statement: COMMENT ON TABLE t1 IS 'test table';
   want:
     - COMMENT

--- a/backend/plugin/parser/redshift/statement_type.go
+++ b/backend/plugin/parser/redshift/statement_type.go
@@ -268,6 +268,13 @@ func (c *statementTypeCollectorWithPosition) EnterDropdbstmt(ctx *parser.Dropdbs
 	c.addStatement(storepb.StatementType_DROP_DATABASE, ctx)
 }
 
+func (c *statementTypeCollectorWithPosition) EnterTruncatestmt(ctx *parser.TruncatestmtContext) {
+	if !isTopLevel(ctx.GetParent()) {
+		return
+	}
+	c.addStatement(storepb.StatementType_TRUNCATE, ctx)
+}
+
 // DROP SCHEMA statements
 func (c *statementTypeCollectorWithPosition) EnterDropschemastmt(ctx *parser.DropschemastmtContext) {
 	if !isTopLevel(ctx.GetParent()) {

--- a/backend/plugin/parser/redshift/statement_type_test.go
+++ b/backend/plugin/parser/redshift/statement_type_test.go
@@ -1,0 +1,37 @@
+package redshift
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestGetStatementTypes(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		want      []storepb.StatementType
+	}{
+		{
+			name:      "truncate table",
+			statement: "TRUNCATE TABLE t1;",
+			want: []storepb.StatementType{
+				storepb.StatementType_TRUNCATE,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stmts, err := base.ParseStatements(storepb.Engine_REDSHIFT, tt.statement)
+			require.NoError(t, err)
+
+			got, err := GetStatementTypes(base.ExtractASTs(stmts))
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Classify PostgreSQL `TRUNCATE` statements as `StatementType_TRUNCATE`.
- Classify Redshift `TRUNCATE` statements as `StatementType_TRUNCATE`.
- Add regression coverage for both parsers so approval CEL receives `statement.sql_type`.

## Test Plan
- `go test -v -count=1 ./backend/plugin/parser/pg -run ^TestGetStatementType`
- `go test -v -count=1 ./backend/plugin/parser/redshift -run ^TestGetStatementTypes`
- `go test -v -count=1 ./backend/plugin/parser/pg ./backend/plugin/parser/redshift`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

Close BYT-9489