### PR TITLE
feat(pg): generate Sync Schema migration DDL for composite types

### DIFF
--- a/backend/plugin/schema/differ.go
+++ b/backend/plugin/schema/differ.go
@@ -47,6 +47,9 @@ type MetadataDiff struct {
 	// Enum type changes
 	EnumTypeChanges []*EnumTypeDiff
 
+	// Composite type changes
+	CompositeTypeChanges []*CompositeTypeDiff
+
 	// Extension changes
 	ExtensionChanges []*ExtensionDiff
 
@@ -231,6 +234,15 @@ type EnumTypeDiff struct {
 	EnumTypeName string
 	OldEnumType  *storepb.EnumTypeMetadata
 	NewEnumType  *storepb.EnumTypeMetadata
+}
+
+// CompositeTypeDiff represents changes to a composite type.
+type CompositeTypeDiff struct {
+	Action            MetadataDiffAction
+	SchemaName        string
+	CompositeTypeName string
+	OldCompositeType  *storepb.CompositeTypeMetadata
+	NewCompositeType  *storepb.CompositeTypeMetadata
 }
 
 // ExtensionDiff represents changes to an extension.
@@ -453,6 +465,18 @@ func addNewSchemaObjects(diff *MetadataDiff, schemaName string, schema *model.Sc
 		}
 	}
 
