### PR TITLE
refactor: add RouterLink for internal navigation

### DIFF
--- a/docs/superpowers/plans/2026-06-05-router-link-migration.md
+++ b/docs/superpowers/plans/2026-06-05-router-link-migration.md
@@ -61,6 +61,22 @@
   - Href-only internal anchors in issue-detail pages and `GroupsPage.tsx`
   - Any `href="#"` controls, which may need buttons instead of links.
 
+## Second-Pass Migration Targets
+
+Follow-up exploration found more React internal navigation patterns after the
+initial PR pass. Migrate the clearly navigational cases below; leave action
+buttons, menu actions, and table-row click handlers alone unless the target is
+already a real anchor.
+
+- Auth route links currently rendered as `href="#"`.
+- Settings and landing-page internal anchors resolved with `router.push` or
+  `router.resolve`.
+- Database/project internal anchors and link-styled spans.
+- Internal links that intentionally open in a new tab, preserving `target`,
+  `rel`, and propagation handlers.
+- Pure navigation button CTAs where the button only routes and has no workflow
+  side effects.
+
 ---
 
 ## Task 1: Add RouterLink Tests

--- a/docs/superpowers/plans/2026-06-05-router-link-migration.md
+++ b/docs/superpowers/plans/2026-06-05-router-link-migration.md
@@ -1,0 +1,740 @@
+# RouterLink Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a shared React `RouterLink` for in-app navigation and migrate repeated internal anchor patterns found in the React frontend.
+
+**Architecture:** `RouterLink` is router-aware application infrastructure, not a shadcn-style visual primitive. It renders a real anchor with a resolved `href`, preserves native browser link behavior, and intercepts only normal same-tab left-click navigation for SPA routing through the existing `@/react/router`.
+
+**Tech Stack:** React, TypeScript, Vitest, React DOM test utilities, existing Bytebase React router (`router`, `RouteTarget`), Tailwind utility classes supplied by callers.
+
+---
+
+## File Structure
+
+- Create `frontend/src/react/components/RouterLink.tsx`
+  - Owns internal route link behavior.
+  - Accepts `to: RouteTarget`.
+  - Extends normal anchor props except `href`.
+  - Does not own visual variants or link colors.
+
+- Create `frontend/src/react/components/RouterLink.test.tsx`
+  - Unit tests for href resolution, click interception, and native-link escape hatches.
+
+- Modify `frontend/src/react/pages/project/ProjectSettingsPage.tsx`
+  - Replace the approval-flow tooltip `Button` with `RouterLink`.
+
+- Modify `frontend/src/react/pages/project/ProjectDataExportPage.tsx`
+  - Replace inline approval/settings route anchors in the deprecation banner.
+  - Replace issue links only after checking row click behavior and nested anchors.
+
+- Modify `frontend/src/react/components/header/HeaderBreadcrumb.tsx`
+  - Replace workspace breadcrumb anchor.
+
+- Modify `frontend/src/react/components/sql-editor/AsidePanel.tsx`
+  - Replace projects link anchor.
+
+- Modify `frontend/src/react/components/sql-review/ResourceLink.tsx`
+  - Replace environment/project resource anchors.
+
+- Modify `frontend/src/react/pages/settings/EnvironmentsPage.tsx`
+  - Replace environment internal anchor, preserving `stopPropagation`.
+
+- Modify `frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx`
+  - Replace user profile internal anchor.
+
+- Modify `frontend/src/react/components/revision/RevisionDetailPanel.tsx`
+  - Replace task link anchor, preserving modifier-click behavior via `RouterLink`.
+
+- Modify `frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx`
+  - Replace task link anchor.
+
+- Modify `frontend/src/react/components/ProjectSidebar.tsx`
+  - Replace sidebar route anchors after preserving active classes and group toggle behavior.
+
+- Modify `frontend/src/react/components/DashboardSidebar.tsx`
+  - Replace dashboard sidebar route anchors after preserving active classes and group toggle behavior.
+
+- Review but do not automatically migrate:
+  - `frontend/src/react/components/IssueTable.tsx`
+  - `frontend/src/react/pages/project/ProjectDataExportPage.tsx` issue-list row links
+  - Href-only internal anchors in issue-detail pages and `GroupsPage.tsx`
+  - Any `href="#"` controls, which may need buttons instead of links.
+
+---
+
+## Task 1: Add RouterLink Tests
+
+**Files:**
+- Create: `frontend/src/react/components/RouterLink.test.tsx`
+
+- [ ] **Step 1: Write the failing test file**
+
+```tsx
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { RouterLink } from "./RouterLink";
+
+const pushMock = vi.fn();
+const resolveMock = vi.fn((to: unknown) => {
+  if (typeof to === "string") {
+    return { href: to, fullPath: to };
+  }
+  return { href: "/setting/custom-approval", fullPath: "/setting/custom-approval" };
+});
+
+vi.mock("@/react/router", () => ({
+  router: {
+    push: pushMock,
+    resolve: resolveMock,
+  },
+}));
+
+describe("RouterLink", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    pushMock.mockClear();
+    resolveMock.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  const render = (element: React.ReactElement) => {
+    act(() => root.render(element));
+    return container.querySelector("a") as HTMLAnchorElement;
+  };
+
+  test("renders the resolved href", () => {
+    const to = { name: "workspace.custom-approval" };
+
+    const link = render(<RouterLink to={to}>Approval</RouterLink>);
+
+    expect(resolveMock).toHaveBeenCalledWith(to);
+    expect(link.getAttribute("href")).toBe("/setting/custom-approval");
+  });
+
+  test("routes normal same-tab left clicks through the app router", () => {
+    const to = { name: "workspace.custom-approval" };
+    const link = render(<RouterLink to={to}>Approval</RouterLink>);
+
+    const event = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });
+    act(() => link.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(pushMock).toHaveBeenCalledWith(to);
+  });
+
+  test("does not intercept meta-click navigation", () => {
+    const to = { name: "workspace.custom-approval" };
+    const link = render(<RouterLink to={to}>Approval</RouterLink>);
+
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      button: 0,
+      cancelable: true,
+      metaKey: true,
+    });
+    act(() => link.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  test("does not intercept middle-click navigation", () => {
+    const to = { name: "workspace.custom-approval" };
+    const link = render(<RouterLink to={to}>Approval</RouterLink>);
+
+    const event = new MouseEvent("click", { bubbles: true, button: 1, cancelable: true });
+    act(() => link.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  test("does not intercept non-self targets", () => {
+    const to = { name: "workspace.custom-approval" };
+    const link = render(
+      <RouterLink to={to} target="_blank">
+        Approval
+      </RouterLink>
+    );
+
+    const event = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });
+    act(() => link.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  test("runs onClick before routing and respects preventDefault", () => {
+    const to = { name: "workspace.custom-approval" };
+    const onClick = vi.fn((event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+    });
+    const link = render(
+      <RouterLink to={to} onClick={onClick}>
+        Approval
+      </RouterLink>
+    );
+
+    const event = new MouseEvent("click", { bubbles: true, button: 0, cancelable: true });
+    act(() => link.dispatchEvent(event));
+
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+pnpm --dir frontend vitest run src/react/components/RouterLink.test.tsx
+```
+
+Expected: FAIL because `./RouterLink` does not exist.
+
+---
+
+## Task 2: Implement RouterLink
+
+**Files:**
+- Create: `frontend/src/react/components/RouterLink.tsx`
+
+- [ ] **Step 1: Implement the component**
+
+```tsx
+import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from "react";
+import { router, type RouteTarget } from "@/react/router";
+
+type RouterLinkProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href"
+> & {
+  readonly to: RouteTarget;
+  readonly children: ReactNode;
+};
+
+function shouldHandleClick(
+  event: MouseEvent<HTMLAnchorElement>,
+  target: AnchorHTMLAttributes<HTMLAnchorElement>["target"],
+  download: AnchorHTMLAttributes<HTMLAnchorElement>["download"]
+): boolean {
+  if (event.defaultPrevented) return false;
+  if (event.button !== 0) return false;
+  if (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey) {
+    return false;
+  }
+  if (target && target !== "_self") return false;
+  if (download !== undefined) return false;
+  return true;
+}
+
+export function RouterLink({
+  to,
+  target,
+  download,
+  onClick,
+  children,
+  ...props
+}: RouterLinkProps) {
+  const href = router.resolve(to).href;
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+    if (!shouldHandleClick(event, target, download)) {
+      return;
+    }
+    event.preventDefault();
+    router.push(to);
+  };
+
+  return (
+    <a
+      {...props}
+      href={href}
+      target={target}
+      download={download}
+      onClick={handleClick}
+    >
+      {children}
+    </a>
+  );
+}
+```
+
+- [ ] **Step 2: Run the focused test**
+
+Run:
+
+```bash
+pnpm --dir frontend vitest run src/react/components/RouterLink.test.tsx
+```
+
+Expected: PASS.
+
+---
+
+## Task 3: Migrate Approval Tooltip and Simple Inline Route Links
+
+**Files:**
+- Modify: `frontend/src/react/pages/project/ProjectSettingsPage.tsx`
+- Modify: `frontend/src/react/pages/project/ProjectDataExportPage.tsx`
+- Modify: `frontend/src/react/components/header/HeaderBreadcrumb.tsx`
+- Modify: `frontend/src/react/components/sql-editor/AsidePanel.tsx`
+
+- [ ] **Step 1: Replace the approval-flow tooltip link**
+
+In `ProjectSettingsPage.tsx`, add:
+
+```tsx
+import { RouterLink } from "@/react/components/RouterLink";
+```
+
+Replace the tooltip `Button` link with:
+
+```tsx
+<RouterLink
+  to={{ name: WORKSPACE_ROUTE_CUSTOM_APPROVAL }}
+  className="text-accent underline text-left hover:text-accent-hover"
+>
+  {t("project.settings.issue-related.view-approval-flow")}
+</RouterLink>
+```
+
+- [ ] **Step 2: Replace ProjectDataExportPage banner links**
+
+Replace each Trans component route anchor shaped like this:
+
+```tsx
+<a
+  className="text-accent underline hover:text-accent-hover"
+  href={customApprovalHref}
+  onClick={(e) => {
+    e.preventDefault();
+    router.push(customApprovalHref);
+  }}
+/>
+```
+
+with this:
+
+```tsx
+<RouterLink
+  className="text-accent underline hover:text-accent-hover"
+  to={{ name: WORKSPACE_ROUTE_CUSTOM_APPROVAL }}
+/>
+```
+
+For the project settings link, use:
+
+```tsx
+<RouterLink
+  className="text-accent underline hover:text-accent-hover"
+  to={{
+    name: PROJECT_V1_ROUTE_SETTINGS,
+    params: { projectId },
+  }}
+/>
+```
+
+Then remove `projectSettingsHref` and `customApprovalHref` if they are no longer used.
+
+- [ ] **Step 3: Replace HeaderBreadcrumb workspace link**
+
+Replace:
+
+```tsx
+<a
+  href={workspaceHref}
+  className="inline-flex items-center gap-x-1.5 rounded-xs px-2 py-1 text-sm font-medium text-control hover:bg-control-bg cursor-pointer no-underline"
+  onClick={(e) => {
+    if (!e.metaKey && !e.ctrlKey) {
+      e.preventDefault();
+      void navigate.push({ name: WORKSPACE_ROUTE_LANDING });
+    }
+  }}
+>
+```
+
+with:
+
+```tsx
+<RouterLink
+  to={{ name: WORKSPACE_ROUTE_LANDING }}
+  className="inline-flex items-center gap-x-1.5 rounded-xs px-2 py-1 text-sm font-medium text-control hover:bg-control-bg cursor-pointer no-underline"
+>
+```
+
+Remove `workspaceHref` if unused.
+
+- [ ] **Step 4: Replace AsidePanel projects link**
+
+Replace the projects anchor with:
+
+```tsx
+<RouterLink
+  to={{
+    name: PROJECT_V1_ROUTE_DASHBOARD,
+    params: { projectId },
+  }}
+  className="text-accent hover:underline"
+>
+```
+
+If the existing route target differs, preserve the exact existing target object and pass it to `to`.
+
+- [ ] **Step 5: Run focused tests for touched areas when available**
+
+Run:
+
+```bash
+pnpm --dir frontend vitest run src/react/components/RouterLink.test.tsx src/react/components/header/DashboardHeader.test.tsx src/react/components/sql-editor/AsidePanel.test.tsx
+```
+
+Expected: PASS, or report if one of the named test files does not exist and continue with full frontend tests in Task 8.
+
+---
+
+## Task 4: Migrate Raw Internal Resource Links
+
+**Files:**
+- Modify: `frontend/src/react/components/sql-review/ResourceLink.tsx`
+- Modify: `frontend/src/react/pages/settings/EnvironmentsPage.tsx`
+- Modify: `frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx`
+- Modify: `frontend/src/react/components/revision/RevisionDetailPanel.tsx`
+- Modify: `frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx`
+
+- [ ] **Step 1: Replace SQL review resource links**
+
+In `ResourceLink.tsx`, replace:
+
+```tsx
+<a
+  href={`/${resource}`}
+  className="inline-flex items-center gap-x-1 normal-link"
+  onClick={(e) => {
+    e.preventDefault();
+    router.push({ path: `/${resource}` });
+  }}
+>
+```
+
+with:
+
+```tsx
+<RouterLink
+  to={{ path: `/${resource}` }}
+  className="inline-flex items-center gap-x-1 normal-link"
+>
+```
+
+For the environment link, preserve its existing class:
+
+```tsx
+<RouterLink
+  to={{ path: `/${resource}` }}
+  className="inline-flex items-center gap-x-1"
+>
+```
+
+Remove the `router` import if unused.
+
+- [ ] **Step 2: Replace EnvironmentsPage internal environment link**
+
+Preserve the existing `stopPropagation()` behavior by passing an `onClick` that does not call `preventDefault`:
+
+```tsx
+<RouterLink
+  to={{ path: `/${formatEnvironmentName(environment.id)}` }}
+  className="hover:underline"
+  onClick={(e) => {
+    e.stopPropagation();
+  }}
+>
+```
+
+- [ ] **Step 3: Replace ProjectMaskingExemptionPage user link**
+
+Replace:
+
+```tsx
+<a
+  href={`/users/${userEmail}`}
+  className="normal-link font-medium"
+  onClick={(e) => {
+    e.preventDefault();
+    router.push(`/users/${userEmail}`);
+  }}
+>
+```
+
+with:
+
+```tsx
+<RouterLink
+  to={`/users/${userEmail}`}
+  className="normal-link font-medium"
+>
+```
+
+- [ ] **Step 4: Replace task links in revision and changelog detail pages**
+
+For `taskFullLink`, replace anchors with:
+
+```tsx
+<RouterLink
+  to={{ path: taskFullLink }}
+  className="normal-link"
+>
+```
+
+Use the exact existing class names and children from each file. Remove local modifier-click guards because `RouterLink` owns that behavior.
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+pnpm --dir frontend vitest run src/react/components/RouterLink.test.tsx src/react/pages/project/DatabaseChangelogDetailPage.test.tsx
+```
+
+Expected: PASS.
+
+---
+
+## Task 5: Migrate Sidebar Navigation Links
+
+**Files:**
+- Modify: `frontend/src/react/components/ProjectSidebar.tsx`
+- Modify: `frontend/src/react/components/DashboardSidebar.tsx`
+- Test: `frontend/src/react/components/DashboardSidebar.test.tsx`
+
+- [ ] **Step 1: Replace ProjectSidebar child and leaf anchors**
+
+Replace child links:
+
+```tsx
+<a
+  key={`${parentIndex}-${j}`}
+  href={resolveHref(child.path)}
+  className={`${childRouteClass} cursor-pointer no-underline text-inherit ${classes.join(" ")}`}
+  onClick={(e) => handleItemClick(e, child.path!)}
+>
+```
+
+with:
+
+```tsx
+<RouterLink
+  key={`${parentIndex}-${j}`}
+  to={{
+    name: child.path,
+    params: { projectId },
+  }}
+  className={`${childRouteClass} cursor-pointer no-underline text-inherit ${classes.join(" ")}`}
+>
+```
+
+Replace leaf links the same way with `item.path`.
+
+- [ ] **Step 2: Replace ProjectSidebar home link**
+
+Use the existing resolved home route target if available. If only `homeHref` exists, introduce a `homeRoute` value:
+
+```tsx
+const homeRoute = resolveHomeRouteTarget();
+```
+
+Then render:
+
+```tsx
+<RouterLink to={homeRoute} className="p-2 shrink-0 m-auto cursor-pointer">
+```
+
+If the file only has `resolveHomeRoute().fullPath`, use:
+
+```tsx
+<RouterLink to={homeHref} className="p-2 shrink-0 m-auto cursor-pointer">
+```
+
+- [ ] **Step 3: Remove obsolete click helpers**
+
+Remove `handleItemClick`, `handleHomeClick`, and `resolveHref` only if no longer used by group toggles or other code.
+
+- [ ] **Step 4: Replace DashboardSidebar anchors**
+
+Apply the same pattern to DashboardSidebar route anchors:
+
+```tsx
+<RouterLink
+  to={{ name: child.name }}
+  className={existingClassName}
+>
+```
+
+Preserve active route class calculation and all icon/text children.
+
+- [ ] **Step 5: Run sidebar tests**
+
+Run:
+
+```bash
+pnpm --dir frontend vitest run src/react/components/DashboardSidebar.test.tsx
+```
+
+Expected: PASS.
+
+---
+
+## Task 6: Review Table and Row-Link Candidates Before Migrating
+
+**Files:**
+- Review: `frontend/src/react/components/IssueTable.tsx`
+- Review: `frontend/src/react/pages/project/ProjectDataExportPage.tsx`
+- Review: `frontend/src/react/components/ProjectTable.tsx`
+
+- [ ] **Step 1: Identify nested anchor and row-click behavior**
+
+For each table, list whether it has:
+
+```text
+- row-level onClick navigation
+- nested anchor links inside that row
+- stopPropagation calls
+- href="#" action controls
+```
+
+- [ ] **Step 2: Migrate only safe nested anchors**
+
+Only replace anchors that already have a real internal `href` and route to the same destination as the anchor:
+
+```tsx
+<RouterLink to={issueUrl} className="font-medium text-main text-base hover:underline min-w-0 block">
+```
+
+Do not migrate `href="#"` controls in this task.
+
+- [ ] **Step 3: Convert action-only href="#" controls separately**
+
+For action controls that do not represent navigation, use `Button` or a real `<button>` according to surrounding patterns. Do not use `RouterLink`.
+
+- [ ] **Step 4: Run table tests**
+
+Run:
+
+```bash
+pnpm --dir frontend vitest run src/react/components/IssueTable.test.tsx src/react/components/ProjectTable.test.tsx
+```
+
+Expected: PASS.
+
+---
+
+## Task 7: Review Href-Only Internal Anchors
+
+**Files:**
+- Review: `frontend/src/react/pages/project/issue-detail/components/IssueDetailCommentList.tsx`
+- Review: `frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx`
+- Review: `frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx`
+- Review: `frontend/src/react/pages/project/issue-detail/components/IssueDetailLabels.tsx`
+- Review: `frontend/src/react/pages/settings/GroupsPage.tsx`
+
+- [ ] **Step 1: Check whether SPA interception is desirable**
+
+For each href-only internal anchor, confirm it is not intentionally doing a full-page load.
+
+- [ ] **Step 2: Migrate only same-tab app navigation**
+
+Replace safe anchors with:
+
+```tsx
+<RouterLink to={existingRouteTargetOrPath} className={existingClassName}>
+  {existingChildren}
+</RouterLink>
+```
+
+Do not migrate anchors with:
+
+```tsx
+target="_blank"
+download
+href starting with "http"
+href starting with "mailto:"
+```
+
+- [ ] **Step 3: Run focused issue-detail tests**
+
+Run:
+
+```bash
+pnpm --dir frontend vitest run src/react/pages/project/plan-detail/components/PlanDetailApprovalFlow.test.tsx src/react/pages/project/ProjectIssueDetailPage.test.tsx
+```
+
+Expected: PASS, or report unavailable focused coverage and rely on full tests in Task 8.
+
+---
+
+## Task 8: Full Frontend Verification
+
+**Files:**
+- Verify all modified frontend files.
+
+- [ ] **Step 1: Run frontend autofix**
+
+Run:
+
+```bash
+pnpm --dir frontend fix
+```
+
+Expected: exit 0.
+
+- [ ] **Step 2: Run frontend check**
+
+Run:
+
+```bash
+pnpm --dir frontend check
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run frontend type-check**
+
+Run:
+
+```bash
+pnpm --dir frontend type-check
+```
+
+Expected: exit 0.
+
+- [ ] **Step 4: Run frontend tests**
+
+Run:
+
+```bash
+pnpm --dir frontend test
+```
+
+Expected: exit 0.
+
+---
+
+## Self-Review
+
+- Spec coverage: The plan adds `RouterLink`, migrates the approval tooltip, and includes all strong candidates reported by the subagents: project/sidebar/dashboard/header/data-export/resource/environment/masking/revision/changelog links.
+- Guardrails: External links, `mailto:`, `download`, `target="_blank"`, and `href="#"` action controls are explicitly excluded from automatic RouterLink migration.
+- Type consistency: The component uses the existing `RouteTarget` type and `router.resolve`/`router.push` APIs from `@/react/router`.

