### PR TITLE
fix: authorize the concrete-project branch of SearchIssues

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -17819,7 +17819,10 @@ components:
           description: |-
             The parent, which owns this collection of issues.
              Format: projects/{project}
-             Use "projects/-" to list all issues from all projects.
+             Use the wildcard "projects/-" to search across collections (AIP-159); the
+             result is restricted to the projects where the caller holds
+             bb.issues.get. For a concrete project, the caller must hold bb.issues.get
+             on that project or the request is denied.
         pageSize:
           type: integer
           title: page_size

--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -337,6 +337,19 @@ func (s *IssueService) SearchIssues(ctx context.Context, req *connect.Request[v1
 			projectIDs = *projectIDsFilter
 		}
 	} else {
+		// Resolve the project first so an unknown parent is a NotFound rather
+		// than an INTERNAL out of CheckPermission's own project lookup. This
+		// matches what the ACL interceptor does for the IAM-authorized RPCs.
+		project, err := s.store.GetProject(ctx, &store.FindProjectMessage{
+			Workspace:  common.GetWorkspaceIDFromContext(ctx),
+			ResourceID: &projectID,
+		})
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get project"))
+		}
+		if project == nil {
+			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("project not found for id: %v", projectID))
+		}
 		ok, err := s.iamManager.CheckPermission(ctx, permission.IssuesGet, user, common.GetWorkspaceIDFromContext(ctx), projectID)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check permission %q", permission.IssuesGet))

--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -318,15 +318,17 @@ func (s *IssueService) SearchIssues(ctx context.Context, req *connect.Request[v1
 	}
 	issueFind.OrderByKeys = orderByKeys
 
+	user, ok := GetUserFromContext(ctx)
+	if !ok {
+		return nil, connect.NewError(connect.CodeInternal, errors.Errorf("user not found"))
+	}
+
+	// This RPC uses CUSTOM auth, so the ACL interceptor performs no permission
+	// check: both branches below must authorize the read themselves.
 	var projectIDs []string
-	if projectID != "-" {
-		projectIDs = append(projectIDs, projectID)
-	} else {
-		// Cross-project search
-		user, ok := GetUserFromContext(ctx)
-		if !ok {
-			return nil, connect.NewError(connect.CodeInternal, errors.Errorf("user not found"))
-		}
+	if projectID == "-" {
+		// AIP-159 wildcard: search across every project where the caller holds
+		// the permission. An empty set makes the store return zero rows.
 		projectIDsFilter, err := getProjectIDsSearchFilter(ctx, user, permission.IssuesGet, s.iamManager, s.store)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get projectIDs"))
@@ -334,6 +336,15 @@ func (s *IssueService) SearchIssues(ctx context.Context, req *connect.Request[v1
 		if projectIDsFilter != nil {
 			projectIDs = *projectIDsFilter
 		}
+	} else {
+		ok, err := s.iamManager.CheckPermission(ctx, permission.IssuesGet, user, common.GetWorkspaceIDFromContext(ctx), projectID)
+		if err != nil {
+			return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to check permission %q", permission.IssuesGet))
+		}
+		if !ok {
+			return nil, connect.NewError(connect.CodePermissionDenied, errors.Errorf("user does not have permission %q in %q", permission.IssuesGet, req.Msg.Parent))
+		}
+		projectIDs = append(projectIDs, projectID)
 	}
 	issueFind.ProjectIDs = projectIDs
 	issueFind.ExcludeDraft = true

--- a/backend/api/v1/issue_service_test.go
+++ b/backend/api/v1/issue_service_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	"github.com/bytebase/bytebase/backend/component/bus"
+	"github.com/bytebase/bytebase/backend/component/iam"
 	"github.com/bytebase/bytebase/backend/component/review"
 	"github.com/bytebase/bytebase/backend/component/webhook"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -1413,6 +1414,15 @@ func setupIssueServiceTestStore(ctx context.Context, t *testing.T) *store.Store 
 	stores, err := store.New(ctx, pgURL, false)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, stores.Close()) })
+
+	// SearchIssues authorizes the caller itself (CUSTOM auth), so the test
+	// principal needs a role carrying bb.issues.get.
+	_, err = stores.PatchWorkspaceIamPolicy(ctx, &store.PatchIamPolicyMessage{
+		Workspace: "default",
+		Member:    common.FormatUserEmail("creator@example.com"),
+		Roles:     []string{"roles/workspaceAdmin"},
+	})
+	require.NoError(t, err)
 	return stores
 }
 
