### PR TITLE
fix(store): prevent maintenance transaction deadlocks

### DIFF
--- a/backend/store/README.md
+++ b/backend/store/README.md
@@ -11,7 +11,11 @@ PostgreSQL holds row locks until a transaction ends. Transactions that acquire t
    - `issue_comment -> issue -> plan -> project`
    - `plan_webhook_delivery -> plan -> project`
    - `plan_check_run -> plan -> project`
-   - `task_run_log -> task_run -> task -> plan -> project`
+   - `task_run_log -> task_run -> task -> plan -> project -> instance`
+   - `worksheet_organizer -> worksheet -> project`
+   - `changelog -> sync_history -> db -> instance`
+   - `revision -> db -> instance`
+   - `db_schema -> db -> instance`
 3. Identify project-scoped rows with every scope column plus either the remaining primary-key columns or every remaining column of a declared non-partial unique key. Verify alternate keys in `LATEST.sql`. Lock batches in full primary-key order; project-scoped `(project, id)` batches therefore use that order, not `id` alone.
 4. Treat locks acquired by `UPDATE`, `DELETE`, foreign-key checks, and `INSERT ... ON CONFLICT DO UPDATE` as part of the order. An upsert that can update an existing row is not a new-row-only insert.
 5. `nextProjectID` locks `project` and requires it to be active before allocating an ID. Call it after locking any existing descendants, and do not lock an existing descendant afterward. Creation is rejected when the project is missing or deleted.
@@ -27,18 +31,17 @@ lifecycle policy: require an active project for new resources, or require only a
 existing project when deleted-project continuation is intentional. Serialize and
 validate that policy against project deletion before writing the managed data.
 
-Transactions spanning project-owned sibling branches follow the order used by `DeleteProject`:
+Transactions spanning project- or instance-owned sibling branches follow this canonical order:
 
 ```text
-query_history -> policy -> worksheet (project reassignment)
+query_history -> policy -> worksheet_organizer -> worksheet
 -> issue_comment -> issue -> plan_webhook_delivery -> plan_check_run
 -> task_run_log -> task_run -> task -> plan -> access_grant -> release
--> db_group -> db (project reassignment) -> project_webhook
--> worksheet_organizer -> worksheet (creator cleanup) -> revision
--> service_account -> workload_identity -> project
+-> db_group -> changelog -> sync_history -> revision -> db_schema -> db
+-> project_webhook -> service_account -> workload_identity -> project -> instance
 ```
 
-Update this list and `DeleteProject` together. A transaction that needs another sibling branch must establish its position here before implementation. Keep transactions short and acquire every required lock before performing work that depends on the protected state.
+Update this list, `DeleteProject`, and `DeleteInstance` together. A transaction that needs another sibling branch must establish its position here before implementation. When one table is touched by multiple predicates, keep those mutations contiguous at that table's position. Keep transactions short and preserve this order whether locks are acquired explicitly or by `UPDATE` and `DELETE` statements.
 
 Examples:
 

--- a/backend/store/instance.go
+++ b/backend/store/instance.go
@@ -585,6 +585,20 @@ func (s *Store) DeleteInstance(ctx context.Context, workspace string, resourceID
 		return errors.Wrapf(err, "failed to delete query_history for instance %s", resourceID)
 	}
 