--- a/frontend/src/react/components/AuditLogTable.tsx
+++ b/frontend/src/react/components/AuditLogTable.tsx
@@ -14,6 +14,7 @@ import {
   type ValueOption,
 } from "@/react/components/AdvancedSearch";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
+import { RouterLink } from "@/react/components/RouterLink";
 import { TimeRangePicker } from "@/react/components/TimeRangePicker";
 import { Button } from "@/react/components/ui/button";
 import {
@@ -162,9 +163,9 @@ function AuditLogViewCell({ log }: { log: AuditLog }) {
   if (!target) return null;
   const href = target.startsWith("/") ? target : `/${target}`;
   return (
-    <a href={href} target="_blank" rel="noreferrer">
+    <RouterLink to={href} target="_blank" rel="noreferrer">
       <ExternalLink className="size-4 text-accent" />
-    </a>
+    </RouterLink>
   );
 }
 

--- a/frontend/src/react/components/BannersWrapper.test.tsx
+++ b/frontend/src/react/components/BannersWrapper.test.tsx
@@ -15,7 +15,7 @@ import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
 const mocks = vi.hoisted(() => ({
   getMinimumRequiredPlan: vi.fn(),
   isDev: vi.fn(),
-  navigatePush: vi.fn(),
+  routerPush: vi.fn(),
   t: vi.fn(),
   urlfy: vi.fn((value: string) => `https://${value}`),
   useAppStore: vi.fn(),
@@ -79,9 +79,10 @@ vi.mock("@/react/hooks/useAppState", () => ({
 vi.mock("@/react/router", () => ({
   SETTING_ROUTE_WORKSPACE_GENERAL: "setting.workspace.general",
   SETTING_ROUTE_WORKSPACE_SUBSCRIPTION: "setting.workspace.subscription",
-  useNavigate: () => ({
-    push: mocks.navigatePush,
-  }),
+  router: {
+    push: mocks.routerPush,
+    resolve: (to: unknown) => ({ href: String(to), fullPath: String(to) }),
+  },
 }));
 
 vi.mock("@/react/stores/app", () => ({
@@ -124,7 +125,7 @@ beforeEach(async () => {
   mocks.getMinimumRequiredPlan.mockReturnValue(PlanType.FREE);
   mocks.isDev.mockReset();
   mocks.isDev.mockReturnValue(false);
-  mocks.navigatePush.mockReset();
+  mocks.routerPush.mockReset();
   mocks.t.mockReset();
   mocks.t.mockImplementation(interpolate);
   mocks.urlfy.mockClear();
@@ -180,16 +181,16 @@ describe("BannersWrapper", () => {
       "Bytebase has not configured --external-url"
     );
 
-    const configureButton = Array.from(
-      container.querySelectorAll("button")
-    ).find((button) => button.textContent?.includes("Configure now"));
+    const configureButton = Array.from(container.querySelectorAll("a")).find(
+      (link) => link.textContent?.includes("Configure now")
+    );
     act(() => {
       configureButton?.dispatchEvent(
-        new MouseEvent("click", { bubbles: true })
+        new MouseEvent("click", { bubbles: true, cancelable: true })
       );
     });
 
-    expect(mocks.navigatePush).toHaveBeenCalledWith({
+    expect(mocks.routerPush).toHaveBeenCalledWith({
       name: "setting.workspace.general",
     });
     unmount();

--- a/frontend/src/react/components/BannersWrapper.tsx
+++ b/frontend/src/react/components/BannersWrapper.tsx
@@ -8,7 +8,8 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
-import { Button } from "@/react/components/ui/button";
+import { RouterLink } from "@/react/components/RouterLink";
+import { Button, buttonVariants } from "@/react/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -24,7 +25,6 @@ import {
 import {
   SETTING_ROUTE_WORKSPACE_GENERAL,
   SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
-  useNavigate,
 } from "@/react/router";
 import { useAppStore } from "@/react/stores/app";
 import {
@@ -79,7 +79,6 @@ function BannerDismissButton({
 
 function BannerExternalUrl() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const hasPermission = useWorkspacePermission(
     "bb.settings.setWorkspaceProfile"
   );
@@ -98,16 +97,16 @@ function BannerExternalUrl() {
           </div>
           {hasPermission ? (
             <div className="order-3 mt-2 w-full shrink-0 sm:order-2 sm:mt-0 sm:w-auto">
-              <Button
-                type="button"
-                className="h-auto rounded-md bg-white py-2 pr-2 pl-4 text-base font-medium text-accent shadow-xs hover:bg-indigo-50"
-                onClick={() => {
-                  void navigate.push({ name: SETTING_ROUTE_WORKSPACE_GENERAL });
-                }}
+              <RouterLink
+                to={{ name: SETTING_ROUTE_WORKSPACE_GENERAL }}
+                className={buttonVariants({
+                  className:
+                    "h-auto rounded-md bg-white py-2 pr-2 pl-4 text-base font-medium text-accent shadow-xs hover:bg-indigo-50",
+                })}
               >
                 {t("common.configure-now")}
                 <Wrench className="ml-1 size-5" />
-              </Button>
+              </RouterLink>
             </div>
           ) : null}
           <div className="order-2 -mr-1 shrink-0 sm:order-3 sm:ml-3">
@@ -124,7 +123,6 @@ function BannerExternalUrl() {
 
 function BannerSubscription() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const { currentPlan, daysBeforeExpire, expireAt, isExpired, isTrialing } =
     useSubscriptionState();
 
@@ -161,14 +159,9 @@ function BannerSubscription() {
           <p className="ml-3 truncate text-base font-medium text-white">
             {content}
           </p>
-          <button
-            type="button"
+          <RouterLink
+            to={{ name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION }}
             className="flex cursor-pointer items-center justify-center py-1 text-base font-medium text-white underline hover:opacity-80"
-            onClick={() => {
-              void navigate.push({
-                name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
-              });
-            }}
           >
             {t(
               isTrialing
@@ -176,7 +169,7 @@ function BannerSubscription() {
                 : "subscription.purchase.update"
             )}
             <ShoppingCart className="ml-1 size-5 text-white" />
-          </button>
+          </RouterLink>
         </div>
       </div>
     </div>
@@ -231,7 +224,6 @@ function BannerAnnouncement() {
 
 function BannerUpgradeSubscription() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const { serverInfo } = useServerState();
   const { currentPlan } = useSubscriptionState();
   const getMinimumRequiredPlan = useAppStore(
@@ -260,7 +252,6 @@ function BannerUpgradeSubscription() {
 
   const gotoSubscriptionPage = () => {
     setShowModal(false);
-    void navigate.push({ name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION });
   };
 
   if (!showBanner) return null;
@@ -293,10 +284,14 @@ function BannerUpgradeSubscription() {
               />
             </div>
             <div className="ml-2">
-              <Button size="sm" onClick={gotoSubscriptionPage}>
+              <RouterLink
+                to={{ name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION }}
+                className={buttonVariants({ size: "sm" })}
+                onClick={gotoSubscriptionPage}
+              >
                 <Sparkles className="h-auto w-4" />
                 {t("subscription.upgrade")}
-              </Button>
+              </RouterLink>
             </div>
           </div>
         </div>
@@ -328,9 +323,13 @@ function BannerUpgradeSubscription() {
               </ul>
             </div>
             <div className="mt-3 mb-4 w-full">
-              <Button className="w-full" onClick={gotoSubscriptionPage}>
+              <RouterLink
+                to={{ name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION }}
+                className={buttonVariants({ className: "w-full" })}
+                onClick={gotoSubscriptionPage}
+              >
                 {t("subscription.upgrade-now")}
-              </Button>
+              </RouterLink>
             </div>
           </div>
         </DialogContent>

--- a/frontend/src/react/components/DashboardSidebar.test.tsx
+++ b/frontend/src/react/components/DashboardSidebar.test.tsx
@@ -26,9 +26,27 @@ const mocks = vi.hoisted(() => ({
   workspaceLogo: "",
   record: vi.fn(),
   push: vi.fn(),
-  resolve: vi.fn(({ name }: { name: string }) => ({
-    fullPath: `/${name}`,
-  })),
+  resolve: vi.fn((target: string | { name?: string; path?: string }) => {
+    const routePathByName: Record<string, string> = {
+      "sql-editor.home": "/sql-editor",
+      "workspace.database": "/databases",
+      "workspace.environment": "/environments",
+      "workspace.instance": "/instances",
+      "workspace.landing": "/landing",
+      "workspace.project": "/projects",
+    };
+    const href =
+      typeof target === "string"
+        ? target
+        : (target.path ??
+          (target.name
+            ? (routePathByName[target.name] ?? `/${target.name}`)
+            : "/"));
+    return {
+      href,
+      fullPath: href,
+    };
+  }),
 }));
 
 const t = vi.hoisted(
@@ -87,6 +105,10 @@ vi.mock("@/react/router", () => ({
     push: mocks.push,
     resolve: mocks.resolve,
   }),
+  router: {
+    push: mocks.push,
+    resolve: mocks.resolve,
+  },
   DATABASE_ROUTE_DASHBOARD: "workspace.database",
   ENVIRONMENT_V1_ROUTE_DASHBOARD: "workspace.environment",
   INSTANCE_ROUTE_DASHBOARD: "workspace.instance",
@@ -188,7 +210,7 @@ describe("DashboardSidebar", () => {
     render();
 
     const logoLink = container.querySelector<HTMLAnchorElement>("nav > a");
-    expect(logoLink?.getAttribute("href")).toBe(`/${SQL_EDITOR_HOME_MODULE}`);
+    expect(logoLink?.getAttribute("href")).toBe("/sql-editor");
     expect(logoLink?.querySelector("img")?.getAttribute("src")).toBe(
       "https://example.com/logo.png"
     );
@@ -199,7 +221,7 @@ describe("DashboardSidebar", () => {
       );
     });
 
-    expect(mocks.record).toHaveBeenCalledWith(`/${SQL_EDITOR_HOME_MODULE}`);
+    expect(mocks.record).toHaveBeenCalledWith("/sql-editor");
     expect(mocks.push).toHaveBeenCalledWith({ name: SQL_EDITOR_HOME_MODULE });
 
     unmount();
@@ -220,7 +242,7 @@ describe("DashboardSidebar", () => {
     unmount();
   });
 
-  test("leaves modifier-click navigation to the browser", () => {
+  test("leaves modified and middle-click route navigation to the browser", () => {
     const { container, render, unmount } = renderIntoContainer(
       <DashboardSidebar />
     );
@@ -229,13 +251,27 @@ describe("DashboardSidebar", () => {
     const projectsLink = Array.from(container.querySelectorAll("a")).find(
       (link) => link.textContent?.includes("Projects")
     );
-    projectsLink?.addEventListener("click", (event) => event.preventDefault());
-    const event = new MouseEvent("click", {
-      bubbles: true,
-      cancelable: true,
-      ctrlKey: true,
-    });
-    projectsLink?.dispatchEvent(event);
+    expect(projectsLink).toBeInstanceOf(HTMLAnchorElement);
+
+    const clickOptions: MouseEventInit[] = [
+      { ctrlKey: true },
+      { metaKey: true },
+      { shiftKey: true },
+      { altKey: true },
+      { button: 1 },
+    ];
+
+    for (const options of clickOptions) {
+      const event = new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        button: 0,
+        ...options,
+      });
+      projectsLink?.dispatchEvent(event);
+
+      expect(event.defaultPrevented).toBe(false);
+    }
 
     expect(mocks.push).not.toHaveBeenCalled();
 

--- a/frontend/src/react/components/DashboardSidebar.tsx
+++ b/frontend/src/react/components/DashboardSidebar.tsx
@@ -16,6 +16,7 @@ import type { ElementType } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import logoFull from "@/assets/logo-full.svg";
+import { RouterLink } from "@/react/components/RouterLink";
 import {
   useAppFeature,
   useIsSaaSMode,
@@ -27,11 +28,11 @@ import {
   ENVIRONMENT_V1_ROUTE_DASHBOARD,
   INSTANCE_ROUTE_DASHBOARD,
   PROJECT_V1_ROUTE_DASHBOARD,
+  router,
   SETTING_ROUTE_WORKSPACE_GENERAL,
   SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
   SQL_EDITOR_HOME_MODULE,
   useCurrentRoute,
-  useNavigate,
   WORKSPACE_ROUTE_AUDIT_LOG,
   WORKSPACE_ROUTE_CUSTOM_APPROVAL,
   WORKSPACE_ROUTE_DATA_CLASSIFICATION,
@@ -296,7 +297,6 @@ const childRouteClass =
 export function DashboardSidebar() {
   const rawItems = useSidebarItems();
   const filteredItems = useMemo(() => filterSidebarList(rawItems), [rawItems]);
-  const navigate = useNavigate();
   const currentRoute = useCurrentRoute();
   const databaseChangeMode = useAppFeature("bb.feature.database-change-mode");
   const workspace = useWorkspace();
@@ -362,16 +362,15 @@ export function DashboardSidebar() {
 
   // -- Navigation ------------------------------------------------------------
 
-  const resolveHomeRoute = useCallback(() => {
+  const homeRoute = useMemo(() => {
     const target =
       databaseChangeMode === DatabaseChangeMode.EDITOR
         ? SQL_EDITOR_HOME_MODULE
         : WORKSPACE_ROUTE_LANDING;
     return {
       name: target,
-      route: navigate.resolve({ name: target }),
     };
-  }, [databaseChangeMode, navigate]);
+  }, [databaseChangeMode]);
 
   const onGroupClick = useCallback((item: SidebarItem, key: string) => {
     if (item.children && item.children.length > 0) {
@@ -389,38 +388,14 @@ export function DashboardSidebar() {
     }
   }, []);
 
-  const resolveHref = useCallback(
-    (name: string) => navigate.resolve({ name }).fullPath,
-    [navigate]
-  );
-
-  const handleRouteClick = useCallback(
-    (e: React.MouseEvent, name: string) => {
-      // Allow Ctrl/Meta+click to open in new tab naturally.
-      if (e.ctrlKey || e.metaKey) return;
-      e.preventDefault();
-      void navigate.push({ name });
-    },
-    [navigate]
-  );
-
-  const handleHomeClick = useCallback(
-    (e: React.MouseEvent<HTMLAnchorElement>) => {
-      const { name, route } = resolveHomeRoute();
-      record(route.fullPath);
-      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
-        return;
-      }
-      e.preventDefault();
-      void navigate.push({ name });
-    },
-    [navigate, record, resolveHomeRoute]
-  );
+  const handleHomeClick = useCallback(() => {
+    const route = router.resolve(homeRoute);
+    record(route.fullPath);
+  }, [homeRoute, record]);
 
   // -- Logo ------------------------------------------------------------------
 
   const logoSrc = workspace?.logo || logoFull;
-  const homeHref = resolveHomeRoute().route.fullPath;
 
   // -- Render ----------------------------------------------------------------
 
@@ -431,14 +406,15 @@ export function DashboardSidebar() {
           const classes = getItemClass(child, currentRouteName);
           if (child.type === "route" && child.name) {
             return (
-              <a
+              <RouterLink
                 key={`${parentIndex}-${j}`}
-                href={resolveHref(child.name)}
+                to={{
+                  name: child.name,
+                }}
                 className={`${childRouteClass} cursor-pointer no-underline text-inherit ${classes.join(" ")}`}
-                onClick={(e) => handleRouteClick(e, child.name!)}
               >
                 {child.title}
-              </a>
+              </RouterLink>
             );
           }
           if (child.type === "div") {
@@ -474,15 +450,16 @@ export function DashboardSidebar() {
       const classes = getItemClass(item, currentRouteName);
       const Icon = item.icon;
       return (
-        <a
+        <RouterLink
           key={index}
-          href={resolveHref(item.name)}
+          to={{
+            name: item.name,
+          }}
           className={`${parentRouteClass} cursor-pointer no-underline text-inherit ${classes.join(" ")}`}
-          onClick={(e) => handleRouteClick(e, item.name!)}
         >
           {Icon && <Icon className="mr-2 w-5 h-5 text-gray-500" />}
           {item.title}
-        </a>
+        </RouterLink>
       );
     }
 
@@ -519,13 +496,13 @@ export function DashboardSidebar() {
 
   return (
     <nav className="flex-1 flex flex-col overflow-y-hidden border-r border-block-border">
-      <a
-        href={homeHref}
+      <RouterLink
+        to={homeRoute}
         className="p-2 shrink-0 m-auto cursor-pointer"
         onClick={handleHomeClick}
       >
         <img src={logoSrc} alt="Bytebase" className="max-w-44" />
-      </a>
+      </RouterLink>
       <div className="flex-1 overflow-y-auto px-2.5 pb-4 flex flex-col gap-y-1">
         {filteredItems.map((item, i) => renderItem(item, i))}
       </div>

--- a/frontend/src/react/components/FeatureBadge.tsx
+++ b/frontend/src/react/components/FeatureBadge.tsx
@@ -1,6 +1,7 @@
 import { Lock, Sparkles } from "lucide-react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { useSubscriptionState } from "@/react/hooks/useAppState";
 import { useAppStore } from "@/react/stores/app";
 import type {
@@ -88,12 +89,12 @@ export function FeatureBadge({
   if (clickable) {
     return (
       <Tooltip content={tooltip}>
-        <a
-          href="/setting/subscription"
+        <RouterLink
+          to="/setting/subscription"
           className={className ?? "text-accent inline-flex"}
         >
           <Sparkles className="w-5 h-5" />
-        </a>
+        </RouterLink>
       </Tooltip>
     );
   }

--- a/frontend/src/react/components/IssueTable.tsx
+++ b/frontend/src/react/components/IssueTable.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/react/components/AdvancedSearch";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
 import { HumanizeTs } from "@/react/components/HumanizeTs";
+import { RouterLink } from "@/react/components/RouterLink";
 import { SelectionActionBar } from "@/react/components/SelectionActionBar";
 import { TimeRangePicker } from "@/react/components/TimeRangePicker";
 import { Button } from "@/react/components/ui/button";
@@ -650,8 +651,8 @@ export const IssueListItem = memo(function IssueListItem({
               <IssueStatusIcon status={issue.status} />
             </div>
             {issue.title ? (
-              <a
-                href={issueUrl}
+              <RouterLink
+                to={issueUrl}
                 className="font-medium text-main text-base hover:underline min-w-0 block"
                 onClick={(e) => e.stopPropagation()}
               >
@@ -661,15 +662,15 @@ export const IssueListItem = memo(function IssueListItem({
                     keyword={highlightWords}
                   />
                 </EllipsisText>
-              </a>
+              </RouterLink>
             ) : (
-              <a
-                href={issueUrl}
+              <RouterLink
+                to={issueUrl}
                 className="font-medium text-base truncate hover:underline italic text-control-placeholder"
                 onClick={(e) => e.stopPropagation()}
               >
                 {t("common.untitled")}
-              </a>
+              </RouterLink>
             )}
             <RiskLevelIcon riskLevel={issue.riskLevel} />
             {labels.map((label: Label) => (
@@ -691,41 +692,35 @@ export const IssueListItem = memo(function IssueListItem({
             {t("common.created")}
             <HumanizeTs ts={createTimeTs} />
             <span>&middot;</span>
-            <a
+            <RouterLink
               className="hover:underline"
-              href="#"
+              to={{
+                name: WORKSPACE_ROUTE_USER_PROFILE,
+                params: { principalEmail: creator.email },
+              }}
               onClick={(e) => {
-                e.preventDefault();
                 e.stopPropagation();
-                router.push({
-                  name: WORKSPACE_ROUTE_USER_PROFILE,
-                  params: { principalEmail: creator.email },
-                });
               }}
             >
               {creator.title}
-            </a>
+            </RouterLink>
             {showProject && issueProject && (
               <>
                 <span>&middot;</span>
-                <a
+                <RouterLink
                   className="hover:underline"
-                  href="#"
+                  to={{
+                    name: PROJECT_V1_ROUTE_DETAIL,
+                    params: {
+                      projectId: extractProjectResourceName(issueProject.name),
+                    },
+                  }}
                   onClick={(e) => {
-                    e.preventDefault();
                     e.stopPropagation();
-                    router.push({
-                      name: PROJECT_V1_ROUTE_DETAIL,
-                      params: {
-                        projectId: extractProjectResourceName(
-                          issueProject.name
-                        ),
-                      },
-                    });
                   }}
                 >
                   {issueProject.title}
-                </a>
+                </RouterLink>
               </>
             )}
           </div>

--- a/frontend/src/react/components/ProjectSidebar.tsx
+++ b/frontend/src/react/components/ProjectSidebar.tsx
@@ -12,6 +12,7 @@ import type { ElementType } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import logoFull from "@/assets/logo-full.svg";
+import { RouterLink } from "@/react/components/RouterLink";
 import { useWorkspace } from "@/react/hooks/useAppState";
 import { useRecentVisit } from "@/react/hooks/useRecentVisit";
 import { router, useCurrentRoute } from "@/react/router";
@@ -328,56 +329,33 @@ export function ProjectSidebar() {
     }
   }, []);
 
-  const resolveHref = useCallback(
-    (path: string) =>
-      router.resolve({
-        name: path,
-        params: { projectId },
-      }).fullPath,
-    [projectId]
-  );
-
-  const handleItemClick = useCallback(
-    (e: React.MouseEvent, path: string) => {
+  const recordItemVisit = useCallback(
+    (path: string) => {
       const route = router.resolve({
         name: path,
         params: { projectId },
       });
       recordVisitRef.current?.(route.fullPath);
-      if (e.ctrlKey || e.metaKey) {
-        // Let the browser's native <a> Ctrl/Meta-click handle new-tab opening.
-        return;
-      }
-      e.preventDefault();
-      router.push(route);
     },
     [projectId]
   );
 
-  const resolveHomeRoute = useCallback(() => {
-    return router.resolve({
+  const homeRoute = useMemo(
+    () => ({
       name: PROJECT_V1_ROUTE_DETAIL,
       params: { projectId },
-    });
-  }, [projectId]);
-
-  const handleHomeClick = useCallback(
-    (e: React.MouseEvent<HTMLAnchorElement>) => {
-      const route = resolveHomeRoute();
-      recordVisitRef.current?.(route.fullPath);
-      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) {
-        return;
-      }
-      e.preventDefault();
-      router.push(route);
-    },
-    [resolveHomeRoute]
+    }),
+    [projectId]
   );
+
+  const handleHomeClick = useCallback(() => {
+    const route = router.resolve(homeRoute);
+    recordVisitRef.current?.(route.fullPath);
+  }, [homeRoute]);
 
   // -- Logo ------------------------------------------------------------------
 
   const logoSrc = customLogo || logoFull;
-  const homeHref = resolveHomeRoute().fullPath;
 
   // -- Render ----------------------------------------------------------------
 
@@ -388,14 +366,17 @@ export function ProjectSidebar() {
           const classes = getItemClass(child, currentRouteName);
           if (child.path) {
             return (
-              <a
+              <RouterLink
                 key={`${parentIndex}-${j}`}
-                href={resolveHref(child.path)}
+                to={{
+                  name: child.path,
+                  params: { projectId },
+                }}
                 className={`${childRouteClass} cursor-pointer no-underline text-inherit ${classes.join(" ")}`}
-                onClick={(e) => handleItemClick(e, child.path!)}
+                onClick={() => recordItemVisit(child.path!)}
               >
                 {child.title}
-              </a>
+              </RouterLink>
             );
           }
           return null;
@@ -414,15 +395,18 @@ export function ProjectSidebar() {
     if (!hasChildren && item.path) {
       const classes = getItemClass(item, currentRouteName);
       return (
-        <a
+        <RouterLink
           key={index}
-          href={resolveHref(item.path)}
+          to={{
+            name: item.path,
+            params: { projectId },
+          }}
           className={`${parentRouteClass} cursor-pointer no-underline text-inherit ${classes.join(" ")}`}
-          onClick={(e) => handleItemClick(e, item.path!)}
+          onClick={() => recordItemVisit(item.path!)}
         >
           {Icon && <Icon className="mr-2 w-5 h-5 text-gray-500" />}
           {item.title}
-        </a>
+        </RouterLink>
       );
     }
 
@@ -453,13 +437,13 @@ export function ProjectSidebar() {
 
   return (
     <nav className="flex-1 flex flex-col overflow-y-hidden border-r border-block-border">
-      <a
-        href={homeHref}
+      <RouterLink
+        to={homeRoute}
         className="p-2 shrink-0 m-auto cursor-pointer"
         onClick={handleHomeClick}
       >
         <img src={logoSrc} alt="Bytebase" className="max-w-44" />
-      </a>
+      </RouterLink>
       <div className="flex-1 overflow-y-auto px-2.5 pb-4 flex flex-col gap-y-1">
         {filteredItems.map((item, i) => renderItem(item, i))}
       </div>

--- a/frontend/src/react/components/ProjectTable.tsx
+++ b/frontend/src/react/components/ProjectTable.tsx
@@ -3,6 +3,7 @@ import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { memo, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Badge } from "@/react/components/ui/badge";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
@@ -355,12 +356,16 @@ const ProjectRowView = memo(function ProjectRowView({
         </TableCell>
       ) : null}
       <TableCell>
-        {rowHref ? (
-          <a
-            href={rowHref}
+        {rowHref && clickable ? (
+          <RouterLink
+            to={rowHref}
             className="block hover:underline"
-            onClick={clickable ? handleRowLinkClick : undefined}
+            onClick={handleRowLinkClick}
           >
+            {resourceIdContent}
+          </RouterLink>
+        ) : rowHref ? (
+          <a href={rowHref} className="block hover:underline">
             {resourceIdContent}
           </a>
         ) : (
@@ -369,12 +374,16 @@ const ProjectRowView = memo(function ProjectRowView({
       </TableCell>
       <TableCell>
         <div className="flex items-center gap-x-2 min-w-0">
-          {rowHref ? (
-            <a
-              href={rowHref}
+          {rowHref && clickable ? (
+            <RouterLink
+              to={rowHref}
               className="min-w-0 block hover:underline"
-              onClick={clickable ? handleRowLinkClick : undefined}
+              onClick={handleRowLinkClick}
             >
+              {titleContent}
+            </RouterLink>
+          ) : rowHref ? (
+            <a href={rowHref} className="min-w-0 block hover:underline">
               {titleContent}
             </a>
           ) : (

--- a/frontend/src/react/components/Quickstart.tsx
+++ b/frontend/src/react/components/Quickstart.tsx
@@ -1,9 +1,9 @@
 import { CheckCircle, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { cn } from "@/react/lib/utils";
 import type { RouteTarget } from "@/react/router";
-import { useNavigate } from "@/react/router";
 import {
   DATABASE_ROUTE_DASHBOARD,
   ENVIRONMENT_V1_ROUTE_DASHBOARD,
@@ -60,7 +60,6 @@ interface IntroItem {
  */
 export function Quickstart() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const loadProjectIamPolicy = useAppStore(
     (state) => state.loadProjectIamPolicy
   );
@@ -315,9 +314,9 @@ export function Quickstart() {
           {introList.map((intro, index) => {
             const active = isTaskActive(index);
             return (
-              <button
+              <RouterLink
                 key={`${intro.name}-${index}`}
-                type="button"
+                to={intro.link}
                 className={cn(
                   "group cursor-pointer flex items-center gap-x-1 text-sm font-medium",
                   index === 0 && "justify-start",
@@ -328,9 +327,6 @@ export function Quickstart() {
                     : "text-control-light group-hover:text-control-light-hover",
                   intro.done && "line-through"
                 )}
-                onClick={() => {
-                  void navigate.push(intro.link);
-                }}
               >
                 <span className="relative h-5 w-5 inline-flex items-center justify-center">
                   {intro.done ? (
@@ -351,7 +347,7 @@ export function Quickstart() {
                   )}
                 </span>
                 <span className="inline-flex">{intro.name}</span>
-              </button>
+              </RouterLink>
             );
           })}
         </div>

--- a/frontend/src/react/components/RouterLink.test.tsx
+++ b/frontend/src/react/components/RouterLink.test.tsx
@@ -1,0 +1,210 @@
+import type { ReactElement, MouseEvent as ReactMouseEvent } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { RouteTarget } from "@/react/router";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  resolve: vi.fn(() => ({
+    href: "/projects/default",
+    fullPath: "/projects/default",
+  })),
+}));
+
+vi.mock("@/react/router", () => ({
+  router: {
+    push: mocks.push,
+    resolve: mocks.resolve,
+  },
+}));
+
+let RouterLink: typeof import("./RouterLink").RouterLink;
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  return {
+    container,
+    render: () => {
+      act(() => {
+        root.render(element);
+      });
+    },
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
+};
+
+function getLink(container: HTMLElement): HTMLAnchorElement {
+  const link = container.querySelector("a");
+  expect(link).toBeInstanceOf(HTMLAnchorElement);
+  return link as HTMLAnchorElement;
+}
+
+function click(
+  link: HTMLAnchorElement,
+  options: MouseEventInit = {}
+): MouseEvent {
+  const event = new MouseEvent("click", {
+    bubbles: true,
+    cancelable: true,
+    button: 0,
+    ...options,
+  });
+  act(() => {
+    link.dispatchEvent(event);
+  });
+  return event;
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  mocks.resolve.mockReturnValue({
+    href: "/projects/default?tab=issues",
+    fullPath: "/projects/default?tab=issues",
+  });
+  ({ RouterLink } = await import("./RouterLink"));
+});
+
+describe("RouterLink", () => {
+  test("renders resolved href", () => {
+    const to: RouteTarget = {
+      name: "project.detail",
+      params: { projectId: "default" },
+    };
+    const { container, render, unmount } = renderIntoContainer(
+      <RouterLink to={to}>Project</RouterLink>
+    );
+    render();
+
+    const link = getLink(container);
+    expect(mocks.resolve).toHaveBeenCalledWith(to);
+    expect(link.getAttribute("href")).toBe("/projects/default?tab=issues");
+    expect(link.textContent).toBe("Project");
+    unmount();
+  });
+
+  test("normal click calls router.push(to) and prevents default", () => {
+    const to: RouteTarget = "/projects/default";
+    const { container, render, unmount } = renderIntoContainer(
+      <RouterLink to={to}>Project</RouterLink>
+    );
+    render();
+
+    const event = click(getLink(container));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.push).toHaveBeenCalledWith(to);
+    unmount();
+  });
+
+  test("meta or ctrl click does not route", () => {
+    mocks.resolve.mockReturnValue({
+      href: "#project",
+      fullPath: "#project",
+    });
+    const to: RouteTarget = "/projects/default";
+    for (const modifier of [{ metaKey: true }, { ctrlKey: true }]) {
+      const { container, render, unmount } = renderIntoContainer(
+        <RouterLink to={to}>Project</RouterLink>
+      );
+      render();
+
+      const event = click(getLink(container), modifier);
+
+      expect(event.defaultPrevented).toBe(false);
+      unmount();
+    }
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
+  test("middle click does not route", () => {
+    mocks.resolve.mockReturnValue({
+      href: "#project",
+      fullPath: "#project",
+    });
+    const to: RouteTarget = "/projects/default";
+    const { container, render, unmount } = renderIntoContainer(
+      <RouterLink to={to}>Project</RouterLink>
+    );
+    render();
+
+    const event = click(getLink(container), { button: 1 });
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(mocks.push).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test('target="_blank" does not route', () => {
+    mocks.resolve.mockReturnValue({
+      href: "#project",
+      fullPath: "#project",
+    });
+    const to: RouteTarget = "/projects/default";
+    const { container, render, unmount } = renderIntoContainer(
+      <RouterLink to={to} target="_blank">
+        Project
+      </RouterLink>
+    );
+    render();
+
+    const event = click(getLink(container));
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(mocks.push).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test("onClick runs before routing", () => {
+    const order: string[] = [];
+    mocks.push.mockImplementation(() => {
+      order.push("push");
+    });
+    const to: RouteTarget = "/projects/default";
+    const { container, render, unmount } = renderIntoContainer(
+      <RouterLink
+        to={to}
+        onClick={() => {
+          order.push("onClick");
+        }}
+      >
+        Project
+      </RouterLink>
+    );
+    render();
+
+    click(getLink(container));
+
+    expect(order).toEqual(["onClick", "push"]);
+    unmount();
+  });
+
+  test("onClick preventDefault skips routing", () => {
+    const to: RouteTarget = "/projects/default";
+    const { container, render, unmount } = renderIntoContainer(
+      <RouterLink
+        to={to}
+        onClick={(event: ReactMouseEvent<HTMLAnchorElement>) => {
+          event.preventDefault();
+        }}
+      >
+        Project
+      </RouterLink>
+    );
+    render();
+
+    const event = click(getLink(container));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mocks.push).not.toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/frontend/src/react/components/RouterLink.tsx
+++ b/frontend/src/react/components/RouterLink.tsx
@@ -1,0 +1,52 @@
+import type { AnchorHTMLAttributes, MouseEvent, ReactNode } from "react";
+import { type RouteTarget, router } from "@/react/router";
+
+export type RouterLinkProps = Omit<
+  AnchorHTMLAttributes<HTMLAnchorElement>,
+  "href"
+> & {
+  to: RouteTarget;
+  children?: ReactNode;
+};
+
+export function RouterLink({
+  to,
+  children,
+  onClick,
+  target,
+  download,
+  ...props
+}: RouterLinkProps) {
+  const href = router.resolve(to).href;
+
+  const handleClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onClick?.(event);
+    if (
+      event.defaultPrevented ||
+      event.metaKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
+      event.altKey ||
+      event.button !== 0 ||
+      (target && target !== "_self") ||
+      download != null
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    router.push(to);
+  };
+
+  return (
+    <a
+      {...props}
+      href={href}
+      target={target}
+      download={download}
+      onClick={handleClick}
+    >
+      {children}
+    </a>
+  );
+}

--- a/frontend/src/react/components/auth/PasswordSigninForm.tsx
+++ b/frontend/src/react/components/auth/PasswordSigninForm.tsx
@@ -2,6 +2,7 @@ import { create } from "@bufbuild/protobuf";
 import { Eye, EyeOff } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { resolveWorkspaceName } from "@/react/lib/workspace";
@@ -58,14 +59,6 @@ export function PasswordSigninForm({
     );
   };
 
-  const goToForgot = (e: React.MouseEvent) => {
-    e.preventDefault();
-    router.push({
-      name: AUTH_PASSWORD_FORGOT_MODULE,
-      query: { hint: router.currentRoute.value.query.hint },
-    });
-  };
-
   return (
     <form className="flex flex-col gap-y-6 px-1" onSubmit={trySignin}>
       <div>
@@ -99,14 +92,16 @@ export function PasswordSigninForm({
             <span className="text-error ml-0.5">*</span>
           </div>
           {showForgotPassword && (
-            <a
-              href="#"
+            <RouterLink
+              to={{
+                name: AUTH_PASSWORD_FORGOT_MODULE,
+                query: { hint: router.currentRoute.value.query.hint },
+              }}
               className="text-sm font-normal text-control-light hover:underline focus:outline-hidden"
               tabIndex={-1}
-              onClick={goToForgot}
             >
               {t("auth.sign-in.forget-password")}
-            </a>
+            </RouterLink>
           )}
         </label>
         <div className="relative flex flex-row items-center mt-1 rounded-md shadow-xs">

--- a/frontend/src/react/components/header/HeaderBreadcrumb.tsx
+++ b/frontend/src/react/components/header/HeaderBreadcrumb.tsx
@@ -1,6 +1,7 @@
 import { Building2, Check, ChevronDown, FolderKanban } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Badge } from "@/react/components/ui/badge";
 import {
   Popover,
@@ -20,11 +21,7 @@ import {
   workspaceNamePrefix,
 } from "@/react/lib/resourceName";
 import { cn } from "@/react/lib/utils";
-import {
-  useCurrentRoute,
-  useNavigate,
-  WORKSPACE_ROUTE_LANDING,
-} from "@/react/router";
+import { useCurrentRoute, WORKSPACE_ROUTE_LANDING } from "@/react/router";
 import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
 import { ProjectCreateDialog } from "./ProjectCreateDialog";
 import { ProjectSwitchPanel } from "./ProjectSwitchPanel";
@@ -71,7 +68,6 @@ function WorkspaceSegment() {
   const label = planLabel(t, currentPlan);
   const hasMultiple = workspaceList.length > 1;
   const switchWorkspace = useSwitchWorkspace();
-  const navigate = useNavigate();
   const [open, setOpen] = useState(false);
 
   const onSwitch = useCallback(
@@ -83,21 +79,11 @@ function WorkspaceSegment() {
     [currentWorkspaceName, switchWorkspace]
   );
 
-  const workspaceHref = navigate.resolve({
-    name: WORKSPACE_ROUTE_LANDING,
-  }).href;
-
   return (
     <div className="inline-flex items-center">
-      <a
-        href={workspaceHref}
+      <RouterLink
+        to={{ name: WORKSPACE_ROUTE_LANDING }}
         className="inline-flex items-center gap-x-1.5 rounded-xs px-2 py-1 text-sm font-medium text-control hover:bg-control-bg cursor-pointer no-underline"
-        onClick={(e) => {
-          if (!e.metaKey && !e.ctrlKey) {
-            e.preventDefault();
-            void navigate.push({ name: WORKSPACE_ROUTE_LANDING });
-          }
-        }}
       >
         <Building2 className="size-4 text-control-light shrink-0" />
         <span className="truncate max-w-40">{workspace?.title}</span>
@@ -109,7 +95,7 @@ function WorkspaceSegment() {
             {label}
           </Badge>
         )}
-      </a>
+      </RouterLink>
       {hasMultiple && (
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger

--- a/frontend/src/react/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/react/components/instance/InstanceFormBody.tsx
@@ -16,6 +16,7 @@ import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { LabelListEditor } from "@/react/components/LabelListEditor";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import { ResourceIdField } from "@/react/components/ResourceIdField";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
@@ -1146,11 +1147,14 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
                 <div className="sm:col-span-2 ml-0 sm:ml-3">
                   <label htmlFor="activation" className="textlabel block">
                     {t("subscription.instance-assignment.assign-license")} (
-                    <a href="/setting/subscription" className="accent-link">
+                    <RouterLink
+                      to="/setting/subscription"
+                      className="accent-link"
+                    >
                       {t("subscription.instance-assignment.n-license-remain", {
                         n: availableLicenseCountText,
                       })}
-                    </a>
+                    </RouterLink>
                     )
                   </label>
                   <div className="h-8.5 flex flex-row items-center mt-1">

--- a/frontend/src/react/components/release/ReleaseInfoCard.tsx
+++ b/frontend/src/react/components/release/ReleaseInfoCard.tsx
@@ -4,6 +4,7 @@ import { ExternalLink, Loader2, Package } from "lucide-react";
 import type { ReactNode } from "react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { cn } from "@/react/lib/utils";
 import { State, VCSType } from "@/types/proto-es/v1/common_pb";
 import type { Release } from "@/types/proto-es/v1/release_service_pb";
@@ -55,15 +56,15 @@ export function ReleaseInfoCard({
           </span>
         </div>
         {effectiveRelease && (
-          <a
+          <RouterLink
+            to={`/${effectiveRelease.name}`}
             className="inline-flex items-center gap-x-1 text-sm text-accent hover:underline"
-            href={`/${effectiveRelease.name}`}
             rel="noreferrer"
             target="_blank"
           >
             <span>{t("common.view")}</span>
             <ExternalLink className="h-4 w-4" />
-          </a>
+          </RouterLink>
         )}
       </div>
       {body}
@@ -111,14 +112,14 @@ function ReleaseBlock({ release }: Readonly<{ release: Release }>) {
                 {t("release.files")} ({release.files.length})
               </div>
               {release.files.length > MAX_DISPLAYED_RELEASE_FILES && (
-                <a
+                <RouterLink
+                  to={`/${release.name}`}
                   className="text-sm text-accent hover:underline"
-                  href={`/${release.name}`}
                   rel="noreferrer"
                   target="_blank"
                 >
                   {t("release.view-all-files")}
-                </a>
+                </RouterLink>
               )}
             </div>
             <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">

--- a/frontend/src/react/components/revision/RevisionDetailPanel.tsx
+++ b/frontend/src/react/components/revision/RevisionDetailPanel.tsx
@@ -1,11 +1,11 @@
 import { ArrowUpRight, LoaderCircle } from "lucide-react";
-import { type MouseEvent, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { sheetServiceClientConnect } from "@/connect";
 import { ReadonlyMonaco } from "@/react/components/monaco";
+import { RouterLink } from "@/react/components/RouterLink";
 import { TaskRunLogViewer } from "@/react/components/task-run-log";
 import { useRevisionByName } from "@/react/hooks/useAppState";
-import { router } from "@/react/router";
 import { useAppStore } from "@/react/stores/app";
 import { pushNotification } from "@/store";
 import { getTimeForPbTimestampProtoEs } from "@/types";
@@ -142,20 +142,6 @@ export function RevisionDetailPanel({
     ? bytesToString(new TextEncoder().encode(statement).length)
     : "";
 
-  const handleTaskFullLinkClick = (event: MouseEvent<HTMLAnchorElement>) => {
-    if (
-      event.button !== 0 ||
-      event.metaKey ||
-      event.altKey ||
-      event.ctrlKey ||
-      event.shiftKey
-    ) {
-      return;
-    }
-    event.preventDefault();
-    router.push({ path: taskFullLink });
-  };
-
   if (loading) {
     return (
       <div className="flex items-center justify-center py-2 text-sm text-gray-400">
@@ -188,14 +174,13 @@ export function RevisionDetailPanel({
               <div className="flex items-center justify-between">
                 <p className="text-lg text-main">{t("issue.task-run.logs")}</p>
                 {taskFullLink ? (
-                  <a
-                    href={taskFullLink}
+                  <RouterLink
+                    to={{ path: taskFullLink }}
                     className="flex items-center gap-x-1 text-sm text-control-light transition-colors hover:text-accent"
-                    onClick={handleTaskFullLinkClick}
                   >
                     {t("common.show-more")}
                     <ArrowUpRight className="h-4 w-4" />
-                  </a>
+                  </RouterLink>
                 ) : null}
               </div>
               <TaskRunLogViewer taskRunName={revision.taskRun} />

--- a/frontend/src/react/components/sql-editor/AccessGrantItem.tsx
+++ b/frontend/src/react/components/sql-editor/AccessGrantItem.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
 import { Tooltip } from "@/react/components/ui/tooltip";
@@ -209,15 +210,15 @@ export function AccessGrantItem({
               </Button>
             )}
             {grant.issue && (
-              <a
-                href={issueLink}
+              <RouterLink
+                to={issueLink}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={(e) => e.stopPropagation()}
                 className="inline-flex items-center justify-center h-6 text-xs px-2 rounded-xs hover:bg-control-bg text-control"
               >
                 {t("sql-editor.view-issue")}
-              </a>
+              </RouterLink>
             )}
           </div>
         </div>

--- a/frontend/src/react/components/sql-editor/AsidePanel.tsx
+++ b/frontend/src/react/components/sql-editor/AsidePanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { ProjectSelect } from "@/react/components/ProjectSelect";
-import { router } from "@/react/router";
+import { RouterLink } from "@/react/components/RouterLink";
 import { PROJECT_V1_ROUTE_DASHBOARD } from "@/react/router/handles";
 import { useAppStore } from "@/react/stores/app";
 import { useSQLEditorStore } from "@/react/stores/sqlEditor";
@@ -79,31 +79,17 @@ export function AsidePanel() {
   // Vue's `<template #empty>` — rich empty state when the user is not
   // a member of any project. Shows a "go to create" link when the user
   // has `bb.projects.create`, or an "ask the admin" hint otherwise.
-  // Vue Router resolves the dashboard route to its href; rendering a
-  // plain anchor lets the page navigate via the router's history side
-  // effects without dragging react-router-dom into the bundle.
-  const projectsHref = router.resolve({
-    name: PROJECT_V1_ROUTE_DASHBOARD,
-    hash: "#new",
-  }).href;
   const emptyContent = (
     <div className="text-sm text-control-placeholder flex flex-col gap-1">
       <p>
         {t("sql-editor.no-project.not-member-of-any-projects")}{" "}
         {allowCreateProject ? (
-          <a
-            href={projectsHref}
+          <RouterLink
+            to={{ name: PROJECT_V1_ROUTE_DASHBOARD, hash: "#new" }}
             className="text-accent hover:underline"
-            onClick={(e) => {
-              e.preventDefault();
-              router.push({
-                name: PROJECT_V1_ROUTE_DASHBOARD,
-                hash: "#new",
-              });
-            }}
           >
             {t("sql-editor.no-project.go-to-create")}
-          </a>
+          </RouterLink>
         ) : null}
       </p>
       {!allowCreateProject ? (

--- a/frontend/src/react/components/sql-editor/GutterBar.tsx
+++ b/frontend/src/react/components/sql-editor/GutterBar.tsx
@@ -1,8 +1,8 @@
 import logoIcon from "@/assets/logo-icon.svg";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Separator } from "@/react/components/ui/separator";
 import { useAppProject } from "@/react/hooks/useAppProject";
 import { useReactiveRoute } from "@/react/hooks/useReactiveRoute";
-import { router } from "@/react/router";
 import {
   PROJECT_V1_ROUTE_DETAIL,
   WORKSPACE_ROUTE_LANDING,
@@ -30,12 +30,12 @@ export function GutterBar() {
     | string
     | undefined;
 
-  const logoHref = routeProjectParam
-    ? router.resolve({
+  const logoRoute = routeProjectParam
+    ? {
         name: PROJECT_V1_ROUTE_DETAIL,
         params: { projectId: routeProjectParam },
-      }).href
-    : router.resolve({ name: WORKSPACE_ROUTE_LANDING }).href;
+      }
+    : { name: WORKSPACE_ROUTE_LANDING };
 
   const handleClickTab = (target: AsidePanelTab) => {
     setAsidePanelTab(target);
@@ -45,9 +45,9 @@ export function GutterBar() {
     <div className="h-full flex flex-col items-stretch justify-between overflow-hidden text-sm p-1">
       <div className="flex flex-col gap-y-1">
         <div className="flex flex-col justify-center items-center pb-1">
-          <a href={logoHref} target="_blank" rel="noopener noreferrer">
+          <RouterLink to={logoRoute} target="_blank" rel="noopener noreferrer">
             <img className="w-9 h-auto" src={logoIcon} alt="Bytebase" />
-          </a>
+          </RouterLink>
         </div>
         <Separator />
         <TabItem tab="WORKSHEET" onClick={() => handleClickTab("WORKSHEET")} />

--- a/frontend/src/react/components/sql-editor/OpenAIButton.test.tsx
+++ b/frontend/src/react/components/sql-editor/OpenAIButton.test.tsx
@@ -105,11 +105,15 @@ vi.mock("@/plugins/ai/logic/prompt", () => ({
 
 vi.mock("@/react/router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/react/router")>()),
-  router: { push: mocks.routerPush },
+  router: {
+    push: mocks.routerPush,
+    resolve: (to: unknown) => ({ href: String(to), fullPath: String(to) }),
+  },
 }));
 
 // Minimal primitive stubs.
 vi.mock("@/react/components/ui/button", () => ({
+  buttonVariants: ({ className }: { className?: string } = {}) => className,
   Button: ({
     children,
     onClick,

--- a/frontend/src/react/components/sql-editor/OpenAIButton.tsx
+++ b/frontend/src/react/components/sql-editor/OpenAIButton.tsx
@@ -3,7 +3,8 @@ import { useTranslation } from "react-i18next";
 import { aiContextEvents } from "@/plugins/ai/logic";
 import * as promptUtils from "@/plugins/ai/logic/prompt";
 import type { ChatAction } from "@/plugins/ai/types";
-import { Button } from "@/react/components/ui/button";
+import { RouterLink } from "@/react/components/RouterLink";
+import { Button, buttonVariants } from "@/react/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -17,7 +18,6 @@ import {
 } from "@/react/components/ui/popover";
 import { useConnectionOfCurrentSQLEditorTab } from "@/react/hooks/useSQLEditorBridge";
 import { cn } from "@/react/lib/utils";
-import { router } from "@/react/router";
 import { SETTING_ROUTE_WORKSPACE_GENERAL } from "@/react/router/handles";
 import { useAppStore } from "@/react/stores/app";
 import { useSQLEditorStore } from "@/react/stores/sqlEditor";
@@ -245,21 +245,23 @@ function AINotConfiguredButton({
             <p>
               {t("plugin.ai.not-configured.self")}{" "}
               {allowConfigure ? (
-                <Button
-                  variant="link"
-                  size="sm"
+                <RouterLink
+                  to={{
+                    name: SETTING_ROUTE_WORKSPACE_GENERAL,
+                    hash: "#ai-assistant",
+                  }}
                   tabIndex={-1}
-                  className="h-auto p-0 text-accent"
+                  className={buttonVariants({
+                    variant: "link",
+                    size: "sm",
+                    className: "h-auto p-0 text-accent",
+                  })}
                   onClick={() => {
                     setOpen(false);
-                    void router.push({
-                      name: SETTING_ROUTE_WORKSPACE_GENERAL,
-                      hash: "#ai-assistant",
-                    });
                   }}
                 >
                   {t("plugin.ai.not-configured.go-to-configure")}
-                </Button>
+                </RouterLink>
               ) : (
                 t("plugin.ai.not-configured.contact-admin-to-configure")
               )}

--- a/frontend/src/react/components/sql-editor/useExportGrantBypass.tsx
+++ b/frontend/src/react/components/sql-editor/useExportGrantBypass.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { useAppStore } from "@/react/stores/app";
 import type { AccessGrant } from "@/types/proto-es/v1/access_grant_service_pb";
 
@@ -313,15 +314,15 @@ export function useExportGrantBypass({
           )}
           {issueHref && (
             <div className="flex justify-end pt-1">
-              <a
-                href={issueHref}
+              <RouterLink
+                to={issueHref}
                 target="_blank"
                 rel="noreferrer"
                 className="text-xs underline whitespace-nowrap"
                 onClick={(e) => e.stopPropagation()}
               >
                 {t("sql-editor.view-issue")}
-              </a>
+              </RouterLink>
             </div>
           )}
         </div>
@@ -360,15 +361,15 @@ export function useExportGrantBypass({
               <div key={grant.name} className="flex items-start gap-x-1">
                 <span className="select-none opacity-60">•</span>
                 {href ? (
-                  <a
-                    href={href}
+                  <RouterLink
+                    to={href}
                     target="_blank"
                     rel="noreferrer"
                     className="flex-1 min-w-0 underline break-words line-clamp-1"
                     onClick={(e) => e.stopPropagation()}
                   >
                     {display}
-                  </a>
+                  </RouterLink>
                 ) : (
                   <span className="flex-1 min-w-0 break-words line-clamp-1">
                     {display}

--- a/frontend/src/react/components/sql-review/ResourceLink.tsx
+++ b/frontend/src/react/components/sql-review/ResourceLink.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
+import { RouterLink } from "@/react/components/RouterLink";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
-import { router } from "@/react/router";
 import { useAppStore } from "@/react/stores/app";
 import {
   environmentNamePrefix,
@@ -23,19 +23,15 @@ export function ResourceLink({ resource }: { resource: string }) {
 function EnvironmentResourceLink({ resource }: { resource: string }) {
   const { t } = useTranslation();
   return (
-    <a
-      href={`/${resource}`}
+    <RouterLink
+      to={{ path: `/${resource}` }}
       className="inline-flex items-center gap-x-1"
-      onClick={(e) => {
-        e.preventDefault();
-        router.push({ path: `/${resource}` });
-      }}
     >
       <span className="text-control-light text-xs mr-0.5">
         {t("common.environment")}:
       </span>
       <EnvironmentLabel environmentName={resource} />
-    </a>
+    </RouterLink>
   );
 }
 
@@ -54,18 +50,14 @@ function ProjectResourceLink({ resource }: { resource: string }) {
   void projectsByName;
 
   return (
-    <a
-      href={`/${resource}`}
+    <RouterLink
+      to={{ path: `/${resource}` }}
       className="inline-flex items-center gap-x-1 normal-link"
-      onClick={(e) => {
-        e.preventDefault();
-        router.push({ path: `/${resource}` });
-      }}
     >
       <span className="text-control-light text-xs mr-0.5">
         {t("common.project")}:
       </span>
       <span>{project?.title || resource}</span>
-    </a>
+    </RouterLink>
   );
 }

--- a/frontend/src/react/pages/auth/PasswordForgotPage.test.tsx
+++ b/frontend/src/react/pages/auth/PasswordForgotPage.test.tsx
@@ -51,6 +51,7 @@ vi.mock("@/react/router", async (importOriginal) => ({
     push: mocks.routerPush,
     replace: mocks.routerReplace,
     currentRoute: mocks.currentRoute,
+    resolve: (to: unknown) => ({ href: String(to), fullPath: String(to) }),
   },
 }));
 

--- a/frontend/src/react/pages/auth/PasswordForgotPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordForgotPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import logoFull from "@/assets/logo-full.svg";
 import { authServiceClientConnect } from "@/connect";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
@@ -67,13 +68,6 @@ export function PasswordForgotPage() {
     }
   };
 
-  const goToSignin = () => {
-    router.push({
-      name: AUTH_SIGNIN_MODULE,
-      query: router.currentRoute.value.query,
-    });
-  };
-
   return (
     <div className="h-full flex flex-col justify-center mx-auto w-full max-w-sm">
       <div>
@@ -132,16 +126,15 @@ export function PasswordForgotPage() {
           <div className="w-full border-t border-control-border" />
         </div>
         <div className="relative flex justify-center text-sm">
-          <a
-            href="#"
-            className="accent-link bg-white px-2"
-            onClick={(e) => {
-              e.preventDefault();
-              goToSignin();
+          <RouterLink
+            to={{
+              name: AUTH_SIGNIN_MODULE,
+              query: router.currentRoute.value.query,
             }}
+            className="accent-link bg-white px-2"
           >
             {t("auth.password-forget.return-to-sign-in")}
-          </a>
+          </RouterLink>
         </div>
       </div>
     </div>

--- a/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.test.tsx
@@ -68,6 +68,7 @@ vi.mock("@/react/router", async (importOriginal) => ({
     replace: mocks.routerReplace,
     push: mocks.routerPush,
     currentRoute: mocks.currentRoute,
+    resolve: (to: unknown) => ({ href: String(to), fullPath: String(to) }),
   },
 }));
 

--- a/frontend/src/react/pages/auth/PasswordResetPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.tsx
@@ -6,6 +6,7 @@ import logoFull from "@/assets/logo-full.svg";
 import { authServiceClientConnect } from "@/connect";
 import { UserPasswordFields } from "@/react/components/auth/UserPasswordFields";
 import { computePasswordValidation } from "@/react/components/auth/userPasswordValidation";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { OtpInput } from "@/react/components/ui/otp-input";
@@ -251,16 +252,12 @@ export function PasswordResetPage() {
             <div className="w-full border-t border-control-border" />
           </div>
           <div className="relative flex justify-center text-sm">
-            <a
-              href="#"
+            <RouterLink
+              to={{ name: AUTH_SIGNIN_MODULE }}
               className="accent-link bg-white px-2"
-              onClick={(e) => {
-                e.preventDefault();
-                router.push({ name: AUTH_SIGNIN_MODULE });
-              }}
             >
               {t("auth.password-forget.return-to-sign-in")}
-            </a>
+            </RouterLink>
           </div>
         </div>
       )}

--- a/frontend/src/react/pages/auth/SigninPage.tsx
+++ b/frontend/src/react/pages/auth/SigninPage.tsx
@@ -4,6 +4,7 @@ import { AuthFooter } from "@/react/components/auth/AuthFooter";
 import { EmailCodeSigninForm } from "@/react/components/auth/EmailCodeSigninForm";
 import { PasswordSigninForm } from "@/react/components/auth/PasswordSigninForm";
 import { BytebaseLogo } from "@/react/components/BytebaseLogo";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import {
@@ -204,19 +205,15 @@ export function SigninPage(props: SigninPageProps) {
                   {!disallowSignup && (
                     <div className="mt-3 flex justify-center items-center text-sm text-control gap-x-2">
                       <span>{t("auth.sign-in.new-user")}</span>
-                      <a
-                        href="#"
-                        className="accent-link"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          router.push({
-                            name: AUTH_SIGNUP_MODULE,
-                            query,
-                          });
+                      <RouterLink
+                        to={{
+                          name: AUTH_SIGNUP_MODULE,
+                          query,
                         }}
+                        className="accent-link"
                       >
                         {t("common.sign-up")}
-                      </a>
+                      </RouterLink>
                     </div>
                   )}
                 </TabsPanel>

--- a/frontend/src/react/pages/auth/SignupPage.tsx
+++ b/frontend/src/react/pages/auth/SignupPage.tsx
@@ -4,6 +4,7 @@ import { AuthFooter } from "@/react/components/auth/AuthFooter";
 import { UserPasswordFields } from "@/react/components/auth/UserPasswordFields";
 import { computePasswordValidation } from "@/react/components/auth/userPasswordValidation";
 import { BytebaseLogo } from "@/react/components/BytebaseLogo";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { Input } from "@/react/components/ui/input";
@@ -232,16 +233,12 @@ export function SignupPage() {
               <span className="pl-2 bg-white text-control">
                 {t("auth.sign-up.existing-user")}
               </span>
-              <a
-                href="#"
+              <RouterLink
+                to={{ name: AUTH_SIGNIN_MODULE, query }}
                 className="accent-link px-2 bg-white"
-                onClick={(e) => {
-                  e.preventDefault();
-                  router.push({ name: AUTH_SIGNIN_MODULE, query });
-                }}
               >
                 {t("common.sign-in")}
-              </a>
+              </RouterLink>
             </div>
           </div>
         )}

--- a/frontend/src/react/pages/project/DatabaseChangelogDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/DatabaseChangelogDetailPage.test.tsx
@@ -7,6 +7,19 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const mocks = vi.hoisted(() => {
+  const resolveRouteTarget = (target: string | { path?: unknown }) => {
+    const path =
+      typeof target === "string"
+        ? target
+        : typeof target.path === "string"
+          ? target.path
+          : "/mock-route";
+
+    return {
+      href: path,
+      fullPath: path,
+    };
+  };
   const localStorage = {
     clear: vi.fn(),
     getItem: vi.fn(() => null),
@@ -36,6 +49,8 @@ const mocks = vi.hoisted(() => {
     previousChangelog,
     localStorage,
     routerPush: vi.fn(),
+    routerResolve: vi.fn(resolveRouteTarget),
+    resolveRouteTarget,
     useProjectDatabaseDetail: vi.fn(),
     getOrFetchChangelogByName: vi.fn(),
     fetchPreviousChangelog: vi.fn(),
@@ -132,6 +147,7 @@ vi.mock("@/react/router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/react/router")>()),
   router: {
     push: mocks.routerPush,
+    resolve: mocks.routerResolve,
   },
 }));
 
@@ -232,6 +248,8 @@ beforeEach(() => {
   mocks.localStorage.removeItem.mockReset();
   mocks.localStorage.clear.mockReset();
   mocks.routerPush.mockReset();
+  mocks.routerResolve.mockReset();
+  mocks.routerResolve.mockImplementation(mocks.resolveRouteTarget);
   mocks.useProjectDatabaseDetail.mockReset();
   mocks.getOrFetchChangelogByName.mockReset();
   mocks.fetchPreviousChangelog.mockReset();

--- a/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
+++ b/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
 import { ReadonlyDiffMonaco, ReadonlyMonaco } from "@/react/components/monaco";
+import { RouterLink } from "@/react/components/RouterLink";
 import { TaskRunLogViewer } from "@/react/components/task-run-log";
 import { Button } from "@/react/components/ui/button";
 import { Switch } from "@/react/components/ui/switch";
@@ -499,17 +500,13 @@ export function DatabaseChangelogDetailPage({
             <div className="flex items-center justify-between">
               <p className="text-lg text-main">{t("issue.task-run.logs")}</p>
               {taskFullLink ? (
-                <a
-                  href={taskFullLink}
+                <RouterLink
+                  to={{ path: taskFullLink }}
                   className="flex items-center gap-x-1 text-sm text-control-light transition-colors hover:text-accent"
-                  onClick={(event) => {
-                    event.preventDefault();
-                    router.push({ path: taskFullLink });
-                  }}
                 >
                   {t("common.show-more")}
                   <ArrowUpRight className="size-4" />
-                </a>
+                </RouterLink>
               ) : null}
             </div>
             {showTaskRunLogs ? (

--- a/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
+++ b/frontend/src/react/pages/project/DatabaseChangelogDetailPage.tsx
@@ -379,36 +379,6 @@ export function DatabaseChangelogDetailPage({
     return bytesToString(Number(resolvedChangelog.schemaSize));
   }, [resolvedChangelog?.schemaSize]);
 
-  const handleProjectBreadcrumbClick = () => {
-    router.push({
-      name: PROJECT_V1_ROUTE_DATABASES,
-      params: { projectId },
-    });
-  };
-
-  const handleDatabaseBreadcrumbClick = () => {
-    router.push({
-      name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-      params: {
-        projectId,
-        instanceId,
-        databaseName,
-      },
-    });
-  };
-
-  const handleChangelogBreadcrumbClick = () => {
-    router.push({
-      name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-      params: {
-        projectId,
-        instanceId,
-        databaseName,
-      },
-      hash: "#changelog",
-    });
-  };
-
   const handleRollback = () => {
     if (!resolvedChangelog || !detail.database) {
       return;
@@ -444,33 +414,48 @@ export function DatabaseChangelogDetailPage({
       <nav aria-label="Breadcrumb" className="mb-4">
         <ol className="flex flex-wrap items-center gap-x-2 text-sm text-control-light">
           <li>
-            <button
-              type="button"
+            <RouterLink
+              to={{
+                name: PROJECT_V1_ROUTE_DATABASES,
+                params: { projectId },
+              }}
               className="transition-colors hover:text-accent"
-              onClick={handleProjectBreadcrumbClick}
             >
               {t("common.databases")}
-            </button>
+            </RouterLink>
           </li>
           <li aria-hidden="true">/</li>
           <li>
-            <button
-              type="button"
+            <RouterLink
+              to={{
+                name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
+                params: {
+                  projectId,
+                  instanceId,
+                  databaseName,
+                },
+              }}
               className="transition-colors hover:text-accent"
-              onClick={handleDatabaseBreadcrumbClick}
             >
               {databaseDisplayName}
-            </button>
+            </RouterLink>
           </li>
           <li aria-hidden="true">/</li>
           <li>
-            <button
-              type="button"
+            <RouterLink
+              to={{
+                name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
+                params: {
+                  projectId,
+                  instanceId,
+                  databaseName,
+                },
+                hash: "#changelog",
+              }}
               className="transition-colors hover:text-accent"
-              onClick={handleChangelogBreadcrumbClick}
             >
               {t("changelog.self")}
-            </button>
+            </RouterLink>
           </li>
           <li aria-hidden="true">/</li>
           <li className="text-main">{changelogId}</li>

--- a/frontend/src/react/pages/project/DatabaseRevisionDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/DatabaseRevisionDetailPage.test.tsx
@@ -66,6 +66,7 @@ vi.mock("@/react/router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/react/router")>()),
   router: {
     push: mocks.routerPush,
+    resolve: (to: unknown) => ({ href: String(to), fullPath: String(to) }),
   },
 }));
 
@@ -220,17 +221,19 @@ describe("DatabaseRevisionDetailPage", () => {
       "instances/inst1/databases/db-from-hook/revisions/7"
     );
 
-    const clickButton = async (label: string) => {
-      const button = Array.from(container.querySelectorAll("button")).find(
+    const clickBreadcrumb = async (label: string) => {
+      const link = Array.from(container.querySelectorAll("a")).find(
         (candidate) => candidate.textContent === label
       );
 
       await act(async () => {
-        button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        link?.dispatchEvent(
+          new MouseEvent("click", { bubbles: true, cancelable: true })
+        );
       });
     };
 
-    await clickButton("common.databases");
+    await clickBreadcrumb("common.databases");
     expect(mocks.routerPush).toHaveBeenCalledWith({
       name: mocks.routeNames.databases,
       params: {
@@ -238,7 +241,7 @@ describe("DatabaseRevisionDetailPage", () => {
       },
     });
 
-    await clickButton("db-from-prop");
+    await clickBreadcrumb("db-from-prop");
     expect(mocks.routerPush).toHaveBeenCalledWith({
       name: mocks.routeNames.databaseDetail,
       params: {
@@ -248,7 +251,7 @@ describe("DatabaseRevisionDetailPage", () => {
       },
     });
 
-    await clickButton("database.revision.self");
+    await clickBreadcrumb("database.revision.self");
     expect(mocks.routerPush).toHaveBeenCalledWith({
       name: mocks.routeNames.databaseDetail,
       params: {
@@ -259,9 +262,9 @@ describe("DatabaseRevisionDetailPage", () => {
       hash: "#revision",
     });
 
-    const databaseBreadcrumb = Array.from(
-      container.querySelectorAll("button")
-    ).find((button) => button.textContent === "db-from-prop");
+    const databaseBreadcrumb = Array.from(container.querySelectorAll("a")).find(
+      (link) => link.textContent === "db-from-prop"
+    );
 
     expect(databaseBreadcrumb).not.toBeNull();
 

--- a/frontend/src/react/pages/project/DatabaseRevisionDetailPage.tsx
+++ b/frontend/src/react/pages/project/DatabaseRevisionDetailPage.tsx
@@ -1,7 +1,7 @@
 import { LoaderCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { RevisionDetailPanel } from "@/react/components/revision";
-import { router } from "@/react/router";
 import {
   PROJECT_V1_ROUTE_DATABASE_DETAIL,
   PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
@@ -30,68 +30,53 @@ export function DatabaseRevisionDetailPage({
   });
   const revisionName = `${detail.databaseName}/revisions/${revisionId}`;
 
-  const handleProjectBreadcrumbClick = () => {
-    router.push({
-      name: PROJECT_V1_ROUTE_DATABASES,
-      params: { projectId },
-    });
-  };
-
-  const handleDatabaseBreadcrumbClick = () => {
-    router.push({
-      name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-      params: {
-        projectId,
-        instanceId,
-        databaseName,
-      },
-    });
-  };
-
-  const handleRevisionBreadcrumbClick = () => {
-    router.push({
-      name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-      params: {
-        projectId,
-        instanceId,
-        databaseName,
-      },
-      hash: "#revision",
-    });
-  };
-
   return (
     <div className="flex min-h-full flex-col gap-y-4 p-4">
       <nav aria-label="Breadcrumb" className="mb-4">
         <ol className="flex flex-wrap items-center gap-x-2 text-sm text-control-light">
           <li>
-            <button
-              type="button"
+            <RouterLink
+              to={{
+                name: PROJECT_V1_ROUTE_DATABASES,
+                params: { projectId },
+              }}
               className="transition-colors hover:text-accent"
-              onClick={handleProjectBreadcrumbClick}
             >
               {t("common.databases")}
-            </button>
+            </RouterLink>
           </li>
           <li aria-hidden="true">/</li>
           <li>
-            <button
-              type="button"
+            <RouterLink
+              to={{
+                name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
+                params: {
+                  projectId,
+                  instanceId,
+                  databaseName,
+                },
+              }}
               className="transition-colors hover:text-accent"
-              onClick={handleDatabaseBreadcrumbClick}
             >
               {databaseName}
-            </button>
+            </RouterLink>
           </li>
           <li aria-hidden="true">/</li>
           <li>
-            <button
-              type="button"
+            <RouterLink
+              to={{
+                name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
+                params: {
+                  projectId,
+                  instanceId,
+                  databaseName,
+                },
+                hash: "#revision",
+              }}
               className="transition-colors hover:text-accent"
-              onClick={handleRevisionBreadcrumbClick}
             >
               {t("database.revision.self")}
-            </button>
+            </RouterLink>
           </li>
           <li aria-hidden="true">/</li>
           <li className="text-main">{revisionId}</li>

--- a/frontend/src/react/pages/project/ProjectAccessGrantsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectAccessGrantsPage.tsx
@@ -11,6 +11,7 @@ import {
 import { ComponentPermissionGuard } from "@/react/components/ComponentPermissionGuard";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
+import { RouterLink } from "@/react/components/RouterLink";
 import { TimeRangePicker } from "@/react/components/TimeRangePicker";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
@@ -33,7 +34,6 @@ import { Tooltip } from "@/react/components/ui/tooltip";
 import { useCurrentUser } from "@/react/hooks/useAppState";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
-import { router } from "@/react/router";
 import { useAppStore } from "@/react/stores/app";
 import type { AccessGrantFilter as AccessFilter } from "@/react/stores/app/types";
 import { pushNotification } from "@/store";
@@ -651,10 +651,8 @@ function AccessGrantRow({
             </Button>
           )}
           {grant.issue && (
-            <a
-              href={
-                grant.issue.startsWith("/") ? grant.issue : `/${grant.issue}`
-              }
+            <RouterLink
+              to={grant.issue.startsWith("/") ? grant.issue : `/${grant.issue}`}
               target="_blank"
               rel="noreferrer"
               onClick={(e) => e.stopPropagation()}
@@ -662,7 +660,7 @@ function AccessGrantRow({
               <Button variant="ghost" size="sm">
                 {t("sql-editor.view-issue")}
               </Button>
-            </a>
+            </RouterLink>
           )}
         </div>
       </TableCell>
@@ -734,13 +732,13 @@ function DatabaseTargets({ targets }: { targets: string[] }) {
   const rest = targets.length - visible.length;
 
   const renderLink = (target: string) => (
-    <span
+    <RouterLink
       key={target}
+      to={{ path: `/${target}` }}
       className="normal-link hover:underline cursor-pointer text-sm"
-      onClick={() => router.push({ path: `/${target}` })}
     >
       {getDatabaseName(target)}
-    </span>
+    </RouterLink>
   );
 
   const inline = (

--- a/frontend/src/react/pages/project/ProjectDataExportPage.tsx
+++ b/frontend/src/react/pages/project/ProjectDataExportPage.tsx
@@ -9,6 +9,7 @@ import {
   type ValueOption,
 } from "@/react/components/AdvancedSearch";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Tooltip } from "@/react/components/ui/tooltip";
@@ -64,22 +65,6 @@ export function ProjectDataExportPage({ projectId }: { projectId: string }) {
   // for export" would be misleading if export is in fact gated there).
   const queryDataPolicy = useSQLEditorQueryDataPolicy(projectName);
 
-  // Resolved hrefs for the inline links in the deprecation banner.
-  // Memoized so render-time JSX stays cheap, and so SPA navigation
-  // works via the click handler while right-click / cmd-click still
-  // opens the real path in a new tab.
-  const projectSettingsHref = useMemo(
-    () =>
-      router.resolve({
-        name: PROJECT_V1_ROUTE_SETTINGS,
-        params: { projectId },
-      }).fullPath,
-    [projectId]
-  );
-  const customApprovalHref = useMemo(
-    () => router.resolve({ name: WORKSPACE_ROUTE_CUSTOM_APPROVAL }).fullPath,
-    []
-  );
   // Workspace-level setting permission: gates the "configure your
   // approval flow" sentence so non-admins don't see advice they can't
   // act on. `bb.settings.set` is the same check the workspace settings
@@ -291,13 +276,12 @@ export function ProjectDataExportPage({ projectId }: { projectId: string }) {
                       // closing tag so the wrapping `<a>` never gets
                       // generated and the link silently vanishes.
                       lnk: (
-                        <a
-                          className="text-accent underline hover:text-accent-hover"
-                          href={projectSettingsHref}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            router.push(projectSettingsHref);
+                        <RouterLink
+                          to={{
+                            name: PROJECT_V1_ROUTE_SETTINGS,
+                            params: { projectId },
                           }}
+                          className="text-accent underline hover:text-accent-hover"
                         />
                       ),
                     }}
@@ -321,13 +305,9 @@ export function ProjectDataExportPage({ projectId }: { projectId: string }) {
                     }}
                     components={{
                       lnk: (
-                        <a
+                        <RouterLink
+                          to={{ name: WORKSPACE_ROUTE_CUSTOM_APPROVAL }}
                           className="text-accent underline hover:text-accent-hover"
-                          href={customApprovalHref}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            router.push(customApprovalHref);
-                          }}
                         />
                       ),
                     }}
@@ -661,8 +641,8 @@ function IssueListItem({
               <IssueStatusIcon status={issue.status} />
             </div>
             {issue.title ? (
-              <a
-                href={issueUrl}
+              <RouterLink
+                to={issueUrl}
                 className="font-medium text-main text-base truncate hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
@@ -670,15 +650,15 @@ function IssueListItem({
                   text={issue.title}
                   keyword={highlightWords}
                 />
-              </a>
+              </RouterLink>
             ) : (
-              <a
-                href={issueUrl}
+              <RouterLink
+                to={issueUrl}
                 className="font-medium text-base truncate hover:underline italic text-control-placeholder"
                 onClick={(e) => e.stopPropagation()}
               >
                 {t("common.untitled")}
-              </a>
+              </RouterLink>
             )}
             <RiskLevelIcon riskLevel={issue.riskLevel} />
             {validLabels.map((label: { value: string; color: string }) => (
@@ -703,20 +683,18 @@ function IssueListItem({
               <span>{humanizeTs(createTimeTs)}</span>
             </Tooltip>
             <span>&middot;</span>
-            <a
+            <RouterLink
               className="hover:underline"
-              href="#"
+              to={{
+                name: WORKSPACE_ROUTE_USER_PROFILE,
+                params: { principalEmail: creator.email },
+              }}
               onClick={(e) => {
-                e.preventDefault();
                 e.stopPropagation();
-                router.push({
-                  name: WORKSPACE_ROUTE_USER_PROFILE,
-                  params: { principalEmail: creator.email },
-                });
               }}
             >
               {creator.title}
-            </a>
+            </RouterLink>
           </div>
           {/* Expanded description for search highlights */}
           {expanded && (

--- a/frontend/src/react/pages/project/ProjectDataExportPage.tsx
+++ b/frontend/src/react/pages/project/ProjectDataExportPage.tsx
@@ -11,7 +11,7 @@ import {
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
 import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
-import { Button } from "@/react/components/ui/button";
+import { Button, buttonVariants } from "@/react/components/ui/button";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
@@ -318,14 +318,16 @@ export function ProjectDataExportPage({ projectId }: { projectId: string }) {
           }
         >
           <div className="mt-3 flex justify-end">
-            <Button
-              size="sm"
-              className="shrink-0 whitespace-nowrap"
-              onClick={() => router.push({ name: SQL_EDITOR_HOME_MODULE })}
+            <RouterLink
+              to={{ name: SQL_EDITOR_HOME_MODULE }}
+              className={buttonVariants({
+                size: "sm",
+                className: "shrink-0 whitespace-nowrap",
+              })}
             >
               <SquareTerminal className="size-4 mr-1" />
               {t("export-center.deprecated.open-sql-editor")}
-            </Button>
+            </RouterLink>
           </div>
         </Alert>
       </div>

--- a/frontend/src/react/pages/project/ProjectGitOpsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectGitOpsPage.tsx
@@ -4,8 +4,9 @@ import { useTranslation } from "react-i18next";
 import gitopsWorkflowImage from "@/assets/gitops-workflow.svg";
 import { CreateWorkloadIdentitySheet } from "@/react/components/CreateWorkloadIdentitySheet";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
-import { Button } from "@/react/components/ui/button";
+import { Button, buttonVariants } from "@/react/components/ui/button";
 import { Combobox, type ComboboxOption } from "@/react/components/ui/combobox";
 import { Switch } from "@/react/components/ui/switch";
 import {
@@ -16,7 +17,6 @@ import {
 } from "@/react/components/ui/tabs";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
 import { cn } from "@/react/lib/utils";
-import { router } from "@/react/router";
 import { SETTING_ROUTE_WORKSPACE_GENERAL } from "@/react/router/handles";
 import { useAppStore } from "@/react/stores/app";
 import { extractWorkloadIdentityId } from "@/react/stores/app/workloadIdentity";
@@ -680,15 +680,12 @@ function MissingExternalURLAttention() {
     >
       {canConfigure && (
         <div className="mt-1">
-          <Button
-            size="sm"
-            className="w-fit"
-            onClick={() =>
-              router.push({ name: SETTING_ROUTE_WORKSPACE_GENERAL })
-            }
+          <RouterLink
+            to={{ name: SETTING_ROUTE_WORKSPACE_GENERAL }}
+            className={buttonVariants({ size: "sm", className: "w-fit" })}
           >
             {t("common.configure-now")}
-          </Button>
+          </RouterLink>
         </div>
       )}
     </Alert>

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/react/components/AdvancedSearch";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Button } from "@/react/components/ui/button";
 import {
   Dialog,
@@ -1030,16 +1031,12 @@ function ExemptionDetailPanel({
             member.member.startsWith(workloadIdentityBindingPrefix) ? (
             <span className="font-medium">{userEmail}</span>
           ) : (
-            <a
+            <RouterLink
               className="normal-link font-medium"
-              href={`/users/${userEmail}`}
-              onClick={(e) => {
-                e.preventDefault();
-                router.push(`/users/${userEmail}`);
-              }}
+              to={`/users/${userEmail}`}
             >
               {userEmail}
-            </a>
+            </RouterLink>
           )}
         </div>
         <div className="mt-1 text-sm textinfolabel">

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
@@ -1204,13 +1204,6 @@ function ExemptionResourceTable({
 
   const isSentinel = (value: string): boolean => value === "" || value === "-1";
 
-  const handleDatabaseClick = (resource: DatabaseResource) => {
-    const path = resource.databaseFullName.startsWith("/")
-      ? resource.databaseFullName
-      : `/${resource.databaseFullName}`;
-    router.push(path);
-  };
-
   return (
     <div className="overflow-x-auto">
       <Table>
@@ -1252,12 +1245,16 @@ function ExemptionResourceTable({
                       {t("database.all")}
                     </span>
                   ) : showDatabaseLink ? (
-                    <span
+                    <RouterLink
+                      to={
+                        resource.databaseFullName.startsWith("/")
+                          ? resource.databaseFullName
+                          : `/${resource.databaseFullName}`
+                      }
                       className="normal-link cursor-pointer"
-                      onClick={() => handleDatabaseClick(resource)}
                     >
                       {databaseName}
-                    </span>
+                    </RouterLink>
                   ) : (
                     <span className="text-control-light">{databaseName}</span>
                   )}

--- a/frontend/src/react/pages/project/ProjectSettingsPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSettingsPage.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { LabelListEditor } from "@/react/components/LabelListEditor";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Button } from "@/react/components/ui/button";
 import {
   Dialog,
@@ -100,15 +101,12 @@ function ApprovalFlowIndicator({
       content={
         <div className="flex flex-col gap-y-1">
           <span>{tooltipText}</span>
-          <button
-            type="button"
-            className="text-accent underline text-left"
-            onClick={() =>
-              router.push({ name: WORKSPACE_ROUTE_CUSTOM_APPROVAL })
-            }
+          <RouterLink
+            to={{ name: WORKSPACE_ROUTE_CUSTOM_APPROVAL }}
+            className="text-accent underline text-left hover:text-accent-hover"
           >
             {t("project.settings.issue-related.view-approval-flow")}
-          </button>
+          </RouterLink>
         </div>
       }
     >

--- a/frontend/src/react/pages/project/ProjectWebhookForm.tsx
+++ b/frontend/src/react/pages/project/ProjectWebhookForm.tsx
@@ -3,7 +3,8 @@ import { isEqual } from "lodash-es";
 import { EllipsisVertical, Info } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/react/components/ui/button";
+import { RouterLink } from "@/react/components/RouterLink";
+import { Button, buttonVariants } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Dialog,
@@ -298,10 +299,6 @@ export function ProjectWebhookForm({
     });
   }, [project, state, testProjectWebhook, t, withLoading]);
 
-  const imSettingsUrl = useMemo(() => {
-    return router.resolve({ name: WORKSPACE_ROUTE_IM }).fullPath;
-  }, []);
-
   return (
     <div className="h-full flex flex-col">
       <div className="flex-1 mb-6 px-4">
@@ -341,15 +338,12 @@ export function ProjectWebhookForm({
               {t("settings.general.workspace.external-url.description")}
             </div>
             {hasWorkspacePermissionV2("bb.settings.setWorkspaceProfile") && (
-              <Button
-                size="sm"
-                className="mt-2"
-                onClick={() =>
-                  router.push({ name: SETTING_ROUTE_WORKSPACE_GENERAL })
-                }
+              <RouterLink
+                to={{ name: SETTING_ROUTE_WORKSPACE_GENERAL }}
+                className={buttonVariants({ size: "sm", className: "mt-2" })}
               >
                 {t("common.configure-now")}
-              </Button>
+              </RouterLink>
             )}
           </div>
         )}
@@ -487,14 +481,14 @@ export function ProjectWebhookForm({
                 ) : (
                   <span className="text-control-light">
                     {t("project.webhook.direct-messages-warning")}{" "}
-                    <a
-                      href={imSettingsUrl}
+                    <RouterLink
+                      to={{ name: WORKSPACE_ROUTE_IM }}
                       target="_blank"
                       rel="noreferrer"
                       className="normal-link"
                     >
                       {t("common.configure-now")}
-                    </a>
+                    </RouterLink>
                   </span>
                 )}
               </div>

--- a/frontend/src/react/pages/project/database-detail/DatabaseDetailHeader.tsx
+++ b/frontend/src/react/pages/project/database-detail/DatabaseDetailHeader.tsx
@@ -2,8 +2,8 @@ import { Check, Copy, ShieldAlert } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EngineIcon } from "@/react/components/EngineIcon";
+import { RouterLink } from "@/react/components/RouterLink";
 import { useEnvironment, usePlanFeature } from "@/react/hooks/useAppState";
-import { router } from "@/react/router";
 import { INSTANCE_ROUTE_DETAIL } from "@/react/router/handles";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
@@ -113,31 +113,6 @@ export function DatabaseDetailHeader({
     }
   }, [database.name]);
 
-  const handleEnvironmentClick = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (isValidEnv) {
-        void router.push({
-          path: `/${formatEnvironmentName(environment.id)}`,
-        });
-      }
-    },
-    [environment, isValidEnv]
-  );
-
-  const handleInstanceClick = useCallback(
-    (e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (canViewInstance && instanceId) {
-        void router.push({
-          name: INSTANCE_ROUTE_DETAIL,
-          params: { instanceId },
-        });
-      }
-    },
-    [canViewInstance, instanceId]
-  );
-
   return (
     <div className="flex min-w-0 flex-1 shrink-0 flex-col gap-y-2">
       <div className="flex w-full min-w-0 flex-col">
@@ -167,14 +142,15 @@ export function DatabaseDetailHeader({
         <div className="flex items-center gap-x-1.5">
           <span className="text-control-light">{t("common.environment")}</span>
           {isValidEnv ? (
-            <a
+            <RouterLink
+              to={{ path: `/${formatEnvironmentName(environment.id)}` }}
               className="inline-flex cursor-pointer items-center gap-x-1 hover:underline"
               style={environmentBadgeStyle}
-              onClick={handleEnvironmentClick}
+              onClick={(e) => e.stopPropagation()}
             >
               <span>{environmentTitle}</span>
               {isProductionEnv && <ShieldAlert className="h-4 w-4 shrink-0" />}
-            </a>
+            </RouterLink>
           ) : (
             <span className="italic text-control-light">
               {environmentTitle}
@@ -184,16 +160,20 @@ export function DatabaseDetailHeader({
         <div className="flex items-center gap-x-1.5">
           <span className="text-control-light">{t("common.instance")}</span>
           {canViewInstance && instanceId ? (
-            <a
+            <RouterLink
+              to={{
+                name: INSTANCE_ROUTE_DETAIL,
+                params: { instanceId },
+              }}
               className="inline-flex cursor-pointer items-center gap-x-1 hover:underline"
-              onClick={handleInstanceClick}
+              onClick={(e) => e.stopPropagation()}
             >
               <EngineIcon
                 engine={instanceResource.engine}
                 className="h-4 w-4"
               />
               {instanceLabel}
-            </a>
+            </RouterLink>
           ) : (
             <span className="inline-flex items-center gap-x-1">
               <EngineIcon

--- a/frontend/src/react/pages/project/database-detail/catalog/SensitiveColumnTable.tsx
+++ b/frontend/src/react/pages/project/database-detail/catalog/SensitiveColumnTable.tsx
@@ -1,6 +1,7 @@
 import { Trash2 } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import {
@@ -19,7 +20,6 @@ import {
   TableRow,
 } from "@/react/components/ui/table";
 import type { MaskData } from "@/react/lib/sensitive-data/types";
-import { router } from "@/react/router";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { autoDatabaseRoute } from "@/utils";
 
@@ -220,23 +220,21 @@ export function SensitiveColumnTable({
                     </TableCell>
                   )}
                   <TableCell className="text-main">
-                    <a
+                    <RouterLink
                       className="normal-link"
-                      href={
-                        router.resolve({
-                          ...autoDatabaseRoute(database),
-                          query: {
-                            schema: item.schema,
-                            table: item.table,
-                          },
-                          hash: "overview",
-                        }).fullPath
-                      }
+                      to={{
+                        ...autoDatabaseRoute(database),
+                        query: {
+                          schema: item.schema,
+                          table: item.table,
+                        },
+                        hash: "overview",
+                      }}
                     >
                       {item.schema
                         ? `${item.schema}.${item.table}`
                         : item.table}
-                    </a>
+                    </RouterLink>
                   </TableCell>
                   <TableCell className="text-main">
                     {item.column || t("common.empty")}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailActionBar.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailActionBar.tsx
@@ -25,7 +25,8 @@ import {
   rolloutServiceClientConnect,
 } from "@/connect";
 import { MarkdownEditor } from "@/react/components/MarkdownEditor";
-import { Button } from "@/react/components/ui/button";
+import { RouterLink } from "@/react/components/RouterLink";
+import { Button, buttonVariants } from "@/react/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -443,17 +444,17 @@ export function IssueDetailActionBar() {
     <>
       <div className="flex items-center gap-x-2">
         {shouldShowPlanLink && planRoute && (
-          <Button
-            className="gap-x-1"
-            onClick={() => {
-              void router.push(planRoute);
-            }}
-            variant="outline"
+          <RouterLink
+            to={planRoute}
+            className={buttonVariants({
+              variant: "outline",
+              className: "gap-x-1",
+            })}
           >
             <span>#{extractPlanUID(page.plan.name)}</span>
             <span>{t("common.plan")}</span>
             <ExternalLink className="size-3.5" />
-          </Button>
+          </RouterLink>
         )}
 
         {primaryAction &&

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailCommentList.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailCommentList.tsx
@@ -21,6 +21,7 @@ import { issueServiceClientConnect } from "@/connect";
 import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { MarkdownEditor } from "@/react/components/MarkdownEditor";
 import { ReadonlyDiffMonaco } from "@/react/components/monaco";
+import { RouterLink } from "@/react/components/RouterLink";
 import { UserAvatar } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import {
@@ -677,10 +678,9 @@ function CommentActionSentence({
           )
         ) {
           const planUID = page.plan ? extractPlanUID(page.plan.name) : "";
-          const planHref = page.plan
-            ? router.resolve(buildPlanDeployRouteFromPlanName(page.plan.name))
-                .href
-            : "";
+          const planRoute = page.plan
+            ? buildPlanDeployRouteFromPlanName(page.plan.name)
+            : undefined;
           const sentence =
             page.issue?.approvalStatus === ApprovalStatus.APPROVED
               ? planUID
@@ -693,15 +693,15 @@ function CommentActionSentence({
           return (
             <span className="wrap-break-word min-w-0 text-gray-600">
               {sentence}
-              {planUID && planHref && (
+              {planUID && planRoute && (
                 <>
                   {" "}
-                  <a
+                  <RouterLink
+                    to={planRoute}
                     className="font-medium text-accent hover:underline"
-                    href={planHref}
                   >
                     #{planUID}
-                  </a>
+                  </RouterLink>
                 </>
               )}
             </span>
@@ -874,27 +874,14 @@ function SpecChangeRow({
   const specIdShort = specId.slice(0, 8);
   // Only link to specs that still exist in the live plan — otherwise the spec
   // view would silently bounce back to specs[0].
-  const href = specInfo?.specId
-    ? router.resolve({
+  const specRoute = specInfo?.specId
+    ? {
         query: {
           ...router.currentRoute.value.query,
           spec: specInfo.specId,
         },
-      }).href
-    : null;
-  const onClick = href
-    ? (e: React.MouseEvent) => {
-        // Allow modifier-clicks (open in new tab) to use the native href.
-        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-        e.preventDefault();
-        void router.push({
-          query: {
-            ...router.currentRoute.value.query,
-            spec: specInfo!.specId,
-          },
-        });
       }
-    : undefined;
+    : null;
 
   const chip = (
     <span className="inline-flex items-center gap-1">
@@ -910,14 +897,13 @@ function SpecChangeRow({
   return (
     <span className="inline-flex items-center gap-1 whitespace-nowrap text-gray-600">
       {children}{" "}
-      {href != null ? (
-        <a
+      {specRoute != null ? (
+        <RouterLink
           className="inline-flex items-center gap-1 hover:underline"
-          href={href}
-          onClick={onClick}
+          to={specRoute}
         >
           {chip}
-        </a>
+        </RouterLink>
       ) : (
         chip
       )}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { instanceRoleServiceClientConnect } from "@/connect";
 import { EngineIcon } from "@/react/components/EngineIcon";
+import { RouterLink } from "@/react/components/RouterLink";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
   Select,
@@ -139,12 +140,12 @@ export function IssueDetailDatabaseChangeView({
           </div>
 
           {page.plan && (
-            <a
+            <RouterLink
+              to={planHref}
               className="px-3 text-sm text-accent hover:underline"
-              href={planHref}
             >
               {t("plan.go-to-plan-page")} →
-            </a>
+            </RouterLink>
           )}
         </div>
 

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
@@ -2,6 +2,7 @@ import { Check, FastForward, Minus, Pause, X } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { EngineIcon } from "@/react/components/EngineIcon";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
 import { cn } from "@/react/lib/utils";
@@ -151,15 +152,15 @@ export function IssueDetailDatabaseCreateView() {
             </span>
             {isTaskDone && createdDatabase ? (
               <>
-                <a
+                <RouterLink
                   className="normal-link"
-                  href={databaseV1Url(createdDatabase)}
+                  to={databaseV1Url(createdDatabase)}
                 >
                   {
                     extractDatabaseResourceName(createdDatabase.name)
                       .databaseName
                   }
-                </a>
+                </RouterLink>
                 <span className="text-sm text-gray-500">
                   ({t("common.created")})
                 </span>
@@ -197,7 +198,7 @@ function IssueDetailDatabaseCreateEnvironment({
   children: string;
   environmentName: string;
 }) {
-  const style = useMemo(() => {
+  const environmentPath = useMemo(() => {
     if (!isValidEnvironmentName(environmentName)) {
       return undefined;
     }
@@ -205,18 +206,17 @@ function IssueDetailDatabaseCreateEnvironment({
     if (!id) {
       return undefined;
     }
-    const href = `/${formatEnvironmentName(id)}`;
-    return href;
+    return `/${formatEnvironmentName(id)}`;
   }, [environmentName]);
 
-  if (!style) {
+  if (!environmentPath) {
     return <span>{children}</span>;
   }
 
   return (
-    <a className="normal-link hover:underline" href={style}>
+    <RouterLink className="normal-link hover:underline" to={environmentPath}>
       <span>{children}</span>
-    </a>
+    </RouterLink>
   );
 }
 
@@ -245,16 +245,16 @@ function IssueDetailDatabaseCreateInstance({
   }
 
   return (
-    <a
+    <RouterLink
+      to={instanceHref}
       className="inline-flex items-center gap-x-1 normal-link hover:underline"
-      href={instanceHref}
       onClick={(event) => {
         event.stopPropagation();
       }}
     >
       <EngineIcon engine={instance.engine} className="h-4 w-4" />
       <span className="truncate">{children}</span>
-    </a>
+    </RouterLink>
   );
 }
 

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailLabels.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailLabels.tsx
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { issueServiceClientConnect } from "@/connect";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
 import { useClickOutside } from "@/react/hooks/useClickOutside";
@@ -203,9 +204,9 @@ export function IssueDetailLabels() {
                   {settingsHref &&
                     project &&
                     hasProjectPermissionV2(project, "bb.projects.update") && (
-                      <a
+                      <RouterLink
+                        to={settingsHref}
                         className="flex items-center gap-x-2 textinfolabel normal-link"
-                        href={settingsHref}
                       >
                         <span>
                           {t(
@@ -213,7 +214,7 @@ export function IssueDetailLabels() {
                           )}
                         </span>
                         <ExternalLink className="h-4 w-4" />
-                      </a>
+                      </RouterLink>
                     )}
                 </div>
               ) : (

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/connect";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
 import {
   AlertDialog,
@@ -1930,14 +1931,14 @@ export function DatabaseGroupTarget({
           {groupName}
         </span>
         {showExternalLink && (
-          <a
+          <RouterLink
+            to={route}
             className="flex items-center opacity-60 hover:opacity-100"
-            href={router.resolve(route).href}
             rel="noreferrer"
             target="_blank"
           >
             <ExternalLink className="h-4 w-4" />
-          </a>
+          </RouterLink>
         )}
       </div>
       {matchedDatabases.length > 0 && (

--- a/frontend/src/react/pages/settings/EnvironmentsPage.tsx
+++ b/frontend/src/react/pages/settings/EnvironmentsPage.tsx
@@ -32,6 +32,7 @@ import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import { ResourceIdField } from "@/react/components/ResourceIdField";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import {
@@ -134,17 +135,15 @@ function EnvironmentName({
 
   if (link) {
     return (
-      <a
-        href={`/${formatEnvironmentName(environment.id)}`}
+      <RouterLink
+        to={{ path: `/${formatEnvironmentName(environment.id)}` }}
         onClick={(e) => {
-          e.preventDefault();
           e.stopPropagation();
-          router.push({ path: `/${formatEnvironmentName(environment.id)}` });
         }}
         className="hover:underline"
       >
         {content}
-      </a>
+      </RouterLink>
     );
   }
 

--- a/frontend/src/react/pages/settings/EnvironmentsPage.tsx
+++ b/frontend/src/react/pages/settings/EnvironmentsPage.tsx
@@ -531,19 +531,17 @@ function SQLReviewSectionInner(
               onChange={setEnforce}
             />
             <div className="flex items-center gap-x-1">
-              <span
-                className="textlabel normal-link text-accent! cursor-pointer"
-                onClick={() => {
-                  router.push({
-                    name: WORKSPACE_ROUTE_SQL_REVIEW_DETAIL,
-                    params: {
-                      sqlReviewPolicySlug: sqlReviewPolicySlug(pendingPolicy),
-                    },
-                  });
+              <RouterLink
+                to={{
+                  name: WORKSPACE_ROUTE_SQL_REVIEW_DETAIL,
+                  params: {
+                    sqlReviewPolicySlug: sqlReviewPolicySlug(pendingPolicy),
+                  },
                 }}
+                className="textlabel normal-link text-accent! cursor-pointer"
               >
                 {pendingPolicy.name}
-              </span>
+              </RouterLink>
               {canUpdatePolicy && (
                 <button
                   type="button"

--- a/frontend/src/react/pages/settings/GroupsPage.tsx
+++ b/frontend/src/react/pages/settings/GroupsPage.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next";
 import { ComponentPermissionGuard } from "@/react/components/ComponentPermissionGuard";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
+import { RouterLink } from "@/react/components/RouterLink";
 import { UserCell } from "@/react/components/UserCell";
 import { UserSelect } from "@/react/components/UserSelect";
 import { Alert } from "@/react/components/ui/alert";
@@ -1029,17 +1030,15 @@ export function GroupsPage() {
               content={
                 <span>
                   {t("settings.members.groups.workspace-domain-required")}{" "}
-                  <a
-                    href={
-                      router.resolve({
-                        name: SETTING_ROUTE_WORKSPACE_GENERAL,
-                        hash: "#domain-restriction",
-                      }).href
-                    }
+                  <RouterLink
+                    to={{
+                      name: SETTING_ROUTE_WORKSPACE_GENERAL,
+                      hash: "#domain-restriction",
+                    }}
                     className="underline text-accent"
                   >
                     {t("common.configure")}
-                  </a>
+                  </RouterLink>
                 </span>
               }
             >

--- a/frontend/src/react/pages/settings/LandingPage.tsx
+++ b/frontend/src/react/pages/settings/LandingPage.tsx
@@ -22,6 +22,7 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { ProjectSwitchDialog } from "@/react/components/header/ProjectSwitchDialog";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Sheet,
@@ -481,12 +482,12 @@ export function LandingPage(_: Record<string, never> = {}) {
               </button>
             </div>
             {lastProject && lastVisitProjectPath && (
-              <a
+              <RouterLink
+                to={{ path: lastVisitProjectPath }}
                 className="underline normal-link cursor-pointer"
-                onClick={() => router.push({ path: lastVisitProjectPath })}
               >
                 {t("landing.last-visit")}: {lastProject.title}
-              </a>
+              </RouterLink>
             )}
           </div>
 
@@ -495,14 +496,15 @@ export function LandingPage(_: Record<string, never> = {}) {
               const tileClass =
                 "flex justify-center items-center gap-x-2 cursor-pointer border rounded-sm px-4 py-5 bg-white hover:bg-gray-100 no-underline text-main";
               if (link.route) {
-                const href = router.resolve({
-                  name: link.route,
-                }).href;
                 return (
-                  <a key={link.id} href={href} className={tileClass}>
+                  <RouterLink
+                    key={link.id}
+                    to={{ name: link.route }}
+                    className={tileClass}
+                  >
                     <link.icon className="w-5 h-5 text-gray-500" />
                     {link.title}
-                  </a>
+                  </RouterLink>
                 );
               }
               return (

--- a/frontend/src/react/pages/settings/MCPPage.tsx
+++ b/frontend/src/react/pages/settings/MCPPage.tsx
@@ -1,8 +1,9 @@
 import { Check, Copy } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
-import { Button } from "@/react/components/ui/button";
+import { Button, buttonVariants } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import {
   Tabs,
@@ -12,7 +13,6 @@ import {
 } from "@/react/components/ui/tabs";
 import { Textarea } from "@/react/components/ui/textarea";
 import { useServerState } from "@/react/hooks/useAppState";
-import { router } from "@/react/router";
 import { SETTING_ROUTE_WORKSPACE_GENERAL } from "@/react/router/handles";
 import { hasWorkspacePermissionV2 } from "@/utils";
 
@@ -98,16 +98,16 @@ export function MCPPage() {
                 {t("settings.general.workspace.external-url.description")}
               </span>
               {canConfigureExternalUrl && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="ml-3"
-                  onClick={() =>
-                    router.push({ name: SETTING_ROUTE_WORKSPACE_GENERAL })
-                  }
+                <RouterLink
+                  to={{ name: SETTING_ROUTE_WORKSPACE_GENERAL }}
+                  className={buttonVariants({
+                    variant: "outline",
+                    size: "sm",
+                    className: "ml-3",
+                  })}
                 >
                   {t("common.configure-now")}
-                </Button>
+                </RouterLink>
               )}
             </>
           }

--- a/frontend/src/react/pages/settings/profile/ProfilePage.tsx
+++ b/frontend/src/react/pages/settings/profile/ProfilePage.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
+import { RouterLink } from "@/react/components/RouterLink";
 import { getAvatarColor, getInitials } from "@/react/components/UserAvatar";
 import { Button } from "@/react/components/ui/button";
 import {
@@ -469,18 +470,12 @@ export function ProfilePage({ principalEmail }: ProfilePageProps) {
                   ))}
                 </div>
                 {!hasFeature(PlanFeature.FEATURE_IAM) && (
-                  <a
-                    href="#"
+                  <RouterLink
+                    to={{ name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION }}
                     className="normal-link"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      router.push({
-                        name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
-                      });
-                    }}
                   >
                     {t("settings.profile.subscription")}
-                  </a>
+                  </RouterLink>
                 )}
               </dd>
             </div>

--- a/frontend/src/react/pages/workspace/Page403.test.tsx
+++ b/frontend/src/react/pages/workspace/Page403.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/react/router", () => ({
   router: {
     currentRoute: mocks.currentRoute,
     push: mocks.routerPush,
+    resolve: (to: unknown) => ({ href: String(to), fullPath: String(to) }),
   },
 }));
 
@@ -53,13 +54,15 @@ describe("Page403", () => {
       root.render(<Page403 />);
     });
 
-    const button = Array.from(container.querySelectorAll("button")).find((el) =>
+    const link = Array.from(container.querySelectorAll("a")).find((el) =>
       el.textContent?.includes("error-page.go-back-home")
     );
-    expect(button).toBeTruthy();
+    expect(link).toBeTruthy();
 
     act(() => {
-      button?.click();
+      link?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
     });
 
     expect(mocks.routerPush).toHaveBeenCalledWith({

--- a/frontend/src/react/pages/workspace/Page403.tsx
+++ b/frontend/src/react/pages/workspace/Page403.tsx
@@ -1,7 +1,8 @@
 import { ChevronLeft, ShieldAlert } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Button } from "@/react/components/ui/button";
+import { RouterLink } from "@/react/components/RouterLink";
+import { buttonVariants } from "@/react/components/ui/button";
 import { router } from "@/react/router";
 import { WORKSPACE_ROUTE_LANDING } from "@/react/router/handles";
 import type { Permission } from "@/types";
@@ -28,10 +29,6 @@ export function Page403() {
 
   const fromPath = query.from;
   const requestAPI = query.api;
-
-  const goHome = () => {
-    router.push({ name: WORKSPACE_ROUTE_LANDING });
-  };
 
   return (
     <div className="mx-6 my-2">
@@ -65,10 +62,13 @@ export function Page403() {
               </div>
             )}
             <div className="mt-2">
-              <Button variant="outline" size="sm" onClick={goHome}>
+              <RouterLink
+                to={{ name: WORKSPACE_ROUTE_LANDING }}
+                className={buttonVariants({ variant: "outline", size: "sm" })}
+              >
                 <ChevronLeft className="h-4 w-4" />
                 {t("error-page.go-back-home")}
-              </Button>
+              </RouterLink>
             </div>
           </div>
         </div>

--- a/frontend/src/react/pages/workspace/Page404.test.tsx
+++ b/frontend/src/react/pages/workspace/Page404.test.tsx
@@ -19,6 +19,7 @@ vi.mock("@/assets/logo-icon.svg", () => ({
 vi.mock("@/react/router", () => ({
   router: {
     push: mocks.routerPush,
+    resolve: (to: unknown) => ({ href: String(to), fullPath: String(to) }),
   },
 }));
 
@@ -50,13 +51,15 @@ describe("Page404", () => {
       root.render(<Page404 />);
     });
 
-    const button = Array.from(container.querySelectorAll("button")).find((el) =>
+    const link = Array.from(container.querySelectorAll("a")).find((el) =>
       el.textContent?.includes("error-page.go-back-home")
     );
-    expect(button).toBeTruthy();
+    expect(link).toBeTruthy();
 
     act(() => {
-      button?.click();
+      link?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
     });
 
     expect(mocks.routerPush).toHaveBeenCalledWith({

--- a/frontend/src/react/pages/workspace/Page404.tsx
+++ b/frontend/src/react/pages/workspace/Page404.tsx
@@ -1,16 +1,12 @@
 import { ChevronLeft } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import logoIcon from "@/assets/logo-icon.svg";
-import { Button } from "@/react/components/ui/button";
-import { router } from "@/react/router";
+import { RouterLink } from "@/react/components/RouterLink";
+import { buttonVariants } from "@/react/components/ui/button";
 import { WORKSPACE_ROUTE_LANDING } from "@/react/router/handles";
 
 export function Page404() {
   const { t } = useTranslation();
-
-  const goHome = () => {
-    router.push({ name: WORKSPACE_ROUTE_LANDING });
-  };
 
   return (
     <div className="w-full px-4 grid place-items-center py-24">
@@ -19,10 +15,13 @@ export function Page404() {
         {t("common.resource-not-found")}
       </p>
       <div className="mt-12">
-        <Button variant="outline" size="sm" onClick={goHome}>
+        <RouterLink
+          to={{ name: WORKSPACE_ROUTE_LANDING }}
+          className={buttonVariants({ variant: "outline", size: "sm" })}
+        >
           <ChevronLeft className="h-4 w-4" />
           {t("error-page.go-back-home")}
-        </Button>
+        </RouterLink>
       </div>
     </div>
   );

--- a/frontend/src/react/plugins/agent/components/AgentChat.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentChat.tsx
@@ -2,8 +2,8 @@ import { useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { Button } from "@/react/components/ui/button";
-import { router } from "@/react/router";
+import { RouterLink } from "@/react/components/RouterLink";
+import { Button, buttonVariants } from "@/react/components/ui/button";
 import { SETTING_ROUTE_WORKSPACE_GENERAL } from "@/react/router/handles";
 import { hasWorkspacePermissionV2 } from "@/utils";
 import type { AgentMessage, ToolCall } from "../logic/types";
@@ -91,10 +91,6 @@ export function AgentChat({ className }: AgentChatProps) {
 
   function goConfigure() {
     clearError(currentChatId);
-    router.push({
-      name: SETTING_ROUTE_WORKSPACE_GENERAL,
-      hash: "#ai-assistant",
-    });
   }
 
   function dismiss() {
@@ -223,9 +219,16 @@ export function AgentChat({ className }: AgentChatProps) {
           <div className="mt-1">{t("agent.ai-not-configured.description")}</div>
           <div className="mt-3 flex flex-wrap gap-x-2 gap-y-2">
             {allowConfigure && (
-              <Button variant="default" size="sm" onClick={goConfigure}>
+              <RouterLink
+                to={{
+                  name: SETTING_ROUTE_WORKSPACE_GENERAL,
+                  hash: "#ai-assistant",
+                }}
+                className={buttonVariants({ size: "sm" })}
+                onClick={goConfigure}
+              >
                 {t("agent.ai-not-configured.configure")}
-              </Button>
+              </RouterLink>
             )}
             <Button variant="outline" size="sm" onClick={dismiss}>
               {t("common.dismiss")}


### PR DESCRIPTION
## Summary
- Add a shared React `RouterLink` that renders real anchors while routing same-tab left clicks through the app router.
- Migrate internal navigation anchors across project/workspace sidebars, project settings/export pages, resource links, issue tables, and issue-detail views.
- Update affected router mocks and add focused `RouterLink` behavior tests.

## Pre-PR Checklist
- Breaking change check: no breaking API, schema, proto, config, webhook, or permission change; UI navigation behavior preserves native anchor semantics.
- Composite-PK query safety: skipped, no backend/store or migrator changes.
- Image compatibility: skipped, no compatibility metadata changes.
- SonarCloud: reviewed; new files are under existing frontend source/test inclusion patterns, no property change needed.

## Test Plan
- [x] `pnpm --dir frontend fix`
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend test` (244 files / 2218 tests)
- [x] Final subagent code review approved the full diff with no findings

## Notes
- Dependency audit surfaced existing frontend dependency advisories on the default branch; they are unrelated to this RouterLink migration and should be handled in a separate dependency hardening PR.
