### PR TITLE
fix: unify just-in-time wording to access grant terminology

### DIFF
--- a/backend/api/v1/access_grant_service.go
+++ b/backend/api/v1/access_grant_service.go
@@ -201,11 +201,9 @@ func (s *AccessGrantService) CreateAccessGrant(ctx context.Context, request *con
 	}
 	if maximumRequestExpiration := workspaceProfileSetting.GetMaximumRequestExpiration(); maximumRequestExpiration != nil {
 		maxExpireTime := time.Now().Add(maximumRequestExpiration.AsDuration())
-		switch {
-		case expireTime != nil && expireTime.After(maxExpireTime):
-			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("expiration exceeds maximum request expiration %s", maximumRequestExpiration.AsDuration()))
-		case requestedDuration != nil && requestedDuration.AsDuration() > maximumRequestExpiration.AsDuration():
-			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("expiration exceeds maximum request expiration %s", maximumRequestExpiration.AsDuration()))
+		if (expireTime != nil && expireTime.After(maxExpireTime)) ||
+			(requestedDuration != nil && requestedDuration.AsDuration() > maximumRequestExpiration.AsDuration()) {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("expiration exceeds maximum access grant expiration %s", maximumRequestExpiration.AsDuration()))
 		}
 	}
 
@@ -232,7 +230,7 @@ func (s *AccessGrantService) CreateAccessGrant(ctx context.Context, request *con
 	issue, err := s.store.CreateIssue(ctx, &store.IssueMessage{
 		ProjectID:    projectID,
 		CreatorEmail: creatorEmail,
-		Title:        fmt.Sprintf("JIT access request by %s", creatorEmail),
+		Title:        fmt.Sprintf("Access grant request by %s", creatorEmail),
 		Type:         storepb.Issue_ACCESS_GRANT,
 		Description:  ag.Reason,
 		Payload: &storepb.Issue{

--- a/frontend/scripts/check-react-i18n.mjs
+++ b/frontend/scripts/check-react-i18n.mjs
@@ -6,6 +6,9 @@
 //   3. Consistency       — all locale files must have the exact same key set
 //   4. Placeholder syntax — react-i18next uses {{name}}; flag stray Vue-style
 //                           {name} placeholders left over from migration
+//   5. Banned wording     — retired user-facing terms must not reappear in
+//                           locale values (keys and code identifiers are
+//                           exempt — only rendered strings are checked)
 //
 // Usage: node frontend/scripts/check-react-i18n.mjs
 
@@ -329,25 +332,24 @@ function findSingleBracePlaceholders(obj, path = "") {
   return issues;
 }
 
+// Parse a locale's four section files as [pathPrefix, parsedJson] pairs.
+// Single source of truth for the locale file layout — used by checks 4 and 5.
+function localeSections(locale) {
+  return [
+    ["", `${locale}.json`],
+    ["dynamic", `dynamic/${locale}.json`],
+    ["sql-review", `sql-review/${locale}.json`],
+    ["subscription", `subscription/${locale}.json`],
+  ].map(([prefix, rel]) => [
+    prefix,
+    JSON.parse(readFileSync(resolve(LOCALES_DIR, rel), "utf-8")),
+  ]);
+}
+
 for (const locale of LOCALES) {
-  const main = JSON.parse(
-    readFileSync(resolve(LOCALES_DIR, `${locale}.json`), "utf-8")
+  const issues = localeSections(locale).flatMap(([prefix, data]) =>
+    findSingleBracePlaceholders(data, prefix)
   );
-  const dynamic = JSON.parse(
-    readFileSync(resolve(LOCALES_DIR, `dynamic/${locale}.json`), "utf-8")
-  );
-  const sqlReview = JSON.parse(
-    readFileSync(resolve(LOCALES_DIR, `sql-review/${locale}.json`), "utf-8")
-  );
-  const subscription = JSON.parse(
-    readFileSync(resolve(LOCALES_DIR, `subscription/${locale}.json`), "utf-8")
-  );
-  const issues = [
-    ...findSingleBracePlaceholders(main),
-    ...findSingleBracePlaceholders(dynamic, "dynamic"),
-    ...findSingleBracePlaceholders(sqlReview, "sql-review"),
-    ...findSingleBracePlaceholders(subscription, "subscription"),
-  ];
   if (issues.length > 0) {
     console.error(
       `${locale}: ${issues.length} string(s) with Vue-style {name} placeholders — react-i18next needs {{name}}:\n`
@@ -360,10 +362,57 @@ for (const locale of LOCALES) {
 }
 
 // ---------------------------------------------------------------------------
+// Check 5: banned wording in locale values
+//
+// BYT-9840 retired "just-in-time"/"JIT" as a product-UI term — the object
+// users see is an "access grant"; the workflow term lives in the docs only.
+// Code identifiers (FEATURE_JIT, allowJustInTimeAccess) intentionally keep
+// the name, so this check walks locale VALUES only, never keys.
+// ---------------------------------------------------------------------------
+const BANNED_WORDING = [
+  { re: /just[- ]?in[- ]?time/i, label: "just-in-time" },
+  { re: /\bJIT\b/i, label: "JIT" },
+  // Each locale's retired native-script rendering of the term. Do not widen
+  // 即时 beyond the full retired phrase — 即时通讯 (IM) is a legitimate use.
+  { re: /ジャストインタイム/, label: "ジャストインタイム" },
+  { re: /即时访问/, label: "即时访问" },
+  { re: /truy cập tức thời/i, label: "truy cập tức thời" },
+];
+
+function findBannedWording(obj, path = "") {
+  const hits = [];
+  if (obj && typeof obj === "object") {
+    for (const [k, v] of Object.entries(obj)) {
+      hits.push(...findBannedWording(v, path ? `${path}.${k}` : k));
+    }
+  } else if (typeof obj === "string") {
+    for (const { re, label } of BANNED_WORDING) {
+      if (re.test(obj)) hits.push({ key: path, value: obj, label });
+    }
+  }
+  return hits;
+}
+
+for (const locale of LOCALES) {
+  const hits = localeSections(locale).flatMap(([prefix, data]) =>
+    findBannedWording(data, prefix)
+  );
+  if (hits.length > 0) {
+    console.error(
+      `${locale}: ${hits.length} string(s) contain retired wording (use "access grant" terms instead — see BYT-9840):\n`
+    );
+    for (const { key, value, label } of hits) {
+      error(`  - ${key} → ${JSON.stringify(value)} (banned: ${label})`);
+    }
+    console.error();
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Result
 // ---------------------------------------------------------------------------
 if (errors > 0) {
   process.exit(1);
 } else {
-  console.log("React i18n: all checks passed (missing keys, unused keys, cross-locale consistency, placeholder syntax).");
+  console.log("React i18n: all checks passed (missing keys, unused keys, cross-locale consistency, placeholder syntax, banned wording).");
 }

--- a/frontend/src/components/FeatureAttention.test.tsx
+++ b/frontend/src/components/FeatureAttention.test.tsx
@@ -139,9 +139,9 @@ describe("FeatureAttention", () => {
 
     render();
 
-    expect(container.textContent).toContain("Just-In-Time access");
+    expect(container.textContent).toContain("Access grants");
     expect(container.textContent).toContain(
-      "Allow users to request temporary database access with approval."
+      "Allow users to request time-boxed access grants with approval."
     );
     expect(container.textContent).not.toContain(
       "dynamic.subscription.features.FEATURE_JIT"

--- a/frontend/src/locales/dynamic/en-US.json
+++ b/frontend/src/locales/dynamic/en-US.json
@@ -190,8 +190,8 @@
         "title": "SSL connection"
       },
       "FEATURE_JIT": {
-        "desc": "Allow users to request temporary database access with approval.",
-        "title": "Just-In-Time access"
+        "desc": "Allow users to request time-boxed access grants with approval.",
+        "title": "Access grants"
       },
       "FEATURE_MULTI_DATABASE_BATCH_CHANGES": {
         "desc": "Apply the same change to multiple databases across different tenants or partitions.",

--- a/frontend/src/locales/dynamic/es-ES.json
+++ b/frontend/src/locales/dynamic/es-ES.json
@@ -190,8 +190,8 @@
         "title": "Conexión SSL"
       },
       "FEATURE_JIT": {
-        "desc": "Permite a los usuarios solicitar acceso temporal a la base de datos con aprobación.",
-        "title": "Acceso Just-In-Time"
+        "desc": "Permite a los usuarios solicitar concesiones de acceso con límite de tiempo mediante aprobación.",
+        "title": "Concesiones de acceso"
       },
       "FEATURE_MULTI_DATABASE_BATCH_CHANGES": {
         "desc": "Aplique el mismo cambio a múltiples bases de datos en diferentes inquilinos o particiones.",

--- a/frontend/src/locales/dynamic/ja-JP.json
+++ b/frontend/src/locales/dynamic/ja-JP.json
@@ -190,8 +190,8 @@
         "title": "SSL接続"
       },
       "FEATURE_JIT": {
-        "desc": "ユーザーが承認付きで一時的なデータベースアクセスをリクエストできます。",
-        "title": "Just-In-Timeアクセス"
+        "desc": "ユーザーが承認付きで期限付きのアクセス付与をリクエストできます。",
+        "title": "アクセス付与"
       },
       "FEATURE_MULTI_DATABASE_BATCH_CHANGES": {
         "desc": "異なるテナントやパーティション間で複数のデータベースに同じ変更を適用します。",

--- a/frontend/src/locales/dynamic/vi-VN.json
+++ b/frontend/src/locales/dynamic/vi-VN.json
@@ -190,8 +190,8 @@
         "title": "Kết nối SSL"
       },
       "FEATURE_JIT": {
-        "desc": "Cho phép người dùng yêu cầu quyền truy cập cơ sở dữ liệu tạm thời kèm phê duyệt.",
-        "title": "Truy cập Just-In-Time"
+        "desc": "Cho phép người dùng yêu cầu cấp quyền truy cập có thời hạn kèm phê duyệt.",
+        "title": "Cấp quyền truy cập"
       },
       "FEATURE_MULTI_DATABASE_BATCH_CHANGES": {
         "desc": "Áp dụng cùng một thay đổi cho nhiều cơ sở dữ liệu trên các tenant hoặc phân vùng khác nhau.",

--- a/frontend/src/locales/dynamic/zh-CN.json
+++ b/frontend/src/locales/dynamic/zh-CN.json
@@ -190,8 +190,8 @@
         "title": "SSL 连接"
       },
       "FEATURE_JIT": {
-        "desc": "允许用户通过审批请求临时数据库访问权限。",
-        "title": "即时访问"
+        "desc": "允许用户通过审批申请限时访问授权。",
+        "title": "访问授权"
       },
       "FEATURE_MULTI_DATABASE_BATCH_CHANGES": {
         "desc": "将相同的更改应用于跨不同租户或分区的多个数据库。",

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -305,6 +305,9 @@
     "environments": "Environments",
     "error": "Error",
     "expiration": "Expiration",
+    "expiration-exceeds-max": "Expiration cannot exceed the workspace limit of {{days}} day(s).",
+    "expiration-max-hint": "Maximum allowed by workspace policy: {{days}} day(s).",
+    "expiration-must-be-future": "Expiration must be in the future.",
     "expired": "Expired",
     "export": "Export",
     "failed": "Failed",
@@ -562,7 +565,7 @@
           "change_database": "Change Database",
           "create_database": "Create Database",
           "data_export": "Export Data",
-          "request-access": "Request Just-In-Time Access",
+          "request-access": "Request Access Grant",
           "request-role": "Request Role"
         },
         "risk-level": {
@@ -1290,7 +1293,7 @@
           }
         }
       },
-      "details": "Access Grant Details",
+      "details": "Access grant details",
       "duration-after-approval": "{{duration}} after issue approved",
       "expired-at": "Expired at",
       "export-results-to-file": "Export results to a file",
@@ -1424,7 +1427,7 @@
     "role-grant": {
       "all-databases": "All databases",
       "all-databases-tip": "All current and future databases in this project.",
-      "details": "Role Grant Details",
+      "details": "Role grant details",
       "expired-at": "Expired at",
       "manually-select": "Manually select",
       "use-cel": "Use CEL Expression"
@@ -1443,7 +1446,7 @@
         "reopen": "Reopen issue?"
       }
     },
-    "subtitle": "Issues cover database changes, data exports, and access requests. Review and approve before execution.",
+    "subtitle": "Issues cover database changes, data exports, and access grants. Review and approve before execution.",
     "table": {
       "approval-progress": "{{approved}}/{{total}} Approvals",
       "approved": "Approved",
@@ -1851,14 +1854,11 @@
           "allow-request-role-disabled": "Allow request role is disabled for this project.",
           "feature-unavailable": "Request role workflow is unavailable on the current plan."
         },
-        "expiration-exceeds-max": "Expiration cannot exceed the workspace limit of {{days}} day(s).",
-        "expiration-must-be-future": "Expiration must be in the future.",
         "failed-to-build-expression": "Failed to build CEL expression. Please try again.",
         "labels-misconfigured": {
           "description": "This project requires issue labels, but no labels have been configured. Please contact the project owner to add labels before requesting a role.",
           "title": "Issue labels required but not configured"
-        },
-        "max-expiration-hint": "Maximum allowed by workspace policy: {{days}} day(s)."
+        }
       },
       "revoke-role-from-member": "Revoke '{{role}}' from '{{member}}'?"
     },
@@ -1870,9 +1870,9 @@
       "confirm-archive-project": "Archiving \"{{name}}\" will make it read-only and hide it from active project lists. All issues, databases, and settings will be preserved. You can restore it later from the archived projects list.",
       "confirm-delete-project": "Deleting \"{{name}}\" will permanently remove the project and all associated data including issues, configurations, and history. All databases in this project will be moved to the default project. This action cannot be undone.",
       "issue-related": {
-        "allow-jit": {
-          "description": "Allow project members to request just-in-time (JIT) access.",
-          "self": "Just-In-Time access"
+        "allow-access-grants": {
+          "description": "Allow project members to request time-boxed access grants for specific read-only statements.",
+          "self": "Allow access grants"
         },
         "allow-request-role": {
           "description": "Allow project members to request roles.",
@@ -2404,11 +2404,11 @@
           "never-expires": "Never expires"
         },
         "maximum-request-expiration": {
-          "description": "Maximum request expiration is the maximum period a data access request can remain valid.",
-          "self": "Maximum request expiration"
+          "description": "Maximum access grant expiration is the longest an access grant can remain valid.",
+          "self": "Maximum access grant expiration"
         },
         "maximum-role-expiration": {
-          "description": "Maximum role expiration applies only to request role. <highlight>This legacy setting will be deprecated in the future; use the just-in-time access flow for temporary access.</highlight>",
+          "description": "Maximum role expiration applies only to request role. <highlight>This legacy setting will be deprecated in the future; use access grants for temporary access.</highlight>",
           "self": "Maximum role expiration"
         },
         "maximum-sql-result": {
@@ -2971,14 +2971,13 @@
       }
     },
     "invalid-database": "Invalid database {{database}}",
-    "jit": "Just-In-Time Access",
     "last-synced": "Last synced: <time></time>",
     "link-access": "Link access",
     "loading-data": "Loading Data...",
     "loading-databases": "Loading Databases...",
     "manage-connections": "Manage connections",
     "next-row": "Next Row",
-    "no-access-requests": "No access requests",
+    "no-access-grants": "No access grants",
     "no-data-available": "No data available",
     "no-database-selected": "No database selected",
     "no-history-found": "No history found",
@@ -3010,11 +3009,7 @@
       "single-node": "Single node"
     },
     "request-aborted": "User aborted the request",
-    "request-access": "Request Access",
-    "request-data-access": "Request Data Access",
-    "request-export": "Request export",
-    "request-jit": "Request just-in-time access",
-    "request-query": "Request query",
+    "request-access-grant": "Request access grant",
     "result-detail": {
       "next-match": "Next match",
       "previous-match": "Previous match",
@@ -3070,7 +3065,7 @@
     "vertical-display": "Vertical display",
     "view-database-detail": "View database detail",
     "view-detail": "View detail",
-    "view-issue": "View Issue",
+    "view-issue": "View issue",
     "view-schema-text": "View schema text",
     "visualize-explain": "Visualize Explain",
     "web-socket": {

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -305,6 +305,9 @@
     "environments": "Entornos",
     "error": "Error",
     "expiration": "Expiración",
+    "expiration-exceeds-max": "La expiración no puede exceder el límite del espacio de trabajo de {{days}} día(s).",
+    "expiration-max-hint": "Máximo permitido por la política del espacio de trabajo: {{days}} día(s).",
+    "expiration-must-be-future": "La expiración debe ser una fecha futura.",
     "expired": "Expirado",
     "export": "Exportar",
     "failed": "Error",
@@ -562,8 +565,8 @@
           "change_database": "Cambiar base de datos",
           "create_database": "Crear base de datos",
           "data_export": "Exportar datos",
-          "request-access": "Solicitar acceso Just-In-Time",
-          "request-role": "Rol de solicitud"
+          "request-access": "Solicitar concesión de acceso",
+          "request-role": "Solicitar rol"
         },
         "risk-level": {
           "default": "Por defecto",
@@ -1443,7 +1446,7 @@
         "reopen": "¿Reabrir incidencia?"
       }
     },
-    "subtitle": "Los problemas abarcan cambios en la base de datos, exportaciones de datos y solicitudes de acceso. Revisar y aprobar antes de la ejecución.",
+    "subtitle": "Los problemas abarcan cambios en la base de datos, exportaciones de datos y concesiones de acceso. Revisar y aprobar antes de la ejecución.",
     "table": {
       "approval-progress": "{{approved}}/{{total}} aprobaciones",
       "approved": "Aprobado",
@@ -1851,14 +1854,11 @@
           "allow-request-role-disabled": "La solicitud de roles está deshabilitada para este proyecto.",
           "feature-unavailable": "El flujo de solicitud de roles no está disponible en el plan actual."
         },
-        "expiration-exceeds-max": "La expiración no puede exceder el límite del espacio de trabajo de {{days}} día(s).",
-        "expiration-must-be-future": "La expiración debe ser una fecha futura.",
         "failed-to-build-expression": "Error al construir la expresión CEL. Inténtalo de nuevo.",
         "labels-misconfigured": {
           "description": "Este proyecto requiere etiquetas de incidencia, pero no se ha configurado ninguna etiqueta. Contacte con el propietario del proyecto para añadir etiquetas antes de solicitar un rol.",
           "title": "Se requieren etiquetas de incidencia pero no están configuradas"
-        },
-        "max-expiration-hint": "Máximo permitido por la política del espacio de trabajo: {{days}} día(s)."
+        }
       },
       "revoke-role-from-member": "¿Revocar '{{role}}' de '{{member}}'?"
     },
@@ -1870,9 +1870,9 @@
       "confirm-archive-project": "Archivar \"{{name}}\" lo hará de solo lectura y lo ocultará de las listas de proyectos activos. Se conservarán todos los issues, bases de datos y configuraciones. Puede restaurarlo más tarde desde la lista de proyectos archivados.",
       "confirm-delete-project": "Eliminar \"{{name}}\" eliminará permanentemente el proyecto y todos los datos asociados, incluidos issues, configuraciones e historial. Todas las bases de datos de este proyecto se moverán al proyecto predeterminado. Esta acción no se puede deshacer.",
       "issue-related": {
-        "allow-jit": {
-          "description": "Una vez habilitado, los usuarios pueden solicitar y usar el acceso justo a tiempo en el Editor SQL.",
-          "self": "Permitir acceso justo a tiempo"
+        "allow-access-grants": {
+          "description": "Permite a los miembros del proyecto solicitar concesiones de acceso con límite de tiempo para sentencias específicas de solo lectura.",
+          "self": "Permitir concesiones de acceso"
         },
         "allow-request-role": {
           "description": "Los usuarios que no son propietarios del proyecto pueden solicitar roles a nivel de proyecto por sí mismos",
@@ -2404,11 +2404,11 @@
           "never-expires": "Nunca expira"
         },
         "maximum-request-expiration": {
-          "description": "La caducidad máxima de la solicitud es el período máximo durante el cual una solicitud de acceso a datos puede permanecer válida.",
-          "self": "Caducidad máxima de la solicitud"
+          "description": "La caducidad máxima de la concesión de acceso es el período máximo durante el cual una concesión de acceso puede permanecer válida.",
+          "self": "Caducidad máxima de la concesión de acceso"
         },
         "maximum-role-expiration": {
-          "description": "La caducidad máxima del rol solo se aplica a la solicitud de rol. <highlight>Esta configuración heredada se dejará de usar en el futuro; usa el flujo de acceso justo a tiempo para acceso temporal.</highlight>",
+          "description": "La caducidad máxima del rol solo se aplica a la solicitud de rol. <highlight>Esta configuración heredada se dejará de usar en el futuro; usa concesiones de acceso para el acceso temporal.</highlight>",
           "self": "Caducidad máxima del rol"
         },
         "maximum-sql-result": {
@@ -2971,14 +2971,13 @@
       }
     },
     "invalid-database": "Base de datos no válida {{database}}",
-    "jit": "Acceso Just-In-Time",
     "last-synced": "Última sincronización: <time></time>",
     "link-access": "Acceso al enlace",
     "loading-data": "Cargando datos...",
     "loading-databases": "Cargando bases de datos...",
     "manage-connections": "Gestionar las conexiones",
     "next-row": "Siguiente fila",
-    "no-access-requests": "No hay solicitudes de acceso",
+    "no-access-grants": "No hay concesiones de acceso",
     "no-data-available": "No hay datos disponibles",
     "no-database-selected": "No se ha seleccionado una base de datos",
     "no-history-found": "No se encontró historial",
@@ -3010,11 +3009,7 @@
       "single-node": "Nodo único"
     },
     "request-aborted": "El usuario abortó la solicitud",
-    "request-access": "Solicitar acceso",
-    "request-data-access": "Solicitar acceso a datos",
-    "request-export": "Solicitar exportación",
-    "request-jit": "Solicitar acceso just-in-time",
-    "request-query": "Solicitar consulta",
+    "request-access-grant": "Solicitar concesión de acceso",
     "result-detail": {
       "next-match": "Siguiente coincidencia",
       "previous-match": "Coincidencia anterior",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -305,6 +305,9 @@
     "environments": "環境",
     "error": "間違い",
     "expiration": "有効期限",
+    "expiration-exceeds-max": "有効期限はワークスペースの上限 {{days}} 日を超えることはできません。",
+    "expiration-max-hint": "ワークスペースポリシーで許可される最大値：{{days}} 日。",
+    "expiration-must-be-future": "有効期限は将来の時刻を指定してください。",
     "expired": "期限切れ",
     "export": "エクスポート",
     "failed": "失敗",
@@ -562,7 +565,7 @@
           "change_database": "データベースの変更",
           "create_database": "データベースの作成",
           "data_export": "データのエクスポート",
-          "request-access": "ジャストインタイムアクセスのリクエスト",
+          "request-access": "アクセス付与のリクエスト",
           "request-role": "ロールのリクエスト"
         },
         "risk-level": {
@@ -1283,7 +1286,7 @@
             "description": "付与がクエリ結果のエクスポートを許可するかどうかでフィルター"
           },
           "status": {
-            "description": "アクセス権限のステータスでフィルター"
+            "description": "アクセス付与のステータスでフィルター"
           },
           "unmask": {
             "description": "付与が機密データのマスク解除を許可するかどうかでフィルター"
@@ -1294,7 +1297,7 @@
       "duration-after-approval": "Issue 承認後 {{duration}}",
       "expired-at": "有効期限",
       "export-results-to-file": "結果をファイルにエクスポート",
-      "this-grant-allows": "このアクセス権限で許可される操作",
+      "this-grant-allows": "このアクセス付与で許可される操作",
       "unmask-data-in-results": "結果内の機密データのマスクを解除"
     },
     "advanced-search": {
@@ -1443,7 +1446,7 @@
         "reopen": "イシューを再開しますか?"
       }
     },
-    "subtitle": "イシューには、データベースの変更、データのエクスポート、アクセス要求が含まれます。実行前に確認と承認が必要です。",
+    "subtitle": "イシューには、データベースの変更、データのエクスポート、アクセス付与が含まれます。実行前に確認と承認が必要です。",
     "table": {
       "approval-progress": "{{approved}}/{{total}} 件承認",
       "approved": "承認済み",
@@ -1851,14 +1854,11 @@
           "allow-request-role-disabled": "このプロジェクトではロール申請が無効になっています。",
           "feature-unavailable": "現在のプランではロール申請ワークフローを利用できません。"
         },
-        "expiration-exceeds-max": "有効期限はワークスペースの上限 {{days}} 日を超えることはできません。",
-        "expiration-must-be-future": "有効期限は将来の時刻を指定してください。",
         "failed-to-build-expression": "CEL 式の構築に失敗しました。もう一度お試しください。",
         "labels-misconfigured": {
           "description": "このプロジェクトはイシューラベルを必須にしていますが、ラベルが設定されていません。ロールをリクエストする前に、プロジェクトのオーナーに連絡してラベルを追加してください。",
           "title": "イシューラベルが必須ですが設定されていません"
-        },
-        "max-expiration-hint": "ワークスペースポリシーで許可される最大値：{{days}} 日。"
+        }
       },
       "revoke-role-from-member": "'{{member}}' から '{{role}}' を取り消しますか？"
     },
