### PR TITLE
fix(lsp): clear stale syntax error markers by never publishing null diagnostics

### DIFF
--- a/backend/plugin/parser/base/diagnose_test.go
+++ b/backend/plugin/parser/base/diagnose_test.go
@@ -1,6 +1,8 @@
 package base
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	lsp "github.com/bytebase/lsp-protocol"
@@ -8,6 +10,32 @@ import (
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
+
+func TestDiagnoseNeverReturnsNil(t *testing.T) {
+	a := require.New(t)
+
+	// Engine diagnose funcs return a nil slice for valid statements.
+	RegisterDiagnoseFunc(storepb.Engine_MONGODB, func(_ context.Context, _ DiagnoseContext, _ string) ([]Diagnostic, error) {
+		return nil, nil
+	})
+
+	for _, engine := range []storepb.Engine{
+		storepb.Engine_MONGODB,
+		// Engine without a registered diagnose func.
+		storepb.Engine_ENGINE_UNSPECIFIED,
+	} {
+		diagnostics, err := Diagnose(context.Background(), DiagnoseContext{}, engine, "db.users.find()")
+		a.NoError(err)
+		a.NotNil(diagnostics)
+		a.Empty(diagnostics)
+
+		// The LSP spec requires publishing an empty array (not null) to clear
+		// previously published diagnostics on the client.
+		payload, err := json.Marshal(lsp.PublishDiagnosticsParams{Diagnostics: diagnostics})
+		a.NoError(err)
+		a.Contains(string(payload), `"diagnostics":[]`)
+	}
+}
 
 func TestConvertPositionToUTF16Position(t *testing.T) {
 	testCases := []struct {

--- a/backend/plugin/parser/base/interface.go
+++ b/backend/plugin/parser/base/interface.go
@@ -167,12 +167,18 @@ func RegisterDiagnoseFunc(engine storepb.Engine, f DiagnoseFunc) {
 }
 
 // Diagnose returns the diagnostics for the statement. The diagnostics never be nil, and may not be empty although the error is not nil.
+// A non-nil result matters: publishing diagnostics as JSON null instead of an empty array
+// does not clear previously published diagnostics on the LSP client.
 func Diagnose(ctx context.Context, dCtx DiagnoseContext, engine storepb.Engine, statement string) ([]Diagnostic, error) {
 	f, ok := diagnoseCollectors[engine]
 	if !ok {
 		return []Diagnostic{}, nil
 	}
-	return f(ctx, dCtx, statement)
+	diagnostics, err := f(ctx, dCtx, statement)
+	if diagnostics == nil {
+		diagnostics = []Diagnostic{}
+	}
+	return diagnostics, err
 }
 
 func RegisterStatementRangesFunc(engine storepb.Engine, f StatementRangeFunc) {

--- a/backend/plugin/parser/mongodb/mongodb_test.go
+++ b/backend/plugin/parser/mongodb/mongodb_test.go
@@ -179,6 +179,16 @@ func TestDiagnose(t *testing.T) {
 			wantHasDiagnostics: false,
 		},
 		{
+			description:        "valid statement without arguments",
+			statement:          `db.users.find()`,
+			wantHasDiagnostics: false,
+		},
+		{
+			description:        "syntax error - mid-typing prefix without parentheses",
+			statement:          `db.users.find`,
+			wantHasDiagnostics: true,
+		},
+		{
 			description:        "syntax error - unclosed brace",
 			statement:          `db.collection.find({`,
 			wantHasDiagnostics: true,


### PR DESCRIPTION
Fixes [BYT-9877](https://linear.app/bytebase/issue/BYT-9877/sql-editor-stale-mongodb-syntax-error-marker-on-valid-dbusersfind).

## What

In the SQL Editor, a syntax error marker produced mid-typing (e.g. MongoDB `db.users.find` before the parens are typed) stayed on screen after the statement became valid.

Engine diagnose funcs return a nil slice when a statement has no errors. The sole publish site (`runDiagnostics` in `backend/api/lsp/performance_optimizer.go`) marshals that nil slice as `"diagnostics": null` in `textDocument/publishDiagnostics`. The LSP spec requires an empty array to clear previously published diagnostics, and `vscode-languageclient` does not clear markers on a `null` payload — so the stale marker persisted. This affects every engine, not just MongoDB.

The fix normalizes the nil slice to an empty one in `base.Diagnose`, enforcing its documented never-nil contract for all engines and callers.

## Testing

- New `TestDiagnoseNeverReturnsNil` in `backend/plugin/parser/base` asserts `Diagnose` returns a non-nil slice when the engine func returns nil, and that the published params marshal as `"diagnostics":[]` (failed before the fix).
- Added the issue's repro statements (`db.users.find()` valid, `db.users.find` mid-typing error) to `TestDiagnose` in the mongodb parser package.
- `go test ./backend/plugin/parser/base/ ./backend/plugin/parser/mongodb/ ./backend/api/lsp/` pass; full `golangci-lint` clean; server binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)