### PR TITLE
test: harden and verify project instance compatibility (BOT-37)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,9 +209,11 @@ When writing or modifying queries on these tables:
 - When adding a new store method touching a composite-PK table, add a corresponding
   `TestCollision_*` test in `backend/tests/`. The existing `setupCollidingProjects`
   fixture and `assertProjectUnchanged` helper cover `plan`, `issue`, `task`, `task_run`,
-  and `plan_check_run`. For tables not in that set (e.g., `plan_webhook_delivery`,
-  `task_run_log`, `db_group`, `release`), write table-specific seed and assertion
-  helpers — or extend the shared helper first
+  `plan_check_run`, `plan_webhook_delivery`, `task_run_log`, `db_group`, and `release`
+  (the snapshot reads the last four through public APIs where one exists; the
+  `plan_webhook_delivery` snapshot uses a table-specific raw metadata-DB read because
+  it has no public read API). For any future composite-PK table outside that set,
+  write table-specific seed and assertion helpers — or extend the shared helper first
 - Collision tests use `setupCollidingProjects` + `fixture.completeRolloutB` for setup
   and `snapshotProject` / `assertProjectUnchanged` for assertions — all going through
   the public gRPC API, no store access. Run with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,11 +209,14 @@ When writing or modifying queries on these tables:
 - When adding a new store method touching a composite-PK table, add a corresponding
   `TestCollision_*` test in `backend/tests/`. The existing `setupCollidingProjects`
   fixture and `assertProjectUnchanged` helper cover `plan`, `issue`, `task`, `task_run`,
-  `plan_check_run`, `plan_webhook_delivery`, `task_run_log`, `db_group`, and `release`
-  (the snapshot reads the last four through public APIs where one exists; the
-  `plan_webhook_delivery` snapshot uses a table-specific raw metadata-DB read because
-  it has no public read API). For any future composite-PK table outside that set,
-  write table-specific seed and assertion helpers — or extend the shared helper first
+  `plan_check_run`, `task_run_log`, `db_group`, and `release` (the snapshot reads the
+  last three through public APIs where one exists). `plan_webhook_delivery` is covered
+  by the dedicated `TestCollision_PlanWebhookDeliveryWrite` with a table-specific raw
+  metadata-DB read and explicit stabilization — its rows are claimed asynchronously
+  after rollout completion, so it is deliberately kept out of the generic snapshot to
+  avoid spurious cross-project-leak failures. For any future composite-PK table
+  outside that set, write table-specific seed and assertion helpers — or extend the
+  shared helper first
 - Collision tests use `setupCollidingProjects` + `fixture.completeRolloutB` for setup
   and `snapshotProject` / `assertProjectUnchanged` for assertions — all going through
   the public gRPC API, no store access. Run with:

--- a/backend/api/v1/audit_log_service_test.go
+++ b/backend/api/v1/audit_log_service_test.go
@@ -1,153 +1,218 @@
 package v1
 
 import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
+	"unsafe"
 
-	"github.com/stretchr/testify/assert"
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/enterprise"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
 )
 
