### PR TITLE
fix: surface MongoDB statement parsing failures in execution logs

### DIFF
--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -877,9 +877,11 @@ func queryRetryStopOnError(
 	// Split the statement into individual SQLs
 	statements, err := parserbase.SplitMultiSQL(instance.Metadata.GetEngine(), statement)
 	if err != nil {
-		// Engines without splitter support (MongoDB, Redis, Elasticsearch) fall back to
-		// treating the entire statement as a single unit. These engines also don't have
-		// GetQuerySpan support, so queryRetry will return nil spans (old behavior).
+		// Engines without splitter support (e.g. Redis) and statements that fail to
+		// split (e.g. MongoDB parse errors) fall back to treating the entire
+		// statement as a single unit. Where GetQuerySpan is supported (e.g. MongoDB),
+		// it re-parses the raw text and surfaces the parse error; otherwise
+		// queryRetry returns nil spans (old behavior).
 		return queryRetry(ctx, stores, user, instance, database, driver, conn, []parserbase.Statement{{Text: statement}}, statement, queryContext, licenseService, optionalAccessCheck, schemaSyncer, false)
 	}
 

--- a/backend/plugin/db/mongodb/mongodb.go
+++ b/backend/plugin/db/mongodb/mongodb.go
@@ -91,6 +91,11 @@ func (*Driver) GetDB() *sql.DB {
 func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteOptions) (int64, error) {
 	stmts, err := mongodbparser.SplitSQL(statement)
 	if err != nil {
+		// Log the unparseable input as a failed command so the parse error is
+		// visible in the task run log instead of the statement silently
+		// disappearing from it (BYT-9950).
+		opts.LogCommandExecute(&storepb.Range{Start: 0, End: int32(len(statement))}, statement)
+		opts.LogCommandResponse(0, nil, err.Error())
 		return 0, errors.Wrap(err, "failed to split MongoDB statement")
 	}
 

--- a/backend/plugin/db/mongodb/mongodb_test.go
+++ b/backend/plugin/db/mongodb/mongodb_test.go
@@ -1,7 +1,9 @@
 package mongodb
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -164,4 +166,47 @@ func TestIsSystemCollection(t *testing.T) {
 			require.Equal(t, tt.want, isSystemCollection(tt.name))
 		})
 	}
+}
+
+// TestExecuteLogsParseFailure pins BYT-9950: when the statement fails to
+// split/parse, Execute must still emit a COMMAND_EXECUTE / COMMAND_RESPONSE
+// pair carrying the parse error so the failure is visible in task run logs,
+// and must report failure.
+func TestExecuteLogsParseFailure(t *testing.T) {
+	const statement = "db.users.find();\nthis is not mongosh"
+
+	run := func(t *testing.T, logStatement bool) []*storepb.TaskRunLog {
+		var logs []*storepb.TaskRunLog
+		opts := db.ExecuteOptions{
+			CreateTaskRunLog: func(_ time.Time, l *storepb.TaskRunLog) error {
+				logs = append(logs, l)
+				return nil
+			},
+			LogCommandStatement: logStatement,
+		}
+
+		d := &Driver{}
+		_, err := d.Execute(context.Background(), statement, opts)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "syntax error")
+
+		require.Len(t, logs, 2)
+		require.Equal(t, storepb.TaskRunLog_COMMAND_EXECUTE, logs[0].Type)
+		require.Equal(t, storepb.TaskRunLog_COMMAND_RESPONSE, logs[1].Type)
+		require.Contains(t, logs[1].CommandResponse.Error, "syntax error")
+		return logs
+	}
+
+	t.Run("range logging", func(t *testing.T) {
+		logs := run(t, false)
+		require.Empty(t, logs[0].CommandExecute.Statement)
+		require.Equal(t, int32(0), logs[0].CommandExecute.Range.GetStart())
+		require.Equal(t, int32(len(statement)), logs[0].CommandExecute.Range.GetEnd())
+	})
+
+	t.Run("statement logging", func(t *testing.T) {
+		logs := run(t, true)
+		require.Nil(t, logs[0].CommandExecute.Range)
+		require.Equal(t, statement, logs[0].CommandExecute.GetStatement())
+	})
 }

