### PR TITLE
chore(frontend): clean up locale translations

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -12,10 +12,6 @@
     "token-expired-description": "Token has expired, please login again",
     "token-expired-title": "Token expired"
   },
-  "branch": {
-    "index": {},
-    "table-partition": {}
-  },
   "common": {
     "access-denied": "Access denied",
     "active": "Active",
@@ -23,7 +19,6 @@
     "closed": "Closed",
     "database": "Database",
     "databases": "Databases",
-    "date": {},
     "dingtalk": "DingTalk",
     "discord": "Discord",
     "draft": "Draft",
@@ -33,7 +28,6 @@
     "feishu": "Feishu",
     "google-chat": "Google Chat",
     "groups": "Groups",
-    "hard-delete": {},
     "home": "Home",
     "instance": "Instance",
     "instances": "Instances",
@@ -75,9 +69,6 @@
     },
     "sync-schema": {
       "title": "Sync Schema"
-    },
-    "transfer": {
-      "errors": {}
     }
   },
   "error-page": {
@@ -87,9 +78,6 @@
   "export-center": {
     "self": "Export Center"
   },
-  "export-data": {
-    "error": {}
-  },
   "gitops": {
     "self": "GitOps"
   },
@@ -97,7 +85,6 @@
     "new-instance": "New Instance"
   },
   "issue": {
-    "sql-check": {},
     "table": {
       "approved": "Approved"
     },
@@ -105,9 +92,6 @@
       "change-database": "Change database",
       "export-data": "Export data"
     }
-  },
-  "landing": {
-    "quick-link": {}
   },
   "multi-factor": {
     "self": "Multi-factor authentication"
@@ -206,11 +190,6 @@
       "self": "Workspace Member"
     }
   },
-  "schema-designer": {},
-  "schema-editor": {
-    "foreign-key": {},
-    "table": {}
-  },
   "settings": {
     "members": {
       "all-users": "All users",
@@ -306,7 +285,6 @@
     "sql-download-unavailable": "SQL download is unavailable for this connection."
   },
   "sql-review": {
-    "category": {},
     "create": {
       "breadcrumb": "Create SQL review policy"
     },
@@ -332,7 +310,6 @@
     }
   },
   "task": {
-    "check-result": {},
     "status": {
       "available": "Available",
       "canceled": "Canceled",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -12,10 +12,6 @@
     "token-expired-description": "El token ha expirado, por favor inicia sesión nuevamente",
     "token-expired-title": "Token expirado"
   },
-  "branch": {
-    "index": {},
-    "table-partition": {}
-  },
   "common": {
     "access-denied": "Acceso denegado",
     "active": "Activo",
@@ -23,7 +19,6 @@
     "closed": "Cerrado",
     "database": "Base de datos",
     "databases": "Bases de datos",
-    "date": {},
     "dingtalk": "DingTalk",
     "discord": "Discord",
     "draft": "Borrador",
@@ -33,7 +28,6 @@
     "feishu": "Feishu",
     "google-chat": "Google Chat",
     "groups": "Grupos",
-    "hard-delete": {},
     "home": "Inicio",
     "instance": "Instancia",
     "instances": "Instancias",
@@ -75,9 +69,6 @@
     },
     "sync-schema": {
       "title": "Sincronizar esquema"
-    },
-    "transfer": {
-      "errors": {}
     }
   },
   "error-page": {
@@ -87,9 +78,6 @@
   "export-center": {
     "self": "centro de exportacion"
   },
-  "export-data": {
-    "error": {}
-  },
   "gitops": {
     "self": "GitOps"
   },
@@ -97,17 +85,13 @@
     "new-instance": "Nueva instancia"
   },
   "issue": {
-    "sql-check": {},
     "table": {
-      "approved": "Approved"
+      "approved": "Aprobado"
     },
     "title": {
       "change-database": "Modificar base de datos",
       "export-data": "Exportar datos"
     }
-  },
-  "landing": {
-    "quick-link": {}
   },
   "multi-factor": {
     "self": "Autenticación de múltiples factores"
@@ -206,11 +190,6 @@
       "self": "Miembro del espacio de trabajo"
     }
   },
