### PR TITLE
fix(issue): clarify disabled batch action tooltips

### DIFF
--- a/frontend/src/components/IssueTable.i18n.test.ts
+++ b/frontend/src/components/IssueTable.i18n.test.ts
@@ -1,0 +1,41 @@
+import i18next from "i18next";
+import { describe, expect, test } from "vitest";
+import enUS from "@/locales/en-US.json";
+import esES from "@/locales/es-ES.json";
+import jaJP from "@/locales/ja-JP.json";
+import viVN from "@/locales/vi-VN.json";
+import zhCN from "@/locales/zh-CN.json";
+
+const LOCALES = {
+  "en-US": enUS,
+  "zh-CN": zhCN,
+  "es-ES": esES,
+  "ja-JP": jaJP,
+  "vi-VN": viVN,
+} as const;
+
+describe("IssueTable locale interpolation", () => {
+  test.each(Object.entries(LOCALES))(
+    "interpolates the disabled batch action in %s",
+    (locale, translation) => {
+      const i18n = i18next.createInstance();
+
+      void i18n.init({
+        resources: {
+          [locale]: { translation },
+        },
+        lng: locale,
+        interpolation: {
+          escapeValue: false,
+        },
+        initAsync: false,
+      });
+
+      expect(
+        i18n.t("issue.batch-transition.not-allowed-tips", {
+          operation: "TRANSITION",
+        })
+      ).toContain("TRANSITION");
+    }
+  );
+});

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1372,7 +1372,7 @@
     "batch-transition": {
       "close": "Close",
       "closed": "closed",
-      "not-allowed-tips": "Some of selected issues cannot be {{}}",
+      "not-allowed-tips": "Some of the selected issues cannot be {{operation}}",
       "reopen": "Reopen",
       "reopened": "reopened"
     },

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1372,7 +1372,7 @@
     "batch-transition": {
       "close": "Cerrar",
       "closed": "cerrado",
-      "not-allowed-tips": "Algunos de las incidencias seleccionadas no se pueden {{}}",
+      "not-allowed-tips": "Algunos de las incidencias seleccionadas no se pueden {{operation}}",
       "reopen": "Reabrir",
       "reopened": "reabierto"
     },

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1372,7 +1372,7 @@
     "batch-transition": {
       "close": "閉じる",
       "closed": "閉まっている",
-      "not-allowed-tips": "選択したイシューの一部を {{}} にすることはできません",
+      "not-allowed-tips": "選択したイシューの一部を {{operation}} にすることはできません",
       "reopen": "再開",
       "reopened": "再開"
     },

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1372,7 +1372,7 @@
     "batch-transition": {
       "close": "Đóng",
       "closed": "đã đóng",
-      "not-allowed-tips": "Một số vấn đề đã chọn không thể {{}}",
+      "not-allowed-tips": "Một số vấn đề đã chọn không thể {{operation}}",
       "reopen": "Mở lại",
       "reopened": "đã mở lại"
     },

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1372,7 +1372,7 @@
     "batch-transition": {
       "close": "关闭",
       "closed": "关闭",
-      "not-allowed-tips": "部分选中的工单无法被{{}}",
+      "not-allowed-tips": "部分选中的工单无法被{{operation}}",
       "reopen": "重开",
       "reopened": "重开"
     },


### PR DESCRIPTION
## Summary

- Resolve [BYT-9966](https://linear.app/bytebase/issue/BYT-9966/issue-selected-disabled-buttons-with-confusing-text) by rendering the intended operation in disabled batch action tooltips.
- Keep the fix consistent across all supported locales.

## Key Changes

- Replace the unnamed issue batch-transition placeholder with the named `operation` interpolation value.
- Improve the English tooltip copy for selected issues.
- Add regression coverage for interpolation in all five locales.

## Motivation

Disabled Close and Reopen actions exposed a raw `{{}}` placeholder instead of explaining why some selected issues could not transition. Naming the interpolation value restores the existing closed or reopened operation in the tooltip.

## Testing

- `pnpm --dir frontend fix`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test` — 409 files, 3,318 tests passed
- `git diff --check`
