### PR TITLE
fix(markdown): open preview links in new tab

### DIFF
--- a/frontend/src/react/components/MarkdownEditor/MarkdownEditor.test.tsx
+++ b/frontend/src/react/components/MarkdownEditor/MarkdownEditor.test.tsx
@@ -1,0 +1,54 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, test, vi } from "vitest";
+import { MarkdownEditor } from "./MarkdownEditor";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  return {
+    container,
+    render: () => {
+      act(() => {
+        root.render(element);
+      });
+    },
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
+};
+
+describe("MarkdownEditor", () => {
+  test("opens rendered markdown links in a new tab", () => {
+    const { container, render, unmount } = renderIntoContainer(
+      <MarkdownEditor
+        content="[docs](https://docs.bytebase.com) https://example.com"
+        mode="preview"
+      />
+    );
+
+    render();
+
+    const links = Array.from(container.querySelectorAll("a"));
+    expect(links).toHaveLength(2);
+    for (const link of links) {
+      expect(link.getAttribute("target")).toBe("_blank");
+      expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    }
+
+    unmount();
+  });
+});

--- a/frontend/src/react/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/frontend/src/react/components/MarkdownEditor/MarkdownEditor.tsx
@@ -57,7 +57,7 @@ export function MarkdownEditor({
     }
     const source = transform ? transform(content) : content;
     const rendered = markdown.render(source);
-    return DOMPurify.sanitize(rendered);
+    return sanitizePreviewHtml(rendered);
   }, [content, transform]);
 
   useEffect(() => {
@@ -222,6 +222,17 @@ export function MarkdownEditor({
       )}
     </div>
   );
+}
+
+function sanitizePreviewHtml(html: string) {
+  const sanitized = DOMPurify.sanitize(html);
+  const template = document.createElement("template");
+  template.innerHTML = sanitized;
+  for (const link of template.content.querySelectorAll("a")) {
+    link.setAttribute("target", "_blank");
+    link.setAttribute("rel", "noopener noreferrer");
+  }
+  return template.innerHTML;
 }
 
 function PreviewBody({ className, html }: { className: string; html: string }) {


### PR DESCRIPTION
## Summary
- Restore new-tab behavior for links rendered by the shared React MarkdownEditor preview.
- Add noopener/noreferrer hardening for rendered markdown anchors.
- Add a regression test covering markdown links and auto-linkified URLs.

## Key Changes
- Post-process sanitized markdown preview HTML to annotate all rendered anchors with `target="_blank"` and `rel="noopener noreferrer"`.
- Cover BYT-9664 with a focused MarkdownEditor preview test.

## Motivation
BYT-9664 reported that clicking links in issue comments redirected the current page after the issue detail migration to React. Restoring new-tab behavior keeps users on the issue page and matches the previous markdown preview behavior while adding rel hardening.

## Testing
- `pnpm --dir frontend test src/react/components/MarkdownEditor/MarkdownEditor.test.tsx`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`

## Pre-PR Checklist
- Breaking change check: not applicable; frontend bug fix restoring prior link behavior.
- Composite-PK query safety: skipped; no backend store or migrator changes.
- Image compatibility window: skipped; no version or compatibility metadata changes.
- SonarCloud properties: skipped; added a test file under an existing test pattern and no new directory structure.
