### PR TITLE
fix(sql-editor): keep JIT request statement editor fixed-height

### DIFF
--- a/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.test.tsx
+++ b/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.test.tsx
@@ -293,12 +293,15 @@ vi.mock("@/react/components/monaco/MonacoEditor", () => ({
   MonacoEditor: ({
     content,
     onChange,
+    autoHeight,
   }: {
     content: string;
     onChange?: (val: string) => void;
+    autoHeight?: boolean;
   }) => (
     <textarea
       data-testid="monaco-editor"
+      data-auto-height={String(autoHeight)}
       value={content}
       onChange={(e) => onChange?.(e.target.value)}
     />
@@ -377,6 +380,31 @@ describe("AccessGrantRequestDrawer", () => {
     ) as HTMLInputElement;
     expect(checkbox).not.toBeNull();
     expect(checkbox.checked).toBe(true);
+
+    unmount();
+  });
+
+  test("statement editor is fixed-height (autoHeight=false) so a long query can't overflow and cover the reason box", () => {
+    const onClose = vi.fn();
+    // A tall statement is what triggered the bug: MonacoEditor's default
+    // autoHeight grows the editor to its content (clamped to 600px), overflowing
+    // the 160px (h-40) wrapper and painting over the fields below it — hiding the
+    // reason box. The fix pins autoHeight={false} so it stays a fixed, internally
+    // scrolling box. jsdom has no layout engine, so we assert the prop contract.
+    const { container, render, unmount } = renderIntoContainer(
+      <AccessGrantRequestDrawer
+        targets={["instances/inst1/databases/mydb"]}
+        query={"SELECT id,\n".repeat(40) + "FROM orders"}
+        onClose={onClose}
+      />
+    );
+    render();
+
+    const monacoEditor = container.querySelector(
+      "[data-testid='monaco-editor']"
+    ) as HTMLTextAreaElement;
+    expect(monacoEditor).not.toBeNull();
+    expect(monacoEditor.getAttribute("data-auto-height")).toBe("false");
 
     unmount();
   });

--- a/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
+++ b/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
@@ -369,6 +369,14 @@ function AccessGrantRequestDrawerInner({
               description={t("sql-editor.only-select-allowed")}
             />
             <MonacoEditor
+              // Fixed-height box: fill the h-40 wrapper and scroll internally.
+              // MonacoEditor defaults to autoHeight, which sizes the editor to
+              // its content (clamped to 600px). A long statement then overflows
+              // the 160px wrapper (which doesn't clip) and paints over the
+              // fields below it — Unmask/Export/Expiration/Reason — hiding the
+              // reason box. autoHeight={false} keeps it a fixed, internally
+              // scrolling box, matching every other fixed-height embed.
+              autoHeight={false}
               // Drawer Monaco portals outside `.sqleditor--wrapper`, so opt the
               // canvas into the transparent-background rule and back it with the
               // themed `bg-background` (from `sheetStyle`'s `--color-background`)


### PR DESCRIPTION
## Problem

A customer reported that in the **Request Data Access** (JIT) drawer, *"if your query is long enough, you can't see the box to supply a reason for requesting JIT access to redacted data."*

## Root cause

The drawer embeds the statement in a `MonacoEditor` inside a fixed-height (`h-40` = 160px) wrapper, but left `autoHeight` at its default (`true`). In that mode the editor sizes its inner container to the **content height, clamped to 600px**, and the `h-40` class only constrains the *outer* wrapper — which has no `overflow:hidden`. A long query therefore overflows the 160px box by up to ~440px and paints over the fields rendered below it in the flex column — **Unmask → Export → Expiration → Reason** — leaving the reason box visually buried (and, depending on the browser/GPU, covered by black repaint artifacts).

Every other fixed-height embed of this component passes `autoHeight={false}` (`StandardPanel/SQLEditor`, `CodeViewer`, `DefinitionViewer`, `ThemePreview`); this drawer was the lone omission.

## Fix

Pass `autoHeight={false}` to the statement `MonacoEditor` (keeping `h-40`). The editor now fills its 160px box and scrolls internally, so the reason box — and every field below the editor — stays visible regardless of query length.

## Before / after

- **Before:** a ~40-line query inflates the editor to ~600px; it overlaps Unmask/Export/Expiration and buries the Reason textarea.
- **After:** the editor is a fixed 160px box with an internal scrollbar; Unmask → Export → Expiration → Reason all render cleanly below it.

Reproduced and verified on a local enterprise instance by rendering the real drawer with a long statement (before/after screenshots captured locally).

## Testing

- Added a regression test pinning `autoHeight={false}` on the statement editor (verified RED→GREEN: fails with `Expected "false", Received "undefined"` when the prop is removed).
- `vitest` `AccessGrantRequestDrawer.test.tsx` — 5/5 pass
- `biome check` (changed files) — clean
- `tsc --build` type-check — pass
- `check-react-layering` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)