### PR TITLE
fix(activity): show actor for bypass deployment

### DIFF
--- a/frontend/src/react/components/issue-activity/IssueCommentActivity.test.tsx
+++ b/frontend/src/react/components/issue-activity/IssueCommentActivity.test.tsx
@@ -1,0 +1,64 @@
+import { create } from "@bufbuild/protobuf";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import {
+  Issue_Type,
+  IssueCommentSchema,
+  IssueSchema,
+  IssueStatus,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { PlanSchema } from "@/types/proto-es/v1/plan_service_pb";
+import { IssueCommentRow } from "./IssueCommentActivity";
+
+vi.mock("react-i18next", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-i18next")>()),
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      getUserByIdentifier: () => ({
+        email: "alice@example.com",
+        title: "Alice",
+      }),
+    }),
+}));
+
+vi.mock("@/react/components/monaco", () => ({
+  ReadonlyDiffMonaco: () => null,
+}));
+
+describe("IssueCommentRow", () => {
+  test("shows who bypassed review and created the rollout", () => {
+    const issue = create(IssueSchema, {
+      type: Issue_Type.DATABASE_CHANGE,
+    });
+    const plan = create(PlanSchema, { hasRollout: true });
+    const comment = create(IssueCommentSchema, {
+      creator: "users/alice@example.com",
+      event: {
+        case: "issueUpdate",
+        value: {
+          fromStatus: IssueStatus.OPEN,
+          toStatus: IssueStatus.DONE,
+        },
+      },
+    });
+
+    render(
+      <IssueCommentRow
+        comment={comment}
+        isLast
+        issue={issue}
+        linkless
+        plan={plan}
+      />
+    );
+
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(
+      screen.getByText("activity.sentence.review-skipped-rollout-created")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/react/components/issue-activity/IssueCommentActivity.tsx
+++ b/frontend/src/react/components/issue-activity/IssueCommentActivity.tsx
@@ -180,9 +180,8 @@ export function CommentCreator({ creator }: { creator: User }) {
   );
 }
 
-// Header line for a comment-backed activity item: creator (suppressed for the
-// done-rollout system comment, whose sentence already names the actor), action
-// sentence, timestamp, and an "(edited)" marker for edited user comments.
+// Header line for a comment-backed activity item: creator, action sentence,
+// timestamp, and an "(edited)" marker for edited user comments.
 function IssueCommentHeader({
   comment,
   issue,
@@ -203,9 +202,7 @@ function IssueCommentHeader({
 
   return (
     <>
-      {!isDoneRolloutComment(issue, plan, comment) && (
-        <CommentCreator creator={creator} />
-      )}
+      <CommentCreator creator={creator} />
       <IssueCommentActionSentence
         comment={comment}
         issue={issue}


### PR DESCRIPTION
## Summary
- Show the recorded actor on bypass-and-deploy activity entries.
- Add regression coverage for skipped-review rollout activity.

## Key Changes
- Always render the issue comment creator for rollout-completion events.
- Verify the actor appears beside the skipped-review rollout message.

## Motivation
The backend already records who manually created the rollout, but the activity UI suppressed that creator and made the bypass action look anonymous.

Linear: https://linear.app/bytebase/issue/BYT-9871/approval-flow-skipped

## Testing
- pnpm -C frontend exec vitest run src/react/components/issue-activity/IssueCommentActivity.test.tsx
- pnpm --dir frontend type-check
- pnpm --dir frontend test
- pnpm --dir frontend exec biome check src/react/components/issue-activity/IssueCommentActivity.tsx src/react/components/issue-activity/IssueCommentActivity.test.tsx
- git diff --check