### PR TITLE
fix(i18n): localize mixed text and unify flat locale keys (BYT-9608)

### DIFF
--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -1,21 +1,25 @@
 {
-  "activity.sentence.added-spec": "added",
-  "activity.sentence.canceled-issue": "closed the issue",
-  "activity.sentence.changed-description": "changed description",
-  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
-  "activity.sentence.changed-labels": "changed labels",
-  "activity.sentence.changed-targets-of": "changed targets of",
-  "activity.sentence.created-issue": "created issue",
-  "activity.sentence.disabled-prior-backup-on": "disabled prior backup on",
-  "activity.sentence.enabled-prior-backup-on": "enabled prior backup on",
-  "activity.sentence.modified-sql-of": "modified SQL of",
-  "activity.sentence.removed-spec": "removed",
-  "activity.sentence.reopened-issue": "reopened issue",
-  "activity.sentence.resolved-issue": "marked the issue as Done",
-  "activity.sentence.review-done-rollout-created": "Review done, rollout created",
-  "activity.sentence.review-done-rollout-created-for-plan": "Review done, rollout created for plan",
-  "activity.sentence.review-skipped-rollout-created": "Review skipped, rollout created",
-  "activity.sentence.review-skipped-rollout-created-for-plan": "Review skipped, rollout created for plan",
+  "activity": {
+    "sentence": {
+      "added-spec": "added",
+      "canceled-issue": "closed the issue",
+      "changed-description": "changed description",
+      "changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
+      "changed-labels": "changed labels",
+      "changed-targets-of": "changed targets of",
+      "created-issue": "created issue",
+      "disabled-prior-backup-on": "disabled prior backup on",
+      "enabled-prior-backup-on": "enabled prior backup on",
+      "modified-sql-of": "modified SQL of",
+      "removed-spec": "removed",
+      "reopened-issue": "reopened issue",
+      "resolved-issue": "marked the issue as Done",
+      "review-done-rollout-created": "Review done, rollout created",
+      "review-done-rollout-created-for-plan": "Review done, rollout created for plan",
+      "review-skipped-rollout-created": "Review skipped, rollout created",
+      "review-skipped-rollout-created-for-plan": "Review skipped, rollout created for plan"
+    }
+  },
   "agent": {
     "active-only-chats": "Active only",
     "ai-not-configured": {
@@ -70,7 +74,6 @@
     "unarchive-all-chats": "Unarchive all chats",
     "unarchive-chat": "Unarchive chat"
   },
-  "agent.self": "Agent",
   "audit-log": {
     "advanced-search": {
       "scope": {
@@ -153,9 +156,9 @@
       "create-admin-account": "Create admin account",
       "existing-user": "Already have an account?",
       "title": "Register your account"
-    }
+    },
+    "token-expired-title": "Token expired"
   },
-  "auth.token-expired-title": "Token expired",
   "banner": {
     "external-url": "Bytebase has not configured --external-url",
     "license-expired": "Your license for {{plan}} has expired on {{expireAt}}.",
@@ -206,6 +209,7 @@
     "actions": "Actions",
     "activated": "Activated",
     "active": "Active",
+    "activity": "Activity",
     "add": "Add",
     "add-permissions": "Add permissions",
     "added": "Added",
@@ -213,6 +217,7 @@
     "admin": "Admin",
     "all": "All",
     "allow": "Allow",
+    "and": "and",
     "approve": "Approve",
     "approved": "Approved",
     "archive": "Archive",
@@ -224,12 +229,16 @@
     "bypassed": "Bypassed",
     "cancel": "Cancel",
     "cannot-undo-this-action": "You cannot undo this action",
+    "catalog": "Catalog",
     "changelog": "Changelog",
     "classification-level": "Classification Level",
     "clear": "Clear",
     "clear-filters": "Clear filters",
     "close": "Close",
+    "close-mobile-sidebar": "Close mobile sidebar",
     "closed": "Closed",
+    "collapse": "Collapse",
+    "column": "Column",
     "comment": "Comment",
     "configure": "Configure",
     "configure-now": "Configure now",
@@ -272,6 +281,7 @@
     "duplicate": "Duplicate",
     "duration": "Duration",
     "edit": "Edit",
+    "edited": "edited",
     "email": "Email",
     "email-ascii-only": "Email addresses only support ASCII characters (letters, numbers, and symbols like . _ - +).",
     "empty": "Empty",
@@ -301,10 +311,12 @@
     "home": "Home",
     "id": "ID",
     "import": "Import",
+    "in-progress": "In progress",
     "info": "Info",
     "instance": "Instance",
     "instances": "Instances",
     "is-required": "is required",
+    "issue": "Issue",
     "issues": "Issues",
     "items": "items",
     "key": "Key",
@@ -313,12 +325,14 @@
     "learn-more": "Learn more",
     "leave-without-saving": "Leave without saving?",
     "license": "License",
+    "line": "Line",
     "load-more": "Load more",
     "loading": "Loading",
     "logout": "Logout",
     "manage": "Manage",
     "manually-select": "Manually select",
     "maximize": "Maximize",
+    "members": "Members",
     "members_one": "Member",
     "members_other": "Members",
     "minutes": "Minutes",
@@ -334,6 +348,9 @@
     "no-data": "No data",
     "not-started": "Not started",
     "ok": "OK",
+    "only-creator-allowed-export": "Only the creator is allowed to export",
+    "open": "Open",
+    "operation": "Operation",
     "operations": "Operations",
     "optional": "Optional",
     "or": "or",
@@ -355,7 +372,10 @@
     "reject": "Reject",
     "rejected": "Rejected",
     "release": "Release",
+    "remaining": "remaining",
     "remove": "Remove",
+    "removed": "Removed",
+    "reopen": "Reopen",
     "reorder": "Reorder",
     "required-permission": "Required permissions",
     "required-workspace-permission": "Following permissions are required to initialize the workspace UX",
@@ -365,6 +385,7 @@
     "resources": "Resources",
     "restore": "Restore",
     "restored": "Restored",
+    "retry": "Retry",
     "revert": "Revert",
     "revoke": "Revoke",
     "revoked": "Revoked",
@@ -392,9 +413,12 @@
     "setting": "Setting",
     "settings": "Settings",
     "share": "Share",
+    "show-less": "Show less",
+    "show-more": "Show more",
     "sign-in": "Sign in",
     "sign-in-as-admin": "Sign in as administrator",
     "sign-up": "Sign up",
+    "skip": "Skip",
     "skipped": "Skipped",
     "snapshot": "Snapshot",
     "sql": "SQL",
@@ -404,8 +428,10 @@
     "status": "Status",
     "submit": "Submit",
     "succeed": "Succeed",
+    "success": "Success",
     "system": "System",
     "table": "Table",
+    "task": "Task",
     "text-wrap": "Text Wrap",
     "tips": "Tips",
     "title": "Title",
@@ -413,10 +439,12 @@
     "total": "Total",
     "total-n-items": "Total {{n}} items",
     "transfer": "Transfer",
+    "troubleshoot": "Troubleshoot",
     "type": "Type",
     "type-to-search": "Type to search",
     "unassigned": "Unassigned",
     "under-review": "Under review",
+    "unknown": "Unknown",
     "unlimited": "Unlimited",
     "untitled": "Untitled",
     "update": "Update",
@@ -431,6 +459,7 @@
     "version": "Version",
     "view": "View",
     "view-details": "View Details",
+    "view-doc": "View doc",
     "visibility": "Visibility",
     "want-help": "Want help",
     "warning": "Warning",
@@ -438,94 +467,6 @@
     "write-only": "write only",
     "you": "you"
   },
-  "common.activity": "Activity",
-  "common.add": "Add",
-  "common.admin": "Admin",
-  "common.all": "All",
-  "common.and": "and",
-  "common.archive": "Archive",
-  "common.archived": "Archived",
-  "common.back-to-workspace": "Back to workspace",
-  "common.cancel": "Cancel",
-  "common.cannot-undo-this-action": "You cannot undo this action",
-  "common.catalog": "Catalog",
-  "common.close": "Close",
-  "common.close-mobile-sidebar": "Close mobile sidebar",
-  "common.collapse": "Collapse",
-  "common.column": "Column",
-  "common.comment": "Comment",
-  "common.confirm": "Confirm",
-  "common.continue-anyway": "Continue anyway",
-  "common.copy": "Copy",
-  "common.create": "Create",
-  "common.creating": "Creating",
-  "common.custom": "Custom",
-  "common.database": "Database",
-  "common.database-group": "Database group",
-  "common.databases": "Databases",
-  "common.default": "default",
-  "common.delete": "Delete",
-  "common.delete-resource": "Delete {{type}}",
-  "common.deleted": "Deleted",
-  "common.detail": "Detail",
-  "common.detailed-guide": "detailed guide",
-  "common.edit": "Edit",
-  "common.edited": "edited",
-  "common.environment": "Environment",
-  "common.import": "Import",
-  "common.in-progress": "In progress",
-  "common.issue": "Issue",
-  "common.key": "Key",
-  "common.labels": "Labels",
-  "common.language": "Language",
-  "common.learn-more": "Learn more",
-  "common.license": "License",
-  "common.line": "Line",
-  "common.load-more": "Load more",
-  "common.loading": "Loading",
-  "common.logout": "Logout",
-  "common.members": "Members",
-  "common.minutes": "Minutes",
-  "common.n-more": "{{n}} more",
-  "common.no-data": "No data",
-  "common.only-creator-allowed-export": "Only the creator is allowed to export",
-  "common.open": "Open",
-  "common.operation": "Operation",
-  "common.optional": "Optional",
-  "common.or": "or",
-  "common.overview": "Overview",
-  "common.password": "Password",
-  "common.project": "Project",
-  "common.read-only": "Read-only",
-  "common.recent": "Recent",
-  "common.remaining": "remaining",
-  "common.remove": "Remove",
-  "common.removed": "Removed",
-  "common.reopen": "Reopen",
-  "common.restore": "Restore",
-  "common.retry": "Retry",
-  "common.role.self": "Role",
-  "common.rollout": "Rollout",
-  "common.save": "Save",
-  "common.sensitive-placeholder": "Sensitive - write only",
-  "common.show-less": "Show less",
-  "common.show-more": "Show more",
-  "common.skip": "Skip",
-  "common.success": "Success",
-  "common.task": "Task",
-  "common.troubleshoot": "Troubleshoot",
-  "common.unknown": "Unknown",
-  "common.unlimited": "Unlimited",
-  "common.updated": "Updated",
-  "common.updating": "Updating",
-  "common.user": "User",
-  "common.username": "Username",
-  "common.value": "Value",
-  "common.version": "Version",
-  "common.view-doc": "View doc",
-  "common.want-help": "Want help",
-  "common.warning": "Warning",
-  "common.write-only": "write only",
   "create-db": {
     "cluster": "Cluster",
     "database-owner-name": "Database owner name",
@@ -564,6 +505,7 @@
     "issue-review": {
       "and-n-other-users": "{{names}} and {{count}} other users",
       "approved-by": "Approved by",
+      "approved-issue": "approved issue",
       "disallow-approve-reason": {
         "some-task-checks-are-still-running": "Some task checks are still running.",
         "some-task-checks-didnt-pass": "Some task checks didn't pass."
@@ -571,7 +513,10 @@
       "generating-approval-flow": "Generating approval flow",
       "re-request-review": "Re-request review",
       "re-request-review-success": "Review re-requested successfully",
+      "re-requested-review": "re-requested issue review",
       "rejected-by": "Rejected by",
+      "rejected-issue": "rejected issue",
+      "retry-approval-finding": "Retry",
       "self-approval-not-allowed": "Self-approval is not allowed in this project. So you cannot approve your own issue."
     },
     "risk": {
@@ -614,10 +559,6 @@
     },
     "self": "Custom Approval"
   },
-  "custom-approval.issue-review.approved-issue": "approved issue",
-  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
-  "custom-approval.issue-review.rejected-issue": "rejected issue",
-  "custom-approval.issue-review.retry-approval-finding": "Retry",
   "data-source": {
     "additional-node-addresses": "Additional Node Addresses",
     "automatic-query-data-source": "Automatic",
@@ -692,47 +633,16 @@
     },
     "ssl-connection": "SSL Connection"
   },
-  "data-source.additional-node-addresses": "Additional Node Addresses",
-  "data-source.connection-string-schema": "Connection String Schema",
-  "data-source.connection-type": "Connection Type",
-  "data-source.delete-read-only-data-source": "Delete read-only data source",
-  "data-source.direct-connection": "Direct Connection",
-  "data-source.extra-params.description": "Additional parameters for database connection string",
-  "data-source.extra-params.self": "Extra Parameters",
-  "data-source.no-read-only-data-source": "No read-only data source",
-  "data-source.private-key-passphrase": "Private Key Passphrase",
-  "data-source.private-key-passphrase-placeholder": "Leave empty if your private key is not encrypted",
-  "data-source.private-key-passphrase-tip": "Optional passphrase for encrypted private keys",
-  "data-source.read-replica-host": "Read-replica Host",
-  "data-source.read-replica-port": "Read-replica Port",
-  "data-source.replica-set": "Replica Set",
-  "data-source.snowflake-keypair-tip": "Key-pair authentication",
-  "data-source.ssh-connection": "SSH Connection",
-  "data-source.ssh-type.none": "None",
-  "data-source.ssh-type.tunnel-and-private-key": "Tunnel + Private Key",
-  "data-source.ssh.host": "Server",
-  "data-source.ssh.password": "Password",
-  "data-source.ssh.port": "Port",
-  "data-source.ssh.private-key": "Private Key",
-  "data-source.ssh.ssh-key": "SSH Key",
-  "data-source.ssh.user": "User",
-  "data-source.ssl-connection": "SSL Connection",
-  "data-source.ssl.ca-cert": "CA Certificate",
-  "data-source.ssl.ca-path": "CA Certificate Path",
-  "data-source.ssl.client-cert": "Client Certificate",
-  "data-source.ssl.client-cert-path": "Client Certificate Path",
-  "data-source.ssl.client-key": "Client Key",
-  "data-source.ssl.client-key-path": "Client Key Path",
-  "data-source.ssl.verify-certificate": "Verify TLS certificate",
-  "data-source.ssl.verify-certificate-tooltip": "Enable TLS certificate verification for secure connections. Disable only for development or when certificates cannot be properly validated (e.g., self-signed certs, VPN environments). Warning: Disabling verification is insecure",
   "database": {
     "access-denied": "You don't have the permission to access this database.",
     "all": "All databases",
     "change-database": "Change Database",
     "checks": "Checks",
     "classification": {
-      "description": "Define classification levels to apply consistent masking policies across columns and databases."
+      "description": "Define classification levels to apply consistent masking policies across columns and databases.",
+      "self": "Classification"
     },
+    "column": "Column",
     "columns": "Columns",
     "comment": "Comment",
     "data-size": "Data size",
@@ -740,9 +650,13 @@
     "edit-labels": "Edit Labels",
     "edit-schema": "Edit Schema",
     "engine": "Engine",
+    "export-schema": "Export Schema",
+    "export-schema-multi-file": "Multi-File (ZIP)",
+    "export-schema-single-file": "Single File",
     "expression": "Expression",
     "external-database-name": "External Database Name",
     "external-server-name": "External Server Name",
+    "failed-to-export-schema": "Failed to export schema",
     "filter-database": "Filter database",
     "foreign-key": {
       "reference": "Reference"
@@ -750,6 +664,7 @@
     "foreign-keys": "Foreign keys",
     "index-size": "Index size",
     "indexes": "Indexes",
+    "labels": "Database Labels",
     "last-sync": "Last sync",
     "mixed-label-values": "mixed values",
     "mixed-label-values-warning": "Some of the selected resources have mixed values for the same key. Only edit these key-value pairs if you intend to change them.",
@@ -796,6 +711,7 @@
       "unspecified": "Unspecified"
     },
     "select": "Select database",
+    "successfully-exported-schema": "Successfully exported schema",
     "successfully-transferred-databases": "Successfully transferred databases",
     "sync-complete-for-instance": "Sync complete for instance '{{0}}'",
     "sync-database": "Sync Database",
@@ -846,21 +762,10 @@
     "select": "Select database group",
     "unmatched-database": "Unmatched database"
   },
-  "database.classification.self": "Classification",
-  "database.column": "Column",
-  "database.engine": "Engine",
-  "database.export-schema": "Export Schema",
-  "database.export-schema-multi-file": "Multi-File (ZIP)",
-  "database.export-schema-single-file": "Single File",
-  "database.failed-to-export-schema": "Failed to export schema",
-  "database.filter-database": "Filter database",
-  "database.labels": "Database Labels",
-  "database.revision.delete-confirm-dialog": "This will delete these applied revisions and the database schema will not be changed. This action cannot be undone.",
-  "database.revision.self": "Revision",
-  "database.successfully-exported-schema": "Successfully exported schema",
-  "database.sync-complete-for-instance": "Sync complete for instance '{{0}}'",
-  "database.sync-database": "Sync Database",
   "db": {
+    "catalog": {
+      "description": "Edit and upload the table catalog."
+    },
     "character-set": "Character set",
     "collation": "Collation",
     "collections": "Collections",
@@ -903,11 +808,6 @@
     "triggers": "Triggers",
     "views": "Views"
   },
-  "db.catalog.description": "Edit and upload the table catalog.",
-  "db.failed-to-sync-schema": "Failed to sync schema",
-  "db.n-databases-had-sync-errors": "{{0}} database(s) had sync errors",
-  "db.start-to-sync-schema": "Start to sync schema",
-  "db.syncing-databases-for-instance": "Syncing databases for {{0}}...",
   "environment": {
     "delete-description": "Delete environment will also remove it from related instances and databases. You cannot undo this action",
     "reorder": "Reorder Environments",
@@ -927,7 +827,6 @@
     "password-info": "Provide a password to encrypt the export file.",
     "password-optional": "Encrypt with password (Optional)"
   },
-  "export-data.password-optional": "Password (optional)",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "For databases sharing the same schema, a database group lets you migrate them together in one change. Define the group once and reuse it across migrations without picking individual databases every time.",
@@ -1000,6 +899,7 @@
     "connection-options": "Connection Options",
     "create-gcp-credentials": "To create credentials, see",
     "database-region": "Database Region",
+    "default-role": "Default role",
     "endpoint": "Endpoint",
     "external-id": "External ID",
     "external-id-description": "External ID for additional security when assuming role (optional)",
@@ -1056,6 +956,62 @@
       "specific-credential": "Specific Credential",
       "tenant-id": "Tenant ID"
     },
+    "info": {
+      "configure-database-user": {
+        "link": "Configure Database User"
+      },
+      "connect-instance": {
+        "link": "Connect Your Instance"
+      },
+      "mongodb": {
+        "authentication": {
+          "content": "Create a dedicated user \"{{user}}\" for Bytebase in the admin database:"
+        },
+        "host": {
+          "content": "Enter the hostname or IP address of your MongoDB server. For MongoDB Atlas, use the connection string host from your cluster's connect dialog."
+        },
+        "ssh": {
+          "content": "Use an SSH tunnel to connect to MongoDB instances in private networks. This is useful when the database is behind a firewall or in a VPC."
+        },
+        "ssl": {
+          "content": "MongoDB Atlas and other cloud-hosted MongoDB services require SSL connections by default. Enable SSL and provide the CA certificate if needed."
+        }
+      },
+      "mysql": {
+        "authentication": {
+          "content": "Create a dedicated user \"{{user}}\" for Bytebase to manage your database. Run the following SQL:"
+        },
+        "host": {
+          "content": "Enter the hostname or IP address of your MySQL server. For cloud-hosted databases (AWS RDS, Google Cloud SQL), use the endpoint provided by your cloud provider."
+        },
+        "ssh": {
+          "content": "Use an SSH tunnel to connect to databases in private networks that are not directly accessible from Bytebase. This routes the connection through a bastion/jump host."
+        },
+        "ssl": {
+          "content": "Cloud-hosted MySQL databases (AWS RDS, Google Cloud SQL, Azure Database) typically require SSL connections. Enable SSL and upload the CA certificate provided by your cloud provider."
+        }
+      },
+      "postgresql": {
+        "authentication": {
+          "content": "Create a dedicated user \"{{user}}\" for Bytebase to manage your database. Run the following SQL as a superuser:"
+        },
+        "host": {
+          "content": "Enter the hostname or IP address of your PostgreSQL server. For cloud-hosted databases, use the endpoint provided by your cloud provider."
+        },
+        "ssh": {
+          "content": "Use an SSH tunnel to connect to databases in private networks that are not directly accessible from Bytebase. This routes the connection through a bastion/jump host."
+        },
+        "ssl": {
+          "content": "Cloud-hosted PostgreSQL databases (AWS RDS, Google Cloud SQL, Azure Database) typically require SSL connections. Enable SSL and upload the CA certificate provided by your cloud provider."
+        }
+      },
+      "ssh-tunnel": {
+        "link": "SSH Tunnel"
+      },
+      "ssl-tls-connection": {
+        "link": "SSL/TLS Connection"
+      }
+    },
     "info-panel": {
       "no-info": "No additional information available for this engine."
     },
@@ -1095,6 +1051,7 @@
       "basic-info": "Basic Info",
       "connection": "Connection"
     },
+    "select-database-user": "Select database user",
     "selected-n-instances_one": "{{count}} instance selected",
     "selected-n-instances_other": "{{count}} instances selected",
     "sentence": {
@@ -1179,146 +1136,6 @@
     "users": "Users",
     "your-snowflake-account-locator": "Your Snowflake account locator"
   },
-  "instance.account-locator": "Account Locator",
-  "instance.archive-instance-instance-name": "Archive instance '{{0}}'?",
-  "instance.archived-instances-will-not-be-displayed": "Archived instances will not be displayed.",
-  "instance.authentication-database": "Authentication Database",
-  "instance.connection-info": "Connection info",
-  "instance.connection-options": "Connection Options",
-  "instance.create-gcp-credentials": "To create credentials, see",
-  "instance.database-region": "Database Region",
-  "instance.default-role": "Default role",
-  "instance.endpoint": "Endpoint",
-  "instance.external-id": "External ID",
-  "instance.external-id-description": "External ID for additional security when assuming role (optional)",
-  "instance.external-id-placeholder": "optional-external-id",
-  "instance.external-link": "External Link",
-  "instance.external-secret-azure.secret-name": "Secret name",
-  "instance.external-secret-azure.secret-name-tips": "The name of the secret stored in Azure Key Vault.",
-  "instance.external-secret-azure.vault-url": "Key Vault URL",
-  "instance.external-secret-azure.vault-url-tips": "The Key Vault URL should be like \"https://myvault.vault.azure.net/\".",
-  "instance.external-secret-gcp.secret-name": "Secret full name",
-  "instance.external-secret-gcp.secret-name-tips": "The secret name should be like \"projects/project-id/secrets/secret-id\".",
-  "instance.external-secret-vault.vault-auth-type.approle.role-id": "Auth role id",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-env-name": "Environment name",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-id": "Auth secret id",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-plain-text": "Plain text",
-  "instance.external-secret-vault.vault-auth-type.approle.self": "AppRole",
-  "instance.external-secret-vault.vault-auth-type.self": "Auth type",
-  "instance.external-secret-vault.vault-auth-type.token.self": "Token",
-  "instance.external-secret-vault.vault-secret-engine-name": "Secret engine name",
-  "instance.external-secret-vault.vault-secret-engine-tips": "Only support KV v2 engine.",
-  "instance.external-secret-vault.vault-secret-key": "Secret key",
-  "instance.external-secret-vault.vault-secret-path": "Secret path",
-  "instance.external-secret-vault.vault-tls-config": "Vault TLS Configuration (Optional)",
-  "instance.external-secret-vault.vault-url": "Vault URL",
-  "instance.external-secret.key-name": "Secret key",
-  "instance.external-secret.secret-name": "Secret name",
-  "instance.failed-to-connect-instance": "Failed to connect instance.",
-  "instance.failed-to-connect-instance-localhost": "If you run Bytebase with Docker, please try \"host.docker.internal\" for the host address.",
-  "instance.find-gcp-project-id": "To find GCP Project ID, see",
-  "instance.find-gcp-project-id-and-instance-id": "To find GCP Project ID and instance ID, see",
-  "instance.force-archive-description": "Force to archive. All databases will be unassigned.",
-  "instance.grants": "Grants",
-  "instance.host-or-socket": "Host or Socket",
-  "instance.iam-extension.client-id": "Client ID",
-  "instance.iam-extension.client-secret": "Client Secret",
-  "instance.iam-extension.credential-source": "Credential Source",
-  "instance.iam-extension.saas-default-credential-restriction": "Default credentials are not available in Bytebase Cloud for security. Please provide specific credentials.",
-  "instance.iam-extension.specific-credential": "Specific Credential",
-  "instance.iam-extension.tenant-id": "Tenant ID",
-  "instance.info-panel.no-info": "No additional information available for this engine.",
-  "instance.info.configure-database-user.link": "Configure Database User",
-  "instance.info.connect-instance.link": "Connect Your Instance",
-  "instance.info.mongodb.authentication.content": "Create a dedicated user \"{{user}}\" for Bytebase in the admin database:",
-  "instance.info.mongodb.host.content": "Enter the hostname or IP address of your MongoDB server. For MongoDB Atlas, use the connection string host from your cluster's connect dialog.",
-  "instance.info.mongodb.ssh.content": "Use an SSH tunnel to connect to MongoDB instances in private networks. This is useful when the database is behind a firewall or in a VPC.",
-  "instance.info.mongodb.ssl.content": "MongoDB Atlas and other cloud-hosted MongoDB services require SSL connections by default. Enable SSL and provide the CA certificate if needed.",
-  "instance.info.mysql.authentication.content": "Create a dedicated user \"{{user}}\" for Bytebase to manage your database. Run the following SQL:",
-  "instance.info.mysql.host.content": "Enter the hostname or IP address of your MySQL server. For cloud-hosted databases (AWS RDS, Google Cloud SQL), use the endpoint provided by your cloud provider.",
-  "instance.info.mysql.ssh.content": "Use an SSH tunnel to connect to databases in private networks that are not directly accessible from Bytebase. This routes the connection through a bastion/jump host.",
-  "instance.info.mysql.ssl.content": "Cloud-hosted MySQL databases (AWS RDS, Google Cloud SQL, Azure Database) typically require SSL connections. Enable SSL and upload the CA certificate provided by your cloud provider.",
-  "instance.info.postgresql.authentication.content": "Create a dedicated user \"{{user}}\" for Bytebase to manage your database. Run the following SQL as a superuser:",
-  "instance.info.postgresql.host.content": "Enter the hostname or IP address of your PostgreSQL server. For cloud-hosted databases, use the endpoint provided by your cloud provider.",
-  "instance.info.postgresql.ssh.content": "Use an SSH tunnel to connect to databases in private networks that are not directly accessible from Bytebase. This routes the connection through a bastion/jump host.",
-  "instance.info.postgresql.ssl.content": "Cloud-hosted PostgreSQL databases (AWS RDS, Google Cloud SQL, Azure Database) typically require SSL connections. Enable SSL and upload the CA certificate provided by your cloud provider.",
-  "instance.info.ssh-tunnel.link": "SSH Tunnel",
-  "instance.info.ssl-tls-connection.link": "SSL/TLS Connection",
-  "instance.instance-id": "Instance ID",
-  "instance.instance-name": "Instance Name",
-  "instance.new-instance": "New Instance",
-  "instance.no-environment": "This instance has not been bound to the environment",
-  "instance.no-extra-params-configured": "No extra connection parameters configured",
-  "instance.no-params-yet-add-above": "No parameters configured yet. Add parameters using the form above.",
-  "instance.no-password": "No password",
-  "instance.parameter-name-placeholder": "Parameter name",
-  "instance.parameter-value-placeholder": "Parameter value",
-  "instance.password-type.aws-iam": "AWS RDS IAM",
-  "instance.password-type.azure-iam": "Azure IAM",
-  "instance.password-type.external-secret-aws": "AWS Secrets Manager",
-  "instance.password-type.external-secret-azure": "Azure Key Vault",
-  "instance.password-type.external-secret-gcp": "GCP Secret Manager",
-  "instance.password-type.external-secret-vault": "Vault (KV v2)",
-  "instance.password-type.google-iam": "Google Cloud SQL IAM",
-  "instance.password-type.password": "Password",
-  "instance.password-write-only": "YOUR_DB_PWD - write only",
-  "instance.port": "Port",
-  "instance.project-id": "Project ID",
-  "instance.restore-instance-instance-name-to-normal-state": "Restore instance '{{0}}' to normal state?",
-  "instance.role-arn": "Role ARN",
-  "instance.role-arn-description": "IAM role to assume for cross-account access. Leave empty for same-account access.",
-  "instance.role-arn-placeholder": "arn:aws:iam::123456789012:role/CrossAccountRole",
-  "instance.scan-interval.default-never": "Default (never)",
-  "instance.scan-interval.description": "Bytebase periodically syncs instance schema and detects anomalies.",
-  "instance.scan-interval.min-value": "Min value {{value}} minutes",
-  "instance.scan-interval.self": "Scan Interval",
-  "instance.section.basic-info": "Basic Info",
-  "instance.section.connection": "Connection",
-  "instance.select-database-user": "Select database user",
-  "instance.sentence.aws-rds.mysql.template": "Below is an example to create user {{user}}@% and grant the user with the needed privileges.",
-  "instance.sentence.aws-rds.postgresql.template": "Below is an example to create user '{{user}}' and grant the user with the needed privileges.",
-  "instance.sentence.console.snowflake": "The external console URL managing this instance (e.g. AWS RDS console, your in-house DB instance console)",
-  "instance.sentence.create-admin-user": "This is the connection user used by Bytebase to perform DDL and DML (non-SELECT) operations.",
-  "instance.sentence.create-admin-user-non-sql": "This is the connection user used by Bytebase to perform write and admin operations.",
-  "instance.sentence.create-readonly-user": "This is the connection used by Bytebase to perform read-only operations such as SELECT query.",
-  "instance.sentence.create-readonly-user-non-sql": "This is the connection used by Bytebase to perform read-only operations.",
-  "instance.sentence.create-user-example.clickhouse.sql-driven-workflow": "SQL-driven workflow",
-  "instance.sentence.create-user-example.clickhouse.template": "Below is an example to create user '{{user}}' with password {{password}} and grant the user with the needed privileges. First you need to enable ClickHouse SQL-driven workflow {{link}} and then run the following query to create the user.",
-  "instance.sentence.create-user-example.mysql.template": "Below is an example to create user {{user}}@% with password {{password}} and grant the user with the needed privileges.",
-  "instance.sentence.create-user-example.postgresql.template": "Below is an example to create user '{{user}}' with password {{password}} and grant the user with the needed privileges. If the connecting instance is self-hosted, then you can grant SUPERUSER.",
-  "instance.sentence.create-user-example.postgresql.warn": "If the connecting instance is managed by the cloud provider, then SUPERUSER is not available and you should create the user via that provider's admin console. The created user will have provider specific semi-SUPERUSER privileges. You should grant Bytebase privileges with 'GRANT role_name TO bytebase;' for all existing roles, otherwise Bytebase may not access existing databases or tables.",
-  "instance.sentence.create-user-example.redis.template": "Below is an example to create user {{user}} with password {{password}} and grant the user with the needed privileges.",
-  "instance.sentence.create-user-example.snowflake.template": "Below is an example to create user '{{user}}' with password {{password}} for {{warehouse}} and grant the user with the needed privileges.",
-  "instance.sentence.firewall-info": "If you use inbound firewall rules for your database instance, please refer to Bytebase Cloud connection instruction.",
-  "instance.sentence.google-cloud-sql.instance-name": "Instance Connection Name",
-  "instance.sentence.google-cloud-sql.instance-name-tips": "The instance connection name should look like {{instance}}.",
-  "instance.sentence.google-cloud-sql.mysql.template": "Create a service account named {{user}}, then add it in your Google Cloud SQL as IAM user {{user}}@'%'. Grant this user with the needed privileges.",
-  "instance.sentence.google-cloud-sql.postgresql.template": "Create a service account named {{user}}, then add it in your Google Cloud SQL as IAM user {{user}}@project-id.iam. Grant the user with the needed privileges.",
-  "instance.sentence.host.none-snowflake": "e.g. host.docker.internal | host ip | local socket",
-  "instance.sentence.proxy.snowflake": "For proxy server, append @PROXY_HOST and specify PROXY_PORT in the port",
-  "instance.show-how-to-create": "Show how to create",
-  "instance.snowflake-web-console": "Snowflake Web Console",
-  "instance.successfully-archived-instance": "Successfully archived the instance '{{0}}'.",
-  "instance.successfully-connected-instance": "Successfully connected instance.",
-  "instance.successfully-created-instance-createdinstance-name": "Successfully created instance '{{0}}'.",
-  "instance.successfully-restored-instance": "Successfully restored the instance '{{0}}'.",
-  "instance.successfully-updated-instance-instance-name": "Successfully updated instance '{{0}}'.",
-  "instance.sync-databases.add-database": "+ Add database, press enter to submit",
-  "instance.sync-databases.description": "Only sync selected databases.",
-  "instance.sync-databases.search-database": "Search database",
-  "instance.sync-databases.self": "Sync Databases",
-  "instance.sync-databases.sync-all": "Sync all databases",
-  "instance.sync.self": "Sync instance",
-  "instance.sync.sync-all": "Sync all databases",
-  "instance.sync.sync-all-tip": "Database sync is asynchronous and might take a few seconds to minutes",
-  "instance.sync.sync-new": "Only sync new databases",
-  "instance.syncing": "Syncing ...",
-  "instance.test-connection": "Test Connection",
-  "instance.testing-connection": "Testing connection",
-  "instance.type-or-paste-credentials-write-only": "Type or paste CREDENTIALS - write only",
-  "instance.unable-to-connect": "Bytebase is unable to connect the instance. We recommend you to review the connection info again. But it's OK to ignore this warning for now. You can still fix the connection info from the instance detail page after creation.\n\nError detail: {{0}}",
-  "instance.users": "Users",
-  "instance.your-snowflake-account-locator": "Your Snowflake account locator",
   "issue": {
     "access-grant": {
       "advanced-search": {
@@ -1331,6 +1148,7 @@
       "details": "Access Grant Details",
       "expired-at": "Expired at"
     },
+    "action-anyway": "{{action}} anyway",
     "advanced-search": {
       "filter": "Filter",
       "scope": {
@@ -1414,6 +1232,20 @@
       "reopened": "reopened"
     },
     "checks-manual-rollout-hint": "Approval is complete, but rollout wasn't created automatically because this plan still has failed checks. Go to Plan to continue.",
+    "checks-warning-hint": "Some checks did not pass. Continue anyway only if this is expected.",
+    "comment-editor": {
+      "nothing-to-preview": "Nothing to preview",
+      "preview": "Preview",
+      "toolbar": {
+        "bold": "Insert bold text",
+        "code": "Insert SQL code snippet",
+        "hashtag": "Insert hashtag",
+        "header": "Insert heading text",
+        "link": "Insert a link"
+      },
+      "write": "Write"
+    },
+    "create-rollout": "Create Rollout",
     "data-export": {
       "download-tooltip": "Available for 24 hours",
       "file-expired": "File Expired",
@@ -1421,9 +1253,13 @@
       "limits": "Limits",
       "options": "Options"
     },
+    "issue-name": "Issue name",
     "labels": "Issue Labels",
     "leave-a-comment": "Leave a comment...",
     "my-issues": "My Issues",
+    "no-description-provided": "No description provided",
+    "options-disabled-due-to-oversize": "Options are disabled because the SQL is oversized.",
+    "overwrite-current-statement": "Overwrite current SQL statement",
     "review": {
       "approve-description": "Submit feedback and approve this issue",
       "comment-description": "Submit general feedback without approval",
@@ -1452,6 +1288,7 @@
       "sort": "Sort",
       "updated": "Update time"
     },
+    "statement-from-sheet-warning": "This statement is loaded from a large sheet. Preview may be truncated.",
     "status-transition": {
       "modal": {
         "close": "Close issue?",
@@ -1469,6 +1306,10 @@
       "updated": "Updated",
       "waiting-role": "Waiting: {{role}}"
     },
+    "task-run": {
+      "logs": "Logs",
+      "session": "Session"
+    },
     "title": {
       "change-database": "Change database",
       "change-from-sql-editor": "Change from SQL Editor",
@@ -1476,34 +1317,13 @@
       "request-role": "Request role",
       "request-specific-role": "Request \"{{role}}\" role"
     },
+    "transaction-mode": {
+      "label": "Transaction Mode"
+    },
     "upload-sql": "Upload SQL",
+    "upload-sql-file-max-size-exceeded": "Max file size ({{size}}) exceeded.",
     "waiting-approval": "Waiting for Approval"
   },
-  "issue.action-anyway": "{{action}} anyway",
-  "issue.checks-warning-hint": "Some checks did not pass. Continue anyway only if this is expected.",
-  "issue.comment-editor.nothing-to-preview": "Nothing to preview",
-  "issue.comment-editor.preview": "Preview",
-  "issue.comment-editor.toolbar.bold": "Insert bold text",
-  "issue.comment-editor.toolbar.code": "Insert SQL code snippet",
-  "issue.comment-editor.toolbar.hashtag": "Insert hashtag",
-  "issue.comment-editor.toolbar.header": "Insert heading text",
-  "issue.comment-editor.toolbar.link": "Insert a link",
-  "issue.comment-editor.write": "Write",
-  "issue.create-rollout": "Create Rollout",
-  "issue.data-export.format": "Format",
-  "issue.data-export.limits": "Limits",
-  "issue.data-export.options": "Options",
-  "issue.issue-name": "Issue name",
-  "issue.my-issues": "My Issues",
-  "issue.no-description-provided": "No description provided",
-  "issue.options-disabled-due-to-oversize": "Options are disabled because the SQL is oversized.",
-  "issue.overwrite-current-statement": "Overwrite current SQL statement",
-  "issue.review.self": "Review",
-  "issue.statement-from-sheet-warning": "This statement is loaded from a large sheet. Preview may be truncated.",
-  "issue.task-run.logs": "Logs",
-  "issue.task-run.session": "Session",
-  "issue.transaction-mode.label": "Transaction Mode",
-  "issue.upload-sql-file-max-size-exceeded": "Max file size ({{size}}) exceeded.",
   "label": {
     "add-label": "Add label",
     "empty-label-value": "Empty",
@@ -1514,12 +1334,6 @@
       "value-necessary": "Value is required"
     }
   },
-  "label.add-label": "Add label",
-  "label.empty-label-value": "Empty",
-  "label.error.key-duplicated": "Duplicated keys",
-  "label.error.key-necessary": "Key is required",
-  "label.error.max-value-length-exceeded": "Value's length cannot exceed {{length}} characters",
-  "label.error.value-necessary": "Value is required",
   "landing": {
     "changelog-for-version": "Changelog for {{version}}",
     "last-visit": "Last visit",
@@ -1568,91 +1382,114 @@
     }
   },
   "plan": {
+    "add-spec": "Add Change",
+    "add-spec-pending-draft": "Save or discard the pending change before adding another",
     "checks": {
-      "self": "Checks"
+      "completed": "Plan checks completed",
+      "failed-to-run": "Failed to run plan checks",
+      "no-check-results": "No check results",
+      "no-results-match-filters": "No results match your filters",
+      "self": "Checks",
+      "started": "Plan checks started"
     },
     "create-plan": "Create Plan",
+    "description": {
+      "placeholder": "Add description"
+    },
     "editor": {
       "save-changes-before-continuing": "Please save or cancel your changes before continuing"
     },
+    "ghost": {
+      "requirements-not-met": "Ghost requirements not met: {{databases}}"
+    },
+    "go-to-plan-page": "Go to plan page",
+    "isolation-level": {
+      "read-committed": "Read Committed",
+      "read-uncommitted": "Read Uncommitted",
+      "repeatable-read": "Repeatable Read",
+      "self": "Isolation Level",
+      "serializable": "Serializable"
+    },
+    "labels-required-for-review": "Labels are required before review",
     "meta": {
       "created-by-at": "Created by {{user}} · {{time}}"
     },
     "navigator": {
       "changes": "Changes",
+      "checks": "Checks",
       "deploy": "Deploy",
-      "review": "Review"
+      "review": "Review",
+      "statement-empty": "Statement is empty"
     },
     "new-plan": "New Plan",
+    "options": {
+      "no-options-available": "No options available",
+      "self": "Options"
+    },
+    "overview": {
+      "no-checks": "No checks"
+    },
+    "phase": {
+      "create-rollout-action": "Manually create rollout",
+      "deploy-approval-must-complete": "Approval flow must be done.",
+      "deploy-approval-optional": "Approval can be bypassed based on the current project settings.",
+      "deploy-approval-pending": "Finish the approval flow before rollout can proceed automatically.",
+      "deploy-approval-ready": "Approval is complete for this plan.",
+      "deploy-checks-blocked": "Failed checks are blocking automatic rollout creation.",
+      "deploy-checks-must-pass": "Checks must pass.",
+      "deploy-checks-optional": "Failed checks won't block manual rollout in this project.",
+      "deploy-checks-ready": "Checks are ready for automatic rollout creation.",
+      "deploy-checks-running": "Wait for running checks to finish before automatic rollout can proceed.",
+      "deploy-description": "Bytebase will automatically create the rollout when all checks pass and the issue is approved.",
+      "deploy-description-gitops": "This plan is ready to roll out. Create a rollout to deploy the linked release.",
+      "deploy-manual-create-description": "Based on the current project settings, you can also create the rollout manually.",
+      "deploy-manual-create-description-readonly": "User with Create Rollout permission can create the rollout manually.",
+      "hide-details": "Hide details",
+      "review-description": "Submit for review to proceed",
+      "show-details": "Show details"
+    },
     "plans": "Plans",
+    "pre-backup": {
+      "requirements-not-met": "Pre-backup requirements not met: {{databases}}"
+    },
+    "ready-for-review": "Ready for Review",
+    "run": "Run checks",
+    "select-isolation-level": "Select isolation level",
+    "select-targets": "Select Targets",
+    "spec": {
+      "change": "Change",
+      "type": {
+        "database-change": "Database Change"
+      }
+    },
+    "state": {
+      "close-confirm": "Close this plan?",
+      "reopen-confirm": "Reopen this plan?"
+    },
     "subtitle": "Draft database changes and run pre-checks before creating an issue for approval.",
+    "summary": {
+      "last-approved-by": "Last approved by {{name}}",
+      "n-changes": "{{n}} changes",
+      "n-database-groups": "{{n}} database groups",
+      "n-databases": "{{n}} databases",
+      "n-error": "{{n}} error",
+      "n-of-m-approved": "{{n}} of {{m}} approved",
+      "n-of-m-tasks": "{{n}}/{{m}} tasks",
+      "n-passed": "{{n}} passed",
+      "n-warning": "{{n}} warning"
+    },
     "targets": {
-      "title": "Targets"
-    }
+      "no-targets-found": "No targets found",
+      "non-env-warning": {
+        "one": "{{count}} database will be excluded from rollout because it has no effective environment:",
+        "other": "{{count}} databases will be excluded from rollout because they have no effective environment:"
+      },
+      "title": "Targets",
+      "view-all": "View all ({{count}})"
+    },
+    "title-required": "Title is required",
+    "view-discussion": "View discussion"
   },
-  "plan.add-spec": "Add Change",
-  "plan.add-spec-pending-draft": "Save or discard the pending change before adding another",
-  "plan.checks.completed": "Plan checks completed",
-  "plan.checks.failed-to-run": "Failed to run plan checks",
-  "plan.checks.no-check-results": "No check results",
-  "plan.checks.no-results-match-filters": "No results match your filters",
-  "plan.checks.started": "Plan checks started",
-  "plan.description.placeholder": "Add description",
-  "plan.ghost.requirements-not-met": "Ghost requirements not met: {{databases}}",
-  "plan.go-to-plan-page": "Go to plan page",
-  "plan.isolation-level.read-committed": "Read Committed",
-  "plan.isolation-level.read-uncommitted": "Read Uncommitted",
-  "plan.isolation-level.repeatable-read": "Repeatable Read",
-  "plan.isolation-level.self": "Isolation Level",
-  "plan.isolation-level.serializable": "Serializable",
-  "plan.labels-required-for-review": "Labels are required before review",
-  "plan.navigator.checks": "Checks",
-  "plan.navigator.statement-empty": "Statement is empty",
-  "plan.options.no-options-available": "No options available",
-  "plan.options.self": "Options",
-  "plan.overview.no-checks": "No checks",
-  "plan.phase.create-rollout-action": "Manually create rollout",
-  "plan.phase.deploy-approval-must-complete": "Approval flow must be done.",
-  "plan.phase.deploy-approval-optional": "Approval can be bypassed based on the current project settings.",
-  "plan.phase.deploy-approval-pending": "Finish the approval flow before rollout can proceed automatically.",
-  "plan.phase.deploy-approval-ready": "Approval is complete for this plan.",
-  "plan.phase.deploy-checks-blocked": "Failed checks are blocking automatic rollout creation.",
-  "plan.phase.deploy-checks-must-pass": "Checks must pass.",
-  "plan.phase.deploy-checks-optional": "Failed checks won't block manual rollout in this project.",
-  "plan.phase.deploy-checks-ready": "Checks are ready for automatic rollout creation.",
-  "plan.phase.deploy-checks-running": "Wait for running checks to finish before automatic rollout can proceed.",
-  "plan.phase.deploy-description": "Bytebase will automatically create the rollout when all checks pass and the issue is approved.",
-  "plan.phase.deploy-description-gitops": "This plan is ready to roll out. Create a rollout to deploy the linked release.",
-  "plan.phase.deploy-manual-create-description": "Based on the current project settings, you can also create the rollout manually.",
-  "plan.phase.deploy-manual-create-description-readonly": "User with Create Rollout permission can create the rollout manually.",
-  "plan.phase.hide-details": "Hide details",
-  "plan.phase.review-description": "Submit for review to proceed",
-  "plan.phase.show-details": "Show details",
-  "plan.pre-backup.requirements-not-met": "Pre-backup requirements not met: {{databases}}",
-  "plan.ready-for-review": "Ready for Review",
-  "plan.run": "Run checks",
-  "plan.select-isolation-level": "Select isolation level",
-  "plan.select-targets": "Select Targets",
-  "plan.spec.change": "Change",
-  "plan.spec.type.database-change": "Database Change",
-  "plan.state.close-confirm": "Close this plan?",
-  "plan.state.reopen-confirm": "Reopen this plan?",
-  "plan.summary.last-approved-by": "Last approved by {{name}}",
-  "plan.summary.n-changes": "{{n}} changes",
-  "plan.summary.n-database-groups": "{{n}} database groups",
-  "plan.summary.n-databases": "{{n}} databases",
-  "plan.summary.n-error": "{{n}} error",
-  "plan.summary.n-of-m-approved": "{{n}} of {{m}} approved",
-  "plan.summary.n-of-m-tasks": "{{n}}/{{m}} tasks",
-  "plan.summary.n-passed": "{{n}} passed",
-  "plan.summary.n-warning": "{{n}} warning",
-  "plan.targets.no-targets-found": "No targets found",
-  "plan.targets.non-env-warning.one": "{{count}} database will be excluded from rollout because it has no effective environment:",
-  "plan.targets.non-env-warning.other": "{{count}} databases will be excluded from rollout because they have no effective environment:",
-  "plan.targets.title": "Targets",
-  "plan.targets.view-all": "View all ({{count}})",
-  "plan.title-required": "Title is required",
-  "plan.view-discussion": "View discussion",
   "plugin": {
     "ai": {
       "actions": {
@@ -1879,15 +1716,12 @@
       "webhook-url": "Webhook URL"
     }
   },
-  "project.select": "Select project",
   "quick-action": {
     "create-db": "Create database",
     "create-project": "Create project",
     "new-project": "New Project",
     "request-export-data": "Request Export"
   },
-  "quick-action.create-project": "Create project",
-  "quick-action.new-project": "New Project",
   "quick-start": {
     "guide": "click on the step to try it out",
     "notice": {
@@ -1903,7 +1737,6 @@
     "visit-member": "Visit Member | Members",
     "visit-project": "Visit Projects"
   },
-  "quick-start.self": "Quick Start",
   "release": {
     "and-n-more-files": "and {{count}} more files",
     "change-tip": "This change is linked to a release artifact.",
@@ -1948,13 +1781,6 @@
       "pattern": "The {{resource}} ID can have lowercase letters, digits, or hyphens. It must start with a lowercase letter and end with a letter or number."
     }
   },
-  "resource-id.cannot-be-changed-later": "It cannot be changed later.",
-  "resource-id.description": "The {{resource}} ID is a unique identifier. You cannot change it after created.",
-  "resource-id.self": "{{resource}} ID",
-  "resource-id.validation.duplicated": "The {{resource}} ID already exists. Please choose another one.",
-  "resource-id.validation.empty": "The {{resource}} ID cannot be empty",
-  "resource-id.validation.overflow": "The {{resource}} ID is too long. It should have less than 64 characters.",
-  "resource-id.validation.pattern": "The {{resource}} ID can have lowercase letters, digits, or hyphens. It must start with a lowercase letter and end with a letter or number.",
   "role": {
     "custom-roles": {
       "self": "Custom roles"
@@ -1976,6 +1802,7 @@
     }
   },
   "rollout": {
+    "bypass-stage-requirements": "Bypass warnings",
     "no-stages": "No stages available",
     "no-tasks-created": "No tasks created yet",
     "pending-tasks-preview": {
@@ -1992,12 +1819,13 @@
       "self_one": "Stage",
       "self_other": "Stages"
     },
+    "task": {
+      "no-tasks": "No tasks in this stage",
+      "selected-count": "{{count}} task selected",
+      "statement-truncated-hint": "Statement truncated due to large size."
+    },
     "task-execution-errors": "Task execution errors"
   },
-  "rollout.bypass-stage-requirements": "Bypass warnings",
-  "rollout.task.no-tasks": "No tasks in this stage",
-  "rollout.task.selected-count": "{{count}} task selected",
-  "rollout.task.statement-truncated-hint": "Statement truncated due to large size.",
   "schema-diagram": {
     "fit-content-with-view": "Fit content within view",
     "self": "Schema Diagram"
@@ -2103,8 +1931,6 @@
       "value-placeholder": "Label value..."
     }
   },
-  "setting.label.key-placeholder": "Label key...",
-  "setting.label.value-placeholder": "Label value...",
   "settings": {
     "general": {
       "workspace": {
@@ -2632,7 +2458,6 @@
       }
     }
   },
-  "settings.general.workspace.default-landing-page.go-to-workspace": "Go to workspace",
   "setup": {
     "basic-info": "Basic info",
     "data": {
@@ -3772,20 +3597,37 @@
       }
     }
   },
-  "subscription.instance-assignment.assign-license": "Assign License",
-  "subscription.instance-assignment.n-license-remain": "{{n}} remaining",
-  "subscription.usage.instance-count.runoutof": "You have run out of your {{total}} instance quota.",
-  "subscription.usage.instance-count.title": "Instance count limit",
   "task": {
+    "affected-rows": "Affected rows",
     "cancel-task": "Cancel task | Cancel tasks",
     "cancel-task-description": "Pending and available task runs are canceled immediately. Running task runs receive a best-effort cancel request and may keep running; retry if needed.",
+    "check-type": {
+      "affected-rows": {
+        "description": "Estimated by statistical information.",
+        "self": "Affected rows"
+      },
+      "sql-review": {
+        "description": "Analyze the SQL statement for potential issues and provide recommendations. Includes built-in rules and your custom rules.",
+        "self": "SQL review"
+      }
+    },
     "created": "Created",
     "data-export-creator-only": "Only the issue creator can execute data export tasks",
     "error": {
       "scheduled-time-must-be-in-the-future": "Scheduled time must be in the future"
     },
+    "executed-by": "Executed by",
     "execution-time": "Execution time",
+    "no-cancelable-tasks": "No cancelable tasks",
     "no-permission": "No permission to perform this action",
+    "no-runnable-tasks": "No runnable tasks",
+    "no-selectable-tasks": "No selectable tasks",
+    "no-skippable-tasks": "No skippable tasks",
+    "no-tasks-selected": "No tasks selected",
+    "online-migration": {
+      "self": "Online migration"
+    },
+    "prior-backup": "Prior backup",
     "run-immediately": {
       "description": "Tasks will start executing as soon as you click Run. No delay or scheduling required.",
       "self": "Run immediately"
@@ -3795,7 +3637,9 @@
       "description": "Set a specific date and time for tasks to automatically start running. Useful for maintenance windows or off-peak hours.",
       "self": "Schedule for later"
     },
+    "scheduled-time": "Scheduled time",
     "select-scheduled-time": "Select scheduled time",
+    "select-task": "Select Task",
     "skip-prior-backup": "Skip prior backup",
     "skip-prior-backup-description": "Skip the automatic data backup before applying changes",
     "skip-task": "Skip task | Skip tasks",
@@ -3810,56 +3654,55 @@
       "skipped": "Skipped"
     }
   },
-  "task-run.blocked-sessions": "Blocked Sessions",
-  "task-run.blocked-sessions-description": "The sessions that are blocked by the current session",
-  "task-run.blocking-sessions": "Blocking Sessions",
-  "task-run.blocking-sessions-description": "The sessions that are blocking the current session",
-  "task-run.history": "History",
-  "task-run.latest": "Latest",
-  "task-run.latest-logs": "Latest Logs",
-  "task-run.log-detail.backing-up": "Backing up...",
-  "task-run.log-detail.backup-completed": "completed ({{count}} tables)",
-  "task-run.log-detail.completed": "Completed",
-  "task-run.log-detail.computing": "Computing...",
-  "task-run.log-detail.dumping": "Dumping...",
-  "task-run.log-detail.retry-attempt": "attempt {{current}}/{{max}}",
-  "task-run.log-detail.syncing": "Syncing...",
-  "task-run.log-type.command-execute": "Command Execute",
-  "task-run.log-type.compute-diff": "Compute Diff",
-  "task-run.log-type.database-sync": "Database Sync",
-  "task-run.log-type.ghost-migration": "gh-ost Migration",
-  "task-run.log-type.prior-backup": "Prior Backup",
-  "task-run.log-type.release-file-execute": "Release File",
-  "task-run.log-type.retry": "Retry",
-  "task-run.log-type.schema-dump": "Schema Dump",
-  "task-run.log-type.transaction": "Transaction",
-  "task-run.log-viewer.collapse-all": "Collapse all",
-  "task-run.log-viewer.expand-all": "Expand all",
-  "task-run.log-viewer.multiple-replicas-notice": "Server restart detected during execution. Logs are grouped by replica.",
-  "task-run.log-viewer.replica-n": "Replica #{{n}}",
-  "task-run.log-viewer.summary": "{{sections}} sections · {{entries}} entries",
-  "task-run.no-session-found": "No session found",
-  "task-run.rollback.available": "{{count}} rollback available",
-  "task-run.rollback.no-statement-generated": "No statement generated",
-  "task-run.rollback.preview-statement.description": "Review the generated rollback statements before creating the rollback plan.",
-  "task-run.status.enqueued": "Waiting for execution.",
-  "task-run.status.enqueued-with-rollout-time": "Waiting to execute after {{time}}.",
-  "task-run.status.waiting-max-tasks-per-rollout": "Waiting for other tasks to finish. Maximum running tasks limit per rollout has been reached. Last report at {{time}}.",
-  "task.affected-rows": "Affected rows",
-  "task.check-type.affected-rows.description": "Estimated by statistical information.",
-  "task.check-type.affected-rows.self": "Affected rows",
-  "task.check-type.sql-review.description": "Analyze the SQL statement for potential issues and provide recommendations. Includes built-in rules and your custom rules.",
-  "task.check-type.sql-review.self": "SQL review",
-  "task.executed-by": "Executed by",
-  "task.no-cancelable-tasks": "No cancelable tasks",
-  "task.no-runnable-tasks": "No runnable tasks",
-  "task.no-selectable-tasks": "No selectable tasks",
-  "task.no-skippable-tasks": "No skippable tasks",
-  "task.no-tasks-selected": "No tasks selected",
-  "task.online-migration.self": "Online migration",
-  "task.prior-backup": "Prior backup",
-  "task.scheduled-time": "Scheduled time",
-  "task.select-task": "Select Task",
+  "task-run": {
+    "blocked-sessions": "Blocked Sessions",
+    "blocked-sessions-description": "The sessions that are blocked by the current session",
+    "blocking-sessions": "Blocking Sessions",
+    "blocking-sessions-description": "The sessions that are blocking the current session",
+    "history": "History",
+    "latest": "Latest",
+    "latest-logs": "Latest Logs",
+    "log-detail": {
+      "backing-up": "Backing up...",
+      "backup-completed": "completed ({{count}} tables)",
+      "completed": "Completed",
+      "computing": "Computing...",
+      "dumping": "Dumping...",
+      "retry-attempt": "attempt {{current}}/{{max}}",
+      "syncing": "Syncing..."
+    },
+    "log-type": {
+      "command-execute": "Command Execute",
+      "compute-diff": "Compute Diff",
+      "database-sync": "Database Sync",
+      "ghost-migration": "gh-ost Migration",
+      "prior-backup": "Prior Backup",
+      "release-file-execute": "Release File",
+      "retry": "Retry",
+      "schema-dump": "Schema Dump",
+      "transaction": "Transaction"
+    },
+    "log-viewer": {
+      "collapse-all": "Collapse all",
+      "expand-all": "Expand all",
+      "multiple-replicas-notice": "Server restart detected during execution. Logs are grouped by replica.",
+      "replica-n": "Replica #{{n}}",
+      "summary": "{{sections}} sections · {{entries}} entries"
+    },
+    "no-session-found": "No session found",
+    "rollback": {
+      "available": "{{count}} rollback available",
+      "no-statement-generated": "No statement generated",
+      "preview-statement": {
+        "description": "Review the generated rollback statements before creating the rollback plan."
+      }
+    },
+    "status": {
+      "enqueued": "Waiting for execution.",
+      "enqueued-with-rollout-time": "Waiting to execute after {{time}}.",
+      "waiting-max-tasks-per-rollout": "Waiting for other tasks to finish. Maximum running tasks limit per rollout has been reached. Last report at {{time}}."
+    }
+  },
   "two-factor": {
     "description": "Two-factor authentication provides an extra layer of security for member accounts. When signing in, you will be required to enter the security code generated by your Authenticator App.",
     "disable": {

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -1,21 +1,25 @@
 {
-  "activity.sentence.added-spec": "añadió",
-  "activity.sentence.canceled-issue": "closed the issue",
-  "activity.sentence.changed-description": "changed description",
-  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
-  "activity.sentence.changed-labels": "changed labels",
-  "activity.sentence.changed-targets-of": "cambió los targets de",
-  "activity.sentence.created-issue": "created issue",
-  "activity.sentence.disabled-prior-backup-on": "desactivó prior backup en",
-  "activity.sentence.enabled-prior-backup-on": "activó prior backup en",
-  "activity.sentence.modified-sql-of": "modificó el SQL de",
-  "activity.sentence.removed-spec": "eliminó",
-  "activity.sentence.reopened-issue": "reopened issue",
-  "activity.sentence.resolved-issue": "marcó la incidencia como completada",
-  "activity.sentence.review-done-rollout-created": "Revisión completada, rollout creado",
-  "activity.sentence.review-done-rollout-created-for-plan": "Revisión completada, rollout creado para el plan",
-  "activity.sentence.review-skipped-rollout-created": "Revisión omitida, rollout creado",
-  "activity.sentence.review-skipped-rollout-created-for-plan": "Revisión omitida, rollout creado para el plan",
+  "activity": {
+    "sentence": {
+      "added-spec": "añadió",
+      "canceled-issue": "cerró el issue",
+      "changed-description": "cambió la descripción",
+      "changed-from-to": "cambió {{name}} de \"{{oldValue}}\" a \"{{newValue}}\"",
+      "changed-labels": "cambió las etiquetas",
+      "changed-targets-of": "cambió los objetivos de",
+      "created-issue": "creó el issue",
+      "disabled-prior-backup-on": "desactivó el respaldo previo en",
+      "enabled-prior-backup-on": "activó el respaldo previo en",
+      "modified-sql-of": "modificó el SQL de",
+      "removed-spec": "eliminó",
+      "reopened-issue": "reabrió el issue",
+      "resolved-issue": "marcó la incidencia como completada",
+      "review-done-rollout-created": "Revisión completada, rollout creado",
+      "review-done-rollout-created-for-plan": "Revisión completada, rollout creado para el plan",
+      "review-skipped-rollout-created": "Revisión omitida, rollout creado",
+      "review-skipped-rollout-created-for-plan": "Revisión omitida, rollout creado para el plan"
+    }
+  },
   "agent": {
     "active-only-chats": "Solo activos",
     "ai-not-configured": {
@@ -52,6 +56,7 @@
     "reply": "Responder",
     "result": "Resultado",
     "retry-last-chat-turn": "Reintentar",
+    "self": "Asistente",
     "send": "Enviar",
     "stop": "Detener",
     "tool-answer": "Respuesta",
@@ -69,7 +74,6 @@
     "unarchive-all-chats": "Desarchivar todos los chats",
     "unarchive-chat": "Desarchivar chat"
   },
-  "agent.self": "Asistente",
   "audit-log": {
     "advanced-search": {
       "scope": {
@@ -152,9 +156,9 @@
       "create-admin-account": "Crear cuenta de administrador",
       "existing-user": "¿Ya tienes una cuenta?",
       "title": "Registre su cuenta"
-    }
+    },
+    "token-expired-title": "Token expirado"
   },
-  "auth.token-expired-title": "Token expirado",
   "banner": {
     "external-url": "Bytebase no ha configurado --external-url",
     "license-expired": "Su licencia para {{plan}} ha expirado el {{expireAt}}.",
@@ -182,7 +186,7 @@
         "or": {
           "description": "Cualquiera de los siguientes es verdadero..."
         },
-        "tooltip": "A condition group is a collection of conditions connected by operators \"And\" and \"Or\"."
+        "tooltip": "Un grupo de condiciones es un conjunto de condiciones conectadas por los operadores \"Y\" y \"O\"."
       },
       "input-value": "Valor de entrada",
       "input-value-press-enter": "Ingrese el valor, presione Enter para confirmar",
@@ -192,9 +196,9 @@
   },
   "changelog": {
     "current-schema-empty": "El esquema actual está vacío",
-    "no-schema-change": "No schema change",
+    "no-schema-change": "Sin cambios de esquema",
     "schema-snapshot-after-change": "La instantánea de esquema registrada después de aplicar este cambio",
-    "select": "Schema version is recorded each time a schema change is applied via Bytebase",
+    "select": "La versión del esquema se registra cada vez que se aplica un cambio de esquema mediante Bytebase",
     "self": "Changelog",
     "show-diff": "Mostrar diferencias"
   },
@@ -205,47 +209,54 @@
     "actions": "Acciones",
     "activated": "Activado",
     "active": "Activo",
+    "activity": "Actividad",
     "add": "Agregar",
     "add-permissions": "Agregar permisos",
     "added": "Agregado",
     "address": "Dirección",
-    "admin": "Admin",
+    "admin": "Administrador",
     "all": "Todos",
     "allow": "Permitir",
-    "approve": "Approve",
+    "and": "y",
+    "approve": "Aprobar",
     "approved": "Aprobado",
     "archive": "Archivo",
-    "archive-description": "Mark \"{{name}}\" as archived and read-only.",
-    "archive-resource": "Archive {{type}}",
+    "archive-description": "Marcar \"{{name}}\" como archivado y de solo lectura.",
+    "archive-resource": "Archivar {{type}}",
     "archived": "Archivada",
     "back": "Volver",
+    "back-to-workspace": "Volver al espacio de trabajo",
     "bypassed": "Omitido",
     "cancel": "Cancelar",
     "cannot-undo-this-action": "No se puede deshacer esta acción",
+    "catalog": "Catálogo",
     "changelog": "Changelog",
     "classification-level": "Nivel de clasificación",
     "clear": "Limpiar",
     "clear-filters": "Limpiar filtros",
     "close": "Cerrar",
+    "close-mobile-sidebar": "Cerrar barra lateral móvil",
     "closed": "Cerrado",
+    "collapse": "Contraer",
+    "column": "Columna",
     "comment": "Comentario",
     "configure": "Configurar",
     "configure-now": "Configurar ahora",
     "confirm": "Confirmar",
-    "confirm-archive": "Archive Resource?",
-    "confirm-delete": "Delete Resource?",
-    "confirm-to-revert": "Confirm to revert your editing?",
+    "confirm-archive": "¿Archivar recurso?",
+    "confirm-delete": "¿Eliminar recurso?",
+    "confirm-to-revert": "¿Confirmar para revertir su edición?",
     "continue-anyway": "De todas maneras, continúe",
     "copied": "Copiado",
     "copy": "Copiar",
-    "copy-failed": "Copy failed",
+    "copy-failed": "Error al copiar",
     "create": "Crear",
     "created": "Creado",
     "created-at": "Creado",
     "creating": "Creando...",
     "creator": "Creador",
     "custom": "Personalizado",
-    "danger-zone": "Danger Zone",
+    "danger-zone": "Zona de peligro",
     "database": "Base de datos",
     "database-group": "Grupo de bases de datos",
     "databases": "Bases de datos",
@@ -253,28 +264,29 @@
     "default": "Predeterminado",
     "definition": "Definición",
     "delete": "Eliminar",
-    "delete-resource": "Delete {{type}}",
-    "delete-resource-description": "Once you delete \"{{name}}\", there is no going back. Please be certain.",
+    "delete-resource": "Eliminar {{type}}",
+    "delete-resource-description": "Una vez que elimine \"{{name}}\", no habrá vuelta atrás. Por favor, esté seguro.",
     "deleted": "Eliminado",
     "deny": "Denegar",
     "description": "Descripción",
-    "deselect-all": "Deselect all",
+    "deselect-all": "Deseleccionar todo",
     "detail": "Detalle",
     "detailed-guide": "guía detallada",
-    "disable": "Disable",
+    "disable": "Deshabilitar",
     "discard-changes": "Descartar cambios",
     "dismiss": "Descartar",
     "done": "Hecho",
     "download": "Descargar",
     "draft": "Borrador",
     "duplicate": "Duplicar",
-    "duration": "Duration",
+    "duration": "Duración",
     "edit": "Editar",
+    "edited": "editado",
     "email": "Correo electrónico",
     "email-ascii-only": "Las direcciones de correo solo admiten caracteres ASCII (letras, números y símbolos como . _ - +).",
-    "empty": "Empty",
+    "empty": "Vacío",
     "enable": "Habilitar",
-    "enabled": "Enabled",
+    "enabled": "Habilitado",
     "environment": "Entorno",
     "environment-name": "Nombre del entorno",
     "environments": "Entornos",
@@ -287,7 +299,7 @@
       "size-limit": "El tamaño del archivo debe ser menor que {{size}} MiB",
       "type-limit": "Solo se admiten archivos {{extension}}"
     },
-    "filter": "Filter",
+    "filter": "Filtrar",
     "filter-by-name": "Filtrar por nombre",
     "fork": "Bifurcación",
     "from": "Desde",
@@ -299,22 +311,28 @@
     "home": "Inicio",
     "id": "ID",
     "import": "Importar",
+    "in-progress": "En progreso",
     "info": "Información",
     "instance": "Instancia",
     "instances": "Instancias",
-    "is-required": "is required",
+    "is-required": "es obligatorio",
+    "issue": "Issue",
     "issues": "Incidencias",
-    "items": "items",
+    "items": "elementos",
     "key": "Clave",
     "labels": "Etiquetas",
+    "language": "Idioma",
     "learn-more": "Aprender más",
     "leave-without-saving": "¿Salir sin guardar?",
+    "license": "Licencia",
+    "line": "Línea",
     "load-more": "Cargar más",
     "loading": "Cargando",
     "logout": "Cerrar sesión",
     "manage": "Administrar",
-    "manually-select": "Manually select",
+    "manually-select": "Seleccionar manualmente",
     "maximize": "Maximizar",
+    "members": "Miembros",
     "members_one": "Miembro",
     "members_other": "Miembros",
     "minutes": "Minutos",
@@ -330,8 +348,11 @@
     "no-data": "Sin datos",
     "not-started": "No iniciado",
     "ok": "OK",
+    "only-creator-allowed-export": "Solo el creador puede exportar",
+    "open": "Abrir",
+    "operation": "Operación",
     "operations": "Operaciones",
-    "optional": "Optional",
+    "optional": "Opcional",
     "or": "o",
     "overview": "Resumen",
     "password": "Contraseña",
@@ -339,27 +360,32 @@
     "permissions": "Permisos",
     "plan": "Plan",
     "preview": "Previsualización",
-    "previous": "Previous",
+    "previous": "Anterior",
     "project": "Proyecto",
     "projects": "Proyectos",
     "query": "Consulta",
     "read-only": "Solo lectura",
     "reason": "Razón",
+    "recent": "Recientes",
     "refresh": "Actualizar",
     "regenerate": "Regenerar",
-    "reject": "Reject",
+    "reject": "Rechazar",
     "rejected": "Rechazado",
     "release": "Versión",
+    "remaining": "restantes",
     "remove": "Eliminar",
+    "removed": "Eliminado",
+    "reopen": "Reabrir",
     "reorder": "Reordenar",
     "required-permission": "Permisos necesarios",
     "required-workspace-permission": "Se requieren los siguientes permisos para inicializar el espacio de trabajo UX",
     "reset": "Restablecer",
-    "resource": "Resource",
+    "resource": "Recurso",
     "resource-not-found": "Recurso no encontrado",
     "resources": "Recursos",
     "restore": "Restaurar",
-    "restored": "Restored",
+    "restored": "Restaurado",
+    "retry": "Reintentar",
     "revert": "Revertir",
     "revoke": "Revocar",
     "revoked": "Revocado",
@@ -373,7 +399,7 @@
       "self": "filas"
     },
     "rows-per-page": "Filas por página",
-    "run": "Run",
+    "run": "Ejecutar",
     "running": "En ejecución",
     "save": "Guardar",
     "schema": "Esquema",
@@ -382,14 +408,17 @@
     "search-for-more": "Buscar más",
     "select": "Seleccionar",
     "select-all": "Seleccionar todo",
-    "selected": "selected",
+    "selected": "seleccionado",
     "sensitive-placeholder": "Sensible - solo escritura",
     "setting": "Configuración",
     "settings": "Configuraciones",
     "share": "Compartir",
+    "show-less": "Mostrar menos",
+    "show-more": "Mostrar más",
     "sign-in": "Iniciar sesión",
     "sign-in-as-admin": "Iniciar sesión como administrador",
     "sign-up": "Registrarse",
+    "skip": "Omitir",
     "skipped": "Omitido",
     "snapshot": "Instantánea",
     "sql": "SQL",
@@ -397,10 +426,12 @@
     "state": "Estado",
     "statement": "Declaración",
     "status": "Estado",
-    "submit": "Submit",
+    "submit": "Enviar",
     "succeed": "Tener éxito",
+    "success": "Éxito",
     "system": "Sistema",
     "table": "Tabla",
+    "task": "Tarea",
     "text-wrap": "Ajuste de texto",
     "tips": "Consejos",
     "title": "Título",
@@ -408,10 +439,12 @@
     "total": "Total",
     "total-n-items": "Total {{n}} elementos",
     "transfer": "Transferir",
+    "troubleshoot": "Solucionar problemas",
     "type": "Tipo",
     "type-to-search": "Escriba para buscar",
     "unassigned": "No asignado",
     "under-review": "En revisión",
+    "unknown": "Desconocido",
     "unlimited": "Ilimitado",
     "untitled": "Sin título",
     "update": "Actualizar",
@@ -426,100 +459,14 @@
     "version": "Versión",
     "view": "Ver",
     "view-details": "Ver Detalles",
+    "view-doc": "Ver doc",
     "visibility": "Visibilidad",
+    "want-help": "¿Quiere ayuda?",
     "warning": "Advertencia",
     "webhooks": "Webhooks",
     "write-only": "solo escritura",
     "you": "tu"
   },
-  "common.activity": "Actividad",
-  "common.add": "Agregar",
-  "common.admin": "Admin",
-  "common.all": "Todos",
-  "common.and": "y",
-  "common.archive": "Archivo",
-  "common.archived": "Archivada",
-  "common.back-to-workspace": "Back to workspace",
-  "common.cancel": "Cancelar",
-  "common.cannot-undo-this-action": "No se puede deshacer esta acción",
-  "common.catalog": "Catálogo",
-  "common.close": "Cerrar",
-  "common.close-mobile-sidebar": "Close mobile sidebar",
-  "common.collapse": "Contraer",
-  "common.column": "Columna",
-  "common.comment": "Comment",
-  "common.confirm": "Confirmar",
-  "common.continue-anyway": "De todas maneras, continúe",
-  "common.copy": "Copiar",
-  "common.create": "Crear",
-  "common.creating": "Creando...",
-  "common.custom": "Personalizado",
-  "common.database": "Base de datos",
-  "common.database-group": "Grupo de bases de datos",
-  "common.databases": "Bases de datos",
-  "common.default": "predeterminado",
-  "common.delete": "Eliminar",
-  "common.delete-resource": "Delete {{type}}",
-  "common.deleted": "Eliminado",
-  "common.detail": "Detail",
-  "common.detailed-guide": "guía detallada",
-  "common.edit": "Editar",
-  "common.edited": "edited",
-  "common.environment": "Entorno",
-  "common.import": "Importar",
-  "common.in-progress": "En progreso",
-  "common.issue": "Issue",
-  "common.key": "Clave",
-  "common.labels": "Etiquetas",
-  "common.language": "Language",
-  "common.learn-more": "Aprender más",
-  "common.license": "License",
-  "common.line": "Línea",
-  "common.load-more": "Cargar más",
-  "common.loading": "Cargando",
-  "common.logout": "Cerrar sesión",
-  "common.members": "Miembros",
-  "common.minutes": "Minutos",
-  "common.n-more": "{{n}} más",
-  "common.no-data": "Sin datos",
-  "common.only-creator-allowed-export": "Only the creator is allowed to export",
-  "common.open": "Abrir",
-  "common.operation": "Operación",
-  "common.optional": "Opcional",
-  "common.or": "o",
-  "common.overview": "Resumen",
-  "common.password": "Contraseña",
-  "common.project": "Proyecto",
-  "common.read-only": "Solo lectura",
-  "common.recent": "Recientes",
-  "common.remaining": "restantes",
-  "common.remove": "Eliminar",
-  "common.removed": "Eliminado",
-  "common.reopen": "Reabrir",
-  "common.restore": "Restaurar",
-  "common.retry": "Reintentar",
-  "common.role.self": "Rol",
-  "common.rollout": "Implementar",
-  "common.save": "Guardar",
-  "common.sensitive-placeholder": "Sensible - solo escritura",
-  "common.show-less": "Mostrar menos",
-  "common.show-more": "Mostrar más",
-  "common.skip": "Omitir",
-  "common.success": "Éxito",
-  "common.task": "Tarea",
-  "common.troubleshoot": "Solucionar problemas",
-  "common.unknown": "Desconocido",
-  "common.unlimited": "Ilimitado",
-  "common.updated": "Actualizado",
-  "common.updating": "Actualizando",
-  "common.user": "Usuario",
-  "common.username": "Nombre de usuario",
-  "common.value": "Valor",
-  "common.version": "Versión",
-  "common.view-doc": "Ver doc",
-  "common.want-help": "Want help",
-  "common.warning": "Advertencia",
-  "common.write-only": "solo escritura",
   "create-db": {
     "cluster": "Clúster",
     "database-owner-name": "Nombre del propietario de la base de datos",
@@ -558,14 +505,18 @@
     "issue-review": {
       "and-n-other-users": "{{names}} y {{count}} otros usuarios",
       "approved-by": "Aprobado por",
+      "approved-issue": "aprobó el issue",
       "disallow-approve-reason": {
-        "some-task-checks-are-still-running": "Some task checks are still running.",
-        "some-task-checks-didnt-pass": "Some task checks didn't pass."
+        "some-task-checks-are-still-running": "Algunas comprobaciones de tareas aún se están ejecutando.",
+        "some-task-checks-didnt-pass": "Algunas comprobaciones de tareas no se superaron."
       },
       "generating-approval-flow": "Generando flujo de aprobación",
       "re-request-review": "Volver a solicitar revisión",
       "re-request-review-success": "Revisión solicitada nuevamente con éxito",
+      "re-requested-review": "volvió a solicitar la revisión del issue",
       "rejected-by": "Rechazado por",
+      "rejected-issue": "rechazó el issue",
+      "retry-approval-finding": "Reintentar",
       "self-approval-not-allowed": "No se permite la autoaprobación para este proyecto. No puedes aprobarlo como creador."
     },
     "risk": {
@@ -608,17 +559,13 @@
     },
     "self": "Aprobación personalizada"
   },
-  "custom-approval.issue-review.approved-issue": "approved issue",
-  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
-  "custom-approval.issue-review.rejected-issue": "rejected issue",
-  "custom-approval.issue-review.retry-approval-finding": "Reintentar",
   "data-source": {
     "additional-node-addresses": "Direcciones de nodos adicionales",
     "automatic-query-data-source": "Automática",
     "connection-string-schema": "Esquema de cadena de conexión",
     "connection-type": "Tipo de conección",
     "delete-read-only-data-source": "Eliminar origen de datos de solo lectura",
-    "direct-connection": "Direct Connection",
+    "direct-connection": "Conexión directa",
     "extra-params": {
       "description": "Parámetros adicionales para la cadena de conexión de la base de datos",
       "self": "Parámetros adicionales"
@@ -686,47 +633,16 @@
     },
     "ssl-connection": "Conexión SSL"
   },
-  "data-source.additional-node-addresses": "Direcciones de nodos adicionales",
-  "data-source.connection-string-schema": "Esquema de cadena de conexión",
-  "data-source.connection-type": "Tipo de conección",
-  "data-source.delete-read-only-data-source": "Eliminar origen de datos de solo lectura",
-  "data-source.direct-connection": "Direct Connection",
-  "data-source.extra-params.description": "Parámetros adicionales para la cadena de conexión de la base de datos",
-  "data-source.extra-params.self": "Parámetros adicionales",
-  "data-source.no-read-only-data-source": "Sin fuente de datos de solo lectura",
-  "data-source.private-key-passphrase": "Frase de contraseña de clave privada",
-  "data-source.private-key-passphrase-placeholder": "Deje vacío si su clave privada no está cifrada",
-  "data-source.private-key-passphrase-tip": "Frase de contraseña opcional para claves privadas cifradas",
-  "data-source.read-replica-host": "Anfitrión de réplica de lectura",
-  "data-source.read-replica-port": "Puerto de réplica de lectura",
-  "data-source.replica-set": "Conjunto de réplicas",
-  "data-source.snowflake-keypair-tip": "Autenticación de par de claves",
-  "data-source.ssh-connection": "Conexión SSH",
-  "data-source.ssh-type.none": "Ninguno",
-  "data-source.ssh-type.tunnel-and-private-key": "Túnel + Clave Privada",
-  "data-source.ssh.host": "Anfitrión",
-  "data-source.ssh.password": "Contraseña",
-  "data-source.ssh.port": "Puerto",
-  "data-source.ssh.private-key": "Clave Privada",
-  "data-source.ssh.ssh-key": "Clave del SSH",
-  "data-source.ssh.user": "Nombre de usuario",
-  "data-source.ssl-connection": "Conexión SSL",
-  "data-source.ssl.ca-cert": "Certificado de CA",
-  "data-source.ssl.ca-path": "Ruta del certificado de CA",
-  "data-source.ssl.client-cert": "Certificado del cliente",
-  "data-source.ssl.client-cert-path": "Ruta del certificado del cliente",
-  "data-source.ssl.client-key": "Clave del cliente",
-  "data-source.ssl.client-key-path": "Ruta de la clave del cliente",
-  "data-source.ssl.verify-certificate": "Verificar certificado TLS",
-  "data-source.ssl.verify-certificate-tooltip": "Habilitar la verificación del certificado TLS para conexiones seguras. Deshabilitar solo para desarrollo o cuando los certificados no se pueden validar correctamente (por ejemplo, certificados autofirmados, entornos VPN). Advertencia: Deshabilitar la verificación es inseguro",
   "database": {
     "access-denied": "No tiene permiso para acceder a esta base de datos.",
     "all": "Todas las bases de datos",
     "change-database": "Modificar base de datos",
     "checks": "Verificaciones",
     "classification": {
-      "description": "Define classification levels to apply consistent masking policies across columns and databases."
+      "description": "Defina niveles de clasificación para aplicar políticas de enmascaramiento coherentes en columnas y bases de datos.",
+      "self": "Clasificación"
     },
+    "column": "Columna",
     "columns": "Columnas",
     "comment": "Comentario",
     "data-size": "Tamaño de datos",
@@ -734,9 +650,13 @@
     "edit-labels": "Editar etiquetas",
     "edit-schema": "Modificar esquema",
     "engine": "Motor",
-    "expression": "Expression",
+    "export-schema": "Exportar esquema",
+    "export-schema-multi-file": "Multi-archivo (ZIP)",
+    "export-schema-single-file": "Archivo único",
+    "expression": "Expresión",
     "external-database-name": "Nombre de la base de datos externa",
     "external-server-name": "Nombre del servidor externo",
+    "failed-to-export-schema": "Error al exportar el esquema",
     "filter-database": "Filtrar base de datos",
     "foreign-key": {
       "reference": "Referencia"
@@ -744,6 +664,7 @@
     "foreign-keys": "claves foráneas",
     "index-size": "Tamaño del índice",
     "indexes": "Índices",
+    "labels": "Etiquetas de base de datos",
     "last-sync": "Última sincronización",
     "mixed-label-values": "valores mixtos",
     "mixed-label-values-warning": "Algunos de los recursos seleccionados tienen valores mixtos para la misma clave. Solo edite estos pares clave-valor si tiene la intención de cambiarlos.",
@@ -790,30 +711,31 @@
       "unspecified": "No especificado"
     },
     "select": "Seleccionar base de datos",
+    "successfully-exported-schema": "Esquema exportado correctamente",
     "successfully-transferred-databases": "Bases de datos transferidas exitosamente",
     "sync-complete-for-instance": "Sincronización completada para la instancia '{{0}}'",
     "sync-database": "Sincronizar base de datos",
     "sync-schema": {
-      "copy-schema": "Copy schema",
-      "description": "Bytebase supports synchronizing a schema to one or multiple target databases. (MySQL, PostgreSQL, Oracle, MSSQL, TiDB only)",
-      "generated-ddl-statement": "Generated DDL statement",
+      "copy-schema": "Copiar esquema",
+      "description": "Bytebase admite la sincronización de un esquema a una o varias bases de datos de destino. (Solo MySQL, PostgreSQL, Oracle, MSSQL, TiDB)",
+      "generated-ddl-statement": "Sentencia DDL generada",
       "message": {
-        "no-diff-found": "No diff found.",
-        "no-target-databases": "No target databases",
-        "select-a-target-database-first": "Please select a target database first."
+        "no-diff-found": "No se encontraron diferencias.",
+        "no-target-databases": "No hay bases de datos de destino",
+        "select-a-target-database-first": "Por favor, seleccione primero una base de datos de destino."
       },
-      "no-diff": "No diff",
-      "preview-issue": "Preview issue",
-      "schema-change": "Schema change",
-      "schema-change-preview": "Preview Schema change for '{{database}}'",
-      "select-source-schema": "Select source schema",
-      "select-target-databases": "Select target databases",
-      "source-schema": "Source schema",
-      "synchronize-statements": "Corresponding generated DDL statements",
-      "synchronize-statements-description": "You can further edit the generated DDL statements",
-      "target-databases": "Target databases",
+      "no-diff": "Sin diferencias",
+      "preview-issue": "Previsualizar issue",
+      "schema-change": "Cambio de esquema",
+      "schema-change-preview": "Previsualización del cambio de esquema para '{{database}}'",
+      "select-source-schema": "Seleccionar esquema de origen",
+      "select-target-databases": "Seleccionar bases de datos de destino",
+      "source-schema": "Esquema de origen",
+      "synchronize-statements": "Sentencias DDL generadas correspondientes",
+      "synchronize-statements-description": "Puede editar aún más las sentencias DDL generadas",
+      "target-databases": "Bases de datos de destino",
       "title": "Sincronizar esquema",
-      "with-diff": "With diff"
+      "with-diff": "Con diferencias"
     },
     "sync-schema-button": "Sincronizar esquema",
     "sync-status": "Estado de sincronización",
@@ -832,29 +754,18 @@
   },
   "database-group": {
     "condition": {
-      "self": "Condition"
+      "self": "Condición"
     },
-    "delete-group": "Delete the database group {{name}}",
-    "matched-database": "Matched database",
-    "no-matched-databases": "No matched databases",
-    "select": "Select database group",
-    "unmatched-database": "Unmatched database"
+    "delete-group": "Eliminar el grupo de bases de datos {{name}}",
+    "matched-database": "Base de datos coincidente",
+    "no-matched-databases": "No hay bases de datos coincidentes",
+    "select": "Seleccionar grupo de bases de datos",
+    "unmatched-database": "Base de datos no coincidente"
   },
-  "database.classification.self": "Clasificación",
-  "database.column": "Columna",
-  "database.engine": "Motor",
-  "database.export-schema": "Exportar esquema",
-  "database.export-schema-multi-file": "Multi-archivo (ZIP)",
-  "database.export-schema-single-file": "Archivo único",
-  "database.failed-to-export-schema": "Error al exportar el esquema",
-  "database.filter-database": "Filtrar base de datos",
-  "database.labels": "Etiquetas de base de datos",
-  "database.revision.delete-confirm-dialog": "Esto eliminará las revisiones aplicadas y el esquema de la base de datos no se modificará. Esta acción no se puede deshacer.",
-  "database.revision.self": "Revisión",
-  "database.successfully-exported-schema": "Esquema exportado correctamente",
-  "database.sync-complete-for-instance": "Sincronización completada para la instancia '{{0}}'",
-  "database.sync-database": "Sincronizar base de datos",
   "db": {
+    "catalog": {
+      "description": "Editar y cargar el catálogo de tablas."
+    },
     "character-set": "Juego de caracteres",
     "collation": "Colación",
     "collections": "Colecciones",
@@ -897,11 +808,6 @@
     "triggers": "Desencadenantes",
     "views": "Vistas"
   },
-  "db.catalog.description": "Editar y cargar el catálogo de tablas.",
-  "db.failed-to-sync-schema": "No se pudo sincronizar el esquema",
-  "db.n-databases-had-sync-errors": "{{0}} base(s) de datos tuvieron errores de sincronización",
-  "db.start-to-sync-schema": "Comenzar a sincronizar el esquema",
-  "db.syncing-databases-for-instance": "Sincronizando bases de datos para {{0}}...",
   "environment": {
     "delete-description": "Eliminar el entorno también lo eliminará de las instancias y bases de datos relacionadas. No se puede deshacer esta acción",
     "reorder": "Reordenar entornos",
@@ -921,7 +827,6 @@
     "password-info": "Proporcione una contraseña para cifrar el archivo de exportación.",
     "password-optional": "Cifrar con contraseña (opcional)"
   },
-  "export-data.password-optional": "Contraseña (opcional)",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "Para bases de datos con el mismo esquema, un grupo de bases de datos permite migrarlas juntas en un solo cambio. Defina el grupo una vez y reutilícelo en las migraciones sin tener que seleccionar bases de datos individuales cada vez.",
@@ -949,7 +854,7 @@
     },
     "workflow": {
       "description": "Copie los archivos de flujo de trabajo en su repositorio para automatizar la revisión de SQL y los despliegues de base de datos.",
-      "file-hint": "Guardar como {{filePath}} en su repositorio",
+      "file-hint": "Guardar como {{filePath}} en su repositorio {{repository}}",
       "provider-not-match": "La workload identity seleccionada solo funciona para {{provider}}.",
       "self-hosted-runner": "Runner self-hosted",
       "title": "Generación de archivo de flujo de trabajo"
@@ -994,6 +899,7 @@
     "connection-options": "Opciones de conexión",
     "create-gcp-credentials": "Para crear credenciales, consulte",
     "database-region": "Región de la base de datos",
+    "default-role": "Rol predeterminado",
     "endpoint": "Punto final",
     "external-id": "ID externo",
     "external-id-description": "ID externo para seguridad adicional al asumir el rol (opcional)",
@@ -1016,9 +922,9 @@
     "external-secret-vault": {
       "vault-auth-type": {
         "approle": {
-          "role-id": "Auth role id",
+          "role-id": "ID de rol de autenticación",
           "secret-env-name": "Nombre del entorno",
-          "secret-id": "Auth secret id",
+          "secret-id": "ID de secreto de autenticación",
           "secret-plain-text": "Texto sin formato",
           "self": "AppRole"
         },
@@ -1027,12 +933,12 @@
           "self": "Token"
         }
       },
-      "vault-secret-engine-name": "Secret engine name",
+      "vault-secret-engine-name": "Nombre del motor de secretos",
       "vault-secret-engine-tips": "Solo admite motor KV v2.",
-      "vault-secret-key": "Secret key",
-      "vault-secret-path": "Secret path",
+      "vault-secret-key": "Clave del secreto",
+      "vault-secret-path": "Ruta del secreto",
       "vault-tls-config": "Configuración TLS de Vault (opcional)",
-      "vault-url": "Vault URL"
+      "vault-url": "URL de Vault"
     },
     "failed-to-connect-instance": "Error al conectar la instancia.",
     "failed-to-connect-instance-localhost": "Si ejecuta Bytebase con Docker, intente \"host.docker.internal\" para la dirección del host.",
@@ -1045,10 +951,66 @@
     "iam-extension": {
       "client-id": "Client ID",
       "client-secret": "Client Secret",
-      "credential-source": "Credential Source",
+      "credential-source": "Origen de credenciales",
       "saas-default-credential-restriction": "Las credenciales predeterminadas no están disponibles en Bytebase Cloud por seguridad. Proporcione credenciales específicas.",
       "specific-credential": "Credencial específica",
       "tenant-id": "Tenant ID"
+    },
+    "info": {
+      "configure-database-user": {
+        "link": "Configurar usuario de base de datos"
+      },
+      "connect-instance": {
+        "link": "Conectar su instancia"
+      },
+      "mongodb": {
+        "authentication": {
+          "content": "Cree un usuario dedicado \"{{user}}\" para Bytebase en la base de datos admin:"
+        },
+        "host": {
+          "content": "Introduzca el nombre de host o la dirección IP de su servidor MongoDB. Para MongoDB Atlas, use el host de la cadena de conexión del diálogo de conexión de su clúster."
+        },
+        "ssh": {
+          "content": "Use un túnel SSH para conectarse a instancias MongoDB en redes privadas. Esto es útil cuando la base de datos está detrás de un firewall o en una VPC."
+        },
+        "ssl": {
+          "content": "MongoDB Atlas y otros servicios MongoDB alojados en la nube requieren conexiones SSL de forma predeterminada. Habilite SSL y proporcione el certificado de CA si es necesario."
+        }
+      },
+      "mysql": {
+        "authentication": {
+          "content": "Cree un usuario dedicado \"{{user}}\" para que Bytebase administre su base de datos. Ejecute el siguiente SQL:"
+        },
+        "host": {
+          "content": "Introduzca el nombre de host o la dirección IP de su servidor MySQL. Para bases de datos alojadas en la nube (AWS RDS, Google Cloud SQL), use el endpoint proporcionado por su proveedor de nube."
+        },
+        "ssh": {
+          "content": "Use un túnel SSH para conectarse a bases de datos en redes privadas que no son accesibles directamente desde Bytebase. Esto enruta la conexión a través de un bastión/jump host."
+        },
+        "ssl": {
+          "content": "Las bases de datos MySQL alojadas en la nube (AWS RDS, Google Cloud SQL, Azure Database) suelen requerir conexiones SSL. Habilite SSL y cargue el certificado de CA proporcionado por su proveedor de nube."
+        }
+      },
+      "postgresql": {
+        "authentication": {
+          "content": "Cree un usuario dedicado \"{{user}}\" para que Bytebase administre su base de datos. Ejecute el siguiente SQL como superusuario:"
+        },
+        "host": {
+          "content": "Introduzca el nombre de host o la dirección IP de su servidor PostgreSQL. Para bases de datos alojadas en la nube, use el endpoint proporcionado por su proveedor de nube."
+        },
+        "ssh": {
+          "content": "Use un túnel SSH para conectarse a bases de datos en redes privadas que no son accesibles directamente desde Bytebase. Esto enruta la conexión a través de un bastión/jump host."
+        },
+        "ssl": {
+          "content": "Las bases de datos PostgreSQL alojadas en la nube (AWS RDS, Google Cloud SQL, Azure Database) suelen requerir conexiones SSL. Habilite SSL y cargue el certificado de CA proporcionado por su proveedor de nube."
+        }
+      },
+      "ssh-tunnel": {
+        "link": "Túnel SSH"
+      },
+      "ssl-tls-connection": {
+        "link": "Conexión SSL/TLS"
+      }
     },
     "info-panel": {
       "no-info": "No hay información adicional disponible para este motor."
@@ -1089,6 +1051,7 @@
       "basic-info": "Información básica",
       "connection": "Conexión"
     },
+    "select-database-user": "Seleccionar usuario de base de datos",
     "selected-n-instances_one": "{{count}} instancia seleccionada",
     "selected-n-instances_other": "{{count}} instancias seleccionadas",
     "sentence": {
@@ -1173,146 +1136,6 @@
     "users": "Usuarios",
     "your-snowflake-account-locator": "Su localizador de cuentas Snowflake"
   },
-  "instance.account-locator": "Localizadora de cuentas",
-  "instance.archive-instance-instance-name": "¿Archivar la instancia '{{0}}'?",
-  "instance.archived-instances-will-not-be-displayed": "Las instancias archivadas no se mostrarán.",
-  "instance.authentication-database": "Base de datos de autenticación",
-  "instance.connection-info": "Información de conexión",
-  "instance.connection-options": "Opciones de conexión",
-  "instance.create-gcp-credentials": "Para crear credenciales, consulte",
-  "instance.database-region": "Región de la base de datos",
-  "instance.default-role": "Rol predeterminado",
-  "instance.endpoint": "Punto final",
-  "instance.external-id": "ID externo",
-  "instance.external-id-description": "ID externo para seguridad adicional al asumir el rol (opcional)",
-  "instance.external-id-placeholder": "ID externo opcional",
-  "instance.external-link": "Enlace externo",
-  "instance.external-secret-azure.secret-name": "Nombre del secreto",
-  "instance.external-secret-azure.secret-name-tips": "El nombre del secreto almacenado en Azure Key Vault.",
-  "instance.external-secret-azure.vault-url": "URL del Key Vault",
-  "instance.external-secret-azure.vault-url-tips": "La URL del Key Vault debe ser similar a \"https://myvault.vault.azure.net/\".",
-  "instance.external-secret-gcp.secret-name": "nombre completo secreto",
-  "instance.external-secret-gcp.secret-name-tips": "El nombre secreto debería ser similar a \"projects/project-id/secrets/secret-id\".",
-  "instance.external-secret-vault.vault-auth-type.approle.role-id": "Auth role id",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-env-name": "Nombre del entorno",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-id": "Auth secret id",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-plain-text": "Texto sin formato",
-  "instance.external-secret-vault.vault-auth-type.approle.self": "AppRole",
-  "instance.external-secret-vault.vault-auth-type.self": "Tipo de autenticación",
-  "instance.external-secret-vault.vault-auth-type.token.self": "Token",
-  "instance.external-secret-vault.vault-secret-engine-name": "Secret engine name",
-  "instance.external-secret-vault.vault-secret-engine-tips": "Solo admite motor KV v2.",
-  "instance.external-secret-vault.vault-secret-key": "Secret key",
-  "instance.external-secret-vault.vault-secret-path": "Secret path",
-  "instance.external-secret-vault.vault-tls-config": "Configuración TLS de Vault (opcional)",
-  "instance.external-secret-vault.vault-url": "Vault URL",
-  "instance.external-secret.key-name": "Clave secreta",
-  "instance.external-secret.secret-name": "Nombre secreto",
-  "instance.failed-to-connect-instance": "Error al conectar la instancia.",
-  "instance.failed-to-connect-instance-localhost": "Si ejecuta Bytebase con Docker, intente \"host.docker.internal\" para la dirección del host.",
-  "instance.find-gcp-project-id": "Para encontrar el ID del proyecto de GCP, consulta",
-  "instance.find-gcp-project-id-and-instance-id": "Para encontrar el ID de proyecto y el ID de instancia de GCP, consulte",
-  "instance.force-archive-description": "Forzar a archivar. Todas las bases de datos quedarán desasignadas.",
-  "instance.grants": "Concesiones",
-  "instance.host-or-socket": "Host o Socket",
-  "instance.iam-extension.client-id": "Client ID",
-  "instance.iam-extension.client-secret": "Client Secret",
-  "instance.iam-extension.credential-source": "Credential Source",
-  "instance.iam-extension.saas-default-credential-restriction": "Las credenciales predeterminadas no están disponibles en Bytebase Cloud por seguridad. Proporcione credenciales específicas.",
-  "instance.iam-extension.specific-credential": "Credencial específica",
-  "instance.iam-extension.tenant-id": "Tenant ID",
-  "instance.info-panel.no-info": "No hay información adicional disponible para este motor.",
-  "instance.info.configure-database-user.link": "Configurar usuario de base de datos",
-  "instance.info.connect-instance.link": "Conectar su instancia",
-  "instance.info.mongodb.authentication.content": "Cree un usuario dedicado \"{{user}}\" para Bytebase en la base de datos admin:",
-  "instance.info.mongodb.host.content": "Introduzca el nombre de host o la dirección IP de su servidor MongoDB. Para MongoDB Atlas, use el host de la cadena de conexión del diálogo de conexión de su clúster.",
-  "instance.info.mongodb.ssh.content": "Use un túnel SSH para conectarse a instancias MongoDB en redes privadas. Esto es útil cuando la base de datos está detrás de un firewall o en una VPC.",
-  "instance.info.mongodb.ssl.content": "MongoDB Atlas y otros servicios MongoDB alojados en la nube requieren conexiones SSL de forma predeterminada. Habilite SSL y proporcione el certificado de CA si es necesario.",
-  "instance.info.mysql.authentication.content": "Cree un usuario dedicado \"{{user}}\" para que Bytebase administre su base de datos. Ejecute el siguiente SQL:",
-  "instance.info.mysql.host.content": "Introduzca el nombre de host o la dirección IP de su servidor MySQL. Para bases de datos alojadas en la nube (AWS RDS, Google Cloud SQL), use el endpoint proporcionado por su proveedor de nube.",
-  "instance.info.mysql.ssh.content": "Use un túnel SSH para conectarse a bases de datos en redes privadas que no son accesibles directamente desde Bytebase. Esto enruta la conexión a través de un bastión/jump host.",
-  "instance.info.mysql.ssl.content": "Las bases de datos MySQL alojadas en la nube (AWS RDS, Google Cloud SQL, Azure Database) suelen requerir conexiones SSL. Habilite SSL y cargue el certificado de CA proporcionado por su proveedor de nube.",
-  "instance.info.postgresql.authentication.content": "Cree un usuario dedicado \"{{user}}\" para que Bytebase administre su base de datos. Ejecute el siguiente SQL como superusuario:",
-  "instance.info.postgresql.host.content": "Introduzca el nombre de host o la dirección IP de su servidor PostgreSQL. Para bases de datos alojadas en la nube, use el endpoint proporcionado por su proveedor de nube.",
-  "instance.info.postgresql.ssh.content": "Use un túnel SSH para conectarse a bases de datos en redes privadas que no son accesibles directamente desde Bytebase. Esto enruta la conexión a través de un bastión/jump host.",
-  "instance.info.postgresql.ssl.content": "Las bases de datos PostgreSQL alojadas en la nube (AWS RDS, Google Cloud SQL, Azure Database) suelen requerir conexiones SSL. Habilite SSL y cargue el certificado de CA proporcionado por su proveedor de nube.",
-  "instance.info.ssh-tunnel.link": "Túnel SSH",
-  "instance.info.ssl-tls-connection.link": "Conexión SSL/TLS",
-  "instance.instance-id": "ID de la instancia",
-  "instance.instance-name": "Nombre de la instancia",
-  "instance.new-instance": "Nueva instancia",
-  "instance.no-environment": "Esta instancia no ha sido ligada al entorno.",
-  "instance.no-extra-params-configured": "No hay parámetros de conexión adicionales configurados",
-  "instance.no-params-yet-add-above": "No hay parámetros configurados todavía. \nAgregue parámetros usando el formulario anterior.",
-  "instance.no-password": "Sin contraseña",
-  "instance.parameter-name-placeholder": "Nombre de parámetro",
-  "instance.parameter-value-placeholder": "Valor de parámetro",
-  "instance.password-type.aws-iam": "AWS RDS IAM",
-  "instance.password-type.azure-iam": "Azure IAM",
-  "instance.password-type.external-secret-aws": "AWS Secrets Manager",
-  "instance.password-type.external-secret-azure": "Azure Key Vault",
-  "instance.password-type.external-secret-gcp": "GCP Secret Manager",
-  "instance.password-type.external-secret-vault": "Vault (KV v2)",
-  "instance.password-type.google-iam": "Google Cloud SQL IAM",
-  "instance.password-type.password": "Contraseña",
-  "instance.password-write-only": "SU_DB_PWD - solo escritura",
-  "instance.port": "Puerto",
-  "instance.project-id": "ID del proyecto",
-  "instance.restore-instance-instance-name-to-normal-state": "¿Restaurar la instancia '{{0}}' al estado normal?",
-  "instance.role-arn": "ARN del rol",
-  "instance.role-arn-description": "Rol IAM para asumir en acceso entre cuentas. Dejar vacío para acceso en la misma cuenta.",
-  "instance.role-arn-placeholder": "arn:aws:iam::123456789012:role/CrossAccountRole",
-  "instance.scan-interval.default-never": "Predeterminado (nunca)",
-  "instance.scan-interval.description": "Bytebase sincroniza periódicamente el esquema de instancia y detecta anomalías.",
-  "instance.scan-interval.min-value": "Valor mínimo {{value}} minutos",
-  "instance.scan-interval.self": "Intervalo de escaneo",
-  "instance.section.basic-info": "Información básica",
-  "instance.section.connection": "Conexión",
-  "instance.select-database-user": "Seleccionar usuario de base de datos",
-  "instance.sentence.aws-rds.mysql.template": "A continuación se muestra un ejemplo para crear el usuario {{user}}@% y otorgarle los privilegios necesarios.",
-  "instance.sentence.aws-rds.postgresql.template": "A continuación se muestra un ejemplo para crear el usuario '{{user}}' y otorgarle los privilegios necesarios.",
-  "instance.sentence.console.snowflake": "La URL de la consola externa que administra esta instancia (por ejemplo, la consola de AWS RDS, la consola de la instancia de base de datos interna)",
-  "instance.sentence.create-admin-user": "Este es el usuario de conexión utilizado por Bytebase para realizar operaciones DDL y DML (no SELECT).",
-  "instance.sentence.create-admin-user-non-sql": "Este es el usuario de conexión utilizado por Bytebase para realizar operaciones de escritura y administración.",
-  "instance.sentence.create-readonly-user": "Esta es la conexión utilizada por Bytebase para realizar operaciones de solo lectura como la consulta SELECT.",
-  "instance.sentence.create-readonly-user-non-sql": "Esta es la conexión utilizada por Bytebase para realizar operaciones de solo lectura.",
-  "instance.sentence.create-user-example.clickhouse.sql-driven-workflow": "Flujo de trabajo impulsado por SQL",
-  "instance.sentence.create-user-example.clickhouse.template": "A continuación se muestra un ejemplo para crear el usuario '{{user}}' con la contraseña {{password}} y otorgar al usuario los privilegios necesarios. Primero debe habilitar el flujo de trabajo impulsado por SQL de ClickHouse {{link}} y luego ejecutar la siguiente consulta para crear el usuario.",
-  "instance.sentence.create-user-example.mysql.template": "A continuación se muestra un ejemplo para crear el usuario {{user}}@% con la contraseña {{password}} y otorgarle al usuario los privilegios necesarios.",
-  "instance.sentence.create-user-example.postgresql.template": "A continuación se muestra un ejemplo para crear el usuario '{{user}}' con la contraseña {{password}} y otorgar al usuario los privilegios necesarios. Si la instancia de conexión está alojada por ti mismo, puedes otorgar SUPERUSER.",
-  "instance.sentence.create-user-example.postgresql.warn": "Si la instancia de conexión es administrada por el proveedor de la nube, entonces SUPERUSER no está disponible y debes crear el usuario a través de la consola de administración del proveedor. El usuario creado tendrá privilegios semi-SUPERUSER específicos del proveedor. Debes otorgar privilegios de Bytebase con 'GRANT role_name TO bytebase;' para todos los roles existentes, de lo contrario Bytebase puede no tener acceso a las bases de datos o tablas existentes.",
-  "instance.sentence.create-user-example.redis.template": "A continuación se muestra un ejemplo para crear el usuario {{user}} con la contraseña {{password}} y otorgar al usuario los privilegios necesarios.",
-  "instance.sentence.create-user-example.snowflake.template": "A continuación se muestra un ejemplo para crear el usuario '{{user}}' con la contraseña {{password}} para {{warehouse}} y otorgar al usuario los privilegios necesarios.",
-  "instance.sentence.firewall-info": "Si usa reglas de firewall entrante para su instancia de base de datos, consulte la instrucción de conexión de Bytebase Cloud.",
-  "instance.sentence.google-cloud-sql.instance-name": "Nombre de conexión de instancia",
-  "instance.sentence.google-cloud-sql.instance-name-tips": "El nombre de la conexión de la instancia debería ser {{instance}}.",
-  "instance.sentence.google-cloud-sql.mysql.template": "Cree una cuenta de servicio llamada {{user}} y luego agréguela en su Google Cloud SQL como usuario de IAM {{user}}@'%'. Otorgue a este usuario los privilegios necesarios.",
-  "instance.sentence.google-cloud-sql.postgresql.template": "Cree una cuenta de servicio llamada {{user}} y luego agréguela en su Google Cloud SQL como usuario de IAM {{user}}@project-id.iam. Otorgue al usuario los privilegios necesarios.",
-  "instance.sentence.host.none-snowflake": "por ejemplo, host.docker.internal | host ip | local socket",
-  "instance.sentence.proxy.snowflake": "Para el servidor proxy, agregue @PROXY_HOST y especifique PROXY_PORT en el puerto",
-  "instance.show-how-to-create": "Mostrar cómo crear",
-  "instance.snowflake-web-console": "Consola web de Snowflake",
-  "instance.successfully-archived-instance": "Se archivó exitosamente la instancia '{{0}}'.",
-  "instance.successfully-connected-instance": "Instancia conectada correctamente.",
-  "instance.successfully-created-instance-createdinstance-name": "Se ha creado correctamente la instancia '{{0}}'.",
-  "instance.successfully-restored-instance": "Se restauró exitosamente la instancia '{{0}}'.",
-  "instance.successfully-updated-instance-instance-name": "Se ha actualizado correctamente la instancia '{{0}}'.",
-  "instance.sync-databases.add-database": "+ Agregar base de datos, presione enter para enviar",
-  "instance.sync-databases.description": "Sincronizar sólo bases de datos seleccionadas.",
-  "instance.sync-databases.search-database": "Buscar en la base de datos",
-  "instance.sync-databases.self": "Sincronizar bases de datos",
-  "instance.sync-databases.sync-all": "Sincronizar todas las bases de datos",
-  "instance.sync.self": "Instancia de sincronización",
-  "instance.sync.sync-all": "Sincronizar todas las bases de datos",
-  "instance.sync.sync-all-tip": "La sincronización de la base de datos es asincrónica y puede tardar entre unos segundos y minutos.",
-  "instance.sync.sync-new": "Sincronizar únicamente bases de datos nuevas",
-  "instance.syncing": "Sincronizando...",
-  "instance.test-connection": "Probar conexión",
-  "instance.testing-connection": "Probando conexión",
-  "instance.type-or-paste-credentials-write-only": "Escriba o pegue las CREDENCIALES - solo escritura",
-  "instance.unable-to-connect": "Bytebase no puede conectar la instancia. Le recomendamos que revise la información de conexión nuevamente. Pero está bien ignorar esta advertencia por ahora. Aún puede solucionar la información de conexión desde la página de detalles de la instancia después de la creación.\n\nDetalle del error: {{0}}",
-  "instance.users": "Usuarios",
-  "instance.your-snowflake-account-locator": "Su localizador de cuentas Snowflake",
   "issue": {
     "access-grant": {
       "advanced-search": {
@@ -1322,9 +1145,10 @@
           }
         }
       },
-      "details": "Access Grant Details",
-      "expired-at": "Expired at"
+      "details": "Detalles de la concesión de acceso",
+      "expired-at": "Expiró el"
     },
+    "action-anyway": "{{action}} de todos modos",
     "advanced-search": {
       "filter": "Filtrar",
       "scope": {
@@ -1367,13 +1191,13 @@
           "title": "Etiqueta de emisión"
         },
         "issue-type": {
-          "description": "Filter by issue type",
-          "title": "Type",
+          "description": "Filtrar por tipo de issue",
+          "title": "Tipo",
           "value": {
-            "access-grant": "Access Grant",
-            "database-change": "Database Change",
-            "database-export": "Database Export",
-            "role-grant": "Role Grant"
+            "access-grant": "Concesión de acceso",
+            "database-change": "Cambio de base de datos",
+            "database-export": "Exportación de base de datos",
+            "role-grant": "Concesión de rol"
           }
         },
         "label": {
@@ -1408,6 +1232,20 @@
       "reopened": "reabierto"
     },
     "checks-manual-rollout-hint": "La aprobación ya se completó, pero el rollout no se creó automáticamente porque este plan todavía tiene verificaciones fallidas. Ve a Plan para continuar.",
+    "checks-warning-hint": "Algunas verificaciones no pasaron. Continúa solo si es esperado.",
+    "comment-editor": {
+      "nothing-to-preview": "Nada que previsualizar",
+      "preview": "Previsualización",
+      "toolbar": {
+        "bold": "Insertar texto en negrita",
+        "code": "Insertar fragmento de código SQL",
+        "hashtag": "Insertar hashtag",
+        "header": "Insertar texto de encabezado",
+        "link": "Insertar un enlace"
+      },
+      "write": "Escribir"
+    },
+    "create-rollout": "Crear rollout",
     "data-export": {
       "download-tooltip": "Disponible por 24 horas",
       "file-expired": "Archivo expirado",
@@ -1415,8 +1253,13 @@
       "limits": "Límites",
       "options": "Opciones de exportación"
     },
+    "issue-name": "Nombre de la incidencia",
     "labels": "Etiquetas de problema",
     "leave-a-comment": "Dejar un comentario...",
+    "my-issues": "Mis issues",
+    "no-description-provided": "No se proporcionó ninguna descripción",
+    "options-disabled-due-to-oversize": "Las opciones están deshabilitadas porque el SQL es demasiado grande.",
+    "overwrite-current-statement": "Sobrescribir la declaración SQL actual",
     "review": {
       "approve-description": "Enviar comentarios y aprobar este problema",
       "comment-description": "Enviar comentarios generales sin aprobación",
@@ -1433,8 +1276,8 @@
     "role-grant": {
       "all-databases": "todas las bases de datos",
       "all-databases-tip": "Todas las bases de datos actuales y futuras de este proyecto.",
-      "details": "Role Grant Details",
-      "expired-at": "Expired at",
+      "details": "Detalles de la concesión de rol",
+      "expired-at": "Expiró el",
       "manually-select": "selección manual",
       "use-cel": "Usar expresión CEL"
     },
@@ -1445,6 +1288,7 @@
       "sort": "Ordenar",
       "updated": "Fecha de actualización"
     },
+    "statement-from-sheet-warning": "Esta sentencia se carga desde una hoja de gran tamaño. La previsualización puede estar truncada.",
     "status-transition": {
       "modal": {
         "close": "¿Cerrar el problema?",
@@ -1453,14 +1297,18 @@
     },
     "subtitle": "Los problemas abarcan cambios en la base de datos, exportaciones de datos y solicitudes de acceso. Revisar y aprobar antes de la ejecución.",
     "table": {
-      "approval-progress": "{{approved}}/{{total}} Approvals",
-      "approved": "Approved",
+      "approval-progress": "{{approved}}/{{total}} aprobaciones",
+      "approved": "Aprobado",
       "closed": "Cerrado",
       "creator": "Creador",
       "name": "Nombre",
       "open": "Abierto",
       "updated": "Actualizado",
-      "waiting-role": "Waiting: {{role}}"
+      "waiting-role": "Esperando: {{role}}"
+    },
+    "task-run": {
+      "logs": "Registros",
+      "session": "Sesión"
     },
     "title": {
       "change-database": "Modificar base de datos",
@@ -1469,34 +1317,13 @@
       "request-role": "Solicitar rol",
       "request-specific-role": "Solicitar rol \"{{role}}\""
     },
-    "upload-sql": "Upload SQL",
+    "transaction-mode": {
+      "label": "Modo de transacción"
+    },
+    "upload-sql": "Subir SQL",
+    "upload-sql-file-max-size-exceeded": "Se ha excedido el tamaño máximo del archivo ({{size}}).",
     "waiting-approval": "A la espera de la aprobación"
   },
-  "issue.action-anyway": "{{action}} de todos modos",
-  "issue.checks-warning-hint": "Algunas verificaciones no pasaron. Continúa solo si es esperado.",
-  "issue.comment-editor.nothing-to-preview": "Nothing to preview",
-  "issue.comment-editor.preview": "Preview",
-  "issue.comment-editor.toolbar.bold": "Insert bold text",
-  "issue.comment-editor.toolbar.code": "Insert SQL code snippet",
-  "issue.comment-editor.toolbar.hashtag": "Insert hashtag",
-  "issue.comment-editor.toolbar.header": "Insert heading text",
-  "issue.comment-editor.toolbar.link": "Insert a link",
-  "issue.comment-editor.write": "Write",
-  "issue.create-rollout": "Crear rollout",
-  "issue.data-export.format": "Formato",
-  "issue.data-export.limits": "Límites",
-  "issue.data-export.options": "Opciones",
-  "issue.issue-name": "Nombre de la incidencia",
-  "issue.my-issues": "Mis issues",
-  "issue.no-description-provided": "No se proporcionó ninguna descripción",
-  "issue.options-disabled-due-to-oversize": "Las opciones están deshabilitadas porque el SQL es demasiado grande.",
-  "issue.overwrite-current-statement": "Sobrescribir la declaración SQL actual",
-  "issue.review.self": "Review",
-  "issue.statement-from-sheet-warning": "This statement is loaded from a large sheet. Preview may be truncated.",
-  "issue.task-run.logs": "Registros",
-  "issue.task-run.session": "Sesión",
-  "issue.transaction-mode.label": "Modo de transacción",
-  "issue.upload-sql-file-max-size-exceeded": "Se ha excedido el tamaño máximo del archivo ({{size}}).",
   "label": {
     "add-label": "Agregar etiqueta",
     "empty-label-value": "Valor",
@@ -1507,12 +1334,6 @@
       "value-necessary": "Se requiere un valor"
     }
   },
-  "label.add-label": "Agregar etiqueta",
-  "label.empty-label-value": "Valor",
-  "label.error.key-duplicated": "Claves duplicadas",
-  "label.error.key-necessary": "Se requiere una clave",
-  "label.error.max-value-length-exceeded": "La longitud del valor no puede exceder {{length}} caracteres",
-  "label.error.value-necessary": "Se requiere un valor",
   "landing": {
     "changelog-for-version": "Registro de cambios para {{version}}",
     "last-visit": "Última visita",
@@ -1561,91 +1382,114 @@
     }
   },
   "plan": {
+    "add-spec": "Agregar cambio",
+    "add-spec-pending-draft": "Guarda o descarta el cambio pendiente antes de agregar otro",
     "checks": {
-      "self": "Verificaciones"
+      "completed": "Se completaron las verificaciones del plan",
+      "failed-to-run": "No se pudieron ejecutar las verificaciones del plan",
+      "no-check-results": "No hay resultados de verificación",
+      "no-results-match-filters": "No hay resultados que coincidan con los filtros",
+      "self": "Verificaciones",
+      "started": "Se iniciaron las verificaciones del plan"
     },
     "create-plan": "Crear plan",
+    "description": {
+      "placeholder": "Agregar descripción"
+    },
     "editor": {
       "save-changes-before-continuing": "Guarde o cancele sus cambios antes de continuar."
     },
+    "ghost": {
+      "requirements-not-met": "Los requisitos de Ghost no se cumplen para: {{databases}}"
+    },
+    "go-to-plan-page": "Ir a la página del plan",
+    "isolation-level": {
+      "read-committed": "Lectura confirmada",
+      "read-uncommitted": "Lectura no confirmada",
+      "repeatable-read": "Lectura repetible",
+      "self": "Nivel de Aislamiento",
+      "serializable": "Serializable"
+    },
+    "labels-required-for-review": "Se requieren etiquetas antes de la revisión",
     "meta": {
       "created-by-at": "Creado por {{user}} · {{time}}"
     },
     "navigator": {
       "changes": "Cambios",
+      "checks": "Verificaciones",
       "deploy": "Desplegar",
-      "review": "Revisión"
+      "review": "Revisión",
+      "statement-empty": "La sentencia está vacía"
     },
     "new-plan": "Nuevo plan",
+    "options": {
+      "no-options-available": "No hay opciones disponibles",
+      "self": "Opciones"
+    },
+    "overview": {
+      "no-checks": "Sin verificaciones"
+    },
+    "phase": {
+      "create-rollout-action": "Crear rollout manualmente",
+      "deploy-approval-must-complete": "El flujo de aprobación debe completarse.",
+      "deploy-approval-optional": "La aprobación puede omitirse según la configuración actual del proyecto.",
+      "deploy-approval-pending": "Completa el flujo de aprobación antes de que el rollout pueda continuar automáticamente.",
+      "deploy-approval-ready": "La aprobación ya está completa para este plan.",
+      "deploy-checks-blocked": "Las verificaciones fallidas están bloqueando la creación automática del rollout.",
+      "deploy-checks-must-pass": "Las comprobaciones deben aprobarse.",
+      "deploy-checks-optional": "Las verificaciones fallidas no bloquearán el rollout manual en este proyecto.",
+      "deploy-checks-ready": "Las verificaciones ya permiten la creación automática del rollout.",
+      "deploy-checks-running": "Espera a que terminen las verificaciones en ejecución antes de que el rollout automático pueda continuar.",
+      "deploy-description": "Bytebase creará automáticamente el rollout cuando todas las comprobaciones pasen y el issue esté aprobado.",
+      "deploy-description-gitops": "Este plan está listo para implementarse. Crea un rollout para desplegar la versión vinculada.",
+      "deploy-manual-create-description": "Según la configuración actual del proyecto, también puede crear el rollout manualmente.",
+      "deploy-manual-create-description-readonly": "Un usuario con el permiso Create Rollout puede crear el rollout manualmente.",
+      "hide-details": "Ocultar detalles",
+      "review-description": "Envíe para revisión para continuar",
+      "show-details": "Mostrar detalles"
+    },
     "plans": "Planes",
+    "pre-backup": {
+      "requirements-not-met": "Los requisitos de copia previa no se cumplen para: {{databases}}"
+    },
+    "ready-for-review": "Listo para revisión",
+    "run": "Volver a verificar",
+    "select-isolation-level": "Seleccionar nivel de aislamiento",
+    "select-targets": "Seleccionar destinos",
+    "spec": {
+      "change": "Cambio",
+      "type": {
+        "database-change": "Cambio de base de datos"
+      }
+    },
+    "state": {
+      "close-confirm": "¿Cerrar este plan?",
+      "reopen-confirm": "¿Reabrir este plan?"
+    },
     "subtitle": "Redactar cambios en la base de datos y ejecutar comprobaciones previas antes de crear un problema para su aprobación.",
+    "summary": {
+      "last-approved-by": "Última aprobación por {{name}}",
+      "n-changes": "{{n}} cambios",
+      "n-database-groups": "{{n}} grupos de bases de datos",
+      "n-databases": "{{n}} bases de datos",
+      "n-error": "{{n}} error",
+      "n-of-m-approved": "{{n}} de {{m}} aprobadas",
+      "n-of-m-tasks": "{{n}}/{{m}} tareas",
+      "n-passed": "{{n}} aprobadas",
+      "n-warning": "{{n}} advertencia"
+    },
     "targets": {
-      "title": "Objetivos"
-    }
+      "no-targets-found": "No se encontraron objetivos",
+      "non-env-warning": {
+        "one": "{{count}} base de datos se excluirá del despliegue porque no tiene un entorno efectivo:",
+        "other": "{{count}} bases de datos se excluirán del despliegue porque no tienen un entorno efectivo:"
+      },
+      "title": "Objetivos",
+      "view-all": "Ver todo ({{count}})"
+    },
+    "title-required": "El título es obligatorio",
+    "view-discussion": "Ver discusión"
   },
-  "plan.add-spec": "Agregar cambio",
-  "plan.add-spec-pending-draft": "Guarda o descarta el cambio pendiente antes de agregar otro",
-  "plan.checks.completed": "Se completaron las verificaciones del plan",
-  "plan.checks.failed-to-run": "No se pudieron ejecutar las verificaciones del plan",
-  "plan.checks.no-check-results": "No hay resultados de verificación",
-  "plan.checks.no-results-match-filters": "No hay resultados que coincidan con los filtros",
-  "plan.checks.started": "Se iniciaron las verificaciones del plan",
-  "plan.description.placeholder": "Agregar descripción",
-  "plan.ghost.requirements-not-met": "Los requisitos de Ghost no se cumplen para: {{databases}}",
-  "plan.go-to-plan-page": "Ir a la página del plan",
-  "plan.isolation-level.read-committed": "Lectura confirmada",
-  "plan.isolation-level.read-uncommitted": "Lectura no confirmada",
-  "plan.isolation-level.repeatable-read": "Lectura repetible",
-  "plan.isolation-level.self": "Nivel de Aislamiento",
-  "plan.isolation-level.serializable": "Serializable",
-  "plan.labels-required-for-review": "Se requieren etiquetas antes de la revisión",
-  "plan.navigator.checks": "Verificaciones",
-  "plan.navigator.statement-empty": "La sentencia está vacía",
-  "plan.options.no-options-available": "No hay opciones disponibles",
-  "plan.options.self": "Opciones",
-  "plan.overview.no-checks": "Sin verificaciones",
-  "plan.phase.create-rollout-action": "Crear rollout manualmente",
-  "plan.phase.deploy-approval-must-complete": "El flujo de aprobación debe completarse.",
-  "plan.phase.deploy-approval-optional": "La aprobación puede omitirse según la configuración actual del proyecto.",
-  "plan.phase.deploy-approval-pending": "Completa el flujo de aprobación antes de que el rollout pueda continuar automáticamente.",
-  "plan.phase.deploy-approval-ready": "La aprobación ya está completa para este plan.",
-  "plan.phase.deploy-checks-blocked": "Las verificaciones fallidas están bloqueando la creación automática del rollout.",
-  "plan.phase.deploy-checks-must-pass": "Las comprobaciones deben aprobarse.",
-  "plan.phase.deploy-checks-optional": "Las verificaciones fallidas no bloquearán el rollout manual en este proyecto.",
-  "plan.phase.deploy-checks-ready": "Las verificaciones ya permiten la creación automática del rollout.",
-  "plan.phase.deploy-checks-running": "Espera a que terminen las verificaciones en ejecución antes de que el rollout automático pueda continuar.",
-  "plan.phase.deploy-description": "Bytebase creará automáticamente el rollout cuando todas las comprobaciones pasen y el issue esté aprobado.",
-  "plan.phase.deploy-description-gitops": "Este plan está listo para implementarse. Crea un rollout para desplegar la versión vinculada.",
-  "plan.phase.deploy-manual-create-description": "Según la configuración actual del proyecto, también puede crear el rollout manualmente.",
-  "plan.phase.deploy-manual-create-description-readonly": "Un usuario con el permiso Create Rollout puede crear el rollout manualmente.",
-  "plan.phase.hide-details": "Ocultar detalles",
-  "plan.phase.review-description": "Envíe para revisión para continuar",
-  "plan.phase.show-details": "Mostrar detalles",
-  "plan.pre-backup.requirements-not-met": "Los requisitos de copia previa no se cumplen para: {{databases}}",
-  "plan.ready-for-review": "Listo para revisión",
-  "plan.run": "Volver a verificar",
-  "plan.select-isolation-level": "Seleccionar nivel de aislamiento",
-  "plan.select-targets": "Seleccionar destinos",
-  "plan.spec.change": "Cambio",
-  "plan.spec.type.database-change": "Cambio de base de datos",
-  "plan.state.close-confirm": "¿Cerrar este plan?",
-  "plan.state.reopen-confirm": "¿Reabrir este plan?",
-  "plan.summary.last-approved-by": "Última aprobación por {{name}}",
-  "plan.summary.n-changes": "{{n}} cambios",
-  "plan.summary.n-database-groups": "{{n}} grupos de bases de datos",
-  "plan.summary.n-databases": "{{n}} bases de datos",
-  "plan.summary.n-error": "{{n}} error",
-  "plan.summary.n-of-m-approved": "{{n}} de {{m}} aprobadas",
-  "plan.summary.n-of-m-tasks": "{{n}}/{{m}} tareas",
-  "plan.summary.n-passed": "{{n}} aprobadas",
-  "plan.summary.n-warning": "{{n}} advertencia",
-  "plan.targets.no-targets-found": "No se encontraron objetivos",
-  "plan.targets.non-env-warning.one": "{{count}} base de datos se excluirá del despliegue porque no tiene un entorno efectivo:",
-  "plan.targets.non-env-warning.other": "{{count}} bases de datos se excluirán del despliegue porque no tienen un entorno efectivo:",
-  "plan.targets.title": "Objetivos",
-  "plan.targets.view-all": "Ver todo ({{count}})",
-  "plan.title-required": "El título es obligatorio",
-  "plan.view-discussion": "Ver discusión",
   "plugin": {
     "ai": {
       "actions": {
@@ -1745,7 +1589,7 @@
       "ddl-warning": "En los entornos seleccionados, las sentencias {{kind}} pueden ejecutarse directamente en el editor SQL sin aprobación.",
       "description": "Los miembros del proyecto determinan el permiso para operar la base de datos y los problemas dentro del proyecto. El propietario del proyecto, el administrador del espacio de trabajo y el DBA del espacio de trabajo tienen permisos completos para el proyecto.",
       "edit-member": "Editar miembro - {{member}}",
-      "never-expires": "Never",
+      "never-expires": "Nunca",
       "request-role": {
         "disabled-reason": {
           "allow-request-role-disabled": "La solicitud de roles está deshabilitada para este proyecto.",
@@ -1766,9 +1610,10 @@
     "overview": {
       "info-slot-content": "Bytebase sincroniza periódicamente el esquema de la instancia. Las bases de datos recién sincronizadas se colocan aquí primero. El usuario debe transferirlas al proyecto de aplicación adecuado."
     },
+    "select": "Seleccionar proyecto",
     "settings": {
-      "confirm-archive-project": "Archiving \"{{name}}\" will make it read-only and hide it from active project lists. All issues, databases, and settings will be preserved. You can restore it later from the archived projects list.",
-      "confirm-delete-project": "Deleting \"{{name}}\" will permanently remove the project and all associated data including issues, configurations, and history. All databases in this project will be moved to the default project. This action cannot be undone.",
+      "confirm-archive-project": "Archivar \"{{name}}\" lo hará de solo lectura y lo ocultará de las listas de proyectos activos. Se conservarán todos los issues, bases de datos y configuraciones. Puede restaurarlo más tarde desde la lista de proyectos archivados.",
+      "confirm-delete-project": "Eliminar \"{{name}}\" eliminará permanentemente el proyecto y todos los datos asociados, incluidos issues, configuraciones e historial. Todas las bases de datos de este proyecto se moverán al proyecto predeterminado. Esta acción no se puede deshacer.",
       "issue-related": {
         "allow-jit": {
           "description": "Una vez habilitado, los usuarios pueden solicitar y usar el acceso justo a tiempo en el Editor SQL.",
@@ -1871,14 +1716,12 @@
       "webhook-url": "URL del webhook"
     }
   },
-  "project.select": "Seleccionar proyecto",
   "quick-action": {
     "create-db": "Crear base de datos",
+    "create-project": "Crear proyecto",
     "new-project": "Nuevo Proyecto",
     "request-export-data": "Solicitar exportación"
   },
-  "quick-action.create-project": "Create project",
-  "quick-action.new-project": "Nuevo Proyecto",
   "quick-start": {
     "guide": "haga clic en el paso para probarlo",
     "notice": {
@@ -1886,6 +1729,7 @@
       "title": "Guía de inicio rápido omitida"
     },
     "query-data": "Consultar datos",
+    "self": "Inicio rápido",
     "view-an-issue": "Ver una incidencia",
     "visit-database": "Visitar Bases de datos",
     "visit-environment": "Visitar Entornos",
@@ -1893,26 +1737,25 @@
     "visit-member": "Visitar Miembro | Miembros",
     "visit-project": "Visitar Proyectos"
   },
-  "quick-start.self": "Quick Start",
   "release": {
-    "and-n-more-files": "and {{count}} more files",
-    "change-tip": "This change is linked to a release artifact.",
+    "and-n-more-files": "y {{count}} archivos más",
+    "change-tip": "Este cambio está vinculado a un artefacto de versión.",
     "file": "Archivo de lanzamiento",
     "file-type": {
-      "declarative": "Declarative",
-      "unspecified": "Unspecified",
-      "versioned": "Versioned"
+      "declarative": "Declarativo",
+      "unspecified": "Sin especificar",
+      "versioned": "Versionado"
     },
     "files": "Archivos",
-    "not-found": "Release not found",
+    "not-found": "Versión no encontrada",
     "releases": "Lanzamientos",
     "total-files": "Total de {{}} archivos",
     "usage-description": "Un lanzamiento es un artefacto de aplicación versionado cuyo despliegue a un entorno es activado por un flujo de trabajo GitOps.",
-    "vcs-source": "VCS Source",
+    "vcs-source": "Origen de VCS",
     "vcs-type": {
-      "unspecified": "Unknown VCS"
+      "unspecified": "VCS desconocido"
     },
-    "view-all-files": "View all files"
+    "view-all-files": "Ver todos los archivos"
   },
   "remind": {
     "role-expire": {
@@ -1938,13 +1781,6 @@
       "pattern": "La identificación {{resource}} puede tener letras, dígitos o guiones minúsculas. Debe comenzar con una letra minúscula y terminar con una letra o número."
     }
   },
-  "resource-id.cannot-be-changed-later": "No se puede cambiar posteriormente.",
-  "resource-id.description": "El ID de {{resource}} es un identificador único. No se puede cambiar una vez creado.",
-  "resource-id.self": "ID de {{resource}}",
-  "resource-id.validation.duplicated": "El ID de {{resource}} ya existe. Por favor, elige otro.",
-  "resource-id.validation.empty": "El ID {{resource}} no puede estar vacío",
-  "resource-id.validation.overflow": "El ID de {{resource}} es demasiado largo. Debe tener menos de 64 caracteres.",
-  "resource-id.validation.pattern": "La identificación {{resource}} puede tener letras, dígitos o guiones minúsculas. Debe comenzar con una letra minúscula y terminar con una letra o número.",
   "role": {
     "custom-roles": {
       "self": "Roles personalizados"
@@ -1966,6 +1802,7 @@
     }
   },
   "rollout": {
+    "bypass-stage-requirements": "Omitir advertencias",
     "no-stages": "No hay etapas disponibles",
     "no-tasks-created": "Aún no se han creado tareas",
     "pending-tasks-preview": {
@@ -1982,47 +1819,48 @@
       "self_one": "Etapa",
       "self_other": "Etapas"
     },
+    "task": {
+      "no-tasks": "No hay tareas en esta etapa",
+      "selected-count": "{{count}} tarea seleccionada",
+      "statement-truncated-hint": "Declaración truncada debido al gran tamaño."
+    },
     "task-execution-errors": "Errores de ejecución de tareas"
   },
-  "rollout.bypass-stage-requirements": "Omitir advertencias",
-  "rollout.task.no-tasks": "No hay tareas en esta etapa",
-  "rollout.task.selected-count": "{{count}} tarea seleccionada",
-  "rollout.task.statement-truncated-hint": "Declaración truncada debido al gran tamaño.",
   "schema-diagram": {
     "fit-content-with-view": "Ajustar contenido dentro de la vista",
     "self": "Diagrama de Esquema"
   },
   "schema-editor": {
     "actions": {
-      "add-column": "Add column",
-      "add-index": "Add index",
-      "add-partition": "Add partition",
-      "create-function": "Create function",
-      "create-procedure": "Create procedure",
-      "create-schema": "Create schema",
-      "create-table": "New table",
-      "create-view": "Create view",
-      "drop": "Drop",
-      "drop-schema": "Drop schema",
-      "drop-table": "Drop table",
-      "rename": "Rename",
-      "rename-table": "Rename table",
-      "restore": "Restore"
+      "add-column": "Añadir columna",
+      "add-index": "Añadir índice",
+      "add-partition": "Añadir partición",
+      "create-function": "Crear función",
+      "create-procedure": "Crear procedimiento",
+      "create-schema": "Crear esquema",
+      "create-table": "Nueva tabla",
+      "create-view": "Crear vista",
+      "drop": "Eliminar",
+      "drop-schema": "Eliminar esquema",
+      "drop-table": "Eliminar tabla",
+      "rename": "Renombrar",
+      "rename-table": "Renombrar tabla",
+      "restore": "Restaurar"
     },
     "column": {
-      "comment": "Comment",
-      "default": "Default",
+      "comment": "Comentario",
+      "default": "Predeterminado",
       "foreign-key": "Clave foránea",
-      "name": "Name",
+      "name": "Nombre",
       "name-placeholder": "Nombre de la columna",
-      "not-null": "Not Null",
+      "not-null": "No nulo",
       "on-update": "En actualización",
-      "operations": "Operations",
-      "primary": "Primary",
-      "type": "Type"
+      "operations": "Operaciones",
+      "primary": "Primaria",
+      "type": "Tipo"
     },
-    "columns": "Columns",
-    "create-foreign-key": "Create Foreign Key",
+    "columns": "Columnas",
+    "create-foreign-key": "Crear clave foránea",
     "database": {
       "collation": "Colación",
       "comment": "Comentario",
@@ -2032,43 +1870,43 @@
     "default": {
       "placeholder": "Introduzca un valor predeterminado o déjelo vacío si no hay ningún valor predeterminado"
     },
-    "edit-foreign-key": "Edit Foreign Key",
+    "edit-foreign-key": "Editar clave foránea",
     "foreign-key": {
-      "name": "Foreign Key Name",
-      "referenced-column": "Referenced Column",
-      "referenced-schema": "Referenced Schema",
-      "referenced-table": "Referenced Table"
+      "name": "Nombre de la clave foránea",
+      "referenced-column": "Columna referenciada",
+      "referenced-schema": "Esquema referenciado",
+      "referenced-table": "Tabla referenciada"
     },
     "index": {
-      "columns": "Columns",
+      "columns": "Columnas",
       "dependency-columns": "Columnas dependientes",
       "indexes": "Índices",
-      "primary": "Primary",
-      "unique": "Unique"
+      "primary": "Primaria",
+      "unique": "Única"
     },
-    "indexes": "Indexes",
+    "indexes": "Índices",
     "insert-sql": "Insertar SQL",
     "no-diff": "No hay cambios para aplicar",
     "partition": {
-      "expression": "Expression",
-      "type": "Type",
-      "value": "Value"
+      "expression": "Expresión",
+      "type": "Tipo",
+      "value": "Valor"
     },
-    "partitions": "Partitions",
-    "preview": "Preview",
-    "raw-sql": "Raw SQL",
+    "partitions": "Particiones",
+    "preview": "Previsualización",
+    "raw-sql": "SQL sin procesar",
     "schema": {
-      "duplicate-name": "Schema name already exists",
-      "name-placeholder": "Schema name",
+      "duplicate-name": "El nombre del esquema ya existe",
+      "name-placeholder": "Nombre del esquema",
       "select": "Seleccionar esquema"
     },
     "select-object-hint": "Selecciona un objeto de base de datos del árbol para editarlo",
     "self": "Editor de esquema",
     "table": {
-      "duplicate-name": "Table name already exists",
-      "name-placeholder": "Table name",
-      "no-match": "No tables match the search",
-      "no-tables": "No tables"
+      "duplicate-name": "El nombre de la tabla ya existe",
+      "name-placeholder": "Nombre de la tabla",
+      "no-match": "Ninguna tabla coincide con la búsqueda",
+      "no-tables": "No hay tablas"
     },
     "table-partition": {
       "expression": "Expresión",
@@ -2093,16 +1931,14 @@
       "value-placeholder": "Valor de etiqueta..."
     }
   },
-  "setting.label.key-placeholder": "Clave de etiqueta...",
-  "setting.label.value-placeholder": "Valor de etiqueta...",
   "settings": {
     "general": {
       "workspace": {
         "access-token-duration": {
-          "description": "How long access tokens remain valid before requiring refresh. Shorter durations improve security.",
-          "hours": "Hour(s)",
-          "minutes": "Minute(s)",
-          "self": "Access token duration"
+          "description": "Cuánto tiempo permanecen válidos los tokens de acceso antes de requerir una renovación. Las duraciones más cortas mejoran la seguridad.",
+          "hours": "Hora(s)",
+          "minutes": "Minuto(s)",
+          "self": "Duración del token de acceso"
         },
         "account": "Cuenta",
         "ai-assistant": {
@@ -2114,7 +1950,7 @@
           },
           "description": "Utilice AI para ayudar en las tareas de desarrollo de bases de datos.",
           "enable-ai-assistant": "Habilitar el Asistente de IA",
-          "enabled-in-saas": "Gemini AI is enabled automatically in the SaaS mode.",
+          "enabled-in-saas": "Gemini AI se habilita automáticamente en el modo SaaS.",
           "endpoint": {
             "description": "Proporcione una implementación privada del Punto de conexión de API.",
             "self": "Punto de conexión de API"
@@ -2145,7 +1981,7 @@
           "self": "Anuncio"
         },
         "announcement-alert-level": {
-          "description": "Level",
+          "description": "Nivel",
           "field": {
             "critical": "Importante",
             "info": "Común",
@@ -2185,6 +2021,7 @@
         "default-landing-page": {
           "default-view-changed-to-sql-editor": "La vista predeterminada del espacio de trabajo se ha cambiado al Editor SQL.",
           "go-to-sql-editor": "Ir al Editor SQL",
+          "go-to-workspace": "Ir al espacio de trabajo",
           "self": "Página de destino predeterminada",
           "sql-editor": {
             "description": "Utilice el Editor SQL para ejecutar cambios en la base de datos directamente, adecuado para uso de una sola persona o entornos que no requieren supervisión.",
@@ -2235,7 +2072,7 @@
           "self": "Tiempo de espera de sesión inactiva"
         },
         "log": "Registro",
-        "logo": "Logo",
+        "logo": "Logotipo",
         "logo-aspect": "El tamaño sugerido para el logo debería tener una proporción de 5:2, por ejemplo, 100 x 40.",
         "logo-upload-tip": "{{extension}} hasta {{size}} MiB",
         "maximum-role-expiration": {
@@ -2280,10 +2117,10 @@
           }
         },
         "refresh-token-duration": {
-          "days": "Day(s)",
-          "description": "How often users must fully reauthenticate. Configuration updates require users to sign in again for changes to take effect.",
-          "hours": "Hour(s)",
-          "self": "Refresh token duration"
+          "days": "Día(s)",
+          "description": "Con qué frecuencia los usuarios deben volver a autenticarse por completo. Las actualizaciones de configuración requieren que los usuarios inicien sesión de nuevo para que los cambios surtan efecto.",
+          "hours": "Hora(s)",
+          "self": "Duración del token de renovación"
         },
         "require-2fa": {
           "description": "Cuando está habilitado, los usuarios que no tienen la autenticación de dos factores habilitada para sus cuentas personales serán obligados a configurarla.",
@@ -2331,8 +2168,8 @@
       },
       "add-member": "Agregar miembro",
       "all-users": "Todos los usuarios",
-      "assign-role": "Assign role",
-      "cannot-revoke-self": "You cannot revoke yourself",
+      "assign-role": "Asignar rol",
+      "cannot-revoke-self": "No puede revocarse a sí mismo",
       "copy-service-key": "Copiar Clave de Servicio",
       "entra-sync": {
         "description": "Sincronice usuarios y grupos de Entra ID (anteriormente Azure AD) u Okta con su instancia de Bytebase.",
@@ -2346,7 +2183,7 @@
       },
       "grant-access": "Conceder acceso",
       "groups": {
-        "external-readonly": "External group is read-only.",
+        "external-readonly": "El grupo externo es de solo lectura.",
         "form": {
           "description": "Descripción",
           "email": "Correo electrónico",
@@ -2391,27 +2228,27 @@
       "view-by-roles": "Ver por roles",
       "workload-identities": "Identidades de Carga de Trabajo",
       "workload-identity": "Workload Identity",
-      "workload-identity-advanced": "Advanced Settings",
-      "workload-identity-all-branches-tags": "All branches and tags",
-      "workload-identity-allowed-branches-tags": "Allowed Branches/Tags",
-      "workload-identity-audience": "Audience",
-      "workload-identity-branch": "Branch",
-      "workload-identity-branch-hint": "Leave empty for all branches",
+      "workload-identity-advanced": "Configuración avanzada",
+      "workload-identity-all-branches-tags": "Todas las ramas y etiquetas",
+      "workload-identity-allowed-branches-tags": "Ramas/etiquetas permitidas",
+      "workload-identity-audience": "Audiencia",
+      "workload-identity-branch": "Rama",
+      "workload-identity-branch-hint": "Dejar vacío para todas las ramas",
       "workload-identity-gitlab-url": "GitLab URL",
-      "workload-identity-gitlab-url-hint": "Your GitLab instance URL",
-      "workload-identity-group": "Group / Username",
-      "workload-identity-issuer": "Issuer URL",
-      "workload-identity-owner": "Organization / Username",
-      "workload-identity-platform": "Platform",
-      "workload-identity-project": "Project",
-      "workload-identity-project-hint": "Leave empty to allow all projects",
-      "workload-identity-repo": "Repository",
-      "workload-identity-repo-hint": "Leave empty for all repositories in the organization",
-      "workload-identity-specific-branch": "Specific branch",
-      "workload-identity-specific-tag": "Specific tag",
-      "workload-identity-subject": "Subject Pattern",
-      "workload-identity-tag": "Tag",
-      "workload-identity-tag-hint": "Leave empty to allow all tags"
+      "workload-identity-gitlab-url-hint": "La URL de su instancia de GitLab",
+      "workload-identity-group": "Grupo / Nombre de usuario",
+      "workload-identity-issuer": "URL del emisor",
+      "workload-identity-owner": "Organización / Nombre de usuario",
+      "workload-identity-platform": "Plataforma",
+      "workload-identity-project": "Proyecto",
+      "workload-identity-project-hint": "Dejar vacío para permitir todos los proyectos",
+      "workload-identity-repo": "Repositorio",
+      "workload-identity-repo-hint": "Dejar vacío para todos los repositorios de la organización",
+      "workload-identity-specific-branch": "Rama específica",
+      "workload-identity-specific-tag": "Etiqueta específica",
+      "workload-identity-subject": "Patrón de sujeto",
+      "workload-identity-tag": "Etiqueta",
+      "workload-identity-tag-hint": "Dejar vacío para permitir todas las etiquetas"
     },
     "profile": {
       "display-name": "Su nombre",
@@ -2477,14 +2314,14 @@
         }
       },
       "classification": {
-        "empty-classification": "The \"classification\" field is empty",
-        "guide-classification": "\"classification\" maps each category by ID. Leaf categories must reference a level number; parent categories omit the level.",
-        "guide-hierarchy": "IDs use a dash-separated hierarchy (e.g., \"1\" is a parent, \"1-1\" and \"1-2\" are its children).",
-        "guide-intro": "Edit the classification JSON below. An example template is provided when no classification is configured.",
-        "guide-levels": "\"levels\" defines sensitivity tiers with consecutive numbers starting from 1 (e.g., 1 = Public, 2 = Internal, 3 = Confidential).",
-        "invalid-json": "Invalid JSON format",
-        "missing-classification": "Missing \"classification\" field",
-        "missing-levels": "Missing \"levels\" field"
+        "empty-classification": "El campo \"classification\" está vacío",
+        "guide-classification": "\"classification\" asigna cada categoría por ID. Las categorías hoja deben referenciar un número de nivel; las categorías padre omiten el nivel.",
+        "guide-hierarchy": "Los ID utilizan una jerarquía separada por guiones (por ejemplo, \"1\" es un padre, \"1-1\" y \"1-2\" son sus hijos).",
+        "guide-intro": "Edite el JSON de clasificación a continuación. Se proporciona una plantilla de ejemplo cuando no hay ninguna clasificación configurada.",
+        "guide-levels": "\"levels\" define niveles de sensibilidad con números consecutivos a partir de 1 (por ejemplo, 1 = Público, 2 = Interno, 3 = Confidencial).",
+        "invalid-json": "Formato JSON no válido",
+        "missing-classification": "Falta el campo \"classification\"",
+        "missing-levels": "Falta el campo \"levels\""
       },
       "global-rules": {
         "condition-order": "Orden de condición",
@@ -2621,7 +2458,6 @@
       }
     }
   },
-  "settings.general.workspace.default-landing-page.go-to-workspace": "Go to workspace",
   "setup": {
     "basic-info": "Información básica",
     "data": {
@@ -2666,7 +2502,7 @@
     "search-sheets": "Hojas de búsqueda"
   },
   "sql-editor": {
-    "access-grants": "Access Grants",
+    "access-grants": "Concesiones de acceso",
     "access-search": {
       "scope": {
         "database": {
@@ -2677,16 +2513,16 @@
         }
       }
     },
-    "access-type-unmask": "See unmasked sensitive data",
-    "activate-access": "Activate",
-    "activate-confirm": "Are you sure you want to activate this access grant?",
+    "access-type-unmask": "Ver datos sensibles sin enmascarar",
+    "activate-access": "Activar",
+    "activate-confirm": "¿Está seguro de que desea activar esta concesión de acceso?",
     "add-a-new-instance": "Agregar nueva instancia",
     "admin-mode": {
       "exit": "Salir del modo administrador",
       "self": "Modo administrador"
     },
     "allow-admin-mode-only": "La instancia <instance></instance> solo es accesible en modo administrador.",
-    "and-n-more-databases": "and {{n}} more databases",
+    "and-n-more-databases": "y {{n}} bases de datos más",
     "batch-export": {
       "database-no-longer-available": "La base de datos ya no está disponible en la pestaña actual.",
       "export-limit-exceeds-executed": "El límite de exportación {{exportLimit}} supera el límite de filas de la consulta ejecutada ({{executedLimit}}); se exportarán solo las filas en caché.",
@@ -2732,20 +2568,20 @@
     "download-too-large-cells": "La descarga tiene {{cells}} celdas en {{statements}} sentencia(s); el límite es {{limit}}. Reduzca el número de filas o use Exportar.",
     "download-too-large-xlsx-columns": "XLSX no puede superar {{limit}} columnas; se obtuvieron {{count}}. Use Exportar o un formato diferente.",
     "download-too-large-xlsx-rows": "XLSX no puede superar {{limit}} filas de datos; se obtuvieron {{count}}. Use Exportar o un formato diferente.",
-    "duration-day": "{{days}} day",
-    "duration-days": "{{days}} days",
+    "duration-day": "{{days}} día",
+    "duration-days": "{{days}} días",
     "duration-hour": "{{hours}} hora",
     "duration-hours": "{{hours}} horas",
     "execute-query": "Ejecutar consulta",
     "executing-query": "Ejecutando consulta",
-    "expire-at": "Expire at {{time}}",
-    "expire-in": "Expire in {{time}}",
-    "expired": "Expired",
+    "expire-at": "Expira el {{time}}",
+    "expire-in": "Expira en {{time}}",
+    "expired": "Expirado",
     "format": "Formato",
     "format-default": "Predeterminado",
-    "format-sql": "Format SQL",
+    "format-sql": "Formatear SQL",
     "generate-sql": "Generar SQL",
-    "grant-type-unmask": "Unmask",
+    "grant-type-unmask": "Desenmascarar",
     "hex-format": "Formato hexadecimal",
     "hint-tips": {
       "confirm-to-close-unsaved-sheet": {
@@ -2754,14 +2590,14 @@
       }
     },
     "invalid-database": "Base de datos no válida {{database}}",
-    "jit": "Just-In-Time Access",
+    "jit": "Acceso Just-In-Time",
     "last-synced": "Última sincronización: <time></time>",
     "link-access": "Acceso al enlace",
     "loading-data": "Cargando datos...",
     "loading-databases": "Cargando bases de datos...",
     "manage-connections": "Gestionar las conexiones",
     "next-row": "Siguiente fila",
-    "no-access-requests": "No access requests",
+    "no-access-requests": "No hay solicitudes de acceso",
     "no-data-available": "No hay datos disponibles",
     "no-database-selected": "No se ha seleccionado una base de datos",
     "no-history-found": "No se encontró historial",
@@ -2795,15 +2631,15 @@
       "single-node": "Nodo único"
     },
     "request-aborted": "El usuario abortó la solicitud",
-    "request-access": "Request Access",
-    "request-data-access": "Request Data Access",
-    "request-jit": "Request just-in-time access",
+    "request-access": "Solicitar acceso",
+    "request-data-access": "Solicitar acceso a datos",
+    "request-jit": "Solicitar acceso just-in-time",
     "request-query": "Solicitar consulta",
     "result-limit": {
       "self": "Límite de resultados"
     },
-    "revoke-access": "Revoke",
-    "revoke-confirm": "Are you sure you want to revoke this access grant?",
+    "revoke-access": "Revocar",
+    "revoke-confirm": "¿Está seguro de que desea revocar esta concesión de acceso?",
     "rows": {
       "self": "filas"
     },
@@ -2844,13 +2680,13 @@
     "table-empty-placeholder": "Haga clic en Ejecutar para ejecutar la consulta.",
     "table-view": "Vista de tabla",
     "text-format": "Formato de texto",
-    "unmask-warning": "The query result may include unmasked sensitive data.",
+    "unmask-warning": "El resultado de la consulta puede incluir datos sensibles sin enmascarar.",
     "upload-file": "Subir archivo",
     "url-copied-to-clipboard": "La URL se copia al portapapeles.",
     "vertical-display": "Pantalla vertical",
     "view-database-detail": "Ver detalle de la base de datos",
     "view-detail": "Ver detalle",
-    "view-issue": "View Issue",
+    "view-issue": "Ver issue",
     "view-schema-text": "Ver texto del esquema",
     "visualize-explain": "Visualizar explicación",
     "web-socket": {
@@ -2862,9 +2698,9 @@
         "title": "Servidor de lenguaje"
       },
       "errors": {
-        "description": "Auto Completion might be limited or disabled.",
-        "disconnected": "WebSocket disconnected",
-        "title": "WebSocket connection failed"
+        "description": "El autocompletado puede estar limitado o deshabilitado.",
+        "disconnected": "WebSocket desconectado",
+        "title": "Error de conexión de WebSocket"
       }
     }
   },
@@ -2938,7 +2774,7 @@
     "policy-removed": "La política de revisión se eliminó correctamente.",
     "policy-update-failed": "No se pudo actualizar la política de revisión.",
     "policy-updated": "La política de revisión se actualizó correctamente.",
-    "review-policy": "Review policy",
+    "review-policy": "Política de revisión",
     "rule": {
       "ADVICE_ONLINE_MIGRATION": {
         "component": {
@@ -3678,23 +3514,23 @@
       "billing-period": "Período de facturación",
       "cancel": "Cancelar suscripción",
       "cancel-dialog": {
-        "comment-label": "Anything else you'd like to share? (optional)",
-        "comment-placeholder": "Tell us more so we can improve...",
-        "confirm": "Confirm cancellation",
-        "description": "We're sorry to see you go. Your feedback helps us improve.",
-        "keep": "Keep subscription",
+        "comment-label": "¿Algo más que le gustaría compartir? (opcional)",
+        "comment-placeholder": "Cuéntenos más para que podamos mejorar...",
+        "confirm": "Confirmar cancelación",
+        "description": "Lamentamos que se vaya. Sus comentarios nos ayudan a mejorar.",
+        "keep": "Mantener suscripción",
         "reason": {
-          "customer-service": "Customer service issues",
-          "low-quality": "Quality didn't meet expectations",
-          "missing-features": "Missing features I need",
-          "other": "Other reason",
-          "switched-service": "Switched to a different product",
-          "too-complex": "Too complex to use",
-          "too-expensive": "Too expensive",
-          "unused": "Not using it enough"
+          "customer-service": "Problemas con la atención al cliente",
+          "low-quality": "La calidad no cumplió las expectativas",
+          "missing-features": "Faltan funciones que necesito",
+          "other": "Otro motivo",
+          "switched-service": "Cambié a un producto diferente",
+          "too-complex": "Demasiado complejo de usar",
+          "too-expensive": "Demasiado caro",
+          "unused": "No lo uso lo suficiente"
         },
-        "reason-label": "Why are you canceling? (required)",
-        "title": "Cancel your subscription"
+        "reason-label": "¿Por qué cancela? (obligatorio)",
+        "title": "Cancelar su suscripción"
       },
       "cancel-pending": "Su suscripción ha sido cancelada y finalizará el {{date}}.",
       "canceled": "Suscripción cancelada",
@@ -3704,8 +3540,8 @@
         "percentage-off": "primer mes {{value}}% de descuento",
         "price-off": "${{value}} de descuento"
       },
-      "enterprise-description": "Scale your business securely while staying compliant.",
-      "free-description": "Designed for solo devs, side-projects, and experiments.",
+      "enterprise-description": "Escale su negocio de forma segura manteniendo el cumplimiento normativo.",
+      "free-description": "Diseñado para desarrolladores individuales, proyectos paralelos y experimentos.",
       "manage-invoices": "Gestionar facturas",
       "next-period-price": "Precio del próximo período",
       "payment-info": "Información de pago",
@@ -3713,7 +3549,7 @@
       "pending-title": "Completando su compra...",
       "per-user-per-month": "/ usuario / mes",
       "privacy-policy": "Política de privacidad",
-      "pro-description": "Built for teams creating production-ready applications.",
+      "pro-description": "Creado para equipos que desarrollan aplicaciones listas para producción.",
       "seats": "Usuarios",
       "see-comparison": "Ver comparación detallada de funciones",
       "subscribe": "Suscribirse ahora",
@@ -3761,20 +3597,37 @@
       }
     }
   },
-  "subscription.instance-assignment.assign-license": "Asignar licencia",
-  "subscription.instance-assignment.n-license-remain": "permanecer {{n}}",
-  "subscription.usage.instance-count.runoutof": "Te has quedado sin tu cuota de instancias {{total}}.",
-  "subscription.usage.instance-count.title": "Límite de cantidad de instancias",
   "task": {
+    "affected-rows": "Filas afectadas",
     "cancel-task": "Cancelar tarea | Cancelar tareas",
     "cancel-task-description": "Las ejecuciones de tareas pendientes y disponibles se cancelan inmediatamente. Las ejecuciones en curso reciben una solicitud de cancelación de mejor esfuerzo y pueden seguir ejecutándose; vuelva a intentarlo si es necesario.",
+    "check-type": {
+      "affected-rows": {
+        "description": "Estimado por información estadística.",
+        "self": "Filas afectadas"
+      },
+      "sql-review": {
+        "description": "Analiza la sentencia SQL en busca de posibles problemas y ofrece recomendaciones. Incluye reglas integradas y sus reglas personalizadas.",
+        "self": "Revisión de SQL"
+      }
+    },
     "created": "Creado",
     "data-export-creator-only": "Sólo el creador del problema puede ejecutar tareas de exportación de datos",
     "error": {
       "scheduled-time-must-be-in-the-future": "La hora programada debe ser en el futuro"
     },
+    "executed-by": "Ejecutado por",
     "execution-time": "Tiempo de ejecución",
+    "no-cancelable-tasks": "No hay tareas cancelables",
     "no-permission": "No hay permiso para realizar esta acción",
+    "no-runnable-tasks": "No hay tareas ejecutables",
+    "no-selectable-tasks": "No hay tareas seleccionables",
+    "no-skippable-tasks": "No hay tareas que se puedan omitir",
+    "no-tasks-selected": "No hay tareas seleccionadas",
+    "online-migration": {
+      "self": "Migración en línea"
+    },
+    "prior-backup": "Respaldo previo",
     "run-immediately": {
       "description": "Las tareas comenzarán a ejecutarse en cuanto haga clic en \"Ejecutar\". No requiere demora ni programación.",
       "self": "Corre inmediatamente"
@@ -3784,7 +3637,9 @@
       "description": "Establezca una fecha y hora específicas para que las tareas comiencen a ejecutarse automáticamente. Útil para periodos de mantenimiento o horas de baja demanda.",
       "self": "Programar para más tarde"
     },
+    "scheduled-time": "Hora programada",
     "select-scheduled-time": "Seleccionar hora programada",
+    "select-task": "Seleccionar tarea",
     "skip-prior-backup": "Omitir respaldo previo",
     "skip-prior-backup-description": "Omitir la copia de seguridad automática de datos antes de aplicar cambios",
     "skip-task": "Saltar tarea | Saltar tareas",
@@ -3799,56 +3654,55 @@
       "skipped": "Omitido"
     }
   },
-  "task-run.blocked-sessions": "Sesiones bloqueadas",
-  "task-run.blocked-sessions-description": "Las sesiones que están bloqueadas por la sesión actual.",
-  "task-run.blocking-sessions": "Sesiones bloqueantes",
-  "task-run.blocking-sessions-description": "Las sesiones que están bloqueando la sesión actual.",
-  "task-run.history": "Historial",
-  "task-run.latest": "Último",
-  "task-run.latest-logs": "Últimos registros",
-  "task-run.log-detail.backing-up": "haciendo copia de seguridad...",
-  "task-run.log-detail.backup-completed": "completadas ({{count}} tablas)",
-  "task-run.log-detail.completed": "Completado",
-  "task-run.log-detail.computing": "computación...",
-  "task-run.log-detail.dumping": "dumping...",
-  "task-run.log-detail.retry-attempt": "intento {{current}}/{{max}}",
-  "task-run.log-detail.syncing": "sincronizando...",
-  "task-run.log-type.command-execute": "Comando Ejecutar",
-  "task-run.log-type.compute-diff": "Calcular diferencia",
-  "task-run.log-type.database-sync": "Sincronización de bases de datos",
-  "task-run.log-type.ghost-migration": "Migración gh-ost",
-  "task-run.log-type.prior-backup": "Copia de seguridad previa",
-  "task-run.log-type.release-file-execute": "Archivo de lanzamiento",
-  "task-run.log-type.retry": "Reintentar",
-  "task-run.log-type.schema-dump": "Volcado de esquema",
-  "task-run.log-type.transaction": "Transacción",
-  "task-run.log-viewer.collapse-all": "Contraer todo",
-  "task-run.log-viewer.expand-all": "Expandir todo",
-  "task-run.log-viewer.multiple-replicas-notice": "Se detectó un reinicio del servidor durante la ejecución. Los registros están agrupados por réplica.",
-  "task-run.log-viewer.replica-n": "Réplica #{{n}}",
-  "task-run.log-viewer.summary": "{{sections}} secciones · {{entries}} entradas",
-  "task-run.no-session-found": "No se encontró sesión",
-  "task-run.rollback.available": "{{count}} rollback disponible",
-  "task-run.rollback.no-statement-generated": "No se generó ninguna sentencia",
-  "task-run.rollback.preview-statement.description": "Revisa las sentencias de rollback generadas antes de crear el plan de rollback.",
-  "task-run.status.enqueued": "Esperando a ser ejecutada.",
-  "task-run.status.enqueued-with-rollout-time": "Esperando para ejecutar después de {{time}}.",
-  "task-run.status.waiting-max-tasks-per-rollout": "Esperando a que terminen otras tareas. Se ha alcanzado el límite máximo de tareas en ejecución por despliegue. Último informe a las {{time}}.",
-  "task.affected-rows": "Filas afectadas",
-  "task.check-type.affected-rows.description": "Estimado por información estadística.",
-  "task.check-type.affected-rows.self": "Filas afectadas",
-  "task.check-type.sql-review.description": "Analyze the SQL statement for potential issues and provide recommendations. Includes built-in rules and your custom rules.",
-  "task.check-type.sql-review.self": "SQL review",
-  "task.executed-by": "Ejecutado por",
-  "task.no-cancelable-tasks": "No hay tareas cancelables",
-  "task.no-runnable-tasks": "No hay tareas ejecutables",
-  "task.no-selectable-tasks": "No hay tareas seleccionables",
-  "task.no-skippable-tasks": "No hay tareas que se puedan omitir",
-  "task.no-tasks-selected": "No hay tareas seleccionadas",
-  "task.online-migration.self": "Migración en línea",
-  "task.prior-backup": "Respaldo previo",
-  "task.scheduled-time": "Hora programada",
-  "task.select-task": "Seleccionar tarea",
+  "task-run": {
+    "blocked-sessions": "Sesiones bloqueadas",
+    "blocked-sessions-description": "Las sesiones que están bloqueadas por la sesión actual.",
+    "blocking-sessions": "Sesiones bloqueantes",
+    "blocking-sessions-description": "Las sesiones que están bloqueando la sesión actual.",
+    "history": "Historial",
+    "latest": "Último",
+    "latest-logs": "Últimos registros",
+    "log-detail": {
+      "backing-up": "haciendo copia de seguridad...",
+      "backup-completed": "completadas ({{count}} tablas)",
+      "completed": "Completado",
+      "computing": "computación...",
+      "dumping": "dumping...",
+      "retry-attempt": "intento {{current}}/{{max}}",
+      "syncing": "sincronizando..."
+    },
+    "log-type": {
+      "command-execute": "Comando Ejecutar",
+      "compute-diff": "Calcular diferencia",
+      "database-sync": "Sincronización de bases de datos",
+      "ghost-migration": "Migración gh-ost",
+      "prior-backup": "Copia de seguridad previa",
+      "release-file-execute": "Archivo de lanzamiento",
+      "retry": "Reintentar",
+      "schema-dump": "Volcado de esquema",
+      "transaction": "Transacción"
+    },
+    "log-viewer": {
+      "collapse-all": "Contraer todo",
+      "expand-all": "Expandir todo",
+      "multiple-replicas-notice": "Se detectó un reinicio del servidor durante la ejecución. Los registros están agrupados por réplica.",
+      "replica-n": "Réplica #{{n}}",
+      "summary": "{{sections}} secciones · {{entries}} entradas"
+    },
+    "no-session-found": "No se encontró sesión",
+    "rollback": {
+      "available": "{{count}} rollback disponible",
+      "no-statement-generated": "No se generó ninguna sentencia",
+      "preview-statement": {
+        "description": "Revisa las sentencias de rollback generadas antes de crear el plan de rollback."
+      }
+    },
+    "status": {
+      "enqueued": "Esperando a ser ejecutada.",
+      "enqueued-with-rollout-time": "Esperando para ejecutar después de {{time}}.",
+      "waiting-max-tasks-per-rollout": "Esperando a que terminen otras tareas. Se ha alcanzado el límite máximo de tareas en ejecución por despliegue. Último informe a las {{time}}."
+    }
+  },
   "two-factor": {
     "description": "La autenticación de dos factores proporciona una capa adicional de seguridad para las cuentas de los miembros. Al iniciar sesión, se te pedirá que ingreses el código de seguridad generado por tu aplicación de autenticación.",
     "disable": {

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -1,21 +1,25 @@
 {
-  "activity.sentence.added-spec": "追加しました",
-  "activity.sentence.canceled-issue": "closed the issue",
-  "activity.sentence.changed-description": "changed description",
-  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
-  "activity.sentence.changed-labels": "changed labels",
-  "activity.sentence.changed-targets-of": "ターゲットを変更しました",
-  "activity.sentence.created-issue": "created issue",
-  "activity.sentence.disabled-prior-backup-on": "事前バックアップを無効化しました",
-  "activity.sentence.enabled-prior-backup-on": "事前バックアップを有効化しました",
-  "activity.sentence.modified-sql-of": "SQL を変更しました",
-  "activity.sentence.removed-spec": "削除しました",
-  "activity.sentence.reopened-issue": "reopened issue",
-  "activity.sentence.resolved-issue": "イシューを完了としてマークしました",
-  "activity.sentence.review-done-rollout-created": "レビューが完了し、ロールアウトが作成されました",
-  "activity.sentence.review-done-rollout-created-for-plan": "レビューが完了し、プランのロールアウトが作成されました",
-  "activity.sentence.review-skipped-rollout-created": "レビューがスキップされ、ロールアウトが作成されました",
-  "activity.sentence.review-skipped-rollout-created-for-plan": "レビューがスキップされ、プランのロールアウトが作成されました",
+  "activity": {
+    "sentence": {
+      "added-spec": "追加しました",
+      "canceled-issue": "Issue をクローズしました",
+      "changed-description": "説明を変更しました",
+      "changed-from-to": "{{name}} を \"{{oldValue}}\" から \"{{newValue}}\" に変更しました",
+      "changed-labels": "ラベルを変更しました",
+      "changed-targets-of": "ターゲットを変更しました",
+      "created-issue": "Issue を作成しました",
+      "disabled-prior-backup-on": "事前バックアップを無効化しました",
+      "enabled-prior-backup-on": "事前バックアップを有効化しました",
+      "modified-sql-of": "SQL を変更しました",
+      "removed-spec": "削除しました",
+      "reopened-issue": "Issue を再オープンしました",
+      "resolved-issue": "イシューを完了としてマークしました",
+      "review-done-rollout-created": "レビューが完了し、ロールアウトが作成されました",
+      "review-done-rollout-created-for-plan": "レビューが完了し、プランのロールアウトが作成されました",
+      "review-skipped-rollout-created": "レビューがスキップされ、ロールアウトが作成されました",
+      "review-skipped-rollout-created-for-plan": "レビューがスキップされ、プランのロールアウトが作成されました"
+    }
+  },
   "agent": {
     "active-only-chats": "アクティブのみ",
     "ai-not-configured": {
@@ -52,6 +56,7 @@
     "reply": "返信",
     "result": "結果",
     "retry-last-chat-turn": "再試行",
+    "self": "エージェント",
     "send": "送信",
     "stop": "停止",
     "tool-answer": "回答",
@@ -69,7 +74,6 @@
     "unarchive-all-chats": "すべてのチャットのアーカイブを解除",
     "unarchive-chat": "アーカイブ解除"
   },
-  "agent.self": "エージェント",
   "audit-log": {
     "advanced-search": {
       "scope": {
@@ -152,9 +156,9 @@
       "create-admin-account": "管理者アカウントを作成",
       "existing-user": "すでにアカウントをお持ちですか？",
       "title": "アカウントを登録してください"
-    }
+    },
+    "token-expired-title": "トークンの期限切れ"
   },
-  "auth.token-expired-title": "トークンの期限切れ",
   "banner": {
     "external-url": "Bytebase は --extern-url を設定していません",
     "license-expired": "{{plan}} のライセンスは {{expireAt}} に期限切れになりました。",
@@ -182,7 +186,7 @@
         "or": {
           "description": "次のいずれかが当てはまります…"
         },
-        "tooltip": "A condition group is a collection of conditions connected by operators \"And\" and \"Or\"."
+        "tooltip": "条件グループは、演算子「And」と「Or」で接続された条件の集合です。"
       },
       "input-value": "入力値",
       "input-value-press-enter": "値を入力し、Enter キーを押して確定します",
@@ -192,9 +196,9 @@
   },
   "changelog": {
     "current-schema-empty": "現在のスキーマは空です",
-    "no-schema-change": "No schema change",
+    "no-schema-change": "スキーマ変更はありません",
     "schema-snapshot-after-change": "この変更を完了した後のスキーマのスナップショット",
-    "select": "Schema version is recorded each time a schema change is applied via Bytebase",
+    "select": "スキーマバージョンは、Bytebase を通じてスキーマ変更が適用されるたびに記録されます",
     "self": "Changelog",
     "show-diff": "違いを表示"
   },
@@ -205,6 +209,7 @@
     "actions": "アクション",
     "activated": "有効化しました",
     "active": "アクティブ",
+    "activity": "アクティビティ",
     "add": "追加",
     "add-permissions": "権限を追加",
     "added": "作成した",
@@ -212,40 +217,46 @@
     "admin": "管理者",
     "all": "全て",
     "allow": "許可",
-    "approve": "Approve",
+    "and": "と",
+    "approve": "承認",
     "approved": "承認済み",
     "archive": "アーカイブ",
-    "archive-description": "Mark \"{{name}}\" as archived and read-only.",
-    "archive-resource": "Archive {{type}}",
+    "archive-description": "\"{{name}}\" をアーカイブ済みかつ読み取り専用としてマークします。",
+    "archive-resource": "{{type}} をアーカイブ",
     "archived": "アーカイブ済み",
     "back": "戻る",
+    "back-to-workspace": "ワークスペースに戻る",
     "bypassed": "バイパス済み",
     "cancel": "キャンセル",
     "cannot-undo-this-action": "この操作は元に戻せません",
+    "catalog": "カタログ",
     "changelog": "Changelog",
     "classification-level": "分類レベル",
     "clear": "クリア",
     "clear-filters": "フィルタをクリア",
     "close": "閉じる",
+    "close-mobile-sidebar": "モバイルサイドバーを閉じる",
     "closed": "閉まっている",
+    "collapse": "折りたたむ",
+    "column": "列",
     "comment": "コメント",
     "configure": "設定",
     "configure-now": "今すぐ設定する",
     "confirm": "確認する",
-    "confirm-archive": "Archive Resource?",
-    "confirm-delete": "Delete Resource?",
-    "confirm-to-revert": "Confirm to revert your editing?",
+    "confirm-archive": "リソースをアーカイブしますか？",
+    "confirm-delete": "リソースを削除しますか？",
+    "confirm-to-revert": "編集内容を元に戻してもよろしいですか？",
     "continue-anyway": "まだ続けたい",
     "copied": "コピーされました",
     "copy": "コピー",
-    "copy-failed": "Copy failed",
+    "copy-failed": "コピーに失敗しました",
     "create": "作成する",
     "created": "作成済",
     "created-at": "作成日時",
     "creating": "作成...",
     "creator": "作成者",
     "custom": "カスタマイズ",
-    "danger-zone": "Danger Zone",
+    "danger-zone": "危険ゾーン",
     "database": "データベース",
     "database-group": "データベースグループ",
     "databases": "データベース",
@@ -253,28 +264,29 @@
     "default": "デフォルト",
     "definition": "定義",
     "delete": "消去",
-    "delete-resource": "Delete {{type}}",
-    "delete-resource-description": "Once you delete \"{{name}}\", there is no going back. Please be certain.",
+    "delete-resource": "{{type}} を削除",
+    "delete-resource-description": "\"{{name}}\" を削除すると元に戻せません。十分にご確認ください。",
     "deleted": "削除されました",
     "deny": "拒否",
     "description": "説明",
-    "deselect-all": "Deselect all",
+    "deselect-all": "すべての選択を解除",
     "detail": "詳細",
     "detailed-guide": "詳細ガイド",
-    "disable": "Disable",
+    "disable": "無効化",
     "discard-changes": "変更をキャンセルする",
     "dismiss": "閉じる",
     "done": "完了",
     "download": "ダウンロード",
     "draft": "下書き",
     "duplicate": "コピー",
-    "duration": "Duration",
+    "duration": "期間",
     "edit": "編集",
+    "edited": "編集済み",
     "email": "メールアドレス",
     "email-ascii-only": "メールアドレスは ASCII 文字のみ使用できます（英数字および . _ - + などの記号）。",
-    "empty": "Empty",
+    "empty": "空",
     "enable": "オンにする",
-    "enabled": "Enabled",
+    "enabled": "有効",
     "environment": "環境",
     "environment-name": "環境名",
     "environments": "環境",
@@ -287,7 +299,7 @@
       "size-limit": "ファイルサイズは {{size}} MiB 未満である必要があります",
       "type-limit": "タイプ {{extension}} のファイルのみがサポートされます"
     },
-    "filter": "Filter",
+    "filter": "フィルター",
     "filter-by-name": "名前でフィルタリングする",
     "fork": "フォーク",
     "from": "開始",
@@ -299,22 +311,28 @@
     "home": "ホームページ",
     "id": "ID",
     "import": "インポート",
+    "in-progress": "進行中",
     "info": "情報",
     "instance": "インスタンス",
     "instances": "インスタンス",
-    "is-required": "is required",
+    "is-required": "は必須です",
+    "issue": "Issue",
     "issues": "イシュー",
-    "items": "items",
+    "items": "件",
     "key": "キー",
     "labels": "ラベル",
+    "language": "言語",
     "learn-more": "もっと詳しく知る",
     "leave-without-saving": "変更を保存していませんか?",
+    "license": "ライセンス",
+    "line": "行",
     "load-more": "もっと読み込む",
     "loading": "読み込み中",
     "logout": "サインアウト",
     "manage": "管理",
-    "manually-select": "Manually select",
+    "manually-select": "手動で選択",
     "maximize": "最大化",
+    "members": "メンバー",
     "members_one": "メンバー",
     "members_other": "メンバー",
     "minutes": "分",
@@ -330,8 +348,11 @@
     "no-data": "データなし",
     "not-started": "未開始",
     "ok": "わかりました",
+    "only-creator-allowed-export": "エクスポートできるのは作成者のみです",
+    "open": "開く",
+    "operation": "操作",
     "operations": "操作",
-    "optional": "Optional",
+    "optional": "任意",
     "or": "または",
     "overview": "概要",
     "password": "パスワード",
@@ -339,27 +360,32 @@
     "permissions": "権限",
     "plan": "Plan",
     "preview": "プレビュー",
-    "previous": "Previous",
+    "previous": "前へ",
     "project": "プロジェクト",
     "projects": "プロジェクト",
     "query": "クエリ",
     "read-only": "読み取り専用",
     "reason": "理由",
+    "recent": "最近",
     "refresh": "リフレッシュ",
     "regenerate": "再生する",
-    "reject": "Reject",
+    "reject": "拒否",
     "rejected": "却下",
     "release": "リリース",
+    "remaining": "残り",
     "remove": "削除",
+    "removed": "削除されました",
+    "reopen": "再開",
     "reorder": "並び替え",
     "required-permission": "必要な権限",
     "required-workspace-permission": "ワークスペース UX の初期化には以下の権限が必要です",
     "reset": "リセット",
-    "resource": "Resource",
+    "resource": "リソース",
     "resource-not-found": "リソースが見つかりません",
     "resources": "リソース",
     "restore": "復元する",
-    "restored": "Restored",
+    "restored": "復元済み",
+    "retry": "再試行",
     "revert": "元に戻す",
     "revoke": "キャンセル",
     "revoked": "取り消し済み",
@@ -373,7 +399,7 @@
       "self": "行"
     },
     "rows-per-page": "ページあたりの行数",
-    "run": "Run",
+    "run": "実行",
     "running": "実行中",
     "save": "保存",
     "schema": "スキーマ",
@@ -382,14 +408,17 @@
     "search-for-more": "さらに検索",
     "select": "選択してください",
     "select-all": "すべて選択",
-    "selected": "selected",
+    "selected": "選択済み",
     "sensitive-placeholder": "機密データ - 書き込みのみ",
     "setting": "設定",
     "settings": "設定",
     "share": "共有",
+    "show-less": "折りたたむ",
+    "show-more": "もっと見る",
     "sign-in": "ログイン",
     "sign-in-as-admin": "管理者としてサインイン",
     "sign-up": "登録する",
+    "skip": "スキップ",
     "skipped": "スキップ",
     "snapshot": "スナップショット",
     "sql": "SQL",
@@ -397,21 +426,25 @@
     "state": "ステート",
     "statement": "ステートメント",
     "status": "ステータス",
-    "submit": "Submit",
+    "submit": "送信",
     "succeed": "成功する",
+    "success": "成功",
     "system": "システム",
     "table": "テーブル",
+    "task": "タスク",
     "text-wrap": "テキストの折り返し",
     "tips": "プロンプトメッセージ",
     "title": "タイトル",
     "to": "終了",
-    "total": "Total",
+    "total": "合計",
     "total-n-items": "合計 {{n}} 件",
     "transfer": "移行",
+    "troubleshoot": "トラブルシューティング",
     "type": "タイプ",
     "type-to-search": "入力して検索",
     "unassigned": "割り当てられていない",
     "under-review": "レビュー中",
+    "unknown": "不明",
     "unlimited": "無制限",
     "untitled": "名前のない",
     "update": "更新する",
@@ -426,100 +459,14 @@
     "version": "バージョン",
     "view": "表示",
     "view-details": "詳細を表示",
+    "view-doc": "ドキュメントを見る",
     "visibility": "可視性",
+    "want-help": "ヘルプが必要ですか",
     "warning": "警告する",
     "webhooks": "Webhook",
     "write-only": "書き込み専用",
     "you": "あなた"
   },
-  "common.activity": "アクティビティ",
-  "common.add": "追加",
-  "common.admin": "管理者",
-  "common.all": "全て",
-  "common.and": "と",
-  "common.archive": "アーカイブ",
-  "common.archived": "アーカイブ済み",
-  "common.back-to-workspace": "Back to workspace",
-  "common.cancel": "キャンセル",
-  "common.cannot-undo-this-action": "この操作は元に戻せません",
-  "common.catalog": "カタログ",
-  "common.close": "閉じる",
-  "common.close-mobile-sidebar": "Close mobile sidebar",
-  "common.collapse": "折りたたむ",
-  "common.column": "列",
-  "common.comment": "Comment",
-  "common.confirm": "確認する",
-  "common.continue-anyway": "まだ続けたい",
-  "common.copy": "コピー",
-  "common.create": "作成する",
-  "common.creating": "作成...",
-  "common.custom": "カスタマイズ",
-  "common.database": "データベース",
-  "common.database-group": "データベースグループ",
-  "common.databases": "データベース",
-  "common.default": "デフォルト",
-  "common.delete": "消去",
-  "common.delete-resource": "Delete {{type}}",
-  "common.deleted": "削除されました",
-  "common.detail": "Detail",
-  "common.detailed-guide": "詳細ガイド",
-  "common.edit": "編集",
-  "common.edited": "edited",
-  "common.environment": "環境",
-  "common.import": "インポート",
-  "common.in-progress": "進行中",
-  "common.issue": "Issue",
-  "common.key": "キー",
-  "common.labels": "ラベル",
-  "common.language": "Language",
-  "common.learn-more": "もっと詳しく知る",
-  "common.license": "License",
-  "common.line": "行",
-  "common.load-more": "さらに読み込む",
-  "common.loading": "読み込み中",
-  "common.logout": "サインアウト",
-  "common.members": "メンバー",
-  "common.minutes": "分",
-  "common.n-more": "あと {{n}} 件",
-  "common.no-data": "データなし",
-  "common.only-creator-allowed-export": "Only the creator is allowed to export",
-  "common.open": "開く",
-  "common.operation": "操作",
-  "common.optional": "オプション",
-  "common.or": "または",
-  "common.overview": "概要",
-  "common.password": "パスワード",
-  "common.project": "プロジェクト",
-  "common.read-only": "読み取り専用",
-  "common.recent": "最近",
-  "common.remaining": "残り",
-  "common.remove": "削除",
-  "common.removed": "削除されました",
-  "common.reopen": "再開",
-  "common.restore": "復元する",
-  "common.retry": "再試行",
-  "common.role.self": "ロール",
-  "common.rollout": "リリース",
-  "common.save": "保存",
-  "common.sensitive-placeholder": "機密データ - 書き込みのみ",
-  "common.show-less": "折りたたむ",
-  "common.show-more": "もっと見る",
-  "common.skip": "スキップ",
-  "common.success": "成功",
-  "common.task": "タスク",
-  "common.troubleshoot": "トラブルシューティング",
-  "common.unknown": "不明",
-  "common.unlimited": "無制限",
-  "common.updated": "更新しました",
-  "common.updating": "更新中",
-  "common.user": "ユーザー",
-  "common.username": "ユーザー名",
-  "common.value": "値",
-  "common.version": "バージョン",
-  "common.view-doc": "ドキュメントを見る",
-  "common.want-help": "Want help",
-  "common.warning": "警告する",
-  "common.write-only": "書き込み専用",
   "create-db": {
     "cluster": "集まる",
     "database-owner-name": "データベース所有者",
@@ -558,14 +505,18 @@
     "issue-review": {
       "and-n-other-users": "{{names}} と他の {{count}} 人のユーザー",
       "approved-by": "承認者",
+      "approved-issue": "Issue を承認しました",
       "disallow-approve-reason": {
-        "some-task-checks-are-still-running": "Some task checks are still running.",
-        "some-task-checks-didnt-pass": "Some task checks didn't pass."
+        "some-task-checks-are-still-running": "一部のタスクチェックがまだ実行中です。",
+        "some-task-checks-didnt-pass": "一部のタスクチェックが合格しませんでした。"
       },
       "generating-approval-flow": "承認フローが生成されています",
       "re-request-review": "再度承認をリクエストする",
       "re-request-review-success": "レビューの再リクエストが完了しました",
+      "re-requested-review": "Issue のレビューを再リクエストしました",
       "rejected-by": "拒否された",
+      "rejected-issue": "Issue を拒否しました",
+      "retry-approval-finding": "リトライ",
       "self-approval-not-allowed": "このプロジェクトでは自己承認は許可されていません。作成者として承認することはできません。"
     },
     "risk": {
@@ -608,17 +559,13 @@
     },
     "self": "カスタム承認"
   },
-  "custom-approval.issue-review.approved-issue": "approved issue",
-  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
-  "custom-approval.issue-review.rejected-issue": "rejected issue",
-  "custom-approval.issue-review.retry-approval-finding": "リトライ",
   "data-source": {
     "additional-node-addresses": "追加のノードアドレス",
     "automatic-query-data-source": "自動",
     "connection-string-schema": "接続文字列モード",
     "connection-type": "接続タイプ",
     "delete-read-only-data-source": "読み取り専用データソースを削除する",
-    "direct-connection": "Direct Connection",
+    "direct-connection": "直接接続",
     "extra-params": {
       "description": "データベース接続文字列の追加パラメーター",
       "self": "追加のパラメーター"
@@ -686,47 +633,16 @@
     },
     "ssl-connection": "SSL接続"
   },
-  "data-source.additional-node-addresses": "追加のノードアドレス",
-  "data-source.connection-string-schema": "接続文字列モード",
-  "data-source.connection-type": "接続タイプ",
-  "data-source.delete-read-only-data-source": "読み取り専用データソースを削除する",
-  "data-source.direct-connection": "Direct Connection",
-  "data-source.extra-params.description": "データベース接続文字列の追加パラメーター",
-  "data-source.extra-params.self": "追加のパラメーター",
-  "data-source.no-read-only-data-source": "読み取り専用データソースがありません",
-  "data-source.private-key-passphrase": "秘密鍵のパスフレーズ",
-  "data-source.private-key-passphrase-placeholder": "秘密鍵が暗号化されていない場合は空のままにしてください",
-  "data-source.private-key-passphrase-tip": "暗号化された秘密鍵のオプションパスフレーズ",
-  "data-source.read-replica-host": "リードレプリカホスト",
-  "data-source.read-replica-port": "リードレプリカポート",
-  "data-source.replica-set": "レプリカセット",
-  "data-source.snowflake-keypair-tip": "キーペア認証",
-  "data-source.ssh-connection": "SSH接続",
-  "data-source.ssh-type.none": "なし",
-  "data-source.ssh-type.tunnel-and-private-key": "トンネル + 秘密鍵",
-  "data-source.ssh.host": "サーバ",
-  "data-source.ssh.password": "パスワード",
-  "data-source.ssh.port": "ポート",
-  "data-source.ssh.private-key": "秘密鍵",
-  "data-source.ssh.ssh-key": "SSHキー",
-  "data-source.ssh.user": "ユーザー名",
-  "data-source.ssl-connection": "SSL接続",
-  "data-source.ssl.ca-cert": "CA証明書",
-  "data-source.ssl.ca-path": "CA証明書のパス",
-  "data-source.ssl.client-cert": "クライアント証明書",
-  "data-source.ssl.client-cert-path": "クライアント証明書のパス",
-  "data-source.ssl.client-key": "クライアントキー",
-  "data-source.ssl.client-key-path": "クライアントキーのパス",
-  "data-source.ssl.verify-certificate": "TLS証明書を検証",
-  "data-source.ssl.verify-certificate-tooltip": "安全な接続のためにTLS証明書の検証を有効にします。開発環境や証明書が適切に検証できない場合（自己署名証明書、VPN環境など）にのみ無効にしてください。警告：検証を無効にすることは安全ではありません",
   "database": {
     "access-denied": "データベースにアクセスする権限がありません",
     "all": "すべてのデータベース",
     "change-database": "データベースの変更",
     "checks": "チェック",
     "classification": {
-      "description": "Define classification levels to apply consistent masking policies across columns and databases."
+      "description": "分類レベルを定義して、列やデータベース全体に一貫したマスキングポリシーを適用します。",
+      "self": "分類"
     },
+    "column": "列",
     "columns": "カラム",
     "comment": "コメント",
     "data-size": "データサイズ",
@@ -734,9 +650,13 @@
     "edit-labels": "ラベルを編集",
     "edit-schema": "スキーマの変更",
     "engine": "エンジン",
-    "expression": "Expression",
+    "export-schema": "スキーマをエクスポート",
+    "export-schema-multi-file": "複数ファイル (ZIP)",
+    "export-schema-single-file": "単一ファイル",
+    "expression": "式",
     "external-database-name": "外部データベース名",
     "external-server-name": "外部サーバー名",
+    "failed-to-export-schema": "スキーマのエクスポートに失敗しました",
     "filter-database": "データベースをフィルター",
     "foreign-key": {
       "reference": "参照"
@@ -744,6 +664,7 @@
     "foreign-keys": "外部キー",
     "index-size": "インデックスサイズ",
     "indexes": "索引",
+    "labels": "データベースラベル",
     "last-sync": "最後の同期",
     "mixed-label-values": "混合値",
     "mixed-label-values-warning": "選択されたリソースの一部は、同じキーに対して異なる値を持っています。これらのキーと値のペアを変更する場合にのみ編集してください。",
@@ -790,30 +711,31 @@
       "unspecified": "不特定"
     },
     "select": "データベースの選択",
+    "successfully-exported-schema": "スキーマのエクスポートに成功しました",
     "successfully-transferred-databases": "データベースの転送に成功しました",
     "sync-complete-for-instance": "インスタンス '{{0}}' の同期が完了しました",
     "sync-database": "データベース同期",
     "sync-schema": {
-      "copy-schema": "Copy schema",
-      "description": "Bytebase supports synchronizing a schema to one or multiple target databases. (MySQL, PostgreSQL, Oracle, MSSQL, TiDB only)",
-      "generated-ddl-statement": "Generated DDL statement",
+      "copy-schema": "スキーマをコピー",
+      "description": "Bytebase は、1 つまたは複数のターゲットデータベースへのスキーマ同期をサポートしています。（MySQL、PostgreSQL、Oracle、MSSQL、TiDB のみ）",
+      "generated-ddl-statement": "生成された DDL ステートメント",
       "message": {
-        "no-diff-found": "No diff found.",
-        "no-target-databases": "No target databases",
-        "select-a-target-database-first": "Please select a target database first."
+        "no-diff-found": "差分が見つかりませんでした。",
+        "no-target-databases": "ターゲットデータベースがありません",
+        "select-a-target-database-first": "先にターゲットデータベースを選択してください。"
       },
-      "no-diff": "No diff",
-      "preview-issue": "Preview issue",
-      "schema-change": "Schema change",
-      "schema-change-preview": "Preview Schema change for '{{database}}'",
-      "select-source-schema": "Select source schema",
-      "select-target-databases": "Select target databases",
-      "source-schema": "Source schema",
-      "synchronize-statements": "Corresponding generated DDL statements",
-      "synchronize-statements-description": "You can further edit the generated DDL statements",
-      "target-databases": "Target databases",
+      "no-diff": "差分なし",
+      "preview-issue": "Issue をプレビュー",
+      "schema-change": "スキーマ変更",
+      "schema-change-preview": "'{{database}}' のスキーマ変更をプレビュー",
+      "select-source-schema": "ソーススキーマを選択",
+      "select-target-databases": "ターゲットデータベースを選択",
+      "source-schema": "ソーススキーマ",
+      "synchronize-statements": "対応する生成された DDL ステートメント",
+      "synchronize-statements-description": "生成された DDL ステートメントをさらに編集できます",
+      "target-databases": "ターゲットデータベース",
       "title": "データベーステーブルの同期",
-      "with-diff": "With diff"
+      "with-diff": "差分あり"
     },
     "sync-schema-button": "スキーマを同期",
     "sync-status": "同期ステータス",
@@ -832,29 +754,18 @@
   },
   "database-group": {
     "condition": {
-      "self": "Condition"
+      "self": "条件"
     },
-    "delete-group": "Delete the database group {{name}}",
-    "matched-database": "Matched database",
-    "no-matched-databases": "No matched databases",
-    "select": "Select database group",
-    "unmatched-database": "Unmatched database"
+    "delete-group": "データベースグループ {{name}} を削除",
+    "matched-database": "一致したデータベース",
+    "no-matched-databases": "一致するデータベースがありません",
+    "select": "データベースグループを選択",
+    "unmatched-database": "一致しないデータベース"
   },
-  "database.classification.self": "分類",
-  "database.column": "列",
-  "database.engine": "エンジン",
-  "database.export-schema": "スキーマをエクスポート",
-  "database.export-schema-multi-file": "複数ファイル (ZIP)",
-  "database.export-schema-single-file": "単一ファイル",
-  "database.failed-to-export-schema": "スキーマのエクスポートに失敗しました",
-  "database.filter-database": "フィルターデータベース",
-  "database.labels": "データベースラベル",
-  "database.revision.delete-confirm-dialog": "これにより、適用されたリビジョンが削除され、データベース スキーマは変更されません。このアクションは元に戻せません。",
-  "database.revision.self": "リビジョン",
-  "database.successfully-exported-schema": "スキーマのエクスポートに成功しました",
-  "database.sync-complete-for-instance": "インスタンス '{{0}}' の同期が完了しました",
-  "database.sync-database": "データベースを同期",
   "db": {
+    "catalog": {
+      "description": "テーブルカタログを編集してアップロードします。"
+    },
     "character-set": "文字セット",
     "collation": "照合順序",
     "collections": "コレクション",
@@ -897,11 +808,6 @@
     "triggers": "トリガー",
     "views": "ビュー"
   },
-  "db.catalog.description": "テーブルカタログを編集してアップロードします。",
-  "db.failed-to-sync-schema": "スキーマの同期に失敗しました",
-  "db.n-databases-had-sync-errors": "{{0}} 個のデータベースで同期エラーが発生しました",
-  "db.start-to-sync-schema": "スキーマの同期を開始します",
-  "db.syncing-databases-for-instance": "{{0}} のデータベースを同期中...",
   "environment": {
     "delete-description": "環境を削除すると、関連するインスタンスとデータベースからも削除されます。この操作は元に戻せません",
     "reorder": "環境の並べ替え",
@@ -921,7 +827,6 @@
     "password-info": "エクスポートされたファイルを暗号化するためのパスワードを入力します",
     "password-optional": "パスワード暗号化の設定 (オプション)"
   },
-  "export-data.password-optional": "パスワード（任意）",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "同じスキーマを持つデータベースには、データベースグループを使用すると一度の変更でまとめてマイグレーションできます。グループを一度定義すれば、毎回個別にデータベースを選択することなく、マイグレーション全体で再利用できます。",
@@ -949,7 +854,7 @@
     },
     "workflow": {
       "description": "ワークフローファイルをリポジトリにコピーして、SQL レビューとデータベースロールアウトを自動化します。",
-      "file-hint": "リポジトリ内に {{filePath}} として保存",
+      "file-hint": "リポジトリ {{repository}} 内に {{filePath}} として保存",
       "provider-not-match": "選択された ワークロード アイデンティティ は {{provider}} 専用です。",
       "self-hosted-runner": "セルフホスト runner",
       "title": "ワークフローファイル生成"
@@ -994,6 +899,7 @@
     "connection-options": "接続オプション",
     "create-gcp-credentials": "認証情報の作成方法については、を参照してください",
     "database-region": "データベース領域",
+    "default-role": "デフォルトロール",
     "endpoint": "エンドポイント",
     "external-id": "外部 ID",
     "external-id-description": "ロールを引き受ける際の追加セキュリティ用の外部 ID（オプション）",
@@ -1045,10 +951,66 @@
     "iam-extension": {
       "client-id": "Client ID",
       "client-secret": "Client Secret",
-      "credential-source": "Credential Source",
+      "credential-source": "認証情報のソース",
       "saas-default-credential-restriction": "セキュリティ上の理由により、Bytebase Cloud ではデフォルトの認証情報は使用できません。具体的な認証情報を入力してください。",
       "specific-credential": "特定の資格情報",
       "tenant-id": "Tenant ID"
+    },
+    "info": {
+      "configure-database-user": {
+        "link": "データベースユーザーを構成"
+      },
+      "connect-instance": {
+        "link": "インスタンスを接続"
+      },
+      "mongodb": {
+        "authentication": {
+          "content": "admin データベースで Bytebase 用の専用ユーザー \"{{user}}\" を作成します:"
+        },
+        "host": {
+          "content": "MongoDB サーバーのホスト名または IP アドレスを入力します。MongoDB Atlas の場合は、クラスターの接続ダイアログに表示される接続文字列のホストを使用してください。"
+        },
+        "ssh": {
+          "content": "プライベートネットワーク内の MongoDB インスタンスに接続するには SSH トンネルを使用します。これは、データベースがファイアウォールや VPC の背後にある場合に便利です。"
+        },
+        "ssl": {
+          "content": "MongoDB Atlas およびその他のクラウドホスト型 MongoDB サービスでは、デフォルトで SSL 接続が必要です。SSL を有効にし、必要に応じて CA 証明書を指定してください。"
+        }
+      },
+      "mysql": {
+        "authentication": {
+          "content": "Bytebase がデータベースを管理するための専用ユーザー \"{{user}}\" を作成します。次の SQL を実行してください:"
+        },
+        "host": {
+          "content": "MySQL サーバーのホスト名または IP アドレスを入力します。クラウドホスト型データベース (AWS RDS、Google Cloud SQL) の場合は、クラウドプロバイダーから提供されたエンドポイントを使用してください。"
+        },
+        "ssh": {
+          "content": "Bytebase から直接アクセスできないプライベートネットワーク内のデータベースに接続するには SSH トンネルを使用します。接続は bastion/jump host 経由でルーティングされます。"
+        },
+        "ssl": {
+          "content": "クラウドホスト型 MySQL データベース (AWS RDS、Google Cloud SQL、Azure Database) では通常 SSL 接続が必要です。SSL を有効にし、クラウドプロバイダーから提供された CA 証明書をアップロードしてください。"
+        }
+      },
+      "postgresql": {
+        "authentication": {
+          "content": "Bytebase がデータベースを管理するための専用ユーザー \"{{user}}\" を作成します。スーパーユーザーとして次の SQL を実行してください:"
+        },
+        "host": {
+          "content": "PostgreSQL サーバーのホスト名または IP アドレスを入力します。クラウドホスト型データベースの場合は、クラウドプロバイダーから提供されたエンドポイントを使用してください。"
+        },
+        "ssh": {
+          "content": "Bytebase から直接アクセスできないプライベートネットワーク内のデータベースに接続するには SSH トンネルを使用します。接続は bastion/jump host 経由でルーティングされます。"
+        },
+        "ssl": {
+          "content": "クラウドホスト型 PostgreSQL データベース (AWS RDS、Google Cloud SQL、Azure Database) では通常 SSL 接続が必要です。SSL を有効にし、クラウドプロバイダーから提供された CA 証明書をアップロードしてください。"
+        }
+      },
+      "ssh-tunnel": {
+        "link": "SSH トンネル"
+      },
+      "ssl-tls-connection": {
+        "link": "SSL/TLS 接続"
+      }
     },
     "info-panel": {
       "no-info": "このエンジンの追加情報はありません。"
@@ -1089,6 +1051,7 @@
       "basic-info": "基本情報",
       "connection": "接続"
     },
+    "select-database-user": "データベースユーザーの選択",
     "selected-n-instances_one": "{{count}} 個のインスタンスが選択されました",
     "selected-n-instances_other": "{{count}} 個のインスタンスが選択されました",
     "sentence": {
@@ -1173,146 +1136,6 @@
     "users": "ユーザー",
     "your-snowflake-account-locator": "Snowflake アカウント ロケーター"
   },
-  "instance.account-locator": "アカウントロケーター",
-  "instance.archive-instance-instance-name": "インスタンス '{{0}}' をアーカイブしますか?",
-  "instance.archived-instances-will-not-be-displayed": "アーカイブされたインスタンスは表示されなくなります。",
-  "instance.authentication-database": "認証データベース",
-  "instance.connection-info": "接続情報",
-  "instance.connection-options": "接続オプション",
-  "instance.create-gcp-credentials": "認証情報の作成方法については、を参照してください",
-  "instance.database-region": "データベース領域",
-  "instance.default-role": "デフォルトロール",
-  "instance.endpoint": "エンドポイント",
-  "instance.external-id": "外部 ID",
-  "instance.external-id-description": "ロールを引き受ける際の追加セキュリティ用の外部 ID（オプション）",
-  "instance.external-id-placeholder": "オプションの外部 ID",
-  "instance.external-link": "外部リンク",
-  "instance.external-secret-azure.secret-name": "シークレット名",
-  "instance.external-secret-azure.secret-name-tips": "Azure Key Vault に保存されているシークレットの名前。",
-  "instance.external-secret-azure.vault-url": "Key Vault URL",
-  "instance.external-secret-azure.vault-url-tips": "Key Vault URL は「https://myvault.vault.azure.net/」のような形式である必要があります。",
-  "instance.external-secret-gcp.secret-name": "キーのフルパス",
-  "instance.external-secret-gcp.secret-name-tips": "キーへのフルパスは、「projects/project-id/secrets/secret-id」のようなものである必要があります。",
-  "instance.external-secret-vault.vault-auth-type.approle.role-id": "認証ロールID",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-env-name": "環境変数名",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-id": "認証シークレットID",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-plain-text": "プレーンテキスト",
-  "instance.external-secret-vault.vault-auth-type.approle.self": "AppRole",
-  "instance.external-secret-vault.vault-auth-type.self": "認証タイプ",
-  "instance.external-secret-vault.vault-auth-type.token.self": "トークン",
-  "instance.external-secret-vault.vault-secret-engine-name": "シークレットエンジン名",
-  "instance.external-secret-vault.vault-secret-engine-tips": "KV v2 ストレージのみをサポートします",
-  "instance.external-secret-vault.vault-secret-key": "秘密鍵",
-  "instance.external-secret-vault.vault-secret-path": "秘密の道",
-  "instance.external-secret-vault.vault-tls-config": "Vault TLS 構成 (オプション)",
-  "instance.external-secret-vault.vault-url": "ボールトの URL",
-  "instance.external-secret.key-name": "秘密鍵",
-  "instance.external-secret.secret-name": "秘密の名前",
-  "instance.failed-to-connect-instance": "インスタンスへの接続に失敗しました。",
-  "instance.failed-to-connect-instance-localhost": "Docker デプロイメントを使用している場合は、ホスト アドレスとして「host.docker.internal」を使用してみてください。",
-  "instance.find-gcp-project-id": "GCP プロジェクト ID とインスタンス ID を表示するには、次を参照してください。",
-  "instance.find-gcp-project-id-and-instance-id": "GCP プロジェクト ID の確認方法については、次を参照してください",
-  "instance.force-archive-description": "アーカイブを強制します。すべてのデータベースの割り当てが解除されます。",
-  "instance.grants": "権限",
-  "instance.host-or-socket": "ホストまたはソケット",
-  "instance.iam-extension.client-id": "Client ID",
-  "instance.iam-extension.client-secret": "Client Secret",
-  "instance.iam-extension.credential-source": "Credential Source",
-  "instance.iam-extension.saas-default-credential-restriction": "セキュリティ上の理由により、Bytebase Cloud ではデフォルトの認証情報は使用できません。具体的な認証情報を入力してください。",
-  "instance.iam-extension.specific-credential": "特定の資格情報",
-  "instance.iam-extension.tenant-id": "Tenant ID",
-  "instance.info-panel.no-info": "このエンジンの追加情報はありません。",
-  "instance.info.configure-database-user.link": "データベースユーザーを構成",
-  "instance.info.connect-instance.link": "インスタンスを接続",
-  "instance.info.mongodb.authentication.content": "admin データベースで Bytebase 用の専用ユーザー \"{{user}}\" を作成します:",
-  "instance.info.mongodb.host.content": "MongoDB サーバーのホスト名または IP アドレスを入力します。MongoDB Atlas の場合は、クラスターの接続ダイアログに表示される接続文字列のホストを使用してください。",
-  "instance.info.mongodb.ssh.content": "プライベートネットワーク内の MongoDB インスタンスに接続するには SSH トンネルを使用します。これは、データベースがファイアウォールや VPC の背後にある場合に便利です。",
-  "instance.info.mongodb.ssl.content": "MongoDB Atlas およびその他のクラウドホスト型 MongoDB サービスでは、デフォルトで SSL 接続が必要です。SSL を有効にし、必要に応じて CA 証明書を指定してください。",
-  "instance.info.mysql.authentication.content": "Bytebase がデータベースを管理するための専用ユーザー \"{{user}}\" を作成します。次の SQL を実行してください:",
-  "instance.info.mysql.host.content": "MySQL サーバーのホスト名または IP アドレスを入力します。クラウドホスト型データベース (AWS RDS、Google Cloud SQL) の場合は、クラウドプロバイダーから提供されたエンドポイントを使用してください。",
-  "instance.info.mysql.ssh.content": "Bytebase から直接アクセスできないプライベートネットワーク内のデータベースに接続するには SSH トンネルを使用します。接続は bastion/jump host 経由でルーティングされます。",
-  "instance.info.mysql.ssl.content": "クラウドホスト型 MySQL データベース (AWS RDS、Google Cloud SQL、Azure Database) では通常 SSL 接続が必要です。SSL を有効にし、クラウドプロバイダーから提供された CA 証明書をアップロードしてください。",
-  "instance.info.postgresql.authentication.content": "Bytebase がデータベースを管理するための専用ユーザー \"{{user}}\" を作成します。スーパーユーザーとして次の SQL を実行してください:",
-  "instance.info.postgresql.host.content": "PostgreSQL サーバーのホスト名または IP アドレスを入力します。クラウドホスト型データベースの場合は、クラウドプロバイダーから提供されたエンドポイントを使用してください。",
-  "instance.info.postgresql.ssh.content": "Bytebase から直接アクセスできないプライベートネットワーク内のデータベースに接続するには SSH トンネルを使用します。接続は bastion/jump host 経由でルーティングされます。",
-  "instance.info.postgresql.ssl.content": "クラウドホスト型 PostgreSQL データベース (AWS RDS、Google Cloud SQL、Azure Database) では通常 SSL 接続が必要です。SSL を有効にし、クラウドプロバイダーから提供された CA 証明書をアップロードしてください。",
-  "instance.info.ssh-tunnel.link": "SSH トンネル",
-  "instance.info.ssl-tls-connection.link": "SSL/TLS 接続",
-  "instance.instance-id": "インスタンスID",
-  "instance.instance-name": "@:common.instance@:instance.name",
-  "instance.new-instance": "新しいインスタンス",
-  "instance.no-environment": "このインスタンスは環境にバインドされていません",
-  "instance.no-extra-params-configured": "追加の接続パラメーターは構成されていません",
-  "instance.no-params-yet-add-above": "まだ構成されていません。\n上記のフォームを使用してパラメーターを追加します。",
-  "instance.no-password": "パスワードがありません",
-  "instance.parameter-name-placeholder": "パラメーター名",
-  "instance.parameter-value-placeholder": "パラメーター値",
-  "instance.password-type.aws-iam": "AWS RDS IAM",
-  "instance.password-type.azure-iam": "Azure IAM",
-  "instance.password-type.external-secret-aws": "AWS シークレットマネージャー",
-  "instance.password-type.external-secret-azure": "Azure Key Vault",
-  "instance.password-type.external-secret-gcp": "GCP シークレット マネージャー",
-  "instance.password-type.external-secret-vault": "ボールト (KV v2)",
-  "instance.password-type.google-iam": "Google Cloud SQL IAM",
-  "instance.password-type.password": "パスワード",
-  "instance.password-write-only": "YOUR_DB_PWD - 書き込み専用",
-  "instance.port": "ポート",
-  "instance.project-id": "プロジェクトID",
-  "instance.restore-instance-instance-name-to-normal-state": "インスタンス '{{0}}' を通常の状態に復元しますか?",
-  "instance.role-arn": "ロール ARN",
-  "instance.role-arn-description": "クロスアカウントアクセス用の IAM ロール。同一アカウントアクセスの場合は空のままにしてください。",
-  "instance.role-arn-placeholder": "arn:aws:iam::123456789012:role/CrossAccountRole",
-  "instance.scan-interval.default-never": "デフォルト (なし)",
-  "instance.scan-interval.description": "Bytebase は定期的にインスタンスのスキーマを同期し、異常検出を実行します。",
-  "instance.scan-interval.min-value": "最短 {{value}} 分",
-  "instance.scan-interval.self": "スキャン間隔",
-  "instance.section.basic-info": "基本情報",
-  "instance.section.connection": "接続",
-  "instance.select-database-user": "データベースユーザーの選択",
-  "instance.sentence.aws-rds.mysql.template": "以下は、ユーザー {{user}}@% を作成し、そのユーザーに必要な権限を付与する例です。",
-  "instance.sentence.aws-rds.postgresql.template": "以下は、ユーザー '{{user}}' を作成し、そのユーザーに必要な権限を付与する例です。",
-  "instance.sentence.console.snowflake": "この インスタンス を管理する外部コンソール URL (AWS RDS コンソール、データベース コンソールなど)",
-  "instance.sentence.create-admin-user": "これは、データベースに接続し、DDL および DML (非 SELECT) 操作を実行するために Bytebase によって使用されるユーザーです。",
-  "instance.sentence.create-admin-user-non-sql": "これは、データベースに接続し、書き込みおよび管理操作を実行するために Bytebase によって使用されるユーザーです。",
-  "instance.sentence.create-readonly-user": "これは、データベースに接続し、SELECT などの読み取り専用操作を実行するために Bytebase によって使用されるユーザーです。",
-  "instance.sentence.create-readonly-user-non-sql": "これは、データベースに接続して読み取り専用操作を実行するために Bytebase によって使用されるユーザーです。",
-  "instance.sentence.create-user-example.clickhouse.sql-driven-workflow": "SQLワークフロー",
-  "instance.sentence.create-user-example.clickhouse.template": "ユーザー {{user}}、パスワード {{password}} を作成し、必要な権限を付与する例は次のとおりです。次のコマンドを実行してユーザーを作成する前に、{{link}} を有効にする必要があります。",
-  "instance.sentence.create-user-example.mysql.template": "ユーザー {{user}}、パスワード {{password}} を作成し、必要な権限を付与する例は次のとおりです。",
-  "instance.sentence.create-user-example.postgresql.template": "ユーザー {{user}}、パスワード {{password}} を作成し、必要な権限を付与する例は次のとおりです。接続しているインスタンスが自己ホスト型の場合は、SUPERUSER を付与できます。",
-  "instance.sentence.create-user-example.postgresql.warn": "接続しているインスタンスがクラウド サービス プロバイダーによって管理されている場合、SUPERUSER は使用できないため、プロバイダーの管理者コンソールを通じてユーザーを作成する必要があります。作成したユーザーには、ベンダー固有の準 SUPERUSER 権限が与えられます。 「GRANT role_name TO bytebase;」ステートメントを使用して、すべてのロールに Bytebase 権限を付与する必要があります。そうしないと、Bytebase に既存のデータベースまたはテーブルを操作する権限がない可能性があり、操作が失敗します。",
-  "instance.sentence.create-user-example.redis.template": "ユーザー {{user}}、パスワード {{password}} を作成し、必要な権限を付与する例は次のとおりです。",
-  "instance.sentence.create-user-example.snowflake.template": "ユーザー {{user}}、パスワード {{password}}、ウェアハウス {{warehouse}} を作成し、必要な権限を付与する例は次のとおりです。",
-  "instance.sentence.firewall-info": "データベースインスタンスにインバウンドファイアウォールルールを使用する場合は、ByteBase Cloud Connection命令を参照してください。",
-  "instance.sentence.google-cloud-sql.instance-name": "インスタンス接続名",
-  "instance.sentence.google-cloud-sql.instance-name-tips": "インスタンス接続名は {{instance}} である必要があります。",
-  "instance.sentence.google-cloud-sql.mysql.template": "{{user}} という名前のサービス アカウントを作成し、IAM ユーザー {{user}}@'%' として Google Cloud SQL に追加します。このユーザーに必要な権限を付与します。",
-  "instance.sentence.google-cloud-sql.postgresql.template": "{{user}} という名前のサービス アカウントを作成し、IAM ユーザー {{user}}@project-id.iam として Google Cloud SQL に追加します。ユーザーに必要な権限を付与します。",
-  "instance.sentence.host.none-snowflake": "たとえば、host.docker.internal | host ip | local socket",
-  "instance.sentence.proxy.snowflake": "プロキシ サーバーの場合は、@PROXY_HOST を追加し、ポートに PROXY_PORT を指定します。",
-  "instance.show-how-to-create": "作成方法",
-  "instance.snowflake-web-console": "スノーフレークウェブコンソール",
-  "instance.successfully-archived-instance": "インスタンス '{{0}}' を正常にアーカイブしました。",
-  "instance.successfully-connected-instance": "インスタンスに正常に接続されました。",
-  "instance.successfully-created-instance-createdinstance-name": "インスタンス '{{0}}' が正常に作成されました。",
-  "instance.successfully-restored-instance": "インスタンス '{{0}}' を正常に復元しました。",
-  "instance.successfully-updated-instance-instance-name": "インスタンス '{{0}}' が正常に更新されました。",
-  "instance.sync-databases.add-database": "+ データベースを追加し、Enterキーを押して送信します",
-  "instance.sync-databases.description": "選択したデータベースのみを同期します。",
-  "instance.sync-databases.search-database": "データベースを検索",
-  "instance.sync-databases.self": "データベースを同期する",
-  "instance.sync-databases.sync-all": "すべてのデータベースを同期する",
-  "instance.sync.self": "インスタンスの同期",
-  "instance.sync.sync-all": "すべてのデータベースを同期する",
-  "instance.sync.sync-all-tip": "データベースの同期は非同期で、数秒から数分かかる場合があります。",
-  "instance.sync.sync-new": "新しいデータベースのみを同期する",
-  "instance.syncing": "同期中 ...",
-  "instance.test-connection": "テスト接続",
-  "instance.testing-connection": "接続をテスト中",
-  "instance.type-or-paste-credentials-write-only": "資格情報を入力または貼り付けます - 書き込みのみ",
-  "instance.unable-to-connect": "Bytebase はインスタンスに接続できません。接続情報を再度確認することをお勧めします。ただし、今のところこの警告は無視してかまいません。作成後もインスタンスの詳細ページで接続情報を修正できます。\n\nエラーの詳細:{{0}}",
-  "instance.users": "ユーザー",
-  "instance.your-snowflake-account-locator": "Snowflake アカウント ロケーター",
   "issue": {
     "access-grant": {
       "advanced-search": {
@@ -1322,9 +1145,10 @@
           }
         }
       },
-      "details": "Access Grant Details",
-      "expired-at": "Expired at"
+      "details": "アクセス付与の詳細",
+      "expired-at": "有効期限"
     },
+    "action-anyway": "まだ {{action}} が必要です",
     "advanced-search": {
       "filter": "フィルター",
       "scope": {
@@ -1367,13 +1191,13 @@
           "title": "イシューラベル"
         },
         "issue-type": {
-          "description": "Filter by issue type",
-          "title": "Type",
+          "description": "Issue タイプでフィルター",
+          "title": "タイプ",
           "value": {
-            "access-grant": "Access Grant",
-            "database-change": "Database Change",
-            "database-export": "Database Export",
-            "role-grant": "Role Grant"
+            "access-grant": "アクセス付与",
+            "database-change": "データベース変更",
+            "database-export": "データベースエクスポート",
+            "role-grant": "ロール付与"
           }
         },
         "label": {
@@ -1408,6 +1232,20 @@
       "reopened": "再開"
     },
     "checks-manual-rollout-hint": "承認は完了しましたが、このプランにはまだチェックエラーがあるため、ロールアウトは自動作成されていません。Plan に移動して続行してください。",
+    "checks-warning-hint": "一部のチェックが未通過です。想定どおりの場合のみ続行してください。",
+    "comment-editor": {
+      "nothing-to-preview": "プレビューする内容がありません",
+      "preview": "プレビュー",
+      "toolbar": {
+        "bold": "太字テキストを挿入",
+        "code": "SQL コードスニペットを挿入",
+        "hashtag": "ハッシュタグを挿入",
+        "header": "見出しテキストを挿入",
+        "link": "リンクを挿入"
+      },
+      "write": "作成"
+    },
+    "create-rollout": "ロールアウトを作成",
     "data-export": {
       "download-tooltip": "24 時間利用可能",
       "file-expired": "ファイルの有効期限が切れました",
@@ -1415,8 +1253,13 @@
       "limits": "制限",
       "options": "設定項目"
     },
+    "issue-name": "イシュー名",
     "labels": "イシューラベル",
     "leave-a-comment": "コメントを残す…",
+    "my-issues": "自分の Issue",
+    "no-description-provided": "説明なし",
+    "options-disabled-due-to-oversize": "SQL が大きすぎるため、オプションは無効になっています。",
+    "overwrite-current-statement": "現在の SQL ステートメントを上書きする",
     "review": {
       "approve-description": "フィードバックを送信してこのイシューを承認する",
       "comment-description": "承認なしで一般的なフィードバックを送信する",
@@ -1433,8 +1276,8 @@
     "role-grant": {
       "all-databases": "すべてのデータベース",
       "all-databases-tip": "このプロジェクトに属する現在および将来のすべてのデータベース。",
-      "details": "Role Grant Details",
-      "expired-at": "Expired at",
+      "details": "ロール付与の詳細",
+      "expired-at": "有効期限",
       "manually-select": "手動選択",
       "use-cel": "CEL式を使用"
     },
@@ -1445,6 +1288,7 @@
       "sort": "並べ替え",
       "updated": "更新日時"
     },
+    "statement-from-sheet-warning": "このステートメントは大きなシートから読み込まれています。プレビューは切り詰められる場合があります。",
     "status-transition": {
       "modal": {
         "close": "イシューを閉じますか?",
@@ -1453,14 +1297,18 @@
     },
     "subtitle": "イシューには、データベースの変更、データのエクスポート、アクセス要求が含まれます。実行前に確認と承認が必要です。",
     "table": {
-      "approval-progress": "{{approved}}/{{total}} Approvals",
-      "approved": "Approved",
+      "approval-progress": "{{approved}}/{{total}} 件承認",
+      "approved": "承認済み",
       "closed": "クローズ　",
       "creator": "作成者",
       "name": "名前",
       "open": "オープン",
       "updated": "更新日時",
-      "waiting-role": "Waiting: {{role}}"
+      "waiting-role": "待機中: {{role}}"
+    },
+    "task-run": {
+      "logs": "ログ",
+      "session": "セッション"
     },
     "title": {
       "change-database": "データベースの変更",
@@ -1469,34 +1317,13 @@
       "request-role": "ロールをリクエスト",
       "request-specific-role": "「{{role}}」ロールをリクエスト"
     },
-    "upload-sql": "Upload SQL",
+    "transaction-mode": {
+      "label": "トランザクションモード"
+    },
+    "upload-sql": "SQL をアップロード",
+    "upload-sql-file-max-size-exceeded": "アップロード ファイルのサイズは {{size}} を超えることはできません。",
     "waiting-approval": "承認待ち"
   },
-  "issue.action-anyway": "まだ {{action}} が必要です",
-  "issue.checks-warning-hint": "一部のチェックが未通過です。想定どおりの場合のみ続行してください。",
-  "issue.comment-editor.nothing-to-preview": "Nothing to preview",
-  "issue.comment-editor.preview": "Preview",
-  "issue.comment-editor.toolbar.bold": "Insert bold text",
-  "issue.comment-editor.toolbar.code": "Insert SQL code snippet",
-  "issue.comment-editor.toolbar.hashtag": "Insert hashtag",
-  "issue.comment-editor.toolbar.header": "Insert heading text",
-  "issue.comment-editor.toolbar.link": "Insert a link",
-  "issue.comment-editor.write": "Write",
-  "issue.create-rollout": "ロールアウトを作成",
-  "issue.data-export.format": "形式",
-  "issue.data-export.limits": "制限",
-  "issue.data-export.options": "オプション",
-  "issue.issue-name": "イシュー名",
-  "issue.my-issues": "自分の Issue",
-  "issue.no-description-provided": "説明なし",
-  "issue.options-disabled-due-to-oversize": "SQL が大きすぎるため、オプションは無効になっています。",
-  "issue.overwrite-current-statement": "現在の SQL ステートメントを上書きする",
-  "issue.review.self": "Review",
-  "issue.statement-from-sheet-warning": "This statement is loaded from a large sheet. Preview may be truncated.",
-  "issue.task-run.logs": "ログ",
-  "issue.task-run.session": "セッション",
-  "issue.transaction-mode.label": "トランザクションモード",
-  "issue.upload-sql-file-max-size-exceeded": "アップロード ファイルのサイズは {{size}} を超えることはできません。",
   "label": {
     "add-label": "タグ付けする",
     "empty-label-value": "ヌル",
@@ -1507,12 +1334,6 @@
       "value-necessary": "値を指定する必要があります"
     }
   },
-  "label.add-label": "タグ付けする",
-  "label.empty-label-value": "ヌル",
-  "label.error.key-duplicated": "キーが繰り返されました",
-  "label.error.key-necessary": "キーを指定する必要があります",
-  "label.error.max-value-length-exceeded": "値は {{length}} 文字を超えることはできません",
-  "label.error.value-necessary": "値を指定する必要があります",
   "landing": {
     "changelog-for-version": "{{version}} の変更履歴",
     "last-visit": "最終訪問",
@@ -1561,91 +1382,114 @@
     }
   },
   "plan": {
+    "add-spec": "変更を追加",
+    "add-spec-pending-draft": "新しい変更を追加する前に、保留中の変更を保存または破棄してください",
     "checks": {
-      "self": "チェック"
+      "completed": "プランチェックが完了しました",
+      "failed-to-run": "プランチェックの実行に失敗しました",
+      "no-check-results": "チェック結果はありません",
+      "no-results-match-filters": "フィルターに一致する結果はありません",
+      "self": "チェック",
+      "started": "プランチェックを開始しました"
     },
     "create-plan": "プランを作成",
+    "description": {
+      "placeholder": "説明を追加"
+    },
     "editor": {
       "save-changes-before-continuing": "続行する前に変更を保存またはキャンセルしてください"
     },
+    "ghost": {
+      "requirements-not-met": "次のデータベースは Ghost の要件を満たしていません: {{databases}}"
+    },
+    "go-to-plan-page": "プランページへ移動",
+    "isolation-level": {
+      "read-committed": "コミット済み読み取り",
+      "read-uncommitted": "未コミット読み取り",
+      "repeatable-read": "反復可能読み取り",
+      "self": "分離レベル",
+      "serializable": "直列化可能"
+    },
+    "labels-required-for-review": "レビュー前にラベルが必要です",
     "meta": {
       "created-by-at": "{{user}} が作成 · {{time}}"
     },
     "navigator": {
       "changes": "変更点",
+      "checks": "チェック",
       "deploy": "デプロイ",
-      "review": "レビュー"
+      "review": "レビュー",
+      "statement-empty": "ステートメントが空です"
     },
     "new-plan": "プランの作成",
+    "options": {
+      "no-options-available": "利用可能なオプションはありません",
+      "self": "オプション"
+    },
+    "overview": {
+      "no-checks": "チェックなし"
+    },
+    "phase": {
+      "create-rollout-action": "手動でロールアウトを作成",
+      "deploy-approval-must-complete": "承認フローが完了している必要があります。",
+      "deploy-approval-optional": "現在のプロジェクト設定では、承認フローをスキップできます。",
+      "deploy-approval-pending": "ロールアウトを自動的に進める前に承認フローを完了してください。",
+      "deploy-approval-ready": "このプランの承認は完了しています。",
+      "deploy-checks-blocked": "失敗したチェックによりロールアウトの自動作成が止まっています。",
+      "deploy-checks-must-pass": "チェックに合格する必要があります。",
+      "deploy-checks-optional": "このプロジェクトでは、チェック失敗は手動ロールアウトを妨げません。",
+      "deploy-checks-ready": "チェックはロールアウトの自動作成が可能な状態です。",
+      "deploy-checks-running": "実行中のチェックが終わるまで、ロールアウトの自動作成は続行されません。",
+      "deploy-description": "すべてのチェックが通過し、Issue が承認されると、Bytebase は自動的にロールアウトを作成します。",
+      "deploy-description-gitops": "このプランはロールアウトの準備ができています。リンクされたリリースをデプロイするにはロールアウトを作成してください。",
+      "deploy-manual-create-description": "現在のプロジェクト設定に応じて、ロールアウトを手動で作成することもできます。",
+      "deploy-manual-create-description-readonly": "Create Rollout 権限を持つユーザーがロールアウトを手動で作成できます。",
+      "hide-details": "詳細を隠す",
+      "review-description": "続行するにはレビューに提出してください",
+      "show-details": "詳細を表示"
+    },
     "plans": "プラン",
+    "pre-backup": {
+      "requirements-not-met": "次のデータベースは事前バックアップ要件を満たしていません: {{databases}}"
+    },
+    "ready-for-review": "レビュー準備完了",
+    "run": "再チェック",
+    "select-isolation-level": "分離レベルを選択",
+    "select-targets": "対象を選択",
+    "spec": {
+      "change": "変更",
+      "type": {
+        "database-change": "データベース変更"
+      }
+    },
+    "state": {
+      "close-confirm": "このプランを閉じますか？",
+      "reopen-confirm": "このプランを再開きますか？"
+    },
     "subtitle": "承認のためにイシューを作成する前に、データベースの変更を下書きし、事前チェックを実行します。",
+    "summary": {
+      "last-approved-by": "{{name}} が最後に承認",
+      "n-changes": "{{n}} 件の変更",
+      "n-database-groups": "{{n}} 個のデータベースグループ",
+      "n-databases": "{{n}} 個のデータベース",
+      "n-error": "{{n}} 件のエラー",
+      "n-of-m-approved": "{{m}} 件中 {{n}} 件承認済み",
+      "n-of-m-tasks": "{{n}}/{{m}} タスク",
+      "n-passed": "{{n}} 件合格",
+      "n-warning": "{{n}} 件の警告"
+    },
     "targets": {
-      "title": "ターゲット"
-    }
+      "no-targets-found": "対象が見つかりません",
+      "non-env-warning": {
+        "one": "有効な環境がないため、{{count}} 件のデータベースはロールアウトから除外されます:",
+        "other": "有効な環境がないため、{{count}} 件のデータベースはロールアウトから除外されます:"
+      },
+      "title": "ターゲット",
+      "view-all": "すべて表示 ({{count}})"
+    },
+    "title-required": "タイトルは必須です",
+    "view-discussion": "ディスカッションを見る"
   },
-  "plan.add-spec": "変更を追加",
-  "plan.add-spec-pending-draft": "新しい変更を追加する前に、保留中の変更を保存または破棄してください",
-  "plan.checks.completed": "プランチェックが完了しました",
-  "plan.checks.failed-to-run": "プランチェックの実行に失敗しました",
-  "plan.checks.no-check-results": "チェック結果はありません",
-  "plan.checks.no-results-match-filters": "フィルターに一致する結果はありません",
-  "plan.checks.started": "プランチェックを開始しました",
-  "plan.description.placeholder": "説明を追加",
-  "plan.ghost.requirements-not-met": "次のデータベースは Ghost の要件を満たしていません: {{databases}}",
-  "plan.go-to-plan-page": "プランページへ移動",
-  "plan.isolation-level.read-committed": "コミット済み読み取り",
-  "plan.isolation-level.read-uncommitted": "未コミット読み取り",
-  "plan.isolation-level.repeatable-read": "反復可能読み取り",
-  "plan.isolation-level.self": "分離レベル",
-  "plan.isolation-level.serializable": "直列化可能",
-  "plan.labels-required-for-review": "レビュー前にラベルが必要です",
-  "plan.navigator.checks": "チェック",
-  "plan.navigator.statement-empty": "ステートメントが空です",
-  "plan.options.no-options-available": "利用可能なオプションはありません",
-  "plan.options.self": "オプション",
-  "plan.overview.no-checks": "チェックなし",
-  "plan.phase.create-rollout-action": "手動でロールアウトを作成",
-  "plan.phase.deploy-approval-must-complete": "承認フローが完了している必要があります。",
-  "plan.phase.deploy-approval-optional": "現在のプロジェクト設定では、承認フローをスキップできます。",
-  "plan.phase.deploy-approval-pending": "ロールアウトを自動的に進める前に承認フローを完了してください。",
-  "plan.phase.deploy-approval-ready": "このプランの承認は完了しています。",
-  "plan.phase.deploy-checks-blocked": "失敗したチェックによりロールアウトの自動作成が止まっています。",
-  "plan.phase.deploy-checks-must-pass": "チェックに合格する必要があります。",
-  "plan.phase.deploy-checks-optional": "このプロジェクトでは、チェック失敗は手動ロールアウトを妨げません。",
-  "plan.phase.deploy-checks-ready": "チェックはロールアウトの自動作成が可能な状態です。",
-  "plan.phase.deploy-checks-running": "実行中のチェックが終わるまで、ロールアウトの自動作成は続行されません。",
-  "plan.phase.deploy-description": "すべてのチェックが通過し、Issue が承認されると、Bytebase は自動的にロールアウトを作成します。",
-  "plan.phase.deploy-description-gitops": "このプランはロールアウトの準備ができています。リンクされたリリースをデプロイするにはロールアウトを作成してください。",
-  "plan.phase.deploy-manual-create-description": "現在のプロジェクト設定に応じて、ロールアウトを手動で作成することもできます。",
-  "plan.phase.deploy-manual-create-description-readonly": "Create Rollout 権限を持つユーザーがロールアウトを手動で作成できます。",
-  "plan.phase.hide-details": "詳細を隠す",
-  "plan.phase.review-description": "続行するにはレビューに提出してください",
-  "plan.phase.show-details": "詳細を表示",
-  "plan.pre-backup.requirements-not-met": "次のデータベースは事前バックアップ要件を満たしていません: {{databases}}",
-  "plan.ready-for-review": "レビュー準備完了",
-  "plan.run": "再チェック",
-  "plan.select-isolation-level": "分離レベルを選択",
-  "plan.select-targets": "対象を選択",
-  "plan.spec.change": "変更",
-  "plan.spec.type.database-change": "データベース変更",
-  "plan.state.close-confirm": "このプランを閉じますか？",
-  "plan.state.reopen-confirm": "このプランを再開きますか？",
-  "plan.summary.last-approved-by": "{{name}} が最後に承認",
-  "plan.summary.n-changes": "{{n}} 件の変更",
-  "plan.summary.n-database-groups": "{{n}} 個のデータベースグループ",
-  "plan.summary.n-databases": "{{n}} 個のデータベース",
-  "plan.summary.n-error": "{{n}} 件のエラー",
-  "plan.summary.n-of-m-approved": "{{m}} 件中 {{n}} 件承認済み",
-  "plan.summary.n-of-m-tasks": "{{n}}/{{m}} タスク",
-  "plan.summary.n-passed": "{{n}} 件合格",
-  "plan.summary.n-warning": "{{n}} 件の警告",
-  "plan.targets.no-targets-found": "対象が見つかりません",
-  "plan.targets.non-env-warning.one": "有効な環境がないため、{{count}} 件のデータベースはロールアウトから除外されます:",
-  "plan.targets.non-env-warning.other": "有効な環境がないため、{{count}} 件のデータベースはロールアウトから除外されます:",
-  "plan.targets.title": "対象",
-  "plan.targets.view-all": "すべて表示 ({{count}})",
-  "plan.title-required": "タイトルは必須です",
-  "plan.view-discussion": "ディスカッションを見る",
   "plugin": {
     "ai": {
       "actions": {
@@ -1745,7 +1589,7 @@
       "ddl-warning": "選択した環境では、{{kind}} ステートメントを SQL エディターで承認なしに直接実行できます。",
       "description": "プロジェクトメンバーのロールにより、プロジェクト内のデータベースとイシューを操作するための権限が決まります。プロジェクト所有者、ワークスペース管理者、および DBA はすべて、プロジェクトに対する完全な権限を持っています。",
       "edit-member": "メンバー編集 - {{member}}",
-      "never-expires": "Never",
+      "never-expires": "なし",
       "request-role": {
         "disabled-reason": {
           "allow-request-role-disabled": "このプロジェクトではロール申請が無効になっています。",
@@ -1766,9 +1610,10 @@
     "overview": {
       "info-slot-content": "Bytebase はインスタンスのスキーマを定期的に同期します。新しく同期されたデータベースは最初にここに配置され、その後、それらを適切なプロジェクトに転送できます。"
     },
+    "select": "プロジェクトを選択",
     "settings": {
-      "confirm-archive-project": "Archiving \"{{name}}\" will make it read-only and hide it from active project lists. All issues, databases, and settings will be preserved. You can restore it later from the archived projects list.",
-      "confirm-delete-project": "Deleting \"{{name}}\" will permanently remove the project and all associated data including issues, configurations, and history. All databases in this project will be moved to the default project. This action cannot be undone.",
+      "confirm-archive-project": "\"{{name}}\" をアーカイブすると、読み取り専用になり、アクティブなプロジェクト一覧から非表示になります。すべての Issue、データベース、設定は保持されます。後でアーカイブ済みプロジェクト一覧から復元できます。",
+      "confirm-delete-project": "\"{{name}}\" を削除すると、Issue、設定、履歴を含むプロジェクトとそれに関連するすべてのデータが完全に削除されます。このプロジェクト内のすべてのデータベースはデフォルトプロジェクトに移動されます。この操作は元に戻せません。",
       "issue-related": {
         "allow-jit": {
           "description": "有効にすると、ユーザーは SQL エディタでジャストインタイムアクセスをリクエストして使用できます。",
@@ -1871,14 +1716,12 @@
       "webhook-url": "Webhook URL"
     }
   },
-  "project.select": "プロジェクトを選択",
   "quick-action": {
     "create-db": "データベースの作成",
+    "create-project": "プロジェクトを作成",
     "new-project": "作成するプロジェクト",
     "request-export-data": "データ出力を申請する"
   },
-  "quick-action.create-project": "Create project",
-  "quick-action.new-project": "作成するプロジェクト",
   "quick-start": {
     "guide": "クリックしてステップを試してみましょう",
     "notice": {
@@ -1886,6 +1729,7 @@
       "title": "クイックスタートガイドを終了しました"
     },
     "query-data": "クエリデータ",
+    "self": "クイックスタート",
     "view-an-issue": "イシューを表示する",
     "visit-database": "データベースにアクセスする",
     "visit-environment": "環境にアクセスする",
@@ -1893,26 +1737,25 @@
     "visit-member": "メンバー | メンバーにアクセスする",
     "visit-project": "プロジェクトにアクセスする"
   },
-  "quick-start.self": "Quick Start",
   "release": {
-    "and-n-more-files": "and {{count}} more files",
-    "change-tip": "This change is linked to a release artifact.",
+    "and-n-more-files": "他 {{count}} 件のファイル",
+    "change-tip": "この変更はリリースアーティファクトにリンクされています。",
     "file": "リリースファイル",
     "file-type": {
-      "declarative": "Declarative",
-      "unspecified": "Unspecified",
-      "versioned": "Versioned"
+      "declarative": "宣言的",
+      "unspecified": "未指定",
+      "versioned": "バージョン管理"
     },
     "files": "ファイル",
-    "not-found": "Release not found",
+    "not-found": "リリースが見つかりません",
     "releases": "リリース",
     "total-files": "合計 {{}} ファイル",
     "usage-description": "リリースは、GitOpsワークフローによって環境へのデプロイがトリガーされるバージョン管理されたアプリケーションアーティファクトです。",
-    "vcs-source": "VCS Source",
+    "vcs-source": "VCS ソース",
     "vcs-type": {
-      "unspecified": "Unknown VCS"
+      "unspecified": "不明な VCS"
     },
-    "view-all-files": "View all files"
+    "view-all-files": "すべてのファイルを表示"
   },
   "remind": {
     "role-expire": {
@@ -1938,13 +1781,6 @@
       "pattern": "{{resource}} ID には、小文字、数字、またはハイフンを持つことができます。\n小文字から始めて、文字または番号で終わる必要があります。"
     }
   },
-  "resource-id.cannot-be-changed-later": "作成後に変更することはできません。",
-  "resource-id.description": "{{resource}} ID は一意の識別子です。作成後に変更することはできません。",
-  "resource-id.self": "{{resource}} ID",
-  "resource-id.validation.duplicated": "{{resource}} ID はすでに存在します。別のIDを使用してください。",
-  "resource-id.validation.empty": "{{resource}} ID は空にできません",
-  "resource-id.validation.overflow": "{{resource}} ID は 64 文字未満である必要があります。",
-  "resource-id.validation.pattern": "{{resource}} ID には、小文字、数字、またはハイフンを持つことができます。\n小文字から始めて、文字または番号で終わる必要があります。",
   "role": {
     "custom-roles": {
       "self": "カスタムロール"
@@ -1966,6 +1802,7 @@
     }
   },
   "rollout": {
+    "bypass-stage-requirements": "警告をバイパス",
     "no-stages": "利用可能なステージはありません",
     "no-tasks-created": "まだタスクが作成されていません",
     "pending-tasks-preview": {
@@ -1982,47 +1819,48 @@
       "self_one": "ステージ",
       "self_other": "ステージ"
     },
+    "task": {
+      "no-tasks": "このステージにはタスクがありません",
+      "selected-count": "{{count}} 件のタスクを選択中",
+      "statement-truncated-hint": "サイズが大きいため、ステートメントは切り捨てられました。"
+    },
     "task-execution-errors": "タスク実行エラー"
   },
-  "rollout.bypass-stage-requirements": "警告をバイパス",
-  "rollout.task.no-tasks": "このステージにはタスクがありません",
-  "rollout.task.selected-count": "{{count}} 件のタスクを選択中",
-  "rollout.task.statement-truncated-hint": "サイズが大きいため、ステートメントは切り捨てられました。",
   "schema-diagram": {
     "fit-content-with-view": "ビューに自動的に適応します",
     "self": "スキーマ図"
   },
   "schema-editor": {
     "actions": {
-      "add-column": "Add column",
-      "add-index": "Add index",
-      "add-partition": "Add partition",
-      "create-function": "Create function",
-      "create-procedure": "Create procedure",
-      "create-schema": "Create schema",
-      "create-table": "New table",
-      "create-view": "Create view",
-      "drop": "Drop",
-      "drop-schema": "Drop schema",
-      "drop-table": "Drop table",
-      "rename": "Rename",
-      "rename-table": "Rename table",
-      "restore": "Restore"
+      "add-column": "カラムを追加",
+      "add-index": "インデックスを追加",
+      "add-partition": "パーティションを追加",
+      "create-function": "関数を作成",
+      "create-procedure": "プロシージャを作成",
+      "create-schema": "スキーマを作成",
+      "create-table": "新規テーブル",
+      "create-view": "ビューを作成",
+      "drop": "ドロップ",
+      "drop-schema": "スキーマをドロップ",
+      "drop-table": "テーブルをドロップ",
+      "rename": "名前変更",
+      "rename-table": "テーブルの名前変更",
+      "restore": "復元"
     },
     "column": {
-      "comment": "Comment",
-      "default": "Default",
+      "comment": "コメント",
+      "default": "デフォルト",
       "foreign-key": "外部キー",
-      "name": "Name",
+      "name": "名前",
       "name-placeholder": "カラム名",
-      "not-null": "Not Null",
+      "not-null": "NOT NULL",
       "on-update": "アップデート時",
-      "operations": "Operations",
-      "primary": "Primary",
-      "type": "Type"
+      "operations": "操作",
+      "primary": "主キー",
+      "type": "型"
     },
-    "columns": "Columns",
-    "create-foreign-key": "Create Foreign Key",
+    "columns": "カラム",
+    "create-foreign-key": "外部キーを作成",
     "database": {
       "collation": "文字の並べ替え規則",
       "comment": "コメント",
@@ -2032,43 +1870,43 @@
     "default": {
       "placeholder": "デフォルト値を入力するか、デフォルト値がない場合は空白のままにします"
     },
-    "edit-foreign-key": "Edit Foreign Key",
+    "edit-foreign-key": "外部キーを編集",
     "foreign-key": {
-      "name": "Foreign Key Name",
-      "referenced-column": "Referenced Column",
-      "referenced-schema": "Referenced Schema",
-      "referenced-table": "Referenced Table"
+      "name": "外部キー名",
+      "referenced-column": "参照先カラム",
+      "referenced-schema": "参照先スキーマ",
+      "referenced-table": "参照先テーブル"
     },
     "index": {
-      "columns": "Columns",
+      "columns": "カラム",
       "dependency-columns": "従属列",
       "indexes": "索引",
-      "primary": "Primary",
-      "unique": "Unique"
+      "primary": "主キー",
+      "unique": "一意"
     },
-    "indexes": "Indexes",
+    "indexes": "インデックス",
     "insert-sql": "SQL を挿入",
     "no-diff": "適用する変更はありません",
     "partition": {
-      "expression": "Expression",
-      "type": "Type",
-      "value": "Value"
+      "expression": "式",
+      "type": "型",
+      "value": "値"
     },
-    "partitions": "Partitions",
-    "preview": "Preview",
-    "raw-sql": "Raw SQL",
+    "partitions": "パーティション",
+    "preview": "プレビュー",
+    "raw-sql": "生 SQL",
     "schema": {
-      "duplicate-name": "Schema name already exists",
-      "name-placeholder": "Schema name",
+      "duplicate-name": "スキーマ名は既に存在します",
+      "name-placeholder": "スキーマ名",
       "select": "スキーマの選択"
     },
     "select-object-hint": "編集するデータベースオブジェクトをツリーから選択してください",
     "self": "スキーマエディタ",
     "table": {
-      "duplicate-name": "Table name already exists",
-      "name-placeholder": "Table name",
-      "no-match": "No tables match the search",
-      "no-tables": "No tables"
+      "duplicate-name": "テーブル名は既に存在します",
+      "name-placeholder": "テーブル名",
+      "no-match": "検索に一致するテーブルがありません",
+      "no-tables": "テーブルがありません"
     },
     "table-partition": {
       "expression": "表現",
@@ -2093,16 +1931,14 @@
       "value-placeholder": "タグ値…"
     }
   },
-  "setting.label.key-placeholder": "タグキー...",
-  "setting.label.value-placeholder": "タグ値…",
   "settings": {
     "general": {
       "workspace": {
         "access-token-duration": {
-          "description": "How long access tokens remain valid before requiring refresh. Shorter durations improve security.",
-          "hours": "Hour(s)",
-          "minutes": "Minute(s)",
-          "self": "Access token duration"
+          "description": "アクセストークンが更新を必要とするまで有効な期間です。期間を短くするとセキュリティが向上します。",
+          "hours": "時間",
+          "minutes": "分",
+          "self": "アクセストークンの有効期間"
         },
         "account": "アカウント",
         "ai-assistant": {
@@ -2185,6 +2021,7 @@
         "default-landing-page": {
           "default-view-changed-to-sql-editor": "ワークスペースのデフォルト ビューが SQL エディターに変更されました。",
           "go-to-sql-editor": "SQLエディタに移動",
+          "go-to-workspace": "ワークスペースへ移動",
           "self": "デフォルトのランディングページ",
           "sql-editor": {
             "description": "SQL エディターを使用してデータベースの変更を直接実行します。これは、1 人で使用する場合や、監視を必要としない環境に適しています。",
@@ -2280,10 +2117,10 @@
           }
         },
         "refresh-token-duration": {
-          "days": "Day(s)",
-          "description": "How often users must fully reauthenticate. Configuration updates require users to sign in again for changes to take effect.",
-          "hours": "Hour(s)",
-          "self": "Refresh token duration"
+          "days": "日",
+          "description": "ユーザーが完全に再認証を行う必要がある頻度です。設定の更新を反映するには、ユーザーは再度サインインする必要があります。",
+          "hours": "時間",
+          "self": "リフレッシュトークンの有効期間"
         },
         "require-2fa": {
           "description": "有効にすると、2 要素認証が設定されていないユーザーは強制的に設定されます。",
@@ -2331,22 +2168,22 @@
       },
       "add-member": "メンバーを追加",
       "all-users": "すべてのユーザー",
-      "assign-role": "Assign role",
-      "cannot-revoke-self": "You cannot revoke yourself",
+      "assign-role": "ロールを割り当て",
+      "cannot-revoke-self": "自分自身を取り消すことはできません",
       "copy-service-key": "サービスキーをコピーする",
       "entra-sync": {
         "description": "Entra ID (旧 Azure AD) または Okta のユーザーとグループを Bytebase インスタンスに同期します。",
-        "endpoint": "Endpoint",
+        "endpoint": "エンドポイント",
         "endpoint-tip": "ユーザーとグループはこのエンドポイントを介して Bytebase に同期されます。",
         "reset-token": "トークンをリセット",
         "reset-token-warning": "Entra アプリケーションのプロビジョニング設定を更新する必要があります。",
-        "secret-token": "Secret Token",
+        "secret-token": "シークレットトークン",
         "secret-token-tip": "エンドポイントの検証トークンです。秘密にしてください。",
         "self": "SCIM から同期"
       },
       "grant-access": "アクセスを許可する",
       "groups": {
-        "external-readonly": "External group is read-only.",
+        "external-readonly": "外部グループは読み取り専用です。",
         "form": {
           "description": "説明",
           "email": "Eメール",
@@ -2391,27 +2228,27 @@
       "view-by-roles": "ロールごとに表示",
       "workload-identities": "ワークロードID",
       "workload-identity": "Workload Identity",
-      "workload-identity-advanced": "Advanced Settings",
-      "workload-identity-all-branches-tags": "All branches and tags",
-      "workload-identity-allowed-branches-tags": "Allowed Branches/Tags",
+      "workload-identity-advanced": "詳細設定",
+      "workload-identity-all-branches-tags": "すべてのブランチとタグ",
+      "workload-identity-allowed-branches-tags": "許可するブランチ/タグ",
       "workload-identity-audience": "Audience",
-      "workload-identity-branch": "Branch",
-      "workload-identity-branch-hint": "Leave empty for all branches",
+      "workload-identity-branch": "ブランチ",
+      "workload-identity-branch-hint": "すべてのブランチを対象とする場合は空欄にしてください",
       "workload-identity-gitlab-url": "GitLab URL",
-      "workload-identity-gitlab-url-hint": "Your GitLab instance URL",
-      "workload-identity-group": "Group / Username",
+      "workload-identity-gitlab-url-hint": "GitLab インスタンスの URL",
+      "workload-identity-group": "グループ / ユーザー名",
       "workload-identity-issuer": "Issuer URL",
-      "workload-identity-owner": "Organization / Username",
-      "workload-identity-platform": "Platform",
-      "workload-identity-project": "Project",
-      "workload-identity-project-hint": "Leave empty to allow all projects",
-      "workload-identity-repo": "Repository",
-      "workload-identity-repo-hint": "Leave empty for all repositories in the organization",
-      "workload-identity-specific-branch": "Specific branch",
-      "workload-identity-specific-tag": "Specific tag",
-      "workload-identity-subject": "Subject Pattern",
-      "workload-identity-tag": "Tag",
-      "workload-identity-tag-hint": "Leave empty to allow all tags"
+      "workload-identity-owner": "組織 / ユーザー名",
+      "workload-identity-platform": "プラットフォーム",
+      "workload-identity-project": "プロジェクト",
+      "workload-identity-project-hint": "すべてのプロジェクトを許可する場合は空欄にしてください",
+      "workload-identity-repo": "リポジトリ",
+      "workload-identity-repo-hint": "組織内のすべてのリポジトリを対象とする場合は空欄にしてください",
+      "workload-identity-specific-branch": "特定のブランチ",
+      "workload-identity-specific-tag": "特定のタグ",
+      "workload-identity-subject": "Subject パターン",
+      "workload-identity-tag": "タグ",
+      "workload-identity-tag-hint": "すべてのタグを許可する場合は空欄にしてください"
     },
     "profile": {
       "display-name": "あなたの名前",
@@ -2477,14 +2314,14 @@
         }
       },
       "classification": {
-        "empty-classification": "The \"classification\" field is empty",
-        "guide-classification": "\"classification\" maps each category by ID. Leaf categories must reference a level number; parent categories omit the level.",
-        "guide-hierarchy": "IDs use a dash-separated hierarchy (e.g., \"1\" is a parent, \"1-1\" and \"1-2\" are its children).",
-        "guide-intro": "Edit the classification JSON below. An example template is provided when no classification is configured.",
-        "guide-levels": "\"levels\" defines sensitivity tiers with consecutive numbers starting from 1 (e.g., 1 = Public, 2 = Internal, 3 = Confidential).",
-        "invalid-json": "Invalid JSON format",
-        "missing-classification": "Missing \"classification\" field",
-        "missing-levels": "Missing \"levels\" field"
+        "empty-classification": "「classification」フィールドが空です",
+        "guide-classification": "「classification」は各カテゴリを ID でマッピングします。リーフカテゴリはレベル番号を参照する必要があり、親カテゴリはレベルを省略します。",
+        "guide-hierarchy": "ID はダッシュ区切りの階層を使用します（例: 「1」は親、「1-1」と「1-2」はその子）。",
+        "guide-intro": "下の分類 JSON を編集してください。分類が未設定の場合はサンプルテンプレートが提供されます。",
+        "guide-levels": "「levels」は 1 から始まる連続した番号で機密度の階層を定義します（例: 1 = 公開、2 = 社内、3 = 機密）。",
+        "invalid-json": "無効な JSON 形式です",
+        "missing-classification": "「classification」フィールドがありません",
+        "missing-levels": "「levels」フィールドがありません"
       },
       "global-rules": {
         "condition-order": "条件付きシーケンス",
@@ -2621,7 +2458,6 @@
       }
     }
   },
-  "settings.general.workspace.default-landing-page.go-to-workspace": "Go to workspace",
   "setup": {
     "basic-info": "基本情報",
     "data": {
@@ -2666,7 +2502,7 @@
     "search-sheets": "ワークシートの検索"
   },
   "sql-editor": {
-    "access-grants": "Access Grants",
+    "access-grants": "アクセス付与",
     "access-search": {
       "scope": {
         "database": {
@@ -2677,16 +2513,16 @@
         }
       }
     },
-    "access-type-unmask": "See unmasked sensitive data",
-    "activate-access": "Activate",
-    "activate-confirm": "Are you sure you want to activate this access grant?",
+    "access-type-unmask": "マスク解除された機密データを表示",
+    "activate-access": "有効化",
+    "activate-confirm": "このアクセス付与を有効化してもよろしいですか？",
     "add-a-new-instance": "新しいインスタンスを追加",
     "admin-mode": {
       "exit": "管理者モードを終了する",
       "self": "管理者モード"
     },
     "allow-admin-mode-only": "インスタンス <instance></instance> には管理者モードでのみアクセスできます。",
-    "and-n-more-databases": "and {{n}} more databases",
+    "and-n-more-databases": "他 {{n}} 件のデータベース",
     "batch-export": {
       "database-no-longer-available": "現在のタブでデータベースを利用できません。",
       "export-limit-exceeds-executed": "エクスポート上限 {{exportLimit}} が実行済みクエリの行数上限 ({{executedLimit}}) を超えています。キャッシュされた行のみエクスポートします。",
@@ -2732,20 +2568,20 @@
     "download-too-large-cells": "{{statements}} 件のステートメントで合計 {{cells}} セルのダウンロードです。上限は {{limit}} セルです。行数を減らすか、エクスポートを使用してください。",
     "download-too-large-xlsx-columns": "XLSX の列数は {{limit}} を超えられません(取得: {{count}})。エクスポートまたは別の形式を使用してください。",
     "download-too-large-xlsx-rows": "XLSX のデータ行数は {{limit}} を超えられません(取得: {{count}})。エクスポートまたは別の形式を使用してください。",
-    "duration-day": "{{days}} day",
-    "duration-days": "{{days}} days",
+    "duration-day": "{{days}} 日",
+    "duration-days": "{{days}} 日",
     "duration-hour": "{{hours}} 時間",
     "duration-hours": "{{hours}} 時間",
     "execute-query": "クエリを実行する",
     "executing-query": "クエリの実行",
-    "expire-at": "Expire at {{time}}",
-    "expire-in": "Expire in {{time}}",
-    "expired": "Expired",
+    "expire-at": "{{time}} に期限切れ",
+    "expire-in": "{{time}} 後に期限切れ",
+    "expired": "期限切れ",
     "format": "フォーマット",
     "format-default": "デフォルト",
-    "format-sql": "Format SQL",
+    "format-sql": "SQL を整形",
     "generate-sql": "SQLの生成",
-    "grant-type-unmask": "Unmask",
+    "grant-type-unmask": "マスク解除",
     "hex-format": "16進形式",
     "hint-tips": {
       "confirm-to-close-unsaved-sheet": {
@@ -2754,14 +2590,14 @@
       }
     },
     "invalid-database": "無効なデータベース {{database}}",
-    "jit": "Just-In-Time Access",
+    "jit": "ジャストインタイムアクセス",
     "last-synced": "最終同期時間: <time></time>",
     "link-access": "リンクアクセス",
     "loading-data": "データのロード...",
     "loading-databases": "データベース情報をロードしています...",
     "manage-connections": "接続を管理する",
     "next-row": "次の行",
-    "no-access-requests": "No access requests",
+    "no-access-requests": "アクセスリクエストはありません",
     "no-data-available": "データがありません",
     "no-database-selected": "データベースが選択されていません",
     "no-history-found": "まだ履歴がありません",
@@ -2795,15 +2631,15 @@
       "single-node": "単一ノード"
     },
     "request-aborted": "ユーザーがリクエストを中止しました",
-    "request-access": "Request Access",
-    "request-data-access": "Request Data Access",
-    "request-jit": "Request just-in-time access",
+    "request-access": "アクセスをリクエスト",
+    "request-data-access": "データアクセスをリクエスト",
+    "request-jit": "ジャストインタイムアクセスをリクエスト",
     "request-query": "リクエストクエリ",
     "result-limit": {
       "self": "結果の制限"
     },
-    "revoke-access": "Revoke",
-    "revoke-confirm": "Are you sure you want to revoke this access grant?",
+    "revoke-access": "取り消し",
+    "revoke-confirm": "このアクセス付与を取り消してもよろしいですか？",
     "rows": {
       "self": "行"
     },
@@ -2844,13 +2680,13 @@
     "table-empty-placeholder": "「実行」をクリックしてクエリを実行します。",
     "table-view": "テーブルビュー",
     "text-format": "テキスト形式",
-    "unmask-warning": "The query result may include unmasked sensitive data.",
+    "unmask-warning": "クエリ結果にマスク解除された機密データが含まれる場合があります。",
     "upload-file": "ファイルをアップロードする",
     "url-copied-to-clipboard": "URLがクリップボードにコピーされました",
     "vertical-display": "縦型表示",
     "view-database-detail": "データベースの詳細を表示する",
     "view-detail": "詳細を見る",
-    "view-issue": "View Issue",
+    "view-issue": "Issue を表示",
     "view-schema-text": "テキストの表示 スキーマ",
     "visualize-explain": "視覚化の説明",
     "web-socket": {
@@ -2862,9 +2698,9 @@
         "title": "言語サーバー"
       },
       "errors": {
-        "description": "Auto Completion might be limited or disabled.",
-        "disconnected": "WebSocket disconnected",
-        "title": "WebSocket connection failed"
+        "description": "自動補完が制限されるか無効になる場合があります。",
+        "disconnected": "WebSocket が切断されました",
+        "title": "WebSocket 接続に失敗しました"
       }
     }
   },
@@ -2938,7 +2774,7 @@
     "policy-removed": "SQL レビューポリシーが削除されました",
     "policy-update-failed": "レビューポリシーの更新に失敗しました。",
     "policy-updated": "SQL レビューポリシーが更新されました",
-    "review-policy": "Review policy",
+    "review-policy": "レビューポリシー",
     "rule": {
       "ADVICE_ONLINE_MIGRATION": {
         "component": {
@@ -3678,23 +3514,23 @@
       "billing-period": "請求期間",
       "cancel": "サブスクリプションをキャンセル",
       "cancel-dialog": {
-        "comment-label": "Anything else you'd like to share? (optional)",
-        "comment-placeholder": "Tell us more so we can improve...",
-        "confirm": "Confirm cancellation",
-        "description": "We're sorry to see you go. Your feedback helps us improve.",
-        "keep": "Keep subscription",
+        "comment-label": "その他に共有したいことはありますか？（任意）",
+        "comment-placeholder": "改善のため、詳しくお聞かせください...",
+        "confirm": "解約を確定",
+        "description": "ご利用の終了を残念に思います。皆さまのフィードバックは改善に役立ちます。",
+        "keep": "サブスクリプションを継続",
         "reason": {
-          "customer-service": "Customer service issues",
-          "low-quality": "Quality didn't meet expectations",
-          "missing-features": "Missing features I need",
-          "other": "Other reason",
-          "switched-service": "Switched to a different product",
-          "too-complex": "Too complex to use",
-          "too-expensive": "Too expensive",
-          "unused": "Not using it enough"
+          "customer-service": "カスタマーサービスに関する問題",
+          "low-quality": "品質が期待に達しなかった",
+          "missing-features": "必要な機能が不足している",
+          "other": "その他の理由",
+          "switched-service": "別の製品に切り替えた",
+          "too-complex": "使いこなすのが難しすぎる",
+          "too-expensive": "価格が高すぎる",
+          "unused": "十分に活用できていない"
         },
-        "reason-label": "Why are you canceling? (required)",
-        "title": "Cancel your subscription"
+        "reason-label": "解約の理由を教えてください（必須）",
+        "title": "サブスクリプションを解約"
       },
       "cancel-pending": "サブスクリプションはキャンセル済みで、{{date}} に終了します。",
       "canceled": "サブスクリプションがキャンセルされました",
@@ -3704,8 +3540,8 @@
         "percentage-off": "初月 {{value}}% オフ",
         "price-off": "${{value}} オフ"
       },
-      "enterprise-description": "Scale your business securely while staying compliant.",
-      "free-description": "Designed for solo devs, side-projects, and experiments.",
+      "enterprise-description": "コンプライアンスを維持しながら、ビジネスを安全にスケールします。",
+      "free-description": "個人開発者、サイドプロジェクト、実験向けに設計されています。",
       "manage-invoices": "請求書を管理",
       "next-period-price": "次期間の金額",
       "payment-info": "支払い情報",
@@ -3713,7 +3549,7 @@
       "pending-title": "購入を完了しています...",
       "per-user-per-month": "/ ユーザー / 月",
       "privacy-policy": "プライバシーポリシー",
-      "pro-description": "Built for teams creating production-ready applications.",
+      "pro-description": "本番環境対応のアプリケーションを開発するチーム向けに構築されています。",
       "seats": "ユーザー数",
       "see-comparison": "機能の詳細比較を見る",
       "subscribe": "今すぐ購読",
@@ -3761,20 +3597,37 @@
       }
     }
   },
-  "subscription.instance-assignment.assign-license": "ライセンスの割り当て",
-  "subscription.instance-assignment.n-license-remain": "残り {{n}}",
-  "subscription.usage.instance-count.runoutof": "すべての {{total}} インスタンス クレジットが使用されました。",
-  "subscription.usage.instance-count.title": "インスタンスの制限",
   "task": {
+    "affected-rows": "影響を受けた行数",
     "cancel-task": "タスクをキャンセルする",
     "cancel-task-description": "保留中および利用可能なタスク実行はすぐにキャンセルされます。実行中のタスク実行にはベストエフォートのキャンセル要求が送信されますが、実行が続く場合があります。必要に応じて再試行してください。",
+    "check-type": {
+      "affected-rows": {
+        "description": "統計情報に基づく推定です。",
+        "self": "影響行数"
+      },
+      "sql-review": {
+        "description": "SQL ステートメントを分析して潜在的な問題を検出し、推奨事項を提示します。組み込みルールとカスタムルールが含まれます。",
+        "self": "SQLレビュー"
+      }
+    },
     "created": "作成日時",
     "data-export-creator-only": "イシュー作成者のみがデータエクスポートタスクを実行できます",
     "error": {
       "scheduled-time-must-be-in-the-future": "スケジュール時間は将来の時間である必要があります"
     },
+    "executed-by": "実行者",
     "execution-time": "実行時間",
+    "no-cancelable-tasks": "キャンセル可能なタスクはありません",
     "no-permission": "この操作を実行する権限がありません",
+    "no-runnable-tasks": "実行可能なタスクはありません",
+    "no-selectable-tasks": "選択可能なタスクはありません",
+    "no-skippable-tasks": "スキップ可能なタスクはありません",
+    "no-tasks-selected": "タスクが選択されていません",
+    "online-migration": {
+      "self": "オンラインでの大規模なテーブル変更"
+    },
+    "prior-backup": "影響を受けるデータの事前バックアップ",
     "run-immediately": {
       "description": "「実行」をクリックするとすぐにタスクの実行が開始されます。遅延やスケジュール設定は必要ありません。",
       "self": "すぐに実行"
@@ -3784,7 +3637,9 @@
       "description": "タスクを自動的に実行開始する日時を指定します。メンテナンス期間やオフピーク時に便利です。",
       "self": "後でスケジュールする"
     },
+    "scheduled-time": "スケジュール時刻",
     "select-scheduled-time": "予定時刻を選択してください",
+    "select-task": "タスクを選択",
     "skip-prior-backup": "事前バックアップをスキップ",
     "skip-prior-backup-description": "変更適用前の自動データバックアップをスキップする",
     "skip-task": "タスクをスキップ | タスクをスキップ",
@@ -3799,56 +3654,55 @@
       "skipped": "スキップ"
     }
   },
-  "task-run.blocked-sessions": "ブロックされたセッション",
-  "task-run.blocked-sessions-description": "現在のセッションによってブロックされているセッション",
-  "task-run.blocking-sessions": "ブロッキングセッション",
-  "task-run.blocking-sessions-description": "現在のセッションをブロックしているセッション",
-  "task-run.history": "履歴",
-  "task-run.latest": "最新",
-  "task-run.latest-logs": "最新ログ",
-  "task-run.log-detail.backing-up": "バックアップ中...",
-  "task-run.log-detail.backup-completed": "完了しました（{{count}} テーブル）",
-  "task-run.log-detail.completed": "完了しました",
-  "task-run.log-detail.computing": "コンピューティング...",
-  "task-run.log-detail.dumping": "ダンピング...",
-  "task-run.log-detail.retry-attempt": "試行 {{current}}/{{max}}",
-  "task-run.log-detail.syncing": "同期中...",
-  "task-run.log-type.command-execute": "コマンド実行",
-  "task-run.log-type.compute-diff": "差分計算",
-  "task-run.log-type.database-sync": "データベース同期",
-  "task-run.log-type.ghost-migration": "gh-ost Migration",
-  "task-run.log-type.prior-backup": "事前のバックアップ",
-  "task-run.log-type.release-file-execute": "リリースファイル",
-  "task-run.log-type.retry": "リトライ",
-  "task-run.log-type.schema-dump": "スキーマダンプ",
-  "task-run.log-type.transaction": "取引",
-  "task-run.log-viewer.collapse-all": "すべて折りたたむ",
-  "task-run.log-viewer.expand-all": "すべて展開",
-  "task-run.log-viewer.multiple-replicas-notice": "実行中にサーバーの再起動が検出されました。ログはレプリカごとにグループ化されています。",
-  "task-run.log-viewer.replica-n": "レプリカ #{{n}}",
-  "task-run.log-viewer.summary": "{{sections}} セクション · {{entries}} エントリ",
-  "task-run.no-session-found": "セッションが見つかりません",
-  "task-run.rollback.available": "{{count}} 件のロールバックが利用可能",
-  "task-run.rollback.no-statement-generated": "文は生成されませんでした",
-  "task-run.rollback.preview-statement.description": "ロールバックプランを作成する前に生成されたロールバック文を確認してください。",
-  "task-run.status.enqueued": "実行を待っています。",
-  "task-run.status.enqueued-with-rollout-time": "{{time}} の後に実行される予定です。",
-  "task-run.status.waiting-max-tasks-per-rollout": "他のタスクが完了するのを待っています。ロールアウトごとの最大実行タスク数制限に達しました。最後の報告は {{time}} です。",
-  "task.affected-rows": "影響を受けた行数",
-  "task.check-type.affected-rows.description": "統計情報に基づく推定です。",
-  "task.check-type.affected-rows.self": "影響行数",
-  "task.check-type.sql-review.description": "Analyze the SQL statement for potential issues and provide recommendations. Includes built-in rules and your custom rules.",
-  "task.check-type.sql-review.self": "SQL review",
-  "task.executed-by": "実行者",
-  "task.no-cancelable-tasks": "キャンセル可能なタスクはありません",
-  "task.no-runnable-tasks": "実行可能なタスクはありません",
-  "task.no-selectable-tasks": "選択可能なタスクはありません",
-  "task.no-skippable-tasks": "スキップ可能なタスクはありません",
-  "task.no-tasks-selected": "タスクが選択されていません",
-  "task.online-migration.self": "オンラインでの大規模なテーブル変更",
-  "task.prior-backup": "影響を受けるデータの事前バックアップ",
-  "task.scheduled-time": "スケジュール時刻",
-  "task.select-task": "タスクを選択",
+  "task-run": {
+    "blocked-sessions": "ブロックされたセッション",
+    "blocked-sessions-description": "現在のセッションによってブロックされているセッション",
+    "blocking-sessions": "ブロッキングセッション",
+    "blocking-sessions-description": "現在のセッションをブロックしているセッション",
+    "history": "履歴",
+    "latest": "最新",
+    "latest-logs": "最新ログ",
+    "log-detail": {
+      "backing-up": "バックアップ中...",
+      "backup-completed": "完了しました（{{count}} テーブル）",
+      "completed": "完了しました",
+      "computing": "コンピューティング...",
+      "dumping": "ダンピング...",
+      "retry-attempt": "試行 {{current}}/{{max}}",
+      "syncing": "同期中..."
+    },
+    "log-type": {
+      "command-execute": "コマンド実行",
+      "compute-diff": "差分計算",
+      "database-sync": "データベース同期",
+      "ghost-migration": "gh-ost マイグレーション",
+      "prior-backup": "事前のバックアップ",
+      "release-file-execute": "リリースファイル",
+      "retry": "リトライ",
+      "schema-dump": "スキーマダンプ",
+      "transaction": "取引"
+    },
+    "log-viewer": {
+      "collapse-all": "すべて折りたたむ",
+      "expand-all": "すべて展開",
+      "multiple-replicas-notice": "実行中にサーバーの再起動が検出されました。ログはレプリカごとにグループ化されています。",
+      "replica-n": "レプリカ #{{n}}",
+      "summary": "{{sections}} セクション · {{entries}} エントリ"
+    },
+    "no-session-found": "セッションが見つかりません",
+    "rollback": {
+      "available": "{{count}} 件のロールバックが利用可能",
+      "no-statement-generated": "文は生成されませんでした",
+      "preview-statement": {
+        "description": "ロールバックプランを作成する前に生成されたロールバック文を確認してください。"
+      }
+    },
+    "status": {
+      "enqueued": "実行を待っています。",
+      "enqueued-with-rollout-time": "{{time}} の後に実行される予定です。",
+      "waiting-max-tasks-per-rollout": "他のタスクが完了するのを待っています。ロールアウトごとの最大実行タスク数制限に達しました。最後の報告は {{time}} です。"
+    }
+  },
   "two-factor": {
     "description": "2 要素認証は、システム メンバーに追加のセキュリティ層を提供します。ログインするとき、ユーザーは認証アプリケーションによって生成されたセキュリティ コードを入力する必要があります。",
     "disable": {

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -1,21 +1,25 @@
 {
-  "activity.sentence.added-spec": "đã thêm",
-  "activity.sentence.canceled-issue": "closed the issue",
-  "activity.sentence.changed-description": "changed description",
-  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
-  "activity.sentence.changed-labels": "changed labels",
-  "activity.sentence.changed-targets-of": "đã thay đổi targets của",
-  "activity.sentence.created-issue": "created issue",
-  "activity.sentence.disabled-prior-backup-on": "đã tắt prior backup trên",
-  "activity.sentence.enabled-prior-backup-on": "đã bật prior backup trên",
-  "activity.sentence.modified-sql-of": "đã sửa đổi SQL của",
-  "activity.sentence.removed-spec": "đã xóa",
-  "activity.sentence.reopened-issue": "reopened issue",
-  "activity.sentence.resolved-issue": "đã đánh dấu vấn đề là Hoàn tất",
-  "activity.sentence.review-done-rollout-created": "Đánh giá đã hoàn tất, rollout đã được tạo",
-  "activity.sentence.review-done-rollout-created-for-plan": "Đánh giá đã hoàn tất, rollout đã được tạo cho kế hoạch",
-  "activity.sentence.review-skipped-rollout-created": "Đánh giá đã được bỏ qua, rollout đã được tạo",
-  "activity.sentence.review-skipped-rollout-created-for-plan": "Đánh giá đã được bỏ qua, rollout đã được tạo cho kế hoạch",
+  "activity": {
+    "sentence": {
+      "added-spec": "đã thêm",
+      "canceled-issue": "đã đóng issue",
+      "changed-description": "đã thay đổi mô tả",
+      "changed-from-to": "đã thay đổi {{name}} từ \"{{oldValue}}\" thành \"{{newValue}}\"",
+      "changed-labels": "đã thay đổi nhãn",
+      "changed-targets-of": "đã thay đổi mục tiêu của",
+      "created-issue": "đã tạo issue",
+      "disabled-prior-backup-on": "đã tắt sao lưu trước trên",
+      "enabled-prior-backup-on": "đã bật sao lưu trước trên",
+      "modified-sql-of": "đã sửa đổi SQL của",
+      "removed-spec": "đã xóa",
+      "reopened-issue": "đã mở lại issue",
+      "resolved-issue": "đã đánh dấu vấn đề là Hoàn tất",
+      "review-done-rollout-created": "Đánh giá đã hoàn tất, rollout đã được tạo",
+      "review-done-rollout-created-for-plan": "Đánh giá đã hoàn tất, rollout đã được tạo cho kế hoạch",
+      "review-skipped-rollout-created": "Đánh giá đã được bỏ qua, rollout đã được tạo",
+      "review-skipped-rollout-created-for-plan": "Đánh giá đã được bỏ qua, rollout đã được tạo cho kế hoạch"
+    }
+  },
   "agent": {
     "active-only-chats": "Chỉ hoạt động",
     "ai-not-configured": {
@@ -52,6 +56,7 @@
     "reply": "Trả lời",
     "result": "Kết quả",
     "retry-last-chat-turn": "Thử lại",
+    "self": "Trợ lý",
     "send": "Gửi",
     "stop": "Dừng",
     "tool-answer": "Câu trả lời",
@@ -69,7 +74,6 @@
     "unarchive-all-chats": "Bỏ lưu trữ tất cả cuộc trò chuyện",
     "unarchive-chat": "Bỏ lưu trữ"
   },
-  "agent.self": "Trợ lý",
   "audit-log": {
     "advanced-search": {
       "scope": {
@@ -152,9 +156,9 @@
       "create-admin-account": "Tạo tài khoản quản trị",
       "existing-user": "Đã có tài khoản?",
       "title": "Đăng ký tài khoản của bạn"
-    }
+    },
+    "token-expired-title": "Mã thông báo đã hết hạn"
   },
-  "auth.token-expired-title": "Mã thông báo đã hết hạn",
   "banner": {
     "external-url": "Bytebase chưa được cấu hình --external-url",
     "license-expired": "Giấy phép {{plan}} của bạn đã hết hạn vào {{expireAt}}.",
@@ -182,7 +186,7 @@
         "or": {
           "description": "Bất kỳ điều nào sau đây là đúng..."
         },
-        "tooltip": "A condition group is a collection of conditions connected by operators \"And\" and \"Or\"."
+        "tooltip": "Nhóm điều kiện là tập hợp các điều kiện được kết nối bằng các toán tử \"And\" và \"Or\"."
       },
       "input-value": "Nhập giá trị",
       "input-value-press-enter": "Nhập giá trị, nhấn Enter để xác nhận",
@@ -192,9 +196,9 @@
   },
   "changelog": {
     "current-schema-empty": "Lược đồ hiện tại trống",
-    "no-schema-change": "No schema change",
+    "no-schema-change": "Không có thay đổi schema",
     "schema-snapshot-after-change": "Ảnh chụp nhanh lược đồ được ghi lại sau khi áp dụng thay đổi này",
-    "select": "Schema version is recorded each time a schema change is applied via Bytebase",
+    "select": "Phiên bản schema được ghi lại mỗi khi một thay đổi schema được áp dụng thông qua Bytebase",
     "self": "Changelog",
     "show-diff": "Hiển thị khác biệt"
   },
@@ -205,6 +209,7 @@
     "actions": "Hành động",
     "activated": "Đã kích hoạt",
     "active": "Hoạt động",
+    "activity": "Hoạt động",
     "add": "Thêm",
     "add-permissions": "Thêm quyền",
     "added": "Đã thêm",
@@ -212,40 +217,46 @@
     "admin": "Quản trị viên",
     "all": "Tất cả",
     "allow": "Cho phép",
-    "approve": "Approve",
+    "and": "và",
+    "approve": "Phê duyệt",
     "approved": "Đã phê duyệt",
     "archive": "Lưu trữ",
-    "archive-description": "Mark \"{{name}}\" as archived and read-only.",
-    "archive-resource": "Archive {{type}}",
+    "archive-description": "Đánh dấu \"{{name}}\" là đã lưu trữ và chỉ đọc.",
+    "archive-resource": "Lưu trữ {{type}}",
     "archived": "Đã lưu trữ",
     "back": "Quay lại",
+    "back-to-workspace": "Quay lại workspace",
     "bypassed": "Đã bỏ qua",
     "cancel": "Hủy",
     "cannot-undo-this-action": "Bạn không thể hoàn tác hành động này.",
+    "catalog": "Danh mục",
     "changelog": "Changelog",
     "classification-level": "Cấp phân loại",
     "clear": "Xóa",
     "clear-filters": "Xóa bộ lọc",
     "close": "Đóng",
+    "close-mobile-sidebar": "Đóng thanh bên di động",
     "closed": "Đã đóng",
+    "collapse": "Thu gọn",
+    "column": "Cột",
     "comment": "Bình luận",
     "configure": "Cấu hình",
     "configure-now": "Cấu hình ngay",
     "confirm": "Xác nhận",
-    "confirm-archive": "Archive Resource?",
-    "confirm-delete": "Delete Resource?",
-    "confirm-to-revert": "Confirm to revert your editing?",
+    "confirm-archive": "Lưu trữ tài nguyên?",
+    "confirm-delete": "Xóa tài nguyên?",
+    "confirm-to-revert": "Xác nhận hoàn tác chỉnh sửa của bạn?",
     "continue-anyway": "Tiếp tục",
     "copied": "Đã sao chép",
     "copy": "Sao chép",
-    "copy-failed": "Copy failed",
+    "copy-failed": "Sao chép thất bại",
     "create": "Tạo",
     "created": "Đã tạo",
     "created-at": "Thời gian tạo",
     "creating": "Đang tạo...",
     "creator": "Người tạo",
     "custom": "Tùy chỉnh",
-    "danger-zone": "Danger Zone",
+    "danger-zone": "Vùng nguy hiểm",
     "database": "Cơ sở dữ liệu",
     "database-group": "Nhóm cơ sở dữ liệu",
     "databases": "Cơ sở dữ liệu",
@@ -253,28 +264,29 @@
     "default": "Mặc định",
     "definition": "Định nghĩa",
     "delete": "Xóa",
-    "delete-resource": "Delete {{type}}",
-    "delete-resource-description": "Once you delete \"{{name}}\", there is no going back. Please be certain.",
+    "delete-resource": "Xóa {{type}}",
+    "delete-resource-description": "Sau khi bạn xóa \"{{name}}\", sẽ không thể hoàn tác. Vui lòng chắc chắn.",
     "deleted": "Đã xóa",
     "deny": "Từ chối",
     "description": "Mô tả",
-    "deselect-all": "Deselect all",
+    "deselect-all": "Bỏ chọn tất cả",
     "detail": "Chi tiết",
     "detailed-guide": "Hướng dẫn chi tiết",
-    "disable": "Disable",
+    "disable": "Tắt",
     "discard-changes": "Hủy thay đổi",
     "dismiss": "Loại bỏ",
     "done": "Hoàn tất",
     "download": "Tải xuống",
     "draft": "Bản nháp",
     "duplicate": "Nhân bản",
-    "duration": "Duration",
+    "duration": "Thời lượng",
     "edit": "Chỉnh sửa",
+    "edited": "đã chỉnh sửa",
     "email": "Email",
     "email-ascii-only": "Địa chỉ email chỉ hỗ trợ ký tự ASCII (chữ cái, số và ký hiệu như . _ - +).",
-    "empty": "Empty",
+    "empty": "Trống",
     "enable": "Bật",
-    "enabled": "Enabled",
+    "enabled": "Đã bật",
     "environment": "Môi trường",
     "environment-name": "Tên môi trường",
     "environments": "Môi trường",
@@ -287,7 +299,7 @@
       "size-limit": "Kích thước tệp phải nhỏ hơn {{size}} MiB",
       "type-limit": "Chỉ hỗ trợ tệp {{extension}}"
     },
-    "filter": "Filter",
+    "filter": "Bộ lọc",
     "filter-by-name": "Lọc theo tên",
     "fork": "Bản sao",
     "from": "Từ",
@@ -299,22 +311,28 @@
     "home": "Trang chủ",
     "id": "ID",
     "import": "Nhập",
+    "in-progress": "Đang thực hiện",
     "info": "Thông tin",
     "instance": "Phiên bản",
     "instances": "Phiên bản",
-    "is-required": "is required",
+    "is-required": "là bắt buộc",
+    "issue": "Issue",
     "issues": "Vấn đề",
-    "items": "items",
+    "items": "mục",
     "key": "Khóa",
     "labels": "Nhãn",
+    "language": "Ngôn ngữ",
     "learn-more": "Tìm hiểu thêm",
     "leave-without-saving": "Thoát mà không lưu?",
+    "license": "Giấy phép",
+    "line": "Dòng",
     "load-more": "Tải thêm",
     "loading": "Đang tải",
     "logout": "Đăng xuất",
     "manage": "Quản lý",
-    "manually-select": "Manually select",
+    "manually-select": "Chọn thủ công",
     "maximize": "Phóng to",
+    "members": "Thành viên",
     "members_one": "Thành viên",
     "members_other": "Thành viên",
     "minutes": "Phút",
@@ -330,8 +348,11 @@
     "no-data": "Không có dữ liệu",
     "not-started": "Chưa bắt đầu",
     "ok": "OK",
+    "only-creator-allowed-export": "Chỉ người tạo mới được phép xuất",
+    "open": "Mở",
+    "operation": "Thao tác",
     "operations": "Các thao tác",
-    "optional": "Optional",
+    "optional": "Tùy chọn",
     "or": "hoặc",
     "overview": "Tổng quan",
     "password": "Mật khẩu",
@@ -339,27 +360,32 @@
     "permissions": "Quyền",
     "plan": "Plan",
     "preview": "Xem trước",
-    "previous": "Previous",
+    "previous": "Trước",
     "project": "Dự án",
     "projects": "Dự án",
     "query": "Truy vấn",
     "read-only": "Chỉ đọc",
     "reason": "Lý do",
+    "recent": "Gần đây",
     "refresh": "Làm mới",
     "regenerate": "Tạo lại",
-    "reject": "Reject",
+    "reject": "Từ chối",
     "rejected": "Đã từ chối",
     "release": "Phiên bản",
+    "remaining": "còn lại",
     "remove": "Gỡ bỏ",
+    "removed": "LOẠI BỎ",
+    "reopen": "Mở lại",
     "reorder": "Sắp xếp lại",
     "required-permission": "Quyền hạn cần thiết",
     "required-workspace-permission": "Các quyền sau đây cần thiết để khởi tạo không gian làm việc UX",
     "reset": "Đặt lại",
-    "resource": "Resource",
+    "resource": "Tài nguyên",
     "resource-not-found": "Không tìm thấy tài nguyên",
     "resources": "Tài nguyên",
     "restore": "Khôi phục",
-    "restored": "Restored",
+    "restored": "Đã khôi phục",
+    "retry": "Thử lại",
     "revert": "Hoàn tác",
     "revoke": "Thu hồi",
     "revoked": "Đã thu hồi",
@@ -373,7 +399,7 @@
       "self": "dòng"
     },
     "rows-per-page": "Số dòng mỗi trang",
-    "run": "Run",
+    "run": "Chạy",
     "running": "Đang chạy",
     "save": "Lưu",
     "schema": "Schema",
@@ -382,14 +408,17 @@
     "search-for-more": "Tìm kiếm thêm",
     "select": "Vui lòng chọn",
     "select-all": "Chọn tất cả",
-    "selected": "selected",
+    "selected": "đã chọn",
     "sensitive-placeholder": "Nhạy cảm - Chỉ ghi",
     "setting": "Cài đặt",
     "settings": "Cài đặt",
     "share": "Chia sẻ",
+    "show-less": "Thu gọn",
+    "show-more": "Hiển thị thêm",
     "sign-in": "Đăng nhập",
     "sign-in-as-admin": "Đăng nhập với tư cách quản trị viên",
     "sign-up": "Đăng ký",
+    "skip": "Bỏ qua",
     "skipped": "Đã bỏ qua",
     "snapshot": "Ảnh chụp nhanh",
     "sql": "SQL",
@@ -397,21 +426,25 @@
     "state": "Trạng thái",
     "statement": "Câu lệnh",
     "status": "Trạng thái",
-    "submit": "Submit",
+    "submit": "Gửi",
     "succeed": "Thành công",
+    "success": "Thành công",
     "system": "Hệ thống",
     "table": "Bảng",
+    "task": "Tác vụ",
     "text-wrap": "Ngắt dòng văn bản",
     "tips": "Mẹo",
     "title": "Tiêu đề",
     "to": "Đến",
-    "total": "Total",
+    "total": "Tổng",
     "total-n-items": "Tổng {{n}} mục",
     "transfer": "Chuyển",
+    "troubleshoot": "Khắc phục sự cố",
     "type": "Loại",
     "type-to-search": "Nhập để tìm kiếm",
     "unassigned": "Chưa gán",
     "under-review": "Đang xem xét",
+    "unknown": "Không xác định",
     "unlimited": "Không giới hạn",
     "untitled": "Không tiêu đề",
     "update": "Cập nhật",
@@ -426,100 +459,14 @@
     "version": "Phiên bản",
     "view": "Xem",
     "view-details": "Xem Chi tiết",
+    "view-doc": "Xem tài liệu",
     "visibility": "Hiển thị",
+    "want-help": "Cần trợ giúp",
     "warning": "Cảnh báo",
-    "webhooks": "Webhooks",
+    "webhooks": "Webhook",
     "write-only": "chỉ ghi",
     "you": "bạn"
   },
-  "common.activity": "Hoạt động",
-  "common.add": "Thêm",
-  "common.admin": "Quản trị viên",
-  "common.all": "Tất cả",
-  "common.and": "và",
-  "common.archive": "Lưu trữ",
-  "common.archived": "Đã lưu trữ",
-  "common.back-to-workspace": "Back to workspace",
-  "common.cancel": "Hủy",
-  "common.cannot-undo-this-action": "Bạn không thể hoàn tác hành động này.",
-  "common.catalog": "Danh mục",
-  "common.close": "Đóng",
-  "common.close-mobile-sidebar": "Close mobile sidebar",
-  "common.collapse": "Thu gọn",
-  "common.column": "Cột",
-  "common.comment": "Comment",
-  "common.confirm": "Xác nhận",
-  "common.continue-anyway": "Tiếp tục",
-  "common.copy": "Sao chép",
-  "common.create": "Tạo",
-  "common.creating": "Đang tạo...",
-  "common.custom": "Tùy chỉnh",
-  "common.database": "Cơ sở dữ liệu",
-  "common.database-group": "Nhóm cơ sở dữ liệu",
-  "common.databases": "Cơ sở dữ liệu",
-  "common.default": "Mặc định",
-  "common.delete": "Xóa",
-  "common.delete-resource": "Delete {{type}}",
-  "common.deleted": "Đã xóa",
-  "common.detail": "Detail",
-  "common.detailed-guide": "Hướng dẫn chi tiết",
-  "common.edit": "Chỉnh sửa",
-  "common.edited": "edited",
-  "common.environment": "Môi trường",
-  "common.import": "Nhập",
-  "common.in-progress": "Đang thực hiện",
-  "common.issue": "Issue",
-  "common.key": "Khóa",
-  "common.labels": "Nhãn",
-  "common.language": "Language",
-  "common.learn-more": "Tìm hiểu thêm",
-  "common.license": "License",
-  "common.line": "Dòng",
-  "common.load-more": "Tải thêm",
-  "common.loading": "Đang tải",
-  "common.logout": "Đăng xuất",
-  "common.members": "Thành viên",
-  "common.minutes": "Phút",
-  "common.n-more": "còn {{n}}",
-  "common.no-data": "Không có dữ liệu",
-  "common.only-creator-allowed-export": "Only the creator is allowed to export",
-  "common.open": "Mở",
-  "common.operation": "Thao tác",
-  "common.optional": "Tùy chọn",
-  "common.or": "hoặc",
-  "common.overview": "Tổng quan",
-  "common.password": "Mật khẩu",
-  "common.project": "Dự án",
-  "common.read-only": "Chỉ đọc",
-  "common.recent": "Gần đây",
-  "common.remaining": "còn lại",
-  "common.remove": "Xóa",
-  "common.removed": "LOẠI BỎ",
-  "common.reopen": "Mở lại",
-  "common.restore": "Khôi phục",
-  "common.retry": "Thử lại",
-  "common.role.self": "Vai trò",
-  "common.rollout": "Triển khai",
-  "common.save": "Lưu",
-  "common.sensitive-placeholder": "Nhạy cảm - Chỉ ghi",
-  "common.show-less": "Thu gọn",
-  "common.show-more": "Hiển thị thêm",
-  "common.skip": "Bỏ qua",
-  "common.success": "Thành công",
-  "common.task": "Tác vụ",
-  "common.troubleshoot": "Khắc phục sự cố",
-  "common.unknown": "Không xác định",
-  "common.unlimited": "Không giới hạn",
-  "common.updated": "Đã cập nhật",
-  "common.updating": "Đang cập nhật",
-  "common.user": "Người dùng",
-  "common.username": "Tên người dùng",
-  "common.value": "Giá trị",
-  "common.version": "Phiên bản",
-  "common.view-doc": "Xem tài liệu",
-  "common.want-help": "Want help",
-  "common.warning": "Cảnh báo",
-  "common.write-only": "chỉ ghi",
   "create-db": {
     "cluster": "Cụm",
     "database-owner-name": "Tên chủ sở hữu cơ sở dữ liệu",
@@ -558,14 +505,18 @@
     "issue-review": {
       "and-n-other-users": "{{names}} và {{count}} người dùng khác",
       "approved-by": "Được chấp thuận bởi",
+      "approved-issue": "đã phê duyệt issue",
       "disallow-approve-reason": {
-        "some-task-checks-are-still-running": "Some task checks are still running.",
-        "some-task-checks-didnt-pass": "Some task checks didn't pass."
+        "some-task-checks-are-still-running": "Một số kiểm tra tác vụ vẫn đang chạy.",
+        "some-task-checks-didnt-pass": "Một số kiểm tra tác vụ không vượt qua."
       },
       "generating-approval-flow": "Đang tạo quy trình phê duyệt",
       "re-request-review": "Yêu cầu xem xét lại",
       "re-request-review-success": "Yêu cầu xem xét lại đã được thực hiện thành công.",
+      "re-requested-review": "đã yêu cầu xem xét lại issue",
       "rejected-by": "Bị từ chối bởi",
+      "rejected-issue": "đã từ chối issue",
+      "retry-approval-finding": "Thử lại",
       "self-approval-not-allowed": "Không được phép tự phê duyệt cho dự án này. Bạn không thể phê duyệt với tư cách là người sáng tạo."
     },
     "risk": {
@@ -608,10 +559,6 @@
     },
     "self": "Phê duyệt tùy chỉnh"
   },
-  "custom-approval.issue-review.approved-issue": "approved issue",
-  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
-  "custom-approval.issue-review.rejected-issue": "rejected issue",
-  "custom-approval.issue-review.retry-approval-finding": "Thử lại",
   "data-source": {
     "additional-node-addresses": "Địa chỉ nút bổ sung",
     "automatic-query-data-source": "Tự động",
@@ -686,47 +633,16 @@
     },
     "ssl-connection": "Kết nối SSL"
   },
-  "data-source.additional-node-addresses": "Địa chỉ nút bổ sung",
-  "data-source.connection-string-schema": "Lược đồ chuỗi kết nối",
-  "data-source.connection-type": "Loại kết nối",
-  "data-source.delete-read-only-data-source": "Xóa nguồn dữ liệu chỉ đọc",
-  "data-source.direct-connection": "Kết nối trực tiếp",
-  "data-source.extra-params.description": "Các tham số bổ sung cho chuỗi kết nối cơ sở dữ liệu",
-  "data-source.extra-params.self": "Thông số bổ sung",
-  "data-source.no-read-only-data-source": "Không có nguồn dữ liệu chỉ đọc",
-  "data-source.private-key-passphrase": "Mật khẩu khóa riêng",
-  "data-source.private-key-passphrase-placeholder": "Để trống nếu khóa riêng của bạn không được mã hóa",
-  "data-source.private-key-passphrase-tip": "Mật khẩu tùy chọn cho khóa riêng được mã hóa",
-  "data-source.read-replica-host": "Máy chủ bản sao đọc",
-  "data-source.read-replica-port": "Cổng bản sao đọc",
-  "data-source.replica-set": "Bộ bản sao",
-  "data-source.snowflake-keypair-tip": "Xác thực cặp khóa",
-  "data-source.ssh-connection": "Kết nối SSH",
-  "data-source.ssh-type.none": "Không có",
-  "data-source.ssh-type.tunnel-and-private-key": "Đường hầm + Khóa riêng",
-  "data-source.ssh.host": "Máy chủ",
-  "data-source.ssh.password": "Mật khẩu",
-  "data-source.ssh.port": "Cổng",
-  "data-source.ssh.private-key": "Khóa riêng",
-  "data-source.ssh.ssh-key": "Khóa SSH",
-  "data-source.ssh.user": "Người dùng",
-  "data-source.ssl-connection": "Kết nối SSL",
-  "data-source.ssl.ca-cert": "Chứng chỉ CA",
-  "data-source.ssl.ca-path": "Đường dẫn chứng chỉ CA",
-  "data-source.ssl.client-cert": "Chứng chỉ máy khách",
-  "data-source.ssl.client-cert-path": "Đường dẫn chứng chỉ máy khách",
-  "data-source.ssl.client-key": "Khóa máy khách",
-  "data-source.ssl.client-key-path": "Đường dẫn khóa máy khách",
-  "data-source.ssl.verify-certificate": "Xác minh chứng chỉ TLS",
-  "data-source.ssl.verify-certificate-tooltip": "Bật xác minh chứng chỉ TLS để kết nối an toàn. Chỉ tắt cho môi trường phát triển hoặc khi không thể xác thực chứng chỉ đúng cách (ví dụ: chứng chỉ tự ký, môi trường VPN). Cảnh báo: Tắt xác minh là không an toàn",
   "database": {
     "access-denied": "Bạn không có quyền truy cập cơ sở dữ liệu này.",
     "all": "Tất cả cơ sở dữ liệu",
     "change-database": "Thay đổi cơ sở dữ liệu",
     "checks": "Kiểm tra",
     "classification": {
-      "description": "Define classification levels to apply consistent masking policies across columns and databases."
+      "description": "Xác định các cấp độ phân loại để áp dụng các chính sách che dữ liệu nhất quán trên các cột và cơ sở dữ liệu.",
+      "self": "Phân loại"
     },
+    "column": "Cột",
     "columns": "Cột",
     "comment": "Bình luận",
     "data-size": "Kích thước dữ liệu",
@@ -734,9 +650,13 @@
     "edit-labels": "Chỉnh sửa nhãn",
     "edit-schema": "Chỉnh sửa lược đồ",
     "engine": "Engine",
+    "export-schema": "Xuất schema",
+    "export-schema-multi-file": "Nhiều tệp (ZIP)",
+    "export-schema-single-file": "Tệp đơn",
     "expression": "Expression",
     "external-database-name": "Tên cơ sở dữ liệu bên ngoài",
     "external-server-name": "Tên máy chủ bên ngoài",
+    "failed-to-export-schema": "Không thể xuất schema",
     "filter-database": "Lọc cơ sở dữ liệu",
     "foreign-key": {
       "reference": "Tham chiếu"
@@ -744,6 +664,7 @@
     "foreign-keys": "Khóa ngoại",
     "index-size": "Kích thước chỉ mục",
     "indexes": "Chỉ mục",
+    "labels": "Nhãn cơ sở dữ liệu",
     "last-sync": "Lần đồng bộ cuối cùng",
     "mixed-label-values": "giá trị hỗn hợp",
     "mixed-label-values-warning": "Một số tài nguyên đã chọn có các giá trị khác nhau cho cùng một khóa. Chỉ chỉnh sửa các cặp khóa-giá trị này nếu bạn muốn thay đổi chúng.",
@@ -790,30 +711,31 @@
       "unspecified": "Không xác định"
     },
     "select": "Chọn cơ sở dữ liệu",
+    "successfully-exported-schema": "Đã xuất schema thành công",
     "successfully-transferred-databases": "Chuyển cơ sở dữ liệu thành công",
     "sync-complete-for-instance": "Đồng bộ hoàn tất cho instance '{{0}}'",
     "sync-database": "Đồng bộ cơ sở dữ liệu",
     "sync-schema": {
-      "copy-schema": "Copy schema",
-      "description": "Bytebase supports synchronizing a schema to one or multiple target databases. (MySQL, PostgreSQL, Oracle, MSSQL, TiDB only)",
-      "generated-ddl-statement": "Generated DDL statement",
+      "copy-schema": "Sao chép schema",
+      "description": "Bytebase hỗ trợ đồng bộ một schema tới một hoặc nhiều cơ sở dữ liệu đích. (Chỉ MySQL, PostgreSQL, Oracle, MSSQL, TiDB)",
+      "generated-ddl-statement": "Câu lệnh DDL được tạo",
       "message": {
-        "no-diff-found": "No diff found.",
-        "no-target-databases": "No target databases",
-        "select-a-target-database-first": "Please select a target database first."
+        "no-diff-found": "Không tìm thấy khác biệt.",
+        "no-target-databases": "Không có cơ sở dữ liệu đích",
+        "select-a-target-database-first": "Vui lòng chọn một cơ sở dữ liệu đích trước."
       },
-      "no-diff": "No diff",
-      "preview-issue": "Preview issue",
-      "schema-change": "Schema change",
-      "schema-change-preview": "Preview Schema change for '{{database}}'",
-      "select-source-schema": "Select source schema",
-      "select-target-databases": "Select target databases",
-      "source-schema": "Source schema",
-      "synchronize-statements": "Corresponding generated DDL statements",
-      "synchronize-statements-description": "You can further edit the generated DDL statements",
-      "target-databases": "Target databases",
+      "no-diff": "Không có khác biệt",
+      "preview-issue": "Xem trước issue",
+      "schema-change": "Thay đổi schema",
+      "schema-change-preview": "Xem trước thay đổi Schema cho '{{database}}'",
+      "select-source-schema": "Chọn schema nguồn",
+      "select-target-databases": "Chọn cơ sở dữ liệu đích",
+      "source-schema": "Schema nguồn",
+      "synchronize-statements": "Các câu lệnh DDL được tạo tương ứng",
+      "synchronize-statements-description": "Bạn có thể chỉnh sửa thêm các câu lệnh DDL được tạo",
+      "target-databases": "Cơ sở dữ liệu đích",
       "title": "Đồng bộ lược đồ",
-      "with-diff": "With diff"
+      "with-diff": "Có khác biệt"
     },
     "sync-schema-button": "Đồng bộ lược đồ",
     "sync-status": "Trạng thái đồng bộ",
@@ -832,29 +754,18 @@
   },
   "database-group": {
     "condition": {
-      "self": "Condition"
+      "self": "Điều kiện"
     },
-    "delete-group": "Delete the database group {{name}}",
-    "matched-database": "Matched database",
-    "no-matched-databases": "No matched databases",
-    "select": "Select database group",
-    "unmatched-database": "Unmatched database"
+    "delete-group": "Xóa nhóm cơ sở dữ liệu {{name}}",
+    "matched-database": "Cơ sở dữ liệu khớp",
+    "no-matched-databases": "Không có cơ sở dữ liệu khớp",
+    "select": "Chọn nhóm cơ sở dữ liệu",
+    "unmatched-database": "Cơ sở dữ liệu không khớp"
   },
-  "database.classification.self": "Phân loại",
-  "database.column": "Cột",
-  "database.engine": "Engine",
-  "database.export-schema": "Xuất schema",
-  "database.export-schema-multi-file": "Nhiều tệp (ZIP)",
-  "database.export-schema-single-file": "Tệp đơn",
-  "database.failed-to-export-schema": "Không thể xuất schema",
-  "database.filter-database": "Lọc cơ sở dữ liệu",
-  "database.labels": "Nhãn cơ sở dữ liệu",
-  "database.revision.delete-confirm-dialog": "Thao tác này sẽ xóa các bản sửa đổi đã áp dụng này và lược đồ cơ sở dữ liệu sẽ không bị thay đổi. Hành động này không thể hoàn tác.",
-  "database.revision.self": "Phiên bản",
-  "database.successfully-exported-schema": "Đã xuất schema thành công",
-  "database.sync-complete-for-instance": "Đồng bộ hoàn tất cho instance '{{0}}'",
-  "database.sync-database": "Đồng bộ cơ sở dữ liệu",
   "db": {
+    "catalog": {
+      "description": "Chỉnh sửa và tải lên danh mục bảng."
+    },
     "character-set": "Bộ ký tự",
     "collation": "Đối chiếu",
     "collections": "Bộ sưu tập",
@@ -897,11 +808,6 @@
     "triggers": "Trình kích hoạt",
     "views": "Khung nhìn"
   },
-  "db.catalog.description": "Chỉnh sửa và tải lên danh mục bảng.",
-  "db.failed-to-sync-schema": "Không đồng bộ hóa được lược đồ",
-  "db.n-databases-had-sync-errors": "{{0}} cơ sở dữ liệu gặp lỗi đồng bộ",
-  "db.start-to-sync-schema": "Bắt đầu đồng bộ hóa lược đồ",
-  "db.syncing-databases-for-instance": "Đang đồng bộ hóa cơ sở dữ liệu cho {{0}}...",
   "environment": {
     "delete-description": "Xóa môi trường cũng sẽ xóa nó khỏi các phiên bản và cơ sở dữ liệu liên quan. Bạn không thể hoàn tác hành động này.",
     "reorder": "Sắp xếp lại môi trường",
@@ -921,7 +827,6 @@
     "password-info": "Cung cấp mật khẩu để mã hóa tệp xuất.",
     "password-optional": "Mã hóa bằng mật khẩu (Tùy chọn)"
   },
-  "export-data.password-optional": "Mật khẩu (không bắt buộc)",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "Đối với các cơ sở dữ liệu có cùng schema, nhóm cơ sở dữ liệu cho phép bạn migration tất cả cùng lúc trong một thay đổi. Chỉ cần định nghĩa nhóm một lần và tái sử dụng trong các lần migration mà không cần chọn từng cơ sở dữ liệu mỗi lần.",
@@ -949,7 +854,7 @@
     },
     "workflow": {
       "description": "Sao chép các tệp workflow vào kho lưu trữ của bạn để tự động hóa SQL review và triển khai cơ sở dữ liệu.",
-      "file-hint": "Lưu dưới dạng {{filePath}} trong kho lưu trữ của bạn",
+      "file-hint": "Lưu dưới dạng {{filePath}} trong kho lưu trữ {{repository}} của bạn",
       "provider-not-match": "Workload identity đã chọn chỉ hoạt động cho {{provider}}.",
       "self-hosted-runner": "Runner tự lưu trữ",
       "title": "Tạo tệp workflow"
@@ -979,11 +884,11 @@
       "scope": {
         "host": {
           "description": "Lọc theo máy chủ lưu trữ. Vui lòng nhập giá trị rồi nhấn Enter.",
-          "title": "Host"
+          "title": "Máy chủ"
         },
         "port": {
           "description": "Lọc theo cổng phiên bản. Vui lòng nhập giá trị rồi nhấn Enter.",
-          "title": "Port"
+          "title": "Cổng"
         }
       }
     },
@@ -994,6 +899,7 @@
     "connection-options": "Tùy chọn kết nối",
     "create-gcp-credentials": "Để tạo thông tin xác thực, xem",
     "database-region": "Khu vực cơ sở dữ liệu",
+    "default-role": "Vai trò mặc định",
     "endpoint": "Điểm cuối",
     "external-id": "ID bên ngoài",
     "external-id-description": "ID bên ngoài để bảo mật bổ sung khi đảm nhận vai trò (tùy chọn)",
@@ -1045,10 +951,66 @@
     "iam-extension": {
       "client-id": "Client ID",
       "client-secret": "Client Secret",
-      "credential-source": "Credential Source",
+      "credential-source": "Nguồn thông tin xác thực",
       "saas-default-credential-restriction": "Thông tin xác thực mặc định không khả dụng trong Bytebase Cloud vì lý do bảo mật. Vui lòng cung cấp thông tin xác thực cụ thể.",
       "specific-credential": "Chứng chỉ cụ thể",
       "tenant-id": "Tenant ID"
+    },
+    "info": {
+      "configure-database-user": {
+        "link": "Cấu hình người dùng cơ sở dữ liệu"
+      },
+      "connect-instance": {
+        "link": "Kết nối phiên bản của bạn"
+      },
+      "mongodb": {
+        "authentication": {
+          "content": "Tạo một người dùng chuyên dụng \"{{user}}\" cho Bytebase trong cơ sở dữ liệu admin:"
+        },
+        "host": {
+          "content": "Nhập tên máy chủ hoặc địa chỉ IP của máy chủ MongoDB. Với MongoDB Atlas, hãy dùng host trong chuỗi kết nối từ hộp thoại kết nối của cụm."
+        },
+        "ssh": {
+          "content": "Dùng đường hầm SSH để kết nối tới các phiên bản MongoDB trong mạng riêng. Điều này hữu ích khi cơ sở dữ liệu nằm sau tường lửa hoặc trong VPC."
+        },
+        "ssl": {
+          "content": "MongoDB Atlas và các dịch vụ MongoDB lưu trữ trên đám mây khác yêu cầu kết nối SSL theo mặc định. Bật SSL và cung cấp chứng chỉ CA nếu cần."
+        }
+      },
+      "mysql": {
+        "authentication": {
+          "content": "Tạo một người dùng chuyên dụng \"{{user}}\" để Bytebase quản lý cơ sở dữ liệu của bạn. Chạy SQL sau:"
+        },
+        "host": {
+          "content": "Nhập tên máy chủ hoặc địa chỉ IP của máy chủ MySQL. Với cơ sở dữ liệu lưu trữ trên đám mây (AWS RDS, Google Cloud SQL), hãy dùng endpoint do nhà cung cấp đám mây cung cấp."
+        },
+        "ssh": {
+          "content": "Dùng đường hầm SSH để kết nối tới cơ sở dữ liệu trong mạng riêng mà Bytebase không thể truy cập trực tiếp. Kết nối này được định tuyến qua bastion/jump host."
+        },
+        "ssl": {
+          "content": "Các cơ sở dữ liệu MySQL lưu trữ trên đám mây (AWS RDS, Google Cloud SQL, Azure Database) thường yêu cầu kết nối SSL. Bật SSL và tải lên chứng chỉ CA do nhà cung cấp đám mây của bạn cung cấp."
+        }
+      },
+      "postgresql": {
+        "authentication": {
+          "content": "Tạo một người dùng chuyên dụng \"{{user}}\" để Bytebase quản lý cơ sở dữ liệu của bạn. Chạy SQL sau với tư cách superuser:"
+        },
+        "host": {
+          "content": "Nhập tên máy chủ hoặc địa chỉ IP của máy chủ PostgreSQL. Với cơ sở dữ liệu lưu trữ trên đám mây, hãy dùng endpoint do nhà cung cấp đám mây cung cấp."
+        },
+        "ssh": {
+          "content": "Dùng đường hầm SSH để kết nối tới cơ sở dữ liệu trong mạng riêng mà Bytebase không thể truy cập trực tiếp. Kết nối này được định tuyến qua bastion/jump host."
+        },
+        "ssl": {
+          "content": "Các cơ sở dữ liệu PostgreSQL lưu trữ trên đám mây (AWS RDS, Google Cloud SQL, Azure Database) thường yêu cầu kết nối SSL. Bật SSL và tải lên chứng chỉ CA do nhà cung cấp đám mây của bạn cung cấp."
+        }
+      },
+      "ssh-tunnel": {
+        "link": "Đường hầm SSH"
+      },
+      "ssl-tls-connection": {
+        "link": "Kết nối SSL/TLS"
+      }
     },
     "info-panel": {
       "no-info": "Không có thông tin bổ sung cho engine này."
@@ -1089,6 +1051,7 @@
       "basic-info": "Thông tin cơ bản",
       "connection": "Kết nối"
     },
+    "select-database-user": "Chọn người dùng cơ sở dữ liệu",
     "selected-n-instances_one": "{{count}} phiên bản đã chọn",
     "selected-n-instances_other": "{{count}} phiên bản đã chọn",
     "sentence": {
@@ -1173,146 +1136,6 @@
     "users": "Người dùng",
     "your-snowflake-account-locator": "Định vị tài khoản Snowflake của bạn"
   },
-  "instance.account-locator": "Định vị tài khoản",
-  "instance.archive-instance-instance-name": "Lưu trữ phiên bản '{{0}}'?",
-  "instance.archived-instances-will-not-be-displayed": "Các phiên bản đã lưu trữ sẽ không được hiển thị.",
-  "instance.authentication-database": "Cơ sở dữ liệu xác thực",
-  "instance.connection-info": "Thông tin kết nối",
-  "instance.connection-options": "Tùy chọn kết nối",
-  "instance.create-gcp-credentials": "Để tạo thông tin xác thực, xem",
-  "instance.database-region": "Khu vực cơ sở dữ liệu",
-  "instance.default-role": "Vai trò mặc định",
-  "instance.endpoint": "Điểm cuối",
-  "instance.external-id": "ID bên ngoài",
-  "instance.external-id-description": "ID bên ngoài để bảo mật bổ sung khi đảm nhận vai trò (tùy chọn)",
-  "instance.external-id-placeholder": "ID bên ngoài tùy chọn",
-  "instance.external-link": "Liên kết ngoài",
-  "instance.external-secret-azure.secret-name": "Tên bí mật",
-  "instance.external-secret-azure.secret-name-tips": "Tên của bí mật được lưu trữ trong Azure Key Vault.",
-  "instance.external-secret-azure.vault-url": "URL Key Vault",
-  "instance.external-secret-azure.vault-url-tips": "URL Key Vault phải giống như \"https://myvault.vault.azure.net/\".",
-  "instance.external-secret-gcp.secret-name": "Tên đầy đủ bí mật",
-  "instance.external-secret-gcp.secret-name-tips": "Tên bí mật phải giống như \"projects/project-id/secrets/secret-id\".",
-  "instance.external-secret-vault.vault-auth-type.approle.role-id": "ID vai trò xác thực",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-env-name": "Tên môi trường",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-id": "ID bí mật xác thực",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-plain-text": "Văn bản thuần",
-  "instance.external-secret-vault.vault-auth-type.approle.self": "AppRole",
-  "instance.external-secret-vault.vault-auth-type.self": "Loại xác thực",
-  "instance.external-secret-vault.vault-auth-type.token.self": "Mã thông báo",
-  "instance.external-secret-vault.vault-secret-engine-name": "Tên công cụ bí mật",
-  "instance.external-secret-vault.vault-secret-engine-tips": "Chỉ hỗ trợ công cụ KV v2.",
-  "instance.external-secret-vault.vault-secret-key": "Khóa bí mật",
-  "instance.external-secret-vault.vault-secret-path": "Đường dẫn bí mật",
-  "instance.external-secret-vault.vault-tls-config": "Cấu hình Vault TLS (Tùy chọn)",
-  "instance.external-secret-vault.vault-url": "URL Vault",
-  "instance.external-secret.key-name": "Khóa bí mật",
-  "instance.external-secret.secret-name": "Tên bí mật",
-  "instance.failed-to-connect-instance": "Không kết nối được với phiên bản.",
-  "instance.failed-to-connect-instance-localhost": "Nếu bạn chạy Bytebase bằng Docker, vui lòng thử \"host.docker.internal\" cho địa chỉ máy chủ.",
-  "instance.find-gcp-project-id": "Để tìm ID dự án GCP, xem",
-  "instance.find-gcp-project-id-and-instance-id": "Để tìm ID dự án GCP và ID phiên bản, xem",
-  "instance.force-archive-description": "Buộc lưu trữ. Tất cả cơ sở dữ liệu sẽ bị hủy gán.",
-  "instance.grants": "Quyền",
-  "instance.host-or-socket": "Máy chủ hoặc Socket",
-  "instance.iam-extension.client-id": "Client ID",
-  "instance.iam-extension.client-secret": "Client Secret",
-  "instance.iam-extension.credential-source": "Credential Source",
-  "instance.iam-extension.saas-default-credential-restriction": "Thông tin xác thực mặc định không khả dụng trong Bytebase Cloud vì lý do bảo mật. Vui lòng cung cấp thông tin xác thực cụ thể.",
-  "instance.iam-extension.specific-credential": "Chứng chỉ cụ thể",
-  "instance.iam-extension.tenant-id": "Tenant ID",
-  "instance.info-panel.no-info": "Không có thông tin bổ sung cho engine này.",
-  "instance.info.configure-database-user.link": "Cấu hình người dùng cơ sở dữ liệu",
-  "instance.info.connect-instance.link": "Kết nối phiên bản của bạn",
-  "instance.info.mongodb.authentication.content": "Tạo một người dùng chuyên dụng \"{{user}}\" cho Bytebase trong cơ sở dữ liệu admin:",
-  "instance.info.mongodb.host.content": "Nhập tên máy chủ hoặc địa chỉ IP của máy chủ MongoDB. Với MongoDB Atlas, hãy dùng host trong chuỗi kết nối từ hộp thoại kết nối của cụm.",
-  "instance.info.mongodb.ssh.content": "Dùng đường hầm SSH để kết nối tới các phiên bản MongoDB trong mạng riêng. Điều này hữu ích khi cơ sở dữ liệu nằm sau tường lửa hoặc trong VPC.",
-  "instance.info.mongodb.ssl.content": "MongoDB Atlas và các dịch vụ MongoDB lưu trữ trên đám mây khác yêu cầu kết nối SSL theo mặc định. Bật SSL và cung cấp chứng chỉ CA nếu cần.",
-  "instance.info.mysql.authentication.content": "Tạo một người dùng chuyên dụng \"{{user}}\" để Bytebase quản lý cơ sở dữ liệu của bạn. Chạy SQL sau:",
-  "instance.info.mysql.host.content": "Nhập tên máy chủ hoặc địa chỉ IP của máy chủ MySQL. Với cơ sở dữ liệu lưu trữ trên đám mây (AWS RDS, Google Cloud SQL), hãy dùng endpoint do nhà cung cấp đám mây cung cấp.",
-  "instance.info.mysql.ssh.content": "Dùng đường hầm SSH để kết nối tới cơ sở dữ liệu trong mạng riêng mà Bytebase không thể truy cập trực tiếp. Kết nối này được định tuyến qua bastion/jump host.",
-  "instance.info.mysql.ssl.content": "Các cơ sở dữ liệu MySQL lưu trữ trên đám mây (AWS RDS, Google Cloud SQL, Azure Database) thường yêu cầu kết nối SSL. Bật SSL và tải lên chứng chỉ CA do nhà cung cấp đám mây của bạn cung cấp.",
-  "instance.info.postgresql.authentication.content": "Tạo một người dùng chuyên dụng \"{{user}}\" để Bytebase quản lý cơ sở dữ liệu của bạn. Chạy SQL sau với tư cách superuser:",
-  "instance.info.postgresql.host.content": "Nhập tên máy chủ hoặc địa chỉ IP của máy chủ PostgreSQL. Với cơ sở dữ liệu lưu trữ trên đám mây, hãy dùng endpoint do nhà cung cấp đám mây cung cấp.",
-  "instance.info.postgresql.ssh.content": "Dùng đường hầm SSH để kết nối tới cơ sở dữ liệu trong mạng riêng mà Bytebase không thể truy cập trực tiếp. Kết nối này được định tuyến qua bastion/jump host.",
-  "instance.info.postgresql.ssl.content": "Các cơ sở dữ liệu PostgreSQL lưu trữ trên đám mây (AWS RDS, Google Cloud SQL, Azure Database) thường yêu cầu kết nối SSL. Bật SSL và tải lên chứng chỉ CA do nhà cung cấp đám mây của bạn cung cấp.",
-  "instance.info.ssh-tunnel.link": "Đường hầm SSH",
-  "instance.info.ssl-tls-connection.link": "Kết nối SSL/TLS",
-  "instance.instance-id": "ID phiên bản",
-  "instance.instance-name": "Tên phiên bản",
-  "instance.new-instance": "Phiên bản mới",
-  "instance.no-environment": "Trường hợp này không bị ràng buộc với môi trường",
-  "instance.no-extra-params-configured": "Không có thông số kết nối bổ sung được cấu hình",
-  "instance.no-params-yet-add-above": "Chưa có thông số nào được cấu hình. \nThêm tham số bằng cách sử dụng biểu mẫu trên.",
-  "instance.no-password": "Không có mật khẩu",
-  "instance.parameter-name-placeholder": "Tên tham số",
-  "instance.parameter-value-placeholder": "Giá trị tham số",
-  "instance.password-type.aws-iam": "AWS RDS IAM",
-  "instance.password-type.azure-iam": "Azure IAM",
-  "instance.password-type.external-secret-aws": "AWS Secrets Manager",
-  "instance.password-type.external-secret-azure": "Azure Key Vault",
-  "instance.password-type.external-secret-gcp": "GCP Secret Manager",
-  "instance.password-type.external-secret-vault": "Vault (KV v2)",
-  "instance.password-type.google-iam": "Google Cloud SQL IAM",
-  "instance.password-type.password": "Mật khẩu",
-  "instance.password-write-only": "YOUR_DB_PWD - chỉ ghi",
-  "instance.port": "Cổng",
-  "instance.project-id": "ID dự án",
-  "instance.restore-instance-instance-name-to-normal-state": "Khôi phục phiên bản '{{0}}' về trạng thái bình thường?",
-  "instance.role-arn": "ARN vai trò",
-  "instance.role-arn-description": "Vai trò IAM để đảm nhận cho truy cập xuyên tài khoản. Để trống cho truy cập cùng tài khoản.",
-  "instance.role-arn-placeholder": "arn:aws:iam::123456789012:role/CrossAccountRole",
-  "instance.scan-interval.default-never": "Mặc định (không bao giờ)",
-  "instance.scan-interval.description": "Bytebase định kỳ đồng bộ lược đồ phiên bản và phát hiện bất thường.",
-  "instance.scan-interval.min-value": "Giá trị nhỏ nhất {{value}} phút",
-  "instance.scan-interval.self": "Khoảng thời gian quét",
-  "instance.section.basic-info": "Thông tin cơ bản",
-  "instance.section.connection": "Kết nối",
-  "instance.select-database-user": "Chọn người dùng cơ sở dữ liệu",
-  "instance.sentence.aws-rds.mysql.template": "Dưới đây là ví dụ để tạo người dùng {{user}}@% và cấp cho người dùng các đặc quyền cần thiết.",
-  "instance.sentence.aws-rds.postgresql.template": "Dưới đây là ví dụ để tạo người dùng '{{user}}' và cấp cho người dùng các đặc quyền cần thiết.",
-  "instance.sentence.console.snowflake": "URL bảng điều khiển bên ngoài quản lý phiên bản này (ví dụ: bảng điều khiển AWS RDS, bảng điều khiển phiên bản cơ sở dữ liệu nội bộ của bạn)",
-  "instance.sentence.create-admin-user": "Đây là người dùng kết nối được Bytebase sử dụng để thực hiện các hoạt động DDL và DML (không phải SELECT).",
-  "instance.sentence.create-admin-user-non-sql": "Đây là người dùng kết nối được Bytebase sử dụng để thực hiện các hoạt động ghi và quản trị.",
-  "instance.sentence.create-readonly-user": "Đây là kết nối được Bytebase sử dụng để thực hiện các hoạt động chỉ đọc như truy vấn SELECT.",
-  "instance.sentence.create-readonly-user-non-sql": "Đây là kết nối được Bytebase sử dụng để thực hiện các hoạt động chỉ đọc.",
-  "instance.sentence.create-user-example.clickhouse.sql-driven-workflow": "Quy trình công việc dựa trên SQL",
-  "instance.sentence.create-user-example.clickhouse.template": "Dưới đây là ví dụ để tạo người dùng '{{user}}' với mật khẩu {{password}} và cấp cho người dùng các đặc quyền cần thiết. Đầu tiên, bạn cần bật {{link}} quy trình công việc dựa trên SQL và sau đó chạy truy vấn sau để tạo người dùng.",
-  "instance.sentence.create-user-example.mysql.template": "Dưới đây là ví dụ để tạo người dùng {{user}}@% với mật khẩu {{password}} và cấp cho người dùng các đặc quyền cần thiết.",
-  "instance.sentence.create-user-example.postgresql.template": "Dưới đây là ví dụ để tạo người dùng '{{user}}' với mật khẩu {{password}} và cấp cho người dùng các đặc quyền cần thiết. Nếu phiên bản kết nối được tự lưu trữ, thì bạn có thể cấp SUPERUSER.",
-  "instance.sentence.create-user-example.postgresql.warn": "Nếu phiên bản kết nối được quản lý bởi nhà cung cấp đám mây, thì SUPERUSER không khả dụng và bạn nên tạo người dùng thông qua bảng điều khiển quản trị của nhà cung cấp đó. Người dùng đã tạo sẽ có các đặc quyền bán SUPERUSER cụ thể của nhà cung cấp. Bạn nên cấp các đặc quyền Bytebase với 'GRANT role_name TO bytebase;' cho tất cả các vai trò hiện có, nếu không Bytebase có thể không truy cập được các cơ sở dữ liệu hoặc bảng hiện có.",
-  "instance.sentence.create-user-example.redis.template": "Dưới đây là ví dụ để tạo người dùng {{user}} với mật khẩu {{password}} và cấp cho người dùng các đặc quyền cần thiết.",
-  "instance.sentence.create-user-example.snowflake.template": "Dưới đây là ví dụ để tạo người dùng '{{user}}' với mật khẩu {{password}} cho {{warehouse}} và cấp cho người dùng các đặc quyền cần thiết.",
-  "instance.sentence.firewall-info": "Nếu bạn sử dụng các quy tắc tường lửa gửi đến cho thể hiện cơ sở dữ liệu của mình, vui lòng tham khảo Hướng dẫn kết nối đám mây Bytebase.",
-  "instance.sentence.google-cloud-sql.instance-name": "Tên kết nối phiên bản",
-  "instance.sentence.google-cloud-sql.instance-name-tips": "Tên kết nối phiên bản phải giống như {{instance}}.",
-  "instance.sentence.google-cloud-sql.mysql.template": "Tạo một tài khoản dịch vụ có tên {{user}}, sau đó thêm nó vào Google Cloud SQL của bạn với tư cách là người dùng IAM {{user}}@'%'. Cấp cho người dùng này các đặc quyền cần thiết.",
-  "instance.sentence.google-cloud-sql.postgresql.template": "Tạo một tài khoản dịch vụ có tên {{user}}, sau đó thêm nó vào Google Cloud SQL của bạn với tư cách là người dùng IAM {{user}}@project-id.iam. Cấp cho người dùng các đặc quyền cần thiết.",
-  "instance.sentence.host.none-snowflake": "ví dụ: host.docker.internal | địa chỉ IP máy chủ | local socket",
-  "instance.sentence.proxy.snowflake": "Đối với máy chủ proxy, thêm @PROXY_HOST và chỉ định PROXY_PORT trong cổng",
-  "instance.show-how-to-create": "Hiển thị cách tạo",
-  "instance.snowflake-web-console": "Bảng điều khiển web Snowflake",
-  "instance.successfully-archived-instance": "Đã lưu trữ thành công phiên bản '{{0}}'.",
-  "instance.successfully-connected-instance": "Đã kết nối thành công với phiên bản.",
-  "instance.successfully-created-instance-createdinstance-name": "Đã tạo thành công phiên bản '{{0}}'.",
-  "instance.successfully-restored-instance": "Đã khôi phục thành công trường hợp '{{0}}'.",
-  "instance.successfully-updated-instance-instance-name": "Đã cập nhật thành công phiên bản '{{0}}'.",
-  "instance.sync-databases.add-database": "+ Thêm cơ sở dữ liệu, nhấn enter để gửi",
-  "instance.sync-databases.description": "Chỉ đồng bộ các cơ sở dữ liệu đã chọn.",
-  "instance.sync-databases.search-database": "Tìm kiếm cơ sở dữ liệu",
-  "instance.sync-databases.self": "Đồng bộ cơ sở dữ liệu",
-  "instance.sync-databases.sync-all": "Đồng bộ tất cả cơ sở dữ liệu",
-  "instance.sync.self": "Đồng bộ phiên bản",
-  "instance.sync.sync-all": "Đồng bộ tất cả cơ sở dữ liệu",
-  "instance.sync.sync-all-tip": "Đồng bộ cơ sở dữ liệu không đồng bộ và có thể mất vài giây đến vài phút",
-  "instance.sync.sync-new": "Chỉ đồng bộ cơ sở dữ liệu mới",
-  "instance.syncing": "Đang đồng bộ hóa ...",
-  "instance.test-connection": "Kiểm tra kết nối",
-  "instance.testing-connection": "Đang kiểm tra kết nối",
-  "instance.type-or-paste-credentials-write-only": "Nhập hoặc dán THÔNG TIN XÁC THỰC - chỉ ghi",
-  "instance.unable-to-connect": "Bytebase không thể kết nối với phiên bản. Chúng tôi khuyên bạn nên xem xét lại thông tin kết nối. Nhưng bạn có thể bỏ qua cảnh báo này ngay bây giờ. Bạn vẫn có thể sửa thông tin kết nối từ trang chi tiết phiên bản sau khi tạo.\n\nChi tiết lỗi: {{0}}",
-  "instance.users": "Người dùng",
-  "instance.your-snowflake-account-locator": "Định vị tài khoản Snowflake của bạn",
   "issue": {
     "access-grant": {
       "advanced-search": {
@@ -1322,9 +1145,10 @@
           }
         }
       },
-      "details": "Access Grant Details",
-      "expired-at": "Expired at"
+      "details": "Chi tiết cấp quyền truy cập",
+      "expired-at": "Hết hạn lúc"
     },
+    "action-anyway": "{{action}} bằng mọi cách",
     "advanced-search": {
       "filter": "Bộ lọc",
       "scope": {
@@ -1367,13 +1191,13 @@
           "title": "Nhãn vấn đề"
         },
         "issue-type": {
-          "description": "Filter by issue type",
-          "title": "Type",
+          "description": "Lọc theo loại issue",
+          "title": "Loại",
           "value": {
-            "access-grant": "Access Grant",
-            "database-change": "Database Change",
-            "database-export": "Database Export",
-            "role-grant": "Role Grant"
+            "access-grant": "Cấp quyền truy cập",
+            "database-change": "Thay đổi cơ sở dữ liệu",
+            "database-export": "Xuất cơ sở dữ liệu",
+            "role-grant": "Cấp vai trò"
           }
         },
         "label": {
@@ -1408,6 +1232,20 @@
       "reopened": "đã mở lại"
     },
     "checks-manual-rollout-hint": "Phê duyệt đã hoàn tất, nhưng rollout không được tạo tự động vì kế hoạch này vẫn còn kiểm tra lỗi. Hãy vào Plan để tiếp tục.",
+    "checks-warning-hint": "Một số kiểm tra chưa đạt. Chỉ tiếp tục nếu đó là điều đã được dự kiến.",
+    "comment-editor": {
+      "nothing-to-preview": "Không có gì để xem trước",
+      "preview": "Xem trước",
+      "toolbar": {
+        "bold": "Chèn văn bản in đậm",
+        "code": "Chèn đoạn mã SQL",
+        "hashtag": "Chèn hashtag",
+        "header": "Chèn văn bản tiêu đề",
+        "link": "Chèn một liên kết"
+      },
+      "write": "Viết"
+    },
+    "create-rollout": "Tạo rollout",
     "data-export": {
       "download-tooltip": "Có sẵn trong 24 giờ",
       "file-expired": "Tệp đã hết hạn",
@@ -1415,8 +1253,13 @@
       "limits": "Giới hạn",
       "options": "Tùy chọn"
     },
+    "issue-name": "Tên vấn đề",
     "labels": "Nhãn vấn đề",
     "leave-a-comment": "Để lại bình luận...",
+    "my-issues": "Issue của tôi",
+    "no-description-provided": "Không có mô tả nào được cung cấp",
+    "options-disabled-due-to-oversize": "Các tùy chọn bị vô hiệu hóa vì SQL quá lớn.",
+    "overwrite-current-statement": "Ghi đè câu lệnh SQL hiện tại",
     "review": {
       "approve-description": "Gửi phản hồi và phê duyệt vấn đề này.",
       "comment-description": "Gửi phản hồi chung mà không cần phê duyệt",
@@ -1433,8 +1276,8 @@
     "role-grant": {
       "all-databases": "Tất cả cơ sở dữ liệu",
       "all-databases-tip": "Tất cả cơ sở dữ liệu hiện tại và tương lai trong dự án này.",
-      "details": "Role Grant Details",
-      "expired-at": "Expired at",
+      "details": "Chi tiết cấp vai trò",
+      "expired-at": "Hết hạn lúc",
       "manually-select": "Chọn thủ công",
       "use-cel": "Sử dụng biểu thức CEL"
     },
@@ -1445,6 +1288,7 @@
       "sort": "Sắp xếp",
       "updated": "Thời gian cập nhật"
     },
+    "statement-from-sheet-warning": "Câu lệnh này được tải từ một sheet lớn. Bản xem trước có thể bị cắt ngắn.",
     "status-transition": {
       "modal": {
         "close": "Đóng vấn đề?",
@@ -1453,14 +1297,18 @@
     },
     "subtitle": "Các vấn đề bao gồm thay đổi cơ sở dữ liệu, xuất dữ liệu và yêu cầu truy cập. Cần xem xét và phê duyệt trước khi thực hiện.",
     "table": {
-      "approval-progress": "{{approved}}/{{total}} Approvals",
-      "approved": "Approved",
+      "approval-progress": "{{approved}}/{{total}} phê duyệt",
+      "approved": "Đã phê duyệt",
       "closed": "Đã đóng",
       "creator": "Người tạo",
       "name": "Tên",
       "open": "Mở",
       "updated": "Đã cập nhật",
-      "waiting-role": "Waiting: {{role}}"
+      "waiting-role": "Đang chờ: {{role}}"
+    },
+    "task-run": {
+      "logs": "Nhật ký",
+      "session": "Phiên"
     },
     "title": {
       "change-database": "Thay đổi cơ sở dữ liệu",
@@ -1469,34 +1317,13 @@
       "request-role": "Yêu cầu vai trò",
       "request-specific-role": "Yêu cầu vai trò \"{{role}}\""
     },
-    "upload-sql": "Upload SQL",
+    "transaction-mode": {
+      "label": "Chế độ giao dịch"
+    },
+    "upload-sql": "Tải lên SQL",
+    "upload-sql-file-max-size-exceeded": "Vượt quá kích thước tệp tối đa ({{size}}).",
     "waiting-approval": "Đang chờ phê duyệt"
   },
-  "issue.action-anyway": "{{action}} bằng mọi cách",
-  "issue.checks-warning-hint": "Một số kiểm tra chưa đạt. Chỉ tiếp tục nếu đó là điều đã được dự kiến.",
-  "issue.comment-editor.nothing-to-preview": "Nothing to preview",
-  "issue.comment-editor.preview": "Preview",
-  "issue.comment-editor.toolbar.bold": "Insert bold text",
-  "issue.comment-editor.toolbar.code": "Insert SQL code snippet",
-  "issue.comment-editor.toolbar.hashtag": "Insert hashtag",
-  "issue.comment-editor.toolbar.header": "Insert heading text",
-  "issue.comment-editor.toolbar.link": "Insert a link",
-  "issue.comment-editor.write": "Write",
-  "issue.create-rollout": "Tạo rollout",
-  "issue.data-export.format": "Định dạng",
-  "issue.data-export.limits": "Giới hạn",
-  "issue.data-export.options": "Tùy chọn",
-  "issue.issue-name": "Tên vấn đề",
-  "issue.my-issues": "Issue của tôi",
-  "issue.no-description-provided": "Không có mô tả nào được cung cấp",
-  "issue.options-disabled-due-to-oversize": "Các tùy chọn bị vô hiệu hóa vì SQL quá lớn.",
-  "issue.overwrite-current-statement": "Ghi đè câu lệnh SQL hiện tại",
-  "issue.review.self": "Review",
-  "issue.statement-from-sheet-warning": "This statement is loaded from a large sheet. Preview may be truncated.",
-  "issue.task-run.logs": "Nhật ký",
-  "issue.task-run.session": "Phiên",
-  "issue.transaction-mode.label": "Chế độ giao dịch",
-  "issue.upload-sql-file-max-size-exceeded": "Vượt quá kích thước tệp tối đa ({{size}}).",
   "label": {
     "add-label": "Thêm nhãn",
     "empty-label-value": "Trống",
@@ -1507,12 +1334,6 @@
       "value-necessary": "Giá trị là bắt buộc"
     }
   },
-  "label.add-label": "Thêm nhãn",
-  "label.empty-label-value": "Trống",
-  "label.error.key-duplicated": "Khóa trùng lặp",
-  "label.error.key-necessary": "Khóa là bắt buộc",
-  "label.error.max-value-length-exceeded": "Độ dài giá trị không được vượt quá {{length}} ký tự",
-  "label.error.value-necessary": "Giá trị là bắt buộc",
   "landing": {
     "changelog-for-version": "Nhật ký thay đổi cho phiên bản {{version}}",
     "last-visit": "Lần truy cập cuối",
@@ -1561,91 +1382,114 @@
     }
   },
   "plan": {
+    "add-spec": "Thêm thay đổi",
+    "add-spec-pending-draft": "Lưu hoặc hủy thay đổi đang chờ trước khi thêm thay đổi khác",
     "checks": {
-      "self": "Kiểm tra"
+      "completed": "Đã hoàn thành kiểm tra kế hoạch",
+      "failed-to-run": "Không thể chạy kiểm tra kế hoạch",
+      "no-check-results": "Không có kết quả kiểm tra",
+      "no-results-match-filters": "Không có kết quả khớp với bộ lọc",
+      "self": "Kiểm tra",
+      "started": "Đã bắt đầu kiểm tra kế hoạch"
     },
     "create-plan": "Tạo kế hoạch",
+    "description": {
+      "placeholder": "Thêm mô tả"
+    },
     "editor": {
       "save-changes-before-continuing": "Vui lòng lưu hoặc hủy thay đổi của bạn trước khi tiếp tục"
     },
+    "ghost": {
+      "requirements-not-met": "Các cơ sở dữ liệu sau không đáp ứng yêu cầu Ghost: {{databases}}"
+    },
+    "go-to-plan-page": "Đi tới trang kế hoạch",
+    "isolation-level": {
+      "read-committed": "Đọc đã cam kết",
+      "read-uncommitted": "Đọc chưa cam kết",
+      "repeatable-read": "Đọc lặp lại",
+      "self": "Mức Độ Cô Lập",
+      "serializable": "Tuần tự hóa"
+    },
+    "labels-required-for-review": "Cần có nhãn trước khi review",
     "meta": {
       "created-by-at": "Tạo bởi {{user}} · {{time}}"
     },
     "navigator": {
       "changes": "Thay đổi",
+      "checks": "Kiểm tra",
       "deploy": "Triển khai",
-      "review": "Xem xét"
+      "review": "Xem xét",
+      "statement-empty": "Câu lệnh đang trống"
     },
     "new-plan": "Kế hoạch mới",
+    "options": {
+      "no-options-available": "Không có tùy chọn nào khả dụng",
+      "self": "Tùy chọn"
+    },
+    "overview": {
+      "no-checks": "Không có kiểm tra"
+    },
+    "phase": {
+      "create-rollout-action": "Tạo rollout thủ công",
+      "deploy-approval-must-complete": "Luồng phê duyệt phải hoàn tất.",
+      "deploy-approval-optional": "Có thể bỏ qua luồng phê duyệt theo cấu hình dự án hiện tại.",
+      "deploy-approval-pending": "Hoàn tất luồng phê duyệt trước khi rollout có thể tiếp tục tự động.",
+      "deploy-approval-ready": "Phê duyệt cho kế hoạch này đã hoàn tất.",
+      "deploy-checks-blocked": "Các kiểm tra lỗi đang chặn việc tạo rollout tự động.",
+      "deploy-checks-must-pass": "Các kiểm tra phải đạt.",
+      "deploy-checks-optional": "Các kiểm tra lỗi sẽ không chặn rollout thủ công trong dự án này.",
+      "deploy-checks-ready": "Các kiểm tra đã sẵn sàng để tạo rollout tự động.",
+      "deploy-checks-running": "Hãy chờ các kiểm tra đang chạy hoàn tất trước khi rollout tự động có thể tiếp tục.",
+      "deploy-description": "Bytebase sẽ tự động tạo rollout khi tất cả kiểm tra đều đạt và issue đã được phê duyệt.",
+      "deploy-description-gitops": "Kế hoạch này đã sẵn sàng để triển khai. Tạo một rollout để triển khai bản phát hành được liên kết.",
+      "deploy-manual-create-description": "Dựa trên cài đặt dự án hiện tại, bạn cũng có thể tạo rollout thủ công.",
+      "deploy-manual-create-description-readonly": "Người dùng có quyền Create Rollout có thể tạo rollout thủ công.",
+      "hide-details": "Ẩn chi tiết",
+      "review-description": "Gửi để xem xét để tiếp tục",
+      "show-details": "Hiển thị chi tiết"
+    },
     "plans": "Kế hoạch",
+    "pre-backup": {
+      "requirements-not-met": "Các cơ sở dữ liệu sau không đáp ứng yêu cầu sao lưu trước: {{databases}}"
+    },
+    "ready-for-review": "Sẵn sàng để xem xét",
+    "run": "Kiểm tra lại",
+    "select-isolation-level": "Chọn mức độ cô lập",
+    "select-targets": "Chọn mục tiêu",
+    "spec": {
+      "change": "Thay đổi",
+      "type": {
+        "database-change": "Thay đổi cơ sở dữ liệu"
+      }
+    },
+    "state": {
+      "close-confirm": "Đóng kế hoạch này?",
+      "reopen-confirm": "Mở lại kế hoạch này?"
+    },
     "subtitle": "Soạn thảo các thay đổi cơ sở dữ liệu và chạy các bước kiểm tra sơ bộ trước khi tạo vấn đề để phê duyệt.",
+    "summary": {
+      "last-approved-by": "Phê duyệt gần nhất bởi {{name}}",
+      "n-changes": "{{n}} thay đổi",
+      "n-database-groups": "{{n}} nhóm cơ sở dữ liệu",
+      "n-databases": "{{n}} cơ sở dữ liệu",
+      "n-error": "{{n}} lỗi",
+      "n-of-m-approved": "{{n}} trên {{m}} đã được phê duyệt",
+      "n-of-m-tasks": "{{n}}/{{m}} tác vụ",
+      "n-passed": "{{n}} đã vượt qua",
+      "n-warning": "{{n}} cảnh báo"
+    },
     "targets": {
-      "title": "Mục tiêu"
-    }
+      "no-targets-found": "Không tìm thấy mục tiêu",
+      "non-env-warning": {
+        "one": "{{count}} cơ sở dữ liệu sẽ bị loại khỏi rollout vì không có môi trường hiệu lực:",
+        "other": "{{count}} cơ sở dữ liệu sẽ bị loại khỏi rollout vì không có môi trường hiệu lực:"
+      },
+      "title": "Mục tiêu",
+      "view-all": "Xem tất cả ({{count}})"
+    },
+    "title-required": "Tiêu đề là bắt buộc",
+    "view-discussion": "Xem thảo luận"
   },
-  "plan.add-spec": "Thêm thay đổi",
-  "plan.add-spec-pending-draft": "Lưu hoặc hủy thay đổi đang chờ trước khi thêm thay đổi khác",
-  "plan.checks.completed": "Đã hoàn thành kiểm tra kế hoạch",
-  "plan.checks.failed-to-run": "Không thể chạy kiểm tra kế hoạch",
-  "plan.checks.no-check-results": "Không có kết quả kiểm tra",
-  "plan.checks.no-results-match-filters": "Không có kết quả khớp với bộ lọc",
-  "plan.checks.started": "Đã bắt đầu kiểm tra kế hoạch",
-  "plan.description.placeholder": "Thêm mô tả",
-  "plan.ghost.requirements-not-met": "Các cơ sở dữ liệu sau không đáp ứng yêu cầu Ghost: {{databases}}",
-  "plan.go-to-plan-page": "Đi tới trang kế hoạch",
-  "plan.isolation-level.read-committed": "Đọc đã cam kết",
-  "plan.isolation-level.read-uncommitted": "Đọc chưa cam kết",
-  "plan.isolation-level.repeatable-read": "Đọc lặp lại",
-  "plan.isolation-level.self": "Mức Độ Cô Lập",
-  "plan.isolation-level.serializable": "Tuần tự hóa",
-  "plan.labels-required-for-review": "Cần có nhãn trước khi review",
-  "plan.navigator.checks": "Kiểm tra",
-  "plan.navigator.statement-empty": "Câu lệnh đang trống",
-  "plan.options.no-options-available": "Không có tùy chọn nào khả dụng",
-  "plan.options.self": "Tùy chọn",
-  "plan.overview.no-checks": "Không có kiểm tra",
-  "plan.phase.create-rollout-action": "Tạo rollout thủ công",
-  "plan.phase.deploy-approval-must-complete": "Luồng phê duyệt phải hoàn tất.",
-  "plan.phase.deploy-approval-optional": "Có thể bỏ qua luồng phê duyệt theo cấu hình dự án hiện tại.",
-  "plan.phase.deploy-approval-pending": "Hoàn tất luồng phê duyệt trước khi rollout có thể tiếp tục tự động.",
-  "plan.phase.deploy-approval-ready": "Phê duyệt cho kế hoạch này đã hoàn tất.",
-  "plan.phase.deploy-checks-blocked": "Các kiểm tra lỗi đang chặn việc tạo rollout tự động.",
-  "plan.phase.deploy-checks-must-pass": "Các kiểm tra phải đạt.",
-  "plan.phase.deploy-checks-optional": "Các kiểm tra lỗi sẽ không chặn rollout thủ công trong dự án này.",
-  "plan.phase.deploy-checks-ready": "Các kiểm tra đã sẵn sàng để tạo rollout tự động.",
-  "plan.phase.deploy-checks-running": "Hãy chờ các kiểm tra đang chạy hoàn tất trước khi rollout tự động có thể tiếp tục.",
-  "plan.phase.deploy-description": "Bytebase sẽ tự động tạo rollout khi tất cả kiểm tra đều đạt và issue đã được phê duyệt.",
-  "plan.phase.deploy-description-gitops": "Kế hoạch này đã sẵn sàng để triển khai. Tạo một rollout để triển khai bản phát hành được liên kết.",
-  "plan.phase.deploy-manual-create-description": "Dựa trên cài đặt dự án hiện tại, bạn cũng có thể tạo rollout thủ công.",
-  "plan.phase.deploy-manual-create-description-readonly": "Người dùng có quyền Create Rollout có thể tạo rollout thủ công.",
-  "plan.phase.hide-details": "Ẩn chi tiết",
-  "plan.phase.review-description": "Gửi để xem xét để tiếp tục",
-  "plan.phase.show-details": "Hiển thị chi tiết",
-  "plan.pre-backup.requirements-not-met": "Các cơ sở dữ liệu sau không đáp ứng yêu cầu sao lưu trước: {{databases}}",
-  "plan.ready-for-review": "Sẵn sàng để xem xét",
-  "plan.run": "Kiểm tra lại",
-  "plan.select-isolation-level": "Chọn mức độ cô lập",
-  "plan.select-targets": "Chọn mục tiêu",
-  "plan.spec.change": "Thay đổi",
-  "plan.spec.type.database-change": "Thay đổi cơ sở dữ liệu",
-  "plan.state.close-confirm": "Đóng kế hoạch này?",
-  "plan.state.reopen-confirm": "Mở lại kế hoạch này?",
-  "plan.summary.last-approved-by": "Phê duyệt gần nhất bởi {{name}}",
-  "plan.summary.n-changes": "{{n}} thay đổi",
-  "plan.summary.n-database-groups": "{{n}} nhóm cơ sở dữ liệu",
-  "plan.summary.n-databases": "{{n}} cơ sở dữ liệu",
-  "plan.summary.n-error": "{{n}} lỗi",
-  "plan.summary.n-of-m-approved": "{{n}} trên {{m}} đã được phê duyệt",
-  "plan.summary.n-of-m-tasks": "{{n}}/{{m}} tác vụ",
-  "plan.summary.n-passed": "{{n}} đã vượt qua",
-  "plan.summary.n-warning": "{{n}} cảnh báo",
-  "plan.targets.no-targets-found": "Không tìm thấy mục tiêu",
-  "plan.targets.non-env-warning.one": "{{count}} cơ sở dữ liệu sẽ bị loại khỏi rollout vì không có môi trường hiệu lực:",
-  "plan.targets.non-env-warning.other": "{{count}} cơ sở dữ liệu sẽ bị loại khỏi rollout vì không có môi trường hiệu lực:",
-  "plan.targets.title": "Mục tiêu",
-  "plan.targets.view-all": "Xem tất cả ({{count}})",
-  "plan.title-required": "Tiêu đề là bắt buộc",
-  "plan.view-discussion": "Xem thảo luận",
   "plugin": {
     "ai": {
       "actions": {
@@ -1745,7 +1589,7 @@
       "ddl-warning": "Trong các môi trường đã chọn, câu lệnh {{kind}} có thể được chạy trực tiếp trong SQL Editor mà không cần phê duyệt.",
       "description": "Thành viên dự án xác định quyền để vận hành cơ sở dữ liệu và các vấn đề bên trong dự án. Chủ sở hữu dự án, Quản trị viên không gian làm việc và DBA không gian làm việc đều có toàn quyền dự án.",
       "edit-member": "Chỉnh sửa thành viên - {{member}}",
-      "never-expires": "Never",
+      "never-expires": "Không bao giờ",
       "request-role": {
         "disabled-reason": {
           "allow-request-role-disabled": "Dự án này đã tắt tính năng yêu cầu vai trò.",
@@ -1766,9 +1610,10 @@
     "overview": {
       "info-slot-content": "Bytebase định kỳ đồng bộ hóa lược đồ phiên bản. Các cơ sở dữ liệu mới được đồng bộ hóa trước tiên được đặt ở đây. Người dùng nên chuyển chúng đến dự án ứng dụng thích hợp."
     },
+    "select": "Chọn dự án",
     "settings": {
-      "confirm-archive-project": "Archiving \"{{name}}\" will make it read-only and hide it from active project lists. All issues, databases, and settings will be preserved. You can restore it later from the archived projects list.",
-      "confirm-delete-project": "Deleting \"{{name}}\" will permanently remove the project and all associated data including issues, configurations, and history. All databases in this project will be moved to the default project. This action cannot be undone.",
+      "confirm-archive-project": "Việc lưu trữ \"{{name}}\" sẽ khiến nó trở thành chỉ đọc và ẩn khỏi danh sách dự án đang hoạt động. Tất cả issue, cơ sở dữ liệu và cài đặt sẽ được giữ lại. Bạn có thể khôi phục lại sau từ danh sách dự án đã lưu trữ.",
+      "confirm-delete-project": "Việc xóa \"{{name}}\" sẽ xóa vĩnh viễn dự án và tất cả dữ liệu liên quan bao gồm issue, cấu hình và lịch sử. Tất cả cơ sở dữ liệu trong dự án này sẽ được chuyển sang dự án mặc định. Hành động này không thể hoàn tác.",
       "issue-related": {
         "allow-jit": {
           "description": "Khi được bật, người dùng có thể yêu cầu và sử dụng quyền truy cập tức thời trong Trình soạn thảo SQL.",
@@ -1871,14 +1716,12 @@
       "webhook-url": "URL Webhook"
     }
   },
-  "project.select": "Chọn dự án",
   "quick-action": {
     "create-db": "Tạo cơ sở dữ liệu",
+    "create-project": "Tạo dự án",
     "new-project": "Mới Dự án",
     "request-export-data": "Yêu cầu Xuất"
   },
-  "quick-action.create-project": "Create project",
-  "quick-action.new-project": "Mới Dự án",
   "quick-start": {
     "guide": "nhấp vào bước để thử",
     "notice": {
@@ -1886,6 +1729,7 @@
       "title": "Đã bỏ qua hướng dẫn bắt đầu nhanh"
     },
     "query-data": "Truy vấn dữ liệu",
+    "self": "Bắt đầu nhanh",
     "view-an-issue": "Xem một vấn đề",
     "visit-database": "Truy cập Cơ sở dữ liệu",
     "visit-environment": "Truy cập Môi trường",
@@ -1893,26 +1737,25 @@
     "visit-member": "Truy cập Thành viên | Thành viên",
     "visit-project": "Truy cập Dự án"
   },
-  "quick-start.self": "Quick Start",
   "release": {
-    "and-n-more-files": "and {{count}} more files",
-    "change-tip": "This change is linked to a release artifact.",
+    "and-n-more-files": "và {{count}} tệp khác",
+    "change-tip": "Thay đổi này được liên kết với một artifact phát hành.",
     "file": "Tệp phát hành",
     "file-type": {
-      "declarative": "Declarative",
-      "unspecified": "Unspecified",
-      "versioned": "Versioned"
+      "declarative": "Khai báo",
+      "unspecified": "Không xác định",
+      "versioned": "Có phiên bản"
     },
     "files": "Tệp",
-    "not-found": "Release not found",
+    "not-found": "Không tìm thấy bản phát hành",
     "releases": "Bản phát hành",
     "total-files": "Tổng số {{}} tệp",
     "usage-description": "Bản phát hành là một artifact ứng dụng có phiên bản mà việc triển khai vào môi trường được kích hoạt bởi quy trình GitOps.",
-    "vcs-source": "VCS Source",
+    "vcs-source": "Nguồn VCS",
     "vcs-type": {
-      "unspecified": "Unknown VCS"
+      "unspecified": "VCS không xác định"
     },
-    "view-all-files": "View all files"
+    "view-all-files": "Xem tất cả tệp"
   },
   "remind": {
     "role-expire": {
@@ -1938,13 +1781,6 @@
       "pattern": "ID {{resource}} có thể có chữ thường, chữ số hoặc dấu gạch nối. \nNó phải bắt đầu với một chữ cái viết thường và kết thúc bằng một chữ cái hoặc số."
     }
   },
-  "resource-id.cannot-be-changed-later": "Nó không thể được thay đổi sau này.",
-  "resource-id.description": "ID {{resource}} là một mã định danh duy nhất. Bạn không thể thay đổi nó sau khi tạo.",
-  "resource-id.self": "ID {{resource}}",
-  "resource-id.validation.duplicated": "ID {{resource}} đã tồn tại. Vui lòng chọn một ID khác.",
-  "resource-id.validation.empty": "ID {{resource}} không được để trống",
-  "resource-id.validation.overflow": "ID {{resource}} quá dài. Nó phải có ít hơn 64 ký tự.",
-  "resource-id.validation.pattern": "ID {{resource}} có thể có chữ thường, chữ số hoặc dấu gạch nối. \nNó phải bắt đầu với một chữ cái viết thường và kết thúc bằng một chữ cái hoặc số.",
   "role": {
     "custom-roles": {
       "self": "Vai trò tùy chỉnh"
@@ -1966,6 +1802,7 @@
     }
   },
   "rollout": {
+    "bypass-stage-requirements": "Bỏ qua cảnh báo",
     "no-stages": "Không có giai đoạn nào",
     "no-tasks-created": "Chưa có tác vụ nào được tạo",
     "pending-tasks-preview": {
@@ -1982,47 +1819,48 @@
       "self_one": "Giai đoạn",
       "self_other": "Các giai đoạn"
     },
+    "task": {
+      "no-tasks": "Không có tác vụ trong giai đoạn này",
+      "selected-count": "Đã chọn {{count}} tác vụ",
+      "statement-truncated-hint": "Câu lệnh bị cắt bớt do kích thước lớn."
+    },
     "task-execution-errors": "Lỗi thực hiện tác vụ"
   },
-  "rollout.bypass-stage-requirements": "Bỏ qua cảnh báo",
-  "rollout.task.no-tasks": "Không có tác vụ trong giai đoạn này",
-  "rollout.task.selected-count": "Đã chọn {{count}} tác vụ",
-  "rollout.task.statement-truncated-hint": "Câu lệnh bị cắt bớt do kích thước lớn.",
   "schema-diagram": {
     "fit-content-with-view": "Điều chỉnh nội dung vừa với khung nhìn",
     "self": "Sơ đồ Lược đồ"
   },
   "schema-editor": {
     "actions": {
-      "add-column": "Add column",
-      "add-index": "Add index",
-      "add-partition": "Add partition",
-      "create-function": "Create function",
-      "create-procedure": "Create procedure",
-      "create-schema": "Create schema",
-      "create-table": "New table",
-      "create-view": "Create view",
+      "add-column": "Thêm cột",
+      "add-index": "Thêm chỉ mục",
+      "add-partition": "Thêm phân vùng",
+      "create-function": "Tạo function",
+      "create-procedure": "Tạo procedure",
+      "create-schema": "Tạo schema",
+      "create-table": "Bảng mới",
+      "create-view": "Tạo view",
       "drop": "Drop",
       "drop-schema": "Drop schema",
-      "drop-table": "Drop table",
-      "rename": "Rename",
-      "rename-table": "Rename table",
-      "restore": "Restore"
+      "drop-table": "Drop bảng",
+      "rename": "Đổi tên",
+      "rename-table": "Đổi tên bảng",
+      "restore": "Khôi phục"
     },
     "column": {
-      "comment": "Comment",
-      "default": "Default",
+      "comment": "Bình luận",
+      "default": "Mặc định",
       "foreign-key": "Khóa ngoại",
-      "name": "Name",
+      "name": "Tên",
       "name-placeholder": "Tên cột",
       "not-null": "Not Null",
       "on-update": "Khi cập nhật",
-      "operations": "Operations",
-      "primary": "Primary",
-      "type": "Type"
+      "operations": "Thao tác",
+      "primary": "Khóa chính",
+      "type": "Loại"
     },
-    "columns": "Columns",
-    "create-foreign-key": "Create Foreign Key",
+    "columns": "Cột",
+    "create-foreign-key": "Tạo khóa ngoại",
     "database": {
       "collation": "Đối chiếu",
       "comment": "Bình luận",
@@ -2032,43 +1870,43 @@
     "default": {
       "placeholder": "Nhập giá trị mặc định hoặc để trống nếu không có giá trị mặc định"
     },
-    "edit-foreign-key": "Edit Foreign Key",
+    "edit-foreign-key": "Chỉnh sửa khóa ngoại",
     "foreign-key": {
-      "name": "Foreign Key Name",
-      "referenced-column": "Referenced Column",
-      "referenced-schema": "Referenced Schema",
-      "referenced-table": "Referenced Table"
+      "name": "Tên khóa ngoại",
+      "referenced-column": "Cột được tham chiếu",
+      "referenced-schema": "Schema được tham chiếu",
+      "referenced-table": "Bảng được tham chiếu"
     },
     "index": {
-      "columns": "Columns",
+      "columns": "Cột",
       "dependency-columns": "Cột phụ thuộc",
       "indexes": "Chỉ mục",
-      "primary": "Primary",
-      "unique": "Unique"
+      "primary": "Khóa chính",
+      "unique": "Duy nhất"
     },
-    "indexes": "Indexes",
+    "indexes": "Chỉ mục",
     "insert-sql": "Chèn SQL",
     "no-diff": "Không có thay đổi nào để áp dụng",
     "partition": {
       "expression": "Expression",
-      "type": "Type",
-      "value": "Value"
+      "type": "Loại",
+      "value": "Giá trị"
     },
-    "partitions": "Partitions",
-    "preview": "Preview",
-    "raw-sql": "Raw SQL",
+    "partitions": "Phân vùng",
+    "preview": "Xem trước",
+    "raw-sql": "SQL thô",
     "schema": {
-      "duplicate-name": "Schema name already exists",
-      "name-placeholder": "Schema name",
+      "duplicate-name": "Tên schema đã tồn tại",
+      "name-placeholder": "Tên schema",
       "select": "Chọn lược đồ"
     },
     "select-object-hint": "Chọn một đối tượng cơ sở dữ liệu từ cây để chỉnh sửa",
     "self": "Trình chỉnh sửa lược đồ",
     "table": {
-      "duplicate-name": "Table name already exists",
-      "name-placeholder": "Table name",
-      "no-match": "No tables match the search",
-      "no-tables": "No tables"
+      "duplicate-name": "Tên bảng đã tồn tại",
+      "name-placeholder": "Tên bảng",
+      "no-match": "Không có bảng nào khớp với tìm kiếm",
+      "no-tables": "Không có bảng"
     },
     "table-partition": {
       "expression": "Biểu thức",
@@ -2093,16 +1931,14 @@
       "value-placeholder": "Giá trị nhãn..."
     }
   },
-  "setting.label.key-placeholder": "Khóa nhãn...",
-  "setting.label.value-placeholder": "Giá trị nhãn...",
   "settings": {
     "general": {
       "workspace": {
         "access-token-duration": {
-          "description": "How long access tokens remain valid before requiring refresh. Shorter durations improve security.",
-          "hours": "Hour(s)",
-          "minutes": "Minute(s)",
-          "self": "Access token duration"
+          "description": "Access token còn hiệu lực trong bao lâu trước khi cần làm mới. Thời lượng ngắn hơn giúp tăng cường bảo mật.",
+          "hours": "Giờ",
+          "minutes": "Phút",
+          "self": "Thời lượng access token"
         },
         "account": "Tài khoản",
         "ai-assistant": {
@@ -2185,6 +2021,7 @@
         "default-landing-page": {
           "default-view-changed-to-sql-editor": "Chế độ xem mặc định của không gian làm việc đã được thay đổi thành SQL Editor.",
           "go-to-sql-editor": "Đi tới Trình soạn thảo SQL",
+          "go-to-workspace": "Đi tới workspace",
           "self": "Trang đích mặc định",
           "sql-editor": {
             "description": "Sử dụng SQL Editor để thực hiện trực tiếp các thay đổi cơ sở dữ liệu, phù hợp cho mục đích sử dụng của một người hoặc môi trường không yêu cầu giám sát.",
@@ -2280,10 +2117,10 @@
           }
         },
         "refresh-token-duration": {
-          "days": "Day(s)",
-          "description": "How often users must fully reauthenticate. Configuration updates require users to sign in again for changes to take effect.",
-          "hours": "Hour(s)",
-          "self": "Refresh token duration"
+          "days": "Ngày",
+          "description": "Tần suất người dùng phải xác thực lại hoàn toàn. Các cập nhật cấu hình yêu cầu người dùng đăng nhập lại để thay đổi có hiệu lực.",
+          "hours": "Giờ",
+          "self": "Thời lượng refresh token"
         },
         "require-2fa": {
           "description": "Những người dùng chưa bật xác thực hai yếu tố cho tài khoản cá nhân của họ sẽ bị buộc phải định cấu hình.",
@@ -2331,8 +2168,8 @@
       },
       "add-member": "Thêm thành viên",
       "all-users": "Tất cả người dùng",
-      "assign-role": "Assign role",
-      "cannot-revoke-self": "You cannot revoke yourself",
+      "assign-role": "Gán vai trò",
+      "cannot-revoke-self": "Bạn không thể thu hồi chính mình",
       "copy-service-key": "Sao chép Khóa Dịch vụ",
       "entra-sync": {
         "description": "Đồng bộ người dùng và nhóm từ Entra ID (trước đây là Azure AD) hoặc Okta sang phiên bản Bytebase của bạn.",
@@ -2346,7 +2183,7 @@
       },
       "grant-access": "Cấp Quyền truy cập",
       "groups": {
-        "external-readonly": "External group is read-only.",
+        "external-readonly": "Nhóm bên ngoài là chỉ đọc.",
         "form": {
           "description": "Mô tả",
           "email": "Email",
@@ -2391,27 +2228,27 @@
       "view-by-roles": "Xem theo vai trò",
       "workload-identities": "Danh tính Workload",
       "workload-identity": "Workload Identity",
-      "workload-identity-advanced": "Advanced Settings",
-      "workload-identity-all-branches-tags": "All branches and tags",
-      "workload-identity-allowed-branches-tags": "Allowed Branches/Tags",
+      "workload-identity-advanced": "Cài đặt nâng cao",
+      "workload-identity-all-branches-tags": "Tất cả branch và tag",
+      "workload-identity-allowed-branches-tags": "Branch/Tag được phép",
       "workload-identity-audience": "Audience",
       "workload-identity-branch": "Branch",
-      "workload-identity-branch-hint": "Leave empty for all branches",
+      "workload-identity-branch-hint": "Để trống cho tất cả branch",
       "workload-identity-gitlab-url": "GitLab URL",
-      "workload-identity-gitlab-url-hint": "Your GitLab instance URL",
-      "workload-identity-group": "Group / Username",
+      "workload-identity-gitlab-url-hint": "URL phiên bản GitLab của bạn",
+      "workload-identity-group": "Nhóm / Tên người dùng",
       "workload-identity-issuer": "Issuer URL",
-      "workload-identity-owner": "Organization / Username",
-      "workload-identity-platform": "Platform",
-      "workload-identity-project": "Project",
-      "workload-identity-project-hint": "Leave empty to allow all projects",
+      "workload-identity-owner": "Tổ chức / Tên người dùng",
+      "workload-identity-platform": "Nền tảng",
+      "workload-identity-project": "Dự án",
+      "workload-identity-project-hint": "Để trống để cho phép tất cả dự án",
       "workload-identity-repo": "Repository",
-      "workload-identity-repo-hint": "Leave empty for all repositories in the organization",
-      "workload-identity-specific-branch": "Specific branch",
-      "workload-identity-specific-tag": "Specific tag",
-      "workload-identity-subject": "Subject Pattern",
+      "workload-identity-repo-hint": "Để trống cho tất cả repository trong tổ chức",
+      "workload-identity-specific-branch": "Branch cụ thể",
+      "workload-identity-specific-tag": "Tag cụ thể",
+      "workload-identity-subject": "Mẫu Subject",
       "workload-identity-tag": "Tag",
-      "workload-identity-tag-hint": "Leave empty to allow all tags"
+      "workload-identity-tag-hint": "Để trống để cho phép tất cả tag"
     },
     "profile": {
       "display-name": "Tên của bạn",
@@ -2477,14 +2314,14 @@
         }
       },
       "classification": {
-        "empty-classification": "The \"classification\" field is empty",
-        "guide-classification": "\"classification\" maps each category by ID. Leaf categories must reference a level number; parent categories omit the level.",
-        "guide-hierarchy": "IDs use a dash-separated hierarchy (e.g., \"1\" is a parent, \"1-1\" and \"1-2\" are its children).",
-        "guide-intro": "Edit the classification JSON below. An example template is provided when no classification is configured.",
-        "guide-levels": "\"levels\" defines sensitivity tiers with consecutive numbers starting from 1 (e.g., 1 = Public, 2 = Internal, 3 = Confidential).",
-        "invalid-json": "Invalid JSON format",
-        "missing-classification": "Missing \"classification\" field",
-        "missing-levels": "Missing \"levels\" field"
+        "empty-classification": "Trường \"classification\" đang trống",
+        "guide-classification": "\"classification\" ánh xạ mỗi danh mục theo ID. Danh mục lá phải tham chiếu một số cấp độ; danh mục cha bỏ qua cấp độ.",
+        "guide-hierarchy": "ID sử dụng cấu trúc phân cấp ngăn cách bằng dấu gạch ngang (ví dụ, \"1\" là cha, \"1-1\" và \"1-2\" là con của nó).",
+        "guide-intro": "Chỉnh sửa JSON phân loại bên dưới. Một mẫu ví dụ được cung cấp khi chưa cấu hình phân loại nào.",
+        "guide-levels": "\"levels\" xác định các bậc nhạy cảm với các số liên tiếp bắt đầu từ 1 (ví dụ, 1 = Công khai, 2 = Nội bộ, 3 = Bảo mật).",
+        "invalid-json": "Định dạng JSON không hợp lệ",
+        "missing-classification": "Thiếu trường \"classification\"",
+        "missing-levels": "Thiếu trường \"levels\""
       },
       "global-rules": {
         "condition-order": "Thứ tự điều kiện",
@@ -2621,7 +2458,6 @@
       }
     }
   },
-  "settings.general.workspace.default-landing-page.go-to-workspace": "Go to workspace",
   "setup": {
     "basic-info": "Thông tin cơ bản",
     "data": {
@@ -2666,7 +2502,7 @@
     "search-sheets": "Tìm kiếm Trang tính"
   },
   "sql-editor": {
-    "access-grants": "Access Grants",
+    "access-grants": "Cấp quyền truy cập",
     "access-search": {
       "scope": {
         "database": {
@@ -2677,16 +2513,16 @@
         }
       }
     },
-    "access-type-unmask": "See unmasked sensitive data",
-    "activate-access": "Activate",
-    "activate-confirm": "Are you sure you want to activate this access grant?",
+    "access-type-unmask": "Xem dữ liệu nhạy cảm chưa che",
+    "activate-access": "Kích hoạt",
+    "activate-confirm": "Bạn có chắc chắn muốn kích hoạt cấp quyền truy cập này không?",
     "add-a-new-instance": "Thêm phiên bản mới",
     "admin-mode": {
       "exit": "Thoát chế độ quản trị",
       "self": "Chế độ quản trị"
     },
     "allow-admin-mode-only": "Phiên bản <instance></instance> chỉ có thể truy cập ở chế độ quản trị.",
-    "and-n-more-databases": "and {{n}} more databases",
+    "and-n-more-databases": "và {{n}} cơ sở dữ liệu khác",
     "batch-export": {
       "database-no-longer-available": "Cơ sở dữ liệu không còn khả dụng trong tab hiện tại.",
       "export-limit-exceeds-executed": "Giới hạn xuất {{exportLimit}} vượt quá giới hạn số dòng của truy vấn đã thực thi ({{executedLimit}}); chỉ xuất các dòng đã được lưu trong bộ nhớ đệm.",
@@ -2732,20 +2568,20 @@
     "download-too-large-cells": "Tải xuống có {{cells}} ô qua {{statements}} câu lệnh; giới hạn là {{limit}}. Hãy giảm số dòng hoặc sử dụng Xuất.",
     "download-too-large-xlsx-columns": "XLSX không thể vượt quá {{limit}} cột; nhận được {{count}}. Hãy sử dụng Xuất hoặc định dạng khác.",
     "download-too-large-xlsx-rows": "XLSX không thể vượt quá {{limit}} dòng dữ liệu; nhận được {{count}}. Hãy sử dụng Xuất hoặc định dạng khác.",
-    "duration-day": "{{days}} day",
-    "duration-days": "{{days}} days",
+    "duration-day": "{{days}} ngày",
+    "duration-days": "{{days}} ngày",
     "duration-hour": "{{hours}} giờ",
     "duration-hours": "{{hours}} giờ",
     "execute-query": "Thực hiện truy vấn",
     "executing-query": "Đang thực hiện truy vấn",
-    "expire-at": "Expire at {{time}}",
-    "expire-in": "Expire in {{time}}",
-    "expired": "Expired",
+    "expire-at": "Hết hạn lúc {{time}}",
+    "expire-in": "Hết hạn sau {{time}}",
+    "expired": "Đã hết hạn",
     "format": "Định dạng",
     "format-default": "Mặc định",
-    "format-sql": "Format SQL",
+    "format-sql": "Định dạng SQL",
     "generate-sql": "Tạo SQL",
-    "grant-type-unmask": "Unmask",
+    "grant-type-unmask": "Bỏ che",
     "hex-format": "Định dạng thập lục phân",
     "hint-tips": {
       "confirm-to-close-unsaved-sheet": {
@@ -2754,14 +2590,14 @@
       }
     },
     "invalid-database": "Cơ sở dữ liệu không hợp lệ {{database}}",
-    "jit": "Just-In-Time Access",
+    "jit": "Truy cập Just-In-Time",
     "last-synced": "Đã đồng bộ lần cuối: <time></time>",
     "link-access": "Truy cập liên kết",
     "loading-data": "Đang tải Dữ liệu...",
     "loading-databases": "Đang tải Cơ sở dữ liệu...",
     "manage-connections": "Quản lý kết nối",
     "next-row": "Dòng tiếp theo",
-    "no-access-requests": "No access requests",
+    "no-access-requests": "Không có yêu cầu truy cập",
     "no-data-available": "Không có dữ liệu",
     "no-database-selected": "Chưa chọn cơ sở dữ liệu",
     "no-history-found": "Không tìm thấy lịch sử",
@@ -2795,15 +2631,15 @@
       "single-node": "Nút đơn"
     },
     "request-aborted": "Người dùng đã hủy yêu cầu",
-    "request-access": "Request Access",
-    "request-data-access": "Request Data Access",
-    "request-jit": "Request just-in-time access",
+    "request-access": "Yêu cầu truy cập",
+    "request-data-access": "Yêu cầu truy cập dữ liệu",
+    "request-jit": "Yêu cầu truy cập just-in-time",
     "request-query": "Yêu cầu truy vấn",
     "result-limit": {
       "self": "Giới hạn kết quả"
     },
-    "revoke-access": "Revoke",
-    "revoke-confirm": "Are you sure you want to revoke this access grant?",
+    "revoke-access": "Thu hồi",
+    "revoke-confirm": "Bạn có chắc chắn muốn thu hồi cấp quyền truy cập này không?",
     "rows": {
       "self": "dòng"
     },
@@ -2844,13 +2680,13 @@
     "table-empty-placeholder": "Nhấp vào Chạy để thực hiện truy vấn.",
     "table-view": "Chế độ xem bảng",
     "text-format": "Định dạng văn bản",
-    "unmask-warning": "The query result may include unmasked sensitive data.",
+    "unmask-warning": "Kết quả truy vấn có thể bao gồm dữ liệu nhạy cảm chưa che.",
     "upload-file": "Tải lên tệp",
     "url-copied-to-clipboard": "URL đã được sao chép vào bảng nhớ tạm của bạn",
     "vertical-display": "Hiển thị dọc",
     "view-database-detail": "Xem chi tiết cơ sở dữ liệu",
     "view-detail": "Xem chi tiết",
-    "view-issue": "View Issue",
+    "view-issue": "Xem Issue",
     "view-schema-text": "Xem văn bản lược đồ",
     "visualize-explain": "Trực quan hóa Giải thích",
     "web-socket": {
@@ -2862,9 +2698,9 @@
         "title": "Máy chủ ngôn ngữ"
       },
       "errors": {
-        "description": "Auto Completion might be limited or disabled.",
-        "disconnected": "WebSocket disconnected",
-        "title": "WebSocket connection failed"
+        "description": "Tự động hoàn thành có thể bị giới hạn hoặc tắt.",
+        "disconnected": "WebSocket đã ngắt kết nối",
+        "title": "Kết nối WebSocket thất bại"
       }
     }
   },
@@ -2938,7 +2774,7 @@
     "policy-removed": "Đã xóa thành công chính sách đánh giá.",
     "policy-update-failed": "Không cập nhật được chính sách đánh giá.",
     "policy-updated": "Đã cập nhật thành công chính sách đánh giá.",
-    "review-policy": "Review policy",
+    "review-policy": "Chính sách xem xét",
     "rule": {
       "ADVICE_ONLINE_MIGRATION": {
         "component": {
@@ -3678,23 +3514,23 @@
       "billing-period": "Kỳ thanh toán",
       "cancel": "Hủy đăng ký",
       "cancel-dialog": {
-        "comment-label": "Anything else you'd like to share? (optional)",
-        "comment-placeholder": "Tell us more so we can improve...",
-        "confirm": "Confirm cancellation",
-        "description": "We're sorry to see you go. Your feedback helps us improve.",
-        "keep": "Keep subscription",
+        "comment-label": "Bạn có điều gì khác muốn chia sẻ không? (tùy chọn)",
+        "comment-placeholder": "Hãy cho chúng tôi biết thêm để chúng tôi cải thiện...",
+        "confirm": "Xác nhận hủy",
+        "description": "Chúng tôi rất tiếc khi bạn rời đi. Phản hồi của bạn giúp chúng tôi cải thiện.",
+        "keep": "Giữ đăng ký",
         "reason": {
-          "customer-service": "Customer service issues",
-          "low-quality": "Quality didn't meet expectations",
-          "missing-features": "Missing features I need",
-          "other": "Other reason",
-          "switched-service": "Switched to a different product",
-          "too-complex": "Too complex to use",
-          "too-expensive": "Too expensive",
-          "unused": "Not using it enough"
+          "customer-service": "Vấn đề về dịch vụ khách hàng",
+          "low-quality": "Chất lượng không đáp ứng kỳ vọng",
+          "missing-features": "Thiếu các tính năng tôi cần",
+          "other": "Lý do khác",
+          "switched-service": "Chuyển sang một sản phẩm khác",
+          "too-complex": "Quá phức tạp để sử dụng",
+          "too-expensive": "Quá đắt",
+          "unused": "Không sử dụng đủ nhiều"
         },
-        "reason-label": "Why are you canceling? (required)",
-        "title": "Cancel your subscription"
+        "reason-label": "Tại sao bạn hủy? (bắt buộc)",
+        "title": "Hủy đăng ký của bạn"
       },
       "cancel-pending": "Đăng ký đã bị hủy và sẽ kết thúc vào {{date}}.",
       "canceled": "Đã hủy đăng ký",
@@ -3704,8 +3540,8 @@
         "percentage-off": "tháng đầu giảm {{value}}%",
         "price-off": "giảm ${{value}}"
       },
-      "enterprise-description": "Scale your business securely while staying compliant.",
-      "free-description": "Designed for solo devs, side-projects, and experiments.",
+      "enterprise-description": "Mở rộng quy mô doanh nghiệp của bạn một cách an toàn trong khi vẫn tuân thủ.",
+      "free-description": "Được thiết kế cho lập trình viên độc lập, dự án phụ và các thử nghiệm.",
       "manage-invoices": "Quản lý hóa đơn",
       "next-period-price": "Giá kỳ tiếp theo",
       "payment-info": "Thông tin thanh toán",
@@ -3713,7 +3549,7 @@
       "pending-title": "Đang hoàn tất giao dịch...",
       "per-user-per-month": "/ người dùng / tháng",
       "privacy-policy": "Chính sách bảo mật",
-      "pro-description": "Built for teams creating production-ready applications.",
+      "pro-description": "Được xây dựng cho các nhóm tạo ra ứng dụng sẵn sàng cho production.",
       "seats": "Người dùng",
       "see-comparison": "Xem so sánh tính năng chi tiết",
       "subscribe": "Đăng ký ngay",
@@ -3761,20 +3597,37 @@
       }
     }
   },
-  "subscription.instance-assignment.assign-license": "Gán giấy phép",
-  "subscription.instance-assignment.n-license-remain": "còn lại {{n}}",
-  "subscription.usage.instance-count.runoutof": "Bạn đã hết hạn ngạch {{total}} phiên bản của mình.",
-  "subscription.usage.instance-count.title": "Giới hạn số lượng phiên bản",
   "task": {
+    "affected-rows": "Hàng bị ảnh hưởng",
     "cancel-task": "Hủy tác vụ | Hủy các tác vụ",
     "cancel-task-description": "Các lần chạy tác vụ đang chờ và sẵn sàng sẽ được hủy ngay. Các lần chạy đang chạy sẽ nhận yêu cầu hủy theo cách cố gắng tối đa và có thể tiếp tục chạy; hãy thử lại nếu cần.",
+    "check-type": {
+      "affected-rows": {
+        "description": "Ước tính theo thông tin thống kê.",
+        "self": "Số dòng bị ảnh hưởng"
+      },
+      "sql-review": {
+        "description": "Phân tích câu lệnh SQL để tìm các vấn đề tiềm ẩn và đưa ra khuyến nghị. Bao gồm các quy tắc tích hợp sẵn và các quy tắc tùy chỉnh của bạn.",
+        "self": "Xem xét SQL"
+      }
+    },
     "created": "Đã tạo",
     "data-export-creator-only": "Chỉ người tạo sự cố mới có thể thực hiện tác vụ xuất dữ liệu",
     "error": {
       "scheduled-time-must-be-in-the-future": "Thời gian dự kiến phải ở trong tương lai"
     },
+    "executed-by": "Người thực thi",
     "execution-time": "Thời gian thực thi",
+    "no-cancelable-tasks": "Không có tác vụ nào có thể hủy",
     "no-permission": "Không có quyền thực hiện hành động này",
+    "no-runnable-tasks": "Không có tác vụ nào có thể chạy được",
+    "no-selectable-tasks": "Không có tác vụ nào có thể chọn",
+    "no-skippable-tasks": "Không có nhiệm vụ nào có thể bỏ qua",
+    "no-tasks-selected": "Không có nhiệm vụ nào được chọn",
+    "online-migration": {
+      "self": "Di chuyển trực tuyến"
+    },
+    "prior-backup": "Sao lưu trước",
     "run-immediately": {
       "description": "Các tác vụ sẽ bắt đầu thực thi ngay khi bạn nhấp vào Chạy. Không cần trì hoãn hay lên lịch.",
       "self": "Chạy ngay lập tức"
@@ -3784,7 +3637,9 @@
       "description": "Đặt ngày và giờ cụ thể để các tác vụ tự động bắt đầu chạy. Hữu ích cho các khung giờ bảo trì hoặc ngoài giờ cao điểm.",
       "self": "Lên lịch cho sau"
     },
+    "scheduled-time": "Thời gian đã lên lịch",
     "select-scheduled-time": "Chọn thời gian đã lên lịch",
+    "select-task": "Chọn tác vụ",
     "skip-prior-backup": "Bỏ qua sao lưu trước",
     "skip-prior-backup-description": "Bỏ qua sao lưu dữ liệu tự động trước khi áp dụng thay đổi",
     "skip-task": "Bỏ qua nhiệm vụ | Bỏ qua nhiệm vụ",
@@ -3799,56 +3654,55 @@
       "skipped": "Đã bỏ qua"
     }
   },
-  "task-run.blocked-sessions": "Phiên bị chặn",
-  "task-run.blocked-sessions-description": "Các phiên bị chặn bởi phiên hiện tại",
-  "task-run.blocking-sessions": "Phiên chặn",
-  "task-run.blocking-sessions-description": "Các phiên đang chặn phiên hiện tại",
-  "task-run.history": "Lịch sử",
-  "task-run.latest": "Mới nhất",
-  "task-run.latest-logs": "Nhật ký mới nhất",
-  "task-run.log-detail.backing-up": "đang sao lưu...",
-  "task-run.log-detail.backup-completed": "đã hoàn thành ({{count}} bảng)",
-  "task-run.log-detail.completed": "Đã hoàn thành",
-  "task-run.log-detail.computing": "tính toán...",
-  "task-run.log-detail.dumping": "đang xuất...",
-  "task-run.log-detail.retry-attempt": "nỗ lực {{current}}/{{max}}",
-  "task-run.log-detail.syncing": "đang đồng bộ hóa...",
-  "task-run.log-type.command-execute": "Lệnh thực thi",
-  "task-run.log-type.compute-diff": "Tính toán chênh lệch",
-  "task-run.log-type.database-sync": "Đồng bộ cơ sở dữ liệu",
-  "task-run.log-type.ghost-migration": "Di chuyển gh-ost",
-  "task-run.log-type.prior-backup": "Sao lưu trước",
-  "task-run.log-type.release-file-execute": "Tệp phát hành",
-  "task-run.log-type.retry": "Thử lại",
-  "task-run.log-type.schema-dump": "Xuất schema",
-  "task-run.log-type.transaction": "Giao dịch",
-  "task-run.log-viewer.collapse-all": "Thu gọn tất cả",
-  "task-run.log-viewer.expand-all": "Mở rộng tất cả",
-  "task-run.log-viewer.multiple-replicas-notice": "Phát hiện khởi động lại máy chủ trong quá trình thực thi. Nhật ký được nhóm theo bản sao.",
-  "task-run.log-viewer.replica-n": "Bản sao #{{n}}",
-  "task-run.log-viewer.summary": "{{sections}} phần · {{entries}} mục",
-  "task-run.no-session-found": "Không tìm thấy phiên",
-  "task-run.rollback.available": "Có {{count}} mục có thể hoàn tác",
-  "task-run.rollback.no-statement-generated": "Không tạo được câu lệnh",
-  "task-run.rollback.preview-statement.description": "Xem lại các câu lệnh hoàn tác đã tạo trước khi tạo kế hoạch hoàn tác.",
-  "task-run.status.enqueued": "Đang chờ thực thi.",
-  "task-run.status.enqueued-with-rollout-time": "Đang chờ thực thi sau {{time}}.",
-  "task-run.status.waiting-max-tasks-per-rollout": "Đang chờ các tác vụ khác hoàn thành. Đã đạt đến giới hạn số lượng tác vụ đang chạy tối đa cho mỗi lần triển khai. Báo cáo gần nhất lúc {{time}}.",
-  "task.affected-rows": "Hàng bị ảnh hưởng",
-  "task.check-type.affected-rows.description": "Ước tính theo thông tin thống kê.",
-  "task.check-type.affected-rows.self": "Số dòng bị ảnh hưởng",
-  "task.check-type.sql-review.description": "Analyze the SQL statement for potential issues and provide recommendations. Includes built-in rules and your custom rules.",
-  "task.check-type.sql-review.self": "SQL review",
-  "task.executed-by": "Người thực thi",
-  "task.no-cancelable-tasks": "Không có tác vụ nào có thể hủy",
-  "task.no-runnable-tasks": "Không có tác vụ nào có thể chạy được",
-  "task.no-selectable-tasks": "Không có tác vụ nào có thể chọn",
-  "task.no-skippable-tasks": "Không có nhiệm vụ nào có thể bỏ qua",
-  "task.no-tasks-selected": "Không có nhiệm vụ nào được chọn",
-  "task.online-migration.self": "Di chuyển trực tuyến",
-  "task.prior-backup": "Sao lưu trước",
-  "task.scheduled-time": "Thời gian đã lên lịch",
-  "task.select-task": "Chọn tác vụ",
+  "task-run": {
+    "blocked-sessions": "Phiên bị chặn",
+    "blocked-sessions-description": "Các phiên bị chặn bởi phiên hiện tại",
+    "blocking-sessions": "Phiên chặn",
+    "blocking-sessions-description": "Các phiên đang chặn phiên hiện tại",
+    "history": "Lịch sử",
+    "latest": "Mới nhất",
+    "latest-logs": "Nhật ký mới nhất",
+    "log-detail": {
+      "backing-up": "đang sao lưu...",
+      "backup-completed": "đã hoàn thành ({{count}} bảng)",
+      "completed": "Đã hoàn thành",
+      "computing": "tính toán...",
+      "dumping": "đang xuất...",
+      "retry-attempt": "nỗ lực {{current}}/{{max}}",
+      "syncing": "đang đồng bộ hóa..."
+    },
+    "log-type": {
+      "command-execute": "Lệnh thực thi",
+      "compute-diff": "Tính toán chênh lệch",
+      "database-sync": "Đồng bộ cơ sở dữ liệu",
+      "ghost-migration": "Di chuyển gh-ost",
+      "prior-backup": "Sao lưu trước",
+      "release-file-execute": "Tệp phát hành",
+      "retry": "Thử lại",
+      "schema-dump": "Xuất schema",
+      "transaction": "Giao dịch"
+    },
+    "log-viewer": {
+      "collapse-all": "Thu gọn tất cả",
+      "expand-all": "Mở rộng tất cả",
+      "multiple-replicas-notice": "Phát hiện khởi động lại máy chủ trong quá trình thực thi. Nhật ký được nhóm theo bản sao.",
+      "replica-n": "Bản sao #{{n}}",
+      "summary": "{{sections}} phần · {{entries}} mục"
+    },
+    "no-session-found": "Không tìm thấy phiên",
+    "rollback": {
+      "available": "Có {{count}} mục có thể hoàn tác",
+      "no-statement-generated": "Không tạo được câu lệnh",
+      "preview-statement": {
+        "description": "Xem lại các câu lệnh hoàn tác đã tạo trước khi tạo kế hoạch hoàn tác."
+      }
+    },
+    "status": {
+      "enqueued": "Đang chờ thực thi.",
+      "enqueued-with-rollout-time": "Đang chờ thực thi sau {{time}}.",
+      "waiting-max-tasks-per-rollout": "Đang chờ các tác vụ khác hoàn thành. Đã đạt đến giới hạn số lượng tác vụ đang chạy tối đa cho mỗi lần triển khai. Báo cáo gần nhất lúc {{time}}."
+    }
+  },
   "two-factor": {
     "description": "Xác thực hai yếu tố cung cấp một lớp bảo mật bổ sung cho các tài khoản thành viên. Khi đăng nhập, bạn sẽ được yêu cầu nhập mã bảo mật do Ứng dụng xác thực của bạn tạo.",
     "disable": {

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -1,21 +1,25 @@
 {
-  "activity.sentence.added-spec": "添加了",
-  "activity.sentence.canceled-issue": "closed the issue",
-  "activity.sentence.changed-description": "changed description",
-  "activity.sentence.changed-from-to": "changed {{name}} from \"{{oldValue}}\" to \"{{newValue}}\"",
-  "activity.sentence.changed-labels": "changed labels",
-  "activity.sentence.changed-targets-of": "修改了 targets：",
-  "activity.sentence.created-issue": "created issue",
-  "activity.sentence.disabled-prior-backup-on": "禁用了 prior backup",
-  "activity.sentence.enabled-prior-backup-on": "启用了 prior backup",
-  "activity.sentence.modified-sql-of": "修改了 SQL",
-  "activity.sentence.removed-spec": "移除了",
-  "activity.sentence.reopened-issue": "reopened issue",
-  "activity.sentence.resolved-issue": "将工单标记为已完成",
-  "activity.sentence.review-done-rollout-created": "审批完成，已创建发布",
-  "activity.sentence.review-done-rollout-created-for-plan": "审批完成，已为计划创建发布",
-  "activity.sentence.review-skipped-rollout-created": "已跳过审批，已创建发布",
-  "activity.sentence.review-skipped-rollout-created-for-plan": "已跳过审批，已为计划创建发布",
+  "activity": {
+    "sentence": {
+      "added-spec": "添加了",
+      "canceled-issue": "关闭了工单",
+      "changed-description": "修改了描述",
+      "changed-from-to": "将 {{name}} 从 \"{{oldValue}}\" 修改为 \"{{newValue}}\"",
+      "changed-labels": "修改了标签",
+      "changed-targets-of": "修改了目标：",
+      "created-issue": "创建了工单",
+      "disabled-prior-backup-on": "禁用了预备份",
+      "enabled-prior-backup-on": "启用了预备份",
+      "modified-sql-of": "修改了 SQL",
+      "removed-spec": "移除了",
+      "reopened-issue": "重新打开了工单",
+      "resolved-issue": "将工单标记为已完成",
+      "review-done-rollout-created": "审批完成，已创建发布",
+      "review-done-rollout-created-for-plan": "审批完成，已为计划创建发布",
+      "review-skipped-rollout-created": "已跳过审批，已创建发布",
+      "review-skipped-rollout-created-for-plan": "已跳过审批，已为计划创建发布"
+    }
+  },
   "agent": {
     "active-only-chats": "仅活跃",
     "ai-not-configured": {
@@ -52,6 +56,7 @@
     "reply": "回复",
     "result": "结果",
     "retry-last-chat-turn": "重试",
+    "self": "助手",
     "send": "发送",
     "stop": "停止",
     "tool-answer": "回答",
@@ -69,7 +74,6 @@
     "unarchive-all-chats": "取消归档所有对话",
     "unarchive-chat": "取消归档"
   },
-  "agent.self": "助手",
   "audit-log": {
     "advanced-search": {
       "scope": {
@@ -152,9 +156,9 @@
       "create-admin-account": "注册管理员",
       "existing-user": "已有账号?",
       "title": "注册您的账号"
-    }
+    },
+    "token-expired-title": "令牌已过期"
   },
-  "auth.token-expired-title": "令牌已过期",
   "banner": {
     "external-url": "Bytebase 还没有配置 --external-url",
     "license-expired": "您的{{plan}}证书已在 {{expireAt}} 过期",
@@ -182,7 +186,7 @@
         "or": {
           "description": "以下任一为真…"
         },
-        "tooltip": "A condition group is a collection of conditions connected by operators \"And\" and \"Or\"."
+        "tooltip": "条件组是由「And」和「Or」运算符连接的一组条件。"
       },
       "input-value": "输入值",
       "input-value-press-enter": "输入值，按回车确认",
@@ -205,6 +209,7 @@
     "actions": "操作",
     "activated": "已激活",
     "active": "开启",
+    "activity": "活动",
     "add": "添加",
     "add-permissions": "添加权限",
     "added": "已创建",
@@ -212,6 +217,7 @@
     "admin": "管理员",
     "all": "全部",
     "allow": "允许",
+    "and": "和",
     "approve": "批准",
     "approved": "已批准",
     "archive": "归档",
@@ -219,15 +225,20 @@
     "archive-resource": "归档{{type}}",
     "archived": "已归档",
     "back": "返回",
+    "back-to-workspace": "返回工作区",
     "bypassed": "已绕过",
     "cancel": "取消",
     "cannot-undo-this-action": "这个操作无法撤销",
+    "catalog": "Catalog",
     "changelog": "变更历史",
     "classification-level": "分类等级",
     "clear": "清除",
     "clear-filters": "清除过滤",
     "close": "关闭",
+    "close-mobile-sidebar": "关闭移动端侧边栏",
     "closed": "已关闭",
+    "collapse": "收起",
+    "column": "列",
     "comment": "评论",
     "configure": "配置",
     "configure-now": "现在配置",
@@ -238,7 +249,7 @@
     "continue-anyway": "仍要继续",
     "copied": "已拷贝",
     "copy": "拷贝",
-    "copy-failed": "Copy failed",
+    "copy-failed": "复制失败",
     "create": "创建",
     "created": "已创建",
     "created-at": "创建于",
@@ -258,7 +269,7 @@
     "deleted": "已删除",
     "deny": "拒绝",
     "description": "描述",
-    "deselect-all": "Deselect all",
+    "deselect-all": "取消全选",
     "detail": "详情",
     "detailed-guide": "详细指南",
     "disable": "禁用",
@@ -268,11 +279,12 @@
     "download": "下载",
     "draft": "草稿",
     "duplicate": "拷贝",
-    "duration": "Duration",
+    "duration": "耗时",
     "edit": "编辑",
+    "edited": "已编辑",
     "email": "邮箱",
     "email-ascii-only": "邮箱地址仅支持 ASCII 字符（英文字母、数字及 . _ - + 等符号）。",
-    "empty": "Empty",
+    "empty": "空",
     "enable": "开启",
     "enabled": "开启",
     "environment": "环境",
@@ -287,7 +299,7 @@
       "size-limit": "文件大小需小于 {{size}} MiB",
       "type-limit": "仅支持 {{extension}} 类型的文件"
     },
-    "filter": "Filter",
+    "filter": "筛选",
     "filter-by-name": "按名称过滤",
     "fork": "复刻",
     "from": "从",
@@ -299,22 +311,28 @@
     "home": "主页",
     "id": "ID",
     "import": "导入",
+    "in-progress": "进行中",
     "info": "信息",
     "instance": "实例",
     "instances": "实例",
-    "is-required": "is required",
+    "is-required": "为必填项",
+    "issue": "工单",
     "issues": "工单",
-    "items": "items",
+    "items": "项",
     "key": "键",
     "labels": "标签",
+    "language": "语言",
     "learn-more": "了解更多",
     "leave-without-saving": "不保存变动？",
+    "license": "License",
+    "line": "行",
     "load-more": "加载更多",
     "loading": "加载中",
     "logout": "登出",
     "manage": "管理",
-    "manually-select": "Manually select",
+    "manually-select": "手动选择",
     "maximize": "最大化",
+    "members": "成员",
     "members_one": "成员",
     "members_other": "成员",
     "minutes": "分钟",
@@ -329,9 +347,12 @@
     "next": "下一步",
     "no-data": "无数据",
     "not-started": "未开始",
-    "ok": "OK",
+    "ok": "确定",
+    "only-creator-allowed-export": "只有创建者可以导出",
+    "open": "打开",
+    "operation": "操作",
     "operations": "操作",
-    "optional": "Optional",
+    "optional": "可选",
     "or": "或者",
     "overview": "概览",
     "password": "密码",
@@ -345,12 +366,16 @@
     "query": "查询",
     "read-only": "只读",
     "reason": "理由",
+    "recent": "最近访问",
     "refresh": "刷新",
     "regenerate": "重新生成",
     "reject": "驳回",
     "rejected": "已拒绝",
     "release": "版本",
+    "remaining": "剩余",
     "remove": "移除",
+    "removed": "已移除",
+    "reopen": "重新打开",
     "reorder": "排序",
     "required-permission": "所需权限",
     "required-workspace-permission": "初始化工作空间 UX 需要以下权限",
@@ -360,6 +385,7 @@
     "resources": "资源",
     "restore": "恢复",
     "restored": "已恢复",
+    "retry": "重试",
     "revert": "恢复",
     "revoke": "撤销",
     "revoked": "已撤销",
@@ -373,7 +399,7 @@
       "self": "行"
     },
     "rows-per-page": "每页行数",
-    "run": "Run",
+    "run": "运行",
     "running": "进行中",
     "save": "保存",
     "schema": "模式",
@@ -382,14 +408,17 @@
     "search-for-more": "搜索更多",
     "select": "请选择",
     "select-all": "全选",
-    "selected": "selected",
+    "selected": "已选择",
     "sensitive-placeholder": "敏感数据 - 仅写入",
     "setting": "设置",
     "settings": "设置",
     "share": "分享",
+    "show-less": "收起",
+    "show-more": "显示更多",
     "sign-in": "登录",
     "sign-in-as-admin": "以管理员身份登录",
     "sign-up": "注册",
+    "skip": "跳过",
     "skipped": "已跳过",
     "snapshot": "快照",
     "sql": "SQL",
@@ -399,19 +428,23 @@
     "status": "状态",
     "submit": "提交",
     "succeed": "成功",
+    "success": "成功",
     "system": "系统",
     "table": "表",
+    "task": "任务",
     "text-wrap": "文本折行",
     "tips": "提示信息",
     "title": "标题",
     "to": "到",
-    "total": "Total",
+    "total": "总计",
     "total-n-items": "共 {{n}} 项",
     "transfer": "转移",
+    "troubleshoot": "排查问题",
     "type": "类型",
     "type-to-search": "输入以搜索",
     "unassigned": "未分配",
     "under-review": "审批中",
+    "unknown": "未知",
     "unlimited": "无限制",
     "untitled": "未命名",
     "update": "更新",
@@ -426,100 +459,14 @@
     "version": "版本",
     "view": "查看",
     "view-details": "查看详情",
+    "view-doc": "查看文档",
     "visibility": "可见性",
+    "want-help": "需要帮助",
     "warning": "警告",
     "webhooks": "Webhook",
     "write-only": "仅写入",
     "you": "您"
   },
-  "common.activity": "活动",
-  "common.add": "添加",
-  "common.admin": "管理员",
-  "common.all": "全部",
-  "common.and": "和",
-  "common.archive": "归档",
-  "common.archived": "已归档",
-  "common.back-to-workspace": "Back to workspace",
-  "common.cancel": "取消",
-  "common.cannot-undo-this-action": "这个操作无法撤销",
-  "common.catalog": "Catalog",
-  "common.close": "关闭",
-  "common.close-mobile-sidebar": "关闭移动端侧边栏",
-  "common.collapse": "收起",
-  "common.column": "列",
-  "common.comment": "Comment",
-  "common.confirm": "确认",
-  "common.continue-anyway": "仍要继续",
-  "common.copy": "拷贝",
-  "common.create": "创建",
-  "common.creating": "创建中...",
-  "common.custom": "自定义",
-  "common.database": "数据库",
-  "common.database-group": "数据库组",
-  "common.databases": "数据库",
-  "common.default": "默认",
-  "common.delete": "删除",
-  "common.delete-resource": "删除{{type}}",
-  "common.deleted": "已删除",
-  "common.detail": "Detail",
-  "common.detailed-guide": "详细指南",
-  "common.edit": "编辑",
-  "common.edited": "edited",
-  "common.environment": "环境",
-  "common.import": "导入",
-  "common.in-progress": "进行中",
-  "common.issue": "工单",
-  "common.key": "键",
-  "common.labels": "标签",
-  "common.language": "Language",
-  "common.learn-more": "了解更多",
-  "common.license": "License",
-  "common.line": "行",
-  "common.load-more": "加载更多",
-  "common.loading": "加载中",
-  "common.logout": "登出",
-  "common.members": "成员",
-  "common.minutes": "分钟",
-  "common.n-more": "还有 {{n}} 个",
-  "common.no-data": "无数据",
-  "common.only-creator-allowed-export": "只有创建者可以导出",
-  "common.open": "打开",
-  "common.operation": "操作",
-  "common.optional": "可选",
-  "common.or": "或者",
-  "common.overview": "概览",
-  "common.password": "密码",
-  "common.project": "项目",
-  "common.read-only": "只读",
-  "common.recent": "最近访问",
-  "common.remaining": "剩余",
-  "common.remove": "删除",
-  "common.removed": "已移除",
-  "common.reopen": "重新打开",
-  "common.restore": "恢复",
-  "common.retry": "重试",
-  "common.role.self": "角色",
-  "common.rollout": "发布",
-  "common.save": "保存",
-  "common.sensitive-placeholder": "敏感数据 - 仅写入",
-  "common.show-less": "收起",
-  "common.show-more": "显示更多",
-  "common.skip": "跳过",
-  "common.success": "成功",
-  "common.task": "任务",
-  "common.troubleshoot": "排查问题",
-  "common.unknown": "未知",
-  "common.unlimited": "无限制",
-  "common.updated": "已更新",
-  "common.updating": "更新中",
-  "common.user": "用户",
-  "common.username": "用户名",
-  "common.value": "值",
-  "common.version": "版本",
-  "common.view-doc": "查看文档",
-  "common.want-help": "Want help",
-  "common.warning": "警告",
-  "common.write-only": "仅写入",
   "create-db": {
     "cluster": "集群",
     "database-owner-name": "数据库所有者",
@@ -558,6 +505,7 @@
     "issue-review": {
       "and-n-other-users": "{{names}} 和另外 {{count}} 位用户",
       "approved-by": "已批准",
+      "approved-issue": "批准了工单",
       "disallow-approve-reason": {
         "some-task-checks-are-still-running": "部分任务检查仍在运行中。",
         "some-task-checks-didnt-pass": "部分任务检查未通过。"
@@ -565,7 +513,10 @@
       "generating-approval-flow": "正在生成审批流",
       "re-request-review": "请求再次审批",
       "re-request-review-success": "已成功请求再次审批",
+      "re-requested-review": "再次请求了工单审批",
       "rejected-by": "被拒绝",
+      "rejected-issue": "拒绝了工单",
+      "retry-approval-finding": "重试",
       "self-approval-not-allowed": "此项目不允许工单创建者审批。您无法以创建者身份批准。"
     },
     "risk": {
@@ -608,17 +559,13 @@
     },
     "self": "自定义审批"
   },
-  "custom-approval.issue-review.approved-issue": "approved issue",
-  "custom-approval.issue-review.re-requested-review": "re-requested issue review",
-  "custom-approval.issue-review.rejected-issue": "rejected issue",
-  "custom-approval.issue-review.retry-approval-finding": "重试",
   "data-source": {
     "additional-node-addresses": "附加节点地址",
     "automatic-query-data-source": "自动",
     "connection-string-schema": "连接串模式",
     "connection-type": "连接类型",
     "delete-read-only-data-source": "删除只读数据源",
-    "direct-connection": "Direct Connection",
+    "direct-connection": "直接连接",
     "extra-params": {
       "description": "数据库连接字符串的其他参数",
       "self": "额外的参数"
@@ -686,47 +633,16 @@
     },
     "ssl-connection": "SSL 连接"
   },
-  "data-source.additional-node-addresses": "附加节点地址",
-  "data-source.connection-string-schema": "连接串模式",
-  "data-source.connection-type": "连接类型",
-  "data-source.delete-read-only-data-source": "删除只读数据源",
-  "data-source.direct-connection": "Direct Connection",
-  "data-source.extra-params.description": "数据库连接字符串的其他参数",
-  "data-source.extra-params.self": "额外的参数",
-  "data-source.no-read-only-data-source": "没有只读数据源",
-  "data-source.private-key-passphrase": "私钥密码",
-  "data-source.private-key-passphrase-placeholder": "如果私钥未加密，请留空",
-  "data-source.private-key-passphrase-tip": "加密私钥的可选密码",
-  "data-source.read-replica-host": "只读副本 Host",
-  "data-source.read-replica-port": "只读副本端口",
-  "data-source.replica-set": "副本集",
-  "data-source.snowflake-keypair-tip": "密钥对认证",
-  "data-source.ssh-connection": "SSH 连接",
-  "data-source.ssh-type.none": "不使用",
-  "data-source.ssh-type.tunnel-and-private-key": "隧道 + 私钥",
-  "data-source.ssh.host": "服务器",
-  "data-source.ssh.password": "密码",
-  "data-source.ssh.port": "端口",
-  "data-source.ssh.private-key": "私钥",
-  "data-source.ssh.ssh-key": "SSH 密钥",
-  "data-source.ssh.user": "用户名",
-  "data-source.ssl-connection": "SSL 连接",
-  "data-source.ssl.ca-cert": "CA 证书",
-  "data-source.ssl.ca-path": "CA 证书路径",
-  "data-source.ssl.client-cert": "客户端证书",
-  "data-source.ssl.client-cert-path": "客户端证书路径",
-  "data-source.ssl.client-key": "客户端密钥",
-  "data-source.ssl.client-key-path": "客户端密钥路径",
-  "data-source.ssl.verify-certificate": "验证 TLS 证书",
-  "data-source.ssl.verify-certificate-tooltip": "启用 TLS 证书验证以确保安全连接。仅在开发环境或证书无法正确验证的情况下禁用（例如自签名证书、VPN 环境）。警告：禁用验证是不安全的",
   "database": {
     "access-denied": "您无权访问该数据库",
     "all": "所有数据库",
     "change-database": "变更数据库",
     "checks": "Check 约束",
     "classification": {
-      "description": "定义分类分级，跨列和数据库统一应用脱敏策略。"
+      "description": "定义分类分级，跨列和数据库统一应用脱敏策略。",
+      "self": "分类"
     },
+    "column": "列",
     "columns": "列",
     "comment": "注释",
     "data-size": "数据大小",
@@ -734,9 +650,13 @@
     "edit-labels": "编辑标签",
     "edit-schema": "变更 Schema",
     "engine": "引擎",
-    "expression": "Expression",
+    "export-schema": "导出 Schema",
+    "export-schema-multi-file": "多文件 (ZIP)",
+    "export-schema-single-file": "单文件",
+    "expression": "表达式",
     "external-database-name": "外部数据库名称",
     "external-server-name": "外部服务器名称",
+    "failed-to-export-schema": "导出 Schema 失败",
     "filter-database": "筛选数据库",
     "foreign-key": {
       "reference": "引用"
@@ -744,6 +664,7 @@
     "foreign-keys": "外键",
     "index-size": "索引大小",
     "indexes": "索引",
+    "labels": "数据库标签",
     "last-sync": "最后一次同步",
     "mixed-label-values": "混合值",
     "mixed-label-values-warning": "部分标签拥有不同的值，编辑标签将会批量应用。仅在您打算更改时再编辑这些键值对。",
@@ -790,6 +711,7 @@
       "unspecified": "未指定"
     },
     "select": "选择数据库",
+    "successfully-exported-schema": "成功导出 Schema",
     "successfully-transferred-databases": "成功转移数据库",
     "sync-complete-for-instance": "实例 '{{0}}' 同步完成",
     "sync-database": "同步数据库",
@@ -828,33 +750,22 @@
     "unassign-alert-title": "取消分配数据库",
     "unassigned-databases": "未分配的数据库",
     "unique": "唯一",
-    "visible": "Visible"
+    "visible": "可见"
   },
   "database-group": {
     "condition": {
-      "self": "Condition"
+      "self": "条件"
     },
-    "delete-group": "Delete the database group {{name}}",
-    "matched-database": "Matched database",
-    "no-matched-databases": "No matched databases",
-    "select": "Select database group",
-    "unmatched-database": "Unmatched database"
+    "delete-group": "删除数据库分组 {{name}}",
+    "matched-database": "匹配的数据库",
+    "no-matched-databases": "没有匹配的数据库",
+    "select": "选择数据库分组",
+    "unmatched-database": "未匹配的数据库"
   },
-  "database.classification.self": "分类",
-  "database.column": "列",
-  "database.engine": "引擎",
-  "database.export-schema": "导出 Schema",
-  "database.export-schema-multi-file": "多文件 (ZIP)",
-  "database.export-schema-single-file": "单文件",
-  "database.failed-to-export-schema": "导出 Schema 失败",
-  "database.filter-database": "过滤数据库",
-  "database.labels": "数据库标签",
-  "database.revision.delete-confirm-dialog": "这将删除这些已应用的修改，但不会影响数据库 Schema。此操作无法撤消。",
-  "database.revision.self": "版本",
-  "database.successfully-exported-schema": "成功导出 Schema",
-  "database.sync-complete-for-instance": "实例 '{{0}}' 同步完成",
-  "database.sync-database": "同步数据库",
   "db": {
+    "catalog": {
+      "description": "编辑并上传表的 Catalog"
+    },
     "character-set": "字符集",
     "collation": "排序规则",
     "collections": "集合",
@@ -897,11 +808,6 @@
     "triggers": "触发器",
     "views": "视图"
   },
-  "db.catalog.description": "编辑并上传表的 Catalog",
-  "db.failed-to-sync-schema": "同步 schema 失败",
-  "db.n-databases-had-sync-errors": "{{0}} 个数据库同步出错",
-  "db.start-to-sync-schema": "开始同步 schema",
-  "db.syncing-databases-for-instance": "正在同步 {{0}} 的数据库...",
   "environment": {
     "delete-description": "删除环境也会将其从相关实例和数据库中删除。这个操作无法撤销",
     "reorder": "重新排序环境",
@@ -921,7 +827,6 @@
     "password-info": "提供密码来对导出的文件进行加密",
     "password-optional": "设置密码加密（可选）"
   },
-  "export-data.password-optional": "密码（可选）",
   "gitops": {
     "checklist": {
       "database-group-recommendation": "对于具有相同 Schema 的数据库，数据库分组可以让您在一次变更中同时迁移它们。只需定义一次分组，即可在多次迁移中复用，无需每次都逐个选择数据库。",
@@ -949,7 +854,7 @@
     },
     "workflow": {
       "description": "将工作流文件复制到您的代码仓库中，以自动化 SQL 审查和数据库变更发布。",
-      "file-hint": "保存为仓库中的 {{filePath}}",
+      "file-hint": "保存为仓库 {{repository}} 中的 {{filePath}}",
       "provider-not-match": "所选的 工作负载标识 (Workload Identity) 仅适用于 {{provider}}。",
       "self-hosted-runner": "自托管 runner",
       "title": "工作流文件生成"
@@ -994,6 +899,7 @@
     "connection-options": "连接选项",
     "create-gcp-credentials": "创建凭据的方法见",
     "database-region": "数据库区域",
+    "default-role": "默认角色",
     "endpoint": "端点",
     "external-id": "外部 ID",
     "external-id-description": "承担角色时用于额外安全性的外部 ID（可选）",
@@ -1050,6 +956,62 @@
       "specific-credential": "指定凭证",
       "tenant-id": "Tenant ID"
     },
+    "info": {
+      "configure-database-user": {
+        "link": "配置数据库用户"
+      },
+      "connect-instance": {
+        "link": "连接实例"
+      },
+      "mongodb": {
+        "authentication": {
+          "content": "在 admin 数据库中为 Bytebase 创建一个专用用户 \"{{user}}\"："
+        },
+        "host": {
+          "content": "输入 MongoDB 服务器的主机名或 IP 地址。对于 MongoDB Atlas，请使用集群连接对话框中的连接字符串主机。"
+        },
+        "ssh": {
+          "content": "使用 SSH 隧道连接专用网络中的 MongoDB 实例。当数据库位于防火墙或 VPC 后面时，这很有用。"
+        },
+        "ssl": {
+          "content": "MongoDB Atlas 和其他云托管 MongoDB 服务默认需要 SSL 连接。请启用 SSL，并在需要时提供 CA 证书。"
+        }
+      },
+      "mysql": {
+        "authentication": {
+          "content": "创建一个专用用户 \"{{user}}\"，供 Bytebase 管理你的数据库。运行以下 SQL："
+        },
+        "host": {
+          "content": "输入 MySQL 服务器的主机名或 IP 地址。对于云托管数据库（AWS RDS、Google Cloud SQL），请使用云服务提供商提供的端点。"
+        },
+        "ssh": {
+          "content": "使用 SSH 隧道连接专用网络中无法由 Bytebase 直接访问的数据库。连接会通过堡垒机/跳板机路由。"
+        },
+        "ssl": {
+          "content": "云托管 MySQL 数据库（AWS RDS、Google Cloud SQL、Azure Database）通常需要 SSL 连接。请启用 SSL，并上传云服务提供商提供的 CA 证书。"
+        }
+      },
+      "postgresql": {
+        "authentication": {
+          "content": "创建一个专用用户 \"{{user}}\"，供 Bytebase 管理你的数据库。以超级用户身份运行以下 SQL："
+        },
+        "host": {
+          "content": "输入 PostgreSQL 服务器的主机名或 IP 地址。对于云托管数据库，请使用云服务提供商提供的端点。"
+        },
+        "ssh": {
+          "content": "使用 SSH 隧道连接专用网络中无法由 Bytebase 直接访问的数据库。连接会通过堡垒机/跳板机路由。"
+        },
+        "ssl": {
+          "content": "云托管 PostgreSQL 数据库（AWS RDS、Google Cloud SQL、Azure Database）通常需要 SSL 连接。请启用 SSL，并上传云服务提供商提供的 CA 证书。"
+        }
+      },
+      "ssh-tunnel": {
+        "link": "SSH 隧道"
+      },
+      "ssl-tls-connection": {
+        "link": "SSL/TLS 连接"
+      }
+    },
     "info-panel": {
       "no-info": "暂无该引擎的额外信息。"
     },
@@ -1089,6 +1051,7 @@
       "basic-info": "基本信息",
       "connection": "连接"
     },
+    "select-database-user": "选择数据库用户",
     "selected-n-instances_one": "已选择 {{count}} 个实例",
     "selected-n-instances_other": "已选择 {{count}} 个实例",
     "sentence": {
@@ -1173,146 +1136,6 @@
     "users": "用户",
     "your-snowflake-account-locator": "您的 Snowflake 账户定位符"
   },
-  "instance.account-locator": "账户定位符",
-  "instance.archive-instance-instance-name": "归档实例'{{0}}'?",
-  "instance.archived-instances-will-not-be-displayed": "不再会显示已归档实例。",
-  "instance.authentication-database": "认证数据库",
-  "instance.connection-info": "连接信息",
-  "instance.connection-options": "连接选项",
-  "instance.create-gcp-credentials": "创建凭据的方法见",
-  "instance.database-region": "数据库区域",
-  "instance.default-role": "默认角色",
-  "instance.endpoint": "端点",
-  "instance.external-id": "外部 ID",
-  "instance.external-id-description": "承担角色时用于额外安全性的外部 ID（可选）",
-  "instance.external-id-placeholder": "可选的外部 ID",
-  "instance.external-link": "外部链接",
-  "instance.external-secret-azure.secret-name": "密钥名称",
-  "instance.external-secret-azure.secret-name-tips": "存储在 Azure Key Vault 中的密钥名称。",
-  "instance.external-secret-azure.vault-url": "Key Vault URL",
-  "instance.external-secret-azure.vault-url-tips": "Key Vault URL 应类似于 \"https://myvault.vault.azure.net/\"",
-  "instance.external-secret-gcp.secret-name": "密钥完整路径",
-  "instance.external-secret-gcp.secret-name-tips": "密钥完整路径应类似于 \"projects/project-id/secrets/secret-id\"",
-  "instance.external-secret-vault.vault-auth-type.approle.role-id": "Auth role id",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-env-name": "环境变量名",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-id": "Auth secret id",
-  "instance.external-secret-vault.vault-auth-type.approle.secret-plain-text": "明文",
-  "instance.external-secret-vault.vault-auth-type.approle.self": "AppRole",
-  "instance.external-secret-vault.vault-auth-type.self": "认证方式",
-  "instance.external-secret-vault.vault-auth-type.token.self": "Token",
-  "instance.external-secret-vault.vault-secret-engine-name": "Secret engine name",
-  "instance.external-secret-vault.vault-secret-engine-tips": "仅支持 KV v2 储存",
-  "instance.external-secret-vault.vault-secret-key": "Secret key",
-  "instance.external-secret-vault.vault-secret-path": "Secret path",
-  "instance.external-secret-vault.vault-tls-config": "Vault TLS 配置（可选）",
-  "instance.external-secret-vault.vault-url": "Vault URL",
-  "instance.external-secret.key-name": "Secret key",
-  "instance.external-secret.secret-name": "Secret name",
-  "instance.failed-to-connect-instance": "连接到实例失败。",
-  "instance.failed-to-connect-instance-localhost": "如果您使用的 Docker 部署，请尝试使用 \"host.docker.internal\" 作为 Host 地址。",
-  "instance.find-gcp-project-id": "查看 GCP 项目 ID 的方法见",
-  "instance.find-gcp-project-id-and-instance-id": "查看 GCP 项目 ID 与实例 ID 的方法见",
-  "instance.force-archive-description": "强制归档。所有数据库均将被取消分配。",
-  "instance.grants": "权限",
-  "instance.host-or-socket": "Host 或 Socket",
-  "instance.iam-extension.client-id": "Client ID",
-  "instance.iam-extension.client-secret": "Client Secret",
-  "instance.iam-extension.credential-source": "凭证来源",
-  "instance.iam-extension.saas-default-credential-restriction": "出于安全考虑，Bytebase Cloud 不支持使用默认凭证。请提供具体凭证。",
-  "instance.iam-extension.specific-credential": "指定凭证",
-  "instance.iam-extension.tenant-id": "Tenant ID",
-  "instance.info-panel.no-info": "暂无该引擎的额外信息。",
-  "instance.info.configure-database-user.link": "配置数据库用户",
-  "instance.info.connect-instance.link": "连接实例",
-  "instance.info.mongodb.authentication.content": "在 admin 数据库中为 Bytebase 创建一个专用用户 \"{{user}}\"：",
-  "instance.info.mongodb.host.content": "输入 MongoDB 服务器的主机名或 IP 地址。对于 MongoDB Atlas，请使用集群连接对话框中的连接字符串主机。",
-  "instance.info.mongodb.ssh.content": "使用 SSH 隧道连接专用网络中的 MongoDB 实例。当数据库位于防火墙或 VPC 后面时，这很有用。",
-  "instance.info.mongodb.ssl.content": "MongoDB Atlas 和其他云托管 MongoDB 服务默认需要 SSL 连接。请启用 SSL，并在需要时提供 CA 证书。",
-  "instance.info.mysql.authentication.content": "创建一个专用用户 \"{{user}}\"，供 Bytebase 管理你的数据库。运行以下 SQL：",
-  "instance.info.mysql.host.content": "输入 MySQL 服务器的主机名或 IP 地址。对于云托管数据库（AWS RDS、Google Cloud SQL），请使用云服务提供商提供的端点。",
-  "instance.info.mysql.ssh.content": "使用 SSH 隧道连接专用网络中无法由 Bytebase 直接访问的数据库。连接会通过堡垒机/跳板机路由。",
-  "instance.info.mysql.ssl.content": "云托管 MySQL 数据库（AWS RDS、Google Cloud SQL、Azure Database）通常需要 SSL 连接。请启用 SSL，并上传云服务提供商提供的 CA 证书。",
-  "instance.info.postgresql.authentication.content": "创建一个专用用户 \"{{user}}\"，供 Bytebase 管理你的数据库。以超级用户身份运行以下 SQL：",
-  "instance.info.postgresql.host.content": "输入 PostgreSQL 服务器的主机名或 IP 地址。对于云托管数据库，请使用云服务提供商提供的端点。",
-  "instance.info.postgresql.ssh.content": "使用 SSH 隧道连接专用网络中无法由 Bytebase 直接访问的数据库。连接会通过堡垒机/跳板机路由。",
-  "instance.info.postgresql.ssl.content": "云托管 PostgreSQL 数据库（AWS RDS、Google Cloud SQL、Azure Database）通常需要 SSL 连接。请启用 SSL，并上传云服务提供商提供的 CA 证书。",
-  "instance.info.ssh-tunnel.link": "SSH 隧道",
-  "instance.info.ssl-tls-connection.link": "SSL/TLS 连接",
-  "instance.instance-id": "实例 ID",
-  "instance.instance-name": "实例名称",
-  "instance.new-instance": "新实例",
-  "instance.no-environment": "此实例尚未绑定到环境",
-  "instance.no-extra-params-configured": "没有配置的额外连接参数",
-  "instance.no-params-yet-add-above": "尚未配置参数。\n使用上面的形式添加参数。",
-  "instance.no-password": "无密码",
-  "instance.parameter-name-placeholder": "参数名称",
-  "instance.parameter-value-placeholder": "参数值",
-  "instance.password-type.aws-iam": "AWS RDS IAM",
-  "instance.password-type.azure-iam": "Azure IAM",
-  "instance.password-type.external-secret-aws": "AWS Secrets Manager",
-  "instance.password-type.external-secret-azure": "Azure Key Vault",
-  "instance.password-type.external-secret-gcp": "GCP Secret Manager",
-  "instance.password-type.external-secret-vault": "Vault (KV v2)",
-  "instance.password-type.google-iam": "Google Cloud SQL IAM",
-  "instance.password-type.password": "密码",
-  "instance.password-write-only": "YOUR_DB_PWD - 仅写入",
-  "instance.port": "端口",
-  "instance.project-id": "项目 ID",
-  "instance.restore-instance-instance-name-to-normal-state": "恢复实例'{{0}}'到正常状态?",
-  "instance.role-arn": "角色 ARN",
-  "instance.role-arn-description": "用于跨账户访问的 IAM 角色。同账户访问请留空。",
-  "instance.role-arn-placeholder": "arn:aws:iam::123456789012:role/CrossAccountRole",
-  "instance.scan-interval.default-never": "默认（永不）",
-  "instance.scan-interval.description": "Bytebase 会定期同步实例的 schema 以及进行异常检测。",
-  "instance.scan-interval.min-value": "最小值 {{value}} 分钟",
-  "instance.scan-interval.self": "扫描间隔",
-  "instance.section.basic-info": "基本信息",
-  "instance.section.connection": "连接",
-  "instance.select-database-user": "选择数据库用户",
-  "instance.sentence.aws-rds.mysql.template": "下面是创建用户 {{user}}@% 并授予该用户所需权限的示例。",
-  "instance.sentence.aws-rds.postgresql.template": "下面是创建用户“{{user}}”并授予该用户所需权限的示例。",
-  "instance.sentence.console.snowflake": "\b管理该实例的外部控制台 URL（如 AWS RDS 控制台，您的数据库控制台）",
-  "instance.sentence.create-admin-user": "这是 Bytebase 用于连接数据库，执行 DDL 和 DML (非 SELECT) 操作的用户。",
-  "instance.sentence.create-admin-user-non-sql": "这是 Bytebase 用于连接数据库，执行写和管理操作的用户。",
-  "instance.sentence.create-readonly-user": "这是 Bytebase 用于连接数据库，执行诸如 SELECT 的只读操作的用户。",
-  "instance.sentence.create-readonly-user-non-sql": "这是 Bytebase 用于连接数据库，执行只读操作的用户。",
-  "instance.sentence.create-user-example.clickhouse.sql-driven-workflow": "SQL 工作流",
-  "instance.sentence.create-user-example.clickhouse.template": "创建用户 {{user}}，密码 {{password}}，并授予必要权限的例子如下。您需要首先启用 {{link}}，才能执行以下创建用户的命令。",
-  "instance.sentence.create-user-example.mysql.template": "创建用户 {{user}}，密码 {{password}}，并授予必要权限的例子如下。",
-  "instance.sentence.create-user-example.postgresql.template": "创建用户 {{user}}，密码 {{password}}，并授予必要权限的例子如下。如果您将要连接到的实例是自己托管的，那么您可以 grant SUPERUSER。",
-  "instance.sentence.create-user-example.postgresql.warn": "如果您将要连接到的实例是由云服务供应商管理的话，那么 SUPERUSER 是不可用的，您需要通过供应商的管理员控制台来创建用户。您所创建的用户会拥有供应商特定的 semi-SUPERUSER 的权限。 您应该对所有 role 用 'GRANT role_name TO bytebase;' 语句赋予 Bytebase 权限，否则 Bytebase 可能没有权限操作已有的数据库或者表导致操作失败。",
-  "instance.sentence.create-user-example.redis.template": "创建用户 {{user}}，密码 {{password}}，并授予必要权限的例子如下。",
-  "instance.sentence.create-user-example.snowflake.template": "创建用户 {{user}}，密码 {{password}}，warehouse 为{{warehouse}}，并授予必要权限的例子如下。",
-  "instance.sentence.firewall-info": "如果您为数据库实例使用入站防火墙规则，请参阅 ByteBase Cloud Connection 文档。",
-  "instance.sentence.google-cloud-sql.instance-name": "实例连接名称",
-  "instance.sentence.google-cloud-sql.instance-name-tips": "实例连接名称应为 {{instance}}。",
-  "instance.sentence.google-cloud-sql.mysql.template": "创建一个名为 {{user}} 的服务帐户，然后将其作为 IAM 用户 {{user}}@'%' 添加到您的 Google Cloud SQL 中。授予此用户所需的权限。",
-  "instance.sentence.google-cloud-sql.postgresql.template": "创建一个名为 {{user}} 的服务帐户，然后将其作为 IAM 用户 {{user}}@project-id.iam 添加到您的 Google Cloud SQL 中。授予用户所需的权限。",
-  "instance.sentence.host.none-snowflake": "例如 host.docker.internal | ip | local socket",
-  "instance.sentence.proxy.snowflake": "对于代理服务器，加上 @PROXY_HOST，并在端口里指定 PROXY_PORT",
-  "instance.show-how-to-create": "如何创建",
-  "instance.snowflake-web-console": "Snowflake Web 控制台",
-  "instance.successfully-archived-instance": "成功归档实例'{{0}}'。",
-  "instance.successfully-connected-instance": "成功连接到实例。",
-  "instance.successfully-created-instance-createdinstance-name": "成功创建实例'{{0}}'。",
-  "instance.successfully-restored-instance": "已成功恢复实例“{{0}}”。",
-  "instance.successfully-updated-instance-instance-name": "成功更新实例'{{0}}'。",
-  "instance.sync-databases.add-database": "+ 添加数据库，按回车键提交",
-  "instance.sync-databases.description": "仅同步选定的数据库。",
-  "instance.sync-databases.search-database": "搜索数据库",
-  "instance.sync-databases.self": "同步数据库",
-  "instance.sync-databases.sync-all": "同步所有数据库",
-  "instance.sync.self": "同步实例",
-  "instance.sync.sync-all": "同步所有数据库",
-  "instance.sync.sync-all-tip": "数据库同步是异步的，可能需要几秒到几分钟",
-  "instance.sync.sync-new": "仅同步新数据库",
-  "instance.syncing": "同步中 ...",
-  "instance.test-connection": "测试连接",
-  "instance.testing-connection": "测试连接中",
-  "instance.type-or-paste-credentials-write-only": "输入或粘贴 CREDENTIALS - 仅写入",
-  "instance.unable-to-connect": "Bytebase 无法连接到实例。我们推荐您再检查一遍连接信息。但也可以暂时忽略此警告。您在创建后仍能在实例详细页里修复连接信息。\n\n错误详情:{{0}}",
-  "instance.users": "用户",
-  "instance.your-snowflake-account-locator": "您的 Snowflake 账户定位符",
   "issue": {
     "access-grant": {
       "advanced-search": {
@@ -1322,9 +1145,10 @@
           }
         }
       },
-      "details": "Access Grant Details",
-      "expired-at": "Expired at"
+      "details": "访问授权详情",
+      "expired-at": "过期时间"
     },
+    "action-anyway": "仍要{{action}}",
     "advanced-search": {
       "filter": "过滤",
       "scope": {
@@ -1408,6 +1232,20 @@
       "reopened": "重开"
     },
     "checks-manual-rollout-hint": "审批已完成，但由于该计划仍有未通过的检查，系统未自动创建发布。请前往变更计划页继续。",
+    "checks-warning-hint": "部分检查未通过。仅在符合预期时继续。",
+    "comment-editor": {
+      "nothing-to-preview": "暂无预览",
+      "preview": "预览",
+      "toolbar": {
+        "bold": "插入粗体文本",
+        "code": "插入 SQL 代码片段",
+        "hashtag": "通过 id 插入工单链接。请在\"#\"后填入工单 id",
+        "header": "插入标题",
+        "link": "插入链接"
+      },
+      "write": "编辑"
+    },
+    "create-rollout": "创建发布",
     "data-export": {
       "download-tooltip": "24 小时可用",
       "file-expired": "文件已过期",
@@ -1415,8 +1253,13 @@
       "limits": "限制",
       "options": "配置项"
     },
+    "issue-name": "工单名称",
     "labels": "工单标签",
     "leave-a-comment": "发表一条评论…",
+    "my-issues": "我的工单",
+    "no-description-provided": "未提供描述",
+    "options-disabled-due-to-oversize": "由于 SQL 文件过大，选项已禁用。",
+    "overwrite-current-statement": "覆盖当前的 SQL 语句",
     "review": {
       "approve-description": "提交反馈并批准此工单",
       "comment-description": "提交反馈，不进行批准操作",
@@ -1433,8 +1276,8 @@
     "role-grant": {
       "all-databases": "所有数据库",
       "all-databases-tip": "所有当前和未来属于这个项目的数据库。",
-      "details": "Role Grant Details",
-      "expired-at": "Expired at",
+      "details": "角色授权详情",
+      "expired-at": "过期时间",
       "manually-select": "手动选择",
       "use-cel": "使用 CEL 表达式"
     },
@@ -1445,6 +1288,7 @@
       "sort": "排序",
       "updated": "更新时间"
     },
+    "statement-from-sheet-warning": "该 SQL 来自较大的 Sheet，预览内容可能已截断。",
     "status-transition": {
       "modal": {
         "close": "关闭工单？",
@@ -1462,6 +1306,10 @@
       "updated": "更新于",
       "waiting-role": "等待: {{role}}"
     },
+    "task-run": {
+      "logs": "日志",
+      "session": "会话"
+    },
     "title": {
       "change-database": "变更数据库",
       "change-from-sql-editor": "从 SQL 编辑器变更",
@@ -1469,34 +1317,13 @@
       "request-role": "申请角色",
       "request-specific-role": "申请 \"{{role}}\" 角色"
     },
+    "transaction-mode": {
+      "label": "事务模式"
+    },
     "upload-sql": "上传 SQL",
+    "upload-sql-file-max-size-exceeded": "上传文件大小不能超过 {{size}}。",
     "waiting-approval": "等待审批"
   },
-  "issue.action-anyway": "仍要{{action}}",
-  "issue.checks-warning-hint": "部分检查未通过。仅在符合预期时继续。",
-  "issue.comment-editor.nothing-to-preview": "暂无预览",
-  "issue.comment-editor.preview": "预览",
-  "issue.comment-editor.toolbar.bold": "插入粗体文本",
-  "issue.comment-editor.toolbar.code": "插入 SQL 代码片段",
-  "issue.comment-editor.toolbar.hashtag": "通过 id 插入工单链接。请在\"#\"后填入工单 id",
-  "issue.comment-editor.toolbar.header": "插入标题",
-  "issue.comment-editor.toolbar.link": "插入链接",
-  "issue.comment-editor.write": "编辑",
-  "issue.create-rollout": "创建发布",
-  "issue.data-export.format": "格式",
-  "issue.data-export.limits": "限制",
-  "issue.data-export.options": "选项",
-  "issue.issue-name": "工单名称",
-  "issue.my-issues": "我的工单",
-  "issue.no-description-provided": "未提供描述",
-  "issue.options-disabled-due-to-oversize": "由于 SQL 文件过大，选项已禁用。",
-  "issue.overwrite-current-statement": "覆盖当前的 SQL 语句",
-  "issue.review.self": "评审",
-  "issue.statement-from-sheet-warning": "该 SQL 来自较大的 Sheet，预览内容可能已截断。",
-  "issue.task-run.logs": "日志",
-  "issue.task-run.session": "会话",
-  "issue.transaction-mode.label": "事务模式",
-  "issue.upload-sql-file-max-size-exceeded": "上传文件大小不能超过 {{size}}。",
   "label": {
     "add-label": "添加标签",
     "empty-label-value": "空",
@@ -1507,12 +1334,6 @@
       "value-necessary": "需要指定值"
     }
   },
-  "label.add-label": "添加标签",
-  "label.empty-label-value": "空",
-  "label.error.key-duplicated": "Key 重复了",
-  "label.error.key-necessary": "需要指定 Key",
-  "label.error.max-value-length-exceeded": "值的长度不能超过 {{length}} 字符",
-  "label.error.value-necessary": "需要指定值",
   "landing": {
     "changelog-for-version": "{{version}} 的更新日志",
     "last-visit": "上次访问",
@@ -1561,91 +1382,114 @@
     }
   },
   "plan": {
+    "add-spec": "添加变更",
+    "add-spec-pending-draft": "请先保存或放弃当前的待处理变更，然后再添加新变更",
     "checks": {
-      "self": "检查"
+      "completed": "已完成计划检查",
+      "failed-to-run": "运行计划检查失败",
+      "no-check-results": "暂无检查结果",
+      "no-results-match-filters": "没有符合筛选条件的结果",
+      "self": "检查",
+      "started": "已开始计划检查"
     },
     "create-plan": "创建计划",
+    "description": {
+      "placeholder": "添加描述"
+    },
     "editor": {
       "save-changes-before-continuing": "请保存或取消更改，然后再继续"
     },
+    "ghost": {
+      "requirements-not-met": "以下数据库不满足 Ghost 要求：{{databases}}"
+    },
+    "go-to-plan-page": "前往计划页面",
+    "isolation-level": {
+      "read-committed": "已提交读",
+      "read-uncommitted": "未提交读",
+      "repeatable-read": "可重复读",
+      "self": "隔离级别",
+      "serializable": "串行化"
+    },
+    "labels-required-for-review": "提交评审前必须设置标签",
     "meta": {
       "created-by-at": "由 {{user}} 创建 · {{time}}"
     },
     "navigator": {
       "changes": "变更项",
+      "checks": "检查",
       "deploy": "部署",
-      "review": "审批"
+      "review": "审批",
+      "statement-empty": "语句为空"
     },
     "new-plan": "创建变更计划",
+    "options": {
+      "no-options-available": "暂无可配置项",
+      "self": "配置项"
+    },
+    "overview": {
+      "no-checks": "没有检查"
+    },
+    "phase": {
+      "create-rollout-action": "手动创建发布",
+      "deploy-approval-must-complete": "审批流必须完成。",
+      "deploy-approval-optional": "根据当前项目设置，审批流可以被绕过。",
+      "deploy-approval-pending": "在系统自动创建发布前，需要先完成审批流。",
+      "deploy-approval-ready": "该计划的审批已完成。",
+      "deploy-checks-blocked": "未通过的检查正在阻止系统自动创建发布。",
+      "deploy-checks-must-pass": "检查必须通过。",
+      "deploy-checks-optional": "在当前项目中，未通过的检查不会阻止手动创建发布。",
+      "deploy-checks-ready": "检查结果已满足系统自动创建发布的条件。",
+      "deploy-checks-running": "请等待运行中的检查完成，系统才能继续自动创建发布。",
+      "deploy-description": "当所有检查都通过且工单审批完成后，Bytebase 会自动创建发布。",
+      "deploy-description-gitops": "此计划已就绪，可以发布。创建一个发布以部署关联的 Release。",
+      "deploy-manual-create-description": "根据当前项目设置，你也可以手动创建发布。",
+      "deploy-manual-create-description-readonly": "拥有“创建发布”权限的用户可以手动创建发布。",
+      "hide-details": "隐藏详情",
+      "review-description": "提交审批以继续",
+      "show-details": "显示详情"
+    },
     "plans": "变更计划",
+    "pre-backup": {
+      "requirements-not-met": "以下数据库不满足预备份要求：{{databases}}"
+    },
+    "ready-for-review": "准备提交评审",
+    "run": "重新检查",
+    "select-isolation-level": "选择隔离级别",
+    "select-targets": "选择目标",
+    "spec": {
+      "change": "变更",
+      "type": {
+        "database-change": "数据库变更"
+      }
+    },
+    "state": {
+      "close-confirm": "确认关闭这个计划？",
+      "reopen-confirm": "确认重新打开这个计划？"
+    },
     "subtitle": "草拟数据库变更并运行预检查，然后创建工单以请求审批。",
+    "summary": {
+      "last-approved-by": "最后由 {{name}} 审批",
+      "n-changes": "{{n}} 个变更",
+      "n-database-groups": "{{n}} 个数据库组",
+      "n-databases": "{{n}} 个数据库",
+      "n-error": "{{n}} 错误",
+      "n-of-m-approved": "{{n}}/{{m}} 已审批",
+      "n-of-m-tasks": "{{n}}/{{m}} 任务",
+      "n-passed": "{{n}} 通过",
+      "n-warning": "{{n}} 警告"
+    },
     "targets": {
-      "title": "目标库"
-    }
+      "no-targets-found": "未找到目标",
+      "non-env-warning": {
+        "one": "{{count}} 个数据库因为没有生效环境，将不会进入发布:",
+        "other": "{{count}} 个数据库因为没有生效环境，将不会进入发布:"
+      },
+      "title": "目标库",
+      "view-all": "查看全部 ({{count}})"
+    },
+    "title-required": "标题不能为空",
+    "view-discussion": "查看讨论"
   },
-  "plan.add-spec": "添加变更",
-  "plan.add-spec-pending-draft": "请先保存或放弃当前的待处理变更，然后再添加新变更",
-  "plan.checks.completed": "已完成计划检查",
-  "plan.checks.failed-to-run": "运行计划检查失败",
-  "plan.checks.no-check-results": "暂无检查结果",
-  "plan.checks.no-results-match-filters": "没有符合筛选条件的结果",
-  "plan.checks.started": "已开始计划检查",
-  "plan.description.placeholder": "添加描述",
-  "plan.ghost.requirements-not-met": "以下数据库不满足 Ghost 要求：{{databases}}",
-  "plan.go-to-plan-page": "前往计划页面",
-  "plan.isolation-level.read-committed": "已提交读",
-  "plan.isolation-level.read-uncommitted": "未提交读",
-  "plan.isolation-level.repeatable-read": "可重复读",
-  "plan.isolation-level.self": "隔离级别",
-  "plan.isolation-level.serializable": "串行化",
-  "plan.labels-required-for-review": "提交评审前必须设置标签",
-  "plan.navigator.checks": "检查",
-  "plan.navigator.statement-empty": "语句为空",
-  "plan.options.no-options-available": "暂无可配置项",
-  "plan.options.self": "配置项",
-  "plan.overview.no-checks": "没有检查",
-  "plan.phase.create-rollout-action": "手动创建发布",
-  "plan.phase.deploy-approval-must-complete": "审批流必须完成。",
-  "plan.phase.deploy-approval-optional": "根据当前项目设置，审批流可以被绕过。",
-  "plan.phase.deploy-approval-pending": "在系统自动创建发布前，需要先完成审批流。",
-  "plan.phase.deploy-approval-ready": "该计划的审批已完成。",
-  "plan.phase.deploy-checks-blocked": "未通过的检查正在阻止系统自动创建发布。",
-  "plan.phase.deploy-checks-must-pass": "检查必须通过。",
-  "plan.phase.deploy-checks-optional": "在当前项目中，未通过的检查不会阻止手动创建发布。",
-  "plan.phase.deploy-checks-ready": "检查结果已满足系统自动创建发布的条件。",
-  "plan.phase.deploy-checks-running": "请等待运行中的检查完成，系统才能继续自动创建发布。",
-  "plan.phase.deploy-description": "当所有检查都通过且工单审批完成后，Bytebase 会自动创建发布。",
-  "plan.phase.deploy-description-gitops": "此计划已就绪，可以发布。创建一个发布以部署关联的 Release。",
-  "plan.phase.deploy-manual-create-description": "根据当前项目设置，你也可以手动创建发布。",
-  "plan.phase.deploy-manual-create-description-readonly": "拥有“创建发布”权限的用户可以手动创建发布。",
-  "plan.phase.hide-details": "隐藏详情",
-  "plan.phase.review-description": "提交审批以继续",
-  "plan.phase.show-details": "显示详情",
-  "plan.pre-backup.requirements-not-met": "以下数据库不满足预备份要求：{{databases}}",
-  "plan.ready-for-review": "准备提交评审",
-  "plan.run": "重新检查",
-  "plan.select-isolation-level": "选择隔离级别",
-  "plan.select-targets": "选择目标",
-  "plan.spec.change": "变更",
-  "plan.spec.type.database-change": "数据库变更",
-  "plan.state.close-confirm": "确认关闭这个计划？",
-  "plan.state.reopen-confirm": "确认重新打开这个计划？",
-  "plan.summary.last-approved-by": "最后由 {{name}} 审批",
-  "plan.summary.n-changes": "{{n}} 个变更",
-  "plan.summary.n-database-groups": "{{n}} 个数据库组",
-  "plan.summary.n-databases": "{{n}} 个数据库",
-  "plan.summary.n-error": "{{n}} 错误",
-  "plan.summary.n-of-m-approved": "{{n}}/{{m}} 已审批",
-  "plan.summary.n-of-m-tasks": "{{n}}/{{m}} 任务",
-  "plan.summary.n-passed": "{{n}} 通过",
-  "plan.summary.n-warning": "{{n}} 警告",
-  "plan.targets.no-targets-found": "未找到目标",
-  "plan.targets.non-env-warning.one": "{{count}} 个数据库因为没有生效环境，将不会进入发布:",
-  "plan.targets.non-env-warning.other": "{{count}} 个数据库因为没有生效环境，将不会进入发布:",
-  "plan.targets.title": "目标",
-  "plan.targets.view-all": "查看全部 ({{count}})",
-  "plan.title-required": "标题不能为空",
-  "plan.view-discussion": "查看讨论",
   "plugin": {
     "ai": {
       "actions": {
@@ -1745,7 +1589,7 @@
       "ddl-warning": "在所选环境中，{{kind}} 语句可在 SQL 编辑器中直接执行，无需审批。",
       "description": "项目成员角色决定了操作项目中的数据库和工单的权限。项目的所有者，工作空间管理员和 DBA 都具有项目所有的权限。",
       "edit-member": "编辑成员 - {{member}}",
-      "never-expires": "Never",
+      "never-expires": "永不",
       "request-role": {
         "disabled-reason": {
           "allow-request-role-disabled": "此项目未启用申请角色。",
@@ -1766,6 +1610,7 @@
     "overview": {
       "info-slot-content": "Bytebase 会定时同步实例的 schema，新同步的数据库会首先被置于这里，之后您可以再将他们转移到适当的项目中。"
     },
+    "select": "选择项目",
     "settings": {
       "confirm-archive-project": "归档「{{name}}」将使其变为只读并从活跃项目列表中隐藏。所有工单、数据库和设置将被保留。您可以稍后从已归档项目列表中恢复。",
       "confirm-delete-project": "删除「{{name}}」将永久移除该项目及所有关联数据，包括工单、配置和历史记录。该项目中的所有数据库将被移至默认项目。此操作无法撤销。",
@@ -1871,14 +1716,12 @@
       "webhook-url": "Webhook URL"
     }
   },
-  "project.select": "选择项目",
   "quick-action": {
     "create-db": "创建数据库",
+    "create-project": "创建项目",
     "new-project": "创建项目",
     "request-export-data": "申请导出数据"
   },
-  "quick-action.create-project": "Create project",
-  "quick-action.new-project": "创建项目",
   "quick-start": {
     "guide": "可点击步骤进行尝试",
     "notice": {
@@ -1886,6 +1729,7 @@
       "title": "新手任务已关闭"
     },
     "query-data": "查询数据",
+    "self": "快速开始",
     "view-an-issue": "查看工单",
     "visit-database": "访问数据库",
     "visit-environment": "访问环境",
@@ -1893,7 +1737,6 @@
     "visit-member": "访问成员 | 成员",
     "visit-project": "访问项目"
   },
-  "quick-start.self": "Quick Start",
   "release": {
     "and-n-more-files": "以及另外 {{count}} 个文件",
     "change-tip": "该变更关联到了一个发布包。",
@@ -1938,13 +1781,6 @@
       "pattern": "{{resource}} ID 可以具有小写字母，数字或连字符。\n它必须从小写字母开始，并以字母或数字结尾。"
     }
   },
-  "resource-id.cannot-be-changed-later": "创建之后无法修改。",
-  "resource-id.description": "{{resource}} ID 是一个唯一的标识符。创建之后无法修改。",
-  "resource-id.self": "{{resource}} ID",
-  "resource-id.validation.duplicated": "{{resource}} ID 已存在。请使用其他 ID。",
-  "resource-id.validation.empty": "{{resource}} ID 不能为空",
-  "resource-id.validation.overflow": "{{resource}} ID 应该少于 64 个字符。",
-  "resource-id.validation.pattern": "{{resource}} ID 可以具有小写字母，数字或连字符。\n它必须从小写字母开始，并以字母或数字结尾。",
   "role": {
     "custom-roles": {
       "self": "自定义角色"
@@ -1966,6 +1802,7 @@
     }
   },
   "rollout": {
+    "bypass-stage-requirements": "绕过警告",
     "no-stages": "暂无阶段",
     "no-tasks-created": "尚未创建任务",
     "pending-tasks-preview": {
@@ -1982,47 +1819,48 @@
       "self_one": "阶段",
       "self_other": "阶段"
     },
+    "task": {
+      "no-tasks": "此阶段没有任务",
+      "selected-count": "已选择 {{count}} 个任务",
+      "statement-truncated-hint": "由于语句过长，已被截断。"
+    },
     "task-execution-errors": "任务执行错误"
   },
-  "rollout.bypass-stage-requirements": "绕过警告",
-  "rollout.task.no-tasks": "此阶段没有任务",
-  "rollout.task.selected-count": "已选择 {{count}} 个任务",
-  "rollout.task.statement-truncated-hint": "由于语句过长，已被截断。",
   "schema-diagram": {
     "fit-content-with-view": "自动适应视图",
     "self": "Schema 关系图"
   },
   "schema-editor": {
     "actions": {
-      "add-column": "Add column",
-      "add-index": "Add index",
-      "add-partition": "Add partition",
-      "create-function": "Create function",
-      "create-procedure": "Create procedure",
-      "create-schema": "Create schema",
-      "create-table": "New table",
-      "create-view": "Create view",
-      "drop": "Drop",
-      "drop-schema": "Drop schema",
-      "drop-table": "Drop table",
-      "rename": "Rename",
-      "rename-table": "Rename table",
-      "restore": "Restore"
+      "add-column": "添加列",
+      "add-index": "添加索引",
+      "add-partition": "添加分区",
+      "create-function": "创建函数",
+      "create-procedure": "创建存储过程",
+      "create-schema": "创建 Schema",
+      "create-table": "新建表",
+      "create-view": "创建视图",
+      "drop": "删除",
+      "drop-schema": "删除 Schema",
+      "drop-table": "删除表",
+      "rename": "重命名",
+      "rename-table": "重命名表",
+      "restore": "恢复"
     },
     "column": {
-      "comment": "Comment",
-      "default": "Default",
+      "comment": "注释",
+      "default": "默认值",
       "foreign-key": "外键",
-      "name": "Name",
+      "name": "名称",
       "name-placeholder": "列名",
-      "not-null": "Not Null",
+      "not-null": "非空",
       "on-update": "更新时",
-      "operations": "Operations",
-      "primary": "Primary",
-      "type": "Type"
+      "operations": "操作",
+      "primary": "主键",
+      "type": "类型"
     },
-    "columns": "Columns",
-    "create-foreign-key": "Create Foreign Key",
+    "columns": "列",
+    "create-foreign-key": "创建外键",
     "database": {
       "collation": "字符排序规则",
       "comment": "注释",
@@ -2032,43 +1870,43 @@
     "default": {
       "placeholder": "输入默认值或留空以不使用默认值"
     },
-    "edit-foreign-key": "Edit Foreign Key",
+    "edit-foreign-key": "编辑外键",
     "foreign-key": {
-      "name": "Foreign Key Name",
-      "referenced-column": "Referenced Column",
-      "referenced-schema": "Referenced Schema",
-      "referenced-table": "Referenced Table"
+      "name": "外键名称",
+      "referenced-column": "引用列",
+      "referenced-schema": "引用 Schema",
+      "referenced-table": "引用表"
     },
     "index": {
-      "columns": "Columns",
+      "columns": "列",
       "dependency-columns": "依赖列",
       "indexes": "索引",
-      "primary": "Primary",
-      "unique": "Unique"
+      "primary": "主键",
+      "unique": "唯一"
     },
-    "indexes": "Indexes",
+    "indexes": "索引",
     "insert-sql": "插入 SQL",
     "no-diff": "没有需要应用的变更",
     "partition": {
-      "expression": "Expression",
-      "type": "Type",
-      "value": "Value"
+      "expression": "表达式",
+      "type": "类型",
+      "value": "值"
     },
-    "partitions": "Partitions",
-    "preview": "Preview",
-    "raw-sql": "Raw SQL",
+    "partitions": "分区",
+    "preview": "预览",
+    "raw-sql": "原始 SQL",
     "schema": {
-      "duplicate-name": "Schema name already exists",
-      "name-placeholder": "Schema name",
+      "duplicate-name": "Schema 名称已存在",
+      "name-placeholder": "Schema 名称",
       "select": "选择 schema"
     },
     "select-object-hint": "从左侧树中选择一个数据库对象进行编辑",
     "self": "Schema 编辑器",
     "table": {
-      "duplicate-name": "Table name already exists",
-      "name-placeholder": "Table name",
-      "no-match": "No tables match the search",
-      "no-tables": "No tables"
+      "duplicate-name": "表名称已存在",
+      "name-placeholder": "表名称",
+      "no-match": "没有匹配搜索的表",
+      "no-tables": "暂无表"
     },
     "table-partition": {
       "expression": "表达式",
@@ -2093,8 +1931,6 @@
       "value-placeholder": "标签值…"
     }
   },
-  "setting.label.key-placeholder": "标签 key...",
-  "setting.label.value-placeholder": "标签值…",
   "settings": {
     "general": {
       "workspace": {
@@ -2117,11 +1953,11 @@
           "enabled-in-saas": "Gemini AI 在 SaaS 模式下自动启用。",
           "endpoint": {
             "description": "提供私有化部署的 API Endpoint。",
-            "self": "API Endpoint"
+            "self": "API 端点"
           },
           "model": {
             "description": "提供私有化部署的模型名称。",
-            "self": "Model Name"
+            "self": "模型名称"
           },
           "provider": {
             "azure_open_ai": "Azure Open AI",
@@ -2185,6 +2021,7 @@
         "default-landing-page": {
           "default-view-changed-to-sql-editor": "工作区的默认视图已更改为 SQL 编辑器。",
           "go-to-sql-editor": "转到 SQL 编辑器",
+          "go-to-workspace": "前往工作区",
           "self": "默认首页",
           "sql-editor": {
             "description": "使用 SQL 编辑器直接执行数据库更改，适合单人使用或不需要管控的环境。",
@@ -2331,12 +2168,12 @@
       },
       "add-member": "添加成员",
       "all-users": "全部用户",
-      "assign-role": "Assign role",
-      "cannot-revoke-self": "You cannot revoke yourself",
+      "assign-role": "分配角色",
+      "cannot-revoke-self": "您不能撤销自己",
       "copy-service-key": "复制 Service Key",
       "entra-sync": {
         "description": "将 Entra ID（前 Azure AD）或 Okta 中的用户和组同步到您的 Bytebase 实例。",
-        "endpoint": "Endpoint",
+        "endpoint": "端点",
         "endpoint-tip": "用户和组将通过此端点同步到 Bytebase。",
         "reset-token": "重置密钥",
         "reset-token-warning": "您需要更新 Entra 应用程序配置。",
@@ -2346,7 +2183,7 @@
       },
       "grant-access": "授予访问权限",
       "groups": {
-        "external-readonly": "External group is read-only.",
+        "external-readonly": "外部群组为只读。",
         "form": {
           "description": "描述",
           "email": "邮箱",
@@ -2621,7 +2458,6 @@
       }
     }
   },
-  "settings.general.workspace.default-landing-page.go-to-workspace": "Go to workspace",
   "setup": {
     "basic-info": "基本信息",
     "data": {
@@ -2677,7 +2513,7 @@
         }
       }
     },
-    "access-type-unmask": "See unmasked sensitive data",
+    "access-type-unmask": "查看未脱敏的敏感数据",
     "activate-access": "激活",
     "activate-confirm": "确定要激活此访问授权吗？",
     "add-a-new-instance": "添加新实例",
@@ -2844,7 +2680,7 @@
     "table-empty-placeholder": "点击 \"运行\" 执行查询",
     "table-view": "表格视图",
     "text-format": "文本格式",
-    "unmask-warning": "The query result may include unmasked sensitive data.",
+    "unmask-warning": "查询结果可能包含未脱敏的敏感数据。",
     "upload-file": "上传文件",
     "url-copied-to-clipboard": "URL 已复制到剪贴板",
     "vertical-display": "竖向展示",
@@ -2862,9 +2698,9 @@
         "title": "语言服务器"
       },
       "errors": {
-        "description": "Auto Completion might be limited or disabled.",
-        "disconnected": "WebSocket disconnected",
-        "title": "WebSocket connection failed"
+        "description": "自动补全可能受限或被禁用。",
+        "disconnected": "WebSocket 已断开连接",
+        "title": "WebSocket 连接失败"
       }
     }
   },
@@ -3761,20 +3597,37 @@
       }
     }
   },
-  "subscription.instance-assignment.assign-license": "分配证书",
-  "subscription.instance-assignment.n-license-remain": "剩余 {{n}} 个",
-  "subscription.usage.instance-count.runoutof": "已用尽全部 {{total}} 个实例额度。",
-  "subscription.usage.instance-count.title": "实例数量限制",
   "task": {
+    "affected-rows": "影响行数",
     "cancel-task": "取消任务",
     "cancel-task-description": "待运行和就绪的任务运行会立即取消。运行中的任务运行会收到尽力而为的取消请求，可能会继续运行；如有需要请重试。",
+    "check-type": {
+      "affected-rows": {
+        "description": "根据统计信息估算。",
+        "self": "影响行数"
+      },
+      "sql-review": {
+        "description": "分析 SQL 语句中的潜在问题并提供建议，包括内置规则和自定义规则。",
+        "self": "SQL 审核"
+      }
+    },
     "created": "创建时间",
     "data-export-creator-only": "只有工单创建者可以执行数据导出任务",
     "error": {
       "scheduled-time-must-be-in-the-future": "计划时间必须是将来的时间"
     },
+    "executed-by": "执行人",
     "execution-time": "执行时间",
+    "no-cancelable-tasks": "没有可取消的任务",
     "no-permission": "无权限执行该操作",
+    "no-runnable-tasks": "没有可运行的任务",
+    "no-selectable-tasks": "没有可选择的任务",
+    "no-skippable-tasks": "没有可跳过的任务",
+    "no-tasks-selected": "未选择任何任务",
+    "online-migration": {
+      "self": "在线大表变更"
+    },
+    "prior-backup": "预备份受影响数据",
     "run-immediately": {
       "description": "点击“运行”后，任务将立即开始执行。",
       "self": "立即运行"
@@ -3784,7 +3637,9 @@
       "description": "设置任务自动开始运行的特定时间。",
       "self": "定时运行"
     },
+    "scheduled-time": "计划执行时间",
     "select-scheduled-time": "选择计划时间",
+    "select-task": "选择任务",
     "skip-prior-backup": "跳过预备份",
     "skip-prior-backup-description": "跳过变更前的自动数据备份",
     "skip-task": "跳过任务 | 跳过任务",
@@ -3799,56 +3654,55 @@
       "skipped": "已跳过"
     }
   },
-  "task-run.blocked-sessions": "被阻塞会话",
-  "task-run.blocked-sessions-description": "当前会话阻塞了以下会话",
-  "task-run.blocking-sessions": "阻塞会话",
-  "task-run.blocking-sessions-description": "当前会话被以下会话阻塞",
-  "task-run.history": "历史",
-  "task-run.latest": "最新",
-  "task-run.latest-logs": "最新日志",
-  "task-run.log-detail.backing-up": "备份中...",
-  "task-run.log-detail.backup-completed": "已完成（{{count}} 个表）",
-  "task-run.log-detail.completed": "已完成",
-  "task-run.log-detail.computing": "计算中...",
-  "task-run.log-detail.dumping": "导出中...",
-  "task-run.log-detail.retry-attempt": "第 {{current}}/{{max}} 次尝试",
-  "task-run.log-detail.syncing": "同步中...",
-  "task-run.log-type.command-execute": "命令执行",
-  "task-run.log-type.compute-diff": "计算差异",
-  "task-run.log-type.database-sync": "数据库同步",
-  "task-run.log-type.ghost-migration": "gh-ost 迁移",
-  "task-run.log-type.prior-backup": "预备份",
-  "task-run.log-type.release-file-execute": "发布包文件",
-  "task-run.log-type.retry": "重试",
-  "task-run.log-type.schema-dump": "结构导出",
-  "task-run.log-type.transaction": "事务",
-  "task-run.log-viewer.collapse-all": "全部收起",
-  "task-run.log-viewer.expand-all": "全部展开",
-  "task-run.log-viewer.multiple-replicas-notice": "检测到执行期间服务重启，日志按副本分组显示。",
-  "task-run.log-viewer.replica-n": "副本 #{{n}}",
-  "task-run.log-viewer.summary": "{{sections}} 个分组 · {{entries}} 条记录",
-  "task-run.no-session-found": "未找到会话",
-  "task-run.rollback.available": "有 {{count}} 个可回滚任务",
-  "task-run.rollback.no-statement-generated": "未生成语句",
-  "task-run.rollback.preview-statement.description": "在创建回滚计划前先检查生成的回滚语句。",
-  "task-run.status.enqueued": "等待执行。",
-  "task-run.status.enqueued-with-rollout-time": "等待执行，{{time}} 后执行。",
-  "task-run.status.waiting-max-tasks-per-rollout": "正在等待其他任务完成。已达到每次发布的最大运行任务数限制。上次报告时间：{{time}}。",
-  "task.affected-rows": "影响行数",
-  "task.check-type.affected-rows.description": "根据统计信息估算。",
-  "task.check-type.affected-rows.self": "影响行数",
-  "task.check-type.sql-review.description": "分析 SQL 语句中的潜在问题并提供建议，包括内置规则和自定义规则。",
-  "task.check-type.sql-review.self": "SQL 审核",
-  "task.executed-by": "执行人",
-  "task.no-cancelable-tasks": "没有可取消的任务",
-  "task.no-runnable-tasks": "没有可运行的任务",
-  "task.no-selectable-tasks": "没有可选择的任务",
-  "task.no-skippable-tasks": "没有可跳过的任务",
-  "task.no-tasks-selected": "未选择任何任务",
-  "task.online-migration.self": "在线大表变更",
-  "task.prior-backup": "预备份受影响数据",
-  "task.scheduled-time": "计划执行时间",
-  "task.select-task": "选择任务",
+  "task-run": {
+    "blocked-sessions": "被阻塞会话",
+    "blocked-sessions-description": "当前会话阻塞了以下会话",
+    "blocking-sessions": "阻塞会话",
+    "blocking-sessions-description": "当前会话被以下会话阻塞",
+    "history": "历史",
+    "latest": "最新",
+    "latest-logs": "最新日志",
+    "log-detail": {
+      "backing-up": "备份中...",
+      "backup-completed": "已完成（{{count}} 个表）",
+      "completed": "已完成",
+      "computing": "计算中...",
+      "dumping": "导出中...",
+      "retry-attempt": "第 {{current}}/{{max}} 次尝试",
+      "syncing": "同步中..."
+    },
+    "log-type": {
+      "command-execute": "命令执行",
+      "compute-diff": "计算差异",
+      "database-sync": "数据库同步",
+      "ghost-migration": "gh-ost 迁移",
+      "prior-backup": "预备份",
+      "release-file-execute": "发布包文件",
+      "retry": "重试",
+      "schema-dump": "结构导出",
+      "transaction": "事务"
+    },
+    "log-viewer": {
+      "collapse-all": "全部收起",
+      "expand-all": "全部展开",
+      "multiple-replicas-notice": "检测到执行期间服务重启，日志按副本分组显示。",
+      "replica-n": "副本 #{{n}}",
+      "summary": "{{sections}} 个分组 · {{entries}} 条记录"
+    },
+    "no-session-found": "未找到会话",
+    "rollback": {
+      "available": "有 {{count}} 个可回滚任务",
+      "no-statement-generated": "未生成语句",
+      "preview-statement": {
+        "description": "在创建回滚计划前先检查生成的回滚语句。"
+      }
+    },
+    "status": {
+      "enqueued": "等待执行。",
+      "enqueued-with-rollout-time": "等待执行，{{time}} 后执行。",
+      "waiting-max-tasks-per-rollout": "正在等待其他任务完成。已达到每次发布的最大运行任务数限制。上次报告时间：{{time}}。"
+    }
+  },
   "two-factor": {
     "description": "双重认证为系统成员提供了一个额外的安全层。在登录时，用户需要输入由认证器应用程序生成的安全代码。",
     "disable": {


### PR DESCRIPTION
## What

Polish of the React i18n locale files to fix the mixed Chinese/English text reported in [BYT-9608](https://linear.app/bytebase/issue/BYT-9608) and to unify the flat dotted keys into nested objects.

### Root cause

The mixed text on the issue-detail / rollout-plan page was **not** hardcoded strings — an audit of those React surfaces confirmed every user-facing string already goes through `t()`. The bug was **untranslated locale values** that fell through to English (e.g. the screenshot's `created issue` → `activity.sentence.created-issue`, which was literally `"created issue"` in zh-CN).

## Changes (`frontend/src/react/locales/`)

1. **Localize mixed/untranslated text** in zh/ja/es/vi — translated the missing + untranslated keys (152 zh, 283 ja, 309 es, 294 vi), reusing each file's existing terminology and keeping technical tokens, brand names, and `{{interpolation}}` placeholders verbatim.
2. **Fix partial-translation leaks** on the activity feed (`targets`, `prior backup`) and restore the dropped `{{repository}}` token in `gitops.workflow.file-hint` (it never rendered before).
3. **Unify flat dotted keys** — merged the 470 flat `"plan.add-spec"`-style keys per file into their nested parents (`plan: { "add-spec": ... }`). Behavior-preserving: i18next resolves nested first and falls back to flat via `ignoreJSONStructure`, so effective resolution is unchanged for all 2,478 lookup keys; the net line reduction comes from dropping ~230 exact-duplicate keys per file.

## Testing

- `pnpm --dir frontend type-check` ✓
- `pnpm --dir frontend test` — 2295 tests pass ✓
- Biome check on locale files — clean ✓
- Consistency script: **0 flat dotted keys, 0 missing-vs-en keys, 0 interpolation-token mismatches** across all five locales ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)