### PR TITLE
chore: migrate redshift completion to omni

### DIFF
--- a/backend/plugin/parser/redshift/completion.go
+++ b/backend/plugin/parser/redshift/completion.go
@@ -134,7 +134,10 @@ func buildCompletionCatalog(ctx context.Context, cCtx base.CompletionContext) *r
 			if viewMeta == nil {
 				continue
 			}
-			execCompletionDDL(cat, createViewDDL("MATERIALIZED VIEW", schemaName, viewName, nil))
+			cat.SetSearchPath([]string{schemaName, "public"})
+			if viewMeta.GetDefinition() == "" || !execCompletionDDL(cat, createMaterializedViewDDL(schemaName, viewName, viewMeta.GetDefinition())) {
+				execCompletionDDL(cat, createViewDDL("MATERIALIZED VIEW", schemaName, viewName, nil))
+			}
 		}
 		for _, sequenceName := range schemaMeta.ListSequenceNames() {
 			execCompletionDDL(cat, fmt.Sprintf("CREATE SEQUENCE %s.%s;", quoteIdent(schemaName), quoteIdent(sequenceName)))
@@ -149,8 +152,9 @@ func buildCompletionCatalog(ctx context.Context, cCtx base.CompletionContext) *r
 	return cat
 }
 
-func execCompletionDDL(cat *redshiftcatalog.Catalog, sql string) {
-	_, _ = cat.Exec(sql, nil)
+func execCompletionDDL(cat *redshiftcatalog.Catalog, sql string) bool {
+	_, err := cat.Exec(sql, nil)
+	return err == nil
 }
 
 func createTableDDL(schemaName, tableName string, columns []*storepb.ColumnMetadata) string {
@@ -183,6 +187,20 @@ func createViewDDL(kind, schemaName, viewName string, columns []*storepb.ColumnM
 		quoteIdent(schemaName),
 		quoteIdent(viewName),
 		strings.Join(selectItems, ", "),
+	)
+}
+
+func createMaterializedViewDDL(schemaName, viewName, definition string) string {
+	definition = strings.TrimSpace(definition)
+	definition = strings.TrimSuffix(definition, ";")
+	if strings.HasPrefix(strings.ToUpper(definition), "CREATE ") {
+		return definition + ";"
+	}
+	return fmt.Sprintf(
+		"CREATE MATERIALIZED VIEW %s.%s AS %s;",
+		quoteIdent(schemaName),
+		quoteIdent(viewName),
+		definition,
 	)
 }
 

--- a/backend/plugin/parser/redshift/completion.go
+++ b/backend/plugin/parser/redshift/completion.go
@@ -6,1290 +6,76 @@ import (
 	"slices"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
-	"github.com/antlr4-go/antlr/v4"
-	parser "github.com/bytebase/parser/redshift"
+	redshiftcatalog "github.com/bytebase/omni/redshift/catalog"
+	redshiftcompletion "github.com/bytebase/omni/redshift/completion"
 
-	"github.com/bytebase/bytebase/backend/generated-go/store"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
-	"github.com/bytebase/bytebase/backend/plugin/parser/pg"
-	"github.com/bytebase/bytebase/backend/store/model"
-)
-
-var (
-	// globalFollowSetsByState is the global follow sets by state.
-	// It is shared by all Redshift completers.
-	// The FollowSetsByState is the thread-safe struct.
-	globalFollowSetsByState = base.NewFollowSetsByState()
 )
 
 func init() {
-	base.RegisterCompleteFunc(store.Engine_REDSHIFT, Completion)
+	base.RegisterCompleteFunc(storepb.Engine_REDSHIFT, Completion)
 }
 
-// Completion is the entry point of Redshift code completion.
+// Completion returns Redshift auto-completion candidates backed by omni's
+// parser-native completer. Bytebase metadata is copied into an omni Redshift
+// catalog with minimal DDL so the completer can resolve schemas, relations,
+// columns, sequences, and Redshift-specific grammar slots.
 func Completion(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) ([]base.Candidate, error) {
-	completer := NewStandardCompleter(ctx, cCtx, statement, caretLine, caretOffset)
-	result, err := completer.completion()
-	if err != nil {
-		return nil, err
-	}
-	if len(result) > 0 {
-		return result, nil
-	}
+	cat := buildCompletionCatalog(ctx, cCtx)
 
-	trickyCompleter := NewTrickyCompleter(ctx, cCtx, statement, caretLine, caretOffset)
-	return trickyCompleter.completion()
-}
+	sql, line, offset := completionStatementAtCaret(statement, caretLine, caretOffset)
+	byteOffset := caretToByteOffset(sql, line, offset)
+	omniCandidates := redshiftcompletion.Complete(sql, byteOffset, cat)
 
-func newIgnoredTokens() map[int]bool {
-	return map[int]bool{
-		antlr.TokenEOF:                                                   true,
-		parser.RedshiftLexerDollar:                                       true,
-		parser.RedshiftLexerOPEN_PAREN:                                   true,
-		parser.RedshiftLexerCLOSE_PAREN:                                  true,
-		parser.RedshiftLexerOPEN_BRACKET:                                 true,
-		parser.RedshiftLexerCLOSE_BRACKET:                                true,
-		parser.RedshiftLexerCOMMA:                                        true,
-		parser.RedshiftLexerSEMI:                                         true,
-		parser.RedshiftLexerCOLON:                                        true,
-		parser.RedshiftLexerEQUAL:                                        true,
-		parser.RedshiftLexerDOT:                                          true,
-		parser.RedshiftLexerPLUS:                                         true,
-		parser.RedshiftLexerMINUS:                                        true,
-		parser.RedshiftLexerSLASH:                                        true,
-		parser.RedshiftLexerCARET:                                        true,
-		parser.RedshiftLexerLT:                                           true,
-		parser.RedshiftLexerGT:                                           true,
-		parser.RedshiftLexerLESS_LESS:                                    true,
-		parser.RedshiftLexerGREATER_GREATER:                              true,
-		parser.RedshiftLexerCOLON_EQUALS:                                 true,
-		parser.RedshiftLexerLESS_EQUALS:                                  true,
-		parser.RedshiftLexerEQUALS_GREATER:                               true,
-		parser.RedshiftLexerGREATER_EQUALS:                               true,
-		parser.RedshiftLexerDOT_DOT:                                      true,
-		parser.RedshiftLexerNOT_EQUALS:                                   true,
-		parser.RedshiftLexerTYPECAST:                                     true,
-		parser.RedshiftLexerPERCENT:                                      true,
-		parser.RedshiftLexerPARAM:                                        true,
-		parser.RedshiftLexerOperator:                                     true,
-		parser.RedshiftLexerIdentifier:                                   true,
-		parser.RedshiftLexerQuotedIdentifier:                             true,
-		parser.RedshiftLexerUnterminatedQuotedIdentifier:                 true,
-		parser.RedshiftLexerInvalidQuotedIdentifier:                      true,
-		parser.RedshiftLexerInvalidUnterminatedQuotedIdentifier:          true,
-		parser.RedshiftLexerUnicodeQuotedIdentifier:                      true,
-		parser.RedshiftLexerUnterminatedUnicodeQuotedIdentifier:          true,
-		parser.RedshiftLexerInvalidUnicodeQuotedIdentifier:               true,
-		parser.RedshiftLexerInvalidUnterminatedUnicodeQuotedIdentifier:   true,
-		parser.RedshiftLexerStringConstant:                               true,
-		parser.RedshiftLexerUnterminatedStringConstant:                   true,
-		parser.RedshiftLexerUnicodeEscapeStringConstant:                  true,
-		parser.RedshiftLexerUnterminatedUnicodeEscapeStringConstant:      true,
-		parser.RedshiftLexerBeginDollarStringConstant:                    true,
-		parser.RedshiftLexerBinaryStringConstant:                         true,
-		parser.RedshiftLexerUnterminatedBinaryStringConstant:             true,
-		parser.RedshiftLexerInvalidBinaryStringConstant:                  true,
-		parser.RedshiftLexerInvalidUnterminatedBinaryStringConstant:      true,
-		parser.RedshiftLexerHexadecimalStringConstant:                    true,
-		parser.RedshiftLexerUnterminatedHexadecimalStringConstant:        true,
-		parser.RedshiftLexerInvalidHexadecimalStringConstant:             true,
-		parser.RedshiftLexerInvalidUnterminatedHexadecimalStringConstant: true,
-		parser.RedshiftLexerIntegral:                                     true,
-		parser.RedshiftLexerNumericFail:                                  true,
-		parser.RedshiftLexerNumeric:                                      true,
-	}
-}
-
-func newPreferredRules() map[int]bool {
-	return map[int]bool{
-		parser.RedshiftParserRULE_relation_expr:  true,
-		parser.RedshiftParserRULE_qualified_name: true,
-		parser.RedshiftParserRULE_columnref:      true,
-		parser.RedshiftParserRULE_func_name:      true,
-	}
-}
-
-func newNoSeparatorRequired() map[int]bool {
-	return map[int]bool{
-		parser.RedshiftLexerDollar:          true,
-		parser.RedshiftLexerOPEN_PAREN:      true,
-		parser.RedshiftLexerCLOSE_PAREN:     true,
-		parser.RedshiftLexerOPEN_BRACKET:    true,
-		parser.RedshiftLexerCLOSE_BRACKET:   true,
-		parser.RedshiftLexerCOMMA:           true,
-		parser.RedshiftLexerSEMI:            true,
-		parser.RedshiftLexerCOLON:           true,
-		parser.RedshiftLexerEQUAL:           true,
-		parser.RedshiftLexerDOT:             true,
-		parser.RedshiftLexerPLUS:            true,
-		parser.RedshiftLexerMINUS:           true,
-		parser.RedshiftLexerSLASH:           true,
-		parser.RedshiftLexerCARET:           true,
-		parser.RedshiftLexerLT:              true,
-		parser.RedshiftLexerGT:              true,
-		parser.RedshiftLexerLESS_LESS:       true,
-		parser.RedshiftLexerGREATER_GREATER: true,
-		parser.RedshiftLexerCOLON_EQUALS:    true,
-		parser.RedshiftLexerLESS_EQUALS:     true,
-		parser.RedshiftLexerEQUALS_GREATER:  true,
-		parser.RedshiftLexerGREATER_EQUALS:  true,
-		parser.RedshiftLexerDOT_DOT:         true,
-		parser.RedshiftLexerNOT_EQUALS:      true,
-		parser.RedshiftLexerTYPECAST:        true,
-		parser.RedshiftLexerPERCENT:         true,
-		parser.RedshiftLexerPARAM:           true,
-	}
-}
-
-type Completer struct {
-	ctx                 context.Context
-	core                *base.CodeCompletionCore
-	scene               base.SceneType
-	parser              *parser.RedshiftParser
-	lexer               *parser.RedshiftLexer
-	scanner             *base.Scanner
-	instanceID          string
-	defaultDatabase     string
-	defaultSchema       string
-	schemaNotSelected   bool // true if user didn't explicitly select a schema
-	getMetadata         base.GetDatabaseMetadataFunc
-	listDatabaseNames   base.ListDatabaseNamesFunc
-	metadataCache       map[string]*model.DatabaseMetadata
-	noSeparatorRequired map[int]bool
-	// referencesStack is a hierarchical stack of table references.
-	// We'll update the stack when we encounter a new FROM clauses.
-	referencesStack [][]base.TableReference
-	// references is the flattened table references.
-	// It's helpful to look up the table reference.
-	references         []base.TableReference
-	cteCache           map[int][]*base.VirtualTableReference
-	cteTables          []*base.VirtualTableReference
-	caretTokenIsQuoted bool
-}
-
-func NewTrickyCompleter(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) *Completer {
-	p, lexer, scanner := prepareTrickyParserAndScanner(statement, caretLine, caretOffset)
-	// For all Redshift completers, we use one global follow sets by state.
-	// The FollowSetsByState is the thread-safe struct.
-	core := base.NewCodeCompletionCore(
-		ctx,
-		p,
-		newIgnoredTokens(),
-		newPreferredRules(),
-		&globalFollowSetsByState,
-		parser.RedshiftParserRULE_simple_select_pramary,
-		parser.RedshiftParserRULE_select_no_parens,
-		parser.RedshiftParserRULE_target_alias,
-		parser.RedshiftParserRULE_with_clause,
-	)
-	defaultSchema := cCtx.DefaultSchema
-	schemaNotSelected := defaultSchema == ""
-	if defaultSchema == "" {
-		defaultSchema = "public"
-	}
-	return &Completer{
-		ctx:                 ctx,
-		core:                core,
-		scene:               cCtx.Scene,
-		parser:              p,
-		lexer:               lexer,
-		scanner:             scanner,
-		instanceID:          cCtx.InstanceID,
-		defaultDatabase:     cCtx.DefaultDatabase,
-		defaultSchema:       defaultSchema,
-		schemaNotSelected:   schemaNotSelected,
-		getMetadata:         cCtx.Metadata,
-		metadataCache:       make(map[string]*model.DatabaseMetadata),
-		noSeparatorRequired: newNoSeparatorRequired(),
-		cteCache:            make(map[int][]*base.VirtualTableReference),
-	}
-}
-
-func NewStandardCompleter(ctx context.Context, cCtx base.CompletionContext, statement string, caretLine int, caretOffset int) *Completer {
-	p, lexer, scanner := prepareParserAndScanner(statement, caretLine, caretOffset)
-	// For all Redshift completers, we use one global follow sets by state.
-	// The FollowSetsByState is the thread-safe struct.
-	core := base.NewCodeCompletionCore(
-		ctx,
-		p,
-		newIgnoredTokens(),
-		newPreferredRules(),
-		&globalFollowSetsByState,
-		parser.RedshiftParserRULE_simple_select_pramary,
-		parser.RedshiftParserRULE_select_no_parens,
-		parser.RedshiftParserRULE_target_alias,
-		parser.RedshiftParserRULE_with_clause,
-	)
-	defaultSchema := cCtx.DefaultSchema
-	schemaNotSelected := defaultSchema == ""
-	if defaultSchema == "" {
-		defaultSchema = "public"
-	}
-	return &Completer{
-		ctx:                 ctx,
-		core:                core,
-		scene:               cCtx.Scene,
-		parser:              p,
-		lexer:               lexer,
-		scanner:             scanner,
-		instanceID:          cCtx.InstanceID,
-		defaultDatabase:     cCtx.DefaultDatabase,
-		defaultSchema:       defaultSchema,
-		schemaNotSelected:   schemaNotSelected,
-		getMetadata:         cCtx.Metadata,
-		metadataCache:       make(map[string]*model.DatabaseMetadata),
-		noSeparatorRequired: newNoSeparatorRequired(),
-		cteCache:            make(map[int][]*base.VirtualTableReference),
-	}
-}
-
-func (c *Completer) completion() ([]base.Candidate, error) {
-	// Check the caret token is quoted or not.
-	// This check should be done before checking the caret token is a separator or not.
-	if c.scanner.IsTokenType(parser.RedshiftLexerQuotedIdentifier) ||
-		c.scanner.IsTokenType(parser.RedshiftLexerInvalidQuotedIdentifier) ||
-		c.scanner.IsTokenType(parser.RedshiftLexerUnicodeQuotedIdentifier) {
-		c.caretTokenIsQuoted = true
-	}
-
-	caretIndex := c.scanner.GetIndex()
-	if caretIndex > 0 && !c.noSeparatorRequired[c.scanner.GetPreviousTokenType(false /* skipHidden */)] {
-		caretIndex--
-	}
-	c.referencesStack = append([][]base.TableReference{{}}, c.referencesStack...)
-	c.parser.Reset()
-	var context antlr.ParserRuleContext
-	if c.scene == base.SceneTypeQuery {
-		context = c.parser.Selectstmt()
-	} else {
-		context = c.parser.Root()
-	}
-
-	candidates := c.core.CollectCandidates(caretIndex, context)
-
-	for ruleName := range candidates.Rules {
-		if ruleName == parser.RedshiftParserRULE_columnref {
-			c.collectLeadingTableReferences(caretIndex)
-			c.takeReferencesSnapshot()
-			c.collectRemainingTableReferences()
-			c.takeReferencesSnapshot()
+	result := make([]base.Candidate, 0, len(omniCandidates))
+	seen := make(map[string]bool, len(omniCandidates))
+	for _, c := range omniCandidates {
+		candidate := base.Candidate{
+			Text:       completionCandidateText(c),
+			Type:       convertCandidateType(c.Type),
+			Definition: c.Definition,
+			Comment:    c.Comment,
 		}
-	}
-
-	return c.convertCandidates(candidates)
-}
-
-type CompletionMap map[string]base.Candidate
-
-func (m CompletionMap) Insert(entry base.Candidate) {
-	m[entry.String()] = entry
-}
-
-func (m CompletionMap) insertFunctions() {
-	// TODO: Add Redshift-specific functions
-	// For now, use a basic set of common functions
-	commonFunctions := []string{
-		"count", "sum", "avg", "min", "max", "abs", "ceil", "floor", "round",
-		"upper", "lower", "trim", "ltrim", "rtrim", "length", "substring",
-		"current_date", "current_timestamp", "date_part", "extract",
-		"coalesce", "nullif", "cast", "convert",
-		"row_number", "rank", "dense_rank", "lead", "lag",
-		"listagg", "median", "percentile_cont", "approximate_count_distinct",
-	}
-	for _, name := range commonFunctions {
-		m.Insert(base.Candidate{
-			Type: base.CandidateTypeFunction,
-			Text: name + "()",
-		})
-	}
-}
-
-func (m CompletionMap) insertSchemas(c *Completer) {
-	// Skip if user has specified the schema.
-	if c.defaultSchema != "" && c.defaultSchema != "public" {
-		return
-	}
-	for _, schema := range c.listAllSchemas() {
-		m.Insert(base.Candidate{
-			Type: base.CandidateTypeSchema,
-			Text: c.quotedIdentifierIfNeeded(schema),
-		})
-	}
-}
-
-func (m CompletionMap) insertTablesWithPrefix(c *Completer, schemas map[string]bool, includeSchemaPrefix bool) {
-	for schema := range schemas {
-		if len(schema) == 0 {
-			// User didn't specify the schema, we need to append cte tables.
-			for _, table := range c.cteTables {
-				m.Insert(base.Candidate{
-					Type: base.CandidateTypeTable,
-					Text: c.quotedIdentifierIfNeeded(table.Table),
-				})
-			}
+		key := candidate.String()
+		if seen[key] {
 			continue
 		}
-		for _, table := range c.listTables(schema) {
-			text := c.quotedIdentifierIfNeeded(table)
-			// Only add schema prefix if user didn't select a schema and the table is not in the default schema
-			if includeSchemaPrefix && schema != c.defaultSchema {
-				text = c.quotedIdentifierIfNeeded(schema) + "." + text
-			}
-			m.Insert(base.Candidate{
-				Type: base.CandidateTypeTable,
-				Text: text,
-			})
-		}
-		for _, fTable := range c.listForeignTables(schema) {
-			text := c.quotedIdentifierIfNeeded(fTable)
-			// Only add schema prefix if user didn't select a schema and the table is not in the default schema
-			if includeSchemaPrefix && schema != c.defaultSchema {
-				text = c.quotedIdentifierIfNeeded(schema) + "." + text
-			}
-			m.Insert(base.Candidate{
-				Type: base.CandidateTypeForeignTable,
-				Text: text,
-			})
-		}
-	}
-}
-
-func (m CompletionMap) insertViewsWithPrefix(c *Completer, schemas map[string]bool, includeSchemaPrefix bool) {
-	for schema := range schemas {
-		if len(schema) == 0 {
-			continue
-		}
-		for _, view := range c.listViews(schema) {
-			text := c.quotedIdentifierIfNeeded(view)
-			// Only add schema prefix if user didn't select a schema and the view is not in the default schema
-			if includeSchemaPrefix && schema != c.defaultSchema {
-				text = c.quotedIdentifierIfNeeded(schema) + "." + text
-			}
-			m.Insert(base.Candidate{
-				Type: base.CandidateTypeView,
-				Text: text,
-			})
-		}
-		for _, matView := range c.listMaterializedViews(schema) {
-			text := c.quotedIdentifierIfNeeded(matView)
-			// Only add schema prefix if user didn't select a schema and the view is not in the default schema
-			if includeSchemaPrefix && schema != c.defaultSchema {
-				text = c.quotedIdentifierIfNeeded(schema) + "." + text
-			}
-			m.Insert(base.Candidate{
-				Type: base.CandidateTypeMaterializedView,
-				Text: text,
-			})
-		}
-	}
-}
-
-func (m CompletionMap) insertColumns(c *Completer, schemas, tables map[string]bool) {
-	if _, exists := c.metadataCache[c.defaultDatabase]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, c.defaultDatabase)
-		if err != nil || metadata == nil {
-			return
-		}
-		c.metadataCache[c.defaultDatabase] = metadata
-	}
-
-	for schema := range schemas {
-		if len(schema) == 0 {
-			// User didn't specify the schema, we need to append cte tables.
-			for _, table := range c.cteTables {
-				if tables[table.Table] {
-					for _, column := range table.Columns {
-						m.Insert(base.Candidate{
-							Type: base.CandidateTypeColumn,
-							Text: c.quotedIdentifierIfNeeded(column),
-						})
-					}
-				}
-			}
-			continue
-		}
-		schemaMeta := c.metadataCache[c.defaultDatabase].GetSchemaMetadata(schema)
-		if schemaMeta == nil {
-			continue
-		}
-		for table := range tables {
-			tableMeta := schemaMeta.GetTable(table)
-			if tableMeta == nil {
-				continue
-			}
-			for _, column := range tableMeta.GetProto().GetColumns() {
-				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
-				if !column.Nullable {
-					definition += ", NOT NULL"
-				}
-				m.Insert(base.Candidate{
-					Type:       base.CandidateTypeColumn,
-					Text:       c.quotedIdentifierIfNeeded(column.Name),
-					Definition: definition,
-					Comment:    column.Comment,
-				})
-			}
-		}
-	}
-}
-
-func (m CompletionMap) insertAllColumns(c *Completer) {
-	if _, exists := c.metadataCache[c.defaultDatabase]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, c.defaultDatabase)
-		if err != nil || metadata == nil {
-			return
-		}
-		c.metadataCache[c.defaultDatabase] = metadata
-	}
-
-	metadata := c.metadataCache[c.defaultDatabase]
-	for _, schema := range metadata.ListSchemaNames() {
-		schemaMeta := metadata.GetSchemaMetadata(schema)
-		if schemaMeta == nil {
-			continue
-		}
-		for _, table := range schemaMeta.ListTableNames() {
-			tableMeta := schemaMeta.GetTable(table)
-			if tableMeta == nil {
-				continue
-			}
-			for _, column := range tableMeta.GetProto().GetColumns() {
-				definition := fmt.Sprintf("%s.%s | %s", schema, table, column.Type)
-				if !column.Nullable {
-					definition += ", NOT NULL"
-				}
-				m.Insert(base.Candidate{
-					Type:       base.CandidateTypeColumn,
-					Text:       c.quotedIdentifierIfNeeded(column.Name),
-					Definition: definition,
-					Comment:    column.Comment,
-				})
-			}
-		}
-	}
-}
-
-func (m CompletionMap) toSlice() []base.Candidate {
-	var result []base.Candidate
-	for _, candidate := range m {
+		seen[key] = true
 		result = append(result, candidate)
 	}
 	slices.SortFunc(result, func(a, b base.Candidate) int {
-		if a.Type != b.Type {
-			if a.Type < b.Type {
-				return -1
-			}
-			return 1
-		}
-		if a.Text < b.Text {
-			return -1
-		}
-		if a.Text > b.Text {
-			return 1
-		}
-		return 0
+		return strings.Compare(a.String(), b.String())
 	})
-	return result
-}
-
-func (c *Completer) convertCandidates(candidates *base.CandidatesCollection) ([]base.Candidate, error) {
-	keywordEntries := make(CompletionMap)
-	runtimeFunctionEntries := make(CompletionMap)
-	schemaEntries := make(CompletionMap)
-	tableEntries := make(CompletionMap)
-	columnEntries := make(CompletionMap)
-	viewEntries := make(CompletionMap)
-
-	for token, value := range candidates.Tokens {
-		if token < 0 {
-			continue
-		}
-		entry := c.parser.SymbolicNames[token]
-		if strings.HasSuffix(entry, "_P") {
-			entry = entry[:len(entry)-2]
-		} else {
-			entry = unquote(entry)
-		}
-
-		list := 0
-		if len(value) > 0 {
-			// For function call:
-			if value[0] == parser.RedshiftLexerOPEN_PAREN {
-				list = 1
-			} else {
-				for _, item := range value {
-					subEntry := c.parser.SymbolicNames[item]
-					if strings.HasSuffix(subEntry, "_P") {
-						subEntry = subEntry[:len(subEntry)-2]
-					} else {
-						subEntry = unquote(subEntry)
-					}
-					entry += " " + subEntry
-				}
-			}
-		}
-
-		switch list {
-		case 1:
-			runtimeFunctionEntries.Insert(base.Candidate{
-				Type: base.CandidateTypeFunction,
-				Text: strings.ToLower(entry) + "()",
-			})
-		default:
-			keywordEntries.Insert(base.Candidate{
-				Type: base.CandidateTypeKeyword,
-				Text: entry,
-			})
-		}
-	}
-
-	for candidate := range candidates.Rules {
-		c.scanner.PopAndRestore()
-		c.scanner.Push()
-
-		c.fetchCommonTableExpression(candidates.Rules[candidate])
-
-		switch candidate {
-		case parser.RedshiftParserRULE_func_name:
-			runtimeFunctionEntries.insertFunctions()
-		case parser.RedshiftParserRULE_relation_expr, parser.RedshiftParserRULE_qualified_name:
-			qualifier, flags := c.determineQualifiedName()
-
-			if flags&ObjectFlagsShowFirst != 0 {
-				schemaEntries.insertSchemas(c)
-			}
-
-			if flags&ObjectFlagsShowSecond != 0 {
-				schemas := make(map[string]bool)
-				if len(qualifier) == 0 {
-					// User didn't specify the schema
-					// If no default schema is selected by user, search all schemas
-					if c.schemaNotSelected {
-						for _, schema := range c.listAllSchemas() {
-							schemas[schema] = true
-						}
-					} else {
-						schemas[c.defaultSchema] = true
-					}
-					// Also include CTE tables
-					schemas[""] = true
-				} else {
-					schemas[qualifier] = true
-				}
-
-				// Pass true for includeSchemaPrefix when no schema is selected by user
-				includeSchemaPrefix := len(qualifier) == 0 && c.schemaNotSelected
-				tableEntries.insertTablesWithPrefix(c, schemas, includeSchemaPrefix)
-				viewEntries.insertViewsWithPrefix(c, schemas, includeSchemaPrefix)
-			}
-		case parser.RedshiftParserRULE_columnref:
-			schema, table, flags := c.determineColumnRef()
-			if flags&ObjectFlagsShowSchemas != 0 {
-				schemaEntries.insertSchemas(c)
-			}
-
-			schemas := make(map[string]bool)
-			if len(schema) != 0 {
-				schemas[schema] = true
-			} else if len(c.references) > 0 {
-				for _, reference := range c.references {
-					if physicalTable, ok := reference.(*base.PhysicalTableReference); ok {
-						if len(physicalTable.Schema) > 0 {
-							schemas[physicalTable.Schema] = true
-						}
-					}
-				}
-			}
-
-			if len(schema) == 0 {
-				// If no default schema is selected by user, search all schemas
-				if c.schemaNotSelected && len(c.references) == 0 {
-					for _, s := range c.listAllSchemas() {
-						schemas[s] = true
-					}
-				} else {
-					schemas[c.defaultSchema] = true
-				}
-				// User didn't specify the schema, we need to append cte tables.
-				schemas[""] = true
-			}
-
-			if flags&ObjectFlagsShowTables != 0 {
-				// Pass true for includeSchemaPrefix when no schema is selected by user and no references
-				includeSchemaPrefix := len(schema) == 0 && c.schemaNotSelected && len(c.references) == 0
-				tableEntries.insertTablesWithPrefix(c, schemas, includeSchemaPrefix)
-				viewEntries.insertViewsWithPrefix(c, schemas, includeSchemaPrefix)
-
-				for _, reference := range c.references {
-					switch reference := reference.(type) {
-					case *base.PhysicalTableReference:
-						if len(schema) == 0 && len(reference.Schema) == 0 || schemas[reference.Schema] {
-							if len(reference.Alias) == 0 {
-								tableEntries.Insert(base.Candidate{
-									Type: base.CandidateTypeTable,
-									Text: c.quotedIdentifierIfNeeded(reference.Table),
-								})
-							} else {
-								tableEntries.Insert(base.Candidate{
-									Type: base.CandidateTypeTable,
-									Text: c.quotedIdentifierIfNeeded(reference.Alias),
-								})
-							}
-						}
-					case *base.VirtualTableReference:
-						if len(schema) > 0 {
-							// If the schema is specified, we should not show the virtual table.
-							continue
-						}
-						tableEntries.Insert(base.Candidate{
-							Type: base.CandidateTypeTable,
-							Text: c.quotedIdentifierIfNeeded(reference.Table),
-						})
-					default:
-					}
-				}
-			}
-
-			if flags&ObjectFlagsShowColumns != 0 {
-				if schema == table {
-					schemas[c.defaultSchema] = true
-					// User didn't specify the schema, we need to append cte tables.
-					schemas[""] = true
-				}
-
-				tables := make(map[string]bool)
-				if len(table) != 0 {
-					tables[table] = true
-
-					for _, reference := range c.references {
-						switch reference := reference.(type) {
-						case *base.PhysicalTableReference:
-							if reference.Alias == table {
-								tables[reference.Table] = true
-								schemas[reference.Schema] = true
-							}
-						case *base.VirtualTableReference:
-							if reference.Table == table {
-								for _, column := range reference.Columns {
-									columnEntries.Insert(base.Candidate{
-										Type: base.CandidateTypeColumn,
-										Text: c.quotedIdentifierIfNeeded(column),
-									})
-								}
-							}
-						default:
-						}
-					}
-				} else if len(c.references) > 0 {
-					list := c.fetchSelectItemAliases(candidates.Rules[candidate])
-					for _, alias := range list {
-						columnEntries.Insert(base.Candidate{
-							Type: base.CandidateTypeColumn,
-							Text: c.quotedIdentifierIfNeeded(alias),
-						})
-					}
-					for _, reference := range c.references {
-						switch reference := reference.(type) {
-						case *base.PhysicalTableReference:
-							schemas[reference.Schema] = true
-							tables[reference.Table] = true
-						case *base.VirtualTableReference:
-							for _, column := range reference.Columns {
-								columnEntries.Insert(base.Candidate{
-									Type: base.CandidateTypeColumn,
-									Text: c.quotedIdentifierIfNeeded(column),
-								})
-							}
-						default:
-						}
-					}
-				} else {
-					// No specified table, return all columns
-					columnEntries.insertAllColumns(c)
-				}
-
-				if len(tables) > 0 {
-					columnEntries.insertColumns(c, schemas, tables)
-				}
-			}
-		default:
-			// No specific completion for this rule
-		}
-	}
-
-	c.scanner.PopAndRestore()
-	var result []base.Candidate
-	result = append(result, keywordEntries.toSlice()...)
-	result = append(result, runtimeFunctionEntries.toSlice()...)
-	result = append(result, schemaEntries.toSlice()...)
-	result = append(result, tableEntries.toSlice()...)
-	result = append(result, viewEntries.toSlice()...)
-	result = append(result, columnEntries.toSlice()...)
-
 	return result, nil
 }
 
