### PR TITLE
fix(plan): fix phase detail sections that cannot be hidden

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/shared/stores/phaseSlice.ts
+++ b/frontend/src/react/pages/project/plan-detail/shared/stores/phaseSlice.ts
@@ -23,6 +23,13 @@ export const createPhaseSlice: PlanDetailSliceCreator<PhaseSlice> = (set) => ({
       next.add(phase);
       return { activePhases: next };
     }),
+  focusPhase: (phase) =>
+    set((state) => {
+      if (state.activePhases.size === 1 && state.activePhases.has(phase)) {
+        return state;
+      }
+      return { activePhases: new Set([phase]) };
+    }),
   collapsePhase: (phase) =>
     set((state) => {
       if (!state.activePhases.has(phase)) return state;

--- a/frontend/src/react/pages/project/plan-detail/shared/stores/types.ts
+++ b/frontend/src/react/pages/project/plan-detail/shared/stores/types.ts
@@ -26,6 +26,7 @@ export type PhaseSlice = {
   activePhases: Set<PlanDetailPhase>;
   togglePhase: (phase: PlanDetailPhase) => void;
   expandPhase: (phase: PlanDetailPhase) => void;
+  focusPhase: (phase: PlanDetailPhase) => void;
   collapsePhase: (phase: PlanDetailPhase) => void;
 };
 

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePhaseState.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePhaseState.ts
@@ -6,6 +6,7 @@ export function usePhaseState() {
   const activePhases = usePlanDetailStore((s) => s.activePhases);
   const togglePhase = usePlanDetailStore((s) => s.togglePhase);
   const expandPhase = usePlanDetailStore((s) => s.expandPhase);
+  const focusPhase = usePlanDetailStore((s) => s.focusPhase);
   const collapsePhase = usePlanDetailStore((s) => s.collapsePhase);
 
   const isActive = useCallback(
@@ -13,5 +14,12 @@ export function usePhaseState() {
     [activePhases]
   );
 
-  return { activePhases, isActive, togglePhase, expandPhase, collapsePhase };
+  return {
+    activePhases,
+    isActive,
+    togglePhase,
+    expandPhase,
+    focusPhase,
+    collapsePhase,
+  };
 }

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
@@ -1,0 +1,203 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { act, type ReactNode } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { State } from "@/types/proto-es/v1/common_pb";
+import type { PlanDetailPageSnapshot } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  fetchPlanSnapshot: vi.fn(),
+  getIssueRoute: vi.fn(() => ({ name: "issue-detail" })),
+  routerPush: vi.fn(),
+  routerReplace: vi.fn(),
+  setDocumentTitle: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/router", () => ({
+  router: {
+    push: mocks.routerPush,
+    replace: mocks.routerReplace,
+  },
+}));
+
+vi.mock("@/router/dashboard/projectV1", () => ({
+  PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL: "project.plan.detail.spec.detail",
+  PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS: "project.plan.detail.specs",
+}));
+
+vi.mock("@/router/dashboard/projectV1RouteHelpers", () => ({
+  getRouteQueryString: (value: string | string[] | undefined) =>
+    Array.isArray(value) ? value[0] : value,
+  PLAN_DETAIL_PHASE_CHANGES: "changes",
+  PLAN_DETAIL_PHASE_REVIEW: "review",
+  PLAN_DETAIL_PHASE_DEPLOY: "deploy",
+}));
+
+vi.mock("@/utils", () => ({
+  getIssueRoute: mocks.getIssueRoute,
+  isDev: () => true,
+  minmax: (value: number, min: number, max: number) =>
+    Math.max(min, Math.min(max, value)),
+  setDocumentTitle: mocks.setDocumentTitle,
+}));
+
+vi.mock("./fetchPlanSnapshot", () => ({
+  fetchPlanSnapshot: mocks.fetchPlanSnapshot,
+}));
+
+import { PlanDetailStoreProvider } from "../../shared/stores/PlanDetailStoreProvider";
+import { usePlanDetailPage } from "./usePlanDetailPage";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <PlanDetailStoreProvider>{children}</PlanDetailStoreProvider>
+);
+
+const buildSnapshotPatch = ({
+  issue,
+  planId = "create",
+  rollout,
+}: {
+  issue?: PlanDetailPageSnapshot["issue"];
+  planId?: string;
+  rollout?: PlanDetailPageSnapshot["rollout"];
+} = {}): Partial<PlanDetailPageSnapshot> =>
+  ({
+    projectId: "foo",
+    planId,
+    pageKey: `foo/${planId}/`,
+    projectTitle: "Foo",
+    projectRequireIssueApproval: false,
+    projectRequirePlanCheckNoError: false,
+    projectCanCreateRollout: true,
+    currentUser: { name: "users/me@example.com" },
+    project: { name: "projects/foo", title: "Foo" },
+    isCreating: planId.toLowerCase() === "create",
+    readonly: false,
+    plan: {
+      name: `projects/foo/plans/${planId}`,
+      title: "",
+      creator: "users/me@example.com",
+      hasRollout: false,
+      state: State.ACTIVE,
+      specs: [{ id: "spec-1" }],
+    },
+    issue,
+    rollout,
+    planCheckRuns: [],
+    taskRuns: [],
+  }) as unknown as Partial<PlanDetailPageSnapshot>;
+
+describe("usePlanDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.fetchPlanSnapshot.mockImplementation(
+      async (_projectId: string, planId: string) =>
+        buildSnapshotPatch({ planId })
+    );
+  });
+
+  test("defaults to only the changes phase on the specs route", async () => {
+    const { result } = renderHook(
+      () =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId: "create",
+          routeName: "project.plan.detail.specs",
+          pageHost: null,
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.activePhases.has("changes")).toBe(true);
+    expect(result.current.activePhases.has("review")).toBe(false);
+    expect(result.current.activePhases.has("deploy")).toBe(false);
+
+    act(() => result.current.togglePhase("changes"));
+    await waitFor(() =>
+      expect(result.current.activePhases.has("changes")).toBe(false)
+    );
+  });
+
+  test("defaults to only the deploy phase on the deploy route query", async () => {
+    const { result } = renderHook(
+      () =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId: "plan-1",
+          routeQuery: { phase: "deploy" },
+          pageHost: null,
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.activePhases.has("changes")).toBe(false);
+    expect(result.current.activePhases.has("review")).toBe(false);
+    expect(result.current.activePhases.has("deploy")).toBe(true);
+
+    act(() => result.current.togglePhase("deploy"));
+    await waitFor(() =>
+      expect(result.current.activePhases.has("deploy")).toBe(false)
+    );
+  });
+
+  test("resets focused phase when navigating to another plan with the same route phase", async () => {
+    const { result, rerender } = renderHook(
+      ({ planId }: { planId: string }) =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId,
+          routeQuery: { phase: "deploy" },
+          pageHost: null,
+        }),
+      {
+        initialProps: { planId: "plan-1" },
+        wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.activePhases.has("deploy")).toBe(true);
+
+    act(() => result.current.togglePhase("changes"));
+    await waitFor(() =>
+      expect(result.current.activePhases.has("changes")).toBe(true)
+    );
+
+    rerender({ planId: "plan-2" });
+    await waitFor(() => expect(result.current.planId).toBe("plan-2"));
+    expect(result.current.activePhases.has("changes")).toBe(false);
+    expect(result.current.activePhases.has("review")).toBe(false);
+    expect(result.current.activePhases.has("deploy")).toBe(true);
+  });
+
+  test("defaults to only the review phase after an issue is created", async () => {
+    mocks.fetchPlanSnapshot.mockResolvedValue(
+      buildSnapshotPatch({
+        issue: {
+          name: "projects/foo/issues/1",
+        } as PlanDetailPageSnapshot["issue"],
+        planId: "plan-1",
+      })
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId: "plan-1",
+          pageHost: null,
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.activePhases.has("changes")).toBe(false);
+    expect(result.current.activePhases.has("review")).toBe(true);
+    expect(result.current.activePhases.has("deploy")).toBe(false);
+  });
+});

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
@@ -5,7 +5,11 @@ import {
   PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
   PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS,
 } from "@/router/dashboard/projectV1";