--- a/backend/plugin/parser/mongodb/mongodb.go
+++ b/backend/plugin/parser/mongodb/mongodb.go
@@ -39,10 +39,9 @@ func GetOmniNode(a base.AST) (ast.Node, bool) {
 // ParseMongoShell parses a MongoDB shell script and returns parsed statements
 // with their ASTs. Conforms to the standard ParseStatementsFunc interface.
 //
-// The omni parser recovers from syntax errors by skipping to the next statement
-// boundary. When at least one statement parses successfully, this function
-// returns the partial results with a nil error. A non-nil error is returned
-// only when no statements could be parsed at all.
+// Parsing is strict: a parse error in any statement fails the whole input so
+// callers never silently lose statements (BYT-9950). Use
+// ParseMongoShellBestEffort for partial results.
 func ParseMongoShell(statement string) ([]base.ParsedStatement, error) {
 	stmts, err := mongo.Parse(statement)
 	if err != nil {

--- a/backend/plugin/parser/mongodb/split_test.go
+++ b/backend/plugin/parser/mongodb/split_test.go
@@ -87,14 +87,15 @@ func TestSplitSQL(t *testing.T) {
 			wantTexts:   []string{`db["my-collection"].find({})`},
 		},
 		{
-			// BYT-9950: constant arithmetic in createIndex options must split
-			// as a single statement instead of failing to parse.
-			description: "createIndex with arithmetic TTL expression",
+			// BYT-9950: arithmetic expressions are not supported; the parse
+			// error must fail the split instead of the statement being
+			// silently dropped.
+			description: "createIndex with arithmetic TTL expression fails",
 			statement: `db.cs_customer_frequency.createIndex(
   { trans_date: 1 },
   { expireAfterSeconds: 90 * 24 * 60 * 60, name: "cs_customer_frequency_idx2" }
 );`,
-			wantCount: 1,
+			wantError: true,
 		},
 		{
 			// Splitting is strict: an unparseable statement fails the whole

--- a/backend/plugin/parser/mongodb/split_test.go
+++ b/backend/plugin/parser/mongodb/split_test.go
@@ -13,6 +13,7 @@ func TestSplitSQL(t *testing.T) {
 		wantCount   int
 		wantTexts   []string
 		wantNil     bool
+		wantError   bool
 	}{
 		{
 			description: "single statement",
@@ -85,11 +86,32 @@ func TestSplitSQL(t *testing.T) {
 			wantCount:   1,
 			wantTexts:   []string{`db["my-collection"].find({})`},
 		},
+		{
+			// BYT-9950: constant arithmetic in createIndex options must split
+			// as a single statement instead of failing to parse.
+			description: "createIndex with arithmetic TTL expression",
+			statement: `db.cs_customer_frequency.createIndex(
+  { trans_date: 1 },
+  { expireAfterSeconds: 90 * 24 * 60 * 60, name: "cs_customer_frequency_idx2" }
+);`,
+			wantCount: 1,
+		},
+		{
+			// Splitting is strict: an unparseable statement fails the whole
+			// batch instead of being silently dropped (BYT-9950).
+			description: "valid statement followed by invalid fails",
+			statement:   "db.users.find();\nthis is not mongosh",
+			wantError:   true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			result, err := SplitSQL(tc.statement)
+			if tc.wantError {
+				require.Error(t, err)
+				return
+			}
 			require.NoError(t, err)
 
 			if tc.wantNil {

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260730021650-cd9ba7a3a4e5
+	github.com/bytebase/omni v0.0.0-20260730024920-8e82223f7635
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260728103305-d2f82de1b468
+	github.com/bytebase/omni v0.0.0-20260730021650-cd9ba7a3a4e5
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/beltran/gohive/v2 v2.1.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/bmatcuk/doublestar/v4 v4.10.0
-	github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352
+	github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
 	github.com/bytebase/omni v0.0.0-20260730024920-8e82223f7635
 	github.com/caarlos0/env/v11 v11.4.1

--- a/go.sum
+++ b/go.sum
@@ -246,8 +246,8 @@ github.com/bytebase/gh-ost2 v1.1.7-0.20260512035759-ca2794d6ebea h1:jj2X8RJaIEjF
 github.com/bytebase/gh-ost2 v1.1.7-0.20260512035759-ca2794d6ebea/go.mod h1:XVUEFLOcM31VxA/pvm1YMolnDWlzVyvsqZy9OZKVJ8k=
 github.com/bytebase/go-mssqldb v0.0.0-20240801091126-3ff3ca07d898 h1:0ggqA9XL4yvtePPvRDRYMed3jtdNk4s0o8AMW8uJPSA=
 github.com/bytebase/go-mssqldb v0.0.0-20240801091126-3ff3ca07d898/go.mod h1:2KhUz4GSLcdJGXSJMXAf2BjmakcgoOkNyPpHdGAxRpY=
-github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhRDQ2Qd1EkW2+CJNAQiL6yB94gzCH/c=
-github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
+github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735 h1:v8y6mXeHmYVsdM8cHul7kXSbOuDPL7yN1XSRMu1zo48=
+github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735/go.mod h1:vTHjcvfn8Pmf65WjnV1ytTCYyC7xNhFjrniv4YWvtA8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
 github.com/bytebase/omni v0.0.0-20260730024920-8e82223f7635 h1:JBDU5vAImt6qBPy4bUDgWhuuc2NQzR6WTMtKRL51YjE=

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260730021650-cd9ba7a3a4e5 h1:1vn2vPAkDMjSVsXuqeVcNEwxpDlAVcA2Iw5Sra7egRY=
-github.com/bytebase/omni v0.0.0-20260730021650-cd9ba7a3a4e5/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260730024920-8e82223f7635 h1:JBDU5vAImt6qBPy4bUDgWhuuc2NQzR6WTMtKRL51YjE=
+github.com/bytebase/omni v0.0.0-20260730024920-8e82223f7635/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352 h1:3sC5pdvJ7bNAhR
 github.com/bytebase/gomongo v0.0.0-20260510192859-8526a440b352/go.mod h1:eyWrxE51HCbjGIChvty/mYaNcAroXshnIiR6SIqlxfY=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260728103305-d2f82de1b468 h1:p5Nm8fUYDwTyDHzv3GqzA1MZAFnDGhgrUWH49LYWgj8=
-github.com/bytebase/omni v0.0.0-20260728103305-d2f82de1b468/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260730021650-cd9ba7a3a4e5 h1:1vn2vPAkDMjSVsXuqeVcNEwxpDlAVcA2Iw5Sra7egRY=
+github.com/bytebase/omni v0.0.0-20260730021650-cd9ba7a3a4e5/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
## What

Fixes BYT-9950: a MongoDB migration statement that failed to parse was invisible in task execution logs and could be silently skipped.

Two stacked problems:

1. **Silent drop.** omni's lenient `mongo.Parse` recovered from syntax errors by dropping unparseable statements — a mixed batch executed the parseable statements and reported task **success**, with the failing statement absent from logs entirely. Fixed upstream in bytebase/omni#395 (bumped here): `Parse` now fails on any statement parse error, so nothing executes and nothing is dropped. LSP surfaces (diagnostics, statement ranges) keep using `ParseBestEffort` and are unaffected.
2. **Missing log entry.** `Driver.Execute` returned before any `COMMAND_EXECUTE` entry was written, so even the all-fail case left no trace in execution logs. `Execute` now logs the unparseable input as a `COMMAND_EXECUTE` + `COMMAND_RESPONSE` pair carrying the parser error, then fails the task.

Arithmetic expressions such as the issue's `expireAfterSeconds: 90 * 24 * 60 * 60` remain unsupported by design — the unintended folding change (bytebase/omni#393) was reverted in bytebase/omni#396, and the omni pin here includes that revert. The statement now fails the task with a clear parser error in the execution log instead of vanishing. A companion PR (bytebase/gomongo#31) tightens gomongo's single-statement contract.

## Behavior note

A migration sheet where an unparseable MongoDB statement previously "succeeded" (by silently skipping it) now fails the whole batch before executing anything. This is fail-closed by design: every caller of the MongoDB parse path was audited (task execution, SQL editor query/export, access-grant classification, write-target resolution) — all degrade to explicit errors or stricter checks, never lost statements.

## Testing

- `TestExecuteLogsParseFailure` (new): parse failure emits the `COMMAND_EXECUTE`/`COMMAND_RESPONSE` pair with the parser error and fails, in both range-logging and statement-logging (`LogCommandStatement`) modes.
- `TestSplitSQL` (extended): the BYT-9950 arithmetic `createIndex` statement fails to split with a parse error; a valid-then-invalid batch fails to split.
- Existing parser/masking/classification suites pass against the bumped omni; full server build and `golangci-lint` clean.

BYT-9950

🤖 Generated with [Claude Code](https://claude.com/claude-code)
