### PR TITLE
fix: prevent stale approval flows

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -760,6 +760,24 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 		return nil, connect.NewError(connect.CodeInternal, errors.New("approval template is required"))
 	}
 
+	var plan *store.PlanMessage
+	var approvalInputVersion int64
+	if issue.Type == storepb.Issue_DATABASE_CHANGE && issue.PlanUID != nil {
+		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
+		}
+		if plan == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
+		}
+		if plan.Config != nil {
+			approvalInputVersion = plan.Config.GetApprovalInputVersion()
+		}
+		if payload.Approval.GetApprovalInputVersion() != approvalInputVersion {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot reject because approval finding is stale"))
+		}
+	}
+
 	rejectedRole := utils.FindRejectedRole(payload.Approval)
 	if rejectedRole != "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("cannot reject because the issue has been rejected"))
@@ -789,13 +807,36 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 		Principal: common.FormatUserEmail(user.Email),
 	})
 
-	issue, err = s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
-		PayloadUpsert: &storepb.Issue{
-			Approval: payload.Approval,
-		},
-	})
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
+	payloadPatch := &storepb.Issue{
+		Approval: payload.Approval,
+	}
+	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
+		updated, err := s.store.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
+		}
+		if !updated {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot reject because approval finding is stale"))
+		}
+		uid := issue.UID
+		issue, err = s.store.GetIssue(ctx, &store.FindIssueMessage{
+			Workspace:  common.GetWorkspaceIDFromContext(ctx),
+			ProjectIDs: []string{issue.ProjectID},
+			UID:        &uid,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to refresh issue"))
+		}
+		if issue == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("issue not found after rejection"))
+		}
+	} else {
+		issue, err = s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
+			PayloadUpsert: payloadPatch,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
+		}
 	}
 
 	if _, err := s.store.CreateIssueComments(ctx, user.Email, &store.IssueCommentMessage{
@@ -870,6 +911,24 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 		return nil, connect.NewError(connect.CodeInternal, errors.New("approval template is required"))
 	}
 
+	var plan *store.PlanMessage
+	var approvalInputVersion int64
+	if issue.Type == storepb.Issue_DATABASE_CHANGE && issue.PlanUID != nil {
+		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
+		}
+		if plan == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
+		}
+		if plan.Config != nil {
+			approvalInputVersion = plan.Config.GetApprovalInputVersion()
+		}
+		if payload.Approval.GetApprovalInputVersion() != approvalInputVersion {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot request issue because approval finding is stale"))
+		}
+	}
+
 	rejectedRole := utils.FindRejectedRole(payload.Approval)
 	if rejectedRole == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("cannot request issues because the issue is not rejected"))
@@ -894,13 +953,36 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 	}
 	payload.Approval.Approvers = updatedApprovers
 
-	issue, err = s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
-		PayloadUpsert: &storepb.Issue{
-			Approval: payload.Approval,
-		},
-	})
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
+	payloadPatch := &storepb.Issue{
+		Approval: payload.Approval,
+	}
+	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
+		updated, err := s.store.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
+		}
+		if !updated {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot request issue because approval finding is stale"))
+		}
+		uid := issue.UID
+		issue, err = s.store.GetIssue(ctx, &store.FindIssueMessage{
+			Workspace:  common.GetWorkspaceIDFromContext(ctx),
+			ProjectIDs: []string{issue.ProjectID},
+			UID:        &uid,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to refresh issue"))
+		}
+		if issue == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("issue not found after request"))
+		}
+	} else {
+		issue, err = s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
+			PayloadUpsert: payloadPatch,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
+		}
 	}
 
 	approval.NotifyApprovalRequested(ctx, s.store, s.webhookManager, issue, project)

--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -641,10 +641,7 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check if the approval is approved"))
 	}
 
-	payloadPatch := &storepb.Issue{
-		Approval: payload.Approval,
-	}
-	issue, err = s.updateIssueApprovalPayload(ctx, issue, payloadPatch, plan, approvalInputVersion)
+	issue, err = s.updateIssueApprovalPayload(ctx, issue, &storepb.Issue{Approval: payload.Approval}, plan, approvalInputVersion)
 	if err != nil {
 		if errors.Is(err, errStaleApprovalFinding) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot approve because approval finding is stale"))
@@ -761,10 +758,7 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 		Principal: common.FormatUserEmail(user.Email),
 	})
 
-	payloadPatch := &storepb.Issue{
-		Approval: payload.Approval,
-	}
-	issue, err = s.updateIssueApprovalPayload(ctx, issue, payloadPatch, plan, approvalInputVersion)
+	issue, err = s.updateIssueApprovalPayload(ctx, issue, &storepb.Issue{Approval: payload.Approval}, plan, approvalInputVersion)
 	if err != nil {
 		if errors.Is(err, errStaleApprovalFinding) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot reject because approval finding is stale"))
@@ -873,10 +867,7 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 	}
 	payload.Approval.Approvers = updatedApprovers
 
-	payloadPatch := &storepb.Issue{
-		Approval: payload.Approval,
-	}
-	issue, err = s.updateIssueApprovalPayload(ctx, issue, payloadPatch, plan, approvalInputVersion)
+	issue, err = s.updateIssueApprovalPayload(ctx, issue, &storepb.Issue{Approval: payload.Approval}, plan, approvalInputVersion)
 	if err != nil {
 		if errors.Is(err, errStaleApprovalFinding) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot request issue because approval finding is stale"))

--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -600,6 +600,24 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 		return nil, connect.NewError(connect.CodeInternal, errors.New("approval template is required"))
 	}
 
+	var plan *store.PlanMessage
+	var approvalInputVersion int64
+	if issue.Type == storepb.Issue_DATABASE_CHANGE && issue.PlanUID != nil {
+		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
+		}
+		if plan == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
+		}
+		if plan.Config != nil {
+			approvalInputVersion = plan.Config.GetApprovalInputVersion()
+		}
+		if payload.Approval.GetApprovalInputVersion() != approvalInputVersion {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot approve because approval finding is stale"))
+		}
+	}
+
 	rejectedRole := utils.FindRejectedRole(payload.Approval)
 	if rejectedRole != "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("cannot approve because the issue has been rejected"))
@@ -629,18 +647,52 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 		Principal: common.FormatUserEmail(user.Email),
 	})
 
-	approved, err := utils.CheckApprovalApproved(payload.Approval)
+	approved, err := utils.CheckIssueApprovedForPlan(issue, plan)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check if the approval is approved"))
 	}
 
-	issue, err = s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
-		PayloadUpsert: &storepb.Issue{
-			Approval: payload.Approval,
-		},
-	})
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
+	payloadPatch := &storepb.Issue{
+		Approval: payload.Approval,
+	}
+	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
+		updated, err := s.store.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
+		}
+		if !updated {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot approve because approval finding is stale"))
+		}
+		uid := issue.UID
+		issue, err = s.store.GetIssue(ctx, &store.FindIssueMessage{
+			Workspace:  common.GetWorkspaceIDFromContext(ctx),
+			ProjectIDs: []string{issue.ProjectID},
+			UID:        &uid,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to refresh issue"))
+		}
+		if issue == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("issue not found after approval"))
+		}
+		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
+		}
+		if plan == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
+		}
+		approved, err = utils.CheckIssueApprovedForPlan(issue, plan)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check if the approval is approved"))
+		}
+	} else {
+		issue, err = s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
+			PayloadUpsert: payloadPatch,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
+		}
 	}
 
 	if _, err := s.store.CreateIssueComments(ctx, user.Email, &store.IssueCommentMessage{
@@ -904,8 +956,21 @@ func (s *IssueService) RetryIssueApproval(ctx context.Context, req *connect.Requ
 		return nil, connect.NewError(connect.CodePermissionDenied, errors.New("only the issue creator can retry approval finding"))
 	}
 
-	// No-op fast path: nothing to retry if the previous attempt completed.
-	if issue.Payload.GetApproval().GetApprovalFindingDone() {
+	approvalFindingCurrent := true
+	var plan *store.PlanMessage
+	if issue.Type == storepb.Issue_DATABASE_CHANGE && issue.PlanUID != nil {
+		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
+		}
+		if plan == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
+		}
+		approvalFindingCurrent = issue.Payload.GetApproval().GetApprovalInputVersion() == plan.Config.GetApprovalInputVersion()
+	}
+
+	// No-op fast path: nothing to retry if the previous attempt completed for the current approval input.
+	if issue.Payload.GetApproval().GetApprovalFindingDone() && approvalFindingCurrent {
 		issueV1, err := s.convertToIssue(issue)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
@@ -939,7 +1004,16 @@ func (s *IssueService) RetryIssueApproval(ctx context.Context, req *connect.Requ
 	//   * ACCESS_GRANT / ROLE_GRANT → activate the grant via
 	//     `completeAccessRequestIssue`.
 	//   * DATABASE_CHANGE with a plan → enqueue rollout creation.
-	approved, err := utils.CheckIssueApproved(refreshed)
+	if plan == nil && refreshed.Type == storepb.Issue_DATABASE_CHANGE && refreshed.PlanUID != nil {
+		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: refreshed.ProjectID, UID: refreshed.PlanUID})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
+		}
+		if plan == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
+		}
+	}
+	approved, err := utils.CheckIssueApprovedForPlan(refreshed, plan)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to check approval state"))
 	}

--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -613,9 +613,6 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 		if plan.Config != nil {
 			approvalInputVersion = plan.Config.GetApprovalInputVersion()
 		}
-		if payload.Approval.GetApprovalInputVersion() != approvalInputVersion {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot approve because approval finding is stale"))
-		}
 	}
 
 	rejectedRole := utils.FindRejectedRole(payload.Approval)
@@ -656,7 +653,7 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 		Approval: payload.Approval,
 	}
 	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
-		updated, err := s.store.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+		updated, err := s.store.UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
 		}
@@ -773,9 +770,6 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 		if plan.Config != nil {
 			approvalInputVersion = plan.Config.GetApprovalInputVersion()
 		}
-		if payload.Approval.GetApprovalInputVersion() != approvalInputVersion {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot reject because approval finding is stale"))
-		}
 	}
 
 	rejectedRole := utils.FindRejectedRole(payload.Approval)
@@ -811,7 +805,7 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 		Approval: payload.Approval,
 	}
 	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
-		updated, err := s.store.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+		updated, err := s.store.UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
 		}
@@ -924,9 +918,6 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 		if plan.Config != nil {
 			approvalInputVersion = plan.Config.GetApprovalInputVersion()
 		}
-		if payload.Approval.GetApprovalInputVersion() != approvalInputVersion {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot request issue because approval finding is stale"))
-		}
 	}
 
 	rejectedRole := utils.FindRejectedRole(payload.Approval)
@@ -957,7 +948,7 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 		Approval: payload.Approval,
 	}
 	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
-		updated, err := s.store.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+		updated, err := s.store.UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
 		}

--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -39,6 +39,8 @@ type IssueService struct {
 	iamManager     *iam.Manager
 }
 
+var errStaleApprovalFinding = errors.New("stale approval finding")
+
 type filterIssueMessage struct {
 	ApprovalStatus *v1pb.ApprovalStatus
 	// Approver is the user who can approve the issue.
@@ -600,19 +602,9 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 		return nil, connect.NewError(connect.CodeInternal, errors.New("approval template is required"))
 	}
 
-	var plan *store.PlanMessage
-	var approvalInputVersion int64
-	if issue.Type == storepb.Issue_DATABASE_CHANGE && issue.PlanUID != nil {
-		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
-		}
-		if plan == nil {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
-		}
-		if plan.Config != nil {
-			approvalInputVersion = plan.Config.GetApprovalInputVersion()
-		}
+	plan, approvalInputVersion, err := s.getIssuePlanApprovalInputVersion(ctx, issue)
+	if err != nil {
+		return nil, err
 	}
 
 	rejectedRole := utils.FindRejectedRole(payload.Approval)
@@ -652,43 +644,21 @@ func (s *IssueService) ApproveIssue(ctx context.Context, req *connect.Request[v1
 	payloadPatch := &storepb.Issue{
 		Approval: payload.Approval,
 	}
-	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
-		updated, err := s.store.UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
-		}
-		if !updated {
+	issue, err = s.updateIssueApprovalPayload(ctx, issue, payloadPatch, plan, approvalInputVersion)
+	if err != nil {
+		if errors.Is(err, errStaleApprovalFinding) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot approve because approval finding is stale"))
 		}
-		uid := issue.UID
-		issue, err = s.store.GetIssue(ctx, &store.FindIssueMessage{
-			Workspace:  common.GetWorkspaceIDFromContext(ctx),
-			ProjectIDs: []string{issue.ProjectID},
-			UID:        &uid,
-		})
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	if plan != nil {
+		plan, _, err = s.getIssuePlanApprovalInputVersion(ctx, issue)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to refresh issue"))
-		}
-		if issue == nil {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("issue not found after approval"))
-		}
-		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
-		}
-		if plan == nil {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
+			return nil, err
 		}
 		approved, err = utils.CheckIssueApprovedForPlan(issue, plan)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check if the approval is approved"))
-		}
-	} else {
-		issue, err = s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
-			PayloadUpsert: payloadPatch,
-		})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
 		}
 	}
 
@@ -757,19 +727,9 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 		return nil, connect.NewError(connect.CodeInternal, errors.New("approval template is required"))
 	}
 
-	var plan *store.PlanMessage
-	var approvalInputVersion int64
-	if issue.Type == storepb.Issue_DATABASE_CHANGE && issue.PlanUID != nil {
-		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
-		}
-		if plan == nil {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
-		}
-		if plan.Config != nil {
-			approvalInputVersion = plan.Config.GetApprovalInputVersion()
-		}
+	plan, approvalInputVersion, err := s.getIssuePlanApprovalInputVersion(ctx, issue)
+	if err != nil {
+		return nil, err
 	}
 
 	rejectedRole := utils.FindRejectedRole(payload.Approval)
@@ -804,33 +764,12 @@ func (s *IssueService) RejectIssue(ctx context.Context, req *connect.Request[v1p
 	payloadPatch := &storepb.Issue{
 		Approval: payload.Approval,
 	}
-	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
-		updated, err := s.store.UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
-		}
-		if !updated {
+	issue, err = s.updateIssueApprovalPayload(ctx, issue, payloadPatch, plan, approvalInputVersion)
+	if err != nil {
+		if errors.Is(err, errStaleApprovalFinding) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot reject because approval finding is stale"))
 		}
-		uid := issue.UID
-		issue, err = s.store.GetIssue(ctx, &store.FindIssueMessage{
-			Workspace:  common.GetWorkspaceIDFromContext(ctx),
-			ProjectIDs: []string{issue.ProjectID},
-			UID:        &uid,
-		})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to refresh issue"))
-		}
-		if issue == nil {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("issue not found after rejection"))
-		}
-	} else {
-		issue, err = s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
-			PayloadUpsert: payloadPatch,
-		})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
-		}
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
 	if _, err := s.store.CreateIssueComments(ctx, user.Email, &store.IssueCommentMessage{
@@ -905,19 +844,9 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 		return nil, connect.NewError(connect.CodeInternal, errors.New("approval template is required"))
 	}
 
-	var plan *store.PlanMessage
-	var approvalInputVersion int64
-	if issue.Type == storepb.Issue_DATABASE_CHANGE && issue.PlanUID != nil {
-		plan, err = s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
-		}
-		if plan == nil {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
-		}
-		if plan.Config != nil {
-			approvalInputVersion = plan.Config.GetApprovalInputVersion()
-		}
+	plan, approvalInputVersion, err := s.getIssuePlanApprovalInputVersion(ctx, issue)
+	if err != nil {
+		return nil, err
 	}
 
 	rejectedRole := utils.FindRejectedRole(payload.Approval)
@@ -947,33 +876,12 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 	payloadPatch := &storepb.Issue{
 		Approval: payload.Approval,
 	}
-	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
-		updated, err := s.store.UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
-		}
-		if !updated {
+	issue, err = s.updateIssueApprovalPayload(ctx, issue, payloadPatch, plan, approvalInputVersion)
+	if err != nil {
+		if errors.Is(err, errStaleApprovalFinding) {
 			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot request issue because approval finding is stale"))
 		}
-		uid := issue.UID
-		issue, err = s.store.GetIssue(ctx, &store.FindIssueMessage{
-			Workspace:  common.GetWorkspaceIDFromContext(ctx),
-			ProjectIDs: []string{issue.ProjectID},
-			UID:        &uid,
-		})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to refresh issue"))
-		}
-		if issue == nil {
-			return nil, connect.NewError(connect.CodeNotFound, errors.New("issue not found after request"))
-		}
-	} else {
-		issue, err = s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
-			PayloadUpsert: payloadPatch,
-		})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to update issue"))
-		}
+		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
 	approval.NotifyApprovalRequested(ctx, s.store, s.webhookManager, issue, project)
@@ -998,6 +906,58 @@ func (s *IssueService) RequestIssue(ctx context.Context, req *connect.Request[v1
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert to issue"))
 	}
 	return connect.NewResponse(issueV1), nil
+}
+
+func (s *IssueService) getIssuePlanApprovalInputVersion(ctx context.Context, issue *store.IssueMessage) (*store.PlanMessage, int64, error) {
+	if issue.Type != storepb.Issue_DATABASE_CHANGE || issue.PlanUID == nil {
+		return nil, 0, nil
+	}
+
+	plan, err := s.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
+	if err != nil {
+		return nil, 0, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get plan"))
+	}
+	if plan == nil {
+		return nil, 0, connect.NewError(connect.CodeNotFound, errors.New("plan not found"))
+	}
+	if plan.Config == nil {
+		return plan, 0, nil
+	}
+	return plan, plan.Config.GetApprovalInputVersion(), nil
+}
+
+func (s *IssueService) updateIssueApprovalPayload(ctx context.Context, issue *store.IssueMessage, payloadPatch *storepb.Issue, plan *store.PlanMessage, approvalInputVersion int64) (*store.IssueMessage, error) {
+	if plan == nil {
+		updatedIssue, err := s.store.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
+			PayloadUpsert: payloadPatch,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to update issue")
+		}
+		return updatedIssue, nil
+	}
+
+	updated, err := s.store.UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to update issue")
+	}
+	if !updated {
+		return nil, errStaleApprovalFinding
+	}
+
+	uid := issue.UID
+	updatedIssue, err := s.store.GetIssue(ctx, &store.FindIssueMessage{
+		Workspace:  common.GetWorkspaceIDFromContext(ctx),
+		ProjectIDs: []string{issue.ProjectID},
+		UID:        &uid,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to refresh issue")
+	}
+	if updatedIssue == nil {
+		return nil, errors.New("issue not found after update")
+	}
+	return updatedIssue, nil
 }
 
 // RetryIssueApproval re-runs approval-template finding for an issue stuck

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -213,7 +213,7 @@ func (s *PlanService) CreatePlan(ctx context.Context, request *connect.Request[v
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan check run for plan"))
 	}
 	if planCheckRun != nil {
-		if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
+		if _, err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
 		}
 	}
@@ -396,11 +396,12 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan check run for plan"))
 		}
 		if planCheckRun != nil {
-			if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
+			created, err := s.store.CreatePlanCheckRun(ctx, planCheckRun)
+			if err != nil {
 				resetApprovalFinding()
 				return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
 			}
-			planCheckRunCreated = true
+			planCheckRunCreated = created
 		}
 	}
 
@@ -515,8 +516,12 @@ func (s *PlanService) RunPlanChecks(ctx context.Context, request *connect.Reques
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan check run for plan"))
 	}
 	if planCheckRun != nil {
-		if err := s.store.CreatePlanCheckRun(ctx, planCheckRun); err != nil {
+		created, err := s.store.CreatePlanCheckRun(ctx, planCheckRun)
+		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
+		}
+		if !created {
+			return connect.NewResponse(&v1pb.RunPlanChecksResponse{}), nil
 		}
 	}
 

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -465,7 +465,9 @@ func resetIssueApprovalFindingIfPlanApprovalInputVersion(ctx context.Context, st
 		},
 	}
 	if issue.Type == storepb.Issue_DATABASE_CHANGE {
-		updated, err := stores.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+		// Plan check rows are visible before the reset finishes. If another worker already
+		// recomputed approval for this version, the reset must not move the issue back to CHECKING.
+		updated, err := stores.ResetIssueApprovalFindingIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, approvalInputVersion)
 		if err != nil {
 			return nil, false, err
 		}

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -515,14 +515,15 @@ func (s *PlanService) RunPlanChecks(ctx context.Context, request *connect.Reques
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get plan check run for plan"))
 	}
-	if planCheckRun != nil {
-		created, err := s.store.CreatePlanCheckRun(ctx, planCheckRun)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
-		}
-		if !created {
-			return connect.NewResponse(&v1pb.RunPlanChecksResponse{}), nil
-		}
+	if planCheckRun == nil {
+		return connect.NewResponse(&v1pb.RunPlanChecksResponse{}), nil
+	}
+	created, err := s.store.CreatePlanCheckRun(ctx, planCheckRun)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to create plan check run"))
+	}
+	if !created {
+		return connect.NewResponse(&v1pb.RunPlanChecksResponse{}), nil
 	}
 
 	// Tickle plan check scheduler.

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -598,6 +598,15 @@ func (s *PlanService) CancelPlanCheckRun(ctx context.Context, request *connect.R
 
 	approvalInputVersion := planCheckRun.Result.GetApprovalInputVersion()
 
+	// Update the status to canceled.
+	canceled, err := s.store.CancelPlanCheckRunIfApprovalInputVersion(ctx, projectID, planCheckRun.UID, approvalInputVersion)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to cancel plan check run"))
+	}
+	if !canceled {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot cancel because plan check run is stale"))
+	}
+
 	// Cancel in-flight plan check run if running.
 	if cancelFunc, ok := s.bus.RunningPlanCheckRunsCancelFunc.Load(bus.PlanCheckRunRef{ProjectID: projectID, UID: planCheckRun.UID, ApprovalInputVersion: approvalInputVersion}); ok {
 		cancelFunc.(context.CancelFunc)()
@@ -606,15 +615,6 @@ func (s *PlanService) CancelPlanCheckRun(ctx context.Context, request *connect.R
 	// Broadcast cancel signal to all replicas for HA.
 	if err := s.store.SendSignal(ctx, storepb.Signal_CANCEL_PLAN_CHECK_RUN, projectID, planCheckRun.UID, approvalInputVersion); err != nil {
 		slog.Warn("failed to send cancel signal", log.BBError(err))
-	}
-
-	// Update the status to canceled.
-	canceled, err := s.store.CancelPlanCheckRunIfApprovalInputVersion(ctx, projectID, planCheckRun.UID, approvalInputVersion)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to cancel plan check run"))
-	}
-	if !canceled {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot cancel because plan check run is stale"))
 	}
 
 	return connect.NewResponse(&v1pb.CancelPlanCheckRunResponse{}), nil

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -334,6 +334,7 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 			config.Specs = allSpecs
 			planUpdate.Config = config
 			planUpdate.BumpApprovalInputVersion = true
+			planUpdate.RequireNoRollout = true
 
 			// Trigger plan check runs.
 			planCheckRunsTrigger = true

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -368,6 +368,9 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 
 	updatedPlan, err := s.store.UpdatePlan(ctx, planUpdate)
 	if err != nil {
+		if errors.Is(err, store.ErrPlanHasRollout) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.Errorf("cannot update specs for plan that has a rollout"))
+		}
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to update plan %q: %v", req.Plan.Name, err))
 	}
 

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -374,15 +374,16 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 		if issueToReset == nil {
 			return nil
 		}
