### PR TITLE
refactor: derive access grant creator from the authenticated caller (backport #20956 to 3.20.0)

### DIFF
--- a/backend/api/v1/access_grant_service.go
+++ b/backend/api/v1/access_grant_service.go
@@ -137,9 +137,6 @@ func (s *AccessGrantService) CreateAccessGrant(ctx context.Context, request *con
 	if ag == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("access_grant is required"))
 	}
-	if ag.Creator == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("creator is required"))
-	}
 	if len(ag.Targets) == 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("targets is required"))
 	}
@@ -169,10 +166,14 @@ func (s *AccessGrantService) CreateAccessGrant(ctx context.Context, request *con
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("only read-only statements are allowed in access grants"))
 	}
 
-	creatorEmail, err := common.GetUserEmail(ag.Creator)
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "invalid creator"))
+	// Derive the creator from the authenticated caller. The client-supplied
+	// creator field is OUTPUT_ONLY and must never be trusted, otherwise any
+	// caller could forge grants and issues attributed to an arbitrary identity.
+	user, ok := GetUserFromContext(ctx)
+	if !ok || user == nil {
+		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("user not found"))
 	}
+	creatorEmail := user.Email
 
 	var expireTime *time.Time
 	var requestedDuration *durationpb.Duration

--- a/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
+++ b/frontend/src/react/components/sql-editor/AccessGrantRequestDrawer.tsx
@@ -28,7 +28,6 @@ import {
   SheetTitle,
 } from "@/react/components/ui/sheet";
 import { Textarea } from "@/react/components/ui/textarea";
-import { useCurrentUser } from "@/react/hooks/useAppState";
 import { router } from "@/react/router";
 import { PROJECT_V1_ROUTE_ISSUE_DETAIL } from "@/react/router/handles";
 import { useAppStore } from "@/react/stores/app";
@@ -63,7 +62,6 @@ function AccessGrantRequestDrawerInner({
   onClose,
 }: AccessGrantRequestDrawerInnerProps) {
   const { t } = useTranslation();
-  const currentUserEmail = useCurrentUser().email;
   const setAsidePanelTab = useSQLEditorStore((s) => s.setAsidePanelTab);
   const setHighlightAccessGrantName = useSQLEditorStore(
     (s) => s.setHighlightAccessGrantName
@@ -246,7 +244,6 @@ function AccessGrantRequestDrawerInner({
             };
 
       const accessGrant = create(AccessGrantSchema, {
-        creator: `users/${currentUserEmail}`,
         targets,
         query,
         unmask,

--- a/frontend/src/react/components/ui/radio-group.tsx
+++ b/frontend/src/react/components/ui/radio-group.tsx
@@ -17,9 +17,13 @@ function RadioGroup({
 function RadioGroupItem({
   children,
   className,
+  radioClassName,
   value,
   ...props
-}: React.ComponentProps<typeof Radio.Root> & { children?: React.ReactNode }) {
+}: React.ComponentProps<typeof Radio.Root> & {
+  children?: React.ReactNode;
+  radioClassName?: string;
+}) {
   return (
     <label
       className={cn("flex items-center gap-x-2 cursor-pointer", className)}
@@ -30,7 +34,8 @@ function RadioGroupItem({
           "flex size-4 shrink-0 items-center justify-center rounded-full border border-control-border",
           "data-[checked]:border-accent data-[checked]:border-[5px]",
           "focus:outline-hidden focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2",
-          "disabled:cursor-not-allowed disabled:opacity-50"
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          radioClassName
         )}
         {...props}
       />


### PR DESCRIPTION
Backport of #20956 to `release/3.20.0`.

Derives the access grant creator from the authenticated caller in `CreateAccessGrant` (matching `CreateIssue`) instead of the request body, and drops the now-unused client-supplied `creator` in the SQL Editor access-request drawer.

Cherry-picked from 32b954b853. The frontend import block conflicted only because this release branch predates the `src/react` → `src/modules` reorg; resolved by keeping the release branch's `@/react/...` paths and removing the now-unused `useCurrentUser` import. Backend applied cleanly. Proto is untouched on both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)