### PR TITLE
feat(partiql): bump omni to pick up T15b.2 length/case scalar functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260526033421-2467fbde8636
+	github.com/bytebase/omni v0.0.0-20260526060846-6c44a3435258
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260526033421-2467fbde8636 h1:BQnHUpxwiJg6iSXD6UW3XDZHB872dLlX80kTUaPnH9Y=
-github.com/bytebase/omni v0.0.0-20260526033421-2467fbde8636/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260526060846-6c44a3435258 h1:gdMrtN/3tZTLCaXCeplnF2uVcp9t0luuwppBvmls2Co=
+github.com/bytebase/omni v0.0.0-20260526060846-6c44a3435258/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary

- Bumps `github.com/bytebase/omni` from `20260526033421-2467fbde8636` to `20260526060846-6c44a3435258`.
- Picks up omni T15b.2 (commit `6c44a34`): the parser now produces `*ast.FuncCall` for the remaining `FunctionCallReserved` simple-`(expr)` keywords — `CHAR_LENGTH`, `CHARACTER_LENGTH`, `OCTET_LENGTH`, `BIT_LENGTH`, `UPPER`, `LOWER`.
- Unblocks queries like `WHERE UPPER(Artist) = 'ACME'` and `WHERE CHAR_LENGTH(SongTitle) > 10` in the SQL editor.
- No code changes in the bytebase partiql plugin — same path as PR #20391 (T15a) and #20397 (T15b.1).

The only `FunctionCallReserved` keyword still stubbed in omni is `COUNT`, which belongs to omni DAG node 14 (parser-aggregates) — but DynamoDB rejects aggregates server-side anyway, so that's parity work rather than customer-facing.

## Test plan

- [ ] `go build ./backend/...` — clean (verified locally)
- [ ] `go test ./backend/plugin/parser/partiql/...` — pass (verified locally)
- [ ] `go test ./backend/plugin/parser/plsql/...` — pass (verified locally; fallback test still uses `REFERENCING TRIGGER`)
- [ ] Manually verify in the SQL editor: `SELECT * FROM Music WHERE UPPER(Artist) = 'ACME BAND'` parses cleanly
- [ ] Manually verify in the SQL editor: `SELECT * FROM Music WHERE CHAR_LENGTH(SongTitle) > 5` parses cleanly

## Out of scope

- The remaining keyword-dispatched builtins in omni (CAST family, CASE, SUBSTRING, TRIM, EXTRACT, COALESCE, NULLIF, DATE_ADD, DATE_DIFF, LIST()/SEXP()) stay stubbed for follow-up sub-PRs.
- Aggregates (COUNT/SUM/AVG/MIN/MAX) — DAG node 14, future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)