### PR TITLE
chore: clean up React z-index layering

### DIFF
--- a/frontend/src/react/components/DatabaseSelect.tsx
+++ b/frontend/src/react/components/DatabaseSelect.tsx
@@ -19,6 +19,7 @@ export interface DatabaseSelectProps {
   placeholder?: string;
   disabled?: boolean;
   className?: string;
+  portal?: boolean;
   projectName?: string;
   environmentName?: string;
   allowedEngineTypeList?: Engine[];
@@ -30,6 +31,7 @@ export function DatabaseSelect({
   placeholder,
   disabled,
   className,
+  portal,
   projectName,
   environmentName,
   allowedEngineTypeList,
@@ -94,6 +96,7 @@ export function DatabaseSelect({
       onSearch={fetchDatabases}
       disabled={disabled}
       className={className}
+      portal={portal}
       renderValue={(opt) => {
         const db = databases.find((d) => d.name === opt.value);
         if (!db) return opt.label;

--- a/frontend/src/react/components/EnvironmentSelect.tsx
+++ b/frontend/src/react/components/EnvironmentSelect.tsx
@@ -12,6 +12,7 @@ export interface EnvironmentSelectProps {
   placeholder?: string;
   disabled?: boolean;
   className?: string;
+  portal?: boolean;
   clearable?: boolean;
   renderSuffix?: (environment: Environment) => React.ReactNode;
 }
@@ -22,6 +23,7 @@ export function EnvironmentSelect({
   placeholder,
   disabled,
   className,
+  portal,
   clearable = true,
   renderSuffix,
 }: EnvironmentSelectProps) {
@@ -56,6 +58,7 @@ export function EnvironmentSelect({
       noResultsText={t("common.no-data")}
       disabled={disabled}
       className={className}
+      portal={portal}
       clearable={clearable}
       renderValue={(opt) => {
         const env = environments.find(

--- a/frontend/src/react/components/InstanceSelect.tsx
+++ b/frontend/src/react/components/InstanceSelect.tsx
@@ -14,6 +14,7 @@ export interface InstanceSelectProps {
   placeholder?: string;
   disabled?: boolean;
   className?: string;
+  portal?: boolean;
   /** Only show instances with these engines */
   engines?: Engine[];
 }
@@ -24,6 +25,7 @@ export function InstanceSelect({
   placeholder,
   disabled,
   className,
+  portal,
   engines,
 }: InstanceSelectProps) {
   const { t } = useTranslation();
@@ -79,6 +81,7 @@ export function InstanceSelect({
       onSearch={fetchInstances}
       disabled={disabled}
       className={className}
+      portal={portal}
       renderValue={(opt) => {
         const inst = instances.find((i) => i.name === opt.value);
         if (!inst) return opt.label;

--- a/frontend/src/react/components/WorkspaceSwitcher.tsx
+++ b/frontend/src/react/components/WorkspaceSwitcher.tsx
@@ -1,6 +1,11 @@
 import { Building2, ChevronsUpDown } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
-import { useClickOutside } from "@/react/hooks/useClickOutside";
+import { useState } from "react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useWorkspaceV1Store } from "@/store";
 
@@ -12,13 +17,6 @@ export function WorkspaceSwitcher() {
   const currentWorkspaceName = currentWorkspace?.name ?? "";
 
   const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useClickOutside(
-    containerRef,
-    open,
-    useCallback(() => setOpen(false), [])
-  );
 
   if (workspaceList.length <= 1) {
     return null;
@@ -31,25 +29,23 @@ export function WorkspaceSwitcher() {
   };
 
   return (
-    <div ref={containerRef} className="relative px-2.5 pb-2">
-      <button
-        type="button"
-        className="w-full flex items-center gap-x-2 px-2 py-1.5 rounded-xs text-sm font-medium text-control hover:bg-control-bg cursor-pointer"
-        onClick={() => setOpen(!open)}
-      >
-        <Building2 className="size-4 text-control-light shrink-0" />
-        <span className="truncate flex-1 text-left">
-          {currentWorkspace?.title}
-        </span>
-        <ChevronsUpDown className="size-3.5 text-control-placeholder shrink-0" />
-      </button>
-      {open && (
-        <div className="absolute left-2.5 right-2.5 z-10 mt-1 bg-background border border-block-border rounded-sm shadow-lg py-1">
+    <div className="px-2.5 pb-2">
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <DropdownMenuTrigger className="w-full flex items-center gap-x-2 px-2 py-1.5 rounded-xs text-sm font-medium text-control hover:bg-control-bg cursor-pointer outline-hidden focus-visible:ring-2 focus-visible:ring-accent">
+          <Building2 className="size-4 text-control-light shrink-0" />
+          <span className="truncate flex-1 text-left">
+            {currentWorkspace?.title}
+          </span>
+          <ChevronsUpDown className="size-3.5 text-control-placeholder shrink-0" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="w-[var(--anchor-width)] py-1"
+        >
           {workspaceList.map((ws) => (
-            <button
+            <DropdownMenuItem
               key={ws.name}
-              type="button"
-              className={`w-full text-left px-3 py-1.5 text-sm hover:bg-control-bg cursor-pointer ${
+              className={`px-3 py-1.5 ${
                 ws.name === currentWorkspaceName
                   ? "font-medium text-accent"
                   : "text-control"
@@ -57,10 +53,10 @@ export function WorkspaceSwitcher() {
               onClick={() => onSwitch(ws.name)}
             >
               {ws.title}
-            </button>
+            </DropdownMenuItem>
           ))}
-        </div>
-      )}
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/frontend/src/react/components/database/CreateDatabaseSheet.test.tsx
+++ b/frontend/src/react/components/database/CreateDatabaseSheet.test.tsx
@@ -15,10 +15,12 @@ import { Engine } from "@/types/proto-es/v1/common_pb";
 vi.mock("@/react/components/InstanceSelect", () => ({
   InstanceSelect: (props: {
     onChange: (name: string, instance: unknown) => void;
+    portal?: boolean;
     value: string;
   }) =>
     createElement("input", {
       "data-testid": "instance-select",
+      "data-portal": String(Boolean(props.portal)),
       value: props.value,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
         props.onChange(e.target.value, undefined),
@@ -64,6 +66,7 @@ vi.mock("@/react/components/ui/combobox", () => ({
     value,
     onChange,
     placeholder,
+    portal,
   }: {
     value: string;
     onChange: (v: string) => void;
@@ -71,10 +74,12 @@ vi.mock("@/react/components/ui/combobox", () => ({
     noResultsText?: string;
     options?: unknown[];
     onSearch?: (q: string) => void;
+    portal?: boolean;
     renderValue?: (opt: unknown) => ReactNode;
   }) =>
     createElement("input", {
       "data-testid": "combobox",
+      "data-portal": String(Boolean(portal)),
       value,
       placeholder,
       onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
@@ -223,6 +228,19 @@ async function renderSheet(enforceIssueTitle: boolean): Promise<void> {
   });
 }
 
+async function renderSheetWithoutFixedProject(): Promise<void> {
+  await act(async () => {
+    root.render(
+      createElement(CreateDatabaseSheet, {
+        open: true,
+        onClose: () => {},
+      })
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 async function fillInstance(): Promise<void> {
   const input = container.querySelector(
     "[data-testid='instance-select']"
@@ -261,6 +279,20 @@ async function flush(): Promise<void> {
 }
 
 describe("CreateDatabaseSheet — enforceIssueTitle (BYT-9310)", () => {
+  it("portals project and instance dropdowns out of the scrollable sheet body", async () => {
+    await renderSheetWithoutFixedProject();
+
+    const projectSelect = container.querySelector(
+      "input[placeholder='common.project']"
+    ) as HTMLInputElement;
+    const instanceSelect = container.querySelector(
+      "[data-testid='instance-select']"
+    ) as HTMLInputElement;
+
+    expect(projectSelect.dataset.portal).toBe("true");
+    expect(instanceSelect.dataset.portal).toBe("true");
+  });
+
   it("auto-fills title from database name when enforceIssueTitle is false", async () => {
     await renderSheet(false);
     await fillInstance();

--- a/frontend/src/react/components/database/CreateDatabaseSheet.tsx
+++ b/frontend/src/react/components/database/CreateDatabaseSheet.tsx
@@ -329,6 +329,7 @@ export function CreateDatabaseSheet({
               <ProjectSelect
                 value={projectName}
                 onChange={(name) => setProjectName(name)}
+                portal
               />
             </div>
           )}
@@ -350,6 +351,7 @@ export function CreateDatabaseSheet({
               value={instanceName}
               onChange={handleInstanceChange}
               engines={enginesSupportCreateDatabase()}
+              portal
             />
           </div>
 

--- a/frontend/src/react/components/ui/sheet.test.tsx
+++ b/frontend/src/react/components/ui/sheet.test.tsx
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+
+describe("Sheet layering policy", () => {
+  test("does not keep stale raw z-index tokens in the shared sheet surface", () => {
+    const source = readFileSync(
+      join(process.cwd(), "src/react/components/ui/sheet.tsx"),
+      "utf8"
+    );
+
+    expect(source).not.toMatch(/\bz-50\b/);
+  });
+});

--- a/frontend/src/react/components/ui/sheet.tsx
+++ b/frontend/src/react/components/ui/sheet.tsx
@@ -53,7 +53,7 @@ function SheetOverlay({
 // legitimate size is needed so all consumers stay aligned.
 const sheetContentVariants = cva(
   cn(
-    "fixed inset-y-0 right-0 z-50 flex h-full flex-col bg-background shadow-lg",
+    "fixed inset-y-0 right-0 flex h-full flex-col bg-background shadow-lg",
     "max-w-[100vw] outline-hidden",
     "data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full",
     "transition-transform duration-200 ease-out"

--- a/frontend/src/react/pages/project/ProjectIssueDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/ProjectIssueDetailPage.test.tsx
@@ -1,0 +1,95 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  LAYER_ROOT_ID,
+  LAYER_SURFACE_CLASS,
+} from "@/react/components/ui/layer";
+import { ProjectIssueDetailPage } from "./ProjectIssueDetailPage";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  page: {
+    ready: true,
+    sidebarMode: "MOBILE",
+    mobileSidebarOpen: true,
+    desktopSidebarWidth: 0,
+    setMobileSidebarOpen: vi.fn(),
+    setEditing: vi.fn(),
+    patchState: vi.fn(),
+    refreshState: vi.fn(),
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/react/hooks/useVueState", () => ({
+  useVueState: (getter: () => unknown) => getter(),
+}));
+
+vi.mock("@/router", () => ({
+  router: {
+    currentRoute: { value: { query: {} } },
+    replace: vi.fn(),
+  },
+}));
+
+vi.mock("./issue-detail/hooks/useIssueDetailPage", () => ({
+  useIssueDetailPage: () => mocks.page,
+}));
+
+vi.mock("./issue-detail/components/IssueDetailActivity", () => ({
+  IssueDetailActivity: () => <div data-testid="issue-detail-activity" />,
+}));
+
+vi.mock("./issue-detail/components/IssueDetailBranchContent", () => ({
+  IssueDetailBranchContent: () => <div data-testid="issue-detail-content" />,
+}));
+
+vi.mock("./issue-detail/components/IssueDetailHeader", () => ({
+  IssueDetailHeader: () => <div data-testid="issue-detail-header" />,
+}));
+
+vi.mock("./issue-detail/components/IssueDetailSidebar", () => ({
+  IssueDetailSidebar: () => <aside data-testid="issue-detail-sidebar" />,
+}));
+
+describe("ProjectIssueDetailPage", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  test("renders the mobile sidebar in the semantic overlay layer", async () => {
+    await act(async () => {
+      root.render(<ProjectIssueDetailPage projectId="p1" issueId="1" />);
+    });
+
+    const overlayRoot = document.getElementById(LAYER_ROOT_ID.overlay);
+    expect(overlayRoot).toBeInstanceOf(HTMLDivElement);
+    expect(
+      overlayRoot?.querySelector("[data-testid='issue-detail-sidebar']")
+    ).toBeInstanceOf(HTMLElement);
+    expect(overlayRoot?.firstElementChild?.className).toContain(
+      LAYER_SURFACE_CLASS
+    );
+  });
+});

--- a/frontend/src/react/pages/project/ProjectIssueDetailPage.tsx
+++ b/frontend/src/react/pages/project/ProjectIssueDetailPage.tsx
@@ -1,7 +1,13 @@
 import { X } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
+import {
+  getLayerRoot,
+  LAYER_BACKDROP_CLASS,
+  LAYER_SURFACE_CLASS,
+} from "@/react/components/ui/layer";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { router } from "@/router";
@@ -99,45 +105,50 @@ export function ProjectIssueDetailPage(props: ProjectIssueDetailPageProps) {
           </div>
         )}
 
-        {showMobileSidebar && (
-          <div
-            className={cn(
-              "absolute inset-0 z-30 transition-[visibility] duration-200",
-              page.mobileSidebarOpen
-                ? "visible"
-                : "invisible pointer-events-none"
-            )}
-          >
-            <button
-              className={cn(
-                "absolute inset-0 bg-black/40 transition-opacity duration-200",
-                page.mobileSidebarOpen ? "opacity-100" : "opacity-0"
-              )}
-              onClick={() => page.setMobileSidebarOpen(false)}
-              type="button"
-            />
+        {showMobileSidebar &&
+          createPortal(
             <div
               className={cn(
-                "absolute right-0 top-0 flex h-full w-[80vw] min-w-[240px] max-w-[320px] transform flex-col border-l bg-white p-2 shadow-lg transition-transform duration-200",
-                page.mobileSidebarOpen ? "translate-x-0" : "translate-x-full"
+                "fixed inset-0 transition-[visibility] duration-200",
+                LAYER_SURFACE_CLASS,
+                page.mobileSidebarOpen
+                  ? "visible"
+                  : "invisible pointer-events-none"
               )}
             >
-              <div className="mb-2 flex justify-end">
-                <Button
-                  aria-label={t("common.close")}
-                  onClick={() => page.setMobileSidebarOpen(false)}
-                  size="sm"
-                  variant="ghost"
-                >
-                  <X className="h-4 w-4" />
-                </Button>
+              <button
+                className={cn(
+                  "absolute inset-0 bg-black/40 transition-opacity duration-200",
+                  LAYER_BACKDROP_CLASS,
+                  page.mobileSidebarOpen ? "opacity-100" : "opacity-0"
+                )}
+                onClick={() => page.setMobileSidebarOpen(false)}
+                type="button"
+              />
+              <div
+                className={cn(
+                  "absolute right-0 top-0 flex h-full w-[80vw] min-w-[240px] max-w-[320px] transform flex-col border-l bg-white p-2 shadow-lg transition-transform duration-200",
+                  LAYER_SURFACE_CLASS,
+                  page.mobileSidebarOpen ? "translate-x-0" : "translate-x-full"
+                )}
+              >
+                <div className="mb-2 flex justify-end">
+                  <Button
+                    aria-label={t("common.close")}
+                    onClick={() => page.setMobileSidebarOpen(false)}
+                    size="sm"
+                    variant="ghost"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  <IssueDetailSidebar />
+                </div>
               </div>
-              <div className="min-h-0 flex-1 overflow-y-auto">
-                <IssueDetailSidebar />
-              </div>
-            </div>
-          </div>
-        )}
+            </div>,
+            getLayerRoot("overlay")
+          )}
       </div>
     </IssueDetailProvider>
   );

--- a/frontend/src/react/pages/project/database-detail/DatabaseExportSchemaButton.tsx
+++ b/frontend/src/react/pages/project/database-detail/DatabaseExportSchemaButton.tsx
@@ -1,12 +1,15 @@
 import { create } from "@bufbuild/protobuf";
 import { ConnectError } from "@connectrpc/connect";
 import { ChevronDown, Download } from "lucide-react";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { databaseServiceClientConnect } from "@/connect";
-import { Button } from "@/react/components/ui/button";
-import { useClickOutside } from "@/react/hooks/useClickOutside";
-import { cn } from "@/react/lib/utils";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { pushNotification } from "@/store";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
@@ -31,9 +34,6 @@ export function DatabaseExportSchemaButton({
   const { t } = useTranslation();
   const [exporting, setExporting] = useState(false);
   const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-
-  useClickOutside(containerRef, open, () => setOpen(false));
 
   const options = useMemo(
     () => [
@@ -104,32 +104,25 @@ export function DatabaseExportSchemaButton({
   );
 
   return (
-    <div className="relative" ref={containerRef}>
-      <Button
-        variant="outline"
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger
+        className="inline-flex h-8 items-center justify-center gap-x-2 whitespace-nowrap rounded-sm border border-control-border bg-background px-3 text-sm font-medium text-control shadow-xs hover:bg-control-bg cursor-pointer outline-hidden focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-50"
         disabled={disabled || exporting}
-        onClick={() => setOpen((value) => !value)}
       >
         <Download className="size-4" />
         {t("database.export-schema")}
         <ChevronDown className="size-4" />
-      </Button>
-      {open && !disabled && !exporting && (
-        <div className="absolute right-0 top-full z-20 mt-1 min-w-52 rounded-sm border border-control-border bg-background py-1 shadow-md">
-          {options.map((option) => (
-            <button
-              key={option.key}
-              type="button"
-              className={cn(
-                "block w-full px-3 py-2 text-left text-sm hover:bg-control-bg"
-              )}
-              onClick={() => void handleExport(option.key)}
-            >
-              {option.label}
-            </button>
-          ))}
-        </div>
-      )}
-    </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-52">
+        {options.map((option) => (
+          <DropdownMenuItem
+            key={option.key}
+            onClick={() => void handleExport(option.key)}
+          >
+            {option.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
@@ -10,15 +10,20 @@ import {
   Pause,
   X,
 } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { planServiceClientConnect } from "@/connect";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { Button } from "@/react/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { Input } from "@/react/components/ui/input";
 import { Switch } from "@/react/components/ui/switch";
 import { Tooltip } from "@/react/components/ui/tooltip";
-import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { router } from "@/router";
@@ -433,13 +438,9 @@ function IssueDetailDatabaseExportTasks({
 function IssueDetailDatabaseExportTaskActions({ task }: { task: Task }) {
   const { t } = useTranslation();
   const page = useIssueDetailContext();
-  const [menuOpen, setMenuOpen] = useState(false);
   const [pendingAction, setPendingAction] = useState<
     "RUN" | "SKIP" | "CANCEL" | undefined
   >();
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useClickOutside(menuRef, menuOpen, () => setMenuOpen(false));
 
   const stage = useMemo(() => {
     return page.rollout?.stages.find((candidate) =>
@@ -462,7 +463,7 @@ function IssueDetailDatabaseExportTaskActions({ task }: { task: Task }) {
 
   return (
     <>
-      <div className="relative flex items-center gap-x-2" ref={menuRef}>
+      <div className="flex items-center gap-x-2">
         {primaryAction && (
           <Button
             onClick={() => setPendingAction("RUN")}
@@ -473,44 +474,26 @@ function IssueDetailDatabaseExportTaskActions({ task }: { task: Task }) {
           </Button>
         )}
         {(canSkip || canCancel) && (
-          <>
-            <Button
+          <DropdownMenu>
+            <DropdownMenuTrigger
               aria-label={t("common.more")}
-              onClick={() => setMenuOpen((open) => !open)}
-              size="xs"
-              variant="ghost"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-sm text-control hover:bg-control-bg cursor-pointer outline-hidden focus-visible:ring-2 focus-visible:ring-accent"
             >
               <EllipsisVertical className="h-3.5 w-3.5" />
-            </Button>
-            {menuOpen && (
-              <div className="absolute right-0 top-full z-20 mt-1 min-w-36 overflow-hidden rounded-sm border border-control-border bg-white py-1 shadow-lg">
-                {canSkip && (
-                  <button
-                    className="flex w-full items-center px-3 py-2 text-left text-sm hover:bg-control-bg"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      setPendingAction("SKIP");
-                    }}
-                    type="button"
-                  >
-                    {t("common.skip")}
-                  </button>
-                )}
-                {canCancel && (
-                  <button
-                    className="flex w-full items-center px-3 py-2 text-left text-sm hover:bg-control-bg"
-                    onClick={() => {
-                      setMenuOpen(false);
-                      setPendingAction("CANCEL");
-                    }}
-                    type="button"
-                  >
-                    {t("common.cancel")}
-                  </button>
-                )}
-              </div>
-            )}
-          </>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="min-w-36">
+              {canSkip && (
+                <DropdownMenuItem onClick={() => setPendingAction("SKIP")}>
+                  {t("common.skip")}
+                </DropdownMenuItem>
+              )}
+              {canCancel && (
+                <DropdownMenuItem onClick={() => setPendingAction("CANCEL")}>
+                  {t("common.cancel")}
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
       </div>
 

--- a/frontend/src/react/pages/settings/SemanticTypesPage.tsx
+++ b/frontend/src/react/pages/settings/SemanticTypesPage.tsx
@@ -8,6 +8,11 @@ import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { NumberInput } from "@/react/components/ui/number-input";
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/react/components/ui/popover";
+import {
   Sheet,
   SheetBody,
   SheetContent,
@@ -90,28 +95,6 @@ function useEscapeKey(onEscape: () => void) {
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [onEscape]);
-}
-
-function useClickOutside(
-  ref: React.RefObject<HTMLElement | null>,
-  onClickOutside: () => void
-) {
-  useEffect(() => {
-    // Delay by one frame so the click that opened the popover doesn't
-    // immediately trigger the outside-click handler.
-    const id = requestAnimationFrame(() => {
-      document.addEventListener("mousedown", handler);
-    });
-    function handler(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        onClickOutside();
-      }
-    }
-    return () => {
-      cancelAnimationFrame(id);
-      document.removeEventListener("mousedown", handler);
-    };
-  }, [ref, onClickOutside]);
 }
 
 export function SemanticTypesPage() {
@@ -1290,14 +1273,13 @@ function IconPicker({ value, onChange }: IconPickerProps) {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [tempValue, setTempValue] = useState(value);
-  const popoverRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const dismiss = useCallback(() => setOpen(false), []);
-  useClickOutside(popoverRef, dismiss);
 
-  const handleOpen = () => {
-    setTempValue(value);
-    setOpen(true);
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen) {
+      setTempValue(value);
+    }
+    setOpen(nextOpen);
   };
 
   const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -1312,73 +1294,67 @@ function IconPicker({ value, onChange }: IconPickerProps) {
   };
 
   return (
-    <div className="relative flex items-center justify-center" ref={popoverRef}>
-      {value ? (
-        <div className="flex items-center gap-1">
-          <img src={value} className="w-6 h-6 object-contain" alt="" />
-          <button
-            className="p-0.5 rounded-xs hover:bg-control-bg-hover text-control-light"
-            onClick={handleOpen}
-          >
-            <Pencil className="w-3 h-3" />
-          </button>
-        </div>
-      ) : (
-        <button
-          className="p-1 rounded-xs hover:bg-control-bg-hover text-control-light"
-          onClick={handleOpen}
-        >
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger
+        className={
+          value
+            ? "flex items-center gap-1 rounded-xs text-control-light outline-hidden focus-visible:ring-2 focus-visible:ring-accent"
+            : "p-1 rounded-xs hover:bg-control-bg-hover text-control-light outline-hidden focus-visible:ring-2 focus-visible:ring-accent"
+        }
+      >
+        {value ? (
+          <>
+            <img src={value} className="w-6 h-6 object-contain" alt="" />
+            <span className="p-0.5 rounded-xs hover:bg-control-bg-hover">
+              <Pencil className="w-3 h-3" />
+            </span>
+          </>
+        ) : (
           <Pencil className="w-4 h-4" />
-        </button>
-      )}
-      {open && (
-        <div className="absolute left-0 top-full z-20 mt-1 bg-background border border-control-border rounded-sm shadow-lg p-3">
-          <div
-            className="w-48 h-48 flex justify-center items-center border border-dashed border-control-border rounded-sm relative cursor-pointer"
-            onClick={() => fileInputRef.current?.click()}
-          >
-            {tempValue ? (
-              <div
-                className="w-1/3 h-1/3 bg-no-repeat bg-contain bg-center rounded-sm"
-                style={{ backgroundImage: `url(${tempValue})` }}
-              />
-            ) : (
-              <span className="text-sm text-control-placeholder">
-                {t("common.upload")}
-              </span>
-            )}
-            <input
-              ref={fileInputRef}
-              type="file"
-              className="hidden"
-              accept={SUPPORTED_IMAGE_EXTENSIONS.join(",")}
-              onChange={handleFileSelect}
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="start" className="p-3">
+        <div
+          className="w-48 h-48 flex justify-center items-center border border-dashed border-control-border rounded-sm relative cursor-pointer"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          {tempValue ? (
+            <div
+              className="w-1/3 h-1/3 bg-no-repeat bg-contain bg-center rounded-sm"
+              style={{ backgroundImage: `url(${tempValue})` }}
             />
-          </div>
-          <div className="flex justify-end gap-x-2 mt-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setTempValue("")}
-            >
-              {t("common.clear")}
-            </Button>
-            <Button variant="outline" size="sm" onClick={() => setOpen(false)}>
-              {t("common.cancel")}
-            </Button>
-            <Button
-              size="sm"
-              onClick={() => {
-                onChange(tempValue);
-                setOpen(false);
-              }}
-            >
-              {t("common.update")}
-            </Button>
-          </div>
+          ) : (
+            <span className="text-sm text-control-placeholder">
+              {t("common.upload")}
+            </span>
+          )}
+          <input
+            ref={fileInputRef}
+            type="file"
+            className="hidden"
+            accept={SUPPORTED_IMAGE_EXTENSIONS.join(",")}
+            onChange={handleFileSelect}
+          />
         </div>
-      )}
-    </div>
+        <div className="flex justify-end gap-x-2 mt-2">
+          <Button variant="outline" size="sm" onClick={() => setTempValue("")}>
+            {t("common.clear")}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setOpen(false)}>
+            {t("common.cancel")}
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => {
+              onChange(tempValue);
+              setOpen(false);
+            }}
+          >
+            {t("common.update")}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -1398,42 +1374,34 @@ function DeleteConfirmButton({
   onConfirm,
 }: DeleteConfirmButtonProps) {
   const { t } = useTranslation();
-  const popoverRef = useRef<HTMLDivElement>(null);
-  const dismiss = useCallback(() => onShowChange(false), [onShowChange]);
-  useClickOutside(popoverRef, dismiss);
 
   return (
-    <div className="relative" ref={popoverRef}>
-      <button
-        className="p-1 rounded-xs hover:bg-error/10 text-error"
-        onClick={() => onShowChange(!show)}
-      >
+    <Popover open={show} onOpenChange={onShowChange}>
+      <PopoverTrigger className="p-1 rounded-xs hover:bg-error/10 text-error">
         <Trash2 className="w-4 h-4" />
-      </button>
-      {show && (
-        <div className="absolute right-0 top-full z-10 mt-1 bg-background border border-control-border rounded-sm shadow-lg p-3 whitespace-nowrap">
-          <p className="text-sm mb-2">{message}</p>
-          <div className="flex justify-end gap-x-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onShowChange(false)}
-            >
-              {t("common.cancel")}
-            </Button>
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={() => {
-                onConfirm();
-                onShowChange(false);
-              }}
-            >
-              {t("common.delete")}
-            </Button>
-          </div>
+      </PopoverTrigger>
+      <PopoverContent className="whitespace-nowrap">
+        <p className="text-sm mb-2">{message}</p>
+        <div className="flex justify-end gap-x-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onShowChange(false)}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => {
+              onConfirm();
+              onShowChange(false);
+            }}
+          >
+            {t("common.delete")}
+          </Button>
         </div>
-      )}
-    </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/frontend/src/react/pages/settings/profile/ProfilePage.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.tsx
@@ -15,9 +15,14 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/react/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/react/components/ui/dropdown-menu";
 import { FeatureModal } from "@/react/components/ui/feature-modal";
 import { Input } from "@/react/components/ui/input";
-import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { useVueState } from "@/react/hooks/useVueState";
 import { RegenerateRecoveryCodesView } from "@/react/pages/settings/two-factor/RegenerateRecoveryCodesView";
 import { router } from "@/router";
@@ -138,13 +143,8 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
   const [showFeatureModal, setShowFeatureModal] = useState(false);
   const [showDisable2FAConfirm, setShowDisable2FAConfirm] = useState(false);
   const [showRegenerateView, setShowRegenerateView] = useState(false);
-  const [showEllipsisMenu, setShowEllipsisMenu] = useState(false);
 
   const editNameRef = useRef<HTMLInputElement>(null);
-  const ellipsisMenuRef = useRef<HTMLDivElement>(null);
-  useClickOutside(ellipsisMenuRef, showEllipsisMenu, () =>
-    setShowEllipsisMenu(false)
-  );
 
   // --- Password validity ---
   const passwordErrors = useMemo(() => {
@@ -603,29 +603,22 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
                     {t("two-factor.recovery-codes.self")}
                   </span>
                   {!showRegenerateView && (
-                    <div className="relative" ref={ellipsisMenuRef}>
-                      <button
-                        type="button"
-                        className="p-1 rounded-xs hover:bg-control-bg"
-                        onClick={() => setShowEllipsisMenu((v) => !v)}
+                    <DropdownMenu>
+                      <DropdownMenuTrigger
+                        aria-label={t("common.more")}
+                        className="p-1 rounded-xs hover:bg-control-bg cursor-pointer outline-hidden focus-visible:ring-2 focus-visible:ring-accent"
                       >
                         <Ellipsis className="w-8" />
-                      </button>
-                      {showEllipsisMenu && (
-                        <div className="absolute right-0 mt-1 z-10 bg-white border border-control-border rounded-sm shadow-md py-1 min-w-36">
-                          <button
-                            type="button"
-                            className="w-full text-left px-3 py-1.5 text-sm hover:bg-control-bg"
-                            onClick={() => {
-                              setShowRegenerateView(true);
-                              setShowEllipsisMenu(false);
-                            }}
-                          >
-                            {t("common.regenerate")}
-                          </button>
-                        </div>
-                      )}
-                    </div>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="min-w-36">
+                        <DropdownMenuItem
+                          className="py-1.5"
+                          onClick={() => setShowRegenerateView(true)}
+                        >
+                          {t("common.regenerate")}
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   )}
                 </div>
                 <p className="mt-4 text-sm text-gray-500">


### PR DESCRIPTION
## Summary
- move React mobile sidebar and combobox-in-sheet dropdowns onto shared overlay layering
- replace ad hoc React popup/menu z-index usage with shared DropdownMenu and Popover primitives
- remove stale Sheet z-index token and add regression coverage for layer policy

## Test Plan
- [x] pnpm --dir frontend fix
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test
- [x] node frontend/scripts/check-react-layering.mjs

## Pre-PR Checklist
- Breaking change check: no breaking API, schema, config, or workflow change
- Composite-PK query safety: skipped, no backend/store/migrator changes
- SonarCloud properties: skipped, new files are React test files covered by existing patterns