### PR TITLE
fix: drop task_run_log primary key to unblock 3.16.2 upgrades

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,10 @@ The canonical frontend ownership map is in `./frontend/AGENTS.md`. In summary:
 
 Several tables use composite primary keys (e.g., `(project, id)`). Check
 `backend/migrator/migration/LATEST.sql` for the full list — any table with a
-multi-column PRIMARY KEY.
+multi-column PRIMARY KEY. `task_run_log` deliberately has no primary key (it is
+an append-only log whose entries can share a `created_at` microsecond,
+BYT-10035) but is equally project-scoped, so the same predicate rules apply to
+it.
 
 When writing or modifying queries on these tables:
 - Every WHERE, JOIN, USING, DELETE, and UPDATE predicate must include every

--- a/backend/api/v1/rollout_service_converter.go
+++ b/backend/api/v1/rollout_service_converter.go
@@ -354,6 +354,23 @@ func convertToTaskRunLog(parent string, logs []*store.TaskRunLog) *v1pb.TaskRunL
 
 func convertToTaskRunLogEntries(logs []*store.TaskRunLog) []*v1pb.TaskRunLogEntry {
 	var entries []*v1pb.TaskRunLogEntry
+	// task_run_log rows have no per-row sequence and can share a created_at
+	// microsecond, so an end/response event may not directly follow its start
+	// entry. Attach each one to the nearest entry of the matching type that is
+	// still awaiting its end instead of requiring strict adjacency.
+	unpaired := map[v1pb.TaskRunLogEntry_Type][]int{}
+	push := func(t v1pb.TaskRunLogEntry_Type) {
+		unpaired[t] = append(unpaired[t], len(entries)-1)
+	}
+	pop := func(t v1pb.TaskRunLogEntry_Type) *v1pb.TaskRunLogEntry {
+		stack := unpaired[t]
+		if len(stack) == 0 {
+			return nil
+		}
+		i := stack[len(stack)-1]
+		unpaired[t] = stack[:len(stack)-1]
+		return entries[i]
+	}
 	for _, l := range logs {
 		switch l.Payload.Type {
 		case storepb.TaskRunLog_SCHEMA_DUMP_START:
@@ -365,13 +382,11 @@ func convertToTaskRunLogEntries(logs []*store.TaskRunLog) []*v1pb.TaskRunLogEntr
 					StartTime: timestamppb.New(l.T),
 				},
 			})
+			push(v1pb.TaskRunLogEntry_SCHEMA_DUMP)
 
 		case storepb.TaskRunLog_SCHEMA_DUMP_END:
-			if len(entries) == 0 {
-				continue
-			}
-			prev := entries[len(entries)-1]
-			if prev == nil || prev.Type != v1pb.TaskRunLogEntry_SCHEMA_DUMP {
+			prev := pop(v1pb.TaskRunLogEntry_SCHEMA_DUMP)
+			if prev == nil {
 				continue
 			}
 			prev.SchemaDump.EndTime = timestamppb.New(l.T)
@@ -388,13 +403,11 @@ func convertToTaskRunLogEntries(logs []*store.TaskRunLog) []*v1pb.TaskRunLogEntr
 					Statement: l.Payload.CommandExecute.Statement,
 				},
 			})
+			push(v1pb.TaskRunLogEntry_COMMAND_EXECUTE)
 
 		case storepb.TaskRunLog_COMMAND_RESPONSE:
-			if len(entries) == 0 {
-				continue
-			}
-			prev := entries[len(entries)-1]
-			if prev == nil || prev.Type != v1pb.TaskRunLogEntry_COMMAND_EXECUTE {
+			prev := pop(v1pb.TaskRunLogEntry_COMMAND_EXECUTE)
+			if prev == nil {
 				continue
 			}
 			prev.CommandExecute.Response = &v1pb.TaskRunLogEntry_CommandExecute_CommandResponse{
@@ -413,13 +426,11 @@ func convertToTaskRunLogEntries(logs []*store.TaskRunLog) []*v1pb.TaskRunLogEntr
 					StartTime: timestamppb.New(l.T),
 				},
 			})
+			push(v1pb.TaskRunLogEntry_DATABASE_SYNC)
 
 		case storepb.TaskRunLog_DATABASE_SYNC_END:
-			if len(entries) == 0 {
-				continue
-			}
-			prev := entries[len(entries)-1]
-			if prev == nil || prev.Type != v1pb.TaskRunLogEntry_DATABASE_SYNC {
+			prev := pop(v1pb.TaskRunLogEntry_DATABASE_SYNC)
+			if prev == nil {
 				continue
 			}
 			prev.DatabaseSync.EndTime = timestamppb.New(l.T)
@@ -445,13 +456,11 @@ func convertToTaskRunLogEntries(logs []*store.TaskRunLog) []*v1pb.TaskRunLogEntr
 					StartTime: timestamppb.New(l.T),
 				},
 			})
+			push(v1pb.TaskRunLogEntry_PRIOR_BACKUP)
 
 		case storepb.TaskRunLog_PRIOR_BACKUP_END:
