### PR TITLE
fix(mysql,tidb): revert “always split statements instead of merging large sheets”

### DIFF
--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -307,11 +307,11 @@ func parseVersion(version string) (string, string, error) {
 	return "", "", errors.Errorf("failed to parse version %q", version)
 }
 
-// buildExecuteCommands splits the statement into single commands.
-// Commands are never merged back into one: a merged sheet is sent as a single
-// COM_QUERY whose size equals the sheet size, tripping max_allowed_packet on
-// large DML, and it collapses per-statement execution logging.
 func buildExecuteCommands(statement string) ([]base.Statement, error) {
+	if len(statement) > common.MaxSheetCheckSize {
+		return []base.Statement{{Text: statement}}, nil
+	}
+
 	commands, err := mysqlparser.SplitSQL(statement)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to split sql")
@@ -319,6 +319,9 @@ func buildExecuteCommands(statement string) ([]base.Statement, error) {
 	commands = base.FilterEmptyStatements(commands)
 	if len(commands) == 0 {
 		return nil, nil
+	}
+	if len(commands) > common.MaximumCommands {
+		return []base.Statement{{Text: statement}}, nil
 	}
 
 	return commands, nil

--- a/backend/plugin/db/mysql/mysql_test.go
+++ b/backend/plugin/db/mysql/mysql_test.go
@@ -1,7 +1,6 @@
 package mysql
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -128,7 +127,7 @@ func TestBuildExecuteCommandsNormalizesDelimiter(t *testing.T) {
 	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
 }
 
-func TestBuildExecuteCommandsNormalizesDelimiterForManyCommands(t *testing.T) {
+func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForTooManyCommands(t *testing.T) {
 	var statement strings.Builder
 	statement.WriteString("DELIMITER //\n")
 	statement.WriteString("CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND//\n")
@@ -140,39 +139,16 @@ func TestBuildExecuteCommandsNormalizesDelimiterForManyCommands(t *testing.T) {
 
 	commands, err := buildExecuteCommands(statement.String())
 	require.NoError(t, err)
-	require.Greater(t, len(commands), common.MaximumCommands)
-	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
-	for _, command := range commands {
-		require.NotContains(t, command.Text, "DELIMITER")
-	}
+	require.Len(t, commands, 1)
+	require.Equal(t, statement.String(), commands[0].Text)
 }
 
-func TestBuildExecuteCommandsNormalizesDelimiterForLargeSheet(t *testing.T) {
+func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForLargeSheet(t *testing.T) {
 	statement := "DELIMITER //\nCREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND//\nDELIMITER ;\n" +
 		strings.Repeat(" ", common.MaxSheetCheckSize)
 
 	commands, err := buildExecuteCommands(statement)
 	require.NoError(t, err)
 	require.Len(t, commands, 1)
-	require.NotContains(t, commands[0].Text, "DELIMITER")
-	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
-}
-
-// A sheet over MaxSheetCheckSize used to be sent as one multi-statement packet,
-// which trips MySQL's max_allowed_packet with error 1153 on large DML backfills.
-func TestBuildExecuteCommandsSplitsOversizedSheet(t *testing.T) {
-	const statementCount = 1800
-	var statement strings.Builder
-	payload := strings.Repeat("x", 5000)
-	for i := 0; i < statementCount; i++ {
-		fmt.Fprintf(&statement, "INSERT INTO t (id, v) VALUES (%d, '%s');\n", i, payload)
-	}
-	require.Greater(t, statement.Len(), common.MaxSheetCheckSize)
-
-	commands, err := buildExecuteCommands(statement.String())
-	require.NoError(t, err)
-	require.Len(t, commands, statementCount)
-	for _, command := range commands {
-		require.Less(t, len(command.Text), common.MaxSheetCheckSize)
-	}
+	require.Equal(t, statement, commands[0].Text)
 }

--- a/backend/plugin/db/tidb/tidb.go
+++ b/backend/plugin/db/tidb/tidb.go
@@ -177,11 +177,11 @@ func parseVersion(version string) (string, error) {
 	return "", errors.Errorf("failed to parse version %q", version)
 }
 
-// buildExecuteCommands splits the statement into single commands.
-// Commands are never merged back into one: a merged sheet is sent as a single
-// COM_QUERY whose size equals the sheet size, tripping max_allowed_packet on
-// large DML, and it collapses per-statement execution logging.
 func buildExecuteCommands(statement string) ([]base.Statement, error) {
+	if len(statement) > common.MaxSheetCheckSize {
+		return []base.Statement{{Text: statement}}, nil
+	}
+
 	commands, err := tidbparser.SplitSQL(statement)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to split sql")
@@ -189,6 +189,9 @@ func buildExecuteCommands(statement string) ([]base.Statement, error) {
 	commands = base.FilterEmptyStatements(commands)
 	if len(commands) == 0 {
 		return nil, nil
+	}
+	if len(commands) > common.MaximumCommands {
+		return []base.Statement{{Text: statement}}, nil
 	}
 
 	return commands, nil

--- a/backend/plugin/db/tidb/tidb_test.go
+++ b/backend/plugin/db/tidb/tidb_test.go
@@ -1,7 +1,6 @@
 package tidb
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -110,7 +109,7 @@ func TestBuildExecuteCommandsNormalizesDelimiter(t *testing.T) {
 	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
 }
 
-func TestBuildExecuteCommandsNormalizesDelimiterForManyCommands(t *testing.T) {
+func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForTooManyCommands(t *testing.T) {
 	var statement strings.Builder
 	statement.WriteString("DELIMITER //\n")
 	statement.WriteString("CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND//\n")
@@ -122,39 +121,16 @@ func TestBuildExecuteCommandsNormalizesDelimiterForManyCommands(t *testing.T) {
 
 	commands, err := buildExecuteCommands(statement.String())
 	require.NoError(t, err)
-	require.Greater(t, len(commands), common.MaximumCommands)
-	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
-	for _, command := range commands {
-		require.NotContains(t, command.Text, "DELIMITER")
-	}
+	require.Len(t, commands, 1)
+	require.Equal(t, statement.String(), commands[0].Text)
 }
 
-func TestBuildExecuteCommandsNormalizesDelimiterForLargeSheet(t *testing.T) {
+func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForLargeSheet(t *testing.T) {
 	statement := "DELIMITER //\nCREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND//\nDELIMITER ;\n" +
 		strings.Repeat(" ", common.MaxSheetCheckSize)
 
 	commands, err := buildExecuteCommands(statement)
 	require.NoError(t, err)
 	require.Len(t, commands, 1)
-	require.NotContains(t, commands[0].Text, "DELIMITER")
-	require.Contains(t, commands[0].Text, "CREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND")
-}
-
-// A sheet over MaxSheetCheckSize used to be sent as one multi-statement packet,
-// which trips the max_allowed_packet limit with error 1153 on large DML backfills.
-func TestBuildExecuteCommandsSplitsOversizedSheet(t *testing.T) {
-	const statementCount = 1800
-	var statement strings.Builder
-	payload := strings.Repeat("x", 5000)
-	for i := 0; i < statementCount; i++ {
-		fmt.Fprintf(&statement, "INSERT INTO t (id, v) VALUES (%d, '%s');\n", i, payload)
-	}
-	require.Greater(t, statement.Len(), common.MaxSheetCheckSize)
-
-	commands, err := buildExecuteCommands(statement.String())
-	require.NoError(t, err)
-	require.Len(t, commands, statementCount)
-	for _, command := range commands {
-		require.Less(t, len(command.Text), common.MaxSheetCheckSize)
-	}
+	require.Equal(t, statement, commands[0].Text)
 }


### PR DESCRIPTION
Reverts bytebase/bytebase#21071

To ensure our system or database is not compromised, we need to retain this restriction; this behavior is currently expected.