### PR TITLE
feat: add PostgreSQL leader lease for schema sync

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -60,6 +60,26 @@ _Avoid_: Plan, rollout, issue
 The recorded history of a database migration after execution. It is evidence that a change ran, not the proposed change itself.
 _Avoid_: Change request, release
 
+**Leader Type**:
+A singleton Bytebase responsibility that at most one replica may hold for each Leader Resource. Every type declares exactly one allowed resource kind.
+_Avoid_: Leadership Role, work claim, job, primary replica
+
+**Leader Resource**:
+The boundary within which a Leader Type is exclusive. `global` represents the entire Bytebase installation; other values identify one canonical Bytebase resource.
+_Avoid_: Leadership Scope, work item
+
+**Leadership Term**:
+One replica's uninterrupted, generation-specific authority to hold a Leader Type for a Leader Resource. Reacquiring an expired lease begins a new term even when the same replica succeeds.
+_Avoid_: Session, process lifetime, work claim
+
+**Leadership Lease**:
+The time-bounded grant underlying a Leadership Term. Expiration ends the authority granted by the term even if its work has not stopped.
+_Avoid_: Heartbeat, work claim
+
+**Work Claim**:
+A replica's right to process one independently distributable unit of work. It does not represent continuous ownership of a Leader Type.
+_Avoid_: Leader Type, Leadership Term, Leadership Lease
+
 **Composite Type**:
 A PostgreSQL-family standalone named row type (`CREATE TYPE x AS (...)`, `pg_type.typtype = 'c'` excluding table row types). Distinct from enums, domains, ranges, Oracle object types, and SQL Server table/alias types — each is its own concept with its own name.
 _Avoid_: UDT, user-defined type, custom type, object type

