### PR TITLE
chore: clean up store signal and task APIs

### DIFF
--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -619,7 +619,7 @@ func (s *PlanService) CancelPlanCheckRun(ctx context.Context, request *connect.R
 	}
 
 	// Broadcast cancel signal to all replicas for HA.
-	if err := s.store.SendSignal(ctx, storepb.Signal_CANCEL_PLAN_CHECK_RUN, projectID, planCheckRun.UID, approvalInputVersion); err != nil {
+	if err := s.store.SendSignal(ctx, storepb.Signal_CANCEL_PLAN_CHECK_RUN, projectID, planCheckRun.UID, &approvalInputVersion); err != nil {
 		slog.Warn("failed to send cancel signal", log.BBError(err))
 	}
 

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -1088,7 +1088,7 @@ func (s *RolloutService) BatchCancelTaskRuns(ctx context.Context, req *connect.R
 				cancelFunc.(context.CancelFunc)()
 			}
 			// Broadcast cancel signal to all replicas for HA.
-			if err := s.store.SendSignal(ctx, storepb.Signal_CANCEL_TASK_RUN, projectID, taskRun.ID); err != nil {
+			if err := s.store.SendSignal(ctx, storepb.Signal_CANCEL_TASK_RUN, projectID, taskRun.ID, nil); err != nil {
 				slog.Warn("failed to send cancel signal", log.BBError(err))
 			}
 		}

--- a/backend/store/signal.go
+++ b/backend/store/signal.go
@@ -13,14 +13,14 @@ import (
 const SignalChannel = "bytebase_signal"
 
 // SendSignal sends a notification to the bytebase_signal channel.
-func (s *Store) SendSignal(ctx context.Context, signalType storepb.Signal_Type, projectID string, uid int64, approvalInputVersion ...int64) error {
+func (s *Store) SendSignal(ctx context.Context, signalType storepb.Signal_Type, projectID string, uid int64, approvalInputVersion *int64) error {
 	signal := &storepb.Signal{
 		Type:    signalType,
 		Uid:     uid,
 		Project: projectID,
 	}
-	if len(approvalInputVersion) > 0 {
-		signal.ApprovalInputVersion = approvalInputVersion[0]
+	if approvalInputVersion != nil {
+		signal.ApprovalInputVersion = *approvalInputVersion
 	}
 	payload, err := protojson.Marshal(signal)
 	if err != nil {

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -495,25 +495,6 @@ func (s *Store) BatchSkipTasks(ctx context.Context, projectID string, taskUIDs [
 	return nil
 }
 
-// CreateTasks creates tasks for a plan.
-func (s *Store) CreateTasks(ctx context.Context, projectID string, planUID int64, tasks []*TaskMessage) ([]*TaskMessage, error) {
-	tx, err := s.GetDB().BeginTx(ctx, nil)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to begin tx")
-	}
-	defer tx.Rollback()
-
-	tasks, err = s.createTasksTxDedup(ctx, tx, projectID, planUID, tasks)
-	if err != nil {
-		return nil, err
-	}
-	if err := tx.Commit(); err != nil {
-		return nil, errors.Wrapf(err, "failed to commit tx")
-	}
-
-	return tasks, nil
-}
-
 // CreateRolloutTasks marks the plan as having rollout and creates tasks in one transaction.
 // If approvalInputVersion is set, the transaction creates no tasks unless the plan
 // still has that approval input version.


### PR DESCRIPTION
## Summary
- Make `Store.SendSignal` use an explicit `*int64` approval input version instead of a variadic pseudo-optional argument.
- Update signal callers to pass either the observed approval input version or `nil`.
- Remove the unused `Store.CreateTasks` wrapper; `CreateRolloutTasks` still uses the shared task creation helper.

## Validation
- `go test -count=1 ./backend/store ./backend/api/v1`
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `git diff --check`

## Pre-PR checklist
- Breaking changes: none; only internal Go APIs changed.
- Composite-PK query safety: touched `backend/store`, but did not add or modify SQL predicates on composite-PK tables. Removed an unused wrapper only.
- SonarCloud: skipped; no new files or directories.
