### PR TITLE
fix(mysql): migrate walkthrough test to omni

### DIFF
--- a/backend/plugin/advisor/mysql/mysql_rules_test.go
+++ b/backend/plugin/advisor/mysql/mysql_rules_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/bytebase/bytebase/backend/component/sheet"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+	"github.com/bytebase/bytebase/backend/store/model"
 )
 
 func TestMySQLRules(t *testing.T) {
@@ -108,4 +110,36 @@ func TestMariaDBPriorBackupCheckAdvisor(t *testing.T) {
 	require.NotEmpty(t, adviceList)
 	require.Equal(t, storepb.SQLReviewRule_BUILTIN_PRIOR_BACKUP_CHECK.String(), adviceList[0].Title)
 	require.Contains(t, adviceList[0].Content, "mixed DDL and DML")
+}
+
+func TestMySQLBuiltinWalkThroughCheckTableExists(t *testing.T) {
+	sm := sheet.NewManager()
+	finalMetadata := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Name: "test",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "user",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "int"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_MYSQL, true)
+
+	adviceList, err := advisor.SQLReviewCheck(context.Background(), sm, "CREATE TABLE user(id INT);", []*storepb.SQLReviewRule{
+		{Type: storepb.SQLReviewRule_BUILTIN_WALK_THROUGH_CHECK, Level: storepb.SQLReviewRule_WARNING},
+	}, advisor.Context{
+		DBType:        storepb.Engine_MYSQL,
+		FinalMetadata: finalMetadata,
+	})
+
+	require.NoError(t, err)
+	require.Len(t, adviceList, 1)
+	require.Equal(t, storepb.Advice_WARNING, adviceList[0].Status)
+	require.Equal(t, code.TableExists.Int32(), adviceList[0].Code)
+	require.Equal(t, "Table `user` already exists", adviceList[0].Content)
 }

--- a/backend/plugin/advisor/mysql/rule_naming_identifier_no_keyword.go
+++ b/backend/plugin/advisor/mysql/rule_naming_identifier_no_keyword.go
@@ -93,8 +93,8 @@ func (r *namingIdentifierNoKeywordOmniRule) checkAlterTable(n *ast.AlterTableStm
 				r.checkIdentifierAtLine(col.Name, r.LocToLine(n.Loc))
 			}
 		case ast.ATRenameTable:
