### PR TITLE
fix: populate check release risk level

### DIFF
--- a/backend/api/v1/release_service_check.go
+++ b/backend/api/v1/release_service_check.go
@@ -368,7 +368,11 @@ loop:
 				}
 				if summaryReport != nil {
 					checkResult.AffectedRows = summaryReport.AffectedRows
+					checkResult.RiskLevel = getRiskLevelFromStatementTypes(summaryReport.StatementTypes)
 					resp.AffectedRows += summaryReport.AffectedRows
+					if checkResult.RiskLevel > resp.RiskLevel {
+						resp.RiskLevel = checkResult.RiskLevel
+					}
 				}
 				if common.EngineSupportSQLReview(engine) {
 					adviceStatus, sqlReviewAdvices, err := s.runSQLReviewCheckForFile(ctx, project, originMetadata, finalMetadata, instance, database, statement)
@@ -697,6 +701,23 @@ func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v
 	return &v1pb.CheckReleaseResponse{
 		Results: results,
 	}, nil
+}
+
+func getRiskLevelFromStatementTypes(statementTypes []storepb.StatementType) v1pb.RiskLevel {
+	statementTypeStrings := make([]string, 0, len(statementTypes))
+	for _, statementType := range statementTypes {
+		statementTypeStrings = append(statementTypeStrings, statementType.String())
+	}
+	switch common.GetRiskLevelFromStatementTypes(statementTypeStrings) {
+	case storepb.RiskLevel_LOW:
+		return v1pb.RiskLevel_LOW
+	case storepb.RiskLevel_MODERATE:
+		return v1pb.RiskLevel_MODERATE
+	case storepb.RiskLevel_HIGH:
+		return v1pb.RiskLevel_HIGH
+	default:
+		return v1pb.RiskLevel_RISK_LEVEL_UNSPECIFIED
+	}
 }
 
 func (s *ReleaseService) runSQLReviewCheckForFile(

--- a/backend/tests/gitops_test.go
+++ b/backend/tests/gitops_test.go
@@ -154,6 +154,49 @@ func TestGitOpsCheck(t *testing.T) {
 	a.Equal(2, checkedTargets[fmt.Sprintf("%s/databases/%s", prodInstance.Name, databaseName)])
 }
 
+func TestGitOpsCheckReleaseRiskLevel(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	database, pgContainer := ctl.createTestPostgreSQLDatabase(ctx, t)
+	defer pgContainer.Close(ctx)
+
+	setupSheet, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet: &v1pb.Sheet{
+			Content: []byte("CREATE TABLE public.risk_check_target (id INTEGER PRIMARY KEY);"),
+		},
+	}))
+	a.NoError(err)
+	a.NoError(ctl.changeDatabase(ctx, ctl.project, database, setupSheet.Msg, false))
+
+	release := &v1pb.Release{
+		Type: v1pb.Release_VERSIONED,
+		Files: []*v1pb.Release_File{
+			{
+				Path:      "migrations/002__drop_risk_check_target.sql",
+				Version:   "002",
+				Statement: []byte("DROP TABLE public.risk_check_target;"),
+			},
+		},
+	}
+
+	checkResp, err := ctl.releaseServiceClient.CheckRelease(ctx, connect.NewRequest(&v1pb.CheckReleaseRequest{
+		Parent:  ctl.project.Name,
+		Release: release,
+		Targets: []string{database.Name},
+	}))
+	a.NoError(err)
+	a.Len(checkResp.Msg.Results, 1)
+	a.Equal(v1pb.RiskLevel_HIGH, checkResp.Msg.Results[0].RiskLevel)
+	a.Equal(v1pb.RiskLevel_HIGH, checkResp.Msg.RiskLevel)
+}
+
 func TestGitOpsCheckReleaseVCSUserTracking(t *testing.T) {
 	t.Parallel()
 	a := require.New(t)


### PR DESCRIPTION
## Summary
- populate per-result and aggregate risk level in CheckRelease responses from SQL summary statement types
- add a GitOps regression test covering a high-risk DROP TABLE release check

## Root Cause
`CheckRelease` already collected statement types through the SQL summary report, but only copied affected rows into the API response. The risk fields remained unspecified, so bytebase-action displayed `None`.

## Test Plan
- go test -v -count=1 ./backend/tests -run ^TestGitOpsCheckReleaseRiskLevel$ -timeout 5m
- go test -v -count=1 ./backend/tests -run ^TestGitOpsCheck$ -timeout 5m
- go test -v -count=1 ./backend/common -run ^TestGetRiskLevelFromStatementTypes$
- go test -v -count=1 ./backend/api/v1 -run TestNonExistent
- golangci-lint run --allow-parallel-runners
- golangci-lint run --fix --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
- git diff --check

Closes BYT-9744
