### PR TITLE
fix(plan-detail): skipped-approval review box, vertical flow rail, dup-key warning

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
@@ -928,6 +928,40 @@ describe("PlanDetailChangesBranch", () => {
     ).toBe(false);
   });
 
+  it("does not render the spec sections with duplicate React keys", async () => {
+    // View mode (not creating) renders the Targets/Statement/Options sections.
+    const page = buildPageState();
+    page.isCreating = false;
+    const renderBranch = () =>
+      act(() => {
+        root.render(
+          <PlanDetailProvider value={{ ...page }}>
+            <PlanDetailChangesBranch
+              selectedSpecId="spec-1"
+              onSelectedSpecIdChange={vi.fn()}
+            />
+          </PlanDetailProvider>
+        );
+      });
+
+    // React only flags duplicate sibling keys during update reconciliation —
+    // the live page hits this constantly as it re-renders (data loads,
+    // polling). The spec sections must not share key={selectedSpec.id}.
+    renderBranch();
+    await flush();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    renderBranch();
+    await flush();
+    const fired = consoleError.mock.calls.some((call) =>
+      String(call[0]).includes("two children with the same key")
+    );
+    consoleError.mockRestore();
+
+    expect(fired).toBe(false);
+  });
+
   it("hides stale draft check runs after the create-plan statement changes", async () => {
     const sheetName = "projects/foo/sheets/-1";
     mocks.localSheets.set(sheetName, {

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -612,15 +612,17 @@ export function PlanDetailChangesBranch({
       </PlanDetailTabStrip>
 
       <div className="flex flex-1 flex-col overflow-y-auto px-4 py-4">
-        <div className="flex flex-col gap-y-4">
+        {/* One key on the wrapper — not on each child — remounts the whole
+            spec-detail group when the selected spec changes (resetting each
+            section's internal state) without the sections colliding on a shared
+            key={selectedSpec.id}, which logged a duplicate-key warning. */}
+        <div key={selectedSpec.id} className="flex flex-col gap-y-4">
           <TargetsSection
-            key={selectedSpec.id}
             allowEdit={canModifySpecs}
             onEdit={() => setShowTargetSelectorSheet(true)}
             selectedSpec={selectedSpec}
           />
           <PlanDetailStatementSection
-            key={selectedSpec.id}
             planCheckRuns={
               page.isCreating
                 ? draftCheckRuns
@@ -633,7 +635,6 @@ export function PlanDetailChangesBranch({
             page.isCreating &&
             selectedSpec.config.case === "changeDatabaseConfig" && (
               <PlanDetailDraftChecks
-                key={selectedSpec.id}
                 checkResults={draftCheckResults}
                 onCheckResultsChange={handleDraftCheckResultsChange}
                 selectedSpec={selectedSpec}
@@ -641,7 +642,6 @@ export function PlanDetailChangesBranch({
             )}
           {!specHasRelease && (
             <OptionsSection
-              key={selectedSpec.id}
               onStatementPersisted={() =>
                 handleStatementPersisted(selectedSpec.id)
               }

--- a/frontend/src/react/pages/project/plan-detail/components/review/PlanReviewSection.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/review/PlanReviewSection.test.tsx
@@ -593,7 +593,7 @@ describe("PlanReviewSection — five review states", () => {
     unmount();
   });
 
-  test("skipped (SKIPPED): skip line renders + footer shows all-gates-passed", () => {
+  test("skipped (SKIPPED): footer shows all-gates-passed", () => {
     const issue = makeIssue({
       approvalStatus: ApprovalStatus.SKIPPED,
       roles: [],
@@ -608,10 +608,9 @@ describe("PlanReviewSection — five review states", () => {
 
     render();
 
-    // Skip placeholder rendered in PlanReviewSection itself
-    expect(container.textContent).toContain(
-      "custom-approval.approval-flow.skip"
-    );
+    // The "no approval required" note is rendered by ReviewApprovalFlow itself
+    // (mocked out here; covered in ReviewApprovalFlow.test.tsx). The footer
+    // treats a skipped approval as satisfied.
     expect(container.textContent).toContain(
       "plan.review.footer.all-gates-passed"
     );

--- a/frontend/src/react/pages/project/plan-detail/components/review/PlanReviewSection.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/review/PlanReviewSection.tsx
@@ -67,20 +67,12 @@ export function PlanReviewSection() {
     );
   }
 
-  const skipped =
-    issue.approvalStatus === ApprovalStatus.SKIPPED ||
-    (issue.approvalTemplate?.flow?.roles ?? []).length === 0;
-
   return (
     <div className="flex flex-col">
       <PlanReviewSectionHeader issue={issue} />
-      {skipped ? (
-        <div className="px-4 py-3 text-sm text-control-placeholder">
-          {t("custom-approval.approval-flow.skip")}
-        </div>
-      ) : (
-        <ReviewApprovalFlow issue={issue} />
-      )}
+      {/* ReviewApprovalFlow renders the "no approval required" note itself when
+          the approval is skipped / has no roles, so no guard is needed here. */}
+      <ReviewApprovalFlow issue={issue} />
       <ReviewRejectionBanner comments={comments} issue={issue} />
       <ReviewActivityTimeline
         comments={comments}

--- a/frontend/src/react/pages/project/plan-detail/components/review/ReviewApprovalFlow.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/review/ReviewApprovalFlow.test.tsx
@@ -1,0 +1,154 @@
+import type { ReactElement } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { describe, expect, test, vi } from "vitest";
+import { ApprovalStatus } from "@/types/proto-es/v1/common_pb";
+import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// Module mocks. The skipped/empty path under test only needs `useTranslation`;
+// the heavy store/context/candidate hooks fire solely when flow nodes render
+// (the non-skipped test below), so stub them to keep the graph isolated.
+// ---------------------------------------------------------------------------
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params && Object.keys(params).length > 0
+        ? `${key}:${JSON.stringify(params)}`
+        : key,
+  }),
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      roleList: [],
+      getUserByIdentifier: () => undefined,
+      projectPoliciesByName: {},
+    }),
+}));
+
+vi.mock("./useApprovalCandidates", () => ({
+  useApprovalCandidates: () => ({
+    candidates: [],
+    isCurrentUserCandidate: false,
+  }),
+}));
+
+vi.mock("../../shell/PlanDetailContext", () => ({
+  usePlanDetailContext: () => ({ projectId: "p1" }),
+}));
+
+vi.mock("@/react/components/UserAvatar", () => ({
+  getAvatarColor: () => "#000",
+  getInitials: (name: string) => name.slice(0, 2),
+}));
+
+vi.mock("@/store/modules/v1/common", () => ({
+  projectNamePrefix: "projects/",
+}));
+
+vi.mock("@/types", () => ({
+  unknownUser: (principal: string) => ({
+    name: principal,
+    email: principal,
+    title: principal,
+  }),
+}));
+
+vi.mock("@/react/lib/role", () => ({
+  displayRoleTitleFromList: (role: string) => role,
+}));
+
+import { ReviewApprovalFlow } from "./ReviewApprovalFlow";
+
+const makeIssue = ({
+  approvalStatus = ApprovalStatus.PENDING,
+  roles = ["roles/PROJECT_OWNER"],
+}: {
+  approvalStatus?: ApprovalStatus;
+  roles?: string[];
+} = {}): Issue =>
+  ({
+    name: "projects/p1/issues/123",
+    approvalStatus,
+    approvers: [],
+    approvalTemplate: { flow: { roles }, title: "Test policy" },
+    riskLevel: 0,
+  }) as unknown as Issue;
+
+const renderIntoContainer = (element: ReactElement) => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  return {
+    container,
+    render: () => act(() => root.render(element)),
+    unmount: () => act(() => root.unmount()),
+  };
+};
+
+describe("ReviewApprovalFlow", () => {
+  // BYT-9745: a skipped approval has no flow to render. The component must show
+  // the "no approval required" note instead of an empty box — otherwise callers
+  // that forget to guard the skipped case (e.g. the bypass confirm sheet) show
+  // an empty bordered box.
+  test("SKIPPED approval renders the no-approval-required note", () => {
+    const issue = makeIssue({
+      approvalStatus: ApprovalStatus.SKIPPED,
+      roles: [],
+    });
+    const { container, render, unmount } = renderIntoContainer(
+      <ReviewApprovalFlow issue={issue} />
+    );
+
+    render();
+
+    expect(container.textContent).toContain(
+      "custom-approval.approval-flow.skip"
+    );
+
+    unmount();
+  });
+
+  test("template with no approver roles renders the note (not an empty box)", () => {
+    const issue = makeIssue({
+      approvalStatus: ApprovalStatus.APPROVED,
+      roles: [],
+    });
+    const { container, render, unmount } = renderIntoContainer(
+      <ReviewApprovalFlow issue={issue} />
+    );
+
+    render();
+
+    expect(container.textContent).toContain(
+      "custom-approval.approval-flow.skip"
+    );
+
+    unmount();
+  });
+
+  test("a pending flow with roles renders the approval node, not the skip note", () => {
+    const issue = makeIssue({
+      approvalStatus: ApprovalStatus.PENDING,
+      roles: ["roles/PROJECT_OWNER"],
+    });
+    const { container, render, unmount } = renderIntoContainer(
+      <ReviewApprovalFlow issue={issue} />
+    );
+
+    render();
+
+    expect(container.textContent).toContain("roles/PROJECT_OWNER");
+    expect(container.textContent).not.toContain(
+      "custom-approval.approval-flow.skip"
+    );
+
+    unmount();
+  });
+});

--- a/frontend/src/react/pages/project/plan-detail/components/review/ReviewApprovalFlow.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/review/ReviewApprovalFlow.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import { unknownUser } from "@/types";
+import { ApprovalStatus } from "@/types/proto-es/v1/common_pb";
 import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
 import { Issue_Approver_Status } from "@/types/proto-es/v1/issue_service_pb";
 import type { User as UserProto } from "@/types/proto-es/v1/user_service_pb";
@@ -51,6 +52,7 @@ export function deriveSteps(issue: Issue): FlowStep[] {
 }
 
 export function ReviewApprovalFlow({ issue }: { issue: Issue }) {
+  const { t } = useTranslation();
   const hostRef = useRef<HTMLDivElement>(null);
   const [width, setWidth] = useState(0);
 
@@ -76,6 +78,18 @@ export function ReviewApprovalFlow({ issue }: { issue: Issue }) {
       ),
     [steps, width]
   );
+
+  // A skipped approval — or a resolved template with no approver roles — has no
+  // flow to render. Show the "no approval required" note here so every caller
+  // (the review section and the bypass confirm sheet) stays consistent, instead
+  // of each guarding the empty case on its own (BYT-9745).
+  if (issue.approvalStatus === ApprovalStatus.SKIPPED || steps.length === 0) {
+    return (
+      <div className="px-4 py-3 text-sm text-control-placeholder">
+        {t("custom-approval.approval-flow.skip")}
+      </div>
+    );
+  }
 
   return (
     <div ref={hostRef} className="min-w-0 px-4 py-3">
@@ -159,9 +173,15 @@ function HorizontalFlow({
 
 function VerticalFlow({ issue, steps }: { issue: Issue; steps: FlowStep[] }) {
   return (
-    <div className="flex flex-col gap-y-3">
-      {steps.map((step) => (
-        <FlowNode key={step.index} issue={issue} step={step} vertical />
+    <div className="flex flex-col">
+      {steps.map((step, i) => (
+        <FlowNode
+          key={step.index}
+          isLast={i === steps.length - 1}
+          issue={issue}
+          step={step}
+          vertical
+        />
       ))}
     </div>
   );
@@ -196,10 +216,12 @@ function FlowNode({
   issue,
   step,
   vertical = false,
+  isLast = false,
 }: {
   issue: Issue;
   step: FlowStep;
   vertical?: boolean;
+  isLast?: boolean;
 }) {
   const { t } = useTranslation();
   const page = usePlanDetailContext();
@@ -227,8 +249,20 @@ function FlowNode({
         !vertical && "shrink-0"
       )}
     >
-      <StatusDot index={step.index + 1} status={step.status} />
-      <div className="min-w-0">
+      {vertical ? (
+        // Timeline rail: the status dot plus a connector line dropping to the
+        // next node — the vertical counterpart of HorizontalFlow's between-node
+        // connectors. The rail stretches to the row height (self-stretch) so the
+        // flex-1 line reaches the next dot; spacing comes from the text's
+        // padding-bottom rather than a container gap, so the line stays unbroken.
+        <div className="flex flex-col items-center self-stretch">
+          <StatusDot index={step.index + 1} status={step.status} />
+          {!isLast && <div className="w-px flex-1 bg-control-border" />}
+        </div>
+      ) : (
+        <StatusDot index={step.index + 1} status={step.status} />
+      )}
+      <div className={cn("min-w-0", vertical && !isLast && "pb-3")}>
         <div className="flex items-center gap-x-1.5">
           <span className="truncate text-sm font-medium text-main">
             {roleName}


### PR DESCRIPTION
## What & why

Three related fixes to the AIO Plan Detail page, surfaced during e2e QA.

### 1. Skipped-approval shows an empty Review box (BYT-9745)
The **Bypass and deploy** confirm sheet rendered `ReviewApprovalFlow` directly, which produced an **empty bordered box** when an issue's approval is SKIPPED (no approver roles → `deriveSteps()` returns `[]`). The main Review section guarded this with a "no approval required" note; the confirm sheet did not.

Fixed at the root: `ReviewApprovalFlow` now renders the note itself for skipped / no-role approvals, so the confirm sheet — and any future caller — is correct with no extra guard. Removed the now-redundant branch in `PlanReviewSection` (single source of truth).

### 2. Vertical approval flow had no connector line
Added a timeline rail between status dots in the vertical layout, mirroring the horizontal flow's between-node connectors.

### 3. Duplicate React key warning on the changes page
The Targets / Statement / DraftChecks / Options sections each used `key={selectedSpec.id}`. A spec id is a UUID, so all the siblings shared one key and React logged *"Encountered two children with the same key"* on every re-render. Moved the key to a single wrapper `<div>` — the group still remounts on spec change (resetting each section's state) without the sibling collision.

## Testing
- New `ReviewApprovalFlow.test.tsx`: skipped / no-role → renders the note; pending flow → renders the node.
- New regression test in `PlanDetailChangesBranch.test.tsx` — renders twice, since React only flags duplicate sibling keys during *update* reconciliation.
- Changed-area tests pass: 37 review + 11 changes-branch.
- `pnpm --dir frontend check` and `pnpm --dir frontend type-check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)