+	// Update worksheets to nullify instance and db_name references
+	q = qb.Q().Space(`
+		UPDATE worksheet
+		SET instance = NULL, db_name = NULL
+		WHERE instance = ?
+	`, resourceID)
+	query, args, err = q.ToSQL()
+	if err != nil {
+		return errors.Wrapf(err, "failed to build sql")
+	}
+	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+		return errors.Wrapf(err, "failed to update worksheets for instance %s", resourceID)
+	}
+
 	// Delete task_run_log entries for tasks associated with this instance
 	q = qb.Q().Space(`
 		DELETE FROM task_run_log trl
@@ -665,20 +679,6 @@ func (s *Store) DeleteInstance(ctx context.Context, workspace string, resourceID
 	}
 	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 		return errors.Wrapf(err, "failed to delete revisions for instance %s", resourceID)
-	}
-
-	// Update worksheets to nullify instance and db_name references
-	q = qb.Q().Space(`
-		UPDATE worksheet
-		SET instance = NULL, db_name = NULL
-		WHERE instance = ?
-	`, resourceID)
-	query, args, err = q.ToSQL()
-	if err != nil {
-		return errors.Wrapf(err, "failed to build sql")
-	}
-	if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-		return errors.Wrapf(err, "failed to update worksheets for instance %s", resourceID)
 	}
 
 	// Delete db_schema entries associated with databases on this instance

--- a/backend/store/maintenance_lock_order_test.go
+++ b/backend/store/maintenance_lock_order_test.go
@@ -1,0 +1,332 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const maintenanceLockWait = 10 * time.Second
+
+type maintenanceLockBarrier struct {
+	ctx  context.Context
+	conn *sql.Conn
+	id   int
+}
+
+func newMaintenanceLockBarrier(ctx context.Context, t *testing.T, db *sql.DB, id int) *maintenanceLockBarrier {
+	t.Helper()
+	conn, err := db.Conn(ctx)
+	require.NoError(t, err)
+	_, err = conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", id)
+	require.NoError(t, err)
+
+	barrier := &maintenanceLockBarrier{ctx: ctx, conn: conn, id: id}
+	t.Cleanup(func() {
+		_, _ = conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", id)
+		require.NoError(t, conn.Close())
+	})
+	return barrier
+}
+
+func (b *maintenanceLockBarrier) release(t *testing.T) {
+	t.Helper()
+	_, err := b.conn.ExecContext(b.ctx, "SELECT pg_advisory_unlock($1)", b.id)
+	require.NoError(t, err)
+}
+
+func installMaintenanceLockBarrier(t *testing.T, db *sql.DB, id int, trigger string) {
+	t.Helper()
+	_, err := db.ExecContext(context.Background(), fmt.Sprintf(`
+		CREATE FUNCTION maintenance_lock_barrier_%[1]d() RETURNS trigger AS $$
+		BEGIN
+			PERFORM pg_advisory_xact_lock(%[1]d);
+			RETURN NULL;
+		END;
+		$$ LANGUAGE plpgsql;
+		CREATE TRIGGER maintenance_lock_barrier_%[1]d
+		%[2]s EXECUTE FUNCTION maintenance_lock_barrier_%[1]d();
+	`, id, trigger))
+	require.NoError(t, err)
+}
+
+func waitForMaintenanceBarrier(ctx context.Context, t *testing.T, db *sql.DB, id int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+			)
+		`, id).Scan(&waiting)
+		return err == nil && waiting
+	}, maintenanceLockWait, 10*time.Millisecond, "operation should reach the advisory barrier")
+}
+
+func waitForOperationBehindMaintenanceBarrier(ctx context.Context, t *testing.T, db *sql.DB, id int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		var waiting bool
+		err := db.QueryRowContext(ctx, `
+			WITH barrier_backend AS (
+				SELECT pid
+				FROM pg_locks
+				WHERE locktype = 'advisory'
+					AND objid = $1
+					AND NOT granted
+				LIMIT 1
+			)
+			SELECT EXISTS (
+				SELECT 1
+				FROM pg_stat_activity AS activity, barrier_backend
+				WHERE barrier_backend.pid = ANY(pg_blocking_pids(activity.pid))
+			)
+		`, id).Scan(&waiting)
+		return err == nil && waiting
+	}, maintenanceLockWait, 10*time.Millisecond, "competing operation should wait behind the barrier owner")
+}
+
+func requireMaintenanceResult(t *testing.T, result <-chan error) {
+	t.Helper()
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(maintenanceLockWait):
+		t.Fatal("timed out waiting for maintenance operation")
+	}
+}
+
+func requireProjectInstanceDeletionState(ctx context.Context, t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, table := range []string{"project", "instance", "db", "revision", "service_account"} {
+		var count int
+		require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count))
+		if table == "project" {
+			require.Equal(t, 1, count, "only the default project should remain")
+		} else {
+			require.Zero(t, count, "%s should be removed", table)
+		}
+	}
+
+	var project string
+	var instance, database sql.NullString
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT project, instance, db_name
+		FROM worksheet
+		WHERE resource_id = 'worksheet-a'
+	`).Scan(&project, &instance, &database))
+	require.Equal(t, "default", project)
+	require.False(t, instance.Valid)
+	require.False(t, database.Valid)
+}
+
+func requireProjectUserDeletionState(ctx context.Context, t *testing.T, db *sql.DB) {
+	t.Helper()
+	var projectCount, planCount, queryHistoryCount int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM project").Scan(&projectCount))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM plan").Scan(&planCount))
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM query_history").Scan(&queryHistoryCount))
+	require.Equal(t, 1, projectCount, "only the default project should remain")
+	require.Zero(t, planCount)
+	require.Zero(t, queryHistoryCount)
+
+	var email string
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT email FROM principal WHERE id = 101").Scan(&email))
+	require.Equal(t, "renamed@example.com", email)
+}
+
+func requireUserInstanceDeletionState(ctx context.Context, t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, table := range []string{"instance", "db", "query_history", "task_run", "task"} {
+		var count int
+		require.NoError(t, db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&count))
+		require.Zero(t, count, "%s should be removed", table)
+	}
+
+	var email string
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT email FROM principal WHERE id = 101").Scan(&email))
+	require.Equal(t, "renamed@example.com", email)
+}
+
+func TestDeleteProjectAndDeleteInstanceLockOrder(t *testing.T) {
+	const seedSQL = `
+		INSERT INTO instance (resource_id, workspace, deleted) VALUES ('instance-a', 'default', TRUE);
+		INSERT INTO db (instance, name, project) VALUES ('instance-a', 'db-a', 'project-a');
+		INSERT INTO service_account (name, email, workspace, service_key_hash, project)
+			VALUES ('service account', 'service-account@example.com', 'default', 'unused', 'project-a');
+		INSERT INTO revision (resource_id, instance, db_name, deleter, version)
+			VALUES ('revision-a', 'instance-a', 'db-a', 'service-account@example.com', 'v1');
+		INSERT INTO plan (id, creator, project, name, description)
+			VALUES (101, 'user@example.com', 'project-a', 'Plan A', '');
+		INSERT INTO task (id, project, plan_id, instance, type)
+			VALUES (101, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
+		INSERT INTO worksheet (resource_id, creator, project, instance, db_name, name, statement, visibility)
+			VALUES ('worksheet-a', 'user@example.com', 'project-a', 'instance-a', 'db-a', 'Worksheet A', '', 'PROJECT_READ');
+	`
+
+	t.Run("delete project first", func(t *testing.T) {
+		fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+		const barrierID = 9921
+		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
+		installMaintenanceLockBarrier(t, fixture.db, barrierID,
+			"AFTER UPDATE OF project ON worksheet FOR EACH ROW")
+
+		projectResult := make(chan error, 1)
+		go func() { projectResult <- fixture.store.DeleteProject(fixture.ctx, "default", "project-a") }()
+		waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+
+		instanceResult := make(chan error, 1)
+		go func() { instanceResult <- fixture.store.DeleteInstance(fixture.ctx, "default", "instance-a") }()
+		waitForOperationBehindMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+		barrier.release(t)
+
+		requireMaintenanceResult(t, projectResult)
+		requireMaintenanceResult(t, instanceResult)
+		requireProjectInstanceDeletionState(fixture.ctx, t, fixture.db)
+	})
+
+	t.Run("delete instance first", func(t *testing.T) {
+		fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+		const barrierID = 9922
+		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
+		installMaintenanceLockBarrier(t, fixture.db, barrierID,
+			"AFTER DELETE ON task FOR EACH ROW")
+
+		instanceResult := make(chan error, 1)
+		go func() { instanceResult <- fixture.store.DeleteInstance(fixture.ctx, "default", "instance-a") }()
+		waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+
+		projectResult := make(chan error, 1)
+		go func() { projectResult <- fixture.store.DeleteProject(fixture.ctx, "default", "project-a") }()
+		waitForOperationBehindMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+		barrier.release(t)
+
+		requireMaintenanceResult(t, instanceResult)
+		requireMaintenanceResult(t, projectResult)
+		requireProjectInstanceDeletionState(fixture.ctx, t, fixture.db)
+	})
+}
+
+func TestUpdateUserEmailAndDeleteProjectLockOrder(t *testing.T) {
+	const seedSQL = `
+		INSERT INTO principal (name, email, password_hash) VALUES ('User A', 'user@example.com', 'unused');
+		INSERT INTO plan (id, creator, project, name, description)
+			VALUES (101, 'user@example.com', 'project-a', 'Plan A', '');
+		INSERT INTO query_history (resource_id, creator, project, database, statement, type)
+			VALUES ('query-history-a', 'user@example.com', 'project-a', 'instances/instance-a/databases/db-a', '', 'QUERY');
+	`
+
+	run := func(t *testing.T, first string) {
+		t.Helper()
+		fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+		user, err := fixture.store.GetUserByEmail(fixture.ctx, "user@example.com")
+		require.NoError(t, err)
+		require.NotNil(t, user)
+
+		barrierID := 9923
+		trigger := "AFTER DELETE ON query_history FOR EACH ROW"
+		if first == "user" {
+			barrierID = 9924
+			trigger = "AFTER UPDATE OF creator ON plan FOR EACH ROW"
+		}
+		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
+		installMaintenanceLockBarrier(t, fixture.db, barrierID, trigger)
+
+		updateUser := func() error {
+			_, err := fixture.store.UpdateUserEmail(fixture.ctx, user, "renamed@example.com")
+			return err
+		}
+		deleteProject := func() error { return fixture.store.DeleteProject(fixture.ctx, "default", "project-a") }
+
+		var firstResult, secondResult chan error
+		if first == "project" {
+			firstResult, secondResult = make(chan error, 1), make(chan error, 1)
+			go func() { firstResult <- deleteProject() }()
+			waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+			go func() { secondResult <- updateUser() }()
+		} else {
+			firstResult, secondResult = make(chan error, 1), make(chan error, 1)
+			go func() { firstResult <- updateUser() }()
+			waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+			go func() { secondResult <- deleteProject() }()
+		}
+		waitForOperationBehindMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+		barrier.release(t)
+
+		requireMaintenanceResult(t, firstResult)
+		requireMaintenanceResult(t, secondResult)
+		requireProjectUserDeletionState(fixture.ctx, t, fixture.db)
+	}
+
+	t.Run("delete project first", func(t *testing.T) { run(t, "project") })
+	t.Run("update user first", func(t *testing.T) { run(t, "user") })
+}
+
+func TestUpdateUserEmailAndDeleteInstanceLockOrder(t *testing.T) {
+	const seedSQL = `
+		INSERT INTO principal (name, email, password_hash) VALUES ('User A', 'user@example.com', 'unused');
+		INSERT INTO instance (resource_id, workspace, deleted) VALUES ('instance-a', 'default', TRUE);
+		INSERT INTO db (instance, name, project) VALUES ('instance-a', 'db-a', 'project-a');
+		INSERT INTO plan (id, creator, project, name, description)
+			VALUES (101, 'user@example.com', 'project-a', 'Plan A', '');
+		INSERT INTO task (id, project, plan_id, instance, type)
+			VALUES (101, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
+		INSERT INTO task_run (id, creator, project, task_id, attempt, status)
+			VALUES (101, 'user@example.com', 'project-a', 101, 0, 'DONE');
+		INSERT INTO query_history (resource_id, creator, project, database, statement, type)
+			VALUES ('query-history-a', 'user@example.com', 'project-a', 'instances/instance-a/databases/db-a', '', 'QUERY');
+	`
+
+	run := func(t *testing.T, first string) {
+		t.Helper()
+		fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+		user, err := fixture.store.GetUserByEmail(fixture.ctx, "user@example.com")
+		require.NoError(t, err)
+		require.NotNil(t, user)
+
+		barrierID := 9925
+		trigger := "AFTER DELETE ON query_history FOR EACH ROW"
+		if first == "user" {
+			barrierID = 9926
+			trigger = "AFTER UPDATE OF creator ON task_run FOR EACH ROW"
+		}
+		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
+		installMaintenanceLockBarrier(t, fixture.db, barrierID, trigger)
+
+		updateUser := func() error {
+			_, err := fixture.store.UpdateUserEmail(fixture.ctx, user, "renamed@example.com")
+			return err
+		}
+		deleteInstance := func() error { return fixture.store.DeleteInstance(fixture.ctx, "default", "instance-a") }
+
+		var firstResult, secondResult chan error
+		if first == "instance" {
+			firstResult, secondResult = make(chan error, 1), make(chan error, 1)
+			go func() { firstResult <- deleteInstance() }()
+			waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+			go func() { secondResult <- updateUser() }()
+		} else {
+			firstResult, secondResult = make(chan error, 1), make(chan error, 1)
+			go func() { firstResult <- updateUser() }()
+			waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+			go func() { secondResult <- deleteInstance() }()
+		}
+		waitForOperationBehindMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+		barrier.release(t)
+
+		requireMaintenanceResult(t, firstResult)
+		requireMaintenanceResult(t, secondResult)
+		requireUserInstanceDeletionState(fixture.ctx, t, fixture.db)
+	}
+
+	t.Run("delete instance first", func(t *testing.T) { run(t, "instance") })
+	t.Run("update user first", func(t *testing.T) { run(t, "user") })
+}

--- a/backend/store/principal.go
+++ b/backend/store/principal.go
@@ -505,81 +505,21 @@ func (s *Store) UpdateUserEmail(ctx context.Context, user *UserMessage, newEmail
 		return nil, errors.Wrapf(err, "failed to update principal email")
 	}
 
-	// 1b. Update creator/deleter columns that previously relied on ON UPDATE CASCADE.
-	creatorUpdates := []string{
-		"UPDATE plan SET creator = $1 WHERE creator = $2",
-		"UPDATE task_run SET creator = $1 WHERE creator = $2",
-		"UPDATE issue SET creator = $1 WHERE creator = $2",
-		"UPDATE issue_comment SET creator = $1 WHERE creator = $2",
-		"UPDATE query_history SET creator = $1 WHERE creator = $2",
-		"UPDATE worksheet SET creator = $1 WHERE creator = $2",
-		"UPDATE worksheet_organizer SET principal = $1 WHERE principal = $2",
-		"UPDATE revision SET deleter = $1 WHERE deleter = $2",
-		"UPDATE release SET creator = $1 WHERE creator = $2",
-		"UPDATE access_grant SET creator = $1 WHERE creator = $2",
-	}
-	for _, stmt := range creatorUpdates {
-		if _, err := tx.ExecContext(ctx, stmt, newEmail, user.Email); err != nil {
-			return nil, errors.Wrapf(err, "failed to update creator/deleter references")
-		}
-	}
-
-	// 2. Update RoleGrant in issue payload.
-	// The user in RoleGrant is stored as "users/{email}" within the JSON payload.
-	// We use text replacement for the specific path.
 	oldUserRef := common.FormatUserEmail(user.Email)
 	newUserRef := common.FormatUserEmail(newEmail)
 
-	// 'roleGrant' is the json key for role_grant field in Issue proto.
-	query = qb.Q().Space(`
-		UPDATE issue 
-		SET payload = jsonb_set(payload, '{roleGrant,user}', to_jsonb(?::text)) 
-		WHERE payload->'roleGrant'->>'user' = ?`,
-		newUserRef, oldUserRef)
-	sqlStr, args, err = query.ToSQL()
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to build update role grant sql")
-	}
-	if _, err := tx.ExecContext(ctx, sqlStr, args...); err != nil {
-		return nil, errors.Wrapf(err, "failed to update issue role grant")
+	updateReference := func(stmt string) error {
+		if _, err := tx.ExecContext(ctx, stmt, newEmail, user.Email); err != nil {
+			return errors.Wrapf(err, "failed to update creator/deleter references")
+		}
+		return nil
 	}
 
-	// 2b. Update Approval approvers in Issue payload
-	// The principal in approvers is stored as "users/{email}" within the JSON payload.
-	// We need to update each approver's principal field if it matches the old user reference.
-	approverSQL := `
-		UPDATE issue
-		SET payload = (
-			SELECT jsonb_set(
-				issue.payload,
-				'{approval,approvers}',
-				COALESCE(
-					(
-						SELECT jsonb_agg(
-							CASE
-								WHEN approver->>'principal' = $1 THEN
-									jsonb_set(approver, '{principal}', to_jsonb($2::text))
-								ELSE approver
-							END
-						)
-						FROM jsonb_array_elements(issue.payload->'approval'->'approvers') AS approver
-					),
-					'[]'::jsonb
-				)
-			)
-		)
-		WHERE payload->'approval' ? 'approvers'
-		  AND EXISTS (
-			  SELECT 1
-			  FROM jsonb_array_elements(payload->'approval'->'approvers') AS approver
-			  WHERE approver->>'principal' = $1
-		  )`
-
-	if _, err := tx.ExecContext(ctx, approverSQL, oldUserRef, newUserRef); err != nil {
-		return nil, errors.Wrapf(err, "failed to update issue approval approvers")
+	if err := updateReference("UPDATE query_history SET creator = $1 WHERE creator = $2"); err != nil {
+		return nil, err
 	}
 
-	// 3. Update Policies
+	// 2. Update Policies
 	// Update IAM policies: bindings->members array contains user references
 	// Update MASKING_EXEMPTION policies: exemptions->members field contains user references
 	var invalidatedPolicies []struct {
@@ -741,7 +681,88 @@ func (s *Store) UpdateUserEmail(ctx context.Context, user *UserMessage, newEmail
 	}
 	rows.Close()
 
-	// 4. Update User Groups
+	if err := updateReference("UPDATE worksheet_organizer SET principal = $1 WHERE principal = $2"); err != nil {
+		return nil, err
+	}
+	if err := updateReference("UPDATE worksheet SET creator = $1 WHERE creator = $2"); err != nil {
+		return nil, err
+	}
+	if err := updateReference("UPDATE issue_comment SET creator = $1 WHERE creator = $2"); err != nil {
+		return nil, err
+	}
+	if err := updateReference("UPDATE issue SET creator = $1 WHERE creator = $2"); err != nil {
+		return nil, err
+	}
+
+	// Update RoleGrant in issue payload.
+	// The user in RoleGrant is stored as "users/{email}" within the JSON payload.
+	// We use text replacement for the specific path.
+	// 'roleGrant' is the json key for role_grant field in Issue proto.
+	query = qb.Q().Space(`
+		UPDATE issue
+		SET payload = jsonb_set(payload, '{roleGrant,user}', to_jsonb(?::text))
+		WHERE payload->'roleGrant'->>'user' = ?`,
+		newUserRef, oldUserRef)
+	sqlStr, args, err = query.ToSQL()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to build update role grant sql")
+	}
+	if _, err := tx.ExecContext(ctx, sqlStr, args...); err != nil {
+		return nil, errors.Wrapf(err, "failed to update issue role grant")
+	}
+
+	// Update Approval approvers in Issue payload.
+	// The principal in approvers is stored as "users/{email}" within the JSON payload.
+	// We need to update each approver's principal field if it matches the old user reference.
+	approverSQL := `
+		UPDATE issue
+		SET payload = (
+			SELECT jsonb_set(
+				issue.payload,
+				'{approval,approvers}',
+				COALESCE(
+					(
+						SELECT jsonb_agg(
+							CASE
+								WHEN approver->>'principal' = $1 THEN
+									jsonb_set(approver, '{principal}', to_jsonb($2::text))
+								ELSE approver
+							END
+						)
+						FROM jsonb_array_elements(issue.payload->'approval'->'approvers') AS approver
+					),
+					'[]'::jsonb
+				)
+			)
+		)
+		WHERE payload->'approval' ? 'approvers'
+		  AND EXISTS (
+			  SELECT 1
+			  FROM jsonb_array_elements(payload->'approval'->'approvers') AS approver
+			  WHERE approver->>'principal' = $1
+		  )`
+
+	if _, err := tx.ExecContext(ctx, approverSQL, oldUserRef, newUserRef); err != nil {
+		return nil, errors.Wrapf(err, "failed to update issue approval approvers")
+	}
+
+	if err := updateReference("UPDATE task_run SET creator = $1 WHERE creator = $2"); err != nil {
+		return nil, err
+	}
+	if err := updateReference("UPDATE plan SET creator = $1 WHERE creator = $2"); err != nil {
+		return nil, err
+	}
+	if err := updateReference("UPDATE access_grant SET creator = $1 WHERE creator = $2"); err != nil {
+		return nil, err
+	}
+	if err := updateReference("UPDATE release SET creator = $1 WHERE creator = $2"); err != nil {
+		return nil, err
+	}
+	if err := updateReference("UPDATE revision SET deleter = $1 WHERE deleter = $2"); err != nil {
+		return nil, err
+	}
+
+	// Update User Groups.
 	// Update user_group.payload to replace old user reference with new one in members array.
 	// Members are stored as GroupMember objects with member field in "users/{email}" format.
 	userGroupSQL := `

--- a/backend/store/project.go
+++ b/backend/store/project.go
@@ -370,7 +370,31 @@ func (s *Store) DeleteProject(ctx context.Context, workspace string, resourceID 
 		return errors.Wrapf(err, "failed to delete policies for project %s", resourceID)
 	}
 
-	// Delete worksheets associated with this project
+	// Delete worksheet_organizer entries referencing project principals.
+	q = qb.Q().Space(`DELETE FROM worksheet_organizer
+		WHERE principal IN (SELECT email FROM service_account WHERE project = ? AND workspace = ?)
+		   OR principal IN (SELECT email FROM workload_identity WHERE project = ? AND workspace = ?)`, resourceID, workspace, resourceID, workspace)
+	sql, args, err = q.ToSQL()
+	if err != nil {
+		return errors.Wrap(err, "failed to build worksheet_organizer delete query")
+	}
+	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
+		return errors.Wrapf(err, "failed to delete worksheet_organizer for project %s", resourceID)
+	}
+
+	// Delete worksheets created by project service accounts or workload identities.
+	q = qb.Q().Space(`DELETE FROM worksheet
+		WHERE creator IN (SELECT email FROM service_account WHERE project = ? AND workspace = ?)
+		   OR creator IN (SELECT email FROM workload_identity WHERE project = ? AND workspace = ?)`, resourceID, workspace, resourceID, workspace)
+	sql, args, err = q.ToSQL()
+	if err != nil {
+		return errors.Wrap(err, "failed to build worksheet delete query for principals")
+	}
+	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
+		return errors.Wrapf(err, "failed to delete worksheets for project principals %s", resourceID)
+	}
+
+	// Reassign remaining worksheets associated with this project.
 	q = qb.Q().Space("UPDATE worksheet SET project = ? WHERE project = ?", defaultProjectID, resourceID)
 	sql, args, err = q.ToSQL()
 	if err != nil {
@@ -523,6 +547,18 @@ func (s *Store) DeleteProject(ctx context.Context, workspace string, resourceID 
 		return errors.Wrapf(err, "failed to delete db_groups for project %s", resourceID)
 	}
 
+	// Nullify revision.deleter references.
+	q = qb.Q().Space(`UPDATE revision SET deleter = NULL
+		WHERE deleter IN (SELECT email FROM service_account WHERE project = ? AND workspace = ?)
+		   OR deleter IN (SELECT email FROM workload_identity WHERE project = ? AND workspace = ?)`, resourceID, workspace, resourceID, workspace)
+	sql, args, err = q.ToSQL()
+	if err != nil {
+		return errors.Wrap(err, "failed to build revision update query")
+	}
+	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
+		return errors.Wrapf(err, "failed to nullify revision.deleter for project %s", resourceID)
+	}
+
 	// Move databases to the default project instead of deleting them
 	q = qb.Q().Space("UPDATE db SET project = ? WHERE project = ?", defaultProjectID, resourceID)
 	sql, args, err = q.ToSQL()
