### PR TITLE
fix(pg): make DML transform position mapping linear

### DIFF
--- a/backend/plugin/parser/pg/backup.go
+++ b/backend/plugin/parser/pg/backup.go
@@ -289,6 +289,9 @@ func prepareTransformation(ctx context.Context, tCtx base.TransformContext, stat
 
 	searchPath := metadata.GetSearchPath()
 	var dmls []statementInfo
+	// Node locations ascend across statements, so a single incremental mapper
+	// converts all offsets in one pass instead of rescanning from byte 0.
+	posMapper := base.NewByteOffsetPositionMapper(statement)
 
 	for i, stmt := range stmts {
 		if stmt.Empty() {
@@ -320,9 +323,9 @@ func prepareTransformation(ctx context.Context, tCtx base.TransformContext, stat
 			}
 			table.StatementType = StatementTypeUpdate
 			nodeLoc := n.Loc
-			startPos := ByteOffsetToRunePosition(statement, nodeLoc.Start)
+			startPos := posMapper.Position(nodeLoc.Start)
 			startPos.Column-- // 0-based column to match existing convention
-			endPos := ByteOffsetToRunePosition(statement, nodeLoc.End)
+			endPos := posMapper.Position(nodeLoc.End)
 			dmls = append(dmls, statementInfo{
 				offset:    i,
 				statement: stmt.Text,
@@ -342,9 +345,9 @@ func prepareTransformation(ctx context.Context, tCtx base.TransformContext, stat
 			}
 			table.StatementType = StatementTypeDelete
 			nodeLoc := n.Loc
-			startPos := ByteOffsetToRunePosition(statement, nodeLoc.Start)
+			startPos := posMapper.Position(nodeLoc.Start)
 			startPos.Column--
-			endPos := ByteOffsetToRunePosition(statement, nodeLoc.End)
+			endPos := posMapper.Position(nodeLoc.End)
 			dmls = append(dmls, statementInfo{
 				offset:    i,
 				statement: stmt.Text,

--- a/backend/plugin/parser/pg/omni.go
+++ b/backend/plugin/parser/pg/omni.go
@@ -1,8 +1,6 @@
 package pg
 
 import (
-	"unicode/utf8"
-
 	omnipg "github.com/bytebase/omni/pg"
 	"github.com/bytebase/omni/pg/ast"
 
@@ -47,26 +45,5 @@ func GetOmniNode(a base.AST) (ast.Node, bool) {
 // ByteOffsetToRunePosition converts a byte offset in sql to a 1-based line:column
 // where column is measured in Unicode code points (runes), matching storepb.Position semantics.
 func ByteOffsetToRunePosition(sql string, byteOffset int) *storepb.Position {
-	if byteOffset > len(sql) {
-		byteOffset = len(sql)
-	}
-
-	line := int32(1)
-	runeCol := int32(0) // 0-based rune count on current line
-	i := 0
-	for i < byteOffset {
-		r, size := utf8.DecodeRuneInString(sql[i:])
-		if r == '\n' {
-			line++
-			runeCol = 0
-		} else {
-			runeCol++
-		}
-		i += size
-	}
-
-	return &storepb.Position{
-		Line:   line,
-		Column: runeCol + 1, // convert to 1-based
-	}
+	return base.NewByteOffsetPositionMapper(sql).Position(byteOffset)
 }

--- a/backend/plugin/parser/pg/restore.go
+++ b/backend/plugin/parser/pg/restore.go
@@ -63,6 +63,7 @@ func findStatementAtPosition(statement string, backupItem *storepb.PriorBackupDe
 		return nil, errors.Wrap(err, "failed to parse statement")
 	}
 
+	posMapper := base.NewByteOffsetPositionMapper(statement)
 	for _, stmt := range stmts {
 		if stmt.Empty() {
 			continue
@@ -70,9 +71,9 @@ func findStatementAtPosition(statement string, backupItem *storepb.PriorBackupDe
 		switch stmt.AST.(type) {
 		case *ast.UpdateStmt, *ast.DeleteStmt:
 			nodeLoc := ast.NodeLoc(stmt.AST)
-			startPos := ByteOffsetToRunePosition(statement, nodeLoc.Start)
+			startPos := posMapper.Position(nodeLoc.Start)
 			startPos.Column-- // 0-based to match backup convention
-			endPos := ByteOffsetToRunePosition(statement, nodeLoc.End)
+			endPos := posMapper.Position(nodeLoc.End)
 			if inRange(startPos, endPos, backupItem.StartPosition, backupItem.EndPosition) {
 				return stmt.AST, nil
 			}
@@ -262,6 +263,7 @@ func extractStatement(statement string, backupItem *storepb.PriorBackupDetail_It
 	}
 
 	var sqls []string
+	posMapper := base.NewByteOffsetPositionMapper(statement)
 	for _, stmt := range stmts {
 		if stmt.Empty() {
 			continue
@@ -269,9 +271,9 @@ func extractStatement(statement string, backupItem *storepb.PriorBackupDetail_It
 		switch stmt.AST.(type) {
 		case *ast.UpdateStmt, *ast.DeleteStmt:
 			nodeLoc := ast.NodeLoc(stmt.AST)
-			startPos := ByteOffsetToRunePosition(statement, nodeLoc.Start)
+			startPos := posMapper.Position(nodeLoc.Start)
 			startPos.Column-- // 0-based
-			endPos := ByteOffsetToRunePosition(statement, nodeLoc.End)
+			endPos := posMapper.Position(nodeLoc.End)
 			if inRange(startPos, endPos, backupItem.StartPosition, backupItem.EndPosition) {
 				// Extract statement text without trailing semicolon/whitespace.
 				text := strings.TrimRight(strings.TrimSpace(stmt.Text), ";")


### PR DESCRIPTION
## What

`TransformDMLToSelect` for PostgreSQL called `ByteOffsetToRunePosition` twice per DML statement, and each call rescanned the script from byte 0 — making an n-statement transform O(n²). A 10k-statement UPDATE/DELETE script spent ~2.4s in position mapping alone, while the mysql/mssql/oracle equivalents take 20–40ms.

This reuses `base.ByteOffsetPositionMapper` (introduced in #20556) to convert the ascending node offsets in a single incremental pass:

- `backup.go` — `prepareTransformation` creates one mapper before the statement loop.
- `restore.go` — the same per-statement loop pattern existed in `findStatementAtPosition` and the statement-extraction loop; both now use a shared mapper.
- `omni.go` — `ByteOffsetToRunePosition` now delegates to the base mapper, so the remaining one-shot error-path call sites (`pg.go`, `diagnose.go`, `query_span_omni.go`) keep working and the package has a single position implementation.

Follow-up to #20556 (omni split position mapping) and #20559 (redshift statement ranges) — same class of bug.

## Why

Transforming large DML scripts for prior-backup was quadratic in statement count. **10k-statement transform: 2.39s/op → 16ms/op (~150x).**

One deliberate semantic note: the old pg converter counted `\r` as an ordinary column character, while the base mapper treats lone `\r` (and `\r\n` as a unit) as a line break. This unifies on the base semantics. Statement boundaries never land between `\r` and `\n`, and backup/restore both use the new semantics so their `inRange` matching stays consistent.

## Testing

- Throwaway 10k-UPDATE benchmark in the pg package: baseline (via `git stash`) 2,392ms/op → 16ms/op with the fix (removed before commit).
- `go test ./backend/plugin/parser/pg/... ./backend/plugin/parser/base/...` — all pass.
- `golangci-lint run` — 0 issues; `gofmt` applied; server binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)