### PR TITLE
fix: choose admin data source for automatic DML queries

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -50,12 +50,4 @@ jobs:
             exit 1
           fi
       - name: golangci-lint
-        run: |
-          while true; do
-            sleep 60
-            echo "golangci-lint is still running..."
-          done &
-          heartbeat_pid=$!
-          trap 'kill "$heartbeat_pid" 2>/dev/null || true' EXIT
-
-          golangci-lint run --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners
+        run: golangci-lint run --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -50,4 +50,12 @@ jobs:
             exit 1
           fi
       - name: golangci-lint
-        run: golangci-lint run --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners
+        run: |
+          while true; do
+            sleep 60
+            echo "golangci-lint is still running..."
+          done &
+          heartbeat_pid=$!
+          trap 'kill "$heartbeat_pid" 2>/dev/null || true' EXIT
+
+          golangci-lint run --verbose -j 8 --timeout 30m --max-same-issues=30 --allow-parallel-runners

--- a/backend/api/v1/access_grant_service.go
+++ b/backend/api/v1/access_grant_service.go
@@ -17,7 +17,6 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/generated-go/v1/v1connect"
-	parserbase "github.com/bytebase/bytebase/backend/plugin/parser/base"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -164,7 +163,7 @@ func (s *AccessGrantService) CreateAccessGrant(ctx context.Context, request *con
 	if instance == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", instanceID))
 	}
-	if ok, _, err := parserbase.ValidateSQLForEditor(instance.Metadata.GetEngine(), ag.Query); err != nil {
+	if ok, err := isReadOnlyStatementForAccessGrant(ctx, instance.Metadata.GetEngine(), ag.Query); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "invalid query"))
 	} else if !ok {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("only read-only statements are allowed in access grants"))

--- a/backend/api/v1/access_grant_service_test.go
+++ b/backend/api/v1/access_grant_service_test.go
@@ -1,0 +1,80 @@
+package v1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+func TestIsReadOnlyStatementForAccessGrantRejectsDocumentEngineWriteStatements(t *testing.T) {
+	tests := []struct {
+		name      string
+		engine    storepb.Engine
+		statement string
+	}{
+		{
+			name:      "MongoDB DML",
+			engine:    storepb.Engine_MONGODB,
+			statement: `db.users.insertOne({name: "Bytebase"})`,
+		},
+		{
+			name:      "MongoDB DDL",
+			engine:    storepb.Engine_MONGODB,
+			statement: `db.createCollection("users")`,
+		},
+		{
+			name:      "Elasticsearch DML",
+			engine:    storepb.Engine_ELASTICSEARCH,
+			statement: "POST /users/_doc\n{\"name\":\"Bytebase\"}",
+		},
+		{
+			name:      "Elasticsearch DDL",
+			engine:    storepb.Engine_ELASTICSEARCH,
+			statement: "PUT /users",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			readOnly, err := isReadOnlyStatementForAccessGrant(context.Background(), tc.engine, tc.statement)
+			require.NoError(t, err)
+			require.False(t, readOnly)
+		})
+	}
+}
+
+func TestIsReadOnlyStatementForAccessGrantAllowsDocumentEngineReadStatements(t *testing.T) {
+	tests := []struct {
+		name      string
+		engine    storepb.Engine
+		statement string
+	}{
+		{
+			name:      "MongoDB read",
+			engine:    storepb.Engine_MONGODB,
+			statement: `db.users.find({})`,
+		},
+		{
+			name:      "Elasticsearch read",
+			engine:    storepb.Engine_ELASTICSEARCH,
+			statement: "GET /users/_search",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			readOnly, err := isReadOnlyStatementForAccessGrant(context.Background(), tc.engine, tc.statement)
+			require.NoError(t, err)
+			require.True(t, readOnly)
+		})
+	}
+}
+
+func TestIsReadOnlyStatementForAccessGrantRejectsDocumentEngineInvalidStatements(t *testing.T) {
+	readOnly, err := isReadOnlyStatementForAccessGrant(context.Background(), storepb.Engine_ELASTICSEARCH, `db.users.find({})`)
+	require.Error(t, err)
+	require.False(t, readOnly)
+}

