### PR TITLE
refactor(frontend): migrate resource stores to zustand

### DIFF
--- a/docs/superpowers/plans/2026-05-28-react-zustand-resource-phase-2.md
+++ b/docs/superpowers/plans/2026-05-28-react-zustand-resource-phase-2.md
@@ -1,0 +1,1887 @@
+# React Zustand Resource Store Migration Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move React consumers of User, Role, Release, Revision, Changelog, and ProjectWebhook protobuf resources from legacy Pinia stores to the React Zustand app store.
+
+**Architecture:** Add one focused app-store slice per resource under `frontend/src/react/stores/app/`, register them in `createAppStore`, expose typed actions/selectors in `types.ts`, and migrate React consumers to `useAppStore(selector)`. Keep legacy Pinia stores for Vue consumers, and add a guard test so React cannot re-import the migrated stores.
+
+**Tech Stack:** React, TypeScript, Zustand, Connect RPC generated clients, Vitest, Biome/ESLint.
+
+---
+
+## File Structure
+
+Create:
+
+- `frontend/src/react/stores/app/user.ts`: user cache, list/get/batch/mutation actions, identifier helpers.
+- `frontend/src/react/stores/app/role.ts`: role list cache and role mutation actions.
+- `frontend/src/react/stores/app/release.ts`: release cache, project list, get/update/delete/undelete actions.
+- `frontend/src/react/stores/app/revision.ts`: revision cache, database list/all/get/delete actions.
+- `frontend/src/react/stores/app/changelog.ts`: changelog cache keyed by name and view, database list cache, previous changelog lookup.
+- `frontend/src/react/stores/app/projectWebhook.ts`: project webhook helper and mutation actions.
+
+Modify:
+
+- `frontend/src/react/stores/app/types.ts`: add resource filter/params and slice types.
+- `frontend/src/react/stores/app/index.ts`: import and compose the new slices.
+- `frontend/src/react/stores/app/index.test.ts`: add client mocks and focused slice tests.
+- `frontend/src/react/hooks/useAppState.ts`: expose small hook facades for migrated resources.
+- `frontend/src/react/no-legacy-vue-deps.test.ts`: add the Phase 2 legacy-store guard.
+- React consumers currently importing `useUserStore`, `useRoleStore`, `useReleaseStore`, `useRevisionStore`, `useChangelogStore`, and `useProjectWebhookV1Store`.
+- Tests for touched consumers that mock the legacy stores.
+
+---
+
+### Task 1: Add User and Role App Store Slices
+
+**Files:**
+- Create: `frontend/src/react/stores/app/user.ts`
+- Create: `frontend/src/react/stores/app/role.ts`
+- Modify: `frontend/src/react/stores/app/types.ts`
+- Modify: `frontend/src/react/stores/app/index.ts`
+- Modify: `frontend/src/react/stores/app/index.test.ts`
+
+- [ ] **Step 1: Extend app-store types for User and Role**
+
+Add imports in `frontend/src/react/stores/app/types.ts` if they are not already present:
+
+```ts
+import type { UpdateUserRequest, User } from "@/types/proto-es/v1/user_service_pb";
+import type { Role } from "@/types/proto-es/v1/role_service_pb";
+```
+
+Add these types near the existing resource filter types:
+
+```ts
+export type UserFilter = {
+  query?: string;
+  project?: string;
+  state?: State;
+};
+
+export type ListUsersParams = {
+  pageSize: number;
+  pageToken?: string;
+  filter?: UserFilter;
+  showDeleted?: boolean;
+};
+```
+
+Add these slice types before `NotificationSlice`:
+
+```ts
+export type UserSlice = {
+  usersByName: Record<string, User>;
+  userRequests: Record<string, Promise<User | undefined>>;
+  listUsers: (
+    params: ListUsersParams
+  ) => Promise<{ users: User[]; nextPageToken: string }>;
+  fetchUser: (name: string, silent?: boolean) => Promise<User | undefined>;
+  batchGetOrFetchUsers: (names: string[]) => Promise<User[]>;
+  getOrFetchUserByIdentifier: (params: {
+    identifier: string;
+    silent?: boolean;
+    fallback?: boolean;
+  }) => Promise<User>;
+  getUserByIdentifier: (identifier: string) => User | undefined;
+  createUser: (user: User) => Promise<User>;
+  updateUser: (request: UpdateUserRequest) => Promise<User>;
+  updateEmail: (oldEmail: string, newEmail: string) => Promise<User>;
+  archiveUser: (name: string) => Promise<void>;
+  restoreUser: (name: string) => Promise<User>;
+};
+
+export type RoleSlice = {
+  roleList: Role[];
+  listRoles: () => Promise<Role[]>;
+  getRoleByName: (name: string) => Role | undefined;
+  upsertRole: (role: Role) => Promise<Role>;
+  deleteRole: (role: Role) => Promise<void>;
+};
+```
+
+Extend `AppStoreState`:
+
+```ts
+  AccessGrantSlice &
+  UserSlice &
+  RoleSlice &
+  NotificationSlice &
+```
+
+- [ ] **Step 2: Create the user slice**
+
+Create `frontend/src/react/stores/app/user.ts`:
+
+```ts
+import { create as createProto } from "@bufbuild/protobuf";
+import { createContextValues } from "@connectrpc/connect";
+import { uniq } from "lodash-es";
+import { userServiceClientConnect } from "@/connect";
+import { silentContextKey } from "@/connect/context-key";
+import {
+  allUsersUser,
+  isValidProjectName,
+  isValidUserName,
+  unknownUser,
+  userBindingPrefix,
+} from "@/types";
+import { State } from "@/types/proto-es/v1/common_pb";
+import {
+  BatchGetUsersRequestSchema,
+  CreateUserRequestSchema,
+  DeleteUserRequestSchema,
+  GetUserRequestSchema,
+  ListUsersRequestSchema,
+  UndeleteUserRequestSchema,
+  UpdateUserRequestSchema,
+  type User,
+} from "@/types/proto-es/v1/user_service_pb";
+import { ensureUserFullName } from "@/utils";
+import { isValidProjectName as isValidReactProjectName } from "@/react/lib/resourceName";
+import { type AppSliceCreator, type UserFilter, type UserSlice } from "./types";
+
+export const extractUserEmail = (identifier: string) => {
+  const matches = identifier.match(/^(?:user:|users\/)(.+)$/);
+  return matches?.[1] ?? identifier;
+};
+
+export const buildUserFilter = (params: UserFilter) => {
+  const filter: string[] = [];
+  const search = params.query?.trim()?.toLowerCase();
+  if (search) {
+    filter.push(`(name.contains("${search}") || email.contains("${search}"))`);
+  }
+  const project = params.project;
+  if (isValidProjectName(project) || isValidReactProjectName(project)) {
+    filter.push(`project == "${project}"`);
+  }
+  if (params.state === State.DELETED) {
+    filter.push(`state == "${State[params.state]}"`);
+  }
+  return filter.join(" && ");
+};
+
+const upsertUsers = (
+  set: Parameters<AppSliceCreator<UserSlice>>[0],
+  users: User[]
+) => {
+  set((state) => ({
+    usersByName: {
+      ...state.usersByName,
+      ...Object.fromEntries(users.map((user) => [user.name, user])),
+    },
+  }));
+};
+
+export const createUserSlice: AppSliceCreator<UserSlice> = (set, get) => ({
+  usersByName: { [allUsersUser().name]: allUsersUser() },
+  userRequests: {},
+
+  listUsers: async (params) => {
+    if (!get().hasWorkspacePermission("bb.users.list")) {
+      return { users: [], nextPageToken: "" };
+    }
+    const showDeleted =
+      params.showDeleted ?? params.filter?.state === State.DELETED;
+    const response = await userServiceClientConnect.listUsers(
+      createProto(ListUsersRequestSchema, {
+        pageSize: params.pageSize,
+        pageToken: params.pageToken,
+        filter: buildUserFilter(params.filter ?? {}),
+        showDeleted,
+      })
+    );
+    upsertUsers(set, response.users);
+    return { users: response.users, nextPageToken: response.nextPageToken };
+  },
+
+  fetchUser: async (name, silent = false) => {
+    const validName = ensureUserFullName(name);
+    const existing = get().usersByName[validName];
+    if (existing) return existing;
+    const pending = get().userRequests[validName];
+    if (pending) return pending;
+    const request = userServiceClientConnect
+      .getUser(createProto(GetUserRequestSchema, { name: validName }), {
+        contextValues: createContextValues().set(silentContextKey, silent),
+      })
+      .then((user) => {
+        set((state) => {
+          const { [validName]: _, ...userRequests } = state.userRequests;
+          return {
+            usersByName: { ...state.usersByName, [user.name]: user },
+            userRequests,
+          };
+        });
+        return user;
+      })
+      .catch(() => {
+        set((state) => {
+          const { [validName]: _, ...userRequests } = state.userRequests;
+          return { userRequests };
+        });
+        return undefined;
+      });
+    set((state) => ({
+      userRequests: { ...state.userRequests, [validName]: request },
+    }));
+    return request;
+  },
+
+  batchGetOrFetchUsers: async (names) => {
+    const validNames = uniq(names).filter(
+      (name) =>
+        Boolean(name) &&
+        (name.startsWith("users/") || name.startsWith(userBindingPrefix))
+    );
+    const missing = validNames
+      .map(ensureUserFullName)
+      .filter((name) => !get().usersByName[name]);
+    if (missing.length > 0) {
+      const response = await userServiceClientConnect.batchGetUsers(
+        createProto(BatchGetUsersRequestSchema, { names: missing }),
+        { contextValues: createContextValues().set(silentContextKey, true) }
+      );
+      upsertUsers(set, response.users);
+    }
+    return validNames.map((name) => get().getUserByIdentifier(name) ?? unknownUser(name));
+  },
+
+  getOrFetchUserByIdentifier: async ({
+    identifier,
+    silent = true,
+    fallback = true,
+  }) => {
+    const cached = get().getUserByIdentifier(identifier);
+    if (cached) return cached;
+    const fullname = ensureUserFullName(identifier);
+    if (!isValidUserName(fullname)) {
+      return unknownUser();
+    }
+    const user = await get().fetchUser(fullname, silent);
+    if (user) return user;
+    return unknownUser(fallback ? fullname : "");
+  },
+
+  getUserByIdentifier: (identifier) => {
+    const email = extractUserEmail(identifier);
+    if (Number.isNaN(Number(email))) {
+      return Object.values(get().usersByName).find((user) => user.email === email);
+    }
+    return get().usersByName[ensureUserFullName(identifier)];
+  },
+
+  createUser: async (user) => {
+    const response = await userServiceClientConnect.createUser(
+      createProto(CreateUserRequestSchema, { user })
+    );
+    upsertUsers(set, [response]);
+    return response;
+  },
+
+  updateUser: async (request) => {
+    const name = request.user?.name || "";
+    const origin = await get().getOrFetchUserByIdentifier({
+      identifier: name,
+      fallback: false,
+    });
+    if (!isValidUserName(origin.name)) {
+      throw new Error(`user with name ${name} not found`);
+    }
+    const response = await userServiceClientConnect.updateUser(
+      createProto(UpdateUserRequestSchema, {
+        user: request.user,
+        updateMask: request.updateMask,
+        otpCode: request.otpCode,
+        regenerateTempMfaSecret: request.regenerateTempMfaSecret,
+        regenerateRecoveryCodes: request.regenerateRecoveryCodes,
+      })
+    );
+    upsertUsers(set, [response]);
+    return response;
+  },
+
+  updateEmail: async (oldEmail, newEmail) => {
+    const origin = await get().getOrFetchUserByIdentifier({
+      identifier: oldEmail,
+      fallback: false,
+    });
+    if (!isValidUserName(origin.name)) {
+      throw new Error(`user with email ${oldEmail} not found`);
+    }
+    const response = await userServiceClientConnect.updateEmail({
+      name: `users/${oldEmail}`,
+      email: newEmail,
+    });
+    set((state) => {
+      const { [origin.name]: _, ...usersByName } = state.usersByName;
+      return { usersByName: { ...usersByName, [response.name]: response } };
+    });
+    return response;
+  },
+
+  archiveUser: async (name) => {
+    const validName = ensureUserFullName(name);
+    await userServiceClientConnect.deleteUser(
+      createProto(DeleteUserRequestSchema, { name: validName })
+    );
+    set((state) => {
+      const cached = state.usersByName[validName];
+      if (!cached) return {};
+      return {
+        usersByName: {
+          ...state.usersByName,
+          [validName]: { ...cached, state: State.DELETED },
+        },
+      };
+    });
+  },
+
+  restoreUser: async (name) => {
+    const response = await userServiceClientConnect.undeleteUser(
+      createProto(UndeleteUserRequestSchema, { name: ensureUserFullName(name) })
+    );
+    upsertUsers(set, [response]);
+    return response;
+  },
+});
+```
+
+- [ ] **Step 3: Create the role slice**
+
+Create `frontend/src/react/stores/app/role.ts`:
+
+```ts
+import { create as createProto } from "@bufbuild/protobuf";
+import { roleServiceClientConnect } from "@/connect";
+import type { Role } from "@/types/proto-es/v1/role_service_pb";
+import {
+  DeleteRoleRequestSchema,
+  ListRolesRequestSchema,
+  UpdateRoleRequestSchema,
+} from "@/types/proto-es/v1/role_service_pb";
+import type { AppSliceCreator, RoleSlice } from "./types";
+
+export const createRoleSlice: AppSliceCreator<RoleSlice> = (set, get) => ({
+  roleList: [],
+
+  listRoles: async () => {
+    const response = await roleServiceClientConnect.listRoles(
+      createProto(ListRolesRequestSchema, {})
+    );
+    set({ roleList: response.roles });
+    return response.roles;
+  },
+
+  getRoleByName: (name) => get().roleList.find((role) => role.name === name),
+
+  upsertRole: async (role) => {
+    const response = await roleServiceClientConnect.updateRole(
+      createProto(UpdateRoleRequestSchema, {
+        role,
+        updateMask: { paths: ["title", "description", "permissions"] },
+        allowMissing: true,
+      })
+    );
+    set((state) => {
+      const roleList = [...state.roleList];
+      const index = roleList.findIndex((item: Role) => item.name === response.name);
+      if (index >= 0) {
+        roleList.splice(index, 1, response);
+      } else {
+        roleList.push(response);
+      }
+      return { roleList };
+    });
+    return response;
+  },
+
+  deleteRole: async (role) => {
+    await roleServiceClientConnect.deleteRole(
+      createProto(DeleteRoleRequestSchema, { name: role.name })
+    );
+    set((state) => ({
+      roleList: state.roleList.filter((item) => item.name !== role.name),
+    }));
+  },
+});
+```
+
+- [ ] **Step 4: Register user and role slices**
+
+Modify `frontend/src/react/stores/app/index.ts`:
+
+```ts
+import { createRoleSlice } from "./role";
+import { createUserSlice } from "./user";
+```
+
+Add them before notification/preferences:
+
+```ts
+    ...createAccessGrantSlice(...args),
+    ...createUserSlice(...args),
+    ...createRoleSlice(...args),
+    ...createNotificationSlice(...args),
+```
+
+- [ ] **Step 5: Add focused app-store tests for User and Role**
+
+Modify `frontend/src/react/stores/app/index.test.ts` mocks:
+
+```ts
+  listUsers: vi.fn(),
+  getUser: vi.fn(),
+  batchGetUsers: vi.fn(),
+  createUser: vi.fn(),
+  updateUser: vi.fn(),
+  updateEmail: vi.fn(),
+  deleteUser: vi.fn(),
+  undeleteUser: vi.fn(),
+  updateRole: vi.fn(),
+  deleteRole: vi.fn(),
+```
+
+Extend the connect mock:
+
+```ts
+  roleServiceClientConnect: {
+    listRoles: mocks.listRoles,
+    updateRole: mocks.updateRole,
+    deleteRole: mocks.deleteRole,
+  },
+  userServiceClientConnect: {
+    getCurrentUser: mocks.getCurrentUser,
+    listUsers: mocks.listUsers,
+    getUser: mocks.getUser,
+    batchGetUsers: mocks.batchGetUsers,
+    createUser: mocks.createUser,
+    updateUser: mocks.updateUser,
+    updateEmail: mocks.updateEmail,
+    deleteUser: mocks.deleteUser,
+    undeleteUser: mocks.undeleteUser,
+  },
+```
+
+Add tests:
+
+```ts
+test("lists and caches users", async () => {
+  const store = createAppStore();
+  mocks.listUsers.mockResolvedValue({ users: [user], nextPageToken: "next" });
+  const result = await store.getState().listUsers({ pageSize: 10 });
+  expect(result).toEqual({ users: [user], nextPageToken: "next" });
+  expect(store.getState().getUserByIdentifier(user.name)).toEqual(user);
+});
+
+test("batch fetches missing users and returns unknown fallback", async () => {
+  const store = createAppStore();
+  mocks.batchGetUsers.mockResolvedValue({ users: [user] });
+  const result = await store
+    .getState()
+    .batchGetOrFetchUsers([user.name, "users/missing@example.com"]);
+  expect(result[0]).toEqual(user);
+  expect(result[1].name).toBe("users/missing@example.com");
+});
+
+test("updates user email and removes old cache key", async () => {
+  const store = createAppStore();
+  mocks.getUser.mockResolvedValue(user);
+  const updated = createProto(UserSchema, {
+    ...user,
+    name: "users/new@example.com",
+    email: "new@example.com",
+  });
+  mocks.updateEmail.mockResolvedValue(updated);
+  await store.getState().fetchUser(user.name);
+  await store.getState().updateEmail(user.email, updated.email);
+  expect(store.getState().usersByName[user.name]).toBeUndefined();
+  expect(store.getState().usersByName[updated.name]).toEqual(updated);
+});
+
+test("lists, upserts, and deletes roles", async () => {
+  const store = createAppStore();
+  const role = createProto(RoleSchema, {
+    name: "roles/PROJECT_OWNER",
+    title: "Project Owner",
+  });
+  mocks.listRoles.mockResolvedValue({ roles: [role] });
+  await store.getState().listRoles();
+  expect(store.getState().getRoleByName(role.name)).toEqual(role);
+  const updated = createProto(RoleSchema, { ...role, title: "Owner" });
+  mocks.updateRole.mockResolvedValue(updated);
+  await store.getState().upsertRole(updated);
+  expect(store.getState().getRoleByName(role.name)?.title).toBe("Owner");
+  mocks.deleteRole.mockResolvedValue({});
+  await store.getState().deleteRole(updated);
+  expect(store.getState().getRoleByName(role.name)).toBeUndefined();
+});
+```
+
+- [ ] **Step 6: Run focused app-store tests**
+
+Run:
+
+```bash
+pnpm --dir frontend exec vitest run src/react/stores/app/index.test.ts
+```
+
+Expected: tests compile and pass. If `User` fallback typing fails, apply the fallback correction from Step 2 and rerun.
+
+- [ ] **Step 7: Commit user and role slices**
+
+```bash
+git add frontend/src/react/stores/app/user.ts frontend/src/react/stores/app/role.ts frontend/src/react/stores/app/types.ts frontend/src/react/stores/app/index.ts frontend/src/react/stores/app/index.test.ts
+git commit -m "feat(frontend): add user and role app stores"
+```
+
+---
+
+### Task 2: Add Release, Revision, Changelog, and ProjectWebhook Slices
+
+**Files:**
+- Create: `frontend/src/react/stores/app/release.ts`
+- Create: `frontend/src/react/stores/app/revision.ts`
+- Create: `frontend/src/react/stores/app/changelog.ts`
+- Create: `frontend/src/react/stores/app/projectWebhook.ts`
+- Modify: `frontend/src/react/stores/app/types.ts`
+- Modify: `frontend/src/react/stores/app/index.ts`
+- Modify: `frontend/src/react/stores/app/index.test.ts`
+
+- [ ] **Step 1: Extend app-store types for the four smaller resources**
+
+Add imports to `types.ts`:
+
+```ts
+import type {
+  Changelog,
+  ChangelogView,
+  ListChangelogsRequest,
+  GetChangelogRequest,
+} from "@/types/proto-es/v1/database_service_pb";
+import type { Release } from "@/types/proto-es/v1/release_service_pb";
+import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
+import type { Webhook } from "@/types/proto-es/v1/project_service_pb";
+```
+
+Add these slice types before `NotificationSlice`:
+
+```ts
+export type ReleaseSlice = {
+  releasesByName: Record<string, Release>;
+  releaseRequests: Record<string, Promise<Release | undefined>>;
+  listReleasesByProject: (
+    project: string,
+    pagination?: { pageSize?: number; pageToken?: string },
+    showDeleted?: boolean,
+    filter?: string
+  ) => Promise<{ releases: Release[]; nextPageToken: string }>;
+  fetchRelease: (name: string, silent?: boolean) => Promise<Release | undefined>;
+  getReleasesByProject: (project: string) => Release[];
+  getReleaseByName: (name: string) => Release;
+  updateRelease: (
+    release: Partial<Release>,
+    updateMask: string[]
+  ) => Promise<Release>;
+  deleteRelease: (name: string) => Promise<void>;
+  undeleteRelease: (name: string) => Promise<Release>;
+};
+
+export type RevisionSlice = {
+  revisionsByName: Record<string, Revision>;
+  listRevisionsByDatabase: (
+    database: string,
+    pagination?: { pageSize?: number; pageToken?: string }
+  ) => Promise<{ revisions: Revision[]; nextPageToken: string }>;
+  listAllRevisionsByDatabase: (
+    database: string,
+    pagination?: { pageSize?: number }
+  ) => Promise<Revision[]>;
+  fetchRevision: (name: string) => Promise<Revision | undefined>;
+  getRevisionsByDatabase: (database: string) => Revision[];
+  getRevisionByName: (name: string) => Revision | undefined;
+  deleteRevision: (name: string) => Promise<void>;
+};
+
+export type ChangelogSlice = {
+  changelogsByCacheKey: Record<string, Changelog>;
+  changelogsByDatabase: Record<string, Changelog[]>;
+  changelogRequests: Record<string, Promise<Changelog | undefined>>;
+  clearChangelogCache: (parent: string) => void;
+  listChangelogs: (
+    params: Partial<ListChangelogsRequest>
+  ) => Promise<{ changelogs: Changelog[]; nextPageToken: string }>;
+  getOrFetchChangelogListOfDatabase: (
+    database: string,
+    pageSize: number,
+    view?: ChangelogView
+  ) => Promise<Changelog[]>;
+  changelogListByDatabase: (database: string) => Changelog[];
+  fetchChangelog: (
+    params: Partial<GetChangelogRequest>
+  ) => Promise<Changelog | undefined>;
+  getOrFetchChangelogByName: (
+    name: string,
+    view?: ChangelogView
+  ) => Promise<Changelog | undefined>;
+  getChangelogByName: (
+    name: string,
+    view?: ChangelogView
+  ) => Changelog | undefined;
+  fetchPreviousChangelog: (name: string) => Promise<Changelog | undefined>;
+};
+
+export type ProjectWebhookSlice = {
+  getProjectWebhookFromProjectById: (
+    project: Project,
+    webhookId: string
+  ) => Webhook | undefined;
+  createProjectWebhook: (project: string, webhook: Webhook) => Promise<Project>;
+  updateProjectWebhook: (
+    webhook: Webhook,
+    updateMask: string[]
+  ) => Promise<Project>;
+  deleteProjectWebhook: (webhook: Webhook) => Promise<Project>;
+  testProjectWebhook: (
+    project: Project,
+    webhook: Webhook
+  ) => Promise<{ error: string }>;
+};
+```
+
+Extend `AppStoreState`:
+
+```ts
+  UserSlice &
+  RoleSlice &
+  ReleaseSlice &
+  RevisionSlice &
+  ChangelogSlice &
+  ProjectWebhookSlice &
+  NotificationSlice &
+```
+
+- [ ] **Step 2: Create release slice**
+
+Create `frontend/src/react/stores/app/release.ts`:
+
+```ts
+import { create as createProto } from "@bufbuild/protobuf";
+import { createContextValues } from "@connectrpc/connect";
+import { releaseServiceClientConnect } from "@/connect";
+import { silentContextKey } from "@/connect/context-key";
+import { isValidReleaseName, unknownRelease } from "@/types";
+import { State } from "@/types/proto-es/v1/common_pb";
+import type { Release } from "@/types/proto-es/v1/release_service_pb";
+import {
+  DeleteReleaseRequestSchema,
+  GetReleaseRequestSchema,
+  ListReleasesRequestSchema,
+  ReleaseSchema,
+  UndeleteReleaseRequestSchema,
+  UpdateReleaseRequestSchema,
+} from "@/types/proto-es/v1/release_service_pb";
+import type { AppSliceCreator, ReleaseSlice } from "./types";
+
+const upsertReleases = (
+  set: Parameters<AppSliceCreator<ReleaseSlice>>[0],
+  releases: Release[]
+) => {
+  set((state) => ({
+    releasesByName: {
+      ...state.releasesByName,
+      ...Object.fromEntries(releases.map((release) => [release.name, release])),
+    },
+  }));
+};
+
+export const createReleaseSlice: AppSliceCreator<ReleaseSlice> = (set, get) => ({
+  releasesByName: {},
+  releaseRequests: {},
+
+  listReleasesByProject: async (project, pagination, showDeleted, filter) => {
+    const response = await releaseServiceClientConnect.listReleases(
+      createProto(ListReleasesRequestSchema, {
+        parent: project,
+        pageSize: pagination?.pageSize,
+        pageToken: pagination?.pageToken || "",
+        showDeleted: Boolean(showDeleted),
+        filter: filter || "",
+      })
+    );
+    upsertReleases(set, response.releases);
+    return { releases: response.releases, nextPageToken: response.nextPageToken };
+  },
+
+  fetchRelease: async (name, silent = false) => {
+    if (!isValidReleaseName(name)) return undefined;
+    const existing = get().releasesByName[name];
+    if (existing) return existing;
+    const pending = get().releaseRequests[name];
+    if (pending) return pending;
+    const request = releaseServiceClientConnect
+      .getRelease(createProto(GetReleaseRequestSchema, { name }), {
+        contextValues: createContextValues().set(silentContextKey, silent),
+      })
+      .then((release) => {
+        set((state) => {
+          const { [name]: _, ...releaseRequests } = state.releaseRequests;
+          return {
+            releasesByName: { ...state.releasesByName, [release.name]: release },
+            releaseRequests,
+          };
+        });
+        return release;
+      })
+      .catch(() => undefined);
+    set((state) => ({
+      releaseRequests: { ...state.releaseRequests, [name]: request },
+    }));
+    return request;
+  },
+
+  getReleasesByProject: (project) =>
+    Object.values(get().releasesByName).filter((release) =>
+      release.name.startsWith(`${project}/releases/`)
+    ),
+
+  getReleaseByName: (name) => get().releasesByName[name] ?? unknownRelease(),
+
+  updateRelease: async (release, updateMask) => {
+    const response = await releaseServiceClientConnect.updateRelease(
+      createProto(UpdateReleaseRequestSchema, {
+        release: { ...createProto(ReleaseSchema, {}), ...release },
+        updateMask: { paths: updateMask },
+      })
+    );
+    upsertReleases(set, [response]);
+    return response;
+  },
+
+  deleteRelease: async (name) => {
+    await releaseServiceClientConnect.deleteRelease(
+      createProto(DeleteReleaseRequestSchema, { name })
+    );
+    set((state) => {
+      const cached = state.releasesByName[name];
+      if (!cached) return {};
+      return {
+        releasesByName: {
+          ...state.releasesByName,
+          [name]: { ...cached, state: State.DELETED },
+        },
+      };
+    });
+  },
+
+  undeleteRelease: async (name) => {
+    const response = await releaseServiceClientConnect.undeleteRelease(
+      createProto(UndeleteReleaseRequestSchema, { name })
+    );
+    upsertReleases(set, [response]);
+    return response;
+  },
+});
+```
+
+- [ ] **Step 3: Create revision slice**
+
+Create `frontend/src/react/stores/app/revision.ts`:
+
+```ts
+import { create as createProto } from "@bufbuild/protobuf";
+import { revisionServiceClientConnect } from "@/connect";
+import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
+import {
+  DeleteRevisionRequestSchema,
+  GetRevisionRequestSchema,
+  ListRevisionsRequestSchema,
+} from "@/types/proto-es/v1/revision_service_pb";
+import { revisionNamePrefix } from "@/store/modules/v1/common";
+import type { AppSliceCreator, RevisionSlice } from "./types";
+
+const upsertRevisions = (
+  set: Parameters<AppSliceCreator<RevisionSlice>>[0],
+  revisions: Revision[]
+) => {
+  set((state) => ({
+    revisionsByName: {
+      ...state.revisionsByName,
+      ...Object.fromEntries(revisions.map((revision) => [revision.name, revision])),
+    },
+  }));
+};
+
+export const createRevisionSlice: AppSliceCreator<RevisionSlice> = (set, get) => ({
+  revisionsByName: {},
+
+  listRevisionsByDatabase: async (database, pagination) => {
+    const response = await revisionServiceClientConnect.listRevisions(
+      createProto(ListRevisionsRequestSchema, {
+        parent: database,
+        pageSize: pagination?.pageSize,
+        pageToken: pagination?.pageToken,
+      })
+    );
+    upsertRevisions(set, response.revisions);
+    return { revisions: response.revisions, nextPageToken: response.nextPageToken };
+  },
+
+  listAllRevisionsByDatabase: async (database, pagination) => {
+    const revisions: Revision[] = [];
+    let pageToken = "";
+    do {
+      const response = await get().listRevisionsByDatabase(database, {
+        pageSize: pagination?.pageSize,
+        pageToken,
+      });
+      revisions.push(...response.revisions);
+      pageToken = response.nextPageToken;
+    } while (pageToken);
+    return revisions;
+  },
+
+  fetchRevision: async (name) => {
+    const existing = get().revisionsByName[name];
+    if (existing) return existing;
+    const revision = await revisionServiceClientConnect.getRevision(
+      createProto(GetRevisionRequestSchema, { name })
+    );
+    upsertRevisions(set, [revision]);
+    return revision;
+  },
+
+  getRevisionsByDatabase: (database) =>
+    Object.values(get().revisionsByName).filter((revision) =>
+      revision.name.startsWith(`${database}/${revisionNamePrefix}`)
+    ),
+
+  getRevisionByName: (name) => get().revisionsByName[name],
+
+  deleteRevision: async (name) => {
+    await revisionServiceClientConnect.deleteRevision(
+      createProto(DeleteRevisionRequestSchema, { name })
+    );
+    set((state) => {
+      const { [name]: _, ...revisionsByName } = state.revisionsByName;
+      return { revisionsByName };
+    });
+  },
+});
+```
+
+- [ ] **Step 4: Create changelog slice**
+
+Create `frontend/src/react/stores/app/changelog.ts`:
+
+```ts
+import { create as createProto } from "@bufbuild/protobuf";
+import { databaseServiceClientConnect } from "@/connect";
+import { UNKNOWN_ID } from "@/types";
+import {
+  ChangelogView,
+  GetChangelogRequestSchema,
+  ListChangelogsRequestSchema,
+  type Changelog,
+} from "@/types/proto-es/v1/database_service_pb";
+import { extractChangelogUID } from "@/utils/v1/changelog";
+import type { AppSliceCreator, ChangelogSlice } from "./types";
+
+const cacheKey = (name: string, view: ChangelogView) => `${name}\u0000${view}`;
+
+const upsertChangelogs = (
+  set: Parameters<AppSliceCreator<ChangelogSlice>>[0],
+  changelogs: Changelog[],
+  view: ChangelogView
+) => {
+  set((state) => ({
+    changelogsByCacheKey: {
+      ...state.changelogsByCacheKey,
+      ...Object.fromEntries(
+        changelogs.map((changelog) => [cacheKey(changelog.name, view), changelog])
+      ),
+    },
+  }));
+};
+
+export const createChangelogSlice: AppSliceCreator<ChangelogSlice> = (
+  set,
+  get
+) => ({
+  changelogsByCacheKey: {},
+  changelogsByDatabase: {},
+  changelogRequests: {},
+
+  clearChangelogCache: (parent) => {
+    set((state) => {
+      const { [parent]: _, ...changelogsByDatabase } = state.changelogsByDatabase;
+      return { changelogsByDatabase };
+    });
+  },
+
+  listChangelogs: async (params) => {
+    const parent = params.parent;
+    if (!parent) throw new Error('"parent" field is required');
+    const view = params.view ?? ChangelogView.BASIC;
+    const response = await databaseServiceClientConnect.listChangelogs(
+      createProto(ListChangelogsRequestSchema, {
+        parent,
+        pageSize: params.pageSize,
+        pageToken: params.pageToken,
+        view,
+        filter: params.filter,
+      })
+    );
+    set((state) => ({
+      changelogsByDatabase: {
+        ...state.changelogsByDatabase,
+        [parent]: response.changelogs,
+      },
+    }));
+    upsertChangelogs(set, response.changelogs, view);
+    return { changelogs: response.changelogs, nextPageToken: response.nextPageToken };
+  },
+
+  getOrFetchChangelogListOfDatabase: async (
+    database,
+    pageSize,
+    view = ChangelogView.BASIC
+  ) => {
+    const existing = get().changelogsByDatabase[database];
+    if (existing) return existing;
+    const { changelogs } = await get().listChangelogs({
+      parent: database,
+      pageSize,
+      view,
+    });
+    return changelogs;
+  },
+
+  changelogListByDatabase: (database) => get().changelogsByDatabase[database] ?? [],
+
+  fetchChangelog: async (params) => {
+    if (!params.name) return undefined;
+    const view = params.view ?? ChangelogView.BASIC;
+    const changelog = await databaseServiceClientConnect.getChangelog(
+      createProto(GetChangelogRequestSchema, {
+        name: params.name,
+        view,
+      })
+    );
+    upsertChangelogs(set, [changelog], view);
+    return changelog;
+  },
+
+  getOrFetchChangelogByName: async (name, view = ChangelogView.BASIC) => {
+    const uid = extractChangelogUID(name);
+    if (!uid || uid === String(UNKNOWN_ID)) return undefined;
+    const existing = get().changelogsByCacheKey[cacheKey(name, view)];
+    if (existing) return existing;
+    const requestKey = cacheKey(name, view);
+    const pending = get().changelogRequests[requestKey];
+    if (pending) return pending;
+    const request = get().fetchChangelog({ name, view });
+    set((state) => ({
+      changelogRequests: { ...state.changelogRequests, [requestKey]: request },
+    }));
+    return request;
+  },
+
+  getChangelogByName: (name, view) => {
+    if (view !== undefined) return get().changelogsByCacheKey[cacheKey(name, view)];
+    return (
+      get().changelogsByCacheKey[cacheKey(name, ChangelogView.FULL)] ??
+      get().changelogsByCacheKey[cacheKey(name, ChangelogView.BASIC)]
+    );
+  },
+
+  fetchPreviousChangelog: async (name) => {
+    const parts = name.split("/changelogs/");
+    if (parts.length !== 2) return undefined;
+    const database = parts[0];
+    const currentUID = extractChangelogUID(name);
+    if (!currentUID || currentUID === String(UNKNOWN_ID)) return undefined;
+    const { changelogs } = await get().listChangelogs({
+      parent: database,
+      pageSize: 1000,
+      view: ChangelogView.BASIC,
+    });
+    const index = changelogs.findIndex(
+      (changelog) => extractChangelogUID(changelog.name) === currentUID
+    );
+    if (index === -1 || index === changelogs.length - 1) return undefined;
+    return get().getOrFetchChangelogByName(
+      changelogs[index + 1].name,
+      ChangelogView.FULL
+    );
+  },
+});
+```
+
+- [ ] **Step 5: Create project webhook slice**
+
+Create `frontend/src/react/stores/app/projectWebhook.ts`:
+
+```ts
+import { create as createProto } from "@bufbuild/protobuf";
+import { projectServiceClientConnect } from "@/connect";
+import {
+  AddWebhookRequestSchema,
+  RemoveWebhookRequestSchema,
+  TestWebhookRequestSchema,
+  UpdateWebhookRequestSchema,
+  type Project,
+  type Webhook,
+} from "@/types/proto-es/v1/project_service_pb";
+import { extractProjectWebhookID } from "@/utils";
+import type { AppSliceCreator, ProjectWebhookSlice } from "./types";
+
+export const createProjectWebhookSlice: AppSliceCreator<ProjectWebhookSlice> = (
+  _set,
+  _get
+) => ({
+  getProjectWebhookFromProjectById: (project: Project, webhookId: string) =>
+    project.webhooks.find(
+      (webhook: Webhook) => extractProjectWebhookID(webhook.name) === webhookId
+    ),
+
+  createProjectWebhook: async (project, webhook) =>
+    projectServiceClientConnect.addWebhook(
+      createProto(AddWebhookRequestSchema, { project, webhook })
+    ),
+
+  updateProjectWebhook: async (webhook, updateMask) =>
+    projectServiceClientConnect.updateWebhook(
+      createProto(UpdateWebhookRequestSchema, {
+        webhook,
+        updateMask: { paths: updateMask },
+      })
+    ),
+
+  deleteProjectWebhook: async (webhook) =>
+    projectServiceClientConnect.removeWebhook(
+      createProto(RemoveWebhookRequestSchema, { webhook })
+    ),
+
+  testProjectWebhook: async (project, webhook) => {
+    const response = await projectServiceClientConnect.testWebhook(
+      createProto(TestWebhookRequestSchema, {
+        project: project.name,
+        webhook,
+      })
+    );
+    return { error: response.error };
+  },
+});
+```
+
+- [ ] **Step 6: Register the four smaller slices**
+
+Modify `frontend/src/react/stores/app/index.ts`:
+
+```ts
+import { createChangelogSlice } from "./changelog";
+import { createProjectWebhookSlice } from "./projectWebhook";
+import { createReleaseSlice } from "./release";
+import { createRevisionSlice } from "./revision";
+```
+
+Add them after role:
+
+```ts
+    ...createRoleSlice(...args),
+    ...createReleaseSlice(...args),
+    ...createRevisionSlice(...args),
+    ...createChangelogSlice(...args),
+    ...createProjectWebhookSlice(...args),
+    ...createNotificationSlice(...args),
+```
+
+- [ ] **Step 7: Add app-store tests for the four smaller slices**
+
+Extend `index.test.ts` mocks and connect clients for:
+
+```ts
+  listReleases: vi.fn(),
+  getRelease: vi.fn(),
+  updateRelease: vi.fn(),
+  deleteRelease: vi.fn(),
+  undeleteRelease: vi.fn(),
+  listRevisions: vi.fn(),
+  getRevision: vi.fn(),
+  deleteRevision: vi.fn(),
+  listChangelogs: vi.fn(),
+  getChangelog: vi.fn(),
+  addWebhook: vi.fn(),
+  updateWebhook: vi.fn(),
+  removeWebhook: vi.fn(),
+  testWebhook: vi.fn(),
+```
+
+Add tests:
+
+```ts
+test("lists and mutates releases", async () => {
+  const store = createAppStore();
+  const release = createProto(ReleaseSchema, {
+    name: "projects/a/releases/r1",
+    title: "R1",
+    state: State.ACTIVE,
+  });
+  mocks.listReleases.mockResolvedValue({ releases: [release], nextPageToken: "" });
+  await store.getState().listReleasesByProject("projects/a");
+  expect(store.getState().getReleaseByName(release.name)).toEqual(release);
+  mocks.deleteRelease.mockResolvedValue({});
+  await store.getState().deleteRelease(release.name);
+  expect(store.getState().getReleaseByName(release.name).state).toBe(State.DELETED);
+});
+
+test("lists all revisions by database", async () => {
+  const store = createAppStore();
+  const revision = createProto(RevisionSchema, {
+    name: "instances/i/databases/d/revisions/1",
+  });
+  mocks.listRevisions.mockResolvedValueOnce({
+    revisions: [revision],
+    nextPageToken: "",
+  });
+  const revisions = await store
+    .getState()
+    .listAllRevisionsByDatabase("instances/i/databases/d");
+  expect(revisions).toEqual([revision]);
+  expect(store.getState().getRevisionByName(revision.name)).toEqual(revision);
+});
+
+test("caches changelogs by database and view", async () => {
+  const store = createAppStore();
+  const changelog = createProto(ChangelogSchema, {
+    name: "instances/i/databases/d/changelogs/1",
+  });
+  mocks.listChangelogs.mockResolvedValue({
+    changelogs: [changelog],
+    nextPageToken: "",
+  });
+  await store.getState().getOrFetchChangelogListOfDatabase(
+    "instances/i/databases/d",
+    100
+  );
+  expect(
+    store.getState().getChangelogByName(changelog.name, ChangelogView.BASIC)
+  ).toEqual(changelog);
+});
+
+test("runs project webhook operations", async () => {
+  const store = createAppStore();
+  const webhook = createProto(WebhookSchema, {
+    name: "projects/a/webhooks/w1",
+    title: "Webhook",
+  });
+  const project = createProto(ProjectSchema, {
+    name: "projects/a",
+    webhooks: [webhook],
+  });
+  expect(store.getState().getProjectWebhookFromProjectById(project, "w1")).toEqual(
+    webhook
+  );
+  mocks.testWebhook.mockResolvedValue({ error: "" });
+  await expect(
+    store.getState().testProjectWebhook(project, webhook)
+  ).resolves.toEqual({ error: "" });
+});
+```
+
+- [ ] **Step 8: Run app-store tests**
+
+Run:
+
+```bash
+pnpm --dir frontend exec vitest run src/react/stores/app/index.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit smaller resource slices**
+
+```bash
+git add frontend/src/react/stores/app/release.ts frontend/src/react/stores/app/revision.ts frontend/src/react/stores/app/changelog.ts frontend/src/react/stores/app/projectWebhook.ts frontend/src/react/stores/app/types.ts frontend/src/react/stores/app/index.ts frontend/src/react/stores/app/index.test.ts
+git commit -m "feat(frontend): add release revision changelog webhook app stores"
+```
+
+---
+
+### Task 3: Add Hook Facades
+
+**Files:**
+- Modify: `frontend/src/react/hooks/useAppState.ts`
+
+- [ ] **Step 1: Add hook facades**
+
+Add these exports near the existing resource hooks in `frontend/src/react/hooks/useAppState.ts`:
+
+```ts
+export function useUserByIdentifier(identifier: string | undefined) {
+  return useAppStore((state) =>
+    identifier ? state.getUserByIdentifier(identifier) : undefined
+  );
+}
+
+export function useRoleByName(name: string | undefined) {
+  return useAppStore((state) =>
+    name ? state.getRoleByName(name) : undefined
+  );
+}
+
+export function useReleaseByName(name: string | undefined) {
+  return useAppStore((state) =>
+    name ? state.getReleaseByName(name) : undefined
+  );
+}
+
+export function useRevisionByName(name: string | undefined) {
+  return useAppStore((state) =>
+    name ? state.getRevisionByName(name) : undefined
+  );
+}
+
+export function useChangelogByName(name: string | undefined) {
+  return useAppStore((state) =>
+    name ? state.getChangelogByName(name) : undefined
+  );
+}
+```
+
+- [ ] **Step 2: Run focused hook type coverage**
+
+Run:
+
+```bash
+pnpm --dir frontend exec vitest run src/react/stores/app/index.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit hook facades**
+
+```bash
+git add frontend/src/react/hooks/useAppState.ts
+git commit -m "feat(frontend): add resource app store hooks"
+```
+
+---
+
+### Task 4: Add Legacy Guard and Observe Current Failures
+
+**Files:**
+- Modify: `frontend/src/react/no-legacy-vue-deps.test.ts`
+
+- [ ] **Step 1: Add Phase 2 guard**
+
+Append a new test in `frontend/src/react/no-legacy-vue-deps.test.ts`:
+
+```ts
+  test("Phase 2 protobuf resource consumers use the React app store", () => {
+    const bannedImports = [
+      "useUserStore",
+      "useRoleStore",
+      "useReleaseStore",
+      "useRevisionStore",
+      "useChangelogStore",
+      "useProjectWebhookV1Store",
+      "@/store/modules/user",
+      "@/store/modules/role",
+      "@/store/modules/release",
+      "@/store/modules/revision",
+      "@/store/modules/v1/changelog",
+      "@/store/modules/v1/projectWebhook",
+    ];
+    const violations: string[] = [];
+    for (const [file, source] of Object.entries(sources)) {
+      for (const bannedImport of bannedImports) {
+        if (source.includes(bannedImport)) {
+          violations.push(`${file}: ${bannedImport}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+```
+
+- [ ] **Step 2: Run guard test and observe expected failure**
+
+Run:
+
+```bash
+pnpm --dir frontend exec vitest run src/react/no-legacy-vue-deps.test.ts
+```
+
+Expected: FAIL listing current React consumers of the Phase 2 legacy stores. Keep this failing state until Tasks 5-9 migrate the consumers.
+
+- [ ] **Step 3: Keep the guard change uncommitted**
+
+```bash
+git diff -- frontend/src/react/no-legacy-vue-deps.test.ts
+```
+
+Expected: the diff contains only the Phase 2 guard test. Do not commit this failing guard yet.
+
+---
+
+### Task 5: Migrate User and Role React Consumers
+
+**Files:**
+- Modify all non-test React files returned by:
+  - `rg -l "useUserStore" frontend/src/react --glob '*.{ts,tsx}' --glob '!**/*.test.ts' --glob '!**/*.test.tsx'`
+  - `rg -l "useRoleStore" frontend/src/react --glob '*.{ts,tsx}' --glob '!**/*.test.ts' --glob '!**/*.test.tsx'`
+- Modify affected tests that mock `useUserStore` or `useRoleStore`.
+
+- [ ] **Step 1: Replace User store imports**
+
+For each React source importing `useUserStore`, add:
+
+```ts
+import { useAppStore } from "@/react/stores/app";
+```
+
+Replace:
+
+```ts
+const userStore = useUserStore();
+```
+
+with only the actions/selectors used in that file. Example for list and cache lookups:
+
+```ts
+const listUsers = useAppStore((state) => state.listUsers);
+const getUserByIdentifier = useAppStore((state) => state.getUserByIdentifier);
+const batchGetOrFetchUsers = useAppStore(
+  (state) => state.batchGetOrFetchUsers
+);
+```
+
+Use these method mappings:
+
+```ts
+userStore.fetchUserList(...) -> listUsers(...)
+userStore.getUserByIdentifier(...) -> getUserByIdentifier(...)
+userStore.getOrFetchUserByIdentifier(...) -> getOrFetchUserByIdentifier(...)
+userStore.batchGetOrFetchUsers(...) -> batchGetOrFetchUsers(...)
+userStore.createUser(...) -> createUser(...)
+userStore.updateUser(...) -> updateUser(...)
+userStore.updateEmail(...) -> updateEmail(...)
+userStore.archiveUser(...) -> archiveUser(...)
+userStore.restoreUser(...) -> restoreUser(...)
+```
+
+For reactive display reads, do not use `useVueState`. Replace patterns like:
+
+```ts
+const user = useVueState(() => userStore.getUserByIdentifier(name));
+```
+
+with:
+
+```ts
+const user = useAppStore((state) => state.getUserByIdentifier(name));
+```
+
+- [ ] **Step 2: Replace Role store imports**
+
+For each React source importing `useRoleStore`, add:
+
+```ts
+import { useAppStore } from "@/react/stores/app";
+```
+
+Replace:
+
+```ts
+const roleStore = useRoleStore();
+```
+
+with only the actions/selectors used in that file:
+
+```ts
+const roleList = useAppStore((state) => state.roleList);
+const listRoles = useAppStore((state) => state.listRoles);
+const getRoleByName = useAppStore((state) => state.getRoleByName);
+const upsertRole = useAppStore((state) => state.upsertRole);
+const deleteRole = useAppStore((state) => state.deleteRole);
+```
+
+Use these method mappings:
+
+```ts
+roleStore.roleList -> roleList
+roleStore.fetchRoleList() -> listRoles()
+roleStore.getRoleByName(name) -> getRoleByName(name)
+roleStore.upsertRole(role) -> upsertRole(role)
+roleStore.deleteRole(role) -> deleteRole(role)
+```
+
+- [ ] **Step 3: Update tests for User and Role consumers**
+
+For tests mocking `@/store` with `useUserStore` or `useRoleStore`, remove those keys and add:
+
+```ts
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      listUsers: mocks.listUsers,
+      fetchUser: mocks.fetchUser,
+      batchGetOrFetchUsers: mocks.batchGetOrFetchUsers,
+      getOrFetchUserByIdentifier: mocks.getOrFetchUserByIdentifier,
+      getUserByIdentifier: mocks.getUserByIdentifier,
+      createUser: mocks.createUser,
+      updateUser: mocks.updateUser,
+      updateEmail: mocks.updateEmail,
+      archiveUser: mocks.archiveUser,
+      restoreUser: mocks.restoreUser,
+      roleList: mocks.roleList,
+      listRoles: mocks.listRoles,
+      getRoleByName: mocks.getRoleByName,
+      upsertRole: mocks.upsertRole,
+      deleteRole: mocks.deleteRole,
+    }),
+}));
+```
+
+Keep only the functions each test actually needs in its mock object.
+
+- [ ] **Step 4: Verify User and Role imports are gone**
+
+Run:
+
+```bash
+rg -n "useUserStore|useRoleStore|@/store/modules/user|@/store/modules/role" frontend/src/react --glob '*.{ts,tsx}' --glob '!no-legacy-vue-deps.test.ts'
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pnpm --dir frontend exec vitest run src/react/stores/app/index.test.ts src/react/no-legacy-vue-deps.test.ts src/react/components/UserSelect.test.tsx src/react/components/RoleSelect.test.tsx src/react/pages/settings/MembersPage.test.tsx src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
+```
+
+Expected: tests for already-migrated resources pass; the guard may still fail for Release/Revision/Changelog/ProjectWebhook until Tasks 6-9 complete.
+
+- [ ] **Step 6: Commit User and Role consumers**
+
+```bash
+git add frontend/src/react
+git commit -m "refactor(frontend): migrate user and role consumers to app store"
+```
+
+---
+
+### Task 6: Migrate Release Consumers
+
+**Files:**
+- Modify: `frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx`
+- Modify: `frontend/src/react/pages/project/ProjectReleaseDetailPage.tsx`
+- Modify: `frontend/src/react/pages/project/database-detail/revision/ImportRevisionSheet.tsx`
+- Modify: `frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx`
+- Modify: `frontend/src/react/components/task-run-log/useTaskRunLogData.ts`
+- Modify affected tests under the same directories.
+
+- [ ] **Step 1: Replace release store imports**
+
+In each release consumer, add:
+
+```ts
+import { useAppStore } from "@/react/stores/app";
+```
+
+Use these mappings:
+
+```ts
+releaseStore.fetchReleasesByProject(...) -> listReleasesByProject(...)
+releaseStore.fetchReleaseByName(...) -> fetchRelease(...)
+releaseStore.getReleasesByProject(...) -> getReleasesByProject(...)
+releaseStore.getReleaseByName(...) -> getReleaseByName(...)
+releaseStore.updateRelase(...) -> updateRelease(...)
+releaseStore.deleteRelease(...) -> deleteRelease(...)
+releaseStore.undeleteRelease(...) -> undeleteRelease(...)
+```
+
+Example:
+
+```ts
+const listReleasesByProject = useAppStore(
+  (state) => state.listReleasesByProject
+);
+const getReleaseByName = useAppStore((state) => state.getReleaseByName);
+```
+
+- [ ] **Step 2: Replace release reactive reads**
+
+Replace:
+
+```ts
+const release = useVueState(() => releaseStore.getReleaseByName(name));
+```
+
+with:
+
+```ts
+const release = useAppStore((state) => state.getReleaseByName(name));
+```
+
+- [ ] **Step 3: Update release tests**
+
+For tests mocking `useReleaseStore`, use:
+
+```ts
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      listReleasesByProject: mocks.listReleasesByProject,
+      fetchRelease: mocks.fetchRelease,
+      getReleasesByProject: mocks.getReleasesByProject,
+      getReleaseByName: mocks.getReleaseByName,
+      updateRelease: mocks.updateRelease,
+      deleteRelease: mocks.deleteRelease,
+      undeleteRelease: mocks.undeleteRelease,
+    }),
+}));
+```
+
+- [ ] **Step 4: Verify release imports are gone**
+
+Run:
+
+```bash
+rg -n "useReleaseStore|@/store/modules/release" frontend/src/react --glob '*.{ts,tsx}' --glob '!no-legacy-vue-deps.test.ts'
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit release consumers**
+
+```bash
+git add frontend/src/react
+git commit -m "refactor(frontend): migrate release consumers to app store"
+```
+
+---
+
+### Task 7: Migrate Revision Consumers
+
+**Files:**
+- Modify: `frontend/src/react/components/revision/RevisionDetailPanel.tsx`
+- Modify: `frontend/src/react/pages/project/database-detail/revision/ImportRevisionSheet.tsx`
+- Modify: `frontend/src/react/pages/project/database-detail/panels/DatabaseRevisionPanel.tsx`
+- Modify affected tests under the same directories.
+
+- [ ] **Step 1: Replace revision store imports**
+
+Add:
+
+```ts
+import { useAppStore } from "@/react/stores/app";
+```
+
+Use these mappings:
+
+```ts
+revisionStore.fetchRevisionsByDatabase(...) -> listRevisionsByDatabase(...)
+revisionStore.fetchAllRevisionsByDatabase(...) -> listAllRevisionsByDatabase(...)
+revisionStore.getRevisionsByDatabase(...) -> getRevisionsByDatabase(...)
+revisionStore.getOrFetchRevisionByName(...) -> fetchRevision(...)
+revisionStore.getRevisionByName(...) -> getRevisionByName(...)
+revisionStore.deleteRevision(...) -> deleteRevision(...)
+```
+
+- [ ] **Step 2: Replace revision reactive reads**
+
+Replace:
+
+```ts
+const revision = useVueState(() => revisionStore.getRevisionByName(name));
+```
+
+with:
+
+```ts
+const revision = useAppStore((state) => state.getRevisionByName(name));
+```
+
+- [ ] **Step 3: Verify revision imports are gone**
+
+Run:
+
+```bash
+rg -n "useRevisionStore|@/store/modules/revision" frontend/src/react --glob '*.{ts,tsx}' --glob '!no-legacy-vue-deps.test.ts'
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit revision consumers**
+
+```bash
+git add frontend/src/react
+git commit -m "refactor(frontend): migrate revision consumers to app store"
+```
+
+---
+
+### Task 8: Migrate Changelog Consumers
+
+**Files:**
+- Modify: `frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx`
+- Modify: `frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx`
+- Modify: `frontend/src/react/pages/project/database-detail/panels/DatabaseChangelogPanel.tsx`
+- Modify affected tests under the same directories.
+
+- [ ] **Step 1: Replace changelog store imports**
+
+Add:
+
+```ts
+import { useAppStore } from "@/react/stores/app";
+```
+
+Use these mappings:
+
+```ts
+changelogStore.clearCache(...) -> clearChangelogCache(...)
+changelogStore.fetchChangelogList(...) -> listChangelogs(...)
+changelogStore.getOrFetchChangelogListOfDatabase(...) -> getOrFetchChangelogListOfDatabase(...)
+changelogStore.changelogListByDatabase(...) -> changelogListByDatabase(...)
+changelogStore.fetchChangelog(...) -> fetchChangelog(...)
+changelogStore.getOrFetchChangelogByName(...) -> getOrFetchChangelogByName(...)
+changelogStore.getChangelogByName(...) -> getChangelogByName(...)
+changelogStore.fetchPreviousChangelog(...) -> fetchPreviousChangelog(...)
+```
+
+- [ ] **Step 2: Replace changelog reactive reads**
+
+Replace:
+
+```ts
+const changelog = useVueState(() => changelogStore.getChangelogByName(name));
+```
+
+with:
+
+```ts
+const changelog = useAppStore((state) => state.getChangelogByName(name));
+```
+
+- [ ] **Step 3: Verify changelog imports are gone**
+
+Run:
+
+```bash
+rg -n "useChangelogStore|@/store/modules/v1/changelog" frontend/src/react --glob '*.{ts,tsx}' --glob '!no-legacy-vue-deps.test.ts'
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit changelog consumers**
+
+```bash
+git add frontend/src/react
+git commit -m "refactor(frontend): migrate changelog consumers to app store"
+```
+
+---
+
+### Task 9: Migrate Project Webhook Consumers
+
+**Files:**
+- Modify: `frontend/src/react/pages/project/ProjectWebhookForm.tsx`
+- Modify: `frontend/src/react/pages/project/ProjectWebhooksPage.tsx`
+- Modify: `frontend/src/react/pages/project/ProjectWebhookDetailPage.tsx`
+- Modify affected tests under the same directories.
+
+- [ ] **Step 1: Replace project webhook store imports**
+
+Add:
+
+```ts
+import { useAppStore } from "@/react/stores/app";
+```
+
+Use these mappings:
+
+```ts
+projectWebhookStore.getProjectWebhookFromProjectById(...) -> getProjectWebhookFromProjectById(...)
+projectWebhookStore.createProjectWebhook(...) -> createProjectWebhook(...)
+projectWebhookStore.updateProjectWebhook(...) -> updateProjectWebhook(...)
+projectWebhookStore.deleteProjectWebhook(...) -> deleteProjectWebhook(...)
+projectWebhookStore.testProjectWebhook(...) -> testProjectWebhook(...)
+```
+
+- [ ] **Step 2: Preserve project refresh behavior**
+
+Where callers currently receive an updated `Project` from webhook mutations, keep the existing follow-up behavior. For example:
+
+```ts
+const project = await updateProjectWebhook(webhook, updateMask);
+projectStore.updateProjectCache?.(project);
+```
+
+Use the refresh/update function already present in the current file. For example, if the file currently calls `fetchProject()` after a webhook mutation, keep that call and replace only the project webhook store call.
+
+- [ ] **Step 3: Verify project webhook imports are gone**
+
+Run:
+
+```bash
+rg -n "useProjectWebhookV1Store|@/store/modules/v1/projectWebhook" frontend/src/react --glob '*.{ts,tsx}' --glob '!no-legacy-vue-deps.test.ts'
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Commit project webhook consumers**
+
+```bash
+git add frontend/src/react
+git commit -m "refactor(frontend): migrate project webhook consumers to app store"
+```
+
+---
+
+### Task 10: Final Guard, Type, and Full Frontend Verification
+
+**Files:**
+- Modify only files needed to fix verification failures found in this task.
+
+- [ ] **Step 1: Run legacy import greps**
+
+Run:
+
+```bash
+rg -n "useUserStore|useRoleStore|useReleaseStore|useRevisionStore|useChangelogStore|useProjectWebhookV1Store|@/store/modules/user|@/store/modules/role|@/store/modules/release|@/store/modules/revision|@/store/modules/v1/changelog|@/store/modules/v1/projectWebhook" frontend/src/react --glob '*.{ts,tsx}' --glob '!no-legacy-vue-deps.test.ts'
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Run focused guard and app-store tests**
+
+Run:
+
+```bash
+pnpm --dir frontend exec vitest run src/react/stores/app/index.test.ts src/react/no-legacy-vue-deps.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run formatter/linter fixer**
+
+Run:
+
+```bash
+pnpm --dir frontend fix
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 4: Run CI-style frontend check**
+
+Run:
+
+```bash
+pnpm --dir frontend check
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 5: Run React/Vue type check**
+
+Run:
+
+```bash
+pnpm --dir frontend type-check
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 6: Run full frontend tests**
+
+Run:
+
+```bash
+pnpm --dir frontend test
+```
+
+Expected: all frontend tests pass.
+
+- [ ] **Step 7: Run whitespace diff check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit 0.
+
+- [ ] **Step 8: Commit final guard and verification fixes**
+
+When the guard and verification commands pass, commit the guard plus any verification fixes:
+
+```bash
+git add frontend/src/react frontend/src/react/stores/app
+git commit -m "fix(frontend): complete phase two app store migration"
+```
+
+Expected: creates a commit containing `frontend/src/react/no-legacy-vue-deps.test.ts` and any source/test files adjusted during final verification.
+
+---
+
+### Task 11: Prepare Review Summary
+
+**Files:**
+- Read-only unless a PR description file is requested separately.
+
+- [ ] **Step 1: Summarize commits**
+
+Run:
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected: shows the Phase 2 migration commits on the working branch.
+
+- [ ] **Step 2: Summarize final changed files**
+
+Run:
+
+```bash
+git diff --stat main...HEAD
+```
+
+Expected: shows app-store slices, migrated consumers, tests, and guard updates.
+
+- [ ] **Step 3: Prepare final handoff**
+
+Report:
+
+```md
+Implemented Phase 2 resource store migration.
+
+Resources migrated:
+- User
+- Role
+- Release
+- Revision
+- Changelog
+- ProjectWebhook
+
+Verification:
+- pnpm --dir frontend exec vitest run src/react/stores/app/index.test.ts src/react/no-legacy-vue-deps.test.ts
+- pnpm --dir frontend fix
+- pnpm --dir frontend check
+- pnpm --dir frontend type-check
+- pnpm --dir frontend test
+- git diff --check
+```
+
+Use the actual command outcomes from Task 10.

