### PR TITLE
chore(starrocks): bump omni to PR3 DML features (diagnose accuracy)

### DIFF
--- a/backend/plugin/parser/starrocks/diagnose_pr3_test.go
+++ b/backend/plugin/parser/starrocks/diagnose_pr3_test.go
@@ -1,0 +1,55 @@
+package starrocks
+
+import (
+	"context"
+	"testing"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestStarRocksPR3DiagnoseE2E is the value-chain keystone for the PR3 DML
+// features (omni #309): the new StarRocks DML forms now parse through the
+// omni/starrocks fork, so Bytebase's diagnose path stops reporting false
+// syntax errors on them (the deliverable is parse-accept, not lineage). Before
+// the omni dep bump these forms do not parse and produce a diagnostic; after,
+// they diagnose clean. A genuinely-invalid statement still reports an error.
+func TestStarRocksPR3DiagnoseE2E(t *testing.T) {
+	cases := []struct {
+		name     string
+		sql      string
+		wantDiag bool
+	}{
+		{
+			"insert_overwrite_no_table", // PR3: INSERT OVERWRITE t (no TABLE)
+			"INSERT OVERWRITE t SELECT a FROM src",
+			false,
+		},
+		{
+			"cte_delete", // PR3: WITH … DELETE
+			"WITH c AS (SELECT id FROM s) DELETE FROM t WHERE id IN (SELECT id FROM c)",
+			false,
+		},
+		{
+			"async_mv_refresh_every", // PR3: REFRESH ASYNC EVERY (INTERVAL …)
+			"CREATE MATERIALIZED VIEW mv REFRESH ASYNC EVERY (INTERVAL 1 DAY) AS SELECT a FROM t",
+			false,
+		},
+		{
+			"invalid_statement", // diagnose still catches real syntax errors
+			"INSERT OVERWRITE t BY NAME (a) SELECT a FROM s", // BY NAME + col list — rejected
+			true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diags, err := base.Diagnose(context.Background(), base.DiagnoseContext{}, storepb.Engine_STARROCKS, tc.sql)
+			if err != nil {
+				t.Fatalf("Diagnose error: %v", err)
+			}
+			if got := len(diags) > 0; got != tc.wantDiag {
+				t.Fatalf("Diagnose(%q): hasDiagnostic=%v, want %v (diags=%+v)", tc.sql, got, tc.wantDiag, diags)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260616044321-57b574a371c1
+	github.com/bytebase/omni v0.0.0-20260616095434-7e1369f4045a
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260616044321-57b574a371c1 h1:U8dSPmTkVxEXBms3fyxneXlBUKqJCnyU+nSaJXyj/yA=
-github.com/bytebase/omni v0.0.0-20260616044321-57b574a371c1/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260616095434-7e1369f4045a h1:X0mpevdOyNtq4u3Lkv+SqtZ9HjeOlY59eAXG9Vssaq8=
+github.com/bytebase/omni v0.0.0-20260616095434-7e1369f4045a/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
Bumps `github.com/bytebase/omni` `57b574a3` → `7e1369f4`, pulling in the PR3 StarRocks DML divergences (omni #309) — the last scoped feature PR of BYT-9140:

- **INSERT:** `OVERWRITE` no-`TABLE`, `BY NAME`, `FILES(propertyList)` target (+ any-order post-target modifiers)
- **CTE-prefixed `DELETE` and `UPDATE`**
- **async-MV `REFRESH ASYNC [START('ts')] EVERY (INTERVAL n unit)`**

`parser/starrocks` diagnose/split ride on omni `Parse`, so the bump alone makes Bytebase stop reporting **false syntax errors** on these forms. This is a **parse-accept / diagnose-accuracy** deliverable — omni's analysis layer ignores DML (no query-span lineage; that's a separate doris-family ticket). The bump also pulls omni #307/#308 (pg/mysql parse fixes).

## Testing
- Keystone `TestStarRocksPR3DiagnoseE2E`: the new DML forms diagnose **clean**, while a genuinely-invalid form (`BY NAME` + column list) still reports an error. RED on the pre-PR3 dep (forms don't parse → false syntax diagnostic), GREEN after the bump.
- `parser/starrocks`, `parser/mysql`, `parser/pg`, `parser/doris` suites all pass (the bump touches those omni engines); `gofmt`, `golangci-lint` (0 issues), and `go build` of the server clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)