### PR TITLE
feat(frontend): shared DateTimePicker for all date/time controls (BYT-9588)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -76,6 +76,7 @@
     "qs": "6.15.2",
     "react": "^19.2.6",
     "react-arborist": "^3.5.0",
+    "react-day-picker": "^10.0.1",
     "react-dom": "^19.2.6",
     "react-i18next": "^17.0.0",
     "react-markdown": "^10.1.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
     dependencies:
       '@base-ui/react':
         specifier: ^1.3.0
-        version: 1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.4.1(@date-fns/tz@1.5.0)(@types/react@19.2.14)(date-fns@4.4.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@buf/googleapis_googleapis.bufbuild_es':
         specifier: 2.10.2-20260414192239-c17df5b2beca.1
         version: 2.10.2-20260414192239-c17df5b2beca.1(@bufbuild/protobuf@2.12.0)
@@ -166,6 +166,9 @@ importers:
       react-arborist:
         specifier: ^3.5.0
         version: 3.5.0(@types/node@24.12.3)(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-day-picker:
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@19.2.14)(react@19.2.6)
       react-dom:
         specifier: ^19.2.6
         version: 19.2.6(react@19.2.6)
@@ -1217,6 +1220,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -2549,6 +2555,9 @@ packages:
     resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
     engines: {node: '>=20'}
 
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
   dayjs@1.11.20:
     resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
@@ -3570,6 +3579,16 @@ packages:
     peerDependencies:
       react: '>= 16.14'
       react-dom: '>= 16.14'
+
+  react-day-picker@10.0.1:
+    resolution: {integrity: sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react-dnd-html5-backend@14.1.0:
     resolution: {integrity: sha512-6ONeqEC3XKVf4eVmMTe0oPds+c5B9Foyj8p/ZKLb7kL2qh9COYxiBHv3szd6gztqi/efkmriywLUVlPotqoJyw==}
@@ -5001,7 +5020,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@base-ui/react@1.4.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@base-ui/react@1.4.1(@date-fns/tz@1.5.0)(@types/react@19.2.14)(date-fns@4.4.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@base-ui/utils': 0.2.8(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -5011,7 +5030,9 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
       use-sync-external-store: 1.6.0(react@19.2.6)
     optionalDependencies:
+      '@date-fns/tz': 1.5.0
       '@types/react': 19.2.14
+      date-fns: 4.4.0
 
   '@base-ui/utils@0.2.8(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -5417,6 +5438,8 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.25': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@date-fns/tz@1.5.0': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.6)':
     dependencies:
@@ -6641,6 +6664,8 @@ snapshots:
     dependencies:
       whatwg-mimetype: 4.0.0
       whatwg-url: 15.1.0
+
+  date-fns@4.4.0: {}
 
   dayjs@1.11.20: {}
 
@@ -7900,6 +7925,14 @@ snapshots:
       - '@types/hoist-non-react-statics'
       - '@types/node'
       - '@types/react'
+
+  react-day-picker@10.0.1(@types/react@19.2.14)(react@19.2.6):
+    dependencies:
+      '@date-fns/tz': 1.5.0
+      date-fns: 4.4.0
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-dnd-html5-backend@14.1.0:
     dependencies:

--- a/frontend/src/react/components/TimeRangePicker.tsx
+++ b/frontend/src/react/components/TimeRangePicker.tsx
@@ -1,24 +1,25 @@
 import dayjs from "dayjs";
 import { ArrowRight, Calendar } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { SearchParams } from "./AdvancedSearch";
 import { Button } from "./ui/button";
-import { Input } from "./ui/input";
-import { LAYER_SURFACE_CLASS } from "./ui/layer";
+import { DateTimePicker } from "./ui/date-time-picker";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 
 interface TimeRangePickerProps {
   params: SearchParams;
   onParamsChange: (p: SearchParams) => void;
 }
 
+const DISPLAY_FORMAT = "YYYY-MM-DD HH:mm";
+
 export function TimeRangePicker({
   params,
   onParamsChange,
 }: TimeRangePickerProps) {
   const { t } = useTranslation();
-  const [showPicker, setShowPicker] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [open, setOpen] = useState(false);
 
   const createdScope = params.scopes.find((s) => s.id === "created");
   const [fromTs, toTs] = useMemo(() => {
@@ -30,30 +31,22 @@ export function TimeRangePicker({
 
   const hasRange = fromTs !== undefined && toTs !== undefined;
 
-  // Local draft state for the inputs inside the dropdown.
-  const [draftFrom, setDraftFrom] = useState("");
-  const [draftTo, setDraftTo] = useState("");
+  // Local draft state for the pickers inside the dropdown.
+  const [draftFrom, setDraftFrom] = useState<Date | undefined>(undefined);
+  const [draftTo, setDraftTo] = useState<Date | undefined>(undefined);
 
-  // Sync drafts when the dropdown opens or the external range changes.
+  // Sync drafts when the external range changes.
   useEffect(() => {
-    if (fromTs) {
-      setDraftFrom(dayjs(fromTs).format("YYYY-MM-DDTHH:mm:ss"));
-    } else {
-      setDraftFrom("");
-    }
-    if (toTs) {
-      setDraftTo(dayjs(toTs).format("YYYY-MM-DDTHH:mm:ss"));
-    } else {
-      setDraftTo("");
-    }
+    setDraftFrom(fromTs ? new Date(fromTs) : undefined);
+    setDraftTo(toTs ? new Date(toTs) : undefined);
   }, [fromTs, toTs]);
 
-  const displayFrom = fromTs ? dayjs(fromTs).format("YYYY-MM-DD HH:mm:ss") : "";
-  const displayTo = toTs ? dayjs(toTs).format("YYYY-MM-DD HH:mm:ss") : "";
+  const displayFrom = fromTs ? dayjs(fromTs).format(DISPLAY_FORMAT) : "";
+  const displayTo = toTs ? dayjs(toTs).format(DISPLAY_FORMAT) : "";
 
   const applyRange = useCallback(() => {
-    const fromVal = draftFrom ? dayjs(draftFrom).valueOf() : undefined;
-    const toVal = draftTo ? dayjs(draftTo).valueOf() : undefined;
+    const fromVal = draftFrom ? draftFrom.getTime() : undefined;
+    const toVal = draftTo ? draftTo.getTime() : undefined;
     const scopes = params.scopes.filter((s) => s.id !== "created");
     if (fromVal !== undefined && toVal !== undefined) {
       scopes.push({
@@ -63,40 +56,20 @@ export function TimeRangePicker({
       });
     }
     onParamsChange({ ...params, scopes });
-    setShowPicker(false);
+    setOpen(false);
   }, [draftFrom, draftTo, params, onParamsChange]);
 
   const clearRange = useCallback(() => {
     const scopes = params.scopes.filter((s) => s.id !== "created");
     onParamsChange({ ...params, scopes });
-    setDraftFrom("");
-    setDraftTo("");
-    setShowPicker(false);
+    setDraftFrom(undefined);
+    setDraftTo(undefined);
+    setOpen(false);
   }, [params, onParamsChange]);
 
-  // Close on click outside.
-  useEffect(() => {
-    if (!showPicker) return;
-    const handler = (e: MouseEvent) => {
-      if (
-        containerRef.current &&
-        !containerRef.current.contains(e.target as Node) &&
-        !containerRef.current.contains(document.activeElement)
-      ) {
-        setShowPicker(false);
-      }
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [showPicker]);
-
   return (
-    <div ref={containerRef} className="relative shrink-0">
-      <button
-        type="button"
-        className="h-9 flex items-center gap-x-2 border border-control-border rounded-xs px-3 text-sm hover:bg-control-bg whitespace-nowrap"
-        onClick={() => setShowPicker(!showPicker)}
-      >
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger className="h-9 flex items-center gap-x-2 border border-control-border rounded-xs px-3 text-sm hover:bg-control-bg whitespace-nowrap shrink-0">
         {displayFrom && displayTo ? (
           <>
             <span>{displayFrom}</span>
@@ -107,51 +80,67 @@ export function TimeRangePicker({
           <span className="text-control-placeholder">{t("common.select")}</span>
         )}
         <Calendar className="size-4 text-control-light ml-1 shrink-0" />
-      </button>
-      {showPicker && (
-        <div
-          className={`absolute right-0 top-[42px] bg-background border border-control-border rounded-sm shadow-lg p-3 flex flex-col gap-y-2 min-w-[300px] ${LAYER_SURFACE_CLASS}`}
-        >
-          <div className="flex items-center gap-x-2">
-            <label className="text-sm text-control-light whitespace-nowrap w-10">
-              {t("common.from")}
-            </label>
-            <Input
-              type="datetime-local"
-              step="1"
-              className="flex-1 accent-accent"
-              value={draftFrom}
-              onChange={(e) => setDraftFrom(e.target.value)}
-            />
-          </div>
-          <div className="flex items-center gap-x-2">
-            <label className="text-sm text-control-light whitespace-nowrap w-10">
-              {t("common.to")}
-            </label>
-            <Input
-              type="datetime-local"
-              step="1"
-              className="flex-1 accent-accent"
-              value={draftTo}
-              onChange={(e) => setDraftTo(e.target.value)}
-            />
-          </div>
-          <div className="flex items-center gap-x-2 mt-1">
-            <Button
-              size="sm"
-              onClick={applyRange}
-              disabled={!draftFrom || !draftTo}
-            >
-              {t("common.confirm")}
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="flex flex-col gap-y-2 min-w-[300px]"
+      >
+        <RangeEndPicker
+          label={t("common.from")}
+          value={draftFrom}
+          maxDate={draftTo}
+          onChange={setDraftFrom}
+        />
+        <RangeEndPicker
+          label={t("common.to")}
+          value={draftTo}
+          minDate={draftFrom}
+          onChange={setDraftTo}
+        />
+        <div className="flex items-center gap-x-2 mt-1">
+          <Button
+            size="sm"
+            onClick={applyRange}
+            disabled={!draftFrom || !draftTo}
+          >
+            {t("common.confirm")}
+          </Button>
+          {hasRange && (
+            <Button variant="ghost" size="sm" onClick={clearRange}>
+              {t("common.clear")}
             </Button>
-            {hasRange && (
-              <Button variant="ghost" size="sm" onClick={clearRange}>
-                {t("common.clear")}
-              </Button>
-            )}
-          </div>
+          )}
         </div>
-      )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function RangeEndPicker({
+  label,
+  value,
+  minDate,
+  maxDate,
+  onChange,
+}: {
+  label: string;
+  value: Date | undefined;
+  minDate?: Date;
+  maxDate?: Date;
+  onChange: (value: Date | undefined) => void;
+}) {
+  return (
+    <div className="flex items-center gap-x-2">
+      <label className="text-sm text-control-light whitespace-nowrap w-10">
+        {label}
+      </label>
+      <DateTimePicker
+        className="flex-1 w-full min-w-0"
+        value={value}
+        minDate={minDate}
+        maxDate={maxDate}
+        onChange={onChange}
+      />
     </div>
   );
 }

--- a/frontend/src/react/components/ui/calendar.tsx
+++ b/frontend/src/react/components/ui/calendar.tsx
@@ -1,0 +1,72 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { ComponentProps } from "react";
+import { DayPicker } from "react-day-picker";
+import { buttonVariants } from "@/react/components/ui/button";
+import { cn } from "@/react/lib/utils";
+
+export type CalendarProps = ComponentProps<typeof DayPicker>;
+
+/**
+ * Calendar — shadcn-style wrapper around react-day-picker, themed with app
+ * tokens (no react-day-picker default CSS).
+ */
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-0", className)}
+      classNames={{
+        months: "flex flex-col gap-4",
+        month: "flex flex-col gap-4",
+        month_caption: "flex h-7 items-center justify-center relative",
+        caption_label: "text-sm font-medium text-control",
+        nav: "flex items-center justify-between absolute inset-x-0 top-0",
+        button_previous: cn(
+          buttonVariants({ variant: "ghost" }),
+          "size-7 p-0 text-control-light"
+        ),
+        button_next: cn(
+          buttonVariants({ variant: "ghost" }),
+          "size-7 p-0 text-control-light"
+        ),
+        month_grid: "w-full border-collapse",
+        weekdays: "flex",
+        weekday: "text-control-light w-8 font-normal text-[0.8rem]",
+        week: "flex w-full mt-1",
+        day: "relative size-8 p-0 text-center text-sm",
+        day_button: cn(
+          buttonVariants({ variant: "ghost" }),
+          "size-8 p-0 font-normal text-control"
+        ),
+        today:
+          "[&>button]:bg-control-bg [&>button]:font-semibold [&>button]:text-accent",
+        selected:
+          "[&>button]:bg-accent [&>button]:text-accent-text [&>button]:hover:bg-accent-hover [&>button]:hover:text-accent-text",
+        outside: "[&>button]:text-control-light [&>button]:opacity-50",
+        disabled:
+          "[&>button]:text-control-light [&>button]:opacity-40 [&>button]:cursor-not-allowed",
+        hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ orientation, className: chevronClassName, ...rest }) =>
+          orientation === "left" ? (
+            <ChevronLeft className={cn("size-4", chevronClassName)} {...rest} />
+          ) : (
+            <ChevronRight
+              className={cn("size-4", chevronClassName)}
+              {...rest}
+            />
+          ),
+      }}
+      {...props}
+    />
+  );
+}
+
+export { Calendar };

--- a/frontend/src/react/components/ui/date-time-picker.tsx
+++ b/frontend/src/react/components/ui/date-time-picker.tsx
@@ -24,10 +24,12 @@ function TimeSelect({
   value,
   items,
   onChange,
+  isDisabled,
 }: {
   value: number;
   items: number[];
   onChange: (value: number) => void;
+  isDisabled?: (value: number) => boolean;
 }) {
   return (
     <Select value={String(value)} onValueChange={(v) => onChange(Number(v))}>
@@ -36,7 +38,11 @@ function TimeSelect({
       </SelectTrigger>
       <SelectContent>
         {items.map((item) => (
-          <SelectItem key={item} value={String(item)}>
+          <SelectItem
+            key={item}
+            value={String(item)}
+            disabled={isDisabled?.(item)}
+          >
             {pad(item)}
           </SelectItem>
         ))}
@@ -74,25 +80,70 @@ export function DateTimePicker({
   const hour = value ? value.getHours() : 0;
   const minute = value ? value.getMinutes() : 0;
 
+  // The picker is minute-granular, so floor the bounds to the minute and clamp
+  // every emitted value into [minTs, maxTs]. The calendar's day matchers only
+  // disable whole days, so without this the time selects could emit a value
+  // outside the bound on the boundary day.
+  const minTs = minDate
+    ? dayjs(minDate).second(0).millisecond(0).valueOf()
+    : undefined;
+  const maxTs = maxDate
+    ? dayjs(maxDate).second(0).millisecond(0).valueOf()
+    : undefined;
+
+  const clamp = (date: Date) => {
+    const ts = date.getTime();
+    if (minTs !== undefined && ts < minTs) return new Date(minTs);
+    if (maxTs !== undefined && ts > maxTs) return new Date(maxTs);
+    return date;
+  };
+
   const handleSelectDate = (day: Date | undefined) => {
     if (!day) {
       onChange(undefined);
       return;
     }
     onChange(
-      dayjs(day).hour(hour).minute(minute).second(0).millisecond(0).toDate()
+      clamp(
+        dayjs(day).hour(hour).minute(minute).second(0).millisecond(0).toDate()
+      )
     );
   };
 
   const handleTimeChange = (h: number, m: number) => {
     onChange(
-      dayjs(value ?? new Date())
-        .hour(h)
-        .minute(m)
-        .second(0)
-        .millisecond(0)
-        .toDate()
+      clamp(
+        dayjs(value ?? new Date())
+          .hour(h)
+          .minute(m)
+          .second(0)
+          .millisecond(0)
+          .toDate()
+      )
     );
+  };
+
+  // Disable hour/minute options that fall outside the bounds on the selected
+  // day, so the UI reflects the same range the value is clamped to.
+  const isHourDisabled = (h: number) => {
+    if (!value) return false;
+    const latest = dayjs(value).hour(h).minute(59).second(0).millisecond(0);
+    const earliest = dayjs(value).hour(h).minute(0).second(0).millisecond(0);
+    if (minTs !== undefined && latest.valueOf() < minTs) return true;
+    if (maxTs !== undefined && earliest.valueOf() > maxTs) return true;
+    return false;
+  };
+  const isMinuteDisabled = (m: number) => {
+    if (!value) return false;
+    const ts = dayjs(value)
+      .hour(hour)
+      .minute(m)
+      .second(0)
+      .millisecond(0)
+      .valueOf();
+    if (minTs !== undefined && ts < minTs) return true;
+    if (maxTs !== undefined && ts > maxTs) return true;
+    return false;
   };
 
   const disabledMatchers = [
@@ -130,12 +181,14 @@ export function DateTimePicker({
             value={hour}
             items={HOURS}
             onChange={(h) => handleTimeChange(h, minute)}
+            isDisabled={isHourDisabled}
           />
           <span className="text-control-light">:</span>
           <TimeSelect
             value={minute}
             items={MINUTES}
             onChange={(m) => handleTimeChange(hour, m)}
+            isDisabled={isMinuteDisabled}
           />
         </div>
       </PopoverContent>

--- a/frontend/src/react/components/ui/date-time-picker.tsx
+++ b/frontend/src/react/components/ui/date-time-picker.tsx
@@ -1,0 +1,144 @@
+import dayjs from "dayjs";
+import { Calendar as CalendarIcon } from "lucide-react";
+import { useState } from "react";
+import { Calendar } from "@/react/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/react/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/react/components/ui/select";
+import { cn } from "@/react/lib/utils";
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+const MINUTES = Array.from({ length: 60 }, (_, i) => i);
+const pad = (n: number) => String(n).padStart(2, "0");
+
+function TimeSelect({
+  value,
+  items,
+  onChange,
+}: {
+  value: number;
+  items: number[];
+  onChange: (value: number) => void;
+}) {
+  return (
+    <Select value={String(value)} onValueChange={(v) => onChange(Number(v))}>
+      <SelectTrigger size="sm" className="w-16 justify-center">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {items.map((item) => (
+          <SelectItem key={item} value={String(item)}>
+            {pad(item)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+/**
+ * DateTimePicker — a styled trigger that opens a Popover containing an
+ * app-themed calendar plus hour/minute selects. Replaces native
+ * `<input type="datetime-local">` for consistent look and a full-width trigger.
+ */
+export function DateTimePicker({
+  value,
+  onChange,
+  placeholder,
+  disabled,
+  minDate,
+  maxDate,
+  className,
+  displayFormat = "YYYY-MM-DD HH:mm",
+}: {
+  value: Date | undefined;
+  onChange: (value: Date | undefined) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  minDate?: Date;
+  maxDate?: Date;
+  className?: string;
+  displayFormat?: string;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const hour = value ? value.getHours() : 0;
+  const minute = value ? value.getMinutes() : 0;
+
+  const handleSelectDate = (day: Date | undefined) => {
+    if (!day) {
+      onChange(undefined);
+      return;
+    }
+    onChange(
+      dayjs(day).hour(hour).minute(minute).second(0).millisecond(0).toDate()
+    );
+  };
+
+  const handleTimeChange = (h: number, m: number) => {
+    onChange(
+      dayjs(value ?? new Date())
+        .hour(h)
+        .minute(m)
+        .second(0)
+        .millisecond(0)
+        .toDate()
+    );
+  };
+
+  const disabledMatchers = [
+    ...(minDate ? [{ before: minDate }] : []),
+    ...(maxDate ? [{ after: maxDate }] : []),
+  ];
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        disabled={disabled}
+        className={cn(
+          "inline-flex h-9 w-64 max-w-full items-center justify-between gap-2 rounded-xs border border-control-border bg-background px-3 text-sm text-control",
+          "cursor-pointer hover:bg-control-bg focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+      >
+        <span className={cn("truncate", !value && "text-control-placeholder")}>
+          {value ? dayjs(value).format(displayFormat) : (placeholder ?? "")}
+        </span>
+        <CalendarIcon className="size-4 shrink-0 text-control-light" />
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-auto p-3">
+        <Calendar
+          mode="single"
+          autoFocus
+          selected={value}
+          defaultMonth={value ?? minDate}
+          disabled={disabledMatchers.length ? disabledMatchers : undefined}
+          onSelect={handleSelectDate}
+        />
+        <div className="mt-2 flex items-center justify-center gap-1 border-t border-control-border pt-3">
+          <TimeSelect
+            value={hour}
+            items={HOURS}
+            onChange={(h) => handleTimeChange(h, minute)}
+          />
+          <span className="text-control-light">:</span>
+          <TimeSelect
+            value={minute}
+            items={MINUTES}
+            onChange={(m) => handleTimeChange(hour, m)}
+          />
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/src/react/components/ui/expiration-picker.tsx
+++ b/frontend/src/react/components/ui/expiration-picker.tsx
@@ -1,6 +1,7 @@
+import dayjs from "dayjs";
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { Input } from "@/react/components/ui/input";
+import { DateTimePicker } from "@/react/components/ui/date-time-picker";
 
 /**
  * ExpirationPicker — a datetime picker with inline clear button.
@@ -23,13 +24,13 @@ export function ExpirationPicker({
 
   return (
     <div className="flex items-center gap-x-2">
-      <Input
-        type="datetime-local"
-        className="w-64"
-        value={value ?? ""}
-        min={minDate}
-        max={maxDate}
-        onChange={(e) => onChange(e.target.value || undefined)}
+      <DateTimePicker
+        value={value ? new Date(value) : undefined}
+        minDate={minDate ? new Date(minDate) : undefined}
+        maxDate={maxDate ? new Date(maxDate) : undefined}
+        onChange={(date) =>
+          onChange(date ? dayjs(date).format("YYYY-MM-DDTHH:mm") : undefined)
+        }
       />
       {value && (
         <button

--- a/frontend/src/react/pages/project/utils/taskRolloutActionPanel.test.tsx
+++ b/frontend/src/react/pages/project/utils/taskRolloutActionPanel.test.tsx
@@ -1,6 +1,7 @@
+import dayjs from "dayjs";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   ScheduledRunTimeInput,
   TASK_ROLLOUT_ACTION_SHEET_WIDTH,
@@ -9,12 +10,6 @@ import {
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
-
-vi.mock("@/react/components/ui/input", () => ({
-  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
-    <input {...props} />
-  ),
-}));
 
 let container: HTMLDivElement;
 let root: ReturnType<typeof createRoot>;
@@ -33,23 +28,41 @@ afterEach(() => {
 });
 
 describe("ScheduledRunTimeInput", () => {
-  it("renders a compact datetime input", () => {
+  it("renders a picker trigger with the formatted value, not a native input", () => {
+    const value = new Date(2026, 5, 4, 9, 30).getTime();
     act(() => {
       root.render(
         <ScheduledRunTimeInput
           onChange={() => {}}
           placeholder="Select scheduled time"
-          value={Date.UTC(2026, 5, 4, 9, 30)}
+          value={value}
         />
       );
     });
 
-    const input = container.querySelector(
-      'input[type="datetime-local"]'
-    ) as HTMLInputElement;
+    // No native datetime-local input — it's a styled popover trigger.
+    expect(container.querySelector('input[type="datetime-local"]')).toBeNull();
 
-    expect(input.className).toContain("w-64");
-    expect(input.className).toContain("max-w-full");
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    expect(trigger).not.toBeNull();
+    expect(trigger.textContent).toContain(
+      dayjs(value).format("YYYY-MM-DD HH:mm")
+    );
+  });
+
+  it("shows the placeholder when no value is set", () => {
+    act(() => {
+      root.render(
+        <ScheduledRunTimeInput
+          onChange={() => {}}
+          placeholder="Select scheduled time"
+          value={undefined}
+        />
+      );
+    });
+
+    const trigger = container.querySelector("button") as HTMLButtonElement;
+    expect(trigger.textContent).toContain("Select scheduled time");
   });
 });
 

--- a/frontend/src/react/pages/project/utils/taskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/utils/taskRolloutActionPanel.tsx
@@ -1,5 +1,4 @@
-import { Input } from "@/react/components/ui/input";
-import { cn } from "@/react/lib/utils";
+import { DateTimePicker } from "@/react/components/ui/date-time-picker";
 
 export const TASK_ROLLOUT_ACTION_SHEET_WIDTH = "standard";
 
@@ -15,31 +14,12 @@ export function ScheduledRunTimeInput({
   value: number | undefined;
 }) {
   return (
-    <Input
-      className={cn("w-64 max-w-full", className)}
-      onChange={(event) =>
-        onChange(parseDatetimeLocalValue(event.target.value))
-      }
+    <DateTimePicker
+      className={className}
+      minDate={new Date()}
+      onChange={(date) => onChange(date ? date.getTime() : undefined)}
       placeholder={placeholder}
-      type="datetime-local"
-      value={formatDatetimeLocalValue(value)}
+      value={value === undefined ? undefined : new Date(value)}
     />
   );
-}
-
-export function formatDatetimeLocalValue(value?: number) {
-  if (value === undefined) {
-    return "";
-  }
-  const date = new Date(value);
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  return `${year}-${month}-${day}T${hours}:${minutes}`;
-}
-
-export function parseDatetimeLocalValue(value: string) {
-  return value ? new Date(value).getTime() : undefined;
 }


### PR DESCRIPTION
## What

Replaces native `<input type="datetime-local">` with a styled, app-themed date/time picker so every date/time control looks consistent — and makes the whole field the trigger (the native control only opened its picker from a tiny calendar glyph).

Closes BYT-9588.

### Changes
- **New** `ui/calendar.tsx` — shadcn-style wrapper around `react-day-picker` (v10), themed entirely with app tokens (no library CSS).
- **New** `ui/date-time-picker.tsx` — `DateTimePicker`: a full-width styled trigger → Popover with the calendar + non-native hour/minute `Select`s. Props: `value/onChange` as `Date`, `placeholder`, `minDate/maxDate`, `disabled`, `displayFormat`.
- Migrated all date/time call sites to the shared component:
  - Run-tasks scheduler (`taskRolloutActionPanel`) — the original BYT-9588 surface; added `minDate={now}`.
  - `ExpirationPicker` (also covers `RequestRoleSheet`).
  - `TimeRangePicker` — dropped its hand-rolled absolute dropdown + `document` click-outside listener in favor of the shared `Popover`; added cross-bounds between From/To. Created-at filter precision goes seconds → minutes.

No native `datetime-local` remains in the app.

## Testing
- `pnpm --dir frontend type-check` — clean
- `pnpm --dir frontend test` (`taskRolloutActionPanel`, `AccessGrantRequestDrawer`) — pass; rewrote the scheduler test to assert the picker trigger renders the formatted value instead of a native input
- `pnpm --dir frontend fix` + React layering scanner — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)