### PR TITLE
fix(mysql): prune MariaDB foreign-key and trigger sync queries to one database

### DIFF
--- a/backend/plugin/db/mysql/sync.go
+++ b/backend/plugin/db/mysql/sync.go
@@ -718,6 +718,9 @@ func (d *Driver) getCreateEventStmt(ctx context.Context, databaseName string, na
 }
 
 func (d *Driver) getTriggerList(ctx context.Context, databaseName string) (map[db.TableKey][]*storepb.TriggerMetadata, error) {
+	// Prune to a single database on MariaDB: filter by EVENT_OBJECT_SCHEMA (the
+	// trigger's table schema), not TRIGGER_SCHEMA, which scans every database's
+	// table metadata. A trigger lives in its table's schema, so they are equivalent.
 	triggersQuery := `
 	SELECT 
 		TRIGGER_NAME,
@@ -729,7 +732,7 @@ func (d *Driver) getTriggerList(ctx context.Context, databaseName string) (map[d
 		CHARACTER_SET_CLIENT,
 		COLLATION_CONNECTION
 	FROM INFORMATION_SCHEMA.TRIGGERS
-	WHERE TRIGGER_SCHEMA = ?
+	WHERE EVENT_OBJECT_SCHEMA = ?
 	ORDER BY EVENT_OBJECT_TABLE ASC, EVENT_MANIPULATION ASC, ACTION_TIMING ASC, ACTION_ORDER ASC;
 	`
 	triggerRows, err := d.db.QueryContext(ctx, triggersQuery, databaseName)
@@ -1316,6 +1319,11 @@ func convertToStorepbTablePartitionType(tp string) storepb.TablePartitionMetadat
 }
 
 func (d *Driver) getForeignKeyList(ctx context.Context, databaseName string) (map[db.TableKey][]*storepb.ForeignKeyMetadata, error) {
+	// Prune to a single database on MariaDB instead of opening every database's
+	// table metadata (Error 1969 on large instances). REFERENTIAL_CONSTRAINTS prunes
+	// on CONSTRAINT_SCHEMA; KEY_COLUMN_USAGE prunes only on TABLE_SCHEMA. A foreign
+	// key lives in its table's schema, so the predicates are equivalent. Never wrap
+	// the column in LOWER() -- it defeats the pruning.
 	fkQuery := `
 		SELECT
 			TABLE_NAME,
@@ -1325,7 +1333,7 @@ func (d *Driver) getForeignKeyList(ctx context.Context, databaseName string) (ma
 			UPDATE_RULE,
 			MATCH_OPTION
 		FROM INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS
-		WHERE LOWER(CONSTRAINT_SCHEMA) = ?;
+		WHERE CONSTRAINT_SCHEMA = ?;
 	`
 
 	kcuQuery := `
@@ -1335,7 +1343,7 @@ func (d *Driver) getForeignKeyList(ctx context.Context, databaseName string) (ma
 			COLUMN_NAME,
 			REFERENCED_COLUMN_NAME
 		FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
-		WHERE POSITION_IN_UNIQUE_CONSTRAINT IS NOT NULL AND LOWER(CONSTRAINT_SCHEMA) = ?
+		WHERE POSITION_IN_UNIQUE_CONSTRAINT IS NOT NULL AND TABLE_SCHEMA = ?
 		ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION;
 	`
 


### PR DESCRIPTION
## Problem

Follow-up to #20643 (CHECK_CONSTRAINTS). A customer on a large MariaDB instance (~200 DBs / 5k tables) deployed that fix and then hit the **same failure mode on a different query**:

`failed to execute query "... FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE POSITION_IN_UNIQUE_CONSTRAINT IS NOT NULL AND LOWER(CONSTRAINT_SCHEMA) = ?": Error 1969 (70100): Query execution was interrupted (max_statement_time exceeded)`

Same root cause as #20643: a per-database sync query that MariaDB cannot prune, so it opens every table in **every** database (`EXPLAIN`: `Scanned all databases`), run once per database. I audited **all** per-database `information_schema` queries this time; three were affected.

## Root cause & fix

| Query | Old predicate | Plan | Fix | Plan after |
|---|---|---|---|---|
| `REFERENTIAL_CONSTRAINTS` | `LOWER(CONSTRAINT_SCHEMA) = ?` | Scanned all databases | `CONSTRAINT_SCHEMA = ?` | Scanned 1 database |
| `KEY_COLUMN_USAGE` | `LOWER(CONSTRAINT_SCHEMA) = ?` | Scanned all databases | `TABLE_SCHEMA = ?` | Scanned 1 database |
| `TRIGGERS` | `TRIGGER_SCHEMA = ?` | Scanned all databases | `EVENT_OBJECT_SCHEMA = ?` | Scanned 1 database |

- `LOWER()` defeats MariaDB's schema pushdown (and was asymmetric — it compared `LOWER(col)` to an un-lowered param, silently returning **zero** FKs for any mixed-case schema name). Introduced by #14245.
- `KEY_COLUMN_USAGE` needs `TABLE_SCHEMA` specifically — bare `CONSTRAINT_SCHEMA` still scans all databases (verified). A foreign key lives in its table's schema, so it's equivalent.
- `TRIGGERS` prunes only on `EVENT_OBJECT_SCHEMA`. A trigger lives in its table's schema, so it's equivalent.

These are general (not MariaDB-gated): semantically identical results and better pruning on MySQL too.

`EVENTS`/`ROUTINES` are system-table backed (no `Scanned`/`Open_full_table`) and already cheap; every other per-db query already filters on a prune-friendly schema column.

## Testing

- Verified on MariaDB 11.4 with 5k tables across 50 databases: each query's `EXPLAIN` goes from `Scanned all databases` → `Scanned 1 database`, and each returns rows **identical** to the old predicate (named/anonymous FKs and triggers).
- Server-side timing on a 2-table target schema in that instance: KEY_COLUMN_USAGE ~0.2 ms (`TABLE_SCHEMA`) vs ~50–880 ms (`LOWER(CONSTRAINT_SCHEMA)`).
- gofmt / go vet / golangci-lint (0 issues) / build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)