### PR TITLE
refactor(frontend): migrate current user to react app store

### DIFF
--- a/frontend/src/connect/middlewares/activeInterceptorMiddleware.ts
+++ b/frontend/src/connect/middlewares/activeInterceptorMiddleware.ts
@@ -1,15 +1,15 @@
 import { type Interceptor } from "@connectrpc/connect";
-import { useCurrentUserV1 } from "@/store";
+import { getCurrentUserV1 } from "@/store";
 import { storageKeyLastActivity } from "@/utils/storage-keys";
 
 export const activeInterceptor: Interceptor = (next) => async (req) => {
   const resp = await next(req);
-  const me = useCurrentUserV1();
+  const me = getCurrentUserV1();
   // ignore the GetCurrentUser method, it's automatically called by the script.
-  if (me.value && req.method.name !== "GetCurrentUser") {
+  if (me.email && req.method.name !== "GetCurrentUser") {
     try {
       localStorage.setItem(
-        storageKeyLastActivity(me.value.email),
+        storageKeyLastActivity(me.email),
         String(Date.now())
       );
     } catch {

--- a/frontend/src/plugins/ai/react/DynamicSuggestions.tsx
+++ b/frontend/src/plugins/ai/react/DynamicSuggestions.tsx
@@ -2,8 +2,8 @@ import { Loader2, RefreshCwIcon, XIcon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
-import { useCurrentUserV1 } from "@/store";
 import { storageKeySqlEditorAiSuggestion } from "@/utils";
 import { useDynamicSuggestions } from "../logic";
 import { useAIContext } from "./context";
@@ -46,8 +46,7 @@ export function DynamicSuggestions({ onEnter }: Props) {
     engine: () => engine,
     schema: () => schema,
   });
-  const currentUserRef = useCurrentUserV1();
-  const currentUserEmail = useVueState(() => currentUserRef.value.email);
+  const currentUserEmail = useCurrentUser().email;
 
   const ready = useVueState(() => suggestionsRef.value?.ready ?? false);
   const state = useVueState<"LOADING" | "IDLE" | "ENDED">(

--- a/frontend/src/react/components/AccountMultiSelect.tsx
+++ b/frontend/src/react/components/AccountMultiSelect.tsx
@@ -3,11 +3,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
 import { SearchInput } from "@/react/components/ui/search-input";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useClickOutside } from "@/react/hooks/useClickOutside";
-import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
-import { useCurrentUserV1 } from "@/store";
 import {
   extractUserEmail,
   groupNamePrefix,
@@ -194,7 +193,7 @@ export function AccountMultiSelect({
   const { t } = useTranslation();
   const listUsers = useAppStore((state) => state.listUsers);
   const listGroups = useAppStore((state) => state.listGroups);
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
 
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");

--- a/frontend/src/react/components/DashboardFrameShell.test.tsx
+++ b/frontend/src/react/components/DashboardFrameShell.test.tsx
@@ -9,6 +9,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getOrFetchSettingByName: vi.fn(),
   fetchEnvironments: vi.fn(),
+  loadCurrentUser: vi.fn(),
   loadEnvironmentList: vi.fn(),
   loadWorkspaceProfile: vi.fn(),
   useAppStore: vi.fn(),
@@ -36,14 +37,17 @@ let DashboardFrameShell: typeof import("./DashboardFrameShell").DashboardFrameSh
 beforeEach(async () => {
   mocks.getOrFetchSettingByName.mockReset();
   mocks.fetchEnvironments.mockReset();
+  mocks.loadCurrentUser.mockReset();
   mocks.loadEnvironmentList.mockReset();
   mocks.loadWorkspaceProfile.mockReset();
   mocks.getOrFetchSettingByName.mockResolvedValue(undefined);
   mocks.fetchEnvironments.mockResolvedValue([]);
+  mocks.loadCurrentUser.mockResolvedValue(undefined);
   mocks.loadEnvironmentList.mockResolvedValue([]);
   mocks.loadWorkspaceProfile.mockResolvedValue(undefined);
   mocks.useAppStore.mockImplementation((selector) =>
     selector({
+      loadCurrentUser: mocks.loadCurrentUser,
       loadEnvironmentList: mocks.loadEnvironmentList,
       loadWorkspaceProfile: mocks.loadWorkspaceProfile,
     })
@@ -70,6 +74,7 @@ describe("DashboardFrameShell", () => {
     });
 
     expect(onReady).toHaveBeenCalled();
+    expect(mocks.loadCurrentUser).toHaveBeenCalled();
     expect(mocks.fetchEnvironments).toHaveBeenCalled();
     expect(mocks.getOrFetchSettingByName).toHaveBeenCalled();
     const targets = onReady.mock.lastCall?.[0];
@@ -89,6 +94,7 @@ describe("DashboardFrameShell", () => {
 
   test("keeps body target hidden while bootstrap requests are pending", () => {
     let resolveEnvironmentList: (value: []) => void = () => {};
+    mocks.loadCurrentUser.mockResolvedValue(undefined);
     mocks.loadEnvironmentList.mockReturnValue(
       new Promise((resolve) => {
         resolveEnvironmentList = resolve;

--- a/frontend/src/react/components/DashboardFrameShell.tsx
+++ b/frontend/src/react/components/DashboardFrameShell.tsx
@@ -19,6 +19,7 @@ export function DashboardFrameShell({ onReady }: DashboardFrameShellProps) {
   const bannerRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   const [initialized, setInitialized] = useState(false);
+  const loadCurrentUser = useAppStore((state) => state.loadCurrentUser);
   const loadEnvironmentList = useAppStore((state) => state.loadEnvironmentList);
   const loadWorkspaceProfile = useAppStore(
     (state) => state.loadWorkspaceProfile
@@ -27,6 +28,7 @@ export function DashboardFrameShell({ onReady }: DashboardFrameShellProps) {
   useEffect(() => {
     let mounted = true;
     void Promise.all([
+      loadCurrentUser(),
       loadEnvironmentList(),
       loadWorkspaceProfile(),
       loadLegacyDashboardState(),
@@ -40,7 +42,7 @@ export function DashboardFrameShell({ onReady }: DashboardFrameShellProps) {
     return () => {
       mounted = false;
     };
-  }, [loadEnvironmentList, loadWorkspaceProfile]);
+  }, [loadCurrentUser, loadEnvironmentList, loadWorkspaceProfile]);
 
   useEffect(() => {
     if (!initialized) return;

--- a/frontend/src/react/components/IssueTable.tsx
+++ b/frontend/src/react/components/IssueTable.tsx
@@ -26,16 +26,16 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { useEscapeKey } from "@/react/hooks/useEscapeKey";
-import { useVueState } from "@/react/hooks/useVueState";
 import { displayRoleTitleFromList } from "@/react/lib/role";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_DETAIL } from "@/router/dashboard/projectV1";
 import { WORKSPACE_ROUTE_USER_PROFILE } from "@/router/dashboard/workspaceRoutes";
-import { pushNotification, useCurrentUserV1, useProjectV1Store } from "@/store";
+import { pushNotification, useProjectV1Store } from "@/store";
 import {
   getTimeForPbTimestampProtoEs,
   isValidProjectName,
@@ -198,8 +198,7 @@ export function PresetButtons({
   onParamsChange: (p: SearchParams) => void;
 }) {
   const { t } = useTranslation();
-  const currentUser = useCurrentUserV1();
-  const me = useVueState(() => currentUser.value);
+  const me = useCurrentUser();
 
   type PresetValue = "WAITING_APPROVAL" | "OPEN" | "CLOSED" | "ALL";
 
@@ -324,8 +323,7 @@ export function useIssueSearchScopeOptions(
   const { t } = useTranslation();
   const listUsers = useAppStore((state) => state.listUsers);
   const projectStore = useProjectV1Store();
-  const currentUser = useCurrentUserV1();
-  const me = useVueState(() => currentUser.value);
+  const me = useCurrentUser();
 
   const [projectLabels, setProjectLabels] = useState<Label[]>([]);
 

--- a/frontend/src/react/components/Watermark.tsx
+++ b/frontend/src/react/components/Watermark.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties } from "react";
 import { useMemo } from "react";
 import { createPortal } from "react-dom";
 import {
-  useCurrentUser,
+  useOptionalCurrentUser,
   usePlanFeature,
   useServerInfo,
   useWorkspaceProfile,
@@ -55,7 +55,7 @@ function makeWatermarkDataURL(opts: {
 }
 
 export function Watermark() {
-  const currentUser = useCurrentUser();
+  const currentUser = useOptionalCurrentUser();
   const hasWatermarkFeature = usePlanFeature(PlanFeature.FEATURE_WATERMARK);
   const serverInfo = useServerInfo();
   const workspaceProfile = useWorkspaceProfile();

--- a/frontend/src/react/components/auth/InactiveRemindModal.tsx
+++ b/frontend/src/react/components/auth/InactiveRemindModal.tsx
@@ -7,15 +7,16 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/react/components/ui/dialog";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
-import { useAuthStore, useCurrentUserV1, useSettingV1Store } from "@/store";
+import { useAuthStore, useSettingV1Store } from "@/store";
 import { storageKeyLastActivity } from "@/utils/storage-keys";
 
 const SHOW_THRESHOLD_MIN = 3;
 
 export function InactiveRemindModal() {
   const { t } = useTranslation();
-  const currentUserEmail = useVueState(() => useCurrentUserV1().value.email);
+  const currentUserEmail = useCurrentUser().email;
   const inactiveTimeoutInSeconds = useVueState(() =>
     Number(
       useSettingV1Store().workspaceProfile.inactiveSessionTimeout?.seconds ?? 0

--- a/frontend/src/react/components/database/CreateDatabaseSheet.test.tsx
+++ b/frontend/src/react/components/database/CreateDatabaseSheet.test.tsx
@@ -141,9 +141,12 @@ vi.mock("@/store", () => ({
   useProjectV1Store: () => stableProjectStore,
   useInstanceV1Store: () => stableInstanceStore,
   useEnvironmentV1Store: () => ({ environmentList: [] }),
-  useCurrentUserV1: () => ({ value: mocks.currentUser }),
   experimentalCreateIssueByPlan: mocks.experimentalCreateIssueByPlan,
   pushNotification: vi.fn(),
+}));
+
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => mocks.currentUser,
 }));
 
 vi.mock("@/react/hooks/useVueState", () => ({

--- a/frontend/src/react/components/database/CreateDatabaseSheet.tsx
+++ b/frontend/src/react/components/database/CreateDatabaseSheet.tsx
@@ -17,13 +17,13 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { router } from "@/router";
 import {
   experimentalCreateIssueByPlan,
   pushNotification,
-  useCurrentUserV1,
   useEnvironmentV1Store,
   useInstanceV1Store,
   useProjectV1Store,
@@ -67,7 +67,7 @@ export function CreateDatabaseSheet({
   const projectStore = useProjectV1Store();
   const instanceStore = useInstanceV1Store();
   const environmentStore = useEnvironmentV1Store();
-  const currentUser = useCurrentUserV1();
+  const currentUser = useCurrentUser();
 
   const [projectName, setProjectName] = useState("");
   const [instanceName, setInstanceName] = useState("");
@@ -280,12 +280,12 @@ export function CreateDatabaseSheet({
       const planCreate = create(PlanSchema, {
         title: effectiveTitle,
         specs: [spec],
-        creator: currentUser.value.name,
+        creator: currentUser.name,
       });
       const issueCreate = create(IssueSchema, {
         title: effectiveTitle,
         type: Issue_Type.DATABASE_CHANGE,
-        creator: `users/${currentUser.value.email}`,
+        creator: `users/${currentUser.email}`,
         labels: issueLabels,
       });
       const { createdIssue } = await experimentalCreateIssueByPlan(

--- a/frontend/src/react/components/header/ProfileMenuTrigger.test.tsx
+++ b/frontend/src/react/components/header/ProfileMenuTrigger.test.tsx
@@ -106,7 +106,7 @@ vi.mock("@/react/router", () => ({
 }));
 
 vi.mock("@/react/hooks/useAppState", () => ({
-  useCurrentUser: () => ({
+  useOptionalCurrentUser: () => ({
     title: "Alice",
     email: "alice@example.com",
   }),

--- a/frontend/src/react/components/header/ProfileMenuTrigger.tsx
+++ b/frontend/src/react/components/header/ProfileMenuTrigger.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/react/components/ui/dropdown-menu";
 import {
   useAppFeature,
-  useCurrentUser,
+  useOptionalCurrentUser,
   useQuickstartReset,
   useServerInfo,
   useSubscription,
@@ -45,7 +45,7 @@ export function ProfileMenuTrigger({
   link = true,
 }: ProfileMenuProps) {
   const { t, i18n } = useTranslation();
-  const currentUser = useCurrentUser();
+  const currentUser = useOptionalCurrentUser();
   const serverInfo = useServerInfo();
   const { subscription, uploadLicense } = useSubscription();
   const workspace = useWorkspace();

--- a/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.test.tsx
+++ b/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.test.tsx
@@ -11,7 +11,6 @@ const mocks = vi.hoisted(() => ({
   useTranslation: vi.fn(() => ({ t: (key: string) => key })),
   // Pinia bridge — resolves the current user's email from the Pinia ref.
   usePiniaBridge: vi.fn<(getter: () => unknown) => unknown>(),
-  useCurrentUserV1: vi.fn(),
   // Zustand editor store project read.
   project: "projects/proj1" as string,
   // Current tab connection database used to derive default targets.
@@ -33,8 +32,14 @@ vi.mock("@/react/hooks/usePiniaBridge", () => ({
   usePiniaBridge: mocks.usePiniaBridge,
 }));
 
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => ({
+    name: "users/me",
+    email: "me@example.com",
+  }),
+}));
+
 vi.mock("@/store", () => ({
-  useCurrentUserV1: mocks.useCurrentUserV1,
   pushNotification: mocks.pushNotification,
   useDatabaseV1Store: mocks.useDatabaseV1Store,
 }));
@@ -304,10 +309,6 @@ const renderIntoContainer = (element: ReactElement) => {
 
 const setupMocks = () => {
   mocks.useTranslation.mockReturnValue({ t: (key: string) => key });
-
-  mocks.useCurrentUserV1.mockReturnValue({
-    value: { email: "user@example.com" },
-  });
 
   mocks.project = "projects/proj1";
   mocks.currentTabDatabase = "instances/inst1/databases/db1";

--- a/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
+++ b/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
@@ -19,17 +19,13 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { Textarea } from "@/react/components/ui/textarea";
-import { usePiniaBridge } from "@/react/hooks/usePiniaBridge";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useSQLEditorStore } from "@/react/stores/sqlEditor";
 import { useSQLEditorEditorState } from "@/react/stores/sqlEditor/editor";
 import { getSQLEditorTabsState } from "@/react/stores/sqlEditor/tab";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
-import {
-  pushNotification,
-  useCurrentUserV1,
-  useDatabaseV1Store,
-} from "@/store";
+import { pushNotification, useDatabaseV1Store } from "@/store";
 import {
   AccessGrant_Status,
   AccessGrantSchema,
@@ -110,13 +106,12 @@ function AccessGrantRequestDrawerInner({
   onClose,
 }: AccessGrantRequestDrawerInnerProps) {
   const { t } = useTranslation();
-  const currentUser = useCurrentUserV1();
+  const currentUserEmail = useCurrentUser().email;
   const setAsidePanelTab = useSQLEditorStore((s) => s.setAsidePanelTab);
   const setHighlightAccessGrantName = useSQLEditorStore(
     (s) => s.setHighlightAccessGrantName
   );
 
-  const currentUserEmail = usePiniaBridge(() => currentUser.value.email);
   const project = useSQLEditorEditorState((s) => s.project);
 
   const defaultTargets = useMemo(() => {

--- a/frontend/src/react/components/sql-editor/ConnectionPane/ConnectionPane.test.tsx
+++ b/frontend/src/react/components/sql-editor/ConnectionPane/ConnectionPane.test.tsx
@@ -92,7 +92,7 @@ const mocks = vi.hoisted(() => {
   const instanceStore = {
     getInstanceByName: vi.fn(),
   };
-  const currentUser = { value: { email: "u@b.com" } };
+  const currentUser = { email: "u@b.com" };
   return {
     tabStore,
     editorStore,
@@ -125,9 +125,12 @@ vi.mock("@/react/hooks/useSQLEditorBridge", () => ({
     feature === 1 ? mocks.features.batchQuery : mocks.features.databaseGroups,
 }));
 
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => mocks.currentUser,
+}));
+
 vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
-  useCurrentUserV1: () => mocks.currentUser,
   useDatabaseV1Store: () => mocks.databaseStore,
   useDBGroupStore: () => mocks.dbGroupStore,
   useEnvironmentV1Store: () => mocks.environmentStore,

--- a/frontend/src/react/components/sql-editor/ConnectionPane/ConnectionPane.tsx
+++ b/frontend/src/react/components/sql-editor/ConnectionPane/ConnectionPane.tsx
@@ -23,6 +23,7 @@ import { Tooltip } from "@/react/components/ui/tooltip";
 import { Tree, type TreeDataNode } from "@/react/components/ui/tree";
 import { countVisibleRows } from "@/react/components/ui/tree-utils";
 import { useCommonSearchScopeOptions } from "@/react/components/useCommonSearchScopeOptions";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { usePiniaBridge } from "@/react/hooks/usePiniaBridge";
 import { useSQLEditorFeature } from "@/react/hooks/useSQLEditorBridge";
 import { cn } from "@/react/lib/utils";
@@ -36,7 +37,6 @@ import {
 } from "@/react/stores/sqlEditor/tab";
 import {
   pushNotification,
-  useCurrentUserV1,
   useDatabaseV1Store,
   useDBGroupStore,
   useEnvironmentV1Store,
@@ -153,13 +153,12 @@ function ConnectionPaneInner({ show, onMissingFeature }: Props) {
   const instanceStore = useInstanceV1Store();
   const setTreeState = useSQLEditorStore((s) => s.setTreeState);
   const treeNodeKeysByTarget = useSQLEditorStore((s) => s.treeNodeKeysByTarget);
-  const currentUser = useCurrentUserV1();
+  const currentUserEmail = useCurrentUser().email;
 
   const supportBatchMode = useSupportBatchMode();
   const isInBatchMode = useIsInBatchMode();
   const treeStoreState = useSQLEditorStore((s) => s.treeState);
   const currentTab = useCurrentSQLEditorTab();
-  const currentUserEmail = usePiniaBridge(() => currentUser.value.email);
   const projectName = useSQLEditorEditorState((s) => s.project);
   const projectContextReady = useSQLEditorEditorState(
     (s) => s.projectContextReady

--- a/frontend/src/react/components/sql-editor/SharePopoverBody.test.tsx
+++ b/frontend/src/react/components/sql-editor/SharePopoverBody.test.tsx
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   useTranslation: vi.fn(() => ({ t: (key: string) => key })),
   usePiniaBridge: vi.fn<(getter: () => unknown) => unknown>(),
   useActuatorV1Store: vi.fn(),
-  useCurrentUserV1: vi.fn(),
+  useCurrentUser: vi.fn(),
   patchWorksheet: vi.fn().mockResolvedValue({}),
   // `useSQLEditorTabState(selector)` runs `selector` against this stub
   // state; the component selects `tabsById.get(currentTabId)?.status`.
@@ -32,9 +32,12 @@ vi.mock("@/react/hooks/usePiniaBridge", () => ({
   usePiniaBridge: mocks.usePiniaBridge,
 }));
 
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: mocks.useCurrentUser,
+}));
+
 vi.mock("@/store", () => ({
   useActuatorV1Store: mocks.useActuatorV1Store,
-  useCurrentUserV1: mocks.useCurrentUserV1,
   pushNotification: mocks.pushNotification,
 }));
 
@@ -135,8 +138,9 @@ beforeEach(async () => {
   mocks.useActuatorV1Store.mockReturnValue({
     serverInfo: { externalUrl: "https://example.com" },
   });
-  mocks.useCurrentUserV1.mockReturnValue({
-    value: { email: "test@example.com", name: "users/test@example.com" },
+  mocks.useCurrentUser.mockReturnValue({
+    email: "test@example.com",
+    name: "users/test@example.com",
   });
   mocks.patchWorksheet.mockResolvedValue({});
   mocks.tabStatus = "CLEAN";
@@ -187,8 +191,9 @@ describe("SharePopoverBody", () => {
   });
 
   test("visibility selector disabled when user is not creator", () => {
-    mocks.useCurrentUserV1.mockReturnValue({
-      value: { email: "other@example.com", name: "users/other@example.com" },
+    mocks.useCurrentUser.mockReturnValue({
+      email: "other@example.com",
+      name: "users/other@example.com",
     });
     mocks.usePiniaBridge.mockImplementation((getter: () => unknown) =>
       getter()

--- a/frontend/src/react/components/sql-editor/SharePopoverBody.tsx
+++ b/frontend/src/react/components/sql-editor/SharePopoverBody.tsx
@@ -13,17 +13,14 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/react/components/ui/popover";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { usePiniaBridge } from "@/react/hooks/usePiniaBridge";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { useSQLEditorTabState } from "@/react/stores/sqlEditor/tab";
 import { router } from "@/router";
 import { SQL_EDITOR_WORKSHEET_MODULE } from "@/router/sqlEditor";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useCurrentUserV1,
-} from "@/store";
+import { pushNotification, useActuatorV1Store } from "@/store";
 import type { Worksheet } from "@/types/proto-es/v1/worksheet_service_pb";
 import { Worksheet_Visibility } from "@/types/proto-es/v1/worksheet_service_pb";
 import { extractProjectResourceName, extractWorksheetID } from "@/utils";
@@ -46,12 +43,11 @@ type Props = {
 export function SharePopoverBody({ worksheet }: Props) {
   const { t } = useTranslation();
   const actuatorStore = useActuatorV1Store();
-  const currentUserStore = useCurrentUserV1();
 
   const workspaceExternalURL = usePiniaBridge(
     () => actuatorStore.serverInfo?.externalUrl
   );
-  const currentUser = usePiniaBridge(() => currentUserStore.value);
+  const currentUser = useCurrentUser();
   const tabStatus = useSQLEditorTabState(
     (s) => s.tabsById.get(s.currentTabId)?.status
   );

--- a/frontend/src/react/components/sql-editor/useDropdown.ts
+++ b/frontend/src/react/components/sql-editor/useDropdown.ts
@@ -9,9 +9,8 @@
 
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { usePiniaBridge } from "@/react/hooks/usePiniaBridge";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useAppStore } from "@/react/stores/app";
-import { useCurrentUserV1 } from "@/store";
 import { isWorksheetWritableV1 } from "@/utils";
 import type {
   SheetViewMode,
@@ -52,8 +51,7 @@ export function useDropdown(
 ) {
   const { t } = useTranslation();
 
-  // Call Pinia store factories at hook top level (React Hooks rule).
-  const meRef = useCurrentUserV1();
+  const me = useCurrentUser();
 
   // ------------------------------------------------------------------
   // Context state — current right-click target
@@ -66,8 +64,6 @@ export function useDropdown(
   // ------------------------------------------------------------------
   // Reactive reads from Pinia / Vue stores
   // ------------------------------------------------------------------
-  const me = usePiniaBridge(() => meRef.value);
-
   const worksheetEntity = useAppStore((s) =>
     viewMode === "draft" || !currentNode?.worksheet
       ? undefined

--- a/frontend/src/react/hooks/useAppState.ts
+++ b/frontend/src/react/hooks/useAppState.ts
@@ -31,7 +31,12 @@ export function useOptionalCurrentUser() {
 }
 
 export function useCurrentUser() {
-  return useOptionalCurrentUser() ?? unknownUser();
+  const user = useOptionalCurrentUser();
+  // Stabilize the fallback identity: a fresh unknownUser() each render would
+  // change identity while the user is unresolved, retriggering identity-keyed
+  // effects in callers (e.g. ProfilePage, TwoFactorSetupPage) and risking a
+  // render loop.
+  return useMemo(() => user ?? unknownUser(), [user]);
 }
 
 export function useWorkspace() {

--- a/frontend/src/react/hooks/useAppState.ts
+++ b/frontend/src/react/hooks/useAppState.ts
@@ -16,17 +16,22 @@ import {
   nullEnvironment,
   unknownEnvironment,
 } from "@/types/v1/environment";
+import { unknownUser } from "@/types/v1/user";
 import { storageKeyRecentProjects } from "@/utils/storage-keys";
 
 export { isConnectAlreadyExists };
 
-export function useCurrentUser() {
+export function useOptionalCurrentUser() {
   const user = useAppStore((state) => state.currentUser);
   const loadCurrentUser = useAppStore((state) => state.loadCurrentUser);
   useEffect(() => {
     void loadCurrentUser();
   }, [loadCurrentUser]);
   return user;
+}
+
+export function useCurrentUser() {
+  return useOptionalCurrentUser() ?? unknownUser();
 }
 
 export function useWorkspace() {
@@ -414,7 +419,7 @@ function readRecentProjectNames(email: string) {
 }
 
 export function useRecentProjects() {
-  const currentUser = useCurrentUser();
+  const currentUser = useOptionalCurrentUser();
   const batchFetchProjects = useAppStore((state) => state.batchFetchProjects);
   const projectsByName = useAppStore((state) => state.projectsByName);
   const [projectNames, setProjectNames] = useState<string[]>([]);
@@ -444,7 +449,7 @@ export function useRecentProjects() {
 }
 
 export function useRecentVisit() {
-  useCurrentUser();
+  useOptionalCurrentUser();
   const recordRecentVisit = useAppStore((state) => state.recordRecentVisit);
   const removeRecentVisit = useAppStore((state) => state.removeRecentVisit);
   return {

--- a/frontend/src/react/hooks/useSessionPageSize.ts
+++ b/frontend/src/react/hooks/useSessionPageSize.ts
@@ -1,7 +1,6 @@
 import { sortBy, uniq } from "lodash-es";
-import { useCallback, useState } from "react";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useCurrentUserV1 } from "@/store";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { getDefaultPagination } from "@/utils";
 
 const PAGE_SIZE_OPTIONS = [50, 100, 200, 500];
@@ -11,29 +10,43 @@ export function getPageSizeOptions(): number[] {
   return sortBy(uniq([defaultSize, ...PAGE_SIZE_OPTIONS]));
 }
 
+function readStoredPageSize(storageKey: string): number {
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      const size = parsed?.pageSize;
+      const options = getPageSizeOptions();
+      if (typeof size === "number" && options.includes(size)) {
+        return Math.max(options[0], size);
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return getPageSizeOptions()[0];
+}
+
 export function useSessionPageSize(
   sessionKey: string
 ): [number, (size: number) => void] {
-  const currentUser = useCurrentUserV1();
-  const email = useVueState(() => currentUser.value.email);
+  const email = useCurrentUser().email;
   const storageKey = `bb.paged-table.${sessionKey}.${email}`;
 
-  const [pageSize, setPageSize] = useState<number>(() => {
-    try {
-      const stored = localStorage.getItem(storageKey);
-      if (stored) {
-        const parsed = JSON.parse(stored);
-        const size = parsed?.pageSize;
-        const options = getPageSizeOptions();
-        if (typeof size === "number" && options.includes(size)) {
-          return Math.max(options[0], size);
-        }
-      }
-    } catch {
-      // ignore
+  const [pageSize, setPageSize] = useState<number>(() =>
+    readStoredPageSize(storageKey)
+  );
+
+  // `email` is empty until the current user loads asynchronously, so the
+  // initial read can hit the wrong key. Re-read the persisted size once the
+  // key (email) resolves.
+  const loadedKeyRef = useRef(storageKey);
+  useEffect(() => {
+    if (loadedKeyRef.current !== storageKey) {
+      loadedKeyRef.current = storageKey;
+      setPageSize(readStoredPageSize(storageKey));
     }
-    return getPageSizeOptions()[0];
-  });
+  }, [storageKey]);
 
   const updatePageSize = useCallback(
     (size: number) => {

--- a/frontend/src/react/hooks/useWorksheetAndTab.ts
+++ b/frontend/src/react/hooks/useWorksheetAndTab.ts
@@ -1,6 +1,6 @@
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useAppStore } from "@/react/stores/app";
 import { useCurrentSQLEditorTab } from "@/react/stores/sqlEditor/tab";
-import { useCurrentUserV1 } from "@/store";
 import { extractUserEmail } from "@/store/modules/v1/common";
 import type { Worksheet } from "@/types/proto-es/v1/worksheet_service_pb";
 import {
@@ -25,14 +25,14 @@ export interface WorksheetAndTab {
 export const useWorksheetAndTab = (): WorksheetAndTab => {
   const currentTab = useCurrentSQLEditorTab();
   const worksheetName = currentTab?.worksheet;
-  const me = useCurrentUserV1();
+  const me = useCurrentUser();
 
   const currentSheet = useAppStore((s) =>
     worksheetName ? s.getWorksheetByName(worksheetName) : undefined
   );
 
   const isCreator = currentSheet
-    ? extractUserEmail(currentSheet.creator) === me.value.email
+    ? extractUserEmail(currentSheet.creator) === me.email
     : false;
 
   let isReadOnly = false;

--- a/frontend/src/react/no-legacy-vue-deps.test.ts
+++ b/frontend/src/react/no-legacy-vue-deps.test.ts
@@ -27,6 +27,21 @@ const sources = import.meta.glob(
   }
 ) as Record<string, string>;
 
+const currentUserMigrationSources = import.meta.glob(
+  [
+    "./**/*.{ts,tsx}",
+    "../plugins/ai/react/**/*.{ts,tsx}",
+    "../connect/middlewares/activeInterceptorMiddleware.ts",
+    "../utils/pagination.ts",
+    "../utils/v1/worksheet.ts",
+  ],
+  {
+    query: "?raw",
+    import: "default",
+    eager: true,
+  }
+) as Record<string, string>;
+
 const legacyVueImportPattern =
   /@\/components\/(?:Plan|RolloutV1|IssueV1|PlanCheckRun|DatabaseDetail)\/[^"']+\.vue/g;
 
@@ -160,6 +175,20 @@ describe("React Project and Settings legacy Vue dependencies", () => {
         if (source.includes(bannedImport)) {
           violations.push(`${file}: ${bannedImport}`);
         }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  test("migrated React and utility surfaces do not use the legacy current-user hook", () => {
+    const legacyCurrentUserHook = ["use", "Current", "User", "V1"].join("");
+    const violations: string[] = [];
+    for (const [file, source] of Object.entries(currentUserMigrationSources)) {
+      if (file.endsWith("/no-legacy-vue-deps.test.ts")) {
+        continue;
+      }
+      if (source.includes(legacyCurrentUserHook)) {
+        violations.push(file);
       }
     }
     expect(violations).toEqual([]);

--- a/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
@@ -22,7 +22,6 @@ const mocks = vi.hoisted(() => ({
     setRequireResetPassword: vi.fn(),
     login: vi.fn(async () => {}),
   })),
-  useCurrentUserV1: vi.fn(() => ({ value: { name: "users/1", email: "u@e" } })),
   updateUser: vi.fn(),
   pushNotification: vi.fn(),
   routerReplace: vi.fn(),
@@ -39,10 +38,13 @@ vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: mocks.useVueState,
 }));
 
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => ({ name: "users/1", email: "u@e" }),
+}));
+
 vi.mock("@/store", () => ({
   useActuatorV1Store: mocks.useActuatorV1Store,
   useAuthStore: mocks.useAuthStore,
-  useCurrentUserV1: mocks.useCurrentUserV1,
   pushNotification: mocks.pushNotification,
 }));
 

--- a/frontend/src/react/pages/auth/PasswordResetPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.tsx
@@ -9,16 +9,12 @@ import { computePasswordValidation } from "@/react/components/auth/userPasswordV
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { OtpInput } from "@/react/components/ui/otp-input";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_SIGNIN_MODULE } from "@/router/auth";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useAuthStore,
-  useCurrentUserV1,
-} from "@/store";
+import { pushNotification, useActuatorV1Store, useAuthStore } from "@/store";
 import {
   LoginRequestSchema,
   ResetPasswordRequestSchema,
@@ -49,7 +45,7 @@ export function PasswordResetPage() {
   const requireResetPassword = useVueState(
     () => useAuthStore().requireResetPassword
   );
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
 
   const redirectQuery = () => {
     const q = new URLSearchParams(window.location.search);

--- a/frontend/src/react/pages/auth/ProfileSetupPage.tsx
+++ b/frontend/src/react/pages/auth/ProfileSetupPage.tsx
@@ -1,25 +1,22 @@
 import { create } from "@bufbuild/protobuf";
 import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { UserAvatar } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import {
-  pushNotification,
-  useCurrentUserV1,
-  useWorkspaceV1Store,
-} from "@/store";
+import { pushNotification, useWorkspaceV1Store } from "@/store";
 import { UpdateUserRequestSchema } from "@/types/proto-es/v1/user_service_pb";
 import { WorkspaceSchema } from "@/types/proto-es/v1/workspace_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
 export function ProfileSetupPage() {
   const { t } = useTranslation();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const updateUser = useAppStore((state) => state.updateUser);
   const workspaceStore = useWorkspaceV1Store();
   const workspace = useVueState(() => workspaceStore.currentWorkspace);
@@ -34,7 +31,20 @@ export function ProfileSetupPage() {
       0
     ) === 1;
 
-  const [name, setName] = useState(currentUser?.title ?? "");
+  // `currentUser` loads asynchronously (unknownUser with an empty email until
+  // then), so seed the name field once the real user is known rather than
+  // freezing on the placeholder title. The ref keeps it a one-shot seed so
+  // later edits aren't clobbered.
+  const [name, setName] = useState(
+    currentUser.email ? (currentUser.title ?? "") : ""
+  );
+  const nameSeededRef = useRef(Boolean(currentUser.email));
+  useEffect(() => {
+    if (!nameSeededRef.current && currentUser.email) {
+      nameSeededRef.current = true;
+      setName(currentUser.title ?? "");
+    }
+  }, [currentUser.email, currentUser.title]);
   const [workspaceTitle, setWorkspaceTitle] = useState(workspace?.title ?? "");
   const [saving, setSaving] = useState(false);
 

--- a/frontend/src/react/pages/project/ProjectAccessGrantsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectAccessGrantsPage.tsx
@@ -30,6 +30,7 @@ import {
   TableRow,
 } from "@/react/components/ui/table";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
@@ -38,7 +39,6 @@ import { router } from "@/router";
 import {
   featureToRef,
   pushNotification,
-  useCurrentUserV1,
   useDatabaseV1Store,
   useProjectV1Store,
 } from "@/store";
@@ -117,7 +117,7 @@ export function ProjectAccessGrantsPage({ projectId }: { projectId: string }) {
   const listAccessGrants = useAppStore((state) => state.listAccessGrants);
   const activateAccessGrant = useAppStore((state) => state.activateAccessGrant);
   const revokeAccessGrant = useAppStore((state) => state.revokeAccessGrant);
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
 
   const projectName = `${projectNamePrefix}${projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));

--- a/frontend/src/react/pages/project/ProjectIssueDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectIssueDashboardPage.tsx
@@ -11,16 +11,12 @@ import {
   useIssueSearchScopeOptions,
 } from "@/react/components/IssueTable";
 import { Alert } from "@/react/components/ui/alert";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import {
-  refreshIssueList,
-  useCurrentUserV1,
-  useIssueV1Store,
-  useUIStateStore,
-} from "@/store";
+import { refreshIssueList, useIssueV1Store, useUIStateStore } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { ApprovalStatus } from "@/types/proto-es/v1/common_pb";
 import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
@@ -42,11 +38,10 @@ export function ProjectIssueDashboardPage({
   const { t } = useTranslation();
   const issueStore = useIssueV1Store();
   const uiStateStore = useUIStateStore();
-  const currentUser = useCurrentUserV1();
   const batchGetOrFetchUsers = useAppStore(
     (state) => state.batchGetOrFetchUsers
   );
-  const me = useVueState(() => currentUser.value);
+  const me = useCurrentUser();
 
   const projectName = `${projectNamePrefix}${projectId}`;
 

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
@@ -29,6 +29,7 @@ import {
   TableRow,
 } from "@/react/components/ui/table";
 import { Tabs, TabsList, TabsTrigger } from "@/react/components/ui/tabs";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
   buildMemberSummary,
@@ -51,7 +52,6 @@ import {
   extractUserEmail,
   hasFeature,
   pushNotification,
-  useCurrentUserV1,
   useDatabaseV1Store,
   usePolicyV1Store,
   useProjectV1Store,
@@ -99,7 +99,7 @@ export function ProjectMaskingExemptionPage({
   const projectStore = useProjectV1Store();
   const databaseStore = useDatabaseV1Store();
   const listUsers = useAppStore((state) => state.listUsers);
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
 
   const projectName = `${projectNamePrefix}${projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -44,6 +44,7 @@ import {
   TableRow,
 } from "@/react/components/ui/table";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useColumnWidths } from "@/react/hooks/useColumnWidths";
 import { useEscapeKey } from "@/react/hooks/useEscapeKey";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
@@ -59,7 +60,6 @@ import {
 } from "@/router/dashboard/projectV1";
 import {
   pushNotification,
-  useCurrentUserV1,
   useDatabaseV1Store,
   useDBGroupStore,
   useEnvironmentV1Store,
@@ -129,11 +129,10 @@ export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
     (state) => state.batchGetOrFetchUsers
   );
   const uiStateStore = useUIStateStore();
-  const currentUser = useCurrentUserV1();
 
   const projectName = `${projectNamePrefix}${projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));
-  const me = useVueState(() => currentUser.value);
+  const me = useCurrentUser();
 
   const [showAddSpecDrawer, setShowAddSpecDrawer] = useState(false);
 

--- a/frontend/src/react/pages/project/export-center/DataExportPrepSheet.test.tsx
+++ b/frontend/src/react/pages/project/export-center/DataExportPrepSheet.test.tsx
@@ -229,9 +229,12 @@ vi.mock("@/store", () => ({
   useDBGroupStore: () => stableDBGroupStore,
   useSheetV1Store: () => stableSheetStore,
   useSettingV1Store: () => stableSettingStore,
-  useCurrentUserV1: () => ({ value: mocks.currentUser }),
   experimentalCreateIssueByPlan: mocks.experimentalCreateIssueByPlan,
   pushNotification: mocks.pushNotification,
+}));
+
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => mocks.currentUser,
 }));
 
 import { nativeChange } from "@/react/test-utils/nativeChange";

--- a/frontend/src/react/pages/project/export-center/DataExportPrepSheet.tsx
+++ b/frontend/src/react/pages/project/export-center/DataExportPrepSheet.tsx
@@ -19,6 +19,7 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { Switch } from "@/react/components/ui/switch";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useSessionPageSize } from "@/react/hooks/useSessionPageSize";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
@@ -28,7 +29,6 @@ import {
   DEFAULT_MAX_RESULT_SIZE_IN_MB,
   experimentalCreateIssueByPlan,
   pushNotification,
-  useCurrentUserV1,
   useDatabaseV1Store,
   useDBGroupStore,
   useProjectV1Store,
@@ -93,7 +93,7 @@ export function DataExportPrepSheet({
   seed,
 }: DataExportPrepSheetProps) {
   const { t } = useTranslation();
-  const currentUser = useCurrentUserV1();
+  const currentUser = useCurrentUser();
   const sheetStore = useSheetV1Store();
   const dbStore = useDatabaseV1Store();
   const dbGroupStore = useDBGroupStore();
@@ -258,13 +258,13 @@ export function DataExportPrepSheet({
         title: effectiveTitle,
         description,
         specs: [spec],
-        creator: currentUser.value.name,
+        creator: currentUser.name,
       });
 
       const issueCreate = create(IssueSchema, {
         title: effectiveTitle,
         description,
-        creator: `users/${currentUser.value.email}`,
+        creator: `users/${currentUser.email}`,
         labels,
         type: Issue_Type.DATABASE_EXPORT,
       });

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailActionBar.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailActionBar.tsx
@@ -40,6 +40,7 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useClickOutside } from "@/react/hooks/useClickOutside";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
@@ -54,7 +55,6 @@ import {
 } from "@/router/dashboard/projectV1RouteHelpers";
 import {
   pushNotification,
-  useCurrentUserV1,
   useIssueCommentStore,
   useProjectV1Store,
   useSQLStore,
@@ -102,7 +102,7 @@ export function IssueDetailActionBar() {
   const projectStore = useProjectV1Store();
   const issueCommentStore = useIssueCommentStore();
   const sqlStore = useSQLStore();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const [pendingConfirmAction, setPendingConfirmAction] =
     useState<ActionDefinition>();
   const [pendingReviewOpen, setPendingReviewOpen] = useState(false);

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
@@ -14,6 +14,7 @@ import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { getAvatarColor, getInitials } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { displayRoleTitleFromList } from "@/react/lib/role";
 import { cn } from "@/react/lib/utils";
@@ -21,7 +22,6 @@ import { useAppStore } from "@/react/stores/app";
 import { ensureGroupIdentifier } from "@/react/stores/app/group";
 import {
   pushNotification,
-  useCurrentUserV1,
   useProjectIamPolicyStore,
   useProjectV1Store,
 } from "@/store";
@@ -400,7 +400,7 @@ function ApprovalCandidateRow({
   user: UserMessage;
 }) {
   const { t } = useTranslation();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const displayName = user.title || user.email.split("@")[0];
   const isCurrentUser = currentUser?.name === user.name;
 
@@ -503,7 +503,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const { t } = useTranslation();
   const roleList = useAppStore((state) => state.roleList);
   const page = useIssueDetailContext();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
   const projectIamPolicyStore = useProjectIamPolicyStore();
   const batchGetOrFetchUsers = useAppStore(

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailChecks.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailChecks.tsx
@@ -3,8 +3,9 @@ import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { planServiceClientConnect } from "@/connect";
 import { PlanCheckSection } from "@/react/components/plan-check/PlanCheckSection";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
-import { pushNotification, useCurrentUserV1, useProjectV1Store } from "@/store";
+import { pushNotification, useProjectV1Store } from "@/store";
 import { extractUserEmail, projectNamePrefix } from "@/store/modules/v1/common";
 import {
   GetPlanCheckRunRequestSchema,
@@ -20,7 +21,7 @@ export function IssueDetailChecks() {
   const { t } = useTranslation();
   const page = useIssueDetailContext();
   const projectStore = useProjectV1Store();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const [isRunningChecks, setIsRunningChecks] = useState(false);
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailCommentList.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailCommentList.tsx
@@ -28,6 +28,7 @@ import {
   DialogContent,
   DialogTitle,
 } from "@/react/components/ui/dialog";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
@@ -38,7 +39,6 @@ import {
   getIssueCommentType,
   IssueCommentType,
   pushNotification,
-  useCurrentUserV1,
   useIssueCommentStore,
   useProjectV1Store,
   useSheetV1Store,
@@ -108,7 +108,7 @@ export function IssueDetailCommentList() {
     (state) => state.batchGetOrFetchUsers
   );
   const issueCommentStore = useIssueCommentStore();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const routeHash = useVueState(() => router.currentRoute.value.hash);
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
@@ -7,14 +7,13 @@ import { MonacoEditor, ReadonlyMonaco } from "@/react/components/monaco";
 import { ReleaseInfoCard } from "@/react/components/release/ReleaseInfoCard";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
-import { useReleaseByName } from "@/react/hooks/useAppState";
+import { useCurrentUser, useReleaseByName } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import {
   projectNamePrefix,
   pushNotification,
-  useCurrentUserV1,
   useDatabaseV1Store,
   useProjectV1Store,
   useSheetV1Store,
@@ -65,7 +64,7 @@ export function IssueDetailStatementSection({
   const fetchRelease = useAppStore((state) => state.fetchRelease);
   const projectStore = useProjectV1Store();
   const databaseStore = useDatabaseV1Store();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const project = useVueState(() =>
     projectStore.getProjectByName(`${projectNamePrefix}${page.projectId}`)
   );

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
@@ -18,11 +18,11 @@ import {
 } from "@/react/components/ui/sheet";
 import { Textarea } from "@/react/components/ui/textarea";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import {
   pushNotification,
-  useCurrentUserV1,
   useDatabaseV1Store,
   useEnvironmentV1Store,
   useProjectV1Store,
@@ -87,7 +87,7 @@ export function IssueDetailTaskRolloutActionPanel({
   const { t } = useTranslation();
   const page = useIssueDetailContext();
   const projectStore = useProjectV1Store();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));
   const [loading, setLoading] = useState(false);

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
@@ -34,9 +34,7 @@ const mocks = vi.hoisted(() => ({
   batchGetOrFetchUsers: vi.fn(async () => []),
   getOrFetchUserByIdentifier: vi.fn(async () => undefined),
   pushNotification: vi.fn(),
-  currentUserStore: {
-    value: { email: "me@example.com", name: "users/me" },
-  },
+  currentUser: { email: "me@example.com", name: "users/me" },
   projectIamPolicyStore: {
     getOrFetchProjectIamPolicy: vi.fn(async () => ({})),
     getProjectIamPolicy: vi.fn(() => ({ bindings: [] })),
@@ -82,10 +80,13 @@ vi.mock("@/connect", () => ({
 
 vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
-  useCurrentUserV1: () => mocks.currentUserStore,
   useProjectIamPolicyStore: () => mocks.projectIamPolicyStore,
   useProjectV1Store: () => mocks.projectStore,
   useWorkspaceV1Store: () => mocks.workspaceStore,
+}));
+
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => mocks.currentUser,
 }));
 
 vi.mock("@/react/stores/app", () => ({

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.tsx
@@ -14,6 +14,7 @@ import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { getAvatarColor, getInitials } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { displayRoleTitleFromList } from "@/react/lib/role";
 import { cn } from "@/react/lib/utils";
@@ -23,7 +24,6 @@ import { router } from "@/router";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
 import {
   pushNotification,
-  useCurrentUserV1,
   useProjectIamPolicyStore,
   useProjectV1Store,
 } from "@/store";
@@ -561,7 +561,7 @@ function ApprovalCandidateRow({
   user: UserMessage;
 }) {
   const { t } = useTranslation();
-  const currentUser = useCurrentUserV1().value;
+  const currentUser = useCurrentUser();
   const displayName = user.title || user.email.split("@")[0];
   const isCurrentUser = currentUser?.name === user.name;
 
@@ -665,7 +665,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const roleList = useAppStore((state) => state.roleList);
   const page = usePlanDetailContext();
   const { patchState } = page;
-  const currentUser = useCurrentUserV1().value;
+  const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
   const projectIamPolicyStore = useProjectIamPolicyStore();
   const batchGetOrFetchUsers = useAppStore(

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
@@ -266,14 +266,18 @@ vi.mock("@/store", () => ({
   getProjectNameAndDatabaseGroupName: (name: string) =>
     name.split("/databaseGroups/"),
   pushNotification: vi.fn(),
-  useCurrentUserV1: () => ({
-    value: { name: "users/me@example.com", email: "me@example.com" },
-  }),
   useDatabaseV1Store: () => mocks.databaseStore,
   useDBGroupStore: () => mocks.dbGroupStore,
   useEnvironmentV1Store: () => mocks.environmentStore,
   useProjectV1Store: () => mocks.projectStore,
   useSheetV1Store: () => mocks.sheetStore,
+}));
+
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => ({
+    name: "users/me@example.com",
+    email: "me@example.com",
+  }),
 }));
 
 vi.mock("@/utils", () => ({

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -57,6 +57,7 @@ import {
 } from "@/react/components/ui/sheet";
 import { Switch } from "@/react/components/ui/switch";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useSessionPageSize } from "@/react/hooks/useSessionPageSize";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
@@ -68,7 +69,6 @@ import {
 import {
   getProjectNameAndDatabaseGroupName,
   pushNotification,
-  useCurrentUserV1,
   useDatabaseV1Store,
   useDBGroupStore,
   useProjectV1Store,
@@ -192,7 +192,7 @@ export function PlanDetailChangesBranch({
   const { t } = useTranslation();
   const page = usePlanDetailContext();
   const { patchState } = page;
-  const currentUser = useCurrentUserV1().value;
+  const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
   const project = useVueState(() =>
     projectStore.getProjectByName(`projects/${page.projectId}`)
@@ -712,7 +712,7 @@ function OptionsSection({
   const { t } = useTranslation();
   const page = usePlanDetailContext();
   const { patchState, refreshState } = page;
-  const currentUser = useCurrentUserV1().value;
+  const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
   const project = useVueState(() =>
     projectStore.getProjectByName(`projects/${page.projectId}`)

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
@@ -18,10 +18,10 @@ import {
 } from "@/react/components/ui/sheet";
 import { Textarea } from "@/react/components/ui/textarea";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { cn } from "@/react/lib/utils";
 import {
   pushNotification,
-  useCurrentUserV1,
   useEnvironmentV1Store,
   useProjectV1Store,
 } from "@/store";
@@ -79,7 +79,7 @@ export function PlanDetailTaskRolloutActionPanel({
   const { t } = useTranslation();
   const page = usePlanDetailContext();
   const projectStore = useProjectV1Store();
-  const currentUser = useCurrentUserV1().value;
+  const currentUser = useCurrentUser();
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const project = projectStore.getProjectByName(projectName);
   const [loading, setLoading] = useState(false);

--- a/frontend/src/react/pages/project/plan-detail/hooks/usePlanCheckActions.tsx
+++ b/frontend/src/react/pages/project/plan-detail/hooks/usePlanCheckActions.tsx
@@ -2,11 +2,11 @@ import { create } from "@bufbuild/protobuf";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { planServiceClientConnect } from "@/connect";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
   projectNamePrefix,
   pushNotification,
-  useCurrentUserV1,
   useProjectV1Store,
 } from "@/store";
 import { extractUserEmail } from "@/store/modules/v1/common";
@@ -26,7 +26,7 @@ export function usePlanCheckActions() {
   const page = usePlanDetailContext();
   const { patchState, isRunningChecks, setIsRunningChecks } = page;
   const projectStore = useProjectV1Store();
-  const currentUser = useCurrentUserV1().value;
+  const currentUser = useCurrentUser();
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const project = useVueState(() => projectStore.getProjectByName(projectName));
 

--- a/frontend/src/react/pages/settings/GroupsPage.tsx
+++ b/frontend/src/react/pages/settings/GroupsPage.tsx
@@ -44,6 +44,7 @@ import {
   TableRow,
 } from "@/react/components/ui/table";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
@@ -53,7 +54,6 @@ import { SETTING_ROUTE_WORKSPACE_GENERAL } from "@/router/dashboard/workspaceSet
 import {
   pushNotification,
   useActuatorV1Store,
-  useCurrentUserV1,
   useSettingV1Store,
   useSubscriptionV1Store,
 } from "@/store";
@@ -116,7 +116,7 @@ function GroupTable({
   onGroupDeleted: (group: Group) => void;
 }) {
   const { t } = useTranslation();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const batchGetOrFetchUsers = useAppStore(
     (state) => state.batchGetOrFetchUsers
   );
@@ -484,7 +484,7 @@ function GroupForm({
   const { t } = useTranslation();
   const settingV1Store = useSettingV1Store();
   const actuatorStore = useActuatorV1Store();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
   const getOrFetchUserByIdentifier = useAppStore(
     (state) => state.getOrFetchUserByIdentifier

--- a/frontend/src/react/pages/settings/LandingPage.tsx
+++ b/frontend/src/react/pages/settings/LandingPage.tsx
@@ -30,7 +30,10 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
-import { useCurrentUser, useServerState } from "@/react/hooks/useAppState";
+import {
+  useOptionalCurrentUser,
+  useServerState,
+} from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
 import {
@@ -432,7 +435,7 @@ export function LandingPage(_: Record<string, never> = {}) {
   const [showConfigDrawer, setShowConfigDrawer] = useState(false);
   const [showProjectSwitchDialog, setShowProjectSwitchDialog] = useState(false);
 
-  const email = useCurrentUser()?.email ?? "";
+  const email = useOptionalCurrentUser()?.email ?? "";
   const { version, changelogURL } = useServerState();
 
   const fullList = useFullQuickLinkList();

--- a/frontend/src/react/pages/settings/MembersPage.test.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.test.tsx
@@ -279,9 +279,6 @@ vi.mock("@/store", () => ({
     isSaaSMode: false,
     userCountInIam: 1,
   }),
-  useCurrentUserV1: () => ({
-    value: { email: "me@example.com", name: "users/me@example.com" },
-  }),
   useProjectIamPolicyStore: () => ({
     getOrFetchProjectIamPolicy: vi.fn(),
     getProjectIamPolicy: () => projectIamPolicy,
@@ -307,6 +304,13 @@ vi.mock("@/store", () => ({
     findRolesByMember: () => [],
     patchIamPolicy: vi.fn(),
     workspaceIamPolicy: { bindings: [] },
+  }),
+}));
+
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => ({
+    email: "me@example.com",
+    name: "users/me@example.com",
   }),
 }));
 

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -65,6 +65,7 @@ import {
   TabsTrigger,
 } from "@/react/components/ui/tabs";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useEscapeKey } from "@/react/hooks/useEscapeKey";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
@@ -82,7 +83,6 @@ import { useAppStore } from "@/react/stores/app";
 import {
   pushNotification,
   useActuatorV1Store,
-  useCurrentUserV1,
   useProjectIamPolicyStore,
   useProjectV1Store,
   useSettingV1Store,
@@ -163,7 +163,7 @@ function MemberTable({
   scope: "workspace" | "project";
 }) {
   const { t } = useTranslation();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const actuatorStore = useActuatorV1Store();
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
   const batchGetOrFetchUsers = useAppStore(
@@ -622,7 +622,7 @@ function MemberTableByRole({
   scope: "workspace" | "project";
 }) {
   const { t } = useTranslation();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const actuatorStore = useActuatorV1Store();
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
   const roleList = useAppStore((state) => state.roleList);
@@ -1894,7 +1894,7 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   const workspaceStore = useWorkspaceV1Store();
   const actuatorStore = useActuatorV1Store();
   const subscriptionStore = useSubscriptionV1Store();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
   const projectIamPolicyStore = useProjectIamPolicyStore();
 

--- a/frontend/src/react/pages/settings/RequestRoleSheet.test.tsx
+++ b/frontend/src/react/pages/settings/RequestRoleSheet.test.tsx
@@ -221,9 +221,12 @@ vi.mock("@/connect", () => ({
 }));
 
 vi.mock("@/store", () => ({
-  useCurrentUserV1: () => ({ value: mocks.currentUser }),
   useSettingV1Store: () => stableSettingStore,
   pushNotification: (...args: unknown[]) => mocks.pushNotification(...args),
+}));
+
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: () => mocks.currentUser,
 }));
 
 vi.mock("@/react/stores/app", () => ({

--- a/frontend/src/react/pages/settings/RequestRoleSheet.tsx
+++ b/frontend/src/react/pages/settings/RequestRoleSheet.tsx
@@ -30,6 +30,7 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { Textarea } from "@/react/components/ui/textarea";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import {
   getRoleEnvironmentLimitationKind,
@@ -39,7 +40,7 @@ import { displayRoleTitleFromList } from "@/react/lib/role";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
-import { pushNotification, useCurrentUserV1, useSettingV1Store } from "@/store";
+import { pushNotification, useSettingV1Store } from "@/store";
 import type { Permission } from "@/types";
 import { type DatabaseResource, PresetRoleType } from "@/types";
 import { ExprSchema as ConditionExprSchema } from "@/types/proto-es/google/type/expr_pb";
@@ -132,13 +133,7 @@ function RequestRoleForm({
   onClose,
 }: Readonly<Omit<RequestRoleSheetProps, "open">>) {
   const { t } = useTranslation();
-  // Call the Pinia store accessor at the top level of the component so
-  // SonarCloud's React-hook-rule doesn't flag the `use*` call inside
-  // a subscription getter. `useCurrentUserV1()` returns a cached Pinia
-  // computed ref, so calling it once and reading `.value` inside the
-  // getter produces identical reactive semantics.
-  const currentUserRef = useCurrentUserV1();
-  const currentUser = useVueState(() => currentUserRef.value);
+  const currentUser = useCurrentUser();
   const [role, setRole] = useState(initialRole);
   const [reason, setReason] = useState("");
   const [expirationTimestamp, setExpirationTimestamp] = useState<

--- a/frontend/src/react/pages/settings/UsersPage.tsx
+++ b/frontend/src/react/pages/settings/UsersPage.tsx
@@ -39,6 +39,7 @@ import {
   TableRow,
 } from "@/react/components/ui/table";
 import { Tooltip } from "@/react/components/ui/tooltip";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
@@ -51,7 +52,6 @@ import {
 import {
   pushNotification,
   useActuatorV1Store,
-  useCurrentUserV1,
   useSettingV1Store,
   useSubscriptionV1Store,
   useWorkspaceV1Store,
@@ -90,7 +90,7 @@ function UserTable({
   onGroupSelected?: (group: Group) => void;
 }) {
   const { t } = useTranslation();
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const archiveUser = useAppStore((state) => state.archiveUser);
   const restoreUser = useAppStore((state) => state.restoreUser);
   const batchGetOrFetchGroups = useAppStore(

--- a/frontend/src/react/pages/settings/general/DangerZoneSection.tsx
+++ b/frontend/src/react/pages/settings/general/DangerZoneSection.tsx
@@ -10,7 +10,10 @@ import {
 } from "@/react/components/ui/alert-dialog";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
-import { useCurrentUser, useWorkspace } from "@/react/hooks/useAppState";
+import {
+  useOptionalCurrentUser,
+  useWorkspace,
+} from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { pushNotification, useWorkspaceV1Store } from "@/store";
 import { PresetRoleType } from "@/types/iam/role";
@@ -20,7 +23,7 @@ import { hasWorkspacePermissionV2 } from "@/utils";
 export function DangerZoneSection() {
   const { t } = useTranslation();
   const workspace = useWorkspace();
-  const currentUser = useCurrentUser()!;
+  const currentUser = useOptionalCurrentUser()!;
   const workspaceStore = useWorkspaceV1Store();
   const workspacePolicy = useVueState(() => workspaceStore.workspaceIamPolicy);
 

--- a/frontend/src/react/pages/settings/profile/ProfilePage.test.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.test.tsx
@@ -26,7 +26,7 @@ const updatedCurrentUser = {
 
 const mocks = vi.hoisted(() => ({
   useVueState: vi.fn<(getter: () => unknown) => unknown>((getter) => getter()),
-  useCurrentUserV1: vi.fn(() => ({ value: legacyCurrentUser })),
+  useCurrentUser: vi.fn(() => legacyCurrentUser),
   useAuthStore: vi.fn(() => ({
     updateCurrentUserNameForEmailChange: vi.fn(),
   })),
@@ -59,6 +59,10 @@ vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: mocks.useVueState,
 }));
 
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: mocks.useCurrentUser,
+}));
+
 vi.mock("@/react/hooks/useUnsavedChangesGuard", () => ({
   useUnsavedChangesGuard: vi.fn(),
 }));
@@ -79,7 +83,6 @@ vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
   useActuatorV1Store: mocks.useActuatorV1Store,
   useAuthStore: mocks.useAuthStore,
-  useCurrentUserV1: mocks.useCurrentUserV1,
   useSettingV1Store: mocks.useSettingV1Store,
   useWorkspaceV1Store: mocks.useWorkspaceV1Store,
 }));

--- a/frontend/src/react/pages/settings/profile/ProfilePage.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/react/components/ui/dropdown-menu";
 import { FeatureModal } from "@/react/components/ui/feature-modal";
 import { Input } from "@/react/components/ui/input";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useUnsavedChangesGuard } from "@/react/hooks/useUnsavedChangesGuard";
 import { useVueState } from "@/react/hooks/useVueState";
 import { displayRoleTitleFromList } from "@/react/lib/role";
@@ -42,7 +43,6 @@ import {
   pushNotification,
   useActuatorV1Store,
   useAuthStore,
-  useCurrentUserV1,
   useSettingV1Store,
   useWorkspaceV1Store,
 } from "@/store";
@@ -81,7 +81,7 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
   const actuatorStore = useActuatorV1Store();
 
   // --- Reactive Vue state ---
-  const legacyCurrentUser = useVueState(() => useCurrentUserV1().value);
+  const legacyCurrentUser = useCurrentUser();
   const [currentUser, setCurrentUser] = useState(legacyCurrentUser);
   const principalUser = useAppStore((state) =>
     principalEmail ? state.getUserByIdentifier(principalEmail) : undefined

--- a/frontend/src/react/pages/settings/two-factor/RegenerateRecoveryCodesView.tsx
+++ b/frontend/src/react/pages/settings/two-factor/RegenerateRecoveryCodesView.tsx
@@ -3,9 +3,9 @@ import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useAppStore } from "@/react/stores/app";
-import { pushNotification, useCurrentUserV1 } from "@/store";
+import { pushNotification } from "@/store";
 import { UpdateUserRequestSchema } from "@/types/proto-es/v1/user_service_pb";
 import { RecoveryCodesView } from "./RecoveryCodesView";
 
@@ -20,7 +20,7 @@ export function RegenerateRecoveryCodesView({
 }: RegenerateRecoveryCodesViewProps) {
   const { t } = useTranslation();
   const updateUser = useAppStore((state) => state.updateUser);
-  const currentUser = useVueState(() => useCurrentUserV1().value);
+  const currentUser = useCurrentUser();
   const [recoveryCodesDownloaded, setRecoveryCodesDownloaded] = useState(false);
 
   useEffect(() => {

--- a/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.test.tsx
+++ b/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.test.tsx
@@ -28,7 +28,7 @@ const regeneratedCurrentUser = {
 
 const mocks = vi.hoisted(() => ({
   useVueState: vi.fn<(getter: () => unknown) => unknown>((getter) => getter()),
-  useCurrentUserV1: vi.fn(() => ({ value: legacyCurrentUser })),
+  useCurrentUser: vi.fn(() => legacyCurrentUser),
   updateUser: vi.fn(async () => regeneratedCurrentUser),
   pushNotification: vi.fn(),
   routerReplace: vi.fn(),
@@ -41,6 +41,10 @@ vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: mocks.useVueState,
 }));
 
+vi.mock("@/react/hooks/useAppState", () => ({
+  useCurrentUser: mocks.useCurrentUser,
+}));
+
 vi.mock("@/react/stores/app", () => ({
   useAppStore: (selector: (state: unknown) => unknown) =>
     selector({
@@ -50,7 +54,6 @@ vi.mock("@/react/stores/app", () => ({
 
 vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
-  useCurrentUserV1: mocks.useCurrentUserV1,
 }));
 
 vi.mock("@/router", () => ({

--- a/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.tsx
+++ b/frontend/src/react/pages/settings/two-factor/TwoFactorSetupPage.tsx
@@ -8,12 +8,12 @@ import { useTranslation } from "react-i18next";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { Button } from "@/react/components/ui/button";
 import { OtpInput } from "@/react/components/ui/otp-input";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_2FA_SETUP_MODULE } from "@/router/auth";
 import { SETTING_ROUTE_PROFILE } from "@/router/dashboard/workspaceSetting";
-import { pushNotification, useCurrentUserV1 } from "@/store";
+import { pushNotification } from "@/store";
 import { UpdateUserRequestSchema } from "@/types/proto-es/v1/user_service_pb";
 import { RecoveryCodesView } from "./RecoveryCodesView";
 import { TwoFactorSecretModal } from "./TwoFactorSecretModal";
@@ -33,7 +33,7 @@ interface TwoFactorSetupPageProps {
 export function TwoFactorSetupPage({ cancelAction }: TwoFactorSetupPageProps) {
   const { t } = useTranslation();
   const updateUser = useAppStore((state) => state.updateUser);
-  const legacyCurrentUser = useVueState(() => useCurrentUserV1().value);
+  const legacyCurrentUser = useCurrentUser();
   const [currentUser, setCurrentUser] = useState(legacyCurrentUser);
 
   const [currentStep, setCurrentStep] = useState<Step>(SETUP_AUTH_APP_STEP);

--- a/frontend/src/react/pages/workspace/MyIssuesPage.tsx
+++ b/frontend/src/react/pages/workspace/MyIssuesPage.tsx
@@ -10,11 +10,11 @@ import {
   PresetButtons,
   useIssueSearchScopeOptions,
 } from "@/react/components/IssueTable";
+import { useCurrentUser } from "@/react/hooks/useAppState";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
-import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import { refreshIssueList, useCurrentUserV1, useIssueV1Store } from "@/store";
+import { refreshIssueList, useIssueV1Store } from "@/store";
 import { ApprovalStatus } from "@/types/proto-es/v1/common_pb";
 import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
 import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
@@ -28,11 +28,10 @@ import {
 export function MyIssuesPage() {
   const { t } = useTranslation();
   const issueStore = useIssueV1Store();
-  const currentUser = useCurrentUserV1();
   const batchGetOrFetchUsers = useAppStore(
     (state) => state.batchGetOrFetchUsers
   );
-  const me = useVueState(() => currentUser.value);
+  const me = useCurrentUser();
 
   const defaultSearchParams = useCallback((): SearchParams => {
     const myEmail = me?.email ?? "";

--- a/frontend/src/react/plugins/agent/logic/context.ts
+++ b/frontend/src/react/plugins/agent/logic/context.ts
@@ -1,5 +1,5 @@
 import type { RouteLocationNormalizedLoaded } from "vue-router";
-import { useCurrentUserV1 } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import { Engine, State } from "@/types/proto-es/v1/common_pb";
 import { Issue_Type, IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 
@@ -18,12 +18,14 @@ export async function extractRouteContext(
 
   // Current user — always available
   try {
-    const user = useCurrentUserV1();
-    if (user.value?.name) {
+    const user =
+      useAppStore.getState().currentUser ??
+      (await useAppStore.getState().loadCurrentUser());
+    if (user?.name) {
       ctx.user = {
-        name: user.value.name,
-        email: user.value.email,
-        title: user.value.title,
+        name: user.name,
+        email: user.email,
+        title: user.title,
       };
     }
   } catch {

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -566,6 +566,24 @@ describe("useAppStore", () => {
     expect(store.getState().usersByName[updated.name]).toBe(updated);
   });
 
+  test("updateEmail refreshes currentUser when the signed-in user changes email", async () => {
+    const updated = createProto(UserSchema, {
+      ...user,
+      name: "users/alice-updated@example.com",
+      email: "alice-updated@example.com",
+    });
+    mocks.updateEmail.mockResolvedValue(updated);
+    const store = createAppStore();
+    store.setState({
+      currentUser: user,
+      usersByName: { [user.name]: user },
+    });
+
+    await store.getState().updateEmail(user.email, updated.email);
+
+    expect(store.getState().currentUser).toBe(updated);
+  });
+
   test("updateUser passes allowMissing through without requiring an existing user", async () => {
     mocks.updateUser.mockResolvedValue(userA);
     const store = createAppStore();
@@ -586,6 +604,27 @@ describe("useAppStore", () => {
       })
     );
     expect(store.getState().usersByName[userA.name]).toBe(userA);
+  });
+
+  test("updateUser refreshes currentUser when the signed-in user is updated", async () => {
+    const updated = createProto(UserSchema, {
+      ...user,
+      title: "Alice Updated",
+    });
+    mocks.updateUser.mockResolvedValue(updated);
+    const store = createAppStore();
+    store.setState({
+      currentUser: user,
+      usersByName: { [user.name]: user },
+    });
+
+    await store.getState().updateUser(
+      createProto(UpdateUserRequestSchema, {
+        user: updated,
+      })
+    );
+
+    expect(store.getState().currentUser).toBe(updated);
   });
 
   test("create archive and restore update activated user count when server info is loaded", async () => {

--- a/frontend/src/react/stores/app/user.ts
+++ b/frontend/src/react/stores/app/user.ts
@@ -223,6 +223,10 @@ export const createUserSlice: AppSliceCreator<UserSlice> = (set, get) => {
       );
       set((state) => ({
         usersByName: { ...state.usersByName, [response.name]: response },
+        currentUser:
+          state.currentUser?.name === response.name
+            ? response
+            : state.currentUser,
       }));
       return response;
     },
@@ -249,7 +253,11 @@ export const createUserSlice: AppSliceCreator<UserSlice> = (set, get) => {
           delete usersByName[oldName];
         }
         usersByName[response.name] = response;
-        return { usersByName };
+        return {
+          usersByName,
+          currentUser:
+            state.currentUser?.name === oldName ? response : state.currentUser,
+        };
       });
       return response;
     },

--- a/frontend/src/react/stores/sqlEditor/tab.ts
+++ b/frontend/src/react/stores/sqlEditor/tab.ts
@@ -4,7 +4,7 @@ import { create, type StoreApi, type UseBoundStore } from "zustand";
 import { immer } from "zustand/middleware/immer";
 import { useShallow } from "zustand/react/shallow";
 import { useAppStore } from "@/react/stores/app";
-import { hasFeature, useCurrentUserV1 } from "@/store";
+import { hasFeature } from "@/store";
 import {
   migrateDraftsFromCache,
   migrateTabViewState,
@@ -122,13 +122,11 @@ const isPersistentTabArray = (v: unknown): v is PersistentTab[] =>
 const currentScope = (): { project: string; email: string } | null => {
   const project = getSQLEditorEditorState().project;
   if (!project) return null;
-  try {
-    const me = useCurrentUserV1();
-    const email = me?.value?.email ?? "";
-    return { project, email };
-  } catch {
-    return null;
-  }
+  // The current user is loaded into the app store during tab hydration
+  // (see hydrateProjectTabs), so it's available by the time tabs are
+  // persisted on user actions.
+  const email = useAppStore.getState().currentUser?.email ?? "";
+  return { project, email };
 };
 
 const persistOpenTabs = (openTabs: PersistentTab[]) => {
@@ -394,12 +392,10 @@ const hydrateProjectTabs = async (project: string): Promise<void> => {
   await migrateDraftsFromCache(project);
   migrateTabViewState(project);
 
-  let email = "";
-  try {
-    email = useCurrentUserV1()?.value?.email ?? "";
-  } catch {
-    email = "";
-  }
+  // Ensure the current user is loaded so tab storage is scoped to the
+  // right email — the SQL editor route doesn't otherwise populate it.
+  await useAppStore.getState().loadCurrentUser();
+  const email = useAppStore.getState().currentUser?.email ?? "";
 
   const storedTabs = readOpenTabs(project, email);
 

--- a/frontend/src/store/modules/v1/auth.ts
+++ b/frontend/src/store/modules/v1/auth.ts
@@ -252,15 +252,16 @@ export const useAuthStore = defineStore("auth_v1", () => {
   };
 });
 
-export const useCurrentUserV1 = () => {
+export const getCurrentUserV1 = () => {
   const authStore = useAuthStore();
   const userStore = useUserStore();
-  return computed(
-    () =>
-      userStore.getUserByIdentifier(authStore.currentUserName || "") ||
-      unknownUser()
+  return (
+    userStore.getUserByIdentifier(authStore.currentUserName || "") ||
+    unknownUser()
   );
 };
+
+export const useCurrentUserV1 = () => computed(() => getCurrentUserV1());
 
 /**
  * Returns true if the user should be prompted to set up their profile.

--- a/frontend/src/utils/pagination.ts
+++ b/frontend/src/utils/pagination.ts
@@ -1,7 +1,7 @@
-import { useCurrentUserV1 } from "@/store";
+import { getCurrentUserV1 } from "@/store";
 
 export const getDefaultPagination = () => {
-  if (useCurrentUserV1().value.email.endsWith("@bytebase.com")) {
+  if (getCurrentUserV1().email.endsWith("@bytebase.com")) {
     return 10;
   }
   return 50;

--- a/frontend/src/utils/v1/worksheet.ts
+++ b/frontend/src/utils/v1/worksheet.ts
@@ -1,5 +1,5 @@
 import {
-  useCurrentUserV1,
+  getCurrentUserV1,
   useDatabaseV1Store,
   useProjectV1Store,
 } from "@/store";
@@ -25,9 +25,9 @@ export const extractWorksheetID = (name: string) => {
 // PROJECT_WRITE: workspace Owner/DBA and all members in the project.
 // PROJECT_READ: workspace Owner/DBA and all members in the project.
 export const isWorksheetReadableV1 = (sheet: Worksheet) => {
-  const currentUser = useCurrentUserV1();
+  const currentUser = getCurrentUserV1();
 
-  if (extractUserEmail(sheet.creator) === currentUser.value.email) {
+  if (extractUserEmail(sheet.creator) === currentUser.email) {
     // Always readable to the creator
     return true;
   }
@@ -56,9 +56,9 @@ export const isWorksheetReadableV1 = (sheet: Worksheet) => {
 // PROJECT_WRITE: workspace Owner/DBA and all members in the project.
 // PROJECT_READ: workspace Owner/DBA and project owner.
 export const isWorksheetWritableV1 = (sheet: Worksheet) => {
-  const currentUser = useCurrentUserV1();
+  const currentUser = getCurrentUserV1();
 
-  if (extractUserEmail(sheet.creator) === currentUser.value.email) {
+  if (extractUserEmail(sheet.creator) === currentUser.email) {
     // Always writable to the creator
     return true;
   }


### PR DESCRIPTION
## What

Replaces the Pinia `useCurrentUserV1` composable with Zustand-backed React hooks so current-user reads are reactive through the app store.

- Add `useCurrentUser` (always defined, `unknownUser()` fallback) and `useOptionalCurrentUser` (`User | undefined`) in `useAppState`.
- Keep `currentUser` in sync on `updateUser` / `updateEmail` in the user slice (the Zustand copy is cached rather than derived).
- Migrate React consumers off `useCurrentUserV1`; `getCurrentUserV1` is retained only for imperative non-component reads (utils, interceptor).
- Read the current user from the app store in the SQL editor tab slice and load it during tab hydration, so tab storage stays scoped to the right email (the editor route doesn't otherwise populate it).
- Seed-then-resync `ProfileSetupPage` and `useSessionPageSize` so they don't freeze on the unknown user before the async load resolves.

## Why

The old Pinia composable returned a `ComputedRef`, requiring a Vue→React bridge (`usePiniaBridge`/`useVueState`) and `.value` access in React. The Zustand-backed hooks subscribe directly, removing the bridge and giving the common case the clean `useCurrentUser()` name while the rare optional case is explicit.

## Testing

- `pnpm --dir frontend type-check` — clean
- `pnpm --dir frontend check` (ESLint + Biome + i18n + layering) — clean
- `pnpm --dir frontend vitest run src/react` — 209 files / 1246 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)