-		updatedIssue, err := s.store.UpdateIssue(ctx, issueToReset.ProjectID, issueToReset.UID, &store.UpdateIssueMessage{
-			PayloadUpsert: &storepb.Issue{
-				Approval: &storepb.IssuePayloadApproval{
-					ApprovalFindingDone: false,
-				},
-			},
-		})
+		updatedIssue, updated, err := resetIssueApprovalFindingIfPlanApprovalInputVersion(ctx, s.store, issueToReset, updatedPlan.Config.GetApprovalInputVersion())
 		if err != nil {
 			slog.Error("failed to reset approval finding status after plan update", log.BBError(err))
+			return nil
+		}
+		if !updated {
+			slog.Info("skip stale approval finding reset after plan update",
+				slog.String("project", issueToReset.ProjectID),
+				slog.Int64("issue_uid", issueToReset.UID),
+				slog.Int64("approval_input_version", updatedPlan.Config.GetApprovalInputVersion()))
 			return nil
 		}
 		return updatedIssue
@@ -454,6 +455,38 @@ func (s *PlanService) GetPlanCheckRun(ctx context.Context, request *connect.Requ
 
 	converted := convertToPlanCheckRun(projectID, planUID, planCheckRun)
 	return connect.NewResponse(converted), nil
+}
+
+func resetIssueApprovalFindingIfPlanApprovalInputVersion(ctx context.Context, stores *store.Store, issue *store.IssueMessage, approvalInputVersion int64) (*store.IssueMessage, bool, error) {
+	payloadPatch := &storepb.Issue{
+		Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  false,
+			ApprovalInputVersion: approvalInputVersion,
+		},
+	}
+	if issue.Type == storepb.Issue_DATABASE_CHANGE {
+		updated, err := stores.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+		if err != nil {
+			return nil, false, err
+		}
+		if !updated {
+			return nil, false, nil
+		}
+		uid := issue.UID
+		updatedIssue, err := stores.GetIssue(ctx, &store.FindIssueMessage{
+			ProjectIDs: []string{issue.ProjectID},
+			UID:        &uid,
+		})
+		return updatedIssue, true, err
+	}
+
+	updatedIssue, err := stores.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
+		PayloadUpsert: payloadPatch,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return updatedIssue, true, nil
 }
 
 // RunPlanChecks runs plan checks for a plan.
@@ -563,19 +596,25 @@ func (s *PlanService) CancelPlanCheckRun(ctx context.Context, request *connect.R
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("plan check run is not running or available"))
 	}
 
+	approvalInputVersion := planCheckRun.Result.GetApprovalInputVersion()
+
 	// Cancel in-flight plan check run if running.
-	if cancelFunc, ok := s.bus.RunningPlanCheckRunsCancelFunc.Load(bus.PlanCheckRunRef{ProjectID: projectID, UID: planCheckRun.UID}); ok {
+	if cancelFunc, ok := s.bus.RunningPlanCheckRunsCancelFunc.Load(bus.PlanCheckRunRef{ProjectID: projectID, UID: planCheckRun.UID, ApprovalInputVersion: approvalInputVersion}); ok {
 		cancelFunc.(context.CancelFunc)()
 	}
 
 	// Broadcast cancel signal to all replicas for HA.
-	if err := s.store.SendSignal(ctx, storepb.Signal_CANCEL_PLAN_CHECK_RUN, projectID, planCheckRun.UID); err != nil {
+	if err := s.store.SendSignal(ctx, storepb.Signal_CANCEL_PLAN_CHECK_RUN, projectID, planCheckRun.UID, approvalInputVersion); err != nil {
 		slog.Warn("failed to send cancel signal", log.BBError(err))
 	}
 
 	// Update the status to canceled.
-	if err := s.store.BatchCancelPlanCheckRuns(ctx, projectID, []int64{planCheckRun.UID}); err != nil {
+	canceled, err := s.store.CancelPlanCheckRunIfApprovalInputVersion(ctx, projectID, planCheckRun.UID, approvalInputVersion)
+	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to cancel plan check run"))
+	}
+	if !canceled {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot cancel because plan check run is stale"))
 	}
 
 	return connect.NewResponse(&v1pb.CancelPlanCheckRunResponse{}), nil

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -820,7 +820,10 @@ func getPlanCheckRunFromPlan(ctx context.Context, s *store.Store, project *store
 	return &store.PlanCheckRunMessage{
 		ProjectID: plan.ProjectID,
 		PlanUID:   plan.UID,
-		Status:    store.PlanCheckRunStatusRunning,
+		Status:    store.PlanCheckRunStatusAvailable,
+		Result: &storepb.PlanCheckRunResult{
+			ApprovalInputVersion: plan.Config.GetApprovalInputVersion(),
+		},
 	}, nil
 }
 

--- a/backend/api/v1/plan_service_test.go
+++ b/backend/api/v1/plan_service_test.go
@@ -124,7 +124,7 @@ func TestResetIssueApprovalFindingSkipsStalePlanApprovalInputVersion(t *testing.
 		Payload: &storepb.Issue{
 			Approval: &storepb.IssuePayloadApproval{
 				ApprovalFindingDone:  true,
-				ApprovalInputVersion: 2,
+				ApprovalInputVersion: 1,
 			},
 		},
 		PlanUID: &plan.UID,
@@ -139,7 +139,7 @@ func TestResetIssueApprovalFindingSkipsStalePlanApprovalInputVersion(t *testing.
 	got, err := s.GetIssue(ctx, &store.FindIssueMessage{ProjectIDs: []string{"project-a"}, UID: &issue.UID})
 	require.NoError(t, err)
 	require.True(t, got.Payload.GetApproval().GetApprovalFindingDone())
-	require.EqualValues(t, 2, got.Payload.GetApproval().GetApprovalInputVersion())
+	require.EqualValues(t, 1, got.Payload.GetApproval().GetApprovalInputVersion())
 
 	updatedIssue, updated, err = resetIssueApprovalFindingIfPlanApprovalInputVersion(ctx, s, issue, 2)
 	require.NoError(t, err)

--- a/backend/api/v1/plan_service_test.go
+++ b/backend/api/v1/plan_service_test.go
@@ -1,11 +1,19 @@
 package v1
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+
+	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
 )
 
 func cdcSpec(id, sheet string, targets []string, priorBackup bool) *storepb.PlanConfig_Spec {
@@ -93,4 +101,76 @@ func TestPlanSpecsEqualSet(t *testing.T) {
 			assert.Equal(t, tc.want, planSpecsEqualSet(tc.a, tc.b))
 		})
 	}
+}
+
+func TestResetIssueApprovalFindingSkipsStalePlanApprovalInputVersion(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanServiceTestStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	issue, err := s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "issue-a",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Description:  "",
+		Payload: &storepb.Issue{
+			Approval: &storepb.IssuePayloadApproval{
+				ApprovalFindingDone:  true,
+				ApprovalInputVersion: 2,
+			},
+		},
+		PlanUID: &plan.UID,
+	})
+	require.NoError(t, err)
+
+	updatedIssue, updated, err := resetIssueApprovalFindingIfPlanApprovalInputVersion(ctx, s, issue, 1)
+	require.NoError(t, err)
+	require.False(t, updated)
+	require.Nil(t, updatedIssue)
+
+	got, err := s.GetIssue(ctx, &store.FindIssueMessage{ProjectIDs: []string{"project-a"}, UID: &issue.UID})
+	require.NoError(t, err)
+	require.True(t, got.Payload.GetApproval().GetApprovalFindingDone())
+	require.EqualValues(t, 2, got.Payload.GetApproval().GetApprovalInputVersion())
+
+	updatedIssue, updated, err = resetIssueApprovalFindingIfPlanApprovalInputVersion(ctx, s, issue, 2)
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.NotNil(t, updatedIssue)
+	require.False(t, updatedIssue.Payload.GetApproval().GetApprovalFindingDone())
+	require.EqualValues(t, 2, updatedIssue.Payload.GetApproval().GetApprovalInputVersion())
+}
+
+func setupPlanServiceTestStore(ctx context.Context, t *testing.T) *store.Store {
+	t.Helper()
+
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	return s
 }

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -41,6 +41,13 @@ type RolloutService struct {
 	iamManager     *iam.Manager
 }
 
+var errStaleRolloutApproval = errors.New("cannot create rollout because issue approval is stale")
+
+// IsStaleRolloutApprovalError reports whether rollout creation lost the approval-version race.
+func IsStaleRolloutApprovalError(err error) bool {
+	return errors.Is(err, errStaleRolloutApproval)
+}
+
 // NewRolloutService returns a rollout service instance.
 func NewRolloutService(store *store.Store, dbFactory *dbfactory.DBFactory, bus *bus.Bus, webhookManager *webhook.Manager, iamManager *iam.Manager) *RolloutService {
 	return &RolloutService{
@@ -300,6 +307,9 @@ func (s *RolloutService) CreateRollout(ctx context.Context, req *connect.Request
 	}
 
 	if err := CreateRolloutAndPendingTasks(ctx, s.store, user.Email, plan, issue, project, tasks); err != nil {
+		if IsStaleRolloutApprovalError(err) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+		}
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
@@ -407,7 +417,7 @@ func CreateRolloutAndPendingTasks(
 		return errors.Wrap(err, "failed to create rollout tasks")
 	}
 	if !marked {
-		return errors.New("cannot create rollout because issue approval is stale")
+		return errStaleRolloutApproval
 	}
 	tasks = createdTasks
 

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -12,7 +12,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/jackc/pgtype"
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -398,40 +397,19 @@ func CreateRolloutAndPendingTasks(
 		}
 	}
 
-	rolloutMarked := false
+	var approvalInputVersion *int64
 	if issue != nil && issue.Type == storepb.Issue_DATABASE_CHANGE {
-		marked, createdTasks, err := s.CreateTasksIfPlanApprovalInputVersion(ctx, project.ResourceID, plan.UID, plan.Config.GetApprovalInputVersion(), tasks)
-		if err != nil {
-			return errors.Wrap(err, "failed to create rollout tasks")
-		}
-		if !marked {
-			return errors.New("cannot create rollout because issue approval is stale")
-		}
-		tasks = createdTasks
-		rolloutMarked = true
+		v := plan.Config.GetApprovalInputVersion()
+		approvalInputVersion = &v
 	}
-
-	// Create rollout tasks
-	if !rolloutMarked {
-		tasks, err = s.CreateTasks(ctx, project.ResourceID, plan.UID, tasks)
-		if err != nil {
-			return errors.Wrap(err, "failed to create rollout tasks")
-		}
+	marked, createdTasks, err := s.CreateRolloutTasks(ctx, project.ResourceID, plan.UID, approvalInputVersion, tasks)
+	if err != nil {
+		return errors.Wrap(err, "failed to create rollout tasks")
 	}
-
-	// Update plan to set hasRollout to true
-	if !rolloutMarked {
-		config := proto.CloneOf(plan.Config)
-		config.HasRollout = true
-		_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
-			UID:       plan.UID,
-			ProjectID: project.ResourceID,
-			Config:    config,
-		})
-		if err != nil {
-			return errors.Wrap(err, "failed to update plan hasRollout")
-		}
+	if !marked {
+		return errors.New("cannot create rollout because issue approval is stale")
 	}
+	tasks = createdTasks
 
 	// Update issue status to DONE when rollout is created
 	if issue != nil {

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -279,6 +279,16 @@ func (s *RolloutService) CreateRollout(ctx context.Context, req *connect.Request
 		}
 	}
 
+	if project.Setting.RequireIssueApproval && issue != nil {
+		approved, err := utils.CheckIssueApprovedForPlan(issue, plan)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check if the issue is approved"))
+		}
+		if !approved {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New("cannot create rollout because issue approval is required but the issue is not approved"))
+		}
+	}
+
 	tasks, err := GetPipelineCreate(ctx, s.store, plan.Config.GetSpecs(), project.ResourceID)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to get pipeline create"))
@@ -388,22 +398,39 @@ func CreateRolloutAndPendingTasks(
 		}
 	}
 
+	rolloutMarked := false
+	if issue != nil && issue.Type == storepb.Issue_DATABASE_CHANGE {
+		marked, createdTasks, err := s.CreateTasksIfPlanApprovalInputVersion(ctx, project.ResourceID, plan.UID, plan.Config.GetApprovalInputVersion(), tasks)
+		if err != nil {
+			return errors.Wrap(err, "failed to create rollout tasks")
+		}
+		if !marked {
+			return errors.New("cannot create rollout because issue approval is stale")
+		}
+		tasks = createdTasks
+		rolloutMarked = true
+	}
+
 	// Create rollout tasks
-	tasks, err = s.CreateTasks(ctx, project.ResourceID, plan.UID, tasks)
-	if err != nil {
-		return errors.Wrap(err, "failed to create rollout tasks")
+	if !rolloutMarked {
+		tasks, err = s.CreateTasks(ctx, project.ResourceID, plan.UID, tasks)
+		if err != nil {
+			return errors.Wrap(err, "failed to create rollout tasks")
+		}
 	}
 
 	// Update plan to set hasRollout to true
-	config := proto.CloneOf(plan.Config)
-	config.HasRollout = true
-	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID:       plan.UID,
-		ProjectID: project.ResourceID,
-		Config:    config,
-	})
-	if err != nil {
-		return errors.Wrap(err, "failed to update plan hasRollout")
+	if !rolloutMarked {
+		config := proto.CloneOf(plan.Config)
+		config.HasRollout = true
+		_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+			UID:       plan.UID,
+			ProjectID: project.ResourceID,
+			Config:    config,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to update plan hasRollout")
+		}
 	}
 
 	// Update issue status to DONE when rollout is created
@@ -798,7 +825,7 @@ func (s *RolloutService) BatchRunTasks(ctx context.Context, req *connect.Request
 
 	// Check if issue approval is required according to the project settings
 	if project.Setting.RequireIssueApproval && issueN != nil {
-		approved, err := utils.CheckIssueApproved(issueN)
+		approved, err := utils.CheckIssueApprovedForPlan(issueN, plan)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check if the issue is approved"))
 		}

--- a/backend/component/bus/bus.go
+++ b/backend/component/bus/bus.go
@@ -25,8 +25,9 @@ type IssueRef struct {
 
 // PlanCheckRunRef identifies a plan check run by project and UID.
 type PlanCheckRunRef struct {
-	ProjectID string
-	UID       int64
+	ProjectID            string
+	UID                  int64
+	ApprovalInputVersion int64
 }
 
 // Bus is the message bus for all in-memory communication within the server.

--- a/backend/component/bus/bus_test.go
+++ b/backend/component/bus/bus_test.go
@@ -1,0 +1,14 @@
+package bus
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanCheckRunRefIncludesApprovalInputVersion(t *testing.T) {
+	require.NotEqual(t,
+		PlanCheckRunRef{ProjectID: "project-a", UID: 1, ApprovalInputVersion: 1},
+		PlanCheckRunRef{ProjectID: "project-a", UID: 1, ApprovalInputVersion: 2},
+	)
+}

--- a/backend/generated-go/store/signal.pb.go
+++ b/backend/generated-go/store/signal.pb.go
@@ -73,12 +73,13 @@ func (Signal_Type) EnumDescriptor() ([]byte, []int) {
 
 // Signal represents a notification payload sent via PostgreSQL NOTIFY for HA coordination.
 type Signal struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Type          Signal_Type            `protobuf:"varint,1,opt,name=type,proto3,enum=bytebase.store.Signal_Type" json:"type,omitempty"`
-	Uid           int64                  `protobuf:"varint,2,opt,name=uid,proto3" json:"uid,omitempty"`
-	Project       string                 `protobuf:"bytes,3,opt,name=project,proto3" json:"project,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	Type                 Signal_Type            `protobuf:"varint,1,opt,name=type,proto3,enum=bytebase.store.Signal_Type" json:"type,omitempty"`
+	Uid                  int64                  `protobuf:"varint,2,opt,name=uid,proto3" json:"uid,omitempty"`
+	Project              string                 `protobuf:"bytes,3,opt,name=project,proto3" json:"project,omitempty"`
+	ApprovalInputVersion int64                  `protobuf:"varint,4,opt,name=approval_input_version,json=approvalInputVersion,proto3" json:"approval_input_version,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *Signal) Reset() {
@@ -132,15 +133,23 @@ func (x *Signal) GetProject() string {
 	return ""
 }
 
+func (x *Signal) GetApprovalInputVersion() int64 {
+	if x != nil {
+		return x.ApprovalInputVersion
+	}
+	return 0
+}
+
 var File_store_signal_proto protoreflect.FileDescriptor
 
 const file_store_signal_proto_rawDesc = "" +
 	"\n" +
-	"\x12store/signal.proto\x12\x0ebytebase.store\"\xb3\x01\n" +
+	"\x12store/signal.proto\x12\x0ebytebase.store\"\xe9\x01\n" +
 	"\x06Signal\x12/\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x1b.bytebase.store.Signal.TypeR\x04type\x12\x10\n" +
 	"\x03uid\x18\x02 \x01(\x03R\x03uid\x12\x18\n" +
-	"\aproject\x18\x03 \x01(\tR\aproject\"L\n" +
+	"\aproject\x18\x03 \x01(\tR\aproject\x124\n" +
+	"\x16approval_input_version\x18\x04 \x01(\x03R\x14approvalInputVersion\"L\n" +
 	"\x04Type\x12\x14\n" +
 	"\x10TYPE_UNSPECIFIED\x10\x00\x12\x19\n" +
 	"\x15CANCEL_PLAN_CHECK_RUN\x10\x01\x12\x13\n" +

--- a/backend/generated-go/store/signal_equal.pb.go
+++ b/backend/generated-go/store/signal_equal.pb.go
@@ -19,5 +19,8 @@ func (x *Signal) Equal(y *Signal) bool {
 	if x.Project != y.Project {
 		return false
 	}
+	if x.ApprovalInputVersion != y.ApprovalInputVersion {
+		return false
+	}
 	return true
 }

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -22,6 +22,7 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	parserbase "github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/runner/plancheck"
 	"github.com/bytebase/bytebase/backend/store"
 	"github.com/bytebase/bytebase/backend/utils"
 )
@@ -165,25 +166,31 @@ func findApprovalTemplateForIssue(ctx context.Context, stores *store.Store, webh
 		return errors.Errorf("project %s not found", issue.ProjectID)
 	}
 
+	approvalInputVersion, err := getIssuePlanApprovalInputVersion(ctx, stores, issue)
+	if err != nil {
+		return err
+	}
+
 	approvalTemplate, celVarsList, approvalInputVersion, done, err := func() (*storepb.ApprovalTemplate, []map[string]any, int64, bool, error) {
 		// no need to find if feature is not enabled
 		if licenseService.IsFeatureEnabled(ctx, project.Workspace, v1pb.PlanFeature_FEATURE_APPROVAL_WORKFLOW) != nil {
 			// nolint:nilerr
-			return nil, nil, 0, true, nil
+			return nil, nil, approvalInputVersion, true, nil
 		}
 
 		// Step 1: Determine approval source from issue type
 		approvalSource, err := getApprovalSourceFromIssue(ctx, stores, issue)
 		if err != nil {
-			return nil, nil, 0, false, errors.Wrap(err, "failed to get approval source from issue")
+			return nil, nil, approvalInputVersion, false, errors.Wrap(err, "failed to get approval source from issue")
 		}
 		if approvalSource == storepb.WorkspaceApprovalSetting_Rule_SOURCE_UNSPECIFIED {
 			// Cannot determine source, no approval needed
-			return nil, nil, 0, true, nil
+			return nil, nil, approvalInputVersion, true, nil
 		}
 
 		// Step 2: Build CEL variables for evaluation
-		celVarsList, approvalInputVersion, done, err := buildCELVariablesForIssue(ctx, stores, issue)
+		celVarsList, celApprovalInputVersion, done, err := buildCELVariablesForIssue(ctx, stores, issue)
+		approvalInputVersion = celApprovalInputVersion
 		if err != nil {
 			return nil, nil, approvalInputVersion, false, errors.Wrap(err, "failed to build CEL variables for issue")
 		}
@@ -250,6 +257,23 @@ func findApprovalTemplateForIssue(ctx context.Context, stores *store.Store, webh
 	NotifyApprovalRequested(ctx, stores, webhookManager, issue, project)
 
 	return nil
+}
+
+func getIssuePlanApprovalInputVersion(ctx context.Context, stores *store.Store, issue *store.IssueMessage) (int64, error) {
+	if issue.Type != storepb.Issue_DATABASE_CHANGE {
+		return 0, nil
+	}
+	if issue.PlanUID == nil {
+		return 0, errors.Errorf("expected plan UID in issue %v", issue.UID)
+	}
+	plan, err := stores.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
+	if err != nil {
+		return 0, errors.Wrapf(err, "failed to get plan %v", *issue.PlanUID)
+	}
+	if plan == nil {
+		return 0, errors.Errorf("plan %v not found", *issue.PlanUID)
+	}
+	return plan.Config.GetApprovalInputVersion(), nil
 }
 
 // calculateRiskLevelFromCELVars calculates the risk level from CEL variables.
@@ -556,13 +580,6 @@ func buildStatementSummaryResultMap(results []*storepb.PlanCheckRunResult_Result
 	return m
 }
 
-func isPlanCheckRunPendingApprovalEvaluation(planCheckRun *store.PlanCheckRunMessage) bool {
-	if planCheckRun == nil {
-		return false
-	}
-	return planCheckRun.Status == store.PlanCheckRunStatusAvailable || planCheckRun.Status == store.PlanCheckRunStatusRunning
-}
-
 func isPlanCheckRunCurrentForApprovalInputVersion(planCheckRun *store.PlanCheckRunMessage, planApprovalInputVersion int64) (current bool, pending bool) {
 	if planCheckRun == nil {
 		return false, true
@@ -593,23 +610,33 @@ func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store
 		return nil, approvalInputVersion, false, errors.Wrapf(err, "failed to get plan check run for plan %v", plan.UID)
 	}
 
-	current, pending := isPlanCheckRunCurrentForApprovalInputVersion(planCheckRun, approvalInputVersion)
-	if pending {
-		return nil, approvalInputVersion, false, nil
-	}
-	if !current {
-		refreshed, err := stores.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, issue.ProjectID, plan.UID, approvalInputVersion)
+	if planCheckRun == nil {
+		checksExpected, err := planChecksExpectedForApproval(ctx, stores, nil, plan)
 		if err != nil {
-			slog.Error("failed to refresh stale plan check run for approval input version",
-				slog.String("project", issue.ProjectID),
-				slog.Int64("issue_uid", issue.UID),
-				slog.Int64("plan_uid", plan.UID),
-				slog.Int64("approval_input_version", approvalInputVersion),
-				log.BBError(err))
-			return nil, approvalInputVersion, false, errors.Wrap(err, "failed to refresh stale plan check run for approval input version")
+			return nil, approvalInputVersion, false, errors.Wrap(err, "failed to derive plan check targets")
 		}
-		_ = refreshed
-		return nil, approvalInputVersion, false, nil
+		if checksExpected {
+			return nil, approvalInputVersion, false, nil
+		}
+	} else {
+		current, pending := isPlanCheckRunCurrentForApprovalInputVersion(planCheckRun, approvalInputVersion)
+		if pending {
+			return nil, approvalInputVersion, false, nil
+		}
+		if !current {
+			refreshed, err := stores.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, issue.ProjectID, plan.UID, approvalInputVersion)
+			if err != nil {
+				slog.Error("failed to refresh stale plan check run for approval input version",
+					slog.String("project", issue.ProjectID),
+					slog.Int64("issue_uid", issue.UID),
+					slog.Int64("plan_uid", plan.UID),
+					slog.Int64("approval_input_version", approvalInputVersion),
+					log.BBError(err))
+				return nil, approvalInputVersion, false, errors.Wrap(err, "failed to refresh stale plan check run for approval input version")
+			}
+			_ = refreshed
+			return nil, approvalInputVersion, false, nil
+		}
 	}
 
 	// Unfold database groups and get all targets
@@ -693,6 +720,78 @@ func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store
 	}
 
 	return celVarsList, approvalInputVersion, true, nil
+}
+
+func planChecksExpectedForApproval(ctx context.Context, stores *store.Store, project *store.ProjectMessage, plan *store.PlanMessage) (bool, error) {
+	if project == nil {
+		var err error
+		project, err = stores.GetProjectByResourceID(ctx, plan.ProjectID)
+		if err != nil {
+			return false, errors.Wrap(err, "failed to get project")
+		}
+		if project == nil {
+			return false, errors.Errorf("project %s not found", plan.ProjectID)
+		}
+	}
+
+	databaseGroup, err := getDatabaseGroupForPlanApproval(ctx, stores, plan)
+	if err != nil {
+		return false, err
+	}
+
+	targets, err := plancheck.DeriveCheckTargets(ctx, stores, project, plan, databaseGroup)
+	if err != nil {
+		return false, err
+	}
+	return len(targets) > 0, nil
+}
+
+func getDatabaseGroupForPlanApproval(ctx context.Context, stores *store.Store, plan *store.PlanMessage) (*v1pb.DatabaseGroup, error) {
+	for _, spec := range plan.Config.GetSpecs() {
+		cfg, ok := spec.Config.(*storepb.PlanConfig_Spec_ChangeDatabaseConfig)
+		if !ok {
+			continue
+		}
+		if len(cfg.ChangeDatabaseConfig.Targets) != 1 {
+			continue
+		}
+
+		target := cfg.ChangeDatabaseConfig.Targets[0]
+		_, databaseGroupID, err := common.GetProjectIDDatabaseGroupID(target)
+		if err != nil {
+			continue
+		}
+
+		dbGroup, err := stores.GetDatabaseGroup(ctx, &store.FindDatabaseGroupMessage{
+			ResourceID: &databaseGroupID,
+			ProjectID:  &plan.ProjectID,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get database group %q", target)
+		}
+		if dbGroup == nil {
+			return nil, errors.Errorf("database group %q not found", target)
+		}
+
+		allDatabases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &plan.ProjectID})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list databases for project %q", plan.ProjectID)
+		}
+
+		matchedDatabases, err := utils.GetMatchedDatabasesInDatabaseGroup(ctx, dbGroup, allDatabases)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get matched databases for group %q", databaseGroupID)
+		}
+
+		result := &v1pb.DatabaseGroup{Name: target}
+		for _, db := range matchedDatabases {
+			result.MatchedDatabases = append(result.MatchedDatabases, &v1pb.DatabaseGroup_Database{
+				Name: common.FormatDatabase(db.InstanceID, db.DatabaseName),
+			})
+		}
+		return result, nil
+	}
+	return nil, nil
 }
 
 // buildCELVariablesForDataExport builds CEL variables for DATABASE_EXPORT issues.

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -140,7 +140,18 @@ func (r *Runner) processIssue(ctx context.Context, ref bus.IssueRef) {
 			return
 		}
 