@@ -1431,7 +1441,9 @@ func newIssueServiceForTest(t *testing.T, stores *store.Store) *IssueService {
 
 	b, err := bus.New()
 	require.NoError(t, err)
-	return NewIssueService(stores, webhook.NewManager(stores, nil), b, nil, nil)
+	iamManager, err := iam.NewManager(stores, nil, false)
+	require.NoError(t, err)
+	return NewIssueService(stores, webhook.NewManager(stores, nil), b, nil, iamManager)
 }
 
 func createIssueServiceApprovalIssue(ctx context.Context, t *testing.T, stores *store.Store) (*store.PlanMessage, *store.IssueMessage) {

--- a/backend/generated-go/v1/issue_service.pb.go
+++ b/backend/generated-go/v1/issue_service.pb.go
@@ -490,7 +490,10 @@ type SearchIssuesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The parent, which owns this collection of issues.
 	// Format: projects/{project}
-	// Use "projects/-" to list all issues from all projects.
+	// Use the wildcard "projects/-" to search across collections (AIP-159); the
+	// result is restricted to the projects where the caller holds
+	// bb.issues.get. For a concrete project, the caller must hold bb.issues.get
+	// on that project or the request is denied.
 	Parent string `protobuf:"bytes,1,opt,name=parent,proto3" json:"parent,omitempty"`
 	// The maximum number of issues to return. The service may return fewer than
 	// this value.

--- a/backend/tests/cross_project_update_test.go
+++ b/backend/tests/cross_project_update_test.go
@@ -322,3 +322,80 @@ func TestCollisionListIssuesIsolation(t *testing.T) {
 			"ListIssues for project A returned an issue from another project: %s", issue.Name)
 	}
 }
+
+// TestSearchIssuesConcreteProjectAuthorization is the regression lock for
+// audit finding T4: SearchIssues uses CUSTOM auth, so the ACL interceptor
+// performs no permission check and the handler must authorize both the
+// concrete-project and the AIP-159 wildcard branch itself. Before the fix,
+// any authenticated workspace member could read every non-draft issue in any
+// project by naming that project as the parent.
+func TestSearchIssuesConcreteProjectAuthorization(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	fixture := setupCollidingProjects(ctx, t, ctl)
+	ownerToken := ctl.authInterceptor.token
+
+	// A member of project A only. Project B is off limits for this user.
+	memberToken := bot35CreateProjectUser(ctx, t, ctl, fixture.ProjectA.Name, "roles/projectDeveloper", "issue-search-member")
+
+	ctl.authInterceptor.token = memberToken
+	// Concrete parent the caller cannot read: denied, not silently served.
+	_, err = ctl.issueServiceClient.SearchIssues(ctx,
+		connect.NewRequest(&v1pb.SearchIssuesRequest{
+			Parent:   fixture.ProjectB.Name,
+			PageSize: 100,
+		}))
+	a.Error(err, "SearchIssues on an unauthorized project must fail")
+	a.Equal(connect.CodePermissionDenied, connect.CodeOf(err))
+
+	// Concrete parent the caller can read still works.
+	allowed, err := ctl.issueServiceClient.SearchIssues(ctx,
+		connect.NewRequest(&v1pb.SearchIssuesRequest{
+			Parent:   fixture.ProjectA.Name,
+			PageSize: 100,
+		}))
+	a.NoError(err, "SearchIssues on an authorized project must succeed")
+	a.Greater(len(allowed.Msg.Issues), 0, "project A should have issues (fixture creates them)")
+	for _, issue := range allowed.Msg.Issues {
+		a.True(strings.HasPrefix(issue.Name, fixture.ProjectA.Name+"/"),
+			"SearchIssues for project A returned an issue from another project: %s", issue.Name)
+	}
+
+	// The AIP-159 wildcard keeps searching across collections, restricted to
+	// the projects the caller can read.
+	wildcard, err := ctl.issueServiceClient.SearchIssues(ctx,
+		connect.NewRequest(&v1pb.SearchIssuesRequest{
+			Parent:   "projects/-",
+			PageSize: 100,
+		}))
+	a.NoError(err, "wildcard search must remain available")
+	a.Greater(len(wildcard.Msg.Issues), 0, "the caller can read project A's issues")
+	for _, issue := range wildcard.Msg.Issues {
+		a.False(strings.HasPrefix(issue.Name, fixture.ProjectB.Name+"/"),
+			"wildcard search leaked an issue from an unauthorized project: %s", issue.Name)
+	}
+
+	// A workspace admin still sees both projects through the wildcard, so the
+	// filter narrows by permission rather than always dropping other projects.
+	ctl.authInterceptor.token = ownerToken
+	adminWildcard, err := ctl.issueServiceClient.SearchIssues(ctx,
+		connect.NewRequest(&v1pb.SearchIssuesRequest{
+			Parent:   "projects/-",
+			PageSize: 100,
+		}))
+	a.NoError(err)
+	var sawB bool
+	for _, issue := range adminWildcard.Msg.Issues {
+		if strings.HasPrefix(issue.Name, fixture.ProjectB.Name+"/") {
+			sawB = true
+		}
+	}
+	a.True(sawB, "an admin wildcard search should include project B's issues")
+}

