### PR TITLE
feat(oracle): ROWID-based backup dedup for LOB tables + LONG pre-flight warning

### DIFF
--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
@@ -217,12 +217,18 @@ func (r *StatementPriorBackupCheckRule) longColumnAdvices(groupByTable map[strin
 //
 // The real Oracle sync stores the connection schema's tables under
 // SchemaMetadata{Name: ""} while the rule normalizes unqualified table
-// references to the database name, so an empty synced schema name matches any
-// requested schema (it IS the current schema).
+// references to the database name, so the empty synced schema name matches
+// the current owner only — a DML explicitly qualified with a different owner
+// must stay silent (its metadata is simply not synced), not borrow the
+// current schema's table of the same name.
 func oracleFindLongColumns(dbSchema *storepb.DatabaseSchemaMetadata, schemaName, tableName string) []string {
 	var result []string
 	for _, schemaMeta := range dbSchema.GetSchemas() {
-		if schemaMeta.GetName() != "" && !strings.EqualFold(schemaMeta.GetName(), schemaName) {
+		if schemaMeta.GetName() == "" {
+			if !strings.EqualFold(schemaName, dbSchema.GetName()) {
+				continue
+			}
+		} else if !strings.EqualFold(schemaMeta.GetName(), schemaName) {
 			continue
 		}
 		for _, tableMeta := range schemaMeta.GetTables() {

--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
@@ -3,6 +3,7 @@ package oracle
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/bytebase/omni/oracle/ast"
 
@@ -177,7 +178,61 @@ func (r *StatementPriorBackupCheckRule) handleSQLScriptExit() {
 		}
 	}
 
+	// Prior backup copies rows with CREATE TABLE ... AS SELECT, which Oracle
+	// does not support for LONG / LONG RAW columns at all (ORA-00997) — the
+	// task would fail at run time with no earlier signal. Warn up front with
+	// the table and column names.
+	adviceList = append(adviceList, r.longColumnAdvices(groupByTable)...)
+
 	r.adviceList = append(r.adviceList, adviceList...)
+}
+
+// longColumnAdvices warns for backup-targeted tables that contain LONG or
+// LONG RAW columns, which CREATE TABLE AS SELECT cannot copy.
+func (r *StatementPriorBackupCheckRule) longColumnAdvices(groupByTable map[string][]statementInfo) []*storepb.Advice {
+	if r.checkCtx.DBSchema == nil {
+		return nil
+	}
+	var adviceList []*storepb.Advice
+	for _, list := range groupByTable {
+		table := list[0].table
+		columns := oracleFindLongColumns(r.checkCtx.DBSchema, table.Schema, table.Table)
+		if len(columns) == 0 {
+			continue
+		}
+		adviceList = append(adviceList, &storepb.Advice{
+			Status:        r.level,
+			Title:         r.title,
+			Content:       fmt.Sprintf("Prior backup cannot copy table %q.%q: column(s) %s use the LONG/LONG RAW type, which CREATE TABLE AS SELECT does not support (ORA-00997). Disable prior backup for this issue or migrate the column type", table.Schema, table.Table, strings.Join(columns, ", ")),
+			Code:          code.BuiltinPriorBackupCheck.Int32(),
+			StartPosition: nil,
+		})
+	}
+	return adviceList
+}
+
+// oracleFindLongColumns returns the names of LONG / LONG RAW columns of the
+// given table, or nil when the table is not found in the synced metadata
+// (missing metadata must not produce false alarms).
+func oracleFindLongColumns(dbSchema *storepb.DatabaseSchemaMetadata, schemaName, tableName string) []string {
+	var result []string
+	for _, schemaMeta := range dbSchema.GetSchemas() {
+		if !strings.EqualFold(schemaMeta.GetName(), schemaName) {
+			continue
+		}
+		for _, tableMeta := range schemaMeta.GetTables() {
+			if !strings.EqualFold(tableMeta.GetName(), tableName) {
+				continue
+			}
+			for _, column := range tableMeta.GetColumns() {
+				typ := strings.ToUpper(strings.TrimSpace(column.GetType()))
+				if typ == "LONG" || typ == "LONG RAW" {
+					result = append(result, fmt.Sprintf("%q", column.GetName()))
+				}
+			}
+		}
+	}
+	return result
 }
 
 func oracleTableReferenceFromObjectName(databaseName string, name *ast.ObjectName, typ StatementType) *TableReference {

--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
@@ -196,7 +196,7 @@ func (r *StatementPriorBackupCheckRule) longColumnAdvices(groupByTable map[strin
 	var adviceList []*storepb.Advice
 	for _, list := range groupByTable {
 		table := list[0].table
-		columns := oracleFindLongColumns(r.checkCtx.DBSchema, table.Schema, table.Table)
+		columns := oracleFindLongColumns(r.checkCtx.DBSchema, table, r.checkCtx.IsObjectCaseSensitive)
 		if len(columns) == 0 {
 			continue
 		}
@@ -211,6 +211,21 @@ func (r *StatementPriorBackupCheckRule) longColumnAdvices(groupByTable map[strin
 	return adviceList
 }
 
+// oracleNameEqual compares an AST object name with a synced-metadata name.
+// The omni Oracle parser already delivers names in catalog form (unquoted
+// identifiers uppercased, "quoted" ones exact-case with quotes stripped) and
+// sync stores data-dictionary names verbatim, so in case-sensitive mode this
+// is plain equality — an EqualFold here would conflate T_LONG with a distinct
+// quoted "t_long" table and warn about the wrong table's columns. In
+// case-insensitive mode both sides fold, matching the rest of the Oracle
+// rules' normalizeNameByCaseSensitivity behavior.
+func oracleNameEqual(astName, metadataName string, isObjectCaseSensitive bool) bool {
+	if isObjectCaseSensitive {
+		return astName == metadataName
+	}
+	return strings.EqualFold(astName, metadataName)
+}
+
 // oracleFindLongColumns returns the names of LONG / LONG RAW columns of the
 // given table, or nil when the table is not found in the synced metadata
 // (missing metadata must not produce false alarms).
@@ -221,18 +236,21 @@ func (r *StatementPriorBackupCheckRule) longColumnAdvices(groupByTable map[strin
 // the current owner only — a DML explicitly qualified with a different owner
 // must stay silent (its metadata is simply not synced), not borrow the
 // current schema's table of the same name.
-func oracleFindLongColumns(dbSchema *storepb.DatabaseSchemaMetadata, schemaName, tableName string) []string {
+func oracleFindLongColumns(dbSchema *storepb.DatabaseSchemaMetadata, table *TableReference, isObjectCaseSensitive bool) []string {
 	var result []string
 	for _, schemaMeta := range dbSchema.GetSchemas() {
 		if schemaMeta.GetName() == "" {
-			if !strings.EqualFold(schemaName, dbSchema.GetName()) {
+			// The anonymous schema holds the connection owner's tables. An
+			// unqualified DML always targets the current owner; a qualified
+			// one matches only when it names the current owner.
+			if table.HasSchema && !oracleNameEqual(table.Schema, dbSchema.GetName(), isObjectCaseSensitive) {
 				continue
 			}
-		} else if !strings.EqualFold(schemaMeta.GetName(), schemaName) {
+		} else if !oracleNameEqual(table.Schema, schemaMeta.GetName(), isObjectCaseSensitive) {
 			continue
 		}
 		for _, tableMeta := range schemaMeta.GetTables() {
-			if !strings.EqualFold(tableMeta.GetName(), tableName) {
+			if !oracleNameEqual(table.Table, tableMeta.GetName(), isObjectCaseSensitive) {
 				continue
 			}
 			for _, column := range tableMeta.GetColumns() {

--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check.go
@@ -214,10 +214,15 @@ func (r *StatementPriorBackupCheckRule) longColumnAdvices(groupByTable map[strin
 // oracleFindLongColumns returns the names of LONG / LONG RAW columns of the
 // given table, or nil when the table is not found in the synced metadata
 // (missing metadata must not produce false alarms).
+//
+// The real Oracle sync stores the connection schema's tables under
+// SchemaMetadata{Name: ""} while the rule normalizes unqualified table
+// references to the database name, so an empty synced schema name matches any
+// requested schema (it IS the current schema).
 func oracleFindLongColumns(dbSchema *storepb.DatabaseSchemaMetadata, schemaName, tableName string) []string {
 	var result []string
 	for _, schemaMeta := range dbSchema.GetSchemas() {
-		if !strings.EqualFold(schemaMeta.GetName(), schemaName) {
+		if schemaMeta.GetName() != "" && !strings.EqualFold(schemaMeta.GetName(), schemaName) {
 			continue
 		}
 		for _, tableMeta := range schemaMeta.GetTables() {

--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check_test.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check_test.go
@@ -17,11 +17,14 @@ import (
 // CREATE TABLE AS SELECT cannot copy those columns (ORA-00997), so prior
 // backup fails at run time with no earlier signal unless the check warns.
 func TestPriorBackupLongColumnWarning(t *testing.T) {
+	// The real Oracle sync stores the connection schema's tables under an
+	// EMPTY schema name (db/oracle/sync.go) — the fixture must match that
+	// shape or the schema comparison is never exercised realistically.
 	dbSchema := &storepb.DatabaseSchemaMetadata{
 		Name: "DB",
 		Schemas: []*storepb.SchemaMetadata{
 			{
-				Name: "DB",
+				Name: "",
 				Tables: []*storepb.TableMetadata{
 					{Name: "T_LONG", Columns: []*storepb.ColumnMetadata{
 						{Name: "ID", Type: "NUMBER"},
@@ -92,6 +95,14 @@ func TestPriorBackupLongColumnWarning(t *testing.T) {
 		advices := longAdvices(check(t,
 			"UPDATE T_LONG SET ID = 1 WHERE ID = 1;\nUPDATE T_LONG SET ID = 2 WHERE ID = 2;"))
 		require.Len(t, advices, 1)
+	})
+
+	t.Run("schema_qualified_dml_warns_too", func(t *testing.T) {
+		// Schema-qualified DML normalizes to an explicit schema name; the
+		// empty synced schema (= current schema) must still match.
+		advices := longAdvices(check(t, "UPDATE DB.T_LONG SET ID = 1 WHERE ID = 2;"))
+		require.Len(t, advices, 1)
+		require.Contains(t, advices[0].Content, `"PAYLOAD"`)
 	})
 
 	t.Run("unknown_table_stays_silent", func(t *testing.T) {

--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check_test.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check_test.go
@@ -116,4 +116,69 @@ func TestPriorBackupLongColumnWarning(t *testing.T) {
 		// Missing metadata must not produce false alarms.
 		require.Empty(t, longAdvices(check(t, "UPDATE NO_SUCH_TABLE SET ID = 1 WHERE ID = 2;")))
 	})
+
+	// Quoted identifiers are case-sensitive in Oracle while unquoted ones are
+	// catalogued upper-case: T_LONG and a quoted "t_long" are DIFFERENT
+	// tables. The lookup must honor that instead of EqualFold-ing across it.
+	t.Run("quoted_identifier_case_semantics", func(t *testing.T) {
+		csSchema := &storepb.DatabaseSchemaMetadata{
+			Name: "DB",
+			Schemas: []*storepb.SchemaMetadata{
+				{
+					Name: "",
+					Tables: []*storepb.TableMetadata{
+						// Unquoted DDL: catalogued upper, has a LONG column.
+						{Name: "T_LONG", Columns: []*storepb.ColumnMetadata{
+							{Name: "ID", Type: "NUMBER"},
+							{Name: "PAYLOAD", Type: "LONG"},
+						}},
+						// Quoted DDL twin: exact-case lower, NO LONG column.
+						{Name: "t_long", Columns: []*storepb.ColumnMetadata{
+							{Name: "ID", Type: "NUMBER"},
+							{Name: "NOTE", Type: "VARCHAR2"},
+						}},
+						// Quoted DDL with a LONG column.
+						{Name: "t_raw", Columns: []*storepb.ColumnMetadata{
+							{Name: "ID", Type: "NUMBER"},
+							{Name: "RAWCOL", Type: "LONG RAW"},
+						}},
+					},
+				},
+			},
+		}
+		checkCS := func(t *testing.T, statement string) []*storepb.Advice {
+			t.Helper()
+			parsed, err := base.ParseStatements(storepb.Engine_ORACLE, statement)
+			require.NoError(t, err)
+			checkCtx := advisor.Context{
+				DBType:                storepb.Engine_ORACLE,
+				DBSchema:              csSchema,
+				EnablePriorBackup:     true,
+				IsObjectCaseSensitive: true,
+				Rule:                  &storepb.SQLReviewRule{Type: storepb.SQLReviewRule_BUILTIN_PRIOR_BACKUP_CHECK, Level: storepb.SQLReviewRule_WARNING},
+				ParsedStatements:      parsed,
+				ListDatabaseNamesFunc: func(context.Context, string) ([]string, error) {
+					return []string{"BBDATAARCHIVE"}, nil
+				},
+			}
+			a := &StatementPriorBackupCheckAdvisor{}
+			advices, err := a.Check(context.Background(), checkCtx)
+			require.NoError(t, err)
+			return advices
+		}
+
+		// Quoted ref targets the exact-case table without LONG: must stay
+		// silent (a fold-blind compare would borrow T_LONG and false-warn).
+		require.Empty(t, longAdvices(checkCS(t, `UPDATE "t_long" SET ID = 1 WHERE ID = 2;`)))
+
+		// Quoted ref targeting a quoted table WITH a LONG RAW column warns.
+		quoted := longAdvices(checkCS(t, `UPDATE "t_raw" SET ID = 1 WHERE ID = 2;`))
+		require.Len(t, quoted, 1)
+		require.Contains(t, quoted[0].Content, `"RAWCOL"`)
+
+		// Unquoted ref folds upper and finds T_LONG.
+		upper := longAdvices(checkCS(t, "UPDATE t_long SET ID = 1 WHERE ID = 2;"))
+		require.Len(t, upper, 1)
+		require.Contains(t, upper[0].Content, `"PAYLOAD"`)
+	})
 }

--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check_test.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check_test.go
@@ -105,6 +105,13 @@ func TestPriorBackupLongColumnWarning(t *testing.T) {
 		require.Contains(t, advices[0].Content, `"PAYLOAD"`)
 	})
 
+	t.Run("cross_owner_dml_stays_silent", func(t *testing.T) {
+		// The empty synced schema holds only the CONNECTED schema's tables;
+		// a different explicit owner must not borrow its metadata even when
+		// a same-named table exists.
+		require.Empty(t, longAdvices(check(t, "UPDATE OTHER_OWNER.T_LONG SET ID = 1 WHERE ID = 2;")))
+	})
+
 	t.Run("unknown_table_stays_silent", func(t *testing.T) {
 		// Missing metadata must not produce false alarms.
 		require.Empty(t, longAdvices(check(t, "UPDATE NO_SUCH_TABLE SET ID = 1 WHERE ID = 2;")))

--- a/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check_test.go
+++ b/backend/plugin/advisor/oracle/rule_builtin_prior_backup_check_test.go
@@ -1,0 +1,101 @@
+package oracle
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+	_ "github.com/bytebase/bytebase/backend/plugin/parser/plsql"
+)
+
+// TestPriorBackupLongColumnWarning pins the LONG/LONG RAW pre-flight warning:
+// CREATE TABLE AS SELECT cannot copy those columns (ORA-00997), so prior
+// backup fails at run time with no earlier signal unless the check warns.
+func TestPriorBackupLongColumnWarning(t *testing.T) {
+	dbSchema := &storepb.DatabaseSchemaMetadata{
+		Name: "DB",
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "DB",
+				Tables: []*storepb.TableMetadata{
+					{Name: "T_LONG", Columns: []*storepb.ColumnMetadata{
+						{Name: "ID", Type: "NUMBER"},
+						{Name: "PAYLOAD", Type: "LONG"},
+					}},
+					{Name: "T_LONG_RAW", Columns: []*storepb.ColumnMetadata{
+						{Name: "ID", Type: "NUMBER"},
+						{Name: "BLOB_ISH", Type: "LONG RAW"},
+					}},
+					{Name: "T_CLOB", Columns: []*storepb.ColumnMetadata{
+						{Name: "ID", Type: "NUMBER"},
+						{Name: "DOC", Type: "CLOB"},
+					}},
+				},
+			},
+		},
+	}
+
+	check := func(t *testing.T, statement string) []*storepb.Advice {
+		t.Helper()
+		parsed, err := base.ParseStatements(storepb.Engine_ORACLE, statement)
+		require.NoError(t, err)
+		checkCtx := advisor.Context{
+			DBType:            storepb.Engine_ORACLE,
+			DBSchema:          dbSchema,
+			EnablePriorBackup: true,
+			Rule:              &storepb.SQLReviewRule{Type: storepb.SQLReviewRule_BUILTIN_PRIOR_BACKUP_CHECK, Level: storepb.SQLReviewRule_WARNING},
+			ParsedStatements:  parsed,
+			ListDatabaseNamesFunc: func(context.Context, string) ([]string, error) {
+				return []string{"BBDATAARCHIVE"}, nil
+			},
+		}
+		a := &StatementPriorBackupCheckAdvisor{}
+		advices, err := a.Check(context.Background(), checkCtx)
+		require.NoError(t, err)
+		return advices
+	}
+
+	longAdvices := func(advices []*storepb.Advice) []*storepb.Advice {
+		var result []*storepb.Advice
+		for _, a := range advices {
+			if strings.Contains(a.Content, "LONG") {
+				result = append(result, a)
+			}
+		}
+		return result
+	}
+
+	t.Run("long_column_warns_with_table_and_column", func(t *testing.T) {
+		advices := longAdvices(check(t, "UPDATE T_LONG SET ID = 1 WHERE ID = 2;"))
+		require.Len(t, advices, 1)
+		require.Contains(t, advices[0].Content, `"T_LONG"`)
+		require.Contains(t, advices[0].Content, `"PAYLOAD"`)
+	})
+
+	t.Run("long_raw_column_warns", func(t *testing.T) {
+		advices := longAdvices(check(t, "DELETE FROM T_LONG_RAW WHERE ID = 2;"))
+		require.Len(t, advices, 1)
+		require.Contains(t, advices[0].Content, `"BLOB_ISH"`)
+	})
+
+	t.Run("clob_does_not_warn", func(t *testing.T) {
+		// CLOB backups work via ROWID deduplication — no warning.
+		require.Empty(t, longAdvices(check(t, "UPDATE T_CLOB SET ID = 1 WHERE ID = 2;")))
+	})
+
+	t.Run("one_warning_per_table_not_per_statement", func(t *testing.T) {
+		advices := longAdvices(check(t,
+			"UPDATE T_LONG SET ID = 1 WHERE ID = 1;\nUPDATE T_LONG SET ID = 2 WHERE ID = 2;"))
+		require.Len(t, advices, 1)
+	})
+
+	t.Run("unknown_table_stays_silent", func(t *testing.T) {
+		// Missing metadata must not produce false alarms.
+		require.Empty(t, longAdvices(check(t, "UPDATE NO_SUCH_TABLE SET ID = 1 WHERE ID = 2;")))
+	})
+}

--- a/backend/plugin/parser/plsql/backup.go
+++ b/backend/plugin/parser/plsql/backup.go
@@ -41,6 +41,7 @@ type TableReference struct {
 	Schema        string
 	Table         string
 	Alias         string
+	DBLink        string
 	StatementType StatementType
 }
 
@@ -68,7 +69,7 @@ func TransformDMLToSelect(_ context.Context, tCtx base.TransformContext, stateme
 func generateSQL(ctx base.TransformContext, statementInfoList []statementInfo, targetDatabase string, tablePrefix string) ([]base.BackupStatement, error) {
 	groupByTable := make(map[string][]statementInfo)
 	for _, item := range statementInfoList {
-		key := fmt.Sprintf("%s.%s", item.table.Schema, item.table.Table)
+		key := fmt.Sprintf("%s.%s@%s", item.table.Schema, item.table.Table, item.table.DBLink)
 		groupByTable[key] = append(groupByTable[key], item)
 	}
 
@@ -121,6 +122,17 @@ func generateSQL(ctx base.TransformContext, statementInfoList []statementInfo, t
 
 func generateSQLForTable(ctx base.TransformContext, statementInfoList []statementInfo, targetDatabase string, tablePrefix string) (*base.BackupStatement, error) {
 	table := statementInfoList[0].table
+
+	// Prior backup cannot round-trip a table referenced through a database
+	// link: the backup CTAS could read the remote rows, but the restore path
+	// only records schema+table and would write the rows back into a LOCAL
+	// table of the same name — silent cross-database corruption on rollback.
+	// That was already true before the ROWID rework (the link was dropped
+	// from the reconstructed source), so fail loudly instead of producing a
+	// backup that cannot be restored correctly.
+	if table.DBLink != "" {
+		return nil, errors.Errorf("prior backup does not support tables referenced through a database link: %s.%s@%s; disable prior backup for this issue", table.Schema, table.Table, table.DBLink)
+	}
 
 	version, ok := ctx.Version.(*Version)
 	if !ok {
@@ -271,6 +283,7 @@ func omniDMLTableReference(databaseName string, name *oracleast.ObjectName, alia
 		HasSchema:     hasSchema,
 		Schema:        schema,
 		Table:         name.Name,
+		DBLink:        name.DBLink,
 		StatementType: statementType,
 	}
 	if alias != nil {

--- a/backend/plugin/parser/plsql/backup.go
+++ b/backend/plugin/parser/plsql/backup.go
@@ -141,30 +141,34 @@ func generateSQLForTable(ctx base.TransformContext, statementInfoList []statemen
 	if _, err := fmt.Fprintf(&buf, `CREATE TABLE "%s"."%s" AS`+"\n", targetDatabase, targetTable); err != nil {
 		return nil, errors.Wrap(err, "failed to write to buffer")
 	}
-	for i, info := range statementInfoList {
-		if i != 0 {
-			if _, err := buf.WriteString("\n  UNION\n"); err != nil {
-				return nil, errors.Wrap(err, "failed to write to buffer")
-			}
+	if len(statementInfoList) == 1 {
+		// Single DML: a plain CTAS needs no deduplication.
+		if err := writeBranchSelect(&buf, statementInfoList[0], "*", "  "); err != nil {
+			return nil, err
 		}
-		t := info.table
-		if t.Alias != "" {
-			if _, err := fmt.Fprintf(&buf, `  SELECT "%s".* FROM `, t.Alias); err != nil {
-				return nil, errors.Wrap(err, "failed to write to buffer")
-			}
-		} else {
-			if t.HasSchema {
-				if _, err := fmt.Fprintf(&buf, `  SELECT "%s"."%s".* FROM `, t.Schema, t.Table); err != nil {
+	} else {
+		// Multiple DMLs on the same table: deduplicate by ROWID instead of a
+		// value-based UNION. UNION's implicit DISTINCT compares every column,
+		// which fails on LOB columns (ORA-22848) and silently collapses
+		// value-identical physical rows into one backup row. ROWID is always
+		// comparable, keeps LOB columns out of the comparison key, and
+		// deduplicates by physical row — the semantics a backup wants.
+		if _, err := fmt.Fprintf(&buf, `  SELECT "%s"."%s".* FROM "%s"."%s" WHERE ROWID IN (`+"\n",
+			table.Schema, table.Table, table.Schema, table.Table); err != nil {
+			return nil, errors.Wrap(err, "failed to write to buffer")
+		}
+		for i, info := range statementInfoList {
+			if i != 0 {
+				if _, err := buf.WriteString("\n    UNION\n"); err != nil {
 					return nil, errors.Wrap(err, "failed to write to buffer")
 				}
-			} else {
-				if _, err := fmt.Fprintf(&buf, `  SELECT "%s".* FROM `, t.Table); err != nil {
-					return nil, errors.Wrap(err, "failed to write to buffer")
-				}
+			}
+			if err := writeBranchSelect(&buf, info, "ROWID", "    "); err != nil {
+				return nil, err
 			}
 		}
-		if err := writeSuffixSelectClause(&buf, info.node, info.fullSQL); err != nil {
-			return nil, errors.Wrap(err, "failed to write suffix select clause")
+		if _, err := buf.WriteString("\n  )"); err != nil {
+			return nil, errors.Wrap(err, "failed to write to buffer")
 		}
 	}
 
@@ -273,6 +277,28 @@ func omniDMLTableReference(databaseName string, name *oracleast.ObjectName, alia
 		table.Alias = alias.Name
 	}
 	return table
+}
+
+// writeBranchSelect writes one `SELECT <qualifier>.<projection> FROM <dml
+// target and predicate>` branch. projection is "*" for a plain CTAS body and
+// "ROWID" for the deduplication subquery branches.
+func writeBranchSelect(buf *strings.Builder, info statementInfo, projection string, indent string) error {
+	t := info.table
+	switch {
+	case t.Alias != "":
+		if _, err := fmt.Fprintf(buf, `%sSELECT "%s".%s FROM `, indent, t.Alias, projection); err != nil {
+			return errors.Wrap(err, "failed to write to buffer")
+		}
+	case t.HasSchema:
+		if _, err := fmt.Fprintf(buf, `%sSELECT "%s"."%s".%s FROM `, indent, t.Schema, t.Table, projection); err != nil {
+			return errors.Wrap(err, "failed to write to buffer")
+		}
+	default:
+		if _, err := fmt.Fprintf(buf, `%sSELECT "%s".%s FROM `, indent, t.Table, projection); err != nil {
+			return errors.Wrap(err, "failed to write to buffer")
+		}
+	}
+	return errors.Wrap(writeSuffixSelectClause(buf, info.node, info.fullSQL), "failed to write suffix select clause")
 }
 
 func writeSuffixSelectClause(buf *strings.Builder, node oracleast.StmtNode, fullSQL string) error {

--- a/backend/plugin/parser/plsql/backup_test.go
+++ b/backend/plugin/parser/plsql/backup_test.go
@@ -148,3 +148,23 @@ func TestBackupOmniBoundaryCases(t *testing.T) {
 		})
 	}
 }
+
+// TestTransformDMLToSelectRejectsDatabaseLinks pins the fail-loud contract for
+// DML targeting a table through a database link: the restore path records only
+// schema+table, so a "successful" backup of remote rows would restore into a
+// LOCAL table of the same name — reject up front instead.
+func TestTransformDMLToSelectRejectsDatabaseLinks(t *testing.T) {
+	for _, statement := range []string{
+		"UPDATE lt1@remote SET c1 = 1 WHERE b1 = 1;",
+		"UPDATE lt1@remote SET c1 = 1 WHERE b1 = 1;\nUPDATE lt1@remote SET c1 = 2 WHERE b1 = 2;",
+	} {
+		_, err := TransformDMLToSelect(context.Background(), base.TransformContext{}, statement, "DB", "backupDB", "rollback")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "database link")
+	}
+
+	// A local table with the same name as a remote one must keep working.
+	stmts, err := TransformDMLToSelect(context.Background(), base.TransformContext{}, "UPDATE lt1 SET c1 = 1 WHERE b1 = 1;", "DB", "backupDB", "rollback")
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+}

--- a/backend/plugin/parser/plsql/test-data/test_backup.yaml
+++ b/backend/plugin/parser/plsql/test-data/test_backup.yaml
@@ -12,11 +12,13 @@
   result:
     - statement: |-
         CREATE TABLE "backupDB"."rollback_TEST11_DB" AS
-          SELECT "TEST11".* FROM test11 WHERE test11.b1 = 2
-          UNION
-          SELECT "TEST11".* FROM test11 WHERE test11.b1 = 4
-          UNION
-          SELECT "TEST11".* FROM test11 WHERE test11.b1 = 6;
+          SELECT "DB"."TEST11".* FROM "DB"."TEST11" WHERE ROWID IN (
+            SELECT "TEST11".ROWID FROM test11 WHERE test11.b1 = 2
+            UNION
+            SELECT "TEST11".ROWID FROM test11 WHERE test11.b1 = 4
+            UNION
+            SELECT "TEST11".ROWID FROM test11 WHERE test11.b1 = 6
+          );
       sourceschema: DB
       sourcetablename: TEST11
       targettablename: rollback_TEST11_DB
@@ -28,19 +30,21 @@
         column: 50
     - statement: |-
         CREATE TABLE "backupDB"."rollback_TEST_DB" AS
-          SELECT "TEST".* FROM test WHERE test.b1 = 1
-          UNION
-          SELECT "TEST".* FROM test WHERE test.b1 = 2
-          UNION
-          SELECT "TEST".* FROM test WHERE test.b1 = 3
-          UNION
-          SELECT "TEST".* FROM test WHERE test.b1 = 4
-          UNION
-          SELECT "TEST".* FROM test WHERE test.b1 = 5
-          UNION
-          SELECT "TEST".* FROM test WHERE test.b1 = 6
-          UNION
-          SELECT "TEST".* FROM test WHERE test.b1 = 7;
+          SELECT "DB"."TEST".* FROM "DB"."TEST" WHERE ROWID IN (
+            SELECT "TEST".ROWID FROM test WHERE test.b1 = 1
+            UNION
+            SELECT "TEST".ROWID FROM test WHERE test.b1 = 2
+            UNION
+            SELECT "TEST".ROWID FROM test WHERE test.b1 = 3
+            UNION
+            SELECT "TEST".ROWID FROM test WHERE test.b1 = 4
+            UNION
+            SELECT "TEST".ROWID FROM test WHERE test.b1 = 5
+            UNION
+            SELECT "TEST".ROWID FROM test WHERE test.b1 = 6
+            UNION
+            SELECT "TEST".ROWID FROM test WHERE test.b1 = 7
+          );
       sourceschema: DB
       sourcetablename: TEST
       targettablename: rollback_TEST_DB
@@ -112,9 +116,11 @@
   result:
     - statement: |-
         CREATE TABLE "backupDB"."rollback_TEST_DB" AS
-          SELECT "T".* FROM test  t WHERE t.c1 = 1
-          UNION
-          SELECT "T".* FROM test  t WHERE t.c1 = 5;
+          SELECT "DB"."TEST".* FROM "DB"."TEST" WHERE ROWID IN (
+            SELECT "T".ROWID FROM test  t WHERE t.c1 = 1
+            UNION
+            SELECT "T".ROWID FROM test  t WHERE t.c1 = 5
+          );
       sourceschema: DB
       sourcetablename: TEST
       targettablename: rollback_TEST_DB
@@ -214,9 +220,11 @@
   result:
     - statement: |-
         CREATE TABLE "backupDB"."rollback_TEST_DB" AS
-          SELECT "TEST".* FROM test WHERE test.c1 = 1
-          UNION
-          SELECT "TEST".* FROM test WHERE test.c1 = 5;
+          SELECT "DB"."TEST".* FROM "DB"."TEST" WHERE ROWID IN (
+            SELECT "TEST".ROWID FROM test WHERE test.c1 = 1
+            UNION
+            SELECT "TEST".ROWID FROM test WHERE test.c1 = 5
+          );
       sourceschema: DB
       sourcetablename: TEST
       targettablename: rollback_TEST_DB


### PR DESCRIPTION
## Problem (BYT-9829)

Prior backup generates `CREATE TABLE ... AS SELECT` and, when one table has multiple DML statements, deduplicates the branches with a value-based `UNION`. UNION's implicit DISTINCT compares every column, so:

- **LOB columns (CLOB/BLOB/NCLOB) are not comparable → ORA-22848** at run time, with no earlier warning (the reported case: bank migration scripts routinely carry several DMLs per table)
- **Value-identical physical rows collapse into one backup row** → restore silently loses rows (pre-existing fidelity bug)

Single-DML backups (plain CTAS, no dedup) always worked — the failure needs LOB × multiple DMLs on one table.

## Fix

**Engine (plsql/backup.go)** — dedup by ROWID instead of by value:
```sql
CREATE TABLE "backupDB"."bak" AS
  SELECT "S"."T".* FROM "S"."T" WHERE ROWID IN (
    SELECT "T".ROWID FROM t WHERE p1
    UNION
    SELECT "T".ROWID FROM t WHERE p2
  );
```
ROWID is always comparable, keeps LOB columns out of the comparison key, and deduplicates by *physical row* — which is what a backup wants. Single-DML statements keep the unchanged plain CTAS. ROWID `IN` subqueries are supported from 11g (the code's version floor); usage is confined to a single consistent-read statement, so no ROWID-drift concerns.

**Advisor (rule_builtin_prior_backup_check.go)** — LONG / LONG RAW columns fail inside CTAS itself (ORA-00997) regardless of dedup strategy, so the prior-backup check now warns up front with table and column names when a targeted table carries them. CLOB tables need no warning anymore. Missing/unknown metadata stays silent to avoid false alarms.

## Verification

- Golden tests regenerated (`test-data/test_backup.yaml`) — multi-DML entries switch to the ROWID form, single-DML entries unchanged
- New advisor unit tests: LONG warns (with table+column), LONG RAW warns, CLOB doesn't, one warning per table, unknown table silent
- **Live Oracle Free 23ai verification** of the exact generated SQL shapes: CLOB table + overlapping predicates → 3 unique rows backed up (previously ORA-22848); value-identical rows → both preserved; aliased-branch qualifier form works
- `plsql` + `advisor/oracle` package suites green; no gofmt/vet findings

Refs BYT-9829. PG (`json`/`xml`) and MSSQL (`xml`/`text`) share the same UNION pattern with their own incomparable types — tracked separately as sibling issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)