### PR TITLE
refactor(frontend): decouple React from the app-shell Pinia stores

### DIFF
--- a/frontend/src/plugins/ai/react/context.tsx
+++ b/frontend/src/plugins/ai/react/context.tsx
@@ -12,11 +12,11 @@ import {
 import { useAppDatabaseMetadata } from "@/react/hooks/useAppDatabaseMetadata";
 import { useConnectionOfCurrentSQLEditorTab } from "@/react/hooks/useSQLEditorBridge";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import {
   getCurrentSQLEditorTab,
   useCurrentSQLEditorTab,
 } from "@/react/stores/sqlEditor/tab";
-import { useSettingV1Store } from "@/store";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type { DatabaseMetadata } from "@/types/proto-es/v1/database_service_pb";
 import type { AISetting } from "@/types/proto-es/v1/setting_service_pb";
@@ -95,24 +95,27 @@ const EMPTY_AI_SETTING: AISetting = createProto(AISettingSchema, {});
 export function AIContextProvider({ children }: { children: ReactNode }) {
   // ---- Vue-side state bridged via useVueState ----------------------------
 
-  const settingV1Store = useSettingV1Store();
   // The original Vue ProvideAIContext fetched the AI setting on mount.
   // Mirror that here. `getOrFetchSettingByName` is idempotent; firing it
   // again on remount is cheap.
   useEffect(() => {
-    void settingV1Store.getOrFetchSettingByName(
-      Setting_SettingName.AI,
-      /* silent */ true
-    );
-  }, [settingV1Store]);
+    void useAppStore
+      .getState()
+      .getOrFetchSettingByName(Setting_SettingName.AI, /* silent */ true);
+  }, []);
 
-  const aiSetting = useVueState<AISetting>(() => {
-    const setting = settingV1Store.getSettingByName(Setting_SettingName.AI);
+  // Subscribe to the setting cache so this re-resolves once the AI setting
+  // loads (selector returns the AI value or the stable empty fallback).
+  const settingsByName = useAppStore((s) => s.settingsByName);
+  const aiSetting = useMemo<AISetting>(() => {
+    const setting = useAppStore
+      .getState()
+      .getSettingByName(Setting_SettingName.AI);
     if (setting?.value?.value?.case === "ai") {
       return setting.value.value.value;
     }
     return EMPTY_AI_SETTING;
-  });
+  }, [settingsByName]);
 
   const currentTab = useCurrentSQLEditorTab();
 

