### PR TITLE
refactor(starrocks): replace ANTLR DealWithDelimiter with omni Split

### DIFF
--- a/backend/plugin/db/starrocks/antlr_dependency_test.go
+++ b/backend/plugin/db/starrocks/antlr_dependency_test.go
@@ -21,3 +21,13 @@ func TestStarRocksQueryDoesNotUseANTLROrMySQLParser(t *testing.T) {
 	require.NotContains(t, source, "omni/mysql/parser")
 	require.NotContains(t, source, "plugin/parser/mysql")
 }
+
+func TestStarRocksDriverDoesNotUseANTLR(t *testing.T) {
+	content, err := os.ReadFile("starrocks.go")
+	require.NoError(t, err)
+	source := string(content)
+
+	require.NotContains(t, source, "github.com/antlr4-go/antlr/v4")
+	require.NotContains(t, source, "github.com/bytebase/parser/mysql")
+	require.NotContains(t, source, "plugin/parser/mysql")
+}

--- a/backend/plugin/db/starrocks/antlr_dependency_test.go
+++ b/backend/plugin/db/starrocks/antlr_dependency_test.go
@@ -31,3 +31,25 @@ func TestStarRocksDriverDoesNotUseANTLR(t *testing.T) {
 	require.NotContains(t, source, "github.com/bytebase/parser/mysql")
 	require.NotContains(t, source, "plugin/parser/mysql")
 }
