### PR TITLE
ci: run cloud rollout Mon-Fri and split runner VM start into its own workflow

### DIFF
--- a/.github/workflows/build-push-cloud-image.yml
+++ b/.github/workflows/build-push-cloud-image.yml
@@ -3,8 +3,9 @@ name: Deploy Bytebase Cloud
 on:
   workflow_dispatch:
   schedule:
-    # Monday-Thursday at 00:00 UTC
-    - cron: "0 0 * * 1-4"
+    # Monday-Friday at 00:23 UTC. The off-the-hour minute avoids GitHub Actions'
+    # hour-boundary high-load window, where scheduled jobs can be delayed or dropped.
+    - cron: "23 0 * * 1-5"
 
 permissions:
   contents: read

--- a/.github/workflows/start-runner-vm.yml
+++ b/.github/workflows/start-runner-vm.yml
@@ -1,0 +1,35 @@
+# Starts the github-runner GCE VM, which hosts this repo's self-hosted Actions
+# runner (used by jobs with `runs-on: self-hosted`, e.g. backend-tests,
+# golangci-lint, test_link). Previously bundled into trigger-oncall-sync.yml.
+name: Start github-runner VM
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Three times a day, at 21:00, 02:00 and 06:00 UTC.
+    - cron: "0 2,6,21 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  start-vm:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Start github-runner VM if stopped
+        run: |
+          STATUS=$(gcloud compute instances describe github-runner \
+            --zone southamerica-east1-b --project bytebase-dev \
+            --format='value(status)')
+          if [ "$STATUS" != "RUNNING" ]; then
+            gcloud compute instances start github-runner \
+              --zone southamerica-east1-b --project bytebase-dev
+          fi

--- a/.github/workflows/start-runner-vm.yml
+++ b/.github/workflows/start-runner-vm.yml
@@ -1,6 +1,6 @@
 # Starts the github-runner GCE VM, which hosts this repo's self-hosted Actions
 # runner (used by jobs with `runs-on: self-hosted`, e.g. backend-tests,
-# golangci-lint, test_link). Previously bundled into trigger-oncall-sync.yml.
+# golangci-lint, test_link).
 name: Start github-runner VM
 
 on:

--- a/.github/workflows/trigger-oncall-sync.yml
+++ b/.github/workflows/trigger-oncall-sync.yml
@@ -16,24 +16,6 @@ jobs:
   dispatch:
     runs-on: ubuntu-24.04
     steps:
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v3
-
-      - name: Start github-runner VM if stopped
-        run: |
-          STATUS=$(gcloud compute instances describe github-runner \
-            --zone southamerica-east1-b --project bytebase-dev \
-            --format='value(status)')
-          if [ "$STATUS" != "RUNNING" ]; then
-            gcloud compute instances start github-runner \
-              --zone southamerica-east1-b --project bytebase-dev
-          fi
-
       - name: Trigger sync-oncall workflow on bytebase/oncall
         env:
           GH_TOKEN: ${{ secrets.GHA_DISPATCH_TOKEN }}


### PR DESCRIPTION
## What changed

- **Deploy Bytebase Cloud** (`build-push-cloud-image.yml`) now runs **Monday–Friday** (was Monday–Thursday), at **00:23 UTC** instead of exactly `00:00`. The off-the-hour minute avoids GitHub Actions' hour-boundary high-load window where scheduled jobs can be delayed or dropped.
- The **"Start github-runner VM"** step (plus its GCP auth + Cloud SDK setup) is moved out of `trigger-oncall-sync.yml` into a new standalone **`start-runner-vm.yml`**.
- The VM start now runs **three times a day** — `0 2,6,21 * * *` (02:00/06:00/21:00 UTC) — instead of once, for better coverage during working hours.

## Why

The `github-runner` VM hosts this repo's **self-hosted CI runner** (`backend-tests`, `golangci-lint`, `test_link` all use `runs-on: self-hosted`). It has **no functional relationship** to the oncall sync — `bytebase/oncall`'s `sync-oncall.yml` runs on `ubuntu-latest`. The VM start was just piggybacking on a convenient daily cron, so pulling it into its own workflow decouples two unrelated concerns. The oncall-sync dispatch job keeps only `gh workflow run` (it needs `GHA_DISPATCH_TOKEN`, not GCP credentials).

## Reviewer notes

- The three files should land **together**: `trigger-oncall-sync.yml` stops starting the VM and `start-runner-vm.yml` takes over.
- `start-runner-vm.yml`'s `schedule:` only activates once it's on the default branch (`main`) — expected for any new scheduled workflow.
- These three times correspond to working-hours coverage; the VM-start logic itself (`describe` → `start if not RUNNING`) is moved verbatim, unchanged.

## Testing

Workflow-only change (no Go/frontend/proto/DB). All three YAML files validated with `yaml.safe_load`, and cron/timezone values were checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)