### PR TITLE
chore: bump omni for Oracle PIVOT/UNPIVOT table_reference parsing

### DIFF
--- a/backend/plugin/db/oracle/query.go
+++ b/backend/plugin/db/oracle/query.go
@@ -391,8 +391,6 @@ func isSimpleOracleSelect(selectStmt *oracleast.SelectStmt) bool {
 		selectStmt.OrderBy == nil &&
 		selectStmt.ForUpdate == nil &&
 		selectStmt.FetchFirst == nil &&
-		selectStmt.Pivot == nil &&
-		selectStmt.Unpivot == nil &&
 		selectStmt.Op == oracleast.SETOP_NONE
 }
 

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -277,20 +277,6 @@ func (q *omniQuerySpanExtractor) extractOmniSelect(stmt *oracleast.SelectStmt) (
 	if stmt.Op != 0 {
 		return q.extractOmniSetSelect(stmt)
 	}
-	if stmt.Pivot != nil {
-		source, err := q.extractOmniPivot(stmt.Pivot)
-		if err != nil {
-			return nil, err
-		}
-		return q.projectOmniTransformedSelect(stmt, source)
-	}
-	if stmt.Unpivot != nil {
-		source, err := q.extractOmniUnpivot(stmt.Unpivot)
-		if err != nil {
-			return nil, err
-		}
-		return q.projectOmniTransformedSelect(stmt, source)
-	}
 	if stmt.ModelClause != nil {
 		source, err := q.extractOmniModelSelect(stmt)
 		if err != nil {

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -573,15 +573,18 @@ func (q *omniQuerySpanExtractor) extractOmniPivot(pivot *oracleast.PivotClause) 
 	if pivot == nil {
 		return nil, nil
 	}
+	// Capture the FROM scope before extracting the source: a join source
+	// appends its operands to tableSourcesFrom, and they must not leak past
+	// this transform — the clause replaces them with its own output.
+	oldFrom := q.tableSourcesFrom
+	defer func() {
+		q.tableSourcesFrom = oldFrom
+	}()
 	source, err := q.extractOmniTableExpr(pivot.Source)
 	if err != nil {
 		return nil, err
 	}
-	oldFrom := q.tableSourcesFrom
 	q.tableSourcesFrom = append(q.tableSourcesFrom, source)
-	defer func() {
-		q.tableSourcesFrom = oldFrom
-	}()
 
 	excluded := make(map[string]bool)
 	pivotSources := make(base.SourceColumnSet)
@@ -646,15 +649,18 @@ func (q *omniQuerySpanExtractor) extractOmniUnpivot(unpivot *oracleast.UnpivotCl
 	if unpivot == nil {
 		return nil, nil
 	}
+	// Capture the FROM scope before extracting the source: a join source
+	// appends its operands to tableSourcesFrom, and they must not leak past
+	// this transform — the clause replaces them with its own output.
+	oldFrom := q.tableSourcesFrom
+	defer func() {
+		q.tableSourcesFrom = oldFrom
+	}()
 	source, err := q.extractOmniTableExpr(unpivot.Source)
 	if err != nil {
 		return nil, err
 	}
-	oldFrom := q.tableSourcesFrom
 	q.tableSourcesFrom = append(q.tableSourcesFrom, source)
-	defer func() {
-		q.tableSourcesFrom = oldFrom
-	}()
 
 	valueColumns := omniExprList(unpivot.ValueColumns)
 	inputSources := make([]base.SourceColumnSet, len(valueColumns))
@@ -773,15 +779,18 @@ func (q *omniQuerySpanExtractor) extractOmniMatchRecognize(ref *oracleast.MatchR
 	if ref == nil {
 		return nil, nil
 	}
+	// Capture the FROM scope before extracting the source: a join source
+	// appends its operands to tableSourcesFrom, and they must not leak past
+	// this transform — the clause replaces them with its own output.
+	oldFrom := q.tableSourcesFrom
+	defer func() {
+		q.tableSourcesFrom = oldFrom
+	}()
 	source, err := q.extractOmniTableExpr(ref.Source)
 	if err != nil {
 		return nil, err
 	}
-	oldFrom := q.tableSourcesFrom
 	q.tableSourcesFrom = append(q.tableSourcesFrom, source)
-	defer func() {
-		q.tableSourcesFrom = oldFrom
-	}()
 
 	partitionResults, err := q.extractOmniResultList(ref.PartitionBy)
 	if err != nil {

--- a/backend/plugin/parser/plsql/query_span_extractor_omni.go
+++ b/backend/plugin/parser/plsql/query_span_extractor_omni.go
@@ -584,7 +584,15 @@ func (q *omniQuerySpanExtractor) extractOmniPivot(pivot *oracleast.PivotClause) 
 	if err != nil {
 		return nil, err
 	}
-	q.tableSourcesFrom = append(q.tableSourcesFrom, source)
+	// While deriving the transform's output, the scope is exactly the
+	// extracted source: the clause's inputs resolve against it alone, never
+	// against enclosing join operands or the source's own leaked operands
+	// (a USING-merged column must attribute to both sides, not to the first
+	// operand in the slice).
+	q.tableSourcesFrom = nil
+	if source != nil {
+		q.tableSourcesFrom = []base.TableSource{source}
+	}
 
 	excluded := make(map[string]bool)
 	pivotSources := make(base.SourceColumnSet)
@@ -660,7 +668,15 @@ func (q *omniQuerySpanExtractor) extractOmniUnpivot(unpivot *oracleast.UnpivotCl
 	if err != nil {
 		return nil, err
 	}
-	q.tableSourcesFrom = append(q.tableSourcesFrom, source)
+	// While deriving the transform's output, the scope is exactly the
+	// extracted source: the clause's inputs resolve against it alone, never
+	// against enclosing join operands or the source's own leaked operands
+	// (a USING-merged column must attribute to both sides, not to the first
+	// operand in the slice).
+	q.tableSourcesFrom = nil
+	if source != nil {
+		q.tableSourcesFrom = []base.TableSource{source}
+	}
 
 	valueColumns := omniExprList(unpivot.ValueColumns)
 	inputSources := make([]base.SourceColumnSet, len(valueColumns))
@@ -790,7 +806,15 @@ func (q *omniQuerySpanExtractor) extractOmniMatchRecognize(ref *oracleast.MatchR
 	if err != nil {
 		return nil, err
 	}
-	q.tableSourcesFrom = append(q.tableSourcesFrom, source)
+	// While deriving the transform's output, the scope is exactly the
+	// extracted source: the clause's inputs resolve against it alone, never
+	// against enclosing join operands or the source's own leaked operands
+	// (a USING-merged column must attribute to both sides, not to the first
+	// operand in the slice).
+	q.tableSourcesFrom = nil
+	if source != nil {
+		q.tableSourcesFrom = []base.TableSource{source}
+	}
 
 	partitionResults, err := q.extractOmniResultList(ref.PartitionBy)
 	if err != nil {

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -467,6 +467,24 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 			},
 		},
 		{
+			// (subquery) PIVOT (...) alias — the alias qualifies projected
+			// and ORDER BY references (the shape stmt-level parsing broke).
+			name:      "pivot trailing alias qualifies references",
+			statement: "SELECT P.A, P.ONE_CNT FROM (SELECT A, B FROM T) PIVOT (COUNT(*) AS CNT FOR B IN (1 AS ONE, 2 AS TWO)) P ORDER BY P.A",
+			want: []base.QuerySpanResult{
+				{Name: "A", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "A"}})},
+				{Name: "ONE_CNT", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+			},
+		},
+		{
+			name:      "pivot alias joins another table",
+			statement: "SELECT P.ONE_CNT, T2.C FROM (SELECT A, B FROM T) PIVOT (COUNT(*) AS CNT FOR B IN (1 AS ONE)) P JOIN T2 ON P.A = T2.C",
+			want: []base.QuerySpanResult{
+				{Name: "ONE_CNT", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T", Column: "B"}})},
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{{Database: "PUBLIC", Table: "T2", Column: "C"}})},
+			},
+		},
+		{
 			name:      "pivot explicit projection",
 			statement: "SELECT A FROM (SELECT A, B FROM T) PIVOT (COUNT(*) AS CNT FOR B IN (1 AS ONE, 2 AS TWO))",
 			want: []base.QuerySpanResult{

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -491,6 +491,20 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 			},
 		},
 		{
+			// The pivot's FOR/aggregate inputs must resolve against the
+			// pivot source ONLY: with a join source, SUM(C) has to attribute
+			// to the USING-merged column (both sides), not the first operand.
+			name:      "pivot aggregate over join source resolves merged input",
+			statement: "SELECT ONE_S FROM (T JOIN T2 USING (C)) PIVOT (SUM(C) AS S FOR B IN (1 AS ONE))",
+			want: []base.QuerySpanResult{
+				{Name: "ONE_S", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "B"},
+					{Database: "PUBLIC", Table: "T", Column: "C"},
+					{Database: "PUBLIC", Table: "T2", Column: "C"},
+				})},
+			},
+		},
+		{
 			name:      "pivot alias joins another table",
 			statement: "SELECT P.ONE_CNT, T2.C FROM (SELECT A, B FROM T) PIVOT (COUNT(*) AS CNT FOR B IN (1 AS ONE)) P JOIN T2 ON P.A = T2.C",
 			want: []base.QuerySpanResult{

--- a/backend/plugin/parser/plsql/query_span_omni_parity_test.go
+++ b/backend/plugin/parser/plsql/query_span_omni_parity_test.go
@@ -477,6 +477,20 @@ func TestOracleOmniTypedLongTailTableSources(t *testing.T) {
 			},
 		},
 		{
+			// A pivot whose source is a parenthesized join must not leak the
+			// join operands into the FROM scope: the USING-merged column has
+			// to resolve to the pivot output (both sides), not to the first
+			// leaked operand.
+			name:      "pivot over join source resolves merged columns",
+			statement: "SELECT C FROM (T JOIN T2 USING (C)) PIVOT (COUNT(*) AS CNT FOR B IN (1 AS ONE))",
+			want: []base.QuerySpanResult{
+				{Name: "C", SourceColumns: sourceColumnSetFromList([]base.ColumnResource{
+					{Database: "PUBLIC", Table: "T", Column: "C"},
+					{Database: "PUBLIC", Table: "T2", Column: "C"},
+				})},
+			},
+		},
+		{
 			name:      "pivot alias joins another table",
 			statement: "SELECT P.ONE_CNT, T2.C FROM (SELECT A, B FROM T) PIVOT (COUNT(*) AS CNT FOR B IN (1 AS ONE)) P JOIN T2 ON P.A = T2.C",
 			want: []base.QuerySpanResult{

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260708021240-171d8abc36d7
+	github.com/bytebase/omni v0.0.0-20260709103218-72e9a03222dc
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260708021240-171d8abc36d7 h1:VcZGq9HvaVTo0rBTdr1CMjjuARYHSkv2TnlE5Y06Ikk=
-github.com/bytebase/omni v0.0.0-20260708021240-171d8abc36d7/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260709103218-72e9a03222dc h1:3RCryLK16wzMjYpnmpgYtXPSDgcjKPVdLXQNbgdFbxc=
+github.com/bytebase/omni v0.0.0-20260709103218-72e9a03222dc/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
Bumps omni to pick up bytebase/omni#373: Oracle PIVOT/UNPIVOT are now parsed inside the table_reference chain, so a pivoted source can carry a trailing bare-identifier alias and participate in joins — the shape a customer's PL/SQL report function uses (`OPEN cur FOR SELECT p.a FROM (subquery) PIVOT (...) p ORDER BY p.a`), which previously failed to parse.

Consumer changes for the removed `SelectStmt.Pivot/Unpivot` fields:

- `backend/plugin/parser/plsql/query_span_extractor_omni.go`: drop the dead select-level branches; the from-item form (`case *oracleast.PivotClause`) already handles extraction, including the new trailing alias via `aliasOmniTableSource`.
- `backend/plugin/db/oracle/query.go`: drop the redundant `isSimpleOracleSelect` conjuncts — a pivot from-item is not a DUAL `TableRef`, so `isOracleSelectFromDual` already excludes pivoted queries.
- New parity span tests pin the trailing-alias and pivot-join shapes (alias-qualified references resolve to base-table source columns).

The omni side was verified against Oracle 23ai Free across three review rounds (source-form × pivot/unpivot matrix, clause chaining, malformed-body rejection, alias-before-pivot acceptance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)