### PR TITLE
feat(ui): reveal absolute timestamp on hover for relative times

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1480,7 +1480,7 @@
     },
     "labels-required-for-review": "Labels are required before review",
     "meta": {
-      "created-by-at": "Created by {{user}} · {{time}}"
+      "created-by": "Created by {{user}}"
     },
     "navigator": {
       "changes": "Changes",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1480,7 +1480,7 @@
     },
     "labels-required-for-review": "Se requieren etiquetas antes de la revisión",
     "meta": {
-      "created-by-at": "Creado por {{user}} · {{time}}"
+      "created-by": "Creado por {{user}}"
     },
     "navigator": {
       "changes": "Cambios",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1480,7 +1480,7 @@
     },
     "labels-required-for-review": "レビュー前にラベルが必要です",
     "meta": {
-      "created-by-at": "{{user}} が作成 · {{time}}"
+      "created-by": "{{user}} が作成"
     },
     "navigator": {
       "changes": "変更点",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1480,7 +1480,7 @@
     },
     "labels-required-for-review": "Cần có nhãn trước khi review",
     "meta": {
-      "created-by-at": "Tạo bởi {{user}} · {{time}}"
+      "created-by": "Tạo bởi {{user}}"
     },
     "navigator": {
       "changes": "Thay đổi",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1480,7 +1480,7 @@
     },
     "labels-required-for-review": "提交审批前必须设置标签",
     "meta": {
-      "created-by-at": "由 {{user}} 创建 · {{time}}"
+      "created-by": "由 {{user}} 创建"
     },
     "navigator": {
       "changes": "变更项",

--- a/frontend/src/react/components/HumanizeTs.test.tsx
+++ b/frontend/src/react/components/HumanizeTs.test.tsx
@@ -1,0 +1,69 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: "en" } }),
+}));
+
+vi.mock("@/utils", () => ({
+  formatRelativeTime: (ms: number) => `relative:${ms}`,
+  formatAbsoluteDateTime: (ms: number) => `absolute:${ms}`,
+}));
+
+import { HumanizeTs } from "./HumanizeTs";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mount = () => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  return { container, root: createRoot(container) };
+};
+
+const focus = async (el: Element | null) => {
+  await act(async () => {
+    el?.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    vi.advanceTimersByTime(100);
+  });
+};
+
+describe("HumanizeTs", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  test("renders relative time and reveals the absolute time on hover", async () => {
+    vi.useFakeTimers();
+    const { container, root } = mount();
+
+    // `ts` is in seconds; both labels are computed from milliseconds.
+    act(() => root.render(<HumanizeTs ts={1000} />));
+    expect(container.textContent).toContain("relative:1000000");
+
+    await focus(container.querySelector("span"));
+
+    const overlay = document.getElementById("bb-react-layer-overlay");
+    expect(overlay?.textContent).toContain("absolute:1000000");
+
+    act(() => root.unmount());
+  });
+
+  test("omits the tooltip when tooltip is false", async () => {
+    vi.useFakeTimers();
+    const { container, root } = mount();
+
+    act(() => root.render(<HumanizeTs ts={1000} tooltip={false} />));
+    expect(container.textContent).toContain("relative:1000000");
+
+    await focus(container.querySelector("span"));
+
+    const overlay = document.getElementById("bb-react-layer-overlay");
+    expect(overlay?.textContent ?? "").not.toContain("absolute:");
+
+    act(() => root.unmount());
+  });
+});

--- a/frontend/src/react/components/HumanizeTs.tsx
+++ b/frontend/src/react/components/HumanizeTs.tsx
@@ -1,24 +1,32 @@
 import { useTranslation } from "react-i18next";
-
-function formatRelativeTime(tsMs: number, locale: string): string {
-  const seconds = Math.floor((Date.now() - tsMs) / 1000);
-  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
-  if (seconds < 60) return rtf.format(-seconds, "second");
-  if (seconds < 3600) return rtf.format(-Math.floor(seconds / 60), "minute");
-  if (seconds < 86400) return rtf.format(-Math.floor(seconds / 3600), "hour");
-  return rtf.format(-Math.floor(seconds / 86400), "day");
-}
+import { Tooltip } from "@/react/components/ui/tooltip";
+import { formatAbsoluteDateTime, formatRelativeTime } from "@/utils";
 
 interface HumanizeTsProps {
+  /** Unix timestamp in seconds. */
   ts: number;
   className?: string;
+  /**
+   * Whether to reveal the absolute timestamp on hover. Defaults to true.
+   * Disable only inside agent-layer overlays, where the shared Tooltip mounts
+   * into the lower overlay layer (behind the agent window); supply an
+   * AgentTooltip at the call site instead.
+   */
+  tooltip?: boolean;
 }
 
