### PR TITLE
fix(mcp): disable SDK DNS-rebinding check that 403s proxied MCP traffic

### DIFF
--- a/backend/api/mcp/server.go
+++ b/backend/api/mcp/server.go
@@ -54,10 +54,22 @@ func NewServer(store *store.Store, profile *config.Profile, secret string) (*Ser
 	}
 	s.registerTools()
 
-	// Create HTTP handler for streamable HTTP transport
+	// Create HTTP handler for streamable HTTP transport.
+	//
+	// DisableLocalhostProtection turns off the SDK's DNS-rebinding check
+	// (auto-enabled since go-sdk v1.4.0). That check rejects requests that
+	// arrive over a loopback connection while carrying a non-loopback Host
+	// header. Behind a same-host reverse proxy (proxy_pass http://127.0.0.1),
+	// Bytebase accepts a loopback connection while the proxy preserves the
+	// public Host, so the check fires on legitimate traffic and returns
+	// "403 Forbidden: invalid Host header" (BYT-9693). It is safe to disable:
+	// /mcp is gated by mandatory OAuth bearer-token auth (authMiddleware), so
+	// the token — not network position — is the security boundary, and the
+	// rebinding threat targets unauthenticated, browser-reached localhost
+	// servers, which Bytebase is not.
 	s.httpHandler = mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
 		return s.mcpServer
-	}, nil)
+	}, &mcp.StreamableHTTPOptions{DisableLocalhostProtection: true})
 
 	return s, nil
 }

--- a/backend/api/mcp/server_test.go
+++ b/backend/api/mcp/server_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -133,6 +134,81 @@ func TestMCPAuthMiddlewareValidToken(t *testing.T) {
 	err = handler(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+// TestMCPProxiedPublicHostNotRejected is the BYT-9693 regression. Behind a
+// same-host reverse proxy (proxy_pass http://127.0.0.1:8080), the connection
+// Bytebase accepts has a loopback LocalAddr while the proxy preserves the public
+// Host header. The embedded MCP SDK's DNS-rebinding protection then saw
+// "loopback connection + non-loopback Host" and returned 403 "Forbidden:
+// invalid Host header" for legitimate, already-authenticated traffic. The
+// handler must not reject such a request: the bearer token (validated by
+// authMiddleware before the request reaches the handler) is the security
+// boundary, not network position, so the SDK check is a false positive here.
+//
+// httptest.NewServer listens on 127.0.0.1, so the accepted connection's
+// LocalAddr is loopback — exactly the condition the SDK keys on.
+func TestMCPProxiedPublicHostNotRejected(t *testing.T) {
+	secret := "test-secret-key"
+	profile := &config.Profile{Mode: common.ReleaseModeDev, ExternalURL: "https://bb.example.com"}
+
+	s, err := NewServer(nil, profile, secret)
+	require.NoError(t, err)
+
+	e := echo.New()
+	s.RegisterRoutes(e)
+	ts := httptest.NewServer(e)
+	defer ts.Close()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"0"}}}`
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/mcp", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+generateValidToken(t, secret))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	// The proxy preserves the public Host while the connection itself arrives
+	// over loopback.
+	req.Host = "bb.example.com"
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.NotEqual(t, http.StatusForbidden, resp.StatusCode,
+		"authenticated request with a proxied public Host must not be rejected by DNS-rebinding protection; body=%s", string(respBody))
+	require.NotContains(t, string(respBody), "invalid Host header")
+}
+
+// TestMCPUnauthenticatedRejectedEndToEnd locks in the security boundary that
+// makes disabling the SDK's rebinding check safe (BYT-9693): a request without a
+// valid bearer token is rejected with 401 by authMiddleware before it ever
+// reaches the MCP handler, regardless of Host. Network position is not the gate;
+// the token is. A DNS-rebinding attacker — who cannot obtain the token — is
+// stopped here, so the disabled rebinding check protects nothing it must.
+func TestMCPUnauthenticatedRejectedEndToEnd(t *testing.T) {
+	secret := "test-secret-key"
+	profile := &config.Profile{Mode: common.ReleaseModeDev, ExternalURL: "https://bb.example.com"}
+
+	s, err := NewServer(nil, profile, secret)
+	require.NoError(t, err)
+
+	e := echo.New()
+	s.RegisterRoutes(e)
+	ts := httptest.NewServer(e)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/mcp", strings.NewReader(`{}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Host = "bb.example.com"
+
+	resp, err := ts.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
 func generateValidToken(t *testing.T, secret string) string {


### PR DESCRIPTION
## Problem (BYT-9693)

Customers hitting `/mcp` through a same-host reverse proxy get **`403 Forbidden: invalid Host header "<their-domain>"`** for every MCP client (Claude Code, Cursor, Codex, Copilot CLI). The customer's config is correct — the rejection happens inside the Bytebase server.

The error comes from the embedded `modelcontextprotocol/go-sdk` streamable handler's **DNS-rebinding protection** (auto-enabled since **v1.4.0**, pulled into Bytebase by #19523 on 2026-03-05). It returns 403 when a request arrives over a **loopback** connection but carries a **non-loopback `Host`** header:

```go
// go-sdk mcp/streamable.go
if util.IsLoopback(localAddr.String()) && !util.IsLoopback(req.Host) {
    http.Error(w, fmt.Sprintf("Forbidden: invalid Host header %q", req.Host), http.StatusForbidden)
}
```

Behind `nginx → proxy_pass http://127.0.0.1:8080`, Bytebase accepts a **loopback** connection while the proxy preserves the **public** `Host` — byte-for-byte the rebinding signature — so the check misfires on legitimate, already-authenticated traffic. (Deployments where the proxy dials a non-loopback IP — many k8s/Docker setups — are unaffected, which is why some customers use MCP fine.)

## Fix

Pass `DisableLocalhostProtection: true` when constructing the `/mcp` handler. Scope is exactly that one handler.

## Why it's safe — no vulnerability introduced

`/mcp` is gated by **mandatory OAuth bearer-token auth** (`authMiddleware`), which runs **before** the SDK handler. An unauthenticated request gets **401** and never reaches the rebinding check, so:

- The **bearer token — not network position — is the security boundary**, and this change doesn't touch it.
- The rebinding check only ever runs on **already-authenticated** requests, so every 403 it produces is a false positive.
- DNS rebinding targets **unauthenticated, browser-reached localhost** servers. Bytebase `/mcp` is authenticated, public, and consumed by **native** MCP clients (no browser to rebind), and bearer tokens aren't ambient credentials the way cookies are — rebinding JS can't obtain one.

A rebinding attacker hitting `/mcp` still gets 401.

## Testing

End-to-end tests through the real server (auth middleware + SDK handler) over an `httptest` loopback listener:

- `TestMCPProxiedPublicHostNotRejected` — valid token + proxied public `Host` must **not** be 403'd. **Verified RED→GREEN**: fails before the fix with `Forbidden: invalid Host header "bb.example.com"`, passes after.
- `TestMCPUnauthenticatedRejectedEndToEnd` — tokenless request is **401'd before the handler**, locking in the security invariant above.

`gofmt` / `go vet` / `golangci-lint` clean; full `backend/api/mcp` package passes.

## Customer unblock (no rebuild)

Set `MCPGODEBUG=disablelocalhostprotection=1` on the Bytebase process and restart — same effect via the SDK's env switch. (Temporary SDK shim; this PR is the durable fix.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)