### PR TITLE
chore: bump omni for MSSQL $-prefixed tokens and trino boolean IS predicate

### DIFF
--- a/backend/plugin/parser/mysql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/mysql/query_span_extractor_omni.go
@@ -1446,6 +1446,8 @@ func collectOmniAccessTablesFromExpr(result base.SourceColumnSet, expr ast.ExprN
 		collectOmniAccessTablesFromExpr(result, e.Array, defaultDatabase, normalizeStarRocksCluster)
 	case *ast.ParenExpr:
 		collectOmniAccessTablesFromExpr(result, e.Expr, defaultDatabase, normalizeStarRocksCluster)
+	case *ast.WeightStringExpr:
+		collectOmniAccessTablesFromExpr(result, e.Expr, defaultDatabase, normalizeStarRocksCluster)
 	default:
 	}
 }

--- a/backend/plugin/parser/mysql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/mysql/query_span_extractor_omni.go
@@ -748,6 +748,16 @@ func (q *omniQuerySpanExtractor) extractOmniExpr(expr ast.ExprNode) (base.QueryS
 			return base.QuerySpanResult{}, err
 		}
 		return base.QuerySpanResult{Name: q.omniExprName(e), SourceColumns: sourceColumns, IsPlainField: false}, nil
+	case *ast.KeywordArg:
+		// Keyword arguments (TIMESTAMPDIFF(SECOND, ...), GET_FORMAT(DATE, ...))
+		// are unit selectors, not column references — no lineage.
+		return base.QuerySpanResult{Name: e.Keyword, SourceColumns: base.SourceColumnSet{}, IsPlainField: false}, nil
+	case *ast.WeightStringExpr:
+		sourceColumns, err := q.mergeOmniExprSources(e.Expr)
+		if err != nil {
+			return base.QuerySpanResult{}, err
+		}
+		return base.QuerySpanResult{Name: q.omniExprName(e), SourceColumns: sourceColumns, IsPlainField: false}, nil
 	default:
 		return base.QuerySpanResult{}, errors.Errorf("unsupported omni MySQL expression %T", expr)
 	}

--- a/backend/plugin/parser/mysql/query_span_extractor_omni_test.go
+++ b/backend/plugin/parser/mysql/query_span_extractor_omni_test.go
@@ -219,6 +219,49 @@ func TestOmniQuerySpanPhase2_ExpressionSourceMerging(t *testing.T) {
 	}, span.Results)
 }
 
