### PR TITLE
fix: make project table links openable in new tabs

### DIFF
--- a/frontend/src/react/components/ProjectTable.test.tsx
+++ b/frontend/src/react/components/ProjectTable.test.tsx
@@ -65,7 +65,7 @@ describe("ProjectTable", () => {
     ]);
   });
 
-  test("does not call the row click handler when clicking row links", () => {
+  test("routes plain clicks on row links through the row click handler", () => {
     const onRowClick = vi.fn();
 
     act(() => {
@@ -81,12 +81,45 @@ describe("ProjectTable", () => {
     const links = [...container.querySelectorAll("a")];
     expect(links).toHaveLength(2);
     for (const link of links) {
-      link.addEventListener("click", (event) => event.preventDefault(), {
-        once: true,
+      const event = new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
       });
-      link.dispatchEvent(
-        new MouseEvent("click", { bubbles: true, cancelable: true })
+      const notPrevented = link.dispatchEvent(event);
+      expect(notPrevented).toBe(false);
+    }
+
+    expect(onRowClick).toHaveBeenCalledTimes(2);
+    expect(onRowClick.mock.calls.map((call) => call[0])).toEqual([
+      project,
+      project,
+    ]);
+  });
+
+  test("keeps modified clicks on row links native", () => {
+    const onRowClick = vi.fn();
+
+    act(() => {
+      root.render(
+        <ProjectTable
+          projectList={[project]}
+          getRowHref={() => "#sample"}
+          onRowClick={onRowClick}
+        />
       );
+    });
+
+    const links = [...container.querySelectorAll("a")];
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      const modifiedNotPrevented = link.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+          metaKey: true,
+        })
+      );
+      expect(modifiedNotPrevented).toBe(true);
     }
 
     expect(onRowClick).not.toHaveBeenCalled();

--- a/frontend/src/react/components/ProjectTable.test.tsx
+++ b/frontend/src/react/components/ProjectTable.test.tsx
@@ -1,0 +1,94 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { Project } from "@/types/proto-es/v1/project_service_pb";
+import { ProjectTable } from "./ProjectTable";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/react/components/ui/ellipsis-text", () => ({
+  EllipsisText: ({ children }: { children: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+const project = {
+  name: "projects/sample",
+  title: "Sample Project",
+  labels: {},
+} as Project;
+
+describe("ProjectTable", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  test("renders project ID and title as links when a row href is provided", () => {
+    act(() => {
+      root.render(
+        <ProjectTable
+          projectList={[project]}
+          getRowHref={() => "/projects/sample/issues"}
+        />
+      );
+    });
+
+    const links = [...container.querySelectorAll("a")];
+    expect(links).toHaveLength(2);
+    expect(links.map((link) => link.getAttribute("href"))).toEqual([
+      "/projects/sample/issues",
+      "/projects/sample/issues",
+    ]);
+    expect(links.map((link) => link.textContent)).toEqual([
+      "sample",
+      "Sample Project",
+    ]);
+  });
+
+  test("does not call the row click handler when clicking row links", () => {
+    const onRowClick = vi.fn();
+
+    act(() => {
+      root.render(
+        <ProjectTable
+          projectList={[project]}
+          getRowHref={() => "/projects/sample/issues"}
+          onRowClick={onRowClick}
+        />
+      );
+    });
+
+    const links = [...container.querySelectorAll("a")];
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      link.addEventListener("click", (event) => event.preventDefault(), {
+        once: true,
+      });
+      link.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    }
+
+    expect(onRowClick).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/react/components/ProjectTable.test.tsx
+++ b/frontend/src/react/components/ProjectTable.test.tsx
@@ -65,6 +65,26 @@ describe("ProjectTable", () => {
     ]);
   });
 
+  test("keeps plain clicks on row links native without a row click handler", () => {
+    act(() => {
+      root.render(
+        <ProjectTable projectList={[project]} getRowHref={() => "#sample"} />
+      );
+    });
+
+    const links = [...container.querySelectorAll("a")];
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      const notPrevented = link.dispatchEvent(
+        new MouseEvent("click", {
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      expect(notPrevented).toBe(true);
+    }
+  });
+
   test("routes plain clicks on row links through the row click handler", () => {
     const onRowClick = vi.fn();
 

--- a/frontend/src/react/components/ProjectTable.tsx
+++ b/frontend/src/react/components/ProjectTable.tsx
@@ -57,6 +57,8 @@ export interface ProjectTableProps {
    */
   readonly showActions?: boolean;
   readonly renderActions?: RenderActions;
+  /** Native link target for each row, used by title anchors. */
+  readonly getRowHref?: (project: Project) => string;
   /** Currently-checked rows (selection mode). */
   readonly selectedProjectNames?: readonly string[];
   /** Selection-change callback. */
@@ -100,6 +102,7 @@ export function ProjectTable({
   showLabels = true,
   showActions = false,
   renderActions,
+  getRowHref,
   selectedProjectNames = [],
   onSelectedChange,
   sortKey,
@@ -145,6 +148,8 @@ export function ProjectTable({
   onRowClickRef.current = onRowClick;
   const renderActionsRef = useRef(renderActions);
   renderActionsRef.current = renderActions;
+  const getRowHrefRef = useRef(getRowHref);
+  getRowHrefRef.current = getRowHref;
 
   const handleSelectAll = useCallback(() => {
     const cb = onSelectedChangeRef.current;
@@ -251,6 +256,7 @@ export function ProjectTable({
               showLabels={showLabels}
               showActions={showActions}
               clickable={!!onRowClick}
+              rowHref={getRowHrefRef.current?.(project)}
               keyword={keyword}
               onToggleRow={handleToggleRow}
               onRowClick={handleRowClick}
@@ -272,6 +278,7 @@ interface ProjectRowViewProps {
   showLabels: boolean;
   showActions: boolean;
   clickable: boolean;
+  rowHref?: string;
   keyword: string;
   onToggleRow: (name: string) => void;
   onRowClick: (
@@ -290,6 +297,7 @@ const ProjectRowView = memo(function ProjectRowView({
   showLabels,
   showActions,
   clickable,
+  rowHref,
   keyword,
   onToggleRow,
   onRowClick,
@@ -299,6 +307,16 @@ const ProjectRowView = memo(function ProjectRowView({
   const resourceId = getProjectName(project.name);
   const isDefault = resourceId === "default";
   const titleText = project.title || resourceId;
+  const titleContent = (
+    <EllipsisText text={titleText} className="min-w-0">
+      <HighlightLabelText text={titleText} keyword={keyword} />
+    </EllipsisText>
+  );
+  const resourceIdContent = (
+    <EllipsisText text={resourceId}>
+      <HighlightLabelText text={resourceId} keyword={keyword} />
+    </EllipsisText>
+  );
   return (
     <TableRow
       className={cn(clickable && "cursor-pointer")}
@@ -328,15 +346,31 @@ const ProjectRowView = memo(function ProjectRowView({
         </TableCell>
       ) : null}
       <TableCell>
-        <EllipsisText text={resourceId}>
-          <HighlightLabelText text={resourceId} keyword={keyword} />
-        </EllipsisText>
+        {rowHref ? (
+          <a
+            href={rowHref}
+            className="block hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {resourceIdContent}
+          </a>
+        ) : (
+          resourceIdContent
+        )}
       </TableCell>
       <TableCell>
         <div className="flex items-center gap-x-2 min-w-0">
-          <EllipsisText text={titleText} className="min-w-0">
-            <HighlightLabelText text={titleText} keyword={keyword} />
-          </EllipsisText>
+          {rowHref ? (
+            <a
+              href={rowHref}
+              className="min-w-0 block hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {titleContent}
+            </a>
+          ) : (
+            titleContent
+          )}
           {project.state === State.DELETED ? (
             <Badge variant="warning" className="text-xs shrink-0">
               {t("common.archived")}

--- a/frontend/src/react/components/ProjectTable.tsx
+++ b/frontend/src/react/components/ProjectTable.tsx
@@ -329,7 +329,7 @@ const ProjectRowView = memo(function ProjectRowView({
   return (
     <TableRow
       className={cn(clickable && "cursor-pointer")}
-      onClick={(event) => onRowClick(project, event)}
+      onClick={clickable ? (event) => onRowClick(project, event) : undefined}
     >
       {showSelection ? (
         <TableCell
@@ -359,7 +359,7 @@ const ProjectRowView = memo(function ProjectRowView({
           <a
             href={rowHref}
             className="block hover:underline"
-            onClick={handleRowLinkClick}
+            onClick={clickable ? handleRowLinkClick : undefined}
           >
             {resourceIdContent}
           </a>
@@ -373,7 +373,7 @@ const ProjectRowView = memo(function ProjectRowView({
             <a
               href={rowHref}
               className="min-w-0 block hover:underline"
-              onClick={handleRowLinkClick}
+              onClick={clickable ? handleRowLinkClick : undefined}
             >
               {titleContent}
             </a>

--- a/frontend/src/react/components/ProjectTable.tsx
+++ b/frontend/src/react/components/ProjectTable.tsx
@@ -27,6 +27,7 @@ export type ProjectTableSortKey = "title";
 export type ProjectTableSortDirection = "asc" | "desc";
 
 type RenderActions = (project: Project) => ReactNode;
+type ProjectRowClickEvent = ReactMouseEvent<HTMLElement>;
 
 export interface ProjectTableProps {
   /** Rows to render. */
@@ -71,10 +72,7 @@ export interface ProjectTableProps {
    * Click handler. Receives the original event so callers can detect
    * `ctrl`/`meta` modifiers for "open in new tab".
    */
-  readonly onRowClick?: (
-    project: Project,
-    event: ReactMouseEvent<HTMLTableRowElement>
-  ) => void;
+  readonly onRowClick?: (project: Project, event: ProjectRowClickEvent) => void;
   readonly className?: string;
 }
 
@@ -171,7 +169,7 @@ export function ProjectTable({
   }, []);
 
   const handleRowClick = useCallback(
-    (project: Project, event: ReactMouseEvent<HTMLTableRowElement>) => {
+    (project: Project, event: ProjectRowClickEvent) => {
       onRowClickRef.current?.(project, event);
     },
     []
@@ -281,10 +279,7 @@ interface ProjectRowViewProps {
   rowHref?: string;
   keyword: string;
   onToggleRow: (name: string) => void;
-  onRowClick: (
-    project: Project,
-    event: ReactMouseEvent<HTMLTableRowElement>
-  ) => void;
+  onRowClick: (project: Project, event: ProjectRowClickEvent) => void;
   renderActions: (project: Project) => ReactNode;
 }
 
@@ -317,6 +312,20 @@ const ProjectRowView = memo(function ProjectRowView({
       <HighlightLabelText text={resourceId} keyword={keyword} />
     </EllipsisText>
   );
+  const handleRowLinkClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation();
+    if (
+      event.button !== 0 ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey ||
+      event.altKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    onRowClick(project, event);
+  };
   return (
     <TableRow
       className={cn(clickable && "cursor-pointer")}
@@ -350,7 +359,7 @@ const ProjectRowView = memo(function ProjectRowView({
           <a
             href={rowHref}
             className="block hover:underline"
-            onClick={(e) => e.stopPropagation()}
+            onClick={handleRowLinkClick}
           >
             {resourceIdContent}
           </a>
@@ -364,7 +373,7 @@ const ProjectRowView = memo(function ProjectRowView({
             <a
               href={rowHref}
               className="min-w-0 block hover:underline"
-              onClick={(e) => e.stopPropagation()}
+              onClick={handleRowLinkClick}
             >
               {titleContent}
             </a>

--- a/frontend/src/react/pages/settings/ProjectsPage.navigation.test.ts
+++ b/frontend/src/react/pages/settings/ProjectsPage.navigation.test.ts
@@ -6,6 +6,8 @@ describe("ProjectsPage navigation", () => {
   test("opens projects from the table on the issues page", () => {
     expect(source).toContain("PROJECT_V1_ROUTE_ISSUES");
     expect(source).toContain("projectIssuesRoute(project)");
+    expect(source).toContain("e.ctrlKey || e.metaKey");
+    expect(source).toContain('window.open(route.fullPath, "_blank")');
     expect(source).not.toContain("PROJECT_V1_ROUTE_DETAIL");
     expect(source).not.toContain("router.push({ path: `/${project.name}` })");
   });

--- a/frontend/src/react/pages/settings/ProjectsPage.tsx
+++ b/frontend/src/react/pages/settings/ProjectsPage.tsx
@@ -587,7 +587,7 @@ export function ProjectsPage() {
   }, []);
 
   const handleRowClick = useCallback(
-    (project: Project, e: React.MouseEvent) => {
+    (project: Project, e: React.MouseEvent<HTMLElement>) => {
       const route = router.resolve(projectIssuesRoute(project));
       if (e.ctrlKey || e.metaKey) {
         window.open(route.fullPath, "_blank");

--- a/frontend/src/react/pages/settings/ProjectsPage.tsx
+++ b/frontend/src/react/pages/settings/ProjectsPage.tsx
@@ -598,6 +598,10 @@ export function ProjectsPage() {
     []
   );
 
+  const getProjectHref = useCallback((project: Project) => {
+    return router.resolve(projectIssuesRoute(project)).fullPath;
+  }, []);
+
   const handleProjectAction = useCallback(() => {
     fetchProjects(true);
   }, [fetchProjects]);
@@ -640,6 +644,7 @@ export function ProjectsPage() {
               onAction={handleProjectAction}
             />
           )}
+          getRowHref={getProjectHref}
           selectedProjectNames={Array.from(selectedNames)}
           onSelectedChange={(names) => setSelectedNames(new Set(names))}
           sortKey={sortKey}


### PR DESCRIPTION
## Summary
- Render project ID and title cells as native links to the project issues page.
- Keep row click behavior consistent with `/issues`: left-click routes in-app, ctrl/cmd-click opens a new tab.
- Add React coverage for project table row links and click propagation.

## Test Plan
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
