### PR TITLE
test(e2e): plan-detail header lifecycle + issue-detail redirect coverage

### DIFF
--- a/frontend/tests/e2e/framework/api-client.ts
+++ b/frontend/tests/e2e/framework/api-client.ts
@@ -512,6 +512,30 @@ export class BytebaseApiClient {
     });
   }
 
+  // Create a create-database plan (a single createDatabaseConfig spec). Unlike a
+  // change plan this shares the DATABASE_CHANGE issue type but is NOT a change
+  // plan, so shouldStayOnPlanDetailPage(plan) is false — used by the redirect
+  // spec to prove create-database issues stay on Issue Detail (BYT-9721).
+  async createCreateDatabasePlan(
+    project: string,
+    title: string,
+    spec: { id: string; target: string; database: string; environment?: string },
+  ): Promise<{ name: string }> {
+    return this.request<{ name: string }>("POST", `/v1/${project}/plans`, {
+      title,
+      specs: [
+        {
+          id: spec.id,
+          createDatabaseConfig: {
+            target: spec.target,
+            database: spec.database,
+            ...(spec.environment ? { environment: spec.environment } : {}),
+          },
+        },
+      ],
+    });
+  }
+
   async getPlan(planName: string): Promise<{ name: string; hasRollout: boolean; state: string }> {
     return this.request("GET", `/v1/${planName}`);
   }

