### PR TITLE
feat(frontend): default change-issue review to Plan Detail (BYT-9721)

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/components/review/ReviewSectionHeader.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/review/ReviewSectionHeader.tsx
@@ -1,19 +1,15 @@
 import { Info, ShieldAlert, ShieldCheck } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { RouterLink } from "@/react/components/RouterLink";
 import { Tooltip } from "@/react/components/ui/tooltip";
-import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/react/router/handles";
 import { RiskLevel } from "@/types/proto-es/v1/common_pb";
 import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
 import { extractIssueUID } from "@/utils/v1/issue/issue";
-import { usePlanDetailContext } from "../../shell/PlanDetailContext";
 
 // The Review advance (Comment / Approve / Reject) lives in the page header's
 // lifecycle slot now (BYT-9722), so this section header is title + metadata only
 // — no duplicate Review action.
 export function PlanReviewSectionHeader({ issue }: { issue: Issue }) {
   const { t } = useTranslation();
-  const page = usePlanDetailContext();
   const issueUID = extractIssueUID(issue.name);
 
   return (
@@ -30,15 +26,11 @@ export function PlanReviewSectionHeader({ issue }: { issue: Issue }) {
       </div>
       <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
         <RiskChip riskLevel={issue.riskLevel} />
-        <RouterLink
-          className="inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-xs text-control hover:border-control-border"
-          to={{
-            name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
-            params: { issueId: issueUID, projectId: page.projectId },
-          }}
-        >
+        {/* Static label, not a link: for change plans the issue route redirects
+            back to this Plan Detail page (BYT-9721), so a link would be a no-op. */}
+        <span className="inline-flex shrink-0 items-center rounded-full border px-2 py-0.5 text-xs text-control">
           {t("common.issue")} #{issueUID}
-        </RouterLink>
+        </span>
       </div>
     </div>
   );

--- a/frontend/src/react/router/issueDetailRedirect.test.ts
+++ b/frontend/src/react/router/issueDetailRedirect.test.ts
@@ -1,0 +1,131 @@
+import type { LoaderFunctionArgs } from "react-router-dom";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getIssue: vi.fn(),
+  getPlan: vi.fn(),
+}));
+
+vi.mock("@/connect", () => ({
+  issueServiceClientConnect: { getIssue: mocks.getIssue },
+  planServiceClientConnect: { getPlan: mocks.getPlan },
+}));
+
+import type { Issue } from "@/types/proto-es/v1/issue_service_pb";
+import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
+import type { Plan } from "@/types/proto-es/v1/plan_service_pb";
+import { issueDetailRedirectLoader } from "./issueDetailRedirect";
+
+const PLAN_NAME = "projects/p1/plans/456";
+
+const makeIssue = (type: Issue_Type, plan = ""): Issue =>
+  ({ name: "projects/p1/issues/123", type, plan }) as unknown as Issue;
+
+const makePlan = (cases: string[]): Plan =>
+  ({
+    specs: cases.map((caseName) => ({ config: { case: caseName, value: {} } })),
+  }) as unknown as Plan;
+
+const run = (
+  params: { projectId?: string; issueId?: string },
+  url = "http://localhost/projects/p1/issues/123"
+): Promise<Response | null> =>
+  issueDetailRedirectLoader({
+    params,
+    request: new Request(url),
+  } as unknown as LoaderFunctionArgs);
+
+beforeEach(() => {
+  mocks.getIssue.mockReset();
+  mocks.getPlan.mockReset();
+});
+
+describe("issueDetailRedirectLoader", () => {
+  test("redirects a schema/data change issue to Plan Detail", async () => {
+    mocks.getIssue.mockResolvedValue(
+      makeIssue(Issue_Type.DATABASE_CHANGE, PLAN_NAME)
+    );
+    mocks.getPlan.mockResolvedValue(makePlan(["changeDatabaseConfig"]));
+
+    const res = await run({ projectId: "p1", issueId: "123" });
+
+    expect(res).toBeInstanceOf(Response);
+    expect(res?.status).toBe(302);
+    expect(res?.headers.get("Location")).toBe("/projects/p1/plans/456");
+    expect(mocks.getPlan).toHaveBeenCalledOnce();
+  });
+
+  test("preserves the query string on redirect", async () => {
+    mocks.getIssue.mockResolvedValue(
+      makeIssue(Issue_Type.DATABASE_CHANGE, PLAN_NAME)
+    );
+    mocks.getPlan.mockResolvedValue(makePlan(["changeDatabaseConfig"]));
+
+    const res = await run(
+      { projectId: "p1", issueId: "123" },
+      "http://localhost/projects/p1/issues/123?stageId=7&foo=bar"
+    );
+
+    expect(res?.headers.get("Location")).toBe(
+      "/projects/p1/plans/456?stageId=7&foo=bar"
+    );
+  });
+
+  test("keeps a create-database issue on Issue Detail", async () => {
+    mocks.getIssue.mockResolvedValue(
+      makeIssue(Issue_Type.DATABASE_CHANGE, PLAN_NAME)
+    );
+    mocks.getPlan.mockResolvedValue(makePlan(["createDatabaseConfig"]));
+
+    expect(await run({ projectId: "p1", issueId: "123" })).toBeNull();
+  });
+
+  test("keeps an export issue on Issue Detail without fetching the plan", async () => {
+    mocks.getIssue.mockResolvedValue(
+      makeIssue(Issue_Type.DATABASE_EXPORT, PLAN_NAME)
+    );
+
+    expect(await run({ projectId: "p1", issueId: "123" })).toBeNull();
+    expect(mocks.getPlan).not.toHaveBeenCalled();
+  });
+
+  test("keeps a role-grant issue on Issue Detail", async () => {
+    mocks.getIssue.mockResolvedValue(makeIssue(Issue_Type.ROLE_GRANT));
+
+    expect(await run({ projectId: "p1", issueId: "123" })).toBeNull();
+    expect(mocks.getPlan).not.toHaveBeenCalled();
+  });
+
+  test("keeps an access-grant issue on Issue Detail", async () => {
+    mocks.getIssue.mockResolvedValue(makeIssue(Issue_Type.ACCESS_GRANT));
+
+    expect(await run({ projectId: "p1", issueId: "123" })).toBeNull();
+  });
+
+  test("stays put when a change issue has no plan", async () => {
+    mocks.getIssue.mockResolvedValue(makeIssue(Issue_Type.DATABASE_CHANGE, ""));
+
+    expect(await run({ projectId: "p1", issueId: "123" })).toBeNull();
+    expect(mocks.getPlan).not.toHaveBeenCalled();
+  });
+
+  test("does not fetch or redirect for the 'create' pseudo-issue", async () => {
+    expect(await run({ projectId: "p1", issueId: "create" })).toBeNull();
+    expect(mocks.getIssue).not.toHaveBeenCalled();
+  });
+
+  test("falls through to Issue Detail when the issue fetch fails", async () => {
+    mocks.getIssue.mockRejectedValue(new Error("not found"));
+
+    expect(await run({ projectId: "p1", issueId: "123" })).toBeNull();
+  });
+
+  test("falls through to Issue Detail when the plan fetch fails", async () => {
+    mocks.getIssue.mockResolvedValue(
+      makeIssue(Issue_Type.DATABASE_CHANGE, PLAN_NAME)
+    );
+    mocks.getPlan.mockRejectedValue(new Error("boom"));
+
+    expect(await run({ projectId: "p1", issueId: "123" })).toBeNull();
+  });
+});

