### PR TITLE
feat(auth): redesign sign-in page for SaaS

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -143,6 +143,8 @@
     },
     "sign-in": {
       "code-sent-hint": "A verification code was sent to {{email}}.",
+      "continue-with-email": "Continue with email",
+      "continue-with-idp": "Continue with {{idp}}",
       "email-code-tab": "Email Code",
       "failed-to-send-code": "Failed to send verification code. {{error}}",
       "forget-password": "Forgot your password?",
@@ -150,8 +152,10 @@
       "new-user": "New to Bytebase?",
       "resend-code": "Resend code",
       "resend-in": "Resend in {{seconds}}s",
-      "send-code": "Send code",
-      "sign-in-with-idp": "Sign in with {{idp}}",
+      "sign-in-or-create": "Sign in or create your account",
+      "sign-in-to-account": "Sign in to your account",
+      "standard-tab": "Standard",
+      "tos": "By continuing, you agree to our <terms>Terms of Service</terms> and <privacy>Privacy Policy</privacy>.",
       "verification-code": "Verification code"
     },
     "sign-up": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -143,6 +143,8 @@
     },
     "sign-in": {
       "code-sent-hint": "Se ha enviado un código de verificación a {{email}}.",
+      "continue-with-email": "Continuar con email",
+      "continue-with-idp": "Continuar con {{idp}}",
       "email-code-tab": "Código por email",
       "failed-to-send-code": "No se pudo enviar el código de verificación. {{error}}",
       "forget-password": "¿Olvidaste tu contraseña?",
@@ -150,8 +152,10 @@
       "new-user": "¿Nuevo en Bytebase?",
       "resend-code": "Reenviar código",
       "resend-in": "Reenviar en {{seconds}}s",
-      "send-code": "Enviar código",
-      "sign-in-with-idp": "Iniciar sesión con {{idp}}",
+      "sign-in-or-create": "Inicia sesión o crea tu cuenta",
+      "sign-in-to-account": "Inicia sesión en tu cuenta",
+      "standard-tab": "Estándar",
+      "tos": "Al continuar, aceptas nuestros <terms>Términos de servicio</terms> y la <privacy>Política de privacidad</privacy>.",
       "verification-code": "Código de verificación"
     },
     "sign-up": {

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -143,6 +143,8 @@
     },
     "sign-in": {
       "code-sent-hint": "{{email}} に認証コードを送信しました。",
+      "continue-with-email": "メールで続行",
+      "continue-with-idp": "{{idp}} で続行",
       "email-code-tab": "メール認証コード",
       "failed-to-send-code": "認証コードの送信に失敗しました。{{error}}",
       "forget-password": "パスワードを忘れましたか？",
@@ -150,8 +152,10 @@
       "new-user": "Bytebase を初めて使用しますか?",
       "resend-code": "コードを再送信",
       "resend-in": "{{seconds}}秒後に再送信可能",
-      "send-code": "コードを送信",
-      "sign-in-with-idp": "{{idp}} 経由でログイン",
+      "sign-in-or-create": "ログインまたはアカウントを作成",
+      "sign-in-to-account": "アカウントにログイン",
+      "standard-tab": "標準",
+      "tos": "続行すると、<terms>利用規約</terms>および<privacy>プライバシーポリシー</privacy>に同意したものとみなされます。",
       "verification-code": "認証コード"
     },
     "sign-up": {

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -143,6 +143,8 @@
     },
     "sign-in": {
       "code-sent-hint": "Mã xác minh đã được gửi đến {{email}}.",
+      "continue-with-email": "Tiếp tục bằng email",
+      "continue-with-idp": "Tiếp tục bằng {{idp}}",
       "email-code-tab": "Mã qua email",
       "failed-to-send-code": "Không gửi được mã xác minh. {{error}}",
       "forget-password": "Quên mật khẩu?",
@@ -150,8 +152,10 @@
       "new-user": "Mới sử dụng Bytebase?",
       "resend-code": "Gửi lại mã",
       "resend-in": "Gửi lại sau {{seconds}}s",
-      "send-code": "Gửi mã",
-      "sign-in-with-idp": "Đăng nhập bằng {{idp}}",
+      "sign-in-or-create": "Đăng nhập hoặc tạo tài khoản của bạn",
+      "sign-in-to-account": "Đăng nhập vào tài khoản của bạn",
+      "standard-tab": "Tiêu chuẩn",
+      "tos": "Bằng cách tiếp tục, bạn đồng ý với <terms>Điều khoản dịch vụ</terms> và <privacy>Chính sách quyền riêng tư</privacy> của chúng tôi.",
       "verification-code": "Mã xác minh"
     },
     "sign-up": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -143,6 +143,8 @@
     },
     "sign-in": {
       "code-sent-hint": "验证码已发送至 {{email}}。",
+      "continue-with-email": "使用邮箱继续",
+      "continue-with-idp": "使用 {{idp}} 继续",
       "email-code-tab": "邮箱验证码",
       "failed-to-send-code": "发送验证码失败。{{error}}",
       "forget-password": "忘记密码?",
@@ -150,8 +152,10 @@
       "new-user": "第一次使用 Bytebase?",
       "resend-code": "重新发送验证码",
       "resend-in": "{{seconds}} 秒后重新发送",
-      "send-code": "发送验证码",
-      "sign-in-with-idp": "通过 {{idp}} 登录",
+      "sign-in-or-create": "登录或创建您的账户",
+      "sign-in-to-account": "登录您的账户",
+      "standard-tab": "标准",
+      "tos": "继续即表示您同意我们的<terms>服务条款</terms>和<privacy>隐私政策</privacy>。",
       "verification-code": "验证码"
     },
     "sign-up": {

--- a/frontend/src/react/components/auth/AuthDivider.tsx
+++ b/frontend/src/react/components/auth/AuthDivider.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/react/lib/utils";
+
+type Props = {
+  readonly className?: string;
+  readonly children: React.ReactNode;
+};
+
+// Horizontal rule with centered content (text or links); the children mask
+// the line with their own background (bg-white on the auth surfaces).
+export function AuthDivider({ className, children }: Props) {
+  return (
+    <div className={cn("relative", className)}>
+      <div aria-hidden="true" className="absolute inset-0 flex items-center">
+        <div className="w-full border-t border-control-border" />
+      </div>
+      <div className="relative flex justify-center text-sm">{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/react/components/auth/EmailCodeSigninForm.test.tsx
+++ b/frontend/src/react/components/auth/EmailCodeSigninForm.test.tsx
@@ -114,11 +114,16 @@ describe("EmailCodeSigninForm", () => {
       'input[type="email"]'
     );
     expect(emailInput).toBeTruthy();
+    expect(emailInput?.placeholder).toBe("you@company.com");
+    // No internal-form required asterisks on the auth surface.
+    expect(container.textContent).not.toContain("*");
     setInputValue(emailInput!, "user@example.com");
 
     const sendCodeButton = Array.from(
       container.querySelectorAll<HTMLButtonElement>("button")
-    ).find((button) => button.textContent === "auth.sign-in.send-code");
+    ).find(
+      (button) => button.textContent === "auth.sign-in.continue-with-email"
+    );
     expect(sendCodeButton).toBeTruthy();
     act(() => {
       sendCodeButton?.click();

--- a/frontend/src/react/components/auth/EmailCodeSigninForm.tsx
+++ b/frontend/src/react/components/auth/EmailCodeSigninForm.tsx
@@ -102,21 +102,17 @@ export function EmailCodeSigninForm({ loading, onSignin }: Props) {
   const allowSignin = !!email && codeParts.join("").length === 6;
 
   return (
-    <form className="flex flex-col gap-y-6 px-1" onSubmit={handleSubmit}>
+    <form className="flex flex-col gap-y-4" onSubmit={handleSubmit}>
       <div>
-        <label
-          htmlFor="email-code-email"
-          className="block text-sm font-medium leading-5 text-control"
-        >
+        <label htmlFor="email-code-email" className="sr-only">
           {t("common.email")}
-          <span className="text-error ml-0.5">*</span>
         </label>
-        <div className="mt-1 rounded-md shadow-xs">
+        <div className="rounded-md shadow-xs">
           <Input
             id="email-code-email"
             type="email"
             autoComplete="email"
-            placeholder="jim@example.com"
+            placeholder="you@company.com"
             required
             value={email}
             disabled={step === "code" || emailFromQuery}
@@ -129,7 +125,6 @@ export function EmailCodeSigninForm({ loading, onSignin }: Props) {
         <div className="flex flex-col gap-y-2">
           <label className="block text-sm font-medium leading-5 text-control">
             {t("auth.sign-in.verification-code")}
-            <span className="text-error ml-0.5">*</span>
           </label>
           <div className="text-sm text-control-light">
             {t("auth.sign-in.code-sent-hint", { email })}
@@ -164,7 +159,7 @@ export function EmailCodeSigninForm({ loading, onSignin }: Props) {
             disabled={!isValidEmail(email) || sending}
             onClick={sendCode}
           >
-            {t("auth.sign-in.send-code")}
+            {t("auth.sign-in.continue-with-email")}
           </Button>
         ) : (
           <Button

--- a/frontend/src/react/components/auth/IdpBrandIcon.test.tsx
+++ b/frontend/src/react/components/auth/IdpBrandIcon.test.tsx
@@ -1,0 +1,86 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, test } from "vitest";
+import type { IdentityProvider } from "@/types/proto-es/v1/idp_service_pb";
+import { IdpBrandIcon } from "./IdpBrandIcon";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  act(() => {
+    root.render(element);
+  });
+  return container;
+};
+
+const oauth2Idp = (title: string, authUrl: string) =>
+  ({
+    name: "idps/test",
+    title,
+    config: { config: { case: "oauth2Config", value: { authUrl } } },
+  }) as IdentityProvider;
+
+const oidcIdp = (title: string, issuer: string) =>
+  ({
+    name: "idps/test",
+    title,
+    config: { config: { case: "oidcConfig", value: { issuer } } },
+  }) as IdentityProvider;
+
+const configlessIdp = (title: string) =>
+  ({ name: "idps/test", title }) as IdentityProvider;
+
+// The Google "G" carries its mandatory brand blue; GitHub is currentColor.
+const GOOGLE_BLUE = "#4285F4";
+
+describe("IdpBrandIcon", () => {
+  test("resolves brand from the OAuth2 auth URL, not the title", () => {
+    const container = renderIntoContainer(
+      <IdpBrandIcon
+        idp={oauth2Idp("Corp SSO", "https://github.com/login/oauth/authorize")}
+      />
+    );
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute("fill")).toBe("currentColor");
+  });
+
+  test("resolves brand from the OIDC issuer", () => {
+    const container = renderIntoContainer(
+      <IdpBrandIcon
+        idp={oidcIdp("Work account", "https://accounts.google.com")}
+      />
+    );
+    expect(
+      container.querySelector(`svg path[fill="${GOOGLE_BLUE}"]`)
+    ).toBeTruthy();
+  });
+
+  test("does not trust the title when the config points elsewhere", () => {
+    const container = renderIntoContainer(
+      <IdpBrandIcon
+        idp={oidcIdp("GitHub Enterprise via Okta", "https://corp.okta.com")}
+      />
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  test("falls back to the title when no config URL is available", () => {
+    const container = renderIntoContainer(
+      <IdpBrandIcon idp={configlessIdp("GitLab")} />
+    );
+    expect(container.querySelector('svg path[fill="#FC6D26"]')).toBeTruthy();
+  });
+
+  test("renders nothing for unrecognized providers", () => {
+    const container = renderIntoContainer(
+      <IdpBrandIcon idp={configlessIdp("Corp SSO")} />
+    );
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/frontend/src/react/components/auth/IdpBrandIcon.tsx
+++ b/frontend/src/react/components/auth/IdpBrandIcon.tsx
@@ -30,17 +30,18 @@ function brandFromTitle(title: string): Brand | undefined {
   return undefined;
 }
 
+function configUrlOf(idp: IdentityProvider): string {
+  const config = idp.config?.config;
+  if (config?.case === "oauth2Config") return config.value.authUrl;
+  if (config?.case === "oidcConfig") return config.value.issuer;
+  return "";
+}
+
 // The config URL identifies where the user actually authenticates, so it is
 // authoritative: when present, a non-brand host renders no icon rather than
 // falling back to the admin-editable title (which could claim another brand).
 function resolveBrand(idp: IdentityProvider): Brand | undefined {
-  const config = idp.config?.config;
-  const configUrl =
-    config?.case === "oauth2Config"
-      ? config.value.authUrl
-      : config?.case === "oidcConfig"
-        ? config.value.issuer
-        : "";
+  const configUrl = configUrlOf(idp);
   if (configUrl) {
     return brandFromHost(hostnameOf(configUrl));
   }

--- a/frontend/src/react/components/auth/IdpBrandIcon.tsx
+++ b/frontend/src/react/components/auth/IdpBrandIcon.tsx
@@ -1,0 +1,114 @@
+import type { IdentityProvider } from "@/types/proto-es/v1/idp_service_pb";
+
+type Brand = "github" | "google" | "gitlab";
+
+type Props = {
+  readonly idp: IdentityProvider;
+  readonly className?: string;
+};
+
+function hostnameOf(url: string): string {
+  try {
+    return new URL(url).hostname.toLowerCase();
+  } catch {
+    return "";
+  }
+}
+
+function brandFromHost(host: string): Brand | undefined {
+  if (host === "github.com" || host.endsWith(".github.com")) return "github";
+  if (host === "google.com" || host.endsWith(".google.com")) return "google";
+  if (host === "gitlab.com" || host.endsWith(".gitlab.com")) return "gitlab";
+  return undefined;
+}
+
+function brandFromTitle(title: string): Brand | undefined {
+  const lowered = title.toLowerCase();
+  if (lowered.includes("github")) return "github";
+  if (lowered.includes("google")) return "google";
+  if (lowered.includes("gitlab")) return "gitlab";
+  return undefined;
+}
+
+// The config URL identifies where the user actually authenticates, so it is
+// authoritative: when present, a non-brand host renders no icon rather than
+// falling back to the admin-editable title (which could claim another brand).
+function resolveBrand(idp: IdentityProvider): Brand | undefined {
+  const config = idp.config?.config;
+  const configUrl =
+    config?.case === "oauth2Config"
+      ? config.value.authUrl
+      : config?.case === "oidcConfig"
+        ? config.value.issuer
+        : "";
+  if (configUrl) {
+    return brandFromHost(hostnameOf(configUrl));
+  }
+  return brandFromTitle(idp.title);
+}
+
+// Brand marks use their official colors — Google's branding guidelines
+// require the standard-color "G", so raw hex values are intentional here.
+export function IdpBrandIcon({ idp, className }: Props) {
+  const brand = resolveBrand(idp);
+  if (brand === "github") {
+    return (
+      <svg
+        viewBox="0 0 16 16"
+        aria-hidden="true"
+        fill="currentColor"
+        className={className}
+      >
+        <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+      </svg>
+    );
+  }
+  if (brand === "google") {
+    return (
+      <svg viewBox="0 0 18 18" aria-hidden="true" className={className}>
+        <path
+          fill="#4285F4"
+          d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 0 1-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615Z"
+        />
+        <path
+          fill="#34A853"
+          d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.26c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 0 0 9 18Z"
+        />
+        <path
+          fill="#FBBC05"
+          d="M3.964 10.71A5.41 5.41 0 0 1 3.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 0 0 0 9c0 1.452.348 2.827.957 4.042l3.007-2.332Z"
+        />
+        <path
+          fill="#EA4335"
+          d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 0 0 .957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58Z"
+        />
+      </svg>
+    );
+  }
+  if (brand === "gitlab") {
+    return (
+      <svg viewBox="0 0 24 24" aria-hidden="true" className={className}>
+        <path fill="#E24329" d="m12 21.42 3.684-11.333H8.316L12 21.42Z" />
+        <path fill="#FC6D26" d="M12 21.42 8.316 10.087H3.16L12 21.42Z" />
+        <path
+          fill="#FCA326"
+          d="m3.16 10.087-1.12 3.447a.762.762 0 0 0 .278.852L12 21.42 3.16 10.087Z"
+        />
+        <path
+          fill="#E24329"
+          d="M3.16 10.087h5.156L6.1 3.27a.38.38 0 0 0-.728 0L3.16 10.087Z"
+        />
+        <path fill="#FC6D26" d="m12 21.42 3.684-11.333h5.156L12 21.42Z" />
+        <path
+          fill="#FCA326"
+          d="m20.84 10.087 1.12 3.447a.762.762 0 0 1-.278.852L12 21.42l8.84-11.333Z"
+        />
+        <path
+          fill="#E24329"
+          d="M20.84 10.087h-5.156L17.9 3.27a.38.38 0 0 1 .728 0l2.212 6.817Z"
+        />
+      </svg>
+    );
+  }
+  return null;
+}

--- a/frontend/src/react/pages/auth/PasswordForgotPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordForgotPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import logoFull from "@/assets/logo-full.svg";
 import { authServiceClientConnect } from "@/connect";
+import { AuthDivider } from "@/react/components/auth/AuthDivider";
 import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
@@ -121,22 +122,17 @@ export function PasswordForgotPage() {
         </div>
       </div>
 
-      <div className="mt-6 relative">
-        <div aria-hidden="true" className="absolute inset-0 flex items-center">
-          <div className="w-full border-t border-control-border" />
-        </div>
-        <div className="relative flex justify-center text-sm">
-          <RouterLink
-            to={{
-              name: AUTH_SIGNIN_MODULE,
-              query: router.currentRoute.value.query,
-            }}
-            className="accent-link bg-white px-2"
-          >
-            {t("auth.password-forget.return-to-sign-in")}
-          </RouterLink>
-        </div>
-      </div>
+      <AuthDivider className="mt-6">
+        <RouterLink
+          to={{
+            name: AUTH_SIGNIN_MODULE,
+            query: router.currentRoute.value.query,
+          }}
+          className="accent-link bg-white px-2"
+        >
+          {t("auth.password-forget.return-to-sign-in")}
+        </RouterLink>
+      </AuthDivider>
     </div>
   );
 }

--- a/frontend/src/react/pages/auth/PasswordResetPage.tsx
+++ b/frontend/src/react/pages/auth/PasswordResetPage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import logoFull from "@/assets/logo-full.svg";
 import { authServiceClientConnect } from "@/connect";
+import { AuthDivider } from "@/react/components/auth/AuthDivider";
 import { UserPasswordFields } from "@/react/components/auth/UserPasswordFields";
 import { computePasswordValidation } from "@/react/components/auth/userPasswordValidation";
 import { RouterLink } from "@/react/components/RouterLink";
@@ -244,22 +245,14 @@ export function PasswordResetPage() {
       </div>
 
       {codeMode && (
-        <div className="mt-6 relative">
-          <div
-            aria-hidden="true"
-            className="absolute inset-0 flex items-center"
+        <AuthDivider className="mt-6">
+          <RouterLink
+            to={{ name: AUTH_SIGNIN_MODULE }}
+            className="accent-link bg-white px-2"
           >
-            <div className="w-full border-t border-control-border" />
-          </div>
-          <div className="relative flex justify-center text-sm">
-            <RouterLink
-              to={{ name: AUTH_SIGNIN_MODULE }}
-              className="accent-link bg-white px-2"
-            >
-              {t("auth.password-forget.return-to-sign-in")}
-            </RouterLink>
-          </div>
-        </div>
+            {t("auth.password-forget.return-to-sign-in")}
+          </RouterLink>
+        </AuthDivider>
       )}
     </div>
   );

--- a/frontend/src/react/pages/auth/SigninPage.test.tsx
+++ b/frontend/src/react/pages/auth/SigninPage.test.tsx
@@ -52,6 +52,7 @@ vi.mock("@/react/stores/app", () => {
 
 vi.mock("@/utils", () => ({
   openWindowForSSO: mocks.openWindowForSSO,
+  isValidEmail: (value: string) => /\S+@\S+\.\S+/.test(value),
 }));
 
 vi.mock("@/react/lib/workspace", () => ({
@@ -63,6 +64,7 @@ vi.mock("react-i18next", () => ({
     t: (key: string, vars?: Record<string, unknown>) =>
       vars ? `${key}:${JSON.stringify(vars)}` : key,
   }),
+  Trans: ({ i18nKey }: { i18nKey: string }) => i18nKey,
   // Completes the mock for the react-i18next migration: `@/react/i18n`
   // registers this plugin via `i18next.use(...)`.
   initReactI18next: { type: "3rdParty", init: () => {} },
@@ -159,6 +161,176 @@ describe("SigninPage", () => {
 
     const emailInput = container.querySelector('input#email[type="email"]');
     expect(emailInput).toBeNull();
+
+    unmount();
+  });
+
+  test("renders flat OAuth-first layout when email code is the only method", async () => {
+    // The real cloud config: the SaaS override sets disallowSignup=true
+    // (it gates the password Signup RPC only) — email-code login still
+    // creates accounts for unknown emails, so the page is a signup surface.
+    mocks.actuatorStore = {
+      serverInfo: {
+        restriction: {
+          disallowPasswordSignin: true,
+          allowEmailCodeSignin: true,
+          disallowSignup: true,
+        },
+      },
+      isSaaSMode: () => true,
+      activeUserCount: () => 1,
+      fetchServerInfo: vi.fn(async () => ({})),
+    };
+    const idps = [
+      {
+        name: "idps/github",
+        title: "GitHub",
+        type: IdentityProviderType.OAUTH2,
+      },
+      {
+        name: "idps/google",
+        title: "Google",
+        type: IdentityProviderType.OAUTH2,
+      },
+    ];
+    mocks.identityProviderList = idps;
+    mocks.listIdentityProviders.mockResolvedValue(idps);
+
+    const { container, render, unmount } = renderIntoContainer(<SigninPage />);
+    render();
+    await flushPromises();
+
+    // Single method: no tab chrome at all.
+    expect(container.querySelector('[role="tab"]')).toBeNull();
+    expect(container.textContent).not.toContain("auth.sign-in.email-code-tab");
+
+    // Combined sign-in/sign-up copy and SaaS terms line.
+    expect(container.textContent).toContain("auth.sign-in.sign-in-or-create");
+    expect(container.textContent).toContain("auth.sign-in.tos");
+
+    // OAuth buttons carry brand icons and "Continue with" copy.
+    const buttons = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button")
+    );
+    const githubButton = buttons.find((button) =>
+      button.textContent?.includes(
+        'auth.sign-in.continue-with-idp:{"idp":"GitHub"}'
+      )
+    );
+    expect(githubButton).toBeTruthy();
+    expect(githubButton?.querySelector("svg")).toBeTruthy();
+    // Icon must not flex-shrink when a long IdP title squeezes the button.
+    expect(githubButton?.querySelector("svg")?.getAttribute("class")).toContain(
+      "shrink-0"
+    );
+    const googleButton = buttons.find((button) =>
+      button.textContent?.includes(
+        'auth.sign-in.continue-with-idp:{"idp":"Google"}'
+      )
+    );
+    expect(googleButton).toBeTruthy();
+    expect(googleButton?.querySelector("svg")).toBeTruthy();
+
+    // OAuth buttons render above the email form.
+    const emailInput = container.querySelector<HTMLInputElement>(
+      'input[type="email"]'
+    );
+    expect(emailInput).toBeTruthy();
+    expect(
+      githubButton!.compareDocumentPosition(emailInput!) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(container.textContent).toContain("auth.sign-in.continue-with-email");
+
+    unmount();
+  });
+
+  test("renders localized tab labels when multiple methods exist", async () => {
+    mocks.actuatorStore = {
+      serverInfo: {
+        restriction: {
+          disallowPasswordSignin: false,
+          allowEmailCodeSignin: true,
+          disallowSignup: false,
+        },
+      },
+      isSaaSMode: () => false,
+      activeUserCount: () => 1,
+      fetchServerInfo: vi.fn(async () => ({})),
+    };
+    mocks.identityProviderList = [];
+    mocks.listIdentityProviders.mockResolvedValue([]);
+
+    const { container, render, unmount } = renderIntoContainer(<SigninPage />);
+    render();
+    await flushPromises();
+
+    expect(container.querySelector('[role="tab"]')).toBeTruthy();
+    expect(container.textContent).toContain("auth.sign-in.standard-tab");
+    expect(container.textContent).not.toContain("Standard");
+    expect(container.textContent).toContain("auth.sign-in.email-code-tab");
+
+    unmount();
+  });
+
+  test("hides terms line and signup copy on a re-auth surface", async () => {
+    // SessionExpiredSurface passes allowSignup={false}: same SaaS config,
+    // but the user already has an account — no signup copy, no terms line.
+    mocks.actuatorStore = {
+      serverInfo: {
+        restriction: {
+          disallowPasswordSignin: true,
+          allowEmailCodeSignin: true,
+          disallowSignup: true,
+        },
+      },
+      isSaaSMode: () => true,
+      activeUserCount: () => 1,
+      fetchServerInfo: vi.fn(async () => ({})),
+    };
+    mocks.identityProviderList = [];
+    mocks.listIdentityProviders.mockResolvedValue([]);
+
+    const { container, render, unmount } = renderIntoContainer(
+      <SigninPage allowSignup={false} />
+    );
+    render();
+    await flushPromises();
+
+    expect(container.textContent).not.toContain("auth.sign-in.tos");
+    expect(container.textContent).toContain("auth.sign-in.sign-in-to-account");
+    expect(container.textContent).not.toContain(
+      "auth.sign-in.sign-in-or-create"
+    );
+
+    unmount();
+  });
+
+  test("hides terms line and signup copy outside SaaS mode", async () => {
+    mocks.actuatorStore = {
+      serverInfo: {
+        restriction: {
+          disallowPasswordSignin: true,
+          allowEmailCodeSignin: true,
+          disallowSignup: true,
+        },
+      },
+      isSaaSMode: () => false,
+      activeUserCount: () => 1,
+      fetchServerInfo: vi.fn(async () => ({})),
+    };
+    mocks.identityProviderList = [];
+    mocks.listIdentityProviders.mockResolvedValue([]);
+
+    const { container, render, unmount } = renderIntoContainer(<SigninPage />);
+    render();
+    await flushPromises();
+
+    expect(container.textContent).not.toContain("auth.sign-in.tos");
+    expect(container.textContent).toContain("auth.sign-in.sign-in-to-account");
+    expect(container.textContent).not.toContain(
+      "auth.sign-in.sign-in-or-create"
+    );
 
     unmount();
   });

--- a/frontend/src/react/pages/auth/SigninPage.tsx
+++ b/frontend/src/react/pages/auth/SigninPage.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
+import { AuthDivider } from "@/react/components/auth/AuthDivider";
 import { AuthFooter } from "@/react/components/auth/AuthFooter";
 import { EmailCodeSigninForm } from "@/react/components/auth/EmailCodeSigninForm";
+import { IdpBrandIcon } from "@/react/components/auth/IdpBrandIcon";
 import { PasswordSigninForm } from "@/react/components/auth/PasswordSigninForm";
 import { BytebaseLogo } from "@/react/components/BytebaseLogo";
 import { RouterLink } from "@/react/components/RouterLink";
@@ -62,11 +64,6 @@ export function SigninPage(props: SigninPageProps) {
   const groupedIdps = identityProviders.filter(
     (idp) => idp.type === IdentityProviderType.LDAP
   );
-
-  const showSignInForm =
-    !serverInfo?.restriction?.disallowPasswordSignin ||
-    groupedIdps.length > 0 ||
-    serverInfo?.restriction?.allowEmailCodeSignin;
 
   const defaultTab = (() => {
     if (serverInfo?.restriction?.allowEmailCodeSignin) return "email-code";
@@ -163,116 +160,163 @@ export function SigninPage(props: SigninPageProps) {
     );
   }
 
+  const methods: {
+    value: string;
+    label: string;
+    panel: React.ReactNode;
+  }[] = [];
+  if (!serverInfo?.restriction?.disallowPasswordSignin) {
+    methods.push({
+      value: "standard",
+      label: t("auth.sign-in.standard-tab"),
+      panel: (
+        <>
+          <PasswordSigninForm loading={isLoading} onSignin={trySignin} />
+          {!disallowSignup && (
+            <div className="mt-3 flex justify-center items-center text-sm text-control gap-x-2">
+              <span>{t("auth.sign-in.new-user")}</span>
+              <RouterLink
+                to={{
+                  name: AUTH_SIGNUP_MODULE,
+                  query,
+                }}
+                className="accent-link"
+              >
+                {t("common.sign-up")}
+              </RouterLink>
+            </div>
+          )}
+        </>
+      ),
+    });
+  }
+  if (serverInfo?.restriction?.allowEmailCodeSignin) {
+    methods.push({
+      value: "email-code",
+      label: t("auth.sign-in.email-code-tab"),
+      panel: <EmailCodeSigninForm loading={isLoading} onSignin={trySignin} />,
+    });
+  }
+  for (const idp of groupedIdps) {
+    methods.push({
+      value: idp.name,
+      label: idp.title,
+      panel: (
+        <PasswordSigninForm
+          loading={isLoading}
+          showForgotPassword={false}
+          credentialLabel={t("common.username")}
+          credentialPlaceholder="jim"
+          credentialInputType="text"
+          credentialAutocomplete="username"
+          onSignin={(req) => trySignin({ ...req, idpName: idp.name })}
+        />
+      ),
+    });
+  }
+
+  // The email-code flow signs an unknown email up on the spot, so the page
+  // doubles as the signup surface — the copy and the terms line reflect that.
+  // On SaaS the restriction reports disallowSignup=true, but that flag only
+  // gates the password Signup RPC, not email-code onboarding.
+  const combinedSignupSurface =
+    methods.length === 1 &&
+    methods[0].value === "email-code" &&
+    allowSignupProp &&
+    (isSaaSMode || !serverInfo?.restriction?.disallowSignup);
+
   return (
     <>
       <div className="h-full flex flex-col justify-center mx-auto w-full max-w-sm">
-        <BytebaseLogo className="mx-auto mb-8" />
+        <BytebaseLogo className="mx-auto mb-2" />
+        <p className="mb-8 text-center text-sm text-control">
+          {combinedSignupSurface
+            ? t("auth.sign-in.sign-in-or-create")
+            : t("auth.sign-in.sign-in-to-account")}
+        </p>
 
         {invitedEmail && (
           <Alert
             variant="info"
-            className="mb-4 mt-4"
+            className="mb-4"
             description={t("auth.sign-in.invited-email", {
               email: invitedEmail,
             })}
           />
         )}
 
-        {showSignInForm && (
+        {separatedIdps.length > 0 && (
+          <div className="flex flex-col gap-y-2">
+            {separatedIdps.map((idp) => (
+              <Button
+                key={idp.name}
+                variant="outline"
+                size="lg"
+                className="w-full"
+                onClick={() => trySigninWithIdp(idp)}
+              >
+                <IdpBrandIcon idp={idp} className="size-4 shrink-0" />
+                {t("auth.sign-in.continue-with-idp", { idp: idp.title })}
+              </Button>
+            ))}
+          </div>
+        )}
+
+        {separatedIdps.length > 0 && methods.length > 0 && (
+          <AuthDivider className="my-4">
+            <span className="px-2 bg-white text-control">{t("common.or")}</span>
+          </AuthDivider>
+        )}
+
+        {methods.length === 1 ? (
+          methods[0].panel
+        ) : methods.length > 1 ? (
           <div className="rounded-sm border border-control-border bg-white p-4">
             <Tabs defaultValue={defaultTab}>
               <TabsList>
-                {!serverInfo?.restriction?.disallowPasswordSignin && (
-                  <TabsTrigger value="standard">Standard</TabsTrigger>
-                )}
-                {serverInfo?.restriction?.allowEmailCodeSignin && (
-                  <TabsTrigger value="email-code">
-                    {t("auth.sign-in.email-code-tab")}
-                  </TabsTrigger>
-                )}
-                {groupedIdps.map((idp) => (
-                  <TabsTrigger key={idp.name} value={idp.name}>
-                    {idp.title}
+                {methods.map((method) => (
+                  <TabsTrigger key={method.value} value={method.value}>
+                    {method.label}
                   </TabsTrigger>
                 ))}
               </TabsList>
-              {!serverInfo?.restriction?.disallowPasswordSignin && (
-                <TabsPanel value="standard" className="pt-3">
-                  <PasswordSigninForm
-                    loading={isLoading}
-                    onSignin={trySignin}
-                  />
-                  {!disallowSignup && (
-                    <div className="mt-3 flex justify-center items-center text-sm text-control gap-x-2">
-                      <span>{t("auth.sign-in.new-user")}</span>
-                      <RouterLink
-                        to={{
-                          name: AUTH_SIGNUP_MODULE,
-                          query,
-                        }}
-                        className="accent-link"
-                      >
-                        {t("common.sign-up")}
-                      </RouterLink>
-                    </div>
-                  )}
-                </TabsPanel>
-              )}
-              {serverInfo?.restriction?.allowEmailCodeSignin && (
-                <TabsPanel value="email-code" className="pt-3">
-                  <EmailCodeSigninForm
-                    loading={isLoading}
-                    onSignin={trySignin}
-                  />
-                </TabsPanel>
-              )}
-              {groupedIdps.map((idp) => (
-                <TabsPanel key={idp.name} value={idp.name} className="pt-3">
-                  <PasswordSigninForm
-                    loading={isLoading}
-                    showForgotPassword={false}
-                    credentialLabel={t("common.username")}
-                    credentialPlaceholder="jim"
-                    credentialInputType="text"
-                    credentialAutocomplete="username"
-                    onSignin={(req) => trySignin({ ...req, idpName: idp.name })}
-                  />
+              {methods.map((method) => (
+                <TabsPanel
+                  key={method.value}
+                  value={method.value}
+                  className="pt-3"
+                >
+                  {method.panel}
                 </TabsPanel>
               ))}
             </Tabs>
           </div>
-        )}
+        ) : null}
 
-        {separatedIdps.length > 0 && (
-          <div className="mb-3 px-1">
-            {showSignInForm && (
-              <div className="relative my-4">
-                <div
-                  aria-hidden="true"
-                  className="absolute inset-0 flex items-center"
-                >
-                  <div className="w-full border-t border-control-border" />
-                </div>
-                <div className="relative flex justify-center text-sm">
-                  <span className="px-2 bg-white text-control">
-                    {t("common.or")}
-                  </span>
-                </div>
-              </div>
-            )}
-            {separatedIdps.map((idp) => (
-              <div key={idp.name} className="w-full mb-2">
-                <Button
-                  variant="outline"
-                  size="lg"
-                  className="w-full"
-                  onClick={() => trySigninWithIdp(idp)}
-                >
-                  {t("auth.sign-in.sign-in-with-idp", { idp: idp.title })}
-                </Button>
-              </div>
-            ))}
-          </div>
+        {isSaaSMode && combinedSignupSurface && (
+          <p className="mt-6 text-center text-xs text-control-light leading-5">
+            <Trans
+              i18nKey="auth.sign-in.tos"
+              components={{
+                terms: (
+                  <a
+                    href="https://www.bytebase.com/terms"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-control"
+                  />
+                ),
+                privacy: (
+                  <a
+                    href="https://www.bytebase.com/privacy"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-control"
+                  />
+                ),
+              }}
+            />
+          </p>
         )}
       </div>
 

--- a/frontend/src/react/pages/auth/SigninPage.tsx
+++ b/frontend/src/react/pages/auth/SigninPage.tsx
@@ -268,9 +268,8 @@ export function SigninPage(props: SigninPageProps) {
           </AuthDivider>
         )}
 
-        {methods.length === 1 ? (
-          methods[0].panel
-        ) : methods.length > 1 ? (
+        {methods.length === 1 && methods[0].panel}
+        {methods.length > 1 && (
           <div className="rounded-sm border border-control-border bg-white p-4">
             <Tabs defaultValue={defaultTab}>
               <TabsList>
@@ -291,20 +290,24 @@ export function SigninPage(props: SigninPageProps) {
               ))}
             </Tabs>
           </div>
-        ) : null}
+        )}
 
         {isSaaSMode && combinedSignupSurface && (
           <p className="mt-6 text-center text-xs text-control-light leading-5">
             <Trans
               i18nKey="auth.sign-in.tos"
               components={{
+                // The anchor children are fallbacks — Trans replaces them
+                // with the localized text inside <terms>/<privacy> tags.
                 terms: (
                   <a
                     href="https://www.bytebase.com/terms"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline hover:text-control"
-                  />
+                  >
+                    Terms of Service
+                  </a>
                 ),
                 privacy: (
                   <a
@@ -312,7 +315,9 @@ export function SigninPage(props: SigninPageProps) {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="underline hover:text-control"
-                  />
+                  >
+                    Privacy Policy
+                  </a>
                 ),
               }}
             />

--- a/frontend/src/react/pages/auth/SignupPage.tsx
+++ b/frontend/src/react/pages/auth/SignupPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
+import { AuthDivider } from "@/react/components/auth/AuthDivider";
 import { AuthFooter } from "@/react/components/auth/AuthFooter";
 import { UserPasswordFields } from "@/react/components/auth/UserPasswordFields";
 import { computePasswordValidation } from "@/react/components/auth/userPasswordValidation";
@@ -222,25 +223,17 @@ export function SignupPage() {
         </div>
 
         {!needAdminSetup && (
-          <div className="mt-6 relative">
-            <div
-              aria-hidden="true"
-              className="absolute inset-0 flex items-center"
+          <AuthDivider className="mt-6">
+            <span className="pl-2 bg-white text-control">
+              {t("auth.sign-up.existing-user")}
+            </span>
+            <RouterLink
+              to={{ name: AUTH_SIGNIN_MODULE, query }}
+              className="accent-link px-2 bg-white"
             >
-              <div className="w-full border-t border-control-border" />
-            </div>
-            <div className="relative flex justify-center text-sm">
-              <span className="pl-2 bg-white text-control">
-                {t("auth.sign-up.existing-user")}
-              </span>
-              <RouterLink
-                to={{ name: AUTH_SIGNIN_MODULE, query }}
-                className="accent-link px-2 bg-white"
-              >
-                {t("common.sign-in")}
-              </RouterLink>
-            </div>
-          </div>
+              {t("common.sign-in")}
+            </RouterLink>
+          </AuthDivider>
         )}
       </div>
 


### PR DESCRIPTION
## What

Redesigns the sign-in page (`cloud.bytebase.com/auth` and self-hosted) to match standard SaaS auth patterns.

**Before (cloud):** a bordered card with a lonely "Email Code" tab, an "Email *" form label, a "Send code" button, and text-only "Sign in with GitHub/Google" buttons below the form. No headline, no signup copy, no terms consent — even though email-code login auto-creates an account for unknown emails on SaaS.

**After (cloud):** logo → "Sign in or create your account" → GitHub/Google buttons with brand icons ("Continue with GitHub") → "or" → email field → "Continue with email" → terms-of-service line.

## Changes

- **Flat single-method layout** — tab chrome and card border render only when multiple methods exist (self-hosted password/email-code/LDAP keeps tabs). A lone method (email-code on cloud, or a single LDAP/password method) renders flat.
- **OAuth above email, with brand icons** — `IdpBrandIcon` resolves the brand from the OAuth2 `authUrl` / OIDC `issuer` hostname (authoritative; a config pointing at e.g. Okta never shows a GitHub logo regardless of title), falling back to title matching only when no config URL is available. Google's mark uses the standard colors per [Google's branding guidelines](https://developers.google.com/identity/branding-guidelines).
- **Copy** — no more "Email Code" jargon on the single-method surface; "Continue with email"/"Continue with {idp}" verb framing; sr-only email label (no red asterisk); `you@company.com` placeholder; subline distinguishes the combined sign-in/sign-up surface from re-auth ("Sign in to your account").
- **Terms consent line** — shown only on the SaaS combined surface (`isSaaSMode && combinedSignupSurface`), since that page creates accounts. Note: the gate is `(isSaaSMode || !disallowSignup)` because the SaaS restriction reports `disallowSignup=true` while email-code onboarding stays open — that flag only gates the password Signup RPC (see `authenticateEmailCodeLogin`). A follow-up will expose this as an explicit `Restriction` field.
- **Cleanups** — localized the previously hardcoded "Standard" tab label (5 locales); extracted the duplicated centered-divider markup into `AuthDivider` (used by 4 auth pages); `shrink-0` on brand icons so long IdP titles can't squeeze them; removed now-unused `send-code`/`sign-in-with-idp` i18n keys.

## Why

The cloud auth page was the self-hosted console's sign-in screen rendered in SaaS mode, which read as an internal tool. Patterns were verified against live auth pages of Vercel, Supabase, PlanetScale, Railway, Linear, Notion, Neon, Slack, and MongoDB Atlas rather than from memory.

## Testing

- TDD throughout: 11 tests across `SigninPage.test.tsx` (flat layout under the real cloud config `disallowSignup=true`, localized tab labels, re-auth surface, non-SaaS), `IdpBrandIcon.test.tsx` (config-over-title resolution, OIDC issuer, false-positive rejection, title fallback), and `EmailCodeSigninForm.test.tsx`.
- Full frontend suite: 2248 tests passing; `pnpm check` (i18n key parity, layering), `type-check`, `fix` all clean.
- Multi-agent code review (9 finder angles + adversarial verification) ran over the diff; all confirmed findings are fixed in this PR except the backend `Restriction` field, which is deliberately split out.

## Reviewer notes

- OAuth-first ordering follows the majority comparator pattern; if we prefer email-first to capture work emails for lead routing (Vercel/PlanetScale precedent), it's a single array swap in `SigninPage.tsx`.
- Self-hosted default (password-only) also loses its single "Standard" tab chrome — intentional, same degenerate-tab fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)