@@ -1870,9 +1870,9 @@
       "confirm-archive-project": "\"{{name}}\" をアーカイブすると、読み取り専用になり、アクティブなプロジェクト一覧から非表示になります。すべての Issue、データベース、設定は保持されます。後でアーカイブ済みプロジェクト一覧から復元できます。",
       "confirm-delete-project": "\"{{name}}\" を削除すると、Issue、設定、履歴を含むプロジェクトとそれに関連するすべてのデータが完全に削除されます。このプロジェクト内のすべてのデータベースはデフォルトプロジェクトに移動されます。この操作は元に戻せません。",
       "issue-related": {
-        "allow-jit": {
-          "description": "有効にすると、ユーザーは SQL エディタでジャストインタイムアクセスをリクエストして使用できます。",
-          "self": "ジャストインタイムアクセスを許可"
+        "allow-access-grants": {
+          "description": "プロジェクトメンバーが特定の読み取り専用ステートメントに対して期限付きのアクセス付与をリクエストできるようにします。",
+          "self": "アクセス付与を許可"
         },
         "allow-request-role": {
           "description": "プロジェクト所有者以外のユーザーがプロジェクトレベルのロールを自分でリクエストできます",
@@ -2404,11 +2404,11 @@
           "never-expires": "期限切れなし"
         },
         "maximum-request-expiration": {
-          "description": "最大リクエスト有効期限は、データアクセスリクエストが有効であり続けられる最大期間です。",
-          "self": "最大リクエスト有効期限"
+          "description": "最大アクセス付与有効期限は、アクセス付与が有効であり続けられる最大期間です。",
+          "self": "最大アクセス付与有効期限"
         },
         "maximum-role-expiration": {
-          "description": "最大ロール有効期限はリクエストロールにのみ適用されます。<highlight>この従来の設定は将来廃止予定です。一時的なアクセスにはジャストインタイムアクセスフローを使用してください。</highlight>",
+          "description": "最大ロール有効期限はリクエストロールにのみ適用されます。<highlight>この従来の設定は将来廃止予定です。一時的なアクセスにはアクセス付与を使用してください。</highlight>",
           "self": "最大ロール有効期限"
         },
         "maximum-sql-result": {
@@ -2884,7 +2884,7 @@
           "description": "付与がクエリ結果のエクスポートを許可するかどうかでフィルター"
         },
         "status": {
-          "description": "アクセス許可のステータスで検索"
+          "description": "アクセス付与のステータスで検索"
         },
         "unmask": {
           "description": "付与が機密データのマスク解除を許可するかどうかでフィルター"
@@ -2901,8 +2901,8 @@
       "self": "管理者モード"
     },
     "allow-admin-mode-only": "インスタンス <instance></instance> には管理者モードでのみアクセスできます。",
-    "and-more-grant": "他 {{count}} 件のアクセス権限",
-    "and-more-grants": "他 {{count}} 件のアクセス権限",
+    "and-more-grant": "他 {{count}} 件のアクセス付与",
+    "and-more-grants": "他 {{count}} 件のアクセス付与",
     "and-n-more-databases": "他 {{n}} 件のデータベース",
     "batch-export": {
       "failed-for-db": "{{db}} のデータのエクスポートに失敗しました",
@@ -2955,8 +2955,8 @@
     "expire-in": "{{time}} 後に期限切れ",
     "expired": "期限切れ",
     "export-available-via-issue": "Issue「{{title}}」によりエクスポート可能",
-    "export-available-via-n-grants": "{{count}} 件のアクセス権限によりエクスポート可能:",
-    "export-enabled-by-grant": "アクセス権限により有効になっています",
+    "export-available-via-n-grants": "{{count}} 件のアクセス付与によりエクスポート可能:",
+    "export-enabled-by-grant": "アクセス付与により有効になっています",
     "format": "フォーマット",
     "format-default": "デフォルト",
     "format-sql": "SQL を整形",
@@ -2971,14 +2971,13 @@
       }
     },
     "invalid-database": "無効なデータベース {{database}}",
-    "jit": "ジャストインタイムアクセス",
     "last-synced": "最終同期時間: <time></time>",
     "link-access": "リンクアクセス",
     "loading-data": "データのロード...",
     "loading-databases": "データベース情報をロードしています...",
     "manage-connections": "接続を管理する",
     "next-row": "次の行",
-    "no-access-requests": "アクセスリクエストはありません",
+    "no-access-grants": "アクセス付与はありません",
     "no-data-available": "データがありません",
     "no-database-selected": "データベースが選択されていません",
     "no-history-found": "まだ履歴がありません",
@@ -3010,11 +3009,7 @@
       "single-node": "単一ノード"
     },
     "request-aborted": "ユーザーがリクエストを中止しました",
