### PR TITLE
chore: optimize display for default project filter

### DIFF
--- a/frontend/src/react/components/BannersWrapper.tsx
+++ b/frontend/src/react/components/BannersWrapper.tsx
@@ -283,7 +283,7 @@ function BannerUpgradeSubscription() {
                   neededPlan: (
                     <button
                       type="button"
-                      className="cursor-pointer underline hover:opacity-60"
+                      className="mr-1 cursor-pointer underline hover:opacity-60"
                       onClick={() => setShowModal(true)}
                     >
                       {neededPlanFeatures}
@@ -294,8 +294,8 @@ function BannerUpgradeSubscription() {
             </div>
             <div className="ml-2">
               <Button size="sm" onClick={gotoSubscriptionPage}>
+                <Sparkles className="h-auto w-4" />
                 {t("subscription.upgrade")}
-                <Sparkles className="ml-1 h-auto w-4 text-accent" />
               </Button>
             </div>
           </div>

--- a/frontend/src/react/components/header/HeaderBreadcrumb.tsx
+++ b/frontend/src/react/components/header/HeaderBreadcrumb.tsx
@@ -17,6 +17,7 @@ import {
 import {
   isValidProjectName,
   projectNamePrefix,
+  workspaceNamePrefix,
 } from "@/react/lib/resourceName";
 import { cn } from "@/react/lib/utils";
 import {
@@ -126,24 +127,39 @@ function WorkspaceSegment() {
             sideOffset={6}
             className="min-w-[14rem] p-1!"
           >
-            {workspaceList.map((ws) => (
-              <button
-                key={ws.name}
-                type="button"
-                className={cn(
-                  "w-full flex items-center justify-between rounded-xs px-3 py-1.5 text-sm cursor-pointer",
-                  ws.name === currentWorkspaceName
-                    ? "bg-control-bg font-medium text-accent"
-                    : "text-control hover:bg-control-bg"
-                )}
-                onClick={() => onSwitch(ws.name)}
-              >
-                <span className="truncate">{ws.title}</span>
-                {ws.name === currentWorkspaceName && (
-                  <Check className="size-4 shrink-0" />
-                )}
-              </button>
-            ))}
+            {workspaceList.map((ws) => {
+              const workspaceId = ws.name.startsWith(workspaceNamePrefix)
+                ? ws.name.slice(workspaceNamePrefix.length)
+                : ws.name;
+              return (
+                <button
+                  key={ws.name}
+                  type="button"
+                  className={cn(
+                    "w-full flex items-center justify-between rounded-xs px-3 py-1.5 text-sm cursor-pointer gap-x-2",
+                    ws.name === currentWorkspaceName
+                      ? "bg-control-bg font-medium text-accent"
+                      : "text-control hover:bg-control-bg"
+                  )}
+                  onClick={() => onSwitch(ws.name)}
+                >
+                  <span className="flex flex-col items-start min-w-0">
+                    <span className="truncate w-full text-left">
+                      {ws.title}
+                    </span>
+                    <span
+                      className="truncate w-full text-left text-xs font-normal text-control-light"
+                      title={workspaceId}
+                    >
+                      {workspaceId}
+                    </span>
+                  </span>
+                  {ws.name === currentWorkspaceName && (
+                    <Check className="size-4 shrink-0" />
+                  )}
+                </button>
+              );
+            })}
           </PopoverContent>
         </Popover>
       )}

--- a/frontend/src/react/pages/settings/DatabasesPage.tsx
+++ b/frontend/src/react/pages/settings/DatabasesPage.tsx
@@ -124,8 +124,29 @@ export function DatabasesPage() {
   );
 
   const projectStore = useProjectV1Store();
-  const defaultProjectId = extractProjectResourceName(
-    actuatorStore.serverInfo?.defaultProject ?? ""
+  // `serverInfo.defaultProject` is fetched asynchronously by the actuator
+  // store; wrap with `useVueState` so the filter value updates the moment
+  // it arrives instead of being captured as an empty string on first
+  // render (which sends a broken `projects/` filter to the backend).
+  const defaultProjectId = useVueState(() =>
+    extractProjectResourceName(actuatorStore.serverInfo?.defaultProject ?? "")
+  );
+  // Shared "Unassigned" option used both by the dropdown (via onSearch) and
+  // by the selected-tag display (via the scope's static `options`). `custom`
+  // hides the raw "default-<random>" id from the dropdown so users only see
+  // the friendly label.
+  const unassignedProjectOption = useMemo<ValueOption>(
+    () => ({
+      value: defaultProjectId,
+      keywords: ["unassigned", "default"],
+      custom: true,
+      render: () => (
+        <span className="italic text-control-light">
+          {t("common.unassigned")}
+        </span>
+      ),
+    }),
+    [defaultProjectId, t]
   );
   const searchProjects = useCallback(
     async (keyword: string): Promise<ValueOption[]> => {
@@ -133,13 +154,6 @@ export function DatabasesPage() {
         pageSize: getDefaultPagination(),
         filter: keyword.trim() ? { query: keyword } : undefined,
       });
-      const unassigned: ValueOption = {
-        value: defaultProjectId,
-        keywords: ["unassigned", "default"],
-        render: () => (
-          <span className="italic text-control-light">Unassigned</span>
-        ),
-      };
       const matchesUnassigned =
         !keyword.trim() || "unassigned".includes(keyword.trim().toLowerCase());
       const remote = projects
@@ -148,9 +162,9 @@ export function DatabasesPage() {
           const id = extractProjectResourceName(p.name);
           return { value: id, keywords: [id, p.title] };
         });
-      return matchesUnassigned ? [unassigned, ...remote] : remote;
+      return matchesUnassigned ? [unassignedProjectOption, ...remote] : remote;
     },
-    [projectStore, defaultProjectId]
+    [projectStore, defaultProjectId, unassignedProjectOption]
   );
 
   const instanceStore = useInstanceV1Store();
@@ -178,6 +192,10 @@ export function DatabasesPage() {
         id: "project",
         title: t("common.project"),
         description: t("issue.advanced-search.scope.project.description"),
+        // Static option lets the selected-tag display resolve the default
+        // project id to "Unassigned" — the tag renderer only looks at
+        // `options`, not async results.
+        options: [unassignedProjectOption],
         onSearch: searchProjects,
       },
       {
@@ -226,7 +244,13 @@ export function DatabasesPage() {
         allowMultiple: true,
       },
     ];
-  }, [t, environments, searchInstances, searchProjects]);
+  }, [
+    t,
+    environments,
+    searchInstances,
+    searchProjects,
+    unassignedProjectOption,
+  ]);
 
   // Derived filter values
   const projectVal = getValueFromScopes(searchParams, "project");
