### PR TITLE
refactor: consolidate task run listing

### DIFF
--- a/backend/runner/taskrun/pending_scheduler.go
+++ b/backend/runner/taskrun/pending_scheduler.go
@@ -78,7 +78,9 @@ func (s *Scheduler) schedulePendingTaskRuns(ctx context.Context) (err error) {
 		return nil
 	}
 
-	taskRuns, err := s.store.ListTaskRunsByStatus(ctx, []storepb.TaskRun_Status{storepb.TaskRun_PENDING})
+	taskRuns, err := s.store.ListTaskRuns(ctx, &store.FindTaskRunMessage{
+		Status: new([]storepb.TaskRun_Status{storepb.TaskRun_PENDING}),
+	})
 	if err != nil {
 		return errors.Wrapf(err, "failed to list pending task runs")
 	}
@@ -224,7 +226,9 @@ type schedulingContext struct {
 }
 
 func newSchedulingContext(ctx context.Context, s *store.Store) (*schedulingContext, error) {
-	activeTaskRuns, err := s.ListTaskRunsByStatus(ctx, []storepb.TaskRun_Status{storepb.TaskRun_AVAILABLE, storepb.TaskRun_RUNNING})
+	activeTaskRuns, err := s.ListTaskRuns(ctx, &store.FindTaskRunMessage{
+		Status: new([]storepb.TaskRun_Status{storepb.TaskRun_AVAILABLE, storepb.TaskRun_RUNNING}),
+	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to list active task runs")
 	}

--- a/backend/runner/taskrun/scheduler.go
+++ b/backend/runner/taskrun/scheduler.go
@@ -71,7 +71,9 @@ func (s *Scheduler) Register(taskType storepb.Task_Type, executorGetter Executor
 
 // failTaskRunsForHA fails all PENDING and AVAILABLE task runs because HA is not licensed.
 func (s *Scheduler) failTaskRunsForHA(ctx context.Context, haErr error) {
-	taskRuns, err := s.store.ListTaskRunsByStatus(ctx, []storepb.TaskRun_Status{storepb.TaskRun_PENDING, storepb.TaskRun_AVAILABLE})
+	taskRuns, err := s.store.ListTaskRuns(ctx, &store.FindTaskRunMessage{
+		Status: new([]storepb.TaskRun_Status{storepb.TaskRun_PENDING, storepb.TaskRun_AVAILABLE}),
+	})
 	if err != nil {
 		slog.Error("failed to list task runs for HA limit check", log.BBError(err))
 		return

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -39,7 +39,7 @@ type FindTaskRunMessage struct {
 	Workspace   string
 	UID         *int64
 	UIDs        *[]int64
-	ProjectID   string
+	ProjectID   string // Empty string skips filtering for cross-project queries like runners.
 	TaskUID     *int64
 	Environment *string
 	PlanUID     *int64
@@ -62,6 +62,40 @@ type TaskRunStatusPatch struct {
 
 // ListTaskRuns lists task runs.
 func (s *Store) ListTaskRuns(ctx context.Context, find *FindTaskRunMessage) ([]*TaskRunMessage, error) {
+	if find.ProjectID == "" && (find.UID != nil || find.UIDs != nil || find.TaskUID != nil || find.Environment != nil || find.PlanUID != nil) {
+		return nil, errors.Errorf("project ID is required for scoped task run filters")
+	}
+
+	where := qb.Q()
+	if find.ProjectID != "" {
+		where.And("task_run.project = ?", find.ProjectID)
+	}
+	if find.Workspace != "" {
+		where.And("task_run.project IN (SELECT resource_id FROM project WHERE workspace = ?)", find.Workspace)
+	}
+	if v := find.UID; v != nil {
+		where.And("task_run.id = ?", *v)
+	}
+	if v := find.UIDs; v != nil {
+		where.And("task_run.id = ANY(?)", *v)
+	}
+	if v := find.TaskUID; v != nil {
+		where.And("task_run.task_id = ?", *v)
+	}
+	if v := find.Environment; v != nil {
+		where.And("task.environment = ?", *v)
+	}
+	if v := find.PlanUID; v != nil {
+		where.And("task.plan_id = ?", *v)
+	}
+	if v := find.Status; v != nil {
+		var statusStrings []string
+		for _, status := range *v {
+			statusStrings = append(statusStrings, status.String())
+		}
+		where.And("task_run.status = ANY(?)", statusStrings)
+	}
+
 	q := qb.Q().Space(`
 		SELECT
 			task_run.id,
@@ -79,34 +113,9 @@ func (s *Store) ListTaskRuns(ctx context.Context, find *FindTaskRunMessage) ([]*
 			task_run.project
 		FROM task_run
 		LEFT JOIN task ON task.project = task_run.project AND task.id = task_run.task_id
-		WHERE task_run.project = ?
-	`, find.ProjectID)
-
-	if find.Workspace != "" {
-		q.And("task_run.project IN (SELECT resource_id FROM project WHERE workspace = ?)", find.Workspace)
-	}
-
-	if v := find.UID; v != nil {
-		q.And("task_run.id = ?", *v)
-	}
-	if v := find.UIDs; v != nil {
-		q.And("task_run.id = ANY(?)", *v)
-	}
-	if v := find.TaskUID; v != nil {
-		q.And("task_run.task_id = ?", *v)
-	}
-	if v := find.Environment; v != nil {
-		q.And("task.environment = ?", *v)
-	}
-	if v := find.PlanUID; v != nil {
-		q.And("task.plan_id = ?", *v)
-	}
-	if v := find.Status; v != nil {
-		var statusStrings []string
-		for _, status := range *v {
-			statusStrings = append(statusStrings, status.String())
-		}
-		q.And("task_run.status = ANY(?)", statusStrings)
+	`)
+	if where.Len() > 0 {
+		q.Space("WHERE ?", where)
 	}
 
 	q.Space("ORDER BY task_run.id ASC")
@@ -561,92 +570,4 @@ func (s *Store) UpdateTaskRunPayload(ctx context.Context, projectID string, task
 		return errors.Wrapf(err, "failed to update task run payload")
 	}
 	return nil
-}
-
-// ListTaskRunsByStatus lists task runs by status across all projects.
-// This is for system schedulers that need cross-project queries.
-func (s *Store) ListTaskRunsByStatus(ctx context.Context, statuses []storepb.TaskRun_Status) ([]*TaskRunMessage, error) {
-	var statusStrings []string
-	for _, status := range statuses {
-		statusStrings = append(statusStrings, status.String())
-	}
-	q := qb.Q().Space(`
-		SELECT
-			task_run.id,
-			task_run.creator,
-			task_run.created_at,
-			task_run.updated_at,
-			task_run.task_id,
-			task_run.status,
-			task_run.started_at,
-			task_run.run_at,
-			task_run.result,
-			task_run.payload,
-			task.plan_id,
-			task.environment,
-			task_run.project
-		FROM task_run
-		LEFT JOIN task ON task.project = task_run.project AND task.id = task_run.task_id
-		WHERE task_run.status = ANY(?)
-		ORDER BY task_run.id ASC
-	`, statusStrings)
-
-	query, args, err := q.ToSQL()
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to build sql")
-	}
-
-	rows, err := s.GetDB().QueryContext(ctx, query, args...)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	var taskRuns []*TaskRunMessage
-	for rows.Next() {
-		var taskRun TaskRunMessage
-		var creatorEmail sql.NullString
-		var statusString string
-		var resultJSON, payloadJSON string
-		if err := rows.Scan(
-			&taskRun.ID,
-			&creatorEmail,
-			&taskRun.CreatedAt,
-			&taskRun.UpdatedAt,
-			&taskRun.TaskUID,
-			&statusString,
-			&taskRun.StartedAt,
-			&taskRun.RunAt,
-			&resultJSON,
-			&payloadJSON,
-			&taskRun.PlanUID,
-			&taskRun.Environment,
-			&taskRun.ProjectID,
-		); err != nil {
-			return nil, err
-		}
-		if creatorEmail.Valid {
-			taskRun.CreatorEmail = creatorEmail.String
-		}
-		if statusValue, ok := storepb.TaskRun_Status_value[statusString]; ok {
-			taskRun.Status = storepb.TaskRun_Status(statusValue)
-		} else {
-			return nil, errors.Errorf("invalid task run status string: %s", statusString)
-		}
-		resultProto := &storepb.TaskRunResult{}
-		if err := common.ProtojsonUnmarshaler.Unmarshal([]byte(resultJSON), resultProto); err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal result")
-		}
-		taskRun.ResultProto = resultProto
-		payloadProto := &storepb.TaskRunPayload{}
-		if err := common.ProtojsonUnmarshaler.Unmarshal([]byte(payloadJSON), payloadProto); err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal payload")
-		}
-		taskRun.PayloadProto = payloadProto
-		taskRuns = append(taskRuns, &taskRun)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return taskRuns, nil
 }


### PR DESCRIPTION
## Summary
- Consolidate cross-project status task-run listing into `ListTaskRuns`.
- Remove the duplicate `ListTaskRunsByStatus` query and scan path.
- Add a guard requiring project scope for ID-like task-run filters.

## Test Plan
- [x] `go test -count=1 ./backend/store ./backend/runner/taskrun`
- [x] `go test -v -count=1 ./backend/tests/ -run "^(TestClaim|TestCollision)" -timeout 5m`
- [x] `golangci-lint run --allow-parallel-runners`
- [x] `golangci-lint run --fix --allow-parallel-runners`
- [x] `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`