### PR TITLE
fix(frontend): remove misleading task run docs link

### DIFF
--- a/frontend/src/react/locales/en-US.json
+++ b/frontend/src/react/locales/en-US.json
@@ -454,7 +454,6 @@
     "total": "Total",
     "total-n-items": "Total {{n}} items",
     "transfer": "Transfer",
-    "troubleshoot": "Troubleshoot",
     "type": "Type",
     "type-to-search": "Type to search",
     "unassigned": "Unassigned",

--- a/frontend/src/react/locales/es-ES.json
+++ b/frontend/src/react/locales/es-ES.json
@@ -454,7 +454,6 @@
     "total": "Total",
     "total-n-items": "Total {{n}} elementos",
     "transfer": "Transferir",
-    "troubleshoot": "Solucionar problemas",
     "type": "Tipo",
     "type-to-search": "Escriba para buscar",
     "unassigned": "No asignado",

--- a/frontend/src/react/locales/ja-JP.json
+++ b/frontend/src/react/locales/ja-JP.json
@@ -454,7 +454,6 @@
     "total": "合計",
     "total-n-items": "合計 {{n}} 件",
     "transfer": "移行",
-    "troubleshoot": "トラブルシューティング",
     "type": "タイプ",
     "type-to-search": "入力して検索",
     "unassigned": "割り当てられていない",

--- a/frontend/src/react/locales/vi-VN.json
+++ b/frontend/src/react/locales/vi-VN.json
@@ -454,7 +454,6 @@
     "total": "Tổng",
     "total-n-items": "Tổng {{n}} mục",
     "transfer": "Chuyển",
-    "troubleshoot": "Khắc phục sự cố",
     "type": "Loại",
     "type-to-search": "Nhập để tìm kiếm",
     "unassigned": "Chưa gán",

--- a/frontend/src/react/locales/zh-CN.json
+++ b/frontend/src/react/locales/zh-CN.json
@@ -454,7 +454,6 @@
     "total": "总计",
     "total-n-items": "共 {{n}} 项",
     "transfer": "转移",
-    "troubleshoot": "排查问题",
     "type": "类型",
     "type-to-search": "输入以搜索",
     "unassigned": "未分配",

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
@@ -253,29 +253,11 @@ function IssueDetailTaskRunComment({ taskRun }: { taskRun: TaskRun }) {
     return taskRun.detail || "-";
   })();
 
-  const commentLink =
-    taskRun.status === TaskRun_Status.FAILED && comment.includes("version")
-      ? {
-          link: "https://docs.bytebase.com/change-database/troubleshoot/?source=console#duplicate-version",
-          title: t("common.troubleshoot"),
-        }
-      : undefined;
-
   return (
     <div className="flex flex-col gap-y-0.5 xl:flex-row xl:items-center xl:gap-x-1">
       <div className="min-w-0 flex-1">
         <EllipsisText className="line-clamp-1" text={comment} />
       </div>
-      {commentLink && (
-        <a
-          className="normal-link shrink-0"
-          href={commentLink.link}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          {commentLink.title}
-        </a>
-      )}
     </div>
   );
 }

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRunTable.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRunTable.tsx
@@ -234,29 +234,11 @@ function TaskRunComment({ taskRun }: { taskRun: TaskRun }) {
     return taskRun.detail || "-";
   })();
 
-  const commentLink =
-    taskRun.status === TaskRun_Status.FAILED && comment.includes("version")
-      ? {
-          link: "https://docs.bytebase.com/change-database/troubleshoot/?source=console#duplicate-version",
-          title: t("common.troubleshoot"),
-        }
-      : undefined;
-
   return (
     <div className="flex flex-col gap-y-0.5 xl:flex-row xl:items-center xl:gap-x-1">
       <div className="min-w-0 flex-1">
         <EllipsisText className="line-clamp-1" text={comment} />
       </div>
-      {commentLink && (
-        <a
-          className="normal-link shrink-0"
-          href={commentLink.link}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          {commentLink.title}
-        </a>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Remove the automatic task-run failure "Troubleshoot" link triggered by `comment.includes("version")`.
- Remove the stale duplicate-version docs URL from plan and issue task-run tables.
- Remove the now-unused `common.troubleshoot` React locale key from all locales.

## Pre-PR Checklist

- Breaking change check: not breaking; this removes a misleading auxiliary link from failure comments.
- Composite-PK query safety: skipped, no `backend/store` or `backend/migrator` changes.
- Image compatibility window: skipped.
- SonarCloud properties: skipped, no new files or directories.

## Test Plan

- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
