### PR TITLE
fix(plan): autofocus title input on plan creation

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
@@ -1,6 +1,6 @@
 import { clone, create } from "@bufbuild/protobuf";
 import { Ban, ChevronUp, Loader2, Menu, Plus } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { issueServiceClientConnect, planServiceClientConnect } from "@/connect";
 import {
@@ -72,6 +72,8 @@ export function PlanDetailHeader() {
     useState(false);
   const [submittingReview, setSubmittingReview] = useState(false);
   const { emptySpecIdSet } = usePlanDetailSpecValidation(page.plan.specs ?? []);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const titleAutoFocusedRef = useRef(false);
 
   useEffect(() => {
     const nextTitle = page.issue?.title ?? page.plan.title;
@@ -122,6 +124,13 @@ export function PlanDetailHeader() {
     page.readonly,
     project,
   ]);
+
+  useEffect(() => {
+    if (titleAutoFocusedRef.current) return;
+    if (!page.isCreating || !page.ready) return;
+    titleAutoFocusedRef.current = true;
+    titleInputRef.current?.focus();
+  }, [page.isCreating, page.ready]);
 
   const showSubmitForReview =
     !!page.plan.name &&
@@ -442,6 +451,7 @@ export function PlanDetailHeader() {
         )}
         <div className="min-w-0 flex-1">
           <input
+            ref={titleInputRef}
             className={cn(
               "h-9 w-full bg-transparent text-xl! font-bold text-main outline-hidden",
               editingTitle

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
@@ -126,8 +126,14 @@ export function PlanDetailHeader() {
   ]);
 
   useEffect(() => {
-    if (titleAutoFocusedRef.current) return;
-    if (!page.isCreating || !page.ready) return;
+    // Route changes within the plan-detail page (create → existing → create)
+    // re-render the same React root, so the guard must reset when leaving
+    // create mode — otherwise the next create visit never re-focuses.
+    if (!page.isCreating) {
+      titleAutoFocusedRef.current = false;
+      return;
+    }
+    if (!page.ready || titleAutoFocusedRef.current) return;
     titleAutoFocusedRef.current = true;
     titleInputRef.current?.focus();
   }, [page.isCreating, page.ready]);


### PR DESCRIPTION
## Summary
Auto-focuses the plan title `<input>` when the creation page becomes ready, so users land with a cursor in the title field instead of having to click "Untitled" first.

## Why the old design was poor UX

- **Hidden requirement.** The title field rendered as the word "Untitled" with no border, no caret, no placeholder styling — it looked like a static heading, not an editable input. Users had no way to know the title was required until they tried to click Create and read the disabled-button tooltip.
- **The Create button gate was the only signal.** Disabled-button tooltips are a *recovery* mechanism, not a *guidance* mechanism. Forcing every user to attempt-and-fail in order to learn what's required is friction in the primary flow.
- **Inconsistent with form conventions.** Single-purpose creation pages (where one action is clearly the goal) conventionally auto-focus the first required field — think GitHub's new-repo page, Linear's new-issue dialog, Notion's new-page input. Bytebase was the outlier.
- **Extra click for every plan creation.** This is a high-traffic flow. Users create plans constantly. Adding an unnecessary click-to-focus to every single one accumulates real friction over time.

## Why this change is better

- **The title declares itself as an input.** Programmatic focus triggers the existing `onFocus` handler, which draws the editing border. Users see immediately that this is an editable required field — no clicking around to discover affordances.
- **Type-and-go.** The cursor is in the right place on arrival. Users can start typing the title without any interaction first. Tab/Shift-Tab then naturally navigates to subsequent fields.
- **Matches platform conventions.** Aligns with how every other "create a thing" form on the web behaves, so users don't have to learn a Bytebase-specific quirk.
- **One-shot and scoped.** Only fires when `page.isCreating && page.ready` and uses a `useRef` guard so unrelated re-renders never yank focus back from where the user has moved it (e.g. the SQL editor). View-only / edit pages are unaffected.

## Technical note
The non-obvious wrinkle: `ProjectPlanDetailPage.tsx:293` wraps the shell in `invisible pointer-events-none` until `page.ready` flips true. `visibility: hidden` elements silently reject `focus()`, so the effect must gate on `page.ready` — otherwise the focus call is a no-op and the bug appears "fixed but doing nothing." This was the failure mode of the first two attempts before identifying the root cause.

## Test plan
- [ ] Visit `/projects/<id>/plans/create/...` — cursor lands in the title field with the editing border drawn; typing immediately replaces "Untitled".
- [ ] Click into the SQL editor, then trigger an unrelated re-render — focus stays in the SQL editor, not yanked back to the title.
- [ ] Open an existing plan (non-creating) — no auto-focus on the title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)