### PR TITLE
fix(monaco): disable native edit context

### DIFF
--- a/frontend/src/react/components/monaco/core.test.ts
+++ b/frontend/src/react/components/monaco/core.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createMonacoDiffEditor, createMonacoEditor } from "./core";
+
+const mocks = vi.hoisted(() => {
+  const readOnlyContribution = { dispose: vi.fn() };
+  const editor = {
+    getContribution: vi.fn(() => readOnlyContribution),
+  };
+  const modifiedEditor = {
+    getContribution: vi.fn(() => readOnlyContribution),
+  };
+  const diffEditor = {
+    getModifiedEditor: vi.fn(() => modifiedEditor),
+  };
+  const monaco = {
+    editor: {
+      create: vi.fn(() => editor),
+      createDiffEditor: vi.fn(() => diffEditor),
+      defineTheme: vi.fn(),
+    },
+  };
+  return {
+    diffEditor,
+    editor,
+    modifiedEditor,
+    monaco,
+    readOnlyContribution,
+  };
+});
+
+vi.mock("./services", () => ({
+  initializeMonacoServices: vi.fn(async () => undefined),
+}));
+
+vi.mock("./themes/bb", () => ({
+  getBBTheme: vi.fn(() => ({})),
+}));
+
+vi.mock("./themes/bb-dark", () => ({
+  getBBDarkTheme: vi.fn(() => ({})),
+}));
+
+vi.mock("monaco-editor", () => mocks.monaco);
+
+vi.mock("@/utils", () => ({
+  defer: <T>() => {
+    let resolve!: (value: T | PromiseLike<T>) => void;
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, reject, resolve };
+  },
+}));
+
+describe("monaco core", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("disables native EditContext for standalone editors", async () => {
+    const container = document.createElement("div");
+
+    await createMonacoEditor({ container });
+
+    expect(mocks.monaco.editor.create).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        editContext: false,
+      })
+    );
+  });
+
+  test("disables native EditContext for diff editors", async () => {
+    const container = document.createElement("div");
+
+    await createMonacoDiffEditor({ container });
+
+    expect(mocks.monaco.editor.createDiffEditor).toHaveBeenCalledWith(
+      container,
+      expect.objectContaining({
+        editContext: false,
+      })
+    );
+  });
+});

--- a/frontend/src/react/components/monaco/core.ts
+++ b/frontend/src/react/components/monaco/core.ts
@@ -82,6 +82,7 @@ export const createMonacoEditor = async (config: {
   await initialize();
   const monaco = await loadMonacoEditor();
   const baseOptions = {
+    editContext: false,
     experimentalEditContextEnabled: false,
   } as const;
 
@@ -103,6 +104,7 @@ export const createMonacoDiffEditor = async (config: {
   await initialize();
   const monaco = await loadMonacoEditor();
   const baseOptions = {
+    editContext: false,
     experimentalEditContextEnabled: false,
   } as const;
 


### PR DESCRIPTION
## Summary
- Disable Monaco v31 native EditContext input handling for Bytebase editors.
- Keep the legacy experimental EditContext flag for compatibility.
- Add regression coverage for standalone and diff Monaco editor options.

## Key Changes
- Pass `editContext: false` when creating standalone and diff Monaco editors.
- Cover option creation in `frontend/src/react/components/monaco/core.test.ts`.

## Motivation
- BYT-9546 reports abnormal SQL Editor input after v3.18.0. Monaco v31 uses the `editContext` option while the existing guard only set the old `experimentalEditContextEnabled` flag, leaving the native EditContext path enabled in supported browsers.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend exec vitest run src/react/components/monaco/core.test.ts src/react/components/monaco/MonacoEditor.test.tsx`
- `pnpm --dir frontend test`
- `git diff --check`