### PR TITLE
feat(partiql): bump omni to pick up T15b.1 SIZE/EXISTS parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260525084621-959d49e4eb34
+	github.com/bytebase/omni v0.0.0-20260526033421-2467fbde8636
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260525084621-959d49e4eb34 h1:bg2VW/KjuI9ivXnY5+y2You0bKLEWmYq0/DMXh8PhYQ=
-github.com/bytebase/omni v0.0.0-20260525084621-959d49e4eb34/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260526033421-2467fbde8636 h1:BQnHUpxwiJg6iSXD6UW3XDZHB872dLlX80kTUaPnH9Y=
+github.com/bytebase/omni v0.0.0-20260526033421-2467fbde8636/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary

- Bumps `github.com/bytebase/omni` from `20260525084621-959d49e4eb34` to `20260526033421-2467fbde8636`.
- Picks up omni T15b.1 (commit `48421e9`): the parser now produces `*ast.FuncCall{Name: "SIZE"|"EXISTS", ...}` for the reserved-name `SIZE` and `EXISTS` builtins instead of returning `"deferred to parser-builtins"` syntax errors.
- Unblocks DynamoDB-typical queries like `WHERE size(Awards) > 0` and `WHERE EXISTS (SELECT * FROM Music WHERE ...)` in the SQL editor.
- No code changes needed in the bytebase partiql plugin — these go through the same `parsePartiQLStatements` / `validateQuery` path that PR #20391 covered.

This is the next sub-PR in the 15b series. Remaining 15b sub-PRs cover the rest of the FunctionCallReserved keywords (`CHAR_LENGTH` / `OCTET_LENGTH` / `UPPER` / `LOWER` / etc.), the CAST family, `CASE`, `SUBSTRING`, `TRIM`, `EXTRACT`, `COALESCE` / `NULLIF`, `DATE_ADD` / `DATE_DIFF`, and the `LIST()` / `SEXP()` constructors.

## Test plan

- [ ] `go build ./backend/...` — clean (verified locally)
- [ ] `go test ./backend/plugin/parser/partiql/...` — pass (verified locally)
- [ ] `go test ./backend/plugin/parser/plsql/...` — pass (verifying the fallback test from #20391 still passes after this further bump; verified locally)
- [ ] Manually verify in the SQL editor: `SELECT * FROM Music WHERE size(Awards) > 0` parses cleanly
- [ ] Manually verify in the SQL editor: `SELECT * FROM Music WHERE EXISTS (SELECT * FROM Music WHERE Artist = 'X' AND SongTitle = 'Y')` parses cleanly

## Out of scope

- The other FunctionCallReserved keywords (`CHAR_LENGTH`, `CHARACTER_LENGTH`, `OCTET_LENGTH`, `BIT_LENGTH`, `UPPER`, `LOWER`) and the rest of 15b stay stubbed for follow-up sub-PRs.
- `COUNT` is in omni DAG node 14 (parser-aggregates), not 15b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)