### PR TITLE
fix(database): preserve load-more rows for equivalent filters

### DIFF
--- a/frontend/src/react/components/database/DatabaseTable.test.tsx
+++ b/frontend/src/react/components/database/DatabaseTable.test.tsx
@@ -1,0 +1,146 @@
+import { act, useMemo, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { DatabaseFilter } from "@/react/lib/databaseFilter";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { DatabaseTable } from "./DatabaseTable";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  fetchDatabases: vi.fn(),
+}));
+
+vi.mock("@/react/stores/app", () => {
+  const state = {
+    fetchDatabases: mocks.fetchDatabases,
+    workspaceResourceName: () => "workspaces/-",
+  };
+  const useAppStore = <T,>(selector: (s: typeof state) => T) => selector(state);
+  useAppStore.getState = () => state;
+  return { useAppStore };
+});
+
+vi.mock("@/react/router", () => ({
+  router: {
+    resolve: () => ({ fullPath: "/database" }),
+    push: vi.fn(),
+  },
+}));
+
+vi.mock("@/utils", () => ({
+  autoDatabaseRoute: () => ({ name: "database" }),
+}));
+
+vi.mock("@/react/hooks/useSessionPageSize", () => ({
+  getPageSizeOptions: () => [50],
+  useSessionPageSize: () => [50, vi.fn()],
+}));
+
+vi.mock("@/react/hooks/usePagedData", () => ({
+  PagedTableFooter: ({
+    hasMore,
+    isFetchingMore,
+    onLoadMore,
+  }: {
+    hasMore: boolean;
+    isFetchingMore: boolean;
+    onLoadMore: () => void;
+  }) =>
+    hasMore ? (
+      <button type="button" disabled={isFetchingMore} onClick={onLoadMore}>
+        load more
+      </button>
+    ) : null,
+}));
+
+vi.mock("./DatabaseTableView", () => ({
+  DatabaseTableView: ({ databases }: { databases: Database[] }) => (
+    <div data-testid="database-names">
+      {databases.map((database) => database.name).join(",")}
+    </div>
+  ),
+}));
+
+const db1 = { name: "instances/i/databases/db1" } as Database;
+const db2 = { name: "instances/i/databases/db2" } as Database;
+
+function ParentRerenderHarness() {
+  const [, setVisibleDatabases] = useState<Database[]>([]);
+
+  const selectedLabels: string[] = [];
+  const filter = useMemo<DatabaseFilter>(
+    () => ({
+      labels: selectedLabels.length > 0 ? selectedLabels : undefined,
+    }),
+    [selectedLabels]
+  );
+
+  return (
+    <DatabaseTable
+      filter={filter}
+      parent="instances/i"
+      onDatabasesChange={setVisibleDatabases}
+    />
+  );
+}
+
+describe("DatabaseTable", () => {
+  let root: Root | undefined;
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    act(() => {
+      root?.unmount();
+    });
+    root = undefined;
+    container = undefined;
+    document.body.innerHTML = "";
+    mocks.fetchDatabases.mockReset();
+  });
+
+  test("keeps appended rows when the parent rerenders with an equivalent filter", async () => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    mocks.fetchDatabases
+      .mockResolvedValueOnce({ databases: [db1], nextPageToken: "next" })
+      .mockResolvedValueOnce({ databases: [db2], nextPageToken: "" })
+      .mockResolvedValueOnce({ databases: [db1], nextPageToken: "next" });
+
+    await act(async () => {
+      root!.render(<ParentRerenderHarness />);
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector("[data-testid='database-names']")?.textContent
+    ).toBe(db1.name);
+
+    await act(async () => {
+      container!
+        .querySelector("button")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(
+      container.querySelector("[data-testid='database-names']")?.textContent
+    ).toBe(`${db1.name},${db2.name}`);
+
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+
+    expect(mocks.fetchDatabases).toHaveBeenCalledTimes(2);
+    expect(
+      container.querySelector("[data-testid='database-names']")?.textContent
+    ).toBe(`${db1.name},${db2.name}`);
+  });
+});

--- a/frontend/src/react/components/database/DatabaseTable.tsx
+++ b/frontend/src/react/components/database/DatabaseTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PagedTableFooter } from "@/react/hooks/usePagedData";
 import {
   getPageSizeOptions,
@@ -36,6 +36,23 @@ export interface DatabaseTableProps {
   refreshToken?: number;
 }
 
+function databaseFilterKey(filter: DatabaseFilter | string | undefined) {
+  if (!filter) return "";
+  if (typeof filter === "string") return filter;
+  return JSON.stringify({
+    project: filter.project ?? "",
+    instance: filter.instance ?? "",
+    environment: filter.environment ?? "",
+    query: filter.query ?? "",
+    showDeleted: filter.showDeleted ?? false,
+    excludeUnassigned: filter.excludeUnassigned ?? false,
+    labels: filter.labels ?? [],
+    engines: filter.engines ?? [],
+    excludeEngines: filter.excludeEngines ?? [],
+    table: filter.table ?? "",
+  });
+}
+
 /**
  * Server-fetching wrapper around `DatabaseTableView`. Owns paging,
  * filter, sort, and the workspace-resource scope; renders the pure view
@@ -62,6 +79,9 @@ export function DatabaseTable({
 
   const [sort, setSort] = useState<DatabaseTableSort | null>(null);
   const orderBy = sort ? `${sort.key} ${sort.order}` : "";
+  const filterRef = useRef(filter);
+  filterRef.current = filter;
+  const filterKey = useMemo(() => databaseFilterKey(filter), [filter]);
 
   const workspaceResourceName = useAppStore((s) => s.workspaceResourceName());
 
@@ -81,7 +101,7 @@ export function DatabaseTable({
           pageToken: token,
           pageSize,
           parent: parent || workspaceResourceName,
-          filter,
+          filter: filterRef.current,
           orderBy,
           skipCacheRemoval: !isRefresh,
         });
@@ -105,7 +125,7 @@ export function DatabaseTable({
         }
       }
     },
-    [pageSize, filter, orderBy, parent, workspaceResourceName]
+    [pageSize, filterKey, orderBy, parent, workspaceResourceName]
   );
 
   const isFirstLoad = useRef(true);

--- a/frontend/src/react/pages/settings/InstanceDetailPage.tsx
+++ b/frontend/src/react/pages/settings/InstanceDetailPage.tsx
@@ -296,9 +296,11 @@ export function InstanceDetailPage({ instanceId }: { instanceId: string }) {
   const selectedProject = projectVal
     ? `${projectNamePrefix}${projectVal}`
     : undefined;
-  const selectedLabels = searchParams.scopes
-    .filter((s) => s.id === "label")
-    .map((s) => s.value);
+  const selectedLabels = useMemo(
+    () =>
+      searchParams.scopes.filter((s) => s.id === "label").map((s) => s.value),
+    [searchParams]
+  );
 
   const filter: DatabaseFilter = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- Prevent `DatabaseTable` from refreshing back to page 1 when a parent rerenders with an equivalent database filter object.
- Memoize instance-detail selected label filters so the Databases tab keeps stable filter inputs.
- Add a regression test covering the BYT-9663 load-more reset case.

## Key Changes
- Compare database filters by a semantic key for fetch callback dependencies while reading the latest filter through a ref.
- Keep appended database rows visible after load-more parent rerenders.
- Cover equivalent-filter parent rerenders in `DatabaseTable.test.tsx`.

## Motivation
BYT-9663 reported that the instance detail Databases tab could flash the next page after clicking Load more, then reset back to the first page. The reset was caused by equivalent filter object identity changes after the parent received appended visible databases.

## Test Plan
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
