### PR TITLE
fix: coordinate plan approval locks

### DIFF
--- a/backend/api/v1/issue_service_test.go
+++ b/backend/api/v1/issue_service_test.go
@@ -793,14 +793,10 @@ func TestStaleReviewRequestDispatchesNoPostCommitEffects(t *testing.T) {
 		PayloadUpsert: &storepb.Issue{Approval: staleApproval},
 	})
 	require.NoError(t, err)
-	_, err = stores.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID:       plan.UID,
-		ProjectID: plan.ProjectID,
-		Config: &storepb.PlanConfig{
-			ApprovalInputVersion: 3,
-			Specs:                plan.Config.GetSpecs(),
-		},
-	})
+	_, err = stores.GetDB().ExecContext(ctx, `
+		UPDATE plan
+		SET config = jsonb_set(config, '{approvalInputVersion}', '3')
+		WHERE project = $1 AND id = $2`, plan.ProjectID, plan.UID)
 	require.NoError(t, err)
 
 	for range 2 {

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -296,7 +296,9 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 		return nil, connect.NewError(connect.CodePermissionDenied, errors.Errorf("permission denied to update plan"))
 	}
 
-	planUpdate := &store.UpdatePlanMessage{}
+	var title *string
+	var description *string
+	var deleted *bool
 	var specs []*storepb.PlanConfig_Spec
 
 	var planCheckRunsTrigger bool
@@ -309,11 +311,11 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 			if project.Setting.EnforceIssueTitle && trimmed == "" {
 				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("project %q requires a manual plan title (enforce_issue_title is enabled)", common.FormatProject(project.ResourceID)))
 			}
-			planUpdate.Name = &trimmed
+			title = &trimmed
 		case "description":
-			planUpdate.Description = new(req.Plan.Description)
+			description = new(req.Plan.Description)
 		case "state":
-			planUpdate.Deleted = new(req.Plan.State == v1pb.State_DELETED)
+			deleted = new(req.Plan.State == v1pb.State_DELETED)
 		case "specs":
 			if oldPlan.Config != nil && oldPlan.Config.GetHasRollout() {
 				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("cannot update specs for plan that has a rollout"))
@@ -345,9 +347,9 @@ func (s *PlanService) UpdatePlan(ctx context.Context, request *connect.Request[v
 		Workspace:   common.GetWorkspaceIDFromContext(ctx),
 		PlanUID:     oldPlan.UID,
 		ProjectID:   oldPlan.ProjectID,
-		Title:       planUpdate.Name,
-		Description: planUpdate.Description,
-		Deleted:     planUpdate.Deleted,
+		Title:       title,
+		Description: description,
+		Deleted:     deleted,
 		Specs:       specsUpdate,
 	})
 	if err != nil {

--- a/backend/api/v1/plan_service_test.go
+++ b/backend/api/v1/plan_service_test.go
@@ -67,9 +67,9 @@ func TestPlanServiceListPlansHidesMalformedUIPlans(t *testing.T) {
 		},
 	}}})
 	deleted := createPlan("deleted", changeConfig("deleted", ""))