-func (c *Completer) fetchCommonTableExpression(ruleStack []*base.RuleContext) {
-	c.cteTables = nil
-	for _, rule := range ruleStack {
-		if rule.ID == parser.RedshiftParserRULE_select_no_parens {
-			for _, pos := range rule.CTEList {
-				c.cteTables = append(c.cteTables, c.extractCTETables(pos)...)
-			}
-		}
-	}
-}
-
-func (c *Completer) extractCTETables(pos int) []*base.VirtualTableReference {
-	if metadata, exists := c.cteCache[pos]; exists {
-		return metadata
-	}
-	followingText := c.scanner.GetFollowingTextAfter(pos)
-	if len(followingText) == 0 {
-		return nil
-	}
-
-	input := antlr.NewInputStream(followingText)
-	lexer := parser.NewRedshiftLexer(input)
-	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	p := parser.NewRedshiftParser(tokens)
-
-	p.BuildParseTrees = true
-	p.RemoveErrorListeners()
-	lexer.RemoveErrorListeners()
-	tree := p.With_clause()
-
-	listener := &CTETableListener{context: c}
-	antlr.ParseTreeWalkerDefault.Walk(listener, tree)
-
-	c.cteCache[pos] = listener.tables
-	return listener.tables
-}
-
-type CTETableListener struct {
-	*parser.BaseRedshiftParserListener
-
-	context *Completer
-	tables  []*base.VirtualTableReference
-}
-
-func (l *CTETableListener) EnterCommon_table_expr(ctx *parser.Common_table_exprContext) {
-	table := &base.VirtualTableReference{}
-	if ctx.Name() != nil {
-		table.Table = normalizeRedshiftName(ctx.Name())
-	}
-	if ctx.Opt_name_list() != nil {
-		for _, column := range ctx.Opt_name_list().Name_list().AllName() {
-			table.Columns = append(table.Columns, normalizeRedshiftName(column))
-		}
-	} else {
-		// For query span extraction, we still use PostgreSQL GetQuerySpan
-		// because it uses pg_query_go internally
-		if span, err := pg.GetQuerySpan(
-			l.context.ctx,
-			base.GetQuerySpanContext{
-				InstanceID:              l.context.instanceID,
-				GetDatabaseMetadataFunc: l.context.getMetadata,
-				ListDatabaseNamesFunc:   l.context.listDatabaseNames,
-			},
-			base.Statement{Text: ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx.Preparablestmt())},
-			l.context.defaultDatabase,
-			"",
-			false,
-		); err == nil && span.NotFoundError == nil {
-			for _, column := range span.Results {
-				table.Columns = append(table.Columns, column.Name)
-			}
-		}
-	}
-
-	l.tables = append(l.tables, table)
-}
-
-func (c *Completer) fetchSelectItemAliases(ruleStack []*base.RuleContext) []string {
-	canUseAliases := false
-	for i := len(ruleStack) - 1; i >= 0; i-- {
-		switch ruleStack[i].ID {
-		case parser.RedshiftParserRULE_simple_select_pramary, parser.RedshiftParserRULE_select_no_parens:
-			if !canUseAliases {
-				return nil
-			}
-			aliasMap := make(map[string]bool)
-			for pos := range ruleStack[i].SelectItemAliases {
-				if aliasText := c.extractAliasText(pos); len(aliasText) > 0 {
-					aliasMap[aliasText] = true
-				}
-			}
-
-			var result []string
-			for alias := range aliasMap {
-				result = append(result, alias)
-			}
-			slices.Sort(result)
-			return result
-		case parser.RedshiftParserRULE_opt_sort_clause, parser.RedshiftParserRULE_group_clause, parser.RedshiftParserRULE_having_clause:
-			canUseAliases = true
-		default:
-		}
-	}
-
-	return nil
-}
-
-func (c *Completer) extractAliasText(pos int) string {
-	followingText := c.scanner.GetFollowingTextAfter(pos)
-	if len(followingText) == 0 {
-		return ""
-	}
-
-	input := antlr.NewInputStream(followingText)
-	lexer := parser.NewRedshiftLexer(input)
-	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	p := parser.NewRedshiftParser(tokens)
-
-	p.BuildParseTrees = true
-	p.RemoveErrorListeners()
-	lexer.RemoveErrorListeners()
-	tree := p.Target_alias()
-
-	listener := &TargetAliasListener{}
-	antlr.ParseTreeWalkerDefault.Walk(listener, tree)
-	return listener.result
-}
-
-type TargetAliasListener struct {
-	*parser.BaseRedshiftParserListener
-
-	result string
-}
-
-func (l *TargetAliasListener) EnterTarget_alias(ctx *parser.Target_aliasContext) {
-	if ctx.Identifier() != nil {
-		l.result = normalizeRedshiftIdentifier(ctx.Identifier())
-	} else if ctx.Collabel() != nil {
-		l.result = normalizeRedshiftCollabel(ctx.Collabel())
-	}
-}
-
-type ObjectFlags int
-
-const (
-	ObjectFlagsShowSchemas ObjectFlags = 1 << iota
-	ObjectFlagsShowTables
-	ObjectFlagsShowColumns
-	ObjectFlagsShowFirst
-	ObjectFlagsShowSecond
-)
-
-func (c *Completer) determineQualifiedName() (string, ObjectFlags) {
-	position := c.scanner.GetIndex()
-	if c.scanner.GetTokenChannel() != 0 {
-		c.scanner.Forward(true /* skipHidden */)
-	}
-
-	if !c.scanner.IsTokenType(parser.RedshiftLexerONLY) && !c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		// We are at the end of an incomplete identifier spec.
-		// Jump back.
-		c.scanner.Backward(true /* skipHidden */)
-	}
-
-	// Go left until we hit a non-identifier token.
-	if position > 0 {
-		if c.lexer.IsIdentifier(c.scanner.GetTokenType()) && c.scanner.GetPreviousTokenType(false /* skipHidden */) == parser.RedshiftLexerDOT {
-			c.scanner.Backward(true /* skipHidden */)
-		}
-		if c.scanner.IsTokenType(parser.RedshiftLexerDOT) && c.lexer.IsIdentifier(c.scanner.GetPreviousTokenType(false /* skipHidden */)) {
-			c.scanner.Backward(true /* skipHidden */)
-		}
-	}
-
-	// The current token is on the leading identifier.
-	qualifier := ""
-	temp := ""
-	if c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		temp = normalizeIdentifier(c.scanner.GetTokenText())
-		c.scanner.Forward(true /* skipHidden */)
-	}
-
-	if !c.scanner.IsTokenType(parser.RedshiftLexerDOT) || position <= c.scanner.GetIndex() {
-		return qualifier, ObjectFlagsShowFirst | ObjectFlagsShowSecond
-	}
-
-	qualifier = temp
-	return qualifier, ObjectFlagsShowSecond
-}
-
-func (c *Completer) determineColumnRef() (schema, table string, flags ObjectFlags) {
-	position := c.scanner.GetIndex()
-	if c.scanner.GetTokenChannel() != 0 {
-		c.scanner.Forward(true /* skipHidden */)
-	}
-
-	tokenType := c.scanner.GetTokenType()
-	if tokenType != parser.RedshiftLexerDOT && !c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		// We are at the end of an incomplete identifier spec.
-		// Jump back.
-		c.scanner.Backward(true /* skipHidden */)
-	}
-
-	if position > 0 {
-		if c.lexer.IsIdentifier(c.scanner.GetTokenType()) && c.scanner.GetPreviousTokenType(false /* skipHidden */) == parser.RedshiftLexerDOT {
-			c.scanner.Backward(true /* skipHidden */)
-		}
-		if c.scanner.IsTokenType(parser.RedshiftLexerDOT) && c.lexer.IsIdentifier(c.scanner.GetPreviousTokenType(false /* skipHidden */)) {
-			c.scanner.Backward(true /* skipHidden */)
-
-			if c.scanner.GetPreviousTokenType(false /* skipHidden */) == parser.RedshiftLexerDOT {
-				c.scanner.Backward(true /* skipHidden */)
-				if c.lexer.IsIdentifier(c.scanner.GetPreviousTokenType(false /* skipHidden */)) {
-					c.scanner.Backward(true /* skipHidden */)
-				}
-			}
-		}
-	}
-
-	schema = ""
-	table = ""
-	temp := ""
-	if c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		temp = normalizeIdentifier(c.scanner.GetTokenText())
-		c.scanner.Forward(true /* skipHidden */)
-	}
-
-	if !c.scanner.IsTokenType(parser.RedshiftLexerDOT) || position <= c.scanner.GetIndex() {
-		return schema, table, ObjectFlagsShowSchemas | ObjectFlagsShowTables | ObjectFlagsShowColumns
-	}
-
-	c.scanner.Forward(true /* skipHidden */) // skip dot
-	table = temp
-	schema = temp
-	if c.lexer.IsIdentifier(c.scanner.GetTokenType()) {
-		temp = normalizeIdentifier(c.scanner.GetTokenText())
-		c.scanner.Forward(true /* skipHidden */)
-
-		if !c.scanner.IsTokenType(parser.RedshiftLexerDOT) || position <= c.scanner.GetIndex() {
-			return schema, table, ObjectFlagsShowTables | ObjectFlagsShowColumns
-		}
-
-		table = temp
-		return schema, table, ObjectFlagsShowColumns
-	}
-
-	return schema, table, ObjectFlagsShowTables | ObjectFlagsShowColumns
-}
-
-func normalizeIdentifier(tokenText string) string {
-	if len(tokenText) >= 2 && tokenText[0] == '"' && tokenText[len(tokenText)-1] == '"' {
-		return normalizeRedshiftQuotedIdentifier(tokenText)
-	}
-	return unquote(tokenText)
-}
-
-func unquote(s string) string {
-	if len(s) < 2 {
-		return s
-	}
-
-	if (s[0] == '\'' || s[0] == '"') && s[0] == s[len(s)-1] {
-		return s[1 : len(s)-1]
-	}
-	return s
-}
-
-func (c *Completer) takeReferencesSnapshot() {
-	for _, references := range c.referencesStack {
-		c.references = append(c.references, references...)
-	}
-}
-
-func (c *Completer) collectRemainingTableReferences() {
-	c.scanner.Push()
-
-	level := 0
-	for {
-		found := c.scanner.GetTokenType() == parser.RedshiftLexerFROM
-		for !found {
-			if !c.scanner.Forward(false /* skipHidden */) {
-				break
-			}
-
-			switch c.scanner.GetTokenType() {
-			case parser.RedshiftLexerOPEN_PAREN:
-				level++
-			case parser.RedshiftLexerCLOSE_PAREN:
-				if level > 0 {
-					level--
-				}
-			case parser.RedshiftLexerFROM:
-				// Open and close parenthesis don't need to match, if we come from within a subquery.
-				if level == 0 {
-					found = true
-				}
-			default:
-			}
-		}
-
-		if !found {
-			c.scanner.PopAndRestore()
-			return // No more FROM clauses found.
-		}
-
-		c.parseTableReferences(c.scanner.GetFollowingText())
-		if c.scanner.GetTokenType() == parser.RedshiftLexerFROM {
-			c.scanner.Forward(false /* skipHidden */)
-		}
-	}
-}
-
-func (c *Completer) collectLeadingTableReferences(caretIndex int) {
-	c.scanner.Push()
-
-	c.scanner.SeekIndex(0)
-
-	level := 0
-	for {
-		found := c.scanner.GetTokenType() == parser.RedshiftLexerFROM
-		for !found {
-			if !c.scanner.Forward(false /* skipHidden */) || c.scanner.GetIndex() >= caretIndex {
-				break
-			}
-
-			switch c.scanner.GetTokenType() {
-			case parser.RedshiftLexerOPEN_PAREN:
-				level++
-				c.referencesStack = append([][]base.TableReference{{}}, c.referencesStack...)
-			case parser.RedshiftLexerCLOSE_PAREN:
-				if level == 0 {
-					c.scanner.PopAndRestore()
-					return // We cannot go above the initial nesting level.
-				}
-
-				level--
-				c.referencesStack = c.referencesStack[1:]
-			case parser.RedshiftLexerFROM:
-				found = true
-			default:
-			}
-		}
-
-		if !found {
-			c.scanner.PopAndRestore()
-			return // No more FROM clauses found.
-		}
-
-		c.parseTableReferences(c.scanner.GetFollowingText())
-		if c.scanner.GetTokenType() == parser.RedshiftLexerFROM {
-			c.scanner.Forward(false /* skipHidden */)
-		}
-	}
-}
-
-func (c *Completer) parseTableReferences(fromClause string) {
-	input := antlr.NewInputStream(fromClause)
-	lexer := parser.NewRedshiftLexer(input)
-	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	p := parser.NewRedshiftParser(tokens)
-
-	p.BuildParseTrees = true
-	p.RemoveErrorListeners()
-	lexer.RemoveErrorListeners()
-	tree := p.From_clause()
-
-	listener := &TableRefListener{
-		context: c,
-	}
-	antlr.ParseTreeWalkerDefault.Walk(listener, tree)
-}
-
-type TableRefListener struct {
-	*parser.BaseRedshiftParserListener
-
-	context *Completer
-	level   int
-}
-
-func (l *TableRefListener) EnterTable_ref(ctx *parser.Table_refContext) {
-	if _, ok := ctx.GetParent().(*parser.Table_refContext); ok {
-		// if the table reference is nested, we should not process it.
-		l.level++
-	}
-
-	if l.level == 0 {
-		switch {
-		case ctx.Relation_expr() != nil:
-			var reference base.TableReference
-			physicalReference := &base.PhysicalTableReference{}
-			// We should use the physical reference as the default reference.
-			reference = physicalReference
-			list := NormalizeRedshiftQualifiedName(ctx.Relation_expr().Qualified_name())
-			switch len(list) {
-			case 1:
-				physicalReference.Table = list[0]
-			case 2:
-				physicalReference.Schema = list[0]
-				physicalReference.Table = list[1]
-			case 3:
-				physicalReference.Database = list[0]
-				physicalReference.Schema = list[1]
-				physicalReference.Table = list[2]
-			default:
-				return
-			}
-
-			if ctx.Opt_alias_clause() != nil {
-				tableAlias, columnAlias := normalizeTableAlias(ctx.Opt_alias_clause())
-				if len(columnAlias) > 0 {
-					virtualReference := &base.VirtualTableReference{
-						Table:   tableAlias,
-						Columns: columnAlias,
-					}
-					// If the table alias has the column alias, we should use the virtual reference.
-					reference = virtualReference
-				} else {
-					physicalReference.Alias = tableAlias
-				}
-			}
-
-			l.context.referencesStack[0] = append(l.context.referencesStack[0], reference)
-		case ctx.Select_with_parens() != nil:
-			if ctx.Opt_alias_clause() != nil {
-				virtualReference := &base.VirtualTableReference{}
-				tableAlias, columnAlias := normalizeTableAlias(ctx.Opt_alias_clause())
-				virtualReference.Table = tableAlias
-				if len(columnAlias) > 0 {
-					virtualReference.Columns = columnAlias
-				} else {
-					// For query span extraction, we still use PostgreSQL GetQuerySpan
-					// because it uses pg_query_go internally
-					if span, err := pg.GetQuerySpan(
-						l.context.ctx,
-						base.GetQuerySpanContext{
-							InstanceID:              l.context.instanceID,
-							GetDatabaseMetadataFunc: l.context.getMetadata,
-							ListDatabaseNamesFunc:   l.context.listDatabaseNames,
-						},
-						base.Statement{Text: fmt.Sprintf("SELECT * FROM %s AS %s;", ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx.Select_with_parens()), tableAlias)},
-						l.context.defaultDatabase,
-						"",
-						false,
-					); err == nil && span.NotFoundError == nil {
-						for _, column := range span.Results {
-							virtualReference.Columns = append(virtualReference.Columns, column.Name)
-						}
-					}
-				}
-
-				l.context.referencesStack[0] = append(l.context.referencesStack[0], virtualReference)
-			}
-		case ctx.OPEN_PAREN() != nil:
-			if ctx.Opt_alias_clause() != nil {
-				virtualReference := &base.VirtualTableReference{}
-				tableAlias, columnAlias := normalizeTableAlias(ctx.Opt_alias_clause())
-				virtualReference.Table = tableAlias
-				if len(columnAlias) > 0 {
-					virtualReference.Columns = columnAlias
-				}
-
-				l.context.referencesStack[0] = append(l.context.referencesStack[0], virtualReference)
-			}
-		default:
-		}
-	}
-}
-
-func (l *TableRefListener) ExitTable_ref(ctx *parser.Table_refContext) {
-	if _, ok := ctx.GetParent().(*parser.Table_refContext); ok {
-		l.level--
-	}
-}
-
-func (l *TableRefListener) EnterSelect_with_parens(_ *parser.Select_with_parensContext) {
-	l.level++
-}
-
-func (l *TableRefListener) ExitSelect_with_parens(_ *parser.Select_with_parensContext) {
-	l.level--
-}
-
-func normalizeTableAlias(ctx parser.IOpt_alias_clauseContext) (string, []string) {
-	if ctx == nil || ctx.Table_alias_clause() == nil {
-		return "", nil
-	}
-
-	tableAlias := ""
-	aliasClause := ctx.Table_alias_clause()
-	if aliasClause.Table_alias() != nil {
-		tableAlias = normalizeRedshiftTableAlias(aliasClause.Table_alias())
-	}
-
-	var columnAliases []string
-	if aliasClause.Name_list() != nil {
-		columnAliases = append(columnAliases, normalizeRedshiftNameList(aliasClause.Name_list())...)
-	}
-
-	return tableAlias, columnAliases
-}
-
-func prepareTrickyParserAndScanner(statement string, caretLine int, caretOffset int) (*parser.RedshiftParser, *parser.RedshiftLexer, *base.Scanner) {
-	statement, caretLine, caretOffset = skipHeadingSQLs(statement, caretLine, caretOffset)
-	statement, caretLine, caretOffset = skipHeadingSQLWithoutSemicolon(statement, caretLine, caretOffset)
-	input := antlr.NewInputStream(statement)
-	lexer := parser.NewRedshiftLexer(input)
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	p := parser.NewRedshiftParser(stream)
-	p.RemoveErrorListeners()
-	lexer.RemoveErrorListeners()
-	scanner := base.NewScanner(stream, true /* fillInput */)
-	scanner.SeekPosition(caretLine, caretOffset)
-	scanner.Push()
-	return p, lexer, scanner
-}
-
-func prepareParserAndScanner(statement string, caretLine int, caretOffset int) (*parser.RedshiftParser, *parser.RedshiftLexer, *base.Scanner) {
-	statement, caretLine, caretOffset = skipHeadingSQLs(statement, caretLine, caretOffset)
-	input := antlr.NewInputStream(statement)
-	lexer := parser.NewRedshiftLexer(input)
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	p := parser.NewRedshiftParser(stream)
-	p.RemoveErrorListeners()
-	lexer.RemoveErrorListeners()
-	scanner := base.NewScanner(stream, true /* fillInput */)
-	scanner.SeekPosition(caretLine, caretOffset)
-	scanner.Push()
-	return p, lexer, scanner
-}
-
-// caretLine is 1-based and caretOffset is 0-based.
-func skipHeadingSQLs(statement string, caretLine int, caretOffset int) (string, int, int) {
-	newCaretLine, newCaretOffset := caretLine, caretOffset
+// completionStatementAtCaret drops statements before the caret so table refs
+// from earlier statements in the same editor buffer cannot leak into completion.
+func completionStatementAtCaret(statement string, caretLine int, caretOffset int) (string, int, int) {
 	list, err := SplitSQL(statement)
 	if err != nil || len(base.FilterEmptyStatements(list)) <= 1 {
 		return statement, caretLine, caretOffset
 	}
 
-	caretLine-- // Convert caretLine to 0-based.
-
+	caretLineZeroBased := caretLine - 1
 	start := 0
+	newCaretLine, newCaretOffset := caretLine, caretOffset
 	for i, sql := range list {
-		// End.Line is 1-based per proto spec, convert to 0-based for comparison with caretLine
 		sqlEndLine := int(sql.End.GetLine()) - 1
 		sqlEndColumn := int(sql.End.GetColumn())
-		if sqlEndLine > caretLine || (sqlEndLine == caretLine && sqlEndColumn >= caretOffset) {
+		if sqlEndLine > caretLineZeroBased || (sqlEndLine == caretLineZeroBased && sqlEndColumn >= caretOffset) {
 			start = i
 			if i == 0 {
-				// The caret is in the first SQL statement, so we don't need to skip any SQL statements.
 				break
 			}
-			// End.Line is 1-based per proto spec, convert to 0-based
-			previousSQLEndLine := int(list[i-1].End.GetLine()) - 1
-			previousSQLEndColumn := int(list[i-1].End.GetColumn())
-			newCaretLine = caretLine - previousSQLEndLine + 1 // Convert to 1-based.
-			if caretLine == previousSQLEndLine {
-				// The caret is in the same line as the last line of the previous SQL statement.
-				// End.Column is 1-based exclusive, so (End.Column - 1) gives 0-based start of next statement.
-				// newCaretOffset = caretOffset - (previousSQLEndColumn - 1)
-				newCaretOffset = caretOffset - previousSQLEndColumn + 1
+			previousEndLine := int(list[i-1].End.GetLine()) - 1
+			previousEndColumn := int(list[i-1].End.GetColumn())
+			newCaretLine = caretLineZeroBased - previousEndLine + 1
+			if caretLineZeroBased == previousEndLine {
+				newCaretOffset = caretOffset - previousEndColumn + 1
 			}
 			break
 		}
@@ -1301,259 +87,235 @@ func skipHeadingSQLs(statement string, caretLine int, caretOffset int) (string, 
 			return statement, caretLine, caretOffset
 		}
 	}
-
 	return buf.String(), newCaretLine, newCaretOffset
 }
 
-// caretLine is 1-based and caretOffset is 0-based.
-func skipHeadingSQLWithoutSemicolon(statement string, caretLine int, caretOffset int) (string, int, int) {
-	input := antlr.NewInputStream(statement)
-	lexer := parser.NewRedshiftLexer(input)
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-	lexer.RemoveErrorListeners()
-	lexerErrorListener := &base.ParseErrorListener{
-		Statement: statement,
-	}
-	lexer.AddErrorListener(lexerErrorListener)
-
-	stream.Fill()
-	tokens := stream.GetAllTokens()
-	latestSelect := 0
-	newCaretLine, newCaretOffset := caretLine, caretOffset
-	for _, token := range tokens {
-		if token.GetLine() > caretLine || (token.GetLine() == caretLine && token.GetColumn() >= caretOffset) {
-			break
-		}
-		if token.GetTokenType() == parser.RedshiftLexerSELECT && token.GetColumn() == 0 {
-			latestSelect = token.GetTokenIndex()
-			newCaretLine = caretLine - token.GetLine() + 1 // convert to 1-based.
-			newCaretOffset = caretOffset
-		}
-	}
-
-	if latestSelect == 0 {
-		return statement, caretLine, caretOffset
-	}
-	return stream.GetTextFromInterval(antlr.NewInterval(latestSelect, stream.Size())), newCaretLine, newCaretOffset
-}
-
-func (c *Completer) listAllSchemas() []string {
-	if _, exists := c.metadataCache[c.defaultDatabase]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, c.defaultDatabase)
-		if err != nil || metadata == nil {
-			return nil
-		}
-		c.metadataCache[c.defaultDatabase] = metadata
-	}
-
-	return c.metadataCache[c.defaultDatabase].ListSchemaNames()
-}
-
-func (c *Completer) listTables(schema string) []string {
-	if _, exists := c.metadataCache[c.defaultDatabase]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, c.defaultDatabase)
-		if err != nil || metadata == nil {
-			return nil
-		}
-		c.metadataCache[c.defaultDatabase] = metadata
-	}
-
-	schemaMeta := c.metadataCache[c.defaultDatabase].GetSchemaMetadata(schema)
-	if schemaMeta == nil {
+func buildCompletionCatalog(ctx context.Context, cCtx base.CompletionContext) *redshiftcatalog.Catalog {
+	if cCtx.Metadata == nil || cCtx.DefaultDatabase == "" {
 		return nil
 	}
-	return schemaMeta.ListTableNames()
-}
 
-func (c *Completer) listForeignTables(schema string) []string {
-	if _, exists := c.metadataCache[c.defaultDatabase]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, c.defaultDatabase)
-		if err != nil || metadata == nil {
-			return nil
-		}
-		c.metadataCache[c.defaultDatabase] = metadata
-	}
-
-	schemaMeta := c.metadataCache[c.defaultDatabase].GetSchemaMetadata(schema)
-	if schemaMeta == nil {
+	_, metadata, err := cCtx.Metadata(ctx, cCtx.InstanceID, cCtx.DefaultDatabase)
+	if err != nil || metadata == nil {
 		return nil
 	}
-	return schemaMeta.ListForeignTableNames()
+
+	cat := redshiftcatalog.New()
+	for _, schemaName := range metadata.ListSchemaNames() {
+		schemaMeta := metadata.GetSchemaMetadata(schemaName)
+		if schemaMeta == nil {
+			continue
+		}
+		execCompletionDDL(cat, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s;", quoteIdent(schemaName)))
+
+		for _, tableName := range schemaMeta.ListTableNames() {
+			tableMeta := schemaMeta.GetTable(tableName)
+			if tableMeta == nil {
+				continue
+			}
+			execCompletionDDL(cat, createTableDDL(schemaName, tableName, tableMeta.GetProto().GetColumns()))
+		}
+		for _, tableName := range schemaMeta.ListForeignTableNames() {
+			tableMeta := schemaMeta.GetExternalTable(tableName)
+			if tableMeta == nil {
+				continue
+			}
+			execCompletionDDL(cat, createTableDDL(schemaName, tableName, tableMeta.GetProto().GetColumns()))
+		}
+		for _, viewName := range schemaMeta.ListViewNames() {
+			viewMeta := schemaMeta.GetView(viewName)
+			if viewMeta == nil {
+				continue
+			}
+			execCompletionDDL(cat, createViewDDL("VIEW", schemaName, viewName, viewMeta.GetColumns()))
+		}
+		for _, viewName := range schemaMeta.ListMaterializedViewNames() {
+			viewMeta := schemaMeta.GetMaterializedView(viewName)
+			if viewMeta == nil {
+				continue
+			}
+			execCompletionDDL(cat, createViewDDL("MATERIALIZED VIEW", schemaName, viewName, nil))
+		}
+		for _, sequenceName := range schemaMeta.ListSequenceNames() {
+			execCompletionDDL(cat, fmt.Sprintf("CREATE SEQUENCE %s.%s;", quoteIdent(schemaName), quoteIdent(sequenceName)))
+		}
+	}
+
+	searchPath := []string{"public"}
+	if cCtx.DefaultSchema != "" {
+		searchPath = []string{cCtx.DefaultSchema, "public"}
+	}
+	cat.SetSearchPath(searchPath)
+	return cat
 }
 
-func (c *Completer) listMaterializedViews(schema string) []string {
-	if _, exists := c.metadataCache[c.defaultDatabase]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, c.defaultDatabase)
-		if err != nil || metadata == nil {
-			return nil
-		}
-		c.metadataCache[c.defaultDatabase] = metadata
-	}
-
-	schemaMeta := c.metadataCache[c.defaultDatabase].GetSchemaMetadata(schema)
-	if schemaMeta == nil {
-		return nil
-	}
-	return schemaMeta.ListMaterializedViewNames()
+func execCompletionDDL(cat *redshiftcatalog.Catalog, sql string) {
+	_, _ = cat.Exec(sql, nil)
 }
 
