### PR TITLE
fix(frontend): preserve permission details on 403

### DIFF
--- a/frontend/src/connect/middlewares/authInterceptorMiddleware.test.ts
+++ b/frontend/src/connect/middlewares/authInterceptorMiddleware.test.ts
@@ -1,5 +1,6 @@
 import { Code, ConnectError, createContextValues } from "@connectrpc/connect";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Permission } from "@/types";
 import { ignoredCodesContextKey, silentContextKey } from "../context-key";
 
 const mocks = vi.hoisted(() => ({
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
     value: {
       name: "workspace.home",
       fullPath: "/instances",
+      requiredPermissions: [] as Permission[],
     },
   },
 }));
@@ -63,7 +65,7 @@ const createRequest = ({
       .set(silentContextKey, silent)
       .set(ignoredCodesContextKey, ignoredCodes),
     method: { name: methodName },
-    service: { name: "bytebase.v1.TestService" },
+    service: { name: "TestService", typeName: "bytebase.v1.TestService" },
   }) as never;
 
 describe("authInterceptor", () => {
@@ -76,6 +78,7 @@ describe("authInterceptor", () => {
     mocks.currentRoute.value = {
       name: "workspace.home",
       fullPath: "/instances",
+      requiredPermissions: [],
     };
   });
 
@@ -167,7 +170,39 @@ describe("authInterceptor", () => {
     });
     expect(mocks.routerPush).toHaveBeenCalledWith({
       name: "error.403",
-      query: undefined,
+      query: {
+        from: "/instances",
+        api: "/bytebase.v1.TestService/Chat",
+        permissions: "",
+        resources: "",
+      },
+    });
+  });
+
+  test("builds a permission denied route query from request and route metadata", async () => {
+    mocks.currentRoute.value = {
+      name: "workspace.database",
+      fullPath: "/databases?q=project:unassigned",
+      requiredPermissions: ["bb.databases.list"],
+    };
+    const error = new ConnectError(
+      'user does not have permission "bb.databases.list"',
+      Code.PermissionDenied
+    );
+    const next = vi.fn().mockRejectedValue(error);
+
+    await expect(authInterceptor(next)(createRequest())).rejects.toMatchObject({
+      code: Code.PermissionDenied,
+    });
+
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: "error.403",
+      query: {
+        from: "/databases?q=project:unassigned",
+        api: "/bytebase.v1.TestService/Chat",
+        permissions: "bb.databases.list",
+        resources: "",
+      },
     });
   });
 });

--- a/frontend/src/connect/middlewares/authInterceptorMiddleware.ts
+++ b/frontend/src/connect/middlewares/authInterceptorMiddleware.ts
@@ -1,7 +1,14 @@
-import { Code, ConnectError, type Interceptor } from "@connectrpc/connect";
+import {
+  Code,
+  ConnectError,
+  type Interceptor,
+  type StreamRequest,
+  type UnaryRequest,
+} from "@connectrpc/connect";
 import { t } from "@/plugins/i18n";
 import { router } from "@/react/router";
 import { WORKSPACE_ROUTE_403 } from "@/react/router/handles";
+import { buildPermissionDeniedRouteQuery } from "@/react/router/permissionDenied";
 import { pushNotification } from "@/store";
 import { PermissionDeniedDetailSchema } from "@/types/proto-es/v1/common_pb";
 import { appStoreUtilBridge } from "@/utils/app-store-bridge";
@@ -16,6 +23,25 @@ const extractPermissionDeniedDetail = (error: unknown) => {
     }
   }
   return undefined;
