### PR TITLE
feat(plan): always-enabled Create button with validation callout (BYT-9531)

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1442,6 +1442,7 @@
   "plan": {
     "add-spec": "Add Change",
     "add-spec-pending-draft": "Save or discard the pending change before adding another",
+    "cannot-create": "Cannot create plan",
     "checks": {
       "completed": "Plan checks completed",
       "failed-to-run": "Failed to run plan checks",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1442,6 +1442,7 @@
   "plan": {
     "add-spec": "Agregar cambio",
     "add-spec-pending-draft": "Guarda o descarta el cambio pendiente antes de agregar otro",
+    "cannot-create": "No se puede crear el plan",
     "checks": {
       "completed": "Se completaron las verificaciones del plan",
       "failed-to-run": "No se pudieron ejecutar las verificaciones del plan",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1442,6 +1442,7 @@
   "plan": {
     "add-spec": "変更を追加",
     "add-spec-pending-draft": "新しい変更を追加する前に、保留中の変更を保存または破棄してください",
+    "cannot-create": "プランを作成できません",
     "checks": {
       "completed": "プランチェックが完了しました",
       "failed-to-run": "プランチェックの実行に失敗しました",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1442,6 +1442,7 @@
   "plan": {
     "add-spec": "Thêm thay đổi",
     "add-spec-pending-draft": "Lưu hoặc hủy thay đổi đang chờ trước khi thêm thay đổi khác",
+    "cannot-create": "Không thể tạo kế hoạch",
     "checks": {
       "completed": "Đã hoàn thành kiểm tra kế hoạch",
       "failed-to-run": "Không thể chạy kiểm tra kế hoạch",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1442,6 +1442,7 @@
   "plan": {
     "add-spec": "添加变更",
     "add-spec-pending-draft": "请先保存或放弃当前的待处理变更，然后再添加新变更",
+    "cannot-create": "无法创建变更计划",
     "checks": {
       "completed": "已完成计划检查",
       "failed-to-run": "运行计划检查失败",
@@ -1468,7 +1469,7 @@
       "self": "隔离级别",
       "serializable": "串行化"
     },
-    "labels-required-for-review": "提交评审前必须设置标签",
+    "labels-required-for-review": "提交审批前必须设置标签",
     "meta": {
       "created-by-at": "由 {{user}} 创建 · {{time}}"
     },
@@ -1499,7 +1500,7 @@
     "pre-backup": {
       "requirements-not-met": "以下数据库不满足预备份要求：{{databases}}"
     },
-    "ready-for-review": "准备提交评审",
+    "ready-for-review": "提交审批",
     "review": {
       "action": "审批",
       "activity": {

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailHeader.tsx
@@ -8,6 +8,7 @@ import {
   IssueLabelSelect,
 } from "@/react/components/IssueLabelSelect";
 import { MarkdownEditor } from "@/react/components/MarkdownEditor";
+import { Alert } from "@/react/components/ui/alert";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import {
@@ -15,7 +16,6 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/react/components/ui/popover";
-import { Tooltip } from "@/react/components/ui/tooltip";
 import { cn } from "@/react/lib/utils";
 import { router } from "@/react/router";
 import {
@@ -49,6 +49,7 @@ import { usePlanDetailContext } from "../shell/PlanDetailContext";
 import {
   getCreateIssueBlockingErrors,
   getCreateIssueConfirmErrors,
+  getCreatePlanBlockingReasons,
   hasChecksWarning,
   shouldStayOnPlanDetailPage,
 } from "../utils/header";
@@ -76,6 +77,18 @@ export function PlanDetailHeader() {
   const { emptySpecIdSet } = usePlanDetailSpecValidation(page.plan.specs ?? []);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const titleAutoFocusedRef = useRef(false);
+  const createButtonRef = useRef<HTMLButtonElement>(null);
+  const [showCreateErrors, setShowCreateErrors] = useState(false);
+  const createPlanBlockingReasons = useMemo(
+    () =>
+      getCreatePlanBlockingReasons({
+        title: page.plan.title,
+        emptySpecCount: emptySpecIdSet.size,
+        t,
+      }),
+    [emptySpecIdSet.size, page.plan.title, t]
+  );
+  const titleMissing = page.plan.title.trim() === "";
 
   useEffect(() => {
     const nextTitle = page.issue?.title ?? page.plan.title;
@@ -323,6 +336,10 @@ export function PlanDetailHeader() {
   };
 
   const handleCreatePlan = async () => {
+    if (createPlanBlockingReasons.length > 0) {
+      setShowCreateErrors(true);
+      return;
+    }
     try {
       setUpdating(true);
       await createSheets();
@@ -351,17 +368,6 @@ export function PlanDetailHeader() {
       setUpdating(false);
     }
   };
-
-  const createPlanDisabledReasons = useMemo(() => {
-    const reasons: string[] = [];
-    if (!page.plan.title.trim()) {
-      reasons.push(t("plan.title-required"));
-    }
-    if (emptySpecIdSet.size > 0) {
-      reasons.push(t("plan.navigator.statement-empty"));
-    }
-    return reasons;
-  }, [emptySpecIdSet.size, page.plan.title, t]);
 
   const createIssueBlockingErrors = useMemo(
     () =>
@@ -502,25 +508,38 @@ export function PlanDetailHeader() {
 
         <div className="flex shrink-0 items-center gap-x-2">
           {page.isCreating ? (
-            <Tooltip
-              content={
-                createPlanDisabledReasons.length > 0 ? (
-                  <div className="flex flex-col gap-y-1">
-                    {createPlanDisabledReasons.map((reason) => (
-                      <span key={reason}>{reason}</span>
-                    ))}
-                  </div>
-                ) : null
-              }
+            <Popover
+              modal={false}
+              onOpenChange={setShowCreateErrors}
+              open={showCreateErrors && createPlanBlockingReasons.length > 0}
             >
               <Button
-                disabled={updating || createPlanDisabledReasons.length > 0}
+                disabled={updating}
                 onClick={() => void handleCreatePlan()}
+                ref={createButtonRef}
               >
                 {updating && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                 {t("common.create")}
               </Button>
-            </Tooltip>
+              <PopoverContent
+                anchor={createButtonRef}
+                className="max-w-xs overflow-hidden border-error/40 p-0"
+                initialFocus={titleMissing ? titleInputRef : false}
+              >
+                <Alert
+                  className="rounded-none border-0 shadow-none"
+                  description={
+                    <ul className="list-disc pl-4">
+                      {createPlanBlockingReasons.map((reason) => (
+                        <li key={reason}>{reason}</li>
+                      ))}
+                    </ul>
+                  }
+                  title={t("plan.cannot-create")}
+                  variant="error"
+                />
+              </PopoverContent>
+            </Popover>
           ) : (
             <>
               {showSubmitForReview && (

--- a/frontend/src/react/pages/project/plan-detail/utils/header.test.ts
+++ b/frontend/src/react/pages/project/plan-detail/utils/header.test.ts
@@ -4,6 +4,7 @@ import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import {
   getCreateIssueBlockingErrors,
   getCreateIssueConfirmErrors,
+  getCreatePlanBlockingReasons,
   hasChecksWarning,
   shouldStayOnPlanDetailPage,
 } from "./header";
@@ -73,5 +74,45 @@ describe("plan detail header create issue helpers", () => {
     ).toContain(
       "custom-approval.issue-review.disallow-approve-reason.some-task-checks-didnt-pass"
     );
+  });
+});
+
+describe("getCreatePlanBlockingReasons", () => {
+  test("flags an empty title", () => {
+    expect(
+      getCreatePlanBlockingReasons({ title: "", emptySpecCount: 0, t })
+    ).toEqual(["plan.title-required"]);
+  });
+
+  test("flags a whitespace-only title", () => {
+    expect(
+      getCreatePlanBlockingReasons({ title: "   ", emptySpecCount: 0, t })
+    ).toEqual(["plan.title-required"]);
+  });
+
+  test("flags empty statements", () => {
+    expect(
+      getCreatePlanBlockingReasons({
+        title: "Add column",
+        emptySpecCount: 2,
+        t,
+      })
+    ).toEqual(["plan.navigator.statement-empty"]);
+  });
+
+  test("lists both blockers, title first", () => {
+    expect(
+      getCreatePlanBlockingReasons({ title: "", emptySpecCount: 1, t })
+    ).toEqual(["plan.title-required", "plan.navigator.statement-empty"]);
+  });
+
+  test("returns no reasons when valid", () => {
+    expect(
+      getCreatePlanBlockingReasons({
+        title: "Add column",
+        emptySpecCount: 0,
+        t,
+      })
+    ).toEqual([]);
   });
 });

--- a/frontend/src/react/pages/project/plan-detail/utils/header.ts
+++ b/frontend/src/react/pages/project/plan-detail/utils/header.ts
@@ -26,6 +26,25 @@ export const hasChecksWarning = (plan: Plan): boolean => {
   );
 };
 
+export const getCreatePlanBlockingReasons = ({
+  title,
+  emptySpecCount,
+  t,
+}: {
+  title: string;
+  emptySpecCount: number;
+  t: T;
+}): string[] => {
+  const reasons: string[] = [];
+  if (!title.trim()) {
+    reasons.push(t("plan.title-required"));
+  }
+  if (emptySpecCount > 0) {
+    reasons.push(t("plan.navigator.statement-empty"));
+  }
+  return reasons;
+};
+
 export const getCreateIssueBlockingErrors = ({
   emptySpecCount,
   plan,


### PR DESCRIPTION
## Summary

Reworks plan creation so the **Create button is always enabled**. The title input autofocuses on open, and clicking Create with unmet requirements opens a button-anchored `Alert` popover listing all blockers ("Title is required", "Statement is empty") and drops focus into the empty title — instead of a silently disabled button with a hover-only tooltip.

- Extract `getCreatePlanBlockingReasons` into `utils/header.ts` (beside its sibling validators) with unit tests.
- Add `plan.cannot-create` i18n key across all locales.
- Replace the disabled-button + tooltip with an always-enabled button + click-to-reveal callout built on the shared `Alert` primitive.

<img width="1196" height="964" alt="image" src="https://github.com/user-attachments/assets/ceb52ac8-1e00-48e1-b6c1-d85a51dd59fa" />

## Test Plan

- [x] `pnpm --dir frontend type-check`
- [x] `pnpm --dir frontend check`
- [x] `pnpm --dir frontend test` (2379 passing, incl. new `getCreatePlanBlockingReasons` cases)
- [ ] Manual: open the plan-create page → title autofocused; Create enabled with empty title; clicking it opens the red callout under the button listing blockers and focuses the title; filling title + statement lets Create succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)