### PR TITLE
fix(tsql): upgrade omni for datepart query span

### DIFF
--- a/backend/plugin/parser/tsql/query_span_extractor_omni_test.go
+++ b/backend/plugin/parser/tsql/query_span_extractor_omni_test.go
@@ -558,6 +558,35 @@ func TestOmniQuerySpan_InListAccessTables(t *testing.T) {
 	}, sortedSources(span.SourceColumns))
 }
 
+func TestOmniQuerySpan_CorrelatedExistsWithDateaddDatepart(t *testing.T) {
+	q := newOmniTestExtractor(t, "db")
+	sql := `
+SELECT outer_t.a
+FROM t AS outer_t
+WHERE outer_t.c > DATEADD(HOUR, 2, GETUTCDATE())
+  AND NOT EXISTS (
+    SELECT 1
+    FROM t1 AS inner_t
+    WHERE inner_t.a = outer_t.a
+      AND inner_t.b > outer_t.b
+  )
+ORDER BY outer_t.a
+`
+	span, err := q.getOmniQuerySpan(context.Background(), sql)
+	require.NoError(t, err)
+	require.Len(t, span.Results, 1)
+	require.ElementsMatch(t, []base.ColumnResource{
+		{Database: "db", Schema: "dbo", Table: "t", Column: "a"},
+	}, sortedSources(span.Results[0].SourceColumns))
+	require.ElementsMatch(t, []base.ColumnResource{
+		{Database: "db", Schema: "dbo", Table: "t", Column: "a"},
+		{Database: "db", Schema: "dbo", Table: "t", Column: "b"},
+		{Database: "db", Schema: "dbo", Table: "t", Column: "c"},
+		{Database: "db", Schema: "dbo", Table: "t1", Column: "a"},
+		{Database: "db", Schema: "dbo", Table: "t1", Column: "b"},
+	}, sortedSources(span.PredicateColumns))
+}
+
 // TestOmniQuerySpan_UnresolvedColumnErrors verifies that an unresolvable
 // column reference is surfaced as an error (both from SELECT list and from
 // WHERE predicates) rather than producing a silently-partial span. Matches

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260513025254-757a020a5974
+	github.com/bytebase/omni v0.0.0-20260513072939-39c04c4cca0f
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260513025254-757a020a5974 h1:5lRFqJXard/WZtAbdf91YHFqnQlD8e0trCD+EpT8k28=
-github.com/bytebase/omni v0.0.0-20260513025254-757a020a5974/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260513072939-39c04c4cca0f h1:HL40pxmFDr0/9iGkp1W+Zzyc257SBPiYc0ld6yZf5aM=
+github.com/bytebase/omni v0.0.0-20260513072939-39c04c4cca0f/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Upgrade github.com/bytebase/omni to 39c04c4 to pick up MSSQL datepart parsing fixes.
- Add a synthetic TSQL query span regression test for correlated EXISTS plus DATEADD(HOUR, ...), without using customer SQL.
- Assert predicate lineage contains real table columns and does not treat DATEADD datepart tokens as columns.

## Test Plan
- [x] go test -v -count=1 ./backend/plugin/parser/tsql -run '^(TestOmniQuerySpan_CorrelatedExistsWithDateaddDatepart|TestOmniQuerySpan_SupportedShapes|TestOmniQuerySpan_SubqueryNotFoundPropagates|TestOmniQuerySpan_UnresolvedColumnErrors)$'
- [x] golangci-lint run --allow-parallel-runners
- [x] golangci-lint run --fix --allow-parallel-runners
- [x] go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
- [x] go mod tidy

## Checklist
- No breaking API/schema/proto/config/UI change.
- No backend/store or migrator changes; composite-PK checklist does not apply.
- No new files/directories; SonarCloud properties do not apply.