### PR TITLE
fix(pg): disable TLS verification for multi-host fallbacks

### DIFF
--- a/backend/plugin/db/cockroachdb/cockroachdb.go
+++ b/backend/plugin/db/cockroachdb/cockroachdb.go
@@ -158,6 +158,7 @@ func getCockroachConnectionConfig(config db.ConnectionConfig) (*pgx.ConnConfig, 
 	}
 	if tlscfg != nil {
 		connConfig.TLSConfig = tlscfg
+		util.ApplyPGTLSConfig(tlscfg, connConfig.Host, connConfig.Fallbacks)
 	}
 	appName := "bytebase"
 	if config.ConnectionContext.TaskRunUID != nil {

--- a/backend/plugin/db/cockroachdb/cockroachdb_test.go
+++ b/backend/plugin/db/cockroachdb/cockroachdb_test.go
@@ -1,9 +1,19 @@
 package cockroachdb
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/db"
 )
 
 func TestGetDatabaseInCreateDatabaseStatement(t *testing.T) {
@@ -85,4 +95,126 @@ func TestGetRoutingIDFromCockroachCloudURL(t *testing.T) {
 		got := getRoutingIDFromCockroachCloudURL(test.host)
 		require.Equal(t, test.expected, got, "host: %s", test.host)
 	}
+}
+
+func TestGetCockroachConnectionConfigAddsClientCertificateForAllHosts(t *testing.T) {
+	certPEM, keyPEM := generateClientCertificatePEM(t)
+	connConfig, err := getCockroachConnectionConfig(db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Username:             "dba",
+			Host:                 "172.18.22.61,172.18.22.62,172.18.22.63",
+			Port:                 "26257",
+			UseSsl:               true,
+			VerifyTlsCertificate: false,
+			SslCert:              certPEM,
+			SslKey:               keyPEM,
+		},
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: "defaultdb",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.TLSConfig)
+	require.Len(t, connConfig.TLSConfig.Certificates, 1)
+	require.Len(t, connConfig.Fallbacks, 2)
+	for _, fallback := range connConfig.Fallbacks {
+		require.NotNil(t, fallback.TLSConfig)
+		require.True(t, fallback.TLSConfig.InsecureSkipVerify)
+		require.Len(t, fallback.TLSConfig.Certificates, 1)
+	}
+}
+
+func TestGetCockroachConnectionConfigVerifiesCustomCAForAllHosts(t *testing.T) {
+	hosts := []string{"crdb-1.example.com", "crdb-2.example.com", "crdb-3.example.com"}
+	caPEM, serverCertDERByHost := generateCAAndServerCertificates(t, hosts)
+	connConfig, err := getCockroachConnectionConfig(db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Username:             "dba",
+			Host:                 "crdb-1.example.com,crdb-2.example.com,crdb-3.example.com",
+			Port:                 "26257",
+			UseSsl:               true,
+			VerifyTlsCertificate: true,
+			SslCa:                caPEM,
+		},
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: "defaultdb",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.TLSConfig)
+	require.NotNil(t, connConfig.TLSConfig.RootCAs)
+	require.NotNil(t, connConfig.TLSConfig.VerifyPeerCertificate)
+	require.NoError(t, connConfig.TLSConfig.VerifyPeerCertificate([][]byte{serverCertDERByHost[hosts[0]]}, nil))
+	require.Len(t, connConfig.Fallbacks, 2)
+	for i, fallback := range connConfig.Fallbacks {
+		require.NotNil(t, fallback.TLSConfig)
+		require.NotNil(t, fallback.TLSConfig.RootCAs)
+		require.NotNil(t, fallback.TLSConfig.VerifyPeerCertificate)
+		require.NoError(t, fallback.TLSConfig.VerifyPeerCertificate([][]byte{serverCertDERByHost[hosts[i+1]]}, nil))
+	}
+}
+
+func generateClientCertificatePEM(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "bytebase-test-client",
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+		},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return string(certPEM), string(keyPEM)
+}
+
+func generateCAAndServerCertificates(t *testing.T, hosts []string) (string, map[string][]byte) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "bytebase-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	serverCertDERByHost := make(map[string][]byte, len(hosts))
+	for i, host := range hosts {
+		serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		serverTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(int64(i + 2)),
+			Subject:      pkix.Name{CommonName: host},
+			DNSNames:     []string{host},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}
+		serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+		require.NoError(t, err)
+		serverCertDERByHost[host] = serverDER
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	return string(caPEM), serverCertDERByHost
 }