+	// Add all composite types
+	for _, compositeProto := range schemaProto.CompositeTypes {
+		if !compositeProto.GetSkipDump() {
+			diff.CompositeTypeChanges = append(diff.CompositeTypeChanges, &CompositeTypeDiff{
+				Action:            MetadataDiffActionCreate,
+				SchemaName:        schemaName,
+				CompositeTypeName: compositeProto.Name,
+				NewCompositeType:  compositeProto,
+			})
+		}
+	}
+
 	// Add all events
 	for _, eventProto := range schemaProto.Events {
 		diff.EventChanges = append(diff.EventChanges, &EventDiff{
@@ -525,6 +549,9 @@ func compareSchemaObjects(engine storepb.Engine, diff *MetadataDiff, schemaName 
 
 	// Compare enum types
 	compareEnumTypes(diff, schemaName, oldSchema, newSchema)
+
+	// Compare composite types
+	compareCompositeTypes(diff, schemaName, oldSchema, newSchema)
 
 	// Compare events
 	compareEvents(diff, schemaName, oldSchema, newSchema)
@@ -1970,6 +1997,77 @@ func compareEnumTypes(diff *MetadataDiff, schemaName string, oldSchema, newSchem
 	}
 }
 
+func compareCompositeTypes(diff *MetadataDiff, schemaName string, oldSchema, newSchema *model.SchemaMetadata) {
+	oldSchemaProto := oldSchema.GetProto()
+	newSchemaProto := newSchema.GetProto()
+
+	oldCompositeMap := make(map[string]*storepb.CompositeTypeMetadata)
+	for _, composite := range oldSchemaProto.CompositeTypes {
+		if !composite.GetSkipDump() {
+			oldCompositeMap[composite.Name] = composite
+		}
+	}
+
+	newCompositeMap := make(map[string]*storepb.CompositeTypeMetadata)
+	for _, composite := range newSchemaProto.CompositeTypes {
+		if !composite.GetSkipDump() {
+			newCompositeMap[composite.Name] = composite
+		}
+	}
+
+	// Check for dropped composite types
+	for compositeName, oldComposite := range oldCompositeMap {
+		if _, exists := newCompositeMap[compositeName]; !exists {
+			diff.CompositeTypeChanges = append(diff.CompositeTypeChanges, &CompositeTypeDiff{
+				Action:            MetadataDiffActionDrop,
+				SchemaName:        schemaName,
+				CompositeTypeName: compositeName,
+				OldCompositeType:  oldComposite,
+			})
+		}
+	}
+
+	// Check for new and modified composite types
+	for compositeName, newComposite := range newCompositeMap {
+		if oldComposite, exists := oldCompositeMap[compositeName]; !exists {
+			diff.CompositeTypeChanges = append(diff.CompositeTypeChanges, &CompositeTypeDiff{
+				Action:            MetadataDiffActionCreate,
+				SchemaName:        schemaName,
+				CompositeTypeName: compositeName,
+				NewCompositeType:  newComposite,
+			})
+		} else if !compositeTypesEqual(oldComposite, newComposite) {
+			diff.CompositeTypeChanges = append(diff.CompositeTypeChanges, &CompositeTypeDiff{
+				Action:            MetadataDiffActionAlter,
+				SchemaName:        schemaName,
+				CompositeTypeName: compositeName,
+				OldCompositeType:  oldComposite,
+				NewCompositeType:  newComposite,
+			})
+		}
+	}
+}
+
+// compositeTypesEqual checks attributes (order-sensitive) and comments.
+func compositeTypesEqual(oldComposite, newComposite *storepb.CompositeTypeMetadata) bool {
+	if oldComposite.Comment != newComposite.Comment {
+		return false
+	}
+	if len(oldComposite.Attributes) != len(newComposite.Attributes) {
+		return false
+	}
+	for i, oldAttribute := range oldComposite.Attributes {
+		newAttribute := newComposite.Attributes[i]
+		if oldAttribute.Name != newAttribute.Name ||
+			oldAttribute.Type != newAttribute.Type ||
+			oldAttribute.Collation != newAttribute.Collation ||
+			oldAttribute.Comment != newAttribute.Comment {
+			return false
+		}
+	}
+	return true
+}
+
 // enumValuesEqual checks if two enum value slices are equal.
 func enumValuesEqual(oldValues, newValues []string) bool {
 	if len(oldValues) != len(newValues) {
@@ -2216,6 +2314,13 @@ func FilterPostgresArchiveSchema(diff *MetadataDiff) *MetadataDiff {
 	for _, enumChange := range diff.EnumTypeChanges {
 		if enumChange.SchemaName != archiveSchemaName {
 			filtered.EnumTypeChanges = append(filtered.EnumTypeChanges, enumChange)
+		}
+	}
+
+	// Filter composite type changes
+	for _, compositeChange := range diff.CompositeTypeChanges {
+		if compositeChange.SchemaName != archiveSchemaName {
+			filtered.CompositeTypeChanges = append(filtered.CompositeTypeChanges, compositeChange)
 		}
 	}
 

--- a/backend/plugin/schema/pg/composite_type_migration_test.go
+++ b/backend/plugin/schema/pg/composite_type_migration_test.go
@@ -1,0 +1,1578 @@
+package pg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+	"github.com/bytebase/bytebase/backend/store/model"
+)
+
+func newPGDatabaseMetadataWithCompositeTypes(compositeTypes []*storepb.CompositeTypeMetadata) *model.DatabaseMetadata {
+	return model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name:           "public",
+				CompositeTypes: compositeTypes,
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+}
+
+func TestPGMetadataDiffCreateCompositeTypesInDependencyOrder(t *testing.T) {
+	source := newPGDatabaseMetadataWithCompositeTypes(nil)
+	// aa_nested sorts before zz_base alphabetically but depends on it.
+	target := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "aa_nested",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "home", Type: "public.zz_base"},
+			},
+		},
+		{
+			Name:    "zz_base",
+			Comment: "base type",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "street", Type: "text", Collation: `"C"`, Comment: "street line"},
+			},
+		},
+	})
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Contains(t, sql, `CREATE TYPE "public"."zz_base" AS (`)
+	require.Contains(t, sql, `"street" text COLLATE "C"`)
+	require.Contains(t, sql, `CREATE TYPE "public"."aa_nested" AS (`)
+	require.Contains(t, sql, `COMMENT ON TYPE "public"."zz_base" IS 'base type';`)
+	require.Contains(t, sql, `COMMENT ON COLUMN "public"."zz_base"."street" IS 'street line';`)
+	require.Less(t,
+		strings.Index(sql, `CREATE TYPE "public"."zz_base"`),
+		strings.Index(sql, `CREATE TYPE "public"."aa_nested"`),
+		"referenced composite must be created before its dependent")
+}
+
+func TestPGMetadataDiffDropCompositeTypesInReverseDependencyOrder(t *testing.T) {
+	source := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "zz_base",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "x", Type: "integer"},
+			},
+		},
+		{
+			Name: "aa_nested",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "home", Type: "public.zz_base"},
+			},
+		},
+	})
+	target := newPGDatabaseMetadataWithCompositeTypes(nil)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Contains(t, sql, `DROP TYPE "public"."aa_nested";`)
+	require.Contains(t, sql, `DROP TYPE "public"."zz_base";`)
+	require.Less(t,
+		strings.Index(sql, `DROP TYPE "public"."aa_nested"`),
+		strings.Index(sql, `DROP TYPE "public"."zz_base"`),
+		"dependent composite must be dropped before the composite it references")
+}
+
+func TestPGMetadataDiffCompositeDropsPrecedeEnumDrops(t *testing.T) {
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				EnumTypes: []*storepb.EnumTypeMetadata{
+					{Name: "status", Values: []string{"a", "b"}},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "uses_status",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "s", Type: "public.status"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := newPGDatabaseMetadataWithCompositeTypes(nil)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Less(t,
+		strings.Index(sql, `DROP TYPE "public"."uses_status"`),
+		strings.Index(sql, `DROP TYPE "public"."status"`),
+		"composite referencing an enum must be dropped before the enum")
+}
+
+func TestPGMetadataDiffAlterCompositeTypeAttributes(t *testing.T) {
+	source := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "addr",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "street", Type: "text"},
+				{Name: "city", Type: "character varying(50)"},
+				{Name: "dropped_attr", Type: "integer"},
+			},
+		},
+	})
+	target := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "addr",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "street", Type: "text"},
+				{Name: "city", Type: "character varying(100)"},
+				{Name: "zip", Type: "text", Collation: `"C"`},
+			},
+		},
+	})
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Contains(t, sql, `ALTER TYPE "public"."addr" DROP ATTRIBUTE "dropped_attr";`)
+	require.Contains(t, sql, `ALTER TYPE "public"."addr" ADD ATTRIBUTE "zip" text COLLATE "C";`)
+	require.Contains(t, sql, `ALTER TYPE "public"."addr" ALTER ATTRIBUTE "city" TYPE character varying(100);`)
+	require.NotContains(t, sql, `"street"`, "unchanged attribute must not produce DDL")
+}
+
+func TestPGMetadataDiffCompositeTypeReorderOnlyWarns(t *testing.T) {
+	source := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "addr",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "a", Type: "text"},
+				{Name: "b", Type: "integer"},
+			},
+		},
+	})
+	target := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "addr",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "b", Type: "integer"},
+				{Name: "a", Type: "text"},
+			},
+		},
+	})
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Contains(t, sql, `-- WARNING: PostgreSQL does not support reordering the attributes of "public"."addr"`)
+	require.NotContains(t, sql, "ALTER TYPE", "reorder-only change must not produce attribute DDL")
+	require.NotContains(t, sql, "DROP TYPE")
+}
+
+func TestPGMetadataDiffCompositeTypeCommentChanges(t *testing.T) {
+	source := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name:    "addr",
+			Comment: "old type comment",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "street", Type: "text", Comment: "old attr comment"},
+			},
+		},
+	})
+	target := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name:    "addr",
+			Comment: "new type comment",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "street", Type: "text", Comment: "new attr comment"},
+			},
+		},
+	})
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Contains(t, sql, `COMMENT ON TYPE "public"."addr" IS 'new type comment';`)
+	require.Contains(t, sql, `COMMENT ON COLUMN "public"."addr"."street" IS 'new attr comment';`)
+	require.NotContains(t, sql, "ALTER TYPE", "comment-only change must not produce attribute DDL")
+}
+
+func TestPGMetadataDiffIdenticalCompositeTypesProduceNoMigration(t *testing.T) {
+	composites := []*storepb.CompositeTypeMetadata{
+		{
+			Name:    "addr",
+			Comment: "c",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "street", Type: "text", Collation: `"C"`, Comment: "s"},
+			},
+		},
+	}
+	source := newPGDatabaseMetadataWithCompositeTypes(composites)
+	target := newPGDatabaseMetadataWithCompositeTypes(composites)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Empty(t, sql)
+}
+
+func TestPGMetadataDiffCompositeDropDeferredAfterColumnRetype(t *testing.T) {
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "public.addr", Nullable: true},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "street", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "text", Nullable: true},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	dropIdx := strings.Index(sql, `DROP TYPE "public"."addr"`)
+	alterIdx := strings.Index(sql, `ALTER COLUMN "c"`)
+	require.GreaterOrEqual(t, dropIdx, 0, "composite type must still be dropped: %s", sql)
+	require.GreaterOrEqual(t, alterIdx, 0, "column must be retyped: %s", sql)
+	require.Greater(t, dropIdx, alterIdx,
+		"composite drop must run after the column retype that releases it: %s", sql)
+}
+
+func TestPGMetadataDiffSchemaDropIncludesCompositeTypes(t *testing.T) {
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "public"},
+			{
+				Name: "s",
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "street", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "public"},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	dropTypeIdx := strings.Index(sql, `DROP TYPE "s"."addr"`)
+	dropSchemaIdx := strings.Index(sql, `DROP SCHEMA`)
+	require.GreaterOrEqual(t, dropTypeIdx, 0, "schema drop must drop its composite types first: %s", sql)
+	require.GreaterOrEqual(t, dropSchemaIdx, 0)
+	require.Less(t, dropTypeIdx, dropSchemaIdx, "composite type drop must precede DROP SCHEMA: %s", sql)
+}
+
+func TestPGMetadataDiffCompositeTypeMiddleInsertWarns(t *testing.T) {
+	source := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "addr",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "a", Type: "text"},
+				{Name: "b", Type: "text"},
+			},
+		},
+	})
+	target := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "addr",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "a", Type: "text"},
+				{Name: "x", Type: "text"},
+				{Name: "b", Type: "text"},
+			},
+		},
+	})
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Contains(t, sql, `ALTER TYPE "public"."addr" ADD ATTRIBUTE "x" text;`)
+	require.Contains(t, sql, `-- WARNING: PostgreSQL does not support reordering the attributes of "public"."addr"`,
+		"middle insertion is not achievable via ADD ATTRIBUTE and must warn: %s", sql)
+}
+
+func TestPGMetadataDiffDeferredCompositeDefersReferencedEnumDrop(t *testing.T) {
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "public.addr", Nullable: true},
+						},
+					},
+				},
+				EnumTypes: []*storepb.EnumTypeMetadata{
+					{Name: "status", Values: []string{"a", "b"}},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "s", Type: "public.status"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "text", Nullable: true},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	retypeIdx := strings.Index(sql, `ALTER COLUMN "c"`)
+	compositeIdx := strings.Index(sql, `DROP TYPE "public"."addr"`)
+	enumIdx := strings.Index(sql, `DROP TYPE "public"."status"`)
+	require.GreaterOrEqual(t, retypeIdx, 0, "column must be retyped: %s", sql)
+	require.GreaterOrEqual(t, compositeIdx, 0, "composite must be dropped: %s", sql)
+	require.GreaterOrEqual(t, enumIdx, 0, "enum must be dropped: %s", sql)
+	require.Greater(t, compositeIdx, retypeIdx, "deferred composite drop must follow the retype: %s", sql)
+	require.Greater(t, enumIdx, compositeIdx, "enum referenced by the deferred composite must drop after it: %s", sql)
+}
+
+func TestPGMetadataDiffSchemaDropDeferredWhenCompositeReleasedByRetype(t *testing.T) {
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "s.addr", Nullable: true},
+						},
+					},
+				},
+			},
+			{
+				Name: "s",
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "street", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "text", Nullable: true},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	retypeIdx := strings.Index(sql, `ALTER COLUMN "c"`)
+	dropTypeIdx := strings.Index(sql, `DROP TYPE "s"."addr"`)
+	dropSchemaIdx := strings.Index(sql, `DROP SCHEMA IF EXISTS "s"`)
+	require.GreaterOrEqual(t, retypeIdx, 0, "column must be retyped: %s", sql)
+	require.GreaterOrEqual(t, dropTypeIdx, 0, "composite in dropped schema must be dropped: %s", sql)
+	require.GreaterOrEqual(t, dropSchemaIdx, 0, "schema must be dropped: %s", sql)
+	require.Greater(t, dropTypeIdx, retypeIdx, "schema-owned composite drop must follow the retype releasing it: %s", sql)
+	require.Greater(t, dropSchemaIdx, dropTypeIdx, "DROP SCHEMA must follow its composite drop: %s", sql)
+}
+
+func TestPGMetadataDiffSchemaDropDeferredWhenDeferredCompositeReferencesItsEnum(t *testing.T) {
+	// public.addr is deferred (public.t.c retyped away from it) and references
+	// s.status; schema s (containing only that enum) must defer its drop too.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "public.addr", Nullable: true},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "st", Type: "s.status"},
+						},
+					},
+				},
+			},
+			{
+				Name: "s",
+				EnumTypes: []*storepb.EnumTypeMetadata{
+					{Name: "status", Values: []string{"a"}},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "text", Nullable: true},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	compositeIdx := strings.Index(sql, `DROP TYPE "public"."addr"`)
+	enumIdx := strings.Index(sql, `DROP TYPE "s"."status"`)
+	schemaIdx := strings.Index(sql, `DROP SCHEMA IF EXISTS "s"`)
+	require.GreaterOrEqual(t, compositeIdx, 0, "deferred composite must be dropped: %s", sql)
+	require.GreaterOrEqual(t, enumIdx, 0, "enum in dropped schema must be dropped: %s", sql)
+	require.GreaterOrEqual(t, schemaIdx, 0, "schema must be dropped: %s", sql)
+	require.Greater(t, enumIdx, compositeIdx,
+		"enum referenced by the deferred composite must drop after it, even inside a schema drop: %s", sql)
+}
+
+func TestPGMetadataDiffDeferredSchemaCompositeDefersReferencedEnumDrop(t *testing.T) {
+	// Schema s is deferred (public.t.c retyped away from s.addr); s.addr
+	// references public.status, a top-level dropped enum, which therefore
+	// must also defer until after the schema drop removes s.addr.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "s.addr", Nullable: true},
+						},
+					},
+				},
+				EnumTypes: []*storepb.EnumTypeMetadata{
+					{Name: "status", Values: []string{"a"}},
+				},
+			},
+			{
+				Name: "s",
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "st", Type: "public.status"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "text", Nullable: true},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	retypeIdx := strings.Index(sql, `ALTER COLUMN "c"`)
+	schemaCompositeIdx := strings.Index(sql, `DROP TYPE "s"."addr"`)
+	enumIdx := strings.Index(sql, `DROP TYPE "public"."status"`)
+	require.GreaterOrEqual(t, retypeIdx, 0, "column must be retyped: %s", sql)
+	require.GreaterOrEqual(t, schemaCompositeIdx, 0, "deferred schema's composite must be dropped: %s", sql)
+	require.GreaterOrEqual(t, enumIdx, 0, "enum must be dropped: %s", sql)
+	require.Greater(t, schemaCompositeIdx, retypeIdx, "schema-owned composite drop must follow the retype: %s", sql)
+	require.Greater(t, enumIdx, schemaCompositeIdx,
+		"enum referenced from the deferred schema's composite must drop last: %s", sql)
+}
+
+func TestPGMetadataDiffCyclicDeferredSchemaDropsGlobalizeTypeDrops(t *testing.T) {
+	// Schemas a and b reference each other: a.ca uses b.eb, b.cb uses a.ea.
+	// Both are deferred (a column retype releases a.ca). Globalized type
+	// drops must remove both composites before either enum, regardless of
+	// the schema-level cycle.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "a.ca", Nullable: true},
+						},
+					},
+				},
+			},
+			{
+				Name: "a",
+				EnumTypes: []*storepb.EnumTypeMetadata{
+					{Name: "ea", Values: []string{"x"}},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "ca",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "v", Type: "b.eb"},
+						},
+					},
+				},
+			},
+			{
+				Name: "b",
+				EnumTypes: []*storepb.EnumTypeMetadata{
+					{Name: "eb", Values: []string{"y"}},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "cb",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "v", Type: "a.ea"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "text", Nullable: true},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	caIdx := strings.Index(sql, `DROP TYPE "a"."ca"`)
+	cbIdx := strings.Index(sql, `DROP TYPE "b"."cb"`)
+	eaIdx := strings.Index(sql, `DROP TYPE "a"."ea"`)
+	ebIdx := strings.Index(sql, `DROP TYPE "b"."eb"`)
+	require.GreaterOrEqual(t, caIdx, 0, "a.ca must be dropped: %s", sql)
+	require.GreaterOrEqual(t, cbIdx, 0, "b.cb must be dropped: %s", sql)
+	require.GreaterOrEqual(t, eaIdx, 0, "a.ea must be dropped: %s", sql)
+	require.GreaterOrEqual(t, ebIdx, 0, "b.eb must be dropped: %s", sql)
+	require.Greater(t, eaIdx, cbIdx, "a.ea must drop after b.cb which references it: %s", sql)
+	require.Greater(t, ebIdx, caIdx, "b.eb must drop after a.ca which references it: %s", sql)
+	dropSchemaAIdx := strings.Index(sql, `DROP SCHEMA IF EXISTS "a"`)
+	dropSchemaBIdx := strings.Index(sql, `DROP SCHEMA IF EXISTS "b"`)
+	require.Greater(t, dropSchemaAIdx, eaIdx, "DROP SCHEMA a must come after its types: %s", sql)
+	require.Greater(t, dropSchemaBIdx, ebIdx, "DROP SCHEMA b must come after its types: %s", sql)
+}
+
+func TestPGMetadataDiffImmediateSchemaDropOrdersTypesGlobally(t *testing.T) {
+	// Dropping schema s (whose composite references top-level types) together
+	// with those top-level types: s.child must drop before public.base and
+	// public.status regardless of the schema-drop boundary.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				EnumTypes: []*storepb.EnumTypeMetadata{
+					{Name: "status", Values: []string{"a"}},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "base",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "x", Type: "integer"},
+						},
+					},
+				},
+			},
+			{
+				Name: "s",
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "child",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "b", Type: "public.base"},
+							{Name: "st", Type: "public.status"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "public"},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	childIdx := strings.Index(sql, `DROP TYPE "s"."child"`)
+	baseIdx := strings.Index(sql, `DROP TYPE "public"."base"`)
+	statusIdx := strings.Index(sql, `DROP TYPE "public"."status"`)
+	schemaIdx := strings.Index(sql, `DROP SCHEMA IF EXISTS "s"`)
+	require.GreaterOrEqual(t, childIdx, 0, "schema-owned composite must be dropped: %s", sql)
+	require.GreaterOrEqual(t, baseIdx, 0)
+	require.GreaterOrEqual(t, statusIdx, 0)
+	require.GreaterOrEqual(t, schemaIdx, 0)
+	require.Less(t, childIdx, baseIdx, "dependent s.child must drop before public.base: %s", sql)
+	require.Less(t, childIdx, statusIdx, "dependent s.child must drop before public.status: %s", sql)
+	require.Greater(t, schemaIdx, childIdx, "DROP SCHEMA must come after its composite drop: %s", sql)
+}
+
+func TestPGMetadataDiffCompositeCreateWaitsForTableRowType(t *testing.T) {
+	// Creating table t and composites c1(public.t) and c2(c1): both
+	// composites must be created after the table.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "public"},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c1",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "r", Type: "public.t"},
+						},
+					},
+					{
+						Name: "c2",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "w", Type: "public.c1"},
+						},
+					},
+					{
+						Name: "plain",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "x", Type: "integer"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	tableIdx := strings.Index(sql, `CREATE TABLE "public"."t"`)
+	c1Idx := strings.Index(sql, `CREATE TYPE "public"."c1"`)
+	c2Idx := strings.Index(sql, `CREATE TYPE "public"."c2"`)
+	plainIdx := strings.Index(sql, `CREATE TYPE "public"."plain"`)
+	require.GreaterOrEqual(t, tableIdx, 0, "table must be created: %s", sql)
+	require.GreaterOrEqual(t, c1Idx, 0)
+	require.GreaterOrEqual(t, c2Idx, 0)
+	require.GreaterOrEqual(t, plainIdx, 0)
+	require.Greater(t, c1Idx, tableIdx, "composite using the table row type must be created after the table: %s", sql)
+	require.Greater(t, c2Idx, c1Idx, "dependent of a post-table composite must follow it: %s", sql)
+	require.Less(t, plainIdx, tableIdx, "independent composite stays before tables: %s", sql)
+}
+
+func TestPGMetadataDiffDeferredCompositeDefersItsCompositeDependency(t *testing.T) {
+	// child(public.base) is deferred by a column retype; base, also dropped,
+	// must defer too so it drops after child.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "public.child", Nullable: true},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "base",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "x", Type: "integer"},
+						},
+					},
+					{
+						Name: "child",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "b", Type: "public.base"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "text", Nullable: true},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	retypeIdx := strings.Index(sql, `ALTER COLUMN "c"`)
+	childIdx := strings.Index(sql, `DROP TYPE "public"."child"`)
+	baseIdx := strings.Index(sql, `DROP TYPE "public"."base"`)
+	require.GreaterOrEqual(t, retypeIdx, 0)
+	require.GreaterOrEqual(t, childIdx, 0)
+	require.GreaterOrEqual(t, baseIdx, 0)
+	require.Greater(t, childIdx, retypeIdx, "deferred child drops after the retype: %s", sql)
+	require.Greater(t, baseIdx, childIdx, "base referenced by deferred child must defer and drop after it: %s", sql)
+}
+
+func TestPGMetadataDiffRowTypeCompositeDropsBeforeTable(t *testing.T) {
+	// Dropping table t and composite c(r public.t): the composite must drop
+	// before the table whose row type it references.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "r", Type: "public.t"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "public"},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	typeIdx := strings.Index(sql, `DROP TYPE "public"."c"`)
+	tableIdx := strings.Index(sql, `DROP TABLE "public"."t"`)
+	require.GreaterOrEqual(t, typeIdx, 0, "composite must be dropped: %s", sql)
+	require.GreaterOrEqual(t, tableIdx, 0, "table must be dropped: %s", sql)
+	require.Less(t, typeIdx, tableIdx, "row-type-referencing composite must drop before the table: %s", sql)
+}
+
+func TestPGMetadataDiffCompositeAlterWaitsForNewTableRowType(t *testing.T) {
+	// Existing composite gains an attribute typed with a row type of a table
+	// created in the same migration; the alter must follow CREATE TABLE.
+	source := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "c",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "x", Type: "integer"},
+			},
+		},
+	})
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "x", Type: "integer"},
+							{Name: "r", Type: "public.t"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	tableIdx := strings.Index(sql, `CREATE TABLE "public"."t"`)
+	alterIdx := strings.Index(sql, `ALTER TYPE "public"."c" ADD ATTRIBUTE "r" public.t;`)
+	require.GreaterOrEqual(t, tableIdx, 0, "table must be created: %s", sql)
+	require.GreaterOrEqual(t, alterIdx, 0, "attribute must be added: %s", sql)
+	require.Greater(t, alterIdx, tableIdx, "composite alter must follow the table creation it references: %s", sql)
+}
+
+func TestPGMetadataDiffCreateSandwichTableCompositeTable(t *testing.T) {
+	// r (row-type provider) -> c (composite using r) -> holder (table using c):
+	// creation order must interleave through the shared graph.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{{Name: "public"}},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "r",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+					{
+						Name: "holder",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "x", Type: "public.c", Nullable: true},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "row", Type: "public.r"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	rIdx := strings.Index(sql, `CREATE TABLE "public"."r"`)
+	cIdx := strings.Index(sql, `CREATE TYPE "public"."c"`)
+	holderIdx := strings.Index(sql, `CREATE TABLE "public"."holder"`)
+	require.GreaterOrEqual(t, rIdx, 0)
+	require.GreaterOrEqual(t, cIdx, 0)
+	require.GreaterOrEqual(t, holderIdx, 0)
+	require.Greater(t, cIdx, rIdx, "composite must follow its row-type provider table: %s", sql)
+	require.Greater(t, holderIdx, cIdx, "consumer table must follow the composite: %s", sql)
+}
+
+func TestPGMetadataDiffDropSandwichTableCompositeTable(t *testing.T) {
+	// holder (table using c) -> c (composite using r) -> r: drop order must
+	// interleave through the shared graph.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "r",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+					{
+						Name: "holder",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "x", Type: "public.c", Nullable: true},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "row", Type: "public.r"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{{Name: "public"}},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	holderIdx := strings.Index(sql, `DROP TABLE "public"."holder"`)
+	cIdx := strings.Index(sql, `DROP TYPE "public"."c"`)
+	rIdx := strings.Index(sql, `DROP TABLE "public"."r"`)
+	require.GreaterOrEqual(t, holderIdx, 0)
+	require.GreaterOrEqual(t, cIdx, 0)
+	require.GreaterOrEqual(t, rIdx, 0)
+	require.Less(t, holderIdx, cIdx, "table using the composite must drop before it: %s", sql)
+	require.Less(t, cIdx, rIdx, "composite must drop before its row-type provider table: %s", sql)
+}
+
+func TestPGMetadataDiffDeferredSchemaCompositeDefersTopLevelDependency(t *testing.T) {
+	// Schema s is deferred (retype releases s.child); s.child references
+	// top-level dropped public.base, which must defer too.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "s.child", Nullable: true},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "base",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "x", Type: "integer"},
+						},
+					},
+				},
+			},
+			{
+				Name: "s",
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "child",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "b", Type: "public.base"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "c", Type: "text", Nullable: true},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	retypeIdx := strings.Index(sql, `ALTER COLUMN "c"`)
+	childIdx := strings.Index(sql, `DROP TYPE "s"."child"`)
+	baseIdx := strings.Index(sql, `DROP TYPE "public"."base"`)
+	require.GreaterOrEqual(t, retypeIdx, 0)
+	require.GreaterOrEqual(t, childIdx, 0)
+	require.GreaterOrEqual(t, baseIdx, 0)
+	require.Greater(t, childIdx, retypeIdx, "deferred schema composite drops after the retype: %s", sql)
+	require.Greater(t, baseIdx, childIdx, "top-level base referenced by the deferred schema composite must defer and drop after it: %s", sql)
+}
+
+func TestPGMetadataDiffCompositeDropDeferredAfterColumnDrop(t *testing.T) {
+	// Dropping the only column using a composite (on a surviving table)
+	// releases it in writeDropAlterTableObjects; the composite drop must
+	// defer past that.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+							{Name: "c", Type: "public.addr", Nullable: true},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "street", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	columnDropIdx := strings.Index(sql, `DROP COLUMN "c"`)
+	typeDropIdx := strings.Index(sql, `DROP TYPE "public"."addr"`)
+	require.GreaterOrEqual(t, columnDropIdx, 0, "column must be dropped: %s", sql)
+	require.GreaterOrEqual(t, typeDropIdx, 0, "composite must be dropped: %s", sql)
+	require.Greater(t, typeDropIdx, columnDropIdx,
+		"composite drop must follow the column drop that releases it: %s", sql)
+}
+
+func TestPGMetadataDiffReleasingCompositeAlterPrecedesTableDrop(t *testing.T) {
+	// Retyping c.r away from public.t's row type releases the dropped table;
+	// the releasing ALTER must precede DROP TABLE.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "r", Type: "public.t"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "r", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	alterIdx := strings.Index(sql, `ALTER TYPE "public"."c" ALTER ATTRIBUTE "r" TYPE text;`)
+	dropIdx := strings.Index(sql, `DROP TABLE "public"."t"`)
+	require.GreaterOrEqual(t, alterIdx, 0, "releasing alter must be emitted: %s", sql)
+	require.GreaterOrEqual(t, dropIdx, 0, "table must be dropped: %s", sql)
+	require.Less(t, alterIdx, dropIdx, "releasing alter must precede the table drop: %s", sql)
+	require.Equal(t, strings.Count(sql, `ALTER ATTRIBUTE "r"`), 1, "releasing alter must not be emitted twice: %s", sql)
+}
+
+func TestPGMetadataDiffCompositeArrayColumnOrdersCreate(t *testing.T) {
+	// Column sync renders composite-array columns as the bare "_name" form;
+	// the create graph must still order the composite first. zz table name
+	// sorts after the composite to defeat accidental ordering.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{{Name: "public"}},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "aa_holder",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "xs", Type: "_zz_addr", Nullable: true},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "zz_addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "street", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	typeIdx := strings.Index(sql, `CREATE TYPE "public"."zz_addr"`)
+	tableIdx := strings.Index(sql, `CREATE TABLE "public"."aa_holder"`)
+	require.GreaterOrEqual(t, typeIdx, 0)
+	require.GreaterOrEqual(t, tableIdx, 0)
+	require.Less(t, typeIdx, tableIdx, "array-typed column must order the composite before the table: %s", sql)
+}
+
+func TestPGMetadataDiffSchemaDropEmitsCompositeDropOnce(t *testing.T) {
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "public"},
+			{
+				Name: "s",
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "street", Type: "text"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{{Name: "public"}},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Equal(t, 1, strings.Count(sql, `DROP TYPE "s"."addr";`),
+		"schema-owned composite must drop exactly once: %s", sql)
+}
+
+func TestPGMetadataDiffReleasingRetypeToCreatedTableSplitsDropReadd(t *testing.T) {
+	// c.r moves from dropped old_t's row type to created new_t's row type:
+	// the drop phase removes the attribute, the create phase re-adds it
+	// after the new table exists.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "old_t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "r", Type: "public.old_t"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "new_t",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "r", Type: "public.new_t"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	dropAttrIdx := strings.Index(sql, `ALTER TYPE "public"."c" DROP ATTRIBUTE "r";`)
+	dropTableIdx := strings.Index(sql, `DROP TABLE "public"."old_t"`)
+	createTableIdx := strings.Index(sql, `CREATE TABLE "public"."new_t"`)
+	addAttrIdx := strings.Index(sql, `ALTER TYPE "public"."c" ADD ATTRIBUTE "r" public.new_t;`)
+	require.GreaterOrEqual(t, dropAttrIdx, 0, "releasing drop must be emitted: %s", sql)
+	require.GreaterOrEqual(t, dropTableIdx, 0)
+	require.GreaterOrEqual(t, createTableIdx, 0)
+	require.GreaterOrEqual(t, addAttrIdx, 0, "attribute must be re-added: %s", sql)
+	require.Less(t, dropAttrIdx, dropTableIdx, "attribute drop must precede the table drop: %s", sql)
+	require.Greater(t, addAttrIdx, createTableIdx, "re-add must follow the new table: %s", sql)
+	require.NotContains(t, sql, `ALTER ATTRIBUTE "r"`, "no premature retype may be emitted: %s", sql)
+}
+
+func TestPGMetadataDiffCompositeCreateWaitsForViewRowType(t *testing.T) {
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{{Name: "public"}},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Views: []*storepb.ViewMetadata{
+					{Name: "v", Definition: "SELECT 1 AS a"},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "row", Type: "public.v"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	viewIdx := strings.Index(sql, `VIEW "public"."v"`)
+	typeIdx := strings.Index(sql, `CREATE TYPE "public"."c"`)
+	require.GreaterOrEqual(t, viewIdx, 0, "view must be created: %s", sql)
+	require.GreaterOrEqual(t, typeIdx, 0, "composite must be created: %s", sql)
+	require.Greater(t, typeIdx, viewIdx, "composite using a view row type must follow the view: %s", sql)
+}
+
+func TestPGMetadataDiffCompositeDropReleasedByCompositeAlterDefers(t *testing.T) {
+	// parent's alter (child -> text) releases dropped child only in the
+	// create phase, so child's drop must defer past it.
+	source := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "child",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "x", Type: "integer"},
+			},
+		},
+		{
+			Name: "parent",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "c", Type: "public.child"},
+			},
+		},
+	})
+	target := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "parent",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "c", Type: "text"},
+			},
+		},
+	})
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	alterIdx := strings.Index(sql, `ALTER TYPE "public"."parent" ALTER ATTRIBUTE "c" TYPE text;`)
+	dropIdx := strings.Index(sql, `DROP TYPE "public"."child"`)
+	require.GreaterOrEqual(t, alterIdx, 0, "releasing alter must be emitted: %s", sql)
+	require.GreaterOrEqual(t, dropIdx, 0, "child must be dropped: %s", sql)
+	require.Greater(t, dropIdx, alterIdx, "child drop must follow the alter that releases it: %s", sql)
+}
+
+func TestPGMetadataDiffEnumDropReleasedByCompositeAlterDefers(t *testing.T) {
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				EnumTypes: []*storepb.EnumTypeMetadata{
+					{Name: "status", Values: []string{"a"}},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "addr",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "s", Type: "public.status"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "addr",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "s", Type: "text"},
+			},
+		},
+	})
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	alterIdx := strings.Index(sql, `ALTER TYPE "public"."addr" ALTER ATTRIBUTE "s" TYPE text;`)
+	dropIdx := strings.Index(sql, `DROP TYPE "public"."status"`)
+	require.GreaterOrEqual(t, alterIdx, 0, "releasing alter must be emitted: %s", sql)
+	require.GreaterOrEqual(t, dropIdx, 0, "enum must be dropped: %s", sql)
+	require.Greater(t, dropIdx, alterIdx, "enum drop must follow the alter that releases it: %s", sql)
+}
+
+func TestPGMetadataDiffReleasingAlterPrecedesViewDrop(t *testing.T) {
+	// c.row moves off dropped view v's row type; the early alter must
+	// precede DROP VIEW.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Views: []*storepb.ViewMetadata{
+					{Name: "v", Definition: "SELECT 1 AS a"},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "row", Type: "public.v"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "c",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "row", Type: "text"},
+			},
+		},
+	})
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	alterIdx := strings.Index(sql, `ALTER TYPE "public"."c" ALTER ATTRIBUTE "row" TYPE text;`)
+	dropViewIdx := strings.Index(sql, `DROP VIEW "public"."v"`)
+	require.GreaterOrEqual(t, alterIdx, 0, "releasing alter must be emitted: %s", sql)
+	require.GreaterOrEqual(t, dropViewIdx, 0, "view must be dropped: %s", sql)
+	require.Less(t, alterIdx, dropViewIdx, "releasing alter must precede the view drop: %s", sql)
+}
+
+func TestPGMetadataDiffCompositeAlterWaitsForCreatedViewRowType(t *testing.T) {
+	source := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name: "c",
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "x", Type: "integer"},
+			},
+		},
+	})
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Views: []*storepb.ViewMetadata{
+					{Name: "v", Definition: "SELECT 1 AS a"},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "x", Type: "integer"},
+							{Name: "row", Type: "public.v"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	viewIdx := strings.Index(sql, `VIEW "public"."v"`)
+	alterIdx := strings.Index(sql, `ALTER TYPE "public"."c" ADD ATTRIBUTE "row" public.v;`)
+	require.GreaterOrEqual(t, viewIdx, 0, "view must be created: %s", sql)
+	require.GreaterOrEqual(t, alterIdx, 0, "attribute must be added: %s", sql)
+	require.Greater(t, alterIdx, viewIdx, "alter gaining the view row type must follow the view: %s", sql)
+}
+
+func TestPGMetadataDiffCompositeDropPrecedesReferencedViewDrop(t *testing.T) {
+	// Dropping both c(row public.v) and v: the composite must drop first
+	// despite the blanket views-before-composites edges.
+	source := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Views: []*storepb.ViewMetadata{
+					{Name: "v", Definition: "SELECT 1 AS a"},
+				},
+				CompositeTypes: []*storepb.CompositeTypeMetadata{
+					{
+						Name: "c",
+						Attributes: []*storepb.CompositeTypeAttribute{
+							{Name: "row", Type: "public.v"},
+						},
+					},
+				},
+			},
+		},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+	target := model.NewDatabaseMetadata(&storepb.DatabaseSchemaMetadata{
+		Schemas: []*storepb.SchemaMetadata{{Name: "public"}},
+	}, nil, nil, storepb.Engine_POSTGRES, true)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	typeIdx := strings.Index(sql, `DROP TYPE "public"."c"`)
+	viewIdx := strings.Index(sql, `DROP VIEW "public"."v"`)
+	require.GreaterOrEqual(t, typeIdx, 0, "composite must be dropped: %s", sql)
+	require.GreaterOrEqual(t, viewIdx, 0, "view must be dropped: %s", sql)
+	require.Less(t, typeIdx, viewIdx, "composite must drop before the view whose row type it references: %s", sql)
+}
+
+func TestFilterPostgresArchiveSchemaKeepsCompositeTypes(t *testing.T) {
+	diff := &schema.MetadataDiff{
+		CompositeTypeChanges: []*schema.CompositeTypeDiff{
+			{Action: schema.MetadataDiffActionCreate, SchemaName: "public", CompositeTypeName: "addr"},
+			{Action: schema.MetadataDiffActionCreate, SchemaName: "bbdataarchive", CompositeTypeName: "archived"},
+		},
+	}
+
+	filtered := schema.FilterPostgresArchiveSchema(diff)
+
+	require.Len(t, filtered.CompositeTypeChanges, 1)
+	require.Equal(t, "public", filtered.CompositeTypeChanges[0].SchemaName)
+}
+
+func TestPGMetadataDiffSkipDumpCompositeTypesIgnored(t *testing.T) {
+	source := newPGDatabaseMetadataWithCompositeTypes([]*storepb.CompositeTypeMetadata{
+		{
+			Name:     "ext_owned",
+			SkipDump: true,
+			Attributes: []*storepb.CompositeTypeAttribute{
+				{Name: "x", Type: "integer"},
+			},
+		},
+	})
+	target := newPGDatabaseMetadataWithCompositeTypes(nil)
+
+	sql, err := schema.DiffMigration(storepb.Engine_POSTGRES, source, target)
+
+	require.NoError(t, err)
+	require.Empty(t, sql, "skip_dump composite types must not be diffed")
+}

