### PR TITLE
fix: enforce transaction lock order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,8 +191,11 @@ Several tables use composite primary keys (e.g., `(project, id)`). Check
 multi-column PRIMARY KEY.
 
 When writing or modifying queries on these tables:
-- Every WHERE, JOIN, USING, DELETE, and UPDATE predicate must include ALL primary key
-  columns — never filter by `id` alone
+- Every WHERE, JOIN, USING, DELETE, and UPDATE predicate must include every
+  project/tenant scope column. Identify rows with either the full primary key or
+  a full declared non-partial UNIQUE key that contains the same scope columns;
+  verify alternate keys in `LATEST.sql`. Never filter by `id` or another locally
+  unique identifier alone
 - When adding a new store method touching a composite-PK table, add a corresponding
   `TestCollision_*` test in `backend/tests/`. The existing `setupCollidingProjects`
   fixture and `assertProjectUnchanged` helper cover `plan`, `issue`, `task`, `task_run`,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,10 @@ When writing or modifying queries on these tables:
   the public gRPC API, no store access. Run with:
   `go test -v -count=1 ./backend/tests/ -run "^(TestClaim|TestCollision)" -timeout 5m`
 
+## Transaction Lock Ordering
+
+Before adding or modifying a transaction that locks multiple rows or tables, follow the canonical [store row-lock ordering](backend/store/README.md#transaction-row-lock-ordering). Lock existing child rows before parents, lock batches in full primary-key order, and treat upserts as existing-row locks. Add a deterministic deadlock regression test for new multi-row or multi-table coordination paths.
+
 ### Imports
 
 - Use organized imports (sorted by the import path)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,7 +209,20 @@ When writing or modifying queries on these tables:
 
 ## Transaction Lock Ordering
 
-Before adding or modifying a transaction that locks multiple rows or tables, follow the canonical [store row-lock ordering](backend/store/README.md#transaction-row-lock-ordering). Lock existing child rows before parents, lock batches in full primary-key order, and treat upserts as existing-row locks. Add a deterministic deadlock regression test for new multi-row or multi-table coordination paths.
+Before adding or modifying a transaction that locks multiple rows or tables, follow the canonical [store row-lock ordering](backend/store/README.md#transaction-row-lock-ordering). Lock existing child rows before parents, lock batches in full primary-key order, and treat upserts as existing-row locks. Add the deterministic real-PostgreSQL regression tests required below for new multi-row or multi-table coordination paths.
+
+Row ordering prevents wait-for cycles on existing rows, but it cannot protect a
+child row that does not exist yet. `nextProjectID` closes that gap for its callers:
+it locks the project and requires the project to be active before allocating an ID,
+so creation is rejected when the project is missing or deleted. This is not a
+repository-wide purge fence because some writers bypass `nextProjectID`.
+
+Every new or modified writer of purge-managed data must define whether its
+lifecycle policy requires an active project or merely an existing project, then
+serialize and validate that policy against project deletion. Add deterministic
+real-PostgreSQL tests for both lock-acquisition directions. Assert the terminal
+outcomes, including that neither direction ends in a foreign-key failure; merely
+checking for the absence of SQLSTATE `40P01` is insufficient.
 
 ### Imports
 

--- a/backend/component/review/draft_creation_lock_order_test.go
+++ b/backend/component/review/draft_creation_lock_order_test.go
@@ -1,0 +1,216 @@
+package review
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+const draftIssueDeletionAdvisoryLockID = 990137
+
+type draftIssueDeletionFixture struct {
+	ctx     context.Context
+	stores  *store.Store
+	planUID int64
+}
+
+type createDraftIssueOutcome struct {
+	result *CreateDraftIssueResult
+	err    error
+}
+
+func TestCreateDraftIssueAndProjectDeletionPurgeFirst(t *testing.T) {
+	fixture := newDraftIssueDeletionFixture(t)
+	ctx, db, stores := fixture.ctx, fixture.stores.GetDB(), fixture.stores
+
+	lockConn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer lockConn.Close()
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", draftIssueDeletionAdvisoryLockID)
+	require.NoError(t, err)
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			_, _ = lockConn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", draftIssueDeletionAdvisoryLockID)
+		}
+	}()
+	_, err = db.ExecContext(ctx, `
+		CREATE FUNCTION block_draft_issue_plan_delete() RETURNS trigger AS $$
+		BEGIN
+			PERFORM pg_advisory_xact_lock(990137);
+			RETURN OLD;
+		END;
+		$$ LANGUAGE plpgsql;
+		CREATE TRIGGER block_draft_issue_plan_delete
+		AFTER DELETE ON plan
+		FOR EACH ROW EXECUTE FUNCTION block_draft_issue_plan_delete();
+	`)
+	require.NoError(t, err)
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		deleteResult <- stores.DeleteProject(ctx, "default", "project-a")
+	}()
+	deleteBackendPID := waitForAdvisoryLockWaiter(ctx, t, db, draftIssueDeletionAdvisoryLockID)
+
+	createResult := make(chan createDraftIssueOutcome, 1)
+	go func() {
+		result, err := createDraftIssue(fixture)
+		createResult <- createDraftIssueOutcome{result: result, err: err}
+	}()
+	waitForBackendBlockedBy(ctx, t, db, deleteBackendPID, "draft Issue creation should wait for the Plan being purged")
+
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", draftIssueDeletionAdvisoryLockID)
+	require.NoError(t, err)
+	lockReleased = true
+	require.NoError(t, <-deleteResult)
+	assertDraftIssueCreationNotFound(t, <-createResult)
+	assertDraftIssueProjectPurged(t, fixture)
+}
+
+func TestCreateDraftIssueAndProjectDeletionCreationFirst(t *testing.T) {
+	fixture := newDraftIssueDeletionFixture(t)
+	ctx, db, stores := fixture.ctx, fixture.stores.GetDB(), fixture.stores
+
+	lockConn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer lockConn.Close()
+	lockTx, err := lockConn.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			_ = lockTx.Rollback()
+		}
+	}()
+	var lockBackendPID int
+	require.NoError(t, lockTx.QueryRowContext(ctx, "SELECT pg_backend_pid()").Scan(&lockBackendPID))
+	var projectID string
+	require.NoError(t, lockTx.QueryRowContext(ctx, `
+		SELECT resource_id
+		FROM project
+		WHERE workspace = 'default' AND resource_id = 'project-a'
+		FOR UPDATE
+	`).Scan(&projectID))
+	require.Equal(t, "project-a", projectID)
+
+	createResult := make(chan createDraftIssueOutcome, 1)
+	go func() {
+		result, err := createDraftIssue(fixture)
+		createResult <- createDraftIssueOutcome{result: result, err: err}
+	}()
+	createBackendPID := waitForBackendBlockedBy(ctx, t, db, lockBackendPID, "draft Issue creation should lock the Plan, then wait for the project")
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		deleteResult <- stores.DeleteProject(ctx, "default", "project-a")
+	}()
+	waitForBackendBlockedBy(ctx, t, db, createBackendPID, "project deletion should pass Issue cleanup, then wait for the locked Plan")
+
+	require.NoError(t, lockTx.Commit())
+	lockReleased = true
+	assertDraftIssueCreationNotFound(t, <-createResult)
+	require.NoError(t, <-deleteResult)
+	assertDraftIssueProjectPurged(t, fixture)
+}
+
+func newDraftIssueDeletionFixture(t *testing.T) *draftIssueDeletionFixture {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	stores := setupWorkflowStore(ctx, t)
+	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      "draft Plan",
+		Config: &storepb.PlanConfig{Specs: []*storepb.PlanConfig_Spec{{
+			Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+				ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{},
+			},
+		}}},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	deleted := true
+	require.NoError(t, stores.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		Workspace: "default", ResourceID: "project-a", Delete: &deleted,
+	}))
+	return &draftIssueDeletionFixture{ctx: ctx, stores: stores, planUID: plan.UID}
+}
+
+func createDraftIssue(fixture *draftIssueDeletionFixture) (*CreateDraftIssueResult, error) {
+	return NewWorkflow(fixture.stores).CreateDraftIssue(fixture.ctx, CreateDraftIssueInput{
+		Workspace: "default",
+		Issue: &store.IssueMessage{
+			ProjectID: "project-a", CreatorEmail: "creator@example.com", PlanUID: &fixture.planUID,
+			Type: storepb.Issue_DATABASE_CHANGE,
+			Payload: &storepb.Issue{
+				Draft: true, Approval: &storepb.IssuePayloadApproval{},
+			},
+		},
+	})
+}
+
+func waitForAdvisoryLockWaiter(ctx context.Context, t *testing.T, db *sql.DB, lockID int) int {
+	t.Helper()
+	var backendPID int
+	require.Eventually(t, func() bool {
+		return db.QueryRowContext(ctx, `
+			SELECT COALESCE((
+				SELECT pid
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+				ORDER BY pid
+				LIMIT 1
+			), 0)
+		`, lockID).Scan(&backendPID) == nil && backendPID != 0
+	}, 10*time.Second, 10*time.Millisecond, "project deletion should reach the blocked Plan delete")
+	return backendPID
+}
+
+func waitForBackendBlockedBy(ctx context.Context, t *testing.T, db *sql.DB, blockerPID int, message string) int {
+	t.Helper()
+	var backendPID int
+	require.Eventually(t, func() bool {
+		return db.QueryRowContext(ctx, `
+			SELECT COALESCE((
+				SELECT pid
+				FROM pg_stat_activity
+				WHERE $1 = ANY(pg_blocking_pids(pid))
+				ORDER BY pid
+				LIMIT 1
+			), 0)
+		`, blockerPID).Scan(&backendPID) == nil && backendPID != 0
+	}, 10*time.Second, 10*time.Millisecond, message)
+	return backendPID
+}
+
+func assertDraftIssueCreationNotFound(t *testing.T, outcome createDraftIssueOutcome) {
+	t.Helper()
+	require.Nil(t, outcome.result)
+	var workflowErr *Error
+	require.True(t, errors.As(outcome.err, &workflowErr))
+	require.Equal(t, ErrorNotFound, workflowErr.Code)
+}
+
+func assertDraftIssueProjectPurged(t *testing.T, fixture *draftIssueDeletionFixture) {
+	t.Helper()
+	projectID := "project-a"
+	project, err := fixture.stores.GetProject(fixture.ctx, &store.FindProjectMessage{
+		Workspace: "default", ResourceID: &projectID,
+	})
+	require.NoError(t, err)
+	require.Nil(t, project)
+	issue, err := fixture.stores.GetIssue(fixture.ctx, &store.FindIssueMessage{
+		Workspace: "default", ProjectIDs: []string{projectID}, PlanUID: &fixture.planUID,
+	})
+	require.NoError(t, err)
+	require.Nil(t, issue)
+}

