### PR TITLE
chore: adapt Oracle parser to omni 484791c

### DIFF
--- a/backend/plugin/parser/plsql/omni_test.go
+++ b/backend/plugin/parser/plsql/omni_test.go
@@ -87,6 +87,28 @@ SPOOL OFF
 	require.IsType(t, &ast.CreateTriggerStmt{}, second.Stmt)
 }
 
+func TestParsePLSQLOmniMatchRecognize(t *testing.T) {
+	statement := `SELECT * FROM TRADES MATCH_RECOGNIZE (
+  PARTITION BY ACCOUNT_ID
+  ORDER BY TRADE_TIME
+  MEASURES FIRST(PRICE) AS FIRST_PRICE, LAST(PRICE) AS LAST_PRICE
+  ONE ROW PER MATCH
+  PATTERN (A B+)
+  DEFINE B AS B.PRICE > A.PRICE
+) MR`
+	stmts, err := SplitSQL(statement)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	require.Equal(t, statement, stmts[0].Text)
+
+	list, err := ParsePLSQLOmni(statement)
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+	raw, ok := list.Items[0].(*ast.RawStmt)
+	require.True(t, ok)
+	require.IsType(t, &ast.SelectStmt{}, raw.Stmt)
+}
+
 func TestParsePLSQLOmniPreservesScriptOffsets(t *testing.T) {
 	sql := `PROMPT setup
 SELECT 1 FROM DUAL;

--- a/backend/plugin/parser/plsql/plsql_test.go
+++ b/backend/plugin/parser/plsql/plsql_test.go
@@ -127,12 +127,7 @@ func TestParsePLSQLStatementsOmniFirst(t *testing.T) {
 	require.IsType(t, &ast.SelectStmt{}, omniAST.Node)
 }
 
-func TestParsePLSQLStatementsFallsBackToANTLR(t *testing.T) {
-	// The second statement exercises a CREATE TRIGGER with a REFERENCING
-	// OLD/NEW clause — currently rejected by omni-oracle's parser but
-	// accepted by ANTLR, so dispatch must fall back. If omni-oracle later
-	// adds REFERENCING support, swap this for another omni-rejected
-	// statement to preserve the fallback path's coverage.
+func TestParsePLSQLStatementsParsesTriggerReferencingWithOmni(t *testing.T) {
 	stmts, err := base.ParseStatements(storepb.Engine_ORACLE, `SELECT * FROM T;
 CREATE OR REPLACE TRIGGER trg
 BEFORE INSERT OR UPDATE OF col1, col2 ON tbl
@@ -148,8 +143,13 @@ END;`)
 	_, ok := stmts[0].AST.(*OmniAST)
 	require.True(t, ok)
 
-	_, ok = stmts[1].AST.(*base.ANTLRAST)
+	omniAST, ok := stmts[1].AST.(*OmniAST)
 	require.True(t, ok)
+	trigger, ok := omniAST.Node.(*ast.CreateTriggerStmt)
+	require.True(t, ok)
+	require.NotNil(t, trigger.Referencing)
+	require.Equal(t, "O", trigger.Referencing.OldAlias)
+	require.Equal(t, "N", trigger.Referencing.NewAlias)
 }
 
 func TestParsePLSQLStatementsFallbackErrorUsesOriginalLine(t *testing.T) {

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -630,6 +630,7 @@ func (q *omniQuerySpanExtractor) extractOmniPivot(pivot *oracleast.PivotClause) 
 			return nil, err
 		}
 		aggregateSources[i] = sourceColumns
+		excludeOmniColumnRefNames(excluded, aggregate.Expr)
 		excludeSourceColumnNames(excluded, sourceColumns)
 	}
 
@@ -1285,6 +1286,17 @@ func excludeSourceColumnNames(excluded map[string]bool, source base.SourceColumn
 		excluded[column.Column] = true
 		excluded[strings.ToUpper(column.Column)] = true
 	}
+}
+
+func excludeOmniColumnRefNames(excluded map[string]bool, expr oracleast.ExprNode) {
+	oracleast.Inspect(expr, func(node oracleast.Node) bool {
+		columnRef, ok := node.(*oracleast.ColumnRef)
+		if ok && columnRef.Schema == "" && columnRef.Table == "" && columnRef.Column != "*" {
+			excluded[columnRef.Column] = true
+			excluded[strings.ToUpper(columnRef.Column)] = true
+		}
+		return true
+	})
 }
 
 func mergeSourceColumnsFromResults(results []base.QuerySpanResult) base.SourceColumnSet {

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -801,8 +801,12 @@ func (q *omniQuerySpanExtractor) extractOmniMatchRecognize(ref *oracleast.MatchR
 	if err != nil {
 		return nil, err
 	}
-	results := make([]base.QuerySpanResult, 0, len(partitionResults)+len(measureResults))
-	results = append(results, partitionResults...)
+	var results []base.QuerySpanResult
+	if strings.HasPrefix(strings.ToUpper(ref.RowsPerMatch), "ALL ROWS PER MATCH") && source != nil {
+		results = cloneQuerySpanResults(source.GetQuerySpanResult())
+	} else {
+		results = append(results, partitionResults...)
+	}
 	results = append(results, measureResults...)
 	return aliasOmniTableSource(&base.PseudoTable{Columns: results}, ref.Alias), nil
 }

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -797,7 +797,7 @@ func (q *omniQuerySpanExtractor) extractOmniMatchRecognize(ref *oracleast.MatchR
 	if err != nil {
 		return nil, err
 	}
-	measureResults, err := q.extractOmniResultList(ref.Measures)
+	measureResults, err := q.extractOmniMatchRecognizeMeasureList(ref.Measures)
 	if err != nil {
 		return nil, err
 	}
@@ -812,6 +812,14 @@ func (q *omniQuerySpanExtractor) extractOmniMatchRecognize(ref *oracleast.MatchR
 }
 
 func (q *omniQuerySpanExtractor) extractOmniResultList(list *oracleast.List) ([]base.QuerySpanResult, error) {
+	return q.extractOmniResultListWithSourceColumns(list, nil)
+}
+
+func (q *omniQuerySpanExtractor) extractOmniMatchRecognizeMeasureList(list *oracleast.List) ([]base.QuerySpanResult, error) {
+	return q.extractOmniResultListWithSourceColumns(list, q.extractOmniMatchRecognizeMeasureSourceColumns)
+}
+
+func (q *omniQuerySpanExtractor) extractOmniResultListWithSourceColumns(list *oracleast.List, sourceColumnsExtractor func(oracleast.ExprNode) (base.SourceColumnSet, error)) ([]base.QuerySpanResult, error) {
 	var results []base.QuerySpanResult
 	for _, node := range listItems(list) {
 		var expr oracleast.ExprNode
@@ -833,6 +841,12 @@ func (q *omniQuerySpanExtractor) extractOmniResultList(list *oracleast.List) ([]
 		if err != nil {
 			return nil, err
 		}
+		if sourceColumnsExtractor != nil {
+			sourceColumns, err = sourceColumnsExtractor(expr)
+			if err != nil {
+				return nil, err
+			}
+		}
 		if name == "" {
 			name = extractedName
 		}
@@ -843,6 +857,16 @@ func (q *omniQuerySpanExtractor) extractOmniResultList(list *oracleast.List) ([]
 		})
 	}
 	return results, nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniMatchRecognizeMeasureSourceColumns(expr oracleast.ExprNode) (base.SourceColumnSet, error) {
+	return q.extractOmniExprSourceColumnsWithResolver(expr, func(node *oracleast.ColumnRef) base.SourceColumnSet {
+		sourceColumns := q.getOmniFieldColumnSource(node.Schema, node.Table, node.Column)
+		if len(sourceColumns) == 0 && node.Schema == "" && node.Table != "" {
+			sourceColumns = q.getOmniFieldColumnSource("", "", node.Column)
+		}
+		return sourceColumns
+	})
 }
 
 func omniSetLeftSelect(stmt *oracleast.SelectStmt) *oracleast.SelectStmt {
@@ -989,6 +1013,12 @@ func (q *omniQuerySpanExtractor) extractOmniExpr(expr oracleast.ExprNode) (strin
 }
 
 func (q *omniQuerySpanExtractor) extractOmniExprSourceColumns(expr oracleast.ExprNode) (base.SourceColumnSet, error) {
+	return q.extractOmniExprSourceColumnsWithResolver(expr, func(node *oracleast.ColumnRef) base.SourceColumnSet {
+		return q.getOmniFieldColumnSource(node.Schema, node.Table, node.Column)
+	})
+}
+
+func (q *omniQuerySpanExtractor) extractOmniExprSourceColumnsWithResolver(expr oracleast.ExprNode, resolveColumn func(*oracleast.ColumnRef) base.SourceColumnSet) (base.SourceColumnSet, error) {
 	result := make(base.SourceColumnSet)
 	var walkErr error
 	oracleast.Inspect(expr, func(node oracleast.Node) bool {
@@ -998,7 +1028,7 @@ func (q *omniQuerySpanExtractor) extractOmniExprSourceColumns(expr oracleast.Exp
 		switch node := node.(type) {
 		case *oracleast.ColumnRef:
 			if node.Column != "*" {
-				result, _ = base.MergeSourceColumnSet(result, q.getOmniFieldColumnSource(node.Schema, node.Table, node.Column))
+				result, _ = base.MergeSourceColumnSet(result, resolveColumn(node))
 			}
 			return false
 		case *oracleast.FuncCallExpr:

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -278,13 +278,25 @@ func (q *omniQuerySpanExtractor) extractOmniSelect(stmt *oracleast.SelectStmt) (
 		return q.extractOmniSetSelect(stmt)
 	}
 	if stmt.Pivot != nil {
-		return q.extractOmniPivot(stmt.Pivot)
+		source, err := q.extractOmniPivot(stmt.Pivot)
+		if err != nil {
+			return nil, err
+		}
+		return q.projectOmniTransformedSelect(stmt, source)
 	}
 	if stmt.Unpivot != nil {
-		return q.extractOmniUnpivot(stmt.Unpivot)
+		source, err := q.extractOmniUnpivot(stmt.Unpivot)
+		if err != nil {
+			return nil, err
+		}
+		return q.projectOmniTransformedSelect(stmt, source)
 	}
 	if stmt.ModelClause != nil {
-		return q.extractOmniModelSelect(stmt)
+		source, err := q.extractOmniModelSelect(stmt)
+		if err != nil {
+			return nil, err
+		}
+		return q.projectOmniTransformedSelect(stmt, source)
 	}
 
 	oldFrom := q.tableSourcesFrom
@@ -318,6 +330,27 @@ func (q *omniQuerySpanExtractor) extractOmniSelect(stmt *oracleast.SelectStmt) (
 	return &base.PseudoTable{
 		Columns: results,
 	}, nil
+}
+
+func (q *omniQuerySpanExtractor) projectOmniTransformedSelect(stmt *oracleast.SelectStmt, source base.TableSource) (base.TableSource, error) {
+	oldFrom := q.tableSourcesFrom
+	oldTopLevelFrom := q.topLevelTableSourcesFrom
+	q.tableSourcesFrom = nil
+	q.topLevelTableSourcesFrom = nil
+	if source != nil {
+		q.tableSourcesFrom = append(q.tableSourcesFrom, source)
+		q.topLevelTableSourcesFrom = append(q.topLevelTableSourcesFrom, source)
+	}
+	defer func() {
+		q.tableSourcesFrom = oldFrom
+		q.topLevelTableSourcesFrom = oldTopLevelFrom
+	}()
+
+	results, err := q.extractOmniTargetList(stmt.TargetList)
+	if err != nil {
+		return nil, err
+	}
+	return &base.PseudoTable{Columns: results}, nil
 }
 
 func (q *omniQuerySpanExtractor) extractOmniSetSelect(stmt *oracleast.SelectStmt) (base.TableSource, error) {
@@ -590,6 +623,16 @@ func (q *omniQuerySpanExtractor) extractOmniPivot(pivot *oracleast.PivotClause) 
 		}
 	}
 
+	aggregateSources := make([]base.SourceColumnSet, len(aggregates))
+	for i, aggregate := range aggregates {
+		_, sourceColumns, err := q.extractOmniExpr(aggregate.Expr)
+		if err != nil {
+			return nil, err
+		}
+		aggregateSources[i] = sourceColumns
+		excludeSourceColumnNames(excluded, sourceColumns)
+	}
+
 	var results []base.QuerySpanResult
 	if source != nil {
 		for _, result := range source.GetQuerySpanResult() {
@@ -600,12 +643,8 @@ func (q *omniQuerySpanExtractor) extractOmniPivot(pivot *oracleast.PivotClause) 
 	}
 	for _, inItem := range inItems {
 		inName := pivotInItemName(q, inItem)
-		for _, aggregate := range aggregates {
-			_, aggregateSources, err := q.extractOmniExpr(aggregate.Expr)
-			if err != nil {
-				return nil, err
-			}
-			sourceColumns, _ := base.MergeSourceColumnSet(pivotSources, aggregateSources)
+		for i, aggregate := range aggregates {
+			sourceColumns, _ := base.MergeSourceColumnSet(pivotSources, aggregateSources[i])
 			results = append(results, base.QuerySpanResult{
 				Name:          pivotColumnName(inName, aggregate.Alias, len(aggregates)),
 				SourceColumns: sourceColumns,
@@ -1161,6 +1200,16 @@ func cloneSourceColumnSet(source base.SourceColumnSet) base.SourceColumnSet {
 		cloned[column] = true
 	}
 	return cloned
+}
+
+func excludeSourceColumnNames(excluded map[string]bool, source base.SourceColumnSet) {
+	for column := range source {
+		if column.Column == "" {
+			continue
+		}
+		excluded[column.Column] = true
+		excluded[strings.ToUpper(column.Column)] = true
+	}
 }
 
 func mergeSourceColumnsFromResults(results []base.QuerySpanResult) base.SourceColumnSet {

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -254,15 +254,6 @@ func (q *omniQuerySpanExtractor) extractOmniSelect(stmt *oracleast.SelectStmt) (
 	if stmt == nil {
 		return nil, nil
 	}
-	if stmt.Pivot != nil {
-		return nil, errors.Errorf("unsupported oracle table source: %T", stmt.Pivot)
-	}
-	if stmt.Unpivot != nil {
-		return nil, errors.Errorf("unsupported oracle table source: %T", stmt.Unpivot)
-	}
-	if stmt.ModelClause != nil {
-		return nil, errors.Errorf("unsupported oracle table source: %T", stmt.ModelClause)
-	}
 
 	oldCTEs := q.ctes
 	if stmt.WithClause != nil {
@@ -285,6 +276,15 @@ func (q *omniQuerySpanExtractor) extractOmniSelect(stmt *oracleast.SelectStmt) (
 
 	if stmt.Op != 0 {
 		return q.extractOmniSetSelect(stmt)
+	}
+	if stmt.Pivot != nil {
+		return q.extractOmniPivot(stmt.Pivot)
+	}
+	if stmt.Unpivot != nil {
+		return q.extractOmniUnpivot(stmt.Unpivot)
+	}
+	if stmt.ModelClause != nil {
+		return q.extractOmniModelSelect(stmt)
 	}
 
 	oldFrom := q.tableSourcesFrom
@@ -537,11 +537,228 @@ func (q *omniQuerySpanExtractor) extractOmniTableExpr(expr oracleast.TableExpr) 
 		return aliasOmniTableSource(tableSource, expr.Alias), nil
 	case *oracleast.InlineExternalTable:
 		return extractOmniInlineExternalTable(expr), nil
-	case *oracleast.TableCollectionExpr, *oracleast.PivotClause, *oracleast.UnpivotClause, *oracleast.MatchRecognizeClause:
-		return nil, errors.Errorf("unsupported oracle table source: %T", expr)
+	case *oracleast.TableCollectionExpr:
+		return q.extractOmniTableCollection(expr)
+	case *oracleast.PivotClause:
+		return q.extractOmniPivot(expr)
+	case *oracleast.UnpivotClause:
+		return q.extractOmniUnpivot(expr)
+	case *oracleast.MatchRecognizeClause:
+		return q.extractOmniMatchRecognize(expr)
 	default:
 		return nil, errors.Errorf("unsupported oracle table source: %T", expr)
 	}
+}
+
+func (q *omniQuerySpanExtractor) extractOmniPivot(pivot *oracleast.PivotClause) (base.TableSource, error) {
+	if pivot == nil {
+		return nil, nil
+	}
+	source, err := q.extractOmniTableExpr(pivot.Source)
+	if err != nil {
+		return nil, err
+	}
+	oldFrom := q.tableSourcesFrom
+	q.tableSourcesFrom = append(q.tableSourcesFrom, source)
+	defer func() {
+		q.tableSourcesFrom = oldFrom
+	}()
+
+	excluded := make(map[string]bool)
+	pivotSources := make(base.SourceColumnSet)
+	for _, expr := range omniExprList(pivot.ForColumns) {
+		name, sourceColumns, err := q.extractOmniExpr(expr)
+		if err != nil {
+			return nil, err
+		}
+		excluded[name] = true
+		pivotSources, _ = base.MergeSourceColumnSet(pivotSources, sourceColumns)
+	}
+
+	var aggregates []*oracleast.PivotAggregate
+	for _, item := range listItems(pivot.Aggregates) {
+		aggregate, ok := item.(*oracleast.PivotAggregate)
+		if ok {
+			aggregates = append(aggregates, aggregate)
+		}
+	}
+	var inItems []*oracleast.PivotInItem
+	for _, item := range listItems(pivot.InItems) {
+		inItem, ok := item.(*oracleast.PivotInItem)
+		if ok {
+			inItems = append(inItems, inItem)
+		}
+	}
+
+	var results []base.QuerySpanResult
+	if source != nil {
+		for _, result := range source.GetQuerySpanResult() {
+			if !excluded[result.Name] {
+				results = append(results, cloneQuerySpanResult(result))
+			}
+		}
+	}
+	for _, inItem := range inItems {
+		inName := pivotInItemName(q, inItem)
+		for _, aggregate := range aggregates {
+			_, aggregateSources, err := q.extractOmniExpr(aggregate.Expr)
+			if err != nil {
+				return nil, err
+			}
+			sourceColumns, _ := base.MergeSourceColumnSet(pivotSources, aggregateSources)
+			results = append(results, base.QuerySpanResult{
+				Name:          pivotColumnName(inName, aggregate.Alias, len(aggregates)),
+				SourceColumns: sourceColumns,
+				IsPlainField:  false,
+			})
+		}
+	}
+	return aliasOmniTableSource(&base.PseudoTable{Columns: results}, pivot.Alias), nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniUnpivot(unpivot *oracleast.UnpivotClause) (base.TableSource, error) {
+	if unpivot == nil {
+		return nil, nil
+	}
+	source, err := q.extractOmniTableExpr(unpivot.Source)
+	if err != nil {
+		return nil, err
+	}
+	oldFrom := q.tableSourcesFrom
+	q.tableSourcesFrom = append(q.tableSourcesFrom, source)
+	defer func() {
+		q.tableSourcesFrom = oldFrom
+	}()
+
+	valueColumns := omniExprList(unpivot.ValueColumns)
+	inputSources := make([]base.SourceColumnSet, len(valueColumns))
+	excluded := make(map[string]bool)
+	for _, item := range listItems(unpivot.InputMappings) {
+		mapping, ok := item.(*oracleast.UnpivotInItem)
+		if !ok {
+			continue
+		}
+		for i, input := range omniExprList(mapping.InputColumns) {
+			name, sourceColumns, err := q.extractOmniExpr(input)
+			if err != nil {
+				return nil, err
+			}
+			excluded[name] = true
+			if i < len(inputSources) {
+				inputSources[i], _ = base.MergeSourceColumnSet(inputSources[i], sourceColumns)
+			}
+		}
+	}
+
+	var results []base.QuerySpanResult
+	if source != nil {
+		for _, result := range source.GetQuerySpanResult() {
+			if !excluded[result.Name] {
+				results = append(results, cloneQuerySpanResult(result))
+			}
+		}
+	}
+	for i, expr := range valueColumns {
+		name, _, err := q.extractOmniExpr(expr)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, base.QuerySpanResult{
+			Name:          name,
+			SourceColumns: inputSources[i],
+			IsPlainField:  false,
+		})
+	}
+	if unpivot.PivotColumn != nil {
+		name, _, err := q.extractOmniExpr(unpivot.PivotColumn)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, base.QuerySpanResult{
+			Name:          name,
+			SourceColumns: base.SourceColumnSet{},
+			IsPlainField:  false,
+		})
+	}
+	return aliasOmniTableSource(&base.PseudoTable{Columns: results}, unpivot.Alias), nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniModelSelect(stmt *oracleast.SelectStmt) (base.TableSource, error) {
+	oldFrom := q.tableSourcesFrom
+	oldTopLevelFrom := q.topLevelTableSourcesFrom
+	q.tableSourcesFrom = nil
+	q.topLevelTableSourcesFrom = nil
+	defer func() {
+		q.tableSourcesFrom = oldFrom
+		q.topLevelTableSourcesFrom = oldTopLevelFrom
+	}()
+
+	for _, node := range listItems(stmt.FromClause) {
+		tableExpr, ok := node.(oracleast.TableExpr)
+		if !ok {
+			continue
+		}
+		tableSource, err := q.extractOmniTableExpr(tableExpr)
+		if err != nil {
+			return nil, err
+		}
+		if tableSource != nil {
+			q.tableSourcesFrom = append(q.tableSourcesFrom, tableSource)
+			q.topLevelTableSourcesFrom = append(q.topLevelTableSourcesFrom, tableSource)
+		}
+	}
+
+	var results []base.QuerySpanResult
+	if stmt.ModelClause != nil && stmt.ModelClause.MainModel != nil && stmt.ModelClause.MainModel.ColumnClauses != nil {
+		columns := stmt.ModelClause.MainModel.ColumnClauses
+		for _, list := range []*oracleast.List{columns.DimensionBy, columns.Measures} {
+			extracted, err := q.extractOmniTargetList(list)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, extracted...)
+		}
+	}
+	return &base.PseudoTable{Columns: results}, nil
+}
+
+func (*omniQuerySpanExtractor) extractOmniTableCollection(ref *oracleast.TableCollectionExpr) (base.TableSource, error) {
+	if ref == nil {
+		return nil, nil
+	}
+	var columns []base.QuerySpanResult
+	for _, name := range omniStringList(ref.ColumnAliases) {
+		columns = append(columns, base.QuerySpanResult{
+			Name:          name,
+			SourceColumns: base.SourceColumnSet{},
+			IsPlainField:  false,
+		})
+	}
+	if len(columns) == 0 {
+		return nil, errors.Errorf("unsupported oracle table collection without column aliases")
+	}
+	return aliasOmniTableSource(&base.PseudoTable{Columns: columns}, ref.Alias), nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniMatchRecognize(ref *oracleast.MatchRecognizeClause) (base.TableSource, error) {
+	if ref == nil {
+		return nil, nil
+	}
+	source, err := q.extractOmniTableExpr(ref.Source)
+	if err != nil {
+		return nil, err
+	}
+	oldFrom := q.tableSourcesFrom
+	q.tableSourcesFrom = append(q.tableSourcesFrom, source)
+	defer func() {
+		q.tableSourcesFrom = oldFrom
+	}()
+
+	results, err := q.extractOmniTargetList(ref.Measures)
+	if err != nil {
+		return nil, err
+	}
+	return aliasOmniTableSource(&base.PseudoTable{Columns: results}, ref.Alias), nil
 }
 
 func omniSetLeftSelect(stmt *oracleast.SelectStmt) *oracleast.SelectStmt {
@@ -922,14 +1139,18 @@ func applyOmniColumnAliases(columns []base.QuerySpanResult, names []string) {
 	}
 }
 
+func cloneQuerySpanResult(result base.QuerySpanResult) base.QuerySpanResult {
+	return base.QuerySpanResult{
+		Name:          result.Name,
+		SourceColumns: cloneSourceColumnSet(result.SourceColumns),
+		IsPlainField:  result.IsPlainField,
+	}
+}
+
 func cloneQuerySpanResults(results []base.QuerySpanResult) []base.QuerySpanResult {
 	cloned := make([]base.QuerySpanResult, 0, len(results))
 	for _, result := range results {
-		cloned = append(cloned, base.QuerySpanResult{
-			Name:          result.Name,
-			SourceColumns: cloneSourceColumnSet(result.SourceColumns),
-			IsPlainField:  result.IsPlainField,
-		})
+		cloned = append(cloned, cloneQuerySpanResult(result))
 	}
 	return cloned
 }
@@ -984,6 +1205,17 @@ func listItems(list *oracleast.List) []oracleast.Node {
 	return list.Items
 }
 
+func omniExprList(list *oracleast.List) []oracleast.ExprNode {
+	var result []oracleast.ExprNode
+	for _, node := range listItems(list) {
+		expr, ok := node.(oracleast.ExprNode)
+		if ok {
+			result = append(result, expr)
+		}
+	}
+	return result
+}
+
 func omniStringList(list *oracleast.List) []string {
 	var result []string
 	for _, node := range listItems(list) {
@@ -996,6 +1228,36 @@ func omniStringList(list *oracleast.List) []string {
 		}
 	}
 	return result
+}
+
+func pivotInItemName(q *omniQuerySpanExtractor, item *oracleast.PivotInItem) string {
+	if item == nil {
+		return ""
+	}
+	if item.Alias != "" {
+		return item.Alias
+	}
+	var parts []string
+	for _, expr := range omniExprList(item.Values) {
+		name, _, err := q.extractOmniExpr(expr)
+		if err != nil {
+			continue
+		}
+		if name != "" {
+			parts = append(parts, name)
+		}
+	}
+	return strings.Join(parts, "_")
+}
+
+func pivotColumnName(inName, aggregateAlias string, _ int) string {
+	if aggregateAlias == "" {
+		return inName
+	}
+	if inName == "" {
+		return aggregateAlias
+	}
+	return inName + "_" + aggregateAlias
 }
 
 func isOmniStar(expr oracleast.ExprNode) bool {

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -751,7 +751,10 @@ func (q *omniQuerySpanExtractor) extractOmniModelSelect(stmt *oracleast.SelectSt
 	var results []base.QuerySpanResult
 	if stmt.ModelClause != nil && stmt.ModelClause.MainModel != nil && stmt.ModelClause.MainModel.ColumnClauses != nil {
 		columns := stmt.ModelClause.MainModel.ColumnClauses
-		for _, list := range []*oracleast.List{columns.DimensionBy, columns.Measures} {
+		for _, list := range []*oracleast.List{columns.PartitionBy, columns.DimensionBy, columns.Measures} {
+			if list == nil {
+				continue
+			}
 			extracted, err := q.extractOmniTargetList(list)
 			if err != nil {
 				return nil, err

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -793,11 +793,52 @@ func (q *omniQuerySpanExtractor) extractOmniMatchRecognize(ref *oracleast.MatchR
 		q.tableSourcesFrom = oldFrom
 	}()
 
-	results, err := q.extractOmniTargetList(ref.Measures)
+	partitionResults, err := q.extractOmniResultList(ref.PartitionBy)
 	if err != nil {
 		return nil, err
 	}
+	measureResults, err := q.extractOmniResultList(ref.Measures)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]base.QuerySpanResult, 0, len(partitionResults)+len(measureResults))
+	results = append(results, partitionResults...)
+	results = append(results, measureResults...)
 	return aliasOmniTableSource(&base.PseudoTable{Columns: results}, ref.Alias), nil
+}
+
+func (q *omniQuerySpanExtractor) extractOmniResultList(list *oracleast.List) ([]base.QuerySpanResult, error) {
+	var results []base.QuerySpanResult
+	for _, node := range listItems(list) {
+		var expr oracleast.ExprNode
+		name := ""
+		switch node := node.(type) {
+		case *oracleast.ResTarget:
+			expr = node.Expr
+			name = node.Name
+		case oracleast.ExprNode:
+			expr = node
+		default:
+			continue
+		}
+		if expr == nil {
+			continue
+		}
+
+		extractedName, sourceColumns, err := q.extractOmniExpr(expr)
+		if err != nil {
+			return nil, err
+		}
+		if name == "" {
+			name = extractedName
+		}
+		results = append(results, base.QuerySpanResult{
+			Name:          name,
+			SourceColumns: sourceColumns,
+			IsPlainField:  false,
+		})
+	}
+	return results, nil
 }
 
 func omniSetLeftSelect(stmt *oracleast.SelectStmt) *oracleast.SelectStmt {

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -467,6 +467,24 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 			},
 		},
 		{
+			name:      "pivot explicit projection",
+			statement: "SELECT A FROM (SELECT A, B FROM T) PIVOT (COUNT(*) AS CNT FOR B IN (1 AS ONE, 2 AS TWO))",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+			},
+		},
+		{
+			name:      "pivot aggregate input is consumed",
+			statement: "SELECT * FROM (SELECT A, B, C FROM T) PIVOT (SUM(C) AS S FOR B IN (1 AS ONE))",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "ONE_S", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "B"},
+					{Database: "PUBLIC", Table: "T", Column: "C"},
+				})},
+			},
+		},
+		{
 			name:      "unpivot typed mappings",
 			statement: "SELECT * FROM (SELECT A, B, C FROM T) UNPIVOT (VAL FOR COL IN (B AS 'B', C AS 'C'))",
 			want: []base.QuerySpanResult{
@@ -479,10 +497,27 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 			},
 		},
 		{
+			name:      "unpivot explicit projection",
+			statement: "SELECT VAL FROM (SELECT A, B, C FROM T) UNPIVOT (VAL FOR COL IN (B AS 'B', C AS 'C'))",
+			want: []base.QuerySpanResult{
+				{Name: "VAL", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "B"},
+					{Database: "PUBLIC", Table: "T", Column: "C"},
+				})},
+			},
+		},
+		{
 			name:      "model dimension and measures",
 			statement: "SELECT * FROM T MODEL DIMENSION BY (A) MEASURES (B) RULES (B[1] = 1)",
 			want: []base.QuerySpanResult{
 				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "B", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+			},
+		},
+		{
+			name:      "model explicit projection",
+			statement: "SELECT B FROM T MODEL DIMENSION BY (A) MEASURES (B) RULES (B[1] = 1)",
+			want: []base.QuerySpanResult{
 				{Name: "B", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
 			},
 		},

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -552,11 +552,44 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 			},
 		},
 		{
+			name: "match recognize pattern variable measures",
+			statement: `SELECT * FROM TRADES MATCH_RECOGNIZE (
+  PARTITION BY ACCOUNT_ID
+  ORDER BY TRADE_TIME
+  MEASURES FIRST(A.PRICE) AS FIRST_PRICE, LAST(B.PRICE) AS LAST_PRICE
+  ONE ROW PER MATCH
+  PATTERN (A B+)
+  DEFINE B AS B.PRICE > A.PRICE
+) MR`,
+			want: []base.QuerySpanResult{
+				{Name: "ACCOUNT_ID", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "ACCOUNT_ID"}})},
+				{Name: "FIRST_PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}})},
+				{Name: "LAST_PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}})},
+			},
+		},
+		{
 			name: "match recognize all rows keeps input columns",
 			statement: `SELECT * FROM TRADES MATCH_RECOGNIZE (
   PARTITION BY ACCOUNT_ID
   ORDER BY TRADE_TIME
   MEASURES FIRST(PRICE) AS FIRST_PRICE
+  ALL ROWS PER MATCH
+  PATTERN (A B+)
+  DEFINE B AS B.PRICE > A.PRICE
+) MR`,
+			want: []base.QuerySpanResult{
+				{Name: "ACCOUNT_ID", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "ACCOUNT_ID"}}), IsPlainField: true},
+				{Name: "TRADE_TIME", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "TRADE_TIME"}}), IsPlainField: true},
+				{Name: "PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}}), IsPlainField: true},
+				{Name: "FIRST_PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}})},
+			},
+		},
+		{
+			name: "match recognize all rows pattern variable measure",
+			statement: `SELECT * FROM TRADES MATCH_RECOGNIZE (
+  PARTITION BY ACCOUNT_ID
+  ORDER BY TRADE_TIME
+  MEASURES FIRST(A.PRICE) AS FIRST_PRICE
   ALL ROWS PER MATCH
   PATTERN (A B+)
   DEFINE B AS B.PRICE > A.PRICE

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -533,6 +533,22 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 			},
 		},
 		{
+			name:      "model partition dimension and measures",
+			statement: "SELECT * FROM T MODEL PARTITION BY (C) DIMENSION BY (A) MEASURES (B) RULES (B[1] = 1)",
+			want: []base.QuerySpanResult{
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "C"}})},
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "B", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+			},
+		},
+		{
+			name:      "model partition explicit projection",
+			statement: "SELECT C FROM T MODEL PARTITION BY (C) DIMENSION BY (A) MEASURES (B) RULES (B[1] = 1)",
+			want: []base.QuerySpanResult{
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "C"}})},
+			},
+		},
+		{
 			name: "match recognize measures",
 			statement: `SELECT * FROM TRADES MATCH_RECOGNIZE (
   PARTITION BY ACCOUNT_ID

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -485,6 +485,17 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 			},
 		},
 		{
+			name:      "pivot aggregate projected alias input is consumed",
+			statement: "SELECT * FROM (SELECT A, B, C AS D FROM T) PIVOT (SUM(D) AS S FOR B IN (1 AS ONE))",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "ONE_S", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "B"},
+					{Database: "PUBLIC", Table: "T", Column: "C"},
+				})},
+			},
+		},
+		{
 			name:      "unpivot typed mappings",
 			statement: "SELECT * FROM (SELECT A, B, C FROM T) UNPIVOT (VAL FOR COL IN (B AS 'B', C AS 'C'))",
 			want: []base.QuerySpanResult{

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -551,6 +551,37 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 				{Name: "ACCOUNT_ID", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "ACCOUNT_ID"}})},
 			},
 		},
+		{
+			name: "match recognize all rows keeps input columns",
+			statement: `SELECT * FROM TRADES MATCH_RECOGNIZE (
+  PARTITION BY ACCOUNT_ID
+  ORDER BY TRADE_TIME
+  MEASURES FIRST(PRICE) AS FIRST_PRICE
+  ALL ROWS PER MATCH
+  PATTERN (A B+)
+  DEFINE B AS B.PRICE > A.PRICE
+) MR`,
+			want: []base.QuerySpanResult{
+				{Name: "ACCOUNT_ID", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "ACCOUNT_ID"}}), IsPlainField: true},
+				{Name: "TRADE_TIME", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "TRADE_TIME"}}), IsPlainField: true},
+				{Name: "PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}}), IsPlainField: true},
+				{Name: "FIRST_PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}})},
+			},
+		},
+		{
+			name: "match recognize all rows input projection",
+			statement: `SELECT PRICE FROM TRADES MATCH_RECOGNIZE (
+  PARTITION BY ACCOUNT_ID
+  ORDER BY TRADE_TIME
+  MEASURES FIRST(PRICE) AS FIRST_PRICE
+  ALL ROWS PER MATCH
+  PATTERN (A B+)
+  DEFINE B AS B.PRICE > A.PRICE
+) MR`,
+			want: []base.QuerySpanResult{
+				{Name: "PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}})},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -443,36 +443,72 @@ func TestOracleOmniResourceNotFoundPropagation(t *testing.T) {
 	}
 }
 
-func TestOracleOmniUnsupportedLongTailTableSources(t *testing.T) {
-	// UNPIVOT and MODEL used to return approximate ANTLR spans that ignored
-	// their transformation semantics. Keep them explicit unsupported until the
-	// omni extractor models their output columns accurately.
+func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 	tests := []struct {
 		name      string
 		statement string
+		want      []base.QuerySpanResult
 	}{
 		{
-			name:      "table collection",
-			statement: "SELECT * FROM TABLE(pkg.values()) X",
+			name:      "table collection column aliases",
+			statement: "SELECT * FROM TABLE(pkg.values()) X(A, B)",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList(nil)},
+				{Name: "B", SourceColumns: sourceColumnSetFromList(nil)},
+			},
 		},
 		{
-			name:      "pivot",
-			statement: "SELECT * FROM (SELECT A, B FROM T) PIVOT (COUNT(*) FOR B IN (1 AS ONE))",
+			name:      "pivot typed output",
+			statement: "SELECT * FROM (SELECT A, B FROM T) PIVOT (COUNT(*) AS CNT FOR B IN (1 AS ONE, 2 AS TWO))",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "ONE_CNT", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+				{Name: "TWO_CNT", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+			},
 		},
 		{
-			name:      "unpivot",
-			statement: "SELECT * FROM (SELECT A, B FROM T) UNPIVOT (VAL FOR COL IN (A AS 'A', B AS 'B'))",
+			name:      "unpivot typed mappings",
+			statement: "SELECT * FROM (SELECT A, B, C FROM T) UNPIVOT (VAL FOR COL IN (B AS 'B', C AS 'C'))",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "VAL", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "B"},
+					{Database: "PUBLIC", Table: "T", Column: "C"},
+				})},
+				{Name: "COL", SourceColumns: sourceColumnSetFromList(nil)},
+			},
 		},
 		{
-			name:      "model",
+			name:      "model dimension and measures",
 			statement: "SELECT * FROM T MODEL DIMENSION BY (A) MEASURES (B) RULES (B[1] = 1)",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "B", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+			},
+		},
+		{
+			name: "match recognize measures",
+			statement: `SELECT * FROM TRADES MATCH_RECOGNIZE (
+  PARTITION BY ACCOUNT_ID
+  ORDER BY TRADE_TIME
+  MEASURES FIRST(PRICE) AS FIRST_PRICE, LAST(PRICE) AS LAST_PRICE
+  ONE ROW PER MATCH
+  PATTERN (A B+)
+  DEFINE B AS B.PRICE > A.PRICE
+) MR`,
+			want: []base.QuerySpanResult{
+				{Name: "FIRST_PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}})},
+				{Name: "LAST_PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}})},
+			},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			_, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(context.Background(), test.statement)
-			require.ErrorContains(t, err, "unsupported oracle table source")
+			span, err := newOmniQuerySpanExtractor("PUBLIC", oracleOmniLongTailTestContext(t)).getOmniQuerySpan(context.Background(), test.statement)
+			require.NoError(t, err)
+			require.NotNil(t, span)
+			require.Equal(t, test.want, span.Results)
 		})
 	}
 }
@@ -498,6 +534,13 @@ func oracleOmniLongTailTestContext(t *testing.T) base.GetQuerySpanContext {
 			"columns": [
 				{"name": "C"},
 				{"name": "D"}
+			]
+		}, {
+			"name": "TRADES",
+			"columns": [
+				{"name": "ACCOUNT_ID"},
+				{"name": "TRADE_TIME"},
+				{"name": "PRICE"}
 			]
 		}]
 	}]

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -532,8 +532,23 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
   DEFINE B AS B.PRICE > A.PRICE
 ) MR`,
 			want: []base.QuerySpanResult{
+				{Name: "ACCOUNT_ID", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "ACCOUNT_ID"}})},
 				{Name: "FIRST_PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}})},
 				{Name: "LAST_PRICE", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "PRICE"}})},
