### PR TITLE
fix(spanner): set query span Type to Select on the SELECT path

### DIFF
--- a/backend/plugin/parser/spanner/query_span_extractor.go
+++ b/backend/plugin/parser/spanner/query_span_extractor.go
@@ -81,6 +81,7 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, stmt string) (*ba
 	}
 
 	return &base.QuerySpan{
+		Type:          base.Select,
 		Results:       querySpanResult,
 		SourceColumns: accessTables,
 	}, nil

--- a/backend/plugin/parser/spanner/query_span_type_test.go
+++ b/backend/plugin/parser/spanner/query_span_type_test.go
@@ -1,0 +1,33 @@
+package spanner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestQuerySpanTypeForSelect guards BYT-9627: a SELECT must produce a query
+// span with Type == base.Select. Spanner is in EngineSupportQueryNewACL, where
+// the access check rejects a QueryTypeUnknown span as "disallowed query type",
+// so a missing Type makes every Spanner SELECT fail in normal (non-admin) mode.
+func TestQuerySpanTypeForSelect(t *testing.T) {
+	getter, lister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{{Name: "db"}})
+	result, err := GetQuerySpan(
+		context.Background(),
+		base.GetQuerySpanContext{
+			GetDatabaseMetadataFunc: getter,
+			ListDatabaseNamesFunc:   lister,
+		},
+		base.Statement{Text: "SELECT 1"},
+		"db",
+		"",
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, base.Select, result.Type,
+		"a plain SELECT must have query span Type=Select; otherwise the new-ACL access check rejects it as \"disallowed query type\"")
+}

--- a/backend/plugin/parser/spanner/test-data/query-span/standard.yaml
+++ b/backend/plugin/parser/spanner/test-data/query-span/standard.yaml
@@ -37,7 +37,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: Id
           sourcecolumns:
@@ -107,7 +107,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: NAME
           sourcecolumns:
@@ -163,7 +163,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: ID
           sourcecolumns:
@@ -257,7 +257,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: ID
           sourcecolumns:
@@ -341,7 +341,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: ID
           sourcecolumns:
@@ -422,7 +422,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: ID
           sourcecolumns:
@@ -501,7 +501,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: C1
           sourcecolumns:
@@ -596,7 +596,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: ID
           sourcecolumns:
@@ -673,7 +673,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: CITY
           sourcecolumns:
@@ -728,7 +728,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: ""
           sourcecolumns: []
@@ -778,7 +778,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: ID
           sourcecolumns:
@@ -848,7 +848,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: Id
           sourcecolumns:
@@ -903,7 +903,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: ID
           sourcecolumns:
@@ -958,7 +958,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: ID
           sourcecolumns:
@@ -1033,7 +1033,7 @@
       ]
     }
   querySpan:
-    type: 0
+    type: 1
     results:
         - name: Id
           sourcecolumns:


### PR DESCRIPTION
## Summary

Spanner SQL Editor queries failed in normal (non-admin) mode at **all permission levels** with `disallowed query type`. Admin mode worked, which made it look like a permissions problem.

Root cause: `spanner.getQuerySpan` left `QuerySpan.Type` unset (`QueryTypeUnknown`) on the SELECT success branch — unlike BigQuery, which sets `base.Select`. Spanner is in `EngineSupportQueryNewACL`, where `accessCheck` rejects a `QueryTypeUnknown` span:

```go
case parserbase.QueryTypeUnknown:
    return connect.NewError(connect.CodePermissionDenied, errors.New("disallowed query type"))
```

So every Spanner SELECT was denied before execution. `AdminExecute` bypasses `GetQuerySpan`/`accessCheck`, which is why it "worked with Admin Console".

Fixes BYT-9627 / TEAC-741.

## Change

- Set `Type: base.Select` on the SELECT success branch of `getQuerySpan` (mirrors BigQuery).
- Re-record query-span fixtures (`type: 0` → `1`); the fixtures had encoded the bug.
- Add `TestQuerySpanTypeForSelect` to guard the regression.

## Testing

- `go test ./backend/plugin/parser/spanner/` is green.
- The new test fails before the fix (`Type=0`) and passes after (`Type=1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)