### PR TITLE
fix: guard skipped rollout tasks

### DIFF
--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -864,6 +864,9 @@ func (s *RolloutService) BatchRunTasks(ctx context.Context, req *connect.Request
 		if !taskIDsToRunMap[task.ID] {
 			continue
 		}
+		if task.Payload.GetSkipped() {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.Errorf("task %d has been skipped and cannot be run", task.ID))
+		}
 
 		create := &store.TaskRunMessage{
 			TaskUID:   task.ID,
@@ -977,7 +980,7 @@ func (s *RolloutService) BatchSkipTasks(ctx context.Context, req *connect.Reques
 	if !ok {
 		return nil, connect.NewError(connect.CodeInternal, errors.New("user not found"))
 	}
-	var taskUIDs []int64
+	var requestedTasks []*store.TaskMessage
 	environmentSet := map[string]struct{}{}
 	for _, task := range request.Tasks {
 		_, _, _, taskID, err := common.GetProjectIDPlanIDStageIDTaskID(task)
@@ -988,7 +991,7 @@ func (s *RolloutService) BatchSkipTasks(ctx context.Context, req *connect.Reques
 		if !ok {
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("task %v not found in the rollout", taskID))
 		}
-		taskUIDs = append(taskUIDs, taskID)
+		requestedTasks = append(requestedTasks, taskMsg)
 		environmentSet[taskMsg.Environment] = struct{}{}
 	}
 
@@ -1000,6 +1003,23 @@ func (s *RolloutService) BatchSkipTasks(ctx context.Context, req *connect.Reques
 		if !ok {
 			return nil, connect.NewError(connect.CodePermissionDenied, errors.Errorf("not allowed to skip tasks in environment %q", environment))
 		}
+	}
+
+	var taskUIDs []int64
+	for _, task := range requestedTasks {
+		if task.Payload.GetSkipped() {
+			continue
+		}
+		switch task.LatestTaskRunStatus {
+		case storepb.TaskRun_NOT_STARTED, storepb.TaskRun_FAILED, storepb.TaskRun_CANCELED:
+			taskUIDs = append(taskUIDs, task.ID)
+		default:
+			status := convertToTaskStatus(task.LatestTaskRunStatus, false)
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.Errorf("task %d cannot be skipped in status %s", task.ID, status.String()))
+		}
+	}
+	if len(taskUIDs) == 0 {
+		return connect.NewResponse(&v1pb.BatchSkipTasksResponse{}), nil
 	}
 
 	if err := s.store.BatchSkipTasks(ctx, projectID, taskUIDs, request.Reason); err != nil {

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -480,9 +480,16 @@ func (s *Store) ListTaskStatusCountByPlanIDs(ctx context.Context, projectIDs []s
 // BatchSkipTasks batch skip tasks.
 func (s *Store) BatchSkipTasks(ctx context.Context, projectID string, taskUIDs []int64, comment string) error {
 	q := qb.Q().Space(`
-		UPDATE task
+		UPDATE task AS t
 		SET payload = payload || jsonb_build_object('skipped', ?::BOOLEAN) || jsonb_build_object('skippedReason', ?::TEXT)
-		WHERE id = ANY(?) AND project = ?`, true, comment, taskUIDs, projectID)
+		WHERE t.id = ANY(?) AND t.project = ?
+		AND (t.payload->>'skipped')::BOOLEAN IS NOT TRUE
+		AND NOT EXISTS (
+			SELECT 1 FROM task_run
+			WHERE task_run.task_id = t.id AND task_run.project = t.project
+			AND task_run.status IN (?, ?, ?, ?)
+		)`, true, comment, taskUIDs, projectID,
+		storepb.TaskRun_PENDING.String(), storepb.TaskRun_AVAILABLE.String(), storepb.TaskRun_RUNNING.String(), storepb.TaskRun_DONE.String())
 	query, args, err := q.ToSQL()
 	if err != nil {
 		return errors.Wrapf(err, "failed to build sql")

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -298,7 +298,7 @@ func (s *Store) UpdateTaskRunStartAt(ctx context.Context, projectID string, task
 
 // CreatePendingTaskRuns creates pending task runs.
 // This operation is idempotent and safe for concurrent calls:
-// - Uses WHERE NOT EXISTS to skip tasks that already have active (PENDING/RUNNING/DONE) task runs
+// - Excludes skipped tasks and tasks that already have active (PENDING/RUNNING/DONE) task runs
 // - Uses ON CONFLICT DO NOTHING to handle race conditions where two requests try to create the same task run
 // - The unique constraint on (task_id, attempt) ensures no duplicates
 func (s *Store) CreatePendingTaskRuns(ctx context.Context, creator string, creates ...*TaskRunMessage) error {
@@ -349,15 +349,15 @@ func (s *Store) CreatePendingTaskRuns(ctx context.Context, creator string, creat
 	}
 
 	// Single query that:
-	// 1. Assigns per-project IDs using ROW_NUMBER() + baseID
-	// 2. Filters out tasks with existing PENDING/RUNNING/DONE task runs (idempotent)
-	// 3. Calculates next attempt for each remaining task
-	// 4. Inserts task runs
-	// 5. Uses ON CONFLICT DO NOTHING to handle race conditions
+	// 1. Locks task rows so task-run creation and skipping cannot both win
+	// 2. Assigns per-project IDs using ROW_NUMBER() + baseID
+	// 3. Filters out tasks with existing PENDING/RUNNING/DONE task runs (idempotent)
+	// 4. Calculates next attempt for each remaining task
+	// 5. Inserts task runs
+	// 6. Uses ON CONFLICT DO NOTHING to handle race conditions
 	q := qb.Q().Space(`
-		WITH candidates AS (
+		WITH requested_tasks AS (
 			SELECT
-				(ROW_NUMBER() OVER ()) + ? - 1 AS new_id,
 				tasks.project,
 				tasks.task_id,
 				tasks.run_at
@@ -367,6 +367,17 @@ func (s *Store) CreatePendingTaskRuns(ctx context.Context, creator string, creat
 					unnest(CAST(? AS BIGINT[])) AS task_id,
 					unnest(CAST(? AS TIMESTAMPTZ[])) AS run_at
 			) tasks
+			JOIN task ON task.project = tasks.project AND task.id = tasks.task_id
+			WHERE (task.payload->>'skipped')::BOOLEAN IS NOT TRUE
+			ORDER BY tasks.project, tasks.task_id
+			FOR UPDATE OF task
+		), candidates AS (
+			SELECT
+				(ROW_NUMBER() OVER ()) + ? - 1 AS new_id,
+				tasks.project,
+				tasks.task_id,
+				tasks.run_at
+			FROM requested_tasks tasks
 			WHERE NOT EXISTS (
 				SELECT 1 FROM task_run
 				WHERE task_run.task_id = tasks.task_id
@@ -395,7 +406,7 @@ func (s *Store) CreatePendingTaskRuns(ctx context.Context, creator string, creat
 			?
 		FROM candidates
 		ON CONFLICT (project, task_id, attempt) DO NOTHING
-	`, baseID, projects, taskUIDs, runAts,
+	`, projects, taskUIDs, runAts, baseID,
 		storepb.TaskRun_PENDING.String(), storepb.TaskRun_AVAILABLE.String(), storepb.TaskRun_RUNNING.String(), storepb.TaskRun_DONE.String(),
 		creatorPtr, storepb.TaskRun_PENDING.String(), payloadStr)
 

--- a/backend/tests/cross_project_update_test.go
+++ b/backend/tests/cross_project_update_test.go
@@ -9,7 +9,9 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/bytebase/bytebase/backend/common"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 )
 
@@ -84,6 +86,93 @@ func TestCollisionCreateRolloutIsolation(t *testing.T) {
 	fixture.completeRolloutB(ctx, t, ctl)
 	aAfter := snapshotProject(ctx, t, ctl, fixture.ProjectA)
 	assertProjectUnchanged(t, fixture.BaselineA, aAfter, "project A after project B rollout")
+}
+
+// TestCollisionBatchRunTasksNoCrossProjectEffect verifies that creating a
+// pending task run in project B cannot mutate project A's colliding task or
+// task_run rows.
+func TestCollisionBatchRunTasksNoCrossProjectEffect(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	fixture := setupCollidingProjects(ctx, t, ctl)
+	a.Greater(len(fixture.BaselineA.TaskRuns), 0, "project A should have task_runs")
+
+	rolloutB, err := ctl.rolloutServiceClient.CreateRollout(ctx,
+		connect.NewRequest(&v1pb.CreateRolloutRequest{Parent: fixture.PlanB.Name}))
+	a.NoError(err)
+	a.Greater(len(rolloutB.Msg.Stages), 0, "project B rollout should have stages")
+	a.Greater(len(rolloutB.Msg.Stages[0].Tasks), 0, "project B rollout should have tasks")
+	taskB := rolloutB.Msg.Stages[0].Tasks[0]
+
+	_, err = ctl.rolloutServiceClient.BatchRunTasks(ctx,
+		connect.NewRequest(&v1pb.BatchRunTasksRequest{
+			Parent:  rolloutB.Msg.Stages[0].Name,
+			Tasks:   []string{taskB.Name},
+			RunTime: timestamppb.New(time.Now().Add(time.Hour)),
+		}))
+	a.NoError(err)
+
+	assertTasksCollide(ctx, t, ctl, fixture)
+	assertTaskRunsCollide(ctx, t, ctl, fixture)
+	aAfter := snapshotProject(ctx, t, ctl, fixture.ProjectA)
+	assertProjectUnchanged(t, fixture.BaselineA, aAfter, "project A after project B task run creation")
+}
+
+// TestCollisionBatchSkipTasksNoCrossProjectEffect verifies that skipping a
+// task in project B cannot mark project A's same-id task as skipped.
+func TestCollisionBatchSkipTasksNoCrossProjectEffect(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	fixture := setupCollidingProjects(ctx, t, ctl)
+	a.Greater(len(fixture.BaselineA.TaskRuns), 0, "project A should have task_runs")
+
+	rolloutA, err := ctl.rolloutServiceClient.GetRollout(ctx,
+		connect.NewRequest(&v1pb.GetRolloutRequest{Name: fixture.PlanA.Name + "/rollout"}))
+	a.NoError(err)
+	rolloutB, err := ctl.rolloutServiceClient.CreateRollout(ctx,
+		connect.NewRequest(&v1pb.CreateRolloutRequest{Parent: fixture.PlanB.Name}))
+	a.NoError(err)
+	a.Greater(len(rolloutA.Msg.Stages), 0, "project A rollout should have stages")
+	a.Greater(len(rolloutA.Msg.Stages[0].Tasks), 0, "project A rollout should have tasks")
+	a.Greater(len(rolloutB.Msg.Stages), 0, "project B rollout should have stages")
+	a.Greater(len(rolloutB.Msg.Stages[0].Tasks), 0, "project B rollout should have tasks")
+	taskA := rolloutA.Msg.Stages[0].Tasks[0]
+	taskB := rolloutB.Msg.Stages[0].Tasks[0]
+	_, _, _, taskAID, err := common.GetProjectIDPlanIDStageIDTaskID(taskA.Name)
+	a.NoError(err)
+	_, _, _, taskBID, err := common.GetProjectIDPlanIDStageIDTaskID(taskB.Name)
+	a.NoError(err)
+	a.Equal(taskAID, taskBID, "project A and B task IDs should collide")
+
+	_, err = ctl.rolloutServiceClient.BatchSkipTasks(ctx,
+		connect.NewRequest(&v1pb.BatchSkipTasksRequest{
+			Parent: rolloutB.Msg.Stages[0].Name,
+			Tasks:  []string{taskB.Name},
+			Reason: "collision isolation",
+		}))
+	a.NoError(err)
+	rolloutBAfter, err := ctl.rolloutServiceClient.GetRollout(ctx,
+		connect.NewRequest(&v1pb.GetRolloutRequest{Name: rolloutB.Msg.Name}))
+	a.NoError(err)
+	a.Equal(v1pb.Task_SKIPPED, rolloutBAfter.Msg.Stages[0].Tasks[0].Status,
+		"project B task should be skipped")
+
+	aAfter := snapshotProject(ctx, t, ctl, fixture.ProjectA)
+	assertProjectUnchanged(t, fixture.BaselineA, aAfter, "project A after project B task skip")
 }
 
 // TestCollisionListPlansIsolation verifies that ListPlans scoped to project A

--- a/backend/tests/task_run_idempotent_test.go
+++ b/backend/tests/task_run_idempotent_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 )
@@ -105,12 +107,14 @@ func TestBatchRunTasks_Idempotent(t *testing.T) {
 		err error
 	}
 	results := make(chan result, 5)
+	runTime := timestamppb.New(time.Now().Add(time.Hour))
 
 	for range 5 {
 		go func() {
 			_, err := ctl.rolloutServiceClient.BatchRunTasks(ctx, connect.NewRequest(&v1pb.BatchRunTasksRequest{
-				Parent: stage.Name,
-				Tasks:  taskNames,
+				Parent:  stage.Name,
+				Tasks:   taskNames,
+				RunTime: runTime,
 			}))
 			results <- result{err: err}
 		}()
@@ -133,8 +137,9 @@ func TestBatchRunTasks_Idempotent(t *testing.T) {
 
 	// Test 2: Sequential double-click (simulates user accidentally clicking twice)
 	_, err = ctl.rolloutServiceClient.BatchRunTasks(ctx, connect.NewRequest(&v1pb.BatchRunTasksRequest{
-		Parent: stage.Name,
-		Tasks:  taskNames,
+		Parent:  stage.Name,
+		Tasks:   taskNames,
+		RunTime: runTime,
 	}))
 	a.NoError(err, "sequential BatchRunTasks call should succeed")
 
@@ -146,4 +151,104 @@ func TestBatchRunTasks_Idempotent(t *testing.T) {
 		a.NoError(err)
 		a.Equal(1, len(taskRunsResp.Msg.TaskRuns), "task %s should still have exactly one task run after sequential call", taskName)
 	}
+
+	_, err = ctl.rolloutServiceClient.BatchSkipTasks(ctx, connect.NewRequest(&v1pb.BatchSkipTasksRequest{
+		Parent: stage.Name,
+		Tasks:  taskNames,
+		Reason: "must not skip pending tasks",
+	}))
+	a.Error(err)
+	a.Equal(connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+func TestBatchRunTasks_RejectsSkippedTasks(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	instanceRootDir := t.TempDir()
+	instanceDir, err := ctl.provisionSQLiteInstance(instanceRootDir, "testInstanceSkippedTask")
+	a.NoError(err)
+
+	instanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       "testInstanceSkippedTask",
+			Engine:      v1pb.Engine_SQLITE,
+			Environment: new("environments/prod"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{{Type: v1pb.DataSourceType_ADMIN, Host: instanceDir, Id: "admin"}},
+		},
+	}))
+	a.NoError(err)
+
+	const databaseName = "testSkippedTaskDb"
+	a.NoError(ctl.createDatabase(ctx, ctl.project, instanceResp.Msg, nil /* environment */, databaseName, ""))
+	databaseResp, err := ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{
+		Name: fmt.Sprintf("%s/databases/%s", instanceResp.Msg.Name, databaseName),
+	}))
+	a.NoError(err)
+
+	sheetResp, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet:  &v1pb.Sheet{Content: []byte("SELECT 1;")},
+	}))
+	a.NoError(err)
+
+	planResp, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan: &v1pb.Plan{Specs: []*v1pb.Plan_Spec{{
+			Id: uuid.NewString(),
+			Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+				ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+					Targets: []string{databaseResp.Msg.Name},
+					Sheet:   sheetResp.Msg.Name,
+				},
+			},
+		}}},
+	}))
+	a.NoError(err)
+
+	rolloutResp, err := ctl.rolloutServiceClient.CreateRollout(ctx, connect.NewRequest(&v1pb.CreateRolloutRequest{
+		Parent: planResp.Msg.Name,
+	}))
+	a.NoError(err)
+	stage := rolloutResp.Msg.Stages[0]
+	task := stage.Tasks[0]
+
+	_, err = ctl.rolloutServiceClient.BatchSkipTasks(ctx, connect.NewRequest(&v1pb.BatchSkipTasksRequest{
+		Parent: stage.Name,
+		Tasks:  []string{task.Name},
+		Reason: "not needed",
+	}))
+	a.NoError(err)
+
+	_, err = ctl.rolloutServiceClient.BatchRunTasks(ctx, connect.NewRequest(&v1pb.BatchRunTasksRequest{
+		Parent: stage.Name,
+		Tasks:  []string{task.Name},
+	}))
+	a.Error(err)
+	a.Equal(connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	_, err = ctl.rolloutServiceClient.BatchSkipTasks(ctx, connect.NewRequest(&v1pb.BatchSkipTasksRequest{
+		Parent: stage.Name,
+		Tasks:  []string{task.Name},
+		Reason: "replacement reason",
+	}))
+	a.NoError(err)
+	rolloutResp, err = ctl.rolloutServiceClient.GetRollout(ctx, connect.NewRequest(&v1pb.GetRolloutRequest{
+		Name: rolloutResp.Msg.Name,
+	}))
+	a.NoError(err)
+	a.Equal(v1pb.Task_SKIPPED, rolloutResp.Msg.Stages[0].Tasks[0].Status)
+	a.Equal("not needed", rolloutResp.Msg.Stages[0].Tasks[0].SkippedReason)
+
+	taskRunsResp, err := ctl.rolloutServiceClient.ListTaskRuns(ctx, connect.NewRequest(&v1pb.ListTaskRunsRequest{
+		Parent: task.Name,
+	}))
+	a.NoError(err)
+	a.Empty(taskRunsResp.Msg.TaskRuns)
 }

