### PR TITLE
chore: standardize watermark layering

### DIFF
--- a/frontend/scripts/check-react-layering.mjs
+++ b/frontend/scripts/check-react-layering.mjs
@@ -28,7 +28,6 @@ const APPROVED_PREFIXES = [
 
 const APPROVED_FILES = new Set([
   "src/react/components/auth/SessionExpiredSurface.tsx",
-  "src/react/components/Watermark.tsx",
 ]);
 
 const CLASS_ATTR_PATTERN = /\bclass(Name)?\s*=\s*/g;

--- a/frontend/src/react/components/Watermark.tsx
+++ b/frontend/src/react/components/Watermark.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from "react";
 import { useMemo } from "react";
+import { createPortal } from "react-dom";
 import {
   useCurrentUser,
   usePlanFeature,
@@ -9,6 +10,7 @@ import {
 import { extractUserEmail } from "@/store/modules/v1/common";
 import { UNKNOWN_USER_NAME } from "@/types";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
+import { getLayerRoot } from "./ui/layer";
 
 const USER_LAYER_CELL_W = 320;
 const USER_LAYER_CELL_H = 200;
@@ -107,14 +109,20 @@ export function Watermark() {
     [userLines]
   );
 
-  return (
+  if (
+    typeof document === "undefined" ||
+    (!versionDataURL && userDataURLs.length === 0)
+  ) {
+    return null;
+  }
+
+  return createPortal(
     <>
       {versionDataURL && (
         <div
           aria-hidden="true"
           style={{
             ...baseLayerStyle,
-            zIndex: 10000000,
             backgroundImage: `url(${versionDataURL})`,
             backgroundSize: `${VERSION_LAYER_CELL}px ${VERSION_LAYER_CELL}px`,
             backgroundPosition: "24px 80px",
@@ -130,7 +138,6 @@ export function Watermark() {
             aria-hidden="true"
             style={{
               ...baseLayerStyle,
-              zIndex: 10000001,
               backgroundImage: `url(${url})`,
               backgroundSize: `${USER_LAYER_CELL_W}px ${USER_LAYER_CELL_H}px`,
               backgroundPosition: `0px ${yOffset}px`,
@@ -138,6 +145,7 @@ export function Watermark() {
           />
         );
       })}
-    </>
+    </>,
+    getLayerRoot("watermark")
   );
 }

--- a/frontend/src/react/components/ui/dialog.test.tsx
+++ b/frontend/src/react/components/ui/dialog.test.tsx
@@ -112,4 +112,70 @@ describe("Dialog", () => {
       root.unmount();
     });
   });
+
+  test("keeps the agent layer visible when watermark content is mounted", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const agentRoot = getLayerRoot("agent");
+    const watermarkRoot = getLayerRoot("watermark");
+    const agentButton = document.createElement("button");
+    const watermarkLayer = document.createElement("div");
+
+    agentButton.textContent = "Agent action";
+    watermarkLayer.setAttribute("aria-hidden", "true");
+    agentRoot.appendChild(agentButton);
+    watermarkRoot.appendChild(watermarkLayer);
+
+    await act(async () => {
+      root.render(
+        <Dialog open>
+          <DialogContent>App dialog</DialogContent>
+        </Dialog>
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(agentRoot.getAttribute("aria-hidden")).toBeNull();
+      expect(agentRoot.getAttribute("inert")).toBeNull();
+      expect(agentRoot.getAttribute("data-base-ui-inert")).toBeNull();
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  test("keeps the critical layer visible when watermark content is mounted", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const criticalRoot = getLayerRoot("critical");
+    const watermarkRoot = getLayerRoot("watermark");
+    const criticalButton = document.createElement("button");
+    const watermarkLayer = document.createElement("div");
+
+    criticalButton.textContent = "Critical action";
+    watermarkLayer.setAttribute("aria-hidden", "true");
+    criticalRoot.appendChild(criticalButton);
+    watermarkRoot.appendChild(watermarkLayer);
+
+    await act(async () => {
+      root.render(
+        <Dialog open>
+          <DialogContent>App dialog</DialogContent>
+        </Dialog>
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(criticalRoot.getAttribute("aria-hidden")).toBeNull();
+      expect(criticalRoot.getAttribute("inert")).toBeNull();
+      expect(criticalRoot.getAttribute("data-base-ui-inert")).toBeNull();
+    });
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
 });

--- a/frontend/src/react/components/ui/layer.test.tsx
+++ b/frontend/src/react/components/ui/layer.test.tsx
@@ -8,26 +8,31 @@ describe("layer roots", () => {
 
   test("creates each layer root once with stable ordering", () => {
     const critical = getLayerRoot("critical");
+    const watermark = getLayerRoot("watermark");
     const overlay = getLayerRoot("overlay");
     const agent = getLayerRoot("agent");
 
     expect(overlay.id).toBe(LAYER_ROOT_ID.overlay);
     expect(agent.id).toBe(LAYER_ROOT_ID.agent);
     expect(critical.id).toBe(LAYER_ROOT_ID.critical);
+    expect(watermark.id).toBe(LAYER_ROOT_ID.watermark);
 
     expect(overlay.style.zIndex).toBe(String(LAYER_Z_INDEX.overlay));
     expect(agent.style.zIndex).toBe(String(LAYER_Z_INDEX.agent));
     expect(critical.style.zIndex).toBe(String(LAYER_Z_INDEX.critical));
+    expect(watermark.style.zIndex).toBe(String(LAYER_Z_INDEX.watermark));
 
     expect(document.body.children[0]?.id).toBe(LAYER_ROOT_ID.overlay);
     expect(document.body.children[1]?.id).toBe(LAYER_ROOT_ID.agent);
     expect(document.body.children[2]?.id).toBe(LAYER_ROOT_ID.critical);
+    expect(document.body.children[3]?.id).toBe(LAYER_ROOT_ID.watermark);
 
     expect(getLayerRoot("overlay")).toBe(overlay);
     expect(getLayerRoot("agent")).toBe(agent);
     expect(getLayerRoot("critical")).toBe(critical);
+    expect(getLayerRoot("watermark")).toBe(watermark);
 
-    expect(document.body.children).toHaveLength(3);
+    expect(document.body.children).toHaveLength(4);
     expect(document.querySelectorAll(`#${LAYER_ROOT_ID.overlay}`)).toHaveLength(
       1
     );
@@ -37,9 +42,16 @@ describe("layer roots", () => {
     expect(
       document.querySelectorAll(`#${LAYER_ROOT_ID.critical}`)
     ).toHaveLength(1);
+    expect(
+      document.querySelectorAll(`#${LAYER_ROOT_ID.watermark}`)
+    ).toHaveLength(1);
   });
 
   test("keeps the critical layer above the legacy Naive overlay stack", () => {
     expect(LAYER_Z_INDEX.critical).toBeGreaterThan(6000);
+  });
+
+  test("keeps the watermark above blocking app surfaces", () => {
+    expect(LAYER_Z_INDEX.watermark).toBeGreaterThan(LAYER_Z_INDEX.critical);
   });
 });

--- a/frontend/src/react/components/ui/layer.ts
+++ b/frontend/src/react/components/ui/layer.ts
@@ -4,17 +4,24 @@ export const LAYER_ROOT_ID = {
   overlay: "bb-react-layer-overlay",
   agent: "bb-react-layer-agent",
   critical: "bb-react-layer-critical",
+  watermark: "bb-react-layer-watermark",
 } as const;
 
 export const LAYER_Z_INDEX = {
   overlay: 2500,
   agent: 2600,
   critical: 7000,
+  watermark: 7100,
 } as const;
 
 export type LayerFamily = keyof typeof LAYER_ROOT_ID;
 
-const ORDERED_FAMILIES: LayerFamily[] = ["overlay", "agent", "critical"];
+const ORDERED_FAMILIES: LayerFamily[] = [
+  "overlay",
+  "agent",
+  "critical",
+  "watermark",
+];
 const LAYER_ACCESSIBLE_ATTRIBUTES = [
   "aria-hidden",
   "inert",
@@ -24,6 +31,7 @@ const HIGHER_LAYER_FAMILIES: Record<LayerFamily, LayerFamily[]> = {
   overlay: ["agent", "critical"],
   agent: ["critical"],
   critical: [],
+  watermark: [],
 };
 
 const getExistingLayerRoot = (family: LayerFamily) =>

--- a/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
@@ -1432,8 +1432,8 @@ function SelectTargetDatabasesView({
         {/* Left panel: target database list */}
         <div className="w-1/4 min-w-[256px] max-w-xs h-full border-r">
           <div className="w-full h-full relative flex flex-col justify-start items-start overflow-y-auto pb-2">
-            <div className="w-full h-auto flex flex-col justify-start items-start sticky top-0 z-[1]">
-              <div className="w-full bg-background border-b p-2 px-3 flex flex-row justify-between items-center sticky top-0 z-[1]">
+            <div className="w-full h-auto flex flex-col justify-start items-start sticky top-0 z-1">
+              <div className="w-full bg-background border-b p-2 px-3 flex flex-row justify-between items-center sticky top-0 z-1">
                 <span className="text-sm">
                   {t("database.sync-schema.target-databases")}
                 </span>

--- a/frontend/src/react/plugins/agent/components/AgentWindow.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentWindow.tsx
@@ -1182,7 +1182,7 @@ export function AgentWindow() {
               aria-hidden="true"
               data-agent-window-resize-zone={direction}
               className={cn(
-                "absolute z-[1] [touch-action:none]",
+                "absolute z-1 [touch-action:none]",
                 resizeZoneClasses[direction]
               )}
               onPointerDown={(event) => startResize(direction, event)}


### PR DESCRIPTION
## Summary
- Add a semantic watermark layer above critical app surfaces.
- Portal the watermark into the shared layer root instead of using raw inline z-index values.
- Remove the watermark scanner exception and normalize remaining local z-index tokens.

## Test Plan
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test
