### PR TITLE
feat(parser/starrocks): route Engine_STARROCKS to the omni/starrocks fork (PR1)

### DIFF
--- a/backend/component/sheet/sheet.go
+++ b/backend/component/sheet/sheet.go
@@ -18,6 +18,7 @@ import (
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/redshift"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/snowflake"
+	_ "github.com/bytebase/bytebase/backend/plugin/parser/starrocks"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/tidb"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/tsql"
 )

--- a/backend/plugin/parser/doris/diagnose.go
+++ b/backend/plugin/parser/doris/diagnose.go
@@ -13,7 +13,6 @@ import (
 
 func init() {
 	base.RegisterDiagnoseFunc(storepb.Engine_DORIS, Diagnose)
-	base.RegisterDiagnoseFunc(storepb.Engine_STARROCKS, Diagnose)
 }
 
 // Diagnose returns syntax diagnostics for the given Doris statement.

--- a/backend/plugin/parser/doris/doris.go
+++ b/backend/plugin/parser/doris/doris.go
@@ -13,7 +13,6 @@ import (
 
 func init() {
 	base.RegisterParseStatementsFunc(storepb.Engine_DORIS, parseDorisStatements)
-	base.RegisterParseStatementsFunc(storepb.Engine_STARROCKS, parseDorisStatements)
 }
 
 // omniAST wraps an omni AST node to implement the base.AST interface.

--- a/backend/plugin/parser/doris/query.go
+++ b/backend/plugin/parser/doris/query.go
@@ -8,7 +8,6 @@ import (
 )
 
 func init() {
-	base.RegisterQueryValidator(storepb.Engine_STARROCKS, validateQuery)
 	base.RegisterQueryValidator(storepb.Engine_DORIS, validateQuery)
 }
 

--- a/backend/plugin/parser/doris/query_span.go
+++ b/backend/plugin/parser/doris/query_span.go
@@ -9,7 +9,6 @@ import (
 
 func init() {
 	base.RegisterGetQuerySpan(storepb.Engine_DORIS, GetQuerySpan)
-	base.RegisterGetQuerySpan(storepb.Engine_STARROCKS, GetQuerySpan)
 }
 
 func GetQuerySpan(

--- a/backend/plugin/parser/doris/split.go
+++ b/backend/plugin/parser/doris/split.go
@@ -10,7 +10,6 @@ import (
 )
 
 func init() {
-	base.RegisterSplitterFunc(storepb.Engine_STARROCKS, SplitSQL)
 	base.RegisterSplitterFunc(storepb.Engine_DORIS, SplitSQL)
 }
 

--- a/backend/plugin/parser/doris/statement_ranges.go
+++ b/backend/plugin/parser/doris/statement_ranges.go
@@ -15,7 +15,6 @@ import (
 
 func init() {
 	base.RegisterStatementRangesFunc(storepb.Engine_DORIS, GetStatementRanges)
-	base.RegisterStatementRangesFunc(storepb.Engine_STARROCKS, GetStatementRanges)
 }
 
 // GetStatementRanges returns the UTF-16 line/character ranges of statements

--- a/backend/plugin/parser/starrocks/diagnose.go
+++ b/backend/plugin/parser/starrocks/diagnose.go
@@ -1,0 +1,65 @@
+package starrocks
+
+import (
+	"context"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bytebase/omni/starrocks/parser"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func init() {
+	base.RegisterDiagnoseFunc(storepb.Engine_STARROCKS, Diagnose)
+}
+
+// Diagnose returns syntax diagnostics for the given Doris statement.
+// Surfaces genuine lex/parse errors from the omni parser, filtering out
+// the "not yet supported" stub messages from statement-dispatch fallthroughs.
+func Diagnose(_ context.Context, _ base.DiagnoseContext, statement string) ([]base.Diagnostic, error) {
+	diags := parser.Diagnose(statement)
+	out := make([]base.Diagnostic, 0, len(diags))
+	for _, d := range diags {
+		if strings.HasSuffix(d.Msg, "statement parsing is not yet supported") {
+			continue
+		}
+		// Convert byte offset to line/col position.
+		line, col := byteOffsetToLineCol(statement, d.Loc.Start)
+		syntaxErr := &base.SyntaxError{
+			Position: &storepb.Position{
+				Line:   int32(line),
+				Column: int32(col),
+			},
+			Message: d.Msg,
+		}
+		out = append(out, base.ConvertSyntaxErrorToDiagnostic(syntaxErr, statement))
+	}
+	return out, nil
+}
+
+// byteOffsetToLineCol returns the 1-based line and 1-based column for a byte
+// offset within the statement. Counts \n as line breaks. The 1-based column
+// matches the storepb.Position convention that ConvertSyntaxErrorToDiagnostic
+// expects (it subtracts 1 internally to land on the 0-based LSP offset).
+func byteOffsetToLineCol(s string, offset int) (int, int) {
+	if offset < 0 {
+		return 1, 1
+	}
+	if offset > len(s) {
+		offset = len(s)
+	}
+	line, col := 1, 1
+	for i := 0; i < offset; {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == '\n' {
+			line++
+			col = 1
+		} else {
+			col++
+		}
+		i += size
+	}
+	return line, col
+}

--- a/backend/plugin/parser/starrocks/query.go
+++ b/backend/plugin/parser/starrocks/query.go
@@ -1,0 +1,92 @@
+package starrocks
+
+import (
+	"github.com/bytebase/omni/starrocks/ast"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func init() {
+	base.RegisterQueryValidator(storepb.Engine_STARROCKS, validateQuery)
+}
+
+// validateQuery reports whether the given statement is a read-only query
+// suitable for the SQL editor / data-query path.
+//
+// Decision is AST-based: each parsed top-level statement must be a SELECT,
+// SHOW, DESCRIBE, EXPLAIN, or HELP. Relying on leading-keyword classification
+// alone would mis-accept CTE-prefixed DML such as `WITH x AS (...) UPDATE ...`,
+// which Classify would tag as SELECT because `WITH` is its first token.
+//
+// Syntax errors are surfaced up; that lets validateQueryRequest reject
+// malformed read-only SQL before execution.
+//
+// The (bool, bool, error) return shape matches the bytebase QueryValidator
+// contract: (isReadOnly, isExplicitReadOnly, syntaxError).
+func validateQuery(statement string) (bool, bool, error) {
+	parsed, err := parseStarRocksSQL(statement)
+	if err != nil {
+		return false, false, err
+	}
+	for _, p := range parsed {
+		if !isReadOnlyAST(p.Node()) {
+			return false, false, nil
+		}
+	}
+	return true, true, nil
+}
+
+// isReadOnlyAST returns true when the given top-level AST node represents a
+// read-only Doris statement (SELECT family, SHOW, DESCRIBE, EXPLAIN, HELP).
+//
+// Omni's parser currently has stub-shaped acceptance for some shapes — bare
+// `SHOW`, `DESCRIBE`, `EXPLAIN` all produce a corresponding AST node with
+// empty content rather than a parse error. We reject those here so the
+// previous ANTLR helper's behaviour (rejecting incomplete forms) is
+// preserved; the database would only reject them at execution time
+// otherwise.
+//
+// Nil nodes are conservatively rejected — they indicate a parse path that
+// produced no concrete statement, which shouldn't happen for valid read-only
+// SQL after parseStarRocksSQL succeeds.
+func isReadOnlyAST(node ast.Node) bool {
+	switch n := node.(type) {
+	case *ast.SelectStmt, *ast.SetOpStmt:
+		return true
+	case *ast.ShowStmt:
+		// Reject bare `SHOW` (Type is empty when the parser took the stub path
+		// without seeing a recognised variant keyword).
+		return n.Type != ""
+	case *ast.ShowRoutineLoadStmt, *ast.ShowRoutineLoadTaskStmt,
+		*ast.ShowJobStmt, *ast.ShowJobTaskStmt,
+		*ast.ShowConstraintsStmt, *ast.ShowAnalyzeStmt, *ast.ShowStatsStmt:
+		return true
+	case *ast.DescribeStmt:
+		// Reject bare `DESCRIBE` / `DESC` (Target nil means no table named).
+		return n.Target != nil
+	case *ast.ExplainStmt:
+		// EXPLAIN requires an inner query; the inner query must itself be a
+		// shape EXPLAIN is meaningful for (SELECT/DML/Show). This blocks
+		// inputs like `EXPLAIN`, `EXPLAIN DROP TABLE t`, etc.
+		return n.Query != nil && isExplainableInner(n.Query)
+	case *ast.HelpStmt:
+		return true
+	default:
+		return false
+	}
+}
+
+// isExplainableInner reports whether `node` is a shape that EXPLAIN can
+// legitimately wrap (SELECT family or DML). DDL inside EXPLAIN is rejected:
+// Doris only supports EXPLAIN on query and DML statements.
+func isExplainableInner(node ast.Node) bool {
+	switch node.(type) {
+	case *ast.SelectStmt, *ast.SetOpStmt:
+		return true
+	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt,
+		*ast.MergeStmt, *ast.TruncateTableStmt:
+		return true
+	}
+	return false
+}

--- a/backend/plugin/parser/starrocks/query_span.go
+++ b/backend/plugin/parser/starrocks/query_span.go
@@ -1,0 +1,27 @@
+package starrocks
+
+import (
+	"context"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func init() {
+	base.RegisterGetQuerySpan(storepb.Engine_STARROCKS, GetQuerySpan)
+}
+
+func GetQuerySpan(
+	ctx context.Context,
+	gCtx base.GetQuerySpanContext,
+	stmt base.Statement,
+	database, _ string,
+	ignoreCaseSensitive bool,
+) (*base.QuerySpan, error) {
+	q := newQuerySpanExtractor(database, gCtx, ignoreCaseSensitive)
+	querySpan, err := q.getQuerySpan(ctx, stmt.Text)
+	if err != nil {
+		return nil, err
+	}
+	return querySpan, nil
+}

--- a/backend/plugin/parser/starrocks/query_span_extractor.go
+++ b/backend/plugin/parser/starrocks/query_span_extractor.go
@@ -1,0 +1,185 @@
+package starrocks
+
+import (
+	"context"
+	"strings"
+
+	"github.com/bytebase/omni/starrocks/analysis"
+	"github.com/bytebase/omni/starrocks/ast"
+	"github.com/bytebase/omni/starrocks/parser"
+	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// querySpanExtractor analyses a single Doris statement and produces a
+// base.QuerySpan: the set of physical tables it reads and its classification
+// as a Select / SelectInfoSchema / DML / DDL statement.
+//
+// The extractor delegates the heavy lifting to omni's analysis.GetQuerySpan,
+// then applies bytebase-specific post-processing:
+//   - default-database fill-in for bare table references,
+//   - system-vs-user mixed-query rejection (MixUserSystemTablesError),
+//   - QueryType promotion to SelectInfoSchema when every accessed table is a
+//     system table (matching the legacy ANTLR listener behaviour).
+type querySpanExtractor struct {
+	ctx             context.Context
+	defaultDatabase string
+	gCtx            base.GetQuerySpanContext
+	// ctes tracks Common Table Expressions in the current scope. omni's
+	// GetQuerySpan already filters CTE references from AccessTables, but we
+	// keep the field to preserve the construction signature used by callers
+	// (and any future logic that needs it).
+	ctes                map[string]bool
+	ignoreCaseSensitive bool
+}
+
+func newQuerySpanExtractor(database string, gCtx base.GetQuerySpanContext, ignoreCaseSensitive bool) *querySpanExtractor {
+	return &querySpanExtractor{
+		defaultDatabase:     database,
+		gCtx:                gCtx,
+		ctes:                make(map[string]bool),
+		ignoreCaseSensitive: ignoreCaseSensitive,
+	}
+}
+
+func (q *querySpanExtractor) getQuerySpan(ctx context.Context, statement string) (*base.QuerySpan, error) {
+	q.ctx = ctx
+
+	// Split into top-level statements so we can reject inputs that contain
+	// multiple statements (matching the legacy behaviour) before doing any
+	// per-statement analysis.
+	stmts, err := SplitSQL(statement)
+	if err != nil {
+		return nil, err
+	}
+	nonEmpty := 0
+	var single string
+	for _, s := range stmts {
+		if s.Empty {
+			continue
+		}
+		nonEmpty++
+		single = s.Text
+	}
+	if nonEmpty == 0 {
+		return &base.QuerySpan{
+			SourceColumns: base.SourceColumnSet{},
+			Results:       []base.QuerySpanResult{},
+		}, nil
+	}
+	if nonEmpty > 1 {
+		return nil, errors.Errorf("expecting only one statement to get query span, but got %d", nonEmpty)
+	}
+
+	// omni's span walker only descends into SELECT/SetOp at the top level,
+	// so EXPLAIN <query> would return zero AccessTables. Unwrap an EXPLAIN
+	// to the inner statement's text before delegating; that way table-level
+	// ACL checks still see what the underlying query reads.
+	spanInput := unwrapExplainForSpan(single)
+
+	// Delegate to omni for table-access extraction + classification.
+	omniSpan, err := analysis.GetQuerySpan(spanInput)
+	if err != nil {
+		return nil, err
+	}
+
+	sources := q.toSourceColumnSet(omniSpan)
+
+	// Track CTE names omni discovered for callers that want to inspect them.
+	for _, name := range omniSpan.CTEs {
+		q.ctes[strings.ToLower(name)] = true
+	}
+
+	allSystems, mixed := isMixedQuery(sources, q.ignoreCaseSensitive)
+	if mixed {
+		return nil, base.MixUserSystemTablesError
+	}
+
+	queryType := getQueryType(single, allSystems)
+
+	return &base.QuerySpan{
+		Type:          queryType,
+		SourceColumns: sources,
+		Results:       []base.QuerySpanResult{},
+	}, nil
+}
+
+// unwrapExplainForSpan returns the inner statement's text when `statement`
+// parses to a top-level EXPLAIN; otherwise it returns the original string.
+//
+// omni's span walker only descends into SELECT/SetOp at the top level, so
+// without this unwrap an `EXPLAIN SELECT ... FROM t` would yield zero
+// AccessTables — table-level ACL checks need to see `t`.
+func unwrapExplainForSpan(statement string) string {
+	file, errs := parser.Parse(statement)
+	if len(errs) > 0 || file == nil || len(file.Stmts) == 0 {
+		return statement
+	}
+	explain, ok := file.Stmts[0].(*ast.ExplainStmt)
+	if !ok || explain.Query == nil {
+		return statement
+	}
+	inner := ast.NodeLoc(explain.Query)
+	if inner.Start < 0 || inner.End > len(statement) || inner.Start >= inner.End {
+		return statement
+	}
+	return statement[inner.Start:inner.End]
+}
+
+// toSourceColumnSet converts an omni QuerySpan's AccessTables into the
+// base.SourceColumnSet shape bytebase expects. Tables with no database
+// qualifier fall back to the extractor's default database.
+func (q *querySpanExtractor) toSourceColumnSet(span *analysis.QuerySpan) base.SourceColumnSet {
+	out := base.SourceColumnSet{}
+	if span == nil {
+		return out
+	}
+	for _, t := range span.AccessTables {
+		db := t.Database
+		if db == "" {
+			db = q.defaultDatabase
+		}
+		out[base.ColumnResource{
+			Database: db,
+			Table:    t.Table,
+		}] = true
+	}
+	return out
+}
+
+// isMixedQuery checks whether the query accesses the user table and system table at the same time.
+// It returns whether all tables are system tables and whether there is a mixture.
+func isMixedQuery(m base.SourceColumnSet, ignoreCaseSensitive bool) (bool, bool) {
+	hasSystem, hasUser := false, false
+	for table := range m {
+		if isSystemResource(table, ignoreCaseSensitive) {
+			hasSystem = true
+		} else {
+			hasUser = true
+		}
+	}
+
+	if hasSystem && hasUser {
+		return false, true
+	}
+
+	return !hasUser && hasSystem, false
+}
+
+// systemDatabases contains Doris system databases
+// Reference: https://doris.apache.org/docs/3.x/admin-manual/system-tables/overview
+var systemDatabases = map[string]bool{
+	"information_schema": true,
+	"mysql":              true,
+	"__internal_schema":  true,
+	"_statistics_":       true,
+}
+
+func isSystemResource(resource base.ColumnResource, ignoreCaseSensitive bool) bool {
+	database := resource.Database
+	if ignoreCaseSensitive {
+		database = strings.ToLower(database)
+	}
+	return systemDatabases[database]
+}

--- a/backend/plugin/parser/starrocks/query_span_extractor_cte_test.go
+++ b/backend/plugin/parser/starrocks/query_span_extractor_cte_test.go
@@ -1,0 +1,159 @@
+package starrocks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestQuerySpanExtractor_CTE(t *testing.T) {
+	tests := []struct {
+		name            string
+		sql             string
+		expectedTables  []base.ColumnResource
+		defaultDatabase string
+	}{
+		{
+			name: "CTE with JOIN between CTE and physical table",
+			sql: `WITH summary AS (
+				SELECT
+					user_id,
+					SUM(amount) as total_amount
+				FROM orders
+				WHERE created_at > '2024-01-01'
+				GROUP BY user_id
+			)
+			SELECT
+				u.id,
+				u.name,
+				s.total_amount
+			FROM summary s
+			LEFT JOIN users u ON s.user_id = u.id`,
+			expectedTables: []base.ColumnResource{
+				{Database: "test", Table: "orders"},
+				{Database: "test", Table: "users"},
+			},
+			defaultDatabase: "test",
+		},
+		{
+			name: "Multiple CTEs with cross-database tables",
+			sql: `WITH
+				cte1 AS (SELECT * FROM db1.table1),
+				cte2 AS (SELECT * FROM db2.table2 WHERE active = 1)
+			SELECT
+				c1.id,
+				c2.name
+			FROM cte1 c1
+			INNER JOIN cte2 c2 ON c1.ref_id = c2.id`,
+			expectedTables: []base.ColumnResource{
+				{Database: "db1", Table: "table1"},
+				{Database: "db2", Table: "table2"},
+			},
+			defaultDatabase: "test",
+		},
+		{
+			name: "Simple CTE",
+			sql: `WITH cte AS (SELECT * FROM users)
+SELECT * FROM cte`,
+			expectedTables: []base.ColumnResource{
+				{Database: "test", Table: "users"},
+			},
+			defaultDatabase: "test",
+		},
+		{
+			name: "Multiple CTEs",
+			sql: `WITH
+cte1 AS (SELECT * FROM table1),
+cte2 AS (SELECT * FROM table2)
+SELECT * FROM cte1 JOIN cte2`,
+			expectedTables: []base.ColumnResource{
+				{Database: "test", Table: "table1"},
+				{Database: "test", Table: "table2"},
+			},
+			defaultDatabase: "test",
+		},
+		{
+			name: "CTE shadowing table name",
+			sql: `WITH products AS (
+				SELECT p.*, c.name as category_name
+				FROM items p
+				JOIN categories c ON p.category_id = c.id
+			)
+			SELECT * FROM products WHERE category_name = 'Electronics'`,
+			expectedTables: []base.ColumnResource{
+				{Database: "test", Table: "items"},
+				{Database: "test", Table: "categories"},
+			},
+			defaultDatabase: "test",
+		},
+		{
+			name: "Nested CTEs",
+			sql: `WITH outer_cte AS (
+  WITH inner_cte AS (SELECT * FROM base_table)
+  SELECT * FROM inner_cte
+)
+SELECT * FROM outer_cte`,
+			expectedTables: []base.ColumnResource{
+				{Database: "test", Table: "base_table"},
+			},
+			defaultDatabase: "test",
+		},
+		{
+			name: "CTE referencing another CTE",
+			sql: `WITH
+				base_data AS (
+					SELECT id, name, department_id
+					FROM employees
+					WHERE active = true
+				),
+				dept_summary AS (
+					SELECT
+						d.name as dept_name,
+						COUNT(b.id) as emp_count
+					FROM base_data b
+					JOIN departments d ON b.department_id = d.id
+					GROUP BY d.name
+				)
+			SELECT * FROM dept_summary WHERE emp_count > 10`,
+			expectedTables: []base.ColumnResource{
+				{Database: "test", Table: "employees"},
+				{Database: "test", Table: "departments"},
+			},
+			defaultDatabase: "test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractor := newQuerySpanExtractor(tt.defaultDatabase, base.GetQuerySpanContext{}, false)
+			querySpan, err := extractor.getQuerySpan(context.Background(), tt.sql)
+			require.NoError(t, err)
+
+			// Convert SourceColumnSet to slice for comparison
+			var actualTables []base.ColumnResource
+			for table := range querySpan.SourceColumns {
+				actualTables = append(actualTables, table)
+			}
+
+			// Check that we have the expected number of tables
+			require.Equal(t, len(tt.expectedTables), len(actualTables),
+				"Expected %d tables but got %d", len(tt.expectedTables), len(actualTables))
+
+			// Check that all expected tables are present
+			for _, expected := range tt.expectedTables {
+				found := false
+				for _, actual := range actualTables {
+					if actual.Database == expected.Database && actual.Table == expected.Table {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "Expected table %s.%s not found in result",
+					expected.Database, expected.Table)
+			}
+		})
+	}
+}

--- a/backend/plugin/parser/starrocks/query_span_extractor_explain_test.go
+++ b/backend/plugin/parser/starrocks/query_span_extractor_explain_test.go
@@ -1,0 +1,59 @@
+package starrocks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestQuerySpanExtractor_ExplainUnwrap pins the behaviour that EXPLAIN
+// statements still surface the tables the underlying query reads — omni's
+// span walker only descends into top-level SELECT/SetOp, so without the
+// EXPLAIN unwrap in the extractor an `EXPLAIN SELECT ... FROM t` would
+// produce zero AccessTables and table-level ACL checks would not see `t`.
+func TestQuerySpanExtractor_ExplainUnwrap(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		expected []base.ColumnResource
+	}{
+		{
+			name:     "EXPLAIN SELECT exposes the SELECT's tables",
+			sql:      "EXPLAIN SELECT * FROM users",
+			expected: []base.ColumnResource{{Database: "test", Table: "users"}},
+		},
+		{
+			name:     "EXPLAIN VERBOSE SELECT exposes tables",
+			sql:      "EXPLAIN VERBOSE SELECT id FROM t1 JOIN t2 ON t1.id = t2.id",
+			expected: []base.ColumnResource{{Database: "test", Table: "t1"}, {Database: "test", Table: "t2"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractor := newQuerySpanExtractor("test", base.GetQuerySpanContext{}, false)
+			span, err := extractor.getQuerySpan(context.Background(), tt.sql)
+			require.NoError(t, err)
+
+			var got []base.ColumnResource
+			for table := range span.SourceColumns {
+				got = append(got, table)
+			}
+			require.Equal(t, len(tt.expected), len(got),
+				"expected %d tables, got %d (%v)", len(tt.expected), len(got), got)
+			for _, want := range tt.expected {
+				found := false
+				for _, g := range got {
+					if g.Database == want.Database && g.Table == want.Table {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "missing table %s.%s in %v", want.Database, want.Table, got)
+			}
+		})
+	}
+}

--- a/backend/plugin/parser/starrocks/query_span_extractor_system_table_test.go
+++ b/backend/plugin/parser/starrocks/query_span_extractor_system_table_test.go
@@ -1,0 +1,93 @@
+package starrocks
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/yamltest"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/store/model"
+)
+
+func TestGetQuerySpan_SystemTable(t *testing.T) {
+	type testCase struct {
+		Description     string `yaml:"description,omitempty"`
+		Statement       string `yaml:"statement,omitempty"`
+		DefaultDatabase string `yaml:"defaultDatabase,omitempty"`
+		// Metadata is the protojson encoded storepb.DatabaseSchemaMetadata,
+		// if it's empty, we will use the defaultDatabaseMetadata.
+		Metadata  string              `yaml:"metadata,omitempty"`
+		QuerySpan *base.YamlQuerySpan `yaml:"querySpan,omitempty"`
+	}
+
+	const (
+		record = false
+	)
+
+	var (
+		testDataPaths = []string{"test-data/query_span_system_table.yaml"}
+	)
+
+	a := require.New(t)
+	for _, testDataPath := range testDataPaths {
+		yamlFile, err := os.Open(testDataPath)
+		a.NoError(err)
+
+		var testCases []testCase
+		byteValue, err := io.ReadAll(yamlFile)
+		a.NoError(err)
+		a.NoError(yamlFile.Close())
+		a.NoError(yaml.Unmarshal(byteValue, &testCases))
+
+		for i, tc := range testCases {
+			metadata := &storepb.DatabaseSchemaMetadata{}
+			a.NoError(common.ProtojsonUnmarshaler.Unmarshal([]byte(tc.Metadata), metadata))
+			databaseMetadataGetter, databaseNameLister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{metadata})
+			result, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
+				GetDatabaseMetadataFunc: databaseMetadataGetter,
+				ListDatabaseNamesFunc:   databaseNameLister,
+			}, base.Statement{Text: tc.Statement}, tc.DefaultDatabase, "", false)
+			a.NoErrorf(err, "statement: %s", tc.Statement)
+			resultYaml := result.ToYaml()
+			if record {
+				testCases[i].QuerySpan = resultYaml
+			} else {
+				a.Equalf(tc.QuerySpan, resultYaml, "statement: %s", tc.Statement)
+			}
+		}
+
+		if record {
+			yamltest.Record(t, testDataPath, testCases)
+		}
+	}
+}
+
+func buildMockDatabaseMetadataGetter(databaseMetadata []*storepb.DatabaseSchemaMetadata) (base.GetDatabaseMetadataFunc, base.ListDatabaseNamesFunc) {
+	return func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
+			m := make(map[string]*model.DatabaseMetadata)
+			for _, metadata := range databaseMetadata {
+				// Doris is case-insensitive for most objects
+				m[metadata.Name] = model.NewDatabaseMetadata(metadata, nil, nil, storepb.Engine_MYSQL, false /* isObjectCaseSensitive */)
+			}
+
+			if databaseMetadata, ok := m[databaseName]; ok {
+				return "", databaseMetadata, nil
+			}
+
+			return "", nil, errors.Errorf("database %q not found", databaseName)
+		}, func(_ context.Context, _ string) ([]string, error) {
+			var names []string
+			for _, metadata := range databaseMetadata {
+				names = append(names, metadata.Name)
+			}
+			return names, nil
+		}
+}

--- a/backend/plugin/parser/starrocks/query_test.go
+++ b/backend/plugin/parser/starrocks/query_test.go
@@ -1,0 +1,172 @@
+package starrocks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateQuery(t *testing.T) {
+	tests := []struct {
+		statement   string
+		valid       bool
+		description string
+	}{
+		{
+			statement:   "SELECT * FROM users",
+			valid:       true,
+			description: "Basic SELECT query",
+		},
+		{
+			statement:   "SELECT * FROM users WHERE id = 1",
+			valid:       true,
+			description: "SELECT with WHERE clause",
+		},
+		{
+			statement:   "SHOW DATA",
+			valid:       true,
+			description: "SHOW DATA statement",
+		},
+		{
+			statement:   "SHOW DATA FROM db1",
+			valid:       true,
+			description: "SHOW DATA with FROM clause",
+		},
+		{
+			statement:   "SHOW DATABASES",
+			valid:       true,
+			description: "SHOW DATABASES statement",
+		},
+		{
+			statement:   "SHOW TABLES",
+			valid:       true,
+			description: "SHOW TABLES statement",
+		},
+		{
+			statement:   "SHOW TABLETS FROM table1",
+			valid:       true,
+			description: "SHOW TABLETS statement",
+		},
+		{
+			statement:   "SHOW VARIABLES",
+			valid:       true,
+			description: "SHOW VARIABLES statement",
+		},
+		{
+			statement:   "SHOW CREATE TABLE users",
+			valid:       true,
+			description: "SHOW CREATE TABLE statement",
+		},
+		{
+			statement:   "SHOW CREATE DATABASE db1",
+			valid:       true,
+			description: "SHOW CREATE DATABASE statement",
+		},
+		{
+			statement:   "INSERT INTO users (id, name) VALUES (1, 'test')",
+			valid:       false,
+			description: "INSERT statement should be invalid",
+		},
+		{
+			statement:   "UPDATE users SET name = 'test' WHERE id = 1",
+			valid:       false,
+			description: "UPDATE statement should be invalid",
+		},
+		{
+			statement:   "DELETE FROM users WHERE id = 1",
+			valid:       false,
+			description: "DELETE statement should be invalid",
+		},
+		{
+			statement:   "CREATE TABLE test (id INT)",
+			valid:       false,
+			description: "CREATE TABLE should be invalid",
+		},
+		{
+			statement:   "DROP TABLE users",
+			valid:       false,
+			description: "DROP TABLE should be invalid",
+		},
+		{
+			statement:   "EXPLAIN INSERT INTO users (id, name) VALUES (1, 'test')",
+			valid:       true,
+			description: "EXPLAIN INSERT should be valid (read-only)",
+		},
+		{
+			statement:   "EXPLAIN UPDATE users SET name = 'test' WHERE id = 1",
+			valid:       true,
+			description: "EXPLAIN UPDATE should be valid (read-only)",
+		},
+		{
+			statement:   "EXPLAIN DELETE FROM users WHERE id = 1",
+			valid:       true,
+			description: "EXPLAIN DELETE should be valid (read-only)",
+		},
+		{
+			statement:   "WITH c AS (SELECT 1) SELECT * FROM c",
+			valid:       true,
+			description: "CTE-prefixed SELECT is read-only",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			a := require.New(t)
+			valid, _, err := validateQuery(tc.statement)
+			a.NoError(err)
+			a.Equal(tc.valid, valid, "statement: %s", tc.statement)
+		})
+	}
+
+	// Cases that must fail validation — either because they're not read-only
+	// or because they don't parse. Both shapes flow through the same code
+	// path and must be rejected (either via valid=false or err!=nil).
+	rejectCases := []struct {
+		statement   string
+		description string
+	}{
+		{
+			// CTE-prefixed DML must NOT be accepted as read-only — the
+			// keyword-based Classify would have tagged it as SELECT because
+			// `WITH` is the leading keyword. AST-based validation catches it
+			// (or, currently, the omni parser rejects it as a syntax error;
+			// either rejection is acceptable).
+			statement:   "WITH c AS (SELECT 1) UPDATE t SET x = 1",
+			description: "CTE-prefixed UPDATE must be rejected",
+		},
+		{
+			statement:   "WITH c AS (SELECT 1) DELETE FROM t",
+			description: "CTE-prefixed DELETE must be rejected",
+		},
+		{
+			statement:   "SELECT a > (select max(a) from t1) FROM",
+			description: "Truncated SELECT must be rejected as syntax error",
+		},
+		{
+			// omni's stub parser accepts bare SHOW as *ast.ShowStmt with
+			// Type="". AST-content validation rejects it.
+			statement:   "SHOW",
+			description: "Bare SHOW must be rejected",
+		},
+		{
+			statement:   "DESCRIBE",
+			description: "Bare DESCRIBE must be rejected",
+		},
+		{
+			statement:   "EXPLAIN",
+			description: "Bare EXPLAIN must be rejected",
+		},
+		{
+			// EXPLAIN over DDL is not a real read-only operation.
+			statement:   "EXPLAIN DROP TABLE t",
+			description: "EXPLAIN over DDL must be rejected",
+		},
+	}
+	for _, tc := range rejectCases {
+		t.Run(tc.description, func(t *testing.T) {
+			a := require.New(t)
+			valid, _, err := validateQuery(tc.statement)
+			a.False(valid && err == nil, "expected rejection, statement: %s", tc.statement)
+		})
+	}
+}

--- a/backend/plugin/parser/starrocks/query_type.go
+++ b/backend/plugin/parser/starrocks/query_type.go
@@ -1,0 +1,103 @@
+package starrocks
+
+import (
+	"github.com/bytebase/omni/starrocks/analysis"
+	"github.com/bytebase/omni/starrocks/ast"
+	"github.com/bytebase/omni/starrocks/parser"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// getQueryType classifies a single statement.
+//
+// Uses AST inspection where possible — keyword-based Classify alone would
+// mislabel CTE-prefixed DML (`WITH ... UPDATE ...`) as Select because `WITH`
+// is its first token, which would propagate into ACL checks. AST inspection
+// surfaces the real operation. If parsing fails or produces no statements
+// (e.g. comment-only input), we fall back to the keyword-based classifier so
+// callers still receive a best-effort classification.
+//
+// allSystems is the flag computed by the query-span extractor that indicates
+// whether every accessed table belongs to a system database. When true and
+// the resolved type is a user SELECT, the result is promoted to
+// SelectInfoSchema to match the legacy ANTLR listener behaviour.
+//
+// EXPLAIN-prefixed statements defer to the inner statement's type — an
+// `EXPLAIN DROP TABLE t` classifies as DDL, not Select, so type-based ACL
+// checks see the inner operation rather than a downgrade-to-read-only.
+func getQueryType(statement string, allSystems bool) base.QueryType {
+	qt := classifyByAST(statement)
+
+	switch qt {
+	case analysis.QueryTypeSelect:
+		if allSystems {
+			return base.SelectInfoSchema
+		}
+		return base.Select
+	case analysis.QueryTypeSelectInfoSchema:
+		return base.SelectInfoSchema
+	case analysis.QueryTypeDML:
+		return base.DML
+	case analysis.QueryTypeDDL:
+		return base.DDL
+	default:
+		return base.QueryTypeUnknown
+	}
+}
+
+// classifyByAST parses the statement and inspects the first top-level AST
+// node. On parse failure or empty input it falls back to the keyword-based
+// Classify.
+func classifyByAST(statement string) analysis.QueryType {
+	file, errs := parser.Parse(statement)
+	if len(errs) > 0 || file == nil || len(file.Stmts) == 0 {
+		return analysis.Classify(statement)
+	}
+	if qt, ok := astQueryType(file.Stmts[0]); ok {
+		return qt
+	}
+	return analysis.Classify(statement)
+}
+
+// astQueryType maps a top-level AST node to its QueryType. The bool return
+// is false only when the node was nil-shaped (e.g. EXPLAIN with no inner
+// Query); callers should fall back to Classify in that case.
+//
+// EXPLAIN recurses into its inner Query so the classification reflects the
+// real operation (e.g. `EXPLAIN DROP TABLE t` → DDL).
+//
+// Anything we don't otherwise enumerate is treated as DDL — that's a safe
+// upper bound for ACL purposes (it won't accidentally label a write as
+// read-only) and matches the legacy listener's "everything else is DDL"
+// behaviour.
+func astQueryType(node ast.Node) (analysis.QueryType, bool) {
+	if node == nil {
+		return 0, false
+	}
+	switch n := node.(type) {
+	case *ast.SelectStmt, *ast.SetOpStmt:
+		return analysis.QueryTypeSelect, true
+	case *ast.ShowStmt,
+		*ast.ShowRoutineLoadStmt, *ast.ShowRoutineLoadTaskStmt,
+		*ast.ShowJobStmt, *ast.ShowJobTaskStmt,
+		*ast.ShowConstraintsStmt, *ast.ShowAnalyzeStmt, *ast.ShowStatsStmt:
+		return analysis.QueryTypeSelectInfoSchema, true
+	case *ast.DescribeStmt, *ast.HelpStmt:
+		return analysis.QueryTypeSelectInfoSchema, true
+	case *ast.ExplainStmt:
+		if n.Query == nil {
+			return 0, false
+		}
+		return astQueryType(n.Query)
+	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt,
+		*ast.MergeStmt, *ast.TruncateTableStmt:
+		return analysis.QueryTypeDML, true
+	case *ast.UseStmt:
+		// USE was rejected as Unknown by the legacy listener — its ACL flow
+		// treats Unknown as a hard deny while DDL is permitted via
+		// bb.sql.ddl. Keep the classification at Unknown so users with DDL
+		// rights cannot run USE.
+		return analysis.QueryTypeUnknown, true
+	}
+	return analysis.QueryTypeDDL, true
+}

--- a/backend/plugin/parser/starrocks/query_type_test.go
+++ b/backend/plugin/parser/starrocks/query_type_test.go
@@ -1,0 +1,98 @@
+package starrocks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestGetQueryType(t *testing.T) {
+	tests := []struct {
+		statement string
+		want      base.QueryType
+	}{
+		{
+			statement: "SELECT * FROM users",
+			want:      base.Select,
+		},
+		{
+			statement: "INSERT INTO users (id, name) VALUES (1, 'test')",
+			want:      base.DML,
+		},
+		{
+			statement: "UPDATE users SET name = 'test' WHERE id = 1",
+			want:      base.DML,
+		},
+		{
+			statement: "DELETE FROM users WHERE id = 1",
+			want:      base.DML,
+		},
+		{
+			statement: "CREATE TABLE test (id INT)",
+			want:      base.DDL,
+		},
+		{
+			statement: "SHOW DATABASES",
+			want:      base.SelectInfoSchema,
+		},
+		{
+			statement: "SHOW TABLES",
+			want:      base.SelectInfoSchema,
+		},
+		{
+			statement: "SHOW DATA",
+			want:      base.SelectInfoSchema,
+		},
+		{
+			statement: "SHOW DATA FROM db1",
+			want:      base.SelectInfoSchema,
+		},
+		{
+			statement: "SHOW TABLETS FROM table1",
+			want:      base.SelectInfoSchema,
+		},
+		{
+			statement: "SHOW VARIABLES",
+			want:      base.SelectInfoSchema,
+		},
+		{
+			statement: "SHOW CREATE TABLE users",
+			want:      base.SelectInfoSchema,
+		},
+		{
+			// EXPLAIN over a query is read-only.
+			statement: "EXPLAIN SELECT * FROM users",
+			want:      base.Select,
+		},
+		{
+			// EXPLAIN defers to the inner statement's type — EXPLAIN over
+			// DML is classified as DML for ACL purposes, not Select.
+			statement: "EXPLAIN INSERT INTO users (id) VALUES (1)",
+			want:      base.DML,
+		},
+		{
+			// EXPLAIN over DDL is DDL, not a read-only downgrade.
+			statement: "EXPLAIN DROP TABLE users",
+			want:      base.DDL,
+		},
+		{
+			// USE is intentionally Unknown so ACL rejects it as a hard
+			// deny rather than authorising it under bb.sql.ddl.
+			statement: "USE db1",
+			want:      base.QueryTypeUnknown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.statement, func(t *testing.T) {
+			a := require.New(t)
+			extractor := newQuerySpanExtractor("testdb", base.GetQuerySpanContext{}, false)
+			result, err := extractor.getQuerySpan(context.Background(), tc.statement)
+			a.NoError(err)
+			a.Equal(tc.want, result.Type, "statement: %s", tc.statement)
+		})
+	}
+}

--- a/backend/plugin/parser/starrocks/split.go
+++ b/backend/plugin/parser/starrocks/split.go
@@ -1,0 +1,90 @@
+package starrocks
+
+import (
+	"unicode/utf8"
+
+	"github.com/bytebase/omni/starrocks/parser"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func init() {
+	base.RegisterSplitterFunc(storepb.Engine_STARROCKS, SplitSQL)
+}
+
+// SplitSQL splits the input into multiple SQL statements using the omni
+// Doris splitter, then converts each Segment into a base.Statement with
+// the position fields bytebase expects.
+//
+// Positions are computed in a single O(n) pass over the input.
+func SplitSQL(statement string) ([]base.Statement, error) {
+	segs := parser.Split(statement)
+	if len(segs) == 0 {
+		return nil, nil
+	}
+
+	type pos struct{ line, col int }
+	positions := make(map[int]pos, len(segs)*3)
+	for _, seg := range segs {
+		positions[seg.ByteStart] = pos{}
+		positions[seg.ByteEnd] = pos{}
+		// Also collect position immediately past the trailing ';' for End column.
+		if seg.ByteEnd < len(statement) && statement[seg.ByteEnd] == ';' {
+			positions[seg.ByteEnd+1] = pos{}
+		}
+	}
+
+	line, col := 1, 1
+	for i := 0; i <= len(statement); {
+		if _, need := positions[i]; need {
+			positions[i] = pos{line, col}
+		}
+		if i == len(statement) {
+			break
+		}
+		r, size := utf8.DecodeRuneInString(statement[i:])
+		if r == '\n' {
+			line++
+			col = 1
+		} else {
+			col++
+		}
+		i += size
+	}
+
+	stmts := make([]base.Statement, 0, len(segs))
+	for _, seg := range segs {
+		// bytebase historically returns Text including the trailing ';' delimiter
+		// (when present). omni's Segment.Text excludes it, so we re-attach when
+		// the byte after ByteEnd is ';'.
+		text := seg.Text
+		end := seg.ByteEnd
+		if end < len(statement) && statement[end] == ';' {
+			text = statement[seg.ByteStart : end+1]
+			end++
+		}
+		sp := positions[seg.ByteStart]
+		ep, ok := positions[end]
+		if !ok {
+			ep = positions[seg.ByteEnd]
+		}
+		stmts = append(stmts, base.Statement{
+			Text:  text,
+			Empty: seg.Empty(),
+			Start: &storepb.Position{
+				Line:   int32(sp.line),
+				Column: int32(sp.col),
+			},
+			End: &storepb.Position{
+				Line:   int32(ep.line),
+				Column: int32(ep.col),
+			},
+			Range: &storepb.Range{
+				Start: int32(seg.ByteStart),
+				End:   int32(end),
+			},
+		})
+	}
+	return stmts, nil
+}

--- a/backend/plugin/parser/starrocks/split_test.go
+++ b/backend/plugin/parser/starrocks/split_test.go
@@ -1,0 +1,13 @@
+package starrocks
+
+import (
+	"testing"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestStarRocksSplitSQL(t *testing.T) {
+	base.RunSplitTests(t, "test-data/test_split.yaml", base.SplitTestOptions{
+		SplitFunc: SplitSQL,
+	})
+}

--- a/backend/plugin/parser/starrocks/starrocks.go
+++ b/backend/plugin/parser/starrocks/starrocks.go
@@ -1,0 +1,158 @@
+package starrocks
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/bytebase/omni/starrocks/ast"
+	"github.com/bytebase/omni/starrocks/parser"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func init() {
+	base.RegisterParseStatementsFunc(storepb.Engine_STARROCKS, parseStarRocksStatements)
+}
+
+// omniAST wraps an omni AST node to implement the base.AST interface.
+type omniAST struct {
+	node     ast.Node
+	startPos *storepb.Position
+}
+
+// ASTStartPosition implements base.AST.
+func (a *omniAST) ASTStartPosition() *storepb.Position {
+	return a.startPos
+}
+
+// Node returns the underlying omni AST node. May be nil if the segment
+// failed to parse cleanly but errors were tolerated by the caller.
+func (a *omniAST) Node() ast.Node {
+	return a.node
+}
+
+// parseStarRocksStatements is the ParseStatementsFunc for StarRocks.
+// Returns []ParsedStatement with both text and AST populated.
+//
+// For non-empty segments, the AST is an *omniAST wrapping the omni AST node.
+// The first parse error encountered (per-segment) is returned to the caller,
+// matching the prior behaviour of bailing out on the first syntax error.
+func parseStarRocksStatements(statement string) ([]base.ParsedStatement, error) {
+	stmts, err := SplitSQL(statement)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]base.ParsedStatement, 0, len(stmts))
+	for _, stmt := range stmts {
+		ps := base.ParsedStatement{
+			Statement: stmt,
+		}
+		if stmt.Empty || strings.TrimSpace(stmt.Text) == "" {
+			result = append(result, ps)
+			continue
+		}
+		// Parse the segment text on its own so byte offsets in any ParseError
+		// align with stmt.Text; convertParseError then shifts them into the
+		// coordinates of the original multi-statement script.
+		file, errs := parser.Parse(stmt.Text)
+		if len(errs) > 0 {
+			pe := errs[0]
+			return nil, convertParseError(stmt.Text, &pe, stmt.Start)
+		}
+		var node ast.Node
+		if file != nil && len(file.Stmts) > 0 {
+			node = file.Stmts[0]
+		}
+		ps.AST = &omniAST{
+			node:     node,
+			startPos: stmt.Start,
+		}
+		result = append(result, ps)
+	}
+
+	return result, nil
+}
+
+// parseStarRocksSQL parses the given SQL statement using the omni Doris parser.
+// Returns one *omniAST per non-empty segment (empty / comment-only segments
+// are skipped).
+//
+// This retains the historical signature shape used by other doris package
+// files; on the first parse error it returns a *base.SyntaxError with the
+// position translated into the coordinates of the original input.
+func parseStarRocksSQL(statement string) ([]*omniAST, error) {
+	stmts, err := SplitSQL(statement)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []*omniAST
+	for _, stmt := range stmts {
+		if stmt.Empty || strings.TrimSpace(stmt.Text) == "" {
+			continue
+		}
+		file, errs := parser.Parse(stmt.Text)
+		if len(errs) > 0 {
+			pe := errs[0]
+			return nil, convertParseError(stmt.Text, &pe, stmt.Start)
+		}
+		var node ast.Node
+		if file != nil && len(file.Stmts) > 0 {
+			node = file.Stmts[0]
+		}
+		result = append(result, &omniAST{
+			node:     node,
+			startPos: stmt.Start,
+		})
+	}
+	return result, nil
+}
+
+// convertParseError converts an omni *parser.ParseError to a
+// *base.SyntaxError that sql_service.go recognises for structured
+// error diagnostics. It converts the byte offset in ParseError.Loc
+// to 1-based line and 1-based column (rune-based) matching the
+// storepb.Position convention used across other omni parser adapters.
+//
+// If basePos is non-nil, the computed position is offset by it so that
+// errors from parsing an isolated statement segment are reported in the
+// coordinates of the original multi-statement script.
+func convertParseError(statement string, pe *parser.ParseError, basePos *storepb.Position) *base.SyntaxError {
+	line, col := byteOffsetToPosition(statement, pe.Loc.Start)
+	if basePos != nil {
+		// The first line of the segment shares a line with basePos, so
+		// column offsets only apply when the error is on that line.
+		if line == 1 {
+			col = int(basePos.Column) + col - 1
+		}
+		line = int(basePos.Line) + line - 1
+	}
+	return &base.SyntaxError{
+		Position: &storepb.Position{
+			Line:   int32(line),
+			Column: int32(col),
+		},
+		Message:    pe.Error(),
+		RawMessage: pe.Msg,
+	}
+}
+
+// byteOffsetToPosition converts a 0-based byte offset to a 1-based line and
+// 1-based column (in runes).
+func byteOffsetToPosition(s string, offset int) (line, col int) {
+	line = 1
+	col = 1
+	for i := 0; i < offset && i < len(s); {
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == '\n' {
+			line++
+			col = 1
+		} else {
+			col++
+		}
+		i += size
+	}
+	return line, col
+}

--- a/backend/plugin/parser/starrocks/starrocks_e2e_test.go
+++ b/backend/plugin/parser/starrocks/starrocks_e2e_test.go
@@ -1,0 +1,57 @@
+package starrocks
+
+import (
+	"context"
+	"testing"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestStarRocksDiagnoseE2E is the PR1 keystone (BYT-9140): it proves the
+// Engine_STARROCKS parse path is re-routed from the doris parser to the
+// omni/starrocks fork end-to-end, through the Bytebase diagnose dispatcher.
+//
+//   - value: a StarRocks generated column `AS (expr)` (which doris rejects as a
+//     false syntax error) now diagnoses clean.
+//   - zero-regression: shared-core statements still diagnose clean.
+//   - diagnose still works: a genuinely-invalid statement still reports an error.
+func TestStarRocksDiagnoseE2E(t *testing.T) {
+	cases := []struct {
+		name     string
+		sql      string
+		wantDiag bool
+	}{
+		{
+			"generated_column_as", // value: doris rejected this; the fork accepts it
+			"CREATE TABLE t (a INT, b INT AS (a + 1)) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a)",
+			false,
+		},
+		{
+			"shared_core_create_table", // zero-regression
+			"CREATE TABLE t (k INT, v VARCHAR(20)) DUPLICATE KEY(k) DISTRIBUTED BY HASH(k) BUCKETS 1",
+			false,
+		},
+		{
+			"shared_core_select", // zero-regression
+			"SELECT a, b FROM t WHERE a > 0",
+			false,
+		},
+		{
+			"invalid_statement", // diagnose still catches real syntax errors
+			"SELECT FROM WHERE",
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diags, err := base.Diagnose(context.Background(), base.DiagnoseContext{}, storepb.Engine_STARROCKS, tc.sql)
+			if err != nil {
+				t.Fatalf("Diagnose error: %v", err)
+			}
+			if got := len(diags) > 0; got != tc.wantDiag {
+				t.Fatalf("Diagnose(%q): hasDiagnostic=%v, want %v (diags=%+v)", tc.sql, got, tc.wantDiag, diags)
+			}
+		})
+	}
+}

--- a/backend/plugin/parser/starrocks/starrocks_test.go
+++ b/backend/plugin/parser/starrocks/starrocks_test.go
@@ -1,0 +1,38 @@
+package starrocks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStarRocksSQLParser(t *testing.T) {
+	tests := []struct {
+		statement    string
+		errorMessage string
+	}{
+		{
+			statement: "SELECT * FROM person LATERAL VIEW EXPLODE(ARRAY(30, 60)) tableName AS c_age;",
+		},
+		{
+			statement: "SELECT * FROM schema1.t1 JOIN schema2.t2 ON t1.c1 = t2.c1",
+		},
+		{
+			// Truncated SELECT — must be reported as a syntax error.
+			statement:    "SELECT a > (select max(a) from t1) FROM",
+			errorMessage: "syntax error at end of input",
+		},
+	}
+
+	for _, test := range tests {
+		res, err := parseStarRocksSQL(test.statement)
+		if test.errorMessage == "" {
+			require.NoError(t, err)
+			require.NotEmpty(t, res)
+			require.NotNil(t, res[0].Node())
+		} else {
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.errorMessage)
+		}
+	}
+}

--- a/backend/plugin/parser/starrocks/statement_ranges.go
+++ b/backend/plugin/parser/starrocks/statement_ranges.go
@@ -1,0 +1,267 @@
+package starrocks
+
+import (
+	"context"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	protocol "github.com/bytebase/lsp-protocol"
+	"github.com/bytebase/omni/starrocks/parser"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func init() {
+	base.RegisterStatementRangesFunc(storepb.Engine_STARROCKS, GetStatementRanges)
+}
+
+// GetStatementRanges returns the UTF-16 line/character ranges of statements
+// in the input, formatted for the LSP protocol. Empty (whitespace-only)
+// segments are skipped, and ranges include the trailing semicolon when present
+// to match the prior ANTLR-based behaviour.
+func GetStatementRanges(_ context.Context, _ base.StatementRangeContext, statement string) ([]base.Range, error) {
+	trimmed := strings.TrimRightFunc(statement, unicode.IsSpace)
+
+	segs := parser.Split(trimmed)
+	if len(segs) == 0 {
+		// omni's splitter drops comment-only buffers entirely. The legacy
+		// ANTLR helper still emitted a range for trailing comment tokens, so
+		// editor features that count statement positions don't lose ground
+		// to a file that contains only `-- note` or `/* ... */`. Emit a
+		// single range covering the non-whitespace span when present.
+		return commentOnlyRanges(trimmed), nil
+	}
+
+	type pos struct{ line, char uint32 }
+	wanted := make(map[int]pos, len(segs)*3)
+	for _, seg := range segs {
+		wanted[seg.ByteStart] = pos{}
+		wanted[seg.ByteEnd] = pos{}
+		if seg.ByteEnd < len(trimmed) && trimmed[seg.ByteEnd] == ';' {
+			wanted[seg.ByteEnd+1] = pos{}
+		}
+	}
+
+	var line, char uint32
+	for i := 0; i <= len(trimmed); {
+		if _, need := wanted[i]; need {
+			wanted[i] = pos{line, char}
+		}
+		if i == len(trimmed) {
+			break
+		}
+		r, size := utf8.DecodeRuneInString(trimmed[i:])
+		if r == '\n' {
+			line++
+			char = 0
+		} else if r <= 0xFFFF {
+			char++
+		} else {
+			char += 2 // UTF-16 surrogate pair
+		}
+		i += size
+	}
+
+	ranges := make([]base.Range, 0, len(segs))
+	for _, seg := range segs {
+		// Skip pure whitespace segments, but preserve comment-only segments
+		// (the legacy ANTLR helper emits ranges for trailing comment tokens).
+		if seg.Empty() && !hasNonWhitespace(trimmed[seg.ByteStart:seg.ByteEnd]) {
+			continue
+		}
+		// Skip only leading whitespace — leading comments are kept inside the
+		// range to match the prior ANTLR-helper behaviour, which includes
+		// hidden-channel tokens but excludes pure whitespace.
+		trimStart := seg.ByteStart
+		for trimStart < seg.ByteEnd {
+			c := trimmed[trimStart]
+			if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+				trimStart++
+				continue
+			}
+			break
+		}
+		if _, ok := wanted[trimStart]; !ok {
+			startPos := wanted[seg.ByteStart]
+			l, c := startPos.line, startPos.char
+			for i := seg.ByteStart; i < trimStart; {
+				r, size := utf8.DecodeRuneInString(trimmed[i:])
+				if r == '\n' {
+					l++
+					c = 0
+				} else if r <= 0xFFFF {
+					c++
+				} else {
+					c += 2
+				}
+				i += size
+			}
+			wanted[trimStart] = pos{l, c}
+		}
+		startPos, ok := wanted[trimStart]
+		if !ok {
+			// trimStart wasn't pre-collected; fall back to ByteStart.
+			startPos = wanted[seg.ByteStart]
+		}
+		end := seg.ByteEnd
+		if end < len(trimmed) && trimmed[end] == ';' {
+			end++
+		}
+		endPos := wanted[end]
+		ranges = append(ranges, base.Range{
+			Start: protocol.Position{Line: startPos.line, Character: startPos.char},
+			End:   protocol.Position{Line: endPos.line, Character: endPos.char},
+		})
+	}
+	// Trailing comment-only content: omni's Split filters out comment-only
+	// segments, so any non-whitespace bytes between the last segment's end
+	// and the end of the trimmed input would otherwise be lost. The legacy
+	// ANTLR helper emits a final range for these — replicate that.
+	if len(segs) > 0 {
+		last := segs[len(segs)-1]
+		tailStart := last.ByteEnd
+		if tailStart < len(trimmed) && trimmed[tailStart] == ';' {
+			tailStart++
+		}
+		// Find first non-whitespace byte after tailStart.
+		i := tailStart
+		for i < len(trimmed) {
+			c := trimmed[i]
+			if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+				break
+			}
+			i++
+		}
+		if i < len(trimmed) {
+			// There's a trailing comment / non-whitespace chunk. Emit a range.
+			if _, ok := wanted[i]; !ok {
+				startPos := wanted[tailStart]
+				l, c := startPos.line, startPos.char
+				for j := tailStart; j < i; {
+					r, size := utf8.DecodeRuneInString(trimmed[j:])
+					if r == '\n' {
+						l++
+						c = 0
+					} else if r <= 0xFFFF {
+						c++
+					} else {
+						c += 2
+					}
+					j += size
+				}
+				wanted[i] = pos{l, c}
+			}
+			startPos := wanted[i]
+			endPos := pos{startPos.line, startPos.char}
+			for j := i; j < len(trimmed); {
+				r, size := utf8.DecodeRuneInString(trimmed[j:])
+				if r == '\n' {
+					endPos.line++
+					endPos.char = 0
+				} else if r <= 0xFFFF {
+					endPos.char++
+				} else {
+					endPos.char += 2
+				}
+				j += size
+			}
+			ranges = append(ranges, base.Range{
+				Start: protocol.Position{Line: startPos.line, Character: startPos.char},
+				End:   protocol.Position{Line: endPos.line, Character: endPos.char},
+			})
+		}
+	}
+
+	return ranges, nil
+}
+
+// commentOnlyRanges emits a single Range covering the non-whitespace span of
+// `trimmed`, or nil when nothing in `trimmed` looks like a comment. Used
+// when the splitter finds zero segments — typically that means comment-only
+// input like `-- note` or `/* ... */`, which the legacy ANTLR helper would
+// have emitted a range for. Pure delimiters (e.g. a single `;`) are NOT
+// turned into ranges; the legacy helper dropped single-terminator inputs.
+func commentOnlyRanges(trimmed string) []base.Range {
+	if !containsCommentMarker(trimmed) {
+		return nil
+	}
+	start := 0
+	for start < len(trimmed) {
+		c := trimmed[start]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			start++
+			continue
+		}
+		break
+	}
+	if start >= len(trimmed) {
+		return nil
+	}
+	var startLine, startChar uint32
+	for i := 0; i < start; {
+		r, size := utf8.DecodeRuneInString(trimmed[i:])
+		if r == '\n' {
+			startLine++
+			startChar = 0
+		} else if r <= 0xFFFF {
+			startChar++
+		} else {
+			startChar += 2
+		}
+		i += size
+	}
+	endLine, endChar := startLine, startChar
+	for i := start; i < len(trimmed); {
+		r, size := utf8.DecodeRuneInString(trimmed[i:])
+		if r == '\n' {
+			endLine++
+			endChar = 0
+		} else if r <= 0xFFFF {
+			endChar++
+		} else {
+			endChar += 2
+		}
+		i += size
+	}
+	return []base.Range{{
+		Start: protocol.Position{Line: startLine, Character: startChar},
+		End:   protocol.Position{Line: endLine, Character: endChar},
+	}}
+}
+
+// containsCommentMarker reports whether s contains one of the SQL comment
+// introducers (`--`, `/*`, `#`). Anything inside a string literal could
+// false-positive, but the splitter only routes us here when there are
+// no segments at all — i.e. no string literals to worry about.
+func containsCommentMarker(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '#' {
+			return true
+		}
+		if i+1 < len(s) {
+			if c == '-' && s[i+1] == '-' {
+				return true
+			}
+			if c == '/' && s[i+1] == '*' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// hasNonWhitespace reports whether s contains any non-whitespace character.
+// Used to detect comment-only segments (omni's Segment.Empty() treats them
+// as empty since they contain no SQL tokens, but bytebase wants their ranges).
+func hasNonWhitespace(s string) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+			return true
+		}
+	}
+	return false
+}

