### PR TITLE
feat: migrate Oracle schema metadata extraction to omni

### DIFF
--- a/backend/plugin/schema/oracle/get_database_metadata.go
+++ b/backend/plugin/schema/oracle/get_database_metadata.go
@@ -21,6 +21,10 @@ func init() {
 
 // GetDatabaseMetadata parses the Oracle schema text and returns the database metadata.
 func GetDatabaseMetadata(schemaText string) (*storepb.DatabaseSchemaMetadata, error) {
+	return GetDatabaseMetadataOmni(schemaText)
+}
+
+func getDatabaseMetadataANTLR(schemaText string) (*storepb.DatabaseSchemaMetadata, error) {
 	results, err := oracleparser.ParsePLSQL(schemaText)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse Oracle schema")

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -32,6 +32,8 @@ func GetDatabaseMetadataOmni(schemaText string) (*storepb.DatabaseSchemaMetadata
 		triggers:          make(map[string]*storepb.TriggerMetadata),
 		sequences:         make(map[string]*storepb.SequenceMetadata),
 		packages:          make(map[string]*storepb.PackageMetadata),
+		checkNames:        make(map[string]map[string]bool),
+		checkNameNext:     make(map[string]map[string]int),
 		schemaText:        schemaText,
 	}
 
@@ -57,6 +59,8 @@ type oracleOmniMetadataExtractor struct {
 	triggers          map[string]*storepb.TriggerMetadata
 	sequences         map[string]*storepb.SequenceMetadata
 	packages          map[string]*storepb.PackageMetadata
+	checkNames        map[string]map[string]bool
+	checkNameNext     map[string]map[string]int
 	schemaText        string
 }
 
@@ -314,7 +318,7 @@ func (e *oracleOmniMetadataExtractor) extractColumnConstraint(n *ast.ColumnConst
 			})
 		}
 	case ast.CONSTRAINT_CHECK:
-		e.appendCheckConstraint(table, checkConstraintName(table, n.Name, fmt.Sprintf("CHK_%s_%s", table.Name, column.Name)), n.Expr)
+		e.appendCheckConstraint(table, e.checkConstraintName(table, n.Name, fmt.Sprintf("CHK_%s_%s", table.Name, column.Name)), n.Expr)
 	case ast.CONSTRAINT_FOREIGN:
 		e.appendForeignKey(table, fallbackName(n.Name, fmt.Sprintf("FK_%s_%s", table.Name, column.Name)), []string{column.Name}, n.RefTable, n.RefColumns, n.OnDelete)
 	default:
@@ -351,7 +355,7 @@ func (e *oracleOmniMetadataExtractor) extractTableConstraint(n *ast.TableConstra
 			IsConstraint: true,
 		})
 	case ast.CONSTRAINT_CHECK:
-		e.appendCheckConstraint(table, checkConstraintName(table, n.Name, fmt.Sprintf("CHK_%s_%d", table.Name, len(table.CheckConstraints)+1)), n.Expr)
+		e.appendCheckConstraint(table, e.checkConstraintName(table, n.Name, fmt.Sprintf("CHK_%s_%d", table.Name, len(table.CheckConstraints)+1)), n.Expr)
 	case ast.CONSTRAINT_FOREIGN:
 		e.appendForeignKey(table, fallbackName(n.Name, fmt.Sprintf("FK_%s_%d", table.Name, len(table.ForeignKeys)+1)), columns, n.RefTable, n.RefColumns, n.OnDelete)
 	default:
@@ -394,33 +398,65 @@ func (e *oracleOmniMetadataExtractor) appendCheckConstraint(table *storepb.Table
 	if expr == nil {
 		return
 	}
+	e.reserveCheckConstraintName(table, name)
 	table.CheckConstraints = append(table.CheckConstraints, &storepb.CheckConstraintMetadata{
 		Name:       name,
 		Expression: e.exprText(expr),
 	})
 }
 
