### PR TITLE
fix(schema/mysql): align omni catalogToProto with driver metadata conventions

### DIFF
--- a/backend/plugin/schema/mysql/get_database_metadata_testcontainer_test.go
+++ b/backend/plugin/schema/mysql/get_database_metadata_testcontainer_test.go
@@ -531,8 +531,9 @@ CREATE TABLE json_features (
 			dbMetadata, err := driver.SyncDBSchema(ctx)
 			require.NoError(t, err)
 
-			// Get metadata from parser
-			parsedMetadata, err := GetDatabaseMetadata(tc.ddl)
+			// Get metadata from the omni parser, the function registered for
+			// the production diff path (see get_database_metadata_omni.go).
+			parsedMetadata, err := GetDatabaseMetadataOmni(tc.ddl)
 			require.NoError(t, err)
 
 			// Compare metadata

--- a/backend/plugin/schema/mysql/testdata/walk_through.yaml
+++ b/backend/plugin/schema/mysql/testdata/walk_through.yaml
@@ -19,8 +19,7 @@
     {
       "name": "test",
       "schemas": [
-        {
-        }
+        {}
       ],
       "characterSet": "utf8mb4",
       "collation": "utf8mb4_0900_ai_ci"
@@ -67,6 +66,7 @@
                 {
                   "name": "a",
                   "position": 1,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 }
@@ -125,8 +125,7 @@
     {
       "name": "test",
       "schemas": [
-        {
-        }
+        {}
       ],
       "characterSet": "utf8mb4",
       "collation": "utf8mb4_polish_ci"
@@ -199,12 +198,14 @@
                 {
                   "name": "a",
                   "position": 1,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 },
                 {
                   "name": "b",
                   "position": 2,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 },
@@ -228,7 +229,7 @@
                     "a"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -241,7 +242,7 @@
                     "b"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -256,7 +257,7 @@
                     "c"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -270,7 +271,7 @@
                     "d"
                   ],
                   "keyLength": [
-                    "0"
+                    "32"
                   ],
                   "descending": [
                     false
@@ -328,6 +329,7 @@
                 {
                   "name": "b",
                   "position": 2,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 }
@@ -339,7 +341,7 @@
                     "a"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -355,7 +357,7 @@
                     "b"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -403,6 +405,7 @@
                 {
                   "name": "b",
                   "position": 2,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 }
@@ -441,12 +444,14 @@
                 {
                   "name": "a",
                   "position": 1,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 },
                 {
                   "name": "b",
                   "position": 2,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 }
@@ -458,7 +463,7 @@
                     "b"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -473,7 +478,7 @@
                     "b"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -499,8 +504,7 @@
     {
       "name": "test",
       "schemas": [
-        {
-        }
+        {}
       ],
       "characterSet": "utf8mb4",
       "collation": "utf8mb4_0900_ai_ci"
@@ -586,13 +590,14 @@
                 {
                   "name": "a",
                   "position": 1,
-                  "default": "1",
+                  "default": "'1'",
                   "nullable": true,
                   "type": "int"
                 },
                 {
                   "name": "d",
                   "position": 2,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "text",
                   "characterSet": "utf8mb4",
@@ -637,12 +642,14 @@
                 {
                   "name": "e",
                   "position": 1,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 },
                 {
                   "name": "f",
                   "position": 2,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "text",
                   "characterSet": "utf8mb4",
@@ -651,6 +658,7 @@
                 {
                   "name": "c",
                   "position": 3,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 }
@@ -683,6 +691,7 @@
                 {
                   "name": "a",
                   "position": 1,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 }
@@ -761,9 +770,9 @@
                 {
                   "name": "c",
                   "position": 1,
+                  "default": "' SELECT '",
                   "nullable": true,
                   "type": "varchar(20)",
-                  "default": "' SELECT '",
                   "characterSet": "utf8mb4",
                   "collation": "utf8mb4_0900_ai_ci"
                 }
@@ -796,6 +805,7 @@
                 {
                   "name": "a",
                   "position": 1,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 }
@@ -809,6 +819,7 @@
                 {
                   "name": "a",
                   "position": 1,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 }
@@ -852,12 +863,13 @@
                 {
                   "name": "b",
                   "position": 2,
-                  "default": "1",
+                  "default": "'1'",
                   "type": "int"
                 },
                 {
                   "name": "c",
                   "position": 3,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 },
@@ -871,6 +883,7 @@
                 {
                   "name": "e",
                   "position": 5,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "varchar(255)",
                   "characterSet": "utf8mb4",
@@ -884,7 +897,7 @@
                     "a"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -901,8 +914,8 @@
                     "c"
                   ],
                   "keyLength": [
-                    "0",
-                    "0"
+                    "-1",
+                    "-1"
                   ],
                   "descending": [
                     false,
@@ -918,7 +931,7 @@
                     "c"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -933,8 +946,8 @@
                     "e"
                   ],
                   "keyLength": [
-                    "0",
-                    "0"
+                    "-1",
+                    "-1"
                   ],
                   "descending": [
                     false,
@@ -1014,12 +1027,13 @@
                 {
                   "name": "a",
                   "position": 1,
-                  "default": "1",
+                  "default": "'1'",
                   "type": "int"
                 },
                 {
                   "name": "b",
                   "position": 2,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 },
@@ -1061,7 +1075,7 @@
                     "a"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -1077,7 +1091,7 @@
                     "b"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -1122,12 +1136,14 @@
                 {
                   "name": "id",
                   "position": 1,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 },
                 {
                   "name": "name",
                   "position": 2,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "varchar(255)",
                   "characterSet": "utf8mb4",
@@ -1141,7 +1157,7 @@
                     "name"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -1159,12 +1175,14 @@
                 {
                   "name": "id",
                   "position": 1,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "int"
                 },
                 {
                   "name": "t1_name",
                   "position": 2,
+                  "default": "NULL",
                   "nullable": true,
                   "type": "varchar(255)",
                   "characterSet": "utf8mb4",
@@ -1178,7 +1196,7 @@
                     "t1_name"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false
@@ -1276,6 +1294,7 @@
                 {
                   "name": "c10",
                   "position": 10,
+                  "default": "AUTO_INCREMENT",
                   "type": "bigint unsigned"
                 }
               ],
@@ -1286,7 +1305,7 @@
                     "c10"
                   ],
                   "keyLength": [
-                    "0"
+                    "-1"
                   ],
                   "descending": [
                     false

--- a/backend/plugin/schema/mysql/walk_through_omni.go
+++ b/backend/plugin/schema/mysql/walk_through_omni.go
@@ -685,6 +685,11 @@ func tableToProto(t *catalog.Table) *storepb.TableMetadata {
 
 	// Columns.
 	for _, col := range t.Columns {
+		if col.Hidden == catalog.ColumnHiddenSystem {
+			// System-hidden columns (e.g. backing columns of functional
+			// indexes) are not reported by information_schema.
+			continue
+		}
 		colMeta := &storepb.ColumnMetadata{
 			Name:         col.Name,
 			Position:     int32(col.Position),
@@ -694,8 +699,18 @@ func tableToProto(t *catalog.Table) *storepb.TableMetadata {
 			Collation:    col.Collation,
 			Comment:      col.Comment,
 		}
-		if col.Default != nil {
-			colMeta.Default = *col.Default
+		switch {
+		case col.AutoIncrement:
+			// Match the driver convention: AUTO_INCREMENT columns report
+			// "AUTO_INCREMENT" as the default (see backend/plugin/db/mysql/sync.go).
+			colMeta.Default = "AUTO_INCREMENT"
+		case col.Default != nil:
+			colMeta.Default = normalizeOmniDefault(*col.Default, col.DefaultKind)
+		case col.Nullable:
+			// Match the driver convention: a nullable column without an explicit
+			// default has an implicit default of NULL.
+			colMeta.Default = "NULL"
+		default:
 		}
 		if col.OnUpdate != "" {
 			colMeta.OnUpdate = col.OnUpdate
@@ -733,7 +748,16 @@ func tableToProto(t *catalog.Table) *storepb.TableMetadata {
 			} else {
 				idxMeta.Expressions = append(idxMeta.Expressions, col.Name)
 			}
-			idxMeta.KeyLength = append(idxMeta.KeyLength, int64(col.Length))
+			keyLength := int64(col.Length)
+			if keyLength == 0 {
+				// Match the driver convention: -1 means no prefix length specified.
+				keyLength = -1
+			}
+			if keyLength == -1 && indexType == "SPATIAL" {
+				// MySQL reports a key length of 32 for spatial index columns.
+				keyLength = 32
+			}
+			idxMeta.KeyLength = append(idxMeta.KeyLength, keyLength)
 			idxMeta.Descending = append(idxMeta.Descending, col.Descending)
 		}
 		table.Indexes = append(table.Indexes, idxMeta)
@@ -773,13 +797,40 @@ func tableToProto(t *catalog.Table) *storepb.TableMetadata {
 	return table
 }
 
+// normalizeOmniDefault converts an omni catalog default value to the driver
+// representation produced by SyncDBSchema (see backend/plugin/db/mysql/sync.go):
+// static defaults are kept single-quoted for mysqldump compatibility and
+// expression defaults are wrapped in parentheses.
+func normalizeOmniDefault(value string, kind catalog.ColumnDefaultKind) string {
+	switch kind {
+	case catalog.ColumnDefaultConstant:
+		if strings.EqualFold(value, "NULL") {
+			return "NULL"
+		}
+		if len(value) >= 2 && strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'") {
+			return value
+		}
+		return fmt.Sprintf("'%s'", value)
+	case catalog.ColumnDefaultExpression:
+		return fmt.Sprintf("(%s)", value)
+	default:
+		return value
+	}
+}
+
 func partitionsToProto(p *catalog.PartitionInfo) []*storepb.TablePartitionMetadata {
+	expr := p.Expr
+	if expr == "" && len(p.Columns) > 0 {
+		// RANGE COLUMNS / LIST COLUMNS / KEY partitioning carries a column
+		// list instead of an expression; the driver reports the joined list.
+		expr = strings.Join(p.Columns, ",")
+	}
 	var result []*storepb.TablePartitionMetadata
 	for _, pd := range p.Partitions {
 		result = append(result, &storepb.TablePartitionMetadata{
 			Name:       pd.Name,
 			Type:       partitionTypeToProto(p.Type),
-			Expression: p.Expr,
+			Expression: expr,
 			Value:      pd.ValueExpr,
 		})
 	}


### PR DESCRIPTION
## What

Fixes Sync Schema false-positive diffs between identical MySQL databases, a regression shipped in 3.17.0. Fixes #20486 (Linear: BYT-9688).

`DiffSchema` compares driver-synced metadata (`backend/plugin/db/mysql/sync.go`) against metadata re-parsed from the schema dump. Since #19905 the parse path is `GetDatabaseMetadataOmni` → `catalogToProto`, which lacked the normalizations the driver applies — and the differ compares these fields byte-for-byte, so every nullable column, auto-increment PK, and index on **identical** databases was flagged as changed, generating spurious ALTER/index DDL.

### Changes to `catalogToProto` (production parity with driver sync)

- AUTO_INCREMENT columns report `Default: "AUTO_INCREMENT"`
- Nullable columns without an explicit default report `Default: "NULL"`
- Static defaults are single-quoted (`'0'`), expression defaults parenthesized (`(uuid())`), keyed off the omni `DefaultKind`; explicit `DEFAULT NULL` stays `NULL`
- Index key length is `-1` when no prefix length is specified, `32` for SPATIAL index columns
- System-hidden columns (functional-index backing columns) are skipped, matching `information_schema`
- `RANGE COLUMNS` / `LIST COLUMNS` partitions report the joined column list as the partition expression

### Test path fix (why CI never caught this)

`TestGetDatabaseMetadataWithTestcontainer` does exactly this driver-vs-parser parity comparison — but it called the package-local **ANTLR** `GetDatabaseMetadata`, while production registers `GetDatabaseMetadataOmni`. CI stayed green for three minor releases while testing a parser the production diff path no longer uses. The test now calls the registered omni function. The five additional mismatches it immediately exposed (default quoting, hidden columns, column partitions, spatial key length) are fixed above.

Walk-through goldens (`testdata/walk_through.yaml`) updated for the new conventions.

## Why

Affects every MySQL and OceanBase user of Sync Schema / DiffSchema on 3.17.0 → 3.19.0: identical databases diff as different, and real diffs include unrelated index/PK/FK churn. Should be cherry-picked to a 3.19.x patch release.

## Testing

- `TestGetDatabaseMetadataWithTestcontainer` against a real MySQL 8.0 testcontainer: 23/23 subtests pass (was 18/23 once repointed at the omni function)
- `backend/plugin/schema/mysql` and `backend/plugin/advisor/mysql` package tests pass
- `golangci-lint` clean, full server build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)