### PR TITLE
fix: gate the MCP settings section behind dev mode

### DIFF
--- a/frontend/src/routes/workspace/general/GeneralPage.tsx
+++ b/frontend/src/routes/workspace/general/GeneralPage.tsx
@@ -7,7 +7,7 @@ import { WorkspacePageLayout } from "@/components/WorkspacePageLayout";
 import { useServerState } from "@/hooks/useAppState";
 import { useUnsavedChangesGuard } from "@/hooks/useUnsavedChangesGuard";
 import { pushNotification } from "@/stores";
-import { hasWorkspacePermissionV2 } from "@/utils";
+import { hasWorkspacePermissionV2, isDev } from "@/utils";
 import { AccountSection } from "./AccountSection";
 import { AIAugmentationSection } from "./AIAugmentationSection";
 import { AnnouncementSection } from "./AnnouncementSection";
@@ -87,14 +87,16 @@ export function GeneralPage() {
         handle: aiRef.current!,
       },
       {
-        name: t("settings.general.workspace.mcp.self"),
-        handle: mcpRef.current!,
-      },
-      {
         name: t("settings.general.workspace.announcement.self"),
         handle: announcementRef.current!,
       },
     ];
+    if (mcpRef.current) {
+      sections.push({
+        name: t("settings.general.workspace.mcp.self"),
+        handle: mcpRef.current,
+      });
+    }
     if (productImprovementRef.current) {
       sections.push({
         name: t("settings.general.workspace.product-improvement.self"),
@@ -183,11 +185,15 @@ export function GeneralPage() {
         title={t("settings.general.workspace.ai-assistant.self")}
         onDirtyChange={onDirtyChange}
       />
-      <MCPSection
-        ref={mcpRef}
-        title={t("settings.general.workspace.mcp.self")}
-        onDirtyChange={onDirtyChange}
-      />
+      {/* Hidden in prod builds until release readiness; the settings API and
+          server-side enforcement stay live intentionally. */}
+      {isDev() && (
+        <MCPSection
+          ref={mcpRef}
+          title={t("settings.general.workspace.mcp.self")}
+          onDirtyChange={onDirtyChange}
+        />
+      )}
       <AnnouncementSection
         ref={announcementRef}
         title={t("settings.general.workspace.announcement.self")}


### PR DESCRIPTION
Reviewer-requested (pre-merge agreement): the MCP workspace-settings section is hidden in prod builds until release readiness; the settings API and server-side enforcement stay live intentionally.

- `GeneralPage.tsx`: the `<MCPSection>` render is wrapped in the standard `isDev()` guard, and its save-flow entry moves from the fixed sections array (`mcpRef.current!`) to the conditional-push pattern used by the other conditionally rendered sections — a prod build's save flow never dereferences the absent section handle.
- No test changes needed: the layout test reads section source files (unchanged) and the MCPSection unit tests target `normalizeCapability` — neither asserts runtime presence.
- Backend, API, and i18n content unchanged.

Frontend gates green on this exact content: Biome fix/check, structure guard, i18n checks, type-check, full suite 3342/3342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)