### PR TITLE
fix(auth): stop "Authentication failed" flash during SSO sign-in

### DIFF
--- a/frontend/scripts/check-react-i18n.mjs
+++ b/frontend/scripts/check-react-i18n.mjs
@@ -32,6 +32,10 @@ const DYNAMIC_PREFIXES = [
   "settings.sensitive-data.algorithms.",
   "instance.selected-n-instances",
   "settings.sidebar.",
+  // Stored as messageKey string literals and translated via t(messageKey) at
+  // render, not as literal t("…") calls. See
+  // frontend/src/react/pages/auth/OAuthCallbackPage.tsx.
+  "auth.oauth-callback.",
   // Returned from getReviewBadge as labelKey string literals, not invoked
   // via t("…") in source. See frontend/src/react/pages/project/utils/reviewBadge.ts.
   "common.bypassed",

--- a/frontend/src/react/app/AuthGate.test.tsx
+++ b/frontend/src/react/app/AuthGate.test.tsx
@@ -72,7 +72,7 @@ vi.mock("@/react/components/auth/InactiveRemindModal", () => ({
 
 vi.mock("@/react/router/guard", () => ({
   buildSigninRedirectQuery: mocks.buildSigninRedirectQuery,
-  isAuthRelatedRoute: () => false,
+  isAuthRelatedRoute: (name: string) => name.startsWith("auth."),
 }));
 
 vi.mock("@/react/router/handles", () => ({
@@ -234,6 +234,39 @@ describe("AuthGate", () => {
 
     expect(mocks.navigate).not.toHaveBeenCalled();
     expect(container.querySelector("[data-testid='page']")).not.toBeNull();
+  });
+
+  test("keeps auth-route children mounted while post-login workspace data loads", async () => {
+    mocks.session.isLoggedIn = false;
+    mocks.routeName = "auth.oauth.callback";
+    mocks.location.pathname = "/oauth/callback";
+    // Hold the post-login data load open so the gate stays in its loading
+    // phase for the rest of the test (once: it must not leak into later tests
+    // — clearAllMocks doesn't restore implementations).
+    mocks.loadSubscription.mockImplementationOnce(() => new Promise(() => {}));
+
+    await act(async () => {
+      root.render(
+        <AuthGate>
+          <div data-testid="page">Page</div>
+        </AuthGate>
+      );
+    });
+
+    expect(container.querySelector("[data-testid='page']")).not.toBeNull();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+
+    // The OAuth callback page completes login() mid-page: the session flips
+    // without a navigation. The callback page must stay mounted — unmounting
+    // would discard its in-flight UI and re-process the single-use OAuth
+    // state token on remount.
+    await act(async () => {
+      mocks.session.isLoggedIn = true;
+      useAppStore.setState({});
+    });
+
+    expect(container.querySelector("[data-testid='page']")).not.toBeNull();
+    expect(container.querySelector("[role='status']")).toBeNull();
   });
 
   test("refreshes permission data in the background during session polling", async () => {

--- a/frontend/src/react/app/AuthGate.tsx
+++ b/frontend/src/react/app/AuthGate.tsx
@@ -132,9 +132,14 @@ export function AuthGate({ children }: { children: ReactNode }) {
     });
   }, [currentUserName, navigate, t]);
 
+  // Auth surfaces (signin, OAuth/OIDC callbacks, MFA, …) render outside the
+  // readiness gate: they don't depend on the workspace data loaded above, and
+  // hiding them while it loads would unmount the OAuth callback page mid-login
+  // (its `login()` flips `isLoggedIn`, which triggers that load) and blank the
+  // signin page on first paint.
   return (
     <>
-      {ready && !shouldRedirectToSignin ? (
+      {(ready || isAuthRoute) && !shouldRedirectToSignin ? (
         children
       ) : (
         <div className="flex items-center justify-center h-screen">

--- a/frontend/src/react/pages/auth/OAuthCallbackPage.test.tsx
+++ b/frontend/src/react/pages/auth/OAuthCallbackPage.test.tsx
@@ -107,6 +107,9 @@ beforeEach(async () => {
   mocks.login.mockResolvedValue(undefined);
   mocks.retrieveOAuthState.mockReset();
   mocks.clearOAuthState.mockReset();
+  // The module memoizes processed callbacks by state token for the lifetime of
+  // the page load (the module instance is cached across tests here), so every
+  // test must use a token unique to that test.
   ({ OAuthCallbackPage } = await import("./OAuthCallbackPage"));
 });
 
@@ -133,7 +136,7 @@ describe("OAuthCallbackPage", () => {
   });
 
   test("renders error when stored state not found", async () => {
-    mocks.currentRoute.value.query = { state: "xyz" };
+    mocks.currentRoute.value.query = { state: "expired-token" };
     mocks.retrieveOAuthState.mockReturnValue(null);
     const { container, render, unmount } = renderIntoContainer(
       <OAuthCallbackPage />
@@ -147,7 +150,7 @@ describe("OAuthCallbackPage", () => {
   });
 
   test("renders security-validation error and clears state when token mismatches", async () => {
-    mocks.currentRoute.value.query = { state: "xyz" };
+    mocks.currentRoute.value.query = { state: "mismatch-token" };
     mocks.retrieveOAuthState.mockReturnValue({
       token: "OTHER",
       event: "bb.oauth.signin.gh",
@@ -162,14 +165,14 @@ describe("OAuthCallbackPage", () => {
     expect(container.textContent).toContain(
       "auth.oauth-callback.security-failed"
     );
-    expect(mocks.clearOAuthState).toHaveBeenCalledWith("xyz");
+    expect(mocks.clearOAuthState).toHaveBeenCalledWith("mismatch-token");
     unmount();
   });
 
   test("redirect mode: valid signin event calls authStore.login with oauth2Context", async () => {
-    mocks.currentRoute.value.query = { state: "xyz", code: "abc" };
+    mocks.currentRoute.value.query = { state: "signin-token", code: "abc" };
     mocks.retrieveOAuthState.mockReturnValue({
-      token: "xyz",
+      token: "signin-token",
       event: "bb.oauth.signin.gh",
       idpType: IdentityProviderType.OAUTH2,
       popup: false,
@@ -199,9 +202,9 @@ describe("OAuthCallbackPage", () => {
   });
 
   test("redirect mode: OIDC event uses oidcContext", async () => {
-    mocks.currentRoute.value.query = { state: "xyz", code: "abc" };
+    mocks.currentRoute.value.query = { state: "oidc-token", code: "abc" };
     mocks.retrieveOAuthState.mockReturnValue({
-      token: "xyz",
+      token: "oidc-token",
       event: "bb.oauth.signin.okta",
       idpType: IdentityProviderType.OIDC,
       popup: false,
@@ -222,10 +225,46 @@ describe("OAuthCallbackPage", () => {
     unmount();
   });
 
+  test("remount replays the processed outcome instead of re-processing the consumed token", async () => {
+    mocks.currentRoute.value.query = { state: "remount-token", code: "abc" };
+    // Single-use token: consumed (cleared) by the first mount, gone afterwards.
+    mocks.retrieveOAuthState
+      .mockReturnValueOnce({
+        token: "remount-token",
+        event: "bb.oauth.signin.gh",
+        idpType: IdentityProviderType.OAUTH2,
+        popup: false,
+        redirect: "/home",
+        timestamp: Date.now(),
+      })
+      .mockReturnValue(null);
+
+    const first = renderIntoContainer(<OAuthCallbackPage />);
+    first.render();
+    await flushPromises();
+    expect(mocks.login).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    // The app shell may remount routed content while login() is still running
+    // (e.g. AuthGate reloading workspace data when the session flips).
+    const second = renderIntoContainer(<OAuthCallbackPage />);
+    second.render();
+    await flushPromises();
+    expect(second.container.textContent).toContain(
+      "auth.oauth-callback.success-redirecting"
+    );
+    expect(second.container.textContent).not.toContain(
+      "auth.oauth-callback.session-expired"
+    );
+    // The in-flight login from the first mount must not be re-issued.
+    expect(mocks.login).toHaveBeenCalledTimes(1);
+    second.unmount();
+  });
+
   test("popup mode: dispatches CustomEvent on window.opener with payload", async () => {
-    mocks.currentRoute.value.query = { state: "xyz", code: "abc" };
+    mocks.currentRoute.value.query = { state: "popup-token", code: "abc" };
     mocks.retrieveOAuthState.mockReturnValue({
-      token: "xyz",
+      token: "popup-token",
       event: "bb.oauth.signin.gh",
       idpType: IdentityProviderType.OAUTH2,
       popup: true,

--- a/frontend/src/react/pages/auth/OAuthCallbackPage.tsx
+++ b/frontend/src/react/pages/auth/OAuthCallbackPage.tsx
@@ -12,57 +12,90 @@ import { LoginRequestSchema } from "@/types/proto-es/v1/auth_service_pb";
 import { IdentityProviderType } from "@/types/proto-es/v1/idp_service_pb";
 import { clearOAuthState, retrieveOAuthState } from "@/utils/sso";
 
+type ProcessedOutcome = {
+  hasError: boolean;
+  messageKey: string;
+  oAuthState: OAuthState | undefined;
+};
+
+// The OAuth `state` token is single-use: processing consumes it from
+// localStorage (`clearOAuthState`). The page component, however, can mount
+// more than once per callback navigation — StrictMode double-invokes effects,
+// and the app shell can remount routed content while the kicked-off `login()`
+// is still running. Re-processing would find the token already consumed and
+// misreport a fatal-looking "session expired" error mid-login. Memoizing the
+// outcome at module scope makes processing once-per-page-load (the standard
+// redirect-callback contract): later mounts replay the outcome render-only,
+// leaving the side effects (opener dispatch / login) to the run that computed
+// it.
+const processedOutcomes = new Map<string, ProcessedOutcome>();
+
 export function OAuthCallbackPage() {
   const { t } = useTranslation();
-  const [message, setMessage] = useState("");
+  const [messageKey, setMessageKey] = useState("");
   const [hasError, setHasError] = useState(false);
   const [oAuthState, setOAuthState] = useState<OAuthState | undefined>(
     undefined
   );
   const [showCloseButton, setShowCloseButton] = useState(false);
   const payloadRef = useRef<OAuthWindowEventPayload>({ error: "", code: "" });
-  // StrictMode double-invokes effects; the OAuth state token is single-use
-  // (consumed via `clearOAuthState`). Without this guard the second invocation
-  // would fail to retrieve the already-cleared token and flash a
-  // "session expired" error before the login completes.
-  const initRef = useRef(false);
 
   useEffect(() => {
-    if (initRef.current) return;
-    initRef.current = true;
     const query = router.currentRoute.value.query;
-    const stateToken = query.state as string | undefined;
+    const stateToken = typeof query.state === "string" ? query.state : "";
 
-    if (
-      !stateToken ||
-      typeof stateToken !== "string" ||
-      stateToken.length === 0
-    ) {
-      setHasError(true);
-      setMessage(t("auth.oauth-callback.invalid-state"));
+    const replayed = processedOutcomes.get(stateToken);
+    if (replayed) {
+      setHasError(replayed.hasError);
+      setMessageKey(replayed.messageKey);
+      setOAuthState(replayed.oAuthState);
+      return;
+    }
+
+    const apply = (outcome: ProcessedOutcome) => {
+      processedOutcomes.set(stateToken, outcome);
+      setHasError(outcome.hasError);
+      setMessageKey(outcome.messageKey);
+      setOAuthState(outcome.oAuthState);
+    };
+
+    if (stateToken.length === 0) {
+      apply({
+        hasError: true,
+        messageKey: "auth.oauth-callback.invalid-state",
+        oAuthState: undefined,
+      });
       triggerAuthCallback(undefined, true);
       return;
     }
 
     const storedState = retrieveOAuthState(stateToken);
     if (!storedState) {
-      setHasError(true);
-      setMessage(t("auth.oauth-callback.session-expired"));
+      apply({
+        hasError: true,
+        messageKey: "auth.oauth-callback.session-expired",
+        oAuthState: undefined,
+      });
       triggerAuthCallback(undefined, true);
       return;
     }
 
     if (storedState.token !== stateToken) {
-      setHasError(true);
-      setMessage(t("auth.oauth-callback.security-failed"));
+      apply({
+        hasError: true,
+        messageKey: "auth.oauth-callback.security-failed",
+        oAuthState: undefined,
+      });
       clearOAuthState(stateToken);
       triggerAuthCallback(undefined, true);
       return;
     }
 
-    setOAuthState(storedState);
-    setHasError(false);
-    setMessage(t("auth.oauth-callback.success-redirecting"));
+    apply({
+      hasError: false,
+      messageKey: "auth.oauth-callback.success-redirecting",
+      oAuthState: storedState,
+    });
     payloadRef.current.code = (query.code as string) || "";
     clearOAuthState(storedState.token);
     triggerAuthCallback(storedState, false);
@@ -76,7 +109,7 @@ export function OAuthCallbackPage() {
       try {
         if (!window.opener || window.opener.closed) {
           setHasError(true);
-          setMessage(t("auth.oauth-callback.opener-unavailable"));
+          setMessageKey("auth.oauth-callback.opener-unavailable");
           setShowCloseButton(true);
           return;
         }
@@ -94,20 +127,20 @@ export function OAuthCallbackPage() {
             if (!window.closed) {
               setShowCloseButton(true);
               if (!isError) {
-                setMessage(t("auth.oauth-callback.success-close"));
+                setMessageKey("auth.oauth-callback.success-close");
               }
             }
           }, 500);
         } catch {
           setShowCloseButton(true);
           if (!isError) {
-            setMessage(t("auth.oauth-callback.please-close"));
+            setMessageKey("auth.oauth-callback.please-close");
           }
         }
       } catch (error) {
         console.error("Failed to communicate with opener window:", error);
         setHasError(true);
-        setMessage(t("auth.oauth-callback.opener-failed"));
+        setMessageKey("auth.oauth-callback.opener-failed");
         setShowCloseButton(true);
       }
       return;
@@ -152,7 +185,7 @@ export function OAuthCallbackPage() {
     <div className="p-4">
       {hasError ? (
         <div className="mt-2">
-          <div>{message}</div>
+          <div>{messageKey && t(messageKey)}</div>
           {oAuthState?.popup ? (
             <Button onClick={() => window.close()}>{t("common.close")}</Button>
           ) : (
@@ -165,7 +198,7 @@ export function OAuthCallbackPage() {
         <div className="mt-2">
           <div className="flex items-center gap-x-2">
             <Loader2 className="size-4 animate-spin" />
-            <span>{message || t("auth.oauth-callback.processing")}</span>
+            <span>{t(messageKey || "auth.oauth-callback.processing")}</span>
           </div>
           {oAuthState?.popup && showCloseButton && (
             <Button className="mt-4" onClick={() => window.close()}>


### PR DESCRIPTION
## What

During Google SSO on Bytebase Cloud, a white screen reading **"Authentication failed: Session expired or invalid. Please try again."** flashed in the middle of the flow — even though the login completed successfully right after.

## Why it happened

1. `/oauth/callback` validates the single-use OAuth `state` token, consumes it from localStorage, and kicks off `login()` in the app store.
2. When `login()` → `fetchCurrentUser()` flips `isLoggedIn`, `AuthGate`'s readiness gate unmounts the routed tree, loads workspace data, then remounts it.
3. The remounted callback page re-ran its init effect (the old `initRef` guard was per-instance — it only covered StrictMode double-effects, not remounts), found the token already consumed, and rendered the session-expired error.
4. Meanwhile the original `login()` promise (store-owned, surviving the unmount) finished and navigated into the app — so the error was a transient race window, wide enough to notice on cloud RPC latencies.

## Fix

Both halves of the standard redirect-callback contract used by Auth0/MSAL/oidc-client-ts (processing has page-load lifetime, runs exactly once, guarded against re-entry):

- **`OAuthCallbackPage`**: memoize the processed outcome at module scope, keyed by state token. Later mounts replay the outcome render-only ("Sign-in successful. Redirecting…"); side effects (login, popup opener dispatch) belong exclusively to the run that computed it, so login can never be double-issued. Replaces `initRef`. Messages are now stored as i18n keys and translated at render.
- **`AuthGate`**: render auth-route children outside the readiness gate (`ready || isAuthRoute`). Auth surfaces don't depend on the workspace data the gate loads, so they stay mounted through the post-login load. Bonus: the signin page paints immediately instead of behind a spinner flash.

Either half alone fixes the visible bug; together the callback page is correct regardless of shell behavior, and the shell stops thrashing auth surfaces.

Support change: the i18n unused-key checker can't trace keys stored as variables, so `auth.oauth-callback.` is added to its documented `DYNAMIC_PREFIXES` list.

## Testing

- TDD: both regression tests written first and watched fail for the right reason (remount showed `session-expired`; AuthGate unmounted auth-route children mid-load), then pass after the fix:
  - `OAuthCallbackPage.test.tsx`: remount replays the processed outcome, doesn't re-process the consumed token, and doesn't re-issue login.
  - `AuthGate.test.tsx`: auth-route children stay mounted while post-login workspace data loads.
- Full frontend suite: 2265 tests / 252 files pass; `pnpm check` and `pnpm type-check` clean.
- Note: reloading a stale callback URL in a fresh page load still shows the session-expired error — same behavior as Auth0/MSAL replayed-callback handling, and correct since the token is legitimately gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)