--- a/backend/tests/cross_project_update_test.go
+++ b/backend/tests/cross_project_update_test.go
@@ -368,6 +368,16 @@ func TestSearchIssuesConcreteProjectAuthorization(t *testing.T) {
 			"SearchIssues for project A returned an issue from another project: %s", issue.Name)
 	}
 
+	// An unknown parent is NotFound, not INTERNAL: CheckPermission's own
+	// project lookup would otherwise surface as a 500 for a typo'd project.
+	_, err = ctl.issueServiceClient.SearchIssues(ctx,
+		connect.NewRequest(&v1pb.SearchIssuesRequest{
+			Parent:   "projects/does-not-exist",
+			PageSize: 100,
+		}))
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err), "unknown project must be NotFound")
+
 	// The AIP-159 wildcard keeps searching across collections, restricted to
 	// the projects the caller can read.
 	wildcard, err := ctl.issueServiceClient.SearchIssues(ctx,
@@ -398,4 +408,15 @@ func TestSearchIssuesConcreteProjectAuthorization(t *testing.T) {
 		}
 	}
 	a.True(sawB, "an admin wildcard search should include project B's issues")
+
+	// An admin holds the permission workspace-wide, so CheckPermission never
+	// reaches its project lookup: without the explicit resolve, an unknown
+	// project would silently return an empty page instead of NotFound.
+	_, err = ctl.issueServiceClient.SearchIssues(ctx,
+		connect.NewRequest(&v1pb.SearchIssuesRequest{
+			Parent:   "projects/does-not-exist",
+			PageSize: 100,
+		}))
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err), "unknown project must be NotFound for an admin too")
 }

--- a/docs/design/v1-api-audit-2026-08.md
+++ b/docs/design/v1-api-audit-2026-08.md
@@ -19,30 +19,8 @@ backend actually does**, which is where everything serious lives.
 `name`, else `resource`, else `project`, and only if that field carries a `resource_reference`
 annotation (`backend/api/v1/acl.go:667-685`). Any *second* resource name in the body is invisible
 to it. `DiffSchema` (fix already written, patch `04`) was one instance; these are the rest.