-func TestGetAuditLogRetentionDays(t *testing.T) {
-	// This test would require mocking the LicenseService
-	// For now, we'll create a simple test that validates the logic
+const (
+	testAuditLogWorkspace = "default"
+	testAuditLogParent    = "projects/project-a"
+)
 
-	tests := []struct {
-		plan         v1pb.PlanType
-		expectedDays int
-	}{
-		{
-			plan:         v1pb.PlanType_FREE,
-			expectedDays: 0, // No access
-		},
-		{
-			plan:         v1pb.PlanType_TEAM,
-			expectedDays: 7, // 7 days retention
-		},
-		{
-			plan:         v1pb.PlanType_ENTERPRISE,
-			expectedDays: -1, // Unlimited
-		},
-	}
+// TestAuditLogRetentionFilteringEndToEnd drives the real SearchAuditLogs
+// handler against a PostgreSQL-backed store under every plan:
+//   - FREE: audit log access is gated off (PermissionDenied).
+//   - TEAM: rows older than the 7-day retention cutoff are excluded, rows
+//     newer than the cutoff are included with canonical resource names.
+//   - ENTERPRISE: unlimited retention, so rows older than the cutoff remain
+//     visible.
+//
+// The license service is constructed normally (NewLicenseService with the
+// embedded dev public key) and then given a test-only RSA keypair so the test
+// can mint a license for each plan. The license is stored in the SYSTEM
+// setting and loaded through the real subscription path, so the feature gate,
+// retention cutoff, filter application, and SQL execution are all exercised.
+// The keypair swap uses the same reflect/unsafe access to the unexported
+// config field as backend/tests/sql_query_data_source_test.go.
+func TestAuditLogRetentionFilteringEndToEnd(t *testing.T) {
+	ctx, stores, licenseService := setupAuditLogRetentionTest(t)
 
-	for _, tt := range tests {
-		t.Run(tt.plan.String(), func(t *testing.T) {
-			// This test documents the expected behavior
-			// In a real test, we would mock the LicenseService and test GetAuditLogRetentionDays
-			t.Logf("Plan %s should have %d days retention", tt.plan, tt.expectedDays)
-		})
-	}
+	now := time.Now().UTC()
+	oldLogTime := now.AddDate(0, 0, -8).Truncate(time.Microsecond)
+	newLogTime := now.AddDate(0, 0, -1).Truncate(time.Microsecond)
+	seedAuditLog(ctx, t, stores, "old-log", oldLogTime)
+	seedAuditLog(ctx, t, stores, "new-log", newLogTime)
+
+	service := NewAuditLogService(stores, licenseService)
+
+	t.Run("FREE plan has no audit log access", func(t *testing.T) {
+		setAuditLogLicense(ctx, t, stores, licenseService, v1pb.PlanType_FREE)
+
+		_, err := service.SearchAuditLogs(ctx, connect.NewRequest(&v1pb.SearchAuditLogsRequest{
+			Parent:   "projects/-",
+			PageSize: 100,
+		}))
+		require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("TEAM plan excludes rows older than the retention cutoff", func(t *testing.T) {
+		setAuditLogLicense(ctx, t, stores, licenseService, v1pb.PlanType_TEAM)
+
+		resp, err := service.SearchAuditLogs(ctx, connect.NewRequest(&v1pb.SearchAuditLogsRequest{
+			Parent:   "projects/-",
+			PageSize: 100,
+		}))
+		require.NoError(t, err)
+		require.Empty(t, resp.Msg.NextPageToken)
+		require.Len(t, resp.Msg.AuditLogs, 1, "the row older than the 7-day cutoff must be filtered out")
+
+		log := resp.Msg.AuditLogs[0]
+		require.Equal(t, fmt.Sprintf("%s/%s%s", testAuditLogParent, common.AuditLogPrefix, "new-log"), log.Name)
+		require.Equal(t, testAuditLogParent, log.Resource)
+		require.Equal(t, "/bytebase.v1.ProjectService/GetProject", log.Method)
+		require.Equal(t, "users/alice@example.com", log.User)
+		require.Equal(t, v1pb.AuditLog_INFO, log.Severity)
+		require.Equal(t, newLogTime.UnixNano(), log.CreateTime.AsTime().UnixNano())
+	})
+
+	t.Run("ENTERPRISE plan keeps rows older than the retention cutoff", func(t *testing.T) {
+		setAuditLogLicense(ctx, t, stores, licenseService, v1pb.PlanType_ENTERPRISE)
+
+		resp, err := service.SearchAuditLogs(ctx, connect.NewRequest(&v1pb.SearchAuditLogsRequest{
+			Parent:   "projects/-",
+			PageSize: 100,
+		}))
+		require.NoError(t, err)
+		require.Len(t, resp.Msg.AuditLogs, 2, "ENTERPRISE plan has unlimited retention")
+	})
 }
 
-func TestRetentionCutoffCalculation(t *testing.T) {
-	now := time.Now()
+// TestAuditLogRetentionFilterIncludesExactCutoffRow pins the >= boundary of
+// ApplyRetentionFilter against real PostgreSQL rows: a row created exactly at
+// the cutoff is retained and a row one microsecond earlier is dropped. This
+// exercises the same filter wiring SearchAuditLogs uses (ApplyRetentionFilter
+// feeding store.SearchAuditLogs) with a fixed, deterministic cutoff.
+func TestAuditLogRetentionFilterIncludesExactCutoffRow(t *testing.T) {
+	ctx, stores, _ := setupAuditLogRetentionTest(t)
 
-	tests := []struct {
-		name            string
-		retentionDays   int
-		expectNilCutoff bool
-		description     string
-	}{
-		{
-			name:            "Free plan (0 days)",
-			retentionDays:   0,
-			expectNilCutoff: true,
-			description:     "Free plan should return nil cutoff",
-		},
-		{
-			name:            "Team plan (7 days)",
-			retentionDays:   7,
-			expectNilCutoff: false,
-			description:     "Team plan should return cutoff 7 days ago",
-		},
-		{
-			name:            "Enterprise plan (unlimited)",
-			retentionDays:   -1,
-			expectNilCutoff: true,
-			description:     "Enterprise plan should return nil cutoff",
-		},
+	cutoff := time.Now().UTC().Truncate(time.Microsecond)
+	seedAuditLog(ctx, t, stores, "before-cutoff", cutoff.Add(-time.Microsecond))
+	seedAuditLog(ctx, t, stores, "at-cutoff", cutoff)
+	seedAuditLog(ctx, t, stores, "after-cutoff", cutoff.Add(time.Microsecond))
+
+	logs, err := stores.SearchAuditLogs(ctx, &store.AuditLogFind{
+		Workspace: testAuditLogWorkspace,
+		FilterQ:   store.ApplyRetentionFilter(nil, &cutoff),
+	})
+	require.NoError(t, err)
+
+	var resourceIDs []string
+	for _, l := range logs {
+		resourceIDs = append(resourceIDs, l.ResourceID)
 	}
+	require.Equal(t, []string{"after-cutoff", "at-cutoff"}, resourceIDs)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Calculate expected cutoff
-			var expectedCutoff *time.Time
-			if tt.retentionDays > 0 {
-				cutoff := now.AddDate(0, 0, -tt.retentionDays)
-				expectedCutoff = &cutoff
-			}
-
-			if tt.expectNilCutoff {
-				assert.Nil(t, expectedCutoff, tt.description)
-			} else {
-				require.NotNil(t, expectedCutoff, tt.description)
-				// Verify the cutoff is approximately correct
-				daysDiff := now.Sub(*expectedCutoff).Hours() / 24
-				assert.InDelta(t, float64(tt.retentionDays), daysDiff, 0.1, "Cutoff should be approximately %d days ago", tt.retentionDays)
-			}
-		})
+	var names []string
+	for _, l := range convertToAuditLogs(logs) {
+		names = append(names, l.Name)
 	}
+	require.Equal(t, []string{
+		fmt.Sprintf("%s/%s%s", testAuditLogParent, common.AuditLogPrefix, "after-cutoff"),
+		fmt.Sprintf("%s/%s%s", testAuditLogParent, common.AuditLogPrefix, "at-cutoff"),
+	}, names)
 }
 
-func TestLogAuditToStdout_IncludesRequestResponse(t *testing.T) {
-	// This test documents the expected behavior that request and response
-	// fields should be included in stdout audit logs when present.
-	//
-	// The actual logAuditToStdout function writes to slog, which would require
-	// setting up a custom handler to capture output. This test validates the
-	// data structure expectations.
+func setupAuditLogRetentionTest(t *testing.T) (context.Context, *store.Store, *enterprise.LicenseService) {
+	t.Helper()
+	ctx := context.WithValue(context.Background(), common.WorkspaceIDContextKey, testAuditLogWorkspace)
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
 
-	tests := []struct {
-		name            string
-		request         string
-		response        string
-		expectRequest   bool
-		expectResponse  bool
-		expectTruncated bool
-	}{
-		{
-			name:           "empty request and response",
-			request:        "",
-			response:       "",
-			expectRequest:  false,
-			expectResponse: false,
-		},
-		{
-			name:           "normal request and response",
-			request:        `{"name":"test"}`,
-			response:       `{"success":true}`,
-			expectRequest:  true,
-			expectResponse: true,
-		},
-		{
-			name:            "large request should be truncated",
-			request:         string(make([]byte, 150000)), // 150KB
-			response:        `{"success":true}`,
-			expectRequest:   true,
-			expectResponse:  true,
-			expectTruncated: true,
-		},
-	}
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	_, err := db.ExecContext(ctx, `INSERT INTO workspace (resource_id) VALUES ('default')`)
+	require.NoError(t, err)
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Validate truncation behavior
-			if tt.expectTruncated && len(tt.request) > 102400 {
-				truncated, wasTruncated := common.TruncateString(tt.request, 102400)
-				assert.True(t, wasTruncated, "Large request should be truncated")
-				assert.LessOrEqual(t, len(truncated), 102400, "Truncated string should be within limit")
-			}
+	pgURL := fmt.Sprintf("host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort())
+	stores, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stores.Close()) })
 
-			// Document that empty strings should not be logged
-			if tt.request == "" {
-				assert.False(t, tt.expectRequest, "Empty request should not be logged")
-			}
-			if tt.response == "" {
-				assert.False(t, tt.expectResponse, "Empty response should not be logged")
-			}
-		})
-	}
+	// The SYSTEM setting must exist before UpdateLicense can write the license.
+	_, err = stores.UpsertSetting(ctx, &store.SettingMessage{
+		Name:      storepb.SettingName_SYSTEM,
+		Workspace: testAuditLogWorkspace,
+		Value:     &storepb.SystemSetting{},
+	})
+	require.NoError(t, err)
+
+	licenseService, err := enterprise.NewLicenseService(common.ReleaseModeDev, stores, false, "")
+	require.NoError(t, err)
+	installTestLicenseKeypair(t, licenseService)
+	return ctx, stores, licenseService
+}
+
+// installTestLicenseKeypair replaces the license service's embedded dev public
+// key with a test-only RSA keypair so the test can mint a license for any
+// plan. The private key matching the embedded dev public key is not checked
+// in, and the LicenseService config field is unexported, so this uses the same
+// reflect/unsafe access as backend/tests/sql_query_data_source_test.go.
+func installTestLicenseKeypair(t *testing.T, licenseService *enterprise.LicenseService) {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	field := reflect.ValueOf(licenseService).Elem().FieldByName("config")
+	config, ok := reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Interface().(*enterprise.Config)
+	require.True(t, ok)
+	config.PrivateKey = privateKey
+	config.PublicKey = &privateKey.PublicKey
+}
+
+// setAuditLogLicense signs a license for the given plan with the test keypair,
+// stores it through the real subscription setting, and invalidates the
+// subscription cache so the next SearchAuditLogs call reloads it from the
+// database.
+func setAuditLogLicense(ctx context.Context, t *testing.T, stores *store.Store, licenseService *enterprise.LicenseService, plan v1pb.PlanType) {
+	t.Helper()
+	token, err := licenseService.CreateLicense(&enterprise.LicenseParams{
+		Plan:        plan.String(),
+		Seats:       10,
+		Instances:   10,
+		WorkspaceID: testAuditLogWorkspace,
+	})
+	require.NoError(t, err)
+	require.NoError(t, stores.UpdateLicense(ctx, testAuditLogWorkspace, token))
+	licenseService.InvalidateCache(testAuditLogWorkspace)
+}
+
+// seedAuditLog inserts an audit_log row directly with a controlled created_at
+// and a canonical project-scoped payload.
+func seedAuditLog(ctx context.Context, t *testing.T, stores *store.Store, resourceID string, createdAt time.Time) {
+	t.Helper()
+	payload, err := protojson.Marshal(&storepb.AuditLog{
+		Parent:   testAuditLogParent,
+		Method:   "/bytebase.v1.ProjectService/GetProject",
+		Resource: testAuditLogParent,
+		User:     "users/alice@example.com",
+		Severity: storepb.AuditLog_INFO,
+		Request:  `{"name":"projects/project-a"}`,
+		Response: `{"name":"projects/project-a"}`,
+	})
+	require.NoError(t, err)
+	_, err = stores.GetDB().ExecContext(ctx, `
+		INSERT INTO audit_log (resource_id, workspace, created_at, payload)
+		VALUES ($1, $2, $3, $4::jsonb)
+	`, resourceID, testAuditLogWorkspace, createdAt, string(payload))
+	require.NoError(t, err)
 }