@@ -288,6 +312,26 @@ export function DatabasesPage() {
       });
     }
   }, [uiStateStore]);
+
+  // Backfill the project scope once the actuator's default project ID
+  // arrives. The initial `useState` initializer reads the actuator
+  // synchronously — if it hasn't finished fetching yet, the project value
+  // is captured as "" and the API filter becomes broken (`projects/`).
+  useEffect(() => {
+    if (!defaultProjectId) return;
+    setSearchParams((prev) => {
+      const projectScope = prev.scopes.find((s) => s.id === "project");
+      if (!projectScope || projectScope.value !== "") return prev;
+      return {
+        ...prev,
+        scopes: prev.scopes.map((s) =>
+          s.id === "project" && s.value === ""
+            ? { ...s, value: defaultProjectId }
+            : s
+        ),
+      };
+    });
+  }, [defaultProjectId]);
 
   // Sync search state to URL
   useEffect(() => {

--- a/frontend/src/react/pages/settings/InstanceDetailPage.tsx
+++ b/frontend/src/react/pages/settings/InstanceDetailPage.tsx
@@ -38,6 +38,7 @@ import { useUnsavedChangesGuard } from "@/react/hooks/useUnsavedChangesGuard";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
   pushNotification,
+  useActuatorV1Store,
   useDatabaseV1Store,
   useDBSchemaV1Store,
   useEnvironmentV1Store,
@@ -318,21 +319,42 @@ export function InstanceDetailPage({ instanceId }: { instanceId: string }) {
   );
 
   const projectStore = useProjectV1Store();
+  const actuatorStore = useActuatorV1Store();
+  // Reactive: the actuator's `defaultProject` is fetched asynchronously, so
+  // we must subscribe through `useVueState` — otherwise the value is
+  // captured as `""` on first render and the API filter becomes broken.
+  const defaultProjectId = useVueState(() =>
+    extractProjectResourceName(actuatorStore.serverInfo?.defaultProject ?? "")
+  );
+  const unassignedProjectOption = useMemo<ValueOption>(
+    () => ({
+      value: defaultProjectId,
+      keywords: ["unassigned", "default"],
+      custom: true,
+      render: () => (
+        <span className="italic text-control-light">
+          {t("common.unassigned")}
+        </span>
+      ),
+    }),
+    [defaultProjectId, t]
+  );
   const searchProjects = useCallback(
     async (keyword: string): Promise<ValueOption[]> => {
       const { projects } = await projectStore.fetchProjectList({
         pageSize: getDefaultPagination(),
         filter: keyword.trim() ? { query: keyword } : undefined,
       });
-      return projects.map((p) => {
+      return projects.map<ValueOption>((p) => {
         const id = extractProjectResourceName(p.name);
+        if (id === defaultProjectId) return unassignedProjectOption;
         return {
           value: id,
           keywords: [id, p.title],
         };
       });
     },
-    [projectStore]
+    [projectStore, defaultProjectId, unassignedProjectOption]
   );
 
   const scopeOptions: ScopeOption[] = useMemo(
@@ -357,6 +379,9 @@ export function InstanceDetailPage({ instanceId }: { instanceId: string }) {
         id: "project",
         title: t("common.project"),
         description: t("issue.advanced-search.scope.project.description"),
+        // Static option lets the selected-tag display resolve the default
+        // project id to "Unassigned".
+        options: [unassignedProjectOption],
         onSearch: searchProjects,
       },
       {
@@ -366,7 +391,7 @@ export function InstanceDetailPage({ instanceId }: { instanceId: string }) {
         allowMultiple: true,
       },
     ],
-    [t, environments, searchProjects]
+    [t, environments, searchProjects, unassignedProjectOption]
   );
 
   const handleTabChange = useCallback((tab: string | number | null) => {


### PR DESCRIPTION
- Optimize display for default project filter, close BYT-9505
<img width="624" height="198" alt="CleanShot 2026-05-26 at 14 52 41@2x" src="https://github.com/user-attachments/assets/a4dace75-764c-4ce1-aecb-ac3191d8fa60" />

- Show workspace id, close BYT-9571
<img width="622" height="298" alt="CleanShot 2026-05-26 at 14 53 04@2x" src="https://github.com/user-attachments/assets/924fcd28-716b-41fe-a007-edbecea4f2a4" />
