### PR TITLE
fix(auth): prevent session refresh flicker

### DIFF
--- a/frontend/src/react/app/AuthGate.test.tsx
+++ b/frontend/src/react/app/AuthGate.test.tsx
@@ -1,0 +1,147 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  navigate: vi.fn(),
+  loadSubscription: vi.fn(async () => undefined),
+  fetchWorkspaceIamPolicy: vi.fn(async () => undefined),
+  loadWorkspaceList: vi.fn(async () => undefined),
+  listRoles: vi.fn(async () => undefined),
+  batchGetOrFetchGroups: vi.fn(async () => undefined),
+  fetchCurrentUser: vi.fn(),
+  setIsSelfEmailUpdate: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useMatches: () => [{ handle: { name: "workspace.dashboard" } }],
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock("@/react/components/auth/InactiveRemindModal", () => ({
+  InactiveRemindModal: () => <div data-testid="inactive-remind-modal" />,
+}));
+
+vi.mock("@/react/router/guard", () => ({
+  isAuthRelatedRoute: () => false,
+}));
+
+vi.mock("@/react/router/handles", () => ({
+  WORKSPACE_ROOT_MODULE: "workspace.root",
+}));
+
+vi.mock("@/react/router/navigation", () => ({
+  resolvePath: () => "/",
+}));
+
+vi.mock("@/store", () => ({
+  pushNotification: vi.fn(),
+}));
+
+vi.mock("@/utils", () => ({
+  isDev: () => true,
+}));
+
+vi.mock("@/react/stores/app", async () => {
+  const { create } = await import("zustand");
+  const initialUser = {
+    name: "users/alice@example.com",
+    email: "alice@example.com",
+    workspace: "workspaces/default",
+    groups: ["groups/dev"],
+  };
+  mocks.fetchCurrentUser.mockImplementation(async () => initialUser);
+  const useAppStore = create(() => ({
+    currentUser: initialUser,
+    currentUserName: initialUser.name,
+    unauthenticatedOccurred: false,
+    isSelfEmailUpdate: false,
+    isLoggedIn: () => true,
+    loadSubscription: mocks.loadSubscription,
+    fetchWorkspaceIamPolicy: mocks.fetchWorkspaceIamPolicy,
+    loadWorkspaceList: mocks.loadWorkspaceList,
+    listRoles: mocks.listRoles,
+    batchGetOrFetchGroups: mocks.batchGetOrFetchGroups,
+    fetchCurrentUser: mocks.fetchCurrentUser,
+    setIsSelfEmailUpdate: mocks.setIsSelfEmailUpdate,
+  }));
+  return { useAppStore };
+});
+
+import { useAppStore } from "@/react/stores/app";
+import { AuthGate } from "./AuthGate";
+
+describe("AuthGate", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test("keeps the page visible when currentUser is refreshed with the same identity", async () => {
+    await act(async () => {
+      root.render(
+        <AuthGate>
+          <div data-testid="page">Page</div>
+        </AuthGate>
+      );
+    });
+
+    expect(container.querySelector("[data-testid='page']")).not.toBeNull();
+    expect(container.querySelector("[role='status']")).toBeNull();
+
+    act(() => {
+      const currentUser = useAppStore.getState().currentUser;
+      expect(currentUser).toBeDefined();
+      useAppStore.setState({
+        currentUser: {
+          ...currentUser,
+        } as NonNullable<typeof currentUser>,
+        currentUserName: currentUser!.name,
+      });
+    });
+
+    expect(container.querySelector("[data-testid='page']")).not.toBeNull();
+    expect(container.querySelector("[role='status']")).toBeNull();
+  });
+
+  test("refreshes permission data in the background during session polling", async () => {
+    await act(async () => {
+      root.render(
+        <AuthGate>
+          <div data-testid="page">Page</div>
+        </AuthGate>
+      );
+    });
+    vi.clearAllMocks();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(mocks.fetchCurrentUser).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchWorkspaceIamPolicy).toHaveBeenCalledTimes(1);
+    expect(mocks.listRoles).toHaveBeenCalledTimes(1);
+    expect(container.querySelector("[data-testid='page']")).not.toBeNull();
+    expect(container.querySelector("[role='status']")).toBeNull();
+  });
+});

--- a/frontend/src/react/app/AuthGate.tsx
+++ b/frontend/src/react/app/AuthGate.tsx
@@ -33,13 +33,15 @@ export function AuthGate({ children }: { children: ReactNode }) {
   const isAuthRoute = Boolean(
     currentRouteName && isAuthRelatedRoute(currentRouteName)
   );
+  const currentUserWorkspace = currentUser?.workspace ?? "";
+  const currentUserGroupsKey = (currentUser?.groups ?? []).join("\0");
 
   const [ready, setReady] = useState(false);
 
   // Load workspace-scoped data once authenticated, then reveal the app.
   useEffect(() => {
     const store = useAppStore.getState();
-    if (!isLoggedIn || !currentUser) {
+    if (!isLoggedIn || !currentUserName) {
       setReady(true);
       return;
     }
@@ -50,14 +52,16 @@ export function AuthGate({ children }: { children: ReactNode }) {
       store.fetchWorkspaceIamPolicy(),
       store.loadWorkspaceList(),
       store.listRoles(),
-      store.batchGetOrFetchGroups(currentUser.groups),
+      store.batchGetOrFetchGroups(
+        currentUserGroupsKey ? currentUserGroupsKey.split("\0") : []
+      ),
     ]).finally(() => {
       if (!cancelled) setReady(true);
     });
     return () => {
       cancelled = true;
     };
-  }, [isLoggedIn, currentUser]);
+  }, [currentUserGroupsKey, currentUserName, currentUserWorkspace, isLoggedIn]);
 
   // Periodically revalidate the session (skip when logged out / on auth routes).
   useEffect(() => {
@@ -65,7 +69,16 @@ export function AuthGate({ children }: { children: ReactNode }) {
       const store = useAppStore.getState();
       if (!store.isLoggedIn() || store.unauthenticatedOccurred) return;
       if (isAuthRoute) return;
-      void store.fetchCurrentUser();
+      void (async () => {
+        const user = await store.fetchCurrentUser();
+        if (!user || !store.isLoggedIn() || store.unauthenticatedOccurred) {
+          return;
+        }
+        await Promise.allSettled([
+          store.fetchWorkspaceIamPolicy(),
+          store.listRoles(),
+        ]);
+      })();
     }, CHECK_AUTHORIZATION_INTERVAL);
     return () => clearInterval(id);
   }, [isAuthRoute]);


### PR DESCRIPTION
## Summary
- Keep the authenticated page visible when session revalidation refreshes the same current user.
- Key AuthGate workspace preload on stable user identity, workspace, and group values instead of the currentUser object reference.

## Key Changes
- Avoid rerunning the global loading gate for same-user currentUser object refreshes.
- Add an AuthGate regression test for same-identity currentUser refreshes.

## Motivation
Routine fetchCurrentUser polling returns a fresh user object. AuthGate previously treated that object reference as a preload dependency, briefly replacing the page with the global loading state.

## Test Plan
- pnpm -C frontend exec vitest run src/react/app/AuthGate.test.tsx
- pnpm -C frontend run fix
- pnpm -C frontend run check
- pnpm -C frontend run type-check
- pnpm -C frontend run test