### PR TITLE
fix(frontend): stop GitOps release/plan pages going blank on refresh (BYT-9605, BYT-9606)

### DIFF
--- a/frontend/src/react/components/release/ReleaseInfoCard.test.tsx
+++ b/frontend/src/react/components/release/ReleaseInfoCard.test.tsx
@@ -111,10 +111,9 @@ describe("ReleaseInfoCard", () => {
     unmount();
   });
 
-  test("renders the not-found state when release is the unknown sentinel", async () => {
+  test("renders the not-found state when release has a placeholder name", async () => {
     ({ ReleaseInfoCard } = await import("./ReleaseInfoCard"));
-    // useReleaseByName returns an unknownRelease() sentinel on miss; its
-    // name is the placeholder "projects/-1/releases/-1" which fails
+    // A release whose name is the placeholder "projects/-1/releases/-1" fails
     // isValidReleaseName. The component must treat that as not-found.
     const sentinel = create(ReleaseSchema, {
       name: "projects/-1/releases/-1",

--- a/frontend/src/react/components/release/ReleaseInfoCard.tsx
+++ b/frontend/src/react/components/release/ReleaseInfoCard.tsx
@@ -25,9 +25,8 @@ export function ReleaseInfoCard({
   releaseName: string;
 }>) {
   const { t } = useTranslation();
-  // useReleaseByName returns a sentinel unknownRelease() when the release
-  // can't be found, so `release` is truthy even on a miss. Treat it as
-  // missing when the name doesn't parse as a real release resource name.
+  // Treat the release as missing when it's absent or its name doesn't parse
+  // as a real release resource name.
   const effectiveRelease =
     release && isValidReleaseName(release.name) ? release : undefined;
   const releaseTitle = useMemo(() => {

--- a/frontend/src/react/pages/project/ProjectReleaseDetailPage.tsx
+++ b/frontend/src/react/pages/project/ProjectReleaseDetailPage.tsx
@@ -1,4 +1,4 @@
-import { Clock4, EllipsisVertical, Link2 } from "lucide-react";
+import { Clock4, EllipsisVertical, Link2, LoaderCircle } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { HumanizeTs } from "@/react/components/HumanizeTs";
@@ -54,15 +54,21 @@ export function ProjectReleaseDetailPage({
   const project = useVueState(() =>
     projectV1Store.getProjectByName(projectName)
   );
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
+    setIsLoading(true);
     void projectV1Store.getOrFetchProjectByName(projectName).catch((error) => {
       if (!cancelled) console.error("Failed to fetch project", error);
     });
-    void fetchRelease(releaseName).catch((error) => {
-      if (!cancelled) console.error("Failed to fetch release", error);
-    });
+    void fetchRelease(releaseName)
+      .catch((error) => {
+        if (!cancelled) console.error("Failed to fetch release", error);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
     return () => {
       cancelled = true;
     };
@@ -80,9 +86,25 @@ export function ProjectReleaseDetailPage({
   const [archiveOpen, setArchiveOpen] = useState(false);
 
   const releaseDisplayName = useMemo(() => {
-    const parts = release.name.split("/");
-    return parts[parts.length - 1] || release.name;
-  }, [release.name]);
+    const name = release?.name ?? releaseName;
+    const parts = name.split("/");
+    return parts[parts.length - 1] || name;
+  }, [release?.name, releaseName]);
+
+  if (!release) {
+    return (
+      <div className="flex flex-col items-start gap-y-4 p-4">
+        <h1 className="text-xl font-medium truncate">{releaseDisplayName}</h1>
+        {isLoading ? (
+          <div className="flex w-full items-center justify-center py-10">
+            <LoaderCircle className="h-4 w-4 animate-spin text-control-light" />
+          </div>
+        ) : (
+          <div className="text-control-light">{t("release.not-found")}</div>
+        )}
+      </div>
+    );
+  }
 
   const isActive = release.state === State.ACTIVE;
   const isDeleted = release.state === State.DELETED;

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailStatementSection.tsx
@@ -141,7 +141,7 @@ export function IssueDetailStatementSection({
     const load = async () => {
       if (isValidReleaseName(releaseName)) {
         const cached = useAppStore.getState().getReleaseByName(releaseName);
-        if (isValidReleaseName(cached.name)) {
+        if (cached) {
           return;
         }
         try {

--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -862,6 +862,18 @@ describe("useAppStore", () => {
     );
   });
 
+  test("returns undefined for an unknown release", () => {
+    const store = createAppStore();
+
+    // getReleaseByName backs the useReleaseByName Zustand selector. Returning a
+    // freshly-constructed sentinel on every call made the selector snapshot
+    // change each render, triggering an infinite re-render loop on cache miss.
+    // A stable undefined avoids that, matching the other cache-miss getters.
+    expect(
+      store.getState().getReleaseByName("projects/a/releases/miss")
+    ).toBeUndefined();
+  });
+
   test("deduplicates release fetches and clears failed requests", async () => {
     mocks.getRelease.mockResolvedValueOnce(releaseA);
     const store = createAppStore();

--- a/frontend/src/react/stores/app/release.ts
+++ b/frontend/src/react/stores/app/release.ts
@@ -2,7 +2,7 @@ import { create as createProto } from "@bufbuild/protobuf";
 import { createContextValues } from "@connectrpc/connect";
 import { releaseServiceClientConnect } from "@/connect";
 import { silentContextKey } from "@/connect/context-key";
-import { isValidReleaseName, unknownRelease } from "@/types";
+import { isValidReleaseName } from "@/types";
 import { State } from "@/types/proto-es/v1/common_pb";
 import type { Release } from "@/types/proto-es/v1/release_service_pb";
 import {
@@ -89,7 +89,7 @@ export const createReleaseSlice: AppSliceCreator<ReleaseSlice> = (
     );
   },
 
-  getReleaseByName: (name) => get().releasesByName[name] ?? unknownRelease(),
+  getReleaseByName: (name) => get().releasesByName[name],
 
   updateRelease: async (release, updateMask) => {
     const response = await releaseServiceClientConnect.updateRelease(

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -509,7 +509,7 @@ export type ReleaseSlice = {
     silent?: boolean
   ) => Promise<Release | undefined>;
   getReleasesByProject: (project: string) => Release[];
-  getReleaseByName: (name: string) => Release;
+  getReleaseByName: (name: string) => Release | undefined;
   updateRelease: (
     release: Partial<Release>,
     updateMask: string[]

--- a/frontend/src/types/release.ts
+++ b/frontend/src/types/release.ts
@@ -1,17 +1,5 @@
-import { create } from "@bufbuild/protobuf";
 import { getProjectNameReleaseId } from "@/store/modules/v1/common";
 import { UNKNOWN_ID } from "./const";
-import type { Release } from "./proto-es/v1/release_service_pb";
-import { ReleaseSchema } from "./proto-es/v1/release_service_pb";
-import { UNKNOWN_PROJECT_NAME } from "./v1/project";
-
-export const UNKNOWN_RELEASE_NAME = `${UNKNOWN_PROJECT_NAME}/releases/${UNKNOWN_ID}`;
-
-export const unknownRelease = (): Release => {
-  return create(ReleaseSchema, {
-    name: UNKNOWN_RELEASE_NAME,
-  });
-};
 
 export const isValidReleaseName = (name: unknown): name is string => {
   if (typeof name !== "string") return false;


### PR DESCRIPTION
## What & why

Fixes **BYT-9605** (GitOps release page loading inconsistency) and **BYT-9606** (plan with GitOps can't load on refresh). Both shared one root cause.

`getReleaseByName` returned a freshly-constructed `unknownRelease()` on cache miss. It's consumed through raw reactive selectors:

- `useReleaseByName` → `DeployReleaseInfoCard` (plan-detail, BYT-9606)
- `useAppStore((s) => s.getReleaseByName(...))` → `ProjectReleaseDetailPage` (release page, BYT-9605)

Both use `useSyncExternalStore`, which compares snapshots with `Object.is`. A new object every render meant the snapshot "always changed" → `The result of getSnapshot should be cached` → `Maximum update depth exceeded` → the component crashed → blank page.

The loop only fired on a **cold load / refresh**: in-app navigation worked because the source page had already warmed `releasesByName`, so the selector returned a stable reference.

## Fix

Return `Release | undefined` on cache miss — a stable primitive — matching the other reactively-consumed getters (`getUserByIdentifier`, `getRoleByName`, `getRevisionByName`). No static `UNKNOWN_RELEASE` const introduced (no other resource has one).

- `release.ts` / `types.ts` — getter returns `undefined` on miss
- `ProjectReleaseDetailPage` — guards `!release` with a spinner / not-found state
- `IssueDetailStatementSection` — cache check simplified to `if (cached)`
- `ReleaseInfoCard` — removed stale sentinel comment (already handled optional release)
- Removed the now-orphaned `unknownRelease()` factory and `UNKNOWN_RELEASE_NAME`

> Note: `getProjectByName`/`getDatabaseByName` still fabricate sentinels but are safe — they're only read via `getState()`/Vue stores, never a raw reactive selector.

## Testing

- New store test asserts `getReleaseByName` returns `undefined` on miss
- App-store + `ReleaseInfoCard` suites: 60 passed
- `pnpm --dir frontend type-check` exit 0; `pnpm --dir frontend fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)