### PR TITLE
fix(starrocks): sweep the Engine_DORIS-dispatch class (driver + parser)

### DIFF
--- a/backend/plugin/db/starrocks/dispatch_test.go
+++ b/backend/plugin/db/starrocks/dispatch_test.go
@@ -1,0 +1,31 @@
+package starrocks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+
+	// Register the doris + starrocks editor validators.
+	_ "github.com/bytebase/bytebase/backend/plugin/parser/doris"
+	_ "github.com/bytebase/bytebase/backend/plugin/parser/starrocks"
+)
+
+// TestValidateSQLForEditor_EngineDispatch guards the #20562 P2 fix: QueryConn
+// must split/validate via the connection's engine (d.dbType), not a hardcoded
+// Engine_DORIS. On a StarRocks-only statement the two engines must disagree —
+// doris rejects it (→ allQuery forced true, DDL wrongly routed through
+// QueryContext), starrocks accepts it (→ correct allQuery=false).
+func TestValidateSQLForEditor_EngineDispatch(t *testing.T) {
+	// StarRocks generated column AS (expr): doris wants GENERATED ALWAYS AS.
+	const ddl = "CREATE TABLE t (a INT, b INT AS (a + 1)) DUPLICATE KEY(a) DISTRIBUTED BY HASH(a)"
+
+	_, srAllQuery, srErr := base.ValidateSQLForEditor(storepb.Engine_STARROCKS, ddl)
+	require.NoError(t, srErr, "starrocks parser should accept StarRocks DDL")
+	require.False(t, srAllQuery, "a CREATE TABLE is DDL, not a read-only query")
+
+	_, _, dorisErr := base.ValidateSQLForEditor(storepb.Engine_DORIS, ddl)
+	require.Error(t, dorisErr, "doris parser rejects StarRocks AS(expr) DDL — why d.dbType matters")
+}

