### PR TITLE
fix: let failed tasks outrank running ones in stage status aggregation

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 vi.stubGlobal("localStorage", mocks.localStorage);
 
 vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 

--- a/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
+++ b/frontend/src/react/pages/project/plan-detail/ProjectPlanDetailPage.tsx
@@ -20,6 +20,7 @@ import {
 import { cn } from "@/react/lib/utils";
 import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
+import { getRolloutStatus } from "@/utils";
 import { getReviewBadge } from "../utils/reviewBadge";
 import { DeployBranch } from "./components/deploy/DeployBranch";
 import { DeployTaskDetailPanel } from "./components/deploy/DeployTaskDetailPanel";
@@ -193,21 +194,30 @@ function ProjectPlanDetailPageInner({
       : undefined;
     const deployBadge = (() => {
       if (deployStatus !== "active" || !page.rollout) return undefined;
-      const hasCompletedTasks = allTasks.some(
-        (task) =>
-          task.status === Task_Status.DONE ||
-          task.status === Task_Status.SKIPPED
-      );
-      if (allTasks.some((task) => task.status === Task_Status.FAILED)) {
+      const rolloutStatus = getRolloutStatus(page.rollout);
+      if (rolloutStatus === Task_Status.FAILED) {
         return { label: t("common.failed"), variant: "destructive" as const };
       }
       if (
+        rolloutStatus === Task_Status.RUNNING ||
+        rolloutStatus === Task_Status.PENDING
+      ) {
+        return {
+          label: t("common.in-progress"),
+          variant: "secondary" as const,
+        };
+      }
+      if (rolloutStatus === Task_Status.CANCELED) {
+        return { label: t("common.canceled"), variant: "default" as const };
+      }
+      // A NOT_STARTED aggregate can still mean earlier stages already finished
+      // (partially deployed) — at the phase level that's progress, not idle.
+      if (
         allTasks.some(
           (task) =>
-            task.status === Task_Status.RUNNING ||
-            task.status === Task_Status.PENDING
-        ) ||
-        hasCompletedTasks
+            task.status === Task_Status.DONE ||
+            task.status === Task_Status.SKIPPED
+        )
       ) {
         return {
           label: t("common.in-progress"),

--- a/frontend/src/utils/v1/issue/rollout.test.ts
+++ b/frontend/src/utils/v1/issue/rollout.test.ts
@@ -1,0 +1,120 @@
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, test } from "vitest";
+import { Plan_TaskStatusCountSchema } from "@/types/proto-es/v1/plan_service_pb";
+import {
+  RolloutSchema,
+  StageSchema,
+  Task_Status,
+  TaskSchema,
+} from "@/types/proto-es/v1/rollout_service_pb";
+import {
+  getRolloutStatus,
+  getStageStatus,
+  getStageStatusFromCounts,
+} from "./rollout";
+
+const stage = (...statuses: Task_Status[]) =>
+  create(StageSchema, {
+    tasks: statuses.map((status) => create(TaskSchema, { status })),
+  });
+
+const rollout = (...stages: ReturnType<typeof stage>[]) =>
+  create(RolloutSchema, { stages });
+
+const counts = (...statuses: Task_Status[]) =>
+  statuses.map((status) =>
+    create(Plan_TaskStatusCountSchema, { status, count: 1 })
+  );
+
+describe("getStageStatus", () => {
+  test("failed outranks running (BYT-9822)", () => {
+    expect(
+      getStageStatus(
+        stage(Task_Status.RUNNING, Task_Status.RUNNING, Task_Status.FAILED)
+      )
+    ).toBe(Task_Status.FAILED);
+    expect(getStageStatus(stage(Task_Status.FAILED, Task_Status.PENDING))).toBe(
+      Task_Status.FAILED
+    );
+    expect(
+      getStageStatus(stage(Task_Status.FAILED, Task_Status.CANCELED))
+    ).toBe(Task_Status.FAILED);
+  });
+
+  test("active work outranks a canceled sibling", () => {
+    expect(
+      getStageStatus(stage(Task_Status.CANCELED, Task_Status.RUNNING))
+    ).toBe(Task_Status.RUNNING);
+    expect(
+      getStageStatus(stage(Task_Status.CANCELED, Task_Status.PENDING))
+    ).toBe(Task_Status.PENDING);
+  });
+
+  test("a cancel surfaces once nothing is active", () => {
+    expect(
+      getStageStatus(stage(Task_Status.CANCELED, Task_Status.NOT_STARTED))
+    ).toBe(Task_Status.CANCELED);
+    expect(getStageStatus(stage(Task_Status.CANCELED, Task_Status.DONE))).toBe(
+      Task_Status.CANCELED
+    );
+    expect(getStageStatus(stage(Task_Status.CANCELED))).toBe(
+      Task_Status.CANCELED
+    );
+  });
+
+  test("plain progressions", () => {
+    expect(getStageStatus(stage(Task_Status.RUNNING, Task_Status.DONE))).toBe(
+      Task_Status.RUNNING
+    );
+    expect(
+      getStageStatus(stage(Task_Status.PENDING, Task_Status.NOT_STARTED))
+    ).toBe(Task_Status.PENDING);
+    expect(getStageStatus(stage(Task_Status.DONE, Task_Status.SKIPPED))).toBe(
+      Task_Status.DONE
+    );
+    expect(getStageStatus(stage(Task_Status.SKIPPED))).toBe(
+      Task_Status.SKIPPED
+    );
+    expect(getStageStatus(stage())).toBe(Task_Status.NOT_STARTED);
+  });
+});
+
+describe("getRolloutStatus", () => {
+  test("a failure anywhere fails the rollout, even with later idle stages", () => {
+    expect(
+      getRolloutStatus(
+        rollout(
+          stage(Task_Status.DONE),
+          stage(Task_Status.FAILED, Task_Status.RUNNING),
+          stage(Task_Status.NOT_STARTED)
+        )
+      )
+    ).toBe(Task_Status.FAILED);
+  });
+
+  test("partially deployed rollout aggregates to the idle frontier", () => {
+    // The Deploy phase badge maps this to "In progress" via its
+    // completed-tasks refinement; the raw aggregate stays NOT_STARTED.
+    expect(
+      getRolloutStatus(
+        rollout(stage(Task_Status.DONE), stage(Task_Status.NOT_STARTED))
+      )
+    ).toBe(Task_Status.NOT_STARTED);
+  });
+
+  test("empty rollout is not started", () => {
+    expect(getRolloutStatus(rollout())).toBe(Task_Status.NOT_STARTED);
+  });
+});
+
+describe("getStageStatusFromCounts", () => {
+  test("failed outranks running", () => {
+    expect(
+      getStageStatusFromCounts(counts(Task_Status.RUNNING, Task_Status.FAILED))
+    ).toBe(Task_Status.FAILED);
+  });
+
+  test("empty counts fall back to unspecified", () => {
+    expect(getStageStatusFromCounts([])).toBe(Task_Status.STATUS_UNSPECIFIED);
+  });
+});

--- a/frontend/src/utils/v1/issue/rollout.ts
+++ b/frontend/src/utils/v1/issue/rollout.ts
@@ -18,7 +18,21 @@ import {
   extractCoreDatabaseInfoFromDatabaseCreateTask,
   mockDatabase,
 } from "./issue";
-import { TASK_STATUS_FILTERS } from "./task";
+
+// Priority order for aggregating child task statuses into a parent (stage /
+// rollout) status: the highest-priority status present wins. Failure outranks
+// active work (a failed task needs attention even while siblings run — see
+// BYT-9822); a cancel is deliberate rather than an error, so it stays below
+// active statuses but above NOT_STARTED, surfacing once nothing is in motion.
+const TASK_STATUS_AGGREGATION_PRIORITY: Task_Status[] = [
+  Task_Status.FAILED,
+  Task_Status.RUNNING,
+  Task_Status.PENDING,
+  Task_Status.CANCELED,
+  Task_Status.NOT_STARTED,
+  Task_Status.DONE,
+  Task_Status.SKIPPED,
+];
 
 export const extractPlanUIDFromRolloutName = (name: string) => {
   const pattern = /(?:^|\/)plans\/([^/]+)\/rollout(?:$|\/)/;
@@ -151,14 +165,14 @@ export const stringifyTaskStatus = (
   }
 };
 
-// Return the highest-priority Task_Status (per TASK_STATUS_FILTERS) for which
-// `has` reports a member, or `fallback` when none match. Shared by the stage
-// and rollout status reducers below.
+// Return the highest-priority Task_Status (per TASK_STATUS_AGGREGATION_PRIORITY)
+// for which `has` reports a member, or `fallback` when none match. Shared by the
+// stage and rollout status reducers below.
 const foldByStatusPriority = (
   has: (status: Task_Status) => boolean,
   fallback: Task_Status
 ): Task_Status => {
-  for (const status of TASK_STATUS_FILTERS) {
+  for (const status of TASK_STATUS_AGGREGATION_PRIORITY) {
     if (has(status)) return status;
   }
   return fallback;

--- a/frontend/src/utils/v1/issue/task.ts
+++ b/frontend/src/utils/v1/issue/task.ts
@@ -1,15 +1,5 @@
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 
-export const TASK_STATUS_FILTERS: Task_Status[] = [
-  Task_Status.RUNNING,
-  Task_Status.FAILED,
-  Task_Status.PENDING,
-  Task_Status.NOT_STARTED,
-  Task_Status.CANCELED,
-  Task_Status.DONE,
-  Task_Status.SKIPPED,
-];
-
 /**
  * Task statuses that allow run/skip actions.
  * Tasks in these states can be started, restarted, or skipped.


### PR DESCRIPTION
## What

Fixes BYT-9822: on Plan Detail, a stage with both failed and running tasks showed **"Running"** in the header status chip while the Deploy phase badge showed **"Failed"** (visible to users without run permission; users with run permission see a "Rerun" button, which masked the bug).

## Why

There was no canonical rule for aggregating task statuses into a stage/rollout status. The header (plus stage tabs and the plan dashboard) folded by `TASK_STATUS_FILTERS` — a filter display order repurposed as an aggregation priority, with RUNNING above FAILED — while the Deploy badge used its own inline failed-first scan. The two disagreed on every mixed state.

A failed task needs attention even while siblings run, and since we don't cancel sibling tasks on failure, the mixed state can persist for minutes. Failure-first display also matches the dominant convention across major CI/CD pipeline tools (research summarized on BYT-9822).

## How

- Define a single aggregation priority in `rollout.ts`, shared by `getStageStatus`, `getStageStatusFromCounts`, and `getRolloutStatus`:
  `FAILED > RUNNING > PENDING > CANCELED > NOT_STARTED > DONE > SKIPPED`
  - FAILED above CANCELED: when both exist, the cancel is usually the operator's response to the failure.
  - CANCELED below active statuses but above NOT_STARTED: a cancel is deliberate, not an error, so it doesn't shout over active work — but it blocks stage completion, so it surfaces once nothing is in motion (previously canceled + not started read "Not started").
- Derive the Deploy phase badge from the shared aggregate instead of its own scan. It gains a "Canceled" label, and keeps one phase-level refinement: a NOT_STARTED aggregate with completed earlier stages still reads "In progress" (partially deployed).
- Remove `TASK_STATUS_FILTERS` — its only importer was the aggregator; the deploy task filter has its own local list.

| Task mix | Before (header / badge) | After |
|---|---|---|
| failed + running | Running / Failed ← the bug | Failed / Failed |
| canceled + running | Running / In progress | unchanged |
| canceled + not started | Not started / Not started | Canceled / Canceled |
| all canceled | Canceled / Not started | Canceled / Canceled |

## Testing

- New `frontend/src/utils/v1/issue/rollout.test.ts` covering the aggregation order across the notable status mixes (9 tests).
- Full frontend suite passes (311 files, 2580 tests); `pnpm --dir frontend check` and `type-check` clean.
- `ProjectPlanDetailPage.test.tsx`: added `initReactI18next` to the react-i18next mock — the page now imports from `@/utils`, which pulls `@/react/i18n` into the module graph (same pattern as `AgentWindow.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)