--- a/docs/superpowers/specs/2026-05-28-react-zustand-resource-phase-2-design.md
+++ b/docs/superpowers/specs/2026-05-28-react-zustand-resource-phase-2-design.md
@@ -1,0 +1,208 @@
+# React Zustand Resource Store Migration Phase 2 Design
+
+## Context
+
+Phase 1 moved the first protobuf resource stores into the React app store and added a guard that prevents React code from re-importing those legacy Pinia stores. The next useful batch is the remaining resource stores with meaningful React usage but bounded API surfaces:
+
+- `User`
+- `Role`
+- `Release`
+- `Revision`
+- `Changelog`
+- `ProjectWebhook`
+
+This phase keeps the Vue Pinia stores in place for Vue consumers. The goal is to migrate React consumers to `useAppStore` and add guard coverage so React does not regress.
+
+## Goals
+
+- Add Zustand slices under `frontend/src/react/stores/app/` for the six resources.
+- Preserve the observable behavior of the current Pinia stores for React callers.
+- Migrate all React non-test consumers of the six legacy stores.
+- Update affected tests to mock `@/react/stores/app` instead of legacy Pinia stores.
+- Extend `frontend/src/react/no-legacy-vue-deps.test.ts` to block these stores from React code.
+
+## Non-Goals
+
+- Do not delete legacy Pinia stores.
+- Do not migrate Vue consumers.
+- Do not include `Issue`, `Plan`, `Rollout`, `Policy`, `ProjectIamPolicy`, worksheet, or SQL editor legacy store migrations in this phase.
+- Do not refactor UI flows beyond the minimum needed for store migration.
+
+## Current React Consumer Surface
+
+Approximate non-test React consumer counts on current `main`:
+
+- `useUserStore`: 20 files
+- `useRoleStore`: 10 files
+- `useReleaseStore`: 5 files
+- `useRevisionStore`: 3 files
+- `useChangelogStore`: 3 files
+- `useProjectWebhookV1Store`: 3 files
+
+The batch is large enough to be a single focused resource-store PR, but not mixed with lifecycle resources such as `Issue`, `Plan`, and `Rollout`.
+
+## Architecture
+
+Add these files:
+
+- `frontend/src/react/stores/app/user.ts`
+- `frontend/src/react/stores/app/role.ts`
+- `frontend/src/react/stores/app/release.ts`
+- `frontend/src/react/stores/app/revision.ts`
+- `frontend/src/react/stores/app/changelog.ts`
+- `frontend/src/react/stores/app/projectWebhook.ts`
+
+Update these shared app-store files:
+
+- `frontend/src/react/stores/app/types.ts`
+- `frontend/src/react/stores/app/index.ts`
+- `frontend/src/react/stores/app/index.test.ts`
+- `frontend/src/react/hooks/useAppState.ts`
+
+Each slice should follow the existing app-store style:
+
+- Store resource maps as plain objects keyed by resource name.
+- Store request maps for deduped fetches where the Pinia store currently caches requests.
+- Keep list functions as async actions that return API response payloads and upsert entities into cache.
+- Use `useAppStore(selector)` for reactive reads in React components.
+- Use selected actions from `useAppStore(selector)` for component event handlers.
+- Reserve `useAppStore.getState()` for imperative contexts where a hook is not legal.
+
+## Slice Responsibilities
+
+### User
+
+The user slice should cover:
+
+- current app user compatibility where needed by user consumers
+- `listUsers`
+- `fetchUser`
+- `batchGetOrFetchUsers`
+- `getOrFetchUserByIdentifier`
+- `getUserByIdentifier`
+- `createUser`
+- `updateUser`
+- `updateEmail`
+- `archiveUser`
+- `restoreUser`
+
+It should preserve the special `allUsersUser()` cache entry and unknown-user fallback behavior used by selectors and tables. It should also invalidate permission cache behavior through app-store permission state if needed, rather than importing the legacy permission Pinia store.
+
+### Role
+
+The role slice should cover:
+
+- `listRoles`
+- `getRoleByName`
+- `upsertRole`
+- `deleteRole`
+
+It should keep the current `allowMissing: true` update behavior and remove deleted roles from the cached list.
+
+### Release
+
+The release slice should cover:
+
+- `listReleasesByProject`
+- `fetchRelease`
+- `getReleasesByProject`
+- `getReleaseByName`
+- `updateRelease`
+- `deleteRelease`
+- `undeleteRelease`
+
+It should preserve deleted release state updates and the unknown-release fallback expected by current UI.
+
+### Revision
+
+The revision slice should cover:
+
+- `listRevisionsByDatabase`
+- `listAllRevisionsByDatabase`
+- `fetchRevision`
+- `getRevisionsByDatabase`
+- `getRevisionByName`
+- `deleteRevision`
+
+It should keep database-scoped list behavior and support the import-revision and revision panel flows.
+
+### Changelog
+
+The changelog slice should cover:
+
+- `clearChangelogCache`
+- `listChangelogs`
+- `getOrFetchChangelogListOfDatabase`
+- `changelogListByDatabase`
+- `fetchChangelog`
+- `getOrFetchChangelogByName`
+- `getChangelogByName`
+- `fetchPreviousChangelog`
+
+The cache key must include `ChangelogView`, preserving the current BASIC/FULL lookup behavior. `getChangelogByName(name)` without a view should continue to prefer FULL and fall back to BASIC.
+
+### ProjectWebhook
+
+The project webhook slice should cover:
+
+- `getProjectWebhookFromProjectById`
+- `createProjectWebhook`
+- `updateProjectWebhook`
+- `deleteProjectWebhook`
+- `testProjectWebhook`
+
+The mutation APIs return updated `Project` responses from the backend. Consumer migration should keep the current project refresh/update behavior unchanged.
+
+## Consumer Migration
+
+Migrate all React non-test consumers of these stores:
+
+- User consumers in account selectors, member/user settings, auth profile/setup/reset flows, issue and audit tables, approval flows, SQL editor display labels, masking exemption, access grant pages, and plan/data export dashboards.
+- Role consumers in role selectors, roles settings, request-role sheets, custom approval utilities, environment settings, role grant details, setup, and SQL editor request query actions.
+- Release consumers in release dashboard/detail, import revision, issue statement section, and task-run log data.
+- Revision consumers in revision panel, database revision panel, and import revision.
+- Changelog consumers in sync schema, database changelog list/detail, and changelog panels.
+- Project webhook consumers in webhook list/detail/form pages.
+
+Tests that currently mock the legacy stores should be updated to mock `@/react/stores/app`.
+
+## Guardrails
+
+Extend `frontend/src/react/no-legacy-vue-deps.test.ts` with a Phase 2 guard that fails if React code imports or references:
+
+- `useUserStore`
+- `useRoleStore`
+- `useReleaseStore`
+- `useRevisionStore`
+- `useChangelogStore`
+- `useProjectWebhookV1Store`
+- direct module imports for the corresponding Pinia store files
+
+The guard should exclude itself and can allow Vue-side Pinia stores to remain untouched.
+
+## Error Handling
+
+Keep current behavior:
+
+- Silent fetches should continue to use `silentContextKey`.
+- User not-found paths should preserve existing unknown-user fallback semantics.
+- Role deletion should keep graceful-request behavior, either by preserving the same wrapper behavior or by matching its notification/error semantics in callers.
+- Changelog invalid or unknown IDs should return `undefined` instead of issuing invalid backend requests.
+
+## Testing
+
+Use focused tests while developing, then run the standard frontend verification:
+
+- `pnpm --dir frontend exec vitest run src/react/stores/app/index.test.ts src/react/no-legacy-vue-deps.test.ts`
+- Focused tests for touched consumers that already have coverage.
+- `pnpm --dir frontend fix`
+- `pnpm --dir frontend check`
+- `pnpm --dir frontend type-check`
+- `pnpm --dir frontend test`
+
+## Implementation Notes
+
+- Migrate the slices first, then migrate consumers by resource group.
+- Prefer small mechanical patches and grep after each group to ensure no React consumer remains.
+- Use `useAppStore(selector)` for reactive values; do not wrap `useAppStore.getState()` in `useVueState`.
+- Keep generated artifacts out of the commit unless verification commands intentionally update them and they are required.