--- a/backend/component/review/draft_creation_test.go
+++ b/backend/component/review/draft_creation_test.go
@@ -130,3 +130,61 @@ func TestCreateDraftIssueUsesLockedPlanMetadata(t *testing.T) {
 	require.Equal(t, "Updated Plan title", result.Issue.Title)
 	require.Equal(t, "Updated Plan description", result.Issue.Description)
 }
+
+func TestCreateDraftIssueRejectsUnavailableProject(t *testing.T) {
+	tests := []struct {
+		name      string
+		projectID string
+		delete    bool
+	}{
+		{name: "missing", projectID: "missing-project"},
+		{name: "soft deleted", projectID: "project-a", delete: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			stores := setupWorkflowStore(ctx, t)
+			planUID := int64(101)
+			if test.projectID == "project-a" {
+				plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+					ProjectID: test.projectID,
+					Name:      "draft Plan",
+					Config: &storepb.PlanConfig{Specs: []*storepb.PlanConfig_Spec{{
+						Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+							ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{},
+						},
+					}}},
+				}, "creator@example.com")
+				require.NoError(t, err)
+				planUID = plan.UID
+			}
+			if test.delete {
+				deleted := true
+				require.NoError(t, stores.UpdateProjects(ctx, &store.UpdateProjectMessage{
+					Workspace: "default", ResourceID: test.projectID, Delete: &deleted,
+				}))
+			}
+
+			result, err := NewWorkflow(stores).CreateDraftIssue(ctx, CreateDraftIssueInput{
+				Workspace: "default",
+				Issue: &store.IssueMessage{
+					ProjectID: test.projectID, CreatorEmail: "creator@example.com", PlanUID: &planUID,
+					Type: storepb.Issue_DATABASE_CHANGE,
+					Payload: &storepb.Issue{
+						Draft: true, Approval: &storepb.IssuePayloadApproval{},
+					},
+				},
+			})
+			require.Nil(t, result)
+			var workflowErr *Error
+			require.ErrorAs(t, err, &workflowErr)
+			require.Equal(t, ErrorNotFound, workflowErr.Code)
+			issue, getErr := stores.GetIssue(ctx, &store.FindIssueMessage{
+				ProjectIDs: []string{test.projectID}, PlanUID: &planUID,
+			})
+			require.NoError(t, getErr)
+			require.Nil(t, issue)
+		})
+	}
+}

--- a/backend/component/review/submission.go
+++ b/backend/component/review/submission.go
@@ -17,6 +17,8 @@ import (
 	"github.com/bytebase/bytebase/backend/store"
 )
 
+const projectNotFoundFormat = "project %s not found"
+
 // SubmittedEvent requests a submission timeline entry.
 type SubmittedEvent struct{}
 
