### PR TITLE
fix: persist streaming audits before response

### DIFF
--- a/backend/api/v1/audit.go
+++ b/backend/api/v1/audit.go
@@ -44,6 +44,11 @@ type AuditInterceptor struct {
 	store   *store.Store
 	secret  string
 	profile *config.Profile
+
+	// createAuditLogFunc, when set, replaces createAuditLog for streaming sends.
+	// Test-only seam that lets unit tests observe audit persistence ordering
+	// without a database.
+	createAuditLogFunc func(context.Context, *auditEntry) error
 }
 
 // NewAuditInterceptor returns a new v1 API audit interceptor.
@@ -145,11 +150,9 @@ func (c *auditConnectStreamingConn) Receive(msg any) error {
 }
 
 func (c *auditConnectStreamingConn) Send(resp any) error {
-	err := c.StreamingHandlerConn.Send(resp)
-	if err != nil {
-		return err
-	}
-	// Create audit log for each message pair
+	// Create the audit log for each message pair before delivering the
+	// response, so a client that observes a successful response can rely on
+	// the audit entry already being durably persisted.
 	if c.curRequest != nil {
 		entry := &auditEntry{
 			request:  c.curRequest,
@@ -159,11 +162,15 @@ func (c *auditConnectStreamingConn) Send(resp any) error {
 			peerAddr: c.Peer().Addr,
 			latency:  time.Since(c.startTime),
 		}
-		if auditErr := c.interceptor.createAuditLog(c.ctx, entry); auditErr != nil {
+		writeAuditLog := c.interceptor.createAuditLog
+		if c.interceptor.createAuditLogFunc != nil {
+			writeAuditLog = c.interceptor.createAuditLogFunc
+		}
+		if auditErr := writeAuditLog(c.ctx, entry); auditErr != nil {
 			return auditErr
 		}
 	}
-	return nil
+	return c.StreamingHandlerConn.Send(resp)
 }
 
 // auditEntry bundles the per-request data needed to write an audit log.

--- a/backend/api/v1/audit_test.go
+++ b/backend/api/v1/audit_test.go
@@ -4,15 +4,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
+	"net/http"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
 	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/generated-go/v1/v1connect"
 )
 
 // TestLogAuditToStdoutFormat is a contract test for the structured JSON fields
@@ -170,4 +175,89 @@ func TestAuditRedactsCredentials(t *testing.T) {
 			"issued Bytebase access token must never be logged — anyone with "+
 				"audit read access could use it as a valid API token")
 	})
+}
+
+// TestStreamingAuditPersistedBeforeSend pins the streaming audit contract: a
+// client must not observe a successful streaming response before the
+// corresponding audit entry is durably persisted. Regression test for the
+// TestAdminExecuteAuditLog flake where the audit insert raced the
+// client-visible response.
+func TestStreamingAuditPersistedBeforeSend(t *testing.T) {
+	t.Run("audit persisted before response delivered", func(t *testing.T) {
+		a := require.New(t)
+		recorder := &auditOrderRecorder{}
+		interceptor := &AuditInterceptor{
+			createAuditLogFunc: func(_ context.Context, _ *auditEntry) error {
+				recorder.record("audit")
+				return nil
+			},
+		}
+		handler := interceptor.WrapStreamingHandler(func(_ context.Context, conn connect.StreamingHandlerConn) error {
+			if err := conn.Receive(&v1pb.AdminExecuteRequest{}); err != nil {
+				return err
+			}
+			return conn.Send(&v1pb.AdminExecuteResponse{})
+		})
+
+		ctx := context.WithValue(context.Background(), common.AuthContextKey, &common.AuthContext{Audit: true})
+		a.NoError(handler(ctx, &auditRecorderConn{recorder: recorder}))
+
+		a.Equal([]string{"audit", "send"}, recorder.events,
+			"audit entry must be durably persisted before the response becomes observable to the client")
+	})
+
+	t.Run("audit failure blocks response delivery", func(t *testing.T) {
+		a := require.New(t)
+		recorder := &auditOrderRecorder{}
+		persistErr := errors.New("persist failed")
+		interceptor := &AuditInterceptor{
+			createAuditLogFunc: func(_ context.Context, _ *auditEntry) error {
+				recorder.record("audit")
+				return persistErr
+			},
+		}
+		handler := interceptor.WrapStreamingHandler(func(_ context.Context, conn connect.StreamingHandlerConn) error {
+			if err := conn.Receive(&v1pb.AdminExecuteRequest{}); err != nil {
+				return err
+			}
+			return conn.Send(&v1pb.AdminExecuteResponse{})
+		})
+
+		ctx := context.WithValue(context.Background(), common.AuthContextKey, &common.AuthContext{Audit: true})
+		a.ErrorIs(handler(ctx, &auditRecorderConn{recorder: recorder}), persistErr)
+		a.Equal([]string{"audit"}, recorder.events,
+			"response must not be delivered when the audit entry cannot be persisted")
+	})
+}
+
+// auditOrderRecorder records the order of audit persistence ("audit") and
+// underlying stream delivery ("send") events.
+type auditOrderRecorder struct {
+	events []string
+}
+
+func (r *auditOrderRecorder) record(event string) {
+	r.events = append(r.events, event)
+}
+
+// auditRecorderConn is a connect.StreamingHandlerConn fake whose Send stands
+// in for the moment the response becomes observable to the client.
+type auditRecorderConn struct {
+	connect.StreamingHandlerConn
+	recorder *auditOrderRecorder
+}
+
+func (*auditRecorderConn) Spec() connect.Spec {
+	return connect.Spec{Procedure: v1connect.SQLServiceAdminExecuteProcedure}
+}
+
+func (*auditRecorderConn) Peer() connect.Peer { return connect.Peer{} }
+
+func (*auditRecorderConn) RequestHeader() http.Header { return http.Header{} }
+
+func (*auditRecorderConn) Receive(any) error { return nil }
+
+func (c *auditRecorderConn) Send(any) error {
+	c.recorder.record("send")
+	return nil
 }


### PR DESCRIPTION
## Summary
- persist streaming audit entries before delivering their responses
- withhold the response when audit persistence fails
- add deterministic regression coverage for persistence/send ordering

## Why
Streaming responses were delivered before their audit rows were inserted, allowing an immediate audit search to race the insert and intermittently return no entries. Persisting first makes a successful response imply durable audit evidence.

A server-produced response is now audited before transport delivery. If delivery subsequently fails, the audit record remains as evidence of the attempted response.

## Testing
- gofmt -w backend/api/v1/audit.go backend/api/v1/audit_test.go
- golangci-lint run --allow-parallel-runners
- go test -v -count=1 ./backend/api/v1/ -run ^TestStreamingAuditPersistedBeforeSend$
- go test -v -count=20 ./backend/tests/ -run ^TestAdminExecuteAuditLog$ -timeout 5m
- go test -p=8 -timeout 30m -ldflags "-w -s" -count=1 ./backend/...
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go