--- a/frontend/src/react/router/issueDetailRedirect.ts
+++ b/frontend/src/react/router/issueDetailRedirect.ts
@@ -1,0 +1,67 @@
+import { create } from "@bufbuild/protobuf";
+import { type LoaderFunctionArgs, redirect } from "react-router-dom";
+import { issueServiceClientConnect, planServiceClientConnect } from "@/connect";
+import { shouldStayOnPlanDetailPage } from "@/react/pages/project/plan-detail/utils/header";
+import { issueNamePrefix, projectNamePrefix } from "@/store/modules/v1/common";
+import {
+  GetIssueRequestSchema,
+  Issue_Type,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { GetPlanRequestSchema } from "@/types/proto-es/v1/plan_service_pb";
+import { extractPlanUID } from "@/utils/v1/issue/plan";
+
+// BYT-9721: Plan Detail is the canonical review surface for schema/data change
+// plans (3.20.0). This route loader redirects the issue-detail route to Plan
+// Detail for those issues, preserving the query string. Create-database, export,
+// and grant issues stay on Issue Detail.
+//
+// The discriminator is the plan's specs, not the issue type: schema-change and
+// create-database share the DATABASE_CHANGE proto type, so we fetch the plan and
+// redirect iff `shouldStayOnPlanDetailPage` — the same predicate Plan Detail's
+// own `useRedirects` uses to decide staying. Sharing it guarantees the two can't
+// ping-pong (issue -> plan -> issue -> ...).
+//
+// Every issue-detail entry point navigates to this route by name, so this single
+// guard covers deep links, inbox/notifications, and review CTAs without patching
+// call sites. Old issue-detail URLs resolve via this redirect rather than 404.
+export async function issueDetailRedirectLoader({
+  params,
+  request,
+}: LoaderFunctionArgs): Promise<Response | null> {
+  const { projectId, issueId } = params;
+  if (!projectId || !issueId || issueId.toLowerCase() === "create") {
+    return null;
+  }
+  try {
+    const issue = await issueServiceClientConnect.getIssue(
+      create(GetIssueRequestSchema, {
+        name: `${projectNamePrefix}${projectId}/${issueNamePrefix}${issueId}`,
+      })
+    );
+    // Export and grant issues stay on Issue Detail; skip the plan fetch for them.
+    // (DATABASE_CHANGE covers both schema-change and create-database.)
+    if (issue.type !== Issue_Type.DATABASE_CHANGE || !issue.plan) {
+      return null;
+    }
+    // DATABASE_CHANGE is ambiguous (schema-change vs create-database); the plan's
+    // specs decide. Reuse Plan Detail's own predicate so they can't loop.
+    const plan = await planServiceClientConnect.getPlan(
+      create(GetPlanRequestSchema, { name: issue.plan })
+    );
+    if (!shouldStayOnPlanDetailPage(plan)) {
+      // create-database (and any non-change plan) → Issue Detail.
+      return null;
+    }
+    const planId = extractPlanUID(issue.plan);
+    if (!planId) {
+      return null;
+    }
+    const { search } = new URL(request.url);
+    return redirect(`/projects/${projectId}/plans/${planId}${search}`);
+  } catch {
+    // 404/403/network → fall through to Issue Detail, which has its own
+    // not-found / permission-denied handling. Avoids turning a transient error
+    // into a broken redirect.
+    return null;
+  }
+}

--- a/frontend/src/react/router/routes/dashboard.tsx
+++ b/frontend/src/react/router/routes/dashboard.tsx
@@ -74,6 +74,7 @@ import {
   WORKSPACE_ROUTE_USERS,
   WORKSPACE_ROUTE_WORKLOAD_IDENTITIES,
 } from "@/react/router/handles";
+import { issueDetailRedirectLoader } from "@/react/router/issueDetailRedirect";
 import { RouteShellOutletPlaceholder } from "@/react/router/layoutPlaceholders";
 import { lazyPage } from "@/react/router/lazyPage";
 import { ProjectRouteGate } from "@/react/router/ProjectRouteGate";
@@ -941,13 +942,17 @@ const projectV1Routes: RouteObject[] = [
           (m) => m.ProjectPlanDetailPage
         ),
       },
