### PR TITLE
fix: use shared select for page size control

### DIFF
--- a/frontend/src/react/components/ui/select.test.tsx
+++ b/frontend/src/react/components/ui/select.test.tsx
@@ -1,7 +1,7 @@
 import { act, type ReactNode } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { Select, SelectContent } from "./select";
+import { Select, SelectContent, SelectTrigger } from "./select";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -14,8 +14,16 @@ const selectMocks = vi.hoisted(() => ({
 vi.mock("@base-ui/react/select", () => ({
   Select: {
     Root: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-    Trigger: ({ children }: { children: ReactNode }) => (
-      <button type="button">{children}</button>
+    Trigger: ({
+      children,
+      ...props
+    }: {
+      children: ReactNode;
+      className?: string;
+    }) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
     ),
     Icon: ({ children }: { children: ReactNode }) => <>{children}</>,
     Value: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -90,6 +98,34 @@ describe("SelectContent", () => {
         className: expect.stringContaining("custom-positioner"),
         sideOffset: 8,
       })
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});
+
+describe("SelectTrigger", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("uses pointer cursor", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <Select>
+          <SelectTrigger>Role</SelectTrigger>
+        </Select>
+      );
+    });
+
+    expect(container.querySelector("button")?.className).toContain(
+      "cursor-pointer"
     );
 
     await act(async () => {

--- a/frontend/src/react/components/ui/select.tsx
+++ b/frontend/src/react/components/ui/select.tsx
@@ -12,6 +12,7 @@ const Select = BaseSelect.Root;
 const selectTriggerVariants = cva(
   cn(
     "inline-flex items-center justify-between gap-1 rounded-xs border border-control-border bg-background text-control whitespace-nowrap",
+    "cursor-pointer",
     "hover:bg-control-bg focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent",
     "disabled:pointer-events-none disabled:opacity-50"
   ),

--- a/frontend/src/react/hooks/usePagedData.test.tsx
+++ b/frontend/src/react/hooks/usePagedData.test.tsx
@@ -1,7 +1,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { usePagedData } from "./usePagedData";
+import { PagedTableFooter, usePagedData } from "./usePagedData";
 
 vi.mock("@/react/hooks/useSessionPageSize", () => ({
   getPageSizeOptions: () => [50, 100],
@@ -87,5 +87,39 @@ describe("usePagedData", () => {
     expect(container.querySelector("[data-state]")?.textContent).toBe(
       "items/1"
     );
+  });
+});
+
+describe("PagedTableFooter", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("uses the shared select trigger for page size", async () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <PagedTableFooter
+          pageSize={10}
+          pageSizeOptions={[10, 20]}
+          onPageSizeChange={vi.fn()}
+          hasMore={false}
+          isFetchingMore={false}
+          onLoadMore={vi.fn()}
+        />
+      );
+    });
+
+    expect(container.querySelector("select")).toBeNull();
+    expect(container.querySelector("button")?.className).toContain(
+      "cursor-pointer"
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
   });
 });

--- a/frontend/src/react/hooks/usePagedData.tsx
+++ b/frontend/src/react/hooks/usePagedData.tsx
@@ -2,6 +2,13 @@ import { useCallback, useEffect, useReducer, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/react/components/ui/select";
+import {
   getPageSizeOptions,
   useSessionPageSize,
 } from "@/react/hooks/useSessionPageSize";
@@ -242,17 +249,21 @@ export function PagedTableFooter({
         <span className="text-sm text-control-light">
           {t("common.rows-per-page")}
         </span>
-        <select
-          value={pageSize}
-          onChange={(e) => onPageSizeChange(Number(e.target.value))}
-          className="border border-control-border rounded-sm text-sm pl-2 pr-6 py-1 min-w-[5rem]"
+        <Select
+          value={String(pageSize)}
+          onValueChange={(value) => onPageSizeChange(Number(value))}
         >
-          {pageSizeOptions.map((opt) => (
-            <option key={opt} value={opt}>
-              {opt}
-            </option>
-          ))}
-        </select>
+          <SelectTrigger size="sm" className="min-w-[5rem] text-control">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {pageSizeOptions.map((opt) => (
+              <SelectItem key={opt} value={String(opt)}>
+                {opt}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
       {hasMore && (
         <Button


### PR DESCRIPTION
## Summary
- Replace the native page-size `<select>` in `PagedTableFooter` with the shared React `Select` primitives.
- Add `cursor-pointer` to the shared `SelectTrigger` so page-size and other React select triggers show the expected cursor.
- Add regression coverage for the footer control and shared select trigger styling.

## Test Plan
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test -- usePagedData.test.tsx select.test.tsx`

## Checklist
- Breaking change: no
- Composite-PK query safety: skipped, frontend-only
- SonarCloud properties: skipped, no new files or directories
