### PR TITLE
fix(frontend): refresh workspace logo without manual reload (BYT-9589)

### DIFF
--- a/frontend/src/react/components/ProjectSidebar.tsx
+++ b/frontend/src/react/components/ProjectSidebar.tsx
@@ -13,6 +13,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { effectScope } from "vue";
 import logoFull from "@/assets/logo-full.svg";
+import { useWorkspace } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { router } from "@/router";
 import {
@@ -35,11 +36,7 @@ import {
   PROJECT_V1_ROUTE_WORKLOAD_IDENTITIES,
 } from "@/router/dashboard/projectV1";
 import { useRecentVisit } from "@/router/useRecentVisit";
-import {
-  useActuatorV1Store,
-  useProjectV1Store,
-  useWorkspaceV1Store,
-} from "@/store";
+import { useActuatorV1Store, useProjectV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 
 // ---------------------------------------------------------------------------
@@ -251,9 +248,7 @@ export function ProjectSidebar() {
       (router.currentRoute.value.params.projectId as string | undefined) ?? ""
   );
 
-  const customLogo = useVueState(
-    () => useWorkspaceV1Store().currentWorkspace?.logo ?? ""
-  );
+  const customLogo = useWorkspace()?.logo ?? "";
 
   const projectStore = useProjectV1Store();
 

--- a/frontend/src/react/components/WorkspaceSwitcher.tsx
+++ b/frontend/src/react/components/WorkspaceSwitcher.tsx
@@ -6,14 +6,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/react/components/ui/dropdown-menu";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useWorkspaceV1Store } from "@/store";
+import { useWorkspace, useWorkspaceList } from "@/react/hooks/useAppState";
+import { useAppStore } from "@/react/stores/app";
 
 export function WorkspaceSwitcher() {
-  const workspaceStore = useWorkspaceV1Store();
-
-  const workspaceList = useVueState(() => workspaceStore.workspaceList);
-  const currentWorkspace = useVueState(() => workspaceStore.currentWorkspace);
+  const workspaceList = useWorkspaceList();
+  const currentWorkspace = useWorkspace();
+  const switchWorkspace = useAppStore((state) => state.switchWorkspace);
   const currentWorkspaceName = currentWorkspace?.name ?? "";
 
   const [open, setOpen] = useState(false);
@@ -25,7 +24,7 @@ export function WorkspaceSwitcher() {
   const onSwitch = (workspaceName: string) => {
     if (workspaceName === currentWorkspaceName) return;
     setOpen(false);
-    workspaceStore.switchWorkspace(workspaceName);
+    switchWorkspace(workspaceName);
   };
 
   return (

--- a/frontend/src/react/pages/auth/ProfileSetupPage.tsx
+++ b/frontend/src/react/pages/auth/ProfileSetupPage.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { UserAvatar } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
-import { useCurrentUser } from "@/react/hooks/useAppState";
+import { useCurrentUser, useWorkspace } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
@@ -18,8 +18,9 @@ export function ProfileSetupPage() {
   const { t } = useTranslation();
   const currentUser = useCurrentUser();
   const updateUser = useAppStore((state) => state.updateUser);
+  const updateWorkspace = useAppStore((state) => state.updateWorkspace);
   const workspaceStore = useWorkspaceV1Store();
-  const workspace = useVueState(() => workspaceStore.currentWorkspace);
+  const workspace = useWorkspace();
   const workspacePolicy = useVueState(() => workspaceStore.workspaceIamPolicy);
 
   // Show workspace name field only if the user is the sole member of the
@@ -64,7 +65,7 @@ export function ProfileSetupPage() {
         })
       );
       if (canRenameWorkspace && workspaceTitle.trim() && workspace?.name) {
-        await workspaceStore.updateWorkspace(
+        await updateWorkspace(
           create(WorkspaceSchema, {
             name: workspace.name,
             title: workspaceTitle.trim(),

--- a/frontend/src/react/pages/settings/general/BrandingSection.tsx
+++ b/frontend/src/react/pages/settings/general/BrandingSection.tsx
@@ -17,9 +17,9 @@ import {
 } from "@/react/components/PermissionGuard";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
-import { usePlanFeature } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
-import { pushNotification, useWorkspaceV1Store } from "@/store";
+import { usePlanFeature, useWorkspace } from "@/react/hooks/useAppState";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification } from "@/store";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import { WorkspaceSchema } from "@/types/proto-es/v1/workspace_service_pb";
 import type { SectionHandle } from "./useSettingSection";
@@ -43,9 +43,8 @@ const convertFileToBase64 = (file: File): Promise<string> =>
 export const BrandingSection = forwardRef<SectionHandle, BrandingSectionProps>(
   function BrandingSection({ title, onDirtyChange }, ref) {
     const { t } = useTranslation();
-    const workspaceStore = useWorkspaceV1Store();
-
-    const workspace = useVueState(() => workspaceStore.currentWorkspace);
+    const workspace = useWorkspace();
+    const updateWorkspace = useAppStore((state) => state.updateWorkspace);
     const hasBrandingFeature = usePlanFeature(PlanFeature.FEATURE_CUSTOM_LOGO);
 
     const [canEdit] = usePermissionCheck(["bb.workspaces.update"]);
@@ -92,11 +91,11 @@ export const BrandingSection = forwardRef<SectionHandle, BrandingSectionProps>(
           updateMasks.push("logo");
         }
 
-        await workspaceStore.updateWorkspace(ws, updateMasks);
+        await updateWorkspace(ws, updateMasks);
       } finally {
         setLoading(false);
       }
-    }, [loading, workspace, localTitle, logoUrl, workspaceStore]);
+    }, [loading, workspace, localTitle, logoUrl, updateWorkspace]);
 
     // Re-sync state when workspace loads asynchronously, only if not dirty
     useEffect(() => {

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -50,6 +50,7 @@ import {
   UserSchema,
 } from "@/types/proto-es/v1/user_service_pb";
 import { WorkloadIdentitySchema } from "@/types/proto-es/v1/workload_identity_service_pb";
+import { WorkspaceSchema } from "@/types/proto-es/v1/workspace_service_pb";
 import {
   storageKeyIntroState,
   storageKeyRecentProjects,
@@ -75,6 +76,7 @@ const mocks = vi.hoisted(() => ({
   logout: vi.fn(),
   getActuatorInfo: vi.fn(),
   getWorkspace: vi.fn(),
+  updateWorkspace: vi.fn(),
   getIamPolicy: vi.fn(),
   listRoles: vi.fn(),
   updateRole: vi.fn(),
@@ -264,6 +266,7 @@ vi.mock("@/connect", () => ({
   },
   workspaceServiceClientConnect: {
     getWorkspace: mocks.getWorkspace,
+    updateWorkspace: mocks.updateWorkspace,
     getIamPolicy: mocks.getIamPolicy,
   },
 }));
@@ -625,6 +628,47 @@ describe("useAppStore", () => {
     );
 
     expect(store.getState().currentUser).toBe(updated);
+  });
+
+  test("updateWorkspace refreshes the current workspace and list entry", async () => {
+    const existing = createProto(WorkspaceSchema, {
+      name: "workspaces/default",
+      title: "Old",
+      logo: "old-logo",
+    });
+    const updated = createProto(WorkspaceSchema, {
+      name: "workspaces/default",
+      title: "Old",
+      logo: "new-logo",
+    });
+    mocks.updateWorkspace.mockResolvedValue(updated);
+    const store = createAppStore();
+    store.setState({ workspace: existing, workspaceList: [existing] });
+
+    const result = await store.getState().updateWorkspace(updated, ["logo"]);
+
+    expect(result).toBe(updated);
+    expect(store.getState().workspace).toBe(updated);
+    expect(store.getState().workspaceList[0]).toBe(updated);
+  });
+
+  test("updateWorkspace leaves workspace untouched when a different workspace is active", async () => {
+    const active = createProto(WorkspaceSchema, {
+      name: "workspaces/other",
+      title: "Other",
+    });
+    const updated = createProto(WorkspaceSchema, {
+      name: "workspaces/default",
+      title: "Default",
+      logo: "new-logo",
+    });
+    mocks.updateWorkspace.mockResolvedValue(updated);
+    const store = createAppStore();
+    store.setState({ workspace: active, workspaceList: [active] });
+
+    await store.getState().updateWorkspace(updated, ["logo"]);
+
+    expect(store.getState().workspace).toBe(active);
   });
 
   test("create archive and restore update activated user count when server info is loaded", async () => {

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -135,6 +135,10 @@ export type WorkspaceSlice = {
   refreshServerInfo: () => Promise<ActuatorInfo | undefined>;
   loadWorkspace: () => Promise<Workspace | undefined>;
   loadWorkspaceList: () => Promise<Workspace[]>;
+  updateWorkspace: (
+    workspace: Workspace,
+    updateMask: string[]
+  ) => Promise<Workspace>;
   switchWorkspace: (workspaceName: string) => Promise<void>;
   loadWorkspaceProfile: (
     force?: boolean

--- a/frontend/src/react/stores/app/workspace.ts
+++ b/frontend/src/react/stores/app/workspace.ts
@@ -1,4 +1,5 @@
 import { create as createProto } from "@bufbuild/protobuf";
+import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import dayjs from "dayjs";
 import semver from "semver";
 import {
@@ -40,6 +41,10 @@ import {
   PlanType,
   UploadLicenseRequestSchema,
 } from "@/types/proto-es/v1/subscription_service_pb";
+import {
+  UpdateWorkspaceRequestSchema,
+  type Workspace,
+} from "@/types/proto-es/v1/workspace_service_pb";
 import {
   getDateForPbTimestampProtoEs,
   getTimeForPbTimestampProtoEs,
@@ -202,6 +207,23 @@ export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
     const resp = await workspaceServiceClientConnect.listWorkspaces({});
     set({ workspaceList: resp.workspaces });
     return resp.workspaces;
+  },
+
+  updateWorkspace: async (workspace: Workspace, updateMask: string[]) => {
+    const updated = await workspaceServiceClientConnect.updateWorkspace(
+      createProto(UpdateWorkspaceRequestSchema, {
+        workspace,
+        updateMask: createProto(FieldMaskSchema, { paths: updateMask }),
+      })
+    );
+    set((state) => ({
+      workspace:
+        state.workspace?.name === updated.name ? updated : state.workspace,
+      workspaceList: state.workspaceList.map((ws) =>
+        ws.name === updated.name ? updated : ws
+      ),
+    }));
+    return updated;
   },
 
   switchWorkspace: async (workspaceName: string) => {


### PR DESCRIPTION
## Summary

Fixes BYT-9589: after updating the workspace logo (or title) in Settings → General, the header logo did not change until a manual page reload.

**Root cause — dual source of truth for `workspace`:**
- `BytebaseLogo` (header) reads the workspace from the React app store (`useWorkspace()` → `useAppStore`).
- The logo/title write path went through the parallel Pinia `useWorkspaceV1Store.updateWorkspace()`, which only updated Pinia's `currentWorkspace`.
- The app store's `workspace` was never updated, and `loadWorkspace()` has a cache guard (`existing?.name === name`) so it wouldn't re-fetch — only a hard reload (fresh store) refreshed the logo.

**Fix (app store as source of truth, mirrors #20436 current-user migration):**
- Add an `updateWorkspace(workspace, updateMask)` action to the app store workspace slice that calls gRPC and updates `workspace` + `workspaceList`.
- Migrate the workspace write + changeable-field readers to the app store:
  - `BrandingSection` — read via `useWorkspace()`, write via app store `updateWorkspace`
  - `ProfileSetupPage` — write via app store `updateWorkspace`
  - `ProjectSidebar` — logo via `useWorkspace()`
  - `WorkspaceSwitcher` — current/list/switch via app store

## Test plan
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend test src/react/stores/app/index.test.ts` (added `updateWorkspace` coverage; 52 pass)
- [ ] Manual: update the workspace logo in Settings → General and confirm the header logo (and project sidebar logo) refresh immediately without a page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)