### PR TITLE
chore(frontend): standardise on uuidv4 and prevent crypto.randomUUID

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -21,6 +21,14 @@ export default [
       "no-console": ["error", { allow: ["warn", "error", "debug", "assert"] }],
       "no-debugger": "error",
       "no-empty-pattern": "error",
+      "no-restricted-properties": [
+        "error",
+        {
+          object: "crypto",
+          property: "randomUUID",
+          message: "Use v4 from 'uuid' package instead of crypto.randomUUID() for compatibility.",
+        },
+      ],
       "vue/no-ref-as-operand": "error",
       "no-useless-escape": "error",
       "@typescript-eslint/no-empty-interface": "error",

--- a/frontend/src/react/components/monaco/MonacoEditor.tsx
+++ b/frontend/src/react/components/monaco/MonacoEditor.tsx
@@ -11,6 +11,7 @@ import {
   useSyncExternalStore,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { v4 as uuidv4 } from "uuid";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { cn } from "@/react/lib/utils";
 import type { Language, SQLDialect } from "@/types";
@@ -162,10 +163,7 @@ export function MonacoEditor({
     if (filename) {
       return filename;
     }
-    const id =
-      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-        ? crypto.randomUUID()
-        : Math.random().toString(36).slice(2);
+    const id = uuidv4();
     return `${id}.${extensionNameOfLanguage(safeLanguage)}`;
   }, [filename, safeLanguage]);
   const [contentHeight, setContentHeight] = useState(min);

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -18,6 +18,7 @@ import React, {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { v4 as uuidv4 } from "uuid";
 import { AccountMultiSelect } from "@/react/components/AccountMultiSelect";
 import { DatabaseResourceSelector as DatabaseResourceSelectorComponent } from "@/react/components/DatabaseResourceSelector";
 import { EnvironmentMultiSelect } from "@/react/components/EnvironmentMultiSelect";
@@ -1220,7 +1221,7 @@ function EditMemberRoleDrawer({
   const [showNestedGrant, setShowNestedGrant] = useState(false);
 
   const [form, setForm] = useState<RoleBindingFormState>(() => ({
-    id: crypto.randomUUID(),
+    id: uuidv4(),
     role: "",
     reason: "",
     expirationDays: 7,


### PR DESCRIPTION
## Summary

- Replace `crypto.randomUUID()` with `uuidv4()` from the `uuid` package in [MembersPage.tsx](file:///Users/steven/Projects/minecraft/bytebase/frontend/src/react/pages/settings/MembersPage.tsx) and [MonacoEditor.tsx](file:///Users/steven/Projects/minecraft/bytebase/frontend/src/react/components/monaco/MonacoEditor.tsx). This fixes potential runtime crashes in insecure/HTTP contexts where the native `crypto.randomUUID` is undefined.
- Add `no-restricted-properties` lint rule to [eslint.config.mjs](file:///Users/steven/Projects/minecraft/bytebase/frontend/eslint.config.mjs) to statically block future introduction of `crypto.randomUUID()`, helping to maintain origin compatibility and standardization on `uuidv4`.

## Test plan

- [x] `pnpm --dir frontend check` — all lint, formatting, i18n, and layering checks pass
- [x] `pnpm --dir frontend type-check` — React type check passes successfully
- [x] `pnpm --dir frontend test` — all 2021 frontend unit tests pass successfully

🤖 Generated with Antigravity
