### PR TITLE
fix(frontend): route overlay cleanup through semantic layers

### DIFF
--- a/frontend/src/react/components/DashboardBodyShell.test.tsx
+++ b/frontend/src/react/components/DashboardBodyShell.test.tsx
@@ -6,6 +6,7 @@ import type {
   DashboardShellTargets,
 } from "@/react/dashboard-shell";
 import { DashboardBodyShell } from "./DashboardBodyShell";
+import { LAYER_ROOT_ID } from "./ui/layer";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -170,6 +171,11 @@ describe("DashboardBodyShell", () => {
     expect(targets.mobileSidebar?.parentElement?.className).toContain(
       "translate-x-0"
     );
+    expect(
+      document
+        .getElementById(LAYER_ROOT_ID.overlay)
+        ?.contains(targets.mobileSidebar)
+    ).toBe(true);
 
     harness.unmount();
   });

--- a/frontend/src/react/components/DashboardBodyShell.tsx
+++ b/frontend/src/react/components/DashboardBodyShell.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { DashboardHeader } from "@/react/components/header/DashboardHeader";
-import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
+import { getLayerRoot, LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
 import type {
   DashboardBodyShellProps,
   DashboardShellTargets,
@@ -46,6 +47,36 @@ export function DashboardBodyShell({
 
   const showWorkspaceChrome = variant === "workspace" && !isRootPath;
   const showHeader = variant === "issues" || showWorkspaceChrome;
+  const mobileSidebarOverlay = (
+    <div
+      className={cn(
+        "fixed inset-0 md:hidden",
+        LAYER_SURFACE_CLASS,
+        isMobileSidebarOpen ? "" : "pointer-events-none"
+      )}
+    >
+      <button
+        aria-label={t("common.close-mobile-sidebar")}
+        className={cn(
+          "absolute inset-0 bg-black/20 transition-opacity",
+          isMobileSidebarOpen ? "opacity-100" : "opacity-0"
+        )}
+        type="button"
+        onClick={() => setIsMobileSidebarOpen(false)}
+      />
+      <div
+        className={cn(
+          "absolute inset-y-0 left-0 w-52 bg-control-bg transition-transform",
+          isMobileSidebarOpen ? "translate-x-0" : "-translate-x-full"
+        )}
+      >
+        <div
+          ref={mobileSidebarRef}
+          className="h-full overflow-y-auto bg-control-bg"
+        />
+      </div>
+    </div>
+  );
 
   useEffect(() => {
     setIsMobileSidebarOpen(false);
@@ -73,34 +104,7 @@ export function DashboardBodyShell({
       <div className="flex flex-1 overflow-hidden">
         {showWorkspaceChrome ? (
           <>
-            <div
-              className={cn(
-                "fixed inset-0 md:hidden",
-                LAYER_SURFACE_CLASS,
-                isMobileSidebarOpen ? "" : "pointer-events-none"
-              )}
-            >
-              <button
-                aria-label={t("common.close-mobile-sidebar")}
-                className={cn(
-                  "absolute inset-0 bg-black/20 transition-opacity",
-                  isMobileSidebarOpen ? "opacity-100" : "opacity-0"
-                )}
-                type="button"
-                onClick={() => setIsMobileSidebarOpen(false)}
-              />
-              <div
-                className={cn(
-                  "absolute inset-y-0 left-0 w-52 bg-control-bg transition-transform",
-                  isMobileSidebarOpen ? "translate-x-0" : "-translate-x-full"
-                )}
-              >
-                <div
-                  ref={mobileSidebarRef}
-                  className="h-full overflow-y-auto bg-control-bg"
-                />
-              </div>
-            </div>
+            {createPortal(mobileSidebarOverlay, getLayerRoot("overlay"))}
 
             <aside
               className={cn("shrink-0", isDesktop ? "flex" : "hidden")}

--- a/frontend/src/react/components/sql-editor/Panels/common/EllipsisCell.test.tsx
+++ b/frontend/src/react/components/sql-editor/Panels/common/EllipsisCell.test.tsx
@@ -2,6 +2,10 @@ import type { ReactElement } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, test } from "vitest";
+import {
+  LAYER_ROOT_ID,
+  LAYER_SURFACE_CLASS,
+} from "@/react/components/ui/layer";
 import { EllipsisCell } from "./EllipsisCell";
 
 (
@@ -61,6 +65,27 @@ describe("EllipsisCell", () => {
     });
     // scrollWidth === clientWidth in jsdom, so the tooltip is suppressed.
     expect(document.querySelector("[role='tooltip']")).toBeNull();
+    unmount();
+  });
+
+  test("mounts overflowing tooltip on the overlay surface layer", () => {
+    const { container, unmount } = renderIntoContainer(
+      <EllipsisCell content="very long cell content" />
+    );
+    const span = container.querySelector("span") as HTMLSpanElement;
+    Object.defineProperties(span, {
+      clientWidth: { configurable: true, value: 40 },
+      scrollWidth: { configurable: true, value: 160 },
+    });
+
+    act(() => {
+      span.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+
+    const overlayRoot = document.getElementById(LAYER_ROOT_ID.overlay);
+    const tooltip = overlayRoot?.querySelector("[role='tooltip']");
+    expect(tooltip).toBeInstanceOf(HTMLSpanElement);
+    expect(tooltip?.className).toContain(LAYER_SURFACE_CLASS);
     unmount();
   });
 });

--- a/frontend/src/react/components/sql-editor/Panels/common/EllipsisCell.tsx
+++ b/frontend/src/react/components/sql-editor/Panels/common/EllipsisCell.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
-import { getLayerRoot } from "@/react/components/ui/layer";
+import { getLayerRoot, LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
 import { cn } from "@/react/lib/utils";
 
 interface EllipsisCellProps {
@@ -66,7 +66,10 @@ export function EllipsisCell({
               transform: "translate(-50%, -100%) translateY(-6px)",
               maxWidth: "min(33vw, 320px)",
             }}
-            className="rounded-sm bg-gray-900 px-2.5 py-1.5 text-xs font-normal text-white shadow-md whitespace-pre-wrap break-all pointer-events-none"
+            className={cn(
+              "rounded-sm bg-gray-900 px-2.5 py-1.5 text-xs font-normal text-white shadow-md whitespace-pre-wrap break-all pointer-events-none",
+              LAYER_SURFACE_CLASS
+            )}
           >
             <HighlightLabelText text={tooltip ?? content} keyword={keyword} />
           </span>,


### PR DESCRIPTION
## Summary
- Portal the dashboard mobile sidebar through the shared overlay layer root.
- Mark the SQL editor ellipsis tooltip with the shared overlay surface class.
- Add regression tests for both layering expectations.

## Test Plan
- [x] pnpm --dir frontend exec vitest run src/react/components/DashboardBodyShell.test.tsx src/react/components/sql-editor/Panels/common/EllipsisCell.test.tsx
- [x] pnpm --dir frontend fix
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test

## Pre-PR Checklist
- Breaking change check: no API, schema, config, permission, or workflow breaking changes.
- Composite-PK query safety: skipped, no backend/store/migrator changes.
- SonarCloud properties: skipped, no new files or directories.
