### PR TITLE
chore(frontend): upgrade react-router to v8

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -82,7 +82,7 @@
     "react-i18next": "^17.0.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^4.11.0",
-    "react-router-dom": "^7.16.0",
+    "react-router": "^8.2.0",
     "regenerator-runtime": "^0.14.1",
     "rxjs": "^7.8.2",
     "scroll-into-view-if-needed": "^3.1.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -181,9 +181,9 @@ importers:
       react-resizable-panels:
         specifier: ^4.11.0
         version: 4.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-router-dom:
-        specifier: ^7.16.0
-        version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-router:
+        specifier: ^8.2.0
+        version: 8.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       regenerator-runtime:
         specifier: ^0.14.1
         version: 0.14.1
@@ -2434,9 +2434,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
@@ -3685,19 +3684,12 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  react-router-dom@7.18.1:
-    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.2.0:
+    resolution: {integrity: sha512-uP1LgGNHyilL1u+ZkecQk74DJOKOb6q4NLNYLRJcD/fjoogftNb5/Rj/07o/QBFsY/5MbAKPm1peTCQuVPv9cQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
-
-  react-router@7.18.1:
-    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -6472,7 +6464,7 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@1.1.1: {}
+  cookie-es@3.1.1: {}
 
   core-js-compat@3.49.0:
     dependencies:
@@ -7936,17 +7928,10 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
-  react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-router@8.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
+      cookie-es: 3.1.1
       react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-router: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-
-  react-router@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      cookie: 1.1.1
-      react: 19.2.7
-      set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.7(react@19.2.7)
 

--- a/frontend/src/react/app/AppRoot.tsx
+++ b/frontend/src/react/app/AppRoot.tsx
@@ -2,8 +2,8 @@ import {
   createBrowserRouter,
   type LoaderFunctionArgs,
   matchRoutes,
-  RouterProvider,
-} from "react-router-dom";
+} from "react-router";
+import { RouterProvider } from "react-router/dom";
 import { rootGuard } from "@/react/router/guard";
 import { setAppRouter, setRouteNameIndex } from "@/react/router/navigation";
 import { buildRouteNameIndex, routes } from "@/react/router/routes";

--- a/frontend/src/react/app/AuthGate.test.tsx
+++ b/frontend/src/react/app/AuthGate.test.tsx
@@ -60,7 +60,7 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
   useLocation: () => mocks.location,
   useMatches: () => [{ handle: { name: mocks.routeName } }],
   useNavigate: () => mocks.navigate,

--- a/frontend/src/react/app/AuthGate.tsx
+++ b/frontend/src/react/app/AuthGate.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation, useMatches, useNavigate } from "react-router-dom";
+import { useLocation, useMatches, useNavigate } from "react-router";
 import { InactiveRemindModal } from "@/react/components/auth/InactiveRemindModal";
 import {
   buildSigninRedirectQuery,

--- a/frontend/src/react/app/RootLayout.tsx
+++ b/frontend/src/react/app/RootLayout.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
-import type { Location } from "react-router-dom";
-import { matchRoutes, Outlet, useBlocker } from "react-router-dom";
+import type { Location } from "react-router";
+import { matchRoutes, Outlet, useBlocker } from "react-router";
 import { AuthGate } from "@/react/app/AuthGate";
 import { SessionExpiredSurfaceGate } from "@/react/app/SessionExpiredSurfaceGate";
 import { Toaster } from "@/react/components/ui/toaster";

--- a/frontend/src/react/app/RouteErrorPage.test.tsx
+++ b/frontend/src/react/app/RouteErrorPage.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { createMemoryRouter, Outlet, RouterProvider } from "react-router-dom";
+import { createMemoryRouter, Outlet } from "react-router";
+import { RouterProvider } from "react-router/dom";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { RouteErrorPage } from "./RouteErrorPage";
 

--- a/frontend/src/react/app/RouteErrorPage.tsx
+++ b/frontend/src/react/app/RouteErrorPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
-import { useRouteError } from "react-router-dom";
+import { useRouteError } from "react-router";
 import { Button } from "@/react/components/ui/button";
 import { cn } from "@/react/lib/utils";
 

--- a/frontend/src/react/app/layouts/BodyLayout.tsx
+++ b/frontend/src/react/app/layouts/BodyLayout.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { Outlet, useLocation, useMatches } from "react-router-dom";
+import { Outlet, useLocation, useMatches } from "react-router";
 import { DashboardBodyShell } from "@/react/components/DashboardBodyShell";
 import { DashboardSidebar } from "@/react/components/DashboardSidebar";
 import { ProjectSidebar } from "@/react/components/ProjectSidebar";

--- a/frontend/src/react/app/layouts/DashboardLayout.tsx
+++ b/frontend/src/react/app/layouts/DashboardLayout.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { createPortal } from "react-dom";
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 import { DashboardFrameShell } from "@/react/components/DashboardFrameShell";
 import type { DashboardFrameShellTargets } from "@/react/dashboard-shell";
 import { useEnsureWorkspaceCommonData } from "@/react/hooks/useEnsureWorkspaceCommonData";

--- a/frontend/src/react/app/layouts/SplashLayout.test.tsx
+++ b/frontend/src/react/app/layouts/SplashLayout.test.tsx
@@ -9,7 +9,7 @@ const storeState = vi.hoisted(() => ({
   isTrialing: false,
 }));
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
   Outlet: () => <div data-testid="auth-page" />,
   useMatches: () => [{ handle: { name: AUTH_SIGNIN_MODULE } }],
 }));