-			if len(entries) == 0 {
-				continue
-			}
-			prev := entries[len(entries)-1]
-			if prev == nil || prev.Type != v1pb.TaskRunLogEntry_PRIOR_BACKUP {
+			prev := pop(v1pb.TaskRunLogEntry_PRIOR_BACKUP)
+			if prev == nil {
 				continue
 			}
 			prev.PriorBackup.EndTime = timestamppb.New(l.T)
@@ -467,13 +476,11 @@ func convertToTaskRunLogEntries(logs []*store.TaskRunLog) []*v1pb.TaskRunLogEntr
 					StartTime: timestamppb.New(l.T),
 				},
 			})
+			push(v1pb.TaskRunLogEntry_COMPUTE_DIFF)
 
 		case storepb.TaskRunLog_COMPUTE_DIFF_END:
-			if len(entries) == 0 {
-				continue
-			}
-			prev := entries[len(entries)-1]
-			if prev == nil || prev.Type != v1pb.TaskRunLogEntry_COMPUTE_DIFF {
+			prev := pop(v1pb.TaskRunLogEntry_COMPUTE_DIFF)
+			if prev == nil {
 				continue
 			}
 			prev.ComputeDiff.EndTime = timestamppb.New(l.T)
@@ -511,13 +518,11 @@ func convertToTaskRunLogEntries(logs []*store.TaskRunLog) []*v1pb.TaskRunLogEntr
 					StartTime: timestamppb.New(l.T),
 				},
 			})
+			push(v1pb.TaskRunLogEntry_GHOST_MIGRATION)
 
 		case storepb.TaskRunLog_GHOST_MIGRATION_END:
