### PR TITLE
fix(plan): focus deploy phase on refresh once a rollout exists

### DIFF
--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.test.tsx
@@ -217,7 +217,7 @@ describe("usePlanDetailPage", () => {
     expect(result.current.activePhases.has("deploy")).toBe(false);
   });
 
-  test("defaults to only the changes phase on the specs route for rollout plans", async () => {
+  test("focuses the deploy phase on the specs route for rollout plans", async () => {
     mocks.fetchPlanSnapshot.mockResolvedValue(
       buildSnapshotPatch({
         planId: "plan-1",
@@ -240,12 +240,12 @@ describe("usePlanDetailPage", () => {
     );
 
     await waitFor(() => expect(result.current.ready).toBe(true));
-    expect(result.current.activePhases.has("changes")).toBe(true);
+    expect(result.current.activePhases.has("changes")).toBe(false);
     expect(result.current.activePhases.has("review")).toBe(false);
-    expect(result.current.activePhases.has("deploy")).toBe(false);
+    expect(result.current.activePhases.has("deploy")).toBe(true);
   });
 
-  test("keeps changes and review on the spec-detail route for reviewed rollout plans", async () => {
+  test("focuses the deploy phase on the spec-detail route for reviewed rollout plans", async () => {
     mocks.fetchPlanSnapshot.mockResolvedValue(
       buildSnapshotPatch({
         issue: {
@@ -272,9 +272,9 @@ describe("usePlanDetailPage", () => {
     );
 
     await waitFor(() => expect(result.current.ready).toBe(true));
-    expect(result.current.activePhases.has("changes")).toBe(true);
-    expect(result.current.activePhases.has("review")).toBe(true);
-    expect(result.current.activePhases.has("deploy")).toBe(false);
+    expect(result.current.activePhases.has("changes")).toBe(false);
+    expect(result.current.activePhases.has("review")).toBe(false);
+    expect(result.current.activePhases.has("deploy")).toBe(true);
   });
 
   test("has review default phases on the first ready render", async () => {

--- a/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
+++ b/frontend/src/react/pages/project/plan-detail/shell/hooks/usePlanDetailPage.ts
@@ -12,8 +12,6 @@ import {
   PLAN_DETAIL_PHASE_CHANGES,
   PLAN_DETAIL_PHASE_DEPLOY,
   PLAN_DETAIL_PHASE_REVIEW,
-  PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL,
-  PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS,
 } from "@/react/router/handles";
 import { State } from "@/types/proto-es/v1/common_pb";
 import { IssueStatus } from "@/types/proto-es/v1/issue_service_pb";
@@ -81,17 +79,18 @@ const getDefaultActivePhases = (phase: PlanDetailPhase): PlanDetailPhase[] => {
 };
 
 type PhaseSelection = {
-  routeName?: string;
   routePhase?: PlanDetailPhase;
   routeStageId?: string;
   routeTaskId?: string;
 };
 
+// The phase to focus by default: an explicit URL selection (phase / stage /
+// task) wins, otherwise the furthest-progressed phase the plan has reached.
 const getCurrentPhase = (
   snapshot: PlanDetailPageSnapshot,
   selection: PhaseSelection
 ): PlanDetailPhase => {
-  const { routeName, routePhase, routeStageId, routeTaskId } = selection;
+  const { routePhase, routeStageId, routeTaskId } = selection;
   if (
     routePhase === PLAN_DETAIL_PHASE_CHANGES ||
     routePhase === PLAN_DETAIL_PHASE_REVIEW ||
@@ -101,17 +100,6 @@ const getCurrentPhase = (
   }
   if (routeStageId || routeTaskId) {
     return PLAN_DETAIL_PHASE_DEPLOY;
-  }
-  // An explicit specs / spec-detail route always defaults to the spec section,
-  // even once the plan has a rollout, so shared/bookmarked spec links stay
-  // usable. A plan under review additionally expands the review section.
-  if (
-    routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPECS ||
-    routeName === PROJECT_V1_ROUTE_PLAN_DETAIL_SPEC_DETAIL
-  ) {
-    return snapshot.issue
-      ? PLAN_DETAIL_PHASE_REVIEW
-      : PLAN_DETAIL_PHASE_CHANGES;
   }
   if (snapshot.rollout) {
     return PLAN_DETAIL_PHASE_DEPLOY;
@@ -165,7 +153,6 @@ export const usePlanDetailPage = ({
   const pageIdentityKey = `${projectId}/${planId}`;
   const phaseSelectionRef = useRef<PhaseSelection>({});
   phaseSelectionRef.current = {
-    routeName,
     routePhase,
     routeStageId,
     routeTaskId,
@@ -270,7 +257,6 @@ export const usePlanDetailPage = ({
     syncDefaultActivePhases(latestSnapshotRef.current);
   }, [
     pageIdentityKey,
-    routeName,
     routePhase,
     routeStageId,
     routeTaskId,


### PR DESCRIPTION
## What & why

BYT-9821: staying on a plan page through the review phase and then refreshing after it advanced to deploy left the page stuck — Changes/Review expanded, Deploy collapsed — instead of collapsing the earlier phases and focusing Deploy.

Root cause: the default-phase resolver (`getCurrentPhase`) ranked the specs / spec-detail route above the rollout check. A user reviewing a plan is often on a `.../specs/<id>` URL (drilled into a spec, or stayed there after submitting for review), so once the plan gained a rollout the resolver still returned `review` and never focused `deploy`. Opening the same plan fresh from the issue list lands on the root URL and worked — which is why it only reproduced on refresh after "staying" in review.

## The change

Check the rollout before the route. The default focus now follows one rule: an explicit URL selection (`?phase` / stage / task) wins, otherwise the furthest-progressed phase — `rollout → deploy`, `issue → review`, else `changes`.

Behavior change worth noting: a shared/bookmarked spec link on a plan that **already has a rollout** now opens **Deploy** instead of the spec section. This reverses the deployed-plan spec-link behavior added in #20416 — intended, per BYT-9821. Spec links on plans **without** a rollout are unchanged (they still open the spec section).

With the reorder, the spec-route branch became dead code (below the rollout check it returned exactly what the fall-through already produced), so it and the now-unused `routeName` plumbing are removed. Net −24/+10.

## Testing

- `usePlanDetailPage.test.tsx` — 12/12 pass. Flipped the two tests that pinned the old behavior (`specs` / `spec-detail` route + rollout now expect Deploy); the no-rollout review/changes cases are unchanged.
- `pnpm --dir frontend check` and `pnpm --dir frontend type-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
