### PR TITLE
fix: canonicalize issue labels

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -395,7 +395,8 @@ func (s *IssueService) CreateIssue(ctx context.Context, req *connect.Request[v1p
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project not found for id: %v", projectID))
 	}
 
-	if project.Setting.ForceIssueLabels && len(req.Msg.Issue.Labels) == 0 {
+	issueLabels := store.CanonicalizeIssueLabels(req.Msg.Issue.Labels)
+	if project.Setting.ForceIssueLabels && len(issueLabels) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("require issue labels"))
 	}
 
@@ -408,7 +409,7 @@ func (s *IssueService) CreateIssue(ctx context.Context, req *connect.Request[v1p
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("user not found"))
 	}
 
-	issue, err := s.buildIssueMessage(ctx, project, user.Email, req.Msg)
+	issue, err := s.buildIssueMessage(ctx, project, user.Email, req.Msg, issueLabels)
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +431,7 @@ func (s *IssueService) CreateIssue(ctx context.Context, req *connect.Request[v1p
 	return connect.NewResponse(converted), nil
 }
 
-func (s *IssueService) buildIssueMessage(ctx context.Context, project *store.ProjectMessage, userEmail string, request *v1pb.CreateIssueRequest) (*store.IssueMessage, error) {
+func (s *IssueService) buildIssueMessage(ctx context.Context, project *store.ProjectMessage, userEmail string, request *v1pb.CreateIssueRequest, labels []string) (*store.IssueMessage, error) {
 	var planUID *int64
 	var roleGrant *storepb.RoleGrant
 	var title, description string
@@ -544,7 +545,7 @@ func (s *IssueService) buildIssueMessage(ctx context.Context, project *store.Pro
 				ApprovalTemplate:    nil,
 				Approvers:           nil,
 			},
-			Labels: request.Issue.Labels,
+			Labels: labels,
 		},
 	}
 
@@ -1037,16 +1038,17 @@ func (s *IssueService) UpdateIssue(ctx context.Context, req *connect.Request[v1p
 			})
 
 		case "labels":
-			if slices.Equal(issue.Payload.Labels, req.Msg.Issue.Labels) {
+			labels := store.CanonicalizeIssueLabels(req.Msg.Issue.Labels)
+			if slices.Equal(issue.Payload.Labels, labels) {
 				continue
 			}
-			if len(req.Msg.Issue.Labels) == 0 {
+			if len(labels) == 0 {
 				patch.RemoveLabels = true
 			} else {
 				if patch.PayloadUpsert == nil {
 					patch.PayloadUpsert = &storepb.Issue{}
 				}
-				patch.PayloadUpsert.Labels = req.Msg.Issue.Labels
+				patch.PayloadUpsert.Labels = labels
 			}
 
 			issueCommentCreates = append(issueCommentCreates, &store.IssueCommentMessage{
@@ -1055,7 +1057,7 @@ func (s *IssueService) UpdateIssue(ctx context.Context, req *connect.Request[v1p
 					Event: &storepb.IssueCommentPayload_IssueUpdate_{
 						IssueUpdate: &storepb.IssueCommentPayload_IssueUpdate{
 							FromLabels: issue.Payload.Labels,
-							ToLabels:   req.Msg.Issue.Labels,
+							ToLabels:   labels,
 						},
 					},
 				},

--- a/backend/store/issue.go
+++ b/backend/store/issue.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,6 +28,28 @@ func init() {
 		segmenter.Dict = segmenterDic.Dict
 		return &segmenter
 	}
+}
+
+// CanonicalizeIssueLabels returns the deterministic representation stored in issue payloads.
+func CanonicalizeIssueLabels(labels []string) []string {
+	if len(labels) == 0 {
+		return nil
+	}
+
+	canonicalLabels := make([]string, 0, len(labels))
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		if label == "" {
+			continue
+		}
+		canonicalLabels = append(canonicalLabels, label)
+	}
+	if len(canonicalLabels) == 0 {
+		return nil
+	}
+
+	slices.Sort(canonicalLabels)
+	return slices.Compact(canonicalLabels)
 }
 
 // IssueMessage is the mssage for issues.
@@ -130,6 +153,9 @@ func (s *Store) GetIssue(ctx context.Context, find *FindIssueMessage) (*IssueMes
 // CreateIssue creates a new issue.
 func (s *Store) CreateIssue(ctx context.Context, create *IssueMessage) (*IssueMessage, error) {
 	create.Status = storepb.Issue_OPEN
+	if create.Payload != nil {
+		create.Payload.Labels = CanonicalizeIssueLabels(create.Payload.Labels)
+	}
 	payload, err := protojson.Marshal(create.Payload)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to marshal issue payload")
@@ -210,6 +236,7 @@ func (s *Store) UpdateIssue(ctx context.Context, projectID string, uid int64, pa
 		set.Comma("description = ?", *v)
 	}
 	if v := patch.PayloadUpsert; v != nil {
+		v.Labels = CanonicalizeIssueLabels(v.Labels)
 		p, err := protojson.Marshal(v)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to marshal patch.PayloadUpsert")

--- a/backend/store/issue_test.go
+++ b/backend/store/issue_test.go
@@ -1,0 +1,26 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalizeIssueLabels(t *testing.T) {
+	got := CanonicalizeIssueLabels([]string{
+		" release ",
+		"bug",
+		"",
+		"bug ",
+		"  feature",
+		"\t",
+		"release",
+	})
+
+	require.Equal(t, []string{"bug", "feature", "release"}, got)
+}
+
+func TestCanonicalizeIssueLabelsEmpty(t *testing.T) {
+	require.Empty(t, CanonicalizeIssueLabels(nil))
+	require.Empty(t, CanonicalizeIssueLabels([]string{"", " ", "\t"}))
+}


### PR DESCRIPTION
## Summary
- Canonicalize issue labels by trimming whitespace, dropping empty labels, sorting, and compacting duplicates before persistence.
- Apply canonical labels in issue create/update API paths so force-label validation and activity comments use the stored representation.
- Add focused tests for deterministic issue label canonicalization.

## Testing
- go test -v -count=1 ./backend/store -run '^TestCanonicalizeIssueLabels'
- go test -v -count=1 ./backend/api/v1 -run '^$'
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- git diff --check
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go

## Not Run
- go test -v -count=1 ./backend/tests/ -run "^(TestClaim|TestCollision)" -timeout 5m: blocked locally because rootless Docker is not available in backend/tests.TestMain.
