### PR TITLE
fix(frontend): use canonical status icon in rollout panels and run tables

### DIFF
--- a/frontend/scripts/check-react-i18n.mjs
+++ b/frontend/scripts/check-react-i18n.mjs
@@ -80,8 +80,9 @@ const DYNAMIC_PREFIXES = [
   //   - sheet.{mine,shared} — src/views/sql-editor/Sheet/context.ts
   "sheet.mine",
   "sheet.shared",
-  //   - task.status.available — src/utils/v1/issue/rollout.ts
+  //   - task.status.available / .not-started — src/utils/v1/issue/rollout.ts
   "task.status.available",
+  "task.status.not-started",
   //   - auth.token-expired-description — src/connect/middlewares/authInterceptorMiddleware.ts
   "auth.token-expired-description",
   //   - issue.title.export-data — src/utils/v1/issue/issue.ts

--- a/frontend/src/react/components/TaskRunStatusIcon.tsx
+++ b/frontend/src/react/components/TaskRunStatusIcon.tsx
@@ -1,0 +1,39 @@
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
+import {
+  Task_Status,
+  TaskRun_Status,
+} from "@/types/proto-es/v1/rollout_service_pb";
+
+// A task run is a single execution attempt, so it only ever reaches a subset of
+// Task_Status. Map the run status onto the canonical TaskStatusIcon so run
+// history shares the exact same status vocabulary as tasks and stages.
+function toTaskStatus(status: TaskRun_Status): Task_Status {
+  switch (status) {
+    case TaskRun_Status.PENDING:
+      return Task_Status.PENDING;
+    case TaskRun_Status.RUNNING:
+      return Task_Status.RUNNING;
+    case TaskRun_Status.DONE:
+      return Task_Status.DONE;
+    case TaskRun_Status.FAILED:
+      return Task_Status.FAILED;
+    case TaskRun_Status.CANCELED:
+      return Task_Status.CANCELED;
+    default:
+      return Task_Status.STATUS_UNSPECIFIED;
+  }
+}
+
+/**
+ * Canonical status icon for a task run. Renders the shared `TaskStatusIcon`
+ * so run history stays visually consistent with task and stage status.
+ */
+export function TaskRunStatusIcon({
+  status,
+  size = "small",
+}: {
+  status: TaskRun_Status;
+  size?: "tiny" | "small" | "medium" | "large";
+}) {
+  return <TaskStatusIcon size={size} status={toTaskStatus(status)} />;
+}

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRolloutActionPanel.tsx
@@ -1,10 +1,11 @@
 import { create } from "@bufbuild/protobuf";
 import { TimestampSchema } from "@bufbuild/protobuf/wkt";
-import { Check, FastForward, Loader2, Pause, X } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
 import { EngineIcon } from "@/react/components/EngineIcon";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
@@ -17,10 +18,8 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { Textarea } from "@/react/components/ui/textarea";
-import { Tooltip } from "@/react/components/ui/tooltip";
 import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
-import { cn } from "@/react/lib/utils";
 import {
   ScheduledRunTimeInput,
   TASK_ROLLOUT_ACTION_SHEET_WIDTH,
@@ -36,7 +35,6 @@ import {
   ListTaskRunsRequestSchema,
   type Stage,
   type Task,
-  Task_Status,
   Task_Type,
   TaskRun_Status,
 } from "@/types/proto-es/v1/rollout_service_pb";
@@ -367,7 +365,7 @@ export function IssueDetailTaskRolloutActionPanel({
                         className="flex h-8 items-center gap-x-2"
                         key={task.name}
                       >
-                        <IssueDetailTaskStatus status={task.status} />
+                        <TaskStatusIcon size="small" status={task.status} />
                         <IssueDetailTaskDatabaseName task={task} />
                       </li>
                     ))}
@@ -643,91 +641,4 @@ function IssueDetailStageEnvironment({
       {environment.title || environmentName.split("/").at(-1)}
     </span>
   );
-}
-
-function IssueDetailTaskStatus({ status }: { status: Task_Status }) {
-  const { t } = useTranslation();
-  return (
-    <Tooltip content={taskStatusLabel(t, status)}>
-      <div
-        aria-label={taskStatusLabel(t, status)}
-        className={cn(
-          "relative flex h-5 w-5 shrink-0 select-none items-center justify-center overflow-hidden rounded-full",
-          taskStatusClassName(status)
-        )}
-      >
-        {status === Task_Status.NOT_STARTED && (
-          <span className="h-1/2 w-1/2 rounded-full bg-control" />
-        )}
-        {status === Task_Status.PENDING && <Pause className="h-3/4 w-3/4" />}
-        {status === Task_Status.RUNNING && (
-          <div className="relative flex h-1/2 w-1/2 overflow-visible">
-            <span
-              className="absolute z-0 h-full w-full animate-ping-slow rounded-full"
-              style={{ backgroundColor: "rgba(37, 99, 235, 0.5)" }}
-            />
-            <span className="z-1 h-full w-full rounded-full bg-info" />
-          </div>
-        )}
-        {status === Task_Status.SKIPPED && (
-          <FastForward className="h-3/4 w-3/4" />
-        )}
-        {status === Task_Status.DONE && <Check className="h-3/4 w-3/4" />}
-        {status === Task_Status.FAILED && (
-          <span className="rounded-full text-base font-medium">!</span>
-        )}
-        {status === Task_Status.CANCELED && (
-          <span className="text-base leading-none">-</span>
-        )}
-        {status !== Task_Status.CANCELED &&
-          status !== Task_Status.FAILED &&
-          status !== Task_Status.DONE &&
-          status !== Task_Status.SKIPPED &&
-          status !== Task_Status.RUNNING &&
-          status !== Task_Status.PENDING &&
-          status !== Task_Status.NOT_STARTED && <X className="h-3/4 w-3/4" />}
-      </div>
-    </Tooltip>
-  );
-}
-
-function taskStatusClassName(status: Task_Status) {
-  switch (status) {
-    case Task_Status.NOT_STARTED:
-      return "border-2 border-control bg-white";
-    case Task_Status.PENDING:
-    case Task_Status.RUNNING:
-      return "border-2 border-info bg-white text-info";
-    case Task_Status.SKIPPED:
-      return "border-2 border-control-light bg-white text-gray-600";
-    case Task_Status.DONE:
-      return "bg-success text-white";
-    case Task_Status.FAILED:
-      return "bg-error text-white";
-    case Task_Status.CANCELED:
-      return "border-2 border-control-light bg-white text-control-light";
-    default:
-      return "border border-dashed border-control bg-white";
-  }
-}
-
-function taskStatusLabel(t: (key: string) => string, status: Task_Status) {
-  switch (status) {
-    case Task_Status.NOT_STARTED:
-      return t("task.status.not-started");
-    case Task_Status.PENDING:
-      return t("task.status.pending");
-    case Task_Status.RUNNING:
-      return t("task.status.running");
-    case Task_Status.SKIPPED:
-      return t("task.status.skipped");
-    case Task_Status.DONE:
-      return t("task.status.done");
-    case Task_Status.FAILED:
-      return t("task.status.failed");
-    case Task_Status.CANCELED:
-      return t("task.status.canceled");
-    default:
-      return t("task.status.not-started");
-  }
 }

--- a/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
+++ b/frontend/src/react/pages/project/issue-detail/components/IssueDetailTaskRunTable.tsx
@@ -1,10 +1,10 @@
 import { create } from "@bufbuild/protobuf";
 import { DurationSchema } from "@bufbuild/protobuf/wkt";
-import { Check, Minus } from "lucide-react";
 import { useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { HumanizeTs } from "@/react/components/HumanizeTs";
+import { TaskRunStatusIcon } from "@/react/components/TaskRunStatusIcon";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
 import {
   Table,
@@ -14,9 +14,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/react/components/ui/table";
-import { Tooltip } from "@/react/components/ui/tooltip";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
-import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { projectNamePrefix } from "@/store/modules/v1/common";
 import {
@@ -140,7 +138,7 @@ export function IssueDetailTaskRunTable({
               return (
                 <TableRow key={taskRun.name}>
                   <TableCell className="px-2">
-                    <IssueDetailTaskRunStatusIcon status={taskRun.status} />
+                    <TaskRunStatusIcon status={taskRun.status} />
                   </TableCell>
                   {showDatabaseColumn && (
                     <TableCell>
@@ -176,52 +174,6 @@ export function IssueDetailTaskRunTable({
         </Table>
       </div>
     </>
-  );
-}
-
-function IssueDetailTaskRunStatusIcon({ status }: { status: TaskRun_Status }) {
-  const { t } = useTranslation();
-  const classes = (() => {
-    switch (status) {
-      case TaskRun_Status.PENDING:
-        return "bg-white border-2 border-info text-info";
-      case TaskRun_Status.RUNNING:
-        return "bg-white border-2 border-info text-info";
-      case TaskRun_Status.DONE:
-        return "bg-success text-white";
-      case TaskRun_Status.FAILED:
-        return "bg-error text-white";
-      case TaskRun_Status.CANCELED:
-        return "bg-white border-2 border-gray-400 text-gray-400";
-      default:
-        return "";
-    }
-  })();
-
-  return (
-    <Tooltip content={taskRunStatusLabel(t, status)}>
-      <div
-        className={cn(
-          "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full select-none",
-          classes
-        )}
-      >
-        {status === TaskRun_Status.PENDING && (
-          <span className="h-1.5 w-1.5 rounded-full bg-info" />
-        )}
-        {status === TaskRun_Status.RUNNING && (
-          <div className="relative flex h-2.5 w-2.5 overflow-visible">
-            <span className="absolute z-0 h-full w-full animate-ping-slow rounded-full bg-blue-600/50" />
-            <span className="z-1 h-full w-full rounded-full bg-info" />
-          </div>
-        )}
-        {status === TaskRun_Status.DONE && <Check className="h-4 w-4" />}
-        {status === TaskRun_Status.FAILED && (
-          <span className="text-base font-medium text-white">!</span>
-        )}
-        {status === TaskRun_Status.CANCELED && <Minus className="h-4 w-4" />}
-      </div>
-    </Tooltip>
   );
 }
 
@@ -349,24 +301,4 @@ function executionDurationOfTaskRun(taskRun: TaskRun) {
     nanos: (elapsedMS % 1000) * 1e6,
     seconds: BigInt(Math.floor(elapsedMS / 1000)),
   });
-}
-
-function taskRunStatusLabel(
-  t: ReturnType<typeof useTranslation>["t"],
-  status: TaskRun_Status
-) {
-  switch (status) {
-    case TaskRun_Status.PENDING:
-      return t("task.status.pending");
-    case TaskRun_Status.RUNNING:
-      return t("task.status.running");
-    case TaskRun_Status.DONE:
-      return t("task.status.done");
-    case TaskRun_Status.FAILED:
-      return t("task.status.failed");
-    case TaskRun_Status.CANCELED:
-      return t("task.status.canceled");
-    default:
-      return String(status);
-  }
 }

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRolloutActionPanel.tsx
@@ -1,9 +1,10 @@
 import { create } from "@bufbuild/protobuf";
 import { TimestampSchema } from "@bufbuild/protobuf/wkt";
-import { Check, FastForward, Loader2, Pause, X } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/connect";
+import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
@@ -18,7 +19,6 @@ import {
 import { Textarea } from "@/react/components/ui/textarea";
 import { Tooltip } from "@/react/components/ui/tooltip";
 import { useCurrentUser } from "@/react/hooks/useAppState";
-import { cn } from "@/react/lib/utils";
 import { useAppStore } from "@/react/stores/app";
 import { pushNotification } from "@/store";
 import { projectNamePrefix } from "@/store/modules/v1/common";
@@ -29,7 +29,6 @@ import {
   BatchRunTasksRequestSchema,
   BatchSkipTasksRequestSchema,
   ListTaskRunsRequestSchema,
-  Task_Status,
   Task_Type,
   TaskRun_Status,
 } from "@/types/proto-es/v1/rollout_service_pb";
@@ -351,7 +350,7 @@ export function PlanDetailTaskRolloutActionPanel({
                         className="flex h-8 items-center gap-x-2"
                         key={task.name}
                       >
-                        <PlanDetailTaskStatus status={task.status} />
+                        <TaskStatusIcon size="small" status={task.status} />
                         <PlanDetailTaskDatabaseName task={task} />
                       </li>
                     ))}
@@ -600,92 +599,4 @@ function PlanDetailStageEnvironment({
       {environment.title || environmentName.split("/").at(-1)}
     </span>
   );
-}
-
-function PlanDetailTaskStatus({ status }: { status: Task_Status }) {
-  const { t } = useTranslation();
-  const label = taskStatusLabel(t, status);
-  return (
-    <Tooltip content={label}>
-      <div
-        aria-label={label}
-        className={cn(
-          "relative flex h-5 w-5 shrink-0 select-none items-center justify-center overflow-hidden rounded-full",
-          taskStatusClassName(status)
-        )}
-      >
-        {status === Task_Status.NOT_STARTED && (
-          <span className="h-1/2 w-1/2 rounded-full bg-control" />
-        )}
-        {status === Task_Status.PENDING && <Pause className="h-3/4 w-3/4" />}
-        {status === Task_Status.RUNNING && (
-          <div className="relative flex h-1/2 w-1/2 overflow-visible">
-            <span
-              className="absolute z-0 h-full w-full animate-ping-slow rounded-full"
-              style={{ backgroundColor: "rgba(37, 99, 235, 0.5)" }}
-            />
-            <span className="z-1 h-full w-full rounded-full bg-info" />
-          </div>
-        )}
-        {status === Task_Status.SKIPPED && (
-          <FastForward className="h-3/4 w-3/4" />
-        )}
-        {status === Task_Status.DONE && <Check className="h-3/4 w-3/4" />}
-        {status === Task_Status.FAILED && (
-          <span className="rounded-full text-base font-medium">!</span>
-        )}
-        {status === Task_Status.CANCELED && (
-          <span className="text-base leading-none">-</span>
-        )}
-        {status !== Task_Status.CANCELED &&
-          status !== Task_Status.FAILED &&
-          status !== Task_Status.DONE &&
-          status !== Task_Status.SKIPPED &&
-          status !== Task_Status.RUNNING &&
-          status !== Task_Status.PENDING &&
-          status !== Task_Status.NOT_STARTED && <X className="h-3/4 w-3/4" />}
-      </div>
-    </Tooltip>
-  );
-}
-
-function taskStatusClassName(status: Task_Status) {
-  switch (status) {
-    case Task_Status.NOT_STARTED:
-      return "border-2 border-control bg-white";
-    case Task_Status.PENDING:
-    case Task_Status.RUNNING:
-      return "border-2 border-info bg-white text-info";
-    case Task_Status.SKIPPED:
-      return "border-2 border-control-light bg-white text-gray-600";
-    case Task_Status.DONE:
-      return "bg-success text-white";
-    case Task_Status.FAILED:
-      return "bg-error text-white";
-    case Task_Status.CANCELED:
-      return "border-2 border-control-light bg-white text-control-light";
-    default:
-      return "border border-dashed border-control bg-white";
-  }
-}
-
-function taskStatusLabel(t: (key: string) => string, status: Task_Status) {
-  switch (status) {
-    case Task_Status.NOT_STARTED:
-      return t("task.status.not-started");
-    case Task_Status.PENDING:
-      return t("task.status.pending");
-    case Task_Status.RUNNING:
-      return t("task.status.running");
-    case Task_Status.SKIPPED:
-      return t("task.status.skipped");
-    case Task_Status.DONE:
-      return t("task.status.done");
-    case Task_Status.FAILED:
-      return t("task.status.failed");
-    case Task_Status.CANCELED:
-      return t("task.status.canceled");
-    default:
-      return t("task.status.not-started");
-  }
 }

--- a/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRunTable.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/PlanDetailTaskRunTable.tsx
@@ -1,9 +1,9 @@
 import { create } from "@bufbuild/protobuf";
 import { DurationSchema } from "@bufbuild/protobuf/wkt";
-import { Check, Minus } from "lucide-react";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { HumanizeTs } from "@/react/components/HumanizeTs";
+import { TaskRunStatusIcon } from "@/react/components/TaskRunStatusIcon";
 import { Button } from "@/react/components/ui/button";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
 import {
@@ -21,7 +21,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/react/components/ui/table";
-import { Tooltip } from "@/react/components/ui/tooltip";
 import { useAppStore } from "@/react/stores/app";
 import {
   getDateForPbTimestampProtoEs,
@@ -157,52 +156,6 @@ export function PlanDetailTaskRunTable({
   );
 }
 
-function TaskRunStatusIcon({ status }: { status: TaskRun_Status }) {
-  const { t } = useTranslation();
-  const classes = (() => {
-    switch (status) {
-      case TaskRun_Status.PENDING:
-        return "border-2 border-info bg-white text-info";
-      case TaskRun_Status.RUNNING:
-        return "border-2 border-info bg-white text-info";
-      case TaskRun_Status.DONE:
-        return "bg-success text-white";
-      case TaskRun_Status.FAILED:
-        return "bg-error text-white";
-      case TaskRun_Status.CANCELED:
-        return "border-2 border-gray-400 bg-white text-gray-400";
-      default:
-        return "";
-    }
-  })();
-
-  return (
-    <Tooltip content={taskRunStatusLabel(t, status)}>
-      <div
-        className={[
-          "relative flex h-5 w-5 shrink-0 items-center justify-center rounded-full select-none",
-          classes,
-        ].join(" ")}
-      >
-        {status === TaskRun_Status.PENDING && (
-          <span className="h-1.5 w-1.5 rounded-full bg-info" />
-        )}
-        {status === TaskRun_Status.RUNNING && (
-          <div className="relative flex h-2.5 w-2.5 overflow-visible">
-            <span className="absolute z-0 h-full w-full animate-ping-slow rounded-full bg-blue-600/50" />
-            <span className="z-1 h-full w-full rounded-full bg-info" />
-          </div>
-        )}
-        {status === TaskRun_Status.DONE && <Check className="h-4 w-4" />}
-        {status === TaskRun_Status.FAILED && (
-          <span className="text-base font-medium text-white">!</span>
-        )}
-        {status === TaskRun_Status.CANCELED && <Minus className="h-4 w-4" />}
-      </div>
-    </Tooltip>
-  );
-}
-
 function TaskRunComment({ taskRun }: { taskRun: TaskRun }) {
   const { t } = useTranslation();
   const earliestAllowedTime = taskRun.runTime
@@ -284,26 +237,6 @@ function executionDurationOfTaskRun(taskRun: TaskRun) {
     nanos: (elapsedMS % 1000) * 1e6,
     seconds: BigInt(Math.floor(elapsedMS / 1000)),
   });
-}
-
-function taskRunStatusLabel(
-  t: ReturnType<typeof useTranslation>["t"],
-  status: TaskRun_Status
-) {
-  switch (status) {
-    case TaskRun_Status.PENDING:
-      return t("task.status.pending");
-    case TaskRun_Status.RUNNING:
-      return t("task.status.running");
-    case TaskRun_Status.DONE:
-      return t("task.status.done");
-    case TaskRun_Status.FAILED:
-      return t("task.status.failed");
-    case TaskRun_Status.CANCELED:
-      return t("task.status.canceled");
-    default:
-      return String(status);
-  }
 }
 
 function shouldShowDetailButton(taskRun: TaskRun) {


### PR DESCRIPTION
## What

The rollout action drawers (Run / Skip / Cancel) and the task-run history tables each carried their own **inline copy** of the status icon — the pre-redesign version (`animate-ping`, `bg-info`, `Pause`/`FastForward`, text `!` / `−`). They never picked up the redesigned `TaskStatusIcon`, so e.g. the cancel-task drawer rendered a stale blue ring/dot for a running task.

- Both rollout action panels (Plan + Issue) now render the canonical `TaskStatusIcon`.
- Added a canonical `TaskRunStatusIcon` wrapper that maps `TaskRun_Status` → `TaskStatusIcon`, and both run-history tables now use it — so task-run status shares the exact same vocabulary as task/stage status.
- Deleted ~320 lines of duplicated icon markup across the four files. There is now a single source of truth for rollout status icons.
- Whitelisted `task.status.not-started` in the React i18n checker: the only literal `t("...")` call for that key lived inside the deleted duplicates, but the key is still live via the aliased `translate()` in `src/utils/v1/issue/rollout.ts` — the same reason its sibling `task.status.available` is already whitelisted two lines above. No locale JSON changed.

Follows up the status-icon redesign (#20731) by bringing the last stragglers onto the shared component.

## Testing

- `pnpm --dir frontend type-check` — passes
- `pnpm --dir frontend check` — passes (biome ci, React i18n, React layering, locale sorter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
