### PR TITLE
chore(deps): bump bytebase/omni to 5b9e7509 (partiql B12/B13 fixes)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260605060926-2a62e5b9cf03
+	github.com/bytebase/omni v0.0.0-20260605065156-5b9e750982c5
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260605060926-2a62e5b9cf03 h1:mAMVA0S3EEbC+t62NWFNPAau+MwjerE90b9zRfxDPMQ=
-github.com/bytebase/omni v0.0.0-20260605060926-2a62e5b9cf03/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260605065156-5b9e750982c5 h1:k+LIxAdWEH4p2bHbdoyuidpz6L38ub9wTMdcp8iVo2s=
+github.com/bytebase/omni v0.0.0-20260605065156-5b9e750982c5/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
Bumps `github.com/bytebase/omni` `2a62e5b9` → `5b9e7509` to pull the final two PartiQL parser fixes into the DynamoDB SQL editor.

- **B12** — accept modifier-prefixed `CROSS JOIN` (`FULL`/`LEFT`/`RIGHT`/`INNER`/`OUTER [OUTER]?` `CROSS JOIN`), previously wrongly rejected.
- **B13** — completion no longer misreads a dotted path step `x.from` as a `FROM` clause (was suggesting all tables).

These were the last two of a 13-fix PartiQL re-validation pass against the ANTLR grammar oracle. **bytebase already pins the other 16 commits** (the 10 bug fixes `#207`–`#212` + the 8-PR negative-test backfill `#228`–`#235`); this is the only remaining consumed change.

## Scope / blast radius
Intentionally a **surgical, partiql-only bump**. The range `2a62e5b9..5b9e7509` contains exactly one bytebase-consumed change (omni partiql #240); the only other commit (googlesql #239) is in a package bytebase does not import. No tidb/pg/oracle/mysql behavior changes ride along. (omni HEAD additionally has unrelated oracle/mysql fixes — a future bump can take those.)

## Verification
- `backend/plugin/parser/partiql` (the sole omni-partiql consumer): build + tests green.
- Full `go build ./backend/...`: green.
- `go.sum` delta is the omni pin hash only (no transitive deps moved).
- Pending: end-to-end re-verification of the 4 consumed features (parse/split/validate/complete) in the DynamoDB-Local emulator via the SQL editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)