### PR TITLE
fix(parser/trino): resolve view-column lineage to base tables for masking (BYT-9679)

### DIFF
--- a/backend/plugin/parser/trino/query_span_extractor.go
+++ b/backend/plugin/parser/trino/query_span_extractor.go
@@ -42,6 +42,21 @@ type querySpanExtractor struct {
 
 	// metaCache memoises database metadata lookups within a single span.
 	metaCache map[string]*model.DatabaseMetadata
+
+	// viewsInProgress guards against view-definition cycles (malformed metadata):
+	// a view currently being analysed is not re-entered. Propagated to the
+	// sub-extractor used to analyse a view's definition.
+	viewsInProgress map[viewKey]bool
+	// viewProjCache memoises each view's output-column -> base-column projection
+	// (nil value cached for a non-view or unresolvable reference).
+	viewProjCache map[viewKey]map[string][]base.ColumnResource
+}
+
+// viewKey identifies a view by its resolved database/schema/name.
+type viewKey struct {
+	database string
+	schema   string
+	view     string
 }
 
 // newQuerySpanExtractor creates a new Trino query span extractor.
@@ -52,6 +67,7 @@ func newQuerySpanExtractor(defaultDatabase, defaultSchema string, gCtx base.GetQ
 		gCtx:                gCtx,
 		ignoreCaseSensitive: ignoreCaseSensitive,
 		metaCache:           make(map[string]*model.DatabaseMetadata),
+		viewProjCache:       make(map[viewKey]map[string][]base.ColumnResource),
 	}
 }
 
@@ -164,7 +180,139 @@ func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string)
 	if notFound != nil {
 		span.NotFoundError = notFound
 	}
+
+	// Rewrite any lineage that resolves to a VIEW column into the underlying
+	// base-table columns the view projects. Masking config (semantic types) can
+	// only be attached to table columns — there is no view catalog — so without
+	// this a sensitive column surfaced through a view is left unmasked.
+	q.resolveViewLineage(ctx, span)
 	return span, nil