--- a/backend/plugin/db/starrocks/starrocks.go
+++ b/backend/plugin/db/starrocks/starrocks.go
@@ -276,7 +276,7 @@ func (d *Driver) executeInAutoCommitMode(ctx context.Context, statement string) 
 
 // QueryConn queries a SQL statement in a given connection.
 func (d *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement string, queryContext db.QueryContext) ([]*v1pb.QueryResult, error) {
-	singleSQLs, err := base.SplitMultiSQL(storepb.Engine_DORIS, statement)
+	singleSQLs, err := base.SplitMultiSQL(d.dbType, statement)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func (d *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement string
 		}
 		sqlWithBytebaseAppComment := util.MySQLPrependBytebaseAppComment(statement)
 
-		_, allQuery, err := base.ValidateSQLForEditor(storepb.Engine_DORIS, statement)
+		_, allQuery, err := base.ValidateSQLForEditor(d.dbType, statement)
 		if err != nil {
 			// TODO(d): need to make parser compatible.
 			slog.Error("failed to validate sql", slog.String("statement", statement), log.BBError(err))

--- a/backend/plugin/db/starrocks/starrocks.go
+++ b/backend/plugin/db/starrocks/starrocks.go
@@ -69,7 +69,7 @@ func (d *Driver) Open(_ context.Context, dbType storepb.Engine, connCfg db.Conne
 		protocol = "unix"
 	}
 	params := []string{"multiStatements=true", "maxAllowedPacket=0"}
-	if dbType == storepb.Engine_DORIS {
+	if dbType == storepb.Engine_DORIS || dbType == storepb.Engine_STARROCKS {
 		params = append(params, "interpolateParams=true")
 	}
 	if connCfg.DataSource.GetSshHost() != "" {

--- a/backend/plugin/db/starrocks/sync.go
+++ b/backend/plugin/db/starrocks/sync.go
@@ -81,7 +81,7 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 		); err != nil {
 			return nil, err
 		}
-		if d.dbType == storepb.Engine_DORIS {
+		if d.dbType == storepb.Engine_DORIS || d.dbType == storepb.Engine_STARROCKS {
 			database.CharacterSet = ""
 			database.Collation = ""
 		}
@@ -375,7 +375,7 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 	}
 	// "characterSet":"utf8\u0000", "collation":"utf8_general_ci\u0000".
 	// ERROR: unsupported Unicode escape sequence (SQLSTATE 22P05).
-	if d.dbType == storepb.Engine_DORIS {
+	if d.dbType == storepb.Engine_DORIS || d.dbType == storepb.Engine_STARROCKS {
 		databaseMetadata.CharacterSet = ""
 		databaseMetadata.Collation = ""
 	}

--- a/backend/plugin/db/starrocks/sync.go
+++ b/backend/plugin/db/starrocks/sync.go
@@ -22,19 +22,17 @@ const (
 	autoIncrementSymbol = "AUTO_INCREMENT"
 )
 
-var (
-	systemDatabases = map[string]bool{
-		"information_schema": true,
-		"_statistics_":       true,
+// systemDatabaseExclusion returns the quoted, comma-joined system databases to
+// exclude from instance discovery, per the driver's engine. StarRocks adds its
+// read-only `sys` metadatabase (Doris has no sys), matching the parser-side
+// system-database classification.
+func (d *Driver) systemDatabaseExclusion() string {
+	dbs := []string{"'information_schema'", "'_statistics_'"}
+	if d.dbType == storepb.Engine_STARROCKS {
+		dbs = append(dbs, "'sys'")
 	}
-	systemDatabaseClause = func() string {
-		var l []string
-		for k := range systemDatabases {
-			l = append(l, fmt.Sprintf("'%s'", k))
-		}
-		return strings.Join(l, ", ")
-	}()
-)
+	return strings.Join(dbs, ", ")
+}
 
 // SyncInstance syncs the instance.
 func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error) {
@@ -57,7 +55,7 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 	}
 
 	// Query db info
-	where := fmt.Sprintf("LOWER(SCHEMA_NAME) NOT IN (%s)", systemDatabaseClause)
+	where := fmt.Sprintf("LOWER(SCHEMA_NAME) NOT IN (%s)", d.systemDatabaseExclusion())
 	query := `
 		SELECT
 			SCHEMA_NAME,

--- a/backend/plugin/db/starrocks/sync_systemdb_test.go
+++ b/backend/plugin/db/starrocks/sync_systemdb_test.go
@@ -1,0 +1,24 @@
+package starrocks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+// #20566 review (P2): SyncInstance's system-database exclusion must match the
+// parser's per-engine system set — StarRocks's read-only `sys` metadatabase
+// must be excluded so it isn't imported as a user database. Doris has no `sys`,
+// so excluding it there would risk hiding a user db named sys (engine-aware).
+func TestSystemDatabaseExclusion(t *testing.T) {
+	sr := (&Driver{dbType: storepb.Engine_STARROCKS}).systemDatabaseExclusion()
+	require.Contains(t, sr, "'sys'", "StarRocks sync must exclude the sys metadatabase")
+	require.Contains(t, sr, "'information_schema'")
+	require.Contains(t, sr, "'_statistics_'")
+
+	doris := (&Driver{dbType: storepb.Engine_DORIS}).systemDatabaseExclusion()
+	require.NotContains(t, doris, "'sys'", "Doris must not exclude sys (StarRocks-only)")
+	require.Contains(t, doris, "'information_schema'")
+}

--- a/backend/plugin/parser/starrocks/query_span_extractor.go
+++ b/backend/plugin/parser/starrocks/query_span_extractor.go
@@ -167,13 +167,14 @@ func isMixedQuery(m base.SourceColumnSet, ignoreCaseSensitive bool) (bool, bool)
 	return !hasUser && hasSystem, false
 }
 
-// systemDatabases contains Doris system databases
-// Reference: https://doris.apache.org/docs/3.x/admin-manual/system-tables/overview
+// systemDatabases contains StarRocks system databases. StarRocks exposes a
+// read-only `sys` metadatabase and does not have Doris's `mysql` /
+// `__internal_schema`.
+// Reference: https://docs.starrocks.io/docs/administration/management/system_catalogs/sys/
 var systemDatabases = map[string]bool{
 	"information_schema": true,
-	"mysql":              true,
-	"__internal_schema":  true,
 	"_statistics_":       true,
+	"sys":                true,
 }
 
 func isSystemResource(resource base.ColumnResource, ignoreCaseSensitive bool) bool {

--- a/backend/plugin/parser/starrocks/system_database_test.go
+++ b/backend/plugin/parser/starrocks/system_database_test.go
@@ -1,0 +1,29 @@
+package starrocks
+
+import (
+	"testing"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// #20562 review (P2): the system-database set must be StarRocks-specific, not the
+// copied Doris list. StarRocks has a read-only `sys` metadatabase (SHOW DATABASES
+// confirms: information_schema, _statistics_, sys) and no `mysql`/`__internal_schema`.
+func TestIsSystemResource_StarRocks(t *testing.T) {
+	cases := []struct {
+		database string
+		want     bool
+	}{
+		{"sys", true},                // StarRocks system metadatabase
+		{"information_schema", true}, // shared
+		{"_statistics_", true},       // statistics
+		{"mysql", false},             // Doris-only, not a StarRocks system db
+		{"__internal_schema", false}, // Doris-only
+		{"my_user_db", false},        // user database
+	}
+	for _, c := range cases {
+		if got := isSystemResource(base.ColumnResource{Database: c.database}, true); got != c.want {
+			t.Errorf("isSystemResource(%q) = %v, want %v", c.database, got, c.want)
+		}
+	}
+}

--- a/backend/plugin/parser/starrocks/test-data/query_span_system_table.yaml
+++ b/backend/plugin/parser/starrocks/test-data/query_span_system_table.yaml
@@ -40,8 +40,8 @@
           table: table_statistics
           column: ""
     predicatecolumns: []
-- description: Query mysql database
-  statement: SELECT * FROM mysql.user
+- description: Query sys metadatabase (StarRocks system db; Doris has no sys, and StarRocks has no mysql/__internal_schema)
+  statement: SELECT * FROM sys.grants_to_roles
   defaultDatabase: testdb
   metadata: '{}'
   querySpan:
@@ -49,23 +49,9 @@
     results: []
     sourcecolumns:
         - server: ""
-          database: mysql
+          database: sys
           schema: ""
-          table: user
-          column: ""
-    predicatecolumns: []
-- description: Query __internal_schema database
-  statement: SELECT * FROM __internal_schema.audit_log
-  defaultDatabase: testdb
-  metadata: '{}'
-  querySpan:
-    type: 3
-    results: []
-    sourcecolumns:
-        - server: ""
-          database: __internal_schema
-          schema: ""
-          table: audit_log
+          table: grants_to_roles
           column: ""
     predicatecolumns: []
 - description: Query user table


### PR DESCRIPTION
## What

Follow-up to #20562. A reviewer (and a bot) flagged one `Engine_DORIS`-dispatch bug; the driver serves **both** engines (`db.Register(Engine_STARROCKS, …)` and `Engine_DORIS`), so every `== Engine_DORIS` conditional takes the wrong branch for a StarRocks connection. Swept `Engine_DORIS` across every StarRocks-serving package (`db/starrocks/` + `parser/starrocks/`) and fixed the class:

| Fix | Site | Notes |
|---|---|---|
| System databases | `parser/starrocks/query_span_extractor.go` | use StarRocks set `{information_schema, _statistics_, sys}`, not Doris's `mysql`/`__internal_schema`; `sys` is StarRocks's read-only metadatabase (container-verified). Fixes mis-classified system-table access (the bot's P2). |
| QueryConn dispatch | `db/starrocks/starrocks.go` | split + validate via `d.dbType`, not hardcoded `Engine_DORIS` — StarRocks-only DDL was hitting the error path (`allQuery=true`) and routing through QueryContext instead of ExecContext. |
| charset/collation | `db/starrocks/sync.go` (×2) | clear them for StarRocks too (OLAP returns junk values with a trailing NUL that breaks Postgres JSONB). |
| interpolateParams | `db/starrocks/starrocks.go` | StarRocks shares Doris's prepared-statement limitations; client-side interpolation is a safe superset. |

## Deferred — materialized views (BYT-9689)

The two MV sites (`sync.go`/`dump.go` `mv_infos()`) are a real StarRocks gap (StarRocks uses `information_schema.materialized_views`, not Doris's `mv_infos()` TVF), but implementing it correctly needs the StarRocks columns **verified against a live BE** — and StarRocks's `information_schema` is BE-served, while the arm64 container BE won't stay up (#65095). Carved out to **BYT-9689** (needs an amd64 BE-alive StarRocks). The MV sites stay `Engine_DORIS`-only — **status quo, zero regression**.

## Tests

- `TestIsSystemResource_StarRocks` (sys→system, mysql→user) + a `sys` query-span case.
- `TestValidateSQLForEditor_EngineDispatch` guards the dispatch (starrocks accepts / doris rejects a StarRocks-only statement).
- Affected packages green; gofmt + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)