### PR TITLE
fix(deps): revert plugin-legacy to v7 and vscode-languageclient to v9

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,7 +92,7 @@
     "tailwind-merge": "^3.4.0",
     "uuid": "14.0.1",
     "vscode": "npm:@codingame/monaco-vscode-extension-api@35.0.0",
-    "vscode-languageclient": "10.1.0",
+    "vscode-languageclient": "9.0.1",
     "vscode-ws-jsonrpc": "3.5.0",
     "vue": "3.5.39",
     "zustand": "^5.0.13"
@@ -126,7 +126,7 @@
     "@types/scrollparent": "^2.0.3",
     "@types/semver": "7.7.1",
     "@types/slug": "5.0.9",
-    "@vitejs/plugin-legacy": "~8.2.0",
+    "@vitejs/plugin-legacy": "~7.2.1",
     "autoprefixer": "10.5.2",
     "code-inspector-plugin": "^1.4.4",
     "dotenv": "^17.4.2",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -215,8 +215,8 @@ importers:
         specifier: npm:@codingame/monaco-vscode-extension-api@35.0.0
         version: '@codingame/monaco-vscode-extension-api@35.0.0'
       vscode-languageclient:
-        specifier: 10.1.0
-        version: 10.1.0
+        specifier: 9.0.1
+        version: 9.0.1
       vscode-ws-jsonrpc:
         specifier: 3.5.0
         version: 3.5.0
@@ -312,8 +312,8 @@ importers:
         specifier: 5.0.9
         version: 5.0.9
       '@vitejs/plugin-legacy':
-        specifier: ~8.2.0
-        version: 8.2.0(terser@5.39.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0))
+        specifier: ~7.2.1
+        version: 7.2.1(terser@5.39.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0))
       autoprefixer:
         specifier: 10.5.2
         version: 10.5.2(postcss@8.5.17)