--- a/backend/component/leader/manager.go
+++ b/backend/component/leader/manager.go
@@ -1,0 +1,305 @@
+// Package leader coordinates singleton component work across replicas.
+package leader
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	pkgerrors "github.com/pkg/errors"
+)
+
+const (
+	leaseTTL          = 30 * time.Second
+	renewalInterval   = 10 * time.Second
+	renewalRetry      = time.Second
+	leaseSafetyMargin = 10 * time.Second
+	cleanupTimeout    = 5 * time.Second
+)
+
+// Type identifies the work guarded by a leader lease.
+type Type string
+
+const (
+	// SchemaSync guards schema synchronization work.
+	SchemaSync Type = "SCHEMA_SYNC"
+)
+
+// ErrLeaseLost reports that this replica can no longer safely act as leader.
+var ErrLeaseLost = errors.New("leader lease lost")
+
+var errReleaseNotOwned = errors.New("leader lease release was not accepted")
+
+// Persistence stores leader leases.
+type Persistence interface {
+	TryAcquireLeaderLease(ctx context.Context, leaderType string, replicaID string, ttl time.Duration) (generation int64, acquired bool, err error)
+	RenewLeaderLease(ctx context.Context, leaderType string, replicaID string, generation int64, ttl time.Duration) (renewed bool, err error)
+	ReleaseLeaderLease(ctx context.Context, leaderType string, replicaID string, generation int64) (released bool, err error)
+}
+
+// Manager runs component work only while this replica holds its lease.
+type Manager struct {
+	persistence Persistence
+	replicaID   string
+	options     managerOptions
+}
+
+type managerOptions struct {
+	ttl             time.Duration
+	renewalInterval time.Duration
+	retryInterval   time.Duration
+	safetyMargin    time.Duration
+	cleanupTimeout  time.Duration
+	clock           clock
+	logger          *slog.Logger
+}
+
+type clock interface {
+	Now() time.Time
+	NewTimer(time.Duration) timer
+}
+
+type timer interface {
+	Chan() <-chan time.Time
+	Stop() bool
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time {
+	return time.Now()
+}
+
+func (systemClock) NewTimer(d time.Duration) timer {
+	return systemTimer{Timer: time.NewTimer(d)}
+}
+
+type systemTimer struct {
+	*time.Timer
+}
+
+func (t systemTimer) Chan() <-chan time.Time {
+	return t.C
+}
+
+// NewManager creates a leader manager for a replica.
+func NewManager(p Persistence, replicaID string) *Manager {
+	return newManagerWithOptions(p, replicaID, managerOptions{})
+}
+
+// newManagerWithOptions allows deterministic timing and log tests without exposing timing
+// as user configuration.
+func newManagerWithOptions(p Persistence, replicaID string, options managerOptions) *Manager {
+	if options.ttl == 0 {
+		options.ttl = leaseTTL
+	}
+	if options.renewalInterval == 0 {
+		options.renewalInterval = renewalInterval
+	}
+	if options.retryInterval == 0 {
+		options.retryInterval = renewalRetry
+	}
+	if options.safetyMargin == 0 {
+		options.safetyMargin = leaseSafetyMargin
+	}
+	if options.cleanupTimeout == 0 {
+		options.cleanupTimeout = cleanupTimeout
+	}
+	if options.clock == nil {
+		options.clock = systemClock{}
+	}
+	if options.logger == nil {
+		options.logger = slog.Default()
+	}
+	return &Manager{persistence: p, replicaID: replicaID, options: options}
+}
+
+// TryRun acquires the lease for typ and runs callback while it remains valid.
+func (m *Manager) TryRun(ctx context.Context, typ Type, callback func(context.Context) error) (bool, error) {
+	if typ != SchemaSync {
+		return false, pkgerrors.Errorf("unsupported leader type %q", typ)
+	}
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	acquireStarted := m.options.clock.Now()
+	generation, acquired, err := m.persistence.TryAcquireLeaderLease(ctx, string(typ), m.replicaID, m.options.ttl)
+	if err != nil {
+		return false, pkgerrors.Wrap(err, "acquire leader lease")
+	}
+	if !acquired {
+		return false, nil
+	}
+
+	validUntil := acquireStarted.Add(m.usableLease())
+	authorityStarted, validUntil, preCallbackErr := m.establishInitialAuthority(ctx, typ, generation, acquireStarted, validUntil)
+	if preCallbackErr != nil {
+		return false, errors.Join(preCallbackErr, m.release(ctx, typ, generation))
+	}
+	if err := ctx.Err(); err != nil {
+		return false, errors.Join(err, m.release(ctx, typ, generation))
+	}
+
+	leaderCtx, cancelLeader := context.WithCancel(ctx)
+	defer cancelLeader()
+	renewStop, stopRenew := context.WithCancel(context.Background())
+	renewDone := make(chan renewalOutcome, 1)
+	go func() {
+		renewDone <- m.renewUntilStopped(ctx, renewStop.Done(), cancelLeader, typ, generation, authorityStarted, validUntil)
+	}()
+
+	callbackErr := callback(leaderCtx)
+	stopRenew()
+	renewal := <-renewDone
+	releaseErr := m.release(ctx, typ, generation)
+
+	var parentErr error
+	if ctx.Err() != nil && !renewal.lost {
+		parentErr = ctx.Err()
+	}
+	return true, errors.Join(callbackErr, renewal.err, parentErr, releaseErr)
+}
+
+func (m *Manager) usableLease() time.Duration {
+	return m.options.ttl - m.options.safetyMargin
+}
+
+func (m *Manager) establishInitialAuthority(ctx context.Context, typ Type, generation int64, authorityStarted, validUntil time.Time) (time.Time, time.Time, error) {
+	for !m.options.clock.Now().Before(validUntil) {
+		if err := ctx.Err(); err != nil {
+			return authorityStarted, validUntil, err
+		}
+		started := m.options.clock.Now()
+		renewed, err := m.persistence.RenewLeaderLease(ctx, string(typ), m.replicaID, generation, m.options.ttl)
+		if err != nil {
+			return authorityStarted, validUntil, pkgerrors.Wrap(err, "renew leader lease before callback")
+		}
+		if !renewed {
+			return authorityStarted, validUntil, ErrLeaseLost
+		}
+		authorityStarted = started
+		validUntil = started.Add(m.usableLease())
+	}
+	return authorityStarted, validUntil, nil
+}
+
+type renewalOutcome struct {
+	lost bool
+	err  error
+}
+
+func (m *Manager) renewUntilStopped(parent context.Context, stop <-chan struct{}, cancelLeader context.CancelFunc, typ Type, generation int64, authorityStarted, validUntil time.Time) renewalOutcome {
+	nextRenewal := authorityStarted.Add(m.options.renewalInterval)
+	loggedFailure := false
+	for {
+		now := m.options.clock.Now()
+		if !now.Before(validUntil) {
+			cancelLeader()
+			return renewalOutcome{lost: true, err: ErrLeaseLost}
+		}
+		wakeAt := nextRenewal
+		if validUntil.Before(wakeAt) {
+			wakeAt = validUntil
+		}
+		wait := m.options.clock.NewTimer(wakeAt.Sub(now))
+		select {
+		case <-stop:
+			wait.Stop()
+			return renewalOutcome{}
+		case <-parent.Done():
+			wait.Stop()
+			return renewalOutcome{}
+		case <-wait.Chan():
+		}
+
+		if parent.Err() != nil {
+			return renewalOutcome{}
+		}
+		if !m.options.clock.Now().Before(validUntil) {
+			cancelLeader()
+			return renewalOutcome{lost: true, err: ErrLeaseLost}
+		}
+		started := m.options.clock.Now()
+		renewCtx, cancelRenew := context.WithCancel(parent)
+		result := make(chan renewResult, 1)
+		go func() {
+			renewed, err := m.persistence.RenewLeaderLease(renewCtx, string(typ), m.replicaID, generation, m.options.ttl)
+			result <- renewResult{renewed: renewed, err: err}
+		}()
+
+		deadline := m.options.clock.NewTimer(validUntil.Sub(m.options.clock.Now()))
+		var renewal renewResult
+		select {
+		case <-stop:
+			deadline.Stop()
+			cancelRenew()
+			<-result
+			return renewalOutcome{}
+		case <-parent.Done():
+			deadline.Stop()
+			cancelRenew()
+			<-result
+			return renewalOutcome{}
+		case renewal = <-result:
+			deadline.Stop()
+			cancelRenew()
+		case <-deadline.Chan():
+			cancelRenew()
+			renewal = <-result
+			if parent.Err() != nil {
+				return renewalOutcome{}
+			}
+			cancelLeader()
+			return renewalOutcome{lost: true, err: errors.Join(ErrLeaseLost, renewal.err)}
+		}
+
+		if parent.Err() != nil {
+			return renewalOutcome{}
+		}
+		if !m.options.clock.Now().Before(validUntil) {
+			cancelLeader()
+			return renewalOutcome{lost: true, err: errors.Join(ErrLeaseLost, renewal.err)}
+		}
+		if renewal.err != nil {
+			if !loggedFailure {
+				m.options.logger.Warn("leader lease renewal failed; retrying", "leader_type", typ, "error", renewal.err)
+				loggedFailure = true
+			}
+			nextRenewal = m.options.clock.Now().Add(m.options.retryInterval)
+			continue
+		}
+		if !renewal.renewed {
+			cancelLeader()
+			return renewalOutcome{lost: true, err: ErrLeaseLost}
+		}
+		if loggedFailure {
+			m.options.logger.Info("leader lease renewal recovered", "leader_type", typ)
+			loggedFailure = false
+		}
+		validUntil = started.Add(m.usableLease())
+		nextRenewal = started.Add(m.options.renewalInterval)
+	}
+}
+
+type renewResult struct {
+	renewed bool
+	err     error
+}
+
+func (m *Manager) release(ctx context.Context, typ Type, generation int64) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), m.options.cleanupTimeout)
+	defer cancel()
+	released, err := m.persistence.ReleaseLeaderLease(cleanupCtx, string(typ), m.replicaID, generation)
+	if err != nil {
+		if !released {
+			return errors.Join(errReleaseNotOwned, pkgerrors.Wrap(err, "release leader lease"))
+		}
+		return pkgerrors.Wrap(err, "release leader lease")
+	}
+	if !released {
+		return errReleaseNotOwned
+	}
+	return nil
+}