-	_, err = stores.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID: deleted.UID, ProjectID: deleted.ProjectID, Deleted: new(true),
-	})
+	_, err = stores.GetDB().ExecContext(ctx, `
+		UPDATE plan SET deleted = TRUE
+		WHERE project = $1 AND id = $2`, deleted.ProjectID, deleted.UID)
 	require.NoError(t, err)
 	linked := createPlan("linked", changeConfig("linked", ""))
 	_, err = stores.CreateIssue(ctx, &store.IssueMessage{

--- a/backend/component/ghost/manifest_test.go
+++ b/backend/component/ghost/manifest_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 // frontendFlagManifestPath is the gh-ost flag manifest the "Configure" UI builds
-// its parameter list from (frontend/src/react/components/ghost/constants.ts
+// its parameter list from (frontend/src/components/ghost/constants.ts
 // imports it). The path is relative to this package directory, where `go test`
 // runs.
-const frontendFlagManifestPath = "../../../frontend/src/react/components/ghost/flags.json"
+const frontendFlagManifestPath = "../../../frontend/src/components/ghost/flags.json"
 
 // TestFrontendFlagManifestInSync fails if the frontend gh-ost flag manifest
 // drifts from the backend allowlist/defaults, so a flag added, removed, or

--- a/backend/component/review/approval.go
+++ b/backend/component/review/approval.go
@@ -145,6 +145,14 @@ func (a *ApprovalEvaluator) ApplyApprovalTemplate(ctx context.Context, input App
 		return nil, workflowWrap(ErrorInternal, err, "failed to begin approval finding transaction")
 	}
 	defer tx.Rollback()
+	if observedPlan != nil {
+		if err := store.AcquirePlanIssueRolloutAdvisoryLock(ctx, tx, input.ProjectID, observedPlan.UID); err != nil {
+			return nil, workflowWrap(ErrorInternal, err, "failed to acquire Plan review lock for approval finding")
+		}
+	}
+	// The existing Issue row is the project-lifecycle fence for this update:
+	// project purge deletes Issues before the Project. Approval may finish while
+	// a soft-deleted Project still exists, but cannot write after purge passes it.
 	lockedIssue, err := lockIssue(ctx, tx, input.ProjectID, input.IssueUID)
 	if err != nil {
 		return nil, err
@@ -152,7 +160,7 @@ func (a *ApprovalEvaluator) ApplyApprovalTemplate(ctx context.Context, input App
 	if lockedIssue == nil {
 		return nil, workflowError(ErrorNotFound, "issue %d not found in project %s", input.IssueUID, input.ProjectID)
 	}
-	lockedPlan, err := lockIssuePlan(ctx, tx, lockedIssue)
+	lockedPlan, err := getIssuePlan(ctx, tx, lockedIssue)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/component/review/approval_lifecycle_test.go
+++ b/backend/component/review/approval_lifecycle_test.go
@@ -1,0 +1,238 @@
+package review
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+const approvalLifecycleAdvisoryLockID = 990138
+
+type approvalLifecycleApplyOutcome struct {
+	result *ApplyApprovalTemplateResult
+	err    error
+}
+
+func TestApplyApprovalTemplateAndProjectDeletionPurgeFirst(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stores := setupWorkflowStore(ctx, t)
+	plan, issue := newApprovalLifecycleFixture(ctx, t, stores)
+	softDeleteApprovalLifecycleProject(ctx, t, stores)
+
+	db := stores.GetDB()
+	lockConn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	defer lockConn.Close()
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", approvalLifecycleAdvisoryLockID)
+	require.NoError(t, err)
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			_, _ = lockConn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", approvalLifecycleAdvisoryLockID)
+		}
+	}()
+	_, err = db.ExecContext(ctx, `
+		CREATE FUNCTION block_approval_lifecycle_issue_delete() RETURNS trigger AS $$
+		BEGIN
+			PERFORM pg_advisory_xact_lock(990138);
+			RETURN OLD;
+		END;
+		$$ LANGUAGE plpgsql;
+		CREATE TRIGGER block_approval_lifecycle_issue_delete
+		AFTER DELETE ON issue
+		FOR EACH ROW EXECUTE FUNCTION block_approval_lifecycle_issue_delete();
+	`)
+	require.NoError(t, err)
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		deleteResult <- stores.DeleteProject(ctx, "default", "project-a")
+	}()
+	deleteBackendPID := waitForAdvisoryLockWaiter(ctx, t, db, approvalLifecycleAdvisoryLockID)
+
+	applyReady := make(chan struct{})
+	applyResult := startApprovalLifecycleApply(ctx, stores, issue, applyReady)
+	<-applyReady
+	waitForBackendBlockedBy(ctx, t, db, deleteBackendPID,
+		"approval should wait for the Issue row being purged")
+
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", approvalLifecycleAdvisoryLockID)
+	require.NoError(t, err)
+	lockReleased = true
+	require.NoError(t, <-deleteResult)
+	assertApprovalLifecycleRejected(t, <-applyResult)
+	assertApprovalLifecyclePurged(ctx, t, stores, plan, issue)
+}
+
+func TestApplyApprovalTemplateAndProjectDeletionApprovalFirst(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stores := setupWorkflowStore(ctx, t)
+	plan, issue := newApprovalLifecycleFixture(ctx, t, stores)
+	softDeleteApprovalLifecycleProject(ctx, t, stores)
+
+	planCheckRunLock, planCheckRunLockPID := lockApprovalLifecyclePlanCheckRun(ctx, t, stores.GetDB(), plan)
+	lockReleased := false
+	defer func() {
+		if !lockReleased {
+			_ = planCheckRunLock.Rollback()
+		}
+	}()
+
+	applyReady := make(chan struct{})
+	applyResult := startApprovalLifecycleApply(ctx, stores, issue, applyReady)
+	<-applyReady
+	applyBackendPID := waitForBackendBlockedBy(ctx, t, stores.GetDB(), planCheckRunLockPID,
+		"approval should lock the Issue, then wait for the Plan Check Run row")
+
+	deleteResult := make(chan error, 1)
+	go func() {
+		deleteResult <- stores.DeleteProject(ctx, "default", "project-a")
+	}()
+	waitForBackendBlockedBy(ctx, t, stores.GetDB(), applyBackendPID,
+		"project deletion should wait for approval's Issue row lock")
+
+	require.NoError(t, planCheckRunLock.Commit())
+	lockReleased = true
+	apply := <-applyResult
+	require.NoError(t, apply.err)
+	require.NotNil(t, apply.result)
+	require.True(t, apply.result.Applied)
+	require.NoError(t, <-deleteResult)
+	assertApprovalLifecyclePurged(ctx, t, stores, plan, issue)
+}
+
+func softDeleteApprovalLifecycleProject(ctx context.Context, t *testing.T, stores *store.Store) {
+	t.Helper()
+	deleted := true
+	require.NoError(t, stores.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		Workspace:  "default",
+		ResourceID: "project-a",
+		Delete:     &deleted,
+	}))
+}
+
+func newApprovalLifecycleFixture(ctx context.Context, t *testing.T, stores *store.Store) (*store.PlanMessage, *store.IssueMessage) {
+	t.Helper()
+	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      "approval lifecycle",
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	issue, err := stores.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "approval lifecycle",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		PlanUID:      &plan.UID,
+		Payload: &storepb.Issue{Approval: &storepb.IssuePayloadApproval{
+			ApprovalInputVersion: 2,
+		}},
+	})
+	require.NoError(t, err)
+	created, err := stores.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+	planCheckRun, err := stores.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NoError(t, stores.UpdatePlanCheckRun(ctx, "project-a", store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: 2,
+	}, planCheckRun.UID))
+	return plan, issue
+}
+
+func startApprovalLifecycleApply(ctx context.Context, stores *store.Store, issue *store.IssueMessage, ready chan<- struct{}) <-chan approvalLifecycleApplyOutcome {
+	evaluator := &ApprovalEvaluator{workflow: NewWorkflow(stores)}
+	evaluator.evaluateApproval = func(_ context.Context, issue *store.IssueMessage, _ *store.ProjectMessage, _ *storepb.WorkspaceApprovalSetting) error {
+		issue.Payload.Approval = &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: 2,
+		}
+		return nil
+	}
+	evaluator.beforeCommit = func() { close(ready) }
+	result := make(chan approvalLifecycleApplyOutcome, 1)
+	go func() {
+		applied, err := evaluator.ApplyApprovalTemplate(ctx, ApplyApprovalTemplateInput{
+			Workspace: "default",
+			ProjectID: issue.ProjectID,
+			IssueUID:  issue.UID,
+		})
+		result <- approvalLifecycleApplyOutcome{result: applied, err: err}
+	}()
+	return result
+}
+
+func lockApprovalLifecyclePlanCheckRun(ctx context.Context, t *testing.T, db *sql.DB, plan *store.PlanMessage) (*sql.Tx, int) {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	var backendPID int
+	var planCheckRunUID int64
+	require.NoError(t, tx.QueryRowContext(ctx, `
+		SELECT pg_backend_pid(), id
+		FROM plan_check_run
+		WHERE project = $1
+		  AND plan_id = $2
+		FOR UPDATE
+	`, plan.ProjectID, plan.UID).Scan(&backendPID, &planCheckRunUID))
+	require.NotZero(t, planCheckRunUID)
+	return tx, backendPID
+}
+
+func assertApprovalLifecycleRejected(t *testing.T, outcome approvalLifecycleApplyOutcome) {
+	t.Helper()
+	require.Nil(t, outcome.result)
+	var workflowErr *Error
+	require.Error(t, outcome.err)
+	require.True(t, errors.As(outcome.err, &workflowErr))
+	require.Equal(t, ErrorNotFound, workflowErr.Code)
+	require.NotContains(t, strings.ToLower(outcome.err.Error()), "foreign key")
+	require.NotContains(t, outcome.err.Error(), "23503")
+	require.NotContains(t, outcome.err.Error(), "40P01")
+}
+
+func assertApprovalLifecyclePurged(ctx context.Context, t *testing.T, stores *store.Store, plan *store.PlanMessage, issue *store.IssueMessage) {
+	t.Helper()
+	projectID := "project-a"
+	project, err := stores.GetProject(ctx, &store.FindProjectMessage{
+		Workspace:  "default",
+		ResourceID: &projectID,
+	})
+	require.NoError(t, err)
+	require.Nil(t, project)
+
+	gotIssue, err := stores.GetIssue(ctx, &store.FindIssueMessage{
+		Workspace:  "default",
+		ProjectIDs: []string{projectID},
+		UID:        &issue.UID,
+	})
+	require.NoError(t, err)
+	require.Nil(t, gotIssue)
+
+	gotPlan, err := stores.GetPlan(ctx, &store.FindPlanMessage{
+		Workspace: "default",
+		ProjectID: projectID,
+		UID:       &plan.UID,
+	})
+	require.NoError(t, err)
+	require.Nil(t, gotPlan)
+
+	planCheckRun, err := stores.GetPlanCheckRun(ctx, projectID, plan.UID)
+	require.NoError(t, err)
+	require.Nil(t, planCheckRun)
+}