--- a/frontend/tests/e2e/issue-detail/issue-detail-comments.spec.ts
+++ b/frontend/tests/e2e/issue-detail/issue-detail-comments.spec.ts
@@ -44,13 +44,22 @@ test.beforeAll(async ({ browser }) => {
 
   // Create a real plan + issue. The description carries a markdown link (sibling
   // surface); the comment is posted right after (the reported surface).
-  const sheet = await env.api.createSheet(
+  //
+  // Re-based onto a create-database plan (BYT-9721, #20722): schema/data CHANGE
+  // issues now redirect off Issue Detail to Plan Detail, so a change issue would
+  // bounce away from the page this test asserts on. A create-database issue
+  // shares the DATABASE_CHANGE type but stays on Issue Detail (its plan is not a
+  // change plan), so it exercises the same MarkdownEditor read-only render path
+  // on the surface those issues still use.
+  const plan = await env.api.createCreateDatabasePlan(
     env.project,
-    "SELECT 1; -- byt9664",
+    `BYT-9664 ${STAMP}`,
+    {
+      id: `spec-${STAMP}`,
+      target: env.instance,
+      database: `e2e_byt9664_${STAMP}`,
+    },
   );
-  const plan = await env.api.createPlan(env.project, `BYT-9664 ${STAMP}`, [
-    { id: `spec-${STAMP}`, targets: [env.database], sheet },
-  ]);
   const issue = await env.api.createIssue(
     env.project,
     `BYT-9664 ${STAMP}`,

--- a/frontend/tests/e2e/issue-detail/issue-detail-redirect.spec.ts
+++ b/frontend/tests/e2e/issue-detail/issue-detail-redirect.spec.ts
@@ -31,12 +31,10 @@ test.beforeAll(async ({ browser }) => {
   env = loadTestEnv();
   projectId = env.project.split("/").pop()!;
   await env.api.login(env.adminEmail, env.adminPassword);
-  // Change issues auto-create a rollout under permissive settings — harmless on
-  // the disposable server, and the redirect fires regardless of rollout state.
-  await env.api.updateProjectSettings(env.project, {
-    requireIssueApproval: false,
-    requirePlanCheckNoError: false,
-  });
+  // The redirect is decided by the route loader from the issue type + plan
+  // specs, independent of approval / plan-check gates and rollout state, so this
+  // spec deliberately does NOT touch project settings — leaving the shared
+  // sample project's gates unchanged for later specs (the suite runs workers:1).
   sharedContext = await browser.newContext({ storageState: ".auth/state.json" });
   page = await sharedContext.newPage();
 });

--- a/frontend/tests/e2e/issue-detail/issue-detail-redirect.spec.ts
+++ b/frontend/tests/e2e/issue-detail/issue-detail-redirect.spec.ts
@@ -1,0 +1,117 @@
+// Issue detail — the route-level redirect to Plan Detail (BYT-9721, PR #20722).
+//
+// Plan Detail is the canonical review surface for schema/data CHANGE issues, so
+// the issue-detail route loader (issueDetailRedirectLoader) redirects those to
+// /plans/{planId}. The discriminator is the plan's specs, not the issue type:
+// create-database shares the DATABASE_CHANGE proto type but is NOT a change plan
+// (shouldStayOnPlanDetailPage === false), so it must STAY on Issue Detail. Both
+// directions are locked here.
+//
+//   B1 — a change issue redirects to Plan Detail, query string preserved.
+//   B2 — a create-database issue (same DATABASE_CHANGE type) stays on Issue Detail.
+
+import {
+  test,
+  expect,
+  type Page,
+  type BrowserContext,
+} from "@playwright/test";
+import { loadTestEnv, type TestEnv } from "../framework/env";
+import { BytebaseApiClient } from "../framework/api-client";
+
+test.setTimeout(180_000);
+test.describe.configure({ mode: "serial" });
+
+let env: TestEnv & { api: BytebaseApiClient };
+let projectId: string;
+let sharedContext: BrowserContext;
+let page: Page;
+
+test.beforeAll(async ({ browser }) => {
+  env = loadTestEnv();
+  projectId = env.project.split("/").pop()!;
+  await env.api.login(env.adminEmail, env.adminPassword);
+  // Change issues auto-create a rollout under permissive settings — harmless on
+  // the disposable server, and the redirect fires regardless of rollout state.
+  await env.api.updateProjectSettings(env.project, {
+    requireIssueApproval: false,
+    requirePlanCheckNoError: false,
+  });
+  sharedContext = await browser.newContext({ storageState: ".auth/state.json" });
+  page = await sharedContext.newPage();
+});
+
+test.afterAll(async () => {
+  await sharedContext?.close();
+});
+
+test.describe("A schema/data change issue redirects to Plan Detail (B1)", () => {
+  let issueId = "";
+  let planId = "";
+
+  test.beforeAll(async () => {
+    const ts = Date.now();
+    const sheet = await env.api.createSheet(env.project, "SELECT 1; -- redirect");
+    const plan = await env.api.createPlan(env.project, `E2E Redirect B1 ${ts}`, [
+      { id: `spec-${ts}`, targets: [env.database], sheet },
+    ]);
+    planId = plan.name.split("/").pop()!;
+    const issue = await env.api.createIssue(
+      env.project,
+      `E2E Redirect B1 ${ts}`,
+      plan.name,
+    );
+    issueId = issue.name.split("/").pop()!;
+  });
+
+  test("opening the issue URL lands on Plan Detail with the query string preserved", async () => {
+    await page.goto(
+      `${env.baseURL}/projects/${projectId}/issues/${issueId}?anchor=xyz`,
+    );
+    // The loader redirects the change issue to its plan, keeping ?anchor=xyz.
+    await page.waitForURL(
+      new RegExp(`/projects/${projectId}/plans/${planId}(\\b|[?/])`),
+      { timeout: 20_000 },
+    );
+    expect(new URL(page.url()).pathname).toBe(
+      `/projects/${projectId}/plans/${planId}`,
+    );
+    expect(page.url()).toContain("anchor=xyz");
+  });
+});
+
+test.describe("A create-database issue stays on Issue Detail (B2)", () => {
+  let issueId = "";
+
+  test.beforeAll(async () => {
+    const ts = Date.now();
+    // Same DATABASE_CHANGE issue type, but a createDatabaseConfig spec — so the
+    // loader's shouldStayOnPlanDetailPage predicate keeps it on Issue Detail.
+    const plan = await env.api.createCreateDatabasePlan(
+      env.project,
+      `E2E Redirect B2 ${ts}`,
+      {
+        id: `spec-${ts}`,
+        target: env.instance,
+        database: `e2e_redirect_stay_${ts}`,
+      },
+    );
+    const issue = await env.api.createIssue(
+      env.project,
+      `E2E Redirect B2 ${ts}`,
+      plan.name,
+    );
+    issueId = issue.name.split("/").pop()!;
+  });
+
+  test("opening the create-database issue URL stays on Issue Detail (no redirect)", async () => {
+    const issuePath = `/projects/${projectId}/issues/${issueId}`;
+    await page.goto(`${env.baseURL}${issuePath}`);
+    await page.waitForLoadState("networkidle").catch(() => {});
+    // Give any (incorrect) redirect a chance to fire, then assert we stayed.
+    await expect(async () => {
+      expect(new URL(page.url()).pathname).toBe(issuePath);
+    }).toPass({ timeout: 10_000 });
+    expect(page.url()).not.toContain("/plans/");
+  });
+});

--- a/frontend/tests/e2e/issue-detail/issue-detail-targets.spec.ts
+++ b/frontend/tests/e2e/issue-detail/issue-detail-targets.spec.ts
@@ -1,17 +1,19 @@
-// Issue detail — Targets "View all" sheet (scrollability).
+// Targets "View all" sheet (scrollability) — on Plan Detail.
 //
-// BYT-9558 (FIXED, #20427): on a Data Change Issue with many targets, clicking
+// BYT-9558 (FIXED, #20427): on a Data Change with many targets, clicking
 // "View all (N)" opened a popup that was frozen — the user could not scroll down
 // to see all the targets. Root cause: the targets list rendered in a Dialog whose
 // nested flex/overflow chain never produced a scrollable container, so content
 // below the fold was unreachable. The fix replaced the Dialog with a Sheet whose
-// SheetBody is `overflow-hidden` and whose inner list is
-// `min-h-0 flex-1 overflow-y-auto` (IssueDetailDatabaseChangeView.tsx) — a real
-// scroll container.
+// body is `overflow-hidden` and whose inner list is `min-h-0 flex-1
+// overflow-y-auto` — a real scroll container.
 //
-// The same broken pattern + fix also lived on the Plan detail Changes/Targets
-// sheet (PlanDetailChangesBranch.tsx); that sibling surface is a candidate for a
-// follow-up lock (CUJ analysis) but is not covered here.
+// SURFACE NOTE (BYT-9721, #20722): schema/data CHANGE issues now redirect off
+// Issue Detail to Plan Detail, so opening this change issue lands on Plan Detail
+// and this test exercises the Plan detail Changes/Targets sheet
+// (PlanDetailChangesBranch.tsx) — the sibling surface that shared the same
+// broken pattern + fix and was previously uncovered. The test asserts the
+// redirect explicitly rather than depending on it silently.
 //
 // Owns its fixtures: creates >20 databases via psql, syncs + transfers them into
 // the project, targets them in a single-spec plan/issue, and drops them in
@@ -106,11 +108,14 @@ test.afterAll(async () => {
   await env.api.syncInstance(env.instance).catch(() => {});
 });
 
-test.describe("Targets 'View all' sheet scrolls to the last target (BYT-9558)", () => {
+test.describe("Targets 'View all' sheet scrolls to the last target on Plan Detail (BYT-9558)", () => {
   test("the all-targets sheet is scrollable — the last target can be brought into view", async () => {
     test.setTimeout(120_000);
 
     await page.goto(issueUrl);
+    // A change issue redirects to Plan Detail (BYT-9721); make that explicit so
+    // the surface under test is intentional, not an accidental redirect.
+    await page.waitForURL(/\/projects\/[^/]+\/plans\/\d+/, { timeout: 20_000 });
     await page.keyboard.press("Escape").catch(() => {});
     await page.waitForLoadState("networkidle").catch(() => {});
 

--- a/frontend/tests/e2e/issue-detail/issue-detail-targets.spec.ts
+++ b/frontend/tests/e2e/issue-detail/issue-detail-targets.spec.ts
@@ -112,9 +112,13 @@ test.describe("Targets 'View all' sheet scrolls to the last target on Plan Detai
   test("the all-targets sheet is scrollable — the last target can be brought into view", async () => {
     test.setTimeout(120_000);
 
-    await page.goto(issueUrl);
-    // A change issue redirects to Plan Detail (BYT-9721); make that explicit so
-    // the surface under test is intentional, not an accidental redirect.
+    // Open the Changes phase explicitly. A change issue redirects to Plan Detail
+    // (BYT-9721) and the loader preserves the query string, so `?phase=changes`
+    // survives the redirect and opens the Changes section this test asserts on —
+    // rather than depending on the phase Plan Detail picks by status (a plan that
+    // has a rollout would default to Deploy, which collapses Changes and would
+    // hide the "View all" button).
+    await page.goto(`${issueUrl}?phase=changes`);
     await page.waitForURL(/\/projects\/[^/]+\/plans\/\d+/, { timeout: 20_000 });
     await page.keyboard.press("Escape").catch(() => {});
     await page.waitForLoadState("networkidle").catch(() => {});

--- a/frontend/tests/e2e/plan-detail/plan-detail-header.spec.ts
+++ b/frontend/tests/e2e/plan-detail/plan-detail-header.spec.ts
@@ -1,0 +1,518 @@
+// Plan detail — HEADER lifecycle slot (the whole sub-area in one file).
+//
+// PR #20720 (BYT-9722) funnels the plan's lifecycle into a single header slot:
+// one resolver (resolvePlanLifecycleHeaderState) reads the plan/issue/rollout
+// state and decides what the header shows — an advance ACTION when the current
+// user can move the plan forward, a read-only STATUS when they can't, or a
+// terminal STAMP. Which of those appears is persona-dependent (candidate vs
+// observer; deployer vs not), so this file is organized as a
+// state × persona × path matrix, not a happy-path walk:
+//
+//   REVIEW
+//   - Persona split: candidate sees the "Review" action; a non-candidate
+//     observer sees the read-only "Under review" pill (same plan). (R1/R2)
+//   - Rejected → "Rejected" pill (error) + re-request in the popover. (R3, unhappy)
+//   - Approved + failing ERROR check → "N checks failing" pill. (R4, unhappy)
+//
+//   DEPLOY (frontier stage)
+//   - canRun → "Run · <stage>" → run → "Deployed" terminal stamp. (D1, happy)
+//   - A failed task → "Rerun · <stage>" (not "Run"). (D2, unhappy)
+//   - Multi-stage rollout → the header advance walks stage by stage to
+//     Deployed. (D3, multi-stage)
+//
+//   TERMINAL / overflow (⋯)
+//   - Close + reopen the review issue. (T1)
+//   - Close + reopen a draft plan (no issue). (T2)
+//
+// Not covered here (with reason): `create` (draft-create flow, covered by the
+// smoke/create paths); `review-generating` / `preparing-rollout` (sub-second
+// transient states — not reliably observable in the browser); GitOps `none`
+// (needs a release-backed plan + VCS setup, out of this sub-area).
+//
+// Each describe configures the settings IT needs and navigates fresh in its own
+// beforeAll, so blocks are order-independent (they share one browser for speed,
+// per AGENTS.md §2). The file-level beforeAll snapshots the originals + opens
+// the admin + dba1 browsers; the file-level afterAll restores + closes them.
+
+import {
+  test,
+  expect,
+  type Page,
+  type BrowserContext,
+} from "@playwright/test";
+import { loadTestEnv, type TestEnv } from "../framework/env";
+import { BytebaseApiClient } from "../framework/api-client";
+import { signInBrowserAs } from "../framework/sign-in";
+import { PlanDetailPage } from "./plan-detail.page";
+import { seedReviewPlan, waitForApprovalStatus } from "./plan-helpers";
+
+test.setTimeout(240_000);
+test.describe.configure({ mode: "serial" });
+
+let env: TestEnv & { api: BytebaseApiClient };
+let projectId: string;
+
+let sharedContext: BrowserContext;
+let page: Page;
+let planPage: PlanDetailPage;
+
+// A second browser signed in as dba1 (workspaceDBA) — the non-candidate
+// observer persona for the review persona-split.
+let dbaContext: BrowserContext;
+let dbaPage: Page;
+let dbaPlanPage: PlanDetailPage;
+
+let originalProjectSettings: {
+  requireIssueApproval?: boolean;
+  requirePlanCheckNoError?: boolean;
+  allowSelfApproval?: boolean;
+} = {};
+let originalApproval: unknown = null;
+const createdReviewConfigs: string[] = [];
+
+const ADMIN_RULE = {
+  source: "CHANGE_DATABASE",
+  condition: { expression: "true" },
+  template: {
+    flow: { roles: ["roles/workspaceAdmin"] },
+    title: "E2E Header Admin",
+    description: "single-step workspaceAdmin approval",
+  },
+};
+
+// Mandatory single-step admin approval. allowSelfApproval decides whether the
+// admin creator is a candidate (true → "Review" action) or an observer
+// (false → "Under review" pill).
+async function setApproval(allowSelfApproval: boolean): Promise<void> {
+  await env.api.deletePolicy(env.project, "tag").catch(() => {});
+  await env.api.updateProjectSettings(env.project, {
+    requireIssueApproval: true,
+    requirePlanCheckNoError: false,
+    allowSelfApproval,
+  });
+  await env.api.upsertSetting(
+    "WORKSPACE_APPROVAL",
+    { workspaceApproval: { rules: [ADMIN_RULE] } },
+    "value.workspace_approval",
+  );
+}
+
+async function setPermissive(): Promise<void> {
+  await env.api.deletePolicy(env.project, "tag").catch(() => {});
+  await env.api.updateProjectSettings(env.project, {
+    requireIssueApproval: false,
+    requirePlanCheckNoError: false,
+  });
+  // Clear any approval rule a prior describe left in WORKSPACE_APPROVAL —
+  // otherwise a leftover rule still forces a pending review (blocking the
+  // auto-rollout) even with requireIssueApproval=false. (Each describe must
+  // reset its arrival state; the page is shared.)
+  await env.api.upsertSetting(
+    "WORKSPACE_APPROVAL",
+    { workspaceApproval: { rules: [] } },
+    "value.workspace_approval",
+  );
+}
+
+// Wait (via API) for the backend to auto-create the rollout, so the deploy
+// tests navigate to a page that already shows the frontier Run advance rather
+// than racing the async rollout creation.
+async function waitForRollout(planName: string, timeoutMs = 30_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if ((await env.api.getPlan(planName)).hasRollout) return;
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`rollout was not auto-created for ${planName} in ${timeoutMs}ms`);
+}
+
+// Attach a single ERROR-level COLUMN_NO_NULL rule so a nullable column trips it.
+async function attachErrorConfig(): Promise<void> {
+  const id = `e2e-hdr-err-${Date.now()}`;
+  const cfg = await env.api.upsertReviewConfig(id, "E2E Header ERROR", [
+    { type: "COLUMN_NO_NULL", level: "ERROR", engine: "POSTGRES" },
+  ]);
+  createdReviewConfigs.push(cfg.name);
+  await env.api.upsertReviewConfigTag(env.project, cfg.name);
+}
+
+async function goPlan(planId: string): Promise<void> {
+  await planPage.goto(projectId, planId);
+  await planPage.dismissModals();
+}
+
+test.beforeAll(async ({ browser }) => {
+  env = loadTestEnv();
+  projectId = env.project.split("/").pop()!;
+  await env.api.login(env.adminEmail, env.adminPassword);
+
+  const project = await env.api.getProject(env.project);
+  originalProjectSettings = {
+    requireIssueApproval: !!project.requireIssueApproval,
+    requirePlanCheckNoError: !!project.requirePlanCheckNoError,
+    allowSelfApproval: !!project.allowSelfApproval,
+  };
+  originalApproval = (await env.api.getSetting("WORKSPACE_APPROVAL"))?.value ?? null;
+
+  sharedContext = await browser.newContext({ storageState: ".auth/state.json" });
+  page = await sharedContext.newPage();
+  planPage = new PlanDetailPage(page, env.baseURL);
+
+  // dba1 = the non-candidate observer persona.
+  await signInBrowserAs(
+    browser,
+    env.baseURL,
+    "dba1@example.com",
+    "12345678",
+    ".auth/dba1-header.json",
+  );
+  dbaContext = await browser.newContext({
+    storageState: ".auth/dba1-header.json",
+  });
+  dbaPage = await dbaContext.newPage();
+  dbaPlanPage = new PlanDetailPage(dbaPage, env.baseURL);
+});
+
+test.afterAll(async () => {
+  await env.api.deletePolicy(env.project, "tag").catch(() => {});
+  for (const name of createdReviewConfigs) {
+    await env.api.deleteReviewConfig(name).catch(() => {});
+  }
+  await env.api
+    .updateProjectSettings(env.project, originalProjectSettings)
+    .catch(() => {});
+  await env.api
+    .upsertSetting(
+      "WORKSPACE_APPROVAL",
+      originalApproval ?? { workspaceApproval: { rules: [] } },
+      "value.workspace_approval",
+    )
+    .catch(() => {});
+  await dbaContext?.close();
+  await sharedContext?.close();
+});
+
+/* ----------------------------- REVIEW ---------------------------------- */
+
+test.describe("Review advance is persona-scoped (R1/R2)", () => {
+  let planId = "";
+
+  test.beforeAll(async () => {
+    // allowSelfApproval → admin (creator) IS the candidate.
+    await setApproval(true);
+    const seeded = await seedReviewPlan(env.api, env.project, env.database, {
+      prefix: "E2E Hdr R1R2",
+      sql: "SELECT 1;",
+      runChecks: true,
+    });
+    planId = seeded.planId;
+    await waitForApprovalStatus(env.api, seeded.issueName, ["PENDING"]);
+  });
+
+  test("candidate sees the Review action in the header slot", async () => {
+    await goPlan(planId);
+    await expect(planPage.headerReviewButton).toBeVisible({ timeout: 15_000 });
+    // The candidate must NOT also see the read-only status pill.
+    await expect(planPage.headerStatusPill("Under review")).toHaveCount(0);
+  });
+
+  test("a non-candidate observer sees the read-only 'Under review' pill instead", async () => {
+    await dbaPlanPage.goto(projectId, planId);
+    await dbaPlanPage.dismissModals();
+    const pill = dbaPlanPage.headerStatusPill("Under review");
+    await expect(pill).toBeVisible({ timeout: 15_000 });
+    // The observer must NOT see the Review advance.
+    await expect(dbaPlanPage.headerReviewButton).toHaveCount(0);
+
+    // The pill opens the gate popover: Review gate + Checks gate.
+    await pill.click();
+    await expect(
+      dbaPage.getByText("Review in progress", { exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(
+      dbaPage.getByText("All checks passed", { exact: true }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Rejected review shows the Rejected pill + re-request (R3)", () => {
+  let planId = "";
+
+  test.beforeAll(async () => {
+    await setApproval(true);
+    const seeded = await seedReviewPlan(env.api, env.project, env.database, {
+      prefix: "E2E Hdr R3",
+      sql: "SELECT 1;",
+      runChecks: true,
+    });
+    planId = seeded.planId;
+    await waitForApprovalStatus(env.api, seeded.issueName, ["PENDING"]);
+    await env.api.rejectIssue(seeded.issueName, "e2e header reject");
+    await waitForApprovalStatus(env.api, seeded.issueName, ["REJECTED"]);
+  });
+
+  test("header shows the error-toned Rejected pill and the popover offers re-request", async () => {
+    await goPlan(planId);
+    const pill = planPage.headerStatusPill("Rejected");
+    await expect(pill).toBeVisible({ timeout: 15_000 });
+    await pill.click();
+    // Scope to the popover the pill controls — a "re-request review" button also
+    // lives in the review-section rejection banner, so an unscoped locator is
+    // ambiguous (strict-mode violation).
+    const popupId = await pill.getAttribute("aria-controls");
+    expect(popupId, "pill should control a popover").toBeTruthy();
+    const popover = page.locator(`#${popupId}`);
+    // The popover's Review gate reflects the rejection…
+    await expect(
+      popover.getByText("Changes requested", { exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+    // …and the creator (admin) can re-request review from its footer.
+    await expect(
+      popover.getByRole("button", { name: "re-request review" }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Approved with a failing ERROR check shows the checks-failing pill (R4)", () => {
+  let planId = "";
+
+  test.beforeAll(async () => {
+    await env.api.deletePolicy(env.project, "tag").catch(() => {});
+    await attachErrorConfig();
+    // requirePlanCheckNoError:true keeps the rollout blocked after approval, so
+    // the resolver stays on the checks-failing status (not deploy).
+    await env.api.updateProjectSettings(env.project, {
+      requireIssueApproval: true,
+      requirePlanCheckNoError: true,
+      allowSelfApproval: true,
+    });
+    await env.api.upsertSetting(
+      "WORKSPACE_APPROVAL",
+      { workspaceApproval: { rules: [ADMIN_RULE] } },
+      "value.workspace_approval",
+    );
+    const ts = Date.now();
+    const seeded = await seedReviewPlan(env.api, env.project, env.database, {
+      // A nullable column trips COLUMN_NO_NULL at ERROR level.
+      prefix: "E2E Hdr R4",
+      sql: `ALTER TABLE employee ADD COLUMN e2e_r4_${ts} TEXT;`,
+      runChecks: true,
+    });
+    planId = seeded.planId;
+    await waitForApprovalStatus(env.api, seeded.issueName, ["PENDING"]);
+    await env.api.approveIssue(seeded.issueName);
+    await waitForApprovalStatus(env.api, seeded.issueName, ["APPROVED"]);
+  });
+
+  test("header shows the '… checks failing' pill after approval", async () => {
+    await goPlan(planId);
+    const pill = planPage.headerStatusPill(/check(s)? failing/i);
+    await expect(pill).toBeVisible({ timeout: 15_000 });
+    await pill.click();
+    await expect(
+      page.getByText("Some checks were not successful", { exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+});
+
+/* ----------------------------- DEPLOY ---------------------------------- */
+
+test.describe("Running the frontier stage from the header reaches the Deployed stamp (D1)", () => {
+  let planId = "";
+
+  test.beforeAll(async () => {
+    await setPermissive();
+    const ts = Date.now();
+    const seeded = await seedReviewPlan(env.api, env.project, env.database, {
+      prefix: "E2E Hdr D1",
+      sql: `ALTER TABLE employee ADD COLUMN IF NOT EXISTS e2e_d1_${ts} TEXT;`,
+      runChecks: true,
+    });
+    planId = seeded.planId;
+    await waitForRollout(seeded.planName);
+  });
+
+  test("header Run·<stage> runs the frontier, then the slot becomes the Deployed stamp", async () => {
+    await goPlan(planId);
+    // The header advance is present and distinct from the deploy-section Run.
+    await expect(planPage.headerRunStage).toBeVisible({ timeout: 20_000 });
+
+    await planPage.headerRunStage.click();
+    await planPage.confirmRunTaskDialog();
+
+    // After the frontier stage completes, the header shows the terminal stamp
+    // and no Run advance remains.
+    await expect(planPage.headerStamp("Deployed")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(planPage.headerRunStage).toHaveCount(0);
+  });
+});
+
+test.describe("A failed task surfaces Rerun in the header slot (D2)", () => {
+  let planId = "";
+
+  test.beforeAll(async () => {
+    await setPermissive();
+    const ts = Date.now();
+    // A nonexistent target makes the task fail at execution.
+    const seeded = await seedReviewPlan(env.api, env.project, env.database, {
+      prefix: "E2E Hdr D2",
+      sql: `ALTER TABLE nonexistent_e2e_hdr_${ts} ADD COLUMN c1 TEXT;`,
+      runChecks: false,
+    });
+    planId = seeded.planId;
+    await waitForRollout(seeded.planName);
+  });
+
+  test("after the task fails, the header advance reads Rerun·<stage>", async () => {
+    await goPlan(planId);
+    // First run (the stage has never executed) — labelled "Run".
+    await expect(planPage.headerRunStage).toBeVisible({ timeout: 20_000 });
+    await planPage.headerRunStage.click();
+    await planPage.confirmRunTaskDialog();
+
+    // The task fails; the frontier now has a failed task → the advance flips to
+    // "Rerun · <stage>" (a re-run of a stage that already executed).
+    await expect(planPage.headerRerunStage).toBeVisible({ timeout: 30_000 });
+    await expect(planPage.headerRunStage).toHaveCount(0);
+  });
+});
+
+test.describe("A multi-stage rollout advances the header stage by stage to Deployed (D3)", () => {
+  let planId = "";
+
+  test.beforeAll(async () => {
+    await setPermissive();
+    const ts = Date.now();
+    const testDb = await env.api.findDatabaseByShortName("hr_test");
+    const prodDb = await env.api.findDatabaseByShortName("hr_prod");
+    if (!testDb || !prodDb) {
+      throw new Error("multi-stage seed needs hr_test + hr_prod sample dbs");
+    }
+    const sheet = await env.api.createSheet(
+      env.project,
+      `ALTER TABLE employee ADD COLUMN IF NOT EXISTS e2e_d3_${ts} TEXT;`,
+    );
+    // One spec targeting two environments → the rollout groups tasks into two
+    // stages (Test, Prod).
+    const plan = await env.api.createPlan(env.project, `E2E Hdr D3 ${ts}`, [
+      { id: `spec-${ts}`, targets: [testDb.database, prodDb.database], sheet },
+    ]);
+    await env.api.createIssue(env.project, `E2E Hdr D3 ${ts}`, plan.name);
+    planId = plan.name.split("/").pop()!;
+    await waitForRollout(plan.name);
+  });
+
+  test("the header Run advance walks each stage until the plan is Deployed", async () => {
+    await goPlan(planId);
+
+    // Frontier = first (earliest-environment) incomplete stage.
+    await expect(planPage.headerRunStage).toBeVisible({ timeout: 20_000 });
+    const firstLabel = (await planPage.headerRunStage.textContent())?.trim();
+
+    await planPage.headerRunStage.click();
+    await planPage.confirmRunTaskDialog();
+
+    // Frontier advances to the next stage — still a Run advance, different stage.
+    await expect(planPage.headerRunStage).toBeVisible({ timeout: 30_000 });
+    await expect(async () => {
+      const nextLabel = (await planPage.headerRunStage.textContent())?.trim();
+      expect(nextLabel).not.toBe(firstLabel);
+    }).toPass({ timeout: 15_000 });
+
+    await planPage.headerRunStage.click();
+    await planPage.confirmRunTaskDialog();
+
+    // Both stages complete → Deployed stamp, no remaining Run advance.
+    await expect(planPage.headerStamp("Deployed")).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(planPage.headerRunStage).toHaveCount(0);
+  });
+});
+
+/* -------------------------- TERMINAL / overflow ------------------------- */
+
+test.describe("Close and reopen the review from the ⋯ overflow menu (T1)", () => {
+  let planId = "";
+  const acceptDialogs = (d: import("@playwright/test").Dialog) => d.accept();
+
+  test.beforeAll(async () => {
+    // Open review, no rollout yet (self-approval off → observer, unapproved).
+    await setApproval(false);
+    const seeded = await seedReviewPlan(env.api, env.project, env.database, {
+      prefix: "E2E Hdr T1",
+      sql: "SELECT 1;",
+      runChecks: true,
+    });
+    planId = seeded.planId;
+    await waitForApprovalStatus(env.api, seeded.issueName, ["PENDING"]);
+    // Close/reopen confirm via window.confirm — auto-accept for this block.
+    page.on("dialog", acceptDialogs);
+  });
+
+  test.afterAll(async () => {
+    page.off("dialog", acceptDialogs);
+  });
+
+  test("Close cancels the review (Closed stamp); Reopen restores it", async () => {
+    await goPlan(planId);
+    await expect(planPage.headerStatusPill("Under review")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Close lives in the ⋯ overflow (the slot's primary is the status pill).
+    await planPage.openOverflow();
+    await planPage.overflowItem("Close").click();
+    await expect(planPage.headerStamp("Closed")).toBeVisible({ timeout: 15_000 });
+
+    // With a terminal slot (no primary), Reopen is promoted to a direct button.
+    await expect(planPage.headerReopenButton).toBeVisible({ timeout: 10_000 });
+    await planPage.headerReopenButton.click();
+    await expect(planPage.headerStatusPill("Under review")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(planPage.headerStamp("Closed")).toHaveCount(0);
+  });
+});
+
+test.describe("Close and reopen a draft plan from the ⋯ overflow menu (T2)", () => {
+  let planId = "";
+  const acceptDialogs = (d: import("@playwright/test").Dialog) => d.accept();
+
+  test.beforeAll(async () => {
+    await setPermissive();
+    // A plan with NO issue and NO rollout → ready-for-review + close-plan.
+    const ts = Date.now();
+    const sheet = await env.api.createSheet(env.project, "SELECT 1;");
+    const plan = await env.api.createPlan(env.project, `E2E Hdr T2 ${ts}`, [
+      { id: `spec-${ts}`, targets: [env.database], sheet },
+    ]);
+    planId = plan.name.split("/").pop()!;
+    page.on("dialog", acceptDialogs);
+  });
+
+  test.afterAll(async () => {
+    page.off("dialog", acceptDialogs);
+  });
+
+  test("Close deletes the draft plan (Closed stamp); Reopen restores it", async () => {
+    await goPlan(planId);
+    // Draft with no issue → the primary is "Ready for Review"; Close is in ⋯.
+    await expect(
+      planPage.headerRow.getByRole("button", { name: "Ready for Review" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await planPage.openOverflow();
+    await planPage.overflowItem("Close").click();
+    await expect(planPage.headerStamp("Closed")).toBeVisible({ timeout: 15_000 });
+
+    await expect(planPage.headerReopenButton).toBeVisible({ timeout: 10_000 });
+    await planPage.headerReopenButton.click();
+    await expect(
+      planPage.headerRow.getByRole("button", { name: "Ready for Review" }),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(planPage.headerStamp("Closed")).toHaveCount(0);
+  });
+});

--- a/frontend/tests/e2e/plan-detail/plan-detail.page.ts
+++ b/frontend/tests/e2e/plan-detail/plan-detail.page.ts
@@ -29,6 +29,21 @@ export class PlanDetailPage {
   // The readiness footer's single action, in either weight (link or button).
   readonly bypassAndDeployAction: Locator;
 
+  // --- Header lifecycle slot (PlanDetailHeader, BYT-9722) ---
+  // The sticky title/action row. Scope every header-slot assertion to this so a
+  // pill/stamp/label in a phase section can't be mistaken for the header slot.
+  readonly headerRow: Locator;
+  // The frontier-stage advance buttons in the header slot: "Run · <stage>" /
+  // "Rerun · <stage>" (distinct from the deploy-section per-task exact "Run").
+  readonly headerRunStage: Locator;
+  readonly headerRerunStage: Locator;
+  // The your-turn Review action in the header slot (opens the approve/reject
+  // composer). Scoped so it never resolves to a phase-section control.
+  readonly headerReviewButton: Locator;
+  // The "⋯" overflow trigger and the promoted secondary action (e.g. Reopen).
+  readonly headerOverflowButton: Locator;
+  readonly headerReopenButton: Locator;
+
   constructor(page: Page, baseURL: string) {
     this.page = page;
     this.baseURL = baseURL;
@@ -50,13 +65,69 @@ export class PlanDetailPage {
     this.composerEditor = page.locator("textarea[placeholder='Add a comment...']");
     this.composerSubmitButton = page.getByRole("button", { name: "Comment", exact: true });
     this.bypassAndDeployAction = page.getByRole("button", { name: "Bypass and deploy" });
+
+    // The sticky header row, located structurally (no product-code testid): the
+    // title <input> sits in the row's left group (beside the terminal stamp), so
+    // its grandparent is the row that also holds the lifecycle slot + ⋯ overflow.
+    // Uses the same `..`-parent pattern as getSectionToggle below.
+    this.headerRow = page.getByRole("textbox").first().locator("..").locator("..");
+    // The frontier advance button reads "Run <stage>" / "Rerun <stage>" (the
+    // "·" separator is aria-hidden, so it's not in the accessible name). "Rerun"
+    // starts with "Re", so /^Run/ and /^Rerun/ never cross-match.
+    this.headerRunStage = this.headerRow.getByRole("button", { name: /^Run/ });
+    this.headerRerunStage = this.headerRow.getByRole("button", { name: /^Rerun/ });
+    this.headerReviewButton = this.headerRow.getByRole("button", {
+      name: "Review",
+      exact: true,
+    });
+    this.headerOverflowButton = this.headerRow.getByRole("button", { name: "More" });
+    this.headerReopenButton = this.headerRow.getByRole("button", {
+      name: "Reopen",
+      exact: true,
+    });
+  }
+
+  // The read-only status pill in the header slot ("Under review", "Rejected",
+  // "N checks failing", "Checking…"). It is a <button> (opens the gate popover),
+  // which distinguishes it from the identical-text review-phase status <span>.
+  headerStatusPill(name: string | RegExp): Locator {
+    return this.headerRow.getByRole("button", { name });
+  }
+
+  // A terminal stamp in the header slot ("Deployed" / "Closed"), rendered as a
+  // non-interactive badge left of the title.
+  headerStamp(text: string): Locator {
+    return this.headerRow.getByText(text, { exact: true });
+  }
+
+  // Open the "⋯" overflow menu and return a menu item by name. The menu portals
+  // outside the header row, so the item is located at page scope.
+  async openOverflow(): Promise<void> {
+    await this.headerOverflowButton.click();
+    await this.page.getByRole("menu").waitFor({ state: "visible" });
+  }
+
+  overflowItem(name: string): Locator {
+    return this.page.getByRole("menuitem", { name, exact: true });
+  }
+
+  // Confirm a "Run task" run-confirmation dialog (shared by the header Run·stage
+  // slot and the deploy-section Run — both open PlanDetailTaskRolloutActionPanel).
+  async confirmRunTaskDialog(): Promise<void> {
+    const dialog = this.page.getByRole("dialog").filter({ hasText: "Run task" });
+    await dialog.getByRole("button", { name: "Run", exact: true }).click();
   }
 
   // The Review phase status badge text (e.g. "Under review", "Approved",
-  // "Rejected", "Skipped"). Scoped to its known label set so it doesn't match
-  // body copy.
+  // "Rejected", "Skipped"). Scoped to the review phase section (#plan-phase-review)
+  // because the header lifecycle slot (BYT-9722, #20720) now renders the SAME
+  // status text as a pill — an unscoped getByText would match both and throw a
+  // strict-mode violation (the header pill is asserted separately, scoped to the
+  // header row, in plan-detail-header.spec.ts).
   reviewBadge(text: string): Locator {
-    return this.page.getByText(text, { exact: true });
+    return this.page
+      .locator("#plan-phase-review")
+      .getByText(text, { exact: true });
   }
 
   // Open the Review popover, pick an action, optionally type a comment, submit.


### PR DESCRIPTION
## What

Adds e2e coverage for the 3.20.0 plan-detail work, and re-scopes two existing guards that the merged PRs silently broke.

### New coverage
- **`plan-detail-header.spec.ts`** — 9 CUJs over the header lifecycle slot (BYT-9722, #20720), as a state × persona × path matrix:
  - Review persona split — candidate sees the **Review** action; a non-candidate observer sees the read-only **Under review** pill + gate popover
  - **Rejected** pill (error) + re-request; **Checks failing** pill after approval
  - Deploy — header **Run/Rerun** → **Deployed** stamp; a multi-stage rollout advances stage-by-stage
  - Close + reopen the review, and a draft plan, via the ⋯ overflow menu
- **`issue-detail-redirect.spec.ts`** — a schema/data change issue redirects Issue Detail → Plan Detail with the query string preserved (B1); a create-database issue stays on Issue Detail (B2) — BYT-9721, #20722
- `framework/api-client.ts` — `createCreateDatabasePlan()` for the B2 case

### Guard fixes (regressions from the merged PRs)
The licensed e2e suite doesn't run in CI, so these went undetected:
- **`issue-detail-comments`** — re-based onto a create-database issue; change issues now redirect off Issue Detail (#20722), and this guard asserts the Issue-Detail markdown render path
- **`plan-detail.page.ts` `reviewBadge()`** — scoped to `#plan-phase-review`; the new header status pill (#20720) renders the same status text as the review-section badge, so an unscoped `getByText` was a strict-mode violation in CUJ C + the permission-boundary test
- **`issue-detail-targets`** — assert the redirect to Plan Detail explicitly (it now exercises `PlanDetailChangesBranch`)

## Testing

Test-only change (no product source). Rebased onto latest `main` and verified: the two new specs + the re-scoped guards — **29/29 passed**.

## Note

The licensed e2e suite isn't wired into CI (needs `BYTEBASE_E2E_LICENSE`), which is why #20720/#20722 broke these guards without anyone noticing — worth wiring in at least a gated subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
