### PR TITLE
store: recycle metadata DB connections after 5m

### DIFF
--- a/backend/store/db_connection.go
+++ b/backend/store/db_connection.go
@@ -315,6 +315,8 @@ func createConnectionWithTracer(ctx context.Context, pgURL string) (*metadataDBC
 		maxOpenConns = 50
 	}
 	db.SetMaxOpenConns(maxOpenConns)
+	db.SetConnMaxLifetime(5 * time.Minute)
+	db.SetMaxIdleConns(10)
 
 	return &metadataDBConnection{db: db, cleanup: cleanup}, nil
 }


### PR DESCRIPTION
## Symptom

In our deployment we've seen the metadata DB pool accumulate stale connections over time — sessions that Go's `database/sql` still considers healthy but that have been silently killed on the server or network path (LB idle timeout, Postgres `idle_session_timeout`, NAT rebinds, etc.). The first query on a stale connection then fails with a bad-connection error before `database/sql`'s retry kicks in.

## Root cause

`createConnectionWithTracer` in `backend/store/db_connection.go` configures `SetMaxOpenConns` but not `SetConnMaxLifetime` or `SetMaxIdleConns`. Without a max lifetime, pooled connections are never rotated, so once a connection goes stale server-side, it stays in the pool indefinitely.

For reference, the existing `reloadConnection` path (line 173) already uses `SetMaxIdleConns(0)` + `SetConnMaxLifetime(1 * time.Minute)` on the *outgoing* pool during PG_URL rotation, which shows the maintainers are aware of the mechanism. This PR extends the same idea to the steady-state pool.

## Fix

Add two lines after the existing `SetMaxOpenConns`:

```go
db.SetConnMaxLifetime(5 * time.Minute)
db.SetMaxIdleConns(10)
```

- **5-minute lifetime** bounds staleness with negligible reconnect churn (~12 refreshes/hour/connection at worst).
- **MaxIdleConns=10** prevents the pool from holding hundreds of idle connections when load drops.

## Notes / open questions for maintainers

- The values are opinionated. Happy to make them configurable via env vars / flags if that's preferred — just point me at the config pattern you'd like followed.
- `time` was already imported, no import changes.
- `gofmt` clean.
- No test changes: this is a pool tuning setting, not behavioral logic. Let me know if you'd like a covering test and where it should live.
- Did not run `golangci-lint` / full `go build` locally on this change — happy to iterate if CI flags anything.

## Reference

Existing precedent for the same API in this file: `backend/store/db_connection.go:173-174` (reload path).