--- a/backend/component/review/approval_lock_order_test.go
+++ b/backend/component/review/approval_lock_order_test.go
@@ -1,0 +1,239 @@
+package review
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+type approvalLockOrderApplyOutcome struct {
+	result *ApplyApprovalTemplateResult
+	err    error
+}
+
+type approvalLockOrderRefreshOutcome struct {
+	created bool
+	err     error
+}
+
+// TestApplyApprovalTemplateAndCreatePlanCheckRunDoNotDeadlock proves both
+// acquisition directions for the shared Plan review advisory lock. Approval
+// takes the advisory lock before locking the Issue and Plan Check Run and reads
+// the Plan without a row lock. Refresh takes the advisory lock before locking
+// the Plan Check Run and Plan. Each first transaction is deliberately blocked
+// after acquiring the advisory lock so the test can prove the competitor waits
+// at the common coordination point.
+func TestApplyApprovalTemplateAndCreatePlanCheckRunDoNotDeadlock(t *testing.T) {
+	t.Run("approval-first", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		stores := setupWorkflowStore(ctx, t)
+		plan, issue, initialGeneration := newApprovalLockOrderFixture(ctx, t, stores, 0)
+
+		blockerTx, blockerPID := lockApprovalIssueForTest(ctx, t, stores.GetDB(), issue)
+		defer blockerTx.Rollback()
+
+		applyReady := make(chan struct{})
+		applyResult := startApprovalLockOrderApply(ctx, stores, issue, applyReady)
+		<-applyReady
+		applyPID := waitForApprovalLockOrderBlock(ctx, t, stores.GetDB(), blockerPID,
+			"approval should acquire the advisory lock, then wait for the Issue row")
+
+		refreshResult := startApprovalLockOrderRefresh(ctx, stores, plan)
+		waitForApprovalLockOrderBlock(ctx, t, stores.GetDB(), applyPID,
+			"Plan check refresh should wait for approval's advisory lock")
+
+		require.NoError(t, blockerTx.Commit())
+		apply := <-applyResult
+		require.NoError(t, apply.err)
+		require.NotNil(t, apply.result)
+		require.True(t, apply.result.Applied)
+		refresh := <-refreshResult
+		require.NoError(t, refresh.err)
+		require.True(t, refresh.created)
+		assertApprovalLockOrderTerminalState(ctx, t, stores, plan, issue, initialGeneration, true)
+	})
+
+	t.Run("refresh-first", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		stores := setupWorkflowStore(ctx, t)
+		plan, issue, initialGeneration := newApprovalLockOrderFixture(ctx, t, stores, 0)
+
+		blockerTx, blockerPID := lockPlanCheckRunForTest(ctx, t, stores.GetDB(), plan)
+		defer blockerTx.Rollback()
+
+		refreshResult := startApprovalLockOrderRefresh(ctx, stores, plan)
+		refreshPID := waitForApprovalLockOrderBlock(ctx, t, stores.GetDB(), blockerPID,
+			"Plan check refresh should acquire the advisory lock, then wait for the Plan Check Run row")
+
+		applyReady := make(chan struct{})
+		applyResult := startApprovalLockOrderApply(ctx, stores, issue, applyReady)
+		<-applyReady
+		waitForApprovalLockOrderBlock(ctx, t, stores.GetDB(), refreshPID,
+			"approval should wait for Plan check refresh's advisory lock")
+
+		require.NoError(t, blockerTx.Commit())
+		refresh := <-refreshResult
+		require.NoError(t, refresh.err)
+		require.True(t, refresh.created)
+		apply := <-applyResult
+		require.Nil(t, apply.result)
+		var workflowErr *Error
+		require.ErrorAs(t, apply.err, &workflowErr)
+		require.Equal(t, ErrorConflict, workflowErr.Code)
+		assertApprovalLockOrderTerminalState(ctx, t, stores, plan, issue, initialGeneration, false)
+	})
+}
+
+func newApprovalLockOrderFixture(ctx context.Context, t *testing.T, stores *store.Store, sequence int) (*store.PlanMessage, *store.IssueMessage, int64) {
+	t.Helper()
+	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      fmt.Sprintf("approval lock order %d", sequence),
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	issue, err := stores.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        fmt.Sprintf("approval lock order %d", sequence),
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		PlanUID:      &plan.UID,
+		Payload: &storepb.Issue{Approval: &storepb.IssuePayloadApproval{
+			ApprovalInputVersion: 2,
+		}},
+	})
+	require.NoError(t, err)
+	created, err := stores.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+	planCheckRun, err := stores.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.NoError(t, stores.UpdatePlanCheckRun(ctx, "project-a", store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: 2,
+	}, planCheckRun.UID))
+	planCheckRun, err = stores.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	return plan, issue, planCheckRun.Generation
+}
+
+func newApprovalLockOrderEvaluator(stores *store.Store) *ApprovalEvaluator {
+	evaluator := &ApprovalEvaluator{workflow: NewWorkflow(stores)}
+	evaluator.evaluateApproval = func(_ context.Context, issue *store.IssueMessage, _ *store.ProjectMessage, _ *storepb.WorkspaceApprovalSetting) error {
+		issue.Payload.Approval = &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: 2,
+		}
+		return nil
+	}
+	return evaluator
+}
+
+func startApprovalLockOrderApply(ctx context.Context, stores *store.Store, issue *store.IssueMessage, ready chan<- struct{}) <-chan approvalLockOrderApplyOutcome {
+	evaluator := newApprovalLockOrderEvaluator(stores)
+	evaluator.beforeCommit = func() { close(ready) }
+	result := make(chan approvalLockOrderApplyOutcome, 1)
+	go func() {
+		applied, err := evaluator.ApplyApprovalTemplate(ctx, ApplyApprovalTemplateInput{
+			Workspace: "default",
+			ProjectID: issue.ProjectID,
+			IssueUID:  issue.UID,
+		})
+		result <- approvalLockOrderApplyOutcome{result: applied, err: err}
+	}()
+	return result
+}
+
+func startApprovalLockOrderRefresh(ctx context.Context, stores *store.Store, plan *store.PlanMessage) <-chan approvalLockOrderRefreshOutcome {
+	result := make(chan approvalLockOrderRefreshOutcome, 1)
+	go func() {
+		created, err := stores.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+			ProjectID: plan.ProjectID,
+			PlanUID:   plan.UID,
+			Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+		})
+		result <- approvalLockOrderRefreshOutcome{created: created, err: err}
+	}()
+	return result
+}
+
+func lockApprovalIssueForTest(ctx context.Context, t *testing.T, db *sql.DB, issue *store.IssueMessage) (*sql.Tx, int) {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	var backendPID int
+	var issueUID int64
+	require.NoError(t, tx.QueryRowContext(ctx, `
+		SELECT pg_backend_pid(), id
+		FROM issue
+		WHERE project = $1 AND id = $2
+		FOR UPDATE
+	`, issue.ProjectID, issue.UID).Scan(&backendPID, &issueUID))
+	require.Equal(t, issue.UID, issueUID)
+	return tx, backendPID
+}
+
+func lockPlanCheckRunForTest(ctx context.Context, t *testing.T, db *sql.DB, plan *store.PlanMessage) (*sql.Tx, int) {
+	t.Helper()
+	tx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	var backendPID int
+	var planCheckRunUID int64
+	require.NoError(t, tx.QueryRowContext(ctx, `
+		SELECT pg_backend_pid(), id
+		FROM plan_check_run
+		WHERE project = $1 AND plan_id = $2
+		FOR UPDATE
+	`, plan.ProjectID, plan.UID).Scan(&backendPID, &planCheckRunUID))
+	require.NotZero(t, planCheckRunUID)
+	return tx, backendPID
+}
+
+func waitForApprovalLockOrderBlock(ctx context.Context, t *testing.T, db *sql.DB, blockerPID int, message string) int {
+	t.Helper()
+	var blockedPID int
+	require.Eventually(t, func() bool {
+		return db.QueryRowContext(ctx, `
+			SELECT COALESCE((
+				SELECT pid
+				FROM pg_stat_activity
+				WHERE $1 = ANY(pg_blocking_pids(pid))
+				ORDER BY pid
+				LIMIT 1
+			), 0)
+		`, blockerPID).Scan(&blockedPID) == nil && blockedPID != 0
+	}, 10*time.Second, 10*time.Millisecond, message)
+	return blockedPID
+}
+
+func assertApprovalLockOrderTerminalState(ctx context.Context, t *testing.T, stores *store.Store, plan *store.PlanMessage, issue *store.IssueMessage, initialGeneration int64, approvalApplied bool) {
+	t.Helper()
+	gotIssue, err := stores.GetIssue(ctx, &store.FindIssueMessage{
+		Workspace:  "default",
+		ProjectIDs: []string{issue.ProjectID},
+		UID:        &issue.UID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, gotIssue)
+	require.Equal(t, approvalApplied, gotIssue.Payload.GetApproval().GetApprovalFindingDone())
+	require.EqualValues(t, 2, gotIssue.Payload.GetApproval().GetApprovalInputVersion())
+
+	planCheckRun, err := stores.GetPlanCheckRun(ctx, plan.ProjectID, plan.UID)
+	require.NoError(t, err)
+	require.NotNil(t, planCheckRun)
+	require.Equal(t, store.PlanCheckRunStatusAvailable, planCheckRun.Status)
+	require.EqualValues(t, 2, planCheckRun.Result.GetApprovalInputVersion())
+	require.NotEqual(t, initialGeneration, planCheckRun.Generation)
+}

--- a/backend/component/review/plan.go
+++ b/backend/component/review/plan.go
@@ -3,7 +3,6 @@ package review
 import (
 	"context"
 	"database/sql"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -74,8 +73,7 @@ func (w *Workflow) UpdatePlan(ctx context.Context, input UpdatePlanInput) (*Upda
 	}
 	defer tx.Rollback()
 
-	key := input.ProjectID + "/" + strconv.FormatInt(input.PlanUID, 10)
-	if err := store.AcquireAdvisoryXactLockWithStringKey(ctx, tx, store.AdvisoryLockKeyPlanIssueRollout, key); err != nil {
+	if err := store.AcquirePlanIssueRolloutAdvisoryLock(ctx, tx, input.ProjectID, input.PlanUID); err != nil {
 		return nil, workflowWrap(ErrorInternal, err, "failed to acquire Plan review lock")
 	}
 	issue, err := lockIssueByPlan(ctx, tx, input.ProjectID, input.PlanUID)

--- a/backend/component/review/rollout.go
+++ b/backend/component/review/rollout.go
@@ -2,7 +2,6 @@ package review
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -99,8 +98,7 @@ func (w *Workflow) CreateRollout(ctx context.Context, input CreateRolloutInput) 
 		return nil, workflowWrap(ErrorInternal, err, "failed to begin rollout transaction")
 	}
 	defer tx.Rollback()
-	key := input.ProjectID + "/" + strconv.FormatInt(input.PlanUID, 10)
-	if err := store.AcquireAdvisoryXactLockWithStringKey(ctx, tx, store.AdvisoryLockKeyPlanIssueRollout, key); err != nil {
+	if err := store.AcquirePlanIssueRolloutAdvisoryLock(ctx, tx, input.ProjectID, input.PlanUID); err != nil {
 		return nil, workflowWrap(ErrorInternal, err, "failed to acquire Plan review lock")
 	}
 	lockedIssue, err := lockIssueByPlan(ctx, tx, input.ProjectID, input.PlanUID)

--- a/backend/component/review/submission.go
+++ b/backend/component/review/submission.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -58,8 +57,7 @@ func (w *Workflow) CreateDraftIssue(ctx context.Context, input CreateDraftIssueI
 		return nil, workflowWrap(ErrorInternal, err, "failed to begin draft creation transaction")
 	}
 	defer tx.Rollback()
-	key := issue.ProjectID + "/" + strconv.FormatInt(*issue.PlanUID, 10)
-	if err := store.AcquireAdvisoryXactLockWithStringKey(ctx, tx, store.AdvisoryLockKeyPlanIssueRollout, key); err != nil {
+	if err := store.AcquirePlanIssueRolloutAdvisoryLock(ctx, tx, issue.ProjectID, *issue.PlanUID); err != nil {
 		return nil, workflowWrap(ErrorInternal, err, "failed to acquire Plan review lock")
 	}
 	existing, err := lockIssueByPlan(ctx, tx, issue.ProjectID, *issue.PlanUID)
@@ -184,8 +182,7 @@ func (w *Workflow) SubmitIssue(ctx context.Context, input SubmitIssueInput) (*Su
 	}
 	defer tx.Rollback()
 
-	key := input.ProjectID + "/" + strconv.FormatInt(*observedIssue.PlanUID, 10)
-	if err := store.AcquireAdvisoryXactLockWithStringKey(ctx, tx, store.AdvisoryLockKeyPlanIssueRollout, key); err != nil {
+	if err := store.AcquirePlanIssueRolloutAdvisoryLock(ctx, tx, input.ProjectID, *observedIssue.PlanUID); err != nil {
 		return nil, workflowWrap(ErrorInternal, err, "failed to acquire Plan review lock")
 	}
 	issue, err := lockIssue(ctx, tx, input.ProjectID, input.IssueUID)

--- a/backend/component/review/workflow.go
+++ b/backend/component/review/workflow.go
@@ -465,14 +465,29 @@ func lockIssuePlan(ctx context.Context, tx *sql.Tx, issue *store.IssueMessage) (
 	if issue.Type != storepb.Issue_DATABASE_CHANGE || issue.PlanUID == nil {
 		return nil, nil
 	}
-	plan := &store.PlanMessage{Config: &storepb.PlanConfig{}}
-	var config []byte
-	err := tx.QueryRowContext(ctx, `
+	return scanIssuePlan(tx.QueryRowContext(ctx, `
 		SELECT id, creator, created_at, updated_at, project, name, description, config, deleted
 		FROM plan
 		WHERE project = $1
 		  AND id = $2
-		FOR UPDATE`, issue.ProjectID, *issue.PlanUID).Scan(
+		FOR UPDATE`, issue.ProjectID, *issue.PlanUID), "failed to lock plan")
+}
+
+func getIssuePlan(ctx context.Context, tx *sql.Tx, issue *store.IssueMessage) (*store.PlanMessage, error) {
+	if issue.Type != storepb.Issue_DATABASE_CHANGE || issue.PlanUID == nil {
+		return nil, nil
+	}
+	return scanIssuePlan(tx.QueryRowContext(ctx, `
+		SELECT id, creator, created_at, updated_at, project, name, description, config, deleted
+		FROM plan
+		WHERE project = $1
+		  AND id = $2`, issue.ProjectID, *issue.PlanUID), "failed to get plan")
+}
+
+func scanIssuePlan(row *sql.Row, queryErrorMessage string) (*store.PlanMessage, error) {
+	plan := &store.PlanMessage{Config: &storepb.PlanConfig{}}
+	var config []byte
+	err := row.Scan(
 		&plan.UID,
 		&plan.Creator,
 		&plan.CreatedAt,
@@ -487,7 +502,7 @@ func lockIssuePlan(ctx context.Context, tx *sql.Tx, issue *store.IssueMessage) (
 		return nil, workflowError(ErrorNotFound, "plan not found")
 	}
 	if err != nil {
-		return nil, workflowWrap(ErrorInternal, err, "failed to lock plan")
+		return nil, workflowWrap(ErrorInternal, err, queryErrorMessage)
 	}
 	if err := common.ProtojsonUnmarshaler.Unmarshal(config, plan.Config); err != nil {
 		return nil, workflowWrap(ErrorInternal, err, "failed to unmarshal plan config")

--- a/backend/component/review/workflow_test.go
+++ b/backend/component/review/workflow_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -671,8 +672,17 @@ func TestLabelResetMakesPendingApprovalActionStale(t *testing.T) {
 			ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{},
 		},
 	}}
-	_, err = stores.UpdatePlan(ctx, &store.UpdatePlanMessage{UID: plan.UID, ProjectID: plan.ProjectID, Config: config})
+	configPayload, err := protojson.Marshal(config)
 	require.NoError(t, err)
+	result, err := stores.GetDB().ExecContext(ctx, `
+		UPDATE plan
+		SET config = $1
+		WHERE project = $2 AND id = $3
+	`, configPayload, plan.ProjectID, plan.UID)
+	require.NoError(t, err)
+	rowsAffected, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rowsAffected)
 
 	workflow := NewWorkflow(stores)
 	proposalReady := make(chan struct{})

--- a/backend/store/advisory_lock.go
+++ b/backend/store/advisory_lock.go
@@ -28,7 +28,9 @@ const (
 	AdvisoryLockKeyPlanIssueRollout AdvisoryLockKey = 1005
 )
 
-func acquirePlanIssueRolloutAdvisoryLock(ctx context.Context, tx *sql.Tx, projectID string, planUID int64) error {
+// AcquirePlanIssueRolloutAdvisoryLock serializes coordinated Plan, linked Issue,
+// Rollout, and Plan Check Run transactions for one Plan.
+func AcquirePlanIssueRolloutAdvisoryLock(ctx context.Context, tx *sql.Tx, projectID string, planUID int64) error {
 	key := projectID + "/" + strconv.FormatInt(planUID, 10)
 	return AcquireAdvisoryXactLockWithStringKey(ctx, tx, AdvisoryLockKeyPlanIssueRollout, key)
 }

--- a/backend/store/issue.go
+++ b/backend/store/issue.go
@@ -171,7 +171,7 @@ func (s *Store) CreateIssue(ctx context.Context, create *IssueMessage) (*IssueMe
 	defer tx.Rollback()
 
 	if create.PlanUID != nil {
-		if err := acquirePlanIssueRolloutAdvisoryLock(ctx, tx, create.ProjectID, *create.PlanUID); err != nil {
+		if err := AcquirePlanIssueRolloutAdvisoryLock(ctx, tx, create.ProjectID, *create.PlanUID); err != nil {
 			return nil, errors.Wrap(err, "failed to acquire plan issue-rollout lock")
 		}
 

--- a/backend/store/plan.go
+++ b/backend/store/plan.go
@@ -54,20 +54,6 @@ type FindPlanMessage struct {
 	FilterQ *qb.Query
 }
 
-// UpdatePlanMessage is the message to update a plan.
-type UpdatePlanMessage struct {
-	UID       int64
-	ProjectID string
-
-	Name        *string
-	Description *string
-	// Config replaces the entire plan config.
-	// Callers should clone the existing config and modify only the fields they want to change.
-	// Example: config := proto.CloneOf(plan.Config); config.HasRollout = true; patch.Config = config
-	Config  *storepb.PlanConfig
-	Deleted *bool
-}
-
 // CreatePlan creates a new plan.
 func (s *Store) CreatePlan(ctx context.Context, plan *PlanMessage, creator string) (*PlanMessage, error) {
 	config, err := protojson.Marshal(plan.Config)
@@ -244,62 +230,6 @@ func (s *Store) ListPlans(ctx context.Context, find *FindPlanMessage) ([]*PlanMe
 	}
 
 	return plans, nil
-}
-
-// UpdatePlan updates an existing plan and returns the updated plan.
-func (s *Store) UpdatePlan(ctx context.Context, patch *UpdatePlanMessage) (*PlanMessage, error) {
-	set := qb.Q().Comma("updated_at = ?", time.Now())
-
-	if v := patch.Name; v != nil {
-		set.Comma("name = ?", *v)
-	}
-	if v := patch.Description; v != nil {
-		set.Comma("description = ?", *v)
-	}
-	if v := patch.Deleted; v != nil {
-		set.Comma("deleted = ?", *v)
-	}
-	if v := patch.Config; v != nil {
-		config, err := protojson.Marshal(v)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to marshal plan config")
-		}
-		set.Comma("config = ?", config)
-	}
-
-	where := qb.Q().Space("id = ? AND project = ?", patch.UID, patch.ProjectID)
-
-	q := qb.Q().Space(`UPDATE plan SET ? WHERE ?
-		RETURNING id, creator, created_at, updated_at, project, name, description, config, deleted`,
-		set, where)
-
-	query, finalArgs, err := q.ToSQL()
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to build sql")
-	}
-
-	plan := PlanMessage{
-		Config: &storepb.PlanConfig{},
-	}
-	var config []byte
-	if err := s.GetDB().QueryRowContext(ctx, query, finalArgs...).Scan(
-		&plan.UID,
-		&plan.Creator,
-		&plan.CreatedAt,
-		&plan.UpdatedAt,
-		&plan.ProjectID,
-		&plan.Name,
-		&plan.Description,
-		&config,
-		&plan.Deleted,
-	); err != nil {
-		return nil, errors.Wrapf(err, "failed to update plan")
-	}
-	if err := common.ProtojsonUnmarshaler.Unmarshal(config, plan.Config); err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal plan config")
-	}
-
-	return &plan, nil
 }
 
 // GetListPlanFilter parses a CEL filter expression into a query builder query for listing plans.

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -70,7 +70,7 @@ func (s *Store) CreatePlanCheckRun(ctx context.Context, create *PlanCheckRunMess
 		return false, errors.Wrapf(err, "failed to begin tx")
 	}
 	defer tx.Rollback()
-	if err := acquirePlanIssueRolloutAdvisoryLock(ctx, tx, create.ProjectID, create.PlanUID); err != nil {
+	if err := AcquirePlanIssueRolloutAdvisoryLock(ctx, tx, create.ProjectID, create.PlanUID); err != nil {
 		return false, errors.Wrap(err, "failed to acquire Plan review lock for Plan check run")
 	}
 	var lockedPlanCheckRunUID int64

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -66,12 +66,7 @@ func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow(
 	require.Len(t, claimed, 1)
 	require.EqualValues(t, 1, claimed[0].ApprovalInputVersion)
 
-	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID:       plan.UID,
-		ProjectID: plan.ProjectID,
-		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
-	})
-	require.NoError(t, err)
+	setPlanApprovalInputVersionTwo(ctx, t, s, plan.ProjectID, plan.UID)
 
 	created, err = s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
 		ProjectID: "project-a",
@@ -126,12 +121,7 @@ func TestUpdatePlanCheckRunIfApprovalInputVersionAllowsClaimedRowAfterPlanVersio
 	require.Len(t, claimed, 1)
 	require.EqualValues(t, 1, claimed[0].ApprovalInputVersion)
 
-	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID:       plan.UID,
-		ProjectID: plan.ProjectID,
-		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
-	})
-	require.NoError(t, err)
+	setPlanApprovalInputVersionTwo(ctx, t, s, plan.ProjectID, plan.UID)
 
 	updated, err := s.UpdatePlanCheckRunIfApprovalInputVersion(ctx, "project-a", store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
 		ApprovalInputVersion: 1,
@@ -380,12 +370,7 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionRefreshesTerminalStaleChe
 	require.NoError(t, err)
 	require.True(t, updated)
 
-	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID:       plan.UID,
-		ProjectID: plan.ProjectID,
-		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
-	})
-	require.NoError(t, err)
+	setPlanApprovalInputVersionTwo(ctx, t, s, plan.ProjectID, plan.UID)
 
 	refreshed, err := s.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, "project-a", plan.UID, 2)
 	require.NoError(t, err)
@@ -433,12 +418,7 @@ func TestRefreshPlanCheckRunIfStaleApprovalInputVersionSkipsSameVersionRow(t *te
 	require.NoError(t, err)
 	require.True(t, updated)
 
-	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID:       plan.UID,
-		ProjectID: plan.ProjectID,
-		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
-	})
-	require.NoError(t, err)
+	setPlanApprovalInputVersionTwo(ctx, t, s, plan.ProjectID, plan.UID)
 
 	refreshed, err := s.RefreshPlanCheckRunIfStaleApprovalInputVersion(ctx, "project-a", plan.UID, 1)
 	require.NoError(t, err)
