### PR TITLE
feat(mariadb): carve out Diagnose to omni/mariadb parser

### DIFF
--- a/backend/component/sheet/sheet.go
+++ b/backend/component/sheet/sheet.go
@@ -13,6 +13,7 @@ import (
 	// Import parsers to register their parse functions.
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/cockroachdb"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/doris"
+	_ "github.com/bytebase/bytebase/backend/plugin/parser/mariadb"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/partiql"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/plsql"

--- a/backend/plugin/parser/mariadb/diagnose.go
+++ b/backend/plugin/parser/mariadb/diagnose.go
@@ -1,4 +1,4 @@
-package mysql
+package mariadb
 
 import (
 	"context"
@@ -6,21 +6,19 @@ import (
 	"strings"
 	"unicode"
 
-	mysqlomniparser "github.com/bytebase/omni/mysql/parser"
+	mariadbomniparser "github.com/bytebase/omni/mariadb/parser"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
 func init() {
-	base.RegisterDiagnoseFunc(storepb.Engine_MYSQL, Diagnose)
-	base.RegisterDiagnoseFunc(storepb.Engine_OCEANBASE, Diagnose)
-	base.RegisterDiagnoseFunc(storepb.Engine_CLICKHOUSE, Diagnose)
+	base.RegisterDiagnoseFunc(storepb.Engine_MARIADB, Diagnose)
 }
 
 func Diagnose(_ context.Context, _ base.DiagnoseContext, statement string) ([]base.Diagnostic, error) {
 	diagnostics := make([]base.Diagnostic, 0)
-	syntaxError := parseMySQLStatement(statement)
+	syntaxError := parseMariaDBStatement(statement)
 	if syntaxError != nil {
 		diagnostics = append(diagnostics, base.ConvertSyntaxErrorToDiagnostic(syntaxError, statement))
 	}
@@ -28,7 +26,7 @@ func Diagnose(_ context.Context, _ base.DiagnoseContext, statement string) ([]ba
 	return diagnostics, nil
 }
 
-func parseMySQLStatement(statement string) *base.SyntaxError {
+func parseMariaDBStatement(statement string) *base.SyntaxError {
 	trimmedStatement := strings.TrimRightFunc(statement, unicode.IsSpace)
 	if len(trimmedStatement) > 0 && !strings.HasSuffix(trimmedStatement, ";") {
 		// Add a semicolon to the end of the statement to allow users to omit the semicolon
@@ -36,12 +34,12 @@ func parseMySQLStatement(statement string) *base.SyntaxError {
 		statement += ";"
 	}
 
-	_, err := ParseMySQLOmni(statement)
+	_, err := ParseMariaDBOmni(statement)
 	if err == nil {
 		return nil
 	}
 
-	var parseErr *mysqlomniparser.ParseError
+	var parseErr *mariadbomniparser.ParseError
 	if !errors.As(err, &parseErr) {
 		return &base.SyntaxError{
 			Position: &storepb.Position{Line: 1, Column: 1},

--- a/backend/plugin/parser/mariadb/diagnose_e2e_test.go
+++ b/backend/plugin/parser/mariadb/diagnose_e2e_test.go
@@ -1,0 +1,48 @@
+package mariadb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/plugin/parser/mysql"
+)
+
+// mariaDBOnlySQL are statements valid in MariaDB but rejected by the omni/mysql
+// parser that backed Engine_MARIADB before this carve-out: SEQUENCE objects,
+// NEXT VALUE FOR, and RETURNING on INSERT/REPLACE/DELETE.
+var mariaDBOnlySQL = []string{
+	"CREATE SEQUENCE s",
+	"INSERT INTO t (id) VALUES (1) RETURNING id",
+	"REPLACE INTO t (id) VALUES (1) RETURNING id",
+	"DELETE FROM t RETURNING id",
+	"SELECT NEXT VALUE FOR s",
+}
+
+// TestMariaDBDiagnoseKeystone is the carve-out keystone. Before the re-point,
+// Engine_MARIADB Diagnose ran through omni/mysql and reported a *false* syntax
+// error on MariaDB-only SQL. After re-pointing to omni/mariadb it parses cleanly.
+// The test contrasts both backends so the green state can't be accidental: the
+// mysql backend must still flag these (the bug), the mariadb backend must not.
+func TestMariaDBDiagnoseKeystone(t *testing.T) {
+	ctx := context.Background()
+	for _, stmt := range mariaDBOnlySQL {
+		// RED baseline: the old omni/mysql backend reports a false syntax error.
+		mysqlDiags, err := mysql.Diagnose(ctx, base.DiagnoseContext{}, stmt)
+		require.NoError(t, err)
+		require.NotEmpty(t, mysqlDiags, "omni/mysql should still (wrongly) flag %q — the false error being fixed", stmt)
+
+		// GREEN: the omni/mariadb backend accepts it (no diagnostics).
+		mariadbDiags, err := Diagnose(ctx, base.DiagnoseContext{}, stmt)
+		require.NoError(t, err)
+		require.Empty(t, mariadbDiags, "omni/mariadb should accept %q with no diagnostic", stmt)
+	}
+
+	// Diagnose must still report a genuine syntax error — proving it actually
+	// validates, not just "returns empty".
+	badDiags, err := Diagnose(ctx, base.DiagnoseContext{}, "SELECT FROM WHERE )(")
+	require.NoError(t, err)
+	require.NotEmpty(t, badDiags, "a real syntax error must still be reported")
+}

--- a/backend/plugin/parser/mariadb/omni.go
+++ b/backend/plugin/parser/mariadb/omni.go
@@ -1,0 +1,42 @@
+package mariadb
+
+import (
+	"unicode/utf8"
+
+	"github.com/bytebase/omni/mariadb/ast"
+	mariadbparser "github.com/bytebase/omni/mariadb/parser"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+// ParseMariaDBOmni parses SQL using omni's MariaDB parser and returns an ast.List.
+func ParseMariaDBOmni(sql string) (*ast.List, error) {
+	return mariadbparser.Parse(sql)
+}
+
+// ByteOffsetToRunePosition converts a byte offset in sql to a 1-based line:column
+// where column is measured in Unicode code points (runes), matching storepb.Position semantics.
+func ByteOffsetToRunePosition(sql string, byteOffset int) *storepb.Position {
+	if byteOffset > len(sql) {
+		byteOffset = len(sql)
+	}
+
+	line := int32(1)
+	runeCol := int32(0) // 0-based rune count on current line
+	i := 0
+	for i < byteOffset {
+		r, size := utf8.DecodeRuneInString(sql[i:])
+		if r == '\n' {
+			line++
+			runeCol = 0
+		} else {
+			runeCol++
+		}
+		i += size
+	}
+
+	return &storepb.Position{
+		Line:   line,
+		Column: runeCol + 1, // convert to 1-based
+	}
+}

--- a/backend/server/ultimate.go
+++ b/backend/server/ultimate.go
@@ -31,6 +31,7 @@ import (
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/cosmosdb"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/doris"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/elasticsearch"
+	_ "github.com/bytebase/bytebase/backend/plugin/parser/mariadb"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/mongodb"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
 	_ "github.com/bytebase/bytebase/backend/plugin/parser/partiql"

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260618025236-cf4c9b844d52
+	github.com/bytebase/omni v0.0.0-20260618070256-8f57f04f5aa2
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260618025236-cf4c9b844d52 h1:4P+GLe/f5JJOU2wwDlGoWI5ve64OyQcTqnHGyqgbhKM=
-github.com/bytebase/omni v0.0.0-20260618025236-cf4c9b844d52/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260618070256-8f57f04f5aa2 h1:DHoqAOglW5+OyeKujkZamgwKidFMSiQANICOofJ0bWA=
+github.com/bytebase/omni v0.0.0-20260618070256-8f57f04f5aa2/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=

--- a/go.sum
+++ b/go.sum
@@ -954,6 +954,8 @@ github.com/stripe/stripe-go/v85 v85.1.0 h1:MywWUmgw9M7cnwFFch9cyLmRZuAiYM5cZ27Jx
 github.com/stripe/stripe-go/v85 v85.1.0/go.mod h1:5P+HGFenpWgak27T5Is6JMsmDfUC1yJnjhhmquz7kXw=
 github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44XtK+qhjat1nI9cneBbUY=
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
+github.com/testcontainers/testcontainers-go/modules/mariadb v0.41.0 h1:t0J/TOgzTKCO+7Pc7wE6ITJXGCZFufisuokOWYVzNaQ=
+github.com/testcontainers/testcontainers-go/modules/mariadb v0.41.0/go.mod h1:ELA34/aGm5oXG0g9OkPVWmIsw+BDdeybr7wk8i+TQCg=
 github.com/testcontainers/testcontainers-go/modules/mongodb v0.40.0 h1:z/1qHeliTLDKNaJ7uOHOx1FjwghbcbYfga4dTFkF0hU=
 github.com/testcontainers/testcontainers-go/modules/mongodb v0.40.0/go.mod h1:GaunAWwMXLtsMKG3xn2HYIBDbKddGArfcGsF2Aog81E=
 github.com/testcontainers/testcontainers-go/modules/mssql v0.41.0 h1:YAuSa+IMTn0nA6iNvSAFgJEeJsQWSghFWu0ubebWXJI=


### PR DESCRIPTION
## What

`Engine_MARIADB` Diagnose (the SQL-editor syntax-error underliner) ran through the omni/mysql parser, which rejects MariaDB-only SQL — SEQUENCE objects, `NEXT VALUE FOR`, and `RETURNING` on INSERT/REPLACE/DELETE — as a **false syntax error**. Valid MariaDB statements were underlined as errors in the editor.

This forks the omni-backed Diagnose slice into a new `parser/mariadb` package on the omni/mariadb parser (omni #316 sequences + #317 RETURNING), registers `Engine_MARIADB` Diagnose there, drops it from `parser/mysql`, and blank-imports the new package. Mirrors the StarRocks PR1 carve-out shape (#20562).

## Scope — Diagnose only

`Engine_MARIADB` **GetQuerySpan stays on `parser/mysql`**. Its re-point is deferred to bundle with the two things it needs to deliver editor value:
- the read-only query **validator** re-point (still omni/mysql, so it rejects MariaDB-only syntax *before* GetQuerySpan is reached — a query-span re-point alone delivers no editor value today), and
- omni/mariadb **extractor support** for the new sequence node (`*ast.NextValueForExpr`), which the mysql-inherited extractor doesn't handle.

The other MARIADB capabilities (split, resource-change, parse-statements, statement-types, query-validator, completion, backup, restore) also stay on `parser/mysql` until follow-ups.

## Behavior change (not breaking)

MARIADB Diagnose now uses omni/mariadb: sequences / `NEXT VALUE FOR` / `RETURNING` are no longer flagged as syntax errors. This restores correct behavior (the flags were false), so it is not labeled breaking.

## Masking

Unaffected. Diagnose does not touch the query/export masking path, and the read-only validator — a whitelist, still on omni/mysql — rejects MariaDB-only writes/`RETURNING` before any span/masking work.

## Tests

`TestMariaDBDiagnoseKeystone` contrasts both backends so green can't be accidental: omni/mysql still (wrongly) flags all five MariaDB-only constructs; omni/mariadb accepts them; a genuine syntax error is still reported.

## Follow-ups

- Re-point GetQuerySpan + the read-only validator together, with omni/mariadb extractor support for sequence/RETURNING lineage.
- The remaining MARIADB capability re-points.
- `parser/mysql` ↔ `parser/mariadb` will diverge; future omni/mysql Diagnose fixes must mirror. Tracked for a possible shared-AST unification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)