--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -211,6 +211,7 @@ func getPGConnectionConfig(config db.ConnectionConfig) (*pgx.ConnConfig, error) 
 	}
 	if tlscfg != nil {
 		connConfig.TLSConfig = tlscfg
+		util.ApplyPGTLSConfig(tlscfg, connConfig.Host, connConfig.Fallbacks)
 	}
 
 	return connConfig, nil

--- a/backend/plugin/db/pg/pg_test.go
+++ b/backend/plugin/db/pg/pg_test.go
@@ -1,9 +1,19 @@
 package pg
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/db"
 )
 
 func TestGetDatabaseInCreateDatabaseStatement(t *testing.T) {
@@ -48,4 +58,148 @@ func TestGetDatabaseInCreateDatabaseStatement(t *testing.T) {
 		}
 		require.Equal(t, test.want, got)
 	}
+}
+
+func TestGetPGConnectionConfigDisablesTLSVerificationForAllHosts(t *testing.T) {
+	connConfig, err := getPGConnectionConfig(db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Username:             "dba",
+			Host:                 "172.18.22.61,172.18.22.62,172.18.22.63",
+			Port:                 "5432",
+			UseSsl:               true,
+			VerifyTlsCertificate: false,
+		},
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: "lapidlive",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.TLSConfig)
+	require.True(t, connConfig.TLSConfig.InsecureSkipVerify)
+	require.Len(t, connConfig.Fallbacks, 2)
+	for _, fallback := range connConfig.Fallbacks {
+		require.NotNil(t, fallback.TLSConfig)
+		require.True(t, fallback.TLSConfig.InsecureSkipVerify)
+	}
+}
+
+func TestGetPGConnectionConfigAddsClientCertificateForAllHosts(t *testing.T) {
+	certPEM, keyPEM := generateClientCertificatePEM(t)
+	connConfig, err := getPGConnectionConfig(db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Username:             "dba",
+			Host:                 "172.18.22.61,172.18.22.62,172.18.22.63",
+			Port:                 "5432",
+			UseSsl:               true,
+			VerifyTlsCertificate: false,
+			SslCert:              certPEM,
+			SslKey:               keyPEM,
+		},
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: "lapidlive",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.TLSConfig)
+	require.Len(t, connConfig.TLSConfig.Certificates, 1)
+	require.Len(t, connConfig.Fallbacks, 2)
+	for _, fallback := range connConfig.Fallbacks {
+		require.NotNil(t, fallback.TLSConfig)
+		require.Len(t, fallback.TLSConfig.Certificates, 1)
+	}
+}
+
+func TestGetPGConnectionConfigVerifiesCustomCAForAllHosts(t *testing.T) {
+	hosts := []string{"pg-1.example.com", "pg-2.example.com", "pg-3.example.com"}
+	caPEM, serverCertDERByHost := generateCAAndServerCertificates(t, hosts)
+	connConfig, err := getPGConnectionConfig(db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Username:             "dba",
+			Host:                 "pg-1.example.com,pg-2.example.com,pg-3.example.com",
+			Port:                 "5432",
+			UseSsl:               true,
+			VerifyTlsCertificate: true,
+			SslCa:                caPEM,
+		},
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: "lapidlive",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, connConfig.TLSConfig)
+	require.NotNil(t, connConfig.TLSConfig.RootCAs)
+	require.NotNil(t, connConfig.TLSConfig.VerifyPeerCertificate)
+	require.NoError(t, connConfig.TLSConfig.VerifyPeerCertificate([][]byte{serverCertDERByHost[hosts[0]]}, nil))
+	require.Len(t, connConfig.Fallbacks, 2)
+	for i, fallback := range connConfig.Fallbacks {
+		require.NotNil(t, fallback.TLSConfig)
+		require.NotNil(t, fallback.TLSConfig.RootCAs)
+		require.NotNil(t, fallback.TLSConfig.VerifyPeerCertificate)
+		require.NoError(t, fallback.TLSConfig.VerifyPeerCertificate([][]byte{serverCertDERByHost[hosts[i+1]]}, nil))
+	}
+}
+
+func generateClientCertificatePEM(t *testing.T) (string, string) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "bytebase-test-client",
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+		KeyUsage:  x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+		},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return string(certPEM), string(keyPEM)
+}
+
+func generateCAAndServerCertificates(t *testing.T, hosts []string) (string, map[string][]byte) {
+	t.Helper()
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "bytebase-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	serverCertDERByHost := make(map[string][]byte, len(hosts))
+	for i, host := range hosts {
+		serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		serverTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(int64(i + 2)),
+			Subject:      pkix.Name{CommonName: host},
+			DNSNames:     []string{host},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}
+		serverDER, err := x509.CreateCertificate(rand.Reader, serverTemplate, caTemplate, &serverKey.PublicKey, caKey)
+		require.NoError(t, err)
+		serverCertDERByHost[host] = serverDER
+	}
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	return string(caPEM), serverCertDERByHost
 }

