### PR TITLE
feat(action): attribute Azure DevOps PR users

### DIFF
--- a/action/command/vcs_user.go
+++ b/action/command/vcs_user.go
@@ -28,6 +28,8 @@ func getVCSUser(platform world.JobPlatform) *v1pb.VCSUser {
 		return getGitLabVCSUser()
 	case world.Bitbucket:
 		return getBitbucketVCSUser()
+	case world.AzureDevOps:
+		return getAzureDevOpsVCSUser()
 	default:
 		return nil
 	}
@@ -200,6 +202,70 @@ func getBitbucketVCSUser() *v1pb.VCSUser {
 	}
 }
 
+func getAzureDevOpsVCSUser() *v1pb.VCSUser {
+	pullRequestID := os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTID")
+	collectionURI := firstNonEmpty(os.Getenv("SYSTEM_COLLECTIONURI"), os.Getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI"))
+	accessToken := os.Getenv("SYSTEM_ACCESSTOKEN")
+	if pullRequestID == "" || collectionURI == "" || accessToken == "" {
+		return nil
+	}
+
+	requestURL, err := buildAzureDevOpsPullRequestURL(collectionURI, pullRequestID)
+	if err != nil {
+		slog.Warn("failed to build Azure DevOps pull request URL for VCS user attribution", "error", err)
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		slog.Warn("failed to create Azure DevOps pull request request for VCS user attribution", "error", err)
+		return nil
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Warn("failed to get Azure DevOps pull request for VCS user attribution", "error", err)
+		return nil
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		slog.Warn("failed to get Azure DevOps pull request for VCS user attribution", "status", resp.Status)
+		return nil
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		slog.Warn("failed to read Azure DevOps pull request for VCS user attribution", "error", err)
+		return nil
+	}
+	var pullRequest struct {
+		CreatedBy struct {
+			ID          string `json:"id"`
+			UniqueName  string `json:"uniqueName"`
+			DisplayName string `json:"displayName"`
+			Descriptor  string `json:"descriptor"`
+		} `json:"createdBy"`
+	}
+	if err := json.Unmarshal(data, &pullRequest); err != nil {
+		slog.Warn("failed to parse Azure DevOps pull request for VCS user attribution", "error", err)
+		return nil
+	}
+
+	creator := pullRequest.CreatedBy
+	if creator.ID == "" || isAzureDevOpsBotUser(creator.Descriptor, creator.UniqueName) {
+		return nil
+	}
+	return &v1pb.VCSUser{
+		VcsType:     v1pb.VCSType_AZURE_DEVOPS,
+		UserId:      creator.ID,
+		UserName:    creator.UniqueName,
+		DisplayName: creator.DisplayName,
+	}
+}
+
 func buildGitLabMergeRequestURL(apiURL, projectID, mergeRequestIID string) (string, error) {
 	parsedURL, err := url.Parse(apiURL)
 	if err != nil {
@@ -239,6 +305,17 @@ func buildBitbucketPullRequestURL(apiURL, workspace, repoSlug, pullRequestID str
 	return parsedURL.String(), nil
 }
 
+func buildAzureDevOpsPullRequestURL(collectionURI, pullRequestID string) (string, error) {
+	parsedURL, err := url.Parse(collectionURI)
+	if err != nil {
+		return "", err
+	}
+	parsedURL.Path = strings.TrimRight(parsedURL.Path, "/") + "/_apis/git/pullrequests/" + url.PathEscape(pullRequestID)
+	parsedURL.RawQuery = url.Values{"api-version": {"7.1"}}.Encode()
+	parsedURL.Fragment = ""
+	return parsedURL.String(), nil
+}
+
 func firstNonEmpty(values ...string) string {
 	for _, value := range values {
 		if value != "" {
@@ -255,6 +332,11 @@ func isGitLabBotUser(userName string) bool {
 
 func isBitbucketBotUser(userType, userName string) bool {
 	return isBotUser(userType, userName) || strings.EqualFold(userType, "app") || strings.EqualFold(userType, "app_user")
+}
+
+func isAzureDevOpsBotUser(descriptor, userName string) bool {
+	lowerDescriptor := strings.ToLower(descriptor)
+	return strings.HasPrefix(lowerDescriptor, "svc.") || strings.HasPrefix(lowerDescriptor, "aadsp.") || isBotUser("", userName)
 }
 
 func isBotUser(userType, userName string) bool {

--- a/action/command/vcs_user_test.go
+++ b/action/command/vcs_user_test.go
@@ -136,6 +136,145 @@ func TestGetVCSUserFromBitbucketPullRequestAuthor(t *testing.T) {
 	require.Equal(t, "Alice", user.DisplayName)
 }
 
+func TestGetVCSUserFromAzureDevOpsPullRequestCreator(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/collection/_apis/git/pullrequests/42", r.URL.Path)
+		require.Equal(t, "7.1", r.URL.Query().Get("api-version"))
+		require.Equal(t, "Bearer access-token", r.Header.Get("Authorization"))
+		require.Equal(t, "application/json", r.Header.Get("Accept"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"createdBy":{"id":"author-id","uniqueName":"alice@example.com","displayName":"Alice"}}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "42")
+	t.Setenv("SYSTEM_COLLECTIONURI", server.URL+"/collection/")
+	t.Setenv("SYSTEM_ACCESSTOKEN", "access-token")
+
+	user := getVCSUser(world.AzureDevOps)
+	require.NotNil(t, user)
+	require.Equal(t, v1pb.VCSType_AZURE_DEVOPS, user.VcsType)
+	require.Equal(t, "author-id", user.UserId)
+	require.Equal(t, "alice@example.com", user.UserName)
+	require.Equal(t, "Alice", user.DisplayName)
+}
+
+func TestGetVCSUserFromAzureDevOpsPullRequestCreatorWithTeamFoundationCollectionURI(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/collection/_apis/git/pullrequests/42", r.URL.Path)
+		_, err := w.Write([]byte(`{"createdBy":{"id":"author-id","uniqueName":"alice@example.com","displayName":"Alice"}}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "42")
+	t.Setenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI", server.URL+"/collection/")
+	t.Setenv("SYSTEM_ACCESSTOKEN", "access-token")
+
+	require.NotNil(t, getVCSUser(world.AzureDevOps))
+}
+
+func TestGetVCSUserSkipsAzureDevOpsWhenPullRequestMetadataUnavailable(t *testing.T) {
+	t.Setenv("SYSTEM_COLLECTIONURI", "https://dev.azure.com/bytebase/")
+	t.Setenv("SYSTEM_ACCESSTOKEN", "access-token")
+	t.Setenv("BUILD_REQUESTEDFORID", "requester-id")
+	t.Setenv("BUILD_REQUESTEDFOR", "Requester")
+
+	require.Nil(t, getVCSUser(world.AzureDevOps))
+}
+
+func TestGetVCSUserSkipsAzureDevOpsWhenAccessTokenUnavailable(t *testing.T) {
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "42")
+	t.Setenv("SYSTEM_COLLECTIONURI", "https://dev.azure.com/bytebase/")
+
+	require.Nil(t, getVCSUser(world.AzureDevOps))
+}
+
+func TestGetVCSUserSkipsAzureDevOpsServicePrincipalCreator(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"createdBy":{"id":"bot-id","uniqueName":"build-service","displayName":"Build Service","descriptor":"aadsp.service-principal"}}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "42")
+	t.Setenv("SYSTEM_COLLECTIONURI", server.URL)
+	t.Setenv("SYSTEM_ACCESSTOKEN", "access-token")
+
+	require.Nil(t, getVCSUser(world.AzureDevOps))
+}
+
+func TestGetVCSUserSkipsAzureDevOpsBuildServiceCreator(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"createdBy":{"id":"bot-id","uniqueName":"build-service","displayName":"Build Service","descriptor":"svc.build-service"}}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "42")
+	t.Setenv("SYSTEM_COLLECTIONURI", server.URL)
+	t.Setenv("SYSTEM_ACCESSTOKEN", "access-token")
+
+	require.Nil(t, getVCSUser(world.AzureDevOps))
+}
+
+func TestGetVCSUserSkipsAzureDevOpsBotCreator(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"createdBy":{"id":"bot-id","uniqueName":"release[bot]","displayName":"Release Bot"}}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "42")
+	t.Setenv("SYSTEM_COLLECTIONURI", server.URL)
+	t.Setenv("SYSTEM_ACCESSTOKEN", "access-token")
+
+	require.Nil(t, getVCSUser(world.AzureDevOps))
+}
+
+func TestGetVCSUserSkipsAzureDevOpsCreatorWithoutID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`{"createdBy":{"uniqueName":"alice@example.com","displayName":"Alice"}}`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "42")
+	t.Setenv("SYSTEM_COLLECTIONURI", server.URL)
+	t.Setenv("SYSTEM_ACCESSTOKEN", "access-token")
+
+	require.Nil(t, getVCSUser(world.AzureDevOps))
+}
+
+func TestGetVCSUserSkipsAzureDevOpsInvalidPullRequestResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, err := w.Write([]byte(`invalid`))
+		require.NoError(t, err)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "42")
+	t.Setenv("SYSTEM_COLLECTIONURI", server.URL)
+	t.Setenv("SYSTEM_ACCESSTOKEN", "access-token")
+
+	require.Nil(t, getVCSUser(world.AzureDevOps))
+}
+
+func TestGetVCSUserSkipsAzureDevOpsNonOKPullRequestResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv("SYSTEM_PULLREQUEST_PULLREQUESTID", "42")
+	t.Setenv("SYSTEM_COLLECTIONURI", server.URL)
+	t.Setenv("SYSTEM_ACCESSTOKEN", "access-token")
+
+	require.Nil(t, getVCSUser(world.AzureDevOps))
+}
+
 func TestBitbucketDefaultAPIUsesPipelinesProxy(t *testing.T) {
 	requestURL, err := buildBitbucketPullRequestURL(getBitbucketAPIBaseURL(), "bytebase", "example", "10")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- Attribute Azure DevOps PR validation builds to the pull request creator using the Azure DevOps Get Pull Request By ID API.
- Skip service principals, build-service identities, and bot accounts; intentionally do not fall back to build requester variables.

## Testing

- `go test -v -count=1 ./action/command -run '^(TestGetVCSUser|TestBuildAzureDevOps)'`
- `golangci-lint run --allow-parallel-runners`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- Full `go test ./...` was attempted. The changed action package and `backend/tests` passed; two unrelated container-dependent tests failed due to environment issues: `TestApplyApprovalTemplateAndProjectDeletionPurgeFirst` (PostgreSQL container startup timeout) and `TestStatementDMLDryRunTiDBContainer` (Docker API/image check 500).

## Breaking Changes

None.