### PR TITLE
ci: trigger bytebase/oncall sync-oncall workflow daily

### DIFF
--- a/.github/workflows/trigger-oncall-sync.yml
+++ b/.github/workflows/trigger-oncall-sync.yml
@@ -1,0 +1,20 @@
+name: Trigger oncall sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Daily at 00:00 UTC. Hosted here because bytebase/oncall has too little
+    # activity for GitHub to keep its own scheduled workflow alive.
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Trigger sync-oncall workflow on bytebase/oncall
+        env:
+          GH_TOKEN: ${{ secrets.GHA_DISPATCH_TOKEN }}
+        run: gh workflow run sync-oncall.yml --repo bytebase/oncall

--- a/.github/workflows/trigger-oncall-sync.yml
+++ b/.github/workflows/trigger-oncall-sync.yml
@@ -3,9 +3,11 @@ name: Trigger oncall sync
 on:
   workflow_dispatch:
   schedule:
-    # Daily at 00:00 UTC. Hosted here because bytebase/oncall has too little
-    # activity for GitHub to keep its own scheduled workflow alive.
-    - cron: "0 0 * * *"
+    # Daily at 00:17 UTC. Hosted here because bytebase/oncall has too little
+    # activity for GitHub to keep its own scheduled workflow alive. The
+    # non-zero minute avoids GitHub Actions' hour-boundary high-load window,
+    # where scheduled jobs can be delayed or dropped.
+    - cron: "17 0 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/trigger-oncall-sync.yml` which runs daily at 00:00 UTC and dispatches `sync-oncall.yml` on `bytebase/oncall`.
- Hosted here because `bytebase/oncall` has too little activity for GitHub to keep its own scheduled workflow alive.
- Uses repo secret `GHA_DISPATCH_TOKEN` (fine-grained PAT with `actions: write` on `bytebase/oncall`).

## Test plan
- [ ] After merge, run the workflow manually via Actions → "Trigger oncall sync" → Run workflow.
- [ ] Confirm a new run appears on https://github.com/bytebase/oncall/actions/workflows/sync-oncall.yml.
- [ ] Verify it fires automatically on the next 00:00 UTC tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)