-import { PLAN_DETAIL_PHASE_DEPLOY } from "@/router/dashboard/projectV1RouteHelpers";
+import {
+  PLAN_DETAIL_PHASE_CHANGES,
+  PLAN_DETAIL_PHASE_DEPLOY,
+  PLAN_DETAIL_PHASE_REVIEW,
+} from "@/router/dashboard/projectV1RouteHelpers";
 import { State } from "@/types/proto-es/v1/common_pb";
 import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
@@ -13,6 +17,7 @@ import { unknownPlan } from "@/types/v1/issue/plan";
 import { unknownProject } from "@/types/v1/project";
 import { unknownUser } from "@/types/v1/user";
 import { setDocumentTitle } from "@/utils";
+import type { PlanDetailPhase } from "../../shared/stores/types";
 import { usePlanDetailStoreApi } from "../../shared/stores/usePlanDetailStore";
 import { fetchPlanSnapshot } from "./fetchPlanSnapshot";
 import type { PlanDetailPageSnapshot, PlanDetailPageState } from "./types";
@@ -105,6 +110,40 @@ export const usePlanDetailPage = ({
   const routePhase = route.phase;
   const routeStageId = route.stageId;
   const routeTaskId = route.taskId;
+  const focusPhase = phase.focusPhase;
+  const routePageKey = `${projectId}/${planId}/${specId ?? ""}`;
+  const currentPhase = useMemo<PlanDetailPhase>(() => {
+    if (
+      routePhase === PLAN_DETAIL_PHASE_CHANGES ||
+      routePhase === PLAN_DETAIL_PHASE_REVIEW ||
+      routePhase === PLAN_DETAIL_PHASE_DEPLOY
+    ) {
+      return routePhase;
+    }
+    if (routeStageId || routeTaskId) {
+      return PLAN_DETAIL_PHASE_DEPLOY;
+    }
+    if (
+      routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS ||
+      routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL
+    ) {
+      return PLAN_DETAIL_PHASE_CHANGES;
+    }
+    if (snapshot.rollout) {
+      return PLAN_DETAIL_PHASE_DEPLOY;
+    }
+    if (snapshot.issue) {
+      return PLAN_DETAIL_PHASE_REVIEW;
+    }
+    return PLAN_DETAIL_PHASE_CHANGES;
+  }, [
+    routeName,
+    routePhase,
+    routeStageId,
+    routeTaskId,
+    snapshot.issue,
+    snapshot.rollout,
+  ]);
 
   useEffect(() => {
     latestSnapshotRef.current = snapshot;
@@ -171,20 +210,8 @@ export const usePlanDetailPage = ({
   });
 
   useEffect(() => {
-    if (
-      routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS ||
-      routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL
-    ) {
-      phase.expandPhase("changes");
-    }
-    if (
-      routePhase === PLAN_DETAIL_PHASE_DEPLOY ||
-      routeStageId ||
-      routeTaskId
-    ) {
-      phase.expandPhase("deploy");
-    }
-  }, [phase, routeName, routePhase, routeStageId, routeTaskId]);
+    focusPhase(currentPhase);
+  }, [currentPhase, focusPhase, routePageKey]);
 
   const isPlanDone = useMemo(() => {
     if (!snapshot.rollout) {

--- a/frontend/src/router/dashboard/projectV1RouteHelpers.ts
+++ b/frontend/src/router/dashboard/projectV1RouteHelpers.ts
@@ -16,6 +16,8 @@ import {
   PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
 } from "./projectV1";
 
+export const PLAN_DETAIL_PHASE_CHANGES = "changes";
+export const PLAN_DETAIL_PHASE_REVIEW = "review";
 export const PLAN_DETAIL_PHASE_DEPLOY = "deploy";
 
 export const getRouteQueryString = (


### PR DESCRIPTION
## Summary
- Fix Plan detail sections reopening immediately after clicking Hide detail.
- Default the page to expand only the current phase and collapse the other phases.

## Key Changes
- Focus the active Plan detail phase from route and plan state instead of keeping all phases expanded.
- Preserve manual collapse behavior for the current changes/deploy section.
- Add regression tests for changes, review, and deploy phase defaults.

## Motivation
- Fixes BYT-9543 where Hide detail sometimes did not work for Change and Deploy sections because route-driven phase expansion reopened them.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
- `git diff --check`