@@ -541,44 +577,6 @@ func (s *Store) DeleteProject(ctx context.Context, workspace string, resourceID 
 	}
 	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
 		return errors.Wrapf(err, "failed to delete project_webhook for project %s", resourceID)
-	}
-
-	// Delete resources referencing project service accounts and workload identities.
-
-	// Delete worksheet_organizer entries
-	q = qb.Q().Space(`DELETE FROM worksheet_organizer
-		WHERE principal IN (SELECT email FROM service_account WHERE project = ? AND workspace = ?)
-		   OR principal IN (SELECT email FROM workload_identity WHERE project = ? AND workspace = ?)`, resourceID, workspace, resourceID, workspace)
-	sql, args, err = q.ToSQL()
-	if err != nil {
-		return errors.Wrap(err, "failed to build worksheet_organizer delete query")
-	}
-	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
-		return errors.Wrapf(err, "failed to delete worksheet_organizer for project %s", resourceID)
-	}
-
-	// Delete worksheets created by project service accounts or workload identities
-	q = qb.Q().Space(`DELETE FROM worksheet
-		WHERE creator IN (SELECT email FROM service_account WHERE project = ? AND workspace = ?)
-		   OR creator IN (SELECT email FROM workload_identity WHERE project = ? AND workspace = ?)`, resourceID, workspace, resourceID, workspace)
-	sql, args, err = q.ToSQL()
-	if err != nil {
-		return errors.Wrap(err, "failed to build worksheet delete query for principals")
-	}
-	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
-		return errors.Wrapf(err, "failed to delete worksheets for project principals %s", resourceID)
-	}
-
-	// Nullify revision.deleter references
-	q = qb.Q().Space(`UPDATE revision SET deleter = NULL
-		WHERE deleter IN (SELECT email FROM service_account WHERE project = ? AND workspace = ?)
-		   OR deleter IN (SELECT email FROM workload_identity WHERE project = ? AND workspace = ?)`, resourceID, workspace, resourceID, workspace)
-	sql, args, err = q.ToSQL()
-	if err != nil {
-		return errors.Wrap(err, "failed to build revision update query")
-	}
-	if _, err := tx.ExecContext(ctx, sql, args...); err != nil {
-		return errors.Wrapf(err, "failed to nullify revision.deleter for project %s", resourceID)
 	}
 
 	// Delete project service accounts


### PR DESCRIPTION
## Summary

- align `DeleteProject`, `DeleteInstance`, and `UpdateUserEmail` with one canonical row-lock order
- rely on the existing `UPDATE` and `DELETE` statements for row locking instead of adding broad upfront locks
- add deterministic PostgreSQL regression coverage for all three transaction pairs in both acquisition directions
- document the project- and instance-owned sibling lock order

## Testing

- `go test -count=1 ./backend/store -timeout 10m`
- `go test -v -count=1 ./backend/tests/ -run "^(TestClaim|TestCollision)" -timeout 5m`
- `golangci-lint run --fix --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`