### PR TITLE
fix(frontend): revoke the exact project role binding on delete (BYT-9770)

### DIFF
--- a/frontend/src/react/pages/settings/MembersPage.tsx
+++ b/frontend/src/react/pages/settings/MembersPage.tsx
@@ -111,6 +111,7 @@ import {
   hasProjectPermissionV2,
   hasWorkspacePermissionV2,
   isBindingPolicyExpired,
+  revokeMemberFromBinding,
   sortRoles,
 } from "@/utils";
 import {
@@ -1501,17 +1502,11 @@ function EditMemberRoleDrawer({
       return;
     setIsRequesting(true);
     try {
-      const policy = structuredClone(getProjectIamPolicy(projectName));
-      const match = policy.bindings.find(
-        (b) =>
-          b.role === roleBinding.role &&
-          (b.condition?.expression ?? "") ===
-            (roleBinding.condition?.expression ?? "")
+      const policy = revokeMemberFromBinding(
+        getProjectIamPolicy(projectName),
+        roleBinding,
+        member.binding
       );
-      if (match) {
-        match.members = match.members.filter((m) => m !== member.binding);
-      }
-      policy.bindings = policy.bindings.filter((b) => b.members.length > 0);
       await updateProjectIamPolicy(projectName, policy);
       pushNotification({
         module: "bytebase",

--- a/frontend/src/utils/v1/iam.test.ts
+++ b/frontend/src/utils/v1/iam.test.ts
@@ -1,0 +1,107 @@
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, test } from "vitest";
+import { ExprSchema as ConditionExprSchema } from "@/types/proto-es/google/type/expr_pb";
+import {
+  BindingSchema,
+  IamPolicySchema,
+} from "@/types/proto-es/v1/iam_policy_pb";
+import { revokeMemberFromBinding } from "./iam";
+
+// A database-scoped grant with no expiration. Several users granted the same
+// database via separate access requests end up as separate single-member
+// bindings that share this exact role + condition expression.
+const DB_SCOPED =
+  '(resource.database in ["instances/nf-prod-jfapp/databases/ekb_app2"])';
+
+const grant = (member: string) =>
+  create(BindingSchema, {
+    role: "roles/sqlEditorReadUser",
+    members: [member],
+    condition: create(ConditionExprSchema, { expression: DB_SCOPED }),
+  });
+
+describe("revokeMemberFromBinding", () => {
+  test("revokes the clicked binding when several bindings share role and condition", () => {
+    const grantA = grant("user:a@example.com");
+    const grantB = grant("user:b@example.com");
+    const policy = create(IamPolicySchema, { bindings: [grantA, grantB] });
+
+    const result = revokeMemberFromBinding(
+      policy,
+      grantB,
+      "user:b@example.com"
+    );
+
+    const members = result.bindings.flatMap((b) => b.members);
+    expect(members).not.toContain("user:b@example.com");
+    expect(members).toContain("user:a@example.com");
+  });
+
+  test("removes only the targeted member from a shared multi-member binding", () => {
+    const binding = create(BindingSchema, {
+      role: "roles/sqlEditorReadUser",
+      members: [
+        "user:a@example.com",
+        "user:b@example.com",
+        "user:c@example.com",
+      ],
+      condition: create(ConditionExprSchema, { expression: DB_SCOPED }),
+    });
+    const policy = create(IamPolicySchema, { bindings: [binding] });
+
+    const result = revokeMemberFromBinding(
+      policy,
+      binding,
+      "user:b@example.com"
+    );
+
+    expect(result.bindings).toHaveLength(1);
+    expect(result.bindings[0].members).toEqual([
+      "user:a@example.com",
+      "user:c@example.com",
+    ]);
+  });
+
+  test("drops the binding once its last member is revoked", () => {
+    const binding = grant("user:a@example.com");
+    const policy = create(IamPolicySchema, { bindings: [binding] });
+
+    const result = revokeMemberFromBinding(
+      policy,
+      binding,
+      "user:a@example.com"
+    );
+
+    expect(result.bindings).toHaveLength(0);
+  });
+
+  test("does not mutate the input policy", () => {
+    const grantA = grant("user:a@example.com");
+    const grantB = grant("user:b@example.com");
+    const policy = create(IamPolicySchema, { bindings: [grantA, grantB] });
+
+    revokeMemberFromBinding(policy, grantB, "user:b@example.com");
+
+    expect(policy.bindings).toHaveLength(2);
+    expect(policy.bindings[1].members).toEqual(["user:b@example.com"]);
+  });
+
+  test("falls back to role + condition + membership when the target is not the same reference", () => {
+    const grantA = grant("user:a@example.com");
+    const grantB = grant("user:b@example.com");
+    const policy = create(IamPolicySchema, { bindings: [grantA, grantB] });
+    // A structurally-equal copy with a different object identity, e.g. after a
+    // round-trip through the cache.
+    const targetCopy = grant("user:b@example.com");
+
+    const result = revokeMemberFromBinding(
+      policy,
+      targetCopy,
+      "user:b@example.com"
+    );
+
+    const members = result.bindings.flatMap((b) => b.members);
+    expect(members).not.toContain("user:b@example.com");
+    expect(members).toContain("user:a@example.com");
+  });
+});

--- a/frontend/src/utils/v1/iam.ts
+++ b/frontend/src/utils/v1/iam.ts
@@ -44,6 +44,41 @@ export const isBindingPolicyExpired = (binding: Binding): boolean => {
   return false;
 };
 
+// Revoke a single member from one specific role binding, returning a new policy
+// (the input is left untouched).
+//
+// The target binding is resolved by reference identity first, then by role +
+// condition expression + membership. Identity matching matters because a policy
+// can hold several bindings that share the same (role, condition) — e.g. when
+// multiple users are granted the same database with no expiration, each grant is
+// stored as a separate single-member binding. Resolving only by (role,
+// condition) would match the first such binding, which need not contain the
+// member being revoked, silently leaving the intended grant in place.
+export const revokeMemberFromBinding = (
+  policy: IamPolicy,
+  targetBinding: Binding,
+  member: string
+): IamPolicy => {
+  let index = policy.bindings.indexOf(targetBinding);
+  if (index < 0) {
+    index = policy.bindings.findIndex(
+      (b) =>
+        b.role === targetBinding.role &&
+        (b.condition?.expression ?? "") ===
+          (targetBinding.condition?.expression ?? "") &&
+        b.members.includes(member)
+    );
+  }
+  const next = structuredClone(policy);
+  if (index >= 0) {
+    next.bindings[index].members = next.bindings[index].members.filter(
+      (m) => m !== member
+    );
+  }
+  next.bindings = next.bindings.filter((b) => b.members.length > 0);
+  return next;
+};
+
 export const convertMemberToFullname = (member: string) => {
   if (member.startsWith(groupBindingPrefix)) {
     return ensureGroupIdentifier(member);


### PR DESCRIPTION
## Summary

Fixes BYT-9770: revoking a role grant in the project **Members** drawer reported success ("Deleted") but did not remove the grant.

## Root cause

`handleDeleteRole` selected the binding to modify with
`bindings.find(b => b.role === … && b.condition?.expression === …)`. That key is **not unique** — a project IAM policy can hold several bindings with the same role and identical condition expression (e.g. multiple users granted the same database with no expiration, each stored as a separate single-member binding). `.find()` returned the *first* match, which need not contain the member being revoked, so the member was filtered out of the wrong binding (a no-op). The unchanged policy was then sent to `SetIamPolicy`, the backend faithfully persisted it, and the UI showed a success toast while the grant remained.

The backend (`SetIamPolicy` full-replace) and the other removal paths (whole-member revoke, grant creation) were already correct — the bug was isolated to this one handler.

## Fix

Extract `revokeMemberFromBinding` in `utils/v1/iam.ts`, which resolves the target binding by **reference identity first**, falling back to role + condition expression + membership, then removes the member and drops emptied bindings. `handleDeleteRole` delegates to it, so the grant the user clicked is always the one removed.

## Testing

- New `utils/v1/iam.test.ts` reproduces the collision (deleting the second of two bindings that share a role + condition) plus edge cases: multi-member binding, last-member removal, input policy not mutated, non-reference fallback. The collision test fails on the old logic and passes with the fix.
- `pnpm --dir frontend check`, `pnpm --dir frontend type-check`, and the iam / members test suites pass.
- Manually reproduced against a seeded project: pre-fix the delete no-ops with a success toast; post-fix the grant is actually removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