-			if len(entries) == 0 {
-				continue
-			}
-			prev := entries[len(entries)-1]
-			if prev == nil || prev.Type != v1pb.TaskRunLogEntry_GHOST_MIGRATION {
+			prev := pop(v1pb.TaskRunLogEntry_GHOST_MIGRATION)
+			if prev == nil {
 				continue
 			}
 			prev.GhostMigration.EndTime = timestamppb.New(l.T)

--- a/backend/api/v1/rollout_service_converter_test.go
+++ b/backend/api/v1/rollout_service_converter_test.go
@@ -68,3 +68,76 @@ func TestConvertToTaskRunLogEntries_GhostMigration(t *testing.T) {
 	require.Equal(t, end.Unix(), entry.GhostMigration.EndTime.AsTime().Unix())
 	require.Equal(t, "copy failed", entry.GhostMigration.Error)
 }
+
+// task_run_log rows can share a created_at microsecond and carry no per-row
+// sequence, so end/response events may not directly follow their start entry.
+func TestConvertToTaskRunLogEntries_TieOrderPairing(t *testing.T) {
+	at := time.Date(2026, 8, 6, 10, 0, 0, 0, time.UTC)
+	execute := func(statement string) *store.TaskRunLog {
+		return &store.TaskRunLog{T: at, Payload: &storepb.TaskRunLog{
+			Type:           storepb.TaskRunLog_COMMAND_EXECUTE,
+			CommandExecute: &storepb.TaskRunLog_CommandExecute{Statement: statement},
+		}}
+	}
+	response := func(affectedRows int64) *store.TaskRunLog {
+		return &store.TaskRunLog{T: at, Payload: &storepb.TaskRunLog{
+			Type:            storepb.TaskRunLog_COMMAND_RESPONSE,
+			CommandResponse: &storepb.TaskRunLog_CommandResponse{AffectedRows: affectedRows},
+		}}
+	}
+
+	t.Run("response attaches across an interleaved entry", func(t *testing.T) {
+		entries := convertToTaskRunLogEntries([]*store.TaskRunLog{
+			execute("SELECT 1"),
+			{T: at, Payload: &storepb.TaskRunLog{
+				Type:               storepb.TaskRunLog_TRANSACTION_CONTROL,
+				TransactionControl: &storepb.TaskRunLog_TransactionControl{Type: storepb.TaskRunLog_TransactionControl_COMMIT},
+			}},
+			response(7),
+		})
+
+		require.Len(t, entries, 2)
+		require.Equal(t, v1pb.TaskRunLogEntry_COMMAND_EXECUTE, entries[0].Type)
+		require.NotNil(t, entries[0].CommandExecute.Response)
+		require.Equal(t, int64(7), entries[0].CommandExecute.Response.AffectedRows)
+	})
+
+	t.Run("crossed responses pair with the nearest unpaired execute", func(t *testing.T) {
+		entries := convertToTaskRunLogEntries([]*store.TaskRunLog{
+			execute("SELECT 1"),
+			execute("SELECT 2"),
+			response(1),
+			response(2),
+		})
+
+		require.Len(t, entries, 2)
+		require.NotNil(t, entries[0].CommandExecute.Response)
+		require.NotNil(t, entries[1].CommandExecute.Response)
+		require.Equal(t, int64(1), entries[1].CommandExecute.Response.AffectedRows)
+		require.Equal(t, int64(2), entries[0].CommandExecute.Response.AffectedRows)
+	})
+
+	t.Run("orphan response is dropped", func(t *testing.T) {
+		entries := convertToTaskRunLogEntries([]*store.TaskRunLog{response(1)})
+		require.Empty(t, entries)
+	})
+
+	t.Run("schema dump end attaches across an interleaved entry", func(t *testing.T) {
+		entries := convertToTaskRunLogEntries([]*store.TaskRunLog{
+			{T: at, Payload: &storepb.TaskRunLog{
+				Type:            storepb.TaskRunLog_SCHEMA_DUMP_START,
+				SchemaDumpStart: &storepb.TaskRunLog_SchemaDumpStart{},
+			}},
+			execute("SELECT 1"),
+			{T: at.Add(time.Second), Payload: &storepb.TaskRunLog{
+				Type:          storepb.TaskRunLog_SCHEMA_DUMP_END,
+				SchemaDumpEnd: &storepb.TaskRunLog_SchemaDumpEnd{Error: "boom"},
+			}},
+		})
+
+		require.Len(t, entries, 2)
+		require.Equal(t, v1pb.TaskRunLogEntry_SCHEMA_DUMP, entries[0].Type)
+		require.NotNil(t, entries[0].SchemaDump.EndTime)
+		require.Equal(t, "boom", entries[0].SchemaDump.Error)
+	})
+}

--- a/backend/migrator/migration/3.16/0002##drop_unused_id_columns.sql
+++ b/backend/migrator/migration/3.16/0002##drop_unused_id_columns.sql
@@ -109,10 +109,11 @@ BEGIN
     END IF;
 END $$;
 
--- task_run_log: use (task_run_id, created_at) as PK
+-- task_run_log: append-only log with no natural key. Entries for one task run
+-- can share a created_at microsecond (BYT-10035), so no primary key is added;
+-- the pre-existing idx_task_run_log_task_run_id index keeps lookups fast.
 ALTER TABLE task_run_log DROP CONSTRAINT IF EXISTS task_run_log_pkey;
 ALTER TABLE task_run_log DROP COLUMN IF EXISTS id;
-ALTER TABLE task_run_log ADD PRIMARY KEY (task_run_id, created_at);
 
 -- release: natural key = (project, train, iteration)
 ALTER TABLE release DROP CONSTRAINT IF EXISTS release_pkey;

--- a/backend/migrator/migration/3.16/0002##drop_unused_id_columns.sql
+++ b/backend/migrator/migration/3.16/0002##drop_unused_id_columns.sql
@@ -110,10 +110,12 @@ BEGIN
 END $$;
 
 -- task_run_log: append-only log with no natural key. Entries for one task run
--- can share a created_at microsecond (BYT-10035), so no primary key is added;
--- the pre-existing idx_task_run_log_task_run_id index keeps lookups fast.
+-- can share a created_at microsecond (BYT-10035), so the intended primary key
+-- is replaced with a non-unique index of the same shape.
 ALTER TABLE task_run_log DROP CONSTRAINT IF EXISTS task_run_log_pkey;
 ALTER TABLE task_run_log DROP COLUMN IF EXISTS id;
+DROP INDEX IF EXISTS idx_task_run_log_task_run_id;
+CREATE INDEX IF NOT EXISTS idx_task_run_log_task_run_id_created_at ON task_run_log(task_run_id, created_at);
 
 -- release: natural key = (project, train, iteration)
 ALTER TABLE release DROP CONSTRAINT IF EXISTS release_pkey;

--- a/backend/migrator/migration/3.17/0001##add_project_to_plan_chain.sql
+++ b/backend/migrator/migration/3.17/0001##add_project_to_plan_chain.sql
@@ -57,17 +57,12 @@ END $$;
 ALTER TABLE task_run_log ADD COLUMN IF NOT EXISTS project TEXT;
 UPDATE task_run_log SET project = task_run.project FROM task_run WHERE task_run_log.project IS NULL AND task_run_log.task_run_id = task_run.id;
 ALTER TABLE task_run_log ALTER COLUMN project SET NOT NULL;
-DO $$ BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint
-        WHERE conname = 'task_run_log_pkey'
-          AND conrelid = 'task_run_log'::regclass
-          AND array_length(conkey, 1) > 1
-    ) THEN
-        ALTER TABLE task_run_log DROP CONSTRAINT IF EXISTS task_run_log_pkey;
-        ALTER TABLE task_run_log ADD PRIMARY KEY (project, task_run_id, created_at);
-    END IF;
-END $$;
+-- Append-only log with no natural key: entries for one task run can share a
+-- created_at microsecond (BYT-10035), so index the read path instead of adding
+-- a primary key.
+ALTER TABLE task_run_log DROP CONSTRAINT IF EXISTS task_run_log_pkey;
+DROP INDEX IF EXISTS idx_task_run_log_task_run_id;
+CREATE INDEX IF NOT EXISTS idx_task_run_log_project_task_run_id_created_at ON task_run_log(project, task_run_id, created_at);
 
 -- plan_check_run
 ALTER TABLE plan_check_run ADD COLUMN IF NOT EXISTS project TEXT;

