### PR TITLE
chore: bump omni for Oracle comment splitting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260727045020-25af7ffb855f
+	github.com/bytebase/omni v0.0.0-20260728103305-d2f82de1b468
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260727045020-25af7ffb855f h1:UXy4gAuQ26e6PJ1KJYIPHbXLi8LXpKO3VxCRCy4LKvM=
-github.com/bytebase/omni v0.0.0-20260727045020-25af7ffb855f/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260728103305-d2f82de1b468 h1:p5Nm8fUYDwTyDHzv3GqzA1MZAFnDGhgrUWH49LYWgj8=
+github.com/bytebase/omni v0.0.0-20260728103305-d2f82de1b468/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
## Summary

- Bump `github.com/bytebase/omni` from `25af7ffb` to `d2f82de1`.
- Brings in omni #394, which matches Oracle's non-nested block comment semantics in the Oracle lexer/splitter.
- Fixes BYT-9963 customer shape where a package body containing `/* ... /* ... */` retained the SQL*Plus `/` delimiter and sent it to Oracle.

## Local validation before PR

Validated the full customer SQL file `/tmp/byt9963/001_pk_reissue.sql` through Bytebase's registered Oracle split/parse entry after the bump:

```text
split statements=2
split[0] bytes=23402 range=0-23402 empty=false slashTail=false
split[1] bytes=208574 range=23404-231978 empty=false slashTail=false
parsed statements=2
parsed[0] bytes=23402 ast=*plsql.OmniAST slashTail=false
parsed[1] bytes=208574 ast=*plsql.OmniAST slashTail=false
```

## Testing

- `go mod tidy`
- `go run /tmp/byt9963_full_parse.go`
- `go test ./backend/plugin/parser/plsql -count=1`
- `go test ./backend/plugin/db/oracle -count=1`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

## Issue

BYT-9963
