### PR TITLE
feat(plan-detail): unify target database display

### DIFF
--- a/frontend/src/react/components/plan-check/PlanCheckSection.tsx
+++ b/frontend/src/react/components/plan-check/PlanCheckSection.tsx
@@ -58,6 +58,7 @@ interface PlanCheckSectionProps {
   onRefreshOnOpen?: () => Promise<PlanCheckRun[]>;
   // Optional trailing element rendered after status counts (e.g. affected rows).
   trailingSummary?: ReactNode;
+  renderTarget?: (target: string) => ReactNode;
   // If true, FAILED check runs without results render as a synthetic error
   // group. Used by plan-detail regular checks.
   includeRunFailure?: boolean;
@@ -74,6 +75,7 @@ export function PlanCheckSection({
   onRun,
   onRefreshOnOpen,
   trailingSummary,
+  renderTarget,
   includeRunFailure = false,
   headingClassName = "textlabel uppercase",
 }: PlanCheckSectionProps) {
@@ -127,6 +129,7 @@ export function PlanCheckSection({
         onRefreshOnOpen={onRefreshOnOpen}
         open={drawerOpen}
         planCheckRuns={planCheckRuns}
+        renderTarget={renderTarget}
       />
     </div>
   );
@@ -240,6 +243,7 @@ interface PlanCheckResultsDrawerProps {
   planCheckRuns: PlanCheckRun[];
   onRefreshOnOpen?: () => Promise<PlanCheckRun[]>;
   includeRunFailure?: boolean;
+  renderTarget?: (target: string) => ReactNode;
 }
 
 export function PlanCheckResultsDrawer({
@@ -248,6 +252,7 @@ export function PlanCheckResultsDrawer({
   planCheckRuns,
   onRefreshOnOpen,
   includeRunFailure = false,
+  renderTarget,
 }: PlanCheckResultsDrawerProps) {
   const { t } = useTranslation();
   const [selectedStatus, setSelectedStatus] = useState<
@@ -358,7 +363,9 @@ export function PlanCheckResultsDrawer({
                         </div>
                         {group.target && (
                           <div className="min-w-0 max-w-[50%] truncate text-sm text-control-light">
-                            {formatCheckTarget(group.target)}
+                            {renderTarget
+                              ? renderTarget(group.target)
+                              : formatCheckTarget(group.target)}
                           </div>
                         )}
                       </div>

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailAggregateChecks.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailAggregateChecks.tsx
@@ -3,6 +3,7 @@ import { PlanCheckSection } from "@/react/components/plan-check/PlanCheckSection
 import { usePlanCheckActions } from "../hooks/usePlanCheckActions";
 import { usePlanDetailContext } from "../shell/PlanDetailContext";
 import { getPlanCheckSummaryWithFallback } from "../utils/planCheck";
+import { PlanTargetDisplay } from "./PlanTargetDisplay";
 
 // Plan-wide checks rendered as a verdict-line footer at the bottom of the
 // CHANGES phase card, so reviewers can scan aggregate check status across
@@ -36,6 +37,9 @@ export function PlanDetailAggregateChecks() {
         onRefreshOnOpen={refreshChecks}
         onRun={runChecks}
         planCheckRuns={page.planCheckRuns}
+        renderTarget={(target) => (
+          <PlanTargetDisplay showEnvironment target={target} />
+        )}
         summaryOverride={summary}
       />
     </div>

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
@@ -7,7 +7,10 @@ import type { PlanCheckRun } from "@/types/proto-es/v1/plan_service_pb";
 import type { CheckReleaseResponse_CheckResult } from "@/types/proto-es/v1/release_service_pb";
 import type { PlanDetailPageState } from "../shell/hooks/types";
 import { PlanDetailProvider } from "../shell/PlanDetailContext";
-import { PlanDetailChangesBranch } from "./PlanDetailChangesBranch";
+import {
+  DatabaseGroupTarget,
+  PlanDetailChangesBranch,
+} from "./PlanDetailChangesBranch";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -38,7 +41,7 @@ const mocks = vi.hoisted(() => ({
     getDBGroupByName: vi.fn(),
     getOrFetchDBGroupByName: vi.fn(async () => ({
       name: "projects/foo/databaseGroups/group-a",
-      matchedDatabases: [],
+      matchedDatabases: [] as Array<{ name: string }>,
     })),
   },
   environmentStore: {
@@ -164,6 +167,16 @@ vi.mock("@/react/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("@/react/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PopoverTrigger: ({ children }: { children: ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
 vi.mock("@/react/lib/utils", () => ({
   cn: (...classes: Array<string | false | null | undefined>) =>
     classes.filter(Boolean).join(" "),
@@ -172,6 +185,7 @@ vi.mock("@/react/lib/utils", () => ({
 vi.mock("@/router", () => ({
   router: {
     push: mocks.routerPush,
+    resolve: () => ({ href: "/database-group-detail" }),
   },
 }));
 
@@ -519,6 +533,35 @@ async function flush() {
 }
 
 describe("PlanDetailChangesBranch", () => {
+  it("renders database group overflow as a popover action", async () => {
+    mocks.dbGroupStore.getDBGroupByName.mockReturnValue({
+      name: "projects/foo/databaseGroups/group-a",
+      matchedDatabases: Array.from({ length: 8 }, (_, index) => ({
+        name: `instances/test/databases/db_${index}`,
+      })),
+    });
+    mocks.dbGroupStore.getOrFetchDBGroupByName.mockResolvedValue({
+      name: "projects/foo/databaseGroups/group-a",
+      matchedDatabases: Array.from({ length: 8 }, (_, index) => ({
+        name: `instances/test/databases/db_${index}`,
+      })),
+    });
+
+    act(() => {
+      root.render(
+        <DatabaseGroupTarget target="projects/foo/databaseGroups/group-a" />
+      );
+    });
+    await flush();
+
+    const moreButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "common.n-more"
+    );
+
+    expect(moreButton).toBeTruthy();
+    expect(container.textContent).toContain("common.databases");
+  });
+
   it("keeps Add Change target selection when the page rerenders", async () => {
     renderHarness(0);
 

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -1,7 +1,6 @@
 import { clone, create } from "@bufbuild/protobuf";
 import {
   CheckCircle,
-  ChevronRight,
   DatabaseIcon,
   EllipsisVertical,
   ExternalLink,
@@ -35,6 +34,11 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/react/components/ui/dropdown-menu";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/react/components/ui/popover";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
   Select,
@@ -67,7 +71,6 @@ import {
   useCurrentUserV1,
   useDatabaseV1Store,
   useDBGroupStore,
-  useEnvironmentV1Store,
   useProjectV1Store,
   useSheetV1Store,
 } from "@/store";
@@ -139,8 +142,10 @@ import { PlanDetailAggregateChecks } from "./PlanDetailAggregateChecks";
 import { PlanDetailDraftChecks } from "./PlanDetailDraftChecks";
 import { PlanDetailStatementSection } from "./PlanDetailStatementSection";
 import { PlanDetailTabItem, PlanDetailTabStrip } from "./PlanDetailTabStrip";
+import { PlanTargetDisplay } from "./PlanTargetDisplay";
 
 const DEFAULT_VISIBLE_TARGETS = 20;
+const DATABASE_GROUP_VISIBLE_DATABASES = 3;
 const EMPTY_SELECT_VALUE = "__empty__";
 
 const pushSpecDetailRoute = (
@@ -1287,7 +1292,7 @@ function TargetsSection({
                   {nonEnvDatabaseNames.map((name) => (
                     <div key={name} className="flex items-center gap-2">
                       <span className="h-1 w-1 shrink-0 rounded-full bg-current" />
-                      <DatabaseTarget target={name} />
+                      <PlanTargetDisplay target={name} />
                     </div>
                   ))}
                 </div>
@@ -1307,7 +1312,7 @@ function TargetsSection({
                   key={target}
                   className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1"
                 >
-                  <DatabaseTarget showEnvironment target={target} />
+                  <PlanTargetDisplay showEnvironment target={target} />
                 </div>
               ) : isValidDatabaseGroupName(target) ? (
                 <div key={target} className="rounded-lg border px-2 py-1">
@@ -1369,7 +1374,7 @@ function TargetsSection({
                           key={target}
                           className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1 transition-all"
                         >
-                          <DatabaseTarget showEnvironment target={target} />
+                          <PlanTargetDisplay showEnvironment target={target} />
                         </div>
                       ) : isValidDatabaseGroupName(target) ? (
                         <div
@@ -1823,38 +1828,6 @@ function DatabaseGroupSelector({
   );
 }
 
-export function DatabaseTarget({
-  showEnvironment = false,
-  target,
-}: {
-  showEnvironment?: boolean;
-  target: string;
-}) {
-  const environmentStore = useEnvironmentV1Store();
-  const databaseStore = useDatabaseV1Store();
-  const database = databaseStore.getDatabaseByName(target);
-  const environment = database.effectiveEnvironment
-    ? environmentStore.getEnvironmentByName(database.effectiveEnvironment)
-    : undefined;
-  const instance = getInstanceResource(database);
-  const databaseName = extractDatabaseResourceName(database.name).databaseName;
-  const instanceName = instance.title;
-
-  return (
-    <div className="flex min-w-0 items-center truncate text-sm">
-      <EngineIcon engine={instance.engine} className="mr-1 h-4 w-4" />
-      {showEnvironment && environment?.title && (
-        <span className="mr-1 truncate text-control-placeholder">
-          {environment.title}
-        </span>
-      )}
-      <span className="truncate text-control-light">{instanceName}</span>
-      <ChevronRight className="h-4 w-4 shrink-0 text-control-light/80" />
-      <span className="truncate text-control">{databaseName}</span>
-    </div>
-  );
-}
-
 export function DatabaseGroupTarget({
   className,
   target,
@@ -1865,11 +1838,29 @@ export function DatabaseGroupTarget({
   const { t } = useTranslation();
   const databaseStore = useDatabaseV1Store();
   const dbGroupStore = useDBGroupStore();
+  const [searchText, setSearchText] = useState("");
   const dbGroup = dbGroupStore.getDBGroupByName(target, DatabaseGroupView.FULL);
   const matchedDatabases = dbGroup.matchedDatabases ?? [];
-  const { extraDatabases, inlineDatabases } =
-    splitInlineDatabases(matchedDatabases);
+  const { extraDatabases, inlineDatabases } = splitInlineDatabases(
+    matchedDatabases,
+    DATABASE_GROUP_VISIBLE_DATABASES
+  );
   const groupName = extractDatabaseGroupName(target);
+  const filteredExtraDatabases = useMemo(() => {
+    const normalized = searchText.trim().toLowerCase();
+    if (!normalized) {
+      return extraDatabases;
+    }
+    return extraDatabases.filter((database) => {
+      const databaseName = extractDatabaseResourceName(
+        database.name
+      ).databaseName.toLowerCase();
+      return (
+        databaseName.includes(normalized) ||
+        database.name.toLowerCase().includes(normalized)
+      );
+    });
+  }, [extraDatabases, searchText]);
 
   useEffect(() => {
     const load = async () => {
@@ -1923,25 +1914,65 @@ export function DatabaseGroupTarget({
               key={database.name}
               className="inline-flex cursor-default items-center gap-x-1 rounded-lg border bg-gray-50 px-2 py-1 transition-all"
             >
-              <DatabaseTarget showEnvironment target={database.name} />
+              <PlanTargetDisplay showEnvironment target={database.name} />
             </div>
           ))}
           {extraDatabases.length > 0 && (
-            <Tooltip
-              content={
-                <div className="flex max-h-64 flex-col gap-y-1 overflow-y-auto py-1">
-                  {extraDatabases.map((database) => (
-                    <div key={database.name} className="py-1">
-                      <DatabaseTarget showEnvironment target={database.name} />
-                    </div>
-                  ))}
-                </div>
-              }
-            >
-              <span className="cursor-pointer text-xs text-accent">
+            <Popover>
+              <PopoverTrigger
+                render={
+                  <Button
+                    className="h-6 px-1.5 text-xs text-accent hover:bg-accent/10 hover:text-accent"
+                    size="xs"
+                    type="button"
+                    variant="ghost"
+                  />
+                }
+              >
                 {t("common.n-more", { n: extraDatabases.length })}
-              </span>
-            </Tooltip>
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                className="w-[min(520px,calc(100vw-2rem))] p-0"
+                side="bottom"
+              >
+                <div className="border-b border-control-border px-3 py-2">
+                  <div className="text-sm font-medium text-control">
+                    {t("common.databases")} ({extraDatabases.length})
+                  </div>
+                </div>
+                {extraDatabases.length > 20 && (
+                  <div className="border-b border-control-border px-3 py-2">
+                    <SearchInput
+                      placeholder={t("common.search")}
+                      value={searchText}
+                      onChange={(event) => setSearchText(event.target.value)}
+                    />
+                  </div>
+                )}
+                <div className="max-h-80 overflow-y-auto p-2">
+                  {filteredExtraDatabases.length > 0 ? (
+                    <div className="flex flex-col gap-1">
+                      {filteredExtraDatabases.map((database) => (
+                        <div
+                          key={database.name}
+                          className="min-w-0 rounded-xs px-2 py-1.5 hover:bg-control-bg"
+                        >
+                          <PlanTargetDisplay
+                            showEnvironment
+                            target={database.name}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <div className="px-2 py-4 text-center text-sm text-control-light">
+                      {t("common.no-data")}
+                    </div>
+                  )}
+                </div>
+              </PopoverContent>
+            </Popover>
           )}
         </div>
       )}

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailDraftChecks.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailDraftChecks.tsx
@@ -17,6 +17,7 @@ import { getSheetStatement } from "@/utils/v1/sheet";
 import { usePlanDetailContext } from "../shell/PlanDetailContext";
 import { getLocalSheetByName } from "../utils/localSheet";
 import { transformReleaseCheckResultsToPlanCheckRuns } from "../utils/planCheck";
+import { PlanTargetDisplay } from "./PlanTargetDisplay";
 
 export function PlanDetailDraftChecks({
   checkResults,
@@ -104,6 +105,9 @@ export function PlanDetailDraftChecks({
       isRunning={isRunningChecks}
       onRun={runChecks}
       planCheckRuns={formattedCheckRuns}
+      renderTarget={(target) => (
+        <PlanTargetDisplay showEnvironment target={target} />
+      )}
       runDisabled={statement.length === 0}
       trailingSummary={trailingSummary}
     />

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailRollbackSheet.tsx
@@ -44,7 +44,7 @@ import {
   extractProjectResourceName,
   hasProjectPermissionV2,
 } from "@/utils";
-import { DatabaseTarget } from "./PlanDetailChangesBranch";
+import { PlanTargetDisplay } from "./PlanTargetDisplay";
 
 export function PlanDetailRollbackSheet({
   open,
@@ -198,7 +198,7 @@ export function PlanDetailRollbackSheet({
                       />
                       <div className="min-w-0 space-y-1">
                         <div className="min-w-0 text-sm font-medium text-main">
-                          <DatabaseTarget
+                          <PlanTargetDisplay
                             showEnvironment
                             target={item.task.target}
                           />
@@ -228,7 +228,7 @@ export function PlanDetailRollbackSheet({
                 previews.map((preview) => (
                   <div key={preview.taskRun.name} className="space-y-2">
                     <div className="text-sm font-medium text-main">
-                      <DatabaseTarget
+                      <PlanTargetDisplay
                         showEnvironment
                         target={preview.task.target}
                       />

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
@@ -4,7 +4,6 @@ import { Check, FastForward, Loader2, Pause, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
-import { EngineIcon } from "@/react/components/EngineIcon";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
@@ -23,7 +22,6 @@ import { cn } from "@/react/lib/utils";
 import {
   pushNotification,
   useCurrentUserV1,
-  useDatabaseV1Store,
   useEnvironmentV1Store,
   useProjectV1Store,
 } from "@/store";
@@ -39,11 +37,7 @@ import {
   Task_Type,
   TaskRun_Status,
 } from "@/types/proto-es/v1/rollout_service_pb";
-import {
-  extractDatabaseResourceName,
-  extractInstanceResourceName,
-  extractStageUID,
-} from "@/utils";
+import { extractStageUID } from "@/utils";
 import {
   CANCELABLE_TASK_STATUSES,
   canRolloutTasks,
@@ -51,6 +45,7 @@ import {
   RUNNABLE_TASK_STATUSES,
 } from "../../issue-detail/utils/rollout";
 import { usePlanDetailContext } from "../shell/PlanDetailContext";
+import { PlanTargetDisplay } from "./PlanTargetDisplay";
 
 const DEFAULT_RUN_DELAY_MS = 60 * 60 * 1000;
 
@@ -601,42 +596,9 @@ function parseDatetimeLocalValue(value: string) {
 
 function PlanDetailTaskDatabaseName({ task }: { task: Task }) {
   if (task.target) {
-    return <PlanDetailDatabaseTarget target={task.target} />;
+    return <PlanTargetDisplay showEnvironment target={task.target} />;
   }
   return <span className="truncate">{task.name.split("/").at(-1)}</span>;
-}
-
-function PlanDetailDatabaseTarget({ target }: { target: string }) {
-  const { t } = useTranslation();
-  const databaseStore = useDatabaseV1Store();
-  const environmentStore = useEnvironmentV1Store();
-  const database = databaseStore.getDatabaseByName(target);
-  const environment = environmentStore.getEnvironmentByName(
-    database.effectiveEnvironment ??
-      database.instanceResource?.environment ??
-      ""
-  );
-  const instance = database.instanceResource;
-  const { databaseName } = extractDatabaseResourceName(target);
-  const instanceTitle =
-    instance?.title ||
-    extractInstanceResourceName(target) ||
-    t("common.unknown");
-
-  return (
-    <div className="flex min-w-0 items-center truncate text-sm">
-      {instance && (
-        <EngineIcon
-          engine={instance.engine}
-          className="mr-1 inline-block h-4 w-4"
-        />
-      )}
-      <span className="mr-1 truncate text-gray-400">{environment.title}</span>
-      <span className="truncate text-gray-600">{instanceTitle}</span>
-      <span className="mx-1 shrink-0 text-gray-500 opacity-60">›</span>
-      <span className="truncate text-gray-800">{databaseName}</span>
-    </div>
-  );
 }
 
 function PlanDetailStageEnvironment({

--- a/frontend/src/react/pages/project/plan-detail/components/PlanTargetDisplay.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanTargetDisplay.test.tsx
@@ -1,0 +1,184 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Engine } from "@/types/proto-es/v1/common_pb";
+import { PlanTargetDisplay } from "./PlanTargetDisplay";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  databaseStore: {
+    getDatabaseByName: vi.fn(),
+  },
+  environmentStore: {
+    getEnvironmentByName: vi.fn(),
+  },
+}));
+
+vi.mock("@/react/components/EngineIcon", () => ({
+  EngineIcon: ({
+    className,
+    engine,
+  }: {
+    className?: string;
+    engine: Engine;
+  }) => (
+    <span className={className} data-testid="engine-icon">
+      {Engine[engine]}
+    </span>
+  ),
+}));
+
+vi.mock("@/react/lib/utils", () => ({
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/store", () => ({
+  useDatabaseV1Store: () => mocks.databaseStore,
+  useEnvironmentV1Store: () => mocks.environmentStore,
+}));
+
+vi.mock("@/types", () => ({
+  isValidDatabaseName: (name: string) => name.includes("/databases/"),
+}));
+
+vi.mock("@/utils", () => ({
+  extractDatabaseResourceName: (name: string) => ({
+    databaseName: name.split("/databases/")[1] ?? name,
+  }),
+  getInstanceResource: (database: {
+    instanceResource?: { engine: Engine; title: string };
+  }) => database.instanceResource,
+}));
+
+describe("PlanTargetDisplay", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+    mocks.databaseStore.getDatabaseByName.mockReturnValue({
+      name: "projects/p/instances/prod/databases/app",
+      effectiveEnvironment: "environments/prod",
+      instanceResource: {
+        engine: Engine.POSTGRES,
+        title: "prod-instance",
+      },
+    });
+    mocks.environmentStore.getEnvironmentByName.mockReturnValue({
+      name: "environments/prod",
+      title: "Production",
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a database target with engine, environment, instance, and database name", () => {
+    act(() => {
+      root.render(
+        <PlanTargetDisplay
+          showEnvironment
+          target="projects/p/instances/prod/databases/app"
+        />
+      );
+    });
+
+    expect(container.textContent).toContain("POSTGRES");
+    expect(container.textContent).toContain("Production");
+    expect(container.textContent).toContain("prod-instance");
+    expect(container.textContent).toContain("app");
+  });
+
+  it("applies stable truncation priority across environment, instance, and database name", () => {
+    act(() => {
+      root.render(
+        <PlanTargetDisplay
+          showEnvironment
+          target="projects/p/instances/prod/databases/app"
+        />
+      );
+    });
+
+    const rootElement = container.firstElementChild;
+    const environment = Array.from(container.querySelectorAll("span")).find(
+      (element) => element.textContent === "Production"
+    );
+    const instance = Array.from(container.querySelectorAll("span")).find(
+      (element) => element.textContent === "prod-instance"
+    );
+    const database = Array.from(container.querySelectorAll("span")).find(
+      (element) => element.textContent === "app"
+    );
+
+    expect(rootElement?.className).toContain("inline-flex");
+    expect(rootElement?.className).toContain("max-w-full");
+    expect(rootElement?.getAttribute("title")).toBe(
+      "Production / prod-instance / app"
+    );
+    expect(environment?.className).toContain("max-w-24");
+    expect(instance?.className).toContain("max-w-40");
+    expect(database?.className).toContain("flex-1");
+    expect(database?.className).toContain("min-w-12");
+  });
+
+  it("can hide optional database metadata", () => {
+    act(() => {
+      root.render(
+        <PlanTargetDisplay
+          showEngine={false}
+          showEnvironment={false}
+          showInstance={false}
+          target="projects/p/instances/prod/databases/app"
+        />
+      );
+    });
+
+    expect(container.textContent).not.toContain("POSTGRES");
+    expect(container.textContent).not.toContain("Production");
+    expect(container.textContent).not.toContain("prod-instance");
+    expect(container.textContent).toContain("app");
+  });
+
+  it("supports a medium size for task target rows", () => {
+    act(() => {
+      root.render(
+        <PlanTargetDisplay
+          showEnvironment
+          size="md"
+          target="projects/p/instances/prod/databases/app"
+        />
+      );
+    });
+
+    const rootElement = container.firstElementChild;
+    const engineIcon = container.querySelector('[data-testid="engine-icon"]');
+    const database = Array.from(container.querySelectorAll("span")).find(
+      (element) => element.textContent === "app"
+    );
+
+    expect(rootElement?.className).toContain("text-base");
+    expect(engineIcon?.className).toContain("h-5");
+    expect(database?.className).toContain("min-w-16");
+  });
+
+  it("falls back to the raw target when the target is not a database", () => {
+    act(() => {
+      root.render(
+        <PlanTargetDisplay target="projects/p/databaseGroups/prod" />
+      );
+    });
+
+    expect(container.textContent).toContain("projects/p/databaseGroups/prod");
+  });
+});

--- a/frontend/src/react/pages/project/plan-detail/components/PlanTargetDisplay.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanTargetDisplay.tsx
@@ -1,0 +1,136 @@
+import { ChevronRight } from "lucide-react";
+import { EngineIcon } from "@/react/components/EngineIcon";
+import { cn } from "@/react/lib/utils";
+import { useDatabaseV1Store, useEnvironmentV1Store } from "@/store";
+import { isValidDatabaseName } from "@/types";
+import { extractDatabaseResourceName, getInstanceResource } from "@/utils";
+
+type PlanTargetDisplaySize = "sm" | "md";
+
+const sizeClasses: Record<
+  PlanTargetDisplaySize,
+  {
+    database: string;
+    environment: string;
+    icon: string;
+    instance: string;
+    root: string;
+    separator: string;
+  }
+> = {
+  sm: {
+    database: "min-w-12",
+    environment: "max-w-24",
+    icon: "h-4 w-4",
+    instance: "max-w-40",
+    root: "text-sm",
+    separator: "h-4 w-4",
+  },
+  md: {
+    database: "min-w-16",
+    environment: "max-w-28",
+    icon: "h-5 w-5",
+    instance: "max-w-48",
+    root: "text-base",
+    separator: "h-5 w-5",
+  },
+};
+
+export function PlanTargetDisplay({
+  className,
+  showEngine = true,
+  showEnvironment = false,
+  showInstance = true,
+  size = "sm",
+  target,
+}: {
+  className?: string;
+  showEngine?: boolean;
+  showEnvironment?: boolean;
+  showInstance?: boolean;
+  size?: PlanTargetDisplaySize;
+  target: string;
+}) {
+  const databaseStore = useDatabaseV1Store();
+  const environmentStore = useEnvironmentV1Store();
+  const classes = sizeClasses[size];
+
+  if (!isValidDatabaseName(target)) {
+    return (
+      <span
+        className={cn(
+          "truncate text-control-placeholder",
+          classes.root,
+          className
+        )}
+      >
+        {target}
+      </span>
+    );
+  }
+
+  const database = databaseStore.getDatabaseByName(target);
+  const environmentName =
+    database.effectiveEnvironment ??
+    database.instanceResource?.environment ??
+    "";
+  const environment = environmentName
+    ? environmentStore.getEnvironmentByName(environmentName)
+    : undefined;
+  const instance = getInstanceResource(database);
+  const { databaseName } = extractDatabaseResourceName(target);
+  const shouldShowSeparator = showInstance && Boolean(instance.title);
+  const title = [
+    showEnvironment ? environment?.title : undefined,
+    showInstance ? instance.title : undefined,
+    databaseName,
+  ]
+    .filter(Boolean)
+    .join(" / ");
+
+  return (
+    <div
+      className={cn(
+        "inline-flex max-w-full min-w-0 items-center",
+        classes.root,
+        className
+      )}
+      title={title}
+    >
+      {showEngine && (
+        <EngineIcon
+          engine={instance.engine}
+          className={cn("mr-1 shrink-0", classes.icon)}
+        />
+      )}
+      {showEnvironment && environment?.title && (
+        <span
+          className={cn(
+            "mr-1 min-w-0 shrink truncate text-control-placeholder",
+            classes.environment
+          )}
+        >
+          {environment.title}
+        </span>
+      )}
+      {showInstance && instance.title && (
+        <span
+          className={cn(
+            "min-w-0 shrink-[2] truncate text-control-light",
+            classes.instance
+          )}
+        >
+          {instance.title}
+        </span>
+      )}
+      {shouldShowSeparator && (
+        <ChevronRight
+          className={cn("shrink-0 text-control-light/80", classes.separator)}
+        />
+      )}
+      <span className={cn("flex-1 truncate text-control", classes.database)}>
+        {databaseName}
+      </span>
+    </div>
+  );
+}

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployPendingTasksSection.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployPendingTasksSection.tsx
@@ -24,10 +24,8 @@ import {
   extractPlanNameFromRolloutName,
 } from "@/utils";
 import { generateRolloutPreview } from "../../utils/rolloutPreview";
-import {
-  DatabaseGroupTarget,
-  DatabaseTarget,
-} from "../PlanDetailChangesBranch";
+import { DatabaseGroupTarget } from "../PlanDetailChangesBranch";
+import { PlanTargetDisplay } from "../PlanTargetDisplay";
 import type { PendingTaskGroup } from "./types";
 
 async function buildPendingTaskGroups(
@@ -213,7 +211,7 @@ export function DeployPendingTasksSection({
                       {group.tasks.map((task) => (
                         <li key={`${task.target}:${task.specId}`}>
                           {isValidDatabaseName(task.target) ? (
-                            <DatabaseTarget
+                            <PlanTargetDisplay
                               showEnvironment
                               target={task.target}
                             />

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
@@ -23,7 +23,6 @@ import {
   releaseNameOfTaskV1,
 } from "@/utils/v1/issue/rollout";
 import { usePlanDetailContext } from "../../shell/PlanDetailContext";
-import { DatabaseTarget } from "../PlanDetailChangesBranch";
 import { PlanDetailRollbackSheet } from "../PlanDetailRollbackSheet";
 import {
   type PlanDetailTaskRolloutAction,
@@ -31,6 +30,7 @@ import {
 } from "../PlanDetailTaskRolloutActionPanel";
 import { PlanDetailTaskRunDetail } from "../PlanDetailTaskRunDetail";
 import { PlanDetailTaskRunTable } from "../PlanDetailTaskRunTable";
+import { PlanTargetDisplay } from "../PlanTargetDisplay";
 import { DeployReleaseInfoCard } from "./DeployReleaseInfoCard";
 import { DeployTaskStatus } from "./DeployTaskStatus";
 import { useDeployTaskActions } from "./taskActions";
@@ -112,9 +112,11 @@ export function DeployTaskDetailPanel({ task }: { task: Task }) {
                 {stageTitle}
               </span>
             )}
-            <div className="min-w-0 text-xl">
-              <DatabaseTarget showEnvironment target={database.name} />
-            </div>
+            <PlanTargetDisplay
+              showEnvironment
+              size="md"
+              target={database.name}
+            />
             {scheduledTimeDisplay && task.status === Task_Status.PENDING && (
               <Tooltip
                 content={

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
@@ -27,12 +27,12 @@ import {
   releaseNameOfTaskV1,
 } from "@/utils/v1/issue/rollout";
 import { usePlanDetailContext } from "../../shell/PlanDetailContext";
-import { DatabaseTarget } from "../PlanDetailChangesBranch";
 import { PlanDetailRollbackSheet } from "../PlanDetailRollbackSheet";
 import {
   type PlanDetailTaskRolloutAction,
   PlanDetailTaskRolloutActionPanel,
 } from "../PlanDetailTaskRolloutActionPanel";
+import { PlanTargetDisplay } from "../PlanTargetDisplay";
 import { DeployLatestTaskRunInfo } from "./DeployLatestTaskRunInfo";
 import { DeployReleaseInfoCard } from "./DeployReleaseInfoCard";
 import { DeployTaskStatus } from "./DeployTaskStatus";
@@ -165,9 +165,7 @@ export function DeployTaskItem({
                 status={task.status}
               />
               <div className="flex min-w-0 items-center gap-x-2">
-                <div className="min-w-0">
-                  <DatabaseTarget target={task.target} />
-                </div>
+                <PlanTargetDisplay size="md" target={task.target} />
                 {isExpanded && !readonly && (
                   <button
                     className="flex shrink-0 items-center gap-x-1 text-xs text-accent transition-opacity hover:opacity-80"


### PR DESCRIPTION
## Summary
- Add a shared plan-detail target display component for database targets.
- Use it across changes, deploy, rollback, rollout action, and plan-check target surfaces.
- Replace database-group overflow tooltip with a searchable popover.

## Key Changes
- Introduces `PlanTargetDisplay` with optional engine, environment, instance, and size variants.
- Standardizes database target rendering across plan detail task and target views.
- Tightens database-group previews and moves `+n more` into a white popover with scroll and search for large groups.
- Adds regression coverage for target display sizing/truncation and database-group overflow behavior.

## Motivation
- Plan detail showed database targets in several inconsistent styles.
- Large database groups used a dark tooltip for hundreds of overflow databases, which was hard to scan and not appropriate for list content.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend exec vitest run src/react/pages/project/plan-detail/components/PlanTargetDisplay.test.tsx src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.test.tsx`
- `pnpm --dir frontend test`
- `git diff --check`

Close BYT-9583, BYT-9581