+			},
+		},
+		{
+			name: "match recognize partition projection",
+			statement: `SELECT ACCOUNT_ID FROM TRADES MATCH_RECOGNIZE (
+  PARTITION BY ACCOUNT_ID
+  ORDER BY TRADE_TIME
+  MEASURES FIRST(PRICE) AS FIRST_PRICE
+  ONE ROW PER MATCH
+  PATTERN (A B+)
+  DEFINE B AS B.PRICE > A.PRICE
+) MR`,
+			want: []base.QuerySpanResult{
+				{Name: "ACCOUNT_ID", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "TRADES", Column: "ACCOUNT_ID"}})},
 			},
 		},
 	}

--- a/backend/plugin/parser/plsql/resource_change_test.go
+++ b/backend/plugin/parser/plsql/resource_change_test.go
@@ -138,8 +138,8 @@ func TestExtractChangedResourcesDropIndexUsesMetadata(t *testing.T) {
 }
 
 func TestExtractChangedResourcesSkipsANTLRFallbackAST(t *testing.T) {
-	statement := `UPDATE t1 SET c1 = 5;
-CREATE OR REPLACE TRIGGER trg
+	updateStatement := "UPDATE t1 SET c1 = 5"
+	triggerStatement := `CREATE OR REPLACE TRIGGER trg
 BEFORE INSERT OR UPDATE OF col1, col2 ON tbl
 REFERENCING OLD AS o NEW AS n
 FOR EACH ROW
@@ -147,6 +147,7 @@ WHEN (n.col1 > 0)
 BEGIN
   :n.col2 := :o.col2 + 1;
 END;`
+	statement := updateStatement + ";\n" + triggerStatement
 	changedResources := model.NewChangedResources(nil /* dbMetadata */)
 	changedResources.AddTable("DB", "", &storepb.ChangedResourceTable{Name: "T1"}, false)
 	want := &base.ChangeSummary{
@@ -157,12 +158,17 @@ END;`
 		DMLCount: 1,
 	}
 
