### PR TITLE
fix: harden ACL error handling

### DIFF
--- a/backend/api/v1/acl.go
+++ b/backend/api/v1/acl.go
@@ -213,14 +213,11 @@ func (in *ACLInterceptor) doACLCheck(ctx context.Context, request any, fullMetho
 }
 
 func resourceResolutionConnectError(err error) error {
-	switch common.ErrorCode(err) {
-	case common.Invalid:
-		return connect.NewError(connect.CodeInvalidArgument, err)
-	case common.NotFound:
-		return connect.NewError(connect.CodeNotFound, err)
-	default:
-		return connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to populate raw resources"))
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		return err
 	}
+	return connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to populate raw resources"))
 }
 
 func getPermissionForRequest(request any, defaultPermission permission.Permission) permission.Permission {
@@ -377,15 +374,16 @@ func resolveProjectResource(ctx context.Context, stores *store.Store, parts []st
 	if err != nil {
 		return nil, err
 	}
+	workspaceID := common.GetWorkspaceIDFromContext(ctx)
 	project, err := stores.GetProject(ctx, &store.FindProjectMessage{
-		Workspace:  common.GetWorkspaceIDFromContext(ctx),
+		Workspace:  workspaceID,
 		ResourceID: &projectID,
 	})
 	if err != nil {
-		return nil, common.Wrapf(err, common.Internal, "failed to get project")
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get project"))
 	}
-	if project == nil {
-		return nil, common.Errorf(common.NotFound, "project %q not found", projectID)
+	if project == nil || project.Workspace != workspaceID {
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %q not found", projectID))
 	}
 	return &common.Resource{Type: common.ResourceTypeProject, ID: projectID}, nil
 }
@@ -429,10 +427,10 @@ func resolveProjectDatabaseResource(ctx context.Context, stores *store.Store, pa
 		ShowDeleted:  true,
 	})
 	if err != nil {
-		return nil, common.Wrapf(err, common.Internal, "failed to get database")
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get database"))
 	}
 	if database == nil {
-		return nil, common.Errorf(common.NotFound, "database %q not found", strings.Join(parts[:6], "/"))
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found", strings.Join(parts[:6], "/")))
 	}
 	return &common.Resource{Type: common.ResourceTypeProject, ID: projectID}, nil
 }
@@ -449,10 +447,10 @@ func resolveWorkspaceInstanceResource(ctx context.Context, stores *store.Store, 
 		ResourceID:    &instanceID,
 	})
 	if err != nil {
-		return nil, common.Wrapf(err, common.Internal, "failed to get instance")
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get instance"))
 	}
-	if instance == nil {
-		return nil, common.Errorf(common.NotFound, "instance %q not found", strings.Join(parts[:2], "/"))
+	if instance == nil || instance.Workspace != workspaceID {
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", strings.Join(parts[:2], "/")))
 	}
 	return &common.Resource{Type: common.ResourceTypeWorkspace, ID: workspaceID}, nil
 }
@@ -473,10 +471,10 @@ func resolveWorkspaceDatabaseResource(ctx context.Context, stores *store.Store, 
 		ResourceID:    &instanceID,
 	})
 	if err != nil {
-		return nil, common.Wrapf(err, common.Internal, "failed to get instance")
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get instance"))
 	}
