### PR TITLE
fix(react): stop infinite render loop in database object explorer

### DIFF
--- a/frontend/src/react/stores/app/dbSchema.ts
+++ b/frontend/src/react/stores/app/dbSchema.ts
@@ -58,6 +58,33 @@ const EMPTY_EXTERNAL_TABLE_LIST: ExternalTableMetadata[] = [];
 const EMPTY_FUNCTION_LIST: FunctionMetadata[] = [];
 const EMPTY_EXTENSION_LIST: ExtensionMetadata[] = [];
 
+// When no schema is selected the list getters flatten across all schemas.
+// `flatMap` allocates a fresh array on every call, which would trip Zustand's
+// `Object.is` snapshot check and loop `useSyncExternalStore` forever (the bug
+// only reproduces on non-schema engines like MySQL, whose single schema is
+// named "" so the flatten branch runs; Postgres selects "public" and hits the
+// stable `.tables` ref). Cache the flattened result keyed by the `schemas`
+// array reference — that reference is stable while the database metadata stays
+// cached, so repeated calls return the same array. The cache entry is dropped
+// automatically once the metadata (and its `schemas` array) is replaced or GC'd.
+const flattenCache = <T>(
+  selector: (schema: SchemaMetadata) => T[]
+): ((schemas: SchemaMetadata[]) => T[]) => {
+  const cache = new WeakMap<SchemaMetadata[], T[]>();
+  return (schemas) => {
+    const cached = cache.get(schemas);
+    if (cached) return cached;
+    const flattened = schemas.flatMap(selector);
+    cache.set(schemas, flattened);
+    return flattened;
+  };
+};
+
+const flattenTables = flattenCache((s) => s.tables);
+const flattenViews = flattenCache((s) => s.views);
+const flattenExternalTables = flattenCache((s) => s.externalTables);
+const flattenFunctions = flattenCache((s) => s.functions);
+
 const isUnknownDatabase = (database: string): boolean => {
   const { databaseName, instanceName } = extractDatabaseResourceName(database);
   return (
@@ -102,7 +129,7 @@ export const createDBSchemaSlice: AppSliceCreator<DBSchemaSlice> = (
     if (schema) {
       return schemas.find((s) => s.name === schema)?.tables ?? EMPTY_TABLE_LIST;
     }
-    return schemas.flatMap((s) => s.tables);
+    return flattenTables(schemas);
   },
 
   getViewList: ({ database, schema }) => {
@@ -111,7 +138,7 @@ export const createDBSchemaSlice: AppSliceCreator<DBSchemaSlice> = (
     if (schema) {
       return schemas.find((s) => s.name === schema)?.views ?? EMPTY_VIEW_LIST;
     }
-    return schemas.flatMap((s) => s.views);
+    return flattenViews(schemas);
   },
 
   getExternalTableList: ({ database, schema }) => {
@@ -123,7 +150,7 @@ export const createDBSchemaSlice: AppSliceCreator<DBSchemaSlice> = (
         EMPTY_EXTERNAL_TABLE_LIST
       );
     }
-    return schemas.flatMap((s) => s.externalTables);
+    return flattenExternalTables(schemas);
   },
 
   getFunctionList: ({ database, schema }) => {
@@ -134,7 +161,7 @@ export const createDBSchemaSlice: AppSliceCreator<DBSchemaSlice> = (
         schemas.find((s) => s.name === schema)?.functions ?? EMPTY_FUNCTION_LIST
       );
     }
-    return schemas.flatMap((s) => s.functions);
+    return flattenFunctions(schemas);
   },
 
   getExtensionList: (database) => {


### PR DESCRIPTION
## What

The dbSchema list getters (`getTableList` / `getViewList` / `getExternalTableList` / `getFunctionList`) flatten across all schemas when no schema is selected, via `schemas.flatMap(...)`, allocating a **fresh array on every call**. They are consumed through reactive selectors like `useAppStore((s) => s.getTableList({...}))` in `DatabaseObjectExplorer`. A fresh reference fails Zustand's `Object.is` snapshot check and loops `useSyncExternalStore`:

```
The result of getSnapshot should be cached to avoid an infinite loop
Uncaught Error: Maximum update depth exceeded.
```

## Why it only hit non-postgres databases

Non-schema engines (MySQL, etc.) expose a single schema named `""`, so `selectedSchemaName` is empty and the `flatMap` branch runs every render → loop. Postgres selects `"public"`, hitting the stable `.tables` reference, so it never looped.

## Fix

Cache each getter's flattened result in a `WeakMap` keyed by the `schemas` array reference. That reference is stable while the database metadata stays cached, so repeated calls return the same array — satisfying the snapshot-stability contract. The entry is dropped automatically when the metadata (and its `schemas` array) is replaced or GC'd.

The four `schema`-scoped branches were already stable (they return `.tables`/`.views`/etc. by reference); only the no-schema flatten branch needed the cache.

## Testing

- `pnpm --dir frontend type-check` passes.
- Swept all `useAppStore` selectors and `useVueState` getters: no other call site invokes an allocating getter inside a zustand selector, and `useVueState` (version-counter, not snapshot-compare) is immune to this class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)