### PR TITLE
chore: update AI provider default models

### DIFF
--- a/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
+++ b/frontend/src/react/pages/settings/general/AIAugmentationSection.tsx
@@ -32,6 +32,7 @@ import {
   SettingValueSchema,
 } from "@/types/proto-es/v1/setting_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
+import { PROVIDER_DEFAULTS } from "./aiProviderDefaults";
 import type { SectionHandle } from "./useSettingSection";
 
 interface AIAugmentationSectionProps {
@@ -46,38 +47,6 @@ interface AIState {
   model: string;
   provider: AISetting_Provider;
 }
-
-const PROVIDER_DEFAULTS: Record<
-  AISetting_Provider,
-  { apiKeyDoc: string; endpoint: string; model: string }
-> = {
-  [AISetting_Provider.OPEN_AI]: {
-    apiKeyDoc: "https://platform.openai.com/account/api-keys",
-    endpoint: "https://api.openai.com/v1/chat/completions",
-    model: "gpt-4o",
-  },
-  [AISetting_Provider.AZURE_OPENAI]: {
-    apiKeyDoc: "https://ai.azure.com/",
-    endpoint:
-      "https://{resource name}.openai.azure.com/openai/deployments/{deployment id}/chat/completions?api-version=2024-06-0",
-    model: "gpt-4o",
-  },
-  [AISetting_Provider.GEMINI]: {
-    apiKeyDoc: "https://ai.google.dev/gemini-api/docs",
-    endpoint: "https://generativelanguage.googleapis.com/v1beta",
-    model: "gemini-2.5-flash",
-  },
-  [AISetting_Provider.CLAUDE]: {
-    apiKeyDoc: "https://docs.anthropic.com/en/api/getting-started",
-    endpoint: "https://api.anthropic.com/v1/messages",
-    model: "claude-sonnet-4-20250514",
-  },
-  [AISetting_Provider.PROVIDER_UNSPECIFIED]: {
-    apiKeyDoc: "",
-    endpoint: "",
-    model: "",
-  },
-};
 
 const PROVIDER_OPTIONS = [
   AISetting_Provider.OPEN_AI,

--- a/frontend/src/react/pages/settings/general/aiProviderDefaults.test.ts
+++ b/frontend/src/react/pages/settings/general/aiProviderDefaults.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "vitest";
+import { AISetting_Provider } from "@/types/proto-es/v1/setting_service_pb";
+import { PROVIDER_DEFAULTS } from "./aiProviderDefaults";
+
+describe("PROVIDER_DEFAULTS", () => {
+  test("uses current default model IDs for built-in AI providers", () => {
+    expect(PROVIDER_DEFAULTS[AISetting_Provider.OPEN_AI].model).toBe("gpt-5.5");
+    expect(PROVIDER_DEFAULTS[AISetting_Provider.AZURE_OPENAI].model).toBe(
+      "gpt-5.5"
+    );
+    expect(PROVIDER_DEFAULTS[AISetting_Provider.GEMINI].model).toBe(
+      "gemini-3.5-flash"
+    );
+    expect(PROVIDER_DEFAULTS[AISetting_Provider.CLAUDE].model).toBe(
+      "claude-sonnet-5"
+    );
+  });
+});

--- a/frontend/src/react/pages/settings/general/aiProviderDefaults.ts
+++ b/frontend/src/react/pages/settings/general/aiProviderDefaults.ts
@@ -1,0 +1,33 @@
+import { AISetting_Provider } from "@/types/proto-es/v1/setting_service_pb";
+
+export const PROVIDER_DEFAULTS: Record<
+  AISetting_Provider,
+  { apiKeyDoc: string; endpoint: string; model: string }
+> = {
+  [AISetting_Provider.OPEN_AI]: {
+    apiKeyDoc: "https://platform.openai.com/account/api-keys",
+    endpoint: "https://api.openai.com/v1/chat/completions",
+    model: "gpt-5.5",
+  },
+  [AISetting_Provider.AZURE_OPENAI]: {
+    apiKeyDoc: "https://ai.azure.com/",
+    endpoint:
+      "https://{resource name}.openai.azure.com/openai/deployments/{deployment id}/chat/completions?api-version=2024-06-01",
+    model: "gpt-5.5",
+  },
+  [AISetting_Provider.GEMINI]: {
+    apiKeyDoc: "https://ai.google.dev/gemini-api/docs",
+    endpoint: "https://generativelanguage.googleapis.com/v1beta",
+    model: "gemini-3.5-flash",
+  },
+  [AISetting_Provider.CLAUDE]: {
+    apiKeyDoc: "https://docs.anthropic.com/en/api/getting-started",
+    endpoint: "https://api.anthropic.com/v1/messages",
+    model: "claude-sonnet-5",
+  },
+  [AISetting_Provider.PROVIDER_UNSPECIFIED]: {
+    apiKeyDoc: "",
+    endpoint: "",
+    model: "",
+  },
+};


### PR DESCRIPTION
## Summary
- Extract AI provider defaults from the settings section into a small frontend module
- Update default model IDs for OpenAI, Azure OpenAI, Gemini, and Claude
- Add a focused unit test to lock the default model IDs

## Testing
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- pnpm --dir frontend test aiProviderDefaults.test.ts
- pnpm --dir frontend test

## Pre-PR Checklist
- Breaking change: no; this only updates frontend defaults for newly selected/enabled AI providers
- Composite-PK query safety: skipped; no backend store or migration changes
- SonarCloud properties: existing frontend test/source globs cover the new files
