### PR TITLE
feat(plan): move targets edit beside title and use edit icons (BYT-9754)

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -6,6 +6,7 @@ import {
   ExternalLink,
   FolderTree,
   Loader2,
+  Pencil,
   XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -1300,21 +1301,25 @@ function TargetsSection({
   return (
     <>
       <div className="flex flex-col gap-y-1">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-1">
-            <span className="textlabel uppercase">
-              {t("plan.targets.title")}
+        <div className="flex items-center gap-1">
+          <span className="textlabel uppercase">{t("plan.targets.title")}</span>
+          {targets.length > 1 && (
+            <span className="textlabel text-control-light">
+              ({targets.length})
             </span>
-            {targets.length > 1 && (
-              <span className="textlabel text-control-light">
-                ({targets.length})
-              </span>
-            )}
-          </div>
+          )}
           {allowEdit && (
-            <Button onClick={onEdit} size="xs" variant="outline">
-              {t("common.edit")}
-            </Button>
+            <Tooltip content={t("common.edit")}>
+              <Button
+                aria-label={t("common.edit")}
+                className="text-control-light hover:text-control"
+                onClick={onEdit}
+                size="xs"
+                variant="ghost"
+              >
+                <Pencil className="size-3.5" />
+              </Button>
+            </Tooltip>
           )}
         </div>
         {!isLoadingTargets && nonEnvDatabaseNames.length > 0 && (

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailStatementSection.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailStatementSection.tsx
@@ -1,5 +1,5 @@
 import { clone, create } from "@bufbuild/protobuf";
-import { Loader2, Table, Upload } from "lucide-react";
+import { Loader2, Pencil, Table, Upload } from "lucide-react";
 import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -238,6 +238,9 @@ export function PlanDetailStatementSection({
         hasProjectPermissionV2(project, "bb.plans.update"))
   );
   const canEdit = canModifyStatement && !isSheetOversize && !page.isCreating;
+  // Editing an existing statement collapses the toolbar to Save/Cancel; hide
+  // Upload/Schema editor, which would replace the in-progress edit.
+  const isInlineEditing = isEditing && !page.isCreating;
   const hasChanges = page.isCreating
     ? draftStatement !== statement
     : isEditing && draftStatement !== statement;
@@ -448,61 +451,61 @@ export function PlanDetailStatementSection({
           onChange={(event) => void handleFileUpload(event)}
           type="file"
         />
-        <div className="flex flex-wrap items-center justify-end gap-x-2 gap-y-2">
-          {(canModifyStatement || isEditing) && (
-            <div className="flex flex-wrap items-center justify-end gap-x-2 gap-y-2">
-              <Button onClick={handleUploadClick} size="xs" variant="outline">
-                <Upload className="h-3.5 w-3.5" />
-                {t("issue.upload-sql")}
+        {(canModifyStatement || isEditing) && (
+          <div className="flex flex-wrap items-center justify-end gap-x-2 gap-y-2">
+            {!isInlineEditing && (
+              <>
+                <Button onClick={handleUploadClick} size="xs" variant="outline">
+                  <Upload className="h-3.5 w-3.5" />
+                  {t("issue.upload-sql")}
+                </Button>
+                {schemaEditorEligible && (
+                  <Button
+                    onClick={() => setIsSchemaEditorOpen(true)}
+                    size="xs"
+                    variant="outline"
+                  >
+                    <Table className="h-3.5 w-3.5" />
+                    {t("schema-editor.self")}
+                  </Button>
+                )}
+              </>
+            )}
+            {!isEditing && canEdit && (
+              <Button
+                onClick={() => setIsEditing(true)}
+                size="xs"
+                variant="outline"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+                {t("common.edit")}
               </Button>
-              {schemaEditorEligible && (
+            )}
+            {isInlineEditing && (
+              <>
                 <Button
-                  onClick={() => setIsSchemaEditorOpen(true)}
+                  disabled={!canSave}
+                  onClick={() => void handleSave()}
                   size="xs"
                   variant="outline"
                 >
-                  <Table className="h-3.5 w-3.5" />
-                  {t("schema-editor.self")}
+                  {isSaving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                  {t("common.save")}
                 </Button>
-              )}
-              {!isEditing ? (
-                canEdit ? (
-                  <Button
-                    onClick={() => setIsEditing(true)}
-                    size="xs"
-                    variant="outline"
-                  >
-                    {t("common.edit")}
-                  </Button>
-                ) : null
-              ) : !page.isCreating ? (
-                <>
-                  <Button
-                    disabled={!canSave}
-                    onClick={() => void handleSave()}
-                    size="xs"
-                    variant="outline"
-                  >
-                    {isSaving && (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    )}
-                    {t("common.save")}
-                  </Button>
-                  <Button
-                    onClick={() => {
-                      setDraftStatement(statement);
-                      setIsEditing(false);
-                    }}
-                    size="xs"
-                    variant="ghost"
-                  >
-                    {t("common.cancel")}
-                  </Button>
-                </>
-              ) : null}
-            </div>
-          )}
-        </div>
+                <Button
+                  onClick={() => {
+                    setDraftStatement(statement);
+                    setIsEditing(false);
+                  }}
+                  size="xs"
+                  variant="ghost"
+                >
+                  {t("common.cancel")}
+                </Button>
+              </>
+            )}
+          </div>
+        )}
       </div>
       {isSheetOversize && (
         <Alert

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailStatementSection.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailStatementSection.tsx
@@ -238,9 +238,11 @@ export function PlanDetailStatementSection({
         hasProjectPermissionV2(project, "bb.plans.update"))
   );
   const canEdit = canModifyStatement && !isSheetOversize && !page.isCreating;
-  // Editing an existing statement collapses the toolbar to Save/Cancel; hide
-  // Upload/Schema editor, which would replace the in-progress edit.
+  // An active edit session (not whole-plan creation) shows Save/Cancel.
   const isInlineEditing = isEditing && !page.isCreating;
+  // Hide Upload/Schema editor only when editing an already-persisted statement;
+  // a new pending-draft spec still needs them to author its first statement.
+  const isEditingExistingStatement = isInlineEditing && !isPendingDraft;
   const hasChanges = page.isCreating
     ? draftStatement !== statement
     : isEditing && draftStatement !== statement;
@@ -453,7 +455,7 @@ export function PlanDetailStatementSection({
         />
         {(canModifyStatement || isEditing) && (
           <div className="flex flex-wrap items-center justify-end gap-x-2 gap-y-2">
-            {!isInlineEditing && (
+            {!isEditingExistingStatement && (
               <>
                 <Button onClick={handleUploadClick} size="xs" variant="outline">
                   <Upload className="h-3.5 w-3.5" />


### PR DESCRIPTION
## What

Refines the edit affordances in the plan spec change panel ([BYT-9754](https://linear.app/bytebase/issue/BYT-9754/move-the-edit-targets-action-from-right-to-near-section-title)).

* **Targets:** moved the TARGETS edit action from the far right to beside the section title, rendered as an icon button (pencil) with tooltip + `aria-label` instead of a bordered text button.
* **Statement:** added a pencil icon to the inline Edit action so it matches its toolbar siblings (Upload SQL, Schema editor).
* **Edit mode:** hide Upload SQL / Schema editor while editing an existing statement — they'd replace the in-progress edit — so the toolbar collapses to Save / Cancel. Create mode keeps them as input methods.
* **Cleanup:** flattened the now-redundant nested toolbar conditional behind a named `isInlineEditing` flag and removed a doubled wrapper `div`.

<img src="https://uploads.linear.app/97459f40-0808-4310-8173-4faf6cc9ba8a/aec453e0-883c-46cf-b5d8-5342d0ad002b/f865e187-9e56-40a4-b7d8-2c4ef75953fc?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzk3NDU5ZjQwLTA4MDgtNDMxMC04MTczLTRmYWY2Y2M5YmE4YS9hZWM0NTNlMC04ODNjLTQ2Y2YtYjVkOC01MzQyZDBhZDAwMmIvZjg2NWUxODctOWU1Ni00MGE0LWI3ZDgtMmM0ZWY3NTk1M2ZjIiwiaWF0IjoxNzgyMTE3OTcxLCJleHAiOjE4MTM2ODg1MzF9.jzrJX027RDzxqbZTAqpvGWOCyWSPD3S215OyoWwAbIg " alt="Screenshot 2026-06-22 at 16.45.47.png" width="831" data-linear-height="550" />

## Testing

* `pnpm --dir frontend type-check` — passes
* `biome check` — clean
* `vitest run PlanDetailChangesBranch.test.tsx` — 10/10 pass

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)