### PR TITLE
fix(frontend): render 404 for unknown routes

### DIFF
--- a/frontend/src/react/router/routes.test.tsx
+++ b/frontend/src/react/router/routes.test.tsx
@@ -1,5 +1,6 @@
-import type { RouteObject } from "react-router-dom";
+import { matchRoutes, type RouteObject } from "react-router-dom";
 import { describe, expect, it } from "vitest";
+import { WORKSPACE_ROUTE_404 } from "@/react/router/handles";
 import { routes } from "./routes";
 
 // Guardrail for the "blank body" route bug class. During the Vue→React router
@@ -68,5 +69,30 @@ function collectBareLeaves(
 describe("react route table reachability", () => {
   it("every leaf route renders something or redirects (no blank-body bare leaves)", () => {
     expect(collectBareLeaves(routes)).toEqual([]);
+  });
+
+  it.each([
+    "/projects/db333/rollouts/605",
+    "/sql-editor/does-not-exist",
+  ])("redirects unknown URL %s to the dedicated 404 route", async (path) => {
+    const matched = matchRoutes(routes, path);
+    const leafRoute = matched?.at(-1)?.route;
+    const leafHandle = leafRoute?.handle as { name?: string } | undefined;
+
+    expect(leafHandle?.name).toBe(WORKSPACE_ROUTE_404);
+    expect(leafRoute?.loader).toBeTypeOf("function");
+
+    const response = await (
+      leafRoute?.loader as (args: {
+        request: Request;
+        params: Record<string, string>;
+      }) => Promise<Response> | Response
+    )({
+      request: new Request(`http://localhost${path}`),
+      params: {},
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("Location")).toBe("/404");
   });
 });

--- a/frontend/src/react/router/routes.tsx
+++ b/frontend/src/react/router/routes.tsx
@@ -1,5 +1,6 @@
-import type { RouteObject } from "react-router-dom";
+import { type RouteObject, redirect } from "react-router-dom";
 import { RootLayout } from "@/react/app/RootLayout";
+import { WORKSPACE_ROUTE_404 } from "@/react/router/handles";
 import { authRoutes } from "@/react/router/routes/auth";
 import { dashboardRoutes } from "@/react/router/routes/dashboard";
 import { sqlEditorRoutes } from "@/react/router/routes/sqlEditor";
@@ -15,7 +16,16 @@ import { sqlEditorRoutes } from "@/react/router/routes/sqlEditor";
 export const routes: RouteObject[] = [
   {
     element: <RootLayout />,
-    children: [...authRoutes, ...dashboardRoutes, ...sqlEditorRoutes],
+    children: [
+      ...authRoutes,
+      ...dashboardRoutes,
+      ...sqlEditorRoutes,
+      {
+        path: "*",
+        handle: { name: WORKSPACE_ROUTE_404 },
+        loader: () => redirect("/404"),
+      },
+    ],
   },
 ];
 


### PR DESCRIPTION
## Summary
- Add a dashboard catch-all route that renders the existing Page404 surface.
- Cover an unknown project rollout URL so it no longer falls through to React Router's default error UI.

## Test Plan
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test
