### PR TITLE
fix(webhook): preserve DingTalk DM phone numbers

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -750,10 +750,12 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 			Approver: &webhook.User{
 				Name:  user.Name,
 				Email: user.Email,
+				Phone: user.Phone,
 			},
 			Creator: &webhook.User{
 				Name:  creatorAccount.Name,
 				Email: creatorAccount.Email,
+				Phone: creatorAccount.Phone,
 			},
 			Issue:  webhook.NewIssue(issue),
 			Reason: req.Msg.Comment,

--- a/backend/component/webhook/event.go
+++ b/backend/component/webhook/event.go
@@ -106,4 +106,5 @@ type EventRolloutCompleted struct {
 type User struct {
 	Name  string
 	Email string
+	Phone string
 }

--- a/backend/component/webhook/manager.go
+++ b/backend/component/webhook/manager.go
@@ -104,6 +104,7 @@ func (m *Manager) getWebhookContextFromEvent(ctx context.Context, e *Event, even
 				mentionUsers = append(mentionUsers, &store.UserMessage{
 					Name:  user.Name,
 					Email: user.Email,
+					Phone: user.Phone,
 					Type:  storepb.PrincipalType_END_USER,
 				})
 			}
@@ -121,6 +122,7 @@ func (m *Manager) getWebhookContextFromEvent(ctx context.Context, e *Event, even
 			mentionUsers = []*store.UserMessage{{
 				Name:  e.IssueApproved.Creator.Name,
 				Email: e.IssueApproved.Creator.Email,
+				Phone: e.IssueApproved.Creator.Phone,
 				Type:  storepb.PrincipalType_END_USER,
 			}}
 		}
@@ -138,6 +140,7 @@ func (m *Manager) getWebhookContextFromEvent(ctx context.Context, e *Event, even
 				{
 					Name:  e.SentBack.Creator.Name,
 					Email: e.SentBack.Creator.Email,
+					Phone: e.SentBack.Creator.Phone,
 					Type:  storepb.PrincipalType_END_USER,
 				},
 			}
@@ -202,13 +205,15 @@ func (m *Manager) getWebhookContextFromEvent(ctx context.Context, e *Event, even
 	// Set issue information if available
 	if issue != nil {
 		creatorName := issue.Title // Fallback
-		creatorAccount, err := m.store.GetAccountByEmail(ctx, issue.CreatorEmail)
-		if err != nil {
-			slog.Warn("failed to get creator user for webhook context",
-				slog.String("issue_title", issue.Title),
-				log.BBError(err))
-		} else if creatorAccount != nil {
-			creatorName = creatorAccount.Name
+		if m.store != nil && issue.CreatorEmail != "" {
+			creatorAccount, err := m.store.GetAccountByEmail(ctx, issue.CreatorEmail)
+			if err != nil {
+				slog.Warn("failed to get creator user for webhook context",
+					slog.String("issue_title", issue.Title),
+					log.BBError(err))
+			} else if creatorAccount != nil {
+				creatorName = creatorAccount.Name
+			}
 		}
 		webhookCtx.Issue = &webhook.Issue{
 			ID:          issue.UID,

--- a/backend/component/webhook/manager_test.go
+++ b/backend/component/webhook/manager_test.go
@@ -200,6 +200,70 @@ func TestGetWebhookContext_ProjectAlwaysSet(t *testing.T) {
 	a.Equal("My Project", webhookCtx.Project.Title)
 }
 
+func TestGetWebhookContext_MentionEndUsersIncludePhone(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		event     *Event
+		wantPhone string
+	}{
+		{
+			name: "approval requested approver",
+			event: &Event{
+				Type:    storepb.Activity_ISSUE_APPROVAL_REQUESTED,
+				Project: &Project{ResourceID: "proj-1", Workspace: "ws-1"},
+				ApprovalRequested: &EventIssueApprovalRequested{
+					Creator: &User{Name: "Alice", Email: "alice@example.com"},
+					Issue:   &Issue{UID: 1, Title: "test"},
+					Approvers: []User{
+						{Name: "Bob", Email: "bob@example.com", Phone: "+8613800000000"},
+					},
+				},
+			},
+			wantPhone: "+8613800000000",
+		},
+		{
+			name: "issue approved creator",
+			event: &Event{
+				Type:    storepb.Activity_ISSUE_APPROVED,
+				Project: &Project{ResourceID: "proj-1", Workspace: "ws-1"},
+				IssueApproved: &EventIssueApproved{
+					Approver: &User{Name: "Bob", Email: "bob@example.com"},
+					Creator:  &User{Name: "Alice", Email: "alice@example.com", Phone: "+8613900000000"},
+					Issue:    &Issue{UID: 1, Title: "test"},
+				},
+			},
+			wantPhone: "+8613900000000",
+		},
+		{
+			name: "sent back creator",
+			event: &Event{
+				Type:    storepb.Activity_ISSUE_SENT_BACK,
+				Project: &Project{ResourceID: "proj-1", Workspace: "ws-1"},
+				SentBack: &EventIssueSentBack{
+					Approver: &User{Name: "Bob", Email: "bob@example.com"},
+					Creator:  &User{Name: "Alice", Email: "alice@example.com", Phone: "+8615000000000"},
+					Issue:    &Issue{UID: 1, Title: "test"},
+				},
+			},
+			wantPhone: "+8615000000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := require.New(t)
+			m := newTestManager()
+
+			webhookCtx, err := m.getWebhookContextFromEvent(ctx, tt.event, tt.event.Type)
+			a.NoError(err)
+			a.Len(webhookCtx.MentionEndUsers, 1)
+			a.Equal(tt.wantPhone, webhookCtx.MentionEndUsers[0].Phone)
+		})
+	}
+}
+
 func TestGetWebhookContext_AllEventLevels(t *testing.T) {
 	m := newTestManager()
 	ctx := context.Background()

--- a/backend/plugin/webhook/dingtalk/app.go
+++ b/backend/plugin/webhook/dingtalk/app.go
@@ -37,7 +37,11 @@ func Validate(ctx context.Context, id, secret, robot, phone string) error {
 	if err := p.refreshToken(ctx); err != nil {
 		return errors.Wrapf(err, "failed to refresh token")
 	}
-	id, err := p.getIDByPhone(ctx, phone)
+	mobile, err := getDingTalkMobileFromPhone(phone)
+	if err != nil {
+		return errors.Wrapf(err, "failed to parse phone number")
+	}
+	id, err = p.getIDByPhone(ctx, mobile)
 	if err != nil {
 		return errors.Wrapf(err, "failed to get user id by phone")
 	}

--- a/backend/plugin/webhook/dingtalk/dingtalk.go
+++ b/backend/plugin/webhook/dingtalk/dingtalk.go
@@ -92,26 +92,31 @@ func sendDirectMessage(webhookCtx webhook.Context) bool {
 		var errs error
 		var userPhones, userIDs []string
 		for _, u := range webhookCtx.MentionEndUsers {
-			if u.Phone == "" {
+			phone, err := getDingTalkMobileFromUser(u)
+			if err != nil {
+				slog.Warn("failed to parse user phone", log.BBError(err), slog.String("user", u.Name))
 				continue
 			}
-			if sent[u.Phone] {
+			if phone == "" {
+				continue
+			}
+			if sent[phone] {
 				continue
 			}
 
-			userID, err := p.getIDByPhone(ctx, u.Phone)
+			userID, err := p.getIDByPhone(ctx, phone)
 			if err != nil {
-				err = errors.Wrapf(err, "failed to get user id by phone %v", u.Phone)
+				err = errors.Wrapf(err, "failed to get user id by phone %v", phone)
 				multierr.AppendInto(&errs, err)
 				continue
 			}
 			if userID == "" {
 				// user not found
-				sent[u.Phone] = true
+				sent[phone] = true
 				continue
 			}
 			userIDs = append(userIDs, userID)
-			userPhones = append(userPhones, u.Phone)
+			userPhones = append(userPhones, phone)
 		}
 		if len(userIDs) == 0 {
 			err := errors.Errorf("dingtalk dm: got 0 user id, errs: %v", errs)
@@ -135,7 +140,7 @@ func sendDirectMessage(webhookCtx webhook.Context) bool {
 	return true
 }
 
-func maybeGetPhoneFromUser(user *store.UserMessage) (string, error) {
+func getDingTalkMobileFromUser(user *store.UserMessage) (string, error) {
 	if user == nil {
 		return "", nil
 	}
@@ -162,7 +167,7 @@ func sendMessage(context webhook.Context) error {
 	if len(context.MentionEndUsers) > 0 {
 		var ats []string
 		for _, user := range context.MentionEndUsers {
-			phone, err := maybeGetPhoneFromUser(user)
+			phone, err := getDingTalkMobileFromUser(user)
 			if err != nil {
 				slog.Warn("failed to parse user phone", log.BBError(err), slog.String("user", user.Name))
 				continue

--- a/backend/plugin/webhook/dingtalk/dingtalk.go
+++ b/backend/plugin/webhook/dingtalk/dingtalk.go
@@ -144,12 +144,16 @@ func getDingTalkMobileFromUser(user *store.UserMessage) (string, error) {
 	if user == nil {
 		return "", nil
 	}
-	if user.Phone == "" {
+	return getDingTalkMobileFromPhone(user.Phone)
+}
+
+func getDingTalkMobileFromPhone(phone string) (string, error) {
+	if phone == "" {
 		return "", nil
 	}
-	phoneNumber, err := phonenumbers.Parse(user.Phone, "")
+	phoneNumber, err := phonenumbers.Parse(phone, "")
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to parse phone number %q", user.Phone)
+		return "", errors.Wrapf(err, "failed to parse phone number %q", phone)
 	}
 	if phoneNumber == nil {
 		return "", nil

--- a/backend/plugin/webhook/dingtalk/dingtalk_test.go
+++ b/backend/plugin/webhook/dingtalk/dingtalk_test.go
@@ -15,3 +15,11 @@ func TestGetDingTalkMobileFromUserStripsCountryCode(t *testing.T) {
 	a.NoError(err)
 	a.Equal("13800000000", got)
 }
+
+func TestGetDingTalkMobileFromPhoneStripsCountryCode(t *testing.T) {
+	a := require.New(t)
+
+	got, err := getDingTalkMobileFromPhone("+8613800000000")
+	a.NoError(err)
+	a.Equal("13800000000", got)
+}

--- a/backend/plugin/webhook/dingtalk/dingtalk_test.go
+++ b/backend/plugin/webhook/dingtalk/dingtalk_test.go
@@ -1,0 +1,17 @@
+package dingtalk
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestGetDingTalkMobileFromUserStripsCountryCode(t *testing.T) {
+	a := require.New(t)
+
+	got, err := getDingTalkMobileFromUser(&store.UserMessage{Phone: "+8613800000000"})
+	a.NoError(err)
+	a.Equal("13800000000", got)
+}

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -1135,6 +1135,7 @@ func getApproversForRole(ctx context.Context, stores *store.Store, projectID str
 		approvers = append(approvers, webhook.User{
 			Name:  user.Name,
 			Email: user.Email,
+			Phone: user.Phone,
 		})
 	}
 
@@ -1175,6 +1176,7 @@ func NotifyApprovalRequested(ctx context.Context, stores *store.Store, webhookMa
 			Creator: &webhook.User{
 				Name:  creatorAccount.Name,
 				Email: creatorAccount.Email,
+				Phone: creatorAccount.Phone,
 			},
 			Issue:     webhook.NewIssue(issue),
 			Approvers: approvers,
@@ -1199,8 +1201,8 @@ func NotifyIssueApproved(ctx context.Context, stores *store.Store, webhookManage
 		Type:    storepb.Activity_ISSUE_APPROVED,
 		Project: webhook.NewProject(project),
 		IssueApproved: &webhook.EventIssueApproved{
-			Approver: &webhook.User{Name: approver.Name, Email: approver.Email},
-			Creator:  &webhook.User{Name: creatorAccount.Name, Email: creatorAccount.Email},
+			Approver: &webhook.User{Name: approver.Name, Email: approver.Email, Phone: approver.Phone},
+			Creator:  &webhook.User{Name: creatorAccount.Name, Email: creatorAccount.Email, Phone: creatorAccount.Phone},
 			Issue:    webhook.NewIssue(issue),
 		},
 	})

--- a/backend/store/account.go
+++ b/backend/store/account.go
@@ -16,6 +16,8 @@ type AccountMessage struct {
 	Email string
 	Name  string
 	Type  storepb.PrincipalType
+	// Phone conforms E.164 format. Empty for principals without a phone number.
+	Phone string
 	// Workspace is the workspace resource ID.
 	// Empty for END_USER (global identity, workspace resolved via IAM policy).
 	// Populated for SERVICE_ACCOUNT and WORKLOAD_IDENTITY (workspace-scoped).
@@ -75,6 +77,7 @@ func (s *Store) GetAccountByEmail(ctx context.Context, email string) (*AccountMe
 		Email:         user.Email,
 		Name:          user.Name,
 		Type:          storepb.PrincipalType_END_USER,
+		Phone:         user.Phone,
 		PasswordHash:  user.PasswordHash,
 		MemberDeleted: user.MemberDeleted,
 	}, nil

--- a/backend/utils/member.go
+++ b/backend/utils/member.go
@@ -153,10 +153,15 @@ func getUserByIdentifier(ctx context.Context, stores *store.Store, identifier, p
 	if account == nil {
 		return nil
 	}
+	return userMessageFromAccount(account)
+}
+
+func userMessageFromAccount(account *store.AccountMessage) *store.UserMessage {
 	return &store.UserMessage{
 		Email:         account.Email,
 		Name:          account.Name,
 		Type:          account.Type,
+		Phone:         account.Phone,
 		MemberDeleted: account.MemberDeleted,
 	}
 }

--- a/backend/utils/member_test.go
+++ b/backend/utils/member_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestUserMessageFromAccountPreservesPhone(t *testing.T) {
+	a := require.New(t)
+
+	got := userMessageFromAccount(&store.AccountMessage{
+		Email:         "alice@example.com",
+		Name:          "Alice",
+		Type:          storepb.PrincipalType_END_USER,
+		Phone:         "+8613800000000",
+		MemberDeleted: true,
+	})
+
+	a.Equal("alice@example.com", got.Email)
+	a.Equal("Alice", got.Name)
+	a.Equal(storepb.PrincipalType_END_USER, got.Type)
+	a.Equal("+8613800000000", got.Phone)
+	a.True(got.MemberDeleted)
+}


### PR DESCRIPTION
## Summary
- Preserve end-user phone numbers through IAM member resolution and webhook approval event payloads.
- Normalize DingTalk DM mobile lookup to the national mobile number DingTalk expects.
- Add regression tests for phone propagation and DingTalk mobile formatting.

## Test Plan
- go test -v -count=1 ./backend/component/webhook ./backend/runner/approval ./backend/plugin/webhook/dingtalk ./backend/utils
- go test -count=1 -run '^$' ./backend/api/v1 ./backend/store\n- golangci-lint run --allow-parallel-runners\n- golangci-lint run --fix --allow-parallel-runners\n- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go\n\nFixes BYT-9703