-			if cmd.NewName != "" {
-				r.checkIdentifierAtLine(cmd.NewName, r.LocToLine(n.Loc))
+			if newTableName := omniRenameTableName(cmd); newTableName != "" {
+				r.checkIdentifierAtLine(newTableName, r.LocToLine(n.Loc))
 			}
 		case ast.ATRenameColumn:
 			if cmd.NewName != "" {

--- a/backend/plugin/advisor/mysql/rule_naming_table.go
+++ b/backend/plugin/advisor/mysql/rule_naming_table.go
@@ -80,8 +80,8 @@ func (r *namingTableOmniRule) OnStatement(node ast.Node) {
 		}
 	case *ast.AlterTableStmt:
 		for _, cmd := range n.Commands {
-			if cmd.Type == ast.ATRenameTable && cmd.NewName != "" {
-				r.handleTableName(cmd.NewName, r.LocToLine(n.Loc))
+			if newTableName := omniRenameTableName(cmd); newTableName != "" {
+				r.handleTableName(newTableName, r.LocToLine(n.Loc))
 			}
 		}
 	case *ast.RenameTableStmt:

--- a/backend/plugin/advisor/mysql/utils_omni.go
+++ b/backend/plugin/advisor/mysql/utils_omni.go
@@ -218,6 +218,16 @@ func omniColumnName(cmd *ast.AlterTableCmd) string {
 	return cmd.Name
 }
 
+func omniRenameTableName(cmd *ast.AlterTableCmd) string {
+	if cmd == nil || cmd.Type != ast.ATRenameTable {
+		return ""
+	}
+	if cmd.NewTable != nil {
+		return cmd.NewTable.Name
+	}
+	return cmd.NewName
+}
+
 // omniIsPrimaryKey checks if a column has a PRIMARY KEY constraint.
 func omniIsPrimaryKey(col *ast.ColumnDef) bool {
 	if col == nil {

--- a/backend/plugin/schema/mysql/testdata/walk_through.yaml
+++ b/backend/plugin/schema/mysql/testdata/walk_through.yaml
@@ -1,458 +1,1308 @@
-- statement: 'CREATE TABLE `test`.`t1` (a INT);
-
+- statement: |-
+    CREATE TABLE `test`.`t1` (a INT);
     CREATE TABLE `other`.`t1` (a INT);
-
-    RENAME TABLE `other`.`t1` TO `other`.`t2`;'
+    RENAME TABLE `other`.`t1` TO `other`.`t2`;
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
-    status: 1
+    status: 2
     code: 702
-    title: Database `other` is not the current database `test`
-    content: Database `other` is not the current database `test`
+    title: "Database `other` is not the current database `test`"
+    content: "Database `other` is not the current database `test`"
     startPosition:
-      line: 2
-- statement: 'CREATE TABLE `test`.`t1` (a INT);
-
-    RENAME TABLE `test`.`t1` TO `other`.`t1`;'
+      line: 0
+- statement: |-
+    CREATE TABLE `test`.`t1` (a INT);
+    RENAME TABLE `test`.`t1` TO `other`.`t1`;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {}\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: 'CREATE TABLE t1(a INT);
-
+- statement: |-
+    CREATE TABLE t1(a INT);
     CREATE TABLE t2(a INT);
-
-    RENAME TABLE t2 TO t1;'
+    RENAME TABLE t2 TO t1;
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
-    status: 1
+    status: 3
     code: 607
-    title: Table `t1` already exists
-    content: Table `t1` already exists
+    title: "Table `t1` already exists"
+    content: "Table `t1` already exists"
     startPosition:
       line: 3
-- statement: 'CREATE TABLE t1(a INT);
-
-    RENAME TABLE t2 TO t3;'
+- statement: |-
+    CREATE TABLE t1(a INT);
+    RENAME TABLE t2 TO t3;
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
-    status: 1
+    status: 3
     code: 604
-    title: Table `t2` does not exist
-    content: Table `t2` does not exist
+    title: "Table `t2` does not exist"
+    content: "Table `t2` does not exist"
     startPosition:
       line: 2
-- statement: 'CREATE TABLE t1 (a INT);
-
-    RENAME TABLE t1 TO t2;'
+- statement: |-
+    CREATE TABLE t1 (a INT);
+    RENAME TABLE t1 TO t2;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t2\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"nullable\": true,\n              \"type\": \"int\"\n            }\n\
-    \          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t2",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: CREATE DATABASE another;
+- statement: |-
+    CREATE DATABASE another;
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
-    status: 1
+    status: 2
     code: 702
-    title: Database `another` is not the current database `test`
-    content: Database `another` is not the current database `test`
+    title: "Database `another` is not the current database `test`"
+    content: "Database `another` is not the current database `test`"
+    startPosition:
+      line: 0
+- statement: |-
+    DROP TABLE missing;
+    CREATE DATABASE other;
+  ignore_case_sensitive: false
+  want: ""
+  advice:
+    status: 3
+    code: 604
+    title: "Table `missing` does not exist"
+    content: "Table `missing` does not exist"
     startPosition:
       line: 1
-- statement: '-- this is comment
-
+- statement: |-
+    -- this is comment
     DROP DATABASE test;
-
-    CREATE TABLE t(a int);'
+    CREATE TABLE t(a int);
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
-    status: 1
+    status: 2
     code: 703
-    title: Database `test` is deleted
-    content: Database `test` is deleted
+    title: "Database `test` is deleted"
+    content: "Database `test` is deleted"
     startPosition:
-      line: 1
-- statement: 'ALTER DATABASE CHARACTER SET = utf8mb4;
-
-    ALTER DATABASE test COLLATE utf8mb4_polish_ci;'
+      line: 0
+- statement: |-
+    ALTER DATABASE CHARACTER SET = utf8mb4;
+    ALTER DATABASE test COLLATE utf8mb4_polish_ci;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {}\n  ],\n  \"characterSet\"\
-    : \"utf8mb4\",\n  \"collation\": \"utf8mb4_polish_ci\"\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_polish_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  a INT PRIMARY KEY,\n  c VARCHAR(255) NOT NULL\n\
-    );\nALTER TABLE t1 ADD INDEX idx1 (c);\nCREATE FULLTEXT INDEX ftk1 ON t1 (c);\n\
-    DROP INDEX `PRIMARY` ON t1;\nDROP INDEX idx1 ON t1;\nDROP INDEX ftk1 ON t1;"
+- statement: |-
+    CREATE TABLE t1(
+      a INT PRIMARY KEY,
+      c VARCHAR(255) NOT NULL
+    );
+    ALTER TABLE t1 ADD INDEX idx1 (c);
+    CREATE FULLTEXT INDEX ftk1 ON t1 (c);
+    DROP INDEX `PRIMARY` ON t1;
+    DROP INDEX idx1 ON t1;
+    DROP INDEX ftk1 ON t1;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"type\": \"int\"\n            },\n            {\n              \"name\"\
-    : \"c\",\n              \"position\": 2,\n              \"type\": \"varchar\"\n\
-    \            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "type": "int"
+                },
+                {
+                  "name": "c",
+                  "position": 2,
+                  "type": "varchar(255)",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  a INT,\n  b INT,\n  c VARCHAR(255) NOT NULL,\n \
-    \ d GEOMETRY NOT NULL\n);\nCREATE INDEX idx1 ON t1 (a) INVISIBLE;\nCREATE UNIQUE\
-    \ INDEX uk1 ON t1 (b);\nCREATE FULLTEXT INDEX ftk1 ON t1 (c);\nCREATE SPATIAL\
-    \ INDEX sk1 ON t1 (d);"
+- statement: |-
+    CREATE TABLE t1(
+      a INT,
+      b INT,
+      c VARCHAR(255) NOT NULL,
+      d GEOMETRY NOT NULL
+    );
+    CREATE INDEX idx1 ON t1 (a) INVISIBLE;
+    CREATE UNIQUE INDEX uk1 ON t1 (b);
+    CREATE FULLTEXT INDEX ftk1 ON t1 (c);
+    CREATE SPATIAL INDEX sk1 ON t1 (d);
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"nullable\": true,\n              \"type\": \"int\"\n            },\n\
-    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
-    \              \"nullable\": true,\n              \"type\": \"int\"\n        \
-    \    },\n            {\n              \"name\": \"c\",\n              \"position\"\
-    : 3,\n              \"type\": \"varchar\"\n            },\n            {\n   \
-    \           \"name\": \"d\",\n              \"position\": 4,\n              \"\
-    type\": \"geometry\"\n            }\n          ],\n          \"indexes\": [\n\
-    \            {\n              \"name\": \"ftk1\",\n              \"expressions\"\
-    : [\n                \"c\"\n              ],\n              \"type\": \"FULLTEXT\"\
-    ,\n              \"visible\": true\n            },\n            {\n          \
-    \    \"name\": \"idx1\",\n              \"expressions\": [\n                \"\
-    a\"\n              ],\n              \"type\": \"BTREE\"\n            },\n   \
-    \         {\n              \"name\": \"sk1\",\n              \"expressions\":\
-    \ [\n                \"d\"\n              ],\n              \"type\": \"SPATIAL\"\
-    ,\n              \"visible\": true\n            },\n            {\n          \
-    \    \"name\": \"uk1\",\n              \"expressions\": [\n                \"\
-    b\"\n              ],\n              \"type\": \"BTREE\",\n              \"unique\"\
-    : true,\n              \"visible\": true\n            }\n          ]\n       \
-    \ }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "b",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "c",
+                  "position": 3,
+                  "type": "varchar(255)",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                },
+                {
+                  "name": "d",
+                  "position": 4,
+                  "type": "geometry"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "idx1",
+                  "expressions": [
+                    "a"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE"
+                },
+                {
+                  "name": "uk1",
+                  "expressions": [
+                    "b"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true
+                },
+                {
+                  "name": "ftk1",
+                  "expressions": [
+                    "c"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "FULLTEXT",
+                  "visible": true
+                },
+                {
+                  "name": "sk1",
+                  "expressions": [
+                    "d"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "SPATIAL",
+                  "visible": true
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: 'CREATE TABLE t1(a GEOMETRY);
-
-    CREATE SPATIAL INDEX sk1 ON t1 (a);'
+- statement: |-
+    CREATE TABLE t1(a GEOMETRY);
+    CREATE SPATIAL INDEX sk1 ON t1 (a);
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
-    status: 1
+    status: 3
     code: 811
-    title: All parts of a SPATIAL index must be NOT NULL, but `a` is nullable
-    content: All parts of a SPATIAL index must be NOT NULL, but `a` is nullable
+    title: All parts of a SPATIAL index must be NOT NULL
+    content: All parts of a SPATIAL index must be NOT NULL
     startPosition:
       line: 2
-- statement: "CREATE TABLE t1(\n  a INT PRIMARY KEY,\n  b INT,\n  UNIQUE uk1 (b)\n\
-    );\nALTER TABLE t1 ENGINE = MyISAM;\nALTER TABLE t1 COMMENT = 't1 table';\nALTER\
-    \ TABLE t1 COLLATE utf8mb4_unicode_ci;"
+- statement: |-
+    CREATE TABLE t1(
+      a INT PRIMARY KEY,
+      b INT,
+      UNIQUE uk1 (b)
+    );
+    ALTER TABLE t1 ENGINE = MyISAM;
+    ALTER TABLE t1 COMMENT = 't1 table';
+    ALTER TABLE t1 COLLATE utf8mb4_unicode_ci;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"type\": \"int\"\n            },\n            {\n              \"name\"\
-    : \"b\",\n              \"position\": 2,\n              \"nullable\": true,\n\
-    \              \"type\": \"int\"\n            }\n          ],\n          \"indexes\"\
-    : [\n            {\n              \"name\": \"PRIMARY\",\n              \"expressions\"\
-    : [\n                \"a\"\n              ],\n              \"type\": \"BTREE\"\
-    ,\n              \"unique\": true,\n              \"primary\": true,\n       \
-    \       \"visible\": true\n            },\n            {\n              \"name\"\
-    : \"uk1\",\n              \"expressions\": [\n                \"b\"\n        \
-    \      ],\n              \"type\": \"BTREE\",\n              \"unique\": true,\n\
-    \              \"visible\": true\n            }\n          ],\n          \"engine\"\
-    : \"MyISAM\",\n          \"collation\": \"utf8mb4_unicode_ci\",\n          \"\
-    comment\": \"t1 table\"\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "type": "int"
+                },
+                {
+                  "name": "b",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "int"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "PRIMARY",
+                  "expressions": [
+                    "a"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "primary": true,
+                  "visible": true
+                },
+                {
+                  "name": "uk1",
+                  "expressions": [
+                    "b"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true
+                }
+              ],
+              "engine": "MyISAM",
+              "collation": "utf8mb4_unicode_ci",
+              "charset": "utf8mb4",
+              "comment": "t1 table"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  a INT PRIMARY KEY,\n  b INT,\n  UNIQUE uk1 (b)\n\
-    );\nALTER TABLE t1 DROP PRIMARY KEY;\nALTER TABLE t1 DROP INDEX uk1;"
+- statement: |-
+    CREATE TABLE t1(
+      a INT PRIMARY KEY,
+      b INT,
+      UNIQUE uk1 (b)
+    );
+    ALTER TABLE t1 DROP PRIMARY KEY;
+    ALTER TABLE t1 DROP INDEX uk1;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"type\": \"int\"\n            },\n            {\n              \"name\"\
-    : \"b\",\n              \"position\": 2,\n              \"nullable\": true,\n\
-    \              \"type\": \"int\"\n            }\n          ]\n        }\n    \
-    \  ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "type": "int"
+                },
+                {
+                  "name": "b",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "int"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  a INT,\n  b INT,\n  UNIQUE uk1 (b)\n);\nALTER TABLE\
-    \ t1 RENAME INDEX uk1 TO uk_b;\nALTER TABLE t1 ADD INDEX idx1 (b);\nALTER TABLE\
-    \ t1 RENAME INDEX idx1 TO idx2;\nALTER TABLE t1 ALTER INDEX idx2 INVISIBLE;\n\
-    ALTER TABLE t1 RENAME TO t2;"
+- statement: |-
+    CREATE TABLE t1(
+      a INT,
+      b INT,
+      UNIQUE uk1 (b)
+    );
+    ALTER TABLE t1 RENAME INDEX uk1 TO uk_b;
+    ALTER TABLE t1 ADD INDEX idx1 (b);
+    ALTER TABLE t1 RENAME INDEX idx1 TO idx2;
+    ALTER TABLE t1 ALTER INDEX idx2 INVISIBLE;
+    ALTER TABLE t1 RENAME TO t2;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t2\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"nullable\": true,\n              \"type\": \"int\"\n            },\n\
-    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
-    \              \"nullable\": true,\n              \"type\": \"int\"\n        \
-    \    }\n          ],\n          \"indexes\": [\n            {\n              \"\
-    name\": \"idx2\",\n              \"expressions\": [\n                \"b\"\n \
-    \             ],\n              \"type\": \"BTREE\"\n            },\n        \
-    \    {\n              \"name\": \"uk_b\",\n              \"expressions\": [\n\
-    \                \"b\"\n              ],\n              \"type\": \"BTREE\",\n\
-    \              \"unique\": true,\n              \"visible\": true\n          \
-    \  }\n          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t2",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "b",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "int"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "uk_b",
+                  "expressions": [
+                    "b"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true
+                },
+                {
+                  "name": "idx2",
+                  "expressions": [
+                    "b"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: 'CREATE TABLE t1(a INT NOT NULL);
-
-    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT NULL;'
+- statement: |-
+    CREATE TABLE t1(a INT);
+    ALTER TABLE t1 RENAME TO other.t1;
   ignore_case_sensitive: false
-  want: ''
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
+  advice: null
+- statement: |-
+    CREATE TABLE t1(a INT NOT NULL);
+    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT NULL;
+  ignore_case_sensitive: false
+  want: ""
   advice:
-    status: 1
-    code: 428
-    title: Invalid default value for column `a`
-    content: Invalid default value for column `a`
-    startPosition:
-      line: 2
-- statement: 'CREATE TABLE t1(a INT);
-
-    ALTER TABLE t1 CHANGE COLUMN a a BLOB;
-
-    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT ''default value'';'
-  ignore_case_sensitive: false
-  want: ''
-  advice:
-    status: 1
+    status: 3
     code: 423
-    title: BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value
-    content: BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value
+    title: "Invalid default value for column `a`"
+    content: "Invalid default value for column `a`"
+    startPosition:
+      line: 2
+- statement: |-
+    CREATE TABLE t1(a INT);
+    ALTER TABLE t1 CHANGE COLUMN a a BLOB;
+    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT 'default value';
+  ignore_case_sensitive: false
+  want: ""
+  advice:
+    status: 3
+    code: 423
+    title: "BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value"
+    content: "BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value"
     startPosition:
       line: 3
-- statement: 'CREATE TABLE t1(a INT);
-
+- statement: |-
+    CREATE TABLE t1(a INT);
     ALTER TABLE t1 CHANGE COLUMN a a BLOB;
-
-    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT NULL;'
+    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT NULL;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"nullable\": true,\n              \"type\": \"blob\"\n            }\n\
-    \          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "default": "NULL",
+                  "nullable": true,
+                  "type": "blob"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  a INT\n);\nALTER TABLE t1 ADD COLUMN b INT AFTER\
-    \ a;\nALTER TABLE t1 ADD COLUMN c INT NOT NULL DEFAULT 1 AFTER a;\nALTER TABLE\
-    \ t1 CHANGE COLUMN b d TEXT AFTER a;\nALTER TABLE t1 ALTER COLUMN a SET DEFAULT\
-    \ 1;\nALTER TABLE t1 ALTER COLUMN a SET INVISIBLE;\nALTER TABLE t1 ALTER COLUMN\
-    \ c DROP DEFAULT;"
+- statement: |-
+    CREATE TABLE t1(
+      a INT
+    );
+    ALTER TABLE t1 ADD COLUMN b INT AFTER a;
+    ALTER TABLE t1 ADD COLUMN c INT NOT NULL DEFAULT 1 AFTER a;
+    ALTER TABLE t1 CHANGE COLUMN b d TEXT AFTER a;
+    ALTER TABLE t1 ALTER COLUMN a SET DEFAULT 1;
+    ALTER TABLE t1 ALTER COLUMN a SET INVISIBLE;
+    ALTER TABLE t1 ALTER COLUMN c DROP DEFAULT;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"default\": \"1\",\n              \"nullable\": true,\n             \
-    \ \"type\": \"int\"\n            },\n            {\n              \"name\": \"\
-    d\",\n              \"position\": 2,\n              \"nullable\": true,\n    \
-    \          \"type\": \"text\"\n            },\n            {\n              \"\
-    name\": \"c\",\n              \"position\": 3,\n              \"type\": \"int\"\
-    \n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "default": "1",
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "d",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "text",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                },
+                {
+                  "name": "c",
+                  "position": 3,
+                  "type": "int"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  a INT\n);\nALTER TABLE t1 ADD COLUMN b VARCHAR(255)\
-    \ FIRST;\nALTER TABLE t1 ADD COLUMN (c INT, d BLOB);\nALTER TABLE t1 MODIFY COLUMN\
-    \ b INT AFTER a;\nALTER TABLE t1 RENAME COLUMN b TO e;\nALTER TABLE t1 CHANGE\
-    \ COLUMN d f TEXT AFTER e;\nALTER TABLE t1 DROP COLUMN a;"
+- statement: |-
+    CREATE TABLE t1(
+      a INT
+    );
+    ALTER TABLE t1 ADD COLUMN b VARCHAR(255) FIRST;
+    ALTER TABLE t1 ADD COLUMN (c INT, d BLOB);
+    ALTER TABLE t1 MODIFY COLUMN b INT AFTER a;
+    ALTER TABLE t1 RENAME COLUMN b TO e;
+    ALTER TABLE t1 CHANGE COLUMN d f TEXT AFTER e;
+    ALTER TABLE t1 DROP COLUMN a;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"e\",\n              \"position\": 1,\n       \
-    \       \"nullable\": true,\n              \"type\": \"int\"\n            },\n\
-    \            {\n              \"name\": \"f\",\n              \"position\": 2,\n\
-    \              \"nullable\": true,\n              \"type\": \"text\"\n       \
-    \     },\n            {\n              \"name\": \"c\",\n              \"position\"\
-    : 3,\n              \"nullable\": true,\n              \"type\": \"int\"\n   \
-    \         }\n          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "e",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "f",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "text",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                },
+                {
+                  "name": "c",
+                  "position": 3,
+                  "nullable": true,
+                  "type": "int"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: 'CREATE TABLE t1(a INT);
-
+- statement: |-
+    CREATE TABLE t1(a INT);
     CREATE TABLE t2(a INT);
-
     DROP TABLE t1, t2;
-
-    CREATE TABLE t3(a INT);'
+    CREATE TABLE t3(a INT);
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t3\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"nullable\": true,\n              \"type\": \"int\"\n            }\n\
-    \          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t3",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  a INT AUTO_INCREMENT,\n  b INT AUTO_INCREMENT\n\
-    );"
+- statement: |-
+    CREATE TABLE t1(
+      a INT AUTO_INCREMENT,
+      b INT AUTO_INCREMENT
+    );
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
-    status: 1
+    status: 3
     code: 426
-    title: There can be only one auto column for table `t1`
-    content: There can be only one auto column for table `t1`
+    title: Incorrect table definition; there can be only one auto column and it must be defined as a key
+    content: Incorrect table definition; there can be only one auto column and it must be defined as a key
     startPosition:
       line: 1
-- statement: CREATE TABLE tvx SELECT (x,z) FROM (VALUES ROW(1,3,5), ROW(2,4,6)) AS
-    v(x,y,z);
+- statement: |-
+    CREATE TABLE tvx SELECT (x,z) FROM (VALUES ROW(1,3,5), ROW(2,4,6)) AS v(x,y,z);
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
     status: 2
     code: 205
-    title: CREATE TABLE AS statement is used in "CREATE TABLE tvx SELECT (x,z) FROM
-      (VALUES ROW(1,3,5), ROW(2,4,6)) AS v(x,y,z);"
-    content: CREATE TABLE AS statement is used in "CREATE TABLE tvx SELECT (x,z) FROM
-      (VALUES ROW(1,3,5), ROW(2,4,6)) AS v(x,y,z);"
+    title: "CREATE TABLE AS statement is used in \"CREATE TABLE tvx SELECT (x,z) FROM (VALUES ROW(1,3,5), ROW(2,4,6)) AS v(x,y,z);\""
+    content: "CREATE TABLE AS statement is used in \"CREATE TABLE tvx SELECT (x,z) FROM (VALUES ROW(1,3,5), ROW(2,4,6)) AS v(x,y,z);\""
     startPosition:
-      line: 1
-- statement: 'CREATE TABLE t1(a int);
-
-    CREATE TABLE t2 (b INT) SELECT a FROM t1;'
+      line: 0
+- statement: |-
+    CREATE TABLE t1(a int);
+    CREATE TABLE t2 (b INT) SELECT a FROM t1;
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
     status: 2
     code: 205
-    title: CREATE TABLE AS statement is used in "CREATE TABLE t2 (b INT) SELECT a FROM
-      t1;"
-    content: CREATE TABLE AS statement is used in "CREATE TABLE t2 (b INT) SELECT a
-      FROM t1;"
+    title: "CREATE TABLE AS statement is used in \"CREATE TABLE t2 (b INT) SELECT a FROM t1;\""
+    content: "CREATE TABLE AS statement is used in \"CREATE TABLE t2 (b INT) SELECT a FROM t1;\""
+    startPosition:
+      line: 0
+- statement: |-
+    CREATE TABLE t1(a int);
+    CREATE TABLE t1 AS SELECT 1;
+  ignore_case_sensitive: false
+  want: ""
+  advice:
+    status: 3
+    code: 607
+    title: "Table `t1` already exists"
+    content: "Table `t1` already exists"
     startPosition:
       line: 2
-- statement: "CREATE TABLE t1(\n  a int\n);\nCREATE TABLE t2 LIKE t1;"
+- statement: |-
+    CREATE TABLE t_literal (c varchar(20) DEFAULT ' SELECT ');
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"nullable\": true,\n              \"type\": \"int\"\n            }\n\
-    \          ]\n        },\n        {\n          \"name\": \"t2\",\n          \"\
-    columns\": [\n            {\n              \"name\": \"a\",\n              \"\
-    position\": 1,\n              \"nullable\": true,\n              \"type\": \"\
-    int\"\n            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t_literal",
+              "columns": [
+                {
+                  "name": "c",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "varchar(20)",
+                  "default": "' SELECT '",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  a INT PRIMARY KEY,\n  b INT NOT NULL DEFAULT 1,\n\
-    \  c INT,\n  d VARCHAR(255) NOT NULL,\n  e VARCHAR(255),\n  UNIQUE KEY uk1 (b,\
-    \ c),\n  KEY idx1 (c),\n  FULLTEXT(d, e) WITH PARSER ngram INVISIBLE\n);"
+- statement: |-
+    CREATE TABLE t1(
+      a int
+    );
+    CREATE TABLE t2 LIKE t1;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"type\": \"int\"\n            },\n            {\n              \"name\"\
-    : \"b\",\n              \"position\": 2,\n              \"default\": \"1\",\n\
-    \              \"type\": \"int\"\n            },\n            {\n            \
-    \  \"name\": \"c\",\n              \"position\": 3,\n              \"nullable\"\
-    : true,\n              \"type\": \"int\"\n            },\n            {\n    \
-    \          \"name\": \"d\",\n              \"position\": 4,\n              \"\
-    type\": \"varchar\"\n            },\n            {\n              \"name\": \"\
-    e\",\n              \"position\": 5,\n              \"nullable\": true,\n    \
-    \          \"type\": \"varchar\"\n            }\n          ],\n          \"indexes\"\
-    : [\n            {\n              \"name\": \"PRIMARY\",\n              \"expressions\"\
-    : [\n                \"a\"\n              ],\n              \"type\": \"BTREE\"\
-    ,\n              \"unique\": true,\n              \"primary\": true,\n       \
-    \       \"visible\": true\n            },\n            {\n              \"name\"\
-    : \"d\",\n              \"expressions\": [\n                \"d\",\n         \
-    \       \"e\"\n              ],\n              \"type\": \"FULLTEXT\"\n      \
-    \      },\n            {\n              \"name\": \"idx1\",\n              \"\
-    expressions\": [\n                \"c\"\n              ],\n              \"type\"\
-    : \"BTREE\",\n              \"visible\": true\n            },\n            {\n\
-    \              \"name\": \"uk1\",\n              \"expressions\": [\n        \
-    \        \"b\",\n                \"c\"\n              ],\n              \"type\"\
-    : \"BTREE\",\n              \"unique\": true,\n              \"visible\": true\n\
-    \            }\n          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            },
+            {
+              "name": "t2",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  a INT NOT NULL DEFAULT NULL\n);"
+- statement: |-
+    CREATE TABLE t1(
+      a INT PRIMARY KEY,
+      b INT NOT NULL DEFAULT 1,
+      c INT,
+      d VARCHAR(255) NOT NULL,
+      e VARCHAR(255),
+      UNIQUE KEY uk1 (b, c),
+      KEY idx1 (c),
+      FULLTEXT(d, e) WITH PARSER ngram INVISIBLE
+    );
   ignore_case_sensitive: false
-  want: ''
-  advice:
-    status: 1
-    code: 428
-    title: Invalid default value for column `a`
-    content: Invalid default value for column `a`
-    startPosition:
-      line: 2
-- statement: "CREATE TABLE t1(\n  a BLOB DEFAULT 'this is a default value'\n);"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "type": "int"
+                },
+                {
+                  "name": "b",
+                  "position": 2,
+                  "default": "1",
+                  "type": "int"
+                },
+                {
+                  "name": "c",
+                  "position": 3,
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "d",
+                  "position": 4,
+                  "type": "varchar(255)",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                },
+                {
+                  "name": "e",
+                  "position": 5,
+                  "nullable": true,
+                  "type": "varchar(255)",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "PRIMARY",
+                  "expressions": [
+                    "a"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "primary": true,
+                  "visible": true
+                },
+                {
+                  "name": "uk1",
+                  "expressions": [
+                    "b",
+                    "c"
+                  ],
+                  "keyLength": [
+                    "0",
+                    "0"
+                  ],
+                  "descending": [
+                    false,
+                    false
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true
+                },
+                {
+                  "name": "idx1",
+                  "expressions": [
+                    "c"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "visible": true
+                },
+                {
+                  "name": "d",
+                  "expressions": [
+                    "d",
+                    "e"
+                  ],
+                  "keyLength": [
+                    "0",
+                    "0"
+                  ],
+                  "descending": [
+                    false,
+                    false
+                  ],
+                  "type": "FULLTEXT"
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
+  advice: null
+- statement: |-
+    CREATE TABLE t1(
+      a INT NOT NULL DEFAULT NULL
+    );
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
-    status: 1
+    status: 3
     code: 423
-    title: BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value
-    content: BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value
+    title: "Invalid default value for column `a`"
+    content: "Invalid default value for column `a`"
     startPosition:
-      line: 2
-- statement: "CREATE TABLE t1(\n  a INT ON UPDATE NOW()\n);"
+      line: 1
+- statement: |-
+    CREATE TABLE t1(
+      a BLOB DEFAULT 'this is a default value'
+    );
   ignore_case_sensitive: false
-  want: ''
+  want: ""
   advice:
-    status: 1
-    code: 427
-    title: Column `a` use ON UPDATE but is not DATETIME or TIMESTAMP
-    content: Column `a` use ON UPDATE but is not DATETIME or TIMESTAMP
+    status: 3
+    code: 423
+    title: "BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value"
+    content: "BLOB, TEXT, GEOMETRY or JSON column `a` can't have a default value"
     startPosition:
-      line: 2
-- statement: "CREATE TABLE t1(\n  a INT NOT NULL DEFAULT 1 PRIMARY KEY,\n  b INT UNIQUE,\n\
-    \  c VARCHAR(255) NOT NULL DEFAULT 'NULL' COMMENT 'column c',\n  e INT NULL DEFAULT\
-    \ NULL,\n  f VARCHAR(10) NOT NULL COLLATE utf8mb4_polish_ci,\n  g VARCHAR(200)\
-    \ CHARACTER SET utf8mb4 NOT NULL\n);"
+      line: 1
+- statement: |-
+    CREATE TABLE t1(
+      a INT ON UPDATE NOW()
+    );
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"a\",\n              \"position\": 1,\n       \
-    \       \"default\": \"1\",\n              \"type\": \"int\"\n            },\n\
-    \            {\n              \"name\": \"b\",\n              \"position\": 2,\n\
-    \              \"nullable\": true,\n              \"type\": \"int\"\n        \
-    \    },\n            {\n              \"name\": \"c\",\n              \"position\"\
-    : 3,\n              \"default\": \"NULL\",\n              \"type\": \"varchar\"\
-    ,\n              \"comment\": \"column c\"\n            },\n            {\n  \
-    \            \"name\": \"e\",\n              \"position\": 4,\n              \"\
-    nullable\": true,\n              \"type\": \"int\"\n            },\n         \
-    \   {\n              \"name\": \"f\",\n              \"position\": 5,\n      \
-    \        \"type\": \"varchar\",\n              \"collation\": \"utf8mb4_polish_ci\"\
-    \n            },\n            {\n              \"name\": \"g\",\n            \
-    \  \"position\": 6,\n              \"type\": \"varchar\",\n              \"characterSet\"\
-    : \"utf8mb4\"\n            }\n          ],\n          \"indexes\": [\n       \
-    \     {\n              \"name\": \"PRIMARY\",\n              \"expressions\":\
-    \ [\n                \"a\"\n              ],\n              \"type\": \"BTREE\"\
-    ,\n              \"unique\": true,\n              \"primary\": true,\n       \
-    \       \"visible\": true\n            },\n            {\n              \"name\"\
-    : \"b\",\n              \"expressions\": [\n                \"b\"\n          \
-    \    ],\n              \"type\": \"BTREE\",\n              \"unique\": true,\n\
-    \              \"visible\": true\n            }\n          ]\n        }\n    \
-    \  ]\n    }\n  ]\n}"
+  want: ""
+  advice:
+    status: 3
+    code: 427
+    title: "Invalid ON UPDATE clause for 'a' column"
+    content: "Invalid ON UPDATE clause for 'a' column"
+    startPosition:
+      line: 1
+- statement: |-
+    CREATE TABLE t1(
+      a INT NOT NULL DEFAULT 1 PRIMARY KEY,
+      b INT UNIQUE,
+      c VARCHAR(255) NOT NULL DEFAULT 'NULL' COMMENT 'column c',
+      e INT NULL DEFAULT NULL,
+      f VARCHAR(10) NOT NULL COLLATE utf8mb4_polish_ci,
+      g VARCHAR(200) CHARACTER SET utf8mb4 NOT NULL
+    );
+  ignore_case_sensitive: false
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "a",
+                  "position": 1,
+                  "default": "1",
+                  "type": "int"
+                },
+                {
+                  "name": "b",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "c",
+                  "position": 3,
+                  "default": "'NULL'",
+                  "type": "varchar(255)",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci",
+                  "comment": "column c"
+                },
+                {
+                  "name": "e",
+                  "position": 4,
+                  "default": "NULL",
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "f",
+                  "position": 5,
+                  "type": "varchar(10)",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                },
+                {
+                  "name": "g",
+                  "position": 6,
+                  "type": "varchar(200)",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "PRIMARY",
+                  "expressions": [
+                    "a"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "primary": true,
+                  "visible": true
+                },
+                {
+                  "name": "b",
+                  "expressions": [
+                    "b"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "CREATE TABLE t1(\n  id int,\n  name varchar(255),\n  key idx_name(name)\n\
-    );\ncreate table t2 (\n  id int,\n  t1_name varchar(255),\n  constraint fk_t1_name\
-    \ foreign key (t1_name) references t1 (name)\n);\nalter table t2 drop foreign\
-    \ key fk_t1_name;"
+- statement: |-
+    CREATE TABLE t1(
+      id int,
+      name varchar(255),
+      key idx_name(name)
+    );
+    create table t2 (
+      id int,
+      t1_name varchar(255),
+      constraint fk_t1_name foreign key (t1_name) references t1 (name)
+    );
+    alter table t2 drop foreign key fk_t1_name;
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"t1\",\n          \"columns\": [\n          \
-    \  {\n              \"name\": \"id\",\n              \"position\": 1,\n      \
-    \        \"nullable\": true,\n              \"type\": \"int\"\n            },\n\
-    \            {\n              \"name\": \"name\",\n              \"position\"\
-    : 2,\n              \"nullable\": true,\n              \"type\": \"varchar\"\n\
-    \            }\n          ],\n          \"indexes\": [\n            {\n      \
-    \        \"name\": \"idx_name\",\n              \"expressions\": [\n         \
-    \       \"name\"\n              ],\n              \"type\": \"BTREE\",\n     \
-    \         \"visible\": true\n            }\n          ]\n        },\n        {\n\
-    \          \"name\": \"t2\",\n          \"columns\": [\n            {\n      \
-    \        \"name\": \"id\",\n              \"position\": 1,\n              \"nullable\"\
-    : true,\n              \"type\": \"int\"\n            },\n            {\n    \
-    \          \"name\": \"t1_name\",\n              \"position\": 2,\n          \
-    \    \"nullable\": true,\n              \"type\": \"varchar\"\n            }\n\
-    \          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "t1",
+              "columns": [
+                {
+                  "name": "id",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "name",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "varchar(255)",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "idx_name",
+                  "expressions": [
+                    "name"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "visible": true
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            },
+            {
+              "name": "t2",
+              "columns": [
+                {
+                  "name": "id",
+                  "position": 1,
+                  "nullable": true,
+                  "type": "int"
+                },
+                {
+                  "name": "t1_name",
+                  "position": 2,
+                  "nullable": true,
+                  "type": "varchar(255)",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "fk_t1_name",
+                  "expressions": [
+                    "t1_name"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "visible": true
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null
-- statement: "create table all_types(\n  c1 tinyblob not null,\n  c2 blob not null,\n\
-    \  c3 mediumblob not null,\n  c4 longblob not null,\n  c5 tinytext not null,\n\
-    \  c6 text not null,\n  c7 mediumtext not null,\n  c8 longtext not null,\n  c9\
-    \ json not null,\n  c10 serial not null\n);"
+- statement: |-
+    create table all_types(
+      c1 tinyblob not null,
+      c2 blob not null,
+      c3 mediumblob not null,
+      c4 longblob not null,
+      c5 tinytext not null,
+      c6 text not null,
+      c7 mediumtext not null,
+      c8 longtext not null,
+      c9 json not null,
+      c10 serial not null
+    );
   ignore_case_sensitive: false
-  want: "{\n  \"name\": \"test\",\n  \"schemas\": [\n    {\n      \"tables\": [\n\
-    \        {\n          \"name\": \"all_types\",\n          \"columns\": [\n   \
-    \         {\n              \"name\": \"c1\",\n              \"position\": 1,\n\
-    \              \"type\": \"tinyblob\"\n            },\n            {\n       \
-    \       \"name\": \"c2\",\n              \"position\": 2,\n              \"type\"\
-    : \"blob\"\n            },\n            {\n              \"name\": \"c3\",\n \
-    \             \"position\": 3,\n              \"type\": \"mediumblob\"\n     \
-    \       },\n            {\n              \"name\": \"c4\",\n              \"position\"\
-    : 4,\n              \"type\": \"longblob\"\n            },\n            {\n  \
-    \            \"name\": \"c5\",\n              \"position\": 5,\n             \
-    \ \"type\": \"tinytext\"\n            },\n            {\n              \"name\"\
-    : \"c6\",\n              \"position\": 6,\n              \"type\": \"text\"\n\
-    \            },\n            {\n              \"name\": \"c7\",\n            \
-    \  \"position\": 7,\n              \"type\": \"mediumtext\"\n            },\n\
-    \            {\n              \"name\": \"c8\",\n              \"position\": 8,\n\
-    \              \"type\": \"longtext\"\n            },\n            {\n       \
-    \       \"name\": \"c9\",\n              \"position\": 9,\n              \"type\"\
-    : \"json\"\n            },\n            {\n              \"name\": \"c10\",\n\
-    \              \"position\": 10,\n              \"type\": \"serial\"\n       \
-    \     }\n          ]\n        }\n      ]\n    }\n  ]\n}"
+  want: |-
+    {
+      "name": "test",
+      "schemas": [
+        {
+          "tables": [
+            {
+              "name": "all_types",
+              "columns": [
+                {
+                  "name": "c1",
+                  "position": 1,
+                  "type": "tinyblob"
+                },
+                {
+                  "name": "c2",
+                  "position": 2,
+                  "type": "blob"
+                },
+                {
+                  "name": "c3",
+                  "position": 3,
+                  "type": "mediumblob"
+                },
+                {
+                  "name": "c4",
+                  "position": 4,
+                  "type": "longblob"
+                },
+                {
+                  "name": "c5",
+                  "position": 5,
+                  "type": "tinytext",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                },
+                {
+                  "name": "c6",
+                  "position": 6,
+                  "type": "text",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                },
+                {
+                  "name": "c7",
+                  "position": 7,
+                  "type": "mediumtext",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                },
+                {
+                  "name": "c8",
+                  "position": 8,
+                  "type": "longtext",
+                  "characterSet": "utf8mb4",
+                  "collation": "utf8mb4_0900_ai_ci"
+                },
+                {
+                  "name": "c9",
+                  "position": 9,
+                  "type": "json"
+                },
+                {
+                  "name": "c10",
+                  "position": 10,
+                  "type": "bigint unsigned"
+                }
+              ],
+              "indexes": [
+                {
+                  "name": "c10",
+                  "expressions": [
+                    "c10"
+                  ],
+                  "keyLength": [
+                    "0"
+                  ],
+                  "descending": [
+                    false
+                  ],
+                  "type": "BTREE",
+                  "unique": true,
+                  "visible": true
+                }
+              ],
+              "collation": "utf8mb4_0900_ai_ci",
+              "charset": "utf8mb4"
+            }
+          ]
+        }
+      ],
+      "characterSet": "utf8mb4",
+      "collation": "utf8mb4_0900_ai_ci"
+    }
   advice: null

--- a/backend/plugin/schema/mysql/walk_through_omni.go
+++ b/backend/plugin/schema/mysql/walk_through_omni.go
@@ -2,15 +2,18 @@ package mysql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
 
+	"github.com/bytebase/omni/mysql/ast"
 	"github.com/bytebase/omni/mysql/catalog"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 	"github.com/bytebase/bytebase/backend/store/model"
 )
@@ -30,16 +33,23 @@ func init() {
 //  3. catalog.Exec(userSQL) → execute user DDL
 //  4. Map errors → *storepb.Advice
 //  5. Convert updated catalog → DatabaseMetadata (for downstream rules)
-func WalkThroughOmni(ctx schema.WalkThroughContext, d *model.DatabaseMetadata, _ []base.AST) *storepb.Advice {
+func WalkThroughOmni(ctx schema.WalkThroughContext, d *model.DatabaseMetadata, asts []base.AST) *storepb.Advice {
 	if ctx.RawSQL == "" {
 		return nil
 	}
 
 	dbName := d.GetProto().GetName()
+	precheck := firstMySQLWalkThroughAdvice(
+		precheckMySQLOmniWalkThrough(d, asts),
+		precheckMySQLRawWalkThrough(d, ctx.RawSQL, asts),
+	)
 
 	// Step 1: Create the catalog and the target database.
 	c := catalog.New()
-	initSQL := fmt.Sprintf("SET foreign_key_checks = 0;\nCREATE DATABASE IF NOT EXISTS `%s`;\nUSE `%s`;", dbName, dbName)
+	initSQL := fmt.Sprintf("SET foreign_key_checks = 0;\nCREATE DATABASE IF NOT EXISTS %s;\nUSE %s;", mysqlQuoteIdentifier(dbName), mysqlQuoteIdentifier(dbName))
+	for _, targetDB := range mysqlRenameTargetDatabases(d, asts) {
+		initSQL += fmt.Sprintf("\nCREATE DATABASE IF NOT EXISTS %s;", mysqlQuoteIdentifier(targetDB))
+	}
 	if _, err := c.Exec(initSQL, &catalog.ExecOptions{ContinueOnError: true}); err != nil {
 		return &storepb.Advice{
 			Status:        storepb.Advice_ERROR,
@@ -66,16 +76,35 @@ func WalkThroughOmni(ctx schema.WalkThroughContext, d *model.DatabaseMetadata, _
 	// Step 3: Execute user SQL.
 	results, execErr := c.Exec(ctx.RawSQL, &catalog.ExecOptions{ContinueOnError: true})
 	if execErr != nil {
-		return &storepb.Advice{
-			Status:        storepb.Advice_ERROR,
-			Code:          code.DDLSimulationFailed.Int32(),
-			Title:         "DDL simulation failed",
-			Content:       execErr.Error(),
-			StartPosition: &storepb.Position{Line: 0},
+		errCode := code.DDLSimulationFailed
+		content := execErr.Error()
+		var catErr *catalog.Error
+		if errors.As(execErr, &catErr) {
+			errCode = mapMySQLErrorToCode(catErr)
+			content = mysqlCatalogErrorAdviceContent(d, catErr)
 		}
+		if strings.Contains(content, "BLOB, TEXT, GEOMETRY or JSON column ") {
+			errCode = code.InvalidColumnDefault
+			content = fmt.Sprintf("BLOB, TEXT, GEOMETRY or JSON column `%s` can't have a default value", mysqlCatalogErrorName(content))
+		}
+		execAdvice := mySQLWalkThroughAdvice{
+			index: -1,
+			advice: &storepb.Advice{
+				Status:        storepb.Advice_ERROR,
+				Code:          errCode.Int32(),
+				Title:         content,
+				Content:       content,
+				StartPosition: &storepb.Position{Line: 0},
+			},
+		}
+		if precheck.beforeOrSame(execAdvice) {
+			return precheck.advice
+		}
+		return execAdvice.advice
 	}
 
 	// Step 4: Report the first error from the simulation.
+	var execAdvice mySQLWalkThroughAdvice
 	for _, r := range results {
 		if r.Error == nil {
 			continue
@@ -83,17 +112,31 @@ func WalkThroughOmni(ctx schema.WalkThroughContext, d *model.DatabaseMetadata, _
 		errCode := mapMySQLErrorToCode(r.Error)
 		content := r.Error.Error()
 		if catErr, ok := r.Error.(*catalog.Error); ok {
-			content = catErr.Message
+			content = mysqlCatalogErrorAdviceContent(d, catErr)
 		}
-		return &storepb.Advice{
-			Status:  storepb.Advice_ERROR,
-			Code:    errCode.Int32(),
-			Title:   content,
-			Content: content,
-			StartPosition: &storepb.Position{
-				Line: int32(r.Line),
+		if strings.Contains(content, "BLOB, TEXT, GEOMETRY or JSON column ") {
+			errCode = code.InvalidColumnDefault
+			content = fmt.Sprintf("BLOB, TEXT, GEOMETRY or JSON column `%s` can't have a default value", mysqlCatalogErrorName(content))
+		}
+		execAdvice = mySQLWalkThroughAdvice{
+			index: r.Index,
+			advice: &storepb.Advice{
+				Status:  storepb.Advice_ERROR,
+				Code:    errCode.Int32(),
+				Title:   content,
+				Content: content,
+				StartPosition: &storepb.Position{
+					Line: int32(r.Line),
+				},
 			},
 		}
+		break
+	}
+	if precheck.beforeOrSame(execAdvice) {
+		return precheck.advice
+	}
+	if execAdvice.advice != nil {
+		return execAdvice.advice
 	}
 
 	// Step 5: Convert catalog state back to DatabaseMetadata for downstream rules.
@@ -102,6 +145,367 @@ func WalkThroughOmni(ctx schema.WalkThroughContext, d *model.DatabaseMetadata, _
 	d.ReplaceFrom(newMetadata)
 
 	return nil
+}
+
+type mySQLWalkThroughAdvice struct {
+	index  int
+	advice *storepb.Advice
+}
+
+func firstMySQLWalkThroughAdvice(advices ...mySQLWalkThroughAdvice) mySQLWalkThroughAdvice {
+	var result mySQLWalkThroughAdvice
+	for _, advice := range advices {
+		if advice.beforeOrSame(result) {
+			result = advice
+		}
+	}
+	return result
+}
+
+func (a mySQLWalkThroughAdvice) beforeOrSame(b mySQLWalkThroughAdvice) bool {
+	if a.advice == nil {
+		return false
+	}
+	if b.advice == nil {
+		return true
+	}
+	if a.index >= 0 && b.index >= 0 {
+		if a.index != b.index {
+			return a.index < b.index
+		}
+		if a.advice.Status != b.advice.Status {
+			return a.advice.Status > b.advice.Status
+		}
+		return true
+	}
+	if a.index >= 0 && b.index < 0 {
+		return true
+	}
+	if a.index < 0 && b.index >= 0 {
+		return false
+	}
+	aLine := mySQLWalkThroughAdviceLine(a.advice)
+	bLine := mySQLWalkThroughAdviceLine(b.advice)
+	if aLine <= 0 || bLine <= 0 {
+		return true
+	}
+	return aLine <= bLine
+}
+
+func mySQLWalkThroughAdviceLine(advice *storepb.Advice) int32 {
+	if advice == nil || advice.StartPosition == nil {
+		return 0
+	}
+	return advice.StartPosition.Line
+}
+
+// Keep a token-aware fallback for CTAS forms that do not produce an omni AST yet.
+func precheckMySQLRawWalkThrough(d *model.DatabaseMetadata, rawSQL string, asts []base.AST) mySQLWalkThroughAdvice {
+	statements, err := mysqlparser.SplitSQL(rawSQL)
+	if err != nil {
+		return mySQLWalkThroughAdvice{}
+	}
+	statementIndex := 0
+	for _, statement := range statements {
+		if statement.Empty {
+			continue
+		}
+		currentIndex := statementIndex
+		statementIndex++
+		text := strings.TrimSpace(statement.Text)
+		if !isMySQLCreateTableAsStatement(text) {
+			continue
+		}
+		if mySQLOmniASTSkipsCreateTableAsAdvice(d, asts, currentIndex) {
+			continue
+		}
+		content := fmt.Sprintf("CREATE TABLE AS statement is used in \"%s\"", text)
+		return mySQLWalkThroughAdvice{
+			index: currentIndex,
+			advice: &storepb.Advice{
+				Status:        storepb.Advice_WARNING,
+				Code:          code.StatementCreateTableAs.Int32(),
+				Title:         content,
+				Content:       content,
+				StartPosition: mySQLStatementStartPosition(statement.Start),
+			},
+		}
+	}
+	return mySQLWalkThroughAdvice{}
+}
+
+func mySQLOmniASTSkipsCreateTableAsAdvice(d *model.DatabaseMetadata, asts []base.AST, index int) bool {
+	if index >= len(asts) {
+		return false
+	}
+	node, ok := mysqlparser.GetOmniNode(asts[index])
+	if !ok {
+		return false
+	}
+	createTable, ok := node.(*ast.CreateTableStmt)
+	return ok && createTable.Select != nil && createTable.IfNotExists && mySQLOmniTableExistsInCurrentDatabase(d, createTable.Table)
+}
+
+func isMySQLCreateTableAsStatement(statement string) bool {
+	tokens := mySQLStatementTokens(statement)
+	if len(tokens) < 3 || tokens[0] != "CREATE" {
+		return false
+	}
+	idx := 1
+	if tokens[idx] == "TEMPORARY" {
+		idx++
+	}
+	if idx >= len(tokens) || tokens[idx] != "TABLE" {
+		return false
+	}
+	return slices.Contains(tokens[idx+1:], "SELECT")
+}
+
+func mySQLStatementTokens(statement string) []string {
+	var tokens []string
+	for i := 0; i < len(statement); {
+		switch statement[i] {
+		case '\'', '"', '`':
+			i = skipMySQLQuotedText(statement, i, statement[i])
+		case '#':
+			i = skipMySQLLineComment(statement, i+1)
+		case '-':
+			if i+1 < len(statement) && statement[i+1] == '-' {
+				i = skipMySQLLineComment(statement, i+2)
+			} else {
+				i++
+			}
+		case '/':
+			if i+1 < len(statement) && statement[i+1] == '*' {
+				i = skipMySQLBlockComment(statement, i+2)
+			} else {
+				i++
+			}
+		default:
+			if !isMySQLIdentifierChar(statement[i]) {
+				i++
+				continue
+			}
+			start := i
+			for i < len(statement) && isMySQLIdentifierChar(statement[i]) {
+				i++
+			}
+			tokens = append(tokens, strings.ToUpper(statement[start:i]))
+		}
+	}
+	return tokens
+}
+
+func skipMySQLQuotedText(statement string, start int, quote byte) int {
+	for i := start + 1; i < len(statement); i++ {
+		if statement[i] == '\\' {
+			i++
+			continue
+		}
+		if statement[i] != quote {
+			continue
+		}
+		if i+1 < len(statement) && statement[i+1] == quote {
+			i++
+			continue
+		}
+		return i + 1
+	}
+	return len(statement)
+}
+
+func skipMySQLLineComment(statement string, start int) int {
+	for i := start; i < len(statement); i++ {
+		if statement[i] == '\n' || statement[i] == '\r' {
+			return i + 1
+		}
+	}
+	return len(statement)
+}
+
+func skipMySQLBlockComment(statement string, start int) int {
+	for i := start; i+1 < len(statement); i++ {
+		if statement[i] == '*' && statement[i+1] == '/' {
+			return i + 2
+		}
+	}
+	return len(statement)
+}
+
+func isMySQLIdentifierChar(ch byte) bool {
+	return ch == '_' || ch == '$' || ch >= '0' && ch <= '9' || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z'
+}
+
+func precheckMySQLOmniWalkThrough(d *model.DatabaseMetadata, asts []base.AST) mySQLWalkThroughAdvice {
+	for i, unifiedAST := range asts {
+		node, ok := mysqlparser.GetOmniNode(unifiedAST)
+		if !ok {
+			continue
+		}
+		text := ""
+		if omniAST, ok := unifiedAST.(*mysqlparser.OmniAST); ok {
+			text = strings.TrimSpace(omniAST.Text)
+		}
+		if advice := precheckMySQLOmniNode(d, node, text); advice != nil {
+			advice.StartPosition = mySQLStatementStartPosition(unifiedAST.ASTStartPosition())
+			return mySQLWalkThroughAdvice{index: i, advice: advice}
+		}
+	}
+	return mySQLWalkThroughAdvice{}
+}
+
+func precheckMySQLOmniNode(d *model.DatabaseMetadata, node ast.Node, text string) *storepb.Advice {
+	switch n := node.(type) {
+	case *ast.CreateDatabaseStmt:
+		if n.Name != "" && !isCurrentDatabase(d, n.Name) {
+			return notCurrentMySQLDatabaseAdvice(d, n.Name)
+		}
+	case *ast.AlterDatabaseStmt:
+		if n.Name != "" && !isCurrentDatabase(d, n.Name) {
+			return notCurrentMySQLDatabaseAdvice(d, n.Name)
+		}
+	case *ast.DropDatabaseStmt:
+		if n.Name != "" && !isCurrentDatabase(d, n.Name) {
+			return notCurrentMySQLDatabaseAdvice(d, n.Name)
+		}
+		if n.Name != "" {
+			content := fmt.Sprintf("Database `%s` is deleted", n.Name)
+			return &storepb.Advice{
+				Status:        storepb.Advice_WARNING,
+				Code:          code.DatabaseIsDeleted.Int32(),
+				Title:         content,
+				Content:       content,
+				StartPosition: &storepb.Position{Line: 0},
+			}
+		}
+	case *ast.CreateTableStmt:
+		if advice := precheckMySQLTableRefDatabase(d, n.Table); advice != nil {
+			return advice
+		}
+		if n.IfNotExists && mySQLOmniTableExistsInCurrentDatabase(d, n.Table) {
+			return nil
+		}
+		if n.Select != nil {
+			content := fmt.Sprintf("CREATE TABLE AS statement is used in \"%s\"", text)
+			return &storepb.Advice{
+				Status:        storepb.Advice_WARNING,
+				Code:          code.StatementCreateTableAs.Int32(),
+				Title:         content,
+				Content:       content,
+				StartPosition: &storepb.Position{Line: 0},
+			}
+		}
+	case *ast.AlterTableStmt:
+		return precheckMySQLTableRefDatabase(d, n.Table)
+	case *ast.DropTableStmt:
+		for _, table := range n.Tables {
+			if advice := precheckMySQLTableRefDatabase(d, table); advice != nil {
+				return advice
+			}
+		}
+	case *ast.CreateIndexStmt:
+		return precheckMySQLTableRefDatabase(d, n.Table)
+	case *ast.DropIndexStmt:
+		return precheckMySQLTableRefDatabase(d, n.Table)
+	case *ast.TruncateStmt:
+		for _, table := range n.Tables {
+			if advice := precheckMySQLTableRefDatabase(d, table); advice != nil {
+				return advice
+			}
+		}
+	case *ast.RenameTableStmt:
+		for _, pair := range n.Pairs {
+			if pair == nil {
+				continue
+			}
+			if advice := precheckMySQLTableRefDatabase(d, pair.Old); advice != nil {
+				return advice
+			}
+		}
+	case *ast.CreateViewStmt:
+		return precheckMySQLTableRefDatabase(d, n.Name)
+	default:
+	}
+	return nil
+}
+
+func mysqlRenameTargetDatabases(d *model.DatabaseMetadata, asts []base.AST) []string {
+	seen := make(map[string]bool)
+	var targets []string
+	addTarget := func(sourceTable, targetTable *ast.TableRef) {
+		if sourceTable == nil || targetTable == nil {
+			return
+		}
+		if sourceTable.Schema != "" && !isCurrentDatabase(d, sourceTable.Schema) {
+			return
+		}
+		if targetTable.Schema == "" || isCurrentDatabase(d, targetTable.Schema) || seen[targetTable.Schema] {
+			return
+		}
+		seen[targetTable.Schema] = true
+		targets = append(targets, targetTable.Schema)
+	}
+	for _, unifiedAST := range asts {
+		node, ok := mysqlparser.GetOmniNode(unifiedAST)
+		if !ok {
+			continue
+		}
+		switch stmt := node.(type) {
+		case *ast.RenameTableStmt:
+			for _, pair := range stmt.Pairs {
+				if pair == nil {
+					continue
+				}
+				addTarget(pair.Old, pair.New)
+			}
+		case *ast.AlterTableStmt:
+			for _, cmd := range stmt.Commands {
+				if cmd == nil || cmd.Type != ast.ATRenameTable {
+					continue
+				}
+				addTarget(stmt.Table, cmd.NewTable)
+			}
+		default:
+		}
+	}
+	return targets
+}
+
+func mySQLStatementStartPosition(pos *storepb.Position) *storepb.Position {
+	if pos == nil {
+		return &storepb.Position{Line: 0}
+	}
+	return &storepb.Position{Line: pos.Line, Column: pos.Column}
+}
+
+func mysqlQuoteIdentifier(identifier string) string {
+	return "`" + strings.ReplaceAll(identifier, "`", "``") + "`"
+}
+
+func precheckMySQLTableRefDatabase(d *model.DatabaseMetadata, table *ast.TableRef) *storepb.Advice {
+	if table == nil || table.Schema == "" || isCurrentDatabase(d, table.Schema) {
+		return nil
+	}
+	return notCurrentMySQLDatabaseAdvice(d, table.Schema)
+}
+
+func mySQLOmniTableExistsInCurrentDatabase(d *model.DatabaseMetadata, table *ast.TableRef) bool {
+	if table == nil || (table.Schema != "" && !isCurrentDatabase(d, table.Schema)) {
+		return false
+	}
+	schema := d.GetSchemaMetadata("")
+	return schema.GetTable(table.Name) != nil
+}
+
+func notCurrentMySQLDatabaseAdvice(d *model.DatabaseMetadata, databaseName string) *storepb.Advice {
+	content := fmt.Sprintf("Database `%s` is not the current database `%s`", databaseName, d.DatabaseName())
+	return &storepb.Advice{
+		Status:        storepb.Advice_WARNING,
+		Code:          code.NotCurrentDatabase.Int32(),
+		Title:         content,
+		Content:       content,
+		StartPosition: &storepb.Position{Line: 0},
+	}
 }
 
 // mapMySQLErrorToCode converts an omni MySQL catalog error to a bytebase error code.
@@ -115,7 +519,7 @@ func mapMySQLErrorToCode(err error) code.Code {
 	case catalog.ErrDupDatabase:
 		return code.DDLSimulationFailed
 	case catalog.ErrUnknownDatabase:
-		return code.DatabaseNotExists
+		return code.NotCurrentDatabase
 	case catalog.ErrDupTable:
 		return code.TableExists
 	case catalog.ErrUnknownTable, catalog.ErrNoSuchTable:
@@ -124,14 +528,22 @@ func mapMySQLErrorToCode(err error) code.Code {
 		return code.ColumnExists
 	case catalog.ErrNoSuchColumn:
 		return code.ColumnNotExists
+	case catalog.ErrInvalidDefault:
+		return code.InvalidColumnDefault
 	case catalog.ErrDupKeyName, catalog.ErrDupIndex:
 		return code.IndexExists
 	case catalog.ErrMultiplePriKey:
 		return code.PrimaryKeyExists
 	case catalog.ErrDupEntry:
 		return code.IndexExists
+	case 1252:
+		return code.SpatialIndexKeyNullable
 	case catalog.ErrCantDropKey:
 		return code.IndexNotExists
+	case catalog.ErrIncorrectTableDefinition:
+		return code.AutoIncrementExists
+	case catalog.ErrInvalidOnUpdate:
+		return code.OnUpdateColumnNotDatetimeOrTimestamp
 	case catalog.ErrFKNoRefTable:
 		return code.TableHasFK
 	case catalog.ErrFKCannotDropParent:
@@ -143,6 +555,49 @@ func mapMySQLErrorToCode(err error) code.Code {
 	default:
 		return code.DDLSimulationFailed
 	}
+}
+
+func mysqlCatalogErrorAdviceContent(d *model.DatabaseMetadata, catErr *catalog.Error) string {
+	name := mysqlCatalogErrorName(catErr.Message)
+	switch catErr.Code {
+	case catalog.ErrUnknownDatabase:
+		return fmt.Sprintf("Database `%s` is not the current database `%s`", name, d.DatabaseName())
+	case catalog.ErrDupTable:
+		return fmt.Sprintf("Table `%s` already exists", mysqlUnqualifiedName(name))
+	case catalog.ErrUnknownTable, catalog.ErrNoSuchTable:
+		return fmt.Sprintf("Table `%s` does not exist", mysqlUnqualifiedName(name))
+	case catalog.ErrDupColumn:
+		return fmt.Sprintf("Column `%s` already exists", mysqlUnqualifiedName(name))
+	case catalog.ErrNoSuchColumn:
+		return fmt.Sprintf("Column `%s` does not exist", mysqlUnqualifiedName(name))
+	case catalog.ErrInvalidDefault:
+		return fmt.Sprintf("Invalid default value for column `%s`", mysqlUnqualifiedName(name))
+	case catalog.ErrDupKeyName, catalog.ErrDupIndex, catalog.ErrDupEntry:
+		return fmt.Sprintf("Index `%s` already exists", mysqlUnqualifiedName(name))
+	case catalog.ErrCantDropKey:
+		return fmt.Sprintf("Index `%s` does not exist", mysqlUnqualifiedName(name))
+	default:
+		return catErr.Message
+	}
+}
+
+func mysqlCatalogErrorName(message string) string {
+	start := strings.Index(message, "'")
+	if start < 0 {
+		return message
+	}
+	end := strings.Index(message[start+1:], "'")
+	if end < 0 {
+		return message[start+1:]
+	}
+	return message[start+1 : start+1+end]
+}
+
+func mysqlUnqualifiedName(name string) string {
+	if idx := strings.LastIndex(name, "."); idx >= 0 {
+		return name[idx+1:]
+	}
+	return name
 }
 
 // catalogToProto converts the omni catalog state to a storepb.DatabaseSchemaMetadata.
@@ -223,21 +678,21 @@ func tableToProto(t *catalog.Table) *storepb.TableMetadata {
 	table := &storepb.TableMetadata{
 		Name:      t.Name,
 		Engine:    t.Engine,
+		Charset:   t.Charset,
 		Collation: t.Collation,
 		Comment:   t.Comment,
-	}
-	if t.Charset != "" {
-		table.Charset = t.Charset
 	}
 
 	// Columns.
 	for _, col := range t.Columns {
 		colMeta := &storepb.ColumnMetadata{
-			Name:     col.Name,
-			Position: int32(col.Position),
-			Type:     col.ColumnType,
-			Nullable: col.Nullable,
-			Comment:  col.Comment,
+			Name:         col.Name,
+			Position:     int32(col.Position),
+			Type:         col.ColumnType,
+			Nullable:     col.Nullable,
+			CharacterSet: col.Charset,
+			Collation:    col.Collation,
+			Comment:      col.Comment,
 		}
 		if col.Default != nil {
 			colMeta.Default = *col.Default
@@ -255,20 +710,18 @@ func tableToProto(t *catalog.Table) *storepb.TableMetadata {
 				Expression: col.Generated.Expr,
 			}
 		}
-		if col.Charset != "" {
-			colMeta.CharacterSet = col.Charset
-		}
-		if col.Collation != "" {
-			colMeta.Collation = col.Collation
-		}
 		table.Columns = append(table.Columns, colMeta)
 	}
 
 	// Indexes.
 	for _, idx := range t.Indexes {
+		indexType := strings.ToUpper(idx.IndexType)
+		if indexType == "" {
+			indexType = "BTREE"
+		}
 		idxMeta := &storepb.IndexMetadata{
 			Name:    idx.Name,
-			Type:    strings.ToUpper(idx.IndexType),
+			Type:    indexType,
 			Unique:  idx.Unique,
 			Primary: idx.Primary,
 			Visible: idx.Visible,

--- a/backend/plugin/schema/mysql/walk_through_test.go
+++ b/backend/plugin/schema/mysql/walk_through_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	omniast "github.com/bytebase/omni/mysql/ast"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -13,9 +14,11 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/component/sheet"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
 	"github.com/bytebase/bytebase/backend/store/model"
 )
 
@@ -42,6 +45,7 @@ func TestWalkThrough(t *testing.T) {
 	require.NoError(t, err)
 	err = yaml.Unmarshal(byteValue, &tests)
 	require.NoError(t, err)
+	sm := sheet.NewManager()
 
 	for _, test := range tests {
 		// Make a deep copy to avoid mutation across tests
@@ -51,17 +55,14 @@ func TestWalkThrough(t *testing.T) {
 		// Create DatabaseMetadata for walk-through
 		state := model.NewDatabaseMetadata(protoData, nil, nil, storepb.Engine_MYSQL, !test.IgnoreCaseSensitive)
 
-		antlrASTs, err := mysqlparser.ParseMySQL(test.Statement)
-		require.NoError(t, err)
-		asts := make([]base.AST, 0, len(antlrASTs))
-		for _, antlrAST := range antlrASTs {
-			asts = append(asts, antlrAST)
-		}
-		advice := WalkThrough(state, asts)
+		stmts, _ := sm.GetStatementsForChecks(storepb.Engine_MYSQL, test.Statement)
+		asts := base.ExtractASTs(stmts)
+		advice := WalkThroughOmni(schema.WalkThroughContext{RawSQL: test.Statement}, state, asts)
 		if advice != nil {
 			// Compare the advice fields
-			require.Equal(t, test.Advice.Code, advice.Code)
-			require.Equal(t, test.Advice.Content, advice.Content)
+			require.NotNil(t, test.Advice, "unexpected advice for statement %q: %+v", test.Statement, advice)
+			require.Equal(t, test.Advice.Code, advice.Code, "statement %q advice %+v", test.Statement, advice)
+			require.Equal(t, test.Advice.Content, advice.Content, "statement %q advice %+v", test.Statement, advice)
 			continue
 		}
 
@@ -79,6 +80,45 @@ func TestWalkThrough(t *testing.T) {
 			protocmp.SortRepeatedFields(&storepb.SchemaMetadata{}, "tables", "views"),
 			protocmp.SortRepeatedFields(&storepb.TableMetadata{}, "indexes", "columns"),
 		)
-		require.Empty(t, diff)
+		require.Empty(t, diff, "statement %q", test.Statement)
 	}
+}
+
+func TestWalkThroughOmniCreateTableIfNotExistsCTASExistingTable(t *testing.T) {
+	originDatabase := &storepb.DatabaseSchemaMetadata{
+		Name: "test",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t1",
+						Columns: []*storepb.ColumnMetadata{
+							{
+								Name:     "a",
+								Position: 1,
+								Nullable: true,
+								Type:     "int",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	state := model.NewDatabaseMetadata(originDatabase, nil, nil, storepb.Engine_MYSQL, true)
+	require.NotNil(t, state.GetSchemaMetadata("").GetTable("t1"))
+	statement := "CREATE TABLE IF NOT EXISTS t1 AS SELECT 1;"
+	sm := sheet.NewManager()
+	stmts, _ := sm.GetStatementsForChecks(storepb.Engine_MYSQL, statement)
+	asts := base.ExtractASTs(stmts)
+	omniAST, ok := asts[0].(*mysqlparser.OmniAST)
+	require.True(t, ok)
+	createTable, ok := omniAST.Node.(*omniast.CreateTableStmt)
+	require.True(t, ok)
+	require.True(t, createTable.IfNotExists)
+
+	advice := WalkThroughOmni(schema.WalkThroughContext{RawSQL: statement}, state, asts)
+	require.Nil(t, advice)
+	require.NotNil(t, state.GetSchemaMetadata("").GetTable("t1"))
 }

--- a/backend/tests/sql_review_test.go
+++ b/backend/tests/sql_review_test.go
@@ -41,8 +41,8 @@ var (
 	builtinOnlyPolicyWithConflict = []*v1pb.PlanCheckRun_Result{
 		{
 			Status:  v1pb.Advice_WARNING,
-			Title:   "Table 'user' already exists",
-			Content: "Table 'user' already exists",
+			Title:   "Table `user` already exists",
+			Content: "Table `user` already exists",
 			Code:    607, // code.TableExists
 			Report: &v1pb.PlanCheckRun_Result_SqlReviewReport_{
 				SqlReviewReport: &v1pb.PlanCheckRun_Result_SqlReviewReport{

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260610004923-a82b547d4b19
+	github.com/bytebase/omni v0.0.0-20260610023532-8cd4bb9614e1
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260610004923-a82b547d4b19 h1:RcisdYSr5RWrmaQqTjvOxhh4SvO6nWARYHotG/Bo4GA=
-github.com/bytebase/omni v0.0.0-20260610004923-a82b547d4b19/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260610023532-8cd4bb9614e1 h1:xsfTH5uRpxOPNa/DV3GwMax+Mfca5Ck/anErItfsXK0=
+github.com/bytebase/omni v0.0.0-20260610023532-8cd4bb9614e1/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Migrate MySQL schema walkthrough test to the Omni statement path instead of the legacy ANTLR walkthrough.
- Preserve historical walkthrough fixture behavior in the Omni catalog conversion layer for database/table defaults, CTAS warnings, non-current database checks, explicit column charset/collation, dropped FK backing indexes, and SERIAL columns.
- Keep the walkthrough test free of legacy parser/ANTLR references.

## Testing
- go test -v -count=1 ./backend/plugin/schema/mysql -run ^TestWalkThrough$
- go test -count=1 ./backend/plugin/db/mysql ./backend/plugin/parser/mysql ./backend/plugin/advisor/oceanbase
- golangci-lint run --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
- git diff --check
- rg check confirmed no legacy parser references in MySQL walkthrough test/Omni walkthrough files