### PR TITLE
fix(frontend): stabilize target list sheets

### DIFF
--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.test.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.test.tsx
@@ -17,21 +17,50 @@ const mocks = vi.hoisted(() => {
   const onSelectedSpecIdChange = vi.fn();
 
   return {
-    Dialog: vi.fn(({ children }: { children: React.ReactNode }) => (
+    Sheet: vi.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
     )),
-    DialogClose: vi.fn(({ children }: { children: React.ReactNode }) => (
+    SheetBody: vi.fn(
+      ({
+        children,
+        className,
+      }: {
+        children: React.ReactNode;
+        className?: string;
+      }) => (
+        <div
+          className={`flex flex-1 flex-col overflow-y-auto px-6 py-4 ${className ?? ""}`}
+          data-testid="targets-sheet-body"
+        >
+          {children}
+        </div>
+      )
+    ),
+    SheetContent: vi.fn(({ children }: { children: React.ReactNode }) => (
+      <div data-testid="targets-sheet-content">{children}</div>
+    )),
+    SheetHeader: vi.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
     )),
-    DialogContent: vi.fn(({ children }: { children: React.ReactNode }) => (
+    SheetTitle: vi.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
     )),
-    DialogTitle: vi.fn(({ children }: { children: React.ReactNode }) => (
-      <div>{children}</div>
-    )),
-    SearchInput: vi.fn((props: React.InputHTMLAttributes<HTMLInputElement>) => (
-      <input {...props} />
-    )),
+    SearchInput: vi.fn(
+      ({
+        wrapperClassName,
+        ...props
+      }: React.InputHTMLAttributes<HTMLInputElement> & {
+        wrapperClassName?: string;
+      }) => (
+        <div
+          className={`relative flex-1 ${wrapperClassName ?? ""}`}
+          data-testid="targets-search-wrapper"
+          data-wrapper-class-name={wrapperClassName}
+        >
+          <input {...props} />
+        </div>
+      )
+    ),
     Select: vi.fn(({ children }: { children: React.ReactNode }) => (
       <div>{children}</div>
     )),
@@ -63,7 +92,6 @@ const mocks = vi.hoisted(() => {
     ChevronRight: vi.fn(() => <div />),
     ExternalLink: vi.fn(() => <div />),
     FolderTree: vi.fn(() => <div />),
-    X: vi.fn(() => <div />),
     useTranslation: vi.fn(() => ({
       t: (key: string) => key,
     })),
@@ -128,7 +156,6 @@ vi.mock("lucide-react", () => ({
   ChevronRight: mocks.ChevronRight,
   ExternalLink: mocks.ExternalLink,
   FolderTree: mocks.FolderTree,
-  X: mocks.X,
 }));
 
 vi.mock("react-i18next", () => ({
@@ -145,11 +172,12 @@ vi.mock("@/react/components/instance/constants", () => ({
   EngineIconPath: {},
 }));
 
-vi.mock("@/react/components/ui/dialog", () => ({
-  Dialog: mocks.Dialog,
-  DialogClose: mocks.DialogClose,
-  DialogContent: mocks.DialogContent,
-  DialogTitle: mocks.DialogTitle,
+vi.mock("@/react/components/ui/sheet", () => ({
+  Sheet: mocks.Sheet,
+  SheetBody: mocks.SheetBody,
+  SheetContent: mocks.SheetContent,
+  SheetHeader: mocks.SheetHeader,
+  SheetTitle: mocks.SheetTitle,
 }));
 
 vi.mock("@/react/components/ui/search-input", () => ({
@@ -274,9 +302,11 @@ vi.mock("./IssueDetailStatementSection", () => ({
 
 const renderIntoContainer = (element: ReturnType<typeof createElement>) => {
   const container = document.createElement("div");
+  document.body.append(container);
   const root = createRoot(container);
 
   return {
+    container,
     render: (nextElement = element) => {
       act(() => {
         root.render(nextElement);
@@ -286,6 +316,7 @@ const renderIntoContainer = (element: ReturnType<typeof createElement>) => {
       act(() => {
         root.unmount();
       });
+      container.remove();
     },
   };
 };
@@ -359,6 +390,75 @@ describe("IssueDetailDatabaseChangeView", () => {
 
     expect(() => render()).not.toThrow();
     expect(mocks.listInstanceRoles).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  test("renders all targets in a single scrollable sheet list", () => {
+    const targets = Array.from(
+      { length: 21 },
+      (_, index) => `instances/inst1/databases/db${index}`
+    );
+    mocks.useIssueDetailContext.mockReturnValue({
+      plan: {
+        hasRollout: false,
+        name: "projects/db333/plans/123",
+        specs: [
+          {
+            id: "spec-1",
+            config: {
+              case: "changeDatabaseConfig",
+              value: {
+                enablePriorBackup: false,
+                release: false,
+                targets,
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const { container, render, unmount } = renderIntoContainer(
+      <IssueDetailDatabaseChangeView
+        onSelectedSpecIdChange={mocks.onSelectedSpecIdChange}
+        selectedSpecId="spec-1"
+      />
+    );
+
+    render();
+
+    const sheetBody = container.querySelector(
+      "[data-testid='targets-sheet-body']"
+    );
+    const elements = Array.from(sheetBody?.querySelectorAll("*") ?? []);
+    const scrollArea = elements.find(
+      (element) =>
+        element.className.includes("min-h-0") &&
+        element.className.includes("flex-1") &&
+        element.className.includes("overflow-y-auto")
+    );
+    const targetList = scrollArea
+      ? Array.from(scrollArea.querySelectorAll("*")).find(
+          (element) =>
+            element.className.includes("flex") &&
+            element.className.includes("flex-col") &&
+            element.className.includes("gap-2")
+        )
+      : undefined;
+    const searchWrapper = container.querySelector(
+      "[data-testid='targets-search-wrapper']"
+    );
+    const targetRows =
+      targetList?.querySelectorAll(".w-full.rounded-lg.border") ?? [];
+
+    expect(sheetBody?.className).toContain("overflow-hidden");
+    expect(searchWrapper?.getAttribute("data-wrapper-class-name")).toContain(
+      "flex-none"
+    );
+    expect(scrollArea).toBeTruthy();
+    expect(targetList).toBeTruthy();
+    expect(targetRows.length).toBe(targets.length);
 
     unmount();
   });

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
@@ -1,15 +1,9 @@
 import { create } from "@bufbuild/protobuf";
-import { ChevronRight, ExternalLink, FolderTree, X } from "lucide-react";
+import { ChevronRight, ExternalLink, FolderTree } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { instanceRoleServiceClientConnect } from "@/connect";
 import { EngineIcon } from "@/react/components/EngineIcon";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogTitle,
-} from "@/react/components/ui/dialog";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
   Select,
@@ -18,6 +12,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/react/components/ui/select";
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/react/components/ui/sheet";
 import { Switch } from "@/react/components/ui/switch";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
@@ -694,62 +695,49 @@ function IssueDetailDatabaseChangeTargets({
         )}
       </div>
 
-      <Dialog
+      <Sheet
         open={showAllTargetsDialog}
         onOpenChange={(open) => setShowAllTargetsDialog(open)}
       >
-        <DialogContent className="relative max-w-[100vw] p-0 md:w-[50rem]">
-          <div className="flex h-full max-h-[calc(100vh-10rem)] flex-col gap-y-4">
-            <div className="flex items-center justify-between border-b px-4 py-4">
-              <DialogTitle>
-                {t("plan.targets.title")} ({targets.length})
-              </DialogTitle>
-              <DialogClose
-                render={
-                  <button
-                    className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-sm text-control transition-colors hover:bg-control-bg"
-                    type="button"
-                  />
-                }
-              >
-                <X className="h-4 w-4" />
-              </DialogClose>
-            </div>
+        <SheetContent width="wide">
+          <SheetHeader>
+            <SheetTitle>
+              {t("plan.targets.title")} ({targets.length})
+            </SheetTitle>
+          </SheetHeader>
 
-            <div className="px-4">
-              <SearchInput
-                placeholder={t("common.search")}
-                value={searchText}
-                onChange={(event) => setSearchText(event.target.value)}
-              />
-            </div>
+          <SheetBody className="gap-y-4 overflow-hidden px-4 pb-4">
+            <SearchInput
+              placeholder={t("common.search")}
+              value={searchText}
+              wrapperClassName="flex-none"
+              onChange={(event) => setSearchText(event.target.value)}
+            />
 
-            <div className="flex-1 overflow-hidden px-4 pb-4">
+            <div className="min-h-0 flex-1 overflow-y-auto">
               {isLoadingAllTargets ? (
                 <div className="flex h-full items-center justify-center">
                   <div className="h-5 w-5 animate-spin rounded-full border-2 border-control-border border-t-accent" />
                 </div>
               ) : filteredTargets.length > 0 ? (
-                <div className="h-full overflow-y-auto">
-                  <div className="flex flex-wrap gap-2">
-                    {filteredTargets.map((target) => (
-                      <div
-                        key={target}
-                        className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1 transition-all"
-                      >
-                        {isValidDatabaseName(target) ? (
-                          <IssueDetailDatabaseTarget
-                            showEnvironment
-                            target={target}
-                          />
-                        ) : isValidDatabaseGroupName(target) ? (
-                          <IssueDetailDatabaseGroupTarget target={target} />
-                        ) : (
-                          <span className="text-sm">{target}</span>
-                        )}
-                      </div>
-                    ))}
-                  </div>
+                <div className="flex flex-col gap-2">
+                  {filteredTargets.map((target) => (
+                    <div
+                      key={target}
+                      className="w-full rounded-lg border px-2 py-1.5"
+                    >
+                      {isValidDatabaseName(target) ? (
+                        <IssueDetailDatabaseTarget
+                          showEnvironment
+                          target={target}
+                        />
+                      ) : isValidDatabaseGroupName(target) ? (
+                        <IssueDetailDatabaseGroupTarget target={target} />
+                      ) : (
+                        <span className="block truncate text-sm">{target}</span>
+                      )}
+                    </div>
+                  ))}
                 </div>
               ) : (
                 <div className="flex h-full items-center justify-center text-control-light">
@@ -757,9 +745,9 @@ function IssueDetailDatabaseChangeTargets({
                 </div>
               )}
             </div>
-          </div>
-        </DialogContent>
-      </Dialog>
+          </SheetBody>
+        </SheetContent>
+      </Sheet>
     </>
   );
 }
@@ -788,21 +776,34 @@ function IssueDetailDatabaseTarget({
     instance?.title ||
     extractInstanceResourceName(target) ||
     t("common.unknown");
+  const title = [
+    showEnvironment ? environment.title : undefined,
+    instanceTitle,
+    databaseName,
+  ]
+    .filter(Boolean)
+    .join(" / ");
 
   return (
-    <div className="flex min-w-0 items-center truncate text-sm">
+    <div className="flex min-w-0 max-w-full items-center text-sm" title={title}>
       {instance && (
         <EngineIcon
           engine={instance.engine}
-          className="mr-1 inline-block h-4 w-4"
+          className="mr-1 inline-block h-4 w-4 shrink-0"
         />
       )}
       {showEnvironment && (
-        <span className="mr-1 truncate text-gray-400">{environment.title}</span>
+        <span className="mr-1 max-w-24 shrink truncate text-control-placeholder">
+          {environment.title}
+        </span>
       )}
-      <span className="truncate text-gray-600">{instanceTitle}</span>
-      <ChevronRight className="h-4 w-4 shrink-0 text-gray-500 opacity-60" />
-      <span className="truncate text-gray-800">{databaseName}</span>
+      <span className="min-w-0 shrink-[2] truncate text-control-light">
+        {instanceTitle}
+      </span>
+      <ChevronRight className="h-4 w-4 shrink-0 text-control-light/80" />
+      <span className="min-w-12 flex-1 truncate text-control">
+        {databaseName}
+      </span>
     </div>
   );
 }

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
@@ -120,8 +120,19 @@ vi.mock("@/react/components/ui/dropdown-menu", () => ({
 }));
 
 vi.mock("@/react/components/ui/search-input", () => ({
-  SearchInput: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
-    <input {...props} />
+  SearchInput: ({
+    wrapperClassName,
+    ...props
+  }: React.InputHTMLAttributes<HTMLInputElement> & {
+    wrapperClassName?: string;
+  }) => (
+    <div
+      className={`relative flex-1 ${wrapperClassName ?? ""}`}
+      data-testid="targets-search-wrapper"
+      data-wrapper-class-name={wrapperClassName}
+    >
+      <input {...props} />
+    </div>
   ),
 }));
 
@@ -164,7 +175,20 @@ vi.mock("@/react/components/ui/select", () => ({
 vi.mock("@/react/components/ui/sheet", () => ({
   Sheet: ({ children, open }: { children: ReactNode; open: boolean }) =>
     open ? <div>{children}</div> : null,
-  SheetBody: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetBody: ({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) => (
+    <div
+      className={`flex flex-1 flex-col overflow-y-auto px-6 py-4 ${className ?? ""}`}
+      data-testid="targets-sheet-body"
+    >
+      {children}
+    </div>
+  ),
   SheetContent: ({ children }: { children: ReactNode }) => (
     <div>{children}</div>
   ),
@@ -586,6 +610,79 @@ async function flush() {
 }
 
 describe("PlanDetailChangesBranch", () => {
+  it("renders all targets in a single scrollable sheet list", async () => {
+    const page = buildPageState();
+    const targets = Array.from(
+      { length: 21 },
+      (_, index) => `instances/test/databases/db_${index}`
+    );
+    page.plan.specs = [
+      {
+        id: "spec-1",
+        config: {
+          case: "changeDatabaseConfig",
+          value: {
+            targets,
+          },
+        },
+      },
+    ] as unknown as PlanDetailPageState["plan"]["specs"];
+
+    act(() => {
+      root.render(
+        <PlanDetailProvider value={page}>
+          <PlanDetailChangesBranch
+            selectedSpecId="spec-1"
+            onSelectedSpecIdChange={vi.fn()}
+          />
+        </PlanDetailProvider>
+      );
+    });
+    await flush();
+
+    const viewAllButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "plan.targets.view-all"
+    );
+    expect(viewAllButton).toBeTruthy();
+
+    await act(async () => {
+      viewAllButton?.click();
+    });
+    await flush();
+
+    const sheetBody = container.querySelector(
+      "[data-testid='targets-sheet-body']"
+    );
+    const elements = Array.from(sheetBody?.querySelectorAll("*") ?? []);
+    const scrollArea = elements.find(
+      (element) =>
+        element.className.includes("min-h-0") &&
+        element.className.includes("flex-1") &&
+        element.className.includes("overflow-y-auto")
+    );
+    const targetList = scrollArea
+      ? Array.from(scrollArea.querySelectorAll("*")).find(
+          (element) =>
+            element.className.includes("flex") &&
+            element.className.includes("flex-col") &&
+            element.className.includes("gap-2")
+        )
+      : undefined;
+    const searchWrapper = container.querySelector(
+      "[data-testid='targets-search-wrapper']"
+    );
+    const targetRows =
+      targetList?.querySelectorAll(".w-full.rounded-lg.border") ?? [];
+
+    expect(sheetBody?.className).toContain("overflow-hidden");
+    expect(searchWrapper?.getAttribute("data-wrapper-class-name")).toContain(
+      "flex-none"
+    );
+    expect(scrollArea).toBeTruthy();
+    expect(targetList).toBeTruthy();
+    expect(targetRows.length).toBe(targets.length);
+  });
+
   it("renders database group overflow as a popover action", async () => {
     mocks.dbGroupStore.getDBGroupByName.mockReturnValue({
       name: "projects/foo/databaseGroups/group-a",

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -1393,45 +1393,34 @@ function TargetsSection({
               {t("plan.targets.title")} ({targets.length})
             </SheetTitle>
           </SheetHeader>
-          <SheetBody className="gap-y-4 px-4 pb-4">
+          <SheetBody className="gap-y-4 overflow-hidden px-4 pb-4">
             <SearchInput
               placeholder={t("common.search")}
               value={searchText}
+              wrapperClassName="flex-none"
               onChange={(event) => setSearchText(event.target.value)}
             />
-            <div className="flex-1 overflow-hidden">
+            <div className="min-h-0 flex-1 overflow-y-auto">
               {isLoadingAllTargets ? (
                 <div className="flex h-full items-center justify-center">
                   <div className="h-5 w-5 animate-spin rounded-full border-2 border-control-border border-t-accent" />
                 </div>
               ) : filteredTargets.length > 0 ? (
-                <div className="h-full overflow-y-auto">
-                  <div className="flex flex-wrap gap-2">
-                    {filteredTargets.map((target) =>
-                      isValidDatabaseName(target) ? (
-                        <div
-                          key={target}
-                          className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1 transition-all"
-                        >
-                          <PlanTargetDisplay showEnvironment target={target} />
-                        </div>
+                <div className="flex flex-col gap-2">
+                  {filteredTargets.map((target) => (
+                    <div
+                      key={target}
+                      className="w-full rounded-lg border px-2 py-1.5"
+                    >
+                      {isValidDatabaseName(target) ? (
+                        <PlanTargetDisplay showEnvironment target={target} />
                       ) : isValidDatabaseGroupName(target) ? (
-                        <div
-                          key={target}
-                          className="rounded-lg border px-2 py-1 transition-all"
-                        >
-                          <DatabaseGroupTarget target={target} />
-                        </div>
+                        <DatabaseGroupTarget target={target} />
                       ) : (
-                        <div
-                          key={target}
-                          className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1 transition-all"
-                        >
-                          <span className="text-sm">{target}</span>
-                        </div>
-                      )
-                    )}
-                  </div>
+                        <span className="block truncate text-sm">{target}</span>
+                      )}
+                    </div>
+                  ))}
                 </div>
               ) : (
                 <div className="flex h-full items-center justify-center text-control-light">


### PR DESCRIPTION
## Summary
- Replace the issue detail target overflow dialog with the shared sheet layout.
- Render issue and plan target overflow views as fixed-search, independently scrollable single-column lists.
- Add regression coverage for both issue detail and plan detail target overflow sheets.

## Key Changes
- Use `Sheet` for issue detail target overflow to avoid dialog scroll conflicts.
- Keep target search inputs `flex-none` and move target rows into dedicated scroll containers.
- Simplify overflow target rows to full-width, truncated list items.

## Motivation
Large target sets could freeze or render incorrectly because the popup mixed flexible search controls, wrapping chips, and nested scroll containers.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend exec vitest run src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.test.tsx`
- `pnpm --dir frontend test`
- `git diff --check`
