### PR TITLE
fix(ui): prevent radio control shrinking

### DIFF
--- a/frontend/src/react/components/ui/radio-group.test.tsx
+++ b/frontend/src/react/components/ui/radio-group.test.tsx
@@ -1,0 +1,60 @@
+import { act, createElement, type ReactElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test } from "vitest";
+import { RadioGroup, RadioGroupItem } from "./radio-group";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(element);
+  });
+  return {
+    container,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+        container.remove();
+      }),
+  };
+};
+
+const getRadio = (container: HTMLElement) => {
+  const radio = container.querySelector('[role="radio"]');
+  if (!radio) throw new Error("radio not found");
+  return radio as HTMLElement;
+};
+
+describe("RadioGroupItem", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("prevents the radio control from shrinking in long option labels", () => {
+    const { container, unmount } = renderIntoContainer(
+      createElement(
+        RadioGroup,
+        { value: "workspace", onValueChange: () => undefined },
+        createElement(
+          RadioGroupItem,
+          { value: "workspace" },
+          createElement(
+            "span",
+            null,
+            "Use issue to request, review, rollout, and version database changes"
+          )
+        )
+      )
+    );
+
+    expect(getRadio(container).className).toContain("size-4");
+    expect(getRadio(container).className).toContain("shrink-0");
+
+    unmount();
+  });
+});

--- a/frontend/src/react/components/ui/radio-group.tsx
+++ b/frontend/src/react/components/ui/radio-group.tsx
@@ -27,7 +27,7 @@ function RadioGroupItem({
       <Radio.Root
         value={value}
         className={cn(
-          "flex size-4 items-center justify-center rounded-full border border-control-border",
+          "flex size-4 shrink-0 items-center justify-center rounded-full border border-control-border",
           "data-[checked]:border-accent data-[checked]:border-[5px]",
           "focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
           "disabled:cursor-not-allowed disabled:opacity-50"


### PR DESCRIPTION
## Summary
- Prevent shared radio controls from shrinking inside long flex option labels.
- Add a focused React UI test covering long-label radio sizing.

## Key Changes
- Add `shrink-0` to `RadioGroupItem` control sizing.
- Verify radio items keep the fixed `size-4` control class alongside `shrink-0`.

## Motivation
- Fixes BYT-9634, where the onboarding default landing page radio control could render as a vertical pill instead of a circle when paired with long descriptive text.

## Test Plan
- `pnpm --dir frontend test radio-group.test.tsx`
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
- `git diff --check`