### PR TITLE
fix(tidb): guard cyclic view expansion in query span extractor

### DIFF
--- a/backend/plugin/parser/tidb/query_span_extractor.go
+++ b/backend/plugin/parser/tidb/query_span_extractor.go
@@ -22,6 +22,11 @@ type querySpanExtractor struct {
 	ctes              []*base.PseudoTable
 	outerTableSources []base.TableSource
 	tableSourcesFrom  []base.TableSource
+
+	// viewResolutionStack tracks the views currently being expanded so a
+	// cyclic view reference (a view that transitively references itself) is
+	// reported as an error instead of recursing until the stack overflows.
+	viewResolutionStack map[string]bool
 }
 
 func newQuerySpanExtractor(defaultDatabase string, gCtx base.GetQuerySpanContext) *querySpanExtractor {
@@ -557,13 +562,14 @@ func (q *querySpanExtractor) extractSourceColumnSetFromExpression(in tidbast.Exp
 		// So that the subquery can access the outer schema.
 		// The reason for new q is that we still need the current fromFieldList, overriding it is not expected.
 		subqueryExtractor := &querySpanExtractor{
-			ctx:               q.ctx,
-			defaultDatabase:   q.defaultDatabase,
-			metaCache:         q.metaCache,
-			gCtx:              q.gCtx,
-			ctes:              q.ctes,
-			outerTableSources: append(q.outerTableSources, q.tableSourcesFrom...),
-			tableSourcesFrom:  []base.TableSource{},
+			ctx:                 q.ctx,
+			defaultDatabase:     q.defaultDatabase,
+			metaCache:           q.metaCache,
+			gCtx:                q.gCtx,
+			ctes:                q.ctes,
+			outerTableSources:   append(q.outerTableSources, q.tableSourcesFrom...),
+			tableSourcesFrom:    []base.TableSource{},
+			viewResolutionStack: cloneViewResolutionStack(q.viewResolutionStack),
 		}
 		tableSource, err := subqueryExtractor.extractTableSourceFromNode(node.Query)
 		if err != nil {
@@ -874,7 +880,7 @@ func (q *querySpanExtractor) findTableSchema(databaseName string, tableName stri
 		if lowerTableName == strings.ToLower(view) {
 			viewMeta := schema.GetView(view)
 			if viewMeta != nil {
-				columns, err := q.getColumnsForView(viewMeta.Definition)
+				columns, err := q.getColumnsForView(databaseName, viewMeta.Name, viewMeta.Definition)
 				if err != nil {
 					return nil, err
 				}
@@ -894,8 +900,14 @@ func (q *querySpanExtractor) findTableSchema(databaseName string, tableName stri
 	}
 }
 
-func (q *querySpanExtractor) getColumnsForView(definition string) ([]base.QuerySpanResult, error) {
+func (q *querySpanExtractor) getColumnsForView(databaseName, viewName, definition string) ([]base.QuerySpanResult, error) {
+	key := viewResolutionKey(databaseName, viewName)
+	if q.viewResolutionStack[key] {
+		return nil, errors.Errorf("cyclic view reference detected while resolving %q", viewName)
+	}
 	newQ := newQuerySpanExtractor(q.defaultDatabase, q.gCtx)
+	newQ.viewResolutionStack = cloneViewResolutionStack(q.viewResolutionStack)
+	newQ.viewResolutionStack[key] = true
 	span, err := newQ.getQuerySpan(q.ctx, definition)
 	if err != nil {
 		return nil, err
@@ -904,6 +916,18 @@ func (q *querySpanExtractor) getColumnsForView(definition string) ([]base.QueryS
 		return nil, span.NotFoundError
 	}
 	return span.Results, nil
+}
+
+func viewResolutionKey(databaseName, viewName string) string {
+	return databaseName + "\x00" + viewName
+}
+
+func cloneViewResolutionStack(in map[string]bool) map[string]bool {
+	out := make(map[string]bool, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func (q *querySpanExtractor) getDatabaseMetadata(databaseName string) (*model.DatabaseMetadata, error) {

--- a/backend/plugin/parser/tidb/query_span_test.go
+++ b/backend/plugin/parser/tidb/query_span_test.go
@@ -231,6 +231,39 @@ func TestGetQuerySpanMissingTableUnionedWithAccessTables(t *testing.T) {
 	a.True(foundUnknown, "not-found table must be unioned into SourceColumns so the pre-execute ACL check sees it")
 }
 
+// TestGetQuerySpanCyclicViewReference pins that a cyclic view reference is
+// reported as an error rather than recursing until the stack overflows.
+// Ported from the MySQL guard (#20153).
+func TestGetQuerySpanCyclicViewReference(t *testing.T) {
+	metadata := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "",
+				Views: []*storepb.ViewMetadata{
+					{Name: "v1", Definition: "SELECT * FROM v2"},
+					{Name: "v2", Definition: "SELECT * FROM v1"},
+				},
+			},
+		},
+	}
+	databaseMetadataGetter, databaseNamesLister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{metadata})
+
+	_, err := GetQuerySpan(
+		context.TODO(),
+		base.GetQuerySpanContext{
+			GetDatabaseMetadataFunc: databaseMetadataGetter,
+			ListDatabaseNamesFunc:   databaseNamesLister,
+		},
+		base.Statement{Text: "SELECT * FROM v1"},
+		"db",
+		"",
+		false,
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cyclic view reference")
+}
+
 func buildMockDatabaseMetadataGetter(databaseMetadata []*storepb.DatabaseSchemaMetadata) (base.GetDatabaseMetadataFunc, base.ListDatabaseNamesFunc) {
 	return func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
 			m := make(map[string]*model.DatabaseMetadata)


### PR DESCRIPTION
## Problem

TiDB's query span extractor resolves a view by spawning a fresh sub-extractor on the view definition (`getColumnsForView`), with **no tracking** of which views are currently being expanded. A cyclic view reference (`v1 → v2 → v1`) recurses indefinitely → **stack overflow → crashes the query-span RPC**.

MySQL already guards this (#20153, `4e2720da05`); TiDB was missing the equivalent. Found via a MySQL→TiDB parser-parity scan.

## Fix

Port the MySQL guard:
- Add `viewResolutionStack map[string]bool` to `querySpanExtractor`.
- Propagate the (cloned) stack into both sub-extractor spawn sites — subquery resolution and `getColumnsForView` — so a cycle through a subquery-referenced view is also caught.
- In `getColumnsForView`, error with `cyclic view reference detected while resolving "<view>"` when the view re-enters the stack, instead of recursing.

## Testing

- New `TestGetQuerySpanCyclicViewReference`: `v1 → v2 → v1` now returns a clean error (pre-fix: stack overflow). Non-cyclic view resolution is unaffected — all existing `query_span.yaml` / `query_type.yaml` golden tests stay green.
- Build + lint clean.

Part of the MySQL→TiDB parity follow-up (TiDB-engine, our scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)