### PR TITLE
feat(parser): migrate Oracle query span to omni

### DIFF
--- a/backend/plugin/parser/plsql/query_span.go
+++ b/backend/plugin/parser/plsql/query_span.go
@@ -14,9 +14,9 @@ func init() {
 }
 
 func GetQuerySpan(ctx context.Context, gCtx base.GetQuerySpanContext, stmt base.Statement, database, _ string, _ bool) (*base.QuerySpan, error) {
-	extractor := newQuerySpanExtractor(database, gCtx)
+	extractor := newOmniQuerySpanExtractor(database, gCtx)
 
-	querySpan, err := extractor.getQuerySpan(ctx, stmt.Text)
+	querySpan, err := extractor.getOmniQuerySpan(ctx, stmt.Text)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get query span from statement: %s", stmt.Text)
 	}

--- a/backend/plugin/parser/plsql/query_span_extractor.go
+++ b/backend/plugin/parser/plsql/query_span_extractor.go
@@ -1,3 +1,4 @@
+//nolint:unused
 package plsql
 
 import (
@@ -1390,8 +1391,8 @@ func (q *querySpanExtractor) getColumnsForView(instanceID, defaultDatabase, defi
 		ListDatabaseNamesFunc:         q.gCtx.ListDatabaseNamesFunc,
 		GetLinkedDatabaseMetadataFunc: q.gCtx.GetLinkedDatabaseMetadataFunc,
 	}
-	newQ := newQuerySpanExtractor(defaultDatabase, newContext)
-	span, err := newQ.getQuerySpan(q.ctx, definition)
+	newQ := newOmniQuerySpanExtractor(defaultDatabase, newContext)
+	span, err := newQ.getOmniQuerySpan(q.ctx, definition)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get query span for view definition: %s", definition)
 	}
@@ -1408,8 +1409,8 @@ func (q *querySpanExtractor) getColumnsForMaterializedView(instanceID, defaultDa
 		ListDatabaseNamesFunc:         q.gCtx.ListDatabaseNamesFunc,
 		GetLinkedDatabaseMetadataFunc: q.gCtx.GetLinkedDatabaseMetadataFunc,
 	}
-	newQ := newQuerySpanExtractor(defaultDatabase, newContext)
-	span, err := newQ.getQuerySpan(q.ctx, definition)
+	newQ := newOmniQuerySpanExtractor(defaultDatabase, newContext)
+	span, err := newQ.getOmniQuerySpan(q.ctx, definition)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get query span for materialized view definition: %s", definition)
 	}

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -578,6 +578,21 @@ func mergeOmniJoinTableSource(join *oracleast.JoinClause, left, right base.Table
 		rightIndex[field.Name] = i
 	}
 
