### PR TITLE
fix(oracle): missing comma before table-level constraints in schema dump

### DIFF
--- a/backend/plugin/schema/oracle/get_database_definition.go
+++ b/backend/plugin/schema/oracle/get_database_definition.go
@@ -187,13 +187,20 @@ func writeTable(buf *strings.Builder, table *storepb.TableMetadata) error {
 	if _, err := buf.WriteString("\" (\n"); err != nil {
 		return err
 	}
-	for i, column := range table.Columns {
-		if i > 0 {
+	itemCount := 0
+	writeSeparator := func() error {
+		if itemCount > 0 {
 			if _, err := buf.WriteString(",\n"); err != nil {
 				return err
 			}
 		}
-		if _, err := buf.WriteString(`  `); err != nil {
+		itemCount++
+		_, err := buf.WriteString(`  `)
+		return err
+	}
+
+	for _, column := range table.Columns {
+		if err := writeSeparator(); err != nil {
 			return err
 		}
 		if err := writeColumn(buf, column); err != nil {
@@ -201,20 +208,11 @@ func writeTable(buf *strings.Builder, table *storepb.TableMetadata) error {
 		}
 	}
 
-	constraints := []*storepb.IndexMetadata{}
 	for _, constraint := range table.Indexes {
-		if constraint.IsConstraint {
-			constraints = append(constraints, constraint)
+		if !constraint.IsConstraint {
+			continue
 		}
-	}
-
-	for i, constraint := range constraints {
-		if i+len(table.Indexes) > 0 {
-			if _, err := buf.WriteString(",\n"); err != nil {
-				return err
-			}
-		}
-		if _, err := buf.WriteString(`  `); err != nil {
+		if err := writeSeparator(); err != nil {
 			return err
 		}
 		if err := writeConstraint(buf, constraint); err != nil {
@@ -222,13 +220,8 @@ func writeTable(buf *strings.Builder, table *storepb.TableMetadata) error {
 		}
 	}
 
-	for i, check := range table.CheckConstraints {
-		if i+len(table.Indexes)+len(constraints) > 0 {
-			if _, err := buf.WriteString(",\n"); err != nil {
-				return err
-			}
-		}
-		if _, err := buf.WriteString(`  `); err != nil {
+	for _, check := range table.CheckConstraints {
+		if err := writeSeparator(); err != nil {
 			return err
 		}
 		if err := writeCheckConstraint(buf, check); err != nil {
@@ -236,13 +229,8 @@ func writeTable(buf *strings.Builder, table *storepb.TableMetadata) error {
 		}
 	}
 
-	for i, fk := range table.ForeignKeys {
-		if i+len(table.Indexes)+len(constraints)+len(table.CheckConstraints) > 0 {
-			if _, err := buf.WriteString(",\n"); err != nil {
-				return err
-			}
-		}
-		if _, err := buf.WriteString(`  `); err != nil {
+	for _, fk := range table.ForeignKeys {
+		if err := writeSeparator(); err != nil {
 			return err
 		}
 		if err := writeForeignKey(buf, fk); err != nil {

--- a/backend/plugin/schema/oracle/get_database_definition_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_test.go
@@ -1,0 +1,111 @@
+package oracle
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+func TestGetTableDefinition(t *testing.T) {
+	tests := []struct {
+		name  string
+		table *storepb.TableMetadata
+		want  string
+	}{
+		{
+			// A table whose last column has DEFAULT + NOT NULL, followed by a
+			// table-level FOREIGN KEY with no other indexes or constraints.
+			// The FK must be separated from the column by a comma (ORA-02253).
+			name: "foreign key after default not null column without other constraints",
+			table: &storepb.TableMetadata{
+				Name: "T1",
+				Columns: []*storepb.ColumnMetadata{
+					{Name: "C1", Type: "NUMBER", Nullable: false},
+					{Name: "C2", Type: "NUMBER(1)", Default: "0", Nullable: false},
+				},
+				ForeignKeys: []*storepb.ForeignKeyMetadata{
+					{
+						Name:              "T1_FK",
+						Columns:           []string{"C1"},
+						ReferencedTable:   "T2",
+						ReferencedColumns: []string{"C1"},
+					},
+				},
+			},
+			want: `CREATE TABLE "T1" (
+  "C1" NUMBER NOT NULL,
+  "C2" NUMBER(1) DEFAULT 0 NOT NULL,
+  CONSTRAINT "T1_FK" FOREIGN KEY ("C1") REFERENCES "T2" ("C1")
+);
+
+`,
+		},
+		{
+			name: "check constraint after column without other constraints",
+			table: &storepb.TableMetadata{
+				Name: "T1",
+				Columns: []*storepb.ColumnMetadata{
+					{Name: "C1", Type: "NUMBER", Nullable: false},
+				},
+				CheckConstraints: []*storepb.CheckConstraintMetadata{
+					{Name: "T1_CK", Expression: `"C1" > 0`},
+				},
+			},
+			want: `CREATE TABLE "T1" (
+  "C1" NUMBER NOT NULL,
+  CONSTRAINT "T1_CK" CHECK ("C1" > 0)
+);
+
+`,
+		},
+		{
+			name: "primary key, check, and foreign key",
+			table: &storepb.TableMetadata{
+				Name: "T1",
+				Columns: []*storepb.ColumnMetadata{
+					{Name: "C1", Type: "NUMBER", Nullable: false},
+					{Name: "C2", Type: "NUMBER(1)", Default: "0", Nullable: false},
+				},
+				Indexes: []*storepb.IndexMetadata{
+					{
+						Name:         "T1_PK",
+						Expressions:  []string{"C1"},
+						Primary:      true,
+						Unique:       true,
+						IsConstraint: true,
+					},
+				},
+				CheckConstraints: []*storepb.CheckConstraintMetadata{
+					{Name: "T1_CK", Expression: `"C2" IN (0, 1)`},
+				},
+				ForeignKeys: []*storepb.ForeignKeyMetadata{
+					{
+						Name:              "T1_FK",
+						Columns:           []string{"C1"},
+						ReferencedTable:   "T2",
+						ReferencedColumns: []string{"C1"},
+					},
+				},
+			},
+			want: `CREATE TABLE "T1" (
+  "C1" NUMBER NOT NULL,
+  "C2" NUMBER(1) DEFAULT 0 NOT NULL,
+  CONSTRAINT "T1_PK" PRIMARY KEY ("C1"),
+  CONSTRAINT "T1_CK" CHECK ("C2" IN (0, 1)),
+  CONSTRAINT "T1_FK" FOREIGN KEY ("C1") REFERENCES "T2" ("C1")
+);
+
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetTableDefinition("", tt.table, nil)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What

Fixes the Oracle schema dump generator emitting invalid `CREATE TABLE` DDL when a table has a table-level constraint (FK/CHECK) but no indexes. The last column and the first out-of-line constraint were joined without a comma, which Oracle rejects with ORA-02253:

```sql
CREATE TABLE "T1" (
  "C1" NUMBER NOT NULL,
  "C2" NUMBER(1) DEFAULT 0 NOT NULL  CONSTRAINT "T1_FK" FOREIGN KEY ("C1") REFERENCES "T2" ("C1")
)
```

## Why

In `writeTable` (`backend/plugin/schema/oracle/get_database_definition.go`), the comma decision for constraints, checks, and foreign keys was `i + len(table.Indexes) + len(constraints) + len(table.CheckConstraints) > 0` — it counted indexes and prior constraint sections but never the columns already written. So for a table with no PK/index and no check constraints, the first FK skipped the `,\n` (but still wrote its two-space indent, hence the double space). Tables with a PK rendered correctly only because `len(table.Indexes) > 0` made the count nonzero. The same flaw affected check constraints, and the old condition could also emit a stray leading comma for a table with non-constraint indexes but zero columns.

The fix replaces the three per-section counting expressions with one separator helper that tracks how many items have been written and emits `,\n` before every item after the first. Output is byte-identical for previously correct cases.

## Testing

- Added `TestGetTableDefinition` covering: the reported shape (last column with `DEFAULT 0 NOT NULL` followed by a table-level FK, no other constraints), a CHECK constraint after a plain column with no indexes, and a PK + CHECK + FK table verifying commas between all sections.
- Verified the first case fails against the pre-fix code with byte-for-byte the reported corruption (`NOT NULL  CONSTRAINT`, no comma) and passes with the fix.
- `golangci-lint run` clean; all non-testcontainer tests in the package pass; server binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)