### PR TITLE
feat: add approval input version stamp

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -302,6 +302,7 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 	var planCheckRunsTrigger bool
 	var databaseGroup *v1pb.DatabaseGroup
 	var issueCommentCreates []*store.IssueCommentMessage
+	var issueToReset *store.IssueMessage
 
 	for _, path := range req.UpdateMask.Paths {
 		switch path {
@@ -332,6 +333,7 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 			config := proto.CloneOf(oldPlan.Config)
 			config.Specs = allSpecs
 			planUpdate.Config = config
+			planUpdate.BumpApprovalInputVersion = true
 
 			// Trigger plan check runs.
 			planCheckRunsTrigger = true
@@ -356,30 +358,7 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 						},
 					})
 				}
-				// Reset approval finding status
-				updatedIssue, err := s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
-					PayloadUpsert: &storepb.Issue{
-						Approval: &storepb.IssuePayloadApproval{
-							ApprovalFindingDone: false,
-						},
-					},
-				})
-				if err != nil {
-					slog.Error("failed to reset approval finding status after plan update", log.BBError(err))
-				}
-
-				// DATABASE_CHANGE: Don't trigger ApprovalCheckChan here - plan update creates new plan check run,
-				// which will trigger approval finding on completion
-				// DATABASE_EXPORT: Re-run approval finding synchronously (no plan checks for export data)
-				if updatedIssue.Type == storepb.Issue_DATABASE_EXPORT {
-					if err := approval.FindAndApplyApprovalTemplate(ctx, s.store, s.webhookManager, s.licenseService, updatedIssue); err != nil {
-						slog.Error("failed to find approval template after plan update",
-							slog.String("project", updatedIssue.ProjectID), slog.Int64("issue_uid", updatedIssue.UID),
-							slog.String("issue_title", updatedIssue.Title),
-							log.BBError(err))
-						// Continue anyway - non-fatal error
-					}
-				}
+				issueToReset = issue
 			}
 		default:
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("invalid update_mask path %q", path))
@@ -389,6 +368,26 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 	updatedPlan, err := s.store.UpdatePlan(ctx, planUpdate)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan %q: %v", req.Plan.Name, err))
+	}
+
+	if issueToReset != nil {
+		updatedIssue, err := s.store.UpdateIssue(ctx, issueToReset.ProjectID, issueToReset.UID, &store.UpdateIssueMessage{
+			PayloadUpsert: &storepb.Issue{
+				Approval: &storepb.IssuePayloadApproval{
+					ApprovalFindingDone: false,
+				},
+			},
+		})
+		if err != nil {
+			slog.Error("failed to reset approval finding status after plan update", log.BBError(err))
+		} else if updatedIssue != nil && updatedIssue.Type == storepb.Issue_DATABASE_EXPORT {
+			if err := approval.FindAndApplyApprovalTemplate(ctx, s.store, s.webhookManager, s.licenseService, updatedIssue); err != nil {
+				slog.Error("failed to find approval template after plan update",
+					slog.String("project", updatedIssue.ProjectID), slog.Int64("issue_uid", updatedIssue.UID),
+					slog.String("issue_title", updatedIssue.Title),
+					log.BBError(err))
+			}
+		}
 	}
 
 	if len(issueCommentCreates) > 0 {

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -370,21 +370,10 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan %q: %v", req.Plan.Name, err))
 	}
 