-    "request-access": "アクセスをリクエスト",
-    "request-data-access": "データアクセスをリクエスト",
-    "request-export": "エクスポートをリクエスト",
-    "request-jit": "ジャストインタイムアクセスをリクエスト",
-    "request-query": "リクエストクエリ",
+    "request-access-grant": "アクセス付与をリクエスト",
     "result-detail": {
       "next-match": "次の一致",
       "previous-match": "前の一致",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -305,6 +305,9 @@
     "environments": "Môi trường",
     "error": "Lỗi",
     "expiration": "Hết hạn",
+    "expiration-exceeds-max": "Thời gian hết hạn không được vượt quá giới hạn {{days}} ngày của không gian làm việc.",
+    "expiration-max-hint": "Tối đa được phép theo chính sách không gian làm việc: {{days}} ngày.",
+    "expiration-must-be-future": "Thời gian hết hạn phải ở tương lai.",
     "expired": "Đã hết hạn",
     "export": "Xuất",
     "failed": "Thất bại",
@@ -562,7 +565,7 @@
           "change_database": "Thay đổi cơ sở dữ liệu",
           "create_database": "Tạo cơ sở dữ liệu",
           "data_export": "Xuất dữ liệu",
-          "request-access": "Yêu cầu quyền truy cập Just-In-Time",
+          "request-access": "Yêu cầu cấp quyền truy cập",
           "request-role": "Yêu cầu vai trò"
         },
         "risk-level": {
@@ -1443,7 +1446,7 @@
         "reopen": "Mở lại vấn đề?"
       }
     },
-    "subtitle": "Các vấn đề bao gồm thay đổi cơ sở dữ liệu, xuất dữ liệu và yêu cầu truy cập. Cần xem xét và phê duyệt trước khi thực hiện.",
+    "subtitle": "Các vấn đề bao gồm thay đổi cơ sở dữ liệu, xuất dữ liệu và cấp quyền truy cập. Cần xem xét và phê duyệt trước khi thực hiện.",
     "table": {
       "approval-progress": "{{approved}}/{{total}} phê duyệt",
       "approved": "Đã phê duyệt",
@@ -1851,14 +1854,11 @@
           "allow-request-role-disabled": "Dự án này đã tắt tính năng yêu cầu vai trò.",
           "feature-unavailable": "Quy trình yêu cầu vai trò không khả dụng trong gói hiện tại."
         },
-        "expiration-exceeds-max": "Thời gian hết hạn không được vượt quá giới hạn {{days}} ngày của không gian làm việc.",
-        "expiration-must-be-future": "Thời gian hết hạn phải ở tương lai.",
         "failed-to-build-expression": "Không thể xây dựng biểu thức CEL. Vui lòng thử lại.",
         "labels-misconfigured": {
           "description": "Dự án này yêu cầu nhãn vấn đề, nhưng chưa có nhãn nào được cấu hình. Vui lòng liên hệ chủ sở hữu dự án để thêm nhãn trước khi yêu cầu vai trò.",
           "title": "Dự án yêu cầu nhãn vấn đề nhưng chưa cấu hình"
-        },
-        "max-expiration-hint": "Tối đa được phép theo chính sách không gian làm việc: {{days}} ngày."
+        }
       },
       "revoke-role-from-member": "Thu hồi '{{role}}' từ '{{member}}'?"
     },
