### PR TITLE
refactor(store): use query builder in UpdatePlan

### DIFF
--- a/backend/store/plan.go
+++ b/backend/store/plan.go
@@ -2,7 +2,6 @@ package store
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -215,32 +214,28 @@ func (s *Store) ListPlans(ctx context.Context, find *FindPlanMessage) ([]*PlanMe
 
 // UpdatePlan updates an existing plan and returns the updated plan.
 func (s *Store) UpdatePlan(ctx context.Context, patch *UpdatePlanMessage) (*PlanMessage, error) {
-	set := []string{"updated_at = ?"}
-	args := []any{time.Now()}
+	set := qb.Q().Comma("updated_at = ?", time.Now())
 
 	if v := patch.Name; v != nil {
-		set = append(set, "name = ?")
-		args = append(args, *v)
+		set.Comma("name = ?", *v)
 	}
 	if v := patch.Description; v != nil {
-		set = append(set, "description = ?")
-		args = append(args, *v)
+		set.Comma("description = ?", *v)
 	}
 	if v := patch.Deleted; v != nil {
-		set = append(set, "deleted = ?")
-		args = append(args, *v)
+		set.Comma("deleted = ?", *v)
 	}
 	if v := patch.Config; v != nil {
 		config, err := protojson.Marshal(v)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to marshal plan config")
 		}
-		set = append(set, "config = ?")
-		args = append(args, config)
+		set.Comma("config = ?", config)
 	}
 
-	args = append(args, patch.UID, patch.ProjectID)
-	q := qb.Q().Space(fmt.Sprintf("UPDATE plan SET %s WHERE id = ? AND project = ? RETURNING id, creator, created_at, updated_at, project, name, description, config, deleted", strings.Join(set, ", ")), args...)
+	q := qb.Q().Space(`UPDATE plan SET ? WHERE id = ? AND project = ?
+		RETURNING id, creator, created_at, updated_at, project, name, description, config, deleted`,
+		set, patch.UID, patch.ProjectID)
 
 	query, finalArgs, err := q.ToSQL()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Update store.UpdatePlan to build its dynamic SET clause with qb.Query.
- Remove the manual fmt.Sprintf/string join SQL assembly while preserving the project/id predicate and returned columns.

## Test Plan
- gofmt -w backend/store/plan.go
- golangci-lint run --allow-parallel-runners
- go test -v -count=1 ./backend/store -timeout 5m
- go test -v -count=1 ./backend/tests/ -run "^(TestClaim|TestCollision)" -timeout 5m
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go