### PR TITLE
fix: prevent masking popover clicks selecting results

### DIFF
--- a/frontend/src/react/components/sql-editor/MaskingReasonPopover.test.tsx
+++ b/frontend/src/react/components/sql-editor/MaskingReasonPopover.test.tsx
@@ -80,8 +80,13 @@ vi.mock("@/react/components/ui/popover", () => ({
       {renderProp}
     </div>
   ),
-  PopoverContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="popover-content">{children}</div>
+  PopoverContent: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid="popover-content" {...props}>
+      {children}
+    </div>
   ),
 }));
 
@@ -200,6 +205,28 @@ describe("MaskingReasonPopover", () => {
 
     const content = container.querySelector("[data-testid='popover-content']");
     expect(content?.textContent).toContain("masking.reason.title");
+    unmount();
+  });
+
+  test("clicking popover content does not bubble to result table", () => {
+    const onTableClick = vi.fn();
+    const { container, render, unmount } = renderIntoContainer(
+      <div onClick={onTableClick}>
+        <MaskingReasonPopover reason={makeReason()} />
+      </div>
+    );
+    render();
+
+    const content = container.querySelector(
+      "[data-testid='popover-content']"
+    ) as HTMLDivElement;
+    expect(content).not.toBeNull();
+
+    act(() => {
+      content.click();
+    });
+
+    expect(onTableClick).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/frontend/src/react/components/sql-editor/MaskingReasonPopover.tsx
+++ b/frontend/src/react/components/sql-editor/MaskingReasonPopover.tsx
@@ -1,4 +1,5 @@
 import { EyeOff } from "lucide-react";
+import type { SyntheticEvent } from "react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
@@ -57,6 +58,10 @@ export function MaskingReasonPopover({
     onClick?.();
   };
 
+  const stopResultTableEvent = (event: SyntheticEvent) => {
+    event.stopPropagation();
+  };
+
   return (
     <>
       <Popover>
@@ -67,7 +72,11 @@ export function MaskingReasonPopover({
           // UI so it doesn't warn about missing native button semantics.
           nativeButton={false}
           render={
-            <div className="inline-flex items-center gap-0.5 cursor-pointer">
+            <div
+              className="inline-flex items-center gap-0.5 cursor-pointer"
+              onClick={stopResultTableEvent}
+              onPointerDown={stopResultTableEvent}
+            >
               {reason.semanticTypeIcon && (
                 <img
                   src={reason.semanticTypeIcon}
@@ -86,6 +95,8 @@ export function MaskingReasonPopover({
           side="bottom"
           align="start"
           className="min-w-80 max-w-md"
+          onClick={stopResultTableEvent}
+          onPointerDown={stopResultTableEvent}
         >
           <div className="w-full flex flex-col gap-y-2">
             <div className="font-medium flex items-center gap-2">


### PR DESCRIPTION
## Summary
- Stop click and pointer events from the masking reason popover from bubbling into the result table selection handlers.
- Add a regression test covering clicks inside the masking popover content.

## Pre-PR Checklist
- Breaking change check: not applicable; this is a scoped UI bug fix.
- Composite-PK query safety: skipped; no backend store or migrator changes.
- SonarCloud properties: skipped; no new files or directories.

## Test Plan
- `pnpm --dir frontend exec vitest run src/react/components/sql-editor/MaskingReasonPopover.test.tsx --passWithNoTests`
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
