### PR TITLE
feat: integrate project instances with workflows and lifecycle

### DIFF
--- a/backend/api/v1/access_grant_service.go
+++ b/backend/api/v1/access_grant_service.go
@@ -147,19 +147,13 @@ func (s *AccessGrantService) CreateAccessGrant(ctx context.Context, request *con
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("reason is required"))
 	}
 
-	// Validate the query is a read-only statement (SELECT).
-	instanceID, _, err := common.GetInstanceDatabaseID(ag.Targets[0])
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "invalid target %q", ag.Targets[0]))
-	}
+	// Validate every target before creating any access-grant or issue rows.
 	workspaceID := common.GetWorkspaceIDFromContext(ctx)
-	instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{Workspace: workspaceID, ResourceID: &instanceID})
+	instance, err := s.validateAccessGrantTargets(ctx, projectID, ag.Targets)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get instance %q", instanceID))
+		return nil, err
 	}
-	if instance == nil {
-		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", instanceID))
-	}
+	// Validate the query is a read-only statement (SELECT).
 	if ok, err := isReadOnlyStatementForAccessGrant(ctx, instance.Metadata.GetEngine(), ag.Query); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "invalid query"))
 	} else if !ok {
@@ -276,6 +270,57 @@ func (s *AccessGrantService) CreateAccessGrant(ctx context.Context, request *con
 	}
 
 	return connect.NewResponse(convertToAccessGrant(grant)), nil
+}
+
+func (s *AccessGrantService) validateAccessGrantTargets(ctx context.Context, projectID string, targets []string) (*store.InstanceMessage, error) {
+	workspaceID := common.GetWorkspaceIDFromContext(ctx)
+	project, err := s.store.GetProject(ctx, &store.FindProjectMessage{
+		Workspace:  workspaceID,
+		ResourceID: &projectID,
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get project %q", projectID))
+	}
+	if project == nil || project.Deleted {
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %q not found", projectID))
+	}
+
+	var firstInstance *store.InstanceMessage
+	for _, target := range targets {
+		targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(target)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "invalid target %q", target))
+		}
+		if targetProjectID != nil && *targetProjectID != projectID {
+			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found in project %q", target, projectID))
+		}
+		database, err := s.store.GetDatabase(ctx, &store.FindDatabaseMessage{
+			Workspace:    workspaceID,
+			InstanceID:   &instanceID,
+			DatabaseName: &databaseName,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get database"))
+		}
+		if database == nil || database.ProjectID != projectID {
+			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found in project %q", target, projectID))
+		}
+		instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{Workspace: workspaceID, ResourceID: &instanceID})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get instance %q", instanceID))
+		}
+		if instance == nil || instance.Deleted {
+			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", instanceID))
+		}
+		if (targetProjectID == nil) != (instance.ProjectID == nil) ||
+			targetProjectID != nil && *targetProjectID != *instance.ProjectID {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("target %q is not canonical for its instance", target))
+		}
+		if firstInstance == nil {
+			firstInstance = instance
+		}
+	}
+	return firstInstance, nil
 }
 
 // ActivateAccessGrant activates a pending access grant.