@@ -95,12 +97,12 @@ func (w *Workflow) CreateDraftIssue(ctx context.Context, input CreateDraftIssueI
 		SELECT deleted FROM project
 		WHERE workspace = $1 AND resource_id = $2
 		FOR UPDATE`, input.Workspace, issue.ProjectID).Scan(&projectDeleted); errors.Is(err, sql.ErrNoRows) {
-		return nil, workflowError(ErrorNotFound, "project %s not found", issue.ProjectID)
+		return nil, workflowError(ErrorNotFound, projectNotFoundFormat, issue.ProjectID)
 	} else if err != nil {
 		return nil, workflowWrap(ErrorInternal, err, "failed to lock project for draft creation")
 	}
 	if projectDeleted {
-		return nil, workflowError(ErrorNotFound, "project %s not found", issue.ProjectID)
+		return nil, workflowError(ErrorNotFound, projectNotFoundFormat, issue.ProjectID)
 	}
 	if err := tx.QueryRowContext(ctx, `
 		SELECT GREATEST(COALESCE(MAX(id), 0) + 1, 101)
@@ -157,7 +159,7 @@ func (w *Workflow) SubmitIssue(ctx context.Context, input SubmitIssueInput) (*Su
 		return nil, workflowWrap(ErrorInternal, err, "failed to get project")
 	}
 	if project == nil {
-		return nil, workflowError(ErrorNotFound, "project %s not found", input.ProjectID)
+		return nil, workflowError(ErrorNotFound, projectNotFoundFormat, input.ProjectID)
 	}
 	observedIssue, err := w.store.GetIssue(ctx, &store.FindIssueMessage{
 		Workspace: input.Workspace, ProjectIDs: []string{input.ProjectID}, UID: &input.IssueUID,

--- a/backend/component/review/submission.go
+++ b/backend/component/review/submission.go
@@ -90,11 +90,17 @@ func (w *Workflow) CreateDraftIssue(ctx context.Context, input CreateDraftIssueI
 	}
 	issue.Title = plan.Name
 	issue.Description = plan.Description
-	if _, err := tx.ExecContext(ctx, `
-		SELECT 1 FROM project
+	var projectDeleted bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT deleted FROM project
 		WHERE workspace = $1 AND resource_id = $2
-		FOR UPDATE`, input.Workspace, issue.ProjectID); err != nil {
+		FOR UPDATE`, input.Workspace, issue.ProjectID).Scan(&projectDeleted); errors.Is(err, sql.ErrNoRows) {
+		return nil, workflowError(ErrorNotFound, "project %s not found", issue.ProjectID)
+	} else if err != nil {
 		return nil, workflowWrap(ErrorInternal, err, "failed to lock project for draft creation")
+	}
+	if projectDeleted {
+		return nil, workflowError(ErrorNotFound, "project %s not found", issue.ProjectID)
 	}
 	if err := tx.QueryRowContext(ctx, `
 		SELECT GREATEST(COALESCE(MAX(id), 0) + 1, 101)

--- a/backend/store/README.md
+++ b/backend/store/README.md
@@ -12,16 +12,28 @@ PostgreSQL holds row locks until a transaction ends. Transactions that acquire t
    - `plan_webhook_delivery -> plan -> project`
    - `plan_check_run -> plan -> project`
    - `task_run_log -> task_run -> task -> plan -> project`
-3. Lock multiple rows in one table in full primary-key order. Project-scoped batches therefore use `(project, id)` order, not `id` alone.
+3. Identify project-scoped rows with every scope column plus either the remaining primary-key columns or every remaining column of a declared non-partial unique key. Verify alternate keys in `LATEST.sql`. Lock batches in full primary-key order; project-scoped `(project, id)` batches therefore use that order, not `id` alone.
 4. Treat locks acquired by `UPDATE`, `DELETE`, foreign-key checks, and `INSERT ... ON CONFLICT DO UPDATE` as part of the order. An upsert that can update an existing row is not a new-row-only insert.
 5. `nextProjectID` locks `project`. Call it after locking any existing descendants, and do not lock an existing descendant afterward.
 
-Transactions that lock unrelated sibling branches must establish one shared order and add it here before implementation. Keep transactions short and acquire every required lock before performing work that depends on the protected state.
+Transactions spanning project-owned sibling branches follow the order used by `DeleteProject`:
+
+```text
+query_history -> policy -> worksheet (project reassignment)
+-> issue_comment -> issue -> plan_webhook_delivery -> plan_check_run
+-> task_run_log -> task_run -> task -> plan -> access_grant -> release
+-> db_group -> db (project reassignment) -> project_webhook
+-> worksheet_organizer -> worksheet (creator cleanup) -> revision
+-> service_account -> workload_identity -> project
+```
+
+Update this list and `DeleteProject` together. A transaction that needs another sibling branch must establish its position here before implementation. Keep transactions short and acquire every required lock before performing work that depends on the protected state.
 
 Examples:
 
 - Pending Task Run creation: existing `task` rows ordered by `(project, id)`, then `project`, then new `task_run` rows.
 - Plan Check Run refresh: existing `plan_check_run`, then `plan`, then `project`, then the upsert.
+- Issue creation: existing `plan`, then `project`, then the new `issue` row.
 - Task skipping: existing `task` rows ordered by `(project, id)`; it does not lock `task_run` rows.
 
 When adding or changing a transaction that coordinates multiple rows or tables, add a deterministic real-PostgreSQL regression test that exercises its competing transaction path and fails on a deadlock.

--- a/backend/store/README.md
+++ b/backend/store/README.md
@@ -14,7 +14,18 @@ PostgreSQL holds row locks until a transaction ends. Transactions that acquire t
    - `task_run_log -> task_run -> task -> plan -> project`
 3. Identify project-scoped rows with every scope column plus either the remaining primary-key columns or every remaining column of a declared non-partial unique key. Verify alternate keys in `LATEST.sql`. Lock batches in full primary-key order; project-scoped `(project, id)` batches therefore use that order, not `id` alone.
 4. Treat locks acquired by `UPDATE`, `DELETE`, foreign-key checks, and `INSERT ... ON CONFLICT DO UPDATE` as part of the order. An upsert that can update an existing row is not a new-row-only insert.
-5. `nextProjectID` locks `project`. Call it after locking any existing descendants, and do not lock an existing descendant afterward.
+5. `nextProjectID` locks `project` and requires it to be active before allocating an ID. Call it after locking any existing descendants, and do not lock an existing descendant afterward. Creation is rejected when the project is missing or deleted.
+
+Row ordering prevents wait-for cycles on existing rows. It cannot protect an
+absent child row because there is no row to lock before a concurrent purge passes
+that branch. The active-project check in `nextProjectID` covers this case only for
+writers that call it; it is not a repository-wide purge fence because other
+writers bypass `nextProjectID`.
+
+Every new or modified writer of purge-managed data must define its project
+lifecycle policy: require an active project for new resources, or require only an
+existing project when deleted-project continuation is intentional. Serialize and
+validate that policy against project deletion before writing the managed data.
 
 Transactions spanning project-owned sibling branches follow the order used by `DeleteProject`:
 
@@ -36,4 +47,8 @@ Examples:
 - Issue creation: existing `plan`, then `project`, then the new `issue` row.
 - Task skipping: existing `task` rows ordered by `(project, id)`; it does not lock `task_run` rows.
 
-When adding or changing a transaction that coordinates multiple rows or tables, add a deterministic real-PostgreSQL regression test that exercises its competing transaction path and fails on a deadlock.
+When adding or changing a transaction that coordinates multiple rows or tables,
+add deterministic real-PostgreSQL regression tests for both lock-acquisition
+directions. Assert the terminal outcomes, including that neither direction ends
+in a foreign-key failure; merely checking for the absence of SQLSTATE `40P01` is
+insufficient.

--- a/backend/store/README.md
+++ b/backend/store/README.md
@@ -1,3 +1,27 @@
 # Bytebase storage package
 
 For schema update, please follow [Bytebase Schema Update Guide](https://github.com/bytebase/bytebase/blob/main/docs/schema-update-guide.md)
+
+## Transaction row-lock ordering
+
+PostgreSQL holds row locks until a transaction ends. Transactions that acquire the same locks in different orders can deadlock, so every store transaction must follow these rules:
+
+1. Acquire transaction-scoped advisory locks before row locks.
+2. Lock existing related rows from the deepest child to its parents. The project workflow chains are:
+   - `issue_comment -> issue -> plan -> project`
+   - `plan_webhook_delivery -> plan -> project`
+   - `plan_check_run -> plan -> project`
+   - `task_run_log -> task_run -> task -> plan -> project`
+3. Lock multiple rows in one table in full primary-key order. Project-scoped batches therefore use `(project, id)` order, not `id` alone.
+4. Treat locks acquired by `UPDATE`, `DELETE`, foreign-key checks, and `INSERT ... ON CONFLICT DO UPDATE` as part of the order. An upsert that can update an existing row is not a new-row-only insert.
+5. `nextProjectID` locks `project`. Call it after locking any existing descendants, and do not lock an existing descendant afterward.
+
+Transactions that lock unrelated sibling branches must establish one shared order and add it here before implementation. Keep transactions short and acquire every required lock before performing work that depends on the protected state.
+
+Examples:
+
+- Pending Task Run creation: existing `task` rows ordered by `(project, id)`, then `project`, then new `task_run` rows.
+- Plan Check Run refresh: existing `plan_check_run`, then `plan`, then `project`, then the upsert.
+- Task skipping: existing `task` rows ordered by `(project, id)`; it does not lock `task_run` rows.
+
+When adding or changing a transaction that coordinates multiple rows or tables, add a deterministic real-PostgreSQL regression test that exercises its competing transaction path and fails on a deadlock.

--- a/backend/store/id.go
+++ b/backend/store/id.go
@@ -16,6 +16,7 @@ const idMinValue int64 = 101
 
 // nextProjectID returns the next per-project auto-increment ID for the given table.
 // Must be called within a transaction. Locks the project row to serialize concurrent inserts.
+// Callers must first lock existing child rows as described in backend/store/README.md.
 // Returns at least idMinValue (101) for new projects.
 func nextProjectID(ctx context.Context, tx *sql.Tx, table, projectID string) (int64, error) {
 	if _, err := tx.ExecContext(ctx,

--- a/backend/store/id.go
+++ b/backend/store/id.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/qb"
 )
 
@@ -15,13 +16,21 @@ import (
 const idMinValue int64 = 101
 
 // nextProjectID returns the next per-project auto-increment ID for the given table.
-// Must be called within a transaction. Locks the project row to serialize concurrent inserts.
+// Must be called within a transaction. Locks and validates the active project row to
+// serialize concurrent inserts with project deletion.
 // Callers must first lock existing child rows as described in backend/store/README.md.
 // Returns at least idMinValue (101) for new projects.
 func nextProjectID(ctx context.Context, tx *sql.Tx, table, projectID string) (int64, error) {
-	if _, err := tx.ExecContext(ctx,
-		"SELECT 1 FROM project WHERE resource_id = $1 FOR UPDATE", projectID); err != nil {
+	var deleted bool
+	if err := tx.QueryRowContext(ctx,
+		"SELECT deleted FROM project WHERE resource_id = $1 FOR UPDATE", projectID).Scan(&deleted); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, common.Errorf(common.NotFound, "project %s not found", projectID)
+		}
 		return 0, errors.Wrapf(err, "failed to lock project %s", projectID)
+	}
+	if deleted {
+		return 0, common.Errorf(common.NotFound, "project %s is deleted", projectID)
 	}
 	var maxID int64
 

--- a/backend/store/issue.go
+++ b/backend/store/issue.go
@@ -180,7 +180,8 @@ func (s *Store) CreateIssue(ctx context.Context, create *IssueMessage) (*IssueMe
 			SELECT COALESCE((config->>'hasRollout')::boolean, false)
 			FROM plan
 			WHERE project = $1
-			  AND id = $2`,
+			  AND id = $2
+			FOR UPDATE`,
 			create.ProjectID, *create.PlanUID).Scan(&hasRollout); err != nil {
 			return nil, errors.Wrapf(err, "failed to get plan %d", *create.PlanUID)
 		}

--- a/backend/store/issue_lock_order_test.go
+++ b/backend/store/issue_lock_order_test.go
@@ -2,10 +2,12 @@ package store_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/store"
 )
@@ -25,6 +27,24 @@ func TestCreateIssueDoesNotDeadlockWithProjectDeletion(t *testing.T) {
 		})
 		return err
 	})
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "deadlock detected")
+	require.ErrorIs(t, err, sql.ErrNoRows)
+}
+
+func TestCreateIssueRejectsDeletedProjectDuringProjectDeletion(t *testing.T) {
+	operationErr, deleteErr := runWithCreationBeforeProjectDeletion(t, `
+		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
+	`, "plan", func(ctx context.Context, s *store.Store) error {
+		planUID := int64(101)
+		_, err := s.CreateIssue(ctx, &store.IssueMessage{
+			ProjectID:    "project-a",
+			CreatorEmail: "creator@example.com",
+			Title:        "Issue A",
+			Type:         storepb.Issue_DATABASE_CHANGE,
+			Payload:      &storepb.Issue{},
+			PlanUID:      &planUID,
+		})
+		return err
+	})
+	require.NoError(t, deleteErr)
+	require.Equal(t, common.NotFound, common.ErrorCode(operationErr))
 }

--- a/backend/store/issue_lock_order_test.go
+++ b/backend/store/issue_lock_order_test.go
@@ -1,0 +1,30 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestCreateIssueDoesNotDeadlockWithProjectDeletion(t *testing.T) {
+	err := runWithConcurrentProjectDeletion(t, `
+		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
+	`, "plan", 9903, func(ctx context.Context, s *store.Store) error {
+		planUID := int64(101)
+		_, err := s.CreateIssue(ctx, &store.IssueMessage{
+			ProjectID:    "project-a",
+			CreatorEmail: "creator@example.com",
+			Title:        "Issue A",
+			Type:         storepb.Issue_DATABASE_CHANGE,
+			Payload:      &storepb.Issue{},
+			PlanUID:      &planUID,
+		})
+		return err
+	})
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "deadlock detected")
+}

