### PR TITLE
feat(plan-list): drop checks column, lead with creator, widen title

### DIFF
--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.columns.test.ts
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.columns.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+
+import source from "./ProjectPlanDashboardPage.tsx?raw";
+
+// Capture every `key: "..."` object-literal occurrence in this file's source.
+// Only the columns array uses this syntax here, so the broad pattern forces any
+// new column entry to be reflected in the expected-order assertion below. If
+// the column definitions are ever extracted to a helper module, this test must
+// be rewritten against the runtime value (or the helper's source).
+const columnKeyOrder = (src: string): string[] => {
+  return Array.from(src.matchAll(/key:\s*"(\w+)"/g), (m) => m[1]);
+};
+
+// Returns the slice of source bounded by `key: "<key>"` and the next column
+// entry, or the close of the columns array (the `],` immediately followed by
+// the `useMemo` deps `[`). Per-property assertions inside the slice are
+// independent of property declaration order. The `\],\s*\[` boundary is more
+// specific than a bare `\],` so it won't be cut short by an incidental inline
+// `],` in a render's JSX.
+const columnEntry = (src: string, key: string): string => {
+  const re = new RegExp(`key:\\s*"${key}",[\\s\\S]*?(?=key:\\s*"|\\],\\s*\\[)`);
+  const match = src.match(re);
+  expect(match, `expected to find column entry for "${key}"`).not.toBeNull();
+  return match?.[0] ?? "";
+};
+
+describe("plan list column composition", () => {
+  test("renders five columns in priority order", () => {
+    expect(columnKeyOrder(source)).toEqual([
+      "name",
+      "creator",
+      "review",
+      "stages",
+      "updated",
+    ]);
+  });
+
+  test("drops the checks column from the navigation surface", () => {
+    expect(source).not.toContain('key: "checks"');
+  });
+
+  test("name carries the tuned default width for plan titles", () => {
+    // P0 column for the navigation surface: holds UID + title + optional
+    // lifecycle badge. 400px gives ~45 effective chars for the title with a
+    // badge present, covering typical long plan titles before truncation.
+    const entry = columnEntry(source, "name");
+    expect(entry.match(/defaultWidth:\s*(\d+)/)?.[1]).toBe("400");
+    expect(entry.match(/minWidth:\s*(\d+)/)?.[1]).toBe("200");
+  });
+
+  test("creator carries the tuned default width and min width", () => {
+    const entry = columnEntry(source, "creator");
+    expect(entry.match(/defaultWidth:\s*(\d+)/)?.[1]).toBe("160");
+    expect(entry.match(/minWidth:\s*(\d+)/)?.[1]).toBe("100");
+  });
+
+  test("creator render truncates long titles on a block element", () => {
+    // The full truncation contract: a block-level container fills the cell
+    // width, then `truncate` clips with an ellipsis. If either piece is
+    // missing, long creator names won't ellipsize cleanly. Anchor on `<span`
+    // so the assertion stays on the truncating element even if a future
+    // refactor wraps it with another element (e.g. a tooltip) that carries
+    // its own `className`.
+    const entry = columnEntry(source, "creator");
+    const spanClass = entry.match(/<span\s+className="([^"]+)"/);
+    expect(spanClass).not.toBeNull();
+    expect(spanClass?.[1]).toContain("block");
+    expect(spanClass?.[1]).toContain("truncate");
+  });
+
+  test("PlanRowContext does not carry check-summary plumbing", () => {
+    // Once the column is gone, the per-row context shouldn't compute or carry
+    // check summaries — that work is dead weight on the navigation surface.
+    expect(source).not.toContain("checkSummary");
+    expect(source).not.toContain("hasAnyCheck");
+  });
+});

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -1,6 +1,5 @@
 import { create as createProto } from "@bufbuild/protobuf";
 import {
-  AlertCircle,
   CheckCircle,
   Database as DatabaseIcon,
   FolderTree,
@@ -389,13 +388,6 @@ interface PlanRowContext {
   creator: { title: string; name: string };
   updateTimeTs: number;
   approvalTag: { label: string; variant: ReviewBadge["variant"] } | undefined;
-  checkSummary: {
-    running: number;
-    success: number;
-    warning: number;
-    error: number;
-  };
-  hasAnyCheck: boolean;
   isDeleted: boolean;
   showDraftTag: boolean;
   environmentStore: ReturnType<typeof useEnvironmentV1Store>;
@@ -418,7 +410,7 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
       {
         key: "name",
         title: t("issue.table.name"),
-        defaultWidth: 320,
+        defaultWidth: 400,
         minWidth: 200,
         resizable: true,
         render: (plan, ctx) => (
@@ -445,42 +437,14 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
         ),
       },
       {
-        key: "checks",
-        title: t("plan.checks.self"),
-        defaultWidth: 200,
-        minWidth: 120,
+        key: "creator",
+        title: t("issue.table.creator"),
+        defaultWidth: 160,
+        minWidth: 100,
         resizable: true,
-        render: (_plan, ctx) =>
-          ctx.hasAnyCheck ? (
-            <div className="flex items-center gap-3 flex-wrap">
-              {ctx.checkSummary.running > 0 && (
-                <div className="flex items-center gap-1 text-control">
-                  <Loader2 className="size-4 animate-spin" />
-                  <span>{t("task.status.running")}</span>
-                </div>
-              )}
-              {ctx.checkSummary.error > 0 && (
-                <div className="flex items-center gap-1 text-error">
-                  <XCircle className="size-4" />
-                  <span>{ctx.checkSummary.error}</span>
-                </div>
-              )}
-              {ctx.checkSummary.warning > 0 && (
-                <div className="flex items-center gap-1 text-warning">
-                  <AlertCircle className="size-4" />
-                  <span>{ctx.checkSummary.warning}</span>
-                </div>
-              )}
-              {ctx.checkSummary.success > 0 && (
-                <div className="flex items-center gap-1 text-success">
-                  <CheckCircle className="size-4" />
-                  <span>{ctx.checkSummary.success}</span>
-                </div>
-              )}
-            </div>
-          ) : (
-            <span className="text-control-light">-</span>
-          ),
+        render: (_plan, ctx) => (
+          <span className="block truncate">{ctx.creator.title}</span>
+        ),
       },
       {
         key: "review",
@@ -547,20 +511,6 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
               {humanizeTs(ctx.updateTimeTs)}
             </span>
           </Tooltip>
-        ),
-      },
-      {
-        key: "creator",
-        title: t("issue.table.creator"),
-        defaultWidth: 152,
-        minWidth: 100,
-        resizable: true,
-        render: (_plan, ctx) => (
-          <div className="flex items-center gap-x-1.5">
-            <span className="text-sm truncate min-w-0">
-              {ctx.creator.title}
-            </span>
-          </div>
         ),
       },
     ],
