### PR TITLE
fix(frontend): enlarge table column resize hitbox

### DIFF
--- a/frontend/src/react/components/ui/column-resize-handle.tsx
+++ b/frontend/src/react/components/ui/column-resize-handle.tsx
@@ -16,11 +16,13 @@ export function ColumnResizeHandle({
   return (
     <div
       className={cn(
-        "absolute right-0 top-1/4 h-1/2 w-[3px] cursor-col-resize rounded-full bg-control-bg-hover hover:bg-accent/60 active:bg-accent transition-colors",
+        "group absolute right-[-6px] top-0 z-10 h-full w-3 cursor-col-resize",
         className
       )}
       onMouseDown={onMouseDown}
       onClick={(e) => e.stopPropagation()}
-    />
+    >
+      <span className="pointer-events-none absolute left-1/2 top-1/4 h-1/2 w-[3px] -translate-x-1/2 rounded-full bg-control-bg-hover transition-colors group-hover:bg-accent/60 group-active:bg-accent" />
+    </div>
   );
 }

--- a/frontend/src/react/components/ui/table.test.tsx
+++ b/frontend/src/react/components/ui/table.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { ColumnResizeHandle } from "./column-resize-handle";
 import { TableBody, TableRow } from "./table";
 
 describe("table primitives", () => {
@@ -23,5 +24,14 @@ describe("table primitives", () => {
 
     expect(element.props["data-striped"]).toBe("false");
     expect(element.props.className).toContain("!bg-transparent");
+  });
+
+  test("ColumnResizeHandle uses a raised 12px hitbox around a 3px visual bar", () => {
+    const element = ColumnResizeHandle({ onMouseDown: () => {} });
+
+    expect(element.props.className).toContain("right-[-6px]");
+    expect(element.props.className).toContain("w-3");
+    expect(element.props.className).toContain("z-10");
+    expect(element.props.children.props.className).toContain("w-[3px]");
   });
 });


### PR DESCRIPTION
## Summary
- Increase the shared table column resize handle hitbox while keeping the visible bar narrow.
- Raise the resize hitbox above adjacent table headers so Audit Log and other table-fixed layouts receive pointer events across the divider.
- Add a regression test for the resize handle geometry.

## Test Plan
- [x] pnpm --dir frontend fix
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test
