### PR TITLE
fix: avoid eager database listing for approval checks

### DIFF
--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -411,10 +411,19 @@ type specTarget struct {
 // unfoldDatabaseTargets unfolds database groups and returns all database targets.
 // If the targets list contains a single database group reference, it unfolds it to individual databases.
 // Otherwise, it returns the targets as-is.
-func unfoldDatabaseTargets(ctx context.Context, stores *store.Store, dbTargets []string, projectID string, allDatabases []*store.DatabaseMessage) ([]string, error) {
+func unfoldDatabaseTargets(ctx context.Context, stores *store.Store, dbTargets []string, projectID string, allDatabases []*store.DatabaseMessage, databaseGroup *v1pb.DatabaseGroup) ([]string, error) {
 	// Check if this is a database group (single target)
 	if len(dbTargets) == 1 {
-		if _, databaseGroupID, err := common.GetProjectIDDatabaseGroupID(dbTargets[0]); err == nil {
+		target := dbTargets[0]
+		if databaseGroup != nil && databaseGroup.Name == target {
+			var unfolded []string
+			for _, db := range databaseGroup.MatchedDatabases {
+				unfolded = append(unfolded, db.Name)
+			}
+			return unfolded, nil
+		}
+
+		if _, databaseGroupID, err := common.GetProjectIDDatabaseGroupID(target); err == nil {
 			// This is a database group - unfold it
 			databaseGroup, err := stores.GetDatabaseGroup(ctx, &store.FindDatabaseGroupMessage{
 				ResourceID: &databaseGroupID,
@@ -444,21 +453,80 @@ func unfoldDatabaseTargets(ctx context.Context, stores *store.Store, dbTargets [
 }
 
 // unfoldSpecTargets unfolds database groups in specs and returns all database targets.
-func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storepb.PlanConfig_Spec, projectID string) ([]specTarget, error) {
-	// Batch fetch all databases for the project
-	allDatabases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &projectID})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to list databases for project %q", projectID)
+// allDatabases must be nil or the full unfiltered project database list; callers pass it
+// through to keep database-group matching and direct database lookup on the same snapshot.
+func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storepb.PlanConfig_Spec, projectID string, allDatabases []*store.DatabaseMessage, databaseGroup *v1pb.DatabaseGroup) ([]specTarget, error) {
+	var databaseMap map[string]*store.DatabaseMessage
+	buildDatabaseMap := func(databases []*store.DatabaseMessage) map[string]*store.DatabaseMessage {
+		m := make(map[string]*store.DatabaseMessage, len(databases))
+		for _, db := range databases {
+			m[common.FormatDatabase(db.InstanceID, db.DatabaseName)] = db
+		}
+		return m
 	}
-
-	// Build a map for quick lookup: instanceID/databaseName -> DatabaseMessage
-	databaseMap := make(map[string]*store.DatabaseMessage)
-	for _, db := range allDatabases {
-		key := common.FormatDatabase(db.InstanceID, db.DatabaseName)
-		databaseMap[key] = db
+	getAllDatabases := func() error {
+		if allDatabases == nil {
+			var err error
+			allDatabases, err = stores.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &projectID})
+			if err != nil {
+				return errors.Wrapf(err, "failed to list databases for project %q", projectID)
+			}
+		}
+		if databaseMap == nil {
+			databaseMap = buildDatabaseMap(allDatabases)
+		}
+		return nil
 	}
+	getDatabase := func(target string) (*store.DatabaseMessage, error) {
+		if databaseMap != nil {
+			if db := databaseMap[target]; db != nil {
+				return db, nil
+			}
+		}
 
+		instanceID, databaseName, err := common.GetInstanceDatabaseID(target)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse database target %q", target)
+		}
+		databases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{
+			ProjectID:    &projectID,
+			InstanceID:   &instanceID,
+			DatabaseName: &databaseName,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get database %q", target)
+		}
+		if len(databases) == 0 {
+			return nil, errors.Errorf("database %q not found", target)
+		}
+		return databases[0], nil
+	}
 	var targets []specTarget
+	appendTargets := func(dbTargets []string, sheetSha256 string) error {
+		if len(dbTargets) == 1 {
+			if _, _, err := common.GetProjectIDDatabaseGroupID(dbTargets[0]); err == nil {
+				if err := getAllDatabases(); err != nil {
+					return err
+				}
+			}
+		}
+
+		unfolded, err := unfoldDatabaseTargets(ctx, stores, dbTargets, projectID, allDatabases, databaseGroup)
+		if err != nil {
+			return err
+		}
+		for _, target := range unfolded {
+			db, err := getDatabase(target)
+			if err != nil {
+				return err
+			}
+			targets = append(targets, specTarget{
+				database:    db,
+				sheetSha256: sheetSha256,
+			})
+		}
+		return nil
+	}
 
 	for _, spec := range specs {
 		switch config := spec.Config.(type) {
@@ -479,37 +547,13 @@ func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storep
 			})
 
 		case *storepb.PlanConfig_Spec_ChangeDatabaseConfig:
-			dbTargets, err := unfoldDatabaseTargets(ctx, stores, config.ChangeDatabaseConfig.Targets, projectID, allDatabases)
-			if err != nil {
+			if err := appendTargets(config.ChangeDatabaseConfig.Targets, config.ChangeDatabaseConfig.SheetSha256); err != nil {
 				return nil, err
-			}
-
-			for _, target := range dbTargets {
-				db := databaseMap[target]
-				if db == nil {
-					return nil, errors.Errorf("database %q not found", target)
-				}
-				targets = append(targets, specTarget{
-					database:    db,
-					sheetSha256: config.ChangeDatabaseConfig.SheetSha256,
-				})
 			}
 
 		case *storepb.PlanConfig_Spec_ExportDataConfig:
-			dbTargets, err := unfoldDatabaseTargets(ctx, stores, config.ExportDataConfig.Targets, projectID, allDatabases)
-			if err != nil {
+			if err := appendTargets(config.ExportDataConfig.Targets, config.ExportDataConfig.SheetSha256); err != nil {
 				return nil, err
-			}
-
-			for _, target := range dbTargets {
-				db := databaseMap[target]
-				if db == nil {
-					return nil, errors.Errorf("database %q not found", target)
-				}
-				targets = append(targets, specTarget{
-					database:    db,
-					sheetSha256: config.ExportDataConfig.SheetSha256,
-				})
 			}
 		default:
 		}
@@ -575,7 +619,7 @@ func buildCELVariablesForDatabaseChange(ctx context.Context, stores *store.Store
 	}
 
 	// Unfold database groups and get all targets
-	targets, err := unfoldSpecTargets(ctx, stores, plan.Config.GetSpecs(), issue.ProjectID)
+	targets, err := unfoldSpecTargets(ctx, stores, plan.Config.GetSpecs(), issue.ProjectID, nil, nil)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to unfold spec targets")
 	}
@@ -671,7 +715,7 @@ func buildCELVariablesForDataExport(ctx context.Context, stores *store.Store, is
 	}
 
 	// Unfold database groups and get all targets (only EXPORT_DATA targets)
-	targets, err := unfoldSpecTargets(ctx, stores, plan.Config.GetSpecs(), issue.ProjectID)
+	targets, err := unfoldSpecTargets(ctx, stores, plan.Config.GetSpecs(), issue.ProjectID, nil, nil)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "failed to unfold spec targets")
 	}

--- a/backend/runner/approval/runner_test.go
+++ b/backend/runner/approval/runner_test.go
@@ -1,13 +1,19 @@
 package approval
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/type/expr"
 
 	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/runner/plancheck"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -235,7 +241,42 @@ func TestBuildStatementSummaryResultMapUsesSheetSHA256(t *testing.T) {
 	}].GetSqlSummaryReport().GetAffectedRows())
 }
 