@@ -2135,12 +2135,12 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
-  '@vitejs/plugin-legacy@8.2.0':
-    resolution: {integrity: sha512-Im1k/PEBgSVs1N8s5+WMWpBd4G7jQAHJsIo+DUvP1H5HCqDSFtKwP2SFfFICD65cq85CYWS6PjEfsj0wTNt7KQ==}
+  '@vitejs/plugin-legacy@7.2.1':
+    resolution: {integrity: sha512-CaXb/y0mlfu7jQRELEJJc2/5w2bX2m1JraARgFnvSB2yfvnCNJVWWlqAo6WjnKoepOwKx8gs0ugJThPLKCOXIg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       terser: ^5.16.0
-      vite: ^8.0.0
+      vite: ^7.0.0
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -2287,6 +2287,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
+  babel-plugin-polyfill-corejs3@0.13.0:
+    resolution: {integrity: sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
   babel-plugin-polyfill-corejs3@0.14.2:
     resolution: {integrity: sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==}
     peerDependencies:
@@ -2300,9 +2305,8 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2320,9 +2324,8 @@ packages:
     peerDependencies:
       '@popperjs/core': ^2.11.8
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
   browserslist-to-esbuild@2.1.1:
     resolution: {integrity: sha512-KN+mty6C3e9AN8Z5dI1xeN15ExcRNeISoC3g7V0Kax/MMF9MSoYA2G7lkTTcVUFntiEjkpI0HNgqJC1NjdyNUw==}
@@ -3397,9 +3400,9 @@ packages:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
 
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
 
   moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
@@ -4249,26 +4252,23 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
   vscode-jsonrpc@8.2.1:
     resolution: {integrity: sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==}
     engines: {node: '>=14.0.0'}
 
-  vscode-jsonrpc@9.0.1:
-    resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
-    engines: {node: '>=14.0.0'}
+  vscode-languageclient@9.0.1:
+    resolution: {integrity: sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==}
+    engines: {vscode: ^1.82.0}
 
-  vscode-languageclient@10.1.0:
-    resolution: {integrity: sha512-XXRx6lqVitQy/oOLr9MfNYRG+MbQkhXkDaxbQMiKxEm8zZNfheRFUKNb8UYNh2stn9btl2wQM5wZFJjJvoc+jA==}
-    engines: {vscode: ^1.91.0}
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
 
-  vscode-languageserver-protocol@3.18.2:
-    resolution: {integrity: sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==}
-
-  vscode-languageserver-textdocument@1.0.13:
-    resolution: {integrity: sha512-nx0ZHwMGIsVkzFG3/VLeJYBLTaFBRuNdGDvevvjuoayU5EOS2fEYazOhtCM3PI9ClMMg5igc0uwXtAq4tJj+Dw==}
-
-  vscode-languageserver-types@3.18.0:
-    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
 
   vscode-oniguruma@2.0.1:
     resolution: {integrity: sha512-poJU8iHIWnC3vgphJnrLZyI3YdqRlR27xzqDmpPXYzA93R4Gk8z7T6oqDzDoHjoikA2aS82crdXFkjELCdJsjQ==}
@@ -6115,13 +6115,13 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-legacy@8.2.0(terser@5.39.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0))':
+  '@vitejs/plugin-legacy@7.2.1(terser@5.39.0)(vite@8.1.4(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.39.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-dynamic-import': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-modules-systemjs': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-env': 7.29.7(@babel/core@7.29.7)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
       babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
       browserslist: 4.28.5
       browserslist-to-esbuild: 2.1.1(browserslist@4.28.5)
@@ -6317,6 +6317,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      core-js-compat: 3.49.0
+    transitivePeerDependencies:
+      - supports-color
+
   babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -6334,7 +6342,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@4.0.4: {}
+  balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
 
@@ -6348,9 +6356,9 @@ snapshots:
     dependencies:
       '@popperjs/core': 2.11.8
 
-  brace-expansion@5.0.7:
+  brace-expansion@2.1.2:
     dependencies:
-      balanced-match: 4.0.4
+      balanced-match: 1.0.2
 
   browserslist-to-esbuild@2.1.1(browserslist@4.28.5):
     dependencies:
@@ -7591,9 +7599,9 @@ snapshots:
 
   mini-svg-data-uri@1.4.4: {}
 
-  minimatch@10.2.5:
+  minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 2.1.2
 
   moo@0.5.2: {}
 
@@ -8521,25 +8529,22 @@ snapshots:
 
   void-elements@3.1.0: {}
 
+  vscode-jsonrpc@8.2.0: {}
+
   vscode-jsonrpc@8.2.1: {}
 
-  vscode-jsonrpc@9.0.1: {}
-
-  vscode-languageclient@10.1.0:
+  vscode-languageclient@9.0.1:
     dependencies:
-      minimatch: 10.2.5
+      minimatch: 5.1.9
       semver: 7.8.5
-      vscode-languageserver-protocol: 3.18.2
-      vscode-languageserver-textdocument: 1.0.13
+      vscode-languageserver-protocol: 3.17.5
 
-  vscode-languageserver-protocol@3.18.2:
+  vscode-languageserver-protocol@3.17.5:
     dependencies:
-      vscode-jsonrpc: 9.0.1
-      vscode-languageserver-types: 3.18.0
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
 
-  vscode-languageserver-textdocument@1.0.13: {}
-
-  vscode-languageserver-types@3.18.0: {}
+  vscode-languageserver-types@3.17.5: {}
 
   vscode-oniguruma@2.0.1: {}
 

--- a/renovate.json
+++ b/renovate.json
@@ -55,6 +55,18 @@
       "groupName": "i18next",
       "description": "Group i18next, react-i18next, and i18next plugins so peer-dep major bumps land together",
       "matchPackageNames": ["/^i18next$/", "/^react-i18next$/", "/^i18next-/"]
+    },
+    {
+      "matchPackageNames": ["@vitejs/plugin-legacy"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+      "description": "v8's modern-browser detection imports a data: URI module, which our CSP script-src blocks — every browser then falls back to the broken legacy (SystemJS) bundle. Re-enable once the detection is CSP-compatible or we drop legacy chunks (renderLegacyChunks: false)."
+    },
+    {
+      "matchPackageNames": ["vscode-languageclient"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false,
+      "description": "v10 dropped the browser-field mapping on the root export, so `import \"vscode-languageclient\"` loads the common build and the browser RAL is never installed — the LSP client dies with 'No runtime abstraction layer installed'. Re-enable after migrating imports to vscode-languageclient/browser and verifying LSP in a real browser."
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
## What

Reverts two of yesterday's major frontend dependency bumps to their previously deployed versions, and disables Renovate major updates for both packages (with the failure mode documented in the rule description):

- `@vitejs/plugin-legacy` ~8.2.0 → ~7.2.1 (reverts #20881)
- `vscode-languageclient` 10.1.0 → 9.0.1 (reverts #20884)

## Why

Both upgrades build cleanly but break the production frontend at runtime. On cloud this surfaced as "clicking create issue does nothing / cannot type SQL".

**plugin-legacy v8 vs our CSP.** v8 changed modern-browser detection to `import 'data:text/javascript,...if(!import.meta.resolve)throw...'`, prepended as the first import of the modern entry chunk. Our backend CSP (`script-src 'self' <build-time hashes> 'wasm-unsafe-eval'`, `backend/server/echo_routes.go`) can hash-allowlist inline scripts but a `data:` script *load* cannot be allowed by any hash. The import is blocked → the whole modern module graph fails → the inline fallback loads the legacy SystemJS bundle for **every** browser. In the legacy bundle Monaco fails to initialize (`editor.addKeybindingRule is not a function`) and routes render empty pages. The dist `csp-hashes.json` from a v8 build matches the CSP hashes in the production console logs exactly, confirming this is the deployed breakage.

**vscode-languageclient v10 RAL.** v9 shipped a `browser` field mapping the root entry to `lib/browser/main.js`, which installs the browser runtime abstraction layer. v10's root export unconditionally resolves to the common build (`lib/common/api.js`), so the RAL is never installed and the LSP client dies on the first message with `No runtime abstraction layer installed` — reproducible in local dev, independent of CSP. A future v10 migration needs the import in `frontend/src/react/components/monaco/lsp-client.ts` moved to `vscode-languageclient/browser` and browser-level verification.

## Testing

- `pnpm --dir frontend type-check` and `pnpm --dir frontend check` pass (the v10 bump shipped no code changes, so the code was already written against the v9/v7 APIs).
- Positive control: a v8 production build's `dist/index.html` contains the `data:text/javascript` guard and its `csp-hashes.json` hashes match the broken production CSP byte-for-byte.
- This pin restores the exact dependency pair (`vite 8.1.4` + `plugin-legacy ~7.2.1` + `vscode-languageclient 9.0.1`) that production ran before the two bumps landed.
- Full production rebuild + browser drive of the create-issue flow is running locally; will follow up on this PR if it surfaces anything.

## Reviewer notes

- `@vitejs/plugin-legacy@7.2.1` declares peer `vite ^7` while we're on vite 8.1.4 — this peer warning existed before the bumps too and is the known-good production combination.
- Renovate dependency PRs run lint/build but no browser-level e2e, which is why both regressions passed CI. Worth a follow-up to gate dependency PRs on the e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)