+	if isOmniNaturalJoin(join.Type) {
+		for _, field := range leftResults {
+			if rightIdx, ok := rightIndex[field.Name]; ok {
+				field.SourceColumns, _ = base.MergeSourceColumnSet(field.SourceColumns, rightResults[rightIdx].SourceColumns)
+			}
+			result.Columns = append(result.Columns, field)
+		}
+		for _, field := range rightResults {
+			if _, ok := leftIndex[field.Name]; !ok {
+				result.Columns = append(result.Columns, field)
+			}
+		}
+		return result, nil
+	}
+
 	if len(listItems(join.Using)) != 0 {
 		usingMap := make(map[string]bool)
 		for _, node := range listItems(join.Using) {
@@ -608,6 +623,15 @@ func mergeOmniJoinTableSource(join *oracleast.JoinClause, left, right base.Table
 	result.Columns = append(result.Columns, leftResults...)
 	result.Columns = append(result.Columns, rightResults...)
 	return result, nil
+}
+
+func isOmniNaturalJoin(joinType oracleast.JoinType) bool {
+	switch joinType {
+	case oracleast.JOIN_NATURAL_INNER, oracleast.JOIN_NATURAL_LEFT, oracleast.JOIN_NATURAL_RIGHT, oracleast.JOIN_NATURAL_FULL:
+		return true
+	default:
+		return false
+	}
 }
 
 func (q *omniQuerySpanExtractor) extractOmniExpr(expr oracleast.ExprNode) (string, base.SourceColumnSet, error) {

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -130,7 +130,8 @@ func omniQueryType(stmt oracleast.StmtNode, allSystem bool) base.QueryType {
 			return base.SelectInfoSchema
 		}
 		return base.Select
-	case *oracleast.InsertStmt, *oracleast.UpdateStmt, *oracleast.DeleteStmt, *oracleast.MergeStmt, *oracleast.CallStmt:
+	case *oracleast.InsertStmt, *oracleast.UpdateStmt, *oracleast.DeleteStmt, *oracleast.MergeStmt,
+		*oracleast.CallStmt, *oracleast.LockTableStmt:
 		return base.DML
 	case *oracleast.CreateTableStmt, *oracleast.AlterTableStmt, *oracleast.DropStmt,
 		*oracleast.CreateIndexStmt, *oracleast.CreateViewStmt,

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -644,7 +644,7 @@ func (q *omniQuerySpanExtractor) extractOmniExpr(expr oracleast.ExprNode) (strin
 		if expr.Column == "*" {
 			return "*", base.SourceColumnSet{}, nil
 		}
-		return expr.Column, q.getFieldColumnSource(expr.Schema, expr.Table, expr.Column), nil
+		return expr.Column, q.getOmniFieldColumnSource(expr.Schema, expr.Table, expr.Column), nil
 	case *oracleast.Star:
 		return "*", base.SourceColumnSet{}, nil
 	case *oracleast.NumberLiteral:
@@ -671,6 +671,14 @@ func (q *omniQuerySpanExtractor) extractOmniExpr(expr oracleast.ExprNode) (strin
 			return "", nil, err
 		}
 		return q.omniExprName(expr.Loc, ""), mergeSourceColumnsFromResults(tableSource.GetQuerySpanResult()), nil
+	case *oracleast.CursorExpr:
+		child := q.clone()
+		child.outerTableSources = append(cloneTableSourceSlice(q.outerTableSources), q.tableSourcesFrom...)
+		tableSource, err := child.extractOmniStmt(expr.Subquery)
+		if err != nil {
+			return "", nil, err
+		}
+		return q.omniExprName(expr.Loc, ""), mergeSourceColumnsFromResults(tableSource.GetQuerySpanResult()), nil
 	default:
 		name := q.omniExprName(getOmniExprFullLoc(expr), oracleast.NodeToString(expr))
 		sourceColumns, err := q.extractOmniExprSourceColumns(expr)
@@ -688,7 +696,7 @@ func (q *omniQuerySpanExtractor) extractOmniExprSourceColumns(expr oracleast.Exp
 		switch node := node.(type) {
 		case *oracleast.ColumnRef:
 			if node.Column != "*" {
-				result, _ = base.MergeSourceColumnSet(result, q.getFieldColumnSource(node.Schema, node.Table, node.Column))
+				result, _ = base.MergeSourceColumnSet(result, q.getOmniFieldColumnSource(node.Schema, node.Table, node.Column))
 			}
 			return false
 		case *oracleast.FuncCallExpr:
@@ -713,11 +721,50 @@ func (q *omniQuerySpanExtractor) extractOmniExprSourceColumns(expr oracleast.Exp
 			}
 			result, _ = base.MergeSourceColumnSet(result, mergeSourceColumnsFromResults(tableSource.GetQuerySpanResult()))
 			return false
+		case *oracleast.CursorExpr:
+			child := q.clone()
+			child.outerTableSources = append(cloneTableSourceSlice(q.outerTableSources), q.tableSourcesFrom...)
+			tableSource, err := child.extractOmniStmt(node.Subquery)
+			if err != nil {
+				walkErr = err
+				return false
+			}
+			result, _ = base.MergeSourceColumnSet(result, mergeSourceColumnsFromResults(tableSource.GetQuerySpanResult()))
+			return false
 		default:
 			return true
 		}
 	})
 	return result, walkErr
+}
+
+func (q *omniQuerySpanExtractor) getOmniFieldColumnSource(schemaName, tableName, columnName string) base.SourceColumnSet {
+	findInTableSource := func(tableSource base.TableSource) (base.SourceColumnSet, bool) {
+		if schemaName != "" && schemaName != tableSource.GetDatabaseName() {
+			return nil, false
+		}
+		if tableName != "" && tableName != tableSource.GetTableName() {
+			return nil, false
+		}
+		for _, field := range tableSource.GetQuerySpanResult() {
+			if field.Name == columnName {
+				return field.SourceColumns, true
+			}
+		}
+		return nil, false
+	}
+
+	for _, tableSource := range q.tableSourcesFrom {
+		if sourceColumnSet, ok := findInTableSource(tableSource); ok {
+			return sourceColumnSet
+		}
+	}
+	for i := len(q.outerTableSources) - 1; i >= 0; i-- {
+		if sourceColumnSet, ok := findInTableSource(q.outerTableSources[i]); ok {
+			return sourceColumnSet
+		}
+	}
+	return base.SourceColumnSet{}
 }
 
 func (q *omniQuerySpanExtractor) expandOmniAsterisk(schemaName, tableName string) ([]base.QuerySpanResult, error) {

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -1,0 +1,1051 @@
+package plsql
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"unicode"
+
+	"github.com/pkg/errors"
+
+	oracleast "github.com/bytebase/omni/oracle/ast"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+type omniQuerySpanExtractor struct {
+	*querySpanExtractor
+
+	source                   string
+	topLevelTableSourcesFrom []base.TableSource
+}
+
+func newOmniQuerySpanExtractor(connectionDatabase string, gCtx base.GetQuerySpanContext) *omniQuerySpanExtractor {
+	return &omniQuerySpanExtractor{
+		querySpanExtractor: newQuerySpanExtractor(connectionDatabase, gCtx),
+	}
+}
+
+func (q *omniQuerySpanExtractor) getOmniQuerySpan(ctx context.Context, statement string) (*base.QuerySpan, error) {
+	q.ctx = ctx
+	q.source = statement
+
+	list, err := ParsePLSQLOmni(statement)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse statement: %s", statement)
+	}
+	if list == nil || len(list.Items) == 0 {
+		return nil, nil
+	}
+	if len(list.Items) > 1 {
+		return nil, errors.Errorf("query span extraction only supports single statement, got %d statements", len(list.Items))
+	}
+	raw, ok := list.Items[0].(*oracleast.RawStmt)
+	if !ok || raw.Stmt == nil {
+		return nil, nil
+	}
+
+	accessTables := collectOmniAccessTables(q.defaultDatabase, raw.Stmt)
+	allSystem, mixed := isMixedQuery(accessTables)
+	if mixed {
+		return nil, base.MixUserSystemTablesError
+	}
+
+	queryType := omniQueryType(raw.Stmt, allSystem)
+	if queryType != base.Select {
+		return &base.QuerySpan{
+			Type:          queryType,
+			SourceColumns: base.SourceColumnSet{},
+			Results:       []base.QuerySpanResult{},
+		}, nil
+	}
+
+	columnSet := make(base.SourceColumnSet)
+	for _, resource := range accessTables {
+		if !q.existsTableMetadata(resource) {
+			continue
+		}
+		columnSet[base.ColumnResource{
+			Server:   resource.LinkedServer,
+			Database: resource.Database,
+			Table:    resource.Table,
+		}] = true
+	}
+
+	selectStmt, ok := raw.Stmt.(*oracleast.SelectStmt)
+	if !ok {
+		return nil, errors.Errorf("expected SELECT statement, got %T", raw.Stmt)
+	}
+	tableSource, err := q.extractOmniSelect(selectStmt)
+	if err != nil {
+		var resourceNotFound *base.ResourceNotFoundError
+		if errors.As(err, &resourceNotFound) {
+			if len(columnSet) == 0 {
+				columnSet[base.ColumnResource{
+					Database: q.defaultDatabase,
+				}] = true
+			}
+			return &base.QuerySpan{
+				Type:          base.Select,
+				SourceColumns: columnSet,
+				Results:       []base.QuerySpanResult{},
+				NotFoundError: resourceNotFound,
+			}, nil
+		}
+		return nil, err
+	}
+	var results []base.QuerySpanResult
+	if tableSource != nil {
+		results = tableSource.GetQuerySpanResult()
+	}
+	if resourceNotFound := q.findMissingOmniAccessTable(raw.Stmt, accessTables); resourceNotFound != nil {
+		if len(columnSet) == 0 {
+			columnSet[base.ColumnResource{
+				Database: q.defaultDatabase,
+			}] = true
+		}
+		return &base.QuerySpan{
+			Type:          base.Select,
+			SourceColumns: columnSet,
+			Results:       []base.QuerySpanResult{},
+			NotFoundError: resourceNotFound,
+		}, nil
+	}
+	return &base.QuerySpan{
+		Type:          base.Select,
+		SourceColumns: columnSet,
+		Results:       results,
+	}, nil
+}
+
+func omniQueryType(stmt oracleast.StmtNode, allSystem bool) base.QueryType {
+	if stmt == nil {
+		return base.QueryTypeUnknown
+	}
+	switch stmt.(type) {
+	case *oracleast.ExplainPlanStmt:
+		return base.Explain
+	case *oracleast.SelectStmt:
+		if allSystem {
+			return base.SelectInfoSchema
+		}
+		return base.Select
+	case *oracleast.InsertStmt, *oracleast.UpdateStmt, *oracleast.DeleteStmt, *oracleast.MergeStmt, *oracleast.CallStmt:
+		return base.DML
+	case *oracleast.CreateTableStmt, *oracleast.AlterTableStmt, *oracleast.DropStmt,
+		*oracleast.CreateIndexStmt, *oracleast.CreateViewStmt,
+		*oracleast.CreateSequenceStmt, *oracleast.CreateSynonymStmt,
+		*oracleast.CreateDatabaseLinkStmt, *oracleast.CreateTypeStmt,
+		*oracleast.CreatePackageStmt, *oracleast.CreateProcedureStmt,
+		*oracleast.CreateFunctionStmt, *oracleast.CreateTriggerStmt,
+		*oracleast.TruncateStmt, *oracleast.AlterSessionStmt,
+		*oracleast.AlterSystemStmt, *oracleast.CreateUserStmt,
+		*oracleast.AlterUserStmt, *oracleast.CreateRoleStmt,
+		*oracleast.AlterRoleStmt, *oracleast.CreateProfileStmt,
+		*oracleast.AlterProfileStmt, *oracleast.AlterResourceCostStmt,
+		*oracleast.AdminDDLStmt, *oracleast.CreateSchemaStmt,
+		*oracleast.AlterDatabaseLinkStmt, *oracleast.AlterSynonymStmt,
+		*oracleast.AlterMaterializedViewStmt,
+		*oracleast.CreateAuditPolicyStmt, *oracleast.AlterAuditPolicyStmt,
+		*oracleast.DropAuditPolicyStmt, *oracleast.CreateTablespaceStmt,
+		*oracleast.AlterTablespaceStmt, *oracleast.CreateTablespaceSetStmt,
+		*oracleast.DropTablespaceStmt, *oracleast.CreateClusterStmt,
+		*oracleast.CreateDimensionStmt, *oracleast.AlterClusterStmt,
+		*oracleast.AlterDimensionStmt, *oracleast.CreateMaterializedZonemapStmt,
+		*oracleast.AlterMaterializedZonemapStmt, *oracleast.CreateInmemoryJoinGroupStmt,
+		*oracleast.AlterInmemoryJoinGroupStmt, *oracleast.AlterIndexStmt,
+		*oracleast.AlterViewStmt, *oracleast.AlterSequenceStmt,
+		*oracleast.AlterProcedureStmt, *oracleast.AlterFunctionStmt,
+		*oracleast.AlterPackageStmt, *oracleast.AlterTriggerStmt,
+		*oracleast.AlterTypeStmt, *oracleast.CreateIndextypeStmt,
+		*oracleast.AlterIndextypeStmt, *oracleast.CreateOperatorStmt,
+		*oracleast.AlterOperatorStmt, *oracleast.CreateMviewLogStmt,
+		*oracleast.AlterMviewLogStmt, *oracleast.CreateAnalyticViewStmt,
+		*oracleast.AlterAnalyticViewStmt, *oracleast.CreateJsonDualityViewStmt,
+		*oracleast.AlterJsonDualityViewStmt, *oracleast.CreateAttributeDimensionStmt,
+		*oracleast.AlterAttributeDimensionStmt, *oracleast.CreateHierarchyStmt,
+		*oracleast.AlterHierarchyStmt, *oracleast.CreateDomainStmt,
+		*oracleast.AlterDomainStmt, *oracleast.CreatePropertyGraphStmt,
+		*oracleast.CreateVectorIndexStmt, *oracleast.CreateLockdownProfileStmt,
+		*oracleast.AlterLockdownProfileStmt, *oracleast.CreateOutlineStmt,
+		*oracleast.AlterOutlineStmt:
+		return base.DDL
+	}
+	return base.QueryTypeUnknown
+}
+
+func (q *omniQuerySpanExtractor) findMissingOmniAccessTable(stmt oracleast.StmtNode, accessTables []base.SchemaResource) *base.ResourceNotFoundError {
+	cteNames := collectOmniCTENames(stmt)
+	for _, resource := range accessTables {
+		if cteNames[resource.Table] || q.existsTableMetadata(resource) {
+			continue
+		}
+		database := resource.Database
+		if database == "" {
+			database = q.defaultDatabase
+		}
+		table := resource.Table
+		return &base.ResourceNotFoundError{
+			Database: &database,
+			Table:    &table,
+		}
+	}
+	return nil
+}
+
+func collectOmniCTENames(stmt oracleast.StmtNode) map[string]bool {
+	result := make(map[string]bool)
+	oracleast.Inspect(stmt, func(node oracleast.Node) bool {
+		cte, ok := node.(*oracleast.CTE)
+		if ok {
+			result[cte.Name] = true
+		}
+		return true
+	})
+	return result
+}
+
+func collectOmniAccessTables(defaultDatabase string, stmt oracleast.StmtNode) []base.SchemaResource {
+	seen := make(map[base.SchemaResource]bool)
+	var result []base.SchemaResource
+	addResource := func(name *oracleast.ObjectName) {
+		if name == nil || name.Name == "DUAL" || name.DBLink != "" {
+			return
+		}
+		database := name.Schema
+		if database == "" {
+			database = defaultDatabase
+		}
+		resource := base.SchemaResource{
+			Database: database,
+			Table:    name.Name,
+		}
+		if !seen[resource] {
+			seen[resource] = true
+			result = append(result, resource)
+		}
+	}
+	oracleast.Inspect(stmt, func(node oracleast.Node) bool {
+		switch node := node.(type) {
+		case *oracleast.TableRef:
+			if node.Dblink == "" {
+				addResource(node.Name)
+			}
+		case *oracleast.ContainersExpr:
+			addResource(node.Name)
+		default:
+		}
+		return true
+	})
+	return result
+}
+
+func (q *omniQuerySpanExtractor) clone() *omniQuerySpanExtractor {
+	copyExtractor := *q.querySpanExtractor
+	return &omniQuerySpanExtractor{
+		querySpanExtractor:       &copyExtractor,
+		source:                   q.source,
+		topLevelTableSourcesFrom: cloneTableSourceSlice(q.topLevelTableSourcesFrom),
+	}
+}
+
+func (q *omniQuerySpanExtractor) extractOmniSelect(stmt *oracleast.SelectStmt) (base.TableSource, error) {
+	if stmt == nil {
+		return nil, nil
+	}
+	if stmt.Pivot != nil {
+		return nil, errors.Errorf("unsupported oracle table source: %T", stmt.Pivot)
+	}
+	if stmt.Unpivot != nil {
+		return nil, errors.Errorf("unsupported oracle table source: %T", stmt.Unpivot)
+	}
+	if stmt.ModelClause != nil {
+		return nil, errors.Errorf("unsupported oracle table source: %T", stmt.ModelClause)
+	}
+
+	oldCTEs := q.ctes
+	if stmt.WithClause != nil {
+		for _, node := range listItems(stmt.WithClause.CTEs) {
+			cte, ok := node.(*oracleast.CTE)
+			if !ok {
+				continue
+			}
+			table, err := q.extractOmniCTE(cte)
+			if err != nil {
+				q.ctes = oldCTEs
+				return nil, err
+			}
+			q.ctes = append(q.ctes, table)
+		}
+	}
+	defer func() {
+		q.ctes = oldCTEs
+	}()
+
+	if stmt.Op != 0 {
+		return q.extractOmniSetSelect(stmt)
+	}
+
+	oldFrom := q.tableSourcesFrom
+	oldTopLevelFrom := q.topLevelTableSourcesFrom
+	q.tableSourcesFrom = nil
+	q.topLevelTableSourcesFrom = nil
+	defer func() {
+		q.tableSourcesFrom = oldFrom
+		q.topLevelTableSourcesFrom = oldTopLevelFrom
+	}()
+
+	for _, node := range listItems(stmt.FromClause) {
+		tableExpr, ok := node.(oracleast.TableExpr)
+		if !ok {
+			continue
+		}
+		tableSource, err := q.extractOmniTableExpr(tableExpr)
+		if err != nil {
+			return nil, err
+		}
+		if tableSource != nil {
+			q.tableSourcesFrom = append(q.tableSourcesFrom, tableSource)
+			q.topLevelTableSourcesFrom = append(q.topLevelTableSourcesFrom, tableSource)
+		}
+	}
+
+	results, err := q.extractOmniTargetList(stmt.TargetList)
+	if err != nil {
+		return nil, err
+	}
+	return &base.PseudoTable{
+		Columns: results,
+	}, nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniSetSelect(stmt *oracleast.SelectStmt) (base.TableSource, error) {
+	left, err := q.extractOmniSelect(omniSetLeftSelect(stmt))
+	if err != nil {
+		return nil, err
+	}
+	right, err := q.extractOmniSelect(stmt.Rarg)
+	if err != nil {
+		return nil, err
+	}
+	return mergeOmniSetTableSources(left, right)
+}
+
+func mergeOmniSetTableSources(left, right base.TableSource) (base.TableSource, error) {
+	if left == nil {
+		return right, nil
+	}
+	if right == nil {
+		return left, nil
+	}
+	leftResults := left.GetQuerySpanResult()
+	rightResults := right.GetQuerySpanResult()
+	if len(leftResults) != len(rightResults) {
+		return nil, errors.Errorf("left and right query span result length mismatch: %d != %d", len(leftResults), len(rightResults))
+	}
+	result := make([]base.QuerySpanResult, 0, len(leftResults))
+	for i, leftResult := range leftResults {
+		sourceColumns, _ := base.MergeSourceColumnSet(leftResult.SourceColumns, rightResults[i].SourceColumns)
+		result = append(result, base.QuerySpanResult{
+			Name:          leftResult.Name,
+			SourceColumns: sourceColumns,
+			IsPlainField:  false,
+		})
+	}
+	return &base.PseudoTable{Columns: result}, nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniCTE(cte *oracleast.CTE) (*base.PseudoTable, error) {
+	if cte == nil {
+		return nil, nil
+	}
+	name := cte.Name
+	columnNames := omniStringList(cte.Columns)
+
+	selectStmt, ok := cte.Query.(*oracleast.SelectStmt)
+	if ok && selectStmt.Op != 0 && len(columnNames) > 0 {
+		initialSource, err := q.extractOmniSelect(omniSetLeftSelect(selectStmt))
+		if err != nil {
+			return nil, err
+		}
+		initial := cloneQuerySpanResults(initialSource.GetQuerySpanResult())
+		applyOmniColumnAliases(initial, columnNames)
+
+		placeholder := &base.PseudoTable{Name: name, Columns: initial}
+		q.ctes = append(q.ctes, placeholder)
+		defer func() {
+			q.ctes = q.ctes[:len(q.ctes)-1]
+		}()
+
+		columns := initial
+		for range 16 {
+			placeholder.Columns = columns
+			rightSource, err := q.extractOmniSelect(selectStmt.Rarg)
+			if err != nil {
+				return nil, err
+			}
+			mergedSource, err := mergeOmniSetTableSources(&base.PseudoTable{Columns: initial}, rightSource)
+			if err != nil {
+				return nil, err
+			}
+			next := cloneQuerySpanResults(mergedSource.GetQuerySpanResult())
+			applyOmniColumnAliases(next, columnNames)
+			if querySpanResultsEqual(columns, next) {
+				return &base.PseudoTable{Name: name, Columns: next}, nil
+			}
+			columns = next
+		}
+		return &base.PseudoTable{Name: name, Columns: columns}, nil
+	}
+
+	child := q.clone()
+	tableSource, err := child.extractOmniStmt(cte.Query)
+	if err != nil {
+		return nil, err
+	}
+	columns := cloneQuerySpanResults(tableSource.GetQuerySpanResult())
+	applyOmniColumnAliases(columns, columnNames)
+	return &base.PseudoTable{Name: name, Columns: columns}, nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniStmt(stmt oracleast.StmtNode) (base.TableSource, error) {
+	selectStmt, ok := stmt.(*oracleast.SelectStmt)
+	if !ok {
+		return nil, errors.Errorf("unsupported statement in query span extractor: %T", stmt)
+	}
+	return q.extractOmniSelect(selectStmt)
+}
+
+func (q *omniQuerySpanExtractor) extractOmniTargetList(list *oracleast.List) ([]base.QuerySpanResult, error) {
+	if list == nil || list.Len() == 0 {
+		return q.expandOmniAsterisk("", "")
+	}
+
+	var results []base.QuerySpanResult
+	for _, node := range listItems(list) {
+		target, ok := node.(*oracleast.ResTarget)
+		if !ok || target.Expr == nil {
+			continue
+		}
+		if isOmniStar(target.Expr) {
+			expanded, err := q.expandOmniAsterisk("", "")
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, expanded...)
+			continue
+		}
+		if ref, ok := target.Expr.(*oracleast.ColumnRef); ok && ref.Column == "*" {
+			expanded, err := q.expandOmniAsterisk(ref.Schema, ref.Table)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, expanded...)
+			continue
+		}
+
+		name, sourceColumns, err := q.extractOmniExpr(target.Expr)
+		if err != nil {
+			return nil, err
+		}
+		if target.Name != "" {
+			name = target.Name
+		}
+		results = append(results, base.QuerySpanResult{
+			Name:          name,
+			SourceColumns: sourceColumns,
+			IsPlainField:  false,
+		})
+	}
+	return results, nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniTableExpr(expr oracleast.TableExpr) (base.TableSource, error) {
+	switch expr := expr.(type) {
+	case *oracleast.TableRef:
+		if expr.Name == nil {
+			return nil, nil
+		}
+		dbLink := expr.Name.DBLink
+		if dbLink == "" {
+			dbLink = expr.Dblink
+		}
+		database := expr.Name.Schema
+		if database == "" && dbLink == "" {
+			database = q.defaultDatabase
+		}
+		tableSource, err := q.plsqlFindTableSchema(splitOmniDBLink(dbLink), database, expr.Name.Name)
+		if err != nil {
+			return nil, err
+		}
+		return aliasOmniTableSource(tableSource, expr.Alias), nil
+	case *oracleast.SubqueryRef:
+		child := q.clone()
+		tableSource, err := child.extractOmniStmt(expr.Subquery)
+		if err != nil {
+			return nil, err
+		}
+		return aliasOmniTableSource(tableSource, expr.Alias), nil
+	case *oracleast.SubqueryExpr:
+		child := q.clone()
+		tableSource, err := child.extractOmniStmt(expr.Subquery)
+		if err != nil {
+			return nil, err
+		}
+		return tableSource, nil
+	case *oracleast.LateralRef:
+		child := q.clone()
+		child.outerTableSources = append(cloneTableSourceSlice(child.outerTableSources), q.tableSourcesFrom...)
+		tableSource, err := child.extractOmniStmt(expr.Subquery)
+		if err != nil {
+			return nil, err
+		}
+		return aliasOmniTableSource(tableSource, expr.Alias), nil
+	case *oracleast.JoinClause:
+		left, err := q.extractOmniTableExpr(expr.Left)
+		if err != nil {
+			return nil, err
+		}
+		if left != nil {
+			q.tableSourcesFrom = append(q.tableSourcesFrom, left)
+		}
+		right, err := q.extractOmniTableExpr(expr.Right)
+		if err != nil {
+			return nil, err
+		}
+		if right != nil {
+			q.tableSourcesFrom = append(q.tableSourcesFrom, right)
+		}
+		return mergeOmniJoinTableSource(expr, left, right)
+	case *oracleast.XmlTableRef:
+		return q.extractOmniXMLTable(expr)
+	case *oracleast.JsonTableRef:
+		return q.extractOmniJSONTable(expr)
+	case *oracleast.ContainersExpr:
+		if expr.Name == nil {
+			return nil, nil
+		}
+		database := expr.Name.Schema
+		if database == "" {
+			database = q.defaultDatabase
+		}
+		tableSource, err := q.plsqlFindTableSchema(nil, database, expr.Name.Name)
+		if err != nil {
+			return nil, err
+		}
+		return aliasOmniTableSource(tableSource, expr.Alias), nil
+	case *oracleast.InlineExternalTable:
+		return extractOmniInlineExternalTable(expr), nil
+	case *oracleast.TableCollectionExpr, *oracleast.PivotClause, *oracleast.UnpivotClause, *oracleast.MatchRecognizeClause:
+		return nil, errors.Errorf("unsupported oracle table source: %T", expr)
+	default:
+		return nil, errors.Errorf("unsupported oracle table source: %T", expr)
+	}
+}
+
+func omniSetLeftSelect(stmt *oracleast.SelectStmt) *oracleast.SelectStmt {
+	if stmt == nil {
+		return nil
+	}
+	if stmt.Larg != nil {
+		return stmt.Larg
+	}
+	body := *stmt
+	body.Op = 0
+	body.SetAll = false
+	body.Larg = nil
+	body.Rarg = nil
+	return &body
+}
+
+func mergeOmniJoinTableSource(join *oracleast.JoinClause, left, right base.TableSource) (base.TableSource, error) {
+	if left == nil {
+		return right, nil
+	}
+	if right == nil {
+		return left, nil
+	}
+	leftResults := left.GetQuerySpanResult()
+	rightResults := right.GetQuerySpanResult()
+	result := new(base.PseudoTable)
+
+	leftIndex := make(map[string]int)
+	rightIndex := make(map[string]int)
+	for i, field := range leftResults {
+		leftIndex[field.Name] = i
+	}
+	for i, field := range rightResults {
+		rightIndex[field.Name] = i
+	}
+
+	if len(listItems(join.Using)) != 0 {
+		usingMap := make(map[string]bool)
+		for _, node := range listItems(join.Using) {
+			switch node := node.(type) {
+			case *oracleast.String:
+				usingMap[node.Str] = true
+			case *oracleast.ColumnRef:
+				usingMap[node.Column] = true
+			default:
+			}
+		}
+		for _, field := range leftResults {
+			if usingMap[field.Name] {
+				if rightIdx, ok := rightIndex[field.Name]; ok {
+					field.SourceColumns, _ = base.MergeSourceColumnSet(field.SourceColumns, rightResults[rightIdx].SourceColumns)
+				}
+			}
+			result.Columns = append(result.Columns, field)
+		}
+		for _, field := range rightResults {
+			if !usingMap[field.Name] {
+				result.Columns = append(result.Columns, field)
+			}
+		}
+		return result, nil
+	}
+
+	result.Columns = append(result.Columns, leftResults...)
+	result.Columns = append(result.Columns, rightResults...)
+	return result, nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniExpr(expr oracleast.ExprNode) (string, base.SourceColumnSet, error) {
+	if expr == nil {
+		return "", base.SourceColumnSet{}, nil
+	}
+
+	switch expr := expr.(type) {
+	case *oracleast.ColumnRef:
+		if expr.Column == "*" {
+			return "*", base.SourceColumnSet{}, nil
+		}
+		return expr.Column, q.getFieldColumnSource(expr.Schema, expr.Table, expr.Column), nil
+	case *oracleast.Star:
+		return "*", base.SourceColumnSet{}, nil
+	case *oracleast.NumberLiteral:
+		return q.omniExprName(expr.Loc, expr.Val), base.SourceColumnSet{}, nil
+	case *oracleast.StringLiteral:
+		return q.omniExprName(expr.Loc, expr.Val), base.SourceColumnSet{}, nil
+	case *oracleast.NullLiteral:
+		return q.omniExprName(expr.Loc, "NULL"), base.SourceColumnSet{}, nil
+	case *oracleast.DateTimeLiteral:
+		return q.omniExprName(expr.Loc, expr.TypeName+" "+expr.Val), base.SourceColumnSet{}, nil
+	case *oracleast.SubqueryExpr:
+		child := q.clone()
+		child.outerTableSources = append(cloneTableSourceSlice(q.outerTableSources), q.tableSourcesFrom...)
+		tableSource, err := child.extractOmniStmt(expr.Subquery)
+		if err != nil {
+			return "", nil, err
+		}
+		return q.omniExprName(expr.Loc, ""), mergeSourceColumnsFromResults(tableSource.GetQuerySpanResult()), nil
+	case *oracleast.ExistsExpr:
+		child := q.clone()
+		child.outerTableSources = append(cloneTableSourceSlice(q.outerTableSources), q.tableSourcesFrom...)
+		tableSource, err := child.extractOmniStmt(expr.Subquery)
+		if err != nil {
+			return "", nil, err
+		}
+		return q.omniExprName(expr.Loc, ""), mergeSourceColumnsFromResults(tableSource.GetQuerySpanResult()), nil
+	default:
+		name := q.omniExprName(getOmniExprFullLoc(expr), oracleast.NodeToString(expr))
+		sourceColumns, err := q.extractOmniExprSourceColumns(expr)
+		return name, sourceColumns, err
+	}
+}
+
+func (q *omniQuerySpanExtractor) extractOmniExprSourceColumns(expr oracleast.ExprNode) (base.SourceColumnSet, error) {
+	result := make(base.SourceColumnSet)
+	var walkErr error
+	oracleast.Inspect(expr, func(node oracleast.Node) bool {
+		if walkErr != nil || node == nil {
+			return false
+		}
+		switch node := node.(type) {
+		case *oracleast.ColumnRef:
+			if node.Column != "*" {
+				result, _ = base.MergeSourceColumnSet(result, q.getFieldColumnSource(node.Schema, node.Table, node.Column))
+			}
+			return false
+		case *oracleast.FuncCallExpr:
+			return true
+		case *oracleast.SubqueryExpr:
+			child := q.clone()
+			child.outerTableSources = append(cloneTableSourceSlice(q.outerTableSources), q.tableSourcesFrom...)
+			tableSource, err := child.extractOmniStmt(node.Subquery)
+			if err != nil {
+				walkErr = err
+				return false
+			}
+			result, _ = base.MergeSourceColumnSet(result, mergeSourceColumnsFromResults(tableSource.GetQuerySpanResult()))
+			return false
+		case *oracleast.ExistsExpr:
+			child := q.clone()
+			child.outerTableSources = append(cloneTableSourceSlice(q.outerTableSources), q.tableSourcesFrom...)
+			tableSource, err := child.extractOmniStmt(node.Subquery)
+			if err != nil {
+				walkErr = err
+				return false
+			}
+			result, _ = base.MergeSourceColumnSet(result, mergeSourceColumnsFromResults(tableSource.GetQuerySpanResult()))
+			return false
+		default:
+			return true
+		}
+	})
+	return result, walkErr
+}
+
+func (q *omniQuerySpanExtractor) expandOmniAsterisk(schemaName, tableName string) ([]base.QuerySpanResult, error) {
+	findInTableSource := func(tableSource base.TableSource) ([]base.QuerySpanResult, bool) {
+		if schemaName != "" && schemaName != tableSource.GetDatabaseName() {
+			return nil, false
+		}
+		if tableName != "" && tableName != tableSource.GetTableName() {
+			return nil, false
+		}
+		return tableSource.GetQuerySpanResult(), true
+	}
+
+	if tableName == "" && schemaName == "" {
+		if len(q.topLevelTableSourcesFrom) > 0 {
+			return cloneQuerySpanResultsFromTableSources(q.topLevelTableSourcesFrom), nil
+		}
+		if len(q.tableSourcesFrom) > 0 {
+			return cloneQuerySpanResultsFromTableSources(q.tableSourcesFrom), nil
+		}
+		if len(q.outerTableSources) > 0 {
+			return cloneQuerySpanResults(q.outerTableSources[len(q.outerTableSources)-1].GetQuerySpanResult()), nil
+		}
+		return []base.QuerySpanResult{}, nil
+	}
+
+	for i := len(q.tableSourcesFrom) - 1; i >= 0; i-- {
+		if results, ok := findInTableSource(q.tableSourcesFrom[i]); ok {
+			return cloneQuerySpanResults(results), nil
+		}
+	}
+	for i := len(q.outerTableSources) - 1; i >= 0; i-- {
+		if results, ok := findInTableSource(q.outerTableSources[i]); ok {
+			return cloneQuerySpanResults(results), nil
+		}
+	}
+	return nil, errors.Errorf("failed to resolve asterisk for table %q", tableName)
+}
+
+func cloneQuerySpanResultsFromTableSources(tableSources []base.TableSource) []base.QuerySpanResult {
+	var result []base.QuerySpanResult
+	for _, tableSource := range tableSources {
+		if tableSource == nil {
+			continue
+		}
+		result = append(result, cloneQuerySpanResults(tableSource.GetQuerySpanResult())...)
+	}
+	return result
+}
+
+func (q *omniQuerySpanExtractor) extractOmniXMLTable(ref *oracleast.XmlTableRef) (base.TableSource, error) {
+	_, sourceColumns, err := q.extractOmniExpr(ref.Passing)
+	if err != nil {
+		return nil, err
+	}
+	var columns []base.QuerySpanResult
+	for _, node := range listItems(ref.Columns) {
+		column, ok := node.(*oracleast.XmlTableColumn)
+		if !ok {
+			continue
+		}
+		columnSource := base.SourceColumnSet{}
+		if !column.ForOrdinality {
+			columnSource = sourceColumns
+		}
+		columns = append(columns, base.QuerySpanResult{
+			Name:          column.Name,
+			SourceColumns: columnSource,
+			IsPlainField:  false,
+		})
+	}
+	name := ""
+	if ref.Alias != nil {
+		name = ref.Alias.Name
+	}
+	return &base.PseudoTable{Name: name, Columns: columns}, nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniJSONTable(ref *oracleast.JsonTableRef) (base.TableSource, error) {
+	_, sourceColumns, err := q.extractOmniExpr(ref.Expr)
+	if err != nil {
+		return nil, err
+	}
+	columns := extractOmniJSONTableColumns(ref.Columns, sourceColumns)
+	name := ""
+	if ref.Alias != nil {
+		name = ref.Alias.Name
+	}
+	return &base.PseudoTable{Name: name, Columns: columns}, nil
+}
+
+func extractOmniJSONTableColumns(list *oracleast.List, sourceColumns base.SourceColumnSet) []base.QuerySpanResult {
+	var columns []base.QuerySpanResult
+	for _, node := range listItems(list) {
+		column, ok := node.(*oracleast.JsonTableColumn)
+		if !ok {
+			continue
+		}
+		if column.Nested != nil {
+			columns = append(columns, extractOmniJSONTableColumns(column.Nested.Columns, sourceColumns)...)
+			continue
+		}
+		columnSource := sourceColumns
+		if column.ForOrdinality {
+			columnSource = base.SourceColumnSet{}
+		}
+		columns = append(columns, base.QuerySpanResult{
+			Name:          column.Name,
+			SourceColumns: columnSource,
+			IsPlainField:  false,
+		})
+	}
+	return columns
+}
+
+func extractOmniInlineExternalTable(ref *oracleast.InlineExternalTable) base.TableSource {
+	var columns []base.QuerySpanResult
+	for _, node := range listItems(ref.Columns) {
+		column, ok := node.(*oracleast.ColumnDef)
+		if !ok {
+			continue
+		}
+		columns = append(columns, base.QuerySpanResult{
+			Name:          column.Name,
+			SourceColumns: base.SourceColumnSet{},
+			IsPlainField:  false,
+		})
+	}
+	name := ""
+	if ref.Alias != nil {
+		name = ref.Alias.Name
+	}
+	return &base.PseudoTable{Name: name, Columns: columns}
+}
+
+func aliasOmniTableSource(tableSource base.TableSource, alias *oracleast.Alias) base.TableSource {
+	if tableSource == nil || alias == nil || alias.Name == "" {
+		return tableSource
+	}
+	columns := cloneQuerySpanResults(tableSource.GetQuerySpanResult())
+	applyOmniColumnAliases(columns, omniStringList(alias.Cols))
+	return &base.PseudoTable{
+		Name:    alias.Name,
+		Columns: columns,
+	}
+}
+
+func applyOmniColumnAliases(columns []base.QuerySpanResult, names []string) {
+	for i, name := range names {
+		if i >= len(columns) {
+			return
+		}
+		columns[i].Name = name
+	}
+}
+
+func cloneQuerySpanResults(results []base.QuerySpanResult) []base.QuerySpanResult {
+	cloned := make([]base.QuerySpanResult, 0, len(results))
+	for _, result := range results {
+		cloned = append(cloned, base.QuerySpanResult{
+			Name:          result.Name,
+			SourceColumns: cloneSourceColumnSet(result.SourceColumns),
+			IsPlainField:  result.IsPlainField,
+		})
+	}
+	return cloned
+}
+
+func cloneSourceColumnSet(source base.SourceColumnSet) base.SourceColumnSet {
+	cloned := make(base.SourceColumnSet, len(source))
+	for column := range source {
+		cloned[column] = true
+	}
+	return cloned
+}
+
+func mergeSourceColumnsFromResults(results []base.QuerySpanResult) base.SourceColumnSet {
+	merged := make(base.SourceColumnSet)
+	for _, result := range results {
+		merged, _ = base.MergeSourceColumnSet(merged, result.SourceColumns)
+	}
+	return merged
+}
+
+func querySpanResultsEqual(left, right []base.QuerySpanResult) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i].Name != right[i].Name || left[i].IsPlainField != right[i].IsPlainField {
+			return false
+		}
+		if !sourceColumnSetEqual(left[i].SourceColumns, right[i].SourceColumns) {
+			return false
+		}
+	}
+	return true
+}
+
+func sourceColumnSetEqual(left, right base.SourceColumnSet) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for column := range left {
+		if !right[column] {
+			return false
+		}
+	}
+	return true
+}
+
+func listItems(list *oracleast.List) []oracleast.Node {
+	if list == nil {
+		return nil
+	}
+	return list.Items
+}
+
+func omniStringList(list *oracleast.List) []string {
+	var result []string
+	for _, node := range listItems(list) {
+		switch node := node.(type) {
+		case *oracleast.String:
+			result = append(result, node.Str)
+		case *oracleast.ColumnRef:
+			result = append(result, node.Column)
+		default:
+		}
+	}
+	return result
+}
+
+func isOmniStar(expr oracleast.ExprNode) bool {
+	_, ok := expr.(*oracleast.Star)
+	return ok
+}
+
+func splitOmniDBLink(dbLink string) []string {
+	if dbLink == "" {
+		return nil
+	}
+	return strings.Split(dbLink, ".")
+}
+
+func cloneTableSourceSlice(sources []base.TableSource) []base.TableSource {
+	cloned := make([]base.TableSource, len(sources))
+	copy(cloned, sources)
+	return cloned
+}
+
+func (q *omniQuerySpanExtractor) omniExprName(loc oracleast.Loc, fallback string) string {
+	if !loc.IsUnknown() && loc.Start >= 0 && loc.End <= len(q.source) && loc.Start < loc.End {
+		return removeWhitespace(q.source[loc.Start:loc.End])
+	}
+	return removeWhitespace(fallback)
+}
+
+func removeWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsSpace(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+func getOmniNodeLoc(node oracleast.Node) oracleast.Loc {
+	value := reflect.ValueOf(node)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return oracleast.NoLoc()
+	}
+	elem := value.Elem()
+	field := elem.FieldByName("Loc")
+	if !field.IsValid() || !field.CanInterface() {
+		return oracleast.NoLoc()
+	}
+	loc, ok := field.Interface().(oracleast.Loc)
+	if !ok {
+		return oracleast.NoLoc()
+	}
+	return loc
+}
+
+func getOmniExprFullLoc(expr oracleast.ExprNode) oracleast.Loc {
+	switch expr := expr.(type) {
+	case *oracleast.BinaryExpr:
+		return mergeOmniLoc(getOmniExprFullLoc(expr.Left), getOmniExprFullLoc(expr.Right), getOmniNodeLoc(expr))
+	case *oracleast.UnaryExpr:
+		return mergeOmniLoc(getOmniNodeLoc(expr), getOmniExprFullLoc(expr.Operand))
+	case *oracleast.BoolExpr:
+		return mergeOmniListLoc(expr.Args, getOmniNodeLoc(expr))
+	case *oracleast.FuncCallExpr:
+		return getOmniNodeLoc(expr)
+	case *oracleast.CaseExpr:
+		return mergeOmniLoc(getOmniNodeLoc(expr), getOmniListLastLoc(expr.Whens), getOmniExprFullLoc(expr.Default))
+	case *oracleast.CaseWhen:
+		return mergeOmniLoc(getOmniNodeLoc(expr), getOmniExprFullLoc(expr.Condition), getOmniExprFullLoc(expr.Result))
+	case *oracleast.DecodeExpr:
+		return mergeOmniLoc(getOmniNodeLoc(expr), getOmniListLastLoc(expr.Pairs), getOmniExprFullLoc(expr.Default))
+	case *oracleast.DecodePair:
+		return mergeOmniLoc(getOmniExprFullLoc(expr.Search), getOmniExprFullLoc(expr.Result), getOmniNodeLoc(expr))
+	case *oracleast.BetweenExpr:
+		return mergeOmniLoc(getOmniExprFullLoc(expr.Expr), getOmniExprFullLoc(expr.Low), getOmniExprFullLoc(expr.High), getOmniNodeLoc(expr))
+	case *oracleast.InExpr:
+		return mergeOmniLoc(getOmniExprFullLoc(expr.Expr), getOmniNodeLoc(expr))
+	case *oracleast.LikeExpr:
+		return mergeOmniLoc(getOmniExprFullLoc(expr.Expr), getOmniExprFullLoc(expr.Pattern), getOmniExprFullLoc(expr.Escape), getOmniNodeLoc(expr))
+	case *oracleast.IsExpr:
+		return mergeOmniLoc(getOmniExprFullLoc(expr.Expr), getOmniNodeLoc(expr))
+	case *oracleast.CastExpr:
+		return mergeOmniLoc(getOmniNodeLoc(expr), getOmniExprFullLoc(expr.Arg))
+	case *oracleast.MultisetExpr:
+		return mergeOmniLoc(getOmniExprFullLoc(expr.Left), getOmniExprFullLoc(expr.Right), getOmniNodeLoc(expr))
+	case *oracleast.CursorExpr:
+		return getOmniNodeLoc(expr)
+	case *oracleast.TreatExpr:
+		return mergeOmniLoc(getOmniNodeLoc(expr), getOmniExprFullLoc(expr.Expr))
+	case *oracleast.ParenExpr:
+		return mergeOmniLoc(getOmniNodeLoc(expr), getOmniExprFullLoc(expr.Expr))
+	default:
+		return getOmniNodeLoc(expr)
+	}
+}
+
+func mergeOmniListLoc(list *oracleast.List, fallback oracleast.Loc) oracleast.Loc {
+	loc := fallback
+	for _, node := range listItems(list) {
+		loc = mergeOmniLoc(loc, getOmniNodeLoc(node))
+	}
+	return loc
+}
+
+func getOmniListLastLoc(list *oracleast.List) oracleast.Loc {
+	var loc oracleast.Loc
+	for _, node := range listItems(list) {
+		loc = mergeOmniLoc(loc, getOmniNodeLoc(node))
+	}
+	return loc
+}
+
+func mergeOmniLoc(locs ...oracleast.Loc) oracleast.Loc {
+	result := oracleast.NoLoc()
+	for _, loc := range locs {
+		if loc.IsUnknown() || loc.Start < 0 || loc.End < loc.Start {
+			continue
+		}
+		if result.IsUnknown() || loc.Start < result.Start {
+			result.Start = loc.Start
+		}
+		if result.IsUnknown() || loc.End > result.End {
+			result.End = loc.End
+		}
+	}
+	return result
+}

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -229,6 +229,21 @@ func TestOracleOmniUnqualifiedStarExpandsAllCommaSources(t *testing.T) {
 				{Name: "D", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "D"}})},
 			},
 		},