--- a/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.test.tsx
+++ b/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.test.tsx
@@ -1,0 +1,170 @@
+import { create } from "@bufbuild/protobuf";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { State } from "@/types/proto-es/v1/common_pb";
+import {
+  IssueSchema,
+  IssueStatus,
+} from "@/types/proto-es/v1/issue_service_pb";
+import { PlanSchema } from "@/types/proto-es/v1/plan_service_pb";
+import { ProjectSchema } from "@/types/proto-es/v1/project_service_pb";
+import {
+  RolloutSchema,
+  Task_Status,
+} from "@/types/proto-es/v1/rollout_service_pb";
+
+const mocks = vi.hoisted(() => ({
+  getIssue: vi.fn(),
+  getPlan: vi.fn(),
+  getPlanCheckRun: vi.fn(),
+  getRollout: vi.fn(),
+  listTaskRuns: vi.fn(),
+  setDocumentTitle: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@/connect", () => ({
+  issueServiceClientConnect: {
+    getIssue: mocks.getIssue,
+  },
+  planServiceClientConnect: {
+    getPlan: mocks.getPlan,
+    getPlanCheckRun: mocks.getPlanCheckRun,
+  },
+  rolloutServiceClientConnect: {
+    getRollout: mocks.getRollout,
+    listTaskRuns: mocks.listTaskRuns,
+  },
+}));
+
+vi.mock("@/react/hooks/useProjectByName", () => ({
+  useProjectByName: () =>
+    create(ProjectSchema, {
+      name: "projects/foo",
+      title: "Foo",
+      state: State.ACTIVE,
+    }),
+}));
+
+vi.mock("@/react/router", () => ({
+  router: {
+    beforeEach: vi.fn(() => vi.fn()),
+    currentRoute: { value: {} },
+    push: vi.fn(),
+  },
+}));
+
+vi.mock("@/react/stores/app", () => ({
+  useAppStore: (
+    selector: (state: { projectsByName: Map<string, never> }) => unknown
+  ) => selector({ projectsByName: new Map<string, never>() }),
+}));
+
+vi.mock("@/utils", () => ({
+  getRolloutFromPlan: (planName: string) => `${planName}/rollout`,
+  minmax: (value: number, min: number, max: number) =>
+    Math.max(min, Math.min(max, value)),
+  setDocumentTitle: mocks.setDocumentTitle,
+}));
+
+import { useIssueDetailPage } from "./useIssueDetailPage";
+
+const issue = create(IssueSchema, {
+  name: "projects/foo/issues/1",
+  title: "Issue",
+  plan: "projects/foo/plans/1",
+  status: IssueStatus.OPEN,
+});
+
+const plan = create(PlanSchema, {
+  name: issue.plan,
+  title: "Plan",
+  state: State.ACTIVE,
+  hasRollout: true,
+});
+
+const rolloutWithStatus = (status: Task_Status) =>
+  create(RolloutSchema, {
+    name: `${plan.name}/rollout`,
+    stages: [
+      {
+        name: `${plan.name}/rollout/stages/prod`,
+        tasks: [
+          {
+            name: `${plan.name}/rollout/stages/prod/tasks/1`,
+            status,
+          },
+        ],
+      },
+    ],
+  });
+
+describe("useIssueDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getIssue.mockResolvedValue(issue);
+    mocks.getPlan.mockResolvedValue(plan);
+    mocks.getPlanCheckRun.mockRejectedValue(new Error("no plan check run"));
+    mocks.getRollout.mockResolvedValue(
+      rolloutWithStatus(Task_Status.NOT_STARTED)
+    );
+    mocks.listTaskRuns.mockResolvedValue({ taskRuns: [] });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("a stale in-flight refresh cannot overwrite a newer task status", async () => {
+    const { result } = renderHook(() =>
+      useIssueDetailPage({ issueId: "1", pageHost: null, projectId: "foo" })
+    );
+    await waitFor(() => expect(result.current.ready).toBe(true));
+
+    let resolveStaleIssue: (value: typeof issue) => void = () => undefined;
+    let resolveFreshIssue: (value: typeof issue) => void = () => undefined;
+    mocks.getIssue
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveStaleIssue = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFreshIssue = resolve;
+          })
+      );
+    mocks.getRollout
+      .mockResolvedValueOnce(rolloutWithStatus(Task_Status.SKIPPED))
+      .mockResolvedValueOnce(rolloutWithStatus(Task_Status.NOT_STARTED));
+
+    let stalePending: Promise<void> = Promise.resolve();
+    let freshPending: Promise<void> = Promise.resolve();
+    act(() => {
+      stalePending = result.current.refreshState();
+      freshPending = result.current.refreshState();
+    });
+
+    await act(async () => {
+      resolveFreshIssue(issue);
+      await freshPending;
+    });
+    expect(result.current.rollout?.stages[0].tasks[0].status).toBe(
+      Task_Status.SKIPPED
+    );
+
+    await act(async () => {
+      resolveStaleIssue(issue);
+      await stalePending;
+    });
+    expect(result.current.rollout?.stages[0].tasks[0].status).toBe(
+      Task_Status.SKIPPED
+    );
+  });
+});

