### PR TITLE
chore: bump omni for the PG splitter fix series

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260709103218-72e9a03222dc
+	github.com/bytebase/omni v0.0.0-20260716044319-2538875143b8
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260709103218-72e9a03222dc h1:3RCryLK16wzMjYpnmpgYtXPSDgcjKPVdLXQNbgdFbxc=
-github.com/bytebase/omni v0.0.0-20260709103218-72e9a03222dc/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260716044319-2538875143b8 h1:10hErnWw+t9H7+GlIZjqFy7oS4OQB5v6HK3ZBH+HXAg=
+github.com/bytebase/omni v0.0.0-20260716044319-2538875143b8/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
Bumps omni to pick up the PG splitter audit fix series (bytebase/omni#374–#383): eight engine-verified defects closed, spanning E-string escapes, dollar-quote/identifier adjacency, parenthesis-depth splitting, COPY FROM STDIN inline data (split + parse layers), BEGIN ATOMIC keyword-context counting, and psql metacommand lines — the last making post-CVE-2025-8714 pg_dump and pg_dumpall output parse end to end (previously any modern dump failed at its first `\restrict` line).

No Bytebase-side consumer changes: the pg split path is a thin wrapper over `omnipg.Split`, and the new `CopyStmt.InlineData` field is additive. Verified by running verbatim pg_dump 17.7 container output through `base.SplitMultiSQL` — 18 statements, metacommand lines dropped as statement-less trivia, COPY inline data intact.

The omni-side series also ships the constructive splitter test framework (10^6 self-truthing cases nightly) with all defect-class atoms enabled, so these shapes are permanently fenced upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)