### PR TITLE
fix(parser/tidb): surface ResourceNotFoundError on QuerySpan for resync recovery

### DIFF
--- a/backend/plugin/parser/tidb/query_span_extractor.go
+++ b/backend/plugin/parser/tidb/query_span_extractor.go
@@ -77,12 +77,17 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 		// Surface ResourceNotFoundError on the span so the SQL service can resync stale metadata and retry.
 		var resourceNotFound *base.ResourceNotFoundError
 		if errors.As(err, &resourceNotFound) {
-			// Union the not-found target into SourceColumns so the pre-execute ACL check sees the missing resource (the check isn't rerun after resync+retry).
 			sourceColumns := make(base.SourceColumnSet, len(accessTables)+1)
 			for k := range accessTables {
 				sourceColumns[k] = true
 			}
-			sourceColumns[notFoundSyncTarget(resourceNotFound, q.defaultDatabase)] = true
+			// Add the not-found target only when it carries a distinct ACL/resync anchor.
+			// For unqualified column-not-found, target.Table is empty and the FROM tables
+			// in accessTables already provide the right table-level ACL keys, so skip.
+			target := notFoundSyncTarget(resourceNotFound, q.defaultDatabase)
+			if len(sourceColumns) == 0 || target.Table != "" {
+				sourceColumns[target] = true
+			}
 			return &base.QuerySpan{
 				Type:          queryType,
 				Results:       []base.QuerySpanResult{},

--- a/backend/plugin/parser/tidb/query_span_extractor.go
+++ b/backend/plugin/parser/tidb/query_span_extractor.go
@@ -77,10 +77,19 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 		// Surface ResourceNotFoundError on the span so the SQL service can resync stale metadata and retry.
 		var resourceNotFound *base.ResourceNotFoundError
 		if errors.As(err, &resourceNotFound) {
+			sourceColumns := accessTables
+			// getAccessTables drops tables not yet in cached metadata, so for an
+			// out-of-band CREATE TABLE the set is empty. Fall back to the
+			// not-found resource itself so the resync loop has a target.
+			if len(sourceColumns) == 0 {
+				sourceColumns = base.SourceColumnSet{
+					notFoundSyncTarget(resourceNotFound, q.defaultDatabase): true,
+				}
+			}
 			return &base.QuerySpan{
 				Type:          queryType,
 				Results:       []base.QuerySpanResult{},
-				SourceColumns: accessTables,
+				SourceColumns: sourceColumns,
 				NotFoundError: resourceNotFound,
 			}, nil
 		}
@@ -99,6 +108,24 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 		Results:       tableSource.GetQuerySpanResult(),
 		SourceColumns: accessTables,
 	}, nil
+}
+
+// notFoundSyncTarget derives a sync target for the resync loop, falling back to defaultDatabase when the error lacks one.
+func notFoundSyncTarget(e *base.ResourceNotFoundError, defaultDatabase string) base.ColumnResource {
+	r := base.ColumnResource{Database: defaultDatabase}
+	if e.Database != nil && *e.Database != "" {
+		r.Database = *e.Database
+	}
+	if e.Schema != nil {
+		r.Schema = *e.Schema
+	}
+	if e.Table != nil {
+		r.Table = *e.Table
+	}
+	if e.Column != nil {
+		r.Column = *e.Column
+	}
+	return r
 }
 
 func skipQuerySpan(node tidbast.Node, queryType base.QueryType) bool {

--- a/backend/plugin/parser/tidb/query_span_extractor.go
+++ b/backend/plugin/parser/tidb/query_span_extractor.go
@@ -77,15 +77,12 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 		// Surface ResourceNotFoundError on the span so the SQL service can resync stale metadata and retry.
 		var resourceNotFound *base.ResourceNotFoundError
 		if errors.As(err, &resourceNotFound) {
-			sourceColumns := accessTables
-			// getAccessTables drops tables not yet in cached metadata, so for an
-			// out-of-band CREATE TABLE the set is empty. Fall back to the
-			// not-found resource itself so the resync loop has a target.
-			if len(sourceColumns) == 0 {
-				sourceColumns = base.SourceColumnSet{
-					notFoundSyncTarget(resourceNotFound, q.defaultDatabase): true,
-				}
+			// Union the not-found target into SourceColumns so the pre-execute ACL check sees the missing resource (the check isn't rerun after resync+retry).
+			sourceColumns := make(base.SourceColumnSet, len(accessTables)+1)
+			for k := range accessTables {
+				sourceColumns[k] = true
 			}
+			sourceColumns[notFoundSyncTarget(resourceNotFound, q.defaultDatabase)] = true
 			return &base.QuerySpan{
 				Type:          queryType,
 				Results:       []base.QuerySpanResult{},

--- a/backend/plugin/parser/tidb/query_span_extractor.go
+++ b/backend/plugin/parser/tidb/query_span_extractor.go
@@ -74,6 +74,16 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 
 	tableSource, err := q.extractTableSourceFromNode(node)
 	if err != nil {
+		// Surface ResourceNotFoundError on the span so the SQL service can resync stale metadata and retry.
+		var resourceNotFound *base.ResourceNotFoundError
+		if errors.As(err, &resourceNotFound) {
+			return &base.QuerySpan{
+				Type:          queryType,
+				Results:       []base.QuerySpanResult{},
+				SourceColumns: accessTables,
+				NotFoundError: resourceNotFound,
+			}, nil
+		}
 		return nil, err
 	}
 	if tableSource == nil {

--- a/backend/plugin/parser/tidb/query_span_test.go
+++ b/backend/plugin/parser/tidb/query_span_test.go
@@ -74,6 +74,64 @@ func TestGetQuerySpan(t *testing.T) {
 	}
 }
 
+// When a referenced column is missing from cached metadata, the extractor must
+// surface ResourceNotFoundError on the span (not as a top-level error) so the
+// SQL service's resync+retry path can recover.
+func TestGetQuerySpanStaleMetadataReturnsNotFoundError(t *testing.T) {
+	a := require.New(t)
+
+	// Metadata omits distribute_level to mimic a stale cache after out-of-band ALTER TABLE ADD COLUMN.
+	staleMetadata := &storepb.DatabaseSchemaMetadata{
+		Name: "cif",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "byt9385_repro",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id"},
+							{Name: "existing_col"},
+							{Name: "create_time"},
+						},
+					},
+				},
+			},
+		},
+	}
+	databaseMetadataGetter, databaseNamesLister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{staleMetadata})
+
+	span, err := GetQuerySpan(
+		context.TODO(),
+		base.GetQuerySpanContext{
+			GetDatabaseMetadataFunc: databaseMetadataGetter,
+			ListDatabaseNamesFunc:   databaseNamesLister,
+		},
+		base.Statement{Text: "SELECT distribute_level FROM byt9385_repro ORDER BY create_time DESC"},
+		"cif",
+		"",
+		false,
+	)
+	a.NoError(err, "expected stale-metadata case to return a span, not a wrapped error")
+	a.NotNil(span)
+	a.NotNil(span.NotFoundError, "stale-metadata case must populate span.NotFoundError so sql_service can resync+retry")
+
+	var resourceNotFound *base.ResourceNotFoundError
+	a.True(errors.As(span.NotFoundError, &resourceNotFound))
+	a.NotNil(resourceNotFound.Column)
+	a.Equal("distribute_level", *resourceNotFound.Column)
+
+	// SourceColumns must reference the FROM table so sql_service knows which database to resync.
+	foundTable := false
+	for k := range span.SourceColumns {
+		if k.Database == "cif" && k.Table == "byt9385_repro" {
+			foundTable = true
+			break
+		}
+	}
+	a.True(foundTable, "span.SourceColumns must reference the FROM table for resync to target the right database")
+}
+
 func buildMockDatabaseMetadataGetter(databaseMetadata []*storepb.DatabaseSchemaMetadata) (base.GetDatabaseMetadataFunc, base.ListDatabaseNamesFunc) {
 	return func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
 			m := make(map[string]*model.DatabaseMetadata)

--- a/backend/plugin/parser/tidb/query_span_test.go
+++ b/backend/plugin/parser/tidb/query_span_test.go
@@ -132,6 +132,51 @@ func TestGetQuerySpanStaleMetadataReturnsNotFoundError(t *testing.T) {
 	a.True(foundTable, "span.SourceColumns must reference the FROM table for resync to target the right database")
 }
 
+// When the referenced table is missing from cached metadata, accessTables is
+// empty; SourceColumns must still expose a sync target so resync+retry can run.
+func TestGetQuerySpanMissingTableFallsBackToNotFoundDatabase(t *testing.T) {
+	a := require.New(t)
+
+	// Metadata is missing the table entirely.
+	staleMetadata := &storepb.DatabaseSchemaMetadata{
+		Name: "cif",
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "", Tables: []*storepb.TableMetadata{}},
+		},
+	}
+	databaseMetadataGetter, databaseNamesLister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{staleMetadata})
+
+	span, err := GetQuerySpan(
+		context.TODO(),
+		base.GetQuerySpanContext{
+			GetDatabaseMetadataFunc: databaseMetadataGetter,
+			ListDatabaseNamesFunc:   databaseNamesLister,
+		},
+		base.Statement{Text: "SELECT name FROM byt9385_caseB"},
+		"cif",
+		"",
+		false,
+	)
+	a.NoError(err)
+	a.NotNil(span)
+	a.NotNil(span.NotFoundError, "missing-table case must populate span.NotFoundError")
+
+	var resourceNotFound *base.ResourceNotFoundError
+	a.True(errors.As(span.NotFoundError, &resourceNotFound))
+	a.NotNil(resourceNotFound.Table)
+	a.Equal("byt9385_caseB", *resourceNotFound.Table)
+
+	a.NotEmpty(span.SourceColumns, "SourceColumns must not be empty — sql_service iterates it to build the resync target list")
+	foundDatabase := false
+	for k := range span.SourceColumns {
+		if k.Database == "cif" {
+			foundDatabase = true
+			break
+		}
+	}
+	a.True(foundDatabase, "resync target must reference the database where the missing table lives")
+}
+
 func buildMockDatabaseMetadataGetter(databaseMetadata []*storepb.DatabaseSchemaMetadata) (base.GetDatabaseMetadataFunc, base.ListDatabaseNamesFunc) {
 	return func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
 			m := make(map[string]*model.DatabaseMetadata)

--- a/backend/plugin/parser/tidb/query_span_test.go
+++ b/backend/plugin/parser/tidb/query_span_test.go
@@ -177,6 +177,57 @@ func TestGetQuerySpanMissingTableFallsBackToNotFoundDatabase(t *testing.T) {
 	a.True(foundDatabase, "resync target must reference the database where the missing table lives")
 }
 
+// SourceColumns must include the not-found target alongside known tables — the
+// pre-execute ACL check isn't rerun after resync+retry, so dropping the missing
+// resource would let an out-of-band CREATE TABLE bypass table-level ACL.
+func TestGetQuerySpanMissingTableUnionedWithAccessTables(t *testing.T) {
+	a := require.New(t)
+
+	// Metadata has the "known" table but not the "unknown" one.
+	staleMetadata := &storepb.DatabaseSchemaMetadata{
+		Name: "cif",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name:    "byt9385_known",
+						Columns: []*storepb.ColumnMetadata{{Name: "a"}},
+					},
+				},
+			},
+		},
+	}
+	databaseMetadataGetter, databaseNamesLister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{staleMetadata})
+
+	span, err := GetQuerySpan(
+		context.TODO(),
+		base.GetQuerySpanContext{
+			GetDatabaseMetadataFunc: databaseMetadataGetter,
+			ListDatabaseNamesFunc:   databaseNamesLister,
+		},
+		base.Statement{Text: "SELECT a FROM byt9385_known UNION SELECT a FROM byt9385_unknown"},
+		"cif",
+		"",
+		false,
+	)
+	a.NoError(err)
+	a.NotNil(span)
+	a.NotNil(span.NotFoundError)
+
+	foundKnown, foundUnknown := false, false
+	for k := range span.SourceColumns {
+		if k.Database == "cif" && k.Table == "byt9385_known" {
+			foundKnown = true
+		}
+		if k.Database == "cif" && k.Table == "byt9385_unknown" {
+			foundUnknown = true
+		}
+	}
+	a.True(foundKnown, "known table must remain in SourceColumns")
+	a.True(foundUnknown, "not-found table must be unioned into SourceColumns so the pre-execute ACL check sees it")
+}
+
 func buildMockDatabaseMetadataGetter(databaseMetadata []*storepb.DatabaseSchemaMetadata) (base.GetDatabaseMetadataFunc, base.ListDatabaseNamesFunc) {
 	return func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
 			m := make(map[string]*model.DatabaseMetadata)

--- a/backend/plugin/parser/tidb/query_span_test.go
+++ b/backend/plugin/parser/tidb/query_span_test.go
@@ -126,8 +126,11 @@ func TestGetQuerySpanStaleMetadataReturnsNotFoundError(t *testing.T) {
 	for k := range span.SourceColumns {
 		if k.Database == "cif" && k.Table == "byt9385_repro" {
 			foundTable = true
-			break
 		}
+		// optionalAccessCheck validates every SourceColumns entry against table-scoped
+		// CEL policies; a synthesized table-less entry would deny least-privilege users
+		// on the recovery path even when the FROM table is already authorized.
+		a.NotEmpty(k.Table, "SourceColumns must not contain table-less entries when the FROM table is known: got %+v", k)
 	}
 	a.True(foundTable, "span.SourceColumns must reference the FROM table for resync to target the right database")
 }


### PR DESCRIPTION
## Summary

- TiDB SQL Editor rejected valid queries that referenced columns added out-of-band since the last metadata sync, returning `resource not found: database: , table: , column: <col>, err: cannot find the column ref` instead of triggering the resync+retry path that MySQL/Snowflake/Trino/TSQL/Redshift already use.
- Catch `*base.ResourceNotFoundError` inside the TiDB extractor's `getQuerySpan` and return it on `QuerySpan.NotFoundError` so the SQL service at `backend/api/v1/sql_service.go` can resync metadata mid-request and retry.
- Adds a regression test that pins the new behavior using a stub `GetDatabaseMetadataFunc` whose metadata omits the referenced column.

## Root cause

The TiDB extractor's column-resolution path raised `&base.ResourceNotFoundError{...}` when an unqualified column wasn't found in `tableSourcesFrom`. That error propagated up through `GetQuerySpan` and out of the SQL service before the resync+retry block (`sql_service.go:624-651`) ever ran — because that block gates on `spans[i].NotFoundError != nil`, not on the top-level error. Other engines convert the same error into `span.NotFoundError`; TiDB was the outlier.

Closes [BYT-9385](https://linear.app/bytebase/issue/BYT-9385/sql-query-reports-existing-column-as-not-found).

## Test plan

- [x] `go test -v -count=1 ./backend/plugin/parser/tidb/ -run ^TestGetQuerySpan` — both the existing YAML-driven test and the new `TestGetQuerySpanStaleMetadataReturnsNotFoundError` pass
- [x] `gofmt -w` + `golangci-lint run --allow-parallel-runners ./backend/plugin/parser/tidb/` — 0 issues
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- [x] Live end-to-end repro against TiDB Cloud through local Bytebase SQL Editor:
  - Before patch: `SELECT distribute_level FROM byt9385_repro ORDER BY create_time DESC` fails with `cannot find the column ref` after out-of-band `ALTER TABLE ADD COLUMN`
  - After patch: same query returns 3 rows and Bytebase's cached metadata picks up the new column
- [x] Same A→B→C sequence against MySQL succeeds before and after the patch (no regression on the engine that already worked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)