-		approved, err := utils.CheckIssueApproved(issue)
+		planID := *issue.PlanUID
+		plan, err := r.store.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: &planID})
+		if err != nil {
+			slog.Error("failed to get plan for approval check",
+				slog.String("project", ref.ProjectID), slog.Int64("issue_uid", ref.UID), log.BBError(err))
+			return
+		}
+		if plan == nil {
+			return
+		}
+
+		approved, err := utils.CheckIssueApprovedForPlan(issue, plan)
 		if err != nil {
 			slog.Error("failed to check if issue is approved",
 				slog.String("project", ref.ProjectID), slog.Int64("issue_uid", ref.UID), log.BBError(err))
@@ -154,9 +165,6 @@ func (r *Runner) processIssue(ctx context.Context, ref bus.IssueRef) {
 
 func findApprovalTemplateForIssue(ctx context.Context, stores *store.Store, webhookManager *webhook.Manager, licenseService *enterprise.LicenseService, issue *store.IssueMessage, approvalSetting *storepb.WorkspaceApprovalSetting) error {
 	payload := issue.Payload
-	if payload.Approval != nil && payload.Approval.ApprovalFindingDone {
-		return nil
-	}
 
 	project, err := stores.GetProjectByResourceID(ctx, issue.ProjectID)
 	if err != nil {
@@ -169,6 +177,9 @@ func findApprovalTemplateForIssue(ctx context.Context, stores *store.Store, webh
 	approvalInputVersion, err := getIssuePlanApprovalInputVersion(ctx, stores, issue)
 	if err != nil {
 		return err
+	}
+	if payload.Approval != nil && payload.Approval.ApprovalFindingDone && payload.Approval.GetApprovalInputVersion() == approvalInputVersion {
+		return nil
 	}
 
 	approvalTemplate, celVarsList, approvalInputVersion, done, err := func() (*storepb.ApprovalTemplate, []map[string]any, int64, bool, error) {
@@ -605,20 +616,43 @@ func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store
 	}
 	approvalInputVersion := plan.Config.GetApprovalInputVersion()
 
+	checksExpected, err := planChecksExpectedForApproval(ctx, stores, nil, plan)
+	if err != nil {
+		return nil, approvalInputVersion, false, errors.Wrap(err, "failed to derive plan check targets")
+	}
+
 	planCheckRun, err := stores.GetPlanCheckRun(ctx, issue.ProjectID, plan.UID)
 	if err != nil {
 		return nil, approvalInputVersion, false, errors.Wrapf(err, "failed to get plan check run for plan %v", plan.UID)
 	}
 
-	if planCheckRun == nil {
-		checksExpected, err := planChecksExpectedForApproval(ctx, stores, nil, plan)
-		if err != nil {
-			return nil, approvalInputVersion, false, errors.Wrap(err, "failed to derive plan check targets")
-		}
-		if checksExpected {
+	if checksExpected {
+		if planCheckRun == nil {
 			return nil, approvalInputVersion, false, nil
 		}
-	} else {
+		if planCheckRun.Status == store.PlanCheckRunStatusAvailable || planCheckRun.Status == store.PlanCheckRunStatusRunning {
+			if planCheckRun.Result.GetApprovalInputVersion() == approvalInputVersion {
+				return nil, approvalInputVersion, false, nil
+			}
+			refreshed, err := stores.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+				ProjectID: issue.ProjectID,
+				PlanUID:   plan.UID,
+				Result: &storepb.PlanCheckRunResult{
+					ApprovalInputVersion: approvalInputVersion,
+				},
+			})
+			if err != nil {
+				slog.Error("failed to refresh active stale plan check run for approval input version",
+					slog.String("project", issue.ProjectID),
+					slog.Int64("issue_uid", issue.UID),
+					slog.Int64("plan_uid", plan.UID),
+					slog.Int64("approval_input_version", approvalInputVersion),
+					log.BBError(err))
+				return nil, approvalInputVersion, false, errors.Wrap(err, "failed to refresh active stale plan check run for approval input version")
+			}
+			_ = refreshed
+			return nil, approvalInputVersion, false, nil
+		}
 		current, pending := isPlanCheckRunCurrentForApprovalInputVersion(planCheckRun, approvalInputVersion)
 		if pending {
 			return nil, approvalInputVersion, false, nil
@@ -637,6 +671,8 @@ func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store
 			_ = refreshed
 			return nil, approvalInputVersion, false, nil
 		}
+	} else {
+		planCheckRun = nil
 	}
 
 	// Unfold database groups and get all targets

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -764,7 +764,7 @@ func getDatabaseGroupForPlanApproval(ctx context.Context, stores *store.Store, p
 
 		dbGroup, err := stores.GetDatabaseGroup(ctx, &store.FindDatabaseGroupMessage{
 			ResourceID: &databaseGroupID,
-			ProjectID:  &plan.ProjectID,
+			ProjectIDs: []string{plan.ProjectID},
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get database group %q", target)

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -165,31 +165,31 @@ func findApprovalTemplateForIssue(ctx context.Context, stores *store.Store, webh
 		return errors.Errorf("project %s not found", issue.ProjectID)
 	}
 
-	approvalTemplate, celVarsList, done, err := func() (*storepb.ApprovalTemplate, []map[string]any, bool, error) {
+	approvalTemplate, celVarsList, approvalInputVersion, done, err := func() (*storepb.ApprovalTemplate, []map[string]any, int64, bool, error) {
 		// no need to find if feature is not enabled
 		if licenseService.IsFeatureEnabled(ctx, project.Workspace, v1pb.PlanFeature_FEATURE_APPROVAL_WORKFLOW) != nil {
 			// nolint:nilerr
-			return nil, nil, true, nil
+			return nil, nil, 0, true, nil
 		}
 
 		// Step 1: Determine approval source from issue type
 		approvalSource, err := getApprovalSourceFromIssue(ctx, stores, issue)
 		if err != nil {
-			return nil, nil, false, errors.Wrap(err, "failed to get approval source from issue")
+			return nil, nil, 0, false, errors.Wrap(err, "failed to get approval source from issue")
 		}
 		if approvalSource == storepb.WorkspaceApprovalSetting_Rule_SOURCE_UNSPECIFIED {
 			// Cannot determine source, no approval needed
-			return nil, nil, true, nil
+			return nil, nil, 0, true, nil
 		}
 
 		// Step 2: Build CEL variables for evaluation
-		celVarsList, done, err := buildCELVariablesForIssue(ctx, stores, issue)
+		celVarsList, approvalInputVersion, done, err := buildCELVariablesForIssue(ctx, stores, issue)
 		if err != nil {
-			return nil, nil, false, errors.Wrap(err, "failed to build CEL variables for issue")
+			return nil, nil, approvalInputVersion, false, errors.Wrap(err, "failed to build CEL variables for issue")
 		}
 		if !done {
 			// Not ready yet (e.g., waiting for plan check runs)
-			return nil, nil, false, nil
+			return nil, nil, approvalInputVersion, false, nil
 		}
 
 		// Step 3: Inject risk level into CEL variables for CHANGE_DATABASE issues
@@ -203,10 +203,10 @@ func findApprovalTemplateForIssue(ctx context.Context, stores *store.Store, webh
 		// Step 4: Find matching approval template
 		approvalTemplate, err := getApprovalTemplate(approvalSetting, approvalSource, celVarsList)
 		if err != nil {
-			return nil, nil, false, errors.Wrapf(err, "failed to get approval template for source: %v", approvalSource)
+			return nil, nil, approvalInputVersion, false, errors.Wrapf(err, "failed to get approval template for source: %v", approvalSource)
 		}
 
-		return approvalTemplate, celVarsList, true, nil
+		return approvalTemplate, celVarsList, approvalInputVersion, true, nil
 	}()
 	if err != nil {
 		// Don't persist error - it will be logged by caller
@@ -222,17 +222,27 @@ func findApprovalTemplateForIssue(ctx context.Context, stores *store.Store, webh
 	riskLevel := calculateRiskLevelFromCELVars(celVarsList)
 
 	payload.Approval = &storepb.IssuePayloadApproval{
-		ApprovalFindingDone: true,
-		ApprovalTemplate:    approvalTemplate,
-		Approvers:           nil,
+		ApprovalFindingDone:  true,
+		ApprovalTemplate:     approvalTemplate,
+		Approvers:            nil,
+		ApprovalInputVersion: approvalInputVersion,
 	}
 	payload.RiskLevel = riskLevel
 
-	if _, err := stores.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
-		PayloadUpsert: &storepb.Issue{
-			Approval:  payload.Approval,
-			RiskLevel: riskLevel,
-		},
+	payloadPatch := &storepb.Issue{
+		Approval:  payload.Approval,
+		RiskLevel: riskLevel,
+	}
+	if issue.Type == storepb.Issue_DATABASE_CHANGE {
+		updated, err := stores.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, issue.ProjectID, issue.UID, payloadPatch, approvalInputVersion)
+		if err != nil {
+			return errors.Wrap(err, "failed to update issue payload")
+		}
+		if !updated {
+			return nil
+		}
+	} else if _, err := stores.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
+		PayloadUpsert: payloadPatch,
 	}); err != nil {
 		return errors.Wrap(err, "failed to update issue payload")
 	}
@@ -387,18 +397,21 @@ func buildFallbackCELVars(celVarsList []map[string]any) []map[string]any {
 // buildCELVariablesForIssue builds the CEL variable maps for evaluating approval rules.
 // Returns a list of CEL variable maps (one per task/component), done flag, and error.
 // done=false means the caller should retry later (e.g., waiting for plan check runs).
-func buildCELVariablesForIssue(ctx context.Context, stores *store.Store, issue *store.IssueMessage) ([]map[string]any, bool, error) {
+func buildCELVariablesForIssue(ctx context.Context, stores *store.Store, issue *store.IssueMessage) ([]map[string]any, int64, bool, error) {
 	switch issue.Type {
 	case storepb.Issue_ROLE_GRANT:
-		return buildCELVariablesForRoleGrant(ctx, stores, issue)
+		celVarsList, done, err := buildCELVariablesForRoleGrant(ctx, stores, issue)
+		return celVarsList, 0, done, err
 	case storepb.Issue_DATABASE_CHANGE:
 		return buildCELVariablesForDatabaseChange(ctx, stores, issue)
 	case storepb.Issue_DATABASE_EXPORT:
-		return buildCELVariablesForDataExport(ctx, stores, issue)
+		celVarsList, done, err := buildCELVariablesForDataExport(ctx, stores, issue)
+		return celVarsList, 0, done, err
 	case storepb.Issue_ACCESS_GRANT:
-		return buildCELVariablesForAccessGrant(ctx, stores, issue)
+		celVarsList, done, err := buildCELVariablesForAccessGrant(ctx, stores, issue)
+		return celVarsList, 0, done, err
 	default:
-		return nil, false, errors.Errorf("unknown issue type %v", issue.Type)
+		return nil, 0, false, errors.Errorf("unknown issue type %v", issue.Type)
 	}
 }
 
@@ -550,34 +563,59 @@ func isPlanCheckRunPendingApprovalEvaluation(planCheckRun *store.PlanCheckRunMes
 	return planCheckRun.Status == store.PlanCheckRunStatusAvailable || planCheckRun.Status == store.PlanCheckRunStatusRunning
 }
 
+func isPlanCheckRunCurrentForApprovalInputVersion(planCheckRun *store.PlanCheckRunMessage, planApprovalInputVersion int64) (current bool, pending bool) {
+	if planCheckRun == nil {
+		return false, true
+	}
+	if planCheckRun.Status == store.PlanCheckRunStatusAvailable || planCheckRun.Status == store.PlanCheckRunStatusRunning {
+		return false, true
+	}
+	return planCheckRun.Result.GetApprovalInputVersion() == planApprovalInputVersion, false
+}
+
 // buildCELVariablesForDatabaseChange builds CEL variables for DATABASE_CHANGE issues.
 // This includes DDL and DML operations.
-func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store, issue *store.IssueMessage) ([]map[string]any, bool, error) {
+func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store, issue *store.IssueMessage) ([]map[string]any, int64, bool, error) {
 	if issue.PlanUID == nil {
-		return nil, false, errors.Errorf("expected plan UID in issue %v", issue.UID)
+		return nil, 0, false, errors.Errorf("expected plan UID in issue %v", issue.UID)
 	}
 	plan, err := stores.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "failed to get plan %v", *issue.PlanUID)
+		return nil, 0, false, errors.Wrapf(err, "failed to get plan %v", *issue.PlanUID)
 	}
 	if plan == nil {
-		return nil, false, errors.Errorf("plan %v not found", *issue.PlanUID)
+		return nil, 0, false, errors.Errorf("plan %v not found", *issue.PlanUID)
 	}
+	approvalInputVersion := plan.Config.GetApprovalInputVersion()
 
 	planCheckRun, err := stores.GetPlanCheckRun(ctx, issue.ProjectID, plan.UID)
 	if err != nil {
-		return nil, false, errors.Wrapf(err, "failed to get plan check run for plan %v", plan.UID)
+		return nil, approvalInputVersion, false, errors.Wrapf(err, "failed to get plan check run for plan %v", plan.UID)
 	}
 
-	// Wait for plan check to complete if available or running.
-	if isPlanCheckRunPendingApprovalEvaluation(planCheckRun) {
-		return nil, false, nil // Not ready yet, retry later
+	current, pending := isPlanCheckRunCurrentForApprovalInputVersion(planCheckRun, approvalInputVersion)
+	if pending {
+		return nil, approvalInputVersion, false, nil
+	}
+	if !current {
+		refreshed, err := stores.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, issue.ProjectID, plan.UID, approvalInputVersion)
+		if err != nil {
+			slog.Error("failed to refresh stale plan check run for approval input version",
+				slog.String("project", issue.ProjectID),
+				slog.Int64("issue_uid", issue.UID),
+				slog.Int64("plan_uid", plan.UID),
+				slog.Int64("approval_input_version", approvalInputVersion),
+				log.BBError(err))
+			return nil, approvalInputVersion, false, errors.Wrap(err, "failed to refresh stale plan check run for approval input version")
+		}
+		_ = refreshed
+		return nil, approvalInputVersion, false, nil
 	}
 
 	// Unfold database groups and get all targets
 	targets, err := unfoldSpecTargets(ctx, stores, plan.Config.GetSpecs(), issue.ProjectID)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "failed to unfold spec targets")
+		return nil, approvalInputVersion, false, errors.Wrap(err, "failed to unfold spec targets")
 	}
 
 	statementSummaryResults := map[statementSummaryKey]*storepb.PlanCheckRunResult_Result{}
@@ -591,10 +629,10 @@ func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store
 		if target.sheetSha256 != "" {
 			sheet, err := stores.GetSheetFull(ctx, target.sheetSha256)
 			if err != nil {
-				return nil, true, errors.Wrapf(err, "failed to get statement in sheet %v", target.sheetSha256)
+				return nil, approvalInputVersion, true, errors.Wrapf(err, "failed to get statement in sheet %v", target.sheetSha256)
 			}
 			if sheet == nil {
-				return nil, true, errors.Errorf("sheet %v not found", target.sheetSha256)
+				return nil, approvalInputVersion, true, errors.Errorf("sheet %v not found", target.sheetSha256)
 			}
 			taskStatement = sheet.Statement
 		}
@@ -654,7 +692,7 @@ func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store
 		celVarsList = append(celVarsList, map[string]any{})
 	}
 
-	return celVarsList, true, nil
+	return celVarsList, approvalInputVersion, true, nil
 }
 
 // buildCELVariablesForDataExport builds CEL variables for DATABASE_EXPORT issues.

--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -628,6 +628,25 @@ func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store
 
 	if checksExpected {
 		if planCheckRun == nil {
+			// Some plans can reach approval without a durable check row, for example after
+			// legacy data import or a previous row creation failure. Waiting without a row
+			// leaves no work for the scheduler to claim.
+			_, err := stores.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+				ProjectID: issue.ProjectID,
+				PlanUID:   plan.UID,
+				Result: &storepb.PlanCheckRunResult{
+					ApprovalInputVersion: approvalInputVersion,
+				},
+			})
+			if err != nil {
+				slog.Error("failed to create missing plan check run for approval input version",
+					slog.String("project", issue.ProjectID),
+					slog.Int64("issue_uid", issue.UID),
+					slog.Int64("plan_uid", plan.UID),
+					slog.Int64("approval_input_version", approvalInputVersion),
+					log.BBError(err))
+				return nil, approvalInputVersion, false, errors.Wrap(err, "failed to create missing plan check run for approval input version")
+			}
 			return nil, approvalInputVersion, false, nil
 		}
 		if planCheckRun.Status == store.PlanCheckRunStatusAvailable || planCheckRun.Status == store.PlanCheckRunStatusRunning {

--- a/backend/runner/approval/runner_test.go
+++ b/backend/runner/approval/runner_test.go
@@ -1,6 +1,7 @@
 package approval
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -235,35 +236,76 @@ func TestBuildStatementSummaryResultMapUsesSheetSHA256(t *testing.T) {
 	}].GetSqlSummaryReport().GetAffectedRows())
 }
 
-func TestIsPlanCheckRunPendingApprovalEvaluation(t *testing.T) {
+func TestPlanChecksExpectedForApproval(t *testing.T) {
 	tests := []struct {
-		name         string
-		planCheckRun *store.PlanCheckRunMessage
-		want         bool
+		name string
+		plan *store.PlanMessage
+		want bool
 	}{
 		{
-			name:         "nil plan check run is ready to evaluate",
-			planCheckRun: nil,
+			name: "create database does not expect checks",
+			plan: &store.PlanMessage{
+				ProjectID: "project",
+				Config: &storepb.PlanConfig{
+					Specs: []*storepb.PlanConfig_Spec{{
+						Config: &storepb.PlanConfig_Spec_CreateDatabaseConfig{
+							CreateDatabaseConfig: &storepb.PlanConfig_CreateDatabaseConfig{},
+						},
+					}},
+				},
+			},
 		},
 		{
-			name:         "AVAILABLE is not ready",
-			planCheckRun: &store.PlanCheckRunMessage{Status: store.PlanCheckRunStatusAvailable},
-			want:         true,
+			name: "release backed change does not expect checks",
+			plan: &store.PlanMessage{
+				ProjectID: "project",
+				Config: &storepb.PlanConfig{
+					Specs: []*storepb.PlanConfig_Spec{{
+						Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+							ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+								Release: "projects/project/releases/release",
+							},
+						},
+					}},
+				},
+			},
 		},
 		{
-			name:         "RUNNING is not ready",
-			planCheckRun: &store.PlanCheckRunMessage{Status: store.PlanCheckRunStatusRunning},
-			want:         true,
+			name: "empty expanded targets do not expect checks",
+			plan: &store.PlanMessage{
+				ProjectID: "project",
+				Config: &storepb.PlanConfig{
+					Specs: []*storepb.PlanConfig_Spec{{
+						Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+							ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{},
+						},
+					}},
+				},
+			},
 		},
 		{
-			name:         "DONE is ready",
-			planCheckRun: &store.PlanCheckRunMessage{Status: store.PlanCheckRunStatusDone},
+			name: "change target expects checks",
+			plan: &store.PlanMessage{
+				ProjectID: "project",
+				Config: &storepb.PlanConfig{
+					Specs: []*storepb.PlanConfig_Spec{{
+						Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+							ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+								Targets: []string{"instances/prod/databases/app"},
+							},
+						},
+					}},
+				},
+			},
+			want: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, isPlanCheckRunPendingApprovalEvaluation(tt.planCheckRun))
+			got, err := planChecksExpectedForApproval(context.Background(), nil, &store.ProjectMessage{ResourceID: "project"}, tt.plan)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/backend/runner/approval/runner_test.go
+++ b/backend/runner/approval/runner_test.go
@@ -267,3 +267,63 @@ func TestIsPlanCheckRunPendingApprovalEvaluation(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPlanCheckRunCurrentForApprovalInputVersion(t *testing.T) {
+	tests := []struct {
+		name         string
+		planVersion  int64
+		planCheckRun *store.PlanCheckRunMessage
+		wantCurrent  bool
+		wantPending  bool
+	}{
+		{
+			name:         "nil run waits for plan check",
+			planVersion:  0,
+			planCheckRun: nil,
+			wantPending:  true,
+		},
+		{
+			name:        "available run is pending",
+			planVersion: 2,
+			planCheckRun: &store.PlanCheckRunMessage{
+				Status: store.PlanCheckRunStatusAvailable,
+				Result: &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+			},
+			wantPending: true,
+		},
+		{
+			name:        "done matching version is current",
+			planVersion: 2,
+			planCheckRun: &store.PlanCheckRunMessage{
+				Status: store.PlanCheckRunStatusDone,
+				Result: &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+			},
+			wantCurrent: true,
+		},
+		{
+			name:        "done stale version is not current",
+			planVersion: 2,
+			planCheckRun: &store.PlanCheckRunMessage{
+				Status: store.PlanCheckRunStatusDone,
+				Result: &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+			},
+		},
+		{
+			name:        "missing result defaults to version zero",
+			planVersion: 0,
+			planCheckRun: &store.PlanCheckRunMessage{
+				Status: store.PlanCheckRunStatusDone,
+				Result: &storepb.PlanCheckRunResult{},
+			},
+			wantCurrent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			current, pending := isPlanCheckRunCurrentForApprovalInputVersion(tt.planCheckRun, tt.planVersion)
+			require.Equal(t, tt.wantCurrent, current)
+			require.Equal(t, tt.wantPending, pending)
+		})
+	}
+}