-func TestIsPlanCheckRunPendingApprovalEvaluation(t *testing.T) {
+func TestDeriveCheckTargetsSkipsCreateDatabaseAndReleaseSpecs(t *testing.T) {
+	project := &store.ProjectMessage{ResourceID: "project"}
+	plan := &store.PlanMessage{
+		ProjectID: "project",
+		Config: &storepb.PlanConfig{
+			Specs: []*storepb.PlanConfig_Spec{
+				{
+					Config: &storepb.PlanConfig_Spec_CreateDatabaseConfig{
+						CreateDatabaseConfig: &storepb.PlanConfig_CreateDatabaseConfig{},
+					},
+				},
+				{
+					Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+							Release: "projects/project/releases/release",
+						},
+					},
+				},
+				{
+					Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+							Targets: []string{"instances/prod/databases/app"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := plancheck.DeriveCheckTargets(context.Background(), nil, project, plan, nil)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "instances/prod/databases/app", got[0].Target)
+}
+
+func TestIsPlanCheckRunCurrentForApprovalInputVersion(t *testing.T) {
 	tests := []struct {
 		name         string
 		planCheckRun *store.PlanCheckRunMessage
@@ -266,4 +307,139 @@ func TestIsPlanCheckRunPendingApprovalEvaluation(t *testing.T) {
 			require.Equal(t, tt.want, isPlanCheckRunPendingApprovalEvaluation(tt.planCheckRun))
 		})
 	}
+}
+
+func TestUnfoldDatabaseTargetsUsesResolvedDatabaseGroup(t *testing.T) {
+	database := &store.DatabaseMessage{
+		InstanceID:   "prod",
+		DatabaseName: "app",
+	}
+	databaseGroup := &v1pb.DatabaseGroup{
+		Name: "projects/project/databaseGroups/group",
+		MatchedDatabases: []*v1pb.DatabaseGroup_Database{{
+			Name: common.FormatDatabase(database.InstanceID, database.DatabaseName),
+		}},
+	}
+
+	got, err := unfoldDatabaseTargets(
+		context.Background(),
+		// nil store is intentional: the resolved-group path must not touch the store.
+		nil,
+		[]string{databaseGroup.Name},
+		"project",
+		[]*store.DatabaseMessage{database},
+		databaseGroup,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{common.FormatDatabase(database.InstanceID, database.DatabaseName)}, got)
+}
+
+func TestUnfoldDatabaseTargetsFallsBackWhenResolvedGroupNameDiffers(t *testing.T) {
+	ctx := context.Background()
+	s := setupApprovalRunnerStore(ctx, t)
+	allDatabases := setupApprovalDatabaseGroupFixture(ctx, t, s)
+
+	got, err := unfoldDatabaseTargets(
+		ctx,
+		s,
+		[]string{"projects/project-a/databaseGroups/group"},
+		"project-a",
+		allDatabases,
+		&v1pb.DatabaseGroup{Name: "projects/project-a/databaseGroups/other"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []string{"instances/prod/databases/app"}, got)
+}
+
+func TestUnfoldSpecTargetsDirectTargetDoesNotListProjectDatabases(t *testing.T) {
+	ctx := context.Background()
+	s := setupApprovalRunnerStore(ctx, t)
+	setupApprovalDatabaseGroupFixture(ctx, t, s)
+
+	_, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "other",
+		Workspace:  "default",
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = s.GetDB().ExecContext(ctx, `
+		INSERT INTO db (instance, name, project, metadata)
+		VALUES ($1, $2, $3, $4::jsonb)
+	`, "other", "broken", "project-a", `{"labels":"not-a-map"}`)
+	require.NoError(t, err)
+
+	targets, err := unfoldSpecTargets(ctx, s, []*storepb.PlanConfig_Spec{{
+		Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+			ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+				Targets: []string{"instances/prod/databases/app"},
+			},
+		},
+	}}, "project-a", nil, nil)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Equal(t, "prod", targets[0].database.InstanceID)
+	require.Equal(t, "app", targets[0].database.DatabaseName)
+}
+
+func setupApprovalRunnerStore(ctx context.Context, t *testing.T) *store.Store {
+	t.Helper()
+
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	return s
+}
+
+func setupApprovalDatabaseGroupFixture(ctx context.Context, t *testing.T, s *store.Store) []*store.DatabaseMessage {
+	t.Helper()
+
+	_, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "prod",
+		Workspace:  "default",
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
+		ProjectID:    "project-a",
+		InstanceID:   "prod",
+		DatabaseName: "app",
+		Metadata:     &storepb.DatabaseMetadata{Labels: map[string]string{}},
+	})
+	require.NoError(t, err)
+	_, err = s.CreateDatabaseGroup(ctx, &store.DatabaseGroupMessage{
+		ProjectID:  "project-a",
+		ResourceID: "group",
+		Title:      "group",
+		Expression: &expr.Expr{Expression: `resource.database_name == "app"`},
+	})
+	require.NoError(t, err)
+
+	projectID := "project-a"
+	allDatabases, err := s.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &projectID})
+	require.NoError(t, err)
+	return allDatabases
 }

