### PR TITLE
revert: downgrade go-ora from v3 back to v2.9.0

### DIFF
--- a/backend/plugin/db/oracle/oracle.go
+++ b/backend/plugin/db/oracle/oracle.go
@@ -14,7 +14,7 @@ import (
 	// Import go-ora Oracle driver.
 
 	"github.com/pkg/errors"
-	goora "github.com/sijms/go-ora/v3"
+	goora "github.com/sijms/go-ora/v2"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/bytebase/bytebase/backend/common"

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/shopspring/decimal v1.4.0
-	github.com/sijms/go-ora/v3 v3.0.2-0.20260725105946-e99dcc874d16
+	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/snowflakedb/gosnowflake/v2 v2.1.0
 	github.com/sourcegraph/conc v0.3.0
 	github.com/sourcegraph/jsonrpc2 v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -911,8 +911,6 @@ github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed h1:KMgQoLJGCq1Io
 github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
 github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg=
 github.com/sijms/go-ora/v2 v2.9.0/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
-github.com/sijms/go-ora/v3 v3.0.2-0.20260725105946-e99dcc874d16 h1:hFkFR1wfcZtZ8Dmq73tylsyT6HSQf7LdDEWAhDRL3Mk=
-github.com/sijms/go-ora/v3 v3.0.2-0.20260725105946-e99dcc874d16/go.mod h1:9NMI4/C/J9ExE/YNgQQlZXic2U1aCLHchJmmnDOK0jM=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=


### PR DESCRIPTION
## What

Reverts the go-ora Oracle driver from v3 (master digest `e99dcc8`, brought in by #21024) back to v2.9.0 — the version shipped through 3.20.x. Import-path + go.mod only; our entire go-ora API surface (`goora.BuildUrl` and the registered `oracle` database/sql driver name) is identical across v2/v3.

## Why

go-ora v3 cannot connect to Oracle 11g and older. Reported against 3.21.0 within a day of release: https://github.com/bytebase/bytebase/issues/20927#issuecomment-5140864020

- v3's `newAcceptPacketFromData` unconditionally reads TNS accept-packet bytes `[41:45]` for the fast-auth negotiation flags (`NegotiatedOptions2`), added upstream in `c41e3eb` ("add support for fast negotiation/login").
- Servers speaking TNS protocol ≤ 314 (Oracle ≤ 11g) reply with a 32-byte accept packet, so every connection attempt panics during the handshake, before any query runs:

  ```
  runtime error: slice bounds out of range [41:32]
  github.com/sijms/go-ora/v3/network.newAcceptPacketFromData
      network/accept_packet.go:61
  ```

- The bug is present in the v3.0.1 tag, our pinned digest, and upstream master as of today. v2.9.0 never reads past offset 40, and its offset 32–40 reads are guarded by the negotiated protocol version — which is why 11g worked through 3.20.x.
- CI could not catch it: the Oracle testcontainer jobs run gvenzl/oracle-free (23ai), which negotiates a modern TNS version with a longer accept packet.

Downgrading also restores `ColumnTypeDatabaseTypeName`, which v3 stubs to return `""` — the accepted trade-off in #21024 that degraded Oracle timestamps/numbers in query results to generic string rendering.

Re-attempt the v3 major once upstream ships a release that length-guards the accept-packet parse and restores column type metadata. Upstream fix PR: https://github.com/sijms/go-ora/pull/737

## Testing

- `go test ./backend/plugin/db/oracle/...` passes
- `go test ./backend/plugin/schema/oracle/ -run '^TestGetDatabaseMetadataWithTestcontainer$'` passes against a live Oracle container (gvenzl/oracle-free)
- Full server build (`go build -ldflags "-w -s" ... ./backend/bin/server/main.go`) passes
- `golangci-lint run --allow-parallel-runners ./backend/plugin/db/oracle/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