@@ -521,12 +501,7 @@ func TestCancelPlanCheckRunIfApprovalInputVersionSkipsRefreshedRow(t *testing.T)
 	require.NoError(t, err)
 	require.Len(t, claimed, 1)
 
-	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID:       plan.UID,
-		ProjectID: plan.ProjectID,
-		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
-	})
-	require.NoError(t, err)
+	setPlanApprovalInputVersionTwo(ctx, t, s, plan.ProjectID, plan.UID)
 
 	created, err = s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
 		ProjectID: "project-a",
@@ -580,12 +555,7 @@ func TestCancelPlanCheckRunIfApprovalInputVersionAllowsObservedStaleRow(t *testi
 	require.NoError(t, err)
 	require.Len(t, claimed, 1)
 
-	_, err = s.UpdatePlan(ctx, &store.UpdatePlanMessage{
-		UID:       plan.UID,
-		ProjectID: plan.ProjectID,
-		Config:    &storepb.PlanConfig{ApprovalInputVersion: 2},
-	})
-	require.NoError(t, err)
+	setPlanApprovalInputVersionTwo(ctx, t, s, plan.ProjectID, plan.UID)
 
 	canceled, err := s.CancelPlanCheckRunIfApprovalInputVersion(ctx, "project-a", claimed[0].UID, 1)
 	require.NoError(t, err)
@@ -656,4 +626,18 @@ func setupPlanCheckRunVersionStore(ctx context.Context, t *testing.T) *store.Sto
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	return s
+}
+
+func setPlanApprovalInputVersionTwo(ctx context.Context, t *testing.T, s *store.Store, projectID string, planUID int64) {
+	t.Helper()
+
+	result, err := s.GetDB().ExecContext(ctx, `
+		UPDATE plan
+		SET config = jsonb_set(config, '{approvalInputVersion}', to_jsonb($1::bigint))
+		WHERE project = $2 AND id = $3
+	`, int64(2), projectID, planUID)
+	require.NoError(t, err)
+	rowsAffected, err := result.RowsAffected()
+	require.NoError(t, err)
+	require.EqualValues(t, 1, rowsAffected)
 }


### PR DESCRIPTION
## Summary

- Acquire the shared Plan/Issue/Rollout advisory lock before approval commits take row locks, avoiding the approval-versus-plan-check-refresh lock cycle.
- Read the linked Plan without `FOR UPDATE`; approval still locks the Issue and existing Plan Check Run needed for its optimistic validation.
- Treat the Issue row as the project-purge lifecycle fence: approval may complete for a soft-deleted Project, but cannot write after purge has deleted its Issue.
- Preserve terminal optimistic conflicts without automatic retry, centralize the Plan review advisory-lock helper, and remove the unused Store.UpdatePlan escape hatch.

## Tests

- `go test -v -count=1 ./backend/tests/ -run "^(TestClaim|TestCollision)" -timeout 5m`
- Focused review, store, and API tests
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

The new deterministic real-PostgreSQL tests cover approval/check-refresh acquisition in both directions and approval/project-purge acquisition in both directions, including terminal outcomes and no foreign-key failure.