### PR TITLE
fix: avoid eager database listing in approval runner

### DIFF
--- a/backend/runner/approval/runner.go
+++ b/backend/runner/approval/runner.go
@@ -525,23 +525,78 @@ func unfoldDatabaseTargets(ctx context.Context, stores *store.Store, dbTargets [
 // allDatabases must be nil or the full unfiltered project database list; callers pass it
 // through to keep database-group matching and direct database lookup on the same snapshot.
 func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storepb.PlanConfig_Spec, projectID string, allDatabases []*store.DatabaseMessage, databaseGroup *v1pb.DatabaseGroup) ([]specTarget, error) {
-	// Batch fetch all databases for the project
-	if allDatabases == nil {
-		var err error
-		allDatabases, err = stores.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &projectID})
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to list databases for project %q", projectID)
+	var databaseMap map[string]*store.DatabaseMessage
+	buildDatabaseMap := func(databases []*store.DatabaseMessage) map[string]*store.DatabaseMessage {
+		m := make(map[string]*store.DatabaseMessage, len(databases))
+		for _, db := range databases {
+			m[common.FormatDatabase(db.InstanceID, db.DatabaseName)] = db
 		}
+		return m
 	}
+	getAllDatabases := func() error {
+		if allDatabases == nil {
+			var err error
+			allDatabases, err = stores.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &projectID})
+			if err != nil {
+				return errors.Wrapf(err, "failed to list databases for project %q", projectID)
+			}
+		}
+		if databaseMap == nil {
+			databaseMap = buildDatabaseMap(allDatabases)
+		}
+		return nil
+	}
+	getDatabase := func(target string) (*store.DatabaseMessage, error) {
+		if databaseMap != nil {
+			if db := databaseMap[target]; db != nil {
+				return db, nil
+			}
+		}
 
-	// Build a map for quick lookup: instanceID/databaseName -> DatabaseMessage
-	databaseMap := make(map[string]*store.DatabaseMessage)
-	for _, db := range allDatabases {
-		key := common.FormatDatabase(db.InstanceID, db.DatabaseName)
-		databaseMap[key] = db
+		instanceID, databaseName, err := common.GetInstanceDatabaseID(target)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to parse database target %q", target)
+		}
+		databases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{
+			ProjectID:    &projectID,
+			InstanceID:   &instanceID,
+			DatabaseName: &databaseName,
+		})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get database %q", target)
+		}
+		if len(databases) == 0 {
+			return nil, errors.Errorf("database %q not found", target)
+		}
+		return databases[0], nil
 	}
 
 	var targets []specTarget
+	appendTargets := func(dbTargets []string, sheetSha256 string) error {
+		if len(dbTargets) == 1 {
+			if _, _, err := common.GetProjectIDDatabaseGroupID(dbTargets[0]); err == nil {
+				if err := getAllDatabases(); err != nil {
+					return err
+				}
+			}
+		}
+
+		unfolded, err := unfoldDatabaseTargets(ctx, stores, dbTargets, projectID, allDatabases, databaseGroup)
+		if err != nil {
+			return err
+		}
+		for _, target := range unfolded {
+			db, err := getDatabase(target)
+			if err != nil {
+				return err
+			}
+			targets = append(targets, specTarget{
+				database:    db,
+				sheetSha256: sheetSha256,
+			})
+		}
+		return nil
+	}
 
 	for _, spec := range specs {
 		switch config := spec.Config.(type) {
@@ -562,37 +617,13 @@ func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storep
 			})
 
 		case *storepb.PlanConfig_Spec_ChangeDatabaseConfig:
-			dbTargets, err := unfoldDatabaseTargets(ctx, stores, config.ChangeDatabaseConfig.Targets, projectID, allDatabases, databaseGroup)
-			if err != nil {
+			if err := appendTargets(config.ChangeDatabaseConfig.Targets, config.ChangeDatabaseConfig.SheetSha256); err != nil {
 				return nil, err
-			}
-
-			for _, target := range dbTargets {
-				db := databaseMap[target]
-				if db == nil {
-					return nil, errors.Errorf("database %q not found", target)
-				}
-				targets = append(targets, specTarget{
-					database:    db,
-					sheetSha256: config.ChangeDatabaseConfig.SheetSha256,
-				})
 			}
 
 		case *storepb.PlanConfig_Spec_ExportDataConfig:
-			dbTargets, err := unfoldDatabaseTargets(ctx, stores, config.ExportDataConfig.Targets, projectID, allDatabases, databaseGroup)
-			if err != nil {
+			if err := appendTargets(config.ExportDataConfig.Targets, config.ExportDataConfig.SheetSha256); err != nil {
 				return nil, err
-			}
-
-			for _, target := range dbTargets {
-				db := databaseMap[target]
-				if db == nil {
-					return nil, errors.Errorf("database %q not found", target)
-				}
-				targets = append(targets, specTarget{
-					database:    db,
-					sheetSha256: config.ExportDataConfig.SheetSha256,
-				})
 			}
 		default:
 		}

--- a/backend/runner/approval/runner_test.go
+++ b/backend/runner/approval/runner_test.go
@@ -424,6 +424,40 @@ func TestUnfoldDatabaseTargetsFallsBackWhenResolvedGroupNameDiffers(t *testing.T
 	require.Equal(t, []string{"instances/prod/databases/app"}, got)
 }
 
+func TestUnfoldSpecTargetsDirectTargetDoesNotListProjectDatabases(t *testing.T) {
+	ctx := context.Background()
+	s := setupApprovalRunnerStore(ctx, t)
+	setupApprovalDatabaseGroupFixture(ctx, t, s)
+
+	_, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "other",
+		Workspace:  "default",
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = s.GetDB().ExecContext(ctx, `
+		INSERT INTO db (instance, name, project, metadata)
+		VALUES ($1, $2, $3, $4::jsonb)
+	`, "other", "broken", "project-a", `{"labels":"not-a-map"}`)
+	require.NoError(t, err)
+
+	targets, err := unfoldSpecTargets(ctx, s, []*storepb.PlanConfig_Spec{{
+		Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+			ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+				Targets: []string{"instances/prod/databases/app"},
+			},
+		},
+	}}, "project-a", nil, nil)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Equal(t, "prod", targets[0].database.InstanceID)
+	require.Equal(t, "app", targets[0].database.DatabaseName)
+}
+
 func TestBuildCELVariablesForDatabaseChangeCreatesMissingPlanCheckRun(t *testing.T) {
 	ctx := context.Background()
 	s := setupApprovalRunnerStore(ctx, t)


### PR DESCRIPTION
## Summary
- Lazily list project databases in the approval runner only when unfolding a database group.
- Resolve direct database targets with scoped project, instance, and database filters.
- Add a regression test proving unrelated malformed database metadata does not break direct target unfolding.

## Checklist
- Breaking change review: not breaking; this narrows internal approval-runner database reads without changing APIs, proto, schema, config, UI, or webhook payloads.
- Composite-PK query safety: skipped; no backend/store or backend/migrator changes.
- Image compatibility window: skipped; no compatibility metadata changes.
- SonarCloud properties: skipped; no new files or directories.
- Pull request template: none found under .github or repository root.

## Testing
- gofmt -w backend/runner/approval/runner.go backend/runner/approval/runner_test.go
- go test -v -count=1 ./backend/runner/approval -run ^TestUnfoldSpecTargetsDirectTargetDoesNotListProjectDatabases$
- go test -v -count=1 ./backend/runner/approval
- golangci-lint run --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go