-func checkConstraintName(table *storepb.TableMetadata, name string, fallback string) string {
+func (e *oracleOmniMetadataExtractor) checkConstraintName(table *storepb.TableMetadata, name string, fallback string) string {
 	if name != "" {
 		return name
 	}
-	return uniqueCheckConstraintName(table, fallback)
+	return e.uniqueCheckConstraintName(table, fallback)
 }
 
-func uniqueCheckConstraintName(table *storepb.TableMetadata, fallback string) string {
-	used := make(map[string]bool)
-	for _, check := range table.CheckConstraints {
-		used[check.Name] = true
-	}
+func (e *oracleOmniMetadataExtractor) uniqueCheckConstraintName(table *storepb.TableMetadata, fallback string) string {
+	used := e.checkConstraintNameSet(table)
 	if !used[fallback] {
 		return fallback
 	}
-	for i := 2; ; i++ {
-		candidate := fmt.Sprintf("%s_%d", fallback, i)
+	nextByFallback := e.checkConstraintNameNextSet(table)
+	next := nextByFallback[fallback]
+	if next < 2 {
+		next = 2
+	}
+	for {
+		candidate := fmt.Sprintf("%s_%d", fallback, next)
+		next++
 		if !used[candidate] {
+			nextByFallback[fallback] = next
 			return candidate
 		}
 	}
+}
+
+func (e *oracleOmniMetadataExtractor) reserveCheckConstraintName(table *storepb.TableMetadata, name string) {
+	e.checkConstraintNameSet(table)[name] = true
+}
+
+func (e *oracleOmniMetadataExtractor) checkConstraintNameSet(table *storepb.TableMetadata) map[string]bool {
+	used := e.checkNames[table.Name]
+	if used != nil {
+		return used
+	}
+	used = make(map[string]bool)
+	for _, check := range table.CheckConstraints {
+		used[check.Name] = true
+	}
+	e.checkNames[table.Name] = used
+	return used
+}
+
+func (e *oracleOmniMetadataExtractor) checkConstraintNameNextSet(table *storepb.TableMetadata) map[string]int {
+	next := e.checkNameNext[table.Name]
+	if next != nil {
+		return next
+	}
+	next = make(map[string]int)
+	e.checkNameNext[table.Name] = next
+	return next
 }
 
 func (*oracleOmniMetadataExtractor) appendForeignKey(table *storepb.TableMetadata, name string, columns []string, refTable *ast.ObjectName, refColumns *ast.List, _ string) {

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -172,6 +172,8 @@ func (e *oracleOmniMetadataExtractor) extractStatement(stmt ast.StmtNode) {
 		e.extractCreateIndex(n)
 	case *ast.CreateViewStmt:
 		e.extractCreateView(n)
+	case *ast.CreateSchemaStmt:
+		e.extractCreateSchema(n)
 	case *ast.CreateSequenceStmt:
 		e.extractCreateSequence(n)
 	case *ast.CreateProcedureStmt:
@@ -193,6 +195,19 @@ func (e *oracleOmniMetadataExtractor) extractStatement(stmt ast.StmtNode) {
 	case *ast.CommentStmt:
 		e.extractComment(n)
 	default:
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) extractCreateSchema(n *ast.CreateSchemaStmt) {
+	if n.SchemaName != "" {
+		e.currentSchema = n.SchemaName
+	}
+	for _, item := range listItems(n.Stmts) {
+		stmt, ok := item.(ast.StmtNode)
+		if !ok {
+			continue
+		}
+		e.extractStatement(stmt)
 	}
 }
 

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -752,7 +752,7 @@ func (e *oracleOmniMetadataExtractor) exprText(expr ast.ExprNode) string {
 		if n.IsNChar {
 			prefix = "N"
 		}
-		return prefix + "'" + n.Val + "'"
+		return prefix + "'" + strings.ReplaceAll(n.Val, "'", "''") + "'"
 	case *ast.NumberLiteral:
 		return n.Val
 	case *ast.NullLiteral:

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -447,7 +447,7 @@ func (e *oracleOmniMetadataExtractor) extractCreateIndex(n *ast.CreateIndexStmt)
 		Unique:      n.Unique,
 		Type:        "NORMAL",
 		Expressions: []string{},
-		Visible:     true,
+		Visible:     !n.Invisible,
 	}
 	if n.Bitmap {
 		index.Type = "BITMAP"
@@ -477,6 +477,8 @@ func (e *oracleOmniMetadataExtractor) extractCreateIndex(n *ast.CreateIndexStmt)
 	}
 	if isFunctionBased && index.Type == "NORMAL" {
 		index.Type = "FUNCTION-BASED NORMAL"
+	} else if isFunctionBased && index.Type == "BITMAP" {
+		index.Type = "FUNCTION-BASED BITMAP"
 	}
 
 	if materializedView := e.materializedViews[tableName]; materializedView != nil {
@@ -596,9 +598,18 @@ func (e *oracleOmniMetadataExtractor) extractComment(n *ast.CommentStmt) {
 	}
 
 	switch n.ObjectType {
-	case ast.OBJECT_TABLE:
-		if table := e.tables[objectName(n.Object)]; table != nil {
+	case ast.OBJECT_TABLE, ast.OBJECT_VIEW:
+		name := objectName(n.Object)
+		if table := e.tables[name]; table != nil {
 			table.Comment = n.Comment
+			return
+		}
+		if view := e.views[name]; view != nil {
+			view.Comment = n.Comment
+		}
+	case ast.OBJECT_MATERIALIZED_VIEW:
+		if materializedView := e.materializedViews[objectName(n.Object)]; materializedView != nil {
+			materializedView.Comment = n.Comment
 		}
 	default:
 	}

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -314,7 +314,7 @@ func (e *oracleOmniMetadataExtractor) extractColumnConstraint(n *ast.ColumnConst
 			})
 		}
 	case ast.CONSTRAINT_CHECK:
-		e.appendCheckConstraint(table, fallbackName(n.Name, fmt.Sprintf("CHK_%s_%s", table.Name, column.Name)), n.Expr)
+		e.appendCheckConstraint(table, checkConstraintName(table, n.Name, fmt.Sprintf("CHK_%s_%s", table.Name, column.Name)), n.Expr)
 	case ast.CONSTRAINT_FOREIGN:
 		e.appendForeignKey(table, fallbackName(n.Name, fmt.Sprintf("FK_%s_%s", table.Name, column.Name)), []string{column.Name}, n.RefTable, n.RefColumns, n.OnDelete)
 	default:
@@ -351,7 +351,7 @@ func (e *oracleOmniMetadataExtractor) extractTableConstraint(n *ast.TableConstra
 			IsConstraint: true,
 		})
 	case ast.CONSTRAINT_CHECK:
-		e.appendCheckConstraint(table, fallbackName(n.Name, fmt.Sprintf("CHK_%s_%d", table.Name, len(table.CheckConstraints)+1)), n.Expr)
+		e.appendCheckConstraint(table, checkConstraintName(table, n.Name, fmt.Sprintf("CHK_%s_%d", table.Name, len(table.CheckConstraints)+1)), n.Expr)
 	case ast.CONSTRAINT_FOREIGN:
 		e.appendForeignKey(table, fallbackName(n.Name, fmt.Sprintf("FK_%s_%d", table.Name, len(table.ForeignKeys)+1)), columns, n.RefTable, n.RefColumns, n.OnDelete)
 	default:
@@ -398,6 +398,29 @@ func (e *oracleOmniMetadataExtractor) appendCheckConstraint(table *storepb.Table
 		Name:       name,
 		Expression: e.exprText(expr),
 	})
+}
+
+func checkConstraintName(table *storepb.TableMetadata, name string, fallback string) string {
+	if name != "" {
+		return name
+	}
+	return uniqueCheckConstraintName(table, fallback)
+}
+
+func uniqueCheckConstraintName(table *storepb.TableMetadata, fallback string) string {
+	used := make(map[string]bool)
+	for _, check := range table.CheckConstraints {
+		used[check.Name] = true
+	}
+	if !used[fallback] {
+		return fallback
+	}
+	for i := 2; ; i++ {
+		candidate := fmt.Sprintf("%s_%d", fallback, i)
+		if !used[candidate] {
+			return candidate
+		}
+	}
 }
 
 func (*oracleOmniMetadataExtractor) appendForeignKey(table *storepb.TableMetadata, name string, columns []string, refTable *ast.ObjectName, refColumns *ast.List, _ string) {

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -184,7 +184,7 @@ func (e *oracleOmniMetadataExtractor) extractStatement(stmt ast.StmtNode) {
 		}
 	case *ast.CreatePackageStmt:
 		if name := objectName(n.Name); name != "" {
-			e.packages[name] = &storepb.PackageMetadata{Name: name, Definition: e.definitionText(n)}
+			e.extractCreatePackage(name, n)
 		}
 	case *ast.CreateTriggerStmt:
 		e.extractCreateTrigger(n)
@@ -464,6 +464,10 @@ func (e *oracleOmniMetadataExtractor) extractCreateIndex(n *ast.CreateIndexStmt)
 		index.Type = "FUNCTION-BASED NORMAL"
 	}
 
+	if materializedView := e.materializedViews[tableName]; materializedView != nil {
+		materializedView.Indexes = append(materializedView.Indexes, index)
+		return
+	}
 	table := e.getOrCreateTable(tableName)
 	table.Indexes = append(table.Indexes, index)
 }
@@ -485,6 +489,7 @@ func (e *oracleOmniMetadataExtractor) extractCreateView(n *ast.CreateViewStmt) {
 		}
 		if table := e.tables[viewName]; table != nil {
 			materializedView.Triggers = append(materializedView.Triggers, table.Triggers...)
+			materializedView.Indexes = append(materializedView.Indexes, table.Indexes...)
 		}
 		if definition != "" && !strings.HasSuffix(definition, "\n") {
 			materializedView.Definition += "\n"
@@ -518,6 +523,23 @@ func (e *oracleOmniMetadataExtractor) extractCreateSequence(n *ast.CreateSequenc
 		sequence.Increment = increment
 	}
 	e.sequences[sequenceName] = sequence
+}
+
+func (e *oracleOmniMetadataExtractor) extractCreatePackage(name string, n *ast.CreatePackageStmt) {
+	definition := e.definitionText(n)
+	if definition == "" {
+		return
+	}
+	pkg := e.packages[name]
+	if pkg == nil {
+		e.packages[name] = &storepb.PackageMetadata{Name: name, Definition: definition}
+		return
+	}
+	if pkg.Definition == "" {
+		pkg.Definition = definition
+		return
+	}
+	pkg.Definition += "\n\n" + definition
 }
 
 func (e *oracleOmniMetadataExtractor) extractCreateTrigger(n *ast.CreateTriggerStmt) {

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -479,21 +479,30 @@ func (e *oracleOmniMetadataExtractor) extractCreateView(n *ast.CreateViewStmt) {
 
 	definition := e.nodeText(n.Query)
 	if n.Materialized {
-		if definition != "" && !strings.HasSuffix(definition, "\n") {
-			definition += "\n"
-		}
-		e.materializedViews[viewName] = &storepb.MaterializedViewMetadata{
+		materializedView := &storepb.MaterializedViewMetadata{
 			Name:       viewName,
 			Definition: definition,
 		}
+		if table := e.tables[viewName]; table != nil {
+			materializedView.Triggers = append(materializedView.Triggers, table.Triggers...)
+		}
+		if definition != "" && !strings.HasSuffix(definition, "\n") {
+			materializedView.Definition += "\n"
+		}
+		e.materializedViews[viewName] = materializedView
 		delete(e.tables, viewName)
 		return
 	}
 
-	e.views[viewName] = &storepb.ViewMetadata{
+	view := &storepb.ViewMetadata{
 		Name:       viewName,
 		Definition: definition,
 	}
+	if table := e.tables[viewName]; table != nil {
+		view.Triggers = append(view.Triggers, table.Triggers...)
+		delete(e.tables, viewName)
+	}
+	e.views[viewName] = view
 }
 
 func (e *oracleOmniMetadataExtractor) extractCreateSequence(n *ast.CreateSequenceStmt) {
@@ -522,6 +531,14 @@ func (e *oracleOmniMetadataExtractor) extractCreateTrigger(n *ast.CreateTriggerS
 		Body: e.definitionText(n),
 	}
 	e.triggers[triggerName] = trigger
+	if view := e.views[tableName]; view != nil {
+		view.Triggers = append(view.Triggers, trigger)
+		return
+	}
+	if materializedView := e.materializedViews[tableName]; materializedView != nil {
+		materializedView.Triggers = append(materializedView.Triggers, trigger)
+		return
+	}
 	table := e.getOrCreateTable(tableName)
 	table.Triggers = append(table.Triggers, trigger)
 }

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -1,0 +1,741 @@
+package oracle
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/bytebase/omni/oracle/ast"
+	"github.com/pkg/errors"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	plsqlparser "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
+)
+
+// GetDatabaseMetadataOmni parses Oracle schema DDL text and returns database metadata
+// using the omni parser AST.
+func GetDatabaseMetadataOmni(schemaText string) (*storepb.DatabaseSchemaMetadata, error) {
+	list, err := plsqlparser.ParsePLSQLOmni(schemaText)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to parse Oracle schema")
+	}
+	if list == nil || len(list.Items) == 0 {
+		return nil, errors.New("no parse results")
+	}
+
+	extractor := &oracleOmniMetadataExtractor{
+		tables:            make(map[string]*storepb.TableMetadata),
+		views:             make(map[string]*storepb.ViewMetadata),
+		materializedViews: make(map[string]*storepb.MaterializedViewMetadata),
+		functions:         make(map[string]*storepb.FunctionMetadata),
+		procedures:        make(map[string]*storepb.ProcedureMetadata),
+		triggers:          make(map[string]*storepb.TriggerMetadata),
+		sequences:         make(map[string]*storepb.SequenceMetadata),
+		packages:          make(map[string]*storepb.PackageMetadata),
+		schemaText:        schemaText,
+	}
+
+	for _, item := range list.Items {
+		raw, ok := item.(*ast.RawStmt)
+		if !ok || raw.Stmt == nil {
+			continue
+		}
+		extractor.extractStatement(raw.Stmt)
+	}
+
+	return extractor.databaseMetadata(), nil
+}
+
+type oracleOmniMetadataExtractor struct {
+	currentDatabase   string
+	currentSchema     string
+	tables            map[string]*storepb.TableMetadata
+	views             map[string]*storepb.ViewMetadata
+	materializedViews map[string]*storepb.MaterializedViewMetadata
+	functions         map[string]*storepb.FunctionMetadata
+	procedures        map[string]*storepb.ProcedureMetadata
+	triggers          map[string]*storepb.TriggerMetadata
+	sequences         map[string]*storepb.SequenceMetadata
+	packages          map[string]*storepb.PackageMetadata
+	schemaText        string
+}
+
+func (e *oracleOmniMetadataExtractor) databaseMetadata() *storepb.DatabaseSchemaMetadata {
+	schemaMetadata := &storepb.DatabaseSchemaMetadata{
+		Name:    e.currentDatabase,
+		Schemas: []*storepb.SchemaMetadata{},
+	}
+	schema := &storepb.SchemaMetadata{
+		Name:              e.currentSchema,
+		Tables:            []*storepb.TableMetadata{},
+		Views:             []*storepb.ViewMetadata{},
+		MaterializedViews: []*storepb.MaterializedViewMetadata{},
+		Procedures:        []*storepb.ProcedureMetadata{},
+		Functions:         []*storepb.FunctionMetadata{},
+		Sequences:         []*storepb.SequenceMetadata{},
+		Packages:          []*storepb.PackageMetadata{},
+	}
+
+	var tableNames []string
+	for name := range e.tables {
+		if _, ok := e.materializedViews[name]; !ok {
+			tableNames = append(tableNames, name)
+		}
+	}
+	slices.Sort(tableNames)
+	for _, name := range tableNames {
+		schema.Tables = append(schema.Tables, e.tables[name])
+	}
+
+	var viewNames []string
+	for name := range e.views {
+		viewNames = append(viewNames, name)
+	}
+	slices.Sort(viewNames)
+	for _, name := range viewNames {
+		schema.Views = append(schema.Views, e.views[name])
+	}
+
+	var materializedViewNames []string
+	for name := range e.materializedViews {
+		materializedViewNames = append(materializedViewNames, name)
+	}
+	slices.Sort(materializedViewNames)
+	for _, name := range materializedViewNames {
+		schema.MaterializedViews = append(schema.MaterializedViews, e.materializedViews[name])
+	}
+
+	var functionNames []string
+	for name := range e.functions {
+		functionNames = append(functionNames, name)
+	}
+	slices.Sort(functionNames)
+	for _, name := range functionNames {
+		schema.Functions = append(schema.Functions, e.functions[name])
+	}
+
+	var procedureNames []string
+	for name := range e.procedures {
+		procedureNames = append(procedureNames, name)
+	}
+	slices.Sort(procedureNames)
+	for _, name := range procedureNames {
+		schema.Procedures = append(schema.Procedures, e.procedures[name])
+	}
+
+	var sequenceNames []string
+	for name := range e.sequences {
+		sequenceNames = append(sequenceNames, name)
+	}
+	slices.Sort(sequenceNames)
+	for _, name := range sequenceNames {
+		schema.Sequences = append(schema.Sequences, e.sequences[name])
+	}
+
+	var packageNames []string
+	for name := range e.packages {
+		packageNames = append(packageNames, name)
+	}
+	slices.Sort(packageNames)
+	for _, name := range packageNames {
+		schema.Packages = append(schema.Packages, e.packages[name])
+	}
+
+	schemaMetadata.Schemas = append(schemaMetadata.Schemas, schema)
+	return schemaMetadata
+}
+
+func (e *oracleOmniMetadataExtractor) getOrCreateTable(tableName string) *storepb.TableMetadata {
+	if table, ok := e.tables[tableName]; ok {
+		return table
+	}
+	table := &storepb.TableMetadata{
+		Name:             tableName,
+		Columns:          []*storepb.ColumnMetadata{},
+		Indexes:          []*storepb.IndexMetadata{},
+		ForeignKeys:      []*storepb.ForeignKeyMetadata{},
+		CheckConstraints: []*storepb.CheckConstraintMetadata{},
+		Triggers:         []*storepb.TriggerMetadata{},
+		Partitions:       []*storepb.TablePartitionMetadata{},
+	}
+	e.tables[tableName] = table
+	return table
+}
+
+func (e *oracleOmniMetadataExtractor) extractStatement(stmt ast.StmtNode) {
+	switch n := stmt.(type) {
+	case *ast.CreateTableStmt:
+		e.extractCreateTable(n)
+	case *ast.CreateIndexStmt:
+		e.extractCreateIndex(n)
+	case *ast.CreateViewStmt:
+		e.extractCreateView(n)
+	case *ast.CreateSequenceStmt:
+		e.extractCreateSequence(n)
+	case *ast.CreateProcedureStmt:
+		if name := objectName(n.Name); name != "" {
+			e.procedures[name] = &storepb.ProcedureMetadata{Name: name, Definition: e.definitionText(n)}
+		}
+	case *ast.CreateFunctionStmt:
+		if name := objectName(n.Name); name != "" {
+			e.functions[name] = &storepb.FunctionMetadata{Name: name, Definition: e.functionDefinitionText(n)}
+		}
+	case *ast.CreatePackageStmt:
+		if name := objectName(n.Name); name != "" {
+			e.packages[name] = &storepb.PackageMetadata{Name: name, Definition: e.definitionText(n)}
+		}
+	case *ast.CreateTriggerStmt:
+		e.extractCreateTrigger(n)
+	case *ast.AlterTableStmt:
+		e.extractAlterTable(n)
+	case *ast.CommentStmt:
+		e.extractComment(n)
+	default:
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) extractCreateTable(n *ast.CreateTableStmt) {
+	tableName := objectName(n.Name)
+	if tableName == "" {
+		return
+	}
+	if n.Name.Schema != "" {
+		e.currentSchema = n.Name.Schema
+	}
+
+	table := e.getOrCreateTable(tableName)
+	for _, item := range listItems(n.Columns) {
+		column, ok := item.(*ast.ColumnDef)
+		if !ok {
+			continue
+		}
+		e.extractColumn(column, table)
+	}
+	for _, item := range listItems(n.Constraints) {
+		constraint, ok := item.(*ast.TableConstraint)
+		if !ok {
+			continue
+		}
+		e.extractTableConstraint(constraint, table)
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) extractColumn(n *ast.ColumnDef, table *storepb.TableMetadata) {
+	column := &storepb.ColumnMetadata{
+		Name:     n.Name,
+		Type:     "VARCHAR2(100)",
+		Nullable: true,
+		Position: int32(len(table.Columns) + 1),
+	}
+	if n.TypeName != nil {
+		column.Type = normalizeDataTypeText(e.nodeText(n.TypeName))
+	} else if n.Domain != nil {
+		column.Type = objectName(n.Domain)
+	}
+	if n.Default != nil {
+		column.Default = e.nodeText(n.Default)
+	}
+	column.DefaultOnNull = n.DefaultOnNull
+	if n.Collation != "" {
+		column.Collation = n.Collation
+	}
+	if n.Identity != nil {
+		column.IsIdentity = true
+		column.Nullable = false
+	}
+	if n.NotNull {
+		column.Nullable = false
+	}
+	if n.Null {
+		column.Nullable = true
+	}
+
+	for _, item := range listItems(n.Constraints) {
+		constraint, ok := item.(*ast.ColumnConstraint)
+		if !ok {
+			continue
+		}
+		e.extractColumnConstraint(constraint, table, column)
+	}
+
+	table.Columns = append(table.Columns, column)
+}
+
+func (e *oracleOmniMetadataExtractor) extractColumnConstraint(n *ast.ColumnConstraint, table *storepb.TableMetadata, column *storepb.ColumnMetadata) {
+	switch n.Type {
+	case ast.CONSTRAINT_NOT_NULL:
+		column.Nullable = false
+	case ast.CONSTRAINT_NULL:
+		column.Nullable = true
+	case ast.CONSTRAINT_DEFAULT:
+		if n.Expr != nil {
+			column.Default = e.nodeText(n.Expr)
+		}
+	case ast.CONSTRAINT_PRIMARY:
+		column.Nullable = false
+		if !hasPrimaryIndex(table) {
+			table.Indexes = append(table.Indexes, &storepb.IndexMetadata{
+				Name:         fallbackName(n.Name, fmt.Sprintf("PK_%s", table.Name)),
+				Primary:      true,
+				Unique:       true,
+				Type:         "NORMAL",
+				Expressions:  []string{column.Name},
+				Visible:      true,
+				IsConstraint: true,
+			})
+		}
+	case ast.CONSTRAINT_UNIQUE:
+		name := fallbackName(n.Name, fmt.Sprintf("UK_%s_%s", table.Name, column.Name))
+		if !hasUniqueIndex(table, []string{column.Name}) {
+			table.Indexes = append(table.Indexes, &storepb.IndexMetadata{
+				Name:         name,
+				Unique:       true,
+				Type:         "NORMAL",
+				Expressions:  []string{column.Name},
+				Visible:      true,
+				IsConstraint: true,
+			})
+		}
+	case ast.CONSTRAINT_CHECK:
+		e.appendCheckConstraint(table, n.Name, n.Expr)
+	case ast.CONSTRAINT_FOREIGN:
+		e.appendForeignKey(table, n.Name, []string{column.Name}, n.RefTable, n.RefColumns, n.OnDelete)
+	default:
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) extractTableConstraint(n *ast.TableConstraint, table *storepb.TableMetadata) {
+	columns := stringList(n.Columns)
+	switch n.Type {
+	case ast.CONSTRAINT_PRIMARY:
+		if len(columns) == 0 {
+			return
+		}
+		table.Indexes = append(table.Indexes, &storepb.IndexMetadata{
+			Name:         fallbackName(n.Name, fmt.Sprintf("PK_%s", table.Name)),
+			Primary:      true,
+			Unique:       true,
+			Type:         "NORMAL",
+			Expressions:  columns,
+			Visible:      true,
+			IsConstraint: true,
+		})
+		markColumnsNotNull(table, columns)
+	case ast.CONSTRAINT_UNIQUE:
+		if len(columns) == 0 {
+			return
+		}
+		table.Indexes = append(table.Indexes, &storepb.IndexMetadata{
+			Name:         fallbackName(n.Name, fmt.Sprintf("UK_%s_%d", table.Name, len(table.Indexes)+1)),
+			Unique:       true,
+			Type:         "NORMAL",
+			Expressions:  columns,
+			Visible:      false,
+			IsConstraint: true,
+		})
+	case ast.CONSTRAINT_CHECK:
+		e.appendCheckConstraint(table, fallbackName(n.Name, fmt.Sprintf("CHK_%s_%d", table.Name, len(table.CheckConstraints)+1)), n.Expr)
+	case ast.CONSTRAINT_FOREIGN:
+		e.appendForeignKey(table, fallbackName(n.Name, fmt.Sprintf("FK_%s_%d", table.Name, len(table.ForeignKeys)+1)), columns, n.RefTable, n.RefColumns, n.OnDelete)
+	default:
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) extractAlterTable(n *ast.AlterTableStmt) {
+	tableName := objectName(n.Name)
+	if tableName == "" {
+		return
+	}
+	table := e.getOrCreateTable(tableName)
+	for _, item := range listItems(n.Actions) {
+		action, ok := item.(*ast.AlterTableCmd)
+		if !ok {
+			continue
+		}
+		switch action.Action {
+		case ast.AT_ADD_COLUMN:
+			if action.ColumnDef != nil {
+				e.extractColumn(action.ColumnDef, table)
+			}
+			for _, item := range listItems(action.ColumnDefs) {
+				column, ok := item.(*ast.ColumnDef)
+				if !ok {
+					continue
+				}
+				e.extractColumn(column, table)
+			}
+		case ast.AT_ADD_CONSTRAINT:
+			if action.Constraint != nil {
+				e.extractTableConstraint(action.Constraint, table)
+			}
+		default:
+		}
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) appendCheckConstraint(table *storepb.TableMetadata, name string, expr ast.ExprNode) {
+	if expr == nil {
+		return
+	}
+	table.CheckConstraints = append(table.CheckConstraints, &storepb.CheckConstraintMetadata{
+		Name:       name,
+		Expression: e.exprText(expr),
+	})
+}
+
+func (*oracleOmniMetadataExtractor) appendForeignKey(table *storepb.TableMetadata, name string, columns []string, refTable *ast.ObjectName, refColumns *ast.List, _ string) {
+	referencedTable := objectName(refTable)
+	referencedColumns := stringList(refColumns)
+	if len(columns) == 0 || referencedTable == "" || len(referencedColumns) == 0 {
+		return
+	}
+	foreignKey := &storepb.ForeignKeyMetadata{
+		Name:              name,
+		Columns:           columns,
+		ReferencedTable:   referencedTable,
+		ReferencedColumns: referencedColumns,
+	}
+	table.ForeignKeys = append(table.ForeignKeys, foreignKey)
+}
+
+func (e *oracleOmniMetadataExtractor) extractCreateIndex(n *ast.CreateIndexStmt) {
+	tableName := objectName(n.Table)
+	indexName := objectName(n.Name)
+	if tableName == "" || indexName == "" {
+		return
+	}
+	if n.Name.Schema != "" {
+		e.currentSchema = n.Name.Schema
+	}
+
+	index := &storepb.IndexMetadata{
+		Name:        indexName,
+		Unique:      n.Unique,
+		Type:        "NORMAL",
+		Expressions: []string{},
+		Visible:     true,
+	}
+	if n.Bitmap {
+		index.Type = "BITMAP"
+	}
+
+	isFunctionBased := false
+	for _, item := range listItems(n.Columns) {
+		column, ok := item.(*ast.IndexColumn)
+		if !ok {
+			continue
+		}
+		expression := e.indexExpression(column.Expr)
+		if expression == "" {
+			continue
+		}
+		if _, ok := column.Expr.(*ast.ColumnRef); !ok {
+			isFunctionBased = true
+		}
+		index.Expressions = append(index.Expressions, expression)
+		index.Descending = append(index.Descending, column.Dir == ast.SORTBY_DESC)
+	}
+	for _, desc := range index.Descending {
+		if desc && index.Type == "NORMAL" {
+			index.Type = "FUNCTION-BASED NORMAL"
+			break
+		}
+	}
+	if isFunctionBased && index.Type == "NORMAL" {
+		index.Type = "FUNCTION-BASED NORMAL"
+	}
+
+	table := e.getOrCreateTable(tableName)
+	table.Indexes = append(table.Indexes, index)
+}
+
+func (e *oracleOmniMetadataExtractor) extractCreateView(n *ast.CreateViewStmt) {
+	viewName := objectName(n.Name)
+	if viewName == "" {
+		return
+	}
+	if n.Name.Schema != "" {
+		e.currentSchema = n.Name.Schema
+	}
+
+	definition := e.nodeText(n.Query)
+	if n.Materialized {
+		if definition != "" && !strings.HasSuffix(definition, "\n") {
+			definition += "\n"
+		}
+		e.materializedViews[viewName] = &storepb.MaterializedViewMetadata{
+			Name:       viewName,
+			Definition: definition,
+		}
+		delete(e.tables, viewName)
+		return
+	}
+
+	e.views[viewName] = &storepb.ViewMetadata{
+		Name:       viewName,
+		Definition: definition,
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) extractCreateSequence(n *ast.CreateSequenceStmt) {
+	sequenceName := objectName(n.Name)
+	if sequenceName == "" {
+		return
+	}
+	sequence := &storepb.SequenceMetadata{Name: sequenceName}
+	if start := e.nodeText(n.StartWith); start != "" {
+		sequence.Start = start
+	}
+	if increment := e.nodeText(n.IncrementBy); increment != "" && increment != "1" {
+		sequence.Increment = increment
+	}
+	e.sequences[sequenceName] = sequence
+}
+
+func (e *oracleOmniMetadataExtractor) extractCreateTrigger(n *ast.CreateTriggerStmt) {
+	triggerName := objectName(n.Name)
+	tableName := objectName(n.Table)
+	if triggerName == "" || tableName == "" {
+		return
+	}
+	trigger := &storepb.TriggerMetadata{
+		Name: triggerName,
+		Body: e.definitionText(n),
+	}
+	e.triggers[triggerName] = trigger
+	table := e.getOrCreateTable(tableName)
+	table.Triggers = append(table.Triggers, trigger)
+}
+
+func (e *oracleOmniMetadataExtractor) extractComment(n *ast.CommentStmt) {
+	if n.Column != "" {
+		table := e.tables[objectName(n.Object)]
+		if table == nil {
+			return
+		}
+		for _, column := range table.Columns {
+			if column.Name == n.Column {
+				column.Comment = n.Comment
+				return
+			}
+		}
+		return
+	}
+
+	switch n.ObjectType {
+	case ast.OBJECT_TABLE:
+		if table := e.tables[objectName(n.Object)]; table != nil {
+			table.Comment = n.Comment
+		}
+	default:
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) indexExpression(expr ast.ExprNode) string {
+	switch n := expr.(type) {
+	case *ast.ColumnRef:
+		return n.Column
+	default:
+		return e.nodeText(expr)
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) exprText(expr ast.ExprNode) string {
+	switch n := expr.(type) {
+	case *ast.BinaryExpr:
+		return e.exprText(n.Left) + n.Op + e.exprText(n.Right)
+	case *ast.BoolExpr:
+		var parts []string
+		for _, item := range listItems(n.Args) {
+			expr, ok := item.(ast.ExprNode)
+			if !ok {
+				continue
+			}
+			parts = append(parts, e.exprText(expr))
+		}
+		switch n.Boolop {
+		case ast.BOOL_AND:
+			return strings.Join(parts, "AND")
+		case ast.BOOL_OR:
+			return strings.Join(parts, "OR")
+		case ast.BOOL_NOT:
+			return "NOT" + strings.Join(parts, "")
+		default:
+			return strings.Join(parts, "")
+		}
+	case *ast.ColumnRef:
+		if n.Table != "" {
+			return n.Table + "." + n.Column
+		}
+		return n.Column
+	case *ast.InExpr:
+		operator := "IN"
+		if n.Not {
+			operator = "NOTIN"
+		}
+		return e.exprText(n.Expr) + operator + "(" + strings.Join(e.exprListText(n.List), ",") + ")"
+	case *ast.BetweenExpr:
+		operator := "BETWEEN"
+		if n.Not {
+			operator = "NOTBETWEEN"
+		}
+		return e.exprText(n.Expr) + operator + e.exprText(n.Low) + "AND" + e.exprText(n.High)
+	case *ast.LikeExpr:
+		operator := "LIKE"
+		if n.Not {
+			operator = "NOTLIKE"
+		}
+		result := e.exprText(n.Expr) + operator + e.exprText(n.Pattern)
+		if n.Escape != nil {
+			result += "ESCAPE" + e.exprText(n.Escape)
+		}
+		return result
+	case *ast.IsExpr:
+		operator := "IS"
+		if n.Not {
+			operator = "ISNOT"
+		}
+		return e.exprText(n.Expr) + operator + n.Test
+	case *ast.ParenExpr:
+		return "(" + e.exprText(n.Expr) + ")"
+	case *ast.StringLiteral:
+		prefix := ""
+		if n.IsNChar {
+			prefix = "N"
+		}
+		return prefix + "'" + n.Val + "'"
+	case *ast.NumberLiteral:
+		return n.Val
+	case *ast.NullLiteral:
+		return "NULL"
+	case *ast.FuncCallExpr:
+		return objectName(n.FuncName) + "(" + strings.Join(e.exprListText(n.Args), ",") + ")"
+	default:
+		return strings.ReplaceAll(e.nodeText(expr), " ", "")
+	}
+}
+
+func (e *oracleOmniMetadataExtractor) exprListText(list *ast.List) []string {
+	var result []string
+	for _, item := range listItems(list) {
+		expr, ok := item.(ast.ExprNode)
+		if !ok {
+			continue
+		}
+		result = append(result, e.exprText(expr))
+	}
+	return result
+}
+
+func (e *oracleOmniMetadataExtractor) functionDefinitionText(node ast.Node) string {
+	definition := e.definitionText(node)
+	upper := strings.ToUpper(definition)
+	if strings.HasPrefix(upper, "CREATE OR REPLACE ") {
+		definition = definition[len("CREATE OR REPLACE "):]
+	} else if strings.HasPrefix(upper, "CREATE ") {
+		definition = definition[len("CREATE "):]
+	}
+	if definition != "" && !strings.HasPrefix(strings.ToUpper(definition), "FUNCTION") {
+		definition = "FUNCTION " + definition
+	}
+	return definition
+}
+
+func (e *oracleOmniMetadataExtractor) definitionText(node ast.Node) string {
+	loc := ast.NodeLoc(node)
+	if loc.Start < 0 || loc.End < 0 || loc.Start > loc.End || loc.End > len(e.schemaText) {
+		return ""
+	}
+	end := loc.End
+	for end < len(e.schemaText) {
+		switch e.schemaText[end] {
+		case ' ', '\t', '\r', '\n':
+			end++
+		default:
+			if e.schemaText[end] == ';' {
+				end++
+			}
+			return strings.TrimSpace(e.schemaText[loc.Start:end])
+		}
+	}
+	return strings.TrimSpace(e.schemaText[loc.Start:end])
+}
+
+func (e *oracleOmniMetadataExtractor) nodeText(node ast.Node) string {
+	loc := ast.NodeLoc(node)
+	if loc.Start < 0 || loc.End < 0 || loc.Start > loc.End || loc.End > len(e.schemaText) {
+		return ""
+	}
+	return e.schemaText[loc.Start:loc.End]
+}
+
+func objectName(name *ast.ObjectName) string {
+	if name == nil {
+		return ""
+	}
+	return name.Name
+}
+
+func listItems(list *ast.List) []ast.Node {
+	if list == nil {
+		return nil
+	}
+	return list.Items
+}
+
+func stringList(list *ast.List) []string {
+	var result []string
+	for _, item := range listItems(list) {
+		switch n := item.(type) {
+		case *ast.String:
+			result = append(result, n.Str)
+		case *ast.ColumnRef:
+			result = append(result, n.Column)
+		default:
+		}
+	}
+	return result
+}
+
+func fallbackName(name, fallback string) string {
+	if name != "" {
+		return name
+	}
+	return fallback
+}
+
+func hasPrimaryIndex(table *storepb.TableMetadata) bool {
+	for _, index := range table.Indexes {
+		if index.Primary {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUniqueIndex(table *storepb.TableMetadata, columns []string) bool {
+	for _, index := range table.Indexes {
+		if !index.Unique || index.Primary || len(index.Expressions) != len(columns) {
+			continue
+		}
+		matches := true
+		for i, column := range columns {
+			if index.Expressions[i] != column {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
+}
+
+func markColumnsNotNull(table *storepb.TableMetadata, columns []string) {
+	for _, column := range table.Columns {
+		if slices.Contains(columns, column.Name) {
+			column.Nullable = false
+		}
+	}
+}

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -256,6 +256,12 @@ func (e *oracleOmniMetadataExtractor) extractColumn(n *ast.ColumnDef, table *sto
 	if n.Default != nil {
 		column.Default = e.nodeText(n.Default)
 	}
+	if n.Virtual != nil {
+		if n.TypeName == nil && n.Domain == nil {
+			column.Type = "NUMBER"
+		}
+		column.Default = e.exprText(n.Virtual)
+	}
 	column.DefaultOnNull = n.DefaultOnNull
 	if n.Collation != "" {
 		column.Collation = n.Collation

--- a/backend/plugin/schema/oracle/get_database_metadata_omni.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni.go
@@ -61,6 +61,8 @@ type oracleOmniMetadataExtractor struct {
 }
 
 func (e *oracleOmniMetadataExtractor) databaseMetadata() *storepb.DatabaseSchemaMetadata {
+	e.resolveForeignKeyReferencedColumns()
+
 	schemaMetadata := &storepb.DatabaseSchemaMetadata{
 		Name:    e.currentDatabase,
 		Schemas: []*storepb.SchemaMetadata{},
@@ -297,9 +299,9 @@ func (e *oracleOmniMetadataExtractor) extractColumnConstraint(n *ast.ColumnConst
 			})
 		}
 	case ast.CONSTRAINT_CHECK:
-		e.appendCheckConstraint(table, n.Name, n.Expr)
+		e.appendCheckConstraint(table, fallbackName(n.Name, fmt.Sprintf("CHK_%s_%s", table.Name, column.Name)), n.Expr)
 	case ast.CONSTRAINT_FOREIGN:
-		e.appendForeignKey(table, n.Name, []string{column.Name}, n.RefTable, n.RefColumns, n.OnDelete)
+		e.appendForeignKey(table, fallbackName(n.Name, fmt.Sprintf("FK_%s_%s", table.Name, column.Name)), []string{column.Name}, n.RefTable, n.RefColumns, n.OnDelete)
 	default:
 	}
 }
@@ -386,7 +388,7 @@ func (e *oracleOmniMetadataExtractor) appendCheckConstraint(table *storepb.Table
 func (*oracleOmniMetadataExtractor) appendForeignKey(table *storepb.TableMetadata, name string, columns []string, refTable *ast.ObjectName, refColumns *ast.List, _ string) {
 	referencedTable := objectName(refTable)
 	referencedColumns := stringList(refColumns)
-	if len(columns) == 0 || referencedTable == "" || len(referencedColumns) == 0 {
+	if len(columns) == 0 || referencedTable == "" {
 		return
 	}
 	foreignKey := &storepb.ForeignKeyMetadata{
@@ -396,6 +398,23 @@ func (*oracleOmniMetadataExtractor) appendForeignKey(table *storepb.TableMetadat
 		ReferencedColumns: referencedColumns,
 	}
 	table.ForeignKeys = append(table.ForeignKeys, foreignKey)
+}
+
+func (e *oracleOmniMetadataExtractor) resolveForeignKeyReferencedColumns() {
+	for _, table := range e.tables {
+		var foreignKeys []*storepb.ForeignKeyMetadata
+		for _, foreignKey := range table.ForeignKeys {
+			if len(foreignKey.ReferencedColumns) == 0 {
+				referencedTable := e.tables[foreignKey.ReferencedTable]
+				foreignKey.ReferencedColumns = primaryKeyColumns(referencedTable)
+			}
+			if len(foreignKey.ReferencedColumns) == 0 {
+				continue
+			}
+			foreignKeys = append(foreignKeys, foreignKey)
+		}
+		table.ForeignKeys = foreignKeys
+	}
 }
 
 func (e *oracleOmniMetadataExtractor) extractCreateIndex(n *ast.CreateIndexStmt) {
@@ -711,6 +730,18 @@ func hasPrimaryIndex(table *storepb.TableMetadata) bool {
 		}
 	}
 	return false
+}
+
+func primaryKeyColumns(table *storepb.TableMetadata) []string {
+	if table == nil {
+		return nil
+	}
+	for _, index := range table.Indexes {
+		if index.Primary {
+			return append([]string(nil), index.Expressions...)
+		}
+	}
+	return nil
 }
 
 func hasUniqueIndex(table *storepb.TableMetadata, columns []string) bool {

--- a/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
@@ -98,6 +98,58 @@ SELECT EMP_ID, EMAIL FROM EMPLOYEES;
 			},
 		},
 		{
+			name: "comments_on_views_and_materialized_views",
+			ddl: `
+CREATE TABLE PRODUCT_SALES (
+    PRODUCT_ID NUMBER NOT NULL,
+    CATEGORY VARCHAR2(50) NOT NULL,
+    SALES_AMOUNT NUMBER(12,2) NOT NULL
+);
+
+CREATE VIEW PRODUCT_SALES_VIEW AS
+SELECT PRODUCT_ID, CATEGORY, SALES_AMOUNT
+FROM PRODUCT_SALES;
+
+CREATE MATERIALIZED VIEW PRODUCT_SALES_MV
+BUILD IMMEDIATE
+REFRESH COMPLETE ON DEMAND
+AS
+SELECT PRODUCT_ID, CATEGORY, SUM(SALES_AMOUNT) AS TOTAL_REVENUE
+FROM PRODUCT_SALES
+GROUP BY PRODUCT_ID, CATEGORY;
+
+COMMENT ON VIEW PRODUCT_SALES_VIEW IS 'Product sales view';
+COMMENT ON MATERIALIZED VIEW PRODUCT_SALES_MV IS 'Product sales materialized view';
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				schemaMetadata := requireSingleSchema(t, metadata)
+				require.Equal(t, "Product sales view", requireView(t, schemaMetadata, "PRODUCT_SALES_VIEW").Comment)
+				require.Len(t, schemaMetadata.MaterializedViews, 1)
+				require.Equal(t, "PRODUCT_SALES_MV", schemaMetadata.MaterializedViews[0].Name)
+				require.Equal(t, "Product sales materialized view", schemaMetadata.MaterializedViews[0].Comment)
+			},
+		},
+		{
+			name: "index_visibility_and_function_based_bitmap",
+			ddl: `
+CREATE TABLE ORDERS (
+    ID NUMBER PRIMARY KEY,
+    STATUS VARCHAR2(20)
+);
+
+CREATE INDEX idx_orders_status_invisible ON ORDERS(STATUS) INVISIBLE;
+CREATE BITMAP INDEX idx_orders_lower_status ON ORDERS(LOWER(STATUS));
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				orders := requireTable(t, requireSingleSchema(t, metadata), "ORDERS")
+				invisibleIndex := requireIndexMetadata(t, orders, "IDX_ORDERS_STATUS_INVISIBLE")
+				require.False(t, invisibleIndex.Visible)
+				functionBasedBitmapIndex := requireIndexMetadata(t, orders, "IDX_ORDERS_LOWER_STATUS")
+				require.Equal(t, "FUNCTION-BASED BITMAP", functionBasedBitmapIndex.Type)
+				require.True(t, functionBasedBitmapIndex.Visible)
+			},
+		},
+		{
 			name: "instead_of_trigger_on_view",
 			ddl: `
 CREATE TABLE EMPLOYEES (
@@ -360,16 +412,21 @@ func findTable(schemaMetadata *storepb.SchemaMetadata, name string) *storepb.Tab
 
 func requireIndex(t *testing.T, table *storepb.TableMetadata, name string, expressions []string, primary bool, unique bool) {
 	t.Helper()
+	index := requireIndexMetadata(t, table, name)
+	require.Equal(t, expressions, index.Expressions)
+	require.Equal(t, primary, index.Primary)
+	require.Equal(t, unique, index.Unique)
+}
+
+func requireIndexMetadata(t *testing.T, table *storepb.TableMetadata, name string) *storepb.IndexMetadata {
+	t.Helper()
 	for _, index := range table.Indexes {
-		if index.Name != name {
-			continue
+		if index.Name == name {
+			return index
 		}
-		require.Equal(t, expressions, index.Expressions)
-		require.Equal(t, primary, index.Primary)
-		require.Equal(t, unique, index.Unique)
-		return
 	}
 	t.Fatalf("index %q not found in table %q", name, table.Name)
+	return nil
 }
 
 func requireMaterializedViewIndex(t *testing.T, materializedView *storepb.MaterializedViewMetadata, name string, expressions []string, primary bool, unique bool) {

--- a/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
@@ -77,6 +77,34 @@ CREATE SEQUENCE emp_seq START WITH 1 INCREMENT BY 1;
 			},
 		},
 		{
+			name: "instead_of_trigger_on_view",
+			ddl: `
+CREATE TABLE EMPLOYEES (
+    EMP_ID NUMBER PRIMARY KEY,
+    EMAIL VARCHAR2(100)
+);
+
+CREATE VIEW EMPLOYEE_VIEW AS
+SELECT EMP_ID, EMAIL
+FROM EMPLOYEES;
+
+CREATE OR REPLACE TRIGGER employee_view_insert_trg
+INSTEAD OF INSERT ON EMPLOYEE_VIEW
+FOR EACH ROW
+BEGIN
+    NULL;
+END;
+/
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				schemaMetadata := requireSingleSchema(t, metadata)
+				view := requireView(t, schemaMetadata, "EMPLOYEE_VIEW")
+				require.Len(t, view.Triggers, 1)
+				require.Equal(t, "EMPLOYEE_VIEW_INSERT_TRG", view.Triggers[0].Name)
+				require.Nil(t, findTable(schemaMetadata, "EMPLOYEE_VIEW"))
+			},
+		},
+		{
 			name: "materialized_view_with_index",
 			ddl: `
 CREATE TABLE PRODUCT_SALES (
@@ -274,6 +302,17 @@ func requireTable(t *testing.T, schemaMetadata *storepb.SchemaMetadata, name str
 	table := findTable(schemaMetadata, name)
 	require.NotNil(t, table)
 	return table
+}
+
+func requireView(t *testing.T, schemaMetadata *storepb.SchemaMetadata, name string) *storepb.ViewMetadata {
+	t.Helper()
+	for _, view := range schemaMetadata.Views {
+		if view.Name == name {
+			return view
+		}
+	}
+	t.Fatalf("view %q not found", name)
+	return nil
 }
 
 func findTable(schemaMetadata *storepb.SchemaMetadata, name string) *storepb.TableMetadata {

--- a/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
@@ -274,6 +274,23 @@ CREATE TABLE EMPLOYEES (
 			},
 		},
 		{
+			name: "virtual_column",
+			ddl: `
+CREATE TABLE ORDER_ITEMS (
+    QTY NUMBER,
+    PRICE NUMBER,
+    TOTAL AS (QTY * PRICE)
+);
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				orderItems := requireTable(t, requireSingleSchema(t, metadata), "ORDER_ITEMS")
+				require.Len(t, orderItems.Columns, 3)
+				require.Equal(t, "TOTAL", orderItems.Columns[2].Name)
+				require.Equal(t, "NUMBER", orderItems.Columns[2].Type)
+				require.Equal(t, "QTY*PRICE", orderItems.Columns[2].Default)
+			},
+		},
+		{
 			name: "default_on_null_column",
 			ddl: `
 CREATE TABLE ORDERS (

--- a/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
@@ -291,6 +291,22 @@ CREATE TABLE ORDER_ITEMS (
 			},
 		},
 		{
+			name: "escaped_string_literals_in_expressions",
+			ddl: `
+CREATE TABLE AUTHORS (
+    NAME VARCHAR2(100),
+    IS_REILLY AS (CASE WHEN NAME = 'O''Reilly' THEN 1 ELSE 0 END),
+    CONSTRAINT chk_author_name CHECK (NAME <> 'O''Reilly')
+);
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				authors := requireTable(t, requireSingleSchema(t, metadata), "AUTHORS")
+				require.Len(t, authors.Columns, 2)
+				require.Equal(t, "CASEWHENNAME='O''Reilly'THEN1ELSE0END", authors.Columns[1].Default)
+				requireCheckConstraint(t, authors, "CHK_AUTHOR_NAME", "NAME<>'O''Reilly'")
+			},
+		},
+		{
 			name: "default_on_null_column",
 			ddl: `
 CREATE TABLE ORDERS (

--- a/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
@@ -129,6 +129,7 @@ CREATE INDEX idx_mv_category ON PRODUCT_SALES_MV(CATEGORY);
 				require.Len(t, schemaMetadata.MaterializedViews, 1)
 				require.Equal(t, "PRODUCT_SALES_MV", schemaMetadata.MaterializedViews[0].Name)
 				require.Contains(t, schemaMetadata.MaterializedViews[0].Definition, "SUM(SALES_AMOUNT)")
+				requireMaterializedViewIndex(t, schemaMetadata.MaterializedViews[0], "IDX_MV_CATEGORY", []string{"CATEGORY"}, false, false)
 				require.Nil(t, findTable(schemaMetadata, "PRODUCT_SALES_MV"))
 			},
 		},
@@ -218,7 +219,16 @@ CREATE TABLE ORDERS (
 			name: "package_metadata",
 			ddl: `
 CREATE OR REPLACE PACKAGE financial_utils AS
+    c_default_currency CONSTANT VARCHAR2(3) := 'USD';
     FUNCTION format_currency(p_amount NUMBER) RETURN VARCHAR2;
+END financial_utils;
+/
+
+CREATE OR REPLACE PACKAGE BODY financial_utils AS
+    FUNCTION format_currency(p_amount NUMBER) RETURN VARCHAR2 IS
+    BEGIN
+        RETURN TO_CHAR(p_amount, 'FM9999990.00');
+    END format_currency;
 END financial_utils;
 /
 `,
@@ -226,7 +236,10 @@ END financial_utils;
 				schemaMetadata := requireSingleSchema(t, metadata)
 				require.Len(t, schemaMetadata.Packages, 1)
 				require.Equal(t, "FINANCIAL_UTILS", schemaMetadata.Packages[0].Name)
+				require.Contains(t, schemaMetadata.Packages[0].Definition, "c_default_currency")
 				require.Contains(t, schemaMetadata.Packages[0].Definition, "FUNCTION format_currency")
+				require.Contains(t, schemaMetadata.Packages[0].Definition, "PACKAGE BODY financial_utils")
+				require.Contains(t, schemaMetadata.Packages[0].Definition, "RETURN TO_CHAR")
 			},
 		},
 	}
@@ -336,6 +349,20 @@ func requireIndex(t *testing.T, table *storepb.TableMetadata, name string, expre
 		return
 	}
 	t.Fatalf("index %q not found in table %q", name, table.Name)
+}
+
+func requireMaterializedViewIndex(t *testing.T, materializedView *storepb.MaterializedViewMetadata, name string, expressions []string, primary bool, unique bool) {
+	t.Helper()
+	for _, index := range materializedView.Indexes {
+		if index.Name != name {
+			continue
+		}
+		require.Equal(t, expressions, index.Expressions)
+		require.Equal(t, primary, index.Primary)
+		require.Equal(t, unique, index.Unique)
+		return
+	}
+	t.Fatalf("index %q not found in materialized view %q", name, materializedView.Name)
 }
 
 func requireCheckConstraint(t *testing.T, table *storepb.TableMetadata, name string, expression string) {

--- a/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
@@ -77,6 +77,27 @@ CREATE SEQUENCE emp_seq START WITH 1 INCREMENT BY 1;
 			},
 		},
 		{
+			name: "create_schema_wrapper",
+			ddl: `
+CREATE SCHEMA AUTHORIZATION HR
+CREATE TABLE EMPLOYEES (
+    EMP_ID NUMBER PRIMARY KEY,
+    EMAIL VARCHAR2(100)
+)
+CREATE VIEW EMPLOYEE_VIEW AS
+SELECT EMP_ID, EMAIL FROM EMPLOYEES;
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				schemaMetadata := requireSingleSchema(t, metadata)
+				require.Equal(t, "HR", schemaMetadata.Name)
+				employees := requireTable(t, schemaMetadata, "EMPLOYEES")
+				require.Len(t, employees.Columns, 2)
+				requireIndex(t, employees, "PK_EMPLOYEES", []string{"EMP_ID"}, true, true)
+				view := requireView(t, schemaMetadata, "EMPLOYEE_VIEW")
+				require.Contains(t, view.Definition, "SELECT EMP_ID, EMAIL FROM EMPLOYEES")
+			},
+		},
+		{
 			name: "instead_of_trigger_on_view",
 			ddl: `
 CREATE TABLE EMPLOYEES (

--- a/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
@@ -65,7 +65,7 @@ CREATE SEQUENCE emp_seq START WITH 1 INCREMENT BY 1;
 				requireIndex(t, employees, "UK_EMPLOYEES_EMAIL", []string{"EMAIL"}, false, true)
 				requireIndex(t, employees, "IDX_EMP_DEPT", []string{"DEPT_ID"}, false, false)
 				requireCheckConstraint(t, employees, "CHK_SALARY", "SALARY>=0")
-				requireForeignKey(t, employees, "FK_EMP_DEPT", []string{"DEPT_ID"}, "DEPARTMENTS", []string{"DEPT_ID"}, "")
+				requireForeignKey(t, employees, "FK_EMP_DEPT", []string{"DEPT_ID"}, "DEPARTMENTS", []string{"DEPT_ID"})
 
 				require.Len(t, schemaMetadata.Views, 1)
 				require.Equal(t, "ACTIVE_EMPLOYEES", schemaMetadata.Views[0].Name)
@@ -122,7 +122,7 @@ ALTER TABLE DEPARTMENTS ADD CONSTRAINT fk_dept_manager
 			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
 				schemaMetadata := requireSingleSchema(t, metadata)
 				departments := requireTable(t, schemaMetadata, "DEPARTMENTS")
-				requireForeignKey(t, departments, "FK_DEPT_MANAGER", []string{"MANAGER_ID"}, "EMPLOYEES", []string{"EMP_ID"}, "")
+				requireForeignKey(t, departments, "FK_DEPT_MANAGER", []string{"MANAGER_ID"}, "EMPLOYEES", []string{"EMP_ID"})
 			},
 		},
 		{
@@ -146,6 +146,28 @@ ALTER TABLE EMPLOYEES ADD (
 				require.Equal(t, "STATUS", employees.Columns[2].Name)
 				require.Equal(t, "VARCHAR2(20 BYTE)", employees.Columns[2].Type)
 				require.Equal(t, "'ACTIVE'", employees.Columns[2].Default)
+			},
+		},
+		{
+			name: "inline_constraints_and_omitted_reference_columns",
+			ddl: `
+CREATE TABLE DEPARTMENTS (
+    DEPT_ID NUMBER PRIMARY KEY
+);
+
+CREATE TABLE EMPLOYEES (
+    EMP_ID NUMBER PRIMARY KEY,
+    SALARY NUMBER CHECK (SALARY > 0),
+    DEPT_ID NUMBER REFERENCES DEPARTMENTS,
+    MANAGER_DEPT_ID NUMBER,
+    CONSTRAINT fk_manager_dept FOREIGN KEY (MANAGER_DEPT_ID) REFERENCES DEPARTMENTS
+);
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				employees := requireTable(t, requireSingleSchema(t, metadata), "EMPLOYEES")
+				requireCheckConstraint(t, employees, "CHK_EMPLOYEES_SALARY", "SALARY>0")
+				requireForeignKey(t, employees, "FK_EMPLOYEES_DEPT_ID", []string{"DEPT_ID"}, "DEPARTMENTS", []string{"DEPT_ID"})
+				requireForeignKey(t, employees, "FK_MANAGER_DEPT", []string{"MANAGER_DEPT_ID"}, "DEPARTMENTS", []string{"DEPT_ID"})
 			},
 		},
 		{
@@ -289,7 +311,7 @@ func requireCheckConstraint(t *testing.T, table *storepb.TableMetadata, name str
 	t.Fatalf("check constraint %q not found in table %q", name, table.Name)
 }
 
-func requireForeignKey(t *testing.T, table *storepb.TableMetadata, name string, columns []string, referencedTable string, referencedColumns []string, onDelete string) {
+func requireForeignKey(t *testing.T, table *storepb.TableMetadata, name string, columns []string, referencedTable string, referencedColumns []string) {
 	t.Helper()
 	for _, fk := range table.ForeignKeys {
 		if fk.Name != name {
@@ -298,7 +320,7 @@ func requireForeignKey(t *testing.T, table *storepb.TableMetadata, name string, 
 		require.Equal(t, columns, fk.Columns)
 		require.Equal(t, referencedTable, fk.ReferencedTable)
 		require.Equal(t, referencedColumns, fk.ReferencedColumns)
-		require.Equal(t, onDelete, fk.OnDelete)
+		require.Empty(t, fk.OnDelete)
 		return
 	}
 	t.Fatalf("foreign key %q not found in table %q", name, table.Name)

--- a/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
@@ -259,7 +259,7 @@ CREATE TABLE DEPARTMENTS (
 
 CREATE TABLE EMPLOYEES (
     EMP_ID NUMBER PRIMARY KEY,
-    SALARY NUMBER CHECK (SALARY > 0),
+    SALARY NUMBER CHECK (SALARY > 0) CHECK (SALARY < 1000000),
     DEPT_ID NUMBER REFERENCES DEPARTMENTS,
     MANAGER_DEPT_ID NUMBER,
     CONSTRAINT fk_manager_dept FOREIGN KEY (MANAGER_DEPT_ID) REFERENCES DEPARTMENTS
@@ -268,6 +268,7 @@ CREATE TABLE EMPLOYEES (
 			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
 				employees := requireTable(t, requireSingleSchema(t, metadata), "EMPLOYEES")
 				requireCheckConstraint(t, employees, "CHK_EMPLOYEES_SALARY", "SALARY>0")
+				requireCheckConstraint(t, employees, "CHK_EMPLOYEES_SALARY_2", "SALARY<1000000")
 				requireForeignKey(t, employees, "FK_EMPLOYEES_DEPT_ID", []string{"DEPT_ID"}, "DEPARTMENTS", []string{"DEPT_ID"})
 				requireForeignKey(t, employees, "FK_MANAGER_DEPT", []string{"MANAGER_DEPT_ID"}, "DEPARTMENTS", []string{"DEPT_ID"})
 			},

--- a/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_omni_test.go
@@ -1,0 +1,355 @@
+package oracle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+)
+
+func TestGetDatabaseMetadataOmni(t *testing.T) {
+	tests := []struct {
+		name   string
+		ddl    string
+		verify func(*testing.T, *storepb.DatabaseSchemaMetadata)
+	}{
+		{
+			name: "table_constraints_indexes_view_sequence",
+			ddl: `
+CREATE TABLE DEPARTMENTS (
+    DEPT_ID NUMBER PRIMARY KEY,
+    DEPT_NAME VARCHAR2(100) NOT NULL UNIQUE,
+    MANAGER_ID NUMBER,
+    CONSTRAINT chk_dept_name CHECK (DEPT_NAME IS NOT NULL)
+);
+
+CREATE TABLE EMPLOYEES (
+    EMP_ID NUMBER,
+    DEPT_ID NUMBER,
+    EMAIL VARCHAR2(100) UNIQUE,
+    SALARY NUMBER(10,2) DEFAULT 0,
+    CONSTRAINT pk_employees PRIMARY KEY (EMP_ID),
+    CONSTRAINT fk_emp_dept FOREIGN KEY (DEPT_ID) REFERENCES DEPARTMENTS(DEPT_ID) ON DELETE SET NULL,
+    CONSTRAINT chk_salary CHECK (SALARY >= 0)
+);
+
+CREATE INDEX idx_emp_dept ON EMPLOYEES(DEPT_ID);
+
+CREATE VIEW ACTIVE_EMPLOYEES AS
+SELECT EMP_ID, DEPT_ID, EMAIL
+FROM EMPLOYEES
+WHERE EMAIL IS NOT NULL;
+
+CREATE SEQUENCE emp_seq START WITH 1 INCREMENT BY 1;
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				schemaMetadata := requireSingleSchema(t, metadata)
+
+				departments := requireTable(t, schemaMetadata, "DEPARTMENTS")
+				require.Len(t, departments.Columns, 3)
+				require.Equal(t, "NUMBER", departments.Columns[0].Type)
+				require.False(t, departments.Columns[0].Nullable)
+				require.Equal(t, "VARCHAR2(100 BYTE)", departments.Columns[1].Type)
+				require.False(t, departments.Columns[1].Nullable)
+				requireIndex(t, departments, "PK_DEPARTMENTS", []string{"DEPT_ID"}, true, true)
+				requireIndex(t, departments, "UK_DEPARTMENTS_DEPT_NAME", []string{"DEPT_NAME"}, false, true)
+				requireCheckConstraint(t, departments, "CHK_DEPT_NAME", "DEPT_NAMEISNOTNULL")
+
+				employees := requireTable(t, schemaMetadata, "EMPLOYEES")
+				require.Len(t, employees.Columns, 4)
+				require.Equal(t, "0", employees.Columns[3].Default)
+				requireIndex(t, employees, "PK_EMPLOYEES", []string{"EMP_ID"}, true, true)
+				requireIndex(t, employees, "UK_EMPLOYEES_EMAIL", []string{"EMAIL"}, false, true)
+				requireIndex(t, employees, "IDX_EMP_DEPT", []string{"DEPT_ID"}, false, false)
+				requireCheckConstraint(t, employees, "CHK_SALARY", "SALARY>=0")
+				requireForeignKey(t, employees, "FK_EMP_DEPT", []string{"DEPT_ID"}, "DEPARTMENTS", []string{"DEPT_ID"}, "")
+
+				require.Len(t, schemaMetadata.Views, 1)
+				require.Equal(t, "ACTIVE_EMPLOYEES", schemaMetadata.Views[0].Name)
+				require.Contains(t, schemaMetadata.Views[0].Definition, "SELECT EMP_ID, DEPT_ID, EMAIL")
+
+				require.Len(t, schemaMetadata.Sequences, 1)
+				require.Equal(t, "EMP_SEQ", schemaMetadata.Sequences[0].Name)
+				require.Equal(t, "1", schemaMetadata.Sequences[0].Start)
+			},
+		},
+		{
+			name: "materialized_view_with_index",
+			ddl: `
+CREATE TABLE PRODUCT_SALES (
+    PRODUCT_ID NUMBER NOT NULL,
+    CATEGORY VARCHAR2(50) NOT NULL,
+    SALES_AMOUNT NUMBER(12,2) NOT NULL
+);
+
+CREATE MATERIALIZED VIEW PRODUCT_SALES_MV
+BUILD IMMEDIATE
+REFRESH COMPLETE ON DEMAND
+AS
+SELECT PRODUCT_ID, CATEGORY, SUM(SALES_AMOUNT) AS TOTAL_REVENUE
+FROM PRODUCT_SALES
+GROUP BY PRODUCT_ID, CATEGORY;
+
+CREATE INDEX idx_mv_category ON PRODUCT_SALES_MV(CATEGORY);
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				schemaMetadata := requireSingleSchema(t, metadata)
+				requireTable(t, schemaMetadata, "PRODUCT_SALES")
+				require.Len(t, schemaMetadata.MaterializedViews, 1)
+				require.Equal(t, "PRODUCT_SALES_MV", schemaMetadata.MaterializedViews[0].Name)
+				require.Contains(t, schemaMetadata.MaterializedViews[0].Definition, "SUM(SALES_AMOUNT)")
+				require.Nil(t, findTable(schemaMetadata, "PRODUCT_SALES_MV"))
+			},
+		},
+		{
+			name: "alter_table_add_foreign_key",
+			ddl: `
+CREATE TABLE DEPARTMENTS (
+    DEPT_ID NUMBER PRIMARY KEY,
+    MANAGER_ID NUMBER
+);
+
+CREATE TABLE EMPLOYEES (
+    EMP_ID NUMBER PRIMARY KEY
+);
+
+ALTER TABLE DEPARTMENTS ADD CONSTRAINT fk_dept_manager
+    FOREIGN KEY (MANAGER_ID) REFERENCES EMPLOYEES(EMP_ID) ON DELETE SET NULL;
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				schemaMetadata := requireSingleSchema(t, metadata)
+				departments := requireTable(t, schemaMetadata, "DEPARTMENTS")
+				requireForeignKey(t, departments, "FK_DEPT_MANAGER", []string{"MANAGER_ID"}, "EMPLOYEES", []string{"EMP_ID"}, "")
+			},
+		},
+		{
+			name: "alter_table_add_column",
+			ddl: `
+CREATE TABLE EMPLOYEES (
+    EMP_ID NUMBER PRIMARY KEY
+);
+
+ALTER TABLE EMPLOYEES ADD (
+    EMAIL VARCHAR2(100) NOT NULL,
+    STATUS VARCHAR2(20) DEFAULT 'ACTIVE'
+);
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				employees := requireTable(t, requireSingleSchema(t, metadata), "EMPLOYEES")
+				require.Len(t, employees.Columns, 3)
+				require.Equal(t, "EMAIL", employees.Columns[1].Name)
+				require.Equal(t, "VARCHAR2(100 BYTE)", employees.Columns[1].Type)
+				require.False(t, employees.Columns[1].Nullable)
+				require.Equal(t, "STATUS", employees.Columns[2].Name)
+				require.Equal(t, "VARCHAR2(20 BYTE)", employees.Columns[2].Type)
+				require.Equal(t, "'ACTIVE'", employees.Columns[2].Default)
+			},
+		},
+		{
+			name: "default_on_null_column",
+			ddl: `
+CREATE TABLE ORDERS (
+    ID NUMBER PRIMARY KEY,
+    STATUS VARCHAR2(20) DEFAULT ON NULL 'PENDING'
+);
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				orders := requireTable(t, requireSingleSchema(t, metadata), "ORDERS")
+				require.Len(t, orders.Columns, 2)
+				require.Equal(t, "STATUS", orders.Columns[1].Name)
+				require.Equal(t, "'PENDING'", orders.Columns[1].Default)
+				require.True(t, orders.Columns[1].DefaultOnNull)
+			},
+		},
+		{
+			name: "package_metadata",
+			ddl: `
+CREATE OR REPLACE PACKAGE financial_utils AS
+    FUNCTION format_currency(p_amount NUMBER) RETURN VARCHAR2;
+END financial_utils;
+/
+`,
+			verify: func(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) {
+				schemaMetadata := requireSingleSchema(t, metadata)
+				require.Len(t, schemaMetadata.Packages, 1)
+				require.Equal(t, "FINANCIAL_UTILS", schemaMetadata.Packages[0].Name)
+				require.Contains(t, schemaMetadata.Packages[0].Definition, "FUNCTION format_currency")
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			metadata, err := GetDatabaseMetadataOmni(tc.ddl)
+			require.NoError(t, err)
+			tc.verify(t, metadata)
+		})
+	}
+}
+
+func TestGetDatabaseMetadataOmniParityWithANTLR(t *testing.T) {
+	for _, tc := range oracleMetadataTestCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			expected, err := getDatabaseMetadataANTLR(tc.ddl)
+			require.NoError(t, err)
+
+			actual, err := GetDatabaseMetadataOmni(tc.ddl)
+			require.NoError(t, err)
+
+			actualForANTLR, ok := proto.Clone(actual).(*storepb.DatabaseSchemaMetadata)
+			require.True(t, ok)
+			trimOmniOnlyConstraintMetadata(expected, actualForANTLR)
+			compareMetadata(t, expected, actualForANTLR, tc.name)
+		})
+	}
+}
+
+func TestGetDatabaseMetadataUsesOmni(t *testing.T) {
+	metadata, err := schema.GetDatabaseMetadata(storepb.Engine_ORACLE, `
+CREATE TABLE T (
+    ID NUMBER PRIMARY KEY
+);
+`)
+	require.NoError(t, err)
+
+	table := requireTable(t, requireSingleSchema(t, metadata), "T")
+	require.Len(t, table.Columns, 1)
+	requireIndex(t, table, "PK_T", []string{"ID"}, true, true)
+}
+
+func TestGetDatabaseMetadataOmniParsesSlashTerminatedPLSQLScript(t *testing.T) {
+	metadata, err := GetDatabaseMetadataOmni(`
+CREATE TABLE AUDIT_LOG (
+    LOG_ID NUMBER PRIMARY KEY
+);
+
+CREATE OR REPLACE TRIGGER audit_log_trigger
+    BEFORE INSERT ON AUDIT_LOG
+    FOR EACH ROW
+BEGIN
+    NULL;
+END;
+/
+`)
+	require.NoError(t, err)
+
+	table := requireTable(t, requireSingleSchema(t, metadata), "AUDIT_LOG")
+	require.Len(t, table.Columns, 1)
+	requireIndex(t, table, "PK_AUDIT_LOG", []string{"LOG_ID"}, true, true)
+}
+
+func requireSingleSchema(t *testing.T, metadata *storepb.DatabaseSchemaMetadata) *storepb.SchemaMetadata {
+	t.Helper()
+	require.Len(t, metadata.Schemas, 1)
+	return metadata.Schemas[0]
+}
+
+func requireTable(t *testing.T, schemaMetadata *storepb.SchemaMetadata, name string) *storepb.TableMetadata {
+	t.Helper()
+	table := findTable(schemaMetadata, name)
+	require.NotNil(t, table)
+	return table
+}
+
+func findTable(schemaMetadata *storepb.SchemaMetadata, name string) *storepb.TableMetadata {
+	for _, table := range schemaMetadata.Tables {
+		if table.Name == name {
+			return table
+		}
+	}
+	return nil
+}
+
+func requireIndex(t *testing.T, table *storepb.TableMetadata, name string, expressions []string, primary bool, unique bool) {
+	t.Helper()
+	for _, index := range table.Indexes {
+		if index.Name != name {
+			continue
+		}
+		require.Equal(t, expressions, index.Expressions)
+		require.Equal(t, primary, index.Primary)
+		require.Equal(t, unique, index.Unique)
+		return
+	}
+	t.Fatalf("index %q not found in table %q", name, table.Name)
+}
+
+func requireCheckConstraint(t *testing.T, table *storepb.TableMetadata, name string, expression string) {
+	t.Helper()
+	for _, check := range table.CheckConstraints {
+		if check.Name != name {
+			continue
+		}
+		require.Equal(t, expression, check.Expression)
+		return
+	}
+	t.Fatalf("check constraint %q not found in table %q", name, table.Name)
+}
+
+func requireForeignKey(t *testing.T, table *storepb.TableMetadata, name string, columns []string, referencedTable string, referencedColumns []string, onDelete string) {
+	t.Helper()
+	for _, fk := range table.ForeignKeys {
+		if fk.Name != name {
+			continue
+		}
+		require.Equal(t, columns, fk.Columns)
+		require.Equal(t, referencedTable, fk.ReferencedTable)
+		require.Equal(t, referencedColumns, fk.ReferencedColumns)
+		require.Equal(t, onDelete, fk.OnDelete)
+		return
+	}
+	t.Fatalf("foreign key %q not found in table %q", name, table.Name)
+}
+
+func trimOmniOnlyConstraintMetadata(expected *storepb.DatabaseSchemaMetadata, actual *storepb.DatabaseSchemaMetadata) {
+	if len(expected.Schemas) != 1 || len(actual.Schemas) != 1 {
+		return
+	}
+
+	expectedTableByName := make(map[string]*storepb.TableMetadata)
+	for _, table := range expected.Schemas[0].Tables {
+		expectedTableByName[table.Name] = table
+	}
+
+	for _, actualTable := range actual.Schemas[0].Tables {
+		expectedTable, ok := expectedTableByName[actualTable.Name]
+		if !ok {
+			continue
+		}
+		actualTable.ForeignKeys = filterForeignKeysByExpected(actualTable.ForeignKeys, expectedTable.ForeignKeys)
+		actualTable.CheckConstraints = filterCheckConstraintsByExpected(actualTable.CheckConstraints, expectedTable.CheckConstraints)
+	}
+}
+
+func filterForeignKeysByExpected(actual []*storepb.ForeignKeyMetadata, expected []*storepb.ForeignKeyMetadata) []*storepb.ForeignKeyMetadata {
+	expectedName := make(map[string]bool)
+	for _, foreignKey := range expected {
+		expectedName[foreignKey.Name] = true
+	}
+
+	var filtered []*storepb.ForeignKeyMetadata
+	for _, foreignKey := range actual {
+		if expectedName[foreignKey.Name] {
+			filtered = append(filtered, foreignKey)
+		}
+	}
+	return filtered
+}
+
+func filterCheckConstraintsByExpected(actual []*storepb.CheckConstraintMetadata, expected []*storepb.CheckConstraintMetadata) []*storepb.CheckConstraintMetadata {
+	expectedName := make(map[string]bool)
+	for _, checkConstraint := range expected {
+		expectedName[checkConstraint.Name] = true
+	}
+
+	var filtered []*storepb.CheckConstraintMetadata
+	for _, checkConstraint := range actual {
+		if expectedName[checkConstraint.Name] {
+			filtered = append(filtered, checkConstraint)
+		}
+	}
+	return filtered
+}

--- a/backend/plugin/schema/oracle/get_database_metadata_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_test.go
@@ -1295,9 +1295,20 @@ func compareMaterializedViews(t *testing.T, dbMViews, parsedMViews []*storepb.Ma
 		require.Equal(t, dbMV.Name, parsedMV.Name, "materialized view names should match")
 		require.NotEmpty(t, parsedMV.Definition, "parsed materialized view definition should not be empty")
 		require.NotEmpty(t, dbMV.Definition, "database materialized view definition should not be empty")
+		if dbMV.Comment != "" || parsedMV.Comment != "" {
+			if parsedMV.Comment == "" && isOracleAutoMaterializedViewComment(dbMV.Comment) {
+				t.Logf("Info: materialized view %s has Oracle-generated comment %q", mvName, dbMV.Comment)
+				continue
+			}
+			require.Equal(t, dbMV.Comment, parsedMV.Comment, "materialized view comments should match for %s", mvName)
+		}
 
 		t.Logf("✓ Materialized View %s: definition length=%d", mvName, len(parsedMV.Definition))
 	}
+}
+
+func isOracleAutoMaterializedViewComment(comment string) bool {
+	return strings.HasPrefix(comment, "snapshot table for snapshot ")
 }
 
 // compareSequences compares sequence metadata

--- a/backend/plugin/schema/oracle/get_database_metadata_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_test.go
@@ -14,28 +14,13 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/db"
 )
 
-// TestGetDatabaseMetadataWithTestcontainer tests the get_database_metadata function
-// by comparing its output with the metadata retrieved from a real Oracle instance.
-//
-//nolint:tparallel
-func TestGetDatabaseMetadataWithTestcontainer(t *testing.T) {
-	ctx := context.Background()
+type oracleMetadataTestCase struct {
+	name string
+	ddl  string
+}
 
-	// Start Oracle container
-	container := testcontainer.GetTestOracleContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-
-	host := container.GetHost()
-	port := container.GetPort()
-
-	// Get SYSTEM database connection for user management
-	systemDB := container.GetDB()
-
-	// Test cases with various Oracle features
-	testCases := []struct {
-		name string
-		ddl  string
-	}{
+func oracleMetadataTestCases() []oracleMetadataTestCase {
+	return []oracleMetadataTestCase{
 		{
 			name: "basic_table",
 			ddl: `
@@ -750,8 +735,26 @@ COMMENT ON COLUMN ORDER_LINE_ITEMS.FULFILLMENT_STATUS IS 'Status: PENDING, PICKE
 `,
 		},
 	}
+}
 
-	for _, tc := range testCases {
+// TestGetDatabaseMetadataWithTestcontainer tests the get_database_metadata function
+// by comparing its output with the metadata retrieved from a real Oracle instance.
+//
+//nolint:tparallel
+func TestGetDatabaseMetadataWithTestcontainer(t *testing.T) {
+	ctx := context.Background()
+
+	// Start Oracle container
+	container := testcontainer.GetTestOracleContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	host := container.GetHost()
+	port := container.GetPort()
+
+	// Get SYSTEM database connection for user management
+	systemDB := container.GetDB()
+
+	for _, tc := range oracleMetadataTestCases() {
 		tc := tc // Capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260529052918-83e6917d2454
+	github.com/bytebase/omni v0.0.0-20260529083135-9af8f51ae75e
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260529052918-83e6917d2454 h1:ZYXm0m5nrQ8hKdQnPEGkV1oDU1HiXjujVmPyjdMFO2I=
-github.com/bytebase/omni v0.0.0-20260529052918-83e6917d2454/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260529083135-9af8f51ae75e h1:Ucb4G4VEjHoyPByA/z4TioDr4y78hZxSMFZtzQslw8k=
+github.com/bytebase/omni v0.0.0-20260529083135-9af8f51ae75e/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Switch Oracle schema metadata extraction to the omni AST path without ANTLR fallback in the production entrypoint.
- Add an omni-based extractor for Oracle tables, columns, constraints, indexes, views, materialized views, sequences, routines, packages, triggers, comments, and ALTER TABLE additions.
- Reuse the existing Oracle metadata corpus to validate omni parity against the previous ANTLR extractor and live Oracle metadata.

## Test Plan
- [x] `go test ./backend/plugin/parser/plsql ./backend/plugin/schema/oracle -count=1`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Notes
- Pre-PR checklist reviewed: no API, DB migration, proto, frontend, store, or composite-PK query changes.
