### PR TITLE
test(plsql): cover Oracle ALTER SYSTEM parsing

### DIFF
--- a/backend/plugin/parser/plsql/diagnose_test.go
+++ b/backend/plugin/parser/plsql/diagnose_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
@@ -55,4 +56,23 @@ END;`
 	diagnostics, err := Diagnose(context.Background(), base.DiagnoseContext{}, statement)
 	require.NoError(t, err)
 	require.Empty(t, diagnostics)
+}
+
+func TestDiagnoseAcceptsAlterSystem(t *testing.T) {
+	tests := []string{
+		"alter system set dg_broker_start=true;",
+		"alter system switch logfile;",
+	}
+
+	for _, statement := range tests {
+		t.Run(statement, func(t *testing.T) {
+			diagnostics, err := Diagnose(context.Background(), base.DiagnoseContext{}, statement)
+			require.NoError(t, err)
+			require.Empty(t, diagnostics)
+
+			stmts, err := base.ParseStatements(store.Engine_ORACLE, statement)
+			require.NoError(t, err)
+			require.Len(t, stmts, 1)
+		})
+	}
 }


### PR DESCRIPTION
close BYT-7330
## Summary
- Add a regression test for Oracle ALTER SYSTEM statements from BYT-7330.
- Verify both diagnostics and the Oracle ParseStatements registry path accept the statements.

## Test Plan
- go test -v -count=1 ./backend/plugin/parser/plsql -run '^TestDiagnoseAcceptsAlterSystem$'
- go test -count=1 ./backend/plugin/parser/plsql
- golangci-lint run --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go

## Pre-PR Checklist
- Breaking change check: skipped, test-only diff.
- Composite-PK query safety: skipped, no backend/store or migration changes.
- SonarCloud properties: skipped, no new files or directories.