### PR TITLE
fix(frontend): localize default credential hints

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -995,6 +995,11 @@
       "client-id": "Client ID",
       "client-secret": "Client Secret",
       "credential-source": "Credential Source",
+      "default-credential": {
+        "aws": "Bytebase will read the credential from environment variables <awsAccessKeyId>AWS_ACCESS_KEY_ID</awsAccessKeyId>/<awsSecretAccessKey>AWS_SECRET_ACCESS_KEY</awsSecretAccessKey>/<awsSessionToken>AWS_SESSION_TOKEN</awsSessionToken>, fallback to shared credentials file <awsCredentialsPath>~/.aws/credentials</awsCredentialsPath> or IAM role in AWS ECS",
+        "azure": "Bytebase will read the credential from environment variables <azureClientId>AZURE_CLIENT_ID</azureClientId>/<azureTenantId>AZURE_TENANT_ID</azureTenantId>/<azureClientSecret>AZURE_CLIENT_SECRET</azureClientSecret> or <azureClientCertificatePath>AZURE_CLIENT_CERTIFICATE_PATH</azureClientCertificatePath>, and fallback to attached users in Azure VM",
+        "gcp": "Bytebase will read the credential from environment variable <googleApplicationCredentials>GOOGLE_APPLICATION_CREDENTIALS</googleApplicationCredentials>, fallback to the attached service account in GCP GCE"
+      },
       "saas-default-credential-restriction": "Default credentials are not available in Bytebase Cloud for security. Please provide specific credentials.",
       "specific-credential": "Specific Credential",
       "tenant-id": "Tenant ID"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -995,6 +995,11 @@
       "client-id": "Client ID",
       "client-secret": "Client Secret",
       "credential-source": "Origen de credenciales",
+      "default-credential": {
+        "aws": "Bytebase leerá la credencial desde las variables de entorno <awsAccessKeyId>AWS_ACCESS_KEY_ID</awsAccessKeyId>/<awsSecretAccessKey>AWS_SECRET_ACCESS_KEY</awsSecretAccessKey>/<awsSessionToken>AWS_SESSION_TOKEN</awsSessionToken>, con respaldo al archivo de credenciales compartidas <awsCredentialsPath>~/.aws/credentials</awsCredentialsPath> o al rol de IAM en AWS ECS",
+        "azure": "Bytebase leerá la credencial desde las variables de entorno <azureClientId>AZURE_CLIENT_ID</azureClientId>/<azureTenantId>AZURE_TENANT_ID</azureTenantId>/<azureClientSecret>AZURE_CLIENT_SECRET</azureClientSecret> o <azureClientCertificatePath>AZURE_CLIENT_CERTIFICATE_PATH</azureClientCertificatePath>, y usará como respaldo los usuarios adjuntos en Azure VM",
+        "gcp": "Bytebase leerá la credencial desde la variable de entorno <googleApplicationCredentials>GOOGLE_APPLICATION_CREDENTIALS</googleApplicationCredentials>, con respaldo a la cuenta de servicio adjunta en GCP GCE"
+      },
       "saas-default-credential-restriction": "Las credenciales predeterminadas no están disponibles en Bytebase Cloud por seguridad. Proporcione credenciales específicas.",
       "specific-credential": "Credencial específica",
       "tenant-id": "Tenant ID"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -995,6 +995,11 @@
       "client-id": "Client ID",
       "client-secret": "Client Secret",
       "credential-source": "認証情報のソース",
+      "default-credential": {
+        "aws": "Bytebase は環境変数 <awsAccessKeyId>AWS_ACCESS_KEY_ID</awsAccessKeyId>/<awsSecretAccessKey>AWS_SECRET_ACCESS_KEY</awsSecretAccessKey>/<awsSessionToken>AWS_SESSION_TOKEN</awsSessionToken> から認証情報を読み取り、共有認証情報ファイル <awsCredentialsPath>~/.aws/credentials</awsCredentialsPath> または AWS ECS の IAM ロールにフォールバックします",
+        "azure": "Bytebase は環境変数 <azureClientId>AZURE_CLIENT_ID</azureClientId>/<azureTenantId>AZURE_TENANT_ID</azureTenantId>/<azureClientSecret>AZURE_CLIENT_SECRET</azureClientSecret> または <azureClientCertificatePath>AZURE_CLIENT_CERTIFICATE_PATH</azureClientCertificatePath> から認証情報を読み取り、Azure VM にアタッチされたユーザーにフォールバックします",
+        "gcp": "Bytebase は環境変数 <googleApplicationCredentials>GOOGLE_APPLICATION_CREDENTIALS</googleApplicationCredentials> から認証情報を読み取り、GCP GCE にアタッチされたサービス アカウントにフォールバックします"
+      },
       "saas-default-credential-restriction": "セキュリティ上の理由により、Bytebase Cloud ではデフォルトの認証情報は使用できません。具体的な認証情報を入力してください。",
       "specific-credential": "特定の資格情報",
       "tenant-id": "Tenant ID"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -995,6 +995,11 @@
       "client-id": "Client ID",
       "client-secret": "Client Secret",
       "credential-source": "Nguồn thông tin xác thực",
