### PR TITLE
chore: migrate Oracle completion to omni

### DIFF
--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -696,21 +696,6 @@ func (c *Completer) insertReferenceAliasCandidates(tableEntries CompletionMap) {
 	}
 }
 
-func (c *Completer) querySpan(statement string) (*base.QuerySpan, error) {
-	return GetQuerySpan(
-		c.ctx,
-		base.GetQuerySpanContext{
-			InstanceID:              c.instanceID,
-			GetDatabaseMetadataFunc: c.getMetadata,
-			ListDatabaseNamesFunc:   c.listDatabaseNames,
-		},
-		base.Statement{Text: statement},
-		c.defaultDatabase,
-		"",
-		false,
-	)
-}
-
 func convertCompletionVirtualReference(reference oracleparser.RangeReference) *base.VirtualTableReference {
 	table := reference.Alias
 	if table == "" {

--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -1101,7 +1101,7 @@ func (c *Completer) querySceneDisallowsCompletion() bool {
 	if c.scene != base.SceneTypeQuery {
 		return false
 	}
-	idx := c.currentStatementFirstTokenIndex()
+	idx := c.currentStatementMainTokenIndex()
 	if idx < 0 {
 		return false
 	}
@@ -1132,7 +1132,7 @@ func (c *Completer) isAtStatementStartCompletion() bool {
 	return token.Type == ';' || token.Loc >= collectOffset
 }
 
-func (c *Completer) currentStatementFirstTokenIndex() int {
+func (c *Completer) currentStatementMainTokenIndex() int {
 	start := c.currentStatementStartTokenIndex(c.cursorByteOffset)
 	if start >= len(c.tokens) {
 		return -1
@@ -1141,7 +1141,42 @@ func (c *Completer) currentStatementFirstTokenIndex() int {
 	if token.Loc >= c.cursorByteOffset || token.Type == ';' {
 		return -1
 	}
+	if token.Type == oracleparser.WITH {
+		return c.withMainStatementTokenIndex(start)
+	}
 	return start
+}
+
+func (c *Completer) withMainStatementTokenIndex(withIdx int) int {
+	depth := 0
+	for i := withIdx + 1; i < len(c.tokens); i++ {
+		token := c.tokens[i]
+		if token.Loc >= c.cursorByteOffset || token.Type == ';' {
+			break
+		}
+		switch token.Type {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 && isOracleStatementStartToken(token.Type) {
+				return i
+			}
+		}
+	}
+	return withIdx
+}
+
+func isOracleStatementStartToken(tokenType int) bool {
+	switch tokenType {
+	case oracleparser.SELECT, oracleparser.INSERT, oracleparser.UPDATE, oracleparser.DELETE, oracleparser.MERGE:
+		return true
+	default:
+		return false
+	}
 }
 
 func (c *Completer) currentStatementStartTokenIndex(offset int) int {

--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -570,7 +570,7 @@ func (c *Completer) insertColumnContextCandidates(schemaEntries, tableEntries, c
 		}
 	}
 	if table == "" {
-		c.insertReferenceAliasCandidates(tableEntries, schemas, tables)
+		c.insertReferenceAliasCandidates(tableEntries)
 	}
 
 	if len(tables) > 0 {
@@ -675,7 +675,7 @@ func (c *Completer) insertAliasColumns(entries CompletionMap, alias string) {
 	}
 }
 
-func (c *Completer) insertReferenceAliasCandidates(tableEntries CompletionMap, schemas, tables map[string]bool) {
+func (c *Completer) insertReferenceAliasCandidates(tableEntries CompletionMap) {
 	for _, reference := range c.references {
 		switch reference := reference.(type) {
 		case *base.PhysicalTableReference:
@@ -694,45 +694,6 @@ func (c *Completer) insertReferenceAliasCandidates(tableEntries CompletionMap, s
 		default:
 		}
 	}
-	for _, reference := range c.scopeReferences {
-		if reference.Kind != oracleparser.RangeReferenceSubquery {
-			continue
-		}
-		for source := range c.querySpanSourceTables(reference) {
-			schemas[source.schema] = true
-			tables[source.table] = true
-		}
-	}
-}
-
-type completionSourceTable struct {
-	schema string
-	table  string
-}
-
-func (c *Completer) querySpanSourceTables(reference oracleparser.RangeReference) map[completionSourceTable]bool {
-	if reference.BodyLoc.Start < 0 || reference.BodyLoc.End <= reference.BodyLoc.Start || reference.BodyLoc.End > len(c.sql) {
-		return nil
-	}
-	alias := reference.Alias
-	if alias == "" {
-		alias = "x"
-	}
-	span, err := c.querySpan(fmt.Sprintf("SELECT * FROM (%s) %s", c.sql[reference.BodyLoc.Start:reference.BodyLoc.End], quoteIdentifierForSQL(alias)))
-	if err != nil || span == nil || span.NotFoundError != nil {
-		return nil
-	}
-	tables := make(map[completionSourceTable]bool)
-	for column := range span.SourceColumns {
-		schema := column.Database
-		if schema == "" {
-			schema = c.defaultDatabase
-		}
-		if schema != "" && column.Table != "" {
-			tables[completionSourceTable{schema: schema, table: column.Table}] = true
-		}
-	}
-	return tables
 }
 
 func (c *Completer) querySpan(statement string) (*base.QuerySpan, error) {

--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -351,9 +351,9 @@ func (c *Completer) convertCandidates(candidates *oracleparser.CandidateSet) ([]
 			case "schema_ref":
 				schemaEntries.insertDatabases(c)
 			case "table_ref":
-				c.insertTableContextCandidates(schemaEntries, tableEntries, viewEntries, sequenceEntries)
+				c.insertTableReferenceCandidates(schemaEntries, tableEntries, viewEntries, sequenceEntries)
 			case "sequence_ref":
-				sequenceEntries.insertSequences(c, c.completionSchemas(""))
+				sequenceEntries.insertSequences(c, c.sequenceCompletionSchemas())
 			case "columnref":
 				c.insertColumnContextCandidates(schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries)
 			default:
@@ -385,10 +385,12 @@ func (c *Completer) insertCompletionIntentCandidates(keywordEntries, functionEnt
 		switch kind {
 		case oracleparser.ObjectKindSchema:
 			schemaEntries.insertDatabases(c)
-		case oracleparser.ObjectKindTable, oracleparser.ObjectKindView:
-			c.insertTableContextCandidates(schemaEntries, tableEntries, viewEntries, sequenceEntries)
+		case oracleparser.ObjectKindTable:
+			c.insertTableIntentCandidates(schemaEntries, tableEntries)
+		case oracleparser.ObjectKindView:
+			c.insertViewIntentCandidates(schemaEntries, viewEntries)
 		case oracleparser.ObjectKindSequence:
-			sequenceEntries.insertSequences(c, c.completionSchemas(""))
+			sequenceEntries.insertSequences(c, c.sequenceCompletionSchemas())
 		case oracleparser.ObjectKindColumn:
 			c.insertColumnContextCandidates(schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries)
 		case oracleparser.ObjectKindFunction:
@@ -424,6 +426,55 @@ func (c *Completer) insertTableContextCandidates(schemaEntries, tableEntries, vi
 	tableEntries.insertTables(c, schemas)
 	viewEntries.insertViews(c, schemas)
 	sequenceEntries.insertSequences(c, schemas)
+}
+
+func (c *Completer) insertTableReferenceCandidates(schemaEntries, tableEntries, viewEntries, sequenceEntries CompletionMap) {
+	if c.completionIntentOnly(oracleparser.ObjectKindTable) {
+		c.insertTableIntentCandidates(schemaEntries, tableEntries)
+		return
+	}
+	if c.completionIntentOnly(oracleparser.ObjectKindView) {
+		c.insertViewIntentCandidates(schemaEntries, viewEntries)
+		return
+	}
+	c.insertTableContextCandidates(schemaEntries, tableEntries, viewEntries, sequenceEntries)
+}
+
+func (c *Completer) completionIntentOnly(kind oracleparser.ObjectKind) bool {
+	return c.completionIntent != nil && len(c.completionIntent.ObjectKinds) == 1 && c.completionIntent.ObjectKinds[0] == kind
+}
+
+func (c *Completer) insertTableIntentCandidates(schemaEntries, tableEntries CompletionMap) {
+	schema := c.completionSchemaQualifier()
+	if schema == "" {
+		schemaEntries.insertDatabases(c)
+	}
+	tableEntries.insertTables(c, c.completionSchemas(schema))
+}
+
+func (c *Completer) insertViewIntentCandidates(schemaEntries, viewEntries CompletionMap) {
+	schema := c.completionSchemaQualifier()
+	if schema == "" {
+		schemaEntries.insertDatabases(c)
+	}
+	viewEntries.insertViews(c, c.completionSchemas(schema))
+}
+
+func (c *Completer) sequenceCompletionSchemas() map[string]bool {
+	return c.completionSchemas(c.completionSchemaQualifier())
+}
+
+func (c *Completer) completionSchemaQualifier() string {
+	if c.completionIntent != nil {
+		if schema := c.completionIntent.Qualifier.Schema; schema != "" {
+			return schema
+		}
+	}
+	parts := c.qualifierParts()
+	if len(parts) == 1 {
+		return parts[0]
+	}
+	return ""
 }
 
 func (c *Completer) insertColumnContextCandidates(schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries CompletionMap) {
@@ -905,20 +956,7 @@ func (c *Completer) selectItemAliases() []string {
 	if !c.isInAliasAllowedContext() {
 		return nil
 	}
-	stmtStart, stmtEnd := c.statementTokenBounds()
-	selectIdx := -1
-	fromIdx := -1
-	for i := stmtStart; i < stmtEnd; i++ {
-		switch c.tokens[i].Type {
-		case oracleparser.SELECT:
-			selectIdx = i
-		case oracleparser.FROM:
-			if selectIdx >= 0 && fromIdx < 0 {
-				fromIdx = i
-			}
-		default:
-		}
-	}
+	selectIdx, fromIdx := c.currentQueryBlockSelectFrom()
 	if selectIdx < 0 || fromIdx < 0 {
 		return nil
 	}
@@ -949,6 +987,52 @@ func (c *Completer) selectItemAliases() []string {
 	}
 	slices.Sort(aliases)
 	return aliases
+}
+
+func (c *Completer) currentQueryBlockSelectFrom() (int, int) {
+	stmtStart, stmtEnd := c.statementTokenBounds()
+	targetDepth := c.depthAtToken(c.caretTokenIndex)
+	selectIdx := -1
+	fromIdx := -1
+	depth := 0
+	for i := stmtStart; i < stmtEnd && i < c.caretTokenIndex; i++ {
+		if c.tokens[i].Type == ')' && depth > 0 {
+			depth--
+		}
+		if depth == targetDepth {
+			switch c.tokens[i].Type {
+			case oracleparser.SELECT:
+				selectIdx = i
+				fromIdx = -1
+			case oracleparser.FROM:
+				if selectIdx >= 0 && fromIdx < 0 {
+					fromIdx = i
+				}
+			default:
+			}
+		}
+		if c.tokens[i].Type == '(' {
+			depth++
+		}
+	}
+	return selectIdx, fromIdx
+}
+
+func (c *Completer) depthAtToken(index int) int {
+	stmtStart, _ := c.statementTokenBounds()
+	depth := 0
+	for i := stmtStart; i < index && i < len(c.tokens); i++ {
+		switch c.tokens[i].Type {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+		}
+	}
+	return depth
 }
 
 func selectAliasFromTokens(tokens []oracleparser.Token) string {

--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -137,6 +137,10 @@ func (c *Completer) completion() ([]base.Candidate, error) {
 		}
 	}
 
+	if c.querySceneDisallowsCompletion() {
+		return nil, nil
+	}
+
 	completionContext := oracleparser.CollectCompletion(c.sql, c.cursorByteOffset)
 	if completionContext != nil {
 		c.completionPrefix = completionContext.Prefix
@@ -151,7 +155,7 @@ func (c *Completer) completion() ([]base.Candidate, error) {
 	if candidates == nil {
 		candidates = oracleparser.Collect(c.sql, c.cursorByteOffset)
 	}
-	return c.convertCandidates(candidates)
+	return c.filterCandidatesByScene(c.convertCandidates(candidates)), nil
 }
 
 type CompletionMap map[string]base.Candidate
@@ -167,6 +171,12 @@ func (m CompletionMap) toSlice() []base.Candidate {
 	}
 	slices.SortFunc(result, compareCandidates)
 	return result
+}
+
+var oracleQuerySceneStartKeywords = map[string]bool{
+	"EXPLAIN": true,
+	"SELECT":  true,
+	"WITH":    true,
 }
 
 func compareCandidates(i, j base.Candidate) int {
@@ -311,7 +321,7 @@ func (c *Completer) columnCandidate(schema, table, name, typ string, notNull boo
 	}
 }
 
-func (c *Completer) convertCandidates(candidates *oracleparser.CandidateSet) ([]base.Candidate, error) {
+func (c *Completer) convertCandidates(candidates *oracleparser.CandidateSet) []base.Candidate {
 	keywordEntries := make(CompletionMap)
 	functionEntries := make(CompletionMap)
 	schemaEntries := make(CompletionMap)
@@ -374,7 +384,7 @@ func (c *Completer) convertCandidates(candidates *oracleparser.CandidateSet) ([]
 	result = append(result, columnEntries.toSlice()...)
 	result = append(result, viewEntries.toSlice()...)
 	result = append(result, sequenceEntries.toSlice()...)
-	return c.filterCandidatesByPrefix(result), nil
+	return c.filterCandidatesByPrefix(result)
 }
 
 func (c *Completer) insertCompletionIntentCandidates(keywordEntries, functionEntries, schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries CompletionMap) {
@@ -1114,6 +1124,80 @@ func (c *Completer) listAllDatabases() []string {
 		}
 	}
 	return result
+}
+
+func (c *Completer) filterCandidatesByScene(candidates []base.Candidate) []base.Candidate {
+	if c.scene != base.SceneTypeQuery || !c.isAtStatementStartCompletion() {
+		return candidates
+	}
+	var result []base.Candidate
+	for _, candidate := range candidates {
+		if candidate.Type == base.CandidateTypeKeyword && !oracleQuerySceneStartKeywords[strings.ToUpper(candidate.Text)] {
+			continue
+		}
+		result = append(result, candidate)
+	}
+	return result
+}
+
+func (c *Completer) querySceneDisallowsCompletion() bool {
+	if c.scene != base.SceneTypeQuery {
+		return false
+	}
+	idx := c.currentStatementFirstTokenIndex()
+	if idx < 0 {
+		return false
+	}
+	if c.tokens[idx].End >= c.cursorByteOffset {
+		return false
+	}
+	if strings.EqualFold(c.tokens[idx].Str, "EXPLAIN") {
+		return false
+	}
+	switch c.tokens[idx].Type {
+	case oracleparser.SELECT, oracleparser.WITH:
+		return false
+	default:
+		return true
+	}
+}
+
+func (c *Completer) isAtStatementStartCompletion() bool {
+	collectOffset := c.cursorByteOffset - len(c.completionPrefix)
+	if collectOffset < 0 {
+		collectOffset = 0
+	}
+	start := c.currentStatementStartTokenIndex(collectOffset)
+	if start >= len(c.tokens) {
+		return true
+	}
+	token := c.tokens[start]
+	return token.Type == ';' || token.Loc >= collectOffset
+}
+
+func (c *Completer) currentStatementFirstTokenIndex() int {
+	start := c.currentStatementStartTokenIndex(c.cursorByteOffset)
+	if start >= len(c.tokens) {
+		return -1
+	}
+	token := c.tokens[start]
+	if token.Loc >= c.cursorByteOffset || token.Type == ';' {
+		return -1
+	}
+	return start
+}
+
+func (c *Completer) currentStatementStartTokenIndex(offset int) int {
+	start := 0
+	for i, token := range c.tokens {
+		if token.Loc >= offset {
+			break
+		}
+		if token.Type == ';' {
+			start = i + 1
+		}
+	}
+	return start
 }
 
 func (c *Completer) listTables(schema string) []string {

--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -95,9 +95,20 @@ func lineColumnToByteOffset(sql string, line, column int) int {
 	for i := 0; i < len(sql); i++ {
 		if currentLine == line {
 			pos := i
-			for c := 0; c < column && pos < len(sql); c++ {
-				_, size := utf8.DecodeRuneInString(sql[pos:])
+			for c := 0; c < column && pos < len(sql); {
+				r, size := utf8.DecodeRuneInString(sql[pos:])
+				if r == '\n' {
+					return pos
+				}
+				unitCount := 1
+				if r > 0xFFFF {
+					unitCount = 2
+				}
+				if c+unitCount > column {
+					return pos
+				}
 				pos += size
+				c += unitCount
 			}
 			if pos > len(sql) {
 				return len(sql)
@@ -1297,6 +1308,8 @@ func lineColumnAtByteOffset(sql string, offset int) (int, int) {
 		if r == '\n' {
 			line++
 			column = 0
+		} else if r > 0xFFFF {
+			column += 2
 		} else {
 			column++
 		}

--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -6,20 +6,13 @@ import (
 	"slices"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
-	"github.com/antlr4-go/antlr/v4"
-	"github.com/bytebase/parser/plsql"
+	oracleparser "github.com/bytebase/omni/oracle/parser"
 
 	"github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	"github.com/bytebase/bytebase/backend/store/model"
-)
-
-var (
-	// globalFollowSetsByState is a map from state to follow sets.
-	// It is shared by all PlSQL completers.
-	// The FollowSetsByState is the thread-safe struct.
-	globalFollowSetsByState = base.NewFollowSetsByState()
 )
 
 func init() {
@@ -40,275 +33,169 @@ func Completion(ctx context.Context, cCtx base.CompletionContext, statement stri
 	return trickyCompleter.completion()
 }
 
-func newIgnoredTokens() map[int]bool {
-	return map[int]bool{
-		plsql.PlSqlParserEOF:                      true,
-		plsql.PlSqlLexerEQUALS_OP:                 true,
-		plsql.PlSqlLexerPERCENT:                   true,
-		plsql.PlSqlLexerAMPERSAND:                 true,
-		plsql.PlSqlLexerLEFT_PAREN:                true,
-		plsql.PlSqlLexerRIGHT_PAREN:               true,
-		plsql.PlSqlLexerDOUBLE_ASTERISK:           true,
-		plsql.PlSqlLexerASTERISK:                  true,
-		plsql.PlSqlLexerPLUS_SIGN:                 true,
-		plsql.PlSqlLexerMINUS_SIGN:                true,
-		plsql.PlSqlLexerCOMMA:                     true,
-		plsql.PlSqlLexerSOLIDUS:                   true,
-		plsql.PlSqlLexerAT_SIGN:                   true,
-		plsql.PlSqlLexerASSIGN_OP:                 true,
-		plsql.PlSqlLexerHASH_OP:                   true,
-		plsql.PlSqlLexerSQ:                        true,
-		plsql.PlSqlLexerNOT_EQUAL_OP:              true,
-		plsql.PlSqlLexerCARRET_OPERATOR_PART:      true,
-		plsql.PlSqlLexerTILDE_OPERATOR_PART:       true,
-		plsql.PlSqlLexerEXCLAMATION_OPERATOR_PART: true,
-		plsql.PlSqlLexerGREATER_THAN_OP:           true,
-		plsql.PlSqlLexerLESS_THAN_OP:              true,
-		plsql.PlSqlLexerCOLON:                     true,
-		plsql.PlSqlLexerSEMICOLON:                 true,
-		plsql.PlSqlLexerBAR:                       true,
-		plsql.PlSqlLexerLEFT_BRACKET:              true,
-		plsql.PlSqlLexerRIGHT_BRACKET:             true,
-		plsql.PlSqlLexerINTRODUCER:                true,
-		plsql.PlSqlLexerBINDVAR:                   true,
-		plsql.PlSqlLexerNULL_:                     true,
-		plsql.PlSqlLexerNATIONAL_CHAR_STRING_LIT:  true,
-		plsql.PlSqlLexerBIT_STRING_LIT:            true,
-		plsql.PlSqlLexerHEX_STRING_LIT:            true,
-		plsql.PlSqlLexerDOUBLE_PERIOD:             true,
-		plsql.PlSqlLexerPERIOD:                    true,
-		plsql.PlSqlLexerUNSIGNED_INTEGER:          true,
-		plsql.PlSqlLexerAPPROXIMATE_NUM_LIT:       true,
-		plsql.PlSqlLexerCHAR_STRING:               true,
-		plsql.PlSqlLexerDELIMITED_ID:              true,
-		plsql.PlSqlLexerREGULAR_ID:                true,
-	}
-}
-
-func newPreferredRules() map[int]bool {
-	return map[int]bool{
-		plsql.PlSqlParserRULE_general_element:          true,
-		plsql.PlSqlParserRULE_tableview_name:           true,
-		plsql.PlSqlParserRULE_column_name:              true,
-		plsql.PlSqlParserRULE_identifier:               true,
-		plsql.PlSqlParserRULE_id_expression:            true,
-		plsql.PlSqlParserRULE_regular_id:               true,
-		plsql.PlSqlParserRULE_xml_column_name:          true,
-		plsql.PlSqlParserRULE_cost_class_name:          true,
-		plsql.PlSqlParserRULE_attribute_name:           true,
-		plsql.PlSqlParserRULE_savepoint_name:           true,
-		plsql.PlSqlParserRULE_rollback_segment_name:    true,
-		plsql.PlSqlParserRULE_schema_name:              true,
-		plsql.PlSqlParserRULE_package_name:             true,
-		plsql.PlSqlParserRULE_implementation_type_name: true,
-		plsql.PlSqlParserRULE_parameter_name:           true,
-		plsql.PlSqlParserRULE_reference_model_name:     true,
-		plsql.PlSqlParserRULE_main_model_name:          true,
-		plsql.PlSqlParserRULE_container_tableview_name: true,
-		plsql.PlSqlParserRULE_aggregate_function_name:  true,
-		plsql.PlSqlParserRULE_grantee_name:             true,
-		plsql.PlSqlParserRULE_role_name:                true,
-		plsql.PlSqlParserRULE_constraint_name:          true,
-		plsql.PlSqlParserRULE_label_name:               true,
-		plsql.PlSqlParserRULE_type_name:                true,
-		plsql.PlSqlParserRULE_sequence_name:            true,
-		plsql.PlSqlParserRULE_exception_name:           true,
-		plsql.PlSqlParserRULE_function_name:            true,
-		plsql.PlSqlParserRULE_procedure_name:           true,
-		plsql.PlSqlParserRULE_trigger_name:             true,
-		plsql.PlSqlParserRULE_variable_name:            true,
-		plsql.PlSqlParserRULE_index_name:               true,
-		plsql.PlSqlParserRULE_record_name:              true,
-		plsql.PlSqlParserRULE_collection_name:          true,
-		plsql.PlSqlParserRULE_link_name:                true,
-		plsql.PlSqlParserRULE_char_set_name:            true,
-		plsql.PlSqlParserRULE_synonym_name:             true,
-		plsql.PlSqlParserRULE_dir_object_name:          true,
-	}
-}
-
-func newNoSeparatorRequired() map[int]bool {
-	return map[int]bool{
-		plsql.PlSqlLexerEQUALS_OP:                 true,
-		plsql.PlSqlLexerPERCENT:                   true,
-		plsql.PlSqlLexerAMPERSAND:                 true,
-		plsql.PlSqlLexerLEFT_PAREN:                true,
-		plsql.PlSqlLexerRIGHT_PAREN:               true,
-		plsql.PlSqlLexerDOUBLE_ASTERISK:           true,
-		plsql.PlSqlLexerASTERISK:                  true,
-		plsql.PlSqlLexerPLUS_SIGN:                 true,
-		plsql.PlSqlLexerMINUS_SIGN:                true,
-		plsql.PlSqlLexerCOMMA:                     true,
-		plsql.PlSqlLexerSOLIDUS:                   true,
-		plsql.PlSqlLexerAT_SIGN:                   true,
-		plsql.PlSqlLexerASSIGN_OP:                 true,
-		plsql.PlSqlLexerHASH_OP:                   true,
-		plsql.PlSqlLexerSQ:                        true,
-		plsql.PlSqlLexerNOT_EQUAL_OP:              true,
-		plsql.PlSqlLexerCARRET_OPERATOR_PART:      true,
-		plsql.PlSqlLexerTILDE_OPERATOR_PART:       true,
-		plsql.PlSqlLexerEXCLAMATION_OPERATOR_PART: true,
-		plsql.PlSqlLexerGREATER_THAN_OP:           true,
-		plsql.PlSqlLexerLESS_THAN_OP:              true,
-		plsql.PlSqlLexerCOLON:                     true,
-		plsql.PlSqlLexerSEMICOLON:                 true,
-		plsql.PlSqlLexerDOUBLE_PERIOD:             true,
-		plsql.PlSqlLexerPERIOD:                    true,
-	}
-}
-
 type Completer struct {
-	ctx                 context.Context
-	core                *base.CodeCompletionCore
-	scene               base.SceneType
-	parser              *plsql.PlSqlParser
-	lexer               *plsql.PlSqlLexer
-	scanner             *base.Scanner
-	instanceID          string
-	getMetadata         base.GetDatabaseMetadataFunc
-	listDatabaseNames   base.ListDatabaseNamesFunc
-	defaultDatabase     string
-	metadataCache       map[string]*model.DatabaseMetadata
-	noSeparatorRequired map[int]bool
-	// referencesStack is a hierarchical stack of table references.
-	// We'll update the stack when we encounter a new FROM clauses.
-	referencesStack [][]base.TableReference
-	// references is the flattened table references.
-	// It's helpful to look up the table reference.
-	references         []base.TableReference
-	cteCache           map[int][]*base.VirtualTableReference
-	cteTables          []*base.VirtualTableReference
-	caretTokenIsQuoted bool
-}
+	ctx              context.Context
+	scene            base.SceneType
+	sql              string
+	cursorByteOffset int
+	tokens           []oracleparser.Token
+	caretTokenIndex  int
 
-func NewTrickyCompleter(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) *Completer {
-	parser, lexer, scanner := prepareTrickyParserAndScanner(statement, caretLine, caretOffset)
-	core := base.NewCodeCompletionCore(
-		ctx,
-		parser,
-		newIgnoredTokens(),
-		newPreferredRules(),
-		&globalFollowSetsByState,
-		plsql.PlSqlParserRULE_select_statement,
-		plsql.PlSqlParserRULE_query_block,
-		plsql.PlSqlParserRULE_column_alias,
-		plsql.PlSqlParserRULE_subquery_factoring_clause,
-	)
-	return &Completer{
-		ctx:                 ctx,
-		core:                core,
-		scene:               cCtx.Scene,
-		parser:              parser,
-		lexer:               lexer,
-		scanner:             scanner,
-		instanceID:          cCtx.InstanceID,
-		getMetadata:         cCtx.Metadata,
-		listDatabaseNames:   cCtx.ListDatabaseNames,
-		defaultDatabase:     cCtx.DefaultDatabase,
-		metadataCache:       make(map[string]*model.DatabaseMetadata),
-		noSeparatorRequired: newNoSeparatorRequired(),
-		cteCache:            make(map[int][]*base.VirtualTableReference),
-	}
+	instanceID        string
+	getMetadata       base.GetDatabaseMetadataFunc
+	listDatabaseNames base.ListDatabaseNamesFunc
+	defaultDatabase   string
+	metadataCache     map[string]*model.DatabaseMetadata
+
+	references         []base.TableReference
+	cteTables          []*base.VirtualTableReference
+	scopeReferences    []oracleparser.RangeReference
+	caretTokenIsQuoted bool
+	completionPrefix   string
+	completionIntent   *oracleparser.CompletionIntent
 }
 
 func NewStandardCompleter(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) *Completer {
-	parser, lexer, scanner := prepareParserAndScanner(statement, caretLine, caretOffset)
-	core := base.NewCodeCompletionCore(
-		ctx,
-		parser,
-		newIgnoredTokens(),
-		newPreferredRules(),
-		&globalFollowSetsByState,
-		plsql.PlSqlParserRULE_select_statement,
-		plsql.PlSqlParserRULE_query_block,
-		plsql.PlSqlParserRULE_column_alias,
-		plsql.PlSqlParserRULE_subquery_factoring_clause,
-	)
+	sql, byteOffset := computeSQLAndByteOffset(statement, caretLine, caretOffset, false /* tricky */)
+	return newCompleter(ctx, cCtx, sql, byteOffset)
+}
+
+func NewTrickyCompleter(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) *Completer {
+	sql, byteOffset := computeSQLAndByteOffset(statement, caretLine, caretOffset, true /* tricky */)
+	return newCompleter(ctx, cCtx, sql, byteOffset)
+}
+
+func newCompleter(ctx context.Context, cCtx base.CompletionContext, sql string, byteOffset int) *Completer {
+	tokens := oracleparser.Tokenize(sql)
 	return &Completer{
-		ctx:                 ctx,
-		core:                core,
-		scene:               cCtx.Scene,
-		parser:              parser,
-		lexer:               lexer,
-		scanner:             scanner,
-		instanceID:          cCtx.InstanceID,
-		getMetadata:         cCtx.Metadata,
-		listDatabaseNames:   cCtx.ListDatabaseNames,
-		defaultDatabase:     cCtx.DefaultDatabase,
-		metadataCache:       make(map[string]*model.DatabaseMetadata),
-		noSeparatorRequired: newNoSeparatorRequired(),
-		cteCache:            make(map[int][]*base.VirtualTableReference),
+		ctx:               ctx,
+		scene:             cCtx.Scene,
+		sql:               sql,
+		cursorByteOffset:  byteOffset,
+		tokens:            tokens,
+		caretTokenIndex:   findCaretTokenIndex(tokens, byteOffset),
+		instanceID:        cCtx.InstanceID,
+		getMetadata:       cCtx.Metadata,
+		listDatabaseNames: cCtx.ListDatabaseNames,
+		defaultDatabase:   cCtx.DefaultDatabase,
+		metadataCache:     make(map[string]*model.DatabaseMetadata),
 	}
 }
 
+func computeSQLAndByteOffset(statement string, caretLine int, caretOffset int, tricky bool) (string, int) {
+	sql, newLine, newOffset := skipHeadingSQLs(statement, caretLine, caretOffset)
+	if tricky {
+		sql, newLine, newOffset = skipHeadingSQLWithoutSemicolon(sql, newLine, newOffset)
+	}
+	return sql, lineColumnToByteOffset(sql, newLine, newOffset)
+}
+
+func lineColumnToByteOffset(sql string, line, column int) int {
+	currentLine := 1
+	for i := 0; i < len(sql); i++ {
+		if currentLine == line {
+			pos := i
+			for c := 0; c < column && pos < len(sql); c++ {
+				_, size := utf8.DecodeRuneInString(sql[pos:])
+				pos += size
+			}
+			if pos > len(sql) {
+				return len(sql)
+			}
+			return pos
+		}
+		if sql[i] == '\n' {
+			currentLine++
+		}
+	}
+	return len(sql)
+}
+
+func findCaretTokenIndex(tokens []oracleparser.Token, byteOffset int) int {
+	for i, tok := range tokens {
+		if tok.Loc >= byteOffset {
+			return i
+		}
+	}
+	return len(tokens)
+}
+
 func (c *Completer) completion() ([]base.Candidate, error) {
-	// Check the caret token is quoted or not.
-	// This check should be done before checking the caret token is a separator or not.
-	if c.scanner.IsTokenType(plsql.PlSqlLexerDELIMITED_ID) {
+	checkTokenQuoted := func(idx int) bool {
+		if idx < 0 || idx >= len(c.tokens) {
+			return false
+		}
+		tok := c.tokens[idx]
+		return tok.Loc < len(c.sql) && c.sql[tok.Loc] == '"'
+	}
+	if checkTokenQuoted(c.caretTokenIndex) {
 		c.caretTokenIsQuoted = true
-	}
-
-	caretIndex := c.scanner.GetIndex()
-	if caretIndex > 0 && !c.noSeparatorRequired[c.scanner.GetPreviousTokenType(false /* skipHidden */)] {
-		caretIndex--
-	}
-	c.referencesStack = append([][]base.TableReference{{}}, c.referencesStack...)
-	c.parser.Reset()
-	var context antlr.ParserRuleContext
-	if c.scene == base.SceneTypeQuery {
-		context = c.parser.Select_statement()
-	} else {
-		context = c.parser.Sql_script()
-	}
-
-	candidates := c.core.CollectCandidates(caretIndex, context)
-
-	for ruleName := range candidates.Rules {
-		if ruleName == plsql.PlSqlParserRULE_general_element {
-			c.collectLeadingTableReferences(caretIndex)
-			c.takeReferencesSnapshot()
-			c.collectRemainingTableReferences()
-			c.takeReferencesSnapshot()
+	} else if c.caretTokenIndex > 0 {
+		prev := c.tokens[c.caretTokenIndex-1]
+		if prev.End >= c.cursorByteOffset && checkTokenQuoted(c.caretTokenIndex-1) {
+			c.caretTokenIsQuoted = true
 		}
 	}
 
+	completionContext := oracleparser.CollectCompletion(c.sql, c.cursorByteOffset)
+	if completionContext != nil {
+		c.completionPrefix = completionContext.Prefix
+		c.completionIntent = completionContext.Intent
+		c.collectCompletionCTEs(completionContext)
+		c.collectCompletionScopeReferences(completionContext)
+	}
+	candidates := (*oracleparser.CandidateSet)(nil)
+	if completionContext != nil {
+		candidates = completionContext.Candidates
+	}
+	if candidates == nil {
+		candidates = oracleparser.Collect(c.sql, c.cursorByteOffset)
+	}
 	return c.convertCandidates(candidates)
 }
 
 type CompletionMap map[string]base.Candidate
+
+func (m CompletionMap) Insert(entry base.Candidate) {
+	m[entry.String()] = entry
+}
 
 func (m CompletionMap) toSlice() []base.Candidate {
 	var result []base.Candidate
 	for _, candidate := range m {
 		result = append(result, candidate)
 	}
-	slices.SortFunc(result, func(i, j base.Candidate) int {
-		if i.Type != j.Type {
-			if i.Type < j.Type {
-				return -1
-			}
-			return 1
-		}
-		if i.Text < j.Text {
-			return -1
-		}
-		if i.Text > j.Text {
-			return 1
-		}
-		return 0
-	})
+	slices.SortFunc(result, compareCandidates)
 	return result
 }
 
-func (m CompletionMap) Insert(entry base.Candidate) {
-	m[entry.String()] = entry
+func compareCandidates(i, j base.Candidate) int {
+	if i.Type != j.Type {
+		if i.Type < j.Type {
+			return -1
+		}
+		return 1
+	}
+	if i.Text < j.Text {
+		return -1
+	}
+	if i.Text > j.Text {
+		return 1
+	}
+	if i.Definition < j.Definition {
+		return -1
+	}
+	if i.Definition > j.Definition {
+		return 1
+	}
+	return 0
 }
 
 func (m CompletionMap) insertDatabases(c *Completer) {
 	for _, name := range c.listAllDatabases() {
 		m.Insert(base.Candidate{
-			Type: base.CandidateTypeSchema, // For oracle, schema is the same as database modified by bytebase.
-			Text: name,
+			Type: base.CandidateTypeSchema,
+			Text: c.quotedIdentifierIfNeeded(name),
 		})
 	}
 }
@@ -337,8 +224,7 @@ func (m CompletionMap) insertSequences(c *Completer, schemas map[string]bool) {
 
 func (m CompletionMap) insertTables(c *Completer, schemas map[string]bool) {
 	for schema := range schemas {
-		if len(schema) == 0 {
-			// User didn't specify the schema, so we need to append cte tables.
+		if schema == "" {
 			for _, table := range c.cteTables {
 				m.Insert(base.Candidate{
 					Type: base.CandidateTypeTable,
@@ -358,30 +244,20 @@ func (m CompletionMap) insertTables(c *Completer, schemas map[string]bool) {
 
 func (m CompletionMap) insertAllColumns(c *Completer) {
 	for _, schema := range c.listAllDatabases() {
-		if _, exists := c.metadataCache[schema]; !exists {
-			_, metadata, err := c.getMetadata(c.ctx, c.instanceID, schema)
-			if err != nil || metadata == nil {
-				continue
-			}
-			c.metadataCache[schema] = metadata
+		if !c.ensureMetadata(schema) {
+			continue
 		}
 		schemaMeta := c.metadataCache[schema].GetSchemaMetadata("")
+		if schemaMeta == nil {
+			continue
+		}
 		for _, table := range schemaMeta.ListTableNames() {
 			tableMeta := schemaMeta.GetTable(table)
 			if tableMeta == nil {
 				continue
 			}
 			for _, column := range tableMeta.GetProto().GetColumns() {
-				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
-				if !column.Nullable {
-					definition += ", NOT NULL"
-				}
-				m.Insert(base.Candidate{
-					Type:       base.CandidateTypeColumn,
-					Text:       c.quotedIdentifierIfNeeded(column.Name),
-					Definition: definition,
-					Comment:    column.Comment,
-				})
+				m.Insert(c.columnCandidate(schema, table, column.Name, column.Type, !column.Nullable, column.Comment))
 			}
 		}
 	}
@@ -389,53 +265,757 @@ func (m CompletionMap) insertAllColumns(c *Completer) {
 
 func (m CompletionMap) insertColumns(c *Completer, schemas, tables map[string]bool) {
 	for schema := range schemas {
-		if len(schema) == 0 {
-			// User didn't specify the schema, so we need to append cte tables.
+		if schema == "" {
 			for _, table := range c.cteTables {
-				if tables[table.Table] {
-					for _, column := range table.Columns {
-						m.Insert(base.Candidate{
+				if !tables[table.Table] {
+					continue
+				}
+				for _, column := range table.Columns {
+					m.Insert(base.Candidate{
+						Type: base.CandidateTypeColumn,
+						Text: c.quotedIdentifierIfNeeded(column),
+					})
+				}
+			}
+			continue
+		}
+		if !c.ensureMetadata(schema) {
+			continue
+		}
+		schemaMeta := c.metadataCache[schema].GetSchemaMetadata("")
+		if schemaMeta == nil {
+			continue
+		}
+		for table := range tables {
+			tableMeta := schemaMeta.GetTable(table)
+			if tableMeta == nil {
+				continue
+			}
+			for _, column := range tableMeta.GetProto().GetColumns() {
+				m.Insert(c.columnCandidate(schema, table, column.Name, column.Type, !column.Nullable, column.Comment))
+			}
+		}
+	}
+}
+
+func (c *Completer) columnCandidate(schema, table, name, typ string, notNull bool, comment string) base.Candidate {
+	definition := fmt.Sprintf("%s.%s | %s", schema, table, typ)
+	if notNull {
+		definition += ", NOT NULL"
+	}
+	return base.Candidate{
+		Type:       base.CandidateTypeColumn,
+		Text:       c.quotedIdentifierIfNeeded(name),
+		Definition: definition,
+		Comment:    comment,
+	}
+}
+
+func (c *Completer) convertCandidates(candidates *oracleparser.CandidateSet) ([]base.Candidate, error) {
+	keywordEntries := make(CompletionMap)
+	functionEntries := make(CompletionMap)
+	schemaEntries := make(CompletionMap)
+	tableEntries := make(CompletionMap)
+	columnEntries := make(CompletionMap)
+	viewEntries := make(CompletionMap)
+	sequenceEntries := make(CompletionMap)
+
+	if candidates != nil {
+		for _, tok := range candidates.Tokens {
+			if tok > 0 && tok < 256 {
+				continue
+			}
+			name := oracleparser.TokenName(tok)
+			if name == "" {
+				continue
+			}
+			keywordEntries.Insert(base.Candidate{
+				Type: base.CandidateTypeKeyword,
+				Text: name,
+			})
+		}
+
+		for _, rule := range candidates.Rules {
+			switch rule.Rule {
+			case "func_name":
+				for _, tok := range candidates.Tokens {
+					name := oracleparser.TokenName(tok)
+					if name == "" {
+						continue
+					}
+					functionEntries.Insert(base.Candidate{
+						Type: base.CandidateTypeFunction,
+						Text: name + "()",
+					})
+				}
+			case "schema_ref":
+				schemaEntries.insertDatabases(c)
+			case "table_ref":
+				c.insertTableContextCandidates(schemaEntries, tableEntries, viewEntries, sequenceEntries)
+			case "sequence_ref":
+				sequenceEntries.insertSequences(c, c.completionSchemas(""))
+			case "columnref":
+				c.insertColumnContextCandidates(schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries)
+			default:
+			}
+		}
+	}
+
+	c.insertCompletionIntentCandidates(keywordEntries, functionEntries, schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries)
+	if len(c.qualifierParts()) > 0 && len(columnEntries) == 0 {
+		c.insertColumnContextCandidates(schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries)
+	}
+
+	var result []base.Candidate
+	result = append(result, keywordEntries.toSlice()...)
+	result = append(result, functionEntries.toSlice()...)
+	result = append(result, schemaEntries.toSlice()...)
+	result = append(result, tableEntries.toSlice()...)
+	result = append(result, columnEntries.toSlice()...)
+	result = append(result, viewEntries.toSlice()...)
+	result = append(result, sequenceEntries.toSlice()...)
+	return c.filterCandidatesByPrefix(result), nil
+}
+
+func (c *Completer) insertCompletionIntentCandidates(keywordEntries, functionEntries, schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries CompletionMap) {
+	if c.completionIntent == nil {
+		return
+	}
+	for _, kind := range c.completionIntent.ObjectKinds {
+		switch kind {
+		case oracleparser.ObjectKindSchema:
+			schemaEntries.insertDatabases(c)
+		case oracleparser.ObjectKindTable, oracleparser.ObjectKindView:
+			c.insertTableContextCandidates(schemaEntries, tableEntries, viewEntries, sequenceEntries)
+		case oracleparser.ObjectKindSequence:
+			sequenceEntries.insertSequences(c, c.completionSchemas(""))
+		case oracleparser.ObjectKindColumn:
+			c.insertColumnContextCandidates(schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries)
+		case oracleparser.ObjectKindFunction:
+			for _, tok := range oracleparser.Collect(c.sql, c.cursorByteOffset).Tokens {
+				name := oracleparser.TokenName(tok)
+				if name == "" {
+					continue
+				}
+				functionEntries.Insert(base.Candidate{
+					Type: base.CandidateTypeFunction,
+					Text: name + "()",
+				})
+			}
+		case oracleparser.ObjectKindType:
+			for _, typ := range oracleDataTypes {
+				keywordEntries.Insert(base.Candidate{Type: base.CandidateTypeKeyword, Text: typ})
+			}
+		default:
+		}
+	}
+}
+
+func (c *Completer) insertTableContextCandidates(schemaEntries, tableEntries, viewEntries, sequenceEntries CompletionMap) {
+	parts := c.qualifierParts()
+	schema := ""
+	if len(parts) == 1 {
+		schema = parts[0]
+	}
+	if schema == "" {
+		schemaEntries.insertDatabases(c)
+	}
+	schemas := c.completionSchemas(schema)
+	tableEntries.insertTables(c, schemas)
+	viewEntries.insertViews(c, schemas)
+	sequenceEntries.insertSequences(c, schemas)
+}
+
+func (c *Completer) insertColumnContextCandidates(schemaEntries, tableEntries, columnEntries, viewEntries, sequenceEntries CompletionMap) {
+	schema, table := c.columnQualifier()
+	if table == "" && c.completionIntent != nil {
+		table = c.completionIntent.Qualifier.Object
+	}
+
+	schemas := make(map[string]bool)
+	if schema != "" {
+		schemas[schema] = true
+	} else {
+		for _, reference := range c.references {
+			if physical, ok := reference.(*base.PhysicalTableReference); ok && physical.Schema != "" {
+				schemas[physical.Schema] = true
+			}
+		}
+	}
+	if len(schemas) == 0 {
+		schemas[c.defaultDatabase] = true
+	}
+	schemas[""] = true
+
+	if table == "" {
+		schemaEntries.insertDatabases(c)
+		tableEntries.insertTables(c, schemas)
+		viewEntries.insertViews(c, schemas)
+		sequenceEntries.insertSequences(c, schemas)
+		for _, alias := range c.selectItemAliases() {
+			columnEntries.Insert(base.Candidate{
+				Type: base.CandidateTypeColumn,
+				Text: c.quotedIdentifierIfNeeded(alias),
+			})
+		}
+	}
+
+	tables := make(map[string]bool)
+	if table != "" {
+		tables[table] = true
+		for _, reference := range c.references {
+			switch reference := reference.(type) {
+			case *base.PhysicalTableReference:
+				if strings.EqualFold(reference.Alias, table) {
+					tables[reference.Table] = true
+					if reference.Schema != "" {
+						schemas[reference.Schema] = true
+					}
+				}
+			case *base.VirtualTableReference:
+				if strings.EqualFold(reference.Table, table) {
+					for _, column := range reference.Columns {
+						columnEntries.Insert(base.Candidate{
 							Type: base.CandidateTypeColumn,
 							Text: c.quotedIdentifierIfNeeded(column),
 						})
 					}
 				}
+			default:
 			}
+		}
+	} else if len(c.references) > 0 {
+		for _, reference := range c.references {
+			switch reference := reference.(type) {
+			case *base.PhysicalTableReference:
+				if reference.Schema != "" {
+					schemas[reference.Schema] = true
+				}
+				tables[reference.Table] = true
+			case *base.VirtualTableReference:
+				for _, column := range reference.Columns {
+					columnEntries.Insert(base.Candidate{
+						Type: base.CandidateTypeColumn,
+						Text: c.quotedIdentifierIfNeeded(column),
+					})
+				}
+			default:
+			}
+		}
+	} else {
+		columnEntries.insertAllColumns(c)
+	}
+	if table == "" {
+		c.insertReferenceAliasCandidates(tableEntries, schemas, tables)
+	}
+
+	if len(tables) > 0 {
+		columnEntries.insertColumns(c, schemas, tables)
+	}
+	if table != "" && len(columnEntries) == 0 {
+		c.insertAliasColumns(columnEntries, table)
+	}
+}
+
+func (c *Completer) completionSchemas(schema string) map[string]bool {
+	schemas := make(map[string]bool)
+	if schema != "" {
+		schemas[schema] = true
+		return schemas
+	}
+	if c.defaultDatabase != "" {
+		schemas[c.defaultDatabase] = true
+	}
+	schemas[""] = true
+	return schemas
+}
+
+func (c *Completer) collectCompletionCTEs(completionContext *oracleparser.CompletionContext) {
+	if completionContext == nil {
+		return
+	}
+	for _, reference := range completionContext.CTEs {
+		virtual := convertCompletionVirtualReference(reference)
+		if virtual == nil {
 			continue
 		}
-		if _, exists := c.metadataCache[schema]; !exists {
-			_, metadata, err := c.getMetadata(c.ctx, c.instanceID, schema)
-			if err != nil || metadata == nil {
-				continue
-			}
-			c.metadataCache[schema] = metadata
+		if len(virtual.Columns) == 0 {
+			virtual.Columns = c.inferCompletionVirtualColumns(reference)
 		}
+		c.appendVirtualReferenceIfMissing(virtual)
+	}
+}
 
-		for table := range tables {
-			tableMeta := c.metadataCache[schema].GetSchemaMetadata("").GetTable(table)
-			if tableMeta == nil {
-				continue
-			}
-			for _, column := range tableMeta.GetProto().GetColumns() {
-				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
-				if !column.Nullable {
-					definition += ", NOT NULL"
-				}
-				m.Insert(base.Candidate{
-					Type:       base.CandidateTypeColumn,
-					Text:       c.quotedIdentifierIfNeeded(column.Name),
-					Definition: definition,
-					Comment:    column.Comment,
-				})
-			}
+func (c *Completer) collectCompletionScopeReferences(completionContext *oracleparser.CompletionContext) {
+	if completionContext == nil || completionContext.Scope == nil {
+		return
+	}
+	appendReference := func(reference oracleparser.RangeReference) {
+		if converted := c.convertCompletionScopeReference(reference); converted != nil {
+			c.appendReferenceIfMissing(converted)
+			c.appendScopeReferenceIfMissing(reference)
 		}
 	}
+	for _, reference := range completionContext.Scope.LocalReferences {
+		appendReference(reference)
+	}
+	for _, level := range completionContext.Scope.OuterReferences {
+		for _, reference := range level {
+			appendReference(reference)
+		}
+	}
+}
+
+func (c *Completer) convertCompletionScopeReference(reference oracleparser.RangeReference) base.TableReference {
+	switch reference.Kind {
+	case oracleparser.RangeReferenceRelation, oracleparser.RangeReferenceDMLTarget, oracleparser.RangeReferenceMergeSource:
+		return &base.PhysicalTableReference{
+			Schema: reference.Schema,
+			Table:  reference.Name,
+			Alias:  reference.Alias,
+		}
+	case oracleparser.RangeReferenceCTE, oracleparser.RangeReferenceSubquery, oracleparser.RangeReferenceJoinAlias:
+		virtual := convertCompletionVirtualReference(reference)
+		if virtual != nil && reference.Kind == oracleparser.RangeReferenceSubquery {
+			if columns := c.inferCompletionVirtualColumns(reference); len(columns) > 0 {
+				virtual.Columns = columns
+			}
+		}
+		if virtual != nil && len(virtual.Columns) == 0 {
+			if columns := c.inferCompletionVirtualColumns(reference); len(columns) > 0 {
+				virtual.Columns = columns
+			}
+		}
+		return virtual
+	default:
+		return nil
+	}
+}
+
+func (c *Completer) insertAliasColumns(entries CompletionMap, alias string) {
+	for _, reference := range c.scopeReferences {
+		if !strings.EqualFold(reference.Alias, alias) && !strings.EqualFold(reference.Name, alias) {
+			continue
+		}
+		columns := append([]string{}, reference.Columns...)
+		if len(columns) == 0 {
+			columns = c.inferCompletionVirtualColumns(reference)
+		}
+		for _, column := range columns {
+			entries.Insert(base.Candidate{
+				Type: base.CandidateTypeColumn,
+				Text: c.quotedIdentifierIfNeeded(column),
+			})
+		}
+		return
+	}
+}
+
+func (c *Completer) insertReferenceAliasCandidates(tableEntries CompletionMap, schemas, tables map[string]bool) {
+	for _, reference := range c.references {
+		switch reference := reference.(type) {
+		case *base.PhysicalTableReference:
+			if reference.Alias == "" || strings.EqualFold(reference.Alias, reference.Table) {
+				continue
+			}
+			tableEntries.Insert(base.Candidate{
+				Type: base.CandidateTypeTable,
+				Text: c.quotedIdentifierIfNeeded(reference.Alias),
+			})
+		case *base.VirtualTableReference:
+			tableEntries.Insert(base.Candidate{
+				Type: base.CandidateTypeTable,
+				Text: c.quotedIdentifierIfNeeded(reference.Table),
+			})
+		default:
+		}
+	}
+	for _, reference := range c.scopeReferences {
+		if reference.Kind != oracleparser.RangeReferenceSubquery {
+			continue
+		}
+		for source := range c.querySpanSourceTables(reference) {
+			schemas[source.schema] = true
+			tables[source.table] = true
+		}
+	}
+}
+
+type completionSourceTable struct {
+	schema string
+	table  string
+}
+
+func (c *Completer) querySpanSourceTables(reference oracleparser.RangeReference) map[completionSourceTable]bool {
+	if reference.BodyLoc.Start < 0 || reference.BodyLoc.End <= reference.BodyLoc.Start || reference.BodyLoc.End > len(c.sql) {
+		return nil
+	}
+	alias := reference.Alias
+	if alias == "" {
+		alias = "x"
+	}
+	span, err := c.querySpan(fmt.Sprintf("SELECT * FROM (%s) %s", c.sql[reference.BodyLoc.Start:reference.BodyLoc.End], quoteIdentifierForSQL(alias)))
+	if err != nil || span == nil || span.NotFoundError != nil {
+		return nil
+	}
+	tables := make(map[completionSourceTable]bool)
+	for column := range span.SourceColumns {
+		schema := column.Database
+		if schema == "" {
+			schema = c.defaultDatabase
+		}
+		if schema != "" && column.Table != "" {
+			tables[completionSourceTable{schema: schema, table: column.Table}] = true
+		}
+	}
+	return tables
+}
+
+func (c *Completer) querySpan(statement string) (*base.QuerySpan, error) {
+	return GetQuerySpan(
+		c.ctx,
+		base.GetQuerySpanContext{
+			InstanceID:              c.instanceID,
+			GetDatabaseMetadataFunc: c.getMetadata,
+			ListDatabaseNamesFunc:   c.listDatabaseNames,
+		},
+		base.Statement{Text: statement},
+		c.defaultDatabase,
+		"",
+		false,
+	)
+}
+
+func convertCompletionVirtualReference(reference oracleparser.RangeReference) *base.VirtualTableReference {
+	table := reference.Alias
+	if table == "" {
+		table = reference.Name
+	}
+	if table == "" {
+		return nil
+	}
+	columns := append([]string{}, reference.Columns...)
+	return &base.VirtualTableReference{
+		Table:   table,
+		Columns: columns,
+	}
+}
+
+func (c *Completer) inferCompletionVirtualColumns(reference oracleparser.RangeReference) []string {
+	if reference.BodyLoc.Start < 0 || reference.BodyLoc.End <= reference.BodyLoc.Start || reference.BodyLoc.End > len(c.sql) {
+		return nil
+	}
+	body := c.sql[reference.BodyLoc.Start:reference.BodyLoc.End]
+	statement := body
+	if reference.Kind == oracleparser.RangeReferenceSubquery {
+		alias := reference.Alias
+		if alias == "" {
+			alias = "x"
+		}
+		statement = fmt.Sprintf("SELECT * FROM (%s) %s", body, quoteIdentifierForSQL(alias))
+		if withPrefix := c.withClausePrefix(); withPrefix != "" {
+			statement = fmt.Sprintf("%s SELECT * FROM (%s) %s", withPrefix, body, quoteIdentifierForSQL(alias))
+		}
+	}
+	span, err := GetQuerySpan(
+		c.ctx,
+		base.GetQuerySpanContext{
+			InstanceID:              c.instanceID,
+			GetDatabaseMetadataFunc: c.getMetadata,
+			ListDatabaseNamesFunc:   c.listDatabaseNames,
+		},
+		base.Statement{Text: statement},
+		c.defaultDatabase,
+		"",
+		false,
+	)
+	if err != nil || span.NotFoundError != nil {
+		return nil
+	}
+	columns := make([]string, 0, len(span.Results))
+	for _, column := range span.Results {
+		columns = append(columns, column.Name)
+	}
+	return columns
+}
+
+func (c *Completer) withClausePrefix() string {
+	first := -1
+	for i, token := range c.tokens {
+		if token.Type != ';' {
+			first = i
+			break
+		}
+	}
+	if first < 0 || c.tokens[first].Type != oracleparser.WITH {
+		return ""
+	}
+	depth := 0
+	for i := first + 1; i < len(c.tokens); i++ {
+		switch c.tokens[i].Type {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case oracleparser.SELECT:
+			if depth == 0 {
+				return strings.TrimSpace(c.sql[:c.tokens[i].Loc])
+			}
+		default:
+		}
+	}
+	return ""
+}
+
+func quoteIdentifierForSQL(identifier string) string {
+	if identifierNeedsQuoting(identifier) {
+		return fmt.Sprintf(`"%s"`, strings.ReplaceAll(identifier, `"`, `""`))
+	}
+	return identifier
+}
+
+func (c *Completer) appendVirtualReferenceIfMissing(reference *base.VirtualTableReference) {
+	for _, existing := range c.cteTables {
+		if strings.EqualFold(existing.Table, reference.Table) {
+			if len(existing.Columns) == 0 && len(reference.Columns) > 0 {
+				existing.Columns = reference.Columns
+			}
+			return
+		}
+	}
+	c.cteTables = append(c.cteTables, reference)
+}
+
+func (c *Completer) appendReferenceIfMissing(reference base.TableReference) {
+	key := tableReferenceKey(reference)
+	for _, existing := range c.references {
+		if tableReferenceKey(existing) == key {
+			return
+		}
+	}
+	c.references = append(c.references, reference)
+}
+
+func (c *Completer) appendScopeReferenceIfMissing(reference oracleparser.RangeReference) {
+	key := completionScopeReferenceKey(reference)
+	for _, existing := range c.scopeReferences {
+		if completionScopeReferenceKey(existing) == key {
+			return
+		}
+	}
+	c.scopeReferences = append(c.scopeReferences, reference)
+}
+
+func tableReferenceKey(reference base.TableReference) string {
+	switch reference := reference.(type) {
+	case *base.PhysicalTableReference:
+		return strings.Join([]string{"physical", reference.Schema, reference.Table, reference.Alias}, "\x00")
+	case *base.VirtualTableReference:
+		return strings.Join([]string{"virtual", reference.Table}, "\x00")
+	default:
+		return fmt.Sprintf("%T", reference)
+	}
+}
+
+func completionScopeReferenceKey(reference oracleparser.RangeReference) string {
+	return strings.Join([]string{
+		fmt.Sprint(reference.Kind),
+		reference.Schema,
+		reference.Name,
+		reference.Alias,
+		fmt.Sprint(reference.Loc.Start),
+		fmt.Sprint(reference.Loc.End),
+	}, "\x00")
+}
+
+func (c *Completer) qualifierParts() []string {
+	collectOffset := c.cursorByteOffset - len(c.completionPrefix)
+	if collectOffset > len(c.sql) {
+		collectOffset = len(c.sql)
+	}
+	before := strings.TrimRight(c.sql[:collectOffset], " \t\r\n")
+	if !strings.HasSuffix(before, ".") {
+		return nil
+	}
+	before = strings.TrimSuffix(before, ".")
+	var parts []string
+	for {
+		before = strings.TrimRight(before, " \t\r\n")
+		part, start := lastIdentifierSpan(before)
+		if part == "" {
+			break
+		}
+		parts = append([]string{unquote(part)}, parts...)
+		before = strings.TrimRight(before[:start], " \t\r\n")
+		if !strings.HasSuffix(before, ".") {
+			break
+		}
+		before = strings.TrimSuffix(before, ".")
+	}
+	return parts
+}
+
+func lastIdentifierSpan(s string) (string, int) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", 0
+	}
+	if s[len(s)-1] == '"' {
+		for i := len(s) - 2; i >= 0; i-- {
+			if s[i] == '"' {
+				return s[i:], i
+			}
+		}
+		return "", 0
+	}
+	end := len(s)
+	start := end
+	for start > 0 {
+		r, size := utf8.DecodeLastRuneInString(s[:start])
+		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '$' && r != '#' {
+			break
+		}
+		start -= size
+	}
+	return s[start:end], start
+}
+
+func (c *Completer) columnQualifier() (schema, table string) {
+	parts := c.qualifierParts()
+	switch len(parts) {
+	case 0:
+		return "", ""
+	case 1:
+		return "", parts[0]
+	default:
+		return parts[len(parts)-2], parts[len(parts)-1]
+	}
+}
+
+func isIdentifierLike(tok oracleparser.Token) bool {
+	return tok.Str != "" && oracleparser.TokenName(tok.Type) == ""
+}
+
+func (c *Completer) selectItemAliases() []string {
+	if !c.isInAliasAllowedContext() {
+		return nil
+	}
+	stmtStart, stmtEnd := c.statementTokenBounds()
+	selectIdx := -1
+	fromIdx := -1
+	for i := stmtStart; i < stmtEnd; i++ {
+		switch c.tokens[i].Type {
+		case oracleparser.SELECT:
+			selectIdx = i
+		case oracleparser.FROM:
+			if selectIdx >= 0 && fromIdx < 0 {
+				fromIdx = i
+			}
+		default:
+		}
+	}
+	if selectIdx < 0 || fromIdx < 0 {
+		return nil
+	}
+	aliasMap := make(map[string]bool)
+	start := selectIdx + 1
+	depth := 0
+	for i := start; i <= fromIdx; i++ {
+		if i == fromIdx || (depth == 0 && c.tokens[i].Type == ',') {
+			if alias := selectAliasFromTokens(c.tokens[start:i]); alias != "" {
+				aliasMap[alias] = true
+			}
+			start = i + 1
+			continue
+		}
+		switch c.tokens[i].Type {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+		}
+	}
+	aliases := make([]string, 0, len(aliasMap))
+	for alias := range aliasMap {
+		aliases = append(aliases, alias)
+	}
+	slices.Sort(aliases)
+	return aliases
+}
+
+func selectAliasFromTokens(tokens []oracleparser.Token) string {
+	for len(tokens) > 0 && tokens[0].Type == ',' {
+		tokens = tokens[1:]
+	}
+	for len(tokens) > 0 && tokens[len(tokens)-1].Type == ',' {
+		tokens = tokens[:len(tokens)-1]
+	}
+	if len(tokens) < 2 {
+		return ""
+	}
+	last := tokens[len(tokens)-1]
+	if !isIdentifierLike(last) {
+		return ""
+	}
+	prev := tokens[len(tokens)-2]
+	if prev.Type == oracleparser.AS {
+		return last.Str
+	}
+	if prev.Type != '.' {
+		return last.Str
+	}
+	return ""
+}
+
+func (c *Completer) isInAliasAllowedContext() bool {
+	stmtStart, _ := c.statementTokenBounds()
+	for i := c.caretTokenIndex - 1; i >= stmtStart; i-- {
+		switch c.tokens[i].Type {
+		case oracleparser.ORDER, oracleparser.GROUP:
+			return true
+		case oracleparser.WHERE, oracleparser.FROM, oracleparser.SELECT:
+			return false
+		default:
+		}
+	}
+	return false
+}
+
+func (c *Completer) statementTokenBounds() (int, int) {
+	start := 0
+	for i, tok := range c.tokens {
+		if tok.Loc >= c.cursorByteOffset {
+			break
+		}
+		if tok.Type == ';' {
+			start = i + 1
+		}
+	}
+	end := len(c.tokens)
+	for i := start; i < len(c.tokens); i++ {
+		if c.tokens[i].Loc < c.cursorByteOffset {
+			continue
+		}
+		if c.tokens[i].Type == ';' {
+			end = i
+			break
+		}
+	}
+	return start, end
 }
 
 func (c *Completer) listAllDatabases() []string {
 	var result []string
 	if c.defaultDatabase != "" {
 		result = append(result, c.defaultDatabase)
+	}
+	if c.listDatabaseNames == nil {
+		return result
 	}
 	list, err := c.listDatabaseNames(c.ctx, c.instanceID)
 	if err != nil {
@@ -450,705 +1030,79 @@ func (c *Completer) listAllDatabases() []string {
 }
 
 func (c *Completer) listTables(schema string) []string {
-	if _, exists := c.metadataCache[schema]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, schema)
-		if err != nil || metadata == nil {
-			return nil
-		}
-		c.metadataCache[schema] = metadata
+	if !c.ensureMetadata(schema) {
+		return nil
 	}
-
-	return c.metadataCache[schema].GetSchemaMetadata("").ListTableNames()
+	schemaMeta := c.metadataCache[schema].GetSchemaMetadata("")
+	if schemaMeta == nil {
+		return nil
+	}
+	return schemaMeta.ListTableNames()
 }
 
 func (c *Completer) listViews(schema string) []string {
-	if _, exists := c.metadataCache[schema]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, schema)
-		if err != nil || metadata == nil {
-			return nil
-		}
-		c.metadataCache[schema] = metadata
+	if !c.ensureMetadata(schema) {
+		return nil
 	}
-
-	return c.metadataCache[schema].GetSchemaMetadata("").ListViewNames()
+	schemaMeta := c.metadataCache[schema].GetSchemaMetadata("")
+	if schemaMeta == nil {
+		return nil
+	}
+	return schemaMeta.ListViewNames()
 }
 
 func (c *Completer) listSequences(schema string) []string {
-	if _, exists := c.metadataCache[schema]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, schema)
-		if err != nil || metadata == nil {
-			return nil
-		}
-		c.metadataCache[schema] = metadata
-	}
-
-	return c.metadataCache[schema].GetSchemaMetadata("").ListSequenceNames()
-}
-
-func (c *Completer) convertCandidates(candidates *base.CandidatesCollection) ([]base.Candidate, error) {
-	keywordEntries := make(CompletionMap)
-	runtimeFunctionEntries := make(CompletionMap)
-	schemaEntries := make(CompletionMap)
-	tableEntries := make(CompletionMap)
-	columnEntries := make(CompletionMap)
-	viewEntries := make(CompletionMap)
-	sequenceEntries := make(CompletionMap)
-
-	for token, value := range candidates.Tokens {
-		entry := c.parser.SymbolicNames[token]
-		entry = unquote(entry)
-
-		list := 0
-		if len(value) > 0 {
-			// For function call:
-			if value[0] == plsql.PlSqlLexerLEFT_PAREN {
-				list = 1
-			} else {
-				for _, item := range value {
-					subEntry := c.parser.SymbolicNames[item]
-					subEntry = unquote(subEntry)
-					entry += " " + subEntry
-				}
-			}
-		}
-
-		switch list {
-		case 1:
-			runtimeFunctionEntries.Insert(base.Candidate{
-				Type: base.CandidateTypeFunction,
-				Text: strings.ToUpper(entry) + "()",
-			})
-		default:
-			keywordEntries.Insert(base.Candidate{
-				Type: base.CandidateTypeKeyword,
-				Text: strings.ToUpper(entry),
-			})
-		}
-	}
-
-	for candidate := range candidates.Rules {
-		c.scanner.PopAndRestore()
-		c.scanner.Push()
-
-		c.fetchCommonTableExpression(candidates.Rules[candidate])
-
-		switch candidate {
-		case plsql.PlSqlParserRULE_tableview_name:
-			schema, flags := c.determineTableViewName()
-
-			if flags&ObjectFlagsShowFirst != 0 {
-				schemaEntries.insertDatabases(c)
-			}
-
-			if flags&ObjectFlagsShowSecond != 0 {
-				schemas := make(map[string]bool)
-				if len(schema) == 0 {
-					schemas[c.defaultDatabase] = true
-					schemas[""] = true
-				} else {
-					schemas[schema] = true
-				}
-
-				tableEntries.insertTables(c, schemas)
-				viewEntries.insertViews(c, schemas)
-				sequenceEntries.insertSequences(c, schemas)
-			}
-		case plsql.PlSqlParserRULE_general_element:
-			schema, table, flags := c.determineGeneralElementPartCandidates()
-			if flags&ObjectFlagsShowSchemas != 0 {
-				schemaEntries.insertDatabases(c)
-			}
-
-			schemas := make(map[string]bool)
-			if len(schema) > 0 {
-				schemas[schema] = true
-			} else if len(c.references) > 0 {
-				for _, reference := range c.references {
-					if physicalTable, ok := reference.(*base.PhysicalTableReference); ok {
-						if len(physicalTable.Schema) > 0 {
-							schemas[physicalTable.Schema] = true
-						}
-					}
-				}
-			}
-
-			if len(schemas) == 0 {
-				schemas[c.defaultDatabase] = true
-				// User didn't specify the schema, so we need to append cte tables.
-				schemas[""] = true
-			}
-
-			if flags&ObjectFlagsShowTables != 0 {
-				tableEntries.insertTables(c, schemas)
-				viewEntries.insertViews(c, schemas)
-				sequenceEntries.insertSequences(c, schemas)
-
-				for _, reference := range c.references {
-					switch reference := reference.(type) {
-					case *base.PhysicalTableReference:
-						if (len(schema) == 0 && len(reference.Schema) == 0) || schemas[reference.Schema] {
-							if len(reference.Alias) == 0 {
-								tableEntries.Insert(base.Candidate{
-									Type: base.CandidateTypeTable,
-									Text: c.quotedIdentifierIfNeeded(reference.Table),
-								})
-							} else {
-								tableEntries.Insert(base.Candidate{
-									Type: base.CandidateTypeTable,
-									Text: c.quotedIdentifierIfNeeded(reference.Alias),
-								})
-							}
-						}
-					case *base.VirtualTableReference:
-						if len(schema) > 0 {
-							continue
-						}
-						tableEntries.Insert(base.Candidate{
-							Type: base.CandidateTypeTable,
-							Text: c.quotedIdentifierIfNeeded(reference.Table),
-						})
-					default:
-					}
-				}
-			}
-
-			if flags&ObjectFlagsShowColumns != 0 {
-				if schema == table { // Schema and table are equal if it's not clear if we see a schema or table qualifier.
-					schemas[c.defaultDatabase] = true
-					// User didn't specify the schema, so we need to append cte tables.
-					schemas[""] = true
-				}
-
-				tables := make(map[string]bool)
-				if len(table) != 0 {
-					tables[table] = true
-
-					for _, reference := range c.references {
-						switch reference := reference.(type) {
-						case *base.PhysicalTableReference:
-							// Could be an alias.
-							if strings.EqualFold(reference.Alias, table) {
-								tables[reference.Table] = true
-								schemas[reference.Schema] = true
-							}
-						case *base.VirtualTableReference:
-							// Could be a virtual table.
-							if strings.EqualFold(reference.Table, table) {
-								for _, column := range reference.Columns {
-									columnEntries.Insert(base.Candidate{
-										Type: base.CandidateTypeColumn,
-										Text: c.quotedIdentifierIfNeeded(column),
-									})
-								}
-							}
-						default:
-						}
-					}
-				} else if len(c.references) > 0 {
-					list := c.fetchSelectItemAliases(candidates.Rules[candidate])
-					for _, alias := range list {
-						columnEntries.Insert(base.Candidate{
-							Type: base.CandidateTypeColumn,
-							Text: c.quotedIdentifierIfNeeded(alias),
-						})
-					}
-					for _, reference := range c.references {
-						switch reference := reference.(type) {
-						case *base.PhysicalTableReference:
-							schemas[reference.Schema] = true
-							tables[reference.Table] = true
-						case *base.VirtualTableReference:
-							for _, column := range reference.Columns {
-								columnEntries.Insert(base.Candidate{
-									Type: base.CandidateTypeColumn,
-									Text: c.quotedIdentifierIfNeeded(column),
-								})
-							}
-						default:
-						}
-					}
-				} else {
-					// User didn't specify the table, so we return all columns from all tables.
-					columnEntries.insertAllColumns(c)
-				}
-
-				if len(tables) > 0 {
-					columnEntries.insertColumns(c, schemas, tables)
-				}
-			}
-		default:
-			// Handle other candidates
-		}
-	}
-
-	c.scanner.PopAndRestore()
-	var result []base.Candidate
-	result = append(result, keywordEntries.toSlice()...)
-	result = append(result, runtimeFunctionEntries.toSlice()...)
-	result = append(result, schemaEntries.toSlice()...)
-	result = append(result, tableEntries.toSlice()...)
-	result = append(result, columnEntries.toSlice()...)
-	result = append(result, viewEntries.toSlice()...)
-	result = append(result, sequenceEntries.toSlice()...)
-	return result, nil
-}
-
-func (c *Completer) fetchCommonTableExpression(ruleStack []*base.RuleContext) {
-	c.cteTables = nil
-	for _, rule := range ruleStack {
-		if rule.ID == plsql.PlSqlParserRULE_query_block {
-			for _, pos := range rule.CTEList {
-				c.cteTables = append(c.cteTables, c.extractCTETables(pos)...)
-			}
-		}
-	}
-}
-
-func (c *Completer) extractCTETables(pos int) []*base.VirtualTableReference {
-	if metadata, exists := c.cteCache[pos]; exists {
-		return metadata
-	}
-	followingText := c.scanner.GetFollowingTextAfter(pos)
-	if len(followingText) == 0 {
+	if !c.ensureMetadata(schema) {
 		return nil
 	}
-
-	input := antlr.NewInputStream(followingText)
-	lexer := plsql.NewPlSqlLexer(input)
-	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	parser := plsql.NewPlSqlParser(tokens)
-
-	parser.BuildParseTrees = true
-	parser.RemoveErrorListeners()
-	tree := parser.Subquery_factoring_clause()
-
-	listener := &CTETableListener{context: c}
-	antlr.ParseTreeWalkerDefault.Walk(listener, tree)
-
-	c.cteCache[pos] = listener.result
-	return listener.result
+	schemaMeta := c.metadataCache[schema].GetSchemaMetadata("")
+	if schemaMeta == nil {
+		return nil
+	}
+	return schemaMeta.ListSequenceNames()
 }
 
-type CTETableListener struct {
-	*plsql.BasePlSqlParserListener
-
-	context *Completer
-	result  []*base.VirtualTableReference
+func (c *Completer) ensureMetadata(schema string) bool {
+	if schema == "" || c.getMetadata == nil {
+		return false
+	}
+	if _, exists := c.metadataCache[schema]; exists {
+		return true
+	}
+	_, metadata, err := c.getMetadata(c.ctx, c.instanceID, schema)
+	if err != nil || metadata == nil {
+		return false
+	}
+	c.metadataCache[schema] = metadata
+	return true
 }
 
-func (l *CTETableListener) EnterFactoring_element(ctx *plsql.Factoring_elementContext) {
-	table := &base.VirtualTableReference{
-		Table: NormalizeIdentifierContext(ctx.Query_name().Identifier()),
+func (c *Completer) filterCandidatesByPrefix(candidates []base.Candidate) []base.Candidate {
+	if c.completionPrefix == "" {
+		return candidates
 	}
-	if ctx.Paren_column_list() != nil {
-		for _, column := range ctx.Paren_column_list().Column_list().AllColumn_name() {
-			_, _, columnName := NormalizeColumnName(column)
-			table.Columns = append(table.Columns, columnName)
-		}
-	} else {
-		// User didn't specify the column list, so we need to fetch the column list from the query.
-		if span, err := GetQuerySpan(
-			l.context.ctx,
-			base.GetQuerySpanContext{
-				InstanceID:              l.context.instanceID,
-				GetDatabaseMetadataFunc: l.context.getMetadata,
-				ListDatabaseNamesFunc:   l.context.listDatabaseNames,
-			},
-			base.Statement{Text: fmt.Sprintf("SELECT * FROM (%s)", ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx.Subquery()))},
-			l.context.defaultDatabase,
-			"",
-			false,
-		); err == nil && span.NotFoundError == nil {
-			for _, column := range span.Results {
-				table.Columns = append(table.Columns, column.Name)
-			}
+	prefix := strings.ToUpper(c.completionPrefix)
+	filtered := make([]base.Candidate, 0, len(candidates))
+	for _, candidate := range candidates {
+		text := strings.TrimSuffix(candidate.Text, "()")
+		text = unquote(text)
+		if strings.HasPrefix(strings.ToUpper(text), prefix) {
+			filtered = append(filtered, candidate)
 		}
 	}
-
-	l.result = append(l.result, table)
-}
-
-func (c *Completer) fetchSelectItemAliases(ruleStack []*base.RuleContext) []string {
-	canUseAliases := false
-	for i := len(ruleStack) - 1; i >= 0; i-- {
-		switch ruleStack[i].ID {
-		case plsql.PlSqlParserRULE_group_by_clause, plsql.PlSqlParserRULE_order_by_clause:
-			canUseAliases = true
-		case plsql.PlSqlParserRULE_query_block, plsql.PlSqlParserRULE_select_statement:
-			if !canUseAliases {
-				return nil
-			}
-			aliasMap := make(map[string]bool)
-			for pos := range ruleStack[i].SelectItemAliases {
-				if aliasText := c.extractAliasText(pos); len(aliasText) > 0 {
-					aliasMap[aliasText] = true
-				}
-			}
-
-			var result []string
-			for alias := range aliasMap {
-				result = append(result, alias)
-			}
-			slices.Sort(result)
-			return result
-		default:
-			// Other cases
-		}
-	}
-	return nil
-}
-
-func (c *Completer) extractAliasText(pos int) string {
-	followingText := c.scanner.GetFollowingTextAfter(pos)
-	if len(followingText) == 0 {
-		return ""
-	}
-
-	input := antlr.NewInputStream(followingText)
-	lexer := plsql.NewPlSqlLexer(input)
-	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	parser := plsql.NewPlSqlParser(tokens)
-
-	parser.BuildParseTrees = true
-	parser.RemoveErrorListeners()
-	lexer.RemoveErrorListeners()
-	tree := parser.Column_alias()
-
-	listener := &AliasListener{}
-	antlr.ParseTreeWalkerDefault.Walk(listener, tree)
-	return listener.result
-}
-
-type AliasListener struct {
-	*plsql.BasePlSqlParserListener
-
-	result string
-}
-
-func (l *AliasListener) EnterColumn_alias(ctx *plsql.Column_aliasContext) {
-	l.result = normalizeColumnAlias(ctx)
-}
-
-type ObjectFlags int
-
-const (
-	ObjectFlagsShowSchemas ObjectFlags = 1 << iota
-	ObjectFlagsShowTables
-	ObjectFlagsShowColumns
-	ObjectFlagsShowFirst
-	ObjectFlagsShowSecond
-)
-
-func (c *Completer) determineTableViewName() (string, ObjectFlags) {
-	position := c.scanner.GetIndex()
-	if c.scanner.GetTokenChannel() != 0 {
-		c.scanner.Forward(true /* skipHidden */) // Skip whitespace.
-	}
-
-	if !c.scanner.IsTokenType(plsql.PlSqlLexerPERIOD) && !c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		c.scanner.Backward(true /* skipHidden */)
-	}
-
-	if position > 0 {
-		if c.lexer.IsIdentifier(c.scanner.GetTokenType()) && c.scanner.GetPreviousTokenType(false /* skipHidden */) == plsql.PlSqlLexerPERIOD {
-			c.scanner.Backward(true /* skipHidden */)
-		}
-		if c.scanner.IsTokenType(plsql.PlSqlLexerPERIOD) && c.lexer.IsIdentifier(c.scanner.GetPreviousTokenType(false /* skipHidden */)) {
-			c.scanner.Backward(true /* skipHidden */)
-		}
-	}
-
-	schema := ""
-	temp := ""
-	if c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		temp = unquote(c.scanner.GetTokenText())
-		c.scanner.Forward(true /* skipHidden */)
-	}
-
-	if !c.scanner.IsTokenType(plsql.PlSqlLexerPERIOD) || position <= c.scanner.GetIndex() {
-		return schema, ObjectFlagsShowFirst | ObjectFlagsShowSecond
-	}
-
-	schema = temp
-	return schema, ObjectFlagsShowSecond
-}
-
-func (c *Completer) determineGeneralElementPartCandidates() (schema, table string, flags ObjectFlags) {
-	position := c.scanner.GetIndex()
-	if c.scanner.GetTokenChannel() != 0 {
-		c.scanner.Forward(true /* skipHidden */) // Skip whitespace.
-	}
-
-	tokenType := c.scanner.GetTokenType()
-	if tokenType != plsql.PlSqlLexerPERIOD && !c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		c.scanner.Backward(true /* skipHidden */)
-	}
-
-	if position > 0 {
-		if c.lexer.IsIdentifier(c.scanner.GetTokenType()) && c.scanner.GetPreviousTokenType(false /* skipHidden */) == plsql.PlSqlLexerPERIOD {
-			c.scanner.Backward(true /* skipHidden */)
-		}
-		if c.scanner.IsTokenType(plsql.PlSqlLexerPERIOD) && c.lexer.IsIdentifier(c.scanner.GetPreviousTokenType(false /* skipHidden */)) {
-			c.scanner.Backward(true /* skipHidden */)
-
-			if c.scanner.GetPreviousTokenType(false /* skipHidden */) == plsql.PlSqlLexerPERIOD {
-				c.scanner.Backward(true /* skipHidden */)
-				if c.lexer.IsIdentifier(c.scanner.GetPreviousTokenType(false /* skipHidden */)) {
-					c.scanner.Backward(true /* skipHidden */)
-				}
-			}
-		}
-	}
-
-	schema = ""
-	table = ""
-	temp := ""
-	if c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		temp = unquote(c.scanner.GetTokenText())
-		c.scanner.Forward(true /* skipHidden */)
-	}
-
-	if !c.scanner.IsTokenType(plsql.PlSqlLexerPERIOD) || position <= c.scanner.GetIndex() {
-		return schema, table, ObjectFlagsShowSchemas | ObjectFlagsShowTables | ObjectFlagsShowColumns
-	}
-
-	c.scanner.Forward(true /* skipHidden */) // skip dot
-	table = temp
-	schema = temp
-	if c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		temp = unquote(c.scanner.GetTokenText())
-		c.scanner.Forward(true /* skipHidden */)
-
-		if !c.scanner.IsTokenType(plsql.PlSqlLexerPERIOD) || position <= c.scanner.GetIndex() {
-			return schema, table, ObjectFlagsShowTables | ObjectFlagsShowColumns
-		}
-
-		table = temp
-		return schema, table, ObjectFlagsShowColumns
-	}
-
-	return schema, table, ObjectFlagsShowTables | ObjectFlagsShowColumns
+	return filtered
 }
 
 func unquote(s string) string {
 	if len(s) < 2 {
 		return strings.ToUpper(s)
 	}
-
 	if (s[0] == '`' || s[0] == '\'' || s[0] == '"') && s[0] == s[len(s)-1] {
 		return s[1 : len(s)-1]
 	}
 	return strings.ToUpper(s)
 }
 
-func (c *Completer) collectRemainingTableReferences() {
-	c.scanner.Push()
-
-	level := 0
-	for {
-		found := c.scanner.GetTokenType() == plsql.PlSqlLexerFROM
-		for !found {
-			if !c.scanner.Forward(false /* skipHidden */) {
-				break
-			}
-
-			switch c.scanner.GetTokenType() {
-			case plsql.PlSqlLexerLEFT_PAREN:
-				level++
-			case plsql.PlSqlLexerRIGHT_PAREN:
-				if level > 0 {
-					level--
-				}
-			case plsql.PlSqlLexerFROM:
-				if level == 0 {
-					found = true
-				}
-			default:
-				// Other tokens, continue scanning
-			}
-		}
-
-		if !found {
-			c.scanner.PopAndRestore()
-			return
-		}
-
-		c.parseTableReferences(c.scanner.GetFollowingText())
-		if c.scanner.GetTokenType() == plsql.PlSqlLexerFROM {
-			c.scanner.Forward(false /* skipHidden */)
-		}
-	}
-}
-
-func (c *Completer) takeReferencesSnapshot() {
-	for _, references := range c.referencesStack {
-		c.references = append(c.references, references...)
-	}
-}
-
-func (c *Completer) collectLeadingTableReferences(caretIndex int) {
-	c.scanner.Push()
-
-	c.scanner.SeekIndex(0)
-	level := 0
-	for {
-		found := c.scanner.GetTokenType() == plsql.PlSqlLexerFROM
-		for !found {
-			if !c.scanner.Forward(false /* skipHidden */) || c.scanner.GetIndex() >= caretIndex {
-				break
-			}
-
-			switch c.scanner.GetTokenType() {
-			case plsql.PlSqlLexerLEFT_PAREN:
-				level++
-				c.referencesStack = append([][]base.TableReference{{}}, c.referencesStack...)
-			case plsql.PlSqlLexerRIGHT_PAREN:
-				if level == 0 {
-					c.scanner.PopAndRestore()
-					return // We cannot go above the initial nesting level.
-				}
-
-				level--
-				c.referencesStack = c.referencesStack[1:]
-			case plsql.PlSqlLexerFROM:
-				found = true
-			default:
-				// Other tokens, continue scanning
-			}
-		}
-
-		if !found {
-			c.scanner.PopAndRestore()
-			return // No FROM clause found.
-		}
-
-		c.parseTableReferences(c.scanner.GetFollowingText())
-		if c.scanner.GetTokenType() == plsql.PlSqlLexerFROM {
-			c.scanner.Forward(false /* skipHidden */)
-		}
-	}
-}
-
-func (c *Completer) parseTableReferences(fromClause string) {
-	// We use a local parser just for the FROM clause to avoid messing up tokens on the autocompletion
-	// parser (which would affect the processing of the found candidates)
-
-	input := antlr.NewInputStream(fromClause)
-	lexer := plsql.NewPlSqlLexer(input)
-	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	parser := plsql.NewPlSqlParser(tokens)
-
-	parser.BuildParseTrees = true
-	parser.RemoveErrorListeners()
-	tree := parser.From_clause()
-
-	listener := &TableRefListener{
-		context: c,
-	}
-	antlr.ParseTreeWalkerDefault.Walk(listener, tree)
-}
-
-type TableRefListener struct {
-	*plsql.BasePlSqlParserListener
-
-	context *Completer
-	done    bool
-	level   int
-}
-
-func (l *TableRefListener) ExitDml_table_expression_clause(ctx *plsql.Dml_table_expression_clauseContext) {
-	if l.done {
-		return
-	}
-
-	if ctx.Tableview_name() != nil && l.level == 0 {
-		reference := &base.PhysicalTableReference{}
-		_, reference.Schema, reference.Table = NormalizeTableViewName("", ctx.Tableview_name())
-		l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-		return
-	}
-
-	if ctx.Select_statement() != nil && l.level == 0 {
-		reference := &base.VirtualTableReference{}
-
-		if span, err := GetQuerySpan(
-			l.context.ctx,
-			base.GetQuerySpanContext{
-				InstanceID:              l.context.instanceID,
-				GetDatabaseMetadataFunc: l.context.getMetadata,
-				ListDatabaseNamesFunc:   l.context.listDatabaseNames,
-			},
-			base.Statement{Text: ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx.Select_statement())},
-			l.context.defaultDatabase,
-			"",
-			false,
-		); err == nil && span.NotFoundError == nil {
-			for _, column := range span.Results {
-				reference.Columns = append(reference.Columns, column.Name)
-			}
-		}
-
-		l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-	}
-}
-
-func (l *TableRefListener) ExitTable_alias(ctx *plsql.Table_aliasContext) {
-	if l.done {
-		return
-	}
-
-	if l.level == 0 && len(l.context.referencesStack) > 0 && len(l.context.referencesStack[0]) > 0 {
-		alias := NormalizeTableAlias(ctx)
-		switch reference := l.context.referencesStack[0][len(l.context.referencesStack[0])-1].(type) {
-		case *base.PhysicalTableReference:
-			reference.Alias = alias
-		case *base.VirtualTableReference:
-			reference.Table = alias
-		default:
-		}
-	}
-}
-
-func prepareParserAndScanner(statement string, caretLine int, caretOffset int) (*plsql.PlSqlParser, *plsql.PlSqlLexer, *base.Scanner) {
-	statement, caretLine, caretOffset = skipHeadingSQLs(statement, caretLine, caretOffset)
-	input := antlr.NewInputStream(statement)
-	lexer := plsql.NewPlSqlLexer(input)
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	parser := plsql.NewPlSqlParser(stream)
-	parser.RemoveErrorListeners()
-	lexer.RemoveErrorListeners()
-	scanner := base.NewScanner(stream, true /* fillInput */)
-	scanner.SeekPosition(caretLine, caretOffset)
-	scanner.Push()
-	return parser, lexer, scanner
-}
-
-func prepareTrickyParserAndScanner(statement string, caretLine int, caretOffset int) (*plsql.PlSqlParser, *plsql.PlSqlLexer, *base.Scanner) {
-	statement, caretLine, caretOffset = skipHeadingSQLs(statement, caretLine, caretOffset)
-	statement, caretLine, caretOffset = skipHeadingSQLWithoutSemicolon(statement, caretLine, caretOffset)
-	input := antlr.NewInputStream(statement)
-	lexer := plsql.NewPlSqlLexer(input)
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	parser := plsql.NewPlSqlParser(stream)
-	parser.RemoveErrorListeners()
-	lexer.RemoveErrorListeners()
-	scanner := base.NewScanner(stream, true /* fillInput */)
-	scanner.SeekPosition(caretLine, caretOffset)
-	scanner.Push()
-	return parser, lexer, scanner
-}
-
-func notEmptySQLCount(list []base.Statement) int {
-	count := 0
-	for _, sql := range list {
-		if !sql.Empty {
-			count++
-		}
-	}
-	return count
-}
-
-// caretLine is 1-based and caretOffset is 0-based.
 func skipHeadingSQLs(statement string, caretLine int, caretOffset int) (string, int, int) {
 	newCaretLine, newCaretOffset := caretLine, caretOffset
 	list, err := SplitSQLForCompletion(statement)
@@ -1156,27 +1110,20 @@ func skipHeadingSQLs(statement string, caretLine int, caretOffset int) (string, 
 		return statement, caretLine, caretOffset
 	}
 
-	caretLine-- // Convert caretLine to 0-based.
-
+	caretLine--
 	start := 0
 	for i, sql := range list {
-		// End.Line is 1-based per proto spec, convert to 0-based for comparison with caretLine
 		sqlEndLine := int(sql.End.GetLine()) - 1
 		sqlEndColumn := int(sql.End.GetColumn())
 		if sqlEndLine > caretLine || (sqlEndLine == caretLine && sqlEndColumn >= caretOffset) {
 			start = i
 			if i == 0 {
-				// The caret is in the first SQL statement, so we don't need to skip any SQL statements.
 				break
 			}
-			// End.Line is 1-based per proto spec, convert to 0-based
 			previousSQLEndLine := int(list[i-1].End.GetLine()) - 1
 			previousSQLEndColumn := int(list[i-1].End.GetColumn())
-			newCaretLine = caretLine - previousSQLEndLine + 1 // Convert to 1-based.
+			newCaretLine = caretLine - previousSQLEndLine + 1
 			if caretLine == previousSQLEndLine {
-				// The caret is in the same line as the last line of the previous SQL statement.
-				// End.Column is 1-based exclusive, so (End.Column - 1) gives 0-based start of next statement.
-				// newCaretOffset = caretOffset - (previousSQLEndColumn - 1)
 				newCaretOffset = caretOffset - previousSQLEndColumn + 1
 			}
 			break
@@ -1189,60 +1136,95 @@ func skipHeadingSQLs(statement string, caretLine int, caretOffset int) (string, 
 			return statement, caretLine, caretOffset
 		}
 	}
-
 	return buf.String(), newCaretLine, newCaretOffset
 }
 
-// caretLine is 1-based and caretOffset is 0-based.
-func skipHeadingSQLWithoutSemicolon(statement string, caretLine int, caretOffset int) (string, int, int) {
-	input := antlr.NewInputStream(statement)
-	lexer := plsql.NewPlSqlLexer(input)
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	lexer.RemoveErrorListeners()
-	lexerErrorListener := &base.ParseErrorListener{
-		Statement: statement,
+func notEmptySQLCount(list []base.Statement) int {
+	count := 0
+	for _, sql := range list {
+		if !sql.Empty {
+			count++
+		}
 	}
-	lexer.AddErrorListener(lexerErrorListener)
+	return count
+}
 
-	stream.Fill()
-	tokens := stream.GetAllTokens()
-	latestSelect := 0
+func skipHeadingSQLWithoutSemicolon(statement string, caretLine int, caretOffset int) (string, int, int) {
+	tokens := oracleparser.Tokenize(statement)
+	caretByteOffset := lineColumnToByteOffset(statement, caretLine, caretOffset)
+
+	latestSelectOffset := -1
 	newCaretLine, newCaretOffset := caretLine, caretOffset
 	for _, token := range tokens {
-		if token.GetLine() > caretLine || (token.GetLine() == caretLine && token.GetColumn() >= caretOffset) {
+		line, column := lineColumnAtByteOffset(statement, token.Loc)
+		if line > caretLine || (line == caretLine && column >= caretOffset) {
 			break
 		}
-		if token.GetTokenType() == plsql.PlSqlLexerSELECT && token.GetColumn() == 0 {
-			latestSelect = token.GetTokenIndex()
-			newCaretLine = caretLine - token.GetLine() + 1 // Convert to 1-based.
+		if token.Type == oracleparser.SELECT && column == 0 {
+			latestSelectOffset = token.Loc
+			newCaretLine = caretLine - line + 1
 			newCaretOffset = caretOffset
 		}
 	}
 
-	if latestSelect == 0 {
+	if latestSelectOffset < 0 || latestSelectOffset >= caretByteOffset {
 		return statement, caretLine, caretOffset
 	}
-	return stream.GetTextFromInterval(antlr.Interval{Start: latestSelect, Stop: stream.Size()}), newCaretLine, newCaretOffset
+	return statement[latestSelectOffset:], newCaretLine, newCaretOffset
+}
+
+func lineColumnAtByteOffset(sql string, offset int) (int, int) {
+	line, column := 1, 0
+	for i := 0; i < len(sql) && i < offset; {
+		r, size := utf8.DecodeRuneInString(sql[i:])
+		if r == '\n' {
+			line++
+			column = 0
+		} else {
+			column++
+		}
+		i += size
+	}
+	return line, column
 }
 
 func (c *Completer) quotedIdentifierIfNeeded(s string) string {
-	if c.caretTokenIsQuoted {
+	if c.caretTokenIsQuoted || !identifierNeedsQuoting(s) {
 		return s
 	}
+	return fmt.Sprintf(`"%s"`, strings.ReplaceAll(s, `"`, `""`))
+}
 
-	if c.lexer.IsReservedKeywords(s) {
-		return fmt.Sprintf(`"%s"`, s)
+func identifierNeedsQuoting(s string) bool {
+	if s == "" {
+		return true
+	}
+	if oracleparser.IsReservedKeyword(s) {
+		return true
 	}
 	if s != strings.ToUpper(s) {
-		return fmt.Sprintf(`"%s"`, s)
+		return true
 	}
 	for i, r := range s {
 		if i == 0 && !unicode.IsLetter(r) {
-			return fmt.Sprintf(`"%s"`, s)
+			return true
 		}
-		if i > 0 && !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
-			return fmt.Sprintf(`"%s"`, s)
+		if i > 0 && !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' && r != '$' && r != '#' {
+			return true
 		}
 	}
-	return s
+	return false
+}
+
+var oracleDataTypes = []string{
+	"NUMBER",
+	"VARCHAR2",
+	"NVARCHAR2",
+	"CHAR",
+	"NCHAR",
+	"DATE",
+	"TIMESTAMP",
+	"CLOB",
+	"BLOB",
+	"RAW",
 }

--- a/backend/plugin/parser/plsql/completion.go
+++ b/backend/plugin/parser/plsql/completion.go
@@ -435,28 +435,11 @@ func (c *Completer) insertColumnContextCandidates(schemaEntries, tableEntries, c
 	schemas := make(map[string]bool)
 	if schema != "" {
 		schemas[schema] = true
-	} else {
+	} else if table == "" {
 		for _, reference := range c.references {
 			if physical, ok := reference.(*base.PhysicalTableReference); ok && physical.Schema != "" {
 				schemas[physical.Schema] = true
 			}
-		}
-	}
-	if len(schemas) == 0 {
-		schemas[c.defaultDatabase] = true
-	}
-	schemas[""] = true
-
-	if table == "" {
-		schemaEntries.insertDatabases(c)
-		tableEntries.insertTables(c, schemas)
-		viewEntries.insertViews(c, schemas)
-		sequenceEntries.insertSequences(c, schemas)
-		for _, alias := range c.selectItemAliases() {
-			columnEntries.Insert(base.Candidate{
-				Type: base.CandidateTypeColumn,
-				Text: c.quotedIdentifierIfNeeded(alias),
-			})
 		}
 	}
 
@@ -471,6 +454,8 @@ func (c *Completer) insertColumnContextCandidates(schemaEntries, tableEntries, c
 					if reference.Schema != "" {
 						schemas[reference.Schema] = true
 					}
+				} else if strings.EqualFold(reference.Table, table) && reference.Schema != "" {
+					schemas[reference.Schema] = true
 				}
 			case *base.VirtualTableReference:
 				if strings.EqualFold(reference.Table, table) {
@@ -504,6 +489,24 @@ func (c *Completer) insertColumnContextCandidates(schemaEntries, tableEntries, c
 		}
 	} else {
 		columnEntries.insertAllColumns(c)
+	}
+
+	if len(schemas) == 0 {
+		schemas[c.defaultDatabase] = true
+	}
+	schemas[""] = true
+
+	if table == "" {
+		schemaEntries.insertDatabases(c)
+		tableEntries.insertTables(c, schemas)
+		viewEntries.insertViews(c, schemas)
+		sequenceEntries.insertSequences(c, schemas)
+		for _, alias := range c.selectItemAliases() {
+			columnEntries.Insert(base.Candidate{
+				Type: base.CandidateTypeColumn,
+				Text: c.quotedIdentifierIfNeeded(alias),
+			})
+		}
 	}
 	if table == "" {
 		c.insertReferenceAliasCandidates(tableEntries, schemas, tables)

--- a/backend/plugin/parser/plsql/completion_test.go
+++ b/backend/plugin/parser/plsql/completion_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -99,6 +100,15 @@ func TestCompletionDoesNotDependOnANTLR(t *testing.T) {
 	require.NotContains(t, source, "github.com/antlr4-go/antlr/v4")
 	require.NotContains(t, source, "github.com/bytebase/parser/plsql")
 	require.NotContains(t, source, "CodeCompletionCore")
+}
+
+func TestCompletionByteOffsetUsesUTF16Columns(t *testing.T) {
+	input := "SELECT '😀' FROM t1 WHERE | AND c1 = 1"
+	statement, caretLine, caretOffset := catchCaretUTF16(input)
+
+	_, byteOffset := computeSQLAndByteOffset(statement, caretLine, caretOffset, false /* tricky */)
+
+	require.Equal(t, strings.Index(input, "|"), byteOffset)
 }
 
 func TestCompletionLongTailTableSources(t *testing.T) {
@@ -1444,6 +1454,27 @@ func catchCaret(s string) (string, int, int) {
 			column = 0
 		default:
 			column++
+		}
+	}
+	return s, -1, -1
+}
+
+func catchCaretUTF16(s string) (string, int, int) {
+	line := 1
+	column := 0
+	for i, c := range s {
+		switch c {
+		case '|':
+			return s[:i] + s[i+1:], line, column
+		case '\n':
+			line++
+			column = 0
+		default:
+			if c > 0xFFFF {
+				column += 2
+			} else {
+				column++
+			}
 		}
 	}
 	return s, -1, -1

--- a/backend/plugin/parser/plsql/completion_test.go
+++ b/backend/plugin/parser/plsql/completion_test.go
@@ -1139,6 +1139,50 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 	}
 }
 
+func TestCompletionQuerySceneRestrictsTopLevelWrites(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []completionCandidateSpec
+		notWant []completionCandidateSpec
+	}{
+		{
+			name:    "statement start offers query keywords only",
+			input:   "|",
+			want:    keywords("SELECT", "WITH", "EXPLAIN"),
+			notWant: keywords("INSERT", "UPDATE", "DELETE", "MERGE", "CREATE", "ALTER", "DROP", "TRUNCATE"),
+		},
+		{
+			name:    "statement start prefix keeps matching query keyword",
+			input:   "SEL|",
+			want:    keywords("SELECT"),
+			notWant: keywords("INSERT", "UPDATE", "CREATE", "DROP"),
+		},
+		{
+			name:    "write statement does not offer object candidates",
+			input:   "DROP TABLE |",
+			notWant: tables("T1", "T2"),
+		},
+		{
+			name:  "select table reference still offers tables",
+			input: "SELECT * FROM |",
+			want:  tables("T1", "T2"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := completeOracleForTestWithScene(t, tt.input, base.SceneTypeQuery)
+			for _, want := range tt.want {
+				require.Truef(t, hasCompletionCandidate(result, want), "missing %s candidate %q in %v", want.typ, want.text, result)
+			}
+			for _, notWant := range tt.notWant {
+				require.Falsef(t, hasCompletionCandidate(result, notWant), "unexpected %s candidate %q in %v", notWant.typ, notWant.text, result)
+			}
+		})
+	}
+}
+
 func completionColumnTexts(candidates []base.Candidate) []string {
 	var columns []string
 	for _, candidate := range candidates {
@@ -1156,10 +1200,14 @@ type completionCandidateSpec struct {
 }
 
 func completeOracleForTest(t *testing.T, input string) []base.Candidate {
+	return completeOracleForTestWithScene(t, input, base.SceneTypeAll)
+}
+
+func completeOracleForTestWithScene(t *testing.T, input string, scene base.SceneType) []base.Candidate {
 	t.Helper()
 	text, caretLine, caretOffset := catchCaret(input)
 	result, err := base.Completion(context.Background(), storepb.Engine_ORACLE, base.CompletionContext{
-		Scene:             base.SceneTypeAll,
+		Scene:             scene,
 		DefaultDatabase:   "SCHEMA1",
 		Metadata:          getMetadataForTest,
 		ListDatabaseNames: listDatabaseNamesForTest,

--- a/backend/plugin/parser/plsql/completion_test.go
+++ b/backend/plugin/parser/plsql/completion_test.go
@@ -92,6 +92,1105 @@ func TestCompletion(t *testing.T) {
 	}
 }
 
+func TestCompletionDoesNotDependOnANTLR(t *testing.T) {
+	content, err := os.ReadFile("completion.go")
+	require.NoError(t, err)
+	source := string(content)
+	require.NotContains(t, source, "github.com/antlr4-go/antlr/v4")
+	require.NotContains(t, source, "github.com/bytebase/parser/plsql")
+	require.NotContains(t, source, "CodeCompletionCore")
+}
+
+func TestCompletionLongTailTableSources(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantColumns []string
+	}{
+		{
+			name:        "json table explicit columns",
+			input:       "SELECT jt.| FROM t1, JSON_TABLE(t1.c1, '$.rows[*]' COLUMNS (id NUMBER PATH '$.id', name VARCHAR2(100) PATH '$.name')) jt",
+			wantColumns: []string{"ID", "NAME"},
+		},
+		{
+			name:        "xmltable explicit columns",
+			input:       "SELECT xt.| FROM t1, XMLTABLE('/root/row' PASSING t1.c1 COLUMNS id NUMBER PATH 'id', name VARCHAR2(100) PATH 'name') xt",
+			wantColumns: []string{"ID", "NAME"},
+		},
+		{
+			name:        "inline external declared columns",
+			input:       "SELECT ext.| FROM EXTERNAL ((a NUMBER, b VARCHAR2(10)) TYPE ORACLE_LOADER DEFAULT DIRECTORY data_dir LOCATION ('x.csv')) ext",
+			wantColumns: []string{"A", "B"},
+		},
+		{
+			name:        "lateral inline view columns",
+			input:       "SELECT l.| FROM t1, LATERAL (SELECT c1 FROM t2 WHERE t2.c1 = t1.c1) l",
+			wantColumns: []string{"C1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, caretLine, caretOffset := catchCaret(tt.input)
+			result, err := base.Completion(context.Background(), storepb.Engine_ORACLE, base.CompletionContext{
+				Scene:             base.SceneTypeAll,
+				DefaultDatabase:   "SCHEMA1",
+				Metadata:          getMetadataForTest,
+				ListDatabaseNames: listDatabaseNamesForTest,
+			}, text, caretLine, caretOffset)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantColumns, completionColumnTexts(result))
+		})
+	}
+}
+
+func TestCompletionCoverageMatrix(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []completionCandidateSpec
+		notWant []completionCandidateSpec
+	}{
+		{
+			name:  "select list uses table columns",
+			input: "SELECT | FROM t1",
+			want:  columns("C1"),
+		},
+		{
+			name:  "select list uses alias columns",
+			input: "SELECT a.| FROM t1 a",
+			want:  columns("C1"),
+		},
+		{
+			name:  "select list uses schema qualified table columns",
+			input: "SELECT | FROM schema1.t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "column prefix keeps matching column available",
+			input: "SELECT C2| FROM t2",
+			want:  columns("C2"),
+		},
+		{
+			name:  "qualified column prefix keeps matching column available",
+			input: "SELECT t2.C2| FROM t2",
+			want:  columns("C2"),
+		},
+		{
+			name:    "unknown qualifier offers no columns",
+			input:   "SELECT missing.| FROM t1",
+			notWant: columns("C1", "C2"),
+		},
+		{
+			name:  "join on left alias columns",
+			input: "SELECT * FROM t1 a JOIN t2 b ON a.|",
+			want:  columns("C1"),
+		},
+		{
+			name:  "join on right alias columns",
+			input: "SELECT * FROM t1 a JOIN t2 b ON b.|",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "join where sees both table columns",
+			input: "SELECT * FROM t1 a JOIN t2 b ON a.c1 = b.c1 WHERE |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:    "left alias excludes right only column",
+			input:   "SELECT a.| FROM t1 a JOIN t2 b ON a.c1 = b.c1",
+			want:    columns("C1"),
+			notWant: columns("C2"),
+		},
+		{
+			name:  "join table reference offers tables",
+			input: "SELECT * FROM t1 JOIN |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "using clause offers joined columns",
+			input: "SELECT * FROM t1 JOIN t2 USING (|)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "cte explicit columns are available",
+			input: "WITH x(x1, x2) AS (SELECT * FROM t2) SELECT x.| FROM x",
+			want:  columns("X1", "X2"),
+		},
+		{
+			name:  "cte star body expands through query span",
+			input: "WITH x AS (SELECT * FROM t2) SELECT x.| FROM x",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "cte table candidate is available without schema qualifier",
+			input: "WITH x AS (SELECT * FROM t2) SELECT * FROM |",
+			want:  tables("X", "T1", "T2"),
+		},
+		{
+			name:    "cte table candidate is excluded from schema qualified table reference",
+			input:   "WITH x AS (SELECT * FROM t2) SELECT * FROM schema1.|",
+			want:    tables("T1", "T2"),
+			notWant: tables("X"),
+		},
+		{
+			name:  "multiple ctes expose selected cte columns",
+			input: "WITH a AS (SELECT c1 FROM t1), b AS (SELECT c1, c2 FROM t2) SELECT b.| FROM a JOIN b ON a.c1 = b.c1",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "derived table explicit projection columns",
+			input: "SELECT x.| FROM (SELECT c1 FROM t1) x",
+			want:  columns("C1"),
+		},
+		{
+			name:  "derived table star body expands through query span",
+			input: "SELECT x.| FROM (SELECT * FROM t2) x",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "unqualified select from derived table exposes derived columns",
+			input: "SELECT | FROM (SELECT c1 FROM t1) x",
+			want:  columns("C1"),
+		},
+		{
+			name:  "lateral alias columns",
+			input: "SELECT l.| FROM t1, LATERAL (SELECT c1 FROM t2 WHERE t2.c1 = t1.c1) l",
+			want:  columns("C1"),
+		},
+		{
+			name:    "lateral body sees left outer reference",
+			input:   "SELECT * FROM t1, LATERAL (SELECT t1.| FROM t2) l",
+			want:    columns("C1"),
+			notWant: columns("C2"),
+		},
+		{
+			name:  "json table qualified columns",
+			input: "SELECT jt.| FROM t1, JSON_TABLE(t1.c1, '$.rows[*]' COLUMNS (id NUMBER PATH '$.id', name VARCHAR2(100) PATH '$.name')) jt",
+			want:  columns("ID", "NAME"),
+		},
+		{
+			name:  "json table unqualified columns",
+			input: "SELECT | FROM t1, JSON_TABLE(t1.c1, '$.rows[*]' COLUMNS (id NUMBER PATH '$.id', name VARCHAR2(100) PATH '$.name')) jt",
+			want:  columns("C1", "ID", "NAME"),
+		},
+		{
+			name:  "xmltable qualified columns",
+			input: "SELECT xt.| FROM t1, XMLTABLE('/root/row' PASSING t1.c1 COLUMNS id NUMBER PATH 'id', name VARCHAR2(100) PATH 'name') xt",
+			want:  columns("ID", "NAME"),
+		},
+		{
+			name:  "inline external qualified columns",
+			input: "SELECT ext.| FROM EXTERNAL ((a NUMBER, b VARCHAR2(10)) TYPE ORACLE_LOADER DEFAULT DIRECTORY data_dir LOCATION ('x.csv')) ext",
+			want:  columns("A", "B"),
+		},
+		{
+			name:  "containers alias resolves base object columns",
+			input: "SELECT c.| FROM CONTAINERS(schema1.t2) c",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:    "table function alias does not invent columns",
+			input:   "SELECT x.| FROM TABLE(pkg.values()) x",
+			notWant: columns("C1", "C2"),
+		},
+		{
+			name:  "insert target table reference",
+			input: "INSERT INTO |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "insert column list uses target table columns",
+			input: "INSERT INTO t2 (|) VALUES (1)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "insert select uses source table columns",
+			input: "INSERT INTO t1 SELECT | FROM t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "update target table reference",
+			input: "UPDATE | SET c1 = 1",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "update set uses target table columns",
+			input: "UPDATE t2 SET |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "update where uses target table columns",
+			input: "UPDATE t2 SET c1 = 1 WHERE |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "delete target table reference",
+			input: "DELETE FROM |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "delete where uses target table columns",
+			input: "DELETE FROM t2 WHERE |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "merge target table reference",
+			input: "MERGE INTO |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:    "merge source table reference offers real tables",
+			input:   "MERGE INTO t1 target USING |",
+			want:    tables("T1", "T2"),
+			notWant: tables("TARGET"),
+		},
+		{
+			name:  "merge on uses target and source columns",
+			input: "MERGE INTO t1 target USING t2 source ON |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "schema qualified table reference offers schema tables",
+			input: "SELECT * FROM schema1.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "table prefix keeps matching table available",
+			input: "SELECT * FROM t|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "quoted identifier context preserves candidate text",
+			input: `SELECT "t2".| FROM t2`,
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "select list uses t2 columns",
+			input: "SELECT | FROM t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "where clause uses table columns",
+			input: "SELECT * FROM t2 WHERE |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "order by clause uses table columns",
+			input: "SELECT * FROM t2 ORDER BY |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "group by clause uses table columns",
+			input: "SELECT * FROM t2 GROUP BY |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "having clause uses grouped table columns",
+			input: "SELECT c1, COUNT(*) FROM t2 GROUP BY c1 HAVING |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "distinct select list uses table columns",
+			input: "SELECT DISTINCT | FROM t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "table name qualifier uses table columns",
+			input: "SELECT t2.| FROM t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "comparison expression uses table columns",
+			input: "SELECT * FROM t2 WHERE c1 = |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "arithmetic expression uses table columns",
+			input: "SELECT * FROM t2 WHERE c1 + |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "case expression uses table columns",
+			input: "SELECT CASE WHEN | THEN c1 ELSE c2 END FROM t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "function argument uses table columns",
+			input: "SELECT NVL(|, 0) FROM t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "between lower bound uses table columns",
+			input: "SELECT * FROM t2 WHERE c1 BETWEEN | AND 10",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "between upper bound uses table columns",
+			input: "SELECT * FROM t2 WHERE c1 BETWEEN 1 AND |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "like expression uses table columns",
+			input: "SELECT * FROM t2 WHERE c1 LIKE |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "is null predicate continuation uses table columns",
+			input: "SELECT * FROM t2 WHERE c1 IS NULL OR |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "select alias is available in order by",
+			input: "SELECT c1 AS c_alias FROM t1 ORDER BY |",
+			want:  columns("C1", "C_ALIAS"),
+		},
+		{
+			name:    "select alias is not available in where",
+			input:   "SELECT c1 AS c_alias FROM t1 WHERE |",
+			want:    columns("C1"),
+			notWant: columns("C_ALIAS"),
+		},
+		{
+			name:  "select alias is available in group by",
+			input: "SELECT c1 AS c_alias FROM t1 GROUP BY |",
+			want:  columns("C1", "C_ALIAS"),
+		},
+		{
+			name:  "comma join select list sees both tables",
+			input: "SELECT | FROM t1 a, t2 b",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "comma join left alias columns",
+			input: "SELECT a.| FROM t1 a, t2 b",
+			want:  columns("C1"),
+		},
+		{
+			name:  "comma join right alias columns",
+			input: "SELECT b.| FROM t1 a, t2 b",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "left join select list sees both sides",
+			input: "SELECT | FROM t1 LEFT JOIN t2 ON t1.c1 = t2.c1",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "right join select list sees both sides",
+			input: "SELECT | FROM t1 RIGHT JOIN t2 ON t1.c1 = t2.c1",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "full outer join select list sees both sides",
+			input: "SELECT | FROM t1 FULL OUTER JOIN t2 ON t1.c1 = t2.c1",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "cross join select list sees both sides",
+			input: "SELECT | FROM t1 CROSS JOIN t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "natural join select list sees both sides",
+			input: "SELECT | FROM t1 NATURAL JOIN t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "multi join final alias columns",
+			input: "SELECT c.| FROM t1 a JOIN t2 b ON a.c1 = b.c1 JOIN t2 c ON b.c1 = c.c1",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "multi join where sees all aliases",
+			input: "SELECT * FROM t1 a JOIN t2 b ON a.c1 = b.c1 JOIN t2 c ON b.c1 = c.c1 WHERE |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "schema qualified join alias columns",
+			input: "SELECT s.| FROM t1 a JOIN schema2.t2 s ON a.c1 = s.c1",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "join table prefix keeps matching tables",
+			input: "SELECT * FROM t1 JOIN t|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "left join table reference offers tables",
+			input: "SELECT * FROM t1 LEFT JOIN |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "right join table reference offers tables",
+			input: "SELECT * FROM t1 RIGHT JOIN |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "cross join table reference offers tables",
+			input: "SELECT * FROM t1 CROSS JOIN |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "subquery select list uses inner table columns",
+			input: "SELECT * FROM t1 WHERE EXISTS (SELECT | FROM t2)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "subquery where uses inner table columns",
+			input: "SELECT * FROM t1 WHERE EXISTS (SELECT * FROM t2 WHERE |)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "correlated subquery can qualify outer table",
+			input: "SELECT * FROM t1 outer_t WHERE EXISTS (SELECT * FROM t2 WHERE outer_t.|)",
+			want:  columns("C1"),
+		},
+		{
+			name:  "correlated subquery can qualify inner table",
+			input: "SELECT * FROM t1 outer_t WHERE EXISTS (SELECT * FROM t2 inner_t WHERE inner_t.|)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "scalar subquery select list uses inner table columns",
+			input: "SELECT (SELECT | FROM t2) FROM t1",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "in subquery select list uses inner table columns",
+			input: "SELECT * FROM t1 WHERE c1 IN (SELECT | FROM t2)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "nested derived table alias columns",
+			input: "SELECT y.| FROM (SELECT x.c1 FROM (SELECT c1 FROM t1) x) y",
+			want:  columns("C1"),
+		},
+		{
+			name:  "derived table with column alias",
+			input: "SELECT x.| FROM (SELECT c1 AS renamed FROM t1) x",
+			want:  columns("RENAMED"),
+		},
+		{
+			name:  "derived table join exposes derived alias columns",
+			input: "SELECT x.| FROM (SELECT c1 FROM t1) x JOIN t2 ON x.c1 = t2.c1",
+			want:  columns("C1"),
+		},
+		{
+			name:  "derived table join where sees derived and physical columns",
+			input: "SELECT * FROM (SELECT c1 FROM t1) x JOIN t2 ON x.c1 = t2.c1 WHERE |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "cte selected through derived table",
+			input: "WITH x AS (SELECT c1 FROM t1) SELECT | FROM (SELECT * FROM x) sub",
+			want:  columns("C1"),
+		},
+		{
+			name:  "cte joined with physical table",
+			input: "WITH x AS (SELECT c1 FROM t1) SELECT | FROM x JOIN t2 ON x.c1 = t2.c1",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "cte alias joined with physical table",
+			input: "WITH x AS (SELECT c1 FROM t1) SELECT xa.| FROM x xa JOIN t2 ON xa.c1 = t2.c1",
+			want:  columns("C1"),
+		},
+		{
+			name:  "cte in insert select",
+			input: "WITH x AS (SELECT * FROM t2) INSERT INTO t1 SELECT | FROM x",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "cte in update scalar subquery",
+			input: "WITH x AS (SELECT c1, c2 FROM t2) UPDATE t1 SET c1 = (SELECT | FROM x)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "cte in delete subquery",
+			input: "WITH x AS (SELECT * FROM t2) DELETE FROM t1 WHERE c1 IN (SELECT | FROM x)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "cte set operation exposes positional columns",
+			input: "WITH x AS (SELECT c1 FROM t1 UNION SELECT c1 FROM t2) SELECT x.| FROM x",
+			want:  columns("C1"),
+		},
+		{
+			name:  "lateral body uses inner alias columns",
+			input: "SELECT * FROM t1, LATERAL (SELECT inner_t.| FROM t2 inner_t WHERE inner_t.c1 = t1.c1) l",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "left join lateral alias columns",
+			input: "SELECT l.| FROM t1 LEFT JOIN LATERAL (SELECT c1 FROM t2 WHERE t2.c1 = t1.c1) l ON 1 = 1",
+			want:  columns("C1"),
+		},
+		{
+			name:  "lateral unqualified select list sees inner columns",
+			input: "SELECT * FROM t1, LATERAL (SELECT | FROM t2 WHERE t2.c1 = t1.c1) l",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "json table table alias is offered as table candidate",
+			input: "SELECT | FROM t1, JSON_TABLE(t1.c1, '$.rows[*]' COLUMNS (id NUMBER PATH '$.id')) jt",
+			want:  tables("JT"),
+		},
+		{
+			name:  "xmltable unqualified columns",
+			input: "SELECT | FROM t1, XMLTABLE('/root/row' PASSING t1.c1 COLUMNS id NUMBER PATH 'id', name VARCHAR2(100) PATH 'name') xt",
+			want:  columns("C1", "ID", "NAME"),
+		},
+		{
+			name:  "inline external unqualified columns",
+			input: "SELECT | FROM EXTERNAL ((a NUMBER, b VARCHAR2(10)) TYPE ORACLE_LOADER DEFAULT DIRECTORY data_dir LOCATION ('x.csv')) ext",
+			want:  columns("A", "B"),
+		},
+		{
+			name:  "containers without alias resolves base object columns",
+			input: "SELECT t2.| FROM CONTAINERS(schema1.t2)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:    "pivot does not invent transformed columns",
+			input:   "SELECT | FROM t2 PIVOT (COUNT(*) FOR c1 IN (1 AS one))",
+			notWant: columns("ONE"),
+		},
+		{
+			name:    "unpivot does not invent transformed columns",
+			input:   "SELECT | FROM t2 UNPIVOT (val FOR col IN (c1 AS 'C1', c2 AS 'C2'))",
+			notWant: columns("VAL", "COL"),
+		},
+		{
+			name:    "model does not invent transformed columns",
+			input:   "SELECT | FROM t2 MODEL DIMENSION BY (c1) MEASURES (c2) RULES (c2[1] = 1)",
+			notWant: columns("VAL", "COL"),
+		},
+		{
+			name:  "insert schema qualified table reference",
+			input: "INSERT INTO schema2.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "insert schema qualified target columns",
+			input: "INSERT INTO schema2.t2 (|) VALUES (1)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "insert values expression uses target columns",
+			input: "INSERT INTO t2 VALUES (|)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "insert second column list position uses target columns",
+			input: "INSERT INTO t2 (c1, |) VALUES (1, 2)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "insert select with schema qualified source",
+			input: "INSERT INTO t1 SELECT | FROM schema2.t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "update schema qualified target reference",
+			input: "UPDATE schema2.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "update schema qualified target set columns",
+			input: "UPDATE schema2.t2 SET |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "update set expression uses target columns",
+			input: "UPDATE t2 SET c1 = |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "update where continuation uses target columns",
+			input: "UPDATE t2 SET c1 = 1 WHERE c1 > 0 AND |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "delete schema qualified table reference",
+			input: "DELETE FROM schema2.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "delete where continuation uses target columns",
+			input: "DELETE FROM t2 WHERE c1 > 0 AND |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "merge target schema qualified table reference",
+			input: "MERGE INTO schema2.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "merge source schema qualified table reference",
+			input: "MERGE INTO t1 target USING schema2.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "merge qualified target columns",
+			input: "MERGE INTO t1 target USING t2 source ON target.|",
+			want:  columns("C1"),
+		},
+		{
+			name:  "merge qualified source columns",
+			input: "MERGE INTO t1 target USING t2 source ON source.|",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "merge update set uses target and source columns",
+			input: "MERGE INTO t1 target USING t2 source ON target.c1 = source.c1 WHEN MATCHED THEN UPDATE SET target.c1 = |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "merge insert values uses target and source columns",
+			input: "MERGE INTO t1 target USING t2 source ON target.c1 = source.c1 WHEN NOT MATCHED THEN INSERT (c1) VALUES (|)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "select from root offers schemas",
+			input: "SELECT * FROM |",
+			want:  schemas("SCHEMA1", "SCHEMA2", "SCHEMA3"),
+		},
+		{
+			name:  "select from root offers views",
+			input: "SELECT * FROM |",
+			want:  views("V1"),
+		},
+		{
+			name:  "select from root offers sequences",
+			input: "SELECT * FROM |",
+			want:  sequences("SEQ1", "USER_ID_SEQ"),
+		},
+		{
+			name:  "schema2 table reference offers schema2 tables",
+			input: "SELECT * FROM schema2.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "schema3 table reference offers schema3 tables",
+			input: "SELECT * FROM schema3.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "schema prefix keeps matching schema available",
+			input: "SELECT * FROM schema|",
+			want:  schemas("SCHEMA1", "SCHEMA2", "SCHEMA3"),
+		},
+		{
+			name:  "view reference offers view candidate",
+			input: "SELECT * FROM v|",
+			want:  views("V1"),
+		},
+		{
+			name:  "sequence reference offers sequence candidates",
+			input: "DROP SEQUENCE |",
+			want:  sequences("SEQ1", "USER_ID_SEQ"),
+		},
+		{
+			name:  "sequence prefix keeps matching sequence",
+			input: "DROP SEQUENCE user|",
+			want:  sequences("USER_ID_SEQ"),
+		},
+		{
+			name:  "alter table reference offers tables",
+			input: "ALTER TABLE |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "alter schema qualified table reference offers tables",
+			input: "ALTER TABLE schema1.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "alter drop column offers table columns",
+			input: "ALTER TABLE t2 DROP COLUMN |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "drop table reference offers tables",
+			input: "DROP TABLE |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "drop schema qualified table reference offers tables",
+			input: "DROP TABLE schema1.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "drop view reference offers views",
+			input: "DROP VIEW |",
+			want:  views("V1"),
+		},
+		{
+			name:  "truncate table reference offers tables",
+			input: "TRUNCATE TABLE |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "comment on table reference offers tables",
+			input: "COMMENT ON TABLE |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "comment on column offers table columns",
+			input: "COMMENT ON COLUMN t2.|",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "grant on object offers tables",
+			input: "GRANT SELECT ON |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "revoke on object offers tables",
+			input: "REVOKE SELECT ON |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "create table datatype offers NUMBER",
+			input: "CREATE TABLE t (c |)",
+			want:  keywords("NUMBER"),
+		},
+		{
+			name:  "create table references offers tables",
+			input: "CREATE TABLE child (parent_id NUMBER REFERENCES |)",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "multiple statements limits to statement at caret insert",
+			input: "SELECT * FROM t1; INSERT INTO |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "multiple statements limits to statement at caret update",
+			input: "SELECT * FROM t1; UPDATE | SET c1 = 1",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "multiple statements limits to statement at caret delete",
+			input: "SELECT * FROM t1; DELETE FROM |",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "multiple statements select columns after invalid first statement",
+			input: "SELECT FROM broken; SELECT | FROM t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "table prefix after multiple statements",
+			input: "SELECT * FROM t1; SELECT * FROM t|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "quoted table alias columns",
+			input: `SELECT "Alias".| FROM t2 "Alias"`,
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "quoted cte alias columns",
+			input: `WITH "X"(x1, x2) AS (SELECT * FROM t2) SELECT "X".| FROM "X"`,
+			want:  columns("X1", "X2"),
+		},
+		{
+			name:  "quoted derived alias columns",
+			input: `SELECT "Sub".| FROM (SELECT c1 FROM t1) "Sub"`,
+			want:  columns("C1"),
+		},
+		{
+			name:  "quoted schema qualified table reference",
+			input: `SELECT * FROM "SCHEMA1".|`,
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "quoted schema qualified columns",
+			input: `SELECT | FROM "SCHEMA1"."T2"`,
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "reserved-like quoted alias columns",
+			input: `SELECT "SELECT".| FROM t2 "SELECT"`,
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:    "database link table keeps local table columns unavailable when metadata missing",
+			input:   "SELECT remote_t.| FROM t2@remote remote_t",
+			notWant: columns("C1", "C2"),
+		},
+		{
+			name:    "schema qualified unknown table offers no known columns",
+			input:   "SELECT | FROM schema1.missing_table",
+			notWant: columns("C1", "C2"),
+		},
+		{
+			name:    "unknown schema table reference offers no local tables",
+			input:   "SELECT * FROM missing_schema.|",
+			notWant: tables("T1", "T2"),
+		},
+		{
+			name:    "unknown cte qualifier offers no columns",
+			input:   "WITH x AS (SELECT c1 FROM t1) SELECT y.| FROM x",
+			notWant: columns("C1", "C2"),
+		},
+		{
+			name:    "unknown physical alias offers no columns",
+			input:   "SELECT z.| FROM t1 a JOIN t2 b ON a.c1 = b.c1",
+			notWant: columns("C1", "C2"),
+		},
+		{
+			name:    "unknown lateral alias offers no columns",
+			input:   "SELECT missing.| FROM t1, LATERAL (SELECT c1 FROM t2) l",
+			notWant: columns("C1", "C2"),
+		},
+		{
+			name:  "hierarchical start with uses from scope",
+			input: "SELECT * FROM t2 START WITH | CONNECT BY PRIOR c1 = c2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "hierarchical connect by uses from scope",
+			input: "SELECT * FROM t2 START WITH c1 IS NULL CONNECT BY |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "analytic partition by uses table columns",
+			input: "SELECT COUNT(*) OVER (PARTITION BY |) FROM t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "analytic order by uses table columns",
+			input: "SELECT COUNT(*) OVER (ORDER BY |) FROM t2",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "for update select list keeps table columns",
+			input: "SELECT | FROM t2 FOR UPDATE",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "subquery alias table candidate is offered",
+			input: "SELECT | FROM (SELECT c1 FROM t1) sub1",
+			want:  tables("SUB1"),
+		},
+		{
+			name:  "physical alias table candidate is offered",
+			input: "SELECT | FROM t1 x",
+			want:  tables("X"),
+		},
+		{
+			name:  "schema2 table prefix keeps matching tables",
+			input: "SELECT * FROM schema2.t|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "quoted schema2 table prefix keeps matching tables",
+			input: `SELECT * FROM "SCHEMA2".t|`,
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "schema3 t1 select list uses columns",
+			input: "SELECT | FROM schema3.t1",
+			want:  columns("C1"),
+		},
+		{
+			name:  "schema3 alias select list uses columns",
+			input: "SELECT s.| FROM schema3.t2 s",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "schema3 alias where uses columns",
+			input: "SELECT * FROM schema3.t2 s WHERE s.|",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "schema3 alias order by uses columns",
+			input: "SELECT * FROM schema3.t2 s ORDER BY s.|",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "join schema3 table alias columns",
+			input: "SELECT s.| FROM t1 a JOIN schema3.t2 s ON a.c1 = s.c1",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "insert schema3 qualified target columns",
+			input: "INSERT INTO schema3.t2 (|) VALUES (1)",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "update schema3 qualified target set columns",
+			input: "UPDATE schema3.t2 SET |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "delete schema3 qualified target where columns",
+			input: "DELETE FROM schema3.t2 WHERE |",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "merge schema3 target qualified columns",
+			input: "MERGE INTO schema3.t1 target USING schema2.t2 source ON source.|",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "cte table prefix keeps matching cte",
+			input: "WITH x AS (SELECT * FROM t2) SELECT * FROM x|",
+			want:  tables("X"),
+		},
+		{
+			name:  "cte explicit column prefix keeps matching column",
+			input: "WITH x(x1, x2) AS (SELECT * FROM t2) SELECT x.X1| FROM x",
+			want:  columns("X1"),
+		},
+		{
+			name:  "derived table column prefix keeps matching column",
+			input: "SELECT x.C1| FROM (SELECT c1 FROM t1) x",
+			want:  columns("C1"),
+		},
+		{
+			name:  "json table column prefix keeps matching column",
+			input: "SELECT jt.I| FROM t1, JSON_TABLE(t1.c1, '$.rows[*]' COLUMNS (id NUMBER PATH '$.id', name VARCHAR2(100) PATH '$.name')) jt",
+			want:  columns("ID"),
+		},
+		{
+			name:  "xmltable column prefix keeps matching column",
+			input: "SELECT xt.N| FROM t1, XMLTABLE('/root/row' PASSING t1.c1 COLUMNS id NUMBER PATH 'id', name VARCHAR2(100) PATH 'name') xt",
+			want:  columns("NAME"),
+		},
+		{
+			name:  "inline external column prefix keeps matching column",
+			input: "SELECT ext.A| FROM EXTERNAL ((a NUMBER, b VARCHAR2(10)) TYPE ORACLE_LOADER DEFAULT DIRECTORY data_dir LOCATION ('x.csv')) ext",
+			want:  columns("A"),
+		},
+		{
+			name:  "comment on schema qualified column offers columns",
+			input: "COMMENT ON COLUMN schema1.t2.|",
+			want:  columns("C1", "C2"),
+		},
+		{
+			name:  "grant on schema qualified object offers tables",
+			input: "GRANT SELECT ON schema1.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "revoke on schema qualified object offers tables",
+			input: "REVOKE SELECT ON schema1.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "truncate schema qualified table reference offers tables",
+			input: "TRUNCATE TABLE schema1.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "comment on schema qualified table reference offers tables",
+			input: "COMMENT ON TABLE schema1.|",
+			want:  tables("T1", "T2"),
+		},
+		{
+			name:  "drop schema qualified view reference offers views",
+			input: "DROP VIEW schema1.|",
+			want:  views("V1"),
+		},
+		{
+			name:  "view schema qualified table reference offers views",
+			input: "SELECT * FROM schema1.v|",
+			want:  views("V1"),
+		},
+		{
+			name:  "sequence schema qualified reference offers sequences",
+			input: "DROP SEQUENCE schema1.|",
+			want:  sequences("SEQ1", "USER_ID_SEQ"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := completeOracleForTest(t, tt.input)
+			for _, want := range tt.want {
+				require.Truef(t, hasCompletionCandidate(result, want), "missing %s candidate %q in %v", want.typ, want.text, result)
+			}
+			for _, notWant := range tt.notWant {
+				require.Falsef(t, hasCompletionCandidate(result, notWant), "unexpected %s candidate %q in %v", notWant.typ, notWant.text, result)
+			}
+		})
+	}
+}
+
+func completionColumnTexts(candidates []base.Candidate) []string {
+	var columns []string
+	for _, candidate := range candidates {
+		if candidate.Type == base.CandidateTypeColumn {
+			columns = append(columns, candidate.Text)
+		}
+	}
+	slices.Sort(columns)
+	return columns
+}
+
+type completionCandidateSpec struct {
+	text string
+	typ  base.CandidateType
+}
+
+func completeOracleForTest(t *testing.T, input string) []base.Candidate {
+	t.Helper()
+	text, caretLine, caretOffset := catchCaret(input)
+	result, err := base.Completion(context.Background(), storepb.Engine_ORACLE, base.CompletionContext{
+		Scene:             base.SceneTypeAll,
+		DefaultDatabase:   "SCHEMA1",
+		Metadata:          getMetadataForTest,
+		ListDatabaseNames: listDatabaseNamesForTest,
+	}, text, caretLine, caretOffset)
+	require.NoError(t, err)
+	return result
+}
+
+func hasCompletionCandidate(candidates []base.Candidate, want completionCandidateSpec) bool {
+	for _, candidate := range candidates {
+		if candidate.Type == want.typ && candidate.Text == want.text {
+			return true
+		}
+	}
+	return false
+}
+
+func columns(texts ...string) []completionCandidateSpec {
+	return completionSpecs(base.CandidateTypeColumn, texts...)
+}
+
+func tables(texts ...string) []completionCandidateSpec {
+	return completionSpecs(base.CandidateTypeTable, texts...)
+}
+
+func views(texts ...string) []completionCandidateSpec {
+	return completionSpecs(base.CandidateTypeView, texts...)
+}
+
+func schemas(texts ...string) []completionCandidateSpec {
+	return completionSpecs(base.CandidateTypeSchema, texts...)
+}
+
+func sequences(texts ...string) []completionCandidateSpec {
+	return completionSpecs(base.CandidateTypeSequence, texts...)
+}
+
+func keywords(texts ...string) []completionCandidateSpec {
+	return completionSpecs(base.CandidateTypeKeyword, texts...)
+}
+
+func completionSpecs(typ base.CandidateType, texts ...string) []completionCandidateSpec {
+	specs := make([]completionCandidateSpec, 0, len(texts))
+	for _, text := range texts {
+		specs = append(specs, completionCandidateSpec{text: text, typ: typ})
+	}
+	return specs
+}
+
 func listDatabaseNamesForTest(_ context.Context, _ string) ([]string, error) {
 	return []string{"SCHEMA1", "SCHEMA2", "SCHEMA3"}, nil
 }

--- a/backend/plugin/parser/plsql/completion_test.go
+++ b/backend/plugin/parser/plsql/completion_test.go
@@ -512,6 +512,12 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want:  columns("C1", "C2"),
 		},
 		{
+			name:    "schema qualified alias excludes same table from other schema",
+			input:   "SELECT a.| FROM schema1.t1 a JOIN schema4.t1 b ON a.c1 = b.c1",
+			want:    columns("C1"),
+			notWant: columns("SCHEMA4_ONLY"),
+		},
+		{
 			name:  "join table prefix keeps matching tables",
 			input: "SELECT * FROM t1 JOIN t|",
 			want:  tables("T1", "T2"),
@@ -1326,6 +1332,30 @@ func getMetadataForTest(_ context.Context, _, databaseName string) (string, *mod
 											SELECT *
 											FROM t1
 							`,
+						},
+					},
+				},
+			},
+		}, nil, nil, storepb.Engine_ORACLE, true /* isObjectCaseSensitive */), nil
+	case "SCHEMA4":
+		return "SCHEMA4", model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+			Name: databaseName,
+			Schemas: []*storepb.SchemaMetadata{
+				{
+					Name: "",
+					Tables: []*storepb.TableMetadata{
+						{
+							Name: "T1",
+							Columns: []*storepb.ColumnMetadata{
+								{
+									Name: "C1",
+									Type: "int",
+								},
+								{
+									Name: "SCHEMA4_ONLY",
+									Type: "int",
+								},
+							},
 						},
 					},
 				},

--- a/backend/plugin/parser/plsql/completion_test.go
+++ b/backend/plugin/parser/plsql/completion_test.go
@@ -249,9 +249,10 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want:  columns("C1", "C2"),
 		},
 		{
-			name:  "unqualified select from derived table exposes derived columns",
-			input: "SELECT | FROM (SELECT c1 FROM t1) x",
-			want:  columns("C1"),
+			name:    "unqualified select from derived table exposes derived columns",
+			input:   "SELECT | FROM (SELECT c1 FROM t2) x",
+			want:    columns("C1"),
+			notWant: columns("C2"),
 		},
 		{
 			name:  "lateral alias columns",

--- a/backend/plugin/parser/plsql/completion_test.go
+++ b/backend/plugin/parser/plsql/completion_test.go
@@ -446,6 +446,11 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want:  columns("C1", "C_ALIAS"),
 		},
 		{
+			name:  "select alias survives nested select in order by",
+			input: "SELECT c1 AS c_alias FROM t1 WHERE EXISTS (SELECT c1 FROM t2) ORDER BY |",
+			want:  columns("C1", "C_ALIAS"),
+		},
+		{
 			name:    "select alias is not available in where",
 			input:   "SELECT c1 AS c_alias FROM t1 WHERE |",
 			want:    columns("C1"),
@@ -1098,9 +1103,10 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			want:  tables("T1", "T2"),
 		},
 		{
-			name:  "drop schema qualified view reference offers views",
-			input: "DROP VIEW schema1.|",
-			want:  views("V1"),
+			name:    "drop schema qualified view reference offers only views",
+			input:   "DROP VIEW schema1.|",
+			want:    views("V1"),
+			notWant: append(tables("T1", "T2"), sequences("SEQ1", "USER_ID_SEQ")...),
 		},
 		{
 			name:  "view schema qualified table reference offers views",
@@ -1111,6 +1117,12 @@ func TestCompletionCoverageMatrix(t *testing.T) {
 			name:  "sequence schema qualified reference offers sequences",
 			input: "DROP SEQUENCE schema1.|",
 			want:  sequences("SEQ1", "USER_ID_SEQ"),
+		},
+		{
+			name:    "sequence schema qualified reference uses non default schema",
+			input:   "DROP SEQUENCE schema2.|",
+			want:    sequences("SCHEMA2_SEQ"),
+			notWant: sequences("SEQ1", "USER_ID_SEQ"),
 		},
 	}
 
@@ -1290,6 +1302,11 @@ func getMetadataForTest(_ context.Context, _, databaseName string) (string, *mod
 											SELECT *
 											FROM t1
 							`,
+						},
+					},
+					Sequences: []*storepb.SequenceMetadata{
+						{
+							Name: "SCHEMA2_SEQ",
 						},
 					},
 				},

--- a/backend/plugin/parser/plsql/completion_test.go
+++ b/backend/plugin/parser/plsql/completion_test.go
@@ -1175,6 +1175,11 @@ func TestCompletionQuerySceneRestrictsTopLevelWrites(t *testing.T) {
 			notWant: tables("T1", "T2"),
 		},
 		{
+			name:    "with prefixed write statement does not offer object candidates",
+			input:   "WITH x AS (SELECT c1 FROM t1) INSERT INTO t1 SELECT * FROM |",
+			notWant: tables("T1", "T2", "X"),
+		},
+		{
 			name:  "select table reference still offers tables",
 			input: "SELECT * FROM |",
 			want:  tables("T1", "T2"),

--- a/backend/plugin/parser/plsql/test-data/test_completion.yaml
+++ b/backend/plugin/parser/plsql/test-data/test_completion.yaml
@@ -367,11 +367,6 @@
       definition: ""
       comment: ""
       priority: 0
-    - text: C1
-      type: COLUMN
-      definition: SCHEMA1.T1 | int, NOT NULL
-      comment: ""
-      priority: 0
     - text: SCHEMA1
       type: SCHEMA
       definition: ""

--- a/backend/plugin/parser/plsql/util.go
+++ b/backend/plugin/parser/plsql/util.go
@@ -23,6 +23,7 @@ func plsqlNormalizeColumnName(currentSchema string, ctx plsql.IColumn_nameContex
 	}
 }
 
+//nolint:unused
 func normalizeColumnAlias(ctx plsql.IColumn_aliasContext) string {
 	if ctx == nil {
 		return ""

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260529083135-9af8f51ae75e
+	github.com/bytebase/omni v0.0.0-20260601085651-b0170787c27d
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260529083135-9af8f51ae75e h1:Ucb4G4VEjHoyPByA/z4TioDr4y78hZxSMFZtzQslw8k=
-github.com/bytebase/omni v0.0.0-20260529083135-9af8f51ae75e/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260601085651-b0170787c27d h1:CvBH5vU+Slc8dvt19IhdHq812Je/fTypbjQjy3D/Fqo=
+github.com/bytebase/omni v0.0.0-20260601085651-b0170787c27d/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Migrate Oracle completion from ANTLR/C3 completion to omni `CollectCompletion` intent and scope.
- Update omni to `v0.0.0-20260601085651-b0170787c27d`, which covers schema-qualified DDL/DCL completion intent without Bytebase token fallbacks.
- Add Oracle completion coverage comparable with PG/MySQL/TSQL, including DML, DDL, DCL, CTE, derived tables, long-tail table sources, quoted identifiers, and multi-statement cases.

## Test Plan
- [x] `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/plsql`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `golangci-lint run --fix --allow-parallel-runners && golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags \"-w -s\" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- [x] `go mod tidy`
- [x] `git diff --check`

## Pre-PR Checklist
- Breaking changes: none. Parser completion implementation changed, no API/proto/schema/config change.
- Composite-PK safety: skipped; no `backend/store/` or `backend/migrator/` changes.
- Frontend/proto checks: skipped; no frontend or proto changes.
- SonarCloud properties: skipped; no new files or directories added.