### PR TITLE
fix(mysql,tidb): always split statements instead of merging large sheets

### DIFF
--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -307,11 +307,11 @@ func parseVersion(version string) (string, string, error) {
 	return "", "", errors.Errorf("failed to parse version %q", version)
 }
 
+// buildExecuteCommands splits the statement into single commands.
+// Commands are never merged back into one: a merged sheet is sent as a single
+// COM_QUERY whose size equals the sheet size, tripping max_allowed_packet on
+// large DML, and it collapses per-statement execution logging.
 func buildExecuteCommands(statement string) ([]base.Statement, error) {
-	if len(statement) > common.MaxSheetCheckSize {
-		return []base.Statement{{Text: statement}}, nil
-	}
-
 	commands, err := mysqlparser.SplitSQL(statement)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to split sql")
@@ -319,9 +319,6 @@ func buildExecuteCommands(statement string) ([]base.Statement, error) {
 	commands = base.FilterEmptyStatements(commands)
 	if len(commands) == 0 {
 		return nil, nil
-	}
-	if len(commands) > common.MaximumCommands {
-		return []base.Statement{{Text: statement}}, nil
 	}
 
 	return commands, nil

--- a/backend/plugin/db/mysql/mysql_test.go
+++ b/backend/plugin/db/mysql/mysql_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -127,7 +128,7 @@ func TestBuildExecuteCommandsNormalizesDelimiter(t *testing.T) {
 	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
 }
 
-func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForTooManyCommands(t *testing.T) {
+func TestBuildExecuteCommandsNormalizesDelimiterForManyCommands(t *testing.T) {
 	var statement strings.Builder
 	statement.WriteString("DELIMITER //\n")
 	statement.WriteString("CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND//\n")
@@ -139,16 +140,39 @@ func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForTooManyCommands(t *test
 
 	commands, err := buildExecuteCommands(statement.String())
 	require.NoError(t, err)
-	require.Len(t, commands, 1)
-	require.Equal(t, statement.String(), commands[0].Text)
+	require.Greater(t, len(commands), common.MaximumCommands)
+	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
+	for _, command := range commands {
+		require.NotContains(t, command.Text, "DELIMITER")
+	}
 }
 
-func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForLargeSheet(t *testing.T) {
+func TestBuildExecuteCommandsNormalizesDelimiterForLargeSheet(t *testing.T) {
 	statement := "DELIMITER //\nCREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND//\nDELIMITER ;\n" +
 		strings.Repeat(" ", common.MaxSheetCheckSize)
 
 	commands, err := buildExecuteCommands(statement)
 	require.NoError(t, err)
 	require.Len(t, commands, 1)
-	require.Equal(t, statement, commands[0].Text)
+	require.NotContains(t, commands[0].Text, "DELIMITER")
+	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
+}
+
+// A sheet over MaxSheetCheckSize used to be sent as one multi-statement packet,
+// which trips MySQL's max_allowed_packet with error 1153 on large DML backfills.
+func TestBuildExecuteCommandsSplitsOversizedSheet(t *testing.T) {
+	const statementCount = 1800
+	var statement strings.Builder
+	payload := strings.Repeat("x", 5000)
+	for i := 0; i < statementCount; i++ {
+		fmt.Fprintf(&statement, "INSERT INTO t (id, v) VALUES (%d, '%s');\n", i, payload)
+	}
+	require.Greater(t, statement.Len(), common.MaxSheetCheckSize)
+
+	commands, err := buildExecuteCommands(statement.String())
+	require.NoError(t, err)
+	require.Len(t, commands, statementCount)
+	for _, command := range commands {
+		require.Less(t, len(command.Text), common.MaxSheetCheckSize)
+	}
 }

--- a/backend/plugin/db/tidb/tidb.go
+++ b/backend/plugin/db/tidb/tidb.go
@@ -177,11 +177,11 @@ func parseVersion(version string) (string, error) {
 	return "", errors.Errorf("failed to parse version %q", version)
 }
 
+// buildExecuteCommands splits the statement into single commands.
+// Commands are never merged back into one: a merged sheet is sent as a single
+// COM_QUERY whose size equals the sheet size, tripping max_allowed_packet on
+// large DML, and it collapses per-statement execution logging.
 func buildExecuteCommands(statement string) ([]base.Statement, error) {
-	if len(statement) > common.MaxSheetCheckSize {
-		return []base.Statement{{Text: statement}}, nil
-	}
-
 	commands, err := tidbparser.SplitSQL(statement)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to split sql")
@@ -189,9 +189,6 @@ func buildExecuteCommands(statement string) ([]base.Statement, error) {
 	commands = base.FilterEmptyStatements(commands)
 	if len(commands) == 0 {
 		return nil, nil
-	}
-	if len(commands) > common.MaximumCommands {
-		return []base.Statement{{Text: statement}}, nil
 	}
 
 	return commands, nil

--- a/backend/plugin/db/tidb/tidb_test.go
+++ b/backend/plugin/db/tidb/tidb_test.go
@@ -1,6 +1,7 @@
 package tidb
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -109,7 +110,7 @@ func TestBuildExecuteCommandsNormalizesDelimiter(t *testing.T) {
 	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
 }
 
-func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForTooManyCommands(t *testing.T) {
+func TestBuildExecuteCommandsNormalizesDelimiterForManyCommands(t *testing.T) {
 	var statement strings.Builder
 	statement.WriteString("DELIMITER //\n")
 	statement.WriteString("CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND//\n")
@@ -121,16 +122,39 @@ func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForTooManyCommands(t *test
 
 	commands, err := buildExecuteCommands(statement.String())
 	require.NoError(t, err)
-	require.Len(t, commands, 1)
-	require.Equal(t, statement.String(), commands[0].Text)
+	require.Greater(t, len(commands), common.MaximumCommands)
+	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
+	for _, command := range commands {
+		require.NotContains(t, command.Text, "DELIMITER")
+	}
 }
 
-func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForLargeSheet(t *testing.T) {
+func TestBuildExecuteCommandsNormalizesDelimiterForLargeSheet(t *testing.T) {
 	statement := "DELIMITER //\nCREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND//\nDELIMITER ;\n" +
 		strings.Repeat(" ", common.MaxSheetCheckSize)
 
 	commands, err := buildExecuteCommands(statement)
 	require.NoError(t, err)
 	require.Len(t, commands, 1)
-	require.Equal(t, statement, commands[0].Text)
+	require.NotContains(t, commands[0].Text, "DELIMITER")
+	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
+}
+
+// A sheet over MaxSheetCheckSize used to be sent as one multi-statement packet,
+// which trips the max_allowed_packet limit with error 1153 on large DML backfills.
+func TestBuildExecuteCommandsSplitsOversizedSheet(t *testing.T) {
+	const statementCount = 1800
+	var statement strings.Builder
+	payload := strings.Repeat("x", 5000)
+	for i := 0; i < statementCount; i++ {
+		fmt.Fprintf(&statement, "INSERT INTO t (id, v) VALUES (%d, '%s');\n", i, payload)
+	}
+	require.Greater(t, statement.Len(), common.MaxSheetCheckSize)
+
+	commands, err := buildExecuteCommands(statement.String())
+	require.NoError(t, err)
+	require.Len(t, commands, statementCount)
+	for _, command := range commands {
+		require.Less(t, len(command.Text), common.MaxSheetCheckSize)
+	}
 }


### PR DESCRIPTION
Fixes [BYT-9977](https://linear.app/bytebase/issue/BYT-9977) / SUP-307 (auxmoney).

## Problem

A customer's ~9 MB DML sheet (~1,800 INSERTs) failed with:

```
Error 1153 (08S01): Got a packet bigger than 'max_allowed_packet' bytes
```

`buildExecuteCommands` merged the entire sheet back into a **single** command whenever it crossed either threshold:

* `len(statement) > common.MaxSheetCheckSize` (2 MiB)
* `len(commands) > common.MaximumCommands` (200)

The merged sheet is sent as one `COM_QUERY` (the DSN sets `multiStatements=true`), so **packet size equaled sheet size**. Neither constant is configurable, so there was no limit for a user to raise.

Transaction mode could not avoid this: the merge happens in `buildExecuteCommands`, called *before* the transaction-mode branch, so both `executeInAutoCommitMode` and `executeInTransactionMode` received the already-merged slice.

## Fix

Always split. This is what `pg.go` has done since #12563 (`// HACK(p0ny): always split for pg`, landed nine days after the merge was introduced in #12446) and what `oracle.go` already does — MySQL and TiDB were the outliers.

The size gate existed to avoid parsing cost. Measured `mysqlparser.SplitSQL` on the customer's 9 MB sheet: **30 ms, 0.5 MB alloc**, linear to 227 ms at 100 MB. It protected nothing.

Also fixed as a side effect: a >2 MB sheet containing `DELIMITER` was previously shipped raw to the server, which does not understand that client-side directive, guaranteeing a 1064. The old tests asserted exactly that broken behavior; they are inverted rather than deleted.

## Testing

Unit tests in both packages, confirmed RED against the old implementation and GREEN after:

* `TestBuildExecuteCommandsSplitsOversizedSheet` — the reported case; old code returns 1 command, new returns 1800
* `TestBuildExecuteCommandsNormalizesDelimiterForManyCommands` — old: `"1" is not greater than "200"`
* `TestBuildExecuteCommandsNormalizesDelimiterForLargeSheet` — `DELIMITER` now normalized

End-to-end against a real MySQL 8.0.46 with `max_allowed_packet=4194304`, driving the same exported parser the shipped code calls, with the customer's 9 MB / 1,800-statement sheet:

```
BEFORE fix      1 commands -> FAIL: packet for query is too large
             rows inserted: 0
AFTER fix    1800 commands -> OK, rows inserted: 1800
```

Gates: `gofmt` clean, `go build ./backend/plugin/db/...` OK, `golangci-lint` 0 issues, full package tests pass.

## Scope

MySQL and TiDB only — they share the identical function and the same go-sql-driver multi-statement packet semantics. **Redshift (`redshift.go:180`) still merges** and is left as a follow-up: it is PG-protocol, where merging changes transaction semantics (implicit transaction wrapping) rather than packet size, so it deserves its own verification.

## Trade-off

Large sheets now cost N round trips instead of 1, plus two synchronous `task_run_log` inserts per statement — `LogCommandExecute` and `LogCommandResponse` each write a row inline in the execution loop via `store.CreateTaskRunLog`.

The shape that regresses is a sheet of **many short statements**. Roughly 2 MB at ~60 bytes per statement is ~35k statements, which previously merged into one fast packet and now becomes ~35k target round trips plus ~70k metadata-DB inserts: order of a minute where it used to be seconds. The reported customer case is unaffected (1,800 statements, 3,600 inserts), and slow-but-correct beats fast-but-broken, but it is a real change and worth naming rather than burying.

This is the same trade pg has run in production since #12563 (2024-06-28), including the identical per-command logging (`pg.go:567`), without a reported problem.

Bounding the logging is tracked separately in [BYT-9982](https://linear.app/bytebase/issue/BYT-9982). It belongs there rather than here: the cap lives in the shared `ExecuteOptions`, and the exposure already exists on pg and oracle, so it is cross-engine hardening rather than fallout from this PR. The key requirement recorded there is that error responses must bypass the cap — execution stops at the first error, so a naive "log the first N" would miss the failing command whenever it fails past N, which is worse than today.

Explicitly **not** doing packet-size-aware chunking. It would fix log volume by re-coarsening execution, reintroducing the same Range-to-result attribution loss that makes this class of failure undiagnosable (a mid-chunk failure still cannot name the failing statement), and it would only divide log rows by the chunk factor rather than bound them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
