### PR TITLE
fix: expose unspecified SQL type in approval rules

### DIFF
--- a/backend/runner/approval/runner_test.go
+++ b/backend/runner/approval/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/expr"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -175,6 +176,25 @@ func TestCalculateRiskLevelFromCELVars(t *testing.T) {
 			a.Equal(tt.want, got)
 		})
 	}
+}
+
+func TestApprovalTemplateMatchesUnspecifiedStatementSQLType(t *testing.T) {
+	a := require.New(t)
+
+	approvalTemplate, err := getApprovalTemplate(&storepb.WorkspaceApprovalSetting{
+		Rules: []*storepb.WorkspaceApprovalSetting_Rule{
+			{
+				Source:    storepb.WorkspaceApprovalSetting_Rule_CHANGE_DATABASE,
+				Condition: &expr.Expr{Expression: `statement.sql_type == "STATEMENT_TYPE_UNSPECIFIED"`},
+				Template:  &storepb.ApprovalTemplate{Title: "Unspecified SQL type rule"},
+			},
+		},
+	}, storepb.WorkspaceApprovalSetting_Rule_CHANGE_DATABASE, expandCELVars(map[string]any{
+		common.CELAttributeResourceProjectID: "project",
+	}, []storepb.StatementType{storepb.StatementType_STATEMENT_TYPE_UNSPECIFIED}, nil))
+	a.NoError(err)
+	a.NotNil(approvalTemplate)
+	a.Equal("Unspecified SQL type rule", approvalTemplate.Title)
 }
 
 func TestBuildStatementSummaryResultMapUsesSheetSHA256(t *testing.T) {

--- a/frontend/src/plugins/cel/types/values.test.ts
+++ b/frontend/src/plugins/cel/types/values.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import { SQLTypeList } from "./values";
+
+describe("SQLTypeList", () => {
+  it("puts the unspecified statement type last for approval CEL rules", () => {
+    expect(SQLTypeList.ALL.at(-1)).toBe("STATEMENT_TYPE_UNSPECIFIED");
+  });
+});

--- a/frontend/src/plugins/cel/types/values.ts
+++ b/frontend/src/plugins/cel/types/values.ts
@@ -1,5 +1,9 @@
 import { StatementType } from "@/types/proto-es/v1/common_pb";
 
+const OTHER_STATEMENT_TYPES = [
+  StatementType.STATEMENT_TYPE_UNSPECIFIED,
+] as const;
+
 // DDL statement types
 const DDL_STATEMENT_TYPES = [
   StatementType.CREATE_DATABASE,
@@ -55,6 +59,12 @@ const getStatementTypeName = (type: StatementType): string => {
 
 // Export lists with string names for backward compatibility with existing code
 export const SQLTypeList = {
+  OTHER: OTHER_STATEMENT_TYPES.map(getStatementTypeName),
   DDL: DDL_STATEMENT_TYPES.map(getStatementTypeName),
   DML: DML_STATEMENT_TYPES.map(getStatementTypeName),
+  ALL: [
+    ...DDL_STATEMENT_TYPES,
+    ...DML_STATEMENT_TYPES,
+    ...OTHER_STATEMENT_TYPES,
+  ].map(getStatementTypeName),
 } as const;

--- a/frontend/src/react/components/CustomApproval/utils.ts
+++ b/frontend/src/react/components/CustomApproval/utils.ts
@@ -205,7 +205,7 @@ const getSQLTypeOptions = (source: WorkspaceApprovalSetting_Rule_Source) => {
   };
   switch (source) {
     case WorkspaceApprovalSetting_Rule_Source.CHANGE_DATABASE:
-      return mapOptions([...SQLTypeList.DDL, ...SQLTypeList.DML]);
+      return mapOptions(SQLTypeList.ALL);
   }
   // unsupported source
   return [];


### PR DESCRIPTION

<img width="1390" height="718" alt="Microsoft Edge 2026-05-28 12 58 25" src="https://github.com/user-attachments/assets/300b3983-a06f-46f3-a53d-88d96803dcd0" />

## Summary
- Add STATEMENT_TYPE_UNSPECIFIED to the approval SQL type selector, ordered after DDL/DML types.
- Add frontend coverage for the selector ordering.
- Add backend coverage that approval CEL can match statement.sql_type == \"STATEMENT_TYPE_UNSPECIFIED\".

## Test Plan
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test
- go test -v -count=1 ./backend/runner/approval
- golangci-lint run --allow-parallel-runners
- go build -ldflags \"-w -s\" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go

## Pre-PR Checklist
- Breaking change check: no breaking API/proto/schema/config changes.
- Composite-PK query safety: skipped, no backend/store or backend/migrator changes.
- SonarCloud properties: existing frontend/src/**/*.test.ts test inclusion covers the new test file.