+}
+
+// resolveViewLineage rewrites every source column in the span that points at a
+// VIEW into the base-table columns the view projects. Bytebase can only attach
+// masking configuration (semantic types) to table columns — SchemaCatalog
+// carries no views — so a column surfaced through a view must be resolved to its
+// underlying table column for masking to apply. The projection is computed by
+// recursively analysing the view's definition (the same resolution the pg
+// extractor performs via its view loader), so a view over a view resolves
+// transitively; a definition cycle in malformed metadata is broken by
+// viewsInProgress. Non-view columns are left untouched.
+func (q *querySpanExtractor) resolveViewLineage(ctx context.Context, span *base.QuerySpan) {
+	if span == nil {
+		return
+	}
+	for i := range span.Results {
+		span.Results[i].SourceColumns = q.expandViewColumns(ctx, span.Results[i].SourceColumns)
+	}
+	span.SourceColumns = q.expandViewColumns(ctx, span.SourceColumns)
+	span.PredicateColumns = q.expandViewColumns(ctx, span.PredicateColumns)
+}
+
+// expandViewColumns returns set with each view column replaced by the view's
+// projected base columns. A non-view column — and a view column the projection
+// cannot resolve — is kept unchanged, so this only ever deepens lineage and
+// never drops a source column.
+func (q *querySpanExtractor) expandViewColumns(ctx context.Context, set base.SourceColumnSet) base.SourceColumnSet {
+	out := make(base.SourceColumnSet, len(set))
+	for col := range set {
+		proj := q.viewProjection(ctx, col.Database, col.Schema, col.Table)
+		if proj == nil {
+			out[col] = true
+			continue
+		}
+		bases, ok := proj[col.Column]
+		if !ok || len(bases) == 0 {
+			out[col] = true
+			continue
+		}
+		for _, b := range bases {
+			out[b] = true
+		}
+	}
+	return out
+}
+
+// viewProjection returns the (output column name -> base columns) projection of
+// the view identified by database/schema/table, or nil when the reference is not
+// a resolvable view. The view's definition is analysed with the view's own
+// catalog/schema as defaults; because the recursive getQuerySpan itself resolves
+// nested views, the returned base columns are fully resolved. Results (including
+// the nil "not a view" result) are memoised.
+func (q *querySpanExtractor) viewProjection(ctx context.Context, database, schema, table string) map[string][]base.ColumnResource {
+	vk := viewKey{database: database, schema: schema, view: table}
+	if cached, ok := q.viewProjCache[vk]; ok {
+		return cached
+	}
+	// Cache "not a view / unresolvable" up front; overwritten on success. This
+	// also short-circuits the (cheap but repeated) lookups of plain tables and
+	// guards re-entrancy for the same view.
+	q.viewProjCache[vk] = nil
+	if q.viewsInProgress[vk] {
+		return nil
+	}
+
+	metadata, err := q.getDatabaseMetadata(database)
+	if err != nil || metadata == nil {
+		return nil
+	}
+	schemaMeta := metadata.GetSchemaMetadata(schema)
+	if schemaMeta == nil && q.ignoreCaseSensitive {
+		for _, name := range metadata.ListSchemaNames() {
+			if strings.EqualFold(name, schema) {
+				schemaMeta = metadata.GetSchemaMetadata(name)
+				break
+			}
+		}
+	}
+	if schemaMeta == nil {
+		return nil
+	}
+	view := schemaMeta.GetView(table)
+	if view == nil && q.ignoreCaseSensitive {
+		for _, name := range schemaMeta.ListViewNames() {
+			if strings.EqualFold(name, table) {
+				view = schemaMeta.GetView(name)
+				break
+			}
+		}
+	}
+	if view == nil || view.GetDefinition() == "" {
+		return nil
+	}
+
+	// Analyse the view body with the view's own catalog/schema as defaults so its
+	// unqualified table references resolve correctly. The sub-extractor inherits
+	// the in-progress set (plus this view) so a cyclic definition terminates.
+	sub := newQuerySpanExtractor(database, schema, q.gCtx, q.ignoreCaseSensitive)
+	sub.metaCache = q.metaCache
+	sub.viewsInProgress = copyViewSet(q.viewsInProgress)
+	sub.viewsInProgress[vk] = true
+	viewSpan, err := sub.getQuerySpan(ctx, view.GetDefinition())
+	if err != nil || viewSpan == nil {
+		return nil
+	}
+
+	proj := make(map[string][]base.ColumnResource, len(viewSpan.Results))
+	for _, res := range viewSpan.Results {
+		cols := make([]base.ColumnResource, 0, len(res.SourceColumns))
+		for c := range res.SourceColumns {
+			cols = append(cols, c)
+		}
+		proj[res.Name] = cols
+	}
+	q.viewProjCache[vk] = proj
+	return proj
+}
+
+// copyViewSet returns a shallow copy of a viewKey set (nil-safe), with capacity
+// for one more entry.
+func copyViewSet(in map[viewKey]bool) map[viewKey]bool {
+	out := make(map[viewKey]bool, len(in)+1)
+	for k := range in {
+		out[k] = true
+	}
+	return out
 }
 
 // toTableResources converts omni AccessTables into table-level

--- a/backend/plugin/parser/trino/query_span_extractor.go
+++ b/backend/plugin/parser/trino/query_span_extractor.go
@@ -204,6 +204,13 @@ func (q *querySpanExtractor) resolveViewLineage(ctx context.Context, span *base.
 	}
 	for i := range span.Results {
 		span.Results[i].SourceColumns = q.expandViewColumns(ctx, span.Results[i].SourceColumns)
+		// A result whose view column expanded to multiple base columns (e.g. a
+		// view column defined as phone || name) is no longer a plain field;
+		// downgrade so the masker treats it as composed. Defensive: Trino is not
+		// currently in EngineSupportQuerySpanPlainField, but keep the flag honest.
+		if len(span.Results[i].SourceColumns) > 1 {
+			span.Results[i].IsPlainField = false
+		}
 	}
 	span.SourceColumns = q.expandViewColumns(ctx, span.SourceColumns)
 	span.PredicateColumns = q.expandViewColumns(ctx, span.PredicateColumns)
