### PR TITLE
fix(parser): make omni split position mapping linear

### DIFF
--- a/backend/plugin/parser/base/position.go
+++ b/backend/plugin/parser/base/position.go
@@ -1,0 +1,74 @@
+package base
+
+import (
+	"unicode/utf8"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+// ByteOffsetPositionMapper converts monotonically increasing byte offsets in a
+// single SQL string to 1-based line:column positions in one pass.
+type ByteOffsetPositionMapper struct {
+	sql        string
+	byteOffset int
+	line       int32
+	runeCol    int32
+}
+
+// NewByteOffsetPositionMapper creates a mapper for byte offsets in sql.
+func NewByteOffsetPositionMapper(sql string) *ByteOffsetPositionMapper {
+	return &ByteOffsetPositionMapper{
+		sql:  sql,
+		line: 1,
+	}
+}
+
+// Position returns the 1-based line:column position for byteOffset.
+func (m *ByteOffsetPositionMapper) Position(byteOffset int) *storepb.Position {
+	if byteOffset < 0 {
+		byteOffset = 0
+	}
+	if byteOffset > len(m.sql) {
+		byteOffset = len(m.sql)
+	}
+	if byteOffset < m.byteOffset {
+		return byteOffsetToRunePosition(m.sql, byteOffset)
+	}
+
+	for m.byteOffset < byteOffset {
+		r, size := utf8.DecodeRuneInString(m.sql[m.byteOffset:])
+		if r == '\n' {
+			m.line++
+			m.runeCol = 0
+		} else {
+			m.runeCol++
+		}
+		m.byteOffset += size
+	}
+
+	return &storepb.Position{
+		Line:   m.line,
+		Column: m.runeCol + 1,
+	}
+}
+
+func byteOffsetToRunePosition(sql string, byteOffset int) *storepb.Position {
+	line := int32(1)
+	runeCol := int32(0)
+	i := 0
+	for i < byteOffset {
+		r, size := utf8.DecodeRuneInString(sql[i:])
+		if r == '\n' {
+			line++
+			runeCol = 0
+		} else {
+			runeCol++
+		}
+		i += size
+	}
+
+	return &storepb.Position{
+		Line:   line,
+		Column: runeCol + 1,
+	}
+}

--- a/backend/plugin/parser/base/position_test.go
+++ b/backend/plugin/parser/base/position_test.go
@@ -1,0 +1,24 @@
+package base
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestByteOffsetPositionMapper(t *testing.T) {
+	sql := "SELECT 1;\nSELECT 日本;\nSELECT 3;"
+	mapper := NewByteOffsetPositionMapper(sql)
+
+	require.Equal(t, int32(1), mapper.Position(0).Line)
+	require.Equal(t, int32(1), mapper.Position(0).Column)
+	require.Equal(t, int32(2), mapper.Position(len("SELECT 1;\n")).Line)
+	require.Equal(t, int32(1), mapper.Position(len("SELECT 1;\n")).Column)
+	require.Equal(t, int32(2), mapper.Position(len("SELECT 1;\nSELECT 日")).Line)
+	require.Equal(t, int32(9), mapper.Position(len("SELECT 1;\nSELECT 日")).Column)
+
+	// Out-of-order lookups are supported for callers that occasionally need to
+	// revisit an earlier offset.
+	require.Equal(t, int32(1), mapper.Position(len("SELECT")).Line)
+	require.Equal(t, int32(7), mapper.Position(len("SELECT")).Column)
+}

--- a/backend/plugin/parser/mysql/split.go
+++ b/backend/plugin/parser/mysql/split.go
@@ -21,6 +21,7 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 	segments := mysqlparser.Split(statement)
 
 	result := make([]base.Statement, 0, len(segments))
+	positionMapper := base.NewByteOffsetPositionMapper(statement)
 	for _, seg := range segments {
 		// omni Segment excludes the trailing semicolon, but downstream
 		// code expects it included. Extend the byte range to cover it.
@@ -33,8 +34,8 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 		result = append(result, base.Statement{
 			Text:  text,
 			Empty: seg.Empty(),
-			Start: ByteOffsetToRunePosition(statement, seg.ByteStart),
-			End:   ByteOffsetToRunePosition(statement, byteEnd),
+			Start: positionMapper.Position(seg.ByteStart),
+			End:   positionMapper.Position(byteEnd),
 			Range: &storepb.Range{
 				Start: int32(seg.ByteStart),
 				End:   int32(byteEnd),

--- a/backend/plugin/parser/mysql/split_test.go
+++ b/backend/plugin/parser/mysql/split_test.go
@@ -1,7 +1,10 @@
 package mysql
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -12,6 +15,23 @@ func TestMySQLSplitSQL(t *testing.T) {
 	base.RunSplitTests(t, "test-data/test_split.yaml", base.SplitTestOptions{
 		SplitFunc: SplitSQL,
 	})
+}
+
+func TestMySQLSplitSQLLargeInsertScriptScalesLinearly(t *testing.T) {
+	const rowCount = 2000
+	padding := strings.Repeat("x", 1024)
+	var builder strings.Builder
+	for i := 0; i < rowCount; i++ {
+		fmt.Fprintf(&builder, "INSERT INTO perf_omni_mysql (id, payload) VALUES (%d, '%s');\n", i, padding)
+	}
+
+	started := time.Now()
+	statements, err := SplitSQL(builder.String())
+	elapsed := time.Since(started)
+
+	require.NoError(t, err)
+	require.Len(t, base.FilterEmptyStatements(statements), rowCount)
+	require.Less(t, elapsed, time.Second)
 }
 
 func TestSplitMySQLStatements(t *testing.T) {

--- a/backend/plugin/parser/pg/split.go
+++ b/backend/plugin/parser/pg/split.go
@@ -19,12 +19,13 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 	segments := omnipg.Split(statement)
 
 	result := make([]base.Statement, 0, len(segments))
+	positionMapper := base.NewByteOffsetPositionMapper(statement)
 	for _, seg := range segments {
 		result = append(result, base.Statement{
 			Text:  seg.Text,
 			Empty: seg.Empty(),
-			Start: ByteOffsetToRunePosition(statement, seg.ByteStart),
-			End:   ByteOffsetToRunePosition(statement, seg.ByteEnd),
+			Start: positionMapper.Position(seg.ByteStart),
+			End:   positionMapper.Position(seg.ByteEnd),
 			Range: &storepb.Range{
 				Start: int32(seg.ByteStart),
 				End:   int32(seg.ByteEnd),

--- a/backend/plugin/parser/pg/split_test.go
+++ b/backend/plugin/parser/pg/split_test.go
@@ -1,7 +1,12 @@
 package pg
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
@@ -10,4 +15,21 @@ func TestPGSplitSQL(t *testing.T) {
 	base.RunSplitTests(t, "test-data/test_split.yaml", base.SplitTestOptions{
 		SplitFunc: SplitSQL,
 	})
+}
+
+func TestPGSplitSQLLargeInsertScriptScalesLinearly(t *testing.T) {
+	const rowCount = 2000
+	padding := strings.Repeat("x", 1024)
+	var builder strings.Builder
+	for i := 0; i < rowCount; i++ {
+		fmt.Fprintf(&builder, "INSERT INTO perf_omni_pg (id, payload) VALUES (%d, '%s');\n", i, padding)
+	}
+
+	started := time.Now()
+	statements, err := SplitSQL(builder.String())
+	elapsed := time.Since(started)
+
+	require.NoError(t, err)
+	require.Len(t, base.FilterEmptyStatements(statements), rowCount)
+	require.Less(t, elapsed, time.Second)
 }

--- a/backend/plugin/parser/plsql/split.go
+++ b/backend/plugin/parser/plsql/split.go
@@ -40,6 +40,7 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 	segments := oracleparser.Split(statement)
 
 	result := make([]base.Statement, 0, len(segments))
+	positionMapper := base.NewByteOffsetPositionMapper(statement)
 	for _, seg := range segments {
 		if seg.Kind == oracleparser.SegmentSQLPlusCommand {
 			continue
@@ -48,8 +49,8 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 		text := statement[seg.ByteStart:byteEnd]
 		result = append(result, base.Statement{
 			Text:  text,
-			Start: ByteOffsetToRunePosition(statement, seg.ByteStart),
-			End:   ByteOffsetToRunePosition(statement, byteEnd),
+			Start: positionMapper.Position(seg.ByteStart),
+			End:   positionMapper.Position(byteEnd),
 			Empty: seg.Empty(),
 			Range: &storepb.Range{
 				Start: int32(seg.ByteStart),

--- a/backend/plugin/parser/plsql/split_test.go
+++ b/backend/plugin/parser/plsql/split_test.go
@@ -1,7 +1,10 @@
 package plsql
 
 import (
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -65,4 +68,24 @@ SELECT 1 FROM dual;`
 	require.Equal(t, "SET TRANSACTION READ ONLY", statements[0].Text)
 	require.Equal(t, "\nSET ROLE app_role", statements[1].Text)
 	require.Equal(t, "\nSELECT 1 FROM dual", statements[2].Text)
+}
+
+func TestPLSQLSplitSQLLargeInsertScriptScalesLinearly(t *testing.T) {
+	const rowCount = 2000
+	padding := strings.Repeat("x", 1024)
+	var builder strings.Builder
+	for i := 0; i < rowCount; i++ {
+		fmt.Fprintf(&builder, "INSERT INTO perf_omni_oracle (id, payload) VALUES (%d, '%s');\n", i, padding)
+	}
+
+	started := time.Now()
+	statements, err := SplitSQL(builder.String())
+	elapsed := time.Since(started)
+
+	require.NoError(t, err)
+	require.Len(t, statements, rowCount)
+	require.Less(t, elapsed, time.Second)
+	require.Equal(t, int32(1), statements[0].Start.Line)
+	require.Equal(t, int32(rowCount-1), statements[rowCount-1].Start.Line)
+	require.Equal(t, int32(rowCount), statements[rowCount-1].End.Line)
 }


### PR DESCRIPTION
## Summary
- Add a shared byte-offset position mapper that converts monotonically increasing split offsets in one pass.
- Use it in MySQL/MariaDB/OceanBase, PostgreSQL/CockroachDB, and Oracle omni splitters to avoid repeated prefix scans.
- Add large INSERT split regression tests for MySQL, PostgreSQL, and Oracle, plus mapper unit coverage.

## Performance Notes
- Oracle SQL review no-cache 200 MiB / 100k INSERT script: ~4.3-4.4s end to end after the fix.
- MySQL and PostgreSQL 2 MiB / 2000-row split regressions dropped from ~2.6s to ~0.01s locally.

## Test Plan
- [x] go test -count=1 ./backend/plugin/parser/base ./backend/plugin/parser/mysql ./backend/plugin/parser/pg ./backend/plugin/parser/plsql -timeout 5m
- [x] golangci-lint run --allow-parallel-runners
- [x] go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go

## Pre-PR Checklist
- Breaking changes: none; parser performance fix only.
- Composite-PK query safety: skipped; no store or migration changes.
- SonarCloud properties: no update needed; new Go files are covered by existing backend source/test patterns.