### PR TITLE
feat: expand plan and task sections by clicking anywhere on the row

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
+++ b/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
@@ -500,14 +500,14 @@ function PhaseSection({
           </div>
         ) : (
           <div className="flex flex-col">
-            <div
-              className="flex items-center gap-2 py-0.5 cursor-pointer"
-              onClick={onToggle}
-            >
+            <div className="flex items-center gap-2 py-0.5">
               <span className="textlabel uppercase text-accent">{label}</span>
               {badge && <Badge variant={badge.variant}>{badge.label}</Badge>}
               <div className="flex-1" />
-              <span className="shrink-0 text-[11px] text-control-placeholder">
+              <span
+                className="shrink-0 cursor-pointer text-[11px] text-control-placeholder hover:text-control"
+                onClick={onToggle}
+              >
                 {t("plan.phase.hide-details")}
               </span>
             </div>

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
@@ -138,14 +138,17 @@ export function DeployTaskItem({
   ].filter((item) => item.visible);
   const showHeaderActions =
     isExpanded && (actionItems.length > 0 || Boolean(rollbackableTaskRun));
+  const isClickableCollapsed = !readonly && !isExpanded;
 
   return (
     <>
       <div
         className={cn(
           "group relative rounded-lg border bg-white transition-all",
-          active && "border-accent bg-accent/5"
+          active && "border-accent bg-accent/5",
+          isClickableCollapsed && "cursor-pointer hover:bg-control-bg"
         )}
+        onClick={isClickableCollapsed ? onToggleExpand : undefined}
       >
         <div
           className={
@@ -241,7 +244,10 @@ export function DeployTaskItem({
             {!readonly && (
               <Button
                 className={isExpanded ? "self-start" : undefined}
-                onClick={onToggleExpand}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onToggleExpand();
+                }}
                 size="xs"
                 variant="ghost"
               >
@@ -270,12 +276,11 @@ export function DeployTaskItem({
               )}
               <span
                 className={cn(
-                  "cursor-pointer truncate",
+                  "truncate",
                   task.status === Task_Status.FAILED
                     ? "text-error"
                     : "italic text-gray-500"
                 )}
-                onClick={onToggleExpand}
               >
                 {collapsedStatusText}
               </span>


### PR DESCRIPTION
## What

Enlarges the click target for expanding the plan-detail **phase sections** (Changes / Review / Deploy) and the **deploy task cards**.

- **Bigger target to expand** — clicking anywhere on a *collapsed* phase section or task card now expands it (previously only a small chevron/area was clickable). The whole row is the hit target, with a hover affordance.
- **No accidental closes** — once expanded, the section/card body is no longer clickable. Collapsing stays on the explicit control only: the **"Hide details"** action (phase section) or the **chevron** (task card).
- Interactive children (checkbox, Run/Skip/Retry actions) `stopPropagation` so they never toggle the section.

Closes BYT-9164.

## Changes

- `ProjectPlanDetailPage.tsx` — in `PhaseSection`, the expanded header row drops its `onClick`/`cursor-pointer`; the "Hide details" span becomes the collapse trigger (with `hover:text-control`).
- `DeployTaskItem.tsx` — collapsed card div is click-to-expand (gated on `!readonly && !isExpanded`, extracted as `isClickableCollapsed`); the chevron `stopPropagation`s and remains the sole collapse control when expanded; removed the now-redundant click handler on the collapsed status text.

## Testing

- `pnpm --dir frontend type-check` ✅
- `pnpm --dir frontend fix` (no changes) ✅
- Behavior validated against an interactive mock of the cards: click a collapsed row → expands; click an expanded body → stays open; chevron → collapses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)