### PR TITLE
chore: bump omni for PostgreSQL default validation

### DIFF
--- a/backend/plugin/schema/pg/testdata/walk_through.yaml
+++ b/backend/plugin/schema/pg/testdata/walk_through.yaml
@@ -71,3 +71,15 @@
   ignore_case_sensitive: false
   want: ""
   advice: null
+- statement: CREATE TABLE t_default_identifier(a text DEFAULT "status");
+  ignore_case_sensitive: false
+  want: ""
+  advice:
+    code: 260
+    content: "ERROR: cannot use column reference in DEFAULT expression (SQLSTATE 0A000)"
+- statement: CREATE TABLE t_default_column(a int, b int DEFAULT a);
+  ignore_case_sensitive: false
+  want: ""
+  advice:
+    code: 260
+    content: "ERROR: cannot use column reference in DEFAULT expression (SQLSTATE 0A000)"

--- a/backend/plugin/schema/pg/walk_through_test.go
+++ b/backend/plugin/schema/pg/walk_through_test.go
@@ -99,12 +99,13 @@ func TestWalkThrough(t *testing.T) {
 		stmts, _ := sm.GetStatementsForChecks(storepb.Engine_POSTGRES, test.Statement)
 		asts := base.ExtractASTs(stmts)
 		advice := WalkThroughWithContext(schema.WalkThroughContext{RawSQL: test.Statement}, state, asts)
+		if test.Advice != nil {
+			require.NotNil(t, advice)
+			require.Equal(t, test.Advice.Code, advice.Code)
+			require.Equal(t, test.Advice.Content, advice.Content)
+			continue
+		}
 		if advice != nil {
-			// Compare the advice fields
-			if test.Advice != nil {
-				require.Equal(t, test.Advice.Code, advice.Code)
-				require.Equal(t, test.Advice.Content, advice.Content)
-			}
 			continue
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260513072939-39c04c4cca0f
+	github.com/bytebase/omni v0.0.0-20260514025606-97e2637df6e9
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260513072939-39c04c4cca0f h1:HL40pxmFDr0/9iGkp1W+Zzyc257SBPiYc0ld6yZf5aM=
-github.com/bytebase/omni v0.0.0-20260513072939-39c04c4cca0f/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260514025606-97e2637df6e9 h1:0XFNGB4qxFlUrpEIfqXOlrgLsvny3gYQpIgRh0/MXtI=
+github.com/bytebase/omni v0.0.0-20260514025606-97e2637df6e9/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Bump `github.com/bytebase/omni` to include PostgreSQL column DEFAULT semantic validation.
- Add PostgreSQL walk-through regression cases for identifier and column-reference defaults without using customer SQL.
- Require YAML walk-through cases with expected advice to actually receive advice.

## Test Plan
- [x] `go test ./backend/plugin/schema/pg -run '^TestWalkThrough$' -count=1`
- [x] `go test ./backend/plugin/schema/pg -count=1`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
