### PR TITLE
fix: avoid SELECT * in rollback restore SQL

### DIFF
--- a/backend/plugin/parser/mysql/restore.go
+++ b/backend/plugin/parser/mysql/restore.go
@@ -72,7 +72,7 @@ func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment str
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get target database ID for %s", backupItem.TargetTable.Database)
 	}
-	generatedColumns, normalColumns, err := classifyColumns(ctx, rCtx.GetDatabaseMetadataFunc, rCtx.ListDatabaseNamesFunc, rCtx.IsCaseSensitive, rCtx.InstanceID, &TableReference{
+	_, normalColumns, err := classifyColumns(ctx, rCtx.GetDatabaseMetadataFunc, rCtx.ListDatabaseNamesFunc, rCtx.IsCaseSensitive, rCtx.InstanceID, &TableReference{
 		Database: sourceDatabase,
 		Table:    backupItem.SourceTable.Table,
 	})
@@ -83,9 +83,9 @@ func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment str
 	var result string
 	switch n := node.(type) {
 	case *ast.DeleteStmt:
-		result = generateDeleteRestore(sourceDatabase, backupItem.SourceTable.Table, targetDatabase, backupItem.TargetTable.Table, generatedColumns, normalColumns)
+		result = generateDeleteRestore(sourceDatabase, backupItem.SourceTable.Table, targetDatabase, backupItem.TargetTable.Table, normalColumns)
 	case *ast.UpdateStmt:
-		r, err := generateUpdateRestore(ctx, rCtx, n, sourceDatabase, backupItem.SourceTable.Table, targetDatabase, backupItem.TargetTable.Table, generatedColumns, normalColumns)
+		r, err := generateUpdateRestore(ctx, rCtx, n, sourceDatabase, backupItem.SourceTable.Table, targetDatabase, backupItem.TargetTable.Table, normalColumns)
 		if err != nil {
 			return "", err
 		}
@@ -97,19 +97,12 @@ func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment str
 	return fmt.Sprintf("/*\nOriginal SQL:\n%s\n*/\n%s", sqlForComment, result), nil
 }
 
-func generateDeleteRestore(originalDatabase, originalTable, backupDatabase, backupTable string, generatedColumns, normalColumns []string) string {
-	if len(generatedColumns) == 0 {
-		return fmt.Sprintf("INSERT INTO `%s`.`%s` SELECT * FROM `%s`.`%s`;", originalDatabase, originalTable, backupDatabase, backupTable)
-	}
-	var quotedColumns []string
-	for _, column := range normalColumns {
-		quotedColumns = append(quotedColumns, fmt.Sprintf("`%s`", column))
-	}
-	quotedColumnList := strings.Join(quotedColumns, ", ")
+func generateDeleteRestore(originalDatabase, originalTable, backupDatabase, backupTable string, normalColumns []string) string {
+	quotedColumnList := quoteMySQLColumns(normalColumns)
 	return fmt.Sprintf("INSERT INTO `%s`.`%s` (%s) SELECT %s FROM `%s`.`%s`;", originalDatabase, originalTable, quotedColumnList, quotedColumnList, backupDatabase, backupTable)
 }
 
-func generateUpdateRestore(ctx context.Context, rCtx base.RestoreContext, stmt *ast.UpdateStmt, originalDatabase, originalTable, backupDatabase, backupTable string, generatedColumns, normalColumns []string) (string, error) {
+func generateUpdateRestore(ctx context.Context, rCtx base.RestoreContext, stmt *ast.UpdateStmt, originalDatabase, originalTable, backupDatabase, backupTable string, normalColumns []string) (string, error) {
 	// Extract single tables from the UPDATE table references.
 	singleTables := extractSingleTablesFromTableExprs(originalDatabase, stmt.Tables)
 
@@ -134,19 +127,9 @@ func generateUpdateRestore(ctx context.Context, rCtx base.RestoreContext, stmt *
 	}
 
 	var buf strings.Builder
-	if len(generatedColumns) == 0 {
-		if _, err := fmt.Fprintf(&buf, "INSERT INTO `%s`.`%s` SELECT * FROM `%s`.`%s` ON DUPLICATE KEY UPDATE ", originalDatabase, originalTable, backupDatabase, backupTable); err != nil {
-			return "", err
-		}
-	} else {
-		var quotedColumns []string
-		for _, column := range normalColumns {
-			quotedColumns = append(quotedColumns, fmt.Sprintf("`%s`", column))
-		}
-		quotedColumnList := strings.Join(quotedColumns, ", ")
-		if _, err := fmt.Fprintf(&buf, "INSERT INTO `%s`.`%s` (%s) SELECT %s FROM `%s`.`%s` ON DUPLICATE KEY UPDATE ", originalDatabase, originalTable, quotedColumnList, quotedColumnList, backupDatabase, backupTable); err != nil {
-			return "", err
-		}
+	quotedColumnList := quoteMySQLColumns(normalColumns)
+	if _, err := fmt.Fprintf(&buf, "INSERT INTO `%s`.`%s` (%s) SELECT %s FROM `%s`.`%s` ON DUPLICATE KEY UPDATE ", originalDatabase, originalTable, quotedColumnList, quotedColumnList, backupDatabase, backupTable); err != nil {
+		return "", err
 	}
 
 	for i, field := range updateColumns {
@@ -163,6 +146,14 @@ func generateUpdateRestore(ctx context.Context, rCtx base.RestoreContext, stmt *
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func quoteMySQLColumns(columns []string) string {
+	var quotedColumns []string
+	for _, column := range columns {
+		quotedColumns = append(quotedColumns, fmt.Sprintf("`%s`", column))
+	}
+	return strings.Join(quotedColumns, ", ")
 }
 
 // extractSingleTablesFromTableExprs walks omni TableExpr nodes and returns

--- a/backend/plugin/parser/mysql/restore_test.go
+++ b/backend/plugin/parser/mysql/restore_test.go
@@ -107,5 +107,5 @@ func TestMariaDBGenerateRestoreSQLRegistration(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, "/*\nOriginal SQL:\nDELETE FROM test WHERE b1 = 1;\n*/\nINSERT INTO `db`.`test` SELECT * FROM `bbarchive`.`prefix_test`;", result)
+	require.Equal(t, "/*\nOriginal SQL:\nDELETE FROM test WHERE b1 = 1;\n*/\nINSERT INTO `db`.`test` (`a`, `b`, `c`) SELECT `a`, `b`, `c` FROM `bbarchive`.`prefix_test`;", result)
 }

--- a/backend/plugin/parser/mysql/test-data/test_restore.yaml
+++ b/backend/plugin/parser/mysql/test-data/test_restore.yaml
@@ -116,7 +116,7 @@
     Original SQL:
     DELETE test FROM test, test2 as t2 where test.id = t2.id;
     */
-    INSERT INTO `db`.`test` SELECT * FROM `bbarchive`.`prefix_1_test`;
+    INSERT INTO `db`.`test` (`a`, `b`, `c`) SELECT `a`, `b`, `c` FROM `bbarchive`.`prefix_1_test`;
 - input: UPDATE test x SET x.c = 1 WHERE x.c = 1;
   backupdatabase: bbarchive
   backuptable: prefix_1_test
@@ -127,7 +127,7 @@
     Original SQL:
     UPDATE test x SET x.c = 1 WHERE x.c = 1;
     */
-    INSERT INTO `db`.`test` SELECT * FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `c` = VALUES(`c`);
+    INSERT INTO `db`.`test` (`a`, `b`, `c`) SELECT `a`, `b`, `c` FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `c` = VALUES(`c`);
 - input: UPDATE test SET a = 1 WHERE c = 1;
   backupdatabase: bbarchive
   backuptable: prefix_1_test
@@ -138,4 +138,4 @@
     Original SQL:
     UPDATE test SET a = 1 WHERE c = 1;
     */
-    INSERT INTO `db`.`test` SELECT * FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `a` = VALUES(`a`);
+    INSERT INTO `db`.`test` (`a`, `b`, `c`) SELECT `a`, `b`, `c` FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `a` = VALUES(`a`);

--- a/backend/plugin/parser/pg/restore.go
+++ b/backend/plugin/parser/pg/restore.go
@@ -119,11 +119,12 @@ func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment str
 	backupTable := backupItem.TargetTable.Table
 	originalSchema := schema
 	originalTable := backupItem.SourceTable.Table
+	quotedColumnList := quotePGColumns(restorableColumns(tableMetadata))
 
 	var result string
 	switch n := node.(type) {
 	case *ast.DeleteStmt:
-		result = fmt.Sprintf(`INSERT INTO "%s"."%s" SELECT * FROM "%s"."%s";`, originalSchema, originalTable, backupSchema, backupTable)
+		result = fmt.Sprintf(`INSERT INTO "%s"."%s" (%s) SELECT %s FROM "%s"."%s";`, originalSchema, originalTable, quotedColumnList, quotedColumnList, backupSchema, backupTable)
 	case *ast.UpdateStmt:
 		fields := extractSetFieldNames(n)
 		uk, err := findDisjointUniqueKey(tableMetadata, fields)
@@ -132,7 +133,7 @@ func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment str
 		}
 
 		var buf strings.Builder
-		if _, err := fmt.Fprintf(&buf, `INSERT INTO "%s"."%s" SELECT * FROM "%s"."%s" ON CONFLICT ON CONSTRAINT "%s" DO UPDATE SET `, originalSchema, originalTable, backupSchema, backupTable, uk); err != nil {
+		if _, err := fmt.Fprintf(&buf, `INSERT INTO "%s"."%s" (%s) SELECT %s FROM "%s"."%s" ON CONFLICT ON CONSTRAINT "%s" DO UPDATE SET `, originalSchema, originalTable, quotedColumnList, quotedColumnList, backupSchema, backupTable, uk); err != nil {
 			return "", errors.Wrapf(err, "failed to generate update statement")
 		}
 		for i, field := range fields {
@@ -161,6 +162,25 @@ func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment str
 		return fmt.Sprintf("%s\n/*\nOriginal SQL:\n%s\n*/\n%s", prependStatements, sqlForComment, result), nil
 	}
 	return fmt.Sprintf("/*\nOriginal SQL:\n%s\n*/\n%s", sqlForComment, result), nil
+}
+
+func restorableColumns(table *model.TableMetadata) []string {
+	var columns []string
+	for _, column := range table.GetProto().GetColumns() {
+		if column.GetGeneration() != nil {
+			continue
+		}
+		columns = append(columns, column.Name)
+	}
+	return columns
+}
+
+func quotePGColumns(columns []string) string {
+	var quotedColumns []string
+	for _, column := range columns {
+		quotedColumns = append(quotedColumns, fmt.Sprintf(`"%s"`, column))
+	}
+	return strings.Join(quotedColumns, ", ")
 }
 
 // extractSetFieldNames extracts the target column names from an UPDATE SET clause.

--- a/backend/plugin/parser/pg/test-data/test_restore.yaml
+++ b/backend/plugin/parser/pg/test-data/test_restore.yaml
@@ -21,7 +21,7 @@
     UPDATE t_generated as t SET t."b" = 6 WHERE a = 6;
     UPDATE t_generated as t SET t."b" = 7 WHERE a = 7
     */
-    INSERT INTO "public"."t_generated" SELECT * FROM "bbarchive"."prefix_t_generated" ON CONFLICT ON CONSTRAINT "t_generated_uk" DO UPDATE SET "b" = EXCLUDED."b";
+    INSERT INTO "public"."t_generated" ("a", "b") SELECT "a", "b" FROM "bbarchive"."prefix_t_generated" ON CONFLICT ON CONSTRAINT "t_generated_uk" DO UPDATE SET "b" = EXCLUDED."b";
 - input: |-
     UPDATE t_generated as t SET t."a" = 1 WHERE b = 1;
     UPDATE t_generated as t SET t."a" = 2 WHERE b = 2;
@@ -45,7 +45,7 @@
     UPDATE t_generated as t SET t."a" = 6 WHERE b = 6;
     UPDATE t_generated as t SET t."a" = 7 WHERE b = 7
     */
-    INSERT INTO "public"."t_generated" SELECT * FROM "bbarchive"."prefix_t_generated" ON CONFLICT ON CONSTRAINT "t_generated_pk" DO UPDATE SET "a" = EXCLUDED."a";
+    INSERT INTO "public"."t_generated" ("a", "b") SELECT "a", "b" FROM "bbarchive"."prefix_t_generated" ON CONFLICT ON CONSTRAINT "t_generated_pk" DO UPDATE SET "a" = EXCLUDED."a";
 - input: |-
     UPDATE t_generated SET A = 1 WHERE b = 1;
     UPDATE t_generated SET A = 2 WHERE b = 2;
@@ -69,7 +69,7 @@
     UPDATE t_generated SET A = 6 WHERE b = 6;
     UPDATE t_generated SET A = 7 WHERE b = 7
     */
-    INSERT INTO "public"."t_generated" SELECT * FROM "bbarchive"."prefix_t_generated" ON CONFLICT ON CONSTRAINT "t_generated_pk" DO UPDATE SET "a" = EXCLUDED."a";
+    INSERT INTO "public"."t_generated" ("a", "b") SELECT "a", "b" FROM "bbarchive"."prefix_t_generated" ON CONFLICT ON CONSTRAINT "t_generated_pk" DO UPDATE SET "a" = EXCLUDED."a";
 - input: DELETE FROM t_generated where a = 1;
   backupdatabase: bbarchive
   backuptable: prefix_1_t_generated
@@ -80,7 +80,7 @@
     Original SQL:
     DELETE FROM t_generated where a = 1
     */
-    INSERT INTO "public"."t_generated" SELECT * FROM "bbarchive"."prefix_1_t_generated";
+    INSERT INTO "public"."t_generated" ("a", "b") SELECT "a", "b" FROM "bbarchive"."prefix_1_t_generated";
 - input: UPDATE t_generated SET a = 1 WHERE a = 2;
   backupdatabase: bbarchive
   backuptable: prefix_1_t_generated
@@ -91,7 +91,7 @@
     Original SQL:
     UPDATE t_generated SET a = 1 WHERE a = 2
     */
-    INSERT INTO "public"."t_generated" SELECT * FROM "bbarchive"."prefix_1_t_generated" ON CONFLICT ON CONSTRAINT "t_generated_pk" DO UPDATE SET "a" = EXCLUDED."a";
+    INSERT INTO "public"."t_generated" ("a", "b") SELECT "a", "b" FROM "bbarchive"."prefix_1_t_generated" ON CONFLICT ON CONSTRAINT "t_generated_pk" DO UPDATE SET "a" = EXCLUDED."a";
 - input: UPDATE test x SET x.c = 1 WHERE x.a = 1;
   backupdatabase: bbarchive
   backuptable: prefix_1_test
@@ -102,7 +102,7 @@
     Original SQL:
     UPDATE test x SET x.c = 1 WHERE x.a = 1
     */
-    INSERT INTO "public"."test" SELECT * FROM "bbarchive"."prefix_1_test" ON CONFLICT ON CONSTRAINT "test_pk" DO UPDATE SET "c" = EXCLUDED."c";
+    INSERT INTO "public"."test" ("a", "b", "c") SELECT "a", "b", "c" FROM "bbarchive"."prefix_1_test" ON CONFLICT ON CONSTRAINT "test_pk" DO UPDATE SET "c" = EXCLUDED."c";
 - input: UPDATE test SET c = 1 WHERE a = 1;
   backupdatabase: bbarchive
   backuptable: prefix_1_test
@@ -113,7 +113,7 @@
     Original SQL:
     UPDATE test SET c = 1 WHERE a = 1
     */
-    INSERT INTO "public"."test" SELECT * FROM "bbarchive"."prefix_1_test" ON CONFLICT ON CONSTRAINT "test_pk" DO UPDATE SET "c" = EXCLUDED."c";
+    INSERT INTO "public"."test" ("a", "b", "c") SELECT "a", "b", "c" FROM "bbarchive"."prefix_1_test" ON CONFLICT ON CONSTRAINT "test_pk" DO UPDATE SET "c" = EXCLUDED."c";
 - input: |-
     SET ROLE admin;
     UPDATE test SET c = 1 WHERE a = 1;
@@ -127,7 +127,7 @@
     Original SQL:
     UPDATE test SET c = 1 WHERE a = 1
     */
-    INSERT INTO "public"."test" SELECT * FROM "bbarchive"."prefix_1_test" ON CONFLICT ON CONSTRAINT "test_pk" DO UPDATE SET "c" = EXCLUDED."c";
+    INSERT INTO "public"."test" ("a", "b", "c") SELECT "a", "b", "c" FROM "bbarchive"."prefix_1_test" ON CONFLICT ON CONSTRAINT "test_pk" DO UPDATE SET "c" = EXCLUDED."c";
 - input: |-
     SET search_path = myschema, public;
     DELETE FROM test WHERE a = 1;
@@ -141,4 +141,4 @@
     Original SQL:
     DELETE FROM test WHERE a = 1
     */
-    INSERT INTO "public"."test" SELECT * FROM "bbarchive"."prefix_1_test";
+    INSERT INTO "public"."test" ("a", "b", "c") SELECT "a", "b", "c" FROM "bbarchive"."prefix_1_test";

--- a/backend/plugin/parser/plsql/restore.go
+++ b/backend/plugin/parser/plsql/restore.go
@@ -127,7 +127,27 @@ func (g *generator) EnterDelete_statement(ctx *parser.Delete_statementContext) {
 	}
 
 	g.isFirst = false
-	g.result = fmt.Sprintf(`INSERT INTO "%s"."%s" SELECT * FROM "%s"."%s";`, g.originalDatabase, g.originalTable, g.backupDatabase, g.backupTable)
+	columnList := quoteOracleColumns(g.restorableColumns())
+	g.result = fmt.Sprintf(`INSERT INTO "%s"."%s" (%s) SELECT %s FROM "%s"."%s";`, g.originalDatabase, g.originalTable, columnList, columnList, g.backupDatabase, g.backupTable)
+}
+
+func (g *generator) restorableColumns() []string {
+	var columns []string
+	for _, column := range g.table.GetProto().GetColumns() {
+		if column.GetGeneration() != nil {
+			continue
+		}
+		columns = append(columns, column.Name)
+	}
+	return columns
+}
+
+func quoteOracleColumns(columns []string) string {
+	var quotedColumns []string
+	for _, column := range columns {
+		quotedColumns = append(quotedColumns, fmt.Sprintf(`"%s"`, column))
+	}
+	return strings.Join(quotedColumns, ", ")
 }
 
 func disjoint(a []string, b map[string]bool) bool {
@@ -224,14 +244,14 @@ func (g *generator) EnterUpdate_statement(ctx *parser.Update_statementContext) {
 		g.err = err
 		return
 	}
-	for i, column := range g.table.GetProto().GetColumns() {
+	for i, column := range g.restorableColumns() {
 		if i > 0 {
 			if _, err := fmt.Fprint(&buf, ", "); err != nil {
 				g.err = err
 				return
 			}
 		}
-		if _, err := fmt.Fprintf(&buf, "\"%s\"", column.Name); err != nil {
+		if _, err := fmt.Fprintf(&buf, "\"%s\"", column); err != nil {
 			g.err = err
 			return
 		}
@@ -240,14 +260,14 @@ func (g *generator) EnterUpdate_statement(ctx *parser.Update_statementContext) {
 		g.err = err
 		return
 	}
-	for i, column := range g.table.GetProto().GetColumns() {
+	for i, column := range g.restorableColumns() {
 		if i > 0 {
 			if _, err := fmt.Fprint(&buf, ", "); err != nil {
 				g.err = err
 				return
 			}
 		}
-		if _, err := fmt.Fprintf(&buf, "b.\"%s\"", column.Name); err != nil {
+		if _, err := fmt.Fprintf(&buf, "b.\"%s\"", column); err != nil {
 			g.err = err
 			return
 		}

--- a/backend/plugin/parser/plsql/test-data/test_restore.yaml
+++ b/backend/plugin/parser/plsql/test-data/test_restore.yaml
@@ -68,7 +68,7 @@
     Original SQL:
     DELETE FROM T_GENERATED where a = 1
     */
-    INSERT INTO "DB"."T_GENERATED" SELECT * FROM "bbarchive"."prefix_1_T_GENERATED";
+    INSERT INTO "DB"."T_GENERATED" ("A", "B") SELECT "A", "B" FROM "bbarchive"."prefix_1_T_GENERATED";
 - input: UPDATE T_GENERATED SET a = 1 WHERE a = 2;
   backupdatabase: bbarchive
   backuptable: prefix_1_T_GENERATED

--- a/backend/plugin/parser/tidb/restore.go
+++ b/backend/plugin/parser/tidb/restore.go
@@ -153,7 +153,7 @@ func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment str
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get target database ID for %s", backupItem.TargetTable.Database)
 	}
-	generatedColumns, normalColumns, err := classifyColumns(ctx, rCtx.GetDatabaseMetadataFunc, rCtx.ListDatabaseNamesFunc, rCtx.IsCaseSensitive, rCtx.InstanceID, &TableReference{
+	_, normalColumns, err := classifyColumns(ctx, rCtx.GetDatabaseMetadataFunc, rCtx.ListDatabaseNamesFunc, rCtx.IsCaseSensitive, rCtx.InstanceID, &TableReference{
 		Database: sourceDatabase,
 		Table:    backupItem.SourceTable.Table,
 	})
@@ -181,31 +181,24 @@ func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment str
 
 	var result string
 	if len(updateStmts) > 0 {
-		r, err := generateUpdateRestore(ctx, rCtx, updateStmts, sourceDatabase, backupItem.SourceTable.Table, targetDatabase, backupItem.TargetTable.Table, generatedColumns, normalColumns)
+		r, err := generateUpdateRestore(ctx, rCtx, updateStmts, sourceDatabase, backupItem.SourceTable.Table, targetDatabase, backupItem.TargetTable.Table, normalColumns)
 		if err != nil {
 			return "", err
 		}
 		result = r
 	} else {
-		result = generateDeleteRestore(sourceDatabase, backupItem.SourceTable.Table, targetDatabase, backupItem.TargetTable.Table, generatedColumns, normalColumns)
+		result = generateDeleteRestore(sourceDatabase, backupItem.SourceTable.Table, targetDatabase, backupItem.TargetTable.Table, normalColumns)
 	}
 
 	return fmt.Sprintf("/*\nOriginal SQL:\n%s\n*/\n%s", sqlForComment, result), nil
 }
 
-func generateDeleteRestore(originalDatabase, originalTable, backupDatabase, backupTable string, generatedColumns, normalColumns []string) string {
-	if len(generatedColumns) == 0 {
-		return fmt.Sprintf("INSERT INTO `%s`.`%s` SELECT * FROM `%s`.`%s`;", originalDatabase, originalTable, backupDatabase, backupTable)
-	}
-	var quotedColumns []string
-	for _, column := range normalColumns {
-		quotedColumns = append(quotedColumns, fmt.Sprintf("`%s`", column))
-	}
-	quotedColumnList := strings.Join(quotedColumns, ", ")
+func generateDeleteRestore(originalDatabase, originalTable, backupDatabase, backupTable string, normalColumns []string) string {
+	quotedColumnList := quoteTiDBColumns(normalColumns)
 	return fmt.Sprintf("INSERT INTO `%s`.`%s` (%s) SELECT %s FROM `%s`.`%s`;", originalDatabase, originalTable, quotedColumnList, quotedColumnList, backupDatabase, backupTable)
 }
 
-func generateUpdateRestore(ctx context.Context, rCtx base.RestoreContext, stmts []*ast.UpdateStmt, originalDatabase, originalTable, backupDatabase, backupTable string, generatedColumns, normalColumns []string) (string, error) {
+func generateUpdateRestore(ctx context.Context, rCtx base.RestoreContext, stmts []*ast.UpdateStmt, originalDatabase, originalTable, backupDatabase, backupTable string, normalColumns []string) (string, error) {
 	// Union update columns across ALL stmts in the bundle. backup.go's
 	// single-table path bundles >maxMixedDMLCount same-table DMLs into one
 	// backup_item; restore must rollback every column touched across the
@@ -237,19 +230,9 @@ func generateUpdateRestore(ctx context.Context, rCtx base.RestoreContext, stmts 
 	}
 
 	var buf strings.Builder
-	if len(generatedColumns) == 0 {
-		if _, err := fmt.Fprintf(&buf, "INSERT INTO `%s`.`%s` SELECT * FROM `%s`.`%s` ON DUPLICATE KEY UPDATE ", originalDatabase, originalTable, backupDatabase, backupTable); err != nil {
-			return "", err
-		}
-	} else {
-		var quotedColumns []string
-		for _, column := range normalColumns {
-			quotedColumns = append(quotedColumns, fmt.Sprintf("`%s`", column))
-		}
-		quotedColumnList := strings.Join(quotedColumns, ", ")
-		if _, err := fmt.Fprintf(&buf, "INSERT INTO `%s`.`%s` (%s) SELECT %s FROM `%s`.`%s` ON DUPLICATE KEY UPDATE ", originalDatabase, originalTable, quotedColumnList, quotedColumnList, backupDatabase, backupTable); err != nil {
-			return "", err
-		}
+	quotedColumnList := quoteTiDBColumns(normalColumns)
+	if _, err := fmt.Fprintf(&buf, "INSERT INTO `%s`.`%s` (%s) SELECT %s FROM `%s`.`%s` ON DUPLICATE KEY UPDATE ", originalDatabase, originalTable, quotedColumnList, quotedColumnList, backupDatabase, backupTable); err != nil {
+		return "", err
 	}
 
 	for i, field := range updateColumns {
@@ -266,6 +249,14 @@ func generateUpdateRestore(ctx context.Context, rCtx base.RestoreContext, stmts 
 		return "", err
 	}
 	return buf.String(), nil
+}
+
+func quoteTiDBColumns(columns []string) string {
+	var quotedColumns []string
+	for _, column := range columns {
+		quotedColumns = append(quotedColumns, fmt.Sprintf("`%s`", column))
+	}
+	return strings.Join(quotedColumns, ", ")
 }
 
 // extractSingleTablesFromTableExprs walks omni TableExpr nodes and returns

--- a/backend/plugin/parser/tidb/restore_test.go
+++ b/backend/plugin/parser/tidb/restore_test.go
@@ -107,7 +107,7 @@ func TestTiDBGenerateRestoreSQLRegistration(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Equal(t, "/*\nOriginal SQL:\nDELETE FROM test WHERE b1 = 1;\n*/\nINSERT INTO `db`.`test` SELECT * FROM `bbarchive`.`prefix_test`;", result)
+	require.Equal(t, "/*\nOriginal SQL:\nDELETE FROM test WHERE b1 = 1;\n*/\nINSERT INTO `db`.`test` (`a`, `b`, `c`) SELECT `a`, `b`, `c` FROM `bbarchive`.`prefix_test`;", result)
 }
 
 // TestGenerateRestoreSQLCaseInsensitiveDatabaseQualifier pins the

--- a/backend/plugin/parser/tidb/test-data/test_restore.yaml
+++ b/backend/plugin/parser/tidb/test-data/test_restore.yaml
@@ -116,7 +116,7 @@
     Original SQL:
     DELETE test FROM test, test2 as t2 where test.id = t2.id;
     */
-    INSERT INTO `db`.`test` SELECT * FROM `bbarchive`.`prefix_1_test`;
+    INSERT INTO `db`.`test` (`a`, `b`, `c`) SELECT `a`, `b`, `c` FROM `bbarchive`.`prefix_1_test`;
 - input: UPDATE test x SET x.c = 1 WHERE x.c = 1;
   backupdatabase: bbarchive
   backuptable: prefix_1_test
@@ -127,7 +127,7 @@
     Original SQL:
     UPDATE test x SET x.c = 1 WHERE x.c = 1;
     */
-    INSERT INTO `db`.`test` SELECT * FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `c` = VALUES(`c`);
+    INSERT INTO `db`.`test` (`a`, `b`, `c`) SELECT `a`, `b`, `c` FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `c` = VALUES(`c`);
 - input: UPDATE test SET a = 1 WHERE c = 1;
   backupdatabase: bbarchive
   backuptable: prefix_1_test
@@ -138,7 +138,7 @@
     Original SQL:
     UPDATE test SET a = 1 WHERE c = 1;
     */
-    INSERT INTO `db`.`test` SELECT * FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `a` = VALUES(`a`);
+    INSERT INTO `db`.`test` (`a`, `b`, `c`) SELECT `a`, `b`, `c` FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `a` = VALUES(`a`);
 - input: |-
     UPDATE test SET a = 1 WHERE c = 1;
     UPDATE test SET b = 2 WHERE c = 2;
@@ -160,4 +160,4 @@
     UPDATE test SET a = 5 WHERE c = 5;
     UPDATE test SET b = 6 WHERE c = 6;
     */
-    INSERT INTO `db`.`test` SELECT * FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `a` = VALUES(`a`), `b` = VALUES(`b`);
+    INSERT INTO `db`.`test` (`a`, `b`, `c`) SELECT `a`, `b`, `c` FROM `bbarchive`.`prefix_1_test` ON DUPLICATE KEY UPDATE `a` = VALUES(`a`), `b` = VALUES(`b`);

--- a/backend/plugin/parser/tsql/restore.go
+++ b/backend/plugin/parser/tsql/restore.go
@@ -145,6 +145,25 @@ func (g *generator) hasIdentityColumn() bool {
 	return false
 }
 
+func (g *generator) restorableColumns() []string {
+	var columns []string
+	for _, column := range g.table.GetProto().GetColumns() {
+		if column.GetGeneration() != nil {
+			continue
+		}
+		columns = append(columns, column.Name)
+	}
+	return columns
+}
+
+func quoteTSQLColumns(columns []string) string {
+	var quotedColumns []string
+	for _, column := range columns {
+		quotedColumns = append(quotedColumns, fmt.Sprintf("[%s]", column))
+	}
+	return strings.Join(quotedColumns, ", ")
+}
+
 func (g *generator) generate(node ast.Node) (string, error) {
 	switch n := node.(type) {
 	case *ast.DeleteStmt:
@@ -159,27 +178,19 @@ func (g *generator) generate(node ast.Node) (string, error) {
 func (g *generator) generateDelete() (string, error) {
 	// Check if the table has IDENTITY columns
 	hasIdentity := g.hasIdentityColumn()
+	columnList := quoteTSQLColumns(g.restorableColumns())
 
 	if hasIdentity {
 		// For tables with IDENTITY columns, we need to enable IDENTITY_INSERT
 		// and use explicit column lists
 		var buf strings.Builder
 
-		// Build column list
-		var columnList strings.Builder
-		for i, column := range g.table.GetProto().GetColumns() {
-			if i > 0 {
-				columnList.WriteString(", ")
-			}
-			fmt.Fprintf(&columnList, "[%s]", column.Name)
-		}
-
 		fmt.Fprintf(&buf, "SET IDENTITY_INSERT [%s].[%s].[%s] ON;\n",
 			g.originalDatabase, g.originalSchema, g.originalTable)
 		fmt.Fprintf(&buf, "INSERT INTO [%s].[%s].[%s] (%s) SELECT %s FROM [%s].[dbo].[%s];\n",
 			g.originalDatabase, g.originalSchema, g.originalTable,
-			columnList.String(),
-			columnList.String(),
+			columnList,
+			columnList,
 			g.backupDatabase, g.backupTable)
 		fmt.Fprintf(&buf, "SET IDENTITY_INSERT [%s].[%s].[%s] OFF;\n",
 			g.originalDatabase, g.originalSchema, g.originalTable)
@@ -190,8 +201,10 @@ func (g *generator) generateDelete() (string, error) {
 	}
 
 	// Simple INSERT for tables without IDENTITY columns
-	return fmt.Sprintf(`INSERT INTO [%s].[%s].[%s] SELECT * FROM [%s].[dbo].[%s];`,
+	return fmt.Sprintf(`INSERT INTO [%s].[%s].[%s] (%s) SELECT %s FROM [%s].[dbo].[%s];`,
 		g.originalDatabase, g.originalSchema, g.originalTable,
+		columnList,
+		columnList,
 		g.backupDatabase, g.backupTable), nil
 }
 
@@ -277,26 +290,26 @@ func (g *generator) generateUpdate(stmt *ast.UpdateStmt) (string, error) {
 	if _, err := fmt.Fprint(&buf, "\nWHEN NOT MATCHED THEN\n INSERT ("); err != nil {
 		return "", err
 	}
-	for i, column := range g.table.GetProto().GetColumns() {
+	for i, column := range g.restorableColumns() {
 		if i > 0 {
 			if _, err := fmt.Fprint(&buf, ", "); err != nil {
 				return "", err
 			}
 		}
-		if _, err := fmt.Fprintf(&buf, "[%s]", column.Name); err != nil {
+		if _, err := fmt.Fprintf(&buf, "[%s]", column); err != nil {
 			return "", err
 		}
 	}
 	if _, err := fmt.Fprint(&buf, ") VALUES ("); err != nil {
 		return "", err
 	}
-	for i, column := range g.table.GetProto().GetColumns() {
+	for i, column := range g.restorableColumns() {
 		if i > 0 {
 			if _, err := fmt.Fprint(&buf, ", "); err != nil {
 				return "", err
 			}
 		}
-		if _, err := fmt.Fprintf(&buf, "b.[%s]", column.Name); err != nil {
+		if _, err := fmt.Fprintf(&buf, "b.[%s]", column); err != nil {
 			return "", err
 		}
 	}

--- a/backend/plugin/parser/tsql/restore_test.go
+++ b/backend/plugin/parser/tsql/restore_test.go
@@ -179,7 +179,7 @@ func TestRestoreOmniBoundaryCases(t *testing.T) {
 				"Original SQL:",
 				"DELETE FROM test WHERE a = 1;",
 				"*/",
-				"INSERT INTO [db].[dbo].[test] SELECT * FROM [bbarchive].[dbo].[prefix_1_test];",
+				"INSERT INTO [db].[dbo].[test] ([a], [b], [c]) SELECT [a], [b], [c] FROM [bbarchive].[dbo].[prefix_1_test];",
 			}, "\n"),
 		},
 	}

--- a/backend/plugin/parser/tsql/test-data/test_restore.yaml
+++ b/backend/plugin/parser/tsql/test-data/test_restore.yaml
@@ -71,7 +71,7 @@
     Original SQL:
     DELETE FROM t_generated where a = 1;
     */
-    INSERT INTO [db].[dbo].[t_generated] SELECT * FROM [bbarchive].[dbo].[prefix_1_t_generated];
+    INSERT INTO [db].[dbo].[t_generated] ([a], [b]) SELECT [a], [b] FROM [bbarchive].[dbo].[prefix_1_t_generated];
 - input: UPDATE t_generated SET a = 1 WHERE a = 2;
   backupdatabase: bbarchive
   backuptable: prefix_1_t_generated
@@ -101,7 +101,7 @@
     Original SQL:
     DELETE test FROM test, test2 as t2 where test.id = t2.id;
     */
-    INSERT INTO [db].[dbo].[test] SELECT * FROM [bbarchive].[dbo].[prefix_1_test];
+    INSERT INTO [db].[dbo].[test] ([a], [b], [c]) SELECT [a], [b], [c] FROM [bbarchive].[dbo].[prefix_1_test];
 - input: UPDATE test SET test.c1 = 1 WHERE test.c1 = 1;
   backupdatabase: bbarchive
   backuptable: prefix_1_test


### PR DESCRIPTION
## Summary
- Generate rollback restore SQL with explicit INSERT and SELECT column lists instead of `SELECT *`.
- Cover MySQL/MariaDB, TiDB, Postgres, MSSQL, and Oracle prior-backup restore paths.
- Update restore SQL golden tests and registration tests to pin SQL Review-friendly output.

## Test Plan
- [x] `go test ./backend/plugin/parser/mysql ./backend/plugin/parser/tidb ./backend/plugin/parser/pg ./backend/plugin/parser/tsql ./backend/plugin/parser/plsql -run TestRestore -count=1`
- [x] `go test ./backend/plugin/parser/mysql ./backend/plugin/parser/tidb ./backend/plugin/parser/pg ./backend/plugin/parser/tsql ./backend/plugin/parser/plsql -count=1`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

Fixes BYT-9565.