--- a/backend/runner/approval/runner_test.go
+++ b/backend/runner/approval/runner_test.go
@@ -292,6 +292,15 @@ func TestIsPlanCheckRunCurrentForApprovalInputVersion(t *testing.T) {
 			wantPending: true,
 		},
 		{
+			name:        "running run is pending",
+			planVersion: 2,
+			planCheckRun: &store.PlanCheckRunMessage{
+				Status: store.PlanCheckRunStatusRunning,
+				Result: &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+			},
+			wantPending: true,
+		},
+		{
 			name:        "done matching version is current",
 			planVersion: 2,
 			planCheckRun: &store.PlanCheckRunMessage{

--- a/backend/runner/approval/runner_test.go
+++ b/backend/runner/approval/runner_test.go
@@ -2,13 +2,16 @@ package approval
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/expr"
 
 	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -377,4 +380,75 @@ func TestIsPlanCheckRunCurrentForApprovalInputVersion(t *testing.T) {
 			require.Equal(t, tt.wantPending, pending)
 		})
 	}
+}
+
+func TestBuildCELVariablesForDatabaseChangeCreatesMissingPlanCheckRun(t *testing.T) {
+	ctx := context.Background()
+	s := setupApprovalRunnerStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config: &storepb.PlanConfig{
+			ApprovalInputVersion: 2,
+			Specs: []*storepb.PlanConfig_Spec{{
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{"instances/prod/databases/app"},
+					},
+				},
+			}},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	issue, err := s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "issue-a",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Description:  "",
+		Payload:      &storepb.Issue{},
+		PlanUID:      &plan.UID,
+	})
+	require.NoError(t, err)
+
+	celVarsList, approvalInputVersion, done, err := buildCELVariablesForDatabaseChange(ctx, s, issue)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Nil(t, celVarsList)
+	require.EqualValues(t, 2, approvalInputVersion)
+
+	planCheckRun, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, planCheckRun)
+	require.Equal(t, store.PlanCheckRunStatusAvailable, planCheckRun.Status)
+	require.EqualValues(t, 2, planCheckRun.Result.GetApprovalInputVersion())
+}
+
+func setupApprovalRunnerStore(ctx context.Context, t *testing.T) *store.Store {
+	t.Helper()
+
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	return s
 }

--- a/backend/runner/notifylistener/listener.go
+++ b/backend/runner/notifylistener/listener.go
@@ -90,7 +90,7 @@ func (l *Listener) handleNotification(payload string) {
 
 	switch signal.Type {
 	case storepb.Signal_CANCEL_PLAN_CHECK_RUN:
-		ref := bus.PlanCheckRunRef{ProjectID: signal.Project, UID: signal.Uid}
+		ref := bus.PlanCheckRunRef{ProjectID: signal.Project, UID: signal.Uid, ApprovalInputVersion: signal.ApprovalInputVersion}
 		if cancel, ok := l.bus.RunningPlanCheckRunsCancelFunc.Load(ref); ok {
 			cancel.(context.CancelFunc)()
 		}

--- a/backend/runner/plancheck/scheduler.go
+++ b/backend/runner/plancheck/scheduler.go
@@ -115,6 +115,7 @@ func (s *Scheduler) runPlanCheckRun(ctx context.Context, projectID string, uid i
 			slog.Int64("plan_check_run_id", uid),
 			slog.Int64("claimed_approval_input_version", approvalInputVersion),
 			slog.Int64("current_approval_input_version", plan.Config.GetApprovalInputVersion()))
+		s.markPlanCheckRunCanceled(ctxWithCancel, projectID, uid, approvalInputVersion, "stale plan check run")
 		return
 	}
 

--- a/backend/runner/plancheck/scheduler.go
+++ b/backend/runner/plancheck/scheduler.go
@@ -86,11 +86,11 @@ func (s *Scheduler) runOnce(ctx context.Context) {
 	}
 
 	for _, c := range claimed {
-		go s.runPlanCheckRun(ctx, c.ProjectID, c.UID, c.PlanUID)
+		go s.runPlanCheckRun(ctx, c.ProjectID, c.UID, c.PlanUID, c.ApprovalInputVersion)
 	}
 }
 
-func (s *Scheduler) runPlanCheckRun(ctx context.Context, projectID string, uid int64, planUID int64) {
+func (s *Scheduler) runPlanCheckRun(ctx context.Context, projectID string, uid int64, planUID int64, approvalInputVersion int64) {
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	defer cancel()
 	planCheckRef := bus.PlanCheckRunRef{ProjectID: projectID, UID: uid}
@@ -100,35 +100,45 @@ func (s *Scheduler) runPlanCheckRun(ctx context.Context, projectID string, uid i
 	// Fetch plan to derive check targets at runtime
 	plan, err := s.store.GetPlan(ctxWithCancel, &store.FindPlanMessage{ProjectID: projectID, UID: &planUID})
 	if err != nil {
-		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, err.Error())
+		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, approvalInputVersion, err.Error())
 		return
 	}
 	if plan == nil {
-		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, "plan not found")
+		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, approvalInputVersion, "plan not found")
+		return
+	}
+
+	if plan.Config.GetApprovalInputVersion() != approvalInputVersion {
+		slog.Info("skip stale plan check run",
+			slog.String("project", projectID),
+			slog.Int64("plan_id", planUID),
+			slog.Int64("plan_check_run_id", uid),
+			slog.Int64("claimed_approval_input_version", approvalInputVersion),
+			slog.Int64("current_approval_input_version", plan.Config.GetApprovalInputVersion()))
 		return
 	}
 
 	project, err := s.store.GetProjectByResourceID(ctxWithCancel, plan.ProjectID)
 	if err != nil {
-		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, err.Error())
+		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, approvalInputVersion, err.Error())
 		return
 	}
 	if project == nil {
-		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, "project not found")
+		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, approvalInputVersion, "project not found")
 		return
 	}
 
 	// Get database group if needed (for spec expansion)
 	databaseGroup, err := s.getDatabaseGroupForPlan(ctxWithCancel, plan)
 	if err != nil {
-		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, err.Error())
+		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, approvalInputVersion, err.Error())
 		return
 	}
 
 	// Derive check targets from plan
 	targets, err := DeriveCheckTargets(ctxWithCancel, s.store, project, plan, databaseGroup)
 	if err != nil {
-		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, err.Error())
+		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, approvalInputVersion, err.Error())
 		return
 	}
 
@@ -143,26 +153,37 @@ func (s *Scheduler) runPlanCheckRun(ctx context.Context, projectID string, uid i
 	}
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			s.markPlanCheckRunCanceled(ctxWithCancel, projectID, uid, err.Error())
+			s.markPlanCheckRunCanceled(ctxWithCancel, projectID, uid, approvalInputVersion, err.Error())
 		} else {
-			s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, err.Error())
+			s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, approvalInputVersion, err.Error())
 		}
 	} else {
-		s.markPlanCheckRunDone(ctxWithCancel, projectID, uid, planUID, results)
+		s.markPlanCheckRunDone(ctxWithCancel, projectID, uid, planUID, approvalInputVersion, results)
 	}
 }
 
