### PR TITLE
fix(pg): support event trigger SDL migration

### DIFF
--- a/backend/plugin/schema/pg/event_trigger_sdl_output_test.go
+++ b/backend/plugin/schema/pg/event_trigger_sdl_output_test.go
@@ -1,0 +1,86 @@
+package pg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+	"github.com/bytebase/bytebase/backend/store/model"
+)
+
+func TestEventTriggerSDLSingleFileOutput(t *testing.T) {
+	metadata := eventTriggerSDLMetadata()
+
+	result, err := GetDatabaseDefinition(schema.GetDefinitionContext{SDLFormat: true}, metadata)
+	require.NoError(t, err)
+	assert.Contains(t, result, `CREATE FUNCTION "public"."audit_ddl"() RETURNS event_trigger`)
+	assert.Contains(t, result, `CREATE EVENT TRIGGER "audit_ddl_start" ON ddl_command_start`)
+	assert.Contains(t, result, `WHEN TAG IN ('CREATE TABLE')`)
+	assert.Contains(t, result, `EXECUTE FUNCTION "public"."audit_ddl"();`)
+	assert.Contains(t, result, `COMMENT ON EVENT TRIGGER "audit_ddl_start" IS 'Audit DDL start';`)
+
+	sdl, err := schema.MetadataToSDL(
+		storepb.Engine_POSTGRES,
+		model.NewDatabaseMetadata(metadata, nil, nil, storepb.Engine_POSTGRES, true),
+	)
+	require.NoError(t, err)
+	assert.Contains(t, sdl, `CREATE EVENT TRIGGER "audit_ddl_start" ON ddl_command_start`)
+	assert.Contains(t, sdl, `COMMENT ON EVENT TRIGGER "audit_ddl_start" IS 'Audit DDL start';`)
+}
+
+func TestEventTriggerSDLMultiFileOutput(t *testing.T) {
+	result, err := GetMultiFileDatabaseDefinition(
+		schema.GetDefinitionContext{SDLFormat: true},
+		eventTriggerSDLMetadata(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	fileMap := make(map[string]string)
+	for _, file := range result.Files {
+		fileMap[file.Name] = file.Content
+	}
+
+	eventTriggerFile, ok := fileMap["event_triggers.sql"]
+	require.True(t, ok, "event_triggers.sql file should exist")
+	assert.Contains(t, eventTriggerFile, `CREATE EVENT TRIGGER "audit_ddl_start" ON ddl_command_start`)
+	assert.Contains(t, eventTriggerFile, `WHEN TAG IN ('CREATE TABLE')`)
+	assert.Contains(t, eventTriggerFile, `EXECUTE FUNCTION "public"."audit_ddl"();`)
+	assert.Contains(t, eventTriggerFile, `COMMENT ON EVENT TRIGGER "audit_ddl_start" IS 'Audit DDL start';`)
+}
+
+func eventTriggerSDLMetadata() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Functions: []*storepb.FunctionMetadata{
+					{
+						Name:      "audit_ddl",
+						Signature: "audit_ddl()",
+						Definition: `CREATE FUNCTION "public"."audit_ddl"() RETURNS event_trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+END;
+$$`,
+					},
+				},
+			},
+		},
+		EventTriggers: []*storepb.EventTriggerMetadata{
+			{
+				Name:           "audit_ddl_start",
+				Event:          "ddl_command_start",
+				Tags:           []string{"CREATE TABLE"},
+				FunctionSchema: "public",
+				FunctionName:   "audit_ddl",
+				Enabled:        true,
+				Comment:        "Audit DDL start",
+			},
+		},
+	}
+}

--- a/backend/plugin/schema/pg/sdl_migration_omni_test.go
+++ b/backend/plugin/schema/pg/sdl_migration_omni_test.go
@@ -7,7 +7,41 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bytebase/omni/pg/catalog"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
+
+const eventTriggerFunctionSDL = `
+CREATE FUNCTION audit_ddl() RETURNS event_trigger
+LANGUAGE plpgsql AS $$
+BEGIN
+END;
+$$;
+`
+
+const eventTriggerSDL = eventTriggerFunctionSDL + `
+CREATE EVENT TRIGGER audit_ddl_start
+	ON ddl_command_start
+	WHEN TAG IN ('CREATE TABLE')
+	EXECUTE FUNCTION audit_ddl();
+`
+
+const eventTriggerModifiedSDL = eventTriggerFunctionSDL + `
+CREATE EVENT TRIGGER audit_ddl_start
+	ON ddl_command_end
+	WHEN TAG IN ('CREATE TABLE')
+	EXECUTE FUNCTION audit_ddl();
+`
+
+const eventTriggerFunctionOnlySDL = eventTriggerFunctionSDL
+
+func diffPostgresSDL(t *testing.T, fromSDL, toSDL string) string {
+	t.Helper()
+	sql, err := schema.DiffSDLMigration(storepb.Engine_POSTGRES, strings.TrimSpace(fromSDL), strings.TrimSpace(toSDL))
+	require.NoError(t, err)
+	return sql
+}
 
 // omniSDLMigration is a test helper that runs the omni SDL migration pipeline:
 // from = LoadSDL(fromSDL), to = LoadSDL(toSDL), Diff, GenerateMigration.
