### PR TITLE
chore(frontend): replace raw navigation buttons

### DIFF
--- a/frontend/src/react/components/BytebaseLogo.test.tsx
+++ b/frontend/src/react/components/BytebaseLogo.test.tsx
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   workspaceLogo: "",
   record: vi.fn(),
   push: vi.fn(),
-  resolve: vi.fn(() => ({ fullPath: "/landing" })),
+  resolve: vi.fn(() => ({ href: "/landing", fullPath: "/landing" })),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -33,6 +33,10 @@ vi.mock("@/react/hooks/useAppState", () => ({
 }));
 
 vi.mock("@/react/router", () => ({
+  router: {
+    push: mocks.push,
+    resolve: mocks.resolve,
+  },
   useNavigate: () => ({
     push: mocks.push,
     resolve: mocks.resolve,
@@ -101,15 +105,15 @@ describe("BytebaseLogo", () => {
     );
     render();
 
-    const button = container.querySelector("button");
-    expect(button).not.toBeNull();
+    const link = container.querySelector("a");
+    expect(link).not.toBeNull();
     act(() => {
-      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      link?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(mocks.resolve).toHaveBeenCalledWith({ name: "workspace.landing" });
     expect(mocks.record).toHaveBeenCalledWith("/landing");
-    expect(mocks.push).toHaveBeenCalled();
+    expect(mocks.push).toHaveBeenCalledWith({ name: "workspace.landing" });
     unmount();
   });
 });

--- a/frontend/src/react/components/BytebaseLogo.tsx
+++ b/frontend/src/react/components/BytebaseLogo.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import logoFull from "@/assets/logo-full.svg";
+import { RouterLink } from "@/react/components/RouterLink";
 import { useRecentVisit, useWorkspace } from "@/react/hooks/useAppState";
 import { cn } from "@/react/lib/utils";
 import { useNavigate } from "@/react/router";
@@ -48,17 +49,16 @@ export function BytebaseLogo({ className, redirect }: Props) {
       )}
     >
       {redirect ? (
-        <button
-          type="button"
+        <RouterLink
+          to={{ name: redirect }}
           className="h-full w-full cursor-pointer"
           onClick={() => {
             const route = navigate.resolve({ name: redirect });
             record(route.fullPath);
-            void navigate.push({ name: redirect });
           }}
         >
           {content}
-        </button>
+        </RouterLink>
       ) : (
         content
       )}

--- a/frontend/src/react/components/header/VersionMenuItem.test.tsx
+++ b/frontend/src/react/components/header/VersionMenuItem.test.tsx
@@ -20,6 +20,10 @@ const mocks = vi.hoisted(() => ({
     plan: 1,
   },
   push: vi.fn(),
+  resolve: vi.fn(() => ({
+    href: "/setting/subscription",
+    fullPath: "/setting/subscription",
+  })),
   closeMenu: vi.fn(),
 }));
 
@@ -47,6 +51,10 @@ vi.mock("@/react/hooks/useAppState", () => ({
 
 vi.mock("@/react/router", () => ({
   SETTING_ROUTE_WORKSPACE_SUBSCRIPTION: "setting.workspace.subscription",
+  router: {
+    push: mocks.push,
+    resolve: mocks.resolve,
+  },
   useNavigate: () => ({
     push: mocks.push,
   }),
@@ -133,12 +141,12 @@ describe("VersionMenuItem", () => {
     );
     render();
 
-    const planButton = Array.from(container.querySelectorAll("button")).find(
-      (button) => button.textContent?.includes("Team")
+    const planLink = Array.from(container.querySelectorAll("a")).find((link) =>
+      link.textContent?.includes("Team")
     );
-    expect(planButton).not.toBeUndefined();
+    expect(planLink).not.toBeUndefined();
     act(() => {
-      planButton?.click();
+      planLink?.click();
     });
 
     expect(mocks.push).toHaveBeenCalledWith({

--- a/frontend/src/react/components/header/VersionMenuItem.tsx
+++ b/frontend/src/react/components/header/VersionMenuItem.tsx
@@ -1,14 +1,12 @@
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import {
   useServerInfo,
   useSubscription,
   useWorkspacePermission,
 } from "@/react/hooks/useAppState";
-import {
-  SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
-  useNavigate,
-} from "@/react/router";
+import { SETTING_ROUTE_WORKSPACE_SUBSCRIPTION } from "@/react/router";
 import { PlanType } from "@/types/proto-es/v1/subscription_service_pb";
 
 export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
@@ -16,7 +14,6 @@ export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
   const serverInfo = useServerInfo();
   const { subscription } = useSubscription();
   const canManageSettings = useWorkspacePermission("bb.settings.set");
-  const navigate = useNavigate();
 
   const version = serverInfo?.version ?? "";
   const gitCommitBE = serverInfo?.gitCommit || "unknown";
@@ -46,18 +43,13 @@ export function VersionMenuItem({ onCloseMenu }: { onCloseMenu: () => void }) {
       <div className="px-3 py-2">
         <div className="mb-2 flex items-center gap-x-2">
           {canManageSettings ? (
-            <button
-              type="button"
+            <RouterLink
+              to={{ name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION }}
               className="cursor-pointer text-sm text-accent hover:underline"
-              onClick={() => {
-                void navigate.push({
-                  name: SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
-                });
-                onCloseMenu();
-              }}
+              onClick={onCloseMenu}
             >
               {planLabel}
-            </button>
+            </RouterLink>
           ) : (
             <span className="text-sm text-control-light">{planLabel}</span>
           )}

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
@@ -10,10 +10,10 @@ import {
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ReadonlyMonaco } from "@/react/components/monaco";
+import { RouterLink } from "@/react/components/RouterLink";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { cn } from "@/react/lib/utils";
-import { router } from "@/react/router";
 import { getTimeForPbTimestampProtoEs } from "@/types";
 import {
   type Stage,
@@ -167,22 +167,19 @@ export function DeployTaskItem({
               <div className="flex min-w-0 items-center gap-x-2">
                 <PlanTargetDisplay size="md" target={task.target} />
                 {isExpanded && !readonly && (
-                  <button
-                    className="flex shrink-0 items-center gap-x-1 text-xs text-accent transition-opacity hover:opacity-80"
-                    onClick={() => {
-                      void router.push({
-                        query: {
-                          phase: "deploy",
-                          stageId,
-                          taskId: task.name.split("/").pop(),
-                        },
-                      });
+                  <RouterLink
+                    to={{
+                      query: {
+                        phase: "deploy",
+                        stageId,
+                        taskId: task.name.split("/").pop(),
+                      },
                     }}
-                    type="button"
+                    className="flex shrink-0 items-center gap-x-1 text-xs text-accent transition-opacity hover:opacity-80"
                   >
                     <ArrowUpRight className="h-4 w-4" />
                     <span>{t("common.view-details")}</span>
-                  </button>
+                  </RouterLink>
                 )}
                 {isExpanded && scheduledTime && (
                   <span className="flex shrink-0 items-center gap-x-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-600">
@@ -241,21 +238,18 @@ export function DeployTaskItem({
             )}
 
             {!readonly && (
-              <button
-                className={
-                  isExpanded
-                    ? "self-start rounded p-1 hover:bg-gray-100"
-                    : "rounded p-1 hover:bg-gray-100"
-                }
+              <Button
+                className={isExpanded ? "self-start" : undefined}
                 onClick={onToggleExpand}
-                type="button"
+                size="xs"
+                variant="ghost"
               >
                 {isExpanded ? (
                   <ChevronDown className="h-4 w-4 text-gray-500" />
                 ) : (
                   <ChevronRight className="h-4 w-4 text-gray-500" />
                 )}
-              </button>
+              </Button>
             )}
           </div>
 


### PR DESCRIPTION
## Summary
- Replace raw navigation buttons in the React logo and version menu with `RouterLink`.
- Convert the deploy task detail navigation to `RouterLink` and use shared `Button` for the expand control.
- Update related tests for anchor-based navigation semantics.

## Test Plan
- [x] `pnpm --dir frontend fix`
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend test`
