### PR TITLE
fix(otp-input): constrain input row to parent width

### DIFF
--- a/frontend/src/react/components/ui/otp-input.tsx
+++ b/frontend/src/react/components/ui/otp-input.tsx
@@ -77,7 +77,7 @@ export function OtpInput({
   );
 
   return (
-    <div className={cn("flex gap-2", className)}>
+    <div className={cn("flex w-full gap-2", className)}>
       {Array.from({ length }, (_, i) => (
         <input
           key={i}


### PR DESCRIPTION
## Summary

The OTP input container used `flex gap-2` with no explicit width. Combined with each cell's `flex-1` (cells size themselves by dividing the available width), this let the row escape its parent card and spread the inputs across the full viewport on every surface that uses `<OtpInput>`:

- `MultiFactorPage` (MFA challenge during signin)
- `TwoFactorSetupPage` (settings → 2FA setup)
- `PasswordResetPage`
- `EmailCodeSigninForm`

Adding `w-full` constrains the row to its parent, so the `flex-1` cells distribute within the card width instead of escaping it.

```diff
- <div className={cn("flex gap-2", className)}>
+ <div className={cn("flex w-full gap-2", className)}>
```

## Screenshots

| Before | After |
| --- | --- |
| <img width="1712" height="1280" alt="スクリーンショット 2026-05-22 20 45 48" src="https://github.com/user-attachments/assets/55c31093-5ed3-4998-8b79-08b20636d6b0" /> | <img width="1710" height="1279" alt="スクリーンショット 2026-05-22 20 46 10" src="https://github.com/user-attachments/assets/36b6bade-49f3-4a9c-a737-504ae7325091" /> |

## Test plan

- [x] Visual check on `/auth/mfa` — OTP row spans the form width
- [x] Visual check on `/2fa/setup` — OTP row spans the form width
- [x] Visual check on `/auth/password-reset` — OTP row spans the form width
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`