### PR TITLE
revert: remove Sonar review constant

### DIFF
--- a/backend/component/review/submission.go
+++ b/backend/component/review/submission.go
@@ -17,8 +17,6 @@ import (
 	"github.com/bytebase/bytebase/backend/store"
 )
 
-const projectNotFoundFormat = "project %s not found"
-
 // SubmittedEvent requests a submission timeline entry.
 type SubmittedEvent struct{}
 
@@ -97,12 +95,12 @@ func (w *Workflow) CreateDraftIssue(ctx context.Context, input CreateDraftIssueI
 		SELECT deleted FROM project
 		WHERE workspace = $1 AND resource_id = $2
 		FOR UPDATE`, input.Workspace, issue.ProjectID).Scan(&projectDeleted); errors.Is(err, sql.ErrNoRows) {
-		return nil, workflowError(ErrorNotFound, projectNotFoundFormat, issue.ProjectID)
+		return nil, workflowError(ErrorNotFound, "project %s not found", issue.ProjectID)
 	} else if err != nil {
 		return nil, workflowWrap(ErrorInternal, err, "failed to lock project for draft creation")
 	}
 	if projectDeleted {
-		return nil, workflowError(ErrorNotFound, projectNotFoundFormat, issue.ProjectID)
+		return nil, workflowError(ErrorNotFound, "project %s not found", issue.ProjectID)
 	}
 	if err := tx.QueryRowContext(ctx, `
 		SELECT GREATEST(COALESCE(MAX(id), 0) + 1, 101)
@@ -159,7 +157,7 @@ func (w *Workflow) SubmitIssue(ctx context.Context, input SubmitIssueInput) (*Su
 		return nil, workflowWrap(ErrorInternal, err, "failed to get project")
 	}
 	if project == nil {
-		return nil, workflowError(ErrorNotFound, projectNotFoundFormat, input.ProjectID)
+		return nil, workflowError(ErrorNotFound, "project %s not found", input.ProjectID)
 	}
 	observedIssue, err := w.store.GetIssue(ctx, &store.FindIssueMessage{
 		Workspace: input.Workspace, ProjectIDs: []string{input.ProjectID}, UID: &input.IssueUID,


### PR DESCRIPTION
## What changed

- Revert the Sonar-specific `projectNotFoundFormat` constant extraction from commit `6f6609d983`.
- Restore the original inline `project %s not found` error messages.

## Why

Requested rollback of the Sonar review follow-up. This changes no runtime behavior; it only restores the prior source form.

## Validation

- `go test -count=1 ./backend/component/review -run '^(TestCreateDraftIssueRejectsUnavailableProject|TestSubmitIssue)' -timeout 5m`
- `golangci-lint run --allow-parallel-runners` — 0 issues
- Server build succeeded
- `git diff --check` passed

SonarCloud may report the pre-existing duplicate-literal rule (`go:S1192`) by design; this PR intentionally restores that source form.

No breaking changes.