+};
+
+const buildPermissionDeniedQuery = ({
+  errorDetail,
+  req,
+}: {
+  errorDetail: ReturnType<typeof extractPermissionDeniedDetail>;
+  req: StreamRequest | UnaryRequest;
+}) => {
+  const route = router.currentRoute.value;
+  const permissions =
+    errorDetail?.requiredPermissions ?? route.requiredPermissions;
+  const resources = errorDetail?.resources ?? [];
+  return buildPermissionDeniedRouteQuery({
+    route,
+    api: errorDetail?.method ?? `/${req.service.typeName}/${req.method.name}`,
+    permissions,
+    resources,
+  });
 };
 
 const handleUnauthenticatedFailure = ({
@@ -98,14 +124,7 @@ export const authInterceptor: Interceptor = (next) => async (req) => {
         const errorDetail = extractPermissionDeniedDetail(error);
         router.push({
           name: WORKSPACE_ROUTE_403,
-          query: errorDetail
-            ? {
-                from: router.currentRoute.value.fullPath,
-                api: errorDetail.method,
-                permissions: errorDetail.requiredPermissions.join(","),
-                resources: errorDetail.resources.join(","),
-              }
-            : undefined,
+          query: buildPermissionDeniedQuery({ errorDetail, req }),
         });
       }
     }

--- a/frontend/src/connect/middlewares/errorNotificationMiddleware.test.ts
+++ b/frontend/src/connect/middlewares/errorNotificationMiddleware.test.ts
@@ -1,0 +1,82 @@
+import { Code, ConnectError, createContextValues } from "@connectrpc/connect";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ignoredCodesContextKey, silentContextKey } from "../context-key";
+
+const mocks = vi.hoisted(() => ({
+  pushNotification: vi.fn(),
+  currentRoute: {
+    value: {
+      name: "workspace.database",
+    },
+  },
+}));
+
+vi.mock("@/plugins/i18n", () => ({
+  t: (key: string) => key,
+}));
+
+vi.mock("@/react/router", () => ({
+  router: {
+    currentRoute: mocks.currentRoute,
+  },
+}));
+
+vi.mock("@/store", () => ({
+  pushNotification: mocks.pushNotification,
+}));
+
+import { errorNotificationInterceptor } from "./errorNotificationMiddleware";
+
+const createRequest = ({
+  silent = false,
+  ignoredCodes = [],
+}: {
+  silent?: boolean;
+  ignoredCodes?: Code[];
+} = {}) =>
+  ({
+    contextValues: createContextValues()
+      .set(silentContextKey, silent)
+      .set(ignoredCodesContextKey, ignoredCodes),
+    method: { name: "ListDatabases" },
+    service: { name: "DatabaseService" },
+  }) as never;
+
+describe("errorNotificationInterceptor", () => {
+  beforeEach(() => {
+    mocks.pushNotification.mockReset();
+    mocks.currentRoute.value = {
+      name: "workspace.database",
+    };
+  });
+
+  test("does not toast permission errors that navigate to the guard page", async () => {
+    const error = new ConnectError(
+      'user does not have permission "bb.databases.list"',
+      Code.PermissionDenied
+    );
+    const next = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      errorNotificationInterceptor(next)(createRequest())
+    ).rejects.toMatchObject({ code: Code.PermissionDenied });
+
+    expect(mocks.pushNotification).not.toHaveBeenCalled();
+  });
+
+  test("still toasts non-permission request failures", async () => {
+    const error = new ConnectError("failed", Code.Internal);
+    const next = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      errorNotificationInterceptor(next)(createRequest())
+    ).rejects.toMatchObject({ code: Code.Internal });
+
+    expect(mocks.pushNotification).toHaveBeenCalledWith({
+      module: "bytebase",
+      style: "CRITICAL",
+      title: "Code 13: Internal",
+      description: "[internal] failed",
+    });
+  });
+});

