### PR TITLE
fix(frontend): gate unknown routes before 404

### DIFF
--- a/frontend/src/react/router/guard.test.ts
+++ b/frontend/src/react/router/guard.test.ts
@@ -1,3 +1,4 @@
+import { matchRoutes } from "react-router-dom";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 // Configurable fake session, controlled per test.
@@ -45,6 +46,7 @@ import {
   WORKSPACE_ROUTE_404,
 } from "./handles";
 import { setRouteNameIndex } from "./navigation";
+import { routes } from "./routes";
 
 beforeEach(() => {
   session.isLoggedIn = false;
@@ -75,9 +77,43 @@ function location(result: Response | null): string | null {
   return result instanceof Response ? result.headers.get("Location") : null;
 }
 
+async function runCatchAllLoader(path: string): Promise<Response> {
+  const matched = matchRoutes(routes, path);
+  const leafRoute = matched?.at(-1)?.route;
+  if (typeof leafRoute?.loader !== "function") {
+    throw new Error(`No loader matched ${path}`);
+  }
+  const url = new URL(`https://app.example.com${path}`);
+  return leafRoute.loader({
+    request: new Request(url),
+    url,
+    pattern: "*",
+    params: {},
+    context: {},
+  }) as Response | Promise<Response>;
+}
+
 describe("rootGuard", () => {
   test("error page is allowed directly", () => {
     expect(run(WORKSPACE_ROUTE_404, "/404")).toBeNull();
+  });
+
+  test("logged-out user on an unknown URL matched by the 404 catch-all is redirected to signin", () => {
+    const target = location(run(WORKSPACE_ROUTE_404, "/ioewjfiwoejf"));
+    expect(target).toBe("/auth?redirect=%2Fioewjfiwoejf");
+  });
+
+  test("logged-out catch-all route loader redirects to signin before 404", async () => {
+    const response = await runCatchAllLoader("/ioewjfiwoejf");
+    expect(response.headers.get("Location")).toBe(
+      "/auth?redirect=%2Fioewjfiwoejf"
+    );
+  });
+
+  test("logged-in catch-all route loader redirects to 404", async () => {
+    session.isLoggedIn = true;
+    const response = await runCatchAllLoader("/ioewjfiwoejf");
+    expect(response.headers.get("Location")).toBe("/404");
   });
 
   test("oauth callback is allowed directly", () => {

--- a/frontend/src/react/router/guard.ts
+++ b/frontend/src/react/router/guard.ts
@@ -168,7 +168,12 @@ export function rootGuard({
   const toName = name ?? "";
 
   // Error pages can be accessed directly.
-  if (toName === WORKSPACE_ROUTE_403 || toName === WORKSPACE_ROUTE_404) {
+  if (
+    (toName === WORKSPACE_ROUTE_403 &&
+      url.pathname === resolvePath(WORKSPACE_ROUTE_403)) ||
+    (toName === WORKSPACE_ROUTE_404 &&
+      url.pathname === resolvePath(WORKSPACE_ROUTE_404))
+  ) {
     return null;
   }
   // Auth callbacks can be accessed directly.

--- a/frontend/src/react/router/routes.test.tsx
+++ b/frontend/src/react/router/routes.test.tsx
@@ -95,25 +95,12 @@ describe("react route table reachability", () => {
   it.each([
     "/projects/db333/rollouts/605",
     "/sql-editor/does-not-exist",
-  ])("redirects unknown URL %s to the dedicated 404 route", async (path) => {
+  ])("matches unknown URL %s to the dedicated 404 catch-all route", (path) => {
     const matched = matchRoutes(routes, path);
     const leafRoute = matched?.at(-1)?.route;
     const leafHandle = leafRoute?.handle as { name?: string } | undefined;
 
     expect(leafHandle?.name).toBe(WORKSPACE_ROUTE_404);
     expect(leafRoute?.loader).toBeTypeOf("function");
-
-    const response = await (
-      leafRoute?.loader as (args: {
-        request: Request;
-        params: Record<string, string>;
-      }) => Promise<Response> | Response
-    )({
-      request: new Request(`http://localhost${path}`),
-      params: {},
-    });
-
-    expect(response.status).toBe(302);
-    expect(response.headers.get("Location")).toBe("/404");
   });
 });

--- a/frontend/src/react/router/routes.tsx
+++ b/frontend/src/react/router/routes.tsx
@@ -1,6 +1,7 @@
-import { type RouteObject, redirect } from "react-router-dom";
+import type { RouteObject } from "react-router-dom";
 import { RootLayout } from "@/react/app/RootLayout";
 import { RouteErrorPage } from "@/react/app/RouteErrorPage";
+import { rootGuard } from "@/react/router/guard";
 import { WORKSPACE_ROUTE_404 } from "@/react/router/handles";
 import { authRoutes } from "@/react/router/routes/auth";
 import { dashboardRoutes } from "@/react/router/routes/dashboard";
@@ -28,7 +29,11 @@ export const routes: RouteObject[] = [
       {
         path: "*",
         handle: { name: WORKSPACE_ROUTE_404 },
-        loader: () => redirect("/404"),
+        loader: ({ request }) =>
+          rootGuard({
+            name: WORKSPACE_ROUTE_404,
+            url: new URL(request.url),
+          }),
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Route unknown frontend URLs through the root auth guard before resolving to the 404 page.
- Keep direct `/403` and `/404` routes publicly accessible.
- Add regression coverage for logged-out and logged-in catch-all route behavior.

## Root Cause

The React Router catch-all route was named `error.404` and had its own loader that unconditionally redirected to `/404`. That child loader bypassed the root auth guard, so logged-out users visiting an unknown URL were sent to `/404` instead of signin.

## Testing

- `pnpm --dir frontend test -- src/react/router/guard.test.ts src/react/router/routes.test.tsx`
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`
- Manual browser check: fresh unauthenticated context visiting `http://localhost:3001/iowjergoirjg` lands on `/auth?redirect=%2Fiowjergoirjg` with `/v1/users/me` returning 401.
