### PR TITLE
docs: describe the frontend as React in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Bytebase is the standard for database development. Every product and engineering
 
 ### Frontend Code Changes
 
-1. **Fix** — Run `pnpm --dir frontend fix` to auto-fix ESLint + Biome issues (format, lint, organize imports)
+1. **Fix** — Run `pnpm --dir frontend fix` to auto-fix Biome issues (format, lint, organize imports)
 2. **Check** — Run `pnpm --dir frontend check` to validate without modifying files (for CI)
 3. **Type check** — Run `pnpm --dir frontend type-check`
 4. **Test** — Run `pnpm --dir frontend test`
@@ -73,7 +73,7 @@ pnpm --dir frontend i
 # Dev server
 pnpm --dir frontend dev
 
-# Fix (ESLint + Biome: format, lint, organize imports)
+# Fix (Biome: format, lint, organize imports)
 pnpm --dir frontend fix
 
 # Check (validate without modifying, for CI)
@@ -136,9 +136,9 @@ psql -U bbdev bbdev
   - **No Empty Objects**: Do not add empty JSON objects (e.g., `"key": {}`) to locale files. Remove any empty objects you encounter
 - **Button Spacing**: Use `gap-x-2` for ALL button groups (modals, drawers, toolbars, inline actions). Never use `space-x` for buttons. See `./frontend/.claude/BUTTON_SPACING_STANDARDIZATION.md` for full guidelines
 
-### React (New Code)
+### React
 
-The frontend is migrating from Vue to React. **All new UI code should be written in React.**
+The frontend is built entirely in React. **All UI code is React** — use the stack and component patterns below.
 
 **Stack**: React + [Base UI](https://base-ui.com/) (`@base-ui/react`) + Tailwind CSS v4 + shadcn-style component patterns
 
@@ -146,7 +146,7 @@ The frontend is migrating from Vue to React. **All new UI code should be written
 - Build UI components in the shadcn style — `class-variance-authority` (cva) for variant props, `clsx`/`tailwind-merge` for class merging
 - Wrap Base UI primitives (Button, Tabs, Input, etc.) with styled variants in `./frontend/src/react/components/ui/`
 - Use `useTranslation()` from `react-i18next` for i18n
-- Use CSS custom properties (`--color-accent`, `--color-error`, `--color-control-border`, etc.) for theme tokens shared with the Vue layer
+- Use CSS custom properties (`--color-accent`, `--color-error`, `--color-control-border`, etc.) for theme tokens, defined in `./frontend/src/assets/css/tailwind.css`
 
 **Shared UI primitives**:
 - For React UI code, prefer shared components from `./frontend/src/react/components/ui/` over native HTML controls or ad hoc styled elements
@@ -161,10 +161,9 @@ The frontend is migrating from Vue to React. **All new UI code should be written
 - Custom utilities use `@utility`, design tokens use `@theme`
 - Default border color is `currentcolor` (compat shim in `tailwind.css` preserves v3 behavior)
 
-**Accessing Vue state from React**:
-- `useVueState(getter)` — React hook that subscribes to Vue reactive state (Pinia stores, refs, computed) via `useSyncExternalStore`. React components access stores directly — no bridge layer needed
-- React pages are self-contained: import Pinia stores, `router`, utility functions directly
-- React `.tsx` is compiled by esbuild (`react-tsx-transform` Vite plugin) and type-checked separately via `tsconfig.react.json` (excluded from vue-tsc)
+**State & build**:
+- React app state lives under `./frontend/src/react/stores/` — the core slices are in `stores/app/`, consumed via the `useAppStore` hook. Routing helpers live in `./frontend/src/react/router/`
+- React `.tsx` is compiled by esbuild (`react-tsx-transform` Vite plugin) and type-checked with `tsc --build` via `pnpm --dir frontend type-check`
 
 ## Naming
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -5,15 +5,9 @@ This file provides additional guidance to AI coding assistants working under `./
 - Follow the repository-wide guidance in `../AGENTS.md`.
 - Treat this file as frontend-specific additions, not a replacement for the root instructions.
 
-## React Migration
+## React
 
-- For Vue-to-React migrations in `frontend/`, read and follow `../docs/plans/2026-04-08-react-migration-playbook.md`.
-- Use that playbook to decide migration order, safe Vue deletions, state/data boundaries, testing expectations, and CI pitfalls.
-
-## Frontend Reminder
-
-- All new UI code should be written in React unless an existing Vue surface must be preserved temporarily for compatibility.
-- Do not delete Vue counterparts until you verify they have no remaining live callers.
+- All UI code is React, under `src/react/`. Write new UI in React, following the stack and component patterns in the root `../AGENTS.md` and the shadcn guidance below.
 
 ## shadcn Skill
 


### PR DESCRIPTION
## What

Update the AI-agent guidance (`AGENTS.md`, `frontend/AGENTS.md`) so the frontend is described as a React codebase rather than an in-progress Vue-to-React migration.

- Root `AGENTS.md` React section: drop the "migrating from Vue" framing; replace the obsolete "Accessing Vue state from React" notes (`useVueState`, Pinia, `vue-tsc`, `tsconfig.react.json`) with current **State & build** guidance — React app state under `src/react/stores/app` via `useAppStore`, and `.tsx` type-checked with `tsc --build`.
- `frontend/AGENTS.md`: collapse the "React Migration" + "Frontend Reminder" sections into a single `## React` section.
- Correct the stale "ESLint + Biome" reference — Biome is the only frontend linter.

## Why

The migration is complete (0 `.vue` files). The old framing was misleading agents into looking for Vue counterparts and a dual-framework setup that no longer exists.

## Testing

Docs-only change. The described facts were verified against the codebase and its guard tests — `no-standalone-vue-reactivity.test.ts` and `no-vue-deps.test.ts` pass (9/9), asserting no `vue-tsc`/`tsconfig.react.json`, Biome as sole linter, and the React chrome free of legacy store/router imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
