### PR TITLE
fix(plan-detail): show why Create / Ready-for-Review is disabled and simplify run history

### DIFF
--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -1652,6 +1652,7 @@
   "plan.targets.non-env-warning.other": "{{count}} databases will be excluded from rollout because they have no effective environment:",
   "plan.targets.title": "Targets",
   "plan.targets.view-all": "View all ({{count}})",
+  "plan.title-required": "Title is required",
   "plan.view-discussion": "View discussion",
   "plugin": {
     "ai": {

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -1644,6 +1644,7 @@
   "plan.targets.non-env-warning.other": "{{count}} bases de datos se excluirán del despliegue porque no tienen un entorno efectivo:",
   "plan.targets.title": "Objetivos",
   "plan.targets.view-all": "Ver todo ({{count}})",
+  "plan.title-required": "El título es obligatorio",
   "plan.view-discussion": "Ver discusión",
   "plugin": {
     "ai": {

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -1644,6 +1644,7 @@
   "plan.targets.non-env-warning.other": "有効な環境がないため、{{count}} 件のデータベースはロールアウトから除外されます:",
   "plan.targets.title": "対象",
   "plan.targets.view-all": "すべて表示 ({{count}})",
+  "plan.title-required": "タイトルは必須です",
   "plan.view-discussion": "ディスカッションを見る",
   "plugin": {
     "ai": {

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -1644,6 +1644,7 @@
   "plan.targets.non-env-warning.other": "{{count}} cơ sở dữ liệu sẽ bị loại khỏi rollout vì không có môi trường hiệu lực:",
   "plan.targets.title": "Mục tiêu",
   "plan.targets.view-all": "Xem tất cả ({{count}})",
+  "plan.title-required": "Tiêu đề là bắt buộc",
   "plan.view-discussion": "Xem thảo luận",
   "plugin": {
     "ai": {

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -1644,6 +1644,7 @@
   "plan.targets.non-env-warning.other": "{{count}} 个数据库因为没有生效环境，将不会进入发布:",
   "plan.targets.title": "目标",
   "plan.targets.view-all": "查看全部 ({{count}})",
+  "plan.title-required": "标题不能为空",
   "plan.view-discussion": "查看讨论",
   "plugin": {
     "ai": {

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
@@ -15,6 +15,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/react/components/ui/popover";
+import { Tooltip } from "@/react/components/ui/tooltip";
 import { cn } from "@/react/lib/utils";
 import { router } from "@/router";
 import {
@@ -327,6 +328,17 @@ export function PlanDetailHeader() {
     }
   };
 
+  const createPlanDisabledReasons = useMemo(() => {
+    const reasons: string[] = [];
+    if (!page.plan.title.trim()) {
+      reasons.push(t("plan.title-required"));
+    }
+    if (emptySpecIdSet.size > 0) {
+      reasons.push(t("plan.navigator.statement-empty"));
+    }
+    return reasons;
+  }, [emptySpecIdSet.size, page.plan.title, t]);
+
   const createIssueBlockingErrors = useMemo(
     () =>
       getCreateIssueBlockingErrors({
@@ -345,20 +357,11 @@ export function PlanDetailHeader() {
     () =>
       getCreateIssueConfirmErrors({
         blockingErrors: createIssueBlockingErrors,
-        checksWarningAcknowledged,
         project,
         selectedLabelCount: selectedLabels.length,
-        showChecksWarning,
         t,
       }),
-    [
-      checksWarningAcknowledged,
-      createIssueBlockingErrors,
-      project,
-      selectedLabels.length,
-      showChecksWarning,
-      t,
-    ]
+    [createIssueBlockingErrors, project, selectedLabels.length, t]
   );
 
   const resetReviewPopoverDraft = () => {
@@ -474,15 +477,25 @@ export function PlanDetailHeader() {
 
         <div className="flex shrink-0 items-center gap-x-2">
           {page.isCreating ? (
-            <Button
-              disabled={
-                updating || !page.plan.title.trim() || emptySpecIdSet.size > 0
+            <Tooltip
+              content={
+                createPlanDisabledReasons.length > 0 ? (
+                  <div className="flex flex-col gap-y-1">
+                    {createPlanDisabledReasons.map((reason) => (
+                      <span key={reason}>{reason}</span>
+                    ))}
+                  </div>
+                ) : null
               }
-              onClick={() => void handleCreatePlan()}
             >
-              {updating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {t("common.create")}
-            </Button>
+              <Button
+                disabled={updating || createPlanDisabledReasons.length > 0}
+                onClick={() => void handleCreatePlan()}
+              >
+                {updating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {t("common.create")}
+              </Button>
+            </Tooltip>
           ) : (
             <>
               {showSubmitForReview && (
@@ -745,7 +758,11 @@ function ReadyForReviewPopoverContent({
       )}
       <div className="flex justify-start gap-x-2 pt-1">
         <Button
-          disabled={confirmErrors.length > 0 || submitting}
+          disabled={
+            confirmErrors.length > 0 ||
+            (showChecksWarning && !checksWarningAcknowledged) ||
+            submitting
+          }
           onClick={onConfirm}
           size="sm"
         >

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployStageContentSidebar.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployStageContentSidebar.tsx
@@ -9,20 +9,21 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
-import { router } from "@/router";
-import { useUserStore } from "@/store";
+import { useDatabaseV1Store, useUserStore } from "@/store";
 import { getDateForPbTimestampProtoEs } from "@/types";
 import {
   type Stage,
-  Task_Status,
+  type TaskRun,
   TaskRun_Status,
 } from "@/types/proto-es/v1/rollout_service_pb";
-import { extractDatabaseResourceName, humanizeDate } from "@/utils";
+import { humanizeDate } from "@/utils";
+import { extractTaskNameFromTaskRunName } from "@/utils/v1/issue/rollout";
 import { usePlanDetailContext } from "../../shell/PlanDetailContext";
+import { DatabaseTarget } from "../PlanDetailChangesBranch";
 import { PlanDetailRollbackSheet } from "../PlanDetailRollbackSheet";
-import { PlanDetailTaskRunTable } from "../PlanDetailTaskRunTable";
+import { PlanDetailTaskRunDetail } from "../PlanDetailTaskRunDetail";
 import { DeployTaskStatus } from "./DeployTaskStatus";
-import { getTaskRunDuration } from "./taskRunUtils";
+import { getTaskRunDuration, taskRunStatusToTaskStatus } from "./taskRunUtils";
 import type { RollbackItem } from "./types";
 
 const MAX_DISPLAY_ITEMS = 10;
@@ -31,19 +32,33 @@ export function DeployStageContentSidebar({ stage }: { stage: Stage }) {
   const { t } = useTranslation();
   const page = usePlanDetailContext();
   const userStore = useUserStore();
+  const databaseStore = useDatabaseV1Store();
   const [rollbackOpen, setRollbackOpen] = useState(false);
-  const [detailOpen, setDetailOpen] = useState(false);
+  const [selectedTaskRun, setSelectedTaskRun] = useState<TaskRun | undefined>();
   const [creatorTitleByRun, setCreatorTitleByRun] = useState<
     Record<string, string>
   >({});
 
+  const tasksByName = useMemo(
+    () => new Map(stage.tasks.map((task) => [task.name, task])),
+    [stage.tasks]
+  );
+
+  const selectedDatabaseEngine = useMemo(() => {
+    if (!selectedTaskRun) return undefined;
+    const target = tasksByName.get(
+      extractTaskNameFromTaskRunName(selectedTaskRun.name)
+    )?.target;
+    return target
+      ? databaseStore.getDatabaseByName(target).instanceResource?.engine
+      : undefined;
+  }, [databaseStore, selectedTaskRun, tasksByName]);
+
   const stageTaskRuns = useMemo(() => {
-    const taskNames = new Set(stage.tasks.map((task) => task.name));
-    return page.taskRuns.filter((taskRun) => {
-      const taskName = taskRun.name.replace(/\/taskRuns\/[^/]+$/, "");
-      return taskNames.has(taskName);
-    });
-  }, [page.taskRuns, stage.tasks]);
+    return page.taskRuns.filter((taskRun) =>
+      tasksByName.has(extractTaskNameFromTaskRunName(taskRun.name))
+    );
+  }, [page.taskRuns, tasksByName]);
 
   const sortedTaskRuns = useMemo(() => {
     return [...stageTaskRuns].sort((left, right) => {
@@ -138,69 +153,35 @@ export function DeployStageContentSidebar({ stage }: { stage: Stage }) {
 
             <div className="flex flex-col gap-y-2 overflow-y-auto px-3 pb-3 pt-1">
               {displayedTaskRuns.map((taskRun) => {
-                const taskName = taskRun.name.replace(/\/taskRuns\/[^/]+$/, "");
-                const task = stage.tasks.find((item) => item.name === taskName);
-                const target = task?.target
-                  ? extractDatabaseResourceName(task.target)
-                  : undefined;
+                const task = tasksByName.get(
+                  extractTaskNameFromTaskRunName(taskRun.name)
+                );
+                if (!task) return null;
                 const creatorTitle = creatorTitleByRun[taskRun.name] ?? "";
                 const duration = getTaskRunDuration(taskRun);
                 const updateDate = taskRun.updateTime
                   ? getDateForPbTimestampProtoEs(taskRun.updateTime)
                   : undefined;
                 return (
-                  <div key={taskRun.name} className="flex items-start gap-2">
+                  <button
+                    key={taskRun.name}
+                    className="flex w-full items-start gap-2 rounded-sm px-1 py-1 text-left hover:bg-gray-50"
+                    onClick={() => setSelectedTaskRun(taskRun)}
+                    type="button"
+                  >
                     <div className="pt-0.5">
                       <DeployTaskStatus
                         size="small"
-                        status={
-                          taskRun.status === TaskRun_Status.DONE
-                            ? Task_Status.DONE
-                            : taskRun.status === TaskRun_Status.FAILED
-                              ? Task_Status.FAILED
-                              : taskRun.status === TaskRun_Status.RUNNING
-                                ? Task_Status.RUNNING
-                                : taskRun.status === TaskRun_Status.PENDING ||
-                                    taskRun.status === TaskRun_Status.AVAILABLE
-                                  ? Task_Status.PENDING
-                                  : Task_Status.CANCELED
-                        }
+                        status={taskRunStatusToTaskStatus(taskRun.status)}
                       />
                     </div>
                     <div className="-mt-0.5 min-w-0 flex-1 px-1 py-0.5">
-                      <button
-                        className="truncate text-left text-sm leading-4 text-gray-700 hover:underline"
-                        onClick={() => {
-                          if (!task) return;
-                          void router.push({
-                            query: {
-                              phase: "deploy",
-                              stageId: stage.name.split("/").pop(),
-                              taskId: task.name.split("/").pop(),
-                            },
-                          });
-                        }}
-                        type="button"
-                      >
-                        {target?.instance ? (
-                          <span className="text-gray-500">
-                            {target.instance}
-                            <span className="mx-0.5 text-gray-400">/</span>
-                          </span>
-                        ) : null}
-                        <span>
-                          {target?.databaseName ?? task?.target ?? ""}
-                        </span>
-                      </button>
+                      <DatabaseTarget target={task.target} />
                       {taskRun.status === TaskRun_Status.FAILED &&
                         taskRun.detail && (
-                          <button
-                            className="mt-0.5 line-clamp-3 text-left text-xs text-error hover:underline"
-                            onClick={() => setDetailOpen(true)}
-                            type="button"
-                          >
+                          <div className="mt-0.5 line-clamp-3 text-xs text-error">
                             {taskRun.detail}
-                          </button>
+                          </div>
                         )}
                       <div className="mt-0.5 flex items-center gap-1 text-xs text-gray-400">
                         <span>
@@ -210,7 +191,7 @@ export function DeployStageContentSidebar({ stage }: { stage: Stage }) {
                         {duration && <span>· {duration}</span>}
                       </div>
                     </div>
-                  </div>
+                  </button>
                 );
               })}
               {sortedTaskRuns.length > MAX_DISPLAY_ITEMS && (
@@ -235,13 +216,21 @@ export function DeployStageContentSidebar({ stage }: { stage: Stage }) {
         />
       )}
 
-      <Sheet onOpenChange={setDetailOpen} open={detailOpen}>
+      <Sheet
+        onOpenChange={(open) => !open && setSelectedTaskRun(undefined)}
+        open={Boolean(selectedTaskRun)}
+      >
         <SheetContent width="wide">
           <SheetHeader>
             <SheetTitle>{t("common.detail")}</SheetTitle>
           </SheetHeader>
           <SheetBody>
-            <PlanDetailTaskRunTable taskRuns={sortedTaskRuns} />
+            {selectedTaskRun && (
+              <PlanDetailTaskRunDetail
+                databaseEngine={selectedDatabaseEngine}
+                taskRun={selectedTaskRun}
+              />
+            )}
           </SheetBody>
         </SheetContent>
       </Sheet>

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/taskRunUtils.ts
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/taskRunUtils.ts
@@ -1,5 +1,23 @@
 import type { TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
-import { TaskRun_Status } from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  Task_Status,
+  TaskRun_Status,
+} from "@/types/proto-es/v1/rollout_service_pb";
+
+const TASK_RUN_STATUS_TO_TASK_STATUS: Partial<
+  Record<TaskRun_Status, Task_Status>
+> = {
+  [TaskRun_Status.DONE]: Task_Status.DONE,
+  [TaskRun_Status.FAILED]: Task_Status.FAILED,
+  [TaskRun_Status.RUNNING]: Task_Status.RUNNING,
+  [TaskRun_Status.PENDING]: Task_Status.PENDING,
+  [TaskRun_Status.AVAILABLE]: Task_Status.PENDING,
+};
+
+export const taskRunStatusToTaskStatus = (
+  status: TaskRun_Status
+): Task_Status =>
+  TASK_RUN_STATUS_TO_TASK_STATUS[status] ?? Task_Status.CANCELED;
 
 const formatDuration = (durationMs: number): string => {
   const seconds = Math.floor(durationMs / 1000);

--- a/frontend/src/react/pages/project/plan-detail/utils/header.test.ts
+++ b/frontend/src/react/pages/project/plan-detail/utils/header.test.ts
@@ -31,7 +31,7 @@ describe("plan detail header create issue helpers", () => {
     );
   });
 
-  test("requires acknowledgement for non-blocking check warnings", () => {
+  test("flags non-blocking check warnings without adding a confirm error", () => {
     const plan = makePlan(["changeDatabaseConfig"], { ERROR: 1 });
     const project = {
       enforceSqlReview: false,
@@ -49,20 +49,8 @@ describe("plan detail header create issue helpers", () => {
     expect(
       getCreateIssueConfirmErrors({
         blockingErrors,
-        checksWarningAcknowledged: false,
         project,
         selectedLabelCount: 0,
-        showChecksWarning: true,
-        t,
-      })
-    ).toContain("issue.checks-warning-hint");
-    expect(
-      getCreateIssueConfirmErrors({
-        blockingErrors,
-        checksWarningAcknowledged: true,
-        project,
-        selectedLabelCount: 0,
-        showChecksWarning: true,
         t,
       })
     ).toEqual([]);

--- a/frontend/src/react/pages/project/plan-detail/utils/header.ts
+++ b/frontend/src/react/pages/project/plan-detail/utils/header.ts
@@ -65,27 +65,20 @@ export const getCreateIssueBlockingErrors = ({
 };
 
 export const getCreateIssueConfirmErrors = ({
-  checksWarningAcknowledged,
   blockingErrors,
   project,
   selectedLabelCount,
-  showChecksWarning,
   t,
 }: {
   blockingErrors: string[];
-  checksWarningAcknowledged: boolean;
   project: Pick<Project, "forceIssueLabels">;
   selectedLabelCount: number;
-  showChecksWarning: boolean;
   t: T;
 }): string[] => {
   const errors = [...blockingErrors];
 
   if (project.forceIssueLabels && selectedLabelCount === 0) {
     errors.push(t("plan.labels-required-for-review"));
-  }
-  if (showChecksWarning && !checksWarningAcknowledged) {
-    errors.push(t("issue.checks-warning-hint"));
   }
 
   return errors;


### PR DESCRIPTION
## Summary
- **BYT-9522 — Create plan disabled reasons.** The header "Create" button (creating mode) now wraps in a Tooltip that lists the reasons it's disabled: missing title (`plan.title-required`, new key, 5 locales) and empty statement specs (`plan.navigator.statement-empty`). Previously the button was disabled with no explanation.
- **Ready-for-Review popover de-duplication.** Removed the duplicate "Some checks did not pass…" red error in the popover. The orange warning banner + "Confirm anyway" checkbox are the single source of truth; Confirm is now gated directly on `showChecksWarning && !checksWarningAcknowledged`.
- **Stage Run History row simplified.** Single interaction: click anywhere on the row → drawer renders `PlanDetailTaskRunDetail` (logs/session tabs) for that run. Dropped the previous mix of router-push-to-task and open-full-history-table affordances, plus the failure-detail click target (now a plain truncated red line).
- **Run History row title** uses `<DatabaseTarget target={task.target} />` (engine icon + instance / database) to match the task card.
- **Internal cleanup.** Added `taskRunStatusToTaskStatus` helper to replace a 5-level nested ternary; adopted `extractTaskNameFromTaskRunName` instead of inline regex; introduced a shared `tasksByName` Map so each row's task lookup and the drawer's database-engine lookup share one allocation (also avoids per-render `unknownDatabase()` proto allocation when a database isn't yet cached).

## Test plan
- [ ] Plan-creation mode: with empty title → Create button disabled, hover tooltip shows "Title is required". Add empty statement spec → tooltip lists both reasons.
- [ ] Plan-edit mode: Ready-for-Review popover with failing checks → orange banner appears, Confirm stays disabled until the "Confirm anyway" checkbox is checked, no red duplicate error.
- [ ] Deploy phase → Stage sidebar Run History: click any row, drawer opens to that run's logs / session. Failure detail still shows in red but is non-interactive. No old "full run history table" sheet path remains.
- [ ] \`pnpm --dir frontend type-check\`, \`pnpm --dir frontend test\`, \`pnpm --dir frontend fix\` clean (run locally).

Closes BYT-9522.

🤖 Generated with [Claude Code](https://claude.com/claude-code)