--- a/backend/api/v1/acl.go
+++ b/backend/api/v1/acl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bytebase/bytebase/backend/component/config"
 	"github.com/bytebase/bytebase/backend/component/iam"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/generated-go/v1/v1connect"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -349,11 +350,18 @@ func findResourceResolver(route resourceRoute) (resourceRoute, resourceResolver,
 }
 
 func resolveRawResource(ctx context.Context, stores *store.Store, name string) (*common.Resource, error) {
+	return resolveRawResourceWithArchivedProject(ctx, stores, name, false)
+}
+
+func resolveRawResourceWithArchivedProject(ctx context.Context, stores *store.Store, name string, allowArchivedProject bool) (*common.Resource, error) {
 	if name == "projects/-" || strings.HasPrefix(name, "instances/-/databases/") {
 		return workspaceFallback(ctx), nil
 	}
 
 	parts := strings.Split(name, "/")
+	if allowArchivedProject && getResourceRoute(parts) == (resourceRoute{projectCollection, instanceCollection}) {
+		return resolveProjectInstanceResourceForLifecycle(ctx, stores, parts)
+	}
 	_, resolver, ok := findResourceResolver(getResourceRoute(parts))
 	if !ok {
 		return workspaceFallback(ctx), nil
@@ -514,7 +522,7 @@ func populateRawResources(ctx context.Context, stores *store.Store, request any,
 
 	var resources []*common.Resource
 	for _, name := range rawNames {
-		resource, err := resolveRawResource(ctx, stores, name)
+		resource, err := resolveRawResourceWithArchivedProject(ctx, stores, name, allowsArchivedProjectResourceResolution(method))
 		if err != nil {
 			return nil, err
 		}
@@ -526,6 +534,10 @@ func populateRawResources(ctx context.Context, stores *store.Store, request any,
 }
 
 func getProjectScopedInstance(ctx context.Context, stores *store.Store, projectID, instanceID string) (*store.InstanceMessage, error) {
+	return getProjectScopedInstanceWithArchivedProject(ctx, stores, projectID, instanceID, false)
+}
+
+func getProjectScopedInstanceWithArchivedProject(ctx context.Context, stores *store.Store, projectID, instanceID string, allowArchivedProject bool) (*store.InstanceMessage, error) {
 	workspaceID := common.GetWorkspaceIDFromContext(ctx)
 	instance, err := stores.GetInstance(ctx, &store.FindInstanceMessage{
 		Workspace:  workspaceID,
@@ -538,7 +550,31 @@ func getProjectScopedInstance(ctx context.Context, stores *store.Store, projectI
 	if instance == nil || instance.Workspace != workspaceID {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", common.FormatProjectInstance(projectID, instanceID)))
 	}
+	if !allowArchivedProject {
+		if err := ensureProjectInstanceIsActive(ctx, stores, instance); err != nil {
+			return nil, err
+		}
+	}
 	return instance, nil
+}
+
+func resolveProjectInstanceResourceForLifecycle(ctx context.Context, stores *store.Store, parts []string) (*common.Resource, error) {
+	projectID, err := requiredResourceIdentifier(parts, 1, projectCollection)
+	if err != nil {
+		return nil, err
+	}
+	instanceID, err := requiredResourceIdentifier(parts, 3, instanceCollection)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := getProjectScopedInstanceWithArchivedProject(ctx, stores, projectID, instanceID, true); err != nil {
+		return nil, err
+	}
+	return &common.Resource{Type: common.ResourceTypeProject, ID: projectID}, nil
+}
+
+func allowsArchivedProjectResourceResolution(method string) bool {
+	return method == v1connect.InstanceServiceDeleteInstanceProcedure || method == v1connect.InstanceServiceUndeleteInstanceProcedure
 }
 
 func getResourceFromRequest(ctx context.Context, request any, method string) ([]string, error) {

--- a/backend/api/v1/audit.go
+++ b/backend/api/v1/audit.go
@@ -431,6 +431,17 @@ func getRequestResource(request any) string {
 		return r.GetName()
 	case *v1pb.UndeleteInstanceRequest:
 		return r.GetName()
+	case *v1pb.CreateProjectRequest:
+		if name := r.GetProject().GetName(); name != "" {
+			return name
+		}
+		return common.FormatProject(r.GetProjectId())
+	case *v1pb.UpdateProjectRequest:
+		return r.GetProject().GetName()
+	case *v1pb.DeleteProjectRequest:
+		return r.GetName()
+	case *v1pb.UndeleteProjectRequest:
+		return r.GetName()
 	case *v1pb.AddDataSourceRequest:
 		return r.GetName()
 	case *v1pb.RemoveDataSourceRequest:

--- a/backend/api/v1/audit_test.go
+++ b/backend/api/v1/audit_test.go
@@ -261,3 +261,19 @@ func (c *auditRecorderConn) Send(any) error {
 	c.recorder.record("send")
 	return nil
 }
+
+func TestProjectLifecycleAuditResource(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		request any
+	}{
+		{name: "create", request: &v1pb.CreateProjectRequest{ProjectId: "project-a", Project: &v1pb.Project{}}},
+		{name: "update", request: &v1pb.UpdateProjectRequest{Project: &v1pb.Project{Name: "projects/project-a"}}},
+		{name: "delete", request: &v1pb.DeleteProjectRequest{Name: "projects/project-a"}},
+		{name: "undelete", request: &v1pb.UndeleteProjectRequest{Name: "projects/project-a"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, "projects/project-a", getRequestResource(test.request))
+		})
+	}
+}

--- a/backend/api/v1/database_group_service.go
+++ b/backend/api/v1/database_group_service.go
@@ -236,7 +236,7 @@ func (s *DatabaseGroupService) ListDatabaseGroups(ctx context.Context, req *conn
 
 	var apiDatabaseGroups []*v1pb.DatabaseGroup
 	for _, databaseGroup := range databaseGroups {
-		group, err := convertStoreToV1DatabaseGroup(ctx, s.store, databaseGroup, projectResourceID, allProjectDatabases)
+		group, err := convertStoreToV1DatabaseGroup(ctx, databaseGroup, projectResourceID, allProjectDatabases)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert database group %q", databaseGroup.ResourceID))
 		}
@@ -295,12 +295,11 @@ func convertStoreToV1DatabaseGroupWithView(ctx context.Context, stores *store.St
 		allProjectDatabases = databases
 	}
 
-	return convertStoreToV1DatabaseGroup(ctx, stores, databaseGroup, projectResourceID, allProjectDatabases)
+	return convertStoreToV1DatabaseGroup(ctx, databaseGroup, projectResourceID, allProjectDatabases)
 }
 
 func convertStoreToV1DatabaseGroup(
 	ctx context.Context,
-	stores *store.Store,
 	databaseGroup *store.DatabaseGroupMessage,
 	projectResourceID string,
 	databases []*store.DatabaseMessage,
@@ -316,12 +315,8 @@ func convertStoreToV1DatabaseGroup(
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get matched databases for group %v with error: %v", ret.Name, err.Error()))
 	}
 	for _, database := range matches {
-		name, err := formatDatabaseTarget(ctx, stores, database)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, err)
-		}
 		ret.MatchedDatabases = append(ret.MatchedDatabases, &v1pb.DatabaseGroup_Database{
-			Name: name,
+			Name: database.ResourceName(),
 		})
 	}
 	return ret, nil

--- a/backend/api/v1/database_group_service.go
+++ b/backend/api/v1/database_group_service.go
@@ -236,7 +236,7 @@ func (s *DatabaseGroupService) ListDatabaseGroups(ctx context.Context, req *conn
 
 	var apiDatabaseGroups []*v1pb.DatabaseGroup
 	for _, databaseGroup := range databaseGroups {
-		group, err := convertStoreToV1DatabaseGroup(ctx, databaseGroup, projectResourceID, allProjectDatabases)
+		group, err := convertStoreToV1DatabaseGroup(ctx, s.store, databaseGroup, projectResourceID, allProjectDatabases)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to convert database group %q", databaseGroup.ResourceID))
 		}
@@ -295,11 +295,12 @@ func convertStoreToV1DatabaseGroupWithView(ctx context.Context, stores *store.St
 		allProjectDatabases = databases
 	}
 
-	return convertStoreToV1DatabaseGroup(ctx, databaseGroup, projectResourceID, allProjectDatabases)
+	return convertStoreToV1DatabaseGroup(ctx, stores, databaseGroup, projectResourceID, allProjectDatabases)
 }
 
 func convertStoreToV1DatabaseGroup(
 	ctx context.Context,
+	stores *store.Store,
 	databaseGroup *store.DatabaseGroupMessage,
 	projectResourceID string,
 	databases []*store.DatabaseMessage,
@@ -315,8 +316,12 @@ func convertStoreToV1DatabaseGroup(
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get matched databases for group %v with error: %v", ret.Name, err.Error()))
 	}
 	for _, database := range matches {
+		name, err := formatDatabaseTarget(ctx, stores, database)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
 		ret.MatchedDatabases = append(ret.MatchedDatabases, &v1pb.DatabaseGroup_Database{
-			Name: common.FormatDatabase(database.InstanceID, database.DatabaseName),
+			Name: name,
 		})
 	}
 	return ret, nil

--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -73,6 +73,9 @@ func (s *DatabaseService) getInstanceForDatabaseResource(ctx context.Context, pr
 	if projectID != nil && (instance.ProjectID == nil || *projectID != *instance.ProjectID) {
 		return nil, errors.Errorf("project in database resource name does not own instance %q", instanceID)
 	}
+	if err := ensureProjectInstanceIsActive(ctx, s.store, instance); err != nil {
+		return nil, err
+	}
 	return instance, nil
 }
 
@@ -300,6 +303,16 @@ func (s *DatabaseService) ListDatabases(ctx context.Context, req *connect.Reques
 		}
 		find.InstanceID = &instanceID
 	} else if projectID, err := common.GetProjectID(req.Msg.Parent); err == nil {
+		project, err := s.store.GetProject(ctx, &store.FindProjectMessage{
+			Workspace:  common.GetWorkspaceIDFromContext(ctx),
+			ResourceID: &projectID,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, err)
+		}
+		if project == nil || project.Deleted {
+			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %q not found", req.Msg.Parent))
+		}
 		ok, err := s.iamManager.CheckPermission(ctx, permission.ProjectsGet, user, common.GetWorkspaceIDFromContext(ctx), projectID)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to check permission with error: %v", err))

--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -894,7 +894,7 @@ func (s *InstanceService) UpdateInstance(ctx context.Context, req *connect.Reque
 
 // DeleteInstance deletes an instance.
 func (s *InstanceService) DeleteInstance(ctx context.Context, req *connect.Request[v1pb.DeleteInstanceRequest]) (*connect.Response[emptypb.Empty], error) {
-	instance, err := getInstanceMessage(ctx, s.store, req.Msg.Name)
+	instance, err := getInstanceMessageForLifecycle(ctx, s.store, req.Msg.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -951,14 +951,17 @@ func (s *InstanceService) DeleteInstance(ctx context.Context, req *connect.Reque
 		}
 	}
 
-	metadata := proto.CloneOf(instance.Metadata)
-	metadata.Activation = false
-	if _, err := s.store.UpdateInstance(ctx, &store.UpdateInstanceMessage{
+	patch := &store.UpdateInstanceMessage{
 		ResourceID: &instance.ResourceID,
 		Workspace:  instance.Workspace,
 		Deleted:    &deletePatch,
-		Metadata:   metadata,
-	}); err != nil {
+	}
+	if instance.ProjectID == nil {
+		metadata := proto.CloneOf(instance.Metadata)
+		metadata.Activation = false
+		patch.Metadata = metadata
+	}
+	if _, err := s.store.UpdateInstance(ctx, patch); err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
 
@@ -974,7 +977,7 @@ func (s *InstanceService) DeleteInstance(ctx context.Context, req *connect.Reque
 
 // UndeleteInstance undeletes an instance.
 func (s *InstanceService) UndeleteInstance(ctx context.Context, req *connect.Request[v1pb.UndeleteInstanceRequest]) (*connect.Response[v1pb.Instance], error) {
-	instance, err := getInstanceMessage(ctx, s.store, req.Msg.Name)
+	instance, err := getInstanceMessageForLifecycle(ctx, s.store, req.Msg.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -1427,6 +1430,14 @@ func (s *InstanceService) RemoveDataSource(ctx context.Context, req *connect.Req
 }
 
 func getInstanceMessage(ctx context.Context, stores *store.Store, name string) (*store.InstanceMessage, error) {
+	return getInstanceMessageWithArchivedProject(ctx, stores, name, false)
+}
+
+func getInstanceMessageForLifecycle(ctx context.Context, stores *store.Store, name string) (*store.InstanceMessage, error) {
+	return getInstanceMessageWithArchivedProject(ctx, stores, name, true)
+}
+
+func getInstanceMessageWithArchivedProject(ctx context.Context, stores *store.Store, name string, allowArchivedProject bool) (*store.InstanceMessage, error) {
 	projectID, instanceID, err := common.GetInstanceResourceName(name)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
@@ -1445,8 +1456,30 @@ func getInstanceMessage(ctx context.Context, stores *store.Store, name string) (
 	if instance == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", name))
 	}
+	if !allowArchivedProject {
+		if err := ensureProjectInstanceIsActive(ctx, stores, instance); err != nil {
+			return nil, err
+		}
+	}
 
 	return instance, nil
+}
+
+func ensureProjectInstanceIsActive(ctx context.Context, stores *store.Store, instance *store.InstanceMessage) error {
+	if instance.ProjectID == nil {
+		return nil
+	}
+	project, err := stores.GetProject(ctx, &store.FindProjectMessage{
+		Workspace:  common.GetWorkspaceIDFromContext(ctx),
+		ResourceID: instance.ProjectID,
+	})
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, errors.Wrap(err, "failed to get instance project"))
+	}
+	if project == nil || project.Deleted {
+		return connect.NewError(connect.CodeNotFound, errors.Errorf("project %q not found", *instance.ProjectID))
+	}
+	return nil
 }
 
 func instanceCollectionParent(projectID *string) *string {

--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -41,10 +41,18 @@ type InstanceService struct {
 	v1connect.UnimplementedInstanceServiceHandler
 	store                 *store.Store
 	profile               *config.Profile
-	licenseService        *enterprise.LicenseService
+	licenseService        instanceLicenseService
 	dbFactory             *dbfactory.DBFactory
 	schemaSyncer          *schemasync.Syncer
 	sampleInstanceManager *sampleinstance.Manager
+}
+
+type instanceLicenseService interface {
+	GetActivatedInstanceLimit(context.Context, string) int
+	GetInstanceLimit(context.Context, string) int
+	IsFeatureEnabledForInstance(context.Context, string, v1pb.PlanFeature, *store.InstanceMessage) error
+	IsInstanceEffectivelyActivated(context.Context, string, *store.InstanceMessage) bool
+	IsUnifiedInstanceLicense(context.Context, string) bool
 }
 
 const (
@@ -987,6 +995,9 @@ func (s *InstanceService) UndeleteInstance(ctx context.Context, req *connect.Req
 		return connect.NewResponse(result), nil
 	}
 	if err := s.instanceCountGuard(ctx); err != nil {
+		return nil, err
+	}
+	if err := s.checkActivationLimit(ctx, instance.Workspace, instance.Metadata.GetActivation()); err != nil {
 		return nil, err
 	}
 

--- a/backend/api/v1/interactive_project_database_test.go
+++ b/backend/api/v1/interactive_project_database_test.go
@@ -1,0 +1,150 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestBOT36SQLPrepareRelatedMessageRequiresCanonicalActiveOwner(t *testing.T) {
+	ctx, stores, projectID, instanceID, databaseName := setupBOT36ProjectDatabase(t)
+	service := NewSQLService(stores, nil, nil, nil, nil, nil)
+
+	_, _, _, err := service.prepareRelatedMessage(ctx, common.FormatDatabase(instanceID, databaseName))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	_, _, _, err = service.prepareRelatedMessage(ctx, common.FormatProjectDatabase("other-project", instanceID, databaseName))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+
+	_, _, _, err = service.prepareRelatedMessage(ctx, common.FormatProjectDatabase(projectID, instanceID, databaseName))
+	require.NoError(t, err)
+	_, _, _, err = service.prepareRelatedMessage(ctx, common.FormatDatabase("workspace-instance", "shared"))
+	require.NoError(t, err)
+
+	require.NoError(t, stores.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: projectID,
+		Workspace:  "default",
+		Delete:     new(true),
+	}))
+	_, _, _, err = service.prepareRelatedMessage(ctx, common.FormatProjectDatabase(projectID, instanceID, databaseName))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+func TestBOT36WorksheetDatabasesUseCanonicalOwningProjectNames(t *testing.T) {
+	ctx, stores, projectID, instanceID, databaseName := setupBOT36ProjectDatabase(t)
+	service := NewWorksheetService(stores, nil)
+
+	_, err := service.getWorksheetDatabase(ctx, projectID, common.FormatDatabase(instanceID, databaseName))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	_, err = service.getWorksheetDatabase(ctx, projectID, common.FormatProjectDatabase("other-project", instanceID, databaseName))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+
+	database, err := service.getWorksheetDatabase(ctx, projectID, common.FormatProjectDatabase(projectID, instanceID, databaseName))
+	require.NoError(t, err)
+	require.Equal(t, databaseName, database.DatabaseName)
+
+	worksheet, err := service.convertWorksheetToAPI(ctx, &store.WorkSheetMessage{
+		ProjectID:    projectID,
+		ResourceID:   "worksheet-a",
+		InstanceID:   &instanceID,
+		DatabaseName: &databaseName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, common.FormatProjectDatabase(projectID, instanceID, databaseName), worksheet.Database)
+
+	workspaceDatabase, err := service.getWorksheetDatabase(ctx, projectID, common.FormatDatabase("workspace-instance", "shared"))
+	require.NoError(t, err)
+	workspaceWorksheet, err := service.convertWorksheetToAPI(ctx, &store.WorkSheetMessage{
+		ProjectID:    projectID,
+		ResourceID:   "worksheet-b",
+		InstanceID:   &workspaceDatabase.InstanceID,
+		DatabaseName: &workspaceDatabase.DatabaseName,
+	})
+	require.NoError(t, err)
+	require.Equal(t, common.FormatDatabase("workspace-instance", "shared"), workspaceWorksheet.Database)
+}
+
+func TestBOT36AccessGrantTargetsRequireCanonicalOwningProject(t *testing.T) {
+	ctx, stores, projectID, instanceID, databaseName := setupBOT36ProjectDatabase(t)
+	service := NewAccessGrantService(stores, nil, nil, nil)
+
+	_, err := service.validateAccessGrantTargets(ctx, projectID, []string{common.FormatDatabase(instanceID, databaseName)})
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	_, err = service.validateAccessGrantTargets(ctx, projectID, []string{common.FormatProjectDatabase(projectID, instanceID, databaseName), common.FormatProjectDatabase("other-project", instanceID, databaseName)})
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+
+	instance, err := service.validateAccessGrantTargets(ctx, projectID, []string{common.FormatProjectDatabase(projectID, instanceID, databaseName)})
+	require.NoError(t, err)
+	require.Equal(t, instanceID, instance.ResourceID)
+	instance, err = service.validateAccessGrantTargets(ctx, projectID, []string{common.FormatDatabase("workspace-instance", "shared")})
+	require.NoError(t, err)
+	require.Equal(t, "workspace-instance", instance.ResourceID)
+}
+
+func setupBOT36ProjectDatabase(t *testing.T) (context.Context, *store.Store, string, string, string) {
+	t.Helper()
+	ctx := context.WithValue(context.Background(), common.WorkspaceIDContextKey, "default")
+	ctx = context.WithValue(ctx, common.UserContextKey, &store.UserMessage{Email: "user@example.com"})
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+	require.NoError(t, migrator.MigrateSchema(ctx, container.GetDB()))
+	_, err := container.GetDB().ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A'), ('other-project', 'default', 'Other Project');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf("host=%s port=%s user=postgres password=root-password database=postgres", container.GetHost(), container.GetPort())
+	stores, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stores.Close()) })
+
+	projectID := "project-a"
+	instanceID := "instance-a"
+	_, err = stores.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: instanceID,
+		Workspace:  "default",
+		ProjectID:  &projectID,
+		Metadata: &storepb.Instance{DataSources: []*storepb.DataSource{{
+			Id:   "admin",
+			Type: storepb.DataSourceType_ADMIN,
+		}}},
+	})
+	require.NoError(t, err)
+	databaseName := "app"
+	_, err = stores.UpsertDatabase(ctx, &store.DatabaseMessage{
+		InstanceID:   instanceID,
+		DatabaseName: databaseName,
+		ProjectID:    projectID,
+		Metadata:     &storepb.DatabaseMetadata{},
+	})
+	require.NoError(t, err)
+	_, err = stores.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "workspace-instance",
+		Workspace:  "default",
+		Metadata: &storepb.Instance{DataSources: []*storepb.DataSource{{
+			Id:   "admin",
+			Type: storepb.DataSourceType_ADMIN,
+		}}},
+	})
+	require.NoError(t, err)
+	_, err = stores.UpsertDatabase(ctx, &store.DatabaseMessage{
+		InstanceID:   "workspace-instance",
+		DatabaseName: "shared",
+		ProjectID:    projectID,
+		Metadata:     &storepb.DatabaseMetadata{},
+	})
+	require.NoError(t, err)
+	return ctx, stores, projectID, instanceID, databaseName
+}

--- a/backend/api/v1/plan_service.go
+++ b/backend/api/v1/plan_service.go
@@ -579,7 +579,7 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 	var releaseCount, sheetCount int
 	var sheetSha256s []string
 	var releaseString string
-	var instanceIDs []string
+	var instanceTargets []string
 	var databaseGroups []string
 	seenDatabaseGroups := map[string]bool{}
 	var databaseNames []string
@@ -599,17 +599,23 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 		case *v1pb.Plan_Spec_CreateDatabaseConfig:
 			configTypeCount["create_database"]++
 			if target := config.CreateDatabaseConfig.Target; target != "" {
-				instanceID, err := common.GetInstanceID(target)
+				targetProjectID, _, err := common.GetInstanceResourceName(target)
 				if err != nil {
 					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("invalid instance name %q: %v", target, err))
 				}
-				instanceIDs = append(instanceIDs, instanceID)
+				if targetProjectID != nil && *targetProjectID != projectID {
+					return nil, errors.Errorf("instance %q (project %q) does not belong to plan project %q", target, *targetProjectID, projectID)
+				}
+				instanceTargets = append(instanceTargets, target)
 			}
 		case *v1pb.Plan_Spec_ChangeDatabaseConfig:
 			configTypeCount["change_database"]++
 			var databaseTarget, databaseGroupTarget int
 			for _, target := range config.ChangeDatabaseConfig.Targets {
-				if _, _, err := common.GetInstanceDatabaseID(target); err == nil {
+				if targetProjectID, _, _, err := common.GetDatabaseResourceName(target); err == nil {
+					if targetProjectID != nil && *targetProjectID != projectID {
+						return nil, errors.Errorf("database %q (project %q) does not belong to plan project %q", target, *targetProjectID, projectID)
+					}
 					databaseTarget++
 					databaseNames = append(databaseNames, target)
 				} else if _, _, err := common.GetProjectIDDatabaseGroupID(target); err == nil {
@@ -654,7 +660,7 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 	}
 
 	// Allow at most one instance.
-	if len(instanceIDs) > 1 {
+	if len(instanceTargets) > 1 {
 		return nil, errors.Errorf("plan contains targets on multiple instances, but only one instance is allowed")
 	}
 
@@ -669,17 +675,13 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 	}
 
 	// Validate resources existence.
-	if len(instanceIDs) == 1 {
-		instanceID := instanceIDs[0]
-		instance, err := s.GetInstance(ctx, &store.FindInstanceMessage{
-			Workspace:  common.GetWorkspaceIDFromContext(ctx),
-			ResourceID: &instanceID,
-		})
+	if len(instanceTargets) == 1 {
+		instance, err := getInstanceMessage(ctx, s, instanceTargets[0])
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to get instance %q: %v", instanceID, err))
+			return nil, err
 		}
-		if instance == nil {
-			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", instanceID))
+		if instance.Deleted {
+			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q has been deleted", instanceTargets[0]))
 		}
 	}
 
@@ -704,9 +706,12 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 	}
 
 	for _, name := range databaseNames {
-		instanceID, dbName, err := common.GetInstanceDatabaseID(name)
+		targetProjectID, instanceID, dbName, err := common.GetDatabaseResourceName(name)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("invalid database name %q", name))
+		}
+		if targetProjectID != nil && *targetProjectID != projectID {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database %q (project %q) does not belong to plan project %q", name, *targetProjectID, projectID))
 		}
 		db, err := s.GetDatabase(ctx, &store.FindDatabaseMessage{
 			Workspace:    common.GetWorkspaceIDFromContext(ctx),
@@ -718,6 +723,17 @@ func validateSpecs(ctx context.Context, s *store.Store, projectID string, specs 
 		}
 		if db == nil {
 			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found", name))
+		}
+		instanceName := common.FormatInstance(instanceID)
+		if targetProjectID != nil {
+			instanceName = common.FormatProjectInstance(*targetProjectID, instanceID)
+		}
+		instance, err := getInstanceMessage(ctx, s, instanceName)
+		if err != nil {
+			return nil, err
+		}
+		if instance.Deleted {
+			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q has been deleted", instanceName))
 		}
 
 		if db.ProjectID != projectID {

--- a/backend/api/v1/project_instance_lifecycle_api_test.go
+++ b/backend/api/v1/project_instance_lifecycle_api_test.go
@@ -1,0 +1,121 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/enterprise"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/generated-go/v1/v1connect"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestProjectInstanceLifecycleAPIGatesArchivedProjectDescendants(t *testing.T) {
+	ctx, stores, projectID, instanceID, databaseName := setupProjectInstanceLifecycleAPITest(t)
+	licenseService, err := enterprise.NewLicenseService(common.ReleaseModeDev, stores, false, "")
+	require.NoError(t, err)
+	projectService := NewProjectService(stores, nil, nil)
+	instanceService := NewInstanceService(stores, nil, licenseService, nil, nil, nil)
+	databaseService := NewDatabaseService(stores, nil, nil, nil, licenseService)
+	instanceName := common.FormatProjectInstance(projectID, instanceID)
+	projectName := common.FormatProject(projectID)
+	databaseResourceName := common.FormatProjectDatabase(projectID, instanceID, databaseName)
+
+	_, err = projectService.DeleteProject(ctx, connect.NewRequest(&v1pb.DeleteProjectRequest{
+		Name:  common.FormatProject("project-b"),
+		Purge: true,
+	}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	_, err = instanceService.DeleteInstance(ctx, connect.NewRequest(&v1pb.DeleteInstanceRequest{Name: instanceName}))
+	require.NoError(t, err)
+	undeleted, err := instanceService.UndeleteInstance(ctx, connect.NewRequest(&v1pb.UndeleteInstanceRequest{Name: instanceName}))
+	require.NoError(t, err)
+	require.True(t, undeleted.Msg.Activation)
+	_, err = instanceService.DeleteInstance(ctx, connect.NewRequest(&v1pb.DeleteInstanceRequest{Name: instanceName, Force: true}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	_, err = projectService.DeleteProject(ctx, connect.NewRequest(&v1pb.DeleteProjectRequest{Name: projectName}))
+	require.NoError(t, err)
+
+	_, err = instanceService.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: instanceName}))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	_, err = databaseService.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: databaseResourceName}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	_, err = resolveRawResource(ctx, stores, databaseResourceName)
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	resources, err := populateRawResources(ctx, stores, &v1pb.UndeleteInstanceRequest{Name: instanceName}, v1connect.InstanceServiceUndeleteInstanceProcedure)
+	require.NoError(t, err)
+	require.Equal(t, []*common.Resource{{Type: common.ResourceTypeProject, ID: projectID}}, resources)
+
+	var databaseCount int
+	require.NoError(t, stores.GetDB().QueryRowContext(ctx, "SELECT COUNT(*) FROM db WHERE instance = $1 AND name = $2", instanceID, databaseName).Scan(&databaseCount))
+	require.Equal(t, 1, databaseCount)
+
+	_, err = instanceService.DeleteInstance(ctx, connect.NewRequest(&v1pb.DeleteInstanceRequest{Name: instanceName}))
+	require.NoError(t, err)
+	undeleted, err = instanceService.UndeleteInstance(ctx, connect.NewRequest(&v1pb.UndeleteInstanceRequest{Name: instanceName}))
+	require.NoError(t, err)
+	require.True(t, undeleted.Msg.Activation)
+
+	_, err = projectService.UndeleteProject(ctx, connect.NewRequest(&v1pb.UndeleteProjectRequest{Name: projectName}))
+	require.NoError(t, err)
+	got, err := instanceService.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: instanceName}))
+	require.NoError(t, err)
+	require.True(t, got.Msg.Activation)
+}
+
+func setupProjectInstanceLifecycleAPITest(t *testing.T) (context.Context, *store.Store, string, string, string) {
+	t.Helper()
+	ctx := context.WithValue(context.Background(), common.WorkspaceIDContextKey, "default")
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES
+			('project-a', 'default', 'Project A'),
+			('project-b', 'default', 'Project B');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf("host=%s port=%s user=postgres password=root-password database=postgres", container.GetHost(), container.GetPort())
+	stores, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stores.Close()) })
+
+	projectID := "project-a"
+	instanceID := "project-instance"
+	_, err = stores.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: instanceID,
+		Workspace:  "default",
+		ProjectID:  &projectID,
+		Metadata: &storepb.Instance{
+			Activation: true,
+			DataSources: []*storepb.DataSource{{
+				Id:   "admin",
+				Type: storepb.DataSourceType_ADMIN,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	databaseName := "app"
+	_, err = stores.UpsertDatabase(ctx, &store.DatabaseMessage{
+		InstanceID:   instanceID,
+		DatabaseName: databaseName,
+		ProjectID:    projectID,
+		Metadata:     &storepb.DatabaseMetadata{},
+	})
+	require.NoError(t, err)
+	return ctx, stores, projectID, instanceID, databaseName
+}

--- a/backend/api/v1/project_instance_lifecycle_api_test.go
+++ b/backend/api/v1/project_instance_lifecycle_api_test.go
@@ -88,7 +88,13 @@ func TestUndeleteProjectInstanceChecksActivationLimit(t *testing.T) {
 		ResourceID: "other-project-instance",
 		Workspace:  "default",
 		ProjectID:  &otherProjectID,
-		Metadata:   &storepb.Instance{Activation: true},
+		Metadata: &storepb.Instance{
+			Activation: true,
+			DataSources: []*storepb.DataSource{{
+				Id:   "admin",
+				Type: storepb.DataSourceType_ADMIN,
+			}},
+		},
 	})
 	require.NoError(t, err)
 

--- a/backend/api/v1/project_instance_lifecycle_api_test.go
+++ b/backend/api/v1/project_instance_lifecycle_api_test.go
@@ -20,11 +20,12 @@ import (
 
 func TestProjectInstanceLifecycleAPIGatesArchivedProjectDescendants(t *testing.T) {
 	ctx, stores, projectID, instanceID, databaseName := setupProjectInstanceLifecycleAPITest(t)
-	licenseService, err := enterprise.NewLicenseService(common.ReleaseModeDev, stores, false, "")
+	licenseService := &instanceLicenseServiceStub{instanceLimit: 10, activatedInstanceLimit: 10}
+	databaseLicenseService, err := enterprise.NewLicenseService(common.ReleaseModeDev, stores, false, "")
 	require.NoError(t, err)
 	projectService := NewProjectService(stores, nil, nil)
-	instanceService := NewInstanceService(stores, nil, licenseService, nil, nil, nil)
-	databaseService := NewDatabaseService(stores, nil, nil, nil, licenseService)
+	instanceService := &InstanceService{store: stores, licenseService: licenseService}
+	databaseService := NewDatabaseService(stores, nil, nil, nil, databaseLicenseService)
 	instanceName := common.FormatProjectInstance(projectID, instanceID)
 	projectName := common.FormatProject(projectID)
 	databaseResourceName := common.FormatProjectDatabase(projectID, instanceID, databaseName)
@@ -71,6 +72,58 @@ func TestProjectInstanceLifecycleAPIGatesArchivedProjectDescendants(t *testing.T
 	got, err := instanceService.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: instanceName}))
 	require.NoError(t, err)
 	require.True(t, got.Msg.Activation)
+}
+
+func TestUndeleteProjectInstanceChecksActivationLimit(t *testing.T) {
+	ctx, stores, projectID, instanceID, _ := setupProjectInstanceLifecycleAPITest(t)
+	licenseService := &instanceLicenseServiceStub{instanceLimit: 10, activatedInstanceLimit: 1}
+	instanceService := &InstanceService{store: stores, licenseService: licenseService}
+	instanceName := common.FormatProjectInstance(projectID, instanceID)
+
+	_, err := instanceService.DeleteInstance(ctx, connect.NewRequest(&v1pb.DeleteInstanceRequest{Name: instanceName}))
+	require.NoError(t, err)
+
+	otherProjectID := "project-b"
+	_, err = stores.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "other-project-instance",
+		Workspace:  "default",
+		ProjectID:  &otherProjectID,
+		Metadata:   &storepb.Instance{Activation: true},
+	})
+	require.NoError(t, err)
+
+	_, err = instanceService.UndeleteInstance(ctx, connect.NewRequest(&v1pb.UndeleteInstanceRequest{Name: instanceName}))
+	require.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
+
+	instance, err := getInstanceMessageForLifecycle(ctx, stores, instanceName)
+	require.NoError(t, err)
+	require.True(t, instance.Deleted)
+	require.True(t, instance.Metadata.GetActivation())
+}
+
+type instanceLicenseServiceStub struct {
+	instanceLimit          int
+	activatedInstanceLimit int
+}
+
+func (s *instanceLicenseServiceStub) GetActivatedInstanceLimit(context.Context, string) int {
+	return s.activatedInstanceLimit
+}
+
+func (s *instanceLicenseServiceStub) GetInstanceLimit(context.Context, string) int {
+	return s.instanceLimit
+}
+
+func (*instanceLicenseServiceStub) IsFeatureEnabledForInstance(context.Context, string, v1pb.PlanFeature, *store.InstanceMessage) error {
+	return nil
+}
+
+func (s *instanceLicenseServiceStub) IsInstanceEffectivelyActivated(_ context.Context, _ string, instance *store.InstanceMessage) bool {
+	return instance.Metadata.GetActivation() || s.instanceLimit <= s.activatedInstanceLimit
+}
+
+func (s *instanceLicenseServiceStub) IsUnifiedInstanceLicense(context.Context, string) bool {
+	return s.instanceLimit <= s.activatedInstanceLimit
 }
 
 func setupProjectInstanceLifecycleAPITest(t *testing.T) (context.Context, *store.Store, string, string, string) {

--- a/backend/api/v1/project_instance_release_check_test.go
+++ b/backend/api/v1/project_instance_release_check_test.go
@@ -1,0 +1,136 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/component/sheet"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestCheckReleaseDatabaseTargetsKeepCanonicalNames(t *testing.T) {
+	ctx, stores, instanceID, databaseName := setupProjectInstanceReleaseCheckTest(t)
+	projectID := "project-a"
+	projectTarget := common.FormatProjectDatabase(projectID, instanceID, databaseName)
+	workspaceTarget := common.FormatDatabase(instanceID, databaseName)
+
+	response, err := NewReleaseService(stores, sheet.NewManager(), nil, nil).CheckRelease(ctx, connect.NewRequest(&v1pb.CheckReleaseRequest{
+		Parent:  common.FormatProject(projectID),
+		Release: declarativeReleaseWithDisallowedStatement(),
+		Targets: []string{projectTarget},
+	}))
+	require.NoError(t, err)
+	require.Len(t, response.Msg.Results, 1)
+	require.Equal(t, projectTarget, response.Msg.Results[0].Target)
+
+	_, err = NewReleaseService(stores, sheet.NewManager(), nil, nil).CheckRelease(ctx, connect.NewRequest(&v1pb.CheckReleaseRequest{
+		Parent:  common.FormatProject(projectID),
+		Release: declarativeReleaseWithDisallowedStatement(),
+		Targets: []string{workspaceTarget},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestCheckReleaseRejectsCrossProjectTargets(t *testing.T) {
+	ctx, stores, instanceID, databaseName := setupProjectInstanceReleaseCheckTest(t)
+	service := NewReleaseService(stores, sheet.NewManager(), nil, nil)
+	request := func(target string) *connect.Request[v1pb.CheckReleaseRequest] {
+		return connect.NewRequest(&v1pb.CheckReleaseRequest{
+			Parent:  common.FormatProject("project-a"),
+			Release: declarativeReleaseWithDisallowedStatement(),
+			Targets: []string{target},
+		})
+	}
+
+	for _, target := range []string{
+		common.FormatProjectDatabase("project-b", instanceID, databaseName),
+		common.FormatProject("project-b") + "/databaseGroups/all",
+	} {
+		_, err := service.CheckRelease(ctx, request(target))
+		require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err), target)
+	}
+}
+
+func TestCheckReleaseRejectsArchivedProject(t *testing.T) {
+	ctx, stores, instanceID, databaseName := setupProjectInstanceReleaseCheckTest(t)
+	archived := true
+	require.NoError(t, stores.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+
+	_, err := NewReleaseService(stores, sheet.NewManager(), nil, nil).CheckRelease(ctx, connect.NewRequest(&v1pb.CheckReleaseRequest{
+		Parent:  common.FormatProject("project-a"),
+		Release: declarativeReleaseWithDisallowedStatement(),
+		Targets: []string{common.FormatProjectDatabase("project-a", instanceID, databaseName)},
+	}))
+	require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+func declarativeReleaseWithDisallowedStatement() *v1pb.Release {
+	return &v1pb.Release{
+		Type: v1pb.Release_DECLARATIVE,
+		Files: []*v1pb.Release_File{{
+			Path:      "schema.sql",
+			Version:   "1",
+			Statement: []byte("DROP TABLE obsolete;"),
+		}},
+	}
+}
+
+func setupProjectInstanceReleaseCheckTest(t *testing.T) (context.Context, *store.Store, string, string) {
+	t.Helper()
+	ctx := context.WithValue(context.Background(), common.WorkspaceIDContextKey, "default")
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES
+			('project-a', 'default', 'Project A'),
+			('project-b', 'default', 'Project B');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf("host=%s port=%s user=postgres password=root-password database=postgres", container.GetHost(), container.GetPort())
+	stores, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stores.Close()) })
+
+	projectID := "project-a"
+	instanceID := "project-instance"
+	_, err = stores.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: instanceID,
+		Workspace:  "default",
+		ProjectID:  &projectID,
+		Metadata: &storepb.Instance{
+			Engine: storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{
+				Id:   "admin",
+				Type: storepb.DataSourceType_ADMIN,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	databaseName := "app"
+	_, err = stores.UpsertDatabase(ctx, &store.DatabaseMessage{
+		InstanceID:   instanceID,
+		DatabaseName: databaseName,
+		ProjectID:    projectID,
+		Metadata:     &storepb.DatabaseMetadata{},
+	})
+	require.NoError(t, err)
+	return ctx, stores, instanceID, databaseName
+}

--- a/backend/api/v1/project_service.go
+++ b/backend/api/v1/project_service.go
@@ -397,16 +397,8 @@ func (s *ProjectService) DeleteProject(ctx context.Context, req *connect.Request
 		if common.IsDefaultProject(project.Workspace, project.ResourceID) {
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("default project cannot be purged"))
 		}
-
-		// If project is not already soft-deleted, soft-delete it first
 		if !project.Deleted {
-			if err := s.store.UpdateProjects(ctx, &store.UpdateProjectMessage{
-				ResourceID: project.ResourceID,
-				Workspace:  project.Workspace,
-				Delete:     &deletePatch,
-			}); err != nil {
-				return nil, connect.NewError(connect.CodeInternal, err)
-			}
+			return nil, connect.NewError(connect.CodeFailedPrecondition, errors.Errorf("project %q must be archived before it can be deleted", req.Msg.Name))
 		}
 
 		// Permanently delete the project and all related resources (moves databases to default project)
@@ -483,20 +475,9 @@ func (s *ProjectService) BatchDeleteProjects(ctx context.Context, request *conne
 			projectsToPurge = append(projectsToPurge, project)
 		}
 
-		// Soft-delete projects that aren't already deleted
-		var projectsToSoftDelete []*store.UpdateProjectMessage
 		for _, project := range projectsToPurge {
 			if !project.Deleted {
-				projectsToSoftDelete = append(projectsToSoftDelete, &store.UpdateProjectMessage{
-					ResourceID: project.ResourceID,
-					Workspace:  project.Workspace,
-					Delete:     &deletePatch,
-				})
-			}
-		}
-		if len(projectsToSoftDelete) > 0 {
-			if err := s.store.UpdateProjects(ctx, projectsToSoftDelete...); err != nil {
-				return nil, connect.NewError(connect.CodeInternal, err)
+				return nil, connect.NewError(connect.CodeFailedPrecondition, errors.Errorf("project %q must be archived before it can be deleted", project.GetName()))
 			}
 		}
 

--- a/backend/api/v1/release_service_check.go
+++ b/backend/api/v1/release_service_check.go
@@ -31,6 +31,11 @@ import (
 	"github.com/bytebase/bytebase/backend/utils"
 )
 
+type releaseCheckTarget struct {
+	database *store.DatabaseMessage
+	name     string
+}
+
 func (s *ReleaseService) CheckRelease(ctx context.Context, req *connect.Request[v1pb.CheckReleaseRequest]) (*connect.Response[v1pb.CheckReleaseResponse], error) {
 	request := req.Msg
 	projectID, err := common.GetProjectID(request.GetParent())
@@ -49,6 +54,9 @@ func (s *ReleaseService) CheckRelease(ctx context.Context, req *connect.Request[
 	if project == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %q not found", projectID))
 	}
+	if project.Deleted {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.Errorf("project %q is archived", projectID))
+	}
 
 	if request.GetRelease() == nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("release is required"))
@@ -66,10 +74,27 @@ func (s *ReleaseService) CheckRelease(ctx context.Context, req *connect.Request[
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("targets cannot be empty"))
 	}
 
-	var targetDatabases []*store.DatabaseMessage
+	var targets []*releaseCheckTarget
 	for _, target := range request.Targets {
 		// Handle database target.
-		if instanceID, databaseName, err := common.GetInstanceDatabaseID(target); err == nil {
+		if targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(target); err == nil {
+			if targetProjectID != nil && *targetProjectID != projectID {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database target %q does not belong to project %q", target, projectID))
+			}
+			instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{
+				Workspace:  workspaceID,
+				ResourceID: &instanceID,
+			})
+			if err != nil {
+				return nil, connect.NewError(connect.CodeInternal, err)
+			}
+			if instance == nil || instance.Deleted {
+				return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", instanceID))
+			}
+			if (targetProjectID == nil) != (instance.ProjectID == nil) ||
+				targetProjectID != nil && *targetProjectID != *instance.ProjectID {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database target %q is not canonical for its instance", target))
+			}
 			database, err := s.store.GetDatabase(ctx, &store.FindDatabaseMessage{
 				Workspace:    common.GetWorkspaceIDFromContext(ctx),
 				InstanceID:   &instanceID,
@@ -81,27 +106,20 @@ func (s *ReleaseService) CheckRelease(ctx context.Context, req *connect.Request[
 			if database == nil {
 				return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %v not found", target))
 			}
-			targetDatabases = append(targetDatabases, database)
+			if database.ProjectID != projectID {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database target %q does not belong to project %q", target, projectID))
+			}
+			targets = append(targets, &releaseCheckTarget{database: database, name: target})
 			continue
 		}
 
 		// Handle database group target. Extract all matched databases in the database group.
 		if projectResourceID, databaseGroupResourceID, err := common.GetProjectIDDatabaseGroupID(target); err == nil {
-			project, err := s.store.GetProject(ctx, &store.FindProjectMessage{
-				Workspace:  workspaceID,
-				ResourceID: &projectResourceID,
-			})
-			if err != nil {
-				return nil, connect.NewError(connect.CodeInternal, err)
-			}
-			if project == nil {
-				return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %q not found", projectResourceID))
-			}
-			if project.Deleted {
-				return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %q has been deleted", projectResourceID))
+			if projectResourceID != projectID {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database group target %q does not belong to project %q", target, projectID))
 			}
 			existedDatabaseGroup, err := s.store.GetDatabaseGroup(ctx, &store.FindDatabaseGroupMessage{
-				ProjectIDs: []string{project.ResourceID},
+				ProjectIDs: []string{projectID},
 				ResourceID: &databaseGroupResourceID,
 			})
 			if err != nil {
@@ -122,15 +140,34 @@ func (s *ReleaseService) CheckRelease(ctx context.Context, req *connect.Request[
 			if err != nil {
 				return nil, err
 			}
-			targetDatabases = append(targetDatabases, matches...)
+			for _, database := range matches {
+				instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{
+					Workspace:  workspaceID,
+					ResourceID: &database.InstanceID,
+				})
+				if err != nil {
+					return nil, connect.NewError(connect.CodeInternal, err)
+				}
+				if instance == nil || instance.Deleted {
+					return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", database.InstanceID))
+				}
+				name := common.FormatDatabase(database.InstanceID, database.DatabaseName)
+				if instance.ProjectID != nil {
+					name = common.FormatProjectDatabase(*instance.ProjectID, database.InstanceID, database.DatabaseName)
+				}
+				targets = append(targets, &releaseCheckTarget{
+					database: database,
+					name:     name,
+				})
+			}
 			continue
 		}
 
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unsupported target %q", target))
 	}
 
-	if project.Setting.GetCiSamplingSize() > 0 && len(targetDatabases) > int(project.Setting.GetCiSamplingSize()) {
-		targetDatabases = targetDatabases[:project.Setting.GetCiSamplingSize()]
+	if project.Setting.GetCiSamplingSize() > 0 && len(targets) > int(project.Setting.GetCiSamplingSize()) {
+		targets = targets[:project.Setting.GetCiSamplingSize()]
 	}
 
 	// Validate and sanitize release files.
@@ -149,13 +186,13 @@ func (s *ReleaseService) CheckRelease(ctx context.Context, req *connect.Request[
 	var response *v1pb.CheckReleaseResponse
 	switch releaseType {
 	case v1pb.Release_DECLARATIVE:
-		resp, err := s.checkReleaseDeclarative(ctx, sanitizedFiles, targetDatabases, request.CustomRules)
+		resp, err := s.checkReleaseDeclarative(ctx, sanitizedFiles, targets, request.CustomRules)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check release declarative"))
 		}
 		response = resp
 	case v1pb.Release_VERSIONED:
-		resp, err := s.checkReleaseVersioned(ctx, project, sanitizedFiles, targetDatabases, request.CustomRules)
+		resp, err := s.checkReleaseVersioned(ctx, project, sanitizedFiles, targets, request.CustomRules)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check release versioned"))
 		}
@@ -230,7 +267,7 @@ func truncateVCSProviderUserMetadata(value string) string {
 	return string([]rune(value)[:maxVCSProviderUserFieldLength])
 }
 
-func (s *ReleaseService) checkReleaseVersioned(ctx context.Context, project *store.ProjectMessage, files []*v1pb.Release_File, databases []*store.DatabaseMessage, customRules string) (*v1pb.CheckReleaseResponse, error) {
+func (s *ReleaseService) checkReleaseVersioned(ctx context.Context, project *store.ProjectMessage, files []*v1pb.Release_File, targets []*releaseCheckTarget, customRules string) (*v1pb.CheckReleaseResponse, error) {
 	resp := &v1pb.CheckReleaseResponse{}
 	var errorAdviceCount, warningAdviceCount int
 
@@ -240,7 +277,8 @@ func (s *ReleaseService) checkReleaseVersioned(ctx context.Context, project *sto
 	}
 
 loop:
-	for _, database := range databases {
+	for _, target := range targets {
+		database := target.database
 		instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{
 			Workspace:  common.GetWorkspaceIDFromContext(ctx),
 			ResourceID: &database.InstanceID,
@@ -326,7 +364,7 @@ loop:
 					// Add a warning advice if SHA256 mismatch
 					checkResult := &v1pb.CheckReleaseResponse_CheckResult{
 						File:   file.Path,
-						Target: common.FormatDatabase(instance.ResourceID, database.DatabaseName),
+						Target: target.name,
 						Advices: []*v1pb.Advice{
 							{
 								Status:  v1pb.Advice_WARNING,
@@ -346,7 +384,7 @@ loop:
 			checkResult, err := func() (*v1pb.CheckReleaseResponse_CheckResult, error) {
 				checkResult := &v1pb.CheckReleaseResponse_CheckResult{
 					File:   file.Path,
-					Target: common.FormatDatabase(instance.ResourceID, database.DatabaseName),
+					Target: target.name,
 				}
 				// statement is guaranteed to be populated by validateAndSanitizeReleaseFiles
 				statement := string(file.Statement)
@@ -404,7 +442,7 @@ loop:
 			if err != nil {
 				checkResult = &v1pb.CheckReleaseResponse_CheckResult{
 					File:   file.Path,
-					Target: common.FormatDatabase(instance.ResourceID, database.DatabaseName),
+					Target: target.name,
 					Advices: []*v1pb.Advice{
 						{
 							Status:  v1pb.Advice_ERROR,
@@ -441,7 +479,7 @@ loop:
 	return resp, nil
 }
 
-func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v1pb.Release_File, databases []*store.DatabaseMessage, customRules string) (*v1pb.CheckReleaseResponse, error) {
+func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v1pb.Release_File, targets []*releaseCheckTarget, customRules string) (*v1pb.CheckReleaseResponse, error) {
 	var results []*v1pb.CheckReleaseResponse_CheckResult
 	var errorAdviceCount, warningAdviceCount int
 
@@ -454,7 +492,8 @@ func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v
 	}
 	combinedTargetSDL := combinedSDLBuilder.String()
 
-	for _, database := range databases {
+	for _, target := range targets {
+		database := target.database
 		instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{
 			Workspace:  common.GetWorkspaceIDFromContext(ctx),
 			ResourceID: &database.InstanceID,
@@ -490,7 +529,7 @@ func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v
 				if fv.LessThanOrEqual(rv) {
 					checkResult := &v1pb.CheckReleaseResponse_CheckResult{
 						File:   file.Path,
-						Target: common.FormatDatabase(instance.ResourceID, database.DatabaseName),
+						Target: target.name,
 						Advices: []*v1pb.Advice{
 							{
 								Status:  v1pb.Advice_WARNING,
@@ -589,7 +628,7 @@ func (s *ReleaseService) checkReleaseDeclarative(ctx context.Context, files []*v
 		for _, file := range files {
 			checkResult := &v1pb.CheckReleaseResponse_CheckResult{
 				File:   file.Path,
-				Target: common.FormatDatabase(instance.ResourceID, database.DatabaseName),
+				Target: target.name,
 			}
 
 			// statement is guaranteed to be populated by validateAndSanitizeReleaseFiles

--- a/backend/api/v1/release_service_check.go
+++ b/backend/api/v1/release_service_check.go
@@ -81,6 +81,20 @@ func (s *ReleaseService) CheckRelease(ctx context.Context, req *connect.Request[
 			if targetProjectID != nil && *targetProjectID != projectID {
 				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database target %q does not belong to project %q", target, projectID))
 			}
+			database, err := s.store.GetDatabase(ctx, &store.FindDatabaseMessage{
+				Workspace:    workspaceID,
+				InstanceID:   &instanceID,
+				DatabaseName: &databaseName,
+			})
+			if err != nil {
+				return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to found database %v", target))
+			}
+			if database == nil {
+				return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %v not found", target))
+			}
+			if database.ProjectID != projectID {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database target %q does not belong to project %q", target, projectID))
+			}
 			instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{
 				Workspace:  workspaceID,
 				ResourceID: &instanceID,
@@ -94,20 +108,6 @@ func (s *ReleaseService) CheckRelease(ctx context.Context, req *connect.Request[
 			if (targetProjectID == nil) != (instance.ProjectID == nil) ||
 				targetProjectID != nil && *targetProjectID != *instance.ProjectID {
 				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database target %q is not canonical for its instance", target))
-			}
-			database, err := s.store.GetDatabase(ctx, &store.FindDatabaseMessage{
-				Workspace:    common.GetWorkspaceIDFromContext(ctx),
-				InstanceID:   &instanceID,
-				DatabaseName: &databaseName,
-			})
-			if err != nil {
-				return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to found database %v", target))
-			}
-			if database == nil {
-				return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %v not found", target))
-			}
-			if database.ProjectID != projectID {
-				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database target %q does not belong to project %q", target, projectID))
 			}
 			targets = append(targets, &releaseCheckTarget{database: database, name: target})
 			continue
@@ -141,23 +141,9 @@ func (s *ReleaseService) CheckRelease(ctx context.Context, req *connect.Request[
 				return nil, err
 			}
 			for _, database := range matches {
-				instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{
-					Workspace:  workspaceID,
-					ResourceID: &database.InstanceID,
-				})
-				if err != nil {
-					return nil, connect.NewError(connect.CodeInternal, err)
-				}
-				if instance == nil || instance.Deleted {
-					return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", database.InstanceID))
-				}
-				name := common.FormatDatabase(database.InstanceID, database.DatabaseName)
-				if instance.ProjectID != nil {
-					name = common.FormatProjectDatabase(*instance.ProjectID, database.InstanceID, database.DatabaseName)
-				}
 				targets = append(targets, &releaseCheckTarget{
 					database: database,
-					name:     name,
+					name:     database.ResourceName(),
 				})
 			}
 			continue

--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -398,6 +398,7 @@ func CreateRolloutAndPendingTasks(
 	if issue != nil && issue.Payload.GetDraft() {
 		return errDraftIssueNotSubmitted
 	}
+	ctx = context.WithValue(ctx, common.WorkspaceIDContextKey, project.Workspace)
 
 	result, err := review.NewWorkflow(s).CreateRollout(ctx, review.CreateRolloutInput{
 		Workspace: project.Workspace,

--- a/backend/api/v1/rollout_service_converter.go
+++ b/backend/api/v1/rollout_service_converter.go
@@ -225,13 +225,17 @@ func convertToTask(project *store.ProjectMessage, task *store.TaskMessage) (*v1p
 
 func convertToTaskFromDatabaseCreate(project *store.ProjectMessage, task *store.TaskMessage) (*v1pb.Task, error) {
 	stageID := common.FormatStageID(task.Environment)
+	target, err := formatTaskInstanceTarget(project, task)
+	if err != nil {
+		return nil, err
+	}
 	v1pbTask := &v1pb.Task{
 		Name:          common.FormatTask(project.ResourceID, task.PlanID, stageID, task.ID),
 		SpecId:        task.Payload.GetSpecId(),
 		Type:          convertToTaskType(task),
 		Status:        convertToTaskStatus(task.LatestTaskRunStatus, task.Payload.GetSkipped()),
 		SkippedReason: task.Payload.GetSkippedReason(),
-		Target:        common.FormatInstance(task.InstanceID),
+		Target:        target,
 		Payload: &v1pb.Task_DatabaseCreate_{
 			DatabaseCreate: &v1pb.Task_DatabaseCreate{
 				Sheet: common.FormatSheet(project.ResourceID, task.Payload.GetSheetSha256()),
@@ -253,6 +257,11 @@ func convertToTaskFromSchemaUpdate(project *store.ProjectMessage, task *store.Ta
 	}
 
 	stageID := common.FormatStageID(task.Environment)
+	instanceTarget, err := formatTaskInstanceTarget(project, task)
+	if err != nil {
+		return nil, err
+	}
+	target := fmt.Sprintf("%s/%s%s", instanceTarget, common.DatabaseIDPrefix, *task.DatabaseName)
 
 	// Build DatabaseUpdate payload
 	databaseUpdate := &v1pb.Task_DatabaseUpdate{}
@@ -274,7 +283,7 @@ func convertToTaskFromSchemaUpdate(project *store.ProjectMessage, task *store.Ta
 		Type:          convertToTaskType(task),
 		Status:        convertToTaskStatus(task.LatestTaskRunStatus, task.Payload.GetSkipped()),
 		SkippedReason: task.Payload.GetSkippedReason(),
-		Target:        fmt.Sprintf("%s%s/%s%s", common.InstanceNamePrefix, task.InstanceID, common.DatabaseIDPrefix, *(task.DatabaseName)),
+		Target:        target,
 		Payload: &v1pb.Task_DatabaseUpdate_{
 			DatabaseUpdate: databaseUpdate,
 		},
@@ -286,6 +295,16 @@ func convertToTaskFromSchemaUpdate(project *store.ProjectMessage, task *store.Ta
 		v1pbTask.RunTime = timestamppb.New(*task.RunAt)
 	}
 	return v1pbTask, nil
+}
+
+func formatTaskInstanceTarget(project *store.ProjectMessage, task *store.TaskMessage) (string, error) {
+	if task.InstanceProjectID == nil {
+		return common.FormatInstance(task.InstanceID), nil
+	}
+	if *task.InstanceProjectID != project.ResourceID {
+		return "", errors.Errorf("task instance %q belongs to project %q, not %q", task.InstanceID, *task.InstanceProjectID, project.ResourceID)
+	}
+	return common.FormatProjectInstance(project.ResourceID, task.InstanceID), nil
 }
 
 func convertToTaskStatus(latestTaskRunStatus storepb.TaskRun_Status, skipped bool) v1pb.Task_Status {

--- a/backend/api/v1/rollout_service_task.go
+++ b/backend/api/v1/rollout_service_task.go
@@ -16,26 +16,6 @@ import (
 	"github.com/bytebase/bytebase/backend/utils"
 )
 
-func formatDatabaseTarget(ctx context.Context, s *store.Store, database *store.DatabaseMessage) (string, error) {
-	instance, err := s.GetInstance(ctx, &store.FindInstanceMessage{
-		Workspace:  common.GetWorkspaceIDFromContext(ctx),
-		ResourceID: &database.InstanceID,
-	})
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to get instance %q", database.InstanceID)
-	}
-	if instance == nil {
-		return "", errors.Errorf("instance %q not found", database.InstanceID)
-	}
-	if instance.Deleted {
-		return "", errors.Errorf("instance %q has been deleted", database.InstanceID)
-	}
-	if instance.ProjectID == nil {
-		return common.FormatDatabase(database.InstanceID, database.DatabaseName), nil
-	}
-	return common.FormatProjectDatabase(*instance.ProjectID, database.InstanceID, database.DatabaseName), nil
-}
-
 func applyDatabaseGroupSpecTransformations(ctx context.Context, s *store.Store, specs []*storepb.PlanConfig_Spec, projectID string) ([]*storepb.PlanConfig_Spec, error) {
 	var result []*storepb.PlanConfig_Spec
 	for _, spec := range specs {
@@ -70,11 +50,7 @@ func applyDatabaseGroupSpecTransformations(ctx context.Context, s *store.Store, 
 
 					var databases []string
 					for _, db := range matchedDatabases {
-						target, err := formatDatabaseTarget(ctx, s, db)
-						if err != nil {
-							return nil, err
-						}
-						databases = append(databases, target)
+						databases = append(databases, db.ResourceName())
 					}
 					config.Targets = databases
 				}
@@ -278,20 +254,9 @@ func getDatabaseMessagesByTargets(ctx context.Context, s *store.Store, targets [
 				return nil, errors.Wrapf(err, "failed to get database group %q", target)
 			}
 			for _, matched := range databaseGroup.MatchedDatabases {
-				matchedProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(matched.Name)
+				_, instanceID, databaseName, err := common.GetDatabaseResourceName(matched.Name)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to parse %q", matched.Name)
-				}
-				instanceName := common.FormatInstance(instanceID)
-				if matchedProjectID != nil {
-					instanceName = common.FormatProjectInstance(*matchedProjectID, instanceID)
-				}
-				instance, err := getInstanceMessage(ctx, s, instanceName)
-				if err != nil {
-					return nil, errors.Wrapf(err, "failed to get instance for %q", matched.Name)
-				}
-				if instance.Deleted {
-					return nil, errors.Errorf("instance %q has been deleted", instanceName)
 				}
 				database, err := s.GetDatabase(ctx, &store.FindDatabaseMessage{
 					Workspace:    common.GetWorkspaceIDFromContext(ctx),
@@ -307,20 +272,12 @@ func getDatabaseMessagesByTargets(ctx context.Context, s *store.Store, targets [
 				if database.ProjectID != targetProjectID {
 					return nil, errors.Errorf("database %q does not belong to project %q", matched.Name, targetProjectID)
 				}
+				if database.ResourceName() != matched.Name {
+					return nil, errors.Errorf("database target %q is not canonical for its instance", matched.Name)
+				}
 				databases = append(databases, database)
 			}
 		} else if targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(target); err == nil {
-			instanceName := common.FormatInstance(instanceID)
-			if targetProjectID != nil {
-				instanceName = common.FormatProjectInstance(*targetProjectID, instanceID)
-			}
-			instance, err := getInstanceMessage(ctx, s, instanceName)
-			if err != nil {
-				return nil, errors.Wrapf(err, "failed to get instance for %q", target)
-			}
-			if instance.Deleted {
-				return nil, errors.Errorf("instance %q has been deleted", instanceName)
-			}
 			database, err := s.GetDatabase(ctx, &store.FindDatabaseMessage{
 				Workspace:    common.GetWorkspaceIDFromContext(ctx),
 				InstanceID:   &instanceID,
@@ -335,12 +292,55 @@ func getDatabaseMessagesByTargets(ctx context.Context, s *store.Store, targets [
 			if targetProjectID != nil && database.ProjectID != *targetProjectID {
 				return nil, errors.Errorf("database %q does not belong to project %q", target, *targetProjectID)
 			}
+			if database.ResourceName() != target {
+				return nil, errors.Errorf("database target %q is not canonical for its instance", target)
+			}
 			databases = append(databases, database)
 		} else {
 			return nil, errors.Errorf("invalid target %q", target)
 		}
 	}
+	if err := validateRolloutDatabaseInstances(ctx, s, databases); err != nil {
+		return nil, err
+	}
 	return databases, nil
+}
+
+func validateRolloutDatabaseInstances(ctx context.Context, s *store.Store, databases []*store.DatabaseMessage) error {
+	instanceIDs := make([]string, 0, len(databases))
+	seen := make(map[string]bool, len(databases))
+	for _, database := range databases {
+		if !seen[database.InstanceID] {
+			seen[database.InstanceID] = true
+			instanceIDs = append(instanceIDs, database.InstanceID)
+		}
+	}
+	if len(instanceIDs) == 0 {
+		return nil
+	}
+
+	instances, err := s.ListInstances(ctx, &store.FindInstanceMessage{
+		Workspace:   common.GetWorkspaceIDFromContext(ctx),
+		ResourceIDs: &instanceIDs,
+		ShowDeleted: true,
+	})
+	if err != nil {
+		return errors.Wrap(err, "failed to list rollout target instances")
+	}
+	instanceByID := make(map[string]*store.InstanceMessage, len(instances))
+	for _, instance := range instances {
+		instanceByID[instance.ResourceID] = instance
+	}
+	for _, database := range databases {
+		instance := instanceByID[database.InstanceID]
+		if instance == nil {
+			return errors.Errorf("instance %q not found", database.InstanceID)
+		}
+		if instance.Deleted {
+			return errors.Errorf("instance %q has been deleted", database.InstanceID)
+		}
+	}
+	return nil
 }
 
 // checkCharacterSetCollationOwner checks if the character set, collation and owner are legal according to the dbType.

--- a/backend/api/v1/rollout_service_task.go
+++ b/backend/api/v1/rollout_service_task.go
@@ -16,6 +16,26 @@ import (
 	"github.com/bytebase/bytebase/backend/utils"
 )
 
+func formatDatabaseTarget(ctx context.Context, s *store.Store, database *store.DatabaseMessage) (string, error) {
+	instance, err := s.GetInstance(ctx, &store.FindInstanceMessage{
+		Workspace:  common.GetWorkspaceIDFromContext(ctx),
+		ResourceID: &database.InstanceID,
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get instance %q", database.InstanceID)
+	}
+	if instance == nil {
+		return "", errors.Errorf("instance %q not found", database.InstanceID)
+	}
+	if instance.Deleted {
+		return "", errors.Errorf("instance %q has been deleted", database.InstanceID)
+	}
+	if instance.ProjectID == nil {
+		return common.FormatDatabase(database.InstanceID, database.DatabaseName), nil
+	}
+	return common.FormatProjectDatabase(*instance.ProjectID, database.InstanceID, database.DatabaseName), nil
+}
+
 func applyDatabaseGroupSpecTransformations(ctx context.Context, s *store.Store, specs []*storepb.PlanConfig_Spec, projectID string) ([]*storepb.PlanConfig_Spec, error) {
 	var result []*storepb.PlanConfig_Spec
 	for _, spec := range specs {
@@ -50,7 +70,11 @@ func applyDatabaseGroupSpecTransformations(ctx context.Context, s *store.Store, 
 
 					var databases []string
 					for _, db := range matchedDatabases {
-						databases = append(databases, common.FormatDatabase(db.InstanceID, db.DatabaseName))
+						target, err := formatDatabaseTarget(ctx, s, db)
+						if err != nil {
+							return nil, err
+						}
+						databases = append(databases, target)
 					}
 					config.Targets = databases
 				}
@@ -248,15 +272,26 @@ func getDatabaseMessagesByTargets(ctx context.Context, s *store.Store, targets [
 	databases := []*store.DatabaseMessage{}
 
 	for _, target := range targets {
-		if _, _, err := common.GetProjectIDDatabaseGroupID(target); err == nil {
+		if targetProjectID, _, err := common.GetProjectIDDatabaseGroupID(target); err == nil {
 			databaseGroup, err := getDatabaseGroupByName(ctx, s, target, v1pb.DatabaseGroupView_DATABASE_GROUP_VIEW_FULL)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to get database group %q", target)
 			}
 			for _, matched := range databaseGroup.MatchedDatabases {
-				instanceID, databaseName, err := common.GetInstanceDatabaseID(matched.Name)
+				matchedProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(matched.Name)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to parse %q", matched.Name)
+				}
+				instanceName := common.FormatInstance(instanceID)
+				if matchedProjectID != nil {
+					instanceName = common.FormatProjectInstance(*matchedProjectID, instanceID)
+				}
+				instance, err := getInstanceMessage(ctx, s, instanceName)
+				if err != nil {
+					return nil, errors.Wrapf(err, "failed to get instance for %q", matched.Name)
+				}
+				if instance.Deleted {
+					return nil, errors.Errorf("instance %q has been deleted", instanceName)
 				}
 				database, err := s.GetDatabase(ctx, &store.FindDatabaseMessage{
 					Workspace:    common.GetWorkspaceIDFromContext(ctx),
@@ -269,12 +304,22 @@ func getDatabaseMessagesByTargets(ctx context.Context, s *store.Store, targets [
 				if database == nil {
 					return nil, errors.Errorf("database %q not found", matched.Name)
 				}
+				if database.ProjectID != targetProjectID {
+					return nil, errors.Errorf("database %q does not belong to project %q", matched.Name, targetProjectID)
+				}
 				databases = append(databases, database)
 			}
-		} else if _, _, err := common.GetInstanceDatabaseID(target); err == nil {
-			instanceID, databaseName, err := common.GetInstanceDatabaseID(target)
+		} else if targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(target); err == nil {
+			instanceName := common.FormatInstance(instanceID)
+			if targetProjectID != nil {
+				instanceName = common.FormatProjectInstance(*targetProjectID, instanceID)
+			}
+			instance, err := getInstanceMessage(ctx, s, instanceName)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed to parse %q", target)
+				return nil, errors.Wrapf(err, "failed to get instance for %q", target)
+			}
+			if instance.Deleted {
+				return nil, errors.Errorf("instance %q has been deleted", instanceName)
 			}
 			database, err := s.GetDatabase(ctx, &store.FindDatabaseMessage{
 				Workspace:    common.GetWorkspaceIDFromContext(ctx),
@@ -286,6 +331,9 @@ func getDatabaseMessagesByTargets(ctx context.Context, s *store.Store, targets [
 			}
 			if database == nil {
 				return nil, errors.Errorf("database %q not found", target)
+			}
+			if targetProjectID != nil && database.ProjectID != *targetProjectID {
+				return nil, errors.Errorf("database %q does not belong to project %q", target, *targetProjectID)
 			}
 			databases = append(databases, database)
 		} else {

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -149,7 +149,7 @@ func (s *SQLService) AdminExecute(ctx context.Context, stream *connect.BidiStrea
 			queryContext,
 		)
 
-		s.createQueryHistory(database, store.QueryHistoryTypeQuery, request.Statement, user.Email, duration, queryErr)
+		s.createQueryHistory(instance, database, store.QueryHistoryTypeQuery, request.Statement, user.Email, duration, queryErr)
 		response := &v1pb.AdminExecuteResponse{}
 		if queryErr != nil {
 			response.Results = []*v1pb.QueryResult{
@@ -220,7 +220,7 @@ func (s *SQLService) preCheckAccess(ctx context.Context, statement string, insta
 		return nil
 	}
 
-	databaseFullName := common.FormatDatabase(database.InstanceID, database.DatabaseName)
+	databaseFullName := formatDatabaseResourceName(instance, database)
 	now := time.Now().UTC().Format(time.RFC3339)
 
 	filter := fmt.Sprintf(
@@ -417,7 +417,7 @@ func (s *SQLService) Query(ctx context.Context, req *connect.Request[v1pb.QueryR
 	)
 
 	// Update activity.
-	s.createQueryHistory(database, store.QueryHistoryTypeQuery, statement, user.Email, duration, queryErr)
+	s.createQueryHistory(instance, database, store.QueryHistoryTypeQuery, statement, user.Email, duration, queryErr)
 
 	if queryErr != nil {
 		if len(results) == 0 {
@@ -1010,7 +1010,7 @@ func (s *SQLService) Export(ctx context.Context, req *connect.Request[v1pb.Expor
 	}
 	bytes, duration, exportErr := doExport(ctx, s.store, s.dbFactory, s.licenseService, request, user, instance, database, optionalAccessCheck, s.schemaSyncer, dataSource, skipMasking)
 
-	s.createQueryHistory(database, store.QueryHistoryTypeExport, statement, user.Email, duration, exportErr)
+	s.createQueryHistory(instance, database, store.QueryHistoryTypeExport, statement, user.Email, duration, exportErr)
 
 	if exportErr != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.New(exportErr.Error()))
@@ -1228,11 +1228,11 @@ func exportSQLWithContext(
 	return export.SQLToWriter(w, instance.Metadata.GetEngine(), statementPrefix, result)
 }
 
-func (s *SQLService) createQueryHistory(database *store.DatabaseMessage, queryType store.QueryHistoryType, statement string, userEmail string, duration time.Duration, queryErr error) {
+func (s *SQLService) createQueryHistory(instance *store.InstanceMessage, database *store.DatabaseMessage, queryType store.QueryHistoryType, statement string, userEmail string, duration time.Duration, queryErr error) {
 	qh := &store.QueryHistoryMessage{
 		Creator:   userEmail,
 		Project:   database.ProjectID,
-		Database:  common.FormatDatabase(database.InstanceID, database.DatabaseName),
+		Database:  formatDatabaseResourceName(instance, database),
 		Statement: statement,
 		Type:      queryType,
 		Payload: &storepb.QueryHistoryPayload{
@@ -1362,7 +1362,8 @@ func (s *SQLService) accessCheckWithGrantedTargets(
 
 	checkDatabaseAccess := func(perm permission.Permission) error {
 		databaseFullName := common.FormatDatabase(instance.ResourceID, database.DatabaseName)
-		if _, granted := grantedTargets[databaseFullName]; granted {
+		grantTargetName := formatDatabaseResourceName(instance, database)
+		if _, granted := grantedTargets[grantTargetName]; granted {
 			return nil
 		}
 		attributes := map[string]any{
@@ -1503,7 +1504,12 @@ func (s *SQLService) accessCheckWithGrantedTargets(
 		var deniedResources []string
 		for column := range span.SourceColumns {
 			columnDatabaseFullName := common.FormatDatabase(instance.ResourceID, column.Database)
-			if _, granted := grantedTargets[columnDatabaseFullName]; granted {
+			grantTargetName := formatDatabaseResourceName(instance, &store.DatabaseMessage{
+				ProjectID:    database.ProjectID,
+				InstanceID:   instance.ResourceID,
+				DatabaseName: column.Database,
+			})
+			if _, granted := grantedTargets[grantTargetName]; granted {
 				continue
 			}
 			attributes := map[string]any{
@@ -1602,7 +1608,12 @@ func (s *SQLService) authorizeWriteTargets(
 	var deniedResources []string
 	for _, t := range targets {
 		databaseFullName := common.FormatDatabase(instance.ResourceID, t.database)
-		if _, granted := grantedTargets[databaseFullName]; granted {
+		grantTargetName := formatDatabaseResourceName(instance, &store.DatabaseMessage{
+			ProjectID:    database.ProjectID,
+			InstanceID:   instance.ResourceID,
+			DatabaseName: t.database,
+		})
+		if _, granted := grantedTargets[grantTargetName]; granted {
 			continue
 		}
 		// A target with no table name is a database-only target: DDL on a non-table object
@@ -1862,7 +1873,7 @@ func (s *SQLService) prepareRelatedMessage(ctx context.Context, requestName stri
 		return nil, nil, nil, connect.NewError(connect.CodeInternal, errors.New(err.Error()))
 	}
 
-	instanceID, databaseName, err := common.GetInstanceDatabaseID(requestName)
+	targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(requestName)
 	if err != nil {
 		return nil, nil, nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to parse %q", requestName))
 	}
@@ -1877,6 +1888,19 @@ func (s *SQLService) prepareRelatedMessage(ctx context.Context, requestName stri
 	if database == nil {
 		return nil, nil, nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found", requestName))
 	}
+	if targetProjectID != nil && database.ProjectID != *targetProjectID {
+		return nil, nil, nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found in project %q", requestName, *targetProjectID))
+	}
+	project, err := s.store.GetProject(ctx, &store.FindProjectMessage{
+		Workspace:  common.GetWorkspaceIDFromContext(ctx),
+		ResourceID: &database.ProjectID,
+	})
+	if err != nil {
+		return nil, nil, nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get project %q", database.ProjectID))
+	}
+	if project == nil || project.Deleted {
+		return nil, nil, nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project %q not found", database.ProjectID))
+	}
 
 	instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{
 		Workspace:  common.GetWorkspaceIDFromContext(ctx),
@@ -1887,6 +1911,13 @@ func (s *SQLService) prepareRelatedMessage(ctx context.Context, requestName stri
 	}
 	if instance == nil {
 		return nil, nil, nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", database.InstanceID))
+	}
+	if instance.Deleted {
+		return nil, nil, nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", database.InstanceID))
+	}
+	if (targetProjectID == nil) != (instance.ProjectID == nil) ||
+		targetProjectID != nil && *targetProjectID != *instance.ProjectID {
+		return nil, nil, nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database name %q is not canonical for its instance", requestName))
 	}
 
 	return user, instance, database, nil

--- a/backend/api/v1/worksheet_service.go
+++ b/backend/api/v1/worksheet_service.go
@@ -69,26 +69,10 @@ func (s *WorksheetService) CreateWorksheet(
 
 	var database *store.DatabaseMessage
 	if request.Worksheet.Database != "" {
-		instanceID, databaseName, err := common.GetInstanceDatabaseID(request.Worksheet.Database)
+		database, err = s.getWorksheetDatabase(ctx, projectResourceID, request.Worksheet.Database)
 		if err != nil {
-			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to parse %q", request.Worksheet.Database))
+			return nil, err
 		}
-		db, err := s.store.GetDatabase(ctx, &store.FindDatabaseMessage{
-			Workspace:    common.GetWorkspaceIDFromContext(ctx),
-			InstanceID:   &instanceID,
-			DatabaseName: &databaseName,
-		})
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get database"))
-		}
-		if db == nil {
-			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found", request.Worksheet.Database))
-		}
-		// Verify the database belongs to the specified project
-		if db.ProjectID != projectResourceID {
-			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found in project %q", request.Worksheet.Database, projectResourceID))
-		}
-		database = db
 	}
 	storeWorksheetCreate, err := convertToStoreWorksheetMessage(project, database, user.Email, request.Worksheet)
 	if err != nil {
@@ -98,7 +82,10 @@ func (s *WorksheetService) CreateWorksheet(
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("failed to create worksheet: %v", err))
 	}
-	v1pbWorksheet := convertToAPIWorksheetMessage(worksheet)
+	v1pbWorksheet, err := s.convertWorksheetToAPI(ctx, worksheet)
+	if err != nil {
+		return nil, err
+	}
 	return connect.NewResponse(v1pbWorksheet), nil
 }
 
@@ -125,7 +112,10 @@ func (s *WorksheetService) GetWorksheet(
 		return nil, connect.NewError(connect.CodePermissionDenied, errors.Errorf("cannot access worksheet %s", worksheet.Title))
 	}
 
-	v1pbWorksheet := convertToAPIWorksheetMessage(worksheet)
+	v1pbWorksheet, err := s.convertWorksheetToAPI(ctx, worksheet)
+	if err != nil {
+		return nil, err
+	}
 	return connect.NewResponse(v1pbWorksheet), nil
 }
 
@@ -191,7 +181,11 @@ func (s *WorksheetService) ListWorksheets(
 
 	v1pbWorksheets := make([]*v1pb.Worksheet, 0, len(worksheetList))
 	for _, worksheet := range worksheetList {
-		v1pbWorksheets = append(v1pbWorksheets, convertToAPIWorksheetMessage(worksheet))
+		v1pbWorksheet, err := s.convertWorksheetToAPI(ctx, worksheet)
+		if err != nil {
+			return nil, err
+		}
+		v1pbWorksheets = append(v1pbWorksheets, v1pbWorksheet)
 	}
 	return connect.NewResponse(&v1pb.ListWorksheetsResponse{
 		Worksheets:    v1pbWorksheets,
@@ -333,7 +327,10 @@ func (s *WorksheetService) SearchWorksheets(
 			slog.Warn("cannot access worksheet", slog.String("name", worksheet.Title))
 			continue
 		}
-		v1pbWorksheet := convertToAPIWorksheetMessage(worksheet)
+		v1pbWorksheet, err := s.convertWorksheetToAPI(ctx, worksheet)
+		if err != nil {
+			return nil, err
+		}
 		v1pbWorksheets = append(v1pbWorksheets, v1pbWorksheet)
 	}
 	return connect.NewResponse(&v1pb.SearchWorksheetsResponse{
@@ -398,24 +395,9 @@ func (s *WorksheetService) UpdateWorksheet(
 			worksheetPatch.Visibility = &stringVisibility
 		case "database":
 			if request.Worksheet.Database != "" {
-				instanceID, databaseName, err := common.GetInstanceDatabaseID(request.Worksheet.Database)
+				database, err := s.getWorksheetDatabase(ctx, worksheet.ProjectID, request.Worksheet.Database)
 				if err != nil {
-					return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to parse %q", request.Worksheet.Database))
-				}
-				database, err := s.store.GetDatabase(ctx, &store.FindDatabaseMessage{
-					Workspace:    common.GetWorkspaceIDFromContext(ctx),
-					InstanceID:   &instanceID,
-					DatabaseName: &databaseName,
-				})
-				if err != nil {
-					return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get database"))
-				}
-				if database == nil {
-					return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %v not found", request.Worksheet.Database))
-				}
-				// Verify the database belongs to the worksheet's project.
-				if database.ProjectID != worksheet.ProjectID {
-					return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found in project %q", request.Worksheet.Database, worksheet.ProjectID))
+					return nil, err
 				}
 				worksheetPatch.InstanceID, worksheetPatch.DatabaseName = &database.InstanceID, &database.DatabaseName
 			} else {
@@ -442,7 +424,10 @@ func (s *WorksheetService) UpdateWorksheet(
 	if worksheet == nil {
 		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("worksheet %q not found", request.Worksheet.Name))
 	}
-	v1pbWorksheet := convertToAPIWorksheetMessage(worksheet)
+	v1pbWorksheet, err := s.convertWorksheetToAPI(ctx, worksheet)
+	if err != nil {
+		return nil, err
+	}
 	return connect.NewResponse(v1pbWorksheet), nil
 }
 
@@ -639,6 +624,42 @@ func (s *WorksheetService) findWorksheet(ctx context.Context, projectID string, 
 	return worksheet, nil
 }
 
+func (s *WorksheetService) getWorksheetDatabase(ctx context.Context, projectID, name string) (*store.DatabaseMessage, error) {
+	targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(name)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to parse %q", name))
+	}
+	if targetProjectID != nil && *targetProjectID != projectID {
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found in project %q", name, projectID))
+	}
+	database, err := s.store.GetDatabase(ctx, &store.FindDatabaseMessage{
+		Workspace:    common.GetWorkspaceIDFromContext(ctx),
+		InstanceID:   &instanceID,
+		DatabaseName: &databaseName,
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get database"))
+	}
+	if database == nil || database.ProjectID != projectID {
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found in project %q", name, projectID))
+	}
+	instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{
+		Workspace:  common.GetWorkspaceIDFromContext(ctx),
+		ResourceID: &instanceID,
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get instance %q", instanceID))
+	}
+	if instance == nil || instance.Deleted {
+		return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("instance %q not found", instanceID))
+	}
+	if (targetProjectID == nil) != (instance.ProjectID == nil) ||
+		targetProjectID != nil && *targetProjectID != *instance.ProjectID {
+		return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("database name %q is not canonical for its instance", name))
+	}
+	return database, nil
+}
+
 // canWriteWorksheet check if the principal can write the worksheet.
 // worksheet is writable when the user has bb.worksheets.manage permission on the workspace, or.
 // PRIVATE: the creator.
@@ -730,10 +751,23 @@ func (s *WorksheetService) checkWorksheetPermission(
 	return ok, nil
 }
 
-func convertToAPIWorksheetMessage(worksheet *store.WorkSheetMessage) *v1pb.Worksheet {
+func (s *WorksheetService) convertWorksheetToAPI(ctx context.Context, worksheet *store.WorkSheetMessage) (*v1pb.Worksheet, error) {
 	databaseParent := ""
 	if worksheet.InstanceID != nil && worksheet.DatabaseName != nil {
+		instance, err := s.store.GetInstance(ctx, &store.FindInstanceMessage{
+			Workspace:  common.GetWorkspaceIDFromContext(ctx),
+			ResourceID: worksheet.InstanceID,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get worksheet instance %q", *worksheet.InstanceID))
+		}
+		if instance == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("worksheet instance %q not found", *worksheet.InstanceID))
+		}
 		databaseParent = common.FormatDatabase(*worksheet.InstanceID, *worksheet.DatabaseName)
+		if instance.ProjectID != nil {
+			databaseParent = common.FormatProjectDatabase(*instance.ProjectID, *worksheet.InstanceID, *worksheet.DatabaseName)
+		}
 	}
 
 	visibility := v1pb.Worksheet_VISIBILITY_UNSPECIFIED
@@ -760,7 +794,7 @@ func convertToAPIWorksheetMessage(worksheet *store.WorkSheetMessage) *v1pb.Works
 		Visibility:  visibility,
 		Starred:     worksheet.Starred,
 		Folders:     worksheet.Folders,
-	}
+	}, nil
 }
 
 func convertToStoreWorksheetMessage(project *store.ProjectMessage, database *store.DatabaseMessage, creator string, worksheet *v1pb.Worksheet) (*store.WorkSheetMessage, error) {

--- a/backend/component/review/approval.go
+++ b/backend/component/review/approval.go
@@ -6,6 +6,7 @@ import (
 
 	"google.golang.org/protobuf/proto"
 
+	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/enterprise"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/store"
@@ -58,6 +59,7 @@ func (a *ApprovalEvaluator) ApplyApprovalTemplate(ctx context.Context, input App
 	if project == nil {
 		return nil, workflowError(ErrorNotFound, "project %s not found", input.ProjectID)
 	}
+	ctx = context.WithValue(ctx, common.WorkspaceIDContextKey, project.Workspace)
 	issue, err := w.store.GetIssue(ctx, &store.FindIssueMessage{
 		Workspace:  input.Workspace,
 		ProjectIDs: []string{input.ProjectID},

--- a/backend/component/review/evaluator.go
+++ b/backend/component/review/evaluator.go
@@ -346,48 +346,56 @@ type specTarget struct {
 	sheetSha256 string
 }
 
-func validateInstanceTarget(ctx context.Context, stores *store.Store, projectID *string, instanceID string) error {
-	workspaceID := common.GetWorkspaceIDFromContext(ctx)
-	if workspaceID == "" {
-		workspaceID = "default"
-	}
-	instance, err := stores.GetInstance(ctx, &store.FindInstanceMessage{
-		Workspace:     workspaceID,
-		ResourceID:    &instanceID,
-		ProjectID:     projectID,
-		WorkspaceOnly: projectID == nil,
-	})
-	if err != nil {
-		return errors.Wrapf(err, "failed to get instance %q", instanceID)
-	}
-	if instance == nil {
-		return errors.Errorf("instance %q not found in requested scope", instanceID)
-	}
-	if instance.Deleted {
-		return errors.Errorf("instance %q has been deleted", instanceID)
-	}
-	return nil
+type instanceTarget struct {
+	projectID  *string
+	instanceID string
 }
 
-func formatDatabaseTarget(ctx context.Context, stores *store.Store, database *store.DatabaseMessage) (string, error) {
+func validateInstanceTarget(ctx context.Context, stores *store.Store, projectID *string, instanceID string) error {
+	_, err := getActiveTargetInstances(ctx, stores, []instanceTarget{{projectID: projectID, instanceID: instanceID}})
+	return err
+}
+
+func getActiveTargetInstances(ctx context.Context, stores *store.Store, targets []instanceTarget) (map[string]*store.InstanceMessage, error) {
 	workspaceID := common.GetWorkspaceIDFromContext(ctx)
 	if workspaceID == "" {
 		workspaceID = "default"
 	}
-	instance, err := stores.GetInstance(ctx, &store.FindInstanceMessage{
-		Workspace:  workspaceID,
-		ResourceID: &database.InstanceID,
+	instanceIDs := make([]string, 0, len(targets))
+	seen := make(map[string]bool, len(targets))
+	for _, target := range targets {
+		if !seen[target.instanceID] {
+			seen[target.instanceID] = true
+			instanceIDs = append(instanceIDs, target.instanceID)
+		}
+	}
+	instanceByID := make(map[string]*store.InstanceMessage, len(instanceIDs))
+	if len(instanceIDs) == 0 {
+		return instanceByID, nil
+	}
+	instances, err := stores.ListInstances(ctx, &store.FindInstanceMessage{
+		Workspace:   workspaceID,
+		ResourceIDs: &instanceIDs,
+		ShowDeleted: true,
 	})
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get instance %q", database.InstanceID)
+		return nil, errors.Wrap(err, "failed to list target instances")
 	}
-	if instance == nil {
-		return "", errors.Errorf("instance %q not found", database.InstanceID)
+	for _, instance := range instances {
+		instanceByID[instance.ResourceID] = instance
 	}
-	if instance.ProjectID == nil {
-		return common.FormatDatabase(database.InstanceID, database.DatabaseName), nil
+	for _, target := range targets {
+		instance := instanceByID[target.instanceID]
+		matchesScope := instance != nil && ((target.projectID == nil && instance.ProjectID == nil) ||
+			(target.projectID != nil && instance.ProjectID != nil && *target.projectID == *instance.ProjectID))
+		if !matchesScope {
+			return nil, errors.Errorf("instance %q not found in requested scope", target.instanceID)
+		}
+		if instance.Deleted {
+			return nil, errors.Errorf("instance %q has been deleted", target.instanceID)
+		}
 	}
-	return common.FormatProjectDatabase(*instance.ProjectID, database.InstanceID, database.DatabaseName), nil
+	return instanceByID, nil
 }
 
 // unfoldDatabaseTargets unfolds database groups and returns all database targets.
@@ -426,11 +434,7 @@ func unfoldDatabaseTargets(ctx context.Context, stores *store.Store, dbTargets [
 			// Replace dbTargets with unfolded databases
 			var unfolded []string
 			for _, db := range matchedDatabases {
-				target, err := formatDatabaseTarget(ctx, stores, db)
-				if err != nil {
-					return nil, err
-				}
-				unfolded = append(unfolded, target)
+				unfolded = append(unfolded, db.ResourceName())
 			}
 			return unfolded, nil
 		}
@@ -460,9 +464,6 @@ func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storep
 		if targetProjectID != nil && *targetProjectID != projectID {
 			return nil, errors.Errorf("database target %q does not belong to project %q", target, projectID)
 		}
-		if err := validateInstanceTarget(ctx, stores, targetProjectID, instanceID); err != nil {
-			return nil, err
-		}
 		databases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{
 			ProjectID:    &projectID,
 			InstanceID:   &instanceID,
@@ -473,6 +474,9 @@ func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storep
 		}
 		if len(databases) == 0 {
 			return nil, errors.Errorf("database %q not found", target)
+		}
+		if databases[0].ResourceName() != target {
+			return nil, errors.Errorf("database target %q is not canonical for its instance", target)
 		}
 		return databases[0], nil
 	}
@@ -880,9 +884,17 @@ func buildCELVariablesForAccessGrant(ctx context.Context, stores *store.Store, i
 		return []map[string]any{baseVars}, true, nil
 	}
 
-	statement := accessGrant.Payload.Query
-	var celVarsList []map[string]any
-
+	type databaseKey struct {
+		instanceID   string
+		databaseName string
+	}
+	type parsedTarget struct {
+		name string
+		key  databaseKey
+	}
+	parsedTargets := make([]parsedTarget, 0, len(targets))
+	instanceTargets := make([]instanceTarget, 0, len(targets))
+	requestedDatabases := make(map[databaseKey]bool, len(targets))
 	for _, target := range targets {
 		targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(target)
 		if err != nil {
@@ -891,29 +903,57 @@ func buildCELVariablesForAccessGrant(ctx context.Context, stores *store.Store, i
 		if targetProjectID != nil && *targetProjectID != issue.ProjectID {
 			return nil, false, errors.Errorf("target %q does not belong to project %q", target, issue.ProjectID)
 		}
-		if err := validateInstanceTarget(ctx, stores, targetProjectID, instanceID); err != nil {
-			return nil, false, err
-		}
+		key := databaseKey{instanceID: instanceID, databaseName: databaseName}
+		parsedTargets = append(parsedTargets, parsedTarget{name: target, key: key})
+		instanceTargets = append(instanceTargets, instanceTarget{projectID: targetProjectID, instanceID: instanceID})
+		requestedDatabases[key] = true
+	}
 
-		databases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{
-			InstanceID:   &instanceID,
-			DatabaseName: &databaseName,
-		})
-		if err != nil {
-			return nil, false, errors.Wrapf(err, "failed to get database %q", target)
+	instanceByID, err := getActiveTargetInstances(ctx, stores, instanceTargets)
+	if err != nil {
+		return nil, false, err
+	}
+
+	workspaceID := common.GetWorkspaceIDFromContext(ctx)
+	databases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{
+		Workspace: workspaceID,
+		ProjectID: &issue.ProjectID,
+	})
+	if err != nil {
+		return nil, false, errors.Wrapf(err, "failed to list databases for project %q", issue.ProjectID)
+	}
+	databaseByKey := make(map[databaseKey]*store.DatabaseMessage, len(requestedDatabases))
+	for _, database := range databases {
+		key := databaseKey{instanceID: database.InstanceID, databaseName: database.DatabaseName}
+		if requestedDatabases[key] {
+			databaseByKey[key] = database
 		}
-		if len(databases) == 0 {
+	}
+
+	resolvedTargets := make([]struct {
+		name     string
+		database *store.DatabaseMessage
+	}, 0, len(parsedTargets))
+	for _, target := range parsedTargets {
+		database := databaseByKey[target.key]
+		if database == nil {
 			continue
 		}
-		database := databases[0]
+		if database.ResourceName() != target.name {
+			return nil, false, errors.Errorf("database target %q is not canonical for its instance", target.name)
+		}
+		resolvedTargets = append(resolvedTargets, struct {
+			name     string
+			database *store.DatabaseMessage
+		}{name: target.name, database: database})
+	}
 
-		instance, err := stores.GetInstance(ctx, &store.FindInstanceMessage{ResourceID: &database.InstanceID})
-		if err != nil {
-			return nil, false, errors.Wrapf(err, "failed to get instance %q", database.InstanceID)
-		}
-		if instance == nil {
-			continue
-		}
+	statement := accessGrant.Payload.Query
+	var celVarsList []map[string]any
+
+	for _, target := range resolvedTargets {
+		database := target.database
+		instance := instanceByID[database.InstanceID]
 		engine := instance.Metadata.GetEngine()
 
 		targetVars := maps.Clone(baseVars)
@@ -945,7 +985,7 @@ func buildCELVariablesForAccessGrant(ctx context.Context, stores *store.Store, i
 			)
 			if err != nil {
 				slog.Debug("failed to extract resources from access grant query; emitting target vars without schema/table",
-					slog.String("target", target), slog.String("instance", database.InstanceID),
+					slog.String("target", target.name), slog.String("instance", database.InstanceID),
 					log.BBError(err))
 				resources = nil
 			}
@@ -984,7 +1024,8 @@ func getDatabasesForRoleGrant(ctx context.Context, stores *store.Store, projectI
 		instanceID   string
 		databaseName string
 	}
-	requestedDBs := make(map[dbKey]bool)
+	requestedDBs := make(map[dbKey][]string)
+	instanceTargets := make([]instanceTarget, 0, len(databaseIdentifiers))
 	for _, identifier := range databaseIdentifiers {
 		targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(identifier)
 		if err != nil {
@@ -993,14 +1034,19 @@ func getDatabasesForRoleGrant(ctx context.Context, stores *store.Store, projectI
 		if targetProjectID != nil && *targetProjectID != projectID {
 			return nil, errors.Errorf("database target %q does not belong to project %q", identifier, projectID)
 		}
-		if err := validateInstanceTarget(ctx, stores, targetProjectID, instanceID); err != nil {
-			return nil, err
-		}
-		requestedDBs[dbKey{instanceID: instanceID, databaseName: databaseName}] = true
+		key := dbKey{instanceID: instanceID, databaseName: databaseName}
+		requestedDBs[key] = append(requestedDBs[key], identifier)
+		instanceTargets = append(instanceTargets, instanceTarget{projectID: targetProjectID, instanceID: instanceID})
+	}
+	if _, err := getActiveTargetInstances(ctx, stores, instanceTargets); err != nil {
+		return nil, err
 	}
 
 	// Batch fetch all databases in the project
-	allDatabases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{ProjectID: &projectID})
+	allDatabases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{
+		Workspace: common.GetWorkspaceIDFromContext(ctx),
+		ProjectID: &projectID,
+	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to list databases for project %q", projectID)
 	}
@@ -1009,7 +1055,12 @@ func getDatabasesForRoleGrant(ctx context.Context, stores *store.Store, projectI
 	var result []*store.DatabaseMessage
 	for _, db := range allDatabases {
 		key := dbKey{instanceID: db.InstanceID, databaseName: db.DatabaseName}
-		if requestedDBs[key] {
+		if identifiers, ok := requestedDBs[key]; ok {
+			for _, identifier := range identifiers {
+				if db.ResourceName() != identifier {
+					return nil, errors.Errorf("database target %q is not canonical for its instance", identifier)
+				}
+			}
 			result = append(result, db)
 		}
 	}

--- a/backend/component/review/evaluator.go
+++ b/backend/component/review/evaluator.go
@@ -346,6 +346,50 @@ type specTarget struct {
 	sheetSha256 string
 }
 
+func validateInstanceTarget(ctx context.Context, stores *store.Store, projectID *string, instanceID string) error {
+	workspaceID := common.GetWorkspaceIDFromContext(ctx)
+	if workspaceID == "" {
+		workspaceID = "default"
+	}
+	instance, err := stores.GetInstance(ctx, &store.FindInstanceMessage{
+		Workspace:     workspaceID,
+		ResourceID:    &instanceID,
+		ProjectID:     projectID,
+		WorkspaceOnly: projectID == nil,
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to get instance %q", instanceID)
+	}
+	if instance == nil {
+		return errors.Errorf("instance %q not found in requested scope", instanceID)
+	}
+	if instance.Deleted {
+		return errors.Errorf("instance %q has been deleted", instanceID)
+	}
+	return nil
+}
+
+func formatDatabaseTarget(ctx context.Context, stores *store.Store, database *store.DatabaseMessage) (string, error) {
+	workspaceID := common.GetWorkspaceIDFromContext(ctx)
+	if workspaceID == "" {
+		workspaceID = "default"
+	}
+	instance, err := stores.GetInstance(ctx, &store.FindInstanceMessage{
+		Workspace:  workspaceID,
+		ResourceID: &database.InstanceID,
+	})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get instance %q", database.InstanceID)
+	}
+	if instance == nil {
+		return "", errors.Errorf("instance %q not found", database.InstanceID)
+	}
+	if instance.ProjectID == nil {
+		return common.FormatDatabase(database.InstanceID, database.DatabaseName), nil
+	}
+	return common.FormatProjectDatabase(*instance.ProjectID, database.InstanceID, database.DatabaseName), nil
+}
+
 // unfoldDatabaseTargets unfolds database groups and returns all database targets.
 // If the targets list contains a single database group reference, it unfolds it to individual databases.
 // Otherwise, it returns the targets as-is.
@@ -382,7 +426,11 @@ func unfoldDatabaseTargets(ctx context.Context, stores *store.Store, dbTargets [
 			// Replace dbTargets with unfolded databases
 			var unfolded []string
 			for _, db := range matchedDatabases {
-				unfolded = append(unfolded, common.FormatDatabase(db.InstanceID, db.DatabaseName))
+				target, err := formatDatabaseTarget(ctx, stores, db)
+				if err != nil {
+					return nil, err
+				}
+				unfolded = append(unfolded, target)
 			}
 			return unfolded, nil
 		}
@@ -394,14 +442,6 @@ func unfoldDatabaseTargets(ctx context.Context, stores *store.Store, dbTargets [
 // allDatabases must be nil or the full unfiltered project database list; callers pass it
 // through to keep database-group matching and direct database lookup on the same snapshot.
 func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storepb.PlanConfig_Spec, projectID string, allDatabases []*store.DatabaseMessage, databaseGroup *v1pb.DatabaseGroup) ([]specTarget, error) {
-	var databaseMap map[string]*store.DatabaseMessage
-	buildDatabaseMap := func(databases []*store.DatabaseMessage) map[string]*store.DatabaseMessage {
-		m := make(map[string]*store.DatabaseMessage, len(databases))
-		for _, db := range databases {
-			m[common.FormatDatabase(db.InstanceID, db.DatabaseName)] = db
-		}
-		return m
-	}
 	getAllDatabases := func() error {
 		if allDatabases == nil {
 			var err error
@@ -410,21 +450,18 @@ func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storep
 				return errors.Wrapf(err, "failed to list databases for project %q", projectID)
 			}
 		}
-		if databaseMap == nil {
-			databaseMap = buildDatabaseMap(allDatabases)
-		}
 		return nil
 	}
 	getDatabase := func(target string) (*store.DatabaseMessage, error) {
-		if databaseMap != nil {
-			if db := databaseMap[target]; db != nil {
-				return db, nil
-			}
-		}
-
-		instanceID, databaseName, err := common.GetInstanceDatabaseID(target)
+		targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(target)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to parse database target %q", target)
+		}
+		if targetProjectID != nil && *targetProjectID != projectID {
+			return nil, errors.Errorf("database target %q does not belong to project %q", target, projectID)
+		}
+		if err := validateInstanceTarget(ctx, stores, targetProjectID, instanceID); err != nil {
+			return nil, err
 		}
 		databases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{
 			ProjectID:    &projectID,
@@ -470,9 +507,15 @@ func unfoldSpecTargets(ctx context.Context, stores *store.Store, specs []*storep
 	for _, spec := range specs {
 		switch config := spec.Config.(type) {
 		case *storepb.PlanConfig_Spec_CreateDatabaseConfig:
-			instanceID, err := common.GetInstanceID(config.CreateDatabaseConfig.Target)
+			targetProjectID, instanceID, err := common.GetInstanceResourceName(config.CreateDatabaseConfig.Target)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to parse instance from target %q", config.CreateDatabaseConfig.Target)
+			}
+			if targetProjectID != nil && *targetProjectID != projectID {
+				return nil, errors.Errorf("instance target %q does not belong to project %q", config.CreateDatabaseConfig.Target, projectID)
+			}
+			if err := validateInstanceTarget(ctx, stores, targetProjectID, instanceID); err != nil {
+				return nil, err
 			}
 			// For CREATE_DATABASE, create a synthetic database message
 			// since the database doesn't exist yet
@@ -508,7 +551,7 @@ func buildStatementSummaryResultMap(results []*storepb.PlanCheckRunResult_Result
 		if result.Type != storepb.PlanCheckType_PLAN_CHECK_TYPE_STATEMENT_SUMMARY_REPORT {
 			continue
 		}
-		instanceID, databaseName, err := common.GetInstanceDatabaseID(result.Target)
+		_, instanceID, databaseName, err := common.GetDatabaseResourceName(result.Target)
 		if err != nil {
 			continue
 		}
@@ -841,9 +884,15 @@ func buildCELVariablesForAccessGrant(ctx context.Context, stores *store.Store, i
 	var celVarsList []map[string]any
 
 	for _, target := range targets {
-		instanceID, databaseName, err := common.GetInstanceDatabaseID(target)
+		targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(target)
 		if err != nil {
 			return nil, false, errors.Wrapf(err, "failed to parse target %q", target)
+		}
+		if targetProjectID != nil && *targetProjectID != issue.ProjectID {
+			return nil, false, errors.Errorf("target %q does not belong to project %q", target, issue.ProjectID)
+		}
+		if err := validateInstanceTarget(ctx, stores, targetProjectID, instanceID); err != nil {
+			return nil, false, err
 		}
 
 		databases, err := stores.ListDatabases(ctx, &store.FindDatabaseMessage{
@@ -937,8 +986,14 @@ func getDatabasesForRoleGrant(ctx context.Context, stores *store.Store, projectI
 	}
 	requestedDBs := make(map[dbKey]bool)
 	for _, identifier := range databaseIdentifiers {
-		instanceID, databaseName, err := common.GetInstanceDatabaseID(identifier)
+		targetProjectID, instanceID, databaseName, err := common.GetDatabaseResourceName(identifier)
 		if err != nil {
+			return nil, err
+		}
+		if targetProjectID != nil && *targetProjectID != projectID {
+			return nil, errors.Errorf("database target %q does not belong to project %q", identifier, projectID)
+		}
+		if err := validateInstanceTarget(ctx, stores, targetProjectID, instanceID); err != nil {
 			return nil, err
 		}
 		requestedDBs[dbKey{instanceID: instanceID, databaseName: databaseName}] = true

--- a/backend/component/review/evaluator_test.go
+++ b/backend/component/review/evaluator_test.go
@@ -2,6 +2,7 @@ package review
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -662,7 +663,218 @@ func TestProcessIssueSkipsDraft(t *testing.T) {
 	require.Empty(t, b.RolloutCreationChan)
 }
 
+func TestApplyApprovalTemplateResolvesProjectInstanceOutsideRequestContext(t *testing.T) {
+	ctx := context.Background()
+	const workspaceID = "workspace-a"
+	s := setupApprovalRunnerStoreInWorkspace(ctx, t, workspaceID)
+
+	environment := "prod"
+	projectID := "project-a"
+	_, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID:    "prod",
+		Workspace:     workspaceID,
+		ProjectID:     &projectID,
+		EnvironmentID: &environment,
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
+		ProjectID:    projectID,
+		InstanceID:   "prod",
+		DatabaseName: "app",
+		Metadata:     &storepb.DatabaseMetadata{Labels: map[string]string{}},
+	})
+	require.NoError(t, err)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: projectID,
+		Name:      "approval plan",
+		Config: &storepb.PlanConfig{
+			ApprovalInputVersion: 2,
+			Specs: []*storepb.PlanConfig_Spec{{
+				Id: "change",
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{"projects/project-a/instances/prod/databases/app"},
+					},
+				},
+			}},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	issue, err := s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    projectID,
+		CreatorEmail: "creator@example.com",
+		Title:        "approval issue",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Payload:      &storepb.Issue{},
+		PlanUID:      &plan.UID,
+	})
+	require.NoError(t, err)
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: projectID,
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 2},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+	planCheckRun, err := s.GetPlanCheckRun(ctx, projectID, plan.UID)
+	require.NoError(t, err)
+	require.NoError(t, s.UpdatePlanCheckRun(ctx, projectID, store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: 2,
+	}, planCheckRun.UID))
+
+	evaluator := &ApprovalEvaluator{workflow: NewWorkflow(s)}
+	evaluator.evaluateApproval = func(ctx context.Context, issue *store.IssueMessage, _ *store.ProjectMessage, _ *storepb.WorkspaceApprovalSetting) error {
+		_, approvalInputVersion, done, err := buildCELVariablesForIssue(ctx, s, issue)
+		if err != nil {
+			return err
+		}
+		if !done {
+			return errors.New("approval variables are not ready")
+		}
+		issue.Payload.Approval = &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: approvalInputVersion,
+		}
+		return nil
+	}
+	result, err := evaluator.ApplyApprovalTemplate(ctx, ApplyApprovalTemplateInput{
+		Workspace: workspaceID,
+		ProjectID: projectID,
+		IssueUID:  issue.UID,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Applied)
+	require.True(t, result.Issue.Payload.GetApproval().GetApprovalFindingDone())
+}
+
+func TestBuildCELVariablesForAccessGrantResolvesProjectInstanceWithoutCache(t *testing.T) {
+	ctx := context.Background()
+	const workspaceID = "workspace-a"
+	s := setupApprovalRunnerStoreInWorkspace(ctx, t, workspaceID)
+	projectID := "project-a"
+	setupApprovalProjectInstanceDatabase(ctx, t, s)
+
+	accessGrant, err := s.CreateAccessGrant(ctx, &store.AccessGrantMessage{
+		ProjectID: projectID,
+		Creator:   "creator@example.com",
+		Status:    storepb.AccessGrant_PENDING,
+		Payload: &storepb.AccessGrantPayload{
+			Targets: []string{"projects/project-a/instances/prod/databases/app"},
+		},
+	})
+	require.NoError(t, err)
+
+	ctx = context.WithValue(ctx, common.WorkspaceIDContextKey, workspaceID)
+	variables, done, err := buildCELVariablesForAccessGrant(ctx, s, &store.IssueMessage{
+		ProjectID: projectID,
+		Payload:   &storepb.Issue{AccessGrantId: accessGrant.ID},
+	})
+	require.NoError(t, err)
+	require.True(t, done)
+	require.Len(t, variables, 1)
+	require.Equal(t, "prod", variables[0][common.CELAttributeResourceInstanceID])
+	require.Equal(t, "app", variables[0][common.CELAttributeResourceDatabaseName])
+	require.Equal(t, storepb.Engine_POSTGRES.String(), variables[0][common.CELAttributeResourceDBEngine])
+	require.Equal(t, "prod", variables[0][common.CELAttributeResourceEnvironmentID])
+}
+
+func TestBuildCELVariablesForAccessGrantRejectsArchivedProjectInstanceWithoutCache(t *testing.T) {
+	ctx := context.Background()
+	const workspaceID = "workspace-a"
+	s := setupApprovalRunnerStoreInWorkspace(ctx, t, workspaceID)
+	projectID := "project-a"
+	setupApprovalProjectInstanceDatabase(ctx, t, s)
+
+	accessGrant, err := s.CreateAccessGrant(ctx, &store.AccessGrantMessage{
+		ProjectID: projectID,
+		Creator:   "creator@example.com",
+		Status:    storepb.AccessGrant_PENDING,
+		Payload: &storepb.AccessGrantPayload{
+			Targets: []string{"projects/project-a/instances/prod/databases/app"},
+		},
+	})
+	require.NoError(t, err)
+	deleted := true
+	instanceID := "prod"
+	_, err = s.UpdateInstance(ctx, &store.UpdateInstanceMessage{
+		Workspace:  workspaceID,
+		ResourceID: &instanceID,
+		Deleted:    &deleted,
+	})
+	require.NoError(t, err)
+
+	ctx = context.WithValue(ctx, common.WorkspaceIDContextKey, workspaceID)
+	_, _, err = buildCELVariablesForAccessGrant(ctx, s, &store.IssueMessage{
+		ProjectID: projectID,
+		Payload:   &storepb.Issue{AccessGrantId: accessGrant.ID},
+	})
+	require.ErrorContains(t, err, `instance "prod" has been deleted`)
+}
+
+func TestGetDatabasesForRoleGrantRejectsEveryNoncanonicalAlias(t *testing.T) {
+	ctx := context.Background()
+	const workspaceID = "workspace-a"
+	s := setupApprovalRunnerStoreInWorkspace(ctx, t, workspaceID)
+	projectID := "project-a"
+	setupApprovalProjectInstanceDatabase(ctx, t, s)
+
+	ctx = context.WithValue(ctx, common.WorkspaceIDContextKey, workspaceID)
+	_, err := getDatabasesForRoleGrant(ctx, s, projectID, []string{
+		"instances/prod/databases/app",
+		"projects/project-a/instances/prod/databases/app",
+	})
+	require.ErrorContains(t, err, `instance "prod" not found in requested scope`)
+}
+
+func TestGetDatabasesForRoleGrantRejectsNoncanonicalScopeForMissingDatabase(t *testing.T) {
+	ctx := context.Background()
+	const workspaceID = "workspace-a"
+	s := setupApprovalRunnerStoreInWorkspace(ctx, t, workspaceID)
+	projectID := "project-a"
+	setupApprovalProjectInstanceDatabase(ctx, t, s)
+
+	ctx = context.WithValue(ctx, common.WorkspaceIDContextKey, workspaceID)
+	_, err := getDatabasesForRoleGrant(ctx, s, projectID, []string{
+		"instances/prod/databases/missing",
+	})
+	require.ErrorContains(t, err, `instance "prod" not found in requested scope`)
+}
+
+func setupApprovalProjectInstanceDatabase(ctx context.Context, t *testing.T, s *store.Store) {
+	t.Helper()
+	const workspaceID = "workspace-a"
+	projectID := "project-a"
+	environment := "prod"
+	_, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID:    "prod",
+		Workspace:     workspaceID,
+		ProjectID:     &projectID,
+		EnvironmentID: &environment,
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
+		ProjectID:    projectID,
+		InstanceID:   "prod",
+		DatabaseName: "app",
+		Metadata:     &storepb.DatabaseMetadata{Labels: map[string]string{}},
+	})
+	require.NoError(t, err)
+}
+
 func setupApprovalRunnerStore(ctx context.Context, t *testing.T) *store.Store {
+	return setupApprovalRunnerStoreInWorkspace(ctx, t, "default")
+}
+
+func setupApprovalRunnerStoreInWorkspace(ctx context.Context, t *testing.T, workspaceID string) *store.Store {
 	t.Helper()
 
 	container := testcontainer.GetTestPgContainer(ctx, t)
@@ -671,11 +883,11 @@ func setupApprovalRunnerStore(ctx context.Context, t *testing.T) *store.Store {
 	db := container.GetDB()
 	require.NoError(t, migrator.MigrateSchema(ctx, db))
 
-	_, err := db.ExecContext(ctx, `
-		INSERT INTO workspace (resource_id) VALUES ('default');
-		INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused');
-		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
-	`)
+	_, err := db.ExecContext(ctx, "INSERT INTO workspace (resource_id) VALUES ($1)", workspaceID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused')")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', $1, 'Project A')", workspaceID)
 	require.NoError(t, err)
 
 	pgURL := fmt.Sprintf(

--- a/backend/plugin/parser/mysql/restore.go
+++ b/backend/plugin/parser/mysql/restore.go
@@ -64,11 +64,11 @@ func findFirstDML(statement string) (ast.Node, error) {
 }
 
 func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment string, node ast.Node, backupItem *storepb.PriorBackupDetail_Item) (string, error) {
-	_, sourceDatabase, err := common.GetInstanceDatabaseID(backupItem.SourceTable.Database)
+	_, _, sourceDatabase, err := common.GetDatabaseResourceName(backupItem.SourceTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get source database ID for %s", backupItem.SourceTable.Database)
 	}
-	_, targetDatabase, err := common.GetInstanceDatabaseID(backupItem.TargetTable.Database)
+	_, _, targetDatabase, err := common.GetDatabaseResourceName(backupItem.TargetTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get target database ID for %s", backupItem.TargetTable.Database)
 	}
@@ -295,7 +295,7 @@ func extractStatement(statement string, backupItem *storepb.PriorBackupDetail_It
 		}
 	}
 
-	_, sourceDatabase, err := common.GetInstanceDatabaseID(backupItem.SourceTable.Database)
+	_, _, sourceDatabase, err := common.GetDatabaseResourceName(backupItem.SourceTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get source database ID for %s", backupItem.SourceTable.Database)
 	}

--- a/backend/plugin/parser/mysql/restore_test.go
+++ b/backend/plugin/parser/mysql/restore_test.go
@@ -43,36 +43,38 @@ func TestRestore(t *testing.T) {
 	a.NoError(err)
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
-	for i, t := range tests {
-		getter, lister := buildFixedMockDatabaseMetadataGetterAndLister()
-		result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
-			GetDatabaseMetadataFunc: getter,
-			ListDatabaseNamesFunc:   lister,
-			IsCaseSensitive:         false,
-		}, t.Input, &store.PriorBackupDetail_Item{
-			SourceTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.OriginalDatabase,
-				Table:    t.OriginalTable,
-			},
-			TargetTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.BackupDatabase,
-				Table:    t.BackupTable,
-			},
-			StartPosition: &store.Position{
-				Line:   0,
-				Column: 0,
-			},
-			EndPosition: &store.Position{
-				Line:   math.MaxInt32,
-				Column: 0,
-			},
-		})
-		a.NoError(err)
+	for _, databasePrefix := range []string{"instances/i1/databases/", "projects/project-a/instances/i1/databases/"} {
+		for i, t := range tests {
+			getter, lister := buildFixedMockDatabaseMetadataGetterAndLister()
+			result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
+				GetDatabaseMetadataFunc: getter,
+				ListDatabaseNamesFunc:   lister,
+				IsCaseSensitive:         false,
+			}, t.Input, &store.PriorBackupDetail_Item{
+				SourceTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.OriginalDatabase,
+					Table:    t.OriginalTable,
+				},
+				TargetTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.BackupDatabase,
+					Table:    t.BackupTable,
+				},
+				StartPosition: &store.Position{
+					Line:   0,
+					Column: 0,
+				},
+				EndPosition: &store.Position{
+					Line:   math.MaxInt32,
+					Column: 0,
+				},
+			})
+			a.NoError(err)
 
-		if record {
-			tests[i].Result = result
-		} else {
-			a.Equal(t.Result, result, t.Input)
+			if record {
+				tests[i].Result = result
+			} else {
+				a.Equal(t.Result, result, t.Input)
+			}
 		}
 	}
 	if record {

--- a/backend/plugin/parser/pg/restore.go
+++ b/backend/plugin/parser/pg/restore.go
@@ -84,7 +84,7 @@ func findStatementAtPosition(statement string, backupItem *storepb.PriorBackupDe
 }
 
 func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment string, node ast.Node, backupItem *storepb.PriorBackupDetail_Item, prependStatements string) (string, error) {
-	_, sourceDatabase, err := common.GetInstanceDatabaseID(backupItem.SourceTable.Database)
+	_, _, sourceDatabase, err := common.GetDatabaseResourceName(backupItem.SourceTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get source database ID for %s", backupItem.SourceTable.Database)
 	}

--- a/backend/plugin/parser/pg/restore_test.go
+++ b/backend/plugin/parser/pg/restore_test.go
@@ -44,35 +44,37 @@ func TestRestore(t *testing.T) {
 	a.NoError(err)
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
-	for i, t := range tests {
-		result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
-			GetDatabaseMetadataFunc: fixedMockDatabaseMetadataGetter,
-		}, t.Input, &store.PriorBackupDetail_Item{
-			SourceTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.OriginalDatabase,
-				Schema:   "public",
-				Table:    t.OriginalTable,
-			},
-			TargetTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.BackupDatabase,
-				Schema:   t.BackupDatabase,
-				Table:    t.BackupTable,
-			},
-			StartPosition: &store.Position{
-				Line:   1,
-				Column: 0,
-			},
-			EndPosition: &store.Position{
-				Line:   math.MaxInt32,
-				Column: 1,
-			},
-		})
-		a.NoError(err)
+	for _, databasePrefix := range []string{"instances/i1/databases/", "projects/project-a/instances/i1/databases/"} {
+		for i, t := range tests {
+			result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
+				GetDatabaseMetadataFunc: fixedMockDatabaseMetadataGetter,
+			}, t.Input, &store.PriorBackupDetail_Item{
+				SourceTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.OriginalDatabase,
+					Schema:   "public",
+					Table:    t.OriginalTable,
+				},
+				TargetTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.BackupDatabase,
+					Schema:   t.BackupDatabase,
+					Table:    t.BackupTable,
+				},
+				StartPosition: &store.Position{
+					Line:   1,
+					Column: 0,
+				},
+				EndPosition: &store.Position{
+					Line:   math.MaxInt32,
+					Column: 1,
+				},
+			})
+			a.NoError(err)
 
-		if record {
-			tests[i].Result = result
-		} else {
-			a.Equal(t.Result, result, t.Input)
+			if record {
+				tests[i].Result = result
+			} else {
+				a.Equal(t.Result, result, t.Input)
+			}
 		}
 	}
 	if record {

--- a/backend/plugin/parser/plsql/restore.go
+++ b/backend/plugin/parser/plsql/restore.go
@@ -99,11 +99,11 @@ func findFirstOracleDMLOnce(statement string) (oracleast.StmtNode, error) {
 }
 
 func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment string, node oracleast.StmtNode, backupItem *storepb.PriorBackupDetail_Item) (string, error) {
-	_, sourceDatabase, err := common.GetInstanceDatabaseID(backupItem.SourceTable.Database)
+	_, _, sourceDatabase, err := common.GetDatabaseResourceName(backupItem.SourceTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get source database ID for %s", backupItem.SourceTable.Database)
 	}
-	_, targetDatabase, err := common.GetInstanceDatabaseID(backupItem.TargetTable.Database)
+	_, _, targetDatabase, err := common.GetDatabaseResourceName(backupItem.TargetTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get target database ID for %s", backupItem.TargetTable.Database)
 	}
@@ -360,7 +360,7 @@ func extractSQL(statement string, backupItem *storepb.PriorBackupDetail_Item) (s
 		}
 	}
 
-	_, sourceDatabase, err := common.GetInstanceDatabaseID(backupItem.SourceTable.Database)
+	_, _, sourceDatabase, err := common.GetDatabaseResourceName(backupItem.SourceTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get source database ID for %s", backupItem.SourceTable.Database)
 	}

--- a/backend/plugin/parser/plsql/restore_test.go
+++ b/backend/plugin/parser/plsql/restore_test.go
@@ -44,33 +44,35 @@ func TestRestore(t *testing.T) {
 	a.NoError(err)
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
-	for i, t := range tests {
-		result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
-			GetDatabaseMetadataFunc: fixedMockDatabaseMetadataGetter,
-		}, t.Input, &store.PriorBackupDetail_Item{
-			SourceTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.OriginalDatabase,
-				Table:    t.OriginalTable,
-			},
-			TargetTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.BackupDatabase,
-				Table:    t.BackupTable,
-			},
-			StartPosition: &store.Position{
-				Line:   0,
-				Column: 0,
-			},
-			EndPosition: &store.Position{
-				Line:   math.MaxInt32,
-				Column: 0,
-			},
-		})
-		a.NoError(err)
+	for _, databasePrefix := range []string{"instances/i1/databases/", "projects/project-a/instances/i1/databases/"} {
+		for i, t := range tests {
+			result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
+				GetDatabaseMetadataFunc: fixedMockDatabaseMetadataGetter,
+			}, t.Input, &store.PriorBackupDetail_Item{
+				SourceTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.OriginalDatabase,
+					Table:    t.OriginalTable,
+				},
+				TargetTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.BackupDatabase,
+					Table:    t.BackupTable,
+				},
+				StartPosition: &store.Position{
+					Line:   0,
+					Column: 0,
+				},
+				EndPosition: &store.Position{
+					Line:   math.MaxInt32,
+					Column: 0,
+				},
+			})
+			a.NoError(err)
 
-		if record {
-			tests[i].Result = result
-		} else {
-			a.Equal(t.Result, result, t.Input)
+			if record {
+				tests[i].Result = result
+			} else {
+				a.Equal(t.Result, result, t.Input)
+			}
 		}
 	}
 	if record {

--- a/backend/plugin/parser/tidb/restore.go
+++ b/backend/plugin/parser/tidb/restore.go
@@ -18,7 +18,7 @@ const (
 	maxCommentLength = 1000
 
 	// errMsgFailedToGetSourceDB is the wrap-error format string used at
-	// every common.GetInstanceDatabaseID(SourceTable.Database) call site.
+	// every common.GetDatabaseResourceName(SourceTable.Database) call site.
 	// Centralized to avoid string drift across the three error-wrap sites
 	// (GenerateRestoreSQL / doGenerate / extractStatement).
 	errMsgFailedToGetSourceDB = "failed to get source database ID for %s"
@@ -45,7 +45,7 @@ func GenerateRestoreSQL(ctx context.Context, rCtx base.RestoreContext, statement
 		return "", errors.Errorf("backup item target table is nil")
 	}
 
-	_, sourceDatabase, err := common.GetInstanceDatabaseID(backupItem.SourceTable.Database)
+	_, _, sourceDatabase, err := common.GetDatabaseResourceName(backupItem.SourceTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, errMsgFailedToGetSourceDB, backupItem.SourceTable.Database)
 	}
@@ -145,11 +145,11 @@ func findMatchingDMLs(statement, database, table string, targetCols map[string]b
 }
 
 func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment string, nodes []ast.Node, backupItem *storepb.PriorBackupDetail_Item) (string, error) {
-	_, sourceDatabase, err := common.GetInstanceDatabaseID(backupItem.SourceTable.Database)
+	_, _, sourceDatabase, err := common.GetDatabaseResourceName(backupItem.SourceTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, errMsgFailedToGetSourceDB, backupItem.SourceTable.Database)
 	}
-	_, targetDatabase, err := common.GetInstanceDatabaseID(backupItem.TargetTable.Database)
+	_, _, targetDatabase, err := common.GetDatabaseResourceName(backupItem.TargetTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get target database ID for %s", backupItem.TargetTable.Database)
 	}

--- a/backend/plugin/parser/tidb/restore_test.go
+++ b/backend/plugin/parser/tidb/restore_test.go
@@ -43,36 +43,38 @@ func TestRestore(t *testing.T) {
 	a.NoError(err)
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
-	for i, t := range tests {
-		getter, lister := buildFixedMockDatabaseMetadataGetterAndLister()
-		result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
-			GetDatabaseMetadataFunc: getter,
-			ListDatabaseNamesFunc:   lister,
-			IsCaseSensitive:         false,
-		}, t.Input, &store.PriorBackupDetail_Item{
-			SourceTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.OriginalDatabase,
-				Table:    t.OriginalTable,
-			},
-			TargetTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.BackupDatabase,
-				Table:    t.BackupTable,
-			},
-			StartPosition: &store.Position{
-				Line:   0,
-				Column: 0,
-			},
-			EndPosition: &store.Position{
-				Line:   math.MaxInt32,
-				Column: 0,
-			},
-		})
-		a.NoError(err)
+	for _, databasePrefix := range []string{"instances/i1/databases/", "projects/project-a/instances/i1/databases/"} {
+		for i, t := range tests {
+			getter, lister := buildFixedMockDatabaseMetadataGetterAndLister()
+			result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
+				GetDatabaseMetadataFunc: getter,
+				ListDatabaseNamesFunc:   lister,
+				IsCaseSensitive:         false,
+			}, t.Input, &store.PriorBackupDetail_Item{
+				SourceTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.OriginalDatabase,
+					Table:    t.OriginalTable,
+				},
+				TargetTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.BackupDatabase,
+					Table:    t.BackupTable,
+				},
+				StartPosition: &store.Position{
+					Line:   0,
+					Column: 0,
+				},
+				EndPosition: &store.Position{
+					Line:   math.MaxInt32,
+					Column: 0,
+				},
+			})
+			a.NoError(err)
 
-		if record {
-			tests[i].Result = result
-		} else {
-			a.Equal(t.Result, result, t.Input)
+			if record {
+				tests[i].Result = result
+			} else {
+				a.Equal(t.Result, result, t.Input)
+			}
 		}
 	}
 	if record {

--- a/backend/plugin/parser/tsql/restore.go
+++ b/backend/plugin/parser/tsql/restore.go
@@ -65,11 +65,11 @@ func GenerateRestoreSQL(ctx context.Context, rCtx base.RestoreContext, statement
 }
 
 func doGenerate(ctx context.Context, rCtx base.RestoreContext, sqlForComment string, node ast.Node, backupItem *storepb.PriorBackupDetail_Item) (string, error) {
-	_, sourceDatabase, err := common.GetInstanceDatabaseID(backupItem.SourceTable.Database)
+	_, _, sourceDatabase, err := common.GetDatabaseResourceName(backupItem.SourceTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get source database ID for %s", backupItem.SourceTable.Database)
 	}
-	_, targetDatabase, err := common.GetInstanceDatabaseID(backupItem.TargetTable.Database)
+	_, _, targetDatabase, err := common.GetDatabaseResourceName(backupItem.TargetTable.Database)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get target database ID for %s", backupItem.TargetTable.Database)
 	}

--- a/backend/plugin/parser/tsql/restore_test.go
+++ b/backend/plugin/parser/tsql/restore_test.go
@@ -226,35 +226,37 @@ func TestRestore(t *testing.T) {
 	a.NoError(err)
 	a.NoError(yaml.Unmarshal(byteValue, &tests))
 
-	for i, t := range tests {
-		result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
-			GetDatabaseMetadataFunc: fixedMockDatabaseMetadataGetter,
-		}, t.Input, &store.PriorBackupDetail_Item{
-			SourceTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.OriginalDatabase,
-				Schema:   "dbo",
-				Table:    t.OriginalTable,
-			},
-			TargetTable: &store.PriorBackupDetail_Item_Table{
-				Database: "instances/i1/databases/" + t.BackupDatabase,
-				Schema:   t.BackupDatabase,
-				Table:    t.BackupTable,
-			},
-			StartPosition: &store.Position{
-				Line:   1,
-				Column: 0,
-			},
-			EndPosition: &store.Position{
-				Line:   math.MaxInt32,
-				Column: 1,
-			},
-		})
-		a.NoError(err)
+	for _, databasePrefix := range []string{"instances/i1/databases/", "projects/project-a/instances/i1/databases/"} {
+		for i, t := range tests {
+			result, err := GenerateRestoreSQL(context.Background(), base.RestoreContext{
+				GetDatabaseMetadataFunc: fixedMockDatabaseMetadataGetter,
+			}, t.Input, &store.PriorBackupDetail_Item{
+				SourceTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.OriginalDatabase,
+					Schema:   "dbo",
+					Table:    t.OriginalTable,
+				},
+				TargetTable: &store.PriorBackupDetail_Item_Table{
+					Database: databasePrefix + t.BackupDatabase,
+					Schema:   t.BackupDatabase,
+					Table:    t.BackupTable,
+				},
+				StartPosition: &store.Position{
+					Line:   1,
+					Column: 0,
+				},
+				EndPosition: &store.Position{
+					Line:   math.MaxInt32,
+					Column: 1,
+				},
+			})
+			a.NoError(err)
 
-		if record {
-			tests[i].Result = result
-		} else {
-			a.Equal(t.Result, result, t.Input)
+			if record {
+				tests[i].Result = result
+			} else {
+				a.Equal(t.Result, result, t.Input)
+			}
 		}
 	}
 	if record {

--- a/backend/runner/plancheck/check_target.go
+++ b/backend/runner/plancheck/check_target.go
@@ -5,7 +5,8 @@ import storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 // CheckTarget represents a derived check target from a plan.
 // This is computed at runtime from the plan's specs, not stored.
 type CheckTarget struct {
-	// Target is the database resource name: instances/{instance}/databases/{database}
+	// Target is the canonical database resource name: instances/{instance}/databases/{database}
+	// or projects/{project}/instances/{instance}/databases/{database}.
 	Target string
 	// SheetSha256 is the content hash of the SQL sheet
 	SheetSha256 string

--- a/backend/runner/plancheck/database_group.go
+++ b/backend/runner/plancheck/database_group.go
@@ -47,8 +47,19 @@ func GetDatabaseGroupForPlan(ctx context.Context, stores *store.Store, plan *sto
 
 	result := &v1pb.DatabaseGroup{Name: target}
 	for _, db := range matchedDatabases {
+		instance, err := stores.GetInstanceByResourceID(ctx, db.InstanceID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to get instance %q", db.InstanceID)
+		}
+		if instance == nil {
+			return nil, errors.Errorf("instance %q not found", db.InstanceID)
+		}
+		name := common.FormatDatabase(db.InstanceID, db.DatabaseName)
+		if instance.ProjectID != nil {
+			name = common.FormatProjectDatabase(*instance.ProjectID, db.InstanceID, db.DatabaseName)
+		}
 		result.MatchedDatabases = append(result.MatchedDatabases, &v1pb.DatabaseGroup_Database{
-			Name: common.FormatDatabase(db.InstanceID, db.DatabaseName),
+			Name: name,
 		})
 	}
 	return result, nil

--- a/backend/runner/plancheck/database_group.go
+++ b/backend/runner/plancheck/database_group.go
@@ -47,19 +47,8 @@ func GetDatabaseGroupForPlan(ctx context.Context, stores *store.Store, plan *sto
 
 	result := &v1pb.DatabaseGroup{Name: target}
 	for _, db := range matchedDatabases {
-		instance, err := stores.GetInstanceByResourceID(ctx, db.InstanceID)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to get instance %q", db.InstanceID)
-		}
-		if instance == nil {
-			return nil, errors.Errorf("instance %q not found", db.InstanceID)
-		}
-		name := common.FormatDatabase(db.InstanceID, db.DatabaseName)
-		if instance.ProjectID != nil {
-			name = common.FormatProjectDatabase(*instance.ProjectID, db.InstanceID, db.DatabaseName)
-		}
 		result.MatchedDatabases = append(result.MatchedDatabases, &v1pb.DatabaseGroup_Database{
-			Name: name,
+			Name: db.ResourceName(),
 		})
 	}
 	return result, nil

--- a/backend/runner/plancheck/database_group_test.go
+++ b/backend/runner/plancheck/database_group_test.go
@@ -89,6 +89,37 @@ func TestGetDatabaseGroupForPlanMatchesDatabases(t *testing.T) {
 	}, databaseNames(got.MatchedDatabases))
 }
 
+func TestGetDatabaseGroupForPlanUsesDatabaseResourceName(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlancheckStore(ctx, t)
+	setupPlancheckDatabaseGroupFixture(ctx, t, s)
+
+	projectID := "project-a"
+	target := "projects/project-a/databaseGroups/group"
+	got, err := GetDatabaseGroupForPlan(ctx, s, &store.PlanMessage{
+		ProjectID: projectID,
+		Config: &storepb.PlanConfig{
+			Specs: []*storepb.PlanConfig_Spec{{
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{target},
+					},
+				},
+			}},
+		},
+	}, []*store.DatabaseMessage{{
+		ProjectID:         projectID,
+		InstanceProjectID: &projectID,
+		InstanceID:        "not-loaded",
+		DatabaseName:      "app",
+		Metadata:          &storepb.DatabaseMetadata{Labels: map[string]string{}},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		common.FormatProjectDatabase(projectID, "not-loaded", "app"),
+	}, databaseNames(got.MatchedDatabases))
+}
+
 func setupPlancheckStore(ctx context.Context, t *testing.T) *store.Store {
 	t.Helper()
 

--- a/backend/runner/plancheck/database_group_test.go
+++ b/backend/runner/plancheck/database_group_test.go
@@ -83,7 +83,10 @@ func TestGetDatabaseGroupForPlanMatchesDatabases(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, target, got.Name)
-	require.Equal(t, []string{common.FormatDatabase("prod", "app")}, databaseNames(got.MatchedDatabases))
+	require.Equal(t, []string{
+		common.FormatDatabase("prod", "app"),
+		common.FormatProjectDatabase("project-a", "project-prod", "app"),
+	}, databaseNames(got.MatchedDatabases))
 }
 
 func setupPlancheckStore(ctx context.Context, t *testing.T) *store.Store {
@@ -123,6 +126,17 @@ func setupPlancheckDatabaseGroupFixture(ctx context.Context, t *testing.T, s *st
 		},
 	})
 	require.NoError(t, err)
+	projectID := "project-a"
+	_, err = s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "project-prod",
+		Workspace:  "default",
+		ProjectID:  &projectID,
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
 	for _, databaseName := range []string{"app", "audit"} {
 		_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
 			ProjectID:    "project-a",
@@ -132,6 +146,13 @@ func setupPlancheckDatabaseGroupFixture(ctx context.Context, t *testing.T, s *st
 		})
 		require.NoError(t, err)
 	}
+	_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
+		ProjectID:    "project-a",
+		InstanceID:   "project-prod",
+		DatabaseName: "app",
+		Metadata:     &storepb.DatabaseMetadata{Labels: map[string]string{}},
+	})
+	require.NoError(t, err)
 	_, err = s.CreateDatabaseGroup(ctx, &store.DatabaseGroupMessage{
 		ProjectID:  "project-a",
 		ResourceID: "group",

--- a/backend/runner/plancheck/ghost_sync_executor.go
+++ b/backend/runner/plancheck/ghost_sync_executor.go
@@ -63,25 +63,9 @@ func (e *GhostSyncExecutor) RunForTarget(ctx context.Context, target *CheckTarge
 		}
 	}()
 
-	instanceID, databaseName, err := common.GetInstanceDatabaseID(target.Target)
+	instance, database, err := resolveDatabaseTarget(ctx, e.store, target.Target)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse target %s", target.Target)
-	}
-
-	instance, err := e.store.GetInstanceByResourceID(ctx, instanceID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get instance %s", instanceID)
-	}
-	if instance == nil {
-		return nil, errors.Errorf("instance %s not found", instanceID)
-	}
-
-	database, err := e.store.GetDatabase(ctx, &store.FindDatabaseMessage{InstanceID: &instance.ResourceID, DatabaseName: &databaseName})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get database %q", databaseName)
-	}
-	if database == nil {
-		return nil, errors.Errorf("database not found %q", databaseName)
+		return nil, err
 	}
 
 	adminDataSource := utils.DataSourceFromInstanceWithType(instance, storepb.DataSourceType_ADMIN)

--- a/backend/runner/plancheck/scheduler.go
+++ b/backend/runner/plancheck/scheduler.go
@@ -125,6 +125,10 @@ func (s *Scheduler) runPlanCheckRun(ctx context.Context, projectID string, uid i
 		s.markPlanCheckRunFailed(ctxWithCancel, projectID, uid, approvalInputVersion, "project not found")
 		return
 	}
+	if project.Deleted {
+		s.markPlanCheckRunCanceled(ctxWithCancel, projectID, uid, approvalInputVersion, "project is archived")
+		return
+	}
 
 	// Get database group if needed (for spec expansion)
 	databaseGroup, err := GetDatabaseGroupForPlan(ctxWithCancel, s.store, plan, nil)

--- a/backend/runner/plancheck/scheduler_test.go
+++ b/backend/runner/plancheck/scheduler_test.go
@@ -51,3 +51,41 @@ func TestMarkPlanCheckRunDoneSkipsDraftIssue(t *testing.T) {
 	require.Equal(t, store.PlanCheckRunStatusDone, run.Status)
 	require.Empty(t, b.ApprovalCheckChan)
 }
+
+func TestRunPlanCheckRunStopsAfterProjectArchive(t *testing.T) {
+	ctx := context.Background()
+	stores := setupPlancheckStore(ctx, t)
+	b, err := bus.New()
+	require.NoError(t, err)
+
+	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      "archived plan",
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 1},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	created, err := stores.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+	claimed, err := stores.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+
+	archived := true
+	require.NoError(t, stores.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+	scheduler := NewScheduler(stores, b, nil, nil)
+	scheduler.runPlanCheckRun(ctx, "project-a", claimed[0].UID, plan.UID, 1)
+
+	run, err := stores.GetPlanCheckRun(ctx, "project-a", plan.UID)
+	require.NoError(t, err)
+	require.Equal(t, store.PlanCheckRunStatusCanceled, run.Status)
+	require.Equal(t, "project is archived", run.Result.GetError())
+}

--- a/backend/runner/plancheck/statement_advise_executor.go
+++ b/backend/runner/plancheck/statement_advise_executor.go
@@ -51,17 +51,9 @@ func (e *StatementAdviseExecutor) RunForTarget(ctx context.Context, target *Chec
 	enablePriorBackup := target.EnablePriorBackup
 	enableGhost := target.EnableGhost
 
-	instanceID, databaseName, err := common.GetInstanceDatabaseID(target.Target)
+	instance, database, err := resolveDatabaseTarget(ctx, e.store, target.Target)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse target %s", target.Target)
-	}
-
-	instance, err := e.store.GetInstanceByResourceID(ctx, instanceID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get instance %s", instanceID)
-	}
-	if instance == nil {
-		return nil, errors.Errorf("instance %s not found", instanceID)
+		return nil, err
 	}
 	if !common.EngineSupportStatementAdvise(instance.Metadata.GetEngine()) {
 		return []*storepb.PlanCheckRunResult_Result{
@@ -72,14 +64,6 @@ func (e *StatementAdviseExecutor) RunForTarget(ctx context.Context, target *Chec
 				Content: "",
 			},
 		}, nil
-	}
-
-	database, err := e.store.GetDatabase(ctx, &store.FindDatabaseMessage{InstanceID: &instance.ResourceID, DatabaseName: &databaseName})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get database %q", databaseName)
-	}
-	if database == nil {
-		return nil, errors.Errorf("database not found %q", databaseName)
 	}
 
 	results, err := e.runReview(ctx, instance, database, fullSheet.Statement, enablePriorBackup, enableGhost)

--- a/backend/runner/plancheck/statement_report_executor.go
+++ b/backend/runner/plancheck/statement_report_executor.go
@@ -66,17 +66,9 @@ func (e *StatementReportExecutor) RunForTarget(ctx context.Context, target *Chec
 		}, nil
 	}
 
-	instanceID, databaseName, err := common.GetInstanceDatabaseID(target.Target)
+	instance, database, err := resolveDatabaseTarget(ctx, e.store, target.Target)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to parse target %s", target.Target)
-	}
-
-	instance, err := e.store.GetInstanceByResourceID(ctx, instanceID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get instance %v", instanceID)
-	}
-	if instance == nil {
-		return nil, errors.Errorf("instance %s not found", instanceID)
+		return nil, err
 	}
 	if !common.EngineSupportStatementReport(instance.Metadata.GetEngine()) {
 		return []*storepb.PlanCheckRunResult_Result{
@@ -87,14 +79,6 @@ func (e *StatementReportExecutor) RunForTarget(ctx context.Context, target *Chec
 				Content: "",
 			},
 		}, nil
-	}
-
-	database, err := e.store.GetDatabase(ctx, &store.FindDatabaseMessage{InstanceID: &instance.ResourceID, DatabaseName: &databaseName})
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get database %q", databaseName)
-	}
-	if database == nil {
-		return nil, errors.Errorf("database not found %q", databaseName)
 	}
 
 	// Check statement syntax error.

--- a/backend/runner/plancheck/target.go
+++ b/backend/runner/plancheck/target.go
@@ -1,0 +1,49 @@
+package plancheck
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+// resolveDatabaseTarget resolves a workspace- or project-scoped database resource name.
+func resolveDatabaseTarget(ctx context.Context, stores *store.Store, target string) (*store.InstanceMessage, *store.DatabaseMessage, error) {
+	projectID, instanceID, databaseName, err := common.GetDatabaseResourceName(target)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to parse target %s", target)
+	}
+
+	instance, err := stores.GetInstanceByResourceID(ctx, instanceID)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to get instance %s", instanceID)
+	}
+	if instance == nil {
+		return nil, nil, errors.Errorf("instance %s not found", instanceID)
+	}
+	if instance.Deleted {
+		return nil, nil, errors.Errorf("instance %s has been deleted", instanceID)
+	}
+	if (projectID == nil) != (instance.ProjectID == nil) ||
+		projectID != nil && *instance.ProjectID != *projectID {
+		if projectID == nil {
+			return nil, nil, errors.Errorf("project instance %q must be addressed through its project", instanceID)
+		}
+		return nil, nil, errors.Errorf("instance %q does not belong to project %q", instanceID, *projectID)
+	}
+
+	database, err := stores.GetDatabase(ctx, &store.FindDatabaseMessage{InstanceID: &instance.ResourceID, DatabaseName: &databaseName})
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "failed to get database %q", databaseName)
+	}
+	if database == nil {
+		return nil, nil, errors.Errorf("database not found %q", databaseName)
+	}
+	if projectID != nil && database.ProjectID != *projectID {
+		return nil, nil, errors.Errorf("database %q does not belong to project %q", target, *projectID)
+	}
+
+	return instance, database, nil
+}

--- a/backend/runner/plancheck/target_test.go
+++ b/backend/runner/plancheck/target_test.go
@@ -1,0 +1,93 @@
+package plancheck
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestResolveDatabaseTarget(t *testing.T) {
+	ctx := context.Background()
+	stores := setupPlancheckStore(ctx, t)
+
+	projectID := "project-a"
+	for _, instance := range []*store.InstanceMessage{
+		{
+			ResourceID: "workspace-instance",
+			Workspace:  "default",
+			Metadata:   &storepb.Instance{Engine: storepb.Engine_POSTGRES, DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}}},
+		},
+		{
+			ResourceID: "project-instance",
+			Workspace:  "default",
+			ProjectID:  &projectID,
+			Metadata:   &storepb.Instance{Engine: storepb.Engine_POSTGRES, DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}}},
+		},
+	} {
+		_, err := stores.CreateInstance(ctx, instance)
+		require.NoError(t, err)
+	}
+	for _, database := range []*store.DatabaseMessage{
+		{ProjectID: projectID, InstanceID: "workspace-instance", DatabaseName: "workspace-db", Metadata: &storepb.DatabaseMetadata{}},
+		{ProjectID: projectID, InstanceID: "project-instance", DatabaseName: "project-db", Metadata: &storepb.DatabaseMetadata{}},
+	} {
+		_, err := stores.UpsertDatabase(ctx, database)
+		require.NoError(t, err)
+	}
+
+	tests := []struct {
+		name       string
+		target     string
+		wantErr    string
+		instanceID string
+		databaseID string
+	}{
+		{
+			name:       "workspace canonical database",
+			target:     common.FormatDatabase("workspace-instance", "workspace-db"),
+			instanceID: "workspace-instance",
+			databaseID: "workspace-db",
+		},
+		{
+			name:       "project canonical database",
+			target:     common.FormatProjectDatabase(projectID, "project-instance", "project-db"),
+			instanceID: "project-instance",
+			databaseID: "project-db",
+		},
+		{
+			name:    "project instance rejects workspace alias",
+			target:  common.FormatDatabase("project-instance", "project-db"),
+			wantErr: "must be addressed through its project",
+		},
+		{
+			name:    "nested project must own instance",
+			target:  common.FormatProjectDatabase(projectID, "workspace-instance", "workspace-db"),
+			wantErr: "does not belong to project",
+		},
+		{
+			name:    "nested project must match instance owner",
+			target:  common.FormatProjectDatabase("project-b", "project-instance", "project-db"),
+			wantErr: "does not belong to project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			instance, database, err := resolveDatabaseTarget(ctx, stores, tt.target)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				require.Nil(t, instance)
+				require.Nil(t, database)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.instanceID, instance.ResourceID)
+			require.Equal(t, tt.databaseID, database.DatabaseName)
+		})
+	}
+}

--- a/backend/runner/schemasync/syncer.go
+++ b/backend/runner/schemasync/syncer.go
@@ -106,6 +106,10 @@ func (s *Syncer) Run(ctx context.Context, wg *sync.WaitGroup) {
 					}
 
 					s.databaseSyncMap.Delete(key)
+					instance, ok := instanceMap[database.InstanceID]
+					if !ok || !s.canScheduleDatabaseSync(ctx, instance, database) {
+						return true
+					}
 					dbwp.Go(func() {
 						slog.Debug("Sync database schema", slog.String("instance", database.InstanceID), slog.String("database", database.DatabaseName))
 						if err := s.SyncDatabaseSchema(ctx, database); err != nil {
@@ -178,6 +182,9 @@ func (s *Syncer) trySyncAll(ctx context.Context) {
 	now := time.Now()
 	for _, instance := range instances {
 		instance := instance
+		if !s.canScheduleInstanceSync(ctx, instance) {
+			continue
+		}
 		interval := s.getOrDefaultSyncInterval(ctx, instance)
 		if interval == defaultSyncInterval {
 			continue
@@ -220,6 +227,9 @@ func (s *Syncer) trySyncAll(ctx context.Context) {
 		if !ok {
 			continue
 		}
+		if !s.canScheduleDatabaseSync(ctx, instance, database) {
+			continue
+		}
 		// The database inherits the sync interval from the instance.
 		interval := s.getOrDefaultSyncInterval(ctx, instance)
 		if interval == defaultSyncInterval {
@@ -237,9 +247,33 @@ func (s *Syncer) trySyncAll(ctx context.Context) {
 	}
 }
 
+func (s *Syncer) canScheduleInstanceSync(ctx context.Context, instance *store.InstanceMessage) bool {
+	return instance.ProjectID == nil || s.isProjectActive(ctx, *instance.ProjectID)
+}
+
+func (s *Syncer) canScheduleDatabaseSync(ctx context.Context, instance *store.InstanceMessage, database *store.DatabaseMessage) bool {
+	return !database.Deleted && s.canScheduleInstanceSync(ctx, instance) && s.isProjectActive(ctx, database.ProjectID)
+}
+
+func (s *Syncer) isProjectActive(ctx context.Context, projectID string) bool {
+	project, err := s.store.GetProjectByResourceID(ctx, projectID)
+	if err != nil {
+		slog.Error("failed to get project for schema sync", slog.String("project", projectID), log.BBError(err))
+		return false
+	}
+	if project == nil {
+		slog.Warn("project not found for schema sync", slog.String("project", projectID))
+		return false
+	}
+	return !project.Deleted
+}
+
 func (s *Syncer) SyncAllDatabases(ctx context.Context, instance *store.InstanceMessage) {
 	find := &store.FindDatabaseMessage{}
 	if instance != nil {
+		if !s.canScheduleInstanceSync(ctx, instance) {
+			return
+		}
 		find.InstanceID = &instance.ResourceID
 	}
 	databases, err := s.store.ListDatabases(ctx, find)
@@ -250,8 +284,7 @@ func (s *Syncer) SyncAllDatabases(ctx context.Context, instance *store.InstanceM
 	}
 
 	for _, database := range databases {
-		// Skip deleted databases.
-		if database.Deleted {
+		if database.Deleted || instance != nil && !s.canScheduleDatabaseSync(ctx, instance, database) {
 			continue
 		}
 		s.databaseSyncMap.Store(database.String(), database)

--- a/backend/runner/schemasync/syncer_test.go
+++ b/backend/runner/schemasync/syncer_test.go
@@ -2,13 +2,17 @@ package schemasync
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -48,4 +52,106 @@ func TestGetOrDefaultSyncIntervalUsesEffectiveActivation(t *testing.T) {
 
 	instance.Metadata.Activation = true
 	require.Equal(t, customInterval, s.getOrDefaultSyncInterval(ctx, instance))
+}
+
+func TestTrySyncAllSkipsDatabasesInArchivedProjects(t *testing.T) {
+	ctx := context.Background()
+	s := setupSyncerStore(ctx, t)
+	archived := true
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+
+	lastSyncTime := timestamppb.New(time.Now())
+	_, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "instance-a",
+		Workspace:  "default",
+		Metadata: &storepb.Instance{
+			Activation:   true,
+			SyncInterval: durationpb.New(time.Minute),
+			LastSyncTime: lastSyncTime,
+			Engine:       storepb.Engine_POSTGRES,
+			DataSources:  []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
+		ProjectID:    "project-a",
+		InstanceID:   "instance-a",
+		DatabaseName: "app",
+		Metadata:     &storepb.DatabaseMetadata{Labels: map[string]string{}},
+	})
+	require.NoError(t, err)
+
+	syncer := NewSyncer(s, nil, nil)
+	syncer.trySyncAll(ctx)
+
+	queued := 0
+	syncer.databaseSyncMap.Range(func(_, _ any) bool {
+		queued++
+		return true
+	})
+	require.Zero(t, queued)
+
+	archived = false
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+	syncer.trySyncAll(ctx)
+	syncer.databaseSyncMap.Range(func(_, _ any) bool {
+		queued++
+		return true
+	})
+	require.Equal(t, 1, queued)
+}
+
+func TestCanScheduleInstanceSyncRequiresActiveProject(t *testing.T) {
+	ctx := context.Background()
+	s := setupSyncerStore(ctx, t)
+	projectID := "project-a"
+	syncer := NewSyncer(s, nil, nil)
+	instance := &store.InstanceMessage{ProjectID: &projectID}
+
+	archived := true
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: projectID,
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+	require.False(t, syncer.canScheduleInstanceSync(ctx, instance))
+
+	archived = false
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: projectID,
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+	require.True(t, syncer.canScheduleInstanceSync(ctx, instance))
+}
+
+func setupSyncerStore(ctx context.Context, t *testing.T) *store.Store {
+	t.Helper()
+
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort(),
+	)
+	s, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	return s
 }

--- a/backend/runner/taskrun/database_migrate_executor.go
+++ b/backend/runner/taskrun/database_migrate_executor.go
@@ -783,13 +783,16 @@ func (exec *DatabaseMigrateExecutor) backupData(
 	}
 
 	sourceDatabaseName := common.FormatDatabase(database.InstanceID, database.DatabaseName)
-	// Format: instances/{instance}/databases/{database}
 	backupDBName := common.BackupDatabaseNameOfEngine(database.Engine)
 	targetDatabaseName := common.FormatDatabase(database.InstanceID, backupDBName)
+	if instance.ProjectID != nil {
+		sourceDatabaseName = common.FormatProjectDatabase(*instance.ProjectID, database.InstanceID, database.DatabaseName)
+		targetDatabaseName = common.FormatProjectDatabase(*instance.ProjectID, database.InstanceID, backupDBName)
+	}
 	var backupDatabase *store.DatabaseMessage
 	var backupDriver db.Driver
 
-	backupInstanceID, backupDatabaseName, err := common.GetInstanceDatabaseID(targetDatabaseName)
+	_, backupInstanceID, backupDatabaseName, err := common.GetDatabaseResourceName(targetDatabaseName)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse backup database")
 	}

--- a/backend/runner/taskrun/pending_scheduler.go
+++ b/backend/runner/taskrun/pending_scheduler.go
@@ -112,9 +112,19 @@ func (s *Scheduler) schedulePendingTaskRun(ctx context.Context, taskRun *store.T
 	if err != nil {
 		return errors.Wrapf(err, "failed to get task")
 	}
-
 	// Check 1: RunAt time
 	if taskRun.RunAt != nil && time.Now().Before(*taskRun.RunAt) {
+		return nil
+	}
+
+	project, err := s.store.GetProjectByResourceID(ctx, task.ProjectID)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get project")
+	}
+	if project == nil {
+		return errors.Errorf("project %v not found", task.ProjectID)
+	}
+	if project.Deleted {
 		return nil
 	}
 

--- a/backend/runner/taskrun/rollout_creator.go
+++ b/backend/runner/taskrun/rollout_creator.go
@@ -125,6 +125,10 @@ func (rc *RolloutCreator) tryCreateRollout(ctx context.Context, ref bus.PlanRef)
 		slog.Error("project not found for rollout creation", slog.String("project_id", plan.ProjectID))
 		return
 	}
+	if project.Deleted {
+		slog.Debug("project is archived, skipping rollout creation", slog.String("project_id", plan.ProjectID))
+		return
+	}
 
 	// Check approval status (must be approved)
 	approved, err := utils.CheckIssueApprovedForPlan(issue, plan)

--- a/backend/runner/taskrun/rollout_creator_test.go
+++ b/backend/runner/taskrun/rollout_creator_test.go
@@ -208,7 +208,178 @@ func TestTryCreateRolloutSkipsArchivedProject(t *testing.T) {
 	require.Empty(t, b.TaskRunTickleChan)
 }
 
+func TestTryCreateRolloutResolvesProjectInstanceOutsideRequestContext(t *testing.T) {
+	ctx := context.Background()
+	const workspaceID = "workspace-a"
+	s := setupRolloutCreatorStoreInWorkspace(ctx, t, workspaceID)
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  workspaceID,
+		Setting:    &storepb.Project{RequireIssueApproval: false},
+	}))
+
+	environment := "prod"
+	projectID := "project-a"
+	_, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID:    "prod",
+		Workspace:     workspaceID,
+		ProjectID:     &projectID,
+		EnvironmentID: &environment,
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
+		ProjectID:    projectID,
+		InstanceID:   "prod",
+		DatabaseName: "app",
+		Metadata:     &storepb.DatabaseMetadata{Labels: map[string]string{}},
+	})
+	require.NoError(t, err)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: projectID,
+		Name:      "auto rollout plan",
+		Config: &storepb.PlanConfig{
+			ApprovalInputVersion: 2,
+			Specs: []*storepb.PlanConfig_Spec{{
+				Id: "change",
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{"projects/project-a/instances/prod/databases/app"},
+					},
+				},
+			}},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	_, err = s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    projectID,
+		CreatorEmail: "creator@example.com",
+		Title:        "auto rollout issue",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Payload: &storepb.Issue{Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: 2,
+		}},
+		PlanUID: &plan.UID,
+	})
+	require.NoError(t, err)
+
+	b, err := bus.New()
+	require.NoError(t, err)
+	NewRolloutCreator(s, b, nil).tryCreateRollout(ctx, bus.PlanRef{ProjectID: projectID, PlanID: plan.UID})
+
+	gotPlan, err := s.GetPlan(ctx, &store.FindPlanMessage{ProjectID: projectID, UID: &plan.UID})
+	require.NoError(t, err)
+	require.True(t, gotPlan.Config.GetHasRollout())
+	tasks, err := s.ListTasks(ctx, &store.TaskFind{ProjectID: projectID, PlanID: &plan.UID})
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	require.Len(t, b.TaskRunTickleChan, 1)
+}
+
+func TestTryCreateRolloutRejectsArchivedProjectInstanceWithWarmDatabaseCache(t *testing.T) {
+	ctx := context.Background()
+	const workspaceID = "workspace-a"
+	s := setupRolloutCreatorStoreInWorkspaceWithCache(ctx, t, workspaceID, true)
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  workspaceID,
+		Setting:    &storepb.Project{RequireIssueApproval: false},
+	}))
+
+	environment := "prod"
+	projectID := "project-a"
+	instance, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID:    "prod",
+		Workspace:     workspaceID,
+		ProjectID:     &projectID,
+		EnvironmentID: &environment,
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
+		ProjectID:    projectID,
+		InstanceID:   instance.ResourceID,
+		DatabaseName: "app",
+		Metadata:     &storepb.DatabaseMetadata{Labels: map[string]string{}},
+	})
+	require.NoError(t, err)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: projectID,
+		Name:      "archived instance rollout plan",
+		Config: &storepb.PlanConfig{
+			ApprovalInputVersion: 2,
+			Specs: []*storepb.PlanConfig_Spec{{
+				Id: "change",
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{"projects/project-a/instances/prod/databases/app"},
+					},
+				},
+			}},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	_, err = s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    projectID,
+		CreatorEmail: "creator@example.com",
+		Title:        "archived instance rollout issue",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Payload: &storepb.Issue{Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: 2,
+		}},
+		PlanUID: &plan.UID,
+	})
+	require.NoError(t, err)
+
+	instanceID := instance.ResourceID
+	databaseName := "app"
+	warmed, err := s.GetDatabase(ctx, &store.FindDatabaseMessage{
+		Workspace:    workspaceID,
+		InstanceID:   &instanceID,
+		DatabaseName: &databaseName,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, warmed)
+	deleted := true
+	_, err = s.UpdateInstance(ctx, &store.UpdateInstanceMessage{
+		ResourceID: &instanceID,
+		Workspace:  workspaceID,
+		Deleted:    &deleted,
+	})
+	require.NoError(t, err)
+
+	b, err := bus.New()
+	require.NoError(t, err)
+	NewRolloutCreator(s, b, nil).tryCreateRollout(ctx, bus.PlanRef{ProjectID: projectID, PlanID: plan.UID})
+
+	gotPlan, err := s.GetPlan(ctx, &store.FindPlanMessage{ProjectID: projectID, UID: &plan.UID})
+	require.NoError(t, err)
+	require.False(t, gotPlan.Config.GetHasRollout())
+	tasks, err := s.ListTasks(ctx, &store.TaskFind{ProjectID: projectID, PlanID: &plan.UID})
+	require.NoError(t, err)
+	require.Empty(t, tasks)
+	require.Empty(t, b.TaskRunTickleChan)
+}
+
 func setupRolloutCreatorStore(ctx context.Context, t *testing.T) *store.Store {
+	return setupRolloutCreatorStoreInWorkspace(ctx, t, "default")
+}
+
+func setupRolloutCreatorStoreInWorkspace(ctx context.Context, t *testing.T, workspaceID string) *store.Store {
+	return setupRolloutCreatorStoreInWorkspaceWithCache(ctx, t, workspaceID, false)
+}
+
+func setupRolloutCreatorStoreInWorkspaceWithCache(ctx context.Context, t *testing.T, workspaceID string, enableCache bool) *store.Store {
 	t.Helper()
 
 	container := testcontainer.GetTestPgContainer(ctx, t)
@@ -217,18 +388,18 @@ func setupRolloutCreatorStore(ctx context.Context, t *testing.T) *store.Store {
 	db := container.GetDB()
 	require.NoError(t, migrator.MigrateSchema(ctx, db))
 
-	_, err := db.ExecContext(ctx, `
-		INSERT INTO workspace (resource_id) VALUES ('default');
-		INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused');
-		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
-	`)
+	_, err := db.ExecContext(ctx, "INSERT INTO workspace (resource_id) VALUES ($1)", workspaceID)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused')")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', $1, 'Project A')", workspaceID)
 	require.NoError(t, err)
 
 	pgURL := fmt.Sprintf(
 		"host=%s port=%s user=postgres password=root-password database=postgres",
 		container.GetHost(), container.GetPort(),
 	)
-	s, err := store.New(ctx, pgURL, false)
+	s, err := store.New(ctx, pgURL, enableCache)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	return s

--- a/backend/runner/taskrun/rollout_creator_test.go
+++ b/backend/runner/taskrun/rollout_creator_test.go
@@ -124,6 +124,90 @@ func TestTryCreateRolloutSkipsDraft(t *testing.T) {
 	require.Empty(t, b.TaskRunTickleChan)
 }
 
+func TestTryCreateRolloutSkipsArchivedProject(t *testing.T) {
+	ctx := context.Background()
+	s := setupRolloutCreatorStore(ctx, t)
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  "default",
+		Setting:    &storepb.Project{RequireIssueApproval: false},
+	}))
+
+	environment := "prod"
+	_, err := s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID:    "prod",
+		Workspace:     "default",
+		EnvironmentID: &environment,
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.UpsertDatabase(ctx, &store.DatabaseMessage{
+		ProjectID:    "project-a",
+		InstanceID:   "prod",
+		DatabaseName: "app",
+		Metadata:     &storepb.DatabaseMetadata{Labels: map[string]string{}},
+	})
+	require.NoError(t, err)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      "archived project plan",
+		Config: &storepb.PlanConfig{
+			ApprovalInputVersion: 2,
+			Specs: []*storepb.PlanConfig_Spec{{
+				Id: "change",
+				Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+						Targets: []string{"instances/prod/databases/app"},
+					},
+				},
+			}},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	_, err = s.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "archived project issue",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Payload: &storepb.Issue{
+			Approval: &storepb.IssuePayloadApproval{
+				ApprovalFindingDone:  true,
+				ApprovalInputVersion: 2,
+			},
+		},
+		PlanUID: &plan.UID,
+	})
+	require.NoError(t, err)
+
+	archived := true
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+
+	b, err := bus.New()
+	require.NoError(t, err)
+	NewRolloutCreator(s, b, nil).tryCreateRollout(ctx, bus.PlanRef{
+		ProjectID: plan.ProjectID,
+		PlanID:    plan.UID,
+	})
+
+	gotPlan, err := s.GetPlan(ctx, &store.FindPlanMessage{ProjectID: plan.ProjectID, UID: &plan.UID})
+	require.NoError(t, err)
+	require.False(t, gotPlan.Config.GetHasRollout())
+
+	tasks, err := s.ListTasks(ctx, &store.TaskFind{ProjectID: plan.ProjectID, PlanID: &plan.UID})
+	require.NoError(t, err)
+	require.Empty(t, tasks)
+	require.Empty(t, b.TaskRunTickleChan)
+}
+
 func setupRolloutCreatorStore(ctx context.Context, t *testing.T) *store.Store {
 	t.Helper()
 

--- a/backend/runner/taskrun/scheduler_test.go
+++ b/backend/runner/taskrun/scheduler_test.go
@@ -1,11 +1,13 @@
 package taskrun
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/component/bus"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/store"
 )
@@ -23,4 +25,69 @@ func TestCompletionWebhookEnvironmentUsesLastEnvironmentOrder(t *testing.T) {
 	})
 
 	require.Equal(t, "prod", completionWebhookEnvironment(tasks, environmentOrderMap))
+}
+
+func TestSchedulePendingTaskRunsSkipsArchivedProject(t *testing.T) {
+	ctx := context.Background()
+	s := setupRolloutCreatorStore(ctx, t)
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      "archived project plan",
+		Config:    &storepb.PlanConfig{},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	_, err = s.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: "unused",
+		Workspace:  "default",
+		Metadata: &storepb.Instance{
+			Engine:      storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{Id: "admin", Type: storepb.DataSourceType_ADMIN}},
+		},
+	})
+	require.NoError(t, err)
+
+	tx, err := s.GetDB().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	tasks, err := s.CreateMissingTasksTx(ctx, tx, plan.ProjectID, plan.UID, []*store.TaskMessage{{
+		InstanceID: "unused",
+		Type:       storepb.Task_TASK_TYPE_UNSPECIFIED,
+		Payload:    &storepb.Task{},
+	}})
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	require.NoError(t, tx.Commit())
+	require.NoError(t, s.CreatePendingTaskRuns(ctx, "", &store.TaskRunMessage{
+		ProjectID: plan.ProjectID,
+		TaskUID:   tasks[0].ID,
+	}))
+
+	archived := true
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: plan.ProjectID,
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+
+	b, err := bus.New()
+	require.NoError(t, err)
+	scheduler := &Scheduler{store: s, bus: b}
+	require.NoError(t, scheduler.schedulePendingTaskRuns(ctx))
+
+	taskRuns, err := s.ListTaskRuns(ctx, &store.FindTaskRunMessage{ProjectID: plan.ProjectID})
+	require.NoError(t, err)
+	require.Len(t, taskRuns, 1)
+	require.Equal(t, storepb.TaskRun_PENDING, taskRuns[0].Status)
+
+	archived = false
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: plan.ProjectID,
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+	require.NoError(t, scheduler.schedulePendingTaskRuns(ctx))
+
+	taskRuns, err = s.ListTaskRuns(ctx, &store.FindTaskRunMessage{ProjectID: plan.ProjectID})
+	require.NoError(t, err)
+	require.Len(t, taskRuns, 1)
+	require.Equal(t, storepb.TaskRun_AVAILABLE, taskRuns[0].Status)
 }

--- a/backend/store/README.md
+++ b/backend/store/README.md
@@ -26,6 +26,13 @@ that branch. The active-project check in `nextProjectID` covers this case only f
 writers that call it; it is not a repository-wide purge fence because other
 writers bypass `nextProjectID`.
 
+Database creation, database-sync, and Query History writers, together with direct
+project/instance purge, additionally take the matching transaction-scoped purge
+fence before any row lock. This closes the absent database-descendant gap;
+writers then retain the normal child-to-parent row-lock order. Database sync may
+continue for an archived project while its row exists, but never through a
+soft-deleted instance.
+
 Every new or modified writer of purge-managed data must define its project
 lifecycle policy: require an active project for new resources, or require only an
 existing project when deleted-project continuation is intentional. Serialize and

--- a/backend/store/advisory_lock.go
+++ b/backend/store/advisory_lock.go
@@ -26,6 +26,12 @@ const (
 	// AdvisoryLockKeyPlanIssueRollout serializes Plan review changes, linked
 	// Bytebase Issue creation, and Rollout creation for the same Plan.
 	AdvisoryLockKeyPlanIssueRollout AdvisoryLockKey = 1005
+	// AdvisoryLockKeyProjectPurge serializes project-owned writes with project
+	// purge, including writes to an otherwise absent database descendant.
+	AdvisoryLockKeyProjectPurge AdvisoryLockKey = 1006
+	// AdvisoryLockKeyInstancePurge serializes database writes with instance
+	// purge, which cannot lock an absent database descendant.
+	AdvisoryLockKeyInstancePurge AdvisoryLockKey = 1007
 )
 
 // AcquirePlanIssueRolloutAdvisoryLock serializes coordinated Plan, linked Issue,
@@ -33,6 +39,14 @@ const (
 func AcquirePlanIssueRolloutAdvisoryLock(ctx context.Context, tx *sql.Tx, projectID string, planUID int64) error {
 	key := projectID + "/" + strconv.FormatInt(planUID, 10)
 	return AcquireAdvisoryXactLockWithStringKey(ctx, tx, AdvisoryLockKeyPlanIssueRollout, key)
+}
+
+func acquireProjectPurgeLock(ctx context.Context, tx *sql.Tx, projectID string) error {
+	return AcquireAdvisoryXactLockWithStringKey(ctx, tx, AdvisoryLockKeyProjectPurge, projectID)
+}
+
+func acquireInstancePurgeLock(ctx context.Context, tx *sql.Tx, instanceID string) error {
+	return AcquireAdvisoryXactLockWithStringKey(ctx, tx, AdvisoryLockKeyInstancePurge, instanceID)
 }
 
 // AdvisoryLock holds a dedicated connection for a session-level advisory lock.

--- a/backend/store/changelog.go
+++ b/backend/store/changelog.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"time"
 
@@ -92,7 +93,16 @@ func (s *Store) CreateChangelog(ctx context.Context, create *ChangelogMessage) (
 	}
 
 	var resourceID string
-	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&resourceID); err != nil {
+	err = s.withDatabasePurgeFence(ctx, create.InstanceID, create.DatabaseName, "", func(tx *sql.Tx) error {
+		if create.SyncHistory == nil {
+			return nil
+		}
+		_, err := tx.ExecContext(ctx, "SELECT 1 FROM sync_history WHERE resource_id = $1 FOR UPDATE", *create.SyncHistory)
+		return err
+	}, func(tx *sql.Tx, _ *databaseOwnership) error {
+		return tx.QueryRowContext(ctx, query, args...).Scan(&resourceID)
+	})
+	if err != nil {
 		return "", errors.Wrapf(err, "failed to insert")
 	}
 

--- a/backend/store/database.go
+++ b/backend/store/database.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/google/cel-go/cel"
@@ -257,23 +258,22 @@ func (s *Store) ListDatabases(ctx context.Context, find *FindDatabaseMessage) ([
 
 // CreateDatabaseDefault creates a database discovered by schema sync.
 func (s *Store) CreateDatabaseDefault(ctx context.Context, create *DatabaseMessage) (*DatabaseMessage, error) {
-	ownership, err := s.getDatabaseOwnership(ctx, create.InstanceID, create.DatabaseName)
+	err := s.withDatabasePurgeFence(ctx, create.InstanceID, create.DatabaseName, create.ProjectID, nil, func(tx *sql.Tx, ownership *databaseOwnership) error {
+		projectID, err := ownership.projectForDefaultCreate(create.ProjectID)
+		if err != nil {
+			return err
+		}
+		query, args, err := qb.Q().Space(`INSERT INTO db (instance, project, name, deleted)
+			VALUES (?, ?, ?, ?)
+			ON CONFLICT (instance, name) DO UPDATE SET deleted = EXCLUDED.deleted`,
+			create.InstanceID, projectID, create.DatabaseName, false).ToSQL()
+		if err != nil {
+			return errors.Wrap(err, "failed to build sql")
+		}
+		_, err = tx.ExecContext(ctx, query, args...)
+		return err
+	})
 	if err != nil {
-		return nil, err
-	}
-	projectID, err := ownership.projectForDefaultCreate(create.ProjectID)
-	if err != nil {
-		return nil, err
-	}
-	q := qb.Q().Space(`INSERT INTO db (instance, project, name, deleted)
-		VALUES (?, ?, ?, ?)
-		ON CONFLICT (instance, name) DO UPDATE SET deleted = EXCLUDED.deleted`,
-		create.InstanceID, projectID, create.DatabaseName, false)
-	query, args, err := q.ToSQL()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to build sql")
-	}
-	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return nil, err
 	}
 	s.removeDatabaseCache(ctx, create.InstanceID, create.DatabaseName)
@@ -286,29 +286,28 @@ func (s *Store) UpsertDatabase(ctx context.Context, create *DatabaseMessage) (*D
 	if err != nil {
 		return nil, err
 	}
-	ownership, err := s.getDatabaseOwnership(ctx, create.InstanceID, create.DatabaseName)
-	if err != nil {
-		return nil, err
-	}
-	projectID, err := ownership.projectForUpsert(create.ProjectID)
-	if err != nil {
-		return nil, err
-	}
 	var environment *string
 	if create.EnvironmentID != nil && *create.EnvironmentID != "" {
 		environment = create.EnvironmentID
 	}
-	q := qb.Q().Space(`INSERT INTO db (instance, project, environment, name, deleted, metadata)
-		VALUES (?, ?, ?, ?, ?, ?)
-		ON CONFLICT (instance, name) DO UPDATE SET
-			project = EXCLUDED.project, environment = EXCLUDED.environment,
-			name = EXCLUDED.name, metadata = EXCLUDED.metadata`,
-		create.InstanceID, projectID, environment, create.DatabaseName, create.Deleted, metadata)
-	query, args, err := q.ToSQL()
+	err = s.withDatabasePurgeFence(ctx, create.InstanceID, create.DatabaseName, create.ProjectID, nil, func(tx *sql.Tx, ownership *databaseOwnership) error {
+		projectID, err := ownership.projectForUpsert(create.ProjectID)
+		if err != nil {
+			return err
+		}
+		query, args, err := qb.Q().Space(`INSERT INTO db (instance, project, environment, name, deleted, metadata)
+			VALUES (?, ?, ?, ?, ?, ?)
+			ON CONFLICT (instance, name) DO UPDATE SET
+				project = EXCLUDED.project, environment = EXCLUDED.environment,
+				name = EXCLUDED.name, metadata = EXCLUDED.metadata`,
+			create.InstanceID, projectID, environment, create.DatabaseName, create.Deleted, metadata).ToSQL()
+		if err != nil {
+			return errors.Wrap(err, "failed to build sql")
+		}
+		_, err = tx.ExecContext(ctx, query, args...)
+		return err
+	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to build sql")
-	}
-	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return nil, err
 	}
 	s.removeDatabaseCache(ctx, create.InstanceID, create.DatabaseName)
@@ -317,54 +316,57 @@ func (s *Store) UpsertDatabase(ctx context.Context, create *DatabaseMessage) (*D
 
 // UpdateDatabase updates a database.
 func (s *Store) UpdateDatabase(ctx context.Context, patch *UpdateDatabaseMessage) (*DatabaseMessage, error) {
-	ownership, err := s.getDatabaseOwnership(ctx, patch.InstanceID, patch.DatabaseName)
-	if err != nil {
-		return nil, err
-	}
-	if !ownership.exists {
-		return nil, common.Errorf(common.NotFound, "database %s not found", common.FormatDatabase(patch.InstanceID, patch.DatabaseName))
-	}
-	projectID, err := ownership.projectForUpdate(patch.ProjectID)
-	if err != nil {
-		return nil, err
-	}
-	set := qb.Q()
+	requestedProjectID := ""
 	if patch.ProjectID != nil {
-		set.Comma("project = ?", projectID)
+		requestedProjectID = *patch.ProjectID
 	}
-	if v := patch.EnvironmentID; v != nil {
-		if *v == "" {
-			set.Comma("environment = NULL")
-		} else {
-			set.Comma("environment = ?", *v)
+	err := s.withDatabasePurgeFence(ctx, patch.InstanceID, patch.DatabaseName, requestedProjectID, nil, func(tx *sql.Tx, ownership *databaseOwnership) error {
+		if !ownership.exists {
+			return common.Errorf(common.NotFound, "database %s not found", common.FormatDatabase(patch.InstanceID, patch.DatabaseName))
 		}
-	}
-	if v := patch.Deleted; v != nil {
-		set.Comma("deleted = ?", *v)
-	}
-	if len(patch.MetadataUpdates) > 0 {
-		metadata := &storepb.DatabaseMetadata{}
-		if err := common.ProtojsonUnmarshaler.Unmarshal(ownership.metadata, metadata); err != nil {
-			return nil, errors.Wrapf(err, "failed to unmarshal metadata for database %q", common.FormatDatabase(patch.InstanceID, patch.DatabaseName))
-		}
-		for _, update := range patch.MetadataUpdates {
-			update(metadata)
-		}
-		metadataBytes, err := protojson.Marshal(metadata)
+		projectID, err := ownership.projectForUpdate(patch.ProjectID)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		set.Comma("metadata = ?", metadataBytes)
-	}
-	if set.Len() == 0 {
-		return nil, errors.New("no fields to update")
-	}
-	q := qb.Q().Space("UPDATE db SET ? WHERE instance = ? AND name = ?", set, patch.InstanceID, patch.DatabaseName)
-	query, args, err := q.ToSQL()
+		set := qb.Q()
+		if patch.ProjectID != nil {
+			set.Comma("project = ?", projectID)
+		}
+		if v := patch.EnvironmentID; v != nil {
+			if *v == "" {
+				set.Comma("environment = NULL")
+			} else {
+				set.Comma("environment = ?", *v)
+			}
+		}
+		if v := patch.Deleted; v != nil {
+			set.Comma("deleted = ?", *v)
+		}
+		if len(patch.MetadataUpdates) > 0 {
+			metadata := &storepb.DatabaseMetadata{}
+			if err := common.ProtojsonUnmarshaler.Unmarshal(ownership.metadata, metadata); err != nil {
+				return errors.Wrapf(err, "failed to unmarshal metadata for database %q", common.FormatDatabase(patch.InstanceID, patch.DatabaseName))
+			}
+			for _, update := range patch.MetadataUpdates {
+				update(metadata)
+			}
+			metadataBytes, err := protojson.Marshal(metadata)
+			if err != nil {
+				return err
+			}
+			set.Comma("metadata = ?", metadataBytes)
+		}
+		if set.Len() == 0 {
+			return errors.New("no fields to update")
+		}
+		query, args, err := qb.Q().Space("UPDATE db SET ? WHERE instance = ? AND name = ?", set, patch.InstanceID, patch.DatabaseName).ToSQL()
+		if err != nil {
+			return errors.Wrap(err, "failed to build sql")
+		}
+		_, err = tx.ExecContext(ctx, query, args...)
+		return err
+	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to build sql")
-	}
-	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
 		return nil, err
 	}
 	s.removeDatabaseCache(ctx, patch.InstanceID, patch.DatabaseName)
@@ -485,24 +487,128 @@ type databaseOwnership struct {
 	instanceProject *string
 }
 
-func (s *Store) getDatabaseOwnership(ctx context.Context, instanceID, databaseName string) (*databaseOwnership, error) {
-	ownership := &databaseOwnership{}
-	var databaseProject sql.NullString
-	var instanceProject sql.NullString
+// withDatabasePurgeFence serializes a database write with direct project and
+// instance purge. Database descendants may be absent, so row locks alone cannot
+// prevent a purge from passing their table before the writer inserts one.
+//
+// Database sync intentionally supports an archived (but still existing) project
+// owner. It does not support a purged or soft-deleted instance: that state is a
+// direct-purge boundary and no new database data may be written through it.
+func (s *Store) withDatabasePurgeFence(
+	ctx context.Context,
+	instanceID, databaseName, requestedProjectID string,
+	lockChild func(*sql.Tx) error,
+	write func(*sql.Tx, *databaseOwnership) error,
+) error {
+	projectID, err := s.databasePurgeProject(ctx, instanceID, databaseName, requestedProjectID)
+	if err != nil {
+		return err
+	}
+
+	tx, err := s.GetDB().BeginTx(ctx, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin database write transaction")
+	}
+	defer tx.Rollback()
+	projectFences := []string{projectID}
+	if requestedProjectID != "" {
+		projectFences = append(projectFences, requestedProjectID)
+	}
+	slices.Sort(projectFences)
+	projectFences = slices.Compact(projectFences)
+	for _, fence := range projectFences {
+		if err := acquireProjectPurgeLock(ctx, tx, fence); err != nil {
+			return errors.Wrapf(err, "failed to lock project purge fence for %s", fence)
+		}
+	}
+	if err := acquireInstancePurgeLock(ctx, tx, instanceID); err != nil {
+		return errors.Wrapf(err, "failed to lock instance purge fence for %s", instanceID)
+	}
+	if lockChild != nil {
+		if err := lockChild(tx); err != nil {
+			return err
+		}
+	}
+
+	ownership, err := lockDatabaseOwnership(ctx, tx, instanceID, databaseName)
+	if err != nil {
+		return err
+	}
+	if ownership.instanceProject != nil {
+		projectID = *ownership.instanceProject
+	} else if requestedProjectID == "" && ownership.exists {
+		projectID = ownership.projectID
+	}
+	if !slices.Contains(projectFences, projectID) {
+		return errors.Errorf("database ownership changed to project %s; retry", projectID)
+	}
+	for _, projectFence := range projectFences {
+		var foundProjectID string
+		if err := tx.QueryRowContext(ctx, "SELECT resource_id FROM project WHERE resource_id = $1 FOR UPDATE", projectFence).Scan(&foundProjectID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return common.Errorf(common.NotFound, "project %s not found", projectFence)
+			}
+			return errors.Wrapf(err, "failed to lock project %s", projectFence)
+		}
+	}
+	if err := write(tx, ownership); err != nil {
+		return err
+	}
+	return errors.Wrap(tx.Commit(), "failed to commit database write transaction")
+}
+
+func (s *Store) databasePurgeProject(ctx context.Context, instanceID, databaseName, requestedProjectID string) (string, error) {
+	var instanceProject, databaseProject sql.NullString
 	if err := s.GetDB().QueryRowContext(ctx, `
-		SELECT db.project, db.metadata, instance.project
+		SELECT instance.project, db.project
 		FROM instance
 		LEFT JOIN db ON db.instance = instance.resource_id AND db.name = $2
 		WHERE instance.resource_id = $1
-	`, instanceID, databaseName).Scan(&databaseProject, &ownership.metadata, &instanceProject); err != nil {
+	`, instanceID, databaseName).Scan(&instanceProject, &databaseProject); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, common.Errorf(common.NotFound, "instance %s not found", instanceID)
+			return "", common.Errorf(common.NotFound, "instance %s not found", instanceID)
 		}
-		return nil, errors.Wrapf(err, "failed to get database ownership for instance %s", instanceID)
+		return "", errors.Wrapf(err, "failed to find database purge project for instance %s", instanceID)
+	}
+	if instanceProject.Valid {
+		return instanceProject.String, nil
+	}
+	if databaseProject.Valid {
+		return databaseProject.String, nil
+	}
+	if requestedProjectID != "" {
+		return requestedProjectID, nil
+	}
+	return "", common.Errorf(common.NotFound, "database %s not found", common.FormatDatabase(instanceID, databaseName))
+}
+
+func lockDatabaseOwnership(ctx context.Context, tx *sql.Tx, instanceID, databaseName string) (*databaseOwnership, error) {
+	ownership := &databaseOwnership{}
+	var databaseProject sql.NullString
+	if err := tx.QueryRowContext(ctx, `
+		SELECT project, metadata FROM db
+		WHERE instance = $1 AND name = $2
+		FOR UPDATE
+	`, instanceID, databaseName).Scan(&databaseProject, &ownership.metadata); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, errors.Wrapf(err, "failed to lock database %s", common.FormatDatabase(instanceID, databaseName))
 	}
 	if databaseProject.Valid {
 		ownership.exists = true
 		ownership.projectID = databaseProject.String
+	}
+
+	var instanceProject sql.NullString
+	var deleted bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT project, deleted FROM instance WHERE resource_id = $1 FOR UPDATE
+	`, instanceID).Scan(&instanceProject, &deleted); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, common.Errorf(common.NotFound, "instance %s not found", instanceID)
+		}
+		return nil, errors.Wrapf(err, "failed to lock instance %s", instanceID)
+	}
+	if deleted {
+		return nil, common.Errorf(common.NotFound, "instance %s is deleted", instanceID)
 	}
 	if instanceProject.Valid {
 		projectID := instanceProject.String

--- a/backend/store/database.go
+++ b/backend/store/database.go
@@ -614,7 +614,7 @@ func lockDatabaseOwnership(ctx context.Context, tx *sql.Tx, instanceID, database
 	var instanceProject sql.NullString
 	var deleted bool
 	if err := tx.QueryRowContext(ctx, `
-		SELECT project, deleted FROM instance WHERE resource_id = $1 FOR UPDATE
+		SELECT project, deleted FROM instance WHERE resource_id = $1 FOR NO KEY UPDATE
 	`, instanceID).Scan(&instanceProject, &deleted); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, common.Errorf(common.NotFound, "instance %s not found", instanceID)

--- a/backend/store/database.go
+++ b/backend/store/database.go
@@ -21,9 +21,10 @@ import (
 
 // DatabaseMessage is the message for database.
 type DatabaseMessage struct {
-	ProjectID    string
-	InstanceID   string
-	DatabaseName string
+	ProjectID         string
+	InstanceProjectID *string
+	InstanceID        string
+	DatabaseName      string
 
 	EnvironmentID          *string
 	EffectiveEnvironmentID *string
@@ -34,6 +35,14 @@ type DatabaseMessage struct {
 }
 
 func (d *DatabaseMessage) String() string {
+	return common.FormatDatabase(d.InstanceID, d.DatabaseName)
+}
+
+// ResourceName returns the canonical database resource name for the owning instance scope.
+func (d *DatabaseMessage) ResourceName() string {
+	if d.InstanceProjectID != nil {
+		return common.FormatProjectDatabase(*d.InstanceProjectID, d.InstanceID, d.DatabaseName)
+	}
 	return common.FormatDatabase(d.InstanceID, d.DatabaseName)
 }
 
@@ -168,6 +177,7 @@ func (s *Store) ListDatabases(ctx context.Context, find *FindDatabaseMessage) ([
 	q := qb.Q().Space(`
 		SELECT
 			db.project,
+			instance.project,
 			COALESCE(
 				db.environment,
 				instance.environment
@@ -213,9 +223,10 @@ func (s *Store) ListDatabases(ctx context.Context, find *FindDatabaseMessage) ([
 	for rows.Next() {
 		databaseMessage := &DatabaseMessage{}
 		var metadataString string
-		var effectiveEnvironment, environment, engine sql.NullString
+		var instanceProject, effectiveEnvironment, environment, engine sql.NullString
 		if err := rows.Scan(
 			&databaseMessage.ProjectID,
+			&instanceProject,
 			&effectiveEnvironment,
 			&environment,
 			&databaseMessage.InstanceID,
@@ -225,6 +236,9 @@ func (s *Store) ListDatabases(ctx context.Context, find *FindDatabaseMessage) ([
 			&engine,
 		); err != nil {
 			return nil, err
+		}
+		if instanceProject.Valid {
+			databaseMessage.InstanceProjectID = &instanceProject.String
 		}
 		if effectiveEnvironment.Valid {
 			databaseMessage.EffectiveEnvironmentID = &effectiveEnvironment.String

--- a/backend/store/database_ownership_test.go
+++ b/backend/store/database_ownership_test.go
@@ -116,6 +116,32 @@ func TestDatabaseWritersRespectProjectInstanceOwnership(t *testing.T) {
 	require.Equal(t, projectB, getDatabaseProject(ctx, t, s, "workspace-instance", "independent"))
 }
 
+func TestListDatabasesIncludesInstanceProject(t *testing.T) {
+	fixture := newProjectDeletionLockOrderFixture(t, `
+		ALTER TABLE instance ADD COLUMN IF NOT EXISTS project TEXT REFERENCES project(resource_id);
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-b', 'default', 'Project B');
+		INSERT INTO instance (resource_id, workspace, project) VALUES
+			('project-instance', 'default', 'project-b'),
+			('workspace-instance', 'default', NULL);
+		INSERT INTO db (instance, name, project) VALUES
+			('project-instance', 'project-db', 'project-b'),
+			('workspace-instance', 'workspace-db', 'project-b');
+	`)
+
+	databases, err := fixture.store.ListDatabases(fixture.ctx, &store.FindDatabaseMessage{ShowDeleted: true})
+	require.NoError(t, err)
+	require.Len(t, databases, 2)
+	byInstance := make(map[string]*store.DatabaseMessage, len(databases))
+	for _, database := range databases {
+		byInstance[database.InstanceID] = database
+	}
+	require.NotNil(t, byInstance["project-instance"].InstanceProjectID)
+	require.Equal(t, "project-b", *byInstance["project-instance"].InstanceProjectID)
+	require.Equal(t, "projects/project-b/instances/project-instance/databases/project-db", byInstance["project-instance"].ResourceName())
+	require.Nil(t, byInstance["workspace-instance"].InstanceProjectID)
+	require.Equal(t, "instances/workspace-instance/databases/workspace-db", byInstance["workspace-instance"].ResourceName())
+}
+
 func getDatabaseProject(ctx context.Context, t *testing.T, s *store.Store, instanceID, databaseName string) string {
 	t.Helper()
 	database, err := s.GetDatabase(ctx, &store.FindDatabaseMessage{

--- a/backend/store/database_purge_writer_test.go
+++ b/backend/store/database_purge_writer_test.go
@@ -1,0 +1,146 @@
+package store_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+)
+
+func TestCreateSyncHistoryAndDeleteProjectSerialize(t *testing.T) {
+	const seedSQL = `
+		INSERT INTO instance (resource_id, workspace, project)
+			VALUES ('instance-a', 'default', 'project-a');
+		INSERT INTO db (instance, name, project) VALUES ('instance-a', 'db-a', 'project-a');
+		INSERT INTO sync_history (instance, db_name) VALUES ('instance-a', 'db-a');
+	`
+	createHistory := func(fixture *projectDeletionLockOrderFixture) error {
+		_, err := fixture.store.CreateSyncHistory(fixture.ctx, "instance-a", "db-a", &storepb.DatabaseSchemaMetadata{}, "")
+		return err
+	}
+
+	t.Run("purge first", func(t *testing.T) {
+		fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+		const barrierID = 9931
+		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
+		installMaintenanceLockBarrier(t, fixture.db, barrierID, "AFTER DELETE ON sync_history FOR EACH ROW")
+
+		purgeResult := make(chan error, 1)
+		go func() { purgeResult <- fixture.store.DeleteProject(fixture.ctx, "default", "project-a") }()
+		waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+
+		writerResult := make(chan error, 1)
+		go func() { writerResult <- createHistory(fixture) }()
+		waitForOperationBehindMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+		barrier.release(t)
+
+		requireMaintenanceResult(t, purgeResult)
+		err := <-writerResult
+		require.Error(t, err)
+		require.NotContains(t, strings.ToLower(err.Error()), "foreign key")
+	})
+
+	t.Run("writer first", func(t *testing.T) {
+		fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+		const barrierID = 9932
+		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
+		_, err := fixture.db.ExecContext(fixture.ctx, `
+			CREATE FUNCTION block_sync_history_insert() RETURNS trigger AS $$
+			BEGIN
+				PERFORM pg_advisory_xact_lock(9932);
+				RETURN NEW;
+			END;
+			$$ LANGUAGE plpgsql;
+			CREATE TRIGGER block_sync_history_insert
+			BEFORE INSERT ON sync_history FOR EACH ROW
+			EXECUTE FUNCTION block_sync_history_insert();
+		`)
+		require.NoError(t, err)
+
+		writerResult := make(chan error, 1)
+		go func() { writerResult <- createHistory(fixture) }()
+		waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+
+		purgeResult := make(chan error, 1)
+		go func() { purgeResult <- fixture.store.DeleteProject(fixture.ctx, "default", "project-a") }()
+		waitForOperationBehindMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+		barrier.release(t)
+
+		requireMaintenanceResult(t, writerResult)
+		requireMaintenanceResult(t, purgeResult)
+	})
+}
+
+func TestCreateSyncHistoryAndDeleteInstanceSerialize(t *testing.T) {
+	const seedSQL = `
+		INSERT INTO instance (resource_id, workspace, project)
+			VALUES ('instance-a', 'default', 'project-a');
+		INSERT INTO db (instance, name, project) VALUES ('instance-a', 'db-a', 'project-a');
+		INSERT INTO sync_history (instance, db_name) VALUES ('instance-a', 'db-a');
+	`
+	createHistory := func(fixture *projectDeletionLockOrderFixture) error {
+		_, err := fixture.store.CreateSyncHistory(fixture.ctx, "instance-a", "db-a", &storepb.DatabaseSchemaMetadata{}, "")
+		return err
+	}
+	archiveAndPurge := func(fixture *projectDeletionLockOrderFixture) error {
+		if _, err := fixture.db.ExecContext(fixture.ctx, `
+			UPDATE instance SET deleted = TRUE WHERE resource_id = 'instance-a'
+		`); err != nil {
+			return err
+		}
+		return fixture.store.DeleteInstance(fixture.ctx, "default", "instance-a")
+	}
+
+	t.Run("purge first", func(t *testing.T) {
+		fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+		const barrierID = 9933
+		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
+		installMaintenanceLockBarrier(t, fixture.db, barrierID, "AFTER DELETE ON sync_history FOR EACH ROW")
+
+		purgeResult := make(chan error, 1)
+		go func() { purgeResult <- archiveAndPurge(fixture) }()
+		waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+
+		writerResult := make(chan error, 1)
+		go func() { writerResult <- createHistory(fixture) }()
+		waitForOperationBehindMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+		barrier.release(t)
+
+		requireMaintenanceResult(t, purgeResult)
+		err := <-writerResult
+		require.Error(t, err)
+		require.NotContains(t, strings.ToLower(err.Error()), "foreign key")
+	})
+
+	t.Run("writer first", func(t *testing.T) {
+		fixture := newProjectDeletionLockOrderFixture(t, seedSQL)
+		const barrierID = 9934
+		barrier := newMaintenanceLockBarrier(fixture.ctx, t, fixture.db, barrierID)
+		_, err := fixture.db.ExecContext(fixture.ctx, `
+			CREATE FUNCTION block_sync_history_insert() RETURNS trigger AS $$
+			BEGIN
+				PERFORM pg_advisory_xact_lock(9934);
+				RETURN NEW;
+			END;
+			$$ LANGUAGE plpgsql;
+			CREATE TRIGGER block_sync_history_insert
+			BEFORE INSERT ON sync_history FOR EACH ROW
+			EXECUTE FUNCTION block_sync_history_insert();
+		`)
+		require.NoError(t, err)
+
+		writerResult := make(chan error, 1)
+		go func() { writerResult <- createHistory(fixture) }()
+		waitForMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+
+		purgeResult := make(chan error, 1)
+		go func() { purgeResult <- archiveAndPurge(fixture) }()
+		waitForOperationBehindMaintenanceBarrier(fixture.ctx, t, fixture.db, barrierID)
+		barrier.release(t)
+
+		requireMaintenanceResult(t, writerResult)
+		requireMaintenanceResult(t, purgeResult)
+	})
+}

--- a/backend/store/db_schema.go
+++ b/backend/store/db_schema.go
@@ -118,12 +118,14 @@ func (s *Store) UpsertDBSchema(
 		return errors.Wrapf(err, "failed to build sql")
 	}
 
-	var metadata, schema, config []byte
-	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(
-		&metadata,
-		&schema,
-		&config,
-	); err != nil {
+	err = s.withDatabasePurgeFence(ctx, instanceID, databaseName, "", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "SELECT 1 FROM db_schema WHERE instance = $1 AND db_name = $2 FOR UPDATE", instanceID, databaseName)
+		return err
+	}, func(tx *sql.Tx, _ *databaseOwnership) error {
+		var metadata, schema, config []byte
+		return tx.QueryRowContext(ctx, query, args...).Scan(&metadata, &schema, &config)
+	})
+	if err != nil {
 		return err
 	}
 
@@ -153,7 +155,14 @@ func (s *Store) UpdateDBSchema(ctx context.Context, instanceID, databaseName str
 		return errors.Wrapf(err, "failed to build sql")
 	}
 
-	if _, err := s.GetDB().ExecContext(ctx, query, args...); err != nil {
+	err = s.withDatabasePurgeFence(ctx, instanceID, databaseName, "", func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, "SELECT 1 FROM db_schema WHERE instance = $1 AND db_name = $2 FOR UPDATE", instanceID, databaseName)
+		return err
+	}, func(tx *sql.Tx, _ *databaseOwnership) error {
+		_, err := tx.ExecContext(ctx, query, args...)
+		return err
+	})
+	if err != nil {
 		return err
 	}
 

--- a/backend/store/instance.go
+++ b/backend/store/instance.go
@@ -226,7 +226,6 @@ func (s *Store) CreateInstance(ctx context.Context, instanceCreate *InstanceMess
 		return nil, err
 	}
 	defer tx.Rollback()
-
 	if instanceCreate.ProjectID != nil {
 		if common.IsDefaultProject(instanceCreate.Workspace, *instanceCreate.ProjectID) {
 			return nil, errors.Errorf("default project %s cannot own an instance", *instanceCreate.ProjectID)
@@ -647,6 +646,9 @@ func (s *Store) DeleteInstance(ctx context.Context, workspace string, resourceID
 		return errors.Wrap(err, "failed to begin transaction")
 	}
 	defer tx.Rollback()
+	if err := acquireInstancePurgeLock(ctx, tx, resourceID); err != nil {
+		return errors.Wrapf(err, "failed to lock instance purge fence for %s", resourceID)
+	}
 
 	// Delete query history before locking database-scoped rows to preserve the
 	// canonical sibling-branch order.

--- a/backend/store/plan_check_run.go
+++ b/backend/store/plan_check_run.go
@@ -423,9 +423,12 @@ func (s *Store) ClaimAvailablePlanCheckRuns(ctx context.Context) ([]*ClaimedPlan
 		UPDATE plan_check_run
 		SET status = ?, updated_at = now()
 		WHERE (project, id) IN (
-			SELECT project, id FROM plan_check_run
-			WHERE status = ?
-			FOR UPDATE SKIP LOCKED
+			SELECT plan_check_run.project, plan_check_run.id
+			FROM plan_check_run
+			JOIN project ON project.resource_id = plan_check_run.project
+			WHERE plan_check_run.status = ?
+			  AND project.deleted = FALSE
+			FOR UPDATE OF plan_check_run SKIP LOCKED
 		)
 		RETURNING id, project, plan_id, COALESCE((result->>'approvalInputVersion')::bigint, 0)
 	`, PlanCheckRunStatusRunning, PlanCheckRunStatusAvailable)

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -41,6 +41,45 @@ func TestClaimAvailablePlanCheckRunsDefaultsMissingApprovalInputVersion(t *testi
 	require.EqualValues(t, 0, claimed[0].ApprovalInputVersion)
 }
 
+func TestClaimAvailablePlanCheckRunsSkipsArchivedProjects(t *testing.T) {
+	ctx := context.Background()
+	s := setupPlanCheckRunVersionStore(ctx, t)
+
+	plan, err := s.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      "archived plan",
+		Config:    &storepb.PlanConfig{ApprovalInputVersion: 1},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	created, err := s.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: "project-a",
+		PlanUID:   plan.UID,
+		Result:    &storepb.PlanCheckRunResult{ApprovalInputVersion: 1},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	archived := true
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+	claimed, err := s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Empty(t, claimed)
+
+	archived = false
+	require.NoError(t, s.UpdateProjects(ctx, &store.UpdateProjectMessage{
+		ResourceID: "project-a",
+		Workspace:  "default",
+		Delete:     &archived,
+	}))
+	claimed, err = s.ClaimAvailablePlanCheckRuns(ctx)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+}
+
 func TestUpdatePlanCheckRunIfApprovalInputVersionSkipsStaleWorkerOnRefreshedRow(t *testing.T) {
 	ctx := context.Background()
 	s := setupPlanCheckRunVersionStore(ctx, t)

--- a/backend/store/project.go
+++ b/backend/store/project.go
@@ -217,7 +217,6 @@ func (s *Store) CreateProject(ctx context.Context, create *ProjectMessage, creat
 		return nil, err
 	}
 	defer tx.Rollback()
-
 	project := &ProjectMessage{
 		ResourceID: create.ResourceID,
 		Workspace:  create.Workspace,
@@ -348,6 +347,9 @@ func (s *Store) DeleteProject(ctx context.Context, workspace string, resourceID 
 		return errors.Wrap(err, "failed to begin transaction")
 	}
 	defer tx.Rollback()
+	if err := acquireProjectPurgeLock(ctx, tx, resourceID); err != nil {
+		return errors.Wrapf(err, "failed to lock project purge fence for %s", resourceID)
+	}
 
 	// Delete query history before locking database-scoped rows to preserve the
 	// canonical sibling-branch order.

--- a/backend/store/query_history.go
+++ b/backend/store/query_history.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"time"
 
@@ -95,15 +96,22 @@ func (s *Store) CreateQueryHistory(ctx context.Context, create *QueryHistoryMess
 		payload,
 	)
 
-	sql, args, err := q.ToSQL()
+	query, args, err := q.ToSQL()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}
 
-	if err := s.GetDB().QueryRowContext(ctx, sql, args...).Scan(
-		&create.ResourceID,
-		&create.CreatedAt,
-	); err != nil {
+	_, instanceID, databaseName, err := common.GetDatabaseResourceName(create.Database)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid query history database %q", create.Database)
+	}
+	err = s.withDatabasePurgeFence(ctx, instanceID, databaseName, create.Project, nil, func(tx *sql.Tx, _ *databaseOwnership) error {
+		return tx.QueryRowContext(ctx, query, args...).Scan(
+			&create.ResourceID,
+			&create.CreatedAt,
+		)
+	})
+	if err != nil {
 		return nil, err
 	}
 

--- a/backend/store/revision.go
+++ b/backend/store/revision.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/pkg/errors"
@@ -167,12 +168,15 @@ func (s *Store) CreateRevision(ctx context.Context, revision *RevisionMessage) (
 		return nil, errors.Wrapf(err, "failed to marshal revision payload")
 	}
 
-	if err := s.GetDB().QueryRowContext(ctx, query,
-		revision.InstanceID,
-		revision.DatabaseName,
-		revision.Version,
-		p,
-	).Scan(&revision.ResourceID, &revision.CreatedAt); err != nil {
+	err = s.withDatabasePurgeFence(ctx, revision.InstanceID, revision.DatabaseName, "", nil, func(tx *sql.Tx, _ *databaseOwnership) error {
+		return tx.QueryRowContext(ctx, query,
+			revision.InstanceID,
+			revision.DatabaseName,
+			revision.Version,
+			p,
+		).Scan(&revision.ResourceID, &revision.CreatedAt)
+	})
+	if err != nil {
 		return nil, errors.Wrapf(err, "failed to query and scan")
 	}
 

--- a/backend/store/sync_history.go
+++ b/backend/store/sync_history.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"time"
 
@@ -93,7 +94,10 @@ func (s *Store) CreateSyncHistory(ctx context.Context, instanceID, databaseName 
 	}
 
 	var resourceID string
-	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(&resourceID); err != nil {
+	err = s.withDatabasePurgeFence(ctx, instanceID, databaseName, "", nil, func(tx *sql.Tx, _ *databaseOwnership) error {
+		return tx.QueryRowContext(ctx, query, args...).Scan(&resourceID)
+	})
+	if err != nil {
 		return "", errors.Wrapf(err, "failed to insert")
 	}
 

--- a/backend/store/task.go
+++ b/backend/store/task.go
@@ -19,11 +19,14 @@ type TaskMessage struct {
 	ID int64
 
 	// Related fields
-	ProjectID    string
-	PlanID       int64
-	InstanceID   string
-	Environment  string // The environment ID (was stage_id). Could be empty if the task does not have an environment.
-	DatabaseName *string
+	ProjectID  string
+	PlanID     int64
+	InstanceID string
+	// InstanceProjectID is the owning project for a Project Instance. Nil means
+	// the task targets a Workspace Instance.
+	InstanceProjectID *string
+	Environment       string // The environment ID (was stage_id). Could be empty if the task does not have an environment.
+	DatabaseName      *string
 
 	// Domain specific fields
 	Type    storepb.Task_Type
@@ -274,6 +277,7 @@ func (*Store) listTasksImpl(ctx context.Context, txn *sql.Tx, find *TaskFind) ([
 			task.project,
 			task.plan_id,
 			task.instance,
+			instance.project,
 			task.db_name,
 			task.environment,
 			COALESCE(latest_task_run.status, ?) AS latest_task_run_status,
@@ -282,6 +286,7 @@ func (*Store) listTasksImpl(ctx context.Context, txn *sql.Tx, find *TaskFind) ([
 			latest_task_run.updated_at,
 			latest_task_run.run_at
 		FROM task
+		JOIN instance ON instance.resource_id = task.instance
 		LEFT JOIN LATERAL (
 			SELECT
 				task_run.status,
@@ -354,6 +359,7 @@ func (*Store) listTasksImpl(ctx context.Context, txn *sql.Tx, find *TaskFind) ([
 			&task.ProjectID,
 			&task.PlanID,
 			&task.InstanceID,
+			&task.InstanceProjectID,
 			&task.DatabaseName,
 			&task.Environment,
 			&latestTaskRunStatusString,

--- a/backend/store/task_run.go
+++ b/backend/store/task_run.go
@@ -238,9 +238,11 @@ func (s *Store) ClaimAvailableTaskRuns(ctx context.Context, replicaID string) ([
 		UPDATE task_run
 		SET status = ?, updated_at = now(), replica_id = ?
 		WHERE (project, id) IN (
-			SELECT task_run.project, task_run.id FROM task_run
-			WHERE task_run.status = ?
-			FOR UPDATE SKIP LOCKED
+			SELECT task_run.project, task_run.id
+			FROM task_run
+			JOIN project ON project.resource_id = task_run.project
+			WHERE task_run.status = ? AND project.deleted = FALSE
+			FOR UPDATE OF task_run SKIP LOCKED
 		)
 		RETURNING id, task_id, project
 	`, storepb.TaskRun_RUNNING.String(), replicaID, storepb.TaskRun_AVAILABLE.String())

--- a/backend/store/task_run_lock_order_test.go
+++ b/backend/store/task_run_lock_order_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -10,6 +11,34 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/store"
 )
+
+func TestClaimAvailableTaskRunsSkipsDeletedProjects(t *testing.T) {
+	fixture := newProjectDeletionLockOrderFixture(t, `
+		INSERT INTO instance (resource_id, workspace) VALUES ('instance-a', 'default');
+		INSERT INTO plan (id, creator, project, name, description)
+			VALUES (101, 'creator@example.com', 'project-a', 'Plan A', '');
+		INSERT INTO task (id, project, plan_id, instance, type)
+			VALUES (101, 'project-a', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
+		INSERT INTO task_run (id, project, task_id, attempt, status)
+			VALUES (101, 'project-a', 101, 0, 'AVAILABLE');
+	`)
+
+	claimed, err := fixture.store.ClaimAvailableTaskRuns(fixture.ctx, "replica-a")
+	require.Empty(t, claimed)
+	require.NoError(t, err)
+
+	var status string
+	require.NoError(t, fixture.db.QueryRowContext(fixture.ctx,
+		"SELECT status FROM task_run WHERE project = 'project-a' AND id = 101",
+	).Scan(&status))
+	require.Equal(t, "AVAILABLE", status)
+
+	var replicaID sql.NullString
+	require.NoError(t, fixture.db.QueryRowContext(fixture.ctx,
+		"SELECT replica_id FROM task_run WHERE project = 'project-a' AND id = 101",
+	).Scan(&replicaID))
+	require.False(t, replicaID.Valid)
+}
 
 func TestCreatePendingTaskRunsDoesNotDeadlockWithProjectDeletion(t *testing.T) {
 	fixture := newProjectDeletionLockOrderFixture(t, `

--- a/backend/tests/cross_project_delete_test.go
+++ b/backend/tests/cross_project_delete_test.go
@@ -38,8 +38,10 @@ func TestCollisionDeleteProjectCascade(t *testing.T) {
 	a.Greater(len(beforeB.Plans), 0, "project B should have plans")
 	a.Greater(len(beforeB.Issues), 0, "project B should have issues")
 
-	// DeleteProject with Purge=true handles both soft-delete and hard-delete
-	// (cascade) in one gRPC call.
+	// Project purge is an explicit archive-then-purge lifecycle.
+	_, err = ctl.projectServiceClient.DeleteProject(ctx,
+		connect.NewRequest(&v1pb.DeleteProjectRequest{Name: fixture.ProjectA.Name}))
+	a.NoError(err)
 	_, err = ctl.projectServiceClient.DeleteProject(ctx,
 		connect.NewRequest(&v1pb.DeleteProjectRequest{
 			Name:  fixture.ProjectA.Name,
@@ -53,6 +55,21 @@ func TestCollisionDeleteProjectCascade(t *testing.T) {
 	_, err = ctl.projectServiceClient.GetProject(ctx,
 		connect.NewRequest(&v1pb.GetProjectRequest{Name: fixture.ProjectA.Name}))
 	a.Error(err, "project A should be gone after purge; GetProject should fail")
+	auditLogs, err := ctl.auditLogServiceClient.SearchAuditLogs(ctx,
+		connect.NewRequest(&v1pb.SearchAuditLogsRequest{
+			Parent: "projects/-",
+			Filter: `method == "/bytebase.v1.ProjectService/DeleteProject"`,
+		}))
+	a.NoError(err)
+	a.NotEmpty(auditLogs.Msg.AuditLogs, "project audit logs must survive project purge under retention policy")
+	foundProjectAudit := false
+	for _, auditLog := range auditLogs.Msg.AuditLogs {
+		if auditLog.Resource == fixture.ProjectA.Name {
+			foundProjectAudit = true
+			break
+		}
+	}
+	a.True(foundProjectAudit, "purged project audit logs retain canonical names as text")
 
 	afterB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
 	assertProjectUnchanged(t, beforeB, afterB, "project B after project A deleted")

--- a/backend/tests/cross_project_read_test.go
+++ b/backend/tests/cross_project_read_test.go
@@ -1,0 +1,59 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+)
+
+func TestCollisionListDatabasesProjectIsolation(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	fixture := setupCollidingProjects(ctx, t, ctl)
+
+	list := func(project *v1pb.Project) []*v1pb.Database {
+		t.Helper()
+		response, err := ctl.databaseServiceClient.ListDatabases(ctx, connect.NewRequest(&v1pb.ListDatabasesRequest{
+			Parent:   project.Name,
+			PageSize: 1000,
+		}))
+		a.NoError(err)
+		return response.Msg.Databases
+	}
+
+	databasesA := list(fixture.ProjectA)
+	a.NotEmpty(databasesA)
+	a.Contains(databaseNames(databasesA), fixture.DatabaseA.Name)
+	a.NotContains(databaseNames(databasesA), fixture.DatabaseB.Name)
+	for _, database := range databasesA {
+		a.Equal(fixture.ProjectA.Name, database.Project)
+	}
+
+	databasesB := list(fixture.ProjectB)
+	a.NotEmpty(databasesB)
+	a.Contains(databaseNames(databasesB), fixture.DatabaseB.Name)
+	a.NotContains(databaseNames(databasesB), fixture.DatabaseA.Name)
+	for _, database := range databasesB {
+		a.Equal(fixture.ProjectB.Name, database.Project)
+	}
+}
+
+func databaseNames(databases []*v1pb.Database) []string {
+	names := make([]string, 0, len(databases))
+	for _, database := range databases {
+		names = append(names, database.Name)
+	}
+	return names
+}

--- a/backend/tests/project_instance_scheduler_test.go
+++ b/backend/tests/project_instance_scheduler_test.go
@@ -1,0 +1,96 @@
+package tests
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+)
+
+func TestProjectInstancePlanCheckSchedulingFollowsProjectLifecycle(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	pg, err := provisionPgInstance(ctx, t)
+	a.NoError(err)
+	const databaseID = "bot36_scheduler_database"
+	createPgDatabase(t, pg, databaseID)
+
+	instance := createProjectInstanceTestInstance(ctx, t, ctl, &ctl.project.Name, "bot36-scheduler-instance", "scheduler instance", pg)
+	_, err = ctl.instanceServiceClient.SyncInstance(ctx, connect.NewRequest(&v1pb.SyncInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	databaseName := fmt.Sprintf("%s/databases/%s", instance.Name, databaseID)
+	_, err = ctl.databaseServiceClient.SyncDatabase(ctx, connect.NewRequest(&v1pb.SyncDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+
+	sheet, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet:  &v1pb.Sheet{Content: []byte("SELECT 1;")},
+	}))
+	a.NoError(err)
+	plan, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan: &v1pb.Plan{Specs: []*v1pb.Plan_Spec{{
+			Id: uuid.NewString(),
+			Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+				Targets: []string{databaseName},
+				Sheet:   sheet.Msg.Name,
+			}},
+		}}},
+	}))
+	a.NoError(err)
+	projectID, planID, err := common.GetProjectIDPlanID(plan.Msg.Name)
+	a.NoError(err)
+	planCheckName := plan.Msg.Name + "/planCheckRun"
+	a.Eventually(func() bool {
+		response, err := ctl.planServiceClient.GetPlanCheckRun(ctx, connect.NewRequest(&v1pb.GetPlanCheckRunRequest{Name: planCheckName}))
+		return err == nil && (response.Msg.Status == v1pb.PlanCheckRun_DONE || response.Msg.Status == v1pb.PlanCheckRun_FAILED)
+	}, 30*time.Second, 100*time.Millisecond, "initial plan check should finish before testing the archive gate")
+
+	_, err = ctl.projectServiceClient.DeleteProject(ctx, connect.NewRequest(&v1pb.DeleteProjectRequest{Name: ctl.project.Name}))
+	a.NoError(err)
+
+	metadataDB, err := sql.Open("pgx", ctl.profile.PgURL)
+	a.NoError(err)
+	defer metadataDB.Close()
+	result, err := metadataDB.ExecContext(ctx, `
+		UPDATE plan_check_run
+		SET status = 'AVAILABLE', updated_at = now()
+		WHERE project = $1 AND plan_id = $2
+	`, projectID, planID)
+	a.NoError(err)
+	rowsAffected, err := result.RowsAffected()
+	a.NoError(err)
+	a.EqualValues(1, rowsAffected)
+
+	time.Sleep(6 * time.Second)
+	var status string
+	a.NoError(metadataDB.QueryRowContext(ctx, `
+		SELECT status
+		FROM plan_check_run
+		WHERE project = $1 AND plan_id = $2
+	`, projectID, planID).Scan(&status))
+	a.Equal("AVAILABLE", status, "an archived project's plan check must not be claimed")
+
+	_, err = ctl.projectServiceClient.UndeleteProject(ctx, connect.NewRequest(&v1pb.UndeleteProjectRequest{Name: ctl.project.Name}))
+	a.NoError(err)
+	_, err = ctl.planServiceClient.RunPlanChecks(ctx, connect.NewRequest(&v1pb.RunPlanChecksRequest{Name: plan.Msg.Name}))
+	a.NoError(err)
+	a.Eventually(func() bool {
+		response, err := ctl.planServiceClient.GetPlanCheckRun(ctx, connect.NewRequest(&v1pb.GetPlanCheckRunRequest{Name: planCheckName}))
+		return err == nil && (response.Msg.Status == v1pb.PlanCheckRun_DONE || response.Msg.Status == v1pb.PlanCheckRun_FAILED)
+	}, 30*time.Second, 100*time.Millisecond, "restoring the project should allow plan check scheduling to resume")
+}

--- a/backend/tests/project_instance_test.go
+++ b/backend/tests/project_instance_test.go
@@ -50,6 +50,15 @@ func TestProjectInstanceCoreBehavior(t *testing.T) {
 	a.NoError(err)
 	a.Equal(databaseName, database.Msg.Name)
 	a.Equal(ctl.project.Name, database.Msg.Project)
+	_, err = ctl.databaseServiceClient.SyncDatabase(ctx, connect.NewRequest(&v1pb.SyncDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+	query, err := ctl.sqlServiceClient.Query(ctx, connect.NewRequest(&v1pb.QueryRequest{
+		Name:      databaseName,
+		Statement: "SELECT 1;",
+		Limit:     10,
+	}))
+	a.NoError(err)
+	a.Len(query.Msg.Results, 1)
 
 	for _, name := range []string{
 		projectInstance.Name + "/databases/missing",
@@ -198,6 +207,47 @@ func TestProjectInstanceCoreBehavior(t *testing.T) {
 	archivedProjectInstance, err := ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: projectInstance.Name}))
 	a.NoError(err)
 	a.Equal(v1pb.State_DELETED, archivedProjectInstance.Msg.State)
+	_, err = ctl.instanceServiceClient.DeleteInstance(ctx, connect.NewRequest(&v1pb.DeleteInstanceRequest{
+		Name:  projectInstance.Name,
+		Purge: true,
+	}))
+	a.NoError(err)
+	_, err = ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: projectInstance.Name}))
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
+	_, err = ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: databaseName}))
+	a.Error(err)
+
+	histories, err := ctl.queryHistoryServiceClient.SearchQueryHistories(ctx, connect.NewRequest(&v1pb.SearchQueryHistoriesRequest{
+		Parent:   ctl.project.Name,
+		PageSize: 1000,
+	}))
+	a.NoError(err)
+	for _, history := range histories.Msg.QueryHistories {
+		a.NotEqual(databaseName, history.Database, "direct instance purge must remove its query history")
+	}
+	auditLogs, err := ctl.auditLogServiceClient.SearchAuditLogs(ctx, connect.NewRequest(&v1pb.SearchAuditLogsRequest{
+		Parent: ctl.project.Name,
+		Filter: `method == "/bytebase.v1.InstanceService/DeleteInstance"`,
+	}))
+	a.NoError(err)
+	foundCanonicalAuditResource := false
+	for _, auditLog := range auditLogs.Msg.AuditLogs {
+		if auditLog.Resource == projectInstance.Name {
+			foundCanonicalAuditResource = true
+			break
+		}
+	}
+	a.True(foundCanonicalAuditResource, "audit logs must retain the canonical instance name after purge")
+
+	physicalDatabaseCount := 0
+	a.NoError(pg.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM pg_database WHERE datname = $1", databaseID).Scan(&physicalDatabaseCount))
+	a.Equal(1, physicalDatabaseCount, "Bytebase purge must not delete the physical database")
+	reused := createProjectInstanceTestInstance(ctx, t, ctl, &projectParent, projectID, "reused project instance", pg)
+	a.Equal(projectInstance.Name, reused.Name)
+	reusedDatabase, err := ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+	a.Equal(databaseName, reusedDatabase.Msg.Name)
 
 	// A database-free project instance can still be archived and restored normally.
 	_, err = ctl.instanceServiceClient.DeleteInstance(ctx, connect.NewRequest(&v1pb.DeleteInstanceRequest{Name: allowMissingName}))
@@ -208,6 +258,24 @@ func TestProjectInstanceCoreBehavior(t *testing.T) {
 	restored, err := ctl.instanceServiceClient.UndeleteInstance(ctx, connect.NewRequest(&v1pb.UndeleteInstanceRequest{Name: allowMissingName}))
 	a.NoError(err)
 	a.Equal(v1pb.State_ACTIVE, restored.Msg.State)
+
+	// Project archival hides descendants without changing their individual
+	// lifecycle state. Restoration reveals the same resources again.
+	_, err = ctl.projectServiceClient.DeleteProject(ctx, connect.NewRequest(&v1pb.DeleteProjectRequest{Name: ctl.project.Name}))
+	a.NoError(err)
+	_, err = ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: reused.Name}))
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
+	_, err = ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: databaseName}))
+	a.Error(err)
+	_, err = ctl.projectServiceClient.UndeleteProject(ctx, connect.NewRequest(&v1pb.UndeleteProjectRequest{Name: ctl.project.Name}))
+	a.NoError(err)
+	restoredInstance, err := ctl.instanceServiceClient.GetInstance(ctx, connect.NewRequest(&v1pb.GetInstanceRequest{Name: reused.Name}))
+	a.NoError(err)
+	a.Equal(v1pb.State_ACTIVE, restoredInstance.Msg.State)
+	restoredDatabase, err := ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+	a.Equal(databaseName, restoredDatabase.Msg.Name)
 }
 
 func TestBatchUpdateProjectInstanceAllowMissing(t *testing.T) {

--- a/backend/tests/project_instance_workflow_test.go
+++ b/backend/tests/project_instance_workflow_test.go
@@ -1,0 +1,155 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+)
+
+func TestProjectInstanceWorkflowTargets(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	pg, err := provisionPgInstance(ctx, t)
+	a.NoError(err)
+	const databaseID = "bot36_workflow_database"
+	createPgDatabase(t, pg, databaseID)
+
+	otherProject := createProjectForProjectInstanceTest(ctx, t, ctl, "bot36-other-project")
+	instance := createProjectInstanceTestInstance(ctx, t, ctl, &ctl.project.Name, "bot36-project-instance", "project instance", pg)
+	_, err = ctl.instanceServiceClient.SyncInstance(ctx, connect.NewRequest(&v1pb.SyncInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+
+	databaseName := fmt.Sprintf("%s/databases/%s", instance.Name, databaseID)
+	database, err := ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+	a.Equal(databaseName, database.Msg.Name)
+
+	sheet, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet:  &v1pb.Sheet{Content: []byte("SELECT 1;")},
+	}))
+	a.NoError(err)
+
+	changeSpec := func(target string) *v1pb.Plan_Spec {
+		return &v1pb.Plan_Spec{
+			Id: uuid.NewString(),
+			Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+				ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+					Targets: []string{target},
+					Sheet:   sheet.Msg.Name,
+				},
+			},
+		}
+	}
+
+	plan, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan:   &v1pb.Plan{Specs: []*v1pb.Plan_Spec{changeSpec(databaseName)}},
+	}))
+	a.NoError(err)
+	a.Equal(databaseName, plan.Msg.Specs[0].GetChangeDatabaseConfig().Targets[0])
+
+	updated, err := ctl.planServiceClient.UpdatePlan(ctx, connect.NewRequest(&v1pb.UpdatePlanRequest{
+		Plan: &v1pb.Plan{
+			Name:  plan.Msg.Name,
+			Specs: []*v1pb.Plan_Spec{changeSpec(databaseName)},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"specs"}},
+	}))
+	a.NoError(err)
+	a.Equal(databaseName, updated.Msg.Specs[0].GetChangeDatabaseConfig().Targets[0])
+	crossProjectDatabaseName := fmt.Sprintf("%s/instances/%s/databases/%s", otherProject.Name, "bot36-project-instance", databaseID)
+	_, err = ctl.planServiceClient.UpdatePlan(ctx, connect.NewRequest(&v1pb.UpdatePlanRequest{
+		Plan: &v1pb.Plan{
+			Name:  plan.Msg.Name,
+			Specs: []*v1pb.Plan_Spec{changeSpec(crossProjectDatabaseName)},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"specs"}},
+	}))
+	a.Error(err)
+	a.Equal(connect.CodeInvalidArgument, connect.CodeOf(err))
+	workspaceAliasDatabase := fmt.Sprintf("instances/%s/databases/%s", "bot36-project-instance", databaseID)
+	_, err = ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan:   &v1pb.Plan{Specs: []*v1pb.Plan_Spec{changeSpec(workspaceAliasDatabase)}},
+	}))
+	a.Error(err)
+
+	_, err = ctl.issueServiceClient.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+		Parent: ctl.project.Name,
+		Issue: &v1pb.Issue{
+			Title: "project instance workflow target",
+			Type:  v1pb.Issue_DATABASE_CHANGE,
+			Plan:  plan.Msg.Name,
+		},
+	}))
+	a.NoError(err)
+	rollout, err := ctl.rolloutServiceClient.CreateRollout(ctx, connect.NewRequest(&v1pb.CreateRolloutRequest{Parent: plan.Msg.Name}))
+	a.NoError(err)
+	a.Equal(databaseName, rollout.Msg.Stages[0].Tasks[0].Target)
+
+	_, err = ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: otherProject.Name,
+		Plan:   &v1pb.Plan{Specs: []*v1pb.Plan_Spec{changeSpec(databaseName)}},
+	}))
+	a.Error(err)
+	a.Equal(connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	createSpec := func(target string) *v1pb.Plan_Spec {
+		return &v1pb.Plan_Spec{
+			Id: uuid.NewString(),
+			Config: &v1pb.Plan_Spec_CreateDatabaseConfig{
+				CreateDatabaseConfig: &v1pb.Plan_CreateDatabaseConfig{
+					Target:       target,
+					Database:     "bot36_create_database",
+					CharacterSet: "UTF8",
+					Collation:    "en_US.UTF-8",
+					Owner:        "postgres",
+				},
+			},
+		}
+	}
+	created, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan:   &v1pb.Plan{Specs: []*v1pb.Plan_Spec{createSpec(instance.Name)}},
+	}))
+	a.NoError(err)
+	a.Equal(instance.Name, created.Msg.Specs[0].GetCreateDatabaseConfig().Target)
+	_, err = ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan:   &v1pb.Plan{Specs: []*v1pb.Plan_Spec{createSpec("instances/bot36-project-instance")}},
+	}))
+	a.Error(err)
+	_, err = ctl.issueServiceClient.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+		Parent: ctl.project.Name,
+		Issue: &v1pb.Issue{
+			Title: "project instance create database target",
+			Type:  v1pb.Issue_DATABASE_CHANGE,
+			Plan:  created.Msg.Name,
+		},
+	}))
+	a.NoError(err)
+	createRollout, err := ctl.rolloutServiceClient.CreateRollout(ctx, connect.NewRequest(&v1pb.CreateRolloutRequest{Parent: created.Msg.Name}))
+	a.NoError(err)
+	a.Equal(instance.Name, createRollout.Msg.Stages[0].Tasks[0].Target)
+
+	_, err = ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: otherProject.Name,
+		Plan:   &v1pb.Plan{Specs: []*v1pb.Plan_Spec{createSpec(instance.Name)}},
+	}))
+	a.Error(err)
+	a.Equal(connect.CodeInvalidArgument, connect.CodeOf(err))
+}


### PR DESCRIPTION
## Summary
- preserve project-scoped canonical instance and database names across plans, releases, review, rollout, interactive SQL, worksheets, access grants, and background runners
- enforce project and instance archive/restore behavior, scheduler gating, and direct/project purge boundaries
- serialize descendant writers against project and instance purge with deterministic PostgreSQL lock-order coverage
- add public workflow, lifecycle, audit-retention, ID-reuse, scheduler, and cross-project collision tests

## Testing
- golangci-lint run --allow-parallel-runners
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
- go test -v -count=1 ./backend/tests/ -run "^(TestClaim|TestCollision)" -timeout 5m
- targeted API, store, runner, lifecycle, workflow, and concurrency test suites
- go test ./... -count=1 -timeout 15m (two unrelated Docker port-discovery flakes; both exact tests passed on isolated rerun)

Linear: BOT-36