### PR TITLE
fix(tidb): restore alias-target multi-table DELETE (BYT-9623)

### DIFF
--- a/backend/plugin/parser/tidb/restore.go
+++ b/backend/plugin/parser/tidb/restore.go
@@ -512,25 +512,50 @@ func extractStatement(statement string, backupItem *storepb.PriorBackupDetail_It
 //
 // For UPDATE: the table must appear as the qualifier of at least one SET
 // assignment — being only joined for filtering is not enough.
-//
-// For DELETE: n.Tables holds the explicit delete-targets (mutation set);
-// n.Using holds JOIN-only refs (filter set). Only n.Tables counts as
-// mutation. Per Codex P1 follow-on catch on PR #20345 — pre-fix
-// matching n.Using too caused a backup item targeting a USING-only
-// table to generate rollback SQL that re-inserted rows that were never
-// deleted (reintroducing stale data).
 func containsTable(node ast.Node, database, table string, targetCols map[string]bool) bool {
 	switch n := node.(type) {
 	case *ast.UpdateStmt:
 		return updateMutatesTable(n, database, table, targetCols)
 	case *ast.DeleteStmt:
+		return deleteMutatesTable(n, database, table)
+	default:
+	}
+	return false
+}
+
+// deleteMutatesTable reports whether the DELETE removes rows from the specified
+// physical table.
+//
+// Single-table DELETE (no USING): n.Tables is the physical table.
+//
+// Multi-table DELETE (DELETE t1, t2 FROM ...): n.Tables holds the delete-target
+// ALIASES (or bare names), which must be resolved through the FROM/USING ref
+// map to their physical tables — backup.go keys each backup item by the
+// physical name (BYT-9623). n.Using is the JOIN-only filter set, used here ONLY
+// to resolve aliases; it is never matched as a mutation target, because doing
+// so re-inserted rows that were never deleted (Codex P1 catch on PR #20345).
+func deleteMutatesTable(n *ast.DeleteStmt, database, table string) bool {
+	if len(n.Using) == 0 {
 		for _, expr := range n.Tables {
 			if tableExprReferences(expr, database, table) {
 				return true
 			}
 		}
-		// n.Using is JOIN-only (filter set), not mutation — do NOT match.
-	default:
+		return false
+	}
+	refs := extractSingleTablesFromTableExprs(database, n.Using)
+	for _, target := range n.Tables {
+		ref, ok := target.(*ast.TableRef)
+		if !ok {
+			continue
+		}
+		resolved, ok := refs[strings.ToLower(ref.Name)]
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(resolved.Database, database) && strings.EqualFold(resolved.Table, table) {
+			return true
+		}
 	}
 	return false
 }

--- a/backend/plugin/parser/tidb/restore_test.go
+++ b/backend/plugin/parser/tidb/restore_test.go
@@ -718,3 +718,52 @@ func TestGenerateRestoreSQLNoDisjointUniqueKey(t *testing.T) {
 	require.Contains(t, err.Error(), "no disjoint unique key found",
 		"error must be the no-disjoint-key error from generateUpdateRestore, not a different failure mode")
 }
+
+// TestGenerateRestoreSQLAliasTargetMultiTableDelete pins BYT-9623: restore must
+// reverse the whole class of alias-target multi-table DELETEs. backup.go keys
+// the backup item by the physical table name, but n.Tables holds the delete-
+// target ALIASES; containsTable must resolve those through the FROM/USING ref
+// map. Pre-fix, every form below returned "no DML statement found in extracted
+// SQL" -> silent data loss on rollback.
+func TestGenerateRestoreSQLAliasTargetMultiTableDelete(t *testing.T) {
+	getter, lister := buildFixedMockDatabaseMetadataGetterAndLister()
+	restore := func(input, sourceTable string) (string, error) {
+		return GenerateRestoreSQL(context.Background(), base.RestoreContext{
+			GetDatabaseMetadataFunc: getter,
+			ListDatabaseNamesFunc:   lister,
+			IsCaseSensitive:         false,
+		}, input, &store.PriorBackupDetail_Item{
+			SourceTable: &store.PriorBackupDetail_Item_Table{
+				Database: "instances/i1/databases/db",
+				Table:    sourceTable,
+			},
+			TargetTable: &store.PriorBackupDetail_Item_Table{
+				Database: "instances/i1/databases/bbarchive",
+				Table:    "prefix_1_" + sourceTable,
+			},
+			StartPosition: &store.Position{Line: 0, Column: 0},
+			EndPosition:   &store.Position{Line: math.MaxInt32, Column: 0},
+		})
+	}
+
+	// (target table -> must resolve through the alias in the FROM/USING list)
+	cases := []struct {
+		name, input, sourceTable string
+	}{
+		{"comma-from target test", "DELETE t1, t2 FROM test AS t1, test2 AS t2 WHERE t1.a = t2.a;", "test"},
+		{"comma-from target test2", "DELETE t1, t2 FROM test AS t1, test2 AS t2 WHERE t1.a = t2.a;", "test2"},
+		{"join target test", "DELETE t1 FROM test t1 JOIN test2 t2 ON t1.a = t2.a;", "test"},
+		{"using target test", "DELETE FROM t1 USING test t1, test2 t2 WHERE t1.a = t2.a;", "test"},
+	}
+	for _, tc := range cases {
+		result, err := restore(tc.input, tc.sourceTable)
+		require.NoError(t, err, "%s: alias-target multi-table DELETE must be restorable", tc.name)
+		require.Contains(t, result, "INSERT INTO `db`.`"+tc.sourceTable+"`",
+			"%s: rollback must re-insert the deleted rows into the resolved physical table", tc.name)
+	}
+
+	// A JOIN-only USING reference (never a delete target) must NOT be matched —
+	// matching it would re-insert rows that were never deleted (#20345 bug).
+	_, err := restore("DELETE t1 FROM test t1 JOIN test2 t2 ON t1.a = t2.a;", "test2")
+	require.Error(t, err, "test2 is JOIN-only (filter), not a delete target; it must not produce a restore")
+}


### PR DESCRIPTION
## Problem (BYT-9623, scope widened)

Prior backup keys each backup item by the **physical** table name, but for a multi-table DELETE the delete targets in `n.Tables` are **aliases**. `containsTable` compared those aliases to the physical table name and never matched, so `GenerateRestoreSQL` returned `no DML statement found in extracted SQL` for the **whole class** of alias-target multi-table DELETEs — the backup was generated but could never be restored = **silent data loss on rollback**.

Forms affected (all back up fine; `DELETE t1, t2 FROM ...` is even in `test_backup.yaml` golden):
- `DELETE t1 FROM test t1 JOIN test2 t2 ON t1.a = t2.a`
- `DELETE t1, t2 FROM test t1, test2 t2 WHERE t1.a = t2.a`
- `DELETE FROM t1 USING test t1, test2 t2 WHERE t1.a = t2.a`

Bare-name forms already worked.

## Fix

In `containsTable`'s DELETE arm (now `deleteMutatesTable`), resolve each `n.Tables` target alias through the FROM/USING ref map (`extractSingleTablesFromTableExprs`, lowercase-keyed) and compare the **resolved physical** Database+Table. `n.Using` is used **only** to resolve aliases — never matched as a target — preserving the no-re-insert property (the #20345 Codex catch: matching `n.Using` re-inserted never-deleted rows).

## Testing

- New `TestGenerateRestoreSQLAliasTargetMultiTableDelete` covers all three forms (comma-FROM, JOIN, USING) for the resolved physical target, plus the **negative**: a JOIN-only USING table must *not* produce a restore.
- Existing restore/backup goldens unchanged; lint clean.
- **End-to-end on `pingcap/tidb:v8.5.0`**: `backup → DELETE t1,t2 FROM test t1, test2 t2 → restore` recovers the deleted rows (pre-fix: restore errored, rows lost permanently).

Closes BYT-9623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)