--- a/frontend/src/react/components/AccountMultiSelect.tsx
+++ b/frontend/src/react/components/AccountMultiSelect.tsx
@@ -7,7 +7,7 @@ import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
-import { useCurrentUserV1, useUserStore } from "@/store";
+import { useCurrentUserV1 } from "@/store";
 import {
   extractUserEmail,
   groupNamePrefix,
@@ -192,7 +192,7 @@ export function AccountMultiSelect({
   includeAllUsers?: boolean;
 }) {
   const { t } = useTranslation();
-  const userStore = useUserStore();
+  const listUsers = useAppStore((state) => state.listUsers);
   const listGroups = useAppStore((state) => state.listGroups);
   const currentUser = useVueState(() => useCurrentUserV1().value);
 
@@ -212,9 +212,9 @@ export function AccountMultiSelect({
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       const query = search.trim();
-      userStore
-        .fetchUserList({ pageSize: getDefaultPagination(), filter: { query } })
-        .then(({ users: fetched }) => setUsers(fetched));
+      listUsers({ pageSize: getDefaultPagination(), filter: { query } }).then(
+        ({ users: fetched }) => setUsers(fetched)
+      );
       listGroups({ pageSize: getDefaultPagination(), filter: { query } }).then(
         ({ groups: fetched }) => setGroups(fetched)
       );
@@ -222,7 +222,7 @@ export function AccountMultiSelect({
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [search, userStore, listGroups]);
+  }, [search, listUsers, listGroups]);
 
   const handleClickOutside = useCallback(() => {
     setOpen(false);

--- a/frontend/src/react/components/AuditLogTable.test.tsx
+++ b/frontend/src/react/components/AuditLogTable.test.tsx
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
   useTranslation: vi.fn(() => ({ t: (key: string) => key })),
   pushNotification: vi.fn(),
   usePlanFeature: vi.fn(() => true),
-  useUserStore: vi.fn(() => ({ fetchUserList: vi.fn() })),
+  listUsers: vi.fn(async () => ({ users: [] })),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -37,7 +37,13 @@ vi.mock("@/connect", () => ({
 
 vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
-  useUserStore: mocks.useUserStore,
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      listUsers: mocks.listUsers,
+    }),
 }));
 
 vi.mock("@/react/hooks/useAppState", () => ({

--- a/frontend/src/react/components/AuditLogTable.tsx
+++ b/frontend/src/react/components/AuditLogTable.tsx
@@ -38,7 +38,8 @@ import {
   useSessionPageSize,
 } from "@/react/hooks/useSessionPageSize";
 import { cn } from "@/react/lib/utils";
-import { pushNotification, useUserStore } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification } from "@/store";
 import {
   extractUserEmail,
   getProjectIdPlanUidStageUidFromRolloutName,
@@ -663,11 +664,10 @@ export function AuditLogTable({
       return t("audit-log.export-tooltip");
     return "";
   }, [filter, t]);
-
-  const userStore = useUserStore();
+  const listUsers = useAppStore((state) => state.listUsers);
   const searchUsers = useCallback(
     async (keyword: string): Promise<ValueOption[]> => {
-      const { users } = await userStore.fetchUserList({
+      const { users } = await listUsers({
         pageSize: getDefaultPagination(),
         filter: keyword.trim() ? { query: keyword } : undefined,
       });
@@ -676,7 +676,7 @@ export function AuditLogTable({
         keywords: [u.email, u.title],
       }));
     },
-    [userStore]
+    [listUsers]
   );
 
   const scopeOptions = useMemo((): ScopeOption[] => {

--- a/frontend/src/react/components/CustomApproval/utils.ts
+++ b/frontend/src/react/components/CustomApproval/utils.ts
@@ -3,7 +3,8 @@ import { v4 as uuidv4 } from "uuid";
 import type { ConditionGroupExpr } from "@/plugins/cel";
 import { ExprType, type Factor, SQLTypeList, wrapAsGroup } from "@/plugins/cel";
 import i18n from "@/react/i18n";
-import { useRoleStore } from "@/store";
+import { displayRoleTitleFromList } from "@/react/lib/role";
+import { useAppStore } from "@/react/stores/app";
 import type { LocalApprovalRule } from "@/types";
 import { PRESET_WORKSPACE_ROLES, PresetRoleType } from "@/types";
 import { Engine, RiskLevel } from "@/types/proto-es/v1/common_pb";
@@ -11,7 +12,6 @@ import { ApprovalFlowSchema } from "@/types/proto-es/v1/issue_service_pb";
 import { WorkspaceApprovalSetting_Rule_Source } from "@/types/proto-es/v1/setting_service_pb";
 import type { ResourceSelectOption } from "@/types/v2-shared";
 import {
-  displayRoleTitle,
   engineNameV1,
   getEnvironmentIdOptions,
   getInstanceIdOptionConfig,
@@ -212,10 +212,11 @@ const getSQLTypeOptions = (source: WorkspaceApprovalSetting_Rule_Source) => {
 };
 
 const getRoleOptions = () => {
-  return useRoleStore()
-    .roleList.filter((role) => !PRESET_WORKSPACE_ROLES.includes(role.name))
+  const roleList = useAppStore.getState().roleList;
+  return roleList
+    .filter((role) => !PRESET_WORKSPACE_ROLES.includes(role.name))
     .map((role) => ({
-      label: displayRoleTitle(role.name),
+      label: displayRoleTitleFromList(role.name, roleList),
       value: role.name,
     }));
 };

--- a/frontend/src/react/components/IssueTable.tsx
+++ b/frontend/src/react/components/IssueTable.tsx
@@ -29,16 +29,13 @@ import { Tooltip } from "@/react/components/ui/tooltip";
 import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { useEscapeKey } from "@/react/hooks/useEscapeKey";
 import { useVueState } from "@/react/hooks/useVueState";
+import { displayRoleTitleFromList } from "@/react/lib/role";
 import { cn } from "@/react/lib/utils";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_DETAIL } from "@/router/dashboard/projectV1";
 import { WORKSPACE_ROUTE_USER_PROFILE } from "@/router/dashboard/workspaceRoutes";
-import {
-  pushNotification,
-  useCurrentUserV1,
-  useProjectV1Store,
-  useUserStore,
-} from "@/store";
+import { pushNotification, useCurrentUserV1, useProjectV1Store } from "@/store";
 import {
   getTimeForPbTimestampProtoEs,
   isValidProjectName,
@@ -53,7 +50,6 @@ import {
 } from "@/types/proto-es/v1/issue_service_pb";
 import type { Label } from "@/types/proto-es/v1/project_service_pb";
 import {
-  displayRoleTitle,
   extractIssueUID,
   extractProjectResourceName,
   getDefaultPagination,
@@ -326,7 +322,7 @@ export function useIssueSearchScopeOptions(
   projectName?: string
 ): ScopeOption[] {
   const { t } = useTranslation();
-  const userStore = useUserStore();
+  const listUsers = useAppStore((state) => state.listUsers);
   const projectStore = useProjectV1Store();
   const currentUser = useCurrentUserV1();
   const me = useVueState(() => currentUser.value);
@@ -346,7 +342,7 @@ export function useIssueSearchScopeOptions(
 
   const searchPrincipal = useCallback(
     async (keyword: string): Promise<ValueOption[]> => {
-      const resp = await userStore.fetchUserList({
+      const resp = await listUsers({
         pageSize: getDefaultPagination(),
         filter: { query: keyword },
       });
@@ -365,7 +361,7 @@ export function useIssueSearchScopeOptions(
         ),
       }));
     },
-    [userStore, me, t]
+    [listUsers, me, t]
   );
 
   return useMemo(
@@ -573,10 +569,10 @@ export const IssueListItem = memo(function IssueListItem({
   showProject?: boolean;
 }) {
   const { t } = useTranslation();
-  const userStore = useUserStore();
-
-  const creator =
-    userStore.getUserByIdentifier(issue.creator) || unknownUser(issue.creator);
+  const creatorUser = useAppStore((state) =>
+    state.getUserByIdentifier(issue.creator)
+  );
+  const creator = creatorUser || unknownUser(issue.creator);
 
   const issueProject = useMemo(() => projectOfIssue(issue), [issue]);
 
@@ -831,6 +827,7 @@ function RiskLevelIcon({ riskLevel }: { riskLevel: RiskLevel }) {
 
 function IssueApprovalStatusTag({ issue }: { issue: Issue }) {
   const { t } = useTranslation();
+  const roleList = useAppStore((state) => state.roleList);
   const approvalSteps = issue.approvalTemplate?.flow?.roles ?? [];
 
   if (issue.approvalStatus === ApprovalStatus.CHECKING) {
@@ -875,7 +872,7 @@ function IssueApprovalStatusTag({ issue }: { issue: Issue }) {
     if (status === ApprovalStatus.PENDING) {
       const currentRoleIndex = issue.approvers.length;
       const role = approvalSteps[currentRoleIndex];
-      const roleName = role ? displayRoleTitle(role) : "";
+      const roleName = role ? displayRoleTitleFromList(role, roleList) : "";
       return (
         <div className="shrink-0 flex flex-row sm:flex-col items-center sm:items-end gap-x-1.5 sm:gap-x-0 mt-1">
           <span className="inline-flex items-center rounded-full bg-control-bg px-2 py-0.5 text-xs text-control-light">

--- a/frontend/src/react/components/RoleSelect.tsx
+++ b/frontend/src/react/components/RoleSelect.tsx
@@ -3,7 +3,12 @@ import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { Combobox, type ComboboxGroup } from "@/react/components/ui/combobox";
 import { useVueState } from "@/react/hooks/useVueState";
-import { useRoleStore, useSubscriptionV1Store } from "@/store";
+import {
+  displayRoleDescriptionFromList,
+  displayRoleTitleFromList,
+} from "@/react/lib/role";
+import { useAppStore } from "@/react/stores/app";
+import { useSubscriptionV1Store } from "@/store";
 import {
   PRESET_PROJECT_ROLES,
   PRESET_ROLES,
@@ -33,9 +38,8 @@ export function RoleSelect({
   filterRole,
 }: RoleSelectProps) {
   const { t } = useTranslation();
-  const roleStore = useRoleStore();
   const subscriptionStore = useSubscriptionV1Store();
-  const roleList = useVueState(() => [...roleStore.roleList]);
+  const roleList = useAppStore((state) => state.roleList);
   const hasCustomRoleFeature = useVueState(() =>
     subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_CUSTOM_ROLES)
   );
@@ -46,7 +50,7 @@ export function RoleSelect({
       if (!filterRole) {
         return true;
       }
-      const role = roleStore.getRoleByName(name);
+      const role = roleList.find((role) => role.name === name);
       return role ? filterRole(role) : false;
     };
 
@@ -69,12 +73,12 @@ export function RoleSelect({
       .filter((r) => !filterRole || filterRole(r))
       .map((r) => ({
         value: r.name,
-        label: displayRoleTitle(r.name),
-        description: displayRoleDescription(r.name),
+        label: displayRoleTitleFromList(r.name, roleList),
+        description: displayRoleDescriptionFromList(r.name, roleList),
         disabled: !hasCustomRoleFeature,
         render: () => (
           <div className="flex items-center gap-x-1">
-            <span>{displayRoleTitle(r.name)}</span>
+            <span>{displayRoleTitleFromList(r.name, roleList)}</span>
             {isCustomRole(r.name) && !hasCustomRoleFeature && (
               <FeatureBadge
                 feature={PlanFeature.FEATURE_CUSTOM_ROLES}
@@ -96,7 +100,7 @@ export function RoleSelect({
     if (custom.length > 0)
       result.push({ label: t("role.custom-roles.self"), options: custom });
     return result;
-  }, [filterRole, roleList, roleStore, hasCustomRoleFeature, scope, t]);
+  }, [filterRole, roleList, hasCustomRoleFeature, scope, t]);
 
   const defaultPlaceholder = multiple
     ? t("settings.members.select-role", { count: 2 })

--- a/frontend/src/react/components/UserSelect.tsx
+++ b/frontend/src/react/components/UserSelect.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Combobox, type ComboboxOption } from "@/react/components/ui/combobox";
-import { useUserStore } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import { userNamePrefix } from "@/store/modules/v1/common";
 import { ALL_USERS_USER_EMAIL } from "@/types";
 import type { User } from "@/types/proto-es/v1/user_service_pb";
@@ -34,7 +34,10 @@ export function UserSelect({
   className,
   includeAllUsers,
 }: UserSelectProps) {
-  const userStore = useUserStore();
+  const listUsers = useAppStore((state) => state.listUsers);
+  const getOrFetchUserByIdentifier = useAppStore(
+    (state) => state.getOrFetchUserByIdentifier
+  );
   const [users, setUsers] = useState<User[]>([]);
   const [selectedUser, setSelectedUser] = useState<User | undefined>(undefined);
   const [search, setSearch] = useState("");
@@ -50,28 +53,26 @@ export function UserSelect({
       return;
     }
     let cancelled = false;
-    userStore.getOrFetchUserByIdentifier({ identifier: value }).then((user) => {
+    getOrFetchUserByIdentifier({ identifier: value }).then((user) => {
       if (!cancelled) setSelectedUser(user);
     });
     return () => {
       cancelled = true;
     };
-  }, [value, userStore]);
+  }, [value, getOrFetchUserByIdentifier]);
 
   const handleSearch = useCallback(
     (query: string) => {
       setSearch(query);
       const seq = ++searchSeqRef.current;
-      userStore
-        .fetchUserList({
-          pageSize: getDefaultPagination(),
-          filter: { query: query.trim() },
-        })
-        .then(({ users: fetched }) => {
-          if (seq === searchSeqRef.current) setUsers(fetched);
-        });
+      listUsers({
+        pageSize: getDefaultPagination(),
+        filter: { query: query.trim() },
+      }).then(({ users: fetched }) => {
+        if (seq === searchSeqRef.current) setUsers(fetched);
+      });
     },
-    [userStore]
+    [listUsers]
   );
 
   const options: ComboboxOption[] = useMemo(() => {

--- a/frontend/src/react/components/revision/RevisionDetailPanel.tsx
+++ b/frontend/src/react/components/revision/RevisionDetailPanel.tsx
@@ -4,9 +4,10 @@ import { useTranslation } from "react-i18next";
 import { sheetServiceClientConnect } from "@/connect";
 import { ReadonlyMonaco } from "@/react/components/monaco";
 import { TaskRunLogViewer } from "@/react/components/task-run-log";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useRevisionByName } from "@/react/hooks/useAppState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import { pushNotification, useRevisionStore } from "@/store";
+import { pushNotification } from "@/store";
 import { getTimeForPbTimestampProtoEs } from "@/types";
 import { bytesToString, formatAbsoluteDateTime } from "@/utils";
 import { extractTaskLink, getRevisionType } from "@/utils/v1/revision";
@@ -82,10 +83,8 @@ export function RevisionDetailPanel({
   revisionName,
 }: RevisionDetailPanelProps) {
   const { t } = useTranslation();
-  const revisionStore = useRevisionStore();
-  const revision = useVueState(() =>
-    revisionStore.getRevisionByName(revisionName)
-  );
+  const fetchRevision = useAppStore((state) => state.fetchRevision);
+  const revision = useRevisionByName(revisionName);
   const [loading, setLoading] = useState(false);
   const [statement, setStatement] = useState("");
 
@@ -101,8 +100,7 @@ export function RevisionDetailPanel({
     setLoading(true);
     setStatement("");
 
-    void revisionStore
-      .getOrFetchRevisionByName(revisionName)
+    void fetchRevision(revisionName)
       .then(async (rev) => {
         if (!rev?.sheet) {
           return;
@@ -132,7 +130,7 @@ export function RevisionDetailPanel({
     return () => {
       cancelled = true;
     };
-  }, [revisionName, revisionStore]);
+  }, [fetchRevision, revisionName]);
 
   const taskFullLink = revision?.taskRun
     ? extractTaskLink(revision.taskRun)

--- a/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.test.tsx
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   useTranslation: vi.fn(() => ({ t: (key: string) => key })),
   useVueState: vi.fn<(getter: () => unknown) => unknown>(),
   useProjectV1Store: vi.fn(),
-  useRoleStore: vi.fn(),
+  roleList: [] as Array<{ name: string; permissions: string[] }>,
   useSQLEditorVueState: vi.fn(),
   useSubscriptionV1Store: vi.fn(),
   hasFeature: vi.fn(() => true),
@@ -31,9 +31,15 @@ vi.mock("@/react/hooks/useVueState", () => ({
 
 vi.mock("@/store", () => ({
   useProjectV1Store: mocks.useProjectV1Store,
-  useRoleStore: mocks.useRoleStore,
   useSubscriptionV1Store: mocks.useSubscriptionV1Store,
   hasFeature: mocks.hasFeature,
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      roleList: mocks.roleList,
+    }),
 }));
 
 vi.mock("@/react/stores/sqlEditor/editor-vue-state", () => ({
@@ -167,22 +173,20 @@ const setupDefaultMocks = (allowJIT = false, allowRequestRole = true) => {
       allowRequestRole,
     })),
   });
-  mocks.useRoleStore.mockReturnValue({
-    roleList: [
-      {
-        name: "roles/sqlEditorUser",
-        permissions: ["bb.sql.select", "bb.sql.dml", "bb.sql.explain"],
-      },
-      {
-        name: "roles/queryOnly",
-        permissions: ["bb.sql.select"],
-      },
-      {
-        name: "roles/sqlEditorReadUser",
-        permissions: ["bb.sql.select", "bb.sql.explain"],
-      },
-    ],
-  });
+  mocks.roleList = [
+    {
+      name: "roles/sqlEditorUser",
+      permissions: ["bb.sql.select", "bb.sql.dml", "bb.sql.explain"],
+    },
+    {
+      name: "roles/queryOnly",
+      permissions: ["bb.sql.select"],
+    },
+    {
+      name: "roles/sqlEditorReadUser",
+      permissions: ["bb.sql.select", "bb.sql.explain"],
+    },
+  ];
   mocks.useSQLEditorVueState.mockReturnValue({ project: "projects/proj1" });
   mocks.useSubscriptionV1Store.mockReturnValue({
     hasInstanceFeature: vi.fn(() => false),

--- a/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
+++ b/frontend/src/react/components/sql-editor/RequestQueryButton.tsx
@@ -7,13 +7,9 @@ import { Button } from "@/react/components/ui/button";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { RequestRoleSheet } from "@/react/pages/settings/RequestRoleSheet";
+import { useAppStore } from "@/react/stores/app";
 import { useSQLEditorVueState } from "@/react/stores/sqlEditor/editor-vue-state";
-import {
-  hasFeature,
-  useProjectV1Store,
-  useRoleStore,
-  useSubscriptionV1Store,
-} from "@/store";
+import { hasFeature, useProjectV1Store, useSubscriptionV1Store } from "@/store";
 import type { DatabaseResource, Permission } from "@/types";
 import { PRESET_ROLES, PresetRoleType } from "@/types";
 import type { PermissionDeniedDetail } from "@/types/proto-es/v1/common_pb";
@@ -70,6 +66,7 @@ export function RequestQueryButton({
   permissionDeniedDetail,
 }: Props) {
   const { t } = useTranslation();
+  const roleList = useAppStore((state) => state.roleList);
 
   // When the layout-level host is mounted (typical case inside the SQL
   // Editor), opening the drawer dispatches up to the host so it survives
@@ -82,7 +79,7 @@ export function RequestQueryButton({
 
   const projectStore = useProjectV1Store();
   const editorStore = useSQLEditorVueState();
-  const roleStore = useRoleStore();
+
   const subscriptionStore = useSubscriptionV1Store();
 
   const projectName = useVueState(() => editorStore.project);
@@ -92,7 +89,7 @@ export function RequestQueryButton({
   );
   const defaultQueryRole = useVueState(() =>
     getDefaultQueryRole(
-      roleStore.roleList,
+      roleList,
       permissionDeniedDetail.requiredPermissions,
       hasCustomRoleFeature
     )

--- a/frontend/src/react/components/sql-editor/TreeNodeSuffix.test.tsx
+++ b/frontend/src/react/components/sql-editor/TreeNodeSuffix.test.tsx
@@ -21,7 +21,7 @@ const mocks = vi.hoisted(() => ({
   useVueState: vi.fn<(getter: () => unknown) => unknown>(),
   useWorkSheetStore: vi.fn(),
   useSQLEditorTabStore: vi.fn(),
-  useUserStore: vi.fn(),
+  getUserByIdentifier: vi.fn(() => ({ title: "Test User" })),
   useSheetContext: vi.fn(),
 }));
 
@@ -35,7 +35,13 @@ vi.mock("@/react/hooks/useVueState", () => ({
 
 vi.mock("@/store", () => ({
   useWorkSheetStore: mocks.useWorkSheetStore,
-  useUserStore: mocks.useUserStore,
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      getUserByIdentifier: mocks.getUserByIdentifier,
+    }),
 }));
 
 vi.mock("@/react/stores/sqlEditor/tab-vue-state", () => ({
@@ -132,9 +138,7 @@ beforeEach(async () => {
   mocks.useSQLEditorTabStore.mockReturnValue({
     closeTab: vi.fn(),
   });
-  mocks.useUserStore.mockReturnValue({
-    getUserByIdentifier: vi.fn(() => ({ title: "Test User" })),
-  });
+  mocks.getUserByIdentifier.mockReturnValue({ title: "Test User" });
   mocks.useSheetContext.mockReturnValue({
     isWorksheetCreator: vi.fn(() => true),
   });

--- a/frontend/src/react/components/sql-editor/TreeNodeSuffix.test.tsx
+++ b/frontend/src/react/components/sql-editor/TreeNodeSuffix.test.tsx
@@ -21,7 +21,10 @@ const mocks = vi.hoisted(() => ({
   useVueState: vi.fn<(getter: () => unknown) => unknown>(),
   useWorkSheetStore: vi.fn(),
   useSQLEditorTabStore: vi.fn(),
-  getUserByIdentifier: vi.fn(() => ({ title: "Test User" })),
+  getUserByIdentifier: vi.fn<() => { title: string } | undefined>(() => ({
+    title: "Test User",
+  })),
+  getOrFetchUserByIdentifier: vi.fn(async () => ({ title: "Test User" })),
   useSheetContext: vi.fn(),
 }));
 
@@ -41,6 +44,7 @@ vi.mock("@/react/stores/app", () => ({
   useAppStore: (selector: (state: unknown) => unknown) =>
     selector({
       getUserByIdentifier: mocks.getUserByIdentifier,
+      getOrFetchUserByIdentifier: mocks.getOrFetchUserByIdentifier,
     }),
 }));
 
@@ -139,6 +143,7 @@ beforeEach(async () => {
     closeTab: vi.fn(),
   });
   mocks.getUserByIdentifier.mockReturnValue({ title: "Test User" });
+  mocks.getOrFetchUserByIdentifier.mockResolvedValue({ title: "Test User" });
   mocks.useSheetContext.mockReturnValue({
     isWorksheetCreator: vi.fn(() => true),
   });
@@ -205,6 +210,31 @@ describe("TreeNodeSuffix", () => {
 
     const starSvg = container.querySelector("svg.lucide-star");
     expect(starSvg).toBeNull();
+
+    unmount();
+  });
+
+  test("fetches worksheet creator before rendering the raw identifier", () => {
+    mocks.getUserByIdentifier.mockReturnValue(undefined);
+    const node = makeWorksheetNode();
+    const onToggleStar = vi.fn();
+    const onSharePanelShow = vi.fn();
+    const onContextMenuShow = vi.fn();
+
+    const { render, unmount } = renderIntoContainer(
+      <TreeNodeSuffix
+        node={node}
+        view="my"
+        onToggleStar={onToggleStar}
+        onSharePanelShow={onSharePanelShow}
+        onContextMenuShow={onContextMenuShow}
+      />
+    );
+    render();
+
+    expect(mocks.getOrFetchUserByIdentifier).toHaveBeenCalledWith({
+      identifier: "users/test@example.com",
+    });
 
     unmount();
   });

--- a/frontend/src/react/components/sql-editor/TreeNodeSuffix.tsx
+++ b/frontend/src/react/components/sql-editor/TreeNodeSuffix.tsx
@@ -1,4 +1,5 @@
 import { MoreHorizontal, Star, Users, X } from "lucide-react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -63,6 +64,20 @@ export function TreeNodeSuffix({
       ? state.getUserByIdentifier(worksheetLite.creator)?.title
       : undefined
   );
+  const getOrFetchUserByIdentifier = useAppStore(
+    (state) => state.getOrFetchUserByIdentifier
+  );
+
+  useEffect(() => {
+    if (!worksheetLite?.creator || worksheetCreatorTitle) {
+      return;
+    }
+    void getOrFetchUserByIdentifier({ identifier: worksheetLite.creator });
+  }, [
+    getOrFetchUserByIdentifier,
+    worksheetCreatorTitle,
+    worksheetLite?.creator,
+  ]);
 
   const visibilityDisplayName = (visibility: Worksheet_Visibility) => {
     switch (visibility) {

--- a/frontend/src/react/components/sql-editor/TreeNodeSuffix.tsx
+++ b/frontend/src/react/components/sql-editor/TreeNodeSuffix.tsx
@@ -3,8 +3,9 @@ import { useTranslation } from "react-i18next";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
+import { useAppStore } from "@/react/stores/app";
 import { useSQLEditorTabStore } from "@/react/stores/sqlEditor/tab-vue-state";
-import { useUserStore, useWorkSheetStore } from "@/store";
+import { useWorkSheetStore } from "@/store";
 import { Worksheet_Visibility } from "@/types/proto-es/v1/worksheet_service_pb";
 import type {
   SheetViewMode,
@@ -40,7 +41,6 @@ export function TreeNodeSuffix({
 
   const worksheetStore = useWorkSheetStore();
   const tabStore = useSQLEditorTabStore();
-  const userStore = useUserStore();
   const { isWorksheetCreator } = useSheetContext();
 
   const worksheetLite = useVueState(() => {
@@ -58,6 +58,11 @@ export function TreeNodeSuffix({
       creator: sheet.creator,
     };
   });
+  const worksheetCreatorTitle = useAppStore((state) =>
+    worksheetLite?.creator
+      ? state.getUserByIdentifier(worksheetLite.creator)?.title
+      : undefined
+  );
 
   const visibilityDisplayName = (visibility: Worksheet_Visibility) => {
     switch (visibility) {
@@ -73,7 +78,7 @@ export function TreeNodeSuffix({
   };
 
   const creatorForSheet = (creator: string) => {
-    return userStore.getUserByIdentifier(creator)?.title ?? creator;
+    return worksheetCreatorTitle ?? creator;
   };
 
   // Draft view: show X button to close the draft tab

--- a/frontend/src/react/components/task-run-log/model.test.ts
+++ b/frontend/src/react/components/task-run-log/model.test.ts
@@ -35,8 +35,11 @@ vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: () => undefined,
 }));
 
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: () => vi.fn(),
+}));
+
 vi.mock("@/store", () => ({
-  useReleaseStore: () => ({}),
   useRolloutStore: () => ({}),
 }));
 

--- a/frontend/src/react/components/task-run-log/useTaskRunLogData.ts
+++ b/frontend/src/react/components/task-run-log/useTaskRunLogData.ts
@@ -5,7 +5,8 @@ import {
   sheetServiceClientConnect,
 } from "@/connect";
 import { useVueState } from "@/react/hooks/useVueState";
-import { useReleaseStore, useRolloutStore } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { useRolloutStore } from "@/store";
 import {
   GetTaskRunLogRequestSchema,
   type Task,
@@ -156,7 +157,7 @@ export const useTaskRunLogData = (
   taskRunName?: string
 ): UseTaskRunLogDataResult => {
   const rolloutStore = useRolloutStore();
-  const releaseStore = useReleaseStore();
+  const fetchRelease = useAppStore((state) => state.fetchRelease);
 
   const [entries, setEntries] = useState<TaskRunLogEntry[]>([]);
   const [sheet, setSheet] = useState<Sheet | undefined>(undefined);
@@ -285,11 +286,10 @@ export const useTaskRunLogData = (
         return;
       }
 
-      void releaseStore
-        .fetchReleaseByName(releaseName, true)
+      void fetchRelease(releaseName, true)
         .then(async (release) => {
           const fileSheets = await Promise.all(
-            release.files
+            (release?.files ?? [])
               .filter((file) => file.sheet && file.version)
               .map(async (file) => {
                 try {
@@ -361,7 +361,7 @@ export const useTaskRunLogData = (
         });
       });
   }, [
-    releaseStore,
+    fetchRelease,
     task,
     taskRunName,
     sheetFetchTaskKey,

--- a/frontend/src/react/hooks/useAppState.ts
+++ b/frontend/src/react/hooks/useAppState.ts
@@ -278,6 +278,34 @@ export function useGroupByIdentifier(id: string) {
   return useAppStore((state) => state.getGroupByIdentifier(id));
 }
 
+export function useUserByIdentifier(identifier: string | undefined) {
+  return useAppStore((state) =>
+    identifier ? state.getUserByIdentifier(identifier) : undefined
+  );
+}
+
+export function useRoleByName(name: string | undefined) {
+  return useAppStore((state) => (name ? state.getRoleByName(name) : undefined));
+}
+
+export function useReleaseByName(name: string | undefined) {
+  return useAppStore((state) =>
+    name ? state.getReleaseByName(name) : undefined
+  );
+}
+
+export function useRevisionByName(name: string | undefined) {
+  return useAppStore((state) =>
+    name ? state.getRevisionByName(name) : undefined
+  );
+}
+
+export function useChangelogByName(name: string | undefined) {
+  return useAppStore((state) =>
+    name ? state.getChangelogByName(name) : undefined
+  );
+}
+
 export function useServiceAccount(name: string) {
   return useAppStore(useShallow((state) => state.getServiceAccount(name)));
 }

--- a/frontend/src/react/lib/project-member/utils.test.ts
+++ b/frontend/src/react/lib/project-member/utils.test.ts
@@ -8,13 +8,24 @@ const fixtures: Record<string, string[]> = {
   "roles/queryOnly": ["bb.sql.select"],
   "roles/projectViewer": [],
 };
-vi.mock("@/store", () => ({
-  useRoleStore: () => ({
-    getRoleByName: (role: string) =>
-      fixtures[role] === undefined
-        ? undefined
-        : { name: role, permissions: fixtures[role] },
-  }),
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        getRoleByName: (role: string) =>
+          fixtures[role] === undefined
+            ? undefined
+            : { name: role, permissions: fixtures[role] },
+      }),
+    {
+      getState: () => ({
+        getRoleByName: (role: string) =>
+          fixtures[role] === undefined
+            ? undefined
+            : { name: role, permissions: fixtures[role] },
+      }),
+    }
+  ),
 }));
 vi.mock("@/utils", () => ({
   displayRoleTitle: (r: string) => r,

--- a/frontend/src/react/lib/project-member/utils.ts
+++ b/frontend/src/react/lib/project-member/utils.ts
@@ -1,9 +1,12 @@
-import { useRoleStore } from "@/store";
+import { displayRoleTitleFromList } from "@/react/lib/role";
+import { useAppStore } from "@/react/stores/app";
 import type { Binding } from "@/types/proto-es/v1/iam_policy_pb";
-import { checkRoleContainsAnyPermission, displayRoleTitle } from "@/utils";
+import { checkRoleContainsAnyPermission } from "@/utils";
 
 export const getBindingIdentifier = (binding: Binding): string => {
-  const identifier = [displayRoleTitle(binding.role)];
+  const identifier = [
+    displayRoleTitleFromList(binding.role, useAppStore.getState().roleList),
+  ];
   if (binding.condition && binding.condition.expression) {
     identifier.push(binding.condition.expression);
   }
@@ -30,7 +33,7 @@ export type EnvLimitationKind = "DDL" | "DML" | "DDL/DML";
 export const getRoleEnvironmentLimitationKind = (
   role: string
 ): EnvLimitationKind | undefined => {
-  const r = useRoleStore().getRoleByName(role);
+  const r = useAppStore.getState().getRoleByName(role);
   if (!r) return undefined;
   const perms = new Set(r.permissions);
   const hasDDL = perms.has("bb.sql.ddl");

--- a/frontend/src/react/lib/role.ts
+++ b/frontend/src/react/lib/role.ts
@@ -1,0 +1,82 @@
+import { t } from "@/plugins/i18n";
+import type { Role } from "@/types/proto-es/v1/role_service_pb";
+
+const PresetRoleType = {
+  WORKSPACE_ADMIN: "roles/workspaceAdmin",
+  WORKSPACE_DBA: "roles/workspaceDBA",
+  WORKSPACE_MEMBER: "roles/workspaceMember",
+  PROJECT_OWNER: "roles/projectOwner",
+  PROJECT_DEVELOPER: "roles/projectDeveloper",
+  SQL_EDITOR_USER: "roles/sqlEditorUser",
+  SQL_EDITOR_READ_USER: "roles/sqlEditorReadUser",
+  PROJECT_RELEASER: "roles/projectReleaser",
+  GITOPS_SERVICE_AGENT: "roles/gitopsServiceAgent",
+  PROJECT_VIEWER: "roles/projectViewer",
+} as const;
+
+const PRESET_ROLES: string[] = Object.values(PresetRoleType);
+
+const PRESET_ROLE_TITLE_KEYS: Record<string, string> = {
+  [PresetRoleType.WORKSPACE_ADMIN]: "role.workspace-admin.self",
+  [PresetRoleType.WORKSPACE_DBA]: "role.workspace-dba.self",
+  [PresetRoleType.WORKSPACE_MEMBER]: "role.workspace-member.self",
+  [PresetRoleType.PROJECT_OWNER]: "role.project-owner.self",
+  [PresetRoleType.PROJECT_DEVELOPER]: "role.project-developer.self",
+  [PresetRoleType.PROJECT_RELEASER]: "role.project-releaser.self",
+  [PresetRoleType.SQL_EDITOR_USER]: "role.sql-editor-user.self",
+  [PresetRoleType.SQL_EDITOR_READ_USER]: "role.sql-editor-read-user.self",
+  [PresetRoleType.GITOPS_SERVICE_AGENT]: "role.gitops-service-agent.self",
+  [PresetRoleType.PROJECT_VIEWER]: "role.project-viewer.self",
+};
+
+const PRESET_ROLE_DESCRIPTION_KEYS: Record<string, string> = {
+  [PresetRoleType.WORKSPACE_ADMIN]: "role.workspace-admin.description",
+  [PresetRoleType.WORKSPACE_DBA]: "role.workspace-dba.description",
+  [PresetRoleType.WORKSPACE_MEMBER]: "role.workspace-member.description",
+  [PresetRoleType.PROJECT_OWNER]: "role.project-owner.description",
+  [PresetRoleType.PROJECT_DEVELOPER]: "role.project-developer.description",
+  [PresetRoleType.PROJECT_RELEASER]: "role.project-releaser.description",
+  [PresetRoleType.SQL_EDITOR_USER]: "role.sql-editor-user.description",
+  [PresetRoleType.SQL_EDITOR_READ_USER]:
+    "role.sql-editor-read-user.description",
+  [PresetRoleType.GITOPS_SERVICE_AGENT]:
+    "role.gitops-service-agent.description",
+  [PresetRoleType.PROJECT_VIEWER]: "role.project-viewer.description",
+};
+
+const extractRoleResourceName = (resourceId: string): string => {
+  const pattern = /(?:^|\/)roles\/([^/]+)(?:$|\/)/;
+  const matches = resourceId.match(pattern);
+  return matches?.[1] ?? "";
+};
+
+const displayPresetRoleTitle = (roleName: string): string => {
+  const key = PRESET_ROLE_TITLE_KEYS[roleName];
+  return key ? t(key) : roleName;
+};
+
+const displayPresetRoleDescription = (roleName: string): string => {
+  const key = PRESET_ROLE_DESCRIPTION_KEYS[roleName];
+  return key ? t(key) : roleName;
+};
+
+export const displayRoleTitleFromList = (
+  roleName: string,
+  roleList: Role[]
+) => {
+  if (PRESET_ROLES.includes(roleName)) {
+    return displayPresetRoleTitle(roleName);
+  }
+  const role = roleList.find((role) => role.name === roleName);
+  return role?.title || extractRoleResourceName(roleName) || roleName;
+};
+
+export const displayRoleDescriptionFromList = (
+  roleName: string,
+  roleList: Role[]
+) => {
+  if (PRESET_ROLES.includes(roleName)) {
+    return displayPresetRoleDescription(roleName);
+  }
+  return roleList.find((role) => role.name === roleName)?.description;
+};

--- a/frontend/src/react/no-legacy-vue-deps.test.ts
+++ b/frontend/src/react/no-legacy-vue-deps.test.ts
@@ -138,4 +138,30 @@ describe("React Project and Settings legacy Vue dependencies", () => {
     }
     expect(violations).toEqual([]);
   });
+
+  test("Phase 2 protobuf resource consumers use the React app store", () => {
+    const bannedImports = [
+      "useUserStore",
+      "useRoleStore",
+      "useReleaseStore",
+      "useRevisionStore",
+      "useChangelogStore",
+      "useProjectWebhookV1Store",
+      "@/store/modules/user",
+      "@/store/modules/role",
+      "@/store/modules/release",
+      "@/store/modules/revision",
+      "@/store/modules/v1/changelog",
+      "@/store/modules/v1/projectWebhook",
+    ];
+    const violations: string[] = [];
+    for (const [file, source] of Object.entries(sources)) {
+      for (const bannedImport of bannedImports) {
+        if (source.includes(bannedImport)) {
+          violations.push(`${file}: ${bannedImport}`);
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
 });

--- a/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
@@ -23,7 +23,7 @@ const mocks = vi.hoisted(() => ({
     login: vi.fn(async () => {}),
   })),
   useCurrentUserV1: vi.fn(() => ({ value: { name: "users/1", email: "u@e" } })),
-  useUserStore: vi.fn(() => ({ updateUser: vi.fn() })),
+  updateUser: vi.fn(),
   pushNotification: vi.fn(),
   routerReplace: vi.fn(),
   routerPush: vi.fn(),
@@ -43,8 +43,21 @@ vi.mock("@/store", () => ({
   useActuatorV1Store: mocks.useActuatorV1Store,
   useAuthStore: mocks.useAuthStore,
   useCurrentUserV1: mocks.useCurrentUserV1,
-  useUserStore: mocks.useUserStore,
   pushNotification: mocks.pushNotification,
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        updateUser: mocks.updateUser,
+      }),
+    {
+      getState: () => ({
+        updateUser: mocks.updateUser,
+      }),
+    }
+  ),
 }));
 
 vi.mock("@/router", () => ({

--- a/frontend/src/react/pages/auth/PasswordResetPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { OtpInput } from "@/react/components/ui/otp-input";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_SIGNIN_MODULE } from "@/router/auth";
 import {
@@ -17,7 +18,6 @@ import {
   useActuatorV1Store,
   useAuthStore,
   useCurrentUserV1,
-  useUserStore,
 } from "@/store";
 import {
   LoginRequestSchema,
@@ -157,7 +157,7 @@ export function PasswordResetPage() {
     // Forced-reset mode
     if (!currentUser) return;
     const patch = { ...currentUser, password };
-    await useUserStore().updateUser(
+    await useAppStore.getState().updateUser(
       create(UpdateUserRequestSchema, {
         user: patch,
         updateMask: create(FieldMaskSchema, { paths: ["password"] }),

--- a/frontend/src/react/pages/auth/ProfileSetupPage.tsx
+++ b/frontend/src/react/pages/auth/ProfileSetupPage.tsx
@@ -6,11 +6,11 @@ import { UserAvatar } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import {
   pushNotification,
   useCurrentUserV1,
-  useUserStore,
   useWorkspaceV1Store,
 } from "@/store";
 import { UpdateUserRequestSchema } from "@/types/proto-es/v1/user_service_pb";
@@ -20,7 +20,7 @@ import { hasWorkspacePermissionV2 } from "@/utils";
 export function ProfileSetupPage() {
   const { t } = useTranslation();
   const currentUser = useVueState(() => useCurrentUserV1().value);
-  const userStore = useUserStore();
+  const updateUser = useAppStore((state) => state.updateUser);
   const workspaceStore = useWorkspaceV1Store();
   const workspace = useVueState(() => workspaceStore.currentWorkspace);
   const workspacePolicy = useVueState(() => workspaceStore.workspaceIamPolicy);
@@ -47,7 +47,7 @@ export function ProfileSetupPage() {
     if (!currentUser?.name || !name.trim()) return;
     setSaving(true);
     try {
-      await userStore.updateUser(
+      await updateUser(
         create(UpdateUserRequestSchema, {
           user: { name: currentUser.name, title: name.trim() },
           updateMask: create(FieldMaskSchema, { paths: ["title"] }),

--- a/frontend/src/react/pages/auth/SetupPage.test.tsx
+++ b/frontend/src/react/pages/auth/SetupPage.test.tsx
@@ -11,7 +11,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   routerIsReady: vi.fn(async () => {}),
   routerPush: vi.fn(),
-  fetchRoleList: vi.fn(async () => {}),
+  listRoles: vi.fn(async () => {}),
   fetchIamPolicy: vi.fn(async () => {}),
   getOrFetchProjectByName: vi.fn(async () => {
     throw new ConnectError("not found", Code.NotFound);
@@ -43,15 +43,26 @@ vi.mock("@/store", () => ({
     getOrFetchProjectByName: mocks.getOrFetchProjectByName,
     createProject: mocks.createProject,
   }),
-  useRoleStore: () => ({
-    fetchRoleList: mocks.fetchRoleList,
-  }),
   useSettingV1Store: () => ({
     updateWorkspaceProfile: mocks.updateWorkspaceProfile,
   }),
   useWorkspaceV1Store: () => ({
     fetchIamPolicy: mocks.fetchIamPolicy,
   }),
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        listRoles: mocks.listRoles,
+      }),
+    {
+      getState: () => ({
+        listRoles: mocks.listRoles,
+      }),
+    }
+  ),
 }));
 
 vi.mock("@/react/hooks/useVueState", () => ({

--- a/frontend/src/react/pages/auth/SetupPage.tsx
+++ b/frontend/src/react/pages/auth/SetupPage.tsx
@@ -14,13 +14,13 @@ import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { SQL_EDITOR_HOME_MODULE } from "@/router/sqlEditor";
 import {
   useActuatorV1Store,
   useAppFeature,
   useProjectV1Store,
-  useRoleStore,
   useSettingV1Store,
   useWorkspaceV1Store,
 } from "@/store";
@@ -56,7 +56,7 @@ export function SetupPage() {
       await router.isReady();
       try {
         await Promise.all([
-          useRoleStore().fetchRoleList(),
+          useAppStore.getState().listRoles(),
           useWorkspaceV1Store().fetchIamPolicy(),
         ]);
       } catch (error) {

--- a/frontend/src/react/pages/project/DatabaseChangelogDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/DatabaseChangelogDetailPage.test.tsx
@@ -40,7 +40,7 @@ const mocks = vi.hoisted(() => {
     getOrFetchChangelogByName: vi.fn(),
     fetchPreviousChangelog: vi.fn(),
     getChangelogByName: vi.fn(),
-    useChangelogStore: vi.fn(),
+    useAppStore: vi.fn(),
     getTaskRunLog: vi.fn(),
     useVueState: vi.fn((getter: () => unknown) => getter()),
     clipboardWriteText,
@@ -165,9 +165,12 @@ vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: mocks.useVueState,
 }));
 
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
 vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
-  useChangelogStore: mocks.useChangelogStore,
 }));
 
 vi.mock("@/connect", () => ({
@@ -244,7 +247,7 @@ beforeEach(() => {
   mocks.getOrFetchChangelogByName.mockReset();
   mocks.fetchPreviousChangelog.mockReset();
   mocks.getChangelogByName.mockReset();
-  mocks.useChangelogStore.mockReset();
+  mocks.useAppStore.mockReset();
   mocks.getTaskRunLog.mockReset();
   mocks.pushNotification.mockReset();
   mocks.useVueState.mockImplementation((getter: () => unknown) => getter());
@@ -293,11 +296,13 @@ beforeEach(() => {
     }
     return undefined;
   });
-  mocks.useChangelogStore.mockReturnValue({
-    getOrFetchChangelogByName: mocks.getOrFetchChangelogByName,
-    fetchPreviousChangelog: mocks.fetchPreviousChangelog,
-    getChangelogByName: mocks.getChangelogByName,
-  });
+  mocks.useAppStore.mockImplementation((selector) =>
+    selector({
+      getOrFetchChangelogByName: mocks.getOrFetchChangelogByName,
+      fetchPreviousChangelog: mocks.fetchPreviousChangelog,
+      getChangelogByName: mocks.getChangelogByName,
+    })
+  );
   mocks.getTaskRunLog.mockResolvedValue({
     entries: [
       {

--- a/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
+++ b/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
@@ -7,7 +7,7 @@ import { ReadonlyDiffMonaco, ReadonlyMonaco } from "@/react/components/monaco";
 import { TaskRunLogViewer } from "@/react/components/task-run-log";
 import { Button } from "@/react/components/ui/button";
 import { Switch } from "@/react/components/ui/switch";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import {
   PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL,
@@ -15,7 +15,7 @@ import {
   PROJECT_V1_ROUTE_DATABASES,
   PROJECT_V1_ROUTE_SYNC_SCHEMA,
 } from "@/router/dashboard/projectV1";
-import { pushNotification, useChangelogStore } from "@/store";
+import { pushNotification } from "@/store";
 import { getTimeForPbTimestampProtoEs } from "@/types";
 import type { Changelog } from "@/types/proto-es/v1/database_service_pb";
 import {
@@ -200,7 +200,12 @@ export function DatabaseChangelogDetailPage({
   changelogId,
 }: DatabaseChangelogDetailPageProps) {
   const { t } = useTranslation();
-  const changelogStore = useChangelogStore();
+  const getOrFetchChangelogByName = useAppStore(
+    (state) => state.getOrFetchChangelogByName
+  );
+  const fetchPreviousChangelog = useAppStore(
+    (state) => state.fetchPreviousChangelog
+  );
   const [loading, setLoading] = useState(true);
   const [showDiff, setShowDiff] = useState(true);
   const [resolvedChangelog, setResolvedChangelog] = useState<Changelog>();
@@ -222,8 +227,8 @@ export function DatabaseChangelogDetailPage({
   });
   const changelogName = `${detail.databaseName}/changelogs/${changelogId}`;
 
-  const changelog = useVueState(() =>
-    changelogStore.getChangelogByName(changelogName, ChangelogView.FULL)
+  const changelog = useAppStore((state) =>
+    state.getChangelogByName(changelogName, ChangelogView.FULL)
   );
 
   useEffect(() => {
@@ -247,11 +252,8 @@ export function DatabaseChangelogDetailPage({
     setHasTaskRunDatabaseSync(undefined);
 
     void Promise.all([
-      changelogStore.getOrFetchChangelogByName(
-        changelogName,
-        ChangelogView.FULL
-      ),
-      changelogStore.fetchPreviousChangelog(changelogName),
+      getOrFetchChangelogByName(changelogName, ChangelogView.FULL),
+      fetchPreviousChangelog(changelogName),
     ])
       .then(([current, previous]) => {
         if (cancelled) {
@@ -278,7 +280,12 @@ export function DatabaseChangelogDetailPage({
     return () => {
       cancelled = true;
     };
-  }, [changelogName, changelogStore, detail.ready]);
+  }, [
+    changelogName,
+    detail.ready,
+    fetchPreviousChangelog,
+    getOrFetchChangelogByName,
+  ]);
 
   useEffect(() => {
     let cancelled = false;

--- a/frontend/src/react/pages/project/ProjectAccessGrantsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectAccessGrantsPage.tsx
@@ -41,7 +41,6 @@ import {
   useCurrentUserV1,
   useDatabaseV1Store,
   useProjectV1Store,
-  useUserStore,
 } from "@/store";
 import { extractUserEmail, projectNamePrefix } from "@/store/modules/v1/common";
 import { getTimeForPbTimestampProtoEs } from "@/types";
@@ -114,7 +113,7 @@ export function ProjectAccessGrantsPage({ projectId }: { projectId: string }) {
   const { t } = useTranslation();
   const projectStore = useProjectV1Store();
   const databaseStore = useDatabaseV1Store();
-  const userStore = useUserStore();
+  const listUsers = useAppStore((state) => state.listUsers);
   const listAccessGrants = useAppStore((state) => state.listAccessGrants);
   const activateAccessGrant = useAppStore((state) => state.activateAccessGrant);
   const revokeAccessGrant = useAppStore((state) => state.revokeAccessGrant);
@@ -202,7 +201,7 @@ export function ProjectAccessGrantsPage({ projectId }: { projectId: string }) {
   // Server-side search for creator filter options
   const searchUsers = useCallback(
     async (keyword: string): Promise<ValueOption[]> => {
-      const result = await userStore.fetchUserList({
+      const result = await listUsers({
         pageSize: getDefaultPagination(),
         filter: keyword ? { query: keyword } : undefined,
       });
@@ -231,7 +230,7 @@ export function ProjectAccessGrantsPage({ projectId }: { projectId: string }) {
         ),
       }));
     },
-    [userStore, currentUser, t]
+    [listUsers, currentUser, t]
   );
 
   const scopeOptions: ScopeOption[] = useMemo(

--- a/frontend/src/react/pages/project/ProjectDataExportPage.creators.test.ts
+++ b/frontend/src/react/pages/project/ProjectDataExportPage.creators.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+
+import source from "./ProjectDataExportPage.tsx?raw";
+
+describe("data export issue list creator cache", () => {
+  test("fetches listed issue creators before rendering fallback names", () => {
+    expect(source).toMatch(
+      /const batchGetOrFetchUsers = useAppStore\(\s*\(state\) => state\.batchGetOrFetchUsers\s*\)/
+    );
+    expect(source).toMatch(
+      /batchGetOrFetchUsers\(paged\.dataList\.map\(\(issue\) => issue\.creator\)\)/
+    );
+  });
+});

--- a/frontend/src/react/pages/project/ProjectDataExportPage.tsx
+++ b/frontend/src/react/pages/project/ProjectDataExportPage.tsx
@@ -49,6 +49,9 @@ export function ProjectDataExportPage({ projectId }: { projectId: string }) {
   const { t } = useTranslation();
   const issueStore = useIssueV1Store();
   const projectStore = useProjectV1Store();
+  const batchGetOrFetchUsers = useAppStore(
+    (state) => state.batchGetOrFetchUsers
+  );
 
   const projectName = `${projectNamePrefix}${projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));
@@ -204,6 +207,13 @@ export function ProjectDataExportPage({ projectId }: { projectId: string }) {
     sessionKey: "export-center",
     fetchList: fetchIssueList,
   });
+
+  useEffect(() => {
+    if (paged.dataList.length === 0) {
+      return;
+    }
+    void batchGetOrFetchUsers(paged.dataList.map((issue) => issue.creator));
+  }, [batchGetOrFetchUsers, paged.dataList]);
 
   return (
     <div className="py-4 w-full flex flex-col">

--- a/frontend/src/react/pages/project/ProjectDataExportPage.tsx
+++ b/frontend/src/react/pages/project/ProjectDataExportPage.tsx
@@ -13,6 +13,8 @@ import { Button } from "@/react/components/ui/button";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
+import { displayRoleTitleFromList } from "@/react/lib/role";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { WORKSPACE_ROUTE_USER_PROFILE } from "@/router/dashboard/workspaceRoutes";
 import {
@@ -20,7 +22,6 @@ import {
   useInstanceV1Store,
   useIssueV1Store,
   useProjectV1Store,
-  useUserStore,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { getTimeForPbTimestampProtoEs, unknownUser } from "@/types";
@@ -29,7 +30,6 @@ import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
 import { Issue_Type, IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import {
   buildIssueFilterBySearchParams,
-  displayRoleTitle,
   extractDatabaseResourceName,
   extractInstanceResourceName,
   extractIssueUID,
@@ -364,6 +364,7 @@ function RiskLevelIcon({ riskLevel }: { riskLevel: RiskLevel }) {
 
 function IssueApprovalStatusTag({ issue }: { issue: Issue }) {
   const { t } = useTranslation();
+  const roleList = useAppStore((state) => state.roleList);
   const approvalSteps = issue.approvalTemplate?.flow?.roles ?? [];
 
   if (issue.approvalStatus === ApprovalStatus.CHECKING) {
@@ -408,7 +409,7 @@ function IssueApprovalStatusTag({ issue }: { issue: Issue }) {
     if (status === ApprovalStatus.PENDING) {
       const currentRoleIndex = issue.approvers.length;
       const role = approvalSteps[currentRoleIndex];
-      const roleName = role ? displayRoleTitle(role) : "";
+      const roleName = role ? displayRoleTitleFromList(role, roleList) : "";
       return (
         <div className="shrink-0 flex flex-row sm:flex-col items-center sm:items-end gap-x-1.5 sm:gap-x-0 mt-1">
           <span className="inline-flex items-center rounded-full bg-control-bg px-2 py-0.5 text-xs text-control-light">
@@ -444,11 +445,12 @@ function IssueListItem({
   highlightText?: string;
 }) {
   const { t } = useTranslation();
-  const userStore = useUserStore();
   const projectStore = useProjectV1Store();
 
-  const creator =
-    userStore.getUserByIdentifier(issue.creator) || unknownUser(issue.creator);
+  const creatorUser = useAppStore((state) =>
+    state.getUserByIdentifier(issue.creator)
+  );
+  const creator = creatorUser || unknownUser(issue.creator);
 
   const issueProject = useVueState(() =>
     projectStore.getProjectByName(

--- a/frontend/src/react/pages/project/ProjectIssueDashboardPage.creators.test.ts
+++ b/frontend/src/react/pages/project/ProjectIssueDashboardPage.creators.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+
+import source from "./ProjectIssueDashboardPage.tsx?raw";
+
+describe("project issue list creator cache", () => {
+  test("fetches listed issue creators before rendering fallback names", () => {
+    expect(source).toMatch(
+      /const batchGetOrFetchUsers = useAppStore\(\s*\(state\) => state\.batchGetOrFetchUsers\s*\)/
+    );
+    expect(source).toMatch(
+      /batchGetOrFetchUsers\(paged\.dataList\.map\(\(issue\) => issue\.creator\)\)/
+    );
+  });
+});

--- a/frontend/src/react/pages/project/ProjectIssueDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectIssueDashboardPage.tsx
@@ -13,6 +13,7 @@ import {
 import { Alert } from "@/react/components/ui/alert";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import {
   refreshIssueList,
@@ -42,6 +43,9 @@ export function ProjectIssueDashboardPage({
   const issueStore = useIssueV1Store();
   const uiStateStore = useUIStateStore();
   const currentUser = useCurrentUserV1();
+  const batchGetOrFetchUsers = useAppStore(
+    (state) => state.batchGetOrFetchUsers
+  );
   const me = useVueState(() => currentUser.value);
 
   const projectName = `${projectNamePrefix}${projectId}`;
@@ -174,6 +178,13 @@ export function ProjectIssueDashboardPage({
     sessionKey: "bb.issue-table.project-issues",
     fetchList: fetchIssueList,
   });
+
+  useEffect(() => {
+    if (paged.dataList.length === 0) {
+      return;
+    }
+    void batchGetOrFetchUsers(paged.dataList.map((issue) => issue.creator));
+  }, [batchGetOrFetchUsers, paged.dataList]);
 
   // Scope options
   const scopeOptions = useIssueSearchScopeOptions(projectName);

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
@@ -56,7 +56,6 @@ import {
   usePolicyV1Store,
   useProjectV1Store,
   useSettingV1Store,
-  useUserStore,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import type { DatabaseResource } from "@/types";
@@ -99,7 +98,7 @@ export function ProjectMaskingExemptionPage({
   const { t } = useTranslation();
   const projectStore = useProjectV1Store();
   const databaseStore = useDatabaseV1Store();
-  const userStore = useUserStore();
+  const listUsers = useAppStore((state) => state.listUsers);
   const currentUser = useVueState(() => useCurrentUserV1().value);
 
   const projectName = `${projectNamePrefix}${projectId}`;
@@ -303,7 +302,7 @@ export function ProjectMaskingExemptionPage({
 
   const searchUsers = useCallback(
     async (keyword: string): Promise<ValueOption[]> => {
-      const result = await userStore.fetchUserList({
+      const result = await listUsers({
         pageSize: getDefaultPagination(),
         filter: keyword ? { query: keyword } : undefined,
       });
@@ -332,7 +331,7 @@ export function ProjectMaskingExemptionPage({
         ),
       }));
     },
-    [userStore, currentUser, t]
+    [listUsers, currentUser, t]
   );
 
   const scopeOptions: ScopeOption[] = useMemo(

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.columns.test.ts
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.columns.test.ts
@@ -74,4 +74,13 @@ describe("plan list column composition", () => {
     expect(source).not.toContain("checkSummary");
     expect(source).not.toContain("hasAnyCheck");
   });
+
+  test("plan row creators are fetched before rendering fallback names", () => {
+    expect(source).toMatch(
+      /const batchGetOrFetchUsers = useAppStore\(\s*\(state\) => state\.batchGetOrFetchUsers\s*\)/
+    );
+    expect(source).toMatch(
+      /batchGetOrFetchUsers\(paged\.dataList\.map\(\(plan\) => plan\.creator\)\)/
+    );
+  });
 });

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -51,6 +51,7 @@ import { useSessionPageSize } from "@/react/hooks/useSessionPageSize";
 import { useVueState } from "@/react/hooks/useVueState";
 import { applyPlanTitleToQuery } from "@/react/lib/plan/title";
 import { cn } from "@/react/lib/utils";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import {
   PROJECT_V1_ROUTE_PLAN_DETAIL,
@@ -64,7 +65,6 @@ import {
   useEnvironmentV1Store,
   useProjectV1Store,
   useUIStateStore,
-  useUserStore,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import {
@@ -124,7 +124,7 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
   const { t } = useTranslation();
   const planStore = usePlanStore();
   const projectStore = useProjectV1Store();
-  const userStore = useUserStore();
+  const listUsers = useAppStore((state) => state.listUsers);
   const uiStateStore = useUIStateStore();
   const currentUser = useCurrentUserV1();
 
@@ -187,7 +187,7 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
         title: t("issue.advanced-search.scope.creator.title"),
         description: t("issue.advanced-search.scope.creator.description"),
         onSearch: async (keyword: string) => {
-          const resp = await userStore.fetchUserList({
+          const resp = await listUsers({
             pageSize: getDefaultPagination(),
             filter: { query: keyword },
           });
@@ -208,7 +208,7 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
         },
       },
     ],
-    [t, userStore, me]
+    [t, listUsers, me]
   );
 
   const [canCreate] = usePermissionCheck(["bb.plans.create"], project);
@@ -570,15 +570,16 @@ function PlanRow({
   projectId: string;
   columns: PlanColumn[];
 }>) {
-  const userStore = useUserStore();
   const environmentStore = useEnvironmentV1Store();
   const { t } = useTranslation();
 
   const isDeleted = plan.state === State.DELETED;
   const showDraftTag = plan.issue === "" && !plan.hasRollout;
 
-  const creator =
-    userStore.getUserByIdentifier(plan.creator) || unknownUser(plan.creator);
+  const creatorUser = useAppStore((state) =>
+    state.getUserByIdentifier(plan.creator)
+  );
+  const creator = creatorUser || unknownUser(plan.creator);
 
   const updateTimeTs = Math.floor(
     getTimeForPbTimestampProtoEs(plan.updateTime, 0) / 1000

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -125,6 +125,9 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
   const planStore = usePlanStore();
   const projectStore = useProjectV1Store();
   const listUsers = useAppStore((state) => state.listUsers);
+  const batchGetOrFetchUsers = useAppStore(
+    (state) => state.batchGetOrFetchUsers
+  );
   const uiStateStore = useUIStateStore();
   const currentUser = useCurrentUserV1();
 
@@ -243,6 +246,13 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
     sessionKey: `bb.${projectName}.plan-table`,
     fetchList: fetchPlanList,
   });
+
+  useEffect(() => {
+    if (paged.dataList.length === 0) {
+      return;
+    }
+    void batchGetOrFetchUsers(paged.dataList.map((plan) => plan.creator));
+  }, [batchGetOrFetchUsers, paged.dataList]);
 
   // Handle spec created from AddSpecDrawer
   const handleSpecCreated = useCallback(

--- a/frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectReleaseDashboardPage.tsx
@@ -17,8 +17,8 @@ import {
 } from "@/react/components/ui/table";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { cn } from "@/react/lib/utils";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import { useReleaseStore } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { getTimeForPbTimestampProtoEs } from "@/types";
 import { State } from "@/types/proto-es/v1/common_pb";
@@ -34,7 +34,9 @@ export function ProjectReleaseDashboardPage({
   projectId: string;
 }) {
   const { t } = useTranslation();
-  const releaseStore = useReleaseStore();
+  const listReleasesByProject = useAppStore(
+    (state) => state.listReleasesByProject
+  );
   const projectName = `${projectNamePrefix}${projectId}`;
 
   // Category filter from URL
@@ -76,16 +78,15 @@ export function ProjectReleaseDashboardPage({
   const fetchReleaseList = useCallback(
     async (params: { pageSize: number; pageToken: string }) => {
       const filter = buildCategoryFilter(selectedCategory);
-      const { nextPageToken, releases } =
-        await releaseStore.fetchReleasesByProject(
-          projectName,
-          { pageSize: params.pageSize, pageToken: params.pageToken },
-          false,
-          filter
-        );
+      const { nextPageToken, releases } = await listReleasesByProject(
+        projectName,
+        { pageSize: params.pageSize, pageToken: params.pageToken },
+        false,
+        filter
+      );
       return { list: releases, nextPageToken };
     },
-    [releaseStore, projectName, selectedCategory]
+    [listReleasesByProject, projectName, selectedCategory]
   );
 
   const paged = usePagedData<Release>({

--- a/frontend/src/react/pages/project/ProjectReleaseDetailPage.tsx
+++ b/frontend/src/react/pages/project/ProjectReleaseDetailPage.tsx
@@ -26,7 +26,8 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { useVueState } from "@/react/hooks/useVueState";
-import { pushNotification, useProjectV1Store, useReleaseStore } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification, useProjectV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { getTimeForPbTimestampProtoEs } from "@/types";
 import { State, VCSType } from "@/types/proto-es/v1/common_pb";
@@ -41,13 +42,15 @@ export function ProjectReleaseDetailPage({
   releaseId: string;
 }) {
   const { t } = useTranslation();
-  const releaseStore = useReleaseStore();
+  const fetchRelease = useAppStore((state) => state.fetchRelease);
+  const deleteRelease = useAppStore((state) => state.deleteRelease);
+  const undeleteRelease = useAppStore((state) => state.undeleteRelease);
   const projectV1Store = useProjectV1Store();
 
   const projectName = `${projectNamePrefix}${projectId}`;
   const releaseName = `${projectName}/releases/${releaseId}`;
 
-  const release = useVueState(() => releaseStore.getReleaseByName(releaseName));
+  const release = useAppStore((state) => state.getReleaseByName(releaseName));
   const project = useVueState(() =>
     projectV1Store.getProjectByName(projectName)
   );
@@ -57,13 +60,13 @@ export function ProjectReleaseDetailPage({
     void projectV1Store.getOrFetchProjectByName(projectName).catch((error) => {
       if (!cancelled) console.error("Failed to fetch project", error);
     });
-    void releaseStore.fetchReleaseByName(releaseName).catch((error) => {
+    void fetchRelease(releaseName).catch((error) => {
       if (!cancelled) console.error("Failed to fetch release", error);
     });
     return () => {
       cancelled = true;
     };
-  }, [projectV1Store, releaseStore, projectName, releaseName]);
+  }, [projectV1Store, fetchRelease, projectName, releaseName]);
 
   useEffect(() => {
     if (project?.title) {
@@ -86,7 +89,7 @@ export function ProjectReleaseDetailPage({
 
   const handleArchive = async () => {
     try {
-      await releaseStore.deleteRelease(release.name);
+      await deleteRelease(release.name);
     } catch (error) {
       pushNotification({
         module: "bytebase",
@@ -101,7 +104,7 @@ export function ProjectReleaseDetailPage({
 
   const handleRestore = async () => {
     try {
-      await releaseStore.undeleteRelease(release.name);
+      await undeleteRelease(release.name);
     } catch (error) {
       pushNotification({
         module: "bytebase",

--- a/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
@@ -47,11 +47,11 @@ import { useEscapeKey } from "@/react/hooks/useEscapeKey";
 import { useVueState } from "@/react/hooks/useVueState";
 import { applyPlanTitleToQuery } from "@/react/lib/plan/title";
 import { cn } from "@/react/lib/utils";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL } from "@/router/dashboard/projectV1";
 import {
   pushNotification,
-  useChangelogStore,
   useDatabaseV1Store,
   useEnvironmentV1Store,
   useProjectV1Store,
@@ -137,7 +137,12 @@ enum Step {
 
 export function ProjectSyncSchemaPage({ projectId }: { projectId: string }) {
   const { t } = useTranslation();
-  const changelogStore = useChangelogStore();
+  const getOrFetchChangelogByName = useAppStore(
+    (state) => state.getOrFetchChangelogByName
+  );
+  const fetchPreviousChangelog = useAppStore(
+    (state) => state.fetchPreviousChangelog
+  );
   const databaseStore = useDatabaseV1Store();
   const projectStore = useProjectV1Store();
 
@@ -225,7 +230,7 @@ export function ProjectSyncSchemaPage({ projectId }: { projectId: string }) {
       try {
         if (sourceSchemaType === SourceSchemaType.SCHEMA_HISTORY_VERSION) {
           if (isValidChangelogName(changelogSource.changelogName)) {
-            const changelog = await changelogStore.getOrFetchChangelogByName(
+            const changelog = await getOrFetchChangelogByName(
               changelogSource.changelogName || "",
               ChangelogView.FULL
             );
@@ -255,6 +260,7 @@ export function ProjectSyncSchemaPage({ projectId }: { projectId: string }) {
     changelogSource.changelogName,
     changelogSource.databaseName,
     rawSQLState.statement,
+    getOrFetchChangelogByName,
   ]);
 
   const sourceEngine = useMemo(() => {
@@ -279,7 +285,7 @@ export function ProjectSyncSchemaPage({ projectId }: { projectId: string }) {
 
       if (isValidChangelogName(changelogName)) {
         // Validate the changelog exists before proceeding.
-        const existing = await changelogStore.getOrFetchChangelogByName(
+        const existing = await getOrFetchChangelogByName(
           changelogName,
           ChangelogView.BASIC
         );
@@ -289,8 +295,7 @@ export function ProjectSyncSchemaPage({ projectId }: { projectId: string }) {
         let targetChangelogName: string | undefined = undefined;
 
         if (isRollback) {
-          const previousChangelog =
-            await changelogStore.fetchPreviousChangelog(changelogName);
+          const previousChangelog = await fetchPreviousChangelog(changelogName);
           if (cancelled) return;
           if (previousChangelog) {
             targetChangelogName = previousChangelog.name;
@@ -318,7 +323,12 @@ export function ProjectSyncSchemaPage({ projectId }: { projectId: string }) {
     return () => {
       cancelled = true;
     };
-  }, [projectId]);
+  }, [
+    databaseStore,
+    fetchPreviousChangelog,
+    getOrFetchChangelogByName,
+    projectId,
+  ]);
 
   const stepList = useMemo(
     () => [
@@ -747,7 +757,7 @@ function ChangelogSelector({
   onChange: (value: string) => void;
 }) {
   const { t } = useTranslation();
-  const changelogStore = useChangelogStore();
+  const listChangelogs = useAppStore((state) => state.listChangelogs);
   const databaseStore = useDatabaseV1Store();
   const [entries, setEntries] = useState<ChangelogEntry[]>([]);
   const [nextPageToken, setNextPageToken] = useState("");
@@ -790,7 +800,7 @@ function ChangelogSelector({
 
     (async () => {
       const { changelogs: fetchedChangelogs, nextPageToken: token } =
-        await changelogStore.fetchChangelogList({
+        await listChangelogs({
           parent: database,
           pageSize: getDefaultPagination(),
           filter: `status == "${Changelog_Status[Changelog_Status.DONE]}"`,
@@ -818,22 +828,21 @@ function ChangelogSelector({
     return () => {
       cancelled = true;
     };
-  }, [database]);
+  }, [database, databaseStore, listChangelogs, toEntry]);
 
   const loadMore = useCallback(async () => {
     if (!nextPageToken || !isValidDatabaseName(database) || loadingMore) return;
     setLoadingMore(true);
-    const { changelogs: more, nextPageToken: token } =
-      await changelogStore.fetchChangelogList({
-        parent: database,
-        pageToken: nextPageToken,
-        pageSize: getDefaultPagination(),
-        filter: `status == "${Changelog_Status[Changelog_Status.DONE]}"`,
-      });
+    const { changelogs: more, nextPageToken: token } = await listChangelogs({
+      parent: database,
+      pageToken: nextPageToken,
+      pageSize: getDefaultPagination(),
+      filter: `status == "${Changelog_Status[Changelog_Status.DONE]}"`,
+    });
     setEntries((prev) => [...prev, ...more.map(toEntry)]);
     setNextPageToken(token);
     setLoadingMore(false);
-  }, [nextPageToken, database, loadingMore, toEntry]);
+  }, [database, listChangelogs, loadingMore, nextPageToken, toEntry]);
 
   const selectedEntry = entries.find((e) => e.name === value);
 
@@ -1168,7 +1177,9 @@ function SelectTargetDatabasesView({
   onSelectedDatabaseNameChange: (name: string | undefined) => void;
 }) {
   const { t } = useTranslation();
-  const changelogStore = useChangelogStore();
+  const getOrFetchChangelogByName = useAppStore(
+    (state) => state.getOrFetchChangelogByName
+  );
   const environmentStore = useEnvironmentV1Store();
   const databaseStore = useDatabaseV1Store();
   const [isLoadingDiff, setIsLoadingDiff] = useState(false);
@@ -1282,11 +1293,10 @@ function SelectTargetDatabasesView({
               clsRef?.targetChangelogName
             );
             if (isRollback) {
-              const previousChangelog =
-                await changelogStore.getOrFetchChangelogByName(
-                  clsRef?.targetChangelogName ?? "",
-                  ChangelogView.FULL
-                );
+              const previousChangelog = await getOrFetchChangelogByName(
+                clsRef?.targetChangelogName ?? "",
+                ChangelogView.FULL
+              );
               newSchemaCache[name] = previousChangelog?.schema ?? "";
             } else {
               const schema = await databaseStore.fetchDatabaseSchema(db.name);

--- a/frontend/src/react/pages/project/ProjectWebhookDetailPage.tsx
+++ b/frontend/src/react/pages/project/ProjectWebhookDetailPage.tsx
@@ -1,7 +1,8 @@
 import { create as createProto } from "@bufbuild/protobuf";
 import { useMemo } from "react";
 import { useVueState } from "@/react/hooks/useVueState";
-import { useProjectV1Store, useProjectWebhookV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { useProjectV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { State } from "@/types/proto-es/v1/common_pb";
 import { WebhookSchema } from "@/types/proto-es/v1/project_service_pb";
@@ -16,17 +17,16 @@ export function ProjectWebhookDetailPage({
   webhookResourceId: string;
 }) {
   const projectStore = useProjectV1Store();
-  const projectWebhookV1Store = useProjectWebhookV1Store();
+  const getProjectWebhookFromProjectById = useAppStore(
+    (state) => state.getProjectWebhookFromProjectById
+  );
   const projectName = `${projectNamePrefix}${projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));
 
-  const webhook = useVueState(() => {
+  const webhook = useMemo(() => {
     if (!project) return undefined;
-    return projectWebhookV1Store.getProjectWebhookFromProjectById(
-      project,
-      webhookResourceId
-    );
-  });
+    return getProjectWebhookFromProjectById(project, webhookResourceId);
+  }, [project, getProjectWebhookFromProjectById, webhookResourceId]);
 
   const allowEdit = useMemo(() => {
     if (!project) return false;

--- a/frontend/src/react/pages/project/ProjectWebhookForm.tsx
+++ b/frontend/src/react/pages/project/ProjectWebhookForm.tsx
@@ -20,6 +20,7 @@ import { Input } from "@/react/components/ui/input";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { WebhookTypeIcon } from "@/react/components/WebhookTypeIcon";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import {
   PROJECT_V1_ROUTE_WEBHOOK_DETAIL,
@@ -31,7 +32,6 @@ import {
   pushNotification,
   useActuatorV1Store,
   useProjectV1Store,
-  useProjectWebhookV1Store,
   useSettingV1Store,
 } from "@/store";
 import {
@@ -63,8 +63,17 @@ export function ProjectWebhookForm({
   const { t } = useTranslation();
   const settingStore = useSettingV1Store();
   const projectStore = useProjectV1Store();
-  const projectWebhookV1Store = useProjectWebhookV1Store();
   const actuatorStore = useActuatorV1Store();
+  const createProjectWebhook = useAppStore(
+    (state) => state.createProjectWebhook
+  );
+  const updateProjectWebhook = useAppStore(
+    (state) => state.updateProjectWebhook
+  );
+  const deleteProjectWebhook = useAppStore(
+    (state) => state.deleteProjectWebhook
+  );
+  const testProjectWebhook = useAppStore((state) => state.testProjectWebhook);
 
   const [state, setState] = useState<Webhook>(() =>
     clone(WebhookSchema, webhook)
@@ -208,10 +217,7 @@ export function ProjectWebhookForm({
 
   const createWebhook = useCallback(() => {
     withLoading(async () => {
-      const updatedProject = await projectWebhookV1Store.createProjectWebhook(
-        project.name,
-        state
-      );
+      const updatedProject = await createProjectWebhook(project.name, state);
       projectStore.updateProjectCache({ ...project, ...updatedProject });
       pushNotification({
         module: "bytebase",
@@ -235,7 +241,7 @@ export function ProjectWebhookForm({
         });
       }
     });
-  }, [project, state, projectStore, projectWebhookV1Store, t, withLoading]);
+  }, [project, state, projectStore, createProjectWebhook, t, withLoading]);
 
   const updateWebhook = useCallback(() => {
     withLoading(async () => {
@@ -247,10 +253,7 @@ export function ProjectWebhookForm({
       if (!isEqual(state.notificationTypes, webhook.notificationTypes))
         updateMask.push("notification_type");
 
-      const updatedProject = await projectWebhookV1Store.updateProjectWebhook(
-        state,
-        updateMask
-      );
+      const updatedProject = await updateProjectWebhook(state, updateMask);
       projectStore.updateProjectCache({ ...project, ...updatedProject });
       pushNotification({
         module: "bytebase",
@@ -265,7 +268,7 @@ export function ProjectWebhookForm({
     state,
     webhook,
     projectStore,
-    projectWebhookV1Store,
+    updateProjectWebhook,
     t,
     withLoading,
   ]);
@@ -273,8 +276,7 @@ export function ProjectWebhookForm({
   const deleteWebhook = useCallback(() => {
     withLoading(async () => {
       const name = state.title;
-      const updatedProject =
-        await projectWebhookV1Store.deleteProjectWebhook(state);
+      const updatedProject = await deleteProjectWebhook(state);
       projectStore.updateProjectCache({ ...project, ...updatedProject });
       pushNotification({
         module: "bytebase",
@@ -287,7 +289,7 @@ export function ProjectWebhookForm({
     project,
     state,
     projectStore,
-    projectWebhookV1Store,
+    deleteProjectWebhook,
     t,
     withLoading,
     cancel,
@@ -295,10 +297,7 @@ export function ProjectWebhookForm({
 
   const testWebhook = useCallback(() => {
     withLoading(async () => {
-      const result = await projectWebhookV1Store.testProjectWebhook(
-        project,
-        state
-      );
+      const result = await testProjectWebhook(project, state);
       if (result.error) {
         pushNotification({
           module: "bytebase",
@@ -315,7 +314,7 @@ export function ProjectWebhookForm({
         });
       }
     });
-  }, [project, state, projectWebhookV1Store, t, withLoading]);
+  }, [project, state, testProjectWebhook, t, withLoading]);
 
   const imSettingsUrl = useMemo(() => {
     return router.resolve({ name: WORKSPACE_ROUTE_IM }).fullPath;

--- a/frontend/src/react/pages/project/ProjectWebhooksPage.tsx
+++ b/frontend/src/react/pages/project/ProjectWebhooksPage.tsx
@@ -24,16 +24,13 @@ import {
 } from "@/react/components/ui/table";
 import { WebhookTypeIcon } from "@/react/components/WebhookTypeIcon";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import {
   PROJECT_V1_ROUTE_WEBHOOK_CREATE,
   PROJECT_V1_ROUTE_WEBHOOK_DETAIL,
 } from "@/router/dashboard/projectV1";
-import {
-  pushNotification,
-  useProjectV1Store,
-  useProjectWebhookV1Store,
-} from "@/store";
+import { pushNotification, useProjectV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { projectWebhookV1ActivityItemList } from "@/types";
 import { State } from "@/types/proto-es/v1/common_pb";
@@ -44,7 +41,9 @@ import { extractProjectWebhookID, hasProjectPermissionV2 } from "@/utils";
 export function ProjectWebhooksPage({ projectId }: { projectId: string }) {
   const { t } = useTranslation();
   const projectStore = useProjectV1Store();
-  const projectWebhookV1Store = useProjectWebhookV1Store();
+  const deleteProjectWebhook = useAppStore(
+    (state) => state.deleteProjectWebhook
+  );
 
   const projectName = `${projectNamePrefix}${projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));
@@ -84,8 +83,7 @@ export function ProjectWebhooksPage({ projectId }: { projectId: string }) {
     if (!deleteTarget || !project) return;
     try {
       const name = deleteTarget.title;
-      const updatedProject =
-        await projectWebhookV1Store.deleteProjectWebhook(deleteTarget);
+      const updatedProject = await deleteProjectWebhook(deleteTarget);
       projectStore.updateProjectCache({
         ...project,
         ...updatedProject,
@@ -103,7 +101,7 @@ export function ProjectWebhooksPage({ projectId }: { projectId: string }) {
       });
     }
     setDeleteTarget(null);
-  }, [deleteTarget, project, projectWebhookV1Store, projectStore, t]);
+  }, [deleteTarget, project, deleteProjectWebhook, projectStore, t]);
 
   return (
     <div className="py-4 flex flex-col">

--- a/frontend/src/react/pages/project/database-detail/panels/DatabaseChangelogPanel.tsx
+++ b/frontend/src/react/pages/project/database-detail/panels/DatabaseChangelogPanel.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
-import { useChangelogStore } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import type {
   Changelog,
   Database,
@@ -8,7 +8,7 @@ import type {
 import { DatabaseChangelogTable } from "../changelog/DatabaseChangelogTable";
 
 export function DatabaseChangelogPanel({ database }: { database: Database }) {
-  const changelogStore = useChangelogStore();
+  const listChangelogs = useAppStore((state) => state.listChangelogs);
   const fetchChangelogList = useCallback(
     async ({
       pageToken,
@@ -17,18 +17,17 @@ export function DatabaseChangelogPanel({ database }: { database: Database }) {
       pageToken: string;
       pageSize: number;
     }) => {
-      const { nextPageToken, changelogs } =
-        await changelogStore.fetchChangelogList({
-          parent: database.name,
-          pageSize,
-          pageToken,
-        });
+      const { nextPageToken, changelogs } = await listChangelogs({
+        parent: database.name,
+        pageSize,
+        pageToken,
+      });
       return {
         nextPageToken,
         list: changelogs,
       };
     },
-    [changelogStore, database.name]
+    [database.name, listChangelogs]
   );
   const paged = usePagedData<Changelog>({
     sessionKey: `bb.paged-changelog-table.${database.name}`,

--- a/frontend/src/react/pages/project/database-detail/panels/DatabaseRevisionPanel.tsx
+++ b/frontend/src/react/pages/project/database-detail/panels/DatabaseRevisionPanel.tsx
@@ -1,7 +1,5 @@
-import { create } from "@bufbuild/protobuf";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { revisionServiceClientConnect } from "@/connect";
 import {
   AlertDialog,
   AlertDialogContent,
@@ -11,16 +9,18 @@ import {
 } from "@/react/components/ui/alert-dialog";
 import { Button } from "@/react/components/ui/button";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
-import { useRevisionStore } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
-import { ListRevisionsRequestSchema } from "@/types/proto-es/v1/revision_service_pb";
 import { DatabaseRevisionTable } from "../revision/DatabaseRevisionTable";
 import { ImportRevisionSheet } from "../revision/ImportRevisionSheet";
 
 export function DatabaseRevisionPanel({ database }: { database: Database }) {
   const { t } = useTranslation();
-  const revisionStore = useRevisionStore();
+  const listRevisionsByDatabase = useAppStore(
+    (state) => state.listRevisionsByDatabase
+  );
+  const deleteRevision = useAppStore((state) => state.deleteRevision);
   const [showCreateRevisionDrawer, setShowCreateRevisionDrawer] =
     useState(false);
   const [selectedNames, setSelectedNames] = useState<Set<string>>(new Set());
@@ -32,19 +32,19 @@ export function DatabaseRevisionPanel({ database }: { database: Database }) {
       pageToken: string;
       pageSize: number;
     }) => {
-      const request = create(ListRevisionsRequestSchema, {
-        parent: database.name,
-        pageSize,
-        pageToken,
-      });
-      const { nextPageToken, revisions } =
-        await revisionServiceClientConnect.listRevisions(request);
+      const { nextPageToken, revisions } = await listRevisionsByDatabase(
+        database.name,
+        {
+          pageToken,
+          pageSize,
+        }
+      );
       return {
         nextPageToken,
         list: revisions,
       };
     },
-    [database.name]
+    [database.name, listRevisionsByDatabase]
   );
   const paged = usePagedData<Revision>({
     sessionKey: `bb.paged-revision-table.${database.name}`,
@@ -68,14 +68,14 @@ export function DatabaseRevisionPanel({ database }: { database: Database }) {
   const handleDeleteSelected = useCallback(async () => {
     try {
       await Promise.allSettled(
-        [...selectedNames].map((name) => revisionStore.deleteRevision(name))
+        [...selectedNames].map((name) => deleteRevision(name))
       );
     } finally {
       setSelectedNames(new Set());
       setShowDeleteConfirm(false);
       handleRevisionDeleted();
     }
-  }, [selectedNames, handleRevisionDeleted, revisionStore]);
+  }, [selectedNames, deleteRevision, handleRevisionDeleted]);
 
   // Clear selection on page size change or database switch, but not on loadMore.
   useEffect(() => {

--- a/frontend/src/react/pages/project/database-detail/revision/ImportRevisionSheet.tsx
+++ b/frontend/src/react/pages/project/database-detail/revision/ImportRevisionSheet.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/react/components/ui/sheet";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
-import { pushNotification, useRevisionStore, useSheetV1Store } from "@/store";
+import { pushNotification, useSheetV1Store } from "@/store";
 import type {
   Release,
   Release_File,
@@ -72,7 +72,9 @@ export function ImportRevisionSheet({
   const listReleasesByProject = useAppStore(
     (state) => state.listReleasesByProject
   );
-  const revisionStore = useRevisionStore();
+  const listAllRevisionsByDatabase = useAppStore(
+    (state) => state.listAllRevisionsByDatabase
+  );
   const sheetStore = useSheetV1Store();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -92,17 +94,16 @@ export function ImportRevisionSheet({
 
   const loadExistingRevisions = useCallback(async () => {
     try {
-      const revisions = await revisionStore.fetchAllRevisionsByDatabase(
-        databaseName,
-        { pageSize: 1000 }
-      );
+      const revisions = await listAllRevisionsByDatabase(databaseName, {
+        pageSize: 1000,
+      });
       setExistingVersions(
         new Set(revisions.map((revision) => revision.version).filter(Boolean))
       );
     } catch (error) {
       console.error("Failed to load existing revisions:", error);
     }
-  }, [databaseName, revisionStore]);
+  }, [databaseName, listAllRevisionsByDatabase]);
 
   const loadReleases = useCallback(async () => {
     setLoadingReleases(true);

--- a/frontend/src/react/pages/project/database-detail/revision/ImportRevisionSheet.tsx
+++ b/frontend/src/react/pages/project/database-detail/revision/ImportRevisionSheet.tsx
@@ -23,12 +23,8 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { cn } from "@/react/lib/utils";
-import {
-  pushNotification,
-  useReleaseStore,
-  useRevisionStore,
-  useSheetV1Store,
-} from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification, useRevisionStore, useSheetV1Store } from "@/store";
 import type {
   Release,
   Release_File,
@@ -73,7 +69,9 @@ export function ImportRevisionSheet({
   onCreated: (revisions: Revision[]) => void;
 }) {
   const { t } = useTranslation();
-  const releaseStore = useReleaseStore();
+  const listReleasesByProject = useAppStore(
+    (state) => state.listReleasesByProject
+  );
   const revisionStore = useRevisionStore();
   const sheetStore = useSheetV1Store();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -109,10 +107,9 @@ export function ImportRevisionSheet({
   const loadReleases = useCallback(async () => {
     setLoadingReleases(true);
     try {
-      const { releases } = await releaseStore.fetchReleasesByProject(
-        projectName,
-        { pageSize: 100 }
-      );
+      const { releases } = await listReleasesByProject(projectName, {
+        pageSize: 100,
+      });
       setReleaseList(releases);
     } catch (error) {
       pushNotification({
@@ -124,7 +121,7 @@ export function ImportRevisionSheet({
     } finally {
       setLoadingReleases(false);
     }
-  }, [projectName, releaseStore, t]);
+  }, [listReleasesByProject, projectName, t]);
 
   useEffect(() => {
     if (!open) {

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
@@ -15,6 +15,7 @@ import { getAvatarColor, getInitials } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
+import { displayRoleTitleFromList } from "@/react/lib/role";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { ensureGroupIdentifier } from "@/react/stores/app/group";
@@ -23,7 +24,6 @@ import {
   useCurrentUserV1,
   useProjectIamPolicyStore,
   useProjectV1Store,
-  useUserStore,
 } from "@/store";
 import { projectNamePrefix, userNamePrefix } from "@/store/modules/v1/common";
 import {
@@ -45,7 +45,6 @@ import {
   groupBindingPrefix,
 } from "@/types/v1/user";
 import {
-  displayRoleTitle,
   ensureUserFullName,
   isBindingPolicyExpired,
   memberMapToRolesInProjectIAM,
@@ -298,14 +297,16 @@ function ApprovalStepItem({
 }
 
 function ApprovalUserText({ candidate }: { candidate: string }) {
-  const userStore = useUserStore();
+  const getOrFetchUserByIdentifier = useAppStore(
+    (state) => state.getOrFetchUserByIdentifier
+  );
   const [user, setUser] = useState<UserMessage>();
 
   useEffect(() => {
     let canceled = false;
 
     const load = async () => {
-      const next = await userStore.getOrFetchUserByIdentifier({
+      const next = await getOrFetchUserByIdentifier({
         identifier: candidate,
       });
       if (canceled || !next) {
@@ -326,7 +327,7 @@ function ApprovalUserText({ candidate }: { candidate: string }) {
     return () => {
       canceled = true;
     };
-  }, [candidate, userStore]);
+  }, [candidate, getOrFetchUserByIdentifier]);
 
   if (!user) {
     return null;
@@ -500,11 +501,14 @@ function getStatusTag(
 
 function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const { t } = useTranslation();
+  const roleList = useAppStore((state) => state.roleList);
   const page = useIssueDetailContext();
   const currentUser = useVueState(() => useCurrentUserV1().value);
   const projectStore = useProjectV1Store();
   const projectIamPolicyStore = useProjectIamPolicyStore();
-  const userStore = useUserStore();
+  const batchGetOrFetchUsers = useAppStore(
+    (state) => state.batchGetOrFetchUsers
+  );
   const batchGetOrFetchGroups = useAppStore(
     (state) => state.batchGetOrFetchGroups
   );
@@ -550,9 +554,9 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
 
   const roleName = useMemo(() => {
     return step
-      ? displayRoleTitle(step)
+      ? displayRoleTitleFromList(step, roleList)
       : t("custom-approval.approval-flow.node.approver");
-  }, [step, t]);
+  }, [roleList, step, t]);
 
   const canReRequest = useMemo(() => {
     return (
@@ -648,7 +652,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
         return;
       }
 
-      const users = await userStore.batchGetOrFetchUsers(
+      const users = await batchGetOrFetchUsers(
         filteredCandidateEmails.map(ensureUserFullName)
       );
       if (canceled) {
@@ -676,7 +680,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
     return () => {
       canceled = true;
     };
-  }, [currentUserEmail, filteredCandidateEmails, status, userStore]);
+  }, [batchGetOrFetchUsers, currentUserEmail, filteredCandidateEmails, status]);
 
   const handleReRequestReview = async () => {
     if (reRequesting) {

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailCommentList.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailCommentList.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/react/components/ui/dialog";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { buildPlanDeployRouteFromPlanName } from "@/router/dashboard/projectV1RouteHelpers";
 import {
@@ -41,7 +42,6 @@ import {
   useIssueCommentStore,
   useProjectV1Store,
   useSheetV1Store,
-  useUserStore,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { getTimeForPbTimestampProtoEs, unknownUser } from "@/types";
@@ -104,7 +104,9 @@ export function IssueDetailCommentList() {
   const page = useIssueDetailContext();
   const { setEditing } = page;
   const projectStore = useProjectV1Store();
-  const userStore = useUserStore();
+  const batchGetOrFetchUsers = useAppStore(
+    (state) => state.batchGetOrFetchUsers
+  );
   const issueCommentStore = useIssueCommentStore();
   const currentUser = useVueState(() => useCurrentUserV1().value);
   const routeHash = useVueState(() => router.currentRoute.value.hash);
@@ -187,8 +189,8 @@ export function IssueDetailCommentList() {
     if (identifiers.size === 0) {
       return;
     }
-    void userStore.batchGetOrFetchUsers([...identifiers]);
-  }, [issueComments, page.issue?.creator, userStore]);
+    void batchGetOrFetchUsers([...identifiers]);
+  }, [batchGetOrFetchUsers, issueComments, page.issue?.creator]);
 
   const refreshIssueComments = async () => {
     if (!issueName) {
@@ -360,14 +362,12 @@ function IssueDescriptionCommentRow({
   const page = useIssueDetailContext();
   const { setEditing } = page;
   const projectStore = useProjectV1Store();
-  const userStore = useUserStore();
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));
-  const creator = useVueState(
-    () =>
-      userStore.getUserByIdentifier(page.issue?.creator || "") ??
-      unknownUser(page.issue?.creator || "")
+  const creatorUser = useAppStore((state) =>
+    state.getUserByIdentifier(page.issue?.creator || "")
   );
+  const creator = creatorUser ?? unknownUser(page.issue?.creator || "");
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(page.issue?.description || "");
   const [isSaving, setIsSaving] = useState(false);
@@ -558,12 +558,10 @@ function IssueCommentRow({
 function CommentActionHeader({ issueComment }: { issueComment: IssueComment }) {
   const { t } = useTranslation();
   const page = useIssueDetailContext();
-  const userStore = useUserStore();
-  const creator = useVueState(
-    () =>
-      userStore.getUserByIdentifier(issueComment.creator) ??
-      unknownUser(issueComment.creator)
+  const creatorUser = useAppStore((state) =>
+    state.getUserByIdentifier(issueComment.creator)
   );
+  const creator = creatorUser ?? unknownUser(issueComment.creator);
   const createdTs = getTimeForPbTimestampProtoEs(issueComment.createTime, 0);
   const updatedTs = getTimeForPbTimestampProtoEs(issueComment.updateTime, 0);
   const isEdited =
@@ -937,12 +935,10 @@ function joinFragments(fragments: ReactNode[], separator: string): ReactNode {
 
 function CommentActionIcon({ issueComment }: { issueComment: IssueComment }) {
   const page = useIssueDetailContext();
-  const userStore = useUserStore();
-  const user = useVueState(
-    () =>
-      userStore.getUserByIdentifier(issueComment.creator) ??
-      unknownUser(issueComment.creator)
+  const creatorUser = useAppStore((state) =>
+    state.getUserByIdentifier(issueComment.creator)
   );
+  const user = creatorUser ?? unknownUser(issueComment.creator);
   const commentType = getIssueCommentType(issueComment);
 
   if (

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.test.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.test.tsx
@@ -68,14 +68,25 @@ vi.mock("@/store", () => ({
     getEnvironmentByName: () => ({ title: "" }),
   }),
   useInstanceV1Store: () => ({ getInstanceByName: () => ({ title: "" }) }),
-  useRoleStore: () => ({
-    getRoleByName: (role: string) =>
-      role === "roles/sqlEditorUser"
-        ? { name: role, permissions: ["bb.sql.ddl", "bb.sql.dml"] }
-        : role === "roles/queryOnly"
-          ? { name: role, permissions: ["bb.sql.select"] }
-          : undefined,
-  }),
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      roleList: [
+        {
+          name: "roles/sqlEditorUser",
+          permissions: ["bb.sql.ddl", "bb.sql.dml"],
+        },
+        { name: "roles/queryOnly", permissions: ["bb.sql.select"] },
+      ],
+      getRoleByName: (role: string) =>
+        role === "roles/sqlEditorUser"
+          ? { name: role, permissions: ["bb.sql.ddl", "bb.sql.dml"] }
+          : role === "roles/queryOnly"
+            ? { name: role, permissions: ["bb.sql.select"] }
+            : undefined,
+    }),
 }));
 
 vi.mock("@/utils", () => ({

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx
@@ -13,14 +13,14 @@ import {
 import { useEnvironmentList } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { getRoleEnvironmentLimitationKind } from "@/react/lib/project-member/utils";
+import { displayRoleTitleFromList } from "@/react/lib/role";
+import { useAppStore } from "@/react/stores/app";
 import {
   useDatabaseV1Store,
   useEnvironmentV1Store,
   useInstanceV1Store,
-  useRoleStore,
 } from "@/store";
 import type { DatabaseResource } from "@/types";
-import { displayRoleTitle } from "@/utils";
 import {
   type ConditionExpression,
   convertFromCELString,
@@ -31,12 +31,12 @@ import { useIssueDetailContext } from "../context/IssueDetailContext";
 export function IssueDetailRoleGrantDetails() {
   const { t } = useTranslation();
   const page = useIssueDetailContext();
-  const roleStore = useRoleStore();
   const databaseStore = useDatabaseV1Store();
   const issue = page.issue;
   const requestRoleName = issue?.roleGrant?.role ?? "";
-  const requestRole = useVueState(() =>
-    roleStore.getRoleByName(requestRoleName)
+  const roleList = useAppStore((state) => state.roleList);
+  const requestRole = useAppStore((state) =>
+    state.getRoleByName(requestRoleName)
   );
   const [condition, setCondition] = useState<ConditionExpression | undefined>();
 
@@ -99,7 +99,9 @@ export function IssueDetailRoleGrantDetails() {
         {requestRoleName && (
           <div className="flex flex-col gap-y-2">
             <span className="text-sm text-control-light">{t("role.self")}</span>
-            <div className="text-base">{displayRoleTitle(requestRoleName)}</div>
+            <div className="text-base">
+              {displayRoleTitleFromList(requestRoleName, roleList)}
+            </div>
           </div>
         )}
 

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
@@ -7,15 +7,16 @@ import { MonacoEditor, ReadonlyMonaco } from "@/react/components/monaco";
 import { ReleaseInfoCard } from "@/react/components/release/ReleaseInfoCard";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
+import { useReleaseByName } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
+import { useAppStore } from "@/react/stores/app";
 import {
   projectNamePrefix,
   pushNotification,
   useCurrentUserV1,
   useDatabaseV1Store,
   useProjectV1Store,
-  useReleaseStore,
   useSheetV1Store,
 } from "@/store";
 import { extractUserEmail } from "@/store/modules/v1/common";
@@ -61,7 +62,7 @@ export function IssueDetailStatementSection({
   const page = useIssueDetailContext();
   const { setEditing } = page;
   const sheetStore = useSheetV1Store();
-  const releaseStore = useReleaseStore();
+  const fetchRelease = useAppStore((state) => state.fetchRelease);
   const projectStore = useProjectV1Store();
   const databaseStore = useDatabaseV1Store();
   const currentUser = useVueState(() => useCurrentUserV1().value);
@@ -73,10 +74,8 @@ export function IssueDetailStatementSection({
       ? spec.config.value.release
       : "";
   const sheetName = useMemo(() => sheetNameOfSpec(spec), [spec]);
-  const release = useVueState(() =>
-    isValidReleaseName(releaseName)
-      ? releaseStore.getReleaseByName(releaseName)
-      : undefined
+  const release = useReleaseByName(
+    isValidReleaseName(releaseName) ? releaseName : undefined
   );
   const [isLoading, setIsLoading] = useState(false);
   const [isSheetOversize, setIsSheetOversize] = useState(false);
@@ -142,13 +141,13 @@ export function IssueDetailStatementSection({
 
     const load = async () => {
       if (isValidReleaseName(releaseName)) {
-        const cached = releaseStore.getReleaseByName(releaseName);
+        const cached = useAppStore.getState().getReleaseByName(releaseName);
         if (isValidReleaseName(cached.name)) {
           return;
         }
         try {
           setIsLoading(true);
-          await releaseStore.fetchReleaseByName(releaseName, true);
+          await fetchRelease(releaseName, true);
         } finally {
           if (!canceled) {
             setIsLoading(false);
@@ -187,7 +186,7 @@ export function IssueDetailStatementSection({
     return () => {
       canceled = true;
     };
-  }, [releaseName, releaseStore, sheetName, sheetStore]);
+  }, [fetchRelease, releaseName, sheetName, sheetStore]);
 
   if (isValidReleaseName(releaseName)) {
     return (

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
@@ -45,20 +45,14 @@ const mocks = vi.hoisted(() => ({
     getOrFetchProjectByName: vi.fn(async () => ({})),
     getProjectByName: vi.fn(() => ({ allowSelfApproval: false })),
   },
-  roleStore: {
-    roleList: [
-      {
-        name: "roles/PROJECT_OWNER",
-        title: "Project Owner",
-      },
-    ],
-  },
+  roleList: [
+    {
+      name: "roles/PROJECT_OWNER",
+      title: "Project Owner",
+    },
+  ],
   workspaceStore: {
     roleMapToUsers: new Map(),
-  },
-  userStore: {
-    batchGetOrFetchUsers: vi.fn(async () => []),
-    getOrFetchUserByIdentifier: vi.fn(async () => undefined),
   },
   issueCommentStore: {
     getIssueComments: vi.fn(() => mocks.comments),
@@ -91,15 +85,16 @@ vi.mock("@/store", () => ({
   useCurrentUserV1: () => mocks.currentUserStore,
   useProjectIamPolicyStore: () => mocks.projectIamPolicyStore,
   useProjectV1Store: () => mocks.projectStore,
-  useRoleStore: () => mocks.roleStore,
   useWorkspaceV1Store: () => mocks.workspaceStore,
-  useUserStore: () => mocks.userStore,
 }));
 
 vi.mock("@/react/stores/app", () => ({
   useAppStore: (selector: (state: unknown) => unknown) =>
     selector({
       batchGetOrFetchGroups: mocks.batchGetOrFetchGroups,
+      batchGetOrFetchUsers: mocks.batchGetOrFetchUsers,
+      getOrFetchUserByIdentifier: mocks.getOrFetchUserByIdentifier,
+      roleList: mocks.roleList,
     }),
 }));
 
@@ -223,8 +218,8 @@ beforeEach(() => {
   mocks.projectIamPolicyStore.getProjectIamPolicy.mockClear();
   mocks.projectStore.getOrFetchProjectByName.mockClear();
   mocks.projectStore.getProjectByName.mockClear();
-  mocks.userStore.batchGetOrFetchUsers.mockClear();
-  mocks.userStore.getOrFetchUserByIdentifier.mockClear();
+  mocks.batchGetOrFetchUsers.mockClear();
+  mocks.getOrFetchUserByIdentifier.mockClear();
 });
 
 describe("PlanDetailApprovalFlow", () => {

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.tsx
@@ -15,6 +15,7 @@ import { getAvatarColor, getInitials } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
+import { displayRoleTitleFromList } from "@/react/lib/role";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { ensureGroupIdentifier } from "@/react/stores/app/group";
@@ -25,7 +26,6 @@ import {
   useCurrentUserV1,
   useProjectIamPolicyStore,
   useProjectV1Store,
-  useUserStore,
 } from "@/store";
 import { projectNamePrefix, userNamePrefix } from "@/store/modules/v1/common";
 import {
@@ -52,7 +52,6 @@ import {
   groupBindingPrefix,
 } from "@/types/v1/user";
 import {
-  displayRoleTitle,
   ensureUserFullName,
   isBindingPolicyExpired,
   memberMapToRolesInProjectIAM,
@@ -467,14 +466,16 @@ function ApprovalStepItem({
 }
 
 function ApprovalUserText({ candidate }: { candidate: string }) {
-  const userStore = useUserStore();
+  const getOrFetchUserByIdentifier = useAppStore(
+    (state) => state.getOrFetchUserByIdentifier
+  );
   const [user, setUser] = useState<UserMessage>();
 
   useEffect(() => {
     let canceled = false;
 
     const load = async () => {
-      const next = await userStore.getOrFetchUserByIdentifier({
+      const next = await getOrFetchUserByIdentifier({
         identifier: candidate,
       });
       if (canceled || !next) return;
@@ -492,7 +493,7 @@ function ApprovalUserText({ candidate }: { candidate: string }) {
     return () => {
       canceled = true;
     };
-  }, [candidate, userStore]);
+  }, [candidate, getOrFetchUserByIdentifier]);
 
   if (!user) return null;
 
@@ -661,12 +662,15 @@ function getStatusTag(
 
 function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const { t } = useTranslation();
+  const roleList = useAppStore((state) => state.roleList);
   const page = usePlanDetailContext();
   const { patchState } = page;
   const currentUser = useCurrentUserV1().value;
   const projectStore = useProjectV1Store();
   const projectIamPolicyStore = useProjectIamPolicyStore();
-  const userStore = useUserStore();
+  const batchGetOrFetchUsers = useAppStore(
+    (state) => state.batchGetOrFetchUsers
+  );
   const batchGetOrFetchGroups = useAppStore(
     (state) => state.batchGetOrFetchGroups
   );
@@ -715,9 +719,9 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
 
   const roleName = useMemo(() => {
     return step
-      ? displayRoleTitle(step)
+      ? displayRoleTitleFromList(step, roleList)
       : t("custom-approval.approval-flow.node.approver");
-  }, [step, t]);
+  }, [roleList, step, t]);
 
   const canReRequest = useMemo(() => {
     return (
@@ -814,7 +818,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
         return;
       }
 
-      const users = await userStore.batchGetOrFetchUsers(
+      const users = await batchGetOrFetchUsers(
         filteredCandidateEmails.map(ensureUserFullName)
       );
       if (canceled) return;
@@ -838,7 +842,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
     return () => {
       canceled = true;
     };
-  }, [currentUserEmail, filteredCandidateEmails, status, userStore]);
+  }, [batchGetOrFetchUsers, currentUserEmail, filteredCandidateEmails, status]);
 
   const handleReRequestReview = async () => {
     if (reRequesting) return;

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployReleaseInfoCard.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployReleaseInfoCard.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import { ReleaseInfoCard } from "@/react/components/release/ReleaseInfoCard";
-import { useReleaseByName } from "@/store/modules/release";
+import { useReleaseByName } from "@/react/hooks/useAppState";
+import { useAppStore } from "@/react/stores/app";
 
 export function DeployReleaseInfoCard({
   className,
@@ -8,12 +10,28 @@ export function DeployReleaseInfoCard({
   className?: string;
   releaseName: string;
 }) {
-  const { release, ready } = useReleaseByName(releaseName);
+  const release = useReleaseByName(releaseName);
+  const fetchRelease = useAppStore((state) => state.fetchRelease);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let canceled = false;
+    setReady(false);
+    void fetchRelease(releaseName, true).finally(() => {
+      if (!canceled) {
+        setReady(true);
+      }
+    });
+    return () => {
+      canceled = true;
+    };
+  }, [fetchRelease, releaseName]);
+
   return (
     <ReleaseInfoCard
       className={className}
-      isLoading={!ready.value}
-      release={release.value ?? undefined}
+      isLoading={!ready}
+      release={release}
       releaseName={releaseName}
     />
   );

--- a/frontend/src/react/pages/settings/EnvironmentsPage.tsx
+++ b/frontend/src/react/pages/settings/EnvironmentsPage.tsx
@@ -58,6 +58,7 @@ import {
 import { useEnvironmentList } from "@/react/hooks/useAppState";
 import { useUnsavedChangesGuard } from "@/react/hooks/useUnsavedChangesGuard";
 import { useVueState } from "@/react/hooks/useVueState";
+import { displayRoleTitleFromList } from "@/react/lib/role";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
@@ -71,7 +72,6 @@ import {
   useDatabaseV1Store,
   useEnvironmentV1Store,
   useInstanceV1Store,
-  useRoleStore,
   useSQLReviewStore,
   useSubscriptionV1Store,
   useUIStateStore,
@@ -101,7 +101,6 @@ import {
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import type { Environment } from "@/types/v1/environment";
 import {
-  displayRoleTitle,
   hasWorkspacePermissionV2,
   hexToRgb,
   sqlReviewPolicySlug,
@@ -208,9 +207,8 @@ function RolloutPolicyConfig({
   onChange: (policy: Policy) => void;
 }) {
   const { t } = useTranslation();
-  const roleStore = useRoleStore();
   const subscriptionStore = useSubscriptionV1Store();
-  const roleList = useVueState(() => [...roleStore.roleList]);
+  const roleList = useAppStore((state) => state.roleList);
   const hasCustomRoleFeature = useVueState(() =>
     subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_CUSTOM_ROLES)
   );
@@ -220,6 +218,14 @@ function RolloutPolicyConfig({
     policy.policy?.case === "rolloutPolicy"
       ? policy.policy.value
       : create(RolloutPolicySchema);
+  const roleByName = useMemo(
+    () => new Map(roleList.map((role) => [role.name, role])),
+    [roleList]
+  );
+  const displayPolicyRoleTitle = useCallback(
+    (name: string) => displayRoleTitleFromList(name, roleList),
+    [roleList]
+  );
 
   const update = (rp: RolloutPolicy) => {
     onChange({
@@ -267,20 +273,16 @@ function RolloutPolicyConfig({
       roles: { name: string; title: string }[];
     }[] = [];
 
-    const wsRoles = PRESET_WORKSPACE_ROLES.map((name) =>
-      roleStore.getRoleByName(name)
-    )
+    const wsRoles = PRESET_WORKSPACE_ROLES.map((name) => roleByName.get(name))
       .filter((r) => r && !selected.has(r.name))
-      .map((r) => ({ name: r!.name, title: displayRoleTitle(r!.name) }));
+      .map((r) => ({ name: r!.name, title: displayPolicyRoleTitle(r!.name) }));
     if (wsRoles.length > 0) {
       groups.push({ label: t("role.workspace-roles.self"), roles: wsRoles });
     }
 
-    const projRoles = PRESET_PROJECT_ROLES.map((name) =>
-      roleStore.getRoleByName(name)
-    )
+    const projRoles = PRESET_PROJECT_ROLES.map((name) => roleByName.get(name))
       .filter((r) => r && !selected.has(r.name))
-      .map((r) => ({ name: r!.name, title: displayRoleTitle(r!.name) }));
+      .map((r) => ({ name: r!.name, title: displayPolicyRoleTitle(r!.name) }));
     if (projRoles.length > 0) {
       groups.push({ label: t("role.project-roles.self"), roles: projRoles });
     }
@@ -288,7 +290,7 @@ function RolloutPolicyConfig({
     if (hasCustomRoleFeature) {
       const customRoles = roleList
         .filter((r) => !PRESET_ROLES.includes(r.name) && !selected.has(r.name))
-        .map((r) => ({ name: r.name, title: displayRoleTitle(r.name) }));
+        .map((r) => ({ name: r.name, title: displayPolicyRoleTitle(r.name) }));
       if (customRoles.length > 0) {
         groups.push({
           label: t("role.custom-roles.self"),
@@ -298,7 +300,14 @@ function RolloutPolicyConfig({
     }
 
     return groups;
-  }, [roleList, rolloutPolicy.roles, roleStore, t]);
+  }, [
+    displayPolicyRoleTitle,
+    hasCustomRoleFeature,
+    roleByName,
+    roleList,
+    rolloutPolicy.roles,
+    t,
+  ]);
 
   const [showRoleDropdown, setShowRoleDropdown] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
@@ -328,7 +337,7 @@ function RolloutPolicyConfig({
                 key={role}
                 className="inline-flex items-center gap-x-1 rounded-xs bg-gray-100 px-2 py-1 text-sm"
               >
-                {displayRoleTitle(role)}
+                {displayPolicyRoleTitle(role)}
                 {canUpdatePolicy && (
                   <button
                     type="button"

--- a/frontend/src/react/pages/settings/GroupsPage.tsx
+++ b/frontend/src/react/pages/settings/GroupsPage.tsx
@@ -56,7 +56,6 @@ import {
   useCurrentUserV1,
   useSettingV1Store,
   useSubscriptionV1Store,
-  useUserStore,
 } from "@/store";
 import { extractUserEmail, groupNamePrefix } from "@/store/modules/v1/common";
 import { UNKNOWN_USER_NAME } from "@/types";
@@ -118,7 +117,9 @@ function GroupTable({
 }) {
   const { t } = useTranslation();
   const currentUser = useVueState(() => useCurrentUserV1().value);
-  const userStore = useUserStore();
+  const batchGetOrFetchUsers = useAppStore(
+    (state) => state.batchGetOrFetchUsers
+  );
   const deleteGroup = useAppStore((state) => state.deleteGroup);
 
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
@@ -134,8 +135,7 @@ function GroupTable({
       if (loadingRef.current.has(group.name)) return;
       loadingRef.current.add(group.name);
       const memberNames = group.members.map((m) => m.member);
-      userStore
-        .batchGetOrFetchUsers(memberNames)
+      batchGetOrFetchUsers(memberNames)
         .then((users) => {
           setMemberCache((prev) => {
             const next = new Map(prev);
@@ -153,7 +153,7 @@ function GroupTable({
           loadingRef.current.delete(group.name);
         });
     },
-    [userStore]
+    [batchGetOrFetchUsers]
   );
 
   // Invalidate member cache when groups data changes (e.g. after editing membership)
@@ -486,7 +486,9 @@ function GroupForm({
   const actuatorStore = useActuatorV1Store();
   const currentUser = useVueState(() => useCurrentUserV1().value);
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
-  const userStore = useUserStore();
+  const getOrFetchUserByIdentifier = useAppStore(
+    (state) => state.getOrFetchUserByIdentifier
+  );
   const createGroup = useAppStore((state) => state.createGroup);
   const updateGroup = useAppStore((state) => state.updateGroup);
   const deleteGroup = useAppStore((state) => state.deleteGroup);
@@ -629,7 +631,7 @@ function GroupForm({
       if (!isSaaSMode) {
         const notFound: string[] = [];
         for (const m of normalizedMembers) {
-          const user = await userStore.getOrFetchUserByIdentifier({
+          const user = await getOrFetchUserByIdentifier({
             identifier: m.member,
             silent: true,
             fallback: false,

--- a/frontend/src/react/pages/settings/MembersPage.test.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.test.tsx
@@ -295,9 +295,6 @@ vi.mock("@/store", () => ({
       state: 1,
     }),
   }),
-  useRoleStore: () => ({
-    roleList: [{ name: "roles/sqlEditorUser", permissions: [] }],
-  }),
   useSettingV1Store: () => ({
     getOrFetchSettingByName: vi.fn(),
     getSettingByName: () => undefined,
@@ -306,12 +303,19 @@ vi.mock("@/store", () => ({
     hasFeature: () => true,
     userCountLimit: 10,
   }),
-  useUserStore: () => ({}),
   useWorkspaceV1Store: () => ({
     findRolesByMember: () => [],
     patchIamPolicy: vi.fn(),
     workspaceIamPolicy: { bindings: [] },
   }),
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      batchGetOrFetchUsers: vi.fn(async () => []),
+      roleList: [{ name: "roles/sqlEditorUser", permissions: [] }],
+    }),
 }));
 
 vi.mock("./MemberBindingEnvironmentBanner", () => ({

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -71,22 +71,22 @@ import {
   getRoleEnvironmentLimitationKind,
   roleHasDatabaseLimitation,
 } from "@/react/lib/project-member/utils";
+import { displayRoleTitleFromList } from "@/react/lib/role";
 import { cn } from "@/react/lib/utils";
 import {
   useNavigate,
   WORKSPACE_ROUTE_GROUPS,
   WORKSPACE_ROUTE_USER_PROFILE,
 } from "@/react/router";
+import { useAppStore } from "@/react/stores/app";
 import {
   pushNotification,
   useActuatorV1Store,
   useCurrentUserV1,
   useProjectIamPolicyStore,
   useProjectV1Store,
-  useRoleStore,
   useSettingV1Store,
   useSubscriptionV1Store,
-  useUserStore,
   useWorkspaceV1Store,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
@@ -106,7 +106,6 @@ import type { GroupBinding, MemberBinding } from "@/types/v1/member";
 import { AccountType, getAccountTypeByEmail } from "@/types/v1/user";
 import {
   batchConvertParsedExprToCELString,
-  displayRoleTitle,
   formatAbsoluteDateTime,
   getDatabaseNameOptionConfig,
   hasProjectPermissionV2,
@@ -167,7 +166,10 @@ function MemberTable({
   const currentUser = useVueState(() => useCurrentUserV1().value);
   const actuatorStore = useActuatorV1Store();
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
-  const userStore = useUserStore();
+  const batchGetOrFetchUsers = useAppStore(
+    (state) => state.batchGetOrFetchUsers
+  );
+  const roleList = useAppStore((state) => state.roleList);
   const navigate = useNavigate();
   const canGetGroups = hasWorkspacePermissionV2("bb.groups.get");
   const canGetUsers = hasWorkspacePermissionV2("bb.users.get");
@@ -194,8 +196,7 @@ function MemberTable({
       if (loadingRef.current.has(group.name)) return;
       loadingRef.current.add(group.name);
       const memberNames = group.members.map((m) => m.member);
-      userStore
-        .batchGetOrFetchUsers(memberNames)
+      batchGetOrFetchUsers(memberNames)
         .then((users: (User | undefined)[]) => {
           setMemberCache((prev) => {
             const next = new Map(prev);
@@ -211,7 +212,7 @@ function MemberTable({
         })
         .finally(() => loadingRef.current.delete(group.name));
     },
-    [userStore]
+    [batchGetOrFetchUsers]
   );
 
   // Signature of just the group bindings — that's all the cache cares
@@ -331,7 +332,7 @@ function MemberTable({
     return [
       ...groupProjectRoleBindings(active).map((group) => (
         <Badge key={`active-${group.role}`} className="text-xs gap-x-1">
-          {displayRoleTitle(group.role)}
+          {displayRoleTitleFromList(group.role, roleList)}
           {group.bindings.length > 1 && (
             <span className="text-control-light">
               ({group.bindings.length})
@@ -344,7 +345,7 @@ function MemberTable({
           key={`expired-${group.role}`}
           className="text-xs gap-x-1 line-through opacity-60"
         >
-          {displayRoleTitle(group.role)}
+          {displayRoleTitleFromList(group.role, roleList)}
           {group.bindings.length > 1 && (
             <span className="text-control-light">
               ({group.bindings.length})
@@ -496,7 +497,7 @@ function MemberTable({
                         : sortRoles([...mb.workspaceLevelRoles]).map((role) => (
                             <Badge key={role} className="text-xs gap-x-1">
                               <Building2 className="h-3 w-3" />
-                              {displayRoleTitle(role)}
+                              {displayRoleTitleFromList(role, roleList)}
                             </Badge>
                           ))}
                     </div>
@@ -624,6 +625,7 @@ function MemberTableByRole({
   const currentUser = useVueState(() => useCurrentUserV1().value);
   const actuatorStore = useActuatorV1Store();
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const roleList = useAppStore((state) => state.roleList);
   const [expandedRoles, setExpandedRoles] = useState<Set<string>>(new Set());
   const initializedRef = useRef(false);
 
@@ -713,7 +715,7 @@ function MemberTableByRole({
                         <Building2 className="h-4 w-4 text-control-light" />
                       )}
                       <span className="font-medium">
-                        {displayRoleTitle(role)}
+                        {displayRoleTitleFromList(role, roleList)}
                       </span>
                       <span className="text-control-light text-xs">
                         ({members.length})
@@ -1004,8 +1006,8 @@ function ProjectRoleBindingForm({
   projectName: string;
 }) {
   const { t } = useTranslation();
-  const roleStore = useRoleStore();
-  const roleList = useVueState(() => [...roleStore.roleList]);
+
+  const roleList = useAppStore((state) => state.roleList);
 
   const expirationPresets = useMemo(() => getExpirationPresets(t), [t]);
   const factorList = useMemo<Factor[]>(
@@ -1241,6 +1243,7 @@ function EditMemberRoleDrawer({
   const projectIamPolicyStore = useProjectIamPolicyStore();
   const isSaaSMode = useVueState(() => useActuatorV1Store().isSaaSMode);
   const settingV1Store = useSettingV1Store();
+  const roleList = useAppStore((state) => state.roleList);
   const hasEmailSetting = useVueState(
     () => !!settingV1Store.getSettingByName(Setting_SettingName.EMAIL)
   );
@@ -1321,7 +1324,7 @@ function EditMemberRoleDrawer({
 
   const handleDeleteRole = async (roleBinding: Binding) => {
     if (!member || !projectName) return;
-    const roleName = displayRoleTitle(roleBinding.role);
+    const roleName = displayRoleTitleFromList(roleBinding.role, roleList);
     if (
       !window.confirm(
         t("project.members.revoke-role-from-member", {
@@ -1680,7 +1683,7 @@ function EditMemberRoleDrawer({
                               isExpired && "line-through"
                             )}
                           >
-                            {displayRoleTitle(binding.role)}
+                            {displayRoleTitleFromList(binding.role, roleList)}
                           </span>
                           {isExpired && (
                             <Badge variant="destructive" className="text-xs">

--- a/frontend/src/react/pages/settings/RequestRoleSheet.test.tsx
+++ b/frontend/src/react/pages/settings/RequestRoleSheet.test.tsx
@@ -222,17 +222,21 @@ vi.mock("@/connect", () => ({
 
 vi.mock("@/store", () => ({
   useCurrentUserV1: () => ({ value: mocks.currentUser }),
-  useRoleStore: () => ({
-    getRoleByName: (name: string) => ({
-      name,
-      permissions:
-        name === "roles/projectOwner"
-          ? ["bb.projects.get", "bb.databases.get"]
-          : [],
-    }),
-  }),
   useSettingV1Store: () => stableSettingStore,
   pushNotification: (...args: unknown[]) => mocks.pushNotification(...args),
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      getRoleByName: (name: string) => ({
+        name,
+        permissions:
+          name === "roles/projectOwner"
+            ? ["bb.projects.get", "bb.databases.get"]
+            : [],
+      }),
+    }),
 }));
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/react/pages/settings/RequestRoleSheet.tsx
+++ b/frontend/src/react/pages/settings/RequestRoleSheet.tsx
@@ -35,14 +35,11 @@ import {
   getRoleEnvironmentLimitationKind,
   roleHasDatabaseLimitation,
 } from "@/react/lib/project-member/utils";
+import { displayRoleTitleFromList } from "@/react/lib/role";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
-import {
-  pushNotification,
-  useCurrentUserV1,
-  useRoleStore,
-  useSettingV1Store,
-} from "@/store";
+import { pushNotification, useCurrentUserV1, useSettingV1Store } from "@/store";
 import type { Permission } from "@/types";
 import { type DatabaseResource, PresetRoleType } from "@/types";
 import { ExprSchema as ConditionExprSchema } from "@/types/proto-es/google/type/expr_pb";
@@ -56,7 +53,6 @@ import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import type { Role } from "@/types/proto-es/v1/role_service_pb";
 import {
   batchConvertParsedExprToCELString,
-  displayRoleTitle,
   extractIssueUID,
   extractProjectResourceName,
   formatIssueTitle,
@@ -169,9 +165,9 @@ function RequestRoleForm({
   const [submitting, setSubmitting] = useState(false);
 
   const settingStore = useSettingV1Store();
-  const roleStore = useRoleStore();
-  const selectedRole = useVueState(() =>
-    role ? roleStore.getRoleByName(role) : undefined
+  const roleList = useAppStore((state) => state.roleList);
+  const selectedRole = useAppStore((state) =>
+    role ? state.getRoleByName(role) : undefined
   );
   const requiredPermissionList = useMemo(
     () => [...new Set(requiredPermissions)],
@@ -402,7 +398,7 @@ function RequestRoleForm({
         ? `[${t("issue.title.request-role")}] ${trimmedReason}`
         : formatIssueTitle(
             t("issue.title.request-specific-role", {
-              role: displayRoleTitle(role),
+              role: displayRoleTitleFromList(role, roleList),
             }),
             titleDatabaseNames
           );

--- a/frontend/src/react/pages/settings/RolesPage.tsx
+++ b/frontend/src/react/pages/settings/RolesPage.tsx
@@ -49,8 +49,12 @@ import { Textarea } from "@/react/components/ui/textarea";
 import { BlockTooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
+  displayRoleDescriptionFromList,
+  displayRoleTitleFromList,
+} from "@/react/lib/role";
+import { useAppStore } from "@/react/stores/app";
+import {
   pushNotification,
-  useRoleStore,
   useSubscriptionV1Store,
   useWorkspaceV1Store,
 } from "@/store";
@@ -64,8 +68,6 @@ import type { Role } from "@/types/proto-es/v1/role_service_pb";
 import { RoleSchema } from "@/types/proto-es/v1/role_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import {
-  displayRoleDescription,
-  displayRoleTitle,
   extractRoleResourceName,
   hasWorkspacePermissionV2,
   isCustomRole,
@@ -211,8 +213,7 @@ function ImportPermissionModal({
   onImport: (permissions: string[]) => void;
 }) {
   const { t } = useTranslation();
-  const roleStore = useRoleStore();
-  const roleList = useVueState(() => [...roleStore.roleList]);
+  const roleList = useAppStore((state) => state.roleList);
   const [selectedRoleName, setSelectedRoleName] = useState<string>("");
 
   const selectedRole = useMemo(
@@ -242,7 +243,7 @@ function ImportPermissionModal({
           {selectedRole && (
             <>
               <p className="textinfolabel">
-                {displayRoleDescription(selectedRole.name)}
+                {displayRoleDescriptionFromList(selectedRole.name, roleList)}
               </p>
               <div>
                 <label className="textlabel mb-1 block">
@@ -292,13 +293,15 @@ function DeleteConfirmModal({
   onCancel: () => void;
 }) {
   const { t } = useTranslation();
+  const roleList = useAppStore((state) => state.roleList);
   const canDelete = occupiedResources.length === 0;
+  const roleTitle = displayRoleTitleFromList(roleName, roleList);
 
   return (
     <AlertDialog open onOpenChange={(nextOpen) => !nextOpen && onCancel()}>
       <AlertDialogContent>
         <AlertDialogTitle>
-          {t("common.delete")} - {displayRoleTitle(roleName)}
+          {t("common.delete")} - {roleTitle}
         </AlertDialogTitle>
 
         {occupiedResources.length > 0 ? (
@@ -309,7 +312,7 @@ function DeleteConfirmModal({
                 <>
                   <p className="mb-2">
                     {t("resource.delete-warning-with-resources", {
-                      name: displayRoleTitle(roleName),
+                      name: roleTitle,
                     })}
                   </p>
                   <ul className="list-disc pl-4 text-sm">
@@ -325,7 +328,7 @@ function DeleteConfirmModal({
         ) : (
           <AlertDialogDescription className="mt-2">
             {t("resource.delete-warning", {
-              name: displayRoleTitle(roleName),
+              name: roleTitle,
             })}
           </AlertDialogDescription>
         )}
@@ -365,7 +368,8 @@ function RoleSheet({
   onShowFeatureModal: () => void;
 }) {
   const { t } = useTranslation();
-  const roleStore = useRoleStore();
+  const upsertRole = useAppStore((state) => state.upsertRole);
+  const roleList = useAppStore((state) => state.roleList);
 
   const [editRole, setEditRole] = useState<Role>(
     create(RoleSchema, { permissions: [...BASIC_WORKSPACE_PERMISSIONS] })
@@ -412,10 +416,7 @@ function RoleSheet({
 
   const validateResourceId = useCallback(
     async (val: string) => {
-      if (
-        val &&
-        roleStore.roleList.find((r) => r.name === `${roleNamePrefix}${val}`)
-      ) {
+      if (val && roleList.find((r) => r.name === `${roleNamePrefix}${val}`)) {
         return [
           {
             type: "error" as const,
@@ -427,7 +428,7 @@ function RoleSheet({
       }
       return [];
     },
-    [roleStore.roleList, t]
+    [roleList, t]
   );
 
   // Sync incoming role prop to local state
@@ -503,7 +504,7 @@ function RoleSheet({
 
     setLoading(true);
     try {
-      await roleStore.upsertRole(editRole);
+      await upsertRole(editRole);
       pushNotification({
         module: "bytebase",
         style: "SUCCESS",
@@ -674,7 +675,9 @@ function RoleSheet({
 
 export function RolesPage() {
   const { t } = useTranslation();
-  const roleStore = useRoleStore();
+  const listRoles = useAppStore((state) => state.listRoles);
+  const getRoleByName = useAppStore((state) => state.getRoleByName);
+  const deleteRole = useAppStore((state) => state.deleteRole);
   const workspaceStore = useWorkspaceV1Store();
   const subscriptionStore = useSubscriptionV1Store();
 
@@ -692,7 +695,7 @@ export function RolesPage() {
   const canCreate = hasWorkspacePermissionV2("bb.roles.create");
   const canDelete = hasWorkspacePermissionV2("bb.roles.delete");
 
-  const roleList = useVueState(() => [...roleStore.roleList]);
+  const roleList = useAppStore((state) => state.roleList);
 
   const filteredRoleList = useMemo(() => {
     return sortBy(roleList, (role) =>
@@ -704,13 +707,12 @@ export function RolesPage() {
 
   // Fetch roles on mount and handle query param
   useEffect(() => {
-    roleStore
-      .fetchRoleList()
+    listRoles()
       .then(() => {
         const urlParams = new URLSearchParams(window.location.search);
         const name = urlParams.get("role");
         if (name?.startsWith(roleNamePrefix)) {
-          const role = roleStore.getRoleByName(name);
+          const role = getRoleByName(name);
           if (role) {
             setDetailRole(role);
             setDetailMode("EDIT");
@@ -748,7 +750,7 @@ export function RolesPage() {
   const confirmDelete = async () => {
     if (!deleteTarget) return;
     try {
-      await roleStore.deleteRole(deleteTarget);
+      await deleteRole(deleteTarget);
       pushNotification({
         module: "bytebase",
         style: "SUCCESS",
@@ -819,7 +821,7 @@ export function RolesPage() {
               {filteredRoleList.map((role) => (
                 <TableRow key={role.name}>
                   <TableCell className="whitespace-nowrap">
-                    <span>{displayRoleTitle(role.name)}</span>
+                    <span>{displayRoleTitleFromList(role.name, roleList)}</span>
                     {!isCustomRole(role.name) && (
                       <Badge variant="secondary" className="ml-2 text-xs">
                         {t("common.system")}
@@ -827,9 +829,14 @@ export function RolesPage() {
                     )}
                   </TableCell>
                   <TableCell className="text-control-light overflow-hidden">
-                    <BlockTooltip content={displayRoleDescription(role.name)}>
+                    <BlockTooltip
+                      content={displayRoleDescriptionFromList(
+                        role.name,
+                        roleList
+                      )}
+                    >
                       <span className="block truncate">
-                        {displayRoleDescription(role.name)}
+                        {displayRoleDescriptionFromList(role.name, roleList)}
                       </span>
                     </BlockTooltip>
                   </TableCell>

--- a/frontend/src/react/pages/settings/UsersPage.tsx
+++ b/frontend/src/react/pages/settings/UsersPage.tsx
@@ -54,7 +54,6 @@ import {
   useCurrentUserV1,
   useSettingV1Store,
   useSubscriptionV1Store,
-  useUserStore,
   useWorkspaceV1Store,
 } from "@/store";
 import { getUserFullNameByType } from "@/store/modules/v1/common";
@@ -92,7 +91,8 @@ function UserTable({
 }) {
   const { t } = useTranslation();
   const currentUser = useVueState(() => useCurrentUserV1().value);
-  const userStore = useUserStore();
+  const archiveUser = useAppStore((state) => state.archiveUser);
+  const restoreUser = useAppStore((state) => state.restoreUser);
   const batchGetOrFetchGroups = useAppStore(
     (state) => state.batchGetOrFetchGroups
   );
@@ -132,7 +132,7 @@ function UserTable({
       } else if (accountType === AccountType.WORKLOAD_IDENTITY) {
         await deleteWorkloadIdentity(fullName);
       } else {
-        await userStore.archiveUser(fullName);
+        await archiveUser(fullName);
       }
 
       const updated = create(UserSchema, { ...user, state: State.DELETED });
@@ -158,7 +158,7 @@ function UserTable({
       } else if (accountType === AccountType.WORKLOAD_IDENTITY) {
         await undeleteWorkloadIdentity(fullName);
       } else {
-        await userStore.restoreUser(fullName);
+        await restoreUser(fullName);
       }
 
       const updated = create(UserSchema, { ...user, state: State.ACTIVE });
@@ -506,7 +506,8 @@ function UserForm({
   onUpdated,
 }: Omit<CreateUserSheetProps, "open">) {
   const { t } = useTranslation();
-  const userStore = useUserStore();
+  const createUser = useAppStore((state) => state.createUser);
+  const updateUser = useAppStore((state) => state.updateUser);
   const workspaceStore = useWorkspaceV1Store();
   const settingV1Store = useSettingV1Store();
 
@@ -666,7 +667,7 @@ function UserForm({
   };
 
   const handleCreate = async () => {
-    const createdUser = await userStore.createUser({
+    const createdUser = await createUser({
       ...create(UserSchema, {}),
       title: title || extractUserTitle(email),
       email,
@@ -711,7 +712,7 @@ function UserForm({
     let updatedUser: User = user;
 
     if (updateMask.length > 0) {
-      updatedUser = await userStore.updateUser(
+      updatedUser = await updateUser(
         create(UpdateUserRequestSchema, {
           user: payload,
           updateMask: create(FieldMaskSchema, { paths: updateMask }),
@@ -918,7 +919,7 @@ export function UsersPage() {
   const { t } = useTranslation();
   const actuatorStore = useActuatorV1Store();
   const subscriptionStore = useSubscriptionV1Store();
-  const userStore = useUserStore();
+  const listUsers = useAppStore((state) => state.listUsers);
 
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
 
@@ -939,14 +940,14 @@ export function UsersPage() {
   // Active users paged data
   const fetchActiveUsers = useCallback(
     async (params: { pageSize: number; pageToken: string }) => {
-      const result = await userStore.fetchUserList({
+      const result = await listUsers({
         pageSize: params.pageSize,
         pageToken: params.pageToken,
         filter: { query: userSearchText },
       });
       return { list: result.users, nextPageToken: result.nextPageToken };
     },
-    [userStore, userSearchText]
+    [listUsers, userSearchText]
   );
 
   const hasUserListPermission = hasWorkspacePermissionV2("bb.users.list");
@@ -959,7 +960,7 @@ export function UsersPage() {
   // Inactive users paged data
   const fetchInactiveUsers = useCallback(
     async (params: { pageSize: number; pageToken: string }) => {
-      const result = await userStore.fetchUserList({
+      const result = await listUsers({
         pageSize: params.pageSize,
         pageToken: params.pageToken,
         filter: { query: inactiveUserSearchText, state: State.DELETED },
@@ -967,7 +968,7 @@ export function UsersPage() {
       });
       return { list: result.users, nextPageToken: result.nextPageToken };
     },
-    [userStore, inactiveUserSearchText]
+    [listUsers, inactiveUserSearchText]
   );
 
   const inactiveUsers = usePagedData<User>({

--- a/frontend/src/react/pages/settings/profile/ProfilePage.test.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.test.tsx
@@ -1,0 +1,282 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { State } from "@/types/proto-es/v1/common_pb";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const legacyCurrentUser = {
+  name: "users/alice@example.com",
+  email: "alice@example.com",
+  title: "Old Alice",
+  phone: "",
+  password: "",
+  state: State.ACTIVE,
+  mfaEnabled: false,
+  tempRecoveryCodes: [],
+};
+
+const updatedCurrentUser = {
+  ...legacyCurrentUser,
+  title: "New Alice",
+};
+
+const mocks = vi.hoisted(() => ({
+  useVueState: vi.fn<(getter: () => unknown) => unknown>((getter) => getter()),
+  useCurrentUserV1: vi.fn(() => ({ value: legacyCurrentUser })),
+  useAuthStore: vi.fn(() => ({
+    updateCurrentUserNameForEmailChange: vi.fn(),
+  })),
+  useSettingV1Store: vi.fn(() => ({
+    workspaceProfile: {
+      passwordRestriction: undefined,
+      requireMfa: false,
+    },
+  })),
+  useWorkspaceV1Store: vi.fn(() => ({
+    getWorkspaceRolesByName: vi.fn(() => []),
+  })),
+  useActuatorV1Store: vi.fn(() => ({
+    isSaaSMode: false,
+  })),
+  hasFeature: vi.fn(() => true),
+  pushNotification: vi.fn(),
+  getUserByIdentifier: vi.fn(),
+  getOrFetchUserByIdentifier: vi.fn(),
+  updateUser: vi.fn(async () => updatedCurrentUser),
+  updateEmail: vi.fn(),
+  routerReplace: vi.fn(),
+  routerPush: vi.fn(),
+  migrateUserStorage: vi.fn(),
+  setDocumentTitle: vi.fn(),
+  hasWorkspacePermissionV2: vi.fn(() => true),
+}));
+
+vi.mock("@/react/hooks/useVueState", () => ({
+  useVueState: mocks.useVueState,
+}));
+
+vi.mock("@/react/hooks/useUnsavedChangesGuard", () => ({
+  useUnsavedChangesGuard: vi.fn(),
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      getUserByIdentifier: mocks.getUserByIdentifier,
+      getOrFetchUserByIdentifier: mocks.getOrFetchUserByIdentifier,
+      updateUser: mocks.updateUser,
+      updateEmail: mocks.updateEmail,
+      roleList: [],
+    }),
+}));
+
+vi.mock("@/store", () => ({
+  hasFeature: mocks.hasFeature,
+  pushNotification: mocks.pushNotification,
+  useActuatorV1Store: mocks.useActuatorV1Store,
+  useAuthStore: mocks.useAuthStore,
+  useCurrentUserV1: mocks.useCurrentUserV1,
+  useSettingV1Store: mocks.useSettingV1Store,
+  useWorkspaceV1Store: mocks.useWorkspaceV1Store,
+}));
+
+vi.mock("@/router", () => ({
+  router: {
+    replace: mocks.routerReplace,
+    push: mocks.routerPush,
+  },
+}));
+
+vi.mock("@/router/dashboard/workspaceRoutes", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/router/dashboard/workspaceRoutes")>();
+  return {
+    ...actual,
+    WORKSPACE_ROUTE_404: "404",
+    WORKSPACE_ROUTE_USER_PROFILE: "user-profile",
+  };
+});
+
+vi.mock("@/router/dashboard/workspaceSetting", () => ({
+  SETTING_ROUTE_PROFILE_TWO_FACTOR: "profile.two-factor",
+  SETTING_ROUTE_WORKSPACE_SUBSCRIPTION: "workspace.subscription",
+}));
+
+vi.mock("@/utils", () => ({
+  hasWorkspacePermissionV2: mocks.hasWorkspacePermissionV2,
+  setDocumentTitle: mocks.setDocumentTitle,
+  sortRoles: (roles: string[]) => roles,
+}));
+
+vi.mock("@/utils/storage-migrate", () => ({
+  migrateUserStorage: mocks.migrateUserStorage,
+}));
+
+vi.mock("@bufbuild/protobuf", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@bufbuild/protobuf")>();
+  return {
+    ...actual,
+    create: (_schema: unknown, data: Record<string, unknown>) => data,
+  };
+});
+
+vi.mock("@/react/components/FeatureBadge", () => ({
+  FeatureBadge: () => <span data-testid="feature-badge" />,
+}));
+
+vi.mock("@/react/components/LearnMoreLink", () => ({
+  LearnMoreLink: () => <a href="https://example.com">learn</a>,
+}));
+
+vi.mock("@/react/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/react/components/ui/input", () => ({
+  Input: ({
+    ref,
+    ...props
+  }: React.InputHTMLAttributes<HTMLInputElement> & {
+    ref?: React.Ref<HTMLInputElement>;
+  }) => <input ref={ref} {...props} />,
+}));
+
+vi.mock("@/react/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock("@/react/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
+  DropdownMenuTrigger: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/react/components/ui/feature-modal", () => ({
+  FeatureModal: () => <div data-testid="feature-modal" />,
+}));
+
+vi.mock("./EmailInput", () => ({
+  EmailInput: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => <input value={value} onChange={(e) => onChange(e.target.value)} />,
+}));
+
+vi.mock("./UserPasswordSection", () => ({
+  getPasswordErrors: () => ({ hasHint: false, hasMismatch: false }),
+  UserPasswordSection: () => <div data-testid="password-section" />,
+}));
+
+vi.mock(
+  "@/react/pages/settings/two-factor/RegenerateRecoveryCodesView",
+  () => ({
+    RegenerateRecoveryCodesView: () => <div data-testid="recovery-codes" />,
+  })
+);
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+let ProfilePage: typeof import("./ProfilePage").ProfilePage;
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  return {
+    container,
+    render: async () => {
+      await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+      });
+    },
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+};
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ ProfilePage } = await import("./ProfilePage"));
+});
+
+describe("ProfilePage", () => {
+  test("renders the updated self profile from the update response", async () => {
+    const { container, render, unmount } = renderIntoContainer(<ProfilePage />);
+
+    await render();
+    expect(container.textContent).toContain("Old Alice");
+
+    const edit = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "common.edit"
+    );
+    await act(async () => {
+      edit?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const titleInput = container.querySelector("input")!;
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value"
+      )?.set?.call(titleInput, "New Alice");
+      titleInput.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const save = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "common.save"
+    );
+    await act(async () => {
+      save?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.updateUser).toHaveBeenCalled();
+    expect(container.textContent).toContain("New Alice");
+
+    unmount();
+  });
+});

--- a/frontend/src/react/pages/settings/profile/ProfilePage.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.tsx
@@ -25,7 +25,9 @@ import { FeatureModal } from "@/react/components/ui/feature-modal";
 import { Input } from "@/react/components/ui/input";
 import { useUnsavedChangesGuard } from "@/react/hooks/useUnsavedChangesGuard";
 import { useVueState } from "@/react/hooks/useVueState";
+import { displayRoleTitleFromList } from "@/react/lib/role";
 import { RegenerateRecoveryCodesView } from "@/react/pages/settings/two-factor/RegenerateRecoveryCodesView";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import {
   WORKSPACE_ROUTE_404,
@@ -42,7 +44,6 @@ import {
   useAuthStore,
   useCurrentUserV1,
   useSettingV1Store,
-  useUserStore,
   useWorkspaceV1Store,
 } from "@/store";
 import {
@@ -56,12 +57,7 @@ import { State } from "@/types/proto-es/v1/common_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import type { User } from "@/types/proto-es/v1/user_service_pb";
 import { UpdateUserRequestSchema } from "@/types/proto-es/v1/user_service_pb";
-import {
-  displayRoleTitle,
-  hasWorkspacePermissionV2,
-  setDocumentTitle,
-  sortRoles,
-} from "@/utils";
+import { hasWorkspacePermissionV2, setDocumentTitle, sortRoles } from "@/utils";
 import { migrateUserStorage } from "@/utils/storage-migrate";
 import { EmailInput } from "./EmailInput";
 import { getPasswordErrors, UserPasswordSection } from "./UserPasswordSection";
@@ -75,19 +71,22 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
 
   const authStore = useAuthStore();
   const settingV1Store = useSettingV1Store();
-  const userStore = useUserStore();
+  const getOrFetchUserByIdentifier = useAppStore(
+    (state) => state.getOrFetchUserByIdentifier
+  );
+  const updateUser = useAppStore((state) => state.updateUser);
+  const updateEmail = useAppStore((state) => state.updateEmail);
+  const roleList = useAppStore((state) => state.roleList);
   const workspaceStore = useWorkspaceV1Store();
   const actuatorStore = useActuatorV1Store();
 
   // --- Reactive Vue state ---
   const currentUser = useVueState(() => useCurrentUserV1().value);
+  const principalUser = useAppStore((state) =>
+    principalEmail ? state.getUserByIdentifier(principalEmail) : undefined
+  );
 
-  const user = useVueState(() => {
-    if (principalEmail) {
-      return userStore.getUserByIdentifier(principalEmail) ?? unknownUser();
-    }
-    return useCurrentUserV1().value;
-  });
+  const user = principalEmail ? (principalUser ?? unknownUser()) : currentUser;
 
   const userRoles = useVueState(() => [
     ...workspaceStore.getWorkspaceRolesByName(user.name),
@@ -177,7 +176,7 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
         return;
       }
       (async () => {
-        const fetched = await userStore.getOrFetchUserByIdentifier({
+        const fetched = await getOrFetchUserByIdentifier({
           identifier: principalEmail,
           fallback: false,
         });
@@ -243,10 +242,7 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
     try {
       if (emailChanged) {
         const oldEmail = user.email;
-        const updatedUser = await userStore.updateEmail(
-          oldEmail,
-          editingUser.email
-        );
+        const updatedUser = await updateEmail(oldEmail, editingUser.email);
         migrateUserStorage(oldEmail, editingUser.email);
         if (isSelf) {
           authStore.updateCurrentUserNameForEmailChange(updatedUser.name);
@@ -254,7 +250,7 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
       }
 
       if (updateMaskPaths.length > 0) {
-        await userStore.updateUser(
+        await updateUser(
           create(UpdateUserRequestSchema, {
             user: editingUser,
             updateMask: create(FieldMaskSchema, {
@@ -337,7 +333,7 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
   }, [requireMfa, t]);
 
   const handleDisable2FA = useCallback(async () => {
-    await userStore.updateUser(
+    await updateUser(
       create(UpdateUserRequestSchema, {
         user: {
           name: user.name,
@@ -463,7 +459,7 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
                       key={role}
                       className="inline-flex items-center rounded-full px-3 py-0.5 text-sm font-medium bg-control-bg text-control"
                     >
-                      {displayRoleTitle(role)}
+                      {displayRoleTitleFromList(role, roleList)}
                     </span>
                   ))}
                 </div>

--- a/frontend/src/react/pages/settings/profile/ProfilePage.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.tsx
@@ -81,7 +81,8 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
   const actuatorStore = useActuatorV1Store();
 
   // --- Reactive Vue state ---
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const legacyCurrentUser = useVueState(() => useCurrentUserV1().value);
+  const [currentUser, setCurrentUser] = useState(legacyCurrentUser);
   const principalUser = useAppStore((state) =>
     principalEmail ? state.getUserByIdentifier(principalEmail) : undefined
   );
@@ -167,6 +168,10 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
 
   // --- Effects ---
 
+  useEffect(() => {
+    setCurrentUser(legacyCurrentUser);
+  }, [legacyCurrentUser]);
+
   // On mount: validate account type and fetch user
   useEffect(() => {
     if (principalEmail) {
@@ -246,11 +251,12 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
         migrateUserStorage(oldEmail, editingUser.email);
         if (isSelf) {
           authStore.updateCurrentUserNameForEmailChange(updatedUser.name);
+          setCurrentUser(updatedUser);
         }
       }
 
       if (updateMaskPaths.length > 0) {
-        await updateUser(
+        const updatedUser = await updateUser(
           create(UpdateUserRequestSchema, {
             user: editingUser,
             updateMask: create(FieldMaskSchema, {
@@ -260,6 +266,9 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
             regenerateTempMfaSecret: false,
           })
         );
+        if (isSelf) {
+          setCurrentUser(updatedUser);
+        }
       }
 
       if (emailChanged || updateMaskPaths.length > 0) {
@@ -333,7 +342,7 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
   }, [requireMfa, t]);
 
   const handleDisable2FA = useCallback(async () => {
-    await updateUser(
+    const updatedUser = await updateUser(
       create(UpdateUserRequestSchema, {
         user: {
           name: user.name,
@@ -344,6 +353,9 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
         }),
       })
     );
+    if (isSelf) {
+      setCurrentUser(updatedUser);
+    }
     setShowDisable2FAConfirm(false);
     pushNotification({
       module: "bytebase",

--- a/frontend/src/react/pages/settings/two-factor/RegenerateRecoveryCodesView.tsx
+++ b/frontend/src/react/pages/settings/two-factor/RegenerateRecoveryCodesView.tsx
@@ -4,7 +4,8 @@ import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
 import { useVueState } from "@/react/hooks/useVueState";
-import { pushNotification, useCurrentUserV1, useUserStore } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification, useCurrentUserV1 } from "@/store";
 import { UpdateUserRequestSchema } from "@/types/proto-es/v1/user_service_pb";
 import { RecoveryCodesView } from "./RecoveryCodesView";
 
@@ -18,12 +19,12 @@ export function RegenerateRecoveryCodesView({
   onClose,
 }: RegenerateRecoveryCodesViewProps) {
   const { t } = useTranslation();
-  const userStore = useUserStore();
+  const updateUser = useAppStore((state) => state.updateUser);
   const currentUser = useVueState(() => useCurrentUserV1().value);
   const [recoveryCodesDownloaded, setRecoveryCodesDownloaded] = useState(false);
 
   useEffect(() => {
-    userStore.updateUser(
+    updateUser(
       create(UpdateUserRequestSchema, {
         user: {
           name: currentUser.name,
@@ -37,7 +38,7 @@ export function RegenerateRecoveryCodesView({
   }, []);
 
   const regenerateRecoveryCodes = useCallback(async () => {
-    await userStore.updateUser(
+    await updateUser(
       create(UpdateUserRequestSchema, {
         user: {
           name: currentUser.name,
@@ -54,7 +55,7 @@ export function RegenerateRecoveryCodesView({
       title: t("two-factor.messages.recovery-codes-regenerated"),
     });
     onClose();
-  }, [currentUser.name, onClose, t, userStore]);
+  }, [currentUser.name, onClose, t, updateUser]);
 
   return (
     <>

--- a/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.test.tsx
+++ b/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.test.tsx
@@ -1,0 +1,183 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const currentTimestamp = () => ({
+  seconds: BigInt(Math.floor(Date.now() / 1000)),
+  nanos: 0,
+});
+
+const legacyCurrentUser = {
+  name: "users/alice@example.com",
+  email: "alice@example.com",
+  tempOtpSecret: "old-secret",
+  tempOtpSecretCreatedTime: currentTimestamp(),
+  tempRecoveryCodes: [],
+};
+
+const regeneratedCurrentUser = {
+  ...legacyCurrentUser,
+  tempOtpSecret: "new-secret",
+  tempOtpSecretCreatedTime: currentTimestamp(),
+};
+
+const mocks = vi.hoisted(() => ({
+  useVueState: vi.fn<(getter: () => unknown) => unknown>((getter) => getter()),
+  useCurrentUserV1: vi.fn(() => ({ value: legacyCurrentUser })),
+  updateUser: vi.fn(async () => regeneratedCurrentUser),
+  pushNotification: vi.fn(),
+  routerReplace: vi.fn(),
+  currentRoute: {
+    value: { name: "workspace.setting.profile" },
+  },
+}));
+
+vi.mock("@/react/hooks/useVueState", () => ({
+  useVueState: mocks.useVueState,
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      updateUser: mocks.updateUser,
+    }),
+}));
+
+vi.mock("@/store", () => ({
+  pushNotification: mocks.pushNotification,
+  useCurrentUserV1: mocks.useCurrentUserV1,
+}));
+
+vi.mock("@/router", () => ({
+  router: {
+    replace: mocks.routerReplace,
+    currentRoute: mocks.currentRoute,
+  },
+}));
+
+vi.mock("@/router/auth", () => ({
+  AUTH_2FA_SETUP_MODULE: "auth.2fa-setup",
+}));
+
+vi.mock("@/router/dashboard/workspaceSetting", () => ({
+  SETTING_ROUTE_PROFILE: "workspace.setting.profile",
+}));
+
+vi.mock("@bufbuild/protobuf", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@bufbuild/protobuf")>();
+  return {
+    ...actual,
+    create: (_schema: unknown, data: Record<string, unknown>) => data,
+  };
+});
+
+vi.mock("@/types/proto-es/v1/user_service_pb", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/types/proto-es/v1/user_service_pb")
+    >();
+  return {
+    ...actual,
+    UpdateUserRequestSchema: {},
+  };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) =>
+      vars ? `${key}:${JSON.stringify(vars)}` : key,
+  }),
+}));
+
+vi.mock("qrcode.react", () => ({
+  QRCodeSVG: ({ value }: { value: string }) => (
+    <div data-testid="qr-code" data-value={value} />
+  ),
+}));
+
+vi.mock("@/react/components/LearnMoreLink", () => ({
+  LearnMoreLink: () => <a href="https://example.com">learn</a>,
+}));
+
+vi.mock("@/react/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/react/components/ui/otp-input", () => ({
+  OtpInput: () => <div data-testid="otp-input" />,
+}));
+
+vi.mock("./RecoveryCodesView", () => ({
+  RecoveryCodesView: () => <div data-testid="recovery-codes" />,
+}));
+
+vi.mock("./TwoFactorSecretModal", () => ({
+  TwoFactorSecretModal: ({ secret }: { secret: string }) => (
+    <div data-testid="secret-modal" data-secret={secret} />
+  ),
+}));
+
+let TwoFactorSetupPage: typeof import("./TwoFactorSetupPage").TwoFactorSetupPage;
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  return {
+    container,
+    render: async () => {
+      await act(async () => {
+        root.render(element);
+        await Promise.resolve();
+      });
+    },
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+};
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  ({ TwoFactorSetupPage } = await import("./TwoFactorSetupPage"));
+});
+
+describe("TwoFactorSetupPage", () => {
+  test("renders regenerated MFA secret from the update response", async () => {
+    const { container, render, unmount } = renderIntoContainer(
+      <TwoFactorSetupPage />
+    );
+
+    await render();
+
+    expect(mocks.updateUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        regenerateTempMfaSecret: true,
+      })
+    );
+    expect(
+      container
+        .querySelector('[data-testid="qr-code"]')
+        ?.getAttribute("data-value")
+    ).toContain("secret=new-secret");
+    expect(
+      container
+        .querySelector('[data-testid="secret-modal"]')
+        ?.getAttribute("data-secret")
+    ).toBe("new-secret");
+
+    unmount();
+  });
+});

--- a/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.tsx
+++ b/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.tsx
@@ -9,10 +9,11 @@ import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { Button } from "@/react/components/ui/button";
 import { OtpInput } from "@/react/components/ui/otp-input";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_2FA_SETUP_MODULE } from "@/router/auth";
 import { SETTING_ROUTE_PROFILE } from "@/router/dashboard/workspaceSetting";
-import { pushNotification, useCurrentUserV1, useUserStore } from "@/store";
+import { pushNotification, useCurrentUserV1 } from "@/store";
 import { UpdateUserRequestSchema } from "@/types/proto-es/v1/user_service_pb";
 import { RecoveryCodesView } from "./RecoveryCodesView";
 import { TwoFactorSecretModal } from "./TwoFactorSecretModal";
@@ -31,7 +32,7 @@ interface TwoFactorSetupPageProps {
 
 export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
   const { t } = useTranslation();
-  const userStore = useUserStore();
+  const updateUser = useAppStore((state) => state.updateUser);
   const currentUser = useVueState(() => useCurrentUserV1().value);
 
   const [currentStep, setCurrentStep] = useState<Step>(SETUP_AUTH_APP_STEP);
@@ -86,7 +87,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
   }, [updateCountdown, stopCountdown]);
 
   const regenerateTempMfaSecret = useCallback(async () => {
-    await userStore.updateUser(
+    await updateUser(
       create(UpdateUserRequestSchema, {
         user: {
           name: currentUser.name,
@@ -97,7 +98,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
         regenerateTempMfaSecret: true,
       })
     );
-  }, [currentUser.name, userStore]);
+  }, [currentUser.name, updateUser]);
 
   // On mount: regenerate secret and start countdown
   useEffect(() => {
@@ -112,7 +113,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
   const verifyOTPCode = useCallback(
     async (codes: string[]) => {
       try {
-        await userStore.updateUser(
+        await updateUser(
           create(UpdateUserRequestSchema, {
             user: {
               name: currentUser.name,
@@ -133,7 +134,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
       }
       return true;
     },
-    [currentUser.name, userStore]
+    [currentUser.name, updateUser]
   );
 
   const handleOtpFinish = useCallback(
@@ -176,7 +177,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
   }, [cancelAction]);
 
   const tryFinishSetup = useCallback(async () => {
-    await userStore.updateUser(
+    await updateUser(
       create(UpdateUserRequestSchema, {
         user: {
           name: currentUser.name,
@@ -198,7 +199,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
     } else {
       router.replace({ name: SETTING_ROUTE_PROFILE });
     }
-  }, [currentUser.name, t, userStore]);
+  }, [currentUser.name, t, updateUser]);
 
   const allowNext =
     currentStep === SETUP_AUTH_APP_STEP

--- a/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.tsx
+++ b/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.tsx
@@ -33,7 +33,8 @@ interface TwoFactorSetupPageProps {
 export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
   const { t } = useTranslation();
   const updateUser = useAppStore((state) => state.updateUser);
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const legacyCurrentUser = useVueState(() => useCurrentUserV1().value);
+  const [currentUser, setCurrentUser] = useState(legacyCurrentUser);
 
   const [currentStep, setCurrentStep] = useState<Step>(SETUP_AUTH_APP_STEP);
   const [showSecretModal, setShowSecretModal] = useState(false);
@@ -47,6 +48,10 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
   // Keep a ref to currentUser so the interval callback always reads fresh state
   const currentUserRef = useRef(currentUser);
   currentUserRef.current = currentUser;
+
+  useEffect(() => {
+    setCurrentUser(legacyCurrentUser);
+  }, [legacyCurrentUser]);
 
   const stopCountdown = useCallback(() => {
     if (countdownRef.current) {
@@ -87,7 +92,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
   }, [updateCountdown, stopCountdown]);
 
   const regenerateTempMfaSecret = useCallback(async () => {
-    await updateUser(
+    const user = await updateUser(
       create(UpdateUserRequestSchema, {
         user: {
           name: currentUser.name,
@@ -98,6 +103,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
         regenerateTempMfaSecret: true,
       })
     );
+    setCurrentUser(user);
   }, [currentUser.name, updateUser]);
 
   // On mount: regenerate secret and start countdown
@@ -113,7 +119,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
   const verifyOTPCode = useCallback(
     async (codes: string[]) => {
       try {
-        await updateUser(
+        const user = await updateUser(
           create(UpdateUserRequestSchema, {
             user: {
               name: currentUser.name,
@@ -124,6 +130,7 @@ export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
             otpCode: codes.join(""),
           })
         );
+        setCurrentUser(user);
       } catch (error) {
         pushNotification({
           module: "bytebase",

--- a/frontend/src/react/pages/workspace/MyIssuesPage.creators.test.ts
+++ b/frontend/src/react/pages/workspace/MyIssuesPage.creators.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+
+import source from "./MyIssuesPage.tsx?raw";
+
+describe("my issue list creator cache", () => {
+  test("fetches listed issue creators before rendering fallback names", () => {
+    expect(source).toMatch(
+      /const batchGetOrFetchUsers = useAppStore\(\s*\(state\) => state\.batchGetOrFetchUsers\s*\)/
+    );
+    expect(source).toMatch(
+      /batchGetOrFetchUsers\(paged\.dataList\.map\(\(issue\) => issue\.creator\)\)/
+    );
+  });
+});

--- a/frontend/src/react/pages/workspace/MyIssuesPage.tsx
+++ b/frontend/src/react/pages/workspace/MyIssuesPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/react/components/IssueTable";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { refreshIssueList, useCurrentUserV1, useIssueV1Store } from "@/store";
 import { ApprovalStatus } from "@/types/proto-es/v1/common_pb";
@@ -28,6 +29,9 @@ export function MyIssuesPage() {
   const { t } = useTranslation();
   const issueStore = useIssueV1Store();
   const currentUser = useCurrentUserV1();
+  const batchGetOrFetchUsers = useAppStore(
+    (state) => state.batchGetOrFetchUsers
+  );
   const me = useVueState(() => currentUser.value);
 
   const defaultSearchParams = useCallback((): SearchParams => {
@@ -122,6 +126,13 @@ export function MyIssuesPage() {
     sessionKey: "bb.issue-table.my-issues",
     fetchList: fetchIssueList,
   });
+
+  useEffect(() => {
+    if (paged.dataList.length === 0) {
+      return;
+    }
+    void batchGetOrFetchUsers(paged.dataList.map((issue) => issue.creator));
+  }, [batchGetOrFetchUsers, paged.dataList]);
 
   // Scope options (no project scope — cross-project)
   const scopeOptions = useIssueSearchScopeOptions();

--- a/frontend/src/react/stores/app/changelog.ts
+++ b/frontend/src/react/stores/app/changelog.ts
@@ -1,0 +1,210 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import { databaseServiceClientConnect } from "@/connect";
+import { UNKNOWN_ID } from "@/types";
+import {
+  ChangelogView,
+  GetChangelogRequestSchema,
+  ListChangelogsRequestSchema,
+} from "@/types/proto-es/v1/database_service_pb";
+import { extractChangelogUID } from "@/utils/v1/changelog";
+import type { AppSliceCreator, ChangelogSlice } from "./types";
+
+const changelogCacheKey = (name: string, view: ChangelogView) =>
+  `${name}|${view}`;
+
+const normalizeView = (view?: ChangelogView) => view ?? ChangelogView.BASIC;
+
+const changelogListCacheKey = (params: {
+  parent: string;
+  view?: ChangelogView;
+  pageSize?: number;
+  pageToken?: string;
+  filter?: string;
+}) =>
+  [
+    params.parent,
+    normalizeView(params.view),
+    params.pageSize ?? 0,
+    params.pageToken ?? "",
+    params.filter ?? "",
+  ].join("|");
+
+export const createChangelogSlice: AppSliceCreator<ChangelogSlice> = (
+  set,
+  get
+) => ({
+  changelogsByCacheKey: {},
+  changelogsByDatabase: {},
+  changelogRequests: {},
+
+  clearChangelogCache: (parent) => {
+    set((state) => {
+      return {
+        changelogsByDatabase: Object.fromEntries(
+          Object.entries(state.changelogsByDatabase).filter(
+            ([key]) => !key.startsWith(`${parent}|`)
+          )
+        ),
+      };
+    });
+  },
+
+  listChangelogs: async (params) => {
+    const { parent } = params;
+    if (!parent) {
+      throw new Error('"parent" field is required');
+    }
+
+    const view = normalizeView(params.view);
+    const listCacheKey = changelogListCacheKey({
+      parent,
+      pageSize: params.pageSize,
+      pageToken: params.pageToken,
+      view,
+      filter: params.filter,
+    });
+    const response = await databaseServiceClientConnect.listChangelogs(
+      createProto(ListChangelogsRequestSchema, {
+        parent,
+        pageSize: params.pageSize,
+        pageToken: params.pageToken ?? "",
+        view,
+        filter: params.filter ?? "",
+      })
+    );
+    set((state) => ({
+      changelogsByDatabase: {
+        ...state.changelogsByDatabase,
+        [listCacheKey]: response.changelogs,
+      },
+      changelogsByCacheKey: {
+        ...state.changelogsByCacheKey,
+        ...Object.fromEntries(
+          response.changelogs.map((changelog) => [
+            changelogCacheKey(changelog.name, view),
+            changelog,
+          ])
+        ),
+      },
+    }));
+    return {
+      changelogs: response.changelogs,
+      nextPageToken: response.nextPageToken,
+    };
+  },
+
+  getOrFetchChangelogListOfDatabase: async (database, pageSize, view) => {
+    const cached =
+      get().changelogsByDatabase[
+        changelogListCacheKey({
+          parent: database,
+          pageSize,
+          view: normalizeView(view),
+        })
+      ];
+    if (cached) return cached;
+    const response = await get().listChangelogs({
+      parent: database,
+      pageSize,
+      view: normalizeView(view),
+    });
+    return response.changelogs;
+  },
+
+  changelogListByDatabase: (database) =>
+    Object.entries(get().changelogsByDatabase).find(([key]) => {
+      const [parent, view, , pageToken, filter] = key.split("|");
+      return (
+        parent === database &&
+        view === String(ChangelogView.BASIC) &&
+        pageToken === "" &&
+        filter === ""
+      );
+    })?.[1] ?? [],
+
+  fetchChangelog: async (params) => {
+    if (!params.name) return undefined;
+    const view = normalizeView(params.view);
+    const changelog = await databaseServiceClientConnect.getChangelog(
+      createProto(GetChangelogRequestSchema, {
+        name: params.name,
+        view,
+      })
+    );
+    set((state) => ({
+      changelogsByCacheKey: {
+        ...state.changelogsByCacheKey,
+        [changelogCacheKey(changelog.name, view)]: changelog,
+      },
+    }));
+    return changelog;
+  },
+
+  getOrFetchChangelogByName: async (name, view = ChangelogView.BASIC) => {
+    const uid = extractChangelogUID(name);
+    if (!uid || uid === String(UNKNOWN_ID)) {
+      return undefined;
+    }
+
+    const key = changelogCacheKey(name, view);
+    const cached = get().changelogsByCacheKey[key];
+    if (cached) return cached;
+    const pending = get().changelogRequests[key];
+    if (pending) return pending;
+
+    const request = get()
+      .fetchChangelog({ name, view })
+      .finally(() => {
+        set((state) => {
+          const { [key]: _, ...changelogRequests } = state.changelogRequests;
+          return { changelogRequests };
+        });
+      });
+    set((state) => ({
+      changelogRequests: { ...state.changelogRequests, [key]: request },
+    }));
+    return request;
+  },
+
+  getChangelogByName: (name, view) => {
+    if (view === undefined) {
+      return (
+        get().changelogsByCacheKey[
+          changelogCacheKey(name, ChangelogView.FULL)
+        ] ??
+        get().changelogsByCacheKey[changelogCacheKey(name, ChangelogView.BASIC)]
+      );
+    }
+    return get().changelogsByCacheKey[changelogCacheKey(name, view)];
+  },
+
+  fetchPreviousChangelog: async (name) => {
+    const parts = name.split("/changelogs/");
+    if (parts.length !== 2) {
+      return undefined;
+    }
+    const database = parts[0];
+    const currentUid = extractChangelogUID(name);
+    if (!currentUid || currentUid === String(UNKNOWN_ID)) {
+      return undefined;
+    }
+
+    const { changelogs } = await get().listChangelogs({
+      parent: database,
+      pageSize: 1000,
+      view: ChangelogView.BASIC,
+    });
+    const index = changelogs.findIndex(
+      (changelog) => extractChangelogUID(changelog.name) === currentUid
+    );
+    if (index < 0 || index === changelogs.length - 1) {
+      return undefined;
+    }
+    return get().getOrFetchChangelogByName(
+      changelogs[index + 1].name,
+      ChangelogView.FULL
+    );
+  },
+});
+
+export { changelogCacheKey };

--- a/frontend/src/react/stores/app/iam.ts
+++ b/frontend/src/react/stores/app/iam.ts
@@ -28,7 +28,11 @@ export const createIamSlice: AppSliceCreator<IamSlice> = (set, get) => ({
       roleServiceClientConnect
         .listRoles(createProto(ListRolesRequestSchema, {}))
         .then((response) => {
-          set({ roles: response.roles, rolesRequest: undefined });
+          set({
+            roles: response.roles,
+            roleList: response.roles,
+            rolesRequest: undefined,
+          });
           return response.roles;
         })
         .catch(() => {

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -1,6 +1,7 @@
 import { create as createProto } from "@bufbuild/protobuf";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ReactShellBridgeEvent } from "@/react/shell-bridge";
+import { UNKNOWN_PROJECT_NAME } from "@/types";
 import { ExprSchema } from "@/types/proto-es/google/type/expr_pb";
 import {
   AccessGrant_Status,
@@ -35,7 +36,10 @@ import {
   PlanType,
   SubscriptionSchema,
 } from "@/types/proto-es/v1/subscription_service_pb";
-import { UserSchema } from "@/types/proto-es/v1/user_service_pb";
+import {
+  UpdateUserRequestSchema,
+  UserSchema,
+} from "@/types/proto-es/v1/user_service_pb";
 import { WorkloadIdentitySchema } from "@/types/proto-es/v1/workload_identity_service_pb";
 import {
   storageKeyIntroState,
@@ -64,6 +68,8 @@ const mocks = vi.hoisted(() => ({
   getWorkspace: vi.fn(),
   getIamPolicy: vi.fn(),
   listRoles: vi.fn(),
+  updateRole: vi.fn(),
+  deleteRole: vi.fn(),
   getSubscription: vi.fn(),
   uploadLicense: vi.fn(),
   getSetting: vi.fn(),
@@ -104,6 +110,14 @@ const mocks = vi.hoisted(() => ({
   createIdentityProvider: vi.fn(),
   updateIdentityProvider: vi.fn(),
   deleteIdentityProvider: vi.fn(),
+  listUsers: vi.fn(),
+  getUser: vi.fn(),
+  batchGetUsers: vi.fn(),
+  createUser: vi.fn(),
+  updateUser: vi.fn(),
+  updateEmail: vi.fn(),
+  deleteUser: vi.fn(),
+  undeleteUser: vi.fn(),
   getAccessGrant: vi.fn(),
   searchMyAccessGrants: vi.fn(),
   createAccessGrant: vi.fn(),
@@ -186,6 +200,8 @@ vi.mock("@/connect", () => ({
   },
   roleServiceClientConnect: {
     listRoles: mocks.listRoles,
+    updateRole: mocks.updateRole,
+    deleteRole: mocks.deleteRole,
   },
   settingServiceClientConnect: {
     getSetting: mocks.getSetting,
@@ -196,6 +212,14 @@ vi.mock("@/connect", () => ({
   },
   userServiceClientConnect: {
     getCurrentUser: mocks.getCurrentUser,
+    listUsers: mocks.listUsers,
+    getUser: mocks.getUser,
+    batchGetUsers: mocks.batchGetUsers,
+    createUser: mocks.createUser,
+    updateUser: mocks.updateUser,
+    updateEmail: mocks.updateEmail,
+    deleteUser: mocks.deleteUser,
+    undeleteUser: mocks.undeleteUser,
   },
   workspaceServiceClientConnect: {
     getWorkspace: mocks.getWorkspace,
@@ -232,6 +256,32 @@ const groupB = createProto(GroupSchema, {
   name: "groups/dev@example.com",
   email: "dev@example.com",
   title: "Dev",
+});
+
+const userA = createProto(UserSchema, {
+  name: "users/bob@example.com",
+  email: "bob@example.com",
+  title: "Bob",
+  state: State.ACTIVE,
+});
+
+const userB = createProto(UserSchema, {
+  name: "users/carol@example.com",
+  email: "carol@example.com",
+  title: "Carol",
+  state: State.ACTIVE,
+});
+
+const roleA = createProto(RoleSchema, {
+  name: "roles/sql-reviewer",
+  title: "SQL Reviewer",
+  permissions: ["bb.plans.get"],
+});
+
+const roleB = createProto(RoleSchema, {
+  name: "roles/sql-admin",
+  title: "SQL Admin",
+  permissions: ["bb.plans.get", "bb.plans.update"],
 });
 
 const serviceAccountA = createProto(ServiceAccountSchema, {
@@ -314,6 +364,214 @@ describe("useAppStore", () => {
     expect(result.nextPageToken).toBe("next");
     expect(store.getState().groupsByName[groupA.name]).toBe(groupA);
     expect(store.getState().groupsByName[groupB.name]).toBe(groupB);
+  });
+
+  test("lists users and populates the user cache", async () => {
+    mocks.listUsers.mockResolvedValue({
+      users: [userA, userB],
+      nextPageToken: "next-user",
+    });
+    const store = createAppStore();
+    store.setState({
+      currentUser: user,
+      roles: [
+        createProto(RoleSchema, {
+          name: "roles/user-viewer",
+          permissions: ["bb.users.list"],
+        }),
+      ],
+      workspacePolicy: createProto(IamPolicySchema, {
+        bindings: [
+          createProto(BindingSchema, {
+            role: "roles/user-viewer",
+            members: [`user:${user.email}`],
+          }),
+        ],
+      }),
+    });
+
+    const result = await store.getState().listUsers({
+      pageSize: 50,
+      filter: { query: "BO", state: State.DELETED },
+    });
+
+    expect(result.users).toEqual([userA, userB]);
+    expect(result.nextPageToken).toBe("next-user");
+    expect(store.getState().usersByName[userA.name]).toBe(userA);
+    expect(store.getState().usersByName[userB.name]).toBe(userB);
+    expect(mocks.listUsers).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter:
+          '(name.contains("bo") || email.contains("bo")) && state == "DELETED"',
+        showDeleted: true,
+      })
+    );
+  });
+
+  test("listUsers omits the project filter for unknown project sentinels", async () => {
+    mocks.listUsers.mockResolvedValue({
+      users: [userA],
+      nextPageToken: "",
+    });
+    const store = createAppStore();
+    store.setState({
+      currentUser: user,
+      roles: [
+        createProto(RoleSchema, {
+          name: "roles/user-viewer",
+          permissions: ["bb.users.list"],
+        }),
+      ],
+      workspacePolicy: createProto(IamPolicySchema, {
+        bindings: [
+          createProto(BindingSchema, {
+            role: "roles/user-viewer",
+            members: [`user:${user.email}`],
+          }),
+        ],
+      }),
+    });
+
+    for (const project of [UNKNOWN_PROJECT_NAME, "projects/-"]) {
+      await store.getState().listUsers({
+        pageSize: 50,
+        filter: { project, query: "BO" },
+      });
+    }
+
+    expect(
+      mocks.listUsers.mock.calls.map(([request]) => request.filter)
+    ).toEqual([
+      '(name.contains("bo") || email.contains("bo"))',
+      '(name.contains("bo") || email.contains("bo"))',
+    ]);
+  });
+
+  test("batchGetOrFetchUsers fetches missing users and returns unknown fallback", async () => {
+    mocks.batchGetUsers.mockResolvedValue({ users: [userB] });
+    const store = createAppStore();
+    store.setState({ usersByName: { [userA.name]: userA } });
+
+    const result = await store
+      .getState()
+      .batchGetOrFetchUsers([userA.name, "user:carol@example.com"]);
+
+    expect(mocks.batchGetUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ names: [userB.name] }),
+      expect.anything()
+    );
+    expect(result.map((u) => u.name)).toEqual([userA.name, userB.name]);
+
+    mocks.batchGetUsers.mockResolvedValueOnce({ users: [] });
+    const missing = await store
+      .getState()
+      .batchGetOrFetchUsers(["users/missing@example.com"]);
+
+    expect(missing[0]).toMatchObject({
+      name: "users/missing@example.com",
+      email: "missing@example.com",
+    });
+  });
+
+  test("updateEmail removes the old user cache key and stores the updated user", async () => {
+    const updated = createProto(UserSchema, {
+      ...userA,
+      name: "users/robert@example.com",
+      email: "robert@example.com",
+    });
+    mocks.updateEmail.mockResolvedValue(updated);
+    const store = createAppStore();
+    store.setState({ usersByName: { [userA.name]: userA } });
+
+    const result = await store
+      .getState()
+      .updateEmail("bob@example.com", "robert@example.com");
+
+    expect(result).toBe(updated);
+    expect(store.getState().usersByName[userA.name]).toBeUndefined();
+    expect(store.getState().usersByName[updated.name]).toBe(updated);
+  });
+
+  test("updateUser passes allowMissing through without requiring an existing user", async () => {
+    mocks.updateUser.mockResolvedValue(userA);
+    const store = createAppStore();
+
+    const result = await store.getState().updateUser(
+      createProto(UpdateUserRequestSchema, {
+        user: userA,
+        allowMissing: true,
+      })
+    );
+
+    expect(result).toBe(userA);
+    expect(mocks.getUser).not.toHaveBeenCalled();
+    expect(mocks.updateUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user: userA,
+        allowMissing: true,
+      })
+    );
+    expect(store.getState().usersByName[userA.name]).toBe(userA);
+  });
+
+  test("create archive and restore update activated user count when server info is loaded", async () => {
+    mocks.createUser.mockResolvedValue(userA);
+    mocks.deleteUser.mockResolvedValue({});
+    mocks.undeleteUser.mockResolvedValue(userA);
+    const store = createAppStore();
+    store.setState({
+      serverInfo: createProto(ActuatorInfoSchema, {
+        activatedUserCount: 2,
+      }),
+    });
+
+    await store.getState().createUser(userA);
+    expect(store.getState().serverInfo?.activatedUserCount).toBe(3);
+
+    await store.getState().archiveUser(userA.name);
+    expect(store.getState().serverInfo?.activatedUserCount).toBe(2);
+
+    await store.getState().restoreUser(userA.name);
+    expect(store.getState().serverInfo?.activatedUserCount).toBe(3);
+
+    store.setState({
+      serverInfo: createProto(ActuatorInfoSchema, {
+        activatedUserCount: 0,
+      }),
+    });
+
+    await store.getState().archiveUser(userA.name);
+    expect(store.getState().serverInfo?.activatedUserCount).toBe(0);
+  });
+
+  test("lists, upserts, and deletes roles", async () => {
+    mocks.listRoles.mockResolvedValue({ roles: [roleA] });
+    mocks.updateRole.mockResolvedValue(roleB);
+    mocks.deleteRole.mockResolvedValue({});
+    const store = createAppStore();
+
+    const roles = await store.getState().listRoles();
+    expect(roles).toEqual([roleA]);
+    expect(store.getState().getRoleByName(roleA.name)).toBe(roleA);
+
+    const upserted = await store.getState().upsertRole(roleB);
+    expect(upserted).toBe(roleB);
+    expect(store.getState().roleList).toEqual([roleA, roleB]);
+    expect(mocks.updateRole).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: roleB,
+        updateMask: expect.objectContaining({
+          paths: ["title", "description", "permissions"],
+        }),
+        allowMissing: true,
+      })
+    );
+
+    await store.getState().deleteRole(roleA);
+    expect(store.getState().roleList).toEqual([roleB]);
+    expect(mocks.deleteRole).toHaveBeenCalledWith(
+      expect.objectContaining({ name: roleA.name })
+    );
   });
 
   test("batchGetOrFetchGroups skips cached groups and preserves order", async () => {

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -10,7 +10,11 @@ import {
 import { ActuatorInfoSchema } from "@/types/proto-es/v1/actuator_service_pb";
 import { State } from "@/types/proto-es/v1/common_pb";
 import { DatabaseGroupSchema } from "@/types/proto-es/v1/database_group_service_pb";
-import { DatabaseSchema$ } from "@/types/proto-es/v1/database_service_pb";
+import {
+  ChangelogSchema,
+  ChangelogView,
+  DatabaseSchema$,
+} from "@/types/proto-es/v1/database_service_pb";
 import { GroupSchema } from "@/types/proto-es/v1/group_service_pb";
 import {
   BindingSchema,
@@ -19,7 +23,12 @@ import {
 import { IdentityProviderSchema } from "@/types/proto-es/v1/idp_service_pb";
 import { InstanceRoleSchema } from "@/types/proto-es/v1/instance_role_service_pb";
 import { InstanceSchema } from "@/types/proto-es/v1/instance_service_pb";
-import { ProjectSchema } from "@/types/proto-es/v1/project_service_pb";
+import {
+  ProjectSchema,
+  WebhookSchema,
+} from "@/types/proto-es/v1/project_service_pb";
+import { ReleaseSchema } from "@/types/proto-es/v1/release_service_pb";
+import { RevisionSchema } from "@/types/proto-es/v1/revision_service_pb";
 import { RoleSchema } from "@/types/proto-es/v1/role_service_pb";
 import { ServiceAccountSchema } from "@/types/proto-es/v1/service_account_service_pb";
 import {
@@ -78,10 +87,24 @@ const mocks = vi.hoisted(() => ({
   batchGetProjects: vi.fn(),
   searchProjects: vi.fn(),
   createProject: vi.fn(),
+  addWebhook: vi.fn(),
+  updateWebhook: vi.fn(),
+  removeWebhook: vi.fn(),
+  testWebhook: vi.fn(),
   getInstance: vi.fn(),
+  listReleases: vi.fn(),
+  getRelease: vi.fn(),
+  updateRelease: vi.fn(),
+  deleteRelease: vi.fn(),
+  undeleteRelease: vi.fn(),
+  listRevisions: vi.fn(),
+  getRevision: vi.fn(),
+  deleteRevision: vi.fn(),
   getDatabase: vi.fn(),
   batchGetDatabases: vi.fn(),
   listDatabases: vi.fn(),
+  listChangelogs: vi.fn(),
+  getChangelog: vi.fn(),
   getDatabaseGroup: vi.fn(),
   listDatabaseGroups: vi.fn(),
   getSheet: vi.fn(),
@@ -139,6 +162,22 @@ vi.mock("@/connect", () => ({
     batchGetProjects: mocks.batchGetProjects,
     searchProjects: mocks.searchProjects,
     createProject: mocks.createProject,
+    addWebhook: mocks.addWebhook,
+    updateWebhook: mocks.updateWebhook,
+    removeWebhook: mocks.removeWebhook,
+    testWebhook: mocks.testWebhook,
+  },
+  releaseServiceClientConnect: {
+    listReleases: mocks.listReleases,
+    getRelease: mocks.getRelease,
+    updateRelease: mocks.updateRelease,
+    deleteRelease: mocks.deleteRelease,
+    undeleteRelease: mocks.undeleteRelease,
+  },
+  revisionServiceClientConnect: {
+    listRevisions: mocks.listRevisions,
+    getRevision: mocks.getRevision,
+    deleteRevision: mocks.deleteRevision,
   },
   instanceServiceClientConnect: {
     getInstance: mocks.getInstance,
@@ -147,6 +186,8 @@ vi.mock("@/connect", () => ({
     getDatabase: mocks.getDatabase,
     batchGetDatabases: mocks.batchGetDatabases,
     listDatabases: mocks.listDatabases,
+    listChangelogs: mocks.listChangelogs,
+    getChangelog: mocks.getChangelog,
   },
   databaseGroupServiceClientConnect: {
     getDatabaseGroup: mocks.getDatabaseGroup,
@@ -307,6 +348,39 @@ const identityProviderA = createProto(IdentityProviderSchema, {
 const accessGrantA = createProto(AccessGrantSchema, {
   name: "projects/a/accessGrants/ag1",
   status: AccessGrant_Status.ACTIVE,
+});
+
+const releaseA = createProto(ReleaseSchema, {
+  name: "projects/a/releases/rel-a",
+  state: State.ACTIVE,
+});
+
+const releaseB = createProto(ReleaseSchema, {
+  name: "projects/a/releases/rel-b",
+  state: State.ACTIVE,
+});
+
+const revisionA = createProto(RevisionSchema, {
+  name: "instances/i1/databases/db1/revisions/1",
+});
+
+const revisionB = createProto(RevisionSchema, {
+  name: "instances/i1/databases/db1/revisions/2",
+});
+
+const changelogA = createProto(ChangelogSchema, {
+  name: "instances/i1/databases/db1/changelogs/1",
+});
+
+const changelogB = createProto(ChangelogSchema, {
+  name: "instances/i1/databases/db1/changelogs/2",
+  schema: "full",
+});
+
+const webhookA = createProto(WebhookSchema, {
+  name: "projects/a/webhooks/hook-a",
+  title: "Hook A",
+  url: "https://example.com/hook-a",
 });
 
 const timestampSeconds = (seconds: number) => ({
@@ -571,6 +645,274 @@ describe("useAppStore", () => {
     expect(store.getState().roleList).toEqual([roleB]);
     expect(mocks.deleteRole).toHaveBeenCalledWith(
       expect.objectContaining({ name: roleA.name })
+    );
+  });
+
+  test("lists releases and marks cached release deleted", async () => {
+    mocks.listReleases.mockResolvedValue({
+      releases: [releaseA, releaseB],
+      nextPageToken: "next-release",
+    });
+    mocks.deleteRelease.mockResolvedValue({});
+    const store = createAppStore();
+
+    const result = await store
+      .getState()
+      .listReleasesByProject("projects/a", { pageSize: 20 }, true, "x");
+
+    expect(result.releases).toEqual([releaseA, releaseB]);
+    expect(result.nextPageToken).toBe("next-release");
+    expect(store.getState().releasesByName[releaseA.name]).toBe(releaseA);
+    expect(store.getState().getReleasesByProject("projects/a")).toEqual([
+      releaseA,
+      releaseB,
+    ]);
+    expect(mocks.listReleases).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent: "projects/a",
+        pageSize: 20,
+        showDeleted: true,
+        filter: "x",
+      })
+    );
+
+    await store.getState().deleteRelease(releaseA.name);
+
+    expect(store.getState().releasesByName[releaseA.name].state).toBe(
+      State.DELETED
+    );
+  });
+
+  test("deduplicates release fetches and clears failed requests", async () => {
+    mocks.getRelease.mockResolvedValueOnce(releaseA);
+    const store = createAppStore();
+
+    const [first, second] = await Promise.all([
+      store.getState().fetchRelease(releaseA.name),
+      store.getState().fetchRelease(releaseA.name),
+    ]);
+
+    expect(first).toBe(releaseA);
+    expect(second).toBe(releaseA);
+    expect(mocks.getRelease).toHaveBeenCalledTimes(1);
+    expect(store.getState().releaseRequests[releaseA.name]).toBeUndefined();
+
+    const failedName = "projects/a/releases/fail";
+    mocks.getRelease.mockRejectedValueOnce(new Error("failed"));
+    await expect(store.getState().fetchRelease(failedName)).rejects.toThrow(
+      "failed"
+    );
+    expect(store.getState().releaseRequests[failedName]).toBeUndefined();
+  });
+
+  test("paginates all revisions by database and caches results", async () => {
+    mocks.listRevisions
+      .mockResolvedValueOnce({
+        revisions: [revisionA],
+        nextPageToken: "next-revision",
+      })
+      .mockResolvedValueOnce({
+        revisions: [revisionB],
+        nextPageToken: "",
+      });
+    const store = createAppStore();
+
+    const result = await store
+      .getState()
+      .listAllRevisionsByDatabase("instances/i1/databases/db1", {
+        pageSize: 1,
+      });
+
+    expect(result).toEqual([revisionA, revisionB]);
+    expect(mocks.listRevisions.mock.calls.map(([request]) => request)).toEqual([
+      expect.objectContaining({
+        parent: "instances/i1/databases/db1",
+        pageSize: 1,
+        pageToken: "",
+      }),
+      expect.objectContaining({
+        parent: "instances/i1/databases/db1",
+        pageSize: 1,
+        pageToken: "next-revision",
+      }),
+    ]);
+    expect(
+      store.getState().getRevisionsByDatabase("instances/i1/databases/db1")
+    ).toEqual([revisionA, revisionB]);
+  });
+
+  test("deleteRevision removes the cached revision", async () => {
+    mocks.deleteRevision.mockResolvedValue({});
+    const store = createAppStore();
+    store.setState({ revisionsByName: { [revisionA.name]: revisionA } });
+
+    await store.getState().deleteRevision(revisionA.name);
+
+    expect(store.getState().revisionsByName[revisionA.name]).toBeUndefined();
+  });
+
+  test("caches changelog list by database and view preference", async () => {
+    mocks.listChangelogs.mockResolvedValue({ changelogs: [changelogA] });
+    const fullChangelog = createProto(ChangelogSchema, {
+      ...changelogA,
+      schema: "full",
+    });
+    const store = createAppStore();
+
+    const changelogs = await store.getState().listChangelogs({
+      parent: "instances/i1/databases/db1",
+      pageSize: 20,
+      view: ChangelogView.BASIC,
+    });
+
+    expect(changelogs.changelogs).toEqual([changelogA]);
+    expect(
+      store.getState().changelogListByDatabase("instances/i1/databases/db1")
+    ).toEqual([changelogA]);
+    expect(store.getState().getChangelogByName(changelogA.name)).toBe(
+      changelogA
+    );
+
+    store.setState({
+      changelogsByCacheKey: {
+        ...store.getState().changelogsByCacheKey,
+        [`${changelogA.name}|${ChangelogView.FULL}`]: fullChangelog,
+      },
+    });
+
+    expect(store.getState().getChangelogByName(changelogA.name)).toBe(
+      fullChangelog
+    );
+  });
+
+  test("keeps changelog list cache isolated by request dimensions", async () => {
+    mocks.listChangelogs
+      .mockResolvedValueOnce({ changelogs: [changelogA] })
+      .mockResolvedValueOnce({ changelogs: [changelogB] });
+    const store = createAppStore();
+
+    await store.getState().listChangelogs({
+      parent: "instances/i1/databases/db1",
+      pageSize: 20,
+      view: ChangelogView.BASIC,
+    });
+    const full = await store
+      .getState()
+      .getOrFetchChangelogListOfDatabase(
+        "instances/i1/databases/db1",
+        20,
+        ChangelogView.FULL
+      );
+
+    expect(full).toEqual([changelogB]);
+    expect(mocks.listChangelogs).toHaveBeenCalledTimes(2);
+    expect(
+      store.getState().changelogListByDatabase("instances/i1/databases/db1")
+    ).toEqual([changelogA]);
+
+    mocks.listChangelogs.mockReset();
+    mocks.listChangelogs
+      .mockResolvedValueOnce({ changelogs: [changelogB] })
+      .mockResolvedValueOnce({ changelogs: [changelogA, changelogB] });
+    const filteredStore = createAppStore();
+
+    await filteredStore.getState().listChangelogs({
+      parent: "instances/i1/databases/db1",
+      pageSize: 20,
+      view: ChangelogView.BASIC,
+      filter: 'status == "DONE"',
+    });
+    const unfiltered = await filteredStore
+      .getState()
+      .getOrFetchChangelogListOfDatabase("instances/i1/databases/db1", 20);
+
+    expect(unfiltered).toEqual([changelogA, changelogB]);
+    expect(mocks.listChangelogs).toHaveBeenCalledTimes(2);
+    expect(
+      filteredStore
+        .getState()
+        .changelogListByDatabase("instances/i1/databases/db1")
+    ).toEqual([changelogA, changelogB]);
+  });
+
+  test("deduplicates changelog fetches and skips unknown changelog names", async () => {
+    mocks.getChangelog.mockResolvedValue(changelogA);
+    const store = createAppStore();
+
+    const missing = await store
+      .getState()
+      .getOrFetchChangelogByName("instances/i1/databases/db1/changelogs/-1");
+    expect(missing).toBeUndefined();
+
+    const [first, second] = await Promise.all([
+      store.getState().getOrFetchChangelogByName(changelogA.name),
+      store.getState().getOrFetchChangelogByName(changelogA.name),
+    ]);
+
+    expect(first).toBe(changelogA);
+    expect(second).toBe(changelogA);
+    expect(mocks.getChangelog).toHaveBeenCalledTimes(1);
+    expect(
+      store.getState().changelogRequests[
+        `${changelogA.name}|${ChangelogView.BASIC}`
+      ]
+    ).toBeUndefined();
+  });
+
+  test("project webhook operations call through and lookup by id", async () => {
+    const projectWithWebhook = createProto(ProjectSchema, {
+      ...projectA,
+      webhooks: [webhookA],
+    });
+    mocks.addWebhook.mockResolvedValue(projectWithWebhook);
+    mocks.updateWebhook.mockResolvedValue(projectWithWebhook);
+    mocks.removeWebhook.mockResolvedValue(projectA);
+    mocks.testWebhook.mockResolvedValue({ error: "no route" });
+    const store = createAppStore();
+
+    expect(
+      store
+        .getState()
+        .getProjectWebhookFromProjectById(projectWithWebhook, "hook-a")
+    ).toBe(webhookA);
+
+    await expect(
+      store.getState().createProjectWebhook(projectA.name, webhookA)
+    ).resolves.toBe(projectWithWebhook);
+    expect(store.getState().projectsByName[projectWithWebhook.name]).toBe(
+      projectWithWebhook
+    );
+
+    await expect(
+      store.getState().updateProjectWebhook(webhookA, ["title"])
+    ).resolves.toBe(projectWithWebhook);
+    expect(store.getState().projectsByName[projectWithWebhook.name]).toBe(
+      projectWithWebhook
+    );
+
+    await expect(store.getState().deleteProjectWebhook(webhookA)).resolves.toBe(
+      projectA
+    );
+    expect(store.getState().projectsByName[projectA.name]).toBe(projectA);
+
+    await expect(
+      store.getState().testProjectWebhook(projectWithWebhook, webhookA)
+    ).resolves.toEqual({ error: "no route" });
+
+    expect(mocks.addWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({ project: projectA.name, webhook: webhookA })
+    );
+    expect(mocks.updateWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        webhook: webhookA,
+        updateMask: expect.objectContaining({ paths: ["title"] }),
+      })
+    );
+    expect(mocks.removeWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({ webhook: webhookA })
+    );
+    expect(mocks.testWebhook).toHaveBeenCalledWith(
+      expect.objectContaining({ project: projectA.name, webhook: webhookA })
     );
   });
 

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -648,6 +648,22 @@ describe("useAppStore", () => {
     );
   });
 
+  test("loads workspace permission roles into the role display cache", async () => {
+    mocks.getCurrentUser.mockResolvedValue(user);
+    mocks.getActuatorInfo.mockResolvedValue({
+      workspace: "workspaces/default",
+    });
+    mocks.getWorkspace.mockResolvedValue({ name: "workspaces/default" });
+    mocks.listRoles.mockResolvedValue({ roles: [roleA, roleB] });
+    mocks.getIamPolicy.mockResolvedValue(createProto(IamPolicySchema, {}));
+    const store = createAppStore();
+
+    await store.getState().loadWorkspacePermissionState();
+
+    expect(store.getState().roles).toEqual([roleA, roleB]);
+    expect(store.getState().roleList).toEqual([roleA, roleB]);
+  });
+
   test("lists releases and marks cached release deleted", async () => {
     mocks.listReleases.mockResolvedValue({
       releases: [releaseA, releaseB],

--- a/frontend/src/react/stores/app/index.ts
+++ b/frontend/src/react/stores/app/index.ts
@@ -11,8 +11,10 @@ import { createInstanceRoleSlice } from "./instanceRole";
 import { createNotificationSlice } from "./notification";
 import { createPreferencesSlice } from "./preferences";
 import { createProjectSlice } from "./project";
+import { createRoleSlice } from "./role";
 import { createServiceAccountSlice } from "./serviceAccount";
 import { createSheetSlice } from "./sheet";
+import { createUserSlice } from "./user";
 import { createWorkspaceSlice } from "./workspace";
 import { createWorkloadIdentitySlice } from "./workloadIdentity";
 
@@ -41,6 +43,8 @@ export const createAppStore = () =>
     ...createWorkloadIdentitySlice(...args),
     ...createIdentityProviderSlice(...args),
     ...createAccessGrantSlice(...args),
+    ...createUserSlice(...args),
+    ...createRoleSlice(...args),
     ...createNotificationSlice(...args),
     ...createPreferencesSlice(...args),
   }));

--- a/frontend/src/react/stores/app/index.ts
+++ b/frontend/src/react/stores/app/index.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { createAccessGrantSlice } from "./accessGrant";
 import { createAuthSlice } from "./auth";
+import { createChangelogSlice } from "./changelog";
 import { createDatabaseSlice } from "./database";
 import { createDBGroupSlice } from "./dbGroup";
 import { createGroupSlice } from "./group";
@@ -11,6 +12,9 @@ import { createInstanceRoleSlice } from "./instanceRole";
 import { createNotificationSlice } from "./notification";
 import { createPreferencesSlice } from "./preferences";
 import { createProjectSlice } from "./project";
+import { createProjectWebhookSlice } from "./projectWebhook";
+import { createReleaseSlice } from "./release";
+import { createRevisionSlice } from "./revision";
 import { createRoleSlice } from "./role";
 import { createServiceAccountSlice } from "./serviceAccount";
 import { createSheetSlice } from "./sheet";
@@ -45,6 +49,10 @@ export const createAppStore = () =>
     ...createAccessGrantSlice(...args),
     ...createUserSlice(...args),
     ...createRoleSlice(...args),
+    ...createReleaseSlice(...args),
+    ...createRevisionSlice(...args),
+    ...createChangelogSlice(...args),
+    ...createProjectWebhookSlice(...args),
     ...createNotificationSlice(...args),
     ...createPreferencesSlice(...args),
   }));

--- a/frontend/src/react/stores/app/projectWebhook.ts
+++ b/frontend/src/react/stores/app/projectWebhook.ts
@@ -1,0 +1,66 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import { projectServiceClientConnect } from "@/connect";
+import {
+  AddWebhookRequestSchema,
+  RemoveWebhookRequestSchema,
+  TestWebhookRequestSchema,
+  UpdateWebhookRequestSchema,
+} from "@/types/proto-es/v1/project_service_pb";
+import { extractProjectWebhookID } from "@/utils";
+import type { AppSliceCreator, ProjectWebhookSlice } from "./types";
+
+export const createProjectWebhookSlice: AppSliceCreator<ProjectWebhookSlice> = (
+  set
+) => ({
+  getProjectWebhookFromProjectById: (project, webhookId) => {
+    return project.webhooks.find(
+      (webhook) => extractProjectWebhookID(webhook.name) === webhookId
+    );
+  },
+
+  createProjectWebhook: async (project, webhook) => {
+    const response = await projectServiceClientConnect.addWebhook(
+      createProto(AddWebhookRequestSchema, {
+        project,
+        webhook,
+      })
+    );
+    set((state) => ({
+      projectsByName: { ...state.projectsByName, [response.name]: response },
+    }));
+    return response;
+  },
+
+  updateProjectWebhook: async (webhook, updateMask) => {
+    const response = await projectServiceClientConnect.updateWebhook(
+      createProto(UpdateWebhookRequestSchema, {
+        webhook,
+        updateMask: { paths: updateMask },
+      })
+    );
+    set((state) => ({
+      projectsByName: { ...state.projectsByName, [response.name]: response },
+    }));
+    return response;
+  },
+
+  deleteProjectWebhook: async (webhook) => {
+    const response = await projectServiceClientConnect.removeWebhook(
+      createProto(RemoveWebhookRequestSchema, { webhook })
+    );
+    set((state) => ({
+      projectsByName: { ...state.projectsByName, [response.name]: response },
+    }));
+    return response;
+  },
+
+  testProjectWebhook: async (project, webhook) => {
+    const response = await projectServiceClientConnect.testWebhook(
+      createProto(TestWebhookRequestSchema, {
+        project: project.name,
+        webhook,
+      })
+    );
+    return { error: response.error };
+  },
+});

--- a/frontend/src/react/stores/app/release.ts
+++ b/frontend/src/react/stores/app/release.ts
@@ -1,0 +1,132 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import { createContextValues } from "@connectrpc/connect";
+import { releaseServiceClientConnect } from "@/connect";
+import { silentContextKey } from "@/connect/context-key";
+import { isValidReleaseName, unknownRelease } from "@/types";
+import { State } from "@/types/proto-es/v1/common_pb";
+import type { Release } from "@/types/proto-es/v1/release_service_pb";
+import {
+  DeleteReleaseRequestSchema,
+  GetReleaseRequestSchema,
+  ListReleasesRequestSchema,
+  ReleaseSchema,
+  UndeleteReleaseRequestSchema,
+  UpdateReleaseRequestSchema,
+} from "@/types/proto-es/v1/release_service_pb";
+import type { AppSliceCreator, ReleaseSlice } from "./types";
+
+export const createReleaseSlice: AppSliceCreator<ReleaseSlice> = (
+  set,
+  get
+) => ({
+  releasesByName: {},
+  releaseRequests: {},
+
+  listReleasesByProject: async (project, pagination, showDeleted, filter) => {
+    const response = await releaseServiceClientConnect.listReleases(
+      createProto(ListReleasesRequestSchema, {
+        parent: project,
+        pageSize: pagination?.pageSize,
+        pageToken: pagination?.pageToken ?? "",
+        showDeleted: Boolean(showDeleted),
+        filter: filter ?? "",
+      })
+    );
+    set((state) => ({
+      releasesByName: {
+        ...state.releasesByName,
+        ...Object.fromEntries(
+          response.releases.map((release) => [release.name, release])
+        ),
+      },
+    }));
+    return {
+      releases: response.releases,
+      nextPageToken: response.nextPageToken,
+    };
+  },
+
+  fetchRelease: async (name, silent = false) => {
+    if (!isValidReleaseName(name)) return undefined;
+    const existing = get().releasesByName[name];
+    if (existing) return existing;
+    const pending = get().releaseRequests[name];
+    if (pending) return pending;
+
+    const request = releaseServiceClientConnect
+      .getRelease(createProto(GetReleaseRequestSchema, { name }), {
+        contextValues: createContextValues().set(silentContextKey, silent),
+      })
+      .then((release) => {
+        set((state) => {
+          const { [name]: _, ...releaseRequests } = state.releaseRequests;
+          return {
+            releasesByName: {
+              ...state.releasesByName,
+              [release.name]: release,
+            },
+            releaseRequests,
+          };
+        });
+        return release;
+      })
+      .catch((error) => {
+        set((state) => {
+          const { [name]: _, ...releaseRequests } = state.releaseRequests;
+          return { releaseRequests };
+        });
+        throw error;
+      });
+    set((state) => ({
+      releaseRequests: { ...state.releaseRequests, [name]: request },
+    }));
+    return request;
+  },
+
+  getReleasesByProject: (project) => {
+    return Object.values(get().releasesByName).filter((release) =>
+      release.name.startsWith(`${project}/releases/`)
+    );
+  },
+
+  getReleaseByName: (name) => get().releasesByName[name] ?? unknownRelease(),
+
+  updateRelease: async (release, updateMask) => {
+    const response = await releaseServiceClientConnect.updateRelease(
+      createProto(UpdateReleaseRequestSchema, {
+        release: createProto(ReleaseSchema, release as Release),
+        updateMask: { paths: updateMask },
+      })
+    );
+    set((state) => ({
+      releasesByName: { ...state.releasesByName, [response.name]: response },
+    }));
+    return response;
+  },
+
+  deleteRelease: async (name) => {
+    await releaseServiceClientConnect.deleteRelease(
+      createProto(DeleteReleaseRequestSchema, { name })
+    );
+    set((state) => {
+      const cached = state.releasesByName[name];
+      if (!cached) return {};
+      return {
+        releasesByName: {
+          ...state.releasesByName,
+          [name]: { ...cached, state: State.DELETED },
+        },
+      };
+    });
+  },
+
+  undeleteRelease: async (name) => {
+    const response = await releaseServiceClientConnect.undeleteRelease(
+      createProto(UndeleteReleaseRequestSchema, { name })
+    );
+    set((state) => ({
+      releasesByName: { ...state.releasesByName, [response.name]: response },
+    }));
+    return response;
+  },
+});

--- a/frontend/src/react/stores/app/revision.ts
+++ b/frontend/src/react/stores/app/revision.ts
@@ -1,0 +1,84 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import { revisionServiceClientConnect } from "@/connect";
+import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
+import {
+  DeleteRevisionRequestSchema,
+  GetRevisionRequestSchema,
+  ListRevisionsRequestSchema,
+} from "@/types/proto-es/v1/revision_service_pb";
+import type { AppSliceCreator, RevisionSlice } from "./types";
+
+const revisionNamePrefix = "revisions/";
+
+export const createRevisionSlice: AppSliceCreator<RevisionSlice> = (
+  set,
+  get
+) => ({
+  revisionsByName: {},
+
+  listRevisionsByDatabase: async (database, pagination) => {
+    const response = await revisionServiceClientConnect.listRevisions(
+      createProto(ListRevisionsRequestSchema, {
+        parent: database,
+        pageSize: pagination?.pageSize,
+        pageToken: pagination?.pageToken ?? "",
+      })
+    );
+    set((state) => ({
+      revisionsByName: {
+        ...state.revisionsByName,
+        ...Object.fromEntries(
+          response.revisions.map((revision) => [revision.name, revision])
+        ),
+      },
+    }));
+    return {
+      revisions: response.revisions,
+      nextPageToken: response.nextPageToken,
+    };
+  },
+
+  listAllRevisionsByDatabase: async (database, pagination) => {
+    const revisions: Revision[] = [];
+    let pageToken = "";
+    do {
+      const response = await get().listRevisionsByDatabase(database, {
+        pageSize: pagination?.pageSize,
+        pageToken,
+      });
+      revisions.push(...response.revisions);
+      pageToken = response.nextPageToken;
+    } while (pageToken);
+    return revisions;
+  },
+
+  fetchRevision: async (name) => {
+    const cached = get().revisionsByName[name];
+    if (cached) return cached;
+    const revision = await revisionServiceClientConnect.getRevision(
+      createProto(GetRevisionRequestSchema, { name })
+    );
+    set((state) => ({
+      revisionsByName: { ...state.revisionsByName, [revision.name]: revision },
+    }));
+    return revision;
+  },
+
+  getRevisionsByDatabase: (database) => {
+    return Object.values(get().revisionsByName).filter((revision) =>
+      revision.name.startsWith(`${database}/${revisionNamePrefix}`)
+    );
+  },
+
+  getRevisionByName: (name) => get().revisionsByName[name],
+
+  deleteRevision: async (name) => {
+    await revisionServiceClientConnect.deleteRevision(
+      createProto(DeleteRevisionRequestSchema, { name })
+    );
+    set((state) => {
+      const { [name]: _, ...revisionsByName } = state.revisionsByName;
+      return { revisionsByName };
+    });
+  },
+});

--- a/frontend/src/react/stores/app/role.ts
+++ b/frontend/src/react/stores/app/role.ts
@@ -1,0 +1,53 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import { roleServiceClientConnect } from "@/connect";
+import {
+  DeleteRoleRequestSchema,
+  ListRolesRequestSchema,
+  UpdateRoleRequestSchema,
+} from "@/types/proto-es/v1/role_service_pb";
+import type { AppSliceCreator, RoleSlice } from "./types";
+
+export const createRoleSlice: AppSliceCreator<RoleSlice> = (set, get) => ({
+  roleList: [],
+
+  listRoles: async () => {
+    const response = await roleServiceClientConnect.listRoles(
+      createProto(ListRolesRequestSchema, {})
+    );
+    set({ roleList: response.roles });
+    return response.roles;
+  },
+
+  getRoleByName: (name) => get().roleList.find((role) => role.name === name),
+
+  upsertRole: async (role) => {
+    const response = await roleServiceClientConnect.updateRole(
+      createProto(UpdateRoleRequestSchema, {
+        role,
+        updateMask: {
+          paths: ["title", "description", "permissions"],
+        },
+        allowMissing: true,
+      })
+    );
+    set((state) => {
+      const index = state.roleList.findIndex((r) => r.name === role.name);
+      if (index < 0) {
+        return { roleList: [...state.roleList, response] };
+      }
+      const roleList = [...state.roleList];
+      roleList.splice(index, 1, response);
+      return { roleList };
+    });
+    return response;
+  },
+
+  deleteRole: async (role) => {
+    await roleServiceClientConnect.deleteRole(
+      createProto(DeleteRoleRequestSchema, { name: role.name })
+    );
+    set((state) => ({
+      roleList: state.roleList.filter((r) => r.name !== role.name),
+    }));
+  },
+});

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -6,7 +6,13 @@ import type { AccessGrant } from "@/types/proto-es/v1/access_grant_service_pb";
 import type { ActuatorInfo } from "@/types/proto-es/v1/actuator_service_pb";
 import type { State } from "@/types/proto-es/v1/common_pb";
 import type { DatabaseGroup } from "@/types/proto-es/v1/database_group_service_pb";
-import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import type {
+  Changelog,
+  ChangelogView,
+  Database,
+  GetChangelogRequest,
+  ListChangelogsRequest,
+} from "@/types/proto-es/v1/database_service_pb";
 import type { Group } from "@/types/proto-es/v1/group_service_pb";
 import type { IamPolicy } from "@/types/proto-es/v1/iam_policy_pb";
 import type { IdentityProvider } from "@/types/proto-es/v1/idp_service_pb";
@@ -15,7 +21,9 @@ import type {
   Instance,
   InstanceResource,
 } from "@/types/proto-es/v1/instance_service_pb";
-import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import type { Project, Webhook } from "@/types/proto-es/v1/project_service_pb";
+import type { Release } from "@/types/proto-es/v1/release_service_pb";
+import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
 import type { Role } from "@/types/proto-es/v1/role_service_pb";
 import type { ServiceAccount } from "@/types/proto-es/v1/service_account_service_pb";
 import type { WorkspaceProfileSetting } from "@/types/proto-es/v1/setting_service_pb";
@@ -379,6 +387,90 @@ export type RoleSlice = {
   deleteRole: (role: Role) => Promise<void>;
 };
 
+export type ReleaseSlice = {
+  releasesByName: Record<string, Release>;
+  releaseRequests: Record<string, Promise<Release | undefined>>;
+  listReleasesByProject: (
+    project: string,
+    pagination?: { pageSize?: number; pageToken?: string },
+    showDeleted?: boolean,
+    filter?: string
+  ) => Promise<{ releases: Release[]; nextPageToken: string }>;
+  fetchRelease: (
+    name: string,
+    silent?: boolean
+  ) => Promise<Release | undefined>;
+  getReleasesByProject: (project: string) => Release[];
+  getReleaseByName: (name: string) => Release;
+  updateRelease: (
+    release: Partial<Release>,
+    updateMask: string[]
+  ) => Promise<Release>;
+  deleteRelease: (name: string) => Promise<void>;
+  undeleteRelease: (name: string) => Promise<Release>;
+};
+
+export type RevisionSlice = {
+  revisionsByName: Record<string, Revision>;
+  listRevisionsByDatabase: (
+    database: string,
+    pagination?: { pageSize?: number; pageToken?: string }
+  ) => Promise<{ revisions: Revision[]; nextPageToken: string }>;
+  listAllRevisionsByDatabase: (
+    database: string,
+    pagination?: { pageSize?: number }
+  ) => Promise<Revision[]>;
+  fetchRevision: (name: string) => Promise<Revision>;
+  getRevisionsByDatabase: (database: string) => Revision[];
+  getRevisionByName: (name: string) => Revision | undefined;
+  deleteRevision: (name: string) => Promise<void>;
+};
+
+export type ChangelogSlice = {
+  changelogsByCacheKey: Record<string, Changelog>;
+  changelogsByDatabase: Record<string, Changelog[]>;
+  changelogRequests: Record<string, Promise<Changelog | undefined>>;
+  clearChangelogCache: (parent: string) => void;
+  listChangelogs: (
+    params: Partial<ListChangelogsRequest>
+  ) => Promise<{ changelogs: Changelog[]; nextPageToken: string }>;
+  getOrFetchChangelogListOfDatabase: (
+    database: string,
+    pageSize: number,
+    view?: ChangelogView
+  ) => Promise<Changelog[]>;
+  changelogListByDatabase: (database: string) => Changelog[];
+  fetchChangelog: (
+    params: Partial<GetChangelogRequest>
+  ) => Promise<Changelog | undefined>;
+  getOrFetchChangelogByName: (
+    name: string,
+    view?: ChangelogView
+  ) => Promise<Changelog | undefined>;
+  getChangelogByName: (
+    name: string,
+    view?: ChangelogView
+  ) => Changelog | undefined;
+  fetchPreviousChangelog: (name: string) => Promise<Changelog | undefined>;
+};
+
+export type ProjectWebhookSlice = {
+  getProjectWebhookFromProjectById: (
+    project: Project,
+    webhookId: string
+  ) => Webhook | undefined;
+  createProjectWebhook: (project: string, webhook: Webhook) => Promise<Project>;
+  updateProjectWebhook: (
+    webhook: Webhook,
+    updateMask: string[]
+  ) => Promise<Project>;
+  deleteProjectWebhook: (webhook: Webhook) => Promise<Project>;
+  testProjectWebhook: (
+    project: Project,
+    webhook: Webhook
+  ) => Promise<{ error: string }>;
+};
+
 export type NotificationSlice = {
   notify: (notification: NotificationCreate) => void;
 };
@@ -406,6 +498,10 @@ export type AppStoreState = AuthSlice &
   AccessGrantSlice &
   UserSlice &
   RoleSlice &
+  ReleaseSlice &
+  RevisionSlice &
+  ChangelogSlice &
+  ProjectWebhookSlice &
   NotificationSlice &
   PreferencesSlice;
 

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -25,7 +25,10 @@ import type {
   PlanType,
   Subscription,
 } from "@/types/proto-es/v1/subscription_service_pb";
-import type { User } from "@/types/proto-es/v1/user_service_pb";
+import type {
+  UpdateUserRequest,
+  User,
+} from "@/types/proto-es/v1/user_service_pb";
 import type { WorkloadIdentity } from "@/types/proto-es/v1/workload_identity_service_pb";
 import type { Workspace } from "@/types/proto-es/v1/workspace_service_pb";
 import type { Environment } from "@/types/v1/environment";
@@ -45,6 +48,19 @@ export type GroupFilter = {
 export type AccountFilter = {
   query?: string;
   state?: State;
+};
+
+export type UserFilter = {
+  query?: string;
+  project?: string;
+  state?: State;
+};
+
+export type ListUsersParams = {
+  pageSize: number;
+  pageToken?: string;
+  filter?: UserFilter;
+  showDeleted?: boolean;
 };
 
 export type ListServiceAccountsParams = {
@@ -334,6 +350,35 @@ export type AccessGrantSlice = {
   revokeAccessGrant: (name: string) => Promise<AccessGrant>;
 };
 
+export type UserSlice = {
+  usersByName: Record<string, User>;
+  userRequests: Record<string, Promise<User | undefined>>;
+  listUsers: (
+    params: ListUsersParams
+  ) => Promise<{ users: User[]; nextPageToken: string }>;
+  fetchUser: (name: string, silent?: boolean) => Promise<User | undefined>;
+  batchGetOrFetchUsers: (names: string[]) => Promise<User[]>;
+  getOrFetchUserByIdentifier: (params: {
+    identifier: string;
+    silent?: boolean;
+    fallback?: boolean;
+  }) => Promise<User>;
+  getUserByIdentifier: (identifier: string) => User | undefined;
+  createUser: (user: User) => Promise<User>;
+  updateUser: (request: UpdateUserRequest) => Promise<User>;
+  updateEmail: (oldEmail: string, newEmail: string) => Promise<User>;
+  archiveUser: (name: string) => Promise<void>;
+  restoreUser: (name: string) => Promise<User>;
+};
+
+export type RoleSlice = {
+  roleList: Role[];
+  listRoles: () => Promise<Role[]>;
+  getRoleByName: (name: string) => Role | undefined;
+  upsertRole: (role: Role) => Promise<Role>;
+  deleteRole: (role: Role) => Promise<void>;
+};
+
 export type NotificationSlice = {
   notify: (notification: NotificationCreate) => void;
 };
@@ -359,6 +404,8 @@ export type AppStoreState = AuthSlice &
   WorkloadIdentitySlice &
   IdentityProviderSlice &
   AccessGrantSlice &
+  UserSlice &
+  RoleSlice &
   NotificationSlice &
   PreferencesSlice;
 

--- a/frontend/src/react/stores/app/user.ts
+++ b/frontend/src/react/stores/app/user.ts
@@ -1,0 +1,288 @@
+import { create as createProto } from "@bufbuild/protobuf";
+import { createContextValues } from "@connectrpc/connect";
+import { uniq } from "lodash-es";
+import { userServiceClientConnect } from "@/connect";
+import { silentContextKey } from "@/connect/context-key";
+import { userNamePrefix } from "@/react/lib/resourceName";
+import { extractUserEmail } from "@/store/modules/v1/common";
+import {
+  allUsersUser,
+  isValidProjectName,
+  isValidUserName,
+  unknownUser,
+  userBindingPrefix,
+} from "@/types";
+import { State } from "@/types/proto-es/v1/common_pb";
+import {
+  BatchGetUsersRequestSchema,
+  CreateUserRequestSchema,
+  DeleteUserRequestSchema,
+  GetUserRequestSchema,
+  ListUsersRequestSchema,
+  UndeleteUserRequestSchema,
+  UpdateEmailRequestSchema,
+  UpdateUserRequestSchema,
+} from "@/types/proto-es/v1/user_service_pb";
+import { ensureUserFullName } from "@/utils";
+import type { AppSliceCreator, UserFilter, UserSlice } from "./types";
+
+const UNKNOWN_PROJECT_NAME_LEGACY = "projects/-";
+
+export const buildUserFilter = (params: UserFilter) => {
+  const filter = [];
+  const search = params.query?.trim()?.toLowerCase();
+  if (search) {
+    filter.push(`(name.contains("${search}") || email.contains("${search}"))`);
+  }
+  if (
+    isValidProjectName(params.project) &&
+    params.project !== UNKNOWN_PROJECT_NAME_LEGACY
+  ) {
+    filter.push(`project == "${params.project}"`);
+  }
+  if (params.state === State.DELETED) {
+    filter.push(`state == "${State[params.state]}"`);
+  }
+  return filter.join(" && ");
+};
+
+export const createUserSlice: AppSliceCreator<UserSlice> = (set, get) => {
+  const adjustActivatedUserCount = (delta: number) => {
+    set((state) => {
+      if (!state.serverInfo) {
+        return {};
+      }
+      return {
+        serverInfo: {
+          ...state.serverInfo,
+          activatedUserCount: Math.max(
+            0,
+            state.serverInfo.activatedUserCount + delta
+          ),
+        },
+      };
+    });
+  };
+
+  return {
+    usersByName: { [allUsersUser().name]: allUsersUser() },
+    userRequests: {},
+
+    listUsers: async (params) => {
+      if (!get().hasWorkspacePermission("bb.users.list")) {
+        return { users: [], nextPageToken: "" };
+      }
+      const response = await userServiceClientConnect.listUsers(
+        createProto(ListUsersRequestSchema, {
+          pageSize: params.pageSize,
+          pageToken: params.pageToken,
+          filter: buildUserFilter(params.filter ?? {}),
+          showDeleted:
+            params.showDeleted ?? params.filter?.state === State.DELETED,
+        })
+      );
+      set((state) => ({
+        usersByName: {
+          ...state.usersByName,
+          ...Object.fromEntries(
+            response.users.map((user) => [user.name, user])
+          ),
+        },
+      }));
+      return { users: response.users, nextPageToken: response.nextPageToken };
+    },
+
+    fetchUser: async (name, silent = false) => {
+      const validName = ensureUserFullName(name);
+      const existing = get().usersByName[validName];
+      if (existing) return existing;
+      const pending = get().userRequests[validName];
+      if (pending) return pending;
+
+      const request = userServiceClientConnect
+        .getUser(createProto(GetUserRequestSchema, { name: validName }), {
+          contextValues: createContextValues().set(silentContextKey, silent),
+        })
+        .then((user) => {
+          set((state) => {
+            const { [validName]: _, ...userRequests } = state.userRequests;
+            return {
+              usersByName: { ...state.usersByName, [user.name]: user },
+              userRequests,
+            };
+          });
+          return user;
+        })
+        .catch(() => {
+          set((state) => {
+            const { [validName]: _, ...userRequests } = state.userRequests;
+            return { userRequests };
+          });
+          return undefined;
+        });
+      set((state) => ({
+        userRequests: { ...state.userRequests, [validName]: request },
+      }));
+      return request;
+    },
+
+    batchGetOrFetchUsers: async (names) => {
+      const validNames = uniq(names).filter(
+        (name) =>
+          Boolean(name) &&
+          (name.startsWith(userNamePrefix) ||
+            name.startsWith(userBindingPrefix))
+      );
+      const missing = validNames
+        .filter((name) => get().getUserByIdentifier(name) === undefined)
+        .map((name) => ensureUserFullName(name));
+
+      if (missing.length > 0) {
+        try {
+          const response = await userServiceClientConnect.batchGetUsers(
+            createProto(BatchGetUsersRequestSchema, { names: missing }),
+            { contextValues: createContextValues().set(silentContextKey, true) }
+          );
+          set((state) => ({
+            usersByName: {
+              ...state.usersByName,
+              ...Object.fromEntries(
+                response.users.map((user) => [user.name, user])
+              ),
+            },
+          }));
+        } catch {
+          // Match the legacy store: return cached users plus unknown fallbacks.
+        }
+      }
+
+      return validNames.map(
+        (name) => get().getUserByIdentifier(name) ?? unknownUser(name)
+      );
+    },
+
+    getOrFetchUserByIdentifier: async ({
+      identifier,
+      silent = true,
+      fallback = true,
+    }) => {
+      const user = get().getUserByIdentifier(identifier);
+      if (user) return user;
+
+      const fullname = ensureUserFullName(identifier);
+      if (!isValidUserName(fullname)) {
+        return unknownUser();
+      }
+      const fetched = await get().fetchUser(fullname, silent);
+      return fetched ?? unknownUser(fallback ? fullname : "");
+    },
+
+    getUserByIdentifier: (identifier) => {
+      if (!identifier) return undefined;
+      const id = extractUserEmail(identifier);
+      if (Number.isNaN(Number(id))) {
+        return Object.values(get().usersByName).find(
+          (user) => user.email === id
+        );
+      }
+      return get().usersByName[`${userNamePrefix}${id}`];
+    },
+
+    createUser: async (user) => {
+      const response = await userServiceClientConnect.createUser(
+        createProto(CreateUserRequestSchema, { user })
+      );
+      set((state) => ({
+        usersByName: { ...state.usersByName, [response.name]: response },
+      }));
+      adjustActivatedUserCount(1);
+      return response;
+    },
+
+    updateUser: async (request) => {
+      const name = request.user?.name || "";
+      if (!request.allowMissing) {
+        const originData = await get().getOrFetchUserByIdentifier({
+          identifier: name,
+          fallback: false,
+        });
+        if (!isValidUserName(originData.name)) {
+          throw new Error(`user with name ${name} not found`);
+        }
+      }
+
+      const response = await userServiceClientConnect.updateUser(
+        createProto(UpdateUserRequestSchema, {
+          user: request.user,
+          updateMask: request.updateMask,
+          otpCode: request.otpCode,
+          regenerateTempMfaSecret: request.regenerateTempMfaSecret,
+          regenerateRecoveryCodes: request.regenerateRecoveryCodes,
+          allowMissing: request.allowMissing,
+        })
+      );
+      set((state) => ({
+        usersByName: { ...state.usersByName, [response.name]: response },
+      }));
+      return response;
+    },
+
+    updateEmail: async (oldEmail, newEmail) => {
+      const originData = await get().getOrFetchUserByIdentifier({
+        identifier: oldEmail,
+        fallback: false,
+      });
+      if (!isValidUserName(originData.name)) {
+        throw new Error(`user with email ${oldEmail} not found`);
+      }
+
+      const oldName = originData.name;
+      const response = await userServiceClientConnect.updateEmail(
+        createProto(UpdateEmailRequestSchema, {
+          name: ensureUserFullName(oldEmail),
+          email: newEmail,
+        })
+      );
+      set((state) => {
+        const usersByName = { ...state.usersByName };
+        if (oldName !== response.name) {
+          delete usersByName[oldName];
+        }
+        usersByName[response.name] = response;
+        return { usersByName };
+      });
+      return response;
+    },
+
+    archiveUser: async (name) => {
+      const validName = ensureUserFullName(name);
+      await userServiceClientConnect.deleteUser(
+        createProto(DeleteUserRequestSchema, { name: validName })
+      );
+      set((state) => {
+        const cached = state.usersByName[validName];
+        if (!cached) return {};
+        return {
+          usersByName: {
+            ...state.usersByName,
+            [validName]: { ...cached, state: State.DELETED },
+          },
+        };
+      });
+      adjustActivatedUserCount(-1);
+    },
+
+    restoreUser: async (name) => {
+      const response = await userServiceClientConnect.undeleteUser(
+        createProto(UndeleteUserRequestSchema, {
+          name: ensureUserFullName(name),
+        })
+      );
+      set((state) => ({
+        usersByName: { ...state.usersByName, [response.name]: response },
+      }));
+      adjustActivatedUserCount(1);
+      return response;
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- Migrate user, role, release, revision, changelog, and project webhook resource reads to the React app store.
- Add app-store resource hooks and regression coverage for migrated consumers.
- Prefetch creator and role display data so migrated pages render titles instead of raw resource identifiers.

## Key Changes
- Add Zustand-backed resource slices for phase 2 resources.
- Replace migrated React consumers with app-store APIs and remove legacy Vue store dependencies from those paths.
- Add guards for creator cache hydration in plan, issue, data export, worksheet, and role display paths.

## Motivation
- Continue the Vue Pinia to React Zustand resource migration while preserving display behavior for protobuf resources.

## Testing
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test
- git diff --check