### PR TITLE
feat(tidb): port auto-completion to omni

### DIFF
--- a/backend/plugin/parser/mysql/completion.go
+++ b/backend/plugin/parser/mysql/completion.go
@@ -19,7 +19,6 @@ import (
 func init() {
 	base.RegisterCompleteFunc(storepb.Engine_MYSQL, Completion)
 	base.RegisterCompleteFunc(storepb.Engine_MARIADB, Completion)
-	base.RegisterCompleteFunc(storepb.Engine_TIDB, Completion)
 	base.RegisterCompleteFunc(storepb.Engine_OCEANBASE, Completion)
 	base.RegisterCompleteFunc(storepb.Engine_CLICKHOUSE, Completion)
 	base.RegisterCompleteFunc(storepb.Engine_STARROCKS, Completion)

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -48,7 +48,7 @@ func init() {
 // Completion provides auto-complete candidates for TiDB statements using the
 // omni TiDB completion engine, replacing the previous mysql ANTLR completer.
 func Completion(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) ([]base.Candidate, error) {
-	cat := buildCatalog(ctx, cCtx)
+	cat := buildCatalog(ctx, cCtx, statement)
 	pos := lineOffsetToBytePos(statement, caretLine, caretOffset)
 
 	candidateMap := make(map[string]base.Candidate)
@@ -96,43 +96,123 @@ func Completion(ctx context.Context, cCtx base.CompletionContext, statement stri
 }
 
 // buildCatalog constructs an omni TiDB catalog from Bytebase metadata by
-// replaying minimal DDL. Every identifier is backticked so reserved words and
-// special characters parse correctly; tables are created one at a time so a
-// single unparseable column type cannot empty the whole catalog.
-func buildCatalog(ctx context.Context, cCtx base.CompletionContext) *catalog.Catalog {
+// replaying minimal DDL. It fully loads the default database plus any database
+// referenced as a qualifier in the statement (so cross-database qualified
+// completion like `other_db.tbl.col` resolves), and registers every other known
+// database name so database-name candidates still surface. Every identifier is
+// backticked so reserved words and special characters parse; tables are created
+// one at a time so a single unparseable column type cannot empty the catalog.
+func buildCatalog(ctx context.Context, cCtx base.CompletionContext, statement string) *catalog.Catalog {
 	cat := catalog.New()
 	if cCtx.Metadata == nil || cCtx.DefaultDatabase == "" {
 		return cat
 	}
-	_, dbMeta, err := cCtx.Metadata(ctx, cCtx.InstanceID, cCtx.DefaultDatabase)
+
+	// Fully load the default database plus any qualifier-referenced database.
+	loadOrder := []string{cCtx.DefaultDatabase}
+	seen := map[string]bool{cCtx.DefaultDatabase: true}
+	allNames := listAllDatabaseNames(ctx, cCtx)
+	for _, name := range allNames {
+		if !seen[name] && statementReferencesDatabase(statement, name) {
+			loadOrder = append(loadOrder, name)
+			seen[name] = true
+		}
+	}
+
+	// Register the remaining known database names (name only) so they surface as
+	// database candidates even when not fully loaded.
+	var reg strings.Builder
+	for _, name := range allNames {
+		if !seen[name] {
+			reg.WriteString("CREATE DATABASE " + backtickIdentifier(name) + "; ")
+		}
+	}
+	if reg.Len() > 0 {
+		_, _ = cat.Exec(reg.String(), &catalog.ExecOptions{ContinueOnError: true})
+	}
+
+	for _, name := range loadOrder {
+		loadDatabaseObjects(ctx, cCtx, cat, name)
+	}
+
+	// Restore the current database to the default so unqualified references
+	// resolve against it.
+	_, _ = cat.Exec("USE "+backtickIdentifier(cCtx.DefaultDatabase)+";", &catalog.ExecOptions{ContinueOnError: true})
+	return cat
+}
+
+// loadDatabaseObjects fully loads one database's tables and views into the
+// catalog, under that database's namespace.
+func loadDatabaseObjects(ctx context.Context, cCtx base.CompletionContext, cat *catalog.Catalog, dbName string) {
+	db := backtickIdentifier(dbName)
+	_, dbMeta, err := cCtx.Metadata(ctx, cCtx.InstanceID, dbName)
 	if err != nil || dbMeta == nil {
-		return cat
+		// Still register the name so it can be a database candidate.
+		_, _ = cat.Exec("CREATE DATABASE "+db+";", &catalog.ExecOptions{ContinueOnError: true})
+		return
 	}
-
-	db := backtickIdentifier(cCtx.DefaultDatabase)
-	if _, err := cat.Exec(fmt.Sprintf("CREATE DATABASE %s; USE %s;", db, db), &catalog.ExecOptions{ContinueOnError: true}); err != nil {
-		return cat
+	if _, err := cat.Exec("CREATE DATABASE "+db+"; USE "+db+";", &catalog.ExecOptions{ContinueOnError: true}); err != nil {
+		return
 	}
-
 	schema := dbMeta.GetSchemaMetadata("")
 	if schema == nil {
-		return cat
+		return
 	}
 	for _, tableName := range schema.ListTableNames() {
-		table := schema.GetTable(tableName)
-		if table == nil {
-			continue
+		if table := schema.GetTable(tableName); table != nil {
+			defineTable(cat, tableName, table.GetProto().GetColumns())
 		}
-		defineTable(cat, tableName, table.GetProto().GetColumns())
 	}
 	for _, viewName := range schema.ListViewNames() {
-		view := schema.GetView(viewName)
-		if view == nil {
-			continue
+		if view := schema.GetView(viewName); view != nil {
+			defineView(cat, viewName, view.GetDefinition())
 		}
-		defineView(cat, viewName, view.GetDefinition())
 	}
-	return cat
+}
+
+// listAllDatabaseNames returns the instance's database names, or nil if the
+// completion context cannot enumerate them.
+func listAllDatabaseNames(ctx context.Context, cCtx base.CompletionContext) []string {
+	if cCtx.ListDatabaseNames == nil {
+		return nil
+	}
+	names, err := cCtx.ListDatabaseNames(ctx, cCtx.InstanceID)
+	if err != nil {
+		return nil
+	}
+	return names
+}
+
+// statementReferencesDatabase reports whether dbName appears as a database
+// qualifier (`dbName.`) in the statement, at an identifier boundary.
+func statementReferencesDatabase(statement, dbName string) bool {
+	if dbName == "" {
+		return false
+	}
+	s := strings.ToLower(statement)
+	name := strings.ToLower(dbName)
+	for _, q := range []string{name + ".", "`" + name + "`."} {
+		from := 0
+		for {
+			i := strings.Index(s[from:], q)
+			if i < 0 {
+				break
+			}
+			at := from + i
+			if at == 0 || !isIdentByte(s[at-1]) {
+				return true
+			}
+			from = at + 1
+		}
+	}
+	return false
+}
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9')
 }
 
 // defineTable installs a table in the catalog, retrying with generic column

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -50,12 +50,14 @@ func init() {
 // Completion provides auto-complete candidates for TiDB statements using the
 // omni TiDB completion engine, replacing the previous mysql ANTLR completer.
 func Completion(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) ([]base.Candidate, error) {
-	cat := buildCatalog(ctx, cCtx, statement)
-	pos := lineOffsetToBytePos(statement, caretLine, caretOffset)
+	// Limit completion to the statement containing the caret so table refs from
+	// earlier statements in the buffer don't leak into the candidate set.
+	stmt, pos := currentStatement(statement, lineOffsetToBytePos(statement, caretLine, caretOffset))
 
-	caretInBacktick := caretInsideBacktickIdentifier(statement, pos)
+	cat := buildCatalog(ctx, cCtx, stmt)
+	caretInBacktick := caretInsideBacktickIdentifier(stmt, pos)
 	candidateMap := make(map[string]base.Candidate)
-	for _, c := range omnicompletion.Complete(statement, pos, cat) {
+	for _, c := range omnicompletion.Complete(stmt, pos, cat) {
 		t := omniCandidateTypeToBase(c.Type)
 		text := c.Text
 		if isObjectIdentifierCandidate(t) {
@@ -390,6 +392,19 @@ func lineOffsetToBytePos(s string, line, offset int) int {
 		return len(s)
 	}
 	return pos
+}
+
+// currentStatement returns the statement containing byte position pos within
+// statement, along with pos translated to an offset within that statement. It
+// uses omni's splitter so completion sees only the caret's statement, not table
+// references from earlier statements in the buffer.
+func currentStatement(statement string, pos int) (string, int) {
+	for _, seg := range tidbparser.Split(statement) {
+		if pos >= seg.ByteStart && pos <= seg.ByteEnd {
+			return seg.Text, pos - seg.ByteStart
+		}
+	}
+	return statement, pos
 }
 
 // omniCandidateTypeToBase maps omni TiDB completion candidate types to the

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/bytebase/omni/tidb/catalog"
 	omnicompletion "github.com/bytebase/omni/tidb/completion"
+	tidbparser "github.com/bytebase/omni/tidb/parser"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
@@ -51,12 +53,17 @@ func Completion(ctx context.Context, cCtx base.CompletionContext, statement stri
 	cat := buildCatalog(ctx, cCtx, statement)
 	pos := lineOffsetToBytePos(statement, caretLine, caretOffset)
 
+	caretInBacktick := caretInsideBacktickIdentifier(statement, pos)
 	candidateMap := make(map[string]base.Candidate)
 	for _, c := range omnicompletion.Complete(statement, pos, cat) {
 		t := omniCandidateTypeToBase(c.Type)
-		candidateMap[string(t)+":"+c.Text] = base.Candidate{
+		text := c.Text
+		if isObjectIdentifierCandidate(t) {
+			text = quoteIdentifierIfNeeded(c.Text, caretInBacktick)
+		}
+		candidateMap[string(t)+":"+text] = base.Candidate{
 			Type:       t,
-			Text:       c.Text,
+			Text:       text,
 			Definition: c.Definition,
 			Comment:    c.Comment,
 		}
@@ -281,6 +288,87 @@ func execOK(cat *catalog.Catalog, ddl string) bool {
 // backticks by doubling them.
 func backtickIdentifier(name string) string {
 	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// isObjectIdentifierCandidate reports whether a candidate type names a schema
+// object referenced as an identifier in SQL (and so must be backtick-quoted
+// when it is a reserved word or a non-bare name). Keywords, builtin functions,
+// and value-like candidates (charset/engine/variable/type) are excluded.
+func isObjectIdentifierCandidate(t base.CandidateType) bool {
+	switch t {
+	case base.CandidateTypeDatabase,
+		base.CandidateTypeTable,
+		base.CandidateTypeView,
+		base.CandidateTypeColumn,
+		base.CandidateTypeIndex,
+		base.CandidateTypeTrigger,
+		base.CandidateTypeEvent,
+		base.CandidateTypeRoutine:
+		return true
+	default:
+		return false
+	}
+}
+
+// quoteIdentifierIfNeeded backtick-quotes an object identifier when it would
+// otherwise be invalid as a bare identifier, so that accepting the completion
+// inserts valid SQL. When the caret already sits inside a backtick-quoted
+// identifier the user is typing, the name is returned unquoted (the user's
+// backticks wrap it).
+func quoteIdentifierIfNeeded(name string, caretInBacktick bool) string {
+	if caretInBacktick || !identifierNeedsQuoting(name) {
+		return name
+	}
+	return backtickIdentifier(name)
+}
+
+// identifierNeedsQuoting reports whether name must be backtick-quoted to be a
+// valid bare identifier: it is empty, contains a character outside
+// [letter,digit,_,$], starts with a digit, or is a reserved keyword.
+func identifierNeedsQuoting(name string) bool {
+	if name == "" {
+		return true
+	}
+	for _, r := range name {
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '$' {
+			return true
+		}
+	}
+	if unicode.IsDigit(rune(name[0])) {
+		return true
+	}
+	return isReservedKeyword(name)
+}
+
+// isReservedKeyword reports whether a bare-shaped name is a reserved keyword
+// that cannot be used as an unquoted identifier. omni exposes no reserved-word
+// predicate, so we parse-check only names that lex as a single keyword token
+// (plain identifiers are never reserved), which keeps this cheap for ordinary
+// names. A keyword is reserved iff it cannot stand as a bare table reference.
+func isReservedKeyword(name string) bool {
+	upper := strings.ToUpper(name)
+	toks := tidbparser.Tokenize(upper)
+	if len(toks) != 1 || tidbparser.TokenName(toks[0].Type) == "" {
+		return false
+	}
+	_, err := tidbparser.Parse("SELECT 1 FROM " + upper)
+	return err != nil
+}
+
+// caretInsideBacktickIdentifier reports whether the caret sits inside an open
+// backtick-quoted identifier (an odd number of backticks precede it), in which
+// case completed identifiers must not add their own quotes.
+func caretInsideBacktickIdentifier(statement string, pos int) bool {
+	if pos > len(statement) {
+		pos = len(statement)
+	}
+	count := 0
+	for i := 0; i < pos; i++ {
+		if statement[i] == '`' {
+			count++
+		}
+	}
+	return count%2 == 1
 }
 
 // lineOffsetToBytePos converts a 1-based line number and 0-based character

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -60,8 +60,13 @@ func Completion(ctx context.Context, cCtx base.CompletionContext, statement stri
 	for _, c := range omnicompletion.Complete(stmt, pos, cat) {
 		t := omniCandidateTypeToBase(c.Type)
 		text := c.Text
-		if isObjectIdentifierCandidate(t) {
+		switch {
+		case isObjectIdentifierCandidate(t):
 			text = quoteIdentifierIfNeeded(c.Text, caretInBacktick)
+		case t == base.CandidateTypeFunction:
+			text = c.Text + "()"
+		default:
+			// Keywords and value-like candidates pass through unchanged.
 		}
 		candidateMap[string(t)+":"+text] = base.Candidate{
 			Type:       t,

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -395,15 +395,23 @@ func isReservedKeyword(name string) bool {
 // caretInsideBacktickIdentifier reports whether the caret sits inside an open
 // backtick-quoted identifier (an odd number of backticks precede it), in which
 // case completed identifiers must not add their own quotes.
+// identifierChars is the set of bytes that can appear in a bare identifier,
+// used to strip a partial identifier the user is typing.
+const identifierChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_$"
+
 // caretAtStatementStart reports whether the caret is at a statement-start
-// position — only whitespace and comments precede it, or it directly follows a
-// ';'. Write keywords are filtered only here (in the query scene) so keywords
-// valid inside read statements are preserved in other positions.
+// position — only whitespace and comments precede it (or it directly follows a
+// ';'), ignoring any partial identifier the user is currently typing (so "CRE"
+// or "...; INS" still count as statement start). Write keywords are filtered
+// only here (in the query scene) so keywords valid inside read statements are
+// preserved in other positions.
 func caretAtStatementStart(statement string, pos int) bool {
 	if pos > len(statement) {
 		pos = len(statement)
 	}
-	before := strings.TrimRight(stripStringsAndComments(statement)[:pos], " \t\r\n")
+	before := stripStringsAndComments(statement)[:pos]
+	before = strings.TrimRight(before, identifierChars) // drop the partial identifier
+	before = strings.TrimRight(before, " \t\r\n")
 	return before == "" || before[len(before)-1] == ';'
 }
 

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -113,23 +113,29 @@ func Completion(ctx context.Context, cCtx base.CompletionContext, statement stri
 // one at a time so a single unparseable column type cannot empty the catalog.
 func buildCatalog(ctx context.Context, cCtx base.CompletionContext, statement string) *catalog.Catalog {
 	cat := catalog.New()
-	if cCtx.Metadata == nil || cCtx.DefaultDatabase == "" {
-		return cat
-	}
-
-	// Fully load the default database plus any qualifier-referenced database.
-	loadOrder := []string{cCtx.DefaultDatabase}
-	seen := map[string]bool{cCtx.DefaultDatabase: true}
 	allNames := listAllDatabaseNames(ctx, cCtx)
-	for _, name := range allNames {
-		if !seen[name] && statementReferencesDatabase(statement, name) {
-			loadOrder = append(loadOrder, name)
-			seen[name] = true
+
+	// Decide which databases to fully load with their objects. This needs a
+	// metadata fetcher and a database to load from: the default database (if one
+	// is selected) plus any database referenced as a qualifier in the statement.
+	seen := map[string]bool{}
+	var loadOrder []string
+	if cCtx.Metadata != nil {
+		if cCtx.DefaultDatabase != "" {
+			loadOrder = append(loadOrder, cCtx.DefaultDatabase)
+			seen[cCtx.DefaultDatabase] = true
+		}
+		for _, name := range allNames {
+			if !seen[name] && statementReferencesDatabase(statement, name) {
+				loadOrder = append(loadOrder, name)
+				seen[name] = true
+			}
 		}
 	}
 
-	// Register the remaining known database names (name only) so they surface as
-	// database candidates even when not fully loaded.
+	// Register every other known database name (name only) so database-name
+	// candidates surface — this works at the instance level even when no database
+	// is selected (DefaultDatabase empty).
 	var reg strings.Builder
 	for _, name := range allNames {
 		if !seen[name] {
@@ -146,7 +152,9 @@ func buildCatalog(ctx context.Context, cCtx base.CompletionContext, statement st
 
 	// Restore the current database to the default so unqualified references
 	// resolve against it.
-	_, _ = cat.Exec("USE "+backtickIdentifier(cCtx.DefaultDatabase)+";", &catalog.ExecOptions{ContinueOnError: true})
+	if cCtx.DefaultDatabase != "" {
+		_, _ = cat.Exec("USE "+backtickIdentifier(cCtx.DefaultDatabase)+";", &catalog.ExecOptions{ContinueOnError: true})
+	}
 	return cat
 }
 

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -76,10 +76,12 @@ func Completion(ctx context.Context, cCtx base.CompletionContext, statement stri
 		}
 	}
 
-	// In the read-only query scene, drop keywords that initiate writes
-	// (DML/DDL/transaction/admin statements) so the editor only suggests
-	// read statements.
-	if cCtx.Scene == base.SceneTypeQuery {
+	// In the read-only query scene, drop keywords that *initiate* writes
+	// (DML/DDL/transaction/admin statements) so the editor doesn't offer to start
+	// a write statement. This only applies at a statement-start position: the same
+	// keywords are valid sub-keywords inside read statements (e.g. CREATE in SHOW
+	// CREATE TABLE, UPDATE in SELECT ... FOR UPDATE) and must be preserved there.
+	if cCtx.Scene == base.SceneTypeQuery && caretAtStatementStart(stmt, pos) {
 		for key, c := range candidateMap {
 			if c.Type == base.CandidateTypeKeyword && writeStatementKeywords[strings.ToUpper(c.Text)] {
 				delete(candidateMap, key)
@@ -393,6 +395,18 @@ func isReservedKeyword(name string) bool {
 // caretInsideBacktickIdentifier reports whether the caret sits inside an open
 // backtick-quoted identifier (an odd number of backticks precede it), in which
 // case completed identifiers must not add their own quotes.
+// caretAtStatementStart reports whether the caret is at a statement-start
+// position — only whitespace and comments precede it, or it directly follows a
+// ';'. Write keywords are filtered only here (in the query scene) so keywords
+// valid inside read statements are preserved in other positions.
+func caretAtStatementStart(statement string, pos int) bool {
+	if pos > len(statement) {
+		pos = len(statement)
+	}
+	before := strings.TrimRight(stripStringsAndComments(statement)[:pos], " \t\r\n")
+	return before == "" || before[len(before)-1] == ';'
+}
+
 func caretInsideBacktickIdentifier(statement string, pos int) bool {
 	if pos > len(statement) {
 		pos = len(statement)

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -284,19 +284,27 @@ func defineView(cat *catalog.Catalog, name, definition string) {
 	}
 }
 
-// execOK runs DDL against the catalog and reports whether every statement
-// applied without error.
+// execOK runs DDL against the catalog and reports whether it actually installed
+// a schema object: every statement parsed without error AND at least one was a
+// non-DML (utility) statement that mutated the catalog. A definition that
+// reduces to only skipped DML — e.g. a bare SELECT view body, which TiDB sync
+// stores in information_schema.VIEWS.VIEW_DEFINITION — is NOT a success, so the
+// caller falls through to the wrapped CREATE VIEW form.
 func execOK(cat *catalog.Catalog, ddl string) bool {
 	results, err := cat.Exec(ddl, &catalog.ExecOptions{ContinueOnError: true})
 	if err != nil {
 		return false
 	}
+	applied := false
 	for _, r := range results {
 		if r.Error != nil {
 			return false
 		}
+		if !r.Skipped {
+			applied = true
+		}
 	}
-	return true
+	return applied
 }
 
 // backtickIdentifier quotes an identifier for TiDB DDL, escaping embedded

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -213,7 +213,10 @@ func statementReferencesDatabase(statement, dbName string) bool {
 	}
 	s := strings.ToLower(stripStringsAndComments(statement))
 	name := strings.ToLower(dbName)
-	for _, q := range []string{name + ".", "`" + name + "`."} {
+	// Match the database name (bare or backtick-quoted) at an identifier
+	// boundary, followed by optional whitespace and a dot. TiDB allows whitespace
+	// around the qualifier dot (e.g. `db . table`).
+	for _, q := range []string{name, "`" + name + "`"} {
 		from := 0
 		for {
 			i := strings.Index(s[from:], q)
@@ -221,10 +224,19 @@ func statementReferencesDatabase(statement, dbName string) bool {
 				break
 			}
 			at := from + i
-			if at == 0 || !isIdentByte(s[at-1]) {
+			from = at + 1
+			// The bare form must start at an identifier boundary so `mydb`
+			// doesn't match inside `notmydb`.
+			if q[0] != '`' && at > 0 && isIdentByte(s[at-1]) {
+				continue
+			}
+			j := at + len(q)
+			for j < len(s) && isSpaceByte(s[j]) {
+				j++
+			}
+			if j < len(s) && s[j] == '.' {
 				return true
 			}
-			from = at + 1
 		}
 	}
 	return false

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -198,7 +198,7 @@ func statementReferencesDatabase(statement, dbName string) bool {
 	if dbName == "" {
 		return false
 	}
-	s := strings.ToLower(statement)
+	s := strings.ToLower(stripStringsAndComments(statement))
 	name := strings.ToLower(dbName)
 	for _, q := range []string{name + ".", "`" + name + "`."} {
 		from := 0
@@ -364,13 +364,106 @@ func caretInsideBacktickIdentifier(statement string, pos int) bool {
 	if pos > len(statement) {
 		pos = len(statement)
 	}
+	masked := stripStringsAndComments(statement)
 	count := 0
 	for i := 0; i < pos; i++ {
-		if statement[i] == '`' {
+		if masked[i] == '`' {
 			count++
 		}
 	}
 	return count%2 == 1
+}
+
+// stripStringsAndComments returns statement with the contents of string literals
+// ('...', "..."), line comments (-- , #), and block comments (/* */) replaced by
+// spaces, preserving byte length (newlines kept) so caret offsets stay valid.
+// Backtick-quoted identifiers are left intact. This lets the lexical heuristics
+// above ignore backticks and database names that appear inside literals or
+// comments rather than as real SQL tokens.
+func stripStringsAndComments(statement string) string {
+	out := []byte(statement)
+	n := len(out)
+	blank := func(i int) {
+		if out[i] != '\n' {
+			out[i] = ' '
+		}
+	}
+	i := 0
+	for i < n {
+		switch c := out[i]; {
+		case c == '\'' || c == '"':
+			q := c
+			blank(i)
+			i++
+			for i < n {
+				if out[i] == '\\' && i+1 < n { // backslash escape
+					blank(i)
+					blank(i + 1)
+					i += 2
+					continue
+				}
+				if out[i] == q {
+					if i+1 < n && out[i+1] == q { // doubled-quote escape
+						blank(i)
+						blank(i + 1)
+						i += 2
+						continue
+					}
+					blank(i)
+					i++
+					break
+				}
+				blank(i)
+				i++
+			}
+		case c == '#':
+			for i < n && out[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+		case c == '-' && i+1 < n && out[i+1] == '-' && (i+2 >= n || isSpaceByte(out[i+2])):
+			for i < n && out[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+		case c == '/' && i+1 < n && out[i+1] == '*':
+			blank(i)
+			blank(i + 1)
+			i += 2
+			for i < n {
+				if out[i] == '*' && i+1 < n && out[i+1] == '/' {
+					blank(i)
+					blank(i + 1)
+					i += 2
+					break
+				}
+				blank(i)
+				i++
+			}
+		case c == '`':
+			// Leave backtick-quoted identifiers intact; skip to the closing
+			// backtick so quote characters inside them are not misread.
+			i++
+			for i < n {
+				if out[i] == '`' {
+					if i+1 < n && out[i+1] == '`' { // doubled backtick
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+		default:
+			i++
+		}
+	}
+	return string(out)
+}
+
+func isSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
 // lineOffsetToBytePos converts a 1-based line number and 0-based character

--- a/backend/plugin/parser/tidb/completion.go
+++ b/backend/plugin/parser/tidb/completion.go
@@ -1,0 +1,264 @@
+package tidb
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bytebase/omni/tidb/catalog"
+	omnicompletion "github.com/bytebase/omni/tidb/completion"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// genericColumnType is a syntactically valid fallback type used when a column's
+// real type is empty or fails to parse, so the column name still surfaces as a
+// completion candidate.
+const genericColumnType = "int"
+
+// writeStatementKeywords are statement-initiating keywords for write, DDL,
+// transaction-control, and admin statements. They are dropped from completion
+// in the read-only query scene, leaving only read statements (SELECT, WITH,
+// EXPLAIN, DESC/DESCRIBE, SHOW, HELP, TABLE, VALUES) and clause keywords.
+var writeStatementKeywords = map[string]bool{
+	// DML.
+	"INSERT": true, "UPDATE": true, "DELETE": true, "REPLACE": true,
+	"LOAD": true, "BATCH": true,
+	// DDL.
+	"CREATE": true, "ALTER": true, "DROP": true, "TRUNCATE": true, "RENAME": true,
+	// Privileges / session.
+	"GRANT": true, "REVOKE": true, "SET": true, "USE": true,
+	// Transaction control.
+	"BEGIN": true, "START": true, "COMMIT": true, "ROLLBACK": true,
+	"SAVEPOINT": true, "RELEASE": true, "XA": true,
+	// Admin / maintenance.
+	"ANALYZE": true, "OPTIMIZE": true, "FLUSH": true, "REPAIR": true,
+	"CHECK": true, "RESET": true, "KILL": true, "LOCK": true, "UNLOCK": true,
+	// Prepared statements / routines.
+	"PREPARE": true, "EXECUTE": true, "DEALLOCATE": true, "CALL": true, "DO": true,
+}
+
+func init() {
+	base.RegisterCompleteFunc(storepb.Engine_TIDB, Completion)
+}
+
+// Completion provides auto-complete candidates for TiDB statements using the
+// omni TiDB completion engine, replacing the previous mysql ANTLR completer.
+func Completion(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) ([]base.Candidate, error) {
+	cat := buildCatalog(ctx, cCtx)
+	pos := lineOffsetToBytePos(statement, caretLine, caretOffset)
+
+	candidateMap := make(map[string]base.Candidate)
+	for _, c := range omnicompletion.Complete(statement, pos, cat) {
+		t := omniCandidateTypeToBase(c.Type)
+		candidateMap[string(t)+":"+c.Text] = base.Candidate{
+			Type:       t,
+			Text:       c.Text,
+			Definition: c.Definition,
+			Comment:    c.Comment,
+		}
+	}
+
+	// In the read-only query scene, drop keywords that initiate writes
+	// (DML/DDL/transaction/admin statements) so the editor only suggests
+	// read statements.
+	if cCtx.Scene == base.SceneTypeQuery {
+		for key, c := range candidateMap {
+			if c.Type == base.CandidateTypeKeyword && writeStatementKeywords[strings.ToUpper(c.Text)] {
+				delete(candidateMap, key)
+			}
+		}
+	}
+
+	result := make([]base.Candidate, 0, len(candidateMap))
+	for _, c := range candidateMap {
+		result = append(result, c)
+	}
+	slices.SortFunc(result, func(a, b base.Candidate) int {
+		if a.Type != b.Type {
+			if a.Type < b.Type {
+				return -1
+			}
+			return 1
+		}
+		if a.Text < b.Text {
+			return -1
+		}
+		if a.Text > b.Text {
+			return 1
+		}
+		return 0
+	})
+	return result, nil
+}
+
+// buildCatalog constructs an omni TiDB catalog from Bytebase metadata by
+// replaying minimal DDL. Every identifier is backticked so reserved words and
+// special characters parse correctly; tables are created one at a time so a
+// single unparseable column type cannot empty the whole catalog.
+func buildCatalog(ctx context.Context, cCtx base.CompletionContext) *catalog.Catalog {
+	cat := catalog.New()
+	if cCtx.Metadata == nil || cCtx.DefaultDatabase == "" {
+		return cat
+	}
+	_, dbMeta, err := cCtx.Metadata(ctx, cCtx.InstanceID, cCtx.DefaultDatabase)
+	if err != nil || dbMeta == nil {
+		return cat
+	}
+
+	db := backtickIdentifier(cCtx.DefaultDatabase)
+	if _, err := cat.Exec(fmt.Sprintf("CREATE DATABASE %s; USE %s;", db, db), &catalog.ExecOptions{ContinueOnError: true}); err != nil {
+		return cat
+	}
+
+	schema := dbMeta.GetSchemaMetadata("")
+	if schema == nil {
+		return cat
+	}
+	for _, tableName := range schema.ListTableNames() {
+		table := schema.GetTable(tableName)
+		if table == nil {
+			continue
+		}
+		defineTable(cat, tableName, table.GetProto().GetColumns())
+	}
+	for _, viewName := range schema.ListViewNames() {
+		view := schema.GetView(viewName)
+		if view == nil {
+			continue
+		}
+		defineView(cat, viewName, view.GetDefinition())
+	}
+	return cat
+}
+
+// defineTable installs a table in the catalog, retrying with generic column
+// types if the real types fail to parse so that column names still surface.
+func defineTable(cat *catalog.Catalog, name string, columns []*storepb.ColumnMetadata) {
+	if len(columns) == 0 {
+		return
+	}
+	if execTableDDL(cat, name, columns, false) {
+		return
+	}
+	execTableDDL(cat, name, columns, true)
+}
+
+func execTableDDL(cat *catalog.Catalog, name string, columns []*storepb.ColumnMetadata, generic bool) bool {
+	defs := make([]string, 0, len(columns))
+	for _, col := range columns {
+		colType := col.GetType()
+		if generic || colType == "" {
+			colType = genericColumnType
+		}
+		defs = append(defs, backtickIdentifier(col.GetName())+" "+colType)
+	}
+	ddl := fmt.Sprintf("CREATE TABLE %s (%s);", backtickIdentifier(name), strings.Join(defs, ", "))
+	return execOK(cat, ddl)
+}
+
+// defineView installs a view in the catalog. Unlike tables, the only structured
+// input is the view's definition SQL, whose exact shape varies (full
+// "CREATE VIEW ..." vs. a bare SELECT). We try the definition as-is, then
+// wrapped in CREATE VIEW, and finally fall back to a trivial view so the view
+// name still surfaces as a candidate (matching mysql, which reads view names
+// straight from metadata) even when the definition cannot be parsed.
+func defineView(cat *catalog.Catalog, name, definition string) {
+	var attempts []string
+	if definition != "" {
+		attempts = append(attempts,
+			definition,
+			fmt.Sprintf("CREATE VIEW %s AS %s", backtickIdentifier(name), definition),
+		)
+	}
+	attempts = append(attempts, fmt.Sprintf("CREATE VIEW %s AS SELECT 1", backtickIdentifier(name)))
+	for _, ddl := range attempts {
+		if execOK(cat, ddl) {
+			return
+		}
+	}
+}
+
+// execOK runs DDL against the catalog and reports whether every statement
+// applied without error.
+func execOK(cat *catalog.Catalog, ddl string) bool {
+	results, err := cat.Exec(ddl, &catalog.ExecOptions{ContinueOnError: true})
+	if err != nil {
+		return false
+	}
+	for _, r := range results {
+		if r.Error != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// backtickIdentifier quotes an identifier for TiDB DDL, escaping embedded
+// backticks by doubling them.
+func backtickIdentifier(name string) string {
+	return "`" + strings.ReplaceAll(name, "`", "``") + "`"
+}
+
+// lineOffsetToBytePos converts a 1-based line number and 0-based character
+// (rune) offset to a 0-based byte position in the string.
+func lineOffsetToBytePos(s string, line, offset int) int {
+	pos := 0
+	currentLine := 1
+	for pos < len(s) && currentLine < line {
+		if s[pos] == '\n' {
+			currentLine++
+		}
+		pos++
+	}
+	for i := 0; i < offset && pos < len(s); i++ {
+		_, size := utf8.DecodeRuneInString(s[pos:])
+		pos += size
+	}
+	if pos > len(s) {
+		return len(s)
+	}
+	return pos
+}
+
+// omniCandidateTypeToBase maps omni TiDB completion candidate types to the
+// Bytebase base types. The six core types (keyword/database/table/view/column/
+// function) map to the same base types the mysql completer emits so candidate
+// sets are directly comparable.
+func omniCandidateTypeToBase(t omnicompletion.CandidateType) base.CandidateType {
+	switch t {
+	case omnicompletion.CandidateKeyword:
+		return base.CandidateTypeKeyword
+	case omnicompletion.CandidateDatabase:
+		return base.CandidateTypeDatabase
+	case omnicompletion.CandidateTable:
+		return base.CandidateTypeTable
+	case omnicompletion.CandidateView:
+		return base.CandidateTypeView
+	case omnicompletion.CandidateColumn:
+		return base.CandidateTypeColumn
+	case omnicompletion.CandidateFunction:
+		return base.CandidateTypeFunction
+	case omnicompletion.CandidateProcedure:
+		return base.CandidateTypeRoutine
+	case omnicompletion.CandidateIndex:
+		return base.CandidateTypeIndex
+	case omnicompletion.CandidateTrigger:
+		return base.CandidateTypeTrigger
+	case omnicompletion.CandidateEvent:
+		return base.CandidateTypeEvent
+	case omnicompletion.CandidateCharset:
+		return base.CandidateTypeCharset
+	case omnicompletion.CandidateEngine:
+		return base.CandidateTypeEngine
+	case omnicompletion.CandidateVariable:
+		return base.CandidateTypeSystemVar
+	case omnicompletion.CandidateType_:
+		return base.CandidateTypeKeyword
+	default:
+		return base.CandidateTypeNone
+	}
+}

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -331,6 +331,26 @@ func TestCompletion_LimitsToStatementAtCaret(t *testing.T) {
 	require.False(t, hasCandidate(got, base.CandidateTypeColumn, "a2"), "t1.a2 must not leak into the 2nd statement; got %v", got)
 }
 
+// Function candidates carry a "()" suffix, matching the mysql completer, so the
+// completion text inserts a call site.
+func TestCompletion_FunctionCandidatesGetParens(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{Name: "", Tables: []*storepb.TableMetadata{
+			{Name: "t1", Columns: []*storepb.ColumnMetadata{{Name: "id"}}},
+		}}},
+	})
+	cCtx := base.CompletionContext{Scene: base.SceneTypeAll, DefaultDatabase: "db", Metadata: meta}
+
+	stmt := "SELECT  FROM t1"
+	got, err := Completion(context.Background(), cCtx, stmt, 1, len("SELECT "))
+	require.NoError(t, err)
+	require.True(t, hasCandidate(got, base.CandidateTypeFunction, "COUNT()"),
+		"function candidates should carry () like the mysql completer; got %v", got)
+	require.False(t, hasCandidate(got, base.CandidateTypeFunction, "COUNT"),
+		"bare function name without () should not appear; got %v", got)
+}
+
 func TestQuoteIdentifierIfNeeded(t *testing.T) {
 	cases := []struct {
 		name            string

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -234,7 +234,7 @@ func TestCompletion_NoCoreCandidateLossVsMySQL(t *testing.T) {
 					{Name: "t2", Columns: []*storepb.ColumnMetadata{{Name: "c1"}, {Name: "c2"}}},
 				},
 				Views: []*storepb.ViewMetadata{
-					{Name: "v1", Definition: "CREATE VIEW v1 AS SELECT c1 FROM t1"},
+					{Name: "v1", Definition: "SELECT c1 FROM t1"}, // bare SELECT, as TiDB sync stores it
 				},
 			},
 		},
@@ -329,6 +329,28 @@ func TestCompletion_LimitsToStatementAtCaret(t *testing.T) {
 	// t1's columns must NOT leak from the earlier statement.
 	require.False(t, hasCandidate(got, base.CandidateTypeColumn, "a1"), "t1.a1 must not leak into the 2nd statement; got %v", got)
 	require.False(t, hasCandidate(got, base.CandidateTypeColumn, "a2"), "t1.a2 must not leak into the 2nd statement; got %v", got)
+}
+
+// TiDB sync stores information_schema.VIEWS.VIEW_DEFINITION as a bare SELECT
+// body (not a CREATE VIEW statement). A bare SELECT is skipped by catalog.Exec,
+// so the view must still be installed (and surface as a candidate) via the
+// wrapped CREATE VIEW form rather than being treated as already created.
+func TestCompletion_ViewWithBareSelectDefinitionSurfaces(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name:   "",
+			Tables: []*storepb.TableMetadata{{Name: "t1", Columns: []*storepb.ColumnMetadata{{Name: "id"}}}},
+			Views:  []*storepb.ViewMetadata{{Name: "v1", Definition: "SELECT id FROM t1"}},
+		}},
+	})
+	cCtx := base.CompletionContext{Scene: base.SceneTypeAll, DefaultDatabase: "db", Metadata: meta}
+
+	stmt := "SELECT * FROM "
+	got, err := Completion(context.Background(), cCtx, stmt, 1, len(stmt))
+	require.NoError(t, err)
+	require.True(t, hasCandidate(got, base.CandidateTypeView, "v1"),
+		"view with a bare SELECT definition should surface as a VIEW candidate; got %v", got)
 }
 
 // Function candidates carry a "()" suffix, matching the mysql completer, so the

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -403,6 +403,31 @@ func TestCompletion_QualifiedColumnScopedInJoin(t *testing.T) {
 	}
 }
 
+// An unknown column qualifier narrows to no columns rather than broadening to
+// all in-scope columns (relies on the omni resolver fix pulled in via the bump).
+func TestCompletion_UnknownQualifierOffersNoColumns(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{Name: "", Tables: []*storepb.TableMetadata{
+			{Name: "t1", Columns: []*storepb.ColumnMetadata{{Name: "a1"}, {Name: "a2"}}},
+			{Name: "t2", Columns: []*storepb.ColumnMetadata{{Name: "b1"}, {Name: "b2"}}},
+		}}},
+	})
+	cCtx := base.CompletionContext{Scene: base.SceneTypeAll, DefaultDatabase: "db", Metadata: meta}
+
+	for _, tc := range []struct{ stmt, at string }{
+		{"SELECT x. FROM t1 AS a JOIN t2 AS b", "SELECT x."}, // unknown alias
+		{"SELECT t3. FROM t1 JOIN t2", "SELECT t3."},         // unknown table
+	} {
+		got, err := Completion(context.Background(), cCtx, tc.stmt, 1, len(tc.at))
+		require.NoError(t, err)
+		require.False(t, hasCandidate(got, base.CandidateTypeColumn, "a1"),
+			"%q must not offer columns; got %v", tc.stmt, got)
+		require.False(t, hasCandidate(got, base.CandidateTypeColumn, "b1"),
+			"%q must not offer columns; got %v", tc.stmt, got)
+	}
+}
+
 // Function candidates carry a "()" suffix, matching the mysql completer, so the
 // completion text inserts a call site.
 func TestCompletion_FunctionCandidatesGetParens(t *testing.T) {

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -280,6 +280,32 @@ func TestCompletion_NoCoreCandidateLossVsMySQL(t *testing.T) {
 	}
 }
 
+// When the LSP is connected to an instance without a selected database
+// (DefaultDatabase empty but ListDatabaseNames available), database-name
+// candidates must still surface so the user can pick a database.
+func TestCompletion_InstanceLevelDatabaseCandidates(t *testing.T) {
+	meta := func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
+		return databaseName, model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+			Name:    databaseName,
+			Schemas: []*storepb.SchemaMetadata{{Name: ""}},
+		}, nil, nil, storepb.Engine_TIDB, true), nil
+	}
+	cCtx := base.CompletionContext{
+		Scene:             base.SceneTypeAll,
+		DefaultDatabase:   "", // instance connected without a selected database
+		Metadata:          meta,
+		ListDatabaseNames: func(_ context.Context, _ string) ([]string, error) { return []string{"appdb", "otherdb"}, nil },
+	}
+
+	stmt := "SELECT * FROM "
+	got, err := Completion(context.Background(), cCtx, stmt, 1, len(stmt))
+	require.NoError(t, err)
+	require.True(t, hasCandidate(got, base.CandidateTypeDatabase, "appdb"),
+		"instance-level db candidate 'appdb' should surface without a default database; got %v", got)
+	require.True(t, hasCandidate(got, base.CandidateTypeDatabase, "otherdb"),
+		"instance-level db candidate 'otherdb' should surface without a default database; got %v", got)
+}
+
 // Completion must be limited to the statement containing the caret: table refs
 // from earlier statements in the buffer must not leak into the candidate set.
 func TestCompletion_LimitsToStatementAtCaret(t *testing.T) {

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -334,16 +334,58 @@ func TestCaretInsideBacktickIdentifier(t *testing.T) {
 		pos       int
 		want      bool
 	}{
-		{"SELECT * FROM ", 14, false},  // no backticks
-		{"SELECT * FROM `o", 16, true}, // one open backtick before caret
-		{"SELECT `a`, ", 12, false},    // closed pair before caret
-		{"`", 1, true},                 // single backtick
-		{"ab", 99, false},              // pos clamped past end, no backticks
+		{"SELECT * FROM ", 14, false},         // no backticks
+		{"SELECT * FROM `o", 16, true},        // one open backtick before caret
+		{"SELECT `a`, ", 12, false},           // closed pair before caret
+		{"`", 1, true},                        // single backtick
+		{"ab", 99, false},                     // pos clamped past end, no backticks
+		{"SELECT '`' FROM ", 16, false},       // backtick inside a string literal is ignored
+		{"SELECT /* `x` */ FROM ", 22, false}, // backticks inside a block comment ignored
+		{"SELECT 1 -- `\nFROM ", 19, false},   // backtick inside a line comment ignored
 	}
 	for _, tc := range cases {
 		require.Equal(t, tc.want, caretInsideBacktickIdentifier(tc.statement, tc.pos),
 			"caretInsideBacktickIdentifier(%q, %d)", tc.statement, tc.pos)
 	}
+}
+
+func TestStatementReferencesDatabase(t *testing.T) {
+	cases := []struct {
+		statement string
+		db        string
+		want      bool
+	}{
+		{"SELECT * FROM otherdb.t", "otherdb", true},         // plain qualifier
+		{"SELECT * FROM `otherdb`.t", "otherdb", true},       // backtick-quoted qualifier
+		{"SELECT OTHERDB.t FROM x", "otherdb", true},         // case-insensitive
+		{"SELECT 'otherdb.' FROM t", "otherdb", false},       // inside a string literal
+		{"SELECT /* otherdb. */ * FROM t", "otherdb", false}, // inside a block comment
+		{"SELECT 1 -- otherdb.\n FROM t", "otherdb", false},  // inside a line comment
+		{"SELECT nototherdb.t FROM x", "otherdb", false},     // not at an identifier boundary
+		{"SELECT a FROM t", "otherdb", false},                // not referenced
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, statementReferencesDatabase(tc.statement, tc.db),
+			"statementReferencesDatabase(%q, %q)", tc.statement, tc.db)
+	}
+}
+
+// A backtick inside a preceding string literal must not be treated as an open
+// identifier quote: the reserved table name must still be quoted on the way out.
+func TestCompletion_QuotesReservedNameAfterStringLiteralWithBacktick(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{Name: "", Tables: []*storepb.TableMetadata{
+			{Name: "order", Columns: []*storepb.ColumnMetadata{{Name: "id"}}},
+		}}},
+	})
+	cCtx := base.CompletionContext{Scene: base.SceneTypeAll, DefaultDatabase: "db", Metadata: meta}
+
+	stmt := "SELECT '`' FROM "
+	got, err := Completion(context.Background(), cCtx, stmt, 1, len(stmt))
+	require.NoError(t, err)
+	require.True(t, hasCandidate(got, base.CandidateTypeTable, "`order`"),
+		"reserved table must stay quoted despite a backtick in a string literal; got %v", got)
 }
 
 // Cross-database qualified completion: when a statement references a non-default

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -209,6 +209,35 @@ func TestCompletion_QuerySceneKeepsReadSubkeywords(t *testing.T) {
 	}
 }
 
+// The query-scene write-keyword filter must also fire when the user has typed a
+// prefix at a statement-start position (the common autocomplete path), while
+// still preserving read sub-keywords typed mid-statement.
+func TestCompletion_QuerySceneFiltersWriteKeywordPrefix(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name:    "db",
+		Schemas: []*storepb.SchemaMetadata{{Name: ""}},
+	})
+	q := base.CompletionContext{Scene: base.SceneTypeQuery, DefaultDatabase: "db", Metadata: meta}
+
+	// Write-keyword prefix at the very start is filtered.
+	got, err := Completion(context.Background(), q, "CRE", 1, len("CRE"))
+	require.NoError(t, err)
+	require.False(t, hasKeyword(got, "CREATE"),
+		"CREATE must be filtered for a prefix at statement start; got %v", got)
+
+	// Write-keyword prefix right after a ';' is filtered.
+	got, err = Completion(context.Background(), q, "SELECT 1; INS", 1, len("SELECT 1; INS"))
+	require.NoError(t, err)
+	require.False(t, hasKeyword(got, "INSERT"),
+		"INSERT must be filtered for a prefix after ';'; got %v", got)
+
+	// A read sub-keyword typed with a prefix mid-statement is preserved.
+	got, err = Completion(context.Background(), q, "SHOW CRE", 1, len("SHOW CRE"))
+	require.NoError(t, err)
+	require.True(t, hasKeyword(got, "CREATE"),
+		"CREATE must be kept after SHOW even with a prefix; got %v", got)
+}
+
 // BATCH is TiDB-only grammar (added to omni in #157); the mysql ANTLR grammar
 // cannot produce it. Its presence for Engine_TIDB and absence for Engine_MYSQL
 // proves Engine_TIDB now routes through the omni shim, not the mysql completer.

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -374,6 +374,35 @@ func TestCompletion_ViewWithBareSelectDefinitionSurfaces(t *testing.T) {
 		"view with a bare SELECT definition should surface as a VIEW candidate; got %v", got)
 }
 
+// Regression for BYT-9599 gap #5: in a multi-table query, a qualified column
+// reference must be scoped to the qualifier's table (relies on the omni resolver
+// honoring the qualifier — pulled in via the go.mod bump).
+func TestCompletion_QualifiedColumnScopedInJoin(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{Name: "", Tables: []*storepb.TableMetadata{
+			{Name: "t1", Columns: []*storepb.ColumnMetadata{{Name: "a1"}, {Name: "a2"}}},
+			{Name: "t2", Columns: []*storepb.ColumnMetadata{{Name: "b1"}, {Name: "b2"}}},
+		}}},
+	})
+	cCtx := base.CompletionContext{Scene: base.SceneTypeAll, DefaultDatabase: "db", Metadata: meta}
+
+	for _, tc := range []struct {
+		stmt, at, want, notWant string
+	}{
+		{"SELECT a. FROM t1 AS a JOIN t2 AS b", "SELECT a.", "a1", "b1"}, // alias for t1
+		{"SELECT b. FROM t1 AS a JOIN t2 AS b", "SELECT b.", "b1", "a1"}, // alias for t2
+		{"SELECT t1. FROM t1 JOIN t2", "SELECT t1.", "a1", "b1"},         // by table name
+	} {
+		got, err := Completion(context.Background(), cCtx, tc.stmt, 1, len(tc.at))
+		require.NoError(t, err)
+		require.True(t, hasCandidate(got, base.CandidateTypeColumn, tc.want),
+			"%q should offer column %s; got %v", tc.stmt, tc.want, got)
+		require.False(t, hasCandidate(got, base.CandidateTypeColumn, tc.notWant),
+			"%q must not offer the other table's column %s; got %v", tc.stmt, tc.notWant, got)
+	}
+}
+
 // Function candidates carry a "()" suffix, matching the mysql completer, so the
 // completion text inserts a call site.
 func TestCompletion_FunctionCandidatesGetParens(t *testing.T) {

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -280,6 +280,31 @@ func TestCompletion_NoCoreCandidateLossVsMySQL(t *testing.T) {
 	}
 }
 
+// Completion must be limited to the statement containing the caret: table refs
+// from earlier statements in the buffer must not leak into the candidate set.
+func TestCompletion_LimitsToStatementAtCaret(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{Name: "", Tables: []*storepb.TableMetadata{
+			{Name: "t1", Columns: []*storepb.ColumnMetadata{{Name: "a1"}, {Name: "a2"}}},
+			{Name: "t2", Columns: []*storepb.ColumnMetadata{{Name: "b1"}, {Name: "b2"}}},
+		}}},
+	})
+	cCtx := base.CompletionContext{Scene: base.SceneTypeAll, DefaultDatabase: "db", Metadata: meta}
+
+	stmt := "SELECT * FROM t1; SELECT  FROM t2"
+	caret := len("SELECT * FROM t1; SELECT ") // projection of the 2nd statement
+	got, err := Completion(context.Background(), cCtx, stmt, 1, caret)
+	require.NoError(t, err)
+
+	// t2's columns are in scope for the 2nd statement.
+	require.True(t, hasCandidate(got, base.CandidateTypeColumn, "b1"), "t2.b1 should be in scope; got %v", got)
+	require.True(t, hasCandidate(got, base.CandidateTypeColumn, "b2"), "t2.b2 should be in scope; got %v", got)
+	// t1's columns must NOT leak from the earlier statement.
+	require.False(t, hasCandidate(got, base.CandidateTypeColumn, "a1"), "t1.a1 must not leak into the 2nd statement; got %v", got)
+	require.False(t, hasCandidate(got, base.CandidateTypeColumn, "a2"), "t1.a2 must not leak into the 2nd statement; got %v", got)
+}
+
 func TestQuoteIdentifierIfNeeded(t *testing.T) {
 	cases := []struct {
 		name            string

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -82,10 +82,11 @@ func candidateSet(cands []base.Candidate, types ...base.CandidateType) map[strin
 	return m
 }
 
-// Reserved-word identifiers (table "order", columns "select"/"key") must still
-// surface as completion candidates. This proves the synthesized catalog DDL
-// backticks every identifier — without it, the DDL fails to parse and the
-// objects silently vanish from the catalog.
+// Reserved-word identifiers (table "order", columns "select"/"key") must surface
+// as completion candidates AND their completion text must be backtick-quoted so
+// accepting a suggestion inserts valid SQL. Surfacing proves the synthesized
+// catalog DDL backticks identifiers; the quoted candidate text proves the shim
+// quotes reserved object names on the way out.
 func TestCompletion_ReservedWordIdentifiersSurface(t *testing.T) {
 	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
 		Name: "testdb",
@@ -113,16 +114,16 @@ func TestCompletion_ReservedWordIdentifiersSurface(t *testing.T) {
 	stmt := "SELECT * FROM "
 	got, err := Completion(context.Background(), cCtx, stmt, 1, len(stmt))
 	require.NoError(t, err)
-	require.True(t, hasCandidate(got, base.CandidateTypeTable, "order"),
-		"reserved-word table 'order' should surface as a TABLE candidate; got %v", got)
+	require.True(t, hasCandidate(got, base.CandidateTypeTable, "`order`"),
+		"reserved-word table 'order' should surface quoted as a TABLE candidate; got %v", got)
 
 	stmt2 := "SELECT  FROM `order`"
 	got2, err := Completion(context.Background(), cCtx, stmt2, 1, len("SELECT "))
 	require.NoError(t, err)
-	require.True(t, hasCandidate(got2, base.CandidateTypeColumn, "select"),
-		"reserved-word column 'select' should surface as a COLUMN candidate; got %v", got2)
-	require.True(t, hasCandidate(got2, base.CandidateTypeColumn, "key"),
-		"reserved-word column 'key' should surface as a COLUMN candidate; got %v", got2)
+	require.True(t, hasCandidate(got2, base.CandidateTypeColumn, "`select`"),
+		"reserved-word column 'select' should surface quoted as a COLUMN candidate; got %v", got2)
+	require.True(t, hasCandidate(got2, base.CandidateTypeColumn, "`key`"),
+		"reserved-word column 'key' should surface quoted as a COLUMN candidate; got %v", got2)
 }
 
 // A column whose stored type cannot be parsed must not silently vanish:
@@ -276,6 +277,47 @@ func TestCompletion_NoCoreCandidateLossVsMySQL(t *testing.T) {
 		"SELECT | FROM t1 JOIN t2 ON t1.c1 = t2.c1",
 	} {
 		assertNoLoss(in, base.CandidateTypeColumn)
+	}
+}
+
+func TestQuoteIdentifierIfNeeded(t *testing.T) {
+	cases := []struct {
+		name            string
+		caretInBacktick bool
+		want            string
+	}{
+		{"users", false, "users"},       // bare identifier — unchanged
+		{"t1", false, "t1"},             // bare with digit suffix — unchanged
+		{"comment", false, "comment"},   // non-reserved keyword — stays bare
+		{"order", false, "`order`"},     // reserved keyword
+		{"select", false, "`select`"},   // reserved keyword
+		{"Order", false, "`Order`"},     // reserved (case-insensitive), original case preserved
+		{"foo-bar", false, "`foo-bar`"}, // non-bare character
+		{"1col", false, "`1col`"},       // leading digit
+		{"a`b", false, "`a``b`"},        // embedded backtick is doubled
+		{"order", true, "order"},        // caret already inside a backtick — no extra quotes
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, quoteIdentifierIfNeeded(tc.name, tc.caretInBacktick),
+			"quoteIdentifierIfNeeded(%q, %v)", tc.name, tc.caretInBacktick)
+	}
+}
+
+func TestCaretInsideBacktickIdentifier(t *testing.T) {
+	cases := []struct {
+		statement string
+		pos       int
+		want      bool
+	}{
+		{"SELECT * FROM ", 14, false},  // no backticks
+		{"SELECT * FROM `o", 16, true}, // one open backtick before caret
+		{"SELECT `a`, ", 12, false},    // closed pair before caret
+		{"`", 1, true},                 // single backtick
+		{"ab", 99, false},              // pos clamped past end, no backticks
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, caretInsideBacktickIdentifier(tc.statement, tc.pos),
+			"caretInsideBacktickIdentifier(%q, %d)", tc.statement, tc.pos)
 	}
 }
 

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -1,0 +1,280 @@
+package tidb
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+
+	// Register the mysql completer (Engine_MYSQL and, pre-swap, Engine_TIDB) so
+	// the no-regression test can compare the old ANTLR path against the new shim.
+	_ "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
+	"github.com/bytebase/bytebase/backend/store/model"
+)
+
+func hasCandidate(cands []base.Candidate, typ base.CandidateType, text string) bool {
+	for _, c := range cands {
+		if c.Type == typ && c.Text == text {
+			return true
+		}
+	}
+	return false
+}
+
+func hasKeyword(cands []base.Candidate, text string) bool {
+	for _, c := range cands {
+		if c.Type == base.CandidateTypeKeyword && strings.EqualFold(c.Text, text) {
+			return true
+		}
+	}
+	return false
+}
+
+func metadataFunc(meta *storepb.DatabaseSchemaMetadata) base.GetDatabaseMetadataFunc {
+	return func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
+		return databaseName, model.NewDatabaseMetadata(meta, nil, nil, storepb.Engine_TIDB, true /* isObjectCaseSensitive */), nil
+	}
+}
+
+func listDBNamesFunc(_ context.Context, _ string) ([]string, error) {
+	return []string{"db"}, nil
+}
+
+// catchCaretLineColumn returns the SQL without the "|" caret marker and the
+// 1-based line + 0-based column of the caret position.
+func catchCaretLineColumn(s string) (string, int, int) {
+	for i, c := range s {
+		if c == '|' {
+			text := s[:i] + s[i+1:]
+			line := 1
+			col := 0
+			for _, ch := range s[:i] {
+				if ch == '\n' {
+					line++
+					col = 0
+				} else {
+					col++
+				}
+			}
+			return text, line, col
+		}
+	}
+	return s, 1, -1
+}
+
+// candidateSet returns the non-empty candidates of the given types, keyed by
+// type+text.
+func candidateSet(cands []base.Candidate, types ...base.CandidateType) map[string]base.Candidate {
+	want := make(map[base.CandidateType]bool, len(types))
+	for _, t := range types {
+		want[t] = true
+	}
+	m := make(map[string]base.Candidate)
+	for _, c := range cands {
+		if want[c.Type] && c.Text != "" {
+			m[string(c.Type)+":"+c.Text] = c
+		}
+	}
+	return m
+}
+
+// Reserved-word identifiers (table "order", columns "select"/"key") must still
+// surface as completion candidates. This proves the synthesized catalog DDL
+// backticks every identifier — without it, the DDL fails to parse and the
+// objects silently vanish from the catalog.
+func TestCompletion_ReservedWordIdentifiersSurface(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name: "testdb",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "order",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "select"},
+							{Name: "key"},
+						},
+					},
+				},
+			},
+		},
+	})
+	cCtx := base.CompletionContext{
+		Scene:           base.SceneTypeAll,
+		DefaultDatabase: "testdb",
+		Metadata:        meta,
+	}
+
+	stmt := "SELECT * FROM "
+	got, err := Completion(context.Background(), cCtx, stmt, 1, len(stmt))
+	require.NoError(t, err)
+	require.True(t, hasCandidate(got, base.CandidateTypeTable, "order"),
+		"reserved-word table 'order' should surface as a TABLE candidate; got %v", got)
+
+	stmt2 := "SELECT  FROM `order`"
+	got2, err := Completion(context.Background(), cCtx, stmt2, 1, len("SELECT "))
+	require.NoError(t, err)
+	require.True(t, hasCandidate(got2, base.CandidateTypeColumn, "select"),
+		"reserved-word column 'select' should surface as a COLUMN candidate; got %v", got2)
+	require.True(t, hasCandidate(got2, base.CandidateTypeColumn, "key"),
+		"reserved-word column 'key' should surface as a COLUMN candidate; got %v", got2)
+}
+
+// A column whose stored type cannot be parsed must not silently vanish:
+// buildCatalog retries the whole table with a generic column type, so every
+// column name still surfaces. Without that retry the failing CREATE TABLE would
+// drop the entire table from the catalog.
+func TestCompletion_UnparseableColumnTypeFallsBackToGeneric(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "",
+				Tables: []*storepb.TableMetadata{
+					{Name: "t", Columns: []*storepb.ColumnMetadata{
+						{Name: "good", Type: "int"},
+						{Name: "weird", Type: ")"}, // unparseable type — forces the generic retry
+					}},
+				},
+			},
+		},
+	})
+	cCtx := base.CompletionContext{Scene: base.SceneTypeAll, DefaultDatabase: "db", Metadata: meta}
+
+	stmt := "SELECT  FROM t"
+	got, err := Completion(context.Background(), cCtx, stmt, 1, len("SELECT "))
+	require.NoError(t, err)
+	require.True(t, hasCandidate(got, base.CandidateTypeColumn, "good"),
+		"column 'good' should surface; got %v", got)
+	require.True(t, hasCandidate(got, base.CandidateTypeColumn, "weird"),
+		"column 'weird' with an unparseable type should still surface via the generic-type retry; got %v", got)
+}
+
+// In the read-only query scene, write statements (DML/DDL incl. TiDB BATCH)
+// must be filtered out, while read keywords (SELECT) stay.
+func TestCompletion_QuerySceneFiltersWriteKeywords(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name:    "testdb",
+		Schemas: []*storepb.SchemaMetadata{{Name: ""}},
+	})
+	ccx := func(scene base.SceneType) base.CompletionContext {
+		return base.CompletionContext{Scene: scene, DefaultDatabase: "testdb", Metadata: meta}
+	}
+
+	const stmt = "SELECT 1; "
+	all, err := Completion(context.Background(), ccx(base.SceneTypeAll), stmt, 1, len(stmt))
+	require.NoError(t, err)
+	query, err := Completion(context.Background(), ccx(base.SceneTypeQuery), stmt, 1, len(stmt))
+	require.NoError(t, err)
+
+	// Read keywords are kept in both scenes.
+	for _, kw := range []string{"SELECT", "WITH", "SHOW"} {
+		require.True(t, hasKeyword(all, kw), "%s in ALL; got %v", kw, all)
+		require.True(t, hasKeyword(query, kw), "%s must be kept in QUERY; got %v", kw, query)
+	}
+
+	// INSERT is a write keyword — present in ALL, dropped in QUERY.
+	require.True(t, hasKeyword(all, "INSERT"), "INSERT in ALL; got %v", all)
+	require.False(t, hasKeyword(query, "INSERT"), "INSERT must be dropped in QUERY; got %v", query)
+
+	// BATCH (TiDB non-transactional DML) — present in ALL, dropped in QUERY.
+	require.True(t, hasKeyword(all, "BATCH"), "BATCH in ALL; got %v", all)
+	require.False(t, hasKeyword(query, "BATCH"), "BATCH must be dropped in QUERY; got %v", query)
+}
+
+// BATCH is TiDB-only grammar (added to omni in #157); the mysql ANTLR grammar
+// cannot produce it. Its presence for Engine_TIDB and absence for Engine_MYSQL
+// proves Engine_TIDB now routes through the omni shim, not the mysql completer.
+func TestCompletion_TiDBRoutesThroughOmni(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name:    "db",
+		Schemas: []*storepb.SchemaMetadata{{Name: ""}},
+	})
+	cCtx := base.CompletionContext{
+		Scene:             base.SceneTypeAll,
+		DefaultDatabase:   "db",
+		Metadata:          meta,
+		ListDatabaseNames: listDBNamesFunc,
+	}
+	const stmt = "SELECT 1; "
+
+	mysqlRes, err := base.Completion(context.Background(), storepb.Engine_MYSQL, cCtx, stmt, 1, len(stmt))
+	require.NoError(t, err)
+	tidbRes, err := base.Completion(context.Background(), storepb.Engine_TIDB, cCtx, stmt, 1, len(stmt))
+	require.NoError(t, err)
+
+	require.False(t, hasKeyword(mysqlRes, "BATCH"), "mysql ANTLR must not know BATCH")
+	require.True(t, hasKeyword(tidbRes, "BATCH"), "Engine_TIDB must route through omni (BATCH present); got %v", tidbRes)
+}
+
+// The TiDB shim must not lose schema-object candidates relative to the prior
+// mysql-ANTLR path, compared in SceneTypeAll so engine candidate deltas are
+// isolated from scene filtering. The guarantee is context-appropriate:
+//   - table/view contexts (after FROM/JOIN): no TABLE or VIEW lost.
+//   - column contexts (projection, WHERE, after "alias."): no COLUMN lost.
+//
+// Classified, accepted strategy difference (NOT asserted): in column contexts
+// the mysql ANTLR completer also offers DATABASE/TABLE *qualifier* names (for
+// fully-qualified db.table.col refs) that omni omits, because omni resolves the
+// in-scope columns directly instead. Tracked as a follow-up candidate gap.
+func TestCompletion_NoCoreCandidateLossVsMySQL(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "",
+				Tables: []*storepb.TableMetadata{
+					{Name: "t1", Columns: []*storepb.ColumnMetadata{{Name: "c1"}}},
+					{Name: "t2", Columns: []*storepb.ColumnMetadata{{Name: "c1"}, {Name: "c2"}}},
+				},
+				Views: []*storepb.ViewMetadata{
+					{Name: "v1", Definition: "CREATE VIEW v1 AS SELECT c1 FROM t1"},
+				},
+			},
+		},
+	})
+	cCtx := base.CompletionContext{
+		Scene:             base.SceneTypeAll,
+		DefaultDatabase:   "db",
+		Metadata:          meta,
+		ListDatabaseNames: listDBNamesFunc,
+	}
+
+	assertNoLoss := func(in string, types ...base.CandidateType) {
+		text, line, col := catchCaretLineColumn(in)
+		mysqlRes, err := base.Completion(context.Background(), storepb.Engine_MYSQL, cCtx, text, line, col)
+		require.NoError(t, err)
+		tidbRes, err := base.Completion(context.Background(), storepb.Engine_TIDB, cCtx, text, line, col)
+		require.NoError(t, err)
+
+		tidbSet := candidateSet(tidbRes, types...)
+		for key, c := range candidateSet(mysqlRes, types...) {
+			require.Contains(t, tidbSet, key,
+				"input %q: TiDB dropped %v that MySQL produced; tidb=%v", in, c, tidbRes)
+		}
+	}
+
+	// Table/view contexts: no TABLE or VIEW candidate may be lost.
+	for _, in := range []string{
+		"SELECT * FROM |",
+		"SELECT * FROM t1 JOIN |",
+		"SELECT * FROM t1, |",
+	} {
+		assertNoLoss(in, base.CandidateTypeTable, base.CandidateTypeView)
+	}
+
+	// Column contexts: no COLUMN candidate may be lost.
+	for _, in := range []string{
+		"SELECT | FROM t1",
+		"SELECT t1.| FROM t1",
+		"SELECT * FROM t1 WHERE |",
+		"SELECT | FROM t1 JOIN t2 ON t1.c1 = t2.c1",
+	} {
+		assertNoLoss(in, base.CandidateTypeColumn)
+	}
+}

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -431,6 +431,8 @@ func TestStatementReferencesDatabase(t *testing.T) {
 		{"SELECT 1 -- otherdb.\n FROM t", "otherdb", false},  // inside a line comment
 		{"SELECT nototherdb.t FROM x", "otherdb", false},     // not at an identifier boundary
 		{"SELECT a FROM t", "otherdb", false},                // not referenced
+		{"SELECT * FROM otherdb . t2", "otherdb", true},      // whitespace around the dot (TiDB allows it)
+		{"SELECT * FROM `otherdb` . t2", "otherdb", true},    // backtick-quoted + whitespace
 	}
 	for _, tc := range cases {
 		require.Equal(t, tc.want, statementReferencesDatabase(tc.statement, tc.db),

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -188,6 +188,27 @@ func TestCompletion_QuerySceneFiltersWriteKeywords(t *testing.T) {
 	require.False(t, hasKeyword(query, "BATCH"), "BATCH must be dropped in QUERY; got %v", query)
 }
 
+// In the query scene, write keywords are only filtered at a statement-start
+// position. Context-specific keywords that are valid inside read statements must
+// survive — e.g. CREATE in SHOW CREATE TABLE, UPDATE in SELECT ... FOR UPDATE.
+func TestCompletion_QuerySceneKeepsReadSubkeywords(t *testing.T) {
+	meta := metadataFunc(&storepb.DatabaseSchemaMetadata{
+		Name:    "db",
+		Schemas: []*storepb.SchemaMetadata{{Name: ""}},
+	})
+	q := base.CompletionContext{Scene: base.SceneTypeQuery, DefaultDatabase: "db", Metadata: meta}
+
+	for _, tc := range []struct{ stmt, keep string }{
+		{"SHOW ", "CREATE"},         // SHOW CREATE TABLE ... (read-only)
+		{"SELECT 1 FOR ", "UPDATE"}, // SELECT ... FOR UPDATE (locking read)
+	} {
+		got, err := Completion(context.Background(), q, tc.stmt, 1, len(tc.stmt))
+		require.NoError(t, err)
+		require.True(t, hasKeyword(got, tc.keep),
+			"%q must be kept after %q in the query scene; got %v", tc.keep, tc.stmt, got)
+	}
+}
+
 // BATCH is TiDB-only grammar (added to omni in #157); the mysql ANTLR grammar
 // cannot produce it. Its presence for Engine_TIDB and absence for Engine_MYSQL
 // proves Engine_TIDB now routes through the omni shim, not the mysql completer.

--- a/backend/plugin/parser/tidb/completion_test.go
+++ b/backend/plugin/parser/tidb/completion_test.go
@@ -278,3 +278,53 @@ func TestCompletion_NoCoreCandidateLossVsMySQL(t *testing.T) {
 		assertNoLoss(in, base.CandidateTypeColumn)
 	}
 }
+
+// Cross-database qualified completion: when a statement references a non-default
+// database as a qualifier, buildCatalog must load that database so
+// `other_db.tbl.col` resolves, and every known database name must surface as a
+// DATABASE candidate. (The `FROM other_db.|` table-list case is a separate
+// omni-side limitation — omni ignores the table qualifier — tracked as a
+// follow-up, not asserted here.)
+func TestCompletion_QualifiedColumnAcrossDatabases(t *testing.T) {
+	appMeta := &storepb.DatabaseSchemaMetadata{
+		Name: "appdb",
+		Schemas: []*storepb.SchemaMetadata{{Name: "", Tables: []*storepb.TableMetadata{
+			{Name: "t1", Columns: []*storepb.ColumnMetadata{{Name: "c1"}}},
+		}}},
+	}
+	otherMeta := &storepb.DatabaseSchemaMetadata{
+		Name: "otherdb",
+		Schemas: []*storepb.SchemaMetadata{{Name: "", Tables: []*storepb.TableMetadata{
+			{Name: "t2", Columns: []*storepb.ColumnMetadata{{Name: "c2"}, {Name: "c3"}}},
+		}}},
+	}
+	metaFn := func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
+		m := appMeta
+		if databaseName == "otherdb" {
+			m = otherMeta
+		}
+		return databaseName, model.NewDatabaseMetadata(m, nil, nil, storepb.Engine_TIDB, true), nil
+	}
+	cCtx := base.CompletionContext{
+		Scene:             base.SceneTypeAll,
+		DefaultDatabase:   "appdb",
+		Metadata:          metaFn,
+		ListDatabaseNames: func(_ context.Context, _ string) ([]string, error) { return []string{"appdb", "otherdb"}, nil },
+	}
+
+	// Qualified column from a non-default database resolves.
+	stmt := "SELECT otherdb.t2. FROM otherdb.t2"
+	got, err := Completion(context.Background(), cCtx, stmt, 1, len("SELECT otherdb.t2."))
+	require.NoError(t, err)
+	require.True(t, hasCandidate(got, base.CandidateTypeColumn, "c2"),
+		"cross-db column 'c2' should surface; got %v", got)
+	require.True(t, hasCandidate(got, base.CandidateTypeColumn, "c3"),
+		"cross-db column 'c3' should surface; got %v", got)
+
+	// Every known database name surfaces as a DATABASE candidate.
+	stmt2 := "SELECT * FROM "
+	got2, err := Completion(context.Background(), cCtx, stmt2, 1, len(stmt2))
+	require.NoError(t, err)
+	require.True(t, hasCandidate(got2, base.CandidateTypeDatabase, "otherdb"),
+		"non-default database 'otherdb' should surface as a DATABASE candidate; got %v", got2)
+}

