### PR TITLE
fix(iam): page the database resource selector to avoid freeze at scale (BYT-9785)

### DIFF
--- a/frontend/src/react/components/DatabaseResourceSelector.test.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.test.tsx
@@ -392,6 +392,77 @@ describe("DatabaseResourceSelector", () => {
     unmount();
   });
 
+  test("discards stale load-more results when the filter changes mid-flight", async () => {
+    mocks.fetchDatabases.mockReset();
+    let resolveStaleLoadMore: (value: unknown) => void = () => {};
+    mocks.fetchDatabases
+      // Initial first page.
+      .mockResolvedValueOnce({
+        databases: [
+          {
+            name: "instances/prod/databases/db1",
+            instanceResource: { title: "Prod" },
+          },
+        ],
+        nextPageToken: "page-2",
+      })
+      // Load-more request: stays pending until we resolve it by hand.
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStaleLoadMore = resolve;
+          })
+      )
+      // Refetch triggered by the filter change.
+      .mockResolvedValueOnce({
+        databases: [
+          {
+            name: "instances/prod/databases/db3",
+            instanceResource: { title: "Prod" },
+          },
+        ],
+        nextPageToken: "",
+      });
+
+    const { container, unmount } = renderIntoContainer(<Harness />);
+    await flushPromises();
+    await waitForText(container, "db1");
+
+    // Kick off load more — the request hangs.
+    const loadMoreButton = Array.from(
+      container.querySelectorAll("button")
+    ).find((button) => button.textContent?.includes("load-more"));
+    act(() => {
+      loadMoreButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushPromises();
+
+    // Change the filter before load-more resolves -> new first page (db3).
+    clickFirstButtonInRow(container, "advanced-search:");
+    await flushPromises();
+    await waitForText(container, "db3");
+
+    // The stale load-more now resolves with a page from the old filter.
+    act(() => {
+      resolveStaleLoadMore({
+        databases: [
+          {
+            name: "instances/prod/databases/db2",
+            instanceResource: { title: "Prod" },
+          },
+        ],
+        nextPageToken: "",
+      });
+    });
+    await flushPromises();
+
+    // Stale page must not leak into the filtered list.
+    expect(container.textContent).not.toContain("db2");
+    expect(container.textContent).toContain("db3");
+
+    unmount();
+  });
+
   test("selecting a table replaces child column selections", async () => {
     const onValueChange = vi.fn();
     const { container, unmount } = renderIntoContainer(

--- a/frontend/src/react/components/DatabaseResourceSelector.test.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.test.tsx
@@ -335,6 +335,63 @@ describe("DatabaseResourceSelector", () => {
     unmount();
   });
 
+  test("loads one page at a time instead of draining every page", async () => {
+    mocks.fetchDatabases.mockReset();
+    mocks.fetchDatabases
+      .mockResolvedValueOnce({
+        databases: [
+          {
+            name: "instances/prod/databases/db1",
+            environment: "environments/prod",
+            effectiveEnvironment: "environments/prod",
+            instanceResource: { title: "Prod" },
+          },
+        ],
+        nextPageToken: "page-2",
+      })
+      .mockResolvedValueOnce({
+        databases: [
+          {
+            name: "instances/prod/databases/db2",
+            environment: "environments/prod",
+            effectiveEnvironment: "environments/prod",
+            instanceResource: { title: "Prod" },
+          },
+        ],
+        nextPageToken: "",
+      });
+
+    const { container, unmount } = renderIntoContainer(<Harness />);
+    await flushPromises();
+    await waitForText(container, "db1");
+
+    // Opening the selector fetches exactly one bounded page, not the whole
+    // list — this is the BYT-9785 freeze fix.
+    expect(mocks.fetchDatabases).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchDatabases).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pageSize: 200, pageToken: "" })
+    );
+    expect(container.textContent).not.toContain("db2");
+
+    const loadMoreButton = Array.from(
+      container.querySelectorAll("button")
+    ).find((button) => button.textContent?.includes("load-more"));
+    expect(loadMoreButton).toBeTruthy();
+
+    act(() => {
+      loadMoreButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushPromises();
+    await waitForText(container, "db2");
+
+    expect(mocks.fetchDatabases).toHaveBeenCalledTimes(2);
+    expect(mocks.fetchDatabases).toHaveBeenLastCalledWith(
+      expect.objectContaining({ pageSize: 200, pageToken: "page-2" })
+    );
+
+    unmount();
+  });
+
   test("selecting a table replaces child column selections", async () => {
     const onValueChange = vi.fn();
     const { container, unmount } = renderIntoContainer(

--- a/frontend/src/react/components/DatabaseResourceSelector.test.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.test.tsx
@@ -463,6 +463,66 @@ describe("DatabaseResourceSelector", () => {
     unmount();
   });
 
+  test("hides Load more while a new filter's first page is refetching", async () => {
+    mocks.fetchDatabases.mockReset();
+    let resolveRefetch: (value: unknown) => void = () => {};
+    mocks.fetchDatabases
+      // Initial first page with more pages available.
+      .mockResolvedValueOnce({
+        databases: [
+          {
+            name: "instances/prod/databases/db1",
+            instanceResource: { title: "Prod" },
+          },
+        ],
+        nextPageToken: "page-2",
+      })
+      // First page after the filter change — stays pending so we can inspect
+      // the in-between state.
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefetch = resolve;
+          })
+      );
+
+    const { container, unmount } = renderIntoContainer(<Harness />);
+    await flushPromises();
+    await waitForText(container, "db1");
+
+    const hasLoadMore = () =>
+      Array.from(container.querySelectorAll("button")).some((button) =>
+        button.textContent?.includes("load-more")
+      );
+    expect(hasLoadMore()).toBe(true);
+
+    // Change the filter; the new first page is still in flight.
+    clickFirstButtonInRow(container, "advanced-search:");
+    await flushPromises();
+
+    // The stale page token must be cleared so Load more cannot fire a request
+    // pairing the old offset token with the new filter.
+    expect(hasLoadMore()).toBe(false);
+
+    // Once the new first page resolves, Load more reflects the new token.
+    act(() => {
+      resolveRefetch({
+        databases: [
+          {
+            name: "instances/prod/databases/db3",
+            instanceResource: { title: "Prod" },
+          },
+        ],
+        nextPageToken: "new-page-2",
+      });
+    });
+    await flushPromises();
+    await waitForText(container, "db3");
+    expect(hasLoadMore()).toBe(true);
+
+    unmount();
+  });
+
   test("selecting a table replaces child column selections", async () => {
     const onValueChange = vi.fn();
     const { container, unmount } = renderIntoContainer(

--- a/frontend/src/react/components/DatabaseResourceSelector.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.tsx
@@ -238,9 +238,13 @@ export function DatabaseResourceSelector({
   useEffect(() => {
     requestGenerationRef.current += 1;
     const generation = requestGenerationRef.current;
-    // A new filter context begins; clear any pending load-more flag so a
-    // discarded in-flight request can't leave the button stuck disabled.
+    // A new filter context begins. Clear the pending load-more flag and the
+    // previous page token so the stale Load more button can't fire a request
+    // that pairs the old offset token with the new filter (page tokens are
+    // offsets bound to the same list params). The new token arrives with the
+    // first page below.
     setLoadingMore(false);
+    setNextPageToken("");
     const fetchFirstPage = async () => {
       const result = await useAppStore.getState().fetchDatabases({
         parent: projectName,

--- a/frontend/src/react/components/DatabaseResourceSelector.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.tsx
@@ -66,6 +66,13 @@ const instanceNamePrefix = "instances/";
 const UNKNOWN_ENVIRONMENT_ID = "-1";
 const UNKNOWN_ENVIRONMENT_NAME = `${environmentNamePrefix}${UNKNOWN_ENVIRONMENT_ID}`;
 
+// Fetch and render databases one page at a time. The selector used to drain
+// every page in a do-while loop and render all rows at once, which froze the
+// tab for projects with thousands of databases (BYT-9785). One bounded page
+// keeps both the network payload and the DOM node count in check; the user
+// loads more on demand or narrows with the instance/environment filter.
+const DATABASE_PAGE_SIZE = 200;
+
 interface DatabaseFilter {
   instance?: string;
   environment?: string;
@@ -98,6 +105,8 @@ export function DatabaseResourceSelector({
   );
 
   const [databases, setDatabases] = useState<Database[]>([]);
+  const [nextPageToken, setNextPageToken] = useState("");
+  const [loadingMore, setLoadingMore] = useState(false);
   const [searchParams, setSearchParams] = useState<SearchParams>({
     query: "",
     scopes: [],
@@ -223,26 +232,39 @@ export function DatabaseResourceSelector({
 
   useEffect(() => {
     let cancelled = false;
-    const fetchAll = async () => {
-      let allDatabases: Database[] = [];
-      let pageToken = "";
-      do {
-        const result = await useAppStore.getState().fetchDatabases({
-          parent: projectName,
-          pageSize: 1000,
-          pageToken,
-          filter: databaseFilter,
-        });
-        allDatabases = [...allDatabases, ...result.databases];
-        pageToken = result.nextPageToken;
-      } while (pageToken);
-      if (!cancelled) setDatabases(allDatabases);
+    const fetchFirstPage = async () => {
+      const result = await useAppStore.getState().fetchDatabases({
+        parent: projectName,
+        pageSize: DATABASE_PAGE_SIZE,
+        pageToken: "",
+        filter: databaseFilter,
+      });
+      if (cancelled) return;
+      setDatabases(result.databases);
+      setNextPageToken(result.nextPageToken);
     };
-    fetchAll();
+    fetchFirstPage();
     return () => {
       cancelled = true;
     };
   }, [projectName, databaseFilter]);
+
+  const loadMore = useCallback(async () => {
+    if (!nextPageToken || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const result = await useAppStore.getState().fetchDatabases({
+        parent: projectName,
+        pageSize: DATABASE_PAGE_SIZE,
+        pageToken: nextPageToken,
+        filter: databaseFilter,
+      });
+      setDatabases((prev) => [...prev, ...result.databases]);
+      setNextPageToken(result.nextPageToken);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [projectName, databaseFilter, nextPageToken, loadingMore]);
 
   const selectedResourceMap = useMemo(() => {
     const map = new Map<string, DatabaseSelection>();
@@ -836,7 +858,9 @@ export function DatabaseResourceSelector({
                 : t("common.select-all")}
             </button>
             <span>
-              {t("common.total")} {databases.length}{" "}
+              {nextPageToken
+                ? `${databases.length}+`
+                : `${t("common.total")} ${databases.length}`}{" "}
               {t("common.items", { count: databases.length })}
             </span>
           </div>
@@ -971,6 +995,18 @@ export function DatabaseResourceSelector({
                 </div>
               );
             })}
+            {nextPageToken && (
+              <button
+                type="button"
+                className="w-full px-2 py-1.5 text-sm text-accent hover:underline cursor-pointer disabled:opacity-50 disabled:no-underline"
+                onClick={loadMore}
+                disabled={loadingMore}
+              >
+                {loadingMore
+                  ? `${t("common.loading")}...`
+                  : t("common.load-more")}
+              </button>
+            )}
           </div>
         </div>
         <div className="flex-1 flex flex-col min-w-0">

--- a/frontend/src/react/components/DatabaseResourceSelector.tsx
+++ b/frontend/src/react/components/DatabaseResourceSelector.tsx
@@ -7,7 +7,7 @@ import {
   Table2,
   X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AdvancedSearch,
@@ -230,8 +230,17 @@ export function DatabaseResourceSelector({
     };
   }, [searchParams]);
 
+  // Bumped whenever the project or filter changes so that in-flight requests
+  // (first page or load-more) from a prior filter discard their results
+  // instead of appending stale databases into the current filtered list.
+  const requestGenerationRef = useRef(0);
+
   useEffect(() => {
-    let cancelled = false;
+    requestGenerationRef.current += 1;
+    const generation = requestGenerationRef.current;
+    // A new filter context begins; clear any pending load-more flag so a
+    // discarded in-flight request can't leave the button stuck disabled.
+    setLoadingMore(false);
     const fetchFirstPage = async () => {
       const result = await useAppStore.getState().fetchDatabases({
         parent: projectName,
@@ -239,18 +248,16 @@ export function DatabaseResourceSelector({
         pageToken: "",
         filter: databaseFilter,
       });
-      if (cancelled) return;
+      if (generation !== requestGenerationRef.current) return;
       setDatabases(result.databases);
       setNextPageToken(result.nextPageToken);
     };
     fetchFirstPage();
-    return () => {
-      cancelled = true;
-    };
   }, [projectName, databaseFilter]);
 
   const loadMore = useCallback(async () => {
     if (!nextPageToken || loadingMore) return;
+    const generation = requestGenerationRef.current;
     setLoadingMore(true);
     try {
       const result = await useAppStore.getState().fetchDatabases({
@@ -259,10 +266,13 @@ export function DatabaseResourceSelector({
         pageToken: nextPageToken,
         filter: databaseFilter,
       });
+      if (generation !== requestGenerationRef.current) return;
       setDatabases((prev) => [...prev, ...result.databases]);
       setNextPageToken(result.nextPageToken);
     } finally {
-      setLoadingMore(false);
+      if (generation === requestGenerationRef.current) {
+        setLoadingMore(false);
+      }
     }
   }, [projectName, databaseFilter, nextPageToken, loadingMore]);
 


### PR DESCRIPTION
## What & why

The **"Manually select"** database picker (`DatabaseResourceSelector`, used in the member/group role-binding flow and 4 other surfaces) froze the browser tab at scale. On open it:

1. **Drained every page** of the project's databases in a `do-while` loop (`pageSize: 1000` until no token), then
2. **Rendered all rows at once** (~10 DOM nodes each, no virtualization).

For a deployment with 145 instances and thousands of databases (BYT-9785) that meant many sequential round-trips followed by tens of thousands of DOM nodes committed synchronously — the tab locked up *before the user could even type into the instance filter*. It doesn't reproduce on small local datasets because the cost is purely a function of database count.

## The fix

Bounded, on-demand loading in the shared component (so all callers benefit, no behavior contract change):

- **One page on open** (`DATABASE_PAGE_SIZE = 200`) instead of draining all pages — caps both the network payload and the DOM node count.
- **"Load more"** button (reuses the existing `common.load-more` key) appends the next page on demand, tracked via `nextPageToken`.
- **Honest count** — shows `N+` while more pages remain, `Total N` once fully loaded. "Select all" stays scoped to loaded rows; the `N+` / Load-more affordance signals partiality.
- **No backend change** — the server already honors the filter and pagination; the client was just choosing to drain everything.

Considered but not needed: virtualization (the in-repo `FlatTableList` precedent deliberately uses bounded paging over virtualization for this case) and a debounce (`AdvancedSearch` already debounces its query input).

Non-goal: a single database with thousands of *tables* still renders its expanded subtree un-virtualized — separate, rarer concern.

## Testing

- New regression test: opening the selector fetches **exactly one** page (not drained), and Load-more pulls the next page with the page token.
- Existing 5 tests still pass (6/6 total).
- `type-check`, biome, React i18n parity, and layering checks all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)