### PR TITLE
ci: schedule cloud rollout Mon-Thu at 00:00 UTC

### DIFF
--- a/.github/workflows/build-push-cloud-image.yml
+++ b/.github/workflows/build-push-cloud-image.yml
@@ -2,6 +2,9 @@ name: Deploy Bytebase Cloud
 
 on:
   workflow_dispatch:
+  schedule:
+    # Monday-Thursday at 00:00 UTC
+    - cron: "0 0 * * 1-4"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add a `schedule` trigger to `build-push-cloud-image.yml` that runs Monday–Thursday at 00:00 UTC.
- `workflow_dispatch` is preserved for on-demand runs.

## Test plan
- [ ] After merge, confirm the workflow appears in GitHub Actions with a scheduled run on the next Mon–Thu at 00:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)