### PR TITLE
fix: make redshift statement ranges linear

### DIFF
--- a/backend/plugin/parser/redshift/statement_ranges.go
+++ b/backend/plugin/parser/redshift/statement_ranges.go
@@ -16,25 +16,43 @@ func init() {
 }
 
 func GetStatementRanges(_ context.Context, _ base.StatementRangeContext, statement string) ([]base.Range, error) {
-	omniRanges, err := omniredshift.StatementRanges(statement)
-	if err == nil {
-		ranges := make([]base.Range, 0, len(omniRanges))
-		for _, r := range omniRanges {
-			ranges = append(ranges, base.Range{
-				Start: lsp.Position{
-					Line:      uint32(r.Start.Line),
-					Character: uint32(r.Start.Character),
-				},
-				End: lsp.Position{
-					Line:      uint32(r.End.Line),
-					Character: uint32(r.End.Character),
-				},
-			})
-		}
-		return ranges, nil
+	if _, err := omniredshift.Parse(statement); err != nil {
+		return getLexicalStatementRanges(statement)
 	}
 
-	return getLexicalStatementRanges(statement)
+	// Keep UTF-16 position mapping local and one-pass. omniredshift.StatementRanges
+	// validates the script, but maps each range offset by rescanning from the start.
+	return getParsedStatementRanges(statement), nil
+}
+
+func getParsedStatementRanges(statement string) []base.Range {
+	segments := omniredshift.Split(statement)
+	if len(segments) == 0 {
+		return nil
+	}
+
+	positions := buildUTF16PositionMap(statement)
+	ranges := make([]base.Range, 0, len(segments))
+	for _, segment := range segments {
+		if segment.Empty() {
+			continue
+		}
+		start := segment.ByteStart + leadingTriviaLen(segment.Text)
+		end := segment.ByteEnd
+		startPos, ok := positionAtByteOffset(positions, start)
+		if !ok {
+			continue
+		}
+		endPos, ok := positionAtByteOffset(positions, end)
+		if !ok {
+			continue
+		}
+		ranges = append(ranges, base.Range{
+			Start: startPos,
+			End:   endPos,
+		})
+	}
+	return ranges
 }
 
 func getLexicalStatementRanges(statement string) ([]base.Range, error) {
@@ -95,4 +113,40 @@ func positionAtByteOffset(positions []lsp.Position, byteOffset int) (lsp.Positio
 		return lsp.Position{}, false
 	}
 	return positions[byteOffset], true
+}
+
+func leadingTriviaLen(statement string) int {
+	i := 0
+	for i < len(statement) {
+		switch {
+		case isLeadingTriviaSpace(statement[i]) || statement[i] == ';':
+			i++
+		case statement[i] == '-' && i+1 < len(statement) && statement[i+1] == '-':
+			i += 2
+			for i < len(statement) && statement[i] != '\n' {
+				i++
+			}
+		case statement[i] == '/' && i+1 < len(statement) && statement[i+1] == '*':
+			i += 2
+			depth := 1
+			for i < len(statement) && depth > 0 {
+				if statement[i] == '/' && i+1 < len(statement) && statement[i+1] == '*' {
+					depth++
+					i += 2
+				} else if statement[i] == '*' && i+1 < len(statement) && statement[i+1] == '/' {
+					depth--
+					i += 2
+				} else {
+					i++
+				}
+			}
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+func isLeadingTriviaSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
 }

--- a/backend/plugin/parser/redshift/statement_ranges_test.go
+++ b/backend/plugin/parser/redshift/statement_ranges_test.go
@@ -2,7 +2,10 @@ package redshift
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	lsp "github.com/bytebase/lsp-protocol"
 	"github.com/stretchr/testify/require"
@@ -51,6 +54,13 @@ func TestGetStatementRanges(t *testing.T) {
 	}
 }
 
+func TestGetStatementRangesScalesLinearlyForLargeScript(t *testing.T) {
+	smallDuration := timeGetStatementRanges(t, redshiftStatementRangeScript(1000))
+	largeDuration := timeGetStatementRanges(t, redshiftStatementRangeScript(10000))
+
+	require.Lessf(t, largeDuration, smallDuration*40, "10x more statements should not take %s vs %s", largeDuration, smallDuration)
+}
+
 func TestGetStatementRangesToleratesIncompleteSQL(t *testing.T) {
 	got, err := GetStatementRanges(context.Background(), base.StatementRangeContext{}, "SELECT * FROM")
 	require.NoError(t, err)
@@ -60,4 +70,35 @@ func TestGetStatementRangesToleratesIncompleteSQL(t *testing.T) {
 			End:   lsp.Position{Line: 0, Character: 13},
 		},
 	}, got)
+}
+
+func redshiftStatementRangeScript(count int) string {
+	var builder strings.Builder
+	for i := range count {
+		if i > 0 {
+			builder.WriteByte('\n')
+		}
+		table := fmt.Sprintf("perf_redshift_%d", i)
+		switch i % 4 {
+		case 0:
+			fmt.Fprintf(&builder, "CREATE TABLE %s (id INT, payload VARCHAR(255))", table)
+		case 1:
+			fmt.Fprintf(&builder, "INSERT INTO %s (id, payload) VALUES (%d, 'payload-%d')", table, i, i)
+		case 2:
+			fmt.Fprintf(&builder, "UPDATE %s SET payload = 'updated-%d' WHERE id = %d", table, i, i)
+		default:
+			fmt.Fprintf(&builder, "DROP TABLE IF EXISTS %s", table)
+		}
+		builder.WriteByte(';')
+	}
+	return builder.String()
+}
+
+func timeGetStatementRanges(t *testing.T, statement string) time.Duration {
+	t.Helper()
+	start := time.Now()
+	ranges, err := GetStatementRanges(context.Background(), base.StatementRangeContext{}, statement)
+	require.NoError(t, err)
+	require.NotEmpty(t, ranges)
+	return time.Since(start)
 }


### PR DESCRIPTION
## Summary
- Keep Redshift statement range validation through `omniredshift.Parse`, but generate ranges with a local one-pass UTF-16 position map instead of `omniredshift.StatementRanges`.
- Preserve lexical fallback for invalid or incomplete editor buffers.
- Add a large-script regression test that fails when 10x more statements grows into the previous near-quadratic range-mapping cost.

## Notes
Before the fix, the new regression failed with 10k statements taking `5.741s` versus `55.8ms` for 1k statements. After the fix, the Redshift parser package test completes normally.

## Test Plan
- `go test -count=1 ./backend/plugin/parser/redshift -timeout 2m`
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
