### PR TITLE
fix(sql-editor): empty tree key for external-table columns crashes the editor

### DIFF
--- a/frontend/src/react/components/sql-editor/SchemaPane/schemaTree.test.ts
+++ b/frontend/src/react/components/sql-editor/SchemaPane/schemaTree.test.ts
@@ -208,6 +208,28 @@ describe("keyForNodeTarget", () => {
     ).toBe(`${DATABASE}/schemas/public/tables/users/columns/id`);
   });
 
+  test("column under an external table joins under the external table", () => {
+    expect(
+      keyForNodeTarget("column", {
+        database: DATABASE,
+        schema: "public",
+        externalTable: "remote_users",
+        column: "id",
+      })
+    ).toBe(`${DATABASE}/schemas/public/externalTables/remote_users/columns/id`);
+  });
+
+  test("column under a view joins under the view", () => {
+    expect(
+      keyForNodeTarget("column", {
+        database: DATABASE,
+        schema: "public",
+        view: "active_users",
+        column: "id",
+      })
+    ).toBe(`${DATABASE}/schemas/public/views/active_users/columns/id`);
+  });
+
   test("expandable-text + error keys join type/id", () => {
     expect(
       keyForNodeTarget("expandable-text", {
@@ -583,6 +605,36 @@ describe("buildDatabaseSchemaTree", () => {
     );
     expect(tablesFolder).toBeDefined();
     expect(tablesFolder!.children![0].meta.type).toBe("error");
+  });
+
+  test("every node key is non-empty and unique (react-arborist throws on falsy ids)", () => {
+    const md = makeMetadata([
+      makeSchema("public", {
+        tables: [
+          makeTable("users", {
+            columns: ["id"],
+            indexes: ["ix"],
+            foreignKeys: ["fk"],
+            checks: ["ck"],
+            triggers: ["trg"],
+            partitions: [makePartition("p1", ["sp1"])],
+          }),
+        ],
+        externalTables: [makeExternalTable("ext", ["c1", "c2"])],
+        views: [makeView("v", ["vc"])],
+        procedures: ["proc"],
+        functions: ["fn"],
+        sequences: ["seq"],
+        packages: ["pkg"],
+      }),
+    ]);
+    const tree = buildDatabaseSchemaTree(makeDatabase(), md);
+    const seen = new Set<string>();
+    for (const { key, type } of walk(tree)) {
+      expect(key, `falsy key on node type=${type}`).toBeTruthy();
+      expect(seen.has(key), `duplicate key: ${key}`).toBe(false);
+      seen.add(key);
+    }
   });
 
   test("external tables / views / procedures / functions / packages / sequences only appear when populated", () => {

--- a/frontend/src/react/components/sql-editor/SchemaPane/schemaTree.ts
+++ b/frontend/src/react/components/sql-editor/SchemaPane/schemaTree.ts
@@ -307,28 +307,21 @@ export const keyForNodeTarget = <T extends NodeType>(
       ].join("/");
     }
     case "column": {
-      const { column } = target as NodeTarget<"column">;
-      const key = `columns/${column}`;
-      if ("table" in target) {
-        return [
-          keyForNodeTarget("table", target as NodeTarget<"table">),
-          key,
-        ].join("/");
-      } else if ("external-table" in target) {
-        return [
-          keyForNodeTarget(
-            "external-table",
-            target as NodeTarget<"external-table">
-          ),
-          key,
-        ].join("/");
-      } else if ("view" in target) {
-        return [
-          keyForNodeTarget("view", target as NodeTarget<"view">),
-          key,
-        ].join("/");
+      // No casts inside the branches: `in` narrows the union, so the
+      // compiler verifies each property name against RichColumnMetadata's
+      // members. A typo here fails the build instead of producing an
+      // empty key (which would crash react-arborist at render).
+      const columnTarget = target as NodeTarget<"column">;
+      const key = `columns/${columnTarget.column}`;
+      if ("externalTable" in columnTarget) {
+        return [keyForNodeTarget("external-table", columnTarget), key].join(
+          "/"
+        );
       }
-      return "";
+      if ("view" in columnTarget) {
+        return [keyForNodeTarget("view", columnTarget), key].join("/");
+      }
+      return [keyForNodeTarget("table", columnTarget), key].join("/");
     }
     default: {
       const { id } = target as NodeTarget<"expandable-text" | "error">;


### PR DESCRIPTION
Fixes #20575

## What

`keyForNodeTarget`'s `column` case checked `"external-table" in target` — but the actual property is `externalTable` (camelCase), so the branch never matched. Columns under an external table (e.g. Postgres foreign tables) fell through to an empty-string key, and react-arborist throws on any falsy node id (`if (!id) throw`), which took down the entire SQL Editor at load for any user whose last connection pointed at a database with foreign tables.

The check dates back to the Vue tree (#15799), where naive-ui silently tolerated empty keys; the React migration (#20124) inherited it onto react-arborist, which hard-throws — turning a latent cosmetic bug into a fatal crash in 3.19.0.

## How

- Replace the casted string-sniffing with cast-free `in` narrowing. The `as NodeTarget<...>` casts were what suppressed compiler verification: without them, a typo'd property name fails to narrow the union and the call on the next line no longer type-checks (verified — re-introducing a typo produces two hard `tsc` errors).
- Remove the silent `return ""` fall-through entirely. The three column parents (`table` / `externalTable` / `view`) are mutually exclusive, so checking `externalTable` and `view` first with `table` as the final return is behavior-identical for valid targets and leaves no falsy-key path.

No persisted-state impact: external-table column keys were always `""` before, and column nodes are leaves with no expand state.

## Testing

- New regression test: `column under an external table joins under the external table` (fails with `""` on the old code) plus coverage for the previously untested view-column variant.
- New invariant test: walks a tree built from metadata exercising every object type (tables, columns, indexes, FKs, checks, triggers, nested partitions, external tables, views, procedures, functions, sequences, packages) and asserts every node key is non-empty and unique — so any future falsy-key path in this builder fails CI regardless of which case introduces it.
- Full frontend suite green on this branch (2292 tests), `pnpm check` clean, `tsc --build --force` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)