### PR TITLE
fix(plan): drop per-tab empty-statement asterisk

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
@@ -208,10 +208,6 @@ vi.mock("@/utils/v1/databaseGroup", () => ({
     name.split("/databaseGroups/")[1] ?? name,
 }));
 
-vi.mock("../hooks/usePlanDetailSpecValidation", () => ({
-  usePlanDetailSpecValidation: () => ({ emptySpecIdSet: new Set() }),
-}));
-
 vi.mock("../utils/localSheet", () => ({
   getLocalSheetByName: (name: string) => ({ name, content: "" }),
   getNextLocalSheetUID: () => "-1",

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -106,7 +106,6 @@ import {
   getSheetStatement,
   setSheetStatement as setLocalSheetStatement,
 } from "@/utils/v1/sheet";
-import { usePlanDetailSpecValidation } from "../hooks/usePlanDetailSpecValidation";
 import { usePlanDetailContext } from "../shell/PlanDetailContext";
 import {
   getDefaultGhostConfig,
@@ -207,7 +206,6 @@ export function PlanDetailChangesBranch({
     () => (pendingNewSpec ? [...specs, pendingNewSpec] : specs),
     [specs, pendingNewSpec]
   );
-  const { emptySpecIdSet } = usePlanDetailSpecValidation(visibleSpecs);
   const selectedSpec = useMemo(() => {
     if (pendingNewSpec && isPendingSelected) {
       return pendingNewSpec;
@@ -556,11 +554,6 @@ export function PlanDetailChangesBranch({
               >
                 <span className="opacity-80">{index + 1}.</span>
                 <span>{getSpecTitle(spec, t)}</span>
-                {emptySpecIdSet.has(spec.id) && (
-                  <Tooltip content={t("plan.navigator.statement-empty")}>
-                    <span className="text-error">*</span>
-                  </Tooltip>
-                )}
               </span>
             </PlanDetailTabItem>
           );


### PR DESCRIPTION
## Summary
Removes the red `*` shown next to a Database Change tab when its SQL statement is empty.

## Why the old design was poor UX

- **Wrong semantic signal.** An asterisk conventionally marks a required *field* — but a tab is a container, not a field. Users read "missing required value" when the actual meaning was "this tab needs SQL." Red color compounded this by signaling an error, when nothing was actually wrong yet.
- **Scolds the user for normal state.** The asterisk appeared the instant the user clicked "Add Change." A user who has just opened an empty tab obviously hasn't filled it in yet — flagging that as an error is premature and patronizing. Good validation surfaces problems *when the user attempts to commit*, not before.
- **Redundant with the Create button gate.** The Create button is already disabled when any spec is empty, and its tooltip enumerates each empty spec as a reason. The per-tab asterisk added no information — just visual noise that needed its own tooltip to explain what the asterisk meant.
- **Requires a tooltip to be understandable.** Any UI element that needs hover text to explain its meaning fails the "glanceable" test. The asterisk's purpose was opaque without inspection.

## Why removing it is better

- **Defers feedback to the moment of action.** Users find out about empty specs when they try to submit (Create button tooltip) — the standard form-validation pattern. No noise during the natural drafting flow.
- **Quieter tab strip.** Tab titles read cleanly; nothing competes with the spec name for attention.
- **Single source of truth for "you can't submit yet."** The Create button's disabled state + tooltip is already authoritative and visible. Two indicators saying the same thing in different visual languages was confusing, not reassuring.

## Scope notes
- Kept `usePlanDetailSpecValidation` (still used by `PlanDetailHeader` for the Create-button gate and by `header.ts` for blocking errors).
- Kept the i18n key `plan.navigator.statement-empty` (still referenced from `PlanDetailHeader`, `IssueDetailDatabaseChangeView`, `actionRegistry`, and `header.ts`).
- Did **not** touch the matching asterisk in `IssueDetailDatabaseChangeView` — that's a post-submission surface where the semantics differ (an empty spec on an already-submitted issue is a real anomaly, not a draft-in-progress). Happy to remove in a follow-up if desired.

## Test plan
- [ ] Plan creation: add a new Database Change tab → no red `*` on the tab.
- [ ] With an empty tab, hover the Create button → tooltip still lists "Statement empty" and the button stays disabled.
- [ ] Existing `PlanDetailChangesBranch` tests still pass (vitest, 1918/1918 green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)