--- a/backend/plugin/db/util/ssl.go
+++ b/backend/plugin/db/util/ssl.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
@@ -212,6 +213,7 @@ func configureClientCertificates(ds *storepb.DataSource, cfg *tls.Config) error 
 type SSLMode string
 
 const (
+	sslModeRequire    SSLMode = "require"
 	sslModeVerifyCA   SSLMode = "verify-ca"
 	sslModeVerifyFull SSLMode = "verify-full"
 )
@@ -219,6 +221,9 @@ const (
 // GetPGSSLMode is used only when SSL is enabled.
 // We should consider allowing user to override this default in the future even if SSL is enabled.
 func GetPGSSLMode(ds *storepb.DataSource) SSLMode {
+	if !ds.GetVerifyTlsCertificate() {
+		return sslModeRequire
+	}
 	sslMode := sslModeVerifyFull
 	if ds.GetSslCa() != "" {
 		if ds.GetSshHost() != "" {
@@ -226,4 +231,28 @@ func GetPGSSLMode(ds *storepb.DataSource) SSLMode {
 		}
 	}
 	return sslMode
+}
+
+// ApplyPGTLSConfig applies Bytebase TLS settings to pgx primary and fallback TLS configs.
+func ApplyPGTLSConfig(tlscfg *tls.Config, host string, fallbacks []*pgconn.FallbackConfig) {
+	if tlscfg == nil {
+		return
+	}
+	applyPGTLSConfigForHost(tlscfg, host, tlscfg)
+	for _, fallback := range fallbacks {
+		if fallback != nil && fallback.TLSConfig != nil {
+			applyPGTLSConfigForHost(fallback.TLSConfig, fallback.Host, tlscfg)
+		}
+	}
+}
+
+func applyPGTLSConfigForHost(dst *tls.Config, host string, src *tls.Config) {
+	if len(src.Certificates) > 0 {
+		dst.Certificates = append([]tls.Certificate(nil), src.Certificates...)
+	}
+	if src.VerifyPeerCertificate != nil {
+		dst.RootCAs = src.RootCAs
+		dst.InsecureSkipVerify = src.InsecureSkipVerify
+		dst.VerifyPeerCertificate = CreateCertificateVerifier(src.RootCAs, host)
+	}
 }


### PR DESCRIPTION
## Summary
- Use PostgreSQL-compatible `sslmode=require` when TLS is enabled but server certificate verification is disabled.
- Apply Bytebase TLS settings to pgx primary and fallback TLS configs for multi-host PostgreSQL and CockroachDB data sources.
- Add regression tests covering libpq-style multi-host configs so pgx fallbacks skip server certificate verification, carry mTLS client certificates, and use Bytebase's custom CA verification policy per host.

## Why
For multi-host PostgreSQL-compatible data sources, pgx builds separate TLS configs for the primary host and each fallback host. Bytebase previously patched only the primary host config after `pgx.ParseConfig`, so fallback hosts still used verifying TLS configs and could fail with `x509: certificate signed by unknown authority` even when `VerifyTlsCertificate=false`.

The same primary-only patching also meant inline client certificates and inline CA verification policy were not consistently present on fallback TLS configs. This PR keeps pgx's per-host fallback TLS settings and applies Bytebase's TLS material and verifier per parsed host.

## Pre-PR Checklist
- Breaking change check: no breaking change; this restores the configured TLS behavior for PostgreSQL-compatible multi-host configs.
- Composite-PK query safety: skipped; no `backend/store/` or migrator changes.
- SonarCloud properties: skipped; no new files or directories.

## Test Plan
- [x] `go test -v -count=1 ./backend/plugin/db/pg ./backend/plugin/db/cockroachdb -run 'Test.*ConnectionConfigVerifiesCustomCAForAllHosts'`
- [x] `go test -count=1 ./backend/plugin/db/pg ./backend/plugin/db/cockroachdb ./backend/plugin/db/util`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
