### PR TITLE
chore(e2e): auto-install version-matched Playwright browser in globalSetup

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "type-check": "export NODE_OPTIONS=--max_old_space_size=8000 && tsc --build --force",
     "pretest": "pnpm run prepare:artifacts",
     "test": "vitest run --passWithNoTests",
+    "test:e2e:install": "playwright install chromium",
     "precoverage": "pnpm run prepare:artifacts",
     "coverage": "vitest --coverage",
     "i18n": "TS_NODE_PROJECT='./tsconfig.i18n.json' ts-node --compiler typescript-6 i18n.ts && pnpm fix",

--- a/frontend/tests/e2e/README.md
+++ b/frontend/tests/e2e/README.md
@@ -17,7 +17,9 @@ Playwright-based end-to-end tests for Bytebase. Starts a disposable Bytebase ser
    or a `@playwright/test` version bump (which invalidates the cached browser)
    self-heals on the next run. Playwright browsers live in a global cache keyed
    to the package version, outside `node_modules`, so `pnpm i` never fetches
-   them. To pre-install (or fix a failed auto-install) manually:
+   them. The auto-install is **skipped when `BYTEBASE_BROWSER_CHANNEL` is set**
+   (see below) — that mode drives a locally installed browser and needs no
+   download. To pre-install (or fix a failed auto-install) manually:
    ```bash
    pnpm --dir frontend test:e2e:install   # or: pnpm exec playwright install chromium
    ```
@@ -44,6 +46,7 @@ pnpm exec playwright test masking-exemption
 | `BYTEBASE_BIN` | No | `./bytebase-build/bytebase` | Path to pre-built binary |
 | `BYTEBASE_STARTUP_TIMEOUT` | No | `300000` (5 min) | Server startup timeout in ms |
 | `BYTEBASE_HEADED` | No | — | Set to `1` for headed browser |
+| `BYTEBASE_BROWSER_CHANNEL` | No | — | Drive a locally installed browser channel (e.g. `chrome`) instead of the downloaded Chromium; skips the Chromium auto-install. Useful when the download is unavailable (offline). |
 | `BYTEBASE_E2E_LICENSE` | **Yes** | — | Enterprise license JWT (see below) |
 | `CI` | No | — | Enables CI-specific reporter |
 

--- a/frontend/tests/e2e/README.md
+++ b/frontend/tests/e2e/README.md
@@ -12,6 +12,16 @@ Playwright-based end-to-end tests for Bytebase. Starts a disposable Bytebase ser
 
 2. **`psql` client** on PATH — required for DDL setup (the Bytebase query API is read-only; tests connect directly to the sample Postgres via Unix socket).
 
+3. **Playwright Chromium** — installed automatically. `globalSetup` runs
+   `playwright install chromium` before booting the server, so a fresh checkout
+   or a `@playwright/test` version bump (which invalidates the cached browser)
+   self-heals on the next run. Playwright browsers live in a global cache keyed
+   to the package version, outside `node_modules`, so `pnpm i` never fetches
+   them. To pre-install (or fix a failed auto-install) manually:
+   ```bash
+   pnpm --dir frontend test:e2e:install   # or: pnpm exec playwright install chromium
+   ```
+
 ## Running Tests
 
 ```bash

--- a/frontend/tests/e2e/framework/global-setup.ts
+++ b/frontend/tests/e2e/framework/global-setup.ts
@@ -1,7 +1,21 @@
+import { execFileSync } from "node:child_process";
 import { saveTestEnv } from "./env";
 import { cleanupOrphans, startServer, stopServer } from "./mode-start-new-bytebase";
 
+// Playwright browsers live in a global cache (e.g. ~/Library/Caches/ms-playwright)
+// keyed to the @playwright/test version, NOT in node_modules — so `pnpm i` never
+// fetches them, and bumping @playwright/test silently invalidates the cache
+// (the matching Chromium build simply isn't there until re-downloaded). Ensure
+// the version-matched Chromium is present before any spec launches it. This is
+// idempotent: a no-op with no download when the correct build is already cached.
+function ensureBrowser() {
+  execFileSync("pnpm", ["exec", "playwright", "install", "chromium"], {
+    stdio: "inherit",
+  });
+}
+
 async function globalSetup() {
+  ensureBrowser();
   cleanupOrphans();
 
   let server: Awaited<ReturnType<typeof startServer>>;

--- a/frontend/tests/e2e/framework/global-setup.ts
+++ b/frontend/tests/e2e/framework/global-setup.ts
@@ -9,6 +9,15 @@ import { cleanupOrphans, startServer, stopServer } from "./mode-start-new-byteba
 // the version-matched Chromium is present before any spec launches it. This is
 // idempotent: a no-op with no download when the correct build is already cached.
 function ensureBrowser() {
+  // When BYTEBASE_BROWSER_CHANNEL is set, playwright.config.ts drives a locally
+  // installed browser (e.g. Chrome) instead of the downloaded Playwright
+  // Chromium — a deliberate escape hatch for when the browser download is
+  // unavailable (e.g. offline). Installing Chromium here would defeat that hatch
+  // by forcing the very download it exists to avoid, so skip it and let the
+  // channel browser handle the run. Mirrors the config's `channel` selection.
+  if (process.env.BYTEBASE_BROWSER_CHANNEL) {
+    return;
+  }
   execFileSync("pnpm", ["exec", "playwright", "install", "chromium"], {
     stdio: "inherit",
   });


### PR DESCRIPTION
## What

Make the e2e suite self-heal the Playwright browser binary so a fresh checkout — or a `@playwright/test` version bump — doesn't fail at launch with `Executable doesn't exist ... run 'playwright install'`.

- `globalSetup` now runs `playwright install chromium` before booting the server (idempotent — a no-op with no download when the version-matched build is already cached).
- Adds a `test:e2e:install` npm script as a manual escape hatch.
- Documents the prerequisite as Prerequisites #3 in `frontend/tests/e2e/README.md`.

## Why

Playwright browsers live in a **global cache** (`~/Library/Caches/ms-playwright`) keyed to the `@playwright/test` version, **outside `node_modules`**. So:

- `pnpm i` installs the npm package but never fetches the browser.
- Bumping `@playwright/test` silently invalidates the cache — the matching Chromium build simply isn't there.

This bit us in practice: `@playwright/test` floated `^1.59.1` → **1.61.1**, which needs Chromium build **v1228**, but only v1208/v1217 were cached. The whole suite failed in setup (`browserType.launch: Executable doesn't exist`) and 0 tests ran.

`postinstall` was rejected as the fix: it would force a ~170 MB download on **every** `pnpm i` for the many contributors who never run e2e. Wiring it into `globalSetup` costs nothing for non-e2e installs and only downloads when a run actually needs a missing/mismatched browser. There is currently no CI job running this suite, so CI browser-caching is out of scope here.

## Testing

Rebuilt the embedded binary, then ran the plan-detail smoke spec against a machine whose cache already had the browser — `globalSetup` ran the new step as a no-op and the suite booted + passed:

```
✓  plan-detail-smoke.spec.ts:7:5 › plan-detail page loads with title, changes section, and a spec tab (1.5s)
2 passed (11.2s)
```

Biome intentionally ignores `tests/**` and `package.json`, so these files aren't affected by `biome ci`. The change is a standard `node:child_process` call in a Playwright-transpiled setup file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)