### PR TITLE
fix(plan): show skipped task reason (BYT-9758)

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -3859,6 +3859,7 @@
     "skip-prior-backup": "Skip prior backup",
     "skip-prior-backup-description": "Skip the automatic data backup before applying changes",
     "skip-task": "Skip task | Skip tasks",
+    "skipped-no-reason": "No reason provided",
     "started": "Started",
     "status": {
       "available": "Available",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -3859,6 +3859,7 @@
     "skip-prior-backup": "Omitir respaldo previo",
     "skip-prior-backup-description": "Omitir la copia de seguridad automática de datos antes de aplicar cambios",
     "skip-task": "Saltar tarea | Saltar tareas",
+    "skipped-no-reason": "No se indicó ningún motivo",
     "started": "Iniciado",
     "status": {
       "available": "Disponible",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -3859,6 +3859,7 @@
     "skip-prior-backup": "事前バックアップをスキップ",
     "skip-prior-backup-description": "変更適用前の自動データバックアップをスキップする",
     "skip-task": "タスクをスキップ | タスクをスキップ",
+    "skipped-no-reason": "理由が指定されていません",
     "started": "開始日時",
     "status": {
       "available": "利用可能",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -3859,6 +3859,7 @@
     "skip-prior-backup": "Bỏ qua sao lưu trước",
     "skip-prior-backup-description": "Bỏ qua sao lưu dữ liệu tự động trước khi áp dụng thay đổi",
     "skip-task": "Bỏ qua nhiệm vụ | Bỏ qua nhiệm vụ",
+    "skipped-no-reason": "Không có lý do",
     "started": "Bắt đầu",
     "status": {
       "available": "Có sẵn",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -3859,6 +3859,7 @@
     "skip-prior-backup": "跳过预备份",
     "skip-prior-backup-description": "跳过变更前的自动数据备份",
     "skip-task": "跳过任务 | 跳过任务",
+    "skipped-no-reason": "未提供原因",
     "started": "开始于",
     "status": {
       "available": "就绪",

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
@@ -32,6 +32,7 @@ import { PlanDetailTaskRunDetail } from "../PlanDetailTaskRunDetail";
 import { PlanDetailTaskRunTable } from "../PlanDetailTaskRunTable";
 import { PlanTargetDisplay } from "../PlanTargetDisplay";
 import { DeployReleaseInfoCard } from "./DeployReleaseInfoCard";
+import { DeployTaskSkippedReason } from "./DeployTaskSkippedReason";
 import { DeployTaskStatus } from "./DeployTaskStatus";
 import { useDeployTaskActions } from "./taskActions";
 import { useDeployTaskStatement } from "./useDeployTaskStatement";
@@ -194,6 +195,8 @@ export function DeployTaskDetailPanel({ task }: { task: Task }) {
           </div>
         </div>
       </div>
+
+      <DeployTaskSkippedReason task={task} />
 
       {latestTaskRun && (
         <div className="flex w-full flex-col gap-2">

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
@@ -35,6 +35,7 @@ import {
 import { PlanTargetDisplay } from "../PlanTargetDisplay";
 import { DeployLatestTaskRunInfo } from "./DeployLatestTaskRunInfo";
 import { DeployReleaseInfoCard } from "./DeployReleaseInfoCard";
+import { DeployTaskSkippedReason } from "./DeployTaskSkippedReason";
 import { DeployTaskStatus } from "./DeployTaskStatus";
 import { useDeployTaskActions } from "./taskActions";
 import { getTaskRunDuration } from "./taskRunUtils";
@@ -279,6 +280,7 @@ export function DeployTaskItem({
 
           {isExpanded && (
             <div className="space-y-3">
+              <DeployTaskSkippedReason task={task} />
               {!isReleaseTask ? (
                 <div>
                   <div className="mb-1 text-sm font-medium text-gray-700">

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskSkippedReason.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskSkippedReason.test.tsx
@@ -1,0 +1,89 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, test, vi } from "vitest";
+import { type Task, Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
+import { DeployTaskSkippedReason } from "./DeployTaskSkippedReason";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  useTranslation: vi.fn(() => ({
+    t: (key: string) => key,
+  })),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: mocks.useTranslation,
+}));
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+
+  return {
+    container,
+    render: () => {
+      act(() => {
+        root.render(element);
+      });
+    },
+    unmount: () =>
+      act(() => {
+        root.unmount();
+      }),
+  };
+};
+
+const makeTask = (overrides: Partial<Task>): Task =>
+  ({
+    status: Task_Status.SKIPPED,
+    skippedReason: "",
+    ...overrides,
+  }) as unknown as Task;
+
+describe("DeployTaskSkippedReason", () => {
+  test("shows the skip reason when present", () => {
+    const { container, render, unmount } = renderIntoContainer(
+      <DeployTaskSkippedReason
+        task={makeTask({ skippedReason: "blocked by migration freeze" })}
+      />
+    );
+
+    render();
+
+    expect(container.textContent).toContain("blocked by migration freeze");
+    expect(container.textContent).toContain("task.status.skipped");
+    expect(container.textContent).not.toContain("task.skipped-no-reason");
+
+    unmount();
+  });
+
+  test("shows a placeholder when the reason is empty", () => {
+    const { container, render, unmount } = renderIntoContainer(
+      <DeployTaskSkippedReason task={makeTask({ skippedReason: "" })} />
+    );
+
+    render();
+
+    expect(container.textContent).toContain("task.skipped-no-reason");
+
+    unmount();
+  });
+
+  test("renders nothing when the task is not skipped", () => {
+    const { container, render, unmount } = renderIntoContainer(
+      <DeployTaskSkippedReason
+        task={makeTask({ status: Task_Status.DONE, skippedReason: "" })}
+      />
+    );
+
+    render();
+
+    expect(container.textContent).toBe("");
+
+    unmount();
+  });
+});

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskSkippedReason.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskSkippedReason.tsx
@@ -1,0 +1,23 @@
+import { useTranslation } from "react-i18next";
+import { type Task, Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
+
+export function DeployTaskSkippedReason({ task }: { task: Task }) {
+  const { t } = useTranslation();
+  if (task.status !== Task_Status.SKIPPED) {
+    return null;
+  }
+  return (
+    <div className="rounded-xs border border-control-border bg-control-bg px-3 py-2 text-sm">
+      <span className="text-control-light">{t("task.status.skipped")}: </span>
+      {task.skippedReason ? (
+        <span className="whitespace-pre-wrap break-words text-control">
+          {task.skippedReason}
+        </span>
+      ) : (
+        <span className="italic text-control-placeholder">
+          {t("task.skipped-no-reason")}
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

When a task is skipped, surface the skip reason in the rollout / deploy UI. The backend already returns `task.skippedReason`, but the UI never rendered it in the task **detail panel** and only showed it in the **collapsed** list row — so an expanded row or the detail view of a skipped task gave no explanation of why it was skipped.

- New shared `DeployTaskSkippedReason` component, used by both the task detail panel and the expanded task row, so the two surfaces can't drift.
- When a task is skipped **without** a reason, show a muted, italic `No reason provided` placeholder instead of hiding the block — a hidden block read as if the reason had failed to load.
- Added the `task.skipped-no-reason` i18n key across all five locales.

## Screenshot

<img width="1454" height="572" alt="image" src="https://github.com/user-attachments/assets/2dfa0eb0-9de4-45d5-b392-5d73b6213f8f" />

## Testing

- New render tests for `DeployTaskSkippedReason`: reason shown / placeholder when empty / nothing rendered when the task is not skipped.
- `pnpm --dir frontend check` (Biome, i18n consistency + sort, layering), `pnpm --dir frontend type-check`, and the deploy-directory tests all pass.

Closes BYT-9758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