-	if instance == nil {
-		return nil, common.Errorf(common.NotFound, "instance %q not found", instanceID)
+	if instance == nil || instance.Workspace != workspaceID {
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", instanceID))
 	}
 	database, err := stores.GetDatabase(ctx, &store.FindDatabaseMessage{
 		Workspace:    workspaceID,
@@ -485,17 +483,17 @@ func resolveWorkspaceDatabaseResource(ctx context.Context, stores *store.Store, 
 		ShowDeleted:  true,
 	})
 	if err != nil {
-		return nil, common.Wrapf(err, common.Internal, "failed to get database")
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get database"))
 	}
 	if database == nil {
-		return nil, common.Errorf(common.NotFound, "database %q not found", strings.Join(parts[:4], "/"))
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found", strings.Join(parts[:4], "/")))
 	}
 	return &common.Resource{Type: common.ResourceTypeProject, ID: database.ProjectID}, nil
 }
 
 func requiredResourceIdentifier(parts []string, index int, collection string) (string, error) {
 	if len(parts) <= index || parts[index] == "" {
-		return "", common.Errorf(common.Invalid, "invalid %s resource %q", collection, strings.Join(parts, "/"))
+		return "", connect.NewError(connect.CodeInvalidArgument, errors.Errorf("invalid %s resource %q", collection, strings.Join(parts, "/")))
 	}
 	return parts[index], nil
 }
@@ -528,16 +526,17 @@ func populateRawResources(ctx context.Context, stores *store.Store, request any,
 }
 
 func getProjectScopedInstance(ctx context.Context, stores *store.Store, projectID, instanceID string) (*store.InstanceMessage, error) {
+	workspaceID := common.GetWorkspaceIDFromContext(ctx)
 	instance, err := stores.GetInstance(ctx, &store.FindInstanceMessage{
-		Workspace:  common.GetWorkspaceIDFromContext(ctx),
+		Workspace:  workspaceID,
 		ProjectID:  &projectID,
 		ResourceID: &instanceID,
 	})
 	if err != nil {
-		return nil, common.Wrapf(err, common.Internal, "failed to get instance")
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get instance"))
 	}
-	if instance == nil {
-		return nil, common.Errorf(common.NotFound, "instance %q not found", common.FormatProjectInstance(projectID, instanceID))
+	if instance == nil || instance.Workspace != workspaceID {
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", common.FormatProjectInstance(projectID, instanceID)))
 	}
 	return instance, nil
 }
@@ -545,13 +544,13 @@ func getProjectScopedInstance(ctx context.Context, stores *store.Store, projectI
 func getResourceFromRequest(ctx context.Context, request any, method string) ([]string, error) {
 	pm, ok := request.(proto.Message)
 	if !ok {
-		return nil, common.Errorf(common.Invalid, "invalid request for method %q", method)
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("invalid request for method %q", method))
 	}
 	mr := pm.ProtoReflect()
 
 	methodTokens := strings.Split(method, "/")
 	if len(methodTokens) != 3 {
-		return nil, common.Errorf(common.Invalid, "invalid method %q", method)
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("invalid method %q", method))
 	}
 	shortMethod := methodTokens[2]
 
@@ -614,7 +613,7 @@ func getResourceFromRequest(ctx context.Context, request any, method string) ([]
 		if hasPath(r.GetUpdateMask(), "project") {
 			projectID, err := common.GetProjectID(r.GetDatabase().GetProject())
 			if err != nil {
-				return nil, common.Wrapf(err, common.Invalid, "failed to get projectID from %q", r.GetDatabase().GetProject())
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to get projectID from %q", r.GetDatabase().GetProject()))
 			}
 			// Allow to transfer databases to the default project.
 			if common.IsDefaultProject(common.GetWorkspaceIDFromContext(ctx), projectID) {

--- a/backend/api/v1/acl.go
+++ b/backend/api/v1/acl.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"log/slog"
 	"regexp"
 	"strings"
 
@@ -16,7 +15,6 @@ import (
 
 	"github.com/bytebase/bytebase/backend/api/auth"
 	"github.com/bytebase/bytebase/backend/common"
-	"github.com/bytebase/bytebase/backend/common/log"
 	"github.com/bytebase/bytebase/backend/common/permission"
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/component/iam"
@@ -118,29 +116,11 @@ func hasAllowMissingEnabled(request any) bool {
 }
 
 func (in *ACLInterceptor) doACLCheck(ctx context.Context, request any, fullMethod string) error {
-	defer func() {
-		if r := recover(); r != nil {
-			perr, ok := r.(error)
-			if !ok {
-				perr = errors.Errorf("%v", r)
-			}
-			slog.Error("iam check PANIC RECOVER", log.BBError(perr), log.BBStack("panic-stack"))
-		}
-	}()
-
 	authContextAny := ctx.Value(common.AuthContextKey)
 	authContext, ok := authContextAny.(*common.AuthContext)
 	if !ok {
 		return connect.NewError(connect.CodeInternal, errors.New("auth context not found"))
 	}
-	resources, err := populateRawResources(ctx, in.store, request, fullMethod)
-	if err != nil {
-		if common.ErrorCode(err) == common.NotFound {
-			return connect.NewError(connect.CodeNotFound, err)
-		}
-		return connect.NewError(connect.CodeInternal, errors.Errorf("failed to populate raw resources %s", err))
-	}
-	authContext.Resources = resources
 	authContext.Permission = getPermissionForRequest(request, authContext.Permission)
 
 	if auth.IsAuthenticationSkipped(fullMethod, authContext) {
@@ -160,10 +140,16 @@ func (in *ACLInterceptor) doACLCheck(ctx context.Context, request any, fullMetho
 	if workspaceID == "" {
 		return connect.NewError(connect.CodeUnauthenticated, errors.Errorf("empty workspace id"))
 	}
+	resources, err := populateRawResources(ctx, in.store, request, fullMethod)
+	if err != nil {
+		return resourceResolutionConnectError(err)
+	}
+	authContext.Resources = resources
 
 	// Workspace isolation: verify all resources belong to the caller's workspace.
-	// Instance and database ownership is already validated in populateRawResources
-	// (via workspace-filtered store lookups). Here we validate workspace and project resources.
+	// Project, instance, and database ownership is already validated in
+	// populateRawResources via workspace-filtered store lookups. Here we validate
+	// workspace resources.
 	// Runs after authentication so unauthenticated requests get 401 first,
 	// preventing resource existence probing.
 	for _, resource := range authContext.Resources {
@@ -171,14 +157,6 @@ func (in *ACLInterceptor) doACLCheck(ctx context.Context, request any, fullMetho
 		case common.ResourceTypeWorkspace:
 			if resource.ID != workspaceID {
 				return connect.NewError(connect.CodePermissionDenied, errors.Errorf("workspace mismatch"))
-			}
-		case common.ResourceTypeProject:
-			project, err := in.store.GetProject(ctx, &store.FindProjectMessage{Workspace: workspaceID, ResourceID: &resource.ID})
-			if err != nil {
-				return connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get project"))
-			}
-			if project == nil || project.Workspace != workspaceID {
-				return connect.NewError(connect.CodeNotFound, errors.Errorf("project %q not found", resource.ID))
 			}
 		default:
 		}
@@ -232,6 +210,17 @@ func (in *ACLInterceptor) doACLCheck(ctx context.Context, request any, fullMetho
 	}
 
 	return nil
+}
+
+func resourceResolutionConnectError(err error) error {
+	switch common.ErrorCode(err) {
+	case common.Invalid:
+		return connect.NewError(connect.CodeInvalidArgument, err)
+	case common.NotFound:
+		return connect.NewError(connect.CodeNotFound, err)
+	default:
+		return connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to populate raw resources"))
+	}
 }
 
 func getPermissionForRequest(request any, defaultPermission permission.Permission) permission.Permission {
@@ -383,10 +372,20 @@ func resolveWorkspaceResource(_ context.Context, _ *store.Store, parts []string)
 	return &common.Resource{Type: common.ResourceTypeWorkspace, ID: workspaceID}, nil
 }
 
-func resolveProjectResource(_ context.Context, _ *store.Store, parts []string) (*common.Resource, error) {
+func resolveProjectResource(ctx context.Context, stores *store.Store, parts []string) (*common.Resource, error) {
 	projectID, err := requiredResourceIdentifier(parts, 1, projectCollection)
 	if err != nil {
 		return nil, err
+	}
+	project, err := stores.GetProject(ctx, &store.FindProjectMessage{
+		Workspace:  common.GetWorkspaceIDFromContext(ctx),
+		ResourceID: &projectID,
+	})
+	if err != nil {
+		return nil, common.Wrapf(err, common.Internal, "failed to get project")
+	}
+	if project == nil {
+		return nil, common.Errorf(common.NotFound, "project %q not found", projectID)
 	}
 	return &common.Resource{Type: common.ResourceTypeProject, ID: projectID}, nil
 }
@@ -430,7 +429,7 @@ func resolveProjectDatabaseResource(ctx context.Context, stores *store.Store, pa
 		ShowDeleted:  true,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get database")
+		return nil, common.Wrapf(err, common.Internal, "failed to get database")
 	}
 	if database == nil {
 		return nil, common.Errorf(common.NotFound, "database %q not found", strings.Join(parts[:6], "/"))
@@ -450,7 +449,7 @@ func resolveWorkspaceInstanceResource(ctx context.Context, stores *store.Store, 
 		ResourceID:    &instanceID,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get instance")
+		return nil, common.Wrapf(err, common.Internal, "failed to get instance")
 	}
 	if instance == nil {
 		return nil, common.Errorf(common.NotFound, "instance %q not found", strings.Join(parts[:2], "/"))
@@ -474,10 +473,10 @@ func resolveWorkspaceDatabaseResource(ctx context.Context, stores *store.Store, 
 		ResourceID:    &instanceID,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get instance")
+		return nil, common.Wrapf(err, common.Internal, "failed to get instance")
 	}
 	if instance == nil {
-		return nil, errors.Errorf("instance %q not found", instanceID)
+		return nil, common.Errorf(common.NotFound, "instance %q not found", instanceID)
 	}
 	database, err := stores.GetDatabase(ctx, &store.FindDatabaseMessage{
 		Workspace:    workspaceID,
@@ -486,7 +485,7 @@ func resolveWorkspaceDatabaseResource(ctx context.Context, stores *store.Store, 
 		ShowDeleted:  true,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get database")
+		return nil, common.Wrapf(err, common.Internal, "failed to get database")
 	}
 	if database == nil {
 		return nil, common.Errorf(common.NotFound, "database %q not found", strings.Join(parts[:4], "/"))
@@ -496,7 +495,7 @@ func resolveWorkspaceDatabaseResource(ctx context.Context, stores *store.Store, 
 
 func requiredResourceIdentifier(parts []string, index int, collection string) (string, error) {
 	if len(parts) <= index || parts[index] == "" {
-		return "", errors.Errorf("invalid %s resource %q", collection, strings.Join(parts, "/"))
+		return "", common.Errorf(common.Invalid, "invalid %s resource %q", collection, strings.Join(parts, "/"))
 	}
 	return parts[index], nil
 }
@@ -535,7 +534,7 @@ func getProjectScopedInstance(ctx context.Context, stores *store.Store, projectI
 		ResourceID: &instanceID,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get instance")
+		return nil, common.Wrapf(err, common.Internal, "failed to get instance")
 	}
 	if instance == nil {
 		return nil, common.Errorf(common.NotFound, "instance %q not found", common.FormatProjectInstance(projectID, instanceID))
@@ -546,13 +545,13 @@ func getProjectScopedInstance(ctx context.Context, stores *store.Store, projectI
 func getResourceFromRequest(ctx context.Context, request any, method string) ([]string, error) {
 	pm, ok := request.(proto.Message)
 	if !ok {
-		return nil, errors.Errorf("invalid request for method %q", method)
+		return nil, common.Errorf(common.Invalid, "invalid request for method %q", method)
 	}
 	mr := pm.ProtoReflect()
 
 	methodTokens := strings.Split(method, "/")
 	if len(methodTokens) != 3 {
-		return nil, errors.Errorf("invalid method %q", method)
+		return nil, common.Errorf(common.Invalid, "invalid method %q", method)
 	}
 	shortMethod := methodTokens[2]
 
@@ -615,7 +614,7 @@ func getResourceFromRequest(ctx context.Context, request any, method string) ([]
 		if hasPath(r.GetUpdateMask(), "project") {
 			projectID, err := common.GetProjectID(r.GetDatabase().GetProject())
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get projectID from %q", r.GetDatabase().GetProject())
+				return nil, common.Wrapf(err, common.Invalid, "failed to get projectID from %q", r.GetDatabase().GetProject())
 			}
 			// Allow to transfer databases to the default project.
 			if common.IsDefaultProject(common.GetWorkspaceIDFromContext(ctx), projectID) {

--- a/backend/api/v1/acl_test.go
+++ b/backend/api/v1/acl_test.go
@@ -4,13 +4,89 @@ import (
 	"context"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/permission"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/store"
 )
+
+const getDatabaseProcedure = "/bytebase.v1.DatabaseService/GetDatabase"
+
+func TestACLCheckResourceResolutionStatus(t *testing.T) {
+	ctx, stores, _, _, _, _ := setupWorkspaceInstanceDescendantServiceTest(t)
+	interceptor := NewACLInterceptor(stores, "", nil, nil)
+
+	for _, test := range []struct {
+		name    string
+		request *v1pb.GetDatabaseRequest
+		want    connect.Code
+	}{
+		{
+			name:    "missing workspace database parent instance",
+			request: &v1pb.GetDatabaseRequest{Name: common.FormatDatabase("missing", "app")},
+			want:    connect.CodeNotFound,
+		},
+		{
+			name:    "malformed workspace database name",
+			request: &v1pb.GetDatabaseRequest{Name: "instances//databases/app"},
+			want:    connect.CodeInvalidArgument,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := interceptor.doACLCheck(authenticatedACLContext(ctx), test.request, getDatabaseProcedure)
+			require.Equal(t, test.want, connect.CodeOf(err))
+		})
+	}
+}
+
+func TestACLCheckAuthenticatesBeforeResolvingResources(t *testing.T) {
+	ctx, stores, _, _, _, _ := setupWorkspaceInstanceDescendantServiceTest(t)
+	interceptor := NewACLInterceptor(stores, "", nil, nil)
+
+	err := interceptor.doACLCheck(
+		unauthenticatedACLContext(ctx),
+		&v1pb.GetDatabaseRequest{Name: common.FormatDatabase("missing", "app")},
+		getDatabaseProcedure,
+	)
+	require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestACLCheckPanicPreventsRequestAdmission(t *testing.T) {
+	ctx := authenticatedACLContext(context.WithValue(context.Background(), common.WorkspaceIDContextKey, "default"))
+	interceptor := NewACLInterceptor(nil, "", nil, nil)
+	aclCheckReturnedNil := false
+
+	panicked := false
+	func() {
+		defer func() {
+			panicked = recover() != nil
+		}()
+		if err := interceptor.doACLCheck(
+			ctx,
+			&v1pb.GetDatabaseRequest{Name: common.FormatDatabase("instance", "app")},
+			getDatabaseProcedure,
+		); err == nil {
+			aclCheckReturnedNil = true
+		}
+	}()
+
+	require.True(t, panicked, "the outer Connect recovery adapter must receive ACL panics")
+	require.False(t, aclCheckReturnedNil, "a recovered ACL panic must not admit the request")
+}
+
+func authenticatedACLContext(ctx context.Context) context.Context {
+	ctx = context.WithValue(ctx, common.AuthContextKey, &common.AuthContext{AuthMethod: common.AuthMethodCustom})
+	return context.WithValue(ctx, common.UserContextKey, &store.UserMessage{Email: "user@example.com"})
+}
+
+func unauthenticatedACLContext(ctx context.Context) context.Context {
+	ctx = context.WithValue(ctx, common.AuthContextKey, &common.AuthContext{AuthMethod: common.AuthMethodCustom})
+	return context.WithValue(ctx, common.UserContextKey, (*store.UserMessage)(nil))
+}
 
 func TestGetResourceRoute(t *testing.T) {
 	tests := []struct {

--- a/backend/api/v1/acl_test.go
+++ b/backend/api/v1/acl_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -15,6 +16,19 @@ import (
 )
 
 const getDatabaseProcedure = "/bytebase.v1.DatabaseService/GetDatabase"
+
+func TestResourceResolutionConnectError(t *testing.T) {
+	t.Run("preserves connect error", func(t *testing.T) {
+		want := connect.NewError(connect.CodeNotFound, errors.New("missing resource"))
+		require.Same(t, want, resourceResolutionConnectError(want))
+	})
+
+	t.Run("converts unknown error", func(t *testing.T) {
+		err := resourceResolutionConnectError(errors.New("store unavailable"))
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+		require.ErrorContains(t, err, "failed to populate raw resources: store unavailable")
+	})
+}
 
 func TestACLCheckResourceResolutionStatus(t *testing.T) {
 	ctx, stores, _, _, _, _ := setupWorkspaceInstanceDescendantServiceTest(t)
@@ -212,12 +226,14 @@ func TestResolveRawResource(t *testing.T) {
 	t.Run("rejects project instance in another project", func(t *testing.T) {
 		resource, err := resolveRawResource(ctx, stores, common.FormatProjectInstance("project-b", instanceID)+"/roles/role-a")
 		require.Error(t, err)
+		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 		require.Nil(t, resource)
 	})
 
 	t.Run("rejects missing project database", func(t *testing.T) {
 		resource, err := resolveRawResource(ctx, stores, common.FormatProjectDatabase("project-a", instanceID, "missing")+"/schema")
 		require.Error(t, err)
+		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 		require.Nil(t, resource)
 	})
 
@@ -232,6 +248,7 @@ func TestResolveRawResource(t *testing.T) {
 		} {
 			resource, err := resolveRawResource(ctx, nil, name)
 			require.Error(t, err, name)
+			require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err), name)
 			require.Nil(t, resource, name)
 		}
 	})

--- a/backend/api/v1/acl_test.go
+++ b/backend/api/v1/acl_test.go
@@ -12,10 +12,9 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/permission"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/generated-go/v1/v1connect"
 	"github.com/bytebase/bytebase/backend/store"
 )
-
-const getDatabaseProcedure = "/bytebase.v1.DatabaseService/GetDatabase"
 
 func TestResourceResolutionConnectError(t *testing.T) {
 	t.Run("preserves connect error", func(t *testing.T) {
@@ -51,7 +50,7 @@ func TestACLCheckResourceResolutionStatus(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			err := interceptor.doACLCheck(authenticatedACLContext(ctx), test.request, getDatabaseProcedure)
+			err := interceptor.doACLCheck(authenticatedACLContext(ctx), test.request, v1connect.DatabaseServiceGetDatabaseProcedure)
 			require.Equal(t, test.want, connect.CodeOf(err))
 		})
 	}
@@ -64,7 +63,7 @@ func TestACLCheckAuthenticatesBeforeResolvingResources(t *testing.T) {
 	err := interceptor.doACLCheck(
 		unauthenticatedACLContext(ctx),
 		&v1pb.GetDatabaseRequest{Name: common.FormatDatabase("missing", "app")},
-		getDatabaseProcedure,
+		v1connect.DatabaseServiceGetDatabaseProcedure,
 	)
 	require.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 }
@@ -82,7 +81,7 @@ func TestACLCheckPanicPreventsRequestAdmission(t *testing.T) {
 		if err := interceptor.doACLCheck(
 			ctx,
 			&v1pb.GetDatabaseRequest{Name: common.FormatDatabase("instance", "app")},
-			getDatabaseProcedure,
+			v1connect.DatabaseServiceGetDatabaseProcedure,
 		); err == nil {
 			aclCheckReturnedNil = true
 		}

--- a/backend/server/grpc_routes.go
+++ b/backend/server/grpc_routes.go
@@ -128,20 +128,20 @@ func configureGrpcRouters(
 		stack := stacktrace.TakeStacktrace(20 /* n */, 5 /* skip */)
 		// keep a multiline stack
 		slog.Error("v1 server panic error", "method", s.Procedure, log.BBError(errors.Errorf("error: %v\n%s", p, stack)))
-		return connect.NewError(connect.CodeInternal, errors.Errorf("error: %v\n%s", p, stack))
+		return connect.NewError(connect.CodeInternal, errors.New("internal error"))
 	}
 
 	// Create validation interceptor.
 	validateInterceptor := validate.NewInterceptor()
 
 	handlerOpts := connect.WithHandlerOptions(
+		connect.WithRecover(onPanic),
 		connect.WithInterceptors(
 			validateInterceptor,
 			auth.New(stores, secret, licenseService, bus, profile),
 			apiv1.NewACLInterceptor(stores, secret, iamManager, profile),
 			apiv1.NewAuditInterceptor(stores, secret, profile),
 		),
-		connect.WithRecover(onPanic),
 	)
 
 	connectHandlers := make(map[string]http.Handler)


### PR DESCRIPTION
## Summary
- authenticate callers before resolving ACL resources to prevent existence probing
- classify invalid, missing, and internal resolution failures consistently and translate them once to Connect errors
- move panic recovery outside the interceptor stack so ACL panics fail closed
- add regression coverage for status mapping, authentication ordering, and panic propagation

## Testing
- golangci-lint run --allow-parallel-runners
- go test -count=1 ./backend/api/v1 ./backend/server
- go test -v -count=1 ./backend/tests -run ^TestProjectInstance\(CoreBehavior\|Validation\)$ -timeout 5m
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go