### PR TITLE
fix(pg): emit schema file for multi-file SDL

### DIFF
--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -3672,6 +3672,17 @@ func GetMultiFileDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *s
 			schemaName = "public"
 		}
 
+		schemaContent, err := getMultiFileSchemaSDL(schemaName, schemaMetadata)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to generate schema SDL for %s", schemaName)
+		}
+		if schemaContent != "" {
+			files = append(files, schema.File{
+				Name:    fmt.Sprintf("schemas/%s/schema.sql", schemaName),
+				Content: schemaContent,
+			})
+		}
+
 		// Collect independent sequences (no owner) for this schema
 		var independentSequences []*storepb.SequenceMetadata
 		for _, sequence := range schemaMetadata.Sequences {
@@ -4011,6 +4022,27 @@ func GetMultiFileDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *s
 	}
 
 	return &schema.MultiFileSchemaResult{Files: files}, nil
+}
+
+func getMultiFileSchemaSDL(schemaName string, schemaMetadata *storepb.SchemaMetadata) (string, error) {
+	var buf strings.Builder
+
+	if schemaName != "public" {
+		if err := writeSchema(&buf, &storepb.SchemaMetadata{Name: schemaName}); err != nil {
+			return "", err
+		}
+	}
+
+	if schemaMetadata.GetComment() != "" {
+		if err := writeSchemaCommentSDL(&buf, &storepb.SchemaMetadata{
+			Name:    schemaName,
+			Comment: schemaMetadata.GetComment(),
+		}); err != nil {
+			return "", err
+		}
+	}
+
+	return buf.String(), nil
 }
 
 // buildSkipSequencesMap builds a map of sequences that should be skipped (serial and identity sequences).

--- a/backend/plugin/schema/pg/get_database_definition_sdl_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_sdl_test.go
@@ -1611,6 +1611,12 @@ func TestGetMultiFileDatabaseDefinition_WithComments(t *testing.T) {
 		fileMap[file.Name] = file.Content
 	}
 
+	// Verify schema-level file with schema comment
+	schemaFile, ok := fileMap["schemas/app_schema/schema.sql"]
+	require.True(t, ok, "schema.sql file should exist for non-public schema")
+	assert.Contains(t, schemaFile, `CREATE SCHEMA IF NOT EXISTS "app_schema";`)
+	assert.Contains(t, schemaFile, `COMMENT ON SCHEMA "app_schema" IS 'Application schema';`)
+
 	// Verify consolidated sequences file with comment (independent sequences go in sequences.sql)
 	sequenceFile, ok := fileMap["schemas/app_schema/sequences.sql"]
 	require.True(t, ok, "sequences.sql file should exist for independent sequences")
@@ -1650,6 +1656,47 @@ func TestGetMultiFileDatabaseDefinition_WithComments(t *testing.T) {
 		require.NoError(t, err, "SQL in file %s should be parseable by PostgreSQL parser", fileName)
 	}
 }
+
+func TestGetMultiFileDatabaseDefinition_SchemaFileMakesCombinedSDLLoadable(t *testing.T) {
+	metadata := &storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "metric_helpers",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "metrics",
+						Columns: []*storepb.ColumnMetadata{
+							{
+								Name:     "id",
+								Type:     "INTEGER",
+								Nullable: false,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := GetMultiFileDatabaseDefinition(schema.GetDefinitionContext{SDLFormat: true}, metadata)
+	require.NoError(t, err)
+
+	fileMap := make(map[string]string)
+	var combined strings.Builder
+	for _, file := range result.Files {
+		fileMap[file.Name] = file.Content
+		combined.WriteString(file.Content)
+		combined.WriteString("\n")
+	}
+
+	schemaFile, ok := fileMap["schemas/metric_helpers/schema.sql"]
+	assert.True(t, ok, "schema.sql file should exist for non-public schema")
+	assert.Contains(t, schemaFile, `CREATE SCHEMA IF NOT EXISTS "metric_helpers";`)
+
+	_, err = schema.DiffSDLMigration(storepb.Engine_POSTGRES, "", combined.String())
+	require.NoError(t, err)
+}
+
 func TestGetDatabaseDefinitionSDLFormat_SerialColumnWithSequence(t *testing.T) {
 	// This test reproduces the issue where a SERIAL column causes duplicate CREATE SEQUENCE statements
 	// SERIAL columns automatically create sequences, so we should NOT output separate CREATE SEQUENCE for them


### PR DESCRIPTION
## Summary
- emit `schemas/<schema>/schema.sql` for PostgreSQL multi-file SDL output
- include schema creation and schema comments in the schema file
- add regression coverage that combined multi-file SDL loads through the SDL diff path

## Testing
- `gofmt -w backend/plugin/schema/pg/get_database_definition.go backend/plugin/schema/pg/get_database_definition_sdl_test.go`
- `go test -v -count=1 ./backend/plugin/schema/pg -run '^(TestGetMultiFileDatabaseDefinition|TestGetDatabaseDefinitionSDLFormat|TestDiffSDLMigration)'`\n- `git diff --check`\n\n## Notes\n- `golangci-lint run --allow-parallel-runners` and `golangci-lint run --fix --allow-parallel-runners` could not complete in this worktree because the local filesystem has about 438MiB free; failures were Go cache/typecheck and `no space left on device`, not a reported issue in this diff.\n- Full server build was not run for the same disk-space reason.