-func (s *Scheduler) markPlanCheckRunDone(ctx context.Context, projectID string, uid int64, planUID int64, results []*storepb.PlanCheckRunResult_Result) {
+func (s *Scheduler) markPlanCheckRunDone(ctx context.Context, projectID string, uid int64, planUID int64, approvalInputVersion int64, results []*storepb.PlanCheckRunResult_Result) {
 	result := &storepb.PlanCheckRunResult{
-		Results: results,
+		Results:              results,
+		ApprovalInputVersion: approvalInputVersion,
 	}
-	if err := s.store.UpdatePlanCheckRun(ctx,
+	updated, err := s.store.UpdatePlanCheckRunIfApprovalInputVersion(ctx,
 		projectID,
 		store.PlanCheckRunStatusDone,
 		result,
 		uid,
-	); err != nil {
+		approvalInputVersion,
+	)
+	if err != nil {
 		slog.Error("failed to mark plan check run done", log.BBError(err))
+		return
+	}
+	if !updated {
+		slog.Info("skip stale plan check run done update",
+			slog.String("project", projectID),
+			slog.Int64("plan_id", planUID),
+			slog.Int64("plan_check_run_id", uid),
+			slog.Int64("claimed_approval_input_version", approvalInputVersion))
 		return
 	}
 
@@ -181,31 +202,51 @@ func (s *Scheduler) markPlanCheckRunDone(ctx context.Context, projectID string, 
 	}
 }
 
-func (s *Scheduler) markPlanCheckRunFailed(ctx context.Context, projectID string, uid int64, reason string) {
+func (s *Scheduler) markPlanCheckRunFailed(ctx context.Context, projectID string, uid int64, approvalInputVersion int64, reason string) {
 	result := &storepb.PlanCheckRunResult{
-		Error: reason,
+		Error:                reason,
+		ApprovalInputVersion: approvalInputVersion,
 	}
-	if err := s.store.UpdatePlanCheckRun(ctx,
+	updated, err := s.store.UpdatePlanCheckRunIfApprovalInputVersion(ctx,
 		projectID,
 		store.PlanCheckRunStatusFailed,
 		result,
 		uid,
-	); err != nil {
+		approvalInputVersion,
+	)
+	if err != nil {
 		slog.Error("failed to mark plan check run failed", log.BBError(err))
+		return
+	}
+	if !updated {
+		slog.Info("skip stale plan check run failed update",
+			slog.String("project", projectID),
+			slog.Int64("plan_check_run_id", uid),
+			slog.Int64("claimed_approval_input_version", approvalInputVersion))
 	}
 }
 
-func (s *Scheduler) markPlanCheckRunCanceled(ctx context.Context, projectID string, uid int64, reason string) {
+func (s *Scheduler) markPlanCheckRunCanceled(ctx context.Context, projectID string, uid int64, approvalInputVersion int64, reason string) {
 	result := &storepb.PlanCheckRunResult{
-		Error: reason,
+		Error:                reason,
+		ApprovalInputVersion: approvalInputVersion,
 	}
-	if err := s.store.UpdatePlanCheckRun(ctx,
+	updated, err := s.store.UpdatePlanCheckRunIfApprovalInputVersion(ctx,
 		projectID,
 		store.PlanCheckRunStatusCanceled,
 		result,
 		uid,
-	); err != nil {
+		approvalInputVersion,
+	)
+	if err != nil {
 		slog.Error("failed to mark plan check run canceled", log.BBError(err))
+		return
+	}
+	if !updated {
+		slog.Info("skip stale plan check run canceled update",
+			slog.String("project", projectID),
+			slog.Int64("plan_check_run_id", uid),
+			slog.Int64("claimed_approval_input_version", approvalInputVersion))
 	}
 }
 

--- a/backend/runner/plancheck/scheduler.go
+++ b/backend/runner/plancheck/scheduler.go
@@ -93,7 +93,7 @@ func (s *Scheduler) runOnce(ctx context.Context) {
 func (s *Scheduler) runPlanCheckRun(ctx context.Context, projectID string, uid int64, planUID int64, approvalInputVersion int64) {
 	ctxWithCancel, cancel := context.WithCancel(ctx)
 	defer cancel()
-	planCheckRef := bus.PlanCheckRunRef{ProjectID: projectID, UID: uid}
+	planCheckRef := bus.PlanCheckRunRef{ProjectID: projectID, UID: uid, ApprovalInputVersion: approvalInputVersion}
 	s.bus.RunningPlanCheckRunsCancelFunc.Store(planCheckRef, cancel)
 	defer s.bus.RunningPlanCheckRunsCancelFunc.Delete(planCheckRef)
 

--- a/backend/runner/taskrun/rollout_creator.go
+++ b/backend/runner/taskrun/rollout_creator.go
@@ -146,8 +146,8 @@ func (rc *RolloutCreator) tryCreateRollout(ctx context.Context, ref bus.PlanRef)
 		return
 	}
 
-	// If plan checks exist, they must be DONE with no errors
-	if planCheckRun != nil {
+	// If current plan checks exist, they must be DONE with no errors.
+	if planCheckRunBlocksRollout(plan, planCheckRun) {
 		// Check if plan checks are in DONE status
 		if planCheckRun.Status != store.PlanCheckRunStatusDone {
 			slog.Debug("plan checks not in DONE status, skipping rollout creation",
@@ -187,6 +187,13 @@ func (rc *RolloutCreator) tryCreateRollout(ctx context.Context, ref bus.PlanRef)
 	rc.bus.TaskRunTickleChan <- 0
 
 	slog.Info("successfully auto-created rollout", slog.String("project", ref.ProjectID), slog.Int("plan_id", int(planID)))
+}
+
+func planCheckRunBlocksRollout(plan *store.PlanMessage, planCheckRun *store.PlanCheckRunMessage) bool {
+	if planCheckRun == nil {
+		return false
+	}
+	return planCheckRun.Result.GetApprovalInputVersion() == plan.Config.GetApprovalInputVersion()
 }
 
 // hasOnlyChangeDatabaseSpecs checks if every spec in the plan is a change database spec.

--- a/backend/runner/taskrun/rollout_creator.go
+++ b/backend/runner/taskrun/rollout_creator.go
@@ -121,7 +121,7 @@ func (rc *RolloutCreator) tryCreateRollout(ctx context.Context, ref bus.PlanRef)
 	}
 
 	// Check approval status (must be approved)
-	approved, err := utils.CheckIssueApproved(issue)
+	approved, err := utils.CheckIssueApprovedForPlan(issue, plan)
 	if err != nil {
 		slog.Error("failed to check if the issue is approved",
 			slog.String("project", ref.ProjectID),

--- a/backend/runner/taskrun/rollout_creator.go
+++ b/backend/runner/taskrun/rollout_creator.go
@@ -176,6 +176,12 @@ func (rc *RolloutCreator) tryCreateRollout(ctx context.Context, ref bus.PlanRef)
 	// Create rollout and pending tasks
 	// Use issue creator's email since this is auto-rollout for their issue
 	if err := apiv1.CreateRolloutAndPendingTasks(ctx, rc.store, issue.CreatorEmail, plan, issue, project, nil); err != nil {
+		if apiv1.IsStaleRolloutApprovalError(err) {
+			slog.Info("skip auto-rollout because issue approval is stale",
+				slog.String("project", ref.ProjectID),
+				slog.Int("plan_id", int(planID)))
+			return
+		}
 		slog.Error("failed to create rollout and pending tasks",
 			slog.String("project", ref.ProjectID),
 			slog.Int("plan_id", int(planID)),

--- a/backend/runner/taskrun/rollout_creator_test.go
+++ b/backend/runner/taskrun/rollout_creator_test.go
@@ -1,0 +1,26 @@
+package taskrun
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestPlanCheckRunBlocksRolloutIgnoresStaleVersion(t *testing.T) {
+	plan := &store.PlanMessage{
+		Config: &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}
+
+	require.False(t, planCheckRunBlocksRollout(plan, nil))
+	require.False(t, planCheckRunBlocksRollout(plan, &store.PlanCheckRunMessage{
+		Status: store.PlanCheckRunStatusRunning,
+		Result: &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	}))
+	require.True(t, planCheckRunBlocksRollout(plan, &store.PlanCheckRunMessage{
+		Status: store.PlanCheckRunStatusRunning,
+		Result: &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	}))
+}

--- a/backend/store/issue.go
+++ b/backend/store/issue.go
@@ -310,6 +310,45 @@ func (s *Store) UpdateIssuePayloadIfPlanApprovalInputVersion(ctx context.Context
 	return rowsAffected > 0, nil
 }
 
+// UpdateIssuePayloadIfCurrentApprovalInputVersion updates the issue payload only when both the issue approval payload
+// and its plan still match the observed approval input version.
+func (s *Store) UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx context.Context, projectID string, uid int64, payload *storepb.Issue, approvalInputVersion int64) (bool, error) {
+	p, err := protojson.Marshal(payload)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to marshal payload")
+	}
+
+	q := qb.Q().Space(`
+		UPDATE issue
+		SET
+			updated_at = ?,
+			payload = payload || ?
+		WHERE project = ?
+		  AND id = ?
+		  AND COALESCE((payload->'approval'->>'approvalInputVersion')::bigint, 0) = ?
+		  AND EXISTS (
+			SELECT 1
+			FROM plan
+			WHERE plan.project = issue.project
+			  AND plan.id = issue.plan_id
+			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = ?
+		  )`, time.Now(), p, projectID, uid, approvalInputVersion, approvalInputVersion)
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to build sql")
+	}
+	result, err := s.GetDB().ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to inspect issue update")
+	}
+	return rowsAffected > 0, nil
+}
+
 // ListIssues returns the list of issues by find query.
 func (s *Store) ListIssues(ctx context.Context, find *FindIssueMessage) ([]*IssueMessage, error) {
 	orderByClause := "ORDER BY issue.id DESC"

--- a/backend/store/issue.go
+++ b/backend/store/issue.go
@@ -274,6 +274,42 @@ func (s *Store) UpdateIssue(ctx context.Context, projectID string, uid int64, pa
 	return s.GetIssue(ctx, &FindIssueMessage{ProjectIDs: []string{projectID}, UID: &uid})
 }
 
+func (s *Store) UpdateIssuePayloadIfPlanApprovalInputVersion(ctx context.Context, projectID string, uid int64, payload *storepb.Issue, approvalInputVersion int64) (bool, error) {
+	p, err := protojson.Marshal(payload)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to marshal payload")
+	}
+
+	q := qb.Q().Space(`
+		UPDATE issue
+		SET
+			updated_at = ?,
+			payload = payload || ?
+		WHERE project = ?
+		  AND id = ?
+		  AND EXISTS (
+			SELECT 1
+			FROM plan
+			WHERE plan.project = issue.project
+			  AND plan.id = issue.plan_id
+			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = ?
+		  )`, time.Now(), p, projectID, uid, approvalInputVersion)
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to build sql")
+	}
+	result, err := s.GetDB().ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to inspect issue update")
+	}
+	return rowsAffected > 0, nil
+}
+
 // ListIssues returns the list of issues by find query.
 func (s *Store) ListIssues(ctx context.Context, find *FindIssueMessage) ([]*IssueMessage, error) {
 	orderByClause := "ORDER BY issue.id DESC"

--- a/backend/store/issue.go
+++ b/backend/store/issue.go
@@ -310,6 +310,55 @@ func (s *Store) UpdateIssuePayloadIfPlanApprovalInputVersion(ctx context.Context
 	return rowsAffected > 0, nil
 }
 
+// ResetIssueApprovalFindingIfPlanApprovalInputVersion avoids clobbering approval work that raced
+// ahead after a new plan check row became visible for the same plan version.
+func (s *Store) ResetIssueApprovalFindingIfPlanApprovalInputVersion(ctx context.Context, projectID string, uid int64, approvalInputVersion int64) (bool, error) {
+	payload := &storepb.Issue{
+		Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  false,
+			ApprovalInputVersion: approvalInputVersion,
+		},
+	}
+	p, err := protojson.Marshal(payload)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to marshal payload")
+	}
+
+	q := qb.Q().Space(`
+		UPDATE issue
+		SET
+			updated_at = ?,
+			payload = payload || ?
+		WHERE project = ?
+		  AND id = ?
+		  AND EXISTS (
+			SELECT 1
+			FROM plan
+			WHERE plan.project = issue.project
+			  AND plan.id = issue.plan_id
+			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = ?
+		  )
+		  AND NOT (
+			COALESCE((payload->'approval'->>'approvalFindingDone')::boolean, false)
+			AND COALESCE((payload->'approval'->>'approvalInputVersion')::bigint, 0) = ?
+		  )`,
+		time.Now(), p, projectID, uid, approvalInputVersion, approvalInputVersion)
+
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to build sql")
+	}
+	result, err := s.GetDB().ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to inspect issue approval reset")
+	}
+	return rowsAffected > 0, nil
+}
+
 // UpdateIssuePayloadIfCurrentApprovalInputVersion updates the issue payload only when both the issue approval payload
 // and its plan still match the observed approval input version.
 func (s *Store) UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx context.Context, projectID string, uid int64, payload *storepb.Issue, approvalInputVersion int64) (bool, error) {

--- a/backend/store/plan.go
+++ b/backend/store/plan.go
@@ -62,7 +62,8 @@ type UpdatePlanMessage struct {
 	// BumpApprovalInputVersion increments config.approvalInputVersion from the
 	// current stored row while applying Config as a full replacement. Use this
 	// only for approval-relevant full config replacements such as spec updates.
-	// This flag is not a partial JSONB patch mechanism for unrelated config fields.
+	// Such updates are pre-rollout input changes, so the store rejects them once
+	// rollout marking has won the race.
 	BumpApprovalInputVersion bool
 	Deleted                  *bool
 }
@@ -242,9 +243,14 @@ func (s *Store) UpdatePlan(ctx context.Context, patch *UpdatePlanMessage) (*Plan
 		}
 	}
 
-	q := qb.Q().Space(`UPDATE plan SET ? WHERE id = ? AND project = ?
+	where := qb.Q().Space("id = ? AND project = ?", patch.UID, patch.ProjectID)
+	if patch.BumpApprovalInputVersion {
+		where.Space("AND COALESCE((config->>'hasRollout')::boolean, false) = false")
+	}
+
+	q := qb.Q().Space(`UPDATE plan SET ? WHERE ?
 		RETURNING id, creator, created_at, updated_at, project, name, description, config, deleted`,
-		set, patch.UID, patch.ProjectID)
+		set, where)
 
 	query, finalArgs, err := q.ToSQL()
 	if err != nil {

--- a/backend/store/plan.go
+++ b/backend/store/plan.go
@@ -62,10 +62,13 @@ type UpdatePlanMessage struct {
 	// BumpApprovalInputVersion increments config.approvalInputVersion from the
 	// current stored row while applying Config as a full replacement. Use this
 	// only for approval-relevant full config replacements such as spec updates.
-	// Such updates are pre-rollout input changes, so the store rejects them once
-	// rollout marking has won the race.
 	BumpApprovalInputVersion bool
-	Deleted                  *bool
+	// RequireNoRollout rejects full config replacements once rollout marking has
+	// won the race. This is separate from BumpApprovalInputVersion because the
+	// user-visible invariant is about spec immutability after rollout, including
+	// spec edits that do not otherwise affect approval input.
+	RequireNoRollout bool
+	Deleted          *bool
 }
 
 // CreatePlan creates a new plan.
@@ -244,7 +247,7 @@ func (s *Store) UpdatePlan(ctx context.Context, patch *UpdatePlanMessage) (*Plan
 	}
 
 	where := qb.Q().Space("id = ? AND project = ?", patch.UID, patch.ProjectID)
-	if patch.BumpApprovalInputVersion {
+	if patch.RequireNoRollout {
 		where.Space("AND COALESCE((config->>'hasRollout')::boolean, false) = false")
 	}
 

--- a/backend/store/plan.go
+++ b/backend/store/plan.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"time"
 
@@ -17,6 +18,9 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 )
+
+// ErrPlanHasRollout indicates that a plan update was rejected because rollout already started.
+var ErrPlanHasRollout = errors.New("plan has rollout")
 
 // PlanMessage is the message for plan.
 type PlanMessage struct {
@@ -275,6 +279,9 @@ func (s *Store) UpdatePlan(ctx context.Context, patch *UpdatePlanMessage) (*Plan
 		&config,
 		&plan.Deleted,
 	); err != nil {
+		if patch.RequireNoRollout && errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrPlanHasRollout
+		}
 		return nil, errors.Wrapf(err, "failed to update plan")
 	}
 	if err := common.ProtojsonUnmarshaler.Unmarshal(config, plan.Config); err != nil {

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -246,6 +246,99 @@ func TestUpdateIssuePayloadIfPlanApprovalInputVersionSkipsIssueWithoutPlan(t *te
 	require.Nil(t, got.Payload.GetApproval())
 }
 
+func TestUpdateIssuePayloadIfCurrentApprovalInputVersionUpdatesMatchingVersion(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	issue, err := s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "issue-a",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Description:  "",
+		Payload: &storepb.Issue{
+			RiskLevel: storepb.RiskLevel_LOW,
+			Approval: &storepb.IssuePayloadApproval{
+				ApprovalFindingDone:  true,
+				ApprovalInputVersion: 2,
+			},
+		},
+		PlanUID: &plan.UID,
+	})
+	require.NoError(t, err)
+
+	updated, err := s.UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx, "project-a", issue.UID, &storepb.Issue{
+		RiskLevel: storepb.RiskLevel_HIGH,
+		Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: 2,
+		},
+	}, 2)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	got, err := s.GetIssue(ctx, &store.FindIssueMessage{ProjectIDs: []string{"project-a"}, UID: &issue.UID})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, storepb.RiskLevel_HIGH, got.Payload.GetRiskLevel())
+	require.True(t, got.Payload.GetApproval().GetApprovalFindingDone())
+	require.EqualValues(t, 2, got.Payload.GetApproval().GetApprovalInputVersion())
+}
+
+func TestUpdateIssuePayloadIfCurrentApprovalInputVersionSkipsStaleIssueApprovalVersion(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	issue, err := s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "issue-a",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Description:  "",
+		Payload: &storepb.Issue{
+			RiskLevel: storepb.RiskLevel_LOW,
+			Approval: &storepb.IssuePayloadApproval{
+				ApprovalFindingDone:  true,
+				ApprovalInputVersion: 1,
+			},
+		},
+		PlanUID: &plan.UID,
+	})
+	require.NoError(t, err)
+
+	updated, err := s.UpdateIssuePayloadIfCurrentApprovalInputVersion(ctx, "project-a", issue.UID, &storepb.Issue{
+		RiskLevel: storepb.RiskLevel_HIGH,
+		Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: 1,
+		},
+	}, 2)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	got, err := s.GetIssue(ctx, &store.FindIssueMessage{ProjectIDs: []string{"project-a"}, UID: &issue.UID})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, storepb.RiskLevel_LOW, got.Payload.GetRiskLevel())
+	require.EqualValues(t, 1, got.Payload.GetApproval().GetApprovalInputVersion())
+}
+
 func requirePlanSpecID(t *testing.T, config *storepb.PlanConfig, id string) {
 	t.Helper()
 	require.Len(t, config.GetSpecs(), 1)

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -97,6 +97,117 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	requirePlanSpecID(t, updated.Config, "spec-e")
 }
 
+func TestUpdateIssuePayloadIfPlanApprovalInputVersionUpdatesMatchingVersion(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	issue, err := s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "issue-a",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Description:  "",
+		Payload:      &storepb.Issue{RiskLevel: storepb.RiskLevel_LOW},
+		PlanUID:      &plan.UID,
+	})
+	require.NoError(t, err)
+
+	updated, err := s.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, "project-a", issue.UID, &storepb.Issue{
+		RiskLevel: storepb.RiskLevel_HIGH,
+		Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: 2,
+		},
+	}, 2)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	got, err := s.GetIssue(ctx, &store.FindIssueMessage{ProjectIDs: []string{"project-a"}, UID: &issue.UID})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, storepb.RiskLevel_HIGH, got.Payload.GetRiskLevel())
+	require.True(t, got.Payload.GetApproval().GetApprovalFindingDone())
+	require.EqualValues(t, 2, got.Payload.GetApproval().GetApprovalInputVersion())
+}
+
+func TestUpdateIssuePayloadIfPlanApprovalInputVersionSkipsStaleVersion(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	issue, err := s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "issue-a",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Description:  "",
+		Payload:      &storepb.Issue{RiskLevel: storepb.RiskLevel_LOW},
+		PlanUID:      &plan.UID,
+	})
+	require.NoError(t, err)
+
+	updated, err := s.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, "project-a", issue.UID, &storepb.Issue{
+		RiskLevel: storepb.RiskLevel_HIGH,
+		Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: 1,
+		},
+	}, 1)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	got, err := s.GetIssue(ctx, &store.FindIssueMessage{ProjectIDs: []string{"project-a"}, UID: &issue.UID})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, storepb.RiskLevel_LOW, got.Payload.GetRiskLevel())
+	require.Nil(t, got.Payload.GetApproval())
+}
+
+func TestUpdateIssuePayloadIfPlanApprovalInputVersionSkipsIssueWithoutPlan(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	issue, err := s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "issue-a",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Description:  "",
+		Payload:      &storepb.Issue{RiskLevel: storepb.RiskLevel_LOW},
+	})
+	require.NoError(t, err)
+
+	updated, err := s.UpdateIssuePayloadIfPlanApprovalInputVersion(ctx, "project-a", issue.UID, &storepb.Issue{
+		RiskLevel: storepb.RiskLevel_HIGH,
+		Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone: true,
+		},
+	}, 0)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	got, err := s.GetIssue(ctx, &store.FindIssueMessage{ProjectIDs: []string{"project-a"}, UID: &issue.UID})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, storepb.RiskLevel_LOW, got.Payload.GetRiskLevel())
+	require.Nil(t, got.Payload.GetApproval())
+}
+
 func requirePlanSpecID(t *testing.T, config *storepb.PlanConfig, id string) {
 	t.Helper()
 	require.Len(t, config.GetSpecs(), 1)

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -284,6 +284,47 @@ func TestUpdateIssuePayloadIfPlanApprovalInputVersionSkipsIssueWithoutPlan(t *te
 	require.Nil(t, got.Payload.GetApproval())
 }
 
+func TestResetIssueApprovalFindingIfPlanApprovalInputVersionSkipsCurrentDoneApproval(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	issue, err := s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "issue-a",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Description:  "",
+		Payload: &storepb.Issue{
+			RiskLevel: storepb.RiskLevel_HIGH,
+			Approval: &storepb.IssuePayloadApproval{
+				ApprovalFindingDone:  true,
+				ApprovalInputVersion: 2,
+			},
+		},
+		PlanUID: &plan.UID,
+	})
+	require.NoError(t, err)
+
+	updated, err := s.ResetIssueApprovalFindingIfPlanApprovalInputVersion(ctx, "project-a", issue.UID, 2)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	got, err := s.GetIssue(ctx, &store.FindIssueMessage{ProjectIDs: []string{"project-a"}, UID: &issue.UID})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, storepb.RiskLevel_HIGH, got.Payload.GetRiskLevel())
+	require.True(t, got.Payload.GetApproval().GetApprovalFindingDone())
+	require.EqualValues(t, 2, got.Payload.GetApproval().GetApprovalInputVersion())
+}
+
 func TestUpdateIssuePayloadIfCurrentApprovalInputVersionUpdatesMatchingVersion(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanApprovalInputVersionStore(ctx, t)

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -98,7 +98,7 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	requirePlanSpecID(t, updated.Config, "spec-e")
 }
 
-func TestCreateTasksIfPlanApprovalInputVersionMarksRollout(t *testing.T) {
+func TestCreateRolloutTasksRequiresMatchingApprovalInputVersion(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanApprovalInputVersionStore(ctx, t)
 
@@ -113,7 +113,8 @@ func TestCreateTasksIfPlanApprovalInputVersionMarksRollout(t *testing.T) {
 	}, "creator@example.com")
 	require.NoError(t, err)
 
-	updated, createdTasks, err := s.CreateTasksIfPlanApprovalInputVersion(ctx, "project-a", plan.UID, 1, nil)
+	staleVersion := int64(1)
+	updated, createdTasks, err := s.CreateRolloutTasks(ctx, "project-a", plan.UID, &staleVersion, nil)
 	require.NoError(t, err)
 	require.False(t, updated)
 	require.Empty(t, createdTasks)
@@ -124,7 +125,8 @@ func TestCreateTasksIfPlanApprovalInputVersionMarksRollout(t *testing.T) {
 	require.EqualValues(t, 2, got.Config.GetApprovalInputVersion())
 	requirePlanSpecID(t, got.Config, "spec-a")
 
-	updated, createdTasks, err = s.CreateTasksIfPlanApprovalInputVersion(ctx, "project-a", plan.UID, 2, nil)
+	currentVersion := int64(2)
+	updated, createdTasks, err = s.CreateRolloutTasks(ctx, "project-a", plan.UID, &currentVersion, nil)
 	require.NoError(t, err)
 	require.True(t, updated)
 	require.Empty(t, createdTasks)
@@ -136,7 +138,42 @@ func TestCreateTasksIfPlanApprovalInputVersionMarksRollout(t *testing.T) {
 	requirePlanSpecID(t, got.Config, "spec-a")
 }
 
-func TestUpdatePlanBumpApprovalInputVersionDoesNotOverwriteRollout(t *testing.T) {
+func TestCreateRolloutTasksAddsMissingTasksAfterRolloutExists(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 1},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	updated, createdTasks, err := s.CreateRolloutTasks(ctx, "project-a", plan.UID, nil, []*store.TaskMessage{
+		newTestRolloutTask("instance-a", "database-a", "sheet-a"),
+	})
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.Len(t, createdTasks, 1)
+
+	got, err := s.GetPlan(ctx, &store.FindPlanMessage{ProjectID: "project-a", UID: &plan.UID})
+	require.NoError(t, err)
+	require.True(t, got.Config.GetHasRollout())
+
+	updated, createdTasks, err = s.CreateRolloutTasks(ctx, "project-a", plan.UID, nil, []*store.TaskMessage{
+		newTestRolloutTask("instance-a", "database-a", "sheet-a"),
+		newTestRolloutTask("instance-a", "database-b", "sheet-b"),
+	})
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.Len(t, createdTasks, 1)
+	require.Equal(t, "instance-a", createdTasks[0].InstanceID)
+	require.Equal(t, "database-b", createdTasks[0].GetDatabaseName())
+	require.Equal(t, "sheet-b", createdTasks[0].Payload.GetSheetSha256())
+}
+
+func TestUpdatePlanRequireNoRolloutDoesNotOverwriteRollout(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanApprovalInputVersionStore(ctx, t)
 
@@ -154,7 +191,8 @@ func TestUpdatePlanBumpApprovalInputVersionDoesNotOverwriteRollout(t *testing.T)
 	staleConfig := proto.CloneOf(plan.Config)
 	staleConfig.Specs = []*storepb.PlanConfig_Spec{{Id: "spec-b"}}
 
-	marked, _, err := s.CreateTasksIfPlanApprovalInputVersion(ctx, "project-a", plan.UID, 1, nil)
+	approvalInputVersion := int64(1)
+	marked, _, err := s.CreateRolloutTasks(ctx, "project-a", plan.UID, &approvalInputVersion, nil)
 	require.NoError(t, err)
 	require.True(t, marked)
 
@@ -163,6 +201,45 @@ func TestUpdatePlanBumpApprovalInputVersionDoesNotOverwriteRollout(t *testing.T)
 		ProjectID:                "project-a",
 		Config:                   staleConfig,
 		BumpApprovalInputVersion: true,
+		RequireNoRollout:         true,
+	})
+	require.Error(t, err)
+
+	got, err := s.GetPlan(ctx, &store.FindPlanMessage{ProjectID: "project-a", UID: &plan.UID})
+	require.NoError(t, err)
+	require.True(t, got.Config.GetHasRollout())
+	require.EqualValues(t, 1, got.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, got.Config, "spec-a")
+}
+
+func TestUpdatePlanRequireNoRolloutRejectsConfigUpdateAfterRollout(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config: &storepb.PlanConfig{
+			ApprovalInputVersion: 1,
+			Specs:                []*storepb.PlanConfig_Spec{{Id: "spec-a"}},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	staleConfig := proto.CloneOf(plan.Config)
+	staleConfig.Specs = []*storepb.PlanConfig_Spec{{Id: "spec-b"}}
+
+	approvalInputVersion := int64(1)
+	marked, _, err := s.CreateRolloutTasks(ctx, "project-a", plan.UID, &approvalInputVersion, nil)
+	require.NoError(t, err)
+	require.True(t, marked)
+
+	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:              plan.UID,
+		ProjectID:        "project-a",
+		Config:           staleConfig,
+		RequireNoRollout: true,
 	})
 	require.Error(t, err)
 
@@ -424,6 +501,19 @@ func requirePlanSpecID(t *testing.T, config *storepb.PlanConfig, id string) {
 	require.Equal(t, id, config.GetSpecs()[0].GetId())
 }
 
+func newTestRolloutTask(instanceID string, databaseName string, sheetSha256 string) *store.TaskMessage {
+	return &store.TaskMessage{
+		InstanceID:   instanceID,
+		DatabaseName: &databaseName,
+		Type:         storepb.Task_DATABASE_MIGRATE,
+		Payload: &storepb.Task{
+			Source: &storepb.Task_SheetSha256{
+				SheetSha256: sheetSha256,
+			},
+		},
+	}
+}
+
 func setupPlanApprovalInputVersionStore(ctx context.Context, t *testing.T) *store.Store {
 	t.Helper()
 
@@ -437,6 +527,7 @@ func setupPlanApprovalInputVersionStore(ctx context.Context, t *testing.T) *stor
 		INSERT INTO workspace (resource_id) VALUES ('default');
 		INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused');
 		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
+		INSERT INTO instance (resource_id, workspace) VALUES ('instance-a', 'default');
 	`)
 	require.NoError(t, err)
 

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -132,6 +133,43 @@ func TestCreateTasksIfPlanApprovalInputVersionMarksRollout(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, got.Config.GetHasRollout())
 	require.EqualValues(t, 2, got.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, got.Config, "spec-a")
+}
+
+func TestUpdatePlanBumpApprovalInputVersionDoesNotOverwriteRollout(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config: &storepb.PlanConfig{
+			ApprovalInputVersion: 1,
+			Specs:                []*storepb.PlanConfig_Spec{{Id: "spec-a"}},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	staleConfig := proto.CloneOf(plan.Config)
+	staleConfig.Specs = []*storepb.PlanConfig_Spec{{Id: "spec-b"}}
+
+	marked, _, err := s.CreateTasksIfPlanApprovalInputVersion(ctx, "project-a", plan.UID, 1, nil)
+	require.NoError(t, err)
+	require.True(t, marked)
+
+	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:                      plan.UID,
+		ProjectID:                "project-a",
+		Config:                   staleConfig,
+		BumpApprovalInputVersion: true,
+	})
+	require.Error(t, err)
+
+	got, err := s.GetPlan(ctx, &store.FindPlanMessage{ProjectID: "project-a", UID: &plan.UID})
+	require.NoError(t, err)
+	require.True(t, got.Config.GetHasRollout())
+	require.EqualValues(t, 1, got.Config.GetApprovalInputVersion())
 	requirePlanSpecID(t, got.Config, "spec-a")
 }
 

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -242,6 +242,7 @@ func TestUpdatePlanRequireNoRolloutRejectsConfigUpdateAfterRollout(t *testing.T)
 		RequireNoRollout: true,
 	})
 	require.Error(t, err)
