### PR TITLE
fix(plan): avoid refetching on spec selection

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/useInitialFetch.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/useInitialFetch.ts
@@ -14,7 +14,6 @@ import type { PlanDetailPageSnapshot } from "./types";
 export interface UseInitialFetchParams {
   projectId: string;
   planId: string;
-  specId?: string;
   routeQueryRef: MutableRefObject<Record<string, unknown>>;
   storeApi: PlanDetailStoreApi;
   patchState: (patch: Partial<PlanDetailPageSnapshot>) => void;
@@ -23,7 +22,6 @@ export interface UseInitialFetchParams {
 export function useInitialFetch({
   projectId,
   planId,
-  specId,
   routeQueryRef,
   storeApi,
   patchState,
@@ -33,8 +31,7 @@ export function useInitialFetch({
     patchState({
       projectId,
       planId,
-      specId,
-      pageKey: `${projectId}/${planId}/${specId ?? ""}`,
+      pageKey: `${projectId}/${planId}`,
       projectTitle: "",
       isCreating: planId.toLowerCase() === "create",
       isInitializing: true,
@@ -60,7 +57,6 @@ export function useInitialFetch({
         patchState({
           ...patch,
           isInitializing: false,
-          specId,
         });
       } catch (error) {
         if (canceled) {
@@ -86,5 +82,5 @@ export function useInitialFetch({
     return () => {
       canceled = true;
     };
-  }, [patchState, planId, projectId, routeQueryRef, specId, storeApi]);
+  }, [patchState, planId, projectId, routeQueryRef, storeApi]);
 }

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
@@ -67,7 +67,7 @@ const buildSnapshotPatch = ({
   ({
     projectId: "foo",
     planId,
-    pageKey: `foo/${planId}/`,
+    pageKey: `foo/${planId}`,
     projectTitle: "Foo",
     projectRequireIssueApproval: false,
     projectRequirePlanCheckNoError: false,
@@ -82,7 +82,7 @@ const buildSnapshotPatch = ({
       creator: "users/me@example.com",
       hasRollout: false,
       state: State.ACTIVE,
-      specs: [{ id: "spec-1" }],
+      specs: [{ id: "spec-1" }, { id: "spec-2" }],
     },
     issue,
     rollout,
@@ -199,5 +199,62 @@ describe("usePlanDetailPage", () => {
     expect(result.current.activePhases.has("changes")).toBe(false);
     expect(result.current.activePhases.has("review")).toBe(true);
     expect(result.current.activePhases.has("deploy")).toBe(false);
+  });
+
+  test("does not refetch the page snapshot when only the route spec changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ specId }: { specId: string }) =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId: "plan-1",
+          routeName: "project.plan.detail.spec.detail",
+          specId,
+          pageHost: null,
+        }),
+      {
+        initialProps: { specId: "spec-1" },
+        wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.pageKey).toBe("foo/plan-1");
+    expect(result.current.activePhases.has("changes")).toBe(true);
+    expect(mocks.fetchPlanSnapshot).toHaveBeenCalledTimes(1);
+
+    rerender({ specId: "spec-2" });
+
+    await waitFor(() =>
+      expect(result.current.activePhases.has("changes")).toBe(true)
+    );
+    expect(result.current.pageKey).toBe("foo/plan-1");
+    expect(mocks.fetchPlanSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  test("refetches the page snapshot when the plan changes", async () => {
+    const { result, rerender } = renderHook(
+      ({ planId }: { planId: string }) =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId,
+          routeName: "project.plan.detail.spec.detail",
+          specId: "spec-1",
+          pageHost: null,
+        }),
+      {
+        initialProps: { planId: "plan-1" },
+        wrapper,
+      }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.pageKey).toBe("foo/plan-1");
+    expect(mocks.fetchPlanSnapshot).toHaveBeenCalledTimes(1);
+
+    rerender({ planId: "plan-2" });
+
+    await waitFor(() => expect(result.current.planId).toBe("plan-2"));
+    expect(result.current.pageKey).toBe("foo/plan-2");
+    expect(mocks.fetchPlanSnapshot).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
@@ -33,13 +33,11 @@ import { useRouteSelection } from "./useRouteSelection";
 
 const buildDefaultSnapshot = (
   projectId: string,
-  planId: string,
-  specId?: string
+  planId: string
 ): PlanDetailPageSnapshot => ({
   projectId,
   planId,
-  specId,
-  pageKey: `${projectId}/${planId}/${specId ?? ""}`,
+  pageKey: `${projectId}/${planId}`,
   projectTitle: "",
   projectRequireIssueApproval: true,
   projectRequirePlanCheckNoError: true,
@@ -87,7 +85,7 @@ export const usePlanDetailPage = ({
 }): PlanDetailPageState => {
   const { t } = useTranslation();
   const [snapshot, setSnapshot] = useState<PlanDetailPageSnapshot>(() =>
-    buildDefaultSnapshot(projectId, planId, specId)
+    buildDefaultSnapshot(projectId, planId)
   );
   const phase = usePhaseState();
   const editing = useEditingScopes();
@@ -110,7 +108,7 @@ export const usePlanDetailPage = ({
   const routeStageId = route.stageId;
   const routeTaskId = route.taskId;
   const focusPhase = phase.focusPhase;
-  const routePageKey = `${projectId}/${planId}/${specId ?? ""}`;
+  const pageIdentityKey = `${projectId}/${planId}`;
   const currentPhase = useMemo<PlanDetailPhase>(() => {
     if (
       routePhase === PLAN_DETAIL_PHASE_CHANGES ||
@@ -179,7 +177,6 @@ export const usePlanDetailPage = ({
   useInitialFetch({
     projectId,
     planId,
-    specId,
     routeQueryRef,
     storeApi,
     patchState,
@@ -209,7 +206,7 @@ export const usePlanDetailPage = ({
 
   useEffect(() => {
     focusPhase(currentPhase);
-  }, [currentPhase, focusPhase, routePageKey]);
+  }, [currentPhase, focusPhase, pageIdentityKey]);
 
   const isPlanDone = useMemo(() => {
     if (!snapshot.rollout) {


### PR DESCRIPTION
## Summary
- Stop treating the selected plan spec as part of the plan-detail page data identity.
- Keep spec route selection and Changes phase focus without rerunning the page-wide initial fetch.

## Key Changes
- Remove `specId` from `useInitialFetch` parameters, reset state, and effect dependencies.
- Base plan-detail `pageKey` and phase reset identity on `projectId/planId`.
- Add regression coverage for spec-only route changes versus real plan navigation.

## Motivation
Switching between Changes specs should update the visible selection and URL, but it should not reload project, plan, issue, rollout, check run, and task run data.

## Testing
- `pnpm --dir frontend exec vitest run src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx src/react/pages/project/plan-detail/ProjectPlanDetailPage.test.tsx`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend fix`
- `pnpm --dir frontend test`
- `git diff --check`
