### PR TITLE
docs: add design principles to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,13 @@
 This file provides guidance to AI coding assistants when working with code in this repository.
 
+## Design Principles
+
+Bytebase is the standard for database development. Every product and engineering decision serves that goal, built on three principles:
+
+1. **Bring every database under unified control.** Every person and AI agent accesses and changes data through one governed path.
+2. **Govern change and access as code.** Reviewed, enforced, and recorded by policy, not by discipline.
+3. **Make the safe path the easy path.** Safe by default, simple by design — so no one routes around it.
+
 ## Project Architecture
 
 - Database schema is defined in `./backend/migrator/migration/LATEST.sql`


### PR DESCRIPTION
## What

Adds a **Design Principles** section to the top of `AGENTS.md`, stating Bytebase's north star and the three principles behind it.

> Bytebase is the standard for database development. Every product and engineering decision serves that goal, built on three principles:
>
> 1. **Bring every database under unified control.** Every person and AI agent accesses and changes data through one governed path.
> 2. **Govern change and access as code.** Reviewed, enforced, and recorded by policy, not by discipline.
> 3. **Make the safe path the easy path.** Safe by default, simple by design — so no one routes around it.

## Why

These principles give AI coding assistants (and engineers) a shared north star to weigh product and engineering decisions against. The first principle maps to the access/change pillars, the second to compliance/governance-as-code, the third to developer experience and safe-by-default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)