### PR TITLE
chore: group react and react-dom renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -57,6 +57,11 @@
       "matchPackageNames": ["/^i18next$/", "/^react-i18next$/", "/^i18next-/"]
     },
     {
+      "groupName": "react",
+      "description": "React 19's renderer enforces an exact version match between react and react-dom at startup, so bump them together",
+      "matchPackageNames": ["react", "react-dom", "@types/react", "@types/react-dom"]
+    },
+    {
       "matchPackageNames": ["@vitejs/plugin-legacy"],
       "matchUpdateTypes": ["major"],
       "enabled": false,


### PR DESCRIPTION
## What

Adds a Renovate `packageRules` group bundling `react`, `react-dom`, `@types/react`, and `@types/react-dom` into a single update PR.

## Why

React 19's renderer enforces an exact version match between `react` and `react-dom` at startup. Renovate split the 19.2.8 bump into #20966 (react) and #20967 (react-dom), producing a lockfile where the two disagreed — flagged in https://github.com/bytebase/bytebase/pull/20966#discussion_r3636759980. Grouping them follows the existing pattern used for connectrpc, i18next, and codingame.

## Testing

- `renovate.json` validated as JSON; rule follows the same shape as the existing groups.
- The immediate mismatch on #20966 was fixed separately by bumping react-dom to 19.2.8 in that PR's lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)