--- a/backend/runner/plancheck/database_group.go
+++ b/backend/runner/plancheck/database_group.go
@@ -1,0 +1,79 @@
+package plancheck
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/backend/common"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/store"
+	"github.com/bytebase/bytebase/backend/utils"
+)
+
+// GetDatabaseGroupForPlan checks if the plan targets a database group and returns it with matched databases.
+// Returns nil if the plan does not target a database group.
+// allDatabases must be nil or the full unfiltered database list for the plan's project;
+// a filtered list would silently make the group expansion incomplete.
+func GetDatabaseGroupForPlan(ctx context.Context, stores *store.Store, plan *store.PlanMessage, allDatabases []*store.DatabaseMessage) (*v1pb.DatabaseGroup, error) {
+	target, databaseGroupID, ok := findDatabaseGroupTarget(plan.Config.GetSpecs())
+	if !ok {
+		return nil, nil
+	}
+
+	dbGroup, err := stores.GetDatabaseGroup(ctx, &store.FindDatabaseGroupMessage{
+		ResourceID: &databaseGroupID,
+		ProjectIDs: []string{plan.ProjectID},
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get database group %q", target)
+	}
+	if dbGroup == nil {
+		return nil, errors.Errorf("database group %q not found", target)
+	}
+
+	if allDatabases == nil {
+		allDatabases, err = stores.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &plan.ProjectID})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to list databases for project %q", plan.ProjectID)
+		}
+	}
+
+	matchedDatabases, err := utils.GetMatchedDatabasesInDatabaseGroup(ctx, dbGroup, allDatabases)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get matched databases for group %q", databaseGroupID)
+	}
+
+	result := &v1pb.DatabaseGroup{Name: target}
+	for _, db := range matchedDatabases {
+		result.MatchedDatabases = append(result.MatchedDatabases, &v1pb.DatabaseGroup_Database{
+			Name: common.FormatDatabase(db.InstanceID, db.DatabaseName),
+		})
+	}
+	return result, nil
+}
+
+// HasDatabaseGroupTarget reports whether any change-database spec targets a database group.
+// It only parses target resource names and does not touch the store.
+func HasDatabaseGroupTarget(specs []*storepb.PlanConfig_Spec) bool {
+	_, _, ok := findDatabaseGroupTarget(specs)
+	return ok
+}
+
+func findDatabaseGroupTarget(specs []*storepb.PlanConfig_Spec) (string, string, bool) {
+	for _, spec := range specs {
+		cfg := spec.GetChangeDatabaseConfig()
+		if cfg == nil || len(cfg.Targets) != 1 {
+			continue
+		}
+
+		target := cfg.Targets[0]
+		_, databaseGroupID, err := common.GetProjectIDDatabaseGroupID(target)
+		if err != nil {
+			continue
+		}
+		return target, databaseGroupID, true
+	}
+	return "", "", false
+}

