### PR TITLE
fix(frontend): distinct icons for close/reopen in plan review activity

### DIFF
--- a/frontend/src/react/components/issue-activity/IssueCommentActivity.tsx
+++ b/frontend/src/react/components/issue-activity/IssueCommentActivity.tsx
@@ -297,8 +297,14 @@ function IssueCommentActionIcon({ issue, plan, comment }: ActivityProps) {
       return <ActivityBadge spec={ISSUE_EVENT_ICON.resolved} />;
     }
 
-    const { fromLabels, toDescription, toLabels, toTitle } =
+    const { fromLabels, toDescription, toLabels, toStatus, toTitle } =
       comment.event.value;
+    if (toStatus === IssueStatus.CANCELED) {
+      return <ActivityBadge spec={ISSUE_EVENT_ICON.closed} />;
+    }
+    if (toStatus === IssueStatus.OPEN) {
+      return <ActivityBadge spec={ISSUE_EVENT_ICON.reopened} />;
+    }
     if (
       toTitle !== undefined ||
       toDescription !== undefined ||

--- a/frontend/src/react/components/issue-activity/activityIcons.ts
+++ b/frontend/src/react/components/issue-activity/activityIcons.ts
@@ -16,11 +16,15 @@
 //   Plan change (activity):  added / deleted / edited — one symmetric "file"
 //     trio, so "edit a change" (FilePen) never collides with an issue-field
 //     edit (Pencil) or a reject.
-//   Issue event (activity):  field edit (Pencil) / resolved (CheckCircle2)
+//   Issue event (activity):  field edit (Pencil) / resolved (CheckCircle2) /
+//     closed (Ban) / reopened (CircleDot) — a close/reopen is a lifecycle
+//     transition, so it stays neutral rather than reading as a verdict.
 //
 // `Pencil` is reserved for exactly one meaning — an issue *field* edit.
 import {
+  Ban,
   CheckCircle2,
+  CircleDot,
   FileMinus2,
   FilePen,
   FilePlus2,
@@ -57,6 +61,8 @@ export const PLAN_CHANGE_ICON = {
 export const ISSUE_EVENT_ICON = {
   fieldEdit: { Icon: Pencil, tone: "neutral" },
   resolved: { Icon: CheckCircle2, tone: "success" },
+  closed: { Icon: Ban, tone: "neutral" },
+  reopened: { Icon: CircleDot, tone: "neutral" },
 } satisfies Record<string, ActivityIconSpec>;
 
 // Tone → classes. Activity badges fill the circle (white glyph on bg-tone);


### PR DESCRIPTION
## What

In the plan-detail **Review → Activity** timeline, the close and reopen actions now render distinct status icons instead of the user-avatar badge that made them look like a plain comment.

- **Close** (issue status → `CANCELED`): gray circle-slash (`Ban`)
- **Reopen** (issue status → `OPEN`): gray circle-dot (`CircleDot`)

## Why

The activity icon selector's `ISSUE_UPDATE` branch only inspected title / description / labels, so status-change comments fell through to the user-avatar default — visually identical to a user comment. The action *sentence* already distinguished close/reopen; only the icon lagged.

## How

<img width="1910" height="1088" alt="image" src="https://github.com/user-attachments/assets/acbf1dd9-ffe7-4ec3-97da-536b37486fbc" />

- Add `closed` (`Ban`) and `reopened` (`CircleDot`) specs to the `ISSUE_EVENT_ICON` family in `activityIcons.ts`, both **neutral** tone — a close/reopen is a lifecycle transition, not a positive/negative verdict, and neutral keeps them from competing with the green resolves or the red reject.
- Map `toStatus === CANCELED` / `OPEN` in `IssueCommentActionIcon`, before the existing field-edit fallthrough.

Both glyphs are circular, so they sit in the same family as the existing resolved (`CheckCircle2`) badge. No new locale keys — the sentences already existed. Status entries aren't consolidated, so they render as standalone rows and reach the selector.

Scope note: a plain resolve (DONE without a rollout) still uses the avatar; that is the same fallthrough class but was intentionally left out of this change.

## Testing

- `pnpm --dir frontend type-check`: clean
- `pnpm --dir frontend check` (biome ci + i18n / layering / locale guardrails): clean
- Review-section vitest suite: 50/50 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