--- a/backend/migrator/migration/3.17/0001##add_project_to_plan_chain.sql
+++ b/backend/migrator/migration/3.17/0001##add_project_to_plan_chain.sql
@@ -62,6 +62,7 @@ ALTER TABLE task_run_log ALTER COLUMN project SET NOT NULL;
 -- a primary key.
 ALTER TABLE task_run_log DROP CONSTRAINT IF EXISTS task_run_log_pkey;
 DROP INDEX IF EXISTS idx_task_run_log_task_run_id;
+DROP INDEX IF EXISTS idx_task_run_log_task_run_id_created_at;
 CREATE INDEX IF NOT EXISTS idx_task_run_log_project_task_run_id_created_at ON task_run_log(project, task_run_id, created_at);
 
 -- plan_check_run

--- a/backend/migrator/migration/3.22/0004##drop_task_run_log_pkey.sql
+++ b/backend/migrator/migration/3.22/0004##drop_task_run_log_pkey.sql
@@ -1,0 +1,9 @@
+-- task_run_log is an append-only log with no natural key: entries for one task
+-- run can legitimately share a created_at microsecond, and legacy data already
+-- does (BYT-10035). Databases that upgraded through the original 3.16.2 carry
+-- PRIMARY KEY (task_run_id, created_at) while fresh installs carry
+-- PRIMARY KEY (project, task_run_id, created_at); drop whichever is present and
+-- index the read path instead.
+ALTER TABLE task_run_log DROP CONSTRAINT IF EXISTS task_run_log_pkey;
+DROP INDEX IF EXISTS idx_task_run_log_task_run_id;
+CREATE INDEX IF NOT EXISTS idx_task_run_log_project_task_run_id_created_at ON task_run_log(project, task_run_id, created_at);

--- a/backend/migrator/migration/3.22/0004##drop_task_run_log_pkey.sql
+++ b/backend/migrator/migration/3.22/0004##drop_task_run_log_pkey.sql
@@ -6,4 +6,5 @@
 -- index the read path instead.
 ALTER TABLE task_run_log DROP CONSTRAINT IF EXISTS task_run_log_pkey;
 DROP INDEX IF EXISTS idx_task_run_log_task_run_id;
+DROP INDEX IF EXISTS idx_task_run_log_task_run_id_created_at;
 CREATE INDEX IF NOT EXISTS idx_task_run_log_project_task_run_id_created_at ON task_run_log(project, task_run_id, created_at);

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -596,15 +596,18 @@ CREATE TABLE replica_heartbeat (
     last_heartbeat TIMESTAMPTZ NOT NULL
 );
 
+-- Append-only log with no primary key on purpose: entries for one task run can
+-- legitimately share a created_at microsecond (BYT-10035).
 CREATE TABLE task_run_log (
     project text NOT NULL REFERENCES project(resource_id),
     task_run_id integer NOT NULL,
     created_at timestamptz NOT NULL DEFAULT now(),
     -- Stored as TaskRunLog (proto/store/store/task_run_log.proto)
     payload jsonb NOT NULL DEFAULT '{}',
-    PRIMARY KEY (project, task_run_id, created_at),
     FOREIGN KEY (project, task_run_id) REFERENCES task_run(project, id)
 );
