### PR TITLE
fix(frontend): show review expand action when bypassed (BYT-9538)

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1493,7 +1493,6 @@
       "deploy-description": "Bytebase will automatically create the rollout when all checks pass and the issue is approved.",
       "deploy-description-gitops": "This plan is ready to roll out. Create a rollout to deploy the linked release.",
       "hide-details": "Hide details",
-      "review-description": "Submit for review to proceed",
       "show-details": "Show details"
     },
     "plans": "Plans",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1493,7 +1493,6 @@
       "deploy-description": "Bytebase creará automáticamente el rollout cuando todas las comprobaciones pasen y el issue esté aprobado.",
       "deploy-description-gitops": "Este plan está listo para implementarse. Crea un rollout para desplegar la versión vinculada.",
       "hide-details": "Ocultar detalles",
-      "review-description": "Envíe para revisión para continuar",
       "show-details": "Mostrar detalles"
     },
     "plans": "Planes",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1493,7 +1493,6 @@
       "deploy-description": "すべてのチェックが通過し、Issue が承認されると、Bytebase は自動的にロールアウトを作成します。",
       "deploy-description-gitops": "このプランはロールアウトの準備ができています。リンクされたリリースをデプロイするにはロールアウトを作成してください。",
       "hide-details": "詳細を隠す",
-      "review-description": "続行するにはレビューに提出してください",
       "show-details": "詳細を表示"
     },
     "plans": "プラン",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1493,7 +1493,6 @@
       "deploy-description": "Bytebase sẽ tự động tạo rollout khi tất cả kiểm tra đều đạt và issue đã được phê duyệt.",
       "deploy-description-gitops": "Kế hoạch này đã sẵn sàng để triển khai. Tạo một rollout để triển khai bản phát hành được liên kết.",
       "hide-details": "Ẩn chi tiết",
-      "review-description": "Gửi để xem xét để tiếp tục",
       "show-details": "Hiển thị chi tiết"
     },
     "plans": "Kế hoạch",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1493,7 +1493,6 @@
       "deploy-description": "当所有检查都通过且工单审批完成后，Bytebase 会自动创建发布。",
       "deploy-description-gitops": "此计划已就绪，可以发布。创建一个发布以部署关联的 Release。",
       "hide-details": "隐藏详情",
-      "review-description": "提交审批以继续",
       "show-details": "显示详情"
     },
     "plans": "变更计划",

--- a/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.test.tsx
@@ -213,8 +213,11 @@ describe("ProjectPlanDetailPage", () => {
     expect(selectedSpecIdText()).toBe("spec-2");
   });
 
