### PR TITLE
fix(frontend): surface missing-license paywall in instance form

### DIFF
--- a/frontend/src/react/components/instance/InstanceFormButtons.tsx
+++ b/frontend/src/react/components/instance/InstanceFormButtons.tsx
@@ -70,7 +70,6 @@ export function InstanceFormButtons({
     readonlyDataSourceList,
     setDataSourceEditState,
     hasReadonlyReplicaFeature,
-    missingFeature: _missingFeature,
     setMissingFeature,
     testConnection,
     checkDataSource,

--- a/frontend/src/react/components/instance/InstanceFormContext.test.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.test.tsx
@@ -9,6 +9,7 @@ import {
   DataSourceType,
   InstanceSchema,
 } from "@/types/proto-es/v1/instance_service_pb";
+import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import { unknownInstance } from "@/types/v1/instance";
 import {
   InstanceFormProvider,
@@ -91,6 +92,33 @@ vi.mock("@/utils/connect", () => ({
     error instanceof Error ? error.message : String(error),
 }));
 
+vi.mock("@/react/components/ui/feature-modal", () => ({
+  FeatureModal: ({
+    open,
+    feature,
+    instance,
+    onOpenChange,
+  }: {
+    open: boolean;
+    feature: number | undefined;
+    instance?: { name: string };
+    onOpenChange: (open: boolean) => void;
+  }) =>
+    open ? (
+      <div
+        data-testid="feature-modal"
+        data-feature={String(feature)}
+        data-instance={instance?.name}
+      >
+        <button
+          data-testid="feature-modal-close"
+          type="button"
+          onClick={() => onOpenChange(false)}
+        />
+      </div>
+    ) : null,
+}));
+
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -156,6 +184,80 @@ describe("InstanceFormProvider", () => {
     const probe = harness.container.firstElementChild as HTMLElement;
     expect(probe.dataset.title).toBe("Production");
     expect(probe.dataset.host).toBe("prod.example.com");
+
+    harness.unmount();
+  });
+
+  // Regression test for BYT-9696: setting missingFeature (e.g. saving a
+  // read-only connection on an unlicensed instance) must surface the
+  // FeatureModal paywall instead of failing silently.
+  test("renders the FeatureModal when missingFeature is set", async () => {
+    const instance = create(InstanceSchema, {
+      name: "instances/prod",
+      title: "Production",
+      engine: Engine.POSTGRES,
+      environment: "environments/prod",
+      dataSources: [
+        create(DataSourceSchema, {
+          id: "admin",
+          type: DataSourceType.ADMIN,
+          host: "prod.example.com",
+          port: "5432",
+        }),
+      ],
+    });
+
+    const MissingFeatureProbe = () => {
+      const ctx = useInstanceFormContext();
+      return (
+        <button
+          data-testid="set-missing-feature"
+          type="button"
+          onClick={() =>
+            ctx.setMissingFeature(
+              PlanFeature.FEATURE_INSTANCE_READ_ONLY_CONNECTION
+            )
+          }
+        />
+      );
+    };
+
+    const harness = renderIntoContainer();
+    await harness.render(
+      <InstanceFormProvider instance={instance}>
+        <MissingFeatureProbe />
+      </InstanceFormProvider>
+    );
+
+    expect(
+      harness.container.querySelector("[data-testid='feature-modal']")
+    ).toBeNull();
+
+    const trigger = harness.container.querySelector(
+      "[data-testid='set-missing-feature']"
+    ) as HTMLButtonElement;
+    await act(async () => {
+      trigger.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const modal = harness.container.querySelector(
+      "[data-testid='feature-modal']"
+    ) as HTMLElement;
+    expect(modal).not.toBeNull();
+    expect(modal.dataset.feature).toBe(
+      String(PlanFeature.FEATURE_INSTANCE_READ_ONLY_CONNECTION)
+    );
+    expect(modal.dataset.instance).toBe("instances/prod");
+
+    const close = harness.container.querySelector(
+      "[data-testid='feature-modal-close']"
+    ) as HTMLButtonElement;
+    await act(async () => {
+      close.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(
+      harness.container.querySelector("[data-testid='feature-modal']")
+    ).toBeNull();
 
     harness.unmount();
   });

--- a/frontend/src/react/components/instance/InstanceFormContext.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.tsx
@@ -34,6 +34,7 @@ import {
   isValidSpannerHost,
 } from "@/utils";
 import { extractGrpcErrorMessage } from "@/utils/connect";
+import { FeatureModal } from "../ui/feature-modal";
 import type { BasicInfo, DataSourceEditState, EditDataSource } from "./common";
 import {
   calcDataSourceUpdateMask,
@@ -613,6 +614,14 @@ export function InstanceFormProvider({
   return (
     <InstanceFormCtx.Provider value={value}>
       {children}
+      <FeatureModal
+        open={!!missingFeature}
+        feature={missingFeature}
+        instance={instance}
+        onOpenChange={(open) => {
+          if (!open) setMissingFeature(undefined);
+        }}
+      />
     </InstanceFormCtx.Provider>
   );
 }


### PR DESCRIPTION
## What

Mount `FeatureModal` in `InstanceFormProvider` so the instance form's `missingFeature` state is actually rendered, restoring the paywall dialog that was lost in the Vue→React migration (#19876).

## Why

Linear [BYT-9696](https://linear.app/bytebase/issue/BYT-9696): adding/editing a read-only connection on an instance without an assigned license produced **no feedback at all** — clicking Update did nothing, no error, no license notice, and the connection wasn't added.

Root cause: `doUpdate` in `InstanceFormButtons.tsx` correctly detects the missing `FEATURE_INSTANCE_READ_ONLY_CONNECTION` feature (instance not activated), calls `setMissingFeature(...)`, and returns early — but nothing in the React instance form rendered that state. The old Vue `InstanceForm.vue` rendered `<FeatureModal :feature="missingFeature" :instance="instance">`; the React migration dropped it.

The fix covers every `setMissingFeature` caller in the form: read-only connection create/update, the external secret manager check, and the read-only host/port input guards in `DataSourceForm.tsx`. With the `instance` prop passed, the modal shows the "Require license" variant with an **Assign license** CTA that deep-links to `/instances?assignLicense=1&instances=<name>`.

## Testing

- New regression test in `InstanceFormContext.test.tsx`: setting `missingFeature` renders the modal with the right feature + instance, dismissing clears it (verified failing before the fix).
- All 50 instance-component tests pass; `pnpm check` and `pnpm type-check` clean.
- Manually verified in dev by simulating an unlicensed instance: pre-fix Update is a silent no-op; post-fix the "Require license / Assign license" dialog appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)