### PR TITLE
cherrypick: [release/3.21.0] revert: downgrade go-ora from v3 back to v2.9.0

### DIFF
--- a/backend/plugin/db/oracle/oracle.go
+++ b/backend/plugin/db/oracle/oracle.go
@@ -14,7 +14,7 @@ import (
 	// Import go-ora Oracle driver.
 
 	"github.com/pkg/errors"
-	goora "github.com/sijms/go-ora/v3"
+	goora "github.com/sijms/go-ora/v2"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/bytebase/bytebase/backend/common"

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/redis/go-redis/v9 v9.21.0
 	github.com/shopspring/decimal v1.4.0
-	github.com/sijms/go-ora/v3 v3.0.2-0.20260725105946-e99dcc874d16
+	github.com/sijms/go-ora/v2 v2.9.0
 	github.com/snowflakedb/gosnowflake/v2 v2.1.0
 	github.com/sourcegraph/conc v0.3.0
 	github.com/sourcegraph/jsonrpc2 v0.2.1

--- a/go.sum
+++ b/go.sum
@@ -911,8 +911,6 @@ github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed h1:KMgQoLJGCq1Io
 github.com/siddontang/go-log v0.0.0-20190221022429-1e957dd83bed/go.mod h1:yFdBgwXP24JziuRl2NMUahT7nGLNOKi1SIiFxMttVD4=
 github.com/sijms/go-ora/v2 v2.9.0 h1:+iQbUeTeCOFMb5BsOMgUhV8KWyrv9yjKpcK4x7+MFrg=
 github.com/sijms/go-ora/v2 v2.9.0/go.mod h1:QgFInVi3ZWyqAiJwzBQA+nbKYKH77tdp1PYoCqhR2dU=
-github.com/sijms/go-ora/v3 v3.0.2-0.20260725105946-e99dcc874d16 h1:hFkFR1wfcZtZ8Dmq73tylsyT6HSQf7LdDEWAhDRL3Mk=
-github.com/sijms/go-ora/v3 v3.0.2-0.20260725105946-e99dcc874d16/go.mod h1:9NMI4/C/J9ExE/YNgQQlZXic2U1aCLHchJmmnDOK0jM=
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=


### PR DESCRIPTION
Cherry-pick of #21087 onto `release/3.21.0` for a 3.21.1 patch release.

go-ora v3 (shipped in 3.21.0 via #21024) cannot connect to Oracle 11g and older: v3's `newAcceptPacketFromData` unconditionally reads TNS accept-packet bytes `[41:45]`, but servers speaking TNS protocol ≤ 314 reply with a 32-byte accept packet, so every connection attempt panics with `slice bounds out of range [41:32]` during the handshake. Reported against 3.21.0 within a day of release: https://github.com/bytebase/bytebase/issues/20927#issuecomment-5140864020

Reverting to v2.9.0 (the driver shipped through 3.20.x) restores connectivity and also restores `ColumnTypeDatabaseTypeName`-based query result typing, which v3 stubs out. See #21087 for the full analysis.

## Testing

- `go test ./backend/plugin/db/oracle/...` passes on this branch
- Full server build passes on this branch
- On the main branch (same change): Oracle testcontainer metadata tests pass against a live Oracle container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
