### PR TITLE
chore(mysql): remove ANTLR bridge from Omni paths

### DIFF
--- a/backend/plugin/advisor/oceanbase/advisor_disallow_offline_ddl.go
+++ b/backend/plugin/advisor/oceanbase/advisor_disallow_offline_ddl.go
@@ -8,15 +8,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/antlr4-go/antlr/v4"
-
-	"github.com/bytebase/parser/mysql"
+	"github.com/bytebase/omni/mysql/ast"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
-	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -50,21 +47,17 @@ func (*DisallowOfflineDdlAdvisor) Check(_ context.Context, checkCtx advisor.Cont
 		if stmt.AST == nil {
 			continue
 		}
-		antlrAST, ok := base.GetANTLRAST(stmt.AST)
+		node, ok := mysqlparser.GetOmniNode(stmt.AST)
 		if !ok {
 			continue
 		}
-		checker.baseLine = stmt.BaseLine()
-		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
+		checker.checkStatement(stmt.Text, stmt.BaseLine(), node)
 	}
 
 	return checker.adviceList, nil
 }
 
 type disallowOfflineDdlChecker struct {
-	*mysql.BaseMySQLParserListener
-
-	baseLine   int
 	adviceList []*storepb.Advice
 	level      storepb.Advice_Status
 	title      string
@@ -72,101 +65,86 @@ type disallowOfflineDdlChecker struct {
 	currentDB  string
 }
 
-// EnterAlterTable is called when production alterTable is entered.
-func (checker *disallowOfflineDdlChecker) EnterAlterTable(ctx *mysql.AlterTableContext) {
-	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
-		return
-	}
-	if ctx.TableRef() == nil {
-		return
-	}
-
-	if ctx.AlterTableActions() == nil {
-		return
-	}
-
-	if ctx.AlterTableActions().PartitionClause() != nil && ctx.AlterTableActions().PartitionClause().PartitionTypeDef() != nil {
-		checker.advice(ctx, "Modifying partitions")
-		return
-	}
-
-	if ctx.AlterTableActions().AlterCommandList() == nil || ctx.AlterTableActions().AlterCommandList().AlterList() == nil {
-		return
-	}
-
-	databaseName, tableName := mysqlparser.NormalizeMySQLTableRef(ctx.TableRef())
-	for _, item := range ctx.AlterTableActions().AlterCommandList().AlterList().AllAlterListItem() {
-		if item == nil {
-			continue
-		}
-
-		switch {
-		case item.ADD_SYMBOL() != nil:
-			switch {
-			// add one column
-			case item.Identifier() != nil && item.FieldDefinition() != nil:
-				if columnType := checker.getSpecialColumnType(item.FieldDefinition()); len(columnType) != 0 {
-					checker.advice(ctx, fmt.Sprintf("Adding %s columns", columnType))
-				}
-			// add multiple columns
-			case item.OPEN_PAR_SYMBOL() != nil && item.TableElementList() != nil:
-				for _, tableElement := range item.TableElementList().AllTableElement() {
-					if tableElement.ColumnDefinition() == nil {
-						continue
-					}
-					if tableElement.ColumnDefinition().FieldDefinition() == nil {
-						continue
-					}
-					if columnType := checker.getSpecialColumnType(item.FieldDefinition()); len(columnType) != 0 {
-						checker.advice(ctx, fmt.Sprintf("Adding %s columns", columnType))
-					}
-				}
-			// add primary key
-			case item.TableConstraintDef() != nil:
-				if item.TableConstraintDef().PRIMARY_SYMBOL() != nil && item.TableConstraintDef().KEY_SYMBOL() != nil {
-					checker.advice(ctx, "Adding primary keys")
-				}
-			default:
-				// Skip other ADD operations
-			}
-		// modify column
-		case item.MODIFY_SYMBOL() != nil && item.ColumnInternalRef() != nil && item.FieldDefinition() != nil:
-			if columnType := checker.getSpecialColumnType(item.FieldDefinition()); len(columnType) != 0 {
-				checker.advice(ctx, fmt.Sprintf("Modifying columns to %s", columnType))
-			}
-		// change column
-		case item.CHANGE_SYMBOL() != nil && item.ColumnInternalRef() != nil && item.FieldDefinition() != nil:
-			if columnType := checker.getSpecialColumnType(item.FieldDefinition()); len(columnType) != 0 {
-				checker.advice(ctx, fmt.Sprintf("Changing columns to %s", columnType))
-			}
-		case item.DROP_SYMBOL() != nil:
-			switch {
-			// drop column
-			case item.ColumnInternalRef() != nil:
-				if len(databaseName) == 0 {
-					databaseName = checker.currentDB
-				}
-				columnName := mysqlparser.NormalizeMySQLColumnInternalRef(item.ColumnInternalRef())
-				if checker.isStoredColumn(databaseName, tableName, columnName) {
-					checker.advice(ctx, "Dropping stored generated columns")
-				}
-			// drop primary key
-			case item.PRIMARY_SYMBOL() != nil && item.KEY_SYMBOL() != nil:
-				checker.advice(ctx, "Dropping primary keys")
-			default:
-				// Skip other DROP operations
-			}
-		// change charset or collate
-		case item.Charset() != nil || item.Collate() != nil:
-			checker.advice(ctx, "Changing charset or collate")
-		default:
-			// Skip other ALTER TABLE operations
-		}
+func (checker *disallowOfflineDdlChecker) checkStatement(text string, baseLine int, node ast.Node) {
+	switch n := node.(type) {
+	case *ast.AlterTableStmt:
+		checker.checkAlterTable(text, baseLine, n)
+	case *ast.DropTableStmt:
+		checker.advice(omniLine(baseLine, text, n.Loc), "Dropping tables")
+	case *ast.TruncateStmt:
+		checker.advice(omniLine(baseLine, text, n.Loc), "Truncating tables")
+	default:
 	}
 }
 
+func (checker *disallowOfflineDdlChecker) checkAlterTable(text string, baseLine int, stmt *ast.AlterTableStmt) {
+	databaseName, tableName := omniTableName(stmt.Table)
+	if databaseName == "" {
+		databaseName = checker.currentDB
+	}
+	for _, cmd := range stmt.Commands {
+		if cmd == nil {
+			continue
+		}
+		line := omniLine(baseLine, text, cmd.Loc)
+		checker.checkAlterTableCmd(line, databaseName, tableName, cmd)
+	}
+}
+
+func (checker *disallowOfflineDdlChecker) checkAlterTableCmd(line int, databaseName, tableName string, cmd *ast.AlterTableCmd) {
+	switch cmd.Type {
+	case ast.ATAddColumn:
+		if columnType := checker.getSpecialColumnType(cmd.Column); columnType != "" {
+			checker.advice(line, fmt.Sprintf("Adding %s columns", columnType))
+		}
+		for _, column := range cmd.Columns {
+			if columnType := checker.getSpecialColumnType(column); columnType != "" {
+				checker.advice(line, fmt.Sprintf("Adding %s columns", columnType))
+			}
+		}
+	case ast.ATAddConstraint:
+		if cmd.Constraint != nil && cmd.Constraint.Type == ast.ConstrPrimaryKey {
+			checker.advice(line, "Adding primary keys")
+		}
+	case ast.ATModifyColumn:
+		if columnType := checker.getSpecialColumnType(cmd.Column); columnType != "" {
+			checker.advice(line, fmt.Sprintf("Modifying columns to %s", columnType))
+		}
+	case ast.ATChangeColumn:
+		if columnType := checker.getSpecialColumnType(cmd.Column); columnType != "" {
+			checker.advice(line, fmt.Sprintf("Changing columns to %s", columnType))
+		}
+	case ast.ATDropColumn:
+		if checker.isStoredColumn(databaseName, tableName, cmd.Name) {
+			checker.advice(line, "Dropping stored generated columns")
+		}
+	case ast.ATDropConstraint:
+		if strings.EqualFold(cmd.Name, "PRIMARY") {
+			checker.advice(line, "Dropping primary keys")
+		}
+	case ast.ATDropPartition:
+		checker.advice(line, "Dropping partitions")
+	case ast.ATTruncatePartition:
+		checker.advice(line, "Truncating partitions")
+	case ast.ATAddPartition, ast.ATCoalescePartition, ast.ATReorganizePartition, ast.ATExchangePartition, ast.ATAnalyzePartition, ast.ATCheckPartition, ast.ATOptimizePartition, ast.ATRebuildPartition, ast.ATRepairPartition, ast.ATDiscardPartitionTablespace, ast.ATImportPartitionTablespace, ast.ATRemovePartitioning, ast.ATPartitionBy:
+		checker.advice(line, "Modifying partitions")
+	case ast.ATConvertCharset:
+		checker.advice(line, "Changing charset or collate")
+	case ast.ATTableOption:
+		if cmd.Option != nil && isCharsetOrCollationOption(cmd.Option) {
+			checker.advice(line, "Changing charset or collate")
+		}
+	default:
+	}
+}
+
+func isCharsetOrCollationOption(option *ast.TableOption) bool {
+	name := strings.ToLower(option.Name)
+	return strings.Contains(name, "charset") || strings.Contains(name, "character set") || strings.Contains(name, "collate") || strings.Contains(name, "collation")
+}
+
 func (checker *disallowOfflineDdlChecker) isStoredColumn(databaseName, tableName, columnName string) bool {
-	if len(databaseName) == 0 || len(tableName) == 0 || len(columnName) == 0 {
+	if checker.driver == nil || len(databaseName) == 0 || len(tableName) == 0 || len(columnName) == 0 {
 		return false
 	}
 
@@ -182,82 +160,28 @@ func (checker *disallowOfflineDdlChecker) isStoredColumn(databaseName, tableName
 	return false
 }
 
-// EnterAlterPartition is called when entering the alterPartition production.
-func (checker *disallowOfflineDdlChecker) EnterAlterPartition(ctx *mysql.AlterPartitionContext) {
-	if ctx.PARTITION_SYMBOL() == nil {
-		return
-	}
-
-	switch {
-	case ctx.DROP_SYMBOL() != nil:
-		checker.advice(ctx, "Dropping partitions")
-	case ctx.TRUNCATE_SYMBOL() != nil:
-		checker.advice(ctx, "Truncating partitions")
-	default:
-		// Skip other partition operations
-	}
-}
-
-// EnterDropStatement is called when entering the dropStatement production.
-func (checker *disallowOfflineDdlChecker) EnterDropStatement(ctx *mysql.DropStatementContext) {
-	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
-		return
-	}
-	if ctx.DropTable() != nil {
-		checker.advice(ctx, "Dropping tables")
-	}
-}
-
-// EnterTruncateTableStatement is called when entering the truncateTableStatement production.
-func (checker *disallowOfflineDdlChecker) EnterTruncateTableStatement(ctx *mysql.TruncateTableStatementContext) {
-	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
-		return
-	}
-	if ctx.TableRef() != nil {
-		checker.advice(ctx, "Truncating tables")
-	}
-}
-
-func (checker *disallowOfflineDdlChecker) getSpecialColumnType(ctx mysql.IFieldDefinitionContext) string {
-	if ctx == nil {
+func (*disallowOfflineDdlChecker) getSpecialColumnType(column *ast.ColumnDef) string {
+	if column == nil {
 		return ""
 	}
 	switch {
-	case ctx.STORED_SYMBOL() != nil:
+	case column.Generated != nil && column.Generated.Stored:
 		return "stored generated"
-	case checker.isAutoIncrementColumn(ctx):
+	case column.AutoIncrement:
 		return "auto increment"
-	case checker.isPrimaryKeyColumn(ctx):
+	case omniColumnHasPrimaryKey(column):
 		return "primary key"
 	default:
 		return ""
 	}
 }
 
-func (*disallowOfflineDdlChecker) isAutoIncrementColumn(ctx mysql.IFieldDefinitionContext) bool {
-	for _, attr := range ctx.AllColumnAttribute() {
-		if attr.AUTO_INCREMENT_SYMBOL() != nil {
-			return true
-		}
-	}
-	return false
-}
-
-func (*disallowOfflineDdlChecker) isPrimaryKeyColumn(ctx mysql.IFieldDefinitionContext) bool {
-	for _, attr := range ctx.AllColumnAttribute() {
-		if attr.PRIMARY_SYMBOL() != nil && attr.KEY_SYMBOL() != nil {
-			return true
-		}
-	}
-	return false
-}
-
-func (checker *disallowOfflineDdlChecker) advice(ctx antlr.ParserRuleContext, operation string) {
+func (checker *disallowOfflineDdlChecker) advice(line int, operation string) {
 	checker.adviceList = append(checker.adviceList, &storepb.Advice{
 		Status:        checker.level,
 		Code:          code.StatementOfflineDDL.Int32(),
 		Title:         checker.title,
 		Content:       fmt.Sprintf("%s is an offline DDL operation.", operation),
-		StartPosition: common.ConvertANTLRLineToPosition(checker.baseLine + ctx.GetStart().GetLine()),
+		StartPosition: common.ConvertANTLRLineToPosition(line),
 	})
 }

--- a/backend/plugin/advisor/oceanbase/advisor_insert_row_limit.go
+++ b/backend/plugin/advisor/oceanbase/advisor_insert_row_limit.go
@@ -7,14 +7,12 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/antlr4-go/antlr/v4"
-	"github.com/bytebase/parser/mysql"
+	"github.com/bytebase/omni/mysql/ast"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
-	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -54,12 +52,15 @@ func (*InsertRowLimitAdvisor) Check(ctx context.Context, checkCtx advisor.Contex
 		if stmt.AST == nil {
 			continue
 		}
-		antlrAST, ok := base.GetANTLRAST(stmt.AST)
+		node, ok := mysqlparser.GetOmniNode(stmt.AST)
 		if !ok {
 			continue
 		}
-		checker.baseLine = stmt.BaseLine()
-		antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
+		insert, ok := node.(*ast.InsertStmt)
+		if !ok {
+			continue
+		}
+		checker.checkInsert(stmt.Text, stmt.BaseLine(), insert)
 		if checker.explainCount >= common.MaximumLintExplainSize {
 			break
 		}
@@ -68,14 +69,9 @@ func (*InsertRowLimitAdvisor) Check(ctx context.Context, checkCtx advisor.Contex
 }
 
 type insertRowLimitChecker struct {
-	*mysql.BaseMySQLParserListener
-
-	baseLine     int
 	adviceList   []*storepb.Advice
 	level        storepb.Advice_Status
 	title        string
-	text         string
-	line         int
 	maxRow       int
 	driver       *sql.DB
 	ctx          context.Context
@@ -86,36 +82,28 @@ func (checker *insertRowLimitChecker) generateAdvice() ([]*storepb.Advice, error
 	return checker.adviceList, nil
 }
 
-func (checker *insertRowLimitChecker) EnterQuery(ctx *mysql.QueryContext) {
-	checker.text = ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx)
+func (checker *insertRowLimitChecker) checkInsert(text string, baseLine int, stmt *ast.InsertStmt) {
+	line := omniLine(baseLine, text, stmt.Loc)
+	if stmt.Select != nil || stmt.TableSource != nil {
+		checker.handleInsertQueryExpression(text, line)
+	}
+	checker.handleNoInsertQueryExpression(text, line, stmt)
 }
 
-// EnterInsertStatement is called when production insertStatement is entered.
-func (checker *insertRowLimitChecker) EnterInsertStatement(ctx *mysql.InsertStatementContext) {
-	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
-		return
-	}
-	checker.line = checker.baseLine + ctx.GetStart().GetLine()
-	if ctx.InsertQueryExpression() != nil {
-		checker.handleInsertQueryExpression(ctx.InsertQueryExpression())
-	}
-	checker.handleNoInsertQueryExpression(ctx)
-}
-
-func (checker *insertRowLimitChecker) handleInsertQueryExpression(ctx mysql.IInsertQueryExpressionContext) {
-	if checker.driver == nil || ctx == nil {
+func (checker *insertRowLimitChecker) handleInsertQueryExpression(text string, line int) {
+	if checker.driver == nil {
 		return
 	}
 
 	checker.explainCount++
-	res, err := advisor.Query(checker.ctx, advisor.QueryContext{}, checker.driver, storepb.Engine_OCEANBASE, fmt.Sprintf("EXPLAIN format=json %s", checker.text))
+	res, err := advisor.Query(checker.ctx, advisor.QueryContext{}, checker.driver, storepb.Engine_OCEANBASE, fmt.Sprintf("EXPLAIN format=json %s", text))
 	if err != nil {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
 			Code:          code.InsertTooManyRows.Int32(),
 			Title:         checker.title,
-			Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", checker.text, err.Error()),
-			StartPosition: common.ConvertANTLRLineToPosition(checker.line),
+			Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", text, err.Error()),
+			StartPosition: common.ConvertANTLRLineToPosition(line),
 		})
 		return
 	}
@@ -125,39 +113,28 @@ func (checker *insertRowLimitChecker) handleInsertQueryExpression(ctx mysql.IIns
 			Status:        checker.level,
 			Code:          code.Internal.Int32(),
 			Title:         checker.title,
-			Content:       fmt.Sprintf("failed to get row count for \"%s\": %s", checker.text, err.Error()),
-			StartPosition: common.ConvertANTLRLineToPosition(checker.line),
+			Content:       fmt.Sprintf("failed to get row count for \"%s\": %s", text, err.Error()),
+			StartPosition: common.ConvertANTLRLineToPosition(line),
 		})
 	} else if rowCount > int64(checker.maxRow) {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
 			Code:          code.InsertTooManyRows.Int32(),
 			Title:         checker.title,
-			Content:       fmt.Sprintf("\"%s\" inserts %d rows. The count exceeds %d.", checker.text, rowCount, checker.maxRow),
-			StartPosition: common.ConvertANTLRLineToPosition(checker.line),
+			Content:       fmt.Sprintf("\"%s\" inserts %d rows. The count exceeds %d.", text, rowCount, checker.maxRow),
+			StartPosition: common.ConvertANTLRLineToPosition(line),
 		})
 	}
 }
 
-func (checker *insertRowLimitChecker) handleNoInsertQueryExpression(ctx mysql.IInsertStatementContext) {
-	if ctx.InsertFromConstructor() == nil {
-		return
-	}
-	if ctx.InsertFromConstructor().InsertValues() == nil {
-		return
-	}
-	if ctx.InsertFromConstructor().InsertValues().ValueList() == nil {
-		return
-	}
-
-	allValues := ctx.InsertFromConstructor().InsertValues().ValueList().AllValues()
-	if len(allValues) > checker.maxRow {
+func (checker *insertRowLimitChecker) handleNoInsertQueryExpression(text string, line int, stmt *ast.InsertStmt) {
+	if len(stmt.Values) > checker.maxRow {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
 			Code:          code.InsertTooManyRows.Int32(),
 			Title:         checker.title,
-			Content:       fmt.Sprintf("\"%s\" inserts %d rows. The count exceeds %d.", checker.text, len(allValues), checker.maxRow),
-			StartPosition: common.ConvertANTLRLineToPosition(checker.line),
+			Content:       fmt.Sprintf("\"%s\" inserts %d rows. The count exceeds %d.", text, len(stmt.Values), checker.maxRow),
+			StartPosition: common.ConvertANTLRLineToPosition(line),
 		})
 	}
 }

--- a/backend/plugin/advisor/oceanbase/advisor_statement_affected_row_limit.go
+++ b/backend/plugin/advisor/oceanbase/advisor_statement_affected_row_limit.go
@@ -7,15 +7,12 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/antlr4-go/antlr/v4"
-
-	"github.com/bytebase/parser/mysql"
+	"github.com/bytebase/omni/mysql/ast"
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
-	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 )
 
@@ -54,12 +51,17 @@ func (*StatementAffectedRowLimitAdvisor) Check(ctx context.Context, checkCtx adv
 			if stmt.AST == nil {
 				continue
 			}
-			antlrAST, ok := base.GetANTLRAST(stmt.AST)
+			node, ok := mysqlparser.GetOmniNode(stmt.AST)
 			if !ok {
 				continue
 			}
-			checker.baseLine = stmt.BaseLine()
-			antlr.ParseTreeWalkerDefault.Walk(checker, antlrAST.Tree)
+			switch n := node.(type) {
+			case *ast.UpdateStmt:
+				checker.handleStmt(stmt.Text, omniLine(stmt.BaseLine(), stmt.Text, n.Loc))
+			case *ast.DeleteStmt:
+				checker.handleStmt(stmt.Text, omniLine(stmt.BaseLine(), stmt.Text, n.Loc))
+			default:
+			}
 			if checker.explainCount >= common.MaximumLintExplainSize {
 				break
 			}
@@ -70,49 +72,24 @@ func (*StatementAffectedRowLimitAdvisor) Check(ctx context.Context, checkCtx adv
 }
 
 type statementAffectedRowLimitChecker struct {
-	*mysql.BaseMySQLParserListener
-
-	baseLine     int
 	adviceList   []*storepb.Advice
 	level        storepb.Advice_Status
 	title        string
-	text         string
 	maxRow       int
 	driver       *sql.DB
 	ctx          context.Context
 	explainCount int
 }
 
-func (checker *statementAffectedRowLimitChecker) EnterQuery(ctx *mysql.QueryContext) {
-	checker.text = ctx.GetParser().GetTokenStream().GetTextFromRuleContext(ctx)
-}
-
-// EnterUpdateStatement is called when production updateStatement is entered.
-func (checker *statementAffectedRowLimitChecker) EnterUpdateStatement(ctx *mysql.UpdateStatementContext) {
-	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
-		return
-	}
-	checker.handleStmt(ctx.GetStart().GetLine())
-}
-
-// EnterDeleteStatement is called when production deleteStatement is entered.
-func (checker *statementAffectedRowLimitChecker) EnterDeleteStatement(ctx *mysql.DeleteStatementContext) {
-	if !mysqlparser.IsTopMySQLRule(&ctx.BaseParserRuleContext) {
-		return
-	}
-	checker.handleStmt(ctx.GetStart().GetLine())
-}
-
-func (checker *statementAffectedRowLimitChecker) handleStmt(lineNumber int) {
-	lineNumber += checker.baseLine
+func (checker *statementAffectedRowLimitChecker) handleStmt(text string, lineNumber int) {
 	checker.explainCount++
-	res, err := advisor.Query(checker.ctx, advisor.QueryContext{}, checker.driver, storepb.Engine_OCEANBASE, fmt.Sprintf("EXPLAIN format=json %s", checker.text))
+	res, err := advisor.Query(checker.ctx, advisor.QueryContext{}, checker.driver, storepb.Engine_OCEANBASE, fmt.Sprintf("EXPLAIN format=json %s", text))
 	if err != nil {
 		checker.adviceList = append(checker.adviceList, &storepb.Advice{
 			Status:        checker.level,
 			Code:          code.StatementAffectedRowExceedsLimit.Int32(),
 			Title:         checker.title,
-			Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", checker.text, err.Error()),
+			Content:       fmt.Sprintf("\"%s\" dry runs failed: %s", text, err.Error()),
 			StartPosition: common.ConvertANTLRLineToPosition(lineNumber),
 		})
 	} else {
@@ -122,7 +99,7 @@ func (checker *statementAffectedRowLimitChecker) handleStmt(lineNumber int) {
 				Status:        checker.level,
 				Code:          code.Internal.Int32(),
 				Title:         checker.title,
-				Content:       fmt.Sprintf("failed to get row count for \"%s\": %s", checker.text, err.Error()),
+				Content:       fmt.Sprintf("failed to get row count for \"%s\": %s", text, err.Error()),
 				StartPosition: common.ConvertANTLRLineToPosition(lineNumber),
 			})
 		} else if rowCount > int64(checker.maxRow) {
@@ -130,7 +107,7 @@ func (checker *statementAffectedRowLimitChecker) handleStmt(lineNumber int) {
 				Status:        checker.level,
 				Code:          code.StatementAffectedRowExceedsLimit.Int32(),
 				Title:         checker.title,
-				Content:       fmt.Sprintf("\"%s\" affected %d rows (estimated). The count exceeds %d.", checker.text, rowCount, checker.maxRow),
+				Content:       fmt.Sprintf("\"%s\" affected %d rows (estimated). The count exceeds %d.", text, rowCount, checker.maxRow),
 				StartPosition: common.ConvertANTLRLineToPosition(lineNumber),
 			})
 		}

--- a/backend/plugin/advisor/oceanbase/antlr_dependency_test.go
+++ b/backend/plugin/advisor/oceanbase/antlr_dependency_test.go
@@ -1,0 +1,28 @@
+package oceanbase
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOceanBaseAdvisorsDoNotUseMySQLANTLRBridge(t *testing.T) {
+	files := []string{
+		"advisor_disallow_offline_ddl.go",
+		"advisor_insert_row_limit.go",
+		"advisor_statement_affected_row_limit.go",
+	}
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			content, err := os.ReadFile(file)
+			require.NoError(t, err)
+			source := string(content)
+
+			require.NotContains(t, source, "github.com/antlr4-go/antlr/v4")
+			require.NotContains(t, source, "github.com/bytebase/parser/mysql")
+			require.NotContains(t, source, "base.GetANTLRAST")
+			require.NotContains(t, source, "BaseMySQLParserListener")
+		})
+	}
+}