--- a/backend/store/lock_order_test.go
+++ b/backend/store/lock_order_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"testing"
 	"time"
@@ -13,16 +14,16 @@ import (
 	"github.com/bytebase/bytebase/backend/store"
 )
 
-func runWithConcurrentProjectDeletion(
-	t *testing.T,
-	seedSQL string,
-	blockedTable string,
-	advisoryLockID int,
-	operation func(context.Context, *store.Store) error,
-) error {
+type projectDeletionLockOrderFixture struct {
+	ctx   context.Context
+	db    *sql.DB
+	store *store.Store
+}
+
+func newProjectDeletionLockOrderFixture(t *testing.T, seedSQL string) *projectDeletionLockOrderFixture {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+	t.Cleanup(cancel)
 	container := testcontainer.GetTestPgContainer(ctx, t)
 	t.Cleanup(func() { container.Close(context.Background()) })
 	db := container.GetDB()
@@ -42,6 +43,20 @@ func runWithConcurrentProjectDeletion(
 	s, err := store.New(ctx, pgURL, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	return &projectDeletionLockOrderFixture{ctx: ctx, db: db, store: s}
+}
+
+func runWithConcurrentProjectDeletion(
+	t *testing.T,
+	seedSQL string,
+	blockedTable string,
+	advisoryLockID int,
+	operation func(context.Context, *store.Store) error,
+) error {
+	t.Helper()
+	fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+	ctx, db, s := fixture.ctx, fixture.db, fixture.store
 
 	lockConn, err := db.Conn(ctx)
 	require.NoError(t, err)
@@ -116,4 +131,76 @@ func runWithConcurrentProjectDeletion(
 	operationErr := <-operationResult
 	require.NoError(t, deleteErr)
 	return operationErr
+}
+
+func runWithCreationBeforeProjectDeletion(
+	t *testing.T,
+	seedSQL string,
+	lockedChildTable string,
+	operation func(context.Context, *store.Store) error,
+) (error, error) {
+	t.Helper()
+	fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+	ctx, db, s := fixture.ctx, fixture.db, fixture.store
+
+	lockConn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer lockConn.Close()
+	lockTx, err := lockConn.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			_ = lockTx.Rollback()
+		}
+	}()
+
+	var lockBackendPID int
+	require.NoError(t, lockTx.QueryRowContext(ctx, "SELECT pg_backend_pid()").Scan(&lockBackendPID))
+	var lockedProjectID string
+	require.NoError(t, lockTx.QueryRowContext(ctx, `
+		SELECT resource_id
+		FROM project
+		WHERE resource_id = 'project-a'
+		FOR UPDATE
+	`).Scan(&lockedProjectID))
+	require.Equal(t, "project-a", lockedProjectID)
+
+	operationResult := make(chan error, 1)
+	go func() {
+		operationResult <- operation(ctx, s)
+	}()
+
+	var operationBackendPID int
+	require.Eventually(t, func() bool {
+		return db.QueryRowContext(ctx, `
+			SELECT COALESCE((
+				SELECT pid
+				FROM pg_stat_activity
+				WHERE $1 = ANY(pg_blocking_pids(pid))
+				ORDER BY pid
+				LIMIT 1
+			), 0)
+		`, lockBackendPID).Scan(&operationBackendPID) == nil && operationBackendPID != 0
+	}, 10*time.Second, 10*time.Millisecond, "creation should lock %s, then wait for the project row", lockedChildTable)
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		deleteResult <- s.DeleteProject(ctx, "default", "project-a")
+	}()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity
+				WHERE $1 = ANY(pg_blocking_pids(pid))
+			)
+		`, operationBackendPID).Scan(&waiting)
+		return err == nil && waiting
+	}, 10*time.Second, 10*time.Millisecond, "project deletion should pass empty child cleanup, then wait for the locked %s", lockedChildTable)
+
+	require.NoError(t, lockTx.Commit())
+	lockReleased = true
+	return <-operationResult, <-deleteResult
 }

--- a/backend/store/lock_order_test.go
+++ b/backend/store/lock_order_test.go
@@ -1,0 +1,119 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func runWithConcurrentProjectDeletion(
+	t *testing.T,
+	seedSQL string,
+	blockedTable string,
+	advisoryLockID int,
+	operation func(context.Context, *store.Store) error,
+) error {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(context.Background()) })
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('default', 'default', 'Default');
+		INSERT INTO project (resource_id, workspace, name, deleted) VALUES ('project-a', 'default', 'Project A', TRUE);
+	`+seedSQL)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	lockConn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer lockConn.Close()
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", advisoryLockID)
+	require.NoError(t, err)
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			_, _ = lockConn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", advisoryLockID)
+		}
+	}()
+	_, err = db.ExecContext(ctx, fmt.Sprintf(`
+		CREATE FUNCTION block_%[1]s_delete() RETURNS trigger AS $$
+		BEGIN
+			PERFORM pg_advisory_xact_lock(%[2]d);
+			RETURN OLD;
+		END;
+		$$ LANGUAGE plpgsql;
+		CREATE TRIGGER block_%[1]s_delete
+		AFTER DELETE ON %[1]s
+		FOR EACH ROW EXECUTE FUNCTION block_%[1]s_delete();
+	`, blockedTable, advisoryLockID))
+	require.NoError(t, err)
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		deleteResult <- s.DeleteProject(ctx, "default", "project-a")
+	}()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+			)
+		`, advisoryLockID).Scan(&waiting)
+		return err == nil && waiting
+	}, 10*time.Second, 10*time.Millisecond, "project deletion should reach the blocked %s delete", blockedTable)
+
+	operationResult := make(chan error, 1)
+	go func() {
+		operationResult <- operation(ctx, s)
+	}()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			WITH delete_backend AS (
+				SELECT pid
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+				LIMIT 1
+			)
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity AS activity, delete_backend
+				WHERE delete_backend.pid = ANY(pg_blocking_pids(activity.pid))
+			)
+		`, advisoryLockID).Scan(&waiting)
+		return err == nil && waiting
+	}, 10*time.Second, 10*time.Millisecond, "the competing operation should wait behind project deletion")
+
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", advisoryLockID)
+	require.NoError(t, err)
+	lockReleased = true
+	deleteErr := <-deleteResult
+	operationErr := <-operationResult
+	require.NoError(t, deleteErr)
+	return operationErr
+}

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -73,6 +73,14 @@ func (s *Store) CreatePlanCheckRun(ctx context.Context, create *PlanCheckRunMess
 	if err := acquirePlanIssueRolloutAdvisoryLock(ctx, tx, create.ProjectID, create.PlanUID); err != nil {
 		return false, errors.Wrap(err, "failed to acquire Plan review lock for Plan check run")
 	}
+	var lockedPlanCheckRunUID int64
+	if err := tx.QueryRowContext(ctx, `
+		SELECT id
+		FROM plan_check_run
+		WHERE project = $1 AND plan_id = $2
+		FOR UPDATE`, create.ProjectID, create.PlanUID).Scan(&lockedPlanCheckRunUID); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, errors.Wrap(err, "failed to lock Plan Check Run")
+	}
 	var lockedPlanUID int64
 	if err := tx.QueryRowContext(ctx, `
 		SELECT id

--- a/backend/store/plan_check_run_lock_order_test.go
+++ b/backend/store/plan_check_run_lock_order_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/store"
 )
@@ -23,4 +24,36 @@ func TestCreatePlanCheckRunDoesNotDeadlockWithProjectDeletion(t *testing.T) {
 		return err
 	})
 	require.NoError(t, err)
+}
+
+func TestCreateFirstPlanCheckRunStopsAfterProjectDeletion(t *testing.T) {
+	var created bool
+	err := runWithConcurrentProjectDeletion(t, `
+		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
+	`, "plan", 9904, func(ctx context.Context, s *store.Store) error {
+		var err error
+		created, err = s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+			ProjectID: "project-a",
+			PlanUID:   101,
+			Result:    &storepb.PlanCheckRunResult{},
+		})
+		return err
+	})
+	require.NoError(t, err)
+	require.False(t, created)
+}
+
+func TestCreatePlanCheckRunRejectsDeletedProjectDuringProjectDeletion(t *testing.T) {
+	operationErr, deleteErr := runWithCreationBeforeProjectDeletion(t, `
+		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
+	`, "plan", func(ctx context.Context, s *store.Store) error {
+		_, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+			ProjectID: "project-a",
+			PlanUID:   101,
+			Result:    &storepb.PlanCheckRunResult{},
+		})
+		return err
+	})
+	require.NoError(t, deleteErr)
+	require.Equal(t, common.NotFound, common.ErrorCode(operationErr))
 }

--- a/backend/store/plan_check_run_lock_order_test.go
+++ b/backend/store/plan_check_run_lock_order_test.go
@@ -2,120 +2,25 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
 func TestCreatePlanCheckRunDoesNotDeadlockWithProjectDeletion(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
-
-	_, err := db.ExecContext(ctx, `
-		INSERT INTO workspace (resource_id) VALUES ('default');
-		INSERT INTO project (resource_id, workspace, name) VALUES ('default', 'default', 'Default');
-		INSERT INTO project (resource_id, workspace, name, deleted) VALUES ('project-a', 'default', 'Project A', TRUE);
+	err := runWithConcurrentProjectDeletion(t, `
 		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
 		INSERT INTO plan_check_run (id, project, plan_id, status) VALUES (101, 'project-a', 101, 'FAILED');
-	`)
-	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
-
-	lockConn, err := db.Conn(ctx)
-	require.NoError(t, err)
-	defer lockConn.Close()
-	const advisoryLockID = 9902
-	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", advisoryLockID)
-	require.NoError(t, err)
-	lockReleased := false
-	defer func() {
-		if !lockReleased {
-			_, _ = lockConn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", advisoryLockID)
-		}
-	}()
-	_, err = db.ExecContext(ctx, `
-		CREATE FUNCTION block_plan_check_run_delete() RETURNS trigger AS $$
-		BEGIN
-			PERFORM pg_advisory_xact_lock(9902);
-			RETURN OLD;
-		END;
-		$$ LANGUAGE plpgsql;
-		CREATE TRIGGER block_plan_check_run_delete
-		AFTER DELETE ON plan_check_run
-		FOR EACH ROW EXECUTE FUNCTION block_plan_check_run_delete();
-	`)
-	require.NoError(t, err)
-
-	deleteResult := make(chan error, 1)
-	go func() {
-		deleteResult <- s.DeleteProject(ctx, "default", "project-a")
-	}()
-	require.Eventually(t, func() bool {
-		var waiting bool
-		err := db.QueryRowContext(ctx, `
-			SELECT EXISTS (
-				SELECT 1
-				FROM pg_locks
-				WHERE locktype = 'advisory'
-					AND objid = $1
-					AND NOT granted
-			)
-		`, advisoryLockID).Scan(&waiting)
-		return err == nil && waiting
-	}, 10*time.Second, 10*time.Millisecond, "project deletion should reach the blocked Plan Check Run delete")
-
-	createResult := make(chan error, 1)
-	go func() {
+	`, "plan_check_run", 9902, func(ctx context.Context, s *store.Store) error {
 		_, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
 			ProjectID: "project-a",
 			PlanUID:   101,
 			Result:    &storepb.PlanCheckRunResult{},
 		})
-		createResult <- err
-	}()
-	require.Eventually(t, func() bool {
-		var waiting bool
-		err := db.QueryRowContext(ctx, `
-			WITH delete_backend AS (
-				SELECT pid
-				FROM pg_locks
-				WHERE locktype = 'advisory'
-					AND objid = $1
-					AND NOT granted
-				LIMIT 1
-			)
-			SELECT EXISTS (
-				SELECT 1
-				FROM pg_stat_activity AS activity, delete_backend
-				WHERE delete_backend.pid = ANY(pg_blocking_pids(activity.pid))
-			)
-		`, advisoryLockID).Scan(&waiting)
-		return err == nil && waiting
-	}, 10*time.Second, 10*time.Millisecond, "Plan Check Run creation should wait behind its deletion")
-
-	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", advisoryLockID)
+		return err
+	})
 	require.NoError(t, err)
-	lockReleased = true
-	deleteErr := <-deleteResult
-	createErr := <-createResult
-	require.NoError(t, deleteErr)
-	require.NoError(t, createErr)
 }

--- a/backend/store/plan_check_run_lock_order_test.go
+++ b/backend/store/plan_check_run_lock_order_test.go
@@ -1,0 +1,121 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestCreatePlanCheckRunDoesNotDeadlockWithProjectDeletion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('default', 'default', 'Default');
+		INSERT INTO project (resource_id, workspace, name, deleted) VALUES ('project-a', 'default', 'Project A', TRUE);
+		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
+		INSERT INTO plan_check_run (id, project, plan_id, status) VALUES (101, 'project-a', 101, 'FAILED');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	lockConn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer lockConn.Close()
+	const advisoryLockID = 9902
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", advisoryLockID)
+	require.NoError(t, err)
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			_, _ = lockConn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", advisoryLockID)
+		}
+	}()
+	_, err = db.ExecContext(ctx, `
+		CREATE FUNCTION block_plan_check_run_delete() RETURNS trigger AS $$
+		BEGIN
+			PERFORM pg_advisory_xact_lock(9902);
+			RETURN OLD;
+		END;
+		$$ LANGUAGE plpgsql;
+		CREATE TRIGGER block_plan_check_run_delete
+		AFTER DELETE ON plan_check_run
+		FOR EACH ROW EXECUTE FUNCTION block_plan_check_run_delete();
+	`)
+	require.NoError(t, err)
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		deleteResult <- s.DeleteProject(ctx, "default", "project-a")
+	}()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+			)
+		`, advisoryLockID).Scan(&waiting)
+		return err == nil && waiting
+	}, 10*time.Second, 10*time.Millisecond, "project deletion should reach the blocked Plan Check Run delete")
+
+	createResult := make(chan error, 1)
+	go func() {
+		_, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+			ProjectID: "project-a",
+			PlanUID:   101,
+			Result:    &storepb.PlanCheckRunResult{},
+		})
+		createResult <- err
+	}()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			WITH delete_backend AS (
+				SELECT pid
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+				LIMIT 1
+			)
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity AS activity, delete_backend
+				WHERE delete_backend.pid = ANY(pg_blocking_pids(activity.pid))
+			)
+		`, advisoryLockID).Scan(&waiting)
+		return err == nil && waiting
+	}, 10*time.Second, 10*time.Millisecond, "Plan Check Run creation should wait behind its deletion")
+
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", advisoryLockID)
+	require.NoError(t, err)
+	lockReleased = true
+	deleteErr := <-deleteResult
+	createErr := <-createResult
+	require.NoError(t, deleteErr)
+	require.NoError(t, createErr)
+}

--- a/backend/store/project.go
+++ b/backend/store/project.go
@@ -440,7 +440,40 @@ func (s *Store) DeleteProject(ctx context.Context, workspace string, resourceID 
 		return errors.Wrapf(err, "failed to delete task_run for project %s", resourceID)
 	}
 
-	// Delete tasks in plans of this project
+	// Lock tasks in full primary-key order before deleting them. Pending Task Run
+	// creation uses the same order, so concurrent batches cannot form a wait cycle.
+	q = qb.Q().Space(`
+		SELECT project, id
+		FROM task
+		WHERE project = ?
+		ORDER BY project, id
+		FOR UPDATE`, resourceID)
+	sql, args, err = q.ToSQL()
+	if err != nil {
+		return errors.Wrap(err, "failed to build task lock query")
+	}
+	if err := func() error {
+		rows, err := tx.QueryContext(ctx, sql, args...)
+		if err != nil {
+			return errors.Wrapf(err, "failed to lock tasks for project %s", resourceID)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var lockedProjectID string
+			var lockedTaskID int64
+			if err := rows.Scan(&lockedProjectID, &lockedTaskID); err != nil {
+				return errors.Wrap(err, "failed to scan locked task")
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return errors.Wrap(err, "failed to read locked tasks")
+		}
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	// Delete tasks in plans of this project after acquiring every task lock.
 	q = qb.Q().Space("DELETE FROM task WHERE project = ?", resourceID)
 	sql, args, err = q.ToSQL()
 	if err != nil {

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -305,6 +305,12 @@ func (s *Store) CreatePendingTaskRuns(ctx context.Context, creator string, creat
 	if len(creates) == 0 {
 		return nil
 	}
+	projectID := creates[0].ProjectID
+	for _, create := range creates[1:] {
+		if create.ProjectID != projectID {
+			return common.Errorf(common.Invalid, "all task runs in a batch must belong to the same project")
+		}
+	}
 
 	var taskUIDs []int64
 	var runAts []*time.Time
@@ -334,8 +340,6 @@ func (s *Store) CreatePendingTaskRuns(ctx context.Context, creator string, creat
 			payloadStr = s
 		}
 	}
-
-	projectID := creates[0].ProjectID
 
 	tx, err := s.GetDB().BeginTx(ctx, nil)
 	if err != nil {

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -343,18 +343,53 @@ func (s *Store) CreatePendingTaskRuns(ctx context.Context, creator string, creat
 	}
 	defer tx.Rollback()
 
+	lockQ := qb.Q().Space(`
+		SELECT task.project, task.id
+		FROM (
+			SELECT
+				unnest(CAST(? AS TEXT[])) AS project,
+				unnest(CAST(? AS BIGINT[])) AS task_id
+		) requested_tasks
+		JOIN task ON task.project = requested_tasks.project AND task.id = requested_tasks.task_id
+		ORDER BY task.project, task.id
+		FOR UPDATE OF task`, projects, taskUIDs)
+	lockQuery, lockArgs, err := lockQ.ToSQL()
+	if err != nil {
+		return errors.Wrapf(err, "failed to build task lock sql")
+	}
+	lockedTaskCount := 0
+	if err := func() error {
+		rows, err := tx.QueryContext(ctx, lockQuery, lockArgs...)
+		if err != nil {
+			return errors.Wrapf(err, "failed to lock tasks")
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var lockedProjectID string
+			var lockedTaskUID int64
+			if err := rows.Scan(&lockedProjectID, &lockedTaskUID); err != nil {
+				return errors.Wrapf(err, "failed to scan locked task")
+			}
+			lockedTaskCount++
+		}
+		if err := rows.Err(); err != nil {
+			return errors.Wrapf(err, "failed to read locked tasks")
+		}
+		return nil
+	}(); err != nil {
+		return err
+	}
+	if lockedTaskCount == 0 {
+		return nil
+	}
+
+	// Keep the child-to-parent lock order used by project deletion: task, then project.
 	baseID, err := nextProjectID(ctx, tx, "task_run", projectID)
 	if err != nil {
 		return err
 	}
 
-	// Single query that:
-	// 1. Locks task rows so task-run creation and skipping cannot both win
-	// 2. Assigns per-project IDs using ROW_NUMBER() + baseID
-	// 3. Filters out tasks with existing PENDING/RUNNING/DONE task runs (idempotent)
-	// 4. Calculates next attempt for each remaining task
-	// 5. Inserts task runs
-	// 6. Uses ON CONFLICT DO NOTHING to handle race conditions
+	// Assign per-project IDs, filter existing task runs, and insert new pending runs.
 	q := qb.Q().Space(`
 		WITH requested_tasks AS (
 			SELECT
@@ -369,8 +404,6 @@ func (s *Store) CreatePendingTaskRuns(ctx context.Context, creator string, creat
 			) tasks
 			JOIN task ON task.project = tasks.project AND task.id = tasks.task_id
 			WHERE (task.payload->>'skipped')::BOOLEAN IS NOT TRUE
-			ORDER BY tasks.project, tasks.task_id
-			FOR UPDATE OF task
 		), candidates AS (
 			SELECT
 				(ROW_NUMBER() OVER ()) + ? - 1 AS new_id,

--- a/backend/store/task_run_batch_test.go
+++ b/backend/store/task_run_batch_test.go
@@ -1,0 +1,61 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestCreatePendingTaskRunsRejectsMultipleProjects(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(context.Background()) })
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES
+			('project-a', 'default', 'Project A'),
+			('project-b', 'default', 'Project B');
+		INSERT INTO instance (resource_id, workspace) VALUES ('instance-a', 'default');
+		INSERT INTO plan (id, creator, project, name, description) VALUES
+			(101, 'creator@example.com', 'project-a', 'Plan A', ''),
+			(101, 'creator@example.com', 'project-b', 'Plan B', '');
+		INSERT INTO task (id, project, plan_id, instance, type) VALUES
+			(101, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE'),
+			(101, 'project-b', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	err = s.CreatePendingTaskRuns(ctx, "creator@example.com",
+		&store.TaskRunMessage{ProjectID: "project-a", TaskUID: 101},
+		&store.TaskRunMessage{ProjectID: "project-b", TaskUID: 101},
+	)
+	require.Equal(t, common.Invalid, common.ErrorCode(err))
+	require.ErrorContains(t, err, "same project")
+
+	for _, projectID := range []string{"project-a", "project-b"} {
+		taskRuns, err := s.ListTaskRuns(ctx, &store.FindTaskRunMessage{ProjectID: projectID})
+		require.NoError(t, err)
+		require.Empty(t, taskRuns)
+	}
+}

--- a/backend/store/task_run_lock_order_test.go
+++ b/backend/store/task_run_lock_order_test.go
@@ -1,0 +1,120 @@
+package store_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestCreatePendingTaskRunsDoesNotDeadlockWithProjectDeletion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('default', 'default', 'Default');
+		INSERT INTO project (resource_id, workspace, name, deleted) VALUES ('project-a', 'default', 'Project A', TRUE);
+		INSERT INTO instance (resource_id, workspace) VALUES ('instance-a', 'default');
+		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
+		INSERT INTO task (id, project, plan_id, instance, type) VALUES (102, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
+		INSERT INTO task (id, project, plan_id, instance, type) VALUES (101, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+
+	lockConn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer lockConn.Close()
+	const advisoryLockID = 9901
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", advisoryLockID)
+	require.NoError(t, err)
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			_, _ = lockConn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", advisoryLockID)
+		}
+	}()
+	_, err = db.ExecContext(ctx, `
+		CREATE FUNCTION block_task_delete() RETURNS trigger AS $$
+		BEGIN
+			PERFORM pg_advisory_xact_lock(9901);
+			RETURN OLD;
+		END;
+		$$ LANGUAGE plpgsql;
+		CREATE TRIGGER block_task_delete
+		AFTER DELETE ON task
+		FOR EACH ROW EXECUTE FUNCTION block_task_delete();
+	`)
+	require.NoError(t, err)
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		deleteResult <- s.DeleteProject(ctx, "default", "project-a")
+	}()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+			)
+		`, advisoryLockID).Scan(&waiting)
+		return err == nil && waiting
+	}, 10*time.Second, 10*time.Millisecond, "project deletion should reach the blocked task delete")
+
+	runResult := make(chan error, 1)
+	go func() {
+		runResult <- s.CreatePendingTaskRuns(ctx, "",
+			&store.TaskRunMessage{ProjectID: "project-a", TaskUID: 101},
+			&store.TaskRunMessage{ProjectID: "project-a", TaskUID: 102},
+		)
+	}()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			WITH delete_backend AS (
+				SELECT pid
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+				LIMIT 1
+			)
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity AS activity, delete_backend
+				WHERE delete_backend.pid = ANY(pg_blocking_pids(activity.pid))
+			)
+		`, advisoryLockID).Scan(&waiting)
+		return err == nil && waiting
+	}, 10*time.Second, 10*time.Millisecond, "Task Run creation should wait behind the task deletion")
+
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", advisoryLockID)
+	require.NoError(t, err)
+	lockReleased = true
+	deleteErr := <-deleteResult
+	runErr := <-runResult
+	require.NoError(t, deleteErr)
+	require.NoError(t, runErr)
+}

