### PR TITLE
fix(auth): prevent nil panic in GetCurrentUser for service accounts

### DIFF
--- a/backend/api/auth/auth.go
+++ b/backend/api/auth/auth.go
@@ -218,9 +218,12 @@ func (in *APIAuthInterceptor) authenticate(ctx context.Context, accessTokenStr s
 	}
 
 	// Convert to UserMessage for context storage.
-	user, err := in.accountToUser(ctx, account)
+	user, err := in.store.ResolvePrincipalAsUser(ctx, account)
 	if err != nil {
 		return nil, nil, err
+	}
+	if user == nil {
+		return nil, nil, errs.Errorf("user %q not found", account.Email)
 	}
 
 	return user, claims, nil
@@ -266,29 +269,6 @@ func (in *APIAuthInterceptor) verifyWorkspaceMembership(ctx context.Context, wor
 	default:
 		return errs.Errorf("unknown principal type %v", account.Type)
 	}
-}
-
-// accountToUser converts an AccountMessage to a UserMessage for context storage.
-// For END_USER, loads the full user record. For SA/WI, constructs a minimal UserMessage.
-func (in *APIAuthInterceptor) accountToUser(ctx context.Context, account *store.AccountMessage) (*store.UserMessage, error) {
-	if account.Type == storepb.PrincipalType_END_USER {
-		user, err := in.store.GetUserByEmail(ctx, account.Email)
-		if err != nil {
-			return nil, errs.Errorf("failed to get user %q", account.Email)
-		}
-		if user == nil {
-			return nil, errs.Errorf("user %q not found", account.Email)
-		}
-		return user, nil
-	}
-
-	// SA/WI: construct a minimal UserMessage with the fields available from AccountMessage.
-	return &store.UserMessage{
-		Email:         account.Email,
-		Name:          account.Name,
-		Type:          account.Type,
-		MemberDeleted: account.MemberDeleted,
-	}, nil
 }
 
 // authenticateConnect is a ConnectRPC-specific version that returns ConnectRPC errors.

--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -541,7 +541,14 @@ func (s *AuthService) getAndVerifyUser(ctx context.Context, request *v1pb.LoginR
 	}
 
 	// Convert AccountMessage to UserMessage for downstream use.
-	return s.accountToUser(ctx, account)
+	user, err := s.store.ResolvePrincipalAsUser(ctx, account)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to resolve principal %q", account.Email))
+	}
+	if user == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.Errorf("user %q not found", account.Email))
+	}
+	return user, nil
 }
 
 // getOrCreateUserWithIDP authenticates a user via an identity provider (SSO).
@@ -1422,29 +1429,6 @@ func (s *AuthService) ExchangeToken(ctx context.Context, req *connect.Request[v1
 	return connect.NewResponse(&v1pb.ExchangeTokenResponse{
 		AccessToken: token,
 	}), nil
-}
-
-// accountToUser converts an AccountMessage to a UserMessage.
-// For END_USER, loads the full user record. For SA/WI, constructs a minimal UserMessage.
-func (s *AuthService) accountToUser(ctx context.Context, account *store.AccountMessage) (*store.UserMessage, error) {
-	if account.Type == storepb.PrincipalType_END_USER {
-		user, err := s.store.GetUserByEmail(ctx, account.Email)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get user %q", account.Email))
-		}
-		if user == nil {
-			return nil, connect.NewError(connect.CodeUnauthenticated, errors.Errorf("user %q not found", account.Email))
-		}
-		return user, nil
-	}
-
-	// SA/WI: construct a minimal UserMessage with the fields available from AccountMessage.
-	return &store.UserMessage{
-		Email:         account.Email,
-		Name:          account.Name,
-		Type:          account.Type,
-		MemberDeleted: account.MemberDeleted,
-	}, nil
 }
 
 func getAccountRestriction(

--- a/backend/store/account.go
+++ b/backend/store/account.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 
+	"github.com/pkg/errors"
+
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
@@ -75,5 +77,33 @@ func (s *Store) GetAccountByEmail(ctx context.Context, email string) (*AccountMe
 		Type:          storepb.PrincipalType_END_USER,
 		PasswordHash:  user.PasswordHash,
 		MemberDeleted: user.MemberDeleted,
+	}, nil
+}
+
+// ResolvePrincipalAsUser converts an AccountMessage into a *UserMessage suitable
+// for downstream code that expects the legacy single-table principal shape.
+//
+// For END_USER, it loads the full record from the principal table. For service
+// accounts and workload identities (which live in separate tables and have no
+// profile/MFA data), it returns a minimal UserMessage with Profile and MFAConfig
+// zero-initialized so downstream code dereferencing those fields does not panic.
+//
+// Returns (nil, nil) if account.Type == END_USER and no matching user exists.
+// Callers map this to their own not-found error.
+func (s *Store) ResolvePrincipalAsUser(ctx context.Context, account *AccountMessage) (*UserMessage, error) {
+	if account.Type == storepb.PrincipalType_END_USER {
+		user, err := s.GetUserByEmail(ctx, account.Email)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get user %q", account.Email)
+		}
+		return user, nil
+	}
+	return &UserMessage{
+		Email:         account.Email,
+		Name:          account.Name,
+		Type:          account.Type,
+		MemberDeleted: account.MemberDeleted,
+		Profile:       &storepb.UserProfile{},
+		MFAConfig:     &storepb.MFAConfig{},
 	}, nil
 }

