### PR TITLE
fix(auth): allow hosted MCP client OAuth callbacks in dynamic client registration

### DIFF
--- a/backend/api/oauth2/oauth2.go
+++ b/backend/api/oauth2/oauth2.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v5"
@@ -181,11 +182,43 @@ func isAllowedDynamicClientRedirectURI(uri string) bool {
 
 	switch parsed.Scheme {
 	case "http", "https":
-		return isLocalhostURI(uri)
+		return isLocalhostURI(uri) || isAllowedHostedRedirectURI(parsed)
 	case "cursor", "vscode", "vscode-insiders":
 		return true
 	case "jetbrains":
 		return parsed.Host == "gateway" && parsed.Path != "" && parsed.Path != "/"
+	default:
+		return false
+	}
+}
+
+// isAllowedHostedRedirectURI whitelists the fixed, vendor-controlled OAuth
+// callback URLs used by popular hosted MCP clients (web/desktop apps that
+// connect to remote MCP servers). These serve the same role as the cursor://,
+// vscode://, and jetbrains://gateway/... schemes above. Each entry is pinned to
+// an exact host (plus an exact or prefix path) so an attacker still cannot
+// register an arbitrary https:// redirect URI and exfiltrate authorization
+// codes.
+func isAllowedHostedRedirectURI(u *url.URL) bool {
+	if u.Scheme != "https" {
+		return false
+	}
+	// Hosts are case-insensitive (RFC 3986) and may carry an explicit default
+	// port; normalize via Hostname()+ToLower so the exact-match cases below hold.
+	// Paths stay case-sensitive and are matched verbatim.
+	switch strings.ToLower(u.Hostname()) {
+	case "claude.ai":
+		// Claude.ai web, Claude Desktop, mobile, and Cowork.
+		return u.Path == "/api/mcp/auth_callback"
+	case "chatgpt.com":
+		// ChatGPT connectors: per-connector path (current) and legacy fixed path.
+		return strings.HasPrefix(u.Path, "/connector/oauth/") || u.Path == "/connector_platform_oauth_redirect"
+	case "vscode.dev", "insiders.vscode.dev":
+		// VS Code for the Web (complements the vscode:// scheme above).
+		return u.Path == "/redirect"
+	case "antigravity.google":
+		// Google Antigravity.
+		return u.Path == "/oauth-callback"
 	default:
 		return false
 	}

--- a/backend/api/oauth2/oauth2.go
+++ b/backend/api/oauth2/oauth2.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"path"
 	"slices"
 	"strings"
 	"time"
@@ -206,6 +207,13 @@ func isAllowedHostedRedirectURI(u *url.URL) bool {
 	// Only the default https port is the real vendor callback; reject any other
 	// port so a code can't be steered to a non-OAuth service on the vendor host.
 	if port := u.Port(); port != "" && port != "443" {
+		return false
+	}
+	// Reject "."/".." path segments (u.Path is already percent-decoded, so this
+	// also covers %2e%2e). Otherwise a prefix match like /connector/oauth/../evil
+	// passes here, but the browser normalizes it and delivers the code to a
+	// different path on the vendor host than the pinned callback.
+	if u.Path != path.Clean(u.Path) {
 		return false
 	}
 	// Hosts are case-insensitive (RFC 3986); normalize via Hostname()+ToLower so

--- a/backend/api/oauth2/oauth2.go
+++ b/backend/api/oauth2/oauth2.go
@@ -203,9 +203,13 @@ func isAllowedHostedRedirectURI(u *url.URL) bool {
 	if u.Scheme != "https" {
 		return false
 	}
-	// Hosts are case-insensitive (RFC 3986) and may carry an explicit default
-	// port; normalize via Hostname()+ToLower so the exact-match cases below hold.
-	// Paths stay case-sensitive and are matched verbatim.
+	// Only the default https port is the real vendor callback; reject any other
+	// port so a code can't be steered to a non-OAuth service on the vendor host.
+	if port := u.Port(); port != "" && port != "443" {
+		return false
+	}
+	// Hosts are case-insensitive (RFC 3986); normalize via Hostname()+ToLower so
+	// the exact-match cases below hold. Paths stay case-sensitive (matched verbatim).
 	switch strings.ToLower(u.Hostname()) {
 	case "claude.ai":
 		// Claude.ai web, Claude Desktop, mobile, and Cowork.

--- a/backend/api/oauth2/oauth2_test.go
+++ b/backend/api/oauth2/oauth2_test.go
@@ -41,6 +41,9 @@ func TestIsAllowedDynamicClientRedirectURI(t *testing.T) {
 		{name: "chatgpt connector prefix", uri: "https://chatgpt.com/connector/oauth/abc123", want: true},
 		{name: "chatgpt legacy exact", uri: "https://chatgpt.com/connector_platform_oauth_redirect", want: true},
 		{name: "chatgpt wrong path", uri: "https://chatgpt.com/evil", want: false},
+		{name: "chatgpt dot-segment traversal", uri: "https://chatgpt.com/connector/oauth/../evil", want: false},
+		{name: "chatgpt encoded traversal", uri: "https://chatgpt.com/connector/oauth/%2e%2e/evil", want: false},
+		{name: "chatgpt empty connector id", uri: "https://chatgpt.com/connector/oauth/", want: false},
 
 		// VS Code for the Web.
 		{name: "vscode.dev redirect", uri: "https://vscode.dev/redirect", want: true},

--- a/backend/api/oauth2/oauth2_test.go
+++ b/backend/api/oauth2/oauth2_test.go
@@ -29,9 +29,11 @@ func TestIsAllowedDynamicClientRedirectURI(t *testing.T) {
 		{name: "claude.ai wrong path", uri: "https://claude.ai/evil", want: false},
 		{name: "claude.ai over http", uri: "http://claude.ai/api/mcp/auth_callback", want: false},
 		{name: "claude.ai subdomain spoof", uri: "https://claude.ai.evil.com/api/mcp/auth_callback", want: false},
-		// Host should match case-insensitively and ignore the default port.
+		// Host should match case-insensitively and allow only the default https port.
 		{name: "claude.ai uppercase host", uri: "https://CLAUDE.AI/api/mcp/auth_callback", want: true},
-		{name: "claude.ai explicit port", uri: "https://claude.ai:443/api/mcp/auth_callback", want: true},
+		{name: "claude.ai explicit port 443", uri: "https://claude.ai:443/api/mcp/auth_callback", want: true},
+		{name: "claude.ai non-default port", uri: "https://claude.ai:8443/api/mcp/auth_callback", want: false},
+		{name: "chatgpt non-default port", uri: "https://chatgpt.com:444/connector/oauth/x", want: false},
 		// Userinfo spoof must resolve to the real (non-allowlisted) host and be rejected.
 		{name: "claude.ai userinfo spoof", uri: "https://claude.ai@evil.com/api/mcp/auth_callback", want: false},
 

--- a/backend/api/oauth2/oauth2_test.go
+++ b/backend/api/oauth2/oauth2_test.go
@@ -1,0 +1,64 @@
+package oauth2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsAllowedDynamicClientRedirectURI(t *testing.T) {
+	testCases := []struct {
+		name string
+		uri  string
+		want bool
+	}{
+		// Localhost (loopback) callbacks — covers Claude Code, Gemini CLI, etc.
+		{name: "localhost http", uri: "http://localhost:8080/callback", want: true},
+		{name: "127.0.0.1 http", uri: "http://127.0.0.1:53682/callback", want: true},
+		{name: "localhost https", uri: "https://localhost/callback", want: true},
+
+		// Native app custom schemes already supported.
+		{name: "cursor scheme", uri: "cursor://anysphere.cursor-mcp/oauth/callback", want: true},
+		{name: "vscode scheme", uri: "vscode://anysphere.cursor/callback", want: true},
+		{name: "vscode-insiders scheme", uri: "vscode-insiders://foo/callback", want: true},
+		{name: "jetbrains gateway", uri: "jetbrains://gateway/auth/callback", want: true},
+		{name: "jetbrains no path", uri: "jetbrains://gateway", want: false},
+
+		// Hosted MCP client callbacks — Claude (web, Desktop, mobile, Cowork).
+		{name: "claude.ai exact", uri: "https://claude.ai/api/mcp/auth_callback", want: true},
+		{name: "claude.ai wrong path", uri: "https://claude.ai/evil", want: false},
+		{name: "claude.ai over http", uri: "http://claude.ai/api/mcp/auth_callback", want: false},
+		{name: "claude.ai subdomain spoof", uri: "https://claude.ai.evil.com/api/mcp/auth_callback", want: false},
+		// Host should match case-insensitively and ignore the default port.
+		{name: "claude.ai uppercase host", uri: "https://CLAUDE.AI/api/mcp/auth_callback", want: true},
+		{name: "claude.ai explicit port", uri: "https://claude.ai:443/api/mcp/auth_callback", want: true},
+		// Userinfo spoof must resolve to the real (non-allowlisted) host and be rejected.
+		{name: "claude.ai userinfo spoof", uri: "https://claude.ai@evil.com/api/mcp/auth_callback", want: false},
+
+		// ChatGPT connectors — current per-connector path + legacy fixed path.
+		{name: "chatgpt connector prefix", uri: "https://chatgpt.com/connector/oauth/abc123", want: true},
+		{name: "chatgpt legacy exact", uri: "https://chatgpt.com/connector_platform_oauth_redirect", want: true},
+		{name: "chatgpt wrong path", uri: "https://chatgpt.com/evil", want: false},
+
+		// VS Code for the Web.
+		{name: "vscode.dev redirect", uri: "https://vscode.dev/redirect", want: true},
+		{name: "insiders.vscode.dev redirect", uri: "https://insiders.vscode.dev/redirect", want: true},
+		{name: "vscode.dev wrong path", uri: "https://vscode.dev/evil", want: false},
+
+		// Antigravity.
+		{name: "antigravity callback", uri: "https://antigravity.google/oauth-callback", want: true},
+		{name: "antigravity wrong path", uri: "https://antigravity.google/evil", want: false},
+
+		// Arbitrary HTTPS / HTTP must stay rejected (the #20033 protection).
+		{name: "arbitrary https", uri: "https://evil.com/callback", want: false},
+		{name: "non-localhost http", uri: "http://evil.com/callback", want: false},
+		{name: "unknown scheme", uri: "ftp://example.com/callback", want: false},
+		{name: "malformed", uri: "://nonsense", want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isAllowedDynamicClientRedirectURI(tc.uri))
+		})
+	}
+}

--- a/backend/api/oauth2/register.go
+++ b/backend/api/oauth2/register.go
@@ -67,7 +67,7 @@ func (s *Service) handleRegister(c *echo.Context) error {
 			return oauth2Error(c, http.StatusBadRequest, "invalid_redirect_uri", "redirect URI is too long")
 		}
 		if !isAllowedDynamicClientRedirectURI(uri) {
-			return oauth2Error(c, http.StatusBadRequest, "invalid_redirect_uri", "redirect URI must be a localhost URL or a whitelisted app scheme (cursor://, vscode://, vscode-insiders://, jetbrains://gateway/...)")
+			return oauth2Error(c, http.StatusBadRequest, "invalid_redirect_uri", "redirect URI must be a localhost URL, a recognized hosted MCP client callback (e.g. claude.ai, chatgpt.com), or a whitelisted app scheme (cursor://, vscode://, vscode-insiders://, jetbrains://gateway/...)")
 		}
 	}
 


### PR DESCRIPTION
## What

Self-hosted instances reject the **claude.ai web connector** (and other hosted MCP clients) during RFC 7591 Dynamic Client Registration with `400 invalid_redirect_uri`.

[PR #20033](https://github.com/bytebase/bytebase/pull/20033) tightened the DCR redirect-URI allowlist so `https://` is only accepted for localhost. That correctly closed an open-redirect/token-exfiltration hole for *arbitrary* `https://` URIs — but it also broke the **fixed, vendor-controlled** hosted callbacks (claude.ai, etc.) that worked before, with no on-instance workaround short of forking or downgrading.

This extends `isAllowedDynamicClientRedirectURI` to also accept a small set of **host-pinned** hosted callbacks. Each is matched on exact host (+ exact or prefix path), so #20033's protection against arbitrary `https://` redirects still holds — an attacker still cannot register `https://evil.com` or a `claude.ai.evil.com` lookalike.

| Client | Host | Path |
|---|---|---|
| Claude (web / Desktop / mobile / Cowork) | `claude.ai` | exact `/api/mcp/auth_callback` |
| ChatGPT connectors | `chatgpt.com` | prefix `/connector/oauth/` **or** exact `/connector_platform_oauth_redirect` |
| VS Code for the Web | `vscode.dev`, `insiders.vscode.dev` | exact `/redirect` |
| Google Antigravity | `antigravity.google` | exact `/oauth-callback` |

Host matching now uses `strings.ToLower(u.Hostname())`, consistent with `isLocalhostURI` (case-insensitive, port-agnostic).

## Why

A self-hosted customer (3.18.0) reported the claude.ai web connector can no longer register, traced to #20033. Local Claude Code still works (localhost loopback); the hosted web app is blocked. Remote MCP usage is increasingly via hosted web apps, so supporting these vendor callbacks out of the box matches the role the existing `cursor://` / `vscode://` / `jetbrains://` scheme entries already serve.

## Not included / notes for reviewers

- **Gemini** needs no change: Gemini CLI uses a localhost loopback (already allowed); the consumer `gemini.google.com` app has no hosted MCP callback to pin today.
- **Antigravity** is added proactively. Its callback (`https://antigravity.google/oauth-callback`) is correct, but Antigravity doesn't yet implement MCP DCR (it uses a manual paste-the-code flow), so this entry only takes effect once it adopts the spec. Harmless to ship now; easy to drop if preferred.
- **ChatGPT** uses a prefix because its current callback has a variable segment (`/connector/oauth/{callback_id}`); the host stays pinned to `chatgpt.com`, so codes can never leave the vendor origin.
- The callback URIs were verified against vendor docs (Anthropic Help Center, OpenAI Apps SDK, Google's cross-app MCP doc).
- Considered but **not** added: a configurable `--oauth2-allowed-redirect-uris` flag — rejected to avoid reintroducing the arbitrary-https surface; better defaults solve the reported case without ops work.

## Testing

- New table-driven test `TestIsAllowedDynamicClientRedirectURI` (restores coverage #20033 removed), including security-negative cases: arbitrary https, non-localhost http, subdomain spoof, **userinfo spoof** (`claude.ai@evil.com` → rejected), http downgrade, and wrong paths; plus uppercase-host and explicit-`:443` acceptance.
- `gofmt` / `golangci-lint` clean (0 issues), full `backend/api/oauth2` package tests pass, server build OK.

## Backport

Targets `main`. The reporting customer is on the 3.18.x line — candidate for cherry-pick to `release/3.18.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)