--- a/backend/plugin/parser/starrocks/statement_ranges_test.go
+++ b/backend/plugin/parser/starrocks/statement_ranges_test.go
@@ -1,0 +1,61 @@
+package starrocks
+
+import (
+	"context"
+	"io"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/bytebase/bytebase/backend/common/yamltest"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func TestGetStatementRange(t *testing.T) {
+	type testCase struct {
+		Statement string       `yaml:"statement,omitempty"`
+		Expected  []base.Range `yaml:"ranges,omitempty"`
+	}
+
+	const (
+		record      = false
+		testDataDir = "test-data/statement-ranges"
+	)
+	a := require.New(t)
+
+	// Recursively find all YAML files in the testDataDir
+	entries, err := os.ReadDir(testDataDir)
+	a.NoError(err)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		filepath := path.Join(testDataDir, entry.Name())
+		yamlFile, err := os.Open(filepath)
+		a.NoError(err)
+		var testCases []testCase
+		byteValue, err := io.ReadAll(yamlFile)
+		a.NoError(err)
+		a.NoError(yamlFile.Close())
+		a.NoError(yaml.Unmarshal(byteValue, &testCases))
+		for i, tc := range testCases {
+			if tc.Statement == "" {
+				continue
+			}
+			ranges, err := GetStatementRanges(context.TODO(), base.StatementRangeContext{}, tc.Statement)
+			a.NoError(err)
+			if record {
+				testCases[i].Expected = ranges
+			} else {
+				a.Equal(tc.Expected, ranges, "statement: %s", tc.Statement)
+			}
+		}
+
+		if record {
+			yamltest.Record(t, filepath, testCases)
+		}
+	}
+}