-
-### T4 ✅ HIGH — `SearchIssues` performs no authorization for a concrete project
-
-`backend/api/v1/issue_service.go:321-323`:
-
-```go
-var projectIDs []string
-if projectID != "-" {
-    projectIDs = append(projectIDs, projectID)   // no permission check
-} else {
-    projectIDsFilter, err := getProjectIDsSearchFilter(ctx, user, permission.IssuesGet, ...)
-}
-```
-
-`auth_method = CUSTOM` makes `doIAMPermissionCheck` return early (`acl.go:246`), and `parent` has
-no `resource_reference` (`issue_service.proto:270`) so the resolver yields only the workspace
-fallback. `CheckPermission` appears in `issue_service.go` only at `:799` and `:1217` — neither on
-this path. `workspaceMember` does not hold `bb.issues.get`.
-
-Perverse detail: the **wildcard** `projects/-` branch is correctly filtered. The concrete-project
-branch — the one that looks safe — is the hole. Any authenticated member reads every non-draft
-issue in any project: titles, descriptions, creators, labels, risk levels, approval state.
-
-**Fix:** call `CheckPermission(IssuesGet, user, workspaceID, projectID)` on the concrete branch.
+The related CUSTOM-auth variant — the interceptor checks nothing at all, so the handler must
+authorize every branch itself — was T4 (`SearchIssues`), now fixed.
 
 ### T5 ✅ HIGH — sheet content is globally readable by SHA256
 
@@ -237,7 +215,7 @@ comment; 22 files have string fields and zero protovalidate constraints despite
 # What I'd do, in order
 
 1. **Runtime-confirm T9.** Eleven bad logins. If the eleventh is accepted, there is no lockout and that outranks everything else here.
-2. **Close the multi-resource ACL class, not the instances** (T4–T7 + the pending `DiffSchema` patch): teach `getResourceFromRequest` to collect *every* `resource_reference`d field including oneof and repeated members, then annotate `DiffSchemaRequest.changelog`, `CheckReleaseRequest.targets`, `Revision.release/file/task_run`. `UpdateDatabase`'s project-transfer case (`acl.go:604-624`) is the in-repo precedent.
+2. **Close the multi-resource ACL class, not the instances** (T6–T7 + the pending `DiffSchema` patch): teach `getResourceFromRequest` to collect *every* `resource_reference`d field including oneof and repeated members, then annotate `DiffSchemaRequest.changelog`, `CheckReleaseRequest.targets`, `Revision.release/file/task_run`. `UpdateDatabase`'s project-transfer case (`acl.go:604-624`) is the in-repo precedent.
 3. **Give sheets an ownership model** (T5), or at minimum scope the blob fetch by the owning project/workspace. Until then the sheet namespace is workspace-global by design, and should be documented as such.
 4. **Fail closed**: reject `AUTH_METHOD_UNSPECIFIED` at startup; make `permission` on a CUSTOM RPC either enforced or a build error, since 20 of them are currently decorative.
 5. **Wire api-linter into CI** at the 474-finding baseline. None of Tier 5 was visible to `buf lint`'s `BASIC` profile, which is why it accumulated.

--- a/frontend/src/types/proto-es/v1/issue_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/issue_service_pb.d.ts
@@ -185,7 +185,10 @@ export declare type SearchIssuesRequest = Message<"bytebase.v1.SearchIssuesReque
   /**
    * The parent, which owns this collection of issues.
    * Format: projects/{project}
-   * Use "projects/-" to list all issues from all projects.
+   * Use the wildcard "projects/-" to search across collections (AIP-159); the
+   * result is restricted to the projects where the caller holds
+   * bb.issues.get. For a concrete project, the caller must hold bb.issues.get
+   * on that project or the request is denied.
    *
    * @generated from field: string parent = 1;
    */

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -29121,7 +29121,10 @@ components:
           description: |-
             The parent, which owns this collection of issues.
              Format: projects/{project}
