### PR TITLE
chore: bump omni for PL/SQL labels, local subprograms, and MSSQL table variable constraints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260716044319-2538875143b8
+	github.com/bytebase/omni v0.0.0-20260727045020-25af7ffb855f
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,6 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260716044319-2538875143b8 h1:10hErnWw+t9H7+GlIZjqFy7oS4OQB5v6HK3ZBH+HXAg=
-github.com/bytebase/omni v0.0.0-20260716044319-2538875143b8/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/omni v0.0.0-20260727045020-25af7ffb855f h1:UXy4gAuQ26e6PJ1KJYIPHbXLi8LXpKO3VxCRCy4LKvM=
 github.com/bytebase/omni v0.0.0-20260727045020-25af7ffb855f/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=

--- a/go.sum
+++ b/go.sum
@@ -252,6 +252,8 @@ github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
 github.com/bytebase/omni v0.0.0-20260716044319-2538875143b8 h1:10hErnWw+t9H7+GlIZjqFy7oS4OQB5v6HK3ZBH+HXAg=
 github.com/bytebase/omni v0.0.0-20260716044319-2538875143b8/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260727045020-25af7ffb855f h1:UXy4gAuQ26e6PJ1KJYIPHbXLi8LXpKO3VxCRCy4LKvM=
+github.com/bytebase/omni v0.0.0-20260727045020-25af7ffb855f/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
Bumps omni to pick up the BYT-9909 fix series (bytebase/omni#390–#392), all engine-verified on Oracle 23ai / SQL Server 2019 across three review rounds:

- **PL/SQL statement labels** (`<<label>>`) — previously rejected entirely; customer statement 3's exact failure.
- **Local subprogram declarations** in PL/SQL declare sections — parameterized forms were rejected and the parameterless procedure form was silently mis-parsed into variable-declaration fragments (fail-open with garbage AST); customer files 001/002's exact failure.
- **MSSQL table-variable table-level constraints** — customer statement 6's remaining gap; the named-constraint prefix stays rejected matching the engine (Msg 156).

No consumer changes: Bytebase's Oracle advisors and span extraction use generic AST traversal (`ast.Inspect` / generated walker), which traverses the new `PLSQLLabeledStatement` and declaration-section subprogram nodes transparently — verified by running the label, local-subprogram, and nested-function shapes plus both customer files through `base.SplitMultiSQL` + `base.ParseStatements` end to end (zero errors).

With this bump, 4 of BYT-9909's 6 statements are fixed in Bytebase (statement 1 shipped earlier via #20922); ATMLOG statements 2/4/5 remain blocked on the customer's untruncated originals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)