+      "default-credential": {
+        "aws": "Bytebase sẽ đọc thông tin xác thực từ các biến môi trường <awsAccessKeyId>AWS_ACCESS_KEY_ID</awsAccessKeyId>/<awsSecretAccessKey>AWS_SECRET_ACCESS_KEY</awsSecretAccessKey>/<awsSessionToken>AWS_SESSION_TOKEN</awsSessionToken>, dự phòng bằng tệp thông tin xác thực dùng chung <awsCredentialsPath>~/.aws/credentials</awsCredentialsPath> hoặc vai trò IAM trong AWS ECS",
+        "azure": "Bytebase sẽ đọc thông tin xác thực từ các biến môi trường <azureClientId>AZURE_CLIENT_ID</azureClientId>/<azureTenantId>AZURE_TENANT_ID</azureTenantId>/<azureClientSecret>AZURE_CLIENT_SECRET</azureClientSecret> hoặc <azureClientCertificatePath>AZURE_CLIENT_CERTIFICATE_PATH</azureClientCertificatePath>, và dự phòng bằng người dùng được gắn trong Azure VM",
+        "gcp": "Bytebase sẽ đọc thông tin xác thực từ biến môi trường <googleApplicationCredentials>GOOGLE_APPLICATION_CREDENTIALS</googleApplicationCredentials>, dự phòng bằng tài khoản dịch vụ được gắn trong GCP GCE"
+      },
       "saas-default-credential-restriction": "Thông tin xác thực mặc định không khả dụng trong Bytebase Cloud vì lý do bảo mật. Vui lòng cung cấp thông tin xác thực cụ thể.",
       "specific-credential": "Chứng chỉ cụ thể",
       "tenant-id": "Tenant ID"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -995,6 +995,11 @@
       "client-id": "Client ID",
       "client-secret": "Client Secret",
       "credential-source": "凭证来源",
+      "default-credential": {
+        "aws": "Bytebase 将从环境变量 <awsAccessKeyId>AWS_ACCESS_KEY_ID</awsAccessKeyId>/<awsSecretAccessKey>AWS_SECRET_ACCESS_KEY</awsSecretAccessKey>/<awsSessionToken>AWS_SESSION_TOKEN</awsSessionToken> 读取凭证，回退到共享凭证文件 <awsCredentialsPath>~/.aws/credentials</awsCredentialsPath> 或 AWS ECS 中的 IAM 角色",
+        "azure": "Bytebase 将从环境变量 <azureClientId>AZURE_CLIENT_ID</azureClientId>/<azureTenantId>AZURE_TENANT_ID</azureTenantId>/<azureClientSecret>AZURE_CLIENT_SECRET</azureClientSecret> 或 <azureClientCertificatePath>AZURE_CLIENT_CERTIFICATE_PATH</azureClientCertificatePath> 读取凭证，并回退到 Azure VM 中附加的用户",
+        "gcp": "Bytebase 将从环境变量 <googleApplicationCredentials>GOOGLE_APPLICATION_CREDENTIALS</googleApplicationCredentials> 读取凭证，回退到 GCP GCE 中附加的服务账号"
+      },
       "saas-default-credential-restriction": "出于安全考虑，Bytebase Cloud 不支持使用默认凭证。请提供具体凭证。",
       "specific-credential": "指定凭证",
       "tenant-id": "Tenant ID"

