### PR TITLE
fix(ghost): trim trailing semicolon so attempt-instant-ddl stays valid

### DIFF
--- a/backend/component/ghost/config.go
+++ b/backend/component/ghost/config.go
@@ -263,7 +263,7 @@ func NewMigrationContext(ctx context.Context, taskID int64, database *store.Data
 	migrationContext.GhostDatabaseName = common.BackupDatabaseNameOfEngine(storepb.Engine_MYSQL)
 	migrationContext.DatabaseName = database.DatabaseName
 	migrationContext.OriginalTableName = tableName
-	migrationContext.AlterStatement = strings.Join(strings.Fields(statement), " ")
+	migrationContext.AlterStatement = strings.TrimRight(strings.Join(strings.Fields(statement), " "), "; ")
 	migrationContext.Noop = noop
 	// On the source and each replica, you must set the server_id system variable to establish a unique replication ID. For each server, you should pick a unique positive integer in the range from 1 to 2^32 − 1, and each ID must be different from every other ID in use by any other source or replica in the replication topology. Example: server-id=3.
 	// https://dev.mysql.com/doc/refman/5.7/en/replication-options-source.html

--- a/backend/component/ghost/config_test.go
+++ b/backend/component/ghost/config_test.go
@@ -55,6 +55,48 @@ func TestNewMigrationContextUsesContextAttrs(t *testing.T) {
 	require.NotContains(t, output, `replica_id=`)
 }
 
+func TestNewMigrationContextTrimsTrailingSemicolon(t *testing.T) {
+	ctx := context.Background()
+	database := &store.DatabaseMessage{DatabaseName: "ghostdb"}
+	dataSource := &storepb.DataSource{
+		Host:               "127.0.0.1",
+		Port:               "3306",
+		Username:           "root",
+		AuthenticationType: storepb.DataSource_PASSWORD,
+	}
+
+	testCases := []struct {
+		name      string
+		statement string
+		wantAlter string
+	}{
+		{
+			name:      "trailing semicolon",
+			statement: "ALTER TABLE t MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT;",
+			wantAlter: "ALTER TABLE t MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT",
+		},
+		{
+			name:      "trailing semicolon with whitespace",
+			statement: "ALTER TABLE t ADD COLUMN c INT ;  ",
+			wantAlter: "ALTER TABLE t ADD COLUMN c INT",
+		},
+		{
+			name:      "no trailing semicolon",
+			statement: "ALTER TABLE t ADD COLUMN c INT",
+			wantAlter: "ALTER TABLE t ADD COLUMN c INT",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			migrationContext, cleanup, err := NewMigrationContext(ctx, 1, database, dataSource, "t", "_suffix", tc.statement, false, nil, 0)
+			require.NoError(t, err)
+			t.Cleanup(cleanup)
+			require.Equal(t, tc.wantAlter, migrationContext.AlterStatement)
+			require.NotContains(t, migrationContext.AlterStatementOptions, ";")
+		})
+	}
+}
+
 func TestNewMigrationContextWritesTLSMaterialToTempFiles(t *testing.T) {
 	certPEM, keyPEM := generateSelfSignedPEM(t)
 

--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -345,7 +345,7 @@ func executeGhostMigration(ctx context.Context, driverCtx context.Context, task 
 		return common.Errorf(common.Internal, "admin data source not found for instance %s", instance.ResourceID)
 	}
 
-	migrationContext, cleanup, err := ghost.NewMigrationContext(ctx, task.ID, database, adminDataSource, tableName, fmt.Sprintf("_%d", time.Now().Unix()), cleanedStatement, false, flags, 10000000)
+	migrationContext, cleanup, err := ghost.NewMigrationContext(ctx, task.ID, database, adminDataSource, tableName, fmt.Sprintf("_%d", time.Now().Unix()), statement, false, flags, 10000000)
 	if err != nil {
 		return errors.Wrap(err, "failed to init migrationContext for gh-ost")
 	}


### PR DESCRIPTION
## What

A trailing `;` in the input DDL broke gh-ost's `attempt-instant-ddl` query generation. gh-ost stores the alter options verbatim (`parser.go`: `alterStatementOptions = alterStatement`, only the `ALTER TABLE schema.table` prefix is stripped) and then builds the instant-DDL probe as:

```go
// go/logic/applier.go
fmt.Sprintf(`ALTER /* gh-ost */ TABLE %s.%s %s, ALGORITHM=INSTANT`, db, table, AlterStatementOptions)
```

So a statement ending in `... AUTO_INCREMENT;` produced the invalid SQL `... AUTO_INCREMENT;, ALGORITHM=INSTANT`. The instant-DDL attempt fails on a syntax error and gh-ost silently falls back to a full table copy — quietly disabling the INSTANT fast path.

There was also an inconsistency between the two call sites:
- `executeGhostMigration` (real run) passed `cleanedStatement` — semicolon **not** trimmed.
- `GhostSyncExecutor` (plan check / dry run) passed `statement` — semicolon trimmed.

## Symptom

Observed in production when running a gh-ost migration through Bytebase whose DDL ended with a trailing `;`:

- The instant-DDL probe was issued against the **original** table (expected — `attempt-instant-ddl` tries `ALGORITHM=INSTANT` on the real table first), but the generated SQL was malformed:

  ```sql
  ALTER /* gh-ost */ TABLE `db`.`tbl` MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT;, ALGORITHM=INSTANT
  ```

  Note the stray `;` before `, ALGORITHM=INSTANT`.
- The instant attempt failed on this syntax error and gh-ost silently fell back to a full table copy.

For a column type change like the above, INSTANT is not supported anyway, so a full copy was unavoidable regardless of the semicolon. But for INSTANT-eligible operations (e.g. `ADD COLUMN`), a trailing `;` would silently disable the fast path and force an unnecessary full copy.

## Changes

- `component/ghost/config.go`: trim trailing semicolons (and whitespace) when building `AlterStatement`, the single place both call sites flow through. This is the defensive fix.
- `runner/taskrun/database_migrate_executor.go`: pass the already-trimmed `statement` instead of `cleanedStatement`, matching the plan-check path.
- `component/ghost/config_test.go`: add `TestNewMigrationContextTrimsTrailingSemicolon`, asserting `AlterStatementOptions` never contains `;` — the exact value that breaks instant-DDL generation.

## Testing

- `go test ./backend/component/ghost/...` — pass
- `golangci-lint run` — 0 issues
- `go build` — OK


