### PR TITLE
refactor(instance): use radio buttons for the Cloud SQL IP type selector

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -926,7 +926,7 @@
     "archived-instances-will-not-be-displayed": "Archived instances will not be displayed.",
     "authentication-database": "Authentication Database",
     "cloud-sql-ip-type": {
-      "description": "Select which Cloud SQL IP to connect through. Use Private IP or PSC when the instance has no public IP and Bytebase runs inside the same VPC.",
+      "description": "Use Private IP when the instance has no public IP and Bytebase runs in the same VPC.",
       "label": "Cloud SQL IP type",
       "private": "Private IP",
       "psc": "Private Service Connect (PSC)",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -926,7 +926,7 @@
     "archived-instances-will-not-be-displayed": "Las instancias archivadas no se mostrarán.",
     "authentication-database": "Base de datos de autenticación",
     "cloud-sql-ip-type": {
-      "description": "Selecciona a través de qué IP de Cloud SQL conectarse. Usa IP privada o PSC cuando la instancia no tiene IP pública y Bytebase se ejecuta dentro de la misma VPC.",
+      "description": "Usa IP privada cuando la instancia no tiene IP pública y Bytebase se ejecuta en la misma VPC.",
       "label": "Tipo de IP de Cloud SQL",
       "private": "IP privada",
       "psc": "Private Service Connect (PSC)",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -926,7 +926,7 @@
     "archived-instances-will-not-be-displayed": "アーカイブされたインスタンスは表示されなくなります。",
     "authentication-database": "認証データベース",
     "cloud-sql-ip-type": {
-      "description": "接続に使用する Cloud SQL の IP を選択します。インスタンスにパブリック IP がなく、Bytebase が同じ VPC 内で実行されている場合は、プライベート IP または PSC を使用してください。",
+      "description": "インスタンスにパブリック IP がなく、Bytebase が同じ VPC 内で実行されている場合は、プライベート IP を使用してください。",
       "label": "Cloud SQL IP タイプ",
       "private": "プライベート IP",
       "psc": "Private Service Connect (PSC)",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -926,7 +926,7 @@
     "archived-instances-will-not-be-displayed": "Các phiên bản đã lưu trữ sẽ không được hiển thị.",
     "authentication-database": "Cơ sở dữ liệu xác thực",
     "cloud-sql-ip-type": {
-      "description": "Chọn IP Cloud SQL nào để kết nối. Dùng IP riêng hoặc PSC khi instance không có IP công khai và Bytebase chạy trong cùng một VPC.",
+      "description": "Dùng IP riêng khi instance không có IP công khai và Bytebase chạy trong cùng một VPC.",
       "label": "Loại IP Cloud SQL",
       "private": "IP riêng",
       "psc": "Private Service Connect (PSC)",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -926,7 +926,7 @@
     "archived-instances-will-not-be-displayed": "不再会显示已归档实例。",
     "authentication-database": "认证数据库",
     "cloud-sql-ip-type": {
-      "description": "选择通过哪个 Cloud SQL IP 进行连接。当实例没有公共 IP 且 Bytebase 运行在同一 VPC 内时，请使用私有 IP 或 PSC。",
+      "description": "当实例没有公共 IP 且 Bytebase 运行在同一 VPC 内时，请使用私有 IP。",
       "label": "Cloud SQL IP 类型",
       "private": "私有 IP",
       "psc": "Private Service Connect (PSC)",

--- a/frontend/src/react/components/instance/CredentialSourceForm.tsx
+++ b/frontend/src/react/components/instance/CredentialSourceForm.tsx
@@ -8,13 +8,6 @@ import {
 } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Input } from "@/react/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/react/components/ui/select";
 import { Textarea } from "@/react/components/ui/textarea";
 import { useServerState } from "@/react/hooks/useAppState";
 import { Engine } from "@/types/proto-es/v1/common_pb";
@@ -360,28 +353,23 @@ function CloudSQLIPTypeField({
       <label className="textlabel block">
         {t("instance.cloud-sql-ip-type.label")}
       </label>
-      <Select
-        value={String(current)}
-        disabled={!allowEdit}
-        onValueChange={(val) => {
-          if (val != null) onChange(Number(val) as DataSource_CloudSQLIPType);
-        }}
-      >
-        <SelectTrigger className="mt-2 w-full">
-          <SelectValue>
-            {(v: string | null) =>
-              options.find((o) => String(o.value) === v)?.label ?? null
-            }
-          </SelectValue>
-        </SelectTrigger>
-        <SelectContent>
-          {options.map((o) => (
-            <SelectItem key={o.value} value={String(o.value)}>
-              {o.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <div className="textlabel mt-2 flex gap-x-4">
+        {options.map((option) => (
+          <label
+            key={option.value}
+            className="inline-flex items-center gap-x-1.5"
+          >
+            <input
+              type="radio"
+              name="cloud-sql-ip-type"
+              checked={current === option.value}
+              disabled={!allowEdit}
+              onChange={() => onChange(option.value)}
+            />
+            <span>{option.label}</span>
+          </label>
+        ))}
+      </div>
       <p className="textinfolabel mt-1">
         {t("instance.cloud-sql-ip-type.description")}
       </p>


### PR DESCRIPTION
Follow-up to #20715. The Cloud SQL IP Type control was a dropdown, inconsistent with the authentication-method and credential-source radio groups directly above it in the same form.

- Switched to native radio buttons matching that pattern.
- Small, fixed option set (Public/Private, plus PSC when already set via API) — radios keep the choices visible without a click.
- Reuses `offeredCloudSQLIPTypes`; drops the now-unused `Select` import.
- Presentational refactor: existing tests unchanged + green; type-check and full `biome ci` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)