### PR TITLE
fix(frontend): polish select dropdown placement

### DIFF
--- a/frontend/src/react/components/ui/select.test.tsx
+++ b/frontend/src/react/components/ui/select.test.tsx
@@ -1,0 +1,99 @@
+import { act, type ReactNode } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Select, SelectContent } from "./select";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const selectMocks = vi.hoisted(() => ({
+  positionerProps: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@base-ui/react/select", () => ({
+  Select: {
+    Root: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Trigger: ({ children }: { children: ReactNode }) => (
+      <button type="button">{children}</button>
+    ),
+    Icon: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Value: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Portal: ({ children }: { children: ReactNode }) => <>{children}</>,
+    Positioner: ({ children, ...props }: { children: ReactNode }) => {
+      selectMocks.positionerProps.push(props);
+      return <div>{children}</div>;
+    },
+    Popup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    Item: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    ItemIndicator: ({ children }: { children: ReactNode }) => <>{children}</>,
+    ItemText: ({ children }: { children: ReactNode }) => <>{children}</>,
+  },
+}));
+
+describe("SelectContent", () => {
+  afterEach(() => {
+    selectMocks.positionerProps.length = 0;
+    document.body.innerHTML = "";
+  });
+
+  test("opens as a dropdown instead of overlapping the trigger", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <Select>
+          <SelectContent>Role options</SelectContent>
+        </Select>
+      );
+    });
+
+    expect(selectMocks.positionerProps).toContainEqual(
+      expect.objectContaining({
+        align: "start",
+        alignItemWithTrigger: false,
+      })
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("allows positioner props to customize dropdown placement", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <Select>
+          <SelectContent
+            positionerProps={{
+              align: "end",
+              className: "custom-positioner",
+              sideOffset: 8,
+            }}
+          >
+            Role options
+          </SelectContent>
+        </Select>
+      );
+    });
+
+    expect(selectMocks.positionerProps).toContainEqual(
+      expect.objectContaining({
+        align: "end",
+        alignItemWithTrigger: false,
+        className: expect.stringContaining("custom-positioner"),
+        sideOffset: 8,
+      })
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/frontend/src/react/components/ui/select.tsx
+++ b/frontend/src/react/components/ui/select.tsx
@@ -58,15 +58,37 @@ function SelectTrigger({
 const SelectValue = BaseSelect.Value;
 
 // ---- Portal + Positioner + Popup  ----
+type SelectContentProps = ComponentProps<typeof BaseSelect.Popup> & {
+  positionerProps?: Omit<
+    ComponentProps<typeof BaseSelect.Positioner>,
+    "children"
+  >;
+};
+
 function SelectContent({
   className,
   children,
+  positionerProps,
   ref,
   ...props
-}: ComponentProps<typeof BaseSelect.Popup>) {
+}: SelectContentProps) {
+  const {
+    align = "start",
+    alignItemWithTrigger = false,
+    className: positionerClassName,
+    sideOffset = 4,
+    ...restPositionerProps
+  } = positionerProps ?? {};
+
   return (
     <BaseSelect.Portal container={getLayerRoot("overlay")}>
-      <BaseSelect.Positioner sideOffset={4} className={LAYER_SURFACE_CLASS}>
+      <BaseSelect.Positioner
+        align={align}
+        alignItemWithTrigger={alignItemWithTrigger}
+        sideOffset={sideOffset}
+        className={cn(LAYER_SURFACE_CLASS, positionerClassName)}
+        {...restPositionerProps}
+      >
         <BaseSelect.Popup
           ref={ref}
           className={cn(

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -1187,6 +1187,7 @@
   "instance.connection-options": "Connection Options",
   "instance.create-gcp-credentials": "To create credentials, see",
   "instance.database-region": "Database Region",
+  "instance.default-role": "Default role",
   "instance.endpoint": "Endpoint",
   "instance.external-id": "External ID",
   "instance.external-id-description": "External ID for additional security when assuming role (optional)",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -1181,6 +1181,7 @@
   "instance.connection-options": "Opciones de conexión",
   "instance.create-gcp-credentials": "Para crear credenciales, consulte",
   "instance.database-region": "Región de la base de datos",
+  "instance.default-role": "Rol predeterminado",
   "instance.endpoint": "Punto final",
   "instance.external-id": "ID externo",
   "instance.external-id-description": "ID externo para seguridad adicional al asumir el rol (opcional)",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -1181,6 +1181,7 @@
   "instance.connection-options": "接続オプション",
   "instance.create-gcp-credentials": "認証情報の作成方法については、を参照してください",
   "instance.database-region": "データベース領域",
+  "instance.default-role": "デフォルトロール",
   "instance.endpoint": "エンドポイント",
   "instance.external-id": "外部 ID",
   "instance.external-id-description": "ロールを引き受ける際の追加セキュリティ用の外部 ID（オプション）",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -1181,6 +1181,7 @@
   "instance.connection-options": "Tùy chọn kết nối",
   "instance.create-gcp-credentials": "Để tạo thông tin xác thực, xem",
   "instance.database-region": "Khu vực cơ sở dữ liệu",
+  "instance.default-role": "Vai trò mặc định",
   "instance.endpoint": "Điểm cuối",
   "instance.external-id": "ID bên ngoài",
   "instance.external-id-description": "ID bên ngoài để bảo mật bổ sung khi đảm nhận vai trò (tùy chọn)",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -1181,6 +1181,7 @@
   "instance.connection-options": "连接选项",
   "instance.create-gcp-credentials": "创建凭据的方法见",
   "instance.database-region": "数据库区域",
+  "instance.default-role": "默认角色",
   "instance.endpoint": "端点",
   "instance.external-id": "外部 ID",
   "instance.external-id-description": "承担角色时用于额外安全性的外部 ID（可选）",

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
@@ -24,6 +24,14 @@ const mocks = vi.hoisted(() => ({
   getInstanceResource: vi.fn(),
   getPlanOptionVisibility: vi.fn(),
   getProjectByName: vi.fn(),
+  selectedSelectValueChange: undefined as
+    | ((value: string | null | undefined) => void)
+    | undefined,
+  instanceRoleServiceClientConnect: {
+    listInstanceRoles: vi.fn(async () => ({
+      roles: [] as Array<{ roleName: string }>,
+    })),
+  },
   localSheets: new Map<
     string,
     { content: Uint8Array; contentSize: bigint; name: string }
@@ -118,11 +126,33 @@ vi.mock("@/react/components/ui/search-input", () => ({
 }));
 
 vi.mock("@/react/components/ui/select", () => ({
-  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Select: ({
+    children,
+    onValueChange,
+  }: {
+    children: ReactNode;
+    onValueChange?: (value: string | null | undefined) => void;
+  }) => {
+    mocks.selectedSelectValueChange = onValueChange;
+    return <div>{children}</div>;
+  },
   SelectContent: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
-  SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children: ReactNode;
+    value?: string;
+  }) => {
+    const onValueChange = mocks.selectedSelectValueChange;
+    return (
+      <button onClick={() => onValueChange?.(value)} type="button">
+        {children}
+      </button>
+    );
+  },
   SelectTrigger: ({ children }: { children: ReactNode }) => (
     <button>{children}</button>
   ),
@@ -202,9 +232,7 @@ vi.mock("@/types", () => ({
 }));
 
 vi.mock("@/connect", () => ({
-  instanceRoleServiceClientConnect: {
-    listInstanceRoles: vi.fn(async () => ({ roles: [] })),
-  },
+  instanceRoleServiceClientConnect: mocks.instanceRoleServiceClientConnect,
   planServiceClientConnect: {
     updatePlan: vi.fn(async (request) => request.plan),
   },
@@ -728,5 +756,69 @@ describe("PlanDetailChangesBranch", () => {
     await flush();
 
     expect(container.textContent).toContain("spec-1::1");
+  });
+
+  it("clears the selected role with the default role option", async () => {
+    mocks.getPlanOptionVisibility.mockReturnValue({
+      shouldShow: true,
+      showGhost: false,
+      showInstanceRole: true,
+      showIsolationLevel: false,
+      showPreBackup: false,
+      showTransactionMode: false,
+    });
+    mocks.instanceRoleServiceClientConnect.listInstanceRoles.mockResolvedValue({
+      roles: [{ roleName: "bbsample" }],
+    });
+    const sheetName = "projects/foo/sheets/-1";
+    const statement =
+      "/* === Bytebase Role Setter. DO NOT EDIT. === */\nSET ROLE bbsample;\nSELECT 1;";
+    mocks.localSheets.set(sheetName, {
+      name: sheetName,
+      content: new TextEncoder().encode(statement),
+      contentSize: 0n,
+    });
+    const page = buildPageState();
+    page.plan.specs = [
+      {
+        id: "spec-1",
+        config: {
+          case: "changeDatabaseConfig",
+          value: {
+            sheet: sheetName,
+            targets: [DB_WIDGETS],
+          },
+        },
+      },
+    ] as unknown as PlanDetailPageState["plan"]["specs"];
+
+    act(() => {
+      root.render(
+        <PlanDetailProvider value={page}>
+          <PlanDetailChangesBranch
+            selectedSpecId="spec-1"
+            onSelectedSpecIdChange={vi.fn()}
+          />
+        </PlanDetailProvider>
+      );
+    });
+    await flush();
+
+    expect(container.textContent).toContain("instance.default-role");
+    expect(container.textContent).toContain("bbsample");
+
+    await act(async () => {
+      (
+        [...container.querySelectorAll("button")].find(
+          (button) => button.textContent === "instance.default-role"
+        ) as HTMLButtonElement | undefined
+      )?.click();
+    });
+    await flush();
+
+    expect(container.textContent).toContain("spec-1::1");
+    expect(
+      new TextDecoder().decode(mocks.localSheets.get(sheetName)?.content)
+    ).toBe("SELECT 1;");
   });
 });

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -968,10 +968,15 @@ function OptionsSection({
                   disabled={!allowChange || isSheetOversize}
                   onValueChange={(value) => {
                     void persistStatement(
-                      updateRoleSetter(sheetStatement, value || undefined)
+                      updateRoleSetter(
+                        sheetStatement,
+                        value && value !== EMPTY_SELECT_VALUE
+                          ? value
+                          : undefined
+                      )
                     );
                   }}
-                  value={selectedRole}
+                  value={selectedRole || EMPTY_SELECT_VALUE}
                 >
                   <SelectTrigger className="w-44" size="sm">
                     <SelectValue>
@@ -981,6 +986,9 @@ function OptionsSection({
                     </SelectValue>
                   </SelectTrigger>
                   <SelectContent>
+                    <SelectItem value={EMPTY_SELECT_VALUE}>
+                      {t("instance.default-role")}
+                    </SelectItem>
                     {instanceRoleOptions.map((option) => (
                       <SelectItem key={option.value} value={option.value}>
                         {option.label}


### PR DESCRIPTION
## Summary
- Make the shared React select popup open as a conventional dropdown instead of overlapping the trigger.
- Add a default role option in plan change options so users can clear a selected PostgreSQL role.

## Key Changes
- Defaults `SelectContent` to start-aligned, non-overlapping Base UI positioning while preserving a typed positioner override.
- Adds localized `Default role` labels across React locales.
- Covers shared select positioning and role clearing behavior with focused tests.

## Motivation
- Fixes BYT-9474 where the role select popup visually overlaps the trigger and looks broken.
- Makes the role selector reversible by removing the generated `SET ROLE` directive when default role is selected.

## Testing
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend exec vitest run src/react/components/ui/select.test.tsx src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx`
- `pnpm --dir frontend test`
- `git diff --check`