### PR TITLE
fix(plan): sync options with statement section

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { act, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { State } from "@/types/proto-es/v1/common_pb";
+import { Engine, State } from "@/types/proto-es/v1/common_pb";
 import type { PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import type { CheckReleaseResponse_CheckResult } from "@/types/proto-es/v1/release_service_pb";
 import type { PlanDetailPageState } from "../shell/hooks/types";
@@ -18,7 +18,13 @@ const mocks = vi.hoisted(() => ({
   fetchDBGroupListByProjectName: vi.fn(),
   getDatabaseByName: vi.fn(),
   getDBGroupByName: vi.fn(),
+  getInstanceResource: vi.fn(),
+  getPlanOptionVisibility: vi.fn(),
   getProjectByName: vi.fn(),
+  localSheets: new Map<
+    string,
+    { content: Uint8Array; contentSize: bigint; name: string }
+  >(),
   patchState: vi.fn(),
   routerPush: vi.fn(),
   databaseStore: {
@@ -135,7 +141,23 @@ vi.mock("@/react/components/ui/sheet", () => ({
 }));
 
 vi.mock("@/react/components/ui/switch", () => ({
-  Switch: () => null,
+  Switch: ({
+    checked,
+    disabled,
+    onCheckedChange,
+  }: {
+    checked: boolean;
+    disabled?: boolean;
+    onCheckedChange: (checked: boolean) => void;
+  }) => (
+    <button
+      disabled={disabled}
+      onClick={() => onCheckedChange(!checked)}
+      type="button"
+    >
+      {checked ? "switch-on" : "switch-off"}
+    </button>
+  ),
 }));
 
 vi.mock("@/react/components/ui/tooltip", () => ({
@@ -195,7 +217,7 @@ vi.mock("@/utils", () => ({
   }),
   getDatabaseEnvironment: () => undefined,
   getDefaultTransactionMode: () => false,
-  getInstanceResource: () => undefined,
+  getInstanceResource: mocks.getInstanceResource,
   hasProjectPermissionV2: () => true,
 }));
 
@@ -209,19 +231,20 @@ vi.mock("@/utils/v1/databaseGroup", () => ({
 }));
 
 vi.mock("../utils/localSheet", () => ({
-  getLocalSheetByName: (name: string) => ({ name, content: "" }),
+  getLocalSheetByName: (name: string) => {
+    const existing = mocks.localSheets.get(name);
+    if (existing) return existing;
+    const sheet = { name, content: new Uint8Array(), contentSize: 0n };
+    mocks.localSheets.set(name, sheet);
+    return sheet;
+  },
   getNextLocalSheetUID: () => "-1",
   removeLocalSheet: vi.fn(),
 }));
 
 vi.mock("../utils/options", () => ({
   allowGhostForDatabase: () => false,
-  getPlanOptionVisibility: () => ({
-    showGhost: false,
-    showPreBackup: false,
-    showRole: false,
-    showTransactionMode: false,
-  }),
+  getPlanOptionVisibility: mocks.getPlanOptionVisibility,
 }));
 
 vi.mock("../utils/planCheck", () => ({
@@ -278,12 +301,15 @@ vi.mock("./PlanDetailStatementSection", () => ({
   PlanDetailStatementSection: ({
     planCheckRuns,
     spec,
+    statementVersion,
   }: {
     planCheckRuns?: PlanCheckRun[];
+    statementVersion?: number;
     spec: { id: string };
   }) => (
     <div data-testid="statement-section">
-      {spec.id}:{planCheckRuns?.map((run) => run.name).join(",") ?? ""}
+      {spec.id}:{planCheckRuns?.map((run) => run.name).join(",") ?? ""}:
+      {statementVersion ?? 0}
     </div>
   ),
 }));
@@ -319,6 +345,21 @@ let root: ReturnType<typeof createRoot>;
 beforeEach(() => {
   vi.useFakeTimers();
   vi.clearAllMocks();
+  mocks.localSheets.clear();
+  mocks.getPlanOptionVisibility.mockReturnValue({
+    shouldShow: false,
+    showGhost: false,
+    showInstanceRole: false,
+    showIsolationLevel: false,
+    showPreBackup: false,
+    showTransactionMode: false,
+  });
+  mocks.getInstanceResource.mockReturnValue({
+    engine: Engine.MYSQL,
+    engineVersion: "",
+    name: "instances/test",
+    title: "test",
+  });
   mocks.databaseStore.fetchDatabases.mockResolvedValue({
     databases: [{ name: DB_WIDGETS }, { name: DB_COGS }],
     nextPageToken: "",
@@ -595,5 +636,54 @@ describe("PlanDetailChangesBranch", () => {
 
     expect(container.textContent).toContain("spec-2:");
     expect(container.textContent).not.toContain("spec-2:check-run-for-spec-1");
+  });
+
+  it("refreshes the statement section after changing create-plan options", async () => {
+    mocks.getPlanOptionVisibility.mockReturnValue({
+      shouldShow: true,
+      showGhost: false,
+      showInstanceRole: false,
+      showIsolationLevel: false,
+      showPreBackup: false,
+      showTransactionMode: true,
+    });
+    const page = buildPageState();
+    page.plan.specs = [
+      {
+        id: "spec-1",
+        config: {
+          case: "changeDatabaseConfig",
+          value: {
+            sheet: "projects/foo/sheets/-1",
+            targets: [DB_WIDGETS],
+          },
+        },
+      },
+    ] as unknown as PlanDetailPageState["plan"]["specs"];
+
+    act(() => {
+      root.render(
+        <PlanDetailProvider value={page}>
+          <PlanDetailChangesBranch
+            selectedSpecId="spec-1"
+            onSelectedSpecIdChange={vi.fn()}
+          />
+        </PlanDetailProvider>
+      );
+    });
+    await flush();
+
+    expect(container.textContent).toContain("spec-1::0");
+
+    await act(async () => {
+      (
+        [...container.querySelectorAll("button")].find(
+          (button) => button.textContent === "switch-off"
+        ) as HTMLButtonElement | undefined
+      )?.click();
+    });
+    await flush();
+
+    expect(container.textContent).toContain("spec-1::1");
   });
 });

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -204,6 +204,9 @@ export function PlanDetailChangesBranch({
   const [draftCheckResultsBySpecId, setDraftCheckResultsBySpecId] = useState<
     Record<string, CheckReleaseResponse_CheckResult[] | undefined>
   >({});
+  const [statementVersionBySpecId, setStatementVersionBySpecId] = useState<
+    Record<string, number>
+  >({});
   const specs = page.plan.specs ?? [];
   // Specs visible in the tab strip — real specs plus any pending draft.
   const visibleSpecs = useMemo(
@@ -463,6 +466,12 @@ export function PlanDetailChangesBranch({
     },
     [selectedSpecIdForDraftChecks]
   );
+  const handleStatementPersisted = useCallback((specId: string) => {
+    setStatementVersionBySpecId((prev) => ({
+      ...prev,
+      [specId]: (prev[specId] ?? 0) + 1,
+    }));
+  }, []);
 
   if (!selectedSpec) {
     return (
@@ -582,6 +591,7 @@ export function PlanDetailChangesBranch({
                 : planCheckRunListForSpec(page.planCheckRuns, selectedSpec)
             }
             spec={selectedSpec}
+            statementVersion={statementVersionBySpecId[selectedSpec.id] ?? 0}
           />
           {!specHasRelease &&
             page.isCreating &&
@@ -593,7 +603,14 @@ export function PlanDetailChangesBranch({
                 selectedSpec={selectedSpec}
               />
             )}
-          {!specHasRelease && <OptionsSection selectedSpec={selectedSpec} />}
+          {!specHasRelease && (
+            <OptionsSection
+              onStatementPersisted={() =>
+                handleStatementPersisted(selectedSpec.id)
+              }
+              selectedSpec={selectedSpec}
+            />
+          )}
         </div>
       </div>
 
@@ -649,7 +666,13 @@ export function PlanDetailChangesBranch({
   );
 }
 
-function OptionsSection({ selectedSpec }: { selectedSpec: Plan_Spec }) {
+function OptionsSection({
+  onStatementPersisted,
+  selectedSpec,
+}: {
+  onStatementPersisted: () => void;
+  selectedSpec: Plan_Spec;
+}) {
   const { t } = useTranslation();
   const page = usePlanDetailContext();
   const { patchState, refreshState } = page;
@@ -824,18 +847,30 @@ function OptionsSection({ selectedSpec }: { selectedSpec: Plan_Spec }) {
         const sheet = getLocalSheetByName(sheetName);
         setLocalSheetStatement(sheet, nextStatement);
         setSheetStatementState(nextStatement);
+        onStatementPersisted();
         return;
       }
 
-      await updateSpecSheetWithStatement(
+      const updatedPlan = await updateSpecSheetWithStatement(
         page.plan,
         selectedSpec,
         nextStatement
       );
+      if (updatedPlan) {
+        patchState({ plan: updatedPlan });
+      }
       setSheetStatementState(nextStatement);
+      onStatementPersisted();
       await refreshState();
     },
-    [page.isCreating, page.plan, refreshState, selectedSpec]
+    [
+      onStatementPersisted,
+      page.isCreating,
+      page.plan,
+      patchState,
+      refreshState,
+      selectedSpec,
+    ]
   );
 
   const setSheetStatementState = (statement: string) => {

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailStatementSection.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailStatementSection.tsx
@@ -54,10 +54,12 @@ export function PlanDetailStatementSection({
   className,
   planCheckRuns = [],
   spec,
+  statementVersion = 0,
 }: {
   className?: string;
   planCheckRuns?: PlanCheckRun[];
   spec: Plan_Spec;
+  statementVersion?: number;
 }) {
   const { t } = useTranslation();
   const page = usePlanDetailContext();
@@ -213,7 +215,7 @@ export function PlanDetailStatementSection({
     return () => {
       canceled = true;
     };
-  }, [releaseName, sheetName, sheetStore]);
+  }, [releaseName, sheetName, sheetStore, statementVersion]);
 
   if (isValidReleaseName(releaseName)) {
     return (

--- a/frontend/src/react/pages/project/plan-detail/utils/specMutation.ts
+++ b/frontend/src/react/pages/project/plan-detail/utils/specMutation.ts
@@ -27,7 +27,7 @@ export const updateSpecSheetWithStatement = async (
   });
   specToPatch.config.value.sheet = createdSheet.name;
 
-  await planServiceClientConnect.updatePlan(
+  return await planServiceClientConnect.updatePlan(
     create(UpdatePlanRequestSchema, {
       plan: planPatch,
       updateMask: { paths: ["specs"] },


### PR DESCRIPTION
## Summary
- Refresh the plan detail statement section after options mutate the backing sheet statement
- Patch existing-plan state immediately with the updated plan returned from option-driven sheet updates
- Add regression coverage for create-plan option changes syncing back into the statement section

## Key Changes
- Add a per-spec statement version signal between the changes branch options and statement section
- Reload statement content when that version changes, covering unchanged local sheet names in create-plan flows
- Return the updated plan from the shared sheet mutation helper so existing plans reflect the new sheet pointer immediately

## Motivation
Plan detail options such as transaction mode, isolation level, role, and gh-ost updated sheet content but did not notify the statement section to reload. In create-plan flows the sheet name stayed the same, so users could toggle options without seeing the SQL section update.

## Testing
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend exec vitest run src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx src/react/pages/project/plan-detail/utils/options.test.ts
- pnpm --dir frontend test
- git diff --check