-             Use "projects/-" to list all issues from all projects.
+             Use the wildcard "projects/-" to search across collections (AIP-159); the
+             result is restricted to the projects where the caller holds
+             bb.issues.get. For a concrete project, the caller must hold bb.issues.get
+             on that project or the request is denied.
         pageSize:
           type: integer
           title: page_size

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -3608,7 +3608,7 @@ For example: creator == &#34;users/ed@bytebase.com&#34; &amp;&amp; status in [&#
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| parent | [string](#string) |  | The parent, which owns this collection of issues. Format: projects/{project} Use &#34;projects/-&#34; to list all issues from all projects. |
+| parent | [string](#string) |  | The parent, which owns this collection of issues. Format: projects/{project} Use the wildcard &#34;projects/-&#34; to search across collections (AIP-159); the result is restricted to the projects where the caller holds bb.issues.get. For a concrete project, the caller must hold bb.issues.get on that project or the request is denied. |
 | page_size | [int32](#int32) |  | The maximum number of issues to return. The service may return fewer than this value. If unspecified, at most 10 issues will be returned. The maximum value is 1000; values above 1000 will be coerced to 1000. |
 | page_token | [string](#string) |  | A page token, received from a previous `SearchIssues` call. Provide this to retrieve the subsequent page.
 

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -10760,7 +10760,10 @@ Format: users/{email}. </p></td>
                   <td></td>
                   <td><p>The parent, which owns this collection of issues.
 Format: projects/{project}
-Use &#34;projects/-&#34; to list all issues from all projects. </p></td>
+Use the wildcard &#34;projects/-&#34; to search across collections (AIP-159); the
+result is restricted to the projects where the caller holds
+bb.issues.get. For a concrete project, the caller must hold bb.issues.get
+on that project or the request is denied. </p></td>
                 </tr>
               
                 <tr>

--- a/proto/v1/v1/issue_service.proto
+++ b/proto/v1/v1/issue_service.proto
@@ -266,7 +266,10 @@ message ListIssuesResponse {
 message SearchIssuesRequest {
   // The parent, which owns this collection of issues.
   // Format: projects/{project}
-  // Use "projects/-" to list all issues from all projects.
+  // Use the wildcard "projects/-" to search across collections (AIP-159); the
+  // result is restricted to the projects where the caller holds
+  // bb.issues.get. For a concrete project, the caller must hold bb.issues.get
+  // on that project or the request is denied.
   string parent = 1 [(google.api.field_behavior) = REQUIRED];
 
   // The maximum number of issues to return. The service may return fewer than


### PR DESCRIPTION
## Summary

Closes audit finding **T4** (`docs/design/v1-api-audit-2026-08.md`).

`SearchIssues` declares `auth_method = CUSTOM`, so `doIAMPermissionCheck` returns early (`acl.go:246`) and the ACL interceptor authorizes nothing. Only the wildcard branch compensated — naming a **concrete** project skipped authorization entirely, so any authenticated workspace member could read every non-draft issue in any project (titles, descriptions, creators, labels, risk levels, approval state) without holding `bb.issues.get` there. `workspaceMember` does not hold that permission.

The fix checks `bb.issues.get` on the named project and returns `PermissionDenied` when the caller lacks it.

## On `projects/-`

The wildcard is kept exactly as-is: per [AIP-159](https://google.aip.dev/159) it means "search across collections", and the branch already narrows results to the projects where the caller holds `bb.issues.get` (`getProjectIDsSearchFilter`). An empty permitted set yields zero rows — `store.ListIssues` treats an empty `ProjectIDs` as a closed filter by design, which is documented at `backend/store/issue.go:327`.

AIP-159 leaves authorization to the service, so the two branches now differ deliberately: the wildcard **filters** to what you may read, a concrete parent **denies** when you may not read it. That mirrors the List/Search split elsewhere in the API and keeps `projects/-` useful for the "My Issues" view, which is its only caller (`frontend/src/stores/app/issue.ts:149`). `SearchIssuesRequest.parent` now documents both, as AIP-159 requires wildcard support to be stated explicitly.

## Testing

- `TestSearchIssuesConcreteProjectAuthorization` (backend/tests): a project-A member is denied on project B, allowed on project A, sees a wildcard search filtered to project A only, while a workspace admin's wildcard still spans both projects. **Verified to fail without the fix** — the unauthorized concrete-project search returned project B's issues instead of an error.
- `TestCollisionListIssuesIsolation` still passes.
- The `api/v1` unit tests previously built `IssueService` with a nil `iam.Manager` (which the concrete branch never touched); they now use a real manager and grant the test principal a workspace role. Full `backend/api/v1` package passes; `golangci-lint` reports 0 issues for `backend/api/v1/...`; `buf lint` clean.

Note: `golangci-lint` reports 4 pre-existing `staticcheck` SA5011 issues in `backend/tests/sql_{export,query}_data_source_test.go` (from #19779) that are untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)