### PR TITLE
fix: parse Oracle omni scripts via splitter

### DIFF
--- a/backend/plugin/parser/plsql/omni.go
+++ b/backend/plugin/parser/plsql/omni.go
@@ -1,6 +1,7 @@
 package plsql
 
 import (
+	"reflect"
 	"unicode/utf8"
 
 	"github.com/antlr4-go/antlr/v4"
@@ -73,7 +74,70 @@ func parseSinglePLSQLLenient(statement string) (antlr.Tree, *antlr.CommonTokenSt
 // ParsePLSQLOmni parses SQL using omni's parser and returns an ast.List.
 // This is the recommended entry point for new Oracle code that needs omni AST nodes.
 func ParsePLSQLOmni(sql string) (*ast.List, error) {
-	return oracleparser.Parse(sql)
+	statements, err := SplitSQL(sql)
+	if err != nil {
+		return nil, err
+	}
+
+	list := &ast.List{}
+	for _, statement := range statements {
+		if statement.Empty {
+			continue
+		}
+		parsed, err := oracleparser.Parse(statement.Text)
+		if err != nil {
+			return nil, err
+		}
+		if parsed == nil {
+			continue
+		}
+		if statement.Range != nil {
+			offsetOmniLocs(parsed, int(statement.Range.Start))
+		}
+		list.Items = append(list.Items, parsed.Items...)
+	}
+	return list, nil
+}
+
+type omniLocOffsetter int
+
+func offsetOmniLocs(node ast.Node, offset int) {
+	if offset == 0 {
+		return
+	}
+	ast.Walk(omniLocOffsetter(offset), node)
+}
+
+func (o omniLocOffsetter) Visit(node ast.Node) ast.Visitor {
+	if node == nil {
+		return nil
+	}
+	value := reflect.ValueOf(node)
+	if value.Kind() != reflect.Pointer || value.IsNil() {
+		return o
+	}
+	elem := value.Elem()
+	if elem.Kind() != reflect.Struct {
+		return o
+	}
+	locField := elem.FieldByName("Loc")
+	if !locField.IsValid() || !locField.CanSet() || locField.Type() != reflect.TypeOf(ast.Loc{}) {
+		return o
+	}
+
+	loc, ok := locField.Interface().(ast.Loc)
+	if !ok {
+		return o
+	}
+	offset := int(o)
+	if loc.Start >= 0 {
+		loc.Start += offset
+	}
+	if loc.End >= 0 {
+		loc.End += offset
+	}
+	locField.Set(reflect.ValueOf(loc))
+	return o
 }
 
 // GetOmniNode extracts the omni AST node from a base.AST interface.

--- a/backend/plugin/parser/plsql/omni_test.go
+++ b/backend/plugin/parser/plsql/omni_test.go
@@ -1,6 +1,7 @@
 package plsql
 
 import (
+	"strings"
 	"testing"
 
 	parser "github.com/bytebase/parser/plsql"
@@ -25,6 +26,87 @@ func TestParsePLSQLOmni(t *testing.T) {
 	second, ok := list.Items[1].(*ast.RawStmt)
 	require.True(t, ok)
 	require.IsType(t, &ast.InsertStmt{}, second.Stmt)
+}
+
+func TestParsePLSQLOmniSplitsSlashTerminatedPLSQLScript(t *testing.T) {
+	list, err := ParsePLSQLOmni(`
+CREATE TABLE AUDIT_LOG (
+  LOG_ID NUMBER PRIMARY KEY
+);
+
+CREATE OR REPLACE TRIGGER audit_log_trigger
+BEFORE INSERT ON AUDIT_LOG
+FOR EACH ROW
+BEGIN
+  NULL;
+END;
+/
+`)
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	require.Len(t, list.Items, 2)
+
+	first, ok := list.Items[0].(*ast.RawStmt)
+	require.True(t, ok)
+	require.IsType(t, &ast.CreateTableStmt{}, first.Stmt)
+
+	second, ok := list.Items[1].(*ast.RawStmt)
+	require.True(t, ok)
+	require.IsType(t, &ast.CreateTriggerStmt{}, second.Stmt)
+}
+
+func TestParsePLSQLOmniSkipsSQLPlusCommands(t *testing.T) {
+	list, err := ParsePLSQLOmni(`
+SET DEFINE OFF
+PROMPT setup
+
+CREATE TABLE AUDIT_LOG (
+  LOG_ID NUMBER PRIMARY KEY
+);
+
+SPOOL out.log
+CREATE OR REPLACE TRIGGER audit_log_trigger
+BEFORE INSERT ON AUDIT_LOG
+FOR EACH ROW
+BEGIN
+  NULL;
+END;
+/
+SPOOL OFF
+`)
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	require.Len(t, list.Items, 2)
+
+	first, ok := list.Items[0].(*ast.RawStmt)
+	require.True(t, ok)
+	require.IsType(t, &ast.CreateTableStmt{}, first.Stmt)
+
+	second, ok := list.Items[1].(*ast.RawStmt)
+	require.True(t, ok)
+	require.IsType(t, &ast.CreateTriggerStmt{}, second.Stmt)
+}
+
+func TestParsePLSQLOmniPreservesScriptOffsets(t *testing.T) {
+	sql := `PROMPT setup
+SELECT 1 FROM DUAL;
+
+SELECT name FROM users;
+`
+	list, err := ParsePLSQLOmni(sql)
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	require.Len(t, list.Items, 2)
+
+	first, ok := list.Items[0].(*ast.RawStmt)
+	require.True(t, ok)
+	require.Equal(t, strings.Index(sql, "SELECT 1"), first.Loc.Start)
+	require.Equal(t, strings.Index(sql, ";"), first.Loc.End)
+
+	second, ok := list.Items[1].(*ast.RawStmt)
+	require.True(t, ok)
+	require.Equal(t, strings.Index(sql, "SELECT name"), second.Loc.Start)
+	require.Equal(t, strings.LastIndex(sql, ";"), second.Loc.End)
 }
 
 func TestParsePLSQLOmniReturnsParseError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Route Bytebase Oracle `ParsePLSQLOmni` through omni's script-level parser so SQL*Plus slash delimiters are split before parsing.
- Preserve the existing `*ast.List` / `*ast.RawStmt` wrapper shape for current callers.
- Add coverage for slash-terminated PL/SQL scripts.

## Test Plan
- `go test ./backend/plugin/parser/plsql -run '^TestParsePLSQLOmni' -count=1`\n- `golangci-lint run --allow-parallel-runners`\n- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`