--- a/backend/api/v1/query_statement_classification.go
+++ b/backend/api/v1/query_statement_classification.go
@@ -1,0 +1,59 @@
+package v1
+
+import (
+	"context"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	parserbase "github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func isReadOnlyStatementForAccessGrant(ctx context.Context, engine storepb.Engine, statement string) (bool, error) {
+	readOnly, _, err := parserbase.ValidateSQLForEditor(engine, statement)
+	if err != nil {
+		return false, err
+	}
+	if !readOnly {
+		return false, nil
+	}
+
+	if !shouldClassifyStatementByQuerySpan(engine) {
+		return true, nil
+	}
+	spans, err := getQuerySpansForStatement(ctx, engine, statement)
+	if err != nil {
+		return false, err
+	}
+	if len(spans) == 0 {
+		return false, nil
+	}
+	for _, span := range spans {
+		if span == nil {
+			return false, nil
+		}
+		switch span.Type {
+		case parserbase.Select, parserbase.SelectInfoSchema, parserbase.Explain:
+		case parserbase.QueryTypeUnknown, parserbase.DDL, parserbase.DML:
+			return false, nil
+		default:
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func getQuerySpansForStatement(ctx context.Context, engine storepb.Engine, statement string) ([]*parserbase.QuerySpan, error) {
+	statements, err := parserbase.SplitMultiSQL(engine, statement)
+	if err != nil {
+		statements = []parserbase.Statement{{Text: statement}}
+	}
+	return parserbase.GetQuerySpan(ctx, parserbase.GetQuerySpanContext{}, engine, statements, "", "", false)
+}
+
+func shouldClassifyStatementByQuerySpan(engine storepb.Engine) bool {
+	switch engine {
+	case storepb.Engine_MONGODB, storepb.Engine_ELASTICSEARCH:
+		return true
+	default:
+		return false
+	}
+}

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -257,7 +257,7 @@ func (s *SQLService) Query(ctx context.Context, req *connect.Request[v1pb.QueryR
 		0,
 		database.ProjectID,
 	)
-	resolvedDataSourceID, err := resolveDataSourceID(instance, request.DataSourceId, statement, queryDataPolicy.AllowAdminDataSource)
+	resolvedDataSourceID, err := resolveDataSourceID(ctx, instance, request.DataSourceId, statement, queryDataPolicy.AllowAdminDataSource)
 	if err != nil {
 		return nil, err
 	}
@@ -885,7 +885,7 @@ func (s *SQLService) Export(ctx context.Context, req *connect.Request[v1pb.Expor
 		}
 	}
 
-	resolvedDataSourceID, err := resolveDataSourceID(instance, request.DataSourceId, statement, false)
+	resolvedDataSourceID, err := resolveDataSourceID(ctx, instance, request.DataSourceId, statement, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1792,7 +1792,7 @@ func (*SQLService) DiffMetadata(_ context.Context, req *connect.Request[v1pb.Dif
 	}), nil
 }
 
-func resolveDataSourceID(instance *store.InstanceMessage, dataSourceID string, statement string, allowAdminDataSource bool) (string, error) {
+func resolveDataSourceID(ctx context.Context, instance *store.InstanceMessage, dataSourceID string, statement string, allowAdminDataSource bool) (string, error) {
 	if dataSourceID != "" {
 		return dataSourceID, nil
 	}
@@ -1811,7 +1811,7 @@ func resolveDataSourceID(instance *store.InstanceMessage, dataSourceID string, s
 		}
 	}
 
-	if allowAdminDataSource && adminDataSourceID != "" && requiresAdminDataSource(instance.Metadata.GetEngine(), statement) {
+	if allowAdminDataSource && adminDataSourceID != "" && requiresAdminDataSource(ctx, instance.Metadata.GetEngine(), statement) {
 		return adminDataSourceID, nil
 	}
 
@@ -1827,9 +1827,44 @@ func resolveDataSourceID(instance *store.InstanceMessage, dataSourceID string, s
 	}
 }
 
-func requiresAdminDataSource(engine storepb.Engine, statement string) bool {
+func requiresAdminDataSource(ctx context.Context, engine storepb.Engine, statement string) bool {
 	readOnly, _, err := parserbase.ValidateSQLForEditor(engine, statement)
-	return err == nil && !readOnly
+	if err != nil {
+		return false
+	}
+	if !readOnly {
+		return true
+	}
+
+	if !shouldResolveDataSourceByQuerySpan(engine) {
+		return false
+	}
+	statements, err := parserbase.SplitMultiSQL(engine, statement)
+	if err != nil {
+		statements = []parserbase.Statement{{Text: statement}}
+	}
+	spans, err := parserbase.GetQuerySpan(ctx, parserbase.GetQuerySpanContext{}, engine, statements, "", "", false)
+	if err != nil {
+		return false
+	}
+	for _, span := range spans {
+		if span == nil {
+			continue
+		}
+		if span.Type == parserbase.DDL || span.Type == parserbase.DML {
+			return true
+		}
+	}
+	return false
+}
+
+func shouldResolveDataSourceByQuerySpan(engine storepb.Engine) bool {
+	switch engine {
+	case storepb.Engine_MONGODB, storepb.Engine_ELASTICSEARCH:
+		return true
+	default:
+		return false
+	}
 }
 
 func checkAndGetDataSourceQueriable(

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -165,7 +165,7 @@ func (s *SQLService) AdminExecute(ctx context.Context, stream *connect.BidiStrea
 // preCheckAccess finds and returns the best matching active access grant for the query.
 // It lists access grants filtered by project, creator, status, statement, target database,
 // and expiry, then prefers the grant with unmask=true if available.
-func (s *SQLService) preCheckAccess(ctx context.Context, request *v1pb.QueryRequest, database *store.DatabaseMessage) *store.AccessGrantMessage {
+func (s *SQLService) preCheckAccess(ctx context.Context, request *v1pb.QueryRequest, instance *store.InstanceMessage, database *store.DatabaseMessage) *store.AccessGrantMessage {
 	project, err := s.store.GetProject(ctx, &store.FindProjectMessage{
 		Workspace:  common.GetWorkspaceIDFromContext(ctx),
 		ResourceID: &database.ProjectID,
@@ -217,6 +217,15 @@ func (s *SQLService) preCheckAccess(ctx context.Context, request *v1pb.QueryRequ
 	if len(grants) == 0 {
 		return nil
 	}
+	readOnly, err := isReadOnlyStatementForAccessGrant(ctx, instance.Metadata.GetEngine(), request.Statement)
+	if err != nil {
+		slog.Warn("failed to validate access grant query", log.BBError(err))
+		return nil
+	}
+	if !readOnly {
+		slog.Warn("skip access grant for non-read-only query", slog.String("instance", instance.ResourceID), slog.String("database", database.DatabaseName))
+		return nil
+	}
 	// Pick the best grant (prefer unmask=true).
 	for _, grant := range grants {
 		if grant.Payload != nil && grant.Payload.Unmask {
@@ -234,7 +243,7 @@ func (s *SQLService) Query(ctx context.Context, req *connect.Request[v1pb.QueryR
 		return nil, err
 	}
 
-	accessGrant := s.preCheckAccess(ctx, request, database)
+	accessGrant := s.preCheckAccess(ctx, request, instance, database)
 
 	statement := request.Statement
 	// In Redshift datashare, Rewrite query used for parser.
@@ -1836,14 +1845,10 @@ func requiresAdminDataSource(ctx context.Context, engine storepb.Engine, stateme
 		return true
 	}
 
-	if !shouldResolveDataSourceByQuerySpan(engine) {
+	if !shouldClassifyStatementByQuerySpan(engine) {
 		return false
 	}
-	statements, err := parserbase.SplitMultiSQL(engine, statement)
-	if err != nil {
-		statements = []parserbase.Statement{{Text: statement}}
-	}
-	spans, err := parserbase.GetQuerySpan(ctx, parserbase.GetQuerySpanContext{}, engine, statements, "", "", false)
+	spans, err := getQuerySpansForStatement(ctx, engine, statement)
 	if err != nil {
 		return false
 	}
@@ -1856,15 +1861,6 @@ func requiresAdminDataSource(ctx context.Context, engine storepb.Engine, stateme
 		}
 	}
 	return false
-}
-
-func shouldResolveDataSourceByQuerySpan(engine storepb.Engine) bool {
-	switch engine {
-	case storepb.Engine_MONGODB, storepb.Engine_ELASTICSEARCH:
-		return true
-	default:
-		return false
-	}
 }
 
 func checkAndGetDataSourceQueriable(

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -250,7 +250,14 @@ func (s *SQLService) Query(ctx context.Context, req *connect.Request[v1pb.QueryR
 		}
 	}
 
-	resolvedDataSourceID, err := resolveDataSourceID(instance, request.DataSourceId)
+	queryDataPolicy := getEffectiveQueryDataPolicy(
+		ctx,
+		s.store,
+		s.licenseService,
+		0,
+		database.ProjectID,
+	)
+	resolvedDataSourceID, err := resolveDataSourceID(instance, request.DataSourceId, statement, queryDataPolicy.AllowAdminDataSource)
 	if err != nil {
 		return nil, err
 	}
@@ -878,7 +885,7 @@ func (s *SQLService) Export(ctx context.Context, req *connect.Request[v1pb.Expor
 		}
 	}
 
-	resolvedDataSourceID, err := resolveDataSourceID(instance, request.DataSourceId)
+	resolvedDataSourceID, err := resolveDataSourceID(instance, request.DataSourceId, statement, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1785,7 +1792,7 @@ func (*SQLService) DiffMetadata(_ context.Context, req *connect.Request[v1pb.Dif
 	}), nil
 }
 
-func resolveDataSourceID(instance *store.InstanceMessage, dataSourceID string) (string, error) {
+func resolveDataSourceID(instance *store.InstanceMessage, dataSourceID string, statement string, allowAdminDataSource bool) (string, error) {
 	if dataSourceID != "" {
 		return dataSourceID, nil
 	}
@@ -1804,6 +1811,10 @@ func resolveDataSourceID(instance *store.InstanceMessage, dataSourceID string) (
 		}
 	}
 
+	if allowAdminDataSource && adminDataSourceID != "" && requiresAdminDataSource(instance.Metadata.GetEngine(), statement) {
+		return adminDataSourceID, nil
+	}
+
 	switch {
 	case readOnlyCount == 1:
 		return readOnlyDataSourceID, nil
@@ -1814,6 +1825,11 @@ func resolveDataSourceID(instance *store.InstanceMessage, dataSourceID string) (
 	default:
 		return "", connect.NewError(connect.CodeFailedPrecondition, errors.New("instance has no admin data source"))
 	}
+}
+
+func requiresAdminDataSource(engine storepb.Engine, statement string) bool {
+	readOnly, _, err := parserbase.ValidateSQLForEditor(engine, statement)
+	return err == nil && !readOnly
 }
 
 func checkAndGetDataSourceQueriable(

--- a/backend/api/v1/sql_service_test.go
+++ b/backend/api/v1/sql_service_test.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,7 +21,7 @@ func TestResolveDataSourceIDUsesAdminForNonReadOnlyAutomaticQueryWhenAllowed(t *
 		},
 	}
 
-	got, err := resolveDataSourceID(instance, "", "INSERT INTO books VALUES (1, 'Bytebase');", true)
+	got, err := resolveDataSourceID(context.Background(), instance, "", "INSERT INTO books VALUES (1, 'Bytebase');", true)
 	require.NoError(t, err)
 	require.Equal(t, "admin", got)
 }
@@ -36,7 +37,7 @@ func TestResolveDataSourceIDKeepsReadOnlyForReadOnlyAutomaticQueryWhenAllowed(t 
 		},
 	}
 
-	got, err := resolveDataSourceID(instance, "", "SELECT * FROM books;", true)
+	got, err := resolveDataSourceID(context.Background(), instance, "", "SELECT * FROM books;", true)
 	require.NoError(t, err)
 	require.Equal(t, "readonly", got)
 }
@@ -52,7 +53,91 @@ func TestResolveDataSourceIDKeepsReadOnlyForNonReadOnlyAutomaticQueryWhenAdminDi
 		},
 	}
 
-	got, err := resolveDataSourceID(instance, "", "INSERT INTO books VALUES (1, 'Bytebase');", false)
+	got, err := resolveDataSourceID(context.Background(), instance, "", "INSERT INTO books VALUES (1, 'Bytebase');", false)
 	require.NoError(t, err)
 	require.Equal(t, "readonly", got)
+}
+
+func TestResolveDataSourceIDUsesAdminForDocumentEngineAutomaticWriteQueryWhenAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		engine    storepb.Engine
+		statement string
+	}{
+		{
+			name:      "MongoDB DML",
+			engine:    storepb.Engine_MONGODB,
+			statement: `db.users.insertOne({name: "Bytebase"})`,
+		},
+		{
+			name:      "MongoDB DDL",
+			engine:    storepb.Engine_MONGODB,
+			statement: `db.createCollection("users")`,
+		},
+		{
+			name:      "Elasticsearch DML",
+			engine:    storepb.Engine_ELASTICSEARCH,
+			statement: "POST /users/_doc\n{\"name\":\"Bytebase\"}",
+		},
+		{
+			name:      "Elasticsearch DDL",
+			engine:    storepb.Engine_ELASTICSEARCH,
+			statement: "PUT /users",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := &store.InstanceMessage{
+				Metadata: &storepb.Instance{
+					Engine: tc.engine,
+					DataSources: []*storepb.DataSource{
+						{Id: "admin", Type: storepb.DataSourceType_ADMIN},
+						{Id: "readonly", Type: storepb.DataSourceType_READ_ONLY},
+					},
+				},
+			}
+
+			got, err := resolveDataSourceID(context.Background(), instance, "", tc.statement, true)
+			require.NoError(t, err)
+			require.Equal(t, "admin", got)
+		})
+	}
+}
+
+func TestResolveDataSourceIDKeepsReadOnlyForDocumentEngineAutomaticReadQueryWhenAllowed(t *testing.T) {
+	tests := []struct {
+		name      string
+		engine    storepb.Engine
+		statement string
+	}{
+		{
+			name:      "MongoDB read",
+			engine:    storepb.Engine_MONGODB,
+			statement: `db.users.find({})`,
+		},
+		{
+			name:      "Elasticsearch read",
+			engine:    storepb.Engine_ELASTICSEARCH,
+			statement: "GET /users/_search",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			instance := &store.InstanceMessage{
+				Metadata: &storepb.Instance{
+					Engine: tc.engine,
+					DataSources: []*storepb.DataSource{
+						{Id: "admin", Type: storepb.DataSourceType_ADMIN},
+						{Id: "readonly", Type: storepb.DataSourceType_READ_ONLY},
+					},
+				},
+			}
+
+			got, err := resolveDataSourceID(context.Background(), instance, "", tc.statement, true)
+			require.NoError(t, err)
+			require.Equal(t, "readonly", got)
+		})
+	}
 }

--- a/backend/api/v1/sql_service_test.go
+++ b/backend/api/v1/sql_service_test.go
@@ -1,0 +1,58 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestResolveDataSourceIDUsesAdminForNonReadOnlyAutomaticQueryWhenAllowed(t *testing.T) {
+	instance := &store.InstanceMessage{
+		Metadata: &storepb.Instance{
+			Engine: storepb.Engine_MYSQL,
+			DataSources: []*storepb.DataSource{
+				{Id: "admin", Type: storepb.DataSourceType_ADMIN},
+				{Id: "readonly", Type: storepb.DataSourceType_READ_ONLY},
+			},
+		},
+	}
+
+	got, err := resolveDataSourceID(instance, "", "INSERT INTO books VALUES (1, 'Bytebase');", true)
+	require.NoError(t, err)
+	require.Equal(t, "admin", got)
+}
+
+func TestResolveDataSourceIDKeepsReadOnlyForReadOnlyAutomaticQueryWhenAllowed(t *testing.T) {
+	instance := &store.InstanceMessage{
+		Metadata: &storepb.Instance{
+			Engine: storepb.Engine_MYSQL,
+			DataSources: []*storepb.DataSource{
+				{Id: "admin", Type: storepb.DataSourceType_ADMIN},
+				{Id: "readonly", Type: storepb.DataSourceType_READ_ONLY},
+			},
+		},
+	}
+
+	got, err := resolveDataSourceID(instance, "", "SELECT * FROM books;", true)
+	require.NoError(t, err)
+	require.Equal(t, "readonly", got)
+}
+
+func TestResolveDataSourceIDKeepsReadOnlyForNonReadOnlyAutomaticQueryWhenAdminDisallowed(t *testing.T) {
+	instance := &store.InstanceMessage{
+		Metadata: &storepb.Instance{
+			Engine: storepb.Engine_MYSQL,
+			DataSources: []*storepb.DataSource{
+				{Id: "admin", Type: storepb.DataSourceType_ADMIN},
+				{Id: "readonly", Type: storepb.DataSourceType_READ_ONLY},
+			},
+		},
+	}
+
+	got, err := resolveDataSourceID(instance, "", "INSERT INTO books VALUES (1, 'Bytebase');", false)
+	require.NoError(t, err)
+	require.Equal(t, "readonly", got)
+}

--- a/backend/tests/sql_query_data_source_test.go
+++ b/backend/tests/sql_query_data_source_test.go
@@ -104,8 +104,14 @@ func TestSQLQueryDataSourceResolution(t *testing.T) {
 	a.Len(queryResp.Msg.Results[0].Rows, 1)
 	a.Equal("Bytebase", queryResp.Msg.Results[0].Rows[0].Values[0].GetStringValue())
 
+	instanceID, err := common.GetInstanceID(instance.Name)
+	a.NoError(err)
+	stores := getStore(t, ctl.server)
+	workspaceID, err := stores.GetWorkspaceID(ctx)
+	a.NoError(err)
+	a.NotEmpty(workspaceID)
 	_, err = ctl.orgPolicyServiceClient.CreatePolicy(ctx, connect.NewRequest(&v1pb.CreatePolicyRequest{
-		Parent: common.FormatWorkspace(common.GetWorkspaceIDFromContext(ctx)),
+		Parent: common.FormatWorkspace(workspaceID),
 		Policy: &v1pb.Policy{
 			Type: v1pb.PolicyType_DATA_QUERY,
 			Policy: &v1pb.Policy_QueryDataPolicy{
@@ -125,10 +131,7 @@ func TestSQLQueryDataSourceResolution(t *testing.T) {
 	a.Len(queryResp.Msg.Results, 1)
 	a.Empty(queryResp.Msg.Results[0].Error)
 
-	instanceID, err := common.GetInstanceID(instance.Name)
-	a.NoError(err)
-	stores := getStore(t, ctl.server)
-	instanceMessage, err := stores.GetInstance(ctx, &store.FindInstanceMessage{Workspace: common.GetWorkspaceIDFromContext(ctx), ResourceID: &instanceID})
+	instanceMessage, err := stores.GetInstance(ctx, &store.FindInstanceMessage{Workspace: workspaceID, ResourceID: &instanceID})
 	a.NoError(err)
 	metadata := proto.CloneOf(instanceMessage.Metadata)
 	var readOnly *storepb.DataSource
@@ -145,7 +148,7 @@ func TestSQLQueryDataSourceResolution(t *testing.T) {
 	metadata.DataSources = append(metadata.DataSources, readOnly)
 	_, err = stores.UpdateInstance(ctx, &store.UpdateInstanceMessage{
 		ResourceID: &instanceID,
-		Workspace:  common.GetWorkspaceIDFromContext(ctx),
+		Workspace:  workspaceID,
 		Metadata:   metadata,
 	})
 	a.NoError(err)

--- a/backend/tests/sql_query_data_source_test.go
+++ b/backend/tests/sql_query_data_source_test.go
@@ -104,6 +104,27 @@ func TestSQLQueryDataSourceResolution(t *testing.T) {
 	a.Len(queryResp.Msg.Results[0].Rows, 1)
 	a.Equal("Bytebase", queryResp.Msg.Results[0].Rows[0].Values[0].GetStringValue())
 
+	_, err = ctl.orgPolicyServiceClient.CreatePolicy(ctx, connect.NewRequest(&v1pb.CreatePolicyRequest{
+		Parent: common.FormatWorkspace(common.GetWorkspaceIDFromContext(ctx)),
+		Policy: &v1pb.Policy{
+			Type: v1pb.PolicyType_DATA_QUERY,
+			Policy: &v1pb.Policy_QueryDataPolicy{
+				QueryDataPolicy: &v1pb.QueryDataPolicy{
+					AllowAdminDataSource: true,
+				},
+			},
+		},
+	}))
+	a.NoError(err)
+
+	queryResp, err = ctl.sqlServiceClient.Query(ctx, connect.NewRequest(&v1pb.QueryRequest{
+		Name:      database.Name,
+		Statement: "INSERT INTO books VALUES (2, 'Bytebase Admin');",
+	}))
+	a.NoError(err)
+	a.Len(queryResp.Msg.Results, 1)
+	a.Empty(queryResp.Msg.Results[0].Error)
+
 	instanceID, err := common.GetInstanceID(instance.Name)
 	a.NoError(err)
 	stores := getStore(t, ctl.server)


### PR DESCRIPTION
## Summary
- Resolve automatic SQL Editor queries against the admin data source when the query is non-read-only and the query data policy allows admin data source usage.
- Preserve read-only data source selection for read-only queries and when admin data source usage is disallowed.
- Add unit coverage for automatic data source resolution and an integration regression for automatic DML execution.

## Test Plan
- [x] `go test -v -count=1 ./backend/api/v1 -run '^TestResolveDataSourceID'`
- [x] `go test -count=1 ./backend/api/v1`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- [ ] `go test -v -count=1 ./backend/tests/ -run '^TestSQLQueryDataSourceResolution$' -timeout 5m` could not complete locally because testcontainers blocked on Docker `Ping` during `TestMain` and timed out before the test case started.
