### PR TITLE
fix: parse multiline OceanBase explain plans

### DIFF
--- a/backend/plugin/db/mysql/stats.go
+++ b/backend/plugin/db/mysql/stats.go
@@ -76,6 +76,7 @@ func countAffectedRowsForOceanBase(ctx context.Context, sqlDB *sql.DB, dml strin
 		return 0, err
 	}
 	defer rows.Close()
+	var planString strings.Builder
 	for rows.Next() {
 		var planColumn sql.NullString
 		if err := rows.Scan(&planColumn); err != nil {
@@ -84,39 +85,47 @@ func countAffectedRowsForOceanBase(ctx context.Context, sqlDB *sql.DB, dml strin
 		if !planColumn.Valid {
 			continue
 		}
-		var planValue map[string]json.RawMessage
-		if err := json.Unmarshal([]byte(planColumn.String), &planValue); err != nil {
-			return 0, errors.Wrapf(err, "failed to parse query plan from string: %+v", planColumn.String)
-		}
-		if len(planValue) == 0 {
-			continue
-		}
-		queryPlan := oceanBaseQueryPlan{}
-		if err := queryPlan.Unmarshal(planValue); err != nil {
-			return 0, errors.Wrapf(err, "failed to parse query plan from map: %+v", planValue)
-		}
-		if queryPlan.Operator != "" {
-			return queryPlan.EstRows, nil
-		}
-		count := int64(-1)
-		for k, v := range planValue {
-			if !strings.HasPrefix(k, "CHILD_") {
-				continue
-			}
-			child := oceanBaseQueryPlan{}
-			if err := child.Unmarshal(v); err != nil {
-				return 0, errors.Wrapf(err, "failed to parse field '%s', value: %+v", k, v)
-			}
-			if child.Operator != "" && child.EstRows > count {
-				count = child.EstRows
-			}
-		}
-		if count >= 0 {
-			return count, nil
-		}
+		planString.WriteString(planColumn.String)
 	}
 	if err := rows.Err(); err != nil {
 		return 0, err
+	}
+	if planString.Len() == 0 {
+		return 0, nil
+	}
+	return getAffectedRowsFromOceanBaseQueryPlan(planString.String())
+}
+
+func getAffectedRowsFromOceanBaseQueryPlan(planString string) (int64, error) {
+	var planValue map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(planString), &planValue); err != nil {
+		return 0, errors.Wrapf(err, "failed to parse query plan from string: %+v", planString)
+	}
+	if len(planValue) == 0 {
+		return 0, nil
+	}
+	queryPlan := oceanBaseQueryPlan{}
+	if err := queryPlan.Unmarshal(planValue); err != nil {
+		return 0, errors.Wrapf(err, "failed to parse query plan from map: %+v", planValue)
+	}
+	if queryPlan.Operator != "" {
+		return queryPlan.EstRows, nil
+	}
+	count := int64(-1)
+	for k, v := range planValue {
+		if !strings.HasPrefix(k, "CHILD_") {
+			continue
+		}
+		child := oceanBaseQueryPlan{}
+		if err := child.Unmarshal(v); err != nil {
+			return 0, errors.Wrapf(err, "failed to parse field '%s', value: %+v", k, v)
+		}
+		if child.Operator != "" && child.EstRows > count {
+			count = child.EstRows
+		}
+	}
+	if count >= 0 {
+		return count, nil
 	}
 	return 0, nil
 }

--- a/backend/plugin/db/mysql/stats_test.go
+++ b/backend/plugin/db/mysql/stats_test.go
@@ -1,0 +1,91 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var testOceanBaseExplainRows [][]driver.Value
+
+func init() {
+	sql.Register("test_oceanbase_explain", testOceanBaseExplainDriver{})
+}
+
+type testOceanBaseExplainDriver struct{}
+
+func (testOceanBaseExplainDriver) Open(string) (driver.Conn, error) {
+	return testOceanBaseExplainConn{}, nil
+}
+
+type testOceanBaseExplainConn struct{}
+
+func (testOceanBaseExplainConn) Prepare(string) (driver.Stmt, error) {
+	return nil, driver.ErrSkip
+}
+
+func (testOceanBaseExplainConn) Close() error {
+	return nil
+}
+
+func (testOceanBaseExplainConn) Begin() (driver.Tx, error) {
+	return nil, driver.ErrSkip
+}
+
+func (testOceanBaseExplainConn) QueryContext(context.Context, string, []driver.NamedValue) (driver.Rows, error) {
+	return &testOceanBaseExplainResultRows{rows: testOceanBaseExplainRows}, nil
+}
+
+type testOceanBaseExplainResultRows struct {
+	rows [][]driver.Value
+	idx  int
+}
+
+func (*testOceanBaseExplainResultRows) Columns() []string {
+	return []string{"Query Plan"}
+}
+
+func (*testOceanBaseExplainResultRows) Close() error {
+	return nil
+}
+
+func (r *testOceanBaseExplainResultRows) Next(dest []driver.Value) error {
+	if r.idx >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.idx])
+	r.idx++
+	return nil
+}
+
+func TestCountAffectedRowsForOceanBaseConcatenatesExplainRows(t *testing.T) {
+	testOceanBaseExplainRows = [][]driver.Value{
+		{`{`},
+		{`  "ID":0,`},
+		{`  "OPERATOR":"UPDATE",`},
+		{`  "NAME":"",`},
+		{`  "EST.ROWS":1000,`},
+		{`  "EST.TIME(us)":7680,`},
+		{`  "output":"",`},
+		{`  "CHILD_1": {`},
+		{`    "ID":1,`},
+		{`    "OPERATOR":"TABLE RANGE SCAN",`},
+		{`    "NAME":"dba_test_1",`},
+		{`    "EST.ROWS":1000,`},
+		{`    "EST.TIME(us)":91,`},
+		{`    "output":"output([dba_test_1.id], [dba_test_1.log_id])"`},
+		{`  }`},
+		{`}`},
+	}
+	db, err := sql.Open("test_oceanbase_explain", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	got, err := countAffectedRowsForOceanBase(context.Background(), db, "update dba_test_1 set log_id=1 where id < 1000;")
+	require.NoError(t, err)
+	require.Equal(t, int64(1000), got)
+}


### PR DESCRIPTION
## Summary
- Concatenate all OceanBase `EXPLAIN FORMAT=JSON` rows before parsing the query plan.
- Preserve existing top-level and child-plan estimated row extraction behavior.
- Add a regression test for multi-row OceanBase explain output from the MySQL driver path.

## Test Plan
- [x] `go test -v -count=1 ./backend/plugin/db/mysql`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `golangci-lint run --fix --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Notes
- Verified manually with `oceanbase/oceanbase-ce:4.4.2.0-100000032026021017` that Go MySQL driver receives OceanBase JSON explain output split across multiple rows, and the fixed parser returns the estimated affected row count.
