### PR TITLE
chore(deps): bump omni to grammar-driven TiDB routine bodies (#223)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260604055152-00018e4c576b
+	github.com/bytebase/omni v0.0.0-20260604130724-8b300c1a5cbc
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260604055152-00018e4c576b h1:1D2BJWeZvynr0O9G4QIl2nvN2kLTCnY6V6svm6ipITY=
-github.com/bytebase/omni v0.0.0-20260604055152-00018e4c576b/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260604130724-8b300c1a5cbc h1:1nQYEAiDH84Tsa6JoTtRs1pkGZU9rmaoExywjZcZQAg=
+github.com/bytebase/omni v0.0.0-20260604130724-8b300c1a5cbc/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## What

Bump `github.com/bytebase/omni` → `8b300c1a` (omni **#223**: grammar-driven TiDB routine bodies + full TiDB v8.5.0 grammar alignment). Pure dependency bump — **no bytebase source changes**.

## Why

omni #223 makes the TiDB parser parse routine bodies via the grammar (instead of a raw-text scanner) and aligns it with the **real TiDB v8.5.0 grammar**. It now rejects forms TiDB itself rejects, removing a class of review-time over-acceptance. It also carries #188 (string-literal alias) and #192 (BINARY modifier).

## Blast-radius audit (why no source changes)

An import-aware audit over all 60 bytebase files that import `omni/tidb`:

- **Compile:** the AST `.Body` `string`→`Node` change (plus new `.BodyText`) touches **no** bytebase consumer. TiDB advisors operate on table/DML nodes; query-span/masking use the native pingcap parser; nothing reads routine `.Body`/`.BodyText`. Build confirms.
- **Tests:** no TiDB test/fixture exercises a now-rejected form.
- **Other engines:** the bump advances omni broadly, but the only changed engines bytebase compiles are **tidb** (#188/#192/#223) and additive **partiql/doris** fixes. `mysql/pg/oracle/mssql/plsql/tsql` are unchanged in range; `trino/googlesql/snowflake` are not imported.

## Behavior change (intended, parity-correct)

TiDB SQL containing a now-rejected routine form (`CREATE/DROP/ALTER/SHOW FUNCTION/TRIGGER/EVENT`, DEFINER-routine, `OR REPLACE PROCEDURE`, `LOOP`/`DECLARE…CONDITION`/`SIGNAL`/`RESIGNAL` in bodies) now surfaces a **syntax error at review/plan-check time** instead of being accepted and failing at apply. The dispatcher positions the error at the offending statement, so a multi-statement migration blocks on it — correct, since TiDB rejects the statement at apply anyway. **Kept forms** (`CREATE/DROP PROCEDURE`, `SHOW CREATE PROCEDURE`, `SHOW … STATUS/TRIGGERS/EVENTS`, procedure bodies with `IF/CASE/WHILE/REPEAT`) still parse.

## Testing

- `go build` server — OK (empirical zero-compile-break proof)
- `go test -short` — `parser/tidb`, `advisor/tidb`, `parser/partiql`, `parser/doris` all pass
- `golangci-lint run` — clean
- **TiDB v8.5.0 container parity** (`pingcap/tidb:v8.5.0`) confirmed both directions: every newly-rejected form returns 1064; every kept form returns 8108/OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
