### PR TITLE
fix(layout): prevent dashboard overscroll chaining

### DIFF
--- a/frontend/src/assets/css/tailwind.css
+++ b/frontend/src/assets/css/tailwind.css
@@ -15,6 +15,10 @@
   color utility to any element that depends on these defaults.
 */
 @layer base {
+  html {
+    overscroll-behavior-y: none;
+  }
+
   *,
   ::after,
   ::before,

--- a/frontend/src/react/components/DashboardBodyShell.test.tsx
+++ b/frontend/src/react/components/DashboardBodyShell.test.tsx
@@ -106,6 +106,9 @@ describe("DashboardBodyShell", () => {
     expect(targets.content).toBeInstanceOf(HTMLDivElement);
     expect(targets.quickstart).toBeInstanceOf(HTMLDivElement);
     expect(targets.mainContainer?.id).toBe("bb-layout-main");
+    expect(targets.mainContainer?.className).toContain("overscroll-y-contain");
+    expect(targets.desktopSidebar?.className).toContain("overscroll-y-contain");
+    expect(targets.mobileSidebar?.className).toContain("overscroll-y-contain");
     expect(
       harness.container.querySelector('[data-label="bb-main-body-wrapper"]')
     ).not.toBeNull();

--- a/frontend/src/react/components/DashboardBodyShell.tsx
+++ b/frontend/src/react/components/DashboardBodyShell.tsx
@@ -72,7 +72,7 @@ export function DashboardBodyShell({
       >
         <div
           ref={mobileSidebarRef}
-          className="h-full overflow-y-auto bg-control-bg"
+          className="h-full overflow-y-auto overscroll-y-contain bg-control-bg"
         />
       </div>
     </div>
@@ -113,7 +113,7 @@ export function DashboardBodyShell({
               <div className="flex w-52 flex-col bg-control-bg">
                 <div
                   ref={desktopSidebarRef}
-                  className="flex flex-1 flex-col overflow-y-auto py-0"
+                  className="flex flex-1 flex-col overflow-y-auto overscroll-y-contain py-0"
                 />
               </div>
             </aside>
@@ -146,7 +146,7 @@ export function DashboardBodyShell({
             id="bb-layout-main"
             ref={mainContainerRef}
             className={cn(
-              "flex-1 overflow-y-auto",
+              "flex-1 overflow-y-auto overscroll-y-contain",
               variant === "workspace" ? "md:min-w-0" : "min-w-0"
             )}
           >


### PR DESCRIPTION
## Summary
- Keep the dashboard shell fixed when scrolling past content boundaries.

## Key Changes
- Disable the root vertical overscroll affordance.
- Contain scroll chaining within the main content and sidebar regions.
- Add regression assertions for dashboard scroll containment.

## Motivation
- Prevent the entire app shell from rubber-banding and exposing the browser background, preserving an app-like fixed shell.

## Testing
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm -C frontend exec vitest run src/react/components/DashboardBodyShell.test.tsx`
- `pnpm --dir frontend exec biome ci src/assets/css/tailwind.css src/react/components/DashboardBodyShell.tsx`