-	var planCheckRunCreated bool
-	if planCheckRunsTrigger {
-		planCheckRun, err := getPlanCheckRunFromPlan(ctx, s.store, project, updatedPlan, databaseGroup)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan check run for plan"))
+	resetApprovalFinding := func() *store.IssueMessage {
+		if issueToReset == nil {
+			return nil
 		}
-		if planCheckRun != nil {
-			if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
-				return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
-			}
-			planCheckRunCreated = true
-		}
-	}
-
-	if issueToReset != nil {
 		updatedIssue, err := s.store.UpdateIssue(ctx, issueToReset.ProjectID, issueToReset.UID, &store.UpdateIssueMessage{
 			PayloadUpsert: &storepb.Issue{
 				Approval: &storepb.IssuePayloadApproval{
@@ -394,14 +383,36 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 		})
 		if err != nil {
 			slog.Error("failed to reset approval finding status after plan update", log.BBError(err))
-		} else if updatedIssue != nil && updatedIssue.Type == storepb.Issue_DATABASE_EXPORT {
+			return nil
+		}
+		return updatedIssue
+	}
+
+	var planCheckRunCreated bool
+	if planCheckRunsTrigger {
+		planCheckRun, err := getPlanCheckRunFromPlan(ctx, s.store, project, updatedPlan, databaseGroup)
+		if err != nil {
+			resetApprovalFinding()
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan check run for plan"))
+		}
+		if planCheckRun != nil {
+			if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
+				resetApprovalFinding()
+				return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
+			}
+			planCheckRunCreated = true
+		}
+	}
+
+	if updatedIssue := resetApprovalFinding(); updatedIssue != nil {
+		if updatedIssue.Type == storepb.Issue_DATABASE_EXPORT {
 			if err := approval.FindAndApplyApprovalTemplate(ctx, s.store, s.webhookManager, s.licenseService, updatedIssue); err != nil {
 				slog.Error("failed to find approval template after plan update",
 					slog.String("project", updatedIssue.ProjectID), slog.Int64("issue_uid", updatedIssue.UID),
 					slog.String("issue_title", updatedIssue.Title),
 					log.BBError(err))
 			}
-		} else if updatedIssue != nil && updatedIssue.Type == storepb.Issue_DATABASE_CHANGE && planCheckRunsTrigger && !planCheckRunCreated {
+		} else if updatedIssue.Type == storepb.Issue_DATABASE_CHANGE && planCheckRunsTrigger && !planCheckRunCreated {
 			s.bus.ApprovalCheckChan <- bus.IssueRef{ProjectID: updatedIssue.ProjectID, UID: updatedIssue.UID}
 		}
 	}

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -370,6 +370,7 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan %q: %v", req.Plan.Name, err))
 	}
 
+	var planCheckRunCreated bool
 	if planCheckRunsTrigger {
 		planCheckRun, err := getPlanCheckRunFromPlan(ctx, s.store, project, updatedPlan, databaseGroup)
 		if err != nil {
@@ -379,6 +380,7 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 			if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
 				return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
 			}
+			planCheckRunCreated = true
 		}
 	}
 
@@ -399,10 +401,12 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 					slog.String("issue_title", updatedIssue.Title),
 					log.BBError(err))
 			}
+		} else if updatedIssue != nil && updatedIssue.Type == storepb.Issue_DATABASE_CHANGE && planCheckRunsTrigger && !planCheckRunCreated {
+			s.bus.ApprovalCheckChan <- bus.IssueRef{ProjectID: updatedIssue.ProjectID, UID: updatedIssue.UID}
 		}
 	}
 
-	if planCheckRunsTrigger {
+	if planCheckRunCreated {
 		// Tickle plan check scheduler.
 		s.bus.PlanCheckTickleChan <- 0
 	}

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -370,6 +370,18 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan %q: %v", req.Plan.Name, err))
 	}
 
+	if planCheckRunsTrigger {
+		planCheckRun, err := getPlanCheckRunFromPlan(ctx, s.store, project, updatedPlan, databaseGroup)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan check run for plan"))
+		}
+		if planCheckRun != nil {
+			if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
+				return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
+			}
+		}
+	}
+
 	if issueToReset != nil {
 		updatedIssue, err := s.store.UpdateIssue(ctx, issueToReset.ProjectID, issueToReset.UID, &store.UpdateIssueMessage{
 			PayloadUpsert: &storepb.Issue{
@@ -390,24 +402,15 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 		}
 	}
 
+	if planCheckRunsTrigger {
+		// Tickle plan check scheduler.
+		s.bus.PlanCheckTickleChan <- 0
+	}
+
 	if len(issueCommentCreates) > 0 {
 		if _, err := s.store.CreateIssueComments(ctx, user.Email, issueCommentCreates...); err != nil {
 			slog.Warn("failed to create plan spec audit issue comments", log.BBError(err))
 		}
-	}
-
-	if planCheckRunsTrigger {
-		planCheckRun, err := getPlanCheckRunFromPlan(ctx, s.store, project, updatedPlan, databaseGroup)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan check run for plan"))
-		}
-		if planCheckRun != nil {
-			if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
-				return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
-			}
-		}
-		// Tickle plan check scheduler.
-		s.bus.PlanCheckTickleChan <- 0
 	}
 
 	convertedPlan, err := convertToPlan(ctx, s.store, updatedPlan)

