### PR TITLE
fix(plan-list): wire creator advanced-search to onSearch API

### DIFF
--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -184,35 +184,25 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
         id: "creator",
         title: t("issue.advanced-search.scope.creator.title"),
         description: t("issue.advanced-search.scope.creator.description"),
-        search: async ({
-          keyword,
-          nextPageToken,
-        }: {
-          keyword: string;
-          nextPageToken?: string;
-        }) => {
+        onSearch: async (keyword: string) => {
           const resp = await userStore.fetchUserList({
-            pageToken: nextPageToken,
             pageSize: getDefaultPagination(),
             filter: { query: keyword },
           });
-          return {
-            nextPageToken: resp.nextPageToken,
-            options: resp.users.map<ValueOption>((user) => ({
-              value: user.email,
-              keywords: [user.email, user.title],
-              render: () => (
-                <div className="flex items-center gap-x-1">
-                  <span>{user.title}</span>
-                  {user.name === me?.name && (
-                    <span className="text-xs text-control-light">
-                      ({t("common.you")})
-                    </span>
-                  )}
-                </div>
-              ),
-            })),
-          };
+          return resp.users.map<ValueOption>((user) => ({
+            value: user.email,
+            keywords: [user.email, user.title],
+            render: () => (
+              <div className="flex items-center gap-x-1">
+                <span>{user.title}</span>
+                {user.name === me?.name && (
+                  <span className="text-xs text-control-light">
+                    ({t("common.you")})
+                  </span>
+                )}
+              </div>
+            ),
+          }));
         },
       },
     ],


### PR DESCRIPTION
## Summary
- The creator scope in the plan list page used `search` with a `{ keyword, nextPageToken }` signature, but `AdvancedSearch` only recognizes `onSearch: (keyword) => Promise<ValueOption[]>` — so `isAsyncScope` stayed false and no users were ever fetched.
- Renamed the field to `onSearch` and aligned the signature with the issue list's `useIssueSearchScopeOptions`, restoring the creator dropdown.
- Backend wiring is unchanged: `buildPlanFindBySearchParams` already reads the scope value (email) and prefixes `users/`.

## Test plan
- [ ] Open a project's Plans tab, click the search bar, pick `creator:`, and confirm the user list loads and filters by keyword
- [ ] Select a creator and confirm the plan list narrows to that user's plans
- [ ] Remove the scope and confirm the list resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)