### PR TITLE
fix(frontend): hide Monaco iPad keyboard overlay

### DIFF
--- a/frontend/src/components/monaco/core.test.ts
+++ b/frontend/src/components/monaco/core.test.ts
@@ -7,13 +7,32 @@ import {
 
 const mocks = vi.hoisted(() => {
   const readOnlyContribution = { dispose: vi.fn() };
+  const editorIPadKeyboardContribution = { dispose: vi.fn() };
+  const originalEditorIPadKeyboardContribution = { dispose: vi.fn() };
+  const modifiedEditorIPadKeyboardContribution = { dispose: vi.fn() };
   const editor = {
-    getContribution: vi.fn(() => readOnlyContribution),
+    getContribution: vi.fn((id: string) =>
+      id === "editor.contrib.iPadShowKeyboard"
+        ? editorIPadKeyboardContribution
+        : readOnlyContribution
+    ),
+  };
+  const originalEditor = {
+    getContribution: vi.fn((id: string) =>
+      id === "editor.contrib.iPadShowKeyboard"
+        ? originalEditorIPadKeyboardContribution
+        : readOnlyContribution
+    ),
   };
   const modifiedEditor = {
-    getContribution: vi.fn(() => readOnlyContribution),
+    getContribution: vi.fn((id: string) =>
+      id === "editor.contrib.iPadShowKeyboard"
+        ? modifiedEditorIPadKeyboardContribution
+        : readOnlyContribution
+    ),
   };
   const diffEditor = {
+    getOriginalEditor: vi.fn(() => originalEditor),
     getModifiedEditor: vi.fn(() => modifiedEditor),
   };
   const monaco = {
@@ -30,8 +49,12 @@ const mocks = vi.hoisted(() => {
   return {
     diffEditor,
     editor,
+    editorIPadKeyboardContribution,
     modifiedEditor,
+    modifiedEditorIPadKeyboardContribution,
     monaco,
+    originalEditor,
+    originalEditorIPadKeyboardContribution,
     readOnlyContribution,
   };
 });
@@ -92,6 +115,32 @@ describe("monaco core", () => {
         editContext: false,
       })
     );
+  });
+
+  test("disables the iPad keyboard overlay for standalone editors", async () => {
+    await createMonacoEditor({ container: document.createElement("div") });
+
+    expect(mocks.editor.getContribution).toHaveBeenCalledWith(
+      "editor.contrib.iPadShowKeyboard"
+    );
+    expect(mocks.editorIPadKeyboardContribution.dispose).toHaveBeenCalledOnce();
+  });
+
+  test("disables the iPad keyboard overlay for both diff editors", async () => {
+    await createMonacoDiffEditor({ container: document.createElement("div") });
+
+    expect(mocks.originalEditor.getContribution).toHaveBeenCalledWith(
+      "editor.contrib.iPadShowKeyboard"
+    );
+    expect(mocks.modifiedEditor.getContribution).toHaveBeenCalledWith(
+      "editor.contrib.iPadShowKeyboard"
+    );
+    expect(
+      mocks.originalEditorIPadKeyboardContribution.dispose
+    ).toHaveBeenCalledOnce();
+    expect(
+      mocks.modifiedEditorIPadKeyboardContribution.dispose
+    ).toHaveBeenCalledOnce();
   });
 
   test("getResolvedTheme allows enumerated themes and falls back by type", async () => {

--- a/frontend/src/components/monaco/core.ts
+++ b/frontend/src/components/monaco/core.ts
@@ -80,6 +80,12 @@ export const isMonacoLoaded = (): boolean => {
   return monacoModule !== undefined;
 };
 
+const disableIPadShowKeyboard = (
+  editor: MonacoType.editor.IStandaloneCodeEditor
+) => {
+  editor.getContribution("editor.contrib.iPadShowKeyboard")?.dispose();
+};
+
 export const createMonacoEditor = async (config: {
   container: HTMLElement;
   options?: MonacoType.editor.IStandaloneEditorConstructionOptions;
@@ -98,6 +104,7 @@ export const createMonacoEditor = async (config: {
   });
 
   editor.getContribution("editor.contrib.readOnlyMessageController")?.dispose();
+  disableIPadShowKeyboard(editor);
   monacoEditorReadyDefer.resolve();
   return editor;
 };
@@ -119,10 +126,13 @@ export const createMonacoDiffEditor = async (config: {
     ...config.options,
   });
 
-  editor
-    .getModifiedEditor()
+  const originalEditor = editor.getOriginalEditor();
+  const modifiedEditor = editor.getModifiedEditor();
+  modifiedEditor
     .getContribution("editor.contrib.readOnlyMessageController")
     ?.dispose();
+  disableIPadShowKeyboard(originalEditor);
+  disableIPadShowKeyboard(modifiedEditor);
   monacoEditorReadyDefer.resolve();
   return editor;
 };


### PR DESCRIPTION
## Summary
- Prevent Monaco’s iPad keyboard overlay from appearing in Bytebase editors.

## Key Changes
- Dispose the built-in iPad keyboard contribution in the shared Monaco factory.
- Apply the behavior to standalone editors and both sides of diff editors.
- Add regression tests for standalone and diff editor creation.

## Motivation
- Avoid the oversized keyboard control occupying SQL editing surfaces on iOS-class devices.

<img width="2284" height="370" alt="image" src="https://github.com/user-attachments/assets/b58eb0f7-8369-4f9d-a7ec-6da698421350" />

## Testing
- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm -C frontend exec vitest run src/components/monaco/core.test.ts`
- `pnpm --dir frontend test`
- `git diff --check`