### PR TITLE
fix(plan): prevent task SQL preview clipping

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+
+import source from "./PlanDetailRollbackSheet.tsx?raw";
+
+const rollbackReadonlyMonacoProps = (src: string): string => {
+  const match = src.match(
+    /<ReadonlyMonaco[\s\S]*?content=\{preview\.statement\}[\s\S]*?\/>/
+  );
+  expect(match, "expected rollback preview ReadonlyMonaco").not.toBeNull();
+  return match?.[0] ?? "";
+};
+
+describe("PlanDetailRollbackSheet statement preview", () => {
+  test("lets Monaco own the compact preview viewport", () => {
+    const props = rollbackReadonlyMonacoProps(source);
+
+    expect(props).toContain("max={256}");
+    expect(props).toContain("min={128}");
+    expect(props).not.toContain("max-h-[320px]");
+    expect(props).not.toContain("overflow-hidden");
+  });
+});

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.tsx
@@ -239,9 +239,11 @@ export function PlanDetailRollbackSheet({
                       </div>
                     ) : preview.statement ? (
                       <ReadonlyMonaco
-                        className="relative h-auto max-h-[320px] min-h-[120px] overflow-hidden rounded-md border border-control-border"
+                        className="relative rounded-md border border-control-border"
                         content={preview.statement}
                         language="sql"
+                        min={128}
+                        max={256}
                       />
                     ) : (
                       <div className="flex items-center justify-center rounded-md border bg-gray-50 p-8">

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+
+import source from "./DeployTaskItem.tsx?raw";
+
+const statementReadonlyMonacoProps = (src: string): string => {
+  const match = src.match(
+    /<ReadonlyMonaco[\s\S]*?content=\{statement\}[\s\S]*?\/>/
+  );
+  expect(match, "expected statement ReadonlyMonaco").not.toBeNull();
+  return match?.[0] ?? "";
+};
+
+describe("DeployTaskItem statement editor", () => {
+  test("lets Monaco own the compact statement viewport", () => {
+    const props = statementReadonlyMonacoProps(source);
+
+    expect(props).toContain("max={256}");
+    expect(props).toContain("min={128}");
+    expect(props).not.toContain("max-h-64");
+    expect(props).not.toContain("overflow-hidden");
+  });
+});

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
@@ -300,11 +300,13 @@ export function DeployTaskItem({
                     <>
                       <ReadonlyMonaco
                         className={cn(
-                          "relative max-h-64 min-h-[120px] overflow-hidden rounded border text-sm",
+                          "relative rounded border text-sm",
                           isTruncated && "rounded-b-none"
                         )}
                         content={statement}
                         language="sql"
+                        min={128}
+                        max={256}
                       />
                       {isTruncated && (
                         <div className="rounded-b border border-t-0 bg-gray-50 px-3 py-1.5 text-xs text-gray-500">


### PR DESCRIPTION
## Summary
- Prevent plan task SQL previews from being clipped by host CSS constraints.
- Move compact preview sizing into ReadonlyMonaco min/max props for task and rollback previews.

## Key Changes
- Replace CSS max-height/overflow clipping with Monaco-owned viewport sizing.
- Add regression tests for task-card and rollback preview statement editors.

## Motivation
- BYT-9561 reports SQL statements cut off in the Plan page task section while other statement surfaces render correctly.

## Testing
- pnpm --dir frontend exec vitest run src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.test.tsx src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.test.tsx
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test