### PR TITLE
fix(db): substitute database name in sync toast (BYT-9553)

### DIFF
--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -910,10 +910,8 @@
   },
   "db.catalog.description": "Edit and upload the table catalog.",
   "db.failed-to-sync-schema": "Failed to sync schema",
-  "db.failed-to-sync-schema-for-database-database-value-name": "Failed to sync schema for database '{{0}}'.",
   "db.n-databases-had-sync-errors": "{{0}} database(s) had sync errors",
   "db.start-to-sync-schema": "Start to sync schema",
-  "db.successfully-synced-schema-for-database-database-value-name": "Successfully synced schema for database '{{0}}'.",
   "db.syncing-databases-for-instance": "Syncing databases for {{0}}...",
   "environment": {
     "delete-description": "Delete environment will also remove it from related instances and databases. You cannot undo this action",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -903,10 +903,8 @@
   },
   "db.catalog.description": "Editar y cargar el catálogo de tablas.",
   "db.failed-to-sync-schema": "No se pudo sincronizar el esquema",
-  "db.failed-to-sync-schema-for-database-database-value-name": "Error al sincronizar el esquema para la base de datos '{{0}}'.",
   "db.n-databases-had-sync-errors": "{{0}} base(s) de datos tuvieron errores de sincronización",
   "db.start-to-sync-schema": "Comenzar a sincronizar el esquema",
-  "db.successfully-synced-schema-for-database-database-value-name": "Esquema sincronizado exitosamente para la base de datos '{{0}}'.",
   "db.syncing-databases-for-instance": "Sincronizando bases de datos para {{0}}...",
   "environment": {
     "delete-description": "Eliminar el entorno también lo eliminará de las instancias y bases de datos relacionadas. No se puede deshacer esta acción",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -903,10 +903,8 @@
   },
   "db.catalog.description": "テーブルカタログを編集してアップロードします。",
   "db.failed-to-sync-schema": "スキーマの同期に失敗しました",
-  "db.failed-to-sync-schema-for-database-database-value-name": "データベース '{{0}}' のスキーマを同期できませんでした。",
   "db.n-databases-had-sync-errors": "{{0}} 個のデータベースで同期エラーが発生しました",
   "db.start-to-sync-schema": "スキーマの同期を開始します",
-  "db.successfully-synced-schema-for-database-database-value-name": "データベース '{{0}}' のスキーマが正常に同期されました。",
   "db.syncing-databases-for-instance": "{{0}} のデータベースを同期中...",
   "environment": {
     "delete-description": "環境を削除すると、関連するインスタンスとデータベースからも削除されます。この操作は元に戻せません",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -903,10 +903,8 @@
   },
   "db.catalog.description": "Chỉnh sửa và tải lên danh mục bảng.",
   "db.failed-to-sync-schema": "Không đồng bộ hóa được lược đồ",
-  "db.failed-to-sync-schema-for-database-database-value-name": "Không đồng bộ hóa được lược đồ cho cơ sở dữ liệu '{{0}}'.",
   "db.n-databases-had-sync-errors": "{{0}} cơ sở dữ liệu gặp lỗi đồng bộ",
   "db.start-to-sync-schema": "Bắt đầu đồng bộ hóa lược đồ",
-  "db.successfully-synced-schema-for-database-database-value-name": "Đồng bộ hóa lược đồ thành công cho cơ sở dữ liệu '{{0}}'.",
   "db.syncing-databases-for-instance": "Đang đồng bộ hóa cơ sở dữ liệu cho {{0}}...",
   "environment": {
     "delete-description": "Xóa môi trường cũng sẽ xóa nó khỏi các phiên bản và cơ sở dữ liệu liên quan. Bạn không thể hoàn tác hành động này.",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -903,10 +903,8 @@
   },
   "db.catalog.description": "编辑并上传表的 Catalog",
   "db.failed-to-sync-schema": "同步 schema 失败",
-  "db.failed-to-sync-schema-for-database-database-value-name": "为数据库 '{{0}}' 同步 schema 失败。",
   "db.n-databases-had-sync-errors": "{{0}} 个数据库同步出错",
   "db.start-to-sync-schema": "开始同步 schema",
-  "db.successfully-synced-schema-for-database-database-value-name": "成功为数据库 '{{0}}' 同步 schema。",
   "db.syncing-databases-for-instance": "正在同步 {{0}} 的数据库...",
   "environment": {
     "delete-description": "删除环境也会将其从相关实例和数据库中删除。这个操作无法撤销",

--- a/frontend/src/react/pages/project/database-detail/DatabaseSyncButton.tsx
+++ b/frontend/src/react/pages/project/database-detail/DatabaseSyncButton.tsx
@@ -45,7 +45,7 @@ export function DatabaseSyncButton({
         title: t(
           "db.successfully-synced-schema-for-database-database-value-name",
           {
-            0: extractDatabaseName(database.name),
+            name: extractDatabaseName(database.name),
           }
         ),
       });
@@ -54,7 +54,7 @@ export function DatabaseSyncButton({
         module: "bytebase",
         style: "CRITICAL",
         title: t("db.failed-to-sync-schema-for-database-database-value-name", {
-          0: extractDatabaseName(database.name),
+          name: extractDatabaseName(database.name),
         }),
         description: (error as ConnectError).message,
       });


### PR DESCRIPTION
## Summary

- Fix the database **Sync Database** toast which rendered literally as `Successfully synced schema for database "{{name}}".` because the call site passed positional `{ 0: ... }` while the React i18n template uses i18next's named `{{name}}` syntax.
- Switch [DatabaseSyncButton.tsx](frontend/src/react/pages/project/database-detail/DatabaseSyncButton.tsx) success + failure toasts to `{ name: ... }`.
- Remove the dead flat `db.successfully-synced-schema-for-database-database-value-name` / `db.failed-to-sync-schema-for-database-database-value-name` duplicates (using `{{0}}`) from all five React locales — they were always shadowed by the nested `{{name}}` entries under i18next's default dotted-key resolution.

## Audit

I scripted a cross-check between every React locale key with placeholders and every `t("...", { ... })` call site (handling shorthand `{ n }` and multi-line nested call args). After filtering false positives where templates are intentionally `.split("{{x}}")`-ed to splice React elements around the placeholder, this was the only real mismatch.

Tracks [BYT-9553](https://linear.app/bytebase/issue/BYT-9553/database-sync-toast-shows-literal-name-placeholder-instead-of-database).

## Test plan

- [x] `pnpm --dir frontend check` (eslint + biome + react-i18n consistency + layering + locale sort)
- [x] `pnpm --dir frontend type-check`
- [ ] Open a database detail page, click **Sync Database**, confirm the success toast reads `Successfully synced schema for database "<db>".` with the real name substituted.
- [ ] Repeat across `zh-CN` / `ja-JP` / `es-ES` / `vi-VN` to confirm no locale lost the toast string (nested entries still resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)