### PR TITLE
fix(frontend): responsive plan detail and list on mobile (BYT-9793)

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -369,6 +369,7 @@
     "ok": "OK",
     "only-creator-allowed-export": "Only the creator is allowed to export",
     "open": "Open",
+    "open-mobile-sidebar": "Open mobile sidebar",
     "operation": "Operation",
     "operations": "Operations",
     "optional": "Optional",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -369,6 +369,7 @@
     "ok": "OK",
     "only-creator-allowed-export": "Solo el creador puede exportar",
     "open": "Abrir",
+    "open-mobile-sidebar": "Abrir barra lateral móvil",
     "operation": "Operación",
     "operations": "Operaciones",
     "optional": "Opcional",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -369,6 +369,7 @@
     "ok": "わかりました",
     "only-creator-allowed-export": "エクスポートできるのは作成者のみです",
     "open": "開く",
+    "open-mobile-sidebar": "モバイルサイドバーを開く",
     "operation": "操作",
     "operations": "操作",
     "optional": "任意",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -369,6 +369,7 @@
     "ok": "OK",
     "only-creator-allowed-export": "Chỉ người tạo mới được phép xuất",
     "open": "Mở",
+    "open-mobile-sidebar": "Mở thanh bên di động",
     "operation": "Thao tác",
     "operations": "Các thao tác",
     "optional": "Tùy chọn",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -369,6 +369,7 @@
     "ok": "确定",
     "only-creator-allowed-export": "只有创建者可以导出",
     "open": "打开",
+    "open-mobile-sidebar": "打开移动端侧边栏",
     "operation": "操作",
     "operations": "操作",
     "optional": "可选",

