### PR TITLE
refactor(frontend): unify rollout status icons across plan surfaces

### DIFF
--- a/frontend/src/react/components/TaskStatusIcon.tsx
+++ b/frontend/src/react/components/TaskStatusIcon.tsx
@@ -5,22 +5,27 @@ import { cn } from "@/react/lib/utils";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { stringifyTaskStatus } from "@/utils";
 
-export function DeployTaskStatus({
+/**
+ * Canonical status icon for a rollout task/stage. Drive the size with the
+ * `size` prop. Use this everywhere a `Task_Status` is shown so the plan table,
+ * plan detail task rows, and stage tabs stay visually consistent.
+ */
+const SIZE_CLASSES = {
+  tiny: "h-4 w-4",
+  small: "h-5 w-5",
+  medium: "h-6 w-6",
+  large: "h-7 w-7",
+} as const;
+
+export function TaskStatusIcon({
   status,
   size = "small",
 }: {
   status: Task_Status;
-  size?: "tiny" | "small" | "medium" | "large";
+  size?: keyof typeof SIZE_CLASSES;
 }) {
   const { t } = useTranslation();
-  const classes =
-    size === "tiny"
-      ? "h-4 w-4"
-      : size === "small"
-        ? "h-5 w-5"
-        : size === "large"
-          ? "h-7 w-7"
-          : "h-6 w-6";
+  const classes = SIZE_CLASSES[size];
 
   const statusLabel = stringifyTaskStatus(status, t);
 

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -23,6 +23,7 @@ import {
   PermissionGuard,
   usePermissionCheck,
 } from "@/react/components/PermissionGuard";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { Alert } from "@/react/components/ui/alert";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
@@ -75,16 +76,11 @@ import {
   type Database,
   SyncStatus,
 } from "@/types/proto-es/v1/database_service_pb";
-import type {
-  Plan,
-  Plan_RolloutStageSummary,
-  Plan_Spec,
-} from "@/types/proto-es/v1/plan_service_pb";
+import type { Plan, Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import {
   Plan_ChangeDatabaseConfigSchema,
   Plan_SpecSchema,
 } from "@/types/proto-es/v1/plan_service_pb";
-import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import {
   extractDatabaseGroupName,
   extractDatabaseResourceName,
@@ -95,19 +91,11 @@ import {
   getInstanceResource,
   type SearchParams as VueSearchParams,
 } from "@/utils";
-import { extractStageUID } from "@/utils/v1/issue/rollout";
+import {
+  extractStageUID,
+  getStageStatusFromCounts,
+} from "@/utils/v1/issue/rollout";
 import { getReviewBadge, type ReviewBadge } from "./utils/reviewBadge";
-
-// Task status priority order for determining rollout stage status
-const TASK_STATUS_FILTERS: Task_Status[] = [
-  Task_Status.RUNNING,
-  Task_Status.FAILED,
-  Task_Status.PENDING,
-  Task_Status.NOT_STARTED,
-  Task_Status.CANCELED,
-  Task_Status.DONE,
-  Task_Status.SKIPPED,
-];
 
 export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
   const { t } = useTranslation();
@@ -391,15 +379,6 @@ interface PlanRowContext {
   showDraftTag: boolean;
 }
 
-function getRolloutStageStatus(summary: Plan_RolloutStageSummary): Task_Status {
-  for (const status of TASK_STATUS_FILTERS) {
-    if (summary.taskStatusCounts.some((item) => item.status === status)) {
-      return status;
-    }
-  }
-  return Task_Status.STATUS_UNSPECIFIED;
-}
-
 function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
   const { t } = useTranslation();
   // Subscribe so stage cells re-render when the environment cache loads.
@@ -482,11 +461,13 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
                 const environment = useAppStore
                   .getState()
                   .getEnvironmentByName(envName);
-                const stageStatus = getRolloutStageStatus(summary);
+                const stageStatus = getStageStatusFromCounts(
+                  summary.taskStatusCounts
+                );
                 return (
                   <div key={summary.stage} className="flex items-center gap-1">
                     <div className="flex items-center gap-1">
-                      <TaskStatusIcon status={stageStatus} />
+                      <TaskStatusIcon size="tiny" status={stageStatus} />
                       <span className="text-sm">
                         {environment?.title || envName}
                       </span>
@@ -646,54 +627,6 @@ function PlanRow({
       ))}
     </TableRow>
   );
-}
-
-// ---------------------------------------------------------------------------
-// TaskStatusIcon
-// ---------------------------------------------------------------------------
-
-function TaskStatusIcon({ status }: { status: Task_Status }) {
-  const size = "size-4";
-  switch (status) {
-    case Task_Status.DONE:
-      return <CheckCircle className={cn(size, "text-success")} />;
-    case Task_Status.RUNNING:
-      return <Loader2 className={cn(size, "text-info animate-spin")} />;
-    case Task_Status.FAILED:
-      return <XCircle className={cn(size, "text-error")} />;
-    case Task_Status.CANCELED:
-      return <XCircle className={cn(size, "text-control-placeholder")} />;
-    case Task_Status.PENDING:
-    case Task_Status.NOT_STARTED:
-      return (
-        <span
-          className={cn(
-            size,
-            "inline-flex items-center justify-center rounded-full border-2 border-control-border"
-          )}
-        />
-      );
-    case Task_Status.SKIPPED:
-      return (
-        <span
-          className={cn(
-            size,
-            "inline-flex items-center justify-center rounded-full bg-control-bg-hover text-control-light"
-          )}
-        >
-          <span className="w-2 h-px bg-current" />
-        </span>
-      );
-    default:
-      return (
-        <span
-          className={cn(
-            size,
-            "inline-flex items-center justify-center rounded-full border-2 border-block-border"
-          )}
-        />
-      );
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
@@ -1,11 +1,9 @@
-import { Check, FastForward, Minus, Pause, X } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { RouterLink } from "@/react/components/RouterLink";
-import { Tooltip } from "@/react/components/ui/tooltip";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
-import { cn } from "@/react/lib/utils";
 import { router } from "@/react/router";
 import { INSTANCE_ROUTE_DETAIL } from "@/react/router/handles";
 import { useAppStore } from "@/react/stores/app";
@@ -177,7 +175,7 @@ export function IssueDetailDatabaseCreateView() {
               <span className="text-sm font-medium text-gray-600">
                 {t("common.status")}:
               </span>
-              <IssueDetailTaskStatus status={createDatabaseTask.status} />
+              <TaskStatusIcon status={createDatabaseTask.status} size="small" />
             </div>
           )}
         </div>
@@ -256,121 +254,4 @@ function IssueDetailDatabaseCreateInstance({
       <span className="truncate">{children}</span>
     </RouterLink>
   );
-}
-
-function IssueDetailTaskStatus({ status }: { status: Task_Status }) {
-  const { t } = useTranslation();
-  const classes = (() => {
-    const sizeClass = "h-5 w-5";
-    let statusClass = "";
-    switch (status) {
-      case Task_Status.NOT_STARTED:
-        statusClass = "bg-white border-2 border-control";
-        break;
-      case Task_Status.PENDING:
-        statusClass = "bg-white border-2 border-info text-info";
-        break;
-      case Task_Status.RUNNING:
-        statusClass = "bg-white border-2 border-info text-info";
-        break;
-      case Task_Status.SKIPPED:
-        statusClass = "bg-white border-2 border-control-light text-gray-600";
-        break;
-      case Task_Status.DONE:
-        statusClass = "bg-success text-white";
-        break;
-      case Task_Status.FAILED:
-        statusClass = "bg-error text-white";
-        break;
-      default:
-        statusClass = "";
-        break;
-    }
-    return `${sizeClass} ${statusClass}`;
-  })();
-
-  return (
-    <Tooltip content={taskStatusLabel(t, status)}>
-      <div
-        aria-label={taskStatusLabel(t, status)}
-        className={cn(
-          "relative flex shrink-0 select-none items-center justify-center overflow-hidden rounded-full",
-          classes
-        )}
-      >
-        {status === Task_Status.STATUS_UNSPECIFIED && (
-          <span className="h-full w-full rounded-full border border-dashed border-control" />
-        )}
-        {status === Task_Status.NOT_STARTED && (
-          <span
-            aria-hidden="true"
-            className="h-1/2 w-1/2 rounded-full bg-control"
-          />
-        )}
-        {status === Task_Status.PENDING && <Pause className="h-3/4 w-3/4" />}
-        {status === Task_Status.RUNNING && (
-          <div className="relative flex h-1/2 w-1/2 overflow-visible">
-            <span
-              aria-hidden="true"
-              className="absolute z-0 h-full w-full animate-ping-slow rounded-full"
-              style={{ backgroundColor: "rgba(37, 99, 235, 0.5)" }}
-            />
-            <span
-              aria-hidden="true"
-              className="z-1 h-full w-full rounded-full bg-info"
-            />
-          </div>
-        )}
-        {status === Task_Status.SKIPPED && (
-          <FastForward className="h-3/4 w-3/4" />
-        )}
-        {status === Task_Status.DONE && <Check className="h-3/4 w-3/4" />}
-        {status === Task_Status.FAILED && (
-          <span
-            aria-hidden="true"
-            className="rounded-full text-center text-base font-medium"
-          >
-            !
-          </span>
-        )}
-        {status === Task_Status.CANCELED && (
-          <Minus className="h-full w-full rounded-full border-2 border-control-light bg-white text-control-light" />
-        )}
-        {status !== Task_Status.CANCELED &&
-          status !== Task_Status.FAILED &&
-          status !== Task_Status.DONE &&
-          status !== Task_Status.SKIPPED &&
-          status !== Task_Status.RUNNING &&
-          status !== Task_Status.PENDING &&
-          status !== Task_Status.NOT_STARTED &&
-          status !== Task_Status.STATUS_UNSPECIFIED && (
-            <X className="h-3/4 w-3/4" />
-          )}
-      </div>
-    </Tooltip>
-  );
-}
-
-function taskStatusLabel(
-  t: ReturnType<typeof useTranslation>["t"],
-  status: Task_Status
-) {
-  switch (status) {
-    case Task_Status.NOT_STARTED:
-      return t("task.status.not-started");
-    case Task_Status.PENDING:
-      return t("task.status.pending");
-    case Task_Status.RUNNING:
-      return t("task.status.running");
-    case Task_Status.DONE:
-      return t("task.status.done");
-    case Task_Status.FAILED:
-      return t("task.status.failed");
-    case Task_Status.CANCELED:
-      return t("task.status.canceled");
-    case Task_Status.SKIPPED:
-      return t("task.status.skipped");
-    default:
-      return String(status);
-  }
 }

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
@@ -1,19 +1,15 @@
 import { clone, create } from "@bufbuild/protobuf";
 import {
-  Check,
   ChevronRight,
   EllipsisVertical,
   ExternalLink,
-  FastForward,
   FolderTree,
-  Minus,
-  Pause,
-  X,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { planServiceClientConnect } from "@/connect";
 import { EngineIcon } from "@/react/components/EngineIcon";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { Button } from "@/react/components/ui/button";
 import {
   DropdownMenu,
@@ -414,7 +410,7 @@ function IssueDetailDatabaseExportTasks({
             key={task.name}
             className="inline-flex min-w-0 items-center gap-2 rounded-sm border px-2 py-1.5"
           >
-            <IssueDetailTaskStatus status={task.status} tiny />
+            <TaskStatusIcon status={task.status} size="tiny" />
             <IssueDetailDatabaseExportDatabaseTarget target={task.target} />
             <IssueDetailDatabaseExportTaskActions task={task} />
           </div>
@@ -797,127 +793,4 @@ function IssueDetailDatabaseExportLimits() {
       </div>
     </div>
   );
-}
-
-function IssueDetailTaskStatus({
-  status,
-  tiny = false,
-}: {
-  status: Task_Status;
-  tiny?: boolean;
-}) {
-  const { t } = useTranslation();
-  const classes = (() => {
-    const sizeClass = tiny ? "h-4 w-4" : "h-5 w-5";
-    let statusClass = "";
-    switch (status) {
-      case Task_Status.NOT_STARTED:
-        statusClass = "bg-white border-2 border-control";
-        break;
-      case Task_Status.PENDING:
-        statusClass = "bg-white border-2 border-info text-info";
-        break;
-      case Task_Status.RUNNING:
-        statusClass = "bg-white border-2 border-info text-info";
-        break;
-      case Task_Status.SKIPPED:
-        statusClass = "bg-white border-2 border-control-light text-gray-600";
-        break;
-      case Task_Status.DONE:
-        statusClass = "bg-success text-white";
-        break;
-      case Task_Status.FAILED:
-        statusClass = "bg-error text-white";
-        break;
-      default:
-        statusClass = "";
-        break;
-    }
-    return `${sizeClass} ${statusClass}`;
-  })();
-
-  return (
-    <Tooltip content={taskStatusLabel(t, status)}>
-      <div
-        aria-label={taskStatusLabel(t, status)}
-        className={cn(
-          "relative flex shrink-0 select-none items-center justify-center overflow-hidden rounded-full",
-          classes
-        )}
-      >
-        {status === Task_Status.STATUS_UNSPECIFIED && (
-          <span className="h-full w-full rounded-full border border-dashed border-control" />
-        )}
-        {status === Task_Status.NOT_STARTED && (
-          <span
-            aria-hidden="true"
-            className="h-1/2 w-1/2 rounded-full bg-control"
-          />
-        )}
-        {status === Task_Status.PENDING && <Pause className="h-3/4 w-3/4" />}
-        {status === Task_Status.RUNNING && (
-          <div className="relative flex h-1/2 w-1/2 overflow-visible">
-            <span
-              aria-hidden="true"
-              className="absolute z-0 h-full w-full animate-ping-slow rounded-full"
-              style={{ backgroundColor: "rgba(37, 99, 235, 0.5)" }}
-            />
-            <span
-              aria-hidden="true"
-              className="z-1 h-full w-full rounded-full bg-info"
-            />
-          </div>
-        )}
-        {status === Task_Status.SKIPPED && (
-          <FastForward className="h-3/4 w-3/4" />
-        )}
-        {status === Task_Status.DONE && <Check className="h-3/4 w-3/4" />}
-        {status === Task_Status.FAILED && (
-          <span
-            aria-hidden="true"
-            className="rounded-full text-center text-base font-medium"
-          >
-            !
-          </span>
-        )}
-        {status === Task_Status.CANCELED && (
-          <Minus className="h-full w-full rounded-full border-2 border-control-light bg-white text-control-light" />
-        )}
-        {status !== Task_Status.CANCELED &&
-          status !== Task_Status.FAILED &&
-          status !== Task_Status.DONE &&
-          status !== Task_Status.SKIPPED &&
-          status !== Task_Status.RUNNING &&
-          status !== Task_Status.PENDING &&
-          status !== Task_Status.NOT_STARTED &&
-          status !== Task_Status.STATUS_UNSPECIFIED && (
-            <X className="h-3/4 w-3/4" />
-          )}
-      </div>
-    </Tooltip>
-  );
-}
-
-function taskStatusLabel(
-  t: ReturnType<typeof useTranslation>["t"],
-  status: Task_Status
-) {
-  switch (status) {
-    case Task_Status.NOT_STARTED:
-      return t("task.status.not-started");
-    case Task_Status.PENDING:
-      return t("task.status.pending");
-    case Task_Status.RUNNING:
-      return t("task.status.running");
-    case Task_Status.DONE:
-      return t("task.status.done");
-    case Task_Status.FAILED:
-      return t("task.status.failed");
-    case Task_Status.CANCELED:
-      return t("task.status.canceled");
-    case Task_Status.SKIPPED:
-      return t("task.status.skipped");
-    default:
-      return t("common.unknown");
-  }
 }

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployStageCard.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployStageCard.tsx
@@ -1,8 +1,8 @@
 import { ArrowRight, Eye } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { Button } from "@/react/components/ui/button";
-import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import type { Rollout, Stage } from "@/types/proto-es/v1/rollout_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
@@ -20,19 +20,10 @@ function StageProgressCard({ stage }: { stage: Stage }) {
       task.status === Task_Status.DONE || task.status === Task_Status.SKIPPED
   ).length;
   const stageStatus = getStageStatus(stage);
-  const dotClass =
-    stageStatus === Task_Status.DONE || stageStatus === Task_Status.SKIPPED
-      ? "bg-success"
-      : stageStatus === Task_Status.FAILED
-        ? "bg-error"
-        : stageStatus === Task_Status.RUNNING ||
-            stageStatus === Task_Status.PENDING
-          ? "bg-accent"
-          : "bg-control-placeholder";
 
   return (
     <div className="flex items-center gap-2">
-      <span className={cn("h-2 w-2 rounded-full", dotClass)} />
+      <TaskStatusIcon size="tiny" status={stageStatus} />
       <span className="text-sm font-medium text-main">{env.title}</span>
       <span className="text-xs text-control-light">
         ({completed}/{stage.tasks.length})

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskDetailPanel.tsx
@@ -2,6 +2,7 @@ import { CalendarClock, EllipsisVertical, Undo2 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ReadonlyMonaco } from "@/react/components/monaco";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { Button } from "@/react/components/ui/button";
 import {
   DropdownMenu,
@@ -33,7 +34,6 @@ import { PlanDetailTaskRunTable } from "../PlanDetailTaskRunTable";
 import { PlanTargetDisplay } from "../PlanTargetDisplay";
 import { DeployReleaseInfoCard } from "./DeployReleaseInfoCard";
 import { DeployTaskSkippedReason } from "./DeployTaskSkippedReason";
-import { DeployTaskStatus } from "./DeployTaskStatus";
 import { useDeployTaskActions } from "./taskActions";
 import { useDeployTaskStatement } from "./useDeployTaskStatement";
 
@@ -114,7 +114,7 @@ export function DeployTaskDetailPanel({ task }: { task: Task }) {
       <div className="flex flex-col gap-y-3">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-row flex-wrap items-center gap-x-3 gap-y-2">
-            <DeployTaskStatus size="large" status={task.status} />
+            <TaskStatusIcon size="large" status={task.status} />
             {stageTitle && (
               <span className="rounded-full bg-control-bg px-2 py-0.5 text-xs text-control">
                 {stageTitle}

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskFilter.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskFilter.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from "react-i18next";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import type { Stage } from "@/types/proto-es/v1/rollout_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { stringifyTaskStatus } from "@/utils";
-import { DeployTaskStatus } from "./DeployTaskStatus";
 
 const TASK_STATUS_FILTERS = [
   Task_Status.NOT_STARTED,
@@ -51,7 +51,7 @@ export function DeployTaskFilter({
             }}
             type="button"
           >
-            <DeployTaskStatus size="small" status={status} />
+            <TaskStatusIcon size="small" status={status} />
             <span className="select-none text-sm">
               {stringifyTaskStatus(status, t)}
             </span>

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
@@ -12,6 +12,7 @@ import { useTranslation } from "react-i18next";
 import { HumanizeTs } from "@/react/components/HumanizeTs";
 import { ReadonlyMonaco } from "@/react/components/monaco";
 import { RouterLink } from "@/react/components/RouterLink";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { cn } from "@/react/lib/utils";
@@ -36,7 +37,6 @@ import { PlanTargetDisplay } from "../PlanTargetDisplay";
 import { DeployLatestTaskRunInfo } from "./DeployLatestTaskRunInfo";
 import { DeployReleaseInfoCard } from "./DeployReleaseInfoCard";
 import { DeployTaskSkippedReason } from "./DeployTaskSkippedReason";
-import { DeployTaskStatus } from "./DeployTaskStatus";
 import { useDeployTaskActions } from "./taskActions";
 import { getTaskRunDuration } from "./taskRunUtils";
 import { useDeployTaskStatement } from "./useDeployTaskStatement";
@@ -161,7 +161,7 @@ export function DeployTaskItem({
                 onCheckedChange={() => onToggleSelect()}
                 onClick={(event) => event.stopPropagation()}
               />
-              <DeployTaskStatus
+              <TaskStatusIcon
                 size={isExpanded ? "large" : "small"}
                 status={task.status}
               />

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskRow.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskRow.tsx
@@ -1,11 +1,11 @@
 import { X } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { Button } from "@/react/components/ui/button";
 import { cn } from "@/react/lib/utils";
 import { router } from "@/react/router";
 import { type Task } from "@/types/proto-es/v1/rollout_service_pb";
 import { stringifyTaskStatus } from "@/utils";
-import { DeployTaskStatus } from "./DeployTaskStatus";
 
 export function DeployTaskRow({
   active,
@@ -41,7 +41,7 @@ export function DeployTaskRow({
       type="button"
     >
       <div className="flex min-w-0 items-center gap-2">
-        <DeployTaskStatus size="small" status={task.status} />
+        <TaskStatusIcon size="small" status={task.status} />
         <div className="min-w-0">
           <div className="truncate text-main">{task.name}</div>
           <div className="text-xs text-control-light">

--- a/frontend/src/utils/v1/issue/rollout.ts
+++ b/frontend/src/utils/v1/issue/rollout.ts
@@ -1,7 +1,10 @@
 import i18n from "@/react/i18n";
 import { getDatabaseByName } from "@/react/stores/app/databaseAccess";
 import { isValidDatabaseName, UNKNOWN_ID, unknownDatabase } from "@/types";
-import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
+import type {
+  Plan,
+  Plan_TaskStatusCount,
+} from "@/types/proto-es/v1/plan_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import {
   type Rollout,
@@ -148,31 +151,44 @@ export const stringifyTaskStatus = (
   }
 };
 
-export const getStageStatus = (stage: Stage): Task_Status => {
-  const tasks = stage.tasks;
-  if (tasks.length === 0) return Task_Status.NOT_STARTED;
-
-  // Priority order follows TASK_STATUS_FILTERS
+// Return the highest-priority Task_Status (per TASK_STATUS_FILTERS) for which
+// `has` reports a member, or `fallback` when none match. Shared by the stage
+// and rollout status reducers below.
+const foldByStatusPriority = (
+  has: (status: Task_Status) => boolean,
+  fallback: Task_Status
+): Task_Status => {
   for (const status of TASK_STATUS_FILTERS) {
-    if (tasks.some((task) => task.status === status)) {
-      return status;
-    }
+    if (has(status)) return status;
   }
-
-  return Task_Status.NOT_STARTED;
+  return fallback;
 };
 
+export const getStageStatus = (stage: Stage): Task_Status => {
+  if (stage.tasks.length === 0) return Task_Status.NOT_STARTED;
+  return foldByStatusPriority(
+    (status) => stage.tasks.some((task) => task.status === status),
+    Task_Status.NOT_STARTED
+  );
+};
+
+// Derive a stage status from aggregated task status counts (used by the plan
+// table, which only has counts rather than the full task list).
+export const getStageStatusFromCounts = (
+  counts: Plan_TaskStatusCount[]
+): Task_Status =>
+  foldByStatusPriority(
+    (status) => counts.some((item) => item.status === status),
+    Task_Status.STATUS_UNSPECIFIED
+  );
+
 export const getRolloutStatus = (rollout: Rollout): Task_Status => {
-  const stages = rollout.stages;
-  if (stages.length === 0) return Task_Status.NOT_STARTED;
-
-  for (const status of TASK_STATUS_FILTERS) {
-    if (stages.some((stage) => getStageStatus(stage) === status)) {
-      return status;
-    }
-  }
-
-  return Task_Status.NOT_STARTED;
+  if (rollout.stages.length === 0) return Task_Status.NOT_STARTED;
+  return foldByStatusPriority(
+    (status) =>
+      rollout.stages.some((stage) => getStageStatus(stage) === status),
+    Task_Status.NOT_STARTED
+  );
 };
 
 export const databaseForTask = (project: Project, task: Task, plan?: Plan) => {


### PR DESCRIPTION
## What

Closes BYT-9759. Unifies the rollout/task **status icon** across every plan surface so the same `Task_Status` always looks the same.

Before, the same status was drawn three different ways (most visibly *skipped*: a dash-circle in the plan list, a `FastForward` glyph in plan detail, and a bare colored dot on the stage tab), and the plan list re-implemented the status-derivation fold with its own copy of `TASK_STATUS_FILTERS`.

### Changes
- **New shared `frontend/src/react/components/TaskStatusIcon.tsx`** — promoted from the plan-detail `DeployTaskStatus` (the most complete renderer: all 8 states, tooltip, `tiny|small|medium|large` sizes via a `SIZE_CLASSES` map).
- **Plan list** (`ProjectPlanDashboardPage`) — dropped its local icon, local `TASK_STATUS_FILTERS`, and `getRolloutStageStatus`; now uses the shared icon + shared `getStageStatusFromCounts`.
- **Plan detail deploy** — stage tabs (`DeployStageCard`) now use the shared icon instead of a colored dot; task rows/detail/filter (`DeployTaskItem`, `DeployTaskRow`, `DeployTaskDetailPanel`, `DeployTaskFilter`) import the shared component; old `DeployTaskStatus.tsx` deleted.
- **Issue detail** — `IssueDetailDatabaseCreateView` and `IssueDetailDatabaseExportView` drop their inline `IssueDetailTaskStatus` + duplicated `taskStatusLabel` and use the shared icon. *(Intentional minor visual change: these views now use the shared glyphs `✓`/`!`/`−`/`≫` instead of lucide `Check`/`Minus`/`X`.)*
- **`utils/v1/issue/rollout.ts`** — extracted a shared `foldByStatusPriority` helper so `getStageStatus`, `getStageStatusFromCounts`, and `getRolloutStatus` share one priority-fold (fallbacks preserved).

<img width="1922" height="2000" alt="bundle-screenshot" src="https://github.com/user-attachments/assets/b098a5c7-c7ad-4195-a85b-1d24a1a319f9" />

## Testing
- `pnpm --dir frontend fix` / `type-check` / `check` (biome + i18n + layering) — clean
- `pnpm --dir frontend test` — 2496 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)