--- a/backend/plugin/parser/starrocks/test-data/query_span_system_table.yaml
+++ b/backend/plugin/parser/starrocks/test-data/query_span_system_table.yaml
@@ -1,0 +1,107 @@
+- description: Query information_schema.tables
+  statement: SELECT * FROM information_schema.tables
+  defaultDatabase: testdb
+  metadata: '{}'
+  querySpan:
+    type: 3
+    results: []
+    sourcecolumns:
+        - server: ""
+          database: information_schema
+          schema: ""
+          table: tables
+          column: ""
+    predicatecolumns: []
+- description: Query information_schema.columns with WHERE clause
+  statement: SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'testdb'
+  defaultDatabase: testdb
+  metadata: '{}'
+  querySpan:
+    type: 3
+    results: []
+    sourcecolumns:
+        - server: ""
+          database: information_schema
+          schema: ""
+          table: columns
+          column: ""
+    predicatecolumns: []
+- description: Query _statistics_ database
+  statement: SELECT * FROM _statistics_.table_statistics
+  defaultDatabase: testdb
+  metadata: '{}'
+  querySpan:
+    type: 3
+    results: []
+    sourcecolumns:
+        - server: ""
+          database: _statistics_
+          schema: ""
+          table: table_statistics
+          column: ""
+    predicatecolumns: []
+- description: Query mysql database
+  statement: SELECT * FROM mysql.user
+  defaultDatabase: testdb
+  metadata: '{}'
+  querySpan:
+    type: 3
+    results: []
+    sourcecolumns:
+        - server: ""
+          database: mysql
+          schema: ""
+          table: user
+          column: ""
+    predicatecolumns: []
+- description: Query __internal_schema database
+  statement: SELECT * FROM __internal_schema.audit_log
+  defaultDatabase: testdb
+  metadata: '{}'
+  querySpan:
+    type: 3
+    results: []
+    sourcecolumns:
+        - server: ""
+          database: __internal_schema
+          schema: ""
+          table: audit_log
+          column: ""
+    predicatecolumns: []
+- description: Query user table
+  statement: SELECT * FROM users
+  defaultDatabase: testdb
+  metadata: |-
+    {
+      "name": "testdb",
+      "schemas": [
+        {
+          "name": "",
+          "tables": [
+            {
+              "name": "users",
+              "columns": [
+                {
+                  "name": "id",
+                  "position": 1
+                },
+                {
+                  "name": "name",
+                  "position": 2
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  querySpan:
+    type: 1
+    results: []
+    sourcecolumns:
+        - server: ""
+          database: testdb
+          schema: ""
+          table: users
+          column: ""
+    predicatecolumns: []

--- a/backend/plugin/parser/starrocks/test-data/statement-ranges/doris-features.yaml
+++ b/backend/plugin/parser/starrocks/test-data/statement-ranges/doris-features.yaml
@@ -1,0 +1,162 @@
+- statement: |-
+    -- External table creation in Doris
+    CREATE EXTERNAL TABLE hdfs_table (
+        id INT,
+        name STRING,
+        age INT
+    )
+    ENGINE=BROKER
+    PROPERTIES (
+        "broker.name" = "hdfs_broker",
+        "path" = "hdfs://namenode:9000/path/to/data",
+        "format" = "parquet"
+    );
+
+    -- Query external table
+    SELECT * FROM hdfs_table WHERE age > 25;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 11
+        character: 2
+    - start:
+        line: 13
+        character: 0
+      end:
+        line: 14
+        character: 40
+- statement: |-
+    -- Doris ROUTINE LOAD for Kafka streaming
+    CREATE ROUTINE LOAD example_db.kafka_load_job ON orders
+    COLUMNS TERMINATED BY ","
+    PROPERTIES
+    (
+        "desired_concurrent_number"="3",
+        "max_batch_interval" = "20",
+        "max_batch_rows" = "300000",
+        "max_batch_size" = "209715200",
+        "strict_mode" = "false"
+    )
+    FROM KAFKA
+    (
+        "kafka_broker_list" = "broker1:9092,broker2:9092",
+        "kafka_topic" = "order_topic",
+        "property.group.id" = "doris_consumer_group",
+        "property.kafka_default_offsets" = "OFFSET_BEGINNING"
+    );
+
+    -- Show routine load status
+    SHOW ROUTINE LOAD FOR kafka_load_job;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 17
+        character: 2
+    - start:
+        line: 19
+        character: 0
+      end:
+        line: 20
+        character: 37
+- statement: |-
+    -- Doris dynamic partition
+    CREATE TABLE dynamic_partition_table (
+        event_date DATE,
+        event_id BIGINT,
+        event_type VARCHAR(50)
+    )
+    PARTITION BY RANGE(event_date)()
+    DISTRIBUTED BY HASH(event_id) BUCKETS 10
+    PROPERTIES(
+        "dynamic_partition.enable" = "true",
+        "dynamic_partition.time_unit" = "DAY",
+        "dynamic_partition.start" = "-7",
+        "dynamic_partition.end" = "3",
+        "dynamic_partition.prefix" = "p",
+        "dynamic_partition.buckets" = "10"
+    );
+
+    -- Cancel decommission backend
+    CANCEL DECOMMISSION BACKEND "host:port";
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 15
+        character: 2
+    - start:
+        line: 17
+        character: 0
+      end:
+        line: 18
+        character: 40
+- statement: "-- Doris OUTFILE export\nSELECT * FROM orders \nINTO OUTFILE \"s3://bucket/export/\"\nFORMAT AS PARQUET\nPROPERTIES(\n    \"s3.endpoint\" = \"s3.amazonaws.com\",\n    \"s3.access_key\" = \"key\",\n    \"s3.secret_key\" = \"secret\",\n    \"s3.region\" = \"us-east-1\"\n);\n\n-- Admin commands\nADMIN SHOW REPLICA DISTRIBUTION FROM tbl;\nADMIN REPAIR TABLE tbl;"
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 9
+        character: 2
+    - start:
+        line: 11
+        character: 0
+      end:
+        line: 12
+        character: 41
+    - start:
+        line: 13
+        character: 0
+      end:
+        line: 13
+        character: 23
+- statement: "-- Doris array and struct operations\nCREATE TABLE complex_types (\n    id INT,\n    tags ARRAY<STRING>,\n    info STRUCT<name:STRING, age:INT>\n) DISTRIBUTED BY HASH(id) BUCKETS 10;\n\nSELECT \n    id,\n    ARRAY_LENGTH(tags) as tag_count,\n    info.name as user_name\nFROM complex_types\nWHERE ARRAY_CONTAINS(tags, 'premium');"
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 5
+        character: 37
+    - start:
+        line: 7
+        character: 0
+      end:
+        line: 12
+        character: 38
+- statement: "-- Backup and restore operations\nBACKUP SNAPSHOT example_db.snapshot_1 \nTO `repository_name`\nON (orders, customers)\nPROPERTIES (\"type\" = \"full\");\n\nRESTORE SNAPSHOT example_db.snapshot_1\nFROM `repository_name`\nON (orders, customers);"
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 4
+        character: 29
+    - start:
+        line: 6
+        character: 0
+      end:
+        line: 8
+        character: 23
+- statement: |-
+    -- S3 table function
+    SELECT * FROM s3(
+        "s3.endpoint" = "s3.amazonaws.com",
+        "s3.region" = "us-east-1",
+        "s3.access_key" = "key",
+        "s3.secret_key" = "secret",
+        "uri" = "s3://bucket/path/to/file.parquet",
+        "format" = "parquet"
+    );
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 8
+        character: 2

--- a/backend/plugin/parser/starrocks/test-data/statement-ranges/standard.yaml
+++ b/backend/plugin/parser/starrocks/test-data/statement-ranges/standard.yaml
@@ -1,0 +1,230 @@
+- statement: SELECT * FROM tbl;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 18
+- statement: SELECT * FROM tbl; SELECT count(*) FROM tbl;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 18
+    - start:
+        line: 0
+        character: 19
+      end:
+        line: 0
+        character: 44
+- statement: |-
+    -- Basic Doris queries
+    SELECT id, name FROM users WHERE status = 'active';
+    INSERT INTO logs (timestamp, message) VALUES (NOW(), 'User login');
+    UPDATE settings SET value = 'true' WHERE key = 'enable_feature';
+    DELETE FROM temp_data WHERE created_at < '2024-01-01';
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 1
+        character: 51
+    - start:
+        line: 2
+        character: 0
+      end:
+        line: 2
+        character: 67
+    - start:
+        line: 3
+        character: 0
+      end:
+        line: 3
+        character: 64
+    - start:
+        line: 4
+        character: 0
+      end:
+        line: 4
+        character: 54
+- statement: |-
+    -- Doris specific DDL statements
+    CREATE TABLE IF NOT EXISTS orders_partition (
+        order_id BIGINT,
+        order_date DATE,
+        customer_id BIGINT,
+        amount DECIMAL(10, 2)
+    )
+    PARTITION BY RANGE(order_date) (
+        PARTITION p202301 VALUES LESS THAN ('2023-02-01'),
+        PARTITION p202302 VALUES LESS THAN ('2023-03-01')
+    )
+    DISTRIBUTED BY HASH(order_id) BUCKETS 32
+    PROPERTIES (
+        "replication_allocation" = "tag.location.default: 3"
+    );
+
+    -- Alter table to add rollup
+    ALTER TABLE orders_partition ADD ROLLUP rollup_customer (customer_id, order_date, amount);
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 14
+        character: 2
+    - start:
+        line: 16
+        character: 0
+      end:
+        line: 17
+        character: 90
+- statement: "-- Doris aggregate materialized view\nCREATE MATERIALIZED VIEW orders_mv AS\nSELECT \n    customer_id,\n    DATE_FORMAT(order_date, '%Y-%m') as order_month,\n    SUM(amount) as total_amount,\n    COUNT(*) as order_count\nFROM orders_partition\nGROUP BY customer_id, order_month;\n\n-- Refresh materialized view\nREFRESH MATERIALIZED VIEW orders_mv;"
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 8
+        character: 34
+    - start:
+        line: 10
+        character: 0
+      end:
+        line: 11
+        character: 36
+- statement: "-- Complex query with window functions\nWITH monthly_sales AS (\n    SELECT \n        customer_id,\n        DATE_FORMAT(order_date, '%Y-%m') as month,\n        SUM(amount) as monthly_total,\n        ROW_NUMBER() OVER (PARTITION BY customer_id ORDER BY SUM(amount) DESC) as rn\n    FROM orders_partition\n    WHERE order_date >= '2023-01-01'\n    GROUP BY customer_id, month\n)\nSELECT \n    customer_id,\n    month,\n    monthly_total,\n    LAG(monthly_total, 1) OVER (PARTITION BY customer_id ORDER BY month) as prev_month_total\nFROM monthly_sales\nWHERE rn <= 3;\n\n-- Load data using stream load syntax comment\n-- curl --location-trusted -u root: -T data.csv -H \"column_separator:,\" http://localhost:8030/api/db/orders/_stream_load;"
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 17
+        character: 14
+    - start:
+        line: 19
+        character: 0
+      end:
+        line: 20
+        character: 121
+- statement: "-- Doris HLL (HyperLogLog) functions\nCREATE TABLE IF NOT EXISTS user_visits (\n    date DATE,\n    user_id_hll HLL HLL_UNION\n)\nAGGREGATE KEY(date)\nDISTRIBUTED BY HASH(date) BUCKETS 10;\n\nSELECT \n    date,\n    HLL_CARDINALITY(user_id_hll) as unique_users\nFROM user_visits\nWHERE date >= '2024-01-01';"
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 6
+        character: 37
+    - start:
+        line: 8
+        character: 0
+      end:
+        line: 12
+        character: 27
+- statement: "-- Bitmap index and operations\nCREATE TABLE page_views (\n    user_id INT,\n    page_id INT,\n    visit_time DATETIME,\n    INDEX idx_user_bitmap (user_id) USING BITMAP\n) DISTRIBUTED BY HASH(user_id) BUCKETS 10;\n\nSELECT \n    page_id,\n    BITMAP_COUNT(BITMAP_UNION(TO_BITMAP(user_id))) as unique_visitors\nFROM page_views\nWHERE visit_time >= '2024-01-01 00:00:00'\nGROUP BY page_id;"
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 6
+        character: 42
+    - start:
+        line: 8
+        character: 0
+      end:
+        line: 13
+        character: 17
+- statement: "-- JSON operations in Doris\nCREATE TABLE json_data (\n    id INT,\n    properties JSON\n) DISTRIBUTED BY HASH(id) BUCKETS 10;\n\nSELECT \n    id,\n    JSON_EXTRACT(properties, '$.name') as name,\n    JSON_EXTRACT(properties, '$.tags[0]') as first_tag\nFROM json_data\nWHERE JSON_EXTRACT(properties, '$.active') = 'true';"
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 4
+        character: 37
+    - start:
+        line: 6
+        character: 0
+      end:
+        line: 11
+        character: 52
+- statement: |-
+    SHOW TABLES;
+    SHOW CREATE TABLE orders_partition;
+    DESC orders_partition;
+    SHOW PARTITIONS FROM orders_partition;
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 12
+    - start:
+        line: 1
+        character: 0
+      end:
+        line: 1
+        character: 35
+    - start:
+        line: 2
+        character: 0
+      end:
+        line: 2
+        character: 22
+    - start:
+        line: 3
+        character: 0
+      end:
+        line: 3
+        character: 38
+- statement: SELECT * FROM tbl
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 17
+- statement: |-
+    /* Multi-line comment with semicolon;
+       This should be ignored */
+    SELECT * FROM users;
+    -- Single line comment with semicolon; ignored
+    INSERT INTO logs VALUES (1, 'test');
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 2
+        character: 20
+    - start:
+        line: 3
+        character: 0
+      end:
+        line: 4
+        character: 36
+- statement: ;
+- statement: ;;
+- statement: -- just a comment
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 17
+- statement: /* block comment */
+  ranges:
+    - start:
+        line: 0
+        character: 0
+      end:
+        line: 0
+        character: 19

--- a/backend/plugin/parser/starrocks/test-data/test_split.yaml
+++ b/backend/plugin/parser/starrocks/test-data/test_split.yaml
@@ -1,0 +1,141 @@
+- description: simple single statement
+  input: SELECT 1;
+  result:
+    - text: SELECT 1;
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 10
+      range:
+        start: 0
+        end: 9
+      empty: false
+- description: multiple statements on one line
+  input: SELECT 1; SELECT 2;
+  result:
+    - text: SELECT 1;
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 10
+      range:
+        start: 0
+        end: 9
+      empty: false
+    - text: ' SELECT 2;'
+      baseline: 0
+      start:
+        line: 1
+        column: 10
+      end:
+        line: 1
+        column: 20
+      range:
+        start: 9
+        end: 19
+      empty: false
+- description: multiple statements on multiple lines
+  input: "SELECT 1;\nSELECT 2;"
+  result:
+    - text: SELECT 1;
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 10
+      range:
+        start: 0
+        end: 9
+      empty: false
+    - text: "\nSELECT 2;"
+      baseline: 0
+      start:
+        line: 1
+        column: 10
+      end:
+        line: 2
+        column: 10
+      range:
+        start: 9
+        end: 19
+      empty: false
+- description: multi-line statement
+  input: "SELECT\n  1;"
+  result:
+    - text: "SELECT\n  1;"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 2
+        column: 5
+      range:
+        start: 0
+        end: 11
+      empty: false
+- description: 'position semantic: leading newlines'
+  input: "\n\nSELECT 1;"
+  result:
+    - text: "\n\nSELECT 1;"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 3
+        column: 10
+      range:
+        start: 0
+        end: 11
+      empty: false
+- description: 'position semantic: leading spaces and newlines'
+  input: "\n  \n  SELECT 1;"
+  result:
+    - text: "\n  \n  SELECT 1;"
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 3
+        column: 12
+      range:
+        start: 0
+        end: 15
+      empty: false
+- description: 'position semantic: multi-statement with leading whitespace'
+  input: "SELECT 1;\n\n  SELECT 2;"
+  result:
+    - text: SELECT 1;
+      baseline: 0
+      start:
+        line: 1
+        column: 1
+      end:
+        line: 1
+        column: 10
+      range:
+        start: 0
+        end: 9
+      empty: false
+    - text: "\n\n  SELECT 2;"
+      baseline: 0
+      start:
+        line: 1
+        column: 10
+      end:
+        line: 3
+        column: 12
+      range:
+        start: 9
+        end: 22
+      empty: false

--- a/backend/server/ultimate.go
+++ b/backend/server/ultimate.go
@@ -41,6 +41,7 @@ import (
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/snowflake"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/spanner"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/standard"
+	_ "github.com/bytebase/bytebase/backend/plugin/parser/starrocks"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/tidb"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/trino"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/tsql"

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260608094457-c8e5a034d279
+	github.com/bytebase/omni v0.0.0-20260610004923-a82b547d4b19
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260608094457-c8e5a034d279 h1:+e9sMU4STu/Vw2rvSSNL3lUaWCGUkWe7aftrNAz9Sbs=
-github.com/bytebase/omni v0.0.0-20260608094457-c8e5a034d279/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260610004923-a82b547d4b19 h1:RcisdYSr5RWrmaQqTjvOxhh4SvO6nWARYHotG/Bo4GA=
+github.com/bytebase/omni v0.0.0-20260610004923-a82b547d4b19/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## What

The keystone of the StarRocks engine epic (BYT-9140): re-routes `Engine_STARROCKS`'s **doris-parser consumers** from `omni/doris` to the new `omni/starrocks` fork, so the StarRocks parser work (CREATE/ALTER TABLE divergences shipped in omni #287–#289) actually reaches Bytebase users.

- New `backend/plugin/parser/starrocks/` package — repackaged from `parser/doris/` (import-swapped to `omni/starrocks`, STARROCKS-only registrations), blank-imported in the registration hubs.
- The **6 doris-path consumers** for STARROCKS now parse via the fork: diagnose, parse-statements, query-span, query-validator, split, statement-ranges.
- `resource-change` (ExtractChangedResources) and `completion` for STARROCKS **stay on the `omni/mysql` parser** — they were never on the doris path. (Note: StarRocks schema-diff via mysql is a pre-existing gap — the mysql parser rejects `DISTRIBUTED BY` — tracked separately, not this PR.)
- omni dep bumped to pull `omni/starrocks`.

## Keystone validation (RED→GREEN, end-to-end)

`TestStarRocksDiagnoseE2E`: a StarRocks generated column `AS (expr)` — which the **doris** parser rejected as a false `syntax error at or near AS` (a red underline the user sees) — now **diagnoses clean** through the Bytebase STARROCKS path. Plus shared-core zero-regression cases and an invalid-statement case (diagnose still reports real errors).

## Note for reviewers — deliberate copy

`parser/starrocks/` is a ~2.3k-line **import-swapped copy** of `parser/doris/`, not a candidate for DRY-refactoring. This is the idiomatic per-engine-package choice (consistent with the omni engine fork). The accepted cost: doris and starrocks wrappers are now duplicates — a future fix to doris's `query_span_extractor`/`query_type` logic must be mirrored to starrocks.

## Testing

- `TestStarRocksDiagnoseE2E` green; full `backend/plugin/parser/...` suite: 22 ok, 0 fail/panic (the multi-engine omni bump broke no wrapper). gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)