+
+CREATE INDEX idx_task_run_log_project_task_run_id_created_at ON task_run_log(project, task_run_id, created_at);
 
 -----------------------
 -- OAuth2 and auth

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -2,6 +2,7 @@ package migrator
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -17,8 +18,8 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.22.3"), *files[len(files)-1].version)
-	require.Equal(t, "migration/3.22/0003##hash_directory_sync_token.sql", files[len(files)-1].path)
+	require.Equal(t, semver.MustParse("3.22.4"), *files[len(files)-1].version)
+	require.Equal(t, "migration/3.22/0004##drop_task_run_log_pkey.sql", files[len(files)-1].path)
 }
 
 func TestVersionUnique(t *testing.T) {
@@ -33,6 +34,190 @@ func TestVersionUnique(t *testing.T) {
 			require.Fail(t, "duplicate version %s", file.version.String())
 		}
 		versions[file.version.String()] = struct{}{}
+	}
+}
+
+// TestMigration3_16_2_TaskRunLogDuplicateTimestamps verifies that the 3.16.2
+// id-column cleanup succeeds on legacy task_run_log data holding duplicate
+// (task_run_id, created_at) pairs, which were legal under the old id primary
+// key. Regression test for BYT-10035.
+func TestMigration3_16_2_TaskRunLogDuplicateTimestamps(t *testing.T) {
+	ctx := context.Background()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+
+	// Minimal pre-3.16.2 shapes for every table the migration touches.
+	setup := `
+		CREATE TABLE project (id BIGSERIAL PRIMARY KEY, resource_id TEXT NOT NULL);
+		CREATE TABLE instance (id BIGSERIAL PRIMARY KEY, resource_id TEXT NOT NULL);
+		CREATE TABLE db (id BIGSERIAL PRIMARY KEY, instance TEXT NOT NULL, name TEXT NOT NULL);
+		CREATE TABLE setting (id BIGSERIAL PRIMARY KEY, name TEXT NOT NULL);
+		CREATE TABLE policy (id BIGSERIAL PRIMARY KEY, resource_type TEXT NOT NULL, resource TEXT NOT NULL, type TEXT NOT NULL);
+		CREATE TABLE idp (id BIGSERIAL PRIMARY KEY, resource_id TEXT NOT NULL);
+		CREATE TABLE role (id BIGSERIAL PRIMARY KEY, resource_id TEXT NOT NULL);
+		CREATE TABLE db_schema (id BIGSERIAL PRIMARY KEY, instance TEXT NOT NULL, db_name TEXT NOT NULL);
+		CREATE TABLE db_group (id BIGSERIAL PRIMARY KEY, project TEXT NOT NULL, resource_id TEXT NOT NULL);
+		CREATE TABLE release (id BIGSERIAL PRIMARY KEY, project TEXT NOT NULL, train TEXT NOT NULL, iteration INT NOT NULL);
+		CREATE TABLE task_run_log (
+			id BIGSERIAL PRIMARY KEY,
+			task_run_id INTEGER NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			payload JSONB NOT NULL DEFAULT '{}'
+		);
+		CREATE INDEX idx_task_run_log_task_run_id ON task_run_log(task_run_id);
+
+		INSERT INTO task_run_log (task_run_id, created_at, payload) VALUES
+			(100, '2026-01-01 00:00:00.000001+00', '{"type":"COMMAND_EXECUTE"}'),
+			(100, '2026-01-01 00:00:00.000001+00', '{"type":"COMMAND_RESPONSE"}'),
+			(100, '2026-01-01 00:00:00.000002+00', '{"type":"COMMAND_EXECUTE"}');
+	`
+	_, err := db.ExecContext(ctx, setup)
+	require.NoError(t, err)
+
+	statement, err := migrationFS.ReadFile("migration/3.16/0002##drop_unused_id_columns.sql")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, string(statement))
+	require.NoError(t, err)
+
+	var rowCount int
+	require.NoError(t, db.QueryRowContext(ctx, `SELECT COUNT(*) FROM task_run_log`).Scan(&rowCount))
+	require.Equal(t, 3, rowCount)
+
+	var hasPkey bool
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'task_run_log_pkey' AND conrelid = 'task_run_log'::regclass)
+	`).Scan(&hasPkey))
+	require.False(t, hasPkey)
+
+	var hasIDColumn bool
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'task_run_log' AND column_name = 'id')
+	`).Scan(&hasIDColumn))
+	require.False(t, hasIDColumn)
+}
+
+// TestMigration3_17_1_TaskRunLogDuplicateTimestamps verifies that the 3.17.1
+// project-scoping migration accepts duplicate (task_run_id, created_at) pairs:
+// it must backfill project and index the table without imposing uniqueness.
+// Regression test for BYT-10035.
+func TestMigration3_17_1_TaskRunLogDuplicateTimestamps(t *testing.T) {
+	ctx := context.Background()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+
+	// Minimal post-3.16.2 shapes for the plan-chain tables the migration touches;
+	// task_run_log has no id column and no primary key at this point.
+	setup := `
+		CREATE TABLE project (resource_id TEXT PRIMARY KEY);
+		CREATE TABLE plan (id BIGINT PRIMARY KEY, project TEXT NOT NULL);
+		CREATE TABLE issue (id BIGINT PRIMARY KEY, project TEXT NOT NULL, plan_id BIGINT);
+		CREATE TABLE task (id INT PRIMARY KEY, plan_id BIGINT NOT NULL, environment TEXT NOT NULL);
+		CREATE TABLE task_run (id INT PRIMARY KEY, task_id INT NOT NULL, attempt INT NOT NULL);
+		CREATE TABLE plan_check_run (id INT PRIMARY KEY, plan_id BIGINT NOT NULL);
+		CREATE TABLE plan_webhook_delivery (id INT PRIMARY KEY, plan_id BIGINT NOT NULL);
+		CREATE TABLE task_run_log (
+			task_run_id INTEGER NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			payload JSONB NOT NULL DEFAULT '{}'
+		);
+		CREATE INDEX idx_task_run_log_task_run_id ON task_run_log(task_run_id);
+
+		INSERT INTO project VALUES ('proj-a');
+		INSERT INTO plan VALUES (1, 'proj-a');
+		INSERT INTO task VALUES (10, 1, 'environments/prod');
+		INSERT INTO task_run VALUES (100, 10, 1);
+		INSERT INTO task_run_log (task_run_id, created_at, payload) VALUES
+			(100, '2026-01-01 00:00:00.000001+00', '{"type":"COMMAND_EXECUTE"}'),
+			(100, '2026-01-01 00:00:00.000001+00', '{"type":"COMMAND_RESPONSE"}'),
+			(100, '2026-01-01 00:00:00.000002+00', '{"type":"COMMAND_EXECUTE"}');
+	`
+	_, err := db.ExecContext(ctx, setup)
+	require.NoError(t, err)
+
+	statement, err := migrationFS.ReadFile("migration/3.17/0001##add_project_to_plan_chain.sql")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, string(statement))
+	require.NoError(t, err)
+
+	var backfilledCount int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM task_run_log WHERE project = 'proj-a'
+	`).Scan(&backfilledCount))
+	require.Equal(t, 3, backfilledCount)
+
+	var hasPkey bool
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'task_run_log_pkey' AND conrelid = 'task_run_log'::regclass)
+	`).Scan(&hasPkey))
+	require.False(t, hasPkey)
+
+	var hasIndex bool
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_task_run_log_project_task_run_id_created_at')
+	`).Scan(&hasIndex))
+	require.True(t, hasIndex)
+
+	var hasOldIndex bool
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_task_run_log_task_run_id')
+	`).Scan(&hasOldIndex))
+	require.False(t, hasOldIndex)
+}
+
+// TestMigration3_22_4_DropTaskRunLogPkey verifies that the pkey drop converges
+// both historical shapes — the 2-column PK left by upgrading through the
+// original 3.16.2 and the 3-column PK of fresh installs — is idempotent, and
+// that same-microsecond entries insert afterwards instead of colliding.
+func TestMigration3_22_4_DropTaskRunLogPkey(t *testing.T) {
+	ctx := context.Background()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+
+	statement, err := migrationFS.ReadFile("migration/3.22/0004##drop_task_run_log_pkey.sql")
+	require.NoError(t, err)
+
+	for _, pkey := range []string{"(task_run_id, created_at)", "(project, task_run_id, created_at)"} {
+		_, err := db.ExecContext(ctx, fmt.Sprintf(`
+			DROP TABLE IF EXISTS task_run_log;
+			CREATE TABLE task_run_log (
+				project TEXT NOT NULL,
+				task_run_id INTEGER NOT NULL,
+				created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				payload JSONB NOT NULL DEFAULT '{}',
+				PRIMARY KEY %s
+			);`, pkey))
+		require.NoError(t, err)
+
+		_, err = db.ExecContext(ctx, string(statement))
+		require.NoError(t, err)
+		// Re-running must be a no-op: the file also applies to databases that
+		// come through the edited 3.16.2/3.17.1 path with no pkey left at all.
+		_, err = db.ExecContext(ctx, string(statement))
+		require.NoError(t, err)
+
+		var hasPkey bool
+		require.NoError(t, db.QueryRowContext(ctx, `
+			SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'task_run_log_pkey' AND conrelid = 'task_run_log'::regclass)
+		`).Scan(&hasPkey))
+		require.False(t, hasPkey, "pkey %s should be dropped", pkey)
+
+		var hasIndex bool
+		require.NoError(t, db.QueryRowContext(ctx, `
+			SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_task_run_log_project_task_run_id_created_at')
+		`).Scan(&hasIndex))
+		require.True(t, hasIndex)
+
+		_, err = db.ExecContext(ctx, `
+			INSERT INTO task_run_log (project, task_run_id, created_at) VALUES
+				('proj-a', 100, '2026-01-01 00:00:00.000001+00'),
+				('proj-a', 100, '2026-01-01 00:00:00.000001+00')`)
+		require.NoError(t, err, "same-microsecond entries must both insert")
 	}
 }
 

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -2,7 +2,6 @@ package migrator
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -96,6 +95,18 @@ func TestMigration3_16_2_TaskRunLogDuplicateTimestamps(t *testing.T) {
 		SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'task_run_log' AND column_name = 'id')
 	`).Scan(&hasIDColumn))
 	require.False(t, hasIDColumn)
+
+	var hasIndex bool
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_task_run_log_task_run_id_created_at')
+	`).Scan(&hasIndex))
+	require.True(t, hasIndex)
+
+	var hasOldIndex bool
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_task_run_log_task_run_id')
+	`).Scan(&hasOldIndex))
+	require.False(t, hasOldIndex)
 }
 
 // TestMigration3_17_1_TaskRunLogDuplicateTimestamps verifies that the 3.17.1
@@ -124,7 +135,7 @@ func TestMigration3_17_1_TaskRunLogDuplicateTimestamps(t *testing.T) {
 			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
 			payload JSONB NOT NULL DEFAULT '{}'
 		);
-		CREATE INDEX idx_task_run_log_task_run_id ON task_run_log(task_run_id);
+		CREATE INDEX idx_task_run_log_task_run_id_created_at ON task_run_log(task_run_id, created_at);
 
 		INSERT INTO project VALUES ('proj-a');
 		INSERT INTO plan VALUES (1, 'proj-a');
@@ -161,17 +172,18 @@ func TestMigration3_17_1_TaskRunLogDuplicateTimestamps(t *testing.T) {
 	`).Scan(&hasIndex))
 	require.True(t, hasIndex)
 
