### PR TITLE
fix(frontend): reset plan-detail poller backoff after task actions

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
@@ -212,7 +212,7 @@ export const usePlanDetailPage = ({
     [syncDefaultActivePhases]
   );
 
-  const refreshState = useCallback(async () => {
+  const fetchState = useCallback(async () => {
     try {
       setIsRefreshing(true);
       const current = latestSnapshotRef.current;
@@ -292,10 +292,19 @@ export const usePlanDetailPage = ({
     );
   }, [snapshot.rollout]);
 
-  usePolling({
+  const { restart: restartPolling } = usePolling({
     enabled: snapshot.ready && !snapshot.isCreating && !isPlanDone,
-    refreshState,
+    refreshState: fetchState,
   });
+
+  // Public refresh used by user actions (run/skip/cancel a task, edits, etc.).
+  // It fetches immediately and then resets the poll backoff so the follow-up
+  // status transition (e.g. a task moving PENDING -> RUNNING) is observed on
+  // the next ~1s tick instead of waiting out the current backoff interval.
+  const refreshState = useCallback(async () => {
+    await fetchState();
+    restartPolling();
+  }, [fetchState, restartPolling]);
 
   return useDerivedPlanState({
     snapshot,

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePolling.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePolling.ts
@@ -7,8 +7,24 @@ export interface UsePollingParams {
   refreshState: () => Promise<void>;
 }
 
-export function usePolling({ enabled, refreshState }: UsePollingParams): void {
+export interface UsePollingResult {
+  // Reset the backoff and poll again from the minimum interval. Call this
+  // after a user-triggered mutation (run/skip/cancel a task, etc.) so the UI
+  // watches closely for the resulting status transition instead of waiting out
+  // the current (possibly maxed-out) backoff interval.
+  restart: () => void;
+}
+
+export function usePolling({
+  enabled,
+  refreshState,
+}: UsePollingParams): UsePollingResult {
   const pollTimerRef = useRef<number | undefined>(undefined);
+  // `active` mirrors the effect's mounted+enabled lifetime so a late-resolving
+  // refreshState (or a `restart` racing an unmount) cannot schedule a new poll.
+  const activeRef = useRef(false);
+  const refreshStateRef = useRef(refreshState);
+  refreshStateRef.current = refreshState;
 
   const stopPolling = useCallback(() => {
     if (!pollTimerRef.current) {
@@ -18,15 +34,8 @@ export function usePolling({ enabled, refreshState }: UsePollingParams): void {
     pollTimerRef.current = undefined;
   }, []);
 
-  useEffect(() => {
-    if (!enabled) {
-      stopPolling();
-      return;
-    }
-
-    let canceled = false;
-
-    const poll = (interval: number) => {
+  const scheduleNext = useCallback(
+    (interval: number) => {
       stopPolling();
       const nextInterval = minmax(
         interval +
@@ -37,24 +46,43 @@ export function usePolling({ enabled, refreshState }: UsePollingParams): void {
       );
 
       pollTimerRef.current = window.setTimeout(async () => {
-        if (canceled) {
+        if (!activeRef.current) {
           return;
         }
-        await refreshState().catch(() => undefined);
-        if (canceled) {
+        await refreshStateRef.current().catch(() => undefined);
+        if (!activeRef.current) {
           return;
         }
-        poll(
+        scheduleNext(
           Math.min(nextInterval * POLLER_INTERVAL.growth, POLLER_INTERVAL.max)
         );
       }, nextInterval);
-    };
+    },
+    [stopPolling]
+  );
 
-    poll(POLLER_INTERVAL.min);
+  const restart = useCallback(() => {
+    if (!activeRef.current) {
+      return;
+    }
+    scheduleNext(POLLER_INTERVAL.min);
+  }, [scheduleNext]);
+
+  useEffect(() => {
+    if (!enabled) {
+      activeRef.current = false;
+      stopPolling();
+      return;
+    }
+
+    activeRef.current = true;
+    scheduleNext(POLLER_INTERVAL.min);
 
     return () => {
-      canceled = true;
+      activeRef.current = false;
       stopPolling();
     };
-  }, [enabled, refreshState, stopPolling]);
+  }, [enabled, scheduleNext, stopPolling]);
+
+  return { restart };
 }


### PR DESCRIPTION
## What

Running a task from the plan detail deploy phase left it stuck in **PENDING** in the UI for several seconds (up to ~30s) before flipping to **RUNNING**, even though the backend transitions it in under a second.

## Why

The plan-detail poller (`usePolling`) uses exponential backoff (1s → 2s → … → 30s). Because `refreshState` was a stable callback, the poll effect never re-ran, so the interval grew to 30s and stayed there while the page sat idle.

When a task action (run/skip/cancel) completed, its `onConfirm` called `refreshState()` once — but at that instant a freshly created task run reads back as `PENDING` (backend maps both `TaskRun_PENDING` and `TaskRun_AVAILABLE` → `Task_PENDING`). That one manual fetch **never rescheduled the poll timer**, so the follow-up `PENDING → RUNNING` transition wasn't observed until the next scheduled poll — up to ~30s out.

## How

- **`usePolling.ts`** now returns a stable `restart()` that clears the pending timer and polls again from the minimum interval. Cancellation is tracked via an `active` ref so a `restart` (or a late-resolving fetch) can't schedule a poll after unmount/disable. Backoff logic is otherwise unchanged.
- **`usePlanDetailPage.ts`** splits the fetch: a private `fetchState` drives the poller (normal ticks still back off to spare the server), while the public `refreshState` — used by every task action — does `await fetchState()` then `restartPolling()`.

All deploy-phase actions route through the single public `refreshState`, so they all get the fast follow-up automatically. Idle backoff behavior is preserved.

> Note: the issue-detail page has the same inline poller pattern (still live for create-database issues) and would benefit from the same fix (ideally by extracting the shared `usePolling` hook). Deferred to a follow-up to keep this change focused.

## Testing

- `pnpm --dir frontend fix` — no changes
- `pnpm --dir frontend type-check` — passes
- `pnpm --dir frontend test` — 2547 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)