### PR TITLE
chore: bump omni for Oracle remark splitter

### DIFF
--- a/backend/plugin/parser/plsql/omni_test.go
+++ b/backend/plugin/parser/plsql/omni_test.go
@@ -86,6 +86,25 @@ SPOOL OFF
 	require.IsType(t, &ast.CreateTriggerStmt{}, second.Stmt)
 }
 
+func TestParsePLSQLOmniKeepsRemarkColumnInCreateTable(t *testing.T) {
+	list, err := ParsePLSQLOmni(`
+CREATE TABLE parser_regression_remark_column (
+  id                  NUMBER NOT NULL
+      CONSTRAINT parser_regression_remark_column_pk
+          PRIMARY KEY,
+  display_name        VARCHAR2(100),
+  source              VARCHAR2(100),
+  remark              VARCHAR2(100)
+)`)
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	require.Len(t, list.Items, 1)
+
+	raw, ok := list.Items[0].(*ast.RawStmt)
+	require.True(t, ok)
+	require.IsType(t, &ast.CreateTableStmt{}, raw.Stmt)
+}
+
 func TestParsePLSQLOmniMatchRecognize(t *testing.T) {
 	statement := `SELECT * FROM TRADES MATCH_RECOGNIZE (
   PARTITION BY ACCOUNT_ID

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260616095434-7e1369f4045a
+	github.com/bytebase/omni v0.0.0-20260618025236-cf4c9b844d52
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260616095434-7e1369f4045a h1:X0mpevdOyNtq4u3Lkv+SqtZ9HjeOlY59eAXG9Vssaq8=
-github.com/bytebase/omni v0.0.0-20260616095434-7e1369f4045a/go.mod h1:EVG8nQbNPUnUBGKn6J0niSGOs3jgfKo3TciY22R4bfo=
+github.com/bytebase/omni v0.0.0-20260618025236-cf4c9b844d52 h1:4P+GLe/f5JJOU2wwDlGoWI5ve64OyQcTqnHGyqgbhKM=
+github.com/bytebase/omni v0.0.0-20260618025236-cf4c9b844d52/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Bump `github.com/bytebase/omni` to `v0.0.0-20260618025236-cf4c9b844d52`.
- Add a synthetic Oracle `CREATE TABLE` regression test for a column line beginning with `remark` so Bytebase keeps the DDL as one statement instead of treating it as SQL*Plus `REM/REMARK`.

## Test Plan
- [x] `go test -v -count=1 ./backend/plugin/parser/plsql -run '^TestParsePLSQLOmniKeepsRemarkColumnInCreateTable$'`
- [x] `go test -v -count=1 ./backend/plugin/parser/plsql`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