@@ -293,13 +300,24 @@ func (q *querySpanExtractor) viewProjection(ctx context.Context, database, schem
 		return nil
 	}
 
+	// Key the projection by the VIEW's metadata column names — what the outer
+	// query references — mapped POSITIONALLY to the definition's analysed output
+	// columns. SQL view columns correspond to the definition's select list by
+	// position, so this is correct even when the view renames them via an
+	// explicit column list (CREATE VIEW v (ph) AS SELECT phone ...), where the
+	// definition's output name (phone) differs from the view column name (ph).
+	viewCols := view.GetColumns()
 	proj := make(map[string][]base.ColumnResource, len(viewSpan.Results))
-	for _, res := range viewSpan.Results {
+	for i, res := range viewSpan.Results {
+		name := res.Name
+		if i < len(viewCols) {
+			name = viewCols[i].GetName()
+		}
 		cols := make([]base.ColumnResource, 0, len(res.SourceColumns))
 		for c := range res.SourceColumns {
 			cols = append(cols, c)
 		}
-		proj[res.Name] = cols
+		proj[name] = cols
 	}
 	q.viewProjCache[vk] = proj
 	return proj

--- a/backend/plugin/parser/trino/query_span_view_test.go
+++ b/backend/plugin/parser/trino/query_span_view_test.go
@@ -47,6 +47,19 @@ func viewLineageMetadata() *storepb.DatabaseSchemaMetadata {
 						Definition: "SELECT phone FROM customer_v",
 						Columns:    []*storepb.ColumnMetadata{{Name: "phone"}},
 					},
+					{
+						// Explicit view column list renames the projection: the
+						// definition outputs "phone" but the view column is "ph".
+						Name:       "renamed_v",
+						Definition: "SELECT phone FROM customer",
+						Columns:    []*storepb.ColumnMetadata{{Name: "ph"}},
+					},
+					{
+						// A composed view column derives from two base columns.
+						Name:       "comp_v",
+						Definition: "SELECT phone || name AS token FROM customer",
+						Columns:    []*storepb.ColumnMetadata{{Name: "token"}},
+					},
 				},
 			},
 		},
@@ -116,6 +129,32 @@ func TestQuerySpan_ViewOverViewResolvesToBase(t *testing.T) {
 	span := viewLineageSpan(t, "SELECT phone FROM v2")
 	srcs := resultSources(t, span, "phone")
 	require.True(t, srcs[customerCol("phone")], "phone should resolve through v2 -> customer_v -> customer.phone; got %+v", srcs)
+}
+
+// TestQuerySpan_ViewExplicitColumnListResolvesToBase covers a view whose column
+// list renames the projection (CREATE VIEW renamed_v (ph) AS SELECT phone ...):
+// the outer ph must map positionally to base customer.phone even though the
+// definition's output name is "phone".
+func TestQuerySpan_ViewExplicitColumnListResolvesToBase(t *testing.T) {
+	span := viewLineageSpan(t, "SELECT ph FROM renamed_v")
+	srcs := resultSources(t, span, "ph")
+	require.True(t, srcs[customerCol("phone")], "ph should resolve positionally to base customer.phone; got %+v", srcs)
+}
+
+// TestQuerySpan_ComposedViewColumnNotPlain covers a view column composed from two
+// base columns: it must resolve to both, and must not stay a plain field.
+func TestQuerySpan_ComposedViewColumnNotPlain(t *testing.T) {
+	span := viewLineageSpan(t, "SELECT token FROM comp_v")
+	for _, r := range span.Results {
+		if r.Name != "token" {
+			continue
+		}
+		require.True(t, r.SourceColumns[customerCol("phone")], "token should include customer.phone; got %+v", r.SourceColumns)
+		require.True(t, r.SourceColumns[customerCol("name")], "token should include customer.name; got %+v", r.SourceColumns)
+		require.False(t, r.IsPlainField, "a composed view column must not be a plain field")
+		return
+	}
+	t.Fatalf("no result column named token in %+v", span.Results)
 }
 
 // TestQuerySpan_BaseTableUnaffectedByViewResolution guards that a plain base

