### PR TITLE
refactor: delete instance UX

### DIFF
--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -943,6 +943,8 @@
     "connecting-database-to-project": "Connecting database...",
     "connection-info": "Connection info",
     "connection-options": "Connection Options",
+    "delete-active-confirmation": "Instance \"{{name}}\" is active. Bytebase will archive it first, then permanently delete it. This action cannot be undone. Type the instance ID \"{{id}}\" to confirm.",
+    "delete-confirmation": "This will permanently delete instance \"{{name}}\". This action cannot be undone. Type the instance ID \"{{id}}\" to confirm.",
     "connection-recovery": {
       "auth": {
         "description": "Verify the username, password, token, or IAM authentication settings, then test the connection again.",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -943,8 +943,6 @@
     "connecting-database-to-project": "Connecting database...",
     "connection-info": "Connection info",
     "connection-options": "Connection Options",
-    "delete-active-confirmation": "Instance \"{{name}}\" is active. Bytebase will archive it first, then permanently delete it. This action cannot be undone. Type the instance ID \"{{id}}\" to confirm.",
-    "delete-confirmation": "This will permanently delete instance \"{{name}}\". This action cannot be undone. Type the instance ID \"{{id}}\" to confirm.",
     "connection-recovery": {
       "auth": {
         "description": "Verify the username, password, token, or IAM authentication settings, then test the connection again.",
@@ -1014,6 +1012,8 @@
     "create-gcp-credentials": "To create credentials, see",
     "database-region": "Database Region",
     "default-role": "Default role",
+    "delete-active-confirmation": "Instance \"{{name}}\" is active. Bytebase will archive it first, then permanently delete it. This action cannot be undone. Type the instance ID \"{{id}}\" to confirm.",
+    "delete-confirmation": "This will permanently delete instance \"{{name}}\". This action cannot be undone. Type the instance ID \"{{id}}\" to confirm.",
     "endpoint": "Endpoint",
     "external-id": "External ID",
     "external-id-description": "External ID for additional security when assuming role (optional)",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -943,6 +943,8 @@
     "connecting-database-to-project": "Conectando base de datos...",
     "connection-info": "Información de conexión",
     "connection-options": "Opciones de conexión",
+    "delete-active-confirmation": "La instancia \"{{name}}\" está activa. Bytebase la archivará primero y luego la eliminará permanentemente. Esta acción no se puede deshacer. Escribe el ID de la instancia \"{{id}}\" para confirmar.",
+    "delete-confirmation": "Esto eliminará permanentemente la instancia \"{{name}}\". Esta acción no se puede deshacer. Escribe el ID de la instancia \"{{id}}\" para confirmar.",
     "connection-recovery": {
       "auth": {
         "description": "Verifica el usuario, la contraseña, el token o la configuración de autenticación IAM y vuelve a probar la conexión.",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -943,8 +943,6 @@
     "connecting-database-to-project": "Conectando base de datos...",
     "connection-info": "Información de conexión",
     "connection-options": "Opciones de conexión",
-    "delete-active-confirmation": "La instancia \"{{name}}\" está activa. Bytebase la archivará primero y luego la eliminará permanentemente. Esta acción no se puede deshacer. Escribe el ID de la instancia \"{{id}}\" para confirmar.",
-    "delete-confirmation": "Esto eliminará permanentemente la instancia \"{{name}}\". Esta acción no se puede deshacer. Escribe el ID de la instancia \"{{id}}\" para confirmar.",
     "connection-recovery": {
       "auth": {
         "description": "Verifica el usuario, la contraseña, el token o la configuración de autenticación IAM y vuelve a probar la conexión.",
@@ -1014,6 +1012,8 @@
     "create-gcp-credentials": "Para crear credenciales, consulte",
     "database-region": "Región de la base de datos",
     "default-role": "Rol predeterminado",
+    "delete-active-confirmation": "La instancia \"{{name}}\" está activa. Bytebase la archivará primero y luego la eliminará permanentemente. Esta acción no se puede deshacer. Escribe el ID de la instancia \"{{id}}\" para confirmar.",
+    "delete-confirmation": "Esto eliminará permanentemente la instancia \"{{name}}\". Esta acción no se puede deshacer. Escribe el ID de la instancia \"{{id}}\" para confirmar.",
     "endpoint": "Punto final",
     "external-id": "ID externo",
     "external-id-description": "ID externo para seguridad adicional al asumir el rol (opcional)",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -943,6 +943,8 @@
     "connecting-database-to-project": "データベースを接続中...",
     "connection-info": "接続情報",
     "connection-options": "接続オプション",
+    "delete-active-confirmation": "インスタンス「{{name}}」はアクティブです。Bytebase はまずアーカイブしてから完全に削除します。この操作は元に戻せません。確認するにはインスタンス ID「{{id}}」を入力してください。",
+    "delete-confirmation": "インスタンス「{{name}}」を完全に削除します。この操作は元に戻せません。確認するにはインスタンス ID「{{id}}」を入力してください。",
     "connection-recovery": {
       "auth": {
         "description": "ユーザー名、パスワード、トークン、または IAM 認証設定を確認してから、もう一度接続をテストしてください。",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -943,8 +943,6 @@
     "connecting-database-to-project": "データベースを接続中...",
     "connection-info": "接続情報",
     "connection-options": "接続オプション",
-    "delete-active-confirmation": "インスタンス「{{name}}」はアクティブです。Bytebase はまずアーカイブしてから完全に削除します。この操作は元に戻せません。確認するにはインスタンス ID「{{id}}」を入力してください。",
-    "delete-confirmation": "インスタンス「{{name}}」を完全に削除します。この操作は元に戻せません。確認するにはインスタンス ID「{{id}}」を入力してください。",
     "connection-recovery": {
       "auth": {
         "description": "ユーザー名、パスワード、トークン、または IAM 認証設定を確認してから、もう一度接続をテストしてください。",
@@ -1014,6 +1012,8 @@
     "create-gcp-credentials": "認証情報の作成方法については、を参照してください",
     "database-region": "データベース領域",
     "default-role": "デフォルトロール",
+    "delete-active-confirmation": "インスタンス「{{name}}」はアクティブです。Bytebase はまずアーカイブしてから完全に削除します。この操作は元に戻せません。確認するにはインスタンス ID「{{id}}」を入力してください。",
+    "delete-confirmation": "インスタンス「{{name}}」を完全に削除します。この操作は元に戻せません。確認するにはインスタンス ID「{{id}}」を入力してください。",
     "endpoint": "エンドポイント",
     "external-id": "外部 ID",
     "external-id-description": "ロールを引き受ける際の追加セキュリティ用の外部 ID（オプション）",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -943,8 +943,6 @@
     "connecting-database-to-project": "Đang kết nối cơ sở dữ liệu...",
     "connection-info": "Thông tin kết nối",
     "connection-options": "Tùy chọn kết nối",
-    "delete-active-confirmation": "Instance \"{{name}}\" đang hoạt động. Bytebase sẽ lưu trữ instance này trước, sau đó xóa vĩnh viễn. Không thể hoàn tác hành động này. Nhập ID instance \"{{id}}\" để xác nhận.",
-    "delete-confirmation": "Thao tác này sẽ xóa vĩnh viễn instance \"{{name}}\". Không thể hoàn tác hành động này. Nhập ID instance \"{{id}}\" để xác nhận.",
     "connection-recovery": {
       "auth": {
         "description": "Kiểm tra tên người dùng, mật khẩu, token hoặc cấu hình xác thực IAM, rồi kiểm tra kết nối lại.",
@@ -1014,6 +1012,8 @@
     "create-gcp-credentials": "Để tạo thông tin xác thực, xem",
     "database-region": "Khu vực cơ sở dữ liệu",
     "default-role": "Vai trò mặc định",
+    "delete-active-confirmation": "Instance \"{{name}}\" đang hoạt động. Bytebase sẽ lưu trữ instance này trước, sau đó xóa vĩnh viễn. Không thể hoàn tác hành động này. Nhập ID instance \"{{id}}\" để xác nhận.",
+    "delete-confirmation": "Thao tác này sẽ xóa vĩnh viễn instance \"{{name}}\". Không thể hoàn tác hành động này. Nhập ID instance \"{{id}}\" để xác nhận.",
     "endpoint": "Điểm cuối",
     "external-id": "ID bên ngoài",
     "external-id-description": "ID bên ngoài để bảo mật bổ sung khi đảm nhận vai trò (tùy chọn)",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -943,6 +943,8 @@
     "connecting-database-to-project": "Đang kết nối cơ sở dữ liệu...",
     "connection-info": "Thông tin kết nối",
     "connection-options": "Tùy chọn kết nối",
+    "delete-active-confirmation": "Instance \"{{name}}\" đang hoạt động. Bytebase sẽ lưu trữ instance này trước, sau đó xóa vĩnh viễn. Không thể hoàn tác hành động này. Nhập ID instance \"{{id}}\" để xác nhận.",
+    "delete-confirmation": "Thao tác này sẽ xóa vĩnh viễn instance \"{{name}}\". Không thể hoàn tác hành động này. Nhập ID instance \"{{id}}\" để xác nhận.",
     "connection-recovery": {
       "auth": {
         "description": "Kiểm tra tên người dùng, mật khẩu, token hoặc cấu hình xác thực IAM, rồi kiểm tra kết nối lại.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -943,8 +943,6 @@
     "connecting-database-to-project": "正在连接数据库...",
     "connection-info": "连接信息",
     "connection-options": "连接选项",
-    "delete-active-confirmation": "实例“{{name}}”当前处于活动状态。Bytebase 将先归档该实例，然后永久删除它。此操作无法撤销。请输入实例 ID “{{id}}” 以确认。",
-    "delete-confirmation": "这将永久删除实例“{{name}}”。此操作无法撤销。请输入实例 ID “{{id}}” 以确认。",
     "connection-recovery": {
       "auth": {
         "description": "请检查用户名、密码、令牌或 IAM 认证配置，然后重新测试连接。",
@@ -1014,6 +1012,8 @@
     "create-gcp-credentials": "创建凭据的方法见",
     "database-region": "数据库区域",
     "default-role": "默认角色",
+    "delete-active-confirmation": "实例“{{name}}”当前处于活动状态。Bytebase 将先归档该实例，然后永久删除它。此操作无法撤销。请输入实例 ID “{{id}}” 以确认。",
+    "delete-confirmation": "这将永久删除实例“{{name}}”。此操作无法撤销。请输入实例 ID “{{id}}” 以确认。",
     "endpoint": "端点",
     "external-id": "外部 ID",
     "external-id-description": "承担角色时用于额外安全性的外部 ID（可选）",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -943,6 +943,8 @@
     "connecting-database-to-project": "正在连接数据库...",
     "connection-info": "连接信息",
     "connection-options": "连接选项",
+    "delete-active-confirmation": "实例“{{name}}”当前处于活动状态。Bytebase 将先归档该实例，然后永久删除它。此操作无法撤销。请输入实例 ID “{{id}}” 以确认。",
+    "delete-confirmation": "这将永久删除实例“{{name}}”。此操作无法撤销。请输入实例 ID “{{id}}” 以确认。",
     "connection-recovery": {
       "auth": {
         "description": "请检查用户名、密码、令牌或 IAM 认证配置，然后重新测试连接。",

--- a/frontend/src/react/components/EnvironmentLabel.test.tsx
+++ b/frontend/src/react/components/EnvironmentLabel.test.tsx
@@ -1,0 +1,81 @@
+import type { MouseEventHandler, ReactElement, ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import type { Environment } from "@/types";
+import { EnvironmentBadge } from "./EnvironmentLabel";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/react/components/RouterLink", () => ({
+  RouterLink: ({
+    children,
+    className,
+    onClick,
+    to,
+  }: {
+    children: ReactNode;
+    className?: string;
+    onClick?: MouseEventHandler<HTMLAnchorElement>;
+    to: { path?: string };
+  }) => (
+    <a className={className} data-path={to.path} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+const render = async (element: ReactElement) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(element);
+    await Promise.resolve();
+  });
+
+  return { container, root };
+};
+
+const environment = {
+  id: "prod",
+  name: "environments/prod",
+  title: "Production",
+  color: "#16a34a",
+  order: 0,
+  tags: {},
+} as Environment;
+
+describe("EnvironmentBadge", () => {
+  let root: Root | undefined;
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    document.body.innerHTML = "";
+    root = undefined;
+  });
+
+  test("wraps the badge with RouterLink when link is enabled", async () => {
+    const rendered = await render(
+      <EnvironmentBadge
+        environment={environment}
+        hasEnvTierFeature={false}
+        link
+      />
+    );
+    root = rendered.root;
+
+    const link = rendered.container.querySelector("a");
+    expect(link?.getAttribute("data-path")).toBe("/environments/prod");
+    expect(link?.className).toBe("hover:underline");
+    expect(link?.textContent).toBe("Production");
+  });
+});

--- a/frontend/src/react/components/EnvironmentLabel.tsx
+++ b/frontend/src/react/components/EnvironmentLabel.tsx
@@ -1,11 +1,13 @@
 import { ShieldAlert } from "lucide-react";
 import { memo } from "react";
 import { useTranslation } from "react-i18next";
+import { RouterLink } from "@/react/components/RouterLink";
 import { useEnvironment, usePlanFeature } from "@/react/hooks/useAppState";
 import { cn } from "@/react/lib/utils";
 import type { Environment } from "@/types";
 import {
   DEFAULT_ENVIRONMENT_COLOR,
+  formatEnvironmentName,
   NULL_ENVIRONMENT_NAME,
   UNKNOWN_ENVIRONMENT_NAME,
 } from "@/types";
@@ -25,10 +27,12 @@ export const EnvironmentBadge = memo(function EnvironmentBadge({
   environment,
   hasEnvTierFeature,
   className,
+  link,
 }: {
   environment: Environment;
   hasEnvTierFeature: boolean;
   className?: string;
+  link?: boolean;
 }) {
   const { t } = useTranslation();
 
@@ -41,7 +45,7 @@ export const EnvironmentBadge = memo(function EnvironmentBadge({
     ? null
     : hexToRgb(environment.color || DEFAULT_ENVIRONMENT_COLOR);
 
-  return (
+  const badge = (
     <span
       className={cn(
         "inline-flex items-center gap-x-1 px-1.5 rounded-xs truncate",
@@ -70,6 +74,22 @@ export const EnvironmentBadge = memo(function EnvironmentBadge({
       )}
     </span>
   );
+
+  if (!link || isUnset) {
+    return badge;
+  }
+
+  return (
+    <RouterLink
+      to={{ path: `/${formatEnvironmentName(environment.id)}` }}
+      className="hover:underline"
+      onClick={(e) => {
+        e.stopPropagation();
+      }}
+    >
+      {badge}
+    </RouterLink>
+  );
 });
 
 /**
@@ -87,10 +107,12 @@ export function EnvironmentLabel({
   environment: envProp,
   environmentName,
   className,
+  link,
 }: {
   environment?: Environment;
   environmentName?: string;
   className?: string;
+  link?: boolean;
 }) {
   // Always called (rules of hooks); result ignored when envProp is provided.
   const envFromStore = useEnvironment(environmentName || NULL_ENVIRONMENT_NAME);
@@ -103,6 +125,7 @@ export function EnvironmentLabel({
       environment={environment}
       hasEnvTierFeature={hasEnvTierFeature}
       className={className}
+      link={link}
     />
   );
 }

--- a/frontend/src/react/components/ProjectLabel.test.tsx
+++ b/frontend/src/react/components/ProjectLabel.test.tsx
@@ -1,0 +1,180 @@
+import type { MouseEventHandler, ReactElement, ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  useProjectByName: vi.fn(),
+  getOrFetchProjectByName: vi.fn(),
+  hasWorkspacePermissionV2: vi.fn(() => true),
+}));
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/react/components/RouterLink", () => ({
+  RouterLink: ({
+    children,
+    className,
+    onClick,
+    to,
+  }: {
+    children: ReactNode;
+    className?: string;
+    onClick?: MouseEventHandler<HTMLAnchorElement>;
+    to: { name?: string; params?: Record<string, string> };
+  }) => (
+    <a
+      className={className}
+      data-route-name={to.name}
+      data-project-id={to.params?.projectId}
+      onClick={onClick}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/react/hooks/useProjectByName", () => ({
+  useProjectByName: mocks.useProjectByName,
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: {
+    getState: () => ({
+      getOrFetchProjectByName: mocks.getOrFetchProjectByName,
+    }),
+  },
+}));
+
+vi.mock("@/utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/utils")>()),
+  hasWorkspacePermissionV2: mocks.hasWorkspacePermissionV2,
+}));
+
+import { ProjectLabel } from "./ProjectLabel";
+
+const render = async (element: ReactElement) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  await act(async () => {
+    root.render(element);
+    await Promise.resolve();
+  });
+
+  return { container, root };
+};
+
+describe("ProjectLabel", () => {
+  let root: Root | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasWorkspacePermissionV2.mockReturnValue(true);
+    mocks.useProjectByName.mockReturnValue({
+      name: "projects/sample",
+      title: "Sample Project",
+    });
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    document.body.innerHTML = "";
+    root = undefined;
+  });
+
+  test("renders the project title as a label", async () => {
+    const rendered = await render(<ProjectLabel projectName="projects/sample" />);
+    root = rendered.root;
+
+    expect(rendered.container.textContent).toBe("Sample Project");
+    expect(rendered.container.querySelector("a")).toBeNull();
+    expect(mocks.getOrFetchProjectByName).toHaveBeenCalledWith(
+      "projects/sample",
+      true
+    );
+  });
+
+  test("preserves className when rendering a label", async () => {
+    const rendered = await render(
+      <ProjectLabel projectName="projects/sample" className="project-label" />
+    );
+    root = rendered.root;
+
+    const label = rendered.container.querySelector(".project-label");
+    expect(label?.textContent).toBe("Sample Project");
+    expect(rendered.container.querySelector("a")).toBeNull();
+  });
+
+  test("renders the project title as a link", async () => {
+    const rendered = await render(
+      <ProjectLabel projectName="projects/sample" link />
+    );
+    root = rendered.root;
+
+    const link = rendered.container.querySelector("a");
+    expect(link?.textContent).toBe("Sample Project");
+    expect(link?.getAttribute("data-route-name")).toBe(
+      "workspace.project.detail"
+    );
+    expect(link?.getAttribute("data-project-id")).toBe("sample");
+    expect(mocks.getOrFetchProjectByName).toHaveBeenCalledWith(
+      "projects/sample",
+      true
+    );
+  });
+
+  test("stops linked label clicks from bubbling", async () => {
+    const onParentClick = vi.fn();
+    const onLabelClick = vi.fn();
+    const rendered = await render(
+      <div onClick={onParentClick}>
+        <ProjectLabel
+          projectName="projects/sample"
+          link
+          onClick={onLabelClick}
+        />
+      </div>
+    );
+    root = rendered.root;
+
+    const link = rendered.container.querySelector("a");
+    expect(link).not.toBeNull();
+    link?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true })
+    );
+
+    expect(onLabelClick).toHaveBeenCalledTimes(1);
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+
+  test("falls back to the project id when the project is not cached", async () => {
+    mocks.useProjectByName.mockReturnValue({
+      name: "projects/UNKNOWN",
+      title: "",
+    });
+
+    const rendered = await render(<ProjectLabel projectName="projects/sample" />);
+    root = rendered.root;
+
+    expect(rendered.container.textContent).toBe("sample");
+  });
+
+  test("does not fetch the project when custom content is provided", async () => {
+    const rendered = await render(
+      <ProjectLabel projectName="projects/sample">Custom Project</ProjectLabel>
+    );
+    root = rendered.root;
+
+    expect(rendered.container.textContent).toBe("Custom Project");
+    expect(mocks.getOrFetchProjectByName).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/react/components/ProjectLabel.tsx
+++ b/frontend/src/react/components/ProjectLabel.tsx
@@ -1,0 +1,91 @@
+import { type MouseEventHandler, type ReactNode, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  RouterLink,
+  type RouterLinkProps,
+} from "@/react/components/RouterLink";
+import { useProjectByName } from "@/react/hooks/useProjectByName";
+import { cn } from "@/react/lib/utils";
+import { PROJECT_V1_ROUTE_DETAIL } from "@/react/router/handles";
+import { useAppStore } from "@/react/stores/app";
+import { projectNamePrefix } from "@/store/modules/v1/common";
+import { extractProjectResourceName, hasWorkspacePermissionV2 } from "@/utils";
+
+export function ProjectLabel({
+  children,
+  projectName,
+  showResourceType = false,
+  className,
+  link,
+  onClick,
+  ...linkProps
+}: {
+  children?: ReactNode;
+  projectName: string;
+  showResourceType?: boolean;
+  link?: boolean;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+} & Pick<RouterLinkProps, "className" | "rel" | "target">) {
+  const { t } = useTranslation();
+  const project = useProjectByName(projectName);
+  const projectId = extractProjectResourceName(projectName);
+  const validProjectName =
+    projectName.startsWith(projectNamePrefix) && projectId.length > 0;
+  const shouldFetchProject = children === undefined;
+
+  useEffect(() => {
+    if (
+      shouldFetchProject &&
+      validProjectName &&
+      hasWorkspacePermissionV2("bb.projects.get")
+    ) {
+      void useAppStore.getState().getOrFetchProjectByName(projectName, true);
+    }
+  }, [projectName, shouldFetchProject, validProjectName]);
+
+  if (!validProjectName) {
+    return (
+      <span className={className}>{children ?? (projectName || "-")}</span>
+    );
+  }
+
+  const label =
+    project.name === projectName && project.title ? project.title : projectId;
+  const content: ReactNode = children ?? (
+    <>
+      {showResourceType && (
+        <span className="mr-1 text-xs text-control-light">
+          {t("common.project")}:
+        </span>
+      )}
+      <span className="truncate">{label}</span>
+    </>
+  );
+
+  if (!link) {
+    if (className) {
+      return <span className={className}>{content}</span>;
+    }
+    return content;
+  }
+
+  return (
+    <RouterLink
+      {...linkProps}
+      to={{
+        name: PROJECT_V1_ROUTE_DETAIL,
+        params: { projectId },
+      }}
+      className={cn(
+        "inline-flex min-w-0 max-w-full normal-link hover:underline",
+        className
+      )}
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick?.(event);
+      }}
+    >
+      {content}
+    </RouterLink>
+  );
+}

--- a/frontend/src/react/components/ProjectTable.test.tsx
+++ b/frontend/src/react/components/ProjectTable.test.tsx
@@ -2,6 +2,7 @@ import type { MouseEventHandler, ReactNode } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { State } from "@/types/proto-es/v1/common_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import { ProjectTable } from "./ProjectTable";
 
@@ -163,5 +164,31 @@ describe("ProjectTable", () => {
     expect(onRowClick).toHaveBeenCalledTimes(1);
     expect(onRowClick.mock.calls[0][0]).toBe(project);
     expect(onRowClick.mock.calls[0][1].metaKey).toBe(true);
+  });
+
+  test("renders a state column when requested", () => {
+    act(() => {
+      root.render(
+        <ProjectTable
+          projectList={[
+            { ...project, state: State.ACTIVE },
+            {
+              name: "projects/archived",
+              title: "Archived Project",
+              labels: {},
+              state: State.DELETED,
+            } as Project,
+          ]}
+          showState
+        />
+      );
+    });
+
+    const headers = [...container.querySelectorAll("thead th")].map(
+      (th) => th.textContent
+    );
+    expect(headers).toContain("common.state");
+    expect(container.textContent).toContain("common.active");
+    expect(container.textContent).toContain("common.archived");
   });
 });

--- a/frontend/src/react/components/ProjectTable.test.tsx
+++ b/frontend/src/react/components/ProjectTable.test.tsx
@@ -1,3 +1,4 @@
+import type { MouseEventHandler, ReactNode } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
@@ -17,6 +18,37 @@ vi.mock("@/react/components/ui/ellipsis-text", () => ({
   EllipsisText: ({ children }: { children: React.ReactNode }) => (
     <span>{children}</span>
   ),
+}));
+
+vi.mock("@/react/components/ProjectLabel", () => ({
+  ProjectLabel: ({
+    children,
+    className,
+    link,
+    onClick,
+    projectName,
+  }: {
+    children: ReactNode;
+    className?: string;
+    link?: boolean;
+    onClick?: MouseEventHandler<HTMLAnchorElement>;
+    projectName: string;
+  }) =>
+    link ? (
+      <a
+        className={className}
+        data-project-name={projectName}
+        data-project-id={projectName.split("/").at(-1)}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick?.(e);
+        }}
+      >
+        {children}
+      </a>
+    ) : (
+      <span className={className}>{children}</span>
+    ),
 }));
 
 const project = {
@@ -43,37 +75,26 @@ describe("ProjectTable", () => {
     vi.clearAllMocks();
   });
 
-  test("renders project ID and title as links when a row href is provided", () => {
+  test("renders project ID as text and title as a settings table link", () => {
     act(() => {
-      root.render(
-        <ProjectTable
-          projectList={[project]}
-          getRowHref={() => "/projects/sample/issues"}
-        />
-      );
+      root.render(<ProjectTable projectList={[project]} showActions />);
     });
 
     const links = [...container.querySelectorAll("a")];
-    expect(links).toHaveLength(2);
-    expect(links.map((link) => link.getAttribute("href"))).toEqual([
-      "/projects/sample/issues",
-      "/projects/sample/issues",
-    ]);
-    expect(links.map((link) => link.textContent)).toEqual([
-      "sample",
-      "Sample Project",
-    ]);
+    expect(links).toHaveLength(1);
+    expect(links[0].dataset.projectName).toBe("projects/sample");
+    expect(links[0].dataset.projectId).toBe("sample");
+    expect(links[0].textContent).toBe("Sample Project");
+    expect(container.textContent).toContain("sample");
   });
 
-  test("keeps plain clicks on row links native without a row click handler", () => {
+  test("keeps plain clicks on settings table links native without a row click handler", () => {
     act(() => {
-      root.render(
-        <ProjectTable projectList={[project]} getRowHref={() => "#sample"} />
-      );
+      root.render(<ProjectTable projectList={[project]} showActions />);
     });
 
     const links = [...container.querySelectorAll("a")];
-    expect(links).toHaveLength(2);
+    expect(links).toHaveLength(1);
     for (const link of links) {
       const notPrevented = link.dispatchEvent(
         new MouseEvent("click", {
@@ -85,63 +106,62 @@ describe("ProjectTable", () => {
     }
   });
 
-  test("routes plain clicks on row links through the row click handler", () => {
+  test("routes plain row clicks through the row click handler", () => {
     const onRowClick = vi.fn();
 
     act(() => {
       root.render(
         <ProjectTable
           projectList={[project]}
-          getRowHref={() => "/projects/sample/issues"}
+          showActions
           onRowClick={onRowClick}
         />
       );
     });
 
-    const links = [...container.querySelectorAll("a")];
-    expect(links).toHaveLength(2);
-    for (const link of links) {
-      const event = new MouseEvent("click", {
-        bubbles: true,
-        cancelable: true,
-      });
-      const notPrevented = link.dispatchEvent(event);
-      expect(notPrevented).toBe(false);
-    }
+    expect(container.querySelectorAll("a")).toHaveLength(0);
 
-    expect(onRowClick).toHaveBeenCalledTimes(2);
-    expect(onRowClick.mock.calls.map((call) => call[0])).toEqual([
-      project,
-      project,
-    ]);
+    const row = container.querySelector("tbody tr");
+    expect(row).not.toBeNull();
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    });
+    const notPrevented = row?.dispatchEvent(event);
+    expect(notPrevented).toBe(true);
+
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick.mock.calls[0][0]).toBe(project);
   });
 
-  test("keeps modified clicks on row links native", () => {
+  test("passes modified row clicks through the row click handler", () => {
     const onRowClick = vi.fn();
 
     act(() => {
       root.render(
         <ProjectTable
           projectList={[project]}
-          getRowHref={() => "#sample"}
+          showActions
           onRowClick={onRowClick}
         />
       );
     });
 
-    const links = [...container.querySelectorAll("a")];
-    expect(links).toHaveLength(2);
-    for (const link of links) {
-      const modifiedNotPrevented = link.dispatchEvent(
-        new MouseEvent("click", {
-          bubbles: true,
-          cancelable: true,
-          metaKey: true,
-        })
-      );
-      expect(modifiedNotPrevented).toBe(true);
-    }
+    expect(container.querySelectorAll("a")).toHaveLength(0);
 
-    expect(onRowClick).not.toHaveBeenCalled();
+    const row = container.querySelector("tbody tr");
+    expect(row).not.toBeNull();
+    const modifiedNotPrevented = row?.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        cancelable: true,
+        metaKey: true,
+      })
+    );
+    expect(modifiedNotPrevented).toBe(true);
+
+    expect(onRowClick).toHaveBeenCalledTimes(1);
+    expect(onRowClick.mock.calls[0][0]).toBe(project);
+    expect(onRowClick.mock.calls[0][1].metaKey).toBe(true);
   });
 });

--- a/frontend/src/react/components/ProjectTable.tsx
+++ b/frontend/src/react/components/ProjectTable.tsx
@@ -3,7 +3,7 @@ import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { memo, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { HighlightLabelText } from "@/react/components/HighlightLabelText";
-import { RouterLink } from "@/react/components/RouterLink";
+import { ProjectLabel } from "@/react/components/ProjectLabel";
 import { Badge } from "@/react/components/ui/badge";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
@@ -59,8 +59,6 @@ export interface ProjectTableProps {
    */
   readonly showActions?: boolean;
   readonly renderActions?: RenderActions;
-  /** Native link target for each row, used by title anchors. */
-  readonly getRowHref?: (project: Project) => string;
   /** Currently-checked rows (selection mode). */
   readonly selectedProjectNames?: readonly string[];
   /** Selection-change callback. */
@@ -101,7 +99,6 @@ export function ProjectTable({
   showLabels = true,
   showActions = false,
   renderActions,
-  getRowHref,
   selectedProjectNames = [],
   onSelectedChange,
   sortKey,
@@ -147,8 +144,6 @@ export function ProjectTable({
   onRowClickRef.current = onRowClick;
   const renderActionsRef = useRef(renderActions);
   renderActionsRef.current = renderActions;
-  const getRowHrefRef = useRef(getRowHref);
-  getRowHrefRef.current = getRowHref;
 
   const handleSelectAll = useCallback(() => {
     const cb = onSelectedChangeRef.current;
@@ -254,11 +249,9 @@ export function ProjectTable({
               showLeadingCheck={showLeadingCheck}
               showLabels={showLabels}
               showActions={showActions}
-              clickable={!!onRowClick}
-              rowHref={getRowHrefRef.current?.(project)}
               keyword={keyword}
               onToggleRow={handleToggleRow}
-              onRowClick={handleRowClick}
+              onRowClick={onRowClick ? handleRowClick : undefined}
               renderActions={renderActionsStable}
             />
           ))
@@ -276,11 +269,9 @@ interface ProjectRowViewProps {
   showLeadingCheck: boolean;
   showLabels: boolean;
   showActions: boolean;
-  clickable: boolean;
-  rowHref?: string;
   keyword: string;
   onToggleRow: (name: string) => void;
-  onRowClick: (project: Project, event: ProjectRowClickEvent) => void;
+  onRowClick?: (project: Project, event: ProjectRowClickEvent) => void;
   renderActions: (project: Project) => ReactNode;
 }
 
@@ -292,8 +283,6 @@ const ProjectRowView = memo(function ProjectRowView({
   showLeadingCheck,
   showLabels,
   showActions,
-  clickable,
-  rowHref,
   keyword,
   onToggleRow,
   onRowClick,
@@ -313,24 +302,10 @@ const ProjectRowView = memo(function ProjectRowView({
       <HighlightLabelText text={resourceId} keyword={keyword} />
     </EllipsisText>
   );
-  const handleRowLinkClick = (event: ReactMouseEvent<HTMLAnchorElement>) => {
-    event.stopPropagation();
-    if (
-      event.button !== 0 ||
-      event.ctrlKey ||
-      event.metaKey ||
-      event.shiftKey ||
-      event.altKey
-    ) {
-      return;
-    }
-    event.preventDefault();
-    onRowClick(project, event);
-  };
   return (
     <TableRow
-      className={cn(clickable && "cursor-pointer")}
-      onClick={clickable ? (event) => onRowClick(project, event) : undefined}
+      className={cn(onRowClick && "cursor-pointer")}
+      onClick={onRowClick ? (event) => onRowClick?.(project, event) : undefined}
     >
       {showSelection ? (
         <TableCell
@@ -356,39 +331,17 @@ const ProjectRowView = memo(function ProjectRowView({
         </TableCell>
       ) : null}
       <TableCell>
-        {rowHref && clickable ? (
-          <RouterLink
-            to={rowHref}
-            className="block hover:underline"
-            onClick={handleRowLinkClick}
-          >
-            {resourceIdContent}
-          </RouterLink>
-        ) : rowHref ? (
-          <a href={rowHref} className="block hover:underline">
-            {resourceIdContent}
-          </a>
-        ) : (
-          resourceIdContent
-        )}
+        {resourceIdContent}
       </TableCell>
       <TableCell>
         <div className="flex items-center gap-x-2 min-w-0">
-          {rowHref && clickable ? (
-            <RouterLink
-              to={rowHref}
-              className="min-w-0 block hover:underline"
-              onClick={handleRowLinkClick}
-            >
-              {titleContent}
-            </RouterLink>
-          ) : rowHref ? (
-            <a href={rowHref} className="min-w-0 block hover:underline">
-              {titleContent}
-            </a>
-          ) : (
-            titleContent
-          )}
+          <ProjectLabel
+            projectName={project.name}
+            link={!onRowClick}
+            className="min-w-0 block hover:underline"
+          >
+            {titleContent}
+          </ProjectLabel>
           {project.state === State.DELETED ? (
             <Badge variant="warning" className="text-xs shrink-0">
               {t("common.archived")}

--- a/frontend/src/react/components/ProjectTable.tsx
+++ b/frontend/src/react/components/ProjectTable.tsx
@@ -53,6 +53,8 @@ export interface ProjectTableProps {
   readonly showSelection?: boolean;
   /** Mirrors Vue's `:show-labels`. Defaults to true. */
   readonly showLabels?: boolean;
+  /** Adds a dedicated state column. */
+  readonly showState?: boolean;
   /**
    * Mirrors Vue's `:show-actions`. When set, the trailing column renders
    * `renderActions(project)` (typically the project action dropdown).
@@ -97,6 +99,7 @@ export function ProjectTable({
   emptyContent,
   showSelection = false,
   showLabels = true,
+  showState = false,
   showActions = false,
   renderActions,
   selectedProjectNames = [],
@@ -131,6 +134,7 @@ export function ProjectTable({
     1 + // id
     1 + // title
     (showLabels ? 1 : 0) +
+    (showState ? 1 : 0) +
     (showActions ? 1 : 0);
 
   // Use refs so per-row handlers stay stable across selection changes.
@@ -213,6 +217,9 @@ export function ProjectTable({
               {t("common.labels")}
             </TableHead>
           ) : null}
+          {showState ? (
+            <TableHead className="min-w-[120px]">{t("common.state")}</TableHead>
+          ) : null}
           {showActions ? <TableHead className="w-[50px]" /> : null}
         </TableRow>
       </TableHeader>
@@ -248,6 +255,7 @@ export function ProjectTable({
               showSelection={showSelection}
               showLeadingCheck={showLeadingCheck}
               showLabels={showLabels}
+              showState={showState}
               showActions={showActions}
               keyword={keyword}
               onToggleRow={handleToggleRow}
@@ -268,6 +276,7 @@ interface ProjectRowViewProps {
   showSelection: boolean;
   showLeadingCheck: boolean;
   showLabels: boolean;
+  showState: boolean;
   showActions: boolean;
   keyword: string;
   onToggleRow: (name: string) => void;
@@ -282,6 +291,7 @@ const ProjectRowView = memo(function ProjectRowView({
   showSelection,
   showLeadingCheck,
   showLabels,
+  showState,
   showActions,
   keyword,
   onToggleRow,
@@ -342,7 +352,7 @@ const ProjectRowView = memo(function ProjectRowView({
           >
             {titleContent}
           </ProjectLabel>
-          {project.state === State.DELETED ? (
+          {!showState && project.state === State.DELETED ? (
             <Badge variant="warning" className="text-xs shrink-0">
               {t("common.archived")}
             </Badge>
@@ -354,6 +364,11 @@ const ProjectRowView = memo(function ProjectRowView({
           <LabelsCell labels={project.labels ?? {}} />
         </TableCell>
       ) : null}
+      {showState ? (
+        <TableCell>
+          <ResourceStateBadge state={project.state} />
+        </TableCell>
+      ) : null}
       {showActions ? (
         <TableCell className="w-[50px]" onClick={(e) => e.stopPropagation()}>
           <div className="flex justify-end">{renderActions(project)}</div>
@@ -362,6 +377,22 @@ const ProjectRowView = memo(function ProjectRowView({
     </TableRow>
   );
 });
+
+function ResourceStateBadge({ state }: { state: State }) {
+  const { t } = useTranslation();
+  if (state === State.DELETED) {
+    return (
+      <Badge variant="warning" className="text-xs">
+        {t("common.archived")}
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="success" className="text-xs">
+      {t("common.active")}
+    </Badge>
+  );
+}
 
 /**
  * Mirrors Vue's `LabelsCell` — show up to N labels inline, "..." for

--- a/frontend/src/react/components/database/DatabaseTableView.tsx
+++ b/frontend/src/react/components/database/DatabaseTableView.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentBadge } from "@/react/components/EnvironmentLabel";
 import { LabelsDisplay } from "@/react/components/LabelsDisplay";
+import { ProjectLabel } from "@/react/components/ProjectLabel";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import { EllipsisText } from "@/react/components/ui/ellipsis-text";
 import {
@@ -36,8 +37,6 @@ import { SyncStatus } from "@/types/proto-es/v1/database_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import {
   extractDatabaseResourceName,
-  extractProjectResourceName,
-  getDatabaseProject,
   getInstanceResource,
   hostPortOfInstanceV1,
 } from "@/utils";
@@ -256,9 +255,11 @@ export function DatabaseTableView({
         sortable: true,
         sortKey: "project",
         render: (db) => (
-          <span className="truncate">
-            {extractProjectResourceName(getDatabaseProject(db).name)}
-          </span>
+          <ProjectLabel
+            projectName={db.project}
+            className="truncate"
+            link={true}
+          />
         ),
       });
     } else {

--- a/frontend/src/react/components/instance/InstanceActionDropdown.test.tsx
+++ b/frontend/src/react/components/instance/InstanceActionDropdown.test.tsx
@@ -1,0 +1,212 @@
+import { create } from "@bufbuild/protobuf";
+import { fireEvent } from "@testing-library/react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { State } from "@/types/proto-es/v1/common_pb";
+import { InstanceSchema } from "@/types/proto-es/v1/instance_service_pb";
+import { InstanceActionDropdown } from "./InstanceActionDropdown";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+globalThis.ResizeObserver ??= class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+const mocks = vi.hoisted(() => ({
+  hasWorkspacePermissionV2: vi.fn(() => true),
+  archiveInstance: vi.fn(),
+  restoreInstance: vi.fn(),
+  deleteInstance: vi.fn(),
+  routerReplace: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/react/router", () => ({
+  router: {
+    replace: mocks.routerReplace,
+  },
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: {
+    getState: () => ({
+      archiveInstance: mocks.archiveInstance,
+      restoreInstance: mocks.restoreInstance,
+      deleteInstance: mocks.deleteInstance,
+    }),
+  },
+}));
+
+vi.mock("@/store", () => ({
+  pushNotification: vi.fn(),
+}));
+
+vi.mock("@/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/utils")>("@/utils");
+  return {
+    ...actual,
+    hasWorkspacePermissionV2: mocks.hasWorkspacePermissionV2,
+  };
+});
+
+const renderMenu = async (state: State) => {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const instance = create(InstanceSchema, {
+    name: "instances/prod",
+    title: "Production",
+    state,
+  });
+
+  await act(async () => {
+    root.render(<InstanceActionDropdown instance={instance} />);
+  });
+  await act(async () => {
+    container
+      .querySelector("button")
+      ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await vi.waitFor(() => {
+    expect(document.body.querySelector("[role='menu']")).toBeTruthy();
+  });
+
+  return {
+    root,
+    text: () => document.body.textContent ?? "",
+  };
+};
+
+describe("InstanceActionDropdown", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  test("offers permanent delete for an active instance", async () => {
+    const menu = await renderMenu(State.ACTIVE);
+
+    expect(menu.text()).toContain("common.archive");
+    expect(menu.text()).toContain("common.delete");
+
+    act(() => menu.root.unmount());
+  });
+
+  test("offers permanent delete for an archived instance", async () => {
+    const menu = await renderMenu(State.DELETED);
+
+    expect(menu.text()).toContain("common.restore");
+    expect(menu.text()).toContain("common.delete");
+
+    act(() => menu.root.unmount());
+  });
+
+  test("opens the archived instance list after archiving", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    mocks.archiveInstance.mockResolvedValue(undefined);
+    const menu = await renderMenu(State.ACTIVE);
+    const archiveItem = Array.from(
+      document.body.querySelectorAll("[role='menuitem']")
+    ).find((el) => el.textContent === "common.archive");
+
+    await act(async () => {
+      archiveItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.archiveInstance).toHaveBeenCalled();
+    expect(mocks.routerReplace).toHaveBeenCalledWith({
+      name: "workspace.instance",
+      query: { q: "state:DELETED" },
+    });
+
+    confirmSpy.mockRestore();
+    act(() => menu.root.unmount());
+  });
+
+  test("archives before purging an active instance after resource id confirmation", async () => {
+    mocks.archiveInstance.mockResolvedValue(undefined);
+    mocks.deleteInstance.mockResolvedValue(undefined);
+    const menu = await renderMenu(State.ACTIVE);
+    const deleteItem = Array.from(
+      document.body.querySelectorAll("[role='menuitem']")
+    ).find((el) => el.textContent === "common.delete");
+
+    await act(async () => {
+      deleteItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const input = document.body.querySelector("input") as HTMLInputElement;
+    const deleteButtons = Array.from(
+      document.body.querySelectorAll("button")
+    ).filter((el) => el.textContent === "common.delete");
+    const dialogDeleteButton = deleteButtons.at(-1) as HTMLButtonElement;
+    expect(dialogDeleteButton.disabled).toBe(true);
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "prod" } });
+    });
+    expect(dialogDeleteButton.disabled).toBe(false);
+
+    await act(async () => {
+      dialogDeleteButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.archiveInstance).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "instances/prod" }),
+      true
+    );
+    expect(mocks.deleteInstance).toHaveBeenCalledWith("instances/prod");
+    expect(mocks.archiveInstance.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.deleteInstance.mock.invocationCallOrder[0]
+    );
+    expect(mocks.routerReplace).toHaveBeenCalledWith({
+      name: "workspace.instance",
+    });
+
+    act(() => menu.root.unmount());
+  });
+
+  test("purges an archived instance after resource id confirmation", async () => {
+    mocks.deleteInstance.mockResolvedValue(undefined);
+    const menu = await renderMenu(State.DELETED);
+    const deleteItem = Array.from(
+      document.body.querySelectorAll("[role='menuitem']")
+    ).find((el) => el.textContent === "common.delete");
+
+    await act(async () => {
+      deleteItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const input = document.body.querySelector("input") as HTMLInputElement;
+    const deleteButtons = Array.from(
+      document.body.querySelectorAll("button")
+    ).filter((el) => el.textContent === "common.delete");
+    const dialogDeleteButton = deleteButtons.at(-1) as HTMLButtonElement;
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "prod" } });
+    });
+    await act(async () => {
+      dialogDeleteButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.archiveInstance).not.toHaveBeenCalled();
+    expect(mocks.deleteInstance).toHaveBeenCalledWith("instances/prod");
+
+    act(() => menu.root.unmount());
+  });
+});

--- a/frontend/src/react/components/instance/InstanceActionDropdown.test.tsx
+++ b/frontend/src/react/components/instance/InstanceActionDropdown.test.tsx
@@ -112,7 +112,7 @@ describe("InstanceActionDropdown", () => {
     act(() => menu.root.unmount());
   });
 
-  test("opens the archived instance list after archiving", async () => {
+  test("opens the default instance list after archiving", async () => {
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     mocks.archiveInstance.mockResolvedValue(undefined);
     const menu = await renderMenu(State.ACTIVE);
@@ -128,7 +128,6 @@ describe("InstanceActionDropdown", () => {
     expect(mocks.archiveInstance).toHaveBeenCalled();
     expect(mocks.routerReplace).toHaveBeenCalledWith({
       name: "workspace.instance",
-      query: { q: "state:DELETED" },
     });
 
     confirmSpy.mockRestore();

--- a/frontend/src/react/components/instance/InstanceActionDropdown.tsx
+++ b/frontend/src/react/components/instance/InstanceActionDropdown.tsx
@@ -48,10 +48,7 @@ export function InstanceActionDropdown({
         0: instance.title,
       }),
     });
-    router.replace({
-      name: INSTANCE_ROUTE_DASHBOARD,
-      query: { q: "state:DELETED" },
-    });
+    router.replace({ name: INSTANCE_ROUTE_DASHBOARD });
   }, [instance, t]);
 
   const handleRestore = useCallback(async () => {

--- a/frontend/src/react/components/instance/InstanceActionDropdown.tsx
+++ b/frontend/src/react/components/instance/InstanceActionDropdown.tsx
@@ -1,5 +1,5 @@
 import { EllipsisVertical } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   DropdownMenu,
@@ -14,6 +14,7 @@ import { pushNotification } from "@/store";
 import { State } from "@/types/proto-es/v1/common_pb";
 import type { Instance } from "@/types/proto-es/v1/instance_service_pb";
 import { hasWorkspacePermissionV2 } from "@/utils";
+import { InstanceDeleteDialog } from "./InstanceDeleteDialog";
 
 interface InstanceActionDropdownProps {
   instance: Instance;
@@ -25,6 +26,7 @@ export function InstanceActionDropdown({
   onDeleted,
 }: InstanceActionDropdownProps) {
   const { t } = useTranslation();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const canArchive = hasWorkspacePermissionV2("bb.instances.delete");
   const canRestore = hasWorkspacePermissionV2("bb.instances.undelete");
@@ -46,7 +48,10 @@ export function InstanceActionDropdown({
         0: instance.title,
       }),
     });
-    router.replace({ name: INSTANCE_ROUTE_DASHBOARD });
+    router.replace({
+      name: INSTANCE_ROUTE_DASHBOARD,
+      query: { q: "state:DELETED" },
+    });
   }, [instance, t]);
 
   const handleRestore = useCallback(async () => {
@@ -69,55 +74,48 @@ export function InstanceActionDropdown({
     });
   }, [instance, t]);
 
-  const handleDelete = useCallback(async () => {
-    if (
-      !window.confirm(
-        `${t("common.delete-resource", { type: instance.title })}\n\n${t("common.cannot-undo-this-action")}`
-      )
-    )
-      return;
-
-    await useAppStore.getState().deleteInstance(instance.name);
-    pushNotification({
-      module: "bytebase",
-      style: "SUCCESS",
-      title: t("common.deleted"),
-    });
-    onDeleted?.();
-    router.replace({
-      name: INSTANCE_ROUTE_DASHBOARD,
-      query: { q: "state:DELETED" },
-    });
-  }, [instance, t, onDeleted]);
-
   const showArchive = instance.state === State.ACTIVE && canArchive;
   const showRestore = instance.state === State.DELETED && canRestore;
-  const showDelete = canArchive || canRestore;
+  const showDelete = canArchive;
 
   if (!showArchive && !showRestore && !showDelete) return null;
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger className="inline-flex items-center justify-center size-8 rounded-xs text-control hover:bg-control-bg cursor-pointer outline-hidden focus-visible:ring-2 focus-visible:ring-accent">
-        <EllipsisVertical className="size-4" />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        {showArchive && (
-          <DropdownMenuItem onClick={handleArchive}>
-            {t("common.archive")}
-          </DropdownMenuItem>
-        )}
-        {showRestore && (
-          <DropdownMenuItem onClick={handleRestore}>
-            {t("common.restore")}
-          </DropdownMenuItem>
-        )}
-        {showDelete && (
-          <DropdownMenuItem className="text-error" onClick={handleDelete}>
-            {t("common.delete")}
-          </DropdownMenuItem>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger className="inline-flex items-center justify-center size-8 rounded-xs text-control hover:bg-control-bg cursor-pointer outline-hidden focus-visible:ring-2 focus-visible:ring-accent">
+          <EllipsisVertical className="size-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          {showArchive && (
+            <DropdownMenuItem onClick={handleArchive}>
+              {t("common.archive")}
+            </DropdownMenuItem>
+          )}
+          {showRestore && (
+            <DropdownMenuItem onClick={handleRestore}>
+              {t("common.restore")}
+            </DropdownMenuItem>
+          )}
+          {showDelete && (
+            <DropdownMenuItem
+              className="text-error"
+              onClick={() => setShowDeleteConfirm(true)}
+            >
+              {t("common.delete")}
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <InstanceDeleteDialog
+        open={showDeleteConfirm}
+        instance={instance}
+        onOpenChange={setShowDeleteConfirm}
+        onDeleted={() => {
+          onDeleted?.();
+          router.replace({ name: INSTANCE_ROUTE_DASHBOARD });
+        }}
+      />
+    </>
   );
 }

--- a/frontend/src/react/components/instance/InstanceDeleteDialog.tsx
+++ b/frontend/src/react/components/instance/InstanceDeleteDialog.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from "@/react/components/ui/alert-dialog";
+import { Button } from "@/react/components/ui/button";
+import { Input } from "@/react/components/ui/input";
+import { useAppStore } from "@/react/stores/app";
+import { pushNotification } from "@/store";
+import { State } from "@/types/proto-es/v1/common_pb";
+import type { Instance } from "@/types/proto-es/v1/instance_service_pb";
+import { extractInstanceResourceName } from "@/utils";
+
+interface InstanceDeleteDialogProps {
+  open: boolean;
+  instance: Instance;
+  onOpenChange: (open: boolean) => void;
+  onDeleted?: () => void;
+}
+
+export function InstanceDeleteDialog({
+  open,
+  instance,
+  onOpenChange,
+  onDeleted,
+}: InstanceDeleteDialogProps) {
+  const { t } = useTranslation();
+  const [confirmText, setConfirmText] = useState("");
+  const [deleting, setDeleting] = useState(false);
+  const instanceId = useMemo(
+    () => extractInstanceResourceName(instance.name),
+    [instance.name]
+  );
+  const isArchived = instance.state === State.DELETED;
+  const canConfirm = confirmText === instanceId && !deleting;
+  const description = isArchived
+    ? t("instance.delete-confirmation", {
+        id: instanceId,
+        name: instance.title,
+      })
+    : t("instance.delete-active-confirmation", {
+        id: instanceId,
+        name: instance.title,
+      });
+
+  useEffect(() => {
+    if (open) {
+      setConfirmText("");
+      setDeleting(false);
+    }
+  }, [open, instanceId]);
+
+  const handleDelete = async () => {
+    if (!canConfirm) return;
+
+    setDeleting(true);
+    try {
+      const store = useAppStore.getState();
+      if (!isArchived) {
+        await store.archiveInstance(instance, true);
+      }
+      await store.deleteInstance(instance.name);
+      pushNotification({
+        module: "bytebase",
+        style: "SUCCESS",
+        title: t("common.deleted"),
+      });
+      onOpenChange(false);
+      onDeleted?.();
+    } catch (error: unknown) {
+      pushNotification({
+        module: "bytebase",
+        style: "CRITICAL",
+        title: t("common.delete"),
+        description: (error as { message?: string }).message,
+      });
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-w-lg">
+        <AlertDialogTitle>
+          {t("common.delete-resource", { type: instance.title })}
+        </AlertDialogTitle>
+        <AlertDialogDescription className="mt-2">
+          {description}
+        </AlertDialogDescription>
+        <div className="mt-4">
+          <Input
+            value={confirmText}
+            onChange={(event) => setConfirmText(event.target.value)}
+            placeholder={instanceId}
+            autoFocus
+            autoComplete="off"
+          />
+        </div>
+        <div className="mt-6 flex justify-end gap-x-2">
+          <Button
+            appearance="outline"
+            disabled={deleting}
+            onClick={() => onOpenChange(false)}
+          >
+            {t("common.cancel")}
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={!canConfirm}
+            onClick={() => void handleDelete()}
+          >
+            {t("common.delete")}
+          </Button>
+        </div>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/react/components/instance/InstanceFormContext.test.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.test.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from "react";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { Engine } from "@/types/proto-es/v1/common_pb";
+import { Engine, State } from "@/types/proto-es/v1/common_pb";
 import {
   DataSourceSchema,
   DataSourceType,
@@ -132,6 +132,8 @@ const Probe = () => {
       data-title={ctx.basicInfo.title}
       data-host={ctx.adminDataSource.host}
       data-environment={ctx.basicInfo.environment}
+      data-value-changed={String(ctx.valueChanged)}
+      data-is-editing={String(ctx.isEditing)}
     />
   );
 };
@@ -158,6 +160,7 @@ const renderIntoContainer = () => {
 describe("InstanceFormProvider", () => {
   beforeEach(() => {
     mockEnvironmentList = [];
+    vi.useRealTimers();
   });
 
   test("selects the first environment by default when creating an instance", async () => {
@@ -209,6 +212,54 @@ describe("InstanceFormProvider", () => {
     expect(probe.dataset.host).toBe("prod.example.com");
 
     harness.unmount();
+  });
+
+  test("does not mark an archived instance as changed after restore", async () => {
+    vi.useFakeTimers();
+    const archivedInstance = create(InstanceSchema, {
+      name: "instances/prod",
+      state: State.DELETED,
+      title: "Production",
+      engine: Engine.POSTGRES,
+      environment: "environments/prod",
+      dataSources: [
+        create(DataSourceSchema, {
+          id: "admin",
+          type: DataSourceType.ADMIN,
+          host: "prod.example.com",
+          port: "5432",
+        }),
+      ],
+    });
+    const restoredInstance = create(InstanceSchema, {
+      ...archivedInstance,
+      state: State.ACTIVE,
+    });
+    const harness = renderIntoContainer();
+
+    await harness.render(
+      <InstanceFormProvider instance={archivedInstance}>
+        <Probe />
+      </InstanceFormProvider>
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(350);
+    });
+    await harness.render(
+      <InstanceFormProvider instance={restoredInstance}>
+        <Probe />
+      </InstanceFormProvider>
+    );
+    await act(async () => {
+      vi.advanceTimersByTime(350);
+    });
+
+    const probe = harness.container.firstElementChild as HTMLElement;
+    expect(probe.dataset.valueChanged).toBe("false");
+    expect(probe.dataset.isEditing).toBe("false");
+
+    harness.unmount();
+    vi.useRealTimers();
   });
 
   // Regression test for BYT-9696: setting missingFeature (e.g. saving a

--- a/frontend/src/react/components/instance/InstanceFormContext.tsx
+++ b/frontend/src/react/components/instance/InstanceFormContext.tsx
@@ -164,15 +164,23 @@ export function InstanceFormProvider({
   const [labelErrors, setLabelErrors] = useState<string[]>([]);
   const [showConnectionOptionsEvent, setShowConnectionOptionsEvent] =
     useState(0);
-  const syncedInstanceNameRef = useRef(instance?.name);
+  const syncedInstanceRef = useRef({
+    name: instance?.name,
+    state: instance?.state,
+  });
   const isCreating = instance === undefined;
 
   useEffect(() => {
-    if (syncedInstanceNameRef.current === instance?.name) {
+    const previous = syncedInstanceRef.current;
+    const next = {
+      name: instance?.name,
+      state: instance?.state,
+    };
+    if (previous.name === next.name && previous.state === next.state) {
       return;
     }
 
-    syncedInstanceNameRef.current = instance?.name;
+    syncedInstanceRef.current = next;
     const nextBasicInfo = extractBasicInfo(instance);
     const nextDataSourceEditState = extractDataSourceEditState(instance);
     setBasicInfo(nextBasicInfo);

--- a/frontend/src/react/components/instance/index.tsx
+++ b/frontend/src/react/components/instance/index.tsx
@@ -6,6 +6,7 @@ export { DataSourceForm } from "./DataSourceForm";
 export { DataSourceSection } from "./DataSourceSection";
 export { InfoPanel, InfoPanelContent } from "./InfoPanel";
 export { InstanceActionDropdown } from "./InstanceActionDropdown";
+export { InstanceDeleteDialog } from "./InstanceDeleteDialog";
 export { InstanceFormBody } from "./InstanceFormBody";
 export { InstanceFormButtons } from "./InstanceFormButtons";
 export {

--- a/frontend/src/react/components/sql-review/Panels.test.tsx
+++ b/frontend/src/react/components/sql-review/Panels.test.tsx
@@ -122,6 +122,28 @@ beforeEach(async () => {
 });
 
 describe("RulesSelectPanel", () => {
+  test("uses the provided selected engine for the rule tabs", () => {
+    const { container, render, unmount } = renderIntoContainer(
+      <RulesSelectPanel
+        show
+        selectedRuleMap={new Map()}
+        selectedEngine={Engine.POSTGRES}
+        onClose={vi.fn()}
+        onRuleSelect={vi.fn()}
+        onRuleRemove={vi.fn()}
+      />
+    );
+
+    render();
+
+    const postgresTab = [...container.querySelectorAll('[role="tab"]')].find(
+      (tab) => tab.textContent?.includes("PostgreSQL")
+    );
+    expect(postgresTab?.getAttribute("aria-selected")).toBe("true");
+
+    unmount();
+  });
+
   test("renders the first rule choices without blocking on the full list", () => {
     const { container, render, unmount } = renderIntoContainer(
       <RulesSelectPanel

--- a/frontend/src/react/components/sql-review/Panels.tsx
+++ b/frontend/src/react/components/sql-review/Panels.tsx
@@ -47,7 +47,9 @@ const RULE_SELECT_RENDER_CHUNK_SIZE = 64;
 interface RulesSelectPanelProps {
   show: boolean;
   selectedRuleMap: Map<Engine, Map<SQLReviewRule_Type, RuleTemplateV2>>;
+  selectedEngine?: Engine;
   onClose: () => void;
+  onSelectedEngineChange?: (engine: Engine) => void;
   onRuleSelect: (rule: RuleTemplateV2) => void;
   onRuleRemove: (rule: RuleTemplateV2) => void;
 }
@@ -55,7 +57,9 @@ interface RulesSelectPanelProps {
 export function RulesSelectPanel({
   show,
   selectedRuleMap,
+  selectedEngine,
   onClose,
+  onSelectedEngineChange,
   onRuleSelect,
   onRuleRemove,
 }: RulesSelectPanelProps) {
@@ -121,7 +125,12 @@ export function RulesSelectPanel({
           <SheetTitle>{t("sql-review.select-review-rules")}</SheetTitle>
         </SheetHeader>
         <SheetBody className="p-4">
-          <TabsByEngine ruleMapByEngine={ruleTemplateMapV2} lazyPanels>
+          <TabsByEngine
+            ruleMapByEngine={ruleTemplateMapV2}
+            lazyPanels
+            selectedEngine={selectedEngine}
+            onSelectedEngineChange={onSelectedEngineChange}
+          >
             {(ruleList, engine) => (
               <RuleSelectListWithFilter
                 engine={engine}

--- a/frontend/src/react/components/sql-review/ResourceLink.test.tsx
+++ b/frontend/src/react/components/sql-review/ResourceLink.test.tsx
@@ -91,7 +91,10 @@ beforeEach(async () => {
     tags: { protected: "protected" },
   });
   mocks.usePlanFeature.mockReturnValue(true);
-  mocks.useProjectByName.mockReturnValue({ title: "Sample project" });
+  mocks.useProjectByName.mockReturnValue({
+    name: "projects/sample",
+    title: "Sample project",
+  });
   ({ ResourceLink } = await import("./ResourceLink"));
 });
 

--- a/frontend/src/react/components/sql-review/ResourceLink.tsx
+++ b/frontend/src/react/components/sql-review/ResourceLink.tsx
@@ -1,20 +1,17 @@
 import { ShieldAlert } from "lucide-react";
-import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
+import { ProjectLabel } from "@/react/components/ProjectLabel";
 import {
   RouterLink,
   type RouterLinkProps,
 } from "@/react/components/RouterLink";
 import { useEnvironment, usePlanFeature } from "@/react/hooks/useAppState";
-import { useProjectByName } from "@/react/hooks/useProjectByName";
 import { cn } from "@/react/lib/utils";
-import { useAppStore } from "@/react/stores/app";
 import {
   environmentNamePrefix,
   projectNamePrefix,
 } from "@/store/modules/v1/common";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
-import { extractProjectResourceName, hasWorkspacePermissionV2 } from "@/utils";
 
 type ResourceLinkAnchorProps = Pick<
   RouterLinkProps,
@@ -40,8 +37,9 @@ export function ResourceLink({
   }
   if (resource.startsWith(projectNamePrefix)) {
     return (
-      <ProjectResourceLink
-        resource={resource}
+      <ProjectLabel
+        projectName={resource}
+        link={true}
         showResourceType={showResourceType}
         {...linkProps}
       />
@@ -80,44 +78,6 @@ function EnvironmentResourceLink({
       )}
       <span>{environment.title || resource}</span>
       {isProtected && <ShieldAlert className="w-3.5 h-3.5 shrink-0" />}
-    </RouterLink>
-  );
-}
-
-function ProjectResourceLink({
-  resource,
-  showResourceType,
-  className,
-  ...linkProps
-}: {
-  resource: string;
-  showResourceType: boolean;
-} & ResourceLinkAnchorProps) {
-  const { t } = useTranslation();
-  // subscribe to re-render on project cache change
-  const projectsByName = useAppStore((s) => s.projectsByName);
-
-  useEffect(() => {
-    if (hasWorkspacePermissionV2("bb.projects.get")) {
-      useAppStore.getState().getOrFetchProjectByName(resource, true);
-    }
-  }, [resource]);
-
-  const project = useProjectByName(resource);
-  void projectsByName;
-
-  return (
-    <RouterLink
-      {...linkProps}
-      to={{ path: `/${resource}` }}
-      className={cn("inline-flex items-center gap-x-1 normal-link", className)}
-    >
-      {showResourceType && (
-        <span className="text-control-light text-xs mr-0.5">
-          {t("common.project")}:
-        </span>
-      )}
-      <span>{project?.title || extractProjectResourceName(resource)}</span>
     </RouterLink>
   );
 }

--- a/frontend/src/react/components/sql-review/ReviewCreation.test.tsx
+++ b/frontend/src/react/components/sql-review/ReviewCreation.test.tsx
@@ -21,6 +21,8 @@ const mocks = vi.hoisted(() => ({
   inputOnChange: vi.fn(),
   resourceIdOnChange: vi.fn(),
   ruleTableProps: [] as unknown[],
+  rulesSelectPanelProps: [] as unknown[],
+  tabsByEngineProps: [] as unknown[],
 }));
 
 let ReviewCreation: typeof import("./ReviewCreation").ReviewCreation;
@@ -124,19 +126,23 @@ vi.mock("./TemplateSelector", () => ({
 }));
 
 vi.mock("./TabsByEngine", () => ({
-  TabsByEngine: ({
-    ruleMapByEngine,
-    children,
-  }: {
+  TabsByEngine: (props: {
     ruleMapByEngine: Map<Engine, Map<SQLReviewRule_Type, RuleTemplateV2>>;
     children: (ruleList: RuleTemplateV2[], engine: Engine) => React.ReactNode;
-  }) => (
-    <div data-testid="tabs-by-engine">
-      {[...ruleMapByEngine.entries()].map(([engine, ruleMap]) => (
-        <div key={engine}>{children([...ruleMap.values()], engine)}</div>
-      ))}
-    </div>
-  ),
+    selectedEngine?: Engine;
+    onSelectedEngineChange?: (engine: Engine) => void;
+  }) => {
+    mocks.tabsByEngineProps.push(props);
+    return (
+      <div data-testid="tabs-by-engine">
+        {[...props.ruleMapByEngine.entries()].map(([engine, ruleMap]) => (
+          <div key={engine}>
+            {props.children([...ruleMap.values()], engine)}
+          </div>
+        ))}
+      </div>
+    );
+  },
 }));
 
 vi.mock("./RuleTable", () => ({
@@ -147,7 +153,10 @@ vi.mock("./RuleTable", () => ({
 }));
 
 vi.mock("./Panels", () => ({
-  RulesSelectPanel: () => <div data-testid="rules-select-panel" />,
+  RulesSelectPanel: (props: unknown) => {
+    mocks.rulesSelectPanelProps.push(props);
+    return <div data-testid="rules-select-panel" />;
+  },
 }));
 
 const renderIntoContainer = (element: ReactElement) => {
@@ -170,6 +179,8 @@ const renderIntoContainer = (element: ReactElement) => {
 beforeEach(async () => {
   vi.clearAllMocks();
   mocks.ruleTableProps = [];
+  mocks.rulesSelectPanelProps = [];
+  mocks.tabsByEngineProps = [];
   ({ ReviewCreation } = await import("./ReviewCreation"));
 });
 
@@ -314,6 +325,51 @@ describe("ReviewCreation", () => {
       `${Engine.MYSQL}:${SQLReviewRule_Type.TABLE_DISALLOW_DDL}`
     );
     expect(lastRuleTableProps.focusRuleSignal).toBeGreaterThan(0);
+
+    unmount();
+  });
+
+  test("opens the rule selection panel on the selected engine", () => {
+    const { container, render, unmount } = renderIntoContainer(
+      <ReviewCreation selectedRuleList={[]} selectedResources={[]} />
+    );
+
+    render();
+
+    act(() => {
+      mocks.resourceIdOnChange("custom-policy");
+    });
+    const nextButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "common.next"
+    );
+    expect(nextButton).toBeTruthy();
+
+    act(() => {
+      nextButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const mainTabsProps = mocks.tabsByEngineProps.at(-1) as {
+      onSelectedEngineChange?: (engine: Engine) => void;
+    };
+    expect(mainTabsProps.onSelectedEngineChange).toBeTruthy();
+
+    act(() => {
+      mainTabsProps.onSelectedEngineChange?.(Engine.POSTGRES);
+    });
+
+    const addRulesButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "sql-review.add-or-remove-rules"
+    );
+    expect(addRulesButton).toBeTruthy();
+
+    act(() => {
+      addRulesButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    const panelProps = mocks.rulesSelectPanelProps.at(-1) as {
+      selectedEngine?: Engine;
+    };
+    expect(panelProps.selectedEngine).toBe(Engine.POSTGRES);
 
     unmount();
   });

--- a/frontend/src/react/components/sql-review/ReviewCreation.tsx
+++ b/frontend/src/react/components/sql-review/ReviewCreation.tsx
@@ -449,7 +449,9 @@ export function ReviewCreation({
             <RulesSelectPanel
               show={showRuleSelectPanel}
               selectedRuleMap={ruleMapByEngine}
+              selectedEngine={focusedEngine}
               onClose={() => setShowRuleSelectPanel(false)}
+              onSelectedEngineChange={setFocusedEngine}
               onRuleSelect={(rule) => upsertRule(rule, {})}
               onRuleRemove={removeRule}
             />

--- a/frontend/src/react/pages/settings/EnvironmentsPage.tsx
+++ b/frontend/src/react/pages/settings/EnvironmentsPage.tsx
@@ -17,7 +17,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { cloneDeep, isEqual } from "lodash-es";
-import { GripVertical, ListOrdered, Plus, ShieldAlert, X } from "lucide-react";
+import { GripVertical, ListOrdered, Plus, X } from "lucide-react";
 import {
   forwardRef,
   useCallback,
@@ -28,6 +28,7 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
+import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { FeatureAttention } from "@/react/components/FeatureAttention";
 import { FeatureBadge } from "@/react/components/FeatureBadge";
 import { LearnMoreLink } from "@/react/components/LearnMoreLink";
@@ -100,66 +101,11 @@ import {
 } from "@/types/proto-es/v1/org_policy_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import type { Environment } from "@/types/v1/environment";
-import {
-  hasWorkspacePermissionV2,
-  hexToRgb,
-  sqlReviewPolicySlug,
-} from "@/utils";
+import { hasWorkspacePermissionV2, sqlReviewPolicySlug } from "@/utils";
 import {
   getEnvironmentListKey,
   resolveSelectedEnvironmentId,
 } from "./environmentSelection";
-
-// ============================================================
-// EnvironmentName - displays env name with color badge
-// ============================================================
-function EnvironmentName({
-  environment,
-  link = false,
-}: {
-  environment: Environment;
-  link?: boolean;
-}) {
-  const hasEnvTierFeature = useAppStore((s) =>
-    s.hasInstanceFeature(PlanFeature.FEATURE_ENVIRONMENT_TIERS)
-  );
-  const color = environment.color || DEFAULT_ENVIRONMENT_COLOR;
-  const rgbValues = hexToRgb(color);
-  const rgbStr = rgbValues.join(", ");
-  const showProductionIcon =
-    hasEnvTierFeature && environment.tags?.protected === "protected";
-
-  const content = (
-    <span
-      className="inline-flex items-center gap-x-1 px-1.5 rounded-xs select-none truncate"
-      style={{
-        backgroundColor: `rgba(${rgbStr}, 0.1)`,
-        color: `rgb(${rgbStr})`,
-      }}
-    >
-      <span className="truncate">{environment.title}</span>
-      {showProductionIcon && (
-        <ShieldAlert className="w-3.5 h-3.5 shrink-0 text-control" />
-      )}
-    </span>
-  );
-
-  if (link) {
-    return (
-      <RouterLink
-        to={{ path: `/${formatEnvironmentName(environment.id)}` }}
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
-        className="hover:underline"
-      >
-        {content}
-      </RouterLink>
-    );
-  }
-
-  return content;
-}
 
 // ============================================================
 // Toggle switch
@@ -1237,7 +1183,7 @@ function SortableEnvironmentRow({
     >
       <div className="flex items-center gap-x-2">
         <span className="textinfo">{index + 1}.</span>
-        <EnvironmentName environment={env} />
+        <EnvironmentLabel environment={env} />
       </div>
       <button
         type="button"
@@ -1549,7 +1495,7 @@ export function EnvironmentsPage() {
           {environmentList.map((env, index) => (
             <TabsTrigger key={env.id} value={env.id} className="px-4">
               <span className="opacity-60 mr-1">{index + 1}.</span>
-              <EnvironmentName environment={env} />
+              <EnvironmentLabel environment={env} />
             </TabsTrigger>
           ))}
           <div className="flex-1" />

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -33,6 +33,7 @@ import {
   AlertDialogDescription,
   AlertDialogTitle,
 } from "@/react/components/ui/alert-dialog";
+import { Badge } from "@/react/components/ui/badge";
 import { Button } from "@/react/components/ui/button";
 import { Checkbox } from "@/react/components/ui/checkbox";
 import {
@@ -73,7 +74,6 @@ import {
 } from "@/react/hooks/useSessionPageSize";
 import {
   createAdvancedSearchParser,
-  legacyStateSearchParams,
   serializeAdvancedSearch,
   useURLSearchParam,
 } from "@/react/hooks/useURLSearchParam";
@@ -101,6 +101,10 @@ import {
   hostPortOfInstanceV1,
   supportedEngineV1List,
 } from "@/utils";
+import {
+  defaultActiveStateSearchParams,
+  getResourceStateFilter,
+} from "./resourceStateFilter";
 
 const ASSIGN_LICENSE_QUERY = "assignLicense";
 const ASSIGN_LICENSE_INSTANCES_QUERY = "instances";
@@ -440,7 +444,7 @@ export function InstancesPage() {
   const route = useCurrentRoute();
 
   const defaultSearchParams = useMemo<SearchParams>(
-    () => legacyStateSearchParams(route.query.state),
+    () => defaultActiveStateSearchParams(route.query.state),
     [route.query.state]
   );
   const [searchParams, setSearchParams] = useURLSearchParam<SearchParams>({
@@ -541,12 +545,7 @@ export function InstancesPage() {
   const searchText = searchParams.query;
 
   const stateFilterVal = getValueFromScopes(searchParams, "state");
-  const selectedState =
-    stateFilterVal === "DELETED"
-      ? State.DELETED
-      : stateFilterVal === "ALL"
-        ? undefined
-        : State.ACTIVE;
+  const selectedState = getResourceStateFilter(stateFilterVal);
 
   const envVal = getValueFromScopes(searchParams, "environment");
   const selectedEnvironment = envVal
@@ -919,6 +918,23 @@ export function InstancesPage() {
       render: (instance) => (
         <EnvironmentLabel environmentName={instance.environment ?? ""} />
       ),
+    },
+    {
+      key: "state",
+      title: t("common.state"),
+      defaultWidth: 120,
+      minWidth: 100,
+      resizable: true,
+      render: (instance) =>
+        instance.state === State.DELETED ? (
+          <Badge variant="warning" className="text-xs">
+            {t("common.archived")}
+          </Badge>
+        ) : (
+          <Badge variant="success" className="text-xs">
+            {t("common.active")}
+          </Badge>
+        ),
     },
     {
       key: "address",

--- a/frontend/src/react/pages/settings/InstancesPage.tsx
+++ b/frontend/src/react/pages/settings/InstancesPage.tsx
@@ -20,6 +20,7 @@ import {
 import { EngineIcon } from "@/react/components/EngineIcon";
 import { EnvironmentLabel } from "@/react/components/EnvironmentLabel";
 import { InstanceAssignmentSheet } from "@/react/components/InstanceAssignmentSheet";
+import { InstanceDeleteDialog } from "@/react/components/instance";
 import { PermissionGuard } from "@/react/components/PermissionGuard";
 import {
   type SelectionAction,
@@ -87,18 +88,15 @@ import { environmentNamePrefix } from "@/store/modules/v1/common";
 import {
   DEFAULT_ENVIRONMENT_COLOR,
   isValidInstanceName,
-  NULL_ENVIRONMENT_NAME,
   UNKNOWN_ENVIRONMENT_NAME,
   unknownEnvironment,
 } from "@/types";
 import { Engine, State } from "@/types/proto-es/v1/common_pb";
 import type { Instance } from "@/types/proto-es/v1/instance_service_pb";
 import { UpdateInstanceRequestSchema } from "@/types/proto-es/v1/instance_service_pb";
-import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import {
   engineNameV1,
   hasWorkspacePermissionV2,
-  hexToRgb,
   hostPortOfDataSource,
   hostPortOfInstanceV1,
   supportedEngineV1List,
@@ -188,75 +186,6 @@ function ConfirmDialog({
 }
 
 // ============================================================
-// EnvironmentName
-// ============================================================
-
-function EnvironmentName({ environmentName }: { environmentName: string }) {
-  const { t } = useTranslation();
-  const environmentList = useAppStore((s) => s.environmentList);
-  const environment = useMemo(
-    () =>
-      useAppStore
-        .getState()
-        .getEnvironmentByName(environmentName || NULL_ENVIRONMENT_NAME),
-    [environmentList, environmentName]
-  );
-
-  const isUnset =
-    environment.name === UNKNOWN_ENVIRONMENT_NAME ||
-    environment.name === NULL_ENVIRONMENT_NAME;
-
-  const hasEnvTierFeature = useAppStore((s) =>
-    s.hasInstanceFeature(PlanFeature.FEATURE_ENVIRONMENT_TIERS)
-  );
-  const isProtected =
-    hasEnvTierFeature && environment.tags?.protected === "protected";
-
-  const bgColorRgb = isUnset
-    ? null
-    : hexToRgb(environment.color || DEFAULT_ENVIRONMENT_COLOR);
-
-  return (
-    <span
-      className="inline-flex items-center gap-x-1"
-      style={
-        bgColorRgb && !isUnset
-          ? {
-              backgroundColor: `rgba(${bgColorRgb.join(", ")}, 0.1)`,
-              color: `rgb(${bgColorRgb.join(", ")})`,
-              padding: "0 6px",
-              borderRadius: "4px",
-            }
-          : undefined
-      }
-    >
-      <span className="truncate">
-        {isUnset ? (
-          <span className="text-control-light italic">
-            {t("common.unassigned")}
-          </span>
-        ) : (
-          environment.title
-        )}
-      </span>
-      {isProtected && !isUnset && (
-        <svg
-          className="w-4 h-4 shrink-0 text-current"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fillRule="evenodd"
-            d="M10 1.944A11.954 11.954 0 012.166 5C2.056 5.649 2 6.319 2 7c0 5.225 3.34 9.67 8 11.317C14.66 16.67 18 12.225 18 7c0-.682-.057-1.351-.166-2.001A11.954 11.954 0 0110 1.944zM11 14a1 1 0 11-2 0 1 1 0 012 0zm0-7a1 1 0 10-2 0v3a1 1 0 102 0V7z"
-            clipRule="evenodd"
-          />
-        </svg>
-      )}
-    </span>
-  );
-}
-
-// ============================================================
 // InstanceActionDropdown
 // ============================================================
 
@@ -319,26 +248,6 @@ function InstanceActionDropdown({
     }
   }, [instance, t, onAction]);
 
-  const handleDelete = useCallback(async () => {
-    try {
-      await useAppStore.getState().deleteInstance(instance.name);
-      pushNotification({
-        module: "bytebase",
-        style: "SUCCESS",
-        title: t("common.deleted"),
-      });
-      setShowDeleteConfirm(false);
-      onAction();
-    } catch (error: unknown) {
-      pushNotification({
-        module: "bytebase",
-        style: "CRITICAL",
-        title: t("common.delete"),
-        description: (error as { message?: string }).message,
-      });
-    }
-  }, [instance, t, onAction]);
-
   if (!canArchive && !canRestore) return null;
 
   const isActive = instance.state === State.ACTIVE;
@@ -373,7 +282,7 @@ function InstanceActionDropdown({
               {t("common.restore")}
             </DropdownMenuItem>
           )}
-          {(canArchive || canRestore) && (
+          {canArchive && (
             <DropdownMenuItem
               className="text-error"
               onClick={(e) => {
@@ -410,16 +319,11 @@ function InstanceActionDropdown({
         </label>
       </ConfirmDialog>
 
-      <ConfirmDialog
+      <InstanceDeleteDialog
         open={showDeleteConfirm}
-        variant="error"
-        title={t("common.delete-resource", {
-          type: instance.title,
-        })}
-        description={t("common.cannot-undo-this-action")}
-        okText={t("common.delete")}
-        onOk={handleDelete}
-        onCancel={() => setShowDeleteConfirm(false)}
+        instance={instance}
+        onOpenChange={setShowDeleteConfirm}
+        onDeleted={onAction}
       />
     </>
   );
@@ -595,11 +499,26 @@ export function InstancesPage() {
         title: t("common.state"),
         description: t("issue.advanced-search.scope.state.description"),
         options: [
-          { value: "ACTIVE", keywords: ["active"] },
+          {
+            value: "ACTIVE",
+            keywords: ["active"],
+            custom: true,
+            render: () => <span>{t("common.active")}</span>,
+          },
           ...(canUndelete
             ? [
-                { value: "DELETED", keywords: ["archived", "deleted"] },
-                { value: "ALL", keywords: ["all"] },
+                {
+                  value: "DELETED",
+                  keywords: ["archived", "deleted"],
+                  custom: true,
+                  render: () => <span>{t("common.archived")}</span>,
+                },
+                {
+                  value: "ALL",
+                  keywords: ["all"],
+                  custom: true,
+                  render: () => <span>{t("common.all")}</span>,
+                },
               ]
             : []),
         ],
@@ -998,7 +917,7 @@ export function InstancesPage() {
       resizable: true,
       sortable: true,
       render: (instance) => (
-        <EnvironmentName environmentName={instance.environment ?? ""} />
+        <EnvironmentLabel environmentName={instance.environment ?? ""} />
       ),
     },
     {

--- a/frontend/src/react/pages/settings/ProjectsPage.tsx
+++ b/frontend/src/react/pages/settings/ProjectsPage.tsx
@@ -40,7 +40,6 @@ import {
 } from "@/react/hooks/useSessionPageSize";
 import {
   createAdvancedSearchParser,
-  legacyStateSearchParams,
   serializeAdvancedSearch,
   useURLSearchParam,
 } from "@/react/hooks/useURLSearchParam";
@@ -58,6 +57,10 @@ import {
   hasProjectPermissionV2,
   hasWorkspacePermissionV2,
 } from "@/utils";
+import {
+  defaultActiveStateSearchParams,
+  getResourceStateFilter,
+} from "./resourceStateFilter";
 
 const parseProjectSearch = createAdvancedSearchParser(["state", "label"]);
 
@@ -244,7 +247,7 @@ export function ProjectsPage() {
   const route = useCurrentRoute();
 
   const defaultSearchParams = useMemo<SearchParams>(
-    () => legacyStateSearchParams(route.query.state),
+    () => defaultActiveStateSearchParams(route.query.state),
     [route.query.state]
   );
   const [searchParams, setSearchParams] = useURLSearchParam<SearchParams>({
@@ -297,12 +300,7 @@ export function ProjectsPage() {
 
   // Derived values from searchParams
   const searchText = searchParams.query;
-  const stateFilter = useMemo(() => {
-    const val = getValueFromScopes(searchParams, "state");
-    if (val === "DELETED") return "DELETED" as const;
-    if (val === "ALL") return "ALL" as const;
-    return "ACTIVE" as const;
-  }, [searchParams]);
+  const stateFilter = getValueFromScopes(searchParams, "state");
   const selectedLabels = useMemo(
     () =>
       searchParams.scopes.filter((s) => s.id === "label").map((s) => s.value),
@@ -355,11 +353,7 @@ export function ProjectsPage() {
     [sortKey, sortOrder]
   );
 
-  const selectedState = useMemo(() => {
-    if (stateFilter === "DELETED") return State.DELETED;
-    if (stateFilter === "ALL") return undefined;
-    return State.ACTIVE;
-  }, [stateFilter]);
+  const selectedState = getResourceStateFilter(stateFilter);
 
   const fetchProjects = useCallback(
     async (isRefresh: boolean) => {
@@ -635,6 +629,7 @@ export function ProjectsPage() {
           loading={loading}
           showSelection={canDelete}
           showLabels
+          showState
           showActions
           renderActions={(project) => (
             <ProjectActionDropdown

--- a/frontend/src/react/pages/settings/ProjectsPage.tsx
+++ b/frontend/src/react/pages/settings/ProjectsPage.tsx
@@ -262,11 +262,26 @@ export function ProjectsPage() {
       title: t("common.state"),
       description: t("issue.advanced-search.scope.state.description"),
       options: [
-        { value: "ACTIVE", keywords: ["active"] },
+        {
+          value: "ACTIVE",
+          keywords: ["active"],
+          custom: true,
+          render: () => <span>{t("common.active")}</span>,
+        },
         ...(canUndelete
           ? [
-              { value: "DELETED", keywords: ["archived", "deleted"] },
-              { value: "ALL", keywords: ["all"] },
+              {
+                value: "DELETED",
+                keywords: ["archived", "deleted"],
+                custom: true,
+                render: () => <span>{t("common.archived")}</span>,
+              },
+              {
+                value: "ALL",
+                keywords: ["all"],
+                custom: true,
+                render: () => <span>{t("common.all")}</span>,
+              },
             ]
           : []),
       ],
@@ -585,10 +600,6 @@ export function ProjectsPage() {
     []
   );
 
-  const getProjectHref = useCallback((project: Project) => {
-    return router.resolve(projectIssuesRoute(project)).fullPath;
-  }, []);
-
   const handleProjectAction = useCallback(() => {
     fetchProjects(true);
   }, [fetchProjects]);
@@ -631,7 +642,6 @@ export function ProjectsPage() {
               onAction={handleProjectAction}
             />
           )}
-          getRowHref={getProjectHref}
           selectedProjectNames={Array.from(selectedNames)}
           onSelectedChange={(names) => setSelectedNames(new Set(names))}
           sortKey={sortKey}

--- a/frontend/src/react/pages/settings/resourceStateFilter.test.ts
+++ b/frontend/src/react/pages/settings/resourceStateFilter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { State } from "@/types/proto-es/v1/common_pb";
+import {
+  defaultActiveStateSearchParams,
+  getResourceStateFilter,
+} from "./resourceStateFilter";
+
+describe("defaultActiveStateSearchParams", () => {
+  test("uses active state as the default filter", () => {
+    expect(defaultActiveStateSearchParams(undefined)).toEqual({
+      query: "",
+      scopes: [{ id: "state", value: "ACTIVE" }],
+    });
+  });
+
+  test("preserves legacy archived and all state query values", () => {
+    expect(defaultActiveStateSearchParams("archived").scopes).toEqual([
+      { id: "state", value: "DELETED" },
+    ]);
+    expect(defaultActiveStateSearchParams("all").scopes).toEqual([
+      { id: "state", value: "ALL" },
+    ]);
+  });
+});
+
+describe("getResourceStateFilter", () => {
+  test("maps an explicit active state to active resources", () => {
+    expect(getResourceStateFilter("ACTIVE")).toBe(State.ACTIVE);
+  });
+
+  test("maps an explicit deleted state to archived resources", () => {
+    expect(getResourceStateFilter("DELETED")).toBe(State.DELETED);
+  });
+
+  test("maps all or no state scope to all resources", () => {
+    expect(getResourceStateFilter("ALL")).toBeUndefined();
+    expect(getResourceStateFilter(undefined)).toBeUndefined();
+  });
+});

--- a/frontend/src/react/pages/settings/resourceStateFilter.ts
+++ b/frontend/src/react/pages/settings/resourceStateFilter.ts
@@ -1,0 +1,25 @@
+import type { SearchParams } from "@/react/components/AdvancedSearch";
+import { legacyStateSearchParams } from "@/react/hooks/useURLSearchParam";
+import { State } from "@/types/proto-es/v1/common_pb";
+
+export const defaultActiveStateSearchParams = (
+  state: unknown
+): SearchParams => {
+  const legacy = legacyStateSearchParams(state);
+  if (legacy.scopes.length > 0) {
+    return legacy;
+  }
+  return { query: "", scopes: [{ id: "state", value: "ACTIVE" }] };
+};
+
+export const getResourceStateFilter = (
+  stateFilterValue: string | undefined
+): State | undefined => {
+  if (stateFilterValue === "ACTIVE") {
+    return State.ACTIVE;
+  }
+  if (stateFilterValue === "DELETED") {
+    return State.DELETED;
+  }
+  return undefined;
+};


### PR DESCRIPTION
- Show alert for double confirm when delete instance. For unarchved instance, this action will auto-archive + auto-delete the instance
<img width="1132" height="662" alt="CleanShot 2026-07-17 at 16 46 05@2x" src="https://github.com/user-attachments/assets/c96b8d87-4242-48cd-b145-ec8a87b4a627" />

- Use `Active` and `Archived` for state filter to avoid confusion. Because for frontend users, the delete is hard-delete

<img width="690" height="470" alt="CleanShot 2026-07-17 at 17 15 26@2x" src="https://github.com/user-attachments/assets/fee282cf-e944-4fff-890f-966fa4767ad6" />

- Project and instance page will add `state=ACTIVE` filter by default
- Extract and use the `ProjectLabel` and `EnvironmentLabel`
