### PR TITLE
docs: decide project scope for sheets, and history on database transfer

### DIFF
--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -109,7 +109,25 @@ CREATE TABLE sheet_blob_ref (
     sha256  bytea NOT NULL REFERENCES sheet_blob(sha256),
     PRIMARY KEY (project, sha256)
 );
+
+CREATE INDEX idx_sheet_blob_ref_sha256 ON sheet_blob_ref(sha256);
 ```
+
+`project` alone is a sufficient scope column: `project.resource_id` is a single-column primary key,
+so project IDs are one global namespace across every workspace, and a project resolves to exactly
+one workspace through `project.workspace`.
+
+The gate and `HasSheets` both query `WHERE project = ? AND sha256 IN (…)`, which the
+project-leading primary key serves directly. The secondary index exists for the two paths that
+start from a hash with no project in hand: the owner lookup for a withheld statement
+([naming the owner](sheet-history-on-database-transfer.md#naming-the-owner)) and the zero-ref
+verification query in [Rollout](#rollout). PostgreSQL can only full-scan a `(project, sha256)` btree
+for a `sha256`-only predicate, so both would degrade as the table grows.
+
+Those hash-first queries are a deliberate exception to the composite-PK predicate rule in
+`AGENTS.md`: their whole purpose is to discover *which* project holds a hash, so the scope column
+cannot be supplied. They are made safe by joining through `project` and constraining to the caller's
+workspace instead — never by omitting scope entirely.
 
 Migration slot `backend/migrator/migration/3.22/0005##scope_sheet_blob.sql`; `TestLatestVersion` in
 `backend/migrator/migrator_test.go` needs updating, and `LATEST.sql` mirrored.

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -164,24 +164,37 @@ Derive the authoring project from the revision's own provenance instead. `Revisi
 name. Parse it out, preferring `release` and falling back to `taskRun`; `backend/store/changelog.go:163-168`
 already does exactly this with `regexp_match(payload->>'taskRun', 'projects/([^/]+)/')`.
 
-The disposition is three-way, not a fallback chain, and conflating the middle case with the last one
-is the trap:
+**Provenance is usable only if it is corroborated**: the `release` or `task_run` row it names must
+still exist under the project it names. Existence of the *project* is not enough. The disposition is
+three-way, not a fallback chain, and conflating the middle case with the last one is the trap:
 
 | Provenance | Action |
 |---|---|
-| Names a project that still exists | Insert `(that project, sha)` |
-| Names a project that has been purged | **Insert nothing.** The string stays for attribution |
+| Corroborated — the named `release` or `task_run` row still exists under that project | Insert `(that project, sha)` |
+| Present but not corroborated | **Insert nothing.** The string stays for attribution |
 | Absent — both fields empty | Fall back to `db.project`, and add to the review list |
 
-**Purged provenance must not fall through to `db.project`.** `revision` is the only source that
-survives a purge of its authoring project: `plan`, `task`, `release` and `plan_check_run` rows are
-all deleted with the project (`backend/store/project.go:578`, `:641`, `:651`, `:671`), but a
+**Uncorroborated provenance must not fall through to `db.project`.** `revision` is the only source
+that survives a purge of its authoring project: `plan`, `task`, `release` and `plan_check_run` rows
+are all deleted with the project (`backend/store/project.go:578`, `:641`, `:651`, `:671`), but a
 workspace-instance database is reassigned to the default project and keeps its revisions, whose
 `release` and `taskRun` strings still name the deleted project. Inserting that ref would violate
 `sheet_blob_ref`'s foreign key and abort the migration; joining only to live projects and then
 falling back would hand the default project SQL the purged project authored — the grant this design
-refuses. Guard the provenance branch with `EXISTS (SELECT 1 FROM project …)` and let those rows
-produce no ref at all.
+refuses.
+
+**Checking that the project exists is not sufficient**, which is why the guard is on the referenced
+row. `DeleteProject` hard-deletes the `project` row and `CreateProject` accepts a caller-supplied
+`ProjectId` (`backend/api/v1/project_service.go:210`), so a purged ID can be reused. A surviving
+revision naming the *old* project would then resolve to an unrelated *new* project of the same name
+and grant it the purged project's SQL — a worse outcome than the foreign-key abort, because it is
+silent. Corroborating the referenced row distinguishes the cases: ordinary release deletion is soft
+(`backend/store/release.go:223`), so the row persists, while purge hard-deletes it.
+
+Residual risk: a reused project ID whose new releases happen to collide with the old release or task
+IDs would still corroborate. Release IDs are deterministic (`train` plus iteration) and task IDs
+restart per project, so this is possible rather than impossible. It is not detectable from the data,
+so it goes on the review list alongside the other ambiguous rows rather than being silently trusted.
 
 Their content then becomes unreadable, which is the intended outcome: the authoring project is gone,
 so there is nobody left to ask. The immutable `release`/`taskRun` string still identifies it, so the
@@ -383,9 +396,9 @@ A long list means cross-project references are already widespread and the plan n
 since the backfill would make them permanent. Capture it at a known-good point: this design is
 public, including the rule that turns a reference into an ownership edge.
 
-**Review provenance-less revisions too.** These are the rows that fell back to `db.project`, so a
-database transferred before the migration would have granted its destination project a source
-project's SQL:
+**Review ambiguous revision provenance too.** Two populations, both of which the backfill had to
+guess at. Rows with no provenance fell back to `db.project`, so a database transferred before the
+migration would have granted its destination project a source project's SQL:
 
 ```sql
 SELECT r.instance, r.db_name, d.project
@@ -393,6 +406,20 @@ FROM revision r JOIN db d ON d.instance = r.instance AND d.name = r.db_name
 WHERE r.payload->>'sheetSha256' IS NOT NULL
   AND COALESCE(r.payload->>'release', '') = ''
   AND COALESCE(r.payload->>'taskRun', '') = '';
+```
+
+Rows whose provenance named a project that no longer corroborates it produced no ref, so their
+content is now unreadable. A large count here means either widespread project purges or reused
+project IDs, and is worth understanding before enforcing:
+
+```sql
+SELECT r.instance, r.db_name,
+       (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1] AS named_project
+FROM revision r
+WHERE r.payload->>'sheetSha256' IS NOT NULL
+  AND COALESCE(r.payload->>'release', '') <> ''
+  AND NOT EXISTS (SELECT 1 FROM sheet_blob_ref b
+                  WHERE b.sha256 = decode(r.payload->>'sheetSha256', 'hex'));
 ```
 
 ## Transaction lock ordering
@@ -478,6 +505,21 @@ No schema needed; worth landing separately and first.
 ## Order
 
 1. The five independent fixes, T6 first.
-2. Migration and backfill; run both verification queries and review the multi-project list.
-3. Store API, gate, call sites, purge delete, tests — gate shipping in shadow mode.
-4. Flip to enforcing one release later, once shadow logs are clean.
+2. Create `sheet_blob_ref` and land the ref *writers* — the transactional `CreateSheets` and the
+   purge delete — **before** any backfill.
+3. Store API, gate, call sites, tests — gate shipping in shadow mode.
+4. Run the backfill once the writers are live everywhere, then the verification queries; review the
+   multi-project list and the ambiguous-provenance list.
+5. Flip to enforcing one release later, once shadow logs are clean.
+
+**Writers must precede the backfill, or new sheets fall into the gap.** A one-shot backfill scans
+history; it cannot cover a sheet created after it runs. If the migration ships before `CreateSheets`
+writes refs, every sheet created in between lands in `sheet_blob` with no ref and appears in no
+historical source, so it becomes a zero-ref miss and a NotFound at enforcement. A rolling upgrade
+widens the same gap even when both ship together, since old replicas keep serving the old
+`CreateSheets` against the new schema until the rollout completes.
+
+The backfill is idempotent (`ON CONFLICT DO NOTHING`), so the safe pattern is to run it after the
+rollout has fully converged and to re-run it immediately before flipping to enforcing. Shadow-mode
+misses are the backstop: anything the backfill missed shows up there as a log line rather than as a
+production NotFound.

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -145,7 +145,7 @@ inside its message (not always top-level). `protojson` camelCases keys.
 | `task` | `payload` | `sheetSha256` | `task.project` |
 | `release` | `payload` | `files[].sheetSha256` | `release.project` |
 | `plan_check_run` | `result` | `results[].sheetSha256` | `plan_check_run.project` |
-| `revision` | `payload` | `sheetSha256` | `release` → else `taskRun` → else `db.project` (see below) |
+| `revision` | `payload` | `sheetSha256` | corroborated `release` → else corroborated `taskRun` → else **no ref** (see below) |
 
 `plan_check_run` punishes assumption: the column is `result`, not `payload`, and the hash sits on
 `PlanCheckRunResult.Result` inside the repeated `results` array.
@@ -164,46 +164,56 @@ Derive the authoring project from the revision's own provenance instead. `Revisi
 name. Parse it out, preferring `release` and falling back to `taskRun`; `backend/store/changelog.go:163-168`
 already does exactly this with `regexp_match(payload->>'taskRun', 'projects/([^/]+)/')`.
 
-**Provenance is usable only if it is corroborated**: the `release` or `task_run` row it names must
-still exist under the project it names. Existence of the *project* is not enough. The disposition is
-three-way, not a fallback chain, and conflating the middle case with the last one is the trap:
+**A revision produces a ref only when its provenance is corroborated**: the `release` or `task_run`
+row it names must still exist under the project it names. There is no fallback — not to
+`db.project`, not to anything. Revisions with absent or uncorroborated provenance get no ref, and
+their content is unreadable until an operator grants it deliberately.
 
 | Provenance | Action |
 |---|---|
 | Corroborated — the named `release` or `task_run` row still exists under that project | Insert `(that project, sha)` |
-| Present but not corroborated | **Insert nothing.** The string stays for attribution |
-| Absent — both fields empty | Fall back to `db.project`, and add to the review list |
+| Present but not corroborated | No ref |
+| Absent — both fields empty | No ref |
 
-**Uncorroborated provenance must not fall through to `db.project`.** `revision` is the only source
-that survives a purge of its authoring project: `plan`, `task`, `release` and `plan_check_run` rows
-are all deleted with the project (`backend/store/project.go:578`, `:641`, `:651`, `:671`), but a
+**There is no `db.project` fallback because shadow mode cannot see an over-grant.** Falling back
+would be correct for every database that never moved, which is most of them, and wrong only for
+transferred ones — a tempting trade until you notice the asymmetry in how the two errors surface.
+Under-granting produces a shadow miss: a log line, during a full release in which content is still
+returned, with the requesting project right there in the log. Over-granting produces nothing at all,
+because the ref exists and the gate is satisfied. A guess that fails loudly and correctably beats a
+guess that fails silently and permanently.
+
+So the operational path for these rows is: no ref, shadow misses during the enforcement-deferred
+release, operator reviews the log, and tops up `(requesting project, sha)` for the ones they confirm.
+That is an informed grant rather than an inferred one, and the operator has context the migration
+does not — whether a database was transferred, and who should see its history.
+
+**Corroboration is checked on the referenced row, not on the project.** `DeleteProject` hard-deletes
+the `project` row and `CreateProject` accepts a caller-supplied `ProjectId`
+(`backend/api/v1/project_service.go:210`), so a purged ID can be reused; a surviving revision naming
+the *old* project would otherwise resolve to an unrelated *new* project of the same name and grant it
+the purged project's SQL. Checking the referenced row distinguishes the cases, because ordinary
+release deletion is soft (`backend/store/release.go:223`) and leaves the row, while purge
+hard-deletes it along with `plan`, `task` and `plan_check_run`
+(`backend/store/project.go:578`, `:641`, `:651`, `:671`).
+
+`revision` is the only source that survives a purge of its authoring project at all: a
 workspace-instance database is reassigned to the default project and keeps its revisions, whose
-`release` and `taskRun` strings still name the deleted project. Inserting that ref would violate
-`sheet_blob_ref`'s foreign key and abort the migration; joining only to live projects and then
-falling back would hand the default project SQL the purged project authored — the grant this design
-refuses.
-
-**Checking that the project exists is not sufficient**, which is why the guard is on the referenced
-row. `DeleteProject` hard-deletes the `project` row and `CreateProject` accepts a caller-supplied
-`ProjectId` (`backend/api/v1/project_service.go:210`), so a purged ID can be reused. A surviving
-revision naming the *old* project would then resolve to an unrelated *new* project of the same name
-and grant it the purged project's SQL — a worse outcome than the foreign-key abort, because it is
-silent. Corroborating the referenced row distinguishes the cases: ordinary release deletion is soft
-(`backend/store/release.go:223`), so the row persists, while purge hard-deletes it.
+`release` and `taskRun` strings still name the deleted project.
 
 Residual risk: a reused project ID whose new releases happen to collide with the old release or task
 IDs would still corroborate. Release IDs are deterministic (`train` plus iteration) and task IDs
 restart per project, so this is possible rather than impossible. It is not detectable from the data,
