### PR TITLE
chore: bump omni for MySQL row constructor support

### DIFF
--- a/backend/plugin/parser/mariadb/diagnose_e2e_test.go
+++ b/backend/plugin/parser/mariadb/diagnose_e2e_test.go
@@ -28,9 +28,6 @@ var mariaDBOnlySQL = []string{
 	// application-time periods (omni #324-#328)
 	"CREATE TABLE t (s DATE, e DATE, PERIOD FOR app_time(s, e))",
 	"UPDATE t FOR PORTION OF app_time FROM '2020-01-01' TO '2021-01-01' SET id = 1",
-	// parenthesized row constructors (omni #330)
-	"SELECT * FROM t WHERE (a, b) IN ((1, 2), (3, 4))",
-	"SELECT * FROM t WHERE (a, b) > (1, 2)",
 }
 
 // TestMariaDBDiagnoseKeystone is the carve-out keystone. Before the re-point,

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260626034734-62d4f668f054
+	github.com/bytebase/omni v0.0.0-20260629024459-98426d3c550f
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260626034734-62d4f668f054 h1:ZjmNACtTuRrUFCqlOhKnPbe9LpwbP18kWfW20mkyDsM=
-github.com/bytebase/omni v0.0.0-20260626034734-62d4f668f054/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260629024459-98426d3c550f h1:VTh/r39h3I5BlmxuD+5gafwTEQH3U8Io2WMlTuNEO5U=
+github.com/bytebase/omni v0.0.0-20260629024459-98426d3c550f/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
## Summary

- Bump omni to `98426d3c` which adds parsing of parenthesized row constructors `(a, b)` in MySQL engine
- MySQL's `parseParenExpr()` now handles `(expr, expr, ...)` as `RowExpr`, matching MySQL 8.0 behavior
- Fixes false-positive syntax errors in Bytebase SQL editor for common patterns like `(a, b) = (1, 2)`, `(a, b) IN ((1, 2), (3, 4))`, keyset pagination `(a, b) > (?, ?)`

Closes BYT-9778

## Test plan

- [x] omni PR #354 merged with full test coverage
- [x] CI green on omni side

🤖 Generated with [Claude Code](https://claude.com/claude-code)