-  it("renders the review phase for sheet-backed plans", async () => {
-    mocks.usePlanDetailPage.mockReturnValue(buildPage());
+  it("renders the review phase for sheet-backed plans with an issue", async () => {
+    mocks.usePlanDetailPage.mockReturnValue({
+      ...buildPage(),
+      issue: { name: "projects/foo/issues/1" },
+    } as unknown as PlanDetailPageState);
 
     await act(async () => {
       root.render(
@@ -228,6 +231,23 @@ describe("ProjectPlanDetailPage", () => {
     });
 
     expect(container.textContent).toContain("plan.navigator.review");
+  });
+
+  it("hides the review phase when there is no issue", async () => {
+    mocks.usePlanDetailPage.mockReturnValue(buildPage());
+
+    await act(async () => {
+      root.render(
+        <ProjectPlanDetailPage
+          planId="create"
+          projectId="foo"
+          specId="spec-1"
+        />
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).not.toContain("plan.navigator.review");
   });
 
   it("hides the review phase for GitOps plans with release-backed specs", async () => {

--- a/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
+++ b/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
@@ -30,16 +30,24 @@ import { PlanReviewSection } from "./components/review/PlanReviewSection";
 import { PlanDetailStoreProvider } from "./shared/stores/PlanDetailStoreProvider";
 import { INLINE_TASK_PANEL_BREAKPOINT_PX } from "./shell/constants";
 import { usePlanDetailPage } from "./shell/hooks/usePlanDetailPage";
-import {
-  PlanDetailProvider,
-  usePlanDetailContext,
-} from "./shell/PlanDetailContext";
+import { PlanDetailProvider } from "./shell/PlanDetailContext";
 import {
   buildChangesSummary,
   buildDeploySummary,
   buildReviewSummary,
 } from "./utils/phaseSummary";
 import { isReleaseBackedPlan } from "./utils/spec";
+
+type PhaseStatus = "completed" | "closed" | "active" | "future";
+
+function phaseLineClass(from: PhaseStatus, to: PhaseStatus): string {
+  if (from === "closed" || to === "closed")
+    return "border-l-2 border-dashed border-control-border";
+  if (from === "completed" && (to === "completed" || to === "active"))
+    return "border-l-2 border-success";
+  if (from === "active") return "border-l-2 border-dashed border-accent";
+  return "border-l-2 border-dashed border-control-border";
+}
 
 export function ProjectPlanDetailPage(props: {
   projectId: string;
@@ -118,6 +126,7 @@ function ProjectPlanDetailPageInner({
     () => isReleaseBackedPlan(page.plan.specs),
     [page.plan.specs]
   );
+  const reviewVisible = !isGitOpsPlan && !!page.issue;
 
   const phaseConfigs = useMemo(() => {
     const hasIssue = !!page.issue;
@@ -134,7 +143,7 @@ function ProjectPlanDetailPageInner({
           task.status === Task_Status.SKIPPED
       );
 
-    let review: "completed" | "closed" | "active" | "future" = "future";
+    let review: PhaseStatus = "future";
     if (hasIssue) {
       if (page.issue?.status === IssueStatus.CANCELED) {
         review = "closed";
@@ -143,12 +152,15 @@ function ProjectPlanDetailPageInner({
       }
     }
 
-    const changesStatus: "completed" | "closed" | "active" | "future" =
+    const changesStatus: PhaseStatus =
       page.isCreating || (!isGitOpsPlan && !hasIssue && !hasRollout)
         ? "active"
         : "completed";
-    const deployStatus: "completed" | "closed" | "active" | "future" =
-      hasRollout ? (allDone ? "completed" : "active") : "future";
+    const deployStatus: PhaseStatus = hasRollout
+      ? allDone
+        ? "completed"
+        : "active"
+      : "future";
 
     const changesBadge =
       changesStatus === "active" && !page.isCreating
@@ -192,33 +204,19 @@ function ProjectPlanDetailPageInner({
       return { label: t("common.not-started"), variant: "default" as const };
     })();
 
-    const lineClass = (
-      from: "completed" | "closed" | "active" | "future",
-      to: "completed" | "closed" | "active" | "future"
-    ) => {
-      if (from === "closed" || to === "closed")
-        return "border-l-2 border-dashed border-control-border";
-      if (from === "completed" && to === "completed")
-        return "border-l-2 border-success";
-      if (from === "completed" && to === "active")
-        return "border-l-2 border-success";
-      if (from === "active") return "border-l-2 border-dashed border-accent";
-      return "border-l-2 border-dashed border-control-border";
-    };
-
     return {
       changes: {
         status: changesStatus,
         badge: changesBadge,
-        lineClass: lineClass(
+        lineClass: phaseLineClass(
           changesStatus,
-          isGitOpsPlan ? deployStatus : review
+          reviewVisible ? review : deployStatus
         ),
       },
       review: {
         status: review,
         badge: reviewBadge,
-        lineClass: lineClass(review, deployStatus),
+        lineClass: phaseLineClass(review, deployStatus),
       },
       deploy: {
         status: deployStatus,
@@ -226,7 +224,14 @@ function ProjectPlanDetailPageInner({
         lineClass: "",
       },
     };
-  }, [isGitOpsPlan, page.isCreating, page.issue, page.rollout, t]);
+  }, [
+    isGitOpsPlan,
+    page.isCreating,
+    page.issue,
+    page.rollout,
+    reviewVisible,
+    t,
+  ]);
 
   // Mirror the URL specId into local state. We deliberately don't include
   // selectedSpecId in the deps — children (e.g. PlanDetailChangesBranch) may
@@ -284,7 +289,7 @@ function ProjectPlanDetailPageInner({
                   />
                 </PhaseSection>
 
-                {!isGitOpsPlan && (
+                {reviewVisible && (
                   <PhaseSection
                     badge={phaseConfigs.review.badge}
                     expanded={page.activePhases.has("review")}
@@ -295,13 +300,8 @@ function ProjectPlanDetailPageInner({
                     status={phaseConfigs.review.status}
                     onToggle={() => page.togglePhase("review")}
                     summary={buildReviewSummary(page.issue, t)}
-                    future={
-                      <p className="mt-0.5 text-sm text-control-placeholder">
-                        {t("plan.phase.review-description")}
-                      </p>
-                    }
                   >
-                    <ReviewBranch />
+                    <PlanReviewSection />
                   </PhaseSection>
                 )}
 
@@ -436,7 +436,7 @@ function PhaseSection({
   future?: ReactNode;
   isLast?: boolean;
   expanded: boolean;
-  status: "completed" | "closed" | "active" | "future";
+  status: PhaseStatus;
   summary?: string;
   children: ReactNode;
   onToggle: () => void;
@@ -490,7 +490,7 @@ function PhaseSection({
               {badge && <Badge variant={badge.variant}>{badge.label}</Badge>}
               <div className="flex-1" />
               <span className="shrink-0 text-[11px] text-control-placeholder">
-                {summary ? t("plan.phase.show-details") : ""}
+                {t("plan.phase.show-details")}
               </span>
             </div>
             {summary && (
@@ -518,21 +518,6 @@ function PhaseSection({
       </div>
     </div>
   );
-}
-
-function ReviewBranch() {
-  const { t } = useTranslation();
-  const page = usePlanDetailContext();
-
-  if (!page.issue) {
-    return (
-      <div className="p-4 text-sm text-control-light">
-        {t("common.no-data")}
-      </div>
-    );
-  }
-
-  return <PlanReviewSection />;
 }
 
 function DesktopColumn({


### PR DESCRIPTION
## What

In the plan detail page's review section, the **"show more"** expand action disappeared whenever the review summary was empty — which is exactly what happens when the review is **Bypassed**. The section was still expandable, but the user had no affordance to expand it.

This makes the display logic simple and explicit:
- **Always** show the expand hint on a collapsed phase section (every section is expandable).
- Render the review section **only when an issue exists** — the single case where it's hidden entirely (no more "future" placeholder when there's no issue).

## Cleanup

While in the file, simplified the surrounding phase logic (no behavior change):
- A single `reviewVisible` flag now drives both the render guard and the changes→next-node connector, removing a double-negative condition that was duplicated in two places.
- Extracted the repeated 4-member status union into a named `PhaseStatus` type.
- Hoisted the line-class helper to a module-level pure function and merged its two identical branches.
- Removed the now-dead `!issue` guard inside `ReviewBranch` (unreachable once the section is gated on `reviewVisible`); inlined `<PlanReviewSection />`.

## Testing

- `pnpm --dir frontend type-check` ✅
- `pnpm --dir frontend test ProjectPlanDetailPage` — 4 passed ✅ (updated the "renders review for sheet-backed plans" test to include an issue, added a "hides review when no issue" test)
- `pnpm --dir frontend fix` — clean ✅

Closes BYT-9538

🤖 Generated with [Claude Code](https://claude.com/claude-code)