--- a/backend/store/task_run_lock_order_test.go
+++ b/backend/store/task_run_lock_order_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -11,18 +12,93 @@ import (
 )
 
 func TestCreatePendingTaskRunsDoesNotDeadlockWithProjectDeletion(t *testing.T) {
-	err := runWithConcurrentProjectDeletion(t, `
+	fixture := newProjectDeletionLockOrderFixture(t, `
 		INSERT INTO instance (resource_id, workspace) VALUES ('instance-a', 'default');
 		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
 		INSERT INTO task (id, project, plan_id, instance, type) VALUES (102, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
 		INSERT INTO task (id, project, plan_id, instance, type) VALUES (101, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
-	`, "task", 9901, func(ctx context.Context, s *store.Store) error {
-		return s.CreatePendingTaskRuns(ctx, "",
+	`)
+	ctx, db, s := fixture.ctx, fixture.db, fixture.store
+
+	const advisoryLockID = 9901
+	lockConn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer lockConn.Close()
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", advisoryLockID)
+	require.NoError(t, err)
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			_, _ = lockConn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", advisoryLockID)
+		}
+	}()
+
+	_, err = db.ExecContext(ctx, `
+		CREATE FUNCTION block_task_delete_after_higher_lock() RETURNS trigger AS $$
+		BEGIN
+			PERFORM id FROM task
+			WHERE project = 'project-a' AND id = 102
+			FOR UPDATE;
+			PERFORM pg_advisory_xact_lock(9901);
+			RETURN NULL;
+		END;
+		$$ LANGUAGE plpgsql;
+		CREATE TRIGGER block_task_delete_after_higher_lock
+		BEFORE DELETE ON task
+		FOR EACH STATEMENT EXECUTE FUNCTION block_task_delete_after_higher_lock();
+	`)
+	require.NoError(t, err)
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		deleteResult <- s.DeleteProject(ctx, "default", "project-a")
+	}()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+			)
+		`, advisoryLockID).Scan(&waiting)
+		return err == nil && waiting
+	}, 10*time.Second, 10*time.Millisecond, "project deletion should lock task 102 before deleting the task batch")
+
+	operationResult := make(chan error, 1)
+	go func() {
+		operationResult <- s.CreatePendingTaskRuns(ctx, "",
 			&store.TaskRunMessage{ProjectID: "project-a", TaskUID: 101},
 			&store.TaskRunMessage{ProjectID: "project-a", TaskUID: 102},
 		)
-	})
+	}()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			WITH delete_backend AS (
+				SELECT pid
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+				LIMIT 1
+			)
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity AS activity, delete_backend
+				WHERE delete_backend.pid = ANY(pg_blocking_pids(activity.pid))
+			)
+		`, advisoryLockID).Scan(&waiting)
+		return err == nil && waiting
+	}, 10*time.Second, 10*time.Millisecond, "task run creation should wait for the project purge")
+
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", advisoryLockID)
 	require.NoError(t, err)
