### PR TITLE
feat(cel): enable cel-go/ext Strings extension for conditions

### DIFF
--- a/backend/api/v1/masking_evaluator.go
+++ b/backend/api/v1/masking_evaluator.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/ext"
 	"github.com/pkg/errors"
 	"google.golang.org/genproto/googleapis/type/expr"
 
@@ -241,6 +242,7 @@ func evaluateMaskingExemptionPolicyCondition(expression *expr.Expr, attributes m
 	maskingExemptionPolicyEnv, err := cel.NewEnv(
 		cel.Variable("resource", cel.MapType(cel.StringType, cel.AnyType)),
 		cel.Variable("request", cel.MapType(cel.StringType, cel.AnyType)),
+		ext.Strings(),
 	)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to create CEL environment for masking exemption policy")

--- a/backend/common/cel.go
+++ b/backend/common/cel.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/google/cel-go/cel"
 	celtypes "github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/ext"
 	"github.com/pkg/errors"
 	exprproto "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	"google.golang.org/genproto/googleapis/type/expr"
@@ -37,6 +38,8 @@ var ApprovalFactors = []cel.EnvOption{
 	cel.Variable(CELAttributeRequestExport, cel.BoolType),
 	// Risk scope
 	cel.Variable(CELAttributeRiskLevel, cel.StringType),
+	// String extension functions (split, join, trim, etc.)
+	ext.Strings(),
 	// Size limit
 	cel.ParserExpressionSizeLimit(celLimit),
 }
@@ -77,6 +80,7 @@ var IAMPolicyConditionCELAttributes = []cel.EnvOption{
 	cel.Variable(CELAttributeResourceSchemaName, cel.StringType),
 	cel.Variable(CELAttributeResourceTableName, cel.StringType),
 	cel.Variable(CELAttributeRequestTime, cel.TimestampType),
+	ext.Strings(),
 	cel.ParserExpressionSizeLimit(celLimit),
 }
 
@@ -90,6 +94,7 @@ var MaskingRulePolicyCELAttributes = []cel.EnvOption{
 	cel.Variable(CELAttributeResourceTableName, cel.StringType),
 	cel.Variable(CELAttributeResourceColumnName, cel.StringType),
 	cel.Variable(CELAttributeResourceClassificationLevel, cel.IntType),
+	ext.Strings(),
 	cel.ParserExpressionSizeLimit(celLimit),
 }
 
@@ -102,6 +107,7 @@ var MaskingExemptionPolicyCELAttributes = []cel.EnvOption{
 	cel.Variable(CELAttributeResourceColumnName, cel.StringType),
 	cel.Variable(CELAttributeResourceClassificationLevel, cel.IntType),
 	cel.Variable(CELAttributeRequestTime, cel.TimestampType),
+	ext.Strings(),
 	cel.ParserExpressionSizeLimit(celLimit),
 }
 
@@ -111,6 +117,7 @@ var DatabaseGroupCELAttributes = []cel.EnvOption{
 	cel.Variable(CELAttributeResourceInstanceID, cel.StringType),
 	cel.Variable(CELAttributeResourceDatabaseName, cel.StringType),
 	cel.Variable(CELAttributeResourceDatabaseLabels, cel.MapType(cel.StringType, cel.StringType)),
+	ext.Strings(),
 	cel.ParserExpressionSizeLimit(celLimit),
 }
 

--- a/backend/common/cel_test.go
+++ b/backend/common/cel_test.go
@@ -209,6 +209,60 @@ func TestApprovalFactorsIncludesRiskLevel(t *testing.T) {
 	a.Nil(issues)
 }
 
+func TestStringsExtensionEnabled(t *testing.T) {
+	a := require.New(t)
+
+	// ext.Strings() functions (split/join/trim) should be available in all
+	// user-authored condition environments.
+	envs := []struct {
+		name string
+		opts []cel.EnvOption
+	}{
+		{"approval", ApprovalFactors},
+		{"iam", IAMPolicyConditionCELAttributes},
+		{"maskingRule", MaskingRulePolicyCELAttributes},
+		{"maskingExemption", MaskingExemptionPolicyCELAttributes},
+		{"databaseGroup", DatabaseGroupCELAttributes},
+	}
+	for _, env := range envs {
+		e, err := cel.NewEnv(env.opts...)
+		a.NoError(err, env.name)
+
+		_, issues := e.Compile(`"a-b-c".split("-")[0] == "a"`)
+		a.Nil(issues, "%s: split should compile", env.name)
+
+		_, issues = e.Compile(`["a", "b"].join("-") == "a-b"`)
+		a.Nil(issues, "%s: join should compile", env.name)
+
+		_, issues = e.Compile(`"  x  ".trim() == "x"`)
+		a.Nil(issues, "%s: trim should compile", env.name)
+	}
+
+	// Evaluate a string-extension expression end to end.
+	e, err := cel.NewEnv(MaskingRulePolicyCELAttributes...)
+	a.NoError(err)
+	ast, issues := e.Compile(`"3-1-2".split("-")[0] == "3"`)
+	a.Nil(issues)
+	prg, err := e.Program(ast)
+	a.NoError(err)
+	out, _, err := prg.Eval(map[string]any{})
+	a.NoError(err)
+	a.Equal(true, out.Value())
+}
+
+func TestFallbackApprovalFactorsExcludeStringsExtension(t *testing.T) {
+	a := require.New(t)
+
+	// Fallback factors are deliberately restricted; ext.Strings() functions
+	// like split() must not be available there.
+	e, err := cel.NewEnv(FallbackApprovalFactors...)
+	a.NoError(err)
+
+	_, issues := e.Compile(`resource.project_id.split("-")[0] == "proj"`)
+	a.NotNil(issues)
+	a.Error(issues.Err())
+}
+
 func TestFallbackFactorsDoNotIncludeRiskLevel(t *testing.T) {
 	a := require.New(t)
 


### PR DESCRIPTION
## What

Enables the `github.com/google/cel-go/ext` **Strings** extension on Bytebase's user-authored CEL condition environments, so condition expressions can use string functions like `split`, `join`, `trim`, `replace`, `substring`, `indexOf`, `lowerAscii`/`upperAscii`, etc. — on top of the core CEL string members (`startsWith`/`endsWith`/`contains`/`matches`) that already worked.

No new dependency: `ext` ships inside the already-required `cel-go` module, so `go.mod`/`go.sum` are unchanged.

## Why

Resolves [BYT-9086](https://linear.app/bytebase/issue/BYT-9086/enable-githubcomgooglecel-goext). Condition authors (approval rules, masking rules/exemptions, IAM policy, database groups) couldn't use string-manipulation functions in raw CEL. Enabling `ext.Strings()` makes them available.

## Changes

- Added `ext.Strings()` to the five shared condition attribute sets in `backend/common/cel.go`: `ApprovalFactors`, `IAMPolicyConditionCELAttributes`, `MaskingRulePolicyCELAttributes`, `MaskingExemptionPolicyCELAttributes`, `DatabaseGroupCELAttributes`. Every `cel.NewEnv(...)` reuses these slices, so validation and evaluation get the extension consistently from one place.
- Added `ext.Strings()` to the one inline masking-exemption **eval** env in `backend/api/v1/masking_evaluator.go` (it uses generic `resource`/`request` maps rather than the shared slice) — needed for validate/eval parity so an exemption expression using e.g. `split()` doesn't validate then fail at eval time.

### Deliberately not changed

- `FallbackApprovalFactors` — intentionally restricted to `resource.project_id` only (existing test asserts its exact composition). A new test confirms `split()` is **not** available there.
- The bare `cel.NewEnv()` calls in `backend/store/*.go` and a few `api/v1` services — those are API **list-filter** parsers (audit log, query history, etc.), a separate mechanism from policy conditions, so out of scope.

## Testing

Written test-first (verified RED → GREEN) in `backend/common/cel_test.go`:
- `TestStringsExtensionEnabled` — `split`/`join`/`trim` compile under all five condition envs, plus an end-to-end eval of `"3-1-2".split("-")[0] == "3"`.
- `TestFallbackApprovalFactorsExcludeStringsExtension` — confirms the restricted fallback env stays restricted.

Verification:
- `go test ./backend/common/...`, `./backend/runner/approval/...`, `./backend/api/v1/...` — all pass
- `golangci-lint run` on both packages — 0 issues
- `go build` of affected packages — clean; `go mod tidy` — no changes

## Notes for reviewers

- This is a backend enablement. The frontend's visual condition builder won't surface these functions, but raw CEL expressions now validate and evaluate.
- The issue's example `resource.classification_id` doesn't map to a real attribute (the actual one is `resource.classification_level`, an `int`). The string functions apply to the genuine string attributes (`database_name`, `table_name`, `statement.text`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)