### PR TITLE
fix(idp): drop Content-Type header on OAuth2 userinfo GET request

### DIFF
--- a/backend/plugin/idp/oauth2/oauth2.go
+++ b/backend/plugin/idp/oauth2/oauth2.go
@@ -107,7 +107,7 @@ func (p *IdentityProvider) UserInfo(token string) (*storepb.IdentityProviderUser
 
 	if resp.StatusCode != http.StatusOK {
 		slog.Error("Unexpected status code from user info endpoint", slog.Int("status", resp.StatusCode), slog.String("body", string(body)))
-		return nil, nil, errors.Errorf("user info request failed with status %d: %s", resp.StatusCode, string(body))
+		return nil, nil, errors.Errorf("user info request failed with status %d", resp.StatusCode)
 	}
 
 	var claims map[string]any

--- a/backend/plugin/idp/oauth2/oauth2.go
+++ b/backend/plugin/idp/oauth2/oauth2.go
@@ -92,7 +92,6 @@ func (p *IdentityProvider) UserInfo(token string) (*storepb.IdentityProviderUser
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to new http request")
 	}
-	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	resp, err := p.client.Do(req)
 	if err != nil {
@@ -104,6 +103,11 @@ func (p *IdentityProvider) UserInfo(token string) (*storepb.IdentityProviderUser
 	if err != nil {
 		slog.Error("Failed to read response body", slog.String("token", token), log.BBError(err))
 		return nil, nil, errors.Wrap(err, "failed to read response body")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		slog.Error("Unexpected status code from user info endpoint", slog.Int("status", resp.StatusCode), slog.String("body", string(body)))
+		return nil, nil, errors.Errorf("user info request failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
 	var claims map[string]any

--- a/backend/plugin/idp/oauth2/oauth2_test.go
+++ b/backend/plugin/idp/oauth2/oauth2_test.go
@@ -98,7 +98,15 @@ func newMockServer(t *testing.T, tls bool, code, accessToken string, userinfo []
 		})
 		require.NoError(t, err)
 	})
-	mux.HandleFunc("/oauth2/userinfo", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/oauth2/userinfo", func(w http.ResponseWriter, r *http.Request) {
+		// Regression guard: a body-less userinfo GET must not declare a request
+		// media type. OCI IAM Identity Domains reject such a request with HTTP 415
+		// and an empty body, which previously surfaced as a misleading JSON
+		// unmarshal error.
+		if r.Header.Get("Content-Type") != "" {
+			w.WriteHeader(http.StatusUnsupportedMediaType)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write(userinfo)
 		require.NoError(t, err)
@@ -163,6 +171,34 @@ func TestIdentityProvider(t *testing.T) {
 		DisplayName: testName,
 	}
 	assert.Equal(t, wantUserInfo, userInfoResult)
+}
+
+func TestUserInfo_NonOKStatusSurfacesError(t *testing.T) {
+	// The user info endpoint returns a non-2xx status with an empty body (e.g.
+	// OCI's HTTP 415). The error must surface the status instead of the
+	// misleading "unexpected end of JSON input".
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnsupportedMediaType)
+	}))
+	defer s.Close()
+
+	p, err := NewIdentityProvider(
+		&storepb.OAuth2IdentityProviderConfig{
+			ClientId:     "test-client-id",
+			ClientSecret: "test-client-secret",
+			TokenUrl:     fmt.Sprintf("%s/oauth2/token", s.URL),
+			UserInfoUrl:  fmt.Sprintf("%s/oauth2/userinfo", s.URL),
+			FieldMapping: &storepb.FieldMapping{
+				Identifier: "sub",
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	_, _, err = p.UserInfo("test-access-token")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "415")
+	assert.NotContains(t, err.Error(), "unexpected end of JSON input")
 }
 
 func TestIdentityProvider_SelfSigned(t *testing.T) {


### PR DESCRIPTION
## Problem

The OAuth2 ("custom") identity provider fails at the userinfo step against
Oracle Cloud Infrastructure (OCI) IAM Identity Domains with:

    failed to get user info, error: failed to unmarshal response body: unexpected end of JSON input

The error is misleading: it is reported as a JSON parsing problem, but the real
cause is an HTTP 415 (Unsupported Media Type) response with an empty body.

## Root cause

`backend/plugin/idp/oauth2/oauth2.go` `UserInfo()` sends the userinfo request as
a GET with no body, but sets a request body media type:

```go
req, err := http.NewRequest(http.MethodGet, p.config.UserInfoUrl, nil)
...
req.Header.Set("Content-Type", "application/json")   // on a body-less GET
req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
```

`Content-Type` describes the request body, but a GET userinfo request has none.
OCI's userinfo endpoint rejects the declared `application/json` media type with
**415 Unsupported Media Type** and an empty body. The function then does not
check `resp.StatusCode` and passes the empty body straight to `json.Unmarshal`,
producing "unexpected end of JSON input".

This matches the OIDC spec: a userinfo GET carries only the bearer token and no
request body / Content-Type.

## Fix

Remove the unnecessary `Content-Type` header from the userinfo GET, and check the
response status so a non-2xx response surfaces the real error instead of a JSON
unmarshal error.

## Reproduction

IdP: OAuth2 custom, pointing at an OCI IAM Identity Domain
(`https://idcs-<id>.identity.oraclecloud.com`), scopes include `openid`.

Same access token, only difference is the Content-Type header:

| Request to `/oauth2/v1/userinfo`                             | Result |
|--------------------------------------------------------------|--------|
| `Authorization: Bearer …` + `Content-Type: application/json` | **HTTP 415**, empty body |
| `Authorization: Bearer …` (no Content-Type)                  | **HTTP 200**, full claims |

200 response body (claims, values redacted):

```json
{ "sub": "user@example.com", "email": "user@example.com",
  "email_verified": true, "name": "...", "preferred_username": "..." }
```

So the only thing standing between a working login and the failure is the
`Content-Type: application/json` header on the GET.

## Test plan

- OAuth2 custom IdP against OCI IAM Identity Domains: login succeeds, claims
  (email/sub) are returned.
- The mock user info handler now rejects any request carrying a `Content-Type`
  header (mirroring OCI's 415), so existing happy-path tests guard against
  re-introducing the header.
- `TestUserInfo_NonOKStatusSurfacesError` asserts a non-2xx user info response
  surfaces the status instead of a JSON unmarshal error.
- Existing OAuth2 IdPs (e.g. GitHub) continue to work — removing a request-body
  Content-Type from a body-less GET is a no-op for servers that ignored it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
