### PR TITLE
chore: bump omni for linear pg catalog Exec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260610023532-8cd4bb9614e1
+	github.com/bytebase/omni v0.0.0-20260610065225-2cf04e304cb1
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260610023532-8cd4bb9614e1 h1:xsfTH5uRpxOPNa/DV3GwMax+Mfca5Ck/anErItfsXK0=
-github.com/bytebase/omni v0.0.0-20260610023532-8cd4bb9614e1/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260610065225-2cf04e304cb1 h1:CsXvtrbHIogzZ7C5iXDnGxbGx+ZiMiooft5KiTs23V0=
+github.com/bytebase/omni v0.0.0-20260610065225-2cf04e304cb1/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## What changed

Bump `github.com/bytebase/omni` to `v0.0.0-20260610065225-2cf04e304cb1`, picking up [omni#298](https://github.com/bytebase/omni/pull/298).

## Why

`pg/catalog` `Exec` rescanned all statements before executing each statement, making pg SQL review O(n²) over large scripts. With the fix, `BenchmarkE2E/pg/review` scales linearly (M4 Pro, benchtime 3x):

| tier | before | after |
|---|---|---|
| dml_1k | 6.6ms | 5.5ms |
| dml_10k | 232ms | 43ms |
| dml_100k | 22.2s | 454ms |

Now in line with the mysql tiers (5.6ms/56ms/567ms).

## Verification

- `go build ./backend/...` passes
- `go test ./backend/plugin/parser/pg/... ./backend/plugin/advisor/pg/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)