### PR TITLE
fix: accept CREATE EXTENSION in PostgreSQL SDL files

### DIFF
--- a/backend/api/v1/release_service_check.go
+++ b/backend/api/v1/release_service_check.go
@@ -843,9 +843,22 @@ var commonAllowedSDLStatementTypes = map[storepb.StatementType]bool{
 // SDL allowlist. MySQL declarative dumps also emit scheduled events as CREATE EVENT —
 // a MySQL-only object with no PostgreSQL analog (the pg parser can never classify one,
 // but keying it per engine documents the intent and keeps other engines' gates exact).
+//
+// CREATE EXTENSION is the PostgreSQL-only counterpart and must be declarable, because an
+// extension is the one object whose declaration the differ cannot infer. The SDL dump
+// emits one per installed extension (pg writeExtension) while deliberately omitting the
+// extension's OWN objects (synced with SkipDump, from pg_depend deptype='e'). Rejecting
+// the statement forced users to delete the line, which left the extension declared on the
+// source side of the diff only — omni materializes a bundled extension's functions when it
+// loads CREATE EXTENSION, so the differ saw them as undeclared orphans and emitted DROP
+// FUNCTION, which PostgreSQL refuses (SQLSTATE 2BP01). Accepting it makes both sides of
+// the diff agree and makes Export Schema output valid SDL.
 var extraAllowedSDLStatementTypesByEngine = map[storepb.Engine]map[storepb.StatementType]bool{
 	storepb.Engine_MYSQL: {
 		storepb.StatementType_CREATE_EVENT: true,
+	},
+	storepb.Engine_POSTGRES: {
+		storepb.StatementType_CREATE_EXTENSION: true,
 	},
 }
 

--- a/backend/api/v1/release_service_check_pg_test.go
+++ b/backend/api/v1/release_service_check_pg_test.go
@@ -1,0 +1,44 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestPostgresSDLAcceptsCreateExtension pins the gate half of the SDL/extension deadlock:
+// the PostgreSQL SDL dump emits CREATE EXTENSION (plus COMMENT ON EXTENSION) for every
+// installed extension, so the release gate must accept both. While CREATE EXTENSION was
+// rejected, Export Schema output was not valid SDL, and the only way to pass the check was
+// to delete the declaration — which left the extension declared on the source side of the
+// diff alone and made the differ emit DROP FUNCTION for the extension's own functions.
+//
+// The PostgreSQL ParseStatements func is registered by the parser/pg package, which
+// release_service_check.go already imports in this package.
+func TestPostgresSDLAcceptsCreateExtension(t *testing.T) {
+	sql := `CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA "public" VERSION '1.3';
+COMMENT ON EXTENSION "pgcrypto" IS 'cryptographic functions';
+CREATE TABLE "public"."users" ("id" integer NOT NULL);
+`
+	stmts, err := base.ParseStatements(storepb.Engine_POSTGRES, sql)
+	require.NoError(t, err)
+
+	got, err := getStatementTypesWithPositionsForEngine(storepb.Engine_POSTGRES, base.ExtractASTs(stmts))
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+
+	require.Equal(t, storepb.StatementType_CREATE_EXTENSION, got[0].Type)
+	require.Equal(t, storepb.StatementType_COMMENT, got[1].Type)
+	require.Equal(t, storepb.StatementType_CREATE_TABLE, got[2].Type)
+	for _, stmt := range got {
+		require.True(t, isAllowedInSDL(storepb.Engine_POSTGRES, stmt.Type), "%s must be allowed in PostgreSQL SDL", stmt.Type)
+	}
+
+	// CREATE EXTENSION stays a PostgreSQL-only overlay: MySQL has no extensions, so its
+	// gate must not widen.
+	require.False(t, isAllowedInSDL(storepb.Engine_MYSQL, storepb.StatementType_CREATE_EXTENSION),
+		"CREATE EXTENSION should be disallowed in MySQL SDL")
+}

--- a/backend/plugin/advisor/code/code.go
+++ b/backend/plugin/advisor/code/code.go
@@ -83,6 +83,7 @@ const (
 	SDLReplaceOperation                       Code = 256
 	StatementDisallowTruncate                 Code = 257
 	StatementExceedMaximumSQLSize             Code = 258
+	SDLUndeclaredExtension                    Code = 259
 
 	// 260 DDL simulation error code.
 	DDLSimulationFailed Code = 260

--- a/backend/plugin/schema/pg/extension_sdl_omni_test.go
+++ b/backend/plugin/schema/pg/extension_sdl_omni_test.go
@@ -1,0 +1,97 @@
+package pg
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+	"github.com/bytebase/bytebase/backend/store/model"
+)
+
+// pgcryptoMetadata is a database carrying an installed extension the way the sync reports
+// one: the extension itself is listed, and the functions it owns arrive with SkipDump set
+// (they are the pg_depend deptype='e' dependents).
+func pgcryptoMetadata() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Extensions: []*storepb.ExtensionMetadata{
+			{Name: "pgcrypto", Schema: "public", Version: "1.3", Description: "cryptographic functions"},
+		},
+		Schemas: []*storepb.SchemaMetadata{
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{Name: "users", Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer"}}},
+				},
+				Functions: []*storepb.FunctionMetadata{
+					{
+						Name:       "armor",
+						Signature:  "armor(bytea)",
+						SkipDump:   true,
+						Definition: "CREATE FUNCTION armor(bytea) RETURNS text LANGUAGE c AS '$libdir/pgcrypto', 'pg_armor';",
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestExtensionSDL_DumpIsRoundTripClean proves the SDL dump of a database with an extension
+// is usable as an SDL file: it declares the extension, omits the objects the extension owns,
+// and diffs against itself to nothing. Before the gate accepted CREATE EXTENSION, feeding
+// Export Schema output back in as SDL failed the check outright.
+func TestExtensionSDL_DumpIsRoundTripClean(t *testing.T) {
+	meta := model.NewDatabaseMetadata(pgcryptoMetadata(), nil, nil, storepb.Engine_POSTGRES, false)
+
+	sdl, err := schema.MetadataToSDL(storepb.Engine_POSTGRES, meta)
+	require.NoError(t, err)
+
+	require.Contains(t, sdl, `CREATE EXTENSION IF NOT EXISTS "pgcrypto"`)
+	require.Contains(t, sdl, "users")
+	require.NotContains(t, sdl, "armor", "extension-owned functions must stay out of the SDL")
+
+	require.Empty(t, strings.TrimSpace(omniSDLMigration(t, sdl, sdl)),
+		"the exported SDL must diff against itself to nothing")
+}
+
+// TestExtensionSDL_DeclaredExtensionProducesNoFunctionDrops covers the differ half of the
+// deadlock. Loading CREATE EXTENSION materializes the bundled extension's functions in the
+// catalog, so the declaration has to be present on BOTH sides for them to cancel out.
+// With it declared, adding a table is the only change — no DROP FUNCTION.
+func TestExtensionSDL_DeclaredExtensionProducesNoFunctionDrops(t *testing.T) {
+	source := `CREATE EXTENSION IF NOT EXISTS "pgcrypto" WITH SCHEMA "public" VERSION '1.3';`
+	target := source + "\n" + `CREATE TABLE "public"."users" ("id" integer NOT NULL);`
+
+	sql := omniSDLMigration(t, source, target)
+
+	require.Contains(t, sql, "users")
+	require.NotContains(t, sql, "DROP FUNCTION",
+		"a declared extension must never yield drops for the functions it owns")
+}
+
+// TestExtensionSDL_UndeclaredExtensionIsAnError pins the guard for the state the reporter
+// was pushed into: an SDL that omits an installed extension used to generate DROP FUNCTION
+// for each of the extension's functions, which PostgreSQL refuses ("cannot drop function
+// armor(bytea) because extension pgcrypto requires it", SQLSTATE 2BP01) — so the rollout
+// could never succeed. The check now fails with an actionable ERROR instead.
+func TestExtensionSDL_UndeclaredExtensionIsAnError(t *testing.T) {
+	current := model.NewDatabaseMetadata(pgcryptoMetadata(), nil, nil, storepb.Engine_POSTGRES, false)
+	userSDL := `CREATE TABLE "public"."users" ("id" integer NOT NULL);`
+
+	advices, err := pgSDLDropAdvices(userSDL, current, "")
+	require.NoError(t, err)
+
+	var found bool
+	for _, advice := range advices {
+		if advice.GetCode() != code.SDLUndeclaredExtension.Int32() {
+			continue
+		}
+		found = true
+		require.Equal(t, storepb.Advice_ERROR, advice.GetStatus())
+		require.Contains(t, advice.GetContent(), `CREATE EXTENSION IF NOT EXISTS "pgcrypto"`)
+	}
+	require.True(t, found, "an installed but undeclared extension must fail the SDL check")
+}

--- a/backend/plugin/schema/pg/sdl_migration_omni.go
+++ b/backend/plugin/schema/pg/sdl_migration_omni.go
@@ -112,6 +112,8 @@ func pgSDLDropAdvices(userSDLText string, currentSchema *model.DatabaseMetadata,
 			advices = append(advices, dropAdvice(fmt.Sprintf("Dropping trigger '%s' on '%s.%s'.", op.ObjectName, op.SchemaName, op.ParentObject)))
 		case catalog.OpDropConstraint:
 			advices = append(advices, dropAdvice(fmt.Sprintf("Dropping constraint from table '%s.%s'.", op.SchemaName, op.ParentObject)))
+		case catalog.OpDropExtension:
+			advices = append(advices, undeclaredExtensionAdvice(op.ObjectName))
 		case catalog.OpAlterFunction:
 			advices = append(advices, replaceAdvice(fmt.Sprintf("Function '%s.%s' definition will be replaced.", op.SchemaName, op.ObjectName)))
 		default:
@@ -119,6 +121,28 @@ func pgSDLDropAdvices(userSDLText string, currentSchema *model.DatabaseMetadata,
 	}
 
 	return advices, nil
+}
+
+// undeclaredExtensionAdvice reports an extension that is installed on the database but
+// absent from the SDL. This is an ERROR, not a warning: the catalog does not track which
+// objects an extension owns, so a plan that drops the extension also drops every object
+// its script materialized, and PostgreSQL refuses those ("cannot drop function armor(bytea)
+// because extension pgcrypto requires it", SQLSTATE 2BP01) — the rollout can never succeed.
+// Failing the check with the one-line fix beats letting the task die mid-transaction.
+func undeclaredExtensionAdvice(name string) *storepb.Advice {
+	return &storepb.Advice{
+		Status: storepb.Advice_ERROR,
+		Code:   code.SDLUndeclaredExtension.Int32(),
+		Title:  "Undeclared extension",
+		Content: fmt.Sprintf(
+			"Extension '%s' is installed on the database but not declared in the SDL.\n\n"+
+				"Add this line to keep it:\n"+
+				"  CREATE EXTENSION IF NOT EXISTS %q;\n\n"+
+				"An undeclared extension makes the differ treat the extension's own functions and "+
+				"types as orphans, and PostgreSQL will not drop them individually. To remove the "+
+				"extension itself, run DROP EXTENSION outside the declarative pipeline.",
+			name, name),
+	}
 }
 
 func dropAdvice(content string) *storepb.Advice {

--- a/backend/plugin/schema/pg/sdl_migration_omni.go
+++ b/backend/plugin/schema/pg/sdl_migration_omni.go
@@ -135,14 +135,13 @@ func undeclaredExtensionAdvice(name string) *storepb.Advice {
 		Code:   code.SDLUndeclaredExtension.Int32(),
 		Title:  "Undeclared extension",
 		Content: fmt.Sprintf(
-			"Extension '%s' is installed on the database but not declared in the SDL.\n\n"+
+			"Extension %s is installed on the database but not declared in the SDL.\n\n"+
 				"Add this line to keep it:\n"+
-				"  CREATE EXTENSION IF NOT EXISTS %q;\n\n"+
+				"  CREATE EXTENSION IF NOT EXISTS %s;\n\n"+
 				"An undeclared extension makes the differ treat the extension's own functions and "+
 				"types as orphans, and PostgreSQL will not drop them individually. To remove the "+
 				"extension itself, run DROP EXTENSION outside the declarative pipeline.",
-			name, name),
-	}
+			wtQuoteIdent(name), wtQuoteIdent(name))
 }
 
 func dropAdvice(content string) *storepb.Advice {


### PR DESCRIPTION
Fixes #21111

## What was broken

A PostgreSQL database with an installed extension could not be managed in declarative (SDL) mode at all. The two halves of the feature contradicted each other, and there was no third configuration:

1. **`Export Schema` emitted invalid SDL.** The dump writes `CREATE EXTENSION` for every installed extension (`get_database_definition.go` `writeExtension`), but `CREATE_EXTENSION` was missing from the SDL statement-type allowlist — so feeding Bytebase's own export back in as an SDL file failed `check` with *"Statement type 'CREATE_EXTENSION' is not allowed in SDL files"*.
2. **Deleting the declaration to pass the check broke the differ.** The plan then emitted `DROP FUNCTION` for each of the extension's functions, which PostgreSQL refuses: `cannot drop function armor(bytea) because extension pgcrypto requires it (SQLSTATE 2BP01)`. The transaction rolls back, so nothing is damaged, but the rollout can never succeed.

## Root cause

Both halves come from one asymmetry.

The sync already excludes extension-owned objects correctly — `getExtensionDepend` reads `pg_depend` `deptype = 'e'` and marks those functions/types `SkipDump` (`backend/plugin/db/pg/sync.go`), and `getSDLFormat` honors it. So the extension's *members* never reach the SDL; only the `CREATE EXTENSION` line does.

Both sides of the diff are loaded through `catalog.LoadSDL`, and omni's `CreateExtension` executes a **bundled DDL script** for the extensions it knows (pgcrypto, uuid-ossp, citext, hstore and a dozen more), materializing their functions as ordinary catalog objects with no record of which extension owns them. With the extension declared on the source side only, those ~30 functions look like undeclared orphans, and the differ dutifully writes a `DROP FUNCTION` for each.

So the only self-consistent state is *declared on both sides* — which is exactly what the exporter already produces. Rejecting the statement was the whole bug.

## Changes

**The fix** — `backend/api/v1/release_service_check.go`: `CREATE_EXTENSION` added to the PostgreSQL SDL allowlist, as a per-engine overlay alongside MySQL's `CREATE_EVENT`. `Export Schema` output becomes valid SDL, and both sides of the diff agree the extension exists, so its members cancel out instead of turning into drops. `COMMENT ON EXTENSION` already classified as `COMMENT` and was already allowed. CockroachDB is deliberately not included — `getStatementTypesWithPositionsForEngine` never runs the gate for it, so an entry there would be dead config.

**A guard** — `backend/plugin/schema/pg/sdl_migration_omni.go` plus advisor code 259: an extension that is installed but absent from the SDL now fails the check with an ERROR naming the one-line fix, instead of passing and letting the rollout die mid-transaction. This is separable from the fix if you'd rather not widen check behavior.

## Behavior change (not breaking)

The guard can fail a `check` that previously passed. That configuration was never able to roll out: because the catalog does not track extension membership, every plan containing `OpDropExtension` also contained per-member drops that PostgreSQL rejects. Non-bundled extensions (PostGIS, TimescaleDB, …) are unaffected — `CreateExtension` never registers them, so they produce no extension diff in either direction. No previously working configuration is blocked.

## Testing

Added:

- `backend/plugin/schema/pg/extension_sdl_omni_test.go` — the dump declares the extension and omits the functions it owns, and diffs against itself to nothing (round-trip clean); a declared extension yields no `DROP FUNCTION`; an undeclared one produces the ERROR advice.
- `backend/api/v1/release_service_check_pg_test.go` — an exported extension declaration plus its comment classify as `CREATE_EXTENSION` / `COMMENT` / `CREATE_TABLE` and all pass the gate; MySQL's gate stays narrow.

Ran locally (Windows host, Go 1.26.5):

- `go test ./backend/plugin/schema/pg/` — passes, including the three new tests. The two `*WithTestcontainer` tests fail for want of a Docker daemon on this machine, unrelated to this change.
- `GOOS=linux go vet ./backend/api/v1/ ./backend/plugin/schema/pg/ ./backend/plugin/advisor/code/` — clean, including test files.
- `gofmt` — clean on all five files.
- `golangci-lint run` (v2.12.2, matching CI) — no findings on any line this PR adds.

**Not run locally:** `go test ./backend/api/v1/` cannot execute on Windows — the package transitively pulls Unix-only `syscall.SysProcAttr.Setpgid`/`Credential` and `log/syslog` through `backend/resources/postgres`. It is type-checked via the `GOOS=linux` vet above; please let CI execute it.

## Follow-up (separate repo)

The deeper defect is in `bytebase/omni`: the catalog does not record which objects a `CREATE EXTENSION` script created, so extension members are indistinguishable from user objects. Tagging them — mirroring `pg_depend deptype='e'`, which Bytebase's own sync already reads — and excluding them from `Diff` would:

- make declaring an extension optional rather than mandatory, in both directions;
- let `DROP EXTENSION` work as one statement, with PostgreSQL cascading to its members;
- make the ~16 bundled-extension limit non-load-bearing (today, declaring PostGIS in SDL is silently ignored);
- allow `ALTER EXTENSION … UPDATE` — the `VERSION` clause the dump writes is currently discarded;
- let the guard added here be deleted, since the situation it protects against could no longer arise.

That would also address the two older issues the reporter linked, #7882 (TimescaleDB's internal objects processed unnecessarily) and #10513 (`uuid_generate_v4() does not exist`) — both are the same missing-ownership problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
