### PR TITLE
fix(plan): show "(edited)" marker in place after comment edit (BYT-9746)

### DIFF
--- a/frontend/src/react/stores/app/index.test.ts
+++ b/frontend/src/react/stores/app/index.test.ts
@@ -26,6 +26,7 @@ import {
 import { IdentityProviderSchema } from "@/types/proto-es/v1/idp_service_pb";
 import { InstanceRoleSchema } from "@/types/proto-es/v1/instance_role_service_pb";
 import { InstanceSchema } from "@/types/proto-es/v1/instance_service_pb";
+import { IssueCommentSchema } from "@/types/proto-es/v1/issue_service_pb";
 import {
   ProjectSchema,
   WebhookSchema,
@@ -154,6 +155,9 @@ const mocks = vi.hoisted(() => ({
   listAccessGrants: vi.fn(),
   activateAccessGrant: vi.fn(),
   revokeAccessGrant: vi.fn(),
+  listIssueComments: vi.fn(),
+  createIssueComment: vi.fn(),
+  updateIssueComment: vi.fn(),
 }));
 
 vi.mock("@/connect", () => ({
@@ -275,6 +279,11 @@ vi.mock("@/connect", () => ({
     updateWorkspace: mocks.updateWorkspace,
     getIamPolicy: mocks.getIamPolicy,
     setIamPolicy: mocks.setIamPolicy,
+  },
+  issueServiceClientConnect: {
+    listIssueComments: mocks.listIssueComments,
+    createIssueComment: mocks.createIssueComment,
+    updateIssueComment: mocks.updateIssueComment,
   },
 }));
 
@@ -1354,6 +1363,40 @@ describe("useAppStore", () => {
     expect(store.getState().accessGrantsByName[accessGrantA.name]).toBe(
       revoked
     );
+  });
+
+  test("updateIssueComment writes the server response so the edited marker shows in place (BYT-9746)", async () => {
+    const issueName = "projects/a/issues/1";
+    const commentName = `${issueName}/issueComments/100`;
+    const original = createProto(IssueCommentSchema, {
+      name: commentName,
+      comment: "before",
+      createTime: timestampSeconds(1000),
+      updateTime: timestampSeconds(1000),
+    });
+    // The server bumps updated_at on edit and returns the refreshed comment.
+    const serverUpdated = createProto(IssueCommentSchema, {
+      name: commentName,
+      comment: "after",
+      createTime: timestampSeconds(1000),
+      updateTime: timestampSeconds(2000),
+    });
+    mocks.updateIssueComment.mockResolvedValue(serverUpdated);
+    const store = createAppStore();
+    store.setState({ issueCommentsByIssue: { [issueName]: [original] } });
+
+    await store.getState().updateIssueComment({
+      issueCommentName: commentName,
+      comment: "after",
+    });
+
+    const cached = store.getState().getIssueComments(issueName)[0];
+    expect(cached.comment).toBe("after");
+    // Regression guard: the optimistic patch used to discard the RPC response
+    // and keep the stale updateTime, so IssueCommentActivity's
+    // `isEdited = createTime !== updateTime` stayed false until a full refetch.
+    expect(cached.updateTime).toEqual(serverUpdated.updateTime);
+    expect(cached.updateTime).not.toEqual(cached.createTime);
   });
 
   test("deduplicates project fetches and caches the result", async () => {

--- a/frontend/src/react/stores/app/issueComment.ts
+++ b/frontend/src/react/stores/app/issueComment.ts
@@ -86,23 +86,24 @@ export const createIssueCommentSlice: AppSliceCreator<IssueCommentSlice> = (
     const { projectId, issueId } =
       getProjectIdIssueIdIssueCommentId(issueCommentName);
     const parent = `${projectNamePrefix}${projectId}/${issueNamePrefix}${issueId}`;
-    await issueServiceClientConnect.updateIssueComment(
-      createProto(UpdateIssueCommentRequestSchema, {
-        parent,
-        issueComment: createProto(IssueCommentSchema, {
-          name: issueCommentName,
-          comment,
-        }),
-        updateMask: { paths: ["comment"] },
-      })
-    );
+    const updatedIssueComment =
+      await issueServiceClientConnect.updateIssueComment(
+        createProto(UpdateIssueCommentRequestSchema, {
+          parent,
+          issueComment: createProto(IssueCommentSchema, {
+            name: issueCommentName,
+            comment,
+          }),
+          updateMask: { paths: ["comment"] },
+        })
+      );
     set((state) => ({
       issueCommentsByIssue: {
         ...state.issueCommentsByIssue,
         [parent]: (state.issueCommentsByIssue[parent] ?? []).map(
           (issueComment) =>
             issueComment.name === issueCommentName
-              ? { ...issueComment, comment }
+              ? updatedIssueComment
               : issueComment
         ),
       },


### PR DESCRIPTION
## What

Inline comment edits in **Plan Review** and **Issue Detail** now show the "(edited)" marker immediately on save, instead of only after a page reload. Both surfaces share the `IssueCommentActivity` renderer, so the fix covers both.

## Root cause

`updateIssueComment()` in the React app store sent the update RPC but **discarded its response**, rebuilding the cached comment as `{ ...issueComment, comment }` — which preserves the stale `updateTime`. `IssueCommentActivity` derives `isEdited = createTime !== updateTime`, so the marker stayed hidden until a `listIssueComments` refetch.

The backend bumps `updated_at` and returns the refreshed comment correctly (a reload always showed the marker), and `createIssueComment` already used its server response — the asymmetry was the bug.

## Fix

Capture the `updateIssueComment` RPC response and write it into the cache, mirroring `createIssueComment`. One behavior change in `frontend/src/react/stores/app/issueComment.ts`.

## Testing

- Added a store regression test in `index.test.ts` — verified it fails **RED** on the old code (cached `updateTime` stayed at `createTime`) and passes **GREEN** after the fix.
- `pnpm --dir frontend test src/react/stores/app/index.test.ts` → 66/66 pass
- `pnpm --dir frontend check` and `pnpm --dir frontend type-check` → pass

Fixes BYT-9746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)