### PR TITLE
fix(plan-detail): toggling options no longer resets the editor on plan create (BYT-9782)

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -104,6 +104,7 @@ import { getStatementSize } from "@/utils/sheet";
 import { extractDatabaseGroupName } from "@/utils/v1/databaseGroup";
 import { sheetNameOfSpec } from "@/utils/v1/issue/plan";
 import {
+  extractSheetUID,
   getSheetStatement,
   setSheetStatement as setLocalSheetStatement,
 } from "@/utils/v1/sheet";
@@ -732,6 +733,19 @@ function OptionsSection({
   );
   const [instanceRoles, setInstanceRoles] = useState<string[]>([]);
 
+  // Draft (local) sheets are edited in place by the statement editor, so the
+  // `sheetStatement` state is only a seed that goes stale after each keystroke.
+  // Read the live content back for them so an option toggle rebases on the
+  // user's latest SQL instead of overwriting it (BYT-9781); persisted (server)
+  // sheets stay on the state seeded by the effect below.
+  const isDraftSheet =
+    sheetName !== "" && extractSheetUID(sheetName).startsWith("-");
+  const readStatement = (): string =>
+    isDraftSheet
+      ? getSheetStatement(getLocalSheetByName(sheetName))
+      : sheetStatement;
+  const currentStatement = readStatement();
+
   const targets = useMemo(() => {
     if (selectedSpec.config?.case === "changeDatabaseConfig") {
       return selectedSpec.config.value.targets ?? [];
@@ -764,8 +778,8 @@ function OptionsSection({
     : "";
 
   const parsed = useMemo(
-    () => parseStatement(sheetStatement),
-    [sheetStatement]
+    () => parseStatement(currentStatement),
+    [currentStatement]
   );
   const selectedRole = parsed.role ?? "";
   const selectedIsolation = parsed.isolationLevel ?? "";
@@ -951,7 +965,7 @@ function OptionsSection({
     patchState({ plan: response });
   };
 
-  const currentGhostConfig = getGhostConfigFromStatement(sheetStatement);
+  const currentGhostConfig = getGhostConfigFromStatement(currentStatement);
   const ghostIssueDatabases = useMemo(() => {
     return databases.filter((db) => {
       const instance = getInstanceResource(db);
@@ -1016,7 +1030,7 @@ function OptionsSection({
                   onValueChange={(value) => {
                     void persistStatement(
                       updateRoleSetter(
-                        sheetStatement,
+                        readStatement(),
                         value && value !== EMPTY_SELECT_VALUE
                           ? value
                           : undefined
@@ -1063,7 +1077,7 @@ function OptionsSection({
                   onCheckedChange={(checked) => {
                     void persistStatement(
                       updateTransactionMode(
-                        sheetStatement,
+                        readStatement(),
                         checked ? "on" : "off"
                       )
                     );
@@ -1093,7 +1107,7 @@ function OptionsSection({
                   onValueChange={(value) => {
                     void persistStatement(
                       updateIsolationLevel(
-                        sheetStatement,
+                        readStatement(),
                         value === EMPTY_SELECT_VALUE
                           ? undefined
                           : (value as IsolationLevel) || undefined
@@ -1192,7 +1206,7 @@ function OptionsSection({
                   onCheckedChange={(checked) => {
                     void persistStatement(
                       updateGhostConfig(
-                        sheetStatement,
+                        readStatement(),
                         checked
                           ? (currentGhostConfig ?? getDefaultGhostConfig())
                           : undefined
@@ -1208,7 +1222,9 @@ function OptionsSection({
                 value={currentGhostConfig ?? {}}
                 disabled={!allowChange || isSheetOversize}
                 onChange={(next) =>
-                  void persistStatement(updateGhostConfig(sheetStatement, next))
+                  void persistStatement(
+                    updateGhostConfig(readStatement(), next)
+                  )
                 }
               />
             )}


### PR DESCRIPTION
## What

Fixes BYT-9782 — toggling a statement option (transaction mode, isolation level, role setter, or online migration / gh-ost) while **creating a plan** wiped the SQL in the editor.

## Why

`OptionsSection` keeps its own copy of the statement in `useState`, seeded once and re-seeded only when the sheet changes. During plan creation the editor mutates the draft sheet **in place on every keystroke**, so that snapshot goes stale. An option toggle then persisted the stale snapshot (`update*(sheetStatement, …)`), overwriting the unsaved SQL — and the resulting reload reset the editor.

## Fix

Read the live draft-sheet content at use time (`readStatement()` / `currentStatement`) instead of the stale snapshot — for both the derived display state and every toggle's persist base. Persisted (server) sheets keep using the seeded snapshot. So the role, transaction-mode, isolation-level, and online-migration controls now rebase on the user's latest edits instead of clobbering them.

## Testing

- `pnpm --dir frontend type-check`
- `pnpm --dir frontend check` — biome, react-i18n, react-layering, i18n sort all pass
- Manual: the reported clobber no longer reproduces when toggling options mid-edit during plan creation.

Frontend-only; no proto / backend / database changes; not a breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