--- a/frontend/src/react/components/instance/CredentialSourceForm.test.tsx
+++ b/frontend/src/react/components/instance/CredentialSourceForm.test.tsx
@@ -1,0 +1,90 @@
+import { create } from "@bufbuild/protobuf";
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, test, vi } from "vitest";
+import {
+  DataSource_AuthenticationType,
+  DataSourceSchema,
+} from "@/types/proto-es/v1/instance_service_pb";
+import { CredentialSourceForm } from "./CredentialSourceForm";
+import type { EditDataSource } from "./common";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  Trans: ({ i18nKey }: { i18nKey: string }) => <>{i18nKey}</>,
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/react/hooks/useAppState", () => ({
+  useServerState: () => ({
+    isSaaSMode: false,
+  }),
+}));
+
+const makeDataSource = (
+  authenticationType: DataSource_AuthenticationType
+): EditDataSource => ({
+  ...create(DataSourceSchema, {
+    id: "admin",
+    authenticationType,
+  }),
+  pendingCreate: false,
+  updatedPassword: "",
+  updatedMasterPassword: "",
+  updatedToken: "",
+});
+
+function render(element: ReactElement) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(element);
+  });
+
+  return {
+    container,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+describe("CredentialSourceForm", () => {
+  test.each([
+    [
+      DataSource_AuthenticationType.AZURE_IAM,
+      "instance.iam-extension.default-credential.azure",
+    ],
+    [
+      DataSource_AuthenticationType.AWS_RDS_IAM,
+      "instance.iam-extension.default-credential.aws",
+    ],
+    [
+      DataSource_AuthenticationType.GOOGLE_CLOUD_SQL_IAM,
+      "instance.iam-extension.default-credential.gcp",
+    ],
+  ])("renders default credential help through i18n for authentication type %s", (authenticationType, expectedKey) => {
+    const { container, unmount } = render(
+      <CredentialSourceForm
+        dataSource={makeDataSource(authenticationType)}
+        allowEdit={true}
+        onDataSourceChange={vi.fn()}
+      />
+    );
+
+    expect(container.textContent).toContain(expectedKey);
+
+    unmount();
+  });
+});

--- a/frontend/src/react/components/instance/CredentialSourceForm.tsx
+++ b/frontend/src/react/components/instance/CredentialSourceForm.tsx
@@ -6,7 +6,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { Input } from "@/react/components/ui/input";
 import { Textarea } from "@/react/components/ui/textarea";
 import { useServerState } from "@/react/hooks/useAppState";
@@ -489,38 +489,49 @@ function DefaultCredentialInfo({
 }: {
   authenticationType: DataSource_AuthenticationType;
 }) {
+  const { t } = useTranslation();
+
   return (
     <div className="mt-1 sm:col-span-3 sm:col-start-1 textinfolabel !leading-6">
       {authenticationType === DataSource_AuthenticationType.AZURE_IAM && (
-        <span>
-          Bytebase will read the credential from environment variables{" "}
-          <Code>AZURE_CLIENT_ID</Code>/<Code>AZURE_TENANT_ID</Code>/
-          <Code>AZURE_CLIENT_SECRET</Code> or{" "}
-          <Code>AZURE_CLIENT_CERTIFICATE_PATH</Code>, and fallback to attached
-          users in Azure VM
-        </span>
+        <Trans
+          t={t}
+          i18nKey="instance.iam-extension.default-credential.azure"
+          components={{
+            azureClientId: <Code />,
+            azureTenantId: <Code />,
+            azureClientSecret: <Code />,
+            azureClientCertificatePath: <Code />,
+          }}
+        />
       )}
       {authenticationType === DataSource_AuthenticationType.AWS_RDS_IAM && (
-        <span>
-          Bytebase will read the credential from environment variables{" "}
-          <Code>AWS_ACCESS_KEY_ID</Code>/<Code>AWS_SECRET_ACCESS_KEY</Code>/
-          <Code>AWS_SESSION_TOKEN</Code>, fallback to shared credentials file{" "}
-          <Code>~/.aws/credentials</Code> or IAM role in AWS ECS
-        </span>
+        <Trans
+          t={t}
+          i18nKey="instance.iam-extension.default-credential.aws"
+          components={{
+            awsAccessKeyId: <Code />,
+            awsSecretAccessKey: <Code />,
+            awsSessionToken: <Code />,
+            awsCredentialsPath: <Code />,
+          }}
+        />
       )}
       {authenticationType ===
         DataSource_AuthenticationType.GOOGLE_CLOUD_SQL_IAM && (
-        <span>
-          Bytebase will read the credential from environment variable{" "}
-          <Code>GOOGLE_APPLICATION_CREDENTIALS</Code>, fallback to the attached
-          service account in GCP GCE
-        </span>
+        <Trans
+          t={t}
+          i18nKey="instance.iam-extension.default-credential.gcp"
+          components={{
+            googleApplicationCredentials: <Code />,
+          }}
+        />
       )}
     </div>
   );
 }
 
-function Code({ children }: { children: React.ReactNode }) {
+function Code({ children }: { children?: React.ReactNode }) {
   return <code className="bg-gray-100 p-1 rounded-sm mr-1">{children}</code>;
 }
 


### PR DESCRIPTION
## Summary
- Localize the default credential help text for Azure, AWS, and GCP IAM authentication.
- Preserve inline code formatting for provider credential names through i18next Trans placeholders.
- Add regression coverage that ensures the provider help text is rendered through i18n keys.

## Test Plan
- pnpm --dir frontend fix
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test

## Breaking Changes
None.