### PR TITLE
fix(schema/pg): skip column-dependent DDL for tables synced without columns

### DIFF
--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -282,72 +282,17 @@ func GetDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *storepb.Da
 		}
 	}
 
-	// Construct triggers. Skip triggers on tables without column metadata;
-	// their definitions (UPDATE OF, WHEN clauses) can reference the missing
-	// columns.
+	// Construct triggers.
 	for _, schema := range metadata.Schemas {
-		for _, table := range schema.Tables {
-			if tableMissingColumnMetadata(table) {
-				continue
-			}
-			for _, trigger := range table.Triggers {
-				if trigger.SkipDump {
-					continue
-				}
-				if err := writeTrigger(&buf, schema.Name, table.Name, trigger); err != nil {
-					return "", err
-				}
-			}
-		}
-
-		for _, view := range schema.Views {
-			for _, trigger := range view.Triggers {
-				if trigger.SkipDump {
-					continue
-				}
-				if err := writeTrigger(&buf, schema.Name, view.Name, trigger); err != nil {
-					return "", err
-				}
-			}
-		}
-
-		for _, materializedView := range schema.MaterializedViews {
-			for _, trigger := range materializedView.Triggers {
-				if trigger.SkipDump {
-					continue
-				}
-				if err := writeTrigger(&buf, schema.Name, materializedView.Name, trigger); err != nil {
-					return "", err
-				}
-			}
+		if err := writeSchemaTriggers(&buf, schema); err != nil {
+			return "", err
 		}
 	}
 
-	// Construct rules. Skip rules on tables without column metadata; their
-	// definitions can reference the missing columns.
+	// Construct rules.
 	for _, schema := range metadata.Schemas {
-		for _, table := range schema.Tables {
-			if len(table.Rules) > 0 && !tableMissingColumnMetadata(table) {
-				if err := writeRules(&buf, schema.Name, table.Name, table.Rules); err != nil {
-					return "", err
-				}
-			}
-		}
-
-		for _, view := range schema.Views {
-			// Rules for views are already written in writeView
-			// Only write non-SELECT rules here (they are not part of the view definition)
-			var nonSelectRules []*storepb.RuleMetadata
-			for _, rule := range view.Rules {
-				if rule.Event != "SELECT" {
-					nonSelectRules = append(nonSelectRules, rule)
-				}
-			}
-			if len(nonSelectRules) > 0 {
-				if err := writeRules(&buf, schema.Name, view.Name, nonSelectRules); err != nil {
-					return "", err
-				}
-			}
+		if err := writeSchemaRules(&buf, schema); err != nil {
+			return "", err
 		}
 	}
 
@@ -559,68 +504,14 @@ func GetSchemaDefinition(schema *storepb.SchemaMetadata) (string, error) {
 		}
 	}
 
-	// Construct triggers. Skip triggers on tables without column metadata;
-	// their definitions (UPDATE OF, WHEN clauses) can reference the missing
-	// columns.
-	for _, table := range schema.Tables {
-		if tableMissingColumnMetadata(table) {
-			continue
-		}
-		for _, trigger := range table.Triggers {
-			if trigger.SkipDump {
-				continue
-			}
-			if err := writeTrigger(&buf, schema.Name, table.Name, trigger); err != nil {
-				return "", err
-			}
-		}
+	// Construct triggers.
+	if err := writeSchemaTriggers(&buf, schema); err != nil {
+		return "", err
 	}
 
-	for _, view := range schema.Views {
-		for _, trigger := range view.Triggers {
-			if trigger.SkipDump {
-				continue
-			}
-			if err := writeTrigger(&buf, schema.Name, view.Name, trigger); err != nil {
-				return "", err
-			}
-		}
-	}
-
-	for _, materializedView := range schema.MaterializedViews {
-		for _, trigger := range materializedView.Triggers {
-			if trigger.SkipDump {
-				continue
-			}
-			if err := writeTrigger(&buf, schema.Name, materializedView.Name, trigger); err != nil {
-				return "", err
-			}
-		}
-	}
-
-	// Construct rules. Skip rules on tables without column metadata; their
-	// definitions can reference the missing columns.
-	for _, table := range schema.Tables {
-		if len(table.Rules) > 0 && !tableMissingColumnMetadata(table) {
-			if err := writeRules(&buf, schema.Name, table.Name, table.Rules); err != nil {
-				return "", err
-			}
-		}
-	}
-
-	for _, view := range schema.Views {
-		// Only write non-SELECT rules here (SELECT rules are part of the view definition)
-		var nonSelectRules []*storepb.RuleMetadata
-		for _, rule := range view.Rules {
-			if rule.Event != "SELECT" {
-				nonSelectRules = append(nonSelectRules, rule)
-			}
-		}
-		if len(nonSelectRules) > 0 {
-			if err := writeRules(&buf, schema.Name, view.Name, nonSelectRules); err != nil {
-				return "", err
-			}
-		}
+	// Construct rules.
+	if err := writeSchemaRules(&buf, schema); err != nil {
+		return "", err
 	}
 
 	// Construct foreign keys.
@@ -1685,14 +1576,22 @@ func splitSequencesByIdentityOrNot(table *storepb.TableMetadata, sequences []*st
 	return generationType, identitySequences, nonIdentitySequences
 }
 
-// tableMissingColumnMetadata reports whether a synced table carries no column
-// metadata. information_schema.columns is privilege-filtered, so a sync user
-// without column privileges on a table sees zero columns while the
-// pg_catalog-based queries still return the table's constraints and indexes.
-// DDL referencing the missing columns would make the dump non-replayable, so
-// writers skip column-dependent statements for such tables.
+// tableMissingColumnMetadata reports whether a synced table's column list
+// was filtered away. information_schema.columns is privilege-filtered, so a
+// sync user without column privileges on a table sees zero columns while the
+// pg_catalog-based queries still return the table's constraints, indexes,
+// triggers, and rules. DDL referencing the missing columns would make the
+// dump non-replayable, so writers skip column-dependent statements for such
+// tables.
+//
+// A genuine zero-column table (CREATE TABLE t ()) is legal in PostgreSQL and
+// may carry column-independent objects such as CHECK (1 = 1), but it cannot
+// carry primary keys, unique constraints, or foreign keys; indexes on it are
+// limited to constant-expression corner cases. Treat zero columns as missing
+// metadata only when indexes or foreign keys are present, so genuine
+// zero-column tables keep their objects.
 func tableMissingColumnMetadata(table *storepb.TableMetadata) bool {
-	return len(table.Columns) == 0
+	return len(table.Columns) == 0 && (len(table.Indexes) > 0 || len(table.ForeignKeys) > 0)
 }
 
 // collectTablesMissingColumns returns the tables without column metadata,
@@ -1707,6 +1606,78 @@ func collectTablesMissingColumns(schemas []*storepb.SchemaMetadata) map[string]b
 		}
 	}
 	return missing
+}
+
+// writeSchemaTriggers writes the triggers of every table, view, and
+// materialized view in the schema. Triggers on tables without column
+// metadata are skipped; their definitions (UPDATE OF, WHEN clauses) can
+// reference the missing columns.
+func writeSchemaTriggers(out io.Writer, schema *storepb.SchemaMetadata) error {
+	for _, table := range schema.Tables {
+		if tableMissingColumnMetadata(table) {
+			continue
+		}
+		for _, trigger := range table.Triggers {
+			if trigger.SkipDump {
+				continue
+			}
+			if err := writeTrigger(out, schema.Name, table.Name, trigger); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, view := range schema.Views {
+		for _, trigger := range view.Triggers {
+			if trigger.SkipDump {
+				continue
+			}
+			if err := writeTrigger(out, schema.Name, view.Name, trigger); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, materializedView := range schema.MaterializedViews {
+		for _, trigger := range materializedView.Triggers {
+			if trigger.SkipDump {
+				continue
+			}
+			if err := writeTrigger(out, schema.Name, materializedView.Name, trigger); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// writeSchemaRules writes the rules of every table and the non-SELECT rules
+// of every view in the schema (SELECT rules are part of the view
+// definition). Rules on tables without column metadata are skipped; their
+// definitions can reference the missing columns.
+func writeSchemaRules(out io.Writer, schema *storepb.SchemaMetadata) error {
+	for _, table := range schema.Tables {
+		if len(table.Rules) > 0 && !tableMissingColumnMetadata(table) {
+			if err := writeRules(out, schema.Name, table.Name, table.Rules); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, view := range schema.Views {
+		var nonSelectRules []*storepb.RuleMetadata
+		for _, rule := range view.Rules {
+			if rule.Event != "SELECT" {
+				nonSelectRules = append(nonSelectRules, rule)
+			}
+		}
+		if len(nonSelectRules) > 0 {
+			if err := writeRules(out, schema.Name, view.Name, nonSelectRules); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // writeSchemaForeignKeys writes the foreign keys of every table in the

--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -2746,13 +2746,17 @@ func getSDLFormat(metadata *storepb.DatabaseSchemaMetadata) (string, error) {
 				return "", err
 			}
 
-			// Write index comments if present
-			for _, index := range table.Indexes {
-				// Only write comment for standalone indexes (not primary key or unique constraint indexes)
-				if !index.Primary && !index.Unique {
-					if len(index.Comment) > 0 {
-						if err := writeIndexCommentSDL(&buf, schema.Name, index); err != nil {
-							return "", err
+			// Write index comments if present. Skip when the table has no
+			// column metadata — its indexes were not emitted, so a COMMENT ON
+			// INDEX would target a nonexistent index.
+			if !tableMissingColumnMetadata(table) {
+				for _, index := range table.Indexes {
+					// Only write comment for standalone indexes (not primary key or unique constraint indexes)
+					if !index.Primary && !index.Unique {
+						if len(index.Comment) > 0 {
+							if err := writeIndexCommentSDL(&buf, schema.Name, index); err != nil {
+								return "", err
+							}
 						}
 					}
 				}
@@ -3810,13 +3814,17 @@ func GetMultiFileDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *s
 				return nil, errors.Wrapf(err, "failed to generate indexes SDL for %s.%s", schemaName, table.Name)
 			}
 
-			// Write index comments if present
-			for _, index := range table.Indexes {
-				// Only write comment for standalone indexes (not primary key or unique constraint indexes)
-				if !index.Primary && !index.Unique {
-					if len(index.Comment) > 0 {
-						if err := writeIndexCommentSDL(&buf, schemaName, index); err != nil {
-							return nil, errors.Wrapf(err, "failed to generate index comment for %s.%s", schemaName, index.Name)
+			// Write index comments if present. Skip when the table has no
+			// column metadata — its indexes were not emitted, so a COMMENT ON
+			// INDEX would target a nonexistent index.
+			if !tableMissingColumnMetadata(table) {
+				for _, index := range table.Indexes {
+					// Only write comment for standalone indexes (not primary key or unique constraint indexes)
+					if !index.Primary && !index.Unique {
+						if len(index.Comment) > 0 {
+							if err := writeIndexCommentSDL(&buf, schemaName, index); err != nil {
+								return nil, errors.Wrapf(err, "failed to generate index comment for %s.%s", schemaName, index.Name)
+							}
 						}
 					}
 				}

--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -345,30 +345,11 @@ func GetDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *storepb.Da
 		}
 	}
 
-	// Construct foreign keys. Skip foreign keys touching a table without
-	// column metadata on either side; they would reference columns absent
-	// from the dump.
-	tablesMissingColumns := make(map[string]bool)
+	// Construct foreign keys.
+	tablesMissingColumns := collectTablesMissingColumns(metadata.Schemas)
 	for _, schema := range metadata.Schemas {
-		for _, table := range schema.Tables {
-			if tableMissingColumnMetadata(table) {
-				tablesMissingColumns[getObjectID(schema.Name, table.Name)] = true
-			}
-		}
-	}
-	for _, schema := range metadata.Schemas {
-		for _, table := range schema.Tables {
-			if table.SkipDump || tablesMissingColumns[getObjectID(schema.Name, table.Name)] {
-				continue
-			}
-			for _, fk := range table.ForeignKeys {
-				if tablesMissingColumns[getObjectID(fk.ReferencedSchema, fk.ReferencedTable)] {
-					continue
-				}
-				if err := writeForeignKey(&buf, schema.Name, table.Name, fk); err != nil {
-					return "", err
-				}
-			}
+		if err := writeSchemaForeignKeys(&buf, schema, tablesMissingColumns); err != nil {
+			return "", err
 		}
 	}
 
@@ -630,27 +611,9 @@ func GetSchemaDefinition(schema *storepb.SchemaMetadata) (string, error) {
 		}
 	}
 
-	// Construct foreign keys. Skip foreign keys touching a table without
-	// column metadata on either side; they would reference columns absent
-	// from the dump.
-	tablesMissingColumns := make(map[string]bool)
-	for _, table := range schema.Tables {
-		if tableMissingColumnMetadata(table) {
-			tablesMissingColumns[table.Name] = true
-		}
-	}
-	for _, table := range schema.Tables {
-		if table.SkipDump || tablesMissingColumns[table.Name] {
-			continue
-		}
-		for _, fk := range table.ForeignKeys {
-			if fk.ReferencedSchema == schema.Name && tablesMissingColumns[fk.ReferencedTable] {
-				continue
-			}
-			if err := writeForeignKey(&buf, schema.Name, table.Name, fk); err != nil {
-				return "", err
-			}
-		}
+	// Construct foreign keys.
+	if err := writeSchemaForeignKeys(&buf, schema, collectTablesMissingColumns([]*storepb.SchemaMetadata{schema})); err != nil {
+		return "", err
 	}
 
 	return buf.String(), nil
@@ -1718,6 +1681,40 @@ func tableMissingColumnMetadata(table *storepb.TableMetadata) bool {
 	return len(table.Columns) == 0
 }
 
+// collectTablesMissingColumns returns the tables without column metadata,
+// keyed by getObjectID(schema, table).
+func collectTablesMissingColumns(schemas []*storepb.SchemaMetadata) map[string]bool {
+	missing := make(map[string]bool)
+	for _, schema := range schemas {
+		for _, table := range schema.Tables {
+			if tableMissingColumnMetadata(table) {
+				missing[getObjectID(schema.Name, table.Name)] = true
+			}
+		}
+	}
+	return missing
+}
+
+// writeSchemaForeignKeys writes the foreign keys of every table in the
+// schema, skipping foreign keys touching a table without column metadata on
+// either side; they would reference columns absent from the dump.
+func writeSchemaForeignKeys(out io.Writer, schema *storepb.SchemaMetadata, tablesMissingColumns map[string]bool) error {
+	for _, table := range schema.Tables {
+		if table.SkipDump || tablesMissingColumns[getObjectID(schema.Name, table.Name)] {
+			continue
+		}
+		for _, fk := range table.ForeignKeys {
+			if tablesMissingColumns[getObjectID(fk.ReferencedSchema, fk.ReferencedTable)] {
+				continue
+			}
+			if err := writeForeignKey(out, schema.Name, table.Name, fk); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequences []*storepb.SequenceMetadata) error {
 	if tableMissingColumnMetadata(table) {
 		// Emit a bare CREATE TABLE so the table still exists on replay, and
@@ -2549,6 +2546,8 @@ func writeExtensionComment(out io.Writer, extension *storepb.ExtensionMetadata) 
 func getSDLFormat(metadata *storepb.DatabaseSchemaMetadata) (string, error) {
 	var buf strings.Builder
 
+	tablesMissingColumns := collectTablesMissingColumns(metadata.Schemas)
+
 	// Write CREATE SCHEMA statements first for non-public schemas
 	for _, schema := range metadata.Schemas {
 		if schema.SkipDump {
@@ -2718,7 +2717,7 @@ func getSDLFormat(metadata *storepb.DatabaseSchemaMetadata) (string, error) {
 			tableSequences := tableSequencesMap[tableKey]
 
 			// Write CREATE TABLE statement
-			if err := writeCreateTableSDL(&buf, schema.Name, table, tableSequences); err != nil {
+			if err := writeCreateTableSDL(&buf, schema.Name, table, tableSequences, tablesMissingColumns); err != nil {
 				return "", err
 			}
 
@@ -2785,8 +2784,11 @@ func getSDLFormat(metadata *storepb.DatabaseSchemaMetadata) (string, error) {
 			if skipSequences[sequenceKey] {
 				continue
 			}
-			// Write ALTER SEQUENCE OWNED BY for sequences with owners
-			if sequence.OwnerTable != "" && sequence.OwnerColumn != "" {
+			// Write ALTER SEQUENCE OWNED BY for sequences with owners. Skip
+			// when the owning table has no column metadata; the OWNED BY
+			// clause would reference a column absent from the dump.
+			if sequence.OwnerTable != "" && sequence.OwnerColumn != "" &&
+				!tablesMissingColumns[getObjectID(schema.Name, sequence.OwnerTable)] {
 				if err := writeAlterSequenceOwnedBy(&buf, schema.Name, sequence); err != nil {
 					return "", err
 				}
@@ -3186,7 +3188,7 @@ func writeColumnSDL(out io.Writer, column *storepb.ColumnMetadata, tableName str
 	return nil
 }
 
-func writeCreateTableSDL(out io.Writer, schemaName string, table *storepb.TableMetadata, sequences []*storepb.SequenceMetadata) error {
+func writeCreateTableSDL(out io.Writer, schemaName string, table *storepb.TableMetadata, sequences []*storepb.SequenceMetadata, tablesMissingColumns map[string]bool) error {
 	if _, err := io.WriteString(out, `CREATE TABLE "`); err != nil {
 		return err
 	}
@@ -3231,7 +3233,7 @@ func writeCreateTableSDL(out io.Writer, schemaName string, table *storepb.TableM
 	}
 
 	// Write table constraints
-	if err := writeTableConstraintsSDL(out, table, writeItemSep); err != nil {
+	if err := writeTableConstraintsSDL(out, table, writeItemSep, tablesMissingColumns); err != nil {
 		return err
 	}
 
@@ -3239,7 +3241,7 @@ func writeCreateTableSDL(out io.Writer, schemaName string, table *storepb.TableM
 	return err
 }
 
-func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata, writeSep func() error) error {
+func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata, writeSep func() error, tablesMissingColumns map[string]bool) error {
 	if tableMissingColumnMetadata(table) {
 		// Constraints would reference columns absent from the dump.
 		return nil
@@ -3289,8 +3291,13 @@ func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata, write
 		}
 	}
 
-	// Write foreign key constraints
+	// Write foreign key constraints. Skip foreign keys whose referenced
+	// table has no column metadata; the REFERENCES clause would name
+	// columns absent from the dump.
 	for _, fk := range table.ForeignKeys {
+		if tablesMissingColumns[getObjectID(fk.ReferencedSchema, fk.ReferencedTable)] {
+			continue
+		}
 		if err := writeSep(); err != nil {
 			return err
 		}
@@ -3723,6 +3730,8 @@ func GetMultiFileDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *s
 	// Build table sequences map for each table
 	tableSequencesMap := buildTableSequencesMap(metadata)
 
+	tablesMissingColumns := collectTablesMissingColumns(metadata.Schemas)
+
 	// Generate files for each schema
 	for _, schemaMetadata := range metadata.Schemas {
 		if schemaMetadata.SkipDump {
@@ -3775,7 +3784,7 @@ func GetMultiFileDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *s
 
 			var buf strings.Builder
 			// Write CREATE TABLE statement in SDL format
-			if err := writeCreateTableSDL(&buf, schemaName, table, tableSequences); err != nil {
+			if err := writeCreateTableSDL(&buf, schemaName, table, tableSequences, tablesMissingColumns); err != nil {
 				return nil, errors.Wrapf(err, "failed to generate table SDL for %s.%s", schemaName, table.Name)
 			}
 			buf.WriteString(";\n\n")
@@ -3851,10 +3860,14 @@ func GetMultiFileDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *s
 						}
 					}
 
-					// Add ALTER SEQUENCE OWNED BY
-					buf.WriteString("\n")
-					if err := writeAlterSequenceOwnedBy(&buf, schemaName, sequence); err != nil {
-						return nil, errors.Wrapf(err, "failed to generate ALTER SEQUENCE OWNED BY for %s.%s", schemaName, sequence.Name)
+					// Add ALTER SEQUENCE OWNED BY. Skip when the owning table
+					// has no column metadata; the OWNED BY clause would
+					// reference a column absent from the dump.
+					if !tableMissingColumnMetadata(table) {
+						buf.WriteString("\n")
+						if err := writeAlterSequenceOwnedBy(&buf, schemaName, sequence); err != nil {
+							return nil, errors.Wrapf(err, "failed to generate ALTER SEQUENCE OWNED BY for %s.%s", schemaName, sequence.Name)
+						}
 					}
 				}
 			}

--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -297,7 +297,7 @@ func GetDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *storepb.Da
 	}
 
 	// Construct foreign keys.
-	tablesMissingColumns := collectTablesMissingColumns(metadata.Schemas)
+	tablesMissingColumns := collectTables(metadata.Schemas, tableMissingColumnMetadata)
 	for _, schema := range metadata.Schemas {
 		if err := writeSchemaForeignKeys(&buf, schema, tablesMissingColumns); err != nil {
 			return "", err
@@ -515,7 +515,7 @@ func GetSchemaDefinition(schema *storepb.SchemaMetadata) (string, error) {
 	}
 
 	// Construct foreign keys.
-	if err := writeSchemaForeignKeys(&buf, schema, collectTablesMissingColumns([]*storepb.SchemaMetadata{schema})); err != nil {
+	if err := writeSchemaForeignKeys(&buf, schema, collectTables([]*storepb.SchemaMetadata{schema}, tableMissingColumnMetadata)); err != nil {
 		return "", err
 	}
 
@@ -1586,26 +1586,35 @@ func splitSequencesByIdentityOrNot(table *storepb.TableMetadata, sequences []*st
 //
 // A genuine zero-column table (CREATE TABLE t ()) is legal in PostgreSQL and
 // may carry column-independent objects such as CHECK (1 = 1), but it cannot
-// carry primary keys, unique constraints, or foreign keys; indexes on it are
+// carry primary keys, unique constraints, foreign keys, or a partition key
+// (PostgreSQL rejects constant partition-key expressions); indexes on it are
 // limited to constant-expression corner cases. Treat zero columns as missing
-// metadata only when indexes or foreign keys are present, so genuine
-// zero-column tables keep their objects.
+// metadata only when such objects are present, so genuine zero-column tables
+// keep their objects.
 func tableMissingColumnMetadata(table *storepb.TableMetadata) bool {
-	return len(table.Columns) == 0 && (len(table.Indexes) > 0 || len(table.ForeignKeys) > 0)
+	return len(table.Columns) == 0 &&
+		(len(table.Indexes) > 0 || len(table.ForeignKeys) > 0 || len(table.Partitions) > 0)
 }
 
-// collectTablesMissingColumns returns the tables without column metadata,
-// keyed by getObjectID(schema, table).
-func collectTablesMissingColumns(schemas []*storepb.SchemaMetadata) map[string]bool {
-	missing := make(map[string]bool)
+// tableHasNoColumns reports an empty synced column list, whether genuinely
+// zero-column or privilege-filtered. A sequence cannot be owned by a column
+// of such a table, so ALTER SEQUENCE ... OWNED BY is skipped either way.
+func tableHasNoColumns(table *storepb.TableMetadata) bool {
+	return len(table.Columns) == 0
+}
+
+// collectTables returns the tables matching include, keyed by
+// getObjectID(schema, table).
+func collectTables(schemas []*storepb.SchemaMetadata, include func(*storepb.TableMetadata) bool) map[string]bool {
+	set := make(map[string]bool)
 	for _, schema := range schemas {
 		for _, table := range schema.Tables {
-			if tableMissingColumnMetadata(table) {
-				missing[getObjectID(schema.Name, table.Name)] = true
+			if include(table) {
+				set[getObjectID(schema.Name, table.Name)] = true
 			}
 		}
 	}
-	return missing
+	return set
 }
 
 // writeSchemaTriggers writes the triggers of every table, view, and
@@ -1733,9 +1742,13 @@ func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequ
 		return err
 	}
 
-	for _, sequence := range nonIdentitySequences {
-		if err := writeAlterSequenceOwnedBy(out, schema, sequence); err != nil {
-			return err
+	// Skip OWNED BY for a table with no columns; the clause would reference
+	// a column absent from the dump.
+	if !tableHasNoColumns(table) {
+		for _, sequence := range nonIdentitySequences {
+			if err := writeAlterSequenceOwnedBy(out, schema, sequence); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -2531,7 +2544,8 @@ func writeExtensionComment(out io.Writer, extension *storepb.ExtensionMetadata) 
 func getSDLFormat(metadata *storepb.DatabaseSchemaMetadata) (string, error) {
 	var buf strings.Builder
 
-	tablesMissingColumns := collectTablesMissingColumns(metadata.Schemas)
+	tablesMissingColumns := collectTables(metadata.Schemas, tableMissingColumnMetadata)
+	tablesWithoutColumns := collectTables(metadata.Schemas, tableHasNoColumns)
 
 	// Write CREATE SCHEMA statements first for non-public schemas
 	for _, schema := range metadata.Schemas {
@@ -2777,10 +2791,10 @@ func getSDLFormat(metadata *storepb.DatabaseSchemaMetadata) (string, error) {
 				continue
 			}
 			// Write ALTER SEQUENCE OWNED BY for sequences with owners. Skip
-			// when the owning table has no column metadata; the OWNED BY
-			// clause would reference a column absent from the dump.
+			// when the owning table has no columns; the OWNED BY clause
+			// would reference a column absent from the dump.
 			if sequence.OwnerTable != "" && sequence.OwnerColumn != "" &&
-				!tablesMissingColumns[getObjectID(schema.Name, sequence.OwnerTable)] {
+				!tablesWithoutColumns[getObjectID(schema.Name, sequence.OwnerTable)] {
 				if err := writeAlterSequenceOwnedBy(&buf, schema.Name, sequence); err != nil {
 					return "", err
 				}
@@ -3722,7 +3736,7 @@ func GetMultiFileDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *s
 	// Build table sequences map for each table
 	tableSequencesMap := buildTableSequencesMap(metadata)
 
-	tablesMissingColumns := collectTablesMissingColumns(metadata.Schemas)
+	tablesMissingColumns := collectTables(metadata.Schemas, tableMissingColumnMetadata)
 
 	// Generate files for each schema
 	for _, schemaMetadata := range metadata.Schemas {
@@ -3860,9 +3874,9 @@ func GetMultiFileDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *s
 					}
 
 					// Add ALTER SEQUENCE OWNED BY. Skip when the owning table
-					// has no column metadata; the OWNED BY clause would
-					// reference a column absent from the dump.
-					if !tableMissingColumnMetadata(table) {
+					// has no columns; the OWNED BY clause would reference a
+					// column absent from the dump.
+					if !tableHasNoColumns(table) {
 						buf.WriteString("\n")
 						if err := writeAlterSequenceOwnedBy(&buf, schemaName, sequence); err != nil {
 							return nil, errors.Wrapf(err, "failed to generate ALTER SEQUENCE OWNED BY for %s.%s", schemaName, sequence.Name)

--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -282,9 +282,14 @@ func GetDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *storepb.Da
 		}
 	}
 
-	// Construct triggers.
+	// Construct triggers. Skip triggers on tables without column metadata;
+	// their definitions (UPDATE OF, WHEN clauses) can reference the missing
+	// columns.
 	for _, schema := range metadata.Schemas {
 		for _, table := range schema.Tables {
+			if tableMissingColumnMetadata(table) {
+				continue
+			}
 			for _, trigger := range table.Triggers {
 				if trigger.SkipDump {
 					continue
@@ -318,10 +323,11 @@ func GetDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *storepb.Da
 		}
 	}
 
-	// Construct rules.
+	// Construct rules. Skip rules on tables without column metadata; their
+	// definitions can reference the missing columns.
 	for _, schema := range metadata.Schemas {
 		for _, table := range schema.Tables {
-			if len(table.Rules) > 0 {
+			if len(table.Rules) > 0 && !tableMissingColumnMetadata(table) {
 				if err := writeRules(&buf, schema.Name, table.Name, table.Rules); err != nil {
 					return "", err
 				}
@@ -553,8 +559,13 @@ func GetSchemaDefinition(schema *storepb.SchemaMetadata) (string, error) {
 		}
 	}
 
-	// Construct triggers.
+	// Construct triggers. Skip triggers on tables without column metadata;
+	// their definitions (UPDATE OF, WHEN clauses) can reference the missing
+	// columns.
 	for _, table := range schema.Tables {
+		if tableMissingColumnMetadata(table) {
+			continue
+		}
 		for _, trigger := range table.Triggers {
 			if trigger.SkipDump {
 				continue
@@ -587,9 +598,10 @@ func GetSchemaDefinition(schema *storepb.SchemaMetadata) (string, error) {
 		}
 	}
 
-	// Construct rules.
+	// Construct rules. Skip rules on tables without column metadata; their
+	// definitions can reference the missing columns.
 	for _, table := range schema.Tables {
-		if len(table.Rules) > 0 {
+		if len(table.Rules) > 0 && !tableMissingColumnMetadata(table) {
 			if err := writeRules(&buf, schema.Name, table.Name, table.Rules); err != nil {
 				return "", err
 			}
@@ -624,6 +636,11 @@ func GetTableDefinition(schema string, table *storepb.TableMetadata, sequences [
 	if err := writeTable(&buf, schema, table, sequences); err != nil {
 		return "", err
 	}
+	// Skip triggers, rules, and foreign keys for a table without column
+	// metadata; their definitions can reference the missing columns.
+	if tableMissingColumnMetadata(table) {
+		return buf.String(), nil
+	}
 	// Construct triggers.
 	for _, trigger := range table.Triggers {
 		if trigger.SkipDump {
@@ -639,13 +656,10 @@ func GetTableDefinition(schema string, table *storepb.TableMetadata, sequences [
 			return "", err
 		}
 	}
-	// Construct foreign keys. A table without column metadata cannot carry
-	// foreign keys referencing its (missing) columns.
-	if !tableMissingColumnMetadata(table) {
-		for _, fk := range table.ForeignKeys {
-			if err := writeForeignKey(&buf, schema, table.Name, fk); err != nil {
-				return "", err
-			}
+	// Construct foreign keys.
+	for _, fk := range table.ForeignKeys {
+		if err := writeForeignKey(&buf, schema, table.Name, fk); err != nil {
+			return "", err
 		}
 	}
 	return buf.String(), nil
@@ -2767,11 +2781,14 @@ func getSDLFormat(metadata *storepb.DatabaseSchemaMetadata) (string, error) {
 				return "", err
 			}
 
-			// Write trigger comments if present
-			for _, trigger := range table.Triggers {
-				if len(trigger.Comment) > 0 {
-					if err := writeTriggerCommentSDL(&buf, schema.Name, table.Name, trigger); err != nil {
-						return "", err
+			// Write trigger comments if present. Skip when the table has no
+			// column metadata — its triggers were not emitted.
+			if !tableMissingColumnMetadata(table) {
+				for _, trigger := range table.Triggers {
+					if len(trigger.Comment) > 0 {
+						if err := writeTriggerCommentSDL(&buf, schema.Name, table.Name, trigger); err != nil {
+							return "", err
+						}
 					}
 				}
 			}
@@ -3835,11 +3852,14 @@ func GetMultiFileDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *s
 				return nil, errors.Wrapf(err, "failed to generate triggers SDL for %s.%s", schemaName, table.Name)
 			}
 
-			// Write trigger comments if present
-			for _, trigger := range table.Triggers {
-				if len(trigger.Comment) > 0 {
-					if err := writeTriggerCommentSDL(&buf, schemaName, table.Name, trigger); err != nil {
-						return nil, errors.Wrapf(err, "failed to generate trigger comment for %s.%s.%s", schemaName, table.Name, trigger.Name)
+			// Write trigger comments if present. Skip when the table has no
+			// column metadata — its triggers were not emitted.
+			if !tableMissingColumnMetadata(table) {
+				for _, trigger := range table.Triggers {
+					if len(trigger.Comment) > 0 {
+						if err := writeTriggerCommentSDL(&buf, schemaName, table.Name, trigger); err != nil {
+							return nil, errors.Wrapf(err, "failed to generate trigger comment for %s.%s.%s", schemaName, table.Name, trigger.Name)
+						}
 					}
 				}
 			}
@@ -4411,6 +4431,11 @@ func writeIndexCommentSDL(out io.Writer, schemaName string, index *storepb.Index
 }
 
 func writeTriggersSDL(out io.Writer, schemaName string, table *storepb.TableMetadata) error {
+	if tableMissingColumnMetadata(table) {
+		// Trigger definitions (UPDATE OF, WHEN clauses) can reference
+		// columns absent from the dump.
+		return nil
+	}
 	for _, trigger := range table.Triggers {
 		if trigger.SkipDump {
 			continue

--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -345,13 +345,26 @@ func GetDatabaseDefinition(ctx schema.GetDefinitionContext, metadata *storepb.Da
 		}
 	}
 
-	// Construct foreign keys.
+	// Construct foreign keys. Skip foreign keys touching a table without
+	// column metadata on either side; they would reference columns absent
+	// from the dump.
+	tablesMissingColumns := make(map[string]bool)
 	for _, schema := range metadata.Schemas {
 		for _, table := range schema.Tables {
-			if table.SkipDump {
+			if tableMissingColumnMetadata(table) {
+				tablesMissingColumns[getObjectID(schema.Name, table.Name)] = true
+			}
+		}
+	}
+	for _, schema := range metadata.Schemas {
+		for _, table := range schema.Tables {
+			if table.SkipDump || tablesMissingColumns[getObjectID(schema.Name, table.Name)] {
 				continue
 			}
 			for _, fk := range table.ForeignKeys {
+				if tablesMissingColumns[getObjectID(fk.ReferencedSchema, fk.ReferencedTable)] {
+					continue
+				}
 				if err := writeForeignKey(&buf, schema.Name, table.Name, fk); err != nil {
 					return "", err
 				}
@@ -617,12 +630,23 @@ func GetSchemaDefinition(schema *storepb.SchemaMetadata) (string, error) {
 		}
 	}
 
-	// Construct foreign keys.
+	// Construct foreign keys. Skip foreign keys touching a table without
+	// column metadata on either side; they would reference columns absent
+	// from the dump.
+	tablesMissingColumns := make(map[string]bool)
 	for _, table := range schema.Tables {
-		if table.SkipDump {
+		if tableMissingColumnMetadata(table) {
+			tablesMissingColumns[table.Name] = true
+		}
+	}
+	for _, table := range schema.Tables {
+		if table.SkipDump || tablesMissingColumns[table.Name] {
 			continue
 		}
 		for _, fk := range table.ForeignKeys {
+			if fk.ReferencedSchema == schema.Name && tablesMissingColumns[fk.ReferencedTable] {
+				continue
+			}
 			if err := writeForeignKey(&buf, schema.Name, table.Name, fk); err != nil {
 				return "", err
 			}
@@ -652,10 +676,13 @@ func GetTableDefinition(schema string, table *storepb.TableMetadata, sequences [
 			return "", err
 		}
 	}
-	// Construct foreign keys.
-	for _, fk := range table.ForeignKeys {
-		if err := writeForeignKey(&buf, schema, table.Name, fk); err != nil {
-			return "", err
+	// Construct foreign keys. A table without column metadata cannot carry
+	// foreign keys referencing its (missing) columns.
+	if !tableMissingColumnMetadata(table) {
+		for _, fk := range table.ForeignKeys {
+			if err := writeForeignKey(&buf, schema, table.Name, fk); err != nil {
+				return "", err
+			}
 		}
 	}
 	return buf.String(), nil
@@ -1681,7 +1708,33 @@ func splitSequencesByIdentityOrNot(table *storepb.TableMetadata, sequences []*st
 	return generationType, identitySequences, nonIdentitySequences
 }
 
+// tableMissingColumnMetadata reports whether a synced table carries no column
+// metadata. information_schema.columns is privilege-filtered, so a sync user
+// without column privileges on a table sees zero columns while the
+// pg_catalog-based queries still return the table's constraints and indexes.
+// DDL referencing the missing columns would make the dump non-replayable, so
+// writers skip column-dependent statements for such tables.
+func tableMissingColumnMetadata(table *storepb.TableMetadata) bool {
+	return len(table.Columns) == 0
+}
+
 func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequences []*storepb.SequenceMetadata) error {
+	if tableMissingColumnMetadata(table) {
+		// Emit a bare CREATE TABLE so the table still exists on replay, and
+		// skip constraints, indexes, partitions, and sequence ownership —
+		// they all reference columns absent from the dump.
+		if err := writeCreateTable(out, schema, table.Name, nil, nil, nil); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(out, ";\n\n"); err != nil {
+			return err
+		}
+		if len(table.Comment) > 0 {
+			return writeTableComment(out, schema, table)
+		}
+		return nil
+	}
+
 	generationTypes, identitySequences, nonIdentitySequences := splitSequencesByIdentityOrNot(table, sequences)
 
 	if err := writeCreateTable(out, schema, table.Name, table.Columns, table.CheckConstraints, table.ExcludeConstraints); err != nil {
@@ -3187,6 +3240,11 @@ func writeCreateTableSDL(out io.Writer, schemaName string, table *storepb.TableM
 }
 
 func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata, writeSep func() error) error {
+	if tableMissingColumnMetadata(table) {
+		// Constraints would reference columns absent from the dump.
+		return nil
+	}
+
 	// Write primary key constraint
 	for _, index := range table.Indexes {
 		if index.Primary {
@@ -3245,6 +3303,10 @@ func writeTableConstraintsSDL(out io.Writer, table *storepb.TableMetadata, write
 }
 
 func writeIndexesSDL(out io.Writer, schemaName string, table *storepb.TableMetadata) error {
+	if tableMissingColumnMetadata(table) {
+		// Indexes would reference columns absent from the dump.
+		return nil
+	}
 	for _, index := range table.Indexes {
 		// Skip indexes that are constraints (primary key, unique constraints)
 		// These are already handled in the CREATE TABLE statement

--- a/backend/plugin/schema/pg/get_database_definition_regressions_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_regressions_test.go
@@ -111,18 +111,34 @@ func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
 		Name: "db",
 		Schemas: []*storepb.SchemaMetadata{{
 			Name: "s1",
-			Sequences: []*storepb.SequenceMetadata{{
-				// Owned by a column missing from t1's metadata: the sequence
-				// itself must dump, its OWNED BY clause must not.
-				Name:        "t1_c1_seq",
-				DataType:    "bigint",
-				Start:       "1",
-				Increment:   "1",
-				MinValue:    "1",
-				MaxValue:    "9223372036854775807",
-				OwnerTable:  "t1",
-				OwnerColumn: "c1",
-			}},
+			Sequences: []*storepb.SequenceMetadata{
+				{
+					// Owned by a column missing from t1's metadata: the sequence
+					// itself must dump, its OWNED BY clause must not.
+					Name:        "t1_c1_seq",
+					DataType:    "bigint",
+					Start:       "1",
+					Increment:   "1",
+					MinValue:    "1",
+					MaxValue:    "9223372036854775807",
+					OwnerTable:  "t1",
+					OwnerColumn: "c1",
+				},
+				{
+					// Owned by a column of t4, a zero-column table with no
+					// broken-metadata signal (no indexes/FKs/partitions):
+					// OWNED BY must still be skipped — a sequence cannot be
+					// owned by a column of a zero-column table.
+					Name:        "t4_id_seq",
+					DataType:    "bigint",
+					Start:       "1",
+					Increment:   "1",
+					MinValue:    "1",
+					MaxValue:    "9223372036854775807",
+					OwnerTable:  "t4",
+					OwnerColumn: "id",
+				},
+			},
 			Tables: []*storepb.TableMetadata{
 				{
 					// Broken sync: constraints and indexes, but no columns.
@@ -194,11 +210,30 @@ func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
 						ReferencedColumns: []string{"c1"},
 					}},
 				},
+				{
+					// Broken sync on a partitioned table with no indexes: the
+					// partition key references missing columns, so the table
+					// must dump bare, without the PARTITION BY clause.
+					Name: "t3",
+					Partitions: []*storepb.TablePartitionMetadata{{
+						Name:       "t3_p1",
+						Expression: "RANGE (created_at)",
+					}},
+				},
+				{
+					// Genuine zero-column table: no indexes, foreign keys, or
+					// partitions. Its column-independent CHECK must be kept.
+					Name: "t4",
+					CheckConstraints: []*storepb.CheckConstraintMetadata{{
+						Name:       "chk_t4_ok",
+						Expression: "(1 = 1)",
+					}},
+				},
 			},
 		}},
 	}
 
-	banned := []string{"pk_t1", "uk_t1_c1", "idx_t1_c2", "chk_t1_c1", "fk_t1_t2", "fk_t2_t1", "trg_t1_c1", "rule_t1", "OWNED BY", "COMMENT ON INDEX"}
+	banned := []string{"pk_t1", "uk_t1_c1", "idx_t1_c2", "chk_t1_c1", "fk_t1_t2", "fk_t2_t1", "trg_t1_c1", "rule_t1", "t3_p1", "PARTITION BY", "OWNED BY", "COMMENT ON INDEX"}
 
 	for name, ctx := range map[string]schema.GetDefinitionContext{
 		"dump": {},
@@ -222,6 +257,12 @@ func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
 		}
 		if !strings.Contains(ddl, `CREATE SEQUENCE "s1"."t1_c1_seq"`) {
 			t.Errorf("[%s] expected CREATE SEQUENCE for t1_c1_seq, got:\n%s", name, ddl)
+		}
+		if !strings.Contains(ddl, `CREATE TABLE "s1"."t3" (`) {
+			t.Errorf("[%s] expected bare CREATE TABLE for t3, got:\n%s", name, ddl)
+		}
+		if !strings.Contains(ddl, "chk_t4_ok") {
+			t.Errorf("[%s] expected genuine zero-column table t4 to keep its CHECK constraint, got:\n%s", name, ddl)
 		}
 
 		if _, parseErr := catalog.New().Exec(ddl, &catalog.ExecOptions{ContinueOnError: true}); parseErr != nil {

--- a/backend/plugin/schema/pg/get_database_definition_regressions_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_regressions_test.go
@@ -84,6 +84,12 @@ func TestGetDatabaseDefinition_TableWithOnlyCheckConstraints(t *testing.T) {
 	if !strings.Contains(ddl, `CREATE TABLE "public"."cons_only" (`) {
 		t.Errorf("expected CREATE TABLE for cons_only, got:\n%s", ddl)
 	}
+	// A genuine zero-column table (no indexes or foreign keys) must keep its
+	// column-independent CHECK constraint — only privilege-filtered broken
+	// metadata goes down the bare-table path.
+	if !strings.Contains(ddl, "cons_only_dummy") {
+		t.Errorf("expected CHECK constraint cons_only_dummy to be preserved, got:\n%s", ddl)
+	}
 	// Omni will reject a table with zero columns semantically, but it must
 	// at least parse cleanly; the test asserts the parse-level contract.
 	if _, parseErr := catalog.New().Exec(ddl, &catalog.ExecOptions{ContinueOnError: true}); parseErr != nil {

--- a/backend/plugin/schema/pg/get_database_definition_regressions_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_regressions_test.go
@@ -140,6 +140,7 @@ func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
 							Type:        "btree",
 							Expressions: []string{"c2"},
 							Definition:  `CREATE INDEX idx_t1_c2 ON s1.t1 USING btree (c2);`,
+							Comment:     "comment on a never-created index",
 						},
 					},
 					CheckConstraints: []*storepb.CheckConstraintMetadata{{
@@ -181,7 +182,7 @@ func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
 		}},
 	}
 
-	banned := []string{"pk_t1", "uk_t1_c1", "idx_t1_c2", "chk_t1_c1", "fk_t1_t2", "fk_t2_t1", "OWNED BY"}
+	banned := []string{"pk_t1", "uk_t1_c1", "idx_t1_c2", "chk_t1_c1", "fk_t1_t2", "fk_t2_t1", "OWNED BY", "COMMENT ON INDEX"}
 
 	for name, ctx := range map[string]schema.GetDefinitionContext{
 		"dump": {},

--- a/backend/plugin/schema/pg/get_database_definition_regressions_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_regressions_test.go
@@ -105,6 +105,18 @@ func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
 		Name: "db",
 		Schemas: []*storepb.SchemaMetadata{{
 			Name: "s1",
+			Sequences: []*storepb.SequenceMetadata{{
+				// Owned by a column missing from t1's metadata: the sequence
+				// itself must dump, its OWNED BY clause must not.
+				Name:        "t1_c1_seq",
+				DataType:    "bigint",
+				Start:       "1",
+				Increment:   "1",
+				MinValue:    "1",
+				MaxValue:    "9223372036854775807",
+				OwnerTable:  "t1",
+				OwnerColumn: "c1",
+			}},
 			Tables: []*storepb.TableMetadata{
 				{
 					// Broken sync: constraints and indexes, but no columns.
@@ -169,25 +181,49 @@ func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
 		}},
 	}
 
-	ddl, err := GetDatabaseDefinition(schema.GetDefinitionContext{}, meta)
-	if err != nil {
-		t.Fatalf("GetDatabaseDefinition: %v", err)
-	}
+	banned := []string{"pk_t1", "uk_t1_c1", "idx_t1_c2", "chk_t1_c1", "fk_t1_t2", "fk_t2_t1", "OWNED BY"}
 
-	if !strings.Contains(ddl, `CREATE TABLE "s1"."t1" (`) {
-		t.Errorf("expected bare CREATE TABLE for t1, got:\n%s", ddl)
-	}
-	for _, banned := range []string{"pk_t1", "uk_t1_c1", "idx_t1_c2", "chk_t1_c1", "fk_t1_t2", "fk_t2_t1"} {
-		if strings.Contains(ddl, banned) {
-			t.Errorf("DDL references %q, which depends on columns missing from t1's metadata; got:\n%s", banned, ddl)
+	for name, ctx := range map[string]schema.GetDefinitionContext{
+		"dump": {},
+		"sdl":  {SDLFormat: true},
+	} {
+		ddl, err := GetDatabaseDefinition(ctx, meta)
+		if err != nil {
+			t.Fatalf("[%s] GetDatabaseDefinition: %v", name, err)
+		}
+
+		if !strings.Contains(ddl, `CREATE TABLE "s1"."t1" (`) {
+			t.Errorf("[%s] expected bare CREATE TABLE for t1, got:\n%s", name, ddl)
+		}
+		for _, b := range banned {
+			if strings.Contains(ddl, b) {
+				t.Errorf("[%s] DDL references %q, which depends on columns missing from t1's metadata; got:\n%s", name, b, ddl)
+			}
+		}
+		if !strings.Contains(ddl, "pk_t2") {
+			t.Errorf("[%s] expected pk_t2 on the healthy table, got:\n%s", name, ddl)
+		}
+		if !strings.Contains(ddl, `CREATE SEQUENCE "s1"."t1_c1_seq"`) {
+			t.Errorf("[%s] expected CREATE SEQUENCE for t1_c1_seq, got:\n%s", name, ddl)
+		}
+
+		if _, parseErr := catalog.New().Exec(ddl, &catalog.ExecOptions{ContinueOnError: true}); parseErr != nil {
+			t.Errorf("[%s] omni catalog parse error: %v\nDDL:\n%s", name, parseErr, ddl)
 		}
 	}
-	if !strings.Contains(ddl, `ADD CONSTRAINT "pk_t2" PRIMARY KEY (id)`) {
-		t.Errorf("expected pk_t2 on the healthy table, got:\n%s", ddl)
-	}
 
-	if _, parseErr := catalog.New().Exec(ddl, &catalog.ExecOptions{ContinueOnError: true}); parseErr != nil {
-		t.Errorf("omni catalog parse error: %v\nDDL:\n%s", parseErr, ddl)
+	multiFile, err := GetMultiFileDatabaseDefinition(schema.GetDefinitionContext{}, meta)
+	if err != nil {
+		t.Fatalf("GetMultiFileDatabaseDefinition: %v", err)
+	}
+	var combined strings.Builder
+	for _, file := range multiFile.Files {
+		combined.WriteString(file.Content)
+	}
+	for _, b := range banned {
+		if strings.Contains(combined.String(), b) {
+			t.Errorf("[multi-file] DDL references %q, which depends on columns missing from t1's metadata; got:\n%s", b, combined.String())
+		}
 	}
 }
 

--- a/backend/plugin/schema/pg/get_database_definition_regressions_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_regressions_test.go
@@ -91,6 +91,106 @@ func TestGetDatabaseDefinition_TableWithOnlyCheckConstraints(t *testing.T) {
 	}
 }
 
+// TestGetDatabaseDefinition_TableWithConstraintsButNoColumns reproduces a
+// dump replay failure observed on a real workspace export: the sync user
+// lacked column privileges on some tables, so information_schema.columns
+// returned nothing while pg_catalog still exposed the tables' constraints.
+// The dump then emitted `CREATE TABLE "s1"."t1" ();` followed by
+// `ALTER TABLE ... ADD CONSTRAINT ... PRIMARY KEY (c1, c2);`, which
+// PostgreSQL rejects because the columns do not exist. The dump must skip
+// column-dependent DDL for such tables instead of producing non-replayable
+// statements.
+func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
+	meta := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name: "s1",
+			Tables: []*storepb.TableMetadata{
+				{
+					// Broken sync: constraints and indexes, but no columns.
+					Name: "t1",
+					Indexes: []*storepb.IndexMetadata{
+						{
+							Name:         "pk_t1",
+							Primary:      true,
+							Unique:       true,
+							IsConstraint: true,
+							Expressions:  []string{"c1", "c2"},
+						},
+						{
+							Name:         "uk_t1_c1",
+							Unique:       true,
+							IsConstraint: true,
+							Expressions:  []string{"c1"},
+						},
+						{
+							Name:        "idx_t1_c2",
+							Type:        "btree",
+							Expressions: []string{"c2"},
+							Definition:  `CREATE INDEX idx_t1_c2 ON s1.t1 USING btree (c2);`,
+						},
+					},
+					CheckConstraints: []*storepb.CheckConstraintMetadata{{
+						Name:       "chk_t1_c1",
+						Expression: "(c1 > 0)",
+					}},
+					ForeignKeys: []*storepb.ForeignKeyMetadata{{
+						Name:              "fk_t1_t2",
+						Columns:           []string{"c1"},
+						ReferencedSchema:  "s1",
+						ReferencedTable:   "t2",
+						ReferencedColumns: []string{"id"},
+					}},
+				},
+				{
+					// Healthy table; its own constraints must still dump, but
+					// its foreign key into the broken table must not.
+					Name: "t2",
+					Columns: []*storepb.ColumnMetadata{
+						{Name: "id", Type: "integer", Nullable: false},
+						{Name: "t1_c1", Type: "integer", Nullable: true},
+					},
+					Indexes: []*storepb.IndexMetadata{{
+						Name:         "pk_t2",
+						Primary:      true,
+						Unique:       true,
+						IsConstraint: true,
+						Expressions:  []string{"id"},
+					}},
+					ForeignKeys: []*storepb.ForeignKeyMetadata{{
+						Name:              "fk_t2_t1",
+						Columns:           []string{"t1_c1"},
+						ReferencedSchema:  "s1",
+						ReferencedTable:   "t1",
+						ReferencedColumns: []string{"c1"},
+					}},
+				},
+			},
+		}},
+	}
+
+	ddl, err := GetDatabaseDefinition(schema.GetDefinitionContext{}, meta)
+	if err != nil {
+		t.Fatalf("GetDatabaseDefinition: %v", err)
+	}
+
+	if !strings.Contains(ddl, `CREATE TABLE "s1"."t1" (`) {
+		t.Errorf("expected bare CREATE TABLE for t1, got:\n%s", ddl)
+	}
+	for _, banned := range []string{"pk_t1", "uk_t1_c1", "idx_t1_c2", "chk_t1_c1", "fk_t1_t2", "fk_t2_t1"} {
+		if strings.Contains(ddl, banned) {
+			t.Errorf("DDL references %q, which depends on columns missing from t1's metadata; got:\n%s", banned, ddl)
+		}
+	}
+	if !strings.Contains(ddl, `ADD CONSTRAINT "pk_t2" PRIMARY KEY (id)`) {
+		t.Errorf("expected pk_t2 on the healthy table, got:\n%s", ddl)
+	}
+
+	if _, parseErr := catalog.New().Exec(ddl, &catalog.ExecOptions{ContinueOnError: true}); parseErr != nil {
+		t.Errorf("omni catalog parse error: %v\nDDL:\n%s", parseErr, ddl)
+	}
+}
+
 // TestGetDatabaseDefinition_TableNameContainingDot reproduces A3: a table
 // whose name literally contains a period was writing out as `"".".."` —
 // because the schema + "." + object object-ID was split back on the first

--- a/backend/plugin/schema/pg/get_database_definition_regressions_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_regressions_test.go
@@ -154,6 +154,16 @@ func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
 						ReferencedTable:   "t2",
 						ReferencedColumns: []string{"id"},
 					}},
+					Triggers: []*storepb.TriggerMetadata{{
+						Name:    "trg_t1_c1",
+						Body:    `CREATE TRIGGER trg_t1_c1 BEFORE UPDATE OF c1 ON s1.t1 FOR EACH ROW EXECUTE FUNCTION s1.f()`,
+						Comment: "comment on a never-created trigger",
+					}},
+					Rules: []*storepb.RuleMetadata{{
+						Name:       "rule_t1",
+						Event:      "INSERT",
+						Definition: `CREATE RULE rule_t1 AS ON INSERT TO s1.t1 WHERE new.c1 > 0 DO INSTEAD NOTHING;`,
+					}},
 				},
 				{
 					// Healthy table; its own constraints must still dump, but
@@ -182,7 +192,7 @@ func TestGetDatabaseDefinition_TableWithConstraintsButNoColumns(t *testing.T) {
 		}},
 	}
 
-	banned := []string{"pk_t1", "uk_t1_c1", "idx_t1_c2", "chk_t1_c1", "fk_t1_t2", "fk_t2_t1", "OWNED BY", "COMMENT ON INDEX"}
+	banned := []string{"pk_t1", "uk_t1_c1", "idx_t1_c2", "chk_t1_c1", "fk_t1_t2", "fk_t2_t1", "trg_t1_c1", "rule_t1", "OWNED BY", "COMMENT ON INDEX"}
 
 	for name, ctx := range map[string]schema.GetDefinitionContext{
 		"dump": {},


### PR DESCRIPTION
## What changed

The PostgreSQL schema dump generator could emit a table with an empty column list followed by constraints referencing its (missing) columns:

```sql
CREATE TABLE "s1"."t1" (
);

ALTER TABLE ONLY "s1"."t1" ADD CONSTRAINT "pk_t1" PRIMARY KEY (c1, c2);
```

PostgreSQL accepts the zero-column `CREATE TABLE` but rejects the `PRIMARY KEY` on nonexistent columns, so the dump is not replayable. Observed on a real workspace export where one schema's tables all had empty column lists while their constraints were still emitted.

**Root cause:** the two sides of metadata sync read from differently-filtered catalogs. Columns come from `INFORMATION_SCHEMA.COLUMNS` (privilege-filtered — a sync user without column/table privileges on a table gets zero rows), while indexes and constraints come from `pg_catalog.pg_index` / `pg_constraint` (no privilege filter). The result is synced table metadata with constraints but no columns.

**Fix (dump side):** added `tableMissingColumnMetadata` and made the writers skip column-dependent DDL when a table's column list is empty:

- `writeTable` emits a bare `CREATE TABLE "s"."t" ();` (plus table comment) and skips PK/unique/index statements, inline CHECK/EXCLUDE constraints, partition DDL, and `ALTER SEQUENCE ... OWNED BY` — all of which reference the missing columns. `CREATE SEQUENCE` is unaffected (emitted at schema level).
- Foreign keys are skipped in both directions — FKs owned by an empty-column table, and FKs from healthy tables referencing one (the referenced PK is skipped, so they would fail replay too). Applied in `GetDatabaseDefinition`, `GetSchemaDefinition`, and `GetTableDefinition`.
- The SDL path (`writeTableConstraintsSDL`, `writeIndexesSDL`) gets the same guard.

Trade-off: a genuine zero-column table with a column-free check like `CHECK (1=1)` no longer dumps that check — replayability of the realistic broken-sync case wins over that pathological fidelity case. The existing `TestGetDatabaseDefinition_TableWithOnlyCheckConstraints` still passes.

This is the defensive dump-side fix; making the sync itself return columns regardless of privileges (e.g. reading `pg_catalog.pg_attribute`) is a separate follow-up since it touches type-string rendering.

## Testing

- New regression test `TestGetDatabaseDefinition_TableWithConstraintsButNoColumns`: a table with PK, unique constraint, index, check, and FK but no columns, next to a healthy table. Asserts the bare `CREATE TABLE` appears, none of the constraint/index names leak into the DDL, the healthy table's own PK still dumps, and the output parses via the omni catalog.
- Replayed both shapes against a real local PostgreSQL: the old shape reproduces the reported error (`column "c1" of relation ... does not exist`); the new shape replays cleanly.
- `go test ./backend/plugin/schema/pg/` passes (except the pre-existing Docker-dependent testcontainer test, which fails locally only because no Docker daemon is running), `golangci-lint` reports 0 issues, full server build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)