--- a/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
+++ b/frontend/src/react/pages/project/issue-detail/hooks/useIssueDetailPage.ts
@@ -324,9 +324,20 @@ export const useIssueDetailPage = ({
     [patchState]
   );
 
+  // A late poll must not overwrite a newer post-action refresh or a snapshot
+  // loaded for a different issue after in-place navigation.
+  const fetchSeqRef = useRef(0);
   const refreshState = useCallback(async () => {
     const current = latestSnapshotRef.current;
+    fetchSeqRef.current += 1;
+    const seq = fetchSeqRef.current;
     const patch = await refreshIssueDetailSnapshot(current);
+    if (
+      seq !== fetchSeqRef.current ||
+      latestSnapshotRef.current.pageKey !== current.pageKey
+    ) {
+      return;
+    }
     patchState(patch);
   }, [patchState]);
 


### PR DESCRIPTION
## Summary

- reject attempts to run skipped rollout tasks at the API boundary
- make repeated skips idempotent and reject skipping pending, running, or completed tasks
- exclude skipped tasks from pending task-run creation and serialize run/skip races with task-row locks
- prevent stale issue-detail polling responses from restoring pre-action task state
- add API, polling-race, and composite-primary-key collision regression coverage

## Root cause

`BatchRunTasks` and `CreatePendingTaskRuns` did not consult the task's persisted `skipped` flag, so a skipped task without an active or completed run could receive a new pending task run. Separately, issue-detail polling applied responses without request-order protection, allowing an older `NOT_STARTED` snapshot to overwrite a newer `SKIPPED` snapshot.

## Impact

Skipped tasks are now terminal across the API and store layers, concurrent run/skip requests cannot both win, and issue-detail actions no longer reappear because of a stale polling response.

## Testing

- `go test -v -count=1 ./backend/tests/ -run '^(TestBatchRunTasks_Idempotent|TestBatchRunTasks_RejectsSkippedTasks)$' -timeout 5m`
- `go test -v -count=1 ./backend/tests/ -run '^(TestClaim|TestCollision)' -timeout 5m`
- `golangci-lint run --allow-parallel-runners`
- `golangci-lint run --fix --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `pnpm --dir frontend check` (completed with existing Biome internal diagnostics in unrelated files; targeted touched-file check passed)
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test` (2,962 tests passed)

Linear: [BYT-9900](https://linear.app/bytebase/issue/BYT-9900/skipped-rollout-tasks-remain-actionable-after-upgrade)
