### PR TITLE
fix(frontend): centralize permission-data prep so project pages stop missing IAM

### DIFF
--- a/frontend/src/react/components/CreateWorkloadIdentitySheet.tsx
+++ b/frontend/src/react/components/CreateWorkloadIdentitySheet.tsx
@@ -22,7 +22,6 @@ import {
   useActuatorV1Store,
   useProjectV1Store,
 } from "@/store";
-import { useProjectIamPolicyStore } from "@/store/modules/v1/projectIamPolicy";
 import {
   getWorkloadIdentityNameInBinding,
   getWorkloadIdentitySuffix,
@@ -135,7 +134,10 @@ function WorkloadIdentityForm({
   const { t } = useTranslation();
   const actuatorStore = useActuatorV1Store();
   const projectStore = useProjectV1Store();
-  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
+  const updateProjectIamPolicy = useAppStore(
+    (state) => state.updateProjectIamPolicy
+  );
   const patchWorkspaceIamPolicy = useAppStore(
     (state) => state.patchWorkspaceIamPolicy
   );
@@ -328,9 +330,7 @@ function WorkloadIdentityForm({
     member: string,
     newRoles: string[]
   ) => {
-    const policy = structuredClone(
-      projectIamPolicyStore.getProjectIamPolicy(projectName)
-    );
+    const policy = structuredClone(getProjectIamPolicy(projectName));
     for (const binding of policy.bindings) {
       binding.members = binding.members.filter((m) => m !== member);
     }
@@ -349,7 +349,7 @@ function WorkloadIdentityForm({
         );
       }
     }
-    await projectIamPolicyStore.updateProjectIamPolicy(projectName, policy);
+    await updateProjectIamPolicy(projectName, policy);
   };
 
   const handleCreate = async () => {

--- a/frontend/src/react/components/DashboardFrameShell.test.tsx
+++ b/frontend/src/react/components/DashboardFrameShell.test.tsx
@@ -10,8 +10,12 @@ const mocks = vi.hoisted(() => ({
   getOrFetchSettingByName: vi.fn(),
   fetchEnvironments: vi.fn(),
   loadCurrentUser: vi.fn(),
+  loadServerInfo: vi.fn(),
+  loadWorkspace: vi.fn(),
   loadEnvironmentList: vi.fn(),
   loadWorkspaceProfile: vi.fn(),
+  loadWorkspacePermissionState: vi.fn(),
+  loadSubscription: vi.fn(),
   useAppStore: vi.fn(),
 }));
 
@@ -38,18 +42,30 @@ beforeEach(async () => {
   mocks.getOrFetchSettingByName.mockReset();
   mocks.fetchEnvironments.mockReset();
   mocks.loadCurrentUser.mockReset();
+  mocks.loadServerInfo.mockReset();
+  mocks.loadWorkspace.mockReset();
   mocks.loadEnvironmentList.mockReset();
   mocks.loadWorkspaceProfile.mockReset();
+  mocks.loadWorkspacePermissionState.mockReset();
+  mocks.loadSubscription.mockReset();
   mocks.getOrFetchSettingByName.mockResolvedValue(undefined);
   mocks.fetchEnvironments.mockResolvedValue([]);
   mocks.loadCurrentUser.mockResolvedValue(undefined);
+  mocks.loadServerInfo.mockResolvedValue(undefined);
+  mocks.loadWorkspace.mockResolvedValue(undefined);
   mocks.loadEnvironmentList.mockResolvedValue([]);
   mocks.loadWorkspaceProfile.mockResolvedValue(undefined);
+  mocks.loadWorkspacePermissionState.mockResolvedValue(undefined);
+  mocks.loadSubscription.mockResolvedValue(undefined);
   mocks.useAppStore.mockImplementation((selector) =>
     selector({
       loadCurrentUser: mocks.loadCurrentUser,
+      loadServerInfo: mocks.loadServerInfo,
+      loadWorkspace: mocks.loadWorkspace,
       loadEnvironmentList: mocks.loadEnvironmentList,
       loadWorkspaceProfile: mocks.loadWorkspaceProfile,
+      loadWorkspacePermissionState: mocks.loadWorkspacePermissionState,
+      loadSubscription: mocks.loadSubscription,
     })
   );
   ({ DashboardFrameShell } = await import("./DashboardFrameShell"));

--- a/frontend/src/react/components/DashboardFrameShell.tsx
+++ b/frontend/src/react/components/DashboardFrameShell.tsx
@@ -1,11 +1,14 @@
 import { LoaderCircle } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { DashboardFrameShellProps } from "@/react/dashboard-shell";
-import { useAppStore } from "@/react/stores/app";
+import { useEnsureWorkspaceCommonData } from "@/react/hooks/useEnsureWorkspaceCommonData";
 import { useEnvironmentV1Store, useSettingV1Store } from "@/store";
 import { Setting_SettingName } from "@/types/proto-es/v1/setting_service_pb";
 import { BannersWrapper } from "./BannersWrapper";
 
+// Legacy Pinia bootstrap kept alongside the app-store bootstrap because the
+// remaining Vue surfaces still read from these Pinia stores. Once those Vue
+// readers are migrated this block can go away.
 const loadLegacyDashboardState = () => {
   return Promise.all([
     useEnvironmentV1Store().fetchEnvironments(),
@@ -18,31 +21,24 @@ const loadLegacyDashboardState = () => {
 export function DashboardFrameShell({ onReady }: DashboardFrameShellProps) {
   const bannerRef = useRef<HTMLDivElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
-  const [initialized, setInitialized] = useState(false);
-  const loadCurrentUser = useAppStore((state) => state.loadCurrentUser);
-  const loadEnvironmentList = useAppStore((state) => state.loadEnvironmentList);
-  const loadWorkspaceProfile = useAppStore(
-    (state) => state.loadWorkspaceProfile
-  );
+  const [legacyReady, setLegacyReady] = useState(false);
+  const commonDataReady = useEnsureWorkspaceCommonData();
 
   useEffect(() => {
     let mounted = true;
-    void Promise.all([
-      loadCurrentUser(),
-      loadEnvironmentList(),
-      loadWorkspaceProfile(),
-      loadLegacyDashboardState(),
-    ])
+    void loadLegacyDashboardState()
       .catch(() => undefined)
       .then(() => {
         if (mounted) {
-          setInitialized(true);
+          setLegacyReady(true);
         }
       });
     return () => {
       mounted = false;
     };
-  }, [loadCurrentUser, loadEnvironmentList, loadWorkspaceProfile]);
+  }, []);
+
+  const initialized = commonDataReady && legacyReady;
 
   useEffect(() => {
     if (!initialized) return;

--- a/frontend/src/react/components/Quickstart.tsx
+++ b/frontend/src/react/components/Quickstart.tsx
@@ -19,7 +19,6 @@ import {
   pushNotification,
   useActuatorV1Store,
   useIssueV1Store,
-  useProjectIamPolicyStore,
   useProjectV1Store,
   useUIStateStore,
 } from "@/store";
@@ -73,7 +72,9 @@ export function Quickstart() {
   const uiStateStore = useUIStateStore();
   const actuatorStore = useActuatorV1Store();
   const issueStore = useIssueV1Store();
-  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const loadProjectIamPolicy = useAppStore(
+    (state) => state.loadProjectIamPolicy
+  );
 
   const quickStartEnabled = useVueState(() => actuatorStore.quickStartEnabled);
   const hidden = useVueState(() => uiStateStore.getIntroStateByKey("hidden"));
@@ -124,14 +125,14 @@ export function Quickstart() {
         setSampleProject(undefined);
         return;
       }
-      await projectIamPolicyStore.getOrFetchProjectIamPolicy(project.name);
+      await loadProjectIamPolicy(project.name);
       if (cancelled) return;
       setSampleProject(project);
     })();
     return () => {
       cancelled = true;
     };
-  }, [quickStartEnabled, projectStore, projectIamPolicyStore]);
+  }, [quickStartEnabled, projectStore, loadProjectIamPolicy]);
 
   useEffect(() => {
     if (!sampleProject) {

--- a/frontend/src/react/components/sql-editor/SQLEditorLayout.tsx
+++ b/frontend/src/react/components/sql-editor/SQLEditorLayout.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from "react";
 import { BannersWrapper } from "@/react/components/BannersWrapper";
-import { useAppStore } from "@/react/stores/app";
+import { useEnsureWorkspaceCommonData } from "@/react/hooks/useEnsureWorkspaceCommonData";
 import { router } from "@/router";
-import { Setting_SettingName } from "@/types/proto-es/v1/setting_service_pb";
 import { provideSheetContext } from "@/views/sql-editor/Sheet";
 import { RequestDrawerHost } from "./RequestDrawerHost";
 import { SQLEditorRouteShell } from "./SQLEditorRouteShell";
@@ -15,47 +14,34 @@ import { useSQLEditorAutoSave } from "./useSQLEditorAutoSave";
  *  - the legacy `#sql-editor-debug` teleport target (kept hidden by
  *    default, used by debug `<li>` strings the inner shells emit).
  *  - the React `<BannersWrapper>` at the top.
- *  - workspace profile + environment fetch on mount, gated by Vue
- *    Router's `isReady()` so the SQL Editor doesn't bootstrap before
- *    initial route resolution.
+ *  - workspace-scope common data via `useEnsureWorkspaceCommonData()` —
+ *    the same hook DashboardFrameShell uses. Idempotent loaders make it
+ *    safe to call from every top-level shell.
  *  - `useSQLEditorAutoSave()` — the 2-second debounced worksheet
  *    auto-save extracted from the legacy `provideSQLEditorContext()`.
  *  - the `<SQLEditorRouteShell>` once `ready` flips true.
  */
 export function SQLEditorLayout() {
-  const getOrFetchSettingByName = useAppStore((s) => s.getOrFetchSettingByName);
-  const loadEnvironmentList = useAppStore((s) => s.loadEnvironmentList);
-  const loadServerInfo = useAppStore((s) => s.loadServerInfo);
-  const loadCurrentUser = useAppStore((s) => s.loadCurrentUser);
   // Boots the per-view watchers (selectedKeys ↔ active tab) the moment
   // the layout appears. The sheet-context singleton is module-level and
   // lazy — calling it here ensures the watchers are wired before any
   // child component reads from it.
   provideSheetContext();
 
-  const [ready, setReady] = useState(false);
+  const commonDataReady = useEnsureWorkspaceCommonData();
+  const [routerReady, setRouterReady] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
-      await router.isReady();
-      await Promise.all([
-        getOrFetchSettingByName(Setting_SettingName.WORKSPACE_PROFILE),
-        loadEnvironmentList(),
-        loadServerInfo(),
-        loadCurrentUser(),
-      ]);
-      if (!cancelled) setReady(true);
-    })();
+    void router.isReady().then(() => {
+      if (!cancelled) setRouterReady(true);
+    });
     return () => {
       cancelled = true;
     };
-  }, [
-    getOrFetchSettingByName,
-    loadEnvironmentList,
-    loadServerInfo,
-    loadCurrentUser,
-  ]);
+  }, []);
+
+  const ready = commonDataReady && routerReady;
 
   useSQLEditorAutoSave();
 

--- a/frontend/src/react/hooks/useEnsureWorkspaceCommonData.ts
+++ b/frontend/src/react/hooks/useEnsureWorkspaceCommonData.ts
@@ -1,0 +1,72 @@
+import { useEffect, useState } from "react";
+import { useAppStore } from "@/react/stores/app";
+
+/**
+ * Workspace-scope common data bootstrap.
+ *
+ * Every top-level React shell (DashboardFrameShell, SQLEditorLayout, and any
+ * future scope shell) calls this once. All loaders are idempotent (they
+ * dedupe via in-flight request refs in the app store), so wiring this hook
+ * up at multiple shells does not produce duplicate gRPC calls — it just
+ * guarantees the data is loading by the time any descendant page mounts.
+ *
+ * Pages should not call these loaders individually any more. The whole
+ * point of this hook is to remove the "did I remember to fetch on this
+ * page?" failure mode. Anything that needs to wait until permissions are
+ * ready can use `usePermissionDataReady()` from ComponentPermissionGuard,
+ * which awaits the same idempotent request.
+ *
+ * Auth-flow pages (SetupPage, ProfileSetupPage, OAuth2ConsentPage) render
+ * outside any shell; they still handle their own loads because they need
+ * a subset of this data before any shell would otherwise mount.
+ *
+ * Returns `true` once the initial bootstrap promise has settled. Shells
+ * use it to gate their loading spinner.
+ */
+export function useEnsureWorkspaceCommonData(): boolean {
+  const loadCurrentUser = useAppStore((state) => state.loadCurrentUser);
+  const loadServerInfo = useAppStore((state) => state.loadServerInfo);
+  const loadWorkspace = useAppStore((state) => state.loadWorkspace);
+  const loadWorkspaceProfile = useAppStore(
+    (state) => state.loadWorkspaceProfile
+  );
+  const loadEnvironmentList = useAppStore((state) => state.loadEnvironmentList);
+  const loadWorkspacePermissionState = useAppStore(
+    (state) => state.loadWorkspacePermissionState
+  );
+  const loadSubscription = useAppStore((state) => state.loadSubscription);
+
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.all([
+      loadCurrentUser(),
+      loadServerInfo(),
+      loadWorkspace(),
+      loadWorkspaceProfile(),
+      loadEnvironmentList(),
+      loadWorkspacePermissionState(),
+      loadSubscription(),
+    ])
+      .catch(() => undefined)
+      .then(() => {
+        if (!cancelled) {
+          setReady(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    loadCurrentUser,
+    loadServerInfo,
+    loadWorkspace,
+    loadWorkspaceProfile,
+    loadEnvironmentList,
+    loadWorkspacePermissionState,
+    loadSubscription,
+  ]);
+
+  return ready;
+}

--- a/frontend/src/react/pages/project/database-detail/DatabaseDetailActions.tsx
+++ b/frontend/src/react/pages/project/database-detail/DatabaseDetailActions.tsx
@@ -5,7 +5,8 @@ import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { Button } from "@/react/components/ui/button";
 import { useVueState } from "@/react/hooks/useVueState";
 import { preCreateIssue } from "@/react/lib/plan/issue";
-import { usePermissionStore, useProjectV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { useProjectV1Store } from "@/store";
 import type { Permission } from "@/types";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { DatabaseExportSchemaButton } from "./DatabaseExportSchemaButton";
@@ -27,20 +28,23 @@ export function DatabaseDetailActions({
 }) {
   const { t } = useTranslation();
   const projectStore = useProjectV1Store();
-  const permissionStore = usePermissionStore();
+  const hasProjectPermissionFn = useAppStore(
+    (state) => state.hasProjectPermission
+  );
+  const hasWorkspacePermissionFn = useAppStore(
+    (state) => state.hasWorkspacePermission
+  );
   const project = useVueState(() =>
     projectStore.getProjectByName(database.project)
   );
   const hasProjectPermission = useMemo(
     () => (permission: Permission) => {
-      if (permissionStore.currentPermissions.has(permission)) {
+      if (hasWorkspacePermissionFn(permission)) {
         return true;
       }
-      return project
-        ? permissionStore.currentPermissionsInProjectV1(project).has(permission)
-        : false;
+      return project ? hasProjectPermissionFn(project, permission) : false;
     },
-    [permissionStore, project]
+    [hasProjectPermissionFn, hasWorkspacePermissionFn, project]
   );
 
   const canUpdate = useMemo(

--- a/frontend/src/react/pages/project/database-detail/DatabaseSQLEditorButton.tsx
+++ b/frontend/src/react/pages/project/database-detail/DatabaseSQLEditorButton.tsx
@@ -1,9 +1,9 @@
 import { SquareTerminal } from "lucide-react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { SQL_EDITOR_DATABASE_MODULE } from "@/router/sqlEditor";
-import { usePermissionStore } from "@/store";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { defaultProject, isDefaultProject } from "@/types/v1/project";
 
@@ -32,7 +32,12 @@ export function DatabaseSQLEditorButton({
   onFailed?: (database: Database) => void;
 }) {
   const { t } = useTranslation();
-  const permissionStore = usePermissionStore();
+  const hasProjectPermissionFn = useAppStore(
+    (state) => state.hasProjectPermission
+  );
+  const hasWorkspacePermissionFn = useAppStore(
+    (state) => state.hasWorkspacePermission
+  );
 
   const handleClick = useCallback(() => {
     if (disabled) {
@@ -40,12 +45,13 @@ export function DatabaseSQLEditorButton({
     }
 
     if (isDefaultProject(database.project)) {
-      if (
-        !permissionStore.currentPermissions.has("bb.sql.select") &&
-        !permissionStore
-          .currentPermissionsInProjectV1(defaultProject(database.project))
-          .has("bb.sql.select")
-      ) {
+      const canQuery =
+        hasWorkspacePermissionFn("bb.sql.select") ||
+        hasProjectPermissionFn(
+          defaultProject(database.project),
+          "bb.sql.select"
+        );
+      if (!canQuery) {
         onFailed?.(database);
         return;
       }
@@ -67,7 +73,13 @@ export function DatabaseSQLEditorButton({
     }
 
     window.open(route.fullPath, "_blank");
-  }, [database, disabled, onFailed, permissionStore]);
+  }, [
+    database,
+    disabled,
+    hasProjectPermissionFn,
+    hasWorkspacePermissionFn,
+    onFailed,
+  ]);
 
   return (
     <dd

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
@@ -501,7 +501,6 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const page = useIssueDetailContext();
   const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
-  const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
   const batchGetOrFetchUsers = useAppStore(
     (state) => state.batchGetOrFetchUsers
   );
@@ -561,10 +560,19 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
     );
   }, [currentUserEmail, issue.creator, stepApprover?.status]);
 
-  const groupNamesKey = useVueState(() => {
-    const policy = getProjectIamPolicy(projectName);
+  // Subscribe directly to the Zustand project IAM cache so groupNames /
+  // candidateEmails recompute the moment loadProjectIamPolicy() resolves.
+  // Wrapping the Zustand getter in useVueState would only react to Vue
+  // dependencies and miss the Zustand write, leaving the approval step
+  // empty on a cold issue page.
+  const projectIamPolicy = useAppStore(
+    (state) => state.projectPoliciesByName[projectName]
+  );
+
+  const groupNames = useMemo(() => {
+    if (!projectIamPolicy) return [];
     const names: string[] = [];
-    for (const binding of policy.bindings) {
+    for (const binding of projectIamPolicy.bindings) {
       if (binding.role !== step || isBindingPolicyExpired(binding)) {
         continue;
       }
@@ -574,20 +582,17 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
         }
       }
     }
-    return [...new Set(names)].sort().join("\u0000");
-  });
-  const groupNames = useMemo(() => {
-    return groupNamesKey ? groupNamesKey.split("\u0000") : [];
-  }, [groupNamesKey]);
+    return [...new Set(names)].sort();
+  }, [projectIamPolicy, step]);
 
   useEffect(() => {
     void batchGetOrFetchGroups(groupNames).catch(() => undefined);
   }, [groupNames, batchGetOrFetchGroups]);
 
-  const candidateEmailsKey = useVueState(() => {
-    const policy = getProjectIamPolicy(projectName);
+  const candidateEmails = useMemo(() => {
+    if (!projectIamPolicy) return [];
     const memberMap = memberMapToRolesInProjectIAM(
-      policy,
+      projectIamPolicy,
       step,
       getGroupByIdentifier
     );
@@ -597,11 +602,8 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
         candidates.push(fullname);
       }
     }
-    return [...new Set(candidates)].sort().join("\u0000");
-  });
-  const candidateEmails = useMemo(() => {
-    return candidateEmailsKey ? candidateEmailsKey.split("\u0000") : [];
-  }, [candidateEmailsKey]);
+    return [...new Set(candidates)].sort();
+  }, [projectIamPolicy, step, getGroupByIdentifier]);
 
   const isCurrentUserInCandidates = useMemo(() => {
     return candidateEmails.includes(`${userNamePrefix}${currentUserEmail}`);

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailApprovalFlow.tsx
@@ -20,11 +20,7 @@ import { displayRoleTitleFromList } from "@/react/lib/role";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { ensureGroupIdentifier } from "@/react/stores/app/group";
-import {
-  pushNotification,
-  useProjectIamPolicyStore,
-  useProjectV1Store,
-} from "@/store";
+import { pushNotification, useProjectV1Store } from "@/store";
 import { projectNamePrefix, userNamePrefix } from "@/store/modules/v1/common";
 import {
   ApprovalStatus,
@@ -57,7 +53,9 @@ export function IssueDetailApprovalFlow() {
   const { t } = useTranslation();
   const page = useIssueDetailContext();
   const projectStore = useProjectV1Store();
-  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const loadProjectIamPolicy = useAppStore(
+    (state) => state.loadProjectIamPolicy
+  );
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const issue = page.issue;
 
@@ -65,10 +63,8 @@ export function IssueDetailApprovalFlow() {
     void projectStore
       .getOrFetchProjectByName(projectName)
       .catch(() => undefined);
-    void projectIamPolicyStore
-      .getOrFetchProjectIamPolicy(projectName)
-      .catch(() => undefined);
-  }, [projectIamPolicyStore, projectName, projectStore]);
+    void loadProjectIamPolicy(projectName).catch(() => undefined);
+  }, [loadProjectIamPolicy, projectName, projectStore]);
 
   if (!issue) {
     return null;
@@ -505,7 +501,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const page = useIssueDetailContext();
   const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
-  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
   const batchGetOrFetchUsers = useAppStore(
     (state) => state.batchGetOrFetchUsers
   );
@@ -566,7 +562,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   }, [currentUserEmail, issue.creator, stepApprover?.status]);
 
   const groupNamesKey = useVueState(() => {
-    const policy = projectIamPolicyStore.getProjectIamPolicy(projectName);
+    const policy = getProjectIamPolicy(projectName);
     const names: string[] = [];
     for (const binding of policy.bindings) {
       if (binding.role !== step || isBindingPolicyExpired(binding)) {
@@ -589,7 +585,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   }, [groupNames, batchGetOrFetchGroups]);
 
   const candidateEmailsKey = useVueState(() => {
-    const policy = projectIamPolicyStore.getProjectIamPolicy(projectName);
+    const policy = getProjectIamPolicy(projectName);
     const memberMap = memberMapToRolesInProjectIAM(
       policy,
       step,

--- a/frontend/src/react/pages/project/issue-detail/utils/rollout.ts
+++ b/frontend/src/react/pages/project/issue-detail/utils/rollout.ts
@@ -1,4 +1,5 @@
-import { usePolicyV1Store, useProjectIamPolicyStore } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { usePolicyV1Store } from "@/store";
 import { roleNamePrefix } from "@/store/modules/v1/common";
 import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
 import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
@@ -59,11 +60,10 @@ export const canRolloutTasks = ({
     return true;
   }
 
-  const projectIamPolicyStore = useProjectIamPolicyStore();
   const policyStore = usePolicyV1Store();
-  const projectIamPolicy = projectIamPolicyStore.getProjectIamPolicy(
-    project.name
-  );
+  const projectIamPolicy = useAppStore
+    .getState()
+    .getProjectIamPolicy(project.name);
   const memberRoles = memberMapToRolesInProjectIAM(projectIamPolicy);
   const userRoles = memberRoles.get(currentUser.name);
 
@@ -117,10 +117,9 @@ export const preloadRolloutPermissionContext = async ({
   }
 
   const policyStore = usePolicyV1Store();
-  const projectIamPolicyStore = useProjectIamPolicyStore();
 
   await Promise.allSettled([
-    projectIamPolicyStore.getOrFetchProjectIamPolicy(projectName),
+    useAppStore.getState().loadProjectIamPolicy(projectName),
   ]);
 
   const policyResults = await Promise.allSettled([

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
@@ -93,7 +93,9 @@ vi.mock("@/react/stores/app", () => ({
       roleList: mocks.roleList,
       loadProjectIamPolicy:
         mocks.projectIamPolicyStore.getOrFetchProjectIamPolicy,
-      getProjectIamPolicy: mocks.projectIamPolicyStore.getProjectIamPolicy,
+      // The approval flow now subscribes to projectPoliciesByName directly
+      // so the candidate list re-renders when the policy resolves.
+      projectPoliciesByName: { "projects/p1": { bindings: [] } },
     }),
 }));
 

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx
@@ -77,7 +77,6 @@ vi.mock("@/connect", () => ({
 
 vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
-  useProjectIamPolicyStore: () => mocks.projectIamPolicyStore,
   useProjectV1Store: () => mocks.projectStore,
 }));
 
@@ -92,6 +91,9 @@ vi.mock("@/react/stores/app", () => ({
       batchGetOrFetchUsers: mocks.batchGetOrFetchUsers,
       getOrFetchUserByIdentifier: mocks.getOrFetchUserByIdentifier,
       roleList: mocks.roleList,
+      loadProjectIamPolicy:
+        mocks.projectIamPolicyStore.getOrFetchProjectIamPolicy,
+      getProjectIamPolicy: mocks.projectIamPolicyStore.getProjectIamPolicy,
     }),
 }));
 

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.tsx
@@ -663,7 +663,6 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const { patchState } = page;
   const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
-  const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
   const batchGetOrFetchUsers = useAppStore(
     (state) => state.batchGetOrFetchUsers
   );
@@ -685,7 +684,14 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const currentUserEmail = currentUser?.email ?? "";
   const project = useVueState(() => projectStore.getProjectByName(projectName));
-  const projectIamPolicy = useVueState(() => getProjectIamPolicy(projectName));
+  // Subscribe directly to the Zustand project IAM cache so this step
+  // re-renders the moment loadProjectIamPolicy() resolves. Wrapping the
+  // Zustand getter in useVueState would only react to Vue dependencies
+  // and miss the Zustand write, leaving the candidates list empty on a
+  // cold plan page.
+  const projectIamPolicy = useAppStore(
+    (state) => state.projectPoliciesByName[projectName]
+  );
   const stepApprover = issue.approvers[stepIndex];
 
   const status = useMemo<ApprovalStepStatus>(() => {

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.tsx
@@ -22,11 +22,7 @@ import { useAppStore } from "@/react/stores/app";
 import { ensureGroupIdentifier } from "@/react/stores/app/group";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
-import {
-  pushNotification,
-  useProjectIamPolicyStore,
-  useProjectV1Store,
-} from "@/store";
+import { pushNotification, useProjectV1Store } from "@/store";
 import { projectNamePrefix, userNamePrefix } from "@/store/modules/v1/common";
 import {
   getIssueCommentType,
@@ -86,7 +82,9 @@ function PlanDetailApprovalFlowContent({
   const { t } = useTranslation();
   const page = usePlanDetailContext();
   const projectStore = useProjectV1Store();
-  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const loadProjectIamPolicy = useAppStore(
+    (state) => state.loadProjectIamPolicy
+  );
   const issueCommentStore = useIssueCommentStore();
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const issue = page.issue;
@@ -95,10 +93,8 @@ function PlanDetailApprovalFlowContent({
     void projectStore
       .getOrFetchProjectByName(projectName)
       .catch(() => undefined);
-    void projectIamPolicyStore
-      .getOrFetchProjectIamPolicy(projectName)
-      .catch(() => undefined);
-  }, [projectIamPolicyStore, projectName, projectStore]);
+    void loadProjectIamPolicy(projectName).catch(() => undefined);
+  }, [loadProjectIamPolicy, projectName, projectStore]);
 
   useEffect(() => {
     if (mode !== "review") {
@@ -667,7 +663,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const { patchState } = page;
   const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
-  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
   const batchGetOrFetchUsers = useAppStore(
     (state) => state.batchGetOrFetchUsers
   );
@@ -689,9 +685,7 @@ function useApprovalStep(issue: Issue, step: string, stepIndex: number) {
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const currentUserEmail = currentUser?.email ?? "";
   const project = useVueState(() => projectStore.getProjectByName(projectName));
-  const projectIamPolicy = useVueState(() =>
-    projectIamPolicyStore.getProjectIamPolicy(projectName)
-  );
+  const projectIamPolicy = useVueState(() => getProjectIamPolicy(projectName));
   const stepApprover = issue.approvers[stepIndex];
 
   const status = useMemo<ApprovalStepStatus>(() => {

--- a/frontend/src/react/pages/settings/MembersPage.test.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.test.tsx
@@ -313,6 +313,10 @@ vi.mock("@/react/stores/app", () => ({
       patchWorkspaceIamPolicy: vi.fn(),
       findWorkspaceRolesByMember: () => [],
       fetchWorkspaceIamPolicy: vi.fn(async () => undefined),
+      // MembersPage now subscribes to projectPoliciesByName directly so it
+      // re-renders when loadProjectIamPolicy() resolves. The getter form is
+      // still used inside async handlers.
+      projectPoliciesByName: { "projects/sample-project": projectIamPolicy },
       getProjectIamPolicy: () => projectIamPolicy,
       updateProjectIamPolicy: mockUpdateProjectIamPolicy,
       loadProjectIamPolicy: vi.fn(async () => undefined),

--- a/frontend/src/react/pages/settings/MembersPage.test.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.test.tsx
@@ -279,11 +279,6 @@ vi.mock("@/store", () => ({
     isSaaSMode: false,
     userCountInIam: 1,
   }),
-  useProjectIamPolicyStore: () => ({
-    getOrFetchProjectIamPolicy: vi.fn(),
-    getProjectIamPolicy: () => projectIamPolicy,
-    updateProjectIamPolicy: mockUpdateProjectIamPolicy,
-  }),
   useProjectV1Store: () => ({
     getProjectByName: (name: string) => ({
       allowRequestRole: true,
@@ -318,6 +313,9 @@ vi.mock("@/react/stores/app", () => ({
       patchWorkspaceIamPolicy: vi.fn(),
       findWorkspaceRolesByMember: () => [],
       fetchWorkspaceIamPolicy: vi.fn(async () => undefined),
+      getProjectIamPolicy: () => projectIamPolicy,
+      updateProjectIamPolicy: mockUpdateProjectIamPolicy,
+      loadProjectIamPolicy: vi.fn(async () => undefined),
     }),
 }));
 

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -1897,7 +1897,6 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   const subscriptionStore = useSubscriptionV1Store();
   const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
-  const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
   const updateProjectIamPolicy = useAppStore(
     (state) => state.updateProjectIamPolicy
   );
@@ -1935,8 +1934,13 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   // loads project IAM on /projects/:projectId/members, and
   // DashboardFrameShell's useEnsureWorkspaceCommonData loads workspace IAM
   // (+ referenced groups) on /settings/members. This page just reads them.
-  const projectIamPolicy = useVueState(() =>
-    projectName ? getProjectIamPolicy(projectName) : undefined
+  // Subscribe directly to the Zustand projectPoliciesByName slice so the
+  // member table re-renders when loadProjectIamPolicy / updateProjectIamPolicy
+  // writes to the app store. Wrapping `getProjectIamPolicy()` in
+  // `useVueState` would only re-render on Vue reactivity changes and miss
+  // these Zustand writes.
+  const projectIamPolicy = useAppStore((state) =>
+    projectName ? state.projectPoliciesByName[projectName] : undefined
   );
 
   // `useVueState` ensures we re-render whenever any reactive dep

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -83,7 +83,6 @@ import { useAppStore } from "@/react/stores/app";
 import {
   pushNotification,
   useActuatorV1Store,
-  useProjectIamPolicyStore,
   useProjectV1Store,
   useSettingV1Store,
   useSubscriptionV1Store,
@@ -1244,7 +1243,10 @@ function EditMemberRoleDrawer({
   const findWorkspaceRolesByMember = useAppStore(
     (state) => state.findWorkspaceRolesByMember
   );
-  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
+  const updateProjectIamPolicy = useAppStore(
+    (state) => state.updateProjectIamPolicy
+  );
   const isSaaSMode = useVueState(() => useActuatorV1Store().isSaaSMode);
   const settingV1Store = useSettingV1Store();
   const roleList = useAppStore((state) => state.roleList);
@@ -1263,7 +1265,7 @@ function EditMemberRoleDrawer({
   // Active bindings come first, expired ones last; original order is preserved within each group.
   const liveProjectRoleBindings = useVueState(() => {
     if (!isProjectEditMode || !member || !projectName) return [];
-    const policy = projectIamPolicyStore.getProjectIamPolicy(projectName);
+    const policy = getProjectIamPolicy(projectName);
     const matching = policy.bindings.filter((b) =>
       b.members.includes(member.binding)
     );
@@ -1340,9 +1342,7 @@ function EditMemberRoleDrawer({
       return;
     setIsRequesting(true);
     try {
-      const policy = structuredClone(
-        projectIamPolicyStore.getProjectIamPolicy(projectName)
-      );
+      const policy = structuredClone(getProjectIamPolicy(projectName));
       const match = policy.bindings.find(
         (b) =>
           b.role === roleBinding.role &&
@@ -1353,7 +1353,7 @@ function EditMemberRoleDrawer({
         match.members = match.members.filter((m) => m !== member.binding);
       }
       policy.bindings = policy.bindings.filter((b) => b.members.length > 0);
-      await projectIamPolicyStore.updateProjectIamPolicy(projectName, policy);
+      await updateProjectIamPolicy(projectName, policy);
       pushNotification({
         module: "bytebase",
         style: "SUCCESS",
@@ -1377,9 +1377,7 @@ function EditMemberRoleDrawer({
     setIsRequesting(true);
     try {
       if (projectName) {
-        const policy = structuredClone(
-          projectIamPolicyStore.getProjectIamPolicy(projectName)
-        );
+        const policy = structuredClone(getProjectIamPolicy(projectName));
         if (isEditMode) {
           // Remove member from unconditional bindings only;
           // preserve conditional bindings (expiration, database scope)
@@ -1544,7 +1542,7 @@ function EditMemberRoleDrawer({
             }
           }
         }
-        await projectIamPolicyStore.updateProjectIamPolicy(projectName, policy);
+        await updateProjectIamPolicy(projectName, policy);
       } else {
         if (isEditMode) {
           await patchWorkspaceIamPolicy([
@@ -1587,14 +1585,12 @@ function EditMemberRoleDrawer({
     setIsRequesting(true);
     try {
       if (projectName) {
-        const policy = structuredClone(
-          projectIamPolicyStore.getProjectIamPolicy(projectName)
-        );
+        const policy = structuredClone(getProjectIamPolicy(projectName));
         for (const binding of policy.bindings) {
           binding.members = binding.members.filter((m) => m !== member.binding);
         }
         policy.bindings = policy.bindings.filter((b) => b.members.length > 0);
-        await projectIamPolicyStore.updateProjectIamPolicy(projectName, policy);
+        await updateProjectIamPolicy(projectName, policy);
       } else {
         await patchWorkspaceIamPolicy([{ member: member.binding, roles: [] }]);
       }
@@ -1904,7 +1900,13 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   const subscriptionStore = useSubscriptionV1Store();
   const currentUser = useCurrentUser();
   const projectStore = useProjectV1Store();
-  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
+  const updateProjectIamPolicy = useAppStore(
+    (state) => state.updateProjectIamPolicy
+  );
+  const loadProjectIamPolicy = useAppStore(
+    (state) => state.loadProjectIamPolicy
+  );
 
   const userCountInIam = useVueState(() => actuatorStore.userCountInIam);
   const userCountLimit = useVueState(() => subscriptionStore.userCountLimit);
@@ -1938,16 +1940,14 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   // Fetch project IAM policy on mount
   useEffect(() => {
     if (projectName) {
-      projectIamPolicyStore.getOrFetchProjectIamPolicy(projectName);
+      void loadProjectIamPolicy(projectName);
     } else {
       void fetchWorkspaceIamPolicy();
     }
-  }, [projectName, projectIamPolicyStore, fetchWorkspaceIamPolicy]);
+  }, [projectName, loadProjectIamPolicy, fetchWorkspaceIamPolicy]);
 
   const projectIamPolicy = useVueState(() =>
-    projectName
-      ? projectIamPolicyStore.getProjectIamPolicy(projectName)
-      : undefined
+    projectName ? getProjectIamPolicy(projectName) : undefined
   );
 
   // `useVueState` ensures we re-render whenever any reactive dep
@@ -2005,10 +2005,7 @@ export function MembersPage({ projectId }: { projectId?: string }) {
             );
           }
           policy.bindings = policy.bindings.filter((b) => b.members.length > 0);
-          await projectIamPolicyStore.updateProjectIamPolicy(
-            projectName,
-            policy
-          );
+          await updateProjectIamPolicy(projectName, policy);
         } else {
           await patchWorkspaceIamPolicy(
             selectedMembers.map((m) => ({ member: m, roles: [] }))
@@ -2039,7 +2036,7 @@ export function MembersPage({ projectId }: { projectId?: string }) {
           b.members = b.members.filter((member) => member !== binding.binding);
         }
         policy.bindings = policy.bindings.filter((b) => b.members.length > 0);
-        await projectIamPolicyStore.updateProjectIamPolicy(projectName, policy);
+        await updateProjectIamPolicy(projectName, policy);
       } else {
         await patchWorkspaceIamPolicy([{ member: binding.binding, roles: [] }]);
       }

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -1893,9 +1893,6 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   const patchWorkspaceIamPolicy = useAppStore(
     (state) => state.patchWorkspaceIamPolicy
   );
-  const fetchWorkspaceIamPolicy = useAppStore(
-    (state) => state.fetchWorkspaceIamPolicy
-  );
   const actuatorStore = useActuatorV1Store();
   const subscriptionStore = useSubscriptionV1Store();
   const currentUser = useCurrentUser();
@@ -1903,9 +1900,6 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
   const updateProjectIamPolicy = useAppStore(
     (state) => state.updateProjectIamPolicy
-  );
-  const loadProjectIamPolicy = useAppStore(
-    (state) => state.loadProjectIamPolicy
   );
 
   const userCountInIam = useVueState(() => actuatorStore.userCountInIam);
@@ -1937,15 +1931,10 @@ export function MembersPage({ projectId }: { projectId?: string }) {
     subscriptionStore.hasFeature(PlanFeature.FEATURE_REQUEST_ROLE_WORKFLOW)
   );
 
-  // Fetch project IAM policy on mount
-  useEffect(() => {
-    if (projectName) {
-      void loadProjectIamPolicy(projectName);
-    } else {
-      void fetchWorkspaceIamPolicy();
-    }
-  }, [projectName, loadProjectIamPolicy, fetchWorkspaceIamPolicy]);
-
+  // IAM policy loads are owned by the parent shells: ProjectRouteShell
+  // loads project IAM on /projects/:projectId/members, and
+  // DashboardFrameShell's useEnsureWorkspaceCommonData loads workspace IAM
+  // (+ referenced groups) on /settings/members. This page just reads them.
   const projectIamPolicy = useVueState(() =>
     projectName ? getProjectIamPolicy(projectName) : undefined
   );

--- a/frontend/src/react/pages/settings/RolesPage.tsx
+++ b/frontend/src/react/pages/settings/RolesPage.tsx
@@ -674,9 +674,6 @@ export function RolesPage() {
   const listRoles = useAppStore((state) => state.listRoles);
   const getRoleByName = useAppStore((state) => state.getRoleByName);
   const deleteRole = useAppStore((state) => state.deleteRole);
-  const fetchWorkspaceIamPolicy = useAppStore(
-    (state) => state.fetchWorkspaceIamPolicy
-  );
   const subscriptionStore = useSubscriptionV1Store();
 
   const [ready, setReady] = useState(false);
@@ -703,11 +700,11 @@ export function RolesPage() {
     );
   }, [roleList]);
 
-  // Fetch roles on mount and handle query param
+  // Fetch roles on mount and handle query param. The workspace IAM policy
+  // and its referenced groups (used by the "users with this role" delete
+  // confirmation) are loaded centrally by useEnsureWorkspaceCommonData in
+  // the dashboard shell, so this page doesn't need to hedge here.
   useEffect(() => {
-    // The workspace IAM policy backs the "users with this role" list shown in
-    // the delete confirmation; load it (and referenced groups) alongside roles.
-    void fetchWorkspaceIamPolicy();
     listRoles()
       .then(() => {
         const urlParams = new URLSearchParams(window.location.search);

--- a/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
+++ b/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
@@ -41,7 +41,6 @@ import {
   useProjectV1Store,
 } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
-import { useProjectIamPolicyStore } from "@/store/modules/v1/projectIamPolicy";
 import {
   getServiceAccountNameInBinding,
   getServiceAccountSuffix,
@@ -436,7 +435,10 @@ function ServiceAccountForm({
   );
   const actuatorStore = useActuatorV1Store();
   const projectStore = useProjectV1Store();
-  const projectIamPolicyStore = useProjectIamPolicyStore();
+  const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
+  const updateProjectIamPolicy = useAppStore(
+    (state) => state.updateProjectIamPolicy
+  );
 
   const projectEntity = useVueState(() =>
     project ? projectStore.getProjectByName(project) : undefined
@@ -504,9 +506,7 @@ function ServiceAccountForm({
     member: string,
     newRoles: string[]
   ) => {
-    const policy = structuredClone(
-      projectIamPolicyStore.getProjectIamPolicy(projectName)
-    );
+    const policy = structuredClone(getProjectIamPolicy(projectName));
     for (const binding of policy.bindings) {
       binding.members = binding.members.filter((m) => m !== member);
     }
@@ -525,7 +525,7 @@ function ServiceAccountForm({
         );
       }
     }
-    await projectIamPolicyStore.updateProjectIamPolicy(projectName, policy);
+    await updateProjectIamPolicy(projectName, policy);
   };
 
   const handleCreate = async () => {

--- a/frontend/src/react/pages/settings/UsersPage.tsx
+++ b/frontend/src/react/pages/settings/UsersPage.tsx
@@ -926,15 +926,6 @@ export function UsersPage() {
   const actuatorStore = useActuatorV1Store();
   const subscriptionStore = useSubscriptionV1Store();
   const listUsers = useAppStore((state) => state.listUsers);
-  const fetchWorkspaceIamPolicy = useAppStore(
-    (state) => state.fetchWorkspaceIamPolicy
-  );
-
-  // Load the workspace IAM policy (and the groups it references) so the
-  // create/edit user sheet can resolve each user's current roles at open.
-  useEffect(() => {
-    void fetchWorkspaceIamPolicy();
-  }, [fetchWorkspaceIamPolicy]);
 
   const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
 

--- a/frontend/src/react/pages/settings/profile/ProfilePage.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.tsx
@@ -80,14 +80,7 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
   const getWorkspaceRolesByName = useAppStore(
     (state) => state.getWorkspaceRolesByName
   );
-  const fetchWorkspaceIamPolicy = useAppStore(
-    (state) => state.fetchWorkspaceIamPolicy
-  );
   const actuatorStore = useActuatorV1Store();
-
-  useEffect(() => {
-    void fetchWorkspaceIamPolicy();
-  }, [fetchWorkspaceIamPolicy]);
 
   // --- Reactive Vue state ---
   const legacyCurrentUser = useCurrentUser();

--- a/frontend/src/react/stores/app/iam.ts
+++ b/frontend/src/react/stores/app/iam.ts
@@ -11,6 +11,7 @@ import {
   BindingSchema,
   GetIamPolicyRequestSchema,
   type IamPolicy,
+  IamPolicySchema,
   SetIamPolicyRequestSchema,
 } from "@/types/proto-es/v1/iam_policy_pb";
 import { ListRolesRequestSchema } from "@/types/proto-es/v1/role_service_pb";
@@ -159,6 +160,48 @@ export const createIamSlice: AppSliceCreator<IamSlice> = (set, get) => ({
       },
     }));
     return request;
+  },
+
+  getProjectIamPolicy: (project) => {
+    return (
+      get().projectPoliciesByName[project] ?? createProto(IamPolicySchema, {})
+    );
+  },
+
+  updateProjectIamPolicy: async (project, policy) => {
+    // Dedupe members within each binding (mirrors the Pinia store's
+    // pre-write normalization).
+    const deduped = cloneDeep(policy);
+    for (const binding of deduped.bindings) {
+      if (binding.members) {
+        binding.members = [...new Set(binding.members)];
+      }
+    }
+    const updated = await projectServiceClientConnect.setIamPolicy(
+      createProto(SetIamPolicyRequestSchema, {
+        resource: project,
+        policy: deduped,
+        etag: deduped.etag,
+      })
+    );
+    set((state) => ({
+      projectPoliciesByName: {
+        ...state.projectPoliciesByName,
+        [project]: updated,
+      },
+    }));
+    // Bridge to the Pinia projectIamPolicy store so the legacy
+    // permission chain sees the updated policy. setProjectIamPolicy also
+    // invalidates the Pinia permission cache by project.
+    try {
+      const { useProjectIamPolicyStore } = await import(
+        "@/store/modules/v1/projectIamPolicy"
+      );
+      useProjectIamPolicyStore().setProjectIamPolicy(project, updated);
+    } catch {
+      // Pinia not available — app-store cache is already populated.
+    }
+    return updated;
   },
 
   fetchWorkspaceIamPolicy: async () => {

--- a/frontend/src/react/stores/app/iam.ts
+++ b/frontend/src/react/stores/app/iam.ts
@@ -92,8 +92,20 @@ export const createIamSlice: AppSliceCreator<IamSlice> = (set, get) => ({
         .getIamPolicy(
           createProto(GetIamPolicyRequestSchema, { resource: policyResource })
         )
-        .then((workspacePolicy) => {
+        .then(async (workspacePolicy) => {
           set({ workspacePolicy, workspacePolicyRequest: undefined });
+          // Prefetch groups referenced by the policy so derived role/user
+          // maps (and any UI that resolves group display names) read from
+          // a populated cache. Without this every page that reads the
+          // policy had to hedge with its own fetchWorkspaceIamPolicy().
+          const groupMembers = workspacePolicy.bindings
+            .flatMap((binding) => binding.members)
+            .filter((member) => member.startsWith(groupBindingPrefix));
+          if (groupMembers.length > 0) {
+            await get()
+              .batchGetOrFetchGroups(groupMembers)
+              .catch(() => []);
+          }
           return workspacePolicy;
         })
         .catch(() => {

--- a/frontend/src/react/stores/app/iam.ts
+++ b/frontend/src/react/stores/app/iam.ts
@@ -146,11 +146,20 @@ export const createIamSlice: AppSliceCreator<IamSlice> = (set, get) => ({
         // the policy without a second fetch. Dynamic import to avoid a
         // static module-load cycle (Pinia projectIamPolicy transitively
         // imports `@/store` chains that would re-enter this app store).
+        // Also run composePolicyBindings so the Pinia user / group /
+        // service-account / workload-identity stores that `getMemberBindings`
+        // reads from are populated — without this prefetch, the project
+        // members table renders "unknown" titles until some unrelated
+        // load happens.
         try {
-          const { useProjectIamPolicyStore } = await import(
-            "@/store/modules/v1/projectIamPolicy"
-          );
+          const { useProjectIamPolicyStore, composePolicyBindings } =
+            await import("@/store/modules/v1/projectIamPolicy");
           useProjectIamPolicyStore().setProjectIamPolicy(project, policy);
+          // Prefetch policy members into the Pinia user / group /
+          // service-account / workload-identity stores so getMemberBindings
+          // can resolve titles immediately. This is the same step the
+          // legacy fetchProjectIamPolicy path used to run.
+          await composePolicyBindings(policy.bindings);
         } catch {
           // Pinia not available (e.g. some isolated test). Safe to ignore —
           // the app-store cache is already populated.
@@ -204,12 +213,16 @@ export const createIamSlice: AppSliceCreator<IamSlice> = (set, get) => ({
     }));
     // Bridge to the Pinia projectIamPolicy store so the legacy
     // permission chain sees the updated policy. setProjectIamPolicy also
-    // invalidates the Pinia permission cache by project.
+    // invalidates the Pinia permission cache by project. composePolicyBindings
+    // refreshes the Pinia user / group / service-account / workload-identity
+    // stores that getMemberBindings reads — without it the members table
+    // could render stale titles for newly granted members.
     try {
-      const { useProjectIamPolicyStore } = await import(
+      const { useProjectIamPolicyStore, composePolicyBindings } = await import(
         "@/store/modules/v1/projectIamPolicy"
       );
       useProjectIamPolicyStore().setProjectIamPolicy(project, updated);
+      await composePolicyBindings(updated.bindings);
     } catch {
       // Pinia not available — app-store cache is already populated.
     }

--- a/frontend/src/react/stores/app/projectWebhook.ts
+++ b/frontend/src/react/stores/app/projectWebhook.ts
@@ -6,7 +6,7 @@ import {
   TestWebhookRequestSchema,
   UpdateWebhookRequestSchema,
 } from "@/types/proto-es/v1/project_service_pb";
-import { extractProjectWebhookID } from "@/utils";
+import { extractProjectWebhookID } from "@/utils/v1/projectWebhook";
 import type { AppSliceCreator, ProjectWebhookSlice } from "./types";
 
 export const createProjectWebhookSlice: AppSliceCreator<ProjectWebhookSlice> = (

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -220,6 +220,11 @@ export type IamSlice = {
   rolesRequest?: Promise<Role[]>;
   loadWorkspacePermissionState: () => Promise<void>;
   loadProjectIamPolicy: (project: string) => Promise<IamPolicy | undefined>;
+  getProjectIamPolicy: (project: string) => IamPolicy;
+  updateProjectIamPolicy: (
+    project: string,
+    policy: IamPolicy
+  ) => Promise<IamPolicy>;
   fetchWorkspaceIamPolicy: () => Promise<IamPolicy>;
   patchWorkspaceIamPolicy: (
     batchPatch: { member: string; roles: string[] }[]

--- a/frontend/src/react/stores/app/user.ts
+++ b/frontend/src/react/stores/app/user.ts
@@ -23,7 +23,7 @@ import {
   UpdateEmailRequestSchema,
   UpdateUserRequestSchema,
 } from "@/types/proto-es/v1/user_service_pb";
-import { ensureUserFullName } from "@/utils";
+import { ensureUserFullName } from "@/utils/v1/user";
 import type { AppSliceCreator, UserFilter, UserSlice } from "./types";
 
 const UNKNOWN_PROJECT_NAME_LEGACY = "projects/-";

--- a/frontend/src/react/stores/app/worksheet.ts
+++ b/frontend/src/react/stores/app/worksheet.ts
@@ -20,7 +20,7 @@ import {
   WorksheetSchema,
 } from "@/types/proto-es/v1/worksheet_service_pb";
 import { isValidDatabaseName } from "@/types/v1/database";
-import { extractWorksheetID } from "@/utils";
+import { extractWorksheetID } from "@/utils/v1/worksheet";
 import type { AppSliceCreator, WorksheetSlice, WorksheetView } from "./types";
 
 const cacheKey = (uid: string, view: WorksheetView) => `${uid}:${view}`;

--- a/frontend/src/utils/v1/iam.ts
+++ b/frontend/src/utils/v1/iam.ts
@@ -20,8 +20,8 @@ import {
 } from "@/types";
 import type { Group } from "@/types/proto-es/v1/group_service_pb";
 import type { Binding, IamPolicy } from "@/types/proto-es/v1/iam_policy_pb";
-import { ensureUserFullName } from "@/utils";
 import { convertFromExpr } from "@/utils/issue/cel";
+import { ensureUserFullName } from "@/utils/v1/user";
 
 export const isBindingPolicyExpired = (binding: Binding): boolean => {
   if (binding.parsedExpr) {


### PR DESCRIPTION
## Summary

The project IAM policy was only loaded by the React `/members` page. Other project routes — issue detail, plan detail, rollout utils, worksheet hydration, Quickstart, the SQL editor — read from the parallel Pinia `projectIamPolicy` store, which stayed empty until the user opened `/members`. Approval flows and permission-gated UI silently saw no bindings.

Three coordinated changes:

### 1. Auto-fetch + dual-cache sync

- `ProjectRouteShell` already calls `useAppStore.loadProjectIamPolicy` on project entry. That action now **mirrors the freshly fetched policy into the Pinia `useProjectIamPolicyStore`** via an awaited dynamic import (using main's `setProjectIamPolicy` bridge added in #20449). `composePolicyBindings` (inside the Pinia chain) also prefetches the groups + users referenced by the policy.
- New app store actions: `getProjectIamPolicy(project)` (sync read with empty-policy fallback) and `updateProjectIamPolicy(project, policy)` (gRPC `setIamPolicy` + cache write + Pinia mirror + Pinia permission-cache invalidation).

### 2. Migrate React consumers off Pinia project IAM / permission stores

- `DatabaseDetailActions`, `DatabaseSQLEditorButton`: drop `usePermissionStore`, read through `useAppStore.hasProjectPermission` / `hasWorkspacePermission`.
- `Quickstart`, `CreateWorkloadIdentitySheet`, `ServiceAccountsPage`, `MembersPage`, `IssueDetailApprovalFlow`, `PlanDetailApprovalFlow`, issue-detail `rollout` utils, and the SQL editor's worksheet slice: replace Pinia `getOrFetchProjectIamPolicy` / `getProjectIamPolicy` / `updateProjectIamPolicy` with the app store equivalents.
- Pinia `useProjectIamPolicyStore` now has zero React (non-test) consumers; remaining Pinia callers (`store/modules/v1/issue.ts`, `store/modules/v1/permission.ts`) stay populated through the new app-store sync.

### 3. Centralize workspace-common data via a shared hook

The workspace IAM policy + roles + workspace profile + environments load was scattered: `DashboardFrameShell` loaded some of it, `ComponentPermissionGuard` loaded permissions on every guarded render, and several pages hedged with their own `fetchWorkspaceIamPolicy()` effect — exactly the "did I remember to fetch on this page?" failure mode.

- New `useEnsureWorkspaceCommonData()` hook bundles every workspace-scope load (currentUser, serverInfo, workspace, workspaceProfile, environments, workspace permission state, subscription) into one idempotent Promise.all and returns a ready flag.
- `DashboardFrameShell` and `SQLEditorLayout` — the two top-level React shells — both call it. Every dashboard or SQL editor route is now covered by one chokepoint per scope, mirroring how `AuthContext.vue` works for Vue.
- `loadWorkspacePermissionState` now also prefetches the groups the policy references, so derived role/user maps work without a follow-up `fetchWorkspaceIamPolicy()` call from each consumer.
- Delete redundant per-page `fetchWorkspaceIamPolicy()` / `loadProjectIamPolicy()` hedges in `UsersPage`, `RolesPage`, `ProfilePage`, `MembersPage`. Auth-flow pages (SetupPage, ProfileSetupPage, OAuth2ConsentPage) keep their own loads since they render outside any shell.

### Review fixes (Codex pass)

- `MembersPage`, `IssueDetailApprovalFlow`, `PlanDetailApprovalFlow` previously read the project policy via `useVueState(() => getProjectIamPolicy(projectName))`. `useVueState` only re-renders on Vue reactive deps, so Zustand writes were missed and these consumers stayed on the empty fallback policy until an unrelated Vue update happened. Switch to a direct `useAppStore((state) => state.projectPoliciesByName[projectName])` subscription so dependent `useMemo`s recompute the moment the policy resolves.

### Cycle hygiene

- Deep-import in `@/utils/v1/iam.ts` and three app store slices (`worksheet.ts`, `projectWebhook.ts`, `user.ts`) so app store construction doesn't transitively re-enter itself through the `@/utils` barrel.

## Test plan

- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend check` (lint + biome + i18n + layering + locale sorter)
- [x] `pnpm --dir frontend test` — 2291/2291 across 239 files
- [ ] Manual: open `/projects/<id>/issues/...`, `/plans/...`, the SQL editor connection pane, and the project Quickstart **without first visiting `/members`**. Confirm permission-gated UI and approval candidate lists render with the right bindings on first paint.
- [ ] Manual: edit a project member role; confirm the member table updates in place without a navigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)