-      // Issue detail.
+      // Issue detail. Schema/data change issues redirect to Plan Detail — the
+      // canonical review surface (BYT-9721); create-database, export, and grant
+      // issues stay here. The `loader` (static) decides the redirect and the
+      // `lazy` Component renders when it doesn't.
       {
         path: "issues/:issueId",
         handle: {
           name: PROJECT_V1_ROUTE_ISSUE_DETAIL,
           requiredPermissionList: (): Permission[] => ["bb.issues.get"],
         },
+        loader: issueDetailRedirectLoader,
         lazy: lazyPage(
           () => import("@/react/pages/project/ProjectIssueDetailPage"),
           (m) => m.ProjectIssueDetailPage


### PR DESCRIPTION
## What

Makes **Plan Detail** the default review surface for schema/data **change** issues (BYT-9721, 3.20.0). A single route-level `loader` on `issues/:issueId` redirects those issues to Plan Detail; other issue types stay on Issue Detail.

| Issue | Surface |
|---|---|
| Schema/data change (`changeDatabaseConfig`) | **Plan Detail** (query string preserved) |
| Create database (also `DATABASE_CHANGE` type) | Issue Detail |
| Export, role grant, access grant | Issue Detail |

## Why

3.19.1 (BYT-9554) made Plan Detail a complete review surface (approval flow, activity, approve/reject inline). This makes it the default for CI/CD change review, leaving Issue Detail for non-change types.

## How

- New `issueDetailRedirectLoader` on the issue-detail route. Because schema-change and create-database share the `DATABASE_CHANGE` proto type, the loader fetches the plan and redirects **iff `shouldStayOnPlanDetailPage(plan)`** — the *same* predicate Plan Detail's own `useRedirects` hook uses to bounce non-change plans back. Sharing it makes the two guards exact inverses, so an issue can't ping-pong between the two pages.
- The `loader` (static) decides the redirect; the `lazy` Component renders when it doesn't. Fast-paths export/grant issues (no plan fetch). Any fetch error falls through to Issue Detail, which owns its own 404/permission handling.
- Plan Detail's existing bounce (`useRedirects` / `shouldStayOnPlanDetailPage`) is **unchanged** — it already keeps only change plans.
- Demotes the now-circular "Issue #N" link in the plan review-section header to a static label (for change plans it would redirect right back to the same page).

One guard covers every entry point (deep links, inbox/notifications, review CTAs) since they all resolve to the issue route by name — no call-site patching.

## Behavior change

Following a review link for a schema/data change issue now lands on Plan Detail instead of Issue Detail. Not upgrade-breaking: old Issue Detail URLs redirect (not 404), Issue Detail stays addressable for all other types, and there are no API/proto/config changes.

## Testing

- New `issueDetailRedirect.test.ts` (10 cases): change → redirect; create-database / export / grant → stay; no-plan / `create` pseudo-issue / fetch-error → stay; query string preserved; `getPlan` skipped for export & grants.
- `pnpm --dir frontend check` + `type-check` clean; router (48), plan-detail review (50), and related issue/plan-detail (22) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