--- a/backend/runner/plancheck/database_group_test.go
+++ b/backend/runner/plancheck/database_group_test.go
@@ -1,0 +1,160 @@
+package plancheck
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/expr"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestHasDatabaseGroupTarget(t *testing.T) {
+	tests := []struct {
+		name  string
+		specs []*storepb.PlanConfig_Spec
+		want  bool
+	}{
+		{
+			name: "direct database target",
+			specs: []*storepb.PlanConfig_Spec{{
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{"instances/prod/databases/app"},
+					},
+				},
+			}},
+		},
+		{
+			name: "multiple targets are not a database group target",
+			specs: []*storepb.PlanConfig_Spec{{
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{"projects/project-a/databaseGroups/group", "instances/prod/databases/app"},
+					},
+				},
+			}},
+		},
+		{
+			name: "database group target",
+			specs: []*storepb.PlanConfig_Spec{{
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{"projects/project-a/databaseGroups/group"},
+					},
+				},
+			}},
+			want: true,
+		},
+		{
+			name: "export data group target does not require plan check group expansion",
+			specs: []*storepb.PlanConfig_Spec{{
+				Config: &storepb.PlanConfig_Spec_ExportDataConfig{
+					ExportDataConfig: &storepb.PlanConfig_ExportDataConfig{
+						Targets: []string{"projects/project-a/databaseGroups/group"},
+					},
+				},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, HasDatabaseGroupTarget(tt.specs))
+		})
+	}
+}
+
+func TestGetDatabaseGroupForPlanMatchesDatabases(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlancheckStore(ctx, t)
+	setupPlancheckDatabaseGroupFixture(ctx, t, s)
+
+	target := "projects/project-a/databaseGroups/group"
+	got, err := GetDatabaseGroupForPlan(ctx, s, &store.PlanMessage{
+		ProjectID: "project-a",
+		Config: &storepb.PlanConfig{
+			Specs: []*storepb.PlanConfig_Spec{{
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{target},
+					},
+				},
+			}},
+		},
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, target, got.Name)
+	require.Equal(t, []string{common.FormatDatabase("prod", "app")}, databaseNames(got.MatchedDatabases))
+}
+
+func setupPlancheckStore(ctx context.Context, t *testing.T) *store.Store {
+	t.Helper()
+
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	return s
+}
+
+func setupPlancheckDatabaseGroupFixture(ctx context.Context, t *testing.T, s *store.Store) {
+	t.Helper()
+
+	_, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "prod",
+		Workspace:  "default",
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+	for _, databaseName := range []string{"app", "audit"} {
+		_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
+			ProjectID:    "project-a",
+			InstanceID:   "prod",
+			DatabaseName: databaseName,
+			Metadata:     &storepb.DatabaseMetadata{Labels: map[string]string{}},
+		})
+		require.NoError(t, err)
+	}
+	_, err = s.CreateDatabaseGroup(ctx, &store.DatabaseGroupMessage{
+		ProjectID:  "project-a",
+		ResourceID: "group",
+		Title:      "group",
+		Expression: &expr.Expr{Expression: `resource.database_name == "app"`},
+	})
+	require.NoError(t, err)
+}
+
+func databaseNames(databases []*v1pb.DatabaseGroup_Database) []string {
+	var names []string
+	for _, database := range databases {
+		names = append(names, database.Name)
+	}
+	return names
+}