+// TestOmniQuerySpanKeywordArgAndWeightString covers the omni AST nodes
+// introduced with the $-token bump: KeywordArg (the unit selector in
+// TIMESTAMPDIFF/TIMESTAMPADD/GET_FORMAT — a keyword, not a column, so no
+// lineage) and WeightStringExpr (lineage follows the real operand).
+// TIMESTAMPDIFF regressed to "unsupported omni MySQL expression" without
+// these cases.
+func TestOmniQuerySpanKeywordArgAndWeightString(t *testing.T) {
+	span, err := newOmniQuerySpanExtractor("db", newOmniTestQuerySpanContext(), false).getOmniQuerySpan(
+		context.Background(),
+		"SELECT TIMESTAMPDIFF(SECOND, a, b) AS d1, TIMESTAMPADD(MINUTE, 5, a) AS d2, GET_FORMAT(DATE, 'ISO') AS d3, WEIGHT_STRING(c AS CHAR(10)) AS w FROM t",
+	)
+	require.NoError(t, err)
+	require.Equal(t, []base.QuerySpanResult{
+		{
+			Name: "d1",
+			SourceColumns: sourceColumnSetFromResources([]base.ColumnResource{
+				{Database: "db", Table: "t", Column: "a"},
+				{Database: "db", Table: "t", Column: "b"},
+			}),
+			IsPlainField: false,
+		},
+		{
+			Name: "d2",
+			SourceColumns: sourceColumnSetFromResources([]base.ColumnResource{
+				{Database: "db", Table: "t", Column: "a"},
+			}),
+			IsPlainField: false,
+		},
+		{
+			Name:          "d3",
+			SourceColumns: base.SourceColumnSet{},
+			IsPlainField:  false,
+		},
+		{
+			Name: "w",
+			SourceColumns: sourceColumnSetFromResources([]base.ColumnResource{
+				{Database: "db", Table: "t", Column: "c"},
+			}),
+			IsPlainField: false,
+		},
+	}, span.Results)
+}
+
 func TestOmniQuerySpanPhase3_FromJoinAliasAndScope(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/backend/plugin/parser/tsql/dollar_token_test.go
+++ b/backend/plugin/parser/tsql/dollar_token_test.go
@@ -30,9 +30,12 @@ OUTPUT $action, INSERTED.k, INSERTED.v;`,
 		// Partition function, bare and database-qualified.
 		"SELECT $PARTITION.pf1(10);",
 		"SELECT db1.$PARTITION.pf1(10);",
-		// Graph edge INSERT and UPDATE SET targets.
+		// OUTPUT $action INTO a table variable — the second customer shape.
+		"MERGE INTO dst AS d USING src AS s ON d.k = s.k WHEN MATCHED THEN UPDATE SET d.v = s.v OUTPUT $action, INSERTED.k INTO @changes;",
+		// Graph edge INSERT, UPDATE SET targets, and index keys.
 		"INSERT INTO e ($from_id, $to_id) VALUES ('a', 'b');",
 		"UPDATE e SET $from_id = 'x';",
+		"CREATE INDEX ix ON Person ($node_id);",
 		// IDENTITYCOL / ROWGUIDCOL keyword column refs.
 		"SELECT IDENTITYCOL, ROWGUIDCOL FROM t;",
 	}

--- a/backend/plugin/parser/tsql/dollar_token_test.go
+++ b/backend/plugin/parser/tsql/dollar_token_test.go
@@ -1,0 +1,60 @@
+package tsql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestDollarTokenStatements validates the omni bump for $-prefixed T-SQL
+// tokens (BYT-9813) through Bytebase's own entry points: base.ParseStatements
+// is what the issue SQL review pipeline calls, so these pins guard the exact
+// path that produced the customer-facing syntax error.
+func TestDollarTokenStatements(t *testing.T) {
+	accept := []string{
+		// The MERGE OUTPUT $action shape that motivated BYT-9813.
+		`MERGE INTO dst AS d
+USING src AS s ON d.k = s.k
+WHEN MATCHED THEN UPDATE SET d.v = s.v
+WHEN NOT MATCHED THEN INSERT (k, v) VALUES (s.k, s.v)
+OUTPUT $action, INSERTED.k, INSERTED.v;`,
+		// Pseudo-columns, bare and qualified.
+		"SELECT $IDENTITY, $ROWGUID FROM t;",
+		"SELECT t.$IDENTITY FROM t;",
+		"SELECT $node_id FROM Person;",
+		// Money constants, including sign/space and non-$ symbols.
+		"SELECT $12.50, -$4.78, $ 4, £10;",
+		// Partition function, bare and database-qualified.
+		"SELECT $PARTITION.pf1(10);",
+		"SELECT db1.$PARTITION.pf1(10);",
+		// Graph edge INSERT and UPDATE SET targets.
+		"INSERT INTO e ($from_id, $to_id) VALUES ('a', 'b');",
+		"UPDATE e SET $from_id = 'x';",
+		// IDENTITYCOL / ROWGUIDCOL keyword column refs.
+		"SELECT IDENTITYCOL, ROWGUIDCOL FROM t;",
+	}
+	for _, sql := range accept {
+		t.Run(sql, func(t *testing.T) {
+			_, err := base.ParseStatements(storepb.Engine_MSSQL, sql)
+			require.NoError(t, err, "SQL review entry must accept %q", sql)
+
+			_, err = ParseTSQLOmni(sql)
+			require.NoError(t, err, "ParseTSQLOmni must accept %q", sql)
+		})
+	}
+
+	// Unknown pseudo-columns stay rejected (engine: Msg 126).
+	reject := []string{
+		"SELECT $foo FROM t;",
+		"SELECT $CUID FROM t;",
+	}
+	for _, sql := range reject {
+		t.Run(sql, func(t *testing.T) {
+			_, err := base.ParseStatements(storepb.Engine_MSSQL, sql)
+			require.Error(t, err, "SQL review entry must reject %q", sql)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260629024459-98426d3c550f
+	github.com/bytebase/omni v0.0.0-20260703065817-5796ec6b6257
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260629024459-98426d3c550f h1:VTh/r39h3I5BlmxuD+5gafwTEQH3U8Io2WMlTuNEO5U=
-github.com/bytebase/omni v0.0.0-20260629024459-98426d3c550f/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260703065817-5796ec6b6257 h1:yY9Z9DkND9Bo75ejzoYlXRjpEWhFrjNufa1BmjEqLpU=
+github.com/bytebase/omni v0.0.0-20260703065817-5796ec6b6257/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
## Summary

Bump `github.com/bytebase/omni` to `5796ec6b`, bringing:

- **MSSQL `$`-prefixed token support** ([omni #362](https://github.com/bytebase/omni/pull/362)): `$action` / `$IDENTITY` / `$ROWGUID` / graph pseudo-columns (expression, INSERT/MERGE column-list, SET-target, index-key, and CREATE STATISTICS positions), money constants (documented 34-symbol table incl. sign/space forms), and `[db.]$PARTITION.fn(args)`. Unknown `$foo` errors align with the engine's Msg 126.
- **Trino boolean test predicate** ([omni #367](https://github.com/bytebase/omni/pull/367)): `IS [NOT] TRUE | FALSE | UNKNOWN`.

Both were verified against live engines (SQL Server 2022 CU19, Trino 482) on the omni side across four review rounds.

## Verification

- `backend/plugin/parser/tsql`, `mariadb`, `mysql` package tests pass
- E2E: the reported MERGE `OUTPUT $action` statement parses through `base.ParseStatements(Engine_MSSQL, ...)` — the SQL review entry point that produced the customer-facing error

Closes BYT-9813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)