### PR TITLE
fix(migrator): backfill legacy rollout policy settings

### DIFF
--- a/backend/migrator/migration/3.13/0025##backfill_project_rollout_settings.sql
+++ b/backend/migrator/migration/3.13/0025##backfill_project_rollout_settings.sql
@@ -6,7 +6,7 @@ SET setting = setting || '{"requireIssueApproval": true}'::jsonb
 WHERE EXISTS (
     SELECT 1 FROM policy
     WHERE type = 'ROLLOUT'
-    AND (payload::jsonb -> 'checkers' -> 'requiredIssueApproval') IS NOT NULL
+    AND (payload::jsonb -> 'checkers' -> 'requiredIssueApproval') = 'true'::jsonb
 );
 
 -- 2. Enable requirePlanCheckNoError for ALL projects if ANY rollout policy has planCheckEnforcement configured.

--- a/backend/migrator/migration/3.13/0025##backfill_project_rollout_settings.sql
+++ b/backend/migrator/migration/3.13/0025##backfill_project_rollout_settings.sql
@@ -1,4 +1,4 @@
--- 1. Enable requireIssueApproval for ALL projects if ANY rollout policy has 'required-issue-approval' config.
+-- 1. Enable requireIssueApproval for ALL projects if ANY rollout policy requires issue approval.
 --    This is a "safety first" global backfill: if strictness is used anywhere, enforce it everywhere at the project level
 --    to prevent security regression, since environment-level rollout policies are being deprecated/moved.
 UPDATE project
@@ -6,16 +6,16 @@ SET setting = setting || '{"requireIssueApproval": true}'::jsonb
 WHERE EXISTS (
     SELECT 1 FROM policy
     WHERE type = 'ROLLOUT'
-    AND (payload::jsonb -> 'checkers' -> 'required-issue-approval') IS NOT NULL
+    AND (payload::jsonb -> 'checkers' -> 'requiredIssueApproval') IS NOT NULL
 );
 
--- 2. Enable requirePlanCheckNoError for ALL projects if ANY rollout policy has 'plan-check-enforcement' config.
+-- 2. Enable requirePlanCheckNoError for ALL projects if ANY rollout policy has planCheckEnforcement configured.
 UPDATE project
 SET setting = setting || '{"requirePlanCheckNoError": true}'::jsonb
 WHERE EXISTS (
     SELECT 1 FROM policy
     WHERE type = 'ROLLOUT'
-    AND (payload::jsonb -> 'checkers' -> 'plan-check-enforcement') IS NOT NULL
+    AND (payload::jsonb -> 'checkers' -> 'requiredStatusChecks' -> 'planCheckEnforcement') IS NOT NULL
 );
 
 -- 3. Cleanup existing checkers and requireIssueApproval from rollout policy in the policy table


### PR DESCRIPTION
## Summary

- read legacy rollout-policy JSON using the protojson camelCase field names
- backfill issue approval and plan-check enforcement from their correct nested paths

## Testing

- PostgreSQL migration behavior check
- `go test ./backend/migrator -run '^(TestLatestVersion|TestVersionUnique)$' -count=1`