### PR TITLE
chore: make latest Docker tagging release-aware

### DIFF
--- a/.github/workflows/build-push-release-image.yml
+++ b/.github/workflows/build-push-release-image.yml
@@ -15,15 +15,14 @@ jobs:
     permissions:
       contents: read
       id-token: write
-      actions: write
     steps:
       - uses: actions/checkout@v6
       - name: Extract build args
         # Extract version from branch name
         # Example: branch name `release/1.0.0` sets up env.IMAGE_VERSION=1.0.0
         run: |
-          echo "VERSION=${GITHUB_REF_NAME#release/}" >> $GITHUB_ENV
-          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "VERSION=${GITHUB_REF_NAME#release/}" >> "$GITHUB_ENV"
+          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
       - name: Login to DockerHub
         uses: docker/login-action@v4
         with:
@@ -45,41 +44,3 @@ jobs:
           build-args: |
             VERSION=${{ env.VERSION }}
             GIT_COMMIT=${{ env.GIT_COMMIT }}
-      - name: Check if version is latest
-        id: check_latest
-        run: |
-          # Fetch all branches to get release branches
-          git fetch --all
-
-          # Get all release branch versions
-          VERSIONS=$(git branch -r | grep -o 'release/[0-9]*\.[0-9]*\.[0-9]*' | sed 's/release\///' | sort -V)
-
-          # Get the latest version
-          LATEST_VERSION=$(echo "$VERSIONS" | tail -n 1)
-
-          echo "Current version: ${{ env.VERSION }}"
-          echo "Latest version: $LATEST_VERSION"
-
-          # Check if current version is the latest
-          if [ "${{ env.VERSION }}" = "$LATEST_VERSION" ]; then
-            echo "is_latest=true" >> $GITHUB_OUTPUT
-            echo "✅ This is the latest version"
-          else
-            echo "is_latest=false" >> $GITHUB_OUTPUT
-            echo "ℹ️ This is not the latest version"
-          fi
-      - name: Trigger docker-tag-latest workflow
-        if: steps.check_latest.outputs.is_latest == 'true'
-        uses: actions/github-script@v9
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'docker-tag-latest.yml',
-              ref: 'main',
-              inputs: {
-                version: '${{ env.VERSION }}'
-              }
-            });
-            console.log('✅ Triggered docker-tag-latest workflow for version ${{ env.VERSION }}');

--- a/.github/workflows/build-push-release-image.yml
+++ b/.github/workflows/build-push-release-image.yml
@@ -12,22 +12,48 @@ concurrency:
 jobs:
   build-release-image:
     runs-on: ubuntu-latest
+    outputs:
+      should_tag_latest: ${{ steps.check_latest.outputs.should_tag_latest }}
+      version: ${{ steps.extract.outputs.version }}
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Extract build args
+        id: extract
         # Extract version from branch name
         # Example: branch name `release/1.0.0` sets up env.IMAGE_VERSION=1.0.0
         run: |
-          echo "VERSION=${GITHUB_REF_NAME#release/}" >> "$GITHUB_ENV"
-          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          VERSION="${GITHUB_REF_NAME#release/}"
+          GIT_COMMIT="$(git rev-parse HEAD)"
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "GIT_COMMIT=${GIT_COMMIT}" >> "$GITHUB_ENV"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       - name: Login to DockerHub
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Check if latest points to this release
+        id: check_latest
+        run: |
+          set +e
+          RELEASE_DIGEST=$(docker buildx imagetools inspect "bytebase/bytebase:${VERSION}" 2>/dev/null | awk '/^Digest:/ {print $2; exit}')
+          LATEST_DIGEST=$(docker buildx imagetools inspect "bytebase/bytebase:latest" 2>/dev/null | awk '/^Digest:/ {print $2; exit}')
+          set -e
+
+          echo "Release version: ${VERSION}"
+          echo "Release digest: ${RELEASE_DIGEST:-<missing>}"
+          echo "Latest digest: ${LATEST_DIGEST:-<missing>}"
+
+          if [ -n "${RELEASE_DIGEST}" ] && [ "${RELEASE_DIGEST}" = "${LATEST_DIGEST}" ]; then
+            echo "should_tag_latest=true" >> "$GITHUB_OUTPUT"
+            echo "latest already points to this release"
+          else
+            echo "should_tag_latest=false" >> "$GITHUB_OUTPUT"
+            echo "latest does not point to this release"
+          fi
       - uses: depot/setup-action@v1
       - name: Build and push
         id: bytebase_build