--- a/frontend/src/react/components/CreateWorkloadIdentitySheet.tsx
+++ b/frontend/src/react/components/CreateWorkloadIdentitySheet.tsx
@@ -17,7 +17,7 @@ import {
 import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { ensureWorkloadIdentityFullName } from "@/react/stores/app/workloadIdentity";
-import { pushNotification, useActuatorV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import {
   getWorkloadIdentityNameInBinding,
   getWorkloadIdentitySuffix,
@@ -128,7 +128,6 @@ function WorkloadIdentityForm({
   onUpdated,
 }: Omit<CreateWorkloadIdentitySheetProps, "open">) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
   // subscribe to re-render on project cache change
   const projectsByName = useAppStore((s) => s.projectsByName);
   const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
@@ -194,8 +193,8 @@ function WorkloadIdentityForm({
   }, [project]);
 
   const parent = useMemo(
-    () => project ?? actuatorStore.workspaceResourceName,
-    [project, actuatorStore]
+    () => project ?? useAppStore.getState().workspaceResourceName(),
+    [project]
   );
 
   const [providerType, setProviderType] =

--- a/frontend/src/react/components/DashboardFrameShell.test.tsx
+++ b/frontend/src/react/components/DashboardFrameShell.test.tsx
@@ -23,6 +23,16 @@ vi.mock("@/react/stores/app", () => ({
   useAppStore: mocks.useAppStore,
 }));
 
+// The legacy-Pinia bootstrap block reads these from `@/store`.
+vi.mock("@/store", () => ({
+  useEnvironmentV1Store: () => ({
+    fetchEnvironments: mocks.fetchEnvironments,
+  }),
+  useSettingV1Store: () => ({
+    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
+  }),
+}));
+
 vi.mock("./BannersWrapper", () => ({
   BannersWrapper: () => <div data-testid="banners-wrapper" />,
 }));

--- a/frontend/src/react/components/DashboardFrameShell.test.tsx
+++ b/frontend/src/react/components/DashboardFrameShell.test.tsx
@@ -19,15 +19,6 @@ const mocks = vi.hoisted(() => ({
   useAppStore: vi.fn(),
 }));
 
-vi.mock("@/store", () => ({
-  useEnvironmentV1Store: () => ({
-    fetchEnvironments: mocks.fetchEnvironments,
-  }),
-  useSettingV1Store: () => ({
-    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
-  }),
-}));
-
 vi.mock("@/react/stores/app", () => ({
   useAppStore: mocks.useAppStore,
 }));
@@ -57,17 +48,21 @@ beforeEach(async () => {
   mocks.loadWorkspaceProfile.mockResolvedValue(undefined);
   mocks.loadWorkspacePermissionState.mockResolvedValue(undefined);
   mocks.loadSubscription.mockResolvedValue(undefined);
-  mocks.useAppStore.mockImplementation((selector) =>
-    selector({
-      loadCurrentUser: mocks.loadCurrentUser,
-      loadServerInfo: mocks.loadServerInfo,
-      loadWorkspace: mocks.loadWorkspace,
-      loadEnvironmentList: mocks.loadEnvironmentList,
-      loadWorkspaceProfile: mocks.loadWorkspaceProfile,
-      loadWorkspacePermissionState: mocks.loadWorkspacePermissionState,
-      loadSubscription: mocks.loadSubscription,
-    })
-  );
+  const appStoreState = {
+    loadCurrentUser: mocks.loadCurrentUser,
+    loadServerInfo: mocks.loadServerInfo,
+    loadWorkspace: mocks.loadWorkspace,
+    loadEnvironmentList: mocks.loadEnvironmentList,
+    loadWorkspaceProfile: mocks.loadWorkspaceProfile,
+    loadWorkspacePermissionState: mocks.loadWorkspacePermissionState,
+    loadSubscription: mocks.loadSubscription,
+    fetchEnvironments: mocks.fetchEnvironments,
+    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
+  };
+  mocks.useAppStore.mockImplementation((selector) => selector(appStoreState));
+  (
+    mocks.useAppStore as unknown as { getState: () => typeof appStoreState }
+  ).getState = () => appStoreState;
   ({ DashboardFrameShell } = await import("./DashboardFrameShell"));
 });
 

--- a/frontend/src/react/components/DashboardFrameShell.tsx
+++ b/frontend/src/react/components/DashboardFrameShell.tsx
@@ -2,18 +2,21 @@ import { LoaderCircle } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { DashboardFrameShellProps } from "@/react/dashboard-shell";
 import { useEnsureWorkspaceCommonData } from "@/react/hooks/useEnsureWorkspaceCommonData";
-import { useAppStore } from "@/react/stores/app";
+import { useEnvironmentV1Store, useSettingV1Store } from "@/store";
 import { Setting_SettingName } from "@/types/proto-es/v1/setting_service_pb";
 import { BannersWrapper } from "./BannersWrapper";
 
 // Legacy Pinia bootstrap kept alongside the app-store bootstrap because the
-// remaining Vue surfaces still read from these Pinia stores. Once those Vue
-// readers are migrated this block can go away.
+// remaining Vue / shared-util surfaces still read from these Pinia stores
+// (e.g. expr.ts environment options, DashboardSidebar's app-feature profile).
+// The app store is loaded separately by useEnsureWorkspaceCommonData. Once
+// those Pinia readers are migrated this block can go away.
 const loadLegacyDashboardState = () => {
-  const store = useAppStore.getState();
   return Promise.all([
-    store.fetchEnvironments(),
-    store.getOrFetchSettingByName(Setting_SettingName.WORKSPACE_PROFILE),
+    useEnvironmentV1Store().fetchEnvironments(),
+    useSettingV1Store().getOrFetchSettingByName(
+      Setting_SettingName.WORKSPACE_PROFILE
+    ),
   ]);
 };
 

--- a/frontend/src/react/components/DashboardFrameShell.tsx
+++ b/frontend/src/react/components/DashboardFrameShell.tsx
@@ -2,7 +2,7 @@ import { LoaderCircle } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { DashboardFrameShellProps } from "@/react/dashboard-shell";
 import { useEnsureWorkspaceCommonData } from "@/react/hooks/useEnsureWorkspaceCommonData";
-import { useEnvironmentV1Store, useSettingV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import { Setting_SettingName } from "@/types/proto-es/v1/setting_service_pb";
 import { BannersWrapper } from "./BannersWrapper";
 
@@ -10,11 +10,10 @@ import { BannersWrapper } from "./BannersWrapper";
 // remaining Vue surfaces still read from these Pinia stores. Once those Vue
 // readers are migrated this block can go away.
 const loadLegacyDashboardState = () => {
+  const store = useAppStore.getState();
   return Promise.all([
-    useEnvironmentV1Store().fetchEnvironments(),
-    useSettingV1Store().getOrFetchSettingByName(
-      Setting_SettingName.WORKSPACE_PROFILE
-    ),
+    store.fetchEnvironments(),
+    store.getOrFetchSettingByName(Setting_SettingName.WORKSPACE_PROFILE),
   ]);
 };
 

--- a/frontend/src/react/components/DatabaseResourceSelector.test.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.test.tsx
@@ -48,10 +48,6 @@ vi.mock("@/plugins/i18n", () => ({
   t: (key: string) => key,
 }));
 
-vi.mock("@/store", () => ({
-  useEnvironmentV1Store: () => mocks.environmentStore,
-}));
-
 vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: (getter: () => unknown) => getter(),
 }));
@@ -90,6 +86,7 @@ vi.mock("@/react/stores/app", () => {
     getOrFetchDatabaseMetadata: mocks.getOrFetchDatabaseMetadata,
     fetchInstanceList: mocks.fetchInstanceList,
     fetchDatabases: mocks.fetchDatabases,
+    environmentList: mocks.environmentStore.environmentList,
   });
   return {
     useAppStore: Object.assign(

--- a/frontend/src/react/components/DatabaseResourceSelector.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.tsx
@@ -18,9 +18,7 @@ import {
 } from "@/react/components/AdvancedSearch";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { Checkbox } from "@/react/components/ui/checkbox";
-import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
-import { useEnvironmentV1Store } from "@/store";
 import type { DatabaseResource } from "@/types";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
@@ -98,7 +96,6 @@ export function DatabaseResourceSelector({
   const getOrFetchDatabaseMetadata = useAppStore(
     (s) => s.getOrFetchDatabaseMetadata
   );
-  const environmentStore = useEnvironmentV1Store();
 
   const [databases, setDatabases] = useState<Database[]>([]);
   const [searchParams, setSearchParams] = useState<SearchParams>({
@@ -118,9 +115,7 @@ export function DatabaseResourceSelector({
   const [loadingMetadata, setLoadingMetadata] = useState<Set<string>>(
     new Set()
   );
-  const environments = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environments = useAppStore((s) => s.environmentList);
 
   const searchInstances = useCallback(
     async (keyword: string): Promise<ValueOption[]> => {

--- a/frontend/src/react/components/DatabaseSelect.tsx
+++ b/frontend/src/react/components/DatabaseSelect.tsx
@@ -4,7 +4,6 @@ import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { Combobox } from "@/react/components/ui/combobox";
 import { useAppStore } from "@/react/stores/app";
-import { useActuatorV1Store } from "@/store";
 import type { Engine } from "@/types/proto-es/v1/common_pb";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
@@ -38,7 +37,7 @@ export function DatabaseSelect({
   allowedEngineTypeList,
 }: DatabaseSelectProps) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
+  const workspaceResourceName = useAppStore((s) => s.workspaceResourceName());
   const [databases, setDatabases] = useState<Database[]>([]);
 
   // Stabilize engines array to avoid re-fetching on every render
@@ -62,7 +61,7 @@ export function DatabaseSelect({
       useAppStore
         .getState()
         .fetchDatabases({
-          parent: projectName ?? actuatorStore.workspaceResourceName,
+          parent: projectName ?? workspaceResourceName,
           filter: {
             environment: environmentName,
             engines: stableEngines,
@@ -73,7 +72,7 @@ export function DatabaseSelect({
         })
         .then((result) => setDatabases(result.databases));
     },
-    [projectName, environmentName, stableEngines, actuatorStore]
+    [projectName, environmentName, stableEngines, workspaceResourceName]
   );
 
   useEffect(() => {

--- a/frontend/src/react/components/ProjectSidebar.tsx
+++ b/frontend/src/react/components/ProjectSidebar.tsx
@@ -37,7 +37,6 @@ import {
   PROJECT_V1_ROUTE_WORKLOAD_IDENTITIES,
 } from "@/router/dashboard/projectV1";
 import { useRecentVisit } from "@/router/useRecentVisit";
-import { useActuatorV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 
 // ---------------------------------------------------------------------------
@@ -74,13 +73,12 @@ function getItemClass(item: SidebarItem, currentRouteName: string): string[] {
 
 function useSidebarItems(): SidebarItem[] {
   const { t } = useTranslation();
+  const defaultProject = useAppStore((s) => s.serverInfo?.defaultProject ?? "");
 
   const isDefault = useVueState(() => {
     const projectId =
       (router.currentRoute.value.params.projectId as string | undefined) ?? "";
     const projectName = projectId ? `${projectNamePrefix}${projectId}` : "";
-    const defaultProject =
-      useActuatorV1Store().serverInfo?.defaultProject ?? "";
     return !!defaultProject && projectName === defaultProject;
   });
 

--- a/frontend/src/react/components/Quickstart.tsx
+++ b/frontend/src/react/components/Quickstart.tsx
@@ -2,7 +2,6 @@ import { CheckCircle, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { RouteLocationRaw } from "vue-router";
-import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { useNavigate } from "@/react/router";
 import { useAppStore } from "@/react/stores/app";
@@ -15,7 +14,7 @@ import {
   WORKSPACE_ROUTE_USERS,
 } from "@/router/dashboard/workspaceRoutes";
 import { SQL_EDITOR_WORKSHEET_MODULE } from "@/router/sqlEditor";
-import { pushNotification, useActuatorV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import type { Permission } from "@/types";
 import { isValidProjectName, UNKNOWN_PROJECT_NAME } from "@/types";
@@ -62,12 +61,11 @@ interface IntroItem {
 export function Quickstart() {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const actuatorStore = useActuatorV1Store();
   const loadProjectIamPolicy = useAppStore(
     (state) => state.loadProjectIamPolicy
   );
 
-  const quickStartEnabled = useVueState(() => actuatorStore.quickStartEnabled);
+  const quickStartEnabled = useAppStore((s) => s.quickStartEnabled());
   const hidden = useAppStore((s) => s.getIntroStateByKey("hidden"));
 
   // Subscribe to each task's done flag so the line-through + progress

--- a/frontend/src/react/components/RoleSelect.tsx
+++ b/frontend/src/react/components/RoleSelect.tsx
@@ -2,13 +2,11 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { Combobox, type ComboboxGroup } from "@/react/components/ui/combobox";
-import { useVueState } from "@/react/hooks/useVueState";
 import {
   displayRoleDescriptionFromList,
   displayRoleTitleFromList,
 } from "@/react/lib/role";
 import { useAppStore } from "@/react/stores/app";
-import { useSubscriptionV1Store } from "@/store";
 import {
   PRESET_PROJECT_ROLES,
   PRESET_ROLES,
@@ -38,10 +36,9 @@ export function RoleSelect({
   filterRole,
 }: RoleSelectProps) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
   const roleList = useAppStore((state) => state.roleList);
-  const hasCustomRoleFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_CUSTOM_ROLES)
+  const hasCustomRoleFeature = useAppStore((s) =>
+    s.hasInstanceFeature(PlanFeature.FEATURE_CUSTOM_ROLES)
   );
 
   const groups: ComboboxGroup[] = useMemo(() => {

--- a/frontend/src/react/components/auth/InactiveRemindModal.tsx
+++ b/frontend/src/react/components/auth/InactiveRemindModal.tsx
@@ -8,8 +8,8 @@ import {
   DialogTitle,
 } from "@/react/components/ui/dialog";
 import { useCurrentUser } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useAuthStore, useSettingV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { useAuthStore } from "@/store";
 import { storageKeyLastActivity } from "@/utils/storage-keys";
 
 const SHOW_THRESHOLD_MIN = 3;
@@ -17,10 +17,8 @@ const SHOW_THRESHOLD_MIN = 3;
 export function InactiveRemindModal() {
   const { t } = useTranslation();
   const currentUserEmail = useCurrentUser().email;
-  const inactiveTimeoutInSeconds = useVueState(() =>
-    Number(
-      useSettingV1Store().workspaceProfile.inactiveSessionTimeout?.seconds ?? 0
-    )
+  const inactiveTimeoutInSeconds = useAppStore((s) =>
+    Number(s.getWorkspaceProfile().inactiveSessionTimeout?.seconds ?? 0)
   );
 
   const storageKey = storageKeyLastActivity(currentUserEmail);

--- a/frontend/src/react/components/database/CreateDatabaseSheet.test.tsx
+++ b/frontend/src/react/components/database/CreateDatabaseSheet.test.tsx
@@ -120,7 +120,6 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@/store", () => ({
-  useEnvironmentV1Store: () => ({ environmentList: [] }),
   pushNotification: vi.fn(),
 }));
 
@@ -138,6 +137,7 @@ const appStoreState = {
   getOrFetchInstanceByName: mocks.getOrFetchInstanceByName,
   fetchProjectList: vi.fn().mockResolvedValue({ projects: [] }),
   projectsByName: {},
+  environmentList: [],
 };
 vi.mock("@/react/stores/app", () => ({
   useAppStore: Object.assign(

--- a/frontend/src/react/components/database/CreateDatabaseSheet.tsx
+++ b/frontend/src/react/components/database/CreateDatabaseSheet.tsx
@@ -23,7 +23,7 @@ import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { experimentalCreateIssueByPlan } from "@/react/stores/app/issue";
 import { router } from "@/router";
-import { pushNotification, useEnvironmentV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import {
   defaultCharsetOfEngineV1,
   defaultCollationOfEngineV1,
@@ -62,7 +62,6 @@ export function CreateDatabaseSheet({
   const { t } = useTranslation();
   // subscribe to re-render on project cache change
   const projectsByName = useAppStore((s) => s.projectsByName);
-  const environmentStore = useEnvironmentV1Store();
   const currentUser = useCurrentUser();
 
   const [projectName, setProjectName] = useState("");
@@ -85,9 +84,7 @@ export function CreateDatabaseSheet({
   const [selectedInstance, setSelectedInstance] = useState<
     Instance | undefined
   >();
-  const environments = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environments = useAppStore((s) => s.environmentList);
 
   const [selectedProject, setSelectedProject] = useState<
     | {

--- a/frontend/src/react/components/database/DatabaseTable.tsx
+++ b/frontend/src/react/components/database/DatabaseTable.tsx
@@ -4,11 +4,9 @@ import {
   getPageSizeOptions,
   useSessionPageSize,
 } from "@/react/hooks/useSessionPageSize";
-import { useVueState } from "@/react/hooks/useVueState";
 import type { DatabaseFilter } from "@/react/lib/databaseFilter";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import { useActuatorV1Store } from "@/store";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { autoDatabaseRoute } from "@/utils";
 import {
@@ -54,8 +52,6 @@ export function DatabaseTable({
   onDatabasesChange,
   refreshToken,
 }: DatabaseTableProps) {
-  const actuatorStore = useActuatorV1Store();
-
   const [databases, setDatabases] = useState<Database[]>([]);
   const [loading, setLoading] = useState(true);
   const nextPageTokenRef = useRef("");
@@ -67,9 +63,7 @@ export function DatabaseTable({
   const [sort, setSort] = useState<DatabaseTableSort | null>(null);
   const orderBy = sort ? `${sort.key} ${sort.order}` : "";
 
-  const workspaceResourceName = useVueState(
-    () => actuatorStore.workspaceResourceName
-  );
+  const workspaceResourceName = useAppStore((s) => s.workspaceResourceName());
 
   const fetchDatabases = useCallback(
     async (isRefresh: boolean) => {

--- a/frontend/src/react/components/database/TransferProjectSheet.tsx
+++ b/frontend/src/react/components/database/TransferProjectSheet.tsx
@@ -11,8 +11,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useActuatorV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 
 export function TransferProjectSheet({
@@ -27,9 +26,8 @@ export function TransferProjectSheet({
   onTransfer: (projectName: string) => Promise<void>;
 }) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
-  const defaultProjectName = useVueState(
-    () => actuatorStore.serverInfo?.defaultProject ?? ""
+  const defaultProjectName = useAppStore(
+    (s) => s.serverInfo?.defaultProject ?? ""
   );
   const [mode, setMode] = useState<"project" | "unassign">("project");
   const [selectedProject, setSelectedProject] = useState("");

--- a/frontend/src/react/components/instance/DataSourceForm.tsx
+++ b/frontend/src/react/components/instance/DataSourceForm.tsx
@@ -6,8 +6,7 @@ import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useActuatorV1Store, useSubscriptionV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import {
   DataSource_AuthenticationType,
@@ -88,10 +87,8 @@ export function DataSourceForm({
   onOpenInfoPanel,
 }: DataSourceFormProps) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
-  const currentPlan = useVueState(() => subscriptionStore.currentPlan);
-  const actuatorStore = useActuatorV1Store();
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const currentPlan = useAppStore((s) => s.currentPlan());
+  const isSaaSMode = useAppStore((s) => s.isSaaSMode());
   const ctx = useInstanceFormContext();
   const {
     instance,

--- a/frontend/src/react/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/react/components/instance/InstanceFormBody.tsx
@@ -20,14 +20,9 @@ import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
-import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import {
   environmentNamePrefix,
   instanceNamePrefix,
@@ -595,11 +590,13 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
   } = ctx;
   const { isEngineBeta, defaultPort, instanceLink, allowEditPort } = specs;
 
-  const actuatorStore = useActuatorV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
-  const hasUnifiedInstanceLicense = useVueState(
-    () => subscriptionStore.hasUnifiedInstanceLicense
+  const hasUnifiedInstanceLicense = useAppStore((s) =>
+    s.hasUnifiedInstanceLicense()
   );
+  const instanceLicenseCount = useAppStore((s) => s.instanceLicenseCount());
+  const activatedInstanceCount = useAppStore((s) => s.activatedInstanceCount());
+  const currentPlan = useAppStore((s) => s.currentPlan());
+  const isSaaSMode = useAppStore((s) => s.isSaaSMode());
 
   const [isEngineSelectorCollapsed, setIsEngineSelectorCollapsed] =
     useState(false);
@@ -667,24 +664,16 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
   // --- Computed values ---
 
   const availableLicenseCount = useMemo(
-    () =>
-      Math.max(
-        0,
-        subscriptionStore.instanceLicenseCount -
-          actuatorStore.activatedInstanceCount
-      ),
-    [
-      subscriptionStore.instanceLicenseCount,
-      actuatorStore.activatedInstanceCount,
-    ]
+    () => Math.max(0, instanceLicenseCount - activatedInstanceCount),
+    [instanceLicenseCount, activatedInstanceCount]
   );
 
   const availableLicenseCountText = useMemo((): string => {
-    if (subscriptionStore.instanceLicenseCount === Number.MAX_VALUE) {
+    if (instanceLicenseCount === Number.MAX_VALUE) {
       return t("common.unlimited");
     }
     return `${availableLicenseCount}`;
-  }, [subscriptionStore.instanceLicenseCount, availableLicenseCount, t]);
+  }, [instanceLicenseCount, availableLicenseCount, t]);
 
   const resourceId = useMemo(() => {
     const id = extractInstanceResourceName(basicInfo.name);
@@ -969,9 +958,9 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
           .getState()
           .updateInstance(instancePatch, ["activation"]);
         useAppStore.getState().updateDatabaseInstance(updated);
-        await actuatorStore.fetchServerInfo(
-          actuatorStore.workspaceResourceName
-        );
+        await useAppStore
+          .getState()
+          .fetchServerInfo(useAppStore.getState().workspaceResourceName());
         pushNotification({
           module: "bytebase",
           style: "SUCCESS",
@@ -979,7 +968,7 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
         });
       }
     },
-    [instance, actuatorStore, updateBasicInfo, t]
+    [instance, updateBasicInfo, t]
   );
 
   const testConnectionForCurrentEditingDS = useCallback(async () => {
@@ -1151,7 +1140,7 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
             </div>
 
             {/* Activation toggle */}
-            {subscriptionStore.currentPlan !== PlanType.FREE &&
+            {currentPlan !== PlanType.FREE &&
               !hasUnifiedInstanceLicense &&
               allowEdit && (
                 <div className="sm:col-span-2 ml-0 sm:ml-3">
@@ -1614,7 +1603,7 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
                 onOpenInfoPanel={onOpenInfoPanel}
               />
 
-              {actuatorStore.isSaaSMode && (
+              {isSaaSMode && (
                 <Alert variant="info" className="mt-4">
                   <a
                     href="https://docs.bytebase.com/get-started/cloud#prerequisites"

--- a/frontend/src/react/components/instance/InstanceFormButtons.tsx
+++ b/frontend/src/react/components/instance/InstanceFormButtons.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import { pushNotification, useSubscriptionV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
   DataSource,
@@ -53,7 +53,6 @@ export function InstanceFormButtons({
   className,
 }: InstanceFormButtonsProps) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
 
   const context = useInstanceFormContext();
   const {
@@ -81,10 +80,8 @@ export function InstanceFormButtons({
     emitShowConnectionOptions,
   } = context;
 
-  const hasExternalSecretFeature = useMemo(
-    () =>
-      subscriptionStore.hasFeature(PlanFeature.FEATURE_EXTERNAL_SECRET_MANAGER),
-    [subscriptionStore]
+  const hasExternalSecretFeature = useAppStore((s) =>
+    s.hasFeature(PlanFeature.FEATURE_EXTERNAL_SECRET_MANAGER)
   );
   const [connectionFailureDialogState, setConnectionFailureDialogState] =
     useState<ConnectionFailureDialogState>({

--- a/frontend/src/react/components/instance/InstanceFormContext.test.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.test.tsx
@@ -51,28 +51,27 @@ vi.mock("@/types", () => ({
 
 vi.mock("@/store", () => ({
   pushNotification: vi.fn(),
-  useActuatorV1Store: () => ({
-    activatedInstanceCount: 0,
-  }),
-  useEnvironmentV1Store: () => ({
-    getEnvironmentByName: (name: string) => ({ name }),
-  }),
-  useSubscriptionV1Store: () => ({
-    currentPlan: 1,
-    instanceLicenseCount: 1,
-    hasInstanceFeature: () => false,
-  }),
 }));
 
-vi.mock("@/react/stores/app", () => ({
-  useAppStore: Object.assign(() => undefined, {
-    getState: () => ({
-      createDataSource: vi.fn(),
-      createInstance: vi.fn(),
-      updateDataSource: vi.fn(),
-    }),
-  }),
-}));
+vi.mock("@/react/stores/app", () => {
+  const appState = () => ({
+    createDataSource: vi.fn(),
+    createInstance: vi.fn(),
+    updateDataSource: vi.fn(),
+    getEnvironmentByName: (name: string) => ({ name }),
+    hasInstanceFeature: () => false,
+    instanceLicenseCount: () => 1,
+    activatedInstanceCount: () => 0,
+    currentPlan: () => 1,
+    environmentList: [],
+  });
+  return {
+    useAppStore: Object.assign(
+      (selector: (state: unknown) => unknown) => selector(appState()),
+      { getState: appState }
+    ),
+  };
+});
 
 vi.mock("@/utils", () => ({
   calcUpdateMask: () => [],

--- a/frontend/src/react/components/instance/InstanceFormContext.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.tsx
@@ -12,11 +12,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppStore } from "@/react/stores/app";
-import {
-  pushNotification,
-  useEnvironmentV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import { Engine, State } from "@/types/proto-es/v1/common_pb";
 import type {
   DataSource,
@@ -63,7 +59,7 @@ export interface InstanceFormContextValue {
   allowEdit: boolean;
   allowCreate: boolean;
   environment: ReturnType<
-    ReturnType<typeof useEnvironmentV1Store>["getEnvironmentByName"]
+    ReturnType<typeof useAppStore.getState>["getEnvironmentByName"]
   >;
   basicInfo: BasicInfo;
   setBasicInfo: React.Dispatch<React.SetStateAction<BasicInfo>>;
@@ -130,8 +126,7 @@ export function InstanceFormProvider({
   children: ReactNode;
 }) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
-  const environmentStore = useEnvironmentV1Store();
+  const environmentList = useAppStore((s) => s.environmentList);
 
   const [state, setState] = useState<LocalState>(() => ({
     editingDataSourceId: instance?.dataSources.find(
@@ -211,20 +206,21 @@ export function InstanceFormProvider({
 
   const hasReadOnlyDataSource = readonlyDataSourceList.length > 0;
 
-  const hasReadonlyReplicaFeature = useMemo(
-    () =>
-      subscriptionStore.hasInstanceFeature(
-        PlanFeature.FEATURE_INSTANCE_READ_ONLY_CONNECTION,
-        instance
-      ),
-    [subscriptionStore, instance]
+  const hasReadonlyReplicaFeature = useAppStore((s) =>
+    s.hasInstanceFeature(
+      PlanFeature.FEATURE_INSTANCE_READ_ONLY_CONNECTION,
+      instance
+    )
   );
 
   const specs = useInstanceSpecs(basicInfo, adminDataSource, editingDataSource);
 
   const environment = useMemo(
-    () => environmentStore.getEnvironmentByName(basicInfo.environment ?? ""),
-    [environmentStore, basicInfo.environment]
+    () =>
+      useAppStore.getState().getEnvironmentByName(basicInfo.environment ?? ""),
+    // Re-resolve when the environment cache loads (environmentList) or the
+    // selected environment changes.
+    [basicInfo.environment, environmentList]
   );
 
   const checkDataSource = useCallback(

--- a/frontend/src/react/components/instance/common.ts
+++ b/frontend/src/react/components/instance/common.ts
@@ -1,6 +1,6 @@
 import { cloneDeep, first } from "lodash-es";
 import i18n from "@/react/i18n";
-import { useActuatorV1Store, useSubscriptionV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import { UNKNOWN_INSTANCE_NAME, unknownDataSource } from "@/types";
 import { Engine, State } from "@/types/proto-es/v1/common_pb";
 import type {
@@ -76,13 +76,11 @@ export const extractDataSourceEditState = (
 };
 
 export const extractBasicInfo = (instance: Instance | undefined): BasicInfo => {
-  const subscriptionStore = useSubscriptionV1Store();
-  const actuatorStore = useActuatorV1Store();
+  const store = useAppStore.getState();
 
   const availableLicenseCount = Math.max(
     0,
-    subscriptionStore.instanceLicenseCount -
-      actuatorStore.activatedInstanceCount
+    store.instanceLicenseCount() - store.activatedInstanceCount()
   );
 
   return {
@@ -94,8 +92,7 @@ export const extractBasicInfo = (instance: Instance | undefined): BasicInfo => {
     environment: instance?.environment,
     activation: instance
       ? instance.activation
-      : subscriptionStore.currentPlan !== PlanType.FREE &&
-        availableLicenseCount > 0,
+      : store.currentPlan() !== PlanType.FREE && availableLicenseCount > 0,
 
     syncInterval: instance?.syncInterval,
     syncDatabases: instance?.syncDatabases ?? [],

--- a/frontend/src/react/components/sql-review/Panels.tsx
+++ b/frontend/src/react/components/sql-review/Panels.tsx
@@ -12,11 +12,10 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { useEscapeKey } from "@/react/hooks/useEscapeKey";
-import { useVueState } from "@/react/hooks/useVueState";
 import { getRuleKey } from "@/react/lib/sql-review/utils";
 import { useAppStore } from "@/react/stores/app";
 import { useSQLReviewStore } from "@/react/stores/sqlReview";
-import { pushNotification, useEnvironmentV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import {
   environmentNamePrefix,
   projectNamePrefix,
@@ -156,10 +155,9 @@ export function AttachResourcesPanel({
 }: AttachResourcesPanelProps) {
   const { t } = useTranslation();
   const sqlReviewStore = useSQLReviewStore();
-  const envStore = useEnvironmentV1Store();
   const projectsByName = useAppStore((s) => s.projectsByName);
 
-  const environments = useVueState(() => envStore.environmentList ?? []);
+  const environments = useAppStore((s) => s.environmentList) ?? [];
   const projects = useMemo(
     () =>
       Object.values(projectsByName).filter(

--- a/frontend/src/react/lib/sensitive-data/components-utils.ts
+++ b/frontend/src/react/lib/sensitive-data/components-utils.ts
@@ -2,18 +2,18 @@ import { create } from "@bufbuild/protobuf";
 import { uniq } from "lodash-es";
 import type { Factor, Operator } from "@/plugins/cel";
 import { CollectionOperatorList, EqualityOperatorList } from "@/plugins/cel";
-import { useSettingV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import type { Algorithm } from "@/types/proto-es/v1/setting_service_pb";
 import { AlgorithmSchema } from "@/types/proto-es/v1/setting_service_pb";
 import type { ResourceSelectOption } from "@/types/v2-shared";
 import { CEL_ATTRIBUTE_RESOURCE_PROJECT_ID } from "@/utils/cel-attributes";
 
 export const getClassificationLevelOptions = () => {
-  const settingStore = useSettingV1Store();
-  if (settingStore.classification.length === 0) {
+  const classification = useAppStore.getState().classification();
+  if (classification.length === 0) {
     return [];
   }
-  const config = settingStore.classification[0];
+  const config = classification[0];
   if (!config?.levels) {
     return [];
   }

--- a/frontend/src/react/pages/auth/OAuth2ConsentPage.test.tsx
+++ b/frontend/src/react/pages/auth/OAuth2ConsentPage.test.tsx
@@ -57,6 +57,11 @@ mocks.useAppStore.mockImplementation((selector: (state: unknown) => unknown) =>
     switchWorkspace: mocks.switchWorkspace,
   })
 );
+// The consent page also calls `useAppStore.getState().loadServerInfo()` on mount.
+(mocks.useAppStore as unknown as { getState: () => unknown }).getState =
+  () => ({
+    loadServerInfo: vi.fn().mockResolvedValue(undefined),
+  });
 
 vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: mocks.useVueState,

--- a/frontend/src/react/pages/auth/OAuth2ConsentPage.test.tsx
+++ b/frontend/src/react/pages/auth/OAuth2ConsentPage.test.tsx
@@ -10,7 +10,6 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   useVueState: vi.fn<(getter: () => unknown) => unknown>((getter) => getter()),
   useAuthStore: vi.fn(),
-  useActuatorV1Store: vi.fn(),
   useAppStore: vi.fn(),
   useWorkspace: vi.fn(),
   isLoggedIn: { value: true },
@@ -42,21 +41,17 @@ mocks.useAuthStore.mockImplementation(() => ({
     return mocks.isLoggedIn.value;
   },
 }));
-mocks.useActuatorV1Store.mockImplementation(() => ({
-  get isSaaSMode() {
-    return mocks.isSaaSMode.value;
-  },
-}));
 mocks.useWorkspace.mockImplementation(() => mocks.currentWorkspace.value);
 // The OAuth2 consent page selects discrete app-store slices via
 // `useAppStore((state) => state.X)`. Resolve each selector against a
 // mock state that exposes the workspace list (live via getter) plus
-// the action mocks under test.
+// the action mocks under test. `isSaaSMode` is now an app-store method.
 mocks.useAppStore.mockImplementation((selector: (state: unknown) => unknown) =>
   selector({
     get workspaceList() {
       return mocks.workspaceList.value;
     },
+    isSaaSMode: () => mocks.isSaaSMode.value,
     loadWorkspace: mocks.loadWorkspace,
     loadWorkspaceList: mocks.loadWorkspaceList,
     switchWorkspace: mocks.switchWorkspace,
@@ -77,7 +72,6 @@ vi.mock("@/react/stores/app", () => ({
 
 vi.mock("@/store", () => ({
   useAuthStore: mocks.useAuthStore,
-  useActuatorV1Store: mocks.useActuatorV1Store,
 }));
 
 // Test-only Select stub: Base UI's Select renders its popup through a portal,

--- a/frontend/src/react/pages/auth/OAuth2ConsentPage.tsx
+++ b/frontend/src/react/pages/auth/OAuth2ConsentPage.tsx
@@ -15,7 +15,7 @@ import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_SIGNIN_MODULE } from "@/router/auth";
-import { useActuatorV1Store, useAuthStore } from "@/store";
+import { useAuthStore } from "@/store";
 
 const AUTHORIZE_URL = "/api/oauth2/authorize";
 
@@ -31,7 +31,6 @@ export function OAuth2ConsentPage() {
   // which trips the React-hooks-in-callback lint rule (typescript:S6440)
   // despite Pinia memoizing the factory.
   const authStore = useAuthStore();
-  const actuatorStore = useActuatorV1Store();
   const loadWorkspace = useAppStore((state) => state.loadWorkspace);
   const loadWorkspaceList = useAppStore((state) => state.loadWorkspaceList);
   const switchWorkspace = useAppStore((state) => state.switchWorkspace);
@@ -41,7 +40,7 @@ export function OAuth2ConsentPage() {
   // user belongs to at least one workspace; on self-hosted there's a single
   // implicit workspace. We display it so the user can confirm which
   // workspace this OAuth grant will be bound to.
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const isSaaSMode = useAppStore((state) => state.isSaaSMode());
   const currentWorkspace = useWorkspace();
   const workspaceList = useAppStore((state) => state.workspaceList);
 

--- a/frontend/src/react/pages/auth/OAuth2ConsentPage.tsx
+++ b/frontend/src/react/pages/auth/OAuth2ConsentPage.tsx
@@ -76,6 +76,11 @@ export function OAuth2ConsentPage() {
       return;
     }
 
+    // This page renders outside any shell, so the workspace bootstrap hasn't
+    // populated the app store — load server info so `isSaaSMode()` resolves
+    // and the SaaS workspace picker can render.
+    void useAppStore.getState().loadServerInfo();
+
     (async () => {
       try {
         const response = await fetch(

--- a/frontend/src/react/pages/auth/PasswordForgotPage.test.tsx
+++ b/frontend/src/react/pages/auth/PasswordForgotPage.test.tsx
@@ -17,6 +17,7 @@ const mocks = vi.hoisted(() => {
   };
   const appStoreState = {
     serverInfo: { restriction } as { restriction: typeof restriction },
+    loadServerInfo: vi.fn().mockResolvedValue(undefined),
   };
   return {
     restriction,

--- a/frontend/src/react/pages/auth/PasswordForgotPage.test.tsx
+++ b/frontend/src/react/pages/auth/PasswordForgotPage.test.tsx
@@ -15,14 +15,21 @@ const mocks = vi.hoisted(() => {
     passwordResetEnabled: true,
     disallowPasswordSignin: false,
   };
+  const appStoreState = {
+    serverInfo: { restriction } as { restriction: typeof restriction },
+  };
   return {
     restriction,
+    appStoreState,
     useVueState: vi.fn<(getter: () => unknown) => unknown>((getter) =>
       getter()
     ),
-    useActuatorV1Store: vi.fn(() => ({
-      serverInfo: { restriction },
-    })),
+    useAppStore: Object.assign(
+      vi.fn((selector?: (s: typeof appStoreState) => unknown) =>
+        selector ? selector(appStoreState) : appStoreState
+      ),
+      { getState: () => appStoreState }
+    ),
     pushNotification: vi.fn(),
     routerPush: vi.fn(),
     routerReplace: vi.fn(),
@@ -36,8 +43,11 @@ vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: mocks.useVueState,
 }));
 
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: mocks.useAppStore,
+}));
+
 vi.mock("@/store", () => ({
-  useActuatorV1Store: mocks.useActuatorV1Store,
   pushNotification: mocks.pushNotification,
 }));
 

--- a/frontend/src/react/pages/auth/PasswordForgotPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordForgotPage.tsx
@@ -5,10 +5,10 @@ import { authServiceClientConnect } from "@/connect";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_PASSWORD_RESET_MODULE, AUTH_SIGNIN_MODULE } from "@/router/auth";
-import { pushNotification, useActuatorV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { isValidEmail, resolveWorkspaceName } from "@/utils";
 
 export function PasswordForgotPage() {
@@ -16,16 +16,11 @@ export function PasswordForgotPage() {
   const [email, setEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
 
-  const passwordResetEnabled = useVueState(
-    () =>
-      useActuatorV1Store().serverInfo?.restriction?.passwordResetEnabled ??
-      false
-  );
-  const disallowPasswordSignin = useVueState(
-    () =>
-      useActuatorV1Store().serverInfo?.restriction?.disallowPasswordSignin ??
-      false
-  );
+  const serverInfo = useAppStore((state) => state.serverInfo);
+  const passwordResetEnabled =
+    serverInfo?.restriction?.passwordResetEnabled ?? false;
+  const disallowPasswordSignin =
+    serverInfo?.restriction?.disallowPasswordSignin ?? false;
 
   useEffect(() => {
     if (disallowPasswordSignin) {

--- a/frontend/src/react/pages/auth/PasswordForgotPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordForgotPage.tsx
@@ -22,6 +22,13 @@ export function PasswordForgotPage() {
   const disallowPasswordSignin =
     serverInfo?.restriction?.disallowPasswordSignin ?? false;
 
+  // This page renders outside any shell, so the workspace bootstrap hasn't
+  // populated the app store yet — load server info so the password-reset
+  // restriction flags resolve.
+  useEffect(() => {
+    void useAppStore.getState().loadServerInfo();
+  }, []);
+
   useEffect(() => {
     if (disallowPasswordSignin) {
       router.replace({

--- a/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@/react/stores/app", () => {
   const getState = () => ({
     ...mocks.appStoreState,
     updateUser: mocks.updateUser,
+    loadServerInfo: vi.fn().mockResolvedValue(undefined),
   });
   return {
     useAppStore: Object.assign(

--- a/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
@@ -9,14 +9,14 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   useVueState: vi.fn<(getter: () => unknown) => unknown>((getter) => getter()),
-  useActuatorV1Store: vi.fn(() => ({
+  appStoreState: {
     serverInfo: {
       restriction: {
-        passwordRestriction: undefined,
+        passwordRestriction: undefined as unknown,
         disallowPasswordSignin: false,
       },
     },
-  })),
+  },
   useAuthStore: vi.fn(() => ({
     requireResetPassword: false,
     setRequireResetPassword: vi.fn(),
@@ -43,24 +43,23 @@ vi.mock("@/react/hooks/useAppState", () => ({
 }));
 
 vi.mock("@/store", () => ({
-  useActuatorV1Store: mocks.useActuatorV1Store,
   useAuthStore: mocks.useAuthStore,
   pushNotification: mocks.pushNotification,
 }));
 
-vi.mock("@/react/stores/app", () => ({
-  useAppStore: Object.assign(
-    (selector: (state: unknown) => unknown) =>
-      selector({
-        updateUser: mocks.updateUser,
-      }),
-    {
-      getState: () => ({
-        updateUser: mocks.updateUser,
-      }),
-    }
-  ),
-}));
+vi.mock("@/react/stores/app", () => {
+  const getState = () => ({
+    ...mocks.appStoreState,
+    updateUser: mocks.updateUser,
+  });
+  return {
+    useAppStore: Object.assign(
+      (selector?: (state: ReturnType<typeof getState>) => unknown) =>
+        selector ? selector(getState()) : getState(),
+      { getState }
+    ),
+  };
+});
 
 vi.mock("@/router", () => ({
   router: {
@@ -168,14 +167,12 @@ const setInputValue = (input: HTMLInputElement, value: string) => {
 beforeEach(async () => {
   vi.clearAllMocks();
   mocks.currentRoute.value.query = {};
-  mocks.useActuatorV1Store.mockReturnValue({
-    serverInfo: {
-      restriction: {
-        passwordRestriction: undefined,
-        disallowPasswordSignin: false,
-      },
+  mocks.appStoreState.serverInfo = {
+    restriction: {
+      passwordRestriction: undefined,
+      disallowPasswordSignin: false,
     },
-  });
+  };
   mocks.useAuthStore.mockReturnValue({
     requireResetPassword: true,
     setRequireResetPassword: vi.fn(),
@@ -199,14 +196,12 @@ describe("PasswordResetPage", () => {
 
   test("code mode: redirects to signin when password signin is disallowed", () => {
     mocks.currentRoute.value.query = { email: "u@e.com" };
-    mocks.useActuatorV1Store.mockReturnValue({
-      serverInfo: {
-        restriction: {
-          passwordRestriction: undefined,
-          disallowPasswordSignin: true,
-        },
+    mocks.appStoreState.serverInfo = {
+      restriction: {
+        passwordRestriction: undefined,
+        disallowPasswordSignin: true,
       },
-    });
+    };
     const { render, unmount } = renderIntoContainer(<PasswordResetPage />);
     render();
     expect(mocks.routerReplace).toHaveBeenCalledWith({

--- a/frontend/src/react/pages/auth/PasswordResetPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.tsx
@@ -14,7 +14,7 @@ import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_SIGNIN_MODULE } from "@/router/auth";
-import { pushNotification, useActuatorV1Store, useAuthStore } from "@/store";
+import { pushNotification, useAuthStore } from "@/store";
 import {
   LoginRequestSchema,
   ResetPasswordRequestSchema,
@@ -34,14 +34,10 @@ export function PasswordResetPage() {
   const query = router.currentRoute.value.query;
   const codeMode = !!query.email;
 
-  const passwordRestriction = useVueState(
-    () => useActuatorV1Store().serverInfo?.restriction?.passwordRestriction
-  );
-  const disallowPasswordSignin = useVueState(
-    () =>
-      useActuatorV1Store().serverInfo?.restriction?.disallowPasswordSignin ??
-      false
-  );
+  const serverInfo = useAppStore((state) => state.serverInfo);
+  const passwordRestriction = serverInfo?.restriction?.passwordRestriction;
+  const disallowPasswordSignin =
+    serverInfo?.restriction?.disallowPasswordSignin ?? false;
   const requireResetPassword = useVueState(
     () => useAuthStore().requireResetPassword
   );

--- a/frontend/src/react/pages/auth/PasswordResetPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.tsx
@@ -43,6 +43,13 @@ export function PasswordResetPage() {
   );
   const currentUser = useCurrentUser();
 
+  // This page renders outside any shell, so the workspace bootstrap hasn't
+  // populated the app store yet — load server info so the password policy
+  // checks resolve.
+  useEffect(() => {
+    void useAppStore.getState().loadServerInfo();
+  }, []);
+
   const redirectQuery = () => {
     const q = new URLSearchParams(window.location.search);
     return q.get("redirect") || "/";

--- a/frontend/src/react/pages/auth/SetupPage.test.tsx
+++ b/frontend/src/react/pages/auth/SetupPage.test.tsx
@@ -34,32 +34,27 @@ vi.mock("@/router/sqlEditor", () => ({
 }));
 
 vi.mock("@/store", () => ({
-  useActuatorV1Store: () => ({
-    enableOnboarding: true,
-    setupSample: mocks.setupSample,
-  }),
   useAppFeature: () => ({ value: 0 }),
-  useSettingV1Store: () => ({
-    updateWorkspaceProfile: mocks.updateWorkspaceProfile,
-  }),
 }));
 
-vi.mock("@/react/stores/app", () => ({
-  useAppStore: Object.assign(
-    (selector: (state: unknown) => unknown) =>
-      selector({
-        listRoles: mocks.listRoles,
-      }),
-    {
-      getState: () => ({
-        listRoles: mocks.listRoles,
-        fetchWorkspaceIamPolicy: mocks.fetchIamPolicy,
-        getOrFetchProjectByName: mocks.getOrFetchProjectByName,
-        createProject: mocks.createProject,
-      }),
-    }
-  ),
-}));
+vi.mock("@/react/stores/app", () => {
+  const state = {
+    enableOnboarding: () => true,
+    listRoles: mocks.listRoles,
+    fetchWorkspaceIamPolicy: mocks.fetchIamPolicy,
+    getOrFetchProjectByName: mocks.getOrFetchProjectByName,
+    createProject: mocks.createProject,
+    setupSample: mocks.setupSample,
+    updateWorkspaceProfile: mocks.updateWorkspaceProfile,
+  };
+  return {
+    useAppStore: Object.assign(
+      (selector?: (s: typeof state) => unknown) =>
+        selector ? selector(state) : state,
+      { getState: () => state }
+    ),
+  };
+});
 
 vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: mocks.useVueState,

--- a/frontend/src/react/pages/auth/SetupPage.tsx
+++ b/frontend/src/react/pages/auth/SetupPage.tsx
@@ -49,6 +49,10 @@ export function SetupPage() {
       await router.isReady();
       try {
         await Promise.all([
+          // Force-refresh server info so `enableOnboarding()` reflects the
+          // post-signup active-user count. This page renders outside any
+          // shell, so useEnsureWorkspaceCommonData hasn't run.
+          useAppStore.getState().fetchServerInfo(),
           useAppStore.getState().listRoles(),
           useAppStore.getState().fetchWorkspaceIamPolicy(),
         ]);

--- a/frontend/src/react/pages/auth/SetupPage.tsx
+++ b/frontend/src/react/pages/auth/SetupPage.tsx
@@ -17,7 +17,7 @@ import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { SQL_EDITOR_HOME_MODULE } from "@/router/sqlEditor";
-import { useActuatorV1Store, useAppFeature, useSettingV1Store } from "@/store";
+import { useAppFeature } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { DatabaseChangeMode } from "@/types/proto-es/v1/setting_service_pb";
 import { extractGrpcErrorMessage, getErrorCode } from "@/utils/connect";
@@ -94,9 +94,7 @@ function SetupWizard() {
   const resourceFieldRef = useRef<ResourceIdFieldRef>(null);
   const [resourceValid, setResourceValid] = useState(false);
 
-  const enableOnboarding = useVueState(
-    () => useActuatorV1Store().enableOnboarding
-  );
+  const enableOnboarding = useAppStore((s) => s.enableOnboarding());
   const databaseChangeMode = useVueState(
     () => useAppFeature("bb.feature.database-change-mode").value
   );
@@ -140,9 +138,9 @@ function SetupWizard() {
       if (data === "self-setup") {
         await useAppStore.getState().createProject(projectTitle, resourceId);
       } else {
-        await useActuatorV1Store().setupSample();
+        await useAppStore.getState().setupSample();
       }
-      await useSettingV1Store().updateWorkspaceProfile({
+      await useAppStore.getState().updateWorkspaceProfile({
         payload: { databaseChangeMode: mode },
         updateMask: create(FieldMaskSchema, {
           paths: ["value.workspace_profile.database_change_mode"],

--- a/frontend/src/react/pages/auth/SigninPage.test.tsx
+++ b/frontend/src/react/pages/auth/SigninPage.test.tsx
@@ -39,25 +39,23 @@ vi.mock("@/router/auth", () => ({
 
 vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
-  useActuatorV1Store: () => mocks.actuatorStore,
   useAuthStore: () => mocks.authStore,
 }));
 
-vi.mock("@/react/stores/app", () => ({
-  useAppStore: Object.assign(
-    (selector: (state: unknown) => unknown) =>
-      selector({
-        identityProviderList: () => mocks.identityProviderList,
-        listIdentityProviders: mocks.listIdentityProviders,
-      }),
-    {
-      getState: () => ({
-        identityProviderList: () => mocks.identityProviderList,
-        listIdentityProviders: mocks.listIdentityProviders,
-      }),
-    }
-  ),
-}));
+vi.mock("@/react/stores/app", () => {
+  const getState = () => ({
+    ...(mocks.actuatorStore as Record<string, unknown>),
+    identityProviderList: () => mocks.identityProviderList,
+    listIdentityProviders: mocks.listIdentityProviders,
+  });
+  return {
+    useAppStore: Object.assign(
+      (selector?: (state: ReturnType<typeof getState>) => unknown) =>
+        selector ? selector(getState()) : getState(),
+      { getState }
+    ),
+  };
+});
 
 vi.mock("@/utils", () => ({
   openWindowForSSO: mocks.openWindowForSSO,
@@ -115,8 +113,8 @@ beforeEach(async () => {
         disallowSignup: false,
       },
     },
-    isSaaSMode: false,
-    activeUserCount: 1,
+    isSaaSMode: () => false,
+    activeUserCount: () => 1,
     fetchServerInfo: vi.fn(async () => ({})),
   };
   mocks.identityProviderList = [

--- a/frontend/src/react/pages/auth/SigninPage.tsx
+++ b/frontend/src/react/pages/auth/SigninPage.tsx
@@ -13,11 +13,10 @@ import {
   TabsTrigger,
 } from "@/react/components/ui/tabs";
 import { useIdentityProviderList } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_SIGNUP_MODULE } from "@/router/auth";
-import { pushNotification, useActuatorV1Store, useAuthStore } from "@/store";
+import { pushNotification, useAuthStore } from "@/store";
 import { idpNamePrefix } from "@/store/modules/v1/common";
 import type { LoginRequest } from "@/types/proto-es/v1/auth_service_pb";
 import type { IdentityProvider } from "@/types/proto-es/v1/idp_service_pb";
@@ -44,11 +43,9 @@ export function SigninPage(props: SigninPageProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [initialized, setInitialized] = useState(false);
 
-  const serverInfo = useVueState(() => useActuatorV1Store().serverInfo);
-  const isSaaSMode = useVueState(() => useActuatorV1Store().isSaaSMode);
-  const activeUserCount = useVueState(
-    () => useActuatorV1Store().activeUserCount
-  );
+  const serverInfo = useAppStore((s) => s.serverInfo);
+  const isSaaSMode = useAppStore((s) => s.isSaaSMode());
+  const activeUserCount = useAppStore((s) => s.activeUserCount());
   const identityProviders = useIdentityProviderList();
 
   const query = router.currentRoute.value.query;
@@ -122,11 +119,10 @@ export function SigninPage(props: SigninPageProps) {
       const workspaceName = resolveWorkspaceName();
       const listIdentityProviders =
         useAppStore.getState().listIdentityProviders;
-      const actuatorStore = useActuatorV1Store();
       try {
         const [idpList] = await Promise.all([
           listIdentityProviders(workspaceName),
-          actuatorStore.fetchServerInfo(workspaceName),
+          useAppStore.getState().fetchServerInfo(workspaceName),
         ]);
         if (idpList.length === 0 && workspaceName) {
           await listIdentityProviders();

--- a/frontend/src/react/pages/auth/SignupPage.tsx
+++ b/frontend/src/react/pages/auth/SignupPage.tsx
@@ -26,6 +26,13 @@ export function SignupPage() {
   const serverInfo = useAppStore((s) => s.serverInfo);
   const needAdminSetup = activeUserCount === 0;
 
+  // This page renders outside any shell, so the workspace bootstrap hasn't
+  // populated the app store yet — load server info so the active-user count
+  // and signup restriction flags resolve.
+  useEffect(() => {
+    void useAppStore.getState().loadServerInfo();
+  }, []);
+
   const [acceptTermsAndPolicy, setAcceptTermsAndPolicy] = useState(
     !needAdminSetup
   );

--- a/frontend/src/react/pages/auth/SignupPage.tsx
+++ b/frontend/src/react/pages/auth/SignupPage.tsx
@@ -7,10 +7,10 @@ import { BytebaseLogo } from "@/react/components/BytebaseLogo";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
-import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { AUTH_SIGNIN_MODULE } from "@/router/auth";
-import { useActuatorV1Store, useAuthStore } from "@/store";
+import { useAuthStore } from "@/store";
 import { isValidEmail } from "@/utils";
 
 export function SignupPage() {
@@ -22,10 +22,8 @@ export function SignupPage() {
   const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const activeUserCount = useVueState(
-    () => useActuatorV1Store().activeUserCount
-  );
-  const serverInfo = useVueState(() => useActuatorV1Store().serverInfo);
+  const activeUserCount = useAppStore((s) => s.activeUserCount());
+  const serverInfo = useAppStore((s) => s.serverInfo);
   const needAdminSetup = activeUserCount === 0;
 
   const [acceptTermsAndPolicy, setAcceptTermsAndPolicy] = useState(

--- a/frontend/src/react/pages/project/ProjectDatabasesPage.tsx
+++ b/frontend/src/react/pages/project/ProjectDatabasesPage.tsx
@@ -29,11 +29,7 @@ import { useVueState } from "@/react/hooks/useVueState";
 import type { DatabaseFilter } from "@/react/lib/databaseFilter";
 import { preCreateIssue } from "@/react/lib/plan/issue";
 import { useAppStore } from "@/react/stores/app";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useEnvironmentV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import {
   environmentNamePrefix,
   instanceNamePrefix,
@@ -71,8 +67,6 @@ export function ProjectDatabasesPage({ projectId }: { projectId: string }) {
     (s) => s.removeDatabaseMetadataCache
   );
   const databasesByName = useAppStore((s) => s.databasesByName);
-  const actuatorStore = useActuatorV1Store();
-  const environmentStore = useEnvironmentV1Store();
 
   const projectName = `${projectNamePrefix}${projectId}`;
   // subscribe to re-render on project cache change
@@ -108,9 +102,7 @@ export function ProjectDatabasesPage({ projectId }: { projectId: string }) {
     setRefreshToken((prev) => prev + 1);
   }, [projectId]);
 
-  const environments = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environments = useAppStore((s) => s.environmentList);
 
   const searchInstances = useCallback(
     async (keyword: string): Promise<ValueOption[]> => {
@@ -359,7 +351,8 @@ export function ProjectDatabasesPage({ projectId }: { projectId: string }) {
   );
 
   const handleUnassign = useCallback(async () => {
-    const defaultProject = actuatorStore.serverInfo?.defaultProject ?? "";
+    const defaultProject =
+      useAppStore.getState().serverInfo?.defaultProject ?? "";
     try {
       await useAppStore.getState().batchUpdateDatabases(
         create(BatchUpdateDatabasesRequestSchema, {
@@ -388,7 +381,7 @@ export function ProjectDatabasesPage({ projectId }: { projectId: string }) {
         title: t("common.failed"),
       });
     }
-  }, [actuatorStore, refresh, t]);
+  }, [refresh, t]);
 
   const handleChangeDatabase = useCallback(() => {
     preCreateIssue(projectName, selectedDatabaseNames);

--- a/frontend/src/react/pages/project/ProjectGitOpsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectGitOpsPage.tsx
@@ -20,7 +20,6 @@ import { useAppStore } from "@/react/stores/app";
 import { extractWorkloadIdentityId } from "@/react/stores/app/workloadIdentity";
 import { router } from "@/router";
 import { SETTING_ROUTE_WORKSPACE_GENERAL } from "@/router/dashboard/workspaceSetting";
-import { useActuatorV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { DatabaseGroupView } from "@/types/proto-es/v1/database_group_service_pb";
 import type { WorkloadIdentity } from "@/types/proto-es/v1/workload_identity_service_pb";
@@ -36,7 +35,7 @@ import {
 
 export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
+  const serverInfo = useAppStore((s) => s.serverInfo);
   const projectsByName = useAppStore((s) => s.projectsByName);
   const listWorkloadIdentities = useAppStore(
     (state) => state.listWorkloadIdentities
@@ -198,8 +197,9 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
 
   const branch = parsedSubject?.branch || "main";
 
-  const bytebaseUrl = useVueState(() =>
-    (actuatorStore.serverInfo?.externalUrl ?? "").replace(/\/$/, "")
+  const bytebaseUrl = useMemo(
+    () => (serverInfo?.externalUrl ?? "").replace(/\/$/, ""),
+    [serverInfo]
   );
 
   const workloadIdentityEmail = selectedIdentityName

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionCreatePage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionCreatePage.tsx
@@ -26,7 +26,7 @@ import { rewriteResourceDatabase } from "@/react/lib/sensitive-data/exemptionDat
 import { getExpressionsForDatabaseResource } from "@/react/lib/sensitive-data/utils";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import { hasFeature, pushNotification, useSettingV1Store } from "@/store";
+import { hasFeature, pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import type { DatabaseResource } from "@/types";
 import { ExprSchema } from "@/types/proto-es/google/type/expr_pb";
@@ -60,7 +60,6 @@ export function ProjectMaskingExemptionCreatePage({
 }) {
   const { t } = useTranslation();
   const projectsByName = useAppStore((s) => s.projectsByName);
-  const settingStore = useSettingV1Store();
 
   const projectName = `${projectNamePrefix}${projectId}`;
   // subscribe to re-render on project cache change
@@ -71,11 +70,10 @@ export function ProjectMaskingExemptionCreatePage({
 
   // Ensure classification config is loaded
   useEffect(() => {
-    settingStore.getOrFetchSettingByName(
-      Setting_SettingName.DATA_CLASSIFICATION,
-      true
-    );
-  }, [settingStore]);
+    useAppStore
+      .getState()
+      .getOrFetchSettingByName(Setting_SettingName.DATA_CLASSIFICATION, true);
+  }, []);
 
   const hasRequiredFeature = useVueState(() =>
     hasFeature(PlanFeature.FEATURE_DATA_MASKING)

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionCreatePage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionCreatePage.tsx
@@ -138,6 +138,9 @@ export function ProjectMaskingExemptionCreatePage({
     []
   );
 
+  // Subscribe so the classification options recompute when DATA_CLASSIFICATION
+  // loads (getClassificationLevelOptions reads the app store imperatively).
+  const settingsByName = useAppStore((s) => s.settingsByName);
   const factorOptionConfigMap = useMemo((): Map<Factor, OptionConfig> => {
     return factorList.reduce((map, factor) => {
       if (factor === CEL_ATTRIBUTE_RESOURCE_DATABASE) {
@@ -151,7 +154,7 @@ export function ProjectMaskingExemptionCreatePage({
       }
       return map;
     }, new Map<Factor, OptionConfig>());
-  }, [factorList, projectName]);
+  }, [factorList, projectName, settingsByName]);
 
   const onRadioChange = useCallback(
     (value: RadioValue) => {

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
@@ -48,12 +48,7 @@ import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_MASKING_EXEMPTION_CREATE } from "@/router/dashboard/projectV1";
-import {
-  extractUserEmail,
-  hasFeature,
-  pushNotification,
-  useSettingV1Store,
-} from "@/store";
+import { extractUserEmail, hasFeature, pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import type { DatabaseResource } from "@/types";
 import {
@@ -594,18 +589,16 @@ function rebuildExemptions(accessList: AccessUser[]) {
 
 function useExemptionDataReact(projectName: string) {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
   const batchGetOrFetchGroups = useAppStore(
     (state) => state.batchGetOrFetchGroups
   );
 
   // Ensure classification config is loaded
   useEffect(() => {
-    settingStore.getOrFetchSettingByName(
-      Setting_SettingName.DATA_CLASSIFICATION,
-      true
-    );
-  }, [settingStore]);
+    useAppStore
+      .getState()
+      .getOrFetchSettingByName(Setting_SettingName.DATA_CLASSIFICATION, true);
+  }, []);
 
   const [rawAccessList, setRawAccessList] = useState<AccessUser[]>([]);
   const [loading, setLoading] = useState(true);
@@ -1358,14 +1351,15 @@ function LevelBadge({
   noLimit?: boolean;
 }) {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
+  const settingsByName = useAppStore((s) => s.settingsByName);
 
-  const levelTitle = useVueState(() => {
+  const levelTitle = useMemo(() => {
     if (level === undefined) return undefined;
-    const config = settingStore.classification[0];
+    void settingsByName;
+    const config = useAppStore.getState().classification()[0];
     return config?.levels?.find((l: { level: number }) => l.level === level)
       ?.title;
-  });
+  }, [level, settingsByName]);
 
   const label = useMemo(() => {
     if (noLimit || level === undefined)

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -59,7 +59,7 @@ import {
   PROJECT_V1_ROUTE_PLAN_DETAIL,
   PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
 } from "@/router/dashboard/projectV1";
-import { pushNotification, useEnvironmentV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import {
   formatEnvironmentName,
@@ -392,7 +392,6 @@ interface PlanRowContext {
   approvalTag: { label: string; variant: ReviewBadge["variant"] } | undefined;
   isDeleted: boolean;
   showDraftTag: boolean;
-  environmentStore: ReturnType<typeof useEnvironmentV1Store>;
 }
 
 function getRolloutStageStatus(summary: Plan_RolloutStageSummary): Task_Status {
@@ -406,6 +405,8 @@ function getRolloutStageStatus(summary: Plan_RolloutStageSummary): Task_Status {
 
 function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
   const { t } = useTranslation();
+  // Subscribe so stage cells re-render when the environment cache loads.
+  void useAppStore((s) => s.environmentList);
 
   const columns = useMemo<PlanColumn[]>(
     () => [
@@ -472,7 +473,7 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
         defaultWidth: 260,
         minWidth: 140,
         resizable: true,
-        render: (plan, ctx) =>
+        render: (plan, _ctx) =>
           plan.rolloutStageSummaries.length === 0 ? (
             <span className="text-control-light">-</span>
           ) : (
@@ -481,8 +482,9 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
                 const envName = formatEnvironmentName(
                   extractStageUID(summary.stage)
                 );
-                const environment =
-                  ctx.environmentStore.getEnvironmentByName(envName);
+                const environment = useAppStore
+                  .getState()
+                  .getEnvironmentByName(envName);
                 const stageStatus = getRolloutStageStatus(summary);
                 return (
                   <div key={summary.stage} className="flex items-center gap-1">
@@ -572,7 +574,6 @@ function PlanRow({
   projectId: string;
   columns: PlanColumn[];
 }>) {
-  const environmentStore = useEnvironmentV1Store();
   const { t } = useTranslation();
 
   const isDeleted = plan.state === State.DELETED;
@@ -635,7 +636,6 @@ function PlanRow({
     approvalTag,
     isDeleted,
     showDraftTag,
-    environmentStore,
   };
 
   return (

--- a/frontend/src/react/pages/project/ProjectSettingsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSettingsPage.tsx
@@ -27,7 +27,7 @@ import {
   WORKSPACE_ROUTE_SQL_REVIEW_CREATE,
   WORKSPACE_ROUTE_SQL_REVIEW_DETAIL,
 } from "@/router/dashboard/workspaceRoutes";
-import { pushNotification, useSubscriptionV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import type { Permission, SQLReviewPolicy } from "@/types";
 import { isDefaultProject } from "@/types";
@@ -128,7 +128,6 @@ export function ProjectSettingsPage() {
   const { t } = useTranslation();
   const projectsByName = useAppStore((s) => s.projectsByName);
   const reviewStore = useSQLReviewStore();
-  const subscriptionStore = useSubscriptionV1Store();
 
   const projectId = useVueState(
     () => router.currentRoute.value.params.projectId as string
@@ -202,8 +201,8 @@ export function ProjectSettingsPage() {
     project?.allowJustInTimeAccess ?? false
   );
 
-  const hasQueryPolicyFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_QUERY_POLICY)
+  const hasQueryPolicyFeature = useAppStore((s) =>
+    s.hasInstanceFeature(PlanFeature.FEATURE_QUERY_POLICY)
   );
 
   // -----------------------------------------------------------------------

--- a/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
@@ -51,7 +51,7 @@ import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL } from "@/router/dashboard/projectV1";
-import { pushNotification, useEnvironmentV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import {
   getDateForPbTimestampProtoEs,
@@ -1171,7 +1171,7 @@ function SelectTargetDatabasesView({
   const getOrFetchChangelogByName = useAppStore(
     (state) => state.getOrFetchChangelogByName
   );
-  const environmentStore = useEnvironmentV1Store();
+  const environmentList = useAppStore((s) => s.environmentList);
   const [isLoadingDiff, setIsLoadingDiff] = useState(false);
 
   // Refs for values read inside the diff-fetching effect without triggering re-runs
@@ -1237,13 +1237,13 @@ function SelectTargetDatabasesView({
       (db) => db.name === selectedDatabaseName
     );
     if (!database) return "";
-    const environment = environmentStore.getEnvironmentByName(
-      database.effectiveEnvironment ?? ""
-    );
+    const environment = useAppStore
+      .getState()
+      .getEnvironmentByName(database.effectiveEnvironment ?? "");
     return t("database.sync-schema.schema-change-preview", {
       database: `${extractDatabaseResourceName(database.name).databaseName} (${environment?.title} - ${getInstanceResource(database).title})`,
     });
-  }, [selectedDatabaseName, targetDatabaseList, t]);
+  }, [selectedDatabaseName, targetDatabaseList, environmentList, t]);
 
   const databaseListWithDiff = useMemo(
     () =>

--- a/frontend/src/react/pages/project/ProjectWebhookForm.tsx
+++ b/frontend/src/react/pages/project/ProjectWebhookForm.tsx
@@ -19,7 +19,6 @@ import {
 import { Input } from "@/react/components/ui/input";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { WebhookTypeIcon } from "@/react/components/WebhookTypeIcon";
-import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import {
@@ -28,11 +27,7 @@ import {
 } from "@/router/dashboard/projectV1";
 import { WORKSPACE_ROUTE_IM } from "@/router/dashboard/workspaceRoutes";
 import { SETTING_ROUTE_WORKSPACE_GENERAL } from "@/router/dashboard/workspaceSetting";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useSettingV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import {
   projectWebhookV1ActivityItemList,
   projectWebhookV1TypeItemList,
@@ -60,8 +55,6 @@ export function ProjectWebhookForm({
   webhook,
 }: Props) {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
-  const actuatorStore = useActuatorV1Store();
   const createProjectWebhook = useAppStore(
     (state) => state.createProjectWebhook
   );
@@ -86,12 +79,10 @@ export function ProjectWebhookForm({
 
   // Fetch IM setting on mount
   useEffect(() => {
-    settingStore.getOrFetchSettingByName(Setting_SettingName.APP_IM);
-  }, [settingStore]);
+    useAppStore.getState().getOrFetchSettingByName(Setting_SettingName.APP_IM);
+  }, []);
 
-  const externalUrl = useVueState(
-    () => actuatorStore.serverInfo?.externalUrl ?? ""
-  );
+  const externalUrl = useAppStore((s) => s.externalUrl());
 
   const webhookTypeItemList = useMemo(() => projectWebhookV1TypeItemList(), []);
   const webhookActivityItemList = useMemo(
@@ -104,13 +95,16 @@ export function ProjectWebhookForm({
     [webhookTypeItemList, state.type]
   );
 
-  const imSetting = useVueState(() => {
-    const setting = settingStore.getSettingByName(Setting_SettingName.APP_IM);
+  const settingsByName = useAppStore((s) => s.settingsByName);
+  const imSetting = useMemo(() => {
+    const setting = useAppStore
+      .getState()
+      .getSettingByName(Setting_SettingName.APP_IM);
     if (!setting?.value?.value) return undefined;
     const value = setting.value.value;
     if (value.case === "appIm") return value.value;
     return undefined;
-  });
+  }, [settingsByName]);
 
   const imApp = useMemo(() => {
     if (!selectedWebhook?.supportDirectMessage) return undefined;

--- a/frontend/src/react/pages/project/database-detail/catalog/GrantAccessDialog.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/catalog/GrantAccessDialog.test.tsx
@@ -197,12 +197,18 @@ vi.mock("@/store", () => ({
 }));
 
 vi.mock("@/react/stores/app", () => ({
-  useAppStore: {
-    getState: () => ({
-      getOrFetchPolicyByParentAndType: mocks.getOrFetchPolicyByParentAndType,
-      upsertPolicy: mocks.upsertPolicy,
-    }),
-  },
+  useAppStore: Object.assign(
+    (
+      selector: (state: { settingsByName: Record<string, unknown> }) => unknown
+    ) => selector({ settingsByName: {} }),
+    {
+      getState: () => ({
+        getOrFetchPolicyByParentAndType: mocks.getOrFetchPolicyByParentAndType,
+        upsertPolicy: mocks.upsertPolicy,
+        classification: () => [],
+      }),
+    }
+  ),
 }));
 
 vi.mock("@/utils", () => ({

--- a/frontend/src/react/pages/project/database-detail/catalog/GrantAccessDialog.tsx
+++ b/frontend/src/react/pages/project/database-detail/catalog/GrantAccessDialog.tsx
@@ -281,6 +281,9 @@ export function GrantAccessDialog({
     []
   );
 
+  // Subscribe so the classification options recompute when DATA_CLASSIFICATION
+  // loads (getClassificationLevelOptions reads the app store imperatively).
+  const settingsByName = useAppStore((s) => s.settingsByName);
   const factorOptionConfigMap = useMemo((): Map<Factor, OptionConfig> => {
     return factorList.reduce((map, factor) => {
       if (factor === CEL_ATTRIBUTE_RESOURCE_DATABASE) {
@@ -294,7 +297,7 @@ export function GrantAccessDialog({
       }
       return map;
     }, new Map<Factor, OptionConfig>());
-  }, [factorList, projectName]);
+  }, [factorList, projectName, settingsByName]);
 
   const minDatetime = dayjs().startOf("day").format("YYYY-MM-DDTHH:mm");
 

--- a/frontend/src/react/pages/project/database-detail/overview/DatabaseObjectExplorer.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/DatabaseObjectExplorer.test.tsx
@@ -27,7 +27,8 @@ const mocks = vi.hoisted(() => {
     getTableCatalog: vi.fn(),
     featureToRef: vi.fn(() => ({ value: true })),
     dbSchemaStore: vi.fn(),
-    useSettingV1Store: vi.fn(),
+    getOrFetchSettingByName: vi.fn(),
+    getProjectClassification: vi.fn(() => undefined),
     getDatabaseProject: vi.fn((database: { project: string }) => ({
       name: database.project,
       dataClassificationConfigId: "classification-config",
@@ -68,14 +69,25 @@ vi.mock("@/router", () => ({
   },
 }));
 
-// The component now reads dbSchema getters via the app store. Route the
-// existing `mocks.dbSchemaStore` shape through `useAppStore` so the
-// test bodies' per-scenario `.mockReturnValue({ getSchemaList, ... })`
-// calls keep working without further changes.
-vi.mock("@/react/stores/app", () => ({
-  useAppStore: (selector: (s: unknown) => unknown) =>
-    selector(mocks.dbSchemaStore()),
-}));
+// The component now reads dbSchema getters plus the former setting-store
+// methods (getProjectClassification / getOrFetchSettingByName) via the app
+// store. Merge the setting mocks into the `mocks.dbSchemaStore` shape so the
+// test bodies' per-scenario `.mockReturnValue({ getSchemaList, ... })` calls
+// keep working without further changes.
+vi.mock("@/react/stores/app", () => {
+  const getState = () => ({
+    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
+    getProjectClassification: mocks.getProjectClassification,
+    ...((mocks.dbSchemaStore() ?? {}) as Record<string, unknown>),
+  });
+  return {
+    useAppStore: Object.assign(
+      (selector?: (s: ReturnType<typeof getState>) => unknown) =>
+        selector ? selector(getState()) : getState(),
+      { getState }
+    ),
+  };
+});
 
 vi.mock("@/react/hooks/useAppDatabaseMetadata", () => ({
   useAppDatabaseMetadata: (name: string) =>
@@ -84,7 +96,6 @@ vi.mock("@/react/hooks/useAppDatabaseMetadata", () => ({
 
 vi.mock("@/store", () => ({
   featureToRef: mocks.featureToRef,
-  useSettingV1Store: mocks.useSettingV1Store,
 }));
 
 vi.mock("@/react/hooks/useDatabaseCatalog", () => ({
@@ -249,11 +260,9 @@ beforeEach(async () => {
   });
   mocks.featureToRef.mockReset();
   mocks.featureToRef.mockReturnValue({ value: true });
-  mocks.useSettingV1Store.mockReset();
-  mocks.useSettingV1Store.mockReturnValue({
-    getOrFetchSettingByName: vi.fn(),
-    getProjectClassification: vi.fn(() => undefined),
-  });
+  mocks.getOrFetchSettingByName.mockReset();
+  mocks.getProjectClassification.mockReset();
+  mocks.getProjectClassification.mockReturnValue(undefined);
   mocks.getDatabaseProject.mockReset();
   mocks.getDatabaseProject.mockImplementation(
     (database: { project: string }) => ({

--- a/frontend/src/react/pages/project/database-detail/overview/DatabaseObjectExplorer.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/DatabaseObjectExplorer.tsx
@@ -18,7 +18,7 @@ import {
   getTableCatalog,
 } from "@/react/stores/app/databaseCatalog";
 import { router } from "@/router";
-import { featureToRef, useSettingV1Store } from "@/store";
+import { featureToRef } from "@/store";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
   Database,
@@ -79,7 +79,6 @@ export function DatabaseObjectExplorer({
   onExternalTableSearchKeywordChange: (value: string) => void;
 }) {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
   const databaseEngine = getDatabaseEngine(database);
   const supportsSchema = hasSchemaProperty(databaseEngine);
   const schemaList = useAppStore((s) => s.getSchemaList(database.name));
@@ -118,10 +117,8 @@ export function DatabaseObjectExplorer({
   );
   const catalog = useDatabaseCatalog(database.name, false);
   const project = getDatabaseProject(database);
-  const classificationConfig = useVueState(() =>
-    settingStore.getProjectClassification(
-      project.dataClassificationConfigId ?? ""
-    )
+  const classificationConfig = useAppStore((s) =>
+    s.getProjectClassification(project.dataClassificationConfigId ?? "")
   );
   const canUpdateCatalog = hasProjectPermissionV2(
     project,
@@ -256,11 +253,10 @@ export function DatabaseObjectExplorer({
     : undefined;
 
   useEffect(() => {
-    void settingStore.getOrFetchSettingByName(
-      Setting_SettingName.DATA_CLASSIFICATION,
-      true
-    );
-  }, [settingStore]);
+    void useAppStore
+      .getState()
+      .getOrFetchSettingByName(Setting_SettingName.DATA_CLASSIFICATION, true);
+  }, []);
 
   useEffect(() => {
     setSelectedTableName((current) =>

--- a/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.test.tsx
@@ -24,8 +24,6 @@ const mocks = vi.hoisted(() => ({
     t: (key: string) => key,
   })),
   useVueState: vi.fn(),
-  useSettingV1Store: vi.fn(),
-  useSubscriptionV1Store: vi.fn(),
   useDatabaseCatalog: vi.fn(),
   updateDatabaseCatalog: vi.fn(),
   getTableCatalog: vi.fn(),
@@ -33,6 +31,8 @@ const mocks = vi.hoisted(() => ({
   getOrFetchSettingByName: vi.fn(),
   getSettingByName: vi.fn(),
   getProjectClassification: vi.fn(),
+  hasFeature: vi.fn(() => true),
+  instanceMissingLicense: vi.fn(() => false),
   updateColumnCatalog: vi.fn(),
   updateTableCatalog: vi.fn(),
   getDatabaseProject: vi.fn(),
@@ -126,8 +126,6 @@ vi.mock("@/react/components/FeatureAttention", () => ({
 
 vi.mock("@/store", () => ({
   pushNotification: mocks.pushNotification,
-  useSettingV1Store: mocks.useSettingV1Store,
-  useSubscriptionV1Store: mocks.useSubscriptionV1Store,
 }));
 
 vi.mock("@/react/hooks/useDatabaseCatalog", () => ({
@@ -138,13 +136,23 @@ vi.mock("@/react/stores/app/databaseCatalog", () => ({
   getTableCatalog: mocks.getTableCatalog,
 }));
 
-vi.mock("@/react/stores/app", () => ({
-  useAppStore: {
-    getState: () => ({
-      updateDatabaseCatalog: mocks.updateDatabaseCatalog,
-    }),
-  },
-}));
+vi.mock("@/react/stores/app", () => {
+  const getState = () => ({
+    updateDatabaseCatalog: mocks.updateDatabaseCatalog,
+    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
+    getSettingByName: mocks.getSettingByName,
+    getProjectClassification: mocks.getProjectClassification,
+    hasFeature: mocks.hasFeature,
+    instanceMissingLicense: mocks.instanceMissingLicense,
+  });
+  return {
+    useAppStore: Object.assign(
+      (selector?: (s: ReturnType<typeof getState>) => unknown) =>
+        selector ? selector(getState()) : getState(),
+      { getState }
+    ),
+  };
+});
 
 vi.mock("@/utils", () => ({
   getDatabaseProject: mocks.getDatabaseProject,
@@ -275,17 +283,10 @@ beforeEach(async () => {
       },
     };
   });
-  mocks.useSettingV1Store.mockReset();
-  mocks.useSettingV1Store.mockReturnValue({
-    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
-    getSettingByName: mocks.getSettingByName,
-    getProjectClassification: mocks.getProjectClassification,
-  });
-  mocks.useSubscriptionV1Store.mockReset();
-  mocks.useSubscriptionV1Store.mockReturnValue({
-    hasFeature: vi.fn(() => true),
-    instanceMissingLicense: vi.fn(() => false),
-  });
+  mocks.hasFeature.mockReset();
+  mocks.hasFeature.mockReturnValue(true);
+  mocks.instanceMissingLicense.mockReset();
+  mocks.instanceMissingLicense.mockReturnValue(false);
   mocks.useDatabaseCatalog.mockReset();
   mocks.useDatabaseCatalog.mockReturnValue({
     name: "instances/inst1/databases/db/catalog",

--- a/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/TableDetailDialog.tsx
@@ -24,18 +24,13 @@ import {
 } from "@/react/components/ui/table";
 import { Textarea } from "@/react/components/ui/textarea";
 import { useDatabaseCatalog } from "@/react/hooks/useDatabaseCatalog";
-import { useVueState } from "@/react/hooks/useVueState";
 import {
   updateColumnCatalog,
   updateTableCatalog,
 } from "@/react/lib/column-data-table/utils";
 import { useAppStore } from "@/react/stores/app";
 import { getTableCatalog } from "@/react/stores/app/databaseCatalog";
-import {
-  pushNotification,
-  useSettingV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import {
   SchemaCatalogSchema,
   TableCatalogSchema,
@@ -769,36 +764,33 @@ function EditableSemanticTypeCell({
   testIdPrefix: string;
 }) {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
   const [showFeatureDialog, setShowFeatureDialog] = useState(false);
   const [showPicker, setShowPicker] = useState(false);
 
-  const semanticTypeList = useVueState(() => {
-    const setting = settingStore.getSettingByName(
-      Setting_SettingName.SEMANTIC_TYPES
-    );
-    return setting?.value?.value.case === "semanticType"
-      ? ((setting.value.value.value.types ??
+  const semanticTypeSetting = useAppStore((s) =>
+    s.getSettingByName(Setting_SettingName.SEMANTIC_TYPES)
+  );
+  const semanticTypeList = useMemo<SemanticTypeSetting_SemanticType[]>(() => {
+    return semanticTypeSetting?.value?.value.case === "semanticType"
+      ? ((semanticTypeSetting.value.value.value.types ??
           []) as SemanticTypeSetting_SemanticType[])
       : [];
-  });
-  const hasSensitiveDataFeature = useVueState(() =>
-    subscriptionStore.hasFeature(PlanFeature.FEATURE_DATA_MASKING)
+  }, [semanticTypeSetting]);
+  const hasSensitiveDataFeature = useAppStore((s) =>
+    s.hasFeature(PlanFeature.FEATURE_DATA_MASKING)
   );
-  const instanceMissingLicense = useVueState(() =>
-    subscriptionStore.instanceMissingLicense(
+  const instanceMissingLicense = useAppStore((s) =>
+    s.instanceMissingLicense(
       PlanFeature.FEATURE_DATA_MASKING,
       getInstanceResource(database)
     )
   );
 
   useEffect(() => {
-    void settingStore.getOrFetchSettingByName(
-      Setting_SettingName.SEMANTIC_TYPES,
-      true
-    );
-  }, [settingStore]);
+    void useAppStore
+      .getState()
+      .getOrFetchSettingByName(Setting_SettingName.SEMANTIC_TYPES, true);
+  }, []);
 
   const semanticTypeTitle = getSemanticTypeTitle(
     semanticTypeId,
@@ -883,7 +875,6 @@ export function TableDetailDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
   const [columnSearchKeyword, setColumnSearchKeyword] = useState("");
 
   const filteredColumns = useMemo(() => {
@@ -905,24 +896,21 @@ export function TableDetailDialog({
     setColumnSearchKeyword("");
   }, [table?.name]);
 
-  const classificationConfig = useVueState(() => {
-    if (table?.classificationConfig) {
-      return table.classificationConfig;
-    }
-    if (!table?.database) {
-      return undefined;
-    }
-    return settingStore.getProjectClassification(
-      getDatabaseProject(table.database).dataClassificationConfigId ?? ""
-    );
-  });
+  const projectClassificationConfig = useAppStore((s) =>
+    table?.database
+      ? s.getProjectClassification(
+          getDatabaseProject(table.database).dataClassificationConfigId ?? ""
+        )
+      : undefined
+  );
+  const classificationConfig =
+    table?.classificationConfig ?? projectClassificationConfig;
 
   useEffect(() => {
-    void settingStore.getOrFetchSettingByName(
-      Setting_SettingName.DATA_CLASSIFICATION,
-      true
-    );
-  }, [settingStore]);
+    void useAppStore
+      .getState()
+      .getOrFetchSettingByName(Setting_SettingName.DATA_CLASSIFICATION, true);
+  }, []);
 
   if (!table) {
     return null;

--- a/frontend/src/react/pages/project/database-detail/overview/TableMetadataTable.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/TableMetadataTable.test.tsx
@@ -23,7 +23,6 @@ const mocks = vi.hoisted(() => ({
   useDatabaseCatalog: vi.fn(),
   getTableCatalog: vi.fn(),
   featureToRef: vi.fn(() => ({ value: true })),
-  useSettingV1Store: vi.fn(),
   updateTableCatalog: vi.fn(),
   getDatabaseEngine: vi.fn(() => Engine.POSTGRES),
   getDatabaseProject: vi.fn(() => ({
@@ -42,6 +41,9 @@ const mocks = vi.hoisted(() => ({
   getOrFetchSettingByName: vi.fn(),
   getSettingByName: vi.fn(),
   getProjectClassification: vi.fn(),
+  hasFeature: vi.fn(() => true),
+  instanceMissingLicense: vi.fn(() => false),
+  updateDatabaseCatalog: vi.fn(),
 }));
 
 let TableMetadataTable: typeof import("./TableMetadataTable").TableMetadataTable;
@@ -56,8 +58,25 @@ vi.mock("@/react/hooks/useVueState", () => ({
 
 vi.mock("@/store", () => ({
   featureToRef: mocks.featureToRef,
-  useSettingV1Store: mocks.useSettingV1Store,
 }));
+
+vi.mock("@/react/stores/app", () => {
+  const getState = () => ({
+    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
+    getSettingByName: mocks.getSettingByName,
+    getProjectClassification: mocks.getProjectClassification,
+    hasFeature: mocks.hasFeature,
+    instanceMissingLicense: mocks.instanceMissingLicense,
+    updateDatabaseCatalog: mocks.updateDatabaseCatalog,
+  });
+  return {
+    useAppStore: Object.assign(
+      (selector?: (s: ReturnType<typeof getState>) => unknown) =>
+        selector ? selector(getState()) : getState(),
+      { getState }
+    ),
+  };
+});
 
 vi.mock("@/react/hooks/useDatabaseCatalog", () => ({
   useDatabaseCatalog: () => mocks.useDatabaseCatalog(),
@@ -281,12 +300,6 @@ beforeEach(async () => {
         level: 2,
       },
     },
-  });
-  mocks.useSettingV1Store.mockReset();
-  mocks.useSettingV1Store.mockReturnValue({
-    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
-    getSettingByName: mocks.getSettingByName,
-    getProjectClassification: mocks.getProjectClassification,
   });
   mocks.updateTableCatalog.mockReset();
   mocks.updateTableCatalog.mockResolvedValue(undefined);

--- a/frontend/src/react/pages/project/database-detail/overview/TableMetadataTable.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/TableMetadataTable.tsx
@@ -11,8 +11,9 @@ import {
 import { useDatabaseCatalog } from "@/react/hooks/useDatabaseCatalog";
 import { useVueState } from "@/react/hooks/useVueState";
 import { updateTableCatalog } from "@/react/lib/column-data-table/utils";
+import { useAppStore } from "@/react/stores/app";
 import { getTableCatalog } from "@/react/stores/app/databaseCatalog";
-import { featureToRef, useSettingV1Store } from "@/store";
+import { featureToRef } from "@/store";
 import { Engine } from "@/types/proto-es/v1/common_pb";
 import type {
   Database,
@@ -43,7 +44,6 @@ export function TableMetadataTable({
   onRowClick?: (table: TableMetadata) => void;
 }) {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
   const databaseEngine = getDatabaseEngine(database);
   const showSchemaColumn = hasSchemaProperty(databaseEngine);
   const showClassificationColumn = useVueState(
@@ -51,10 +51,8 @@ export function TableMetadataTable({
   );
   const catalog = useDatabaseCatalog(database.name, false);
   const project = getDatabaseProject(database);
-  const classificationConfig = useVueState(() =>
-    settingStore.getProjectClassification(
-      project.dataClassificationConfigId ?? ""
-    )
+  const classificationConfig = useAppStore((s) =>
+    s.getProjectClassification(project.dataClassificationConfigId ?? "")
   );
   const editable = hasProjectPermissionV2(
     project,
@@ -65,11 +63,10 @@ export function TableMetadataTable({
   const showPartitionedColumn = databaseEngine === Engine.POSTGRES;
 
   useEffect(() => {
-    void settingStore.getOrFetchSettingByName(
-      Setting_SettingName.DATA_CLASSIFICATION,
-      true
-    );
-  }, [settingStore]);
+    void useAppStore
+      .getState()
+      .getOrFetchSettingByName(Setting_SettingName.DATA_CLASSIFICATION, true);
+  }, []);
 
   const columns = useMemo(
     () =>

--- a/frontend/src/react/pages/project/database-detail/panels/DatabaseCatalogPanel.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/panels/DatabaseCatalogPanel.test.tsx
@@ -181,40 +181,38 @@ const mocks = vi.hoisted(() => {
     getOrFetchPolicyByParentAndType: vi.fn(),
     upsertPolicy: vi.fn(),
     updateDatabaseCatalog: vi.fn(),
-    useSettingV1Store: vi.fn(() => ({
-      getOrFetchSettingByName: vi.fn(),
-      getProjectClassification: vi.fn(() => ({
-        id: "classification-config",
-        classification: {
-          PII: {
-            id: "PII",
-            title: "PII",
-          },
-          CONFIDENTIAL: {
-            id: "CONFIDENTIAL",
-            title: "Confidential",
-          },
+    getOrFetchSettingByName: vi.fn(),
+    getProjectClassification: vi.fn(() => ({
+      id: "classification-config",
+      classification: {
+        PII: {
+          id: "PII",
+          title: "PII",
         },
-      })),
-      getSettingByName: vi.fn(() => ({
+        CONFIDENTIAL: {
+          id: "CONFIDENTIAL",
+          title: "Confidential",
+        },
+      },
+    })),
+    getSettingByName: vi.fn(() => ({
+      value: {
         value: {
+          case: "semanticType",
           value: {
-            case: "semanticType",
-            value: {
-              types: [
-                {
-                  id: "EMAIL",
-                  title: "Email",
-                },
-                {
-                  id: "PHONE",
-                  title: "Phone",
-                },
-              ],
-            },
+            types: [
+              {
+                id: "EMAIL",
+                title: "Email",
+              },
+              {
+                id: "PHONE",
+                title: "Phone",
+              },
+            ],
           },
         },
-      })),
+      },
     })),
     pushNotification: vi.fn(),
     getDatabaseProject: vi.fn((database: { project: string }) => ({
@@ -370,22 +368,29 @@ vi.mock("@/react/hooks/useVueState", () => ({
 vi.mock("@/store", () => ({
   featureToRef: mocks.featureToRef,
   pushNotification: mocks.pushNotification,
-  useSettingV1Store: mocks.useSettingV1Store,
 }));
 
 vi.mock("@/react/hooks/useDatabaseCatalog", () => ({
   useDatabaseCatalog: () => mocks.useDatabaseCatalog(),
 }));
 
-vi.mock("@/react/stores/app", () => ({
-  useAppStore: {
-    getState: () => ({
-      updateDatabaseCatalog: mocks.updateDatabaseCatalog,
-      getOrFetchPolicyByParentAndType: mocks.getOrFetchPolicyByParentAndType,
-      upsertPolicy: mocks.upsertPolicy,
-    }),
-  },
-}));
+vi.mock("@/react/stores/app", () => {
+  const getState = () => ({
+    updateDatabaseCatalog: mocks.updateDatabaseCatalog,
+    getOrFetchPolicyByParentAndType: mocks.getOrFetchPolicyByParentAndType,
+    upsertPolicy: mocks.upsertPolicy,
+    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
+    getSettingByName: mocks.getSettingByName,
+    getProjectClassification: mocks.getProjectClassification,
+  });
+  return {
+    useAppStore: Object.assign(
+      (selector?: (s: ReturnType<typeof getState>) => unknown) =>
+        selector ? selector(getState()) : getState(),
+      { getState }
+    ),
+  };
+});
 
 vi.mock("@/utils", () => ({
   autoDatabaseRoute: mocks.autoDatabaseRoute,
@@ -476,41 +481,40 @@ beforeEach(async () => {
   mocks.upsertPolicy.mockReset();
   mocks.updateDatabaseCatalog.mockReset();
   mocks.updateDatabaseCatalog.mockResolvedValue(undefined);
-  mocks.useSettingV1Store.mockReset();
-  mocks.useSettingV1Store.mockReturnValue({
-    getOrFetchSettingByName: vi.fn(),
-    getProjectClassification: vi.fn(() => ({
-      id: "classification-config",
-      classification: {
-        PII: {
-          id: "PII",
-          title: "PII",
-        },
-        CONFIDENTIAL: {
-          id: "CONFIDENTIAL",
-          title: "Confidential",
-        },
+  mocks.getOrFetchSettingByName.mockReset();
+  mocks.getProjectClassification.mockReset();
+  mocks.getProjectClassification.mockReturnValue({
+    id: "classification-config",
+    classification: {
+      PII: {
+        id: "PII",
+        title: "PII",
       },
-    })),
-    getSettingByName: vi.fn(() => ({
+      CONFIDENTIAL: {
+        id: "CONFIDENTIAL",
+        title: "Confidential",
+      },
+    },
+  });
+  mocks.getSettingByName.mockReset();
+  mocks.getSettingByName.mockReturnValue({
+    value: {
       value: {
+        case: "semanticType",
         value: {
-          case: "semanticType",
-          value: {
-            types: [
-              {
-                id: "EMAIL",
-                title: "Email",
-              },
-              {
-                id: "PHONE",
-                title: "Phone",
-              },
-            ],
-          },
+          types: [
+            {
+              id: "EMAIL",
+              title: "Email",
+            },
+            {
+              id: "PHONE",
+              title: "Phone",
+            },
+          ],
         },
       },
-    })),
+    },
   });
   mocks.pushNotification.mockReset();
   mocks.getDatabaseProject.mockReset();
@@ -714,42 +718,7 @@ describe("DatabaseCatalogPanel", () => {
 
   test("updates semantic type and classification independently", async () => {
     const updateDatabaseCatalog = mocks.updateDatabaseCatalog;
-    const getOrFetchSettingByName = vi.fn();
-    mocks.useSettingV1Store.mockReturnValue({
-      getOrFetchSettingByName,
-      getProjectClassification: vi.fn(() => ({
-        id: "classification-config",
-        classification: {
-          PII: {
-            id: "PII",
-            title: "PII",
-          },
-          CONFIDENTIAL: {
-            id: "CONFIDENTIAL",
-            title: "Confidential",
-          },
-        },
-      })),
-      getSettingByName: vi.fn(() => ({
-        value: {
-          value: {
-            case: "semanticType",
-            value: {
-              types: [
-                {
-                  id: "EMAIL",
-                  title: "Email",
-                },
-                {
-                  id: "PHONE",
-                  title: "Phone",
-                },
-              ],
-            },
-          },
-        },
-      })),
-    });
+    const getOrFetchSettingByName = mocks.getOrFetchSettingByName;
     const catalog = makeSimpleCatalog();
     mocks.useDatabaseCatalog.mockReturnValue(catalog);
 

--- a/frontend/src/react/pages/project/database-detail/panels/DatabaseCatalogPanel.tsx
+++ b/frontend/src/react/pages/project/database-detail/panels/DatabaseCatalogPanel.tsx
@@ -30,7 +30,7 @@ import {
   isCurrentColumnException,
 } from "@/react/lib/sensitive-data/utils";
 import { useAppStore } from "@/react/stores/app";
-import { featureToRef, pushNotification, useSettingV1Store } from "@/store";
+import { featureToRef, pushNotification } from "@/store";
 import type { Permission } from "@/types";
 import type {
   ColumnCatalog,
@@ -185,7 +185,6 @@ const itemKey = (item: MaskData) => {
 
 export function DatabaseCatalogPanel({ database }: { database: Database }) {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
 
   const catalog = useDatabaseCatalog(database.name, false);
   const project = getDatabaseProject(database);
@@ -199,19 +198,17 @@ export function DatabaseCatalogPanel({ database }: { database: Database }) {
     (permission) => hasProjectPermissionV2(project, permission)
   );
 
-  const semanticTypeList = useVueState(() => {
-    const setting = settingStore.getSettingByName(
-      Setting_SettingName.SEMANTIC_TYPES
-    );
-    return setting?.value?.value.case === "semanticType"
-      ? ((setting.value.value.value.types ??
+  const semanticTypeSetting = useAppStore((s) =>
+    s.getSettingByName(Setting_SettingName.SEMANTIC_TYPES)
+  );
+  const semanticTypeList = useMemo<SemanticTypeSetting_SemanticType[]>(() => {
+    return semanticTypeSetting?.value?.value.case === "semanticType"
+      ? ((semanticTypeSetting.value.value.value.types ??
           []) as SemanticTypeSetting_SemanticType[])
       : [];
-  });
-  const classificationConfig = useVueState(() =>
-    settingStore.getProjectClassification(
-      project.dataClassificationConfigId ?? ""
-    )
+  }, [semanticTypeSetting]);
+  const classificationConfig = useAppStore((s) =>
+    s.getProjectClassification(project.dataClassificationConfigId ?? "")
   );
   const hasSensitiveDataFeature = useVueState(
     () => featureToRef(PlanFeature.FEATURE_DATA_MASKING, instance).value
@@ -226,15 +223,16 @@ export function DatabaseCatalogPanel({ database }: { database: Database }) {
   );
 
   useEffect(() => {
-    void settingStore.getOrFetchSettingByName(
+    const store = useAppStore.getState();
+    void store.getOrFetchSettingByName(
       Setting_SettingName.SEMANTIC_TYPES,
       true
     );
-    void settingStore.getOrFetchSettingByName(
+    void store.getOrFetchSettingByName(
       Setting_SettingName.DATA_CLASSIFICATION,
       true
     );
-  }, [settingStore]);
+  }, []);
 
   useEffect(() => {
     setSearchText("");

--- a/frontend/src/react/pages/project/database-detail/panels/DatabaseOverviewPanel.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/panels/DatabaseOverviewPanel.test.tsx
@@ -35,13 +35,16 @@ const mocks = vi.hoisted(() => {
     dbSchemaStore: vi.fn(),
     useDatabaseCatalog: vi.fn(),
     updateDatabaseCatalog: vi.fn(),
-    useSubscriptionV1Store: vi.fn(),
     getColumnCatalog: vi.fn(() => ({
       semanticType: "",
       classification: "",
     })),
     getTableCatalog: vi.fn(),
-    useSettingV1Store: vi.fn(),
+    getOrFetchSettingByName: vi.fn(),
+    getSettingByName: vi.fn(() => undefined),
+    getProjectClassification: vi.fn(() => undefined),
+    hasFeature: vi.fn(() => true),
+    instanceMissingLicense: vi.fn(() => false),
     featureToRef: vi.fn(() => ({ value: true })),
     getDatabaseProject: vi.fn((database: { project: string }) => ({
       name: database.project,
@@ -89,17 +92,28 @@ vi.mock("@/router", () => ({
   },
 }));
 
-// The component (and its child `DatabaseObjectExplorer`) now read dbSchema
-// getters via the app store. Route the existing `mocks.dbSchemaStore`
-// shape through `useAppStore` so the per-scenario `.mockReturnValue({...})`
-// calls in test bodies keep working without further changes.
+// The component (and its children `DatabaseObjectExplorer`, `TableDetailDialog`,
+// `TableMetadataTable`) now read dbSchema getters plus the former
+// setting/subscription store methods via the app store. Merge the
+// setting/subscription mocks into the `mocks.dbSchemaStore` shape so the
+// per-scenario `.mockReturnValue({...})` calls in test bodies keep working.
 vi.mock("@/react/stores/app", () => {
-  const useAppStore = (selector: (s: unknown) => unknown) =>
-    selector(mocks.dbSchemaStore());
-  useAppStore.getState = () => ({
+  const getState = () => ({
     updateDatabaseCatalog: mocks.updateDatabaseCatalog,
+    getOrFetchSettingByName: mocks.getOrFetchSettingByName,
+    getSettingByName: mocks.getSettingByName,
+    getProjectClassification: mocks.getProjectClassification,
+    hasFeature: mocks.hasFeature,
+    instanceMissingLicense: mocks.instanceMissingLicense,
+    ...((mocks.dbSchemaStore() ?? {}) as Record<string, unknown>),
   });
-  return { useAppStore };
+  return {
+    useAppStore: Object.assign(
+      (selector?: (s: ReturnType<typeof getState>) => unknown) =>
+        selector ? selector(getState()) : getState(),
+      { getState }
+    ),
+  };
 });
 
 vi.mock("@/react/hooks/useAppDatabaseMetadata", () => ({
@@ -108,8 +122,6 @@ vi.mock("@/react/hooks/useAppDatabaseMetadata", () => ({
 }));
 
 vi.mock("@/store", () => ({
-  useSubscriptionV1Store: mocks.useSubscriptionV1Store,
-  useSettingV1Store: mocks.useSettingV1Store,
   featureToRef: mocks.featureToRef,
 }));
 
@@ -363,17 +375,15 @@ beforeEach(async () => {
   mocks.getTableCatalog.mockReturnValue({
     classification: "",
   });
-  mocks.useSettingV1Store.mockReset();
-  mocks.useSettingV1Store.mockReturnValue({
-    getOrFetchSettingByName: vi.fn(),
-    getSettingByName: vi.fn(() => undefined),
-    getProjectClassification: vi.fn(() => undefined),
-  });
-  mocks.useSubscriptionV1Store.mockReset();
-  mocks.useSubscriptionV1Store.mockReturnValue({
-    hasFeature: vi.fn(() => true),
-    instanceMissingLicense: vi.fn(() => false),
-  });
+  mocks.getOrFetchSettingByName.mockReset();
+  mocks.getSettingByName.mockReset();
+  mocks.getSettingByName.mockReturnValue(undefined);
+  mocks.getProjectClassification.mockReset();
+  mocks.getProjectClassification.mockReturnValue(undefined);
+  mocks.hasFeature.mockReset();
+  mocks.hasFeature.mockReturnValue(true);
+  mocks.instanceMissingLicense.mockReset();
+  mocks.instanceMissingLicense.mockReturnValue(false);
   mocks.featureToRef.mockReset();
   mocks.featureToRef.mockReturnValue({
     value: true,

--- a/frontend/src/react/pages/project/export-center/DataExportPrepSheet.test.tsx
+++ b/frontend/src/react/pages/project/export-center/DataExportPrepSheet.test.tsx
@@ -189,13 +189,12 @@ const mocks = vi.hoisted(() => ({
   currentUser: { name: "users/me@example.com", email: "me@example.com" },
 }));
 
-const stableSettingStore = {
-  workspaceProfile: { sqlResultSize: BigInt(100 * 1024 * 1024) },
+const stableWorkspaceProfile = {
+  sqlResultSize: BigInt(100 * 1024 * 1024),
 };
 
 vi.mock("@/store", () => ({
   DEFAULT_MAX_RESULT_SIZE_IN_MB: 100,
-  useSettingV1Store: () => stableSettingStore,
   pushNotification: mocks.pushNotification,
 }));
 
@@ -205,6 +204,9 @@ vi.mock("@/react/stores/app", () => {
     // `useProjectV1Store` now lives on the app store.
     getProjectByName: mocks.getProjectByName,
     projectsByName: {} as Record<string, unknown>,
+    // The workspace profile getter previously lived on the Pinia
+    // `useSettingV1Store`; it is now an app-store method.
+    getWorkspaceProfile: () => stableWorkspaceProfile,
     fetchDatabases: mocks.fetchDatabases,
     getOrFetchDatabaseByName: mocks.getOrFetchDatabaseByName,
     getDatabaseByName: mocks.getDatabaseByName,

--- a/frontend/src/react/pages/project/export-center/DataExportPrepSheet.tsx
+++ b/frontend/src/react/pages/project/export-center/DataExportPrepSheet.tsx
@@ -27,11 +27,7 @@ import { useAppStore } from "@/react/stores/app";
 import { experimentalCreateIssueByPlan } from "@/react/stores/app/issue";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
-import {
-  DEFAULT_MAX_RESULT_SIZE_IN_MB,
-  pushNotification,
-  useSettingV1Store,
-} from "@/store";
+import { DEFAULT_MAX_RESULT_SIZE_IN_MB, pushNotification } from "@/store";
 import { isValidDatabaseGroupName, isValidDatabaseName } from "@/types";
 import { ExportFormat } from "@/types/proto-es/v1/common_pb";
 import type { DatabaseGroup } from "@/types/proto-es/v1/database_group_service_pb";
@@ -92,7 +88,6 @@ export function DataExportPrepSheet({
 }: DataExportPrepSheetProps) {
   const { t } = useTranslation();
   const currentUser = useCurrentUser();
-  const settingStore = useSettingV1Store();
   // subscribe to re-render on project cache change
   const projectsByName = useAppStore((s) => s.projectsByName);
 
@@ -213,13 +208,16 @@ export function DataExportPrepSheet({
   }, [projectName]);
 
   // Limits
-  const maximumResultSize = useVueState(() => {
-    let size = settingStore.workspaceProfile.sqlResultSize;
+  const sqlResultSize = useAppStore(
+    (s) => s.getWorkspaceProfile().sqlResultSize
+  );
+  const maximumResultSize = (() => {
+    let size = sqlResultSize;
     if (size <= 0) {
       size = BigInt(DEFAULT_MAX_RESULT_SIZE_IN_MB * 1024 * 1024);
     }
     return Number(size) / 1024 / 1024;
-  });
+  })();
 
   const handleCancel = () => {
     if (step === 2 && !seed?.step) {

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx
@@ -1,12 +1,11 @@
 import { Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { Alert } from "@/react/components/ui/alert";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
-import { useEnvironmentV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { isValidDatabaseName } from "@/types";
 import type { AccessGrant } from "@/types/proto-es/v1/access_grant_service_pb";
@@ -157,15 +156,22 @@ export function IssueDetailAccessGrantDetails() {
 }
 
 function IssueDetailAccessGrantTarget({ target }: { target: string }) {
-  const environmentStore = useEnvironmentV1Store();
   const databasesByName = useAppStore((s) => s.databasesByName);
   const database = useVueState(
     () => databasesByName[target] ?? unknownDatabase()
   );
-  const environment = useVueState(() =>
-    environmentStore.getEnvironmentByName(
-      database.effectiveEnvironment ?? database.environment ?? ""
-    )
+  // Subscribe to the env cache so the row re-resolves once it loads; compute
+  // via getState() in a memo because getEnvironmentByName returns a fresh
+  // fallback object on a miss (unsafe as a raw selector — would loop).
+  const environmentList = useAppStore((s) => s.environmentList);
+  const environment = useMemo(
+    () =>
+      useAppStore
+        .getState()
+        .getEnvironmentByName(
+          database.effectiveEnvironment ?? database.environment ?? ""
+        ),
+    [environmentList, database]
   );
   const instance = database.instanceResource;
   const { databaseName } = extractDatabaseResourceName(target);

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.test.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.test.tsx
@@ -225,9 +225,6 @@ vi.mock("@/router/dashboard/projectV1RouteHelpers", () => ({
 
 vi.mock("@/store", () => ({
   getProjectNameAndDatabaseGroupName: mocks.getProjectNameAndDatabaseGroupName,
-  useEnvironmentV1Store: () => ({
-    getEnvironmentByName: mocks.getEnvironmentByName,
-  }),
 }));
 
 vi.mock("@/types", () => ({
@@ -259,14 +256,16 @@ vi.mock("@/react/stores/app", () => {
       selector: (s: {
         dbGroupsByName: Record<string, unknown>;
         databasesByName: Record<string, unknown>;
+        environmentList: unknown[];
       }) => unknown
-    ) => selector({ dbGroupsByName, databasesByName }),
+    ) => selector({ dbGroupsByName, databasesByName, environmentList: [] }),
     {
       getState: () => ({
         getDBGroupByName: mocks.getDBGroupByName,
         getOrFetchDBGroupByName: mocks.getOrFetchDBGroupByName,
         getOrFetchSheetByName: mocks.getOrFetchSheetByName,
         batchGetOrFetchDatabases: mocks.batchGetOrFetchDatabases,
+        getEnvironmentByName: mocks.getEnvironmentByName,
       }),
     }
   );

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
@@ -30,10 +30,7 @@ import {
   PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS,
 } from "@/router/dashboard/projectV1";
 import { buildPlanDeployRouteFromPlanName } from "@/router/dashboard/projectV1RouteHelpers";
-import {
-  getProjectNameAndDatabaseGroupName,
-  useEnvironmentV1Store,
-} from "@/store";
+import { getProjectNameAndDatabaseGroupName } from "@/store";
 import {
   isValidDatabaseGroupName,
   isValidDatabaseName,
@@ -763,17 +760,18 @@ function IssueDetailDatabaseTarget({
   target: string;
 }) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
   const databasesByName = useAppStore((s) => s.databasesByName);
+  const environmentList = useAppStore((s) => s.environmentList);
   const database = useVueState(
     () => databasesByName[target] ?? unknownDatabase()
   );
-  const environment = useVueState(() =>
-    environmentStore.getEnvironmentByName(
-      database.effectiveEnvironment ??
-        database.instanceResource?.environment ??
-        ""
-    )
+  const environmentName =
+    database.effectiveEnvironment ??
+    database.instanceResource?.environment ??
+    "";
+  const environment = useMemo(
+    () => useAppStore.getState().getEnvironmentByName(environmentName),
+    [environmentList, environmentName]
   );
   const instance = database.instanceResource;
   const { databaseName } = extractDatabaseResourceName(target);

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
@@ -8,7 +8,6 @@ import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { INSTANCE_ROUTE_DETAIL } from "@/router/dashboard/instance";
-import { useEnvironmentV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import {
   formatEnvironmentName,
@@ -35,7 +34,7 @@ export function IssueDetailDatabaseCreateView() {
   const page = useIssueDetailContext();
   // subscribe to re-render on project cache change
   const projectsByName = useAppStore((s) => s.projectsByName);
-  const environmentStore = useEnvironmentV1Store();
+  const environmentList = useAppStore((s) => s.environmentList);
   const projectName = `${projectNamePrefix}${page.projectId}`;
   const project = useVueState(() =>
     useAppStore.getState().getProjectByName(projectName)
@@ -55,8 +54,9 @@ export function IssueDetailDatabaseCreateView() {
 
   const environmentName = createDatabaseConfig?.environment ?? "";
   const targetInstanceName = createDatabaseConfig?.target ?? "";
-  const environment = useVueState(() =>
-    environmentStore.getEnvironmentByName(environmentName)
+  const environment = useMemo(
+    () => useAppStore.getState().getEnvironmentByName(environmentName),
+    [environmentList, environmentName]
   );
   const cachedInstance = useAppStore(
     (s) => s.instancesByName[targetInstanceName]

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
@@ -33,8 +33,6 @@ import {
   DEFAULT_MAX_RESULT_SIZE_IN_MB,
   getProjectNameAndDatabaseGroupName,
   pushNotification,
-  useEnvironmentV1Store,
-  useSettingV1Store,
 } from "@/store";
 import {
   isValidDatabaseGroupName,
@@ -640,17 +638,18 @@ function IssueDetailDatabaseExportDatabaseTarget({
   target: string;
 }) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
   const databasesByName = useAppStore((s) => s.databasesByName);
+  const environmentList = useAppStore((s) => s.environmentList);
   const database = useVueState(
     () => databasesByName[target] ?? unknownDatabase()
   );
-  const environment = useVueState(() =>
-    environmentStore.getEnvironmentByName(
-      database.effectiveEnvironment ??
-        database.instanceResource?.environment ??
-        ""
-    )
+  const environmentName =
+    database.effectiveEnvironment ??
+    database.instanceResource?.environment ??
+    "";
+  const environment = useMemo(
+    () => useAppStore.getState().getEnvironmentByName(environmentName),
+    [environmentList, environmentName]
   );
   const instance = database.instanceResource;
   const { databaseName } = extractDatabaseResourceName(target);
@@ -778,14 +777,14 @@ function IssueDetailDatabaseExportDatabaseGroupTarget({
 
 function IssueDetailDatabaseExportLimits() {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
-  const maximumResultSize = useVueState(() => {
-    let size = settingStore.workspaceProfile.sqlResultSize;
+  const workspaceProfile = useAppStore((s) => s.getWorkspaceProfile());
+  const maximumResultSize = useMemo(() => {
+    let size = workspaceProfile.sqlResultSize;
     if (size <= 0) {
       size = BigInt(DEFAULT_MAX_RESULT_SIZE_IN_MB * 1024 * 1024);
     }
     return Number(size) / 1024 / 1024;
-  });
+  }, [workspaceProfile]);
 
   return (
     <div className="flex w-full flex-col gap-y-2">

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.test.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.test.tsx
@@ -56,12 +56,6 @@ vi.mock("@/react/hooks/useVueState", () => ({
   useVueState: <T,>(getter: () => T) => getter(),
 }));
 
-vi.mock("@/store", () => ({
-  useEnvironmentV1Store: () => ({
-    getEnvironmentByName: () => ({ title: "" }),
-  }),
-}));
-
 vi.mock("@/types/v1/database", () => ({
   unknownDatabase: () => ({
     name: "instances/-/databases/-",
@@ -87,6 +81,8 @@ vi.mock("@/react/stores/app", () => {
           : undefined,
     instancesByName: {} as Record<string, unknown>,
     databasesByName: {} as Record<string, unknown>,
+    environmentList: [] as unknown[],
+    getEnvironmentByName: () => ({ title: "" }),
     batchGetOrFetchDatabases: vi.fn(),
   });
   return {

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx
@@ -15,7 +15,6 @@ import { useVueState } from "@/react/hooks/useVueState";
 import { getRoleEnvironmentLimitationKind } from "@/react/lib/project-member/utils";
 import { displayRoleTitleFromList } from "@/react/lib/role";
 import { useAppStore } from "@/react/stores/app";
-import { useEnvironmentV1Store } from "@/store";
 import type { DatabaseResource } from "@/types";
 import { unknownDatabase } from "@/types/v1/database";
 import {
@@ -177,12 +176,13 @@ function IssueDetailDatabaseResourceTable({
   databaseResourceList: DatabaseResource[];
 }) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
   // Subscribe to the instance cache so rows reactively pick up titles once
   // instances hydrate; a bare getState() read would not re-render here because
   // useVueState only tracks Vue dependencies.
   const instancesByName = useAppStore((s) => s.instancesByName);
   const databasesByName = useAppStore((s) => s.databasesByName);
+  // Subscribe so titles refresh if the environment list changes.
+  void useAppStore((s) => s.environmentList);
   const rows = useVueState(() =>
     databaseResourceList.map((resource) => {
       const database =
@@ -197,8 +197,9 @@ function IssueDetailDatabaseResourceTable({
         database.effectiveEnvironment ??
         database.instanceResource?.environment ??
         "";
-      const environment =
-        environmentStore.getEnvironmentByName(environmentName);
+      const environment = useAppStore
+        .getState()
+        .getEnvironmentByName(environmentName);
       return {
         databaseName,
         environmentTitle: environment.title,

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
@@ -22,7 +22,7 @@ import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
-import { pushNotification, useEnvironmentV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
 import {
@@ -598,16 +598,17 @@ function IssueDetailTaskDatabaseName({ task }: { task: Task }) {
 function IssueDetailDatabaseTarget({ target }: { target: string }) {
   const { t } = useTranslation();
   const databasesByName = useAppStore((s) => s.databasesByName);
-  const environmentStore = useEnvironmentV1Store();
+  const environmentList = useAppStore((s) => s.environmentList);
   const database = useVueState(
     () => databasesByName[target] ?? unknownDatabase()
   );
-  const environment = useVueState(() =>
-    environmentStore.getEnvironmentByName(
-      database.effectiveEnvironment ??
-        database.instanceResource?.environment ??
-        ""
-    )
+  const environmentName =
+    database.effectiveEnvironment ??
+    database.instanceResource?.environment ??
+    "";
+  const environment = useMemo(
+    () => useAppStore.getState().getEnvironmentByName(environmentName),
+    [environmentList, environmentName]
   );
   const instance = database.instanceResource;
   const { databaseName } = extractDatabaseResourceName(target);
@@ -637,9 +638,10 @@ function IssueDetailStageEnvironment({
 }: {
   environmentName: string;
 }) {
-  const environmentStore = useEnvironmentV1Store();
-  const environment = useVueState(() =>
-    environmentStore.getEnvironmentByName(environmentName)
+  const environmentList = useAppStore((s) => s.environmentList);
+  const environment = useMemo(
+    () => useAppStore.getState().getEnvironmentByName(environmentName),
+    [environmentList, environmentName]
   );
 
   return (

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
@@ -17,7 +17,6 @@ import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
-import { useEnvironmentV1Store } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import {
   getDateForPbTimestampProtoEs,
@@ -312,13 +311,14 @@ function IssueDetailTaskRunDateCell({
 
 function IssueDetailTaskRunDatabaseCell({ database }: { database: Database }) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
-  const environment = useVueState(() =>
-    environmentStore.getEnvironmentByName(
-      database.effectiveEnvironment ??
-        database.instanceResource?.environment ??
-        ""
-    )
+  const environmentList = useAppStore((s) => s.environmentList);
+  const environmentName =
+    database.effectiveEnvironment ??
+    database.instanceResource?.environment ??
+    "";
+  const environment = useMemo(
+    () => useAppStore.getState().getEnvironmentByName(environmentName),
+    [environmentList, environmentName]
   );
   const instance = database.instanceResource;
   const { databaseName } = extractDatabaseResourceName(database.name);

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
@@ -265,7 +265,6 @@ vi.mock("@/store", () => ({
   getProjectNameAndDatabaseGroupName: (name: string) =>
     name.split("/databaseGroups/"),
   pushNotification: vi.fn(),
-  useEnvironmentV1Store: () => mocks.environmentStore,
 }));
 
 // The migrated component reads resource state via imperative
@@ -305,6 +304,7 @@ vi.mock("@/react/stores/app", async () => {
         dbGroupsByName: Record<string, unknown>;
         dbGroupViewByName: Record<string, unknown>;
         projectsByName: Record<string, unknown>;
+        environmentList: unknown[];
       }) => unknown
     ) =>
       selector({
@@ -312,12 +312,14 @@ vi.mock("@/react/stores/app", async () => {
         dbGroupsByName,
         dbGroupViewByName,
         projectsByName,
+        environmentList: [],
       }),
     {
       getState: () => ({
         ...mocks.databaseStore,
         ...mocks.dbGroupStore,
         getProjectByName: mocks.projectStore.getProjectByName,
+        getEnvironmentByName: mocks.environmentStore.getEnvironmentByName,
       }),
     }
   );

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
@@ -21,7 +21,7 @@ import { Tooltip } from "@/react/components/ui/tooltip";
 import { useCurrentUser } from "@/react/hooks/useAppState";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
-import { pushNotification, useEnvironmentV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
 import type { Stage, Task } from "@/types/proto-es/v1/rollout_service_pb";
@@ -606,8 +606,11 @@ function PlanDetailStageEnvironment({
 }: {
   environmentName: string;
 }) {
-  const environmentStore = useEnvironmentV1Store();
-  const environment = environmentStore.getEnvironmentByName(environmentName);
+  const environmentList = useAppStore((s) => s.environmentList);
+  const environment = useMemo(
+    () => useAppStore.getState().getEnvironmentByName(environmentName),
+    [environmentList, environmentName]
+  );
 
   return (
     <span className="text-sm text-control">

--- a/frontend/src/react/pages/project/plan-detail/components/PlanTargetDisplay.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanTargetDisplay.test.tsx
@@ -10,9 +10,8 @@ import { PlanTargetDisplay } from "./PlanTargetDisplay";
 
 const mocks = vi.hoisted(() => ({
   databasesByName: {} as Record<string, unknown>,
-  environmentStore: {
-    getEnvironmentByName: vi.fn(),
-  },
+  environmentList: [] as unknown[],
+  getEnvironmentByName: vi.fn(),
 }));
 
 vi.mock("@/react/components/EngineIcon", () => ({
@@ -34,15 +33,18 @@ vi.mock("@/react/lib/utils", () => ({
     classes.filter(Boolean).join(" "),
 }));
 
-vi.mock("@/react/stores/app", () => ({
-  useAppStore: <T,>(
-    selector: (state: { databasesByName: Record<string, unknown> }) => T
-  ) => selector({ databasesByName: mocks.databasesByName }),
-}));
-
-vi.mock("@/store", () => ({
-  useEnvironmentV1Store: () => mocks.environmentStore,
-}));
+vi.mock("@/react/stores/app", () => {
+  const getState = () => ({
+    databasesByName: mocks.databasesByName,
+    environmentList: mocks.environmentList,
+    getEnvironmentByName: mocks.getEnvironmentByName,
+  });
+  const useAppStore = <T,>(
+    selector: (state: ReturnType<typeof getState>) => T
+  ) => selector(getState());
+  useAppStore.getState = getState;
+  return { useAppStore };
+});
 
 vi.mock("@/types", () => ({
   isValidDatabaseName: (name: string) => name.includes("/databases/"),
@@ -75,7 +77,7 @@ describe("PlanTargetDisplay", () => {
         },
       },
     };
-    mocks.environmentStore.getEnvironmentByName.mockReturnValue({
+    mocks.getEnvironmentByName.mockReturnValue({
       name: "environments/prod",
       title: "Production",
     });

--- a/frontend/src/react/pages/project/plan-detail/components/PlanTargetDisplay.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanTargetDisplay.tsx
@@ -1,8 +1,8 @@
 import { ChevronRight } from "lucide-react";
+import { useMemo } from "react";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
-import { useEnvironmentV1Store } from "@/store";
 import { isValidDatabaseName } from "@/types";
 import { unknownDatabase } from "@/types/v1/database";
 import { extractDatabaseResourceName, getInstanceResource } from "@/utils";
@@ -54,8 +54,21 @@ export function PlanTargetDisplay({
   target: string;
 }) {
   const databasesByName = useAppStore((s) => s.databasesByName);
-  const environmentStore = useEnvironmentV1Store();
+  const environmentList = useAppStore((s) => s.environmentList);
   const classes = sizeClasses[size];
+
+  const database = databasesByName[target] ?? unknownDatabase();
+  const environmentName =
+    database.effectiveEnvironment ??
+    database.instanceResource?.environment ??
+    "";
+  const environment = useMemo(
+    () =>
+      environmentName
+        ? useAppStore.getState().getEnvironmentByName(environmentName)
+        : undefined,
+    [environmentList, environmentName]
+  );
 
   if (!isValidDatabaseName(target)) {
     return (
@@ -71,14 +84,6 @@ export function PlanTargetDisplay({
     );
   }
 
-  const database = databasesByName[target] ?? unknownDatabase();
-  const environmentName =
-    database.effectiveEnvironment ??
-    database.instanceResource?.environment ??
-    "";
-  const environment = environmentName
-    ? environmentStore.getEnvironmentByName(environmentName)
-    : undefined;
   const instance = getInstanceResource(database);
   const { databaseName } = extractDatabaseResourceName(target);
   const shouldShowSeparator = showInstance && Boolean(instance.title);

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployStageCard.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployStageCard.tsx
@@ -1,16 +1,20 @@
 import { ArrowRight, Eye } from "lucide-react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
 import { cn } from "@/react/lib/utils";
-import { useEnvironmentV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import type { Rollout, Stage } from "@/types/proto-es/v1/rollout_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { getStageStatus } from "@/utils";
 import { PlanDetailTabItem, PlanDetailTabStrip } from "../PlanDetailTabStrip";
 
 function StageProgressCard({ stage }: { stage: Stage }) {
-  const environmentStore = useEnvironmentV1Store();
-  const env = environmentStore.getEnvironmentByName(stage.environment);
+  const environmentList = useAppStore((s) => s.environmentList);
+  const env = useMemo(
+    () => useAppStore.getState().getEnvironmentByName(stage.environment),
+    [environmentList, stage.environment]
+  );
   const completed = stage.tasks.filter(
     (task) =>
       task.status === Task_Status.DONE || task.status === Task_Status.SKIPPED

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/react/components/ui/dropdown-menu";
 import { Tooltip } from "@/react/components/ui/tooltip";
-import { useEnvironmentV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import { getTimeForPbTimestampProtoEs } from "@/types";
 import type { Task } from "@/types/proto-es/v1/rollout_service_pb";
 import {
@@ -39,7 +39,7 @@ import { useDeployTaskStatement } from "./useDeployTaskStatement";
 export function DeployTaskDetailPanel({ task }: { task: Task }) {
   const { t } = useTranslation();
   const page = usePlanDetailContext();
-  const environmentStore = useEnvironmentV1Store();
+  const environmentList = useAppStore((s) => s.environmentList);
   const project = page.project;
   const taskRuns = useMemo(
     () =>
@@ -73,9 +73,13 @@ export function DeployTaskDetailPanel({ task }: { task: Task }) {
       ),
     [page.rollout?.stages, task.name]
   );
-  const stageTitle = stage?.environment
-    ? environmentStore.getEnvironmentByName(stage.environment).title
-    : "";
+  const stageTitle = useMemo(
+    () =>
+      stage?.environment
+        ? useAppStore.getState().getEnvironmentByName(stage.environment).title
+        : "",
+    [environmentList, stage?.environment]
+  );
   const scheduledTimeDisplay = useMemo(() => {
     const ts = getTimeForPbTimestampProtoEs(task.runTime, 0);
     if (!ts) return "";

--- a/frontend/src/react/pages/project/plan-detail/utils/rolloutPreview.ts
+++ b/frontend/src/react/pages/project/plan-detail/utils/rolloutPreview.ts
@@ -1,6 +1,5 @@
 import { create } from "@bufbuild/protobuf";
 import { useAppStore } from "@/react/stores/app";
-import { useEnvironmentV1Store } from "@/store";
 import { isValidDatabaseGroupName, isValidDatabaseName } from "@/types";
 import { DatabaseGroupView } from "@/types/proto-es/v1/database_group_service_pb";
 import type {
@@ -154,8 +153,7 @@ async function generateChangeDatabaseTasks(
 }
 
 function getEnvironmentOrder(): string[] {
-  const environmentStore = useEnvironmentV1Store();
-  return environmentStore.environmentList.map((env) => env.name);
+  return useAppStore.getState().environmentList.map((env) => env.name);
 }
 
 function groupTasksIntoStages(

--- a/frontend/src/react/pages/settings/CreateInstancePage.tsx
+++ b/frontend/src/react/pages/settings/CreateInstancePage.tsx
@@ -9,13 +9,10 @@ import {
   useInstanceFormContext,
 } from "@/react/components/instance";
 import type { InfoSection } from "@/react/components/instance/info-content";
+import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { INSTANCE_ROUTE_DASHBOARD } from "@/router/dashboard/workspaceRoutes";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 
 const MIN_DOCKED_MAIN_WIDTH = 700;
 const DOCKED_INFO_RAIL_WIDTH = 500;
@@ -25,26 +22,22 @@ const MIN_DOCKED_LAYOUT_WIDTH =
 
 export function CreateInstancePage() {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
-  const actuatorStore = useActuatorV1Store();
 
   // Check instance limit on mount
   useEffect(() => {
-    if (
-      subscriptionStore.instanceCountLimit <=
-      actuatorStore.activatedInstanceCount
-    ) {
+    const store = useAppStore.getState();
+    if (store.instanceCountLimit() <= store.activatedInstanceCount()) {
       pushNotification({
         module: "bytebase",
         style: "CRITICAL",
         title: t("subscription.usage.instance-count.title"),
         description: t("subscription.usage.instance-count.runoutof", {
-          total: subscriptionStore.instanceCountLimit,
+          total: store.instanceCountLimit(),
         }),
       });
       router.push({ name: INSTANCE_ROUTE_DASHBOARD });
     }
-  }, [subscriptionStore, actuatorStore, t]);
+  }, [t]);
 
   const goBack = useCallback(() => {
     router.push({ name: INSTANCE_ROUTE_DASHBOARD });

--- a/frontend/src/react/pages/settings/CustomApprovalPage.tsx
+++ b/frontend/src/react/pages/settings/CustomApprovalPage.tsx
@@ -6,24 +6,23 @@ import { APPROVAL_SOURCES } from "@/react/components/CustomApproval/utils";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { Alert } from "@/react/components/ui/alert";
 import { useVueState } from "@/react/hooks/useVueState";
+import { useAppStore } from "@/react/stores/app";
 import {
   useWorkspaceApprovalSettingStore,
   type WorkspaceApprovalSettingState,
 } from "@/react/stores/workspaceApprovalSetting";
-import { useSubscriptionV1Store } from "@/store";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
 export function CustomApprovalPage() {
   const { t } = useTranslation();
   const store = useWorkspaceApprovalSettingStore();
-  const subscriptionStore = useSubscriptionV1Store();
   const featureAttentionRef = useRef<HTMLDivElement>(null);
 
   const [ready, setReady] = useState(false);
 
-  const hasFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_APPROVAL_WORKFLOW)
+  const hasFeature = useAppStore((s) =>
+    s.hasInstanceFeature(PlanFeature.FEATURE_APPROVAL_WORKFLOW)
   );
   const allowAdmin = hasWorkspacePermissionV2("bb.settings.set");
 

--- a/frontend/src/react/pages/settings/DataClassificationPage.tsx
+++ b/frontend/src/react/pages/settings/DataClassificationPage.tsx
@@ -8,13 +8,9 @@ import { ClassificationTree } from "@/react/components/ClassificationTree";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { Button } from "@/react/components/ui/button";
-import { useVueState } from "@/react/hooks/useVueState";
 import classificationExample from "@/react/lib/sensitive-data/classification-example.json";
-import {
-  pushNotification,
-  useSettingV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification } from "@/store";
 import type {
   DataClassificationSetting_DataClassificationConfig_DataClassification as DataClassification,
   DataClassificationSetting_DataClassificationConfig,
@@ -131,17 +127,17 @@ function MonacoJSONEditor({
 
 export function DataClassificationPage() {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
 
-  const hasClassificationFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(
-      PlanFeature.FEATURE_DATA_CLASSIFICATION
-    )
+  const hasClassificationFeature = useAppStore((s) =>
+    s.hasInstanceFeature(PlanFeature.FEATURE_DATA_CLASSIFICATION)
   );
   const allowEdit = hasWorkspacePermissionV2("bb.settings.set");
 
-  const classificationConfigs = useVueState(() => settingStore.classification);
+  const settingsByName = useAppStore((s) => s.settingsByName);
+  const classificationConfigs = useMemo(
+    () => useAppStore.getState().classification(),
+    [settingsByName]
+  );
 
   const [loaded, setLoaded] = useState(false);
   const [editing, setEditing] = useState(false);
@@ -171,10 +167,11 @@ export function DataClassificationPage() {
 
   // Fetch setting on mount
   useEffect(() => {
-    settingStore
+    useAppStore
+      .getState()
       .getOrFetchSettingByName(Setting_SettingName.DATA_CLASSIFICATION)
       .then(() => setLoaded(true));
-  }, [settingStore]);
+  }, []);
 
   // Sync editor content when not editing
   useEffect(() => {
@@ -193,7 +190,7 @@ export function DataClassificationPage() {
 
   const upsertSetting = useCallback(
     async (configs: DataClassificationSetting_DataClassificationConfig[]) => {
-      await settingStore.upsertSetting({
+      await useAppStore.getState().upsertSetting({
         name: Setting_SettingName.DATA_CLASSIFICATION,
         value: create(SettingValueSchema, {
           value: {
@@ -210,7 +207,7 @@ export function DataClassificationPage() {
         title: t("common.updated"),
       });
     },
-    [settingStore, t]
+    [t]
   );
 
   const onSave = async () => {

--- a/frontend/src/react/pages/settings/DatabasesPage.tsx
+++ b/frontend/src/react/pages/settings/DatabasesPage.tsx
@@ -22,15 +22,10 @@ import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { Button } from "@/react/components/ui/button";
-import { useVueState } from "@/react/hooks/useVueState";
 import type { DatabaseFilter } from "@/react/lib/databaseFilter";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useEnvironmentV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import {
   environmentNamePrefix,
   instanceNamePrefix,
@@ -64,8 +59,6 @@ export function DatabasesPage() {
   const removeDatabaseMetadataCache = useAppStore(
     (s) => s.removeDatabaseMetadataCache
   );
-  const actuatorStore = useActuatorV1Store();
-  const environmentStore = useEnvironmentV1Store();
 
   const [syncing, setSyncing] = useState(false);
   const [showCreateDrawer, setShowCreateDrawer] = useState(false);
@@ -110,23 +103,21 @@ export function DatabasesPage() {
         {
           id: "project",
           value: extractProjectResourceName(
-            actuatorStore.serverInfo?.defaultProject ?? ""
+            useAppStore.getState().serverInfo?.defaultProject ?? ""
           ),
         },
       ],
     };
   });
 
-  const environments = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environments = useAppStore((s) => s.environmentList);
 
   // `serverInfo.defaultProject` is fetched asynchronously by the actuator
-  // store; wrap with `useVueState` so the filter value updates the moment
-  // it arrives instead of being captured as an empty string on first
-  // render (which sends a broken `projects/` filter to the backend).
-  const defaultProjectId = useVueState(() =>
-    extractProjectResourceName(actuatorStore.serverInfo?.defaultProject ?? "")
+  // store; use a selector so the filter value updates the moment it arrives
+  // instead of being captured as an empty string on first render (which
+  // sends a broken `projects/` filter to the backend).
+  const defaultProjectId = useAppStore((s) =>
+    extractProjectResourceName(s.serverInfo?.defaultProject ?? "")
   );
   // Shared "Unassigned" option used both by the dropdown (via onSearch) and
   // by the selected-tag display (via the scope's static `options`). `custom`

--- a/frontend/src/react/pages/settings/EnvironmentsPage.tsx
+++ b/frontend/src/react/pages/settings/EnvironmentsPage.tsx
@@ -68,12 +68,7 @@ import {
   WORKSPACE_ROUTE_SQL_REVIEW_CREATE,
   WORKSPACE_ROUTE_SQL_REVIEW_DETAIL,
 } from "@/router/dashboard/workspaceRoutes";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useEnvironmentV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import { environmentNamePrefix } from "@/store/modules/v1/common";
 import {
   formatEnvironmentName,
@@ -114,9 +109,8 @@ function EnvironmentName({
   environment: Environment;
   link?: boolean;
 }) {
-  const subscriptionStore = useSubscriptionV1Store();
-  const hasEnvTierFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_ENVIRONMENT_TIERS)
+  const hasEnvTierFeature = useAppStore((s) =>
+    s.hasInstanceFeature(PlanFeature.FEATURE_ENVIRONMENT_TIERS)
   );
   const color = environment.color || "#4f46e5";
   const rgbValues = hexToRgb(color);
@@ -201,10 +195,9 @@ function RolloutPolicyConfig({
   onChange: (policy: Policy) => void;
 }) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
   const roleList = useAppStore((state) => state.roleList);
-  const hasCustomRoleFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_CUSTOM_ROLES)
+  const hasCustomRoleFeature = useAppStore((s) =>
+    s.hasInstanceFeature(PlanFeature.FEATURE_CUSTOM_ROLES)
   );
   const canUpdatePolicy = hasWorkspacePermissionV2("bb.policies.update");
 
@@ -645,8 +638,6 @@ function EnvironmentDetail({
   onDirtyChange: (dirty: boolean) => void;
 }) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
   const refreshEnvironmentList = useAppStore(
     (state) => state.refreshEnvironmentList
   );
@@ -670,8 +661,8 @@ function EnvironmentDetail({
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [sqlReviewDirty, setSqlReviewDirty] = useState(false);
 
-  const hasEnvironmentTiers = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_ENVIRONMENT_TIERS)
+  const hasEnvironmentTiers = useAppStore((s) =>
+    s.hasInstanceFeature(PlanFeature.FEATURE_ENVIRONMENT_TIERS)
   );
 
   const environmentList = useEnvironmentList();
@@ -709,8 +700,6 @@ function EnvironmentDetail({
   }, [environment.id]);
 
   // Check for related resources (instances/databases)
-  const actuatorStore = useActuatorV1Store();
-
   useEffect(() => {
     const checkRelatedResources = async () => {
       if (!canEdit || environmentList.length <= 1) {
@@ -726,7 +715,7 @@ function EnvironmentDetail({
           }),
           useAppStore.getState().fetchDatabases({
             pageSize: 1,
-            parent: actuatorStore.workspaceResourceName,
+            parent: useAppStore.getState().workspaceResourceName(),
             filter: { environment: environment.name },
             silent: true,
           }),
@@ -739,13 +728,7 @@ function EnvironmentDetail({
       }
     };
     checkRelatedResources();
-  }, [
-    environment.id,
-    environment.name,
-    canEdit,
-    environmentList.length,
-    actuatorStore,
-  ]);
+  }, [environment.id, environment.name, canEdit, environmentList.length]);
 
   const envChanged = useMemo(() => {
     return (
@@ -786,7 +769,7 @@ function EnvironmentDetail({
     if (envChanged) {
       const newTags = { ...environment.tags };
       newTags.protected = editProtected ? "protected" : "unprotected";
-      const updated = await environmentStore.updateEnvironment({
+      const updated = await useAppStore.getState().updateEnvironment({
         ...environment,
         title: editTitle,
         color: editColor,
@@ -1054,11 +1037,9 @@ function CreateSheet({
   }) => void;
 }) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
-  const environmentStore = useEnvironmentV1Store();
 
-  const hasEnvironmentTiers = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_ENVIRONMENT_TIERS)
+  const hasEnvironmentTiers = useAppStore((s) =>
+    s.hasInstanceFeature(PlanFeature.FEATURE_ENVIRONMENT_TIERS)
   );
 
   const [title, setTitle] = useState("");
@@ -1107,10 +1088,9 @@ function CreateSheet({
 
   const validateResourceId = useCallback(
     async (id: string) => {
-      const env = environmentStore.getEnvironmentByName(
-        `${environmentNamePrefix}${id}`,
-        false
-      );
+      const env = useAppStore
+        .getState()
+        .getEnvironmentByName(`${environmentNamePrefix}${id}`, false);
       if (isValidEnvironmentName(env.name)) {
         return [
           {
@@ -1123,7 +1103,7 @@ function CreateSheet({
       }
       return [];
     },
-    [environmentStore, t]
+    [t]
   );
 
   const onColorChange = (newColor: string) => {
@@ -1435,7 +1415,6 @@ function ReorderSheetInner({
 // ============================================================
 export function EnvironmentsPage() {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
   const refreshEnvironmentList = useAppStore(
     (state) => state.refreshEnvironmentList
   );
@@ -1454,8 +1433,8 @@ export function EnvironmentsPage() {
   const canEdit = hasWorkspacePermissionV2("bb.settings.setEnvironment");
 
   useEffect(() => {
-    void environmentStore.fetchEnvironments();
-  }, [environmentStore]);
+    void useAppStore.getState().fetchEnvironments();
+  }, []);
 
   // Initialize selected tab and intro state
   useEffect(() => {
@@ -1526,7 +1505,7 @@ export function EnvironmentsPage() {
       "",
       PolicyResourceType.ENVIRONMENT
     );
-    const createdEnvironment = await environmentStore.createEnvironment({
+    const createdEnvironment = await useAppStore.getState().createEnvironment({
       id: environment.id,
       title: environment.title,
       order: environmentList.length,
@@ -1548,9 +1527,9 @@ export function EnvironmentsPage() {
   };
 
   const handleDelete = async (environment: Environment) => {
-    await environmentStore.deleteEnvironment(
-      formatEnvironmentName(environment.id)
-    );
+    await useAppStore
+      .getState()
+      .deleteEnvironment(formatEnvironmentName(environment.id));
     pushNotification({
       module: "bytebase",
       style: "SUCCESS",
@@ -1564,7 +1543,7 @@ export function EnvironmentsPage() {
   };
 
   const handleReorder = async (reordered: Environment[]) => {
-    await environmentStore.reorderEnvironmentList(reordered);
+    await useAppStore.getState().reorderEnvironmentList(reordered);
     await refreshEnvironmentList();
     setShowReorder(false);
     pushNotification({

--- a/frontend/src/react/pages/settings/GlobalMaskingPage.tsx
+++ b/frontend/src/react/pages/settings/GlobalMaskingPage.tsx
@@ -36,12 +36,7 @@ import {
   getClassificationLevelOptions,
 } from "@/react/lib/sensitive-data/components-utils";
 import { useAppStore } from "@/react/stores/app";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useSettingV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import { ExprSchema } from "@/types/proto-es/google/type/expr_pb";
 import type {
   MaskingRulePolicy_MaskingRule,
@@ -112,7 +107,6 @@ function MaskingRuleConfig({
   onConfirm: (rule: MaskingRulePolicy_MaskingRule) => void;
 }) {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
 
   const readonly = mode === "NORMAL";
 
@@ -126,15 +120,17 @@ function MaskingRuleConfig({
   const [dirty, setDirty] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  const semanticTypeOptions = useVueState(() => {
-    const setting = settingStore.getSettingByName(
-      Setting_SettingName.SEMANTIC_TYPES
-    );
+  const settingsByName = useAppStore((s) => s.settingsByName);
+  const semanticTypeOptions = useMemo(() => {
+    const setting = useAppStore
+      .getState()
+      .getSettingByName(Setting_SettingName.SEMANTIC_TYPES);
     if (setting?.value?.value?.case === "semanticType") {
       return setting.value.value.value.types ?? [];
     }
     return [];
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settingsByName]);
 
   const resetIdRef = useRef(0);
   const resetToRule = useCallback(
@@ -358,12 +354,9 @@ function MaskingRuleConfig({
 
 export function GlobalMaskingPage() {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
-  const settingStore = useSettingV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
 
   const hasSensitiveDataFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_DATA_MASKING)
+    useAppStore.getState().hasInstanceFeature(PlanFeature.FEATURE_DATA_MASKING)
   );
 
   const hasPermission = hasWorkspacePermissionV2(
@@ -394,7 +387,7 @@ export function GlobalMaskingPage() {
   );
 
   const factorOptionsMap = useMemo((): Map<Factor, OptionConfig> => {
-    const workspaceName = actuatorStore.workspaceResourceName;
+    const workspaceName = useAppStore.getState().workspaceResourceName();
     return factorList.reduce((map, factor) => {
       switch (factor) {
         case CEL_ATTRIBUTE_RESOURCE_ENVIRONMENT_ID:
@@ -424,7 +417,7 @@ export function GlobalMaskingPage() {
       const policy = await useAppStore
         .getState()
         .getOrFetchPolicyByParentAndType({
-          parentPath: actuatorStore.workspaceResourceName,
+          parentPath: useAppStore.getState().workspaceResourceName(),
           policyType: PolicyType.MASKING_RULE,
         });
       if (policy) {
@@ -435,14 +428,12 @@ export function GlobalMaskingPage() {
         setItems(rules.map((rule) => ({ mode: "NORMAL", rule })));
       }
       await Promise.all([
-        settingStore.getOrFetchSettingByName(
-          Setting_SettingName.SEMANTIC_TYPES,
-          true
-        ),
-        settingStore.getOrFetchSettingByName(
-          Setting_SettingName.DATA_CLASSIFICATION,
-          true
-        ),
+        useAppStore
+          .getState()
+          .getOrFetchSettingByName(Setting_SettingName.SEMANTIC_TYPES, true),
+        useAppStore
+          .getState()
+          .getOrFetchSettingByName(Setting_SettingName.DATA_CLASSIFICATION, true),
       ]);
     };
     load();
@@ -462,7 +453,7 @@ export function GlobalMaskingPage() {
       },
     };
     await useAppStore.getState().upsertPolicy({
-      parentPath: actuatorStore.workspaceResourceName,
+      parentPath: useAppStore.getState().workspaceResourceName(),
       policy: patch,
     });
   }, []);
@@ -576,7 +567,7 @@ export function GlobalMaskingPage() {
                 useAppStore
                   .getState()
                   .getOrFetchPolicyByParentAndType({
-                    parentPath: actuatorStore.workspaceResourceName,
+                    parentPath: useAppStore.getState().workspaceResourceName(),
                     policyType: PolicyType.MASKING_RULE,
                   })
                   .then((policy) => {

--- a/frontend/src/react/pages/settings/GlobalMaskingPage.tsx
+++ b/frontend/src/react/pages/settings/GlobalMaskingPage.tsx
@@ -129,7 +129,6 @@ function MaskingRuleConfig({
       return setting.value.value.value.types ?? [];
     }
     return [];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settingsByName]);
 
   const resetIdRef = useRef(0);
@@ -433,7 +432,10 @@ export function GlobalMaskingPage() {
           .getOrFetchSettingByName(Setting_SettingName.SEMANTIC_TYPES, true),
         useAppStore
           .getState()
-          .getOrFetchSettingByName(Setting_SettingName.DATA_CLASSIFICATION, true),
+          .getOrFetchSettingByName(
+            Setting_SettingName.DATA_CLASSIFICATION,
+            true
+          ),
       ]);
     };
     load();

--- a/frontend/src/react/pages/settings/GlobalMaskingPage.tsx
+++ b/frontend/src/react/pages/settings/GlobalMaskingPage.tsx
@@ -381,8 +381,13 @@ export function GlobalMaskingPage() {
 
   // Subscribe to reactive store data so the memo recomputes when settings load.
   const environmentOptions = useVueState(() => getEnvironmentIdOptions());
-  const classificationOptions = useVueState(() =>
-    getClassificationLevelOptions()
+  // `getClassificationLevelOptions` reads the app store imperatively, so key
+  // this on a `settingsByName` subscription to recompute once the
+  // DATA_CLASSIFICATION setting resolves.
+  const classificationSettingsByName = useAppStore((s) => s.settingsByName);
+  const classificationOptions = useMemo(
+    () => getClassificationLevelOptions(),
+    [classificationSettingsByName]
   );
 
   const factorOptionsMap = useMemo((): Map<Factor, OptionConfig> => {

--- a/frontend/src/react/pages/settings/GroupsPage.tsx
+++ b/frontend/src/react/pages/settings/GroupsPage.tsx
@@ -51,12 +51,7 @@ import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { SETTING_ROUTE_WORKSPACE_GENERAL } from "@/router/dashboard/workspaceSetting";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useSettingV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import { extractUserEmail, groupNamePrefix } from "@/store/modules/v1/common";
 import { UNKNOWN_USER_NAME } from "@/types";
 import type { Group, GroupMember } from "@/types/proto-es/v1/group_service_pb";
@@ -482,10 +477,8 @@ function GroupForm({
   onRemoved,
 }: Omit<CreateGroupSheetProps, "open">) {
   const { t } = useTranslation();
-  const settingV1Store = useSettingV1Store();
-  const actuatorStore = useActuatorV1Store();
   const currentUser = useCurrentUser();
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const isSaaSMode = useVueState(() => useAppStore.getState().isSaaSMode());
   const getOrFetchUserByIdentifier = useAppStore(
     (state) => state.getOrFetchUserByIdentifier
   );
@@ -494,8 +487,8 @@ function GroupForm({
   const deleteGroup = useAppStore((state) => state.deleteGroup);
 
   const isEditMode = !!group;
-  const workspaceDomains = useVueState(
-    () => settingV1Store.workspaceProfile.domains
+  const workspaceDomains = useAppStore(
+    (s) => s.getWorkspaceProfile().domains
   );
   const domainOptions = workspaceDomains.filter((d) => d.trim());
 
@@ -932,19 +925,15 @@ function GroupForm({
 
 export function GroupsPage() {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
-  const settingV1Store = useSettingV1Store();
   const listGroups = useAppStore((state) => state.listGroups);
   const fetchGroup = useAppStore((state) => state.fetchGroup);
 
   const hasUserGroupFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_USER_GROUPS)
+    useAppStore.getState().hasInstanceFeature(PlanFeature.FEATURE_USER_GROUPS)
   );
-  const workspaceDomains = useVueState(
-    () => settingV1Store.workspaceProfile.domains
-  );
+  const workspaceDomains = useAppStore((s) => s.getWorkspaceProfile().domains);
   const hasDirectorySyncFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_DIRECTORY_SYNC)
+    useAppStore.getState().hasInstanceFeature(PlanFeature.FEATURE_DIRECTORY_SYNC)
   );
   const canAccessSettings = hasWorkspacePermissionV2("bb.settings.get");
 

--- a/frontend/src/react/pages/settings/GroupsPage.tsx
+++ b/frontend/src/react/pages/settings/GroupsPage.tsx
@@ -487,9 +487,7 @@ function GroupForm({
   const deleteGroup = useAppStore((state) => state.deleteGroup);
 
   const isEditMode = !!group;
-  const workspaceDomains = useAppStore(
-    (s) => s.getWorkspaceProfile().domains
-  );
+  const workspaceDomains = useAppStore((s) => s.getWorkspaceProfile().domains);
   const domainOptions = workspaceDomains.filter((d) => d.trim());
 
   // Initial values derived from the group prop. The parent keys this
@@ -933,7 +931,9 @@ export function GroupsPage() {
   );
   const workspaceDomains = useAppStore((s) => s.getWorkspaceProfile().domains);
   const hasDirectorySyncFeature = useVueState(() =>
-    useAppStore.getState().hasInstanceFeature(PlanFeature.FEATURE_DIRECTORY_SYNC)
+    useAppStore
+      .getState()
+      .hasInstanceFeature(PlanFeature.FEATURE_DIRECTORY_SYNC)
   );
   const canAccessSettings = hasWorkspacePermissionV2("bb.settings.get");
 

--- a/frontend/src/react/pages/settings/IDPsPage.tsx
+++ b/frontend/src/react/pages/settings/IDPsPage.tsx
@@ -1974,9 +1974,7 @@ export function IDPsPage() {
   const [showCreateDrawer, setShowCreateDrawer] = useState(false);
 
   const hasSSOFeature = useVueState(() =>
-    useAppStore
-      .getState()
-      .hasFeature(PlanFeature.FEATURE_GOOGLE_AND_GITHUB_SSO)
+    useAppStore.getState().hasFeature(PlanFeature.FEATURE_GOOGLE_AND_GITHUB_SSO)
   );
   const canCreate = hasWorkspacePermissionV2("bb.identityProviders.create");
 

--- a/frontend/src/react/pages/settings/IDPsPage.tsx
+++ b/frontend/src/react/pages/settings/IDPsPage.tsx
@@ -52,11 +52,7 @@ import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { WORKSPACE_ROUTE_IDENTITY_PROVIDER_DETAIL } from "@/router/dashboard/workspaceRoutes";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import {
   getIdentityProviderResourceId,
   idpNamePrefix,
@@ -140,9 +136,8 @@ interface FieldMappingState {
 
 function ExternalURLInfo({ type }: { type: IdentityProviderType }) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
   const externalUrl = useVueState(
-    () => actuatorStore.serverInfo?.externalUrl ?? ""
+    () => useAppStore.getState().serverInfo?.externalUrl ?? ""
   );
 
   const redirectUrl = useMemo(() => {
@@ -1304,11 +1299,10 @@ function CreateWizardDrawer({
     (state) => state.createIdentityProvider
   );
   const identityProviderList = useIdentityProviderList();
-  const subscriptionStore = useSubscriptionV1Store();
   useEscapeKey(onClose);
 
   const hasEnterpriseSSOFeature = useVueState(() =>
-    subscriptionStore.hasFeature(PlanFeature.FEATURE_ENTERPRISE_SSO)
+    useAppStore.getState().hasFeature(PlanFeature.FEATURE_ENTERPRISE_SSO)
   );
 
   const [currentStep, setCurrentStep] = useState(1);
@@ -1713,9 +1707,9 @@ function CreateWizardDrawer({
                   <div className="max-w-2xl mx-auto w-full">
                     {PROVIDER_TYPE_LIST.map((item) => {
                       const Icon = getProviderIcon(item.type);
-                      const hasFeature = subscriptionStore.hasFeature(
-                        item.feature
-                      );
+                      const hasFeature = useAppStore
+                        .getState()
+                        .hasFeature(item.feature);
                       return (
                         <label
                           key={item.type}
@@ -1770,9 +1764,9 @@ function CreateWizardDrawer({
                   <div className="max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-4">
                     {templateList.map((tmpl) => {
                       const Icon = getTemplateIcon(tmpl.title);
-                      const hasFeature = subscriptionStore.hasFeature(
-                        tmpl.feature
-                      );
+                      const hasFeature = useAppStore
+                        .getState()
+                        .hasFeature(tmpl.feature);
                       return (
                         <label
                           key={tmpl.title}
@@ -1976,20 +1970,20 @@ export function IDPsPage() {
     (state) => state.listIdentityProviders
   );
 
-  const subscriptionStore = useSubscriptionV1Store();
-
   const [ready, setReady] = useState(false);
   const [showCreateDrawer, setShowCreateDrawer] = useState(false);
 
   const hasSSOFeature = useVueState(() =>
-    subscriptionStore.hasFeature(PlanFeature.FEATURE_GOOGLE_AND_GITHUB_SSO)
+    useAppStore
+      .getState()
+      .hasFeature(PlanFeature.FEATURE_GOOGLE_AND_GITHUB_SSO)
   );
   const canCreate = hasWorkspacePermissionV2("bb.identityProviders.create");
 
   useEffect(() => {
-    listIdentityProviders(useActuatorV1Store().workspaceResourceName).finally(
-      () => setReady(true)
-    );
+    listIdentityProviders(
+      useAppStore.getState().workspaceResourceName()
+    ).finally(() => setReady(true));
   }, [listIdentityProviders]);
 
   const handleCreateSSO = () => {

--- a/frontend/src/react/pages/settings/IMPage.tsx
+++ b/frontend/src/react/pages/settings/IMPage.tsx
@@ -236,11 +236,7 @@ export function IMPage() {
 
   // Subscribe to store changes
   const settingsByName = useAppStore((s) => s.settingsByName);
-  const storedSetting = useMemo(
-    () => getStoredIMSetting(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [settingsByName]
-  );
+  const storedSetting = useMemo(() => getStoredIMSetting(), [settingsByName]);
 
   // Local state
   const [localSettings, setLocalSettings] = useState<AppIMSetting_IMSetting[]>(

--- a/frontend/src/react/pages/settings/IMPage.tsx
+++ b/frontend/src/react/pages/settings/IMPage.tsx
@@ -1,7 +1,13 @@
 import { clone, create } from "@bufbuild/protobuf";
 import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import { Plus, Trash2 } from "lucide-react";
-import { type ChangeEvent, useCallback, useEffect, useState } from "react";
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 // Static image imports — Vite cannot resolve dynamic src in <img>
 import dingtalkIcon from "@/assets/im/dingtalk.png";
@@ -12,8 +18,8 @@ import wecomIcon from "@/assets/im/wecom.png";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
-import { useVueState } from "@/react/hooks/useVueState";
-import { pushNotification, useSettingV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification } from "@/store";
 import { WebhookType } from "@/types/proto-es/v1/common_pb";
 import {
   AppIMSetting_DingTalkSchema,
@@ -180,10 +186,10 @@ function maskValues(payload: Record<string, unknown>): Record<string, string> {
   return result;
 }
 
-function getStoredIMSetting(
-  settingStore: ReturnType<typeof useSettingV1Store>
-) {
-  const setting = settingStore.getSettingByName(Setting_SettingName.APP_IM);
+function getStoredIMSetting() {
+  const setting = useAppStore
+    .getState()
+    .getSettingByName(Setting_SettingName.APP_IM);
   if (setting?.value?.value?.case !== "appIm") {
     return create(AppIMSettingSchema, { settings: [] });
   }
@@ -226,11 +232,15 @@ function buildSettingsView(
 
 export function IMPage() {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
   const allowEdit = hasWorkspacePermissionV2("bb.settings.set");
 
   // Subscribe to store changes
-  const storedSetting = useVueState(() => getStoredIMSetting(settingStore));
+  const settingsByName = useAppStore((s) => s.settingsByName);
+  const storedSetting = useMemo(
+    () => getStoredIMSetting(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [settingsByName]
+  );
 
   // Local state
   const [localSettings, setLocalSettings] = useState<AppIMSetting_IMSetting[]>(
@@ -242,19 +252,20 @@ export function IMPage() {
 
   // Fetch on mount
   useEffect(() => {
-    settingStore
+    useAppStore
+      .getState()
       .getOrFetchSettingByName(Setting_SettingName.APP_IM)
       .then(() => setInitialized(true));
-  }, [settingStore]);
+  }, []);
 
   // Sync local state from store
   const syncFromStore = useCallback(() => {
-    const stored = getStoredIMSetting(settingStore);
+    const stored = getStoredIMSetting();
     const cloned = stored.settings.map((s) =>
       clone(AppIMSetting_IMSettingSchema, s)
     );
     setLocalSettings(cloned);
-  }, [settingStore]);
+  }, []);
 
   useEffect(() => {
     if (initialized) syncFromStore();
@@ -326,17 +337,14 @@ export function IMPage() {
     setPendingSaveType(typeKey);
     try {
       const reconstructed = createIMSetting(wt, values);
-      const current = clone(
-        AppIMSettingSchema,
-        getStoredIMSetting(settingStore)
-      );
+      const current = clone(AppIMSettingSchema, getStoredIMSetting());
       const existingIdx = current.settings.findIndex((s) => s.type === wt);
       if (existingIdx >= 0) {
         current.settings[existingIdx] = reconstructed;
       } else {
         current.settings.push(reconstructed);
       }
-      await settingStore.upsertSetting({
+      await useAppStore.getState().upsertSetting({
         name: Setting_SettingName.APP_IM,
         value: create(SettingValueSchema, {
           value: { case: "appIm", value: current },
@@ -357,10 +365,10 @@ export function IMPage() {
   const handleDelete = async (index: number, typeKey: string) => {
     if (!window.confirm(t("bbkit.confirm-button.sure-to-delete"))) return;
     const wt = webhookTypeFromKey(typeKey);
-    const stored = getStoredIMSetting(settingStore);
+    const stored = getStoredIMSetting();
     const wasConfigured = stored.settings.some((s) => s.type === wt);
     if (wasConfigured) {
-      await settingStore.upsertSetting({
+      await useAppStore.getState().upsertSetting({
         name: Setting_SettingName.APP_IM,
         value: create(SettingValueSchema, {
           value: {

--- a/frontend/src/react/pages/settings/InstanceDetailPage.tsx
+++ b/frontend/src/react/pages/settings/InstanceDetailPage.tsx
@@ -35,14 +35,9 @@ import {
   TabsTrigger,
 } from "@/react/components/ui/tabs";
 import { useUnsavedChangesGuard } from "@/react/hooks/useUnsavedChangesGuard";
-import { useVueState } from "@/react/hooks/useVueState";
 import type { DatabaseFilter } from "@/react/lib/databaseFilter";
 import { useAppStore } from "@/react/stores/app";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useEnvironmentV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import {
   environmentNamePrefix,
   instanceNamePrefix,
@@ -315,17 +310,13 @@ export function InstanceDetailPage({ instanceId }: { instanceId: string }) {
     [selectedEnvironment, selectedProject, searchParams.query, selectedLabels]
   );
 
-  const environmentStore = useEnvironmentV1Store();
-  const environments = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environments = useAppStore((s) => s.environmentList ?? []);
 
-  const actuatorStore = useActuatorV1Store();
   // Reactive: the actuator's `defaultProject` is fetched asynchronously, so
-  // we must subscribe through `useVueState` — otherwise the value is
+  // we subscribe through the store selector — otherwise the value is
   // captured as `""` on first render and the API filter becomes broken.
-  const defaultProjectId = useVueState(() =>
-    extractProjectResourceName(actuatorStore.serverInfo?.defaultProject ?? "")
+  const defaultProjectId = useAppStore((s) =>
+    extractProjectResourceName(s.serverInfo?.defaultProject ?? "")
   );
   const unassignedProjectOption = useMemo<ValueOption>(
     () => ({

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -69,13 +69,7 @@ import { useAppStore } from "@/react/stores/app";
 import type { InstanceFilter } from "@/react/stores/app/types";
 import { router } from "@/router";
 import { INSTANCE_ROUTE_CREATE } from "@/router/dashboard/instance";
-import {
-  featureToRef,
-  pushNotification,
-  useActuatorV1Store,
-  useEnvironmentV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { featureToRef, pushNotification } from "@/store";
 import { environmentNamePrefix } from "@/store/modules/v1/common";
 import {
   isValidInstanceName,
@@ -179,11 +173,13 @@ function ConfirmDialog({
 
 function EnvironmentName({ environmentName }: { environmentName: string }) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
-  const environment = useVueState(() =>
-    environmentStore.getEnvironmentByName(
-      environmentName || NULL_ENVIRONMENT_NAME
-    )
+  const environmentList = useAppStore((s) => s.environmentList);
+  const environment = useMemo(
+    () =>
+      useAppStore
+        .getState()
+        .getEnvironmentByName(environmentName || NULL_ENVIRONMENT_NAME),
+    [environmentList, environmentName]
   );
 
   const isUnset =
@@ -448,10 +444,7 @@ function EditEnvironmentSheet({
   onUpdate: (environment: string) => Promise<void>;
 }) {
   const { t } = useTranslation();
-  const environmentStore = useEnvironmentV1Store();
-  const environments = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environments = useAppStore((s) => s.environmentList ?? []);
   const [selected, setSelected] = useState("");
   useEffect(() => {
     if (open) setSelected("");
@@ -520,8 +513,6 @@ function EditEnvironmentSheet({
 
 export function InstancesPage() {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
-  const actuatorStore = useActuatorV1Store();
 
   // Search state
   const [searchParams, setSearchParams] = useState<SearchParams>(() => {
@@ -564,10 +555,7 @@ export function InstancesPage() {
 
   // Scope options
   const canUndelete = hasWorkspacePermissionV2("bb.instances.undelete");
-  const environmentStore = useEnvironmentV1Store();
-  const environments = useVueState(
-    () => environmentStore.environmentList ?? []
-  );
+  const environments = useAppStore((s) => s.environmentList ?? []);
   const scopeOptions: ScopeOption[] = useMemo(() => {
     const options: ScopeOption[] = [
       {
@@ -699,14 +687,10 @@ export function InstancesPage() {
   }, [searchParams]);
 
   // Instance count warning
-  const instanceCountLimit = useVueState(
-    () => subscriptionStore.instanceCountLimit
-  );
-  const totalInstanceCount = useVueState(
-    () => actuatorStore.totalInstanceCount
-  );
-  const hasSplitInstanceLicense = useVueState(
-    () => subscriptionStore.hasSplitInstanceLicense
+  const instanceCountLimit = useAppStore((s) => s.instanceCountLimit());
+  const totalInstanceCount = useAppStore((s) => s.totalInstanceCount());
+  const hasSplitInstanceLicense = useAppStore((s) =>
+    s.hasSplitInstanceLicense()
   );
   const quotaExhausted = totalInstanceCount >= instanceCountLimit;
 
@@ -955,8 +939,8 @@ export function InstancesPage() {
     });
   }, []);
 
-  const activatedInstanceCount = useVueState(
-    () => actuatorStore.activatedInstanceCount
+  const activatedInstanceCount = useAppStore((s) =>
+    s.activatedInstanceCount()
   );
   const navigateToCreate = useCallback(() => {
     if (instanceCountLimit <= activatedInstanceCount) {

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -939,9 +939,7 @@ export function InstancesPage() {
     });
   }, []);
 
-  const activatedInstanceCount = useAppStore((s) =>
-    s.activatedInstanceCount()
-  );
+  const activatedInstanceCount = useAppStore((s) => s.activatedInstanceCount());
   const navigateToCreate = useCallback(() => {
     if (instanceCountLimit <= activatedInstanceCount) {
       // Limit reached — the warning banner is already visible

--- a/frontend/src/react/pages/settings/MembersPage.test.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.test.tsx
@@ -276,19 +276,6 @@ const projectIamPolicy = { bindings: [] };
 
 vi.mock("@/store", () => ({
   pushNotification: mockPushNotification,
-  useActuatorV1Store: () => ({
-    isSaaSMode: false,
-    userCountInIam: 1,
-  }),
-  useSettingV1Store: () => ({
-    getOrFetchSettingByName: vi.fn(),
-    getSettingByName: () => undefined,
-    workspaceProfile: {},
-  }),
-  useSubscriptionV1Store: () => ({
-    hasFeature: () => true,
-    userCountLimit: 10,
-  }),
 }));
 
 vi.mock("@/react/hooks/useAppState", () => ({
@@ -321,6 +308,15 @@ vi.mock("@/react/stores/app", () => {
       permissions: ["bb.projects.setIamPolicy"],
       state: 1,
     }),
+    // Migrated off the Pinia actuator/setting/subscription store mocks.
+    isSaaSMode: () => false,
+    userCountInIam: () => 1,
+    userCountLimit: () => 10,
+    hasFeature: () => true,
+    settingsByName: {},
+    getOrFetchSettingByName: vi.fn(),
+    getSettingByName: () => undefined,
+    getWorkspaceProfile: () => ({}),
   });
   const useAppStore = (selector?: (state: unknown) => unknown) =>
     selector ? selector(buildState()) : buildState();

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -1386,7 +1386,6 @@ function EditMemberRoleDrawer({
   const settingsByName = useAppStore((s) => s.settingsByName);
   const hasEmailSetting = useMemo(
     () => !!useAppStore.getState().getSettingByName(Setting_SettingName.EMAIL),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [settingsByName]
   );
   useEffect(() => {

--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -86,12 +86,7 @@ import {
   WORKSPACE_ROUTE_USER_PROFILE,
 } from "@/react/router";
 import { useAppStore } from "@/react/stores/app";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useSettingV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import {
   ALL_USERS_USER_EMAIL,
@@ -167,8 +162,7 @@ function MemberTable({
 }) {
   const { t } = useTranslation();
   const currentUser = useCurrentUser();
-  const actuatorStore = useActuatorV1Store();
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const isSaaSMode = useVueState(() => useAppStore.getState().isSaaSMode());
   const batchGetOrFetchUsers = useAppStore(
     (state) => state.batchGetOrFetchUsers
   );
@@ -626,8 +620,7 @@ function MemberTableByRole({
 }) {
   const { t } = useTranslation();
   const currentUser = useCurrentUser();
-  const actuatorStore = useActuatorV1Store();
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const isSaaSMode = useVueState(() => useAppStore.getState().isSaaSMode());
   const roleList = useAppStore((state) => state.roleList);
   const [expandedRoles, setExpandedRoles] = useState<Set<string>>(new Set());
   const initializedRef = useRef(false);
@@ -1388,15 +1381,19 @@ function EditMemberRoleDrawer({
   const updateProjectIamPolicy = useAppStore(
     (state) => state.updateProjectIamPolicy
   );
-  const isSaaSMode = useVueState(() => useActuatorV1Store().isSaaSMode);
-  const settingV1Store = useSettingV1Store();
+  const isSaaSMode = useVueState(() => useAppStore.getState().isSaaSMode());
   const roleList = useAppStore((state) => state.roleList);
-  const hasEmailSetting = useVueState(
-    () => !!settingV1Store.getSettingByName(Setting_SettingName.EMAIL)
+  const settingsByName = useAppStore((s) => s.settingsByName);
+  const hasEmailSetting = useMemo(
+    () => !!useAppStore.getState().getSettingByName(Setting_SettingName.EMAIL),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [settingsByName]
   );
   useEffect(() => {
-    settingV1Store.getOrFetchSettingByName(Setting_SettingName.EMAIL, true);
-  }, [settingV1Store]);
+    useAppStore
+      .getState()
+      .getOrFetchSettingByName(Setting_SettingName.EMAIL, true);
+  }, []);
 
   const isEditMode = !!member;
   const isProjectCreateMode = !!projectName && !isEditMode;
@@ -1446,13 +1443,13 @@ function EditMemberRoleDrawer({
   // Workspace-configured maximum role expiration, in days. PROJECT_OWNER
   // grants are exempt; returns undefined when no cap is set. Mirrors
   // RequestRoleSheet so direct grants and role requests behave the same.
-  const maximumRoleExpirationDays = useVueState(() => {
+  const workspaceProfile = useAppStore((s) => s.getWorkspaceProfile());
+  const maximumRoleExpirationDays = useMemo(() => {
     if (form.role === PresetRoleType.PROJECT_OWNER) return undefined;
-    const seconds =
-      settingV1Store.workspaceProfile.maximumRoleExpiration?.seconds;
+    const seconds = workspaceProfile.maximumRoleExpiration?.seconds;
     if (!seconds) return undefined;
     return Math.floor(Number(seconds) / (60 * 60 * 24));
-  });
+  }, [workspaceProfile, form.role]);
 
   // Helpers for project edit mode
   const getSingleBindingRows = useCallback(
@@ -2048,8 +2045,6 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   const patchWorkspaceIamPolicy = useAppStore(
     (state) => state.patchWorkspaceIamPolicy
   );
-  const actuatorStore = useActuatorV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
   const currentUser = useCurrentUser();
   const projectsByName = useAppStore((s) => s.projectsByName);
   const updateProjectIamPolicy = useAppStore(
@@ -2058,8 +2053,8 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   // subscribe to re-render on project cache change
   void projectsByName;
 
-  const userCountInIam = useVueState(() => actuatorStore.userCountInIam);
-  const userCountLimit = useVueState(() => subscriptionStore.userCountLimit);
+  const userCountInIam = useAppStore((s) => s.userCountInIam());
+  const userCountLimit = useAppStore((s) => s.userCountLimit());
   const remainingUserCount = useMemo(
     () => Math.max(0, userCountLimit - userCountInIam),
     [userCountLimit, userCountInIam]
@@ -2086,7 +2081,7 @@ export function MembersPage({ projectId }: { projectId?: string }) {
   const [showRequestRoleDialog, setShowRequestRoleDialog] = useState(false);
 
   const hasRequestRoleFeature = useVueState(() =>
-    subscriptionStore.hasFeature(PlanFeature.FEATURE_REQUEST_ROLE_WORKFLOW)
+    useAppStore.getState().hasFeature(PlanFeature.FEATURE_REQUEST_ROLE_WORKFLOW)
   );
 
   // IAM policy loads are owned by the parent shells: ProjectRouteShell

--- a/frontend/src/react/pages/settings/PurchaseSection.tsx
+++ b/frontend/src/react/pages/settings/PurchaseSection.tsx
@@ -292,12 +292,7 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
       if (isPlanConfigChanged(card)) {
         paymentUrl = await useAppStore
           .getState()
-          .updatePurchase(
-            card.type,
-            interval,
-            seats,
-            subscription?.etag ?? ""
-          );
+          .updatePurchase(card.type, interval, seats, subscription?.etag ?? "");
       } else {
         paymentUrl = await useAppStore
           .getState()

--- a/frontend/src/react/pages/settings/PurchaseSection.tsx
+++ b/frontend/src/react/pages/settings/PurchaseSection.tsx
@@ -5,9 +5,8 @@ import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { useSubscriptionState } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
-import { pushNotification, useSubscriptionV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import type { PurchasePlanAdditional } from "@/types/proto-es/v1/subscription_service_pb";
 import {
   BillingInterval,
@@ -85,13 +84,12 @@ const planPrefix: Record<number, string> = {
 
 export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
   const { t } = useTranslation();
-  const subscriptionStore = useSubscriptionV1Store();
   const refreshSubscription = useAppStore((state) => state.refreshSubscription);
 
   const { currentPlan, isFreePlan, isExpired, subscription } =
     useSubscriptionState();
-  const paymentInfo = useVueState(() => subscriptionStore.paymentInfo);
-  const purchasePlans = useVueState(() => subscriptionStore.purchasePlans);
+  const paymentInfo = useAppStore((s) => s.paymentInfo);
+  const purchasePlans = useAppStore((s) => s.purchasePlans);
 
   const allowManage = hasWorkspacePermissionV2("bb.subscription.manage");
 
@@ -112,7 +110,7 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
 
   // Fetch plans on mount.
   useEffect(() => {
-    subscriptionStore.fetchPurchasePlans();
+    useAppStore.getState().fetchPurchasePlans();
   }, []);
 
   // Handle session_id polling on mount (covers both new purchase and plan update fallback).
@@ -124,14 +122,17 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
     const controller = new AbortController();
     (async () => {
       try {
-        const status = await subscriptionStore.verifyCheckoutSession(sessionId);
+        const status = await useAppStore
+          .getState()
+          .verifyCheckoutSession(sessionId);
         if (status !== "complete" || controller.signal.aborted) return;
 
         setPendingPayment(true);
-        await subscriptionStore.pollSubscriptionUntil(
-          (sub) => sub.plan !== PlanType.FREE,
-          { signal: controller.signal }
-        );
+        await useAppStore
+          .getState()
+          .pollSubscriptionUntil((sub) => sub.plan !== PlanType.FREE, {
+            signal: controller.signal,
+          });
         if (!controller.signal.aborted) {
           await refreshSubscription();
           setPendingPayment(false);
@@ -146,14 +147,14 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
     return () => {
       controller.abort();
     };
-  }, [allowManage, refreshSubscription, subscriptionStore]);
+  }, [allowManage, refreshSubscription]);
 
   // Fetch payment info for active subscriptions.
   useEffect(() => {
     if (!isFreePlan && !isExpired) {
-      subscriptionStore.fetchPaymentInfo();
+      useAppStore.getState().fetchPaymentInfo();
     }
-  }, [isFreePlan, isExpired, subscriptionStore]);
+  }, [isFreePlan, isExpired]);
 
   const isCurrentPlan = useCallback(
     (plan: PlanType) => currentPlan === plan && !isExpired,
@@ -289,27 +290,29 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
     try {
       let paymentUrl: string;
       if (isPlanConfigChanged(card)) {
-        paymentUrl = await subscriptionStore.updatePurchase(
-          card.type,
-          interval,
-          seats,
-          subscription?.etag ?? ""
-        );
+        paymentUrl = await useAppStore
+          .getState()
+          .updatePurchase(
+            card.type,
+            interval,
+            seats,
+            subscription?.etag ?? ""
+          );
       } else {
-        paymentUrl = await subscriptionStore.createPurchase(
-          card.type,
-          interval,
-          seats
-        );
+        paymentUrl = await useAppStore
+          .getState()
+          .createPurchase(card.type, interval, seats);
       }
       if (paymentUrl) {
         window.location.href = paymentUrl;
       } else {
         // Direct update — wait for the webhook-driven reconciliation.
         setPendingPayment(true);
-        await subscriptionStore.pollSubscriptionUntil(
-          (sub) => sub.plan !== PlanType.FREE && sub.seats === seats
-        );
+        await useAppStore
+          .getState()
+          .pollSubscriptionUntil(
+            (sub) => sub.plan !== PlanType.FREE && sub.seats === seats
+          );
         await refreshSubscription();
         setPendingPayment(false);
       }
@@ -323,12 +326,12 @@ export function PurchaseSection({ onRequireEnterprise }: PurchaseSectionProps) {
   const handleCancel = async (feedback: string, comment: string) => {
     setCanceling(true);
     try {
-      await subscriptionStore.cancelPurchase(feedback, comment);
+      await useAppStore.getState().cancelPurchase(feedback, comment);
       // Wait for the Stripe webhook to reconcile before releasing the UI,
       // so the cached subscription/license reflects the new state.
-      await subscriptionStore.pollSubscriptionUntil(
-        (sub) => sub.plan === PlanType.FREE
-      );
+      await useAppStore
+        .getState()
+        .pollSubscriptionUntil((sub) => sub.plan === PlanType.FREE);
       await refreshSubscription();
       pushNotification({
         module: "bytebase",

--- a/frontend/src/react/pages/settings/RequestRoleSheet.test.tsx
+++ b/frontend/src/react/pages/settings/RequestRoleSheet.test.tsx
@@ -210,10 +210,6 @@ const mocks = vi.hoisted(() => ({
   currentUser: { name: "users/me@example.com", email: "me@example.com" },
 }));
 
-const stableSettingStore = {
-  workspaceProfile: { maximumRoleExpiration: undefined },
-};
-
 vi.mock("@/connect", () => ({
   issueServiceClientConnect: {
     createIssue: (req: unknown) => mocks.createIssue(req),
@@ -221,7 +217,6 @@ vi.mock("@/connect", () => ({
 }));
 
 vi.mock("@/store", () => ({
-  useSettingV1Store: () => stableSettingStore,
   pushNotification: (...args: unknown[]) => mocks.pushNotification(...args),
 }));
 
@@ -232,6 +227,7 @@ vi.mock("@/react/hooks/useAppState", () => ({
 vi.mock("@/react/stores/app", () => ({
   useAppStore: (selector: (state: unknown) => unknown) =>
     selector({
+      roleList: [],
       getRoleByName: (name: string) => ({
         name,
         permissions:
@@ -239,6 +235,8 @@ vi.mock("@/react/stores/app", () => ({
             ? ["bb.projects.get", "bb.databases.get"]
             : [],
       }),
+      // Migrated off the Pinia useSettingV1Store mock.
+      getWorkspaceProfile: () => ({ maximumRoleExpiration: undefined }),
     }),
 }));
 

--- a/frontend/src/react/pages/settings/RequestRoleSheet.tsx
+++ b/frontend/src/react/pages/settings/RequestRoleSheet.tsx
@@ -31,7 +31,6 @@ import {
 } from "@/react/components/ui/sheet";
 import { Textarea } from "@/react/components/ui/textarea";
 import { useCurrentUser } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
 import {
   getRoleEnvironmentLimitationKind,
   roleHasDatabaseLimitation,
@@ -40,7 +39,7 @@ import { displayRoleTitleFromList } from "@/react/lib/role";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/router/dashboard/projectV1";
-import { pushNotification, useSettingV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import type { Permission } from "@/types";
 import { type DatabaseResource, PresetRoleType } from "@/types";
 import { ExprSchema as ConditionExprSchema } from "@/types/proto-es/google/type/expr_pb";
@@ -159,7 +158,6 @@ function RequestRoleForm({
   const [environments, setEnvironments] = useState<string[]>([]);
   const [submitting, setSubmitting] = useState(false);
 
-  const settingStore = useSettingV1Store();
   const roleList = useAppStore((state) => state.roleList);
   const selectedRole = useAppStore((state) =>
     role ? state.getRoleByName(role) : undefined
@@ -186,13 +184,13 @@ function RequestRoleForm({
   // Vue ExpirationSelector: PROJECT_OWNER grants are exempted (project
   // owners can request unbounded expirations), otherwise the workspace cap
   // applies. Returns undefined when no cap is set.
-  const maximumRoleExpirationDays = useVueState(() => {
+  const workspaceProfile = useAppStore((state) => state.getWorkspaceProfile());
+  const maximumRoleExpirationDays = useMemo(() => {
     if (role === PresetRoleType.PROJECT_OWNER) return undefined;
-    const seconds =
-      settingStore.workspaceProfile.maximumRoleExpiration?.seconds;
+    const seconds = workspaceProfile.maximumRoleExpiration?.seconds;
     if (!seconds) return undefined;
     return Math.floor(Number(seconds) / (60 * 60 * 24));
-  });
+  }, [workspaceProfile, role]);
 
   // ExprEditor factor/option config — mirrors the old Vue
   // DatabaseResourceForm config for role-grant requests.

--- a/frontend/src/react/pages/settings/RolesPage.tsx
+++ b/frontend/src/react/pages/settings/RolesPage.tsx
@@ -53,7 +53,7 @@ import {
   displayRoleTitleFromList,
 } from "@/react/lib/role";
 import { useAppStore } from "@/react/stores/app";
-import { pushNotification, useSubscriptionV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { roleNamePrefix } from "@/store/modules/v1/common";
 import {
   BASIC_WORKSPACE_PERMISSIONS,
@@ -674,7 +674,6 @@ export function RolesPage() {
   const listRoles = useAppStore((state) => state.listRoles);
   const getRoleByName = useAppStore((state) => state.getRoleByName);
   const deleteRole = useAppStore((state) => state.deleteRole);
-  const subscriptionStore = useSubscriptionV1Store();
 
   const [ready, setReady] = useState(false);
   const [detailRole, setDetailRole] = useState<Role | undefined>();
@@ -684,7 +683,7 @@ export function RolesPage() {
   const [deleteResources, setDeleteResources] = useState<string[]>([]);
 
   const hasCustomRoleFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_CUSTOM_ROLES)
+    useAppStore.getState().hasInstanceFeature(PlanFeature.FEATURE_CUSTOM_ROLES)
   );
 
   const canCreate = hasWorkspacePermissionV2("bb.roles.create");

--- a/frontend/src/react/pages/settings/SemanticTypesPage.tsx
+++ b/frontend/src/react/pages/settings/SemanticTypesPage.tsx
@@ -119,7 +119,6 @@ export function SemanticTypesPage() {
     return setting?.value?.value?.case === "semanticType"
       ? (setting.value.value.value.types ?? [])
       : [];
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settingsByName]);
 
   useEffect(() => {

--- a/frontend/src/react/pages/settings/SemanticTypesPage.tsx
+++ b/frontend/src/react/pages/settings/SemanticTypesPage.tsx
@@ -30,11 +30,8 @@ import {
 } from "@/react/components/ui/table";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useVueState } from "@/react/hooks/useVueState";
-import {
-  pushNotification,
-  useSettingV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification } from "@/store";
 import { getSemanticTemplateList } from "@/types";
 import type {
   Algorithm,
@@ -99,13 +96,10 @@ function useEscapeKey(onEscape: () => void) {
 
 export function SemanticTypesPage() {
   const { t } = useTranslation();
-  const settingStore = useSettingV1Store();
-
-  const subscriptionStore = useSubscriptionV1Store();
 
   const hasPermission = hasWorkspacePermissionV2("bb.policies.update");
   const hasSensitiveDataFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_DATA_MASKING)
+    useAppStore.getState().hasInstanceFeature(PlanFeature.FEATURE_DATA_MASKING)
   );
   const isReadonly = !hasPermission || !hasSensitiveDataFeature;
 
@@ -117,17 +111,20 @@ export function SemanticTypesPage() {
     algorithm?: Algorithm;
   } | null>(null);
 
-  const semanticTypeSettingValue = useVueState(() => {
-    const setting = settingStore.getSettingByName(
-      Setting_SettingName.SEMANTIC_TYPES
-    );
+  const settingsByName = useAppStore((s) => s.settingsByName);
+  const semanticTypeSettingValue = useMemo(() => {
+    const setting = useAppStore
+      .getState()
+      .getSettingByName(Setting_SettingName.SEMANTIC_TYPES);
     return setting?.value?.value?.case === "semanticType"
       ? (setting.value.value.value.types ?? [])
       : [];
-  });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settingsByName]);
 
   useEffect(() => {
-    settingStore
+    useAppStore
+      .getState()
       .getOrFetchSettingByName(Setting_SettingName.SEMANTIC_TYPES)
       .then(() => setLoaded(true));
   }, []);
@@ -145,7 +142,7 @@ export function SemanticTypesPage() {
 
   const upsertSetting = useCallback(
     async (types: SemanticTypeSetting_SemanticType[], notification: string) => {
-      await settingStore.upsertSetting({
+      await useAppStore.getState().upsertSetting({
         name: Setting_SettingName.SEMANTIC_TYPES,
         value: create(SettingSettingValueSchema, {
           value: {

--- a/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
+++ b/frontend/src/react/pages/settings/ServiceAccountsPage.tsx
@@ -35,7 +35,7 @@ import {
   ensureServiceAccountFullName,
   serviceAccountToUser,
 } from "@/react/stores/app/serviceAccount";
-import { pushNotification, useActuatorV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import {
   getServiceAccountNameInBinding,
@@ -429,7 +429,7 @@ function ServiceAccountForm({
   const patchWorkspaceIamPolicy = useAppStore(
     (state) => state.patchWorkspaceIamPolicy
   );
-  const actuatorStore = useActuatorV1Store();
+  const workspaceResourceName = useAppStore((s) => s.workspaceResourceName());
   const projectsByName = useAppStore((s) => s.projectsByName);
   const getProjectIamPolicy = useAppStore((state) => state.getProjectIamPolicy);
   const updateProjectIamPolicy = useAppStore(
@@ -442,9 +442,7 @@ function ServiceAccountForm({
     project ? useAppStore.getState().getProjectByName(project) : undefined
   );
 
-  const parent = useVueState(
-    () => project ?? actuatorStore.workspaceResourceName
-  );
+  const parent = useVueState(() => project ?? workspaceResourceName);
 
   const isEditMode = !!serviceAccount && !!serviceAccount.email;
   const emailSuffix = useMemo(() => {
@@ -673,7 +671,7 @@ function ServiceAccountForm({
 
 export function ServiceAccountsPage({ projectId }: { projectId?: string }) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
+  const workspaceResourceName = useAppStore((s) => s.workspaceResourceName());
   const projectsByName = useAppStore((s) => s.projectsByName);
   const listServiceAccounts = useAppStore((state) => state.listServiceAccounts);
   const getServiceAccount = useAppStore((state) => state.getServiceAccount);
@@ -689,9 +687,7 @@ export function ServiceAccountsPage({ projectId }: { projectId?: string }) {
       : undefined
   );
 
-  const parent = useVueState(
-    () => projectName ?? actuatorStore.workspaceResourceName
-  );
+  const parent = useVueState(() => projectName ?? workspaceResourceName);
 
   const [showInactive, setShowInactive] = useState(false);
   const [showDrawer, setShowDrawer] = useState(false);

--- a/frontend/src/react/pages/settings/UsersPage.tsx
+++ b/frontend/src/react/pages/settings/UsersPage.tsx
@@ -41,7 +41,6 @@ import {
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useCurrentUser } from "@/react/hooks/useAppState";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
-import { useVueState } from "@/react/hooks/useVueState";
 import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
@@ -49,12 +48,7 @@ import {
   WORKSPACE_ROUTE_GROUPS,
   WORKSPACE_ROUTE_USER_PROFILE,
 } from "@/router/dashboard/workspaceRoutes";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useSettingV1Store,
-  useSubscriptionV1Store,
-} from "@/store";
+import { pushNotification } from "@/store";
 import { getUserFullNameByType } from "@/store/modules/v1/common";
 import {
   AccountType,
@@ -510,17 +504,13 @@ function UserForm({
   const patchWorkspaceIamPolicy = useAppStore(
     (state) => state.patchWorkspaceIamPolicy
   );
-  const settingV1Store = useSettingV1Store();
-
-  const passwordRestriction = useVueState(
-    () => settingV1Store.workspaceProfile.passwordRestriction
+  const passwordRestriction = useAppStore(
+    (s) => s.getWorkspaceProfile().passwordRestriction
   );
-  const enforceIdentityDomain = useVueState(
-    () => settingV1Store.workspaceProfile.enforceIdentityDomain
+  const enforceIdentityDomain = useAppStore(
+    (s) => s.getWorkspaceProfile().enforceIdentityDomain
   );
-  const workspaceDomains = useVueState(
-    () => settingV1Store.workspaceProfile.domains
-  );
+  const workspaceDomains = useAppStore((s) => s.getWorkspaceProfile().domains);
 
   const isEditMode =
     !!user && user.name !== "" && !user.name.endsWith("/unknown");
@@ -923,14 +913,12 @@ function UserForm({
 
 export function UsersPage() {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
-  const subscriptionStore = useSubscriptionV1Store();
   const listUsers = useAppStore((state) => state.listUsers);
 
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const isSaaSMode = useAppStore((s) => s.isSaaSMode());
 
-  const hasDirectorySyncFeature = useVueState(() =>
-    subscriptionStore.hasInstanceFeature(PlanFeature.FEATURE_DIRECTORY_SYNC)
+  const hasDirectorySyncFeature = useAppStore((s) =>
+    s.hasInstanceFeature(PlanFeature.FEATURE_DIRECTORY_SYNC)
   );
   const canAccessSettings = hasWorkspacePermissionV2("bb.settings.get");
 

--- a/frontend/src/react/pages/settings/WorkloadIdentitiesPage.tsx
+++ b/frontend/src/react/pages/settings/WorkloadIdentitiesPage.tsx
@@ -22,7 +22,7 @@ import {
   ensureWorkloadIdentityFullName,
   workloadIdentityToUser,
 } from "@/react/stores/app/workloadIdentity";
-import { pushNotification, useActuatorV1Store } from "@/store";
+import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { State } from "@/types/proto-es/v1/common_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
@@ -233,7 +233,7 @@ function WorkloadIdentityTable({
 
 export function WorkloadIdentitiesPage({ projectId }: { projectId?: string }) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
+  const workspaceResourceName = useAppStore((s) => s.workspaceResourceName());
   const projectsByName = useAppStore((s) => s.projectsByName);
   const listWorkloadIdentities = useAppStore(
     (state) => state.listWorkloadIdentities
@@ -253,9 +253,7 @@ export function WorkloadIdentitiesPage({ projectId }: { projectId?: string }) {
       : undefined
   );
 
-  const parent = useVueState(
-    () => projectName ?? actuatorStore.workspaceResourceName
-  );
+  const parent = useVueState(() => projectName ?? workspaceResourceName);
 
   const [showInactive, setShowInactive] = useState(false);
   const [showDrawer, setShowDrawer] = useState(false);

--- a/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
+++ b/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -16,8 +17,7 @@ import { Alert } from "@/react/components/ui/alert";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { useServerState } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useSettingV1Store } from "@/store/modules";
+import { useAppStore } from "@/react/stores/app";
 import {
   AISetting_Provider,
   AISettingSchema,
@@ -84,19 +84,21 @@ export const AIAugmentationSection = forwardRef<
   AIAugmentationSectionProps
 >(function AIAugmentationSection({ title, onDirtyChange }, ref) {
   const { t } = useTranslation();
-  const settingV1Store = useSettingV1Store();
   const containerRef = useRef<HTMLDivElement>(null);
 
   const { isSaaSMode } = useServerState();
   const canEdit = hasWorkspacePermissionV2("bb.settings.set") && !isSaaSMode;
 
-  const aiSetting = useVueState(() => {
-    const setting = settingV1Store.getSettingByName(Setting_SettingName.AI);
+  const settingsByName = useAppStore((s) => s.settingsByName);
+  const aiSetting = useMemo(() => {
+    const setting = useAppStore
+      .getState()
+      .getSettingByName(Setting_SettingName.AI);
     if (setting?.value?.value?.case === "ai") {
       return setting.value.value.value;
     }
     return undefined;
-  });
+  }, [settingsByName]);
 
   const getInitialState = useCallback((): AIState => {
     return {
@@ -121,8 +123,10 @@ export const AIAugmentationSection = forwardRef<
 
   // Fetch setting on mount.
   useEffect(() => {
-    settingV1Store.getOrFetchSettingByName(Setting_SettingName.AI, true);
-  }, [settingV1Store]);
+    useAppStore
+      .getState()
+      .getOrFetchSettingByName(Setting_SettingName.AI, true);
+  }, []);
 
   // Scroll into view on mount.
   useEffect(() => {
@@ -160,7 +164,7 @@ export const AIAugmentationSection = forwardRef<
     if (state.apiKey || state.provider !== init.provider)
       paths.push("value.ai.api_key");
 
-    await settingV1Store.upsertSetting({
+    await useAppStore.getState().upsertSetting({
       name: Setting_SettingName.AI,
       value: create(SettingValueSchema, {
         value: {
@@ -177,7 +181,7 @@ export const AIAugmentationSection = forwardRef<
       }),
       updateMask: create(FieldMaskSchema, { paths }),
     });
-  }, [state, getInitialState, aiSetting, settingV1Store]);
+  }, [state, getInitialState, aiSetting]);
 
   useImperativeHandle(ref, () => ({ isDirty, revert, update }));
 

--- a/frontend/src/react/pages/settings/general/AccountSection.tsx
+++ b/frontend/src/react/pages/settings/general/AccountSection.tsx
@@ -21,9 +21,7 @@ import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { NumberInput } from "@/react/components/ui/number-input";
 import { usePlanFeature, useServerState } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
-import { useSettingV1Store } from "@/store/modules/v1/setting";
 import {
   defaultAccessTokenDurationInHours,
   defaultRefreshTokenDurationInHours,
@@ -96,7 +94,6 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
   function AccountSection({ title, onDirtyChange }, ref) {
     const { t } = useTranslation();
 
-    const settingV1Store = useSettingV1Store();
     const listIdentityProviders = useAppStore(
       (state) => state.listIdentityProviders
     );
@@ -123,9 +120,9 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
     );
 
     // Track whether the EMAIL setting is configured (required to enable email-code signin).
-    // Reactively reads from the Vue store so the value updates when EMAIL is (un)configured.
-    const hasEmailSetting = useVueState(
-      () => !!settingV1Store.getSettingByName(Setting_SettingName.EMAIL)
+    // Reactively reads from the app store so the value updates when EMAIL is (un)configured.
+    const hasEmailSetting = useAppStore(
+      (s) => !!s.getSettingByName(Setting_SettingName.EMAIL)
     );
 
     // Fetch identity providers after the workspace resource name is ready.
@@ -137,20 +134,21 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
 
     // Fetch EMAIL setting on mount.
     useEffect(() => {
-      // Populate the EMAIL setting into the store cache; useVueState above
+      // Populate the EMAIL setting into the store cache; the selector above
       // picks up the change reactively.
-      settingV1Store.getOrFetchSettingByName(Setting_SettingName.EMAIL, true);
-    }, [settingV1Store]);
+      useAppStore
+        .getState()
+        .getOrFetchSettingByName(Setting_SettingName.EMAIL, true);
+    }, []);
 
     // --- Toggle state ---
     const getInitialToggleState = useCallback((): ToggleState => {
+      const profile = useAppStore.getState().getWorkspaceProfile();
       return {
-        disallowSignup: settingV1Store.workspaceProfile.disallowSignup,
-        requireMfa: settingV1Store.workspaceProfile.requireMfa,
-        disallowPasswordSignin:
-          settingV1Store.workspaceProfile.disallowPasswordSignin,
-        allowEmailCodeSignin:
-          settingV1Store.workspaceProfile.allowEmailCodeSignin,
+        disallowSignup: profile.disallowSignup,
+        requireMfa: profile.requireMfa,
+        disallowPasswordSignin: profile.disallowPasswordSignin,
+        allowEmailCodeSignin: profile.allowEmailCodeSignin,
       };
     }, []);
 
@@ -162,7 +160,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
     const getInitialPasswordRestriction =
       useCallback((): WorkspaceProfileSetting_PasswordRestriction => {
         return cloneDeep(
-          settingV1Store.workspaceProfile.passwordRestriction ??
+          useAppStore.getState().getWorkspaceProfile().passwordRestriction ??
             create(WorkspaceProfileSetting_PasswordRestrictionSchema, {})
         );
       }, []);
@@ -174,6 +172,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
 
     // --- Token duration state ---
     const getInitialTokenState = useCallback((): TokenState => {
+      const profile = useAppStore.getState().getWorkspaceProfile();
       const state: TokenState = {
         accessTokenDuration: defaultAccessTokenDurationInHours,
         accessTokenTimeFormat: "HOURS",
@@ -182,9 +181,8 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
         inactiveTimeout: -1,
       };
 
-      const accessTokenSeconds = settingV1Store.workspaceProfile
-        .accessTokenDuration?.seconds
-        ? Number(settingV1Store.workspaceProfile.accessTokenDuration.seconds)
+      const accessTokenSeconds = profile.accessTokenDuration?.seconds
+        ? Number(profile.accessTokenDuration.seconds)
         : undefined;
       if (accessTokenSeconds && accessTokenSeconds > 0) {
         if (accessTokenSeconds < 60 * 60) {
@@ -197,9 +195,8 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
         }
       }
 
-      const refreshTokenSeconds = settingV1Store.workspaceProfile
-        .refreshTokenDuration?.seconds
-        ? Number(settingV1Store.workspaceProfile.refreshTokenDuration.seconds)
+      const refreshTokenSeconds = profile.refreshTokenDuration?.seconds
+        ? Number(profile.refreshTokenDuration.seconds)
         : undefined;
       if (refreshTokenSeconds && refreshTokenSeconds > 0) {
         if (refreshTokenSeconds < 60 * 60 * 24) {
@@ -214,7 +211,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
       }
 
       const inactiveTimeoutSeconds = Number(
-        settingV1Store.workspaceProfile.inactiveSessionTimeout?.seconds ?? 0
+        profile.inactiveSessionTimeout?.seconds ?? 0
       );
       if (inactiveTimeoutSeconds) {
         state.inactiveTimeout =
@@ -359,7 +356,7 @@ export const AccountSection = forwardRef<SectionHandle, AccountSectionProps>(
 
       if (updateMaskPaths.length === 0) return;
 
-      await settingV1Store.updateWorkspaceProfile({
+      await useAppStore.getState().updateWorkspaceProfile({
         payload,
         updateMask: create(FieldMaskSchema, { paths: updateMaskPaths }),
       });

--- a/frontend/src/react/pages/settings/general/AnnouncementSection.tsx
+++ b/frontend/src/react/pages/settings/general/AnnouncementSection.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/react/components/PermissionGuard";
 import { Input } from "@/react/components/ui/input";
 import { usePlanFeature } from "@/react/hooks/useAppState";
-import { useSettingV1Store } from "@/store/modules/v1/setting";
+import { useAppStore } from "@/react/stores/app";
 import {
   Announcement_AlertLevel,
   AnnouncementSchema,
@@ -46,14 +46,15 @@ export const AnnouncementSection = forwardRef<
   AnnouncementSectionProps
 >(function AnnouncementSection({ title, onDirtyChange }, ref) {
   const { t } = useTranslation();
-  const settingV1Store = useSettingV1Store();
 
   const hasFeature = usePlanFeature(PlanFeature.FEATURE_DASHBOARD_ANNOUNCEMENT);
 
   const [canEdit] = usePermissionCheck(["bb.settings.setWorkspaceProfile"]);
 
   const getRawAnnouncement = useCallback((): AnnouncementState => {
-    const announcement = settingV1Store.workspaceProfile.announcement;
+    const announcement = useAppStore
+      .getState()
+      .getWorkspaceProfile().announcement;
     if (announcement) {
       return {
         level: announcement.level,
@@ -66,7 +67,7 @@ export const AnnouncementSection = forwardRef<
       text: "",
       link: "",
     };
-  }, [settingV1Store]);
+  }, []);
 
   const [state, setState] = useState<AnnouncementState>(() =>
     cloneDeep(getRawAnnouncement())
@@ -82,7 +83,7 @@ export const AnnouncementSection = forwardRef<
   }, [getRawAnnouncement]);
 
   const update = useCallback(async () => {
-    await settingV1Store.updateWorkspaceProfile({
+    await useAppStore.getState().updateWorkspaceProfile({
       payload: {
         announcement: create(AnnouncementSchema, { ...state }),
       },
@@ -90,7 +91,7 @@ export const AnnouncementSection = forwardRef<
         paths: ["value.workspace_profile.announcement"],
       }),
     });
-  }, [state, settingV1Store]);
+  }, [state]);
 
   useImperativeHandle(ref, () => ({ isDirty, revert, update }));
 

--- a/frontend/src/react/pages/settings/general/AuditLogSection.tsx
+++ b/frontend/src/react/pages/settings/general/AuditLogSection.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { usePlanFeature } from "@/react/hooks/useAppState";
-import { useSettingV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import type { SectionHandle } from "./useSettingSection";
 
@@ -29,18 +29,16 @@ interface State {
 export const AuditLogSection = forwardRef<SectionHandle, AuditLogSectionProps>(
   function AuditLogSection({ allowEdit, onDirtyChange }, ref) {
     const { t } = useTranslation();
-    const settingV1Store = useSettingV1Store();
 
     const hasAuditLogFeature = usePlanFeature(PlanFeature.FEATURE_AUDIT_LOG);
 
-    const getInitialState = useCallback(
-      (): State => ({
-        enableAuditLogStdout:
-          settingV1Store.workspaceProfile.enableAuditLogStdout,
-        enableDebug: settingV1Store.workspaceProfile.enableDebug,
-      }),
-      [settingV1Store]
-    );
+    const getInitialState = useCallback((): State => {
+      const profile = useAppStore.getState().getWorkspaceProfile();
+      return {
+        enableAuditLogStdout: profile.enableAuditLogStdout,
+        enableDebug: profile.enableDebug,
+      };
+    }, []);
 
     const [state, setState] = useState<State>(getInitialState);
 
@@ -54,7 +52,7 @@ export const AuditLogSection = forwardRef<SectionHandle, AuditLogSectionProps>(
     }, [getInitialState]);
 
     const update = useCallback(async () => {
-      await settingV1Store.updateWorkspaceProfile({
+      await useAppStore.getState().updateWorkspaceProfile({
         payload: {
           enableAuditLogStdout: state.enableAuditLogStdout,
           enableDebug: state.enableDebug,
@@ -66,7 +64,7 @@ export const AuditLogSection = forwardRef<SectionHandle, AuditLogSectionProps>(
           ],
         }),
       });
-    }, [state, settingV1Store]);
+    }, [state]);
 
     const title = t("settings.general.workspace.log");
 

--- a/frontend/src/react/pages/settings/general/GeneralSection.tsx
+++ b/frontend/src/react/pages/settings/general/GeneralSection.tsx
@@ -26,7 +26,6 @@ import { useServerState } from "@/react/hooks/useAppState";
 import { useAppStore } from "@/react/stores/app";
 import { router } from "@/router";
 import { SQL_EDITOR_HOME_MODULE } from "@/router/sqlEditor";
-import { useSettingV1Store } from "@/store";
 import { DatabaseChangeMode } from "@/types/proto-es/v1/setting_service_pb";
 import type { SectionHandle } from "./useSettingSection";
 
@@ -43,7 +42,6 @@ interface LocalState {
 export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
   function GeneralSection({ title, onDirtyChange }, ref) {
     const { t } = useTranslation();
-    const settingV1Store = useSettingV1Store();
     const refreshServerInfo = useAppStore((state) => state.refreshServerInfo);
 
     const { isSaaSMode, externalUrl, serverInfo } = useServerState();
@@ -52,7 +50,9 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
     const [canEdit] = usePermissionCheck(["bb.settings.setWorkspaceProfile"]);
 
     const getInitialState = useCallback((): LocalState => {
-      const mode = settingV1Store.workspaceProfile.databaseChangeMode;
+      const mode = useAppStore
+        .getState()
+        .getWorkspaceProfile().databaseChangeMode;
       return {
         databaseChangeMode:
           mode === DatabaseChangeMode.PIPELINE ||
@@ -61,7 +61,7 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
             : DatabaseChangeMode.PIPELINE,
         externalUrl,
       };
-    }, [settingV1Store, externalUrl]);
+    }, [externalUrl]);
 
     const [state, setState] = useState<LocalState>(getInitialState);
     const [showModal, setShowModal] = useState(false);
@@ -78,7 +78,7 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
     const update = useCallback(async () => {
       const initState = getInitialState();
       if (state.externalUrl !== initState.externalUrl) {
-        await settingV1Store.updateWorkspaceProfile({
+        await useAppStore.getState().updateWorkspaceProfile({
           payload: {
             externalUrl: state.externalUrl,
           },
@@ -89,7 +89,7 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
         await refreshServerInfo();
       }
       if (state.databaseChangeMode !== initState.databaseChangeMode) {
-        await settingV1Store.updateWorkspaceProfile({
+        await useAppStore.getState().updateWorkspaceProfile({
           payload: {
             databaseChangeMode: state.databaseChangeMode,
           },
@@ -101,7 +101,7 @@ export const GeneralSection = forwardRef<SectionHandle, GeneralSectionProps>(
           setShowModal(true);
         }
       }
-    }, [state, getInitialState, settingV1Store, refreshServerInfo]);
+    }, [state, getInitialState, refreshServerInfo]);
 
     useImperativeHandle(
       ref,

--- a/frontend/src/react/pages/settings/general/ProductImprovementSection.tsx
+++ b/frontend/src/react/pages/settings/general/ProductImprovementSection.tsx
@@ -9,7 +9,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { Checkbox } from "@/react/components/ui/checkbox";
-import { useSettingV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 import type { SectionHandle } from "./useSettingSection";
 
 interface ProductImprovementSectionProps {
@@ -26,14 +26,13 @@ export const ProductImprovementSection = forwardRef<
   ProductImprovementSectionProps
 >(function ProductImprovementSection({ allowEdit, onDirtyChange }, ref) {
   const { t } = useTranslation();
-  const settingV1Store = useSettingV1Store();
 
   const getInitialState = useCallback(
     (): State => ({
-      enableMetricCollection:
-        settingV1Store.workspaceProfile.enableMetricCollection,
+      enableMetricCollection: useAppStore.getState().getWorkspaceProfile()
+        .enableMetricCollection,
     }),
-    [settingV1Store]
+    []
   );
 
   const [state, setState] = useState<State>(getInitialState);
@@ -49,7 +48,7 @@ export const ProductImprovementSection = forwardRef<
   }, [getInitialState]);
 
   const update = useCallback(async () => {
-    await settingV1Store.updateWorkspaceProfile({
+    await useAppStore.getState().updateWorkspaceProfile({
       payload: {
         enableMetricCollection: state.enableMetricCollection,
       },
@@ -57,7 +56,7 @@ export const ProductImprovementSection = forwardRef<
         paths: ["value.workspace_profile.enable_metric_collection"],
       }),
     });
-  }, [state, settingV1Store]);
+  }, [state]);
 
   const title = t("settings.general.workspace.product-improvement.self");
 

--- a/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
+++ b/frontend/src/react/pages/settings/general/SQLEditorSection.tsx
@@ -18,10 +18,8 @@ import {
   usePlanFeature,
   useWorkspaceResourceName,
 } from "@/react/hooks/useAppState";
-import { useVueState } from "@/react/hooks/useVueState";
 import { useAppStore } from "@/react/stores/app";
 import { DEFAULT_MAX_RESULT_SIZE_IN_MB } from "@/store";
-import { useSettingV1Store } from "@/store/modules/v1/setting";
 import {
   PolicyResourceType,
   PolicyType,
@@ -52,7 +50,6 @@ export const SQLEditorSection = forwardRef<
   SQLEditorSectionProps
 >(function SQLEditorSection({ title, onDirtyChange }, ref) {
   const { t } = useTranslation();
-  const settingV1Store = useSettingV1Store();
 
   const resource = useWorkspaceResourceName();
   const hasQueryPolicyFeature = usePlanFeature(
@@ -85,7 +82,7 @@ export const SQLEditorSection = forwardRef<
     s.getQueryDataPolicyByParent(resource)
   );
 
-  const workspaceProfile = useVueState(() => settingV1Store.workspaceProfile);
+  const workspaceProfile = useAppStore((s) => s.getWorkspaceProfile());
 
   const getInitialState = useCallback((): LocalState => {
     let size = workspaceProfile.sqlResultSize;
@@ -152,7 +149,7 @@ export const SQLEditorSection = forwardRef<
 
     // Update query timeout if changed
     if (init.maxQueryTimeInSeconds !== maxQueryTimeInSeconds) {
-      await settingV1Store.updateWorkspaceProfile({
+      await useAppStore.getState().updateWorkspaceProfile({
         payload: {
           queryTimeout: create(DurationSchema, {
             seconds: BigInt(maxQueryTimeInSeconds),
@@ -166,7 +163,7 @@ export const SQLEditorSection = forwardRef<
 
     // Update result size if changed
     if (init.maximumResultSize !== maximumResultSize) {
-      await settingV1Store.updateWorkspaceProfile({
+      await useAppStore.getState().updateWorkspaceProfile({
         payload: {
           sqlResultSize: BigInt(maximumResultSize * 1024 * 1024),
         },
@@ -194,7 +191,7 @@ export const SQLEditorSection = forwardRef<
         },
       },
     });
-  }, [state, resource, policyPayload, settingV1Store, getInitialState]);
+  }, [state, resource, policyPayload, getInitialState]);
 
   useImperativeHandle(ref, () => ({ isDirty, revert, update }));
 

--- a/frontend/src/react/pages/settings/general/SecuritySection.tsx
+++ b/frontend/src/react/pages/settings/general/SecuritySection.tsx
@@ -20,7 +20,6 @@ import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
 import { usePlanFeature } from "@/react/hooks/useAppState";
 import { useAppStore } from "@/react/stores/app";
-import { useSettingV1Store } from "@/store/modules/v1/setting";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import type { SectionHandle } from "./useSettingSection";
 
@@ -42,7 +41,7 @@ interface SecuritySectionProps {
 export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
   function SecuritySection({ title, onDirtyChange }, ref) {
     const { t } = useTranslation();
-    const settingV1Store = useSettingV1Store();
+    const workspaceProfile = useAppStore((s) => s.getWorkspaceProfile());
 
     const hasWatermarkFeature = usePlanFeature(PlanFeature.FEATURE_WATERMARK);
     const hasDomainRestrictionFeature = usePlanFeature(
@@ -51,7 +50,7 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
     const [canEdit] = usePermissionCheck(["bb.settings.setWorkspaceProfile"]);
 
     const getInitialState = useCallback((): SecurityState => {
-      const profile = settingV1Store.workspaceProfile;
+      const profile = workspaceProfile;
 
       // Watermark
       const enableWatermark = profile.watermark;
@@ -81,7 +80,7 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
         domains,
         enableRestriction,
       };
-    }, [settingV1Store]);
+    }, [workspaceProfile]);
 
     const [state, setState] = useState<SecurityState>(getInitialState);
     const [domainInput, setDomainInput] = useState("");
@@ -108,7 +107,7 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
 
       // Watermark
       if (state.enableWatermark !== init.enableWatermark) {
-        await settingV1Store.updateWorkspaceProfile({
+        await useAppStore.getState().updateWorkspaceProfile({
           payload: { watermark: state.enableWatermark },
           updateMask: create(FieldMaskSchema, {
             paths: ["value.workspace_profile.watermark"],
@@ -125,7 +124,7 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
         if (!state.neverExpire) {
           seconds = state.inputValue * 24 * 60 * 60;
         }
-        await settingV1Store.updateWorkspaceProfile({
+        await useAppStore.getState().updateWorkspaceProfile({
           payload: {
             maximumRoleExpiration: create(DurationSchema, {
               seconds: BigInt(seconds),
@@ -156,7 +155,7 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
         domainUpdatePaths.push("value.workspace_profile.domains");
       }
       if (domainUpdatePaths.length > 0) {
-        await settingV1Store.updateWorkspaceProfile({
+        await useAppStore.getState().updateWorkspaceProfile({
           payload: {
             domains: currentValidDomains,
             enforceIdentityDomain: effectiveRestriction,
@@ -172,7 +171,7 @@ export const SecuritySection = forwardRef<SectionHandle, SecuritySectionProps>(
       // load-once cache, so we refresh it here so consumers like
       // <Watermark /> and <BannersWrapper /> pick up the new values.
       await useAppStore.getState().loadWorkspaceProfile(true);
-    }, [state, domainInput, settingV1Store, getInitialState]);
+    }, [state, domainInput, getInitialState]);
 
     useImperativeHandle(ref, () => ({ isDirty, revert, update }));
 

--- a/frontend/src/react/pages/settings/profile/EmailInput.tsx
+++ b/frontend/src/react/pages/settings/profile/EmailInput.tsx
@@ -8,8 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/react/components/ui/select";
-import { useVueState } from "@/react/hooks/useVueState";
-import { useSettingV1Store } from "@/store";
+import { useAppStore } from "@/react/stores/app";
 
 // WHATWG HTML spec email validation (lowercase only).
 const emailRegex =
@@ -35,14 +34,11 @@ export function EmailInput({
   showDomain = false,
 }: EmailInputProps) {
   const { t } = useTranslation();
-  const settingV1Store = useSettingV1Store();
 
-  const enforceIdentityDomain = useVueState(
-    () => settingV1Store.workspaceProfile.enforceIdentityDomain
+  const enforceIdentityDomain = useAppStore(
+    (s) => s.getWorkspaceProfile().enforceIdentityDomain
   );
-  const workspaceDomains = useVueState(
-    () => settingV1Store.workspaceProfile.domains
-  );
+  const workspaceDomains = useAppStore((s) => s.getWorkspaceProfile().domains);
 
   const enforceDomain = enforceIdentityDomain || showDomain;
 

--- a/frontend/src/react/pages/settings/profile/ProfilePage.test.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.test.tsx
@@ -30,17 +30,8 @@ const mocks = vi.hoisted(() => ({
   useAuthStore: vi.fn(() => ({
     updateCurrentUserNameForEmailChange: vi.fn(),
   })),
-  useSettingV1Store: vi.fn(() => ({
-    workspaceProfile: {
-      passwordRestriction: undefined,
-      requireMfa: false,
-    },
-  })),
   getWorkspaceRolesByName: vi.fn(() => new Set<string>()),
   fetchWorkspaceIamPolicy: vi.fn(async () => undefined),
-  useActuatorV1Store: vi.fn(() => ({
-    isSaaSMode: false,
-  })),
   hasFeature: vi.fn(() => true),
   pushNotification: vi.fn(),
   getUserByIdentifier: vi.fn(),
@@ -66,26 +57,33 @@ vi.mock("@/react/hooks/useUnsavedChangesGuard", () => ({
   useUnsavedChangesGuard: vi.fn(),
 }));
 
-vi.mock("@/react/stores/app", () => ({
-  useAppStore: (selector: (state: unknown) => unknown) =>
-    selector({
-      getUserByIdentifier: mocks.getUserByIdentifier,
-      getOrFetchUserByIdentifier: mocks.getOrFetchUserByIdentifier,
-      updateUser: mocks.updateUser,
-      updateEmail: mocks.updateEmail,
-      roleList: [],
-      workspacePolicy: undefined,
-      getWorkspaceRolesByName: mocks.getWorkspaceRolesByName,
-      fetchWorkspaceIamPolicy: mocks.fetchWorkspaceIamPolicy,
+vi.mock("@/react/stores/app", () => {
+  const buildState = () => ({
+    getUserByIdentifier: mocks.getUserByIdentifier,
+    getOrFetchUserByIdentifier: mocks.getOrFetchUserByIdentifier,
+    updateUser: mocks.updateUser,
+    updateEmail: mocks.updateEmail,
+    roleList: [],
+    workspacePolicy: undefined,
+    getWorkspaceRolesByName: mocks.getWorkspaceRolesByName,
+    fetchWorkspaceIamPolicy: mocks.fetchWorkspaceIamPolicy,
+    // Migrated off the Pinia actuator/setting store mocks.
+    isSaaSMode: () => false,
+    getWorkspaceProfile: () => ({
+      passwordRestriction: undefined,
+      requireMfa: false,
     }),
-}));
+  });
+  const useAppStore = (selector: (state: unknown) => unknown) =>
+    selector(buildState());
+  useAppStore.getState = () => buildState();
+  return { useAppStore };
+});
 
 vi.mock("@/store", () => ({
   hasFeature: mocks.hasFeature,
   pushNotification: mocks.pushNotification,
-  useActuatorV1Store: mocks.useActuatorV1Store,
   useAuthStore: mocks.useAuthStore,
-  useSettingV1Store: mocks.useSettingV1Store,
 }));
 
 vi.mock("@/router", () => ({

--- a/frontend/src/react/pages/settings/profile/ProfilePage.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.tsx
@@ -38,13 +38,7 @@ import {
   SETTING_ROUTE_PROFILE_TWO_FACTOR,
   SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
 } from "@/router/dashboard/workspaceSetting";
-import {
-  hasFeature,
-  pushNotification,
-  useActuatorV1Store,
-  useAuthStore,
-  useSettingV1Store,
-} from "@/store";
+import { hasFeature, pushNotification, useAuthStore } from "@/store";
 import {
   AccountType,
   ALL_USERS_USER_EMAIL,
@@ -69,7 +63,6 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
   const { t } = useTranslation();
 
   const authStore = useAuthStore();
-  const settingV1Store = useSettingV1Store();
   const getOrFetchUserByIdentifier = useAppStore(
     (state) => state.getOrFetchUserByIdentifier
   );
@@ -80,7 +73,6 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
   const getWorkspaceRolesByName = useAppStore(
     (state) => state.getWorkspaceRolesByName
   );
-  const actuatorStore = useActuatorV1Store();
 
   // --- Reactive Vue state ---
   const legacyCurrentUser = useCurrentUser();
@@ -97,19 +89,17 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
     [getWorkspaceRolesByName, user.name, workspacePolicy]
   );
 
-  const passwordRestriction = useVueState(
-    () => settingV1Store.workspaceProfile.passwordRestriction
+  const passwordRestriction = useAppStore(
+    (s) => s.getWorkspaceProfile().passwordRestriction
   );
 
-  const isSaaSMode = useVueState(() => actuatorStore.isSaaSMode);
+  const isSaaSMode = useVueState(() => useAppStore.getState().isSaaSMode());
 
   const has2FAFeature = useVueState(() =>
     hasFeature(PlanFeature.FEATURE_TWO_FA)
   );
 
-  const requireMfa = useVueState(
-    () => settingV1Store.workspaceProfile.requireMfa
-  );
+  const requireMfa = useAppStore((s) => s.getWorkspaceProfile().requireMfa);
 
   const tempRecoveryCodes = useVueState(() => currentUser.tempRecoveryCodes);
 

--- a/frontend/src/react/pages/settings/shared/AADSyncSheet.tsx
+++ b/frontend/src/react/pages/settings/shared/AADSyncSheet.tsx
@@ -14,12 +14,8 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/react/components/ui/sheet";
-import { useVueState } from "@/react/hooks/useVueState";
-import {
-  pushNotification,
-  useActuatorV1Store,
-  useSettingV1Store,
-} from "@/store";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification } from "@/store";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
 // ============================================================
@@ -34,17 +30,11 @@ export function AADSyncSheet({
   onClose: () => void;
 }) {
   const { t } = useTranslation();
-  const actuatorStore = useActuatorV1Store();
-  const settingV1Store = useSettingV1Store();
 
-  const externalUrl = useVueState(
-    () => actuatorStore.serverInfo?.externalUrl ?? ""
-  );
-  const workspaceResourceName = useVueState(
-    () => actuatorStore.workspaceResourceName
-  );
-  const directorySyncToken = useVueState(
-    () => settingV1Store.workspaceProfile.directorySyncToken
+  const externalUrl = useAppStore((s) => s.serverInfo?.externalUrl ?? "");
+  const workspaceResourceName = useAppStore((s) => s.workspaceResourceName());
+  const directorySyncToken = useAppStore(
+    (s) => s.getWorkspaceProfile().directorySyncToken
   );
 
   const scimUrl =
@@ -88,7 +78,7 @@ export function AADSyncSheet({
     if (!confirmed) return;
 
     try {
-      await settingV1Store.updateWorkspaceProfile({
+      await useAppStore.getState().updateWorkspaceProfile({
         payload: { directorySyncToken: "" },
         updateMask: create(FieldMaskSchema, {
           paths: ["value.workspace_profile.directory_sync_token"],

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -266,6 +266,9 @@ export type WorkspaceSlice = {
   enableOnboarding: () => boolean;
   quickStartEnabled: () => boolean;
   setupSample: () => Promise<void>;
+  // Always returns a profile (never undefined), mirroring the Pinia
+  // `workspaceProfile` getter so consumers read fields without null checks.
+  getWorkspaceProfile: () => WorkspaceProfileSetting;
   // Data-classification config from the DATA_CLASSIFICATION setting cache.
   classification: () => DataClassificationSetting_DataClassificationConfig[];
   getProjectClassification: (

--- a/frontend/src/react/stores/app/types.ts
+++ b/frontend/src/react/stores/app/types.ts
@@ -1,3 +1,4 @@
+import type { FieldMask } from "@bufbuild/protobuf/wkt";
 import type { StateCreator } from "zustand";
 import type { ConditionGroupExpr } from "@/plugins/cel";
 import type { DatabaseFilter } from "@/react/lib/databaseFilter";
@@ -61,8 +62,10 @@ import type { Role } from "@/types/proto-es/v1/role_service_pb";
 import type { Rollout } from "@/types/proto-es/v1/rollout_service_pb";
 import type { ServiceAccount } from "@/types/proto-es/v1/service_account_service_pb";
 import type {
+  DataClassificationSetting_DataClassificationConfig,
   Setting,
   Setting_SettingName,
+  SettingValue,
   WorkspaceProfileSetting,
 } from "@/types/proto-es/v1/setting_service_pb";
 import type { Sheet } from "@/types/proto-es/v1/sheet_service_pb";
@@ -71,8 +74,11 @@ import type {
   QueryRequest,
 } from "@/types/proto-es/v1/sql_service_pb";
 import type {
+  BillingInterval,
+  PaymentInfo,
   PlanFeature,
   PlanType,
+  PurchasePlan,
   Subscription,
 } from "@/types/proto-es/v1/subscription_service_pb";
 import type {
@@ -180,8 +186,17 @@ export type WorkspaceSlice = {
   appFeatures: AppFeatures;
   subscription?: Subscription;
   subscriptionRequest?: Promise<Subscription | undefined>;
+  // Subscription purchase metadata (SaaS). Mirrors the legacy Pinia
+  // `useSubscriptionV1Store` `purchasePlans` / `paymentInfo` refs.
+  purchasePlans: PurchasePlan[];
+  paymentInfo?: PaymentInfo;
   loadServerInfo: () => Promise<ActuatorInfo | undefined>;
   refreshServerInfo: () => Promise<ActuatorInfo | undefined>;
+  // Alias for the legacy Pinia `actuatorStore.fetchServerInfo(workspace?)`
+  // so consumers map 1:1. Delegates to the slice's refresh path.
+  fetchServerInfo: (
+    workspaceResourceName?: string
+  ) => Promise<ActuatorInfo | undefined>;
   loadWorkspace: () => Promise<Workspace | undefined>;
   loadWorkspaceList: () => Promise<Workspace[]>;
   updateWorkspace: (
@@ -204,6 +219,14 @@ export type WorkspaceSlice = {
   // updates into the app store after a save, so still-app-store consumers
   // (e.g. SQL editor's `OpenAIButton`) see fresh values without a refresh.
   setSettingByName: (setting: Setting) => void;
+  // Writes a setting to the server and updates the cache. Mirrors the legacy
+  // Pinia `useSettingV1Store().upsertSetting`.
+  upsertSetting: (params: {
+    name: Setting_SettingName;
+    value: SettingValue;
+    validateOnly?: boolean;
+    updateMask?: FieldMask;
+  }) => Promise<Setting>;
   loadSubscription: () => Promise<Subscription | undefined>;
   refreshSubscription: () => Promise<Subscription | undefined>;
   uploadLicense: (license: string) => Promise<Subscription | undefined>;
@@ -239,6 +262,49 @@ export type WorkspaceSlice = {
   totalInstanceCount: () => number;
   userCountInIam: () => number;
   activeVcsUserCount: () => number;
+  activeUserCount: () => number;
+  enableOnboarding: () => boolean;
+  quickStartEnabled: () => boolean;
+  setupSample: () => Promise<void>;
+  // Data-classification config from the DATA_CLASSIFICATION setting cache.
+  classification: () => DataClassificationSetting_DataClassificationConfig[];
+  getProjectClassification: (
+    classificationId: string
+  ) => DataClassificationSetting_DataClassificationConfig | undefined;
+  updateWorkspaceProfile: (params: {
+    payload: Partial<WorkspaceProfileSetting>;
+    updateMask: FieldMask;
+  }) => Promise<void>;
+  fetchEnvironments: (silent?: boolean) => Promise<void>;
+  createEnvironment: (
+    environment: Partial<Environment>
+  ) => Promise<Environment>;
+  updateEnvironment: (update: Partial<Environment>) => Promise<Environment>;
+  deleteEnvironment: (name: string) => Promise<void>;
+  reorderEnvironmentList: (
+    orderedEnvironmentList: Environment[]
+  ) => Promise<Environment[]>;
+  setSubscription: (subscription: Subscription) => void;
+  hasSplitInstanceLicense: () => boolean;
+  pollSubscriptionUntil: (
+    predicate: (subscription: Subscription) => boolean,
+    options?: { timeoutMs?: number; intervalMs?: number; signal?: AbortSignal }
+  ) => Promise<Subscription | undefined>;
+  createPurchase: (
+    plan: PlanType,
+    interval: BillingInterval,
+    seats: number
+  ) => Promise<string>;
+  updatePurchase: (
+    plan: PlanType,
+    interval: BillingInterval,
+    seats: number,
+    etag: string
+  ) => Promise<string>;
+  cancelPurchase: (feedback: string, comment: string) => Promise<void>;
+  fetchPaymentInfo: () => Promise<PaymentInfo | undefined>;
+  verifyCheckoutSession: (sessionId: string) => Promise<string>;
+  fetchPurchasePlans: () => Promise<PurchasePlan[] | undefined>;
 };
 
 export type IamSlice = {

--- a/frontend/src/react/stores/app/workspace.ts
+++ b/frontend/src/react/stores/app/workspace.ts
@@ -713,7 +713,8 @@ export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
     // Always returns a profile (never undefined), mirroring the Pinia
     // `useSettingV1Store().workspaceProfile` getter, so consumers can read
     // fields without null checks. Reactive via Zustand's selector re-run.
-    getWorkspaceProfile: () => get().workspaceProfile ?? EMPTY_WORKSPACE_PROFILE,
+    getWorkspaceProfile: () =>
+      get().workspaceProfile ?? EMPTY_WORKSPACE_PROFILE,
 
     classification: () => {
       const setting =

--- a/frontend/src/react/stores/app/workspace.ts
+++ b/frontend/src/react/stores/app/workspace.ts
@@ -32,17 +32,28 @@ import {
 import { SwitchWorkspaceRequestSchema } from "@/types/proto-es/v1/auth_service_pb";
 import {
   DatabaseChangeMode,
+  type DataClassificationSetting_DataClassificationConfig,
   type EnvironmentSetting_Environment,
   EnvironmentSetting_EnvironmentSchema,
+  EnvironmentSettingSchema,
   GetSettingRequestSchema,
   Setting_SettingName,
+  SettingSchema,
+  SettingValueSchema,
+  UpdateSettingRequestSchema,
   WorkspaceProfileSettingSchema,
 } from "@/types/proto-es/v1/setting_service_pb";
 import type { Subscription } from "@/types/proto-es/v1/subscription_service_pb";
 import {
+  CancelPurchaseRequestSchema,
+  CreatePurchaseRequestSchema,
+  GetPaymentInfoRequestSchema,
   GetSubscriptionRequestSchema,
+  ListPurchasePlansRequestSchema,
   PlanType,
+  UpdatePurchaseRequestSchema,
   UploadLicenseRequestSchema,
+  VerifyCheckoutSessionRequestSchema,
 } from "@/types/proto-es/v1/subscription_service_pb";
 import {
   UpdateWorkspaceRequestSchema,
@@ -139,471 +150,746 @@ function isSelfHostLicense() {
   return import.meta.env.MODE.toLowerCase() !== "release-aws";
 }
 
+function convertEnvironmentsToSetting(
+  environments: Environment[]
+): EnvironmentSetting_Environment[] {
+  return environments.map((env) =>
+    createProto(EnvironmentSetting_EnvironmentSchema, {
+      name: env.name,
+      id: env.id,
+      title: env.title,
+      color: env.color,
+      tags: env.tags,
+    })
+  );
+}
+
 export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
   set,
   get
-) => ({
-  serverInfoTs: 0,
-  workspaceList: [],
-  environmentList: [],
-  settingsByName: {},
-  settingRequests: {},
-  appFeatures: defaultAppProfile().features,
-
-  loadServerInfo: async () => {
-    const existing = get().serverInfo;
-    if (existing) return existing;
-    const pending = get().serverInfoRequest;
-    if (pending) return pending;
-    const request = actuatorServiceClientConnect
-      .getActuatorInfo({ name: get().currentUser?.workspace ?? "" })
-      .then((info) => {
-        set({
-          serverInfo: info,
-          serverInfoRequest: undefined,
-          serverInfoTs: Date.now(),
-        });
-        return info;
-      })
-      .catch(() => {
-        set({ serverInfoRequest: undefined });
-        return undefined;
-      });
-    set({ serverInfoRequest: request });
-    return request;
-  },
-
-  refreshServerInfo: async () => {
-    const info = await actuatorServiceClientConnect.getActuatorInfo({
-      name: get().currentUser?.workspace ?? get().serverInfo?.workspace ?? "",
+) => {
+  // Persist the ENVIRONMENT setting and re-derive the cached environment list
+  // from the server's response (mirrors the legacy Pinia env store).
+  const writeEnvironmentSetting = async (
+    environments: EnvironmentSetting_Environment[]
+  ): Promise<Environment[]> => {
+    const response = await get().upsertSetting({
+      name: Setting_SettingName.ENVIRONMENT,
+      value: createProto(SettingValueSchema, {
+        value: {
+          case: "environment",
+          value: createProto(EnvironmentSettingSchema, { environments }),
+        },
+      }),
     });
-    set({ serverInfo: info, serverInfoTs: Date.now() });
-    return info;
-  },
+    const next =
+      response.value?.value?.case === "environment"
+        ? convertEnvironmentList(response.value.value.value.environments)
+        : [];
+    set({ environmentList: next });
+    return next;
+  };
 
-  loadWorkspace: async () => {
-    // Always re-fetch currentUser to get the latest auth context.
-    // The cached currentUser may be from before login (undefined or stale).
-    const user = await userServiceClientConnect
-      .getCurrentUser({})
-      .catch(() => undefined);
-    if (user) {
-      set({ currentUser: user });
-    }
-    const name =
-      user?.workspace ||
-      get().currentUser?.workspace ||
-      get().serverInfo?.workspace ||
-      `${workspaceNamePrefix}-`;
-    // Return cached workspace if it matches the current auth context.
-    const existing = get().workspace;
-    if (existing?.name === name) return existing;
-    const pending = get().workspaceRequest;
-    if (pending) return pending;
-    const request = workspaceServiceClientConnect
-      .getWorkspace({ name })
-      .then((workspace) => {
-        set({ workspace, workspaceRequest: undefined });
-        return workspace;
-      })
-      .catch(() => {
-        set({ workspaceRequest: undefined });
-        return undefined;
-      });
-    set({ workspaceRequest: request });
-    return request;
-  },
+  return {
+    serverInfoTs: 0,
+    workspaceList: [],
+    environmentList: [],
+    settingsByName: {},
+    settingRequests: {},
+    appFeatures: defaultAppProfile().features,
+    purchasePlans: [],
 
-  loadWorkspaceList: async () => {
-    const resp = await workspaceServiceClientConnect.listWorkspaces({});
-    set({ workspaceList: resp.workspaces });
-    return resp.workspaces;
-  },
-
-  updateWorkspace: async (workspace: Workspace, updateMask: string[]) => {
-    const updated = await workspaceServiceClientConnect.updateWorkspace(
-      createProto(UpdateWorkspaceRequestSchema, {
-        workspace,
-        updateMask: createProto(FieldMaskSchema, { paths: updateMask }),
-      })
-    );
-    set((state) => ({
-      workspace:
-        state.workspace?.name === updated.name ? updated : state.workspace,
-      workspaceList: state.workspaceList.map((ws) =>
-        ws.name === updated.name ? updated : ws
-      ),
-    }));
-    return updated;
-  },
-
-  switchWorkspace: async (workspaceName: string, redirect = true) => {
-    await authServiceClientConnect.switchWorkspace(
-      createProto(SwitchWorkspaceRequestSchema, {
-        workspace: workspaceName,
-        web: true,
-      })
-    );
-    // Notify other tabs to reload with the new workspace.
-    broadcastWorkspaceSwitch(workspaceName);
-    if (redirect) {
-      // Full-reload to the landing page to reset all frontend state.
-      window.location.href = "/";
-    }
-  },
-
-  loadWorkspaceProfile: async (force = false) => {
-    const existing = get().workspaceProfile;
-    if (!force && existing) return existing;
-    const pending = get().workspaceProfileRequest;
-    if (!force && pending) return pending;
-    // request is captured so .then handlers can identity-check against
-    // the latest in-flight request before writing — protects against an
-    // older in-flight request resolving after a newer forced reload.
-    const request = settingServiceClientConnect
-      .getSetting(
-        createProto(GetSettingRequestSchema, {
-          name: workspaceProfileSettingName,
+    loadServerInfo: async () => {
+      const existing = get().serverInfo;
+      if (existing) return existing;
+      const pending = get().serverInfoRequest;
+      if (pending) return pending;
+      const request = actuatorServiceClientConnect
+        .getActuatorInfo({ name: get().currentUser?.workspace ?? "" })
+        .then((info) => {
+          set({
+            serverInfo: info,
+            serverInfoRequest: undefined,
+            serverInfoTs: Date.now(),
+          });
+          return info;
         })
-      )
-      .then((setting) => {
-        if (get().workspaceProfileRequest !== request) {
-          return get().workspaceProfile;
-        }
-        const settingValue = setting.value?.value;
-        const profile =
-          settingValue?.case === "workspaceProfile"
-            ? settingValue.value
-            : createProto(WorkspaceProfileSettingSchema, {});
-        set({
-          workspaceProfile: profile,
-          workspaceProfileRequest: undefined,
-          appFeatures: appFeaturesFromDatabaseChangeMode(
-            profile.databaseChangeMode
-          ),
+        .catch(() => {
+          set({ serverInfoRequest: undefined });
+          return undefined;
         });
-        return profile;
-      })
-      .catch(() => {
-        if (get().workspaceProfileRequest === request) {
-          set({ workspaceProfileRequest: undefined });
-        }
-        return undefined;
-      });
-    set({ workspaceProfileRequest: request });
-    return request;
-  },
+      set({ serverInfoRequest: request });
+      return request;
+    },
 
-  loadEnvironmentList: async (force = false) => {
-    const existing = get().environmentList;
-    if (!force && existing.length > 0) return existing;
-    const pending = get().environmentRequest;
-    if (pending) return pending;
-    const request = settingServiceClientConnect
-      .getSetting(
-        createProto(GetSettingRequestSchema, {
-          name: environmentSettingName,
+    refreshServerInfo: async () => {
+      const info = await actuatorServiceClientConnect.getActuatorInfo({
+        name: get().currentUser?.workspace ?? get().serverInfo?.workspace ?? "",
+      });
+      set({ serverInfo: info, serverInfoTs: Date.now() });
+      return info;
+    },
+
+    loadWorkspace: async () => {
+      // Always re-fetch currentUser to get the latest auth context.
+      // The cached currentUser may be from before login (undefined or stale).
+      const user = await userServiceClientConnect
+        .getCurrentUser({})
+        .catch(() => undefined);
+      if (user) {
+        set({ currentUser: user });
+      }
+      const name =
+        user?.workspace ||
+        get().currentUser?.workspace ||
+        get().serverInfo?.workspace ||
+        `${workspaceNamePrefix}-`;
+      // Return cached workspace if it matches the current auth context.
+      const existing = get().workspace;
+      if (existing?.name === name) return existing;
+      const pending = get().workspaceRequest;
+      if (pending) return pending;
+      const request = workspaceServiceClientConnect
+        .getWorkspace({ name })
+        .then((workspace) => {
+          set({ workspace, workspaceRequest: undefined });
+          return workspace;
         })
-      )
-      .then((setting) => {
-        const settingValue = setting.value?.value;
-        const environments =
-          settingValue?.case === "environment"
-            ? convertEnvironmentList(settingValue.value.environments)
-            : [];
-        set({ environmentList: environments, environmentRequest: undefined });
-        return environments;
-      })
-      .catch(() => {
-        set({ environmentRequest: undefined });
-        return [];
-      });
-    set({ environmentRequest: request });
-    return request;
-  },
-
-  refreshEnvironmentList: async () => get().loadEnvironmentList(true),
-
-  // Mirrors the Pinia `useEnvironmentV1Store().getEnvironmentByName`: maps
-  // a resource name to its environment, falling back to a synthesized
-  // entry (id-as-title) for unknown names when `fallback` is set.
-  getEnvironmentByName: (name, fallback = true) => {
-    if (name === NULL_ENVIRONMENT_NAME) {
-      return nullEnvironment();
-    }
-    const id = getEnvironmentId(name);
-    if (!id) {
-      return unknownEnvironment();
-    }
-    const environment =
-      get().environmentList.find((e) => e.id === id) ?? unknownEnvironment();
-    if (!isValidEnvironmentName(environment.name) && fallback) {
-      return { ...environment, id, name, title: id };
-    }
-    return environment;
-  },
-
-  // Mirrors the Pinia `useSettingV1Store`: general-purpose setting cache
-  // keyed by resource name (`settings/{Setting_SettingName}`). Used for AI /
-  // workspace-profile / etc.
-  getSettingByName: (name) => {
-    const resourceName = `${settingNamePrefix}${Setting_SettingName[name]}`;
-    return get().settingsByName[resourceName];
-  },
-
-  setSettingByName: (setting) => {
-    set((state) => ({
-      settingsByName: {
-        ...state.settingsByName,
-        [setting.name]: setting,
-      },
-    }));
-  },
-
-  getOrFetchSettingByName: async (name, silent = false) => {
-    const resourceName = `${settingNamePrefix}${Setting_SettingName[name]}`;
-    const cached = get().settingsByName[resourceName];
-    if (cached) return cached;
-    const pending = get().settingRequests[resourceName];
-    if (pending) return pending;
-
-    const request = settingServiceClientConnect
-      .getSetting(
-        createProto(GetSettingRequestSchema, { name: resourceName }),
-        {
-          contextValues: createContextValues().set(silentContextKey, silent),
-        }
-      )
-      .then((response) => {
-        set((state) => {
-          const { [resourceName]: _, ...settingRequests } =
-            state.settingRequests;
-          return {
-            settingsByName: {
-              ...state.settingsByName,
-              [response.name]: response,
-            },
-            settingRequests,
-          };
+        .catch(() => {
+          set({ workspaceRequest: undefined });
+          return undefined;
         });
-        return response;
-      })
-      .catch(() => {
-        set((state) => {
-          const { [resourceName]: _, ...settingRequests } =
-            state.settingRequests;
-          return { settingRequests };
+      set({ workspaceRequest: request });
+      return request;
+    },
+
+    loadWorkspaceList: async () => {
+      const resp = await workspaceServiceClientConnect.listWorkspaces({});
+      set({ workspaceList: resp.workspaces });
+      return resp.workspaces;
+    },
+
+    updateWorkspace: async (workspace: Workspace, updateMask: string[]) => {
+      const updated = await workspaceServiceClientConnect.updateWorkspace(
+        createProto(UpdateWorkspaceRequestSchema, {
+          workspace,
+          updateMask: createProto(FieldMaskSchema, { paths: updateMask }),
+        })
+      );
+      set((state) => ({
+        workspace:
+          state.workspace?.name === updated.name ? updated : state.workspace,
+        workspaceList: state.workspaceList.map((ws) =>
+          ws.name === updated.name ? updated : ws
+        ),
+      }));
+      return updated;
+    },
+
+    switchWorkspace: async (workspaceName: string, redirect = true) => {
+      await authServiceClientConnect.switchWorkspace(
+        createProto(SwitchWorkspaceRequestSchema, {
+          workspace: workspaceName,
+          web: true,
+        })
+      );
+      // Notify other tabs to reload with the new workspace.
+      broadcastWorkspaceSwitch(workspaceName);
+      if (redirect) {
+        // Full-reload to the landing page to reset all frontend state.
+        window.location.href = "/";
+      }
+    },
+
+    loadWorkspaceProfile: async (force = false) => {
+      const existing = get().workspaceProfile;
+      if (!force && existing) return existing;
+      const pending = get().workspaceProfileRequest;
+      if (!force && pending) return pending;
+      // request is captured so .then handlers can identity-check against
+      // the latest in-flight request before writing — protects against an
+      // older in-flight request resolving after a newer forced reload.
+      const request = settingServiceClientConnect
+        .getSetting(
+          createProto(GetSettingRequestSchema, {
+            name: workspaceProfileSettingName,
+          })
+        )
+        .then((setting) => {
+          if (get().workspaceProfileRequest !== request) {
+            return get().workspaceProfile;
+          }
+          const settingValue = setting.value?.value;
+          const profile =
+            settingValue?.case === "workspaceProfile"
+              ? settingValue.value
+              : createProto(WorkspaceProfileSettingSchema, {});
+          set({
+            workspaceProfile: profile,
+            workspaceProfileRequest: undefined,
+            appFeatures: appFeaturesFromDatabaseChangeMode(
+              profile.databaseChangeMode
+            ),
+          });
+          return profile;
+        })
+        .catch(() => {
+          if (get().workspaceProfileRequest === request) {
+            set({ workspaceProfileRequest: undefined });
+          }
+          return undefined;
         });
-        return undefined;
+      set({ workspaceProfileRequest: request });
+      return request;
+    },
+
+    loadEnvironmentList: async (force = false) => {
+      const existing = get().environmentList;
+      if (!force && existing.length > 0) return existing;
+      const pending = get().environmentRequest;
+      if (pending) return pending;
+      const request = settingServiceClientConnect
+        .getSetting(
+          createProto(GetSettingRequestSchema, {
+            name: environmentSettingName,
+          })
+        )
+        .then((setting) => {
+          const settingValue = setting.value?.value;
+          const environments =
+            settingValue?.case === "environment"
+              ? convertEnvironmentList(settingValue.value.environments)
+              : [];
+          set({ environmentList: environments, environmentRequest: undefined });
+          return environments;
+        })
+        .catch(() => {
+          set({ environmentRequest: undefined });
+          return [];
+        });
+      set({ environmentRequest: request });
+      return request;
+    },
+
+    refreshEnvironmentList: async () => get().loadEnvironmentList(true),
+
+    // Mirrors the Pinia `useEnvironmentV1Store().getEnvironmentByName`: maps
+    // a resource name to its environment, falling back to a synthesized
+    // entry (id-as-title) for unknown names when `fallback` is set.
+    getEnvironmentByName: (name, fallback = true) => {
+      if (name === NULL_ENVIRONMENT_NAME) {
+        return nullEnvironment();
+      }
+      const id = getEnvironmentId(name);
+      if (!id) {
+        return unknownEnvironment();
+      }
+      const environment =
+        get().environmentList.find((e) => e.id === id) ?? unknownEnvironment();
+      if (!isValidEnvironmentName(environment.name) && fallback) {
+        return { ...environment, id, name, title: id };
+      }
+      return environment;
+    },
+
+    // Mirrors the Pinia `useSettingV1Store`: general-purpose setting cache
+    // keyed by resource name (`settings/{Setting_SettingName}`). Used for AI /
+    // workspace-profile / etc.
+    getSettingByName: (name) => {
+      const resourceName = `${settingNamePrefix}${Setting_SettingName[name]}`;
+      return get().settingsByName[resourceName];
+    },
+
+    setSettingByName: (setting) => {
+      set((state) => ({
+        settingsByName: {
+          ...state.settingsByName,
+          [setting.name]: setting,
+        },
+      }));
+    },
+
+    upsertSetting: async ({
+      name,
+      value,
+      validateOnly = false,
+      updateMask,
+    }) => {
+      const response = await settingServiceClientConnect.updateSetting(
+        createProto(UpdateSettingRequestSchema, {
+          setting: createProto(SettingSchema, {
+            name: `${settingNamePrefix}${Setting_SettingName[name]}`,
+            value,
+          }),
+          validateOnly,
+          allowMissing: true,
+          updateMask,
+        })
+      );
+      get().setSettingByName(response);
+      return response;
+    },
+
+    getOrFetchSettingByName: async (name, silent = false) => {
+      const resourceName = `${settingNamePrefix}${Setting_SettingName[name]}`;
+      const cached = get().settingsByName[resourceName];
+      if (cached) return cached;
+      const pending = get().settingRequests[resourceName];
+      if (pending) return pending;
+
+      const request = settingServiceClientConnect
+        .getSetting(
+          createProto(GetSettingRequestSchema, { name: resourceName }),
+          {
+            contextValues: createContextValues().set(silentContextKey, silent),
+          }
+        )
+        .then((response) => {
+          set((state) => {
+            const { [resourceName]: _, ...settingRequests } =
+              state.settingRequests;
+            return {
+              settingsByName: {
+                ...state.settingsByName,
+                [response.name]: response,
+              },
+              settingRequests,
+            };
+          });
+          return response;
+        })
+        .catch(() => {
+          set((state) => {
+            const { [resourceName]: _, ...settingRequests } =
+              state.settingRequests;
+            return { settingRequests };
+          });
+          return undefined;
+        });
+      set((state) => ({
+        settingRequests: {
+          ...state.settingRequests,
+          [resourceName]: request,
+        },
+      }));
+      return request;
+    },
+
+    loadSubscription: async () => {
+      const existing = get().subscription;
+      if (existing) return existing;
+      const pending = get().subscriptionRequest;
+      if (pending) return pending;
+      const request = subscriptionServiceClientConnect
+        .getSubscription(createProto(GetSubscriptionRequestSchema, {}))
+        .then((subscription) => {
+          set({ subscription, subscriptionRequest: undefined });
+          syncSubscriptionToPinia(subscription);
+          return subscription;
+        })
+        .catch(() => {
+          set({ subscriptionRequest: undefined });
+          return undefined;
+        });
+      set({ subscriptionRequest: request });
+      return request;
+    },
+
+    refreshSubscription: async () => {
+      const request = subscriptionServiceClientConnect
+        .getSubscription(createProto(GetSubscriptionRequestSchema, {}))
+        .then((subscription) => {
+          set({ subscription, subscriptionRequest: undefined });
+          syncSubscriptionToPinia(subscription);
+          return subscription;
+        })
+        .catch(() => {
+          set({ subscriptionRequest: undefined });
+          return undefined;
+        });
+      set({ subscriptionRequest: request });
+      return request;
+    },
+
+    uploadLicense: async (license) => {
+      const subscription = await subscriptionServiceClientConnect.uploadLicense(
+        createProto(UploadLicenseRequestSchema, { license })
+      );
+      set({ subscription });
+      syncSubscriptionToPinia(subscription);
+      return subscription;
+    },
+
+    currentPlan: () => {
+      return get().subscription?.plan ?? PlanType.FREE;
+    },
+
+    isFreePlan: () => get().currentPlan() === PlanType.FREE,
+
+    isTrialing: () => Boolean(get().subscription?.trialing),
+
+    isExpired: () => {
+      const subscription = get().subscription;
+      if (!subscription?.expiresTime || get().isFreePlan()) {
+        return false;
+      }
+      return dayjs(
+        getDateForPbTimestampProtoEs(subscription.expiresTime)
+      ).isBefore(new Date());
+    },
+
+    daysBeforeExpire: () => {
+      const subscription = get().subscription;
+      if (!subscription?.expiresTime || get().isFreePlan()) {
+        return -1;
+      }
+      return Math.max(
+        dayjs(getDateForPbTimestampProtoEs(subscription.expiresTime)).diff(
+          new Date(),
+          "day"
+        ),
+        0
+      );
+    },
+
+    trialingDays: () => trialingDays,
+
+    showTrial: () => {
+      if (!isSelfHostLicense()) {
+        return false;
+      }
+      return !get().subscription || get().isFreePlan();
+    },
+
+    expireAt: () => {
+      const subscription = get().subscription;
+      if (!subscription?.expiresTime || get().isFreePlan()) {
+        return "";
+      }
+      return formatAbsoluteDateTime(
+        getTimeForPbTimestampProtoEs(subscription.expiresTime)
+      );
+    },
+
+    instanceCountLimit: () => {
+      const subscription = get().subscription;
+      const licenseLimit = subscription?.instances ?? 0;
+      if (licenseLimit > 0) {
+        return licenseLimit;
+      }
+      const planLimit =
+        PLANS.find((plan) => plan.type === get().currentPlan())
+          ?.maximumInstanceCount ?? 0;
+      if (planLimit < 0) {
+        return licenseLimit > 0 ? licenseLimit : Number.MAX_VALUE;
+      }
+      return planLimit;
+    },
+
+    userCountLimit: () => {
+      let limit =
+        PLANS.find((plan) => plan.type === get().currentPlan())
+          ?.maximumSeatCount ?? 0;
+      if (limit < 0) {
+        limit = Number.MAX_VALUE;
+      }
+      const seats = get().subscription?.seats ?? 0;
+      if (seats < 0) {
+        return Number.MAX_VALUE;
+      }
+      if (seats === 0) {
+        return limit;
+      }
+      return seats;
+    },
+
+    instanceLicenseCount: () => {
+      const count = get().subscription?.activeInstances ?? 0;
+      return count < 0 ? Number.MAX_VALUE : count;
+    },
+
+    hasUnifiedInstanceLicense: () => {
+      return get().instanceCountLimit() <= get().instanceLicenseCount();
+    },
+
+    hasFeature: (feature) => {
+      if (get().isExpired()) {
+        return false;
+      }
+      return checkFeature(get().currentPlan(), feature);
+    },
+
+    hasInstanceFeature: (feature, instance) => {
+      const plan = get().currentPlan();
+      if (plan === PlanType.FREE) {
+        return get().hasFeature(feature);
+      }
+      if (!instance || !instanceLimitFeature.has(feature)) {
+        return get().hasFeature(feature);
+      }
+      return checkInstanceFeature(
+        plan,
+        feature,
+        get().hasUnifiedInstanceLicense() || instance.activation
+      );
+    },
+
+    instanceMissingLicense: (feature, instance) => {
+      if (!instanceLimitFeature.has(feature) || !instance) {
+        return false;
+      }
+      if (get().hasUnifiedInstanceLicense()) {
+        return false;
+      }
+      return get().hasFeature(feature) && !instance.activation;
+    },
+
+    getMinimumRequiredPlan,
+
+    isSaaSMode: () => get().serverInfo?.saas ?? false,
+
+    workspaceResourceName: () => get().serverInfo?.workspace ?? "",
+
+    externalUrl: () => get().serverInfo?.externalUrl ?? "",
+
+    needConfigureExternalUrl: () => {
+      const serverInfo = get().serverInfo;
+      if (!serverInfo) return false;
+      const url = serverInfo.externalUrl ?? "";
+      return url === "" || url === externalUrlPlaceholder;
+    },
+
+    version: () => get().serverInfo?.version ?? "",
+
+    changelogURL: () => {
+      const version = semver.valid(get().serverInfo?.version);
+      if (!version) return "";
+      return `https://docs.bytebase.com/changelog/bytebase-${version
+        .split(".")
+        .join("-")}/`;
+    },
+
+    activatedInstanceCount: () => get().serverInfo?.activatedInstanceCount ?? 0,
+
+    totalInstanceCount: () => get().serverInfo?.totalInstanceCount ?? 0,
+
+    userCountInIam: () => get().serverInfo?.userCountInIam ?? 0,
+
+    activeVcsUserCount: () => get().serverInfo?.activeVcsUserCount ?? 0,
+
+    activeUserCount: () => get().serverInfo?.activatedUserCount ?? 0,
+
+    enableOnboarding: () =>
+      get().activeUserCount() === 1 && !get().isSaaSMode(),
+
+    quickStartEnabled: () => {
+      if (get().appFeatures["bb.feature.hide-quick-start"]) {
+        return false;
+      }
+      if (!get().serverInfo?.enableSample) {
+        return false;
+      }
+      return get().activeUserCount() <= 1;
+    },
+
+    setupSample: async () => {
+      await actuatorServiceClientConnect.setupSample({});
+    },
+
+    // Alias for the legacy Pinia `actuatorStore.fetchServerInfo(workspace?)`.
+    fetchServerInfo: async (workspaceResourceName) => {
+      const info = await actuatorServiceClientConnect.getActuatorInfo({
+        name: workspaceResourceName ?? get().serverInfo?.workspace ?? "",
       });
-    set((state) => ({
-      settingRequests: {
-        ...state.settingRequests,
-        [resourceName]: request,
-      },
-    }));
-    return request;
-  },
+      set({ serverInfo: info, serverInfoTs: Date.now() });
+      return info;
+    },
 
-  loadSubscription: async () => {
-    const existing = get().subscription;
-    if (existing) return existing;
-    const pending = get().subscriptionRequest;
-    if (pending) return pending;
-    const request = subscriptionServiceClientConnect
-      .getSubscription(createProto(GetSubscriptionRequestSchema, {}))
-      .then((subscription) => {
-        set({ subscription, subscriptionRequest: undefined });
-        syncSubscriptionToPinia(subscription);
-        return subscription;
-      })
-      .catch(() => {
-        set({ subscriptionRequest: undefined });
-        return undefined;
+    classification: () => {
+      const setting =
+        get().settingsByName[
+          `${settingNamePrefix}${
+            Setting_SettingName[Setting_SettingName.DATA_CLASSIFICATION]
+          }`
+        ];
+      const value = setting?.value?.value;
+      if (value?.case === "dataClassification") {
+        return value.value.configs;
+      }
+      return [] as DataClassificationSetting_DataClassificationConfig[];
+    },
+
+    getProjectClassification: (classificationId) =>
+      get()
+        .classification()
+        .find((config) => config.id === classificationId),
+
+    updateWorkspaceProfile: async ({ payload, updateMask }) => {
+      const base =
+        get().workspaceProfile ??
+        createProto(WorkspaceProfileSettingSchema, {});
+      const profile = { ...base, ...payload };
+      await get().upsertSetting({
+        name: Setting_SettingName.WORKSPACE_PROFILE,
+        value: createProto(SettingValueSchema, {
+          value: { case: "workspaceProfile", value: profile },
+        }),
+        updateMask,
       });
-    set({ subscriptionRequest: request });
-    return request;
-  },
-
-  refreshSubscription: async () => {
-    const request = subscriptionServiceClientConnect
-      .getSubscription(createProto(GetSubscriptionRequestSchema, {}))
-      .then((subscription) => {
-        set({ subscription, subscriptionRequest: undefined });
-        syncSubscriptionToPinia(subscription);
-        return subscription;
-      })
-      .catch(() => {
-        set({ subscriptionRequest: undefined });
-        return undefined;
+      set({
+        workspaceProfile: profile,
+        appFeatures: appFeaturesFromDatabaseChangeMode(
+          profile.databaseChangeMode
+        ),
       });
-    set({ subscriptionRequest: request });
-    return request;
-  },
+      // Refresh the latest server info (mirrors the Pinia store).
+      await get().fetchServerInfo(get().workspaceResourceName());
+    },
 
-  uploadLicense: async (license) => {
-    const subscription = await subscriptionServiceClientConnect.uploadLicense(
-      createProto(UploadLicenseRequestSchema, { license })
-    );
-    set({ subscription });
-    syncSubscriptionToPinia(subscription);
-    return subscription;
-  },
+    fetchEnvironments: async (force = false) => {
+      await get().loadEnvironmentList(force);
+    },
 
-  currentPlan: () => {
-    return get().subscription?.plan ?? PlanType.FREE;
-  },
+    createEnvironment: async (environment) => {
+      const next = await writeEnvironmentSetting([
+        ...convertEnvironmentsToSetting(get().environmentList),
+        createProto(EnvironmentSetting_EnvironmentSchema, {
+          name: "",
+          id: environment.id ?? "",
+          title: environment.title ?? "",
+          color: environment.color ?? "",
+          tags: environment.tags ?? {},
+        }),
+      ]);
+      const created = next.find((e) => e.id === (environment.id ?? ""));
+      if (!created) {
+        throw new Error(`environment with id ${environment.id} not found`);
+      }
+      return created;
+    },
 
-  isFreePlan: () => get().currentPlan() === PlanType.FREE,
+    updateEnvironment: async (update) => {
+      const next = await writeEnvironmentSetting(
+        convertEnvironmentsToSetting(
+          get().environmentList.map((environment) =>
+            environment.id === update.id
+              ? {
+                  ...environment,
+                  title: update.title ?? environment.title,
+                  color: update.color ?? environment.color,
+                  tags: update.tags ?? environment.tags,
+                  order: update.order ?? environment.order,
+                }
+              : environment
+          )
+        )
+      );
+      const updated = next.find((e) => e.id === update.id);
+      if (!updated) {
+        throw new Error(`environment with id ${update.id} not found`);
+      }
+      return updated;
+    },
 
-  isTrialing: () => Boolean(get().subscription?.trialing),
+    deleteEnvironment: async (name) => {
+      const id = getEnvironmentId(name);
+      await writeEnvironmentSetting(
+        convertEnvironmentsToSetting(
+          get().environmentList.filter((environment) => environment.id !== id)
+        )
+      );
+    },
 
-  isExpired: () => {
-    const subscription = get().subscription;
-    if (!subscription?.expiresTime || get().isFreePlan()) {
-      return false;
-    }
-    return dayjs(
-      getDateForPbTimestampProtoEs(subscription.expiresTime)
-    ).isBefore(new Date());
-  },
-
-  daysBeforeExpire: () => {
-    const subscription = get().subscription;
-    if (!subscription?.expiresTime || get().isFreePlan()) {
-      return -1;
-    }
-    return Math.max(
-      dayjs(getDateForPbTimestampProtoEs(subscription.expiresTime)).diff(
-        new Date(),
-        "day"
+    reorderEnvironmentList: async (orderedEnvironmentList) =>
+      writeEnvironmentSetting(
+        convertEnvironmentsToSetting(orderedEnvironmentList)
       ),
-      0
-    );
-  },
 
-  trialingDays: () => trialingDays,
+    setSubscription: (subscription) => {
+      set({ subscription });
+      syncSubscriptionToPinia(subscription);
+    },
 
-  showTrial: () => {
-    if (!isSelfHostLicense()) {
-      return false;
-    }
-    return !get().subscription || get().isFreePlan();
-  },
+    hasSplitInstanceLicense: () =>
+      !get().isFreePlan() && !get().hasUnifiedInstanceLicense(),
 
-  expireAt: () => {
-    const subscription = get().subscription;
-    if (!subscription?.expiresTime || get().isFreePlan()) {
-      return "";
-    }
-    return formatAbsoluteDateTime(
-      getTimeForPbTimestampProtoEs(subscription.expiresTime)
-    );
-  },
+    pollSubscriptionUntil: async (predicate, options = {}) => {
+      const { timeoutMs = 60_000, intervalMs = 2_000, signal } = options;
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (signal?.aborted) return undefined;
+        const sub = await subscriptionServiceClientConnect
+          .getSubscription(createProto(GetSubscriptionRequestSchema, {}))
+          .catch(() => undefined);
+        if (signal?.aborted) return undefined;
+        if (sub && predicate(sub)) {
+          get().setSubscription(sub);
+          return sub;
+        }
+        await new Promise((r) => setTimeout(r, intervalMs));
+      }
+      return undefined;
+    },
 
-  instanceCountLimit: () => {
-    const subscription = get().subscription;
-    const licenseLimit = subscription?.instances ?? 0;
-    if (licenseLimit > 0) {
-      return licenseLimit;
-    }
-    const planLimit =
-      PLANS.find((plan) => plan.type === get().currentPlan())
-        ?.maximumInstanceCount ?? 0;
-    if (planLimit < 0) {
-      return licenseLimit > 0 ? licenseLimit : Number.MAX_VALUE;
-    }
-    return planLimit;
-  },
+    createPurchase: async (plan, interval, seats) => {
+      const response = await subscriptionServiceClientConnect.createPurchase(
+        createProto(CreatePurchaseRequestSchema, { plan, interval, seats })
+      );
+      return response.paymentUrl;
+    },
 
-  userCountLimit: () => {
-    let limit =
-      PLANS.find((plan) => plan.type === get().currentPlan())
-        ?.maximumSeatCount ?? 0;
-    if (limit < 0) {
-      limit = Number.MAX_VALUE;
-    }
-    const seats = get().subscription?.seats ?? 0;
-    if (seats < 0) {
-      return Number.MAX_VALUE;
-    }
-    if (seats === 0) {
-      return limit;
-    }
-    return seats;
-  },
+    updatePurchase: async (plan, interval, seats, etag) => {
+      const response = await subscriptionServiceClientConnect.updatePurchase(
+        createProto(UpdatePurchaseRequestSchema, {
+          plan,
+          interval,
+          seats,
+          etag,
+        })
+      );
+      return response.paymentUrl;
+    },
 
-  instanceLicenseCount: () => {
-    const count = get().subscription?.activeInstances ?? 0;
-    return count < 0 ? Number.MAX_VALUE : count;
-  },
+    cancelPurchase: async (feedback, comment) => {
+      await subscriptionServiceClientConnect.cancelPurchase(
+        createProto(CancelPurchaseRequestSchema, { feedback, comment })
+      );
+      await get().refreshSubscription();
+    },
 
-  hasUnifiedInstanceLicense: () => {
-    return get().instanceCountLimit() <= get().instanceLicenseCount();
-  },
+    fetchPaymentInfo: async () => {
+      try {
+        const info = await subscriptionServiceClientConnect.getPaymentInfo(
+          createProto(GetPaymentInfoRequestSchema, {})
+        );
+        set({ paymentInfo: info });
+        return info;
+      } catch (e) {
+        console.error(e);
+        return undefined;
+      }
+    },
 
-  hasFeature: (feature) => {
-    if (get().isExpired()) {
-      return false;
-    }
-    return checkFeature(get().currentPlan(), feature);
-  },
+    verifyCheckoutSession: async (sessionId) => {
+      const response =
+        await subscriptionServiceClientConnect.verifyCheckoutSession(
+          createProto(VerifyCheckoutSessionRequestSchema, { sessionId })
+        );
+      return response.status;
+    },
 
-  hasInstanceFeature: (feature, instance) => {
-    const plan = get().currentPlan();
-    if (plan === PlanType.FREE) {
-      return get().hasFeature(feature);
-    }
-    if (!instance || !instanceLimitFeature.has(feature)) {
-      return get().hasFeature(feature);
-    }
-    return checkInstanceFeature(
-      plan,
-      feature,
-      get().hasUnifiedInstanceLicense() || instance.activation
-    );
-  },
-
-  instanceMissingLicense: (feature, instance) => {
-    if (!instanceLimitFeature.has(feature) || !instance) {
-      return false;
-    }
-    if (get().hasUnifiedInstanceLicense()) {
-      return false;
-    }
-    return get().hasFeature(feature) && !instance.activation;
-  },
-
-  getMinimumRequiredPlan,
-
-  isSaaSMode: () => get().serverInfo?.saas ?? false,
-
-  workspaceResourceName: () => get().serverInfo?.workspace ?? "",
-
-  externalUrl: () => get().serverInfo?.externalUrl ?? "",
-
-  needConfigureExternalUrl: () => {
-    const serverInfo = get().serverInfo;
-    if (!serverInfo) return false;
-    const url = serverInfo.externalUrl ?? "";
-    return url === "" || url === externalUrlPlaceholder;
-  },
-
-  version: () => get().serverInfo?.version ?? "",
-
-  changelogURL: () => {
-    const version = semver.valid(get().serverInfo?.version);
-    if (!version) return "";
-    return `https://docs.bytebase.com/changelog/bytebase-${version
-      .split(".")
-      .join("-")}/`;
-  },
-
-  activatedInstanceCount: () => get().serverInfo?.activatedInstanceCount ?? 0,
-
-  totalInstanceCount: () => get().serverInfo?.totalInstanceCount ?? 0,
-
-  userCountInIam: () => get().serverInfo?.userCountInIam ?? 0,
-
-  activeVcsUserCount: () => get().serverInfo?.activeVcsUserCount ?? 0,
-});
+    fetchPurchasePlans: async () => {
+      try {
+        const response =
+          await subscriptionServiceClientConnect.listPurchasePlans(
+            createProto(ListPurchasePlansRequestSchema, {})
+          );
+        set({ purchasePlans: response.plans });
+        return response.plans;
+      } catch (e) {
+        console.error(e);
+        return undefined;
+      }
+    },
+  };
+};

--- a/frontend/src/react/stores/app/workspace.ts
+++ b/frontend/src/react/stores/app/workspace.ts
@@ -112,6 +112,11 @@ const externalUrlPlaceholder =
   "https://docs.bytebase.com/get-started/self-host/external-url";
 const trialingDays = 14;
 
+// Stable empty profile so `getWorkspaceProfile()` can return a non-null value
+// without allocating a fresh object each call (which would break Zustand's
+// selector identity check). Mirrors the Pinia getter's default.
+const EMPTY_WORKSPACE_PROFILE = createProto(WorkspaceProfileSettingSchema, {});
+
 function appFeaturesFromDatabaseChangeMode(mode: DatabaseChangeMode) {
   const appFeatures = defaultAppProfile().features;
   appFeatures["bb.feature.database-change-mode"] =
@@ -704,6 +709,11 @@ export const createWorkspaceSlice: AppSliceCreator<WorkspaceSlice> = (
       set({ serverInfo: info, serverInfoTs: Date.now() });
       return info;
     },
+
+    // Always returns a profile (never undefined), mirroring the Pinia
+    // `useSettingV1Store().workspaceProfile` getter, so consumers can read
+    // fields without null checks. Reactive via Zustand's selector re-run.
+    getWorkspaceProfile: () => get().workspaceProfile ?? EMPTY_WORKSPACE_PROFILE,
 
     classification: () => {
       const setting =


### PR DESCRIPTION
## What

Continues the React store-decoupling effort: cuts **all React consumers** off the four app-shell Pinia stores — `useActuatorV1Store`, `useSettingV1Store`, `useEnvironmentV1Store`, `useSubscriptionV1Store` — onto the app-store `WorkspaceSlice`.

These four Pinia stores are **kept** (not deleted): the Vue shell (`App.vue`, `BodyLayout`/`SplashLayout`, `AuthContext`), `main.ts`, the router, and shared `utils/*`/`customAppProfile.ts` still use them. They'll be removed in the routing/app-shell migration phase.

### Slice port (additive)
Extends `WorkspaceSlice` with the methods these consumers call, mirroring the Pinia impls 1:1:
- **actuator**: `activeUserCount`, `enableOnboarding`, `quickStartEnabled`, `setupSample`, `fetchServerInfo`
- **setting**: `upsertSetting` (server write + cache), `updateWorkspaceProfile`, `classification`, `getProjectClassification`, `getWorkspaceProfile` (always-present getter mirroring the Pinia getter)
- **environment**: `fetchEnvironments`, `createEnvironment`, `updateEnvironment`, `deleteEnvironment`, `reorderEnvironmentList` (all via `upsertSetting` on the ENVIRONMENT setting, re-deriving `environmentList`)
- **subscription**: `setSubscription`, `hasSplitInstanceLicense`, `pollSubscriptionUntil`, `createPurchase`, `updatePurchase`, `cancelPurchase`, `verifyCheckoutSession`, `fetchPaymentInfo`, `fetchPurchasePlans` (+ `purchasePlans`/`paymentInfo` state)

### Consumer cutover (~82 files)
Each `store.method` → `useAppStore`. The main subtlety: several Pinia **getters** (computed properties) are now slice **methods**, so they're called with `()` (`isSaaSMode()`, `workspaceResourceName()`, `currentPlan()`, `instanceLicenseCount()`, …); `store.workspaceProfile` → `getWorkspaceProfile()`; `store.classification` → `classification()`. Reactive reads use selectors; imperative calls use `useAppStore.getState()`. Object-returning getters (`getEnvironmentByName` fallback, `classification`, settings) are read via a cache-map subscription + `useMemo` to avoid the fresh-sentinel `useSyncExternalStore` loop.

## Testing
- `pnpm --dir frontend type-check` — clean
- `pnpm --dir frontend check` — clean (lint, biome, i18n, layering, locale sort)
- `pnpm --dir frontend test` — 239 files / 2308 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)