### PR TITLE
chore(renovate): delay npm updates until they clear pnpm's minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
   ],
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "description": "Wait out pnpm 11's 24h minimumReleaseAge supply-chain policy so PRs don't arrive with failing installs",
+      "minimumReleaseAge": "1 day"
+    },
+    {
       "groupName": "pnpm",
       "description": "Bump pnpm together across package.json, workflows, and the Dockerfile",
       "matchPackageNames": ["pnpm"]


### PR DESCRIPTION
## What

Add a Renovate package rule setting `minimumReleaseAge: "1 day"` for npm-datasource dependencies, aligning Renovate's proposal timing with pnpm 11's built-in `minimumReleaseAge` supply-chain policy (24 hours).

## Why

Renovate opens update PRs the moment a release is published, but pnpm 11 refuses to install packages younger than 24 hours (`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`). Every npm PR for a fresh release therefore arrives with `frontend-tests`, `static-checks`, and `renovate/artifacts` all red for its first ~24 hours — #20777 is the latest example (the @codingame v35 packages were ~9.5h old when CI ran).

With this rule, Renovate waits until a version has been on the registry for a day before proposing it, so update PRs are installable on arrival. This also inherits the safety property of the pnpm policy: versions that get yanked as malicious within the window simply never become a PR.

Scoped to `matchDatasources: ["npm"]` — Go modules, GitHub releases, and other datasources are unaffected.

## Testing

- `python3 -m json.tool renovate.json` validates
- Semantics verified against pnpm 11's observed cutoff in the #20777 CI logs (exactly 24h before install time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)