### PR TITLE
fix(frontend): detach external window.open tabs from the opener

### DIFF
--- a/frontend/src/react/components/FeatureAttention.test.tsx
+++ b/frontend/src/react/components/FeatureAttention.test.tsx
@@ -138,7 +138,11 @@ describe("FeatureAttention", () => {
       );
     });
 
-    expect(openSpy).toHaveBeenCalledWith(ENTERPRISE_INQUIRE_LINK, "_blank");
+    expect(openSpy).toHaveBeenCalledWith(
+      ENTERPRISE_INQUIRE_LINK,
+      "_blank",
+      "noopener,noreferrer"
+    );
 
     openSpy.mockRestore();
     unmount();

--- a/frontend/src/react/components/FeatureAttention.tsx
+++ b/frontend/src/react/components/FeatureAttention.tsx
@@ -109,7 +109,7 @@ export function FeatureAttention({
 
   const onAction = () => {
     if (!hasFeature) {
-      window.open(ENTERPRISE_INQUIRE_LINK, "_blank");
+      window.open(ENTERPRISE_INQUIRE_LINK, "_blank", "noopener,noreferrer");
       return;
     }
     if (instanceMissingLicense || existInstanceWithoutLicense) {

--- a/frontend/src/react/components/header/DashboardHeader.test.tsx
+++ b/frontend/src/react/components/header/DashboardHeader.test.tsx
@@ -211,4 +211,27 @@ describe("DashboardHeader", () => {
 
     unmount();
   });
+
+  test("want help opens docs in a detached tab", () => {
+    const { container, render, unmount } = renderIntoContainer(
+      <DashboardHeader showLogo={false} />
+    );
+
+    render();
+
+    const helpButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("Want help")
+    );
+    expect(helpButton).not.toBeUndefined();
+    act(() => {
+      helpButton?.click();
+    });
+    expect(window.open).toHaveBeenCalledWith(
+      "https://docs.bytebase.com/faq#how-to-reach-us",
+      "_blank",
+      "noopener,noreferrer"
+    );
+
+    unmount();
+  });
 });

--- a/frontend/src/react/components/header/DashboardHeader.tsx
+++ b/frontend/src/react/components/header/DashboardHeader.tsx
@@ -143,7 +143,8 @@ export function DashboardHeader({
             onClick={() => {
               window.open(
                 "https://docs.bytebase.com/faq#how-to-reach-us",
-                "_blank"
+                "_blank",
+                "noopener,noreferrer"
               );
             }}
           >

--- a/frontend/src/react/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/react/components/instance/InstanceFormBody.tsx
@@ -1255,7 +1255,8 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
                         e.preventDefault();
                         window.open(
                           urlfy(basicInfo.externalLink ?? ""),
-                          "_blank"
+                          "_blank",
+                          "noopener,noreferrer"
                         );
                       }}
                     >

--- a/frontend/src/react/components/ui/feature-modal.test.tsx
+++ b/frontend/src/react/components/ui/feature-modal.test.tsx
@@ -138,6 +138,7 @@ const renderIntoContainer = (element: ReactElement) => {
 
 beforeEach(async () => {
   vi.clearAllMocks();
+  window.open = vi.fn();
   mocks.instanceMissingLicense = false;
   mocks.requiredPlan = 1;
   mocks.showTrial = false;
@@ -213,6 +214,38 @@ describe("FeatureModal", () => {
     expect(buttons[0].textContent).toBe(
       "subscription.instance-assignment.assign-license"
     );
+    unmount();
+  });
+
+  test("trial CTA opens inquiry page without an opener and closes the modal", () => {
+    mocks.showTrial = true;
+    mocks.useSubscriptionState.mockReturnValue({
+      showTrial: true,
+      trialingDays: mocks.trialingDays,
+    });
+    const onOpenChange = vi.fn();
+    const { container, render, unmount } = renderIntoContainer(
+      <FeatureModal open feature={1} onOpenChange={onOpenChange} />
+    );
+
+    render();
+
+    const trialButton = Array.from(
+      container.querySelectorAll("[data-testid='button']")
+    ).find((button) =>
+      button.textContent?.includes("subscription.request-n-days-trial")
+    );
+    expect(trialButton).not.toBeUndefined();
+    act(() => {
+      (trialButton as HTMLButtonElement).click();
+    });
+    expect(window.open).toHaveBeenCalledWith(
+      "https://enterprise",
+      "_blank",
+      "noopener,noreferrer"
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
     unmount();
   });
 });

--- a/frontend/src/react/components/ui/feature-modal.tsx
+++ b/frontend/src/react/components/ui/feature-modal.tsx
@@ -154,7 +154,11 @@ export function FeatureModal({ open, feature, instance, onOpenChange }: Props) {
               <Button
                 variant="default"
                 onClick={() => {
-                  window.open(ENTERPRISE_INQUIRE_LINK, "_blank");
+                  window.open(
+                    ENTERPRISE_INQUIRE_LINK,
+                    "_blank",
+                    "noopener,noreferrer"
+                  );
                   // Vue's BBModal default-closes after a CTA click; mirror
                   // that so the paywall doesn't linger after the inquiry
                   // tab opens.

--- a/frontend/src/react/pages/settings/SubscriptionPage.test.tsx
+++ b/frontend/src/react/pages/settings/SubscriptionPage.test.tsx
@@ -7,6 +7,24 @@ import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
+const mocks = vi.hoisted(() => ({
+  subscriptionState: {
+    currentPlan: 3,
+    expireAt: "",
+    hasUnifiedInstanceLicense: true,
+    instanceCountLimit: 10,
+    instanceLicenseCount: 10,
+    isExpired: false,
+    isFreePlan: false,
+    isSelfHostLicense: true,
+    isTrialing: false,
+    showTrial: false,
+    trialingDays: 14,
+    uploadLicense: vi.fn(),
+    userCountLimit: 20,
+  },
+}));
+
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
     t: (key: string) => key,
@@ -55,21 +73,7 @@ vi.mock("@/react/hooks/useAppState", () => ({
     userCountInIam: 4,
     workspaceResourceName: "workspaces/workspace-id",
   }),
-  useSubscriptionState: () => ({
-    currentPlan: PlanType.ENTERPRISE,
-    expireAt: "",
-    hasUnifiedInstanceLicense: true,
-    instanceCountLimit: 10,
-    instanceLicenseCount: 10,
-    isExpired: false,
-    isFreePlan: false,
-    isSelfHostLicense: true,
-    isTrialing: false,
-    showTrial: false,
-    trialingDays: 14,
-    uploadLicense: vi.fn(),
-    userCountLimit: 20,
-  }),
+  useSubscriptionState: () => mocks.subscriptionState,
 }));
 
 vi.mock("@/types", () => ({
@@ -92,6 +96,20 @@ describe("SubscriptionPage", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    window.open = vi.fn();
+    mocks.subscriptionState.currentPlan = PlanType.ENTERPRISE;
+    mocks.subscriptionState.expireAt = "";
+    mocks.subscriptionState.hasUnifiedInstanceLicense = true;
+    mocks.subscriptionState.instanceCountLimit = 10;
+    mocks.subscriptionState.instanceLicenseCount = 10;
+    mocks.subscriptionState.isExpired = false;
+    mocks.subscriptionState.isFreePlan = false;
+    mocks.subscriptionState.isSelfHostLicense = true;
+    mocks.subscriptionState.isTrialing = false;
+    mocks.subscriptionState.showTrial = false;
+    mocks.subscriptionState.trialingDays = 14;
+    mocks.subscriptionState.uploadLicense = vi.fn();
+    mocks.subscriptionState.userCountLimit = 20;
     ({ SubscriptionPage } = await import("./SubscriptionPage"));
     container = document.createElement("div");
     document.body.append(container);
@@ -109,6 +127,32 @@ describe("SubscriptionPage", () => {
       )
     ).toBe(true);
     expect(container.textContent?.includes("3/10")).toBe(true);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  test("requesting enterprise opens inquiry page without an opener", () => {
+    mocks.subscriptionState.showTrial = true;
+    act(() => {
+      root.render(<SubscriptionPage />);
+    });
+
+    const buttons = Array.from(container.querySelectorAll("button"));
+    const upgradeButton = buttons.find((button) =>
+      button.textContent?.includes("subscription.enterprise-free-trial")
+    );
+    expect(upgradeButton).not.toBeUndefined();
+
+    act(() => {
+      upgradeButton?.click();
+    });
+
+    expect(window.open).toHaveBeenCalledWith(
+      "https://example.com",
+      "_blank",
+      "noopener,noreferrer"
+    );
 
     act(() => root.unmount());
     container.remove();

--- a/frontend/src/react/pages/settings/SubscriptionPage.tsx
+++ b/frontend/src/react/pages/settings/SubscriptionPage.tsx
@@ -67,7 +67,8 @@ export function SubscriptionPage({
   const disabled = loading || !license;
   const onRequireEnterprise =
     onRequireEnterpriseProp ??
-    (() => window.open(ENTERPRISE_INQUIRE_LINK, "_blank"));
+    (() =>
+      window.open(ENTERPRISE_INQUIRE_LINK, "_blank", "noopener,noreferrer"));
   const onManageInstanceLicenses =
     onManageInstanceLicensesProp ??
     (() => setShowInstanceAssignmentSheet(true));


### PR DESCRIPTION
## What
A few external CTAs were using `window.open(url, "_blank")` with no `noopener`. That leaves `window.opener` attached on the new tab. Kinda small, but real.

This adds `noopener,noreferrer` to those opens in Subscription, FeatureAttention, FeatureModal, DashboardHeader, and the instance external-link button. Tests got updated too.

## Repro
1. Open one of those CTAs and let it open a new tab.
2. In the opened tab, run `window.opener !== null` in devtools.
3. Before this patch it can be `true`. After this patch it should stay `false`.

No weird quota or hard limit here, this path is hit on a normal click.

## Test
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test src/react/components/FeatureAttention.test.tsx src/react/components/header/DashboardHeader.test.tsx src/react/components/ui/feature-modal.test.tsx src/react/pages/settings/SubscriptionPage.test.tsx`
- `pnpm --dir frontend test` still fails outside this diff in `src/react/components/release/ReleaseInfoCard.test.tsx` with a timeout
