### PR TITLE
fix(mysql): use MariaDB-native CHECK_CONSTRAINTS query in schema sync

### DIFF
--- a/backend/plugin/db/mysql/sync.go
+++ b/backend/plugin/db/mysql/sync.go
@@ -185,6 +185,7 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 	atLeast8_0_13 := semVersion.GE(semver.MustParse("8.0.13"))
 	atLeast8_0_16 := semVersion.GE(semver.MustParse("8.0.16"))
 	atLeast5_7_0 := semVersion.GE(semver.MustParse("5.7.0"))
+	isMariaDB := strings.Contains(rest, "MariaDB")
 
 	// Query index info.
 	indexMap := make(map[db.TableKey]map[string]*storepb.IndexMetadata)
@@ -208,7 +209,7 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 	// https://dev.mysql.com/doc/refman/8.0/en/information-schema-statistics-table.html
 	// MariaDB doesn't have the EXPRESSION column.
 	// https://mariadb.com/docs/server/ref/mdb/information-schema/STATISTICS
-	if atLeast8_0_13 && !strings.Contains(rest, "MariaDB") {
+	if atLeast8_0_13 && !isMariaDB {
 		indexQuery = `
 			SELECT
 				TABLE_NAME,
@@ -390,17 +391,7 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 	// Check constraints info.
 	checkMap := make(map[db.TableKey][]*storepb.CheckConstraintMetadata)
 	if atLeast8_0_16 {
-		checkQuery := `
-		SELECT
-			tc.TABLE_NAME,
-			cc.CONSTRAINT_NAME,
-			cc.CHECK_CLAUSE
-		FROM information_schema.CHECK_CONSTRAINTS cc
-			JOIN information_schema.TABLE_CONSTRAINTS tc
-				ON cc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
-				AND cc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA
-		WHERE tc.CONSTRAINT_TYPE = 'CHECK' AND tc.TABLE_SCHEMA = ?
-	`
+		checkQuery := getCheckConstraintQuery(isMariaDB)
 		checkRows, err := d.db.QueryContext(ctx, checkQuery, d.databaseName)
 		if err != nil {
 			return nil, util.FormatErrorWithQuery(err, checkQuery)
@@ -920,6 +911,34 @@ func (d *Driver) getCreateFunctionStmt(ctx context.Context, databaseName, functi
 // SQL and must be unescaped before being written back into DDL.
 func unescapeCheckClause(clause string) string {
 	return strings.ReplaceAll(clause, `\'`, `'`)
+}
+
+func getCheckConstraintQuery(isMariaDB bool) string {
+	if isMariaDB {
+		// MariaDB includes TABLE_NAME in CHECK_CONSTRAINTS. Joining TABLE_CONSTRAINTS
+		// by constraint name/schema is both slower and incorrect because MariaDB check
+		// names are scoped to a table, not the whole schema.
+		return `
+			SELECT
+				TABLE_NAME,
+				CONSTRAINT_NAME,
+				CHECK_CLAUSE
+			FROM information_schema.CHECK_CONSTRAINTS
+			WHERE CONSTRAINT_SCHEMA = ?
+		`
+	}
+
+	return `
+			SELECT
+				tc.TABLE_NAME,
+				cc.CONSTRAINT_NAME,
+				cc.CHECK_CLAUSE
+			FROM information_schema.CHECK_CONSTRAINTS cc
+				JOIN information_schema.TABLE_CONSTRAINTS tc
+					ON cc.CONSTRAINT_NAME = tc.CONSTRAINT_NAME
+					AND cc.CONSTRAINT_SCHEMA = tc.CONSTRAINT_SCHEMA
+			WHERE tc.CONSTRAINT_TYPE = 'CHECK' AND tc.TABLE_SCHEMA = ?
+		`
 }
 
 // stripReturnsCharset removes the " CHARSET ... [COLLATE ...]" attributes that

--- a/backend/plugin/db/mysql/sync_test.go
+++ b/backend/plugin/db/mysql/sync_test.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -468,6 +469,27 @@ func TestUnescapeCheckClause(t *testing.T) {
 	for _, tc := range testCases {
 		require.Equal(t, tc.want, unescapeCheckClause(tc.clause))
 	}
+}
+
+func TestGetCheckConstraintQuery(t *testing.T) {
+	t.Run("MariaDB uses native table name column", func(t *testing.T) {
+		query := strings.ToUpper(getCheckConstraintQuery(true))
+
+		require.Contains(t, query, "TABLE_NAME")
+		require.Contains(t, query, "FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS")
+		require.Contains(t, query, "WHERE CONSTRAINT_SCHEMA = ?")
+		require.NotContains(t, query, "JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS")
+		require.NotContains(t, query, "TC.TABLE_SCHEMA")
+	})
+
+	t.Run("MySQL keeps table constraints join", func(t *testing.T) {
+		query := strings.ToUpper(getCheckConstraintQuery(false))
+
+		require.Contains(t, query, "TC.TABLE_NAME")
+		require.Contains(t, query, "JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS")
+		require.Contains(t, query, "TC.CONSTRAINT_TYPE = 'CHECK'")
+		require.Contains(t, query, "TC.TABLE_SCHEMA = ?")
+	})
 }
 
 func TestStripReturnsCharset(t *testing.T) {


### PR DESCRIPTION
## Problem

MariaDB databases sync through the MySQL driver. On large MariaDB instances, schema sync is extremely slow or fails. A customer with ~200 databases / 5k tables hit, on the check-constraint sync query:

`Error 1969 (70100): Query execution was interrupted (max_statement_time exceeded)`

and saw databases flagged sync-failed.

## Root cause

The check-constraint query is written for MySQL 8.0, where `CHECK_CONSTRAINTS` has no `TABLE_NAME` column, so it joins `TABLE_CONSTRAINTS` to recover it. MariaDB reports 10.x/11.x, which passes the `atLeast8_0_16` gate, so it runs this MySQL-shaped query. On MariaDB it is wrong on two axes:

- **Performance** — the schema filter only reaches `CHECK_CONSTRAINTS` through the join (a non-constant), so MariaDB cannot push it down and scans every table in every database on the instance (`EXPLAIN`: `Scanned all databases`), once per database. ~330x slower than the native query on a 5k-table instance, scaling with total instance tables rather than schema size. This is the single sync statement with instance-wide cost, so it is the first to trip `max_statement_time` / the 15m sync deadline at scale.
- **Correctness** — MariaDB scopes check-constraint names per table (and auto-names anonymous ones `CONSTRAINT_1`), so joining on `(CONSTRAINT_NAME, CONSTRAINT_SCHEMA)` produces a cartesian product that attaches check clauses to the wrong tables.

## Fix

MariaDB's `CHECK_CONSTRAINTS` already exposes `TABLE_NAME`, so for MariaDB we filter by `CONSTRAINT_SCHEMA` directly and drop the join. MySQL 8.0 keeps the join (no `TABLE_NAME` column there, schema-unique names, indexed data dictionary).

## Testing

- Unit test `TestGetCheckConstraintQuery` covers both branches.
- Verified on MariaDB 11.4: native query `EXPLAIN` = `Scanned 1 database`, 0.35 ms vs join 114 ms (~330x); returns the correct/complete constraint set across named, anonymous, column-level, multi-check, no-check, and colliding-name tables (the old join returns a cartesian).
- gofmt / go vet / golangci-lint (0 issues) / full build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)