+	lockReleased = true
+	require.NoError(t, <-deleteResult)
+	require.NoError(t, <-operationResult)
 }
 
 func TestCreatePendingTaskRunsRejectsDeletedProjectDuringProjectDeletion(t *testing.T) {

--- a/backend/store/task_run_lock_order_test.go
+++ b/backend/store/task_run_lock_order_test.go
@@ -2,119 +2,24 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
 func TestCreatePendingTaskRunsDoesNotDeadlockWithProjectDeletion(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
-
-	_, err := db.ExecContext(ctx, `
-		INSERT INTO workspace (resource_id) VALUES ('default');
-		INSERT INTO project (resource_id, workspace, name) VALUES ('default', 'default', 'Default');
-		INSERT INTO project (resource_id, workspace, name, deleted) VALUES ('project-a', 'default', 'Project A', TRUE);
+	err := runWithConcurrentProjectDeletion(t, `
 		INSERT INTO instance (resource_id, workspace) VALUES ('instance-a', 'default');
 		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
 		INSERT INTO task (id, project, plan_id, instance, type) VALUES (102, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
 		INSERT INTO task (id, project, plan_id, instance, type) VALUES (101, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
-	`)
-	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
-
-	lockConn, err := db.Conn(ctx)
-	require.NoError(t, err)
-	defer lockConn.Close()
-	const advisoryLockID = 9901
-	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", advisoryLockID)
-	require.NoError(t, err)
-	lockReleased := false
-	defer func() {
-		if !lockReleased {
-			_, _ = lockConn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", advisoryLockID)
-		}
-	}()
-	_, err = db.ExecContext(ctx, `
-		CREATE FUNCTION block_task_delete() RETURNS trigger AS $$
-		BEGIN
-			PERFORM pg_advisory_xact_lock(9901);
-			RETURN OLD;
-		END;
-		$$ LANGUAGE plpgsql;
-		CREATE TRIGGER block_task_delete
-		AFTER DELETE ON task
-		FOR EACH ROW EXECUTE FUNCTION block_task_delete();
-	`)
-	require.NoError(t, err)
-
-	deleteResult := make(chan error, 1)
-	go func() {
-		deleteResult <- s.DeleteProject(ctx, "default", "project-a")
-	}()
-	require.Eventually(t, func() bool {
-		var waiting bool
-		err := db.QueryRowContext(ctx, `
-			SELECT EXISTS (
-				SELECT 1
-				FROM pg_locks
-				WHERE locktype = 'advisory'
-					AND objid = $1
-					AND NOT granted
-			)
-		`, advisoryLockID).Scan(&waiting)
-		return err == nil && waiting
-	}, 10*time.Second, 10*time.Millisecond, "project deletion should reach the blocked task delete")
-
-	runResult := make(chan error, 1)
-	go func() {
-		runResult <- s.CreatePendingTaskRuns(ctx, "",
+	`, "task", 9901, func(ctx context.Context, s *store.Store) error {
+		return s.CreatePendingTaskRuns(ctx, "",
 			&store.TaskRunMessage{ProjectID: "project-a", TaskUID: 101},
 			&store.TaskRunMessage{ProjectID: "project-a", TaskUID: 102},
 		)
-	}()
-	require.Eventually(t, func() bool {
-		var waiting bool
-		err := db.QueryRowContext(ctx, `
-			WITH delete_backend AS (
-				SELECT pid
-				FROM pg_locks
-				WHERE locktype = 'advisory'
-					AND objid = $1
-					AND NOT granted
-				LIMIT 1
-			)
-			SELECT EXISTS (
-				SELECT 1
-				FROM pg_stat_activity AS activity, delete_backend
-				WHERE delete_backend.pid = ANY(pg_blocking_pids(activity.pid))
-			)
-		`, advisoryLockID).Scan(&waiting)
-		return err == nil && waiting
-	}, 10*time.Second, 10*time.Millisecond, "Task Run creation should wait behind the task deletion")
-
-	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", advisoryLockID)
+	})
 	require.NoError(t, err)
-	lockReleased = true
-	deleteErr := <-deleteResult
-	runErr := <-runResult
-	require.NoError(t, deleteErr)
-	require.NoError(t, runErr)
 }

--- a/backend/store/task_run_lock_order_test.go
+++ b/backend/store/task_run_lock_order_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -22,4 +23,19 @@ func TestCreatePendingTaskRunsDoesNotDeadlockWithProjectDeletion(t *testing.T) {
 		)
 	})
 	require.NoError(t, err)