--- a/backend/component/leader/manager_test.go
+++ b/backend/component/leader/manager_test.go
@@ -1,0 +1,466 @@
+package leader
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+type testPersistence struct {
+	acquire func(context.Context, string, string, time.Duration) (int64, bool, error)
+	renew   func(context.Context, string, string, int64, time.Duration) (bool, error)
+	release func(context.Context, string, string, int64) (bool, error)
+}
+
+func (p testPersistence) TryAcquireLeaderLease(ctx context.Context, typ, replica string, ttl time.Duration) (int64, bool, error) {
+	return p.acquire(ctx, typ, replica, ttl)
+}
+
+func (p testPersistence) RenewLeaderLease(ctx context.Context, typ, replica string, generation int64, ttl time.Duration) (bool, error) {
+	return p.renew(ctx, typ, replica, generation, ttl)
+}
+
+func (p testPersistence) ReleaseLeaderLease(ctx context.Context, typ, replica string, generation int64) (bool, error) {
+	return p.release(ctx, typ, replica, generation)
+}
+
+func successPersistence() testPersistence {
+	return testPersistence{
+		acquire: func(context.Context, string, string, time.Duration) (int64, bool, error) { return 7, true, nil },
+		renew:   func(context.Context, string, string, int64, time.Duration) (bool, error) { return true, nil },
+		release: func(context.Context, string, string, int64) (bool, error) { return true, nil },
+	}
+}
+
+func TestManagerContentionDoesNotRunCallback(t *testing.T) {
+	p := successPersistence()
+	p.acquire = func(context.Context, string, string, time.Duration) (int64, bool, error) { return 0, false, nil }
+	p.release = func(context.Context, string, string, int64) (bool, error) {
+		t.Fatal("ReleaseLeaderLease called after contention")
+		return false, nil
+	}
+	called := false
+	ran, err := NewManager(p, "replica-1").TryRun(context.Background(), SchemaSync, func(context.Context) error {
+		called = true
+		return nil
+	})
+	if err != nil || ran || called {
+		t.Fatalf("TryRun() = (%v, %v), called=%v", ran, err, called)
+	}
+}
+
+func TestManagerAcquireErrorDoesNotRunCallback(t *testing.T) {
+	want := errors.New("database unavailable")
+	p := successPersistence()
+	p.acquire = func(context.Context, string, string, time.Duration) (int64, bool, error) { return 0, false, want }
+	ran, err := NewManager(p, "replica-1").TryRun(context.Background(), SchemaSync, func(context.Context) error {
+		t.Fatal("callback called after acquire failure")
+		return nil
+	})
+	if ran || !errors.Is(err, want) {
+		t.Fatalf("TryRun() = (%v, %v), want false and %v", ran, err, want)
+	}
+}
+
+func TestManagerReturnsCallbackErrorAndReleases(t *testing.T) {
+	want := errors.New("callback failed")
+	released := false
+	p := successPersistence()
+	p.release = func(_ context.Context, typ, replica string, generation int64) (bool, error) {
+		released = true
+		if typ != string(SchemaSync) || replica != "replica-1" || generation != 7 {
+			t.Fatalf("release = (%q, %q, %d)", typ, replica, generation)
+		}
+		return true, nil
+	}
+	ran, err := NewManager(p, "replica-1").TryRun(context.Background(), SchemaSync, func(context.Context) error { return want })
+	if !ran || !released || !errors.Is(err, want) {
+		t.Fatalf("TryRun() = (%v, %v), released=%v", ran, err, released)
+	}
+}
+
+func TestManagerRejectsUnsupportedTypeBeforePersistence(t *testing.T) {
+	p := successPersistence()
+	p.acquire = func(context.Context, string, string, time.Duration) (int64, bool, error) {
+		t.Fatal("persistence called for unsupported type")
+		return 0, false, nil
+	}
+	ran, err := NewManager(p, "replica-1").TryRun(context.Background(), Type("OTHER"), func(context.Context) error { return nil })
+	if ran || err == nil {
+		t.Fatalf("TryRun() = (%v, %v), want validation failure", ran, err)
+	}
+}
+
+func TestManagerDelayedAcquireRenewsBeforeCallback(t *testing.T) {
+	clock := newTestClock(time.Unix(0, 0))
+	p := successPersistence()
+	p.acquire = func(context.Context, string, string, time.Duration) (int64, bool, error) {
+		clock.Advance(21 * time.Second)
+		return 7, true, nil
+	}
+	called := false
+	renewed := false
+	p.renew = func(context.Context, string, string, int64, time.Duration) (bool, error) {
+		renewed = true
+		return true, nil
+	}
+	ran, err := newManagerWithOptions(p, "replica-1", testOptions(clock)).TryRun(context.Background(), SchemaSync, func(context.Context) error {
+		called = true
+		return nil
+	})
+	if !ran || err != nil || !renewed || !called {
+		t.Fatalf("TryRun() = (%v, %v), renewed=%v, called=%v", ran, err, renewed, called)
+	}
+}
+
+func TestManagerDelayedAcquireRenewsUntilItHasACompleteWindow(t *testing.T) {
+	clock := newTestClock(time.Unix(0, 0))
+	p := successPersistence()
+	p.acquire = func(context.Context, string, string, time.Duration) (int64, bool, error) {
+		clock.Advance(21 * time.Second)
+		return 7, true, nil
+	}
+	renewals := 0
+	p.renew = func(context.Context, string, string, int64, time.Duration) (bool, error) {
+		renewals++
+		if renewals == 1 {
+			// This successful operation consumed its whole local usable window.
+			clock.Advance(20 * time.Second)
+		}
+		return true, nil
+	}
+	ran, err := newManagerWithOptions(p, "replica-1", testOptions(clock)).TryRun(context.Background(), SchemaSync, func(context.Context) error {
+		if renewals != 2 {
+			t.Fatalf("callback started after %d renewals, want 2", renewals)
+		}
+		return nil
+	})
+	if !ran || err != nil || renewals != 2 {
+		t.Fatalf("TryRun() = (%v, %v), renewals=%d", ran, err, renewals)
+	}
+}
+
+func TestManagerRenewFalseCancelsCallbackAndReleasesAfterDrain(t *testing.T) {
+	clock := newTestClock(time.Unix(0, 0))
+	started := make(chan struct{})
+	finished := make(chan struct{})
+	released := make(chan struct{})
+	p := successPersistence()
+	p.renew = func(context.Context, string, string, int64, time.Duration) (bool, error) { return false, nil }
+	p.release = func(context.Context, string, string, int64) (bool, error) {
+		select {
+		case <-finished:
+		default:
+			t.Error("released before callback drained")
+		}
+		close(released)
+		return true, nil
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := newManagerWithOptions(p, "replica-1", testOptions(clock)).TryRun(context.Background(), SchemaSync, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			close(finished)
+			return ctx.Err()
+		})
+		result <- err
+	}()
+	<-started
+	advanceAfterTimer(t, clock, 10*time.Second)
+	if err := <-result; !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("TryRun error = %v, want ErrLeaseLost", err)
+	}
+	<-released
+}
+
+func TestManagerRenewFailureRetriesAndLogsRecoveryOnce(t *testing.T) {
+	clock := newTestClock(time.Unix(0, 0))
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	started := make(chan struct{})
+	stop := make(chan struct{})
+	var mu sync.Mutex
+	calls := 0
+	p := successPersistence()
+	p.renew = func(context.Context, string, string, int64, time.Duration) (bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		calls++
+		if calls < 3 {
+			return false, errors.New("temporary")
+		}
+		return true, nil
+	}
+	options := testOptions(clock)
+	options.logger = logger
+	result := make(chan error, 1)
+	go func() {
+		_, err := newManagerWithOptions(p, "replica-1", options).TryRun(context.Background(), SchemaSync, func(context.Context) error {
+			close(started)
+			<-stop
+			return nil
+		})
+		result <- err
+	}()
+	<-started
+	advanceAfterTimer(t, clock, 10*time.Second)
+	advanceAfterTimer(t, clock, time.Second)
+	advanceAfterTimer(t, clock, time.Second)
+	clock.WaitForActiveTimer(t, 10*time.Second)
+	close(stop)
+	if err := <-result; err != nil {
+		t.Fatalf("TryRun error = %v", err)
+	}
+	mu.Lock()
+	gotCalls := calls
+	mu.Unlock()
+	if gotCalls != 3 || bytes.Count(logs.Bytes(), []byte("renewal failed")) != 1 || bytes.Count(logs.Bytes(), []byte("renewal recovered")) != 1 {
+		t.Fatalf("calls=%d logs=%q", gotCalls, logs.String())
+	}
+}
+
+func TestManagerParentCancellationIsNotLeaseLoss(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{})
+	p := successPersistence()
+	result := make(chan error, 1)
+	go func() {
+		_, err := NewManager(p, "replica-1").TryRun(ctx, SchemaSync, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+		result <- err
+	}()
+	<-started
+	cancel()
+	if err := <-result; !errors.Is(err, context.Canceled) || errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("TryRun error = %v", err)
+	}
+}
+
+func TestManagerParentCancellationUsesUncanceledCleanupContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{})
+	released := make(chan struct{})
+	p := successPersistence()
+	p.release = func(cleanupCtx context.Context, _ string, _ string, _ int64) (bool, error) {
+		if err := cleanupCtx.Err(); err != nil {
+			t.Errorf("cleanup context is canceled: %v", err)
+		}
+		close(released)
+		return true, nil
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := NewManager(p, "replica-1").TryRun(ctx, SchemaSync, func(callbackCtx context.Context) error {
+			close(started)
+			<-callbackCtx.Done()
+			return nil
+		})
+		result <- err
+	}()
+	<-started
+	cancel()
+	if err := <-result; !errors.Is(err, context.Canceled) || errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("TryRun error = %v", err)
+	}
+	<-released
+}
+
+func TestManagerReleaseFailureJoinsCallbackAndLeaseErrors(t *testing.T) {
+	clock := newTestClock(time.Unix(0, 0))
+	callbackErr := errors.New("callback")
+	releaseErr := errors.New("release")
+	started := make(chan struct{})
+	p := successPersistence()
+	p.renew = func(context.Context, string, string, int64, time.Duration) (bool, error) { return false, nil }
+	p.release = func(context.Context, string, string, int64) (bool, error) { return false, releaseErr }
+	result := make(chan error, 1)
+	go func() {
+		_, err := newManagerWithOptions(p, "replica-1", testOptions(clock)).TryRun(context.Background(), SchemaSync, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return callbackErr
+		})
+		result <- err
+	}()
+	<-started
+	advanceAfterTimer(t, clock, 10*time.Second)
+	if err := <-result; !errors.Is(err, callbackErr) || !errors.Is(err, ErrLeaseLost) || !errors.Is(err, releaseErr) {
+		t.Fatalf("TryRun error = %v", err)
+	}
+}
+
+func TestManagerDeadlineExhaustionJoinsFinalRenewalError(t *testing.T) {
+	clock := newTestClock(time.Unix(0, 0))
+	started := make(chan struct{})
+	finalRenewalErr := errors.New("renewal timed out")
+	p := successPersistence()
+	p.renew = func(ctx context.Context, _ string, _ string, _ int64, _ time.Duration) (bool, error) {
+		<-ctx.Done()
+		return false, finalRenewalErr
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := newManagerWithOptions(p, "replica-1", testOptions(clock)).TryRun(context.Background(), SchemaSync, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return nil
+		})
+		result <- err
+	}()
+	<-started
+	advanceAfterTimer(t, clock, 10*time.Second)
+	advanceAfterTimer(t, clock, 10*time.Second)
+	if err := <-result; !errors.Is(err, ErrLeaseLost) || !errors.Is(err, finalRenewalErr) {
+		t.Fatalf("TryRun error = %v, want lease loss and %v", err, finalRenewalErr)
+	}
+}
+
+func TestManagerDrainsInFlightRenewalBeforeRelease(t *testing.T) {
+	clock := newTestClock(time.Unix(0, 0))
+	renewStarted := make(chan struct{})
+	allowRenewReturn := make(chan struct{})
+	callbackStarted := make(chan struct{})
+	released := make(chan struct{})
+	p := successPersistence()
+	p.renew = func(context.Context, string, string, int64, time.Duration) (bool, error) {
+		close(renewStarted)
+		<-allowRenewReturn
+		return false, errors.New("late renewal")
+	}
+	p.release = func(context.Context, string, string, int64) (bool, error) {
+		close(released)
+		return true, nil
+	}
+	result := make(chan error, 1)
+	go func() {
+		_, err := newManagerWithOptions(p, "replica-1", testOptions(clock)).TryRun(context.Background(), SchemaSync, func(ctx context.Context) error {
+			close(callbackStarted)
+			<-ctx.Done()
+			return nil
+		})
+		result <- err
+	}()
+	<-callbackStarted
+	advanceAfterTimer(t, clock, 10*time.Second)
+	<-renewStarted
+	advanceAfterTimer(t, clock, 10*time.Second)
+	select {
+	case <-released:
+		t.Fatal("release raced with in-flight renewal")
+	default:
+	}
+	close(allowRenewReturn)
+	if err := <-result; !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("TryRun error = %v, want ErrLeaseLost", err)
+	}
+	<-released
+}
+
+func testOptions(clock *testClock) managerOptions {
+	return managerOptions{
+		ttl:             30 * time.Second,
+		renewalInterval: 10 * time.Second,
+		retryInterval:   time.Second,
+		safetyMargin:    10 * time.Second,
+		cleanupTimeout:  time.Second,
+		clock:           clock,
+	}
+}
+
+func advanceAfterTimer(t *testing.T, clock *testClock, d time.Duration) {
+	t.Helper()
+	clock.WaitForActiveTimer(t, d)
+	clock.Advance(d)
+}
+
+type testClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*testTimer
+	added  chan struct{}
+}
+
+func newTestClock(now time.Time) *testClock {
+	return &testClock{now: now, added: make(chan struct{}, 32)}
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) NewTimer(d time.Duration) timer {
+	c.mu.Lock()
+	t := &testTimer{due: c.now.Add(d), c: make(chan time.Time, 1)}
+	c.timers = append(c.timers, t)
+	c.mu.Unlock()
+	c.added <- struct{}{}
+	return t
+}
+
+func (c *testClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	now := c.now
+	var due []*testTimer
+	for _, t := range c.timers {
+		if !t.stopped && !now.Before(t.due) {
+			t.stopped = true
+			due = append(due, t)
+		}
+	}
+	c.mu.Unlock()
+	for _, t := range due {
+		t.c <- now
+	}
+}
+
+func (c *testClock) WaitForActiveTimer(t *testing.T, d time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		c.mu.Lock()
+		want := c.now.Add(d)
+		for _, timer := range c.timers {
+			if !timer.stopped && timer.due.Equal(want) {
+				c.mu.Unlock()
+				return
+			}
+		}
+		c.mu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("manager did not schedule active timer")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+type testTimer struct {
+	mu      sync.Mutex
+	due     time.Time
+	c       chan time.Time
+	stopped bool
+}
+
+func (t *testTimer) Chan() <-chan time.Time { return t.c }
+
+func (t *testTimer) Stop() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.stopped {
+		return false
+	}
+	t.stopped = true
+	return true
+}

