### PR TITLE
chore: bump omni for PG query span

### DIFF
--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -27,7 +27,7 @@ type omniQuerySpanExtractor struct {
 	// Use getDatabaseMetadata() instead of accessing directly.
 	metaCache     map[string]*model.DatabaseMetadata
 	cat           *catalog.Catalog
-	funcBodyCache map[uint32][]base.SourceColumnSet
+	funcBodyCache map[uint32]*funcBodyAnalysis
 	// funcOrigDefs stores the original (non-stubbed) function definitions keyed
 	// by lowercase function name. Used by analyzeFunctionBody to get the real
 	// body when it was stubbed during catalog loading.
@@ -35,8 +35,9 @@ type omniQuerySpanExtractor struct {
 	// funcSourceColumns accumulates table-level access (column="") discovered inside
 	// function bodies. Merged into the top-level QuerySpan.SourceColumns.
 	funcSourceColumns base.SourceColumnSet
-	// funcPredicateColumns accumulates columns used in WHERE/JOIN conditions
-	// inside function bodies. Merged into the top-level QuerySpan.PredicateColumns.
+	// funcPredicateColumns accumulates columns used in fallback WHERE/JOIN
+	// conditions. Function body analysis records predicates separately so callers
+	// can decide whether they enter the top-level QuerySpan.PredicateColumns.
 	funcPredicateColumns base.SourceColumnSet
 	// fallbackCTEMap holds CTE definitions during fallback column extraction.
 	// Set by extractFallbackColumns and used by extractColumnsFromRangeVar
@@ -71,7 +72,7 @@ func newOmniQuerySpanExtractor(defaultDatabase string, searchPath []string, gCtx
 		searchPath:           searchPath,
 		gCtx:                 gCtx,
 		metaCache:            make(map[string]*model.DatabaseMetadata),
-		funcBodyCache:        make(map[uint32][]base.SourceColumnSet),
+		funcBodyCache:        make(map[uint32]*funcBodyAnalysis),
 		funcOrigDefs:         make(map[string]string),
 		funcSourceColumns:    make(base.SourceColumnSet),
 		funcPredicateColumns: make(base.SourceColumnSet),
@@ -814,7 +815,7 @@ func (e *omniQuerySpanExtractor) resolveVar(queryStack []*catalog.Query, v *cata
 		if len(rte.FuncExprs) > 0 {
 			if fc, ok := rte.FuncExprs[0].(*catalog.FuncCallExpr); ok {
 				if proc := e.cat.GetUserProcByOID(fc.FuncOID); proc != nil {
-					bodySets := e.analyzeFunctionBody(proc)
+					bodySets := e.analyzeTableFunctionBody(proc)
 					if colIdx >= 0 && colIdx < len(bodySets) {
 						for k, val := range bodySets[colIdx] {
 							result[k] = val
@@ -1286,7 +1287,7 @@ func (e *omniQuerySpanExtractor) extractColumnsFromRangeFunction(rf *ast.RangeFu
 		if proc := e.lookupUserProcByName(funcName); proc != nil {
 			outNames := getOutputParamNames(proc)
 			if len(outNames) > 0 {
-				bodySets := e.analyzeFunctionBody(proc)
+				bodySets := e.analyzeTableFunctionBody(proc)
 				var results []base.QuerySpanResult
 				for i, name := range outNames {
 					colSet := make(base.SourceColumnSet)
@@ -1448,7 +1449,7 @@ func (e *omniQuerySpanExtractor) tryUserFuncTableSource(selStmt *ast.SelectStmt,
 			if len(outNames) == 0 {
 				continue
 			}
-			bodySets := e.analyzeFunctionBody(proc)
+			bodySets := e.analyzeTableFunctionBody(proc)
 			return e.buildFuncResults(outNames, bodySets, accessesMap)
 		}
 
@@ -1595,7 +1596,7 @@ func (e *omniQuerySpanExtractor) tryMetadataFuncLookup(funcName string, accesses
 	// Use a temporary OID for caching.
 	syntheticProc.OID = uint32(0xFFFF0000 + len(e.funcBodyCache))
 
-	bodySets := e.analyzeFunctionBody(syntheticProc)
+	bodySets := e.analyzeTableFunctionBody(syntheticProc)
 	return e.buildFuncResults(outNames, bodySets, accessesMap)
 }
 

--- a/backend/plugin/parser/pg/query_span_omni_plpgsql.go
+++ b/backend/plugin/parser/pg/query_span_omni_plpgsql.go
@@ -13,22 +13,49 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
+type funcBodyAnalysis struct {
+	sourceColumns    []base.SourceColumnSet
+	predicateColumns base.SourceColumnSet
+}
+
 // analyzeFunctionBody analyzes a user-defined function body and returns per-column
 // source column sets. Results are cached by function OID on the extractor.
 // A nil value in the cache means analysis is in progress (recursion sentinel).
 // On parse errors, it degrades gracefully by returning empty sets.
 func (e *omniQuerySpanExtractor) analyzeFunctionBody(proc *catalog.UserProc) []base.SourceColumnSet {
+	analysis := e.analyzeFunctionBodyForProc(proc)
+	e.mergeFunctionSourceTables(analysis.sourceColumns)
+	mergeSourceColumnSetInto(e.funcPredicateColumns, analysis.predicateColumns)
+	return analysis.sourceColumns
+}
+
+func (e *omniQuerySpanExtractor) analyzeTableFunctionBody(proc *catalog.UserProc) []base.SourceColumnSet {
+	analysis := e.analyzeFunctionBodyForProc(proc)
+	e.mergeFunctionSourceTables(analysis.sourceColumns)
+	return analysis.sourceColumns
+}
+
+func (e *omniQuerySpanExtractor) analyzeFunctionBodyForProc(proc *catalog.UserProc) *funcBodyAnalysis {
 	// Check cache.
 	if cached, ok := e.funcBodyCache[proc.OID]; ok {
 		if cached == nil {
 			// In-progress sentinel — recursive call. Return empty sets.
-			return makeEmptySets(proc)
+			return &funcBodyAnalysis{
+				sourceColumns:    makeEmptySets(proc),
+				predicateColumns: make(base.SourceColumnSet),
+			}
 		}
 		return cached
 	}
 
 	// Store nil sentinel to detect recursion.
 	e.funcBodyCache[proc.OID] = nil
+	outerPredicateColumns := e.funcPredicateColumns
+	bodyPredicateColumns := make(base.SourceColumnSet)
+	e.funcPredicateColumns = bodyPredicateColumns
+	defer func() {
+		e.funcPredicateColumns = outerPredicateColumns
+	}()
 
 	// If the function body was stubbed during catalog loading (to avoid type
 	// validation errors), use the original body from metadata instead.
@@ -52,12 +79,45 @@ func (e *omniQuerySpanExtractor) analyzeFunctionBody(proc *catalog.UserProc) []b
 
 	if err != nil {
 		// On error, cache empty sets so we don't retry.
-		e.funcBodyCache[proc.OID] = makeEmptySets(proc)
+		e.funcBodyCache[proc.OID] = &funcBodyAnalysis{
+			sourceColumns:    makeEmptySets(proc),
+			predicateColumns: make(base.SourceColumnSet),
+		}
 		return e.funcBodyCache[proc.OID]
 	}
 
-	e.funcBodyCache[proc.OID] = result
-	return result
+	e.funcBodyCache[proc.OID] = &funcBodyAnalysis{
+		sourceColumns:    result,
+		predicateColumns: cloneSourceColumnSet(bodyPredicateColumns),
+	}
+	return e.funcBodyCache[proc.OID]
+}
+
+func cloneSourceColumnSet(src base.SourceColumnSet) base.SourceColumnSet {
+	dst := make(base.SourceColumnSet)
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
+}
+
+func mergeSourceColumnSetInto(dst, src base.SourceColumnSet) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+func (e *omniQuerySpanExtractor) mergeFunctionSourceTables(bodySets []base.SourceColumnSet) {
+	for _, colSet := range bodySets {
+		for k := range colSet {
+			e.funcSourceColumns[base.ColumnResource{
+				Server:   k.Server,
+				Database: k.Database,
+				Schema:   k.Schema,
+				Table:    k.Table,
+			}] = true
+		}
+	}
 }
 
 func makeEmptySets(proc *catalog.UserProc) []base.SourceColumnSet {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260509101155-5091fce0322a
+	github.com/bytebase/omni v0.0.0-20260513025254-757a020a5974
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260509101155-5091fce0322a h1:DFSkgKegf9yqinPUKo13O6x7STk3SbRY4eeurJt3WVI=
-github.com/bytebase/omni v0.0.0-20260509101155-5091fce0322a/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260513025254-757a020a5974 h1:5lRFqJXard/WZtAbdf91YHFqnQlD8e0trCD+EpT8k28=
+github.com/bytebase/omni v0.0.0-20260513025254-757a020a5974/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Bump `github.com/bytebase/omni` to `v0.0.0-20260513025254-757a020a5974`.
- Preserve the legacy PG query span behavior where predicates inside table-function bodies do not enter the outer query span.
- Keep function-body predicate data cached separately so expression-function calls can still merge predicates when appropriate.

## Test Plan
- [x] `git diff --check`
- [x] `go test -v -count=1 ./backend/plugin/parser/pg -run '^(TestLoaderIntegration_CorrelatedRangeFunctionSubquery|TestGetQuerySpan)$'`
- [x] `go test -count=1 ./backend/plugin/parser/pg`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Notes
- `govulncheck` is not installed in the local environment. OSV fallback for `github.com/bytebase/omni@v0.0.0-20260513025254-757a020a5974` returned no vulnerabilities.
