### PR TITLE
chore(plsql): classify statement types with omni

### DIFF
--- a/backend/plugin/parser/plsql/statement_type.go
+++ b/backend/plugin/parser/plsql/statement_type.go
@@ -1,7 +1,10 @@
 package plsql
 
 import (
+	"strings"
+
 	"github.com/antlr4-go/antlr/v4"
+	oracleast "github.com/bytebase/omni/oracle/ast"
 	parser "github.com/bytebase/parser/plsql"
 	"github.com/pkg/errors"
 
@@ -13,9 +16,15 @@ import (
 func GetStatementTypes(asts []base.AST) ([]storepb.StatementType, error) {
 	sqlTypeSet := make(map[storepb.StatementType]bool)
 	for _, ast := range asts {
+		node, ok := GetOmniNode(ast)
+		if ok {
+			sqlTypeSet[classifyOmniStatementType(node)] = true
+			continue
+		}
+
 		antlrAST, ok := base.GetANTLRAST(ast)
 		if !ok {
-			return nil, errors.New("expected ANTLR AST for Oracle")
+			return nil, errors.New("expected Oracle AST")
 		}
 		t := getStatementType(antlrAST.Tree)
 		sqlTypeSet[t] = true
@@ -25,6 +34,98 @@ func GetStatementTypes(asts []base.AST) ([]storepb.StatementType, error) {
 		sqlTypes = append(sqlTypes, sqlType)
 	}
 	return sqlTypes, nil
+}
+
+func classifyOmniStatementType(node oracleast.Node) storepb.StatementType {
+	switch n := node.(type) {
+	case *oracleast.CreateTableStmt:
+		return storepb.StatementType_CREATE_TABLE
+	case *oracleast.CreateIndexStmt:
+		return storepb.StatementType_CREATE_INDEX
+	case *oracleast.CreateViewStmt:
+		return storepb.StatementType_CREATE_VIEW
+	case *oracleast.CreateSequenceStmt:
+		return storepb.StatementType_CREATE_SEQUENCE
+	case *oracleast.CreateSchemaStmt:
+		return storepb.StatementType_CREATE_SCHEMA
+	case *oracleast.CreateFunctionStmt:
+		return storepb.StatementType_CREATE_FUNCTION
+	case *oracleast.CreateTriggerStmt:
+		return storepb.StatementType_CREATE_TRIGGER
+	case *oracleast.CreateProcedureStmt:
+		return storepb.StatementType_CREATE_PROCEDURE
+	case *oracleast.CreateTypeStmt:
+		return storepb.StatementType_CREATE_TYPE
+	case *oracleast.DropStmt:
+		return classifyOmniDropStatementType(n.ObjectType)
+	case *oracleast.AdminDDLStmt:
+		return classifyOmniAdminDDLStatementType(n.Action, n.ObjectType)
+	case *oracleast.AlterTableStmt:
+		return storepb.StatementType_ALTER_TABLE
+	case *oracleast.AlterIndexStmt:
+		return storepb.StatementType_ALTER_INDEX
+	case *oracleast.AlterViewStmt:
+		return storepb.StatementType_ALTER_VIEW
+	case *oracleast.AlterSequenceStmt:
+		return storepb.StatementType_ALTER_SEQUENCE
+	case *oracleast.AlterTypeStmt:
+		return storepb.StatementType_ALTER_TYPE
+	case *oracleast.TruncateStmt:
+		return storepb.StatementType_TRUNCATE
+	case *oracleast.RenameStmt:
+		return storepb.StatementType_RENAME
+	case *oracleast.CommentStmt:
+		return storepb.StatementType_COMMENT
+	case *oracleast.InsertStmt:
+		return storepb.StatementType_INSERT
+	case *oracleast.UpdateStmt:
+		return storepb.StatementType_UPDATE
+	case *oracleast.DeleteStmt:
+		return storepb.StatementType_DELETE
+	default:
+		return storepb.StatementType_STATEMENT_TYPE_UNSPECIFIED
+	}
+}
+
+func classifyOmniAdminDDLStatementType(action string, objectType oracleast.ObjectType) storepb.StatementType {
+	if objectType != oracleast.OBJECT_DATABASE {
+		return storepb.StatementType_STATEMENT_TYPE_UNSPECIFIED
+	}
+	switch strings.ToUpper(action) {
+	case "CREATE":
+		return storepb.StatementType_CREATE_DATABASE
+	case "ALTER":
+		return storepb.StatementType_ALTER_DATABASE
+	case "DROP":
+		return storepb.StatementType_DROP_DATABASE
+	default:
+		return storepb.StatementType_STATEMENT_TYPE_UNSPECIFIED
+	}
+}
+
+func classifyOmniDropStatementType(objectType oracleast.ObjectType) storepb.StatementType {
+	switch objectType {
+	case oracleast.OBJECT_DATABASE:
+		return storepb.StatementType_DROP_DATABASE
+	case oracleast.OBJECT_TABLE:
+		return storepb.StatementType_DROP_TABLE
+	case oracleast.OBJECT_VIEW, oracleast.OBJECT_MATERIALIZED_VIEW:
+		return storepb.StatementType_DROP_VIEW
+	case oracleast.OBJECT_INDEX:
+		return storepb.StatementType_DROP_INDEX
+	case oracleast.OBJECT_SEQUENCE:
+		return storepb.StatementType_DROP_SEQUENCE
+	case oracleast.OBJECT_FUNCTION:
+		return storepb.StatementType_DROP_FUNCTION
+	case oracleast.OBJECT_TRIGGER:
+		return storepb.StatementType_DROP_TRIGGER
+	case oracleast.OBJECT_PROCEDURE:
+		return storepb.StatementType_DROP_PROCEDURE
+	case oracleast.OBJECT_TYPE, oracleast.OBJECT_TYPE_BODY:
+		return storepb.StatementType_DROP_TYPE
+	default:
+		return storepb.StatementType_STATEMENT_TYPE_UNSPECIFIED
+	}
 }
 
 func getStatementType(node antlr.Tree) storepb.StatementType {

--- a/backend/plugin/parser/plsql/statement_type_test.go
+++ b/backend/plugin/parser/plsql/statement_type_test.go
@@ -48,3 +48,18 @@ func TestGetStatementType(t *testing.T) {
 		a.Equal(test.Want, sqlTypeStrings)
 	}
 }
+
+func TestGetStatementTypeUsesOmniASTWithoutANTLRFallback(t *testing.T) {
+	stmts, err := base.ParseStatements(storepb.Engine_ORACLE, "CREATE SEQUENCE seq START WITH 1;")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+
+	omniAST, ok := stmts[0].AST.(*OmniAST)
+	require.True(t, ok)
+	require.False(t, omniAST.antlrParsed)
+
+	sqlTypes, err := GetStatementTypes(base.ExtractASTs(stmts))
+	require.NoError(t, err)
+	require.Equal(t, []storepb.StatementType{storepb.StatementType_CREATE_SEQUENCE}, sqlTypes)
+	require.False(t, omniAST.antlrParsed)
+}


### PR DESCRIPTION
## Summary
- Classify Oracle statement types directly from omni ASTs before falling back to ANTLR ASTs.
- Add omni mappings for core Oracle DDL/DML statement nodes, including sequence, schema, function, procedure, trigger, type, rename, comment, and drop variants.
- Add regression coverage proving Oracle statement type classification does not lazily materialize ANTLR for omni ASTs.

## Test Plan
- go test -v -count=1 ./backend/plugin/parser/plsql -run '^(TestGetStatementType|TestGetStatementTypeUsesOmniASTWithoutANTLRFallback)$'
- go test -v -count=1 ./backend/plugin/parser/plsql
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
- git diff --check