### PR TITLE
fix(approval): prevent rollout for invalid approval roles

### DIFF
--- a/backend/utils/utils.go
+++ b/backend/utils/utils.go
@@ -69,6 +69,14 @@ func CheckApprovalApproved(approval *storepb.IssuePayloadApproval) (bool, error)
 	if approval.ApprovalTemplate == nil {
 		return true, nil
 	}
+	if approval.ApprovalTemplate.Flow == nil {
+		return false, errors.Errorf("approval template flow cannot be nil")
+	}
+	for i, role := range approval.ApprovalTemplate.Flow.Roles {
+		if strings.TrimSpace(role) == "" {
+			return false, errors.Errorf("approval template role at position %d cannot be empty", i+1)
+		}
+	}
 	return FindRejectedRole(approval) == "" && FindNextPendingRole(approval) == "", nil
 }
 

--- a/backend/utils/utils_test.go
+++ b/backend/utils/utils_test.go
@@ -63,6 +63,7 @@ func TestCheckIssueApprovedForPlan(t *testing.T) {
 		issue     *storepb.Issue
 		plan      *storepb.PlanConfig
 		want      bool
+		wantErr   string
 	}{
 		{
 			name:      "database change approved for matching plan version",
@@ -109,6 +110,64 @@ func TestCheckIssueApprovedForPlan(t *testing.T) {
 			plan: &storepb.PlanConfig{ApprovalInputVersion: 2},
 			want: true,
 		},
+		{
+			name:      "empty approval flow skips approval",
+			issueType: storepb.Issue_DATABASE_CHANGE,
+			issue: &storepb.Issue{
+				Approval: &storepb.IssuePayloadApproval{
+					ApprovalFindingDone:  true,
+					ApprovalInputVersion: 2,
+					ApprovalTemplate: &storepb.ApprovalTemplate{
+						Flow: &storepb.ApprovalFlow{},
+					},
+				},
+			},
+			plan: &storepb.PlanConfig{ApprovalInputVersion: 2},
+			want: true,
+		},
+		{
+			name:      "empty approval role is invalid",
+			issueType: storepb.Issue_DATABASE_CHANGE,
+			issue: &storepb.Issue{
+				Approval: &storepb.IssuePayloadApproval{
+					ApprovalFindingDone:  true,
+					ApprovalInputVersion: 2,
+					ApprovalTemplate: &storepb.ApprovalTemplate{
+						Flow: &storepb.ApprovalFlow{Roles: []string{""}},
+					},
+				},
+			},
+			plan:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+			wantErr: "approval template role at position 1 cannot be empty",
+		},
+		{
+			name:      "blank approval role is invalid",
+			issueType: storepb.Issue_DATABASE_CHANGE,
+			issue: &storepb.Issue{
+				Approval: &storepb.IssuePayloadApproval{
+					ApprovalFindingDone:  true,
+					ApprovalInputVersion: 2,
+					ApprovalTemplate: &storepb.ApprovalTemplate{
+						Flow: &storepb.ApprovalFlow{Roles: []string{" "}},
+					},
+				},
+			},
+			plan:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+			wantErr: "approval template role at position 1 cannot be empty",
+		},
+		{
+			name:      "nil approval flow is invalid",
+			issueType: storepb.Issue_DATABASE_CHANGE,
+			issue: &storepb.Issue{
+				Approval: &storepb.IssuePayloadApproval{
+					ApprovalFindingDone:  true,
+					ApprovalInputVersion: 2,
+					ApprovalTemplate:     &storepb.ApprovalTemplate{},
+				},
+			},
+			plan:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+			wantErr: "approval template flow cannot be nil",
+		},
 	}
 
 	for _, tt := range tests {
@@ -119,6 +178,11 @@ func TestCheckIssueApprovedForPlan(t *testing.T) {
 			}, &store.PlanMessage{
 				Config: tt.plan,
 			})
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				assert.False(t, got)
+				return
+			}
 			assert.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
## Summary

- Prevent malformed approval templates from being interpreted as approved at runtime.
- Preserve an empty role list as the intentional “no approval required” configuration.
- Keep automatic rollout creator attribution unchanged.

## Key Changes

- Return an error when a stored approval template contains a nil flow or an empty/whitespace-only role.
- Use the shared approval-status check to block automatic and manual rollout creation for malformed templates.
- Add regression coverage for malformed roles, nil flows, and valid empty flows.

## Motivation

PR #20909 prevents new approval rules with empty roles from being saved. However, existing workspace settings or issue approval snapshots can still contain `roles: [""]`. Previously, that value was interpreted as having no pending approver and could unexpectedly trigger automatic rollout creation.

## Testing

- `go test -count=1 ./backend/utils`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- Backend server build
- Runner integration tests were attempted but require Docker, which was unavailable locally.