--- a/backend/plugin/parser/tidb/dispatcher_test.go
+++ b/backend/plugin/parser/tidb/dispatcher_test.go
@@ -20,27 +20,29 @@ import (
 //
 // Also asserts the per-fallback observability sub-contract: the
 // tidb_dispatcher_omni_fallback_total{reason} counter increments by
-// exactly 1 for the BATCH statement, with the empirically-verified
-// "batch_dml" label.
+// exactly 1 for the rejected statement, with the empirically-verified
+// "sequence" label.
 //
-// Empirical note: BATCH non-transactional DML is the canonical Option B
-// case — omni rejects (Tier 4 grammar gap; cumulative #30 dual-path
-// pattern), pingcap accepts. The plan's draft suggested
-// `FLASHBACK TABLE foo TO BEFORE DROP;` for this test, but pre-flip
-// empirical probe (invariant #9) found pingcap ALSO rejects that exact
-// syntax — it would test the both-engines-reject path, not Option B.
-// `BATCH ... DELETE` is the empirically-correct Option B input.
+// Empirical note (invariant #9): the Option B fixture must be a statement
+// omni REJECTS but pingcap ACCEPTS. BATCH non-transactional DML was the
+// original choice, but omni now SUPPORTS BATCH (grammar merged in omni
+// #157, consumed via the go.mod bump), so it no longer falls back.
+// `FLASHBACK TABLE foo TO BEFORE DROP;` can't be used either — pingcap
+// rejects that exact syntax (both-engines-reject path). `CREATE SEQUENCE`
+// is the correct Option B input: omni rejects it (Tier-4 grammar gap),
+// pingcap accepts it (TiDB sequences). If pingcap also rejected it, the
+// require.NoError below would fail.
 func TestParseTiDBStatementsOmni_OptionBFallback(t *testing.T) {
 	const (
 		omniAccepted1 = "CREATE TABLE t (id INT);"
-		omniRejected  = "BATCH ON id LIMIT 5000 DELETE FROM t WHERE 1=1;"
+		omniRejected  = "CREATE SEQUENCE seq;"
 		omniAccepted2 = "INSERT INTO t (id) VALUES (1);"
 	)
 	input := omniAccepted1 + "\n" + omniRejected + "\n" + omniAccepted2
 
 	// Snapshot the counter before so the assertion is delta-based — other
 	// tests in the package may have incremented it already.
-	before := testutil.ToFloat64(tidbDispatcherOmniFallbackTotal.WithLabelValues("batch_dml"))
+	before := testutil.ToFloat64(tidbDispatcherOmniFallbackTotal.WithLabelValues("sequence"))
 
 	result, err := parseTiDBStatementsOmni(input)
 	require.NoError(t, err,
@@ -54,9 +56,9 @@ func TestParseTiDBStatementsOmni_OptionBFallback(t *testing.T) {
 	// trailing whitespace etc.).
 	for _, ps := range result {
 		switch {
-		case strings.Contains(ps.Text, "BATCH"):
+		case strings.Contains(ps.Text, "SEQUENCE"):
 			require.IsType(t, &AST{}, ps.AST,
-				"BATCH statement must carry pingcap *AST after Option B fallback (un-migrated advisors continue to function)")
+				"omni-rejected statement must carry pingcap *AST after Option B fallback (un-migrated advisors continue to function)")
 		case strings.Contains(ps.Text, "CREATE TABLE") || strings.Contains(ps.Text, "INSERT"):
 			require.IsType(t, &OmniAST{}, ps.AST,
 				"omni-accepted statements must carry *OmniAST")
@@ -66,9 +68,9 @@ func TestParseTiDBStatementsOmni_OptionBFallback(t *testing.T) {
 	}
 
 	// Counter sub-contract.
-	after := testutil.ToFloat64(tidbDispatcherOmniFallbackTotal.WithLabelValues("batch_dml"))
+	after := testutil.ToFloat64(tidbDispatcherOmniFallbackTotal.WithLabelValues("sequence"))
 	require.InDelta(t, 1.0, after-before, 0.0001,
-		"counter must increment by exactly 1 for the single BATCH fallback")
+		"counter must increment by exactly 1 for the single SEQUENCE fallback")
 }
 
 // TestParseTiDBStatementsOmni_BothEnginesReject pins the Q2 design

--- a/backend/plugin/parser/tidb/metrics_test.go
+++ b/backend/plugin/parser/tidb/metrics_test.go
@@ -39,18 +39,12 @@ func TestClassifyOmniParseError(t *testing.T) {
 			wantOK:   false,
 			expected: "sequence",
 		},
-		{
-			name:     "BATCH keyword in error msg AND input",
-			sql:      "BATCH ON id LIMIT 100 DELETE FROM t WHERE 1=1;",
-			wantOK:   false,
-			expected: "batch_dml",
-		},
-		{
-			name:     "lowercase batch in input is matched (case-insensitive)",
-			sql:      "batch on id limit 100 delete from t where 1=1;",
-			wantOK:   false,
-			expected: "batch_dml",
-		},
+		// NOTE: BATCH non-transactional DML is now SUPPORTED by omni (grammar
+		// merged in omni #157, consumed via the go.mod bump). It therefore
+		// parses successfully and no longer reaches the fallback classifier, so
+		// the previous "omni rejects BATCH" cases were removed. The classifier's
+		// stale BATCH→batch_dml pattern in metrics.go is dead post-support and is
+		// tracked for removal as part of the BATCH-support (B1.2) cleanup.
 		{
 			name:     "genuine syntax error → unknown (no Tier-4 keyword present)",
 			sql:      "SELECT FROM WHERE;",

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260528202243-20ea3387d09a
+	github.com/bytebase/omni v0.0.0-20260529045003-6531f7be1550
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260529045003-6531f7be1550
+	github.com/bytebase/omni v0.0.0-20260529052918-83e6917d2454
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260528064644-6ef6c2c2b826
+	github.com/bytebase/omni v0.0.0-20260528202243-20ea3387d09a
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260529045003-6531f7be1550 h1:k15cQs1ONRzbcNjixUPNcXZoYa3Jh71bZ91AFlvLcvw=
-github.com/bytebase/omni v0.0.0-20260529045003-6531f7be1550/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260529052918-83e6917d2454 h1:ZYXm0m5nrQ8hKdQnPEGkV1oDU1HiXjujVmPyjdMFO2I=
+github.com/bytebase/omni v0.0.0-20260529052918-83e6917d2454/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260528202243-20ea3387d09a h1:BVEpGg4+fUjnl2BKKNCaWfS7cwYJx84oq8lCTpcXSLc=
-github.com/bytebase/omni v0.0.0-20260528202243-20ea3387d09a/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260529045003-6531f7be1550 h1:k15cQs1ONRzbcNjixUPNcXZoYa3Jh71bZ91AFlvLcvw=
+github.com/bytebase/omni v0.0.0-20260529045003-6531f7be1550/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260528064644-6ef6c2c2b826 h1:Ow343I2DTKscD+MG65qItnE60jM3dQTJovVz0UPCelM=
-github.com/bytebase/omni v0.0.0-20260528064644-6ef6c2c2b826/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260528202243-20ea3387d09a h1:BVEpGg4+fUjnl2BKKNCaWfS7cwYJx84oq8lCTpcXSLc=
+github.com/bytebase/omni v0.0.0-20260528202243-20ea3387d09a/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## What

Port TiDB SQL auto-completion off the mysql ANTLR completer onto a thin shim over `omni/tidb/completion`, removing the last ANTLR dependency for the TiDB engine.

- New `backend/plugin/parser/tidb/completion.go`: builds the omni catalog from Bytebase metadata via DDL Exec-replay (every identifier backtick-escaped; per-table isolation; generic-type retry so a column with an unparseable type still surfaces; best-effort views with a name-surfacing fallback), runs `omnicompletion.Complete`, maps candidate types to `base`, and filters write statements (DML/DDL/txn/admin, incl. TiDB `BATCH`) in the read-only query scene.
- `Engine_TIDB` completion registration moves from `mysql/completion.go` to the new shim. mysql keeps MYSQL / MARIADB / OCEANBASE / CLICKHOUSE / STARROCKS / DORIS.
- Bumps `github.com/bytebase/omni` to the BATCH-grammar commit (shared with the upcoming `dml_dry_run` migration).

## Why

Per the "omni only" direction, TiDB should not depend on the mysql ANTLR completer (part of BYT-9141). `omni/tidb/completion` is already built and genuinely TiDB-flavored (AUTO_RANDOM, CLUSTERED, TIFLASH, PLACEMENT, BATCH), so this is a shim + registration swap rather than a port.

## Behavior change

- TiDB autocomplete candidates now come from omni. In the **read-only query scene**, write-statement keywords (incl. `BATCH`) are no longer suggested — consistent with trino/redshift/plsql/partiql; the prior mysql-ANTLR path did not filter by scene.
- Classified, documented candidate differences vs the old path (not regressions): in column contexts omni does not offer DATABASE/TABLE *qualifier* names (it resolves in-scope columns directly). Tracked as a follow-up candidate gap. Schema-object no-loss — tables/views in FROM contexts, columns in column contexts — is asserted by tests.

## omni bump collateral

The bump flips `BATCH` from unsupported to supported, so two dispatcher tests that used `BATCH` as the canonical omni-rejected fixture are updated: the stale classifier cases are dropped, and the Option B fallback fixture is switched to `CREATE SEQUENCE` (omni rejects, pingcap accepts — empirically confirmed by the test). The now-dead `BATCH→batch_dml` pattern in `metrics.go` is left for the BATCH-support (dml_dry_run) cleanup.

## Testing

5 new unit tests in `completion_test.go`:
- reserved-word identifiers (`order`, `select`, `key`) surface;
- a column with an unparseable type still surfaces via the generic-type retry;
- query scene filters write keywords (incl. `BATCH`) while keeping read keywords;
- `Engine_TIDB` routes through omni (BATCH discriminator absent from mysql ANTLR);
- no core-candidate loss vs `Engine_MYSQL` across representative inputs.

`go build ./...`, `go vet`, `gofmt`, `golangci-lint` all clean; tidb + mysql parser packages pass.

Part of BYT-9141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