+
+func TestContainsDelimiterDirective(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want bool
+	}{
+		{"basic directive", "DELIMITER ;;\nCREATE PROCEDURE p() BEGIN SELECT 1; END;;\nDELIMITER ;", true},
+		{"indented directive", "  DELIMITER //\nSELECT 1//\nDELIMITER ;", true},
+		{"tab-indented directive", "\tDELIMITER $$\n", true},
+		{"string literal not a directive", "INSERT INTO t VALUES ('DELIMITER ');\nSELECT 1;", false},
+		{"comment not a directive", "-- DELIMITER //\nSELECT 1;", false},
+		{"column name not a directive", "SELECT delimiter FROM t;", false},
+		{"no delimiter at all", "SELECT 1;\nSELECT 2;", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := containsDelimiterDirective(tt.sql)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/backend/plugin/db/starrocks/starrocks.go
+++ b/backend/plugin/db/starrocks/starrocks.go
@@ -168,17 +168,19 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 		transactionMode = common.GetDefaultTransactionMode()
 	}
 
-	// Normalize DELIMITER directives using omni's DELIMITER-aware splitter,
-	// then rejoin with semicolons for the SQL driver.
-	segments := mysqlomni.Split(statement)
-	var buf strings.Builder
-	for i, seg := range segments {
-		if i > 0 {
-			buf.WriteString(";\n")
+	// Only preprocess when DELIMITER directives are present; normal
+	// StarRocks SQL passes through unchanged.
+	if containsDelimiterDirective(statement) {
+		segments := mysqlomni.Split(statement)
+		var buf strings.Builder
+		for i, seg := range segments {
+			if i > 0 {
+				buf.WriteString(";\n")
+			}
+			buf.WriteString(seg.Text)
 		}
-		buf.WriteString(seg.Text)
+		statement = buf.String()
 	}
-	statement = buf.String()
 	// Execute based on transaction mode
 	// Note: StarRocks is an OLAP database with limited transaction support.
 	// For DDL operations, transactions are not supported. For DML operations,
@@ -370,6 +372,14 @@ func (d *Driver) QueryConn(ctx context.Context, conn *sql.Conn, statement string
 func (d *Driver) StopConnectionByID(id string) error {
 	_, err := d.db.Exec(fmt.Sprintf("KILL QUERY %s", id)) // NOSONAR(go:S2077) id is from CONNECTION_ID() server function, not user input
 	return err
+}
+
+func containsDelimiterDirective(s string) bool {
+	upper := strings.ToUpper(s)
+	return strings.HasPrefix(upper, "DELIMITER ") ||
+		strings.HasPrefix(upper, "DELIMITER\t") ||
+		strings.Contains(upper, "\nDELIMITER ") ||
+		strings.Contains(upper, "\nDELIMITER\t")
 }
 
 func getConnectionID(ctx context.Context, conn *sql.Conn) (string, error) {

--- a/backend/plugin/db/starrocks/starrocks.go
+++ b/backend/plugin/db/starrocks/starrocks.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	mysqlomni "github.com/bytebase/omni/mysql/parser"
 	"github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -25,7 +26,6 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/db/util"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
-	mysqlomni "github.com/bytebase/omni/mysql/parser"
 )
 
 var (

--- a/backend/plugin/db/starrocks/starrocks.go
+++ b/backend/plugin/db/starrocks/starrocks.go
@@ -25,7 +25,7 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/db/util"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
-	mysqlparser "github.com/bytebase/bytebase/backend/plugin/parser/mysql"
+	mysqlomni "github.com/bytebase/omni/mysql/parser"
 )
 
 var (
@@ -168,10 +168,17 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 		transactionMode = common.GetDefaultTransactionMode()
 	}
 
-	statement, err := mysqlparser.DealWithDelimiter(statement)
-	if err != nil {
-		return 0, errors.Wrapf(err, "failed to deal with delimiter")
+	// Normalize DELIMITER directives using omni's DELIMITER-aware splitter,
+	// then rejoin with semicolons for the SQL driver.
+	segments := mysqlomni.Split(statement)
+	var buf strings.Builder
+	for i, seg := range segments {
+		if i > 0 {
+			buf.WriteString(";\n")
+		}
+		buf.WriteString(seg.Text)
 	}
+	statement = buf.String()
 	// Execute based on transaction mode
 	// Note: StarRocks is an OLAP database with limited transaction support.
 	// For DDL operations, transactions are not supported. For DML operations,

--- a/backend/plugin/db/starrocks/starrocks.go
+++ b/backend/plugin/db/starrocks/starrocks.go
@@ -376,10 +376,8 @@ func (d *Driver) StopConnectionByID(id string) error {
 
 func containsDelimiterDirective(s string) bool {
 	upper := strings.ToUpper(s)
-	return strings.HasPrefix(upper, "DELIMITER ") ||
-		strings.HasPrefix(upper, "DELIMITER\t") ||
-		strings.Contains(upper, "\nDELIMITER ") ||
-		strings.Contains(upper, "\nDELIMITER\t")
+	return strings.Contains(upper, "DELIMITER ") ||
+		strings.Contains(upper, "DELIMITER\t")
 }
 
 func getConnectionID(ctx context.Context, conn *sql.Conn) (string, error) {

--- a/backend/plugin/db/starrocks/starrocks.go
+++ b/backend/plugin/db/starrocks/starrocks.go
@@ -375,9 +375,14 @@ func (d *Driver) StopConnectionByID(id string) error {
 }
 
 func containsDelimiterDirective(s string) bool {
-	upper := strings.ToUpper(s)
-	return strings.Contains(upper, "DELIMITER ") ||
-		strings.Contains(upper, "DELIMITER\t")
+	for _, line := range strings.Split(s, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		upper := strings.ToUpper(trimmed)
+		if strings.HasPrefix(upper, "DELIMITER ") || strings.HasPrefix(upper, "DELIMITER\t") {
+			return true
+		}
+	}
+	return false
 }
 
 func getConnectionID(ctx context.Context, conn *sql.Conn) (string, error) {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260625023543-cd8cfff6bed3
+	github.com/bytebase/omni v0.0.0-20260626034734-62d4f668f054
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260625023543-cd8cfff6bed3 h1:OzvEFEDDAuf1TALMF9cuFsISPCF0nchW+wCUv/6o8PQ=
-github.com/bytebase/omni v0.0.0-20260625023543-cd8cfff6bed3/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260626034734-62d4f668f054 h1:ZjmNACtTuRrUFCqlOhKnPbe9LpwbP18kWfW20mkyDsM=
+github.com/bytebase/omni v0.0.0-20260626034734-62d4f668f054/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640 h1:g4Jed1/Jv/DHBiQmEgN5ILOQDDBjFlG4N4Lp+3B4aYE=
 github.com/bytebase/parser v0.0.0-20260417075056-57b6ef7a2640/go.mod h1:jeak/EfutSOAuWKvrFIT2IZunhWprM7oTFBRgZ9RCxo=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=


### PR DESCRIPTION
## Summary
- Replace `mysqlparser.DealWithDelimiter()` (ANTLR-dependent) with omni's MySQL `Split()` for DELIMITER-aware statement normalization
- Remove the `plugin/parser/mysql` import from StarRocks db plugin, eliminating the last indirect ANTLR dependency in the StarRocks driver
- Bump omni to `62d4f668` which includes the DELIMITER fix (omni#335: gate DELIMITER on statement-start + require whitespace)
- Add dependency guard test (`TestStarRocksDriverDoesNotUseANTLR`) to prevent re-introduction of ANTLR imports

## Test plan
- [x] `TestStarRocksDriverDoesNotUseANTLR` — guards against ANTLR re-introduction
- [x] `TestStarRocksQueryDoesNotUseANTLROrMySQLParser` — existing guard still passes
- [x] `go build ./backend/plugin/db/starrocks/` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)