--- a/backend/migrator/migration/3.21/0003##add_leader_lease.sql
+++ b/backend/migrator/migration/3.21/0003##add_leader_lease.sql
@@ -1,0 +1,6 @@
+CREATE TABLE leader_lease (
+    type TEXT PRIMARY KEY,
+    replica_id TEXT NOT NULL,
+    generation BIGINT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL
+);

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -601,6 +601,13 @@ CREATE TABLE replica_heartbeat (
     last_heartbeat TIMESTAMPTZ NOT NULL
 );
 
+CREATE TABLE leader_lease (
+    type TEXT PRIMARY KEY,
+    replica_id TEXT NOT NULL,
+    generation BIGINT NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
 CREATE TABLE task_run_log (
     project text NOT NULL REFERENCES project(resource_id),
     task_run_id integer NOT NULL,

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -17,8 +17,8 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.21.2"), *files[len(files)-1].version)
-	require.Equal(t, "migration/3.21/0002##migrate_instance_sync_databases.sql", files[len(files)-1].path)
+	require.Equal(t, semver.MustParse("3.21.3"), *files[len(files)-1].version)
+	require.Equal(t, "migration/3.21/0003##add_leader_lease.sql", files[len(files)-1].path)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/backend/runner/schemasync/syncer.go
+++ b/backend/runner/schemasync/syncer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/component/dbfactory"
+	"github.com/bytebase/bytebase/backend/component/leader"
 	"github.com/bytebase/bytebase/backend/enterprise"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
@@ -37,11 +38,12 @@ const (
 )
 
 // NewSyncer creates a schema syncer.
-func NewSyncer(stores *store.Store, dbFactory *dbfactory.DBFactory, licenseService *enterprise.LicenseService) *Syncer {
+func NewSyncer(stores *store.Store, dbFactory *dbfactory.DBFactory, licenseService *enterprise.LicenseService, leaderManager *leader.Manager) *Syncer {
 	return &Syncer{
 		store:          stores,
 		dbFactory:      dbFactory,
 		licenseService: licenseService,
+		leaderManager:  leaderManager,
 	}
 }
 
@@ -52,6 +54,7 @@ type Syncer struct {
 	store           *store.Store
 	dbFactory       *dbfactory.DBFactory
 	licenseService  *enterprise.LicenseService
+	leaderManager   *leader.Manager
 	databaseSyncMap sync.Map // map[string]*store.DatabaseMessage
 }
 
@@ -144,6 +147,20 @@ func (s *Syncer) Run(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 func (s *Syncer) trySyncAll(ctx context.Context) {
+	ran, err := s.leaderManager.TryRun(ctx, leader.SchemaSync, func(leaderCtx context.Context) error {
+		s.syncAll(leaderCtx)
+		return nil
+	})
+	if err != nil {
+		slog.Error("Failed to run schema syncer as leader", log.BBError(err))
+		return
+	}
+	if !ran {
+		slog.Debug("Schema syncer leadership held by another replica, skipping")
+	}
+}
+
+func (s *Syncer) syncAll(ctx context.Context) {
 	defer func() {
 		if r := recover(); r != nil {
 			err, ok := r.(error)
@@ -151,21 +168,6 @@ func (s *Syncer) trySyncAll(ctx context.Context) {
 				err = errors.Errorf("%v", r)
 			}
 			slog.Error("Instance syncer PANIC RECOVER", log.BBError(err), log.BBStack("panic-stack"))
-		}
-	}()
-
-	lock, acquired, err := store.TryAdvisoryLock(ctx, s.store.GetDB(), store.AdvisoryLockKeySchemaSyncer)
-	if err != nil {
-		slog.Error("Failed to acquire schema syncer advisory lock", log.BBError(err))
-		return
-	}
-	if !acquired {
-		slog.Debug("Schema syncer advisory lock held by another replica, skipping")
-		return
-	}
-	defer func() {
-		if err := lock.Release(); err != nil {
-			slog.Error("Failed to release schema syncer advisory lock", log.BBError(err))
 		}
 	}()
 

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/component/dbfactory"
 	"github.com/bytebase/bytebase/backend/component/iam"
+	"github.com/bytebase/bytebase/backend/component/leader"
 	"github.com/bytebase/bytebase/backend/component/review"
 	"github.com/bytebase/bytebase/backend/component/sampleinstance"
 	"github.com/bytebase/bytebase/backend/component/sheet"
@@ -60,6 +61,7 @@ type Server struct {
 	taskScheduler      *taskrun.Scheduler
 	planCheckScheduler *plancheck.Scheduler
 	schemaSyncer       *schemasync.Syncer
+	leaderManager      *leader.Manager
 	approvalRunner     *review.Runner
 	notifyListener     *notifylistener.Listener
 	dataCleaner        *cleaner.DataCleaner
@@ -209,11 +211,12 @@ func NewServer(ctx context.Context, profile *config.Profile) (*Server, error) {
 	}
 	s.webhookManager = webhook.NewManager(stores, profile)
 	s.dbFactory = dbfactory.New(s.store, s.licenseService)
+	s.leaderManager = leader.NewManager(stores, profile.ReplicaID)
 
 	// Configure echo server.
 	s.echoServer = echo.New()
 
-	s.schemaSyncer = schemasync.NewSyncer(stores, s.dbFactory, s.licenseService)
+	s.schemaSyncer = schemasync.NewSyncer(stores, s.dbFactory, s.licenseService, s.leaderManager)
 	s.approvalRunner = review.NewRunner(stores, s.bus, s.webhookManager, s.licenseService)
 
 	s.taskScheduler = taskrun.NewScheduler(stores, s.bus, s.webhookManager, s.licenseService, profile)

--- a/backend/store/advisory_lock.go
+++ b/backend/store/advisory_lock.go
@@ -17,9 +17,6 @@ const (
 	// AdvisoryLockKeyMigration is used by the schema migrator to ensure only
 	// one replica runs database migrations at a time.
 	AdvisoryLockKeyMigration AdvisoryLockKey = 1002
-	// AdvisoryLockKeySchemaSyncer is used by the schema syncer to ensure only
-	// one replica runs periodic schema sync at a time.
-	AdvisoryLockKeySchemaSyncer AdvisoryLockKey = 1003
 	// AdvisoryLockKeyVCSProviderUser is used as the namespace for active VCS
 	// provider user limit checks and upserts.
 	AdvisoryLockKeyVCSProviderUser AdvisoryLockKey = 1004
@@ -33,35 +30,6 @@ const (
 func AcquirePlanIssueRolloutAdvisoryLock(ctx context.Context, tx *sql.Tx, projectID string, planUID int64) error {
 	key := projectID + "/" + strconv.FormatInt(planUID, 10)
 	return AcquireAdvisoryXactLockWithStringKey(ctx, tx, AdvisoryLockKeyPlanIssueRollout, key)
-}
-
-// AdvisoryLock holds a dedicated connection for a session-level advisory lock.
-type AdvisoryLock struct {
-	conn *sql.Conn
-	key  AdvisoryLockKey
-}
-
-// TryAdvisoryLock attempts to acquire a session-level advisory lock using a
-// dedicated connection. Returns (lock, true) if acquired, (nil, false) if
-// already held by another session. Caller must call lock.Release() when done.
-func TryAdvisoryLock(ctx context.Context, db *sql.DB, key AdvisoryLockKey) (*AdvisoryLock, bool, error) {
-	conn, err := db.Conn(ctx)
-	if err != nil {
-		return nil, false, err
-	}
-
-	var acquired bool
-	if err := conn.QueryRowContext(ctx, "SELECT pg_try_advisory_lock($1)", int64(key)).Scan(&acquired); err != nil {
-		conn.Close()
-		return nil, false, err
-	}
-
-	if !acquired {
-		conn.Close()
-		return nil, false, nil
-	}
-
-	return &AdvisoryLock{conn: conn, key: key}, true, nil
 }
 
 // TryAdvisoryXactLock attempts to acquire a transaction-level advisory lock.
@@ -101,33 +69,4 @@ func AcquireAdvisoryXactLock(ctx context.Context, tx *sql.Tx, key AdvisoryLockKe
 func AcquireAdvisoryXactLockWithStringKey(ctx context.Context, tx *sql.Tx, namespace AdvisoryLockKey, key string) error {
 	_, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock($1, hashtext($2))", int32(namespace), key)
 	return err
-}
-
-// Release releases the advisory lock and returns the connection to the pool.
-// Uses context.Background() to ensure cleanup completes even if parent ctx is cancelled.
-func (l *AdvisoryLock) Release() error {
-	if l.conn == nil {
-		return nil
-	}
-	// Unlock then close; closing also releases but explicit unlock is cleaner
-	_, _ = l.conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", int64(l.key))
-	return l.conn.Close()
-}
-
-// AcquireAdvisoryLock acquires a session-level advisory lock, blocking until
-// the lock is available. Caller must call lock.Release() when done.
-// This is useful for migrations where we want to wait rather than fail fast.
-func AcquireAdvisoryLock(ctx context.Context, db *sql.DB, key AdvisoryLockKey) (*AdvisoryLock, error) {
-	conn, err := db.Conn(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// pg_advisory_lock blocks until the lock is acquired
-	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", int64(key)); err != nil {
-		conn.Close()
-		return nil, err
-	}
-
-	return &AdvisoryLock{conn: conn, key: key}, nil
 }

--- a/backend/store/leader_lease.go
+++ b/backend/store/leader_lease.go
@@ -1,0 +1,99 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+const schemaSyncLeaderLeaseType = "SCHEMA_SYNC"
+
+// TryAcquireLeaderLease acquires an expired or previously unclaimed leader lease.
+func (s *Store) TryAcquireLeaderLease(ctx context.Context, leaderType string, replicaID string, ttl time.Duration) (int64, bool, error) {
+	if err := validateLeaderLeaseType(leaderType); err != nil {
+		return 0, false, err
+	}
+
+	const query = `
+		INSERT INTO leader_lease (type, replica_id, generation, expires_at)
+		VALUES ($1, $2, 1, clock_timestamp() + $3::interval)
+		ON CONFLICT (type) DO UPDATE
+		SET replica_id = EXCLUDED.replica_id,
+			generation = leader_lease.generation + 1,
+			expires_at = clock_timestamp() + $3::interval
+		WHERE leader_lease.expires_at <= clock_timestamp()
+		RETURNING generation
+	`
+
+	var generation int64
+	err := s.GetDB().QueryRowContext(ctx, query, leaderType, replicaID, ttl.String()).Scan(&generation)
+	if err == sql.ErrNoRows {
+		return 0, false, nil
+	}
+	if err != nil {
+		return 0, false, errors.Wrap(err, "try acquire leader lease")
+	}
+	return generation, true, nil
+}
+
+// RenewLeaderLease extends the lease only for its current, unexpired generation.
+func (s *Store) RenewLeaderLease(ctx context.Context, leaderType string, replicaID string, generation int64, ttl time.Duration) (bool, error) {
+	if err := validateLeaderLeaseType(leaderType); err != nil {
+		return false, err
+	}
+
+	const query = `
+		UPDATE leader_lease
+		SET expires_at = clock_timestamp() + $4::interval
+		WHERE type = $1
+			AND replica_id = $2
+			AND generation = $3
+			AND expires_at > clock_timestamp()
+		RETURNING generation
+	`
+
+	var renewedGeneration int64
+	err := s.GetDB().QueryRowContext(ctx, query, leaderType, replicaID, generation, ttl.String()).Scan(&renewedGeneration)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.Wrap(err, "renew leader lease")
+	}
+	return true, nil
+}
+
+// ReleaseLeaderLease expires the lease while retaining its current generation.
+func (s *Store) ReleaseLeaderLease(ctx context.Context, leaderType string, replicaID string, generation int64) (bool, error) {
+	if err := validateLeaderLeaseType(leaderType); err != nil {
+		return false, err
+	}
+
+	const query = `
+		UPDATE leader_lease
+		SET expires_at = clock_timestamp()
+		WHERE type = $1
+			AND replica_id = $2
+			AND generation = $3
+		RETURNING generation
+	`
+
+	var releasedGeneration int64
+	err := s.GetDB().QueryRowContext(ctx, query, leaderType, replicaID, generation).Scan(&releasedGeneration)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, errors.Wrap(err, "release leader lease")
+	}
+	return true, nil
+}
+
+func validateLeaderLeaseType(leaderType string) error {
+	if leaderType != schemaSyncLeaderLeaseType {
+		return errors.Errorf("unsupported leader lease type %q", leaderType)
+	}
+	return nil
+}

--- a/backend/store/leader_lease_test.go
+++ b/backend/store/leader_lease_test.go
@@ -1,0 +1,267 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+
+	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
+)
+
+const schemaSyncLeaderType = "SCHEMA_SYNC"
+
+func TestLeaderLease(t *testing.T) {
+	ctx := context.Background()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	newStore := func(t *testing.T) *store.Store {
+		t.Helper()
+		leaseStore, err := store.New(ctx, pgURL, false)
+		require.NoError(t, err)
+		t.Cleanup(func() { require.NoError(t, leaseStore.Close()) })
+		return leaseStore
+	}
+
+	reset := func(t *testing.T) {
+		t.Helper()
+		_, err := db.ExecContext(ctx, "DELETE FROM leader_lease")
+		require.NoError(t, err)
+	}
+
+	t.Run("acquire, renew, and contend", func(t *testing.T) {
+		reset(t)
+		generation, acquired, err := s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-a", time.Second)
+		require.NoError(t, err)
+		require.True(t, acquired)
+		require.EqualValues(t, 1, generation)
+
+		generation, acquired, err = s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-a", time.Second)
+		require.NoError(t, err)
+		require.False(t, acquired, "an unexpired lease contends even for its current holder")
+		require.Zero(t, generation)
+
+		generation, acquired, err = s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-b", time.Second)
+		require.NoError(t, err)
+		require.False(t, acquired)
+		require.Zero(t, generation)
+
+		renewed, err := s.RenewLeaderLease(ctx, schemaSyncLeaderType, "replica-a", 1, time.Second)
+		require.NoError(t, err)
+		require.True(t, renewed)
+
+		var holder string
+		var storedGeneration int64
+		require.NoError(t, db.QueryRowContext(ctx, "SELECT replica_id, generation FROM leader_lease WHERE type = $1", schemaSyncLeaderType).Scan(&holder, &storedGeneration))
+		require.Equal(t, "replica-a", holder)
+		require.EqualValues(t, 1, storedGeneration, "renewing must preserve the generation")
+	})
+
+	t.Run("release retains the row and permits an immediate takeover", func(t *testing.T) {
+		reset(t)
+		generation, acquired, err := s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-a", time.Second)
+		require.NoError(t, err)
+		require.True(t, acquired)
+		require.EqualValues(t, 1, generation)
+
+		released, err := s.ReleaseLeaderLease(ctx, schemaSyncLeaderType, "replica-a", generation)
+		require.NoError(t, err)
+		require.True(t, released)
+
+		generation, acquired, err = s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-b", time.Second)
+		require.NoError(t, err)
+		require.True(t, acquired)
+		require.EqualValues(t, 2, generation)
+
+		var holder string
+		var storedGeneration int64
+		require.NoError(t, db.QueryRowContext(ctx, "SELECT replica_id, generation FROM leader_lease WHERE type = $1", schemaSyncLeaderType).Scan(&holder, &storedGeneration))
+		require.Equal(t, "replica-b", holder)
+		require.EqualValues(t, 2, storedGeneration)
+	})
+
+	t.Run("stale and non-holder generations cannot renew or release", func(t *testing.T) {
+		reset(t)
+		generation, acquired, err := s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-a", time.Second)
+		require.NoError(t, err)
+		require.True(t, acquired)
+
+		renewed, err := s.RenewLeaderLease(ctx, schemaSyncLeaderType, "replica-b", generation, time.Second)
+		require.NoError(t, err)
+		require.False(t, renewed)
+		released, err := s.ReleaseLeaderLease(ctx, schemaSyncLeaderType, "replica-b", generation)
+		require.NoError(t, err)
+		require.False(t, released)
+
+		_, err = db.ExecContext(ctx, "UPDATE leader_lease SET expires_at = clock_timestamp() - interval '1 second' WHERE type = $1", schemaSyncLeaderType)
+		require.NoError(t, err)
+		renewed, err = s.RenewLeaderLease(ctx, schemaSyncLeaderType, "replica-a", 1, time.Second)
+		require.NoError(t, err)
+		require.False(t, renewed, "an expired lease cannot be renewed")
+		released, err = s.ReleaseLeaderLease(ctx, schemaSyncLeaderType, "replica-a", 1)
+		require.NoError(t, err)
+		require.True(t, released, "release must match the current generation even after expiry")
+		generation, acquired, err = s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-a", time.Second)
+		require.NoError(t, err)
+		require.True(t, acquired)
+		require.EqualValues(t, 2, generation, "the same replica takes an expired lease with a new generation")
+
+		renewed, err = s.RenewLeaderLease(ctx, schemaSyncLeaderType, "replica-a", 1, time.Second)
+		require.NoError(t, err)
+		require.False(t, renewed)
+		released, err = s.ReleaseLeaderLease(ctx, schemaSyncLeaderType, "replica-a", 1)
+		require.NoError(t, err)
+		require.False(t, released)
+	})
+
+	t.Run("subsecond ttl is not truncated", func(t *testing.T) {
+		reset(t)
+		generation, acquired, err := s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-a", 900*time.Millisecond)
+		require.NoError(t, err)
+		require.True(t, acquired)
+		require.EqualValues(t, 1, generation)
+
+		var remainingSeconds float64
+		require.NoError(t, db.QueryRowContext(ctx, "SELECT EXTRACT(EPOCH FROM expires_at - clock_timestamp()) FROM leader_lease WHERE type = $1", schemaSyncLeaderType).Scan(&remainingSeconds))
+		require.Positive(t, remainingSeconds, "the TTL must retain subsecond precision")
+	})
+
+	t.Run("lease lifecycle spans independent database pools", func(t *testing.T) {
+		reset(t)
+		acquirer := newStore(t)
+		renewer := newStore(t)
+		releaser := newStore(t)
+		takeover := newStore(t)
+
+		generation, acquired, err := acquirer.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-a", time.Second)
+		require.NoError(t, err)
+		require.True(t, acquired)
+		require.EqualValues(t, 1, generation)
+
+		renewed, err := renewer.RenewLeaderLease(ctx, schemaSyncLeaderType, "replica-a", generation, time.Second)
+		require.NoError(t, err)
+		require.True(t, renewed)
+
+		released, err := releaser.ReleaseLeaderLease(ctx, schemaSyncLeaderType, "replica-a", generation)
+		require.NoError(t, err)
+		require.True(t, released)
+
+		generation, acquired, err = takeover.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-b", time.Second)
+		require.NoError(t, err)
+		require.True(t, acquired)
+		require.EqualValues(t, 2, generation)
+	})
+
+	t.Run("invalid leader type fails before database access", func(t *testing.T) {
+		invalidStore := &store.Store{}
+		_, _, err := invalidStore.TryAcquireLeaderLease(ctx, "", "replica-a", time.Second)
+		require.Error(t, err)
+		_, _, err = invalidStore.TryAcquireLeaderLease(ctx, "OTHER", "replica-a", time.Second)
+		require.Error(t, err)
+		_, err = invalidStore.RenewLeaderLease(ctx, "OTHER", "replica-a", 1, time.Second)
+		require.Error(t, err)
+		_, err = invalidStore.ReleaseLeaderLease(ctx, "OTHER", "replica-a", 1)
+		require.Error(t, err)
+	})
+
+	t.Run("two first acquirers use distinct pooled connections and elect one leader", func(t *testing.T) {
+		reset(t)
+		s.GetDB().SetMaxOpenConns(2)
+		defer s.GetDB().SetMaxOpenConns(0)
+		assertRaceOneWinner(ctx, t, db, func() (int64, bool, error) {
+			return s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-a", time.Second)
+		}, func() (int64, bool, error) {
+			return s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-b", time.Second)
+		})
+	})
+
+	t.Run("two expired takeovers elect one next generation", func(t *testing.T) {
+		reset(t)
+		_, err := db.ExecContext(ctx, `
+			INSERT INTO leader_lease (type, replica_id, generation, expires_at)
+			VALUES ($1, 'expired-replica', 41, clock_timestamp() - interval '1 second')
+		`, schemaSyncLeaderType)
+		require.NoError(t, err)
+		s.GetDB().SetMaxOpenConns(2)
+		defer s.GetDB().SetMaxOpenConns(0)
+		assertRaceOneWinner(ctx, t, db, func() (int64, bool, error) {
+			return s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-a", time.Second)
+		}, func() (int64, bool, error) {
+			return s.TryAcquireLeaderLease(ctx, schemaSyncLeaderType, "replica-b", time.Second)
+		})
+
+		var generation int64
+		require.NoError(t, db.QueryRowContext(ctx, "SELECT generation FROM leader_lease WHERE type = $1", schemaSyncLeaderType).Scan(&generation))
+		require.EqualValues(t, 42, generation)
+	})
+}
+
+func assertRaceOneWinner(ctx context.Context, t *testing.T, db *sql.DB, first, second func() (int64, bool, error)) {
+	t.Helper()
+	lockTx, err := db.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer lockTx.Rollback()
+	_, err = lockTx.ExecContext(ctx, "LOCK TABLE leader_lease IN ACCESS EXCLUSIVE MODE")
+	require.NoError(t, err)
+
+	type result struct {
+		generation int64
+		acquired   bool
+		err        error
+	}
+	results := make(chan result, 2)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, acquire := range []func() (int64, bool, error){first, second} {
+		wg.Go(func() {
+			<-start
+			generation, acquired, err := acquire()
+			results <- result{generation: generation, acquired: acquired, err: err}
+		})
+	}
+	close(start)
+
+	require.Eventually(t, func() bool {
+		var waiting int
+		err := db.QueryRowContext(ctx, `
+			SELECT count(*)
+			FROM pg_stat_activity
+			WHERE datname = current_database()
+			  AND wait_event_type = 'Lock'
+			  AND query LIKE '%leader_lease%'
+		`).Scan(&waiting)
+		return err == nil && waiting >= 2
+	}, 2*time.Second, 10*time.Millisecond, "both acquirers must be observed blocked on PostgreSQL")
+
+	require.NoError(t, lockTx.Commit())
+	wg.Wait()
+	close(results)
+
+	wins := 0
+	for result := range results {
+		require.NoError(t, result.err)
+		if result.acquired {
+			wins++
+		}
+	}
+	require.Equal(t, 1, wins)
+}

--- a/docs/adr/0002-stage-leader-resource-migrations.md
+++ b/docs/adr/0002-stage-leader-resource-migrations.md
@@ -1,0 +1,13 @@
+# Stage leader-resource migrations across two releases
+
+Changing a responsibility from a global Leader Type to a distinct concrete-resource Leader Type changes which replicas may work concurrently, so mixed behavior during an HA rolling upgrade could violate mutual exclusion. The accepted path therefore separates compatibility from activation.
+
+The compatibility release adds a non-null `resource` column with default `global` and a composite uniqueness constraint on Leader Type and resource. It retains the existing type-only uniqueness constraint and continues global behavior only. It must understand and safely honor the later protocol, but must not enable any concrete-resource Leader Types.
+
+Only the subsequent activation release removes the type-only uniqueness constraint. After that removal, it may enable concrete-resource Leader Types. This favors safe mixed-version operation and rollback over activating the new behavior in the release that first introduces it.
+
+## Consequences
+
+- Each Leader Type retains one resource kind; concrete-resource behavior uses a distinct type rather than broadening a global type in place.
+- The compatibility release retains both uniqueness constraints and performs global work only.
+- The activation release removes type-only uniqueness before enabling concrete-resource Leader Types, and still needs a defined drain and rollback sequence.

--- a/docs/adr/0003-use-row-leases-for-leader-coordination.md
+++ b/docs/adr/0003-use-row-leases-for-leader-coordination.md
@@ -1,0 +1,13 @@
+# Use row leases for leader coordination
+
+Bytebase will coordinate singleton background responsibilities with PostgreSQL rows instead of session advisory locks because PgBouncer transaction pooling does not preserve session affinity. The `leader` component will use short acquire, renew, and release statements against `leader_lease`, while callbacks run outside transactions; schema sync is the first Leader Type and retains its existing per-pass coordination boundary.
+
+## Consequences
+
+- V1 stores one row per Leader Type with the last replica ID, a monotonic generation, and an expiration evaluated with PostgreSQL `clock_timestamp()`, never replica wall clocks. A future Leader Resource column requires the staged migration in ADR-0002.
+- Expired and released rows persist, retaining the last holder and generation; a later acquisition advances the generation.
+- A successful lease is valid in PostgreSQL for 30 seconds, renews every 10 seconds, and is treated as locally invalid 10 seconds before database expiry.
+- Generation protects renewal and release inside the component. V1 does not expose terms for side-effect fencing, add Prometheus metrics, or terminate replicas whose callbacks fail to stop.
+- Schema sync uses the one-shot `TryRun` callback API, preserving current contention, cancellation, and best-effort side-effect semantics.
+- Lease coordination has no heartbeat foreign key or lifecycle coupling.
+- The obsolete session advisory-lock API is removed; transaction-scoped advisory locks remain available for short transactions and schema migration.


### PR DESCRIPTION
## Summary

- replace the schema-sync session advisory lock with a PostgreSQL row lease that works through transaction-pooled connections
- add one-shot leader lifecycle management with renewal, conservative local validity, cooperative cancellation, draining, and guarded release
- add migration, real-PostgreSQL race coverage, deterministic lifecycle tests, and the leadership glossary and ADRs

## Testing

- `golangci-lint run --allow-parallel-runners`
- `go test -count=3 ./backend/store -run ^TestLeaderLease$`
- `go test -count=1 ./backend/component/leader`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `go test -count=1 ./...` passed in the initial full run; the final concurrent rerun hit testcontainer port-discovery failures in five unrelated tests, all of which passed when rerun sequentially

## Issue

- [BOT-29](https://linear.app/bytebase/issue/BOT-29/replace-schema-sync-session-lock-with-postgresql-leader-lease)