--- a/backend/common/directory_sync.go
+++ b/backend/common/directory_sync.go
@@ -1,3 +1,4 @@
+// nolint:revive // Package name "common" is the established repository-wide name.
 package common
 
 import (

--- a/backend/common/resource_name_test.go
+++ b/backend/common/resource_name_test.go
@@ -100,6 +100,7 @@ func TestGetDatabaseResourceNameWithSuffix(t *testing.T) {
 		wantInstanceID string
 		wantDatabaseID string
 		wantErr        bool
+		wantErrMsg     string
 	}{
 		{
 			name:           "instances/instance-1/databases/database-1/metadata",
@@ -115,14 +116,113 @@ func TestGetDatabaseResourceNameWithSuffix(t *testing.T) {
 			wantDatabaseID: "database-1",
 		},
 		{
-			name:    "instances/instance-1/databases/database-1/metadata",
-			suffix:  "/schema",
-			wantErr: true,
+			name:           "instances/instance-1/databases/database-1/schema",
+			suffix:         SchemaSuffix,
+			wantInstanceID: "instance-1",
+			wantDatabaseID: "database-1",
+		},
+		{
+			name:           "instances/instance-1/databases/database-1/sdlSchema",
+			suffix:         SDLSchemaSuffix,
+			wantInstanceID: "instance-1",
+			wantDatabaseID: "database-1",
+		},
+		{
+			name:           "instances/instance-1/databases/database-1/schemaString",
+			suffix:         SchemaStringSuffix,
+			wantInstanceID: "instance-1",
+			wantDatabaseID: "database-1",
+		},
+		{
+			name:           "instances/instance-1/databases/database-1/catalog",
+			suffix:         CatalogSuffix,
+			wantInstanceID: "instance-1",
+			wantDatabaseID: "database-1",
+		},
+		{
+			name:           "projects/project-1/instances/instance-1/databases/database-1/schema",
+			suffix:         SchemaSuffix,
+			wantProjectID:  new("project-1"),
+			wantInstanceID: "instance-1",
+			wantDatabaseID: "database-1",
+		},
+		{
+			name:           "projects/project-1/instances/instance-1/databases/database-1/sdlSchema",
+			suffix:         SDLSchemaSuffix,
+			wantProjectID:  new("project-1"),
+			wantInstanceID: "instance-1",
+			wantDatabaseID: "database-1",
+		},
+		{
+			name:           "projects/project-1/instances/instance-1/databases/database-1/schemaString",
+			suffix:         SchemaStringSuffix,
+			wantProjectID:  new("project-1"),
+			wantInstanceID: "instance-1",
+			wantDatabaseID: "database-1",
+		},
+		{
+			name:           "projects/project-1/instances/instance-1/databases/database-1/catalog",
+			suffix:         CatalogSuffix,
+			wantProjectID:  new("project-1"),
+			wantInstanceID: "instance-1",
+			wantDatabaseID: "database-1",
+		},
+		{
+			name:       "instances/instance-1/databases/database-1/metadata",
+			suffix:     "/schema",
+			wantErr:    true,
+			wantErrMsg: `invalid request "instances/instance-1/databases/database-1/metadata" with suffix "/schema"`,
+		},
+		{
+			name:       "instances/instance-1/databases/database-1/schema",
+			suffix:     MetadataSuffix,
+			wantErr:    true,
+			wantErrMsg: `invalid request "instances/instance-1/databases/database-1/schema" with suffix "/metadata"`,
+		},
+		{
+			name:       "projects/project-1/instances/instance-1/databases/database-1/sdlSchema",
+			suffix:     SchemaSuffix,
+			wantErr:    true,
+			wantErrMsg: `invalid request "projects/project-1/instances/instance-1/databases/database-1/sdlSchema" with suffix "/schema"`,
+		},
+		{
+			name:       "instances/instance-1/databases/database-1",
+			suffix:     SchemaSuffix,
+			wantErr:    true,
+			wantErrMsg: `invalid request "instances/instance-1/databases/database-1" with suffix "/schema"`,
+		},
+		{
+			name:       "projects/project-1/instances/instance-1/databases/database-1",
+			suffix:     SchemaSuffix,
+			wantErr:    true,
+			wantErrMsg: `invalid request "projects/project-1/instances/instance-1/databases/database-1" with suffix "/schema"`,
+		},
+		{
+			name:       "instances/instance-1/database-1/schema",
+			suffix:     SchemaSuffix,
+			wantErr:    true,
+			wantErrMsg: `invalid request "instances/instance-1/database-1"`,
+		},
+		{
+			name:       "projects/project-1/databases/database-1/schema",
+			suffix:     SchemaSuffix,
+			wantErr:    true,
+			wantErrMsg: `invalid request "projects/project-1/databases/database-1"`,
+		},
+		{
+			name:       "projects/project-1/instances/instance-1/schema",
+			suffix:     SchemaSuffix,
+			wantErr:    true,
+			wantErrMsg: `invalid request "projects/project-1/instances/instance-1"`,
 		},
 	} {
 		t.Run(test.name+test.suffix, func(t *testing.T) {
 			projectID, instanceID, databaseID, err := GetDatabaseResourceNameWithSuffix(test.name, test.suffix)
 			if test.wantErr {
+				if test.wantErrMsg != "" {
+					require.EqualError(t, err, test.wantErrMsg)
+					return
+				}
 				require.Error(t, err)
 				return
 			}

--- a/backend/plugin/parser/pg/query_span.go
+++ b/backend/plugin/parser/pg/query_span.go
@@ -23,6 +23,9 @@ func GetQuerySpan(ctx context.Context, gCtx base.GetQuerySpanContext, stmt base.
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get database metadata for instance %q and database %q", gCtx.InstanceID, database)
 	}
+	if meta == nil {
+		return nil, errors.Errorf("database metadata for database %q not found (database not synced)", database)
+	}
 	searchPath := meta.GetSearchPath()
 	if schema != "" {
 		searchPath = searchPathForSelectedSchema(schema, searchPath)

--- a/backend/plugin/parser/pg/query_span_test.go
+++ b/backend/plugin/parser/pg/query_span_test.go
@@ -70,6 +70,19 @@ func TestGetQuerySpan(t *testing.T) {
 	}
 }
 
+// TestGetQuerySpanNilMetadata ensures a never-synced database (nil metadata)
+// returns an error instead of panicking. Access Grant approval evaluation
+// calls GetQuerySpan for databases that may not have been schema-synced yet.
+func TestGetQuerySpanNilMetadata(t *testing.T) {
+	_, err := GetQuerySpan(context.TODO(), base.GetQuerySpanContext{
+		GetDatabaseMetadataFunc: func(context.Context, string, string) (string, *model.DatabaseMetadata, error) {
+			return "", nil, nil
+		},
+	}, base.Statement{Text: "SELECT 1;"}, "unsynced-db", "", false)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "database metadata for database \"unsynced-db\" not found")
+}
+
 func buildMockDatabaseMetadataGetter(databaseMetadata []*storepb.DatabaseSchemaMetadata) (base.GetDatabaseMetadataFunc, base.ListDatabaseNamesFunc) {
 	return func(_ context.Context, _, databaseName string) (string, *model.DatabaseMetadata, error) {
 			m := make(map[string]*model.DatabaseMetadata)

--- a/backend/tests/collision_helper_test.go
+++ b/backend/tests/collision_helper_test.go
@@ -543,6 +543,10 @@ type projectSnapshot struct {
 	DatabaseGroups []*v1pb.DatabaseGroup
 	// PlanWebhookDeliveries is the only snapshot field read directly from
 	// the metadata DB — plan_webhook_delivery has no public gRPC read API.
+	// It is NOT compared in assertProjectUnchanged: delivery rows are
+	// claimed asynchronously after rollout completion, so only the dedicated
+	// webhook collision test compares them, after explicitly waiting for the
+	// row set to stabilize.
 	PlanWebhookDeliveries []*planWebhookDelivery
 }
 
@@ -735,7 +739,6 @@ func assertProjectUnchanged(
 ) {
 	t.Helper()
 	a := require.New(t)
-
 	assertNoChange(t, before.Plans, after.Plans,
 		func(p *v1pb.Plan) string { return p.Name },
 		func(b, af *v1pb.Plan) {
@@ -800,14 +803,6 @@ func assertProjectUnchanged(
 			a.True(proto.Equal(b.DatabaseExpr, af.DatabaseExpr), "%s: database group %s expression changed", label, b.Name)
 		},
 		label, "db_group")
-
-	assertNoChange(t, before.PlanWebhookDeliveries, after.PlanWebhookDeliveries,
-		func(d *planWebhookDelivery) string { return fmt.Sprintf("%d", d.PlanID) },
-		func(b, af *planWebhookDelivery) {
-			a.Equal(b.EventType, af.EventType, "%s: plan_webhook_delivery plan %d event_type changed", label, b.PlanID)
-			a.True(b.DeliveredAt.Equal(af.DeliveredAt), "%s: plan_webhook_delivery plan %d delivered_at changed", label, b.PlanID)
-		},
-		label, "plan_webhook_delivery")
 }
 
 // assertNoChange compares two row slices keyed by name, fails if any

--- a/backend/tests/collision_helper_test.go
+++ b/backend/tests/collision_helper_test.go
@@ -2,9 +2,11 @@ package tests
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -531,18 +533,65 @@ func createPlanIssueRollout(ctx context.Context, t *testing.T, ctl *controller, 
 // observed through the public gRPC API. Each slice's rows are keyed by the
 // UID parsed from their resource name.
 type projectSnapshot struct {
-	Plans         []*v1pb.Plan
-	Issues        []*v1pb.Issue
-	TaskRuns      []*v1pb.TaskRun
-	PlanCheckRuns []*v1pb.PlanCheckRun
-	IssueComments []*v1pb.IssueComment
+	Plans          []*v1pb.Plan
+	Issues         []*v1pb.Issue
+	TaskRuns       []*v1pb.TaskRun
+	TaskRunLogs    []*v1pb.TaskRunLog
+	PlanCheckRuns  []*v1pb.PlanCheckRun
+	IssueComments  []*v1pb.IssueComment
+	Releases       []*v1pb.Release
+	DatabaseGroups []*v1pb.DatabaseGroup
+	// PlanWebhookDeliveries is the only snapshot field read directly from
+	// the metadata DB — plan_webhook_delivery has no public gRPC read API.
+	PlanWebhookDeliveries []*planWebhookDelivery
 }
 
-// snapshotProject captures every plan/issue/task_run/plan_check_run row
-// visible to the public gRPC API for the given project. Every read goes
-// through the service layer (auth + audit), not the raw store — so a
-// read-path regression that leaks cross-project data would also surface in
-// these calls.
+// planWebhookDelivery is one row of the plan_webhook_delivery table, which
+// has no public gRPC read API. The collision suite snapshots it with the
+// table-specific direct DB read below (see AGENTS.md's allowance for
+// tables without public read APIs).
+type planWebhookDelivery struct {
+	PlanID      int64
+	EventType   string
+	DeliveredAt time.Time
+}
+
+// listPlanWebhookDeliveries reads every plan_webhook_delivery row for the
+// project directly from the test metadata database. This mirrors the raw
+// metadata-DB access pattern used elsewhere in backend/tests (e.g.
+// project_instance_archive_task_run_test.go).
+func listPlanWebhookDeliveries(ctx context.Context, t *testing.T, ctl *controller, projectID string) []*planWebhookDelivery {
+	t.Helper()
+	a := require.New(t)
+	db, err := sql.Open("pgx", ctl.profile.PgURL)
+	a.NoError(err, "open metadata DB")
+	defer db.Close()
+
+	rows, err := db.QueryContext(ctx, `
+		SELECT plan_id, event_type, delivered_at
+		FROM plan_webhook_delivery
+		WHERE project = $1
+		ORDER BY plan_id
+	`, projectID)
+	a.NoError(err, "query plan_webhook_delivery for project %s", projectID)
+	defer rows.Close()
+
+	var out []*planWebhookDelivery
+	for rows.Next() {
+		var d planWebhookDelivery
+		a.NoError(rows.Scan(&d.PlanID, &d.EventType, &d.DeliveredAt))
+		out = append(out, &d)
+	}
+	a.NoError(rows.Err())
+	return out
+}
+
+// snapshotProject captures every plan/issue/task_run/task_run_log/
+// plan_check_run/issue_comment/release/database_group row visible to the
+// public gRPC API for the given project, plus the project's raw
+// plan_webhook_delivery rows. Every read goes through the service layer
+// (auth + audit) where an API exists — so a read-path regression that
+// leaks cross-project data would also surface in these calls.
 //
 // PlanCheckRuns are fetched via GetPlanCheckRun(planName+"/planCheckRun"),
 // which is the single-consolidated-PCR endpoint the UI itself uses. One
@@ -609,6 +658,19 @@ func snapshotProject(
 		}
 	}
 
+	// task_run_log rows are exposed through GetTaskRunLog, one message per
+	// task run.
+	var taskRunLogs []*v1pb.TaskRunLog
+	for _, tr := range taskRuns {
+		logResp, err := ctl.rolloutServiceClient.GetTaskRunLog(ctx, connect.NewRequest(&v1pb.GetTaskRunLogRequest{
+			Parent: tr.Name,
+		}))
+		a.NoError(err, "GetTaskRunLog for task run %s", tr.Name)
+		a.True(strings.HasPrefix(logResp.Msg.Name, project.Name+"/"),
+			"GetTaskRunLog for task run %s returned %q — read-path leak", tr.Name, logResp.Msg.Name)
+		taskRunLogs = append(taskRunLogs, logResp.Msg)
+	}
+
 	var issueComments []*v1pb.IssueComment
 	for _, i := range issues {
 		icResp, err := ctl.issueServiceClient.ListIssueComments(ctx, connect.NewRequest(&v1pb.ListIssueCommentsRequest{
@@ -623,12 +685,38 @@ func snapshotProject(
 		issueComments = append(issueComments, icResp.Msg.IssueComments...)
 	}
 
+	releasesResp, err := ctl.releaseServiceClient.ListReleases(ctx, connect.NewRequest(&v1pb.ListReleasesRequest{
+		Parent:   project.Name,
+		PageSize: 1000,
+	}))
+	a.NoError(err, "ListReleases(%s)", project.Name)
+	for _, r := range releasesResp.Msg.Releases {
+		a.True(strings.HasPrefix(r.Name, project.Name+"/"),
+			"ListReleases(%s) returned %q — read-path leak", project.Name, r.Name)
+	}
+
+	groupsResp, err := ctl.databaseGroupServiceClient.ListDatabaseGroups(ctx, connect.NewRequest(&v1pb.ListDatabaseGroupsRequest{
+		Parent: project.Name,
+	}))
+	a.NoError(err, "ListDatabaseGroups(%s)", project.Name)
+	for _, g := range groupsResp.Msg.DatabaseGroups {
+		a.True(strings.HasPrefix(g.Name, project.Name+"/"),
+			"ListDatabaseGroups(%s) returned %q — read-path leak", project.Name, g.Name)
+	}
+
+	projectID, err := common.GetProjectID(project.Name)
+	a.NoError(err, "GetProjectID(%s)", project.Name)
+
 	return &projectSnapshot{
-		Plans:         plans,
-		Issues:        issues,
-		TaskRuns:      taskRuns,
-		PlanCheckRuns: planCheckRuns,
-		IssueComments: issueComments,
+		Plans:                 plans,
+		Issues:                issues,
+		TaskRuns:              taskRuns,
+		TaskRunLogs:           taskRunLogs,
+		PlanCheckRuns:         planCheckRuns,
+		IssueComments:         issueComments,
+		Releases:              releasesResp.Msg.Releases,
+		DatabaseGroups:        groupsResp.Msg.DatabaseGroups,
+		PlanWebhookDeliveries: listPlanWebhookDeliveries(ctx, t, ctl, projectID),
 	}
 }
 
@@ -671,6 +759,16 @@ func assertProjectUnchanged(
 		},
 		label, "task_run")
 
+	// task_run_log is keyed by composite (project, task_run_id); log rows
+	// are append-only once a task run is terminal, so any delta here means
+	// a cross-project write leaked into project B.
+	assertNoChange(t, before.TaskRunLogs, after.TaskRunLogs,
+		func(l *v1pb.TaskRunLog) string { return l.Name },
+		func(b, af *v1pb.TaskRunLog) {
+			a.True(proto.Equal(b, af), "%s: task_run_log %s content changed", label, b.Name)
+		},
+		label, "task_run_log")
+
 	assertNoChange(t, before.PlanCheckRuns, after.PlanCheckRuns,
 		func(p *v1pb.PlanCheckRun) string { return p.Name },
 		func(b, af *v1pb.PlanCheckRun) {
@@ -687,6 +785,29 @@ func assertProjectUnchanged(
 			a.Equal(b.Comment, af.Comment, "%s: issue_comment %s comment changed", label, b.Name)
 		},
 		label, "issue_comment")
+
+	assertNoChange(t, before.Releases, after.Releases,
+		func(r *v1pb.Release) string { return r.Name },
+		func(b, af *v1pb.Release) {
+			a.True(proto.Equal(b, af), "%s: release %s content changed", label, b.Name)
+		},
+		label, "release")
+
+	assertNoChange(t, before.DatabaseGroups, after.DatabaseGroups,
+		func(g *v1pb.DatabaseGroup) string { return g.Name },
+		func(b, af *v1pb.DatabaseGroup) {
+			a.Equal(b.Title, af.Title, "%s: database group %s title changed", label, b.Name)
+			a.True(proto.Equal(b.DatabaseExpr, af.DatabaseExpr), "%s: database group %s expression changed", label, b.Name)
+		},
+		label, "db_group")
+
+	assertNoChange(t, before.PlanWebhookDeliveries, after.PlanWebhookDeliveries,
+		func(d *planWebhookDelivery) string { return fmt.Sprintf("%d", d.PlanID) },
+		func(b, af *planWebhookDelivery) {
+			a.Equal(b.EventType, af.EventType, "%s: plan_webhook_delivery plan %d event_type changed", label, b.PlanID)
+			a.True(b.DeliveredAt.Equal(af.DeliveredAt), "%s: plan_webhook_delivery plan %d delivered_at changed", label, b.PlanID)
+		},
+		label, "plan_webhook_delivery")
 }
 
 // assertNoChange compares two row slices keyed by name, fails if any

--- a/backend/tests/project_instance_collision_extras_test.go
+++ b/backend/tests/project_instance_collision_extras_test.go
@@ -1,0 +1,325 @@
+package tests
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/type/expr"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/bytebase/bytebase/backend/common"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+)
+
+// TestCollision_PlanWebhookDeliveryWrite verifies that claiming a
+// PIPELINE_COMPLETED webhook delivery for a plan in project A writes a
+// plan_webhook_delivery row scoped by (project, plan_id) without touching
+// project B's rows — even though the two projects' plan ids collide under
+// the composite primary key.
+func TestCollision_PlanWebhookDeliveryWrite(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	fixture := setupCollidingProjects(ctx, t, ctl)
+
+	// Give project B a completed rollout too, so B owns a
+	// plan_webhook_delivery row whose plan id collides with the fresh
+	// project-A plan we are about to roll out.
+	planB2, issueB2, rolloutB2 := createPlanIssueRollout(ctx, t, ctl, fixture.ProjectB, fixture.DatabaseB, "webhook delivery test B")
+	a.NoError(ctl.waitRollout(ctx, issueB2.Name, rolloutB2.Name))
+
+	projectBID, err := common.GetProjectID(fixture.ProjectB.Name)
+	a.NoError(err)
+	_, planB2UID, err := common.GetProjectIDPlanID(planB2.Name)
+	a.NoError(err)
+	// The scheduler claims the delivery row asynchronously after the last
+	// task is marked DONE, so wait for the row to land before snapshotting.
+	waitForPlanWebhookDelivery(ctx, t, ctl, projectBID, planB2UID)
+	// The fixture's create-database plan also claims PIPELINE_COMPLETED
+	// asynchronously during setup; wait for the whole row set to settle so a
+	// late legitimate claim cannot masquerade as a cross-project leak.
+	waitForPlanWebhookDeliveriesStable(ctx, t, ctl, projectBID)
+
+	beforeB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
+	a.NotEmpty(beforeB.PlanWebhookDeliveries, "project B should own PIPELINE_COMPLETED delivery rows")
+	foundB2Delivery := false
+	for _, d := range beforeB.PlanWebhookDeliveries {
+		if d.PlanID == planB2UID {
+			foundB2Delivery = true
+			break
+		}
+	}
+	a.True(foundB2Delivery, "project B should own the delivery row for its plan %d", planB2UID)
+
+	// Roll out a fresh plan in project A whose plan id collides with B2's.
+	planA2, issueA2, rolloutA2 := createPlanIssueRollout(ctx, t, ctl, fixture.ProjectA, fixture.DatabaseA, "webhook delivery test A")
+	_, planA2UID, err := common.GetProjectIDPlanID(planA2.Name)
+	a.NoError(err)
+	a.Equal(planA2UID, planB2UID, "plan ids must collide across projects for the composite-PK case")
+
+	a.NoError(ctl.waitRollout(ctx, issueA2.Name, rolloutA2.Name))
+
+	// Positive check: project A actually claimed its delivery row. Without
+	// this, a regression that turned the claim into a no-op (e.g. resolving
+	// project B's plan by colliding plan id alone) would still pass the
+	// project-B-unchanged check below.
+	projectAID, err := common.GetProjectID(fixture.ProjectA.Name)
+	a.NoError(err)
+	waitForPlanWebhookDelivery(ctx, t, ctl, projectAID, planA2UID)
+
+	afterB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
+	assertProjectUnchanged(t, beforeB, afterB, "project B after plan A webhook delivery claim")
+}
+
+// waitForPlanWebhookDelivery polls the metadata DB until the
+// plan_webhook_delivery row for (projectID, planUID) appears. The claim
+// runs in the scheduler after the rollout's last task is marked DONE, so
+// the row may land slightly after waitRollout returns.
+func waitForPlanWebhookDelivery(ctx context.Context, t *testing.T, ctl *controller, projectID string, planUID int64) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		for _, d := range listPlanWebhookDeliveries(ctx, t, ctl, projectID) {
+			if d.PlanID == planUID {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			require.Failf(t, "timed out waiting for plan webhook delivery",
+				"no plan_webhook_delivery row for project %s plan %d", projectID, planUID)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// waitForPlanWebhookDeliveriesStable polls until the project's
+// plan_webhook_delivery row set stops changing for a full second. Delivery
+// claims run in the scheduler after a rollout completes, so a snapshot must
+// not race a legitimate late claim.
+func waitForPlanWebhookDeliveriesStable(ctx context.Context, t *testing.T, ctl *controller, projectID string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	lastCount := -1
+	stableSince := time.Now()
+	for {
+		count := len(listPlanWebhookDeliveries(ctx, t, ctl, projectID))
+		if count != lastCount {
+			lastCount = count
+			stableSince = time.Now()
+		}
+		if time.Since(stableSince) >= time.Second {
+			return
+		}
+		if time.Now().After(deadline) {
+			require.Failf(t, "timed out waiting for plan webhook deliveries to stabilize",
+				"project %s delivery rows kept changing; last count %d", projectID, lastCount)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// TestCollision_TaskRunLogWrite verifies that executing a rollout in
+// project A writes task_run_log rows scoped by (project, task_run_id)
+// without touching project B's rows, even though task run ids collide
+// across the two projects.
+func TestCollision_TaskRunLogWrite(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	fixture := setupCollidingProjects(ctx, t, ctl)
+	fixture.completeRolloutB(ctx, t, ctl)
+
+	// Give project B a second completed rollout (plan B2, task run UID 2)
+	// so B owns task_run_log rows whose ids collide with the fresh
+	// project-A rollout we are about to run.
+	planB2, issueB2, rolloutB2 := createPlanIssueRollout(ctx, t, ctl, fixture.ProjectB, fixture.DatabaseB, "task run log test B")
+	a.NoError(ctl.waitRollout(ctx, issueB2.Name, rolloutB2.Name))
+
+	beforeB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
+	a.Greater(len(beforeB.TaskRunLogs), 0, "project B should own task_run_log rows after its rollout")
+
+	// Roll out a fresh plan in project A whose task run ids collide with
+	// B2's.
+	planA2, issueA2, rolloutA2 := createPlanIssueRollout(ctx, t, ctl, fixture.ProjectA, fixture.DatabaseA, "task run log test A")
+	a.NoError(ctl.waitRollout(ctx, issueA2.Name, rolloutA2.Name))
+
+	// The task runs of the second pair must genuinely collide, otherwise a
+	// cross-project write could not be detected (B has no task run with
+	// A2's UID, so the FK on (project, task_run_id) would reject it).
+	a2TaskRunUIDs, _ := listTaskRunAndTaskUIDs(ctx, t, ctl, planA2.Name)
+	b2TaskRunUIDs, _ := listTaskRunAndTaskUIDs(ctx, t, ctl, planB2.Name)
+	a.Greater(len(a2TaskRunUIDs), 0, "project A's fresh plan should have task runs")
+	assertAtLeastOneUIDCollides(t, a2TaskRunUIDs, b2TaskRunUIDs, "task_run (second pair)")
+
+	// Positive check: project A's fresh task run actually wrote log rows.
+	a2Logs := listTaskRunLogsForPlan(ctx, t, ctl, planA2.Name)
+	a.NotEmpty(a2Logs, "project A plan A2 should have task runs")
+	totalEntries := 0
+	for _, l := range a2Logs {
+		totalEntries += len(l.Entries)
+	}
+	a.Greater(totalEntries, 0, "project A's plan A2 task run should have written task_run_log entries")
+
+	afterB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
+	assertProjectUnchanged(t, beforeB, afterB, "project B after task run log write in project A")
+}
+
+// listTaskRunLogsForPlan returns the task run log messages for every task
+// run under the plan, via the public GetTaskRunLog API.
+func listTaskRunLogsForPlan(ctx context.Context, t *testing.T, ctl *controller, planName string) []*v1pb.TaskRunLog {
+	t.Helper()
+	a := require.New(t)
+	resp, err := ctl.rolloutServiceClient.ListTaskRuns(ctx, connect.NewRequest(&v1pb.ListTaskRunsRequest{
+		Parent: planName + "/rollout/stages/-/tasks/-",
+	}))
+	a.NoError(err, "ListTaskRuns(%s)", planName)
+	var logs []*v1pb.TaskRunLog
+	for _, tr := range resp.Msg.TaskRuns {
+		logResp, err := ctl.rolloutServiceClient.GetTaskRunLog(ctx, connect.NewRequest(&v1pb.GetTaskRunLogRequest{
+			Parent: tr.Name,
+		}))
+		a.NoError(err, "GetTaskRunLog(%s)", tr.Name)
+		logs = append(logs, logResp.Msg)
+	}
+	return logs
+}
+
+// TestCollision_DbGroupWrite verifies that creating and updating a
+// database group in project A writes db_group rows scoped by
+// (project, resource_id) without touching project B's rows, even though
+// both projects use the same group resource id.
+func TestCollision_DbGroupWrite(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	fixture := setupCollidingProjects(ctx, t, ctl)
+
+	// Project B owns the baseline group with resource id "collide-group".
+	_, err = ctl.databaseGroupServiceClient.CreateDatabaseGroup(ctx, connect.NewRequest(&v1pb.CreateDatabaseGroupRequest{
+		Parent:          fixture.ProjectB.Name,
+		DatabaseGroupId: "collide-group",
+		DatabaseGroup: &v1pb.DatabaseGroup{
+			Title:        "B group",
+			DatabaseExpr: &expr.Expr{Expression: "true"},
+		},
+	}))
+	a.NoError(err)
+
+	beforeB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
+	a.Len(beforeB.DatabaseGroups, 1, "project B should own one database group")
+
+	// Same resource id in project A — (project, resource_id) collides.
+	groupA, err := ctl.databaseGroupServiceClient.CreateDatabaseGroup(ctx, connect.NewRequest(&v1pb.CreateDatabaseGroupRequest{
+		Parent:          fixture.ProjectA.Name,
+		DatabaseGroupId: "collide-group",
+		DatabaseGroup: &v1pb.DatabaseGroup{
+			Title:        "A group",
+			DatabaseExpr: &expr.Expr{Expression: "true"},
+		},
+	}))
+	a.NoError(err)
+	_, groupAID, err := common.GetProjectIDDatabaseGroupID(groupA.Msg.Name)
+	a.NoError(err)
+	a.Equal("collide-group", groupAID, "database group resource id must collide across projects")
+
+	// Exercise the update writer (Store.UpdateDatabaseGroup) as well.
+	_, err = ctl.databaseGroupServiceClient.UpdateDatabaseGroup(ctx, connect.NewRequest(&v1pb.UpdateDatabaseGroupRequest{
+		DatabaseGroup: &v1pb.DatabaseGroup{
+			Name:         groupA.Msg.Name,
+			Title:        "A group updated",
+			DatabaseExpr: &expr.Expr{Expression: `resource.database_name.startsWith("collision_")`},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"title", "database_expr"}},
+	}))
+	a.NoError(err)
+
+	// Positive check: the update landed on project A's group, not B's.
+	gotA, err := ctl.databaseGroupServiceClient.GetDatabaseGroup(ctx, connect.NewRequest(&v1pb.GetDatabaseGroupRequest{
+		Name: groupA.Msg.Name,
+	}))
+	a.NoError(err)
+	a.Equal("A group updated", gotA.Msg.Title)
+
+	afterB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
+	assertProjectUnchanged(t, beforeB, afterB, "project B after database group write in project A")
+}
+
+// TestCollision_ReleaseWrite verifies that creating a release in project A
+// writes a release row scoped by (project, train, iteration) without
+// touching project B's rows, even though both projects produce the same
+// release id (same train and iteration).
+func TestCollision_ReleaseWrite(t *testing.T) {
+	t.Parallel()
+	a := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	fixture := setupCollidingProjects(ctx, t, ctl)
+
+	const releaseIDTemplate = "collision_{date}-RC{iteration}"
+	createRelease := func(project *v1pb.Project, category string) *v1pb.Release {
+		t.Helper()
+		resp, err := ctl.releaseServiceClient.CreateRelease(ctx, connect.NewRequest(&v1pb.CreateReleaseRequest{
+			Parent:            project.Name,
+			ReleaseIdTemplate: releaseIDTemplate,
+			Release: &v1pb.Release{
+				Type:     v1pb.Release_VERSIONED,
+				Category: category,
+				Files: []*v1pb.Release_File{{
+					Path:      "V0001__create.sql",
+					Version:   "1",
+					Statement: []byte("CREATE TABLE t1 (id int);"),
+				}},
+			},
+		}))
+		a.NoError(err, "CreateRelease(%s)", project.Name)
+		return resp.Msg
+	}
+
+	// Project B owns the baseline release with the same train as project A's.
+	releaseB := createRelease(fixture.ProjectB, "b")
+
+	beforeB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
+	a.Len(beforeB.Releases, 1, "project B should own one release")
+
+	// Same template and first iteration (0) in both projects — the
+	// (project, train, iteration) primary key collides across projects.
+	releaseA := createRelease(fixture.ProjectA, "a")
+	_, releaseAID, err := common.GetProjectReleaseID(releaseA.Name)
+	a.NoError(err)
+	_, releaseBID, err := common.GetProjectReleaseID(releaseB.Name)
+	a.NoError(err)
+	a.Equal(releaseBID, releaseAID, "release ids must collide across projects (same train and iteration)")
+
+	// Positive check: project A really owns its release.
+	gotA := snapshotProject(ctx, t, ctl, fixture.ProjectA)
+	a.Len(gotA.Releases, 1, "project A should own its release")
+
+	afterB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
+	assertProjectUnchanged(t, beforeB, afterB, "project B after release write in project A")
+}

--- a/backend/tests/project_instance_collision_extras_test.go
+++ b/backend/tests/project_instance_collision_extras_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -75,9 +76,20 @@ func TestCollision_PlanWebhookDeliveryWrite(t *testing.T) {
 	projectAID, err := common.GetProjectID(fixture.ProjectA.Name)
 	a.NoError(err)
 	waitForPlanWebhookDelivery(ctx, t, ctl, projectAID, planA2UID)
+	// Project B's delivery row set was stabilized before the baseline; the
+	// webhook table is async-claimed so it is compared here explicitly
+	// rather than inside the generic assertProjectUnchanged.
+	waitForPlanWebhookDeliveriesStable(ctx, t, ctl, projectBID)
 
 	afterB := snapshotProject(ctx, t, ctl, fixture.ProjectB)
 	assertProjectUnchanged(t, beforeB, afterB, "project B after plan A webhook delivery claim")
+	assertNoChange(t, beforeB.PlanWebhookDeliveries, afterB.PlanWebhookDeliveries,
+		func(d *planWebhookDelivery) string { return fmt.Sprintf("%d", d.PlanID) },
+		func(b, af *planWebhookDelivery) {
+			a.Equal(b.EventType, af.EventType, "project B plan_webhook_delivery plan %d event_type changed", b.PlanID)
+			a.True(b.DeliveredAt.Equal(af.DeliveredAt), "project B plan_webhook_delivery plan %d delivered_at changed", b.PlanID)
+		},
+		"project B after plan A webhook delivery claim", "plan_webhook_delivery")
 }
 
 // waitForPlanWebhookDelivery polls the metadata DB until the

--- a/backend/tests/project_instance_compat_extras_test.go
+++ b/backend/tests/project_instance_compat_extras_test.go
@@ -1,0 +1,333 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/alexmullins/zip"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/bytebase/bytebase/backend/common"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+)
+
+// TestProjectInstanceExport verifies that SQL export accepts the canonical
+// project-scoped database name for a database on a project instance and
+// rejects cross-project and workspace-form names for the same database.
+func TestProjectInstanceExport(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	pg, err := provisionPgInstance(ctx, t)
+	a.NoError(err)
+	const instanceID = "bot37-export-instance"
+	const databaseID = "bot37_export_database"
+	createPgDatabase(t, pg, databaseID)
+
+	instance := createProjectInstanceTestInstance(ctx, t, ctl, &ctl.project.Name, instanceID, "export project instance", pg)
+	_, err = ctl.instanceServiceClient.SyncInstance(ctx, connect.NewRequest(&v1pb.SyncInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	databaseName := fmt.Sprintf("%s/databases/%s", instance.Name, databaseID)
+	database, err := ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+	a.Equal(databaseName, database.Msg.Name)
+	a.Equal(ctl.project.Name, database.Msg.Project)
+	_, err = ctl.databaseServiceClient.SyncDatabase(ctx, connect.NewRequest(&v1pb.SyncDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+
+	export := func(name string) error {
+		_, err := ctl.sqlServiceClient.Export(ctx, connect.NewRequest(&v1pb.ExportRequest{
+			Name:         name,
+			Format:       v1pb.ExportFormat_CSV,
+			Statement:    "SELECT 1;",
+			DataSourceId: "admin",
+		}))
+		return err
+	}
+
+	// The canonical project-scoped name succeeds and yields a parseable export.
+	exportResp, err := ctl.sqlServiceClient.Export(ctx, connect.NewRequest(&v1pb.ExportRequest{
+		Name:         databaseName,
+		Format:       v1pb.ExportFormat_CSV,
+		Statement:    "SELECT 1;",
+		DataSourceId: "admin",
+	}))
+	a.NoError(err)
+	zipReader, err := zip.NewReader(bytes.NewReader(exportResp.Msg.Content), int64(len(exportResp.Msg.Content)))
+	a.NoError(err)
+	a.NotEmpty(zipReader.File)
+	foundResult := false
+	for _, compressedFile := range zipReader.File {
+		if !strings.HasSuffix(compressedFile.Name, ".result.csv") {
+			continue
+		}
+		foundResult = true
+		file, err := compressedFile.Open()
+		a.NoError(err)
+		content, err := io.ReadAll(file)
+		a.NoError(err)
+		a.Equal("?column?\n1", string(content))
+	}
+	a.True(foundResult, "export zip must contain a .result.csv file")
+
+	// A cross-project name for the same database is rejected.
+	otherProject := createProjectForProjectInstanceTest(ctx, t, ctl, "bot37-export-other-project")
+	crossProjectName := fmt.Sprintf("%s/instances/%s/databases/%s", otherProject.Name, instanceID, databaseID)
+	err = export(crossProjectName)
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
+
+	// The workspace-form name for a project-instance database is rejected by
+	// the ACL layer (workspace-scoped instance resolution) before the handler
+	// runs, so it can never leak through the workspace alias.
+	workspaceFormName := fmt.Sprintf("instances/%s/databases/%s", instanceID, databaseID)
+	err = export(workspaceFormName)
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
+	a.Contains(err.Error(), fmt.Sprintf("instance %q not found", instanceID))
+}
+
+// TestProjectInstanceWorksheet verifies that worksheets accept the canonical
+// project-scoped database name for databases on a project instance and reject
+// cross-project references.
+func TestProjectInstanceWorksheet(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	pg, err := provisionPgInstance(ctx, t)
+	a.NoError(err)
+	const instanceID = "bot37-worksheet-instance"
+	const databaseID = "bot37_worksheet_database"
+	createPgDatabase(t, pg, databaseID)
+
+	instance := createProjectInstanceTestInstance(ctx, t, ctl, &ctl.project.Name, instanceID, "worksheet project instance", pg)
+	_, err = ctl.instanceServiceClient.SyncInstance(ctx, connect.NewRequest(&v1pb.SyncInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	databaseName := fmt.Sprintf("%s/databases/%s", instance.Name, databaseID)
+	_, err = ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+
+	createWorksheet := func(database string) (*v1pb.Worksheet, error) {
+		resp, err := ctl.worksheetServiceClient.CreateWorksheet(ctx, connect.NewRequest(&v1pb.CreateWorksheetRequest{
+			Parent: ctl.project.Name,
+			Worksheet: &v1pb.Worksheet{
+				Title:      "project instance worksheet",
+				Content:    []byte("SELECT 1;"),
+				Database:   database,
+				Visibility: v1pb.Worksheet_PRIVATE,
+			},
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return resp.Msg, nil
+	}
+
+	// The canonical project-scoped name is accepted and retained.
+	created, err := createWorksheet(databaseName)
+	a.NoError(err)
+	a.Equal(databaseName, created.Database)
+	got, err := ctl.worksheetServiceClient.GetWorksheet(ctx, connect.NewRequest(&v1pb.GetWorksheetRequest{Name: created.Name}))
+	a.NoError(err)
+	a.Equal(databaseName, got.Msg.Database)
+
+	// A project-instance database referenced from a different project is
+	// rejected with NotFound rather than leaking across projects.
+	otherProject := createProjectForProjectInstanceTest(ctx, t, ctl, "bot37-worksheet-other-project")
+	crossProjectName := fmt.Sprintf("%s/instances/%s/databases/%s", otherProject.Name, instanceID, databaseID)
+	_, err = createWorksheet(crossProjectName)
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
+	projectID, projectIDErr := common.GetProjectID(ctl.project.Name)
+	a.NoError(projectIDErr)
+	a.Contains(err.Error(), fmt.Sprintf("database %q not found in project %q", crossProjectName, projectID))
+
+	// The workspace-form name for a project-instance database is rejected as
+	// non-canonical instead of resolving through the workspace alias.
+	workspaceFormName := fmt.Sprintf("instances/%s/databases/%s", instanceID, databaseID)
+	_, err = createWorksheet(workspaceFormName)
+	a.Error(err)
+	a.Equal(connect.CodeInvalidArgument, connect.CodeOf(err))
+	a.Contains(err.Error(), fmt.Sprintf("database name %q is not canonical for its instance", workspaceFormName))
+}
+
+// TestProjectInstanceAccessGrant verifies that access grants targeting a
+// project-instance database work inside the owning project and are rejected
+// across projects.
+func TestProjectInstanceAccessGrant(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	pg, err := provisionPgInstance(ctx, t)
+	a.NoError(err)
+	const instanceID = "bot37-grant-instance"
+	const databaseID = "bot37_grant_database"
+	createPgDatabase(t, pg, databaseID)
+
+	instance := createProjectInstanceTestInstance(ctx, t, ctl, &ctl.project.Name, instanceID, "grant project instance", pg)
+	_, err = ctl.instanceServiceClient.SyncInstance(ctx, connect.NewRequest(&v1pb.SyncInstanceRequest{Name: instance.Name}))
+	a.NoError(err)
+	databaseName := fmt.Sprintf("%s/databases/%s", instance.Name, databaseID)
+	_, err = ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+	_, err = ctl.databaseServiceClient.SyncDatabase(ctx, connect.NewRequest(&v1pb.SyncDatabaseRequest{Name: databaseName}))
+	a.NoError(err)
+
+	createGrant := func(parent string, targets []string) (*v1pb.AccessGrant, error) {
+		resp, err := ctl.accessGrantServiceClient.CreateAccessGrant(ctx, connect.NewRequest(&v1pb.CreateAccessGrantRequest{
+			Parent: parent,
+			AccessGrant: &v1pb.AccessGrant{
+				Creator:    ctl.principalName,
+				Targets:    targets,
+				Query:      "SELECT 1",
+				Reason:     "bot37 access grant compatibility",
+				Expiration: &v1pb.AccessGrant_Ttl{Ttl: durationpb.New(time.Hour)},
+			},
+		}))
+		if err != nil {
+			return nil, err
+		}
+		return resp.Msg, nil
+	}
+
+	// A grant targeting the canonical project-scoped database works in the
+	// owning project and retains the target.
+	grant, err := createGrant(ctl.project.Name, []string{databaseName})
+	a.NoError(err)
+	a.NotEmpty(grant.Name)
+	a.Equal([]string{databaseName}, grant.Targets)
+
+	// The same database targeted from a different project is rejected.
+	otherProject := createProjectForProjectInstanceTest(ctx, t, ctl, "bot37-grant-other-project")
+	_, err = createGrant(otherProject.Name, []string{databaseName})
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
+	a.Contains(err.Error(), fmt.Sprintf("database %q not found in project %q", databaseName, "bot37-grant-other-project"))
+
+	// A project-scoped target naming a different project is rejected even when
+	// requested inside the owning project.
+	crossProjectName := fmt.Sprintf("%s/instances/%s/databases/%s", otherProject.Name, instanceID, databaseID)
+	_, err = createGrant(ctl.project.Name, []string{crossProjectName})
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
+	projectID, projectIDErr := common.GetProjectID(ctl.project.Name)
+	a.NoError(projectIDErr)
+	a.Contains(err.Error(), fmt.Sprintf("database %q not found in project %q", crossProjectName, projectID))
+
+	// The workspace-form target for a project-instance database is rejected as
+	// non-canonical instead of resolving through the workspace alias.
+	workspaceFormName := fmt.Sprintf("instances/%s/databases/%s", instanceID, databaseID)
+	_, err = createGrant(ctl.project.Name, []string{workspaceFormName})
+	a.Error(err)
+	a.Equal(connect.CodeInvalidArgument, connect.CodeOf(err))
+	a.Contains(err.Error(), fmt.Sprintf("target %q is not canonical for its instance", workspaceFormName))
+}
+
+// TestBatchSyncInstancesCompatibility verifies BatchSyncInstances collection
+// enforcement with mixed workspace and project instance targets, rejection of
+// invalid members with zero side effects, and retained workspace batch
+// behavior.
+func TestBatchSyncInstancesCompatibility(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	pg, err := provisionPgInstance(ctx, t)
+	a.NoError(err)
+	const (
+		workspaceInstanceID = "bot37-batch-workspace-instance"
+		projectInstanceID   = "bot37-batch-project-instance"
+		workspaceDB         = "bot37_batch_ws_db"
+		workspaceNewDB      = "bot37_batch_ws_new_db"
+		projectDB           = "bot37_batch_proj_db"
+		projectNewDB        = "bot37_batch_proj_new_db"
+	)
+	// Create both instances while the server has no physical databases yet:
+	// instance creation itself discovers databases, so the "zero side
+	// effects" probes below rely on databases created after both instances.
+	workspaceInstance := createProjectInstanceTestInstance(ctx, t, ctl, nil, workspaceInstanceID, "batch workspace instance", pg)
+	a.Equal("instances/"+workspaceInstanceID, workspaceInstance.Name)
+	projectInstance := createProjectInstanceTestInstance(ctx, t, ctl, &ctl.project.Name, projectInstanceID, "batch project instance", pg)
+	a.Equal(fmt.Sprintf("%s/instances/%s", ctl.project.Name, projectInstanceID), projectInstance.Name)
+	for _, database := range []string{workspaceDB, workspaceNewDB, projectDB, projectNewDB} {
+		createPgDatabase(t, pg, database)
+	}
+
+	workspaceDBName := fmt.Sprintf("instances/%s/databases/%s", workspaceInstanceID, workspaceDB)
+	workspaceNewDBName := fmt.Sprintf("instances/%s/databases/%s", workspaceInstanceID, workspaceNewDB)
+	projectDBName := fmt.Sprintf("%s/instances/%s/databases/%s", ctl.project.Name, projectInstanceID, projectDB)
+	projectNewDBName := fmt.Sprintf("%s/instances/%s/databases/%s", ctl.project.Name, projectInstanceID, projectNewDB)
+
+	getDatabase := func(name string) error {
+		_, err := ctl.databaseServiceClient.GetDatabase(ctx, connect.NewRequest(&v1pb.GetDatabaseRequest{Name: name}))
+		return err
+	}
+	batchSync := func(parent *string, names ...string) error {
+		requests := make([]*v1pb.SyncInstanceRequest, 0, len(names))
+		for _, name := range names {
+			requests = append(requests, &v1pb.SyncInstanceRequest{Name: name})
+		}
+		_, err := ctl.instanceServiceClient.BatchSyncInstances(ctx, connect.NewRequest(&v1pb.BatchSyncInstancesRequest{
+			Parent:   parent,
+			Requests: requests,
+		}))
+		return err
+	}
+
+	// A project instance is not in the workspace collection: the mixed batch is
+	// rejected before any member is synced.
+	err = batchSync(nil, workspaceInstance.Name, projectInstance.Name)
+	a.Error(err)
+	a.Equal(connect.CodeInvalidArgument, connect.CodeOf(err))
+	a.Contains(err.Error(), fmt.Sprintf("instance %q is not in its requested collection", projectInstance.Name))
+	a.Error(getDatabase(workspaceNewDBName), "a rejected batch must not sync the workspace member")
+	a.Error(getDatabase(workspaceDBName))
+
+	// A workspace instance is not in the project collection either.
+	err = batchSync(&ctl.project.Name, projectInstance.Name, workspaceInstance.Name)
+	a.Error(err)
+	a.Equal(connect.CodeInvalidArgument, connect.CodeOf(err))
+	a.Contains(err.Error(), fmt.Sprintf("instance %q is not in its requested collection", workspaceInstance.Name))
+	a.Error(getDatabase(projectNewDBName), "a rejected batch must not sync the project member")
+	a.Error(getDatabase(projectDBName))
+
+	// A nonexistent member aborts the whole batch with zero side effects.
+	err = batchSync(nil, workspaceInstance.Name, "instances/bot37-batch-ghost")
+	a.Error(err)
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
+	a.Error(getDatabase(workspaceNewDBName), "a batch with an invalid member must not sync the valid member")
+
+	// A functional batch over the exact project collection syncs the project
+	// instance and discovers both pre-existing databases.
+	a.NoError(batchSync(&ctl.project.Name, projectInstance.Name))
+	a.NoError(getDatabase(projectDBName))
+	a.NoError(getDatabase(projectNewDBName))
+
+	// Workspace batch behavior is retained: a batch without a parent syncs
+	// workspace instances.
+	a.NoError(batchSync(nil, workspaceInstance.Name))
+	a.NoError(getDatabase(workspaceDBName))
+	a.NoError(getDatabase(workspaceNewDBName))
+}

--- a/docs/pre-pr-checklist.md
+++ b/docs/pre-pr-checklist.md
@@ -89,10 +89,12 @@ If the diff adds or modifies a store method that touches a composite-PK table:
 1. Check if a corresponding `TestCollision*` or `TestClaim*` test exists in `backend/tests/`
 2. If not, add one using `setupCollidingProjects` and `assertProjectUnchanged` from
    `backend/tests/collision_helper_test.go`. The shared snapshot covers `plan`,
-   `issue`, `task`, `task_run`, `plan_check_run`, `task_run_log`, `db_group`,
-   `release`, and `plan_webhook_delivery` (public APIs where one exists; the
-   `plan_webhook_delivery` snapshot uses a table-specific raw metadata-DB read
-   because it has no public read API). For methods touching any future table
+   `issue`, `task`, `task_run`, `plan_check_run`, `task_run_log`, `db_group`, and
+   `release` (public APIs where one exists). `plan_webhook_delivery` is covered by the
+   dedicated `TestCollision_PlanWebhookDeliveryWrite` with a table-specific raw
+   metadata-DB read and explicit stabilization — its rows are claimed asynchronously
+   after rollout completion, so it is deliberately kept out of the generic snapshot to
+   avoid spurious cross-project-leak failures. For methods touching any future table
    outside that set, add table-specific assertions inline — or extend the shared
    helper first
 3. If your test needs project B rolled out (to create task/task_run/plan_check_run

--- a/docs/pre-pr-checklist.md
+++ b/docs/pre-pr-checklist.md
@@ -88,10 +88,13 @@ If the diff adds or modifies a store method that touches a composite-PK table:
 
 1. Check if a corresponding `TestCollision*` or `TestClaim*` test exists in `backend/tests/`
 2. If not, add one using `setupCollidingProjects` and `assertProjectUnchanged` from
-   `backend/tests/collision_helper_test.go`. Note: the shared snapshot currently
-   covers `plan`, `issue`, `task`, `task_run`, and `plan_check_run`. For methods
-   touching `task_run_log`, `plan_webhook_delivery`, `db_group`, or `release`,
-   add table-specific assertions inline — the shared helper is not sufficient
+   `backend/tests/collision_helper_test.go`. The shared snapshot covers `plan`,
+   `issue`, `task`, `task_run`, `plan_check_run`, `task_run_log`, `db_group`,
+   `release`, and `plan_webhook_delivery` (public APIs where one exists; the
+   `plan_webhook_delivery` snapshot uses a table-specific raw metadata-DB read
+   because it has no public read API). For methods touching any future table
+   outside that set, add table-specific assertions inline — or extend the shared
+   helper first
 3. If your test needs project B rolled out (to create task/task_run/plan_check_run
    rows that could collide with project A's), call `fixture.completeRolloutB(ctx, t, ctl)`
    — this is the ONLY supported rollout path and it proves `task` and `task_run`
@@ -100,7 +103,10 @@ If the diff adds or modifies a store method that touches a composite-PK table:
    from public gRPC. The PCR claim test is belt-and-suspenders coverage; the
    load-bearing regression lock is the task_run claim test.) Do NOT hand-roll
    `CreateRollout` + `waitRollout` — the collision invariant must not be a
-   per-test responsibility
+   per-test responsibility. Tests that need a second colliding rollout pair
+   (e.g. `task_run_log` or `plan_webhook_delivery` writers) use
+   `createPlanIssueRollout` for both projects and assert the second pair's
+   plan/task-run UIDs collide explicitly
 4. If testing delete cascades across projects where both projects share an
    instance, also consider adding a variant using `setupCollidingProjectsSeparateInstances`
    to catch cross-project over-delete bugs that shared-instance tests cannot detect


### PR DESCRIPTION
Closes BOT-37 (Linear). Final integration and verification gate for Project Instance compatibility per spec BOT-34.

## What changed

Verification coverage closed (all through public v1 API on real PostgreSQL unless noted):

- **Resource names** — `TestGetDatabaseResourceNameWithSuffix` now covers schema/sdlSchema/schemaString/catalog suffixes in both Workspace and Project hierarchies plus malformed, shortened, and cross-scope negatives.
- **Workflows** — new public-API tests for exports, worksheets, access grants, and functional batch sync against Project Instance targets, including cross-project rejection.
- **Collision suite** — shared snapshot/assertion helper now covers `task_run_log`, `release`, `db_group`, and `plan_webhook_delivery`; four new `TestCollision_*` writers added. AGENTS.md + pre-pr-checklist updated to match.
- **Audit retention** — replaced no-op documentation tests with real enforcement tests: FREE → PermissionDenied, TEAM → 7-day cutoff excludes old rows (canonical names asserted), ENTERPRISE → unlimited, plus the exact cutoff `>=` boundary.
- **Hardening** — `pg.GetQuerySpan` now returns an error for never-synced databases instead of panicking (Access Grant approval 500); `directory_sync.go` lint fix (revive package-naming).

## Verification

- `buf format` / `buf lint` clean; generated artifacts fresh.
- `golangci-lint run --fix --allow-parallel-runners` → 0 issues.
- Full migrator, common, parser/pg, api/v1, store (concurrency suite ×2, both lock directions), and backend/tests collision + project-instance suites pass.
- Production build succeeds with release flags.

## Notes

- Found a pre-existing (non-project-instance) 500 panic when creating an access grant for a never schema-synced database — fixed with a nil-metadata guard and regression test.
- Migration upgrade-chain test and pagination token collection binding are intentionally not part of this PR.