### PR TITLE
refactor: simplify plan header status & action labels

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1476,8 +1476,7 @@
     "labels-required-for-review": "Labels are required before review",
     "lifecycle": {
       "checking": "Checking…",
-      "checks-failing_one": "{{count}} check failing",
-      "checks-failing_other": "{{count}} checks failing",
+      "checks-failing": "Checks failing",
       "deployed": "Deployed",
       "gate-checks-failed": "Some checks were not successful",
       "gate-checks-failed-sub": "{{failing}} failing, {{passed}} passed",
@@ -1490,10 +1489,9 @@
       "gate-review-rejected": "Changes requested",
       "preparing-rollout": "Preparing rollout…",
       "rejected": "Rejected",
-      "rerun-stage": "Rerun · {{stage}}",
+      "rerun": "Rerun",
       "review-waiting": "Waiting for {{role}}",
-      "run-stage": "Run · {{stage}}",
-      "stage-status": "{{status}} · {{stage}}"
+      "run": "Run"
     },
     "meta": {
       "created-by": "Created by {{user}}"

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1476,8 +1476,7 @@
     "labels-required-for-review": "Se requieren etiquetas antes de la revisión",
     "lifecycle": {
       "checking": "Comprobando…",
-      "checks-failing_one": "{{count}} comprobación fallida",
-      "checks-failing_other": "{{count}} comprobaciones fallidas",
+      "checks-failing": "Comprobaciones fallidas",
       "deployed": "Desplegado",
       "gate-checks-failed": "Algunas comprobaciones fallaron",
       "gate-checks-failed-sub": "{{failing}} con errores, {{passed}} correctas",
@@ -1490,10 +1489,9 @@
       "gate-review-rejected": "Cambios solicitados",
       "preparing-rollout": "Preparando despliegue…",
       "rejected": "Rechazado",
-      "rerun-stage": "Reejecutar · {{stage}}",
+      "rerun": "Reejecutar",
       "review-waiting": "Esperando a {{role}}",
-      "run-stage": "Ejecutar · {{stage}}",
-      "stage-status": "{{status}} · {{stage}}"
+      "run": "Ejecutar"
     },
     "meta": {
       "created-by": "Creado por {{user}}"

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1476,8 +1476,7 @@
     "labels-required-for-review": "レビュー前にラベルが必要です",
     "lifecycle": {
       "checking": "チェック中…",
-      "checks-failing_one": "{{count}} 件のチェック失敗",
-      "checks-failing_other": "{{count}} 件のチェック失敗",
+      "checks-failing": "チェック失敗",
       "deployed": "デプロイ済み",
       "gate-checks-failed": "一部のチェックが失敗しました",
       "gate-checks-failed-sub": "{{failing}} 件失敗、{{passed}} 件成功",
@@ -1490,10 +1489,9 @@
       "gate-review-rejected": "変更がリクエストされました",
       "preparing-rollout": "ロールアウトを準備中…",
       "rejected": "却下されました",
-      "rerun-stage": "再実行 · {{stage}}",
+      "rerun": "再実行",
       "review-waiting": "{{role}} の承認待ち",
-      "run-stage": "実行 · {{stage}}",
-      "stage-status": "{{status}} · {{stage}}"
+      "run": "実行"
     },
     "meta": {
       "created-by": "{{user}} が作成"

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1476,8 +1476,7 @@
     "labels-required-for-review": "Cần có nhãn trước khi review",
     "lifecycle": {
       "checking": "Đang kiểm tra…",
-      "checks-failing_one": "{{count}} kiểm tra thất bại",
-      "checks-failing_other": "{{count}} kiểm tra thất bại",
+      "checks-failing": "Kiểm tra thất bại",
       "deployed": "Đã triển khai",
       "gate-checks-failed": "Một số kiểm tra không thành công",
       "gate-checks-failed-sub": "{{failing}} thất bại, {{passed}} thành công",
@@ -1490,10 +1489,9 @@
       "gate-review-rejected": "Yêu cầu thay đổi",
       "preparing-rollout": "Đang chuẩn bị triển khai…",
       "rejected": "Đã từ chối",
-      "rerun-stage": "Chạy lại · {{stage}}",
+      "rerun": "Chạy lại",
       "review-waiting": "Đang chờ {{role}}",
-      "run-stage": "Chạy · {{stage}}",
-      "stage-status": "{{status}} · {{stage}}"
+      "run": "Chạy"
     },
     "meta": {
       "created-by": "Tạo bởi {{user}}"

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1476,8 +1476,7 @@
     "labels-required-for-review": "提交审批前必须设置标签",
     "lifecycle": {
       "checking": "检查中…",
-      "checks-failing_one": "{{count}} 项检查失败",
-      "checks-failing_other": "{{count}} 项检查失败",
+      "checks-failing": "检查失败",
       "deployed": "已部署",
       "gate-checks-failed": "部分检查未通过",
       "gate-checks-failed-sub": "{{failing}} 项失败，{{passed}} 项通过",
@@ -1486,14 +1485,13 @@
       "gate-checks-running": "检查运行中",
       "gate-checks-running-sub": "{{running}} 项运行中，{{passed}} 项通过",
       "gate-review-approved": "变更已批准",
-      "gate-review-pending": "审核中",
+      "gate-review-pending": "审批中",
       "gate-review-rejected": "请求变更",
       "preparing-rollout": "正在准备发布…",
       "rejected": "已拒绝",
-      "rerun-stage": "重新执行 · {{stage}}",
+      "rerun": "重新执行",
       "review-waiting": "等待 {{role}}",
-      "run-stage": "执行 · {{stage}}",
-      "stage-status": "{{status}} · {{stage}}"
+      "run": "执行"
     },
     "meta": {
       "created-by": "由 {{user}} 创建"

--- a/frontend/src/react/pages/project/plan-detail/components/lifecycle/DeployStageActions.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/lifecycle/DeployStageActions.tsx
@@ -28,6 +28,17 @@ import { stageHasFailedOrCanceledTasks } from "./frontierStage";
 import { LifecycleStamp } from "./LifecycleStamp";
 import { useStageTitle } from "./useStageTitle";
 
+// A middot separator between the action/status word and the stage name. Purely
+// presentational (aria-hidden) and inherits the surrounding text color, so it
+// matches the label — the stage is a sibling span, not baked into the i18n string.
+function StageSeparator() {
+  return (
+    <span aria-hidden className="shrink-0">
+      ·
+    </span>
+  );
+}
+
 export function RunStageAction({ stage }: { stage: Stage }) {
   const { t } = useTranslation();
   const page = usePlanDetailContext();
@@ -90,9 +101,7 @@ export function RunStageAction({ stage }: { stage: Stage }) {
     return <FrontierStatusStamp stage={stage} />;
   }
 
-  const runLabel = isRerun
-    ? t("plan.lifecycle.rerun-stage", { stage: title })
-    : t("plan.lifecycle.run-stage", { stage: title });
+  const runVerb = isRerun ? t("plan.lifecycle.rerun") : t("plan.lifecycle.run");
 
   return (
     <>
@@ -101,8 +110,10 @@ export function RunStageAction({ stage }: { stage: Stage }) {
         onClick={() => setOpen(true)}
       >
         <Play className="size-4 shrink-0" />
-        <span className="truncate" title={runLabel}>
-          {runLabel}
+        <span className="shrink-0">{runVerb}</span>
+        <StageSeparator />
+        <span className="truncate" title={title}>
+          {title}
         </span>
       </Button>
       <PlanDetailTaskRolloutActionPanel
@@ -134,10 +145,7 @@ export function FrontierStatusStamp({ stage }: { stage: Stage }) {
   const { t } = useTranslation();
   const title = useStageTitle(stage);
   const status = getStageStatus(stage);
-  const label = t("plan.lifecycle.stage-status", {
-    stage: title,
-    status: stringifyTaskStatus(status, t),
-  });
+  const statusText = stringifyTaskStatus(status, t);
 
   return (
     <LifecycleStamp
@@ -146,8 +154,10 @@ export function FrontierStatusStamp({ stage }: { stage: Stage }) {
       tone={status === Task_Status.FAILED ? "error" : "neutral"}
     >
       <TaskStatusIcon size="tiny" status={status} />
-      <span className="truncate" title={label}>
-        {label}
+      <span className="shrink-0">{statusText}</span>
+      <StageSeparator />
+      <span className="truncate" title={title}>
+        {title}
       </span>
     </LifecycleStamp>
   );

--- a/frontend/src/react/pages/project/plan-detail/components/lifecycle/PlanLifecycleSlot.test.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/lifecycle/PlanLifecycleSlot.test.tsx
@@ -68,7 +68,6 @@ const renderEl = (element: React.ReactElement) =>
 const slot = (state: PlanLifecycleHeaderState) =>
   renderEl(<PlanLifecycleSlot state={state} />);
 
-const checks = { error: 1, running: 0, success: 0, total: 1, warning: 0 };
 const stage = create(StageSchema, { name: "stages/1" });
 
 describe("PlanLifecycleSlot (right action area)", () => {
@@ -79,7 +78,7 @@ describe("PlanLifecycleSlot (right action area)", () => {
     slot({ kind: "review-your-turn" });
     expect(container.textContent).toContain("marker-review-your-turn");
 
-    slot({ kind: "plan-status", reason: "rejected", checks });
+    slot({ kind: "plan-status", reason: "rejected" });
     expect(container.textContent).toContain("marker-plan-status");
 
     slot({ kind: "preparing-rollout" });

--- a/frontend/src/react/pages/project/plan-detail/components/lifecycle/PlanLifecycleSlot.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/lifecycle/PlanLifecycleSlot.tsx
@@ -36,11 +36,7 @@ export function PlanLifecycleSlot({
       return page.issue ? <ReviewYourTurnAction issue={page.issue} /> : null;
     case "plan-status":
       return page.issue ? (
-        <PlanStatusAction
-          checks={state.checks}
-          issue={page.issue}
-          reason={state.reason}
-        />
+        <PlanStatusAction issue={page.issue} reason={state.reason} />
       ) : null;
     case "preparing-rollout":
       return (

--- a/frontend/src/react/pages/project/plan-detail/components/lifecycle/PlanStatusAction.tsx
+++ b/frontend/src/react/pages/project/plan-detail/components/lifecycle/PlanStatusAction.tsx
@@ -51,11 +51,9 @@ const TONE_TRIGGER: Record<PlanStatusTone, string> = {
 export function PlanStatusAction({
   issue,
   reason,
-  checks,
 }: {
   issue: Issue;
   reason: PlanStatusReason;
-  checks: PlanCheckSummary;
 }) {
   const { t } = useTranslation();
   const page = usePlanDetailContext();
@@ -81,7 +79,7 @@ export function PlanStatusAction({
       case "rejected":
         return t("plan.lifecycle.rejected");
       case "checks-failing":
-        return t("plan.lifecycle.checks-failing", { count: checks.error });
+        return t("plan.lifecycle.checks-failing");
     }
   })();
 

--- a/frontend/src/react/pages/project/plan-detail/components/lifecycle/planLifecycleHeaderState.ts
+++ b/frontend/src/react/pages/project/plan-detail/components/lifecycle/planLifecycleHeaderState.ts
@@ -37,7 +37,7 @@ export type PlanLifecycleHeaderState =
   // Review.
   | { kind: "review-generating" } // disabled + loading
   | { kind: "review-your-turn" }
-  | { kind: "plan-status"; reason: PlanStatusReason; checks: PlanCheckSummary }
+  | { kind: "plan-status"; reason: PlanStatusReason }
   // Pre-deploy → rollout creation.
   | { kind: "preparing-rollout" }
   // Deploy (frontier stage). Run permission is enforced by the run confirmation
@@ -141,7 +141,7 @@ export function resolvePlanLifecycleHeaderState(
 
   // Rejected review.
   if (input.approvalStatus === ApprovalStatus.REJECTED) {
-    return { kind: "plan-status", reason: "rejected", checks: input.checks };
+    return { kind: "plan-status", reason: "rejected" };
   }
 
   // Approved / skipped: pre-deploy gate evaluation, then rollout creation.
@@ -150,14 +150,10 @@ export function resolvePlanLifecycleHeaderState(
     input.approvalStatus === ApprovalStatus.SKIPPED
   ) {
     if (input.checks.error > 0) {
-      return {
-        kind: "plan-status",
-        reason: "checks-failing",
-        checks: input.checks,
-      };
+      return { kind: "plan-status", reason: "checks-failing" };
     }
     if (input.checks.running > 0) {
-      return { kind: "plan-status", reason: "checking", checks: input.checks };
+      return { kind: "plan-status", reason: "checking" };
     }
     // All required gates passed; the backend auto-creates the rollout. Show a
     // transient progress state until it arrives, then resolveDeploy takes over.
@@ -169,7 +165,7 @@ export function resolvePlanLifecycleHeaderState(
     return { kind: "review-your-turn" };
   }
   // Review is the active gate — surface it plainly regardless of check state.
-  return { kind: "plan-status", reason: "in-review", checks: input.checks };
+  return { kind: "plan-status", reason: "in-review" };
 }
 
 // Whether the right-hand lifecycle slot renders a primary action/status control.


### PR DESCRIPTION
## What & why

Leans out the plan-detail header's lifecycle-slot labels and removes the
custom/interpolated text that had accumulated in them. The guiding rule: real
words belong in i18n; separators, layout, and data belong in code.

## Changes

**1. Approved-but-checks-failed status → "Checks failing"**
The status pill dropped the interpolated count. It read "{{count}} checks
failing"; it now reads a plain "Checks failing" (a plan-level status — the
per-check breakdown still lives one click away in the popover's checks row).
The `_one`/`_other` plural forms collapse to a single literal key.

**2. Compose the stage labels instead of baking the separator into i18n**
`Run · {{stage}}`, `Rerun · {{stage}}`, and `{{status}} · {{stage}}` were flat
strings with the `·` separator and stage name interpolated in. They now render
as siblings — verb/status word + a presentational `·` element + the stage in
its own span — so:
- the `·` is `aria-hidden` UI chrome, not translated text;
- only the stage truncates (the verb/status word never clips);
- `{{status}}` reuses the existing `task.status.*` label instead of nesting a
  translation inside another translation.

The rendered result is visually unchanged for normal-length names.

**3. Remove a dead resolver field**
With the count gone, nothing reads `checks` off the `plan-status` header state
anymore, so the field is removed from the resolver union (and the stale test
fixture).

## i18n

- Removed: `plan.lifecycle.checks-failing_one/_other`,
  `plan.lifecycle.run-stage`, `plan.lifecycle.rerun-stage`,
  `plan.lifecycle.stage-status`.
- Added: `plan.lifecycle.checks-failing` (single literal),
  `plan.lifecycle.run`, `plan.lifecycle.rerun`.
- Applied across all 5 locales; `review-waiting` ("Waiting for {{role}}") was
  intentionally left as a normal interpolation — it's a sentence, not a
  separator label.

## Testing

- `pnpm --dir frontend type-check` — clean
- `pnpm --dir frontend check` — biome, i18n cross-locale consistency (no
  missing/unused keys), layering, and locale sorter all pass
- `pnpm --dir frontend test` (plan-detail lifecycle) — 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