-so it goes on the review list alongside the other ambiguous rows rather than being silently trusted.
+so it goes on the review list rather than being silently trusted.
 
 Their content then becomes unreadable, which is the intended outcome: the authoring project is gone,
 so there is nobody left to ask. The immutable `release`/`taskRun` string still identifies it, so the
 withheld-statement response can name it as purged — see
 [naming the owner](sheet-history-on-database-transfer.md#naming-the-owner).
 
-A revision with no provenance at all falls back to `db.project`, correct for every database that
-never moved, which is the common case. Those rows go on the review list in [Rollout](#rollout)
-rather than being trusted silently.
+A revision with no provenance at all is treated the same way: no ref, surfaced as a shadow miss, and
+granted only if an operator confirms it. Both populations appear together on the review list in
+[Rollout](#rollout).
 
 Two tables that look like sources are not. `ChangelogPayload` carries only `task_run` and
 `git_commit`, and the v1 `Changelog` message exposes no statement or sheet field. `issue_comment`
@@ -396,31 +406,38 @@ A long list means cross-project references are already widespread and the plan n
 since the backfill would make them permanent. Capture it at a known-good point: this design is
 public, including the rule that turns a reference into an ownership edge.
 
-**Review ambiguous revision provenance too.** Two populations, both of which the backfill had to
-guess at. Rows with no provenance fell back to `db.project`, so a database transferred before the
-migration would have granted its destination project a source project's SQL:
+**Review revisions that produced no ref.** These are the rows whose statements are now unreadable —
+absent provenance, or provenance the backfill could not corroborate. They will appear as shadow
+misses during the deferred-enforcement release; this query is the same population identified up
+front, so a top-up can be prepared before the log accumulates.
 
-```sql
-SELECT r.instance, r.db_name, d.project
-FROM revision r JOIN db d ON d.instance = r.instance AND d.name = r.db_name
-WHERE r.payload->>'sheetSha256' IS NOT NULL
-  AND COALESCE(r.payload->>'release', '') = ''
-  AND COALESCE(r.payload->>'taskRun', '') = '';
-```
-
-Rows whose provenance named a project that no longer corroborates it produced no ref, so their
-content is now unreadable. A large count here means either widespread project purges or reused
-project IDs, and is worth understanding before enforcing:
+The test must repeat the corroboration check rather than asking whether the hash has any ref at all.
+The design expects hashes to be shared, so a revision whose own provenance failed may still have a
+ref from an unrelated project that authored identical SQL — and a ref-existence proxy would silently
+drop exactly the rows this list exists to surface.
 
 ```sql
 SELECT r.instance, r.db_name,
-       (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1] AS named_project
+       (regexp_match(COALESCE(NULLIF(r.payload->>'release', ''),
+                              r.payload->>'taskRun'), 'projects/([^/]+)/'))[1] AS named_project
 FROM revision r
 WHERE r.payload->>'sheetSha256' IS NOT NULL
-  AND COALESCE(r.payload->>'release', '') <> ''
-  AND NOT EXISTS (SELECT 1 FROM sheet_blob_ref b
-                  WHERE b.sha256 = decode(r.payload->>'sheetSha256', 'hex'));
+  AND NOT EXISTS (
+    -- the corroboration test from the backfill, repeated verbatim
+    SELECT 1 FROM release rel
+    WHERE rel.project = (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1]
+      AND rel.release_id = (regexp_match(r.payload->>'release', 'releases/([^/]+)'))[1]
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM task t
+    WHERE t.project = (regexp_match(r.payload->>'taskRun', 'projects/([^/]+)/'))[1]
+      AND t.id = (regexp_match(r.payload->>'taskRun', 'tasks/(\d+)/'))[1]::int
+  );
 ```
+
+A large count means either widespread project purges, reused project IDs, or a population of
+revisions created without provenance — each worth understanding before enforcing, since all of them
+end in unreadable statements.
 
 ## Transaction lock ordering
 

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -302,6 +302,13 @@ separate operations. The runners are why that distinction is real rather than co
 not making an access decision. Threading a project through it to satisfy a signature would be
 authorization theater.
 
+**That exemption is conditional, and the condition is not free.** It holds only if the stored plan
+was authorized against the same rule the gate enforces. Plans created before enforcement were not:
+`HasSheets` was deployment-wide, so a plan in project B can reference a hash owned by project A, and
+`validateSpecs` runs only at `CreatePlan` (`backend/api/v1/plan_service.go:196`) and `UpdatePlan`
+(`:325`) — never again. Every path that turns stored plan state into runner work therefore
+revalidates; see [Revalidating stored plans](#revalidating-stored-plans).
+
 Every primitive is set-shaped (R5).
 
 ```go
@@ -385,6 +392,35 @@ Three of these call sites also need reshaping for batching, which is a separate 
 per-file scope check would double. `rollout_service_task.go:214` fetches a loop-invariant hash once
 per target database, masked today only by the LRU. `plan_service.go:746` is already correct and
 worth copying: it collects across every spec and makes one call.
+
+### Revalidating stored plans
+
+The runner exemption assumes creation-time authorization. Historical data does not satisfy it, so
+the assumption has to be re-established at the point a user asks to act on a stored plan rather than
+assumed from the fact that the plan exists.
+
+Three API entry points materialize stored plan state into runner work, and none of them re-runs
+`validateSpecs`:
+
+| Entry point | Location | Produces |
+|---|---|---|
+| `CreateRollout` | `backend/api/v1/rollout_service.go:238` | tasks, via `GetPipelineCreate` from the stored specs |
+| `RunPlanChecks` | `backend/api/v1/plan_service.go:442` | plan check runs, which read the sheet at `backend/runner/plancheck/derive.go:49` |
+| `BatchRunTasks` | `backend/api/v1/rollout_service.go:746` | task runs — this is where the SQL actually executes |
+
+Without revalidation, a project-B user can take an old plan that references project A's hash and,
+after enforcement, still have A's SQL parsed and summarized by plan checks or executed against a
+database of their own — through the front door, with the gate untouched. Plan-check advices quote
+object names and statement fragments, so this is a disclosure path as well as an execution one.
+
+Each of the three revalidates the plan's sheets against the plan's project, using the same scoped
+`HasSheets` as `CreatePlan`, and is shadow-gated on the same switch as everything else. Shadow mode
+matters here more than elsewhere: these are *stored* objects, so a miss identifies a plan that will
+stop working at enforcement, and the operator needs that list while content is still being served.
+
+`BatchRunTasks` is the one to get right even though it never mentions sheets — it resolves a project
+and creates task runs from tasks whose payloads already carry the hash, so it is the last gate
+before execution and the easiest to overlook.
 
 ### Project purge
 
@@ -612,6 +648,10 @@ No schema needed; worth landing separately and first.
   cache read.
 - **Gate confinement** — nothing under `backend/api/v1/` calls a store content getter outside the
   gate.
+- **Stored-plan revalidation** — create a plan in project B referencing project A's hash while
+  `HasSheets` is unscoped, then enforce, then assert each of `CreateRollout`, `RunPlanChecks` and
+  `BatchRunTasks` refuses it. Without this the runner exemption is a bypass: the runners read by bare
+  hash, so anything these three admit is executed or summarized outside the gate.
 - **Query count** — a release with many files must issue a bounded number of queries. A correctness
   test passes just as happily against an N+1.
 - **Backfill** — exercise all five sources; every referenced hash resolves under its project and no

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -146,9 +146,33 @@ Derive the authoring project from the revision's own provenance instead. `Revisi
 name. Parse it out, preferring `release` and falling back to `taskRun`; `backend/store/changelog.go:163-168`
 already does exactly this with `regexp_match(payload->>'taskRun', 'projects/([^/]+)/')`.
 
-Both fields are optional, so a revision created with neither has no recoverable provenance. For
-those, fall back to `db.project` — correct for every database that never moved, which is the common
-case — and add them to the review list in [Rollout](#rollout) rather than trusting them silently.
+The disposition is three-way, not a fallback chain, and conflating the middle case with the last one
+is the trap:
+
+| Provenance | Action |
+|---|---|
+| Names a project that still exists | Insert `(that project, sha)` |
+| Names a project that has been purged | **Insert nothing.** The string stays for attribution |
+| Absent — both fields empty | Fall back to `db.project`, and add to the review list |
+
+**Purged provenance must not fall through to `db.project`.** `revision` is the only source that
+survives a purge of its authoring project: `plan`, `task`, `release` and `plan_check_run` rows are
+all deleted with the project (`backend/store/project.go:578`, `:641`, `:651`, `:671`), but a
+workspace-instance database is reassigned to the default project and keeps its revisions, whose
+`release` and `taskRun` strings still name the deleted project. Inserting that ref would violate
+`sheet_blob_ref`'s foreign key and abort the migration; joining only to live projects and then
+falling back would hand the default project SQL the purged project authored — the grant this design
+refuses. Guard the provenance branch with `EXISTS (SELECT 1 FROM project …)` and let those rows
+produce no ref at all.
+
+Their content then becomes unreadable, which is the intended outcome: the authoring project is gone,
+so there is nobody left to ask. The immutable `release`/`taskRun` string still identifies it, so the
+withheld-statement response can name it as purged — see
+[naming the owner](sheet-history-on-database-transfer.md#naming-the-owner).
+
+A revision with no provenance at all falls back to `db.project`, correct for every database that
+never moved, which is the common case. Those rows go on the review list in [Rollout](#rollout)
+rather than being trusted silently.
 
 Two tables that look like sources are not. `ChangelogPayload` carries only `task_run` and
 `git_commit`, and the v1 `Changelog` message exposes no statement or sheet field. `issue_comment`

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -210,8 +210,15 @@ a `taskRun` name is the weakest version of this and would pass routinely.
 
 Three constraints together close it:
 
-- **Full chain.** For `taskRun`, match the `task_run` row on `(project, id)` *and* require its
-  `task_id` to equal the task ID in the name. For `release`, match `(project, release_id)`.
+- **Full chain, on a key that identifies one row.** For `taskRun`, match the `task_run` row on
+  `(project, id)` — its primary key — *and* require its `task_id` to equal the task ID in the name.
+  For `release`, `(project, release_id)` is **not** a declared unique key: `release` is
+  `PRIMARY KEY (project, train, iteration)` and `idx_release_project_release_id` is a plain
+  `CREATE INDEX`, not a unique one. Corroboration must therefore require `(project, release_id)` to
+  match *exactly one* row rather than merely to match some row; provenance that does not identify a
+  single release has not identified anything, and `EXISTS` would accept whichever duplicate happens
+  to predate the revision and carry the hash. This is the composite-PK identification rule in
+  `AGENTS.md` applied to an alternate key that turns out not to be one.
 - **Temporal.** Require the corroborating row's `created_at` to be no later than the revision's.
   A revision is written after the task run it records completes, so a genuine reference always
   predates it, whereas a row that reused the ID after a purge is necessarily newer — the purge, the
@@ -423,8 +430,14 @@ source is a silent NotFound (R4). Treat that as demonstrated risk rather than hy
 drafts of this document got the source list wrong, first inventing two sources that do not exist,
 then naming the wrong column and nesting for `plan_check_run`.
 
-**Ship the gate in shadow mode.** It evaluates the scope check and logs a miss — project, hash, call
-site — but still returns content. Run one full release; flip to enforcing only once logs are clean.
+**Ship every scope check in shadow mode, not just the read gate.** The gate evaluates the check and
+logs a miss — project, hash, call site — but still returns content. `HasSheets` needs the same
+treatment and is easy to overlook, because it is a *validation* predicate rather than a read: it
+backs plan, release and revision validation and fails the request outright with "some sheets are not
+found". Left unshadowed, any pre-existing blob without a ref would turn into a spurious validation
+error on a write path — a worse failure than a withheld read, since it blocks work rather than
+hiding content. In shadow mode it falls back to the deployment-wide existence check and logs the
+miss. Run one full release; flip to enforcing only once logs are clean.
 
 **Verify the backfill first.** Blobs with zero refs should be a small, non-growing population:
 
@@ -461,15 +474,21 @@ SELECT r.instance, r.db_name,
                               r.payload->>'taskRun'), 'projects/([^/]+)/'))[1] AS named_project
 FROM revision r
 WHERE r.payload->>'sheetSha256' IS NOT NULL
-  AND NOT EXISTS (
-    -- the corroboration test from the backfill, repeated verbatim:
-    -- identity, age, and the hash the row actually references
-    SELECT 1 FROM release rel
-    CROSS JOIN LATERAL jsonb_array_elements(COALESCE(rel.payload->'files', '[]'::jsonb)) AS f
-    WHERE rel.project      = (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1]
-      AND rel.release_id   = (regexp_match(r.payload->>'release', 'releases/([^/]+)'))[1]
-      AND rel.created_at  <= r.created_at
-      AND f->>'sheetSha256' = r.payload->>'sheetSha256'
+  -- the corroboration test from the backfill, repeated verbatim:
+  -- single-row identity, age, and the hash the row actually references.
+  -- (project, release_id) is not a declared unique key, so require exactly one match.
+  AND NOT (
+    (SELECT count(*) FROM release rel
+      WHERE rel.project    = (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1]
+        AND rel.release_id = (regexp_match(r.payload->>'release', 'releases/([^/]+)'))[1]) = 1
+    AND EXISTS (
+      SELECT 1 FROM release rel
+      CROSS JOIN LATERAL jsonb_array_elements(COALESCE(rel.payload->'files', '[]'::jsonb)) AS f
+      WHERE rel.project      = (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1]
+        AND rel.release_id   = (regexp_match(r.payload->>'release', 'releases/([^/]+)'))[1]
+        AND rel.created_at  <= r.created_at
+        AND f->>'sheetSha256' = r.payload->>'sheetSha256'
+    )
   )
   AND NOT EXISTS (
     SELECT 1 FROM task_run tr
@@ -580,11 +599,11 @@ No schema needed; worth landing separately and first.
 
 1. The five independent fixes, T6 first.
 2. Create `sheet_blob_ref` and land the ref *writers* — the transactional `CreateSheets` and the
-   purge delete — **before** any backfill.
-3. Store API, gate, call sites, tests — gate shipping in shadow mode.
-4. Run the backfill once the writers are live everywhere, then the verification queries; review the
+   purge delete. No scope check reads the table yet.
+3. Run the backfill once the writers are live everywhere, then the verification queries; review the
    multi-project list and the ambiguous-provenance list.
-5. Flip to enforcing one release later, once shadow logs are clean.
+4. Land the scope checks — the read gate and the scoped validators — both in shadow mode.
+5. Re-run the backfill, then flip to enforcing one release later, once shadow logs are clean.
 
 **Writers must precede the backfill, or new sheets fall into the gap.** A one-shot backfill scans
 history; it cannot cover a sheet created after it runs. If the migration ships before `CreateSheets`

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -355,7 +355,25 @@ arrangement a cache hit can skip.
 A test asserts nothing under `backend/api/v1/` calls a store content getter outside the gate.
 Runner and component call sites keep the unscoped getters.
 
-Three existing call patterns need reshaping to feed it. `validateAndSanitizeReleaseFiles`
+**Every v1 call site, enumerated.** `git grep -n 'GetSheetFull\|GetSheetTruncated\|HasSheets' -- backend/api/v1`
+returns exactly these seven on `main`; re-run it before implementing, since a route added since this
+was written would otherwise slip past the gate:
+
+| Call site | Path | Routes to |
+|---|---|---|
+| `sheet_service.go:136,138` | `GetSheet` | gate |
+| `release_service.go:398` | `validateAndSanitizeReleaseFiles`, via `CreateRelease` and `CheckRelease` | gate |
+| `rollout_service.go:1233` | `PreviewTaskRunRollback` | gate |
+| `rollout_service_task.go:463` | `getSheetContentBySha256` | gate |
+| `release_service.go:144` | `CreateRelease` validation | scoped `HasSheets` |
+| `revision_service.go:158` | `BatchCreateRevisions` validation | scoped `HasSheets` |
+| `plan_service.go:746` | `validateSpecs` | scoped `HasSheets` |
+
+`PreviewTaskRunRollback` is the one most easily missed — it is a content read that does not look
+like one, reached through a rollback-preview route rather than through anything named for sheets.
+The confinement test is what keeps this table from going stale.
+
+Three of these call sites also need reshaping for batching, which is a separate concern from routing. `validateAndSanitizeReleaseFiles`
 (`release_service.go:377-413`) fetches once per file inside its loop — a pre-existing N+1 that a
 per-file scope check would double. `rollout_service_task.go:214` fetches a loop-invariant hash once
 per target database, masked today only by the LRU. `plan_service.go:746` is already correct and
@@ -603,7 +621,8 @@ No schema needed; worth landing separately and first.
 3. Run the backfill once the writers are live everywhere, then the verification queries; review the
    multi-project list and the ambiguous-provenance list.
 4. Land the scope checks — the read gate and the scoped validators — both in shadow mode.
-5. Re-run the backfill, then flip to enforcing one release later, once shadow logs are clean.
+5. Review the shadow-miss log and top up refs deliberately; re-run the audits; then flip to
+   enforcing, one release after step 4.
 
 **Writers must precede the backfill, or new sheets fall into the gap.** A one-shot backfill scans
 history; it cannot cover a sheet created after it runs. If the migration ships before `CreateSheets`
@@ -612,7 +631,20 @@ historical source, so it becomes a zero-ref miss and a NotFound at enforcement. 
 widens the same gap even when both ship together, since old replicas keep serving the old
 `CreateSheets` against the new schema until the rollout completes.
 
-The backfill is idempotent (`ON CONFLICT DO NOTHING`), so the safe pattern is to run it after the
-rollout has fully converged and to re-run it immediately before flipping to enforcing. Shadow-mode
-misses are the backstop: anything the backfill missed shows up there as a log line rather than as a
-production NotFound.
+The backfill is idempotent (`ON CONFLICT DO NOTHING`), so run it once the rollout has fully
+converged. Shadow-mode misses are the backstop: anything it missed shows up as a log line rather
+than a production NotFound.
+
+**Do not re-run the backfill blindly before enforcing.** By step 5 the writers have been live for a
+release, so every genuinely new sheet already has a ref from `CreateSheets`. The only rows a second
+backfill would add are references made to *pre-existing* blobs during the shadow window — which is
+exactly the unscoped-reference shape this design exists to close. Shadow-mode `HasSheets` falls back
+to the deployment-wide existence check, so a plan or release written during that window can
+reference a foreign hash and succeed with only a log line; a blind re-run would then mint
+`(that project, sha)`, clean the subsequent shadow logs, and carry an unreviewed grant into
+enforcement.
+
+Instead, close the window deliberately: review the shadow-miss log, grant the entries that are
+legitimate, and re-run the multi-project and ambiguous-provenance audits afterwards so anything
+added since step 3 is seen before the flip. This is the same posture taken for provenance-less
+revisions — an operator confirms, rather than a query inferring.

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -616,6 +616,9 @@ No schema needed; worth landing separately and first.
   test passes just as happily against an N+1.
 - **Backfill** — exercise all five sources; every referenced hash resolves under its project and no
   unreferenced hash does.
+- **Missing-ref audit** — create a plan in project B referencing a pre-existing hash owned by A
+  *after* the backfill has run, and assert the source-level audit reports it. This is the case the
+  shadow log cannot see, because no `CreateSheets` runs and nothing revalidates the plan.
 - **Multi-project hashes** — seed a plan in project B referencing a hash created in project A, run
   the backfill, assert the audit query reports it. The point is that it is detected, not blessed.
 - **Project purge** — purge a project holding sheet refs and assert it succeeds. Direct regression
@@ -632,11 +635,12 @@ No schema needed; worth landing separately and first.
 1. The five independent fixes, T6 first.
 2. Create `sheet_blob_ref` and land the ref *writers* — the transactional `CreateSheets` and the
    purge delete. No scope check reads the table yet.
-3. Run the backfill once the writers are live everywhere, then the verification queries; review the
-   multi-project list and the ambiguous-provenance list.
-4. Land the scope checks — the read gate and the scoped validators — both in shadow mode.
-5. Review the shadow-miss log and top up refs deliberately; re-run the audits; then flip to
-   enforcing, one release after step 4.
+3. Ship the backfill **and** the shadow-mode scope checks in the same release, so the migration runs
+   at startup and the binary that then serves traffic is already instrumented. Run the verification
+   queries.
+4. Before flipping: run the **missing-ref audit** below, review the shadow-miss log, and top up refs
+   deliberately. Re-run the multi-project and ambiguous-provenance audits afterwards.
+5. Flip to enforcing, one release after step 3.
 
 **Writers must precede the backfill, or new sheets fall into the gap.** A one-shot backfill scans
 history; it cannot cover a sheet created after it runs. If the migration ships before `CreateSheets`
@@ -660,5 +664,36 @@ enforcement.
 
 Instead, close the window deliberately: review the shadow-miss log, grant the entries that are
 legitimate, and re-run the multi-project and ambiguous-provenance audits afterwards so anything
-added since step 3 is seen before the flip. This is the same posture taken for provenance-less
-revisions — an operator confirms, rather than a query inferring.
+added since the backfill is seen before the flip. This is the same posture taken for
+provenance-less revisions — an operator confirms, rather than a query inferring.
+
+**The shadow log is not sufficient on its own, because it only sees traffic.** A reference created
+while the check was not yet instrumented — or created once and never revalidated — produces no log
+line, so relying on shadow alone reproduces exactly the silent NotFound R4 forbids. Concretely: a
+plan or release in project B can reference a *pre-existing* hash owned by project A, which invokes
+no `CreateSheets` and therefore writes no ref, and which the multi-project audit cannot see because
+that audit reads `sheet_blob_ref` and no row was ever created.
+
+So audit the sources directly rather than inferring from refs. For each of the four project-scoped
+sources, find `(project, hash)` pairs with no matching ref:
+
+```sql
+SELECT DISTINCT pl.project, spec->'changeDatabaseConfig'->>'sheetSha256' AS sha
+FROM plan pl
+CROSS JOIN LATERAL jsonb_array_elements(COALESCE(pl.config->'specs', '[]'::jsonb)) AS spec
+WHERE spec->'changeDatabaseConfig'->>'sheetSha256' IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM sheet_blob_ref r
+    WHERE r.project = pl.project
+      AND r.sha256  = decode(spec->'changeDatabaseConfig'->>'sheetSha256', 'hex')
+  )
+-- UNION ALL the same shape for task, release, plan_check_run
+;
+```
+
+Every row is something that will 404 at enforcement. It is exhaustive rather than traffic-dependent,
+so it strictly dominates the shadow log for these four sources, and it needs no assumption about
+when a reference was created or whether anything has revalidated it since.
+
+`revision` is deliberately excluded: uncorroborated revisions produce no ref *by design*, so they
+would flood this query with expected rows. They have their own list above.

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -117,17 +117,16 @@ CREATE INDEX idx_sheet_blob_ref_sha256 ON sheet_blob_ref(sha256);
 so project IDs are one global namespace across every workspace, and a project resolves to exactly
 one workspace through `project.workspace`.
 
-The gate and `HasSheets` both query `WHERE project = ? AND sha256 IN (…)`, which the
-project-leading primary key serves directly. The secondary index exists for the two paths that
-start from a hash with no project in hand: the owner lookup for a withheld statement
-([naming the owner](sheet-history-on-database-transfer.md#naming-the-owner)) and the zero-ref
-verification query in [Rollout](#rollout). PostgreSQL can only full-scan a `(project, sha256)` btree
-for a `sha256`-only predicate, so both would degrade as the table grows.
+The gate, `HasSheets` and the source-level missing-ref audit all query
+`WHERE project = ? AND sha256 …`, which the project-leading primary key serves directly. The
+secondary index exists for the one query that starts from a hash with no project in hand: the
+zero-ref verification in [Rollout](#rollout), which PostgreSQL can only satisfy by full-scanning a
+`(project, sha256)` btree. That is an operator query rather than a hot path, but it runs over the
+whole table and a future `sheet_blob` GC would need the same access shape.
 
-Those hash-first queries are a deliberate exception to the composite-PK predicate rule in
-`AGENTS.md`: their whole purpose is to discover *which* project holds a hash, so the scope column
-cannot be supplied. They are made safe by joining through `project` and constraining to the caller's
-workspace instead — never by omitting scope entirely.
+That query is a deliberate exception to the composite-PK predicate rule in `AGENTS.md`: it asks
+which blobs have no ref at all, so there is no scope column to supply. It is an offline audit, not a
+request-path read, which is what makes the exception acceptable — no request-path query omits scope.
 
 Migration slot `backend/migrator/migration/3.22/0005##scope_sheet_blob.sql`; `TestLatestVersion` in
 `backend/migrator/migrator_test.go` needs updating, and `LATEST.sql` mirrored.
@@ -413,8 +412,22 @@ after enforcement, still have A's SQL parsed and summarized by plan checks or ex
 database of their own — through the front door, with the gate untouched. Plan-check advices quote
 object names and statement fragments, so this is a disclosure path as well as an execution one.
 
-Each of the three revalidates the plan's sheets against the plan's project, using the same scoped
-`HasSheets` as `CreatePlan`, and is shadow-gated on the same switch as everything else. Shadow mode
+Each of the three revalidates the plan's sheets against the plan's project, and is shadow-gated on
+the same switch as everything else.
+
+**Revalidation must expand releases; reusing `CreatePlan`'s check is not enough.** `validateSpecs`
+collects only the direct `ChangeDatabaseConfig.Sheet` hashes into `HasSheets`, and for a release it
+verifies the project matches and the row exists — it never touches `release.Payload.Files[]`
+(`backend/api/v1/plan_service.go:755-774`). The release runners then read every file's hash by bare
+`GetSheetFull` (`backend/runner/taskrun/database_migrate_executor.go:543`, `:654`). So a release in
+project B whose files reference project A's hash — creatable today, since
+`validateAndSanitizeReleaseFiles` discards the project and `HasSheets` is deployment-wide — passes a
+`CreatePlan`-shaped check with nothing to test, and the runner still executes A's SQL.
+
+Revalidation therefore expands each referenced release and checks every `files[].sheetSha256`
+against the plan's project, not just the spec's direct sheet. `validateSpecs` gains the same
+expansion so the two agree: new releases cannot carry foreign hashes once `CreateRelease` uses
+scoped `HasSheets`, but plans may reference releases created before that. Shadow mode
 matters here more than elsewhere: these are *stored* objects, so a miss identifies a plan that will
 stop working at enforcement, and the operator needs that list while content is still being served.
 
@@ -650,7 +663,9 @@ No schema needed; worth landing separately and first.
   gate.
 - **Stored-plan revalidation** — create a plan in project B referencing project A's hash while
   `HasSheets` is unscoped, then enforce, then assert each of `CreateRollout`, `RunPlanChecks` and
-  `BatchRunTasks` refuses it. Without this the runner exemption is a bypass: the runners read by bare
+  `BatchRunTasks` refuses it. Run it twice: once with the hash on the spec directly, and once with
+  the hash inside a referenced release's `files[]`, which is the shape a `CreatePlan`-style check
+  does not look at. Without this the runner exemption is a bypass: the runners read by bare
   hash, so anything these three admit is executed or summarized outside the gate.
 - **Query count** — a release with many files must issue a bounded number of queries. A correctness
   test passes just as happily against an N+1.

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -1,100 +1,125 @@
-# Scoping `sheet_blob` — fixing the global-by-SHA256 read
+# Scoping `sheet_blob` to its project
 
 Fixes T5 in `docs/design/v1-api-audit-2026-08.md`.
 
-## Problem
+Sheet content is fetched by SHA256 with no scope predicate, so any principal holding
+`bb.sheets.get` on any one project can read any sheet in the deployment — across projects and
+across tenants — given the hash. A `sheet_blob_ref(project, sha256)` edge table makes ownership an
+explicit stored fact, and an API-layer gate enforces it.
+
+## Background
 
 `sheet_blob` is `(sha256 PRIMARY KEY, content)` — no project column, no workspace column.
 `getSheet` selects `WHERE sha256 = decode(?, 'hex')` with no scope predicate
 (`backend/store/sheet.go:60-71`), while the ACL authorizes `bb.sheets.get` against the
-caller-named project, correctly pinned to the caller's workspace
-(`backend/api/v1/acl.go:397`).
-
-Authorization is per-tenant; the data fetch is deployment-global. Anyone holding
-`bb.sheets.get` on any one project reads any blob in the deployment, across projects and
-across workspaces, given the hash.
+caller-named project, correctly pinned to the caller's workspace (`backend/api/v1/acl.go:397`).
+Authorization is per-tenant; the data fetch is deployment-global.
 
 This is a regression, not an oversight. Commit `bee2080737` (#18552, Dec 2025) dropped the
 project-scoped `sheet` table — which carried `project text NOT NULL REFERENCES
-project(resource_id)` — and promoted the `sheet_blob` dedup side-table to primary store. Its
-design doc's Non-Goals recorded "Change authorization model (already project-scoped, no
-changes needed)", which was true before the cutover and false after. The assumption is still
-in the tree as a justification for skipping checks, at `backend/api/v1/release_service.go:331`
-and `:405`.
+project(resource_id)` and `idx_sheet_project` — and promoted the `sheet_blob` dedup side-table to
+primary store. Its design doc recorded "Change authorization model (already project-scoped, no
+changes needed)" as a non-goal, true before the cutover and false after. The assumption survives in
+the tree as a justification for skipping checks, at `backend/api/v1/release_service.go:331` and
+`:405`.
 
-## The model is per-project
+## Requirements
 
-This is not a new decision — it is the model the rest of the code already implements, and
-sheets are the one thing that fell out of it.
+**R1 — Close cross-tenant read.** A principal in workspace W1 must not read sheet content belonging
+to workspace W2. In Bytebase Cloud this is tenant isolation; it is the severe half of the finding
+and is non-negotiable.
 
-`validateSpecs` rejects a release whose project differs from the plan's project
-(`backend/api/v1/plan_service.go:759`). Three lines above, the sheet check is
-`HasSheets(ctx, sheetSha256s...)` with no project, and `:642` discards the project segment of
-a caller-supplied sheet name outright. Same function, two resources, opposite treatment. The
-dropped `sheet` table carried `project text NOT NULL REFERENCES project(resource_id)`, and the
-resource name is still `projects/{project}/sheets/{sha}`.
+**R2 — Preserve authoring governance.** Customers restrict who may author change SQL under a given
+project. `CreateSheet` is gated on `bb.sheets.create` against the parent project, and that must
+remain expressible.
 
-So the fix restores project scoping rather than inventing a scope.
+**R3 — Preserve content-addressed dedup.** Identical SQL must not be stored twice. This was the
+point of the refactor that introduced the bug and must not be undone to fix it.
 
-Scoping on `project` alone is sufficient for tenant isolation too: `project.resource_id` is a
-global primary key carrying a `workspace` column, and the ACL already pins the caller-named
-project to the caller's workspace (`backend/api/v1/acl.go:397`). One predicate closes both
-boundaries.
+**R4 — No silent breakage of existing reads.** The fix rests on a backfill whose completeness
+cannot be established by construction. A missed reference source must not become a production
+NotFound with no signal.
 
-## Design decision: an ownership edge, not a column
+**R5 — Bounded round-trips.** Requests routinely carry many sheets; a release can have hundreds of
+files. The scope check must not be O(n) in queries.
 
-Adding `project` directly to `sheet_blob` would break the content-addressed dedup that
-motivated the refactor — the same statement in two projects would need two rows, and the
-migration would have to split existing shared rows.
+**R6 — Projects remain a confidentiality boundary.** Many customers separate projects specifically
+so teams cannot read each other's SQL — regulated separation where a PCI- or HIPAA-scoped project
+is walled off and audited, and agency or multi-end-customer workspaces where one workspace holds
+databases belonging to different clients.
 
-Instead, keep `sheet_blob` as pure content storage and add an edge table recording which
-projects may read a given hash. Two projects that independently author identical SQL share one
-blob and hold one ref row each. Dedup survives; "who can read this hash" becomes an explicit
-stored fact rather than an implicit one.
+**R7 — The resource name states the truth.** Across this API the prefix in a resource name
+identifies the resource's actual owner, never a scope the caller selected. A scope that disagrees
+with the name is the defect being fixed, not a fix for it.
 
-### Schema
+## Decision
 
-`backend/migrator/migration/3.22/0005##scope_sheet_blob.sql` (current head is 3.22.4;
-`TestLatestVersion` in `backend/migrator/migrator_test.go` needs updating).
+**A sheet is owned by a project.** The resource is the pair (project, content): two projects that
+independently author identical SQL own two distinct sheets that happen to share storage.
+Content-addressed dedup becomes a storage optimization invisible at the API layer.
+
+Everything else follows from that one commitment. `projects/{project}/sheets/{sha}` is an honest
+name, `parent = projects/{project}` on `CreateSheet` is a real parent, project-level
+`bb.sheets.create` is coherent, read is project-scoped, and no part of the public contract changes.
+
+The alternative — treating the resource as the content, shared tenant-wide — is examined under
+[Alternatives](#alternatives-considered). It fails R2 and R6 and requires a breaking rename.
+
+### Why the name forces this
+
+The API has one consistent rule and it is unbroken. Project-owned resources use a single
+project-prefixed pattern: `AccessGrant` (`projects/{project}/accessGrants/{access_grant}`),
+`DatabaseGroup`, `Plan`, `PlanCheckRun`, `Issue`, `Release`. Workspace-global resources use a bare
+collection with the workspace implicit from the JWT: `Group` (`groups/{group}`), `IdP`
+(`idps/{idp}`), `ReviewConfig` (`reviewConfigs/{reviewConfig}`). Resources with two legitimate
+addressings declare both patterns — `Database`, `DatabaseChangelog`, `DatabaseCatalog`,
+`DatabaseMetadata`, `InstanceRole`, `Instance` all carry `instances/{instance}/…` alongside
+`projects/{project}/instances/{instance}/…`, and `Policy` carries three.
+
+In every case the prefix names the **actual owner**. A project instance really is owned by that
+project; a database's `projects/{p}/…` form names the project in `db.project`, not one the caller
+picked. Nowhere else in this API does a name prefix identify a caller-supplied scope. `Sheet`
+declaring `projects/{project}/sheets/{sheet}` while the lookup ignores the project *is* T5, stated
+as a naming defect rather than an authorization one.
+
+The create side is equally strict: a create request's `parent` is always exactly the prefix of the
+created resource's name. Workspace-scoped resources therefore have no parent at all —
+`CreateGroup` is `POST /v1/groups`, `CreateReviewConfig` is `POST /v1/reviewConfigs`,
+`CreateIdentityProvider` is `POST /v1/idps`. `CreatePolicyRequest.parent` is `workspaces/{workspace}`
+or `environments/{environment}` or `projects/{project}`, and the resulting `Policy` name is that
+parent plus `/policies/{policy}`.
+
+So project-parented creation and a workspace-scoped resource cannot coexist. Keeping
+`parent = projects/{project}` while naming the resource `sheets/{sha}` would make the parent a
+permission argument wearing a parent's name; dropping the parent to match the name moves
+`bb.sheets.create` to the workspace and loses R2. Project ownership is the only shape in which
+creation, naming, and access all agree.
+
+## Design
+
+### An ownership edge, not a column
+
+Adding `project` directly to `sheet_blob` would break dedup (R3): the same statement in two projects
+would need two rows, and the migration would have to split existing shared rows. Keep `sheet_blob`
+as pure content storage and record ownership beside it.
 
 ```sql
 CREATE TABLE sheet_blob_ref (
-    project text NOT NULL REFERENCES project(resource_id),
-    sha256 bytea NOT NULL REFERENCES sheet_blob(sha256),
+    project text  NOT NULL REFERENCES project(resource_id),
+    sha256  bytea NOT NULL REFERENCES sheet_blob(sha256),
     PRIMARY KEY (project, sha256)
 );
 ```
 
-Mirror into `backend/migrator/migration/LATEST.sql`.
-
-### Project purge
-
-The `project` foreign key makes `sheet_blob_ref` a dependent of `project`, and project purge
-ends with `DELETE FROM project WHERE resource_id = ?` (`backend/store/project.go:826`) after
-clearing every other dependent table. Add
-
-```sql
-DELETE FROM sheet_blob_ref WHERE project = ?
-```
-
-to that sequence at the position established under transaction lock ordering below — after the
-`db` delete (`:704`) and before `project_webhook` (`:739`). Without it, purging any project fails
-on the foreign key, a hard breakage of a shipped path.
-
-Blobs whose only ref belonged to the purged project are left behind with zero refs. That is
-consistent with today's behavior (nothing has ever deleted from `sheet_blob`) and is the state
-a future GC would collect; see the GC note under independent fixes.
+Migration slot `backend/migrator/migration/3.22/0005##scope_sheet_blob.sql`; `TestLatestVersion` in
+`backend/migrator/migrator_test.go` needs updating, and `LATEST.sql` mirrored.
 
 ### Backfill
 
-Derive `(project, sha256)` from every surviving reference. All of them live inside JSONB
-payloads, and `protojson` camelCases the keys — `sheetSha256`, not `sheet_sha256`.
-
-The authoritative source list is `grep -rn "sheet_sha256" proto/store/`, which returns exactly
-five messages. Re-run it before writing the migration rather than trusting this table — and for
-each hit, confirm two things the grep does not tell you: the **column name** in `LATEST.sql`
-(it is not always `payload`) and the **nesting** of the field inside its message (it is not
-always top-level).
+Five reference sources, and only five. `grep -rn "sheet_sha256" proto/store/` returns exactly these
+messages; re-run it before writing the migration, and for each hit confirm two things the grep does
+not give you — the column name in `LATEST.sql` (not always `payload`) and the nesting of the field
+inside its message (not always top-level). `protojson` camelCases keys.
 
 | Source | Column | Path to the hash | Route to project |
 |---|---|---|---|
@@ -104,427 +129,283 @@ always top-level).
 | `plan_check_run` | `result` | `results[].sheetSha256` | `plan_check_run.project` |
 | `revision` | `payload` | `sheetSha256` | `db(instance, db_name)` → `db.project` |
 
-`plan_check_run` is the one that punishes assumption: the column is `result`, not `payload`, and
-the hash lives on `PlanCheckRunResult.Result` inside the repeated `results` array, so the path is
-`result->'results'` with a `jsonb_array_elements` expansion — the same shape as `plan` and
-`release`, not the flat shape of `task` and `revision`.
-
-The first four carry `project` directly. Only `revision` needs the join through `db`, because
-it keys on `(instance, db_name)` and inherits its project from the database.
+`plan_check_run` punishes assumption: the column is `result`, not `payload`, and the hash sits on
+`PlanCheckRunResult.Result` inside the repeated `results` array.
 
 Two tables that look like sources are not. `ChangelogPayload` carries only `task_run` and
-`git_commit` — a changelog reaches SQL transitively through its task run, and the v1
-`Changelog` message exposes no statement or sheet field. `issue_comment` has no sheet reference
-of any kind.
+`git_commit`, and the v1 `Changelog` message exposes no statement or sheet field. `issue_comment`
+has no sheet reference of any kind.
 
-Representative statement for the plan source; the others follow the same shape and are
-`UNION`ed into one insert:
+Guard every derivation with `EXISTS (SELECT 1 FROM sheet_blob …)` so a payload naming a hash with no
+blob cannot violate the foreign key.
 
-```sql
-INSERT INTO sheet_blob_ref (project, sha256)
-SELECT DISTINCT pl.project, decode(x.sha, 'hex')
-FROM plan pl
-CROSS JOIN LATERAL jsonb_array_elements(COALESCE(pl.config->'specs', '[]'::jsonb)) spec
-CROSS JOIN LATERAL (SELECT spec->'changeDatabaseConfig'->>'sheetSha256' AS sha) x
-WHERE x.sha IS NOT NULL
-  AND EXISTS (SELECT 1 FROM sheet_blob b WHERE b.sha256 = decode(x.sha, 'hex'))
-ON CONFLICT DO NOTHING;
-```
+**Unreferenced blobs become unreadable.** A blob referenced by nothing has no derivable project. In
+practice this is a sheet created but never attached to a plan or release; the UI attaches
+immediately, and `createSheet` caches content client-side (`frontend/src/stores/app/sheet.ts:91`) so
+a fresh draft does not re-fetch. Leaving orphans globally readable would reproduce the bug, so the
+gap is accepted and noted in the migration comment.
 
-The `EXISTS` guard keeps the foreign key satisfiable if any payload ever names a hash with no
-blob.
-
-**Known gap.** A blob referenced by nothing has no derivable project — there is no information
-anywhere that ties it to one. Those rows get no ref and become unreadable. In practice this is
-a sheet created but never attached to a plan or release; the UI attaches immediately, and
-`createSheet` caches the content client-side (`frontend/src/stores/app/sheet.ts:91`) so a fresh
-draft does not re-fetch. The alternative — leaving orphans globally readable — reproduces the
-bug, so accept the gap and note it in the migration comment.
-
-**Observed references are not authorization.** This is the sharpest limitation of the whole
-approach and it needs a decision before the migration runs.
-
-The backfill reconstructs which project *referenced* a hash. That is not the same as which
-project was *entitled* to it, and today's unscoped paths let the two diverge.
+**Observed references are not authorization.** The backfill reconstructs which project *referenced*
+a hash, which is not the same as which project was *entitled* to it.
 `convertPlanSpecChangeDatabaseConfig` (`backend/api/v1/plan_service.go:1157`) parses a
-caller-supplied `projects/{project}/sheets/{sha}` and stores only the hash, discarding the
-project; `HasSheets` currently validates existence with no scope. So a plan in project B can
-already hold a reference to a hash owned by project A, and after the write nothing distinguishes
-it from a legitimate one. Backfilling `(B, sha)` would mint a permanent grant out of exactly the
-access this change exists to close.
+caller-supplied `projects/{project}/sheets/{sha}` and stores only the hash, and `HasSheets`
+currently validates existence with no scope — so a plan in project B may already reference a hash
+owned by project A, indistinguishable after the write from a legitimate one. Backfilling `(B, sha)`
+would mint a permanent grant out of the access being closed, and shadow mode cannot see it because
+the ref row exists.
 
-Shadow mode does not catch this. The ref row exists, so the gate neither logs nor denies — it
-is invisible to the safety net described below.
-
-There is no clean automated fix: the refactor that created this bug deleted the sheet's creator
-and project metadata, so no ground truth for "who owned this hash" survives anywhere. What can
-be done is to size the population and decide deliberately:
-
-```sql
-SELECT sha256, count(DISTINCT project) AS projects, array_agg(DISTINCT project)
-FROM sheet_blob_ref
-GROUP BY sha256
-HAVING count(DISTINCT project) > 1;
-```
-
-Run this immediately after the backfill, before enforcement. A hash claimed by more than one
-project is either honest dedup — two projects independently authored identical SQL, and both
-claims are real — or a laundered cross-project reference. They are indistinguishable from the
-data, so this is a review list, not an automatic filter. In most deployments it should be short
-or empty; if it is long, that is itself a finding worth reporting before proceeding.
-
-One timing note: this design is public on the PR, including the rule that a reference becomes an
-ownership edge. Between publication and the migration there is a window in which references could
-be planted deliberately. Capture the multi-project list at a known-good point rather than only
-after upgrade.
+No ground truth survives: the refactor that caused this bug deleted the sheet's creator and project
+metadata. The population is therefore sized and reviewed rather than filtered — see
+[Rollout](#rollout).
 
 ### Store API
 
-`sheet_blob_ref` is an ACL fact, enforced at the API layer. Content retrieval and access
-control are separate operations and the store API keeps them separate.
+`sheet_blob_ref` is an ACL fact enforced at the API layer; content retrieval and access control stay
+separate operations. The runners are why that distinction is real rather than cosmetic: when
+`database_migrate_executor` reads a sheet it is executing work authorized when the plan was created,
+not making an access decision. Threading a project through it to satisfy a signature would be
+authorization theater.
 
-The runners are the reason this distinction is real rather than cosmetic. When
-`database_migrate_executor` reads a sheet, it is executing work that was authorized when the
-plan was created; it is not making an access-control decision. Threading a project through it
-purely to satisfy a signature would be authorization theater.
-
-Every primitive is set-shaped. Requests routinely carry many sheets — a release can have
-hundreds of files — so nothing here may be O(n) in round-trips. See "Batch shape" below.
+Every primitive is set-shaped (R5).
 
 ```go
-// Content only. A hash fully determines the content, so no scope is involved.
-// Returns a map keyed by hex hash; an absent key means no such blob.
-func (s *Store) GetSheetsFull(ctx context.Context, sha256Hexes ...string) (map[string]*SheetMessage, error)
-func (s *Store) GetSheetsTruncated(ctx context.Context, sha256Hexes ...string) (map[string]*SheetMessage, error)
+// Content only. A hash fully determines content, so no scope is involved.
+func (s *Store) GetSheetsFull(ctx, sha256Hexes ...string) (map[string]*SheetMessage, error)
+func (s *Store) GetSheetsTruncated(ctx, sha256Hexes ...string) (map[string]*SheetMessage, error)
 
 // Scoped: which of these hashes may this project read? One query.
-func (s *Store) FilterSheetsForProject(ctx context.Context, projectID string, sha256Hexes ...string) (map[string]bool, error)
+func (s *Store) FilterSheetsForProject(ctx, projectID string, sha256Hexes ...string) (map[string]bool, error)
 
-// Scoped: a validation predicate, not a content read. Already batched today.
-func (s *Store) HasSheets(ctx context.Context, projectID string, sha256Hexes ...string) (bool, error)
+// Scoped: validation predicate, not a content read.
+func (s *Store) HasSheets(ctx, projectID string, sha256Hexes ...string) (bool, error)
 
-// Scoped: writes blobs and ref rows, both as set inserts.
-func (s *Store) CreateSheets(ctx context.Context, projectID string, creates ...*SheetMessage) ([]*SheetMessage, error)
+// Scoped: writes blobs and ref rows, both as set inserts, in one transaction.
+func (s *Store) CreateSheets(ctx, projectID string, creates ...*SheetMessage) ([]*SheetMessage, error)
 ```
 
-The singular `GetSheetFull`/`GetSheetTruncated` can stay as thin wrappers for the genuinely
-single-sheet callers in the runners, but the batch form is the primitive.
+`CreateSheets` needs a transaction so a blob cannot land without its ref; it currently issues a bare
+`ExecContext`. The ref insert mirrors the blob insert's array shape rather than looping.
 
-`HasSheets` gains the join and stops being a deployment-wide existence oracle:
+Three of its four call sites have a project to hand — `sheet_service.go:54` and `:97`, and
+`release_service.go:96`. The fourth does not: `rollout_service_task.go:143` stores generated
+`CREATE DATABASE` boilerplate from inside `getTaskCreatesFromCreateDatabaseConfig`, which takes no
+project, and neither does its caller `getTaskCreatesFromSpec`. Thread it down from
+`rollout_service.go:1279`, which has the plan's project.
 
-```sql
-SELECT COUNT(*)
-FROM sheet_blob b
-JOIN sheet_blob_ref r ON r.sha256 = b.sha256
-WHERE b.sha256 IN (...) AND r.project = ?
-```
+### Cache ordering
 
-`CreateSheets` writes blobs and ref rows in one transaction. It currently issues a bare
-`ExecContext`; it needs a transaction so a blob cannot land without its ref. The ref insert
-mirrors the existing blob insert's array shape — one statement, not a loop:
+`sheetFullCache` stays keyed by hex hash alone (`backend/store/store.go:51,82,110`, a 10-entry LRU).
+Content is a pure function of the hash, so a hash-keyed content cache is always correct, and the
+dominant consumer — a runner reading the same sheet repeatedly — keeps full hit rate.
 
-```sql
-INSERT INTO sheet_blob_ref (project, sha256)
-SELECT ?, unnest(CAST(? AS BYTEA[]))
-ON CONFLICT DO NOTHING
-```
+This is safe **only** because the scope check is a separate step that runs first. The cache read at
+`backend/store/sheet.go:43` returns before any query executes, so a scope predicate placed inside
+`getSheet` would be skipped on a cache hit. Enforcement must not live there, and the check and the
+fetch must not be fused into one join.
 
-Three of its four call sites have a project to hand — `sheet_service.go:54` and `:97` (the
-resolved parent) and `release_service.go:96`. The fourth does not:
-`rollout_service_task.go:143` stores generated `CREATE DATABASE` boilerplate from inside
-`getTaskCreatesFromCreateDatabaseConfig(ctx, s *store.Store, spec, c)`, which takes no project,
-and neither does its caller `getTaskCreatesFromSpec`. Thread it down from
-`rollout_service.go:1279`, which has the plan's project — two signature changes.
-
-### Cache
-
-`sheetFullCache` stays keyed by hex hash alone (`backend/store/store.go:51,82,110`, a 10-entry
-LRU). Because content is a pure function of the hash, a hash-keyed content cache is always
-correct, and the dominant consumer — a runner reading the same sheet repeatedly — keeps full
-hit rate.
-
-This is safe only because the ACL check is a separate step that runs first. The cache read at
-`backend/store/sheet.go:43` returns before any query executes, so a scope predicate placed
-inside `getSheet` would be skipped on a cache hit. Enforcement must not live there.
-
-Ten entries is sized for the runner pattern — one sheet read repeatedly — not for batch reads,
-and a release with hundreds of files will miss on nearly all of them. That is fine and not a
-reason to grow it: the batch path collapses those misses into a single query, so the cache is an
-optimization for the repeated-single-sheet case rather than load-bearing for throughput.
+Ten entries is sized for the runner pattern, not for batch reads, and a release with hundreds of
+files will miss on nearly all of them. That is not a reason to grow it: the batch path collapses
+those misses into a single query.
 
 ### API-layer gate
 
-Moving enforcement out of the store means the compiler no longer finds missed call sites — and
-a forgotten check is exactly how `release_service.go:398` and `plan_service.go:642` ended up
-unscoped. Replace the compiler with structure:
+Moving enforcement out of the store means the compiler no longer finds missed call sites, and a
+forgotten check is exactly how `release_service.go:398` and `plan_service.go:642` ended up unscoped.
+Structure replaces the compiler: one package-level helper doing check-then-fetch — package-level
+because most routed call sites live in `ReleaseService` and `RolloutService`, not `SheetService` —
+taking a set and costing two queries whatever the input size.
 
-Add one helper in `backend/api/v1/` that does check-then-fetch. It has to be a package-level
-function, not a method — three of the four routed call sites live in `ReleaseService` and
-`RolloutService`, not `SheetService` — and it takes a set, because its heaviest caller iterates
-over release files:
+1. One ref query returning the subset of requested hashes the project may read.
+2. Cache lookups for survivors, then one content query for the misses.
 
-```go
-func sheetsForProject(ctx context.Context, s *store.Store, projectID string, sha256Hexes []string, raw bool) (map[string]*store.SheetMessage, error)
-```
+A hash that does not survive yields NotFound rather than PermissionDenied, so the response does not
+confirm the hash exists in another project. Fusing the two steps into a single join is rejected: it
+would put the content read in the same statement as the permission check, which is exactly the
+arrangement a cache hit can skip.
 
-It filters the requested hashes through `sheet_blob_ref` for `projectID`, and any hash that does
-not survive yields NotFound — NotFound rather than PermissionDenied, so the response does not
-confirm that a hash exists somewhere else. Only the surviving hashes reach the content getter.
-Every v1 sheet read routes through it:
+A test asserts nothing under `backend/api/v1/` calls a store content getter outside the gate.
+Runner and component call sites keep the unscoped getters.
 
-- `backend/api/v1/sheet_service.go:136,138` — `project.ResourceID`, already resolved and
-  workspace-checked at `:119-131`
-- `backend/api/v1/release_service.go:398` — where `validateAndSanitizeReleaseFiles` currently
-  discards the project outright
-- `backend/api/v1/rollout_service.go:1233`, `rollout_service_task.go:463` — the resolved project
+Three existing call patterns need reshaping to feed it. `validateAndSanitizeReleaseFiles`
+(`release_service.go:377-413`) fetches once per file inside its loop — a pre-existing N+1 that a
+per-file scope check would double. `rollout_service_task.go:214` fetches a loop-invariant hash once
+per target database, masked today only by the LRU. `plan_service.go:746` is already correct and
+worth copying: it collects across every spec and makes one call.
 
-`HasSheets` call sites pass a project directly: `release_service.go:144`,
-`revision_service.go:158` (`database.ProjectID`), `plan_service.go:746` (`plan.ProjectID` — the
-same value already used to validate the release at `:759`).
+### Project purge
 
-Runner and component call sites keep the unscoped content getters:
-`backend/runner/taskrun/*`, `backend/runner/plancheck/*`, `backend/component/review/evaluator.go:710`.
+The `project` foreign key makes `sheet_blob_ref` a dependent of `project`, and purge ends with
+`DELETE FROM project WHERE resource_id = ?` (`backend/store/project.go:826`) after clearing every
+other dependent table. Add `DELETE FROM sheet_blob_ref WHERE project = ?` after the `db` delete
+(`:704`) and before `project_webhook` (`:739`), matching the position established under
+[lock ordering](#transaction-lock-ordering). Without it, purging any project fails on the foreign
+key.
 
-Hold the line with a test asserting that nothing under `backend/api/v1/` calls any store sheet
-content getter directly except the gate helper. Six call sites today, so it is cheap.
+Blobs whose only ref belonged to the purged project are left with zero refs, consistent with today's
+behavior — nothing has ever deleted from `sheet_blob` — and the state a future GC would collect.
 
-### Batch shape
+### Database transfer
 
-The gate must cost a bounded number of round-trips regardless of how many sheets a request
-carries. A release with two hundred files must not produce two hundred queries — still less four
-hundred, which a naive check-then-fetch per file would give.
+No sheet references are carried when a database changes project. Change history follows the
+database; statement content stays with the project that authored it. The four code paths that move a
+database between projects therefore need no changes here.
+[`sheet-history-on-database-transfer.md`](sheet-history-on-database-transfer.md) records that
+decision and its requirements.
 
-`sheetsForProject` is therefore two queries, whatever the input size:
+## Alternatives considered
 
-1. **One ref query** returning the subset of requested hashes readable by this project:
+**Workspace scope.** Make sheets shared within a tenant: `sheet_blob_ref(workspace, sha256)`, the
+resource renamed to a bare `sheets/{sheet}` collection, and `CreateSheet` parentless with
+`bb.sheets.create` checked at workspace level. This is internally consistent and it is attractive on
+cost — databases cannot move between workspaces (`UpdateProject`'s mask has no `workspace` case), so
+the transfer question never arises; the ref table would reference `workspace` rather than `project`,
+so purge would not touch it; and the laundering problem would shrink to cross-workspace references,
+which cannot be created legitimately and should audit to zero.
 
-   ```sql
-   SELECT encode(sha256, 'hex')
-   FROM sheet_blob_ref
-   WHERE project = ?
-     AND sha256 IN (SELECT decode(unnest(CAST(? AS TEXT[])), 'hex'))
-   ```
+It fails R2 and R6. Parentless creation moves authoring governance to the workspace, so "this user
+may write change SQL for project A only" stops being expressible. Cross-project read inside a
+workspace stays open, which is a policy violation for regulated-separation and agency customers, and
+it leaves sheets inconsistent with `worksheet`, which already applies `PRIVATE` / `PROJECT_READ` /
+`PROJECT_WRITE` visibility to SQL text.
 
-   Anything requested but absent from the result is NotFound. This runs first, which is what
-   preserves the cache-ordering invariant above.
+It is also a breaking API change across four proto sites — the `Sheet` pattern
+(`proto/v1/v1/sheet_service.proto:92`), `GetSheetRequest.name` (`:83`), `Release_File.sheet`
+(`proto/v1/v1/release_service.proto:331`), `Revision.sheet`
+(`proto/v1/v1/revision_service.proto:183`) — plus the shape of `CreateSheet`. Storage is unaffected,
+since only the hash persists and the resource name is constructed on read, so this is a contract
+break rather than a data migration; it would still need the `breaking` label and a dual-accept
+deprecation window.
 
-2. **Cache lookups** for the surviving hashes, then **one content query** for the misses, using
-   the same `unnest` shape.
+The asymmetry decides it. Project scope costs no API change in either direction and can be relaxed
+later behind a stable contract. Workspace scope costs one breaking change to adopt and a second, in
+the opposite direction, to reverse.
 
-Note that fusing both into a single join would be tempting and is wrong: it would make the
-content read the same statement as the permission check, which is exactly the arrangement that
-lets a cache hit skip the check. Keeping them as two steps is deliberate.
+**Workspace scope keeping the project prefix.** Rejected outright. It would make `Sheet` the only
+resource in the API whose name prefix is a caller-chosen scope, and it aliases — the same sheet
+answering to `projects/A/sheets/X` and `projects/B/sheets/X`, with `name` echoing whichever was
+asked. That is the decorative prefix the audit named, preserved deliberately.
 
-Three existing call patterns need reshaping to feed it:
+**A `project` column on `sheet_blob`.** Fails R3. The same statement in two projects would need two
+rows, and the migration would have to split existing shared rows.
 
-- **`validateAndSanitizeReleaseFiles`** (`release_service.go:377-413`) calls `GetSheetFull` once
-  per file inside its loop. It already has all the files up front, so hoist a single collect pass
-  for every `f.Sheet`, one `sheetsForProject` call, then loop over the map. This path is O(n)
-  today, before this change — the fix is not new debt, it is a pre-existing N+1 that the scope
-  check would otherwise double.
-- **`rollout_service_task.go:214`** calls `getSheetContentBySha256(ctx, s, c.SheetSha256)` inside
-  a loop over target databases, but `c.SheetSha256` is loop-invariant — a spec targeting a
-  hundred databases fetches the same hash a hundred times. Hoist it above the loop. Only the
-  10-entry LRU keeps this from being a hundred queries today, which is a fragile reason for it to
-  be fast.
-- **`plan_service.go:746`** is already correct and worth copying: it collects `sheetSha256s`
-  across every spec and makes one `HasSheets` call.
+**Enforcement inside the store.** Attractive because a required parameter is compiler-checked at
+every call site, which is stronger than a convention. Rejected because the content cache is keyed by
+hash and returns before any query runs, so a predicate inside `getSheet` is skipped on a cache hit —
+and because the runners would be forced to supply a project purely to satisfy a signature, when they
+are executing already-authorized work rather than making an access decision.
 
-The write paths are already set-shaped and stay that way: `CreateSheets` uses array `unnest` for
-both inserts, the backfill is `INSERT ... SELECT`, and the transfer handler below is a single
-`INSERT ... SELECT` rather than a per-revision loop.
+## Rollout
 
-## Rollout safety
+Correctness rests on backfill completeness, which cannot be established by construction; a missed
+source is a silent NotFound (R4). Treat that as demonstrated risk rather than hypothesis — two
+drafts of this document got the source list wrong, first inventing two sources that do not exist,
+then naming the wrong column and nesting for `plan_check_run`.
 
-This is a read-path change to a shipped multi-tenant product whose correctness rests entirely
-on backfill completeness, and completeness cannot be established by construction. A missed
-source means sheets silently return NotFound in production with no signal.
+**Ship the gate in shadow mode.** It evaluates the scope check and logs a miss — project, hash, call
+site — but still returns content. Run one full release; flip to enforcing only once logs are clean.
 
-Treat that as a live risk rather than a hypothetical: the first draft of the source table above
-listed seven sources, two of which do not exist. The list is now verified, but the failure mode
-it illustrates is the one to design against.
-
-**Ship the gate in shadow mode.** It evaluates the ref check and logs a miss — project, hash,
-call site — but still returns the content. Run it for a full release. Flip to denying only once
-the log is clean.
-
-**Verify the backfill before that.** After the migration, for each of the five sources, compare
-the count of distinct `(project, sha256)` pairs derivable from it against the ref rows present,
-and count blobs with zero refs:
+**Verify the backfill first.** Blobs with zero refs should be a small, non-growing population:
 
 ```sql
 SELECT count(*) FROM sheet_blob b
 WHERE NOT EXISTS (SELECT 1 FROM sheet_blob_ref r WHERE r.sha256 = b.sha256);
 ```
 
-A non-zero result is expected — it is the orphan-draft population noted under the backfill — but
-it should be small and should not grow once the shadow period begins. A large number means a
-source was missed.
-
-## Database project transfer
-
-The one case where a hash legitimately needs to become readable under a second project.
-
-`revision` has no project column — it keys on `(instance, db_name)` and inherits its project
-through `db`. When `BatchUpdateDatabases` sets `project = ?` (`backend/store/database.go:403`),
-a database's revision history follows it, and `convertToRevision` then formats the sheet name
-with the *new* project (`backend/api/v1/revision_service.go:304`). Under a strict check those
-reads would start returning NotFound for history that was readable before the transfer.
-
-Revisions are the only case. `changelog` also keys on `(instance, db_name)`, but carries no
-sheet reference at all, so it moves without implicating any hash.
-
-Handle it in the transfer path: when a database changes project, insert ref rows for the
-destination project covering every hash in that database's revisions, inside the transaction
-that already locks the project (`backend/store/database.go:512`). One statement, not a loop over
-revisions, and it stays one statement for a batch transfer of many databases:
+**Review multi-project hashes before enforcing.** Each is either honest dedup or a laundered
+reference, and the data cannot distinguish them, so this is a review list rather than a filter:
 
 ```sql
-INSERT INTO sheet_blob_ref (project, sha256)
-SELECT ?, decode(r.payload->>'sheetSha256', 'hex')
-FROM revision r
-WHERE (r.instance, r.db_name) IN (...)
-  AND r.payload->>'sheetSha256' IS NOT NULL
-  AND EXISTS (
-    SELECT 1 FROM sheet_blob b
-    WHERE b.sha256 = decode(r.payload->>'sheetSha256', 'hex')
-  )
-ON CONFLICT DO NOTHING
+SELECT encode(sha256, 'hex'), count(DISTINCT project), array_agg(DISTINCT project)
+FROM sheet_blob_ref GROUP BY sha256 HAVING count(DISTINCT project) > 1;
 ```
 
-The `EXISTS` guard is the same one the backfill uses, and it matters more here. A revision naming
-a hash with no blob would otherwise violate the new foreign key and abort the whole
-`BatchUpdateDatabases` call — turning a scoping change into a regression on database transfer,
-a path that reads no sheet blobs today and has no reason to start failing.
-
-Ref rows for the source project stay — the content was genuinely authored there.
-
-This keeps the resource name honest rather than weakening the predicate to match the looser
-behavior.
+A long list means cross-project references are already widespread and the plan needs revisiting,
+since the backfill would make them permanent. Capture it at a known-good point: this design is
+public, including the rule that turns a reference into an ownership edge.
 
 ## Transaction lock ordering
 
-Two new multi-table write paths fall under the canonical ordering in
-`backend/store/README.md#transaction-row-lock-ordering`, which `AGENTS.md` requires be settled
-before the code is written.
-
-### Position in the canonical sibling order
-
-The README requires a new project-owned branch to establish its position in the canonical order
-before implementation, and to update that list, `DeleteProject`, and `DeleteInstance` together.
-`sheet_blob_ref` is a direct child of `project` with no descendants and no dependents, and every
-table that can reference a hash (`plan`, `task`, `release`, `plan_check_run`, `revision`) sits
-earlier in the list. Place it immediately after `db`:
+`sheet_blob_ref` is a project-owned branch and takes a position in the canonical sibling order in
+`backend/store/README.md`, updating that list, `DeleteProject`, and `DeleteInstance` together. It is
+a direct child of `project` with no descendants, and every table that can reference a hash sits
+earlier, so it belongs immediately after `db` and before `project_webhook` — the same position as
+the purge delete.
 
 ```text
 ... -> changelog -> sync_history -> revision -> db_schema -> db
 -> sheet_blob_ref -> project_webhook -> service_account -> ...
 ```
 
-That is also where the purge delete belongs — between the `db` delete
-(`backend/store/project.go:704`) and `project_webhook` (`:739`) — so the purge sequence and the
-canonical list stay consistent.
+`CreateSheets` becomes a transaction spanning `sheet_blob` and `sheet_blob_ref`. Insert the blob
+first: the ref's foreign key requires it, so the order is forced. Both are `ON CONFLICT DO NOTHING`
+— new-row-only inserts, not upserts that can update an existing row, so the README's rule 4 upsert
+clause does not apply.
 
-### Lifecycle policy
-
-`sheet_blob_ref` is purge-managed data, so the README requires its writers to state whether they
-need an **active** project or merely an **existing** one, and to serialize that against project
-deletion.
-
-**`CreateSheets` requires an active project.** A sheet ref is a new resource; there is no
-deleted-project continuation case for it. The API create paths check the project before calling
-the store, but that check is not serialized with purge — a concurrent purge between the check and
-the insert would surface as a raw foreign-key violation rather than a controlled NotFound. So
-`CreateSheets` takes the same transaction-scoped purge fence before any row lock that database
-creation, batch database updates, and task-run creation already take.
-
-The transfer path needs nothing extra here: `BatchUpdateDatabases` already locks every involved
-project `FOR UPDATE` (`backend/store/database.go:509-517`) and fails NotFound on a missing one.
-
-### Ordering of the two paths
-
-- **`CreateSheets`** spans `sheet_blob` and `sheet_blob_ref`. Insert the blob first, then the
-  ref: the ref's foreign key requires the blob to exist, so the order is forced. Both are
-  `ON CONFLICT DO NOTHING` — new-row-only inserts, not upserts that can update an existing row,
-  so the README's rule 4 upsert clause does not apply to them. The foreign-key checks on
-  `project` and `sheet_blob` do count as locks and are covered by the purge fence above.
-- **The transfer path** inserts refs inside the existing `BatchUpdateDatabases` transaction,
-  which has already taken `FOR UPDATE` on every involved project. Note this is *not* an instance
-  of the child-to-parent rule — that rule governs locking **existing** rows, and these refs are
-  new rows with nothing to lock beforehand. The insert is safe here because the transaction
-  already holds a stronger lock on the parent than the foreign-key check needs, not because
-  parent-then-child is the required order. It is not; an earlier draft of this doc claimed
-  otherwise.
+As a writer of purge-managed data, `CreateSheets` must declare a lifecycle policy. **It requires an
+active project**: a sheet ref is a new resource with no deleted-project continuation case. The API
+create paths check the project before calling the store, but that check is not serialized with
+purge, so a concurrent purge would surface as a raw foreign-key violation rather than a controlled
+NotFound. `CreateSheets` therefore takes the same transaction-scoped purge fence that database
+creation and task-run creation already take; `withDatabasePurgeFence`
+(`backend/store/database.go:798-820`) is the pattern to mirror.
 
 Both need the deterministic real-PostgreSQL regression tests that section mandates, asserting
-terminal outcomes in both lock-acquisition directions rather than merely the absence of
-SQLSTATE `40P01`, and covering the create-versus-purge race named above.
+terminal outcomes in both lock-acquisition directions rather than merely the absence of SQLSTATE
+`40P01`.
 
-## Independent fixes, no schema needed
+## Independent fixes
 
-These are worth landing separately and first — none needs a migration.
+No schema needed; worth landing separately and first.
 
 1. **The T6 hash echo.** `backend/api/v1/revision_service.go:203` takes `projectID` from the
    attacker-supplied `revision.File` and uses it as a store key without comparing it to
    `database.ProjectID`. `FindReleaseMessage` has no `Workspace` field
    (`backend/store/release.go:30-37`), so this reaches any project in any workspace, and `:223`
-   echoes the real hash. Add the comparison; drop the hash from the error string. The same
-   missing comparison appears for `revision.TaskRun` at `:167-186`.
-2. **Delete the two stale comments** at `release_service.go:331` and `:405`
-   (`// Sheets are now project-agnostic, no need to check projectID`). They are now false and
-   will mislead the next reader into repeating the mistake.
-3. **Add audit annotations** to `proto/v1/v1/sheet_service.proto`. It declares none, while 20
-   other v1 services do — so sheet reads and enumeration are currently unlogged.
-4. **Drop `bb.sheets.update`.** Granted to four roles in `backend/store/predefined_roles.go`,
-   declared by no RPC; dead since sheets became immutable.
-5. **Comment the GC hazard on `sheet_blob`.** Nothing deletes from it today — not the cleaner,
-   not project purge, and there is no `DeleteSheet` RPC. The only foreign key that ever pointed
-   at it (`task_run.sheet_sha256`, migration 3.14) was dropped in `7192406c5f`, so every
-   surviving reference now lives in JSONB and is invisible to referential integrity. A future GC
-   written the obvious way — "delete blobs no FK points at" — would empty the table.
-   `sheet_blob_ref` makes a correct GC possible later, but that is out of scope here.
+   echoes the real hash. Add the comparison, drop the hash from the error. The same missing
+   comparison appears for `revision.TaskRun` at `:167-186`. This is the cheapest way to obtain a hash
+   today and should go first.
+2. **Delete the stale comments** at `release_service.go:331` and `:405`
+   (`// Sheets are now project-agnostic, no need to check projectID`) — the original wrong assumption,
+   sitting where it will talk the next reader into repeating it.
+3. **Add audit annotations** to `proto/v1/v1/sheet_service.proto`, which declares none while 20 other
+   v1 services do, leaving sheet reads and enumeration unlogged.
+4. **Drop `bb.sheets.update`** — granted to four roles, declared by no RPC, dead since sheets became
+   immutable.
+5. **Comment the GC hazard on `sheet_blob`.** Nothing deletes from it; the only foreign key that ever
+   pointed at it (`task_run.sheet_sha256`, migration 3.14) was dropped in `7192406c5f`, so every
+   surviving reference lives in JSONB and is invisible to referential integrity. A GC written the
+   obvious way — delete blobs no FK points at — would empty the table. `sheet_blob_ref` makes a
+   correct GC possible later.
 
 ## Tests
 
-- **Cross-project read** — seed a blob in project A, request it under project B, expect
-  NotFound. This is the regression test for the whole finding. Run it with A and B in the same
-  workspace *and* in different workspaces; the second is the tenant-isolation case.
-- **Cache ordering** — request a blob under its owning project to warm the cache, then request
-  the same hash under a foreign project and assert NotFound. This is the test that fails if
-  enforcement ever migrates back into `getSheet` behind the cache read.
-- **Gate coverage** — assert nothing under `backend/api/v1/` calls a store sheet content getter
-  outside the gate helper.
-- **Query count** — create a release with many files and assert the gate issues a bounded number
-  of queries, not one per file. A count assertion is the only thing that actually holds the batch
-  shape; a correctness test passes just as happily against an N+1 implementation.
-- **Backfill** — build a metadata DB exercising each of the five reference sources, run the
-  migration, assert every referenced hash resolves under its project and no unreferenced hash
-  does.
-- **Project purge** — purge a project that owns sheet refs and assert it succeeds. This is the
-  direct regression test for the new foreign key.
-- **Transfer** — create a revision under project A, move the database to project B, assert the
-  statement is still readable under B. Add a variant where a revision names a hash with no blob
-  and assert the transfer still succeeds, covering the `EXISTS` guard.
-- **Create versus purge** — the deterministic race required by the lifecycle policy: a
-  `CreateSheets` concurrent with a purge of its project must end in a controlled NotFound, not a
-  foreign-key error, in both lock-acquisition directions.
-- **Multi-project hashes** — seed a plan in project B referencing a hash created in project A
-  (the pre-existing unscoped path), run the backfill, and assert the audit query reports it.
-  The point is that the row is *detected*, not that it is silently blessed.
+- **Cross-tenant read** — seed a blob in workspace W1, request it under a project in W2, expect
+  NotFound. The regression test for the severe half.
+- **Cross-project read** — same workspace, different project, expect NotFound. The regression test
+  for R6.
+- **Cache ordering** — warm the cache under the owning project, then request the same hash under a
+  foreign project and assert NotFound. Fails if enforcement ever migrates into `getSheet` behind the
+  cache read.
+- **Gate confinement** — nothing under `backend/api/v1/` calls a store content getter outside the
+  gate.
+- **Query count** — a release with many files must issue a bounded number of queries. A correctness
+  test passes just as happily against an N+1.
+- **Backfill** — exercise all five sources; every referenced hash resolves under its project and no
+  unreferenced hash does.
+- **Multi-project hashes** — seed a plan in project B referencing a hash created in project A, run
+  the backfill, assert the audit query reports it. The point is that it is detected, not blessed.
+- **Project purge** — purge a project holding sheet refs and assert it succeeds. Direct regression
+  test for the new foreign key.
+- **Create versus purge** — `CreateSheets` concurrent with a purge of its project ends in a
+  controlled NotFound, not a foreign-key error, in both lock-acquisition directions.
 - **`HasSheets`** no longer answers for a foreign project's hash.
-- **`TestCollision_Sheet`** in `backend/tests/`, per the composite-PK convention in `AGENTS.md`.
-  Note that the shared `setupCollidingProjects` fixture and `assertProjectUnchanged` helper do
-  not currently cover sheets — extend them first rather than writing a table-specific variant.
-- **Lock ordering** — the deterministic real-PostgreSQL tests required by the section above, for
-  `CreateSheets` and for the transfer path.
+- **`TestCollision_Sheet`** per the composite-PK convention in `AGENTS.md`. The shared
+  `setupCollidingProjects` fixture and `assertProjectUnchanged` helper do not currently cover sheets;
+  extend them rather than writing a table-specific variant.
 
 ## Order
 
-1. The five no-schema fixes above — T6 first, since it is the cheapest way to obtain a hash.
-2. Migration, backfill, purge delete, backfill verification query.
-3. Run the multi-project audit query and review its output. This is a gate, not a report: a long
-   list means cross-project references are already widespread and the plan needs revisiting
-   before enforcement, since the backfill would otherwise make them permanent.
-4. Store API split, gate helper, call sites, transfer handling, tests — gate shipping in shadow
-   mode.
-5. Flip the gate to denying, one release later, once the shadow log is clean.
+1. The five independent fixes, T6 first.
+2. Migration and backfill; run both verification queries and review the multi-project list.
+3. Store API, gate, call sites, purge delete, tests — gate shipping in shadow mode.
+4. Flip to enforcing one release later, once shadow logs are clean.

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -219,6 +219,13 @@ Three constraints together close it:
   single release has not identified anything, and `EXISTS` would accept whichever duplicate happens
   to predate the revision and carry the hash. This is the composite-PK identification rule in
   `AGENTS.md` applied to an alternate key that turns out not to be one.
+
+  **A release is resolved in two places, and both need the same test.** Directly, from the
+  revision's own `release`; and indirectly, when a corroborating task's `payload.release` names one.
+  The indirect path is easy to leave on a bare `EXISTS` — it sits nested inside the task branch and
+  reads like a lookup rather than a corroboration — but a duplicate release carrying the hash would
+  corroborate a task whose intended release did not, which is the same over-grant by a longer route.
+  Exactly-one, age, and hash apply wherever `(project, release_id)` is resolved.
 - **Temporal.** Require the corroborating row's `created_at` to be no later than the revision's.
   A revision is written after the task run it records completes, so a genuine reference always
   predates it, whereas a row that reused the ID after a purge is necessarily newer — the purge, the
@@ -518,12 +525,19 @@ WHERE r.payload->>'sheetSha256' IS NOT NULL
       AND (
         -- task.payload.source is a oneof: a sheet hash, or a release naming one
         t.payload->>'sheetSha256' = r.payload->>'sheetSha256'
-        OR EXISTS (
-          SELECT 1 FROM release rel2
-          CROSS JOIN LATERAL jsonb_array_elements(COALESCE(rel2.payload->'files', '[]'::jsonb)) AS f2
-          WHERE rel2.project      = (regexp_match(t.payload->>'release', 'projects/([^/]+)/'))[1]
-            AND rel2.release_id   = (regexp_match(t.payload->>'release', 'releases/([^/]+)'))[1]
-            AND f2->>'sheetSha256' = r.payload->>'sheetSha256'
+        OR (
+          -- same exactly-one / age / hash test as the direct release branch
+          (SELECT count(*) FROM release rel2
+            WHERE rel2.project    = (regexp_match(t.payload->>'release', 'projects/([^/]+)/'))[1]
+              AND rel2.release_id = (regexp_match(t.payload->>'release', 'releases/([^/]+)'))[1]) = 1
+          AND EXISTS (
+            SELECT 1 FROM release rel2
+            CROSS JOIN LATERAL jsonb_array_elements(COALESCE(rel2.payload->'files', '[]'::jsonb)) AS f2
+            WHERE rel2.project      = (regexp_match(t.payload->>'release', 'projects/([^/]+)/'))[1]
+              AND rel2.release_id   = (regexp_match(t.payload->>'release', 'releases/([^/]+)'))[1]
+              AND rel2.created_at  <= r.created_at
+              AND f2->>'sheetSha256' = r.payload->>'sheetSha256'
+          )
         )
       )
   );

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -201,10 +201,27 @@ hard-deletes it along with `plan`, `task` and `plan_check_run`
 workspace-instance database is reassigned to the default project and keeps its revisions, whose
 `release` and `taskRun` strings still name the deleted project.
 
-Residual risk: a reused project ID whose new releases happen to collide with the old release or task
-IDs would still corroborate. Release IDs are deterministic (`train` plus iteration) and task IDs
-restart per project, so this is possible rather than impossible. It is not detectable from the data,
-so it goes on the review list rather than being silently trusted.
+**Match the whole reference, and require it to predate the revision.** Row identity alone is not
+enough, because every ID in these names restarts per project. `task_run` is
+`PRIMARY KEY (project, id)` and `task` is `(project, id)`, so a reused project ID whose first
+rollout allocates low IDs reproduces exactly the IDs an old revision names — and the first rollout
+in a fresh project is precisely when those low IDs get allocated. Checking only the `task` row from
+a `taskRun` name is the weakest version of this and would pass routinely.
+
+Two constraints together close it:
+
+- **Full chain.** For `taskRun`, match the `task_run` row on `(project, id)` *and* require its
+  `task_id` to equal the task ID in the name. For `release`, match `(project, release_id)`.
+- **Temporal.** Require the corroborating row's `created_at` to be no later than the revision's.
+  A revision is written after the task run it records completes, so a genuine reference always
+  predates it, whereas a row that reused the ID after a purge is necessarily newer — the purge, the
+  new project, and its rollout all happen after the old revision was written. `task_run`, `release`
+  and `revision` all carry `created_at`, and `DEFAULT now()` means it cannot be backdated.
+
+The temporal test is what actually defeats ID reuse; the full chain narrows the window it has to
+cover. Residual risk after both is limited to clock anomalies rather than ordinary ID collision, and
+uncorroborated rows fail closed to no ref, so the failure mode is an unreadable statement rather than
+a wrong grant.
 
 Their content then becomes unreadable, which is the intended outcome: the authoring project is gone,
 so there is nobody left to ask. The immutable `release`/`taskRun` string still identifies it, so the
@@ -425,13 +442,16 @@ WHERE r.payload->>'sheetSha256' IS NOT NULL
   AND NOT EXISTS (
     -- the corroboration test from the backfill, repeated verbatim
     SELECT 1 FROM release rel
-    WHERE rel.project = (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1]
+    WHERE rel.project    = (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1]
       AND rel.release_id = (regexp_match(r.payload->>'release', 'releases/([^/]+)'))[1]
+      AND rel.created_at <= r.created_at
   )
   AND NOT EXISTS (
-    SELECT 1 FROM task t
-    WHERE t.project = (regexp_match(r.payload->>'taskRun', 'projects/([^/]+)/'))[1]
-      AND t.id = (regexp_match(r.payload->>'taskRun', 'tasks/(\d+)/'))[1]::int
+    SELECT 1 FROM task_run tr
+    WHERE tr.project    = (regexp_match(r.payload->>'taskRun', 'projects/([^/]+)/'))[1]
+      AND tr.id         = (regexp_match(r.payload->>'taskRun', 'taskRuns/(\d+)$'))[1]::bigint
+      AND tr.task_id    = (regexp_match(r.payload->>'taskRun', 'tasks/(\d+)/'))[1]::int
+      AND tr.created_at <= r.created_at
   );
 ```
 

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -127,10 +127,28 @@ inside its message (not always top-level). `protojson` camelCases keys.
 | `task` | `payload` | `sheetSha256` | `task.project` |
 | `release` | `payload` | `files[].sheetSha256` | `release.project` |
 | `plan_check_run` | `result` | `results[].sheetSha256` | `plan_check_run.project` |
-| `revision` | `payload` | `sheetSha256` | `db(instance, db_name)` → `db.project` |
+| `revision` | `payload` | `sheetSha256` | `release` → else `taskRun` → else `db.project` (see below) |
 
 `plan_check_run` punishes assumption: the column is `result`, not `payload`, and the hash sits on
 `PlanCheckRunResult.Result` inside the repeated `results` array.
+
+**`revision` must not route through `db.project`.** The first four sources are project-scoped rows
+that never move, so their `project` column is the authoring project. `revision` is not: it has no
+project column and inherits one through `db.project`, which is the database's *current* project. A
+database transferred before this migration would backfill its revisions to the destination, granting
+that project's members access to SQL the source authored — precisely the grant
+[the transfer decision](sheet-history-on-database-transfer.md) refuses, and invisible to shadow mode
+because the ref row exists.
+
+Derive the authoring project from the revision's own provenance instead. `RevisionPayload` carries
+`release` (`projects/{project}/releases/{release}`) and `task_run`
+(`projects/{project}/plans/…/taskRuns/{taskRun}`), both with the project embedded in the resource
+name. Parse it out, preferring `release` and falling back to `taskRun`; `backend/store/changelog.go:163-168`
+already does exactly this with `regexp_match(payload->>'taskRun', 'projects/([^/]+)/')`.
+
+Both fields are optional, so a revision created with neither has no recoverable provenance. For
+those, fall back to `db.project` — correct for every database that never moved, which is the common
+case — and add them to the review list in [Rollout](#rollout) rather than trusting them silently.
 
 Two tables that look like sources are not. `ChangelogPayload` carries only `task_run` and
 `git_commit`, and the v1 `Changelog` message exposes no statement or sheet field. `issue_comment`
@@ -322,6 +340,18 @@ FROM sheet_blob_ref GROUP BY sha256 HAVING count(DISTINCT project) > 1;
 A long list means cross-project references are already widespread and the plan needs revisiting,
 since the backfill would make them permanent. Capture it at a known-good point: this design is
 public, including the rule that turns a reference into an ownership edge.
+
+**Review provenance-less revisions too.** These are the rows that fell back to `db.project`, so a
+database transferred before the migration would have granted its destination project a source
+project's SQL:
+
+```sql
+SELECT r.instance, r.db_name, d.project
+FROM revision r JOIN db d ON d.instance = r.instance AND d.name = r.db_name
+WHERE r.payload->>'sheetSha256' IS NOT NULL
+  AND COALESCE(r.payload->>'release', '') = ''
+  AND COALESCE(r.payload->>'taskRun', '') = '';
+```
 
 ## Transaction lock ordering
 

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -208,7 +208,7 @@ rollout allocates low IDs reproduces exactly the IDs an old revision names — a
 in a fresh project is precisely when those low IDs get allocated. Checking only the `task` row from
 a `taskRun` name is the weakest version of this and would pass routinely.
 
-Two constraints together close it:
+Three constraints together close it:
 
 - **Full chain.** For `taskRun`, match the `task_run` row on `(project, id)` *and* require its
   `task_id` to equal the task ID in the name. For `release`, match `(project, release_id)`.
@@ -217,11 +217,32 @@ Two constraints together close it:
   predates it, whereas a row that reused the ID after a purge is necessarily newer — the purge, the
   new project, and its rollout all happen after the old revision was written. `task_run`, `release`
   and `revision` all carry `created_at`, and `DEFAULT now()` means it cannot be backdated.
+- **Hash match.** Require the corroborating row to actually reference *this* revision's
+  `sheetSha256`. Identity and age establish that the row is the one the string names; only this
+  establishes that the row has anything to do with the sheet being attributed to it.
 
-The temporal test is what actually defeats ID reuse; the full chain narrows the window it has to
-cover. Residual risk after both is limited to clock anomalies rather than ordinary ID collision, and
-uncorroborated rows fail closed to no ref, so the failure mode is an unreadable statement rather than
-a wrong grant.
+**The hash match is what makes provenance mean something.** Without it, corroboration proves a task
+run exists and is old enough, and nothing more. `createRevisions` validates a `taskRun` thoroughly —
+project, plan, environment and task all have to line up, and `:173` even requires the task run to
+belong to the database's own project — but it never compares the task's sheet to `revision.Sheet`
+(`backend/api/v1/revision_service.go:167-192`), while `HasSheets` at `:158` is still deployment-wide.
+So a revision in project B can name a genuine B task run alongside an unrelated project A hash, and
+a corroboration that only checks identity would insert `(B, shaA)` — a laundered grant, permanent,
+and invisible to shadow mode because the ref exists.
+
+Matching the hash costs one more join and closes it. `task.payload` is a oneof
+(`proto/store/store/task.proto:27-36`), so the task branch has two shapes: `sheetSha256` equal to
+the revision's hash, or `release` naming a release whose `payload.files[]` contains it. The release
+branch is the single-hop form of the same test.
+
+Apply it to the release branch too, even though `createRevisions` already enforces
+`fileSheet == revision.Sheet` there (`:222`). Uniformity is worth more than the saved join: it
+removes any need to reason about which creation-time validation happened to run, on a path where T6
+shows those validations can be steered.
+
+The temporal test defeats ID reuse, the full chain narrows the window it must cover, and the hash
+match defeats laundering. Residual risk after all three is limited to clock anomalies, and
+uncorroborated rows fail closed to no ref — an unreadable statement rather than a wrong grant.
 
 Their content then becomes unreadable, which is the intended outcome: the authoring project is gone,
 so there is nobody left to ask. The immutable `release`/`taskRun` string still identifies it, so the
@@ -440,18 +461,33 @@ SELECT r.instance, r.db_name,
 FROM revision r
 WHERE r.payload->>'sheetSha256' IS NOT NULL
   AND NOT EXISTS (
-    -- the corroboration test from the backfill, repeated verbatim
+    -- the corroboration test from the backfill, repeated verbatim:
+    -- identity, age, and the hash the row actually references
     SELECT 1 FROM release rel
-    WHERE rel.project    = (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1]
-      AND rel.release_id = (regexp_match(r.payload->>'release', 'releases/([^/]+)'))[1]
-      AND rel.created_at <= r.created_at
+    CROSS JOIN LATERAL jsonb_array_elements(COALESCE(rel.payload->'files', '[]'::jsonb)) AS f
+    WHERE rel.project      = (regexp_match(r.payload->>'release', 'projects/([^/]+)/'))[1]
+      AND rel.release_id   = (regexp_match(r.payload->>'release', 'releases/([^/]+)'))[1]
+      AND rel.created_at  <= r.created_at
+      AND f->>'sheetSha256' = r.payload->>'sheetSha256'
   )
   AND NOT EXISTS (
     SELECT 1 FROM task_run tr
-    WHERE tr.project    = (regexp_match(r.payload->>'taskRun', 'projects/([^/]+)/'))[1]
-      AND tr.id         = (regexp_match(r.payload->>'taskRun', 'taskRuns/(\d+)$'))[1]::bigint
-      AND tr.task_id    = (regexp_match(r.payload->>'taskRun', 'tasks/(\d+)/'))[1]::int
+    JOIN task t ON t.project = tr.project AND t.id = tr.task_id
+    WHERE tr.project     = (regexp_match(r.payload->>'taskRun', 'projects/([^/]+)/'))[1]
+      AND tr.id          = (regexp_match(r.payload->>'taskRun', 'taskRuns/(\d+)$'))[1]::bigint
+      AND tr.task_id     = (regexp_match(r.payload->>'taskRun', 'tasks/(\d+)/'))[1]::int
       AND tr.created_at <= r.created_at
+      AND (
+        -- task.payload.source is a oneof: a sheet hash, or a release naming one
+        t.payload->>'sheetSha256' = r.payload->>'sheetSha256'
+        OR EXISTS (
+          SELECT 1 FROM release rel2
+          CROSS JOIN LATERAL jsonb_array_elements(COALESCE(rel2.payload->'files', '[]'::jsonb)) AS f2
+          WHERE rel2.project      = (regexp_match(t.payload->>'release', 'projects/([^/]+)/'))[1]
+            AND rel2.release_id   = (regexp_match(t.payload->>'release', 'releases/([^/]+)'))[1]
+            AND f2->>'sheetSha256' = r.payload->>'sheetSha256'
+        )
+      )
   );
 ```
 

--- a/docs/design/sheet-blob-scoping.md
+++ b/docs/design/sheet-blob-scoping.md
@@ -245,8 +245,9 @@ match defeats laundering. Residual risk after all three is limited to clock anom
 uncorroborated rows fail closed to no ref — an unreadable statement rather than a wrong grant.
 
 Their content then becomes unreadable, which is the intended outcome: the authoring project is gone,
-so there is nobody left to ask. The immutable `release`/`taskRun` string still identifies it, so the
-withheld-statement response can name it as purged — see
+so there is nobody left to ask. The withheld-statement response reports the owner as unknown rather
+than echoing the parsed ID — an ID that failed corroboration cannot be verified against any
+workspace, so it is not safe to surface. See
 [naming the owner](sheet-history-on-database-transfer.md#naming-the-owner).
 
 A revision with no provenance at all is treated the same way: no ref, surfaced as a shadow miss, and

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -227,8 +227,11 @@ corruption outweighs the modelling improvement.
   — and distinguishing a live owning project from a purged one.
 - A UI affordance for the withheld state that names the owning project rather than rendering an
   error, and says the project no longer exists when that is the case.
-- No changes to `UpdateDatabase`, `BatchUpdateDatabases`, `updateInstanceLifecycle`, or
-  `DeleteProject`.
+- No *carry* logic in `UpdateDatabase`, `BatchUpdateDatabases`, `updateInstanceLifecycle`, or
+  `DeleteProject` — nothing moves refs between projects. `DeleteProject` still needs its
+  `DELETE FROM sheet_blob_ref WHERE project = ?` from the scoping doc: `sheet_blob_ref(project)` has
+  a plain foreign key with no `ON DELETE CASCADE`, so purging a project that owns refs fails without
+  it. "No changes" here means no transfer behavior, not no purge cleanup.
 
 Tests:
 

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -93,6 +93,8 @@ Change history follows the database; statement content does not.
 - When a revision's sheet is not readable by the current project, the statement is withheld and the
   response says so explicitly — naming the owning project where that can be verified — rather than
   returning NotFound for the sheet.
+- The sheet *name* is formatted from that same resolved owner, not from the database's current
+  project. A name is emitted only when it is true.
 - No sheet references are carried between projects. A database transfer grants no new read access,
   and the four reassignment paths above need no changes.
 
@@ -223,8 +225,13 @@ corruption outweighs the modelling improvement.
 ## Implementation
 
 - A field on the revision response carrying the withheld-content reason and the owning project,
-  populated by the resolution order above — provenance first, `sheet_blob_ref` second, unknown last
-  — and distinguishing a live owning project from a purged one.
+  populated by the resolution order above — provenance first, `sheet_blob_ref` second, unknown last.
+- `convertToRevision` formats `Revision.sheet` from the resolved owner rather than from
+  `database.ProjectID` (`backend/api/v1/revision_service.go:304`), and emits no sheet name when the
+  owner does not resolve. Leaving it built from the current project would keep exactly the false
+  resource name R7 exists to eliminate — a response asserting that project A owns the statement while
+  handing the client `projects/B/sheets/{sha}` to follow, which then 404s. The owner is already
+  computed for the withheld-content field, so this costs nothing extra.
 - A UI affordance for the withheld state that names the owning project rather than rendering an
   error, and says the project no longer exists when that is the case.
 - No *carry* logic in `UpdateDatabase`, `BatchUpdateDatabases`, `updateInstanceLifecycle`, or
@@ -254,15 +261,16 @@ Tests:
   is a regression test rather than a contrived one.
 - Ambiguity: two projects in the caller's own workspace holding refs for one hash resolves to
   unknown, not to whichever row comes back first.
+- Sheet name: after a transfer, `Revision.sheet` names the resolved owner and resolves to that
+  project's readable sheet for a caller who holds rights there; when the owner is unknown, no sheet
+  name is emitted rather than one pointing at the current project.
 
 ## Open items
 
-**Sheet name attribution.** `convertToRevision` formats the sheet name with the database's current
-project, which is incorrect after a transfer: it names the destination as owner of a sheet the source
-authored. The withheld-content response resolves this through provenance, but the `name` field itself
-is still built from `db.project` and stays wrong. Fixing it means formatting the name from the same
-provenance chain — which works for revisions carrying `release` or `taskRun` and leaves the rest
-without a correct name, so it is a partial fix rather than a clean one.
+**Revisions with no resolvable owner have no sheet name.** Where the owner resolves, the name is
+correct and unchanged for every database that never moved. Where it does not, the response carries
+no sheet name at all — a behavior change for clients that assume the field is always populated, and
+the residual cost of refusing to emit a name that is not true.
 
 **Workspace-level roles have no escape hatch.** The gate checks the ref table for the named project,
 so workspace admins and DBAs are refused as well, despite holding `bb.sheets.get` broadly. Whether

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -20,12 +20,23 @@ Four code paths move a database between projects, only one of which is a user-fa
 |---|---|---|
 | `UpdateDatabase` | `backend/store/database.go:332-380` | one database |
 | `BatchUpdateDatabases` | `backend/store/database.go:397-560` | a batch |
-| `updateInstanceLifecycle` | `backend/store/instance.go:438-455` | every database of an instance, on project-instance archive |
+| `updateInstanceLifecycle` | `backend/store/instance.go:373-455` | every database of a **workspace** instance, on archive |
 | `DeleteProject` | `backend/store/project.go:722-729` | workspace-instance databases, reassigned to the default project |
 
-The last is easy to miss: purge does not delete workspace-instance databases, it reassigns them to
-the default project, and the `revision` delete at `:702` covers only project instances — so those
-revisions survive a purge with their hashes intact.
+Both instance-related paths concern **workspace** instances specifically, and for the same reason:
+those instances are shared infrastructure, so their databases cannot simply be deleted along with a
+project and must be reassigned somewhere.
+
+`updateInstanceLifecycle` transfers databases only when archiving a workspace instance —
+`MoveDatabasesToProjectID` is documented as "only valid when archiving a resource-scoped workspace
+instance" (`backend/store/instance.go:44-46`), and `:434` rejects the project-instance case outright
+with *cannot transfer databases while archiving project instance*. It also requires `Deleted` to be
+set (`:288`), so it is an archive path rather than an ordinary update.
+
+`DeleteProject` is the same shape and the one most easily missed: purge does not delete
+workspace-instance databases, it reassigns them to the default project, and the `revision` delete at
+`:702` covers only project instances — so those revisions survive a purge with their hashes intact.
+Project-instance databases are deleted with their instance in both paths and raise no question.
 
 ## Requirements
 
@@ -250,6 +261,11 @@ Tests:
   the response reports the owner as unknown and names no project.
   This is the case most likely to regress — it is not a user-facing transfer, and it is the one
   where `sheet_blob_ref` has already been deleted, so it exercises the provenance path specifically.
+- Instance archive: put a database on a **workspace** instance in project A, create a revision, then
+  archive the instance with `MoveDatabasesToProjectID` set to project B, and assert the revision list
+  is complete under B while the statement is withheld with A named. Archiving a *project* instance is
+  the wrong path — `backend/store/instance.go:434` rejects it — so a test written that way would pass
+  vacuously without exercising any transfer.
 - A revision carrying neither `release` nor `taskRun` falls through to `sheet_blob_ref`, and to
   unknown when that is empty too.
 - Cross-tenant leak guard, both paths: (a) seed identical SQL in two workspaces so one blob carries

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -91,8 +91,8 @@ Change history follows the database; statement content does not.
   a previous project. Versions, timestamps, authors, status, schema snapshots, and the sheet *name*
   are all present.
 - When a revision's sheet is not readable by the current project, the statement is withheld and the
-  response says so explicitly, naming the owning project, rather than returning NotFound for the
-  sheet.
+  response says so explicitly — naming the owning project where that can be verified — rather than
+  returning NotFound for the sheet.
 - No sheet references are carried between projects. A database transfer grants no new read access,
   and the four reassignment paths above need no changes.
 
@@ -112,12 +112,39 @@ The owning project is derivable without new storage, from the revision's own pro
 resource name; `backend/store/changelog.go:163-168` already parses a project out of a stored
 `taskRun` this way. Resolution order:
 
-1. The revision's `release`, else its `taskRun` — the authoring project, and correct even after the
-   database has moved or the project has been purged, because the string is immutable.
+1. The revision's `release`, else its `taskRun` — **verified against the caller's workspace before
+   it is echoed**, per below. Correct even after the database has moved, because the string is
+   immutable.
 2. `sheet_blob_ref` — which projects currently hold a ref for that hash, **joined through `project`
    and constrained to the caller's workspace**, and only when that leaves exactly one candidate.
    Useful when the revision carries no provenance, both fields being optional.
 3. Neither, or more than one candidate — report that the authoring project is unknown.
+
+**Provenance is a hint, not an assertion, and must be verified before it is echoed.** Both fields
+are stored verbatim from the caller: `convertRevision` writes `Release: revision.Release` and
+`TaskRun: revision.TaskRun` straight through (`backend/api/v1/revision_service.go:352-364`). Until
+the T6 fix lands, `createRevisions` resolves `revision.Release` with `GetRelease` and no workspace or
+database-project comparison (`:207-223`), so revisions already in the database can carry provenance
+naming a project in another tenant. Echoing the parsed string unchecked would leak a foreign
+workspace's project name — the same disclosure step 2 is guarded against, arrived at by a different
+route.
+
+So resolve the parsed project and branch on what it turns out to be:
+
+| Parsed project | Response |
+|---|---|
+| Exists, in the caller's workspace | Name it |
+| Exists, in a different workspace | Unknown — do not echo the string |
+| Does not exist | Authoring project no longer exists — say so **without naming it**, since its workspace can no longer be verified |
+
+The third row still delivers what the user needs: the statement is permanently unavailable and there
+is nobody to ask. Withholding the name costs a little diagnostic value and removes an unverifiable
+string from the response.
+
+This applies to *naming*, not to the backfill's use of the same fields. Granting a ref to the project
+that genuinely authored a sheet is correct regardless of which workspace the referencing revision
+sits in — the backfill's corroboration check is about attributing ownership, while this is about what
+a caller is allowed to be told.
 
 Step 2 must not read the ref table unqualified. `sheet_blob_ref` has no workspace column, and
 content-addressed dedup means one blob is shared by every project that authored identical SQL —
@@ -139,14 +166,13 @@ refs for one hash is honest dedup, and neither is more the author than the other
 Purge is why step 1 has to come first. `DeleteProject` removes `sheet_blob_ref WHERE project = A`
 before deleting project A, while a workspace-instance database that belonged to A is reassigned to
 the default project and keeps its revisions. Relying on the ref table alone would leave those
-revisions with no owner to name at exactly the moment a user most needs to know where the SQL came
-from. Parsing the revision's own `release` or `taskRun` still yields A.
+revisions with nothing to report at exactly the moment a user most needs to know where the SQL came
+from — step 1 can still tell them the authoring project is gone, which step 2 cannot.
 
-Step 1 is therefore attribution only — it never implies access. A purged project holds no refs and
-cannot be granted any, since `sheet_blob_ref.project` has a live foreign key; the backfill skips
-provenance naming a project that no longer exists for the same reason. So a revision whose authoring
-project was purged names A and withholds the statement permanently, which is correct: there is
-nobody left to ask.
+Step 1 is attribution only and never implies access. A purged project holds no refs and cannot be
+granted any, since `sheet_blob_ref.project` has a live foreign key, and the backfill skips
+uncorroborated provenance for the same reason. So a revision whose authoring project was purged
+withholds its statement permanently, which is correct: there is nobody left to ask.
 
 The response should distinguish the two outcomes rather than flattening them: a live project the
 caller can ask, versus an authoring project that no longer exists and whose content is now
@@ -205,14 +231,16 @@ Tests:
   complete under B while the statement is withheld with A named.
 - Purge path: put a database on a *workspace* instance in project A, create a revision, purge A, then
   assert that under the default project the list is still complete, the statement is withheld, and
-  the response names A as purged rather than reporting an unknown owner. This is the case most likely
-  to regress — it is not a user-facing transfer, and it is the one where `sheet_blob_ref` has already
-  been deleted, so it exercises the provenance path specifically.
+  the response reports the authoring project as gone rather than naming it or reporting unknown.
+  This is the case most likely to regress — it is not a user-facing transfer, and it is the one
+  where `sheet_blob_ref` has already been deleted, so it exercises the provenance path specifically.
 - A revision carrying neither `release` nor `taskRun` falls through to `sheet_blob_ref`, and to
   unknown when that is empty too.
-- Cross-tenant leak guard: seed identical SQL in two workspaces so one blob carries refs from both,
-  then request a withheld statement from one of them and assert the response never names the other
-  workspace's project. Generated `CREATE DATABASE` boilerplate makes this collision realistic, so it
+- Cross-tenant leak guard, both paths: (a) seed identical SQL in two workspaces so one blob carries
+  refs from both, then request a withheld statement from one and assert the response never names the
+  other workspace's project; (b) seed a revision whose `release` provenance names a project in
+  another workspace — the state T6 permits — and assert the response reports unknown rather than
+  echoing it. Generated `CREATE DATABASE` boilerplate makes this collision realistic, so it
   is a regression test rather than a contrived one.
 - Ambiguity: two projects in the caller's own workspace holding refs for one hash resolves to
   unknown, not to whichever row comes back first.

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -1,0 +1,176 @@
+# Database change history across project transfers
+
+Companion to [`sheet-blob-scoping.md`](sheet-blob-scoping.md), which scopes sheet content to the
+owning project. This document decides what a project sees of a database's change history after the
+database is transferred into it: **the history list follows the database, the statement text does
+not.**
+
+## Background
+
+`revision` and `changelog` have no project column. They key on `(instance, db_name)` and inherit
+their project through `db.project`, so when `UPDATE db SET project = ?` runs, the history moves with
+the database. This was never a design decision; it falls out of the schema. `convertToRevision` then
+formats the sheet name with the database's new project
+(`backend/api/v1/revision_service.go:304`), so a project-scoped sheet gate denies statements that
+were readable moments earlier.
+
+Four code paths move a database between projects, only one of which is a user-facing transfer:
+
+| Path | Location | Scope |
+|---|---|---|
+| `UpdateDatabase` | `backend/store/database.go:332-380` | one database |
+| `BatchUpdateDatabases` | `backend/store/database.go:397-560` | a batch |
+| `updateInstanceLifecycle` | `backend/store/instance.go:438-455` | every database of an instance, on project-instance archive |
+| `DeleteProject` | `backend/store/project.go:722-729` | workspace-instance databases, reassigned to the default project |
+
+The last is easy to miss: purge does not delete workspace-instance databases, it reassigns them to
+the default project, and the `revision` delete at `:702` covers only project instances — so those
+revisions survive a purge with their hashes intact.
+
+## Requirements
+
+**R1 — The applied-version ledger stays complete regardless of project.** `revision` carries a
+`version` column and serves as Bytebase's equivalent of `flyway_schema_history`: the record of which
+versioned migrations have already run against a database. Hiding revisions from the project
+currently holding the database risks a versioned release re-running migrations that already applied.
+This is a correctness constraint, not a preference.
+
+**R2 — The audit record survives reorgs intact.** Regulated customers must answer "what changed on
+this database, when, and by whom" for the full life of the database, across ownership changes. A
+database moving between teams is an administrative event and must not create a gap in the compliance
+record.
+
+**R3 — The inheriting team can operate the database.** Whoever takes ownership needs to know what has
+been applied. Handing a team a production database whose history is a black box is a worse outcome
+than the disclosure it avoids.
+
+**R4 — Projects remain a confidentiality boundary.** A database transfer that silently grants the
+destination project read access to statements the source project authored is a policy violation, and
+one performed by an operation that does not present itself as an access change. The principals who
+gain access are not the person performing the transfer — who already holds rights on both sides —
+but the destination project's other members.
+
+R1 through R3 are satisfied by any design that keeps the history list complete. R4 is the only
+requirement that discriminates, and it concerns statement text rather than the list.
+
+## Current behavior
+
+### Changelogs carry no SQL
+
+The v1 `Changelog` message (`proto/v1/v1/changelog_service.proto:105`) carries `name`, `create_time`,
+`status`, `schema` and `schema_size`, `task_run`, and `plan_title`. There is no statement and no
+sheet field; fields 4–6, 9–10 and 12–14 are reserved, having been removed as the model evolved.
+`backend/api/v1/changelog_service.go` populates no statement either.
+
+A changelog therefore answers when a change ran, whether it succeeded, what the schema looked like
+afterwards, and which rollout produced it — entirely from its own row. The `schema` snapshot is the
+load-bearing part: consecutive changelogs diff to show what changed structurally without reference
+to the SQL text. R2 rests almost entirely on this record, and no part of it depends on sheet scoping.
+
+### Changelog SQL already stops at the project boundary
+
+The statement behind a changelog is reachable only through `task_run` → `task.payload.sheetSha256`.
+`task` is project-scoped with its own column and does not move with the database. The stored pointer
+keeps naming the source project (`FormatTaskRun(database.ProjectID, ...)` at
+`backend/runner/taskrun/database_migrate_executor.go:273`), and resolving it requires rights on that
+project.
+
+Changelogs already implement *metadata follows the database, SQL stays with the authoring project*.
+That behavior predates this work.
+
+### Revisions carry a hash directly
+
+`RevisionPayload.sheet_sha256` names the sheet inline, so revisions — unlike changelogs — surface
+statement content through the sheet gate. They are the only history record this decision affects.
+
+## Design
+
+Change history follows the database; statement content does not.
+
+- Revision and changelog lists are returned in full after a transfer, including entries created under
+  a previous project. Versions, timestamps, authors, status, schema snapshots, and the sheet *name*
+  are all present.
+- When a revision's sheet is not readable by the current project, the statement is withheld and the
+  response says so explicitly, naming the owning project, rather than returning NotFound for the
+  sheet.
+- No sheet references are carried between projects. A database transfer grants no new read access,
+  and the four reassignment paths above need no changes.
+
+This satisfies R1 through R3 by keeping the list intact and R4 by leaving statement text with the
+project that authored it. It also makes revisions consistent with how changelogs already behave,
+rather than introducing two rules for two views of the same history.
+
+The explicit withholding matters as much as the withholding itself. A destination team that sees
+"statement owned by project `payments-core`" can make an informed request to the right owner. A team
+that sees a list of failed content loads sees a broken product.
+
+The owning project is derivable without new storage: `sheet_blob_ref` records which projects hold a
+ref for a hash, so the withheld response can name them. This discloses that some other project holds
+SQL with that hash, which is acceptable within a workspace and is strictly less than the content
+itself.
+
+## Alternatives considered
+
+**Carry sheet references on transfer.** On any project change, insert ref rows for the destination
+covering every hash in that database's revisions. Preserves current behavior exactly and grants
+narrowly — only hashes that database's own revisions reference. It fails R4: it widens access as a
+side effect of an operation that is not about access, for principals who were not party to it.
+
+It is also the most machinery of any option, and the machinery is where the risk lives. A carry
+helper must be wired into all four paths, purge additionally requires carrying before the source
+project's refs are deleted, and each path needs its own test because the failure is silent until a
+later read. Three of the four paths were missed on first analysis; only `BatchUpdateDatabases` is an
+obvious transfer, and the other three are consequences of unrelated operations.
+
+**Withhold with no signal.** Carry nothing and let the gate return NotFound. Costs nothing and
+satisfies R4, but produces a history list where every statement fails to load with no indication of
+why or where to look. This is the default outcome if the decision is not made explicitly, which is
+the main reason to make it explicitly.
+
+**Project-scope revisions and changelogs.** Add a `project` column to both, set at creation, and
+filter reads to the caller's project, so a database transferred into project B shows only history
+created while it was in B. This is the cleanest authorization story — history becomes project-scoped
+like `plan`, `task`, `issue`, and `release` — and it would also resolve the dangling `taskRun`
+pointer noted below. It fails R1: a transferred database would appear to have no applied versions,
+and a versioned release would re-run migrations that already ran. A reorg-triggered path to data
+corruption outweighs the modelling improvement.
+
+> This rejection rests on revisions being what determines whether a version is already applied.
+> Confirm against `runVersionedRelease` in
+> `backend/runner/taskrun/database_migrate_executor.go` before treating it as settled. If revisions
+> do not drive version-skip logic, this alternative becomes considerably more attractive.
+
+**Delete history on transfer.** Fails R1, R2, and R3 simultaneously. Recorded for completeness.
+
+## Implementation
+
+- A field on the revision response carrying the withheld-content reason and the owning project, plus
+  the handler change to populate it from `sheet_blob_ref`.
+- A UI affordance for the withheld state that names the owning project rather than rendering an
+  error.
+- No changes to `UpdateDatabase`, `BatchUpdateDatabases`, `updateInstanceLifecycle`, or
+  `DeleteProject`.
+
+Tests: create a revision under project A, move the database to project B, then assert the revision
+list is complete under B while the statement is withheld with A named. Repeat for the purge path,
+where a workspace-instance database is reassigned to the default project — the case most likely to
+regress, since it is not a user-facing transfer.
+
+## Open items
+
+**Sheet name attribution.** `convertToRevision` formats the sheet name with the database's current
+project, which is incorrect after a transfer: it names the destination as owner of a sheet the source
+authored. Deriving the owner from `sheet_blob_ref` covers the withheld-content response, but the
+`name` field itself remains wrong. Recording the authoring project on the revision at creation would
+fix it for new rows; rows predating the migration cannot recover it.
+
+**Workspace-level roles have no escape hatch.** The gate checks the ref table for the named project,
+so workspace admins and DBAs are refused as well, despite holding `bb.sheets.get` broadly. Whether
+workspace-scoped roles should bypass project scoping is a policy decision worth making deliberately
+rather than inheriting from the mechanism.
+
+**`plan_title` crosses the boundary today.** It is derived by parsing the source project out of the
+stored `taskRun` string and joining through it (`backend/store/changelog.go:163-168`), so a changelog
+in the destination project surfaces the source project's plan title. Minor and pre-existing, but it
+is the one place changelog display crosses a project line, and it should be fixed or accepted
+deliberately.

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -124,6 +124,12 @@ the default project and keeps its revisions. Relying on the ref table alone woul
 revisions with no owner to name at exactly the moment a user most needs to know where the SQL came
 from. Parsing the revision's own `release` or `taskRun` still yields A.
 
+Step 1 is therefore attribution only — it never implies access. A purged project holds no refs and
+cannot be granted any, since `sheet_blob_ref.project` has a live foreign key; the backfill skips
+provenance naming a project that no longer exists for the same reason. So a revision whose authoring
+project was purged names A and withholds the statement permanently, which is correct: there is
+nobody left to ask.
+
 The response should distinguish the two outcomes rather than flattening them: a live project the
 caller can ask, versus an authoring project that no longer exists and whose content is now
 unreadable by anyone. The second is a permanent consequence of purging a project, consistent with

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -112,34 +112,39 @@ The owning project is derivable without new storage, from the revision's own pro
 resource name; `backend/store/changelog.go:163-168` already parses a project out of a stored
 `taskRun` this way. Resolution order:
 
-1. The revision's `release`, else its `taskRun` — **verified against the caller's workspace before
-   it is echoed**, per below. Correct even after the database has moved, because the string is
-   immutable.
+1. The revision's `release`, else its `taskRun` — **corroborated by exactly the rule the backfill
+   uses**, and resolving to a project in the caller's workspace.
 2. `sheet_blob_ref` — which projects currently hold a ref for that hash, **joined through `project`
    and constrained to the caller's workspace**, and only when that leaves exactly one candidate.
    Useful when the revision carries no provenance, both fields being optional.
-3. Neither, or more than one candidate — report that the authoring project is unknown.
+3. Anything else — report the owner as unknown, and never echo a project ID that failed either test.
 
-**Provenance is a hint, not an assertion, and must be verified before it is echoed.** Both fields
-are stored verbatim from the caller: `convertRevision` writes `Release: revision.Release` and
-`TaskRun: revision.TaskRun` straight through (`backend/api/v1/revision_service.go:352-364`). Until
-the T6 fix lands, `createRevisions` resolves `revision.Release` with `GetRelease` and no workspace or
-database-project comparison (`:207-223`), so revisions already in the database can carry provenance
-naming a project in another tenant. Echoing the parsed string unchecked would leak a foreign
-workspace's project name — the same disclosure step 2 is guarded against, arrived at by a different
-route.
+**Provenance is a hint, not an assertion.** Both fields are stored verbatim from the caller:
+`convertRevision` writes `Release: revision.Release` and `TaskRun: revision.TaskRun` straight through
+(`backend/api/v1/revision_service.go:352-364`). Until the T6 fix lands, `createRevisions` resolves
+`revision.Release` with no workspace or database-project comparison (`:207-223`), and it never
+compares a `taskRun`'s task to `revision.Sheet` at all — so a revision can carry provenance naming
+another tenant's project, or naming a perfectly real project in the caller's own workspace that had
+nothing to do with the sheet.
 
-So resolve the parsed project and branch on what it turns out to be:
+**Naming therefore uses the same corroboration rule as the backfill, not a weaker one.** Identity,
+age, and hash match, exactly as specified in
+[the backfill section](sheet-blob-scoping.md#backfill). A design in which the backfill trusts
+corroborated provenance while the response trusts raw provenance has two different notions of
+provenance in it, and the weaker one would be the user-visible one.
 
-| Parsed project | Response |
+| Provenance | Response |
 |---|---|
-| Exists, in the caller's workspace | Name it |
-| Exists, in a different workspace | Unknown — do not echo the string |
-| Does not exist | Authoring project no longer exists — say so **without naming it**, since its workspace can no longer be verified |
+| Corroborated, project in the caller's workspace | Name it |
+| Corroborated, project in another workspace | Owner unknown |
+| Present but not corroborated — stale, purged, or fabricated | Owner unknown |
+| Absent | Fall through to step 2 |
 
-The third row still delivers what the user needs: the statement is permanently unavailable and there
-is nobody to ask. Withholding the name costs a little diagnostic value and removes an unverifiable
-string from the response.
+The response may still distinguish *why* it is unavailable — no provenance, provenance that cannot
+be verified, an owner outside the caller's workspace — since a reason is not an identifier. What it
+must never do is echo a project ID that failed a check. Misattribution is not a harmless default: a
+user told that project `payments-core` owns a statement it never authored will go and ask them for
+it, and may be granted access on a false premise.
 
 This applies to *naming*, not to the backfill's use of the same fields. Granting a ref to the project
 that genuinely authored a sheet is correct regardless of which workspace the referencing revision
@@ -163,16 +168,16 @@ WHERE r.sha256 = ? AND p.workspace = ?
 Ambiguity resolves to unknown rather than to a guess. Two projects in the same workspace holding
 refs for one hash is honest dedup, and neither is more the author than the other.
 
-Purge is why step 1 has to come first. `DeleteProject` removes `sheet_blob_ref WHERE project = A`
-before deleting project A, while a workspace-instance database that belonged to A is reassigned to
-the default project and keeps its revisions. Relying on the ref table alone would leave those
-revisions with nothing to report at exactly the moment a user most needs to know where the SQL came
-from — step 1 can still tell them the authoring project is gone, which step 2 cannot.
+A purged authoring project resolves to unknown, not to a name. `DeleteProject` hard-deletes the
+`release`, `task` and `plan` rows along with the project, so provenance naming it can no longer
+corroborate, and `sheet_blob_ref WHERE project = A` is deleted too, so step 2 finds nothing either.
+That is the correct outcome rather than a gap: the statement is permanently unavailable, there is
+nobody left to ask, and the only thing withheld beyond the content is an ID that can no longer be
+verified against any workspace.
 
 Step 1 is attribution only and never implies access. A purged project holds no refs and cannot be
 granted any, since `sheet_blob_ref.project` has a live foreign key, and the backfill skips
-uncorroborated provenance for the same reason. So a revision whose authoring project was purged
-withholds its statement permanently, which is correct: there is nobody left to ask.
+uncorroborated provenance for the same reason.
 
 The response should distinguish the two outcomes rather than flattening them: a live project the
 caller can ask, versus an authoring project that no longer exists and whose content is now
@@ -228,10 +233,11 @@ corruption outweighs the modelling improvement.
 Tests:
 
 - Create a revision under project A, move the database to project B, assert the revision list is
-  complete under B while the statement is withheld with A named.
+  complete under B while the statement is withheld with A named — A's provenance corroborates, and A
+  is in the caller's workspace.
 - Purge path: put a database on a *workspace* instance in project A, create a revision, purge A, then
   assert that under the default project the list is still complete, the statement is withheld, and
-  the response reports the authoring project as gone rather than naming it or reporting unknown.
+  the response reports the owner as unknown and names no project.
   This is the case most likely to regress — it is not a user-facing transfer, and it is the one
   where `sheet_blob_ref` has already been deleted, so it exercises the provenance path specifically.
 - A revision carrying neither `release` nor `taskRun` falls through to `sheet_blob_ref`, and to
@@ -240,7 +246,8 @@ Tests:
   refs from both, then request a withheld statement from one and assert the response never names the
   other workspace's project; (b) seed a revision whose `release` provenance names a project in
   another workspace — the state T6 permits — and assert the response reports unknown rather than
-  echoing it. Generated `CREATE DATABASE` boilerplate makes this collision realistic, so it
+  echoing it; (c) seed a revision naming a real project in the caller's *own* workspace that never
+  authored the sheet, and assert the response reports unknown rather than misattributing it. Generated `CREATE DATABASE` boilerplate makes this collision realistic, so it
   is a regression test rather than a contrived one.
 - Ambiguity: two projects in the caller's own workspace holding refs for one hash resolves to
   unknown, not to whichever row comes back first.

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -104,10 +104,33 @@ The explicit withholding matters as much as the withholding itself. A destinatio
 "statement owned by project `payments-core`" can make an informed request to the right owner. A team
 that sees a list of failed content loads sees a broken product.
 
-The owning project is derivable without new storage: `sheet_blob_ref` records which projects hold a
-ref for a hash, so the withheld response can name them. This discloses that some other project holds
-SQL with that hash, which is acceptable within a workspace and is strictly less than the content
-itself.
+### Naming the owner
+
+The owning project is derivable without new storage, from the revision's own provenance.
+`RevisionPayload` carries `release` (`projects/{project}/releases/{release}`) and `task_run`
+(`projects/{project}/plans/…/taskRuns/{taskRun}`), both embedding the authoring project in the
+resource name; `backend/store/changelog.go:163-168` already parses a project out of a stored
+`taskRun` this way. Resolution order:
+
+1. The revision's `release`, else its `taskRun` — the authoring project, and correct even after the
+   database has moved or the project has been purged, because the string is immutable.
+2. `sheet_blob_ref` — which projects currently hold a ref for that hash. Useful when the revision
+   carries no provenance, both fields being optional.
+3. Neither — report that the authoring project is unknown.
+
+Purge is why step 1 has to come first. `DeleteProject` removes `sheet_blob_ref WHERE project = A`
+before deleting project A, while a workspace-instance database that belonged to A is reassigned to
+the default project and keeps its revisions. Relying on the ref table alone would leave those
+revisions with no owner to name at exactly the moment a user most needs to know where the SQL came
+from. Parsing the revision's own `release` or `taskRun` still yields A.
+
+The response should distinguish the two outcomes rather than flattening them: a live project the
+caller can ask, versus an authoring project that no longer exists and whose content is now
+unreadable by anyone. The second is a permanent consequence of purging a project, consistent with
+the zero-ref blobs described in the scoping doc.
+
+Naming the owner discloses that some other project holds SQL with that hash. That is acceptable
+within a workspace and strictly less than the content itself.
 
 ## Alternatives considered
 
@@ -144,25 +167,34 @@ corruption outweighs the modelling improvement.
 
 ## Implementation
 
-- A field on the revision response carrying the withheld-content reason and the owning project, plus
-  the handler change to populate it from `sheet_blob_ref`.
+- A field on the revision response carrying the withheld-content reason and the owning project,
+  populated by the resolution order above — provenance first, `sheet_blob_ref` second, unknown last
+  — and distinguishing a live owning project from a purged one.
 - A UI affordance for the withheld state that names the owning project rather than rendering an
-  error.
+  error, and says the project no longer exists when that is the case.
 - No changes to `UpdateDatabase`, `BatchUpdateDatabases`, `updateInstanceLifecycle`, or
   `DeleteProject`.
 
-Tests: create a revision under project A, move the database to project B, then assert the revision
-list is complete under B while the statement is withheld with A named. Repeat for the purge path,
-where a workspace-instance database is reassigned to the default project — the case most likely to
-regress, since it is not a user-facing transfer.
+Tests:
+
+- Create a revision under project A, move the database to project B, assert the revision list is
+  complete under B while the statement is withheld with A named.
+- Purge path: put a database on a *workspace* instance in project A, create a revision, purge A, then
+  assert that under the default project the list is still complete, the statement is withheld, and
+  the response names A as purged rather than reporting an unknown owner. This is the case most likely
+  to regress — it is not a user-facing transfer, and it is the one where `sheet_blob_ref` has already
+  been deleted, so it exercises the provenance path specifically.
+- A revision carrying neither `release` nor `taskRun` falls through to `sheet_blob_ref`, and to
+  unknown when that is empty too.
 
 ## Open items
 
 **Sheet name attribution.** `convertToRevision` formats the sheet name with the database's current
 project, which is incorrect after a transfer: it names the destination as owner of a sheet the source
-authored. Deriving the owner from `sheet_blob_ref` covers the withheld-content response, but the
-`name` field itself remains wrong. Recording the authoring project on the revision at creation would
-fix it for new rows; rows predating the migration cannot recover it.
+authored. The withheld-content response resolves this through provenance, but the `name` field itself
+is still built from `db.project` and stays wrong. Fixing it means formatting the name from the same
+provenance chain — which works for revisions carrying `release` or `taskRun` and leaves the rest
+without a correct name, so it is a partial fix rather than a clean one.
 
 **Workspace-level roles have no escape hatch.** The gate checks the ref table for the named project,
 so workspace admins and DBAs are refused as well, despite holding `bb.sheets.get` broadly. Whether

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -127,10 +127,7 @@ resource name; `backend/store/changelog.go:163-168` already parses a project out
 
 1. The revision's `release`, else its `taskRun` — **corroborated by exactly the rule the backfill
    uses**, and resolving to a project in the caller's workspace.
-2. `sheet_blob_ref` — which projects currently hold a ref for that hash, **joined through `project`
-   and constrained to the caller's workspace**, and only when that leaves exactly one candidate.
-   Useful when the revision carries no provenance, both fields being optional.
-3. Anything else — report the owner as unknown, and never echo a project ID that failed either test.
+2. Anything else — report the owner as unknown, and never echo a project ID that failed the test.
 
 **Provenance is a hint, not an assertion.** Both fields are stored verbatim from the caller:
 `convertRevision` writes `Release: revision.Release` and `TaskRun: revision.TaskRun` straight through
@@ -151,7 +148,7 @@ provenance in it, and the weaker one would be the user-visible one.
 | Corroborated, project in the caller's workspace | Name it |
 | Corroborated, project in another workspace | Owner unknown |
 | Present but not corroborated — stale, purged, or fabricated | Owner unknown |
-| Absent | Fall through to step 2 |
+| Absent | Owner unknown |
 
 The response may still distinguish *why* it is unavailable — no provenance, provenance that cannot
 be verified, an owner outside the caller's workspace — since a reason is not an identifier. What it
@@ -164,31 +161,29 @@ that genuinely authored a sheet is correct regardless of which workspace the ref
 sits in — the backfill's corroboration check is about attributing ownership, while this is about what
 a caller is allowed to be told.
 
-Step 2 must not read the ref table unqualified. `sheet_blob_ref` has no workspace column, and
-content-addressed dedup means one blob is shared by every project that authored identical SQL —
-across tenants. Generated boilerplate makes that routine rather than rare: `getCreateDatabaseStatement`
-emits `CREATE DATABASE %s;` for several engines, so a common statement will carry refs from many
-workspaces. Naming an arbitrary one would leak a foreign tenant's project name from a design whose
-purpose is closing cross-tenant leakage.
+**`sheet_blob_ref` is not a fallback for authorship.** An earlier draft resolved a provenance-less
+revision by finding which projects hold a ref for its hash and naming the one candidate in the
+caller's workspace. That is not evidence about *this revision*: a ref proves only that some project
+authored identical content. Content-addressed dedup makes identical content the normal case rather
+than a coincidence — `getCreateDatabaseStatement` emits `CREATE DATABASE %s;` for several engines,
+so exactly-one collisions on boilerplate are plausible rather than contrived, and the answer would
+be a project that had nothing to do with the revision.
 
-```sql
-SELECT r.project
-FROM sheet_blob_ref r
-JOIN project p ON p.resource_id = r.project
-WHERE r.sha256 = ? AND p.workspace = ?
-```
+Naming it would send the user to request access from a project that never authored the statement,
+which is the misattribution this section already rejects for uncorroborated provenance. Applying the
+corroboration standard to provenance and a weaker inference to the ref table would be the same
+inconsistency in a different place.
 
-Ambiguity resolves to unknown rather than to a guess. Two projects in the same workspace holding
-refs for one hash is honest dedup, and neither is more the author than the other.
+So there is no ref-table fallback. A revision names an owner when its own provenance corroborates
+one, and reports unknown otherwise.
 
 A purged authoring project resolves to unknown, not to a name. `DeleteProject` hard-deletes the
 `release`, `task` and `plan` rows along with the project, so provenance naming it can no longer
-corroborate, and `sheet_blob_ref WHERE project = A` is deleted too, so step 2 finds nothing either.
-That is the correct outcome rather than a gap: the statement is permanently unavailable, there is
-nobody left to ask, and the only thing withheld beyond the content is an ID that can no longer be
-verified against any workspace.
+corroborate. That is the correct outcome rather than a gap: the statement is permanently
+unavailable, there is nobody left to ask, and the only thing withheld beyond the content is an ID
+that can no longer be verified against any workspace.
 
-Step 1 is attribution only and never implies access. A purged project holds no refs and cannot be
+Provenance resolution is attribution only and never implies access. A purged project holds no refs and cannot be
 granted any, since `sheet_blob_ref.project` has a live foreign key, and the backfill skips
 uncorroborated provenance for the same reason.
 
@@ -236,7 +231,7 @@ corruption outweighs the modelling improvement.
 ## Implementation
 
 - A field on the revision response carrying the withheld-content reason and the owning project,
-  populated by the resolution order above — provenance first, `sheet_blob_ref` second, unknown last.
+  populated by the resolution above — corroborated provenance, else unknown.
 - `convertToRevision` formats `Revision.sheet` from the resolved owner rather than from
   `database.ProjectID` (`backend/api/v1/revision_service.go:304`), and emits no sheet name when the
   owner does not resolve. Leaving it built from the current project would keep exactly the false
@@ -266,8 +261,9 @@ Tests:
   is complete under B while the statement is withheld with A named. Archiving a *project* instance is
   the wrong path — `backend/store/instance.go:434` rejects it — so a test written that way would pass
   vacuously without exercising any transfer.
-- A revision carrying neither `release` nor `taskRun` falls through to `sheet_blob_ref`, and to
-  unknown when that is empty too.
+- A revision carrying neither `release` nor `taskRun` reports unknown, even when exactly one project
+  in the caller's workspace holds a ref for that hash — that ref proves identical content, not
+  authorship.
 - Cross-tenant leak guard, both paths: (a) seed identical SQL in two workspaces so one blob carries
   refs from both, then request a withheld statement from one and assert the response never names the
   other workspace's project; (b) seed a revision whose `release` provenance names a project in
@@ -275,8 +271,6 @@ Tests:
   echoing it; (c) seed a revision naming a real project in the caller's *own* workspace that never
   authored the sheet, and assert the response reports unknown rather than misattributing it. Generated `CREATE DATABASE` boilerplate makes this collision realistic, so it
   is a regression test rather than a contrived one.
-- Ambiguity: two projects in the caller's own workspace holding refs for one hash resolves to
-  unknown, not to whichever row comes back first.
 - Sheet name: after a transfer, `Revision.sheet` names the resolved owner and resolves to that
   project's readable sheet for a caller who holds rights there; when the owner is unknown, no sheet
   name is emitted rather than one pointing at the current project.

--- a/docs/design/sheet-history-on-database-transfer.md
+++ b/docs/design/sheet-history-on-database-transfer.md
@@ -114,9 +114,27 @@ resource name; `backend/store/changelog.go:163-168` already parses a project out
 
 1. The revision's `release`, else its `taskRun` — the authoring project, and correct even after the
    database has moved or the project has been purged, because the string is immutable.
-2. `sheet_blob_ref` — which projects currently hold a ref for that hash. Useful when the revision
-   carries no provenance, both fields being optional.
-3. Neither — report that the authoring project is unknown.
+2. `sheet_blob_ref` — which projects currently hold a ref for that hash, **joined through `project`
+   and constrained to the caller's workspace**, and only when that leaves exactly one candidate.
+   Useful when the revision carries no provenance, both fields being optional.
+3. Neither, or more than one candidate — report that the authoring project is unknown.
+
+Step 2 must not read the ref table unqualified. `sheet_blob_ref` has no workspace column, and
+content-addressed dedup means one blob is shared by every project that authored identical SQL —
+across tenants. Generated boilerplate makes that routine rather than rare: `getCreateDatabaseStatement`
+emits `CREATE DATABASE %s;` for several engines, so a common statement will carry refs from many
+workspaces. Naming an arbitrary one would leak a foreign tenant's project name from a design whose
+purpose is closing cross-tenant leakage.
+
+```sql
+SELECT r.project
+FROM sheet_blob_ref r
+JOIN project p ON p.resource_id = r.project
+WHERE r.sha256 = ? AND p.workspace = ?
+```
+
+Ambiguity resolves to unknown rather than to a guess. Two projects in the same workspace holding
+refs for one hash is honest dedup, and neither is more the author than the other.
 
 Purge is why step 1 has to come first. `DeleteProject` removes `sheet_blob_ref WHERE project = A`
 before deleting project A, while a workspace-instance database that belonged to A is reassigned to
@@ -192,6 +210,12 @@ Tests:
   been deleted, so it exercises the provenance path specifically.
 - A revision carrying neither `release` nor `taskRun` falls through to `sheet_blob_ref`, and to
   unknown when that is empty too.
+- Cross-tenant leak guard: seed identical SQL in two workspaces so one blob carries refs from both,
+  then request a withheld statement from one of them and assert the response never names the other
+  workspace's project. Generated `CREATE DATABASE` boilerplate makes this collision realistic, so it
+  is a regression test rather than a contrived one.
+- Ambiguity: two projects in the caller's own workspace holding refs for one hash resolves to
+  unknown, not to whichever row comes back first.
 
 ## Open items
 


### PR DESCRIPTION
Design docs only — no implementation. Rewrites both sheet design docs from option menus into decisions with the reasoning that produced them.

Supersedes #21133, which proposed the reference-carry approach these docs now reject.

## Scope is the project, and the API contract is why

The earlier draft weighed project vs. workspace scope on cost. That was the wrong axis. The deciding argument is the resource contract:

- Across this API the prefix in a resource name identifies the resource's **actual owner**, never a scope the caller selected. `AccessGrant`, `Plan`, `Issue`, `Release` are project-prefixed; `Group`, `IdP`, `ReviewConfig` are bare collections with the workspace implicit; `Database` and `Instance` declare both patterns, and in each the project prefix names the real owner.
- A create request's `parent` is always exactly the prefix of the created resource's name. Workspace-scoped resources therefore have **no parent at all** — `POST /v1/groups`, `POST /v1/reviewConfigs`, `POST /v1/idps`. `CreatePolicyRequest.parent` is `workspaces/{w}` / `environments/{e}` / `projects/{p}`, producing a Policy named exactly that parent plus `/policies/{policy}`.

Those two rules make project-parented creation and a workspace-scoped resource mutually exclusive. `Sheet` declaring `projects/{project}/sheets/{sheet}` while the lookup ignores the project **is** T5, stated as a naming defect rather than an authorization one.

So the decision is that a sheet is owned by a project: the resource is the pair (project, content), two projects authoring identical SQL own two distinct sheets that share storage, and content-addressed dedup becomes a storage optimization invisible at the API layer. Name, create parent, permission level, and read scope then all agree.

## Workspace scope, and why it lost

Recorded in full under Alternatives rather than dismissed. It is genuinely cheaper — databases cannot move between workspaces, so the transfer question never arises; the ref table would reference `workspace`, so purge would not touch it; and the laundering problem would shrink to cross-workspace references that cannot be created legitimately.

It fails **R2** (parentless creation moves authoring governance to the workspace, so "this user may write change SQL for project A only" stops being expressible), fails **R6** for regulated-separation and agency customers, and needs a breaking rename across four proto sites plus a reshaped `CreateSheet`. The asymmetry decides it: project scope costs no API change in either direction; workspace scope costs one break to adopt and a second to reverse.

## History on database transfer

Decided as: **the list follows the database, the statement text does not.** A revision's statement is withheld when its sheet belongs to another project, with the owning project named — derived from `sheet_blob_ref`, so no new storage is needed for attribution.

This satisfies the applied-version ledger (hiding revisions would make a transferred database re-run migrations), audit completeness, and operational awareness, while leaving statement text with the project that authored it. It also matches how changelogs already behave: `ChangelogPayload` carries no sheet reference, and changelog SQL is reachable only through `task_run` → `task`, which is project-scoped and does not move.

Consequence for the main design: no reference-carry helper, no wiring into the four reassignment paths, no purge ordering constraint. Project purge keeps only the ref delete. That removes the machinery every review round so far has found defects in.

## Still open

One claim is flagged in-doc as unverified: rejecting project-scoped revisions rests on revisions driving version-skip logic. It needs confirming against `runVersionedRelease` before it is settled — if revisions do not drive that logic, the alternative becomes considerably more attractive.

## Testing

None — documentation only. Both docs carry their own test plans for the implementation that follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
