### PR TITLE
refactor(plan): reuse shared target selection tables

### DIFF
--- a/frontend/src/react/components/DatabaseGroupDataTable.test.tsx
+++ b/frontend/src/react/components/DatabaseGroupDataTable.test.tsx
@@ -112,12 +112,34 @@ describe("DatabaseGroupDataTable", () => {
       />
     );
     render();
-    const cb = container.querySelector(
-      "input[type='checkbox']"
-    ) as HTMLInputElement;
+    const cb = container.querySelector("[role='checkbox']") as HTMLElement;
     act(() => {
       cb.click();
     });
+    expect(onChange).toHaveBeenCalledWith(["projects/p/databaseGroups/a"]);
+    unmount();
+  });
+
+  test("uses the shared checkbox control in single-select mode", () => {
+    const groups = [
+      makeGroup({ name: "projects/p/databaseGroups/a", title: "A" }),
+    ];
+    const onChange = vi.fn();
+    const { container, render, unmount } = renderIntoContainer(
+      <DatabaseGroupDataTable
+        databaseGroupList={groups}
+        showSelection
+        singleSelection
+        selectedDatabaseGroupNames={[]}
+        onSelectedDatabaseGroupNamesChange={onChange}
+      />
+    );
+    render();
+    const checkbox = container.querySelector(
+      "[role='checkbox']"
+    ) as HTMLElement;
+    expect(checkbox).toBeTruthy();
+    act(() => checkbox.click());
     expect(onChange).toHaveBeenCalledWith(["projects/p/databaseGroups/a"]);
     unmount();
   });

