### PR TITLE
chore: hold root google.golang.org/genproto until spanner catches up

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -72,6 +72,11 @@
       "matchUpdateTypes": ["major"],
       "enabled": false,
       "description": "v10 dropped the browser-field mapping on the root export, so `import \"vscode-languageclient\"` loads the common build and the browser RAL is never installed — the LSP client dies with 'No runtime abstraction layer installed'. Re-enable after migrating imports to vscode-languageclient/browser and verifying LSP in a real browser."
+    },
+    {
+      "matchPackageNames": ["google.golang.org/genproto"],
+      "enabled": false,
+      "description": "Revisions after 0afa2a65878a delete the bigtable, datastore, firestore, pubsub and spanner package trees, which moved into the per-product client libraries with no split-out genproto module replacing them. cloud.google.com/go/spanner still requires an older genproto and test-imports genproto/googleapis/spanner/admin/database/v1, so `go mod tidy` cannot resolve the graph and fails outright. Re-enable once cloud.google.com/go/spanner drops the deleted packages. This pins only the root module — googleapis/api and googleapis/rpc are separate modules, lost nothing, and keep updating."
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
## What

Disables Renovate updates for the root `google.golang.org/genproto` module. Scoped by exact package name, so `googleapis/api` and `googleapis/rpc` — separate modules — keep updating normally.

## Why

Revisions after `0afa2a65878a` delete the `bigtable`, `datastore`, `firestore`, `pubsub` and `spanner` package trees from the root module. Those protos moved into the per-product client libraries, and no split-out genproto module replaces them (the proxy 404s `genproto/googleapis/spanner/admin/database`).

`cloud.google.com/go/spanner` v1.93.0 — the latest release — still requires an older genproto and test-imports the removed path, so `go mod tidy` cannot resolve the graph and fails outright:

```
go: finding module for package google.golang.org/genproto/googleapis/spanner/admin/database/v1
    backend/plugin/db/spanner imports
    cloud.google.com/go/spanner/admin/database/apiv1 tested by
    cloud.google.com/go/spanner/admin/database/apiv1.test imports
    google.golang.org/genproto/googleapis/spanner/admin/database/v1
```

#21025 worked around this by holding the root module and taking the bump only for `googleapis/api`/`googleapis/rpc`. Renovate immediately re-proposed the root-only bump as #21037, which fails `go-tests`, `golangci-lint` and `renovate/artifacts` the same way. Without this rule it will keep recurring.

Follows the existing `@vitejs/plugin-legacy` and `vscode-languageclient` precedent in this file. Re-enable once `cloud.google.com/go/spanner` drops the deleted packages.

## Testing

- `renovate-config-validator` reports the same 8 pre-existing errors before and after this change (version skew in the npx-fetched validator, unrelated to `packageRules`), and zero errors mentioning `matchPackageNames`/`packageRules`.
- JSON parses; rule ordering verified — the new exact-name rule follows the existing regex grouping rule, so `enabled: false` wins for the root module only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)