--- a/backend/plugin/advisor/oceanbase/omni_helpers.go
+++ b/backend/plugin/advisor/oceanbase/omni_helpers.go
@@ -1,0 +1,33 @@
+package oceanbase
+
+import (
+	"github.com/bytebase/omni/mysql/ast"
+
+	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
+)
+
+func omniLine(baseLine int, text string, loc ast.Loc) int {
+	if loc.Start < 0 {
+		return baseLine + 1
+	}
+	return baseLine + int(mysqlparser.ByteOffsetToRunePosition(text, loc.Start).Line)
+}
+
+func omniTableName(table *ast.TableRef) (string, string) {
+	if table == nil {
+		return "", ""
+	}
+	return table.Schema, table.Name
+}
+
+func omniColumnHasPrimaryKey(column *ast.ColumnDef) bool {
+	if column == nil {
+		return false
+	}
+	for _, constraint := range column.Constraints {
+		if constraint.Type == ast.ColConstrPrimaryKey {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/plugin/db/mysql/antlr_dependency_test.go
+++ b/backend/plugin/db/mysql/antlr_dependency_test.go
@@ -1,0 +1,21 @@
+package mysql
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMySQLQueryLimitRewriteDoesNotFallbackToANTLR(t *testing.T) {
+	content, err := os.ReadFile("query.go")
+	require.NoError(t, err)
+	source := string(content)
+
+	require.NotContains(t, source, "github.com/antlr4-go/antlr/v4")
+	require.NotContains(t, source, "github.com/bytebase/parser/mysql")
+	require.NotContains(t, source, "getStatementWithResultLimitInlineLegacy")
+	require.NotContains(t, source, "ParseMySQL(")
+	require.NotContains(t, source, "TokenStreamRewriter")
+	require.NotContains(t, source, "BaseMySQLParserListener")
+}

--- a/backend/plugin/db/mysql/query.go
+++ b/backend/plugin/db/mysql/query.go
@@ -5,15 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"reflect"
-	"strconv"
 	"strings"
 
-	"github.com/antlr4-go/antlr/v4"
 	"github.com/bytebase/omni/mysql/ast"
 	omnimysqlparser "github.com/bytebase/omni/mysql/parser"
 	"github.com/pkg/errors"
-
-	antlrmysql "github.com/bytebase/parser/mysql"
 
 	"github.com/bytebase/bytebase/backend/common/log"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
@@ -108,7 +104,7 @@ func getStatementWithResultLimitInline(statement string, limitCount int) (string
 
 	list, err := mysqlparser.ParseMySQLOmni(statement)
 	if err != nil {
-		if stmt, legacyErr := getStatementWithResultLimitInlineLegacy(statement, limitCount); legacyErr == nil {
+		if stmt, procedureErr := rewriteMySQLSelectProcedureLimit(statement, limitCount); procedureErr == nil {
 			return stmt, nil
 		}
 		return "", err
@@ -125,72 +121,70 @@ func getStatementWithResultLimitInline(statement string, limitCount int) (string
 	return rewriteMySQLSelectLimit(statement, stmt, limitCount)
 }
 
-func getStatementWithResultLimitInlineLegacy(statement string, limitCount int) (string, error) {
-	list, err := mysqlparser.ParseMySQL(statement)
+func rewriteMySQLSelectProcedureLimit(sql string, limitCount int) (string, error) {
+	statements, err := mysqlparser.SplitSQL(sql)
 	if err != nil {
 		return "", err
 	}
-	if len(list) != 1 {
-		return "", errors.Errorf("expected exactly one statement, got %d", len(list))
-	}
-
-	listener := &mysqlRewriter{
-		limitCount:     limitCount,
-		outerMostQuery: true,
-	}
-
-	for _, stmt := range list {
-		listener.rewriter = *antlr.NewTokenStreamRewriter(stmt.Tokens)
-		antlr.ParseTreeWalkerDefault.Walk(listener, stmt.Tree)
-		if listener.err != nil {
-			return "", errors.Wrapf(listener.err, "statement: %s", statement)
+	statementCount := 0
+	for _, statement := range statements {
+		if !statement.Empty {
+			statementCount++
 		}
 	}
-	return listener.rewriter.GetTextDefault(), nil
+	if statementCount != 1 {
+		return "", errors.Errorf("expected exactly one statement, got %d", statementCount)
+	}
+
+	tokens := omnimysqlparser.Tokenize(sql)
+	if len(tokens) == 0 || omnimysqlparser.TokenName(tokens[0].Type) != "SELECT" {
+		return "", errors.New("not a SELECT PROCEDURE statement")
+	}
+	for i, token := range tokens[1:] {
+		if omnimysqlparser.TokenName(token.Type) == "PROCEDURE" {
+			procedureTokenIndex := i + 1
+			if stmt, ok := rewriteMySQLLimitBeforeProcedure(sql, tokens[:procedureTokenIndex], limitCount); ok {
+				return stmt, nil
+			}
+			return sql[:token.Loc] + fmt.Sprintf("LIMIT %d ", limitCount) + sql[token.Loc:], nil
+		}
+	}
+	return "", errors.New("SELECT PROCEDURE clause not found")
 }
 
-type mysqlRewriter struct {
-	*antlrmysql.BaseMySQLParserListener
-
-	rewriter       antlr.TokenStreamRewriter
-	err            error
-	outerMostQuery bool
-	limitCount     int
-}
-
-func (r *mysqlRewriter) EnterQueryExpression(ctx *antlrmysql.QueryExpressionContext) {
-	if !r.outerMostQuery {
-		return
-	}
-	r.outerMostQuery = false
-	limitClause := ctx.LimitClause()
-	if limitClause != nil && limitClause.LimitOptions() != nil && len(limitClause.LimitOptions().AllLimitOption()) > 0 {
-		userLimitOption := limitClause.LimitOptions().LimitOption(0)
-		if limitClause.LimitOptions().COMMA_SYMBOL() != nil {
-			userLimitOption = limitClause.LimitOptions().LimitOption(1)
-		}
-
-		userLimitText := userLimitOption.GetText()
-		limit, _ := strconv.Atoi(userLimitText)
-		if limit == 0 || r.limitCount < limit {
-			limit = r.limitCount
-		}
-		r.rewriter.ReplaceDefault(userLimitOption.GetStart().GetTokenIndex(), userLimitOption.GetStop().GetTokenIndex(), fmt.Sprintf("%d", limit))
-		return
-	}
-
-	if ctx.OrderClause() != nil {
-		r.rewriter.InsertAfterDefault(ctx.OrderClause().GetStop().GetTokenIndex(), fmt.Sprintf(" LIMIT %d", r.limitCount))
-	} else {
-		switch {
-		case ctx.QueryExpressionBody() != nil:
-			r.rewriter.InsertAfterDefault(ctx.QueryExpressionBody().GetStop().GetTokenIndex(), fmt.Sprintf(" LIMIT %d", r.limitCount))
-		case ctx.QueryExpressionParens() != nil:
-			r.rewriter.InsertAfterDefault(ctx.QueryExpressionParens().GetStop().GetTokenIndex(), fmt.Sprintf(" LIMIT %d", r.limitCount))
+func rewriteMySQLLimitBeforeProcedure(sql string, tokens []omnimysqlparser.Token, limitCount int) (string, bool) {
+	depth := 0
+	for i := len(tokens) - 1; i >= 0; i-- {
+		switch tokens[i].Str {
+		case ")":
+			depth++
+			continue
+		case "(":
+			if depth > 0 {
+				depth--
+			}
+			continue
 		default:
-			// No action needed for other query expression types.
 		}
+		if depth > 0 {
+			continue
+		}
+		if omnimysqlparser.TokenName(tokens[i].Type) != "LIMIT" {
+			continue
+		}
+		countTokenIndex := i + 1
+		if i+3 < len(tokens) && tokens[i+2].Str == "," {
+			countTokenIndex = i + 3
+		}
+		if countTokenIndex >= len(tokens) {
+			return "", false
+		}
+		if tokens[countTokenIndex].Ival > 0 && int(tokens[countTokenIndex].Ival) <= limitCount {
+			return sql, true
+		}
+		return sql[:tokens[countTokenIndex].Loc] + fmt.Sprintf("%d", limitCount) + sql[tokens[countTokenIndex].End:], true
 	}
+	return "", false
 }
 
 func rewriteMySQLSelectLimit(sql string, stmt *ast.SelectStmt, limitCount int) (string, error) {

--- a/backend/plugin/db/mysql/query_test.go
+++ b/backend/plugin/db/mysql/query_test.go
@@ -106,6 +106,51 @@ func TestGetStatementWithResultLimit(t *testing.T) {
 			want:  "SELECT col1, col2 FROM table1 LIMIT 10 PROCEDURE ANALYSE(10, 2000);",
 		},
 		{
+			stmt:  "SELECT col1, col2 FROM table1 LIMIT 20 PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 LIMIT 10 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
+			stmt:  "SELECT col1, col2 FROM table1 LIMIT 5 PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 LIMIT 5 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
+			stmt:  "SELECT col1, col2 FROM table1 LIMIT 0 PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 LIMIT 10 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
+			stmt:  "SELECT col1, col2 FROM table1 LIMIT row_count PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 LIMIT 10 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
+			stmt:  "SELECT col1, col2 FROM table1 LIMIT row_count OFFSET 100 PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 LIMIT 10 OFFSET 100 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
+			stmt:  "SELECT col1, col2 FROM table1 LIMIT 100,20 PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 LIMIT 100,10 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
+			stmt:  "SELECT col1, col2 FROM table1 LIMIT 100,5 PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 LIMIT 100,5 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
+			stmt:  "SELECT col1, col2 FROM table1 LIMIT 100,row_count PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT col1, col2 FROM table1 LIMIT 100,10 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
+			stmt:  "SELECT * FROM (SELECT * FROM t LIMIT 100) s JOIN u PROCEDURE ANALYSE(10, 2000);",
+			count: 10,
+			want:  "SELECT * FROM (SELECT * FROM t LIMIT 100) s JOIN u LIMIT 10 PROCEDURE ANALYSE(10, 2000);",
+		},
+		{
 			stmt:  "SELECT col1, col2 FROM table1 ORDER BY col1;",
 			count: 10,
 			want:  "SELECT col1, col2 FROM table1 ORDER BY col1 LIMIT 10;",

--- a/backend/plugin/parser/mysql/antlr_dependency_test.go
+++ b/backend/plugin/parser/mysql/antlr_dependency_test.go
@@ -1,0 +1,20 @@
+package mysql
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMySQLOmniASTDoesNotFallbackToANTLR(t *testing.T) {
+	content, err := os.ReadFile("omni.go")
+	require.NoError(t, err)
+	source := string(content)
+
+	require.NotContains(t, source, "AsANTLRAST")
+	require.NotContains(t, source, "AntlrASTProvider")
+	require.NotContains(t, source, "base.ANTLRAST")
+	require.NotContains(t, source, "antlrAST")
+	require.NotContains(t, source, "parseSingleStatementLenient")
+}

--- a/backend/plugin/parser/mysql/mysql.go
+++ b/backend/plugin/parser/mysql/mysql.go
@@ -211,22 +211,6 @@ func parseSingleStatement(baseLine int, statement string) (antlr.Tree, *antlr.Co
 	return tree, stream, nil
 }
 
-// parseSingleStatementLenient parses a single MySQL statement with ANTLR in error-recovery mode
-// (no error listeners). Used by OmniAST.AsANTLRAST() for backward-compatible tree walking.
-func parseSingleStatementLenient(statement string) (antlr.Tree, *antlr.CommonTokenStream) {
-	statement = mysqlAddSemicolonIfNeeded(statement)
-	input := antlr.NewInputStream(statement)
-	lexer := parser.NewMySQLLexer(input)
-	stream := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
-
-	p := parser.NewMySQLParser(stream)
-	p.RemoveErrorListeners()
-	p.BuildParseTrees = true
-
-	tree := p.Script()
-	return tree, stream
-}
-
 func mysqlAddSemicolonIfNeeded(sql string) string {
 	lexer := parser.NewMySQLLexer(antlr.NewInputStream(sql))
 	lexerErrorListener := &base.ParseErrorListener{

--- a/backend/plugin/parser/mysql/omni.go
+++ b/backend/plugin/parser/mysql/omni.go
@@ -11,8 +11,6 @@ import (
 )
 
 // OmniAST wraps an omni AST node and implements the base.AST interface.
-// During migration, it also implements AntlrASTProvider so that callers
-// still using GetANTLRAST() can fall back to the ANTLR tree.
 type OmniAST struct {
 	// Node is the omni AST node (e.g. *ast.SelectStmt, *ast.CreateTableStmt).
 	Node ast.Node
@@ -20,38 +18,11 @@ type OmniAST struct {
 	Text string
 	// StartPosition is the 1-based position where this statement starts.
 	StartPosition *storepb.Position
-
-	// antlrAST is lazily populated when AsANTLRAST() is called.
-	// This field will be removed once all callers are migrated to omni.
-	antlrAST *base.ANTLRAST
-	// antlrParsed tracks whether we've attempted the ANTLR parse.
-	antlrParsed bool
 }
 
 // ASTStartPosition implements base.AST.
 func (a *OmniAST) ASTStartPosition() *storepb.Position {
 	return a.StartPosition
-}
-
-// AsANTLRAST implements base.AntlrASTProvider for backward compatibility.
-// It lazily parses the SQL text with the ANTLR parser and caches the result.
-// This will be removed once all MySQL modules are migrated to omni.
-func (a *OmniAST) AsANTLRAST() (*base.ANTLRAST, bool) {
-	if a.antlrParsed {
-		return a.antlrAST, a.antlrAST != nil
-	}
-	a.antlrParsed = true
-
-	// Use lenient ANTLR parsing (no error listeners) since omni already
-	// validated the SQL. The ANTLR tree is only needed for backward-compatible
-	// tree walking by callers that haven't migrated to omni yet.
-	tree, tokens := parseSingleStatementLenient(a.Text)
-	a.antlrAST = &base.ANTLRAST{
-		StartPosition: a.StartPosition,
-		Tree:          tree,
-		Tokens:        tokens,
-	}
-	return a.antlrAST, true
 }
 
 // ParseMySQLOmni parses SQL using omni's parser and returns an ast.List.

--- a/backend/plugin/schema/mysql/walk_through_test.go
+++ b/backend/plugin/schema/mysql/walk_through_test.go
@@ -13,9 +13,9 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/bytebase/bytebase/backend/common"
-	"github.com/bytebase/bytebase/backend/component/sheet"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 	"github.com/bytebase/bytebase/backend/store/model"
 )
 
@@ -42,7 +42,6 @@ func TestWalkThrough(t *testing.T) {
 	require.NoError(t, err)
 	err = yaml.Unmarshal(byteValue, &tests)
 	require.NoError(t, err)
-	sm := sheet.NewManager()
 
 	for _, test := range tests {
 		// Make a deep copy to avoid mutation across tests
@@ -52,8 +51,12 @@ func TestWalkThrough(t *testing.T) {
 		// Create DatabaseMetadata for walk-through
 		state := model.NewDatabaseMetadata(protoData, nil, nil, storepb.Engine_MYSQL, !test.IgnoreCaseSensitive)
 
-		stmts, _ := sm.GetStatementsForChecks(storepb.Engine_MYSQL, test.Statement)
-		asts := base.ExtractASTs(stmts)
+		antlrASTs, err := mysqlparser.ParseMySQL(test.Statement)
+		require.NoError(t, err)
+		asts := make([]base.AST, 0, len(antlrASTs))
+		for _, antlrAST := range antlrASTs {
+			asts = append(asts, antlrAST)
+		}
 		advice := WalkThrough(state, asts)
 		if advice != nil {
 			// Compare the advice fields
@@ -68,7 +71,7 @@ func TestWalkThrough(t *testing.T) {
 		}
 
 		want := &storepb.DatabaseSchemaMetadata{}
-		err := common.ProtojsonUnmarshaler.Unmarshal([]byte(test.Want), want)
+		err = common.ProtojsonUnmarshaler.Unmarshal([]byte(test.Want), want)
 		require.NoError(t, err)
 		result := state.GetProto()
 		diff := cmp.Diff(want, result, protocmp.Transform(),


### PR DESCRIPTION
## Summary
- Remove the lazy MySQL `OmniAST.AsANTLRAST()` compatibility bridge and its lenient ANTLR parse helper.
- Remove the MySQL query-limit ANTLR fallback, keeping a narrow Omni-tokenizer path for `SELECT ... PROCEDURE` placement.
- Migrate OceanBase MySQL-family advisors from `GetANTLRAST()`/ANTLR listeners to Omni AST checks, with guard tests for these paths.

## Test Plan
- `go test -count=1 ./backend/plugin/parser/mysql`
- `go test -count=1 ./backend/plugin/db/mysql`
- `go test -count=1 ./backend/plugin/advisor/oceanbase`
- `go test -count=1 ./backend/plugin/schema/mysql -run '^$'`
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `git diff --check`

## Checklist
- No API/proto/schema/store migration changes.
- Composite-PK query safety check skipped: no `backend/store/` or `backend/migrator/` changes.
- SonarCloud properties check skipped: new files are Go test/helper files under existing backend paths; `backend/**/*_test.go` is already included.