--- a/frontend/src/react/app/layouts/SplashLayout.tsx
+++ b/frontend/src/react/app/layouts/SplashLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Outlet, useMatches } from "react-router-dom";
+import { Outlet, useMatches } from "react-router";
 import signinImage from "@/assets/illustration/signin.webp";
 import signupImage from "@/assets/illustration/signup.webp";
 import { AUTH_SIGNUP_MODULE } from "@/react/router/handles";

--- a/frontend/src/react/hooks/useURLSearchParam.test.tsx
+++ b/frontend/src/react/hooks/useURLSearchParam.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MemoryRouter, useLocation, useNavigate } from "react-router-dom";
+import { MemoryRouter, useLocation, useNavigate } from "react-router";
 import { describe, expect, test } from "vitest";
 import {
   createAdvancedSearchParser,

--- a/frontend/src/react/hooks/useURLSearchParam.ts
+++ b/frontend/src/react/hooks/useURLSearchParam.ts
@@ -5,7 +5,7 @@ import {
   useMemo,
   useRef,
 } from "react";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams } from "react-router";
 import {
   buildSearchParamsBySearchText,
   buildSearchTextBySearchParams,

--- a/frontend/src/react/pages/settings/DatabasesPage.test.tsx
+++ b/frontend/src/react/pages/settings/DatabasesPage.test.tsx
@@ -1,6 +1,6 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { MemoryRouter } from "react-router-dom";
+import { MemoryRouter } from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 (

--- a/frontend/src/react/pages/settings/InstanceDetailPage.tsx
+++ b/frontend/src/react/pages/settings/InstanceDetailPage.tsx
@@ -2,7 +2,7 @@ import { create } from "@bufbuild/protobuf";
 import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router";
 import {
   AdvancedSearch,
   getValueFromScopes,

--- a/frontend/src/react/router/NavigationScrollRestoration.test.tsx
+++ b/frontend/src/react/router/NavigationScrollRestoration.test.tsx
@@ -1,10 +1,7 @@
 import { act, useState } from "react";
 import { createRoot } from "react-dom/client";
-import {
-  createMemoryRouter,
-  Outlet,
-  RouterProvider,
-} from "react-router-dom";
+import { createMemoryRouter, Outlet } from "react-router";
+import { RouterProvider } from "react-router/dom";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { setAppRouter } from "./navigation";
 import {

--- a/frontend/src/react/router/NavigationScrollRestoration.tsx
+++ b/frontend/src/react/router/NavigationScrollRestoration.tsx
@@ -9,11 +9,7 @@ import {
   useRef,
   useState,
 } from "react";
-import {
-  type Location,
-  useLocation,
-  useNavigationType,
-} from "react-router-dom";
+import { type Location, useLocation, useNavigationType } from "react-router";
 import type { PagedDataResult } from "@/react/hooks/usePagedData";
 import { getAppRouterState, subscribeRoute } from "@/react/router/navigation";
 import { minmax } from "@/utils/math";

--- a/frontend/src/react/router/ProjectRouteGate.test.tsx
+++ b/frontend/src/react/router/ProjectRouteGate.test.tsx
@@ -28,7 +28,7 @@ const mocks = vi.hoisted(() => ({
   notify: vi.fn(),
 }));
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
   Outlet: () => <div data-testid="outlet" />,
   useParams: () => mocks.params,
 }));

--- a/frontend/src/react/router/ProjectRouteGate.tsx
+++ b/frontend/src/react/router/ProjectRouteGate.tsx
@@ -1,6 +1,6 @@
 import { LoaderCircle } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { Outlet, useParams } from "react-router-dom";
+import { Outlet, useParams } from "react-router";
 import {
   PermissionDeniedFallback,
   useComponentPermissionState,

--- a/frontend/src/react/router/guard.test.ts
+++ b/frontend/src/react/router/guard.test.ts
@@ -1,4 +1,4 @@
-import { matchRoutes } from "react-router-dom";
+import { matchRoutes, RouterContextProvider } from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 // Configurable fake session, controlled per test.
@@ -89,7 +89,7 @@ async function runCatchAllLoader(path: string): Promise<Response> {
     url,
     pattern: "*",
     params: {},
-    context: {},
+    context: new RouterContextProvider(),
   }) as Response | Promise<Response>;
 }
 

