### PR TITLE
perf: optimize plan migration high-water lookup

### DIFF
--- a/backend/migrator/migration_3_21_1.go
+++ b/backend/migrator/migration_3_21_1.go
@@ -142,10 +142,16 @@ func captureMigration3_21_1HighWater(ctx context.Context, conn *sql.Conn, projec
 	highWaterByProject := make(map[string]int64)
 	if len(lockedProjectIDs) > 0 {
 		rows, err := tx.QueryContext(ctx, `
-			SELECT project, MAX(id)
-			FROM plan
-			WHERE project = ANY($1)
-			GROUP BY project`, pq.Array(lockedProjectIDs))
+			SELECT locked_project.project_id, latest_plan.id
+			FROM unnest($1::TEXT[]) AS locked_project(project_id)
+			CROSS JOIN LATERAL (
+				SELECT plan.id
+				FROM plan
+				WHERE plan.project = locked_project.project_id
+				ORDER BY plan.id DESC
+				LIMIT 1
+			) AS latest_plan
+			ORDER BY locked_project.project_id`, pq.Array(lockedProjectIDs))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to capture UI Plan high-water marks")
 		}


### PR DESCRIPTION
## Summary

- replace grouped `MAX(id)` aggregation with one reverse primary-key index probe per locked project
- preserve the existing bounded project high-water capture and migration behavior

## Why

The 3.21.1 backfill previously aggregated all Plan rows for up to 100 locked projects to determine each high-water mark. On installations with long Plan histories, PostgreSQL could scan substantial history while Plan and Issue creation waited on those project locks.

The lateral lookup fixes the project first and reads the latest Plan with `ORDER BY id DESC LIMIT 1`, allowing the `(project, id)` primary key to answer each high-water lookup directly.

Follow-up to #20928.

## Validation

- `go test -count=1 ./backend/migrator`
- `go test -v -count=1 -parallel 2 ./backend/tests/ -run '^(TestClaim|TestCollision)' -timeout 5m`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- `go build -ldflags '-w -s' -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