--- a/backend/generated-go/store/approval.pb.go
+++ b/backend/generated-go/store/approval.pb.go
@@ -87,8 +87,10 @@ type IssuePayloadApproval struct {
 	// Whether the system has finished finding a matching approval template.
 	// False means the backend is still searching for matching templates.
 	ApprovalFindingDone bool `protobuf:"varint,3,opt,name=approval_finding_done,json=approvalFindingDone,proto3" json:"approval_finding_done,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
+	// The plan approval input version used to generate this approval flow.
+	ApprovalInputVersion int64 `protobuf:"varint,4,opt,name=approval_input_version,json=approvalInputVersion,proto3" json:"approval_input_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *IssuePayloadApproval) Reset() {
@@ -140,6 +142,13 @@ func (x *IssuePayloadApproval) GetApprovalFindingDone() bool {
 		return x.ApprovalFindingDone
 	}
 	return false
+}
+
+func (x *IssuePayloadApproval) GetApprovalInputVersion() int64 {
+	if x != nil {
+		return x.ApprovalInputVersion
+	}
+	return 0
 }
 
 // ApprovalTemplate defines the approval workflow and requirements for an issue.
@@ -312,11 +321,12 @@ var File_store_approval_proto protoreflect.FileDescriptor
 
 const file_store_approval_proto_rawDesc = "" +
 	"\n" +
-	"\x14store/approval.proto\x12\x0ebytebase.store\"\xaa\x03\n" +
+	"\x14store/approval.proto\x12\x0ebytebase.store\"\xe0\x03\n" +
 	"\x14IssuePayloadApproval\x12M\n" +
 	"\x11approval_template\x18\x01 \x01(\v2 .bytebase.store.ApprovalTemplateR\x10approvalTemplate\x12K\n" +
 	"\tapprovers\x18\x02 \x03(\v2-.bytebase.store.IssuePayloadApproval.ApproverR\tapprovers\x122\n" +
-	"\x15approval_finding_done\x18\x03 \x01(\bR\x13approvalFindingDone\x1a\xc1\x01\n" +
+	"\x15approval_finding_done\x18\x03 \x01(\bR\x13approvalFindingDone\x124\n" +
+	"\x16approval_input_version\x18\x04 \x01(\x03R\x14approvalInputVersion\x1a\xc1\x01\n" +
 	"\bApprover\x12L\n" +
 	"\x06status\x18\x01 \x01(\x0e24.bytebase.store.IssuePayloadApproval.Approver.StatusR\x06status\x12\x1c\n" +
 	"\tprincipal\x18\x02 \x01(\tR\tprincipal\"I\n" +

--- a/backend/generated-go/store/approval_equal.pb.go
+++ b/backend/generated-go/store/approval_equal.pb.go
@@ -40,6 +40,9 @@ func (x *IssuePayloadApproval) Equal(y *IssuePayloadApproval) bool {
 	if x.ApprovalFindingDone != y.ApprovalFindingDone {
 		return false
 	}
+	if x.ApprovalInputVersion != y.ApprovalInputVersion {
+		return false
+	}
 	return true
 }
 

--- a/backend/generated-go/store/plan.pb.go
+++ b/backend/generated-go/store/plan.pb.go
@@ -26,9 +26,12 @@ type PlanConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Specs []*PlanConfig_Spec     `protobuf:"bytes,1,rep,name=specs,proto3" json:"specs,omitempty"`
 	// Whether the plan has started the rollout.