--- a/frontend/src/react/router/guard.ts
+++ b/frontend/src/react/router/guard.ts
@@ -1,4 +1,4 @@
-import { redirect } from "react-router-dom";
+import { redirect } from "react-router";
 import { useAppStore } from "@/react/stores/app";
 import { DatabaseChangeMode } from "@/types/proto-es/v1/setting_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";

--- a/frontend/src/react/router/index.ts
+++ b/frontend/src/react/router/index.ts
@@ -3,7 +3,7 @@ import {
   useNavigate as useReactRouterNavigate,
   useMatches,
   useParams,
-} from "react-router-dom";
+} from "react-router";
 import type { Permission } from "@/types";
 import type {
   NavigationOptions,

--- a/frontend/src/react/router/issueDetailRedirect.test.ts
+++ b/frontend/src/react/router/issueDetailRedirect.test.ts
@@ -1,4 +1,4 @@
-import type { LoaderFunctionArgs } from "react-router-dom";
+import type { LoaderFunctionArgs } from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({

--- a/frontend/src/react/router/issueDetailRedirect.ts
+++ b/frontend/src/react/router/issueDetailRedirect.ts
@@ -1,5 +1,5 @@
 import { create } from "@bufbuild/protobuf";
-import { type LoaderFunctionArgs, redirect } from "react-router-dom";
+import { type LoaderFunctionArgs, redirect } from "react-router";
 import { issueServiceClientConnect, planServiceClientConnect } from "@/connect";
 import { shouldStayOnPlanDetailPage } from "@/react/pages/project/plan-detail/utils/header";
 import { issueNamePrefix, projectNamePrefix } from "@/store/modules/v1/common";

--- a/frontend/src/react/router/layoutPlaceholders.tsx
+++ b/frontend/src/react/router/layoutPlaceholders.tsx
@@ -10,6 +10,6 @@
 //
 // (The Splash / Body / Dashboard layout placeholders that previously lived here
 // have been replaced by the real layouts in `@/react/app/layouts/*`.)
-import { Outlet } from "react-router-dom";
+import { Outlet } from "react-router";
 
 export const RouteShellOutletPlaceholder = () => <Outlet />;

--- a/frontend/src/react/router/lazyPage.ts
+++ b/frontend/src/react/router/lazyPage.ts
@@ -1,5 +1,5 @@
 import { type ComponentType, createElement, useMemo } from "react";
-import { useLocation, useMatches, useParams } from "react-router-dom";
+import { useLocation, useMatches, useParams } from "react-router";
 
 // Adapter for react-router's `lazy` route field.
 //

--- a/frontend/src/react/router/routes.test.tsx
+++ b/frontend/src/react/router/routes.test.tsx
@@ -1,4 +1,4 @@
-import { matchRoutes, type RouteObject } from "react-router-dom";
+import { matchRoutes, type RouteObject } from "react-router";
 import { describe, expect, it } from "vitest";
 import { WORKSPACE_ROUTE_404 } from "@/react/router/handles";
 import { routes } from "./routes";

--- a/frontend/src/react/router/routes.tsx
+++ b/frontend/src/react/router/routes.tsx
@@ -1,4 +1,4 @@
-import type { RouteObject } from "react-router-dom";
+import type { RouteObject } from "react-router";
 import { RootLayout } from "@/react/app/RootLayout";
 import { RouteErrorPage } from "@/react/app/RouteErrorPage";
 import { rootGuard } from "@/react/router/guard";

--- a/frontend/src/react/router/routes/auth.tsx
+++ b/frontend/src/react/router/routes/auth.tsx
@@ -1,4 +1,4 @@
-import type { RouteObject } from "react-router-dom";
+import type { RouteObject } from "react-router";
 import { SplashLayout } from "@/react/app/layouts/SplashLayout";
 import {
   AUTH_2FA_SETUP_MODULE,

--- a/frontend/src/react/router/routes/dashboard.tsx
+++ b/frontend/src/react/router/routes/dashboard.tsx
@@ -1,4 +1,4 @@
-import { Navigate, type RouteObject, redirect } from "react-router-dom";
+import { Navigate, type RouteObject, redirect } from "react-router";
 import { BodyLayout } from "@/react/app/layouts/BodyLayout";
 import { DashboardLayout } from "@/react/app/layouts/DashboardLayout";
 import { RouteErrorPage } from "@/react/app/RouteErrorPage";

--- a/frontend/src/react/router/routes/sqlEditor.tsx
+++ b/frontend/src/react/router/routes/sqlEditor.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense } from "react";
-import { Outlet, type RouteObject } from "react-router-dom";
+import { Outlet, type RouteObject } from "react-router";
 import {
   SQL_EDITOR_DATABASE_MODULE,
   SQL_EDITOR_HOME_MODULE,

--- a/frontend/src/react/router/useCurrentRoute.integration.test.tsx
+++ b/frontend/src/react/router/useCurrentRoute.integration.test.tsx
@@ -1,6 +1,7 @@
 import { act } from "react";
 import { createRoot } from "react-dom/client";
-import { createMemoryRouter, Outlet, RouterProvider } from "react-router-dom";
+import { createMemoryRouter, Outlet } from "react-router";
+import { RouterProvider } from "react-router/dom";
 import { describe, expect, test } from "vitest";
 import { SQL_EDITOR_DATABASE_MODULE } from "./handles";
 import { type ReactRoute, useCurrentRoute } from "./index";

--- a/frontend/src/react/router/useCurrentRoute.test.tsx
+++ b/frontend/src/react/router/useCurrentRoute.test.tsx
@@ -30,7 +30,7 @@ const mocks = vi.hoisted(() => ({
   ],
 }));
 
-vi.mock("react-router-dom", () => ({
+vi.mock("react-router", () => ({
   useLocation: () => mocks.location,
   useMatches: () => mocks.matches,
   useNavigate: () => vi.fn(),

--- a/frontend/vite-plugin-export-csp-hashes.ts
+++ b/frontend/vite-plugin-export-csp-hashes.ts
@@ -110,37 +110,7 @@ export function exportCspHashes(): Plugin {
           );
         }
 
-        // 2. Hash dynamically-injected scripts (e.g., iframe content)
-        const dynamicScripts = [
-          "src/components/MarkdownEditor/resize-observer.ts",
-        ];
-        console.log(
-          `✓ Computing hashes for ${dynamicScripts.length} dynamically-injected scripts...`
-        );
-
-        for (const scriptPath of dynamicScripts) {
-          try {
-            const fullPath = resolve(__dirname, scriptPath);
-            const scriptContent = readFileSync(fullPath, "utf-8");
-            const hash = computeSha256(scriptContent);
-            const cspHash = `'sha256-${hash}'`;
-
-            allHashes.add(cspHash);
-            inlineScriptSources.push({
-              file: scriptPath,
-              content:
-                scriptContent.length > 60
-                  ? scriptContent.substring(0, 60) + "..."
-                  : scriptContent,
-              hash: cspHash,
-            });
-            console.log(`  ✓ ${scriptPath} -> ${cspHash}`);
-          } catch (error) {
-            console.warn(`  ⚠️  Failed to hash ${scriptPath}:`, error);
-          }
-        }
-
-        // 3. Scan built HTML files for inline scripts
+        // 2. Scan built HTML files for inline scripts
         const htmlFiles = findHtmlFiles(outDir);
         console.log(
           `✓ Scanning ${htmlFiles.length} HTML files for inline scripts...`


### PR DESCRIPTION
## What

- Upgrade `react-router-dom@7.16` → `react-router@8.2.0`. The `react-router-dom` package is removed in v8, so imports are swapped: `RouterProvider` now comes from `react-router/dom`, everything else from `react-router` (32 files, mechanical).
- v8 always enables middleware, so a loader's `context` is typed as `RouterContextProvider`; `guard.test.ts` now constructs one instead of passing `{}` when invoking a route loader directly.
- Remove the dead dynamic-script hashing block from `vite-plugin-export-csp-hashes.ts`: it hashed `src/components/MarkdownEditor/resize-observer.ts`, which was deleted with the Vue removal, so it only emitted a warning on every build. The plugin still collects legacy-plugin hashes and scans built HTML for inline scripts.

No behavior change: the app already runs on the data-router APIs (`createBrowserRouter` + loaders) that carry over unchanged, and none of the other v8 breaking changes (`hasErrorBoundary`, `future` flags, meta `data` param) are used in this codebase. React ≥ 19.2.7 and Node ≥ 22.22 requirements are already met (React 19.2.7 installed, CI on Node 24.18).

## Testing

- `pnpm --dir frontend check` ✓ (i18n, layering, locale sorter all pass)
- `pnpm --dir frontend type-check` ✓
- `pnpm --dir frontend test` ✓ — 371 files, 2940 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)