--- a/backend/runner/plancheck/scheduler.go
+++ b/backend/runner/plancheck/scheduler.go
@@ -10,14 +10,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/component/bus"
 	"github.com/bytebase/bytebase/backend/enterprise"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/store"
-	"github.com/bytebase/bytebase/backend/utils"
 )
 
 const (
@@ -119,7 +116,7 @@ func (s *Scheduler) runPlanCheckRun(ctx context.Context, projectID string, uid i
 	}
 
 	// Get database group if needed (for spec expansion)
-	databaseGroup, err := s.getDatabaseGroupForPlan(ctxWithCancel, plan)
+	databaseGroup, err := GetDatabaseGroupForPlan(ctxWithCancel, s.store, plan, nil)
 	if err != nil {
 		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, err.Error())
 		return
@@ -207,61 +204,4 @@ func (s *Scheduler) markPlanCheckRunCanceled(ctx context.Context, projectID stri
 	); err != nil {
 		slog.Error("failed to mark plan check run canceled", log.BBError(err))
 	}
-}
-
-// getDatabaseGroupForPlan checks if the plan targets a database group and returns it with matched databases.
-// Returns nil if the plan does not target a database group.
-func (s *Scheduler) getDatabaseGroupForPlan(ctx context.Context, plan *store.PlanMessage) (*v1pb.DatabaseGroup, error) {
-	for _, spec := range plan.Config.Specs {
-		cfg, ok := spec.Config.(*storepb.PlanConfig_Spec_ChangeDatabaseConfig)
-		if !ok {
-			continue
-		}
-		if len(cfg.ChangeDatabaseConfig.Targets) != 1 {
-			continue
-		}
-
-		target := cfg.ChangeDatabaseConfig.Targets[0]
-		_, databaseGroupID, err := common.GetProjectIDDatabaseGroupID(target)
-		if err != nil {
-			// Not a database group reference, skip
-			continue
-		}
-
-		// Found a database group reference - fetch and expand it
-		dbGroup, err := s.store.GetDatabaseGroup(ctx, &store.FindDatabaseGroupMessage{
-			ResourceID: &databaseGroupID,
-			ProjectIDs: []string{plan.ProjectID},
-		})
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get database group %q", target)
-		}
-		if dbGroup == nil {
-			return nil, errors.Errorf("database group %q not found", target)
-		}
-
-		// Get all databases in the project to compute matches
-		allDatabases, err := s.store.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &plan.ProjectID})
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to list databases for project %q", plan.ProjectID)
-		}
-
-		// Compute matched databases using CEL expression
-		matchedDatabases, err := utils.GetMatchedDatabasesInDatabaseGroup(ctx, dbGroup, allDatabases)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get matched databases for group %q", databaseGroupID)
-		}
-
-		// Convert to v1pb.DatabaseGroup format
-		result := &v1pb.DatabaseGroup{
-			Name: target,
-		}
-		for _, db := range matchedDatabases {
-			result.MatchedDatabases = append(result.MatchedDatabases, &v1pb.DatabaseGroup_Database{
-				Name: common.FormatDatabase(db.InstanceID, db.DatabaseName),
-			})
-		}
-		return result, nil
-	}
-	return nil, nil
 }


### PR DESCRIPTION
Backport #20741 to release/3.20.0.

Summary:
- Avoid project-wide database listing on non-group approval-check paths until target unfolding actually needs it.
- Resolve direct database targets with a scoped project+instance+database lookup; keep full project database listing only for database-group expansion.
- Add shared database-group target detection helpers for plan check approval paths.
- Add coverage for direct non-group unfolding, database-group detection, and resolved-group unfolding behavior.

Testing:
- go test -v -count=1 ./backend/runner/approval ./backend/runner/plancheck
- golangci-lint run --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go