-	var hasOldIndex bool
+	var oldIndexCount int
 	require.NoError(t, db.QueryRowContext(ctx, `
-		SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_task_run_log_task_run_id')
-	`).Scan(&hasOldIndex))
-	require.False(t, hasOldIndex)
+		SELECT COUNT(*) FROM pg_indexes WHERE schemaname = 'public' AND indexname IN ('idx_task_run_log_task_run_id', 'idx_task_run_log_task_run_id_created_at')
+	`).Scan(&oldIndexCount))
+	require.Zero(t, oldIndexCount)
 }
 
 // TestMigration3_22_4_DropTaskRunLogPkey verifies that the pkey drop converges
-// both historical shapes — the 2-column PK left by upgrading through the
-// original 3.16.2 and the 3-column PK of fresh installs — is idempotent, and
-// that same-microsecond entries insert afterwards instead of colliding.
+// every historical shape — the 2-column PK left by upgrading through the
+// original 3.16.2, the 3-column PK of fresh installs, and the no-PK state left
+// by a release-branch backport of the 3.16.2 fix — is idempotent, and that
+// same-microsecond entries insert afterwards instead of colliding.
 func TestMigration3_22_4_DropTaskRunLogPkey(t *testing.T) {
 	ctx := context.Background()
 	container := testcontainer.GetTestPgContainer(ctx, t)
@@ -182,36 +194,59 @@ func TestMigration3_22_4_DropTaskRunLogPkey(t *testing.T) {
 	statement, err := migrationFS.ReadFile("migration/3.22/0004##drop_task_run_log_pkey.sql")
 	require.NoError(t, err)
 
-	for _, pkey := range []string{"(task_run_id, created_at)", "(project, task_run_id, created_at)"} {
-		_, err := db.ExecContext(ctx, fmt.Sprintf(`
-			DROP TABLE IF EXISTS task_run_log;
-			CREATE TABLE task_run_log (
-				project TEXT NOT NULL,
-				task_run_id INTEGER NOT NULL,
-				created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-				payload JSONB NOT NULL DEFAULT '{}',
-				PRIMARY KEY %s
-			);`, pkey))
-		require.NoError(t, err)
+	const tableDDL = `
+		CREATE TABLE task_run_log (
+			project TEXT NOT NULL,
+			task_run_id INTEGER NOT NULL,
+			created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+			payload JSONB NOT NULL DEFAULT '{}'`
+
+	scenarios := []struct {
+		name  string
+		setup string
+	}{
+		{
+			"2-col pkey from the original 3.16.2",
+			tableDDL + `, PRIMARY KEY (task_run_id, created_at));
+			CREATE INDEX idx_task_run_log_task_run_id ON task_run_log(task_run_id);`,
+		},
+		{
+			"3-col pkey from a fresh install",
+			tableDDL + `, PRIMARY KEY (project, task_run_id, created_at));`,
+		},
+		{
+			"no pkey from a release-branch backport of the 3.16.2 fix",
+			tableDDL + `);
+			CREATE INDEX idx_task_run_log_task_run_id_created_at ON task_run_log(task_run_id, created_at);`,
+		},
+	}
+	for _, scenario := range scenarios {
+		_, err := db.ExecContext(ctx, `DROP TABLE IF EXISTS task_run_log;`+scenario.setup)
+		require.NoError(t, err, scenario.name)
 
 		_, err = db.ExecContext(ctx, string(statement))
-		require.NoError(t, err)
-		// Re-running must be a no-op: the file also applies to databases that
-		// come through the edited 3.16.2/3.17.1 path with no pkey left at all.
+		require.NoError(t, err, scenario.name)
+		// Re-running must be a no-op.
 		_, err = db.ExecContext(ctx, string(statement))
-		require.NoError(t, err)
+		require.NoError(t, err, scenario.name)
 
 		var hasPkey bool
 		require.NoError(t, db.QueryRowContext(ctx, `
 			SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'task_run_log_pkey' AND conrelid = 'task_run_log'::regclass)
 		`).Scan(&hasPkey))
-		require.False(t, hasPkey, "pkey %s should be dropped", pkey)
+		require.False(t, hasPkey, scenario.name)
 
 		var hasIndex bool
 		require.NoError(t, db.QueryRowContext(ctx, `
 			SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'idx_task_run_log_project_task_run_id_created_at')
 		`).Scan(&hasIndex))
-		require.True(t, hasIndex)
+		require.True(t, hasIndex, scenario.name)
+
+		var oldIndexCount int
+		require.NoError(t, db.QueryRowContext(ctx, `
+			SELECT COUNT(*) FROM pg_indexes WHERE schemaname = 'public' AND indexname IN ('idx_task_run_log_task_run_id', 'idx_task_run_log_task_run_id_created_at')
+		`).Scan(&oldIndexCount))
+		require.Zero(t, oldIndexCount, scenario.name)
 
 		_, err = db.ExecContext(ctx, `
 			INSERT INTO task_run_log (project, task_run_id, created_at) VALUES

