### PR TITLE
fix(router): inherit params for named project routes

### DIFF
--- a/frontend/src/react/router/currentRouteSnapshot.test.ts
+++ b/frontend/src/react/router/currentRouteSnapshot.test.ts
@@ -1,5 +1,41 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  PROJECT_V1_ROUTE_WEBHOOK_CREATE,
+  PROJECT_V1_ROUTE_WEBHOOK_DETAIL,
+  PROJECT_V1_ROUTE_WEBHOOKS,
+} from "./handles";
 import { router } from "./index";
+import { setAppRouter, setRouteNameIndex } from "./navigation";
+
+beforeEach(() => {
+  setRouteNameIndex(
+    new Map<string, string>([
+      [PROJECT_V1_ROUTE_WEBHOOKS, "/projects/:projectId/webhooks"],
+      [PROJECT_V1_ROUTE_WEBHOOK_CREATE, "/projects/:projectId/webhooks/new"],
+      [
+        PROJECT_V1_ROUTE_WEBHOOK_DETAIL,
+        "/projects/:projectId/webhooks/:webhookResourceId",
+      ],
+    ])
+  );
+  setAppRouter({
+    navigate: vi.fn(),
+    state: {
+      location: {
+        pathname: "/projects/project-sample/webhooks",
+        search: "",
+        hash: "",
+      },
+      matches: [
+        {
+          handle: { name: PROJECT_V1_ROUTE_WEBHOOKS },
+          params: { projectId: "project-sample" },
+        },
+      ],
+      initialized: true,
+    },
+  });
+});
 
 // Guardrail for the "getSnapshot should be cached" infinite-loop class.
 // `router.currentRoute.value` backs the `useReactiveRoute` `useSyncExternalStore`
@@ -13,5 +49,19 @@ describe("router.currentRoute snapshot stability", () => {
     const a = router.currentRoute.value;
     const b = router.currentRoute.value;
     expect(a).toBe(b);
+  });
+});
+
+describe("router named route params", () => {
+  it("inherits current params when resolving project child routes", () => {
+    expect(
+      router.resolve({ name: PROJECT_V1_ROUTE_WEBHOOK_CREATE }).fullPath
+    ).toBe("/projects/project-sample/webhooks/new");
+    expect(
+      router.resolve({
+        name: PROJECT_V1_ROUTE_WEBHOOK_DETAIL,
+        params: { webhookResourceId: "hook-1" },
+      }).fullPath
+    ).toBe("/projects/project-sample/webhooks/hook-1");
   });
 });

--- a/frontend/src/react/router/index.ts
+++ b/frontend/src/react/router/index.ts
@@ -108,7 +108,10 @@ function resolveTarget(to: RouteTarget): string {
       : `#${to.hash}`
     : "";
   if (to.name) {
-    return `${resolvePath(to.name, { params: to.params, query: to.query })}${hash}`;
+    return `${resolvePath(to.name, {
+      params: inheritCurrentParams(to.params),
+      query: to.query,
+    })}${hash}`;
   }
   if (to.path) {
     const search = to.query ? buildSearchString(to.query) : "";
@@ -125,6 +128,18 @@ function resolveTarget(to: RouteTarget): string {
   const search = to.query ? buildSearchString(to.query) : "";
   const path = window.location.pathname;
   return `${search ? `${path}?${search}` : path}${hash}`;
+}
+
+function inheritCurrentParams(
+  params: Record<string, string | string[] | undefined> | undefined
+): Record<string, string | string[] | undefined> {
+  const merged = { ...currentRouteSnapshot().params };
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value !== undefined) {
+      merged[key] = value;
+    }
+  }
+  return merged;
 }
 
 // Shared builder for both the `useCurrentRoute` hook and the non-hook


### PR DESCRIPTION
## Summary

Fixes BYT-9651 by making the React router shim inherit current route params when resolving named routes.

The webhook create flow navigated with `{ name: PROJECT_V1_ROUTE_WEBHOOK_CREATE }` from a project-scoped page. The shim resolved only explicitly supplied params, so the parent `:projectId` placeholder stayed literal and the app attempted to fetch `projects/:projectId` before falling back to the workspace route.

## Changes

- Merge current route params into named route targets before resolving their path.
- Add a regression test covering project Webhook Create and Detail named route resolution.

## Validation

- `CI=true pnpm --dir frontend exec vitest run currentRouteSnapshot.test.ts navigation.test.ts`
- `CI=true pnpm --dir frontend check`
- `CI=true pnpm --dir frontend type-check`

## Pre-PR checklist

- Breaking change check: not breaking; frontend bug fix only.
- Composite-PK query safety: skipped; no backend/store or migrator changes.
- Image compatibility window: skipped; no version or action compatibility changes.
- SonarCloud properties: skipped; no new files or directories.