### PR TITLE
chore(ci): start github-runner VM before triggering oncall sync

### DIFF
--- a/.github/workflows/trigger-oncall-sync.yml
+++ b/.github/workflows/trigger-oncall-sync.yml
@@ -16,6 +16,24 @@ jobs:
   dispatch:
     runs-on: ubuntu-24.04
     steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Start github-runner VM if stopped
+        run: |
+          STATUS=$(gcloud compute instances describe github-runner \
+            --zone southamerica-east1-b --project bytebase-dev \
+            --format='value(status)')
+          if [ "$STATUS" != "RUNNING" ]; then
+            gcloud compute instances start github-runner \
+              --zone southamerica-east1-b --project bytebase-dev
+          fi
+
       - name: Trigger sync-oncall workflow on bytebase/oncall
         env:
           GH_TOKEN: ${{ secrets.GHA_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary
- The `github-runner` VM in `bytebase-dev` (zone `southamerica-east1-b`) can be stopped to save cost. Add a pre-step to the daily oncall-sync dispatch that wakes it via `gcloud` when its status isn't `RUNNING`.
- Reuses the existing `bb-hub@bytebase-saas-prod.iam.gserviceaccount.com` SA already wired up via `secrets.GCP_SERVICE_ACCOUNT_KEY` in `build-push-cloud-image.yml`. The SA has been granted `roles/compute.admin` on the target VM (cross-project).
- The dispatch job itself runs on a GitHub-hosted runner (`ubuntu-24.04`), so it does not depend on the self-hosted runner being up — it can be the thing that wakes it.

## Test plan
- [ ] Manually trigger the workflow via the Actions tab (`workflow_dispatch`) while the VM is RUNNING — the start step should describe and skip.
- [ ] Stop the VM, re-trigger, and confirm the step issues `gcloud compute instances start` successfully.
- [ ] Confirm the subsequent `gh workflow run sync-oncall.yml` step still dispatches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)