### PR TITLE
fix(pg): bump omni to recognize PG 18 builtins (uuidv7, etc.)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260526084046-c2f9fab67b1a
+	github.com/bytebase/omni v0.0.0-20260526091314-3332e95cbcc5
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260526084046-c2f9fab67b1a h1:ylY4JarRfTJvZtlnOg8CmMLLEcc/eeIdByCLLP85IRQ=
-github.com/bytebase/omni v0.0.0-20260526084046-c2f9fab67b1a/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260526091314-3332e95cbcc5 h1:nwOlLs/5GLVxqjmWRZt0TMO9SIUGoYyo8/sUWsPLuMc=
+github.com/bytebase/omni v0.0.0-20260526091314-3332e95cbcc5/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary

- Bumps `github.com/bytebase/omni` from `20260525084621-959d49e4eb34` to `20260526091314-3332e95cbcc5`.
- Picks up the PG-18 `pg_catalog` refresh in omni — `pg_proc`, `pg_type`, `pg_cast`, `pg_operator`, and `oids_generated.go` regenerated from `postgres @ REL_18_STABLE` source via `pgddl-gen`.
- Adds ~83 new built-in functions to omni's in-memory catalog, including `uuidv4()`, `uuidv7()`, `uuidv7(interval)`, `crc32`, `crc32c`, `array_reverse`, plus 6 new casts.
- No code changes in this repo — only the dependency bump.

## Root cause

Omni's `pg_proc` table was snapshotted from PostgreSQL 17 source. Declarative SDL flow goes:

```
runDeclarativeRelease
  → schema.SDLMigration
    → pgDiffSDLMigration
      → loadCatalog(sourceSDL)            ← omni in-memory simulator
        → catalog.LoadSDL(text)
          → resolve DEFAULT uuidv7()      ← lookup in BuiltinProcs (PG 17!)
            → 42883 "function uuidv7() does not exist"
```

The PG-17 baseline didn't include the `uuidv7()`/`uuidv4()` symbols added in PG 18, so any column declared with `DEFAULT uuidv7()` blew up `loadCatalog` of the source schema, surfacing as `failed to compute SDL migration: failed to load source schema`.

## Test plan

- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go` — clean
- [x] `go build -o /tmp/bytebase-action ./action` — clean
- [x] `golangci-lint run --allow-parallel-runners` — 0 issues
- [x] Manual: with a local omni `replace`, ran `bytebase-action rollout --declarative` against a PG 18 instance whose schema includes `id uuid DEFAULT uuidv7() PRIMARY KEY`. The previous failure is gone; the rollout creates the release/plan and produces the expected migration SQL with the `DEFAULT uuidv7()` clause preserved.

## Related

- Linear: [BYT-9570](https://linear.app/bytebase/issue/BYT-9570/declarative-sdl-migration-fails-with-postgresql-18-built-in-uuidv7)
- GitHub issue: #20351
- Upstream commit: bytebase/omni@3332e95cbcc5

🤖 Generated with [Claude Code](https://claude.com/claude-code)