### PR TITLE
fix(frontend): prevent target chip overflow in change/export views

### DIFF
--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseChangeView.tsx
@@ -646,11 +646,11 @@ function IssueDetailDatabaseChangeTargets({
             <div className="h-5 w-5 animate-spin rounded-full border-2 border-control-border border-t-accent" />
           </div>
         ) : targets.length > 0 ? (
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             {visibleTargets.map((target) => (
               <div
                 key={target}
-                className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1"
+                className="inline-flex max-w-full min-w-0 cursor-default items-center gap-x-1 rounded-lg border px-2 py-1"
               >
                 {isValidDatabaseName(target) ? (
                   <IssueDetailDatabaseTarget showEnvironment target={target} />
@@ -660,7 +660,7 @@ function IssueDetailDatabaseChangeTargets({
                     target={target}
                   />
                 ) : (
-                  <span className="text-sm text-control-placeholder">
+                  <span className="truncate text-sm text-control-placeholder">
                     {target}
                   </span>
                 )}
@@ -858,7 +858,7 @@ function IssueDetailDatabaseGroupTarget({
         <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs">
           {t("common.database-group")}
         </span>
-        <span className="truncate text-sm text-gray-800">
+        <span className="min-w-0 truncate text-sm text-gray-800">
           {extractDatabaseGroupName(databaseGroup.name || target)}
         </span>
         {isValidDatabaseGroupName(databaseGroup.name) && (
@@ -873,11 +873,11 @@ function IssueDetailDatabaseGroupTarget({
       </div>
 
       {databases.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2 pl-7">
+        <div className="flex min-w-0 flex-wrap items-center gap-2 pl-7">
           {databases.slice(0, MAX_INLINE_DATABASES).map((database) => (
             <div
               key={database}
-              className="inline-flex cursor-default items-center gap-x-1 rounded-lg border bg-gray-50 px-2 py-1 transition-all"
+              className="inline-flex max-w-full min-w-0 cursor-default items-center gap-x-1 rounded-lg border bg-gray-50 px-2 py-1 transition-all"
             >
               <IssueDetailDatabaseTarget showEnvironment target={database} />
             </div>

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailDatabaseExportView.tsx
@@ -401,14 +401,14 @@ function IssueDetailDatabaseExportTasks({
       <h3 className="text-base font-medium">{t("common.task")}</h3>
       <div
         className={cn(
-          "flex flex-wrap gap-2",
+          "flex min-w-0 flex-wrap gap-2",
           tasksExpanded && hasMore && "max-h-96 overflow-y-auto"
         )}
       >
         {visibleTasks.map((task) => (
           <div
             key={task.name}
-            className="inline-flex min-w-0 items-center gap-2 rounded-sm border px-2 py-1.5"
+            className="inline-flex max-w-full min-w-0 items-center gap-2 rounded-sm border px-2 py-1.5"
           >
             <TaskStatusIcon status={task.status} size="tiny" />
             <IssueDetailDatabaseExportDatabaseTarget target={task.target} />
@@ -607,11 +607,11 @@ function IssueDetailDatabaseExportTargets({ targets }: { targets: string[] }) {
   return (
     <div className="flex flex-col gap-y-2">
       <h3 className="text-base font-medium">{t("plan.targets.title")}</h3>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex min-w-0 flex-wrap gap-2">
         {targets.map((target) => (
           <div
             key={target}
-            className="inline-flex min-w-0 items-center gap-2 rounded-sm border px-2 py-1.5"
+            className="inline-flex max-w-full min-w-0 items-center gap-2 rounded-sm border px-2 py-1.5"
           >
             {isValidDatabaseName(target) ? (
               <IssueDetailDatabaseExportDatabaseTarget target={target} />
@@ -655,17 +655,23 @@ function IssueDetailDatabaseExportDatabaseTarget({
     t("common.unknown");
 
   return (
-    <div className="flex min-w-0 items-center truncate text-sm">
+    <div className="flex min-w-0 max-w-full items-center text-sm">
       {instance && (
         <EngineIcon
           engine={instance.engine}
-          className="mr-1 inline-block h-4 w-4"
+          className="mr-1 inline-block h-4 w-4 shrink-0"
         />
       )}
-      <span className="mr-1 truncate text-gray-400">{environment.title}</span>
-      <span className="truncate text-gray-600">{instanceTitle}</span>
+      <span className="mr-1 max-w-24 shrink truncate text-gray-400">
+        {environment.title}
+      </span>
+      <span className="min-w-0 shrink-[2] truncate text-gray-600">
+        {instanceTitle}
+      </span>
       <ChevronRight className="h-4 w-4 shrink-0 text-gray-500 opacity-60" />
-      <span className="truncate text-gray-800">{databaseName}</span>
+      <span className="min-w-12 flex-1 truncate text-gray-800">
+        {databaseName}
+      </span>
     </div>
   );
 }
@@ -723,7 +729,7 @@ function IssueDetailDatabaseExportDatabaseGroupTarget({
         <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs">
           {t("common.database-group")}
         </span>
-        <span className="truncate text-sm text-gray-800">
+        <span className="min-w-0 truncate text-sm text-gray-800">
           {extractDatabaseGroupName(databaseGroup.name || target)}
         </span>
         {isValidDatabaseGroupName(databaseGroup.name) && (
@@ -738,11 +744,11 @@ function IssueDetailDatabaseExportDatabaseGroupTarget({
       </div>
 
       {databases.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2 pl-7">
+        <div className="flex min-w-0 flex-wrap items-center gap-2 pl-7">
           {databases.slice(0, MAX_INLINE_DATABASES).map((database) => (
             <div
               key={database}
-              className="inline-flex cursor-default items-center gap-x-1 rounded-lg border bg-gray-50 px-2 py-1 transition-all"
+              className="inline-flex max-w-full min-w-0 cursor-default items-center gap-x-1 rounded-lg border bg-gray-50 px-2 py-1 transition-all"
             >
               <IssueDetailDatabaseExportDatabaseTarget target={database} />
             </div>

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -1393,25 +1393,28 @@ function TargetsSection({
             <div className="h-5 w-5 animate-spin rounded-full border-2 border-control-border border-t-accent" />
           </div>
         ) : targets.length > 0 ? (
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
             {visibleTargets.map((target) =>
               isValidDatabaseName(target) ? (
                 <div
                   key={target}
-                  className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1"
+                  className="inline-flex max-w-full min-w-0 cursor-default items-center gap-x-1 rounded-lg border px-2 py-1"
                 >
                   <PlanTargetDisplay showEnvironment target={target} />
                 </div>
               ) : isValidDatabaseGroupName(target) ? (
-                <div key={target} className="rounded-lg border px-2 py-1">
+                <div
+                  key={target}
+                  className="min-w-0 max-w-full rounded-lg border px-2 py-1"
+                >
                   <DatabaseGroupTarget className="py-1" target={target} />
                 </div>
               ) : (
                 <div
                   key={target}
-                  className="inline-flex cursor-default items-center gap-x-1 rounded-lg border px-2 py-1"
+                  className="inline-flex max-w-full min-w-0 cursor-default items-center gap-x-1 rounded-lg border px-2 py-1"
                 >
-                  <span className="text-sm text-control-placeholder">
+                  <span className="truncate text-sm text-control-placeholder">
                     {target}
                   </span>
                 </div>
@@ -1994,11 +1997,11 @@ export function DatabaseGroupTarget({
         )}
       </div>
       {matchedDatabases.length > 0 && (
-        <div className="flex flex-wrap items-center gap-2 pl-7">
+        <div className="flex min-w-0 flex-wrap items-center gap-2 pl-7">
           {inlineDatabases.map((database) => (
             <div
               key={database.name}
-              className="inline-flex cursor-default items-center gap-x-1 rounded-lg border bg-gray-50 px-2 py-1 transition-all"
+              className="inline-flex max-w-full min-w-0 cursor-default items-center gap-x-1 rounded-lg border bg-gray-50 px-2 py-1 transition-all"
             >
               <PlanTargetDisplay showEnvironment target={database.name} />
             </div>


### PR DESCRIPTION
## What

Database target chip lists could overflow their container in narrow panels (e.g. the spec editor's left panel, or a Database Group's inline databases). The text spilled past the panel's right edge instead of truncating.

## Why

The target *display* components already truncate internally — but only when their parent gives them a bounded width. The chip wrappers were `inline-flex` with the default `min-width: auto`, which forbids a flex item from shrinking below its content's intrinsic width. So a wide chip kept its full width and overflowed; the inner truncation never got a bounded width to work against.

## Changes

- Constrain each target chip with `min-w-0` (load-bearing) + `max-w-full` so an over-wide chip drops to its own line and shrinks to the row width, letting the existing internal `truncate` engage.
- Applied consistently across all three surfaces that hand-roll this markup:
  - `PlanDetailChangesBranch.tsx` — `TargetsSection` chips + `DatabaseGroupTarget` inline databases
  - `IssueDetailDatabaseChangeView.tsx` — target chips, group name span, group inline databases
  - `IssueDetailDatabaseExportView.tsx` — task/target chips + group inline databases
- Fixed the export view's inner display (`IssueDetailDatabaseExportDatabaseTarget`): its instance/database spans had `truncate` but no `min-w-0`/shrink controls, so they never actually truncated. Rewrote them to mirror the change-view display (icon `shrink-0`, env `max-w-24 shrink truncate`, instance `min-w-0 shrink-[2] truncate`, database `min-w-12 flex-1 truncate`).
- Added `min-w-0` to group-name spans so their `truncate` engages inside the flex row.

CSS-only; no behavior change.

## Follow-up (not in this PR)

These three surfaces each hand-roll near-identical target-display + chip-wrapper markup, which is *why* the same overflow bug had to be fixed three times. A follow-up should consolidate them onto the shared `DatabaseTargetDisplay` (+ a shared group display / chip wrapper) so the truncation contract lives in one place and can't drift again.

## Testing

- `pnpm --dir frontend type-check` — passes
- `pnpm --dir frontend test PlanDetailChangesBranch` — 11/11 pass
- biome clean on all three files

Verified by layout/flexbox reasoning + the above checks (not a live browser render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)