### PR TITLE
chore: align Connect Go generator

### DIFF
--- a/proto/buf.gen.yaml
+++ b/proto/buf.gen.yaml
@@ -15,7 +15,7 @@ plugins:
   - remote: buf.build/grpc/go
     out: ../backend/generated-go
     opt: paths=source_relative
-  - remote: buf.build/connectrpc/go:v1.19.1
+  - remote: buf.build/connectrpc/go:v1.19.2
     out: ../backend/generated-go
     opt:
       - paths=source_relative


### PR DESCRIPTION
## Summary
- Align `buf.build/connectrpc/go` from `v1.19.1` to `v1.19.2`.
- Match the proto generator pin with `connectrpc.com/connect v1.19.2` in `go.mod`.
- Regeneration produced no generated file changes.

## Test Plan
- [x] `buf format -w proto`
- [x] `buf lint proto`
- [x] `cd proto && buf generate`

## Pre-PR Checklist
- Breaking change check: not applicable; generator version pin only, no proto schema/API change.
- Composite-PK query safety: skipped; no `backend/store/` or `backend/migrator/` changes.
- Image compatibility window: skipped; no version compatibility logic changes.
- SonarCloud properties: skipped; no new files or directories.
