### PR TITLE
fix(pg): preserve CTE lineage across nested scopes

### DIFF
--- a/backend/plugin/parser/pg/query_span_loader_integration_test.go
+++ b/backend/plugin/parser/pg/query_span_loader_integration_test.go
@@ -313,6 +313,90 @@ where a.reviewer_by in ('****** ', '******')
 	mustHaveExactSource(t, span.Results[7], "compliance_cases", "case_info")
 }
 
+func TestLoaderIntegration_MultipleCTEsWithLateralJoinKeepsJSONBLineage(t *testing.T) {
+	meta := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name: "public",
+			Tables: []*storepb.TableMetadata{{
+				Name: "ai_conversation",
+				Columns: []*storepb.ColumnMetadata{
+					{Name: "id", Type: "text"},
+					{Name: "parts", Type: "jsonb"},
+				},
+			}},
+		}},
+	}
+
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "single_cte",
+			sql: `
+WITH convs AS (
+  SELECT ac.id, ac.parts AS conv_parts
+  FROM ai_conversation ac
+  LIMIT 1
+)
+SELECT
+  LEFT(
+    COALESCE(
+      (SELECT string_agg(v::text, ' ')
+       FROM jsonb_array_elements_text(
+         jsonb_path_query_array(t.part->'bodyData', 'strict $.**.text', '{}'::jsonb, true)
+       ) AS v),
+      '<no text>'
+    ),
+    2000
+  ) AS content
+FROM convs c
+CROSS JOIN LATERAL jsonb_array_elements(c.conv_parts) WITH ORDINALITY AS t(part, part_ord)
+WHERE t.part->>'type' IN ('prompt', 'text');
+`,
+		},
+		{
+			name: "multiple_ctes",
+			sql: `
+WITH cte1 AS (
+  SELECT ac.id, ac.parts AS conv_parts
+  FROM ai_conversation ac
+  LIMIT 1
+),
+cte2 AS (
+  SELECT id, conv_parts
+  FROM cte1
+)
+SELECT
+  LEFT(
+    COALESCE(
+      (SELECT string_agg(v::text, ' ')
+       FROM jsonb_array_elements_text(
+         jsonb_path_query_array(t.part->'bodyData', 'strict $.**.text', '{}'::jsonb, true)
+       ) AS v),
+      '<no text>'
+    ),
+    2000
+  ) AS content
+FROM cte2 c
+CROSS JOIN LATERAL jsonb_array_elements(c.conv_parts) WITH ORDINALITY AS t(part, part_ord)
+WHERE t.part->>'type' IN ('prompt', 'text');
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			span := mustGetQuerySpan(t, meta, tt.sql)
+			if len(span.Results) != 1 {
+				t.Fatalf("got %d results, want 1", len(span.Results))
+			}
+			mustHaveExactSource(t, span.Results[0], "ai_conversation", "parts")
+		})
+	}
+}
+
 func TestAppendQueryDoesNotMutateSharedStack(t *testing.T) {
 	outer := &catalog.Query{}
 	parent := &catalog.Query{}

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -799,12 +799,9 @@ func (e *omniQuerySpanExtractor) resolveVar(queryStack []*catalog.Query, v *cata
 		}
 
 	case catalog.RTECTE:
-		if rte.CTEIndex >= 0 && rte.CTEIndex < len(q.CTEList) {
-			cte := q.CTEList[rte.CTEIndex]
-			if cte.Query != nil && colIdx >= 0 && colIdx < len(cte.Query.TargetList) {
-				te := cte.Query.TargetList[colIdx]
-				e.walkExprWithVisited(appendQuery(effectiveStack, cte.Query), te.Expr, result, visited)
-			}
+		if cte := findCTEForRangeTableEntry(effectiveStack, rte); cte != nil && cte.Query != nil && colIdx >= 0 && colIdx < len(cte.Query.TargetList) {
+			te := cte.Query.TargetList[colIdx]
+			e.walkExprWithVisited(appendQuery(effectiveStack, cte.Query), te.Expr, result, visited)
 		}
 
 	case catalog.RTEJoin:
@@ -834,6 +831,29 @@ func (e *omniQuerySpanExtractor) resolveVar(queryStack []*catalog.Query, v *cata
 	default:
 		// Unknown RTE kind — skip.
 	}
+}
+
+func findCTEForRangeTableEntry(queryStack []*catalog.Query, rte *catalog.RangeTableEntry) *catalog.CommonTableExprQ {
+	if len(queryStack) == 0 || rte == nil {
+		return nil
+	}
+
+	current := currentQuery(queryStack)
+	if current != nil && rte.CTEIndex >= 0 && rte.CTEIndex < len(current.CTEList) {
+		return current.CTEList[rte.CTEIndex]
+	}
+
+	if rte.CTEName == "" {
+		return nil
+	}
+	for i := len(queryStack) - 1; i >= 0; i-- {
+		for _, cte := range queryStack[i].CTEList {
+			if strings.EqualFold(cte.Name, rte.CTEName) {
+				return cte
+			}
+		}
+	}
+	return nil
 }
 
 // extractFallbackColumns attempts to extract column names and lineage from the parse tree


### PR DESCRIPTION
## Summary
- Preserve PostgreSQL CTE lineage when a CTE body references a sibling/outer CTE through Omni analyzed query scope.
- Add a BYT-9549 regression test covering single CTE and multiple CTE + lateral jsonb function masking lineage.
- Checked other engine CTE implementations; they already maintain CTE scope stacks or do not use the same column-lineage path.

## Testing
- go test -v -count=1 ./backend/plugin/parser/pg
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
- go test -v -count=1 ./backend/plugin/parser/mysql -run '^(TestOmniQuerySpanPhase5And6_CTEAndSetOperations|TestOmniQuerySpanScenarioBatch2_SubqueryCTEAndSetCoverage)$'
- go test -v -count=1 ./backend/plugin/parser/tidb -run '^TestGetQuerySpan$'
- go test -v -count=1 ./backend/plugin/parser/doris -run '^TestQuerySpanExtractor_CTE$'
- go test -v -count=1 ./backend/plugin/parser/plsql -run '^TestGetQuerySpan$'
- go test -v -count=1 ./backend/plugin/parser/bigquery -run '^TestGetQuerySpan$'
- go test -v -count=1 ./backend/plugin/parser/trino -run '^(TestCTEHandling|TestGetQuerySpanFromYAML)$'
- go test -v -count=1 ./backend/plugin/parser/redshift -run '^TestValidateSQLForEditor$'