--- a/backend/plugin/parser/trino/query_span_view_test.go
+++ b/backend/plugin/parser/trino/query_span_view_test.go
@@ -1,0 +1,128 @@
+package trino
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+// viewLineageMetadata builds a catalog with a base table customer(id, phone,
+// name), a pass-through view customer_v, a renaming view cust_masked
+// (phone AS ph), and a view-over-view v2.
+func viewLineageMetadata() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: "catalog1",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "customer",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+							{Name: "phone", Type: "varchar"},
+							{Name: "name", Type: "varchar"},
+						},
+					},
+				},
+				Views: []*storepb.ViewMetadata{
+					{
+						Name:       "customer_v",
+						Definition: "SELECT id, phone, name FROM customer",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id"}, {Name: "phone"}, {Name: "name"},
+						},
+					},
+					{
+						Name:       "cust_masked",
+						Definition: "SELECT phone AS ph FROM customer",
+						Columns:    []*storepb.ColumnMetadata{{Name: "ph"}},
+					},
+					{
+						Name:       "v2",
+						Definition: "SELECT phone FROM customer_v",
+						Columns:    []*storepb.ColumnMetadata{{Name: "phone"}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func viewLineageSpan(t *testing.T, sql string) *base.QuerySpan {
+	getter, lister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{viewLineageMetadata()})
+	gCtx := base.GetQuerySpanContext{
+		GetDatabaseMetadataFunc: getter,
+		ListDatabaseNamesFunc:   lister,
+		Engine:                  storepb.Engine_TRINO,
+	}
+	extractor := newQuerySpanExtractor("catalog1", "public", gCtx, false)
+	span, err := extractor.getQuerySpan(context.Background(), sql)
+	require.NoError(t, err)
+	return span
+}
+
+func resultSources(t *testing.T, span *base.QuerySpan, name string) base.SourceColumnSet {
+	t.Helper()
+	for _, r := range span.Results {
+		if r.Name == name {
+			return r.SourceColumns
+		}
+	}
+	t.Fatalf("no result column named %q in %+v", name, span.Results)
+	return nil
+}
+
+func customerCol(col string) base.ColumnResource {
+	return base.ColumnResource{Database: "catalog1", Schema: "public", Table: "customer", Column: col}
+}
+
+// TestQuerySpan_ViewColumnResolvesToBase covers BYT-9679: a column selected
+// through a view must resolve to the underlying base-table column (where masking
+// config lives), not the view column.
+func TestQuerySpan_ViewColumnResolvesToBase(t *testing.T) {
+	span := viewLineageSpan(t, "SELECT phone FROM customer_v")
+	srcs := resultSources(t, span, "phone")
+	require.True(t, srcs[customerCol("phone")], "phone should resolve to base customer.phone; got %+v", srcs)
+	// The view column must not survive as the (unmaskable) lineage.
+	require.False(t, srcs[base.ColumnResource{Database: "catalog1", Schema: "public", Table: "customer_v", Column: "phone"}],
+		"view column customer_v.phone must be rewritten to the base column; got %+v", srcs)
+}
+
+// TestQuerySpan_ViewStarResolvesToBase resolves every column of SELECT * over a
+// view to its base columns.
+func TestQuerySpan_ViewStarResolvesToBase(t *testing.T) {
+	span := viewLineageSpan(t, "SELECT * FROM customer_v")
+	require.True(t, resultSources(t, span, "phone")[customerCol("phone")], "SELECT * phone should resolve to customer.phone")
+	require.True(t, resultSources(t, span, "id")[customerCol("id")], "SELECT * id should resolve to customer.id")
+	require.True(t, resultSources(t, span, "name")[customerCol("name")], "SELECT * name should resolve to customer.name")
+}
+
+// TestQuerySpan_RenamingViewResolvesToBase resolves a view that renames the
+// projected column (phone AS ph): the outer ph must map to base customer.phone.
+func TestQuerySpan_RenamingViewResolvesToBase(t *testing.T) {
+	span := viewLineageSpan(t, "SELECT ph FROM cust_masked")
+	srcs := resultSources(t, span, "ph")
+	require.True(t, srcs[customerCol("phone")], "ph should resolve to base customer.phone; got %+v", srcs)
+}
+
+// TestQuerySpan_ViewOverViewResolvesToBase resolves a view defined over another
+// view transitively to the base column.
+func TestQuerySpan_ViewOverViewResolvesToBase(t *testing.T) {
+	span := viewLineageSpan(t, "SELECT phone FROM v2")
+	srcs := resultSources(t, span, "phone")
+	require.True(t, srcs[customerCol("phone")], "phone should resolve through v2 -> customer_v -> customer.phone; got %+v", srcs)
+}
+
+// TestQuerySpan_BaseTableUnaffectedByViewResolution guards that a plain base
+// table query is unchanged by the view post-pass.
+func TestQuerySpan_BaseTableUnaffectedByViewResolution(t *testing.T) {
+	span := viewLineageSpan(t, "SELECT phone FROM customer")
+	srcs := resultSources(t, span, "phone")
+	require.True(t, srcs[customerCol("phone")], "base customer.phone expected; got %+v", srcs)
+	require.Len(t, srcs, 1, "base-table lineage should be exactly customer.phone; got %+v", srcs)
+}

--- a/backend/plugin/parser/trino/query_span_view_test.go
+++ b/backend/plugin/parser/trino/query_span_view_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
 // viewLineageMetadata builds a catalog with a base table customer(id, phone,


### PR DESCRIPTION
## Summary

A column selected through a **view** (`SELECT phone FROM customer_v`) had lineage pointing at the *view* column. Masking config (semantic types) can only be attached to **table** columns — `SchemaCatalog` has no view catalog — so the masker found no masker for a view column and returned the (possibly sensitive) value **unmasked** (BYT-9679).

This adds a post-pass to the Trino query-span extractor that rewrites any source column resolving to a view into the **base-table columns the view projects**, computed by recursively analysing `view.Definition` (the same resolution the pg extractor performs via its view loader):

- Views over views resolve transitively; a definition cycle in malformed metadata is broken by an in-progress guard; projections are memoised.
- The projection is keyed by the view's **metadata** column names mapped **positionally** to the definition's analysed columns, so an explicit view column list (`CREATE VIEW v (ph) AS SELECT phone …`) resolves correctly.
- A view column that expands to multiple base columns (`phone || name`) is downgraded from a plain field.
- Non-view columns, and view columns that can't be resolved, are left untouched — lineage is only ever **deepened**, never dropped.

Once lineage points at the base table column, the **existing** `GetTable`-based masker path applies the configured masker — no masker change needed. `SELECT *` over a view keeps result order, so positional masking stays aligned. 7 regression tests; `go test ./backend/plugin/parser/trino/...` green.

## Cross-review

Reviewed with an independent agent (Codex). It confirmed the cycle guard terminates and found the explicit-column-list name-mismatch and the `IsPlainField` staleness, both fixed here.

## Dependency

A view **definition** that itself uses CTEs/derived tables resolves fully only once bytebase consumes the omni lineage resolver in **bytebase/omni#286**. With the currently pinned omni, such a definition resolves shallowly (no regression — the column is unmasked as it was before this change). Simple/expression view definitions resolve fully today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)