@@ -44,3 +70,10 @@ jobs:
           build-args: |
             VERSION=${{ env.VERSION }}
             GIT_COMMIT=${{ env.GIT_COMMIT }}
+  tag-latest:
+    needs: build-release-image
+    if: needs.build-release-image.outputs.should_tag_latest == 'true'
+    uses: ./.github/workflows/docker-tag-latest.yml
+    with:
+      version: ${{ needs.build-release-image.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/build-push-release-image.yml
+++ b/.github/workflows/build-push-release-image.yml
@@ -37,11 +37,37 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if latest points to this release
         id: check_latest
+        shell: bash
         run: |
-          set +e
-          RELEASE_DIGEST=$(docker buildx imagetools inspect "bytebase/bytebase:${VERSION}" 2>/dev/null | awk '/^Digest:/ {print $2; exit}')
-          LATEST_DIGEST=$(docker buildx imagetools inspect "bytebase/bytebase:latest" 2>/dev/null | awk '/^Digest:/ {print $2; exit}')
-          set -e
+          set -euo pipefail
+
+          inspect_digest() {
+            local image="$1"
+            local allow_missing="$2"
+            local output
+            local digest
+
+            if output="$(docker buildx imagetools inspect "${image}" 2>&1)"; then
+              digest="$(printf '%s\n' "${output}" | awk '/^Digest:/ {print $2; exit}')"
+              if [ -z "${digest}" ]; then
+                echo "::error::Unable to find digest for ${image}"
+                exit 1
+              fi
+              printf '%s\n' "${digest}"
+              return
+            fi
+
+            if [ "${allow_missing}" = "true" ] && printf '%s\n' "${output}" | grep -Eiq 'not found|manifest unknown|no such|name unknown'; then
+              return
+            fi
+
+            echo "::error::Failed to inspect ${image}"
+            printf '%s\n' "${output}"
+            exit 1
+          }
+
+          RELEASE_DIGEST="$(inspect_digest "bytebase/bytebase:${VERSION}" true)"
+          LATEST_DIGEST="$(inspect_digest "bytebase/bytebase:latest" false)"
 
           echo "Release version: ${VERSION}"
           echo "Release digest: ${RELEASE_DIGEST:-<missing>}"
@@ -73,6 +99,7 @@ jobs:
   tag-latest:
     needs: build-release-image
     if: needs.build-release-image.outputs.should_tag_latest == 'true'
+    permissions: {}
     uses: ./.github/workflows/docker-tag-latest.yml
     with:
       version: ${{ needs.build-release-image.outputs.version }}

--- a/.github/workflows/build-push-release-image.yml
+++ b/.github/workflows/build-push-release-image.yml
@@ -37,7 +37,10 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Check if version matches latest release tag
         id: check_latest
+        shell: bash
         run: |
+          set -euo pipefail
+
           LATEST_VERSION=$(git ls-remote --tags --refs origin 'refs/tags/[0-9]*.[0-9]*.[0-9]*' | awk -F/ '{print $3}' | sort -V | tail -n 1)
 
           echo "Release version: ${VERSION}"

--- a/.github/workflows/build-push-release-image.yml
+++ b/.github/workflows/build-push-release-image.yml
@@ -35,50 +35,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Check if latest points to this release
+      - name: Check if version matches latest release tag
         id: check_latest
-        shell: bash
         run: |
-          set -euo pipefail
-
-          inspect_digest() {
-            local image="$1"
-            local allow_missing="$2"
-            local output
-            local digest
-
-            if output="$(docker buildx imagetools inspect "${image}" 2>&1)"; then
-              digest="$(printf '%s\n' "${output}" | awk '/^Digest:/ {print $2; exit}')"
-              if [ -z "${digest}" ]; then
-                echo "::error::Unable to find digest for ${image}"
-                exit 1
-              fi
-              printf '%s\n' "${digest}"
-              return
-            fi
-
-            if [ "${allow_missing}" = "true" ] && printf '%s\n' "${output}" | grep -Eiq 'not found|manifest unknown|no such|name unknown'; then
-              return
-            fi
-
-            echo "::error::Failed to inspect ${image}"
-            printf '%s\n' "${output}"
-            exit 1
-          }
-
-          RELEASE_DIGEST="$(inspect_digest "bytebase/bytebase:${VERSION}" true)"
-          LATEST_DIGEST="$(inspect_digest "bytebase/bytebase:latest" false)"
+          LATEST_VERSION=$(git ls-remote --tags --refs origin 'refs/tags/[0-9]*.[0-9]*.[0-9]*' | awk -F/ '{print $3}' | sort -V | tail -n 1)
 
           echo "Release version: ${VERSION}"
-          echo "Release digest: ${RELEASE_DIGEST:-<missing>}"
-          echo "Latest digest: ${LATEST_DIGEST:-<missing>}"
+          echo "Latest release tag: ${LATEST_VERSION:-<missing>}"
 
-          if [ -n "${RELEASE_DIGEST}" ] && [ "${RELEASE_DIGEST}" = "${LATEST_DIGEST}" ]; then
+          if [ "${VERSION}" = "${LATEST_VERSION}" ]; then
             echo "should_tag_latest=true" >> "$GITHUB_OUTPUT"
-            echo "latest already points to this release"
+            echo "version matches latest release tag"
           else
             echo "should_tag_latest=false" >> "$GITHUB_OUTPUT"
-            echo "latest does not point to this release"
+            echo "version does not match latest release tag"
           fi
       - uses: depot/setup-action@v1
       - name: Build and push

--- a/.github/workflows/docker-tag-latest.yml
+++ b/.github/workflows/docker-tag-latest.yml
@@ -7,6 +7,12 @@ on:
         description: 'Version to tag as latest (e.g., 1.0.0)'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version to tag as latest (e.g., 1.0.0)'
+        required: true
+        type: string
 
 permissions: {}
 

--- a/.github/workflows/docker-tag-latest.yml
+++ b/.github/workflows/docker-tag-latest.yml
@@ -5,12 +5,6 @@ on:
     inputs:
       version:
         description: 'Version to tag as latest (e.g., 1.0.0)'
-        required: false
-        type: string
-  workflow_call:
-    inputs:
-      version:
-        description: 'Version to tag as latest (e.g., 1.0.0)'
         required: true
         type: string
 
@@ -27,12 +21,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Tag latest image in DockerHub
         run: |
-          # Use input version if provided, otherwise extract from branch name
-          if [ -n "${{ inputs.version }}" ]; then
-            RELEASE_VERSION="${{ inputs.version }}"
-          else
-            RELEASE_VERSION=${GITHUB_REF_NAME#release/}
-          fi
+          RELEASE_VERSION="${{ inputs.version }}"
           echo version: ${RELEASE_VERSION}
           docker buildx imagetools create -t bytebase/bytebase:latest bytebase/bytebase:${RELEASE_VERSION}
           docker buildx imagetools create -t bytebase/bytebase-action:latest bytebase/bytebase-action:${RELEASE_VERSION}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -19,3 +19,9 @@ jobs:
           args: release --config scripts/.goreleaser-release.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  tag-latest:
+    needs: draft-release
+    uses: ./.github/workflows/docker-tag-latest.yml
+    with:
+      version: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -21,6 +21,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   tag-latest:
     needs: draft-release
+    permissions: {}
     uses: ./.github/workflows/docker-tag-latest.yml
     with:
       version: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
- Keep `docker-tag-latest.yml` manually runnable and reusable via `workflow_call`.
- Tag Docker `latest` automatically from the tag-triggered draft release workflow using the release tag name as the version.
- Let release-branch image rebuilds refresh `latest` only when the release branch version matches the latest semver tag in GitHub, so cherrypicks to older release branches do not steal `latest`.
- Drop the GitHub API dispatch path and add explicit no-token permissions to reusable latest-tag caller jobs.

## Review Notes
- The tag-triggered release workflow intentionally updates `latest` for every semver release tag. We do not normally cut older maintenance/backport tags after a newer release tag.

## Test Plan
- `git diff --check origin/main...HEAD`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/build-push-release-image.yml .github/workflows/docker-tag-latest.yml .github/workflows/draft-release.yml`

## Pre-PR Checklist
- Breaking change check: no product/API breaking change; workflow behavior change is intentional.
- Composite-PK query safety: skipped, no backend/store or migrator changes.
- Lint/test gates: workflow-only; validated with actionlint.
- SonarCloud properties: skipped, no new files or directories.