@@ -1870,9 +1870,9 @@
       "confirm-archive-project": "Việc lưu trữ \"{{name}}\" sẽ khiến nó trở thành chỉ đọc và ẩn khỏi danh sách dự án đang hoạt động. Tất cả issue, cơ sở dữ liệu và cài đặt sẽ được giữ lại. Bạn có thể khôi phục lại sau từ danh sách dự án đã lưu trữ.",
       "confirm-delete-project": "Việc xóa \"{{name}}\" sẽ xóa vĩnh viễn dự án và tất cả dữ liệu liên quan bao gồm issue, cấu hình và lịch sử. Tất cả cơ sở dữ liệu trong dự án này sẽ được chuyển sang dự án mặc định. Hành động này không thể hoàn tác.",
       "issue-related": {
-        "allow-jit": {
-          "description": "Khi được bật, người dùng có thể yêu cầu và sử dụng quyền truy cập tức thời trong Trình soạn thảo SQL.",
-          "self": "Cho phép truy cập tức thời"
+        "allow-access-grants": {
+          "description": "Cho phép thành viên dự án yêu cầu cấp quyền truy cập có thời hạn cho các câu lệnh chỉ đọc cụ thể.",
+          "self": "Cho phép cấp quyền truy cập"
         },
         "allow-request-role": {
           "description": "Người dùng không phải chủ sở hữu dự án có thể tự yêu cầu vai trò cấp dự án",
@@ -2404,11 +2404,11 @@
           "never-expires": "Không bao giờ hết hạn"
         },
         "maximum-request-expiration": {
-          "description": "Thời hạn yêu cầu tối đa là khoảng thời gian tối đa mà yêu cầu truy cập dữ liệu có thể còn hiệu lực.",
-          "self": "Thời hạn yêu cầu tối đa"
+          "description": "Thời hạn cấp quyền truy cập tối đa là khoảng thời gian tối đa mà cấp quyền truy cập có thể còn hiệu lực.",
+          "self": "Thời hạn cấp quyền truy cập tối đa"
         },
         "maximum-role-expiration": {
-          "description": "Thời hạn vai trò tối đa chỉ áp dụng cho yêu cầu vai trò. <highlight>Cấu hình cũ này sẽ bị ngừng sử dụng trong tương lai; hãy dùng luồng truy cập đúng lúc cho quyền truy cập tạm thời.</highlight>",
+          "description": "Thời hạn vai trò tối đa chỉ áp dụng cho yêu cầu vai trò. <highlight>Cấu hình cũ này sẽ bị ngừng sử dụng trong tương lai; hãy dùng cấp quyền truy cập khi cần truy cập tạm thời.</highlight>",
           "self": "Thời hạn vai trò tối đa"
         },
         "maximum-sql-result": {
@@ -2971,14 +2971,13 @@
       }
     },
     "invalid-database": "Cơ sở dữ liệu không hợp lệ {{database}}",
-    "jit": "Truy cập Just-In-Time",
     "last-synced": "Đã đồng bộ lần cuối: <time></time>",
     "link-access": "Truy cập liên kết",
     "loading-data": "Đang tải Dữ liệu...",
     "loading-databases": "Đang tải Cơ sở dữ liệu...",
     "manage-connections": "Quản lý kết nối",
     "next-row": "Dòng tiếp theo",
-    "no-access-requests": "Không có yêu cầu truy cập",
+    "no-access-grants": "Chưa có quyền truy cập nào được cấp",
     "no-data-available": "Không có dữ liệu",
     "no-database-selected": "Chưa chọn cơ sở dữ liệu",
     "no-history-found": "Không tìm thấy lịch sử",
@@ -3010,11 +3009,7 @@
       "single-node": "Nút đơn"
     },
     "request-aborted": "Người dùng đã hủy yêu cầu",
-    "request-access": "Yêu cầu truy cập",
-    "request-data-access": "Yêu cầu truy cập dữ liệu",
-    "request-export": "Yêu cầu xuất dữ liệu",
-    "request-jit": "Yêu cầu truy cập just-in-time",
-    "request-query": "Yêu cầu truy vấn",
+    "request-access-grant": "Yêu cầu cấp quyền truy cập",
     "result-detail": {
       "next-match": "Kết quả tiếp theo",
       "previous-match": "Kết quả trước",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -305,6 +305,9 @@
     "environments": "环境",
     "error": "错误",
     "expiration": "过期时间",
+    "expiration-exceeds-max": "过期时间不能超过工作空间上限 {{days}} 天。",
+    "expiration-max-hint": "工作空间策略允许的最大值：{{days}} 天。",
+    "expiration-must-be-future": "过期时间必须是将来的时间。",
     "expired": "已过期",
     "export": "导出",
     "failed": "失败",
@@ -562,8 +565,8 @@
           "change_database": "变更数据库",
           "create_database": "创建数据库",
           "data_export": "导出数据",
-          "request-access": "请求即时访问",
-          "request-role": "请求角色"
+          "request-access": "申请访问授权",
+          "request-role": "申请角色"
         },
         "risk-level": {
           "default": "默认",
@@ -1443,7 +1446,7 @@
         "reopen": "重开工单？"
       }
     },
-    "subtitle": "工单涵盖数据库变更、数据导出和权限申请。执行前需审查和审批。",
+    "subtitle": "工单涵盖数据库变更、数据导出和访问授权。执行前需审查和审批。",
     "table": {
       "approval-progress": "{{approved}}/{{total}} 已审批",
       "approved": "已审批",
@@ -1851,14 +1854,11 @@
           "allow-request-role-disabled": "此项目未启用申请角色。",
           "feature-unavailable": "当前套餐不支持申请角色工作流。"
         },
-        "expiration-exceeds-max": "过期时间不能超过工作空间上限 {{days}} 天。",
-        "expiration-must-be-future": "过期时间必须是将来的时间。",
         "failed-to-build-expression": "构建 CEL 表达式失败，请重试。",
         "labels-misconfigured": {
           "description": "此项目要求选择工单标签，但尚未配置任何标签。请联系项目所有者添加标签后再申请角色。",
           "title": "项目要求工单标签但未配置"
-        },
-        "max-expiration-hint": "工作空间策略允许的最大值：{{days}} 天。"
+        }
       },
       "revoke-role-from-member": "从 '{{member}}' 撤销 '{{role}}' 角色？"
     },
@@ -1870,9 +1870,9 @@
       "confirm-archive-project": "归档「{{name}}」将使其变为只读并从活跃项目列表中隐藏。所有工单、数据库和设置将被保留。您可以稍后从已归档项目列表中恢复。",
       "confirm-delete-project": "删除「{{name}}」将永久移除该项目及所有关联数据，包括工单、配置和历史记录。该项目中的所有数据库将被移至默认项目。此操作无法撤销。",
       "issue-related": {
-        "allow-jit": {
-          "description": "启用后，用户可以在 SQL 编辑器中请求并使用即时数据访问权限。",
-          "self": "允许即时访问"
+        "allow-access-grants": {
+          "description": "允许项目成员为特定只读语句申请限时访问授权。",
+          "self": "允许访问授权"
         },
         "allow-request-role": {
           "description": "非项目所有者可以自行申请项目级角色",
@@ -2404,11 +2404,11 @@
           "never-expires": "永不过期"
         },
         "maximum-request-expiration": {
-          "description": "最大申请有效期是数据访问申请可保持有效的最长时间。",
-          "self": "最大申请有效期"
+          "description": "最大访问授权有效期是访问授权可保持有效的最长时间。",
+          "self": "最大访问授权有效期"
         },
         "maximum-role-expiration": {
-          "description": "最大角色有效期仅适用于申请角色。<highlight>此旧设置未来会被废弃；建议使用即时访问流程授予临时访问。</highlight>",
+          "description": "最大角色有效期仅适用于申请角色。<highlight>此旧设置未来会被废弃；建议使用访问授权来获得临时访问权限。</highlight>",
           "self": "最大角色有效期"
         },
         "maximum-sql-result": {
@@ -2971,14 +2971,13 @@
       }
     },
     "invalid-database": "数据库 {{database}} 无效",
-    "jit": "即时访问",
     "last-synced": "上次同步时间：<time></time>",
     "link-access": "链接访问权限",
     "loading-data": "加载数据中...",
     "loading-databases": "加载数据库信息...",
     "manage-connections": "管理连接",
     "next-row": "下一行",
-    "no-access-requests": "暂无访问请求",
+    "no-access-grants": "暂无访问授权",
     "no-data-available": "暂无数据",
     "no-database-selected": "未选择数据库",
     "no-history-found": "暂无历史记录",
@@ -3010,11 +3009,7 @@
       "single-node": "单节点"
     },
     "request-aborted": "用户中止了请求",
