### PR TITLE
chore(starrocks): bump omni to PR4 query features (lineage)

### DIFF
--- a/backend/plugin/parser/starrocks/query_span_pr4_test.go
+++ b/backend/plugin/parser/starrocks/query_span_pr4_test.go
@@ -1,0 +1,71 @@
+package starrocks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestQuerySpanExtractor_PR4Features is the value-chain keystone for the PR4
+// query features (omni #305 + #306): it proves that the new StarRocks query
+// constructs deliver correct query-span lineage end-to-end through Bytebase
+// (the extractor delegates to omni/starrocks/analysis). Before the omni dep
+// bump these constructs do not parse, so lineage is empty/wrong; after, the
+// physical sources resolve and the literal-derived relations contribute none.
+func TestQuerySpanExtractor_PR4Features(t *testing.T) {
+	tests := []struct {
+		name           string
+		sql            string
+		expectedTables []base.ColumnResource
+	}{
+		{
+			// PR4a: LATERAL + unnest table function — t is the only physical
+			// source; the unnest relation must not leak a phantom table.
+			name:           "lateral_unnest",
+			sql:            "SELECT t.id, u.unnest FROM t, LATERAL unnest(t.arr) AS u",
+			expectedTables: []base.ColumnResource{{Database: "test", Table: "t"}},
+		},
+		{
+			// PR4a: VALUES inline-table is literal-derived — no physical table.
+			name:           "values_inline_table",
+			sql:            "SELECT * FROM (VALUES (1,'a'),(2,'b')) AS v(id,name)",
+			expectedTables: nil,
+		},
+		{
+			// PR4b: a column ref inside a map literal value flows to lineage.
+			name:           "map_literal_column",
+			sql:            "SELECT map<varchar,int>{'x':a_col} AS m FROM t",
+			expectedTables: []base.ColumnResource{{Database: "test", Table: "t"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			extractor := newQuerySpanExtractor("test", base.GetQuerySpanContext{}, false)
+			querySpan, err := extractor.getQuerySpan(context.Background(), tt.sql)
+			require.NoError(t, err)
+
+			var actualTables []base.ColumnResource
+			for table := range querySpan.SourceColumns {
+				actualTables = append(actualTables, table)
+			}
+
+			require.Equal(t, len(tt.expectedTables), len(actualTables),
+				"expected %d source tables, got %d (%+v)", len(tt.expectedTables), len(actualTables), actualTables)
+			for _, expected := range tt.expectedTables {
+				found := false
+				for _, actual := range actualTables {
+					if actual.Database == expected.Database && actual.Table == expected.Table {
+						found = true
+						break
+					}
+				}
+				require.True(t, found, "expected source table %s.%s not found in %+v",
+					expected.Database, expected.Table, actualTables)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260611091433-2bdffb0599b3
+	github.com/bytebase/omni v0.0.0-20260616044321-57b574a371c1
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260611091433-2bdffb0599b3 h1:e53I+ahF1zSk7ZrDcRrP5ZttInx6iRB2QaV8RMoa2oU=
-github.com/bytebase/omni v0.0.0-20260611091433-2bdffb0599b3/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260616044321-57b574a371c1 h1:U8dSPmTkVxEXBms3fyxneXlBUKqJCnyU+nSaJXyj/yA=
+github.com/bytebase/omni v0.0.0-20260616044321-57b574a371c1/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
Bumps `github.com/bytebase/omni` `2bdffb05` → `57b574a3`, pulling in the 5 PR4 StarRocks query features that complete BYT-9140's lineage surface:

- **omni #305 (FROM-side):** `VALUES (…) AS v(cols)` inline-table, `LATERAL`/`unnest(…)` table functions
- **omni #306 (expr-side):** `IGNORE NULLS` windows, `X''`/`B''`/`BINARY` literals+operator, `map<>{}`/`array<>[]` collection literals

`parser/starrocks` delegates query-span to `omni/starrocks/analysis` (`query_span_extractor.go`), so the bump alone routes these constructs into `Engine_STARROCKS` query-span lineage — no extractor changes needed.

## Testing
- New keystone `TestQuerySpanExtractor_PR4Features` asserts the value chain end-to-end: `LATERAL unnest` and a map-literal column resolve their physical source (`t`) with **no phantom relation**; a `VALUES` inline-table contributes none. It is RED on the pre-PR4 dep (constructs don't parse → empty lineage) and GREEN after the bump.
- Full `backend/plugin/parser/starrocks` suite passes (no regression).
- `gofmt`, `golangci-lint` (0 issues), and `go build` of the server all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)