### PR TITLE
refactor: derive access grant creator from the authenticated caller

### DIFF
--- a/backend/api/v1/access_grant_service.go
+++ b/backend/api/v1/access_grant_service.go
@@ -137,9 +137,6 @@ func (s *AccessGrantService) CreateAccessGrant(ctx context.Context, request *con
 	if ag == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("access_grant is required"))
 	}
-	if ag.Creator == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("creator is required"))
-	}
 	if len(ag.Targets) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("targets is required"))
 	}
@@ -169,10 +166,14 @@ func (s *AccessGrantService) CreateAccessGrant(ctx context.Context, request *con
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("only read-only statements are allowed in access grants"))
 	}
 
-	creatorEmail, err := common.GetUserEmail(ag.Creator)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "invalid creator"))
+	// Derive the creator from the authenticated caller. The client-supplied
+	// creator field is OUTPUT_ONLY and must never be trusted, otherwise any
+	// caller could forge grants and issues attributed to an arbitrary identity.
+	user, ok := GetUserFromContext(ctx)
+	if !ok || user == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not found"))
 	}
+	creatorEmail := user.Email
 
 	var expireTime *time.Time
 	var requestedDuration *durationpb.Duration

--- a/frontend/src/modules/sql-editor/components/AccessGrantRequestDrawer.tsx
+++ b/frontend/src/modules/sql-editor/components/AccessGrantRequestDrawer.tsx
@@ -30,7 +30,6 @@ import {
   SheetTitle,
 } from "@/components/ui/sheet";
 import { Textarea } from "@/components/ui/textarea";
-import { useCurrentUser } from "@/hooks/useAppState";
 import {
   monacoThemeName,
   themeColorScheme,
@@ -70,7 +69,6 @@ function AccessGrantRequestDrawerInner({
   onClose,
 }: AccessGrantRequestDrawerInnerProps) {
   const { t } = useTranslation();
-  const currentUserEmail = useCurrentUser().email;
   const setAsidePanelTab = useSQLEditorStore((s) => s.setAsidePanelTab);
   const setHighlightAccessGrantName = useSQLEditorStore(
     (s) => s.setHighlightAccessGrantName
@@ -253,7 +251,6 @@ function AccessGrantRequestDrawerInner({
             };
 
       const accessGrant = create(AccessGrantSchema, {
-        creator: `users/${currentUserEmail}`,
         targets,
         query,
         unmask,

--- a/proto/v1/v1/access_grant_service.proto
+++ b/proto/v1/v1/access_grant_service.proto
@@ -88,9 +88,9 @@ message AccessGrant {
   // The {access_grant} segment is a server-generated unique ID.
   string name = 1;
 
-  // The creator of the access grant, derived from the authenticated caller.
+  // The creator of the access grant.
   // Format: users/{email}
-  string creator = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  string creator = 2 [(google.api.field_behavior) = REQUIRED];
 
   // The status of the access grant.
   // An ACTIVE grant with `expire_time` in the past is effectively expired

--- a/proto/v1/v1/access_grant_service.proto
+++ b/proto/v1/v1/access_grant_service.proto
@@ -88,9 +88,9 @@ message AccessGrant {
   // The {access_grant} segment is a server-generated unique ID.
   string name = 1;
 
-  // The creator of the access grant.
+  // The creator of the access grant, derived from the authenticated caller.
   // Format: users/{email}
-  string creator = 2 [(google.api.field_behavior) = REQUIRED];
+  string creator = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 
   // The status of the access grant.
   // An ACTIVE grant with `expire_time` in the past is effectively expired


### PR DESCRIPTION
## What

`CreateAccessGrant` previously read the grant's `creator` from the request body. This change derives it from the authenticated caller in context instead, matching how `CreateIssue` already sets its creator. The proto `AccessGrant.creator` field is marked `OUTPUT_ONLY` to reflect that it is server-determined, and the SQL Editor access-request drawer no longer sends a client-supplied `creator`.

## Why

The creator of a JIT access grant (and the issue it opens) should always be the authenticated user making the request, not a value chosen by the client. This keeps `CreateAccessGrant` consistent with the rest of the create RPCs, which source the creator from the request context.

## Changes

- `backend/api/v1/access_grant_service.go` — derive `creatorEmail` from `GetUserFromContext(ctx)`; drop the client-supplied `creator` input handling.
- `proto/v1/v1/access_grant_service.proto` — `AccessGrant.creator` → `OUTPUT_ONLY`.
- `frontend/src/modules/sql-editor/components/AccessGrantRequestDrawer.tsx` — stop setting `creator` on the create request.

## Testing

- `go build` and `golangci-lint run` clean on `backend/api/v1/...` and `backend/tests/...`.
- Frontend `biome check` and `type-check` pass.

> Note: `buf generate` was not run in this environment (no network access to remote plugins). The `field_behavior` change is annotation-only and does not affect the generated Go structs or wire format, but regenerate protos before merge to keep descriptors in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)