### PR TITLE
fix(frontend): always show review phase for CI/CD UI plans (BYT-9753)

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1493,6 +1493,7 @@
       "deploy-description": "Bytebase will automatically create the rollout when all checks pass and the issue is approved.",
       "deploy-description-gitops": "This plan is ready to roll out. Create a rollout to deploy the linked release.",
       "hide-details": "Hide details",
+      "review-description": "Submit for review to proceed",
       "show-details": "Show details"
     },
     "plans": "Plans",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1493,6 +1493,7 @@
       "deploy-description": "Bytebase creará automáticamente el rollout cuando todas las comprobaciones pasen y el issue esté aprobado.",
       "deploy-description-gitops": "Este plan está listo para implementarse. Crea un rollout para desplegar la versión vinculada.",
       "hide-details": "Ocultar detalles",
+      "review-description": "Envíe para revisión para continuar",
       "show-details": "Mostrar detalles"
     },
     "plans": "Planes",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1493,6 +1493,7 @@
       "deploy-description": "すべてのチェックが通過し、Issue が承認されると、Bytebase は自動的にロールアウトを作成します。",
       "deploy-description-gitops": "このプランはロールアウトの準備ができています。リンクされたリリースをデプロイするにはロールアウトを作成してください。",
       "hide-details": "詳細を隠す",
+      "review-description": "続行するにはレビューに提出してください",
       "show-details": "詳細を表示"
     },
     "plans": "プラン",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1493,6 +1493,7 @@
       "deploy-description": "Bytebase sẽ tự động tạo rollout khi tất cả kiểm tra đều đạt và issue đã được phê duyệt.",
       "deploy-description-gitops": "Kế hoạch này đã sẵn sàng để triển khai. Tạo một rollout để triển khai bản phát hành được liên kết.",
       "hide-details": "Ẩn chi tiết",
+      "review-description": "Gửi để xem xét để tiếp tục",
       "show-details": "Hiển thị chi tiết"
     },
     "plans": "Kế hoạch",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1493,6 +1493,7 @@
       "deploy-description": "当所有检查都通过且工单审批完成后，Bytebase 会自动创建发布。",
       "deploy-description-gitops": "此计划已就绪，可以发布。创建一个发布以部署关联的 Release。",
       "hide-details": "隐藏详情",
+      "review-description": "提交审批以继续",
       "show-details": "显示详情"
     },
     "plans": "变更计划",

--- a/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.test.tsx
@@ -233,7 +233,7 @@ describe("ProjectPlanDetailPage", () => {
     expect(container.textContent).toContain("plan.navigator.review");
   });
 
-  it("hides the review phase when there is no issue", async () => {
+  it("shows the review phase for sheet-backed plans without an issue", async () => {
     mocks.usePlanDetailPage.mockReturnValue(buildPage());
 
     await act(async () => {
@@ -247,7 +247,10 @@ describe("ProjectPlanDetailPage", () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).not.toContain("plan.navigator.review");
+    // CI/CD UI (sheet-backed) plans always surface the review phase, even
+    // before an issue exists — it renders as an upcoming "future" step.
+    expect(container.textContent).toContain("plan.navigator.review");
+    expect(container.textContent).toContain("plan.phase.review-description");
   });
 
   it("hides the review phase for GitOps plans with release-backed specs", async () => {

--- a/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
+++ b/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
@@ -126,7 +126,10 @@ function ProjectPlanDetailPageInner({
     () => isReleaseBackedPlan(page.plan.specs),
     [page.plan.specs]
   );
-  const reviewVisible = !isGitOpsPlan && !!page.issue;
+  // CI/CD UI (sheet-backed) plans always surface the review phase — even
+  // before an issue exists it shows as an upcoming step. Only GitOps
+  // release-backed plans, which bypass review entirely, hide it.
+  const reviewVisible = !isGitOpsPlan;
 
   const phaseConfigs = useMemo(() => {
     const hasIssue = !!page.issue;
@@ -153,7 +156,7 @@ function ProjectPlanDetailPageInner({
     }
 
     const changesStatus: PhaseStatus =
-      page.isCreating || (!isGitOpsPlan && !hasIssue && !hasRollout)
+      page.isCreating || (reviewVisible && !hasIssue && !hasRollout)
         ? "active"
         : "completed";
     const deployStatus: PhaseStatus = hasRollout
@@ -224,14 +227,7 @@ function ProjectPlanDetailPageInner({
         lineClass: "",
       },
     };
-  }, [
-    isGitOpsPlan,
-    page.isCreating,
-    page.issue,
-    page.rollout,
-    reviewVisible,
-    t,
-  ]);
+  }, [page.isCreating, page.issue, page.rollout, reviewVisible, t]);
 
   // Mirror the URL specId into local state. We deliberately don't include
   // selectedSpecId in the deps — children (e.g. PlanDetailChangesBranch) may
@@ -300,6 +296,11 @@ function ProjectPlanDetailPageInner({
                     status={phaseConfigs.review.status}
                     onToggle={() => page.togglePhase("review")}
                     summary={buildReviewSummary(page.issue, t)}
+                    future={
+                      <p className="mt-0.5 text-sm text-control-placeholder">
+                        {t("plan.phase.review-description")}
+                      </p>
+                    }
                   >
                     <PlanReviewSection />
                   </PhaseSection>


### PR DESCRIPTION
## What & why

The review phase vanished from the plan detail page for sheet-backed (CI/CD UI) plans that don't have an issue yet — notably the draft/create state. A recent change (BYT-9538, #20621) gated the review section on `!!page.issue`, but that condition should only apply to GitOps release-backed plans, which bypass review entirely.

This restores the intended behavior: **non-release (CI/CD UI) plans always show the review phase**, rendering an upcoming "future" step with a "Submit for review to proceed" placeholder before an issue exists. GitOps plans still hide it.

## Changes

- `reviewVisible = !isGitOpsPlan` (was `!isGitOpsPlan && !!page.issue`)
- Restore the review phase's `future` placeholder and re-add the `plan.phase.review-description` key across all 5 locales (cross-locale parity is enforced by `check-react-i18n.mjs`)
- Simplify the `phaseConfigs` memo to key on the single `reviewVisible` flag, dropping the now-redundant `isGitOpsPlan` dependency

## Testing

- Updated the page test that previously asserted the buggy "hidden when no issue" behavior; it now asserts the review phase shows for sheet-backed draft plans (verified RED → GREEN)
- `plan-detail/` suite: 102/102 pass
- `tsc --build` clean; biome, `check-react-i18n`, and i18n sort checks all clean

Fixes BYT-9753

🤖 Generated with [Claude Code](https://claude.com/claude-code)