### PR TITLE
chore(frontend): use shared select for schema picker

### DIFF
--- a/frontend/src/react/pages/project/database-detail/overview/DatabaseObjectExplorer.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/DatabaseObjectExplorer.test.tsx
@@ -263,6 +263,42 @@ beforeEach(async () => {
 });
 
 describe("DatabaseObjectExplorer", () => {
+  test("renders the default schema label when the schema name is empty", async () => {
+    mocks.useDBSchemaV1Store.mockReturnValue({
+      getSchemaList: vi.fn(() => [{ name: "" }]),
+      getTableList: vi.fn(() => []),
+      getViewList: vi.fn(() => []),
+      getExtensionList: vi.fn(() => []),
+      getExternalTableList: vi.fn(() => []),
+      getFunctionList: vi.fn(() => []),
+      getDatabaseMetadata: vi.fn(() => ({
+        schemas: [],
+      })),
+    });
+
+    const { container, render, unmount } = renderIntoContainer(
+      createElement(DatabaseObjectExplorer, {
+        database: makeDatabase(),
+        loading: false,
+        selectedSchemaName: "",
+        tableSearchKeyword: "",
+        externalTableSearchKeyword: "",
+        onSelectedSchemaNameChange: vi.fn(),
+        onTableSearchKeywordChange: vi.fn(),
+        onExternalTableSearchKeywordChange: vi.fn(),
+      })
+    );
+
+    render();
+    await flush();
+
+    expect(container.querySelector("#schema-select")?.textContent).toContain(
+      "db.schema.default"
+    );
+
+    unmount();
+  });
+
   test("passes serializable detail props after selecting a table row", async () => {
     const { container, render, unmount } = renderIntoContainer(
       createElement(DatabaseObjectExplorer, {

--- a/frontend/src/react/pages/project/database-detail/overview/DatabaseObjectExplorer.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/DatabaseObjectExplorer.tsx
@@ -2,6 +2,13 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getColumnDefaultValuePlaceholder } from "@/react/components/SchemaEditorLite/core/columnDefaultValue";
 import { Input } from "@/react/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/react/components/ui/select";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
 import {
@@ -353,6 +360,10 @@ export function DatabaseObjectExplorer({
     description: pkg.definition || "-",
   }));
 
+  const selectedSchemaLabel =
+    schemaList.find((schema) => schema.name === selectedSchemaName)?.name ||
+    (selectedSchemaName === "" ? t("db.schema.default") : selectedSchemaName);
+
   return (
     <div className="flex flex-col gap-6 pt-6">
       {supportsSchema && (
@@ -363,21 +374,24 @@ export function DatabaseObjectExplorer({
           >
             {t("common.schema")}
           </label>
-          <select
-            id="schema-select"
-            className="min-w-48 rounded-xs border border-control-border bg-background px-3 py-2 text-sm text-main"
+          <Select
             disabled={loading}
             value={selectedSchemaName}
-            onChange={(event) =>
-              onSelectedSchemaNameChange(event.target.value.trim())
+            onValueChange={(value) =>
+              onSelectedSchemaNameChange(String(value).trim())
             }
           >
-            {schemaList.map((schema) => (
-              <option key={schema.name} value={schema.name}>
-                {schema.name || t("db.schema.default")}
-              </option>
-            ))}
-          </select>
+            <SelectTrigger id="schema-select" className="min-w-48">
+              <SelectValue>{selectedSchemaLabel}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              {schemaList.map((schema) => (
+                <SelectItem key={schema.name} value={schema.name}>
+                  {schema.name || t("db.schema.default")}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       )}
 

--- a/frontend/src/react/pages/project/database-detail/panels/DatabaseOverviewPanel.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/panels/DatabaseOverviewPanel.test.tsx
@@ -125,6 +125,40 @@ vi.mock("@/react/components/ui/input", () => ({
   ),
 }));
 
+vi.mock("@/react/components/ui/select", () => ({
+  Select: ({
+    children,
+    disabled,
+    onValueChange,
+    value,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+    onValueChange?: (value: string) => void;
+    value?: string;
+  }) => (
+    <select
+      disabled={disabled}
+      value={value}
+      onChange={(event) => onValueChange?.(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: string;
+  }) => <option value={value}>{children}</option>,
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+}));
+
 vi.mock("@/react/components/ui/dialog", () => ({
   Dialog: ({
     open,


### PR DESCRIPTION
## Summary
- Replace the project database detail schema picker native `<select>` with the shared React `Select` primitive.
- Preserve the existing schema value, disabled state, labels, and route sync behavior.
- Update overview panel tests to mock the shared select primitive while continuing to exercise schema selection.

## Test Plan
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend test`