-    "request-access": "申请访问",
-    "request-data-access": "申请数据访问",
-    "request-export": "申请导出",
-    "request-jit": "申请即时访问",
-    "request-query": "请求查询",
+    "request-access-grant": "申请访问授权",
     "result-detail": {
       "next-match": "下一个匹配项",
       "previous-match": "上一个匹配项",

--- a/frontend/src/modules/access-control/RequestRoleSheet.test.tsx
+++ b/frontend/src/modules/access-control/RequestRoleSheet.test.tsx
@@ -354,7 +354,7 @@ describe("RequestRoleSheet — enforceIssueTitle (BYT-9310)", () => {
     await renderSheet(false);
 
     expect(container.textContent).toContain(
-      "project.members.request-role.max-expiration-hint"
+      "common.expiration-max-hint"
     );
   });
 
@@ -364,7 +364,7 @@ describe("RequestRoleSheet — enforceIssueTitle (BYT-9310)", () => {
     await renderSheet(false);
 
     expect(container.textContent).not.toContain(
-      "project.members.request-role.max-expiration-hint"
+      "common.expiration-max-hint"
     );
   });
 

--- a/frontend/src/modules/access-control/RequestRoleSheet.tsx
+++ b/frontend/src/modules/access-control/RequestRoleSheet.tsx
@@ -84,7 +84,7 @@ export interface RequestRoleSheetProps {
   /**
    * Pre-fill the role select. Useful when the sheet is opened from a
    * surface that already knows which role the user needs (e.g. the SQL
-   * Editor's "Request query" button hard-codes
+   * Editor's RequestQueryButton hard-codes
    * `PresetRoleType.SQL_EDITOR_USER`). The user can still change the
    * role from the picker — pass `requiredPermissions` to constrain the
    * available roles instead of hard-locking the selection.
@@ -609,7 +609,7 @@ function RequestRoleForm({
             }
             description={
               maximumRoleExpirationDays !== undefined
-                ? t("project.members.request-role.max-expiration-hint", {
+                ? t("common.expiration-max-hint", {
                     days: maximumRoleExpirationDays,
                   })
                 : undefined
@@ -622,13 +622,11 @@ function RequestRoleForm({
               maxDate={maxDatetime}
             />
             {expirationIsInPast && (
-              <FormError>
-                {t("project.members.request-role.expiration-must-be-future")}
-              </FormError>
+              <FormError>{t("common.expiration-must-be-future")}</FormError>
             )}
             {expirationExceedsMax && (
               <FormError>
-                {t("project.members.request-role.expiration-exceeds-max", {
+                {t("common.expiration-exceeds-max", {
                   days: maximumRoleExpirationDays,
                 })}
               </FormError>

--- a/frontend/src/modules/sql-editor/components/AccessGrantRequestDrawer.test.tsx
+++ b/frontend/src/modules/sql-editor/components/AccessGrantRequestDrawer.test.tsx
@@ -409,9 +409,7 @@ describe("AccessGrantRequestDrawer", () => {
     );
     render();
 
-    expect(container.textContent).toContain(
-      "project.members.request-role.max-expiration-hint"
-    );
+    expect(container.textContent).toContain("common.expiration-max-hint");
 
     unmount();
   });
@@ -618,7 +616,7 @@ describe("AccessGrantRequestDrawer", () => {
     unmount();
   });
 
-  test("typing in the Request Data Access database picker re-queries the server (BYT-9801)", async () => {
+  test("typing in the access-grant drawer database picker re-queries the server (BYT-9801)", async () => {
     const onClose = vi.fn();
     const { render: renderFn, unmount } = renderIntoContainer(
       <AccessGrantRequestDrawer

--- a/frontend/src/modules/sql-editor/components/AccessGrantRequestDrawer.tsx
+++ b/frontend/src/modules/sql-editor/components/AccessGrantRequestDrawer.tsx
@@ -294,7 +294,7 @@ function AccessGrantRequestDrawerInner({
   return (
     <SQLEditorThemeScope theme={active} asContents>
       <SheetHeader>
-        <SheetTitle>{t("sql-editor.request-data-access")}</SheetTitle>
+        <SheetTitle>{t("sql-editor.request-access-grant")}</SheetTitle>
       </SheetHeader>
       <SheetBody>
         <div className="flex flex-col gap-y-6">
@@ -382,7 +382,7 @@ function AccessGrantRequestDrawerInner({
             }
             description={
               maximumExpirationDays !== undefined
-                ? t("project.members.request-role.max-expiration-hint", {
+                ? t("common.expiration-max-hint", {
                     days: maximumExpirationDays,
                   })
                 : undefined
@@ -403,13 +403,11 @@ function AccessGrantRequestDrawerInner({
               />
             )}
             {expirationIsInPast && (
-              <FormError>
-                {t("project.members.request-role.expiration-must-be-future")}
-              </FormError>
+              <FormError>{t("common.expiration-must-be-future")}</FormError>
             )}
             {expirationExceedsMax && maximumExpirationDays !== undefined && (
               <FormError>
-                {t("project.members.request-role.expiration-exceeds-max", {
+                {t("common.expiration-exceeds-max", {
                   days: maximumExpirationDays,
                 })}
               </FormError>

--- a/frontend/src/modules/sql-editor/components/AccessPane.test.tsx
+++ b/frontend/src/modules/sql-editor/components/AccessPane.test.tsx
@@ -285,7 +285,7 @@ afterEach(() => {
 });
 
 describe("AccessPane", () => {
-  test("empty state — shows no-access-requests text when no grants and not loading", async () => {
+  test("empty state — shows no-access-grants text when no grants and not loading", async () => {
     const { container, render, unmount } = renderIntoContainer(<AccessPane />);
     render();
 
@@ -294,7 +294,7 @@ describe("AccessPane", () => {
       await new Promise((r) => setTimeout(r, 0));
     });
 
-    expect(container.textContent).toContain("sql-editor.no-access-requests");
+    expect(container.textContent).toContain("sql-editor.no-access-grants");
     unmount();
   });
 
@@ -385,7 +385,7 @@ describe("AccessPane", () => {
     unmount();
   });
 
-  test("click Request Access → drawer opens", async () => {
+  test("click Request access grant → drawer opens", async () => {
     const { container, render, unmount } = renderIntoContainer(<AccessPane />);
     render();
 
@@ -398,11 +398,11 @@ describe("AccessPane", () => {
       container.querySelector("[data-testid='access-grant-request-drawer']")
     ).toBeNull();
 
-    // Find and click the "request access" button
+    // Find and click the "Request access grant" button
     const buttons = container.querySelectorAll("button");
     let requestBtn: HTMLButtonElement | null = null;
     for (const btn of Array.from(buttons)) {
-      if (btn.textContent?.includes("sql-editor.request-access")) {
+      if (btn.textContent?.includes("sql-editor.request-access-grant")) {
         requestBtn = btn;
         break;
       }

--- a/frontend/src/modules/sql-editor/components/AccessPane.tsx
+++ b/frontend/src/modules/sql-editor/components/AccessPane.tsx
@@ -351,7 +351,7 @@ export function AccessPane() {
                   className="mr-1"
                 />
               )}
-              {t("sql-editor.request-access")}
+              {t("sql-editor.request-access-grant")}
             </Button>
           )}
         </PermissionGuard>
@@ -392,7 +392,7 @@ export function AccessPane() {
           </div>
         ) : (
           <div className="w-full flex items-center justify-center py-8 textinfolabel">
-            {t("sql-editor.no-access-requests")}
+            {t("sql-editor.no-access-grants")}
           </div>
         ))}
 

--- a/frontend/src/modules/sql-editor/components/MaskingReasonPopover.test.tsx
+++ b/frontend/src/modules/sql-editor/components/MaskingReasonPopover.test.tsx
@@ -243,7 +243,7 @@ describe("MaskingReasonPopover", () => {
     unmount();
   });
 
-  test("does not show request-jit button when JIT not available", () => {
+  test("does not show the request-access-grant button when JIT not available", () => {
     setupDefaultMocks(false);
     const { container, render, unmount } = renderIntoContainer(
       <MaskingReasonPopover reason={makeReason()} statement="SELECT * FROM t" />
@@ -252,13 +252,13 @@ describe("MaskingReasonPopover", () => {
 
     const buttons = container.querySelectorAll("[data-testid='jit-button']");
     const jitBtn = Array.from(buttons).find((b) =>
-      b.textContent?.includes("sql-editor.request-jit")
+      b.textContent?.includes("sql-editor.request-access-grant")
     );
     expect(jitBtn).toBeUndefined();
     unmount();
   });
 
-  test("shows request-jit button and opens drawer when JIT available and statement provided", async () => {
+  test("shows the request-access-grant button and opens drawer when JIT available and statement provided", async () => {
     setupDefaultMocks(true);
     const { container, render, unmount } = renderIntoContainer(
       <MaskingReasonPopover
@@ -277,7 +277,7 @@ describe("MaskingReasonPopover", () => {
       "[data-testid='jit-button']"
     ) as HTMLButtonElement;
     expect(jitBtn).not.toBeNull();
-    expect(jitBtn.textContent).toContain("sql-editor.request-jit");
+    expect(jitBtn.textContent).toContain("sql-editor.request-access-grant");
 
     await act(async () => {
       jitBtn.click();

--- a/frontend/src/modules/sql-editor/components/MaskingReasonPopover.tsx
+++ b/frontend/src/modules/sql-editor/components/MaskingReasonPopover.tsx
@@ -155,7 +155,7 @@ export function MaskingReasonPopover({
                 className="self-start"
                 onClick={() => setShowDrawer(true)}
               >
-                {t("sql-editor.request-jit")}
+                {t("sql-editor.request-access-grant")}
               </Button>
             )}
           </div>

--- a/frontend/src/modules/sql-editor/components/RequestExportButton.tsx
+++ b/frontend/src/modules/sql-editor/components/RequestExportButton.tsx
@@ -20,9 +20,9 @@ interface Props {
 
 /**
  * Shown in the result panel when the query-data policy disables export but
- * the project allows just-in-time access. Clicking it opens the access-grant
- * drawer pre-filled with the current database, statement, and both the unmask
- * and export capabilities checked.
+ * the project allows access grants. Clicking it opens the access-grant
+ * drawer pre-filled with the current database, statement, and the export
+ * capability checked (unmask is left unchecked — see #20516).
  */
 export function RequestExportButton({
   size = "sm",
@@ -89,7 +89,7 @@ export function RequestExportButton({
                 feature={PlanFeature.FEATURE_JIT}
               />
             )}
-            {t("sql-editor.request-export")}
+            {t("sql-editor.request-access-grant")}
           </Button>
         )}
       </PermissionGuard>

--- a/frontend/src/modules/sql-editor/components/RequestQueryButton.test.tsx
+++ b/frontend/src/modules/sql-editor/components/RequestQueryButton.test.tsx
@@ -249,7 +249,7 @@ describe("RequestQueryButton", () => {
     unmount();
   });
 
-  test("renders request-query button in non-JIT mode", () => {
+  test("renders the Request role label in non-JIT mode", () => {
     setupDefaultMocks(false, true);
     const { container, render, unmount } = renderIntoContainer(
       <RequestQueryButton
@@ -260,11 +260,11 @@ describe("RequestQueryButton", () => {
       />
     );
     render();
-    expect(container.textContent).toContain("sql-editor.request-query");
+    expect(container.textContent).toContain("issue.title.request-role");
     unmount();
   });
 
-  test("renders request-jit button in JIT mode", () => {
+  test("renders the Request access grant label in JIT mode", () => {
     setupDefaultMocks(true, true);
     const { container, render, unmount } = renderIntoContainer(
       <RequestQueryButton
@@ -275,7 +275,7 @@ describe("RequestQueryButton", () => {
       />
     );
     render();
-    expect(container.textContent).toContain("sql-editor.request-jit");
+    expect(container.textContent).toContain("sql-editor.request-access-grant");
     unmount();
   });
 

--- a/frontend/src/modules/sql-editor/components/RequestQueryButton.tsx
+++ b/frontend/src/modules/sql-editor/components/RequestQueryButton.tsx
@@ -181,8 +181,8 @@ export function RequestQueryButton({
               <FeatureBadge clickable={false} feature={requiredFeature} />
             )}
             {useJIT
-              ? t("sql-editor.request-jit")
-              : t("sql-editor.request-query")}
+              ? t("sql-editor.request-access-grant")
+              : t("issue.title.request-role")}
           </Button>
         )}
       </PermissionGuard>

--- a/frontend/src/modules/sql-editor/components/TabItem.test.tsx
+++ b/frontend/src/modules/sql-editor/components/TabItem.test.tsx
@@ -91,7 +91,7 @@ describe("TabItem", () => {
       <TabItem tab="ACCESS" onClick={() => {}} />
     );
     render();
-    expect(container.textContent).toContain("sql-editor.jit");
+    expect(container.textContent).toContain("sql-editor.access-grants");
     unmount();
   });
 

--- a/frontend/src/modules/sql-editor/components/TabItem.tsx
+++ b/frontend/src/modules/sql-editor/components/TabItem.tsx
@@ -33,7 +33,7 @@ export function TabItem({ tab, onClick }: TabItemProps) {
     WORKSHEET: t("worksheet.self"),
     SCHEMA: t("common.schema"),
     HISTORY: t("common.history"),
-    ACCESS: t("sql-editor.jit"),
+    ACCESS: t("sql-editor.access-grants"),
   } as const;
   const label = labelByTab[tab];
 

--- a/frontend/src/routes/project/ProjectSettingsPage.tsx
+++ b/frontend/src/routes/project/ProjectSettingsPage.tsx
@@ -843,14 +843,16 @@ export function ProjectSettingsPage() {
               }
             />
 
-            {/* Allow JIT Access */}
+            {/* Allow access grants */}
             <ToggleRow
               checked={allowJustInTimeAccess}
               onCheckedChange={setAllowJustInTimeAccess}
               disabled={!canUpdateProject}
-              label={t("project.settings.issue-related.allow-jit.self")}
+              label={t(
+                "project.settings.issue-related.allow-access-grants.self"
+              )}
               description={t(
-                "project.settings.issue-related.allow-jit.description"
+                "project.settings.issue-related.allow-access-grants.description"
               )}
               trailing={
                 <ApprovalFlowIndicator

--- a/frontend/src/routes/workspace/MembersPage.test.tsx
+++ b/frontend/src/routes/workspace/MembersPage.test.tsx
@@ -427,7 +427,7 @@ describe("MembersPage project role grant drawer", () => {
     await flush();
 
     expect(container.textContent).not.toContain(
-      "project.members.request-role.max-expiration-hint"
+      "common.expiration-max-hint"
     );
 
     maximumRoleExpirationSeconds.value = 7 * 24 * 60 * 60;
@@ -452,7 +452,7 @@ describe("MembersPage project role grant drawer", () => {
     await flush();
 
     expect(container.textContent).toContain(
-      "project.members.request-role.max-expiration-hint"
+      "common.expiration-max-hint"
     );
   });
 

--- a/frontend/src/routes/workspace/MembersPage.tsx
+++ b/frontend/src/routes/workspace/MembersPage.tsx
@@ -1277,7 +1277,7 @@ function ProjectRoleBindingForm({
         }
         description={
           maximumRoleExpirationDays !== undefined
-            ? t("project.members.request-role.max-expiration-hint", {
+            ? t("common.expiration-max-hint", {
                 days: maximumRoleExpirationDays,
               })
             : undefined
@@ -1323,13 +1323,11 @@ function ProjectRoleBindingForm({
           />
         )}
         {expirationIsInPast && (
-          <FormError>
-            {t("project.members.request-role.expiration-must-be-future")}
-          </FormError>
+          <FormError>{t("common.expiration-must-be-future")}</FormError>
         )}
         {expirationExceedsMax && (
           <FormError>
-            {t("project.members.request-role.expiration-exceeds-max", {
+            {t("common.expiration-exceeds-max", {
               days: maximumRoleExpirationDays,
             })}
           </FormError>

--- a/frontend/tests/e2e/sql-editor/sql-editor-access-grants.spec.ts
+++ b/frontend/tests/e2e/sql-editor/sql-editor-access-grants.spec.ts
@@ -1,10 +1,10 @@
-// SQL Editor — JIT access flow (Batch 8, L-series + H1 CUJs).
+// SQL Editor — access-grant flow (Batch 8, L-series + H1 CUJs).
 //
 // Covers:
-//   - L1 / L2 RequestQueryButton label switches to "Request just-in-time
-//     access" when project.allowJustInTimeAccess is on AND the missing
-//     permission is exactly bb.sql.select (the JIT path).
-//   - L4 ACCESS pane shows the "Request access" CTA when JIT is enabled.
+//   - L1 / L2 RequestQueryButton label switches to "Request access grant"
+//     when project.allowJustInTimeAccess is on AND the missing
+//     permission is exactly bb.sql.select (the access-grant path).
+//   - L4 ACCESS pane shows the "Request access grant" CTA when JIT is enabled.
 //   - L5 AccessGrantRequestDrawer renders Databases / Statement / Unmask /
 //     Export / Expiration / Reason fields when opened from the pane
 //     (Unmask + Export capability sections added by PRs #20491/#20487).
@@ -171,39 +171,33 @@ test.describe("ACCESS gutter tab follows the project's allowJustInTimeAccess fla
 // L1 / L2 — RequestQueryButton's `useJIT` is true when
 // project.allowJustInTimeAccess is on AND the missing permissions are
 // exactly bb.sql.select. The visible label switches from
-// "Request query" to "Request just-in-time access" accordingly.
+// "Request role" to "Request access grant" accordingly.
 test.describe("RequestQueryButton label tracks the project's JIT flag", () => {
-  test("with JIT off, running a forbidden SELECT shows the non-JIT 'Request query' CTA", async () => {
+  test("with access grants off, running a forbidden SELECT shows the 'Request role' CTA", async () => {
     await setJIT(false);
     await viewerEditor.runPreparedQuery("SELECT 1;");
     await viewerPage.waitForTimeout(800);
 
-    await expect(
-      viewerPage.getByRole("button", { name: "Request query", exact: true }).first(),
-    ).toBeVisible({ timeout: 10_000 });
-    await expect(
-      viewerPage.getByRole("button", { name: /Request just-in-time/i }),
-    ).toHaveCount(0);
+    await expect(viewerEditor.requestRoleButton.first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(viewerEditor.requestAccessGrantButton).toHaveCount(0);
   });
 
-  test("with JIT on, running a forbidden SELECT shows the JIT 'Request just-in-time access' CTA", async () => {
+  test("with access grants on, running a forbidden SELECT shows the 'Request access grant' CTA", async () => {
     await setJIT(true);
     await viewerEditor.runPreparedQuery("SELECT 1;");
     await viewerPage.waitForTimeout(800);
 
-    await expect(
-      viewerPage
-        .getByRole("button", { name: /Request just-in-time access/i })
-        .first(),
-    ).toBeVisible({ timeout: 10_000 });
-    await expect(
-      viewerPage.getByRole("button", { name: "Request query", exact: true }),
-    ).toHaveCount(0);
+    await expect(viewerEditor.requestAccessGrantButton.first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(viewerEditor.requestRoleButton).toHaveCount(0);
   });
 });
 
 // L4 + L5 — the ACCESS pane (visible only when JIT is on) renders a
-// "Request access" button at its top-right. Clicking it opens the
+// "Request access grant" button at its top-right. Clicking it opens the
 // AccessGrantRequestDrawer with the four expected sections.
 //
 // REQUIRES ENTERPRISE LICENSE: the button is gated by
@@ -212,8 +206,8 @@ test.describe("RequestQueryButton label tracks the project's JIT flag", () => {
 // (Playwright's `force: true` bypasses actionability checks but does NOT
 // override the HTML `disabled` attribute, so onClick never fires and the
 // drawer never opens). The license is installed at bootstrap, so the feature is available here.
-test.describe("ACCESS pane Request-access button opens the grant drawer", () => {
-  test("opening the ACCESS tab and clicking Request access opens a drawer with Databases / Statement / Expiration / Reason", async () => {
+test.describe("ACCESS pane Request-access-grant button opens the grant drawer", () => {
+  test("opening the ACCESS tab and clicking Request access grant opens a drawer with Databases / Statement / Expiration / Reason", async () => {
     await setJIT(true);
 
     // Click the ACCESS gutter tab to mount the pane.
@@ -221,25 +215,19 @@ test.describe("ACCESS pane Request-access button opens the grant drawer", () => 
     await viewerPage.waitForTimeout(500);
 
     // The pane's primary action — label from
-    // `sql-editor.request-access` ("Request Access" in en-US).
-    const requestAccessBtn = viewerPage
-      .getByRole("button", { name: /Request Access/i })
-      .first();
+    // `sql-editor.request-access-grant` ("Request access grant" in en-US).
+    const requestAccessBtn = viewerEditor.requestAccessGrantButton.first();
     await expect(requestAccessBtn).toBeVisible({ timeout: 10_000 });
-    // PermissionGuard renders the button as disabled when JIT feature
-    // is unlicensed. The demo build ships the feature on (sample data
-    // includes JIT grants), so we expect enabled — but assert via a
-    // try/catch fallback so a future license change doesn't bury the
-    // structural CUJ. The CUJ here is "the button is present and
-    // wired", which already shows that the pane is on the right
-    // surface.
+    // PermissionGuard renders the button disabled when the JIT feature is
+    // unlicensed; the bootstrap-installed license makes it enabled here.
     await requestAccessBtn.click({ force: true });
     await viewerPage.waitForTimeout(500);
 
-    // Drawer header — i18n key `sql-editor.request-data-access`.
-    await expect(
-      viewerPage.getByText("Request Data Access", { exact: true }).first(),
-    ).toBeVisible({ timeout: 10_000 });
+    // Drawer open — matched by the dialog's accessible name; see
+    // SqlEditorPage.accessGrantDrawer for the button/title collision note.
+    await expect(viewerEditor.accessGrantDrawer).toBeVisible({
+      timeout: 10_000,
+    });
 
     // L5: the labelled regions inside the drawer. Each is a headline
     // above its input — we match the label as a substring because the
@@ -261,21 +249,21 @@ test.describe("ACCESS pane Request-access button opens the grant drawer", () => 
     ]) {
       const re = new RegExp(`^${label}(\\s*\\*)?\\s*$`);
       await expect(
-        viewerPage.getByText(re).first(),
+        viewerEditor.accessGrantDrawer.getByText(re).first(),
         `drawer must contain a "${label}" section`,
       ).toBeVisible({ timeout: 5000 });
     }
 
     // The two capability checkboxes are present AND default UNCHECKED when the
-    // drawer is opened from the generic "Request access" CTA (no pendingCreate).
+    // drawer is opened from the generic ACCESS-pane CTA (no pendingCreate).
     // Asserting unchecked — not just visible — catches a regression that
-    // pre-checks either capability for a plain request. (The "Request export"
-    // entry point pre-checks ONLY Export, not Unmask, after BYT-9654/#20516 —
-    // covered in sql-editor-export.spec.ts.)
-    const unmaskCheckbox = viewerPage.getByRole("checkbox", {
+    // pre-checks either capability for a plain request. (The export-blocked
+    // entry point (RequestExportButton) pre-checks ONLY Export, not Unmask,
+    // after BYT-9654/#20516 — covered in sql-editor-export.spec.ts.)
+    const unmaskCheckbox = viewerEditor.accessGrantDrawer.getByRole("checkbox", {
       name: "See unmasked sensitive data",
     });
-    const exportCheckbox = viewerPage.getByRole("checkbox", {
+    const exportCheckbox = viewerEditor.accessGrantDrawer.getByRole("checkbox", {
       name: "Export the query result",
     });
     await expect(
@@ -285,11 +273,11 @@ test.describe("ACCESS pane Request-access button opens the grant drawer", () => 
     await expect(exportCheckbox).toBeVisible();
     await expect(
       unmaskCheckbox,
-      "Unmask must default unchecked from the generic Request-access CTA",
+      "Unmask must default unchecked from the generic Request-access-grant CTA",
     ).not.toBeChecked();
     await expect(
       exportCheckbox,
-      "Export must default unchecked from the generic Request-access CTA",
+      "Export must default unchecked from the generic Request-access-grant CTA",
     ).not.toBeChecked();
 
     // Close the drawer so any follow-up test doesn't inherit it.
@@ -300,9 +288,9 @@ test.describe("ACCESS pane Request-access button opens the grant drawer", () => 
   });
 });
 
-// BYT-9801 — the Request Data Access picker used to fetch a single flat page of
+// BYT-9801 — the access-grant drawer's database picker used to fetch a single flat page of
 // 100 databases with no server-side search, so any database past that page was
-// invisible AND unsearchable in the JIT drawer (even though the SQL Editor tree
+// invisible AND unsearchable in the drawer (even though the SQL Editor tree
 // found it via per-environment pagination + server search). The fix routes the
 // picker through the shared DatabaseSelect, which re-queries the server on every
 // keystroke (onSearch). This test seeds > one picker page of databases (the
@@ -316,7 +304,7 @@ test.describe("ACCESS pane Request-access button opens the grant drawer", () => 
 // drops onSearch while keeping the 50-row page, the target stays absent AND never
 // appears on search — failing the "found via search" assertion. Either way the
 // server-side-search fix is required for this test to pass.
-test.describe("Request Data Access picker finds a database beyond the first page (BYT-9801)", () => {
+test.describe("access-grant drawer picker finds a database beyond the first page (BYT-9801)", () => {
   const DB_COUNT = 60; // > the picker's first page (50) with comfortable margin
   const dbShortNames = Array.from(
     { length: DB_COUNT },
@@ -415,21 +403,20 @@ test.describe("Request Data Access picker finds a database beyond the first page
   test("a database past the first page is absent initially but found via search", async () => {
     test.setTimeout(120_000);
 
-    // Open the ACCESS pane → Request Access → drawer.
+    // Open the ACCESS pane → Request access grant → drawer.
     await viewerEditor.gutterAccessTab.click();
     await viewerPage.waitForTimeout(500);
-    await viewerPage
-      .getByRole("button", { name: /Request Access/i })
-      .first()
-      .click({ force: true });
-    await expect(
-      viewerPage.getByText("Request Data Access", { exact: true }).first(),
-    ).toBeVisible({ timeout: 10_000 });
+    await viewerEditor.requestAccessGrantButton.first().click({ force: true });
+    await expect(viewerEditor.accessGrantDrawer).toBeVisible({
+      timeout: 10_000,
+    });
 
     // Locate the "Databases" section (label headline + picker) and open the
     // picker's dropdown.
-    const dbSection = viewerPage
-      .locator("div.flex.flex-col.gap-y-2")
+    const dbSection = viewerEditor.accessGrantDrawer
+      // FormField renders StyleX atomic classes since #20942 — target the
+      // stable data-slot attribute, not utility class names.
+      .locator('div[data-slot="form-field"]')
       .filter({ has: viewerPage.getByText(/^Databases\s*\*?$/) })
       .first();
     await dbSection.locator("div.cursor-pointer").first().click();
@@ -458,10 +445,7 @@ test.describe("Request Data Access picker finds a database beyond the first page
     // the combobox) so the option row disappears. The target text remaining
     // proves a selected CHIP was rendered — not merely the still-open row.
     await dbSection.getByText(targetShort, { exact: true }).first().click();
-    await viewerPage
-      .getByText("Request Data Access", { exact: true })
-      .first()
-      .click();
+    await viewerEditor.accessGrantDrawerTitle.click();
     await viewerPage.waitForTimeout(300);
     await expect(
       dbSection.getByText(targetShort, { exact: true }).first(),

--- a/frontend/tests/e2e/sql-editor/sql-editor-export.spec.ts
+++ b/frontend/tests/e2e/sql-editor/sql-editor-export.spec.ts
@@ -3,8 +3,8 @@
 // The export path was rewritten: the client-side `sql-download` formatter
 // library was deleted and export now goes through the backend Export RPC. A
 // workspace `DATA_QUERY` policy (`disableExport`) gates the toolbar's Export
-// button; when export is disabled but the project allows just-in-time access,
-// a new "Request export" affordance replaces it, and an active export grant
+// button; when export is disabled but the project allows access grants,
+// a "Request access grant" affordance replaces it, and an active export grant
 // for the EXACT statement re-enables the real Export button.
 //
 // One file per sub-area (the repo convention): all export CUJs live here as
@@ -16,7 +16,7 @@
 //
 // Groups (CUJ ids from the QA session):
 //   - Direct export (export allowed): C1 backend Export RPC, C9 password
-//   - Gated + JIT on: C2 Request-export, C3/C4 drawer pre-fill (unmask+export)
+//   - Gated + JIT on: C2 Request access grant, C3/C4 drawer pre-fill (export only)
 //   - Gated + JIT off: C8 no affordance
 //   - Multi-statement: C10 one affordance above the tabs
 //   - Active export grant: C7 exact-match re-enable, C5 badge, C6 filter
@@ -258,15 +258,15 @@ test.describe("Direct export when the policy allows it (C1, C9)", () => {
   });
 });
 
-// --- Gated export, JIT on → Request export (C2, C3, C4) -------------------
+// --- Gated export, JIT on → Request access grant (C2, C3, C4) -------------
 
 test.describe("Export gated by policy, JIT enabled (C2, C3, C4)", () => {
-  test('the toolbar shows "Request export" instead of "Export"', async () => {
+  test('the toolbar shows "Request access grant" instead of "Export"', async () => {
     await applyExportState({ disableExport: true, jit: true });
     await sqlEditor.runPreparedQuery("SELECT emp_no, first_name FROM employee LIMIT 5;");
 
     await expect(
-      page.getByRole("button", { name: "Request export", exact: true }).first(),
+      sqlEditor.requestAccessGrantButton.first(),
     ).toBeVisible({ timeout: 10_000 });
     await expect(page.getByRole("button", { name: /^Export$/ })).toHaveCount(0);
     await expect(
@@ -274,28 +274,21 @@ test.describe("Export gated by policy, JIT enabled (C2, C3, C4)", () => {
     ).toBeVisible();
   });
 
-  test('"Request export" opens the grant drawer pre-filled with the statement, DB, and Export checked (unmask not)', async () => {
+  test('the export-blocked "Request access grant" CTA opens the grant drawer pre-filled with the statement, DB, and Export checked (unmask not)', async () => {
     await applyExportState({ disableExport: true, jit: true });
     const statement = "SELECT emp_no, last_name FROM employee LIMIT 4;";
     await sqlEditor.runPreparedQuery(statement);
 
-    await page
-      .getByRole("button", { name: "Request export", exact: true })
-      .first()
-      .click();
+    await sqlEditor.requestAccessGrantButton.first().click();
 
-    const drawer = page
-      .getByRole("dialog")
-      .filter({ hasText: "Request Data Access" });
-    await expect(drawer.getByText("Request Data Access")).toBeVisible({
-      timeout: 10_000,
-    });
+    const drawer = sqlEditor.accessGrantDrawer;
+    await expect(drawer).toBeVisible({ timeout: 10_000 });
     await expect(drawer.getByText(statement)).toBeVisible();
     await expect(drawer.getByText(env.databaseId, { exact: false })).toBeVisible();
 
     // C4: the RequestExportButton scopes its pre-fill to the EXPORT capability
-    // (#20516 changed it from unmask+export to export-only — "Request export"
-    // requests export, not unmasking). So Export is pre-checked and Unmask is
+    // (#20516 changed it from unmask+export to export-only — the export-blocked
+    // CTA requests export, not unmasking). So Export is pre-checked and Unmask is
     // left for the user to opt into.
     await expect(
       drawer.getByRole("checkbox", { name: "Export the query result" }),
@@ -320,17 +313,10 @@ test.describe("Export gated by policy, JIT enabled (C2, C3, C4)", () => {
     const statement = `SELECT emp_no FROM employee WHERE emp_no = ${marker % 100000} LIMIT 1;`;
     await sqlEditor.runPreparedQuery(statement);
 
-    await page
-      .getByRole("button", { name: "Request export", exact: true })
-      .first()
-      .click();
+    await sqlEditor.requestAccessGrantButton.first().click();
 
-    const drawer = page
-      .getByRole("dialog")
-      .filter({ hasText: "Request Data Access" });
-    await expect(drawer.getByText("Request Data Access")).toBeVisible({
-      timeout: 10_000,
-    });
+    const drawer = sqlEditor.accessGrantDrawer;
+    await expect(drawer).toBeVisible({ timeout: 10_000 });
     // Leave the pre-filled capabilities untouched (Export checked, Unmask not).
     await expect(
       drawer.getByRole("checkbox", { name: "Export the query result" }),
@@ -389,7 +375,7 @@ test.describe("Export gated by policy, JIT disabled (C8)", () => {
     ).toBeVisible({ timeout: 10_000 });
     await expect(page.getByRole("button", { name: /^Export$/ })).toHaveCount(0);
     await expect(
-      page.getByRole("button", { name: "Request export", exact: true }),
+      sqlEditor.requestAccessGrantButton,
     ).toHaveCount(0);
   });
 });
@@ -408,7 +394,7 @@ test.describe("Multi-statement result export affordance (C10)", () => {
       page.getByRole("tab", { name: /Query\s*#2/ }).first(),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Request export", exact: true }),
+      sqlEditor.requestAccessGrantButton,
     ).toHaveCount(1);
   });
 });
@@ -454,7 +440,7 @@ test.describe("Active export grant (C5, C6, C7)", () => {
     const exportButton = page.getByRole("button", { name: /^Export$/ }).first();
     await expect(exportButton).toBeVisible({ timeout: 10_000 });
     await expect(
-      page.getByRole("button", { name: "Request export", exact: true }),
+      sqlEditor.requestAccessGrantButton,
     ).toHaveCount(0);
 
     await exportButton.hover();
@@ -486,11 +472,11 @@ test.describe("Active export grant (C5, C6, C7)", () => {
     ).toBeTruthy();
   });
 
-  test("running a DIFFERENT statement keeps export gated (Request export, no Export) (C7)", async () => {
+  test("running a DIFFERENT statement keeps export gated (Request access grant, no Export) (C7)", async () => {
     await sqlEditor.runPreparedQuery(UNGRANTED_STATEMENT);
 
     await expect(
-      page.getByRole("button", { name: "Request export", exact: true }).first(),
+      sqlEditor.requestAccessGrantButton.first(),
     ).toBeVisible({ timeout: 10_000 });
     await expect(page.getByRole("button", { name: /^Export$/ })).toHaveCount(0);
   });
@@ -520,7 +506,7 @@ test.describe("Active export grant (C5, C6, C7)", () => {
 
     const searchRow = page
       .locator("div")
-      .filter({ has: page.getByRole("button", { name: "Request Access" }) })
+      .filter({ has: sqlEditor.requestAccessGrantButton })
       .last();
     await searchRow.locator("input").first().click();
     await page
@@ -530,7 +516,7 @@ test.describe("Active export grant (C5, C6, C7)", () => {
     await page.waitForTimeout(800);
 
     await expect(page.getByText(GRANTED_STATEMENT)).toHaveCount(0);
-    await expect(page.getByText("No access requests")).toBeVisible({
+    await expect(page.getByText("No access grants")).toBeVisible({
       timeout: 5000,
     });
   });
@@ -801,12 +787,8 @@ test.describe("Re-requesting a revoked grant restores Unmask AND Export (BYT-965
     ).toBeVisible();
     await grantRow.getByRole("button", { name: "Re-request" }).click();
 
-    const drawer = page
-      .getByRole("dialog")
-      .filter({ hasText: "Request Data Access" });
-    await expect(drawer.getByText("Request Data Access")).toBeVisible({
-      timeout: 10_000,
-    });
+    const drawer = sqlEditor.accessGrantDrawer;
+    await expect(drawer).toBeVisible({ timeout: 10_000 });
 
     // Both capabilities the original grant held must be pre-checked on
     // re-request. Unmask was always carried over; Export is the one BYT-9656

--- a/frontend/tests/e2e/sql-editor/sql-editor-permissions.spec.ts
+++ b/frontend/tests/e2e/sql-editor/sql-editor-permissions.spec.ts
@@ -2,9 +2,9 @@
 //
 // Covers:
 //   - I1  admin wrench absent for projectDeveloper
-//   - I4  RequestQueryButton ("Request query") on a non-JIT project
+//   - I4  RequestQueryButton ("Request role") on a non-JIT project
 //         where the user lacks bb.sql.select
-//   - I9  Sidebar surfaces the same Request-query affordance when the
+//   - I9  Sidebar surfaces the same Request-role affordance when the
 //         user lands on a database they have no access to
 //   - I10 admin wrench absent for sqlEditorUser
 //   - I11 INSERT denied (no "EditorHint" modal, just an inline error
@@ -228,13 +228,16 @@ test.describe("INSERT is denied with an inline error for sqlEditorReadUser", () 
 
     // The error pane renders the permission detail somewhere in the
     // result region. We accept any of the common shapes: an explicit
-    // "permission" mention, the role name, or the request-query CTA.
+    // "permission" mention, the role name, or the request-role /
+    // request-access-grant CTA.
     // The strong assertion is that the row-count footer DID NOT appear
     // (Run reached an error state) AND a request affordance is offered.
     const permissionMention = rc.page.getByText(
       /(permission denied|no.*permission|bb\.sql\.(update|delete|create|admin|insert)|missing.*permission)/i,
     );
-    const requestCTA = rc.page.getByRole("button", { name: /Request query|Request just-in-time/i });
+    const requestCTA = rc.sqlEditor.requestRoleButton.or(
+      rc.sqlEditor.requestAccessGrantButton,
+    );
     const anySignal = permissionMention.or(requestCTA).first();
     await expect(anySignal).toBeVisible({ timeout: 10_000 });
 
@@ -248,18 +251,19 @@ test.describe("INSERT is denied with an inline error for sqlEditorReadUser", () 
 //     Request button at all, regardless of permission state).
 //   - `project.allowRequestRole === true` AND user lacks bb.sql.select →
 //     the button renders. Label switches on `useJIT` (non-JIT label is
-//     "Request query" — covered here; JIT label is in sql-editor-jit.spec.ts).
+//     "Request role" — covered here; the access-grant label is in
+//     sql-editor-access-grants.spec.ts).
 //
 // The new bootstrap creates `project-sample` with `allowRequestRole=false`
 // by default (sampleinstance/manager.go:171 uses an empty Setting). We
 // exercise BOTH halves of the gate so a future regression on either side
 // is caught:
 //   D1 ("…off → no button"): projectViewer + allowRequestRole=false →
-//     no Request query button (the negative case the framework relies on).
+//     no Request role button (the negative case the framework relies on).
 //   D2 ("…on → button"): flip allowRequestRole=true via API, re-navigate,
 //     verify the button now renders. afterEach flips it back.
 
-test.describe("Request-query CTA respects project.allowRequestRole", () => {
+test.describe("Request-role CTA respects project.allowRequestRole", () => {
   test.afterEach(async () => {
     // Always restore to the default-off state so other tests in this
     // file (and downstream specs that share env.project) inherit a
@@ -269,7 +273,7 @@ test.describe("Request-query CTA respects project.allowRequestRole", () => {
       .catch(() => {});
   });
 
-  test("with allowRequestRole=false, projectViewer running a forbidden SELECT sees NO Request query button", async () => {
+  test("with allowRequestRole=false, projectViewer running a forbidden SELECT sees NO Request role button", async () => {
     // Confirm the seeded state (sample project is created with
     // allowRequestRole=false). RequestQueryButton's `if (!available)
     // return null` then suppresses both the non-JIT and JIT variants.
@@ -282,15 +286,11 @@ test.describe("Request-query CTA respects project.allowRequestRole", () => {
     await rc.page.waitForTimeout(800);
 
     // Neither label should appear — the component returned null.
-    await expect(
-      rc.page.getByRole("button", { name: "Request query", exact: true }),
-    ).toHaveCount(0);
-    await expect(
-      rc.page.getByRole("button", { name: /Request just-in-time/i }),
-    ).toHaveCount(0);
+    await expect(rc.sqlEditor.requestRoleButton).toHaveCount(0);
+    await expect(rc.sqlEditor.requestAccessGrantButton).toHaveCount(0);
   });
 
-  test("with allowRequestRole=true, projectViewer running a forbidden SELECT sees the 'Request query' button", async () => {
+  test("with allowRequestRole=true, projectViewer running a forbidden SELECT sees the 'Request role' button", async () => {
     // Flip the project's allowRequestRole on. Once the editor re-reads
     // the project (we force a fresh navigation), the button renders.
     await env.api.updateProjectSettings(env.project, { allowRequestRole: true });
@@ -301,16 +301,14 @@ test.describe("Request-query CTA respects project.allowRequestRole", () => {
     await rc.sqlEditor.runPreparedQuery("SELECT 1;");
     await rc.page.waitForTimeout(800);
 
-    // Non-JIT label — `sql-editor.request-query` → "Request query".
-    await expect(
-      rc.page.getByRole("button", { name: "Request query", exact: true }).first(),
-    ).toBeVisible({ timeout: 10_000 });
+    // Non-JIT label — `issue.title.request-role` → "Request role".
+    await expect(rc.sqlEditor.requestRoleButton.first()).toBeVisible({
+      timeout: 10_000,
+    });
 
-    // JIT variant must NOT show — this project has
+    // Access-grant variant must NOT show — this project has
     // allowJustInTimeAccess=false (its default), so `useJIT` resolves
     // to false and the label switch picks the non-JIT side.
-    await expect(
-      rc.page.getByRole("button", { name: /Request just-in-time/i }),
-    ).toHaveCount(0);
+    await expect(rc.sqlEditor.requestAccessGrantButton).toHaveCount(0);
   });
 });

--- a/frontend/tests/e2e/sql-editor/sql-editor.page.ts
+++ b/frontend/tests/e2e/sql-editor/sql-editor.page.ts
@@ -14,6 +14,10 @@ export class SqlEditorPage {
   readonly gutterSchemaTab: Locator;
   readonly gutterHistoryTab: Locator;
   readonly gutterAccessTab: Locator;
+  readonly requestAccessGrantButton: Locator;
+  readonly requestRoleButton: Locator;
+  readonly accessGrantDrawer: Locator;
+  readonly accessGrantDrawerTitle: Locator;
 
   constructor(page: Page, baseURL = "") {
     this.page = page;
@@ -49,11 +53,36 @@ export class SqlEditorPage {
     this.gutterHistoryTab = page.getByRole("button", { name: "History", exact: true });
     // ACCESS gutter tab only renders when project.allowJustInTimeAccess=true.
     // The button's screen-reader name comes from i18n key
-    // `sql-editor.jit` → "Just-In-Time Access" (not the shorter "Access"
-    // — that's the label of an entirely different "Data Access" sidebar
-    // entry in the workspace nav).
+    // `sql-editor.access-grants` → "Access Grants" (shared with the project
+    // sidebar's Access Grants page — both list the same objects).
     this.gutterAccessTab = page.getByRole("button", {
-      name: "Just-In-Time Access",
+      name: "Access Grants",
+      exact: true,
+    });
+    // "Request access grant" is ONE shared label (i18n key
+    // `sql-editor.request-access-grant`) used by every entry point that opens
+    // the grant drawer — ACCESS pane CTA, permission-denied result button,
+    // masked-cell popover, export-blocked toolbar button — AND by the drawer's
+    // own SheetTitle. Button and drawer title are therefore textually
+    // identical: match buttons by role=button, and match the drawer by its
+    // accessible name (SheetTitle wraps BaseDialog.Title, which labels the
+    // dialog), so the two never collide.
+    this.requestAccessGrantButton = page.getByRole("button", {
+      name: "Request access grant",
+      exact: true,
+    });
+    // Non-JIT permission-denied CTA (opens RequestRoleSheet); label comes from
+    // i18n key `issue.title.request-role`, shared with the Members page.
+    this.requestRoleButton = page.getByRole("button", {
+      name: "Request role",
+      exact: true,
+    });
+    this.accessGrantDrawer = page.getByRole("dialog", {
+      name: "Request access grant",
+      exact: true,
+    });
+    this.accessGrantDrawerTitle = this.accessGrantDrawer.getByRole("heading", {
+      name: "Request access grant",
       exact: true,
     });
   }


### PR DESCRIPTION
Implements the wording half of [BYT-9840](https://linear.app/bytebase/issue/BYT-9840/unclear-text-copy-in-request-query-request-just-in-time-access) (parent: BYT-9954, JIT Data Access Phase III). Design reviewed and locked 2026-07-29.

## What & why

The product shipped one object under six names — **Just-In-Time access** (project toggle), **Just-In-Time Access** (SQL Editor tab), **Request Access** (pane CTA), **Request Data Access** (drawer title), **Request just-in-time access** (permission-denied buttons), **JIT access request by …** (default issue title) — while the API (`AccessGrantService`, `ACCESS_GRANT`) and the docs Database Permission section already converged on **access grant**. Root cause: labels named the workflow (just-in-time) or the lost capability (query/export) instead of the object the user receives. The naming contract applied here: **labels name objects** — *access grant* and *role* are the only nouns; "just-in-time" survives in docs only.

## Changes

**Frontend (en + zh/ja/es/vi + dynamic locales)**
- Project setting: **"Allow access grants"** — "Allow project members to request time-boxed access grants for specific read-only statements."
- SQL Editor gutter tab reuses **"Access Grants"** (same i18n key as the project sidebar page); five request labels (`request-access`, `request-jit`, `request-data-access`, `request-export`, `request-query`) collapse into **one** shared key → **"Request access grant"** on every entry point that opens the grant drawer (pane CTA, denied-query button, masked-cell popover, export-blocked button) and on the drawer title itself.
- The non-JIT denied-state button now says **"Request role"** — it opens the RequestRoleSheet, so the old "Request query" label named the wrong thing (Case 1 in BYT-9840).
- Approval source label: **"Request Access Grant"** (Title Case, matching its enumeration siblings); plan feature `FEATURE_JIT` title: **"Access grants"**.
- Casing rule: sentence case by default; Title Case only for proper nouns and inside already-uniform Title Case enumerations (nav, approval sources, issue-type filters).
- Locale glossary invariant enforced per language (one object term, one request verb): zh 访问授权/申请, ja アクセス付与 (also fixed six legacy keys that still said アクセス権限/アクセス許可 on the same surfaces), es concesión de acceso (also fixed the pre-existing "Rol de solicitud" mistranslation), vi cấp quyền truy cập.
- **New CI gate**: `check-react-i18n.mjs` check 5 fails the build if any locale *value* reintroduces `just-in-time`, `JIT`, `ジャストインタイム`, `即时访问`, or `truy cập tức thời` (keys and code identifiers exempt).
- Three expiration-validation strings shared by RequestRoleSheet, MembersPage, and the grant drawer moved to `common.*` (removes a cross-namespace coupling where editing role copy silently rewrote grant copy).

**Backend**
- Default issue title: `"Access grant request by %s"` (was `"JIT access request by %s"`); expiration error says "maximum access grant expiration". Merged two identical switch branches. Existing issues keep their stored titles.

**Unchanged by design (compat):** proto field `allow_just_in_time_access`, enums `FEATURE_JIT` / `REQUEST_ACCESS`, `AccessGrantService`, issue type `ACCESS_GRANT`, route paths, store schema. Proto *comments* and the Terraform provider descriptions follow in separate PRs.

**Known trade-off (locked design decision):** the export-blocked toolbar button and the ACCESS-pane CTA now share the label "Request access grant" with different drawer pre-fills (export pre-checked vs. blank). Context and the pre-checked capability carry the specificity; one label per object was chosen deliberately.

## Testing

- `pnpm fix/check/type-check/test`: all green, 3342/3342 unit tests; `golangci-lint` 0 issues; i18n checker validates key parity across all 5 locales + the new banned-wording gate.
- E2e: `sql-editor-jit.spec.ts` renamed to `sql-editor-access-grants.spec.ts`; volatile labels hoisted into `SqlEditorPage` locators (exact-match, dialog-scoped via accessible name). Touched specs (access-grants, export, permissions): **26/26 pass**. Full licensed suite: 169/180 — all 11 failures reproduce identically on a pure-main baseline build at the merge-base (pre-existing since the #20942 reorg; tracked separately). This branch additionally *repairs* one of them (the BYT-9801 picker test's stale `div.flex.flex-col.gap-y-2` locator → `div[data-slot="form-field"]`).
- Reviewed to convergence over four rounds (simplify + multi-dimension review workflow + Codex review + Codex adversarial review); ~20 findings fixed, final adversarial verdict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)