### PR TITLE
fix(frontend): replace usage-based legacy targets with explicit version floors (13x build regression)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -26,12 +26,19 @@ export default defineConfig({
       // pulled Chrome 39-60 above the threshold, which made the babel pass
       // in plugin-legacy's renderChunk down-level every chunk to ES5 and
       // took the release build from ~2.5min to ~32min (13x).
+      // (and_qq/and_uc from the old resolution are omitted: babel's
+      // browserNameMap has no entry for them, so they never influenced
+      // the transforms. ios 11 dominates the transform/polyfill union.)
       targets: [
         "chrome >= 103",
         "edge >= 100",
         "firefox >= 115",
         "safari >= 15",
         "ios >= 11",
+        "android >= 103",
+        "samsung >= 29",
+        "opera >= 99",
+        "op_mob >= 80",
       ],
       additionalLegacyPolyfills: ["regenerator-runtime/runtime"],
     }),

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,7 +20,19 @@ const extractHostPort = (url: string) => {
 export default defineConfig({
   plugins: [
     legacy({
-      targets: ["> 0.08%, not dead"],
+      // Explicit version floors, matching what "> 0.08%, not dead" resolved
+      // to as of caniuse-lite 1.0.30001792. Usage-based queries re-resolve
+      // against every caniuse-lite/browserslist update; a 2026-07 data update
+      // pulled Chrome 39-60 above the threshold, which made the babel pass
+      // in plugin-legacy's renderChunk down-level every chunk to ES5 and
+      // took the release build from ~2.5min to ~32min (13x).
+      targets: [
+        "chrome >= 103",
+        "edge >= 100",
+        "firefox >= 115",
+        "safari >= 15",
+        "ios >= 11",
+      ],
       additionalLegacyPolyfills: ["regenerator-runtime/runtime"],
     }),
     {


### PR DESCRIPTION
## What

Replaces `@vitejs/plugin-legacy`'s `targets: ["> 0.08%, not dead"]` in `frontend/vite.config.ts` with explicit browser version floors:

```
chrome >= 103, edge >= 100, firefox >= 115, safari >= 15, ios >= 11
```

These match what the usage-based query resolved to before the 2026-07 browserslist data drift, so the supported-browser envelope is unchanged.

## Why

**Deploy Bytebase Cloud went from ~8 min to ~38 min starting 2026-07-13** ([fast run, Jul 10](https://github.com/bytebase/bytebase/actions/runs/29065788716) vs [slow](https://github.com/bytebase/bytebase/actions/runs/29216423249), [slow](https://github.com/bytebase/bytebase/actions/runs/29231331047)). The frontend release build (`vite build --mode release`) regressed 143s → ~1950s.

Root cause chain:

1. The autoprefixer renovate PR #20822 refreshed `pnpm-lock.yaml`, carrying transitive bumps of **browserslist 4.28.2 → 4.28.5** and **caniuse-lite 30001792 → 30001803**.
2. Either bump alone changes what `"> 0.08%, not dead"` resolves to: **61 targets → 98 targets, now including Chrome 39–60** (2014–2017, pre-ES6).
3. plugin-legacy feeds those targets to babel `preset-env` in its `renderChunk` hook, which began down-leveling every chunk toward ES5 — a silent ~30 min stall between "modules transformed" and "rendering chunks", plus fatter legacy chunks for users (e.g. error-boundary-legacy 141.8 kB → 127.3 kB after this fix).

Notably, the headline packages first suspected (vite 8.1.4, node 24.18) were exonerated by direct test — each was pinned back individually with no improvement. The culprit was found by bisecting the 48 lockfile commits between the last fast and first slow deploy with a timed local build per step; the first slow commit is exactly the one carrying the browserslist/caniuse swap.

Usage-based browserslist queries re-resolve against every caniuse-lite update, so build time and bundle output could silently shift again at any lockfile refresh. Explicit floors are immune to data drift; changing browser support becomes a deliberate, reviewable edit.

## Testing

All local, same machine, HEAD deps unless noted:

| Configuration | `vite build --mode release` |
|---|---|
| Last-fast commit (Jul 10, 16532fce) | 60s |
| HEAD, unchanged | ~16 min (killed at cap in bisect runs) |
| HEAD + vite pinned to 8.0.16 (exoneration test) | 16m 13s |
| HEAD + node 24.15.0 (exoneration test) | >14 min, killed |
| **HEAD + this change** | **1m 5s** |

Also verified with this change: CSP hash export intact (9 hashes, consumed by `backend/server/echo_routes.go`), 340 legacy chunks still emitted, `pnpm check`, `pnpm type-check`, and `pnpm test` (2732/2732) all pass.

## Notes for reviewers

- The floors are the *effective* pre-drift floors per browser family. `ios >= 11` is the oldest engine and keeps the legacy-chunk transpile level identical to before; raising it is a product decision that can be made separately.
- Follow-up candidate: report the 61→98 resolution jump upstream (browserslist 4.28.3+ / caniuse-lite 30001803 usage redistribution) — either bump alone triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)