### PR TITLE
fix(frontend): restore custom expiration time for project role grants (BYT-9612)

### DIFF
--- a/frontend/scripts/check-react-i18n.mjs
+++ b/frontend/scripts/check-react-i18n.mjs
@@ -48,6 +48,9 @@ const DYNAMIC_PREFIXES = [
   "common.skipped",
   "common.under-review",
   "issue.table.approved",
+  // Role-grant expiration presets, rendered via t(preset.labelKey) in
+  // MembersPage.tsx (EXPIRATION_PRESETS), not as literal t("…") calls.
+  "project.members.expiration-presets.",
 ];
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -1589,6 +1589,13 @@
       "ddl-warning": "In the selected environments, {{kind}} statements can be directly run in SQL Editor without approval.",
       "description": "Project members determine the permission to operate database and issues inside the project. Project Owner, Workspace Admin and Workspace DBA all have full project permissions.",
       "edit-member": "Edit member - {{member}}",
+      "expiration-presets": {
+        "one-month": "1 month",
+        "one-week": "1 week",
+        "one-year": "1 year",
+        "three-months": "3 months"
+      },
+      "expires-at": "Expires: {{date}}",
       "never-expires": "Never",
       "request-role": {
         "disabled-reason": {

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -1589,6 +1589,13 @@
       "ddl-warning": "En los entornos seleccionados, las sentencias {{kind}} pueden ejecutarse directamente en el editor SQL sin aprobación.",
       "description": "Los miembros del proyecto determinan el permiso para operar la base de datos y los problemas dentro del proyecto. El propietario del proyecto, el administrador del espacio de trabajo y el DBA del espacio de trabajo tienen permisos completos para el proyecto.",
       "edit-member": "Editar miembro - {{member}}",
+      "expiration-presets": {
+        "one-month": "1 mes",
+        "one-week": "1 semana",
+        "one-year": "1 año",
+        "three-months": "3 meses"
+      },
+      "expires-at": "Caduca: {{date}}",
       "never-expires": "Nunca",
       "request-role": {
         "disabled-reason": {

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -1589,6 +1589,13 @@
       "ddl-warning": "選択した環境では、{{kind}} ステートメントを SQL エディターで承認なしに直接実行できます。",
       "description": "プロジェクトメンバーのロールにより、プロジェクト内のデータベースとイシューを操作するための権限が決まります。プロジェクト所有者、ワークスペース管理者、および DBA はすべて、プロジェクトに対する完全な権限を持っています。",
       "edit-member": "メンバー編集 - {{member}}",
+      "expiration-presets": {
+        "one-month": "1か月",
+        "one-week": "1週間",
+        "one-year": "1年",
+        "three-months": "3か月"
+      },
+      "expires-at": "有効期限: {{date}}",
       "never-expires": "なし",
       "request-role": {
         "disabled-reason": {

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -1589,6 +1589,13 @@
       "ddl-warning": "Trong các môi trường đã chọn, câu lệnh {{kind}} có thể được chạy trực tiếp trong SQL Editor mà không cần phê duyệt.",
       "description": "Thành viên dự án xác định quyền để vận hành cơ sở dữ liệu và các vấn đề bên trong dự án. Chủ sở hữu dự án, Quản trị viên không gian làm việc và DBA không gian làm việc đều có toàn quyền dự án.",
       "edit-member": "Chỉnh sửa thành viên - {{member}}",
+      "expiration-presets": {
+        "one-month": "1 tháng",
+        "one-week": "1 tuần",
+        "one-year": "1 năm",
+        "three-months": "3 tháng"
+      },
+      "expires-at": "Hết hạn: {{date}}",
       "never-expires": "Không bao giờ",
       "request-role": {
         "disabled-reason": {

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -1589,6 +1589,13 @@
       "ddl-warning": "在所选环境中，{{kind}} 语句可在 SQL 编辑器中直接执行，无需审批。",
       "description": "项目成员角色决定了操作项目中的数据库和工单的权限。项目的所有者，工作空间管理员和 DBA 都具有项目所有的权限。",
       "edit-member": "编辑成员 - {{member}}",
+      "expiration-presets": {
+        "one-month": "1 个月",
+        "one-week": "1 周",
+        "one-year": "1 年",
+        "three-months": "3 个月"
+      },
+      "expires-at": "过期时间：{{date}}",
       "never-expires": "永不",
       "request-role": {
         "disabled-reason": {

--- a/frontend/src/react/pages/settings/MembersPage.test.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.test.tsx
@@ -207,6 +207,7 @@ vi.mock("@/plugins/cel", () => ({
 vi.mock("@/types", () => ({
   ALL_USERS_USER_EMAIL: "allUsers",
   isDefaultProject: () => false,
+  PresetRoleType: { PROJECT_OWNER: "roles/projectOwner" },
   userBindingPrefix: "user:",
 }));
 
@@ -290,6 +291,7 @@ vi.mock("@/store", () => ({
   useSettingV1Store: () => ({
     getOrFetchSettingByName: vi.fn(),
     getSettingByName: () => undefined,
+    workspaceProfile: {},
   }),
   useSubscriptionV1Store: () => ({
     hasFeature: () => true,

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -1,4 +1,5 @@
 import { create } from "@bufbuild/protobuf";
+import dayjs from "dayjs";
 import {
   Building2,
   ChevronDown,
@@ -40,6 +41,7 @@ import { Alert } from "@/react/components/ui/alert";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
+import { ExpirationPicker } from "@/react/components/ui/expiration-picker";
 import { Input } from "@/react/components/ui/input";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
@@ -92,6 +94,7 @@ import {
   ALL_USERS_USER_EMAIL,
   type DatabaseResource,
   isDefaultProject,
+  PresetRoleType,
   userBindingPrefix,
 } from "@/types";
 import { ExprSchema as ConditionExprSchema } from "@/types/proto-es/google/type/expr_pb";
@@ -860,22 +863,18 @@ function MemberTableByRole({
 // ============================================================
 
 interface ExpirationPreset {
-  label: string;
-  days?: number;
+  labelKey: string;
+  days: number;
 }
 
-function getExpirationPresets(t: (key: string) => string): ExpirationPreset[] {
-  return [
-    { label: t("project.members.never-expires") },
-    { label: "1 day", days: 1 },
-    { label: "3 days", days: 3 },
-    { label: "1 week", days: 7 },
-    { label: "1 month", days: 30 },
-    { label: "3 months", days: 90 },
-    { label: "6 months", days: 180 },
-    { label: "1 year", days: 365 },
-  ];
-}
+// A small set of common presets. Users needing any other duration pick the
+// "Custom" option, which reveals a datetime picker.
+const EXPIRATION_PRESETS: ExpirationPreset[] = [
+  { labelKey: "project.members.expiration-presets.one-week", days: 7 },
+  { labelKey: "project.members.expiration-presets.one-month", days: 30 },
+  { labelKey: "project.members.expiration-presets.three-months", days: 90 },
+  { labelKey: "project.members.expiration-presets.one-year", days: 365 },
+];
 
 function computeExpirationTimestamp(days?: number): number | undefined {
   if (days === undefined) return undefined;
@@ -893,6 +892,52 @@ function formatExpirationDate(timestampMs?: number): string {
   });
 }
 
+// Validates the form's expiration against the workspace cap. "Never" (no
+// timestamp) is only allowed when no cap is configured; a chosen timestamp
+// must be in the future and within the cap.
+function isExpirationValid(
+  form: RoleBindingFormState,
+  maximumRoleExpirationDays: number | undefined
+): boolean {
+  if (form.expirationTimestampInMS === undefined) {
+    return maximumRoleExpirationDays === undefined;
+  }
+  const now = Date.now();
+  if (form.expirationTimestampInMS <= now) return false;
+  if (
+    maximumRoleExpirationDays !== undefined &&
+    form.expirationTimestampInMS > now + maximumRoleExpirationDays * 86400000
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function ExpirationChip({
+  label,
+  selected,
+  onClick,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "px-2.5 py-1 text-xs rounded-sm border transition-colors",
+        selected
+          ? "bg-accent text-accent-text border-accent"
+          : "bg-background text-control border-control-border hover:bg-control-bg"
+      )}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}
+
 // ============================================================
 // ProjectRoleBindingForm — one role binding form in create mode
 // ============================================================
@@ -903,6 +948,8 @@ interface RoleBindingFormState {
   reason: string;
   expirationDays: number | undefined;
   expirationTimestampInMS: number | undefined;
+  // When true, the user picked a custom datetime instead of a preset.
+  expirationCustom: boolean;
   databaseMode: DatabaseMode;
   databaseResources: DatabaseResource[];
   exprGroup: ConditionGroupExpr;
@@ -996,18 +1043,44 @@ function ProjectRoleBindingForm({
   onRemove,
   canRemove,
   projectName,
+  maximumRoleExpirationDays,
 }: {
   form: RoleBindingFormState;
   onChange: (updated: RoleBindingFormState) => void;
   onRemove: () => void;
   canRemove: boolean;
   projectName: string;
+  maximumRoleExpirationDays: number | undefined;
 }) {
   const { t } = useTranslation();
 
   const roleList = useAppStore((state) => state.roleList);
 
-  const expirationPresets = useMemo(() => getExpirationPresets(t), [t]);
+  const visibleExpirationPresets = useMemo(
+    () =>
+      EXPIRATION_PRESETS.filter(
+        (preset) =>
+          maximumRoleExpirationDays === undefined ||
+          preset.days <= maximumRoleExpirationDays
+      ),
+    [maximumRoleExpirationDays]
+  );
+  const minDatetime = dayjs().format("YYYY-MM-DDTHH:mm");
+  const maxDatetime =
+    maximumRoleExpirationDays !== undefined
+      ? dayjs()
+          .add(maximumRoleExpirationDays, "days")
+          .format("YYYY-MM-DDTHH:mm")
+      : undefined;
+  const now = Date.now();
+  const expirationIsInPast =
+    form.expirationCustom &&
+    form.expirationTimestampInMS !== undefined &&
+    form.expirationTimestampInMS <= now;
+  const expirationExceedsMax =
+    form.expirationTimestampInMS !== undefined &&
+    maximumRoleExpirationDays !== undefined &&
+    form.expirationTimestampInMS > now + maximumRoleExpirationDays * 86400000;
   const factorList = useMemo<Factor[]>(
     () => [
       CEL_ATTRIBUTE_RESOURCE_DATABASE,
@@ -1071,11 +1144,37 @@ function ProjectRoleBindingForm({
     onChange({ ...form, reason });
   };
 
-  const handleExpirationChange = (days: number | undefined) => {
+  const handlePresetChange = (days: number | undefined) => {
     onChange({
       ...form,
+      expirationCustom: false,
       expirationDays: days,
       expirationTimestampInMS: computeExpirationTimestamp(days),
+    });
+  };
+
+  const handleCustomClick = () => {
+    // Seed the picker with the current timestamp, or a default 1 week
+    // (clamped to the cap) when switching from "Never".
+    const seedDays =
+      maximumRoleExpirationDays !== undefined
+        ? Math.min(7, maximumRoleExpirationDays)
+        : 7;
+    onChange({
+      ...form,
+      expirationCustom: true,
+      expirationDays: undefined,
+      expirationTimestampInMS:
+        form.expirationTimestampInMS ?? computeExpirationTimestamp(seedDays),
+    });
+  };
+
+  const handleCustomDateChange = (value: string | undefined) => {
+    onChange({
+      ...form,
+      expirationCustom: true,
+      expirationDays: undefined,
+      expirationTimestampInMS: value ? dayjs(value).valueOf() : undefined,
     });
   };
 
@@ -1192,28 +1291,68 @@ function ProjectRoleBindingForm({
           <span className="ml-0.5 text-error">*</span>
         </label>
         <div className="flex flex-wrap gap-1.5">
-          {expirationPresets.map((preset) => {
-            const isSelected = form.expirationDays === preset.days;
-            return (
-              <button
-                key={preset.label}
-                type="button"
-                className={cn(
-                  "px-2.5 py-1 text-xs rounded-sm border transition-colors",
-                  isSelected
-                    ? "bg-accent text-accent-text border-accent"
-                    : "bg-background text-control border-control-border hover:bg-control-bg"
-                )}
-                onClick={() => handleExpirationChange(preset.days)}
-              >
-                {preset.label}
-              </button>
-            );
-          })}
+          {/* "Never" is only offered when the workspace sets no cap. */}
+          {maximumRoleExpirationDays === undefined && (
+            <ExpirationChip
+              label={t("project.members.never-expires")}
+              selected={
+                !form.expirationCustom && form.expirationDays === undefined
+              }
+              onClick={() => handlePresetChange(undefined)}
+            />
+          )}
+          {visibleExpirationPresets.map((preset) => (
+            <ExpirationChip
+              key={preset.days}
+              label={t(preset.labelKey)}
+              selected={
+                !form.expirationCustom && form.expirationDays === preset.days
+              }
+              onClick={() => handlePresetChange(preset.days)}
+            />
+          ))}
+          <ExpirationChip
+            label={t("common.custom")}
+            selected={form.expirationCustom}
+            onClick={handleCustomClick}
+          />
         </div>
-        {form.expirationTimestampInMS && (
+        {form.expirationCustom && (
+          <ExpirationPicker
+            value={
+              form.expirationTimestampInMS
+                ? dayjs(form.expirationTimestampInMS).format("YYYY-MM-DDTHH:mm")
+                : undefined
+            }
+            onChange={handleCustomDateChange}
+            minDate={minDatetime}
+            maxDate={maxDatetime}
+          />
+        )}
+        {maximumRoleExpirationDays !== undefined && (
+          <p className="text-xs text-control-light">
+            {t("project.members.request-role.max-expiration-hint", {
+              days: maximumRoleExpirationDays,
+            })}
+          </p>
+        )}
+        {expirationIsInPast && (
+          <p className="text-xs text-error">
+            {t("project.members.request-role.expiration-must-be-future")}
+          </p>
+        )}
+        {expirationExceedsMax && (
+          <p className="text-xs text-error">
+            {t("project.members.request-role.expiration-exceeds-max", {
+              days: maximumRoleExpirationDays,
+            })}
+          </p>
+        )}
+        {!form.expirationCustom && form.expirationTimestampInMS && (
           <span className="text-xs text-control-light">
-            Expires: {formatExpirationDate(form.expirationTimestampInMS)}
+            {t("project.members.expires-at", {
+              date: formatExpirationDate(form.expirationTimestampInMS),
+            })}
           </span>
         )}
       </div>
@@ -1293,6 +1432,7 @@ function EditMemberRoleDrawer({
     reason: "",
     expirationDays: 7,
     expirationTimestampInMS: computeExpirationTimestamp(7),
+    expirationCustom: false,
     databaseMode: "ALL",
     databaseResources: [],
     exprGroup: wrapAsGroup(emptySimpleExpr()),
@@ -1300,6 +1440,17 @@ function EditMemberRoleDrawer({
   }));
 
   useEscapeKey(true, onClose);
+
+  // Workspace-configured maximum role expiration, in days. PROJECT_OWNER
+  // grants are exempt; returns undefined when no cap is set. Mirrors
+  // RequestRoleSheet so direct grants and role requests behave the same.
+  const maximumRoleExpirationDays = useVueState(() => {
+    if (form.role === PresetRoleType.PROJECT_OWNER) return undefined;
+    const seconds =
+      settingV1Store.workspaceProfile.maximumRoleExpiration?.seconds;
+    if (!seconds) return undefined;
+    return Math.floor(Number(seconds) / (60 * 60 * 24));
+  });
 
   // Helpers for project edit mode
   const getSingleBindingRows = useCallback(
@@ -1610,6 +1761,7 @@ function EditMemberRoleDrawer({
   const allowConfirm = isProjectCreateMode
     ? selectedBindings.length > 0 &&
       !!form.role &&
+      isExpirationValid(form, maximumRoleExpirationDays) &&
       !(
         roleHasDatabaseLimitation(form.role) &&
         form.databaseMode === "SELECT" &&
@@ -1837,6 +1989,7 @@ function EditMemberRoleDrawer({
                   onRemove={() => {}}
                   canRemove={false}
                   projectName={projectName}
+                  maximumRoleExpirationDays={maximumRoleExpirationDays}
                 />
               </div>
             ) : (


### PR DESCRIPTION
## What & why

Closes BYT-9612. When granting a user a project role, the expiration picker no longer offered a custom time — only fixed presets.

**Root cause:** the Vue→React migration of `MembersPage` rebuilt the role-grant expiration UI (`ProjectRoleBindingForm`) as preset buttons only, dropping the custom-date option the old `ExpirationSelector.vue` had (that component was later deleted). The same migration also stopped honoring the workspace `maximumRoleExpiration` cap and hardcoded the duration labels in English. The sibling `RequestRoleSheet` was migrated correctly and served as the reference.

## Changes

- **Restore custom time** — adds a **Custom** chip that reveals the shared `ExpirationPicker` (datetime-local), reusing the same component `RequestRoleSheet` uses.
- **Reduced presets** — Never · 1 week · 1 month · 3 months · 1 year + Custom (was a longer fixed list with no custom option).
- **Honor the workspace cap** — presets over `maximumRoleExpiration` are hidden, the custom picker's max is clamped, "Never" is hidden when a cap is set, and in-the-past / exceeds-max validation errors show. `PROJECT_OWNER` is exempt, matching the request flow.
- **Gate submit** — invalid expiration now blocks the grant via `allowConfirm`.
- **i18n** — moved the hardcoded `"1 day"`…`"1 year"` labels into all 5 React locale files (`project.members.expiration-presets.*`, `project.members.expires-at`); reused existing `request-role.*` keys for the cap hint and validation messages.

## Testing

- `pnpm --dir frontend type-check` (`tsconfig.react.json`) — 0 errors
- `pnpm --dir frontend check` — eslint, biome, React i18n, layering scanner, locale sort all pass

Note: scope is the **project** role-grant form only; workspace-level grants have no expiration field and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)