+	require.ErrorIs(t, err, store.ErrPlanHasRollout)
 
 	got, err := s.GetPlan(ctx, &store.FindPlanMessage{ProjectID: "project-a", UID: &plan.UID})
 	require.NoError(t, err)

--- a/backend/store/plan_approval_input_version_test.go
+++ b/backend/store/plan_approval_input_version_test.go
@@ -97,6 +97,44 @@ func TestUpdatePlanBumpsApprovalInputVersionOnlyWhenRequested(t *testing.T) {
 	requirePlanSpecID(t, updated.Config, "spec-e")
 }
 
+func TestCreateTasksIfPlanApprovalInputVersionMarksRollout(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanApprovalInputVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config: &storepb.PlanConfig{
+			ApprovalInputVersion: 2,
+			Specs:                []*storepb.PlanConfig_Spec{{Id: "spec-a"}},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	updated, createdTasks, err := s.CreateTasksIfPlanApprovalInputVersion(ctx, "project-a", plan.UID, 1, nil)
+	require.NoError(t, err)
+	require.False(t, updated)
+	require.Empty(t, createdTasks)
+
+	got, err := s.GetPlan(ctx, &store.FindPlanMessage{ProjectID: "project-a", UID: &plan.UID})
+	require.NoError(t, err)
+	require.False(t, got.Config.GetHasRollout())
+	require.EqualValues(t, 2, got.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, got.Config, "spec-a")
+
+	updated, createdTasks, err = s.CreateTasksIfPlanApprovalInputVersion(ctx, "project-a", plan.UID, 2, nil)
+	require.NoError(t, err)
+	require.True(t, updated)
+	require.Empty(t, createdTasks)
+
+	got, err = s.GetPlan(ctx, &store.FindPlanMessage{ProjectID: "project-a", UID: &plan.UID})
+	require.NoError(t, err)
+	require.True(t, got.Config.GetHasRollout())
+	require.EqualValues(t, 2, got.Config.GetApprovalInputVersion())
+	requirePlanSpecID(t, got.Config, "spec-a")
+}
+
 func TestUpdateIssuePayloadIfPlanApprovalInputVersionUpdatesMatchingVersion(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanApprovalInputVersionStore(ctx, t)

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -266,8 +266,8 @@ func (s *Store) UpdatePlanCheckRunIfApprovalInputVersion(ctx context.Context, pr
 // RefreshPlanCheckRunIfStaleApprovalInputVersion refreshes a terminal stale-version plan check run to AVAILABLE.
 //
 // Approval recompute may observe an older terminal row while another request is already moving
-// the plan forward. Treat the caller's version as the version to materialize, and leave checking
-// which version is current to the caller that read the plan.
+// the plan forward. Only move rows to a newer materialized version; never rewind a row that has
+// already advanced beyond the caller's observed plan version.
 func (s *Store) RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx context.Context, projectID string, planUID int64, approvalInputVersion int64) (bool, error) {
 	result := &storepb.PlanCheckRunResult{ApprovalInputVersion: approvalInputVersion}
 	resultBytes, err := protojson.Marshal(result)
@@ -284,7 +284,7 @@ func (s *Store) RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx context.Conte
 		WHERE project = ?
 		  AND plan_id = ?
 		  AND status NOT IN (?, ?)
-		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) != ?`,
+		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) < ?`,
 		time.Now(), PlanCheckRunStatusAvailable, resultBytes, projectID, planUID, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion)
 	query, args, err := q.ToSQL()
 	if err != nil {

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -207,6 +207,72 @@ func (s *Store) UpdatePlanCheckRun(ctx context.Context, projectID string, status
 	return nil
 }
 
+// UpdatePlanCheckRunIfApprovalInputVersion updates a running plan check run only when it still matches the claimed approval input version.
+func (s *Store) UpdatePlanCheckRunIfApprovalInputVersion(ctx context.Context, projectID string, status PlanCheckRunStatus, result *storepb.PlanCheckRunResult, uid int64, approvalInputVersion int64) (bool, error) {
+	resultBytes, err := protojson.Marshal(result)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to marshal result %v", result)
+	}
+	q := qb.Q().Space(`
+		UPDATE plan_check_run
+		SET
+			updated_at = ?,
+			status = ?,
+			result = ?
+		WHERE id = ?
+		  AND project = ?
+		  AND status = ?
+		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) = ?`,
+		time.Now(), status, resultBytes, uid, projectID, PlanCheckRunStatusRunning, approvalInputVersion)
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to build sql")
+	}
+	sqlResult, err := s.GetDB().ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to update plan check run")
+	}
+	rowsAffected, err := sqlResult.RowsAffected()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to inspect plan check run update")
+	}
+	return rowsAffected > 0, nil
+}
+
+// RefreshPlanCheckRunIfStaleApprovalInputVersion refreshes a terminal stale-version plan check run to AVAILABLE.
+func (s *Store) RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx context.Context, projectID string, planUID int64, approvalInputVersion int64) (bool, error) {
+	result := &storepb.PlanCheckRunResult{ApprovalInputVersion: approvalInputVersion}
+	resultBytes, err := protojson.Marshal(result)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to marshal result")
+	}
+
+	q := qb.Q().Space(`
+		UPDATE plan_check_run
+		SET
+			updated_at = ?,
+			status = ?,
+			result = ?
+		WHERE project = ?
+		  AND plan_id = ?
+		  AND status NOT IN (?, ?)
+		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) != ?`,
+		time.Now(), PlanCheckRunStatusAvailable, resultBytes, projectID, planUID, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion)
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to build sql")
+	}
+	sqlResult, err := s.GetDB().ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to refresh stale plan check run")
+	}
+	rowsAffected, err := sqlResult.RowsAffected()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to inspect stale plan check run refresh")
+	}
+	return rowsAffected > 0, nil
+}
+
 // BatchCancelPlanCheckRuns updates the status of planCheckRuns to CANCELED.
 func (s *Store) BatchCancelPlanCheckRuns(ctx context.Context, projectID string, planCheckRunUIDs []int64) error {
 	q := qb.Q().Space(`
@@ -227,9 +293,10 @@ func (s *Store) BatchCancelPlanCheckRuns(ctx context.Context, projectID string, 
 
 // ClaimedPlanCheckRun represents a plan check run that was atomically claimed.
 type ClaimedPlanCheckRun struct {
-	UID       int64
-	ProjectID string
-	PlanUID   int64
+	UID                  int64
+	ProjectID            string
+	PlanUID              int64
+	ApprovalInputVersion int64
 }
 
 // FailStalePlanCheckRuns marks RUNNING plan check runs as FAILED if they have been running
@@ -239,7 +306,14 @@ func (s *Store) FailStalePlanCheckRuns(ctx context.Context, timeout time.Duratio
 	q := qb.Q().Space(`
 		UPDATE plan_check_run
 		SET status = ?,
-		    result = '{"results": [{"status": "ERROR", "title": "Plan check run timed out", "content": "The plan check run was abandoned because it exceeded the maximum execution time."}]}',
+		    result = jsonb_build_object(
+		        'approvalInputVersion', COALESCE((result->>'approvalInputVersion')::bigint, 0),
+		        'results', jsonb_build_array(jsonb_build_object(
+		            'status', 'ERROR',
+		            'title', 'Plan check run timed out',
+		            'content', 'The plan check run was abandoned because it exceeded the maximum execution time.'
+		        ))
+		    ),
 		    updated_at = now()
 		WHERE status = ?
 		  AND updated_at < now() - ?::INTERVAL
@@ -269,7 +343,7 @@ func (s *Store) ClaimAvailablePlanCheckRuns(ctx context.Context) ([]*ClaimedPlan
 			WHERE status = ?
 			FOR UPDATE SKIP LOCKED
 		)
-		RETURNING id, project, plan_id
+		RETURNING id, project, plan_id, COALESCE((result->>'approvalInputVersion')::bigint, 0)
 	`, PlanCheckRunStatusRunning, PlanCheckRunStatusAvailable)
 
 	query, args, err := q.ToSQL()
@@ -286,7 +360,7 @@ func (s *Store) ClaimAvailablePlanCheckRuns(ctx context.Context) ([]*ClaimedPlan
 	var claimed []*ClaimedPlanCheckRun
 	for rows.Next() {
 		var c ClaimedPlanCheckRun
-		if err := rows.Scan(&c.UID, &c.ProjectID, &c.PlanUID); err != nil {
+		if err := rows.Scan(&c.UID, &c.ProjectID, &c.PlanUID, &c.ApprovalInputVersion); err != nil {
 			return nil, err
 		}
 		claimed = append(claimed, &c)

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -335,15 +335,8 @@ func (s *Store) CancelPlanCheckRunIfApprovalInputVersion(ctx context.Context, pr
 		WHERE id = ?
 		  AND project = ?
 		  AND status IN (?, ?)
-		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) = ?
-		  AND EXISTS (
-			SELECT 1
-			FROM plan
-			WHERE plan.project = plan_check_run.project
-			  AND plan.id = plan_check_run.plan_id
-			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = ?
-		  )`,
-		PlanCheckRunStatusCanceled, time.Now(), planCheckRunUID, projectID, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion, approvalInputVersion)
+		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) = ?`,
+		PlanCheckRunStatusCanceled, time.Now(), planCheckRunUID, projectID, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion)
 	query, args, err := q.ToSQL()
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to build sql")

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -242,15 +242,8 @@ func (s *Store) UpdatePlanCheckRunIfApprovalInputVersion(ctx context.Context, pr
 		WHERE id = ?
 		  AND project = ?
 		  AND status = ?
-		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) = ?
-		  AND EXISTS (
-			SELECT 1
-			FROM plan
-			WHERE plan.project = plan_check_run.project
-			  AND plan.id = plan_check_run.plan_id
-			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = ?
-		  )`,
-		time.Now(), status, resultBytes, uid, projectID, PlanCheckRunStatusRunning, approvalInputVersion, approvalInputVersion)
+		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) = ?`,
+		time.Now(), status, resultBytes, uid, projectID, PlanCheckRunStatusRunning, approvalInputVersion)
 	query, args, err := q.ToSQL()
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to build sql")
@@ -283,15 +276,8 @@ func (s *Store) RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx context.Conte
 		WHERE project = ?
 		  AND plan_id = ?
 		  AND status NOT IN (?, ?)
-		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) != ?
-		  AND EXISTS (
-			SELECT 1
-			FROM plan
-			WHERE plan.project = plan_check_run.project
-			  AND plan.id = plan_check_run.plan_id
-			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = ?
-		  )`,
-		time.Now(), PlanCheckRunStatusAvailable, resultBytes, projectID, planUID, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion, approvalInputVersion)
+		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) != ?`,
+		time.Now(), PlanCheckRunStatusAvailable, resultBytes, projectID, planUID, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion)
 	query, args, err := q.ToSQL()
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to build sql")

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -325,6 +325,40 @@ func (s *Store) BatchCancelPlanCheckRuns(ctx context.Context, projectID string, 
 	return nil
 }
 
+// CancelPlanCheckRunIfApprovalInputVersion cancels an active plan check run only when it still matches the observed approval input version.
+func (s *Store) CancelPlanCheckRunIfApprovalInputVersion(ctx context.Context, projectID string, planCheckRunUID int64, approvalInputVersion int64) (bool, error) {
+	q := qb.Q().Space(`
+		UPDATE plan_check_run
+		SET
+			status = ?,
+			updated_at = ?
+		WHERE id = ?
+		  AND project = ?
+		  AND status IN (?, ?)
+		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) = ?
+		  AND EXISTS (
+			SELECT 1
+			FROM plan
+			WHERE plan.project = plan_check_run.project
+			  AND plan.id = plan_check_run.plan_id
+			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = ?
+		  )`,
+		PlanCheckRunStatusCanceled, time.Now(), planCheckRunUID, projectID, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion, approvalInputVersion)
+	query, args, err := q.ToSQL()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to build sql")
+	}
+	result, err := s.GetDB().ExecContext(ctx, query, args...)
+	if err != nil {
+		return false, err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to inspect plan check run cancel")
+	}
+	return rowsAffected > 0, nil
+}
+
 // ClaimedPlanCheckRun represents a plan check run that was atomically claimed.
 type ClaimedPlanCheckRun struct {
 	UID                  int64

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -71,17 +71,30 @@ func (s *Store) CreatePlanCheckRun(ctx context.Context, create *PlanCheckRunMess
 		return false, err
 	}
 
+	approvalInputVersion := create.Result.GetApprovalInputVersion()
 	query := `
 		INSERT INTO plan_check_run (id, project, plan_id, status, result)
-		VALUES ($1, $2, $3, $4, $5)
+		SELECT $1, $2, $3, $4, $5
+		FROM plan
+		WHERE plan.project = $2
+		  AND plan.id = $3
+		  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = $6
 		ON CONFLICT (project, plan_id) DO UPDATE SET
 			status = EXCLUDED.status,
 			result = EXCLUDED.result,
 			updated_at = now()
-		WHERE plan_check_run.status NOT IN ($6, $7)
+		WHERE (plan_check_run.status NOT IN ($7, $8)
 		   OR COALESCE((plan_check_run.result->>'approvalInputVersion')::bigint, 0) != COALESCE((EXCLUDED.result->>'approvalInputVersion')::bigint, 0)
+		)
+		  AND EXISTS (
+			SELECT 1
+			FROM plan
+			WHERE plan.project = plan_check_run.project
+			  AND plan.id = plan_check_run.plan_id
+			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = $9
+		  )
 	`
-	sqlResult, err := tx.ExecContext(ctx, query, nextID, create.ProjectID, create.PlanUID, PlanCheckRunStatusAvailable, result, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning)
+	sqlResult, err := tx.ExecContext(ctx, query, nextID, create.ProjectID, create.PlanUID, PlanCheckRunStatusAvailable, result, approvalInputVersion, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion)
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to upsert plan check run")
 	}
@@ -270,8 +283,15 @@ func (s *Store) RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx context.Conte
 		WHERE project = ?
 		  AND plan_id = ?
 		  AND status NOT IN (?, ?)
-		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) != ?`,
-		time.Now(), PlanCheckRunStatusAvailable, resultBytes, projectID, planUID, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion)
+		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) != ?
+		  AND EXISTS (
+			SELECT 1
+			FROM plan
+			WHERE plan.project = plan_check_run.project
+			  AND plan.id = plan_check_run.plan_id
+			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = ?
+		  )`,
+		time.Now(), PlanCheckRunStatusAvailable, resultBytes, projectID, planUID, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning, approvalInputVersion, approvalInputVersion)
 	query, args, err := q.ToSQL()
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to build sql")

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -229,8 +229,9 @@ func (s *Store) UpdatePlanCheckRun(ctx context.Context, projectID string, status
 
 // UpdatePlanCheckRunIfApprovalInputVersion updates a running plan check run only when it still matches the claimed approval input version.
 //
-// The version guard validates the materialized run row only. Callers that change approval inputs
-// are responsible for refreshing the row to the new plan approval input version.
+// Plan check workers finish against the row version they claimed. We do not join back to the
+// current plan here because plan edits move the row forward separately; this update only prevents
+// an old worker from publishing over a row that has already been refreshed.
 func (s *Store) UpdatePlanCheckRunIfApprovalInputVersion(ctx context.Context, projectID string, status PlanCheckRunStatus, result *storepb.PlanCheckRunResult, uid int64, approvalInputVersion int64) (bool, error) {
 	resultBytes, err := protojson.Marshal(result)
 	if err != nil {
@@ -264,8 +265,9 @@ func (s *Store) UpdatePlanCheckRunIfApprovalInputVersion(ctx context.Context, pr
 
 // RefreshPlanCheckRunIfStaleApprovalInputVersion refreshes a terminal stale-version plan check run to AVAILABLE.
 //
-// The version guard validates the materialized run row only. Callers pass the plan approval input
-// version they want to materialize after checking the current plan.
+// Approval recompute may observe an older terminal row while another request is already moving
+// the plan forward. Treat the caller's version as the version to materialize, and leave checking
+// which version is current to the caller that read the plan.
 func (s *Store) RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx context.Context, projectID string, planUID int64, approvalInputVersion int64) (bool, error) {
 	result := &storepb.PlanCheckRunResult{ApprovalInputVersion: approvalInputVersion}
 	resultBytes, err := protojson.Marshal(result)

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -228,6 +228,9 @@ func (s *Store) UpdatePlanCheckRun(ctx context.Context, projectID string, status
 }
 
 // UpdatePlanCheckRunIfApprovalInputVersion updates a running plan check run only when it still matches the claimed approval input version.
+//
+// The version guard validates the materialized run row only. Callers that change approval inputs
+// are responsible for refreshing the row to the new plan approval input version.
 func (s *Store) UpdatePlanCheckRunIfApprovalInputVersion(ctx context.Context, projectID string, status PlanCheckRunStatus, result *storepb.PlanCheckRunResult, uid int64, approvalInputVersion int64) (bool, error) {
 	resultBytes, err := protojson.Marshal(result)
 	if err != nil {
@@ -260,6 +263,9 @@ func (s *Store) UpdatePlanCheckRunIfApprovalInputVersion(ctx context.Context, pr
 }
 
 // RefreshPlanCheckRunIfStaleApprovalInputVersion refreshes a terminal stale-version plan check run to AVAILABLE.
+//
+// The version guard validates the materialized run row only. Callers pass the plan approval input
+// version they want to materialize after checking the current plan.
 func (s *Store) RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx context.Context, projectID string, planUID int64, approvalInputVersion int64) (bool, error) {
 	result := &storepb.PlanCheckRunResult{ApprovalInputVersion: approvalInputVersion}
 	resultBytes, err := protojson.Marshal(result)

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -52,23 +52,23 @@ type FindPlanCheckRunMessage struct {
 	ResultStatus *[]storepb.Advice_Status
 }
 
-// CreatePlanCheckRun creates or replaces the plan check run for a plan.
-// Always creates with AVAILABLE status for HA-safe scheduling.
-func (s *Store) CreatePlanCheckRun(ctx context.Context, create *PlanCheckRunMessage) error {
+// CreatePlanCheckRun creates or refreshes the plan check run for a plan.
+// It skips active same-version rows to avoid resetting checks already queued or running.
+func (s *Store) CreatePlanCheckRun(ctx context.Context, create *PlanCheckRunMessage) (bool, error) {
 	result, err := protojson.Marshal(create.Result)
 	if err != nil {
-		return errors.Wrapf(err, "failed to marshal result")
+		return false, errors.Wrapf(err, "failed to marshal result")
 	}
 
 	tx, err := s.GetDB().BeginTx(ctx, nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to begin tx")
+		return false, errors.Wrapf(err, "failed to begin tx")
 	}
 	defer tx.Rollback()
 
 	nextID, err := nextProjectID(ctx, tx, "plan_check_run", create.ProjectID)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	query := `