--- a/backend/tests/user_test.go
+++ b/backend/tests/user_test.go
@@ -8,6 +8,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/expr"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -351,4 +352,67 @@ func TestUpdateUserEmail(t *testing.T) {
 	}))
 	a.NoError(err)
 	a.Empty(oldEmailAuditLogs.Msg.AuditLogs, "Should not have audit logs with old email")
+}
+
+func TestGetCurrentUser_ServiceAccount(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	// Create a dummy user to get the workspace reference.
+	userResp, err := ctl.userServiceClient.CreateUser(ctx, connect.NewRequest(&v1pb.CreateUserRequest{
+		User: &v1pb.User{
+			Title:    "dummy",
+			Email:    "dummy@bytebase.com",
+			Password: "1024bytebase",
+		},
+	}))
+	a.NoError(err)
+	workspace := userResp.Msg.Workspace
+
+	// Get actuator info using the workspace reference.
+	actuator, err := ctl.actuatorServiceClient.GetActuatorInfo(ctx, connect.NewRequest(&v1pb.GetActuatorInfoRequest{
+		Name: workspace,
+	}))
+	a.NoError(err)
+
+	// Create a service account.
+	saResp, err := ctl.serviceAccountServiceClient.CreateServiceAccount(ctx, connect.NewRequest(&v1pb.CreateServiceAccountRequest{
+		Parent:           actuator.Msg.Workspace,
+		ServiceAccountId: "sa-test",
+		ServiceAccount: &v1pb.ServiceAccount{
+			Title: "SA Test",
+		},
+	}))
+	a.NoError(err)
+	sa := saResp.Msg
+
+	// Grant the service account workspace admin role.
+	_, err = ctl.addMemberToWorkspaceIAM(ctx, actuator.Msg.Workspace, fmt.Sprintf("serviceAccount:%v", sa.Email), "roles/workspaceAdmin")
+	a.NoError(err)
+
+	// Login as the service account using its service_key as password.
+	loginResp, err := ctl.authServiceClient.Login(ctx, connect.NewRequest(&v1pb.LoginRequest{
+		Email:    sa.Email,
+		Password: sa.ServiceKey,
+	}))
+	a.NoError(err)
+
+	// Swap the controller token to the service account's token.
+	originalToken := ctl.authInterceptor.token
+	ctl.authInterceptor.token = loginResp.Msg.Token
+	defer func() {
+		ctl.authInterceptor.token = originalToken
+	}()
+
+	meResp, err := ctl.userServiceClient.GetCurrentUser(ctx, connect.NewRequest(&emptypb.Empty{}))
+
+	// Assertions per the task specification.
+	a.NoError(err)
+	a.NotNil(meResp.Msg)
+	a.Equal(sa.Email, meResp.Msg.Email)
+	a.NotNil(meResp.Msg.Profile)
 }


### PR DESCRIPTION
## Summary

- Service-account and workload-identity tokens calling `GET /v1/users/me` panicked with `runtime error: invalid memory address or nil pointer dereference` in `convertToUser`. Regression introduced in 3.17 by #19512 (principal-table split): SAs and WIs moved out of the `principal` table, the auth shim synthesized a `UserMessage` with nil `Profile`/`MFAConfig`, and `convertToUser` then dereferenced `user.Profile.LastLoginTime` unconditionally.
- Fix at the source: `Store.ResolvePrincipalAsUser` (the new home of the shim logic) zero-initializes `Profile` and `MFAConfig` on the synthesized record so downstream code that assumes those fields are non-nil keeps working.
- While here, the two duplicated `accountToUser` methods (one in `backend/api/auth/auth.go`, one in `backend/api/v1/auth_service.go`) are consolidated into the single `Store.ResolvePrincipalAsUser`.

## Test plan

- [x] New regression test `TestGetCurrentUser_ServiceAccount` reproduces the customer's exact panic trace on the pre-fix tree
- [x] Same test passes after the fix
- [x] `TestDeleteUser`, `TestUpdateUserEmail` (user lifecycle around SA membership) still pass
- [x] Login / auth e2e suite still passes
- [x] `golangci-lint run --allow-parallel-runners` clean
- [ ] Cherry-pick onto `release/3.18.0` after merge (single small commit; low backport risk)

## Notes

A separate, larger refactor is planned to stop using `*store.UserMessage` as the auth-context principal handle entirely (`AccountMessage` becomes the canonical "who is calling" handle, `UserMessage` reverts to its narrow store-row job). That work is documented and will land as follow-up PRs — this PR is scoped to the immediate panic and is safe to backport on its own.