### PR TITLE
fix(pg): fail-safe whitelist for read-only CTE detection + SELECT INTO (BYT-9751)

### DIFF
--- a/backend/plugin/parser/pg/query_antlr.go
+++ b/backend/plugin/parser/pg/query_antlr.go
@@ -12,11 +12,12 @@ import (
 // Returns (isReadOnly, allQueriesReturnData, error)
 //
 // Validation rules:
-// 1. Allow: SELECT statements
-// 2. Allow: EXPLAIN statements (but not EXPLAIN ANALYZE for non-SELECT)
-// 3. Allow: SHOW/SET statements (SET is considered executable)
-// 4. Allow: CTEs with only SELECT (reject CTEs with INSERT/UPDATE/DELETE/MERGE)
-// 5. Reject: All other statements (DDL, DML except SELECT)
+//  1. Allow: SELECT statements
+//  2. Allow: EXPLAIN statements (but not EXPLAIN ANALYZE for non-SELECT)
+//  3. Allow: SHOW/SET statements (SET is considered executable)
+//  4. Allow: CTEs whose every term is a read (SELECT/VALUES/TABLE/set-op/RECURSIVE);
+//     reject a SELECT with a data-modifying CTE term — a fail-safe whitelist.
+//  5. Reject: SELECT ... INTO (creates a table) and all other statements (DDL, DML).
 func validateQueryANTLR(statement string) (bool, bool, error) {
 	stmts, err := ParsePg(statement)
 	if err != nil {
@@ -35,19 +36,17 @@ func validateQueryANTLR(statement string) (bool, bool, error) {
 
 		switch n := stmt.AST.(type) {
 		case *ast.SelectStmt:
-			// SELECT is allowed. Check for DML in CTEs.
-			if n.WithClause != nil && hasDMLInTree(n) {
+			// SELECT is read-only unless it writes: SELECT ... INTO creates a table,
+			// or a data-modifying CTE smuggles a write into the read path.
+			if isWriteSelect(n) {
 				return false, false, nil
 			}
 
 		case *ast.ExplainStmt:
 			if isExplainAnalyze(n) {
-				// EXPLAIN ANALYZE is only valid for SELECT
-				if _, ok := n.Query.(*ast.SelectStmt); !ok {
-					return false, false, nil
-				}
-				// Check for DML in CTEs within the explained SELECT
-				if hasDMLInTree(n.Query) {
+				// EXPLAIN ANALYZE executes the query, so it must be a read-only SELECT.
+				sel, ok := n.Query.(*ast.SelectStmt)
+				if !ok || isWriteSelect(sel) {
 					return false, false, nil
 				}
 			}
@@ -82,22 +81,40 @@ func isExplainAnalyze(n *ast.ExplainStmt) bool {
 	return false
 }
 
-// hasDMLInTree walks the AST tree and returns true if any INSERT/UPDATE/DELETE/MERGE
-// is found. MERGE is included so a data-modifying MERGE smuggled into a CTE
-// (e.g. WITH x AS (MERGE ... RETURNING col) SELECT col FROM x) is classified as a
-// write: this keeps the set aligned with classifyQueryType (query_type.go) and
-// stops the editor from taking the row-returning read path for it, which would
-// otherwise return masked columns unmasked.
-func hasDMLInTree(node ast.Node) bool {
+// isWriteSelect reports whether a SelectStmt actually writes — and so must not take
+// the read-only editor path. A SELECT writes if it has an INTO target (SELECT ...
+// INTO creates a table) or any of its CTE terms is data-modifying.
+//
+// This is the unified write-detection primitive for the read-only gate;
+// classifyQueryType (query_type.go) keeps reporting the root statement type for its
+// own consumers — only the detection is shared, not the classifiers' outputs.
+func isWriteSelect(n *ast.SelectStmt) bool {
+	if n == nil {
+		return false
+	}
+	if hasOmniIntoClause(n) {
+		return true
+	}
+	return containsWriteCTE(n)
+}
+
+// containsWriteCTE reports whether any common table expression in the tree is
+// data-modifying. Fail-safe by construction — a whitelist, not a denylist: a CTE
+// term is read-only ONLY if it is an *ast.SelectStmt, which is how pg models
+// SELECT, VALUES, TABLE, set operations and WITH RECURSIVE. Anything else —
+// INSERT/UPDATE/DELETE/MERGE today, or any write node added to the grammar
+// tomorrow — counts as a write, so the next forgotten write type fails closed.
+func containsWriteCTE(node ast.Node) bool {
 	found := false
 	ast.Inspect(node, func(n ast.Node) bool {
 		if found {
 			return false
 		}
-		switch n.(type) {
-		case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt, *ast.MergeStmt:
-			found = true
-			return false
+		if cte, ok := n.(*ast.CommonTableExpr); ok {
+			if _, isSelect := cte.Ctequery.(*ast.SelectStmt); !isSelect {
+				found = true
+				return false
+			}
 		}
 		return true
 	})

--- a/backend/plugin/parser/pg/query_test.go
+++ b/backend/plugin/parser/pg/query_test.go
@@ -92,6 +92,38 @@ func TestValidateSQLForEditor(t *testing.T) {
 			allQuery: false,
 		},
 		{
+			// BYT-9751 RED→GREEN: SELECT ... INTO creates a table (a write), but the
+			// validator treated it as read-only — it never checked the INTO clause.
+			sql:      `SELECT a INTO t2 FROM t`,
+			valid:    false,
+			allQuery: false,
+		},
+		{
+			// no-over-block guard: a data-modifying CTE must reject, but read-only
+			// CTE terms pg models as SelectStmt must stay allowed — VALUES.
+			sql:      `WITH x AS (VALUES (1), (2)) SELECT * FROM x`,
+			valid:    true,
+			allQuery: true,
+		},
+		{
+			// no-over-block guard: TABLE t is a SelectStmt CTE term.
+			sql:      `WITH x AS (TABLE t) SELECT * FROM x`,
+			valid:    true,
+			allQuery: true,
+		},
+		{
+			// no-over-block guard: a set-operation CTE term is a SelectStmt.
+			sql:      `WITH x AS (SELECT 1 UNION SELECT 2) SELECT * FROM x`,
+			valid:    true,
+			allQuery: true,
+		},
+		{
+			// no-over-block guard: WITH RECURSIVE — the CTE term is still a SelectStmt.
+			sql:      `WITH RECURSIVE x AS (SELECT 1 UNION SELECT n + 1 FROM x WHERE n < 5) SELECT * FROM x`,
+			valid:    true,
+			allQuery: true,
+		},
+		{
 			sql:      "select * from t where a = 'klasjdfkljsa$tag$; -- lkjdlkfajslkdfj'",
 			valid:    true,
 			allQuery: true,


### PR DESCRIPTION
The durable **class fix** behind #20631 (BYT-9751). #20631 patched the instance (added `MergeStmt` to the CTE denylist); this removes the per-classifier whack-a-mole that allowed it.

## Changes to `validateQueryANTLR`
1. **Fail-safe CTE whitelist.** Inverts the CTE write-detection: a CTE term is read-only **only if** it is an `*ast.SelectStmt` (`containsWriteCTE`), replacing the denylist (`hasDMLInTree`, which enumerated write node types and missed `MERGE`). Any non-SELECT CTE term — INSERT/UPDATE/DELETE/MERGE today, **or any write node added to the grammar tomorrow** — counts as a write and fails closed.
2. **SELECT … INTO is a write.** The validator never checked the `INTO` clause, so `SELECT a INTO t2 FROM t` was classified read-only (it creates a table). `classifyQueryType` already calls it DDL; this aligns them.

Unified into one `isWriteSelect` primitive; `classifyQueryType` keeps reporting the root statement type for its own consumers (no output merge).

## Verification (the whitelist's failure mode is over-block, so this is load-bearing)
Read-only CTE terms that pg models as `SelectStmt` stay allowed — **no over-block**:
- `WITH x AS (VALUES …)`, `(TABLE t)`, `(SELECT 1 UNION SELECT 2)`, `WITH RECURSIVE …` → all still valid.
- The four data-modifying CTEs (INSERT/UPDATE/DELETE/MERGE) → still rejected (regression guards).
- `SELECT … INTO` → now rejected (the RED→GREEN).

#20631's MERGE-CTE masking e2e (`TestQueryConnMergeCTEDoesNotLeakRows`, PG17) still passes — now via the whitelist. Applies to **POSTGRES and COCKROACHDB** (shared validator). `go build ./...` clean.

## Behavior change (not breaking)
`SELECT … INTO` is now treated as non-read-only — rejected on export, routed to Exec (affected-rows, not an empty grid) on the query path. Restores correctness (SELECT INTO is a write), so not labeled breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)