### PR TITLE
fix(plan): stabilize default phase expansion

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/shared/stores/phaseSlice.ts
+++ b/frontend/src/react/pages/project/plan-detail/shared/stores/phaseSlice.ts
@@ -7,8 +7,21 @@ import type {
 const defaultActivePhases = (): Set<PlanDetailPhase> =>
   new Set(["changes", "review", "deploy"]);
 
+const isSamePhaseSet = (
+  a: Set<PlanDetailPhase>,
+  b: Set<PlanDetailPhase>
+): boolean => a.size === b.size && Array.from(a).every((phase) => b.has(phase));
+
 export const createPhaseSlice: PlanDetailSliceCreator<PhaseSlice> = (set) => ({
   activePhases: defaultActivePhases(),
+  setActivePhases: (phases) =>
+    set((state) => {
+      const next = new Set(phases);
+      if (isSamePhaseSet(state.activePhases, next)) {
+        return state;
+      }
+      return { activePhases: next };
+    }),
   togglePhase: (phase) =>
     set((state) => {
       const next = new Set(state.activePhases);
@@ -21,20 +34,6 @@ export const createPhaseSlice: PlanDetailSliceCreator<PhaseSlice> = (set) => ({
       if (state.activePhases.has(phase)) return state;
       const next = new Set(state.activePhases);
       next.add(phase);
-      return { activePhases: next };
-    }),
-  focusPhase: (phase) =>
-    set((state) => {
-      if (state.activePhases.size === 1 && state.activePhases.has(phase)) {
-        return state;
-      }
-      return { activePhases: new Set([phase]) };
-    }),
-  collapsePhase: (phase) =>
-    set((state) => {
-      if (!state.activePhases.has(phase)) return state;
-      const next = new Set(state.activePhases);
-      next.delete(phase);
       return { activePhases: next };
     }),
 });

--- a/frontend/src/react/pages/project/plan-detail/shared/stores/types.ts
+++ b/frontend/src/react/pages/project/plan-detail/shared/stores/types.ts
@@ -24,10 +24,9 @@ export type SnapshotSlice = {
 
 export type PhaseSlice = {
   activePhases: Set<PlanDetailPhase>;
+  setActivePhases: (phases: Iterable<PlanDetailPhase>) => void;
   togglePhase: (phase: PlanDetailPhase) => void;
   expandPhase: (phase: PlanDetailPhase) => void;
-  focusPhase: (phase: PlanDetailPhase) => void;
-  collapsePhase: (phase: PlanDetailPhase) => void;
 };
 
 export type EditingSlice = {

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePhaseState.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePhaseState.ts
@@ -4,10 +4,9 @@ import { usePlanDetailStore } from "../../shared/stores/usePlanDetailStore";
 
 export function usePhaseState() {
   const activePhases = usePlanDetailStore((s) => s.activePhases);
+  const setActivePhases = usePlanDetailStore((s) => s.setActivePhases);
   const togglePhase = usePlanDetailStore((s) => s.togglePhase);
   const expandPhase = usePlanDetailStore((s) => s.expandPhase);
-  const focusPhase = usePlanDetailStore((s) => s.focusPhase);
-  const collapsePhase = usePlanDetailStore((s) => s.collapsePhase);
 
   const isActive = useCallback(
     (phase: PlanDetailPhase) => activePhases.has(phase),
@@ -17,9 +16,8 @@ export function usePhaseState() {
   return {
     activePhases,
     isActive,
+    setActivePhases,
     togglePhase,
     expandPhase,
-    focusPhase,
-    collapsePhase,
   };
 }

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
@@ -228,6 +228,66 @@ describe("usePlanDetailPage", () => {
     expect(result.current.activePhases.has("deploy")).toBe(false);
   });
 
+  test("defaults to only the changes phase on the specs route for rollout plans", async () => {
+    mocks.fetchPlanSnapshot.mockResolvedValue(
+      buildSnapshotPatch({
+        planId: "plan-1",
+        rollout: {
+          name: "projects/foo/rollouts/1",
+          stages: [],
+        } as unknown as PlanDetailPageSnapshot["rollout"],
+      })
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId: "plan-1",
+          routeName: "project.plan.detail.specs",
+          pageHost: null,
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.activePhases.has("changes")).toBe(true);
+    expect(result.current.activePhases.has("review")).toBe(false);
+    expect(result.current.activePhases.has("deploy")).toBe(false);
+  });
+
+  test("keeps changes and review on the spec-detail route for reviewed rollout plans", async () => {
+    mocks.fetchPlanSnapshot.mockResolvedValue(
+      buildSnapshotPatch({
+        issue: {
+          name: "projects/foo/issues/1",
+        } as PlanDetailPageSnapshot["issue"],
+        planId: "plan-1",
+        rollout: {
+          name: "projects/foo/rollouts/1",
+          stages: [],
+        } as unknown as PlanDetailPageSnapshot["rollout"],
+      })
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId: "plan-1",
+          routeName: "project.plan.detail.spec.detail",
+          specId: "spec-1",
+          pageHost: null,
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.activePhases.has("changes")).toBe(true);
+    expect(result.current.activePhases.has("review")).toBe(true);
+    expect(result.current.activePhases.has("deploy")).toBe(false);
+  });
+
   test("has review default phases on the first ready render", async () => {
     mocks.fetchPlanSnapshot.mockResolvedValue(
       buildSnapshotPatch({
@@ -348,5 +408,44 @@ describe("usePlanDetailPage", () => {
     await waitFor(() => expect(result.current.planId).toBe("plan-2"));
     expect(result.current.pageKey).toBe("foo/plan-2");
     expect(mocks.fetchPlanSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  test("preserves a manual phase toggle across a poll refresh", async () => {
+    mocks.fetchPlanSnapshot.mockResolvedValue(
+      buildSnapshotPatch({
+        issue: {
+          name: "projects/foo/issues/1",
+        } as PlanDetailPageSnapshot["issue"],
+        planId: "plan-1",
+      })
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId: "plan-1",
+          pageHost: null,
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.activePhases.has("review")).toBe(true);
+
+    // User manually collapses the review section.
+    act(() => result.current.togglePhase("review"));
+    await waitFor(() =>
+      expect(result.current.activePhases.has("review")).toBe(false)
+    );
+
+    // A background poll re-fetches the same snapshot; the dedup guard must not
+    // re-expand the section the user just collapsed.
+    await act(async () => {
+      await result.current.refreshState();
+    });
+
+    expect(result.current.activePhases.has("review")).toBe(false);
+    expect(result.current.activePhases.has("changes")).toBe(true);
   });
 });

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
@@ -175,7 +175,7 @@ describe("usePlanDetailPage", () => {
     expect(result.current.activePhases.has("deploy")).toBe(true);
   });
 
-  test("defaults to only the review phase after an issue is created", async () => {
+  test("defaults to the changes and review phases after an issue is created", async () => {
     mocks.fetchPlanSnapshot.mockResolvedValue(
       buildSnapshotPatch({
         issue: {
@@ -196,9 +196,101 @@ describe("usePlanDetailPage", () => {
     );
 
     await waitFor(() => expect(result.current.ready).toBe(true));
-    expect(result.current.activePhases.has("changes")).toBe(false);
+    expect(result.current.activePhases.has("changes")).toBe(true);
     expect(result.current.activePhases.has("review")).toBe(true);
     expect(result.current.activePhases.has("deploy")).toBe(false);
+  });
+
+  test("keeps the review section visible for reviewed plans on the specs route", async () => {
+    mocks.fetchPlanSnapshot.mockResolvedValue(
+      buildSnapshotPatch({
+        issue: {
+          name: "projects/foo/issues/1",
+        } as PlanDetailPageSnapshot["issue"],
+        planId: "plan-1",
+      })
+    );
+
+    const { result } = renderHook(
+      () =>
+        usePlanDetailPage({
+          projectId: "foo",
+          planId: "plan-1",
+          routeName: "project.plan.detail.specs",
+          pageHost: null,
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(result.current.activePhases.has("changes")).toBe(true);
+    expect(result.current.activePhases.has("review")).toBe(true);
+    expect(result.current.activePhases.has("deploy")).toBe(false);
+  });
+
+  test("has review default phases on the first ready render", async () => {
+    mocks.fetchPlanSnapshot.mockResolvedValue(
+      buildSnapshotPatch({
+        issue: {
+          name: "projects/foo/issues/1",
+        } as PlanDetailPageSnapshot["issue"],
+        planId: "plan-1",
+      })
+    );
+    const readyRenders: Set<string>[] = [];
+
+    const { result } = renderHook(
+      () => {
+        const page = usePlanDetailPage({
+          projectId: "foo",
+          planId: "plan-1",
+          pageHost: null,
+        });
+        if (page.ready) {
+          readyRenders.push(new Set(page.activePhases));
+        }
+        return page;
+      },
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(readyRenders[0].has("changes")).toBe(true);
+    expect(readyRenders[0].has("review")).toBe(true);
+    expect(readyRenders[0].has("deploy")).toBe(false);
+  });
+
+  test("has deploy as the only phase on the first ready render for rollout plans", async () => {
+    mocks.fetchPlanSnapshot.mockResolvedValue(
+      buildSnapshotPatch({
+        planId: "plan-1",
+        rollout: {
+          name: "projects/foo/rollouts/1",
+          stages: [],
+        } as unknown as PlanDetailPageSnapshot["rollout"],
+      })
+    );
+    const readyRenders: Set<string>[] = [];
+
+    const { result } = renderHook(
+      () => {
+        const page = usePlanDetailPage({
+          projectId: "foo",
+          planId: "plan-1",
+          pageHost: null,
+        });
+        if (page.ready) {
+          readyRenders.push(new Set(page.activePhases));
+        }
+        return page;
+      },
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.ready).toBe(true));
+    expect(readyRenders[0].has("changes")).toBe(false);
+    expect(readyRenders[0].has("review")).toBe(false);
+    expect(readyRenders[0].has("deploy")).toBe(true);
   });
 
   test("does not refetch the page snapshot when only the route spec changes", async () => {

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
@@ -104,17 +104,22 @@ const getCurrentPhase = (
   if (routeStageId || routeTaskId) {
     return PLAN_DETAIL_PHASE_DEPLOY;
   }
+  // An explicit specs / spec-detail route always defaults to the spec section,
+  // even once the plan has a rollout, so shared/bookmarked spec links stay
+  // usable. A plan under review additionally expands the review section.
+  if (
+    routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS ||
+    routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL
+  ) {
+    return snapshot.issue
+      ? PLAN_DETAIL_PHASE_REVIEW
+      : PLAN_DETAIL_PHASE_CHANGES;
+  }
   if (snapshot.rollout) {
     return PLAN_DETAIL_PHASE_DEPLOY;
   }
   if (snapshot.issue) {
     return PLAN_DETAIL_PHASE_REVIEW;
-  }
-  if (
-    routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS ||
-    routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL
-  ) {
-    return PLAN_DETAIL_PHASE_CHANGES;
   }
   return PLAN_DETAIL_PHASE_CHANGES;
 };
@@ -195,10 +200,6 @@ export const usePlanDetailPage = ({
     },
     [pageIdentityKey, setActivePhases]
   );
-
-  useEffect(() => {
-    latestSnapshotRef.current = snapshot;
-  }, [snapshot]);
 
   const patchState = useCallback(
     (patch: Partial<PlanDetailPageSnapshot>) => {

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { router } from "@/router";
 import {
@@ -68,6 +75,50 @@ const applyDerivedState = (
   };
 };
 
+const getDefaultActivePhases = (phase: PlanDetailPhase): PlanDetailPhase[] => {
+  if (phase === PLAN_DETAIL_PHASE_REVIEW) {
+    return [PLAN_DETAIL_PHASE_CHANGES, PLAN_DETAIL_PHASE_REVIEW];
+  }
+  return [phase];
+};
+
+type PhaseSelection = {
+  routeName?: string;
+  routePhase?: PlanDetailPhase;
+  routeStageId?: string;
+  routeTaskId?: string;
+};
+
+const getCurrentPhase = (
+  snapshot: PlanDetailPageSnapshot,
+  selection: PhaseSelection
+): PlanDetailPhase => {
+  const { routeName, routePhase, routeStageId, routeTaskId } = selection;
+  if (
+    routePhase === PLAN_DETAIL_PHASE_CHANGES ||
+    routePhase === PLAN_DETAIL_PHASE_REVIEW ||
+    routePhase === PLAN_DETAIL_PHASE_DEPLOY
+  ) {
+    return routePhase;
+  }
+  if (routeStageId || routeTaskId) {
+    return PLAN_DETAIL_PHASE_DEPLOY;
+  }
+  if (snapshot.rollout) {
+    return PLAN_DETAIL_PHASE_DEPLOY;
+  }
+  if (snapshot.issue) {
+    return PLAN_DETAIL_PHASE_REVIEW;
+  }
+  if (
+    routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS ||
+    routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL
+  ) {
+    return PLAN_DETAIL_PHASE_CHANGES;
+  }
+  return PLAN_DETAIL_PHASE_CHANGES;
+};
+
 export const usePlanDetailPage = ({
   projectId,
   planId,
@@ -107,48 +158,60 @@ export const usePlanDetailPage = ({
   const routePhase = route.phase;
   const routeStageId = route.stageId;
   const routeTaskId = route.taskId;
-  const focusPhase = phase.focusPhase;
+  const setActivePhases = phase.setActivePhases;
   const pageIdentityKey = `${projectId}/${planId}`;
-  const currentPhase = useMemo<PlanDetailPhase>(() => {
-    if (
-      routePhase === PLAN_DETAIL_PHASE_CHANGES ||
-      routePhase === PLAN_DETAIL_PHASE_REVIEW ||
-      routePhase === PLAN_DETAIL_PHASE_DEPLOY
-    ) {
-      return routePhase;
-    }
-    if (routeStageId || routeTaskId) {
-      return PLAN_DETAIL_PHASE_DEPLOY;
-    }
-    if (
-      routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS ||
-      routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL
-    ) {
-      return PLAN_DETAIL_PHASE_CHANGES;
-    }
-    if (snapshot.rollout) {
-      return PLAN_DETAIL_PHASE_DEPLOY;
-    }
-    if (snapshot.issue) {
-      return PLAN_DETAIL_PHASE_REVIEW;
-    }
-    return PLAN_DETAIL_PHASE_CHANGES;
-  }, [
+  const phaseSelectionRef = useRef<PhaseSelection>({});
+  phaseSelectionRef.current = {
     routeName,
     routePhase,
     routeStageId,
     routeTaskId,
-    snapshot.issue,
-    snapshot.rollout,
-  ]);
+  };
+  const syncedDefaultPhaseRef = useRef<
+    | {
+        pageIdentityKey: string;
+        phase: PlanDetailPhase;
+      }
+    | undefined
+  >(undefined);
+  const syncDefaultActivePhases = useCallback(
+    (nextSnapshot: PlanDetailPageSnapshot) => {
+      const nextPhase = getCurrentPhase(
+        nextSnapshot,
+        phaseSelectionRef.current
+      );
+      const synced = syncedDefaultPhaseRef.current;
+      if (
+        synced?.pageIdentityKey === pageIdentityKey &&
+        synced.phase === nextPhase
+      ) {
+        return;
+      }
+      setActivePhases(getDefaultActivePhases(nextPhase));
+      syncedDefaultPhaseRef.current = {
+        pageIdentityKey,
+        phase: nextPhase,
+      };
+    },
+    [pageIdentityKey, setActivePhases]
+  );
 
   useEffect(() => {
     latestSnapshotRef.current = snapshot;
   }, [snapshot]);
 
-  const patchState = useCallback((patch: Partial<PlanDetailPageSnapshot>) => {
-    setSnapshot((prev) => applyDerivedState({ ...prev, ...patch }));
-  }, []);
+  const patchState = useCallback(
+    (patch: Partial<PlanDetailPageSnapshot>) => {
+      const nextSnapshot = applyDerivedState({
+        ...latestSnapshotRef.current,
+        ...patch,
+      });
+      syncDefaultActivePhases(nextSnapshot);
+      latestSnapshotRef.current = nextSnapshot;
+      setSnapshot(nextSnapshot);
+    },
+    [syncDefaultActivePhases]
+  );
 
   const refreshState = useCallback(async () => {
     try {
@@ -204,9 +267,16 @@ export const usePlanDetailPage = ({
     issue: snapshot.issue,
   });
 
-  useEffect(() => {
-    focusPhase(currentPhase);
-  }, [currentPhase, focusPhase, pageIdentityKey]);
+  useLayoutEffect(() => {
+    syncDefaultActivePhases(latestSnapshotRef.current);
+  }, [
+    pageIdentityKey,
+    routeName,
+    routePhase,
+    routeStageId,
+    routeTaskId,
+    syncDefaultActivePhases,
+  ]);
 
   const isPlanDone = useMemo(() => {
     if (!snapshot.rollout) {


### PR DESCRIPTION
## Summary
- Update plan detail default section expansion so review opens both changes and review sections.
- Keep deploy focused on the deploy section while preserving explicit route phase selection.
- Synchronize default phase state before the first ready render to avoid section flicker.

## Key Changes
- Replace single-phase focus state with explicit active phase sets.
- Derive default phases from route/query and loaded plan state in one helper.
- Add regression tests for review/spec route behavior and first-ready-render phase state.

## Motivation
- BYT-9586 reports inconsistent default collapse behavior after submitting plans for review.
- Reviewers need the change section visible during review, and the page should not briefly render the wrong collapsed state.

## Test Plan
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend exec vitest run src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx src/react/pages/project/plan-detail/shared/stores/__tests__/usePlanDetailStore.test.tsx
- pnpm --dir frontend test
- git diff --check