@@ -225,6 +259,69 @@ func TestOmniSDLMigration_CreateTrigger(t *testing.T) {
 	`)
 	require.Contains(t, sql, "CREATE TRIGGER")
 	require.Contains(t, sql, "trg_update_timestamp")
+}
+
+func TestOmniSDLMigration_EventTriggerSourceSDL(t *testing.T) {
+	sdl := `
+		CREATE FUNCTION audit_ddl() RETURNS event_trigger
+		LANGUAGE plpgsql AS $$
+		BEGIN
+		END;
+		$$;
+
+		CREATE EVENT TRIGGER audit_ddl_start
+			ON ddl_command_start
+			WHEN TAG IN ('CREATE TABLE')
+			EXECUTE FUNCTION audit_ddl();
+	`
+	sql := omniSDLMigration(t, sdl, sdl)
+	require.Empty(t, sql)
+}
+
+func TestDiffSDLMigration_EventTriggerChanges(t *testing.T) {
+	tests := []struct {
+		name     string
+		fromSDL  string
+		toSDL    string
+		contains []string
+	}{
+		{
+			name:    "add event trigger",
+			fromSDL: eventTriggerFunctionOnlySDL,
+			toSDL:   eventTriggerSDL,
+			contains: []string{
+				`CREATE EVENT TRIGGER "audit_ddl_start" ON "ddl_command_start"`,
+				`WHEN TAG IN ('CREATE TABLE')`,
+				`EXECUTE FUNCTION "public"."audit_ddl"()`,
+			},
+		},
+		{
+			name:    "drop event trigger",
+			fromSDL: eventTriggerSDL,
+			toSDL:   eventTriggerFunctionOnlySDL,
+			contains: []string{
+				`DROP EVENT TRIGGER "audit_ddl_start"`,
+			},
+		},
+		{
+			name:    "modify event trigger",
+			fromSDL: eventTriggerSDL,
+			toSDL:   eventTriggerModifiedSDL,
+			contains: []string{
+				`DROP EVENT TRIGGER "audit_ddl_start"`,
+				`CREATE EVENT TRIGGER "audit_ddl_start" ON "ddl_command_end"`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sql := diffPostgresSDL(t, tt.fromSDL, tt.toSDL)
+			for _, want := range tt.contains {
+				require.Contains(t, sql, want)
+			}
+		})
+	}
 }
 
 func TestOmniSDLMigration_Comment(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260514025606-97e2637df6e9
+	github.com/bytebase/omni v0.0.0-20260514035324-696c014a2eb6
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260514025606-97e2637df6e9 h1:0XFNGB4qxFlUrpEIfqXOlrgLsvny3gYQpIgRh0/MXtI=
-github.com/bytebase/omni v0.0.0-20260514025606-97e2637df6e9/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260514035324-696c014a2eb6 h1:TO+6vcgImaB7GHGCjo/JKC2OBQ2AJamYxEa2EsaiBJs=
+github.com/bytebase/omni v0.0.0-20260514035324-696c014a2eb6/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Bump `github.com/bytebase/omni` to include event trigger support in the PG SDL catalog.
- Add SDL regression coverage for source schemas containing `CREATE EVENT TRIGGER`.
- Add Bytebase wrapper/output tests for event trigger SDL generation, multi-file output, and add/drop/modify SDL migrations.

## Test Plan
- [x] `go test ./backend/plugin/schema/pg -run 'SDL|Omni|GetMultiFileDatabaseDefinition|MetadataToSDL' -count=1`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `golangci-lint run --fix --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- [x] `git diff --check`

## Pre-PR Checklist
- Breaking change check: not applicable; this fixes PG SDL migration handling and adds tests.
- Composite-PK query safety: skipped; no `backend/store/` or `backend/migrator/` changes.
- SonarCloud properties: no update needed; new file is covered by existing `backend/**/*_test.go` test inclusions and CPD exclusions.