-  "schema-designer": {},
-  "schema-editor": {
-    "foreign-key": {},
-    "table": {}
-  },
   "settings": {
     "members": {
       "all-users": "Todos los usuarios",
@@ -291,7 +270,7 @@
     "shared": "Compartido"
   },
   "sql-editor": {
-    "access-grants": "Access Grants",
+    "access-grants": "Permisos de acceso",
     "batch-query": {
       "select-data-source": {
         "admin": "Administración",
@@ -301,12 +280,11 @@
     "download-encryption-failed": "Error al cifrar la descarga.",
     "download-failed": "Error en la descarga.",
     "download-too-large": "El resultado es demasiado grande para descargar. Reduzca el número de filas o use Exportar.",
-    "expired": "Expired",
+    "expired": "Expirado",
     "self": "Editor de SQL",
     "sql-download-unavailable": "La descarga SQL no está disponible para esta conexión."
   },
   "sql-review": {
-    "category": {},
     "create": {
       "breadcrumb": "Crear política de revisión SQL"
     },
@@ -332,7 +310,6 @@
     }
   },
   "task": {
-    "check-result": {},
     "status": {
       "available": "Disponible",
       "canceled": "Cancelado",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -12,10 +12,6 @@
     "token-expired-description": "トークンの有効期限が切れています。再度ログインしてください。",
     "token-expired-title": "トークンの有効期限が切れました"
   },
-  "branch": {
-    "index": {},
-    "table-partition": {}
-  },
   "common": {
     "access-denied": "アクセスが拒否されました",
     "active": "アクティブ",
@@ -23,7 +19,6 @@
     "closed": "閉まっている",
     "database": "データベース",
     "databases": "データベース",
-    "date": {},
     "dingtalk": "DingTalk",
     "discord": "Discord",
     "draft": "下書き",
@@ -33,7 +28,6 @@
     "feishu": "Feishu",
     "google-chat": "Google Chat",
     "groups": "グループ",
-    "hard-delete": {},
     "home": "ホームページ",
     "instance": "インスタンス",
     "instances": "インスタンス",
@@ -75,9 +69,6 @@
     },
     "sync-schema": {
       "title": "データベーステーブルの同期"
-    },
-    "transfer": {
-      "errors": {}
     }
   },
   "error-page": {
@@ -87,9 +78,6 @@
   "export-center": {
     "self": "エクスポートセンター"
   },
-  "export-data": {
-    "error": {}
-  },
   "gitops": {
     "self": "GitOps"
   },
@@ -97,17 +85,13 @@
     "new-instance": "新しいインスタンス"
   },
   "issue": {
-    "sql-check": {},
     "table": {
-      "approved": "Approved"
+      "approved": "承認済み"
     },
     "title": {
       "change-database": "データベースの変更",
       "export-data": "データをエクスポート"
     }
-  },
-  "landing": {
-    "quick-link": {}
   },
   "multi-factor": {
     "self": "多要素認証"
@@ -206,11 +190,6 @@
       "self": "ワークスペースメンバー"
     }
   },
-  "schema-designer": {},
-  "schema-editor": {
-    "foreign-key": {},
-    "table": {}
-  },
   "settings": {
     "members": {
       "all-users": "すべてのユーザー",
@@ -291,7 +270,7 @@
     "shared": "共有"
   },
   "sql-editor": {
-    "access-grants": "Access Grants",
+    "access-grants": "アクセス権限",
     "batch-query": {
       "select-data-source": {
         "admin": "管理者",
@@ -301,12 +280,11 @@
     "download-encryption-failed": "ダウンロードの暗号化に失敗しました。",
     "download-failed": "ダウンロードに失敗しました。",
     "download-too-large": "ダウンロードするには結果が大きすぎます。行数を減らすか、エクスポートを使用してください。",
-    "expired": "Expired",
+    "expired": "期限切れ",
     "self": "SQLエディタ",
     "sql-download-unavailable": "この接続では SQL ダウンロードを利用できません。"
   },
   "sql-review": {
-    "category": {},
     "create": {
       "breadcrumb": "SQL レビューポリシーを作成する"
     },
@@ -332,7 +310,6 @@
     }
   },
   "task": {
-    "check-result": {},
     "status": {
       "available": "利用可能",
       "canceled": "キャンセル",

--- a/frontend/src/locales/sql-review/es-ES.json
+++ b/frontend/src/locales/sql-review/es-ES.json
@@ -416,7 +416,7 @@
       "title": "Prohibir el uso de la cláusula \"ORDER BY\" en las declaraciones \"UPDATE\" y \"DELETE\""
     },
     "STATEMENT_DISALLOW_RM_TBL_CASCADE": {
-      "description": "Using the \"CASCADE\" option when removing a table can cause a large number of dependent objects to be deleted or modified, which may cause unexpected results. Suggestion error level: Error",
+      "description": "Usar la opción \"CASCADE\" al eliminar una tabla puede hacer que se eliminen o modifiquen una gran cantidad de objetos dependientes, lo que puede causar resultados inesperados. Nivel de error sugerido: Error",
       "title": "Prohibir el uso de CASCADE al eliminar una tabla"
     },
     "STATEMENT_DISALLOW_TRUNCATE": {

--- a/frontend/src/locales/sql-review/vi-VN.json
+++ b/frontend/src/locales/sql-review/vi-VN.json
@@ -4,7 +4,7 @@
     "builtin": "Quy tắc có sẵn",
     "column": "Cột",
     "database": "Cơ sở dữ liệu",
-    "engine": "Engine",
+    "engine": "Công cụ",
     "index": "Chỉ mục",
     "naming": "Đặt tên",
     "schema": "Lược đồ",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -12,10 +12,6 @@
     "token-expired-description": "Mã thông báo đã hết hạn, vui lòng đăng nhập lại",
     "token-expired-title": "Mã thông báo đã hết hạn"
   },
-  "branch": {
-    "index": {},
-    "table-partition": {}
-  },
   "common": {
     "access-denied": "Truy cập bị từ chối",
     "active": "Hoạt động",
@@ -23,7 +19,6 @@
     "closed": "Đã đóng",
     "database": "Cơ sở dữ liệu",
     "databases": "Cơ sở dữ liệu",
-    "date": {},
     "dingtalk": "DingTalk",
     "discord": "Discord",
     "draft": "Bản nháp",
@@ -33,7 +28,6 @@
     "feishu": "Feishu",
     "google-chat": "Google Chat",
     "groups": "Nhóm",
-    "hard-delete": {},
     "home": "Trang chủ",
     "instance": "Phiên bản",
     "instances": "Phiên bản",
@@ -75,9 +69,6 @@
     },
     "sync-schema": {
       "title": "Đồng bộ lược đồ"
-    },
-    "transfer": {
-      "errors": {}
     }
   },
   "error-page": {
@@ -87,9 +78,6 @@
   "export-center": {
     "self": "Trung tâm xuất"
   },
-  "export-data": {
-    "error": {}
-  },
   "gitops": {
     "self": "GitOps"
   },
@@ -97,17 +85,13 @@
     "new-instance": "Phiên bản mới"
   },
   "issue": {
-    "sql-check": {},
     "table": {
-      "approved": "Approved"
+      "approved": "Đã phê duyệt"
     },
     "title": {
       "change-database": "Thay đổi cơ sở dữ liệu",
       "export-data": "Xuất dữ liệu"
     }
-  },
-  "landing": {
-    "quick-link": {}
   },
   "multi-factor": {
     "self": "Xác thực đa yếu tố"
@@ -206,11 +190,6 @@
       "self": "Thành viên không gian làm việc"
     }
   },
-  "schema-designer": {},
-  "schema-editor": {
-    "foreign-key": {},
-    "table": {}
-  },
   "settings": {
     "members": {
       "all-users": "Tất cả người dùng",
@@ -291,7 +270,7 @@
     "shared": "Được chia sẻ"
   },
   "sql-editor": {
-    "access-grants": "Access Grants",
+    "access-grants": "Quyền truy cập",
     "batch-query": {
       "select-data-source": {
         "admin": "Quản trị viên",
@@ -301,12 +280,11 @@
     "download-encryption-failed": "Không thể mã hóa bản tải xuống.",
     "download-failed": "Tải xuống thất bại.",
     "download-too-large": "Kết quả quá lớn để tải xuống. Hãy giảm số dòng hoặc sử dụng Xuất.",
-    "expired": "Expired",
+    "expired": "Đã hết hạn",
     "self": "Trình soạn thảo SQL",
     "sql-download-unavailable": "Tải xuống SQL không khả dụng cho kết nối này."
   },
   "sql-review": {
-    "category": {},
     "create": {
       "breadcrumb": "Tạo chính sách đánh giá SQL"
     },
@@ -332,7 +310,6 @@
     }
   },
   "task": {
-    "check-result": {},
     "status": {
       "available": "Có sẵn",
       "canceled": "Đã hủy",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -12,10 +12,6 @@
     "token-expired-description": "Token 已过期，请重新登录",
     "token-expired-title": "Token 已过期"
   },
-  "branch": {
-    "index": {},
-    "table-partition": {}
-  },
   "common": {
     "access-denied": "拒绝访问",
     "active": "开启",
@@ -23,7 +19,6 @@
     "closed": "已关闭",
     "database": "数据库",
     "databases": "数据库",
-    "date": {},
     "dingtalk": "钉钉",
     "discord": "Discord",
     "draft": "草稿",
@@ -33,7 +28,6 @@
     "feishu": "飞书",
     "google-chat": "Google Chat",
     "groups": "分组",
-    "hard-delete": {},
     "home": "主页",
     "instance": "实例",
     "instances": "实例",
@@ -75,9 +69,6 @@
     },
     "sync-schema": {
       "title": "库表同步"
-    },
-    "transfer": {
-      "errors": {}
     }
   },
   "error-page": {
@@ -87,9 +78,6 @@
   "export-center": {
     "self": "导出中心"
   },
-  "export-data": {
-    "error": {}
-  },
   "gitops": {
     "self": "GitOps"
   },
@@ -97,7 +85,6 @@
     "new-instance": "新实例"
   },
   "issue": {
-    "sql-check": {},
     "table": {
       "approved": "已审批"
     },
@@ -105,9 +92,6 @@
       "change-database": "变更数据库",
       "export-data": "导出数据"
     }
-  },
-  "landing": {
-    "quick-link": {}
   },
   "multi-factor": {
     "self": "多重认证"
@@ -206,11 +190,6 @@
       "self": "工作空间成员"
     }
   },
-  "schema-designer": {},
-  "schema-editor": {
-    "foreign-key": {},
-    "table": {}
-  },
   "settings": {
     "members": {
       "all-users": "全部用户",
@@ -306,7 +285,6 @@
     "sql-download-unavailable": "当前连接不支持 SQL 下载。"
   },
   "sql-review": {
-    "category": {},
     "create": {
       "breadcrumb": "创建审核策略"
     },
@@ -332,7 +310,6 @@
     }
   },
   "task": {
-    "check-result": {},
     "status": {
       "available": "就绪",
       "canceled": "取消",


### PR DESCRIPTION
## Summary
- Translate leftover English UI labels in Japanese, Spanish, and Vietnamese locale files.
- Localize one Spanish SQL review rule description and the Vietnamese SQL review engine category.
- Remove empty placeholder objects from top-level locale JSON files.

## Test Plan
- [x] pnpm --dir frontend check
- [x] pnpm --dir frontend type-check
- [x] pnpm --dir frontend test
- [x] git diff --check

## Pre-PR Checklist
- Breaking change check: no breaking changes; locale-only cleanup.
- Composite-PK query safety: skipped; no backend/store or migrator changes.
- SonarCloud properties: skipped; no new files or directories.