--- a/frontend/src/react/components/header/DashboardHeader.tsx
+++ b/frontend/src/react/components/header/DashboardHeader.tsx
@@ -111,6 +111,8 @@ export function DashboardHeader({
       {showMobileSidebarToggle ? (
         <button
           type="button"
+          aria-label={t("common.open-mobile-sidebar")}
+          title={t("common.open-mobile-sidebar")}
           className="p-1 text-gray-500 hover:text-gray-900 md:hidden"
           onClick={onOpenMobileSidebar}
         >
@@ -129,6 +131,8 @@ export function DashboardHeader({
         <Button
           size="sm"
           variant="outline"
+          aria-label={t("agent.self")}
+          title={t("agent.self")}
           onClick={() => {
             void import("@/react/plugins/agent/store/agent").then(
               ({ useAgentStore }) => {
@@ -145,6 +149,8 @@ export function DashboardHeader({
           <Button
             size="sm"
             variant="outline"
+            aria-label={t("common.want-help")}
+            title={t("common.want-help")}
             className="border-success text-success hover:bg-success/10"
             onClick={() => {
               window.open(
@@ -161,6 +167,8 @@ export function DashboardHeader({
         <Button
           size="sm"
           variant="outline"
+          aria-label={t("sql-editor.self")}
+          title={t("sql-editor.self")}
           onClick={() => {
             window.open(sqlEditorHref, "_blank", "noopener,noreferrer");
           }}
@@ -174,6 +182,8 @@ export function DashboardHeader({
         <Button
           size="sm"
           variant="outline"
+          aria-label={t("issue.my-issues")}
+          title={t("issue.my-issues")}
           onClick={() => {
             record(myIssueHref);
             localStorage.setItem(STORAGE_KEY_MY_ISSUES_TAB, uuidv4());

--- a/frontend/src/react/components/ui/sheet.tsx
+++ b/frontend/src/react/components/ui/sheet.tsx
@@ -72,7 +72,11 @@ const sheetContentVariants = cva(
         // a ~5vw strip on the left as a visual anchor; clicking the strip
         // closes the sheet like any other scrim click.
         huge: "w-[95vw]",
-        workspace: "w-[calc(100vw-8rem)] lg:w-240 max-w-[calc(100vw-8rem)]",
+        // Phones get a near-full-width sheet (a thin scrim strip stays
+        // tappable to close); tablets keep the original ~8rem gap, large
+        // screens cap at a fixed width.
+        workspace:
+          "w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] sm:w-[calc(100vw-8rem)] sm:max-w-[calc(100vw-8rem)] lg:w-240",
       },
     },
     defaultVariants: {

--- a/frontend/src/react/hooks/useMediaQuery.test.tsx
+++ b/frontend/src/react/hooks/useMediaQuery.test.tsx
@@ -1,0 +1,108 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { useMediaQuery } from "./useMediaQuery";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type MediaListener = () => void;
+
+// Controllable `matchMedia` mock: each query keeps a live `matches` flag and a
+// set of change listeners that the returned setter can flip to emulate a
+// viewport crossing the breakpoint.
+function installMatchMedia(initialMatches: (query: string) => boolean) {
+  const registry = new Map<
+    string,
+    { matches: boolean; listeners: Set<MediaListener> }
+  >();
+  const entryFor = (query: string) => {
+    let entry = registry.get(query);
+    if (!entry) {
+      entry = { matches: initialMatches(query), listeners: new Set() };
+      registry.set(query, entry);
+    }
+    return entry;
+  };
+  window.matchMedia = ((query: string) => {
+    const entry = entryFor(query);
+    return {
+      get matches() {
+        return entry.matches;
+      },
+      media: query,
+      onchange: null,
+      addEventListener: (_: string, cb: MediaListener) =>
+        entry.listeners.add(cb),
+      removeEventListener: (_: string, cb: MediaListener) =>
+        entry.listeners.delete(cb),
+      addListener: (cb: MediaListener) => entry.listeners.add(cb),
+      removeListener: (cb: MediaListener) => entry.listeners.delete(cb),
+      dispatchEvent: () => true,
+    } as unknown as MediaQueryList;
+  }) as unknown as typeof window.matchMedia;
+  return (query: string, matches: boolean) => {
+    const entry = entryFor(query);
+    entry.matches = matches;
+    entry.listeners.forEach((cb) => cb());
+  };
+}
+
+describe("useMediaQuery", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const realMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    window.matchMedia = realMatchMedia;
+  });
+
+  test("reflects the initial match state of the query", () => {
+    let value: boolean | undefined;
+    installMatchMedia(() => true);
+    function Probe() {
+      value = useMediaQuery("(min-width: 1024px)");
+      return null;
+    }
+    act(() => root.render(<Probe />));
+    expect(value).toBe(true);
+  });
+
+  test("passes the query through to matchMedia", () => {
+    let seenQuery = "";
+    installMatchMedia((query) => {
+      seenQuery = query;
+      return false;
+    });
+    function Probe() {
+      useMediaQuery("(max-width: 639px)");
+      return null;
+    }
+    act(() => root.render(<Probe />));
+    expect(seenQuery).toBe("(max-width: 639px)");
+  });
+
+  test("re-renders when the query flips", () => {
+    let value: boolean | undefined;
+    const query = "(max-width: 639px)";
+    const setMatches = installMatchMedia(() => false);
+    function Probe() {
+      value = useMediaQuery(query);
+      return null;
+    }
+    act(() => root.render(<Probe />));
+    expect(value).toBe(false);
+
+    act(() => setMatches(query, true));
+    expect(value).toBe(true);
+  });
+});

--- a/frontend/src/react/hooks/useMediaQuery.ts
+++ b/frontend/src/react/hooks/useMediaQuery.ts
@@ -1,0 +1,33 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+/**
+ * Subscribes to a CSS media query and returns whether it currently matches.
+ *
+ * Backed by `matchMedia`, so it re-renders only when the match state flips —
+ * not on every resize event. SSR-safe: returns `false` when `window` is
+ * unavailable.
+ *
+ * @param query - A media query string, e.g. `"(max-width: 639px)"`.
+ *
+ * @example
+ * const isWide = useMediaQuery("(min-width: 1024px)");
+ */
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (typeof window === "undefined") return () => {};
+      const mql = window.matchMedia(query);
+      mql.addEventListener("change", onStoreChange);
+      return () => mql.removeEventListener("change", onStoreChange);
+    },
+    [query]
+  );
+
+  const getSnapshot = useCallback(
+    () => typeof window !== "undefined" && window.matchMedia(query).matches,
+    [query]
+  );
+
+  // Server snapshot: assume the query does not match (desktop-first default).
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.columns.test.ts
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.columns.test.ts
@@ -41,11 +41,13 @@ describe("plan list column composition", () => {
 
   test("name carries the tuned default width for plan titles", () => {
     // P0 column for the navigation surface: holds UID + title + optional
-    // lifecycle badge. 400px gives ~45 effective chars for the title with a
-    // badge present, covering typical long plan titles before truncation.
+    // lifecycle badge. 400px (desktop) gives ~45 effective chars for the title
+    // with a badge present. Phones use a fixed 200px and disable resizing so the
+    // title column doesn't push the table wider than the viewport.
     const entry = columnEntry(source, "name");
-    expect(entry.match(/defaultWidth:\s*(\d+)/)?.[1]).toBe("400");
+    expect(entry).toMatch(/defaultWidth:\s*isMobile\s*\?\s*200\s*:\s*400/);
     expect(entry.match(/minWidth:\s*(\d+)/)?.[1]).toBe("200");
+    expect(entry).toMatch(/resizable:\s*!isMobile/);
   });
 
   test("creator carries the tuned default width and min width", () => {

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -526,7 +526,20 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
     [t, isMobile]
   );
 
-  const { widths, totalWidth, onResizeStart } = useColumnWidths(columns);
+  const { widths, totalWidth, onResizeStart, setWidths } =
+    useColumnWidths(columns);
+
+  // useColumnWidths seeds its state only on first render, so a viewport that
+  // crosses the `sm` breakpoint after mount (resize / rotate) would keep the
+  // stale name-column width. Re-seed from the rebuilt column defaults whenever
+  // the breakpoint flips.
+  const wasMobile = useRef(isMobile);
+  useEffect(() => {
+    if (wasMobile.current !== isMobile) {
+      wasMobile.current = isMobile;
+      setWidths(columns.map((c) => c.defaultWidth));
+    }
+  }, [isMobile, columns, setWidths]);
 
   return (
     <div className="overflow-x-auto">

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -48,6 +48,7 @@ import { Tooltip } from "@/react/components/ui/tooltip";
 import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useColumnWidths } from "@/react/hooks/useColumnWidths";
 import { useEscapeKey } from "@/react/hooks/useEscapeKey";
+import { useMediaQuery } from "@/react/hooks/useMediaQuery";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
 import { useSessionPageSize } from "@/react/hooks/useSessionPageSize";
@@ -108,6 +109,10 @@ const TASK_STATUS_FILTERS: Task_Status[] = [
   Task_Status.DONE,
   Task_Status.SKIPPED,
 ];
+
+// Below Tailwind's `sm` breakpoint (640px) we switch the plan list and the
+// database picker to their compact mobile layouts.
+const MOBILE_MEDIA_QUERY = "(max-width: 639px)";
 
 export function ProjectPlanDashboardPage({ projectId }: { projectId: string }) {
   const { t } = useTranslation();
@@ -402,6 +407,7 @@ function getRolloutStageStatus(summary: Plan_RolloutStageSummary): Task_Status {
 
 function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
   const { t } = useTranslation();
+  const isMobile = useMediaQuery(MOBILE_MEDIA_QUERY);
   // Subscribe so stage cells re-render when the environment cache loads.
   void useAppStore((s) => s.environmentList);
 
@@ -410,9 +416,12 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
       {
         key: "name",
         title: t("issue.table.name"),
-        defaultWidth: 400,
+        // On phones the name column keeps a fixed, compact width so it does
+        // not dominate the row or push the whole table wider than the
+        // viewport; the remaining columns scroll horizontally.
+        defaultWidth: isMobile ? 200 : 400,
         minWidth: 200,
-        resizable: true,
+        resizable: !isMobile,
         render: (plan, ctx) => (
           <div className="flex items-center gap-x-2 overflow-hidden">
             <span className="whitespace-nowrap text-control opacity-60">
@@ -514,7 +523,7 @@ function PlanTable({ plans, projectId }: { plans: Plan[]; projectId: string }) {
         ),
       },
     ],
-    [t]
+    [t, isMobile]
   );
 
   const { widths, totalWidth, onResizeStart } = useColumnWidths(columns);
@@ -1004,7 +1013,7 @@ function DatabaseSelector({
         </div>
       ) : (
         <>
-          <table className="w-full text-sm">
+          <table className="w-full text-sm max-sm:table-fixed">
             <thead>
               <tr className="border-b text-left text-control-light">
                 <th className="py-2 pl-3 pr-2 w-10">
@@ -1019,10 +1028,10 @@ function DatabaseSelector({
                 <th className="py-2 pr-4 font-medium">
                   {t("common.instance")}
                 </th>
-                <th className="py-2 pr-4 font-medium">
+                <th className="hidden py-2 pr-4 font-medium sm:table-cell">
                   {t("common.environment")}
                 </th>
-                <th className="py-2 pr-4 font-medium whitespace-nowrap">
+                <th className="hidden py-2 pr-4 font-medium whitespace-nowrap sm:table-cell">
                   {t("common.status")}
                 </th>
               </tr>
@@ -1046,18 +1055,23 @@ function DatabaseSelector({
                       <Checkbox checked={isSelected} />
                     </td>
                     <td className="py-2 pr-4">
-                      <div className="flex items-center gap-x-1.5">
+                      <div className="flex min-w-0 items-center gap-x-1.5">
                         {inst && (
-                          <EngineIcon engine={inst.engine} className="size-4" />
+                          <EngineIcon
+                            engine={inst.engine}
+                            className="size-4 shrink-0"
+                          />
                         )}
-                        <span>{databaseName}</span>
+                        <span className="truncate">{databaseName}</span>
                       </div>
                     </td>
-                    <td className="py-2 pr-4">{inst?.title}</td>
                     <td className="py-2 pr-4">
+                      <span className="block truncate">{inst?.title}</span>
+                    </td>
+                    <td className="hidden py-2 pr-4 sm:table-cell">
                       {env && <EnvironmentLabel environmentName={env.name} />}
                     </td>
-                    <td className="py-2 pr-4">
+                    <td className="hidden py-2 pr-4 sm:table-cell">
                       {db.syncStatus === SyncStatus.FAILED ? (
                         <Tooltip
                           content={

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskItem.tsx
@@ -155,7 +155,14 @@ export function DeployTaskItem({
             isExpanded ? "space-y-3 py-4 pl-3 pr-4" : "py-2.5 pl-3 pr-4"
           }
         >
-          <div className="flex items-center justify-between gap-x-3">
+          <div
+            className={cn(
+              "flex justify-between gap-x-3",
+              isExpanded
+                ? "flex-col gap-y-2 sm:flex-row sm:items-center"
+                : "items-center"
+            )}
+          >
             <div className="flex min-w-0 flex-1 items-center gap-x-2">
               <Checkbox
                 checked={isSelected}
@@ -168,7 +175,7 @@ export function DeployTaskItem({
                 size={isExpanded ? "large" : "small"}
                 status={task.status}
               />
-              <div className="flex min-w-0 items-center gap-x-2">
+              <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
                 <PlanTargetDisplay size="md" target={task.target} />
                 {isExpanded && !readonly && (
                   <RouterLink
@@ -211,52 +218,57 @@ export function DeployTaskItem({
               )}
             </div>
 
-            {showHeaderActions && (
-              <div className="flex shrink-0 items-center gap-x-2">
-                {actionItems.map((item) => (
+            {(showHeaderActions || !readonly) && (
+              <div className="flex shrink-0 items-center gap-x-2 max-sm:justify-end">
+                {showHeaderActions && (
+                  <div className="flex flex-wrap items-center justify-end gap-2">
+                    {actionItems.map((item) => (
+                      <Button
+                        key={item.key}
+                        onClick={() => {
+                          setAction(item.key);
+                          setActionOpen(true);
+                        }}
+                        size="xs"
+                        variant={item.key === "RUN" ? "default" : "outline"}
+                      >
+                        {item.key === "RUN" && <Play className="h-3 w-3" />}
+                        {item.key === "SKIP" && (
+                          <SkipForward className="h-3 w-3" />
+                        )}
+                        {item.key === "CANCEL" && <X className="h-3 w-3" />}
+                        {item.label}
+                      </Button>
+                    ))}
+                    {rollbackableTaskRun && (
+                      <Button
+                        onClick={() => setRollbackOpen(true)}
+                        size="xs"
+                        variant="outline"
+                      >
+                        {t("common.rollback")}
+                      </Button>
+                    )}
+                  </div>
+                )}
+
+                {!readonly && (
                   <Button
-                    key={item.key}
-                    onClick={() => {
-                      setAction(item.key);
-                      setActionOpen(true);
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      onToggleExpand();
                     }}
                     size="xs"
-                    variant={item.key === "RUN" ? "default" : "outline"}
+                    variant="ghost"
                   >
-                    {item.key === "RUN" && <Play className="h-3 w-3" />}
-                    {item.key === "SKIP" && <SkipForward className="h-3 w-3" />}
-                    {item.key === "CANCEL" && <X className="h-3 w-3" />}
-                    {item.label}
-                  </Button>
-                ))}
-                {rollbackableTaskRun && (
-                  <Button
-                    onClick={() => setRollbackOpen(true)}
-                    size="xs"
-                    variant="outline"
-                  >
-                    {t("common.rollback")}
+                    {isExpanded ? (
+                      <ChevronDown className="h-4 w-4 text-gray-500" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-gray-500" />
+                    )}
                   </Button>
                 )}
               </div>
-            )}
-
-            {!readonly && (
-              <Button
-                className={isExpanded ? "self-start" : undefined}
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onToggleExpand();
-                }}
-                size="xs"
-                variant="ghost"
-              >
-                {isExpanded ? (
-                  <ChevronDown className="h-4 w-4 text-gray-500" />
-                ) : (
-                  <ChevronRight className="h-4 w-4 text-gray-500" />
-                )}
-              </Button>
             )}
           </div>
 

--- a/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskToolbar.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/deploy/DeployTaskToolbar.tsx
@@ -109,7 +109,7 @@ export function DeployTaskToolbar({
     <>
       <div className="sticky top-0 z-10 px-4">
         <div className="flex items-center justify-between rounded-lg border border-blue-200 bg-blue-100 px-3 py-1">
-          <div className="flex items-center gap-x-3">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
             <Tooltip
               content={
                 selectableTasks.length === 0


### PR DESCRIPTION
## What

Mobile / small-screen fixes for the plan surfaces. Desktop layout is unchanged.

### Deploy section (plan detail)
- The task selection toolbar and the expanded task row were single, non-wrapping flex lines that overflowed on phones — the row's database target, `View Details` link and actions overlapped, and the toolbar clipped `Cancel`. Both now wrap/stack below the `sm` breakpoint.
- Header icon buttons (menu / Agent / SQL Editor / My Issues) get `aria-label`/`title`; new `common.open-mobile-sidebar` key added to all locales.

| Before | After |
| - | - |
| <img width="512" alt="image" src="https://github.com/user-attachments/assets/5b1019c5-6c25-40b1-b222-54a86849d597" /> | <img width="512" alt="image" src="https://github.com/user-attachments/assets/195c1586-3983-4a9c-844d-97e6502f3cc4" /> |


### Plans list + New Plan
- Plans table title column uses a fixed 200px width on phones (was 400px flexible) so it no longer pushes the table past the viewport.
- The `workspace` sheet tier is near full-width on phones (was leaving a ~128px gap → 247px drawer). The New Plan database picker switches to a fixed table layout, hides Environment/Status, and truncates Database/Instance so it fits without horizontal scroll.
- Added a reusable `useMediaQuery` hook (+ unit test).

## Testing
- `type-check`, `biome ci`, `check-react-i18n`, `check-react-layering`, `sort_i18n_keys --check` all pass.
- Unit tests: `useMediaQuery` (3), plans columns (7), `DeployTaskItem` — pass.
- Verified live at 375 / 768 / 1440px: no overlap, no horizontal page scroll, drawer 359px, desktop pixel-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
