### PR TITLE
chore: align Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bytebase/bytebase
 
-go 1.26.3
+go 1.26.5
 
 // workaround mssql-docker default TLS cert negative serial number problem
 // https://github.com/microsoft/mssql-docker/issues/895


### PR DESCRIPTION
## Summary
- align the module Go directive with CI, Docker images, and the build bootstrap script

## Testing
- go mod verify
- golangci-lint run --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go