### PR TITLE
feat(partiql): bump omni to pick up T15b.3 CASE expressions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260526060846-6c44a3435258
+	github.com/bytebase/omni v0.0.0-20260526084046-c2f9fab67b1a
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260526060846-6c44a3435258 h1:gdMrtN/3tZTLCaXCeplnF2uVcp9t0luuwppBvmls2Co=
-github.com/bytebase/omni v0.0.0-20260526060846-6c44a3435258/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260526084046-c2f9fab67b1a h1:ylY4JarRfTJvZtlnOg8CmMLLEcc/eeIdByCLLP85IRQ=
+github.com/bytebase/omni v0.0.0-20260526084046-c2f9fab67b1a/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary

- Bumps `github.com/bytebase/omni` from `20260526060846-6c44a3435258` to `20260526084046-c2f9fab67b1a`.
- Picks up omni T15b.3 (commit `c2f9fab`): the parser now produces `*ast.CaseExpr` for both PartiQL CASE forms — searched (`CASE WHEN cond THEN r [WHEN ...]... [ELSE r] END`) and simple (`CASE operand WHEN val THEN r [WHEN ...]... [ELSE r] END`).
- Unblocks queries that use CASE in projections or WHERE clauses (e.g., `SELECT CASE WHEN Awards IS MISSING THEN 0 ELSE Awards END FROM Music`).
- No code changes in the bytebase partiql plugin — same path as PR #20391 (T15a), #20397 (T15b.1), and #20399 (T15b.2).

## Test plan

- [ ] `go build ./backend/...` — clean (verified locally)
- [ ] `go test ./backend/plugin/parser/partiql/...` — pass (verified locally)
- [ ] `go test ./backend/plugin/parser/plsql/...` — pass (verified locally)
- [ ] Manually verify in the SQL editor: `SELECT CASE WHEN Awards IS MISSING THEN 0 ELSE Awards END FROM Music` parses cleanly
- [ ] Manually verify in the SQL editor: `SELECT * FROM Music WHERE CASE Artist WHEN 'Acme Band' THEN 1 ELSE 0 END = 1` parses cleanly
- [ ] Manually verify in the SQL editor: malformed `CASE 1 + 1 END` returns a clear syntax error ("CASE expression requires at least one WHEN clause")

## Out of scope

- Remaining keyword-dispatched builtins in omni: CAST family (CAST/CAN_CAST/CAN_LOSSLESS_CAST), SUBSTRING, TRIM, EXTRACT, COALESCE, NULLIF, DATE_ADD, DATE_DIFF, LIST()/SEXP() constructors. All stubbed until follow-up sub-PRs.
- Aggregates (COUNT/SUM/AVG/MIN/MAX) — DAG node 14, future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)