+		{
+			name:      "natural join",
+			statement: "SELECT * FROM T NATURAL JOIN T2",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "B", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "C"},
+					{Database: "PUBLIC", Table: "T2", Column: "C"},
+				})},
+				{Name: "J", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "J"}})},
+				{Name: "X", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "X"}})},
+				{Name: "D", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "D"}})},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -1,0 +1,505 @@
+package plsql
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/bytebase/bytebase/backend/common"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestOracleOmniQuerySpanGoldenHarness is the strict cutover guard. It compares
+// the package-internal omni path against the existing YAML corpus instead of
+// comparing GetQuerySpan to itself after the production cutover.
+func TestOracleOmniQuerySpanGoldenHarness(t *testing.T) {
+	type testCase struct {
+		Description           string              `yaml:"description,omitempty"`
+		Statement             string              `yaml:"statement,omitempty"`
+		DefaultDatabase       string              `yaml:"defaultDatabase,omitempty"`
+		Metadata              string              `yaml:"metadata,omitempty"`
+		CrossDatabaseMetadata string              `yaml:"crossDatabaseMetadata,omitempty"`
+		QuerySpan             *base.YamlQuerySpan `yaml:"querySpan,omitempty"`
+	}
+
+	type diff struct {
+		index       int
+		description string
+		statement   string
+		details     string
+	}
+
+	const testDataPath = "test-data/query_span.yaml"
+	yamlFile, err := os.Open(testDataPath)
+	require.NoError(t, err)
+	byteValue, err := io.ReadAll(yamlFile)
+	require.NoError(t, err)
+	require.NoError(t, yamlFile.Close())
+
+	var testCases []testCase
+	require.NoError(t, yaml.Unmarshal(byteValue, &testCases))
+
+	var diffs []diff
+	for i, tc := range testCases {
+		if strings.TrimSpace(tc.Statement) == "" {
+			continue
+		}
+
+		omni, err := runOracleOmniGoldenCase(context.Background(), tc.Statement, tc.Metadata, tc.CrossDatabaseMetadata, tc.DefaultDatabase)
+		if err != nil {
+			diffs = append(diffs, diff{
+				index:       i,
+				description: tc.Description,
+				statement:   tc.Statement,
+				details:     err.Error(),
+			})
+			continue
+		}
+		if !reflect.DeepEqual(tc.QuerySpan, omni) {
+			diffs = append(diffs, diff{
+				index:       i,
+				description: tc.Description,
+				statement:   tc.Statement,
+				details:     fmt.Sprintf("want=%+v omni=%+v", tc.QuerySpan, omni),
+			})
+		}
+	}
+
+	t.Logf("Oracle omni query-span golden: %d/%d matched, %d diffs", len(testCases)-len(diffs), len(testCases), len(diffs))
+	for i, d := range diffs {
+		if i >= 10 {
+			t.Logf("... %d more diffs omitted", len(diffs)-i)
+			break
+		}
+		t.Logf("[case %d %q] %s\n  SQL: %s", d.index, d.description, d.details, firstOracleOmniProbeLine(d.statement))
+	}
+	require.Empty(t, diffs)
+}
+
+func runOracleOmniGoldenCase(
+	ctx context.Context,
+	statement string,
+	metadataText string,
+	crossDatabaseMetadataText string,
+	defaultDatabase string,
+) (*base.YamlQuerySpan, error) {
+	metadata := &storepb.DatabaseSchemaMetadata{}
+	if err := common.ProtojsonUnmarshaler.Unmarshal([]byte(metadataText), metadata); err != nil {
+		return nil, err
+	}
+	list := []*storepb.DatabaseSchemaMetadata{metadata}
+	if crossDatabaseMetadataText != "" {
+		crossDatabase := &storepb.DatabaseSchemaMetadata{}
+		if err := common.ProtojsonUnmarshaler.Unmarshal([]byte(crossDatabaseMetadataText), crossDatabase); err != nil {
+			return nil, err
+		}
+		list = append(list, crossDatabase)
+	}
+
+	databaseMetadataGetter, databaseNamesLister, linkedDatabaseMetadataGetter := buildMockDatabaseMetadataGetter(list)
+	gCtx := base.GetQuerySpanContext{
+		InstanceID:                    instanceIDA,
+		GetDatabaseMetadataFunc:       databaseMetadataGetter,
+		ListDatabaseNamesFunc:         databaseNamesLister,
+		GetLinkedDatabaseMetadataFunc: linkedDatabaseMetadataGetter,
+	}
+
+	omni, err := newOmniQuerySpanExtractor(defaultDatabase, gCtx).getOmniQuerySpan(ctx, statement)
+	if err != nil {
+		return nil, err
+	}
+	return omni.ToYaml(), nil
+}
+
+func TestOracleOmniLongTailTableSources(t *testing.T) {
+	tests := []struct {
+		name              string
+		statement         string
+		wantResult        string
+		wantSourceColumns []base.ColumnResource
+		wantQuerySources  []base.ColumnResource
+	}{
+		{
+			name:              "json table",
+			statement:         "SELECT JT.ID FROM T, JSON_TABLE(T.J, '$' COLUMNS (ID NUMBER PATH '$.id')) JT",
+			wantResult:        "ID",
+			wantSourceColumns: []base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "J"}},
+			wantQuerySources:  []base.ColumnResource{{Database: "PUBLIC", Table: "T"}},
+		},
+		{
+			name:              "xml table",
+			statement:         "SELECT XT.ID FROM T, XMLTABLE('/root' PASSING T.X COLUMNS ID NUMBER PATH 'id') XT",
+			wantResult:        "ID",
+			wantSourceColumns: []base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "X"}},
+			wantQuerySources:  []base.ColumnResource{{Database: "PUBLIC", Table: "T"}},
+		},
+		{
+			name:              "containers",
+			statement:         "SELECT A FROM CONTAINERS(T)",
+			wantResult:        "A",
+			wantSourceColumns: []base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}},
+			wantQuerySources:  []base.ColumnResource{{Database: "PUBLIC", Table: "T"}},
+		},
+		{
+			name:              "inline external table",
+			statement:         "SELECT EXT.A FROM EXTERNAL ((A NUMBER, B VARCHAR2(20)) TYPE ORACLE_LOADER DEFAULT DIRECTORY D ACCESS PARAMETERS (FIELDS TERMINATED BY ',') LOCATION ('x.csv')) EXT",
+			wantResult:        "A",
+			wantSourceColumns: []base.ColumnResource{},
+			wantQuerySources:  []base.ColumnResource{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			span, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(context.Background(), test.statement)
+			require.NoError(t, err)
+			require.NotNil(t, span)
+			require.Len(t, span.Results, 1)
+			require.Equal(t, test.wantResult, span.Results[0].Name)
+			require.Equal(t, sourceColumnSetFromList(test.wantSourceColumns), span.Results[0].SourceColumns)
+			require.Equal(t, sourceColumnSetFromList(test.wantQuerySources), span.SourceColumns)
+		})
+	}
+}
+
+func TestOracleOmniAnalyticCountStarSources(t *testing.T) {
+	span, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(
+		context.Background(),
+		"SELECT COUNT(*) OVER (PARTITION BY B ORDER BY A) AS C FROM T",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, span)
+	require.Len(t, span.Results, 1)
+	require.Equal(t, "C", span.Results[0].Name)
+	require.Equal(t, sourceColumnSetFromList([]base.ColumnResource{
+		{Database: "PUBLIC", Table: "T", Column: "A"},
+		{Database: "PUBLIC", Table: "T", Column: "B"},
+	}), span.Results[0].SourceColumns)
+}
+
+func TestOracleOmniUnqualifiedStarExpandsAllCommaSources(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		want      []base.QuerySpanResult
+	}{
+		{
+			name:      "base tables",
+			statement: "SELECT * FROM T, T2",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "B", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "C"}})},
+				{Name: "J", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "J"}})},
+				{Name: "X", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "X"}})},
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "C"}})},
+				{Name: "D", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "D"}})},
+			},
+		},
+		{
+			name:      "json table",
+			statement: "SELECT * FROM T, JSON_TABLE(T.J, '$' COLUMNS (ID NUMBER PATH '$.id')) JT",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "B", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "C"}})},
+				{Name: "J", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "J"}})},
+				{Name: "X", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "X"}})},
+				{Name: "ID", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "J"}})},
+			},
+		},
+		{
+			name:      "join",
+			statement: "SELECT * FROM T JOIN T2 ON T.A = T2.C",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "B", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "C"}})},
+				{Name: "J", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "J"}})},
+				{Name: "X", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "X"}})},
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "C"}})},
+				{Name: "D", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "D"}})},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			span, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(context.Background(), test.statement)
+			require.NoError(t, err)
+			require.NotNil(t, span)
+			require.Len(t, span.Results, len(test.want))
+			for i, want := range test.want {
+				require.Equal(t, want.Name, span.Results[i].Name)
+				require.Equal(t, want.SourceColumns, span.Results[i].SourceColumns)
+			}
+		})
+	}
+}
+
+func TestOracleOmniCTEScopeAndSetOperations(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		want      []base.QuerySpanResult
+	}{
+		{
+			name:      "sibling cte references previous cte",
+			statement: "WITH C1 AS (SELECT A FROM T), C2 AS (SELECT A FROM C1 UNION SELECT C FROM T2) SELECT * FROM C2",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "A"},
+					{Database: "PUBLIC", Table: "T2", Column: "C"},
+				})},
+			},
+		},
+		{
+			name:      "cte name shadows physical table",
+			statement: "WITH T AS (SELECT C FROM T2) SELECT * FROM T",
+			want: []base.QuerySpanResult{
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "C"}})},
+			},
+		},
+		{
+			name:      "nested cte name shadows outer cte",
+			statement: "WITH C AS (WITH C AS (SELECT C FROM T2) SELECT C FROM C) SELECT * FROM C",
+			want: []base.QuerySpanResult{
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "C"}})},
+			},
+		},
+		{
+			name:      "multiple ctes join",
+			statement: "WITH C1 AS (SELECT A FROM T), C2 AS (SELECT C FROM T2) SELECT C1.A, C2.C FROM C1 JOIN C2 ON C1.A = C2.C",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "C"}})},
+			},
+		},
+		{
+			name:      "intersect merges source columns positionally",
+			statement: "SELECT A FROM T INTERSECT SELECT C FROM T2",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "A"},
+					{Database: "PUBLIC", Table: "T2", Column: "C"},
+				})},
+			},
+		},
+		{
+			name:      "minus merges source columns positionally",
+			statement: "SELECT A FROM T MINUS SELECT C FROM T2",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "A"},
+					{Database: "PUBLIC", Table: "T2", Column: "C"},
+				})},
+			},
+		},
+		{
+			name:      "recursive cte reaches stable source closure",
+			statement: "WITH C(X) AS (SELECT A FROM T UNION ALL SELECT T2.C FROM T2 JOIN C ON C.X = T2.C) SELECT * FROM C",
+			want: []base.QuerySpanResult{
+				{Name: "X", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "A"},
+					{Database: "PUBLIC", Table: "T2", Column: "C"},
+				})},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			span, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(context.Background(), test.statement)
+			require.NoError(t, err)
+			require.NotNil(t, span)
+			require.Equal(t, test.want, span.Results)
+		})
+	}
+}
+
+func TestOracleOmniExpressionAndAccessTableCoverage(t *testing.T) {
+	t.Run("expression nodes keep source columns", func(t *testing.T) {
+		span, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(
+			context.Background(),
+			`SELECT
+  CASE WHEN A > 0 THEN B ELSE C END AS CASE_VALUE,
+  DECODE(A, 1, B, C) AS DECODE_VALUE,
+  CAST(A AS NUMBER) AS CAST_VALUE,
+  B BETWEEN A AND C AS BETWEEN_VALUE,
+  X LIKE J AS LIKE_VALUE
+FROM T`,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, span)
+		want := []base.QuerySpanResult{
+			{Name: "CASE_VALUE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+				{Database: "PUBLIC", Table: "T", Column: "A"},
+				{Database: "PUBLIC", Table: "T", Column: "B"},
+				{Database: "PUBLIC", Table: "T", Column: "C"},
+			})},
+			{Name: "DECODE_VALUE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+				{Database: "PUBLIC", Table: "T", Column: "A"},
+				{Database: "PUBLIC", Table: "T", Column: "B"},
+				{Database: "PUBLIC", Table: "T", Column: "C"},
+			})},
+			{Name: "CAST_VALUE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+			{Name: "BETWEEN_VALUE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+				{Database: "PUBLIC", Table: "T", Column: "A"},
+				{Database: "PUBLIC", Table: "T", Column: "B"},
+				{Database: "PUBLIC", Table: "T", Column: "C"},
+			})},
+			{Name: "LIKE_VALUE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+				{Database: "PUBLIC", Table: "T", Column: "J"},
+				{Database: "PUBLIC", Table: "T", Column: "X"},
+			})},
+		}
+		require.Equal(t, want, span.Results)
+	})
+
+	t.Run("subqueries in non result clauses contribute access tables", func(t *testing.T) {
+		tests := []string{
+			"SELECT A FROM T WHERE EXISTS (SELECT C FROM T2 WHERE T2.C = T.A)",
+			"SELECT A FROM T ORDER BY (SELECT C FROM T2)",
+			"SELECT COALESCE((SELECT C FROM T2), A) FROM T",
+		}
+		for _, statement := range tests {
+			span, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(context.Background(), statement)
+			require.NoError(t, err, statement)
+			require.NotNil(t, span, statement)
+			require.Equal(t, sourceColumnSetFromList([]base.ColumnResource{
+				{Database: "PUBLIC", Table: "T"},
+				{Database: "PUBLIC", Table: "T2"},
+			}), span.SourceColumns, statement)
+		}
+	})
+}
+
+func TestOracleOmniResourceNotFoundPropagation(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "top level table",
+			statement: "SELECT A FROM MISSING_TABLE",
+		},
+		{
+			name:      "predicate subquery",
+			statement: "SELECT A FROM T WHERE EXISTS (SELECT 1 FROM MISSING_TABLE)",
+		},
+		{
+			name:      "target subquery",
+			statement: "SELECT (SELECT A FROM MISSING_TABLE) AS A FROM T",
+		},
+		{
+			name:      "recursive cte arm",
+			statement: "WITH C(X) AS (SELECT A FROM T UNION ALL SELECT MISSING_TABLE.A FROM MISSING_TABLE JOIN C ON C.X = MISSING_TABLE.A) SELECT * FROM C",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			span, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(context.Background(), test.statement)
+			require.NoError(t, err)
+			require.NotNil(t, span)
+			require.Empty(t, span.Results)
+			require.ErrorAs(t, span.NotFoundError, new(*base.ResourceNotFoundError))
+		})
+	}
+}
+
+func TestOracleOmniUnsupportedLongTailTableSources(t *testing.T) {
+	// UNPIVOT and MODEL used to return approximate ANTLR spans that ignored
+	// their transformation semantics. Keep them explicit unsupported until the
+	// omni extractor models their output columns accurately.
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "table collection",
+			statement: "SELECT * FROM TABLE(pkg.values()) X",
+		},
+		{
+			name:      "pivot",
+			statement: "SELECT * FROM (SELECT A, B FROM T) PIVOT (COUNT(*) FOR B IN (1 AS ONE))",
+		},
+		{
+			name:      "unpivot",
+			statement: "SELECT * FROM (SELECT A, B FROM T) UNPIVOT (VAL FOR COL IN (A AS 'A', B AS 'B'))",
+		},
+		{
+			name:      "model",
+			statement: "SELECT * FROM T MODEL DIMENSION BY (A) MEASURES (B) RULES (B[1] = 1)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(context.Background(), test.statement)
+			require.ErrorContains(t, err, "unsupported oracle table source")
+		})
+	}
+}
+
+func oracleOmniLongTailTestContext(t *testing.T) base.GetQuerySpanContext {
+	t.Helper()
+
+	const metadataText = `{
+		"name": "PUBLIC",
+		"schemas": [{
+			"name": "",
+			"tables": [{
+			"name": "T",
+			"columns": [
+				{"name": "A"},
+				{"name": "B"},
+				{"name": "C"},
+				{"name": "J"},
+				{"name": "X"}
+			]
+		}, {
+			"name": "T2",
+			"columns": [
+				{"name": "C"},
+				{"name": "D"}
+			]
+		}]
+	}]
+}`
+
+	metadata := &storepb.DatabaseSchemaMetadata{}
+	require.NoError(t, common.ProtojsonUnmarshaler.Unmarshal([]byte(metadataText), metadata))
+	databaseMetadataGetter, databaseNamesLister, linkedDatabaseMetadataGetter := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{metadata})
+	return base.GetQuerySpanContext{
+		InstanceID:                    instanceIDA,
+		GetDatabaseMetadataFunc:       databaseMetadataGetter,
+		ListDatabaseNamesFunc:         databaseNamesLister,
+		GetLinkedDatabaseMetadataFunc: linkedDatabaseMetadataGetter,
+	}
+}
+
+func firstOracleOmniProbeLine(statement string) string {
+	for _, line := range strings.Split(statement, "\n") {
+		if strings.TrimSpace(line) != "" {
+			return strings.TrimSpace(line)
+		}
+	}
+	return ""
+}
+
+func sourceColumnSetFromList(columns []base.ColumnResource) base.SourceColumnSet {
+	result := make(base.SourceColumnSet, len(columns))
+	for _, column := range columns {
+		result[column] = true
+	}
+	return result
+}

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -395,6 +395,18 @@ FROM T`,
 			}), span.SourceColumns, statement)
 		}
 	})
+
+	t.Run("cursor expression uses subquery scope", func(t *testing.T) {
+		span, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(
+			context.Background(),
+			"SELECT CURSOR(SELECT C FROM T2) AS CUR FROM T",
+		)
+		require.NoError(t, err)
+		require.NotNil(t, span)
+		require.Equal(t, []base.QuerySpanResult{
+			{Name: "CUR", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "C"}})},
+		}, span.Results)
+	})
 }
 
 func TestOracleOmniResourceNotFoundPropagation(t *testing.T) {

--- a/backend/plugin/parser/plsql/query_span_omni_probe_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_probe_test.go
@@ -1,0 +1,198 @@
+package plsql
+
+import (
+	"io"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/bytebase/omni/oracle/ast"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestOracleOmniParsesQuerySpanFixtureCorpus(t *testing.T) {
+	type testCase struct {
+		Description string `yaml:"description,omitempty"`
+		Statement   string `yaml:"statement,omitempty"`
+	}
+
+	yamlFile, err := os.Open("test-data/query_span.yaml")
+	require.NoError(t, err)
+	defer yamlFile.Close()
+
+	byteValue, err := io.ReadAll(yamlFile)
+	require.NoError(t, err)
+
+	var testCases []testCase
+	require.NoError(t, yaml.Unmarshal(byteValue, &testCases))
+
+	for _, tc := range testCases {
+		t.Run(tc.Description, func(t *testing.T) {
+			list, err := ParsePLSQLOmni(tc.Statement)
+			require.NoError(t, err)
+			require.NotNil(t, list)
+			require.Len(t, list.Items, 1)
+			require.IsType(t, &ast.RawStmt{}, list.Items[0])
+		})
+	}
+}
+
+func TestOracleOmniQuerySpanMigrationProbe(t *testing.T) {
+	tests := []struct {
+		name          string
+		statement     string
+		expectedNodes []string
+		check         func(*testing.T, *ast.RawStmt)
+	}{
+		{
+			name:          "select columns and table ref",
+			statement:     "SELECT A, T.B, PUBLIC.T.C FROM T",
+			expectedNodes: []string{"SelectStmt", "ResTarget", "ColumnRef", "TableRef"},
+		},
+		{
+			name:          "join using",
+			statement:     "SELECT * FROM T T1 JOIN T T2 USING(A)",
+			expectedNodes: []string{"SelectStmt", "JoinClause", "TableRef"},
+		},
+		{
+			name:          "derived table",
+			statement:     "SELECT * FROM (SELECT A FROM T) DT",
+			expectedNodes: []string{"SelectStmt", "SubqueryRef", "TableRef"},
+		},
+		{
+			name:          "scalar and in subqueries",
+			statement:     "SELECT (SELECT MAX(A) FROM T) AS M FROM T WHERE B IN (SELECT C FROM T)",
+			expectedNodes: []string{"SelectStmt", "SubqueryExpr", "FuncCallExpr", "InExpr"},
+		},
+		{
+			name:          "cte and set operation",
+			statement:     "WITH T1(D, C) AS (SELECT A, B FROM T UNION ALL SELECT C, D FROM T) SELECT * FROM T1",
+			expectedNodes: []string{"WithClause", "CTE", "SelectStmt", "TableRef"},
+			check: func(t *testing.T, raw *ast.RawStmt) {
+				var foundSetOp bool
+				ast.Inspect(raw, func(node ast.Node) bool {
+					if sel, ok := node.(*ast.SelectStmt); ok && sel.Op != ast.SETOP_NONE {
+						foundSetOp = true
+					}
+					return true
+				})
+				require.True(t, foundSetOp)
+			},
+		},
+		{
+			name:          "database link",
+			statement:     "SELECT * FROM SCHEMA1.LT1@REMOTE",
+			expectedNodes: []string{"SelectStmt", "TableRef", "ObjectName"},
+			check: func(t *testing.T, raw *ast.RawStmt) {
+				var foundDBLink bool
+				ast.Inspect(raw, func(node ast.Node) bool {
+					if name, ok := node.(*ast.ObjectName); ok && name.Schema == "SCHEMA1" && name.Name == "LT1" && name.DBLink == "REMOTE" {
+						foundDBLink = true
+					}
+					return true
+				})
+				require.True(t, foundDBLink)
+			},
+		},
+		{
+			name:          "json table",
+			statement:     "SELECT JT.ID FROM T, JSON_TABLE(T.J, '$' COLUMNS (ID NUMBER PATH '$.id')) JT",
+			expectedNodes: []string{"SelectStmt", "JsonTableRef", "JsonTableColumn", "TableRef"},
+		},
+		{
+			name:          "xml table",
+			statement:     "SELECT XT.ID FROM T, XMLTABLE('/root' PASSING T.X COLUMNS ID NUMBER PATH 'id') XT",
+			expectedNodes: []string{"SelectStmt", "XmlTableRef", "XmlTableColumn", "TableRef"},
+		},
+		{
+			name:          "containers",
+			statement:     "SELECT A FROM CONTAINERS(T)",
+			expectedNodes: []string{"SelectStmt", "ContainersExpr", "ObjectName"},
+		},
+		{
+			name:          "inline external table",
+			statement:     "SELECT EXT.A FROM EXTERNAL ((A NUMBER, B VARCHAR2(20)) TYPE ORACLE_LOADER DEFAULT DIRECTORY D ACCESS PARAMETERS (FIELDS TERMINATED BY ',') LOCATION ('x.csv')) EXT",
+			expectedNodes: []string{"SelectStmt", "InlineExternalTable", "ColumnDef"},
+		},
+		{
+			name:          "pivot",
+			statement:     "SELECT * FROM (SELECT A, B FROM T) PIVOT (COUNT(*) FOR B IN (1 AS ONE))",
+			expectedNodes: []string{"SelectStmt", "PivotClause", "SubqueryRef"},
+		},
+		{
+			name:          "unpivot",
+			statement:     "SELECT * FROM (SELECT A, B FROM T) UNPIVOT (VAL FOR COL IN (A AS 'A', B AS 'B'))",
+			expectedNodes: []string{"SelectStmt", "UnpivotClause", "SubqueryRef"},
+		},
+		{
+			name:          "model",
+			statement:     "SELECT * FROM T MODEL DIMENSION BY (A) MEASURES (B) RULES (B[1] = 1)",
+			expectedNodes: []string{"SelectStmt", "ModelClause", "ModelRule"},
+		},
+		{
+			name:          "lateral inline view",
+			statement:     "SELECT * FROM T, LATERAL (SELECT A FROM DUAL) L",
+			expectedNodes: []string{"SelectStmt", "LateralRef", "TableRef"},
+		},
+		{
+			name:          "hierarchical query",
+			statement:     "SELECT A FROM T START WITH A = 1 CONNECT BY PRIOR A = B",
+			expectedNodes: []string{"SelectStmt", "HierarchicalClause", "UnaryExpr", "BinaryExpr"},
+		},
+		{
+			name:          "analytic function",
+			statement:     "SELECT SUM(A) OVER (PARTITION BY B ORDER BY C) FROM T",
+			expectedNodes: []string{"SelectStmt", "FuncCallExpr", "WindowSpec", "SortBy"},
+		},
+		{
+			name:          "explain root",
+			statement:     "EXPLAIN PLAN FOR SELECT * FROM T",
+			expectedNodes: []string{"ExplainPlanStmt", "SelectStmt"},
+		},
+		{
+			name:          "dml roots",
+			statement:     "INSERT INTO T(A) SELECT A FROM T2",
+			expectedNodes: []string{"InsertStmt", "SelectStmt", "TableRef"},
+		},
+		{
+			name:          "ddl root",
+			statement:     "CREATE TABLE T(A NUMBER)",
+			expectedNodes: []string{"CreateTableStmt", "ColumnDef"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			list, err := ParsePLSQLOmni(test.statement)
+			require.NoError(t, err)
+			require.Len(t, list.Items, 1)
+			raw, ok := list.Items[0].(*ast.RawStmt)
+			require.True(t, ok)
+
+			nodeTypes := collectOracleOmniNodeTypes(raw)
+			for _, expectedNode := range test.expectedNodes {
+				require.Contains(t, nodeTypes, expectedNode)
+			}
+			if test.check != nil {
+				test.check(t, raw)
+			}
+		})
+	}
+}
+
+func collectOracleOmniNodeTypes(node ast.Node) map[string]bool {
+	result := make(map[string]bool)
+	ast.Inspect(node, func(node ast.Node) bool {
+		if node == nil {
+			return false
+		}
+		typ := reflect.TypeOf(node)
+		if typ.Kind() == reflect.Pointer {
+			typ = typ.Elem()
+		}
+		result[typ.Name()] = true
+		return true
+	})
+	return result
+}

--- a/backend/plugin/parser/plsql/query_type.go
+++ b/backend/plugin/parser/plsql/query_type.go
@@ -1,3 +1,4 @@
+//nolint:unused
 package plsql
 
 import (

--- a/backend/plugin/parser/plsql/query_type_omni_test.go
+++ b/backend/plugin/parser/plsql/query_type_omni_test.go
@@ -36,6 +36,11 @@ func TestOracleOmniQueryTypeDDLClassification(t *testing.T) {
 			want:      base.DDL,
 		},
 		{
+			name:      "lock table is dml",
+			statement: "LOCK TABLE T IN EXCLUSIVE MODE",
+			want:      base.DML,
+		},
+		{
 			name:      "transaction remains unknown",
 			statement: "COMMIT",
 			want:      base.QueryTypeUnknown,

--- a/backend/plugin/parser/plsql/query_type_omni_test.go
+++ b/backend/plugin/parser/plsql/query_type_omni_test.go
@@ -1,0 +1,57 @@
+package plsql
+
+import (
+	"testing"
+
+	oracleast "github.com/bytebase/omni/oracle/ast"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestOracleOmniQueryTypeDDLClassification(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		want      base.QueryType
+	}{
+		{
+			name:      "create table",
+			statement: "CREATE TABLE T(A NUMBER)",
+			want:      base.DDL,
+		},
+		{
+			name:      "create database admin ddl",
+			statement: "CREATE DATABASE",
+			want:      base.DDL,
+		},
+		{
+			name:      "alter database admin ddl",
+			statement: "ALTER DATABASE OPEN",
+			want:      base.DDL,
+		},
+		{
+			name:      "drop database admin ddl",
+			statement: "DROP DATABASE",
+			want:      base.DDL,
+		},
+		{
+			name:      "transaction remains unknown",
+			statement: "COMMIT",
+			want:      base.QueryTypeUnknown,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			list, err := ParsePLSQLOmni(test.statement)
+			require.NoError(t, err)
+			require.Len(t, list.Items, 1)
+			raw, ok := list.Items[0].(*oracleast.RawStmt)
+			require.True(t, ok)
+			require.NotNil(t, raw.Stmt)
+
+			require.Equal(t, test.want, omniQueryType(raw.Stmt, false))
+		})
+	}
+}

--- a/docs/plans/2026-05-28-oracle-query-span-omni-migration.md
+++ b/docs/plans/2026-05-28-oracle-query-span-omni-migration.md
@@ -1,0 +1,108 @@
+# Oracle Query Span Omni Migration Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Migrate Oracle query span extraction from the ANTLR parser path to the omni Oracle AST path while preserving the existing query span fixture behavior.
+
+**Architecture:** Add a package-internal omni golden harness that compares the new extractor against `backend/plugin/parser/plsql/test-data/query_span.yaml`. Implement an Oracle omni query span extractor that reuses the existing metadata lookup and column-source semantics where practical, then switch the public `GetQuerySpan` registration to the omni path. Keep the legacy ANTLR extractor available during the migration for existing access-table tests and as a reference until follow-up cleanup.
+
+**Tech Stack:** Go, `github.com/bytebase/omni/oracle/ast`, `github.com/bytebase/omni/oracle/parser`, existing Bytebase parser base query span model.
+
+### Task 1: Oracle Omni Golden Harness
+
+**Files:**
+- Create: `backend/plugin/parser/plsql/query_span_omni_parity_test.go`
+
+**Step 1: Write the failing test**
+
+Add a test that loads `backend/plugin/parser/plsql/test-data/query_span.yaml`, builds the same mock metadata context as `TestGetQuerySpan`, and calls `newOmniQuerySpanExtractor(...).getOmniQuerySpan(...)`.
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/plsql -run '^TestOracleOmniQuerySpanGoldenHarness$'`
+
+Expected: FAIL because `newOmniQuerySpanExtractor` is undefined.
+
+### Task 2: Upgrade Omni
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+**Step 1: Update dependency**
+
+Run: `go get github.com/bytebase/omni@v0.0.0-20260528064644-6ef6c2c2b826`
+
+**Step 2: Verify parser coverage**
+
+Run: `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/plsql -run '^TestOracleOmniQuerySpanMigrationProbe$'`
+
+Expected: PASS, including inline external table support through the upgraded omni parser.
+
+### Task 3: Implement Oracle Omni Extractor
+
+**Files:**
+- Create: `backend/plugin/parser/plsql/query_span_extractor_omni.go`
+
+**Step 1: Add minimal extractor scaffold**
+
+Implement `newOmniQuerySpanExtractor` and `getOmniQuerySpan` with parsing, statement classification, access-table collection, and select result extraction.
+
+**Step 2: Run golden harness**
+
+Run: `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/plsql -run '^TestOracleOmniQuerySpanGoldenHarness$'`
+
+Expected: PASS.
+
+### Intentional Behavior Changes
+
+- `JSON_TABLE`, `XMLTABLE`, `CONTAINERS`, and inline external table are supported by the omni query span extractor.
+- `PIVOT`, `UNPIVOT`, `MODEL`, and `TABLE(collection)` are intentionally typed unsupported for this migration. In particular, ANTLR could return a successful approximate span for some `UNPIVOT` and `MODEL` queries, but it did not model their transformation semantics accurately. The omni path should fail explicitly until those output columns can be represented correctly.
+
+### Task 4: Switch Public Oracle Query Span Entry
+
+**Files:**
+- Modify: `backend/plugin/parser/plsql/query_span.go`
+
+**Step 1: Change registration**
+
+Replace the public Oracle `GetQuerySpan` implementation with the omni extractor path.
+
+**Step 2: Run public fixture test**
+
+Run: `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/plsql -run '^TestGetQuerySpan$'`
+
+Expected: PASS.
+
+### Task 5: Final Verification
+
+**Files:**
+- All modified Go files
+
+**Step 1: Format**
+
+Run: `gofmt -w backend/plugin/parser/plsql/query_span_omni_parity_test.go backend/plugin/parser/plsql/query_span_extractor_omni.go backend/plugin/parser/plsql/query_span.go`
+
+**Step 2: Package tests**
+
+Run: `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/plsql`
+
+Expected: PASS.
+
+**Step 3: Lint**
+
+Run: `golangci-lint run --allow-parallel-runners`
+
+Expected: `0 issues.`
+
+**Step 4: Auto-fix lint**
+
+Run: `golangci-lint run --fix --allow-parallel-runners`
+
+Expected: `0 issues.`
+
+**Step 5: Build**
+
+Run: `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
+
+Expected: PASS.

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260527100738-02b1a9f3a954
+	github.com/bytebase/omni v0.0.0-20260528064644-6ef6c2c2b826
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260527100738-02b1a9f3a954 h1:ADmVnC+pOrjcqzI7m8UAafCUYQwGsXgawz/nsuJYQDY=
-github.com/bytebase/omni v0.0.0-20260527100738-02b1a9f3a954/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260528064644-6ef6c2c2b826 h1:Ow343I2DTKscD+MG65qItnE60jM3dQTJovVz0UPCelM=
+github.com/bytebase/omni v0.0.0-20260528064644-6ef6c2c2b826/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Migrate Oracle query span extraction to the omni Oracle AST path and keep the public Oracle `GetQuerySpan` entry on omni.
- Add a strict Oracle omni golden harness plus parser/table-source probes for the existing query span fixture corpus.
- Add query span support for Oracle `JSON_TABLE`, `XMLTABLE`, `CONTAINERS`, and inline external table sources.

## Breaking Changes
- `PIVOT`, `UNPIVOT`, `MODEL`, and `TABLE(collection)` are now explicit unsupported Oracle table sources in query span extraction.
- `UNPIVOT` and `MODEL` could previously return approximate ANTLR spans that did not model their transformation semantics accurately; the omni path fails explicitly until those output columns can be represented correctly.

## Test Plan
- [x] `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/plsql`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `golangci-lint run --fix --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Pre-PR Checklist
- Breaking-change check: documented above and labeled `breaking`.
- Composite-PK query safety: skipped; no `backend/store/` or migration SQL changes.
- SonarCloud properties: skipped; new files are Go source/tests/docs under existing patterns.
