### PR TITLE
chore: fix Renovate config warnings, lookup failures, and restore a monthly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "schedule:monthly"],
   "postUpdateOptions": ["gomodTidy", "pnpmDedupe"],
   "customManagers": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "schedule": ["* * 31 2 *"],
   "postUpdateOptions": ["gomodTidy", "pnpmDedupe"],
-  "allowedCommands": ["^pnpm install --no-frozen-lockfile$"],
   "customManagers": [
     {
       "customType": "regex",
@@ -80,7 +78,9 @@
     }
   ],
   "ignoreDeps": [
+    "github.com/pingcap/tidb",
     "github.com/pingcap/tidb/pkg/parser",
+    "github.com/form3tech-oss/jwt-go",
     "github.com/elastic/go-elasticsearch/v7",
     "typescript-6"
   ]


### PR DESCRIPTION
Fixes all three repository problems reported on the Mend dashboard and the dependency dashboard (#2527).

## 1. `⚠️ Invalid cron schedule. No next run is possible`

`"schedule": ["* * 31 2 *"]` asks for **February 31st**. `cron-parser` — the parser Renovate uses — rejects it outright:

```
"* 0-3 1 * *"  -> next: 2026-08-01T07:00 | 2026-08-01T07:01
"* * 31 2 *"   -> NO NEXT RUN: Invalid explicit day of month definition
```

Renovate therefore discards the schedule and runs **unrestricted**, which is why this repo sees a continuous stream of dependency PRs.

Replaced with the built-in `schedule:monthly` preset, which expands to `["* 0-3 1 * *"]` — the 1st of each month, 00:00–03:59.

**Worth knowing:** the value that preceded this cron in #15531 was the literal string `"every month"`, and that is *also* invalid — `@breejs/later` rejects it at character 6. So this repo has never had a working Renovate schedule for as long as the key has been set; the flow of PRs has been unrestricted throughout. Using the named preset avoids hand-rolling a cron or later phrase that silently fails to parse.

## 2. `⚠️ Found renovate config warnings`

```
The "allowedCommands" option is a global option reserved only for Renovate's
global configuration and cannot be configured within a repository's config file.
```

`allowedCommands` was the permission slip for the `postUpgradeTasks` command (`pnpm install --no-frozen-lockfile`): Renovate will not run a shell command unless it is allowlisted, precisely so a repo cannot authorize arbitrary code on a shared runner. Because that allowlist is admin-only, Renovate ignored the line and warned. Removing it changes no behavior.

Two consequences: the `postUpgradeTasks` block it was meant to authorize was likely never permitted to run either, and nothing is lost by removal — lockfile maintenance is handled natively by Renovate's pnpm support (see #21035, #21031, #21027, which all updated `frontend/pnpm-lock.yaml`). I left that block in place; confirming whether it executes needs visibility into Mend's global config, and it may be related to the recurring `renovate/artifacts` failures.

## 3. `⚠️ Package lookup failures`

```
Could not determine new digest for update (go package github.com/pingcap/tidb)
Could not determine new digest for update (go package github.com/form3tech-oss/jwt-go)
```

Both are `replace` targets in `go.mod` pinned to pseudo-versions:

```
github.com/pingcap/tidb     => github.com/bytebase/tidb v0.0.0-20251104040057-d29df9dd1b3b
github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.6-0.20210809144907-32ab6a8243d7+incompatible
```

Renovate cannot resolve new digests through those redirects. Added both to `ignoreDeps`, alongside the existing `github.com/pingcap/tidb/pkg/parser` entry — the same replace pair, already ignored for the same reason.

## Testing

- `renovate-config-validator` pinned to **43.280.0** (the version Mend reports for this repo), run with no arguments so it validates as *repository* config: `WARN: Found errors in configuration` before, `INFO: Config validated successfully` after. Validation mode matters — passing the filename explicitly validates it as *global* config, where `allowedCommands` is legal and the warning never appears.
- Schedule expressions checked directly against `cron-parser` and `@breejs/later` (with Renovate's `fixShortHours` preprocessing) to confirm the replacement yields real next runs and the old values do not.
- `customManagers`, `postUpdateOptions`, and all 12 `packageRules` verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)