--- a/backend/store/task_run_log.go
+++ b/backend/store/task_run_log.go
@@ -58,13 +58,16 @@ func (s *Store) CreateTaskRunLog(ctx context.Context, projectID string, taskRunU
 }
 
 func (s *Store) ListTaskRunLogs(ctx context.Context, projectID string, taskRunUID int64) ([]*TaskRunLog, error) {
+	// created_at can tie across entries (no per-row sequence exists); ctid
+	// breaks ties in insertion order, which is stable because the table is
+	// append-only and rows are never updated.
 	q := qb.Q().Space(`
 		SELECT
 			created_at,
 			payload
 		FROM task_run_log
 		WHERE task_run_log.project = ? AND task_run_log.task_run_id = ?
-		ORDER BY created_at
+		ORDER BY created_at, ctid
 	`, projectID, taskRunUID)
 
 	sql, args, err := q.ToSQL()

--- a/docs/pre-pr-checklist.md
+++ b/docs/pre-pr-checklist.md
@@ -58,9 +58,13 @@ Read `backend/migrator/migration/LATEST.sql` and find every table with a multi-c
 - `issue (project, id)`
 - `task (project, id)`
 - `task_run (project, id)`
-- `task_run_log (project, task_run_id, created_at)`
 - `db_group (project, resource_id)`
 - `release (project, train, iteration)`
+
+`task_run_log` deliberately has no primary key (append-only log; entries for one
+task run can share a `created_at` microsecond — BYT-10035), but it is equally
+project-scoped: every predicate on it must include `project` alongside
+`task_run_id`.
 
 Always verify against LATEST.sql — tables may have been added since this list was
 last updated. Cross-reference with the tables your diff touches.


### PR DESCRIPTION
## Summary

Customer upgrade 3.5.2 → 3.20.1 crash-loops at migration 3.16.2 with `could not create unique index "task_run_log_pkey" (SQLSTATE 23505)` (BYT-10035). The migration promotes `(task_run_id, created_at)` to a primary key, but `task_run_log` is an append-only log whose entries can legitimately share a `created_at` microsecond — timestamps come from per-entry `time.Now()` truncated to microsecond resolution, and the legacy `id bigserial` PK never implied uniqueness on that pair. The PK also made the live write path lossy: a same-microsecond insert hits 23505 and `CreateTaskRunLogS` swallows it, silently dropping the log entry.

Remove the PK on every path and index the read path instead:

- `3.16/0002` drops the constraint and `id` column and replaces the intended PK with a non-unique `(task_run_id, created_at)` index — stuck upgrades proceed with all log rows preserved, no manual data surgery, and the file is self-contained for release-branch backports.
- `3.17/0001` replaces its PK rebuild with the `(project, task_run_id, created_at)` index, fixing the follow-on stranding at 3.17.1. Its old `array_length(conkey, 1) > 1` guard also mistook the 2-column PK left by 3.16.2 for the migrated state, so upgraded installs today carry `(task_run_id, created_at)` while fresh installs carry `(project, task_run_id, created_at)` — pre-existing drift.
- New `3.22/0004` converges already-upgraded databases from every historical shape (2-column PK, 3-column PK, or backported no-PK state); idempotent on all paths.
- The read path is hardened for now-legal ties: `ListTaskRunLogs` orders by `created_at, ctid` (insertion order — the table is append-only and never updated), and the API converter attaches end/response events to the nearest unpaired start entry instead of requiring strict adjacency. Previously a tie-reordered pair silently dropped the response details from the log view.
- `LATEST.sql` documents the deliberate absence of a PK; `AGENTS.md` and `docs/pre-pr-checklist.md` move `task_run_log` out of the composite-PK lists while keeping the project-scoped predicate rules.

## Backporting to release branches

The `3.16/0002` and `3.17/0001` edits are the portable core — they apply cleanly on any release branch since 3.17 and unstick upgrades on their own.

- **`3.22/0004` must be renamed to the target branch's next migration slot** (e.g. `3.20/0005` on the 3.20 branch). Cherry-picked as-is, a 3.20.x binary would apply it and record version 3.22.4 in `instance_change_history`, causing the real 3.21.x–3.22.x migrations to be **skipped** on the next upgrade. After a renamed backport runs, mainline `3.22/0004` re-runs harmlessly (fully idempotent — covered by a regression test).
- Drop the `LATEST.sql`, `migrator_test.go`, and docs hunks in backports; they are mainline-only.
- A backported install must upgrade into a version that also contains this fix: e.g. a patched 3.16.x jumping to an unpatched 3.17–3.21 binary re-hits the PK creation in the original `3.17/0001` and gets stuck again. Backport to every maintained release branch, or point upgrade guidance at fixed versions.

## Breaking Changes

Database schema: `task_run_log` loses its primary key (3.22.4 drops it on existing installs). No Bytebase code addresses rows by PK — reads filter `(project, task_run_id)`, deletes are set-based — but a PK-less table has no default replica identity, so a deployment that logically replicates the metadata DB (not a supported topology; streaming/physical replication is unaffected) would need `REPLICA IDENTITY FULL` on this table to replicate deletes.

## Testing

- New regression tests: 3.16.2 and 3.17.1 run against seeded duplicate `(task_run_id, created_at)` rows (the exact BYT-10035 shape) and assert the index handoff; 3.22.4 is verified against all three historical shapes — 2-column PK, 3-column PK, and the backported no-PK state — re-run for idempotency, and confirms same-microsecond inserts now succeed instead of colliding.
- Converter unit tests cover tie-order pairing: response attaching across an interleaved entry, crossed pairs resolving nearest-first, orphan responses still dropped, and the same for schema-dump end events.
- Full `backend/migrator`, `backend/api/v1`, and `backend/store` packages, the `TestClaim`/`TestCollision` e2e suite, `golangci-lint` (0 issues), and the server build all pass.

Fixes BYT-10035.

🤖 Generated with [Claude Code](https://claude.com/claude-code)