-	stmts, err := base.ParseStatements(storepb.Engine_ORACLE, statement)
+	stmts, err := base.ParseStatements(storepb.Engine_ORACLE, updateStatement)
 	require.NoError(t, err)
 	asts := base.ExtractASTs(stmts)
-	require.Len(t, asts, 2)
-	_, ok := asts[1].(*base.ANTLRAST)
+	require.Len(t, asts, 1)
+	_, ok := asts[0].(*OmniAST)
 	require.True(t, ok)
+
+	antlrASTs, err := ParsePLSQL(triggerStatement)
+	require.NoError(t, err)
+	require.Len(t, antlrASTs, 1)
+	asts = append(asts, antlrASTs[0])
 
 	got, err := extractChangedResources("DB", "", nil /* dbMetadata */, asts, statement)
 	require.NoError(t, err)

--- a/backend/plugin/parser/plsql/split.go
+++ b/backend/plugin/parser/plsql/split.go
@@ -1,6 +1,8 @@
 package plsql
 
 import (
+	"strings"
+
 	"github.com/antlr4-go/antlr/v4"
 	oracleparser "github.com/bytebase/omni/oracle/parser"
 	parser "github.com/bytebase/parser/plsql"
@@ -41,24 +43,54 @@ func SplitSQL(statement string) ([]base.Statement, error) {
 
 	result := make([]base.Statement, 0, len(segments))
 	positionMapper := base.NewByteOffsetPositionMapper(statement)
-	for _, seg := range segments {
+	for i := 0; i < len(segments); i++ {
+		seg := segments[i]
 		if seg.Kind == oracleparser.SegmentSQLPlusCommand {
 			continue
 		}
-		byteEnd := seg.ByteStart + trimOracleSegmentTrailingHidden(seg.Text)
-		text := statement[seg.ByteStart:byteEnd]
+		byteStart := seg.ByteStart
+		byteEnd := seg.ByteEnd
+		if end, ok := matchRecognizeDefineMergeEnd(statement, segments, i); ok {
+			byteEnd = end
+			i += 2
+		}
+		byteEnd = byteStart + trimOracleSegmentTrailingHidden(statement[byteStart:byteEnd])
+		text := statement[byteStart:byteEnd]
 		result = append(result, base.Statement{
 			Text:  text,
-			Start: positionMapper.Position(seg.ByteStart),
+			Start: positionMapper.Position(byteStart),
 			End:   positionMapper.Position(byteEnd),
 			Empty: seg.Empty(),
 			Range: &storepb.Range{
-				Start: int32(seg.ByteStart),
+				Start: int32(byteStart),
 				End:   int32(byteEnd),
 			},
 		})
 	}
 	return result, nil
+}
+
+func matchRecognizeDefineMergeEnd(statement string, segments []oracleparser.Segment, index int) (int, bool) {
+	if index+2 >= len(segments) {
+		return 0, false
+	}
+	current := segments[index]
+	define := segments[index+1]
+	suffix := segments[index+2]
+	if current.Kind != oracleparser.SegmentSQL || define.Kind != oracleparser.SegmentSQLPlusCommand || suffix.Kind != oracleparser.SegmentSQL {
+		return 0, false
+	}
+	if !strings.Contains(strings.ToUpper(current.Text), "MATCH_RECOGNIZE") {
+		return 0, false
+	}
+	if !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(define.Text)), "DEFINE ") {
+		return 0, false
+	}
+	merged := statement[current.ByteStart:suffix.ByteEnd]
+	if _, err := oracleparser.Parse(merged); err != nil {
+		return 0, false
+	}
+	return suffix.ByteEnd, true
 }
 
 func trimOracleSegmentTrailingHidden(text string) int {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260601085651-b0170787c27d
+	github.com/bytebase/omni v0.0.0-20260602032407-484791c35e5e
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260601085651-b0170787c27d h1:CvBH5vU+Slc8dvt19IhdHq812Je/fTypbjQjy3D/Fqo=
-github.com/bytebase/omni v0.0.0-20260601085651-b0170787c27d/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260602032407-484791c35e5e h1:mii0c1rt6qKlsFFkdKM4Zrt79FHWsAO+gXqZMpyDi30=
+github.com/bytebase/omni v0.0.0-20260602032407-484791c35e5e/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- upgrade `github.com/bytebase/omni` to `v0.0.0-20260602032407-484791c35e5e`
- wire new Oracle Omni AST nodes into Bytebase query span extraction for `TABLE(collection)`, `PIVOT`, `UNPIVOT`, `MODEL`, and `MATCH_RECOGNIZE`
- keep `MATCH_RECOGNIZE ... DEFINE` statements intact in the Oracle splitter and update migration coverage

## Test Plan
- `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/parser/plsql`
- `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/schema/oracle -run '^(TestGetDatabaseMetadataOmni|TestGetDatabaseMetadataUsesOmni)'`\n- `go test -v -count=1 github.com/bytebase/bytebase/backend/plugin/advisor/oracle -run '^(TestOracleAdvisorUsesOmniWithoutANTLRFallback|TestOracleRules)'`\n- `golangci-lint run --allow-parallel-runners`\n- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`