@@ -676,28 +626,10 @@ function PlanRow({
     return { label: t(badge.labelKey), variant: badge.variant };
   }, [plan.approvalStatus, plan.hasRollout, plan.issue, t]);
 
-  const checkSummary = useMemo(() => {
-    const statusCount = plan.planCheckRunStatusCount || {};
-    const running = statusCount["RUNNING"] || 0;
-    const success = statusCount["SUCCESS"] || 0;
-    const warning = statusCount["WARNING"] || 0;
-    const error = (statusCount["ERROR"] || 0) + (statusCount["FAILED"] || 0);
-    return { running, success, warning, error };
-  }, [plan.planCheckRunStatusCount]);
-
-  const hasAnyCheck =
-    checkSummary.running +
-      checkSummary.success +
-      checkSummary.warning +
-      checkSummary.error >
-    0;
-
   const ctx: PlanRowContext = {
     creator,
     updateTimeTs,
     approvalTag,
-    checkSummary,
-    hasAnyCheck,
     isDeleted,
     showDraftTag,
     environmentStore,


### PR DESCRIPTION
## Summary

Refresh the plan list column composition for the navigation surface it actually is:

- **Drop the Checks column.** Pre-flight check breakdowns (errors/warnings/successes) are work-surface detail — they belong on plan detail, one click away. On the list, the Review column already encodes whether a plan is actionable.
- **Move Creator from position 6 to position 2.** Was the first column clipped on narrow viewports despite being a primary scan target for DBAs and reviewers ("is this mine?"). Now right after Name.
- **Widen Name from 320 to 400px.** P0 column — holds UID + title + lifecycle badge. The old 320px clipped typical long titles like "Production deploy 2026-05-15 - schema update."
- Strip dead `checkSummary` / `hasAnyCheck` plumbing and the unused `AlertCircle` import.

## Why

The plan list is a navigation surface (scan → click into detail to act), not a work surface. Information density should match scan priority. The Checks column ate ~200px of P3 detail and pushed the P1 Creator column off narrow viewports. Same column count (5 vs 6), better priority ordering.

## Trade-offs / deferred

- **At-a-glance check breakdown is gone from the list.** The Review badge still reflects check-driven outcomes (Rejected, blocked-from-Approved). If real-user feedback shows the deeper signal is missed, follow up with a compact issue indicator on the Review badge (Approach B from the design draft).
- **Column resize redistributes across siblings on wide screens** (widening one column shrinks others, instead of pushing the table right). Pre-existing in all 4 resizable tables — root cause is `<table class="w-full">` + `table-fixed` + `minWidth: totalWidth`. Tried `width: totalWidth` here and reverted because it creates empty space on wide screens when columns total less than the container. Real fix needs a "flex" column that absorbs slack, or a layout strategy that grows past container width on resize. Filed as a separate spike.

## Test plan

- [x] `pnpm --dir frontend test` — 2017 tests pass (6 new tests in `ProjectPlanDashboardPage.columns.test.ts` cover column order, no-Checks, Name/Creator widths, span-anchored truncation contract, no check-summary plumbing)
- [x] `pnpm --dir frontend check` — eslint, biome, i18n, layering, locale sort all clean
- [x] `pnpm --dir frontend type-check` — clean
- [ ] Visual verification on the plans list page (dev server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)