### PR TITLE
fix(dynamodb): honor configured endpoint (host:port) instead of always using real AWS

### DIFF
--- a/backend/plugin/db/dynamodb/dynamodb.go
+++ b/backend/plugin/db/dynamodb/dynamodb.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -53,9 +55,48 @@ func (d *Driver) Open(ctx context.Context, _ storepb.Engine, conf db.ConnectionC
 		return nil, errors.Wrapf(err, "failed to load AWS config")
 	}
 	d.awsConfig = cfg
-	client := dynamodb.NewFromConfig(cfg)
-	d.client = client
+
+	var optFns []func(*dynamodb.Options)
+	// Honor a custom endpoint (e.g. DynamoDB Local) when the data source
+	// specifies a host. Without this the AWS SDK resolves the real AWS endpoint
+	// for the region and the configured host:port is silently ignored, routing
+	// queries intended for a local/compatible endpoint to real AWS.
+	if endpoint := dynamoDBEndpoint(conf.DataSource); endpoint != "" {
+		optFns = append(optFns, func(o *dynamodb.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+	}
+	d.client = dynamodb.NewFromConfig(cfg, optFns...)
 	return d, nil
+}
+
+// dynamoDBEndpoint returns a custom DynamoDB endpoint URL derived from the data
+// source host/port, or "" to fall back to the AWS SDK's default (real AWS)
+// endpoint resolution. A custom endpoint lets bytebase target DynamoDB Local —
+// or any DynamoDB-compatible service — instead of real AWS.
+func dynamoDBEndpoint(ds *storepb.DataSource) string {
+	host := ds.GetHost()
+	if host == "" {
+		// No host configured: use the AWS SDK's default endpoint for the region.
+		return ""
+	}
+	port := ds.GetPort()
+	// If the host already carries a scheme, treat it as a full base URL and
+	// only append the port when one isn't already present.
+	if strings.Contains(host, "://") {
+		if port != "" && !strings.Contains(host[strings.Index(host, "://")+len("://"):], ":") {
+			return host + ":" + port
+		}
+		return host
+	}
+	scheme := "http"
+	if ds.GetUseSsl() {
+		scheme = "https"
+	}
+	if port != "" {
+		return fmt.Sprintf("%s://%s:%s", scheme, host, port)
+	}
+	return fmt.Sprintf("%s://%s", scheme, host)
 }
 
 // Close closes the driver.

--- a/backend/plugin/db/dynamodb/dynamodb_test.go
+++ b/backend/plugin/db/dynamodb/dynamodb_test.go
@@ -1,0 +1,58 @@
+package dynamodb
+
+import (
+	"testing"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+func TestDynamoDBEndpoint(t *testing.T) {
+	testCases := []struct {
+		name string
+		ds   *storepb.DataSource
+		want string
+	}{
+		{
+			// No host: fall back to the AWS SDK default (real AWS) endpoint.
+			name: "no_host_uses_default_aws",
+			ds:   &storepb.DataSource{Region: "ap-northeast-1"},
+			want: "",
+		},
+		{
+			// DynamoDB Local: host + port, no TLS -> http endpoint.
+			name: "local_http",
+			ds:   &storepb.DataSource{Host: "localhost", Port: "18000"},
+			want: "http://localhost:18000",
+		},
+		{
+			name: "host_only_no_port",
+			ds:   &storepb.DataSource{Host: "127.0.0.1"},
+			want: "http://127.0.0.1",
+		},
+		{
+			// useSsl toggles the scheme to https.
+			name: "https_via_use_ssl",
+			ds:   &storepb.DataSource{Host: "dynamo.internal", Port: "8000", UseSsl: true},
+			want: "https://dynamo.internal:8000",
+		},
+		{
+			// Explicit scheme in host is respected; port appended once.
+			name: "scheme_prefixed_host_appends_port",
+			ds:   &storepb.DataSource{Host: "http://localhost", Port: "18000"},
+			want: "http://localhost:18000",
+		},
+		{
+			// Explicit scheme + port already in host: used verbatim.
+			name: "scheme_prefixed_full_url",
+			ds:   &storepb.DataSource{Host: "https://dynamodb.example.com:443"},
+			want: "https://dynamodb.example.com:443",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := dynamoDBEndpoint(tc.ds); got != tc.want {
+				t.Errorf("dynamoDBEndpoint() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
A DynamoDB instance configured with a host/port (e.g. **DynamoDB Local** at `localhost:18000`) is **silently ignored** — every query goes to **real AWS**.

`backend/plugin/db/dynamodb` builds its client from `util.GetAWSConnectionConfig`, which only sets `region` + credentials and **never applies `host`/`port` as an endpoint**. The AWS SDK therefore resolves the real AWS endpoint for the region. With no static creds in the data source, the driver also falls back to the **default credential chain** (`env` / `~/.aws`), so the request authenticates against the user's real AWS account.

**Repro (how this surfaced):** a `dynamodb-local` instance pinned to `localhost:18000` returned live DynamoDB `ResourceNotFoundException` / `ValidationException` responses **while the local container was down** — because it was actually hitting real AWS (`sts get-caller-identity` matched the synced `{account}-{region}` database name exactly). Filed as BYT-9645.

This is both a **functional bug** (DynamoDB Local can't work) and a **data-safety risk** (queries/writes meant for a local endpoint silently reach real AWS).

## Fix
When the data source specifies a `host`, set the DynamoDB client's `BaseEndpoint` to `scheme://host[:port]` (`scheme` from `useSsl`, default `http`). When `host` is empty, behavior is **unchanged** (default AWS endpoint resolution), so real-AWS instances are unaffected.

Scoped to the DynamoDB driver's client construction — the shared `GetAWSConnectionConfig` (also used by pg/mysql/elasticsearch) is **untouched**.

```go
if endpoint := dynamoDBEndpoint(conf.DataSource); endpoint != "" {
    optFns = append(optFns, func(o *dynamodb.Options) { o.BaseEndpoint = aws.String(endpoint) })
}
d.client = dynamodb.NewFromConfig(cfg, optFns...)
```

## Scope note
`SyncInstance` still calls STS `GetCallerIdentity` (real AWS) to derive the `{account}-{region}` pseudo-database name. A fully offline local setup (no real credentials at all) is out of scope for this PR.

## Test
`TestDynamoDBEndpoint` covers host/port/scheme/`useSsl` and the host-empty (default-AWS) case. `go build ./backend/...`, `go vet`, and the unit test all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)