### PR TITLE
fix: preserve task run cancellation error

### DIFF
--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -374,7 +374,7 @@ func executeGhostMigration(ctx context.Context, driverCtx context.Context, task 
 		opts.LogGhostMigrationEnd("")
 		return nil
 	case <-driverCtx.Done():
-		err := errors.New("task canceled")
+		err := errors.Wrap(driverCtx.Err(), "task canceled")
 		opts.LogGhostMigrationEnd(err.Error())
 		abortCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()

--- a/backend/runner/taskrun/database_migrate_executor_test.go
+++ b/backend/runner/taskrun/database_migrate_executor_test.go
@@ -1,12 +1,24 @@
 package taskrun
 
 import (
+	"context"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
+
+func TestWrappedContextCanceledMatchesErrorsIs(t *testing.T) {
+	driverCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := errors.Wrap(driverCtx.Err(), "task canceled")
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "task canceled")
+}
 
 func TestGetPrependStatements(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- Preserve `context.Canceled` when gh-ost task runs are canceled.
- Keep the running task scheduler's existing `errors.Is(err, context.Canceled)` branch working.
- Add a regression test proving `pkg/errors.Wrap` still matches `context.Canceled`.

## Test Plan
- [x] `go test -v -count=1 ./backend/runner/taskrun`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `golangci-lint run --fix --allow-parallel-runners`
- [x] repeated `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- [x] `git diff --check`