-	HasRollout    bool `protobuf:"varint,2,opt,name=has_rollout,json=hasRollout,proto3" json:"has_rollout,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	HasRollout bool `protobuf:"varint,2,opt,name=has_rollout,json=hasRollout,proto3" json:"has_rollout,omitempty"`
+	// Internal monotonic version for plan inputs that affect approval generation.
+	// Starts at the proto default 0 for compatibility with existing plans.
+	ApprovalInputVersion int64 `protobuf:"varint,3,opt,name=approval_input_version,json=approvalInputVersion,proto3" json:"approval_input_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *PlanConfig) Reset() {
@@ -73,6 +76,13 @@ func (x *PlanConfig) GetHasRollout() bool {
 		return x.HasRollout
 	}
 	return false
+}
+
+func (x *PlanConfig) GetApprovalInputVersion() int64 {
+	if x != nil {
+		return x.ApprovalInputVersion
+	}
+	return 0
 }
 
 type PlanConfig_Spec struct {
@@ -447,12 +457,13 @@ var File_store_plan_proto protoreflect.FileDescriptor
 
 const file_store_plan_proto_rawDesc = "" +
 	"\n" +
-	"\x10store/plan.proto\x12\x0ebytebase.store\x1a\x1fgoogle/api/field_behavior.proto\x1a\x12store/common.proto\"\xac\b\n" +
+	"\x10store/plan.proto\x12\x0ebytebase.store\x1a\x1fgoogle/api/field_behavior.proto\x1a\x12store/common.proto\"\xe2\b\n" +
 	"\n" +
 	"PlanConfig\x125\n" +
 	"\x05specs\x18\x01 \x03(\v2\x1f.bytebase.store.PlanConfig.SpecR\x05specs\x12\x1f\n" +
 	"\vhas_rollout\x18\x02 \x01(\bR\n" +
-	"hasRollout\x1a\xcf\x02\n" +
+	"hasRollout\x124\n" +
+	"\x16approval_input_version\x18\x03 \x01(\x03R\x14approvalInputVersion\x1a\xcf\x02\n" +
 	"\x04Spec\x12\x0e\n" +
 	"\x02id\x18\x05 \x01(\tR\x02id\x12g\n" +
 	"\x16create_database_config\x18\x01 \x01(\v2/.bytebase.store.PlanConfig.CreateDatabaseConfigH\x00R\x14createDatabaseConfig\x12g\n" +

--- a/backend/generated-go/store/plan_check_run.pb.go
+++ b/backend/generated-go/store/plan_check_run.pb.go
@@ -74,11 +74,13 @@ func (PlanCheckType) EnumDescriptor() ([]byte, []int) {
 }
 
 type PlanCheckRunResult struct {
-	state         protoimpl.MessageState       `protogen:"open.v1"`
-	Results       []*PlanCheckRunResult_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
-	Error         string                       `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state   protoimpl.MessageState       `protogen:"open.v1"`
+	Results []*PlanCheckRunResult_Result `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+	Error   string                       `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	// The plan approval input version this check run was created for.
+	ApprovalInputVersion int64 `protobuf:"varint,3,opt,name=approval_input_version,json=approvalInputVersion,proto3" json:"approval_input_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *PlanCheckRunResult) Reset() {
@@ -123,6 +125,13 @@ func (x *PlanCheckRunResult) GetError() string {
 		return x.Error
 	}
 	return ""
+}
+
+func (x *PlanCheckRunResult) GetApprovalInputVersion() int64 {
+	if x != nil {
+		return x.ApprovalInputVersion
+	}
+	return 0
 }
 
 type ChangedResources struct {
@@ -586,10 +595,11 @@ var File_store_plan_check_run_proto protoreflect.FileDescriptor
 
 const file_store_plan_check_run_proto_rawDesc = "" +
 	"\n" +
-	"\x1astore/plan_check_run.proto\x12\x0ebytebase.store\x1a\x12store/advice.proto\x1a\x12store/common.proto\"\xa5\a\n" +
+	"\x1astore/plan_check_run.proto\x12\x0ebytebase.store\x1a\x12store/advice.proto\x1a\x12store/common.proto\"\xdb\a\n" +
 	"\x12PlanCheckRunResult\x12C\n" +
 	"\aresults\x18\x01 \x03(\v2).bytebase.store.PlanCheckRunResult.ResultR\aresults\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\x1a\xb3\x06\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\x124\n" +
+	"\x16approval_input_version\x18\x03 \x01(\x03R\x14approvalInputVersion\x1a\xb3\x06\n" +
 	"\x06Result\x125\n" +
 	"\x06status\x18\x01 \x01(\x0e2\x1d.bytebase.store.Advice.StatusR\x06status\x12\x14\n" +
 	"\x05title\x18\x02 \x01(\tR\x05title\x12\x18\n" +

--- a/backend/generated-go/store/plan_check_run_equal.pb.go
+++ b/backend/generated-go/store/plan_check_run_equal.pb.go
@@ -98,6 +98,9 @@ func (x *PlanCheckRunResult) Equal(y *PlanCheckRunResult) bool {
 	if x.Error != y.Error {
 		return false
 	}
+	if x.ApprovalInputVersion != y.ApprovalInputVersion {
+		return false
+	}
 	return true
 }
 

--- a/backend/generated-go/store/plan_equal.pb.go
+++ b/backend/generated-go/store/plan_equal.pb.go
@@ -131,5 +131,8 @@ func (x *PlanConfig) Equal(y *PlanConfig) bool {
 	if x.HasRollout != y.HasRollout {
 		return false
 	}
+	if x.ApprovalInputVersion != y.ApprovalInputVersion {
+		return false
+	}
 	return true
 }

--- a/backend/store/plan.go
+++ b/backend/store/plan.go
@@ -58,8 +58,13 @@ type UpdatePlanMessage struct {
 	// Config replaces the entire plan config.
 	// Callers should clone the existing config and modify only the fields they want to change.
 	// Example: config := proto.CloneOf(plan.Config); config.HasRollout = true; patch.Config = config
-	Config  *storepb.PlanConfig
-	Deleted *bool
+	Config *storepb.PlanConfig
+	// BumpApprovalInputVersion increments config.approvalInputVersion from the
+	// current stored row while applying Config as a full replacement. Use this
+	// only for approval-relevant full config replacements such as spec updates.
+	// This flag is not a partial JSONB patch mechanism for unrelated config fields.
+	BumpApprovalInputVersion bool
+	Deleted                  *bool
 }
 
 // CreatePlan creates a new plan.
@@ -230,7 +235,11 @@ func (s *Store) UpdatePlan(ctx context.Context, patch *UpdatePlanMessage) (*Plan
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to marshal plan config")
 		}
-		set.Comma("config = ?", config)
+		if patch.BumpApprovalInputVersion {
+			set.Comma("config = jsonb_set(?::jsonb, '{approvalInputVersion}', to_jsonb(COALESCE((config->>'approvalInputVersion')::bigint, 0) + 1), true)", config)
+		} else {
+			set.Comma("config = ?", config)
+		}
 	}
 
 	q := qb.Q().Space(`UPDATE plan SET ? WHERE id = ? AND project = ?

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -29,6 +29,7 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	}, "creator@example.com")
 	require.NoError(t, err)
 	require.EqualValues(t, 0, created.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, created.Config, "spec-a")
 
 	config := &storepb.PlanConfig{
 		ApprovalInputVersion: 99,
@@ -42,6 +43,7 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, updated.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, updated.Config, "spec-b")
 
 	description := "description-only"
 	updated, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
@@ -51,6 +53,7 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 1, updated.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, updated.Config, "spec-b")
 
 	config = &storepb.PlanConfig{
 		ApprovalInputVersion: 99,
@@ -64,6 +67,7 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 2, updated.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, updated.Config, "spec-c")
 
 	config = &storepb.PlanConfig{
 		ApprovalInputVersion: 7,
@@ -76,6 +80,7 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 7, updated.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, updated.Config, "spec-d")
 
 	config = &storepb.PlanConfig{
 		ApprovalInputVersion: 99,
@@ -89,6 +94,13 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 8, updated.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, updated.Config, "spec-e")
+}
+
+func requirePlanSpecID(t *testing.T, config *storepb.PlanConfig, id string) {
+	t.Helper()
+	require.Len(t, config.GetSpecs(), 1)
+	require.Equal(t, id, config.GetSpecs()[0].GetId())
 }
 
 func setupPlanApprovalInputVersionStore(ctx context.Context, t *testing.T) *store.Store {

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -31,7 +31,8 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	require.EqualValues(t, 0, created.Config.GetApprovalInputVersion())
 
 	config := &storepb.PlanConfig{
-		Specs: []*storepb.PlanConfig_Spec{{Id: "spec-b"}},
+		ApprovalInputVersion: 99,
+		Specs:                []*storepb.PlanConfig_Spec{{Id: "spec-b"}},
 	}
 	updated, err := s.UpdatePlan(ctx, &store.UpdatePlanMessage{
 		UID:                      created.UID,
@@ -52,7 +53,8 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	require.EqualValues(t, 1, updated.Config.GetApprovalInputVersion())
 
 	config = &storepb.PlanConfig{
-		Specs: []*storepb.PlanConfig_Spec{{Id: "spec-c"}},
+		ApprovalInputVersion: 99,
+		Specs:                []*storepb.PlanConfig_Spec{{Id: "spec-c"}},
 	}
 	updated, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
 		UID:                      created.UID,
@@ -62,6 +64,31 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.EqualValues(t, 2, updated.Config.GetApprovalInputVersion())
+
+	config = &storepb.PlanConfig{
+		ApprovalInputVersion: 7,
+		Specs:                []*storepb.PlanConfig_Spec{{Id: "spec-d"}},
+	}
+	updated, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:       created.UID,
+		ProjectID: created.ProjectID,
+		Config:    config,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 7, updated.Config.GetApprovalInputVersion())
+
+	config = &storepb.PlanConfig{
+		ApprovalInputVersion: 99,
+		Specs:                []*storepb.PlanConfig_Spec{{Id: "spec-e"}},
+	}
+	updated, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:                      created.UID,
+		ProjectID:                created.ProjectID,
+		Config:                   config,
+		BumpApprovalInputVersion: true,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 8, updated.Config.GetApprovalInputVersion())
 }
 
 func setupPlanApprovalInputVersionStore(ctx context.Context, t *testing.T) *store.Store {

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -1,0 +1,91 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+
+	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
+)
+
+func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	created, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config: &storepb.PlanConfig{
+			Specs: []*storepb.PlanConfig_Spec{{Id: "spec-a"}},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	require.EqualValues(t, 0, created.Config.GetApprovalInputVersion())
+
+	config := &storepb.PlanConfig{
+		Specs: []*storepb.PlanConfig_Spec{{Id: "spec-b"}},
+	}
+	updated, err := s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:                      created.UID,
+		ProjectID:                created.ProjectID,
+		Config:                   config,
+		BumpApprovalInputVersion: true,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, updated.Config.GetApprovalInputVersion())
+
+	description := "description-only"
+	updated, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:         created.UID,
+		ProjectID:   created.ProjectID,
+		Description: &description,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, updated.Config.GetApprovalInputVersion())
+
+	config = &storepb.PlanConfig{
+		Specs: []*storepb.PlanConfig_Spec{{Id: "spec-c"}},
+	}
+	updated, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:                      created.UID,
+		ProjectID:                created.ProjectID,
+		Config:                   config,
+		BumpApprovalInputVersion: true,
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 2, updated.Config.GetApprovalInputVersion())
+}
+
+func setupPlanApprovalInputVersionStore(ctx context.Context, t *testing.T) *store.Store {
+	t.Helper()
+
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	return s
+}

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -765,6 +765,7 @@ IssuePayloadApproval records the approval template used and approval history for
 | approval_template | [ApprovalTemplate](#bytebase-store-ApprovalTemplate) |  | The approval template being used for this issue. |
 | approvers | [IssuePayloadApproval.Approver](#bytebase-store-IssuePayloadApproval-Approver) | repeated | List of approvers and their current status. |
 | approval_finding_done | [bool](#bool) |  | Whether the system has finished finding a matching approval template. False means the backend is still searching for matching templates. |
+| approval_input_version | [int64](#int64) |  | The plan approval input version used to generate this approval flow. |
 
 
 
@@ -2836,6 +2837,7 @@ Type represents the category of issue.
 | ----- | ---- | ----- | ----------- |
 | specs | [PlanConfig.Spec](#bytebase-store-PlanConfig-Spec) | repeated |  |
 | has_rollout | [bool](#bool) |  | Whether the plan has started the rollout. |
+| approval_input_version | [int64](#int64) |  | Internal monotonic version for plan inputs that affect approval generation. Starts at the proto default 0 for compatibility with existing plans. |
 
 
 
@@ -3148,6 +3150,7 @@ add/remove/update from the snapshot pair.
 | ----- | ---- | ----- | ----------- |
 | results | [PlanCheckRunResult.Result](#bytebase-store-PlanCheckRunResult-Result) | repeated |  |
 | error | [string](#string) |  |  |
+| approval_input_version | [int64](#int64) |  | The plan approval input version this check run was created for. |
 
 
 

--- a/proto/gen/grpc-doc/store/index.html
+++ b/proto/gen/grpc-doc/store/index.html
@@ -2705,6 +2705,13 @@ TODO: use range instead. </p></td>
 False means the backend is still searching for matching templates. </p></td>
                 </tr>
               
+                <tr>
+                  <td>approval_input_version</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>The plan approval input version used to generate this approval flow. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -8494,6 +8501,14 @@ Format: users/{email}. </p></td>
                   <td><p>Whether the plan has started the rollout. </p></td>
                 </tr>
               
+                <tr>
+                  <td>approval_input_version</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>Internal monotonic version for plan inputs that affect approval generation.
+Starts at the proto default 0 for compatibility with existing plans. </p></td>
+                </tr>
+              
             </tbody>
           </table>
 
@@ -9155,6 +9170,13 @@ Leave it empty if there is no need to encrypt the zip file. </p></td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>approval_input_version</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p>The plan approval input version this check run was created for. </p></td>
                 </tr>
               
             </tbody>

--- a/proto/store/store/approval.proto
+++ b/proto/store/store/approval.proto
@@ -34,6 +34,9 @@ message IssuePayloadApproval {
   // Whether the system has finished finding a matching approval template.
   // False means the backend is still searching for matching templates.
   bool approval_finding_done = 3;
+
+  // The plan approval input version used to generate this approval flow.
+  int64 approval_input_version = 4;
 }
 
 // ApprovalTemplate defines the approval workflow and requirements for an issue.

--- a/proto/store/store/plan.proto
+++ b/proto/store/store/plan.proto
@@ -10,6 +10,13 @@ option go_package = "generated-go/store";
 message PlanConfig {
   repeated Spec specs = 1;
 
+  // Whether the plan has started the rollout.
+  bool has_rollout = 2;
+
+  // Internal monotonic version for plan inputs that affect approval generation.
+  // Starts at the proto default 0 for compatibility with existing plans.
+  int64 approval_input_version = 3;
+
   message Spec {
     // A UUID4 string that uniquely identifies the Spec.
     string id = 5;
@@ -20,9 +27,6 @@ message PlanConfig {
       ExportDataConfig export_data_config = 7;
     }
   }
-
-  // Whether the plan has started the rollout.
-  bool has_rollout = 2;
 
   message CreateDatabaseConfig {
     // The resource name of the instance on which the database is created.

--- a/proto/store/store/plan_check_run.proto
+++ b/proto/store/store/plan_check_run.proto
@@ -18,6 +18,9 @@ message PlanCheckRunResult {
   repeated Result results = 1;
   string error = 2;
 
+  // The plan approval input version this check run was created for.
+  int64 approval_input_version = 3;
+
   message Result {
     Advice.Status status = 1;
     string title = 2;


### PR DESCRIPTION
## Summary
- Add an internal approval input version to plan config, issue approval payloads, and plan check results.
- Bump the plan approval input version when approval-relevant plan specs change.
- Reset stored approval/check state around plan spec updates so later PRs can detect stale derived state.

## Test Plan
- go test -v -count=1 ./backend/store -run '^TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested$'
- go test -v -count=1 ./backend/api/v1 -run '^$'
- buf lint proto