### PR TITLE
fix(frontend): prevent rollout session table column header overlap

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRunSession.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRunSession.tsx
@@ -128,23 +128,23 @@ function SessionTable({ rows }: { rows: TaskRunSession_Postgres_Session[] }) {
 
   return (
     <div className="overflow-auto rounded-sm border">
-      <Table className="table-fixed">
+      <Table className="[&_td]:whitespace-nowrap [&_th]:whitespace-nowrap">
         <TableHeader>
           <TableRow className="hover:bg-transparent">
-            <TableHead className="w-20">pid</TableHead>
-            <TableHead className="w-28">blocked_by_pids</TableHead>
-            <TableHead className="min-w-[256px]">query</TableHead>
-            <TableHead className="w-28">state</TableHead>
-            <TableHead className="w-28">wait_event_type</TableHead>
-            <TableHead className="w-28">wait_event</TableHead>
-            <TableHead className="w-28">datname</TableHead>
-            <TableHead className="w-28">usename</TableHead>
-            <TableHead className="w-36">application_name</TableHead>
-            <TableHead className="w-28">client_addr</TableHead>
-            <TableHead className="w-24">client_port</TableHead>
-            <TableHead className="w-40">backend_start</TableHead>
-            <TableHead className="w-40">xact_start</TableHead>
-            <TableHead className="w-40">query_start</TableHead>
+            <TableHead>pid</TableHead>
+            <TableHead>blocked_by_pids</TableHead>
+            <TableHead>query</TableHead>
+            <TableHead>state</TableHead>
+            <TableHead>wait_event_type</TableHead>
+            <TableHead>wait_event</TableHead>
+            <TableHead>datname</TableHead>
+            <TableHead>usename</TableHead>
+            <TableHead>application_name</TableHead>
+            <TableHead>client_addr</TableHead>
+            <TableHead>client_port</TableHead>
+            <TableHead>backend_start</TableHead>
+            <TableHead>xact_start</TableHead>
+            <TableHead>query_start</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -152,7 +152,9 @@ function SessionTable({ rows }: { rows: TaskRunSession_Postgres_Session[] }) {
             <TableRow key={`${row.pid}-${row.queryStart?.seconds ?? 0}`}>
               <TableCell>{row.pid}</TableCell>
               <TableCell>{row.blockedByPids.join(", ") || "-"}</TableCell>
-              <TableCell className="truncate">{row.query || "-"}</TableCell>
+              <TableCell>
+                <div className="max-w-[360px] truncate">{row.query || "-"}</div>
+              </TableCell>
               <TableCell>{row.state || "-"}</TableCell>
               <TableCell>{row.waitEventType || "-"}</TableCell>
               <TableCell>{row.waitEvent || "-"}</TableCell>


### PR DESCRIPTION
## What

Fixes column header overlap in the rollout task-run **Session** table (under Detail → Latest Logs → Session). Underscore-joined Postgres column headers like `blocked_by_pids` and `wait_event_type` collided with their neighbors.

## Why

The table used `table-fixed` with hardcoded per-column widths (`w-28`, etc.). Those cells were narrower than the header labels, and CSS `overflow-wrap` does **not** break on underscores — so each label was treated as one unbreakable word that spilled horizontally into the next column.

## How

- Drop `table-fixed` and all magic-number widths → `table-layout: auto` sizes each column to its content.
- Add `whitespace-nowrap` to headers/cells so the underscore tokens widen their own column instead of overflowing into the next one.
- Clamp the one unbounded column (`query`) with an inner `max-w-[360px] truncate` div so long SQL clips with an ellipsis rather than blowing out the row.

This needs no per-column width tuning and is agnostic to label length.

## Screenshot

<img width="680" height="340" alt="image" src="https://github.com/user-attachments/assets/b44825d1-7a70-43b6-b887-5d08e122511b" />

## Testing

- `pnpm --dir frontend type-check` — passed
- `pnpm --dir frontend fix` (ESLint + Biome) — clean
- Verified layout by rendering the table at drawer width (overlap gone, horizontal scroll works, `query` clips with ellipsis).

Closes BYT-9757

🤖 Generated with [Claude Code](https://claude.com/claude-code)