### PR TITLE
chore: update Omni parser compatibility

### DIFF
--- a/backend/plugin/advisor/mysql/rule_function_disallowed_list.go
+++ b/backend/plugin/advisor/mysql/rule_function_disallowed_list.go
@@ -134,6 +134,18 @@ func (r *functionDisallowedListOmniRule) checkSelectStmt(n *ast.SelectStmt) {
 	if n == nil {
 		return
 	}
+	for _, cte := range n.CTEs {
+		if cte != nil {
+			r.checkSelectStmt(cte.Select)
+		}
+	}
+	if inner := n.ParenSource; inner != nil {
+		r.checkSelectStmt(inner)
+	}
+	if n.SetOp != ast.SetOpNone {
+		r.checkSelectStmt(n.Left)
+		r.checkSelectStmt(n.Right)
+	}
 	for _, expr := range n.TargetList {
 		r.checkExpr(expr)
 	}

--- a/backend/plugin/advisor/mysql/rule_insert_disallow_order_by_rand.go
+++ b/backend/plugin/advisor/mysql/rule_insert_disallow_order_by_rand.go
@@ -74,6 +74,9 @@ func (r *insertDisallowOrderByRandOmniRule) checkSelectForRandOrderBy(sel *ast.S
 	if sel == nil {
 		return
 	}
+	if inner := sel.ParenSource; inner != nil {
+		r.checkSelectForRandOrderBy(inner, text)
+	}
 
 	for _, item := range sel.OrderBy {
 		if r.isRandFunc(item.Expr) {

--- a/backend/plugin/advisor/mysql/rule_statement_join_strict_column_attrs.go
+++ b/backend/plugin/advisor/mysql/rule_statement_join_strict_column_attrs.go
@@ -80,6 +80,10 @@ func (r *joinStrictColumnAttrsOmniRule) checkSelect(sel *ast.SelectStmt) {
 	if sel == nil {
 		return
 	}
+	if inner := sel.ParenSource; inner != nil {
+		r.checkSelect(inner)
+		return
+	}
 	if sel.SetOp != ast.SetOpNone {
 		r.checkSelect(sel.Left)
 		r.checkSelect(sel.Right)

--- a/backend/plugin/advisor/mysql/rule_statement_maximum_join_table_count.go
+++ b/backend/plugin/advisor/mysql/rule_statement_maximum_join_table_count.go
@@ -68,6 +68,10 @@ func (r *maxJoinTableCountOmniRule) checkSelect(sel *ast.SelectStmt, text string
 	if sel == nil {
 		return
 	}
+	if inner := sel.ParenSource; inner != nil {
+		r.checkSelect(inner, text)
+		return
+	}
 	if sel.SetOp != ast.SetOpNone {
 		r.checkSelect(sel.Left, text)
 		r.checkSelect(sel.Right, text)

--- a/backend/plugin/advisor/mysql/rule_statement_maximum_limit_value.go
+++ b/backend/plugin/advisor/mysql/rule_statement_maximum_limit_value.go
@@ -70,6 +70,13 @@ func (r *maxLimitValueOmniRule) checkSelectLimit(sel *ast.SelectStmt, _ string) 
 	if sel == nil {
 		return
 	}
+	if inner := sel.ParenSource; inner != nil {
+		if sel.Limit != nil {
+			r.checkLimit(sel.Limit)
+		}
+		r.checkSelectLimit(inner, "")
+		return
+	}
 	if sel.SetOp != ast.SetOpNone {
 		r.checkSelectLimit(sel.Left, "")
 		r.checkSelectLimit(sel.Right, "")

--- a/backend/plugin/advisor/mysql/rule_statement_where_disallow_using_function.go
+++ b/backend/plugin/advisor/mysql/rule_statement_where_disallow_using_function.go
@@ -161,6 +161,10 @@ func (r *whereDisallowFuncOmniRule) checkSelectInScope(sel *ast.SelectStmt, oute
 			r.checkSelect(cte.Select)
 		}
 	}
+	if inner := sel.ParenSource; inner != nil {
+		r.checkSelectInScope(inner, outer)
+		return
+	}
 	if sel.SetOp != ast.SetOpNone {
 		r.checkSelectInScope(sel.Left, outer)
 		r.checkSelectInScope(sel.Right, outer)

--- a/backend/plugin/advisor/mysql/rule_statement_where_maximum_logical_operator_count.go
+++ b/backend/plugin/advisor/mysql/rule_statement_where_maximum_logical_operator_count.go
@@ -97,6 +97,10 @@ func (r *maxLogicalOperatorOmniRule) checkSelect(sel *ast.SelectStmt, text strin
 	if sel == nil {
 		return
 	}
+	if inner := sel.ParenSource; inner != nil {
+		r.checkSelect(inner, text)
+		return
+	}
 	if sel.SetOp != ast.SetOpNone {
 		r.checkSelect(sel.Left, text)
 		r.checkSelect(sel.Right, text)

--- a/backend/plugin/advisor/mysql/rule_stmt_disallow_limit.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_disallow_limit.go
@@ -75,11 +75,20 @@ func (r *disallowLimitOmniRule) checkSelectLimit(sel *ast.SelectStmt, text strin
 	if sel == nil {
 		return
 	}
+	if inner := sel.ParenSource; inner != nil {
+		if sel.Limit != nil {
+			r.addLimitAdvice(code.InsertUseLimit, text, sel.Loc)
+		}
+		r.checkSelectLimit(inner, text)
+		return
+	}
 	if sel.SetOp != ast.SetOpNone {
 		// Check set operation top-level limit.
 		if sel.Limit != nil {
 			r.addLimitAdvice(code.InsertUseLimit, text, sel.Loc)
 		}
+		r.checkSelectLimit(sel.Left, text)
+		r.checkSelectLimit(sel.Right, text)
 		return
 	}
 	if sel.Limit != nil {

--- a/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_select.go
+++ b/backend/plugin/advisor/mysql/rule_stmt_where_requirement_for_select.go
@@ -72,6 +72,10 @@ func (r *whereRequirementForSelectOmniRule) checkSelectStmt(sel *ast.SelectStmt,
 			r.checkSelectStmt(cte.Select, text)
 		}
 	}
+	if inner := sel.ParenSource; inner != nil {
+		r.checkSelectStmt(inner, text)
+		return
+	}
 
 	// Check set operations (UNION left/right).
 	if sel.SetOp != ast.SetOpNone {

--- a/backend/plugin/advisor/mysql/test/statement_disallow_limit.yaml
+++ b/backend/plugin/advisor/mysql/test/statement_disallow_limit.yaml
@@ -36,6 +36,18 @@
         column: 0
       endposition: null
 - statement: |
+    INSERT INTO tech_book SELECT * FROM tech_book;
+    INSERT INTO tech_book (SELECT * FROM tech_book LIMIT 1);
+  want:
+    - status: 2
+      code: 1103
+      title: STATEMENT_DISALLOW_LIMIT
+      content: LIMIT clause is forbidden in INSERT, UPDATE and DELETE statement, but "INSERT INTO tech_book (SELECT * FROM tech_book LIMIT 1);" uses
+      startposition:
+        line: 2
+        column: 0
+      endposition: null
+- statement: |
     UPDATE tech_book SET name = 'my name';
     UPDATE tech_book SET name = 'my name' LIMIT 10;
   want:

--- a/backend/plugin/advisor/mysql/test/statement_where_disallow_functions_and_calculations.yaml
+++ b/backend/plugin/advisor/mysql/test/statement_where_disallow_functions_and_calculations.yaml
@@ -10,6 +10,18 @@
         column: 0
       endposition: null
 
+# Test: Function on indexed column inside a parenthesized query expression should flag.
+- statement: (SELECT * FROM tech_book WHERE UPPER(name) = 'test');
+  want:
+    - status: 2
+      code: 234
+      title: STATEMENT_WHERE_DISALLOW_FUNCTIONS_AND_CALCULATIONS
+      content: "Function \"UPPER\" is applied to indexed column \"name\" in the WHERE clause, which prevents index usage"
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+
 # Test: Calculation on indexed column should flag
 - statement: SELECT * FROM tech_book WHERE id + 1 > 5;
   want:

--- a/backend/plugin/advisor/mysql/test/statement_where_require_select.yaml
+++ b/backend/plugin/advisor/mysql/test/statement_where_require_select.yaml
@@ -18,6 +18,18 @@
     SELECT id FROM book WHERE id > 0;
 - statement: |
     CREATE TABLE book(id INT);
+    (SELECT id FROM book);
+  want:
+    - status: 2
+      code: 202
+      title: STATEMENT_WHERE_REQUIRE_SELECT
+      content: '"(SELECT id FROM book);" requires WHERE clause'
+      startposition:
+        line: 2
+        column: 0
+      endposition: null
+- statement: |
+    CREATE TABLE book(id INT);
     SELECT id
     FROM book
     WHERE id > (

--- a/backend/plugin/db/mysql/query_test.go
+++ b/backend/plugin/db/mysql/query_test.go
@@ -71,6 +71,16 @@ func TestGetStatementWithResultLimit(t *testing.T) {
 			stmt:  "SELECT firstName, lastName FROM employees UNION SELECT contactFirstName, contactLastName FROM customers;",
 			count: 10,
 			want:  "SELECT firstName, lastName FROM employees UNION SELECT contactFirstName, contactLastName FROM customers LIMIT 10;",
+		},
+		{
+			stmt:  "(SELECT * FROM t LIMIT 100) LIMIT 20;",
+			count: 10,
+			want:  "(SELECT * FROM t LIMIT 100) LIMIT 10;",
+		},
+		{
+			stmt:  "(SELECT * FROM t) FOR UPDATE;",
+			count: 10,
+			want:  "(SELECT * FROM t) LIMIT 10 FOR UPDATE;",
 		}, {
 			stmt:  "SELECT customerNumber, checkNumber, amount FROM payments WHERE amount = (SELECT MAX(amount) FROM payments);",
 			count: 10,

--- a/backend/plugin/parser/mysql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/mysql/query_span_extractor_omni.go
@@ -125,6 +125,15 @@ func (q *omniQuerySpanExtractor) extractOmniSelectStmt(stmt *ast.SelectStmt) (*b
 	if err := q.processOmniCTEs(stmt.CTEs); err != nil {
 		return nil, err
 	}
+	if inner := stmt.ParenSource; inner != nil {
+		return q.extractOmniSelectStmt(inner)
+	}
+	if tableStmt := stmt.TableSource; tableStmt != nil {
+		return q.extractOmniTableStmt(tableStmt)
+	}
+	if valuesStmt := stmt.ValuesSource; valuesStmt != nil {
+		return q.extractOmniValuesStmt(valuesStmt)
+	}
 	if stmt.SetOp != ast.SetOpNone {
 		return q.extractOmniSetOp(stmt)
 	}
@@ -243,10 +252,11 @@ func (q *omniQuerySpanExtractor) extractOmniNonRecursiveCTE(cte *ast.CommonTable
 }
 
 func (q *omniQuerySpanExtractor) extractOmniRecursiveCTE(cte *ast.CommonTableExpr) (*base.PseudoTable, error) {
-	if cte.Select == nil || cte.Select.SetOp == ast.SetOpNone {
+	selectStmt := ast.UnwrapParenSource(cte.Select)
+	if selectStmt == nil || selectStmt.SetOp == ast.SetOpNone {
 		return q.extractOmniNonRecursiveCTE(cte)
 	}
-	initialTable, err := q.extractOmniRecursiveCTEAnchor(cte.Select)
+	initialTable, err := q.extractOmniRecursiveCTEAnchor(selectStmt)
 	if err != nil {
 		return nil, err
 	}
@@ -289,6 +299,7 @@ func (q *omniQuerySpanExtractor) extractOmniRecursiveCTE(cte *ast.CommonTableExp
 }
 
 func (q *omniQuerySpanExtractor) extractOmniRecursiveCTEAnchor(stmt *ast.SelectStmt) (*base.PseudoTable, error) {
+	stmt = ast.UnwrapParenSource(stmt)
 	if stmt == nil || stmt.SetOp == ast.SetOpNone {
 		return q.extractOmniSelectStmt(stmt)
 	}
@@ -1106,6 +1117,15 @@ func collectOmniAccessTablesFromNode(result base.SourceColumnSet, node ast.Node,
 		}
 		if n.Right != nil {
 			collectOmniAccessTablesFromNode(result, n.Right, defaultDatabase, normalizeStarRocksCluster)
+		}
+		if inner := n.ParenSource; inner != nil {
+			collectOmniAccessTablesFromNode(result, inner, defaultDatabase, normalizeStarRocksCluster)
+		}
+		if tableStmt := n.TableSource; tableStmt != nil {
+			collectOmniAccessTablesFromNode(result, tableStmt, defaultDatabase, normalizeStarRocksCluster)
+		}
+		if valuesStmt := n.ValuesSource; valuesStmt != nil {
+			collectOmniAccessTablesFromNode(result, valuesStmt, defaultDatabase, normalizeStarRocksCluster)
 		}
 		for _, target := range n.TargetList {
 			collectOmniAccessTablesFromExpr(result, target, defaultDatabase, normalizeStarRocksCluster)

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260608064432-78a73ea71d76
+	github.com/bytebase/omni v0.0.0-20260608071738-731478feee32
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260605060926-2a62e5b9cf03
+	github.com/bytebase/omni v0.0.0-20260608064432-78a73ea71d76
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260605060926-2a62e5b9cf03 h1:mAMVA0S3EEbC+t62NWFNPAau+MwjerE90b9zRfxDPMQ=
-github.com/bytebase/omni v0.0.0-20260605060926-2a62e5b9cf03/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260608064432-78a73ea71d76 h1:gC/3nRtEwNKJ0kUJ/tBwMF0ElikJVRadiAMuhYKcsKA=
+github.com/bytebase/omni v0.0.0-20260608064432-78a73ea71d76/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260608064432-78a73ea71d76 h1:gC/3nRtEwNKJ0kUJ/tBwMF0ElikJVRadiAMuhYKcsKA=
-github.com/bytebase/omni v0.0.0-20260608064432-78a73ea71d76/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260608071738-731478feee32 h1:Ws8/0AvaLfN19AADsQJMuq0mxWW9fLno72HAEdP/R+k=
+github.com/bytebase/omni v0.0.0-20260608071738-731478feee32/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Update `github.com/bytebase/omni` to `v0.0.0-20260608071738-731478feee32`.
- Pull in Oracle parser fixes that cover the previously observed split/parse issues, including the `FROM` fragment syntax error class and wrapped PL/SQL procedure parsing.
- Adapt Bytebase MySQL consumers to Omni's parenthesized query expression AST (`ParenSource`, `TableSource`, `ValuesSource`) without reflection shims.

## Validation
- Local exported Oracle corpus scan from the earlier revision of this PR: 1157 statements, 2 parse failures, 2 metadata failures. The remaining failures are `CREATE TABLE` statements that were separately verified to be rejected by real Oracle with `ORA-02253`.
- Confirmed `origin/main` in Omni at `731478feee3213ec60e12306f49f4a838b2cdee7` contains Oracle `78a73ea` and the MySQL parenthesized-query AST/helper changes.
- `go test -count=1 ./backend/plugin/parser/mysql -timeout 5m`
- `go test -count=1 ./backend/plugin/advisor/mysql -timeout 5m`
- `go test -count=1 ./backend/plugin/db/mysql -timeout 5m`
- `go test -count=1 ./backend/plugin/schema/mysql -run '^(TestWalkThrough|TestWalkThroughLoader|TestGetDatabaseMetadataOmni|TestGetDatabaseDefinitionOmni)' -timeout 5m`
- `go test -count=1 ./backend/plugin/parser/plsql -timeout 5m`
- `go test -count=1 ./backend/plugin/advisor/oracle -timeout 5m`
- `go test -count=1 ./backend/plugin/db/oracle -timeout 5m`
- `go test -count=1 ./backend/plugin/schema/oracle -run '^(TestGetDatabaseMetadataOmni|TestGetDatabaseMetadataUsesOmni|TestGetDatabaseMetadataOmniParsesSlashTerminatedPLSQLScript|TestTopologicalOrderCreateObjects|TestTopologicalOrderWithCycles)$' -timeout 5m`
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Notes
- Full `go test -count=1 ./backend/plugin/schema/oracle -timeout 5m` was not usable locally because Docker daemon is unavailable for Oracle testcontainers.

## Checklist
- No breaking change: dependency parser compatibility update plus MySQL AST consumer adaptation.
- Composite-PK safety: skipped, no store or migration changes.
- SonarCloud properties: skipped, no new committed files or directories.