--- a/backend/plugin/schema/pg/metadata_migration.go
+++ b/backend/plugin/schema/pg/metadata_migration.go
@@ -51,6 +51,7 @@ func metadataDiffEmpty(diff *schema.MetadataDiff) bool {
 			len(diff.ProcedureChanges) == 0 &&
 			len(diff.SequenceChanges) == 0 &&
 			len(diff.EnumTypeChanges) == 0 &&
+			len(diff.CompositeTypeChanges) == 0 &&
 			len(diff.ExtensionChanges) == 0 &&
 			len(diff.EventTriggerChanges) == 0 &&
 			len(diff.EventChanges) == 0 &&
@@ -203,7 +204,476 @@ func pgGenerateMetadataMigration(diff *schema.MetadataDiff) (string, error) {
 	if err := writeCreateOrAlterPhase(&buf, diff); err != nil {
 		return "", err
 	}
+	if err := writeDeferredDropPhase(&buf, diff); err != nil {
+		return "", err
+	}
 	return buf.String(), nil
+}
+
+// postViewCompositeCreates selects created composites whose attributes
+// reference a created view or materialized view row type, expanded over
+// composite-to-composite references, for emission after the views phase.
+func postViewCompositeCreates(diff *schema.MetadataDiff) map[*schema.CompositeTypeDiff]bool {
+	createdViews := make(map[string]bool)
+	for _, viewDiff := range diff.ViewChanges {
+		if viewDiff.Action == schema.MetadataDiffActionCreate {
+			createdViews[viewDiff.SchemaName+"\x00"+viewDiff.ViewName] = true
+		}
+	}
+	for _, viewDiff := range diff.MaterializedViewChanges {
+		if viewDiff.Action == schema.MetadataDiffActionCreate {
+			createdViews[viewDiff.SchemaName+"\x00"+viewDiff.MaterializedViewName] = true
+		}
+	}
+	post := make(map[*schema.CompositeTypeDiff]bool)
+	if len(createdViews) == 0 {
+		return post
+	}
+	postKeys := make(map[string]bool)
+	for changed := true; changed; {
+		changed = false
+		for _, compositeDiff := range diff.CompositeTypeChanges {
+			if compositeDiff.Action != schema.MetadataDiffActionCreate || post[compositeDiff] {
+				continue
+			}
+			for _, attribute := range compositeDiff.NewCompositeType.GetAttributes() {
+				depSchema, depName, ok := parseQualifiedTypeIdent(attribute.Type)
+				if !ok {
+					continue
+				}
+				depKey := depSchema + "\x00" + depName
+				if createdViews[depKey] || postKeys[depKey] {
+					post[compositeDiff] = true
+					postKeys[compositeDiff.SchemaName+"\x00"+compositeDiff.CompositeTypeName] = true
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	return post
+}
+
+// postViewCompositeAlters selects altered composites whose added or retyped
+// attributes reference a created view or materialized view row type; their
+// alter statements run after the views phase.
+func postViewCompositeAlters(diff *schema.MetadataDiff) map[*schema.CompositeTypeDiff]bool {
+	createdViews := make(map[string]bool)
+	for _, viewDiff := range diff.ViewChanges {
+		if viewDiff.Action == schema.MetadataDiffActionCreate {
+			createdViews[viewDiff.SchemaName+"\x00"+viewDiff.ViewName] = true
+		}
+	}
+	for _, viewDiff := range diff.MaterializedViewChanges {
+		if viewDiff.Action == schema.MetadataDiffActionCreate {
+			createdViews[viewDiff.SchemaName+"\x00"+viewDiff.MaterializedViewName] = true
+		}
+	}
+	post := make(map[*schema.CompositeTypeDiff]bool)
+	if len(createdViews) == 0 {
+		return post
+	}
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action != schema.MetadataDiffActionAlter {
+			continue
+		}
+		oldAttributes := make(map[string]*storepb.CompositeTypeAttribute)
+		for _, attribute := range compositeDiff.OldCompositeType.GetAttributes() {
+			oldAttributes[attribute.Name] = attribute
+		}
+		for _, newAttribute := range compositeDiff.NewCompositeType.GetAttributes() {
+			oldAttribute := oldAttributes[newAttribute.Name]
+			if oldAttribute != nil && oldAttribute.Type == newAttribute.Type {
+				continue
+			}
+			if depSchema, depName, ok := parseQualifiedTypeIdent(newAttribute.Type); ok && createdViews[depSchema+"\x00"+depName] {
+				post[compositeDiff] = true
+				break
+			}
+		}
+	}
+	return post
+}
+
+// deferredDropSet resolves which drops must wait until the alter phase has
+// released the last reference.
+type deferredDropSet struct {
+	composites []*schema.CompositeTypeDiff
+	enums      map[*schema.EnumTypeDiff]bool
+	schemas    map[*schema.SchemaDiff]bool
+}
+
+// computeDeferredDrops seeds the set with composites released by a column
+// retype and schemas owning such composites, then expands to a fixpoint: a
+// dropped schema is also deferred when any pooled deferred composite
+// references a type inside it, and every deferred schema contributes its own
+// composites to the pool. Finally, dropped enums referenced by any pooled
+// composite are deferred.
+func computeDeferredDrops(diff *schema.MetadataDiff) *deferredDropSet {
+	deferred := &deferredDropSet{
+		enums:   make(map[*schema.EnumTypeDiff]bool),
+		schemas: make(map[*schema.SchemaDiff]bool),
+	}
+	var topLevelDrops []*schema.CompositeTypeDiff
+	deferredComposites := make(map[*schema.CompositeTypeDiff]bool)
+	var pool []*storepb.CompositeTypeMetadata
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action != schema.MetadataDiffActionDrop {
+			continue
+		}
+		topLevelDrops = append(topLevelDrops, compositeDiff)
+		if compositeDropReleasedByRetype(diff, compositeDiff) {
+			deferredComposites[compositeDiff] = true
+			pool = append(pool, compositeDiff.OldCompositeType)
+		}
+	}
+
+	// Combined fixpoint: pooled composites pull in (a) top-level dropped
+	// composites they reference and (b) dropped schemas containing types
+	// they reference; every newly deferred schema contributes its own
+	// composites to the pool.
+	for changed := true; changed; {
+		changed = false
+		for _, candidate := range topLevelDrops {
+			if deferredComposites[candidate] {
+				continue
+			}
+			for _, member := range pool {
+				if compositeReferencesType(member, candidate.SchemaName, candidate.CompositeTypeName) {
+					deferredComposites[candidate] = true
+					pool = append(pool, candidate.OldCompositeType)
+					changed = true
+					break
+				}
+			}
+		}
+		for _, schemaDiff := range diff.SchemaChanges {
+			if schemaDiff.Action != schema.MetadataDiffActionDrop || deferred.schemas[schemaDiff] {
+				continue
+			}
+			if !schemaOwnsRetypeReleasedComposite(diff, schemaDiff) && !compositePoolReferencesSchema(pool, schemaDiff.SchemaName) {
+				continue
+			}
+			deferred.schemas[schemaDiff] = true
+			for _, compositeType := range schemaDiff.OldSchema.GetCompositeTypes() {
+				if !compositeType.GetSkipDump() {
+					pool = append(pool, compositeType)
+				}
+			}
+			changed = true
+		}
+	}
+	for _, compositeDiff := range topLevelDrops {
+		if deferredComposites[compositeDiff] {
+			deferred.composites = append(deferred.composites, compositeDiff)
+		}
+	}
+
+	for _, enumDiff := range diff.EnumTypeChanges {
+		if enumDiff.Action != schema.MetadataDiffActionDrop {
+			continue
+		}
+		if typeReleasedByCompositeAlter(diff, enumDiff.SchemaName, enumDiff.EnumTypeName) {
+			deferred.enums[enumDiff] = true
+			continue
+		}
+		for _, compositeType := range pool {
+			if compositeReferencesType(compositeType, enumDiff.SchemaName, enumDiff.EnumTypeName) {
+				deferred.enums[enumDiff] = true
+				break
+			}
+		}
+	}
+	return deferred
+}
+
+// writeDeferredDropPhase emits the deferred drops after the alter phase.
+// Type drops are globalized across schema boundaries so cross-schema (even
+// cyclic) references between deferred schemas cannot produce an invalid
+// order: first the deferred schemas' non-type objects, then every deferred
+// composite (top-level and schema-owned) in one reverse-dependency pass,
+// then every deferred enum — nothing references an enum by that point —
+// and finally the bare DROP SCHEMA statements.
+func writeDeferredDropPhase(out *strings.Builder, diff *schema.MetadataDiff) error {
+	deferred := computeDeferredDrops(diff)
+
+	deferredSchemas := make([]*schema.SchemaDiff, 0, len(deferred.schemas))
+	for _, schemaDiff := range diff.SchemaChanges {
+		if schemaDiff.Action == schema.MetadataDiffActionDrop && deferred.schemas[schemaDiff] {
+			deferredSchemas = append(deferredSchemas, schemaDiff)
+		}
+	}
+	slices.SortStableFunc(deferredSchemas, func(a, b *schema.SchemaDiff) int {
+		return strings.Compare(a.SchemaName, b.SchemaName)
+	})
+
+	for _, schemaDiff := range deferredSchemas {
+		if skipPostgresSchemaDDL(schemaDiff.SchemaName) {
+			continue
+		}
+		if err := writeDropSchemaNonTypeObjects(out, schemaDiff.SchemaName, schemaDiff.OldSchema); err != nil {
+			return err
+		}
+	}
+
+	compositeDrops := slices.Clone(deferred.composites)
+	for _, schemaDiff := range deferredSchemas {
+		if skipPostgresSchemaDDL(schemaDiff.SchemaName) {
+			continue
+		}
+		schemaObjects := buildDropSchemaObjectsDiff(schemaDiff.SchemaName, schemaDiff.OldSchema)
+		compositeDrops = append(compositeDrops, schemaObjects.CompositeTypeChanges...)
+	}
+	if err := writeCompositeTypeDropsInReverseDependencyOrder(out, compositeDrops); err != nil {
+		return err
+	}
+
+	for _, enumDiff := range diff.EnumTypeChanges {
+		if enumDiff.Action == schema.MetadataDiffActionDrop && deferred.enums[enumDiff] {
+			if err := writeEnumTypeDiff(out, enumDiff); err != nil {
+				return err
+			}
+		}
+	}
+	for _, schemaDiff := range deferredSchemas {
+		if skipPostgresSchemaDDL(schemaDiff.SchemaName) {
+			continue
+		}
+		schemaObjects := buildDropSchemaObjectsDiff(schemaDiff.SchemaName, schemaDiff.OldSchema)
+		for _, enumDiff := range schemaObjects.EnumTypeChanges {
+			if err := writeEnumTypeDiff(out, enumDiff); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, schemaDiff := range deferredSchemas {
+		if skipPostgresSchemaDDL(schemaDiff.SchemaName) {
+			continue
+		}
+		if _, err := fmt.Fprintf(out, "DROP SCHEMA IF EXISTS \"%s\";\n\n", schemaDiff.SchemaName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// compositePoolReferencesSchema reports whether any composite in the pool has
+// an attribute whose (always schema-qualified) type lives in the schema.
+func compositePoolReferencesSchema(pool []*storepb.CompositeTypeMetadata, schemaName string) bool {
+	for _, compositeType := range pool {
+		for _, attribute := range compositeType.GetAttributes() {
+			if depSchema, _, ok := parseQualifiedTypeIdent(attribute.Type); ok && depSchema == schemaName {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// schemaOwnsRetypeReleasedComposite reports whether the dropped schema owns a
+// composite that a column retype in the alter phase releases.
+func schemaOwnsRetypeReleasedComposite(diff *schema.MetadataDiff, schemaDiff *schema.SchemaDiff) bool {
+	for _, compositeType := range schemaDiff.OldSchema.GetCompositeTypes() {
+		if compositeType.GetSkipDump() {
+			continue
+		}
+		probe := &schema.CompositeTypeDiff{
+			SchemaName:        schemaDiff.SchemaName,
+			CompositeTypeName: compositeType.GetName(),
+		}
+		if compositeDropReleasedByRetype(diff, probe) {
+			return true
+		}
+	}
+	return false
+}
+
+// compositeReferencesType reports whether any attribute of the composite
+// references the given type. Attribute types are stored schema-qualified for
+// user-defined types; the bare fallback matches by name alone, which may
+// defer a drop unnecessarily — a safe direction.
+func compositeReferencesType(composite *storepb.CompositeTypeMetadata, typeSchema, typeName string) bool {
+	for _, attribute := range composite.GetAttributes() {
+		if typeStringReferencesComposite(attribute.Type, typeSchema, typeName) {
+			return true
+		}
+	}
+	return false
+}
+
+// partitionDroppedCompositeTypes splits composite type drops into those safe
+// to run in the drop phase and those that must wait until after the alter
+// phase because a column retype releases the last reference to the type.
+// immediateCompositeDrops returns the top-level composite drops that run in
+// the drop phase — everything not claimed by the deferred set.
+func immediateCompositeDrops(diff *schema.MetadataDiff, deferred *deferredDropSet) []*schema.CompositeTypeDiff {
+	deferredSet := make(map[*schema.CompositeTypeDiff]bool, len(deferred.composites))
+	for _, compositeDiff := range deferred.composites {
+		deferredSet[compositeDiff] = true
+	}
+	var immediate []*schema.CompositeTypeDiff
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action == schema.MetadataDiffActionDrop && !deferredSet[compositeDiff] {
+			immediate = append(immediate, compositeDiff)
+		}
+	}
+	return immediate
+}
+
+// dropGraphComposites splits the immediate top-level composite drops into
+// those ordered inside the dependent-object graph and those held back to the
+// post-graph batch because a schema-owned composite (which only drops after
+// the graph) references them, directly or transitively. A composite that is
+// both held back and a row-type referencer of a dropped table has genuinely
+// conflicting constraints; resolving that requires schema-owned objects in
+// the same graph.
+func dropGraphComposites(diff *schema.MetadataDiff) (map[string]*schema.CompositeTypeDiff, []*schema.CompositeTypeDiff) {
+	immediate := immediateCompositeDrops(diff, computeDeferredDrops(diff))
+	var pool []*storepb.CompositeTypeMetadata
+	for _, schemaDiff := range diff.SchemaChanges {
+		if schemaDiff.Action != schema.MetadataDiffActionDrop || skipPostgresSchemaDDL(schemaDiff.SchemaName) {
+			continue
+		}
+		for _, compositeType := range schemaDiff.OldSchema.GetCompositeTypes() {
+			if !compositeType.GetSkipDump() {
+				pool = append(pool, compositeType)
+			}
+		}
+	}
+	held := make(map[*schema.CompositeTypeDiff]bool)
+	for changed := true; changed; {
+		changed = false
+		for _, candidate := range immediate {
+			if held[candidate] {
+				continue
+			}
+			for _, member := range pool {
+				if compositeReferencesType(member, candidate.SchemaName, candidate.CompositeTypeName) {
+					held[candidate] = true
+					pool = append(pool, candidate.OldCompositeType)
+					changed = true
+					break
+				}
+			}
+		}
+	}
+	inGraph := make(map[string]*schema.CompositeTypeDiff)
+	var heldBack []*schema.CompositeTypeDiff
+	for _, compositeDiff := range immediate {
+		if held[compositeDiff] {
+			heldBack = append(heldBack, compositeDiff)
+		} else {
+			inGraph[getMigrationObjectID(compositeDiff.SchemaName, compositeDiff.CompositeTypeName)] = compositeDiff
+		}
+	}
+	return inGraph, heldBack
+}
+
+// typeReleasedByCompositeAlter reports whether an ALTERED composite's old
+// attributes reference the given type while its new version does not — the
+// release happens only when the create-phase alter runs.
+func typeReleasedByCompositeAlter(diff *schema.MetadataDiff, typeSchema, typeName string) bool {
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action != schema.MetadataDiffActionAlter {
+			continue
+		}
+		for _, oldAttribute := range compositeDiff.OldCompositeType.GetAttributes() {
+			if typeStringReferencesComposite(oldAttribute.Type, typeSchema, typeName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func compositeDropReleasedByRetype(diff *schema.MetadataDiff, compositeDiff *schema.CompositeTypeDiff) bool {
+	if typeReleasedByCompositeAlter(diff, compositeDiff.SchemaName, compositeDiff.CompositeTypeName) {
+		return true
+	}
+	for _, tableDiff := range diff.TableChanges {
+		if tableDiff.Action != schema.MetadataDiffActionAlter {
+			continue
+		}
+		for _, columnDiff := range tableDiff.ColumnChanges {
+			var oldType string
+			switch columnDiff.Action {
+			case schema.MetadataDiffActionAlter:
+				// A retype away from the composite releases it in the alter
+				// phase.
+				oldType = columnDiff.OldColumn.GetType()
+				if oldType == columnDiff.NewColumn.GetType() {
+					continue
+				}
+			case schema.MetadataDiffActionDrop:
+				// A column drop on a surviving table runs in
+				// writeDropAlterTableObjects, after the dependent-object
+				// graph — too late for a graph-ordered type drop.
+				oldType = columnDiff.OldColumn.GetType()
+			default:
+				continue
+			}
+			if typeStringReferencesComposite(oldType, compositeDiff.SchemaName, compositeDiff.CompositeTypeName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// columnTypeCompositeIDs resolves a column type string to candidate
+// composite IDs in the given map. Qualified references resolve exactly;
+// bare references (including the "_name" array form column sync produces)
+// match every same-named composite — over-edging only tightens ordering.
+func columnTypeCompositeIDs(columnType string, composites map[string]*schema.CompositeTypeDiff) []string {
+	if depSchema, depName, ok := parseQualifiedTypeIdent(columnType); ok {
+		id := getMigrationObjectID(depSchema, depName)
+		if composites[id] != nil {
+			return []string{id}
+		}
+		return nil
+	}
+	base := strings.TrimSuffix(strings.TrimSpace(columnType), "[]")
+	base = strings.TrimPrefix(base, "_")
+	var ids []string
+	for id, compositeDiff := range composites {
+		if compositeDiff.CompositeTypeName == base {
+			ids = append(ids, id)
+		}
+	}
+	slices.Sort(ids)
+	return ids
+}
+
+// typeStringReferencesComposite matches a column type string against a
+// composite type. Column sync renders user-defined column types as
+// "schema.name" and array columns as the bare "_name" element type, so both
+// forms plus explicit array suffixes are recognized. The bare form matches
+// by name alone, which may defer a drop unnecessarily — a safe direction.
+func typeStringReferencesComposite(typeStr, schemaName, compositeName string) bool {
+	if depSchema, depName, ok := parseQualifiedTypeIdent(typeStr); ok {
+		return depSchema == schemaName && depName == compositeName
+	}
+	base := strings.TrimSuffix(strings.TrimSpace(typeStr), "[]")
+	base = strings.TrimPrefix(base, "_")
+	return base == compositeName
+}
+
+func writeCompositeTypeDropsInReverseDependencyOrder(out *strings.Builder, drops []*schema.CompositeTypeDiff) error {
+	droppedCompositeDiffs := make(map[string]*schema.CompositeTypeDiff, len(drops))
+	droppedComposites := make([]qualifiedCompositeType, 0, len(drops))
+	for _, compositeDiff := range drops {
+		droppedCompositeDiffs[compositeDiff.SchemaName+"\x00"+compositeDiff.CompositeTypeName] = compositeDiff
+		droppedComposites = append(droppedComposites, qualifiedCompositeType{Schema: compositeDiff.SchemaName, Composite: compositeDiff.OldCompositeType})
+	}
+	orderedDrops := sortCompositeTypesTopologically(droppedComposites)
+	for i := len(orderedDrops) - 1; i >= 0; i-- {
+		t := orderedDrops[i]
+		if err := writeCompositeTypeDiff(out, droppedCompositeDiffs[t.Schema+"\x00"+t.Composite.Name]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func writeDropPhase(out *strings.Builder, diff *schema.MetadataDiff) error {
@@ -227,6 +697,9 @@ func writeDropPhase(out *strings.Builder, diff *schema.MetadataDiff) error {
 	if err := writeDropSequenceOwnershipBeforeTableDrops(out, diff); err != nil {
 		return err
 	}
+	if err := writeReleasingCompositeAlters(out, diff); err != nil {
+		return err
+	}
 	if err := writeDropDependentObjects(out, diff); err != nil {
 		return err
 	}
@@ -244,8 +717,59 @@ func writeDropPhase(out *strings.Builder, diff *schema.MetadataDiff) error {
 			}
 		}
 	}
+	// Non-deferred dropped schemas participate in the same global type-drop
+	// ordering as top-level drops: a schema-owned composite may reference a
+	// top-level type (or vice versa), so their non-type objects drop first,
+	// then every composite in one reverse-dependency pass, then enums, and
+	// the bare DROP SCHEMA statements last.
+	deferred := computeDeferredDrops(diff)
+	var immediateSchemaDrops []*schema.SchemaDiff
+	for _, schemaDiff := range diff.SchemaChanges {
+		if schemaDiff.Action == schema.MetadataDiffActionDrop && !deferred.schemas[schemaDiff] && !skipPostgresSchemaDDL(schemaDiff.SchemaName) {
+			immediateSchemaDrops = append(immediateSchemaDrops, schemaDiff)
+		}
+	}
+	slices.SortStableFunc(immediateSchemaDrops, func(a, b *schema.SchemaDiff) int {
+		return strings.Compare(a.SchemaName, b.SchemaName)
+	})
+	for _, schemaDiff := range immediateSchemaDrops {
+		if err := writeDropSchemaNonTypeObjects(out, schemaDiff.SchemaName, schemaDiff.OldSchema); err != nil {
+			return err
+		}
+	}
+
+	// Drop composite types before enum types: composite attributes may
+	// reference enums. Dependents drop before the composites they reference.
+	// Composites released only by a column retype cannot be dropped yet —
+	// the retype runs in the later alter phase — so those drops are deferred
+	// to the end of the migration.
+	// Top-level immediate composite drops are ordered inside the dependent-
+	// object graph (writeDropDependentObjects), except those a schema-owned
+	// composite references — they drop here, merged with the schema-owned
+	// composites in one reverse-dependency pass. Residual corner: a
+	// schema-owned composite referencing a top-level dropped table drops
+	// after it — full generality needs the schema-owned objects in the
+	// same graph.
+	_, remainingDrops := dropGraphComposites(diff)
+	for _, schemaDiff := range immediateSchemaDrops {
+		schemaObjects := buildDropSchemaObjectsDiff(schemaDiff.SchemaName, schemaDiff.OldSchema)
+		remainingDrops = append(remainingDrops, schemaObjects.CompositeTypeChanges...)
+	}
+	if err := writeCompositeTypeDropsInReverseDependencyOrder(out, remainingDrops); err != nil {
+		return err
+	}
+	// Enums referenced by a deferred composite cannot be dropped until that
+	// composite is gone; they are deferred alongside it.
 	for _, enumDiff := range diff.EnumTypeChanges {
-		if enumDiff.Action == schema.MetadataDiffActionDrop {
+		if enumDiff.Action == schema.MetadataDiffActionDrop && !deferred.enums[enumDiff] {
+			if err := writeEnumTypeDiff(out, enumDiff); err != nil {
+				return err
+			}
+		}
+	}
+	for _, schemaDiff := range immediateSchemaDrops {
+		schemaObjects := buildDropSchemaObjectsDiff(schemaDiff.SchemaName, schemaDiff.OldSchema)
+		for _, enumDiff := range schemaObjects.EnumTypeChanges {
 			if err := writeEnumTypeDiff(out, enumDiff); err != nil {
 				return err
 			}
@@ -258,11 +782,9 @@ func writeDropPhase(out *strings.Builder, diff *schema.MetadataDiff) error {
 			}
 		}
 	}
-	for _, schemaDiff := range diff.SchemaChanges {
-		if schemaDiff.Action == schema.MetadataDiffActionDrop {
-			if err := writeSchemaDiff(out, schemaDiff); err != nil {
-				return err
-			}
+	for _, schemaDiff := range immediateSchemaDrops {
+		if _, err := fmt.Fprintf(out, "DROP SCHEMA IF EXISTS \"%s\";\n\n", schemaDiff.SchemaName); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -290,6 +812,7 @@ func writeCreateOrAlterPhase(out *strings.Builder, diff *schema.MetadataDiff) er
 			}
 		}
 	}
+
 	for _, sequenceDiff := range diff.SequenceChanges {
 		if sequenceDiff.Action == schema.MetadataDiffActionCreate || sequenceDiff.Action == schema.MetadataDiffActionAlter {
 			if err := writeSequenceDiff(out, sequenceDiff); err != nil {
@@ -301,6 +824,21 @@ func writeCreateOrAlterPhase(out *strings.Builder, diff *schema.MetadataDiff) er
 	if err := writeCreateTables(out, diff); err != nil {
 		return err
 	}
+	// Composite alters run after table creation: an added or retyped
+	// attribute may reference a row type created in this migration, while
+	// table creation itself only references the composite by name and never
+	// depends on its attribute set. Statements that release a dropped
+	// table's row type were already emitted in the drop phase. Alters that
+	// gain a created view's row type wait until after the views phase.
+	released := releasingCompositeAttributes(diff)
+	postViewAlters := postViewCompositeAlters(diff)
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action == schema.MetadataDiffActionAlter && !postViewAlters[compositeDiff] {
+			if err := writeCompositeTypeDiffWithReleased(out, compositeDiff, released); err != nil {
+				return err
+			}
+		}
+	}
 	if err := writeAlterTables(out, diff); err != nil {
 		return err
 	}
@@ -309,6 +847,29 @@ func writeCreateOrAlterPhase(out *strings.Builder, diff *schema.MetadataDiff) er
 	}
 	if err := writeCreateRoutinesViewsAndMaterializedViews(out, diff); err != nil {
 		return err
+	}
+	// Composites whose attributes use a created view or materialized view
+	// row type (directly or through another such composite) are created only
+	// now. Residual: a created table consuming such a composite still emits
+	// earlier — resolving that needs views in the create graph.
+	postView := postViewCompositeCreates(diff)
+	var postViewCreates []qualifiedCompositeType
+	postViewDiffs := make(map[string]*schema.CompositeTypeDiff)
+	for compositeDiff := range postView {
+		postViewDiffs[compositeDiff.SchemaName+"\x00"+compositeDiff.CompositeTypeName] = compositeDiff
+		postViewCreates = append(postViewCreates, qualifiedCompositeType{Schema: compositeDiff.SchemaName, Composite: compositeDiff.NewCompositeType})
+	}
+	for _, t := range sortCompositeTypesTopologically(postViewCreates) {
+		if err := writeCompositeTypeDiff(out, postViewDiffs[t.Schema+"\x00"+t.Composite.Name]); err != nil {
+			return err
+		}
+	}
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action == schema.MetadataDiffActionAlter && postViewAlters[compositeDiff] {
+			if err := writeCompositeTypeDiffWithReleased(out, compositeDiff, released); err != nil {
+				return err
+			}
+		}
 	}
 	if err := writeCreateTableForeignKeys(out, diff); err != nil {
 		return err
@@ -514,7 +1075,14 @@ func isSequenceOwnedByDroppedTable(diff *schema.MetadataDiff, schemaName string,
 
 func writeDropDependentObjects(out *strings.Builder, diff *schema.MetadataDiff) error {
 	maps := buildDropObjectMaps(diff)
+	// Top-level immediate composite drops participate in the same graph:
+	// tables/views drop before composites their columns use, and composites
+	// drop before tables whose row types their attributes reference.
+	composites, _ := dropGraphComposites(diff)
 	graph := base.NewGraph()
+	for _, id := range sortedMapKeys(composites) {
+		graph.AddNode(id)
+	}
 	for _, id := range sortedMapKeys(maps.tables) {
 		graph.AddNode(id)
 	}
@@ -542,6 +1110,39 @@ func writeDropDependentObjects(out *strings.Builder, diff *schema.MetadataDiff) 
 		}
 		for _, id := range sortedMapKeys(maps.functions) {
 			graph.AddEdge(id, tableID)
+		}
+	}
+	// Views, matviews, and routines drop before every composite type, like
+	// they do before every table — except when the composite's attributes
+	// reference that view's row type, where only the composite -> view edge
+	// applies (the blanket edge would create a cycle and break the order).
+	compositeRowTypeRefs := make(map[string]map[string]bool)
+	for compositeID, compositeDiff := range composites {
+		refs := make(map[string]bool)
+		for _, attribute := range compositeDiff.OldCompositeType.GetAttributes() {
+			if depSchema, depName, ok := parseQualifiedTypeIdent(attribute.Type); ok {
+				refs[getMigrationObjectID(depSchema, depName)] = true
+			}
+		}
+		compositeRowTypeRefs[compositeID] = refs
+	}
+	for _, compositeID := range sortedMapKeys(composites) {
+		refs := compositeRowTypeRefs[compositeID]
+		for _, id := range sortedMapKeys(maps.views) {
+			if !refs[id] {
+				graph.AddEdge(id, compositeID)
+			}
+		}
+		for _, id := range sortedMapKeys(maps.materializedViews) {
+			if !refs[id] {
+				graph.AddEdge(id, compositeID)
+			}
+		}
+		for _, id := range sortedMapKeys(maps.procedures) {
+			graph.AddEdge(id, compositeID)
+		}
+		for _, id := range sortedMapKeys(maps.functions) {
+			graph.AddEdge(id, compositeID)
 		}
 	}
 
@@ -580,6 +1181,26 @@ func writeDropDependentObjects(out *strings.Builder, diff *schema.MetadataDiff) 
 				graph.AddEdge(tableID, depID)
 			}
 		}
+		// A table whose column uses a dropped composite drops before it.
+		for _, column := range tableDiff.OldTable.GetColumns() {
+			for _, depID := range columnTypeCompositeIDs(column.GetType(), composites) {
+				graph.AddEdge(tableID, depID)
+			}
+		}
+	}
+	for compositeID, compositeDiff := range composites {
+		for _, attribute := range compositeDiff.OldCompositeType.GetAttributes() {
+			depSchema, depName, ok := parseQualifiedTypeIdent(attribute.Type)
+			if !ok {
+				continue
+			}
+			depID := getMigrationObjectID(depSchema, depName)
+			// A composite drops before the composite or table row type it
+			// references.
+			if depID != compositeID && hasNode(depID) {
+				graph.AddEdge(compositeID, depID)
+			}
+		}
 	}
 
 	orderedIDs, err := graph.TopologicalSort()
@@ -588,6 +1209,7 @@ func writeDropDependentObjects(out *strings.Builder, diff *schema.MetadataDiff) 
 		orderedIDs = append(orderedIDs, sortedMapKeys(maps.materializedViews)...)
 		orderedIDs = append(orderedIDs, sortedMapKeys(maps.procedures)...)
 		orderedIDs = append(orderedIDs, sortedMapKeys(maps.functions)...)
+		orderedIDs = append(orderedIDs, sortedMapKeys(composites)...)
 		orderedIDs = append(orderedIDs, sortedMapKeys(maps.tables)...)
 	}
 	for _, id := range orderedIDs {
@@ -610,6 +1232,10 @@ func writeDropDependentObjects(out *strings.Builder, diff *schema.MetadataDiff) 
 			}
 		case maps.tables[id] != nil:
 			if err := writeTableDiff(out, maps.tables[id]); err != nil {
+				return err
+			}
+		case composites[id] != nil:
+			if err := writeCompositeTypeDiff(out, composites[id]); err != nil {
 				return err
 			}
 		default:
@@ -678,7 +1304,21 @@ func writeDropAlterTableObjects(out *strings.Builder, diff *schema.MetadataDiff)
 
 func writeCreateTables(out *strings.Builder, diff *schema.MetadataDiff) error {
 	maps := buildCreateObjectMaps(diff)
+	// Created composite types share the graph: a composite referencing a
+	// created table's row type comes after that table, and a table whose
+	// column uses a created composite comes after the composite. Composites
+	// referencing created view row types wait for the views phase instead.
+	postView := postViewCompositeCreates(diff)
+	composites := make(map[string]*schema.CompositeTypeDiff)
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action == schema.MetadataDiffActionCreate && !postView[compositeDiff] {
+			composites[getMigrationObjectID(compositeDiff.SchemaName, compositeDiff.CompositeTypeName)] = compositeDiff
+		}
+	}
 	graph := base.NewGraph()
+	for _, id := range sortedMapKeys(composites) {
+		graph.AddNode(id)
+	}
 	for _, id := range sortedMapKeys(maps.tables) {
 		graph.AddNode(id)
 	}
@@ -689,13 +1329,39 @@ func writeCreateTables(out *strings.Builder, diff *schema.MetadataDiff) error {
 				graph.AddEdge(depID, tableID)
 			}
 		}
+		for _, column := range tableDiff.NewTable.GetColumns() {
+			for _, depID := range columnTypeCompositeIDs(column.GetType(), composites) {
+				graph.AddEdge(depID, tableID)
+			}
+		}
+	}
+	for compositeID, compositeDiff := range composites {
+		for _, attribute := range compositeDiff.NewCompositeType.GetAttributes() {
+			depSchema, depName, ok := parseQualifiedTypeIdent(attribute.Type)
+			if !ok {
+				continue
+			}
+			depID := getMigrationObjectID(depSchema, depName)
+			if depID == compositeID {
+				continue
+			}
+			if composites[depID] != nil || maps.tables[depID] != nil {
+				graph.AddEdge(depID, compositeID)
+			}
+		}
 	}
 
 	orderedIDs, err := graph.TopologicalSort()
 	if err != nil {
-		orderedIDs = sortedMapKeys(maps.tables)
+		orderedIDs = append(sortedMapKeys(composites), sortedMapKeys(maps.tables)...)
 	}
 	for _, id := range orderedIDs {
+		if compositeDiff := composites[id]; compositeDiff != nil {
+			if err := writeCompositeTypeDiff(out, compositeDiff); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := writeTableDiff(out, maps.tables[id]); err != nil {
 			return err
 		}
@@ -1486,10 +2152,22 @@ func skipPostgresSchemaDDL(schemaName string) bool {
 }
 
 func writeDropSchemaObjects(out *strings.Builder, schemaName string, schemaMeta *storepb.SchemaMetadata) error {
+	if err := writeDropSchemaNonTypeObjects(out, schemaName, schemaMeta); err != nil {
+		return err
+	}
+	return writeDropSchemaTypes(out, schemaName, schemaMeta)
+}
+
+func writeDropSchemaNonTypeObjects(out *strings.Builder, schemaName string, schemaMeta *storepb.SchemaMetadata) error {
 	if schemaMeta == nil {
 		return nil
 	}
 	diff := buildDropSchemaObjectsDiff(schemaName, schemaMeta)
+	// This pass emits only non-type objects; the caller drops the schema's
+	// types afterwards. Clearing the type changes keeps the shared graph in
+	// writeDropDependentObjects from emitting them here too.
+	diff.CompositeTypeChanges = nil
+	diff.EnumTypeChanges = nil
 	if err := writeDropTableTriggers(out, diff); err != nil {
 		return err
 	}
@@ -1506,6 +2184,18 @@ func writeDropSchemaObjects(out *strings.Builder, schemaName string, schemaMeta 
 		if err := writeSequenceDiff(out, sequenceDiff); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func writeDropSchemaTypes(out *strings.Builder, schemaName string, schemaMeta *storepb.SchemaMetadata) error {
+	if schemaMeta == nil {
+		return nil
+	}
+	diff := buildDropSchemaObjectsDiff(schemaName, schemaMeta)
+	// Composite types drop before enum types they may reference.
+	if err := writeCompositeTypeDropsInReverseDependencyOrder(out, diff.CompositeTypeChanges); err != nil {
+		return err
 	}
 	for _, enumDiff := range diff.EnumTypeChanges {
 		if err := writeEnumTypeDiff(out, enumDiff); err != nil {
@@ -1600,6 +2290,17 @@ func buildDropSchemaObjectsDiff(schemaName string, schemaMeta *storepb.SchemaMet
 			SchemaName:   schemaName,
 			EnumTypeName: enumType.GetName(),
 			OldEnumType:  enumType,
+		})
+	}
+	for _, compositeType := range schemaMeta.GetCompositeTypes() {
+		if compositeType.GetSkipDump() {
+			continue
+		}
+		diff.CompositeTypeChanges = append(diff.CompositeTypeChanges, &schema.CompositeTypeDiff{
+			Action:            schema.MetadataDiffActionDrop,
+			SchemaName:        schemaName,
+			CompositeTypeName: compositeType.GetName(),
+			OldCompositeType:  compositeType,
 		})
 	}
 	return diff
@@ -1901,6 +2602,311 @@ func writeAlterEnumTypeAddValues(out *strings.Builder, schemaName string, oldEnu
 		return writeComment(out, fmt.Sprintf("TYPE \"%s\".\"%s\"", schemaName, newEnum.GetName()), newEnum.GetComment())
 	}
 	return nil
+}
+
+// releasedCompositeAttributeKey identifies an old composite attribute whose
+// releasing statement (DROP ATTRIBUTE or ALTER ATTRIBUTE ... TYPE) is emitted
+// early in the drop phase because its old type references a dropped table's
+// row type.
+func releasedCompositeAttributeKey(schemaName, typeName, attributeName string) string {
+	return schemaName + "\x00" + typeName + "\x00" + attributeName
+}
+
+// Modes for a released composite attribute.
+const (
+	releasedModeRetypeEarly = iota + 1
+	releasedModeDropReadd
+)
+
+// releasingCompositeAttributes finds old attributes of ALTERED composites
+// whose type references a dropped table and which the alter removes or
+// retypes — those statements must run before the table drop. When the
+// retype's target type is itself created in this migration, the early
+// statement is a DROP ATTRIBUTE and the create phase re-adds it.
+func releasingCompositeAttributes(diff *schema.MetadataDiff) map[string]int {
+	droppedTables := make(map[string]bool)
+	createdTypes := make(map[string]bool)
+	for _, tableDiff := range diff.TableChanges {
+		switch tableDiff.Action {
+		case schema.MetadataDiffActionDrop:
+			droppedTables[tableDiff.SchemaName+"\x00"+tableDiff.TableName] = true
+		case schema.MetadataDiffActionCreate:
+			createdTypes[tableDiff.SchemaName+"\x00"+tableDiff.TableName] = true
+		default:
+		}
+	}
+	// Dropped views and materialized views provide row types too.
+	for _, viewDiff := range diff.ViewChanges {
+		if viewDiff.Action == schema.MetadataDiffActionDrop {
+			droppedTables[viewDiff.SchemaName+"\x00"+viewDiff.ViewName] = true
+		}
+	}
+	for _, viewDiff := range diff.MaterializedViewChanges {
+		if viewDiff.Action == schema.MetadataDiffActionDrop {
+			droppedTables[viewDiff.SchemaName+"\x00"+viewDiff.MaterializedViewName] = true
+		}
+	}
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action == schema.MetadataDiffActionCreate {
+			createdTypes[compositeDiff.SchemaName+"\x00"+compositeDiff.CompositeTypeName] = true
+		}
+	}
+	for _, viewDiff := range diff.ViewChanges {
+		if viewDiff.Action == schema.MetadataDiffActionCreate {
+			createdTypes[viewDiff.SchemaName+"\x00"+viewDiff.ViewName] = true
+		}
+	}
+	for _, viewDiff := range diff.MaterializedViewChanges {
+		if viewDiff.Action == schema.MetadataDiffActionCreate {
+			createdTypes[viewDiff.SchemaName+"\x00"+viewDiff.MaterializedViewName] = true
+		}
+	}
+	released := make(map[string]int)
+	if len(droppedTables) == 0 {
+		return released
+	}
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action != schema.MetadataDiffActionAlter {
+			continue
+		}
+		newAttributes := make(map[string]*storepb.CompositeTypeAttribute)
+		for _, attribute := range compositeDiff.NewCompositeType.GetAttributes() {
+			newAttributes[attribute.Name] = attribute
+		}
+		for _, oldAttribute := range compositeDiff.OldCompositeType.GetAttributes() {
+			depSchema, depName, ok := parseQualifiedTypeIdent(oldAttribute.Type)
+			if !ok || !droppedTables[depSchema+"\x00"+depName] {
+				continue
+			}
+			newAttribute := newAttributes[oldAttribute.Name]
+			if newAttribute == nil || newAttribute.Type == oldAttribute.Type {
+				if newAttribute == nil {
+					released[releasedCompositeAttributeKey(compositeDiff.SchemaName, compositeDiff.CompositeTypeName, oldAttribute.Name)] = releasedModeRetypeEarly
+				}
+				continue
+			}
+			mode := releasedModeRetypeEarly
+			if newSchema, newName, ok := parseQualifiedTypeIdent(newAttribute.Type); ok && createdTypes[newSchema+"\x00"+newName] {
+				// The target type does not exist during the drop phase.
+				mode = releasedModeDropReadd
+			}
+			released[releasedCompositeAttributeKey(compositeDiff.SchemaName, compositeDiff.CompositeTypeName, oldAttribute.Name)] = mode
+		}
+	}
+	return released
+}
+
+// writeReleasingCompositeAlters emits, before the dependent-object graph,
+// the alter statements that release dropped tables' row types. Residual
+// corner: a dropped view over such a composite drops later inside the graph.
+func writeReleasingCompositeAlters(out *strings.Builder, diff *schema.MetadataDiff) error {
+	released := releasingCompositeAttributes(diff)
+	if len(released) == 0 {
+		return nil
+	}
+	for _, compositeDiff := range diff.CompositeTypeChanges {
+		if compositeDiff.Action != schema.MetadataDiffActionAlter {
+			continue
+		}
+		newAttributes := make(map[string]*storepb.CompositeTypeAttribute)
+		for _, attribute := range compositeDiff.NewCompositeType.GetAttributes() {
+			newAttributes[attribute.Name] = attribute
+		}
+		for _, oldAttribute := range compositeDiff.OldCompositeType.GetAttributes() {
+			mode := released[releasedCompositeAttributeKey(compositeDiff.SchemaName, compositeDiff.CompositeTypeName, oldAttribute.Name)]
+			if mode == 0 {
+				continue
+			}
+			newAttribute := newAttributes[oldAttribute.Name]
+			if mode == releasedModeRetypeEarly && newAttribute != nil {
+				if err := writeAlterCompositeAttribute(out, compositeDiff.SchemaName, compositeDiff.CompositeTypeName, alterAttributeAction, newAttribute); err != nil {
+					return err
+				}
+				continue
+			}
+			// Attribute dropped outright, or its retype target is created
+			// only later in this migration: drop now, re-add in the create
+			// phase.
+			if _, err := fmt.Fprintf(out, "ALTER TYPE \"%s\".\"%s\" DROP ATTRIBUTE \"%s\";\n\n", compositeDiff.SchemaName, compositeDiff.CompositeTypeName, oldAttribute.Name); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeCompositeTypeDiff(out *strings.Builder, compositeDiff *schema.CompositeTypeDiff) error {
+	return writeCompositeTypeDiffWithReleased(out, compositeDiff, nil)
+}
+
+// writeCompositeTypeDiffWithReleased is writeCompositeTypeDiff for the alter
+// path, skipping releasing statements already emitted in the drop phase.
+func writeCompositeTypeDiffWithReleased(out *strings.Builder, compositeDiff *schema.CompositeTypeDiff, released map[string]int) error {
+	switch compositeDiff.Action {
+	case schema.MetadataDiffActionCreate:
+		if err := writeCompositeType(out, compositeDiff.SchemaName, compositeDiff.NewCompositeType); err != nil {
+			return err
+		}
+		if _, err := out.WriteString(";\n\n"); err != nil {
+			return err
+		}
+		if compositeTypeHasComments(compositeDiff.NewCompositeType) {
+			return writeCompositeTypeComments(out, compositeDiff.SchemaName, compositeDiff.NewCompositeType)
+		}
+		return nil
+	case schema.MetadataDiffActionDrop:
+		_, err := fmt.Fprintf(out, "DROP TYPE \"%s\".\"%s\";\n\n", compositeDiff.SchemaName, compositeDiff.CompositeTypeName)
+		return err
+	case schema.MetadataDiffActionAlter:
+		return writeAlterCompositeType(out, compositeDiff.SchemaName, compositeDiff.OldCompositeType, compositeDiff.NewCompositeType, released)
+	default:
+		return nil
+	}
+}
+
+// alterAttributeAction is the writeAlterCompositeAttribute action that emits
+// ALTER ATTRIBUTE ... TYPE rather than ADD ATTRIBUTE.
+const alterAttributeAction = "ALTER ATTRIBUTE"
+
+// writeAlterCompositeType diffs attributes by name and emits real DDL.
+// ALTER ATTRIBUTE ... TYPE fails at execution when any table column uses the
+// type — PostgreSQL has no online path for that change; the reviewer sees the
+// statement and the executor surfaces the error. Attribute reordering has no
+// DDL at all and only produces a warning comment.
+func writeAlterCompositeType(out *strings.Builder, schemaName string, oldComposite, newComposite *storepb.CompositeTypeMetadata, released map[string]int) error {
+	oldAttributeMap := make(map[string]*storepb.CompositeTypeAttribute)
+	for _, attribute := range oldComposite.GetAttributes() {
+		oldAttributeMap[attribute.Name] = attribute
+	}
+	newAttributeMap := make(map[string]*storepb.CompositeTypeAttribute)
+	for _, attribute := range newComposite.GetAttributes() {
+		newAttributeMap[attribute.Name] = attribute
+	}
+
+	// Dropped attributes, in old declaration order. Dropping an attribute
+	// discards its data in every value of the type.
+	for _, oldAttribute := range oldComposite.GetAttributes() {
+		if released[releasedCompositeAttributeKey(schemaName, newComposite.GetName(), oldAttribute.Name)] != 0 {
+			continue
+		}
+		if _, exists := newAttributeMap[oldAttribute.Name]; !exists {
+			if _, err := fmt.Fprintf(out, "ALTER TYPE \"%s\".\"%s\" DROP ATTRIBUTE \"%s\";\n\n", schemaName, newComposite.GetName(), oldAttribute.Name); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Added attributes, in new declaration order.
+	for _, newAttribute := range newComposite.GetAttributes() {
+		if _, exists := oldAttributeMap[newAttribute.Name]; !exists {
+			if err := writeAlterCompositeAttribute(out, schemaName, newComposite.GetName(), "ADD ATTRIBUTE", newAttribute); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Attributes whose type or collation changed.
+	for _, newAttribute := range newComposite.GetAttributes() {
+		oldAttribute, exists := oldAttributeMap[newAttribute.Name]
+		if !exists {
+			continue
+		}
+		mode := released[releasedCompositeAttributeKey(schemaName, newComposite.GetName(), newAttribute.Name)]
+		if mode == releasedModeDropReadd {
+			// The early drop-phase statement removed the attribute; re-add
+			// it now that its target type exists.
+			if err := writeAlterCompositeAttribute(out, schemaName, newComposite.GetName(), "ADD ATTRIBUTE", newAttribute); err != nil {
+				return err
+			}
+			continue
+		}
+		if mode != 0 {
+			continue
+		}
+		if oldAttribute.Type != newAttribute.Type || oldAttribute.Collation != newAttribute.Collation {
+			if err := writeAlterCompositeAttribute(out, schemaName, newComposite.GetName(), alterAttributeAction, newAttribute); err != nil {
+				return err
+			}
+		}
+	}
+
+	if compositeAttributesReordered(oldComposite, newComposite) {
+		if _, err := fmt.Fprintf(out, "-- WARNING: PostgreSQL does not support reordering the attributes of \"%s\".\"%s\"\n\n", schemaName, newComposite.GetName()); err != nil {
+			return err
+		}
+	}
+
+	if oldComposite.GetComment() != newComposite.GetComment() {
+		if err := writeComment(out, fmt.Sprintf("TYPE \"%s\".\"%s\"", schemaName, newComposite.GetName()), newComposite.GetComment()); err != nil {
+			return err
+		}
+	}
+	for _, newAttribute := range newComposite.GetAttributes() {
+		oldAttribute, exists := oldAttributeMap[newAttribute.Name]
+		oldComment := ""
+		if exists {
+			oldComment = oldAttribute.Comment
+		}
+		// Comments of added attributes are covered here as well: ADD ATTRIBUTE
+		// carries no comment syntax.
+		if oldComment != newAttribute.Comment {
+			if err := writeComment(out, fmt.Sprintf("COLUMN \"%s\".\"%s\".\"%s\"", schemaName, newComposite.GetName(), newAttribute.Name), newAttribute.Comment); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func writeAlterCompositeAttribute(out *strings.Builder, schemaName, typeName, action string, attribute *storepb.CompositeTypeAttribute) error {
+	typeClause := attribute.Type
+	if action == alterAttributeAction {
+		typeClause = "TYPE " + attribute.Type
+	}
+	if _, err := fmt.Fprintf(out, "ALTER TYPE \"%s\".\"%s\" %s \"%s\" %s", schemaName, typeName, action, attribute.Name, typeClause); err != nil {
+		return err
+	}
+	// The collation is stored as an emit-ready identifier reference
+	// (quoted as needed, schema-qualified outside pg_catalog).
+	if attribute.Collation != "" {
+		if _, err := fmt.Fprintf(out, " COLLATE %s", attribute.Collation); err != nil {
+			return err
+		}
+	}
+	_, err := out.WriteString(";\n\n")
+	return err
+}
+
+// compositeAttributesReordered reports whether the attribute order ALTER TYPE
+// can achieve differs from the target order. Surviving attributes keep their
+// old relative positions and ADD ATTRIBUTE always appends at the end, so any
+// target that deviates from that achievable order — including an attribute
+// inserted in the middle — is unreachable and warrants the warning.
+func compositeAttributesReordered(oldComposite, newComposite *storepb.CompositeTypeMetadata) bool {
+	oldNames := make(map[string]bool)
+	for _, attribute := range oldComposite.GetAttributes() {
+		oldNames[attribute.Name] = true
+	}
+	newNames := make(map[string]bool)
+	for _, attribute := range newComposite.GetAttributes() {
+		newNames[attribute.Name] = true
+	}
+	var achieved []string
+	for _, attribute := range oldComposite.GetAttributes() {
+		if newNames[attribute.Name] {
+			achieved = append(achieved, attribute.Name)
+		}
+	}
+	for _, attribute := range newComposite.GetAttributes() {
+		if !oldNames[attribute.Name] {
+			achieved = append(achieved, attribute.Name)
+		}
+	}
+	var target []string
+	for _, attribute := range newComposite.GetAttributes() {
+		target = append(target, attribute.Name)
+	}
+	return !slices.Equal(achieved, target)
 }
 
 func writeViewDiff(out *strings.Builder, viewDiff *schema.ViewDiff) error {


### PR DESCRIPTION
## What

Adds composite type support to the metadata differ and the PostgreSQL metadata-migration writer, giving Sync Schema parity with the SDL flow. Second PR of the BYT-9668 chain, stacked on #20911.

## How

- `CompositeTypeDiff` in the shared differ: create/drop, and alter when attributes (order-sensitive), collations, or comments change. `FilterPostgresArchiveSchema` filters the new changes like every other kind.
- Migration DDL: `CREATE TYPE ... AS` in dependency order after enums; attribute changes as real `ALTER TYPE ADD/DROP ATTRIBUTE` and `ALTER ATTRIBUTE ... TYPE` statements (reviewable in the issue; PostgreSQL surfaces the in-use restriction at execution); attribute reordering — including middle insertion, which `ADD ATTRIBUTE` cannot express — emits a warning comment, mirroring the enum value-removal precedent.
- **Deferred drop phase**: `DROP TYPE` must run after its last reference is released, and a column *retype* releases references only in the alter phase. `computeDeferredDrops` resolves this with a fixpoint — retype-released composites seed a pool; dropped schemas containing pooled-referenced types join the deferred set and contribute their composites; dropped enums referenced by any pooled composite defer too. The deferred phase then drops all deferred composites in one global reverse-dependency pass (correct even for cyclic cross-schema references), then deferred enums, then `DROP SCHEMA` statements.
- Schema drops now include their composite types (previously `DROP SCHEMA` could run on a non-empty schema).

## Testing

Sixteen focused tests covering create/drop/alter ordering, dependency and reverse-dependency ordering, enum-drop interaction, retype deferral, schema-drop deferral, cross-schema and cyclic deferred references, middle-insertion warnings, comment changes, archive-schema filtering, and skip_dump handling. `ALTER TYPE ... ADD/ALTER ATTRIBUTE ... COLLATE` syntax verified against PostgreSQL 17. Full `schema/pg` suite and lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)