### PR TITLE
fix: require a concrete parent project in SearchQueryHistories

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -17868,8 +17868,8 @@ components:
           description: |-
             The parent project to search query histories in.
              Format: projects/{project}
-             Use "projects/-" to search across all projects
-             (https://google.aip.dev/159).
+             The AIP-159 wildcard "projects/-" is not supported; use
+             ListQueryHistories for cross-project reads.
         pageSize:
           type: integer
           title: page_size

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -1406,7 +1406,8 @@ func (s *SQLService) createQueryHistory(database *store.DatabaseMessage, queryTy
 }
 
 // SearchQueryHistories lists the caller's own query histories in the parent
-// project, or across all projects for the AIP-159 wildcard "projects/-".
+// project. The AIP-159 wildcard "projects/-" is rejected: cross-project reads
+// are reserved for the IAM-gated ListQueryHistories.
 func (s *SQLService) SearchQueryHistories(ctx context.Context, req *connect.Request[v1pb.SearchQueryHistoriesRequest]) (*connect.Response[v1pb.SearchQueryHistoriesResponse], error) {
 	request := req.Msg
 	user, ok := GetUserFromContext(ctx)
@@ -1415,7 +1416,7 @@ func (s *SQLService) SearchQueryHistories(ctx context.Context, req *connect.Requ
 	}
 
 	find := &store.FindQueryHistoryMessage{Creator: &user.Email}
-	if err := s.resolveQueryHistoryParent(ctx, request.Parent, find); err != nil {
+	if err := s.resolveQueryHistoryParent(ctx, request.Parent, find, false); err != nil {
 		return nil, err
 	}
 
@@ -1483,7 +1484,7 @@ func (s *SQLService) paginatedQueryHistories(ctx context.Context, find *store.Fi
 func (s *SQLService) ListQueryHistories(ctx context.Context, req *connect.Request[v1pb.ListQueryHistoriesRequest]) (*connect.Response[v1pb.ListQueryHistoriesResponse], error) {
 	request := req.Msg
 	find := &store.FindQueryHistoryMessage{}
-	if err := s.resolveQueryHistoryParent(ctx, request.Parent, find); err != nil {
+	if err := s.resolveQueryHistoryParent(ctx, request.Parent, find, true); err != nil {
 		return nil, err
 	}
 
@@ -1505,15 +1506,18 @@ func (s *SQLService) ListQueryHistories(ctx context.Context, req *connect.Reques
 
 // resolveQueryHistoryParent applies the parent scope to find: a concrete
 // "projects/{id}" parent must exist in the caller's workspace and scopes by
-// project; the AIP-159 wildcard "projects/-" scopes by workspace, which is
-// mandatory because query_history rows are workspace-scoped only through
-// their project.
-func (s *SQLService) resolveQueryHistoryParent(ctx context.Context, parent string, find *store.FindQueryHistoryMessage) error {
+// project. When allowWildcard is set, the AIP-159 wildcard "projects/-"
+// scopes by workspace instead, which is mandatory because query_history rows
+// are workspace-scoped only through their project.
+func (s *SQLService) resolveQueryHistoryParent(ctx context.Context, parent string, find *store.FindQueryHistoryMessage, allowWildcard bool) error {
 	projectID, err := common.GetProjectID(parent)
 	if err != nil {
 		return connect.NewError(connect.CodeInvalidArgument, err)
 	}
 	if projectID == "-" {
+		if !allowWildcard {
+			return connect.NewError(connect.CodeInvalidArgument, errors.Errorf(`the wildcard parent "projects/-" is not supported; specify a concrete project`))
+		}
 		workspaceID := common.GetWorkspaceIDFromContext(ctx)
 		if workspaceID == "" {
 			return connect.NewError(connect.CodeInternal, errors.Errorf("workspace not found in context"))

--- a/backend/generated-go/v1/sql_service.pb.go
+++ b/backend/generated-go/v1/sql_service.pb.go
@@ -1754,8 +1754,8 @@ type SearchQueryHistoriesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The parent project to search query histories in.
 	// Format: projects/{project}
-	// Use "projects/-" to search across all projects
-	// (https://google.aip.dev/159).
+	// The AIP-159 wildcard "projects/-" is not supported; use
+	// ListQueryHistories for cross-project reads.
 	Parent string `protobuf:"bytes,4,opt,name=parent,proto3" json:"parent,omitempty"`
 	// The maximum number of histories to return.
 	// The service may return fewer than this value.

--- a/backend/tests/query_history_test.go
+++ b/backend/tests/query_history_test.go
@@ -288,8 +288,9 @@ func TestListQueryHistories(t *testing.T) {
 	a.NoError(err)
 	a.Empty(wildcardResp.Msg.QueryHistories)
 
-	// 8. SearchQueryHistories takes the same parent semantics as
-	// ListQueryHistories while staying caller-scoped.
+	// 8. SearchQueryHistories requires a concrete parent project and stays
+	// caller-scoped; cross-project reads are reserved for the IAM-gated
+	// ListQueryHistories.
 	searchResp, err = ctl.sqlServiceClient.SearchQueryHistories(ctx, connect.NewRequest(&v1pb.SearchQueryHistoriesRequest{
 		Parent: ctl.project.Name,
 	}))
@@ -307,12 +308,12 @@ func TestListQueryHistories(t *testing.T) {
 	a.Len(searchResp.Msg.QueryHistories, 1)
 	a.Equal(otherStatement, searchResp.Msg.QueryHistories[0].Statement)
 
-	// The wildcard parent searches across all projects.
-	searchResp, err = ctl.sqlServiceClient.SearchQueryHistories(ctx, connect.NewRequest(&v1pb.SearchQueryHistoriesRequest{
+	// The AIP-159 wildcard parent is rejected.
+	_, err = ctl.sqlServiceClient.SearchQueryHistories(ctx, connect.NewRequest(&v1pb.SearchQueryHistoriesRequest{
 		Parent: "projects/-",
 	}))
-	a.NoError(err)
-	a.GreaterOrEqual(len(searchResp.Msg.QueryHistories), 3)
+	a.Error(err)
+	a.Equal(connect.CodeInvalidArgument, connect.CodeOf(err))
 
 	// The parent is required.
 	_, err = ctl.sqlServiceClient.SearchQueryHistories(ctx, connect.NewRequest(&v1pb.SearchQueryHistoriesRequest{}))
@@ -326,14 +327,4 @@ func TestListQueryHistories(t *testing.T) {
 	}))
 	a.Error(err)
 	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
-
-	// Search stays caller-scoped even with the wildcard parent: the auditor
-	// has run no queries and sees nothing.
-	ctl.authInterceptor.token = auditorToken
-	searchResp, err = ctl.sqlServiceClient.SearchQueryHistories(ctx, connect.NewRequest(&v1pb.SearchQueryHistoriesRequest{
-		Parent: "projects/-",
-	}))
-	a.NoError(err)
-	a.Empty(searchResp.Msg.QueryHistories)
-	ctl.authInterceptor.token = ownerToken
 }

--- a/frontend/src/components/WorkspaceSetupGuide.test.tsx
+++ b/frontend/src/components/WorkspaceSetupGuide.test.tsx
@@ -710,7 +710,7 @@ describe("WorkspaceSetupGuide", () => {
     expect(container.querySelector("[data-testid='active-action']")).toBeNull();
   });
 
-  it("passes the wildcard parent to the query history check", async () => {
+  it("scopes the query history check to the found project", async () => {
     mocks.fetchProjectList.mockResolvedValue({
       projects: [{ name: "projects/project-a" }],
       nextPageToken: "",
@@ -730,7 +730,7 @@ describe("WorkspaceSetupGuide", () => {
     await render(<WorkspaceSetupGuide />);
 
     expect(mocks.searchQueryHistories).toHaveBeenCalledWith(
-      expect.objectContaining({ parent: "projects/-" })
+      expect.objectContaining({ parent: "projects/project-a" })
     );
   });
 

--- a/frontend/src/components/WorkspaceSetupGuide.tsx
+++ b/frontend/src/components/WorkspaceSetupGuide.tsx
@@ -186,11 +186,14 @@ export function WorkspaceSetupGuide() {
       }
 
       if (databaseName) {
+        // databaseName is only set from the project database lookup, so
+        // projectName is always concrete here — which SearchQueryHistories
+        // requires (it has no cross-project wildcard).
         try {
           const queryHistoryResult =
             await sqlServiceClientConnect.searchQueryHistories(
               create(SearchQueryHistoriesRequestSchema, {
-                parent: "projects/-",
+                parent: projectName,
                 pageSize: 1,
                 filter: 'type == "QUERY"',
               })

--- a/frontend/src/modules/sql-editor/store/queryHistory.test.ts
+++ b/frontend/src/modules/sql-editor/store/queryHistory.test.ts
@@ -131,16 +131,16 @@ describe("queryHistory slice — request parent scoping", () => {
     }
   });
 
-  test("falls back to the projects/- wildcard without a valid project", async () => {
-    searchQueryHistoriesMock.mockResolvedValue({
-      queryHistories: [],
-      nextPageToken: "",
-    });
+  test("skips the request entirely without a valid project", async () => {
     const store = makeStore();
-    await store.getState().fetchQueryHistoryList({ project: "", database: "" });
-    expect(searchQueryHistoriesMock.mock.calls[0][0]).toMatchObject({
-      parent: "projects/-",
-    });
+    const emptyFilter: QueryHistoryFilter = { project: "", database: "" };
+    const fetchResp = await store.getState().fetchQueryHistoryList(emptyFilter);
+    const mergeResp = await store.getState().mergeLatest(emptyFilter);
+    expect(searchQueryHistoriesMock).not.toHaveBeenCalled();
+    expect(fetchResp.queryHistories).toEqual([]);
+    expect(mergeResp.queryHistories).toEqual([]);
+    const entry = selectQueryHistoryEntry(emptyFilter)(store.getState());
+    expect(entry.queryHistories).toEqual([]);
   });
 });
 

--- a/frontend/src/modules/sql-editor/store/queryHistory.ts
+++ b/frontend/src/modules/sql-editor/store/queryHistory.ts
@@ -4,6 +4,7 @@ import type { QueryHistory } from "@/types/proto-es/v1/sql_service_pb";
 import {
   GetQueryHistoryRequestSchema,
   SearchQueryHistoriesRequestSchema,
+  SearchQueryHistoriesResponseSchema,
 } from "@/types/proto-es/v1/sql_service_pb";
 import { isValidDatabaseName } from "@/types/v1/database";
 import { isValidProjectName } from "@/types/v1/project";
@@ -18,12 +19,11 @@ import type {
 
 const EMPTY_ENTRY: QueryHistoryEntry = { queryHistories: [] };
 
-// Project scoping travels in `parent` (AIP-159; "projects/-" means all
-// projects), so the CEL filter only carries the non-project dimensions.
-const getSearchParent = (filter: QueryHistoryFilter) =>
-  isValidProjectName(filter.project)
-    ? (filter.project as string)
-    : "projects/-";
+// Project scoping travels in `parent`, so the CEL filter only carries the
+// non-project dimensions. SearchQueryHistories requires a concrete parent
+// project — there is no cross-project wildcard — so both fetch paths no-op
+// until the editor's project context resolves.
+const EMPTY_RESPONSE = create(SearchQueryHistoriesResponseSchema, {});
 
 const getListQueryHistoryFilter = (filter: QueryHistoryFilter) => {
   const params = [`type == "QUERY"`];
@@ -55,12 +55,15 @@ export const createQueryHistorySlice: SQLEditorSliceCreator<
   queryHistoryByKey: {},
 
   fetchQueryHistoryList: async (filter) => {
+    if (!isValidProjectName(filter.project)) {
+      return EMPTY_RESPONSE;
+    }
     const key = getQueryHistoryCacheKey(filter);
     const existing = get().queryHistoryByKey[key] ?? EMPTY_ENTRY;
     const pageToken = existing.nextPageToken;
 
     const request = create(SearchQueryHistoriesRequestSchema, {
-      parent: getSearchParent(filter),
+      parent: filter.project,
       pageSize: 5,
       pageToken,
       filter: getListQueryHistoryFilter(filter),
@@ -114,10 +117,13 @@ export const createQueryHistorySlice: SQLEditorSliceCreator<
    * the list.
    */
   mergeLatest: async (filter) => {
+    if (!isValidProjectName(filter.project)) {
+      return EMPTY_RESPONSE;
+    }
     const key = getQueryHistoryCacheKey(filter);
     const resp = await sqlServiceClientConnect.searchQueryHistories(
       create(SearchQueryHistoriesRequestSchema, {
-        parent: getSearchParent(filter),
+        parent: filter.project,
         pageSize: 5,
         filter: getListQueryHistoryFilter(filter),
       })

--- a/frontend/src/types/proto-es/v1/sql_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/sql_service_pb.d.ts
@@ -1155,8 +1155,8 @@ export declare type SearchQueryHistoriesRequest = Message<"bytebase.v1.SearchQue
   /**
    * The parent project to search query histories in.
    * Format: projects/{project}
-   * Use "projects/-" to search across all projects
-   * (https://google.aip.dev/159).
+   * The AIP-159 wildcard "projects/-" is not supported; use
+   * ListQueryHistories for cross-project reads.
    *
    * @generated from field: string parent = 4;
    */

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -26218,8 +26218,8 @@ components:
           description: |-
             The parent project to search query histories in.
              Format: projects/{project}
-             Use "projects/-" to search across all projects
-             (https://google.aip.dev/159).
+             The AIP-159 wildcard "projects/-" is not supported; use
+             ListQueryHistories for cross-project reads.
         pageSize:
           type: integer
           title: page_size

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -4950,7 +4950,7 @@ Syntax error with position information for editor highlighting
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| parent | [string](#string) |  | The parent project to search query histories in. Format: projects/{project} Use &#34;projects/-&#34; to search across all projects (https://google.aip.dev/159). |
+| parent | [string](#string) |  | The parent project to search query histories in. Format: projects/{project} The AIP-159 wildcard &#34;projects/-&#34; is not supported; use ListQueryHistories for cross-project reads. |
 | page_size | [int32](#int32) |  | The maximum number of histories to return. The service may return fewer than this value. If unspecified, at most 10 history entries will be returned. The maximum value is 1000; values above 1000 will be coerced to 1000. |
 | page_token | [string](#string) |  | A page token, received from a previous `ListQueryHistory` call. Provide this to retrieve the subsequent page. |
 | filter | [string](#string) |  | Filter is the filter to apply on the search query history The syntax and semantics of CEL are documented at https://github.com/google/cel-spec

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -3021,11 +3021,11 @@
                 <li>
                   <a href="#bytebase.v1.ListWorksheetsRequest"><span class="badge">M</span>ListWorksheetsRequest</a>
                 </li>
-
+              
                 <li>
                   <a href="#bytebase.v1.ListWorksheetsResponse"><span class="badge">M</span>ListWorksheetsResponse</a>
                 </li>
-
+              
                 <li>
                   <a href="#bytebase.v1.SearchWorksheetsRequest"><span class="badge">M</span>SearchWorksheetsRequest</a>
                 </li>
@@ -14900,10 +14900,10 @@ time.Time.Zone() </p></td>
                   <td></td>
                   <td><p>The parent project to search query histories in.
 Format: projects/{project}
-Use &#34;projects/-&#34; to search across all projects
-(https://google.aip.dev/159). </p></td>
+The AIP-159 wildcard &#34;projects/-&#34; is not supported; use
+ListQueryHistories for cross-project reads. </p></td>
                 </tr>
-
+              
                 <tr>
                   <td>page_size</td>
                   <td><a href="#int32">int32</a></td>
@@ -34162,13 +34162,13 @@ Format: projects/{project}/worksheets/{worksheet} </p></td>
         <h3 id="bytebase.v1.ListWorksheetsRequest">ListWorksheetsRequest</h3>
         <p></p>
 
-
+        
           <table class="field-table">
             <thead>
               <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
             </thead>
             <tbody>
-
+              
                 <tr>
                   <td>parent</td>
                   <td><a href="#string">string</a></td>
@@ -34177,7 +34177,7 @@ Format: projects/{project}/worksheets/{worksheet} </p></td>
 Format: projects/{project}
 Use &#34;projects/-&#34; to list worksheets across all projects. </p></td>
                 </tr>
-
+              
                 <tr>
                   <td>filter</td>
                   <td><a href="#string">string</a></td>
@@ -34192,7 +34192,7 @@ For example:
 creator == &#34;users/{email}&#34;
 creator != &#34;users/{email}&#34; </p></td>
                 </tr>
-
+              
                 <tr>
                   <td>page_size</td>
                   <td><a href="#int32">int32</a></td>
@@ -34202,7 +34202,7 @@ this value.
 If unspecified, at most 10 worksheets will be returned.
 The maximum value is 1000; values above 1000 will be coerced to 1000. </p></td>
                 </tr>
-
+              
                 <tr>
                   <td>page_token</td>
                   <td><a href="#string">string</a></td>
@@ -34213,31 +34213,31 @@ Provide this to retrieve the subsequent page.
 When paginating, all other parameters provided to `ListWorksheets` must match
 the call that provided the page token. </p></td>
                 </tr>
-
+              
             </tbody>
           </table>
 
+          
 
-
-
-
+        
+      
         <h3 id="bytebase.v1.ListWorksheetsResponse">ListWorksheetsResponse</h3>
         <p></p>
 
-
+        
           <table class="field-table">
             <thead>
               <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
             </thead>
             <tbody>
-
+              
                 <tr>
                   <td>worksheets</td>
                   <td><a href="#bytebase.v1.Worksheet">Worksheet</a></td>
                   <td>repeated</td>
                   <td><p>The worksheets from the specified parent. </p></td>
                 </tr>
-
+              
                 <tr>
                   <td>next_page_token</td>
                   <td><a href="#string">string</a></td>
@@ -34246,14 +34246,14 @@ the call that provided the page token. </p></td>
 Pass this value in the page_token field in the subsequent call to
 `ListWorksheets` method to retrieve the next page of worksheets. </p></td>
                 </tr>
-
+              
             </tbody>
           </table>
 
+          
 
-
-
-
+        
+      
         <h3 id="bytebase.v1.SearchWorksheetsRequest">SearchWorksheetsRequest</h3>
         <p></p>
 
@@ -34635,7 +34635,7 @@ Permissions required: bb.worksheets.get (or creator, or project member for share
 This is used for listing worksheets in a project, or across all projects by using `projects/-`.
 Permissions required: bb.worksheets.list</p></td>
               </tr>
-
+            
               <tr>
                 <td>SearchWorksheets</td>
                 <td><a href="#bytebase.v1.SearchWorksheetsRequest">SearchWorksheetsRequest</a></td>
@@ -34731,10 +34731,10 @@ Permissions required: bb.worksheets.manage (or creator, or project member for PR
                 <td>/v1/{parent=projects/*}/worksheets</td>
                 <td></td>
               </tr>
-
-
-
-
+              
+            
+              
+              
               <tr>
                 <td>SearchWorksheets</td>
                 <td>POST</td>

--- a/proto/v1/v1/sql_service.proto
+++ b/proto/v1/v1/sql_service.proto
@@ -490,8 +490,8 @@ message DiffMetadataResponse {
 message SearchQueryHistoriesRequest {
   // The parent project to search query histories in.
   // Format: projects/{project}
-  // Use "projects/-" to search across all projects
-  // (https://google.aip.dev/159).
+  // The AIP-159 wildcard "projects/-" is not supported; use
+  // ListQueryHistories for cross-project reads.
   string parent = 4 [(google.api.field_behavior) = REQUIRED];
 
   // The maximum number of histories to return.


### PR DESCRIPTION
## What

`SearchQueryHistories` now rejects the AIP-159 wildcard parent `projects/-` with `InvalidArgument` and requires a concrete `projects/{project}`. Cross-project query history reads are reserved for `ListQueryHistories`, where the IAM interceptor resolves the wildcard to a workspace-level `bb.queryHistories.list` check.

## Why

The caller-scoped Search uses CUSTOM auth with no project permission gate, so it must not grow a workspace-wide read scope. Cross-collection reads belong exclusively on the governed, IAM-checked List path.

## Changes

- `resolveQueryHistoryParent` gains an `allowWildcard` flag: List keeps wildcard→workspace scoping unchanged; Search rejects the wildcard.
- SQL Editor history store no longer falls back to `projects/-`: both fetch paths no-op until the editor's concrete project context resolves (route-resolved, so the empty window is transient). History pane behavior with a selected project is unchanged.
- Workspace setup guide scopes its first-query check to the project it already found (`projectName` is always concrete where the check runs).
- Proto field doc updated; regenerated generated-go, proto-es, grpc-doc, and MCP OpenAPI (comment-only diffs).

## Breaking changes

None against any released version — this narrows an API surface introduced by unreleased #21053. The released→next-release delta remains exactly what #21053 declared (required parent, moved REST route).

## Testing

- `TestListQueryHistories` integration test updated TDD-style (watched fail, then pass): wildcard Search → `InvalidArgument`; concrete-parent scoping, empty-parent rejection, and NotFound cases retained.
- Frontend: store slice and setup-guide tests updated first and watched fail, then pass; full suite green (413 files / 3342 tests), type-check and biome clean.
- `golangci-lint` 0 issues (run twice), server build passes, `buf lint` clean, `go test ./backend/api/v1/` passes.

BYT-9892

🤖 Generated with [Claude Code](https://claude.com/claude-code)