### PR TITLE
fix(frontend): improve Vietnamese translation for cancel task message

### DIFF
--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -3745,7 +3745,7 @@
   "task": {
     "affected-rows": "Hàng bị ảnh hưởng",
     "cancel-task": "Hủy tác vụ | Hủy các tác vụ",
-    "cancel-task-description": "Các lần chạy tác vụ đang chờ và sẵn sàng sẽ được hủy ngay. Các lần chạy đang chạy sẽ nhận yêu cầu hủy theo cách cố gắng tối đa và có thể tiếp tục chạy; hãy thử lại nếu cần.",
+    "cancel-task-description": "Các tác vụ đang chờ hoặc ở trạng thái sẵn sàng sẽ bị hủy ngay lập tức. Những tiến trình đang chạy sẽ nhận được yêu cầu hủy trên cơ sở nỗ lực tối đa và có thể vẫn tiếp tục chạy; hãy thử lại nếu cần.",
     "check-type": {
       "affected-rows": {
         "description": "Ước tính theo thông tin thống kê.",


### PR DESCRIPTION
## Summary

Improves the Vietnamese translation of the task-run cancel confirmation message (`task.cancel-task-description` in `vi-VN.json`), which previously read like a word-by-word translation with duplicated words ("Các lần chạy đang chạy..."). Replaced with the natural wording proposed by Cong Nguyen.

Fixes [BYT-9700](https://linear.app/bytebase/issue/BYT-9700/cai-thien-ban-dich-tieng-viet-cho-thong-bao-huy-tac-vu).

## Testing

Single locale string change; verified the JSON still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)