-export function HumanizeTs({ ts, className }: HumanizeTsProps) {
-  const { i18n } = useTranslation();
-  return (
-    <span className={className}>
-      {formatRelativeTime(ts * 1000, i18n.language)}
-    </span>
-  );
+/**
+ * Renders a relative timestamp ("5 minutes ago") and, by default, reveals the
+ * absolute timestamp on hover. This is the single canonical way to display a
+ * relative time across the app.
+ */
+export function HumanizeTs({ ts, className, tooltip = true }: HumanizeTsProps) {
+  // Subscribe to locale changes so the rendered strings update on a language switch.
+  useTranslation();
+  const tsMs = ts * 1000;
+  const label = <span className={className}>{formatRelativeTime(tsMs)}</span>;
+  if (!tooltip) {
+    return label;
+  }
+  return <Tooltip content={formatAbsoluteDateTime(tsMs)}>{label}</Tooltip>;
 }

--- a/frontend/src/react/pages/project/ProjectDataExportPage.tsx
+++ b/frontend/src/react/pages/project/ProjectDataExportPage.tsx
@@ -9,6 +9,7 @@ import {
   type ValueOption,
 } from "@/react/components/AdvancedSearch";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { RouterLink } from "@/react/components/RouterLink";
 import { Alert } from "@/react/components/ui/alert";
 import { Button, buttonVariants } from "@/react/components/ui/button";
@@ -36,12 +37,10 @@ import {
   extractInstanceResourceName,
   extractIssueUID,
   extractProjectResourceName,
-  formatAbsoluteDateTime,
   getDefaultPagination,
   getIssueRoute,
   hasProjectPermissionV2,
   hasWorkspacePermissionV2,
-  humanizeTs,
   PERMISSIONS_FOR_DATABASE_EXPORT_ISSUE,
   type SearchParams as VueSearchParams,
 } from "@/utils";
@@ -681,9 +680,7 @@ function IssueListItem({
             <span className="opacity-80">#{extractIssueUID(issue.name)}</span>
             <span>&middot;</span>
             {t("common.created")}
-            <Tooltip content={formatAbsoluteDateTime(createTimeTs * 1000)}>
-              <span>{humanizeTs(createTimeTs)}</span>
-            </Tooltip>
+            <HumanizeTs ts={createTimeTs} />
             <span>&middot;</span>
             <RouterLink
               className="hover:underline"

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/react/components/AdvancedSearch";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import {
   PermissionGuard,
   usePermissionCheck,
@@ -88,12 +89,10 @@ import {
   extractDatabaseGroupName,
   extractDatabaseResourceName,
   extractPlanUID,
-  formatAbsoluteDateTime,
   generatePlanTitle,
   getDatabaseEnvironment,
   getDefaultPagination,
   getInstanceResource,
-  humanizeTs,
   type SearchParams as VueSearchParams,
 } from "@/utils";
 import { extractStageUID } from "@/utils/v1/issue/rollout";
@@ -508,11 +507,10 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
         minWidth: 100,
         resizable: true,
         render: (_plan, ctx) => (
-          <Tooltip content={formatAbsoluteDateTime(ctx.updateTimeTs * 1000)}>
-            <span className="text-control-light whitespace-nowrap">
-              {humanizeTs(ctx.updateTimeTs)}
-            </span>
-          </Tooltip>
+          <HumanizeTs
+            ts={ctx.updateTimeTs}
+            className="text-control-light whitespace-nowrap"
+          />
         ),
       },
     ],

--- a/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
@@ -15,6 +15,7 @@ import { v4 as uuidv4 } from "uuid";
 import { DatabaseSelect } from "@/react/components/DatabaseSelect";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentSelect } from "@/react/components/EnvironmentSelect";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
 import {
   createMonacoDiffEditor,
@@ -77,7 +78,6 @@ import {
   getDatabaseEnvironment,
   getDefaultPagination,
   getInstanceResource,
-  humanizeDate,
 } from "@/utils";
 import {
   extractDatabaseNameAndChangelogUID,
@@ -916,7 +916,11 @@ function ChangelogLabel({ entry }: { entry: ChangelogEntry }) {
   return (
     <span className="flex items-center gap-1.5 truncate">
       <span className="text-control-light">
-        {entry.date ? humanizeDate(entry.date) : "Latest version"}
+        {entry.date ? (
+          <HumanizeTs ts={entry.date.getTime() / 1000} />
+        ) : (
+          "Latest version"
+        )}
       </span>
       {entry.planTitle && (
         <span className="inline-flex items-center px-1.5 py-0 rounded-full bg-control-bg text-xs">

--- a/frontend/src/react/pages/project/database-detail/changelog/DatabaseChangelogTable.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/changelog/DatabaseChangelogTable.test.tsx
@@ -30,8 +30,8 @@ vi.mock("@/types", () => ({
   getDateForPbTimestampProtoEs: () => new Date("2026-04-15T00:00:00Z"),
 }));
 
-vi.mock("@/utils", () => ({
-  humanizeDate: () => "Apr 15, 2026",
+vi.mock("@/react/components/HumanizeTs", () => ({
+  HumanizeTs: () => null,
 }));
 
 import { DatabaseChangelogTable } from "./DatabaseChangelogTable";

--- a/frontend/src/react/pages/project/database-detail/changelog/DatabaseChangelogTable.tsx
+++ b/frontend/src/react/pages/project/database-detail/changelog/DatabaseChangelogTable.tsx
@@ -1,6 +1,7 @@
 import { Check } from "lucide-react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import {
   Table,
   TableBody,
@@ -15,7 +16,6 @@ import {
   type Changelog,
   Changelog_Status,
 } from "@/types/proto-es/v1/database_service_pb";
-import { humanizeDate } from "@/utils";
 import { changelogLink } from "@/utils/v1/changelog";
 
 function ChangelogStatusIcon({ status }: { status: Changelog_Status }) {
@@ -100,11 +100,19 @@ export function DatabaseChangelogTable({
                 <ChangelogStatusIcon status={changelog.status} />
               </TableCell>
               <TableCell className="text-main">
-                {getDateForPbTimestampProtoEs(changelog.createTime)
-                  ? humanizeDate(
-                      getDateForPbTimestampProtoEs(changelog.createTime) as Date
-                    )
-                  : "-"}
+                {changelog.createTime ? (
+                  <HumanizeTs
+                    ts={
+                      (
+                        getDateForPbTimestampProtoEs(
+                          changelog.createTime
+                        ) as Date
+                      ).getTime() / 1000
+                    }
+                  />
+                ) : (
+                  "-"
+                )}
               </TableCell>
               <TableCell className="truncate text-main">
                 {changelog.planTitle || "-"}

--- a/frontend/src/react/pages/project/database-detail/overview/DatabaseOverviewInfo.tsx
+++ b/frontend/src/react/pages/project/database-detail/overview/DatabaseOverviewInfo.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { useAppDatabaseMetadata } from "@/react/hooks/useAppDatabaseMetadata";
 import { Engine, State } from "@/types/proto-es/v1/common_pb";
 import {
@@ -7,7 +8,6 @@ import {
 } from "@/types/proto-es/v1/database_service_pb";
 import {
   getDatabaseEngine,
-  humanizeDate,
   instanceV1HasCollationAndCharacterSet,
 } from "@/utils";
 
@@ -15,10 +15,9 @@ export function DatabaseOverviewInfo({ database }: { database: Database }) {
   const { t } = useTranslation();
   const databaseEngine = getDatabaseEngine(database);
   const databaseSchemaMetadata = useAppDatabaseMetadata(database.name);
-  const lastSyncDate = database.successfulSyncTime
-    ? new Date(Number(database.successfulSyncTime.seconds) * 1000)
-    : undefined;
-  const hasLastSyncDate = !!lastSyncDate && lastSyncDate.getTime() !== 0;
+  const lastSyncTs = database.successfulSyncTime
+    ? Number(database.successfulSyncTime.seconds)
+    : 0;
 
   return (
     <div className="rounded border border-block-border px-5 py-4">
@@ -77,7 +76,7 @@ export function DatabaseOverviewInfo({ database }: { database: Database }) {
             {t("database.last-sync")}
           </dt>
           <dd className="mt-1 text-sm text-main">
-            {hasLastSyncDate ? humanizeDate(lastSyncDate) : "-"}
+            {lastSyncTs ? <HumanizeTs ts={lastSyncTs} /> : "-"}
           </dd>
         </div>
       </dl>

--- a/frontend/src/react/pages/project/database-detail/panels/DatabaseOverviewPanel.test.tsx
+++ b/frontend/src/react/pages/project/database-detail/panels/DatabaseOverviewPanel.test.tsx
@@ -68,7 +68,8 @@ const mocks = vi.hoisted(() => {
     instanceV1SupportsSequence: vi.fn(() => false),
     instanceV1SupportsTrigger: vi.fn(() => false),
     bytesToString: vi.fn((size: number) => `${size} B`),
-    humanizeDate: vi.fn(() => "5 minutes ago"),
+    formatRelativeTime: vi.fn(() => "5 minutes ago"),
+    formatAbsoluteDateTime: vi.fn(() => "Jan 1, 1970, 12:00:01 AM UTC"),
   };
 });
 
@@ -147,7 +148,8 @@ vi.mock("@/utils", () => ({
   getDatabaseEngine: mocks.getDatabaseEngine,
   getInstanceResource: mocks.getInstanceResource,
   getDatabaseProject: mocks.getDatabaseProject,
-  humanizeDate: mocks.humanizeDate,
+  formatRelativeTime: mocks.formatRelativeTime,
+  formatAbsoluteDateTime: mocks.formatAbsoluteDateTime,
   hasIndexSizeProperty: mocks.hasIndexSizeProperty,
   isDev: mocks.isDev,
   hasProjectPermissionV2: mocks.hasProjectPermissionV2,
@@ -352,8 +354,8 @@ beforeEach(async () => {
   mocks.instanceV1SupportsSequence.mockReturnValue(false);
   mocks.bytesToString.mockReset();
   mocks.bytesToString.mockImplementation((size: number) => `${size} B`);
-  mocks.humanizeDate.mockReset();
-  mocks.humanizeDate.mockReturnValue("5 minutes ago");
+  mocks.formatRelativeTime.mockReset();
+  mocks.formatRelativeTime.mockReturnValue("5 minutes ago");
   mocks.dbSchemaStore.mockReset();
   mocks.dbSchemaStore.mockReturnValue({
     getSchemaList: vi.fn(() => mocks.schemaList),
@@ -561,7 +563,7 @@ describe("DatabaseOverviewPanel", () => {
 
     expect(container.textContent).toContain("database.last-sync");
     expect(container.textContent).toContain("-");
-    expect(mocks.humanizeDate).not.toHaveBeenCalled();
+    expect(mocks.formatRelativeTime).not.toHaveBeenCalled();
 
     unmount();
   });

--- a/frontend/src/react/pages/project/database-detail/revision/DatabaseRevisionTable.tsx
+++ b/frontend/src/react/pages/project/database-detail/revision/DatabaseRevisionTable.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from "react-i18next";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Table,
@@ -11,7 +12,6 @@ import {
 import { router } from "@/react/router";
 import { getDateForPbTimestampProtoEs } from "@/types";
 import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
-import { humanizeDate } from "@/utils";
 import { getRevisionType, revisionLink } from "@/utils/v1/revision";
 
 export function DatabaseRevisionTable({
@@ -105,11 +105,17 @@ export function DatabaseRevisionTable({
             </TableCell>
             <TableCell>{getRevisionType(revision.type)}</TableCell>
             <TableCell>
-              {getDateForPbTimestampProtoEs(revision.createTime)
-                ? humanizeDate(
-                    getDateForPbTimestampProtoEs(revision.createTime) as Date
-                  )
-                : "-"}
+              {revision.createTime ? (
+                <HumanizeTs
+                  ts={
+                    (
+                      getDateForPbTimestampProtoEs(revision.createTime) as Date
+                    ).getTime() / 1000
+                  }
+                />
+              ) : (
+                "-"
+              )}
             </TableCell>
           </TableRow>
         ))}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
@@ -4,6 +4,7 @@ import { Check, Minus } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { EngineIcon } from "@/react/components/EngineIcon";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
 import {
   Table,
@@ -34,7 +35,6 @@ import {
   extractInstanceResourceName,
   extractTaskUID,
   formatAbsoluteDateTime,
-  humanizeDate,
   humanizeDurationV1,
 } from "@/utils";
 import { useIssueDetailContext } from "../context/IssueDetailContext";
@@ -277,15 +277,19 @@ function IssueDetailTaskRunDateCell({
   if (!parsedDate) {
     return <span className="text-control-light">-</span>;
   }
-  const text =
-    format === "absolute"
-      ? formatAbsoluteDateTime(parsedDate.getTime())
-      : humanizeDate(parsedDate);
+  if (format === "absolute") {
+    return (
+      <span className="text-sm text-control">
+        {formatAbsoluteDateTime(parsedDate.getTime())}
+      </span>
+    );
+  }
 
   return (
-    <Tooltip content={formatAbsoluteDateTime(parsedDate.getTime())}>
-      <span className="text-sm text-control">{text}</span>
-    </Tooltip>
+    <HumanizeTs
+      ts={parsedDate.getTime() / 1000}
+      className="text-sm text-control"
+    />
   );
 }
 

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailMeta.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailMeta.tsx
@@ -3,6 +3,7 @@ import { Plus, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { issueServiceClientConnect } from "@/connect";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   Popover,
@@ -17,7 +18,7 @@ import {
   IssueStatus,
   UpdateIssueRequestSchema,
 } from "@/types/proto-es/v1/issue_service_pb";
-import { hasProjectPermissionV2, humanizeTs } from "@/utils";
+import { hasProjectPermissionV2 } from "@/utils";
 import { usePlanDetailContext } from "../shell/PlanDetailContext";
 
 export function PlanDetailMeta() {
@@ -39,11 +40,10 @@ export function PlanDetailMeta() {
     () => extractUserEmail(page.plan.creator),
     [page.plan.creator]
   );
-  const createdTimeDisplay = useMemo(() => {
-    const ts = getTimeForPbTimestampProtoEs(page.plan.createTime, 0);
-    if (!ts) return "";
+  const createdTimeTs = useMemo(() => {
+    // Reference `now` so the relative label re-renders on each tick.
     void now;
-    return humanizeTs(ts / 1000);
+    return getTimeForPbTimestampProtoEs(page.plan.createTime, 0);
   }, [now, page.plan.createTime]);
   const allowChangeLabels = useMemo(() => {
     if (!project || !page.issue || page.issue.status !== IssueStatus.OPEN) {
@@ -85,12 +85,13 @@ export function PlanDetailMeta() {
 
   return (
     <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-control-placeholder">
-      <span>
-        {t("plan.meta.created-by-at", {
-          time: createdTimeDisplay,
-          user: creatorEmail,
-        })}
-      </span>
+      <span>{t("plan.meta.created-by", { user: creatorEmail })}</span>
+      {createdTimeTs > 0 && (
+        <>
+          <span aria-hidden="true">·</span>
+          <HumanizeTs ts={createdTimeTs / 1000} />
+        </>
+      )}
 
       {page.issue && (
         <>

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRunTable.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRunTable.tsx
@@ -3,6 +3,7 @@ import { DurationSchema } from "@bufbuild/protobuf/wkt";
 import { Check, Minus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { Button } from "@/react/components/ui/button";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
 import {
@@ -28,11 +29,7 @@ import {
 } from "@/types";
 import type { TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
 import { TaskRun_Status } from "@/types/proto-es/v1/rollout_service_pb";
-import {
-  formatAbsoluteDateTime,
-  humanizeDate,
-  humanizeDurationV1,
-} from "@/utils";
+import { formatAbsoluteDateTime, humanizeDurationV1 } from "@/utils";
 import { PlanDetailTaskRunDetail } from "./PlanDetailTaskRunDetail";
 
 export function PlanDetailTaskRunTable({
@@ -258,9 +255,10 @@ function TaskRunDateCell({
   }
 
   return (
-    <Tooltip content={formatAbsoluteDateTime(parsedDate.getTime())}>
-      <span className="text-sm text-control">{humanizeDate(parsedDate)}</span>
-    </Tooltip>
+    <HumanizeTs
+      ts={parsedDate.getTime() / 1000}
+      className="text-sm text-control"
+    />
   );
 }
 

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployLatestTaskRunInfo.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployLatestTaskRunInfo.tsx
@@ -8,11 +8,11 @@ import {
   XCircle,
 } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { TaskRunLogViewer } from "@/react/components/task-run-log";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { getDateForPbTimestampProtoEs } from "@/types";
 import { TaskRun_Status } from "@/types/proto-es/v1/rollout_service_pb";
-import { formatAbsoluteDateTime, humanizeDate } from "@/utils";
 
 export function DeployLatestTaskRunInfo({
   duration,
@@ -88,11 +88,10 @@ export function DeployLatestTaskRunInfo({
         {updateDate && (
           <>
             <span className="text-gray-300">·</span>
-            <Tooltip content={formatAbsoluteDateTime(updateDate.getTime())}>
-              <span className="shrink-0 text-gray-500">
-                {humanizeDate(updateDate)}
-              </span>
-            </Tooltip>
+            <HumanizeTs
+              ts={updateDate.getTime() / 1000}
+              className="shrink-0 text-gray-500"
+            />
           </>
         )}
         {executorEmail && (

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
@@ -17,7 +17,7 @@ import {
   Task_Status,
   TaskRun_Status,
 } from "@/types/proto-es/v1/rollout_service_pb";
-import { databaseForTask, humanizeTs } from "@/utils";
+import { databaseForTask, formatAbsoluteDateTime, humanizeTs } from "@/utils";
 import {
   isReleaseBasedTask,
   releaseNameOfTaskV1,
@@ -81,10 +81,13 @@ export function DeployTaskDetailPanel({ task }: { task: Task }) {
         : "",
     [environmentList, stage?.environment]
   );
-  const scheduledTimeDisplay = useMemo(() => {
+  const scheduledTime = useMemo(() => {
     const ts = getTimeForPbTimestampProtoEs(task.runTime, 0);
-    if (!ts) return "";
-    return humanizeTs(ts / 1000);
+    if (!ts) return undefined;
+    return {
+      relative: humanizeTs(ts / 1000),
+      absolute: formatAbsoluteDateTime(ts),
+    };
   }, [task.runTime]);
   const isReleaseTask = useMemo(() => isReleaseBasedTask(task), [task]);
   const {
@@ -122,7 +125,7 @@ export function DeployTaskDetailPanel({ task }: { task: Task }) {
               size="md"
               target={database.name}
             />
-            {scheduledTimeDisplay && task.status === Task_Status.PENDING && (
+            {scheduledTime && task.status === Task_Status.PENDING && (
               <Tooltip
                 content={
                   <div className="flex flex-col gap-y-1">
@@ -130,14 +133,14 @@ export function DeployTaskDetailPanel({ task }: { task: Task }) {
                       {t("task.scheduled-time")}
                     </div>
                     <div className="whitespace-nowrap text-sm">
-                      {scheduledTimeDisplay}
+                      {scheduledTime.absolute}
                     </div>
                   </div>
                 }
               >
                 <span className="inline-flex items-center gap-1 rounded-full bg-control-bg px-2 py-0.5 text-xs text-control">
                   <CalendarClock className="h-3.5 w-3.5 opacity-80" />
-                  <span>{scheduledTimeDisplay}</span>
+                  <span>{scheduledTime.relative}</span>
                 </span>
               </Tooltip>
             )}

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { ReadonlyMonaco } from "@/react/components/monaco";
 import { RouterLink } from "@/react/components/RouterLink";
 import { Button } from "@/react/components/ui/button";
@@ -21,7 +22,6 @@ import {
   Task_Status,
   TaskRun_Status,
 } from "@/types/proto-es/v1/rollout_service_pb";
-import { humanizeTs } from "@/utils";
 import {
   isReleaseBasedTask,
   releaseNameOfTaskV1,
@@ -99,10 +99,10 @@ export function DeployTaskItem({
     latestTaskRun.hasPriorBackup
       ? latestTaskRun
       : undefined;
-  const scheduledTime =
+  const scheduledTimeTs =
     task.runTime && task.status === Task_Status.PENDING
-      ? humanizeTs(getTimeForPbTimestampProtoEs(task.runTime, 0) / 1000)
-      : "";
+      ? getTimeForPbTimestampProtoEs(task.runTime, 0) / 1000
+      : 0;
   const timingDisplay = latestTaskRun ? getTaskRunDuration(latestTaskRun) : "";
   const executorEmail =
     latestTaskRun?.creator.match(/users\/([^/]+)/)?.[1] ?? "";
@@ -182,19 +182,19 @@ export function DeployTaskItem({
                     <span>{t("common.view-details")}</span>
                   </RouterLink>
                 )}
-                {isExpanded && scheduledTime && (
+                {isExpanded && scheduledTimeTs > 0 && (
                   <span className="flex shrink-0 items-center gap-x-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-600">
                     <LoaderCircle className="h-3 w-3 animate-spin" />
-                    {scheduledTime}
+                    <HumanizeTs ts={scheduledTimeTs} />
                   </span>
                 )}
               </div>
               {!isExpanded && (
                 <div className="ml-auto shrink-0 text-xs text-gray-500">
-                  {scheduledTime ? (
+                  {scheduledTimeTs > 0 ? (
                     <span className="flex items-center gap-x-1 text-blue-600">
                       <LoaderCircle className="h-3 w-3 animate-spin" />
-                      {scheduledTime}
+                      <HumanizeTs ts={scheduledTimeTs} />
                     </span>
                   ) : task.status === Task_Status.RUNNING && timingDisplay ? (
                     <span className="flex items-center gap-x-1 text-blue-600">
@@ -258,10 +258,14 @@ export function DeployTaskItem({
             <div className="mt-1 flex items-center gap-x-2 text-xs">
               {latestTaskRun?.createTime && (
                 <span className="rounded-full border bg-gray-50 px-2 py-0.5 text-gray-500">
-                  {humanizeTs(
-                    getTimeForPbTimestampProtoEs(latestTaskRun.createTime, 0) /
-                      1000
-                  )}
+                  <HumanizeTs
+                    ts={
+                      getTimeForPbTimestampProtoEs(
+                        latestTaskRun.createTime,
+                        0
+                      ) / 1000
+                    }
+                  />
                 </span>
               )}
               <span

--- a/frontend/src/react/plugins/agent/components/AgentWindow.test.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentWindow.test.tsx
@@ -40,6 +40,7 @@ function createMockStorage(): Storage {
 }
 
 vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
   useTranslation: mocks.useTranslation,
 }));
 

--- a/frontend/src/react/plugins/agent/components/AgentWindow.tsx
+++ b/frontend/src/react/plugins/agent/components/AgentWindow.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/react/components/ui/button";
 import { Input } from "@/react/components/ui/input";
 import { getLayerRoot } from "@/react/components/ui/layer";
 import { cn } from "@/react/lib/utils";
+import { formatAbsoluteDateTime } from "@/utils";
 import type { AgentChat as AgentChatRecord } from "../logic/types";
 import {
   selectCurrentChat,
@@ -1101,9 +1102,14 @@ export function AgentWindow() {
                             }`}
                             data-agent-chat-updated-ts
                           >
-                            <HumanizeTs
-                              ts={Math.floor(chat.updatedTs / 1000)}
-                            />
+                            <AgentTooltip
+                              content={formatAbsoluteDateTime(chat.updatedTs)}
+                            >
+                              <HumanizeTs
+                                ts={Math.floor(chat.updatedTs / 1000)}
+                                tooltip={false}
+                              />
+                            </AgentTooltip>
                           </span>
                         </button>
                         <div className="pointer-events-none flex shrink-0 items-center gap-x-2 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">


### PR DESCRIPTION
## What

Unify every relative-time display so hovering reveals the absolute timestamp (with timezone). `HumanizeTs` is now the single canonical component — it wraps the relative label in the shared tooltip showing the absolute time — and all inline `humanizeTs()` / `humanizeDate()` displays plus the previously hand-rolled `<Tooltip content={formatAbsoluteDateTime(...)}>` wrappers now route through it.

Covers plan, issue, database (changelog / revision / overview), release, data-export, and sync-schema surfaces (~20 sites).

## Notes

- **Agent window** timestamps use `AgentTooltip` (agent overlay layer) via `tooltip={false}`, since the shared tooltip portals to the lower `overlay` layer and would otherwise render behind the window.
- The plan **"Scheduled time"** pill keeps its labeled tooltip but now shows the absolute time instead of repeating the relative one.
- The plan-meta **"Created by … · &lt;time&gt;"** line composes the timestamp as a layout element; the i18n key stays text-only (no markup in translation strings).

## Test plan

- `pnpm --dir frontend type-check` ✅
- `pnpm --dir frontend check` — Biome, i18n cross-locale consistency, React layering scanner ✅
- `pnpm --dir frontend test` — 140 affected tests pass, including a new `HumanizeTs.test.tsx` contract test (relative text + absolute-on-hover + `tooltip={false}` opt-out) ✅

Ref: BYT-9780

🤖 Generated with [Claude Code](https://claude.com/claude-code)
