### PR TITLE
feat(frontend): tiered error containment — recovery page, layout seams, widget boundaries

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -842,8 +842,11 @@
     "successfully-updated-environment": "Successfully updated environment '{{name}}'."
   },
   "error-page": {
+    "error-details": "Error details",
     "go-back-home": "Go back home",
-    "not-found": "Not Found"
+    "not-found": "Not Found",
+    "something-went-wrong": "Something went wrong",
+    "unexpected-error-description": "An unexpected error occurred while displaying this page. Refreshing usually fixes it; if it keeps happening, please report the error details below."
   },
   "export-center": {
     "data-export": "Data Export",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -394,6 +394,7 @@
     "remaining": "remaining",
     "remove": "Remove",
     "removed": "Removed",
+    "render-failed": "Failed to display this content.",
     "reopen": "Reopen",
     "reorder": "Reorder",
     "required-permission": "Required permissions",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -847,7 +847,7 @@
     "go-back-home": "Go back home",
     "not-found": "Not Found",
     "something-went-wrong": "Something went wrong",
-    "unexpected-error-description": "An unexpected error occurred while displaying this page. Refreshing usually fixes it; if it keeps happening, please report the error details below."
+    "unexpected-error-description": "An unexpected error occurred while displaying this page. Refreshing usually fixes it; if it keeps happening, please report the issue to your administrator."
   },
   "export-center": {
     "data-export": "Data Export",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -394,6 +394,7 @@
     "remaining": "restantes",
     "remove": "Eliminar",
     "removed": "Eliminado",
+    "render-failed": "No se pudo mostrar este contenido.",
     "reopen": "Reabrir",
     "reorder": "Reordenar",
     "required-permission": "Permisos necesarios",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -842,8 +842,11 @@
     "successfully-updated-environment": "entorno '{{name}}' actualizado exitosamente."
   },
   "error-page": {
+    "error-details": "Detalles del error",
     "go-back-home": "Volver al inicio",
-    "not-found": "No encontrado"
+    "not-found": "No encontrado",
+    "something-went-wrong": "Algo salió mal",
+    "unexpected-error-description": "Se produjo un error inesperado al mostrar esta página. Actualizar suele solucionarlo; si persiste, informa los detalles del error a continuación."
   },
   "export-center": {
     "data-export": "Exportación de datos",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -847,7 +847,7 @@
     "go-back-home": "Volver al inicio",
     "not-found": "No encontrado",
     "something-went-wrong": "Algo salió mal",
-    "unexpected-error-description": "Se produjo un error inesperado al mostrar esta página. Actualizar suele solucionarlo; si persiste, informa los detalles del error a continuación."
+    "unexpected-error-description": "Se produjo un error inesperado al mostrar esta página. Actualizar suele solucionarlo; si persiste, informa el problema a tu administrador."
   },
   "export-center": {
     "data-export": "Exportación de datos",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -842,8 +842,11 @@
     "successfully-updated-environment": "環境「{{name}}」は正常に更新されました"
   },
   "error-page": {
+    "error-details": "エラー詳細",
     "go-back-home": "ホームページに戻る",
-    "not-found": "ページが見つかりません"
+    "not-found": "ページが見つかりません",
+    "something-went-wrong": "問題が発生しました",
+    "unexpected-error-description": "このページの表示中に予期しないエラーが発生しました。通常は更新すると解決します。問題が続く場合は、以下のエラー詳細をご報告ください。"
   },
   "export-center": {
     "data-export": "データエクスポート",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -847,7 +847,7 @@
     "go-back-home": "ホームページに戻る",
     "not-found": "ページが見つかりません",
     "something-went-wrong": "問題が発生しました",
-    "unexpected-error-description": "このページの表示中に予期しないエラーが発生しました。通常は更新すると解決します。問題が続く場合は、以下のエラー詳細をご報告ください。"
+    "unexpected-error-description": "このページの表示中に予期しないエラーが発生しました。通常は更新すると解決します。問題が続く場合は、管理者にご報告ください。"
   },
   "export-center": {
     "data-export": "データエクスポート",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -394,6 +394,7 @@
     "remaining": "残り",
     "remove": "削除",
     "removed": "削除されました",
+    "render-failed": "このコンテンツを表示できませんでした。",
     "reopen": "再開",
     "reorder": "並び替え",
     "required-permission": "必要な権限",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -842,8 +842,11 @@
     "successfully-updated-environment": "Đã cập nhật thành công môi trường '{{name}}'."
   },
   "error-page": {
+    "error-details": "Chi tiết lỗi",
     "go-back-home": "Về trang chủ",
-    "not-found": "Không tìm thấy"
+    "not-found": "Không tìm thấy",
+    "something-went-wrong": "Đã xảy ra lỗi",
+    "unexpected-error-description": "Đã xảy ra lỗi không mong muốn khi hiển thị trang này. Tải lại thường sẽ khắc phục được; nếu lỗi tiếp diễn, vui lòng báo cáo chi tiết lỗi bên dưới."
   },
   "export-center": {
     "data-export": "Xuất dữ liệu",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -847,7 +847,7 @@
     "go-back-home": "Về trang chủ",
     "not-found": "Không tìm thấy",
     "something-went-wrong": "Đã xảy ra lỗi",
-    "unexpected-error-description": "Đã xảy ra lỗi không mong muốn khi hiển thị trang này. Tải lại thường sẽ khắc phục được; nếu lỗi tiếp diễn, vui lòng báo cáo chi tiết lỗi bên dưới."
+    "unexpected-error-description": "Đã xảy ra lỗi không mong muốn khi hiển thị trang này. Tải lại thường sẽ khắc phục được; nếu lỗi tiếp diễn, vui lòng báo cáo cho quản trị viên."
   },
   "export-center": {
     "data-export": "Xuất dữ liệu",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -394,6 +394,7 @@
     "remaining": "còn lại",
     "remove": "Gỡ bỏ",
     "removed": "LOẠI BỎ",
+    "render-failed": "Không thể hiển thị nội dung này.",
     "reopen": "Mở lại",
     "reorder": "Sắp xếp lại",
     "required-permission": "Quyền hạn cần thiết",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -842,8 +842,11 @@
     "successfully-updated-environment": "环境'{{name}}'更新成功"
   },
   "error-page": {
+    "error-details": "错误详情",
     "go-back-home": "回到主页",
-    "not-found": "页面未找到"
+    "not-found": "页面未找到",
+    "something-went-wrong": "出错了",
+    "unexpected-error-description": "显示此页面时发生意外错误。刷新通常可以解决；如果问题持续出现，请将下方的错误详情反馈给我们。"
   },
   "export-center": {
     "data-export": "数据导出",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -394,6 +394,7 @@
     "remaining": "剩余",
     "remove": "移除",
     "removed": "已移除",
+    "render-failed": "无法显示此内容。",
     "reopen": "重新打开",
     "reorder": "排序",
     "required-permission": "所需权限",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -847,7 +847,7 @@
     "go-back-home": "回到主页",
     "not-found": "页面未找到",
     "something-went-wrong": "出错了",
-    "unexpected-error-description": "显示此页面时发生意外错误。刷新通常可以解决；如果问题持续出现，请将下方的错误详情反馈给我们。"
+    "unexpected-error-description": "显示此页面时发生意外错误。刷新通常可以解决；如果问题持续出现，请联系管理员反馈。"
   },
   "export-center": {
     "data-export": "数据导出",

--- a/frontend/src/react/app/RouteErrorPage.test.tsx
+++ b/frontend/src/react/app/RouteErrorPage.test.tsx
@@ -1,0 +1,60 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { RouteErrorPage } from "./RouteErrorPage";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const Boom = () => {
+  throw new Error("boom from render");
+};
+
+describe("RouteErrorPage", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+  });
+
+  test("a route render crash shows the recovery page with error details", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const router = createMemoryRouter(
+        [{ path: "/", element: <Boom />, errorElement: <RouteErrorPage /> }],
+        { initialEntries: ["/"] }
+      );
+      await act(async () => {
+        root.render(<RouterProvider router={router} />);
+      });
+      expect(container.textContent).toContain(
+        "error-page.something-went-wrong"
+      );
+      // The thrown error is surfaced so users can report it.
+      expect(container.textContent).toContain("boom from render");
+      // Recovery actions.
+      expect(container.textContent).toContain("common.refresh");
+      expect(container.textContent).toContain("error-page.go-back-home");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/frontend/src/react/app/RouteErrorPage.test.tsx
+++ b/frontend/src/react/app/RouteErrorPage.test.tsx
@@ -1,6 +1,6 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { createMemoryRouter, Outlet, RouterProvider } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { RouteErrorPage } from "./RouteErrorPage";
 
@@ -31,6 +31,77 @@ describe("RouteErrorPage", () => {
       root.unmount();
     });
     document.body.removeChild(container);
+  });
+
+  test("inline variant renders a panel without the full-screen container", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const router = createMemoryRouter(
+        [
+          {
+            path: "/",
+            element: <Boom />,
+            errorElement: <RouteErrorPage inline />,
+          },
+        ],
+        { initialEntries: ["/"] }
+      );
+      await act(async () => {
+        root.render(<RouterProvider router={router} />);
+      });
+      expect(container.textContent).toContain(
+        "error-page.something-went-wrong"
+      );
+      // The inline panel must not claim the whole viewport — it renders
+      // inside a layout's content area.
+      expect(container.querySelector(".h-screen")).toBeNull();
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test("a pathless errorElement route keeps the parent layout shell alive", async () => {
+    // The tier-2 "layout seam" pattern: the boundary lives BELOW the
+    // layout route, so a crashing page renders the error panel inside the
+    // layout's outlet — navigation chrome survives. (An errorElement ON
+    // the layout route would replace the layout itself.)
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const Shell = () => (
+        <div>
+          <nav>APP-SHELL</nav>
+          <Outlet />
+        </div>
+      );
+      const router = createMemoryRouter(
+        [
+          {
+            path: "/",
+            element: <Shell />,
+            children: [
+              {
+                errorElement: <RouteErrorPage inline />,
+                children: [{ index: true, element: <Boom /> }],
+              },
+            ],
+          },
+        ],
+        { initialEntries: ["/"] }
+      );
+      await act(async () => {
+        root.render(<RouterProvider router={router} />);
+      });
+      expect(container.textContent).toContain("APP-SHELL");
+      expect(container.textContent).toContain(
+        "error-page.something-went-wrong"
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   test("a route render crash shows the recovery page with error details", async () => {

--- a/frontend/src/react/app/RouteErrorPage.test.tsx
+++ b/frontend/src/react/app/RouteErrorPage.test.tsx
@@ -104,7 +104,9 @@ describe("RouteErrorPage", () => {
     }
   });
 
-  test("a route render crash shows the recovery page with error details", async () => {
+  test("a route render crash shows the recovery page, with raw details in dev mode", async () => {
+    // Vitest runs with import.meta.env.DEV = true, so this covers the
+    // dev/diagnostic contract: raw error details are shown for debugging.
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -119,13 +121,52 @@ describe("RouteErrorPage", () => {
       expect(container.textContent).toContain(
         "error-page.something-went-wrong"
       );
-      // The thrown error is surfaced so users can report it.
       expect(container.textContent).toContain("boom from render");
       // Recovery actions.
       expect(container.textContent).toContain("common.refresh");
       expect(container.textContent).toContain("error-page.go-back-home");
     } finally {
       consoleError.mockRestore();
+    }
+  });
+
+  test("production hides raw error details and logs them to the console instead", async () => {
+    // The recovery page catches render/loader/lazy-route failures across
+    // the whole app — raw stacks and loader error text can leak bundle
+    // paths, component names, or backend messages. Ordinary users get
+    // generic copy + recovery actions; the raw error goes to the console
+    // for diagnostics (react-router does not log it for custom
+    // errorElements).
+    vi.stubEnv("DEV", false);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const router = createMemoryRouter(
+        [{ path: "/", element: <Boom />, errorElement: <RouteErrorPage /> }],
+        { initialEntries: ["/"] }
+      );
+      await act(async () => {
+        root.render(<RouterProvider router={router} />);
+      });
+      expect(container.textContent).toContain(
+        "error-page.something-went-wrong"
+      );
+      expect(container.textContent).toContain("common.refresh");
+      expect(container.textContent).toContain("error-page.go-back-home");
+      // No raw error text or details block for end users.
+      expect(container.textContent).not.toContain("boom from render");
+      expect(container.querySelector("details")).toBeNull();
+      // The raw error is still logged for diagnostics.
+      expect(
+        consoleError.mock.calls.some(
+          (args) =>
+            typeof args[0] === "string" && args[0].includes("[RouteErrorPage]")
+        )
+      ).toBe(true);
+    } finally {
+      consoleError.mockRestore();
+      vi.unstubAllEnvs();
     }
   });
 });

--- a/frontend/src/react/app/RouteErrorPage.tsx
+++ b/frontend/src/react/app/RouteErrorPage.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from "react-i18next";
+import { useRouteError } from "react-router-dom";
+import { Button } from "@/react/components/ui/button";
+
+/**
+ * Root-route `errorElement`: any uncaught render/loader exception in the
+ * route tree lands here instead of react-router's developer-facing default
+ * error screen. Shows a recoverable page with the error surfaced so users
+ * can copy it into a bug report.
+ */
+export function RouteErrorPage() {
+  const { t } = useTranslation();
+  const error = useRouteError();
+  const message = error instanceof Error ? error.message : String(error);
+  const stack = error instanceof Error ? error.stack : undefined;
+
+  return (
+    <div className="flex h-screen w-full flex-col items-center justify-center gap-y-4 px-4">
+      <h1 className="text-2xl font-semibold text-main">
+        {t("error-page.something-went-wrong")}
+      </h1>
+      <p className="text-sm text-control-light">
+        {t("error-page.unexpected-error-description")}
+      </p>
+      <div className="flex gap-x-2">
+        <Button onClick={() => window.location.reload()}>
+          {t("common.refresh")}
+        </Button>
+        <Button variant="outline" onClick={() => window.location.assign("/")}>
+          {t("error-page.go-back-home")}
+        </Button>
+      </div>
+      <details className="w-full max-w-2xl text-sm text-control-light">
+        <summary className="cursor-pointer select-none">
+          {t("error-page.error-details")}
+        </summary>
+        <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap rounded-sm border border-control-border bg-control-bg p-3 text-xs">
+          {stack ?? message}
+        </pre>
+      </details>
+    </div>
+  );
+}

--- a/frontend/src/react/app/RouteErrorPage.tsx
+++ b/frontend/src/react/app/RouteErrorPage.tsx
@@ -1,21 +1,30 @@
 import { useTranslation } from "react-i18next";
 import { useRouteError } from "react-router-dom";
 import { Button } from "@/react/components/ui/button";
+import { cn } from "@/react/lib/utils";
 
 /**
- * Root-route `errorElement`: any uncaught render/loader exception in the
- * route tree lands here instead of react-router's developer-facing default
- * error screen. Shows a recoverable page with the error surfaced so users
- * can copy it into a bug report.
+ * `errorElement` for uncaught render/loader exceptions, instead of
+ * react-router's developer-facing default error screen. Shows a recoverable
+ * page with the error surfaced so users can copy it into a bug report.
+ *
+ * Default renders full-screen (the root-route last resort). Pass `inline`
+ * when mounting on a layout-seam route so the panel fills the layout's
+ * content area and the navigation chrome stays alive.
  */
-export function RouteErrorPage() {
+export function RouteErrorPage({ inline = false }: { inline?: boolean }) {
   const { t } = useTranslation();
   const error = useRouteError();
   const message = error instanceof Error ? error.message : String(error);
   const stack = error instanceof Error ? error.stack : undefined;
 
   return (
-    <div className="flex h-screen w-full flex-col items-center justify-center gap-y-4 px-4">
+    <div
+      className={cn(
+        "flex w-full flex-col items-center justify-center gap-y-4 px-4",
+        inline ? "h-full py-16" : "h-screen"
+      )}
+    >
       <h1 className="text-2xl font-semibold text-main">
         {t("error-page.something-went-wrong")}
       </h1>

--- a/frontend/src/react/app/RouteErrorPage.tsx
+++ b/frontend/src/react/app/RouteErrorPage.tsx
@@ -12,7 +12,9 @@ import { cn } from "@/react/lib/utils";
  * when mounting on a layout-seam route so the panel fills the layout's
  * content area and the navigation chrome stays alive.
  */
-export function RouteErrorPage({ inline = false }: { inline?: boolean }) {
+export function RouteErrorPage({
+  inline = false,
+}: Readonly<{ inline?: boolean }>) {
   const { t } = useTranslation();
   const error = useRouteError();
   const message = error instanceof Error ? error.message : String(error);
@@ -32,10 +34,13 @@ export function RouteErrorPage({ inline = false }: { inline?: boolean }) {
         {t("error-page.unexpected-error-description")}
       </p>
       <div className="flex gap-x-2">
-        <Button onClick={() => window.location.reload()}>
+        <Button onClick={() => globalThis.location.reload()}>
           {t("common.refresh")}
         </Button>
-        <Button variant="outline" onClick={() => window.location.assign("/")}>
+        <Button
+          variant="outline"
+          onClick={() => globalThis.location.assign("/")}
+        >
           {t("error-page.go-back-home")}
         </Button>
       </div>

--- a/frontend/src/react/app/RouteErrorPage.tsx
+++ b/frontend/src/react/app/RouteErrorPage.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useRouteError } from "react-router-dom";
 import { Button } from "@/react/components/ui/button";
@@ -5,8 +6,10 @@ import { cn } from "@/react/lib/utils";
 
 /**
  * `errorElement` for uncaught render/loader exceptions, instead of
- * react-router's developer-facing default error screen. Shows a recoverable
- * page with the error surfaced so users can copy it into a bug report.
+ * react-router's developer-facing default error screen. Shows generic
+ * recovery copy; raw error details (stack, loader error text) can leak
+ * bundle paths, component names, or backend messages, so they render only
+ * in dev builds — production logs them to the console for diagnostics.
  *
  * Default renders full-screen (the root-route last resort). Pass `inline`
  * when mounting on a layout-seam route so the panel fills the layout's
@@ -19,6 +22,13 @@ export function RouteErrorPage({
   const error = useRouteError();
   const message = error instanceof Error ? error.message : String(error);
   const stack = error instanceof Error ? error.stack : undefined;
+  const showDetails = import.meta.env.DEV;
+
+  // react-router does not log errors that reach a custom errorElement —
+  // without this, production errors would be invisible everywhere.
+  useEffect(() => {
+    console.error("[RouteErrorPage] uncaught route error:", error);
+  }, [error]);
 
   return (
     <div
@@ -44,14 +54,16 @@ export function RouteErrorPage({
           {t("error-page.go-back-home")}
         </Button>
       </div>
-      <details className="w-full max-w-2xl text-sm text-control-light">
-        <summary className="cursor-pointer select-none">
-          {t("error-page.error-details")}
-        </summary>
-        <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap rounded-sm border border-control-border bg-control-bg p-3 text-xs">
-          {stack ?? message}
-        </pre>
-      </details>
+      {showDetails && (
+        <details className="w-full max-w-2xl text-sm text-control-light">
+          <summary className="cursor-pointer select-none">
+            {t("error-page.error-details")}
+          </summary>
+          <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap rounded-sm border border-control-border bg-control-bg p-3 text-xs">
+            {stack ?? message}
+          </pre>
+        </details>
+      )}
     </div>
   );
 }

--- a/frontend/src/react/components/SchemaEditorLite/Aside/AsideTree.tsx
+++ b/frontend/src/react/components/SchemaEditorLite/Aside/AsideTree.tsx
@@ -25,6 +25,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/react/components/ui/dropdown-menu";
+import { ErrorBoundary } from "@/react/components/ui/error-boundary";
 import { getLayerRoot, LAYER_SURFACE_CLASS } from "@/react/components/ui/layer";
 import { SearchInput } from "@/react/components/ui/search-input";
 import { cn } from "@/react/lib/utils";
@@ -541,30 +542,45 @@ export function AsideTree() {
         )}
       </div>
       <div ref={containerRef} className="flex-1 overflow-hidden">
-        <Tree
-          data={arboristData}
-          idAccessor="id"
-          searchTerm={searchPattern}
-          searchMatch={(node, term) =>
-            node.data.name.toLowerCase().includes(term.toLowerCase())
+        {/* react-arborist hard-throws on malformed data (e.g. a falsy
+            node id) — contain that to this pane, same as the shared
+            ui/Tree primitive does. */}
+        <ErrorBoundary
+          resetKey={arboristData}
+          fallback={
+            <div className="px-2 py-1 text-sm text-control-light">
+              {t("common.render-failed")}
+            </div>
           }
-          rowHeight={28}
-          indent={16}
-          openByDefault={false}
-          width="100%"
-          height={containerRef.current?.clientHeight ?? 400}
+          onError={(error) => {
+            console.error("[AsideTree] failed to render tree data:", error);
+          }}
         >
-          {(props) => (
-            <NodeRenderer
-              {...props}
-              nodeMap={nodeMap}
-              onNodeClick={handleNodeClick}
-              onContextMenu={readonly ? undefined : showMenu}
-              getNodeStatus={getNodeStatus}
-              selection={selection}
-            />
-          )}
-        </Tree>
+          <Tree
+            data={arboristData}
+            idAccessor="id"
+            searchTerm={searchPattern}
+            searchMatch={(node, term) =>
+              node.data.name.toLowerCase().includes(term.toLowerCase())
+            }
+            rowHeight={28}
+            indent={16}
+            openByDefault={false}
+            width="100%"
+            height={containerRef.current?.clientHeight ?? 400}
+          >
+            {(props) => (
+              <NodeRenderer
+                {...props}
+                nodeMap={nodeMap}
+                onNodeClick={handleNodeClick}
+                onContextMenu={readonly ? undefined : showMenu}
+                getNodeStatus={getNodeStatus}
+                selection={selection}
+              />
+            )}
+          </Tree>
+        </ErrorBoundary>
       </div>
 
       {/* Context menu portal */}

--- a/frontend/src/react/components/ui/error-boundary.tsx
+++ b/frontend/src/react/components/ui/error-boundary.tsx
@@ -1,0 +1,56 @@
+import { Component, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  /** Rendered in place of children after a render error is caught. */
+  readonly fallback: ReactNode;
+  /** Called once per caught error — wire to console.error or telemetry. */
+  readonly onError?: (error: unknown) => void;
+  /**
+   * When this value changes (by `Object.is`) after an error, the boundary
+   * clears the error and re-attempts rendering children. Pass the data the
+   * children render so fresh input gets a fresh chance.
+   */
+  readonly resetKey?: unknown;
+  readonly children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+/**
+ * Containment for render-time exceptions: a crash inside `children` swaps in
+ * `fallback` instead of unmounting the application. Use it around components
+ * that render data they don't control (e.g. third-party tree/virtualization
+ * libraries that throw on malformed input).
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  override componentDidCatch(error: unknown) {
+    this.props.onError?.(error);
+  }
+
+  override componentDidUpdate(prevProps: ErrorBoundaryProps) {
+    if (
+      this.state.hasError &&
+      !Object.is(prevProps.resetKey, this.props.resetKey)
+    ) {
+      this.setState({ hasError: false });
+    }
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/react/components/ui/tree.test.tsx
+++ b/frontend/src/react/components/ui/tree.test.tsx
@@ -4,6 +4,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { TreeDataNode } from "./tree";
 import { Tree } from "./tree";
 
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -44,6 +48,72 @@ describe("Tree", () => {
       root.unmount();
     });
     document.body.removeChild(container);
+  });
+
+  test("a node with a falsy id renders a contained fallback instead of crashing", async () => {
+    // react-arborist throws on falsy ids. The Tree must contain that
+    // failure to the pane (fallback + console.error) instead of letting
+    // the exception unmount the whole app.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const nodes = [makeNode("", "Broken")];
+      await act(async () => {
+        root.render(
+          <Tree
+            data={nodes}
+            renderNode={({ node, style }) => (
+              <div style={style}>{node.data.data.label}</div>
+            )}
+            height={200}
+          />
+        );
+      });
+      expect(container.textContent).toContain("common.render-failed");
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+
+  test("recovers from the fallback when the data prop changes", async () => {
+    // After a contained crash, swapping in new data (e.g. the user picks
+    // another database) must re-attempt rendering, not stay broken.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const renderNode = ({
+        node,
+        style,
+      }: {
+        node: { data: TreeDataNode<TestPayload> };
+        style: React.CSSProperties;
+      }) => <div style={style}>{node.data.data.label}</div>;
+      await act(async () => {
+        root.render(
+          <Tree
+            data={[makeNode("", "Broken")]}
+            renderNode={renderNode}
+            height={200}
+          />
+        );
+      });
+      expect(container.textContent).toContain("common.render-failed");
+
+      await act(async () => {
+        root.render(
+          <Tree
+            data={[makeNode("ok", "Recovered")]}
+            renderNode={renderNode}
+            height={200}
+          />
+        );
+      });
+      expect(container.textContent).toContain("Recovered");
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   test("renders nodes from data via renderNode", async () => {

--- a/frontend/src/react/components/ui/tree.tsx
+++ b/frontend/src/react/components/ui/tree.tsx
@@ -2,6 +2,8 @@ import type { CSSProperties, ReactNode } from "react";
 import { useLayoutEffect, useRef } from "react";
 import type { MoveHandler, NodeApi, TreeApi } from "react-arborist";
 import { Tree as ArboristTree } from "react-arborist";
+import { useTranslation } from "react-i18next";
+import { ErrorBoundary } from "@/react/components/ui/error-boundary";
 import { cn } from "@/react/lib/utils";
 
 export interface TreeDataNode<T> {
@@ -62,6 +64,7 @@ export function Tree<T>({
   disableDrop = true,
   className,
 }: TreeProps<T>) {
+  const { t } = useTranslation();
   const treeRef = useRef<TreeApi<TreeDataNode<T>> | null>(null);
   const prevExpandedRef = useRef<readonly string[] | undefined>(undefined);
   // react-arborist fires `onToggle` synchronously inside `tree.open()` /
@@ -159,30 +162,45 @@ export function Tree<T>({
     <div
       className={cn("outline-none focus:outline-none rounded-sm", className)}
     >
-      <ArboristTree<TreeDataNode<T>>
-        ref={treeRef}
-        data={data as TreeDataNode<T>[]}
-        idAccessor="id"
-        childrenAccessor="children"
-        selection={selectedIds?.[0]}
-        onSelect={handleSelect}
-        onToggle={handleArboristToggle}
-        onMove={onMove}
-        searchTerm={searchTerm}
-        searchMatch={resolvedSearchMatch}
-        openByDefault={false}
-        disableDrag={disableDrag}
-        disableDrop={disableDrop}
-        disableEdit
-        height={height}
-        rowHeight={rowHeight}
-        indent={indent}
-        width="100%"
-      >
-        {({ node, style, dragHandle }) =>
-          renderNode({ node, style, dragHandle })
+      {/* react-arborist hard-throws on malformed data (e.g. a falsy node
+          id). Contain that to this pane — a broken tree must not unmount
+          the whole app. */}
+      <ErrorBoundary
+        resetKey={data}
+        fallback={
+          <div className="px-2 py-1 text-sm text-control-light">
+            {t("common.render-failed")}
+          </div>
         }
-      </ArboristTree>
+        onError={(error) => {
+          console.error("[Tree] failed to render tree data:", error);
+        }}
+      >
+        <ArboristTree<TreeDataNode<T>>
+          ref={treeRef}
+          data={data as TreeDataNode<T>[]}
+          idAccessor="id"
+          childrenAccessor="children"
+          selection={selectedIds?.[0]}
+          onSelect={handleSelect}
+          onToggle={handleArboristToggle}
+          onMove={onMove}
+          searchTerm={searchTerm}
+          searchMatch={resolvedSearchMatch}
+          openByDefault={false}
+          disableDrag={disableDrag}
+          disableDrop={disableDrop}
+          disableEdit
+          height={height}
+          rowHeight={rowHeight}
+          indent={indent}
+          width="100%"
+        >
+          {({ node, style, dragHandle }) =>
+            renderNode({ node, style, dragHandle })
+          }
+        </ArboristTree>
+      </ErrorBoundary>
     </div>
   );
 }

--- a/frontend/src/react/router/routes.test.tsx
+++ b/frontend/src/react/router/routes.test.tsx
@@ -78,6 +78,20 @@ describe("react route table reachability", () => {
     expect(routes[0].errorElement).toBeTruthy();
   });
 
+  it("dashboard pages sit behind a layout-seam errorElement below BodyLayout", () => {
+    // The seam must be a pathless route BELOW BodyLayout: an errorElement
+    // ON the layout route would replace the layout (sidebar and all) when
+    // a page crashes, instead of rendering the panel in the content area.
+    const dashboardRoot = routes[0].children?.find((r) => r.path === "/");
+    expect(dashboardRoot).toBeDefined();
+    const bodyLayoutRoute = dashboardRoot!.children?.find((r) => r.path === "");
+    expect(bodyLayoutRoute).toBeDefined();
+    const seam = bodyLayoutRoute!.children?.[0];
+    expect(seam?.path).toBeUndefined();
+    expect(seam?.errorElement).toBeTruthy();
+    expect(seam?.children?.length).toBeGreaterThan(0);
+  });
+
   it.each([
     "/projects/db333/rollouts/605",
     "/sql-editor/does-not-exist",

--- a/frontend/src/react/router/routes.test.tsx
+++ b/frontend/src/react/router/routes.test.tsx
@@ -71,6 +71,13 @@ describe("react route table reachability", () => {
     expect(collectBareLeaves(routes)).toEqual([]);
   });
 
+  it("the root route declares an errorElement so render crashes show a recovery page", () => {
+    // Without this, any uncaught render error anywhere in the app shows
+    // react-router's developer-facing default error screen (raw minified
+    // stack, "Hey developer" hint) — see issue #20575.
+    expect(routes[0].errorElement).toBeTruthy();
+  });
+
   it.each([
     "/projects/db333/rollouts/605",
     "/sql-editor/does-not-exist",

--- a/frontend/src/react/router/routes.tsx
+++ b/frontend/src/react/router/routes.tsx
@@ -1,5 +1,6 @@
 import { type RouteObject, redirect } from "react-router-dom";
 import { RootLayout } from "@/react/app/RootLayout";
+import { RouteErrorPage } from "@/react/app/RouteErrorPage";
 import { WORKSPACE_ROUTE_404 } from "@/react/router/handles";
 import { authRoutes } from "@/react/router/routes/auth";
 import { dashboardRoutes } from "@/react/router/routes/dashboard";
@@ -16,6 +17,10 @@ import { sqlEditorRoutes } from "@/react/router/routes/sqlEditor";
 export const routes: RouteObject[] = [
   {
     element: <RootLayout />,
+    // Catch-all for uncaught render/loader exceptions anywhere in the
+    // tree: show a user-facing recovery page instead of react-router's
+    // developer default screen.
+    errorElement: <RouteErrorPage />,
     children: [
       ...authRoutes,
       ...dashboardRoutes,

--- a/frontend/src/react/router/routes/dashboard.tsx
+++ b/frontend/src/react/router/routes/dashboard.tsx
@@ -1,6 +1,7 @@
 import { Navigate, type RouteObject, redirect } from "react-router-dom";
 import { BodyLayout } from "@/react/app/layouts/BodyLayout";
 import { DashboardLayout } from "@/react/app/layouts/DashboardLayout";
+import { RouteErrorPage } from "@/react/app/RouteErrorPage";
 import { rootGuard } from "@/react/router/guard";
 import {
   DATABASE_ROUTE_DASHBOARD,
@@ -1010,22 +1011,32 @@ export const dashboardRoutes: RouteObject[] = [
         path: "",
         element: <BodyLayout />,
         children: [
-          ...workspaceLevelRoutes,
-          ...workspaceSettingRoutes,
-          ...environmentV1Routes,
-          ...instanceRoutes,
-          ...projectV1Routes,
-          // Workspace "My Issues" — lives under BodyLayout for the shared
-          // dashboard header, but renders as a standalone full-width page
-          // (header with logo, no sidebar): BodyLayout switches it to the
-          // `issues` shell variant.
           {
-            path: "issues",
-            handle: { name: WORKSPACE_ROUTE_MY_ISSUES },
-            lazy: lazyPage(
-              () => import("@/react/pages/workspace/MyIssuesPage"),
-              (m) => m.MyIssuesPage
-            ),
+            // Layout-seam error boundary (pathless): a crashing page
+            // renders the recovery panel inside BodyLayout's content
+            // area, keeping the sidebar + header alive. Placing the
+            // errorElement on the BodyLayout route itself would replace
+            // the whole shell.
+            errorElement: <RouteErrorPage inline />,
+            children: [
+              ...workspaceLevelRoutes,
+              ...workspaceSettingRoutes,
+              ...environmentV1Routes,
+              ...instanceRoutes,
+              ...projectV1Routes,
+              // Workspace "My Issues" — lives under BodyLayout for the
+              // shared dashboard header, but renders as a standalone
+              // full-width page (header with logo, no sidebar):
+              // BodyLayout switches it to the `issues` shell variant.
+              {
+                path: "issues",
+                handle: { name: WORKSPACE_ROUTE_MY_ISSUES },
+                lazy: lazyPage(
+                  () => import("@/react/pages/workspace/MyIssuesPage"),
+                  (m) => m.MyIssuesPage
+                ),
+              },
+            ],
           },
         ],
       },


### PR DESCRIPTION
Follow-up hardening from #20575 (fixed in #20577). That incident showed the failure mode: one malformed tree node unmounted the entire React app into react-router's developer-facing error screen. This PR adds the standard three-tier error-containment architecture so the next render bug — whatever causes it — degrades gracefully instead of taking the product down.

## What

**Tier 1 — root recovery page.** The root route now declares an `errorElement` (`RouteErrorPage`): any uncaught render/loader exception shows a localized recovery page (Refresh / Go back home) with a collapsible error-details block users can paste into bug reports, instead of react-router's default raw-stack screen.

**Tier 2 — layout seam.** Dashboard pages sit behind a pathless `errorElement` route *below* `BodyLayout`, so a crashing page renders the recovery panel (new `inline` variant) inside the content area while the sidebar and header stay alive and navigable. Placement matters: an `errorElement` on the layout route itself would replace the whole shell — this is locked in by a behavioral test (shell survives a child crash) and a route-config regression test. The SQL editor intentionally has no route seam (`layoutAsPage` — the layout is the page); its containment is tier 3.

**Tier 3 — risky-widget boundaries.** New shared `ErrorBoundary` primitive (`ui/error-boundary.tsx`) with `fallback` / `onError` / `resetKey` (re-attempts rendering when the data prop changes, mirroring `react-error-boundary`'s `resetKeys`). Wrapped around:
- the shared `Tree` primitive (schema / connection / worksheet panes) — react-arborist hard-throws on malformed data; a bad node now degrades to one pane showing a localized fallback while tabs, editor, and results keep working, and the pane self-recovers on data change;
- `SchemaEditorLite`'s `AsideTree`, which uses react-arborist directly and bypassed the shared primitive.

This mirrors what React meta-frameworks bake in as conventions (Next.js `global-error.tsx` / per-segment `error.tsx`, Remix per-route `ErrorBoundary`) — react-router SPAs wire it manually. The `onError` hooks are the insertion point if we ever want frontend error telemetry; for now errors log loudly to the console and surface to the user.

## Why now

The old Vue app tolerated render errors (Vue logs and keeps going); React unmounts the whole tree by default, so the Vue→React migration silently converted every render bug into a full-app outage. #20575 was the first to ship; this removes the class of outcome rather than one instance.

## Testing

TDD throughout — every behavior was a failing test first:
- `RouteErrorPage`: crash shows recovery page with error details; `inline` variant renders as a panel; pathless-seam pattern keeps the parent shell alive.
- Route config: root `errorElement` present; dashboard seam present, pathless, and wrapping the page routes.
- `Tree`: falsy-id node renders contained fallback instead of crashing; recovers when the data prop changes.
- Full frontend suite green (2306 tests), `pnpm check` clean, `tsc --build --force` clean, all re-verified after rebasing onto post-#20577/#20578 main.
- Known gap, flagged for honesty: `AsideTree` has no dedicated crash test (fully context-driven; would need the whole SchemaEditorLite harness) — the boundary behavior itself is covered by the `ErrorBoundary`/`Tree` unit tests.

New locale keys (`common.render-failed`, `error-page.*`) added to all five locale files.

Deferred follow-up: tier-3 boundaries for the schema diagram, AI markdown renderer, and query result grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)