+}
+
+func TestCreatePendingTaskRunsRejectsDeletedProjectDuringProjectDeletion(t *testing.T) {
+	operationErr, deleteErr := runWithCreationBeforeProjectDeletion(t, `
+		INSERT INTO instance (resource_id, workspace) VALUES ('instance-a', 'default');
+		INSERT INTO plan (id, creator, project, name, description) VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
+		INSERT INTO task (id, project, plan_id, instance, type) VALUES (101, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
+	`, "task", func(ctx context.Context, s *store.Store) error {
+		return s.CreatePendingTaskRuns(ctx, "", &store.TaskRunMessage{
+			ProjectID: "project-a",
+			TaskUID:   101,
+		})
+	})
+	require.NoError(t, deleteErr)
+	require.Equal(t, common.NotFound, common.ErrorCode(operationErr))
 }

--- a/backend/tests/cross_project_update_test.go
+++ b/backend/tests/cross_project_update_test.go
@@ -83,7 +83,15 @@ func TestCollisionCreateRolloutIsolation(t *testing.T) {
 	defer ctl.Close(ctx)
 
 	fixture := setupCollidingProjects(ctx, t, ctl)
+	a.Greater(len(fixture.BaselineA.PlanCheckRuns), 0, "project A should have plan_check_runs")
 	fixture.completeRolloutB(ctx, t, ctl)
+	planCheckRunB, err := ctl.planServiceClient.GetPlanCheckRun(ctx,
+		connect.NewRequest(&v1pb.GetPlanCheckRunRequest{
+			Name: fixture.PlanB.Name + "/planCheckRun",
+		}))
+	a.NoError(err)
+	a.True(strings.HasPrefix(planCheckRunB.Msg.Name, fixture.ProjectB.Name+"/"),
+		"GetPlanCheckRun for plan B returned %s from another project", planCheckRunB.Msg.Name)
 	aAfter := snapshotProject(ctx, t, ctl, fixture.ProjectA)
 	assertProjectUnchanged(t, fixture.BaselineA, aAfter, "project A after project B rollout")
 }

