### PR TITLE
feat(frontend): reserve stable scrollbar gutter on main scroll surfaces

### DIFF
--- a/frontend/src/react/components/DashboardBodyShell.tsx
+++ b/frontend/src/react/components/DashboardBodyShell.tsx
@@ -146,7 +146,7 @@ export function DashboardBodyShell({
             id="bb-layout-main"
             ref={mainContainerRef}
             className={cn(
-              "flex-1 overflow-y-auto",
+              "flex-1 overflow-y-auto scrollbar-gutter-stable",
               variant === "workspace" ? "md:min-w-0" : "min-w-0"
             )}
           >

--- a/frontend/src/react/components/DashboardSidebar.tsx
+++ b/frontend/src/react/components/DashboardSidebar.tsx
@@ -505,7 +505,7 @@ export function DashboardSidebar() {
         <img src={logoSrc} alt="Bytebase" className="max-w-44" />
       </RouterLink>
       <MobileSidebarSwitchers />
-      <div className="flex-1 overflow-y-auto px-2.5 pb-4 flex flex-col gap-y-1">
+      <div className="flex-1 overflow-y-auto scrollbar-gutter-stable px-2.5 pb-4 flex flex-col gap-y-1">
         {filteredItems.map((item, i) => renderItem(item, i))}
       </div>
     </nav>

--- a/frontend/src/react/components/ProjectSidebar.tsx
+++ b/frontend/src/react/components/ProjectSidebar.tsx
@@ -438,7 +438,7 @@ export function ProjectSidebar() {
       >
         <img src={logoSrc} alt="Bytebase" className="max-w-44" />
       </RouterLink>
-      <div className="flex-1 overflow-y-auto px-2.5 pb-4 flex flex-col gap-y-1">
+      <div className="flex-1 overflow-y-auto scrollbar-gutter-stable px-2.5 pb-4 flex flex-col gap-y-1">
         {filteredItems.map((item, i) => renderItem(item, i))}
       </div>
     </nav>

--- a/frontend/src/react/pages/project/ProjectIssueDetailPage.tsx
+++ b/frontend/src/react/pages/project/ProjectIssueDetailPage.tsx
@@ -52,7 +52,7 @@ export function ProjectIssueDetailPage(props: ProjectIssueDetailPageProps) {
     <IssueDetailProvider value={page}>
       <div
         ref={setPageHost}
-        className="relative h-full overflow-x-hidden overflow-y-auto"
+        className="relative h-full overflow-x-hidden overflow-y-auto scrollbar-gutter-stable"
       >
         <div
           className={`flex min-h-full flex-col ${

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionCreatePage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionCreatePage.tsx
@@ -199,7 +199,7 @@ export function ProjectMaskingExemptionCreatePage({
       </div>
 
       {/* Body */}
-      <div className="flex-1 mb-6 px-4 overflow-y-auto">
+      <div className="flex-1 mb-6 px-4 overflow-y-auto scrollbar-gutter-stable">
         <div className="flex flex-col gap-y-8 pt-4">
           <FeatureAttention feature={PlanFeature.FEATURE_DATA_MASKING} />
 

--- a/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
+++ b/frontend/src/react/pages/project/ProjectMaskingExemptionPage.tsx
@@ -443,7 +443,7 @@ export function ProjectMaskingExemptionPage({
             onSelect={setSelectedMemberKey}
             onRevoke={handleRevoke}
           />
-          <div className="flex-1 min-w-0 overflow-y-auto">
+          <div className="flex-1 min-w-0 overflow-y-auto scrollbar-gutter-stable">
             {!membersFromVue.loading && selectedMemberData ? (
               <ExemptionDetailPanel
                 member={selectedMemberData}
@@ -792,7 +792,7 @@ function ExemptionMemberList({
 
   if (loading) {
     return (
-      <div className={cn("overflow-y-auto", className)}>
+      <div className={cn("overflow-y-auto scrollbar-gutter-stable", className)}>
         <div className="flex items-center justify-center py-12">
           <div className="animate-spin rounded-full size-5 border-2 border-accent border-t-transparent" />
         </div>
@@ -802,7 +802,7 @@ function ExemptionMemberList({
 
   if (members.length === 0) {
     return (
-      <div className={cn("overflow-y-auto", className)}>
+      <div className={cn("overflow-y-auto scrollbar-gutter-stable", className)}>
         <div className="flex items-center justify-center py-12 text-control-placeholder text-sm">
           {t("project.masking-exemption.no-exemptions")}
         </div>
@@ -811,7 +811,7 @@ function ExemptionMemberList({
   }
 
   return (
-    <div className={cn("overflow-y-auto", className)}>
+    <div className={cn("overflow-y-auto scrollbar-gutter-stable", className)}>
       <div className="divide-y divide-block-border">
         {members.map((member) => (
           <div key={member.member}>

--- a/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/react/pages/project/ProjectSyncSchemaPage.tsx
@@ -447,7 +447,7 @@ export function ProjectSyncSchemaPage({ projectId }: { projectId: string }) {
           <StepIndicator steps={stepList} currentIndex={currentStep} />
 
           {/* Step content */}
-          <div className="flex-1 overflow-y-auto">
+          <div className="flex-1 overflow-y-auto scrollbar-gutter-stable">
             {currentStep === Step.SELECT_SOURCE_SCHEMA && (
               <SourceSchemaStep
                 project={project}

--- a/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
+++ b/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
@@ -259,7 +259,7 @@ function ProjectPlanDetailPageInner({
     <PlanDetailProvider value={page}>
       <div
         ref={setPageHost}
-        className="relative h-full overflow-x-hidden bg-gray-50"
+        className="relative h-full overflow-x-hidden bg-gray-50 scrollbar-gutter-stable"
       >
         <div
           className={cn(
@@ -562,7 +562,9 @@ function DesktopColumn({
     <div className="min-w-0 border-l bg-white">
       <div className="sticky top-0 flex max-h-[calc(100vh-4rem)] min-h-[calc(100vh-4rem)] flex-col overflow-hidden">
         {header ? <div className="shrink-0">{header}</div> : null}
-        <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-gutter-stable">
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/react/pages/settings/CreateInstancePage.tsx
+++ b/frontend/src/react/pages/settings/CreateInstancePage.tsx
@@ -130,7 +130,7 @@ function CreateInstanceFormInner() {
     >
       <div className="min-w-0 min-h-0 flex-1 flex flex-col">
         {/* Body */}
-        <div className="flex-1 min-h-0 overflow-auto py-4">
+        <div className="flex-1 min-h-0 overflow-auto py-4 scrollbar-gutter-stable">
           <InstanceFormBody onOpenInfoPanel={handleOpenInfoPanel} />
         </div>
 

--- a/frontend/src/react/pages/settings/EnvironmentsPage.tsx
+++ b/frontend/src/react/pages/settings/EnvironmentsPage.tsx
@@ -1598,7 +1598,7 @@ export function EnvironmentsPage() {
           <TabsPanel
             key={env.id}
             value={env.id}
-            className="flex-1 overflow-auto"
+            className="flex-1 overflow-auto scrollbar-gutter-stable"
             keepMounted={false}
           >
             <EnvironmentDetail


### PR DESCRIPTION
## What

Apply Tailwind v4's built-in `scrollbar-gutter-stable` utility to the React app's primary page-scroll surfaces, so content no longer shifts horizontally when a vertical scrollbar appears/disappears (e.g. navigating from a short page to a tall one). Scrollbars are thin (6px), so this reserves a consistent 6px gutter and keeps the content's right edge stable across navigations.

No custom CSS — `scrollbar-gutter-{auto,stable,both}` ships natively in Tailwind 4.3.0.

## Where

| Surface | File |
|---|---|
| Shared main page scroll (`#bb-layout-main`) | `DashboardBodyShell.tsx` |
| Workspace + project nav sidebars | `DashboardSidebar.tsx`, `ProjectSidebar.tsx` |
| Issue detail page host | `ProjectIssueDetailPage.tsx` |
| Plan detail page host + desktop column | `ProjectPlanDetailPage.tsx` |
| Environments tab panel | `EnvironmentsPage.tsx` |
| Create Instance form body | `CreateInstancePage.tsx` |
| Masking Exemption (detail panel + member list) | `ProjectMaskingExemptionPage.tsx` |
| Masking Exemption create body | `ProjectMaskingExemptionCreatePage.tsx` |
| Sync Schema wizard step content | `ProjectSyncSchemaPage.tsx` |

## Deliberately excluded

Compact dropdowns/menus, `max-h-*` popover panels, tables, dialogs/overlays, and the settings sub-pages whose `overflow-x-hidden` wrappers are content-height-driven (they already scroll through `#bb-layout-main`). Adding a gutter there would show an empty 6px strip with no benefit.

## Testing

- `pnpm --dir frontend type-check` ✅
- `pnpm --dir frontend check` (biome) ✅
- Verified against the running Vite build that the compiled CSS emits `.scrollbar-gutter-stable { scrollbar-gutter: stable }` exactly once (from the Tailwind built-in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
