### PR TITLE
refactor(react): migrate useWorkspaceV1Store consumers to the app store

### DIFF
--- a/frontend/src/react/components/CreateWorkloadIdentitySheet.tsx
+++ b/frontend/src/react/components/CreateWorkloadIdentitySheet.tsx
@@ -21,7 +21,6 @@ import {
   pushNotification,
   useActuatorV1Store,
   useProjectV1Store,
-  useWorkspaceV1Store,
 } from "@/store";
 import { useProjectIamPolicyStore } from "@/store/modules/v1/projectIamPolicy";
 import {
@@ -134,10 +133,12 @@ function WorkloadIdentityForm({
   onUpdated,
 }: Omit<CreateWorkloadIdentitySheetProps, "open">) {
   const { t } = useTranslation();
-  const workspaceStore = useWorkspaceV1Store();
   const actuatorStore = useActuatorV1Store();
   const projectStore = useProjectV1Store();
   const projectIamPolicyStore = useProjectIamPolicyStore();
+  const patchWorkspaceIamPolicy = useAppStore(
+    (state) => state.patchWorkspaceIamPolicy
+  );
   const createWorkloadIdentity = useAppStore(
     (state) => state.createWorkloadIdentity
   );
@@ -375,7 +376,7 @@ function WorkloadIdentityForm({
           roles
         );
       } else {
-        await workspaceStore.patchIamPolicy([{ member, roles }]);
+        await patchWorkspaceIamPolicy([{ member, roles }]);
       }
     }
 

--- a/frontend/src/react/components/sql-editor/Welcome.test.tsx
+++ b/frontend/src/react/components/sql-editor/Welcome.test.tsx
@@ -52,7 +52,6 @@ vi.mock("@/router/dashboard/workspaceRoutes", () => ({
 
 vi.mock("@/store", () => ({
   useProjectV1Store: vi.fn(),
-  useWorkspaceV1Store: vi.fn(),
 }));
 
 vi.mock("@/react/stores/sqlEditor/editor-vue-state", () => ({

--- a/frontend/src/react/pages/auth/OAuth2ConsentPage.test.tsx
+++ b/frontend/src/react/pages/auth/OAuth2ConsentPage.test.tsx
@@ -11,7 +11,8 @@ const mocks = vi.hoisted(() => ({
   useVueState: vi.fn<(getter: () => unknown) => unknown>((getter) => getter()),
   useAuthStore: vi.fn(),
   useActuatorV1Store: vi.fn(),
-  useWorkspaceV1Store: vi.fn(),
+  useAppStore: vi.fn(),
+  useWorkspace: vi.fn(),
   isLoggedIn: { value: true },
   isSaaSMode: { value: false },
   currentWorkspace: {
@@ -23,8 +24,9 @@ const mocks = vi.hoisted(() => ({
       | undefined,
   },
   workspaceList: { value: [] as { name: string; title: string }[] },
-  fetchWorkspaceList: vi.fn(async () => {}),
-  switchWorkspaceWithoutRedirect: vi.fn(async () => {}),
+  loadWorkspace: vi.fn(async () => {}),
+  loadWorkspaceList: vi.fn(async () => {}),
+  switchWorkspace: vi.fn(async () => {}),
   routerReplace: vi.fn(),
   routerBack: vi.fn(),
   currentRoute: {
@@ -45,25 +47,37 @@ mocks.useActuatorV1Store.mockImplementation(() => ({
     return mocks.isSaaSMode.value;
   },
 }));
-mocks.useWorkspaceV1Store.mockImplementation(() => ({
-  get currentWorkspace() {
-    return mocks.currentWorkspace.value;
-  },
-  get workspaceList() {
-    return mocks.workspaceList.value;
-  },
-  fetchWorkspaceList: mocks.fetchWorkspaceList,
-  switchWorkspaceWithoutRedirect: mocks.switchWorkspaceWithoutRedirect,
-}));
+mocks.useWorkspace.mockImplementation(() => mocks.currentWorkspace.value);
+// The OAuth2 consent page selects discrete app-store slices via
+// `useAppStore((state) => state.X)`. Resolve each selector against a
+// mock state that exposes the workspace list (live via getter) plus
+// the action mocks under test.
+mocks.useAppStore.mockImplementation((selector: (state: unknown) => unknown) =>
+  selector({
+    get workspaceList() {
+      return mocks.workspaceList.value;
+    },
+    loadWorkspace: mocks.loadWorkspace,
+    loadWorkspaceList: mocks.loadWorkspaceList,
+    switchWorkspace: mocks.switchWorkspace,
+  })
+);
 
 vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: mocks.useVueState,
 }));
 
+vi.mock("@/react/hooks/useAppState", () => ({
+  useWorkspace: mocks.useWorkspace,
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
 vi.mock("@/store", () => ({
   useAuthStore: mocks.useAuthStore,
   useActuatorV1Store: mocks.useActuatorV1Store,
-  useWorkspaceV1Store: mocks.useWorkspaceV1Store,
 }));
 
 // Test-only Select stub: Base UI's Select renders its popup through a portal,
@@ -265,7 +279,7 @@ describe("OAuth2ConsentPage", () => {
     expect(container.textContent).toContain("oauth2.consent.workspace-label");
     expect(container.textContent).toContain("Acme Corp");
     // Self-hosted (default in this test) does NOT prefetch the workspace list.
-    expect(mocks.fetchWorkspaceList).not.toHaveBeenCalled();
+    expect(mocks.loadWorkspaceList).not.toHaveBeenCalled();
     unmount();
   });
 
@@ -291,7 +305,7 @@ describe("OAuth2ConsentPage", () => {
     );
     render();
     await flushPromises();
-    expect(mocks.fetchWorkspaceList).toHaveBeenCalledTimes(1);
+    expect(mocks.loadWorkspaceList).toHaveBeenCalledTimes(1);
     // Picker trigger renders the current workspace title.
     expect(container.textContent).toContain("Acme Corp");
     unmount();
@@ -348,9 +362,10 @@ describe("OAuth2ConsentPage", () => {
     // crucially, that variant does NOT fire the store's onmessage handler
     // in this tab, so we don't race-redirect to the landing page and lose
     // the OAuth query params.
-    expect(mocks.switchWorkspaceWithoutRedirect).toHaveBeenCalledTimes(1);
-    expect(mocks.switchWorkspaceWithoutRedirect).toHaveBeenCalledWith(
-      "workspaces/ws-2"
+    expect(mocks.switchWorkspace).toHaveBeenCalledTimes(1);
+    expect(mocks.switchWorkspace).toHaveBeenCalledWith(
+      "workspaces/ws-2",
+      false
     );
     expect(reload).toHaveBeenCalledTimes(1);
     unmount();
@@ -387,7 +402,7 @@ describe("OAuth2ConsentPage", () => {
       select!.dispatchEvent(new Event("change", { bubbles: true }));
       await Promise.resolve();
     });
-    expect(mocks.switchWorkspaceWithoutRedirect).not.toHaveBeenCalled();
+    expect(mocks.switchWorkspace).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/frontend/src/react/pages/auth/OAuth2ConsentPage.tsx
+++ b/frontend/src/react/pages/auth/OAuth2ConsentPage.tsx
@@ -10,10 +10,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/react/components/ui/select";
+import { useWorkspace } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_SIGNIN_MODULE } from "@/router/auth";
-import { useActuatorV1Store, useAuthStore, useWorkspaceV1Store } from "@/store";
+import { useActuatorV1Store, useAuthStore } from "@/store";
 
 const AUTHORIZE_URL = "/api/oauth2/authorize";
 
@@ -30,7 +32,9 @@ export function OAuth2ConsentPage() {
   // despite Pinia memoizing the factory.
   const authStore = useAuthStore();
   const actuatorStore = useActuatorV1Store();
-  const workspaceStore = useWorkspaceV1Store();
+  const loadWorkspace = useAppStore((state) => state.loadWorkspace);
+  const loadWorkspaceList = useAppStore((state) => state.loadWorkspaceList);
+  const switchWorkspace = useAppStore((state) => state.switchWorkspace);
 
   const isLoggedIn = useVueState(() => authStore.isLoggedIn);
   // Workspace context shown on the consent card. On SaaS, every Bytebase
@@ -38,8 +42,14 @@ export function OAuth2ConsentPage() {
   // implicit workspace. We display it so the user can confirm which
   // workspace this OAuth grant will be bound to.
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
-  const currentWorkspace = useVueState(() => workspaceStore.currentWorkspace);
-  const workspaceList = useVueState(() => workspaceStore.workspaceList);
+  const currentWorkspace = useWorkspace();
+  const workspaceList = useAppStore((state) => state.workspaceList);
+
+  // Ensure the app store has loaded the current workspace for the consent
+  // card. Idempotent: loadWorkspace returns the cached value when present.
+  useEffect(() => {
+    void loadWorkspace();
+  }, [loadWorkspace]);
 
   const query = router.currentRoute.value.query;
   const clientId = (query.client_id as string) || "";
@@ -99,11 +109,11 @@ export function OAuth2ConsentPage() {
   useEffect(() => {
     if (!isSaaSMode || prefetchRef.current) return;
     prefetchRef.current = true;
-    workspaceStore.fetchWorkspaceList().catch(() => {});
-  }, [isSaaSMode, workspaceStore]);
+    loadWorkspaceList().catch(() => {});
+  }, [isSaaSMode, loadWorkspaceList]);
 
   // Switch the active workspace in-place, preserving the consent flow.
-  // Uses the workspace store's withoutRedirect variant so that
+  // Calls switchWorkspace with redirect=false so that
   //   (a) the bb-workspace-switch channel notification is posted on the
   //       store's own channel instance, so the store's onmessage listener
   //       in *this* tab does NOT fire (BroadcastChannel excludes the
@@ -116,7 +126,7 @@ export function OAuth2ConsentPage() {
     if (!workspaceName || workspaceName === currentWorkspace?.name) return;
     setSubmitting(true);
     try {
-      await workspaceStore.switchWorkspaceWithoutRedirect(workspaceName);
+      await switchWorkspace(workspaceName, false);
       globalThis.location.reload();
     } catch {
       setError(t("oauth2.consent.error-switch-failed"));

--- a/frontend/src/react/pages/auth/ProfileSetupPage.tsx
+++ b/frontend/src/react/pages/auth/ProfileSetupPage.tsx
@@ -6,10 +6,9 @@ import { UserAvatar } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { useCurrentUser, useWorkspace } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import { pushNotification, useWorkspaceV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { UpdateUserRequestSchema } from "@/types/proto-es/v1/user_service_pb";
 import { WorkspaceSchema } from "@/types/proto-es/v1/workspace_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
@@ -19,15 +18,23 @@ export function ProfileSetupPage() {
   const currentUser = useCurrentUser();
   const updateUser = useAppStore((state) => state.updateUser);
   const updateWorkspace = useAppStore((state) => state.updateWorkspace);
-  const workspaceStore = useWorkspaceV1Store();
+  const fetchWorkspaceIamPolicy = useAppStore(
+    (state) => state.fetchWorkspaceIamPolicy
+  );
   const workspace = useWorkspace();
-  const workspacePolicy = useVueState(() => workspaceStore.workspaceIamPolicy);
+  const workspacePolicy = useAppStore((state) => state.workspacePolicy);
+
+  // The member count below gates the workspace-rename field, so make sure the
+  // policy is loaded even when this page is reached outside the setup flow.
+  useEffect(() => {
+    void fetchWorkspaceIamPolicy();
+  }, [fetchWorkspaceIamPolicy]);
 
   // Show workspace name field only if the user is the sole member of the
   // workspace (i.e. they just created it), not when they were invited.
   const canRenameWorkspace =
     hasWorkspacePermissionV2("bb.workspaces.update") &&
-    workspacePolicy.bindings.reduce(
+    (workspacePolicy?.bindings ?? []).reduce(
       (count, b) => count + b.members.length,
       0
     ) === 1;

--- a/frontend/src/react/pages/auth/SetupPage.test.tsx
+++ b/frontend/src/react/pages/auth/SetupPage.test.tsx
@@ -46,9 +46,6 @@ vi.mock("@/store", () => ({
   useSettingV1Store: () => ({
     updateWorkspaceProfile: mocks.updateWorkspaceProfile,
   }),
-  useWorkspaceV1Store: () => ({
-    fetchIamPolicy: mocks.fetchIamPolicy,
-  }),
 }));
 
 vi.mock("@/react/stores/app", () => ({
@@ -60,6 +57,7 @@ vi.mock("@/react/stores/app", () => ({
     {
       getState: () => ({
         listRoles: mocks.listRoles,
+        fetchWorkspaceIamPolicy: mocks.fetchIamPolicy,
       }),
     }
   ),

--- a/frontend/src/react/pages/auth/SetupPage.tsx
+++ b/frontend/src/react/pages/auth/SetupPage.tsx
@@ -22,7 +22,6 @@ import {
   useAppFeature,
   useProjectV1Store,
   useSettingV1Store,
-  useWorkspaceV1Store,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { DatabaseChangeMode } from "@/types/proto-es/v1/setting_service_pb";
@@ -57,7 +56,7 @@ export function SetupPage() {
       try {
         await Promise.all([
           useAppStore.getState().listRoles(),
-          useWorkspaceV1Store().fetchIamPolicy(),
+          useAppStore.getState().fetchWorkspaceIamPolicy(),
         ]);
       } catch (error) {
         // Roles/IAM pre-fetch failed — proceed to render the wizard anyway.

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
@@ -49,9 +49,6 @@ const mocks = vi.hoisted(() => ({
       title: "Project Owner",
     },
   ],
-  workspaceStore: {
-    roleMapToUsers: new Map(),
-  },
   issueCommentStore: {
     getIssueComments: vi.fn(() => mocks.comments),
     listIssueComments: vi.fn(async () => ({ issueComments: mocks.comments })),
@@ -82,7 +79,6 @@ vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
   useProjectIamPolicyStore: () => mocks.projectIamPolicyStore,
   useProjectV1Store: () => mocks.projectStore,
-  useWorkspaceV1Store: () => mocks.workspaceStore,
 }));
 
 vi.mock("@/react/hooks/useAppState", () => ({

--- a/frontend/src/react/pages/settings/MembersPage.test.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.test.tsx
@@ -300,11 +300,6 @@ vi.mock("@/store", () => ({
     hasFeature: () => true,
     userCountLimit: 10,
   }),
-  useWorkspaceV1Store: () => ({
-    findRolesByMember: () => [],
-    patchIamPolicy: vi.fn(),
-    workspaceIamPolicy: { bindings: [] },
-  }),
 }));
 
 vi.mock("@/react/hooks/useAppState", () => ({
@@ -319,6 +314,10 @@ vi.mock("@/react/stores/app", () => ({
     selector({
       batchGetOrFetchUsers: vi.fn(async () => []),
       roleList: [{ name: "roles/sqlEditorUser", permissions: [] }],
+      workspacePolicy: { bindings: [] },
+      patchWorkspaceIamPolicy: vi.fn(),
+      findWorkspaceRolesByMember: () => [],
+      fetchWorkspaceIamPolicy: vi.fn(async () => undefined),
     }),
 }));
 

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -87,7 +87,6 @@ import {
   useProjectV1Store,
   useSettingV1Store,
   useSubscriptionV1Store,
-  useWorkspaceV1Store,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import {
@@ -1239,7 +1238,12 @@ function EditMemberRoleDrawer({
   initialBindings?: string[];
 }) {
   const { t } = useTranslation();
-  const workspaceStore = useWorkspaceV1Store();
+  const patchWorkspaceIamPolicy = useAppStore(
+    (state) => state.patchWorkspaceIamPolicy
+  );
+  const findWorkspaceRolesByMember = useAppStore(
+    (state) => state.findWorkspaceRolesByMember
+  );
   const projectIamPolicyStore = useProjectIamPolicyStore();
   const isSaaSMode = useVueState(() => useActuatorV1Store().isSaaSMode);
   const settingV1Store = useSettingV1Store();
@@ -1543,18 +1547,18 @@ function EditMemberRoleDrawer({
         await projectIamPolicyStore.updateProjectIamPolicy(projectName, policy);
       } else {
         if (isEditMode) {
-          await workspaceStore.patchIamPolicy([
+          await patchWorkspaceIamPolicy([
             { member: member.binding, roles: selectedRoles },
           ]);
         } else {
           const batchPatch = selectedBindings.map((binding) => {
-            const existedRoles = workspaceStore.findRolesByMember(binding);
+            const existedRoles = findWorkspaceRolesByMember(binding);
             return {
               member: binding,
               roles: [...new Set([...selectedRoles, ...existedRoles])],
             };
           });
-          await workspaceStore.patchIamPolicy(batchPatch);
+          await patchWorkspaceIamPolicy(batchPatch);
         }
       }
       pushNotification({
@@ -1592,9 +1596,7 @@ function EditMemberRoleDrawer({
         policy.bindings = policy.bindings.filter((b) => b.members.length > 0);
         await projectIamPolicyStore.updateProjectIamPolicy(projectName, policy);
       } else {
-        await workspaceStore.patchIamPolicy([
-          { member: member.binding, roles: [] },
-        ]);
+        await patchWorkspaceIamPolicy([{ member: member.binding, roles: [] }]);
       }
       pushNotification({
         module: "bytebase",
@@ -1891,7 +1893,13 @@ function EditMemberRoleDrawer({
 
 export function MembersPage({ projectId }: { projectId?: string }) {
   const { t } = useTranslation();
-  const workspaceStore = useWorkspaceV1Store();
+  const workspacePolicy = useAppStore((state) => state.workspacePolicy);
+  const patchWorkspaceIamPolicy = useAppStore(
+    (state) => state.patchWorkspaceIamPolicy
+  );
+  const fetchWorkspaceIamPolicy = useAppStore(
+    (state) => state.fetchWorkspaceIamPolicy
+  );
   const actuatorStore = useActuatorV1Store();
   const subscriptionStore = useSubscriptionV1Store();
   const currentUser = useCurrentUser();
@@ -1931,8 +1939,10 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   useEffect(() => {
     if (projectName) {
       projectIamPolicyStore.getOrFetchProjectIamPolicy(projectName);
+    } else {
+      void fetchWorkspaceIamPolicy();
     }
-  }, [projectName, projectIamPolicyStore]);
+  }, [projectName, projectIamPolicyStore, fetchWorkspaceIamPolicy]);
 
   const projectIamPolicy = useVueState(() =>
     projectName
@@ -1947,17 +1957,20 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   // render; the table component handles that with content-based change
   // detection (a group-bindings signature) so its expand-cache only
   // resets on real membership changes.
+  // Keep this in useVueState so it re-runs when the Pinia user/group/
+  // service-account/workload-identity stores that getMemberBindings reads
+  // for member metadata change. The workspace IAM policy itself now comes
+  // from the app store: subscribing to `workspacePolicy` above re-renders
+  // this component on policy changes, and useVueState reads the latest getter
+  // each render, so both reactivity sources are covered.
   const memberBindings = useVueState(() =>
     getMemberBindings({
       policies:
         projectName && projectIamPolicy
           ? [{ level: "PROJECT" as const, policy: projectIamPolicy }]
-          : [
-              {
-                level: "WORKSPACE" as const,
-                policy: workspaceStore.workspaceIamPolicy,
-              },
-            ],
+          : workspacePolicy
+            ? [{ level: "WORKSPACE" as const, policy: workspacePolicy }]
+            : [],
       searchText: memberSearchText,
       ignoreRoles: EMPTY_ROLE_SET,
     })
@@ -1997,7 +2010,7 @@ export function MembersPage({ projectId }: { projectId?: string }) {
             policy
           );
         } else {
-          await workspaceStore.patchIamPolicy(
+          await patchWorkspaceIamPolicy(
             selectedMembers.map((m) => ({ member: m, roles: [] }))
           );
         }
@@ -2028,9 +2041,7 @@ export function MembersPage({ projectId }: { projectId?: string }) {
         policy.bindings = policy.bindings.filter((b) => b.members.length > 0);
         await projectIamPolicyStore.updateProjectIamPolicy(projectName, policy);
       } else {
-        await workspaceStore.patchIamPolicy([
-          { member: binding.binding, roles: [] },
-        ]);
+        await patchWorkspaceIamPolicy([{ member: binding.binding, roles: [] }]);
       }
       pushNotification({
         module: "bytebase",

--- a/frontend/src/react/pages/settings/RolesPage.tsx
+++ b/frontend/src/react/pages/settings/RolesPage.tsx
@@ -53,11 +53,7 @@ import {
   displayRoleTitleFromList,
 } from "@/react/lib/role";
 import { useAppStore } from "@/react/stores/app";
-import {
-  pushNotification,
-  useSubscriptionV1Store,
-  useWorkspaceV1Store,
-} from "@/store";
+import { pushNotification, useSubscriptionV1Store } from "@/store";
 import { roleNamePrefix } from "@/store/modules/v1/common";
 import {
   BASIC_WORKSPACE_PERMISSIONS,
@@ -678,7 +674,9 @@ export function RolesPage() {
   const listRoles = useAppStore((state) => state.listRoles);
   const getRoleByName = useAppStore((state) => state.getRoleByName);
   const deleteRole = useAppStore((state) => state.deleteRole);
-  const workspaceStore = useWorkspaceV1Store();
+  const fetchWorkspaceIamPolicy = useAppStore(
+    (state) => state.fetchWorkspaceIamPolicy
+  );
   const subscriptionStore = useSubscriptionV1Store();
 
   const [ready, setReady] = useState(false);
@@ -707,6 +705,9 @@ export function RolesPage() {
 
   // Fetch roles on mount and handle query param
   useEffect(() => {
+    // The workspace IAM policy backs the "users with this role" list shown in
+    // the delete confirmation; load it (and referenced groups) alongside roles.
+    void fetchWorkspaceIamPolicy();
     listRoles()
       .then(() => {
         const urlParams = new URLSearchParams(window.location.search);
@@ -741,7 +742,8 @@ export function RolesPage() {
     }
 
     const usersWithRole = [
-      ...(workspaceStore.roleMapToUsers.get(role.name) ?? new Set()),
+      ...(useAppStore.getState().workspaceRoleMapToUsers().get(role.name) ??
+        new Set<string>()),
     ];
     setDeleteResources(usersWithRole);
     setDeleteTarget(role);

--- a/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
+++ b/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
@@ -39,7 +39,6 @@ import {
   pushNotification,
   useActuatorV1Store,
   useProjectV1Store,
-  useWorkspaceV1Store,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { useProjectIamPolicyStore } from "@/store/modules/v1/projectIamPolicy";
@@ -432,7 +431,9 @@ function ServiceAccountForm({
   const updateServiceAccount = useAppStore(
     (state) => state.updateServiceAccount
   );
-  const workspaceStore = useWorkspaceV1Store();
+  const patchWorkspaceIamPolicy = useAppStore(
+    (state) => state.patchWorkspaceIamPolicy
+  );
   const actuatorStore = useActuatorV1Store();
   const projectStore = useProjectV1Store();
   const projectIamPolicyStore = useProjectIamPolicyStore();
@@ -543,7 +544,7 @@ function ServiceAccountForm({
           roles
         );
       } else {
-        await workspaceStore.patchIamPolicy([{ member, roles }]);
+        await patchWorkspaceIamPolicy([{ member, roles }]);
       }
     }
 

--- a/frontend/src/react/pages/settings/UsersPage.tsx
+++ b/frontend/src/react/pages/settings/UsersPage.tsx
@@ -54,7 +54,6 @@ import {
   useActuatorV1Store,
   useSettingV1Store,
   useSubscriptionV1Store,
-  useWorkspaceV1Store,
 } from "@/store";
 import { getUserFullNameByType } from "@/store/modules/v1/common";
 import {
@@ -508,10 +507,11 @@ function UserForm({
   const { t } = useTranslation();
   const createUser = useAppStore((state) => state.createUser);
   const updateUser = useAppStore((state) => state.updateUser);
-  const workspaceStore = useWorkspaceV1Store();
+  const patchWorkspaceIamPolicy = useAppStore(
+    (state) => state.patchWorkspaceIamPolicy
+  );
   const settingV1Store = useSettingV1Store();
 
-  const userMapToRoles = useVueState(() => workspaceStore.userMapToRoles);
   const passwordRestriction = useVueState(
     () => settingV1Store.workspaceProfile.passwordRestriction
   );
@@ -543,7 +543,13 @@ function UserForm({
     if (!user || !isEditMode) {
       return [PresetRoleType.WORKSPACE_MEMBER];
     }
-    const roles = userMapToRoles.get(getUserFullNameByType(user));
+    // Read a one-shot snapshot of the workspace role map at mount. The parent
+    // page loads the workspace IAM policy, so it is populated by the time an
+    // edit sheet opens; reading via getState keeps this baseline mount-only.
+    const roles = useAppStore
+      .getState()
+      .workspaceUserMapToRoles()
+      .get(getUserFullNameByType(user));
     return roles ? [...roles] : [];
   }, []);
   const initialTitle = user?.title ?? "";
@@ -676,7 +682,7 @@ function UserForm({
     });
     if (roles.length > 0) {
       try {
-        await workspaceStore.patchIamPolicy([
+        await patchWorkspaceIamPolicy([
           {
             member: getUserEmailInBinding(createdUser.email),
             roles,
@@ -721,7 +727,7 @@ function UserForm({
     }
 
     if (!isEqual([...initialRoles].sort(), [...roles].sort())) {
-      await workspaceStore.patchIamPolicy([
+      await patchWorkspaceIamPolicy([
         {
           member: getUserEmailInBinding(updatedUser.email),
           roles,
@@ -920,6 +926,15 @@ export function UsersPage() {
   const actuatorStore = useActuatorV1Store();
   const subscriptionStore = useSubscriptionV1Store();
   const listUsers = useAppStore((state) => state.listUsers);
+  const fetchWorkspaceIamPolicy = useAppStore(
+    (state) => state.fetchWorkspaceIamPolicy
+  );
+
+  // Load the workspace IAM policy (and the groups it references) so the
+  // create/edit user sheet can resolve each user's current roles at open.
+  useEffect(() => {
+    void fetchWorkspaceIamPolicy();
+  }, [fetchWorkspaceIamPolicy]);
 
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
 

--- a/frontend/src/react/pages/settings/general/DangerZoneSection.tsx
+++ b/frontend/src/react/pages/settings/general/DangerZoneSection.tsx
@@ -14,8 +14,8 @@ import {
   useOptionalCurrentUser,
   useWorkspace,
 } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
-import { pushNotification, useWorkspaceV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification } from "@/store";
 import { PresetRoleType } from "@/types/iam/role";
 import { userBindingPrefix } from "@/types/v1/user";
 import { hasWorkspacePermissionV2 } from "@/utils";
@@ -24,8 +24,7 @@ export function DangerZoneSection() {
   const { t } = useTranslation();
   const workspace = useWorkspace();
   const currentUser = useOptionalCurrentUser()!;
-  const workspaceStore = useWorkspaceV1Store();
-  const workspacePolicy = useVueState(() => workspaceStore.workspaceIamPolicy);
+  const workspacePolicy = useAppStore((state) => state.workspacePolicy);
 
   const canDelete = hasWorkspacePermissionV2("bb.workspaces.delete");
 
@@ -34,7 +33,7 @@ export function DangerZoneSection() {
   // contain other users — the backend does the definitive check.
   const hasOtherAdmin = useMemo(() => {
     const currentBinding = `${userBindingPrefix}${currentUser.email}`;
-    for (const binding of workspacePolicy.bindings) {
+    for (const binding of workspacePolicy?.bindings ?? []) {
       if (binding.role !== PresetRoleType.WORKSPACE_ADMIN) continue;
       for (const member of binding.members) {
         if (member === currentBinding) continue;

--- a/frontend/src/react/pages/settings/profile/ProfilePage.test.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.test.tsx
@@ -36,9 +36,8 @@ const mocks = vi.hoisted(() => ({
       requireMfa: false,
     },
   })),
-  useWorkspaceV1Store: vi.fn(() => ({
-    getWorkspaceRolesByName: vi.fn(() => []),
-  })),
+  getWorkspaceRolesByName: vi.fn(() => new Set<string>()),
+  fetchWorkspaceIamPolicy: vi.fn(async () => undefined),
   useActuatorV1Store: vi.fn(() => ({
     isSaaSMode: false,
   })),
@@ -75,6 +74,9 @@ vi.mock("@/react/stores/app", () => ({
       updateUser: mocks.updateUser,
       updateEmail: mocks.updateEmail,
       roleList: [],
+      workspacePolicy: undefined,
+      getWorkspaceRolesByName: mocks.getWorkspaceRolesByName,
+      fetchWorkspaceIamPolicy: mocks.fetchWorkspaceIamPolicy,
     }),
 }));
 
@@ -84,7 +86,6 @@ vi.mock("@/store", () => ({
   useActuatorV1Store: mocks.useActuatorV1Store,
   useAuthStore: mocks.useAuthStore,
   useSettingV1Store: mocks.useSettingV1Store,
-  useWorkspaceV1Store: mocks.useWorkspaceV1Store,
 }));
 
 vi.mock("@/router", () => ({

--- a/frontend/src/react/pages/settings/profile/ProfilePage.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.tsx
@@ -44,7 +44,6 @@ import {
   useActuatorV1Store,
   useAuthStore,
   useSettingV1Store,
-  useWorkspaceV1Store,
 } from "@/store";
 import {
   AccountType,
@@ -77,8 +76,18 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
   const updateUser = useAppStore((state) => state.updateUser);
   const updateEmail = useAppStore((state) => state.updateEmail);
   const roleList = useAppStore((state) => state.roleList);
-  const workspaceStore = useWorkspaceV1Store();
+  const workspacePolicy = useAppStore((state) => state.workspacePolicy);
+  const getWorkspaceRolesByName = useAppStore(
+    (state) => state.getWorkspaceRolesByName
+  );
+  const fetchWorkspaceIamPolicy = useAppStore(
+    (state) => state.fetchWorkspaceIamPolicy
+  );
   const actuatorStore = useActuatorV1Store();
+
+  useEffect(() => {
+    void fetchWorkspaceIamPolicy();
+  }, [fetchWorkspaceIamPolicy]);
 
   // --- Reactive Vue state ---
   const legacyCurrentUser = useCurrentUser();
@@ -89,9 +98,11 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
 
   const user = principalEmail ? (principalUser ?? unknownUser()) : currentUser;
 
-  const userRoles = useVueState(() => [
-    ...workspaceStore.getWorkspaceRolesByName(user.name),
-  ]);
+  const userRoles = useMemo(
+    () => [...getWorkspaceRolesByName(user.name)],
+    // Recompute when the policy changes; getWorkspaceRolesByName reads it.
+    [getWorkspaceRolesByName, user.name, workspacePolicy]
+  );
 
   const passwordRestriction = useVueState(
     () => settingV1Store.workspaceProfile.passwordRestriction

--- a/frontend/src/react/stores/app/iam.ts
+++ b/frontend/src/react/stores/app/iam.ts
@@ -1,15 +1,54 @@
 import { create as createProto } from "@bufbuild/protobuf";
+import { cloneDeep } from "lodash-es";
 import {
   projectServiceClientConnect,
   roleServiceClientConnect,
   workspaceServiceClientConnect,
 } from "@/connect";
-import { workspaceNamePrefix } from "@/react/lib/resourceName";
+import { userNamePrefix, workspaceNamePrefix } from "@/react/lib/resourceName";
 import { PRESET_WORKSPACE_ROLES } from "@/types/iam/role";
-import { GetIamPolicyRequestSchema } from "@/types/proto-es/v1/iam_policy_pb";
+import {
+  BindingSchema,
+  GetIamPolicyRequestSchema,
+  type IamPolicy,
+  SetIamPolicyRequestSchema,
+} from "@/types/proto-es/v1/iam_policy_pb";
 import { ListRolesRequestSchema } from "@/types/proto-es/v1/role_service_pb";
+import { ALL_USERS_USER_EMAIL, groupBindingPrefix } from "@/types/v1/user";
+import { getUserListInBinding, isBindingPolicyExpired } from "@/utils/v1/iam";
 import type { AppSliceCreator, IamSlice } from "./types";
 import { bindingMatchesUser } from "./utils";
+
+// Merge a member's role set into a policy clone: drop the member from roles it
+// no longer holds, add it to roles it gained, and append bindings for brand-new
+// roles. Mirrors the Vue workspace store's mergeBinding.
+const mergeBinding = ({
+  member,
+  roles,
+  policy,
+}: {
+  member: string;
+  roles: string[];
+  policy: IamPolicy;
+}): IamPolicy => {
+  const newRolesSet = new Set(roles);
+  const next = cloneDeep(policy);
+  for (const binding of next.bindings) {
+    const index = binding.members.findIndex((m) => m === member);
+    if (!newRolesSet.has(binding.role)) {
+      if (index >= 0) {
+        binding.members.splice(index, 1);
+      }
+    } else if (index < 0) {
+      binding.members.push(member);
+    }
+    newRolesSet.delete(binding.role);
+  }
+  for (const role of newRolesSet) {
+    next.bindings.push(createProto(BindingSchema, { role, members: [member] }));
+  }
+  return next;
+};
 
 export const createIamSlice: AppSliceCreator<IamSlice> = (set, get) => ({
   projectPoliciesByName: {},
@@ -106,6 +145,118 @@ export const createIamSlice: AppSliceCreator<IamSlice> = (set, get) => ({
       },
     }));
     return request;
+  },
+
+  fetchWorkspaceIamPolicy: async () => {
+    const resource =
+      get().serverInfo?.workspace ||
+      get().workspace?.name ||
+      get().currentUser?.workspace ||
+      `${workspaceNamePrefix}-`;
+    const policy = await workspaceServiceClientConnect.getIamPolicy(
+      createProto(GetIamPolicyRequestSchema, { resource })
+    );
+    // Prefetch groups referenced by the policy so the derived role/user maps
+    // can expand group members from the same app-store cache.
+    const groups = policy.bindings
+      .flatMap((binding) => binding.members)
+      .filter((member) => member.startsWith(groupBindingPrefix));
+    if (groups.length > 0) {
+      await get()
+        .batchGetOrFetchGroups(groups)
+        .catch(() => []);
+    }
+    set({ workspacePolicy: policy });
+    return policy;
+  },
+
+  patchWorkspaceIamPolicy: async (batchPatch) => {
+    if (batchPatch.length === 0) {
+      return;
+    }
+    const current =
+      get().workspacePolicy ?? (await get().fetchWorkspaceIamPolicy());
+    let policy = cloneDeep(current);
+    for (const patch of batchPatch) {
+      policy = mergeBinding({ ...patch, policy });
+    }
+    const resource =
+      get().serverInfo?.workspace ||
+      get().workspace?.name ||
+      get().currentUser?.workspace ||
+      `${workspaceNamePrefix}-`;
+    const updated = await workspaceServiceClientConnect.setIamPolicy(
+      createProto(SetIamPolicyRequestSchema, {
+        resource,
+        policy,
+        etag: policy.etag,
+      })
+    );
+    set({ workspacePolicy: updated });
+  },
+
+  workspaceRoleMapToUsers: () => {
+    const policy = get().workspacePolicy;
+    const getGroupByIdentifier = get().getGroupByIdentifier;
+    const map = new Map<string, Set<string>>();
+    for (const binding of policy?.bindings ?? []) {
+      if (!map.has(binding.role)) {
+        map.set(binding.role, new Set());
+      }
+      for (const fullname of getUserListInBinding({
+        binding,
+        ignoreGroup: false,
+        getGroupByIdentifier,
+      })) {
+        map.get(binding.role)?.add(fullname);
+      }
+    }
+    return map;
+  },
+
+  workspaceUserMapToRoles: () => {
+    const policy = get().workspacePolicy;
+    const getGroupByIdentifier = get().getGroupByIdentifier;
+    const map = new Map<string, Set<string>>();
+    for (const binding of policy?.bindings ?? []) {
+      for (const fullname of getUserListInBinding({
+        binding,
+        ignoreGroup: false,
+        getGroupByIdentifier,
+      })) {
+        if (!map.has(fullname)) {
+          map.set(fullname, new Set());
+        }
+        map.get(fullname)?.add(binding.role);
+      }
+    }
+    return map;
+  },
+
+  findWorkspaceRolesByMember: (member) => {
+    const roles = new Set<string>();
+    for (const binding of get().workspacePolicy?.bindings ?? []) {
+      if (isBindingPolicyExpired(binding)) {
+        continue;
+      }
+      if (binding.members.includes(member)) {
+        roles.add(binding.role);
+      }
+    }
+    return [...roles];
+  },
+
+  getWorkspaceRolesByName: (name) => {
+    const userMapToRoles = get().workspaceUserMapToRoles();
+    const roles = new Set<string>(userMapToRoles.get(name) ?? []);
+    const allUsersName = `${userNamePrefix}${ALL_USERS_USER_EMAIL}`;
+    const allUsersRoles = userMapToRoles.get(allUsersName);
+    if (allUsersRoles) {
+      for (const role of allUsersRoles) {
+        roles.add(role);
+      }
+    }
+    return roles;
   },
 
   hasWorkspacePermission: (permission) => {

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -78,6 +78,7 @@ const mocks = vi.hoisted(() => ({
   getWorkspace: vi.fn(),
   updateWorkspace: vi.fn(),
   getIamPolicy: vi.fn(),
+  setIamPolicy: vi.fn(),
   listRoles: vi.fn(),
   updateRole: vi.fn(),
   deleteRole: vi.fn(),
@@ -268,6 +269,7 @@ vi.mock("@/connect", () => ({
     getWorkspace: mocks.getWorkspace,
     updateWorkspace: mocks.updateWorkspace,
     getIamPolicy: mocks.getIamPolicy,
+    setIamPolicy: mocks.setIamPolicy,
   },
 }));
 
@@ -669,6 +671,84 @@ describe("useAppStore", () => {
     await store.getState().updateWorkspace(updated, ["logo"]);
 
     expect(store.getState().workspace).toBe(active);
+  });
+
+  test("patchWorkspaceIamPolicy adds the member to the requested role bindings", async () => {
+    const existing = createProto(IamPolicySchema, {
+      bindings: [
+        createProto(BindingSchema, {
+          role: "roles/workspaceMember",
+          members: ["user:alice@example.com"],
+        }),
+      ],
+    });
+    const setPolicy = createProto(IamPolicySchema, {
+      bindings: [
+        createProto(BindingSchema, {
+          role: "roles/workspaceMember",
+          members: ["user:alice@example.com", "user:bob@example.com"],
+        }),
+        createProto(BindingSchema, {
+          role: "roles/workspaceAdmin",
+          members: ["user:bob@example.com"],
+        }),
+      ],
+    });
+    mocks.setIamPolicy.mockResolvedValue(setPolicy);
+    const store = createAppStore();
+    store.setState({ workspacePolicy: existing });
+
+    await store.getState().patchWorkspaceIamPolicy([
+      {
+        member: "user:bob@example.com",
+        roles: ["roles/workspaceMember", "roles/workspaceAdmin"],
+      },
+    ]);
+
+    expect(mocks.setIamPolicy).toHaveBeenCalledTimes(1);
+    const request = mocks.setIamPolicy.mock.calls[0][0] as {
+      policy: { bindings: { role: string; members: string[] }[] };
+    };
+    // Existing member binding gains bob, and a new admin binding is appended.
+    expect(
+      request.policy.bindings.map(({ role, members }) => ({ role, members }))
+    ).toEqual([
+      {
+        role: "roles/workspaceMember",
+        members: ["user:alice@example.com", "user:bob@example.com"],
+      },
+      {
+        role: "roles/workspaceAdmin",
+        members: ["user:bob@example.com"],
+      },
+    ]);
+    expect(store.getState().workspacePolicy).toBe(setPolicy);
+  });
+
+  test("workspaceUserMapToRoles inverts policy bindings to member -> roles", () => {
+    const policy = createProto(IamPolicySchema, {
+      bindings: [
+        createProto(BindingSchema, {
+          role: "roles/workspaceMember",
+          members: ["user:alice@example.com", "user:bob@example.com"],
+        }),
+        createProto(BindingSchema, {
+          role: "roles/workspaceAdmin",
+          members: ["user:alice@example.com"],
+        }),
+      ],
+    });
+    const store = createAppStore();
+    store.setState({ workspacePolicy: policy });
+
+    const map = store.getState().workspaceUserMapToRoles();
+    expect([...(map.get("users/alice@example.com") ?? [])].sort()).toEqual([
+      "roles/workspaceAdmin",
+      "roles/workspaceMember",
+    ]);
+    expect([...(map.get("users/bob@example.com") ?? [])]).toEqual([
+      "roles/workspaceMember",
+    ]);
   });
 
   test("create archive and restore update activated user count when server info is loaded", async () => {

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -143,7 +143,7 @@ export type WorkspaceSlice = {
     workspace: Workspace,
     updateMask: string[]
   ) => Promise<Workspace>;
-  switchWorkspace: (workspaceName: string) => Promise<void>;
+  switchWorkspace: (workspaceName: string, redirect?: boolean) => Promise<void>;
   loadWorkspaceProfile: (
     force?: boolean
   ) => Promise<WorkspaceProfileSetting | undefined>;
@@ -195,6 +195,14 @@ export type IamSlice = {
   rolesRequest?: Promise<Role[]>;
   loadWorkspacePermissionState: () => Promise<void>;
   loadProjectIamPolicy: (project: string) => Promise<IamPolicy | undefined>;
+  fetchWorkspaceIamPolicy: () => Promise<IamPolicy>;
+  patchWorkspaceIamPolicy: (
+    batchPatch: { member: string; roles: string[] }[]
+  ) => Promise<void>;
+  workspaceRoleMapToUsers: () => Map<string, Set<string>>;
+  workspaceUserMapToRoles: () => Map<string, Set<string>>;
+  findWorkspaceRolesByMember: (member: string) => string[];
+  getWorkspaceRolesByName: (name: string) => Set<string>;
   hasWorkspacePermission: (permission: Permission) => boolean;
   hasProjectPermission: (project: Project, permission: Permission) => boolean;
 };

--- a/frontend/src/react/stores/app/workspace.ts
+++ b/frontend/src/react/stores/app/workspace.ts
@@ -233,7 +233,7 @@ export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
     return updated;
   },
 
-  switchWorkspace: async (workspaceName: string) => {
+  switchWorkspace: async (workspaceName: string, redirect = true) => {
     await authServiceClientConnect.switchWorkspace(
       createProto(SwitchWorkspaceRequestSchema, {
         workspace: workspaceName,
@@ -242,8 +242,10 @@ export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
     );
     // Notify other tabs to reload with the new workspace.
     broadcastWorkspaceSwitch(workspaceName);
-    // Full-reload to the landing page to reset all frontend state.
-    window.location.href = "/";
+    if (redirect) {
+      // Full-reload to the landing page to reset all frontend state.
+      window.location.href = "/";
+    }
   },
 
   loadWorkspaceProfile: async (force = false) => {


### PR DESCRIPTION
## Summary

Move every React (non-test) consumer of the Pinia `useWorkspaceV1Store` to the React app store. Zero `useWorkspaceV1Store` imports remain anywhere in `frontend/src/react/**/*.{ts,tsx}`. Mirrors the #20436 / #20442 / #20443 (BYT-9589) migration pattern.

## App store additions (workspace/iam slices)

- **Workspace slice:** collapse `switchWorkspace` + `switchWorkspaceWithoutRedirect` into `switchWorkspace(name, redirect = true)` to avoid a duplicate method.
- **IAM slice:**
  - `fetchWorkspaceIamPolicy` — `getIamPolicy` + prefetch referenced groups so the derived role/user maps can expand group members.
  - `patchWorkspaceIamPolicy` — `mergeBinding` semantics with etag → `setIamPolicy`.
  - Derived selectors `workspaceRoleMapToUsers` / `workspaceUserMapToRoles` / `findWorkspaceRolesByMember` / `getWorkspaceRolesByName`. These are selector functions (not stored state); callers wrap them in `useMemo` keyed on `workspacePolicy` where reactivity matters.

## Consumer migration

- `OAuth2ConsentPage`: `useWorkspace` + `useAppStore` selectors. `switchWorkspaceWithoutRedirect` callsites become `switchWorkspace(name, false)`.
- `DangerZoneSection`, `ProfileSetupPage`: read `workspacePolicy` with optional chaining; `ProfileSetupPage` triggers `fetchWorkspaceIamPolicy` on mount so the member-count gate is accurate when reached outside the setup flow.
- `BrandingSection`, `ProfilePage`, `UsersPage`, `ServiceAccountsPage`, `RolesPage`, `CreateWorkloadIdentitySheet`, `SetupPage`: swap `patchIamPolicy` / `findRolesByMember` / `userMapToRoles` / `roleMapToUsers` / `getWorkspaceRolesByName` / `fetchIamPolicy` / `workspaceIamPolicy` for the app store equivalents. Pages that drive derived maps fetch `fetchWorkspaceIamPolicy` on mount so the policy + referenced groups are loaded before dependent UI renders.
- `MembersPage` members table keeps `useVueState` around `getMemberBindings` (which still reads Pinia user/group/service-account/workload-identity stores for member metadata reactivity), but sources the workspace policy from `useAppStore` so a subscribe-triggered re-render re-runs the getter with the latest policy.

## Test plan
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend test` (240/240 files, 2291/2291 tests)
- [x] grep confirms zero `useWorkspaceV1Store` references in `frontend/src/react/**`
- [ ] Manual smoke (settings → members add/edit/revoke, role delete, profile page, OAuth2 consent workspace picker, setup flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)