@@ -78,15 +78,22 @@ func (s *Store) CreatePlanCheckRun(ctx context.Context, create *PlanCheckRunMess
 			status = EXCLUDED.status,
 			result = EXCLUDED.result,
 			updated_at = now()
+		WHERE plan_check_run.status NOT IN ($6, $7)
+		   OR COALESCE((plan_check_run.result->>'approvalInputVersion')::bigint, 0) != COALESCE((EXCLUDED.result->>'approvalInputVersion')::bigint, 0)
 	`
-	if _, err := tx.ExecContext(ctx, query, nextID, create.ProjectID, create.PlanUID, PlanCheckRunStatusAvailable, result); err != nil {
-		return errors.Wrapf(err, "failed to upsert plan check run")
+	sqlResult, err := tx.ExecContext(ctx, query, nextID, create.ProjectID, create.PlanUID, PlanCheckRunStatusAvailable, result, PlanCheckRunStatusAvailable, PlanCheckRunStatusRunning)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to upsert plan check run")
+	}
+	rowsAffected, err := sqlResult.RowsAffected()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to inspect plan check run upsert")
 	}
 
 	if err := tx.Commit(); err != nil {
-		return errors.Wrapf(err, "failed to commit tx")
+		return false, errors.Wrapf(err, "failed to commit tx")
 	}
-	return nil
+	return rowsAffected > 0, nil
 }
 
 // ListPlanCheckRuns returns a list of plan check runs based on find.
@@ -222,8 +229,15 @@ func (s *Store) UpdatePlanCheckRunIfApprovalInputVersion(ctx context.Context, pr
 		WHERE id = ?
 		  AND project = ?
 		  AND status = ?
-		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) = ?`,
-		time.Now(), status, resultBytes, uid, projectID, PlanCheckRunStatusRunning, approvalInputVersion)
+		  AND COALESCE((result->>'approvalInputVersion')::bigint, 0) = ?
+		  AND EXISTS (
+			SELECT 1
+			FROM plan
+			WHERE plan.project = plan_check_run.project
+			  AND plan.id = plan_check_run.plan_id
+			  AND COALESCE((plan.config->>'approvalInputVersion')::bigint, 0) = ?
+		  )`,
+		time.Now(), status, resultBytes, uid, projectID, PlanCheckRunStatusRunning, approvalInputVersion, approvalInputVersion)
 	query, args, err := q.ToSQL()
 	if err != nil {
 		return false, errors.Wrapf(err, "failed to build sql")

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -1,0 +1,157 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+
+	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
+)
+
+func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	}))
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+	require.EqualValues(t, 1, claimed[0].ApprovalInputVersion)
+
+	require.NoError(t, s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	}))
+
+	refreshedRun, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, refreshedRun)
+	require.EqualValues(t, claimed[0].UID, refreshedRun.UID)
+
+	updated, err := s.UpdatePlanCheckRunIfApprovalInputVersion(ctx, "project-a", store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: 1,
+		Error:                "stale result",
+	}, claimed[0].UID, 1)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusAvailable, run.Status)
+	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
+	require.Empty(t, run.Result.GetError())
+}
+
+func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotResetRunningCheck(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	}))
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+	require.EqualValues(t, 2, claimed[0].ApprovalInputVersion)
+
+	refreshed, err := s.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, "project-a", plan.UID, 2)
+	require.NoError(t, err)
+	require.False(t, refreshed)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusRunning, run.Status)
+	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
+}
+
+func TestFailStalePlanCheckRunsPreservesApprovalInputVersion(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	require.NoError(t, s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 7},
+	}))
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	rowsAffected, err := s.FailStalePlanCheckRuns(ctx, 0)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rowsAffected)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.Equal(t, store.PlanCheckRunStatusFailed, run.Status)
+	require.EqualValues(t, 7, run.Result.GetApprovalInputVersion())
+	require.NotEmpty(t, run.Result.GetResults())
+}
+
+func setupPlanCheckRunVersionStore(ctx context.Context, t *testing.T) *store.Store {
+	t.Helper()
+
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	return s
+}

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -101,7 +101,7 @@ func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow(
 	require.Empty(t, run.Result.GetError())
 }
 
-func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerAfterPlanVersionBump(t *testing.T) {
+func TestUpdatePlanCheckRunIfApprovalInputVersionAllowsClaimedRowAfterPlanVersionBump(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 
@@ -141,14 +141,14 @@ func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerAfterPlanVersio
 		}},
 	}, claimed[0].UID, 1)
 	require.NoError(t, err)
-	require.False(t, updated)
+	require.True(t, updated)
 
 	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
 	require.NoError(t, err)
 	require.NotNil(t, run)
-	require.Equal(t, store.PlanCheckRunStatusRunning, run.Status)
+	require.Equal(t, store.PlanCheckRunStatusDone, run.Status)
 	require.EqualValues(t, 1, run.Result.GetApprovalInputVersion())
-	require.Empty(t, run.Result.GetResults())
+	require.Len(t, run.Result.GetResults(), 1)
 }
 
 func TestCreatePlanCheckRunDoesNotResetActiveSameVersionRun(t *testing.T) {
@@ -399,7 +399,7 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionRefreshesTerminalStaleChe
 	require.Empty(t, run.Result.GetResults())
 }
 
-func TestRefreshPlanCheckRunIfStaleApprovalInputVersionSkipsStaleRequestedVersion(t *testing.T) {
+func TestRefreshPlanCheckRunIfStaleApprovalInputVersionSkipsSameVersionRow(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
 

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -15,6 +15,32 @@ import (
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
 )
 
+func TestClaimAvailablePlanCheckRunsDefaultsMissingApprovalInputVersion(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+	require.EqualValues(t, 0, claimed[0].ApprovalInputVersion)
+}
+
 func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
@@ -200,6 +226,90 @@ func TestCreatePlanCheckRunDoesNotResetActiveSameVersionAvailableRun(t *testing.
 	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
 }
 
+func TestCreatePlanCheckRunAllowsTerminalSameVersionRerun(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	updated, err := s.UpdatePlanCheckRunIfApprovalInputVersion(ctx, "project-a", store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: 2,
+		Results: []*storepb.PlanCheckRunResult_Result{{
+			Status: storepb.Advice_SUCCESS,
+			Title:  "current result",
+		}},
+	}, claimed[0].UID, 2)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	created, err = s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusAvailable, run.Status)
+	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
+}
+
+func TestCreatePlanCheckRunSkipsStaleIncomingApprovalInputVersion(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	created, err = s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	})
+	require.NoError(t, err)
+	require.False(t, created)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusAvailable, run.Status)
+	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
+}
+
 func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotResetRunningCheck(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
@@ -270,6 +380,13 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionRefreshesTerminalStaleChe
 	require.NoError(t, err)
 	require.True(t, updated)
 
+	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:       plan.UID,
+		ProjectID: plan.ProjectID,
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+
 	refreshed, err := s.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, "project-a", plan.UID, 2)
 	require.NoError(t, err)
 	require.True(t, refreshed)
@@ -280,6 +397,58 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionRefreshesTerminalStaleChe
 	require.Equal(t, store.PlanCheckRunStatusAvailable, run.Status)
 	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
 	require.Empty(t, run.Result.GetResults())
+}
+
+func TestRefreshPlanCheckRunIfStaleApprovalInputVersionSkipsStaleRequestedVersion(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 1},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	updated, err := s.UpdatePlanCheckRunIfApprovalInputVersion(ctx, "project-a", store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: 1,
+		Results: []*storepb.PlanCheckRunResult_Result{{
+			Status: storepb.Advice_SUCCESS,
+			Title:  "stale result",
+		}},
+	}, claimed[0].UID, 1)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:       plan.UID,
+		ProjectID: plan.ProjectID,
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+
+	refreshed, err := s.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, "project-a", plan.UID, 1)
+	require.NoError(t, err)
+	require.False(t, refreshed)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusDone, run.Status)
+	require.EqualValues(t, 1, run.Result.GetApprovalInputVersion())
 }
 
 func TestFailStalePlanCheckRunsPreservesApprovalInputVersion(t *testing.T) {

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -510,6 +510,48 @@ func TestCancelPlanCheckRunIfApprovalInputVersionSkipsRefreshedRow(t *testing.T)
 	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
 }
 
+func TestCancelPlanCheckRunIfApprovalInputVersionAllowsObservedStaleRow(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 1},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:       plan.UID,
+		ProjectID: plan.ProjectID,
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+
+	canceled, err := s.CancelPlanCheckRunIfApprovalInputVersion(ctx, "project-a", claimed[0].UID, 1)
+	require.NoError(t, err)
+	require.True(t, canceled)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusCanceled, run.Status)
+	require.EqualValues(t, 1, run.Result.GetApprovalInputVersion())
+}
+
 func TestFailStalePlanCheckRunsPreservesApprovalInputVersion(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -23,26 +23,37 @@ func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow(
 		ProjectID:   "project-a",
 		Name:        "plan-a",
 		Description: "",
-		Config:      &storepb.PlanConfig{},
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 1},
 	}, "creator@example.com")
 	require.NoError(t, err)
 
-	require.NoError(t, s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
 		ProjectID: "project-a",
 		PlanUID:   plan.UID,
 		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
-	}))
+	})
+	require.NoError(t, err)
+	require.True(t, created)
 
 	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
 	require.NoError(t, err)
 	require.Len(t, claimed, 1)
 	require.EqualValues(t, 1, claimed[0].ApprovalInputVersion)
 
-	require.NoError(t, s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:       plan.UID,
+		ProjectID: plan.ProjectID,
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+
+	created, err = s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
 		ProjectID: "project-a",
 		PlanUID:   plan.UID,
 		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
-	}))
+	})
+	require.NoError(t, err)
+	require.True(t, created)
 
 	refreshedRun, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
 	require.NoError(t, err)
@@ -64,6 +75,96 @@ func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow(
 	require.Empty(t, run.Result.GetError())
 }
 
+func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerAfterPlanVersionBump(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 1},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+	require.EqualValues(t, 1, claimed[0].ApprovalInputVersion)
+
+	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:       plan.UID,
+		ProjectID: plan.ProjectID,
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+
+	updated, err := s.UpdatePlanCheckRunIfApprovalInputVersion(ctx, "project-a", store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: 1,
+		Results: []*storepb.PlanCheckRunResult_Result{{
+			Status: storepb.Advice_SUCCESS,
+			Title:  "stale result",
+		}},
+	}, claimed[0].UID, 1)
+	require.NoError(t, err)
+	require.False(t, updated)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusRunning, run.Status)
+	require.EqualValues(t, 1, run.Result.GetApprovalInputVersion())
+	require.Empty(t, run.Result.GetResults())
+}
+
+func TestCreatePlanCheckRunDoesNotResetActiveSameVersionRun(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+	require.EqualValues(t, 2, claimed[0].ApprovalInputVersion)
+
+	created, err = s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.False(t, created)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusRunning, run.Status)
+	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
+}
+
 func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotResetRunningCheck(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
@@ -72,15 +173,17 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotResetRunningCheck(
 		ProjectID:   "project-a",
 		Name:        "plan-a",
 		Description: "",
-		Config:      &storepb.PlanConfig{},
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
 	}, "creator@example.com")
 	require.NoError(t, err)
 
-	require.NoError(t, s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
 		ProjectID: "project-a",
 		PlanUID:   plan.UID,
 		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
-	}))
+	})
+	require.NoError(t, err)
+	require.True(t, created)
 
 	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
 	require.NoError(t, err)
@@ -98,6 +201,52 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotResetRunningCheck(
 	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
 }
 
+func TestRefreshPlanCheckRunIfStaleApprovalInputVersionRefreshesTerminalStaleCheck(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 1},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	updated, err := s.UpdatePlanCheckRunIfApprovalInputVersion(ctx, "project-a", store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: 1,
+		Results: []*storepb.PlanCheckRunResult_Result{{
+			Status: storepb.Advice_SUCCESS,
+			Title:  "current result",
+		}},
+	}, claimed[0].UID, 1)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	refreshed, err := s.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, "project-a", plan.UID, 2)
+	require.NoError(t, err)
+	require.True(t, refreshed)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusAvailable, run.Status)
+	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
+	require.Empty(t, run.Result.GetResults())
+}
+
 func TestFailStalePlanCheckRunsPreservesApprovalInputVersion(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)
@@ -106,15 +255,17 @@ func TestFailStalePlanCheckRunsPreservesApprovalInputVersion(t *testing.T) {
 		ProjectID:   "project-a",
 		Name:        "plan-a",
 		Description: "",
-		Config:      &storepb.PlanConfig{},
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 7},
 	}, "creator@example.com")
 	require.NoError(t, err)
 
-	require.NoError(t, s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
 		ProjectID: "project-a",
 		PlanUID:   plan.UID,
 		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 7},
-	}))
+	})
+	require.NoError(t, err)
+	require.True(t, created)
 	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
 	require.NoError(t, err)
 	require.Len(t, claimed, 1)

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -451,6 +451,52 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionSkipsSameVersionRow(t *te
 	require.EqualValues(t, 1, run.Result.GetApprovalInputVersion())
 }
 
+func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotRewindNewerRow(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 3},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 3},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	updated, err := s.UpdatePlanCheckRunIfApprovalInputVersion(ctx, "project-a", store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: 3,
+		Results: []*storepb.PlanCheckRunResult_Result{{
+			Status: storepb.Advice_SUCCESS,
+			Title:  "newer result",
+		}},
+	}, claimed[0].UID, 3)
+	require.NoError(t, err)
+	require.True(t, updated)
+
+	refreshed, err := s.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, "project-a", plan.UID, 2)
+	require.NoError(t, err)
+	require.False(t, refreshed)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusDone, run.Status)
+	require.EqualValues(t, 3, run.Result.GetApprovalInputVersion())
+	require.Len(t, run.Result.GetResults(), 1)
+}
+
 func TestCancelPlanCheckRunIfApprovalInputVersionSkipsRefreshedRow(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -165,6 +165,41 @@ func TestCreatePlanCheckRunDoesNotResetActiveSameVersionRun(t *testing.T) {
 	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
 }
 
+func TestCreatePlanCheckRunDoesNotResetActiveSameVersionAvailableRun(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	created, err = s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.False(t, created)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusAvailable, run.Status)
+	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
+}
+
 func TestRefreshPlanCheckRunIfStaleApprovalInputVersionDoesNotResetRunningCheck(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -451,6 +451,65 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionSkipsStaleRequestedVersio
 	require.EqualValues(t, 1, run.Result.GetApprovalInputVersion())
 }
 
+func TestCancelPlanCheckRunIfApprovalInputVersionSkipsRefreshedRow(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config:      &storepb.PlanConfig{ApprovalInputVersion: 1},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:       plan.UID,
+		ProjectID: plan.ProjectID,
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+
+	created, err = s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	canceled, err := s.CancelPlanCheckRunIfApprovalInputVersion(ctx, "project-a", claimed[0].UID, 1)
+	require.NoError(t, err)
+	require.False(t, canceled)
+
+	run, err := s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, run)
+	require.Equal(t, store.PlanCheckRunStatusAvailable, run.Status)
+	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
+
+	canceled, err = s.CancelPlanCheckRunIfApprovalInputVersion(ctx, "project-a", claimed[0].UID, 2)
+	require.NoError(t, err)
+	require.True(t, canceled)
+
+	run, err = s.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.Equal(t, store.PlanCheckRunStatusCanceled, run.Status)
+	require.EqualValues(t, 2, run.Result.GetApprovalInputVersion())
+}
+
 func TestFailStalePlanCheckRunsPreservesApprovalInputVersion(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)

--- a/backend/store/signal.go
+++ b/backend/store/signal.go
@@ -13,12 +13,16 @@ import (
 const SignalChannel = "bytebase_signal"
 
 // SendSignal sends a notification to the bytebase_signal channel.
-func (s *Store) SendSignal(ctx context.Context, signalType storepb.Signal_Type, projectID string, uid int64) error {
-	payload, err := protojson.Marshal(&storepb.Signal{
+func (s *Store) SendSignal(ctx context.Context, signalType storepb.Signal_Type, projectID string, uid int64, approvalInputVersion ...int64) error {
+	signal := &storepb.Signal{
 		Type:    signalType,
 		Uid:     uid,
 		Project: projectID,
-	})
+	}
+	if len(approvalInputVersion) > 0 {
+		signal.ApprovalInputVersion = approvalInputVersion[0]
+	}
+	payload, err := protojson.Marshal(signal)
 	if err != nil {
 		return errors.Wrap(err, "failed to marshal signal payload")
 	}

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -503,6 +503,57 @@ func (s *Store) CreateTasks(ctx context.Context, projectID string, planUID int64
 	}
 	defer tx.Rollback()
 
+	tasks, err = s.createTasksTxDedup(ctx, tx, projectID, planUID, tasks)
+	if err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, errors.Wrapf(err, "failed to commit tx")
+	}
+
+	return tasks, nil
+}
+
+// CreateTasksIfPlanApprovalInputVersion marks the plan as having rollout and creates tasks atomically if the approval input version is current.
+func (s *Store) CreateTasksIfPlanApprovalInputVersion(ctx context.Context, projectID string, planUID int64, approvalInputVersion int64, tasks []*TaskMessage) (bool, []*TaskMessage, error) {
+	tx, err := s.GetDB().BeginTx(ctx, nil)
+	if err != nil {
+		return false, nil, errors.Wrapf(err, "failed to begin tx")
+	}
+	defer tx.Rollback()
+
+	result, err := tx.ExecContext(ctx, `
+		UPDATE plan
+		SET
+			updated_at = $1,
+			config = jsonb_set(config, '{hasRollout}', 'true'::jsonb, true)
+		WHERE project = $2
+		  AND id = $3
+		  AND COALESCE((config->>'approvalInputVersion')::bigint, 0) = $4`,
+		time.Now(), projectID, planUID, approvalInputVersion)
+	if err != nil {
+		return false, nil, errors.Wrapf(err, "failed to mark plan has rollout")
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, nil, errors.Wrapf(err, "failed to inspect plan has rollout update")
+	}
+	if rowsAffected == 0 {
+		return false, nil, nil
+	}
+
+	tasks, err = s.createTasksTxDedup(ctx, tx, projectID, planUID, tasks)
+	if err != nil {
+		return false, nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return false, nil, errors.Wrapf(err, "failed to commit tx")
+	}
+
+	return true, tasks, nil
+}
+
+func (s *Store) createTasksTxDedup(ctx context.Context, tx *sql.Tx, projectID string, planUID int64, tasks []*TaskMessage) ([]*TaskMessage, error) {
 	// Check existing tasks to avoid duplicates
 	existingTasks, err := s.listTasksImpl(ctx, tx, &TaskFind{
 		ProjectID: projectID,
@@ -554,14 +605,7 @@ func (s *Store) CreateTasks(ctx context.Context, projectID string, planUID int64
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create tasks")
 		}
-		if err := tx.Commit(); err != nil {
-			return nil, errors.Wrapf(err, "failed to commit tx")
-		}
 		return tasks, nil
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, errors.Wrapf(err, "failed to commit tx")
 	}
 
 	return []*TaskMessage{}, nil

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -514,32 +514,40 @@ func (s *Store) CreateTasks(ctx context.Context, projectID string, planUID int64
 	return tasks, nil
 }
 
-// CreateTasksIfPlanApprovalInputVersion marks the plan as having rollout and creates tasks atomically if the approval input version is current.
-func (s *Store) CreateTasksIfPlanApprovalInputVersion(ctx context.Context, projectID string, planUID int64, approvalInputVersion int64, tasks []*TaskMessage) (bool, []*TaskMessage, error) {
+// CreateRolloutTasks marks the plan as having rollout and creates tasks in one transaction.
+// If approvalInputVersion is set, the transaction creates no tasks unless the plan
+// still has that approval input version.
+func (s *Store) CreateRolloutTasks(ctx context.Context, projectID string, planUID int64, approvalInputVersion *int64, tasks []*TaskMessage) (bool, []*TaskMessage, error) {
 	tx, err := s.GetDB().BeginTx(ctx, nil)
 	if err != nil {
 		return false, nil, errors.Wrapf(err, "failed to begin tx")
 	}
 	defer tx.Rollback()
 
-	result, err := tx.ExecContext(ctx, `
+	var updatedPlanUID int64
+	if err := tx.QueryRowContext(ctx, `
 		UPDATE plan
 		SET
-			updated_at = $1,
-			config = jsonb_set(config, '{hasRollout}', 'true'::jsonb, true)
+			updated_at = CASE
+				WHEN COALESCE((config->>'hasRollout')::boolean, false) = false THEN $1
+				ELSE updated_at
+			END,
+			config = CASE
+				WHEN COALESCE((config->>'hasRollout')::boolean, false) = false THEN jsonb_set(config, '{hasRollout}', 'true'::jsonb, true)
+				ELSE config
+			END
 		WHERE project = $2
 		  AND id = $3
-		  AND COALESCE((config->>'approvalInputVersion')::bigint, 0) = $4`,
-		time.Now(), projectID, planUID, approvalInputVersion)
-	if err != nil {
+		  AND (
+			$4::bigint IS NULL
+			OR COALESCE((config->>'approvalInputVersion')::bigint, 0) = $4
+		  )
+		RETURNING id`,
+		time.Now(), projectID, planUID, approvalInputVersion).Scan(&updatedPlanUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil, nil
+		}
 		return false, nil, errors.Wrapf(err, "failed to mark plan has rollout")
-	}
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return false, nil, errors.Wrapf(err, "failed to inspect plan has rollout update")
-	}
-	if rowsAffected == 0 {
-		return false, nil, nil
 	}
 
 	tasks, err = s.createTasksTxDedup(ctx, tx, projectID, planUID, tasks)

--- a/backend/tests/approval_test.go
+++ b/backend/tests/approval_test.go
@@ -150,6 +150,141 @@ func TestDirectApprovalRuleMatching(t *testing.T) {
 	a.Equal("Prod Change Database Approval", issue.GetApprovalTemplate().GetTitle(), "Correct approval template should be applied")
 }
 
+func TestApprovalFindingRerunsPlanCheckForStaleApprovalInputVersion(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	t.Cleanup(func() { _ = ctl.Close(ctx) })
+
+	instanceDir := t.TempDir()
+	instanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("inst"),
+		Instance: &v1pb.Instance{
+			Title:       "Approval Input Version Instance",
+			Engine:      v1pb.Engine_SQLITE,
+			Environment: new("environments/prod"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{
+				Type: v1pb.DataSourceType_ADMIN,
+				Host: instanceDir,
+				Id:   "admin",
+			}},
+		},
+	}))
+	a.NoError(err)
+
+	dbName := generateRandomString("db")
+	err = ctl.createDatabase(ctx, ctl.project, instanceResp.Msg, nil, dbName, "")
+	a.NoError(err)
+	databaseName := fmt.Sprintf("%s/databases/%s", instanceResp.Msg.Name, dbName)
+
+	_, err = ctl.settingServiceClient.UpdateSetting(ctx, connect.NewRequest(&v1pb.UpdateSettingRequest{
+		AllowMissing: true,
+		Setting: &v1pb.Setting{
+			Name: "settings/WORKSPACE_APPROVAL",
+			Value: &v1pb.SettingValue{
+				Value: &v1pb.SettingValue_WorkspaceApproval{
+					WorkspaceApproval: &v1pb.WorkspaceApprovalSetting{
+						Rules: []*v1pb.WorkspaceApprovalSetting_Rule{{
+							Source: v1pb.WorkspaceApprovalSetting_Rule_CHANGE_DATABASE,
+							Condition: &expr.Expr{
+								Expression: `resource.db_engine == "SQLITE"`,
+							},
+							Template: &v1pb.ApprovalTemplate{
+								Title: "SQLite change approval",
+								Flow: &v1pb.ApprovalFlow{
+									Roles: []string{"roles/workspaceOwner"},
+								},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}))
+	a.NoError(err)
+
+	sheet1, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet: &v1pb.Sheet{
+			Content: []byte("CREATE TABLE stale_approval_a (id INTEGER PRIMARY KEY);"),
+		},
+	}))
+	a.NoError(err)
+	sheet2, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet: &v1pb.Sheet{
+			Content: []byte("CREATE TABLE stale_approval_b (id INTEGER PRIMARY KEY);"),
+		},
+	}))
+	a.NoError(err)
+
+	specID := uuid.NewString()
+	planResp, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan: &v1pb.Plan{
+			Title: "Approval input version plan",
+			Specs: []*v1pb.Plan_Spec{{
+				Id: specID,
+				Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+						Targets: []string{databaseName},
+						Sheet:   sheet1.Msg.Name,
+					},
+				},
+			}},
+		},
+	}))
+	a.NoError(err)
+
+	issueResp, err := ctl.issueServiceClient.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+		Parent: ctl.project.Name,
+		Issue: &v1pb.Issue{
+			Title:       "Approval input version issue",
+			Type:        v1pb.Issue_DATABASE_CHANGE,
+			Description: "Testing approval input version rerun",
+			Plan:        planResp.Msg.Name,
+		},
+	}))
+	a.NoError(err)
+
+	waitForApprovalFindingDone(ctx, t, ctl, issueResp.Msg)
+
+	updatedPlanResp, err := ctl.planServiceClient.UpdatePlan(ctx, connect.NewRequest(&v1pb.UpdatePlanRequest{
+		Plan: &v1pb.Plan{
+			Name: planResp.Msg.Name,
+			Specs: []*v1pb.Plan_Spec{{
+				Id: specID,
+				Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+						Targets: []string{databaseName},
+						Sheet:   sheet2.Msg.Name,
+					},
+				},
+			}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"specs"}},
+	}))
+	a.NoError(err)
+
+	waitForApprovalFindingDone(ctx, t, ctl, issueResp.Msg)
+
+	gotIssueResp, err := ctl.issueServiceClient.GetIssue(ctx, connect.NewRequest(&v1pb.GetIssueRequest{Name: issueResp.Msg.Name}))
+	a.NoError(err)
+	a.NotEqual(v1pb.ApprovalStatus_CHECKING, gotIssueResp.Msg.ApprovalStatus)
+	a.Equal("SQLite change approval", gotIssueResp.Msg.GetApprovalTemplate().GetTitle())
+
+	checkResp, err := ctl.planServiceClient.GetPlanCheckRun(ctx, connect.NewRequest(&v1pb.GetPlanCheckRunRequest{
+		Name: updatedPlanResp.Msg.Name + "/planCheckRun",
+	}))
+	a.NoError(err)
+	a.Equal(v1pb.PlanCheckRun_DONE, checkResp.Msg.Status)
+}
+
 // TestApprovalRuleFirstMatchWins tests that the first matching approval rule is applied
 // when multiple rules could potentially match.
 func TestApprovalRuleFirstMatchWins(t *testing.T) {

--- a/backend/tests/approval_test.go
+++ b/backend/tests/approval_test.go
@@ -318,6 +318,24 @@ func TestApprovalActionRejectsStaleApprovalInputVersion(t *testing.T) {
 
 	stores := getStore(t, ctl.server)
 
+	t.Run("ApproveIssue", func(t *testing.T) {
+		issue, staleApproval, approver := createStaleApprovalInputVersionIssue(ctx, t, ctl, stores, "stale-approve")
+
+		withImpersonation(ctx, t, ctl, approver, func() {
+			_, err := ctl.issueServiceClient.ApproveIssue(ctx, connect.NewRequest(&v1pb.ApproveIssueRequest{
+				Name:    issue.Name,
+				Comment: "approve stale approval",
+			}))
+			require.Error(t, err)
+			require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		})
+
+		got, err := ctl.issueServiceClient.GetIssue(ctx, connect.NewRequest(&v1pb.GetIssueRequest{Name: issue.Name}))
+		require.NoError(t, err)
+		require.Equal(t, v1pb.ApprovalStatus_PENDING, got.Msg.ApprovalStatus)
+		requireApprovalPayloadApproverCount(ctx, t, stores, issue.Name, len(staleApproval.Approvers))
+	})
+
 	t.Run("RejectIssue", func(t *testing.T) {
 		issue, staleApproval, approver := createStaleApprovalInputVersionIssue(ctx, t, ctl, stores, "stale-reject")
 

--- a/backend/tests/approval_test.go
+++ b/backend/tests/approval_test.go
@@ -11,9 +11,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/expr"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	"github.com/bytebase/bytebase/backend/common"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/store"
 )
 
 // TestDirectApprovalRuleMatching tests the new direct approval rule API
@@ -302,6 +306,172 @@ func TestApprovalFindingRerunsPlanCheckForStaleApprovalInputVersion(t *testing.T
 	}))
 	a.NoError(err)
 	a.Equal(v1pb.PlanCheckRun_DONE, checkResp.Msg.Status)
+}
+
+func TestApprovalActionRejectsStaleApprovalInputVersion(t *testing.T) {
+	ctx := context.Background()
+	ctl := &controller{}
+
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ctl.Close(ctx) })
+
+	stores := getStore(t, ctl.server)
+
+	t.Run("RejectIssue", func(t *testing.T) {
+		issue, staleApproval, approver := createStaleApprovalInputVersionIssue(ctx, t, ctl, stores, "stale-reject")
+
+		withImpersonation(ctx, t, ctl, approver, func() {
+			_, err := ctl.issueServiceClient.RejectIssue(ctx, connect.NewRequest(&v1pb.RejectIssueRequest{
+				Name:    issue.Name,
+				Comment: "reject stale approval",
+			}))
+			require.Error(t, err)
+			require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		})
+
+		got, err := ctl.issueServiceClient.GetIssue(ctx, connect.NewRequest(&v1pb.GetIssueRequest{Name: issue.Name}))
+		require.NoError(t, err)
+		require.Equal(t, v1pb.ApprovalStatus_PENDING, got.Msg.ApprovalStatus)
+		requireApprovalPayloadApproverCount(ctx, t, stores, issue.Name, len(staleApproval.Approvers))
+	})
+
+	t.Run("RequestIssue", func(t *testing.T) {
+		issue, staleApproval, approver := createStaleApprovalInputVersionIssue(ctx, t, ctl, stores, "stale-request")
+		staleApproval.Approvers = append(staleApproval.Approvers, &storepb.IssuePayloadApproval_Approver{
+			Status:    storepb.IssuePayloadApproval_Approver_REJECTED,
+			Principal: common.FormatUserEmail(approver.Email),
+		})
+		writeIssueApprovalPayload(ctx, t, stores, issue.Name, staleApproval)
+
+		_, err := ctl.issueServiceClient.RequestIssue(ctx, connect.NewRequest(&v1pb.RequestIssueRequest{
+			Name:    issue.Name,
+			Comment: "request stale approval",
+		}))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+		got, err := ctl.issueServiceClient.GetIssue(ctx, connect.NewRequest(&v1pb.GetIssueRequest{Name: issue.Name}))
+		require.NoError(t, err)
+		require.Equal(t, v1pb.ApprovalStatus_REJECTED, got.Msg.ApprovalStatus)
+		requireApprovalPayloadApproverCount(ctx, t, stores, issue.Name, len(staleApproval.Approvers))
+	})
+}
+
+func createStaleApprovalInputVersionIssue(ctx context.Context, t *testing.T, ctl *controller, stores *store.Store, suffix string) (*v1pb.Issue, *storepb.IssuePayloadApproval, testApprover) {
+	t.Helper()
+	project := ctl.createTestProject(ctx, t, suffix)
+
+	instanceDir := t.TempDir()
+	instanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("inst"),
+		Instance: &v1pb.Instance{
+			Title:       "Stale Approval Instance",
+			Engine:      v1pb.Engine_SQLITE,
+			Environment: new("environments/prod"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{
+				Type: v1pb.DataSourceType_ADMIN,
+				Host: instanceDir,
+				Id:   "admin",
+			}},
+		},
+	}))
+	require.NoError(t, err)
+
+	dbName := generateRandomString("db")
+	require.NoError(t, ctl.createDatabase(ctx, project, instanceResp.Msg, nil, dbName, ""))
+	target := dbTargetName(instanceResp.Msg, dbName)
+
+	disableSelfApproval(ctx, t, ctl, project)
+	installWorkspaceApprovalRule(ctx, t, ctl, project, []string{"roles/projectOwner"})
+	approver := provisionApprover(ctx, t, ctl, project, suffix, "roles/projectOwner")
+
+	sheet1 := createSheetWithContent(ctx, t, ctl, project, []byte(fmt.Sprintf("CREATE TABLE %s_a (id INTEGER PRIMARY KEY);", strings.ReplaceAll(suffix, "-", "_"))))
+
+	specID := uuid.NewString()
+	planResp, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: project.Name,
+		Plan: &v1pb.Plan{
+			Title: "Stale approval input version plan " + suffix,
+			Specs: []*v1pb.Plan_Spec{{
+				Id: specID,
+				Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+						Targets: []string{target},
+						Sheet:   sheet1,
+					},
+				},
+			}},
+		},
+	}))
+	require.NoError(t, err)
+
+	issue := createIssueForPlan(ctx, t, ctl, project, planResp.Msg, "stale approval input version "+suffix)
+	waitForIssuePending(ctx, t, ctl, issue)
+
+	_, issueUID, err := common.GetProjectIDIssueUID(issue.Name)
+	require.NoError(t, err)
+	projectID, err := common.GetProjectID(project.Name)
+	require.NoError(t, err)
+	storeIssue, err := stores.GetIssue(ctx, &store.FindIssueMessage{
+		ProjectIDs: []string{projectID},
+		UID:        &issueUID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, storeIssue)
+	staleApproval := proto.CloneOf(storeIssue.Payload.Approval)
+
+	_, planUID, err := common.GetProjectIDPlanID(planResp.Msg.Name)
+	require.NoError(t, err)
+	plan, err := stores.GetPlan(ctx, &store.FindPlanMessage{ProjectID: projectID, UID: &planUID})
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+	_, err = stores.UpdatePlan(ctx, &store.UpdatePlanMessage{
+		UID:                      plan.UID,
+		ProjectID:                plan.ProjectID,
+		Config:                   proto.CloneOf(plan.Config),
+		BumpApprovalInputVersion: true,
+	})
+	require.NoError(t, err)
+
+	writeIssueApprovalPayload(ctx, t, stores, issue.Name, staleApproval)
+	return issue, staleApproval, approver
+}
+
+func createSheetWithContent(ctx context.Context, t *testing.T, ctl *controller, project *v1pb.Project, content []byte) string {
+	t.Helper()
+	resp, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: project.Name,
+		Sheet:  &v1pb.Sheet{Content: content},
+	}))
+	require.NoError(t, err)
+	return resp.Msg.Name
+}
+
+func writeIssueApprovalPayload(ctx context.Context, t *testing.T, stores *store.Store, issueName string, approval *storepb.IssuePayloadApproval) {
+	t.Helper()
+	projectID, issueUID, err := common.GetProjectIDIssueUID(issueName)
+	require.NoError(t, err)
+	_, err = stores.UpdateIssue(ctx, projectID, issueUID, &store.UpdateIssueMessage{
+		PayloadUpsert: &storepb.Issue{
+			Approval: approval,
+		},
+	})
+	require.NoError(t, err)
+}
+
+func requireApprovalPayloadApproverCount(ctx context.Context, t *testing.T, stores *store.Store, issueName string, count int) {
+	t.Helper()
+	projectID, issueUID, err := common.GetProjectIDIssueUID(issueName)
+	require.NoError(t, err)
+	issue, err := stores.GetIssue(ctx, &store.FindIssueMessage{
+		ProjectIDs: []string{projectID},
+		UID:        &issueUID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, issue)
+	require.Len(t, issue.Payload.GetApproval().GetApprovers(), count)
 }
 
 // TestApprovalRuleFirstMatchWins tests that the first matching approval rule is applied

--- a/backend/tests/approval_test.go
+++ b/backend/tests/approval_test.go
@@ -189,18 +189,32 @@ func TestApprovalFindingRerunsPlanCheckForStaleApprovalInputVersion(t *testing.T
 			Value: &v1pb.SettingValue{
 				Value: &v1pb.SettingValue_WorkspaceApproval{
 					WorkspaceApproval: &v1pb.WorkspaceApprovalSetting{
-						Rules: []*v1pb.WorkspaceApprovalSetting_Rule{{
-							Source: v1pb.WorkspaceApprovalSetting_Rule_CHANGE_DATABASE,
-							Condition: &expr.Expr{
-								Expression: `resource.db_engine == "SQLITE"`,
-							},
-							Template: &v1pb.ApprovalTemplate{
-								Title: "SQLite change approval",
-								Flow: &v1pb.ApprovalFlow{
-									Roles: []string{"roles/workspaceOwner"},
+						Rules: []*v1pb.WorkspaceApprovalSetting_Rule{
+							{
+								Source: v1pb.WorkspaceApprovalSetting_Rule_CHANGE_DATABASE,
+								Condition: &expr.Expr{
+									Expression: `statement.text.contains("stale_approval_b")`,
+								},
+								Template: &v1pb.ApprovalTemplate{
+									Title: "SQLite change approval B",
+									Flow: &v1pb.ApprovalFlow{
+										Roles: []string{"roles/workspaceOwner"},
+									},
 								},
 							},
-						}},
+							{
+								Source: v1pb.WorkspaceApprovalSetting_Rule_CHANGE_DATABASE,
+								Condition: &expr.Expr{
+									Expression: `statement.text.contains("stale_approval_a")`,
+								},
+								Template: &v1pb.ApprovalTemplate{
+									Title: "SQLite change approval A",
+									Flow: &v1pb.ApprovalFlow{
+										Roles: []string{"roles/workspaceOwner"},
+									},
+								},
+							},
+						},
 					},
 				},
 			},
@@ -254,6 +268,11 @@ func TestApprovalFindingRerunsPlanCheckForStaleApprovalInputVersion(t *testing.T
 
 	waitForApprovalFindingDone(ctx, t, ctl, issueResp.Msg)
 
+	gotIssueResp, err := ctl.issueServiceClient.GetIssue(ctx, connect.NewRequest(&v1pb.GetIssueRequest{Name: issueResp.Msg.Name}))
+	a.NoError(err)
+	a.NotEqual(v1pb.ApprovalStatus_CHECKING, gotIssueResp.Msg.ApprovalStatus)
+	a.Equal("SQLite change approval A", gotIssueResp.Msg.GetApprovalTemplate().GetTitle())
+
 	updatedPlanResp, err := ctl.planServiceClient.UpdatePlan(ctx, connect.NewRequest(&v1pb.UpdatePlanRequest{
 		Plan: &v1pb.Plan{
 			Name: planResp.Msg.Name,
@@ -273,13 +292,13 @@ func TestApprovalFindingRerunsPlanCheckForStaleApprovalInputVersion(t *testing.T
 
 	waitForApprovalFindingDone(ctx, t, ctl, issueResp.Msg)
 
-	gotIssueResp, err := ctl.issueServiceClient.GetIssue(ctx, connect.NewRequest(&v1pb.GetIssueRequest{Name: issueResp.Msg.Name}))
+	gotIssueResp, err = ctl.issueServiceClient.GetIssue(ctx, connect.NewRequest(&v1pb.GetIssueRequest{Name: issueResp.Msg.Name}))
 	a.NoError(err)
 	a.NotEqual(v1pb.ApprovalStatus_CHECKING, gotIssueResp.Msg.ApprovalStatus)
-	a.Equal("SQLite change approval", gotIssueResp.Msg.GetApprovalTemplate().GetTitle())
+	a.Equal("SQLite change approval B", gotIssueResp.Msg.GetApprovalTemplate().GetTitle())
 
 	checkResp, err := ctl.planServiceClient.GetPlanCheckRun(ctx, connect.NewRequest(&v1pb.GetPlanCheckRunRequest{
-		Name: updatedPlanResp.Msg.Name + "/planCheckRun",
+		Name: fmt.Sprintf("%s/planCheckRun", updatedPlanResp.Msg.Name),
 	}))
 	a.NoError(err)
 	a.Equal(v1pb.PlanCheckRun_DONE, checkResp.Msg.Status)

--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -77,6 +77,20 @@ func CheckIssueApproved(issue *store.IssueMessage) (bool, error) {
 	return CheckApprovalApproved(issue.Payload.Approval)
 }
 
+// CheckIssueApprovedForPlan checks if the issue is approved for the current plan approval input version.
+func CheckIssueApprovedForPlan(issue *store.IssueMessage, plan *store.PlanMessage) (bool, error) {
+	if issue.Type == storepb.Issue_DATABASE_CHANGE && plan != nil {
+		var approvalInputVersion int64
+		if plan.Config != nil {
+			approvalInputVersion = plan.Config.GetApprovalInputVersion()
+		}
+		if issue.Payload.GetApproval().GetApprovalInputVersion() != approvalInputVersion {
+			return false, nil
+		}
+	}
+	return CheckIssueApproved(issue)
+}
+
 // UpdateProjectPolicyFromRoleGrantIssue updates the project policy from a role grant issue.
 func UpdateProjectPolicyFromRoleGrantIssue(ctx context.Context, stores *store.Store, workspaceID string, issue *store.IssueMessage, roleGrant *storepb.RoleGrant) error {
 	policyMessage, err := stores.GetProjectIamPolicy(ctx, workspaceID, issue.ProjectID)

--- a/backend/utils/utils_test.go
+++ b/backend/utils/utils_test.go
@@ -55,3 +55,72 @@ func TestCheckDatabaseGroupMatch(t *testing.T) {
 		assert.Equal(t, test.match, match)
 	}
 }
+
+func TestCheckIssueApprovedForPlan(t *testing.T) {
+	tests := []struct {
+		name      string
+		issueType storepb.Issue_Type
+		issue     *storepb.Issue
+		plan      *storepb.PlanConfig
+		want      bool
+	}{
+		{
+			name:      "database change approved for matching plan version",
+			issueType: storepb.Issue_DATABASE_CHANGE,
+			issue: &storepb.Issue{
+				Approval: &storepb.IssuePayloadApproval{
+					ApprovalFindingDone:  true,
+					ApprovalInputVersion: 2,
+				},
+			},
+			plan: &storepb.PlanConfig{ApprovalInputVersion: 2},
+			want: true,
+		},
+		{
+			name:      "database change stale approval is not approved",
+			issueType: storepb.Issue_DATABASE_CHANGE,
+			issue: &storepb.Issue{
+				Approval: &storepb.IssuePayloadApproval{
+					ApprovalFindingDone:  true,
+					ApprovalInputVersion: 1,
+				},
+			},
+			plan: &storepb.PlanConfig{ApprovalInputVersion: 2},
+		},
+		{
+			name:      "database change matching version still requires completed approval",
+			issueType: storepb.Issue_DATABASE_CHANGE,
+			issue: &storepb.Issue{
+				Approval: &storepb.IssuePayloadApproval{
+					ApprovalInputVersion: 2,
+				},
+			},
+			plan: &storepb.PlanConfig{ApprovalInputVersion: 2},
+		},
+		{
+			name:      "non database change keeps existing approval behavior",
+			issueType: storepb.Issue_ROLE_GRANT,
+			issue: &storepb.Issue{
+				Approval: &storepb.IssuePayloadApproval{
+					ApprovalFindingDone:  true,
+					ApprovalInputVersion: 1,
+				},
+			},
+			plan: &storepb.PlanConfig{ApprovalInputVersion: 2},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CheckIssueApprovedForPlan(&store.IssueMessage{
+				Type:    tt.issueType,
+				Payload: tt.issue,
+			}, &store.PlanMessage{
+				Config: tt.plan,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/proto/gen/grpc-doc/store/README.md
+++ b/proto/gen/grpc-doc/store/README.md
@@ -4868,6 +4868,7 @@ Signal represents a notification payload sent via PostgreSQL NOTIFY for HA coord
 | type | [Signal.Type](#bytebase-store-Signal-Type) |  |  |
 | uid | [int64](#int64) |  |  |
 | project | [string](#string) |  |  |
+| approval_input_version | [int64](#int64) |  |  |
 
 
 

--- a/proto/gen/grpc-doc/store/index.html
+++ b/proto/gen/grpc-doc/store/index.html
@@ -13327,6 +13327,13 @@ Default to this mode.</p></td>
                   <td><p> </p></td>
                 </tr>
               
+                <tr>
+                  <td>approval_input_version</td>
+                  <td><a href="#int64">int64</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
             </tbody>
           </table>
 

--- a/proto/store/store/signal.proto
+++ b/proto/store/store/signal.proto
@@ -16,4 +16,5 @@ message Signal {
   Type type = 1;
   int64 uid = 2;
   string project = 3;
+  int64 approval_input_version = 4;
 }


### PR DESCRIPTION
## Summary
- Stamp approval-generated issue payloads and plan check runs with the plan approval input version used to create them.
- Make approval runner and plan check scheduling detect stale derived state and refresh/recompute it.
- Guard plan check result writes and cancellation so stale workers or stale cancel signals cannot affect refreshed current runs.
- Block stale approval-derived side effects for approve, reject, request, rollout task creation, and rollout execution checks.

## Stack
- Built on #20700, which has merged into `main`.

## Test Plan
- go test -v -count=1 ./backend/api/v1 -run '^TestResetIssueApprovalFindingSkipsStalePlanApprovalInputVersion$'
- go test -v -count=1 ./backend/store -run '^(TestUpdateIssuePayloadIfCurrentApprovalInputVersionUpdatesMatchingVersion|TestUpdateIssuePayloadIfCurrentApprovalInputVersionSkipsStaleIssueApprovalVersion|TestUpdateIssuePayloadIfPlanApprovalInputVersionUpdatesMatchingVersion|TestUpdateIssuePayloadIfPlanApprovalInputVersionSkipsStaleVersion)$'
- go test -v -count=1 ./backend/store -run '^(TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow|TestUpdatePlanCheckRunIfApprovalInputVersionAllowsClaimedRowAfterPlanVersionBump|TestRefreshPlanCheckRunIfStaleApprovalInputVersionRefreshesTerminalStaleCheck|TestRefreshPlanCheckRunIfStaleApprovalInputVersionSkipsSameVersionRow|TestCreatePlanCheckRunSkipsStaleIncomingApprovalInputVersion)$'
- go test -v -count=1 ./backend/store -run '^(TestCancelPlanCheckRunIfApprovalInputVersionSkipsRefreshedRow|TestCancelPlanCheckRunIfApprovalInputVersionAllowsObservedStaleRow|TestCreatePlanCheckRunDoesNotResetActiveSameVersionRun|TestCreatePlanCheckRunDoesNotResetActiveSameVersionAvailableRun)$'
- go test -v -count=1 ./backend/component/bus ./backend/runner/notifylistener ./backend/runner/plancheck
- go test -v -count=1 ./backend/runner/approval ./backend/utils
- go test -v -count=1 ./backend/api/v1 -run '^$'
- go test -v -count=1 ./backend/tests/ -run '^TestApprovalActionRejectsStaleApprovalInputVersion$' -timeout 5m
- go test -v -count=1 ./backend/tests/ -run '^(TestApprovalActionRejectsStaleApprovalInputVersion|TestApprovalFindingRerunsPlanCheckForStaleApprovalInputVersion)$' -timeout 5m
- go test -v -count=1 ./backend/tests/ -run '^(TestClaim|TestCollision)' -timeout 5m
- buf lint proto
- golangci-lint run --allow-parallel-runners
- golangci-lint run --allow-parallel-runners
- go build -ldflags \"-w -s\" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
- git diff --check -- ':!proto/gen/grpc-doc/store/index.html'

Note: full `git diff --check` only reports generated whitespace in `proto/gen/grpc-doc/store/index.html`.