-func (c *Completer) listViews(schema string) []string {
-	if _, exists := c.metadataCache[c.defaultDatabase]; !exists {
-		_, metadata, err := c.getMetadata(c.ctx, c.instanceID, c.defaultDatabase)
-		if err != nil || metadata == nil {
-			return nil
-		}
-		c.metadataCache[c.defaultDatabase] = metadata
-	}
-
-	schemaMeta := c.metadataCache[c.defaultDatabase].GetSchemaMetadata(schema)
-	if schemaMeta == nil {
-		return nil
-	}
-	return schemaMeta.ListViewNames()
+func createTableDDL(schemaName, tableName string, columns []*storepb.ColumnMetadata) string {
+	return fmt.Sprintf(
+		"CREATE TABLE %s.%s (%s);",
+		quoteIdent(schemaName),
+		quoteIdent(tableName),
+		columnListDDL(columns),
+	)
 }
 
-func (c *Completer) quotedIdentifierIfNeeded(s string) string {
-	if c.caretTokenIsQuoted {
-		return s
-	}
-	if strings.ToLower(s) != s {
-		return fmt.Sprintf(`"%s"`, s)
-	}
-	if c.lexer.IsReservedKeyword(strings.ToUpper(s)) {
-		return fmt.Sprintf(`"%s"`, s)
-	}
-	// Redshift requires double quotes for identifiers with special characters or start with digits
-	if !isValidUnquotedIdentifier(s) {
-		// If the identifier contains double quotes, we need to escape them by doubling them
-		if strings.Contains(s, `"`) {
-			s = strings.ReplaceAll(s, `"`, `""`)
+func createViewDDL(kind, schemaName, viewName string, columns []*storepb.ColumnMetadata) string {
+	selectItems := make([]string, 0, len(columns))
+	for _, column := range columns {
+		if column == nil || column.GetName() == "" {
+			continue
 		}
-		return fmt.Sprintf(`"%s"`, s)
+		selectItems = append(selectItems, fmt.Sprintf(
+			"CAST(NULL AS %s) AS %s",
+			normalizeCompletionType(column.GetType()),
+			quoteIdent(column.GetName()),
+		))
+	}
+	if len(selectItems) == 0 {
+		selectItems = append(selectItems, "1 AS __bytebase_completion_placeholder")
+	}
+	return fmt.Sprintf(
+		"CREATE %s %s.%s AS SELECT %s;",
+		kind,
+		quoteIdent(schemaName),
+		quoteIdent(viewName),
+		strings.Join(selectItems, ", "),
+	)
+}
+
+func columnListDDL(columns []*storepb.ColumnMetadata) string {
+	columnDefs := make([]string, 0, len(columns))
+	for _, column := range columns {
+		if column == nil || column.GetName() == "" {
+			continue
+		}
+		columnDefs = append(columnDefs, fmt.Sprintf("%s %s", quoteIdent(column.GetName()), normalizeCompletionType(column.GetType())))
+	}
+	if len(columnDefs) == 0 {
+		columnDefs = append(columnDefs, "__bytebase_completion_placeholder text")
+	}
+	return strings.Join(columnDefs, ", ")
+}
+
+func normalizeCompletionType(typ string) string {
+	lower := strings.ToLower(strings.TrimSpace(typ))
+	switch {
+	case lower == "":
+		return "text"
+	case strings.Contains(lower, "bigint"):
+		return "bigint"
+	case strings.Contains(lower, "int"):
+		return "integer"
+	case strings.Contains(lower, "bool"):
+		return "boolean"
+	case strings.Contains(lower, "char"), strings.Contains(lower, "text"), strings.Contains(lower, "string"):
+		return "text"
+	case strings.Contains(lower, "numeric"), strings.Contains(lower, "decimal"):
+		return "numeric"
+	case strings.Contains(lower, "double"):
+		return "double precision"
+	case strings.Contains(lower, "float"), strings.Contains(lower, "real"):
+		return "real"
+	case strings.Contains(lower, "date"):
+		return "date"
+	case strings.Contains(lower, "time"):
+		return "timestamp"
+	default:
+		return "text"
+	}
+}
+
+func quoteIdent(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+func completionCandidateText(candidate redshiftcompletion.Candidate) string {
+	switch candidate.Type {
+	case redshiftcompletion.CandidateKeyword, redshiftcompletion.CandidateFunction:
+		return candidate.Text
+	default:
+		return quotedIdentifierIfNeeded(candidate.Text)
+	}
+}
+
+func quotedIdentifierIfNeeded(s string) string {
+	if strings.ToLower(s) != s || !isValidUnquotedIdentifier(s) {
+		return quoteIdent(s)
 	}
 	return s
 }
 
 // isValidUnquotedIdentifier checks if the identifier can be used without quotes in Redshift.
-// Redshift unquoted identifiers must:
-// - Begin with a letter (a-z, A-Z) or underscore
-// - Contain only letters, digits, and underscores
 func isValidUnquotedIdentifier(s string) bool {
 	if len(s) == 0 {
 		return false
 	}
 
-	// First character must be a letter or underscore
 	first := rune(s[0])
 	if !unicode.IsLetter(first) && first != '_' {
 		return false
 	}
-
-	// Remaining characters must be letters, digits, or underscores
 	for _, ch := range s[1:] {
 		if !unicode.IsLetter(ch) && !unicode.IsDigit(ch) && ch != '_' {
 			return false
 		}
 	}
-
 	return true
 }
 
-// Normalization functions for Redshift
-func normalizeRedshiftName(ctx parser.INameContext) string {
-	if ctx == nil {
-		return ""
+func convertCandidateType(t redshiftcompletion.CandidateType) base.CandidateType {
+	switch t {
+	case redshiftcompletion.CandidateKeyword:
+		return base.CandidateTypeKeyword
+	case redshiftcompletion.CandidateSchema:
+		return base.CandidateTypeSchema
+	case redshiftcompletion.CandidateTable:
+		return base.CandidateTypeTable
+	case redshiftcompletion.CandidateView:
+		return base.CandidateTypeView
+	case redshiftcompletion.CandidateMaterializedView:
+		return base.CandidateTypeMaterializedView
+	case redshiftcompletion.CandidateColumn:
+		return base.CandidateTypeColumn
+	case redshiftcompletion.CandidateFunction:
+		return base.CandidateTypeFunction
+	case redshiftcompletion.CandidateSequence:
+		return base.CandidateTypeSequence
+	case redshiftcompletion.CandidateIndex:
+		return base.CandidateTypeIndex
+	case redshiftcompletion.CandidateTrigger:
+		return base.CandidateTypeTrigger
+	default:
+		return base.CandidateTypeNone
 	}
-	text := ctx.GetText()
-	return normalizeRedshiftIdentifierText(text)
 }
 
-func normalizeRedshiftColid(ctx parser.IColidContext) string {
-	if ctx == nil {
-		return ""
-	}
-	text := ctx.GetText()
-	return normalizeRedshiftIdentifierText(text)
-}
-
-func normalizeRedshiftIdentifier(ctx parser.IIdentifierContext) string {
-	if ctx == nil {
-		return ""
-	}
-	text := ctx.GetText()
-	return normalizeRedshiftIdentifierText(text)
-}
-
-func normalizeRedshiftCollabel(ctx parser.ICollabelContext) string {
-	if ctx == nil {
-		return ""
-	}
-	text := ctx.GetText()
-	return normalizeRedshiftIdentifierText(text)
-}
-
-func normalizeRedshiftAttrName(ctx parser.IAttr_nameContext) string {
-	if ctx == nil {
-		return ""
-	}
-	text := ctx.GetText()
-	return normalizeRedshiftIdentifierText(text)
-}
-
-func normalizeRedshiftTableAlias(ctx parser.ITable_aliasContext) string {
-	if ctx == nil {
-		return ""
-	}
-	text := ctx.GetText()
-	return normalizeRedshiftIdentifierText(text)
-}
-
-func normalizeRedshiftNameList(ctx parser.IName_listContext) []string {
-	if ctx == nil {
-		return nil
-	}
-	var result []string
-	for _, name := range ctx.AllName() {
-		result = append(result, normalizeRedshiftName(name))
-	}
-	return result
-}
-
-func normalizeRedshiftQuotedIdentifier(text string) string {
-	if len(text) < 2 {
-		return text
-	}
-	// Remove quotes and handle escaped quotes
-	return strings.ReplaceAll(text[1:len(text)-1], `""`, `"`)
-}
-
-func normalizeRedshiftIdentifierText(text string) string {
-	if len(text) >= 2 && text[0] == '"' && text[len(text)-1] == '"' {
-		return normalizeRedshiftQuotedIdentifier(text)
-	}
-	// Redshift stores unquoted identifiers in lowercase
-	return strings.ToLower(text)
-}
-
-func NormalizeRedshiftQualifiedName(ctx parser.IQualified_nameContext) []string {
-	if ctx == nil {
-		return nil
-	}
-	var result []string
-
-	// First part is the colid
-	if ctx.Colid() != nil {
-		result = append(result, normalizeRedshiftColid(ctx.Colid()))
-	}
-
-	// Additional parts come from indirection
-	if ctx.Indirection() != nil {
-		for _, el := range ctx.Indirection().AllIndirection_el() {
-			if el.Attr_name() != nil {
-				result = append(result, normalizeRedshiftAttrName(el.Attr_name()))
-			}
+// caretToByteOffset converts a (1-based line, 0-based column) caret position
+// into a byte offset into statement. The column is interpreted as a UTF-16
+// code-unit offset, matching Monaco/LSP completion positions.
+func caretToByteOffset(statement string, caretLine, caretColumn int) int {
+	line := 1
+	col := 0
+	for i := 0; i < len(statement); {
+		if line == caretLine && col >= caretColumn {
+			return i
 		}
+		r, size := utf8.DecodeRuneInString(statement[i:])
+		if r == '\n' {
+			if line == caretLine {
+				return i
+			}
+			line++
+			col = 0
+		} else if r <= 0xFFFF {
+			col++
+		} else {
+			col += 2
+		}
+		i += size
 	}
-
-	return result
+	return len(statement)
 }

--- a/backend/plugin/parser/redshift/completion_test.go
+++ b/backend/plugin/parser/redshift/completion_test.go
@@ -1,0 +1,753 @@
+package redshift
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/store/model"
+)
+
+type completionWant struct {
+	text string
+	typ  base.CandidateType
+}
+
+type completionCase struct {
+	name       string
+	input      string
+	want       []completionWant
+	absentText []string
+}
+
+func TestCompletionDoesNotDependOnANTLR(t *testing.T) {
+	content, err := os.ReadFile("completion.go")
+	require.NoError(t, err)
+	source := string(content)
+	require.NotContains(t, source, "github.com/antlr4-go/antlr/v4")
+	require.NotContains(t, source, "github.com/bytebase/parser/redshift")
+	require.NotContains(t, source, "CodeCompletionCore")
+}
+
+func TestCompletionRedshiftSlots(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		want       []completionWant
+		absentText []string
+	}{
+		{
+			name:  "statement start",
+			input: "|",
+			want: []completionWant{
+				{"SELECT", base.CandidateTypeKeyword},
+				{"COPY", base.CandidateTypeKeyword},
+				{"UNLOAD", base.CandidateTypeKeyword},
+				{"SHOW", base.CandidateTypeKeyword},
+			},
+		},
+		{
+			name:  "prefix filtering",
+			input: "SH|",
+			want: []completionWant{
+				{"SHOW", base.CandidateTypeKeyword},
+			},
+			absentText: []string{"SELECT", "COPY"},
+		},
+		{
+			name:  "create dispatch",
+			input: "CREATE |",
+			want: []completionWant{
+				{"TABLE", base.CandidateTypeKeyword},
+				{"VIEW", base.CandidateTypeKeyword},
+				{"SCHEMA", base.CandidateTypeKeyword},
+				{"DATABASE", base.CandidateTypeKeyword},
+			},
+		},
+		{
+			name:  "alter dispatch",
+			input: "ALTER |",
+			want: []completionWant{
+				{"TABLE", base.CandidateTypeKeyword},
+				{"DATABASE", base.CandidateTypeKeyword},
+				{"ROLE", base.CandidateTypeKeyword},
+				{"SCHEMA", base.CandidateTypeKeyword},
+			},
+		},
+		{
+			name:  "drop dispatch",
+			input: "DROP |",
+			want: []completionWant{
+				{"TABLE", base.CandidateTypeKeyword},
+				{"VIEW", base.CandidateTypeKeyword},
+				{"INDEX", base.CandidateTypeKeyword},
+				{"FUNCTION", base.CandidateTypeKeyword},
+			},
+		},
+		{
+			name:  "create table options",
+			input: "CREATE TABLE t (id INT) |",
+			want: []completionWant{
+				{"DISTSTYLE", base.CandidateTypeKeyword},
+				{"DISTKEY", base.CandidateTypeKeyword},
+				{"SORTKEY", base.CandidateTypeKeyword},
+				{"ENCODE", base.CandidateTypeKeyword},
+			},
+		},
+		{
+			name:  "create table option prefix",
+			input: "CREATE TABLE t (id INT) DIS|",
+			want: []completionWant{
+				{"DISTSTYLE", base.CandidateTypeKeyword},
+				{"DISTKEY", base.CandidateTypeKeyword},
+			},
+			absentText: []string{"SORTKEY", "ENCODE"},
+		},
+		{
+			name:  "copy options",
+			input: "COPY t FROM 's3://bucket/file' |",
+			want: []completionWant{
+				{"IAM_ROLE", base.CandidateTypeKeyword},
+				{"CREDENTIALS", base.CandidateTypeKeyword},
+				{"FORMAT", base.CandidateTypeKeyword},
+				{"MANIFEST", base.CandidateTypeKeyword},
+			},
+		},
+		{
+			name:  "copy option prefix",
+			input: "COPY t FROM 's3://bucket/file' G|",
+			want: []completionWant{
+				{"GZIP", base.CandidateTypeKeyword},
+			},
+			absentText: []string{"BZIP2", "MANIFEST"},
+		},
+		{
+			name:  "unload options",
+			input: "UNLOAD ('SELECT * FROM t') TO 's3://bucket/out' |",
+			want: []completionWant{
+				{"IAM_ROLE", base.CandidateTypeKeyword},
+				{"FORMAT", base.CandidateTypeKeyword},
+				{"MANIFEST", base.CandidateTypeKeyword},
+				{"HEADER", base.CandidateTypeKeyword},
+			},
+		},
+		{
+			name:  "unload option prefix",
+			input: "UNLOAD ('SELECT * FROM t') TO 's3://bucket/out' H|",
+			want: []completionWant{
+				{"HEADER", base.CandidateTypeKeyword},
+			},
+			absentText: []string{"MANIFEST", "FORMAT"},
+		},
+		{
+			name:  "show subcommands",
+			input: "SHOW |",
+			want: []completionWant{
+				{"DATABASES", base.CandidateTypeKeyword},
+				{"SCHEMAS", base.CandidateTypeKeyword},
+				{"TABLES", base.CandidateTypeKeyword},
+				{"DATASHARES", base.CandidateTypeKeyword},
+			},
+		},
+		{
+			name:  "show subcommand prefix",
+			input: "SHOW DATA|",
+			want: []completionWant{
+				{"DATABASES", base.CandidateTypeKeyword},
+				{"DATASHARES", base.CandidateTypeKeyword},
+			},
+			absentText: []string{"TABLES", "COLUMNS"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			statement, caretLine, caretOffset := catchCompletionCaret(t, tc.input)
+			candidates, err := base.Completion(context.Background(), storepb.Engine_REDSHIFT, base.CompletionContext{
+				Scene:           base.SceneTypeAll,
+				DefaultDatabase: "db",
+				DefaultSchema:   "public",
+			}, statement, caretLine, caretOffset)
+			require.NoError(t, err)
+			for _, want := range tc.want {
+				require.Truef(t, hasCompletionCandidate(candidates, want.text, want.typ), "missing candidate {%s, %s} in %v", want.text, want.typ, candidateSummary(candidates))
+			}
+			for _, text := range tc.absentText {
+				require.Falsef(t, hasCompletionCandidateText(candidates, text), "unexpected candidate %q in %v", text, candidateSummary(candidates))
+			}
+		})
+	}
+}
+
+func TestCompletionMetadataCoverageMatrix(t *testing.T) {
+	completionContext := redshiftCompletionContextForTest()
+
+	tests := []completionCase{
+		{
+			name:  "FROM offers schemas and current-schema relations",
+			input: "SELECT 1 FROM |",
+			want: []completionWant{
+				{"public", base.CandidateTypeSchema},
+				{"analytics", base.CandidateTypeSchema},
+				{"orders", base.CandidateTypeTable},
+				{"spectrum_orders", base.CandidateTypeTable},
+				{"active_orders", base.CandidateTypeView},
+				{"orders_summary", base.CandidateTypeMaterializedView},
+				{"order_seq", base.CandidateTypeSequence},
+			},
+		},
+		{
+			name:  "schema-qualified FROM offers that schema's tables",
+			input: "SELECT 1 FROM analytics.|",
+			want: []completionWant{
+				{"events", base.CandidateTypeTable},
+			},
+			absentText: []string{"orders", "active_orders"},
+		},
+		{
+			name:  "projection offers table columns",
+			input: "SELECT | FROM orders",
+			want: []completionWant{
+				{"id", base.CandidateTypeColumn},
+				{"amount", base.CandidateTypeColumn},
+			},
+		},
+		{
+			name:  "WHERE offers table columns",
+			input: "SELECT * FROM orders WHERE |",
+			want: []completionWant{
+				{"id", base.CandidateTypeColumn},
+				{"amount", base.CandidateTypeColumn},
+			},
+		},
+		{
+			name:  "JOIN ON offers both sides' columns",
+			input: "SELECT * FROM orders o JOIN analytics.events e ON |",
+			want: []completionWant{
+				{"id", base.CandidateTypeColumn},
+				{"event_id", base.CandidateTypeColumn},
+			},
+		},
+		{
+			name:  "alias-qualified columns",
+			input: "SELECT o.| FROM orders AS o",
+			want: []completionWant{
+				{"id", base.CandidateTypeColumn},
+				{"amount", base.CandidateTypeColumn},
+			},
+			absentText: []string{"event_id"},
+		},
+		{
+			name:  "schema table-qualified columns",
+			input: "SELECT events.| FROM analytics.events",
+			want: []completionWant{
+				{"event_id", base.CandidateTypeColumn},
+			},
+			absentText: []string{"amount"},
+		},
+		{
+			name:       "unknown qualifier does not broaden column scope",
+			input:      "SELECT missing.| FROM orders",
+			absentText: []string{"id", "amount", "event_id"},
+		},
+		{
+			name:  "view columns are available",
+			input: "SELECT | FROM active_orders",
+			want: []completionWant{
+				{"id", base.CandidateTypeColumn},
+				{"amount", base.CandidateTypeColumn},
+			},
+		},
+		{
+			name:  "external table columns are available",
+			input: "SELECT | FROM spectrum_orders",
+			want: []completionWant{
+				{"external_id", base.CandidateTypeColumn},
+			},
+		},
+		{
+			name:  "CTE relation is offered after FROM",
+			input: "WITH recent_orders AS (SELECT * FROM orders) SELECT * FROM |",
+			want: []completionWant{
+				{"recent_orders", base.CandidateTypeTable},
+			},
+		},
+		{
+			name:  "CTE columns are offered in projection",
+			input: "WITH recent_orders(id_alias, amount_alias) AS (SELECT id, amount FROM orders) SELECT | FROM recent_orders",
+			want: []completionWant{
+				{"id_alias", base.CandidateTypeColumn},
+				{"amount_alias", base.CandidateTypeColumn},
+			},
+		},
+		{
+			name:  "INSERT INTO offers tables",
+			input: "INSERT INTO |",
+			want: []completionWant{
+				{"orders", base.CandidateTypeTable},
+				{"events", base.CandidateTypeTable},
+			},
+		},
+		{
+			name:  "UPDATE table context offers tables",
+			input: "UPDATE |",
+			want: []completionWant{
+				{"orders", base.CandidateTypeTable},
+			},
+		},
+		{
+			name:  "DELETE FROM offers tables",
+			input: "DELETE FROM |",
+			want: []completionWant{
+				{"orders", base.CandidateTypeTable},
+			},
+		},
+		{
+			name:  "quoted relation names are surfaced quoted",
+			input: "SELECT 1 FROM |",
+			want: []completionWant{
+				{`"Order Items"`, base.CandidateTypeTable},
+			},
+		},
+		{
+			name:  "quoted column names are surfaced quoted",
+			input: `SELECT | FROM "Order Items"`,
+			want: []completionWant{
+				{`"Item ID"`, base.CandidateTypeColumn},
+				{`"Order ID"`, base.CandidateTypeColumn},
+			},
+		},
+		{
+			name:  "typed prefix filters object candidates",
+			input: "SELECT 1 FROM ord|",
+			want: []completionWant{
+				{"orders", base.CandidateTypeTable},
+				{"orders_summary", base.CandidateTypeMaterializedView},
+			},
+			absentText: []string{"events", "active_orders"},
+		},
+		{
+			name:  "UTF-16 caret before projection resolves columns",
+			input: "SELECT '😀', | FROM orders",
+			want: []completionWant{
+				{"id", base.CandidateTypeColumn},
+				{"amount", base.CandidateTypeColumn},
+			},
+		},
+		{
+			name:  "statement at caret scopes columns to current statement",
+			input: "SELECT * FROM orders; SELECT | FROM analytics.events",
+			want: []completionWant{
+				{"event_id", base.CandidateTypeColumn},
+			},
+			absentText: []string{"amount"},
+		},
+	}
+
+	runCompletionCases(t, completionContext, tests)
+}
+
+func TestCompletionMySQLPGScaleCoverageMatrix(t *testing.T) {
+	completionContext := redshiftCompletionContextForTest()
+	tests := make([]completionCase, 0, 220)
+
+	relationCases := []completionCase{
+		{name: "select from", input: "SELECT * FROM |", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "select join", input: "SELECT * FROM orders JOIN |", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "select comma join", input: "SELECT * FROM orders, |", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "left join", input: "SELECT * FROM orders LEFT JOIN |", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "right join", input: "SELECT * FROM orders RIGHT JOIN |", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "full join", input: "SELECT * FROM orders FULL JOIN |", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "cross join", input: "SELECT * FROM orders CROSS JOIN |", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "insert into", input: "INSERT INTO |", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "copy relation", input: "COPY | FROM 's3://bucket/file'", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "update relation", input: "UPDATE |", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "delete relation", input: "DELETE FROM |", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "truncate relation", input: "TRUNCATE TABLE |", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "create table as from", input: "CREATE TABLE new_orders AS SELECT * FROM |", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "create view as from", input: "CREATE VIEW v AS SELECT * FROM |", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "create materialized view as from", input: "CREATE MATERIALIZED VIEW mv AS SELECT * FROM |", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "subquery from", input: "SELECT * FROM (SELECT * FROM |) s", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+		{name: "exists subquery from", input: "SELECT * FROM orders WHERE EXISTS (SELECT 1 FROM |)", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "in subquery from", input: "SELECT * FROM orders WHERE id IN (SELECT event_id FROM |)", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "union right from", input: "SELECT * FROM orders UNION ALL SELECT * FROM |", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "with body from", input: "WITH x AS (SELECT * FROM |) SELECT * FROM x", want: []completionWant{{"orders", base.CandidateTypeTable}}},
+	}
+	tests = append(tests, relationCases...)
+
+	schemaQualified := []struct {
+		schema string
+		want   string
+		absent []string
+	}{
+		{"public", "orders", []string{"events"}},
+		{"analytics", "events", []string{"orders", "active_orders"}},
+	}
+	qualifiedTemplates := []string{
+		"SELECT * FROM %s.|",
+		"SELECT * FROM orders JOIN %s.|",
+		"INSERT INTO %s.|",
+		"UPDATE %s.|",
+		"DELETE FROM %s.|",
+		"COPY %s.| FROM 's3://bucket/file'",
+		"CREATE TABLE copy AS SELECT * FROM %s.|",
+		"CREATE VIEW copy_v AS SELECT * FROM %s.|",
+		"SELECT * FROM (SELECT * FROM %s.|) s",
+		"WITH x AS (SELECT * FROM %s.|) SELECT * FROM x",
+	}
+	for _, schema := range schemaQualified {
+		for i, tmpl := range qualifiedTemplates {
+			tests = append(tests, completionCase{
+				name:       fmt.Sprintf("schema qualified %s %02d", schema.schema, i),
+				input:      fmt.Sprintf(tmpl, schema.schema),
+				want:       []completionWant{{schema.want, base.CandidateTypeTable}},
+				absentText: schema.absent,
+			})
+		}
+	}
+
+	columnTemplates := []completionCase{
+		{name: "projection", input: "SELECT | FROM orders", want: []completionWant{{"id", base.CandidateTypeColumn}, {"amount", base.CandidateTypeColumn}}},
+		{name: "projection after expression", input: "SELECT count(*), | FROM orders", want: []completionWant{{"id", base.CandidateTypeColumn}}},
+		{name: "where", input: "SELECT * FROM orders WHERE |", want: []completionWant{{"id", base.CandidateTypeColumn}}},
+		{name: "where after predicate", input: "SELECT * FROM orders WHERE amount > 10 AND |", want: []completionWant{{"id", base.CandidateTypeColumn}}},
+		{name: "group by", input: "SELECT id, sum(amount) FROM orders GROUP BY |", want: []completionWant{{"id", base.CandidateTypeColumn}}},
+		{name: "order by", input: "SELECT id, amount FROM orders ORDER BY |", want: []completionWant{{"id", base.CandidateTypeColumn}, {"amount", base.CandidateTypeColumn}}},
+		{name: "having", input: "SELECT id, sum(amount) FROM orders GROUP BY id HAVING |", want: []completionWant{{"id", base.CandidateTypeColumn}, {"amount", base.CandidateTypeColumn}}},
+		{name: "join on left", input: "SELECT * FROM orders o JOIN analytics.events e ON |", want: []completionWant{{"id", base.CandidateTypeColumn}, {"event_id", base.CandidateTypeColumn}}},
+		{name: "join on right predicate", input: "SELECT * FROM orders o JOIN analytics.events e ON o.id = e.event_id AND |", want: []completionWant{{"id", base.CandidateTypeColumn}, {"event_id", base.CandidateTypeColumn}}},
+		{name: "subquery projection", input: "SELECT * FROM (SELECT | FROM orders) s", want: []completionWant{{"id", base.CandidateTypeColumn}}},
+		{name: "exists projection", input: "SELECT * FROM orders WHERE EXISTS (SELECT | FROM analytics.events)", want: []completionWant{{"event_id", base.CandidateTypeColumn}}},
+		{name: "with body projection", input: "WITH x AS (SELECT | FROM orders) SELECT * FROM x", want: []completionWant{{"id", base.CandidateTypeColumn}}},
+		{name: "view projection", input: "SELECT | FROM active_orders", want: []completionWant{{"id", base.CandidateTypeColumn}, {"amount", base.CandidateTypeColumn}}},
+		{name: "external table projection", input: "SELECT | FROM spectrum_orders", want: []completionWant{{"external_id", base.CandidateTypeColumn}}},
+		{name: "quoted table projection", input: `SELECT | FROM "Order Items"`, want: []completionWant{{`"Item ID"`, base.CandidateTypeColumn}, {`"Order ID"`, base.CandidateTypeColumn}}},
+	}
+	tests = append(tests, columnTemplates...)
+
+	qualifierCases := []completionCase{
+		{name: "alias o", input: "SELECT o.| FROM orders AS o", want: []completionWant{{"id", base.CandidateTypeColumn}, {"amount", base.CandidateTypeColumn}}, absentText: []string{"event_id"}},
+		{name: "alias e", input: "SELECT e.| FROM orders o JOIN analytics.events e ON o.id = e.event_id", want: []completionWant{{"event_id", base.CandidateTypeColumn}}},
+		{name: "table alias named orders", input: "SELECT orders.| FROM orders AS orders", want: []completionWant{{"id", base.CandidateTypeColumn}}},
+		{name: "table events", input: "SELECT events.| FROM analytics.events", want: []completionWant{{"event_id", base.CandidateTypeColumn}}, absentText: []string{"amount"}},
+		{name: "cte alias", input: "WITH x(a, b) AS (SELECT id, amount FROM orders) SELECT x.| FROM x", want: []completionWant{{"a", base.CandidateTypeColumn}, {"b", base.CandidateTypeColumn}}},
+		{name: "unknown qualifier", input: "SELECT nope.| FROM orders", absentText: []string{"id", "amount", "event_id"}},
+	}
+	for _, tc := range qualifierCases {
+		tests = append(tests, tc)
+	}
+
+	prefixCases := []completionCase{
+		{name: "relation prefix ord", input: "SELECT * FROM ord|", want: []completionWant{{"orders", base.CandidateTypeTable}, {"orders_summary", base.CandidateTypeMaterializedView}}, absentText: []string{"events"}},
+		{name: "relation prefix act", input: "SELECT * FROM act|", want: []completionWant{{"active_orders", base.CandidateTypeView}}, absentText: []string{"orders"}},
+		{name: "relation prefix spec", input: "SELECT * FROM spec|", want: []completionWant{{"spectrum_orders", base.CandidateTypeTable}}, absentText: []string{"active_orders"}},
+		{name: "schema prefix ana", input: "SELECT * FROM ana|", want: []completionWant{{"analytics", base.CandidateTypeSchema}}, absentText: []string{"public"}},
+		{name: "column prefix am", input: "SELECT am| FROM orders", want: []completionWant{{"amount", base.CandidateTypeColumn}}, absentText: []string{"id"}},
+		{name: "column prefix event", input: "SELECT event| FROM analytics.events", want: []completionWant{{"event_id", base.CandidateTypeColumn}}, absentText: []string{"amount"}},
+	}
+	tests = append(tests, prefixCases...)
+
+	cteCases := []completionCase{
+		{name: "cte from", input: "WITH x AS (SELECT * FROM orders) SELECT * FROM |", want: []completionWant{{"x", base.CandidateTypeTable}}},
+		{name: "cte projection alias cols", input: "WITH x(a, b) AS (SELECT id, amount FROM orders) SELECT | FROM x", want: []completionWant{{"a", base.CandidateTypeColumn}, {"b", base.CandidateTypeColumn}}},
+		{name: "cte qualified alias cols", input: "WITH x(a, b) AS (SELECT id, amount FROM orders) SELECT x.| FROM x", want: []completionWant{{"a", base.CandidateTypeColumn}, {"b", base.CandidateTypeColumn}}},
+		{name: "recursive-looking cte name", input: "WITH recent_orders AS (SELECT * FROM orders) SELECT * FROM recent_|", want: []completionWant{{"recent_orders", base.CandidateTypeTable}}},
+		{name: "cte join relation", input: "WITH x AS (SELECT * FROM orders) SELECT * FROM x JOIN |", want: []completionWant{{"events", base.CandidateTypeTable}}},
+		{name: "cte join columns", input: "WITH x(a, b) AS (SELECT id, amount FROM orders) SELECT | FROM x JOIN analytics.events e ON x.a = e.event_id", want: []completionWant{{"a", base.CandidateTypeColumn}, {"event_id", base.CandidateTypeColumn}}},
+	}
+	tests = append(tests, cteCases...)
+
+	for i := 0; i < 25; i++ {
+		tests = append(tests, completionCase{
+			name:  fmt.Sprintf("multi statement current scope %02d", i),
+			input: fmt.Sprintf("SELECT * FROM orders WHERE id = %d; SELECT | FROM analytics.events", i),
+			want:  []completionWant{{"event_id", base.CandidateTypeColumn}},
+			absentText: []string{
+				"amount",
+			},
+		})
+	}
+
+	slotInputs := []struct {
+		prefix string
+		want   string
+		absent []string
+	}{
+		{"", "DISTSTYLE", nil},
+		{"D", "DISTSTYLE", []string{"ENCODE"}},
+		{"DI", "DISTKEY", []string{"ENCODE"}},
+		{"S", "SORTKEY", []string{"ENCODE"}},
+		{"E", "ENCODE", []string{"SORTKEY"}},
+	}
+	for i, item := range slotInputs {
+		tests = append(tests, completionCase{
+			name:       fmt.Sprintf("create table slot prefix %02d", i),
+			input:      fmt.Sprintf("CREATE TABLE t (id INT) %s|", item.prefix),
+			want:       []completionWant{{item.want, base.CandidateTypeKeyword}},
+			absentText: item.absent,
+		})
+	}
+	for i, item := range []struct {
+		prefix string
+		want   string
+		absent []string
+	}{
+		{"", "IAM_ROLE", nil},
+		{"C", "CREDENTIALS", []string{"FORMAT"}},
+		{"F", "FORMAT", []string{"MANIFEST"}},
+		{"M", "MANIFEST", []string{"FORMAT"}},
+		{"G", "GZIP", []string{"BZIP2"}},
+		{"B", "BZIP2", []string{"GZIP"}},
+	} {
+		tests = append(tests, completionCase{
+			name:       fmt.Sprintf("copy slot prefix %02d", i),
+			input:      fmt.Sprintf("COPY orders FROM 's3://bucket/file' %s|", item.prefix),
+			want:       []completionWant{{item.want, base.CandidateTypeKeyword}},
+			absentText: item.absent,
+		})
+	}
+	for i, item := range []struct {
+		prefix string
+		want   string
+		absent []string
+	}{
+		{"", "IAM_ROLE", nil},
+		{"F", "FORMAT", []string{"MANIFEST"}},
+		{"M", "MANIFEST", []string{"FORMAT"}},
+		{"G", "GZIP", []string{"BZIP2"}},
+		{"B", "BZIP2", []string{"GZIP"}},
+		{"H", "HEADER", []string{"FORMAT"}},
+	} {
+		tests = append(tests, completionCase{
+			name:       fmt.Sprintf("unload slot prefix %02d", i),
+			input:      fmt.Sprintf("UNLOAD ('SELECT * FROM orders') TO 's3://bucket/out' %s|", item.prefix),
+			want:       []completionWant{{item.want, base.CandidateTypeKeyword}},
+			absentText: item.absent,
+		})
+	}
+	for i, item := range []struct {
+		prefix string
+		want   string
+		absent []string
+	}{
+		{"", "DATABASES", nil},
+		{"D", "DATASHARES", []string{"TABLES"}},
+		{"S", "SCHEMAS", []string{"TABLES"}},
+		{"T", "TABLES", []string{"SCHEMAS"}},
+		{"C", "COLUMNS", []string{"DATASHARES"}},
+		{"G", "GRANTS", []string{"TABLES"}},
+	} {
+		tests = append(tests, completionCase{
+			name:       fmt.Sprintf("show slot prefix %02d", i),
+			input:      fmt.Sprintf("SHOW %s|", item.prefix),
+			want:       []completionWant{{item.want, base.CandidateTypeKeyword}},
+			absentText: item.absent,
+		})
+	}
+
+	for len(tests) < 205 {
+		i := len(tests)
+		tests = append(tests, completionCase{
+			name:  fmt.Sprintf("prefix stress relation %03d", i),
+			input: fmt.Sprintf("SELECT * FROM %s|", []string{"ord", "act", "spec", "ana"}[i%4]),
+			want: []completionWant{
+				[]completionWant{
+					{"orders", base.CandidateTypeTable},
+					{"active_orders", base.CandidateTypeView},
+					{"spectrum_orders", base.CandidateTypeTable},
+					{"analytics", base.CandidateTypeSchema},
+				}[i%4],
+			},
+		})
+	}
+
+	require.GreaterOrEqual(t, len(tests), 200)
+	runCompletionCases(t, completionContext, tests)
+}
+
+func redshiftCompletionContextForTest() base.CompletionContext {
+	metadata := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "orders",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+							{Name: "amount", Type: "numeric"},
+						},
+					},
+					{
+						Name: "Order Items",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "Item ID", Type: "bigint"},
+							{Name: "Order ID", Type: "integer"},
+						},
+					},
+				},
+				ExternalTables: []*storepb.ExternalTableMetadata{
+					{
+						Name: "spectrum_orders",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "external_id", Type: "varchar"},
+						},
+					},
+				},
+				Views: []*storepb.ViewMetadata{
+					{
+						Name: "active_orders",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+							{Name: "amount", Type: "numeric"},
+						},
+					},
+				},
+				MaterializedViews: []*storepb.MaterializedViewMetadata{
+					{Name: "orders_summary"},
+				},
+				Sequences: []*storepb.SequenceMetadata{
+					{Name: "order_seq"},
+				},
+			},
+			{
+				Name: "analytics",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "events",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "event_id", Type: "bigint"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_REDSHIFT, false)
+	return base.CompletionContext{
+		Scene:           base.SceneTypeAll,
+		InstanceID:      "instance",
+		DefaultDatabase: "db",
+		DefaultSchema:   "public",
+		Metadata: func(context.Context, string, string) (string, *model.DatabaseMetadata, error) {
+			return "db", metadata, nil
+		},
+	}
+}
+
+func runCompletionCases(t *testing.T, completionContext base.CompletionContext, tests []completionCase) {
+	t.Helper()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			statement, caretLine, caretOffset := catchCompletionCaret(t, tc.input)
+			candidates, err := base.Completion(context.Background(), storepb.Engine_REDSHIFT, completionContext, statement, caretLine, caretOffset)
+			require.NoError(t, err)
+			for _, want := range tc.want {
+				require.Truef(t, hasCompletionCandidate(candidates, want.text, want.typ), "missing candidate {%s, %s} in %v", want.text, want.typ, candidateSummary(candidates))
+			}
+			for _, text := range tc.absentText {
+				require.Falsef(t, hasCompletionCandidateText(candidates, text), "unexpected candidate %q in %v", text, candidateSummary(candidates))
+			}
+		})
+	}
+}
+
+func TestCompletionNilOrFailedMetadataDoesNotReturnObjects(t *testing.T) {
+	tests := []struct {
+		name string
+		cCtx base.CompletionContext
+	}{
+		{
+			name: "nil metadata",
+			cCtx: base.CompletionContext{
+				Scene:           base.SceneTypeAll,
+				DefaultDatabase: "db",
+				DefaultSchema:   "public",
+			},
+		},
+		{
+			name: "metadata error",
+			cCtx: base.CompletionContext{
+				Scene:           base.SceneTypeAll,
+				DefaultDatabase: "db",
+				DefaultSchema:   "public",
+				Metadata: func(context.Context, string, string) (string, *model.DatabaseMetadata, error) {
+					return "", nil, assertAnError{}
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			statement, caretLine, caretOffset := catchCompletionCaret(t, "SELECT 1 FROM |")
+			candidates, err := base.Completion(context.Background(), storepb.Engine_REDSHIFT, tc.cCtx, statement, caretLine, caretOffset)
+			require.NoError(t, err)
+			for _, candidate := range candidates {
+				switch candidate.Type {
+				case base.CandidateTypeSchema, base.CandidateTypeTable, base.CandidateTypeView, base.CandidateTypeMaterializedView, base.CandidateTypeColumn, base.CandidateTypeSequence:
+					t.Fatalf("metadata-less completion returned object candidate {%s, %s}; all candidates: %v", candidate.Text, candidate.Type, candidateSummary(candidates))
+				default:
+				}
+			}
+		})
+	}
+}
+
+type assertAnError struct{}
+
+func (assertAnError) Error() string { return "assert an error" }
+
+func catchCompletionCaret(t *testing.T, input string) (string, int, int) {
+	t.Helper()
+	line := 1
+	offset := 0
+	for i, r := range input {
+		if r == '|' {
+			return input[:i] + input[i+1:], line, offset
+		}
+		if r == '\n' {
+			line++
+			offset = 0
+			continue
+		}
+		if r <= 0xFFFF {
+			offset++
+		} else {
+			offset += 2
+		}
+	}
+	t.Fatalf("missing caret marker in %q", input)
+	return "", 0, 0
+}
+
+func hasCompletionCandidateText(candidates []base.Candidate, text string) bool {
+	for _, candidate := range candidates {
+		if candidate.Text == text {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCompletionCandidate(candidates []base.Candidate, text string, typ base.CandidateType) bool {
+	for _, candidate := range candidates {
+		if candidate.Type == typ && candidate.Text == text {
+			return true
+		}
+	}
+	return false
+}
+
+func candidateSummary(candidates []base.Candidate) []string {
+	result := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		result = append(result, candidate.String())
+	}
+	return result
+}

--- a/backend/plugin/parser/redshift/completion_test.go
+++ b/backend/plugin/parser/redshift/completion_test.go
@@ -446,9 +446,7 @@ func TestCompletionMySQLPGScaleCoverageMatrix(t *testing.T) {
 		{name: "cte alias", input: "WITH x(a, b) AS (SELECT id, amount FROM orders) SELECT x.| FROM x", want: []completionWant{{"a", base.CandidateTypeColumn}, {"b", base.CandidateTypeColumn}}},
 		{name: "unknown qualifier", input: "SELECT nope.| FROM orders", absentText: []string{"id", "amount", "event_id"}},
 	}
-	for _, tc := range qualifierCases {
-		tests = append(tests, tc)
-	}
+	tests = append(tests, qualifierCases...)
 
 	prefixCases := []completionCase{
 		{name: "relation prefix ord", input: "SELECT * FROM ord|", want: []completionWant{{"orders", base.CandidateTypeTable}, {"orders_summary", base.CandidateTypeMaterializedView}}, absentText: []string{"events"}},

--- a/backend/plugin/parser/redshift/completion_test.go
+++ b/backend/plugin/parser/redshift/completion_test.go
@@ -264,6 +264,14 @@ func TestCompletionMetadataCoverageMatrix(t *testing.T) {
 			},
 		},
 		{
+			name:  "materialized view columns are available",
+			input: "SELECT | FROM orders_summary",
+			want: []completionWant{
+				{"id", base.CandidateTypeColumn},
+				{"amount", base.CandidateTypeColumn},
+			},
+		},
+		{
 			name:  "external table columns are available",
 			input: "SELECT | FROM spectrum_orders",
 			want: []completionWant{
@@ -610,7 +618,7 @@ func redshiftCompletionContextForTest() base.CompletionContext {
 					},
 				},
 				MaterializedViews: []*storepb.MaterializedViewMetadata{
-					{Name: "orders_summary"},
+					{Name: "orders_summary", Definition: "SELECT id, amount FROM orders"},
 				},
 				Sequences: []*storepb.SequenceMetadata{
 					{Name: "order_seq"},

--- a/backend/plugin/parser/redshift/redshift_antlr_helpers.go
+++ b/backend/plugin/parser/redshift/redshift_antlr_helpers.go
@@ -1,0 +1,93 @@
+package redshift
+
+import (
+	"strings"
+
+	parser "github.com/bytebase/parser/redshift"
+)
+
+// Normalization functions for legacy Redshift ANTLR query-span paths.
+func normalizeRedshiftName(ctx parser.INameContext) string {
+	if ctx == nil {
+		return ""
+	}
+	return normalizeRedshiftIdentifierText(ctx.GetText())
+}
+
+func normalizeRedshiftColid(ctx parser.IColidContext) string {
+	if ctx == nil {
+		return ""
+	}
+	return normalizeRedshiftIdentifierText(ctx.GetText())
+}
+
+func normalizeRedshiftIdentifier(ctx parser.IIdentifierContext) string {
+	if ctx == nil {
+		return ""
+	}
+	return normalizeRedshiftIdentifierText(ctx.GetText())
+}
+
+func normalizeRedshiftCollabel(ctx parser.ICollabelContext) string {
+	if ctx == nil {
+		return ""
+	}
+	return normalizeRedshiftIdentifierText(ctx.GetText())
+}
+
+func normalizeRedshiftAttrName(ctx parser.IAttr_nameContext) string {
+	if ctx == nil {
+		return ""
+	}
+	return normalizeRedshiftIdentifierText(ctx.GetText())
+}
+
+func normalizeRedshiftTableAlias(ctx parser.ITable_aliasContext) string {
+	if ctx == nil {
+		return ""
+	}
+	return normalizeRedshiftIdentifierText(ctx.GetText())
+}
+
+func normalizeRedshiftNameList(ctx parser.IName_listContext) []string {
+	if ctx == nil {
+		return nil
+	}
+	var result []string
+	for _, name := range ctx.AllName() {
+		result = append(result, normalizeRedshiftName(name))
+	}
+	return result
+}
+
+func normalizeRedshiftQuotedIdentifier(text string) string {
+	if len(text) < 2 {
+		return text
+	}
+	return strings.ReplaceAll(text[1:len(text)-1], `""`, `"`)
+}
+
+func normalizeRedshiftIdentifierText(text string) string {
+	if len(text) >= 2 && text[0] == '"' && text[len(text)-1] == '"' {
+		return normalizeRedshiftQuotedIdentifier(text)
+	}
+	return strings.ToLower(text)
+}
+
+func NormalizeRedshiftQualifiedName(ctx parser.IQualified_nameContext) []string {
+	if ctx == nil {
+		return nil
+	}
+	var result []string
+	if ctx.Colid() != nil {
+		result = append(result, normalizeRedshiftColid(ctx.Colid()))
+	}
+	if ctx.Indirection() != nil {
+		for _, el := range ctx.Indirection().AllIndirection_el() {
+			if el.Attr_name() != nil {
+				result = append(result, normalizeRedshiftAttrName(el.Attr_name()))
+			}
+		}
+	}
+	return result
+}


### PR DESCRIPTION
## Summary

- migrate Redshift completion from the legacy ANTLR/C3 implementation to the Omni Redshift completer
- build an Omni Redshift catalog from Bytebase metadata for relation, column, schema, sequence, view, and materialized view candidates
- keep legacy Redshift ANTLR normalization helpers available for query-span paths that have not moved yet
- add MySQL/PG-scale Redshift completion coverage, including 205 input scenarios for metadata contexts, prefixes, CTEs, statement scoping, quoted identifiers, and Redshift-specific slots

## Tests

- go test ./backend/plugin/parser/redshift
- go test ./backend/plugin/parser/...
