### PR TITLE
fix(oracle): Trigger sync invalid

### DIFF
--- a/backend/plugin/db/oracle/sync.go
+++ b/backend/plugin/db/oracle/sync.go
@@ -247,14 +247,14 @@ func getTriggers(txn *sql.Tx, schemaName string) (map[db.TableKey][]*storepb.Tri
 		}
 		key := db.TableKey{Schema: schemaName, Table: tableName.String}
 		trigger := &storepb.TriggerMetadata{
-			Name: triggerName.String,
-			Body: constructTriggerBody(description.String, triggerBody.String),
+			Name: common.SanitizeUTF8String(triggerName.String),
+			Body: constructTriggerBody(common.SanitizeUTF8String(description.String), common.SanitizeUTF8String(triggerBody.String)),
 		}
 		if triggerType.Valid {
-			trigger.Timing = triggerType.String
+			trigger.Timing = common.SanitizeUTF8String(triggerType.String)
 		}
 		if triggeringEvent.Valid {
-			trigger.Event = triggeringEvent.String
+			trigger.Event = common.SanitizeUTF8String(triggeringEvent.String)
 		}
 		// Add trigger comment if available
 		triggerKey := db.TableKey{Schema: schemaName, Table: triggerName.String}


### PR DESCRIPTION
Fix trigger metadata fields to ensure UTF-8 compliance.

```
Code 13: Internal
[internal] failed to sync database schema for database "instances/mmtest/databases/TEST_USER", error failed to upsert database schema for database "TEST_USER": proto: field bytebase.store.TriggerMetadata.body contains invalid UTF-8
```