### PR TITLE
fix(pg): treat MERGE in a CTE as a write to close a data-masking bypass

### DIFF
--- a/backend/common/testcontainer/testcontainer.go
+++ b/backend/common/testcontainer/testcontainer.go
@@ -101,10 +101,20 @@ func GetTestMySQLContainer(ctx context.Context) (retc *Container, retErr error) 
 	}, nil
 }
 
-// GetPgContainer creates a PostgreSQL container for testing
-func GetPgContainer(ctx context.Context) (retC *Container, retErr error) {
+// GetPgContainer creates a PostgreSQL 16 container for testing.
+func GetPgContainer(ctx context.Context) (*Container, error) {
+	return getPgContainerWithImage(ctx, "postgres:16-alpine")
+}
+
+// GetPg17Container creates a PostgreSQL 17 container for testing. PG17 is required
+// for features absent in 16 — notably MERGE ... RETURNING.
+func GetPg17Container(ctx context.Context) (*Container, error) {
+	return getPgContainerWithImage(ctx, "postgres:17-alpine")
+}
+
+func getPgContainerWithImage(ctx context.Context, image string) (retC *Container, retErr error) {
 	req := testcontainers.ContainerRequest{
-		Image: "postgres:16-alpine",
+		Image: image,
 		Env: map[string]string{
 			"LANG":              "en_US.UTF-8",
 			"POSTGRES_PASSWORD": "root-password",
@@ -181,6 +191,17 @@ func GetTestPgContainer(ctx context.Context, t testing.TB) *Container {
 	container, err := GetPgContainer(ctx)
 	if err != nil {
 		t.Fatalf("failed to create PostgreSQL container: %v", err)
+	}
+	return container
+}
+
+// GetTestPg17Container creates a PostgreSQL 17 container for testing, failing the
+// test on error.
+func GetTestPg17Container(ctx context.Context, t testing.TB) *Container {
+	t.Helper()
+	container, err := GetPg17Container(ctx)
+	if err != nil {
+		t.Fatalf("failed to create PostgreSQL 17 container: %v", err)
 	}
 	return container
 }

--- a/backend/plugin/db/pg/query_merge_cte_test.go
+++ b/backend/plugin/db/pg/query_merge_cte_test.go
@@ -1,0 +1,93 @@
+package pg
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/plugin/db"
+)
+
+// TestQueryConnMergeCTEDoesNotLeakRows is a security regression test for the
+// PostgreSQL data-masking bypass where a MERGE smuggled into a data-modifying CTE
+//
+//	WITH x AS (MERGE ... RETURNING masked_col) SELECT masked_col FROM x
+//
+// was misclassified as a read-only query (hasDMLInTree did not recognise MergeStmt
+// as a write). That routed it through QueryConn's row-returning QueryContext path,
+// so the RETURNING columns came back to the client and — because the query-span
+// extractor cannot trace lineage through a MERGE — were returned UNMASKED.
+//
+// The fix classifies MERGE as a write, so the editor routes the statement to
+// ExecContext, which discards the RETURNING rows. This test asserts the
+// security-relevant outcome at the driver boundary: the MERGE-CTE must NOT return
+// the secret value as data rows. MERGE ... RETURNING requires PostgreSQL 17.
+func TestQueryConnMergeCTEDoesNotLeakRows(t *testing.T) {
+	ctx := context.Background()
+
+	pgContainer := testcontainer.GetTestPg17Container(ctx, t)
+	defer pgContainer.Close(ctx)
+
+	const secret = "TOP-SECRET-SSN-123-45-6789"
+	rawDB := pgContainer.GetDB()
+	require.NoError(t, rawDB.Ping())
+	_, err := rawDB.ExecContext(ctx, `CREATE TABLE secret_doc (id int PRIMARY KEY, secret text);`)
+	require.NoError(t, err)
+	_, err = rawDB.ExecContext(ctx, `INSERT INTO secret_doc VALUES (1, '`+secret+`');`)
+	require.NoError(t, err)
+
+	driver, err := (&Driver{}).Open(ctx, storepb.Engine_POSTGRES, db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Host:     pgContainer.GetHost(),
+			Port:     pgContainer.GetPort(),
+			Username: "postgres",
+		},
+		Password:          "root-password",
+		ConnectionContext: db.ConnectionContext{DatabaseName: "postgres"},
+	})
+	require.NoError(t, err)
+	defer driver.Close(ctx)
+
+	conn, err := driver.GetDB().Conn(ctx)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Baseline: a plain SELECT returns the secret as a data row. This proves the
+	// harness actually surfaces row data, so the negative assertion below is meaningful.
+	selectResults, err := driver.QueryConn(ctx, conn, `SELECT secret FROM secret_doc`, db.QueryContext{Limit: 5000, MaximumSQLResultSize: 1 << 30})
+	require.NoError(t, err)
+	require.True(t, resultsContainValue(selectResults, secret),
+		"baseline plain SELECT should return the secret as a data row")
+
+	// Exploit attempt: a MERGE smuggled into a data-modifying CTE. After the fix it
+	// is classified as a write and routed to Exec, so the RETURNING rows are dropped
+	// and the secret is never returned as data.
+	const mergeCTE = `WITH x AS (
+		MERGE INTO secret_doc t USING secret_doc s ON t.id = s.id
+		WHEN MATCHED THEN UPDATE SET id = t.id
+		RETURNING t.secret AS secret
+	) SELECT secret FROM x`
+	mergeResults, err := driver.QueryConn(ctx, conn, mergeCTE, db.QueryContext{Limit: 5000, MaximumSQLResultSize: 1 << 30})
+	require.NoError(t, err)
+	require.False(t, resultsContainValue(mergeResults, secret),
+		"SECURITY: MERGE-in-CTE must not return the masked column as data rows; got %v", mergeResults)
+}
+
+// resultsContainValue reports whether any string cell in the results contains want.
+func resultsContainValue(results []*v1pb.QueryResult, want string) bool {
+	for _, r := range results {
+		for _, row := range r.GetRows() {
+			for _, v := range row.GetValues() {
+				if sv, ok := v.GetKind().(*v1pb.RowValue_StringValue); ok && strings.Contains(sv.StringValue, want) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/backend/plugin/parser/pg/query_antlr.go
+++ b/backend/plugin/parser/pg/query_antlr.go
@@ -15,7 +15,7 @@ import (
 // 1. Allow: SELECT statements
 // 2. Allow: EXPLAIN statements (but not EXPLAIN ANALYZE for non-SELECT)
 // 3. Allow: SHOW/SET statements (SET is considered executable)
-// 4. Allow: CTEs with only SELECT (reject CTEs with INSERT/UPDATE/DELETE)
+// 4. Allow: CTEs with only SELECT (reject CTEs with INSERT/UPDATE/DELETE/MERGE)
 // 5. Reject: All other statements (DDL, DML except SELECT)
 func validateQueryANTLR(statement string) (bool, bool, error) {
 	stmts, err := ParsePg(statement)
@@ -82,7 +82,12 @@ func isExplainAnalyze(n *ast.ExplainStmt) bool {
 	return false
 }
 
-// hasDMLInTree walks the AST tree and returns true if any INSERT/UPDATE/DELETE is found.
+// hasDMLInTree walks the AST tree and returns true if any INSERT/UPDATE/DELETE/MERGE
+// is found. MERGE is included so a data-modifying MERGE smuggled into a CTE
+// (e.g. WITH x AS (MERGE ... RETURNING col) SELECT col FROM x) is classified as a
+// write: this keeps the set aligned with classifyQueryType (query_type.go) and
+// stops the editor from taking the row-returning read path for it, which would
+// otherwise return masked columns unmasked.
 func hasDMLInTree(node ast.Node) bool {
 	found := false
 	ast.Inspect(node, func(n ast.Node) bool {
@@ -90,7 +95,7 @@ func hasDMLInTree(node ast.Node) bool {
 			return false
 		}
 		switch n.(type) {
-		case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt:
+		case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt, *ast.MergeStmt:
 			found = true
 			return false
 		}

--- a/backend/plugin/parser/pg/query_test.go
+++ b/backend/plugin/parser/pg/query_test.go
@@ -75,6 +75,23 @@ func TestValidateSQLForEditor(t *testing.T) {
 			allQuery: false,
 		},
 		{
+			// Security regression: a MERGE smuggled into a data-modifying CTE must
+			// be treated as a write (not read-only), so the editor routes it to Exec
+			// (RETURNING rows discarded) and export rejects it. Before the fix,
+			// hasDMLInTree missed MergeStmt, so this took the read path and returned
+			// masked columns unmasked.
+			sql:      `WITH x AS (MERGE INTO t a USING t b ON a.id = b.id WHEN MATCHED THEN UPDATE SET id = a.id RETURNING a.secret) SELECT secret FROM x`,
+			valid:    false,
+			allQuery: false,
+		},
+		{
+			// Top-level MERGE ... RETURNING is already blocked by the default case;
+			// pin it so the classifier sets stay aligned.
+			sql:      `MERGE INTO t a USING t b ON a.id = b.id WHEN MATCHED THEN UPDATE SET id = a.id RETURNING a.secret`,
+			valid:    false,
+			allQuery: false,
+		},
+		{
 			sql:      "select * from t where a = 'klasjdfkljsa$tag$; -- lkjdlkfajslkdfj'",
 			valid:    true,
 			allQuery: true,


### PR DESCRIPTION
## What

A `MERGE` inside a data-modifying CTE — `WITH x AS (MERGE ... RETURNING col) SELECT col FROM x` — was classified as read-only by `validateQueryANTLR`, because `hasDMLInTree` recognised only `INSERT`/`UPDATE`/`DELETE`, not `MERGE`. The SQL Editor then took the row-returning read path, and since the query-span extractor can't trace lineage through a `MERGE`, a write-permitted, masking-subject user received the masked column **unmasked**. The same misclassification let the statement pass the export read-only gate.

`classifyQueryType` (query_type.go) already treats `MergeStmt` as DML; this aligns `hasDMLInTree` with it. The single change routes the statement to `Exec` (rows discarded) on the query path and rejects it as non-read-only on export — closing both vectors.

## Scope

- Confirmed against **PostgreSQL 17** (a masking-subject user read a masked column in plaintext).
- Exposure requires **PostgreSQL 17+** (`MERGE ... RETURNING`) or **CockroachDB** (shares this validator), masking configured, and a **write-permitted, masking-subject** user. Plain `INSERT/UPDATE/DELETE ... RETURNING` were never exploitable — already classified as writes.
- Backport candidate for supported releases that have the omni pg query-span + new-ACL query path.

## Behavior change

A `MERGE`-in-CTE statement in the SQL Editor now returns an affected-rows result (instead of RETURNING rows) and is rejected on export, matching how the other DML-in-CTE forms already behave. Not labeled breaking: it restores intended masking/read-only behavior for an exotic, PG17-only statement.

## Tests

- **Unit** (`query_test.go`): `validateQueryANTLR` classifies a MERGE-CTE as non-read-only / non-allQuery (plus a top-level `MERGE ... RETURNING` pin).
- **e2e** (`query_merge_cte_test.go`, `postgres:17` container): `QueryConn` on the MERGE-CTE returns no secret rows. Verified RED→GREEN — reverting the fix returns the plaintext secret.

## Follow-ups (separate ticket, not this PR)

- **Span-layer backstop**: if a row-returning statement is an untraceable write, fail closed — catches the next statement type added and forgotten (the durable class fix).
- **`SELECT INTO` alignment**: `validateQueryANTLR` treats `SELECT ... INTO t` as read-only while `classifyQueryType` calls it DDL. Not a masking exfil (returns no rows), but a read-only-enforcement nit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)