### PR TITLE
feat(plan): consolidate consecutive similar review-timeline activities

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1,5 +1,7 @@
 {
   "activity": {
+    "n-similar-activities_one": "{{count}} similar activity",
+    "n-similar-activities_other": "{{count}} similar activities",
     "sentence": {
       "added-spec": "added",
       "canceled-issue": "closed the issue",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1,7 +1,6 @@
 {
   "activity": {
-    "n-similar-activities_one": "{{count}} similar activity",
-    "n-similar-activities_other": "{{count}} similar activities",
+    "n-similar-activities": "{{count}} similar activities",
     "sentence": {
       "added-spec": "added",
       "canceled-issue": "closed the issue",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1,5 +1,7 @@
 {
   "activity": {
+    "n-similar-activities_one": "{{count}} actividad similar",
+    "n-similar-activities_other": "{{count}} actividades similares",
     "sentence": {
       "added-spec": "añadió",
       "canceled-issue": "cerró el issue",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1,7 +1,6 @@
 {
   "activity": {
-    "n-similar-activities_one": "{{count}} actividad similar",
-    "n-similar-activities_other": "{{count}} actividades similares",
+    "n-similar-activities": "{{count}} actividades similares",
     "sentence": {
       "added-spec": "añadió",
       "canceled-issue": "cerró el issue",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1,5 +1,7 @@
 {
   "activity": {
+    "n-similar-activities_one": "{{count}} 件の類似アクティビティ",
+    "n-similar-activities_other": "{{count}} 件の類似アクティビティ",
     "sentence": {
       "added-spec": "追加しました",
       "canceled-issue": "Issue をクローズしました",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1,7 +1,6 @@
 {
   "activity": {
-    "n-similar-activities_one": "{{count}} 件の類似アクティビティ",
-    "n-similar-activities_other": "{{count}} 件の類似アクティビティ",
+    "n-similar-activities": "{{count}} 件の類似アクティビティ",
     "sentence": {
       "added-spec": "追加しました",
       "canceled-issue": "Issue をクローズしました",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1,7 +1,6 @@
 {
   "activity": {
-    "n-similar-activities_one": "{{count}} hoạt động tương tự",
-    "n-similar-activities_other": "{{count}} hoạt động tương tự",
+    "n-similar-activities": "{{count}} hoạt động tương tự",
     "sentence": {
       "added-spec": "đã thêm",
       "canceled-issue": "đã đóng issue",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1,5 +1,7 @@
 {
   "activity": {
+    "n-similar-activities_one": "{{count}} hoạt động tương tự",
+    "n-similar-activities_other": "{{count}} hoạt động tương tự",
     "sentence": {
       "added-spec": "đã thêm",
       "canceled-issue": "đã đóng issue",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1,7 +1,6 @@
 {
   "activity": {
-    "n-similar-activities_one": "{{count}} 条相似动态",
-    "n-similar-activities_other": "{{count}} 条相似动态",
+    "n-similar-activities": "{{count}} 条相似活动",
     "sentence": {
       "added-spec": "添加了",
       "canceled-issue": "关闭了工单",
@@ -1514,9 +1513,9 @@
         "add-a-comment": "添加评论...",
         "created-this-plan": "创建了此计划",
         "marked-ready-for-review": "将此计划提交审批",
-        "n-hidden-events_one": "{{count}} 条隐藏动态",
-        "n-hidden-events_other": "{{count}} 条隐藏动态",
-        "self": "动态",
+        "n-hidden-events_one": "{{count}} 条隐藏活动",
+        "n-hidden-events_other": "{{count}} 条隐藏活动",
+        "self": "活动",
         "show-all": "显示全部"
       },
       "approval-flow": {

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1,5 +1,7 @@
 {
   "activity": {
+    "n-similar-activities_one": "{{count}} 条相似动态",
+    "n-similar-activities_other": "{{count}} 条相似动态",
     "sentence": {
       "added-spec": "添加了",
       "canceled-issue": "关闭了工单",

--- a/frontend/src/react/components/issue-activity/IssueCommentActivity.tsx
+++ b/frontend/src/react/components/issue-activity/IssueCommentActivity.tsx
@@ -16,6 +16,7 @@ import {
 import { ReadonlyDiffMonaco } from "@/react/components/monaco";
 import { RouterLink } from "@/react/components/RouterLink";
 import { UserAvatar } from "@/react/components/UserAvatar";
+import { Badge } from "@/react/components/ui/badge";
 import {
   Dialog,
   DialogContent,
@@ -182,7 +183,13 @@ export function CommentCreator({ creator }: { creator: User }) {
 // Header line for a comment-backed activity item: creator (suppressed for the
 // done-rollout system comment, whose sentence already names the actor), action
 // sentence, timestamp, and an "(edited)" marker for edited user comments.
-function IssueCommentHeader({ comment, issue, linkless, plan }: ActivityProps) {
+function IssueCommentHeader({
+  comment,
+  issue,
+  linkless,
+  plan,
+  similarCount,
+}: ActivityProps & { similarCount?: number }) {
   const { t } = useTranslation();
   const creatorUser = useAppStore((state) =>
     state.getUserByIdentifier(comment.creator)
@@ -205,6 +212,11 @@ function IssueCommentHeader({ comment, issue, linkless, plan }: ActivityProps) {
         linkless={linkless}
         plan={plan}
       />
+      {similarCount !== undefined && similarCount > 1 && (
+        <Badge className="px-2 text-xs" variant="default">
+          {t("activity.n-similar-activities", { count: similarCount })}
+        </Badge>
+      )}
       {comment.createTime && (
         <HumanizeTs className="text-gray-500" ts={createdTs / 1000} />
       )}
@@ -224,10 +236,12 @@ export function IssueCommentRow({
   issue,
   linkless,
   plan,
+  similarCount,
   subjectSuffix,
 }: ActivityProps & {
   body?: ReactNode;
   isLast: boolean;
+  similarCount?: number;
   subjectSuffix?: ReactNode;
 }) {
   return (
@@ -239,6 +253,7 @@ export function IssueCommentRow({
           issue={issue}
           linkless={linkless}
           plan={plan}
+          similarCount={similarCount}
         />
       }
       icon={

--- a/frontend/src/react/pages/project/plan-detail/components/review/ReviewActivityTimeline.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/review/ReviewActivityTimeline.tsx
@@ -26,6 +26,7 @@ import type { Issue, IssueComment } from "@/types/proto-es/v1/issue_service_pb";
 import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
 import { hasProjectPermissionV2 } from "@/utils/iam/permission";
 import { usePlanDetailContext } from "../../shell/PlanDetailContext";
+import { consolidateConsecutive } from "./consolidateTimeline";
 import { foldTimeline } from "./foldTimeline";
 import { ReviewCommentComposer } from "./ReviewCommentComposer";
 import {
@@ -61,7 +62,8 @@ export function ReviewActivityTimeline({
   );
   const items = useMemo(() => {
     const renderable = entries.filter(isRenderableEntry);
-    return foldTimeline(renderable, expanded);
+    const consolidated = consolidateConsecutive(renderable);
+    return foldTimeline(consolidated, expanded);
   }, [entries, expanded]);
   // Permission-gated only — comments are allowed regardless of issue status
   // (the backend and the issue-detail list allow commenting on done issues).
@@ -175,6 +177,7 @@ function ActivityRow({
         isLast={isLast}
         issue={issue}
         plan={plan}
+        similarCount={entry.similarCount}
       />
     );
   }
@@ -247,11 +250,13 @@ function ReviewCommentRow({
   isLast,
   issue,
   plan,
+  similarCount,
 }: {
   comment: IssueComment;
   isLast: boolean;
   issue: Issue;
   plan: Plan;
+  similarCount?: number;
 }) {
   const { t } = useTranslation();
   const page = usePlanDetailContext();
@@ -341,6 +346,7 @@ function ReviewCommentRow({
       issue={issue}
       linkless
       plan={plan}
+      similarCount={similarCount}
       subjectSuffix={subjectSuffix}
     />
   );

--- a/frontend/src/react/pages/project/plan-detail/components/review/consolidateTimeline.test.ts
+++ b/frontend/src/react/pages/project/plan-detail/components/review/consolidateTimeline.test.ts
@@ -1,0 +1,222 @@
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, test } from "vitest";
+import {
+  IssueCommentSchema,
+  IssueStatus,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { consolidateConsecutive } from "./consolidateTimeline";
+import type { TimelineEntry } from "./timelineEvents";
+
+const labelEntry = (id: string, creator = "users/a@x.com"): TimelineEntry => ({
+  id,
+  source: {
+    type: "comment",
+    comment: create(IssueCommentSchema, {
+      name: id,
+      creator,
+      event: { case: "issueUpdate", value: { toLabels: ["x"] } },
+    }),
+  },
+});
+
+const statusEntry = (id: string, creator = "users/a@x.com"): TimelineEntry => ({
+  id,
+  source: {
+    type: "comment",
+    comment: create(IssueCommentSchema, {
+      name: id,
+      creator,
+      event: {
+        case: "issueUpdate",
+        value: { fromStatus: IssueStatus.OPEN, toStatus: IssueStatus.DONE },
+      },
+    }),
+  },
+});
+
+const descriptionEntry = (
+  id: string,
+  creator = "users/a@x.com"
+): TimelineEntry => ({
+  id,
+  source: {
+    type: "comment",
+    comment: create(IssueCommentSchema, {
+      name: id,
+      creator,
+      event: {
+        case: "issueUpdate",
+        value: { fromDescription: "old", toDescription: "new" },
+      },
+    }),
+  },
+});
+
+const titleEntry = (
+  id: string,
+  from: string,
+  to: string,
+  creator = "users/a@x.com"
+): TimelineEntry => ({
+  id,
+  source: {
+    type: "comment",
+    comment: create(IssueCommentSchema, {
+      name: id,
+      creator,
+      event: { case: "issueUpdate", value: { fromTitle: from, toTitle: to } },
+    }),
+  },
+});
+
+const userEntry = (id: string, creator = "users/a@x.com"): TimelineEntry => ({
+  id,
+  source: {
+    type: "comment",
+    comment: create(IssueCommentSchema, { name: id, creator, comment: "hi" }),
+  },
+});
+
+const syntheticEntry = (id: string): TimelineEntry => ({
+  id,
+  source: { type: "plan-created", creator: "users/a@x.com" },
+});
+
+const shape = (entries: TimelineEntry[]) =>
+  entries.map((e) => ({ id: e.id, similarCount: e.similarCount }));
+
+// Reads the (possibly merged) title from/to off a consolidated entry.
+const titleOf = (entry: TimelineEntry) => {
+  if (entry.source.type !== "comment") return undefined;
+  const event = entry.source.comment.event;
+  return event.case === "issueUpdate"
+    ? { from: event.value.fromTitle, to: event.value.toTitle }
+    : undefined;
+};
+
+describe("consolidateConsecutive", () => {
+  test("empty input returns empty", () => {
+    expect(consolidateConsecutive([])).toEqual([]);
+  });
+
+  test("a lone label change passes through without a count", () => {
+    expect(shape(consolidateConsecutive([labelEntry("c1")]))).toEqual([
+      { id: "c1", similarCount: undefined },
+    ]);
+  });
+
+  test("consecutive same-actor label changes collapse to the latest, tagged with the run length", () => {
+    const result = consolidateConsecutive([
+      labelEntry("c1"),
+      labelEntry("c2"),
+      labelEntry("c3"),
+    ]);
+    // Representative is the last (latest) entry; count is the full run length.
+    expect(shape(result)).toEqual([{ id: "c3", similarCount: 3 }]);
+  });
+
+  test("label changes by different actors are not merged", () => {
+    const result = consolidateConsecutive([
+      labelEntry("c1", "users/a@x.com"),
+      labelEntry("c2", "users/b@x.com"),
+    ]);
+    expect(shape(result)).toEqual([
+      { id: "c1", similarCount: undefined },
+      { id: "c2", similarCount: undefined },
+    ]);
+  });
+
+  test("a non-label entry splits two label runs", () => {
+    const result = consolidateConsecutive([
+      labelEntry("c1"),
+      labelEntry("c2"),
+      userEntry("u1"),
+      labelEntry("c3"),
+      labelEntry("c4"),
+    ]);
+    expect(shape(result)).toEqual([
+      { id: "c2", similarCount: 2 },
+      { id: "u1", similarCount: undefined },
+      { id: "c4", similarCount: 2 },
+    ]);
+  });
+
+  test("status-change issue updates are not consolidated", () => {
+    const result = consolidateConsecutive([
+      statusEntry("c1"),
+      statusEntry("c2"),
+    ]);
+    expect(shape(result)).toEqual([
+      { id: "c1", similarCount: undefined },
+      { id: "c2", similarCount: undefined },
+    ]);
+  });
+
+  test("synthetic entries are never consolidated", () => {
+    const result = consolidateConsecutive([
+      syntheticEntry("plan-created"),
+      syntheticEntry("ready-for-review"),
+    ]);
+    expect(shape(result)).toEqual([
+      { id: "plan-created", similarCount: undefined },
+      { id: "ready-for-review", similarCount: undefined },
+    ]);
+  });
+
+  test("consecutive same-actor description edits collapse with a count", () => {
+    const result = consolidateConsecutive([
+      descriptionEntry("c1"),
+      descriptionEntry("c2"),
+      descriptionEntry("c3"),
+    ]);
+    expect(shape(result)).toEqual([{ id: "c3", similarCount: 3 }]);
+  });
+
+  test("label and description runs do not blend together", () => {
+    const result = consolidateConsecutive([
+      labelEntry("l1"),
+      labelEntry("l2"),
+      descriptionEntry("d1"),
+      descriptionEntry("d2"),
+    ]);
+    expect(shape(result)).toEqual([
+      { id: "l2", similarCount: 2 },
+      { id: "d2", similarCount: 2 },
+    ]);
+  });
+
+  test("consecutive title renames net-merge to first-from and last-to", () => {
+    const result = consolidateConsecutive([
+      titleEntry("c1", "A", "B"),
+      titleEntry("c2", "B", "C"),
+      titleEntry("c3", "C", "D"),
+    ]);
+    expect(shape(result)).toEqual([{ id: "c3", similarCount: 3 }]);
+    expect(titleOf(result[0])).toEqual({ from: "A", to: "D" });
+  });
+
+  test("a lone title rename is left intact", () => {
+    const result = consolidateConsecutive([titleEntry("c1", "A", "B")]);
+    expect(shape(result)).toEqual([{ id: "c1", similarCount: undefined }]);
+    expect(titleOf(result[0])).toEqual({ from: "A", to: "B" });
+  });
+
+  test("title renames by different actors are not merged", () => {
+    const result = consolidateConsecutive([
+      titleEntry("c1", "A", "B", "users/a@x.com"),
+      titleEntry("c2", "B", "C", "users/b@x.com"),
+    ]);
+    expect(shape(result)).toEqual([
+      { id: "c1", similarCount: undefined },
+      { id: "c2", similarCount: undefined },
+    ]);
+  });
+
+  test("a title run that nets to no change is dropped", () => {
+    const result = consolidateConsecutive([
+      titleEntry("c1", "A", "B"),
+      titleEntry("c2", "B", "A"),
+    ]);
+    expect(result).toEqual([]);
+  });
+});

--- a/frontend/src/react/pages/project/plan-detail/components/review/consolidateTimeline.ts
+++ b/frontend/src/react/pages/project/plan-detail/components/review/consolidateTimeline.ts
@@ -1,0 +1,145 @@
+// Consolidates runs of consecutive "similar" timeline entries (spec: BYT-9756).
+// Repetitive system events — per-toggle label edits, repeated description/title
+// edits — each land as their own comment and clutter the feed. A maximal run of
+// >=2 consecutive entries that share a consolidation key collapses into a single
+// representative row, tagged with the run length so it can show a "N similar
+// activities" badge.
+//
+// To extend consolidation, add a ConsolidationKind to KINDS — the badge / fold /
+// render pipeline downstream is kind-agnostic. A kind supplies:
+//   - key:   groups adjacent entries (same actor + same repetitive action).
+//   - merge: builds the one representative row from the run; defaults to keeping
+//            the latest entry as-is, which is faithful for content-free rows
+//            (labels, description) where collapsing loses nothing. Value-bearing
+//            rows (a title rename shows old->new) need a real merge so the badge
+//            summarizes the net change rather than just the last hop.
+import { clone } from "@bufbuild/protobuf";
+import {
+  getIssueCommentType,
+  IssueCommentType,
+} from "@/react/stores/app/issueComment";
+import {
+  type IssueComment,
+  IssueCommentSchema,
+} from "@/types/proto-es/v1/issue_service_pb";
+import type { TimelineEntry } from "./timelineEvents";
+
+interface ConsolidationKind {
+  key: (entry: TimelineEntry) => string | null;
+  merge?: (run: TimelineEntry[]) => TimelineEntry | null;
+}
+
+// A single issue-update comment edits exactly one field (the backend emits one
+// comment per changed field), so classify it by which from/to pair is set —
+// mirroring the renderer's precedence (title > description > status > labels).
+type IssueField = "title" | "description" | "status" | "labels";
+
+function classifyIssueUpdate(
+  entry: TimelineEntry
+): { field: IssueField; comment: IssueComment } | null {
+  if (entry.source.type !== "comment") return null;
+  const comment = entry.source.comment;
+  if (getIssueCommentType(comment) !== IssueCommentType.ISSUE_UPDATE) {
+    return null;
+  }
+  if (comment.event.case !== "issueUpdate") return null;
+  const e = comment.event.value;
+  if (e.fromTitle !== undefined || e.toTitle !== undefined) {
+    return { field: "title", comment };
+  }
+  if (e.fromDescription !== undefined || e.toDescription !== undefined) {
+    return { field: "description", comment };
+  }
+  if (e.fromStatus !== undefined || e.toStatus !== undefined) {
+    return { field: "status", comment };
+  }
+  if (e.fromLabels.length > 0 || e.toLabels.length > 0) {
+    return { field: "labels", comment };
+  }
+  return null;
+}
+
+// Labels and description render content-free sentences, so the latest row plus a
+// count badge is a faithful summary. Keyed by field so the two never blend into
+// a single ambiguous row.
+const contentFreeFieldKind: ConsolidationKind = {
+  key: (entry) => {
+    const c = classifyIssueUpdate(entry);
+    if (!c || (c.field !== "labels" && c.field !== "description")) return null;
+    return `${c.field}:${c.comment.creator}`;
+  },
+};
+
+// Title renames carry old/new values, so a plain "latest row" would show only
+// the last hop (Y->Z) while claiming to stand for the whole run. Merge to the
+// net change (first.from -> last.to); drop a run that nets to no change.
+const titleRenameKind: ConsolidationKind = {
+  key: (entry) => {
+    const c = classifyIssueUpdate(entry);
+    return c?.field === "title" ? `title:${c.comment.creator}` : null;
+  },
+  merge: (run) => {
+    const first = classifyIssueUpdate(run[0]);
+    const last = classifyIssueUpdate(run[run.length - 1]);
+    if (!first || !last) return run[run.length - 1];
+    const fromTitle =
+      first.comment.event.case === "issueUpdate"
+        ? first.comment.event.value.fromTitle
+        : undefined;
+    const toTitle =
+      last.comment.event.case === "issueUpdate"
+        ? last.comment.event.value.toTitle
+        : undefined;
+    if (fromTitle === toTitle) return null; // net no-op — nothing to show
+    const comment = clone(IssueCommentSchema, last.comment);
+    if (comment.event.case === "issueUpdate") {
+      comment.event.value.fromTitle = fromTitle;
+    }
+    return { id: run[run.length - 1].id, source: { type: "comment", comment } };
+  },
+};
+
+const KINDS: ConsolidationKind[] = [contentFreeFieldKind, titleRenameKind];
+
+function classify(
+  entry: TimelineEntry
+): { key: string; kind: ConsolidationKind } | null {
+  for (const kind of KINDS) {
+    const key = kind.key(entry);
+    if (key !== null) return { key, kind };
+  }
+  return null;
+}
+
+const latestMerge = (run: TimelineEntry[]): TimelineEntry =>
+  run[run.length - 1];
+
+export function consolidateConsecutive(
+  entries: TimelineEntry[]
+): TimelineEntry[] {
+  const result: TimelineEntry[] = [];
+  let i = 0;
+  while (i < entries.length) {
+    const classified = classify(entries[i]);
+    if (classified === null) {
+      result.push(entries[i]);
+      i++;
+      continue;
+    }
+    let j = i + 1;
+    while (j < entries.length && classify(entries[j])?.key === classified.key) {
+      j++;
+    }
+    const run = entries.slice(i, j);
+    if (run.length === 1) {
+      result.push(run[0]);
+    } else {
+      const rep = (classified.kind.merge ?? latestMerge)(run);
+      if (rep !== null) {
+        result.push({ ...rep, similarCount: run.length });
+      }
+    }
+    i = j;
+  }
+  return result;
+}

--- a/frontend/src/react/pages/project/plan-detail/components/review/timelineEvents.ts
+++ b/frontend/src/react/pages/project/plan-detail/components/review/timelineEvents.ts
@@ -13,6 +13,10 @@ export type TimelineSource =
 export interface TimelineEntry {
   id: string;
   source: TimelineSource;
+  // Set by consolidateConsecutive when this row stands in for a run of N>=2
+  // consecutive similar activities (e.g. repeated label edits). Drives the
+  // "(N similar activities)" badge. Absent means a standalone row.
+  similarCount?: number;
 }
 
 export function buildTimelineEntries(input: {


### PR DESCRIPTION
## What

Consecutive, same-actor system events in the plan review activity timeline now consolidate into a single row with a neutral 'N similar activities' badge, replacing runs of identical low-signal entries. The motivating case: six 'changed labels' rows produced by per-toggle label saves.

## How

A new pure helper (consolidateConsecutive) collapses each maximal run of adjacent entries that share a consolidation key (same actor + same repetitive action):

- Labels and description render content-free sentences, so the latest entry is kept and tagged with the run length.
- Title renames carry old/new values, so they are net-merged (first-from -> last-to); a run that nets to no change is dropped.

The kind registry is structured to extend: add a { key, merge } entry to wire a new event kind. Status transitions, approvals, user comments, plan-spec edits, and the synthetic plan-created / ready-for-review rows are intentionally never consolidated. The existing length-based fold over long histories is unchanged.

## Testing

- New unit tests for consolidateConsecutive covering labels, description, title net-merge and no-op drop, actor/field boundaries, and synthetics; all green.
- pnpm --dir frontend type-check and pnpm --dir frontend check (biome + i18n cross-locale + layering + sort) pass.

Refs BYT-9756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)