--- a/frontend/src/connect/middlewares/errorNotificationMiddleware.ts
+++ b/frontend/src/connect/middlewares/errorNotificationMiddleware.ts
@@ -41,6 +41,9 @@ export const errorNotificationInterceptor: Interceptor =
           ).includes(error.code)
         ) {
           // ignored
+        } else if (error.code === Code.PermissionDenied) {
+          // The auth interceptor navigates permission failures to /403, where
+          // the route-level guard displays the missing permission details.
         } else {
           const details = [error.message];
           maybePushNotification(

--- a/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
+++ b/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
@@ -13,6 +13,7 @@ import {
   WORKSPACE_ROUTE_403,
   WORKSPACE_ROUTE_404,
 } from "@/react/router/handles";
+import { buildPermissionDeniedRouteQuery } from "@/react/router/permissionDenied";
 import { useAppStore } from "@/react/stores/app";
 import { projectNamePrefix } from "@/store";
 import { State } from "@/types/proto-es/v1/common_pb";
@@ -384,7 +385,12 @@ export const useIssueDetailPage = ({
           if (error.code === Code.NotFound) {
             void router.push({ name: WORKSPACE_ROUTE_404 });
           } else if (error.code === Code.PermissionDenied) {
-            void router.push({ name: WORKSPACE_ROUTE_403 });
+            void router.push({
+              name: WORKSPACE_ROUTE_403,
+              query: buildPermissionDeniedRouteQuery({
+                route: router.currentRoute.value,
+              }),
+            });
           }
           patchState({ isInitializing: false });
           return;

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/useInitialFetch.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/useInitialFetch.ts
@@ -6,6 +6,7 @@ import {
   WORKSPACE_ROUTE_403,
   WORKSPACE_ROUTE_404,
 } from "@/react/router/handles";
+import { buildPermissionDeniedRouteQuery } from "@/react/router/permissionDenied";
 import { unknownPlan } from "@/types/v1/issue/plan";
 import type { PlanDetailStoreApi } from "../../shared/stores/usePlanDetailStore";
 import { fetchPlanSnapshot } from "./fetchPlanSnapshot";
@@ -66,7 +67,12 @@ export function useInitialFetch({
           if (error.code === Code.NotFound) {
             void router.push({ name: WORKSPACE_ROUTE_404 });
           } else if (error.code === Code.PermissionDenied) {
-            void router.push({ name: WORKSPACE_ROUTE_403 });
+            void router.push({
+              name: WORKSPACE_ROUTE_403,
+              query: buildPermissionDeniedRouteQuery({
+                route: router.currentRoute.value,
+              }),
+            });
           }
           patchState({ isInitializing: false });
           return;

--- a/frontend/src/react/pages/workspace/Page403.test.tsx
+++ b/frontend/src/react/pages/workspace/Page403.test.tsx
@@ -1,0 +1,69 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { WORKSPACE_ROUTE_LANDING } from "@/react/router/handles";
+import { Page403 } from "./Page403";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+  currentRoute: {
+    value: {
+      query: {},
+    },
+  },
+}));
+
+vi.mock("@/react/router", () => ({
+  router: {
+    currentRoute: mocks.currentRoute,
+    push: mocks.routerPush,
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  mocks.routerPush.mockReset();
+  mocks.currentRoute.value = { query: {} };
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  document.body.removeChild(container);
+});
+
+describe("Page403", () => {
+  test("go back home navigates to the landing page", () => {
+    act(() => {
+      root.render(<Page403 />);
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((el) =>
+      el.textContent?.includes("error-page.go-back-home")
+    );
+    expect(button).toBeTruthy();
+
+    act(() => {
+      button?.click();
+    });
+
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: WORKSPACE_ROUTE_LANDING,
+    });
+  });
+});

--- a/frontend/src/react/pages/workspace/Page403.tsx
+++ b/frontend/src/react/pages/workspace/Page403.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
 import { router } from "@/react/router";
-import { WORKSPACE_ROOT_MODULE } from "@/react/router/handles";
+import { WORKSPACE_ROUTE_LANDING } from "@/react/router/handles";
 import type { Permission } from "@/types";
 
 export function Page403() {
@@ -30,7 +30,7 @@ export function Page403() {
   const requestAPI = query.api;
 
   const goHome = () => {
-    router.push({ name: WORKSPACE_ROOT_MODULE });
+    router.push({ name: WORKSPACE_ROUTE_LANDING });
   };
 
   return (

--- a/frontend/src/react/pages/workspace/Page404.test.tsx
+++ b/frontend/src/react/pages/workspace/Page404.test.tsx
@@ -1,0 +1,66 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { WORKSPACE_ROUTE_LANDING } from "@/react/router/handles";
+import { Page404 } from "./Page404";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  routerPush: vi.fn(),
+}));
+
+vi.mock("@/assets/logo-icon.svg", () => ({
+  default: "logo.svg",
+}));
+
+vi.mock("@/react/router", () => ({
+  router: {
+    push: mocks.routerPush,
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+let container: HTMLDivElement;
+let root: ReturnType<typeof createRoot>;
+
+beforeEach(() => {
+  mocks.routerPush.mockReset();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  document.body.removeChild(container);
+});
+
+describe("Page404", () => {
+  test("go back home navigates to the landing page", () => {
+    act(() => {
+      root.render(<Page404 />);
+    });
+
+    const button = Array.from(container.querySelectorAll("button")).find((el) =>
+      el.textContent?.includes("error-page.go-back-home")
+    );
+    expect(button).toBeTruthy();
+
+    act(() => {
+      button?.click();
+    });
+
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: WORKSPACE_ROUTE_LANDING,
+    });
+  });
+});

--- a/frontend/src/react/pages/workspace/Page404.tsx
+++ b/frontend/src/react/pages/workspace/Page404.tsx
@@ -3,13 +3,13 @@ import { useTranslation } from "react-i18next";
 import logoIcon from "@/assets/logo-icon.svg";
 import { Button } from "@/react/components/ui/button";
 import { router } from "@/react/router";
-import { WORKSPACE_ROOT_MODULE } from "@/react/router/handles";
+import { WORKSPACE_ROUTE_LANDING } from "@/react/router/handles";
 
 export function Page404() {
   const { t } = useTranslation();
 
   const goHome = () => {
-    router.push({ name: WORKSPACE_ROOT_MODULE });
+    router.push({ name: WORKSPACE_ROUTE_LANDING });
   };
 
   return (

--- a/frontend/src/react/router/permissionDenied.test.ts
+++ b/frontend/src/react/router/permissionDenied.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "vitest";
+import type { Permission } from "@/types";
+import { buildPermissionDeniedRouteQuery } from "./permissionDenied";
+
+describe("permission denied route query", () => {
+  test("falls back to current route permissions", () => {
+    expect(
+      buildPermissionDeniedRouteQuery({
+        route: {
+          fullPath: "/projects/prod/issues/101",
+          requiredPermissions: ["bb.issues.get"],
+        },
+      })
+    ).toEqual({
+      from: "/projects/prod/issues/101",
+      api: "",
+      permissions: "bb.issues.get",
+      resources: "",
+    });
+  });
+
+  test("prefers explicit API, permissions, and resources", () => {
+    expect(
+      buildPermissionDeniedRouteQuery({
+        route: {
+          fullPath: "/databases",
+          requiredPermissions: ["bb.databases.list"] as Permission[],
+        },
+        api: "/bytebase.v1.DatabaseService/ListDatabases",
+        permissions: ["bb.instances.get"],
+        resources: ["instances/prod"],
+      })
+    ).toEqual({
+      from: "/databases",
+      api: "/bytebase.v1.DatabaseService/ListDatabases",
+      permissions: "bb.instances.get",
+      resources: "instances/prod",
+    });
+  });
+});

--- a/frontend/src/react/router/permissionDenied.ts
+++ b/frontend/src/react/router/permissionDenied.ts
@@ -1,0 +1,23 @@
+export type PermissionDeniedRoute = {
+  fullPath: string;
+  requiredPermissions: readonly string[];
+};
+
+export function buildPermissionDeniedRouteQuery({
+  route,
+  api = "",
+  permissions,
+  resources = [],
+}: {
+  route: PermissionDeniedRoute;
+  api?: string;
+  permissions?: readonly string[];
+  resources?: string[];
+}): Record<string, string> {
+  return {
+    from: route.fullPath,
+    api,
+    permissions: (permissions ?? route.requiredPermissions).join(","),
+    resources: resources.join(","),
+  };
+}


### PR DESCRIPTION
## Summary
- Preserve required permission details when PermissionDenied redirects to `/403`.
- Suppress duplicate global PermissionDenied toast notifications when the guard page already explains the issue.
- Route 403/404 "Go back home" actions directly to the workspace landing page.

## Key Changes
- Add a shared permission-denied route query helper with route metadata fallback.
- Reuse the helper from the auth interceptor, plan detail, and issue detail PermissionDenied paths.
- Add regression coverage for PermissionDenied query fallback, notification suppression, and fixed landing navigation from 403/404 pages.

## Motivation
- Some PermissionDenied responses do not include structured details, which made `/403` lose required permissions on routes like `/databases`.
- Navigating to the workspace root follows recent-visit redirect behavior, so error-page home actions could land on an unrelated page instead of the fixed landing page.

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
- `git diff --check`
