### PR TITLE
fix(sql-editor): malformed persisted folder paths send sheet tree into infinite recursion

### DIFF
--- a/frontend/src/views/sql-editor/Sheet/context.ts
+++ b/frontend/src/views/sql-editor/Sheet/context.ts
@@ -32,6 +32,7 @@ import {
   storageKeySqlEditorWorksheetTree,
   workspaceCacheScope,
 } from "@/utils";
+import { isSubFolder } from "./folder";
 import { type SheetViewMode, SheetViewModeList } from "./types";
 
 // Worksheet caches, folder sets, and the sheet-tree contain Map / Set
@@ -421,21 +422,6 @@ const rootTreeNodeFor = (view: SheetViewMode): WorksheetFolderNode => ({
   label: rootLabelFor(view),
   editable: false,
 });
-
-const isSubFolder = ({
-  parent,
-  path,
-  dig,
-}: {
-  parent: string;
-  path: string;
-  dig: boolean;
-}) => {
-  const parentPrefix = `${parent}/`;
-  return path !== parentPrefix && path.startsWith(parentPrefix) && dig
-    ? true
-    : !path.replace(parentPrefix, "").includes("/");
-};
 
 const ensureFolderPath = (view: SheetViewMode, path: string): string => {
   const root = rootPathFor(view);

--- a/frontend/src/views/sql-editor/Sheet/folder.test.ts
+++ b/frontend/src/views/sql-editor/Sheet/folder.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { isSubFolder } from "./folder";
+
+describe("isSubFolder", () => {
+  test("direct child matches with dig=false", () => {
+    expect(isSubFolder({ parent: "/my", path: "/my/a", dig: false })).toBe(
+      true
+    );
+  });
+
+  test("deeper descendant does not match with dig=false", () => {
+    expect(isSubFolder({ parent: "/my", path: "/my/a/b", dig: false })).toBe(
+      false
+    );
+  });
+
+  test("any descendant matches with dig=true", () => {
+    expect(isSubFolder({ parent: "/my", path: "/my/a", dig: true })).toBe(true);
+    expect(isSubFolder({ parent: "/my", path: "/my/a/b", dig: true })).toBe(
+      true
+    );
+  });
+
+  test("a path outside the parent never matches", () => {
+    expect(isSubFolder({ parent: "/my", path: "/shared/a", dig: false })).toBe(
+      false
+    );
+    expect(isSubFolder({ parent: "/my", path: "/shared/a", dig: true })).toBe(
+      false
+    );
+  });
+
+  test("the parent itself (with or without trailing slash) is not its own subfolder", () => {
+    expect(isSubFolder({ parent: "/my", path: "/my", dig: false })).toBe(false);
+    expect(isSubFolder({ parent: "/my", path: "/my/", dig: false })).toBe(
+      false
+    );
+  });
+
+  // Malformed entries can reach us from persisted localStorage (the read
+  // path only validates "array of strings"). They must be inert — the old
+  // implementation treated them as subfolders of EVERY parent, including
+  // themselves, sending the sheet-tree builder into infinite recursion.
+  test("malformed persisted entries are never subfolders of anything", () => {
+    for (const dig of [false, true]) {
+      expect(isSubFolder({ parent: "/my", path: "", dig })).toBe(false);
+      expect(isSubFolder({ parent: "/my", path: "foo", dig })).toBe(false);
+      expect(isSubFolder({ parent: "", path: "", dig })).toBe(false);
+      expect(isSubFolder({ parent: "foo", path: "foo", dig })).toBe(false);
+    }
+  });
+
+  test("a parent that appears as an inner segment elsewhere does not match", () => {
+    // The old `.replace(parentPrefix, "")` stripped the FIRST occurrence
+    // anywhere in the string, not just the prefix.
+    expect(
+      isSubFolder({ parent: "/my", path: "/shared/my/a", dig: false })
+    ).toBe(false);
+  });
+});

--- a/frontend/src/views/sql-editor/Sheet/folder.ts
+++ b/frontend/src/views/sql-editor/Sheet/folder.ts
@@ -1,0 +1,29 @@
+// Pure worksheet-folder path helpers, extracted from context.ts so the
+// hierarchy logic is directly unit-testable.
+
+/**
+ * Whether `path` is a subfolder of `parent`. With `dig` set, any depth of
+ * descendant matches; otherwise only direct children.
+ *
+ * Folder paths come back from localStorage with only an "array of strings"
+ * shape check, so malformed entries (empty strings, paths missing the
+ * `/{view}` root prefix) must be treated as inert — never as subfolders.
+ */
+export const isSubFolder = ({
+  parent,
+  path,
+  dig,
+}: {
+  parent: string;
+  path: string;
+  dig: boolean;
+}): boolean => {
+  const parentPrefix = `${parent}/`;
+  if (path === parentPrefix || !path.startsWith(parentPrefix)) {
+    return false;
+  }
+  if (dig) {
+    return true;
+  }
+  return !path.slice(parentPrefix.length).includes("/");
+};


### PR DESCRIPTION
Found while auditing for the bug class behind #20575 (SQL Editor tree builders trusting unvalidated input). No field report for this one — it's a latent bug confirmed by analysis.

## What

The worksheet folder list is restored from localStorage with only an "array of strings" shape check. `isSubFolder` treated any entry that didn't start with the parent prefix and contained no `/` — e.g. `""` or a bare `"foo"` from corrupted or legacy persisted data — as a subfolder of EVERY parent, including itself. `buildTree` then recurses on such a node forever: stack overflow and a frozen or crashed SQL Editor.

The predicate also had two milder quirks: `path.replace(parentPrefix, "")` strips the first occurrence anywhere in the string (not just the prefix), and an entry exactly equal to `parent + "/"` counted as its own subfolder.

## How

Extract `isSubFolder` from `Sheet/context.ts` into a pure module (`Sheet/folder.ts`) with corrected semantics: a path must start with the parent prefix; with `dig` any deeper descendant matches, otherwise only direct children. Malformed entries are inert — never subfolders of anything — so they can no longer reach the tree builder. Well-formed folder behavior is unchanged.

## Testing

- New unit tests cover the legitimate hierarchy cases (direct child, deep descendant, dig mode, outside-parent) and the malformed cases that previously caused the cycle (`""`, bare names, self-reference, trailing-slash, inner-segment prefix collision). The malformed-path tests fail on the old implementation.
- Full frontend suite green on this branch (2296 tests), `pnpm check` clean, `tsc --build --force` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)