### PR TITLE
feat(frontend): move add-change action onto the changes tab strip

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.test.tsx
@@ -464,14 +464,17 @@ vi.mock("./PlanDetailTabStrip", () => ({
   }) => <button onClick={onSelect}>{children}</button>,
   PlanDetailTabStrip: ({
     action,
+    trailing,
     children,
   }: {
     action?: ReactNode;
+    trailing?: ReactNode;
     children: ReactNode;
   }) => (
     <div>
       {action}
       {children}
+      {trailing}
     </div>
   ),
 }));
@@ -765,7 +768,7 @@ describe("PlanDetailChangesBranch", () => {
     renderHarness(0);
 
     const addChangeButton = [...container.querySelectorAll("button")].find(
-      (button) => button.textContent === "plan.add-spec"
+      (button) => button.getAttribute("aria-label") === "plan.add-spec"
     );
     expect(addChangeButton).toBeTruthy();
 
@@ -806,7 +809,7 @@ describe("PlanDetailChangesBranch", () => {
     });
 
     const addChangeButton = [...container.querySelectorAll("button")].find(
-      (button) => button.textContent === "plan.add-spec"
+      (button) => button.getAttribute("aria-label") === "plan.add-spec"
     );
     expect(addChangeButton).toBeTruthy();
 

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailChangesBranch.tsx
@@ -7,6 +7,7 @@ import {
   FolderTree,
   Loader2,
   Pencil,
+  Plus,
   XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -151,6 +152,12 @@ import { PlanTargetDisplay } from "./PlanTargetDisplay";
 const DEFAULT_VISIBLE_TARGETS = 20;
 const DATABASE_GROUP_VISIBLE_DATABASES = 3;
 const EMPTY_SELECT_VALUE = "__empty__";
+
+// Shared hover/focus recipe for the square icon buttons on the tab strip
+// (the per-tab actions menu and the add-change button). Callers append their
+// own size and corner radius.
+const ICON_ACTION_CLASS =
+  "inline-flex cursor-pointer items-center justify-center text-control-light outline-hidden transition-colors hover:bg-control-bg hover:text-control focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-50";
 
 const pushSpecDetailRoute = (
   projectId: string,
@@ -530,21 +537,27 @@ export function PlanDetailChangesBranch({
   return (
     <div className="flex w-full flex-1 flex-col">
       <PlanDetailTabStrip
-        action={
+        trailing={
           canModifySpecs ? (
             <Tooltip
               content={
-                pendingNewSpec ? t("plan.add-spec-pending-draft") : undefined
+                pendingNewSpec
+                  ? t("plan.add-spec-pending-draft")
+                  : t("plan.add-spec")
               }
             >
-              <Button
+              <button
+                aria-label={t("plan.add-spec")}
+                className={cn(
+                  ICON_ACTION_CLASS,
+                  "size-7 rounded-md [touch-action:manipulation]"
+                )}
                 disabled={Boolean(pendingNewSpec)}
                 onClick={() => setShowAddSpecSheet(true)}
-                size="xs"
-                variant="outline"
+                type="button"
               >
-                {t("plan.add-spec")}
-              </Button>
+                <Plus aria-hidden="true" className="size-4" />
+              </button>
             </Tooltip>
           ) : undefined
         }
@@ -560,7 +573,8 @@ export function PlanDetailChangesBranch({
                   <DropdownMenu>
                     <DropdownMenuTrigger
                       className={cn(
-                        "mr-2 inline-flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-xs text-control-light outline-hidden transition-colors hover:bg-control-bg hover:text-control focus-visible:ring-2 focus-visible:ring-accent"
+                        ICON_ACTION_CLASS,
+                        "mr-2 size-6 shrink-0 rounded-xs"
                       )}
                     >
                       <EllipsisVertical className="size-3.5" />

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTabStrip.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTabStrip.tsx
@@ -3,17 +3,33 @@ import { cn } from "@/react/lib/utils";
 
 export function PlanDetailTabStrip({
   action,
+  trailing,
   children,
 }: {
   action?: ReactNode;
+  trailing?: ReactNode;
   children: ReactNode;
 }) {
   return (
     <div className="relative bg-white pt-3">
       <div className="absolute bottom-0 w-full border-b border-b-gray-200 leading-0" />
       <div className="flex items-center justify-between gap-x-4">
-        <div className="flex min-w-0 flex-1 items-center overflow-x-auto px-4">
+        <div
+          className={cn(
+            "flex min-w-0 items-center overflow-x-auto",
+            // With a trailing slot the container shrinks to its tabs so the
+            // sticky button sits right after the last tab (and pins to the
+            // edge on overflow); the occluder below supplies the right
+            // padding. Otherwise fill the row with symmetric padding.
+            trailing ? "pl-4" : "flex-1 px-4"
+          )}
+        >
           {children}
+          {trailing && (
+            <div className="sticky right-0 ml-1 flex shrink-0 items-center self-stretch border-b border-b-gray-200 bg-white pr-4 pl-2">
+              {trailing}
+            </div>
+          )}
         </div>
         {action && <div className="shrink-0 px-4">{action}</div>}
       </div>


### PR DESCRIPTION
## What

Replaces the boxed **Add Change** button that floated at the far-right of the tab baseline with a quiet, "new tab"–style **`+`** on the tab strip itself — the universal gesture for adding a sibling tab (editors, browsers).

## Why

The old button read as "unplaced": a fully-bordered button gapped off to the right edge, disconnected from both the tab it creates and the `CHANGES` section title.

## Changes

- **First-class `trailing` slot on `PlanDetailTabStrip`.** When present, the strip shrinks to its tabs so the sticky `+` sits right after the last tab, and pins flush to the right edge on overflow (tabs scroll cleanly beneath it). When absent, the strip keeps its original `flex-1` full-width layout, so `DeployStageCard` is unchanged. The strip owns the sticky occluder (background + bottom hairline) — its surface stays a single source of truth.
- **Accessibility:** icon-only button carries `aria-label`, `aria-hidden` icon, `focus-visible` ring, and `touch-action: manipulation`. The tooltip explains the disabled (pending-draft) state and fires even while disabled.
- **Reuse:** the icon-button hover/focus recipe is shared between the per-tab actions menu and the add button via a local `ICON_ACTION_CLASS`.

<img width="2162" height="376" alt="image" src="https://github.com/user-attachments/assets/b8b86c1b-cba7-4227-ab42-4702ad79ab34" />

### Overflow fix

The earlier naive placement let tabs peek through the scroll container's right padding. Root cause: `position: sticky; right: 0` pins to the padding edge. Fixed by giving the container left padding only and moving the right inset onto the occluder, so it pins flush and its background covers to the edge. Verified in an isolated browser repro (flush occluder, 16px button inset, zero peek) across the few-tabs and overflow states.

## Testing

- `pnpm --dir frontend fix` and `type-check` pass
- `PlanDetail` vitest suites pass (31 tests, incl. `DeployStageCard`)
- React layering scanner passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)