--- a/frontend/src/react/components/DatabaseGroupDataTable.tsx
+++ b/frontend/src/react/components/DatabaseGroupDataTable.tsx
@@ -2,6 +2,7 @@ import { EllipsisVertical, ExternalLink } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/react/components/ui/button";
+import { Checkbox } from "@/react/components/ui/checkbox";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -175,12 +176,11 @@ export function DatabaseGroupDataTable({
                     >
                       {showSelection && (
                         <TableCell onClick={(e) => e.stopPropagation()}>
-                          <input
-                            type={singleSelection ? "radio" : "checkbox"}
-                            className="rounded-xs border-control-border"
+                          <Checkbox
                             checked={isSelected}
-                            onChange={(e) =>
-                              toggleSingle(group.name, e.target.checked)
+                            aria-label={group.title}
+                            onCheckedChange={(checked) =>
+                              toggleSingle(group.name, checked)
                             }
                           />
                         </TableCell>

--- a/frontend/src/react/components/DatabaseGroupTable.test.tsx
+++ b/frontend/src/react/components/DatabaseGroupTable.test.tsx
@@ -1,0 +1,67 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { DatabaseGroupView } from "@/types/proto-es/v1/database_group_service_pb";
+import { DatabaseGroupTable } from "./DatabaseGroupTable";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  fetchDBGroupListByProjectName: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/react/stores/app", () => {
+  const state = {
+    fetchDBGroupListByProjectName: mocks.fetchDBGroupListByProjectName,
+  };
+  const useAppStore = () => undefined;
+  useAppStore.getState = () => state;
+  return { useAppStore };
+});
+
+describe("DatabaseGroupTable", () => {
+  let root: Root | undefined;
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    root = undefined;
+    container = undefined;
+    document.body.innerHTML = "";
+    mocks.fetchDBGroupListByProjectName.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  test("leaves the loading state when the fetch fails", async () => {
+    const error = new Error("failed to load database groups");
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    mocks.fetchDBGroupListByProjectName.mockRejectedValueOnce(error);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(
+        <DatabaseGroupTable
+          projectName="projects/p"
+          view={DatabaseGroupView.BASIC}
+        />
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(consoleError).toHaveBeenCalledWith(error);
+    expect(container.textContent).not.toContain("common.loading");
+    expect(container.textContent).toContain("common.no-data");
+  });
+});

--- a/frontend/src/react/components/DatabaseGroupTable.tsx
+++ b/frontend/src/react/components/DatabaseGroupTable.tsx
@@ -79,6 +79,10 @@ export function DatabaseGroupTable({
     void useAppStore
       .getState()
       .fetchDBGroupListByProjectName(projectName, view)
+      .catch((error: unknown) => {
+        console.error(error);
+        return [];
+      })
       .then((groups) => {
         if (cancelled) return;
         setInternalList(groups);

--- a/frontend/src/react/components/database/DatabaseTable.test.tsx
+++ b/frontend/src/react/components/database/DatabaseTable.test.tsx
@@ -60,11 +60,19 @@ vi.mock("./DatabaseTableView", () => ({
   DatabaseTableView: ({
     databases,
     emptyPlaceholder,
+    onRowClick,
+    selectOnRowClick,
   }: {
     databases: Database[];
     emptyPlaceholder?: React.ReactNode;
+    onRowClick?: (database: Database, event: React.MouseEvent) => void;
+    selectOnRowClick?: boolean;
   }) => (
-    <div data-testid="database-names">
+    <div
+      data-testid="database-names"
+      data-has-row-click={Boolean(onRowClick)}
+      data-select-on-row-click={Boolean(selectOnRowClick)}
+    >
       {databases.map((database) => database.name).join(",")}
       {emptyPlaceholder && (
         <div data-testid="empty-placeholder">{emptyPlaceholder}</div>
@@ -203,5 +211,33 @@ describe("DatabaseTable", () => {
     expect(
       container.querySelector("[data-testid='empty-placeholder']")
     ).toBeNull();
+  });
+
+  test("uses selection instead of navigation for selectable rows", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    mocks.fetchDatabases.mockResolvedValueOnce({
+      databases: [db1],
+      nextPageToken: "",
+    });
+
+    await act(async () => {
+      root!.render(
+        <DatabaseTable
+          filter={{}}
+          parent="instances/i"
+          selectOnRowClick
+          selectedNames={new Set()}
+          onSelectedNamesChange={vi.fn()}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    const view = container.querySelector("[data-testid='database-names']");
+    expect(view?.getAttribute("data-has-row-click")).toBe("false");
+    expect(view?.getAttribute("data-select-on-row-click")).toBe("true");
   });
 });

--- a/frontend/src/react/components/database/DatabaseTable.tsx
+++ b/frontend/src/react/components/database/DatabaseTable.tsx
@@ -21,6 +21,8 @@ export interface DatabaseTableProps {
   filter: DatabaseFilter;
   parent?: string;
   mode?: DatabaseTableMode;
+  /** Row click selects instead of navigating to the database page. */
+  selectOnRowClick?: boolean;
   selectedNames?: Set<string>;
   onSelectedNamesChange?: (names: Set<string>) => void;
   /**
@@ -65,6 +67,7 @@ export function DatabaseTable({
   filter,
   parent,
   mode = "ALL",
+  selectOnRowClick = false,
   selectedNames,
   onSelectedNamesChange,
   onDatabasesChange,
@@ -190,7 +193,8 @@ export function DatabaseTable({
         onSelectedNamesChange={onSelectedNamesChange}
         sort={sort}
         onSortChange={setSort}
-        onRowClick={handleRowClick}
+        onRowClick={selectOnRowClick ? undefined : handleRowClick}
+        selectOnRowClick={selectOnRowClick}
       />
       <div className="mt-4 mx-2">
         <PagedTableFooter

--- a/frontend/src/react/components/database/DatabaseTableView.test.tsx
+++ b/frontend/src/react/components/database/DatabaseTableView.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { DatabaseTableView } from "./DatabaseTableView";
 
 (
@@ -16,6 +17,13 @@ vi.mock("@/react/hooks/useAppState", () => ({
   useEnvironmentList: () => [],
   usePlanFeature: () => false,
 }));
+
+const makeDatabase = (name: string): Database =>
+  ({
+    name,
+    effectiveEnvironment: "environments/test",
+    labels: {},
+  }) as Database;
 
 describe("DatabaseTableView", () => {
   let root: Root | undefined;
@@ -63,5 +71,66 @@ describe("DatabaseTableView", () => {
     expect(placeholder).toBeTruthy();
     expect(placeholder.className).toContain("sticky");
     expect(placeholder.style.width).toBe("640px");
+  });
+
+  test("selects a database when a selectable row is clicked", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const database = makeDatabase("instances/i/databases/db1");
+    const onSelectedNamesChange = vi.fn();
+
+    await act(async () => {
+      root!.render(
+        <DatabaseTableView
+          databases={[database]}
+          mode="PROJECT"
+          selectedNames={new Set()}
+          onSelectedNamesChange={onSelectedNamesChange}
+          selectOnRowClick
+        />
+      );
+      await Promise.resolve();
+    });
+
+    const row = container.querySelector("tbody tr") as HTMLTableRowElement;
+    act(() => row.click());
+
+    expect(onSelectedNamesChange).toHaveBeenCalledTimes(1);
+    expect([...onSelectedNamesChange.mock.calls[0][0]]).toEqual([
+      database.name,
+    ]);
+  });
+
+  test("select all checks database names instead of selection size", async () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    const databases = [
+      makeDatabase("instances/i/databases/db1"),
+      makeDatabase("instances/i/databases/db2"),
+    ];
+    const onSelectedNamesChange = vi.fn();
+
+    await act(async () => {
+      root!.render(
+        <DatabaseTableView
+          databases={databases}
+          mode="PROJECT"
+          selectedNames={new Set(["old-1", "old-2"])}
+          onSelectedNamesChange={onSelectedNamesChange}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    const selectAllCell = container.querySelector(
+      "thead th"
+    ) as HTMLTableCellElement;
+    act(() => selectAllCell.click());
+
+    expect([...onSelectedNamesChange.mock.calls[0][0]]).toEqual(
+      databases.map((database) => database.name)
+    );
   });
 });

--- a/frontend/src/react/components/database/DatabaseTableView.tsx
+++ b/frontend/src/react/components/database/DatabaseTableView.tsx
@@ -63,7 +63,12 @@ interface DatabaseTableViewProps {
   onSortChange?: (sort: DatabaseTableSort | null) => void;
   /** Row click handler. Not wired by default — pure UI doesn't navigate. */
   onRowClick?: (db: Database, e: React.MouseEvent) => void;
+  /** Select the row when it is clicked and no explicit row handler is set. */
+  selectOnRowClick?: boolean;
 }
+
+const isAllSelected = (databases: Database[], selected?: Set<string>) =>
+  databases.length > 0 && databases.every((db) => selected?.has(db.name));
 
 interface DatabaseColumn {
   key: string;
@@ -105,6 +110,7 @@ export function DatabaseTableView({
   sort,
   onSortChange,
   onRowClick,
+  selectOnRowClick = false,
 }: DatabaseTableViewProps) {
   const { t } = useTranslation();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -182,18 +188,23 @@ export function DatabaseTableView({
     const cb = onSelectedNamesChangeRef.current;
     const dbs = databasesRef.current;
     if (!current || !cb) return;
-    if (current.size === dbs.length) {
+    if (isAllSelected(dbs, current)) {
       cb(new Set());
     } else {
       cb(new Set(dbs.map((db) => db.name)));
     }
   }, []);
 
-  const allSelected =
-    databases.length > 0 && (selectedNames?.size ?? 0) === databases.length;
+  const allSelected = isAllSelected(databases, selectedNames);
   const someSelected =
-    (selectedNames?.size ?? 0) > 0 &&
-    (selectedNames?.size ?? 0) < databases.length;
+    !allSelected && databases.some((db) => selectedNames?.has(db.name));
+
+  const selectRowClick = useCallback(
+    (db: Database) => toggleSelection(db.name),
+    [toggleSelection]
+  );
+  const effectiveRowClick =
+    onRowClick ?? (selectOnRowClick ? selectRowClick : undefined);
 
   // `columns` is intentionally NOT a function of `selectedNames` /
   // `databases` so it stays referentially stable across selection toggles
@@ -428,7 +439,7 @@ export function DatabaseTableView({
                 showSelection={showSelection}
                 selected={selectedNames?.has(db.name) ?? false}
                 onToggleSelection={toggleSelection}
-                onRowClick={onRowClick}
+                onRowClick={effectiveRowClick}
               />
             ))
           )}

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.columns.test.ts
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.columns.test.ts
@@ -25,6 +25,12 @@ const columnEntry = (src: string, key: string): string => {
 };
 
 describe("plan list column composition", () => {
+  test("composes the new-plan selectors from shared tables", () => {
+    expect(source).toContain("<DatabaseTable");
+    expect(source).toContain("<DatabaseGroupTable");
+    expect(source).not.toContain("<table");
+  });
+
   test("renders five columns in priority order", () => {
     expect(columnKeyOrder(source)).toEqual([
       "name",

--- a/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
+++ b/frontend/src/react/pages/project/ProjectPlanDashboardPage.tsx
@@ -1,11 +1,9 @@
 import { create as createProto } from "@bufbuild/protobuf";
 import {
-  CheckCircle,
   Database as DatabaseIcon,
   FolderTree,
   Loader2,
   Plus,
-  XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -16,8 +14,8 @@ import {
   type SearchParams,
   type ValueOption,
 } from "@/react/components/AdvancedSearch";
-import { EngineIcon } from "@/react/components/EngineIcon";
-import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
+import { DatabaseGroupTable } from "@/react/components/DatabaseGroupTable";
+import { DatabaseTable } from "@/react/components/database";
 import { HumanizeTs } from "@/react/components/HumanizeTs";
 import {
   PermissionGuard,
@@ -32,8 +30,6 @@ import {
 import { TaskStatusIcon } from "@/react/components/TaskStatusIcon";
 import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
-import { Checkbox } from "@/react/components/ui/checkbox";
-import { RadioGroup, RadioGroupItem } from "@/react/components/ui/radio-group";
 import { SearchInput } from "@/react/components/ui/search-input";
 import {
   Sheet,
@@ -51,14 +47,12 @@ import {
   TableHeader,
   TableRow,
 } from "@/react/components/ui/table";
-import { Tooltip } from "@/react/components/ui/tooltip";
 import { useCurrentUser } from "@/react/hooks/useAppState";
 import { useColumnWidths } from "@/react/hooks/useColumnWidths";
 import { useEscapeKey } from "@/react/hooks/useEscapeKey";
 import { useMediaQuery } from "@/react/hooks/useMediaQuery";
 import { PagedTableFooter, usePagedData } from "@/react/hooks/usePagedData";
 import { useProjectByName } from "@/react/hooks/useProjectByName";
-import { useSessionPageSize } from "@/react/hooks/useSessionPageSize";
 import { applyPlanTitleToQuery } from "@/react/lib/plan/title";
 import { cn } from "@/react/lib/utils";
 import { router } from "@/react/router";
@@ -77,12 +71,7 @@ import {
   unknownUser,
 } from "@/types";
 import { State } from "@/types/proto-es/v1/common_pb";
-import type { DatabaseGroup } from "@/types/proto-es/v1/database_group_service_pb";
 import { DatabaseGroupView } from "@/types/proto-es/v1/database_group_service_pb";
-import {
-  type Database,
-  SyncStatus,
-} from "@/types/proto-es/v1/database_service_pb";
 import type { Plan, Plan_Spec } from "@/types/proto-es/v1/plan_service_pb";
 import {
   Plan_ChangeDatabaseConfigSchema,
@@ -93,9 +82,7 @@ import {
   extractDatabaseResourceName,
   extractPlanUID,
   generatePlanTitle,
-  getDatabaseEnvironment,
   getDefaultPagination,
-  getInstanceResource,
   type SearchParams as VueSearchParams,
 } from "@/utils";
 import {
@@ -835,10 +822,17 @@ function DatabaseAndGroupSelector({
           onSelectedNamesChange={onSelectedDatabaseNamesChange}
         />
       ) : (
-        <DatabaseGroupSelector
+        <DatabaseGroupTable
           projectName={projectName}
-          selectedGroup={selectedDatabaseGroup}
-          onSelectedGroupChange={onSelectedDatabaseGroupChange}
+          view={DatabaseGroupView.BASIC}
+          showSelection
+          singleSelection
+          selectedDatabaseGroupNames={
+            selectedDatabaseGroup ? [selectedDatabaseGroup] : []
+          }
+          onSelectedDatabaseGroupNamesChange={(names) =>
+            onSelectedDatabaseGroupChange(names[0])
+          }
         />
       )}
     </div>
@@ -859,283 +853,23 @@ function DatabaseSelector({
   onSelectedNamesChange: (names: Set<string>) => void;
 }) {
   const { t } = useTranslation();
-
-  const [databases, setDatabases] = useState<Database[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [hasMore, setHasMore] = useState(false);
-  const [isFetchingMore, setIsFetchingMore] = useState(false);
   const [query, setQuery] = useState("");
-  const [pageSize] = useSessionPageSize("bb.plan-db-selector");
-  const nextPageTokenRef = useRef("");
-  const fetchIdRef = useRef(0);
-
-  const doFetch = useCallback(
-    async (isRefresh: boolean) => {
-      const currentFetchId = ++fetchIdRef.current;
-      if (isRefresh) {
-        setLoading(true);
-      } else {
-        setIsFetchingMore(true);
-      }
-      try {
-        const token = isRefresh ? "" : nextPageTokenRef.current;
-        const result = await useAppStore.getState().fetchDatabases({
-          parent: projectName,
-          pageSize,
-          pageToken: token || undefined,
-          filter: { query },
-        });
-        if (currentFetchId !== fetchIdRef.current) return;
-        setDatabases((prev) =>
-          isRefresh ? result.databases : [...prev, ...result.databases]
-        );
-        nextPageTokenRef.current = result.nextPageToken;
-        setHasMore(Boolean(result.nextPageToken));
-      } finally {
-        if (currentFetchId === fetchIdRef.current) {
-          setLoading(false);
-          setIsFetchingMore(false);
-        }
-      }
-    },
-    [projectName, pageSize, query]
-  );
-
-  const isFirstLoad = useRef(true);
-  useEffect(() => {
-    if (isFirstLoad.current) {
-      isFirstLoad.current = false;
-      doFetch(true);
-      return;
-    }
-    const timer = setTimeout(() => doFetch(true), 300);
-    return () => clearTimeout(timer);
-  }, [doFetch]);
-
-  const toggleDatabase = (name: string) => {
-    const next = new Set(selectedNames);
-    if (next.has(name)) {
-      next.delete(name);
-    } else {
-      next.add(name);
-    }
-    onSelectedNamesChange(next);
-  };
-
-  const toggleAll = () => {
-    const allSelected = databases.every((db) => selectedNames.has(db.name));
-    if (allSelected) {
-      onSelectedNamesChange(new Set());
-    } else {
-      onSelectedNamesChange(new Set(databases.map((db) => db.name)));
-    }
-  };
-
-  const allSelected =
-    databases.length > 0 && databases.every((db) => selectedNames.has(db.name));
-  const someSelected =
-    databases.some((db) => selectedNames.has(db.name)) && !allSelected;
 
   return (
-    <div className="flex flex-col gap-y-2">
+    <div className="flex flex-col gap-y-3">
       <SearchInput
         placeholder={t("database.filter-database")}
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
-
-      {loading ? (
-        <div className="flex justify-center py-8 text-control-light">
-          <Loader2 className="size-5 animate-spin" />
-        </div>
-      ) : databases.length === 0 ? (
-        <div className="flex justify-center py-8 text-control-light">
-          {t("common.no-data")}
-        </div>
-      ) : (
-        <>
-          <table className="w-full text-sm max-sm:table-fixed">
-            <thead>
-              <tr className="border-b text-left text-control-light">
-                <th className="py-2 pl-3 pr-2 w-10">
-                  <Checkbox
-                    checked={someSelected ? "indeterminate" : allSelected}
-                    onCheckedChange={toggleAll}
-                  />
-                </th>
-                <th className="py-2 pr-4 font-medium">
-                  {t("common.database")}
-                </th>
-                <th className="py-2 pr-4 font-medium">
-                  {t("common.instance")}
-                </th>
-                <th className="hidden py-2 pr-4 font-medium sm:table-cell">
-                  {t("common.environment")}
-                </th>
-                <th className="hidden py-2 pr-4 font-medium whitespace-nowrap sm:table-cell">
-                  {t("common.status")}
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              {databases.map((db) => {
-                const { databaseName } = extractDatabaseResourceName(db.name);
-                const inst = getInstanceResource(db);
-                const env = getDatabaseEnvironment(db);
-                const isSelected = selectedNames.has(db.name);
-                return (
-                  <tr
-                    key={db.name}
-                    className={cn(
-                      "border-b cursor-pointer hover:bg-control-bg",
-                      isSelected && "bg-accent/5"
-                    )}
-                    onClick={() => toggleDatabase(db.name)}
-                  >
-                    <td className="py-2 pl-3 pr-2">
-                      <Checkbox checked={isSelected} />
-                    </td>
-                    <td className="py-2 pr-4">
-                      <div className="flex min-w-0 items-center gap-x-1.5">
-                        {inst && (
-                          <EngineIcon
-                            engine={inst.engine}
-                            className="size-4 shrink-0"
-                          />
-                        )}
-                        <span className="truncate">{databaseName}</span>
-                      </div>
-                    </td>
-                    <td className="py-2 pr-4">
-                      <span className="block truncate">{inst?.title}</span>
-                    </td>
-                    <td className="hidden py-2 pr-4 sm:table-cell">
-                      {env && <EnvironmentLabel environmentName={env.name} />}
-                    </td>
-                    <td className="hidden py-2 pr-4 sm:table-cell">
-                      {db.syncStatus === SyncStatus.FAILED ? (
-                        <Tooltip
-                          content={
-                            db.syncError || t("database.sync-status-failed")
-                          }
-                        >
-                          <XCircle className="size-4 text-error" />
-                        </Tooltip>
-                      ) : (
-                        <CheckCircle className="size-4 text-success" />
-                      )}
-                    </td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-
-          {hasMore && (
-            <div className="flex justify-center">
-              <Button
-                appearance="secondary"
-                size="sm"
-                disabled={isFetchingMore}
-                onClick={() => doFetch(false)}
-              >
-                {isFetchingMore ? t("common.loading") : t("common.load-more")}
-              </Button>
-            </div>
-          )}
-        </>
-      )}
+      <DatabaseTable
+        filter={{ query }}
+        parent={projectName}
+        mode="PROJECT"
+        selectOnRowClick
+        selectedNames={selectedNames}
+        onSelectedNamesChange={onSelectedNamesChange}
+      />
     </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// DatabaseGroupSelector
-// ---------------------------------------------------------------------------
-
-function DatabaseGroupSelector({
-  projectName,
-  selectedGroup,
-  onSelectedGroupChange,
-}: {
-  projectName: string;
-  selectedGroup: string | undefined;
-  onSelectedGroupChange: (name: string | undefined) => void;
-}) {
-  const { t } = useTranslation();
-  const [groups, setGroups] = useState<DatabaseGroup[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    setLoading(true);
-    useAppStore
-      .getState()
-      .fetchDBGroupListByProjectName(projectName, DatabaseGroupView.BASIC)
-      .then((result) => {
-        setGroups(result);
-      })
-      .finally(() => setLoading(false));
-  }, [projectName]);
-
-  if (loading) {
-    return (
-      <div className="flex justify-center py-8 text-control-light">
-        <Loader2 className="size-5 animate-spin" />
-      </div>
-    );
-  }
-
-  if (groups.length === 0) {
-    return (
-      <div className="flex justify-center py-8 text-control-light">
-        {t("common.no-data")}
-      </div>
-    );
-  }
-
-  return (
-    <RadioGroup
-      value={selectedGroup ?? ""}
-      onValueChange={(value) => onSelectedGroupChange(String(value))}
-      className="block"
-    >
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b text-left text-control-light">
-            <th className="py-2 pr-2 w-8" />
-            <th className="py-2 pr-4 font-medium">
-              {t("common.database-group")}
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {groups.map((group) => {
-            const isSelected = selectedGroup === group.name;
-            return (
-              <tr
-                key={group.name}
-                className={cn(
-                  "border-b cursor-pointer hover:bg-control-bg",
-                  isSelected && "bg-accent/5"
-                )}
-                onClick={() =>
-                  onSelectedGroupChange(isSelected ? undefined : group.name)
-                }
-              >
-                <td className="py-2 pr-2">
-                  <RadioGroupItem value={group.name} aria-label={group.title} />
-                </td>
-                <td className="py-2 pr-4">
-                  <div className="flex items-center gap-x-1.5">
-                    <FolderTree className="size-4 text-control-light shrink-0" />
-                    <span>{group.title}</span>
-                  </div>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </RadioGroup>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the New Plan drawer database and database-group table reimplementations with the shared table components.
- Preserve target-selection behavior while aligning both tabs with the canonical table UI.

## Key Changes
- Compose `DatabaseTable` and `DatabaseGroupTable` in the plan target selector.
- Add row-click selection support and make select-all compare database names rather than set sizes.
- Use the shared checkbox control for database-group selection and settle loading after fetch failures.
- Add regression coverage for shared-table composition, selection, search-result changes, and failed group fetches.

## Motivation
- Eliminate duplicated table implementations and prevent UI drift tracked by [BYT-9856](https://linear.app/bytebase/issue/BYT-9856/new-plan-drawer-duplicates-the-database-and-database-group-table-uis).

## Testing
- `pnpm --dir frontend type-check`
- Focused Vitest suites: 8 tests passed
- Full frontend Vitest suite: 823 suites, 2,781 tests passed
- Targeted Biome checks and `git diff --check`