--- a/docs/pre-pr-checklist.md
+++ b/docs/pre-pr-checklist.md
@@ -156,11 +156,27 @@ Read the canonical [store row-lock ordering](../backend/store/README.md#transact
 - Batches are locked in full primary-key order
 - Project-owned sibling branches follow the documented `DeleteProject` order
 - `nextProjectID` is called only after required existing-child locks
+- `nextProjectID` locks the project and requires it to be active before allocation;
+  missing or deleted projects reject creation
 - `UPDATE`, `DELETE`, foreign-key checks, and conflicting upserts are included in the ordering analysis
 
-If the transaction coordinates multiple rows or tables, add a deterministic real-PostgreSQL regression test against its competing transaction path. The test must observe the public store behavior and fail with the old lock order.
+Row ordering prevents wait-for cycles on existing rows, but it cannot protect an
+absent child row. The `nextProjectID` active-project check covers only writers that
+call it, not every repository writer. For every new or modified writer of
+purge-managed data, define whether it requires an active project or merely an
+existing project, then serialize and validate that lifecycle policy against
+project deletion.
 
-**STOP — do not proceed to PR creation if the transaction conflicts with the canonical order or lacks the required deadlock regression.**
+If the transaction coordinates multiple rows or tables or races with project
+deletion, add deterministic real-PostgreSQL regression tests for both
+lock-acquisition directions. The tests must observe public store behavior, fail
+against the old behavior, and assert terminal outcomes. Verify that neither
+direction ends in a foreign-key failure; merely checking for the absence of
+SQLSTATE `40P01` is insufficient.
+
+**STOP — do not proceed to PR creation if the transaction conflicts with the
+canonical order or lacks the required deterministic lock and lifecycle regression
+tests.**
 
 ## 5. Image Compatibility Window
 

--- a/docs/pre-pr-checklist.md
+++ b/docs/pre-pr-checklist.md
@@ -142,7 +142,23 @@ spots — they document what helpers exist and what guarantees they make.
 Stale references don't break the build but they actively mislead future
 contributors and AI agents that read these docs at session start.
 
-## 4. Image Compatibility Window
+## 4. Transaction Lock Ordering
+
+**Skip if:** the diff does not add or modify a transaction in `backend/store/`.
+
+Read the canonical [store row-lock ordering](../backend/store/README.md#transaction-row-lock-ordering), then inspect every explicit and implicit lock in the changed transaction:
+
+- Transaction-scoped advisory locks are acquired before row locks
+- Existing related rows are locked child-to-parent
+- Batches are locked in full primary-key order
+- `nextProjectID` is called only after required existing-child locks
+- `UPDATE`, `DELETE`, foreign-key checks, and conflicting upserts are included in the ordering analysis
+
+If the transaction coordinates multiple rows or tables, add a deterministic real-PostgreSQL regression test against its competing transaction path. The test must observe the public store behavior and fail with the old lock order.
+
+**STOP — do not proceed to PR creation if the transaction conflicts with the canonical order or lacks the required deadlock regression.**
+
+## 5. Image Compatibility Window
 
 **Skip if:** diff does not touch server version metadata, actuator compatibility
 metadata, or `bytebase-action` version/compatibility logic.
@@ -156,7 +172,7 @@ If the diff changes, narrows, or may break the compatibility window, call out
 the policy change, compatibility impact, and validation plan in the PR
 description.
 
-## 5. Lint and Format Gate
+## 6. Lint and Format Gate
 
 **Skip if:** no code changes (docs-only PR).
 
@@ -180,7 +196,7 @@ pnpm --dir frontend type-check
 buf lint proto
 ```
 
-## 6. Test Gate
+## 7. Test Gate
 
 **Skip if:** no code changes.
 
@@ -189,7 +205,7 @@ buf lint proto
 - For Go changes: `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
 - For new migration files: update `TestLatestVersion` in `backend/migrator/migrator_test.go`
 
-## 7. SonarCloud Properties
+## 8. SonarCloud Properties
 
 **Skip if:** no new files or directories added.
 
@@ -198,7 +214,7 @@ Update `.sonarcloud.properties` to reflect the latest file structure:
 - `sonar.test.inclusions` for test file patterns (e.g., `**/*_test.go`)
 - `sonar.cpd.exclusions` to skip copy-paste detection on test files
 
-## 8. Final Verification
+## 9. Final Verification
 
 Before running `gh pr create`:
 

--- a/docs/pre-pr-checklist.md
+++ b/docs/pre-pr-checklist.md
@@ -69,14 +69,17 @@ last updated. Cross-reference with the tables your diff touches.
 
 For every query in the diff that touches a composite-PK table, verify:
 
-- Every `WHERE` clause includes ALL primary key columns
-- Every `JOIN ... ON` includes ALL primary key columns
-- Every `DELETE ... USING` includes ALL primary key columns
-- Every `UPDATE ... FROM` includes ALL primary key columns
+- Every `WHERE`, `JOIN ... ON`, `DELETE ... USING`, and `UPDATE ... FROM`
+  predicate includes every project/tenant scope column
+- Each row is identified by either the full primary key or a full declared
+  non-partial UNIQUE key containing the same scope columns
+- Any alternate unique key is verified against `LATEST.sql`
 
-**Red flag pattern:** `WHERE id = ?` without `AND project = ?` on any of these tables.
+**Red flag patterns:** `WHERE id = ?` or `WHERE plan_id = ?` without
+`AND project = ?` on any of these tables.
 
-**STOP — do not proceed to PR creation if any predicate is missing a PK column.**
+**STOP — do not proceed to PR creation if any predicate is missing a required
+scope or key column.**
 This is the exact bug pattern that caused BYT-9259. Fix the query first.
 
 ### Step 3c: Verify collision test coverage
@@ -151,6 +154,7 @@ Read the canonical [store row-lock ordering](../backend/store/README.md#transact
 - Transaction-scoped advisory locks are acquired before row locks
 - Existing related rows are locked child-to-parent
 - Batches are locked in full primary-key order
+- Project-owned sibling branches follow the documented `DeleteProject` order
 - `nextProjectID` is called only after required existing-child locks
 - `UPDATE`, `DELETE`, foreign-key checks, and conflicting upserts are included in the ordering analysis
 


### PR DESCRIPTION
## What changed

- Lock requested Tasks before the Project ID allocator when creating pending Task Runs.
- Make project purge prelock every Task in full `(project, id)` order before deleting the Task batch.
- Lock an existing Plan Check Run before its Plan and Project parents when refreshing it.
- Lock an Issue's existing Plan before its Project when creating a linked Issue.
- Make `nextProjectID` lock and validate an active Project before allocating IDs, closing first-child creation races with project purge.
- Apply the same active-Project lifecycle gate to the draft-Issue workflow, which allocates IDs manually.
- Reject mixed-project Task Run batches before entering the transaction.
- Document the canonical row-lock hierarchy, absent-child lifecycle rule, and full project-purge sibling order in `backend/store/README.md`, `AGENTS.md`, and the pre-PR checklist.
- Add deterministic PostgreSQL regressions for both lock-acquisition directions, including first Task Run, first Plan Check Run, linked Issue, and draft Issue creation.

## Why

Follow-up to #20935 and BYT-9900.

`nextProjectID` locks the Project row. Calling it before locking an existing child or intermediate parent produced lock orders opposite to project deletion:

- Task Run creation used `project -> task` instead of `task -> project`.
- Plan Check Run refresh used `plan -> project -> plan_check_run` instead of `plan_check_run -> plan -> project`.
- Linked Issue creation used `project -> plan` through its foreign-key check instead of `plan -> project`.

Correcting those inversions prevents deadlocks on existing rows, but an absent child cannot be locked. If purge passed the empty child table and creation later inserted the first row, either side could terminate with SQLSTATE `23503`. The active-Project lifecycle gate serializes first-child creation with purge and rejects creation once the Project is deleted.

## User impact

Concurrent Task Run, Plan Check Run, linked Issue, or draft Issue creation and project purge now have deterministic terminal behavior: purge succeeds and creation either completes before purge or returns the path's not-found outcome. They no longer terminate with SQLSTATE `40P01` or `23503`. Run/skip mutual exclusion remains intact.

## Validation

- Red-before-green proofs for the three first-child races: each previously terminated with SQLSTATE `23503` under the creation-first schedule.
- A forced high-ID-first purge regression reproduced SQLSTATE `40P01` before the ordered Task prelock and passes afterward.
- Store lock/lifecycle regressions passed three consecutive runs; draft-Issue races also passed three consecutive runs.
- Full `backend/store` and `backend/component/review` test suites.
- Full `TestClaim|TestCollision` gate.
- `golangci-lint`: 0 issues, including fix pass and clean rerun.
- Server build.
- Three-agent standards, concurrency, and test-rigor review; follow-up review clean.

No breaking changes.
