### PR TITLE
docs(tidb): correct stale omni bridge-removal comments

### DIFF
--- a/backend/plugin/advisor/tidb/utils.go
+++ b/backend/plugin/advisor/tidb/utils.go
@@ -57,7 +57,9 @@ func (t tablePK) tableList() []string {
 	return tableList
 }
 
-// getTiDBNodes extracts pingcap-AST nodes for un-migrated advisors.
+// getTiDBNodes extracts pingcap-AST nodes. Post-dml_dry_run migration (PR
+// #20467) its only consumer is advisor_builtin_prior_backup_check, which uses
+// pingcap AST for authoritative DDL detection on its dual-path (cumulative #30).
 //
 // On a PingCapASTProvider whose AsPingCapAST returns (nil, false) — i.e.
 // the bridge tried and pingcap rejected the statement — the statement is

--- a/backend/plugin/parser/tidb/omni.go
+++ b/backend/plugin/parser/tidb/omni.go
@@ -20,10 +20,14 @@ import (
 // *OmniAST from ParseStatements, those un-migrated advisors keep working
 // because GetTiDBAST routes through AsPingCapAST() automatically.
 //
-// Bridge cleanup is deferred until Phase 2 §Tier 4g (NonTransactionalDMLStmt
-// + production-grade restore equivalent) ships and `dml_dry_run` (the one
-// Class III advisor) can migrate. See plans/2026-04-23-omni-tidb-completion-
-// plan.md §1.5.0 invariant #4 + Bridge persistence rule.
+// The PingCapASTProvider bridge is retained after the dml_dry_run migration
+// (PR #20467): its sole remaining consumer is advisor_builtin_prior_backup_check,
+// which reads pingcap AST for authoritative DDL detection on its dual-path
+// (cumulative #30). Removal is gated on that consumer moving its DDL detection
+// off pingcap (deemed brittle, deferred) — NOT on any advisor migration. (This
+// is distinct from the dispatcher's Option B pingcap-fallback for omni-rejected
+// SQL, which persists until Option A retirement; see dispatcher.go + invariant
+// #8 in plans/2026-04-23-omni-tidb-completion-plan.md §1.5.0.)
 //
 // Mirrors backend/plugin/parser/mysql/omni.go's AsANTLRAST pattern:
 //   - Lazy parse + cache via pingcapParsed flag (matches mysql's antlrParsed).
@@ -39,8 +43,8 @@ type OmniAST struct {
 
 	// pingcapAST is lazily populated when AsPingCapAST() is called for the
 	// first time. Cached for the lifetime of this OmniAST instance.
-	// Will be removed once dml_dry_run migrates and the bridge is no longer
-	// needed (post-Phase-2 §Tier 4g).
+	// Retained for the prior_backup_check dual-path (cumulative #30); see the
+	// type doc above.
 	pingcapAST *AST
 	// pingcapParsed tracks whether we've attempted the native parse, to
 	// distinguish "not yet parsed" from "parsed and got nil".


### PR DESCRIPTION
## What

Corrects misleading comments in `backend/plugin/parser/tidb/omni.go` and `backend/plugin/advisor/tidb/utils.go` that claimed the pingcap bridge *"will be removed once dml_dry_run migrates and the bridge is no longer needed."*

## Why

`dml_dry_run` has migrated to omni (PR #20467), but the bridge is **retained**, for two reasons unrelated to that advisor:

1. **`advisor_builtin_prior_backup_check`** reads pingcap AST for authoritative DDL detection on its dual-path (cumulative #30) — it's the bridge's sole remaining `getTiDBNodes`/`AsPingCapAST` consumer.
2. The dispatcher's **Option B fallback** still produces raw pingcap `*AST` for omni-rejected SQL (FLASHBACK / SEQUENCE / SPLIT — deferred grammar omni doesn't have). Removal there is gated on Option A retirement (telemetry, months out), not on any advisor migration.

The old comments nearly drove an incorrect follow-up ("delete the `*tidbparser.AST` arm in `getTiDBOmniNodes`, 3-arm → 2-arm") that would have broken `TestGetTiDBOmniNodesSkipsPingcapFallbackAST` and violated the Phase 1.5 invariant #2 soft-fail — that arm is exactly what handles the Option B fallback.

## Scope

Comment-only, **no behavior change**. The broader "un-migrated advisors" phrasings in the bridge's implementation notes / log messages are left for the dedicated comment-cleanup pass (BYT-9396).

## Testing

`gofmt`, `go build`, `golangci-lint` (0 issues), and `go test -short` (`TestGetTiDBOmniNodesSkipsPingcapFallbackAST` + `TestTiDBRules`) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)