### PR TITLE
chore: bump omni to 00018e4c (doris window OVER fix #186)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260602032407-484791c35e5e
+	github.com/bytebase/omni v0.0.0-20260604055152-00018e4c576b
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260602032407-484791c35e5e h1:mii0c1rt6qKlsFFkdKM4Zrt79FHWsAO+gXqZMpyDi30=
-github.com/bytebase/omni v0.0.0-20260602032407-484791c35e5e/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260604055152-00018e4c576b h1:1D2BJWeZvynr0O9G4QIl2nvN2kLTCnY6V6svm6ipITY=
+github.com/bytebase/omni v0.0.0-20260604055152-00018e4c576b/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary

Bumps `github.com/bytebase/omni` `v0.0.0-20260602032407-484791c` → **`v0.0.0-20260604055152-00018e4c`**.

**Primary motivation:** brings in omni `doris/parser` [#186](https://github.com/bytebase/omni/pull/186), which parses the window-function `OVER` clause. This fixes `syntax error at or near OVER` for window functions **inside a CTE body** in the Doris / StarRocks SQL editor (BYT-9636):

```sql
WITH ranked AS (
  SELECT region, ROW_NUMBER() OVER (PARTITION BY region ORDER BY amount DESC) AS rn
  FROM sales)
SELECT region FROM ranked WHERE rn = 1;
```

## Also pulled in (packages bytebase imports)

- **tidb/parser**: accept string-literal aliases in the SELECT list (#188)
- **partiql/parser**: window functions, GPML graph patterns, DATE/TIME literals, aggregates, Ion literals, LET/PIVOT, typed builtins
- **oracle**: query-clause AST + completion hardening

The new in-progress omni engines (trino, googlesql) aren't imported by bytebase yet, so they're inert here.

## Verification

- `go build ./...` — clean
- `go test ./backend/plugin/parser/...` — **21 packages, 0 failures**
- Confirmed the window-in-CTE query now parses via the doris plugin (previously errored with `syntax error at or near OVER`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
