### PR TITLE
fix(plan): add left padding to database selector checkbox column

### DIFF
--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -1002,7 +1002,7 @@ function DatabaseSelector({
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b text-left text-control-light">
-                <th className="py-2 pr-2 w-8">
+                <th className="py-2 pl-3 pr-2 w-10">
                   <Checkbox
                     checked={someSelected ? "indeterminate" : allSelected}
                     onCheckedChange={toggleAll}
@@ -1037,7 +1037,7 @@ function DatabaseSelector({
                     )}
                     onClick={() => toggleDatabase(db.name)}
                   >
-                    <td className="py-2 pr-2">
+                    <td className="py-2 pl-3 pr-2">
                       <Checkbox checked={isSelected} />
                     </td>
                     <td className="py-2 pr-4">


### PR DESCRIPTION
## Summary
- Give the checkbox column in the New Plan database selector some breathing room from the left edge of the table.

## Test plan
- [ ] Open New Plan dialog in a project; confirm checkboxes in the Databases tab have left padding and aren't flush against the table edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)