### PR TITLE
fix: support pgbouncer transaction mode for Postgres

### DIFF
--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -214,6 +214,8 @@ func getPGConnectionConfig(config db.ConnectionConfig) (*pgx.ConnConfig, error) 
 		util.ApplyPGTLSConfig(tlscfg, connConfig.Host, connConfig.Fallbacks)
 	}
 
+	connConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
+	connConfig.StatementCacheCapacity = 0
 	return connConfig, nil
 }
 
@@ -250,7 +252,13 @@ func getRDSConnectionConfig(ctx context.Context, conf db.ConnectionConfig) (*pgx
 	dsn := fmt.Sprintf("host=%s port=%s user=%s password=%s",
 		conf.DataSource.Host, conf.DataSource.Port, conf.DataSource.Username, password,
 	)
-	return pgx.ParseConfig(dsn)
+	config, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return nil, err
+	}
+	config.DefaultQueryExecMode = pgx.QueryExecModeExec
+	config.StatementCacheCapacity = 0
+	return config, nil
 }
 
 // getCloudSQLConnectionConfig returns config for Cloud SQL connector.
@@ -272,6 +280,8 @@ func getCloudSQLConnectionConfig(ctx context.Context, conf db.ConnectionConfig) 
 		return d.Dial(ctx, conf.DataSource.Host)
 	}
 
+	config.DefaultQueryExecMode = pgx.QueryExecModeExec
+	config.StatementCacheCapacity = 0
 	return config, nil
 }
 

--- a/backend/plugin/db/pg/pg.go
+++ b/backend/plugin/db/pg/pg.go
@@ -214,8 +214,16 @@ func getPGConnectionConfig(config db.ConnectionConfig) (*pgx.ConnConfig, error) 
 		util.ApplyPGTLSConfig(tlscfg, connConfig.Host, connConfig.Fallbacks)
 	}
 
-	connConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
-	connConfig.StatementCacheCapacity = 0
+	// Apply pgbouncer-safe defaults unless the user has explicitly configured
+	// them via ExtraConnectionParameters (preserves escape hatches such as
+	// default_query_exec_mode=simple_protocol for non-PostgreSQL-compatible proxies).
+	extraParams := config.DataSource.GetExtraConnectionParameters()
+	if _, ok := extraParams["default_query_exec_mode"]; !ok {
+		connConfig.DefaultQueryExecMode = pgx.QueryExecModeExec
+	}
+	if _, ok := extraParams["statement_cache_capacity"]; !ok {
+		connConfig.StatementCacheCapacity = 0
+	}
 	return connConfig, nil
 }
 

--- a/backend/plugin/db/pg/pg_test.go
+++ b/backend/plugin/db/pg/pg_test.go
@@ -77,6 +77,26 @@ func TestGetPGConnectionConfigUsesPgBouncerCompatibleQueryMode(t *testing.T) {
 	require.Zero(t, connConfig.StatementCacheCapacity)
 }
 
+func TestGetPGConnectionConfigPreservesExplicitQueryExecMode(t *testing.T) {
+	connConfig, err := getPGConnectionConfig(db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Username: "dba",
+			Host:     "proxy.example.com",
+			Port:     "6432",
+			ExtraConnectionParameters: map[string]string{
+				"default_query_exec_mode":  "simple_protocol",
+				"statement_cache_capacity": "128",
+			},
+		},
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: "postgres",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pgx.QueryExecModeSimpleProtocol, connConfig.DefaultQueryExecMode)
+	require.Equal(t, 128, connConfig.StatementCacheCapacity)
+}
+
 func TestGetPGConnectionConfigDisablesTLSVerificationForAllHosts(t *testing.T) {
 	connConfig, err := getPGConnectionConfig(db.ConnectionConfig{
 		DataSource: &storepb.DataSource{

--- a/backend/plugin/db/pg/pg_test.go
+++ b/backend/plugin/db/pg/pg_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/require"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -58,6 +59,22 @@ func TestGetDatabaseInCreateDatabaseStatement(t *testing.T) {
 		}
 		require.Equal(t, test.want, got)
 	}
+}
+
+func TestGetPGConnectionConfigUsesPgBouncerCompatibleQueryMode(t *testing.T) {
+	connConfig, err := getPGConnectionConfig(db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Username: "dba",
+			Host:     "pgbouncer.example.com",
+			Port:     "6432",
+		},
+		ConnectionContext: db.ConnectionContext{
+			DatabaseName: "postgres",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, pgx.QueryExecModeExec, connConfig.DefaultQueryExecMode)
+	require.Zero(t, connConfig.StatementCacheCapacity)
 }
 
 func TestGetPGConnectionConfigDisablesTLSVerificationForAllHosts(t *testing.T) {


### PR DESCRIPTION
## Summary
- Disable pgx statement cache for Postgres connections by using QueryExecModeExec and zero statement cache capacity.
- Apply the setting across password, AWS RDS IAM, and Cloud SQL IAM Postgres connection configs.
- Add regression coverage for the pgbouncer-compatible query mode.

## Testing
- gofmt -w backend/plugin/db/pg/pg.go backend/plugin/db/pg/pg_test.go
- go test -v -count=1 ./backend/plugin/db/pg -run '^TestGetPGConnectionConfig'\n- golangci-lint run --allow-parallel-runners\n- golangci-lint run --fix --allow-parallel-runners\n- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go\n\n## Pre-PR Checklist\n- Breaking change check: no breaking change; this avoids session-scoped prepared statement cache for pgbouncer transaction pooling compatibility.\n- Composite-PK query safety: skipped, no backend/store or migrator changes.\n- Frontend/proto/migration/Sonar checks: skipped, not applicable.