### PR TITLE
fix: several fix for project instance

### DIFF
--- a/backend/store/instance.go
+++ b/backend/store/instance.go
@@ -1093,8 +1093,23 @@ func (s *Store) DeleteInstance(ctx context.Context, workspace string, resourceID
 		return errors.Wrap(err, "failed to commit transaction")
 	}
 
-	// Clear the instance from cache
+	// Publish cache invalidation only after the purge commits. Descendant cache
+	// keys carry the instance ID, so invalidation does not need to read every
+	// database row before deleting it.
 	s.instanceCache.Remove(getInstanceCacheKey(resourceID))
+	unscopedDatabaseCachePrefix := getDatabaseCacheKey("", resourceID, "")
+	workspaceDatabaseCachePrefix := getDatabaseCacheKey(workspace, resourceID, "")
+	for _, key := range s.databaseCache.Keys() {
+		if strings.HasPrefix(key, unscopedDatabaseCachePrefix) || strings.HasPrefix(key, workspaceDatabaseCachePrefix) {
+			s.databaseCache.Remove(key)
+		}
+	}
+	dbSchemaCachePrefix := getDBSchemaCacheKey(resourceID, "")
+	for _, key := range s.dbSchemaCache.Keys() {
+		if strings.HasPrefix(key, dbSchemaCachePrefix) {
+			s.dbSchemaCache.Remove(key)
+		}
+	}
 
 	return nil
 }

--- a/backend/store/instance_purge_cache_test.go
+++ b/backend/store/instance_purge_cache_test.go
@@ -1,0 +1,82 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestDeleteInstancePurgeInvalidatesDescendantCaches(t *testing.T) {
+	ctx, db, s := newProjectPurgeCacheFixture(t)
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO instance (resource_id, workspace, project, deleted)
+			VALUES ('project-instance', 'default', 'project-a', TRUE);
+		INSERT INTO db (instance, name, project)
+			VALUES ('project-instance', 'project-db', 'project-a');
+		INSERT INTO db_schema (instance, db_name)
+			VALUES ('project-instance', 'project-db');
+	`)
+	require.NoError(t, err)
+
+	instanceID := "project-instance"
+	databaseName := "project-db"
+	instance, err := s.GetInstance(ctx, &store.FindInstanceMessage{
+		Workspace:  "default",
+		ResourceID: &instanceID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, instance)
+	for _, find := range []*store.FindDatabaseMessage{
+		{Workspace: "default", InstanceID: &instanceID, DatabaseName: &databaseName, ShowDeleted: true},
+		{Workspace: "", InstanceID: &instanceID, DatabaseName: &databaseName, ShowDeleted: true},
+	} {
+		database, err := s.GetDatabase(ctx, find)
+		require.NoError(t, err)
+		require.NotNil(t, database)
+	}
+	schema, err := s.GetDBSchemaSnapshot(ctx, "default", instanceID, databaseName)
+	require.NoError(t, err)
+	require.NotNil(t, schema)
+
+	require.NoError(t, s.DeleteInstance(ctx, "default", instanceID))
+
+	instance, err = s.GetInstance(ctx, &store.FindInstanceMessage{
+		Workspace:  "default",
+		ResourceID: &instanceID,
+	})
+	require.NoError(t, err)
+	require.Nil(t, instance)
+	for _, find := range []*store.FindDatabaseMessage{
+		{Workspace: "default", InstanceID: &instanceID, DatabaseName: &databaseName, ShowDeleted: true},
+		{Workspace: "", InstanceID: &instanceID, DatabaseName: &databaseName, ShowDeleted: true},
+	} {
+		database, err := s.GetDatabase(ctx, find)
+		require.NoError(t, err)
+		require.Nil(t, database)
+	}
+	schema, err = s.GetDBSchemaSnapshot(ctx, "default", instanceID, databaseName)
+	require.NoError(t, err)
+	require.Nil(t, schema)
+
+	_, err = db.ExecContext(ctx, `
+		INSERT INTO instance (resource_id, workspace, project)
+			VALUES ('project-instance', 'default', 'project-b');
+		INSERT INTO db (instance, name, project)
+			VALUES ('project-instance', 'project-db', 'project-b');
+	`)
+	require.NoError(t, err)
+	for _, find := range []*store.FindDatabaseMessage{
+		{Workspace: "default", InstanceID: &instanceID, DatabaseName: &databaseName},
+		{Workspace: "", InstanceID: &instanceID, DatabaseName: &databaseName},
+	} {
+		database, err := s.GetDatabase(ctx, find)
+		require.NoError(t, err)
+		require.NotNil(t, database)
+		require.Equal(t, "project-b", database.ProjectID)
+	}
+	schema, err = s.GetDBSchemaSnapshot(ctx, "default", instanceID, databaseName)
+	require.NoError(t, err)
+	require.Nil(t, schema)
+}

--- a/backend/utils/setting_test.go
+++ b/backend/utils/setting_test.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package utils
 
 import (

--- a/frontend/src/components/WorkspaceSetupGuide.test.tsx
+++ b/frontend/src/components/WorkspaceSetupGuide.test.tsx
@@ -131,6 +131,22 @@ vi.mock("@/api", () => ({
 }));
 
 vi.mock("@/utils", () => ({
+  autoSQLEditorDatabaseRoute: (database: {
+    name: string;
+    project: string;
+  }) => {
+    const match = database.name.match(
+      /^(?:projects\/[^/]+\/)?instances\/(?<instance>[^/]+)\/databases\/(?<database>[^/]+)$/
+    );
+    return {
+      name: "sql-editor.database",
+      params: {
+        project: database.project.replace(/^projects\//, ""),
+        instance: match?.groups?.instance ?? "",
+        database: match?.groups?.database ?? "",
+      },
+    };
+  },
   extractDatabaseResourceName: (name: string) => {
     const match = name.match(/^instances\/([^/]+)\/databases\/([^/]+)$/);
     return {

--- a/frontend/src/components/WorkspaceSetupGuide.tsx
+++ b/frontend/src/components/WorkspaceSetupGuide.tsx
@@ -31,7 +31,7 @@ import { cn } from "@/lib/utils";
 import { useAppStore } from "@/stores/app";
 import { SearchQueryHistoriesRequestSchema } from "@/types/proto-es/v1/query_history_service_pb";
 import {
-  extractDatabaseResourceName,
+  autoSQLEditorDatabaseRoute,
   extractProjectResourceName,
   hasWorkspacePermissionV2,
 } from "@/utils";
@@ -225,25 +225,15 @@ export function WorkspaceSetupGuide() {
     currentRoute.name,
   ]);
 
-  const projectId = setupState.projectName
-    ? extractProjectResourceName(setupState.projectName)
-    : "";
-  const databaseRouteParams = useMemo(() => {
-    if (!setupState.databaseName || !projectId) {
+  const databaseRoute = useMemo(() => {
+    if (!setupState.databaseName || !setupState.projectName) {
       return undefined;
     }
-    const { instanceName, databaseName } = extractDatabaseResourceName(
-      setupState.databaseName
-    );
-    if (!instanceName || !databaseName) {
-      return undefined;
-    }
-    return {
-      project: projectId,
-      instance: instanceName,
-      database: databaseName,
-    };
-  }, [projectId, setupState.databaseName]);
+    return autoSQLEditorDatabaseRoute({
+      name: setupState.databaseName,
+      project: setupState.projectName,
+    });
+  }, [setupState.databaseName, setupState.projectName]);
 
   const steps = useMemo<SetupStep[]>(
     () => [
@@ -422,13 +412,10 @@ export function WorkspaceSetupGuide() {
               {t("workspace-setup-guide.actions.change")}
             </Button>
           )}
-        {actionStep.key === "hasFirstQuery" && (
+        {actionStep.key === "hasFirstQuery" && databaseRoute && (
           <RouterLink
             data-testid="active-action"
-            to={{
-              name: SQL_EDITOR_DATABASE_MODULE,
-              params: databaseRouteParams,
-            }}
+            to={databaseRoute}
             className={buttonVariants({ size: "sm" })}
           >
             {t("workspace-setup-guide.actions.query")}

--- a/frontend/src/components/monaco/MonacoEditor.test.tsx
+++ b/frontend/src/components/monaco/MonacoEditor.test.tsx
@@ -101,8 +101,13 @@ vi.mock("@/types", () => ({
 }));
 
 vi.mock("@/utils", () => ({
-  extractDatabaseResourceName: () => ({ databaseName: "db" }),
-  extractInstanceResourceName: () => "instance",
+  extractDatabaseResourceName: (name: string) => ({
+    databaseName: name.match(/\/databases\/([^/]+)/)?.[1] ?? "",
+  }),
+  extractInstanceResourceName: (name: string) =>
+    name.match(/\/instances\/([^/]+)/)?.[1] ??
+    name.match(/^instances\/([^/]+)/)?.[1] ??
+    "",
   formatAbsoluteDateTime: () => "2024-04-25 12:26:40",
   isDev: () => true,
 }));
@@ -351,6 +356,35 @@ describe("MonacoEditor", () => {
           instanceId: "instances/prod",
           scene: "query",
           schema: "public",
+        }),
+      ]
+    );
+
+    unmount();
+  });
+
+  test("normalizes project instance names in LSP metadata", async () => {
+    const { executeCommand } = await import("./lsp-client");
+
+    const { unmount } = await renderIntoContainer(
+      createElement(MonacoEditor, {
+        autoCompleteContext: {
+          database: "projects/project/instances/instance/databases/db",
+          instance: "projects/project/instances/instance",
+        },
+        content: "select 1",
+      })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    expect(executeCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      "setMetadata",
+      [
+        expect.objectContaining({
+          databaseName: "db",
+          instanceId: "instances/instance",
         }),
       ]
     );

--- a/frontend/src/components/monaco/MonacoEditor.tsx
+++ b/frontend/src/components/monaco/MonacoEditor.tsx
@@ -12,6 +12,7 @@ import {
 import { useTranslation } from "react-i18next";
 import { v4 as uuidv4 } from "uuid";
 import { Tooltip } from "@/components/ui/tooltip";
+import { instanceNamePrefix } from "@/lib/resourceName";
 import { cn } from "@/lib/utils";
 import type { Language, SQLDialect } from "@/types";
 import { UNKNOWN_ID } from "@/types";
@@ -624,7 +625,7 @@ export function MonacoEditor({
     };
     const instance = extractInstanceResourceName(ctx.instance);
     if (instance && instance !== String(UNKNOWN_ID)) {
-      params.instanceId = ctx.instance;
+      params.instanceId = `${instanceNamePrefix}${instance}`;
     }
     const { databaseName } = extractDatabaseResourceName(ctx.database ?? "");
     if (databaseName && databaseName !== String(UNKNOWN_ID)) {

--- a/frontend/src/modules/agent/logic/context.test.ts
+++ b/frontend/src/modules/agent/logic/context.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { ReactRoute } from "@/app/router";
+import { Engine } from "@/types/proto-es/v1/common_pb";
+
+const mocks = vi.hoisted(() => ({
+  getOrFetchDatabaseByName: vi.fn(),
+}));
+
+vi.mock("@/stores/app", () => ({
+  useAppStore: {
+    getState: () => ({
+      currentUser: undefined,
+      loadCurrentUser: vi.fn(async () => undefined),
+      getProjectByName: vi.fn(() => undefined),
+      getOrFetchDatabaseByName: mocks.getOrFetchDatabaseByName,
+      fetchIssueByName: vi.fn(async () => undefined),
+    }),
+  },
+}));
+
+import { extractRouteContext } from "./context";
+
+const databaseRoute = {
+  params: {
+    projectId: "project1",
+    instanceId: "instance1",
+    databaseName: "database1",
+  },
+  query: {},
+} as unknown as ReactRoute;
+
+const unknownDatabase = {
+  name: "instances/-1/databases/-1",
+  effectiveEnvironment: "environments/-1",
+};
+
+describe("extractRouteContext", () => {
+  beforeEach(() => {
+    mocks.getOrFetchDatabaseByName.mockReset();
+  });
+
+  test("resolves a workspace instance database", async () => {
+    mocks.getOrFetchDatabaseByName.mockResolvedValueOnce({
+      name: "instances/instance1/databases/database1",
+      instanceResource: { engine: Engine.POSTGRES },
+      effectiveEnvironment: "environments/test",
+    });
+
+    const context = await extractRouteContext(databaseRoute);
+
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenCalledOnce();
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenCalledWith(
+      "instances/instance1/databases/database1"
+    );
+    expect(context.database).toEqual({
+      name: "instances/instance1/databases/database1",
+      engine: "POSTGRES",
+      environment: "environments/test",
+    });
+  });
+
+  test("falls back to a project instance database", async () => {
+    mocks.getOrFetchDatabaseByName
+      .mockResolvedValueOnce(unknownDatabase)
+      .mockResolvedValueOnce({
+        name: "projects/project1/instances/instance1/databases/database1",
+        instanceResource: { engine: Engine.MYSQL },
+        effectiveEnvironment: "environments/prod",
+      });
+
+    const context = await extractRouteContext(databaseRoute);
+
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenNthCalledWith(
+      1,
+      "instances/instance1/databases/database1"
+    );
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenNthCalledWith(
+      2,
+      "projects/project1/instances/instance1/databases/database1"
+    );
+    expect(context.database).toEqual({
+      name: "projects/project1/instances/instance1/databases/database1",
+      engine: "MYSQL",
+      environment: "environments/prod",
+    });
+  });
+
+  test("omits database context when neither resource exists", async () => {
+    mocks.getOrFetchDatabaseByName.mockResolvedValue(unknownDatabase);
+
+    const context = await extractRouteContext(databaseRoute);
+
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenCalledTimes(2);
+    expect(context.database).toBeUndefined();
+  });
+});

--- a/frontend/src/modules/agent/logic/context.ts
+++ b/frontend/src/modules/agent/logic/context.ts
@@ -1,5 +1,6 @@
 import type { ReactRoute } from "@/app/router";
 import { useAppStore } from "@/stores/app";
+import { isValidDatabaseName } from "@/types";
 import { Engine, IssueStatus, State } from "@/types/proto-es/v1/common_pb";
 import { Issue_Type } from "@/types/proto-es/v1/issue_service_pb";
 
@@ -56,10 +57,19 @@ export async function extractRouteContext(
   // Database context
   if (instanceId && databaseName) {
     try {
-      const db = useAppStore
+      let db = await useAppStore
         .getState()
-        .getDatabaseByName(`instances/${instanceId}/databases/${databaseName}`);
-      if (db?.name) {
+        .getOrFetchDatabaseByName(
+          `instances/${instanceId}/databases/${databaseName}`
+        );
+      if (!isValidDatabaseName(db.name) && projectId) {
+        db = await useAppStore
+          .getState()
+          .getOrFetchDatabaseByName(
+            `projects/${projectId}/instances/${instanceId}/databases/${databaseName}`
+          );
+      }
+      if (isValidDatabaseName(db.name)) {
         ctx.database = {
           name: db.name,
           engine: db.instanceResource

--- a/frontend/src/modules/sql-editor/components/ConnectionPane/actions.tsx
+++ b/frontend/src/modules/sql-editor/components/ConnectionPane/actions.tsx
@@ -7,7 +7,6 @@ import {
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { router } from "@/app/router";
-import { PROJECT_V1_ROUTE_DATABASE_DETAIL } from "@/app/router/handles";
 import { useSQLEditorAllowAdmin } from "@/modules/sql-editor/hooks/useSQLEditorState";
 import { sqlEditorEvents } from "@/modules/sql-editor/model/events";
 import { useSQLEditorStore } from "@/modules/sql-editor/store";
@@ -25,9 +24,8 @@ import {
 } from "@/types";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
+  autoDatabaseRoute,
   extractDatabaseResourceName,
-  extractInstanceResourceName,
-  extractProjectResourceName,
   getInstanceResource,
   instanceV1HasAlterSchema,
   instanceV1HasReadonlyMode,
@@ -159,22 +157,12 @@ export function useConnectionMenu(node: SQLEditorTreeNode | null) {
 
     if (type === "database") {
       const database = target as Database;
-      const { instance, databaseName } = extractDatabaseResourceName(
-        database.name
-      );
       out.push({
         key: "view-database-detail",
         label: t("sql-editor.view-database-detail"),
         icon: <ExternalLink className="size-4" />,
         onSelect: () => {
-          const route = router.resolve({
-            name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-            params: {
-              projectId: extractProjectResourceName(database.project),
-              instanceId: extractInstanceResourceName(instance),
-              databaseName,
-            },
-          });
+          const route = router.resolve(autoDatabaseRoute(database));
           window.open(route.href, "_blank");
         },
       });

--- a/frontend/src/modules/sql-editor/components/SQLEditorRouteShell.test.tsx
+++ b/frontend/src/modules/sql-editor/components/SQLEditorRouteShell.test.tsx
@@ -49,6 +49,9 @@ const mocks = vi.hoisted(() => {
       name,
       project: "projects/proj1",
     })),
+    fetchInstance: vi.fn<
+      (name: string) => Promise<{ name: string } | undefined>
+    >(async (name: string) => ({ name })),
     getWorksheetByName: vi.fn(),
     getOrFetchWorksheetByName: vi.fn(),
     searchProjects: vi.fn(),
@@ -140,6 +143,7 @@ vi.mock("@/stores/app", () => ({
   useAppStore: {
     getState: () => ({
       getOrFetchDatabaseByName: mocks.getOrFetchDatabaseByName,
+      fetchInstance: mocks.fetchInstance,
       getWorksheetByName: mocks.getWorksheetByName,
       getOrFetchWorksheetByName: mocks.getOrFetchWorksheetByName,
       searchProjects: mocks.searchProjects,
@@ -234,6 +238,7 @@ beforeEach(() => {
     name,
     project: "projects/proj1",
   }));
+  mocks.fetchInstance.mockImplementation(async (name: string) => ({ name }));
   mocks.getWorksheetByName.mockImplementation((name: string) => ({
     name,
     project: "projects/proj1",
@@ -380,6 +385,114 @@ describe("SQLEditorRouteShell", () => {
         table: "users",
       },
       mode: "WORKSHEET",
+    });
+
+    unmount();
+  });
+
+  test("resolves a project instance database without a parent query", async () => {
+    const parent = "projects/proj1/instances/inst1";
+    mocks.getOrFetchDatabaseByName.mockImplementation(async (name: string) =>
+      name.startsWith("projects/")
+        ? { name, project: "projects/proj1" }
+        : {
+            name: "instances/-1/databases/-1",
+            project: "projects/-1",
+          }
+    );
+
+    const { unmount } = renderShell();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenNthCalledWith(
+      1,
+      "instances/inst1/databases/db1"
+    );
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenNthCalledWith(
+      2,
+      `${parent}/databases/db1`
+    );
+    expect(mocks.tabsState.addTab).toHaveBeenCalledWith({
+      connection: {
+        instance: parent,
+        database: `${parent}/databases/db1`,
+        schema: "public",
+        table: "users",
+      },
+      mode: "WORKSHEET",
+    });
+    expect(mocks.navigateReplace).toHaveBeenCalledWith({
+      name: "sql-editor.database",
+      params: {
+        project: "proj1",
+        instance: "inst1",
+        database: "db1",
+      },
+      query: {
+        table: "users",
+        schema: "public",
+      },
+    });
+
+    unmount();
+  });
+
+  test("restores a project instance connection without a parent query", async () => {
+    const parent = "projects/proj1/instances/inst1";
+    mocks.fetchInstance.mockImplementation(async (name: string) =>
+      name.startsWith("projects/") ? { name } : undefined
+    );
+    mocks.renderRoute = {
+      ...mocks.renderRoute,
+      name: "sql-editor.instance",
+      params: {
+        project: "proj1",
+        instance: "inst1",
+      },
+      query: {},
+    };
+    mocks.currentRoute = {
+      ...mocks.currentRoute,
+      name: "sql-editor.instance",
+      params: {
+        project: "proj1",
+        instance: "inst1",
+      },
+      query: {},
+    };
+
+    const { unmount } = renderShell();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mocks.fetchInstance).toHaveBeenNthCalledWith(
+      1,
+      "instances/inst1"
+    );
+    expect(mocks.fetchInstance).toHaveBeenNthCalledWith(2, parent);
+    expect(mocks.tabsState.addTab).toHaveBeenCalledWith({
+      connection: {
+        instance: parent,
+        database: "",
+      },
+      mode: "WORKSHEET",
+    });
+    expect(mocks.navigateReplace).toHaveBeenCalledWith({
+      name: "sql-editor.instance",
+      params: {
+        project: "proj1",
+        instance: "inst1",
+      },
+      query: {},
     });
 
     unmount();

--- a/frontend/src/modules/sql-editor/components/SQLEditorRouteShell.tsx
+++ b/frontend/src/modules/sql-editor/components/SQLEditorRouteShell.tsx
@@ -41,6 +41,7 @@ import {
   type SQLEditorConnection,
 } from "@/types";
 import {
+  autoSQLEditorDatabaseRoute,
   extractDatabaseResourceName,
   extractInstanceResourceName,
   extractProjectResourceName,
@@ -258,16 +259,45 @@ export function SQLEditorRouteShell() {
     ) {
       return false;
     }
-    const databaseName = `instances/${route.params.instance}/databases/${route.params.database}`;
-    if (!isValidDatabaseName(databaseName)) return false;
-    const database = await useAppStore
+    const instanceId = route.params.instance;
+    if (typeof instanceId !== "string" || !instanceId) return false;
+    const projectId = route.params.project;
+    if (typeof projectId !== "string" || !projectId) return false;
+
+    if (route.name === SQL_EDITOR_INSTANCE_MODULE) {
+      let instance = await useAppStore
+        .getState()
+        .fetchInstance(`instances/${instanceId}`);
+      if (!instance || !isValidInstanceName(instance.name)) {
+        instance = await useAppStore
+          .getState()
+          .fetchInstance(`projects/${projectId}/instances/${instanceId}`);
+      }
+      if (!instance || !isValidInstanceName(instance.name)) return false;
+      getSQLEditorTabsState().addTab({
+        connection: {
+          instance: instance.name,
+          database: "",
+        },
+        mode: DEFAULT_SQL_EDITOR_TAB_MODE,
+      });
+      return true;
+    }
+
+    const databaseId = route.params.database;
+    if (typeof databaseId !== "string" || !databaseId) return false;
+    let database = await useAppStore
       .getState()
-      .getOrFetchDatabaseByName(databaseName);
-    // The app-store getter returns the `unknownDatabase` fallback (rather
-    // than throwing) when the database can't be resolved — e.g. a bookmarked
-    // URL to a deleted or no-longer-readable database. Bail so bootstrap
-    // falls back to the default project instead of opening a bogus
-    // `instances/-1/databases/-1` connection.
+      .getOrFetchDatabaseByName(
+        `instances/${instanceId}/databases/${databaseId}`
+      );
+    if (!isValidDatabaseName(database.name)) {
+      database = await useAppStore
+        .getState()
+        .getOrFetchDatabaseByName(
+          `projects/${projectId}/instances/${instanceId}/databases/${databaseId}`
+        );
+    }
     if (!isValidDatabaseName(database.name)) return false;
     if (
       getSQLEditorEditorState().project !== database.project &&
@@ -436,6 +466,7 @@ export function SQLEditorRouteShell() {
     const query = omit(
       currentRoute.query,
       "filter",
+      "parent",
       "project",
       "schema",
       "database",
@@ -494,14 +525,9 @@ export function SQLEditorRouteShell() {
           query.table = vals.table;
           query.schema = vals.schema ?? "";
         }
-        const dbResource = extractDatabaseResourceName(database.name);
+        const route = autoSQLEditorDatabaseRoute(database);
         await navigate.replace({
-          name: SQL_EDITOR_DATABASE_MODULE,
-          params: {
-            project: extractProjectResourceName(database.project),
-            instance: extractInstanceResourceName(dbResource.instance),
-            database: dbResource.databaseName,
-          },
+          ...route,
           query,
         });
         return;

--- a/frontend/src/modules/sql-editor/components/SchemaPane/actions.test.tsx
+++ b/frontend/src/modules/sql-editor/components/SchemaPane/actions.test.tsx
@@ -9,6 +9,7 @@ import type { NodeTarget, NodeType, TreeNode } from "./schemaTree";
 
 const mocks = vi.hoisted(() => {
   return {
+    resolve: vi.fn(() => ({ href: "/sql-editor/db" })),
     getDatabaseByName: vi.fn(() => ({
       name: "instances/i/databases/db",
       project: "projects/p",
@@ -87,6 +88,14 @@ vi.mock("@/utils", () => ({
   // Stub everything actions.tsx imports. We don't `importOriginal` here
   // because the real `@/utils` transitively pulls in monaco / vue
   // surfaces that vitest can't load.
+  autoSQLEditorDatabaseRoute: () => ({
+    name: "sql-editor.database",
+    params: {
+      project: "p",
+      instance: "i",
+      database: "db",
+    },
+  }),
   defaultSQLEditorTab: () => ({
     id: "new",
     title: "Untitled",
@@ -133,7 +142,7 @@ vi.mock("@/types/proto-es/v1/database_service_pb", () => ({
 vi.mock("@/app/router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/app/router")>()),
   router: {
-    resolve: () => ({ href: "/sql-editor/db" }),
+    resolve: mocks.resolve,
   },
 }));
 
@@ -240,6 +249,19 @@ describe("useSchemaPaneContextMenu", () => {
       "generate-sql--update",
       "generate-sql--delete",
     ]);
+    items.find((item) => item.key === "copy-url")?.onSelect?.();
+    expect(mocks.resolve).toHaveBeenCalledWith({
+      name: "sql-editor.database",
+      params: {
+        project: "p",
+        instance: "i",
+        database: "db",
+      },
+      query: {
+        table: "users",
+        schema: "public",
+      },
+    });
   });
 
   test("view node yields copy-name + view-schema-text + preview-table + generate-sql(SELECT only) + view-detail", () => {

--- a/frontend/src/modules/sql-editor/components/SchemaPane/actions.tsx
+++ b/frontend/src/modules/sql-editor/components/SchemaPane/actions.tsx
@@ -16,7 +16,6 @@ import type { ReactNode } from "react";
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { router } from "@/app/router";
-import { SQL_EDITOR_DATABASE_MODULE } from "@/app/router/handles";
 import { formatSQL } from "@/components/monaco/sqlFormatter";
 import { useExecuteSQL } from "@/hooks/useExecuteSQL";
 import { writeTextToClipboard } from "@/lib/clipboard";
@@ -41,10 +40,9 @@ import {
 } from "@/types/proto-es/v1/database_service_pb";
 import { defaultViewState } from "@/types/sqlEditor/tabViewState";
 import {
+  autoSQLEditorDatabaseRoute,
   defaultSQLEditorTab,
   extractDatabaseResourceName,
-  extractInstanceResourceName,
-  extractProjectResourceName,
   generateSimpleDeleteStatement,
   generateSimpleInsertStatement,
   generateSimpleSelectAllStatement,
@@ -523,16 +521,9 @@ export function useSchemaPaneContextMenu(
           label: t("sql-editor.copy-url"),
           icon: <LinkIcon className="size-4" />,
           onSelect: () => {
-            const { instance, databaseName } = extractDatabaseResourceName(
-              db.name
-            );
+            const databaseRoute = autoSQLEditorDatabaseRoute(db);
             const route = router.resolve({
-              name: SQL_EDITOR_DATABASE_MODULE,
-              params: {
-                project: extractProjectResourceName(db.project),
-                instance: extractInstanceResourceName(instance),
-                database: databaseName,
-              },
+              ...databaseRoute,
               query: { table, schema },
             });
             const url = new URL(route.href, window.location.origin).href;

--- a/frontend/src/routes/project/DatabaseChangelogDetailPage.test.tsx
+++ b/frontend/src/routes/project/DatabaseChangelogDetailPage.test.tsx
@@ -212,6 +212,18 @@ vi.mock("@/utils/v1/project", () => ({
 }));
 
 vi.mock("@/utils", () => ({
+  autoDatabaseRoute: (database: { name: string; project: string }) => {
+    const parent = database.name.split("/databases/")[0];
+    return {
+      name: mocks.projectRouteNames.databaseDetail,
+      params: {
+        projectId: database.project.split("/").at(-1),
+        instanceId: parent.split("/instances/").at(-1),
+        databaseName: database.name.split("/databases/").at(-1),
+      },
+      query: { parent },
+    };
+  },
   bytesToString: (size: number) => `${size} B`,
   formatAbsoluteDateTime: () => "formatted time",
   extractDatabaseResourceName: (name: string) => ({

--- a/frontend/src/routes/project/DatabaseChangelogDetailPage.tsx
+++ b/frontend/src/routes/project/DatabaseChangelogDetailPage.tsx
@@ -5,8 +5,6 @@ import { useTranslation } from "react-i18next";
 import { rolloutServiceClientConnect } from "@/api";
 import { router } from "@/app/router";
 import {
-  PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL,
-  PROJECT_V1_ROUTE_DATABASE_DETAIL,
   PROJECT_V1_ROUTE_DATABASES,
   PROJECT_V1_ROUTE_SYNC_SCHEMA,
 } from "@/app/router/handles";
@@ -29,6 +27,7 @@ import {
   TaskRunLogEntry_Type,
 } from "@/types/proto-es/v1/rollout_service_pb";
 import {
+  autoDatabaseRoute,
   bytesToString,
   extractDatabaseResourceName,
   formatAbsoluteDateTime,
@@ -43,6 +42,7 @@ export interface DatabaseChangelogDetailPageProps {
   instanceId: string;
   databaseName: string;
   changelogId: string;
+  routeQuery?: Record<string, string | undefined>;
 }
 
 function ChangelogStatusIndicator({ status }: { status: Changelog_Status }) {
@@ -129,8 +129,14 @@ export function DatabaseChangelogDetailPage({
   instanceId,
   databaseName,
   changelogId,
+  routeQuery,
 }: DatabaseChangelogDetailPageProps) {
   const { t } = useTranslation();
+  const parent = routeQuery?.parent ?? `instances/${instanceId}`;
+  const databaseRouteQuery = useMemo(
+    () => ({ ...routeQuery, parent }),
+    [parent, routeQuery]
+  );
   const getOrFetchChangelogByName = useAppStore(
     (state) => state.getOrFetchChangelogByName
   );
@@ -146,11 +152,10 @@ export function DatabaseChangelogDetailPage({
   >(undefined);
 
   const detail = useProjectDatabaseDetail({
+    parent,
     projectId,
     instanceId,
     databaseName,
-    routeName: PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL,
-    changelogId,
   });
   const changelogName = `${detail.databaseName}/changelogs/${changelogId}`;
 
@@ -343,6 +348,15 @@ export function DatabaseChangelogDetailPage({
     return null;
   }
 
+  const baseDatabaseRoute = autoDatabaseRoute(detail.database);
+  const databaseRoute = {
+    ...baseDatabaseRoute,
+    query: {
+      ...databaseRouteQuery,
+      ...baseDatabaseRoute.query,
+    },
+  };
+
   return (
     <div className="flex min-h-full flex-col gap-y-4 p-4">
       <nav aria-label="Breadcrumb" className="mb-4">
@@ -361,14 +375,7 @@ export function DatabaseChangelogDetailPage({
           <li aria-hidden="true">/</li>
           <li>
             <RouterLink
-              to={{
-                name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-                params: {
-                  projectId,
-                  instanceId,
-                  databaseName,
-                },
-              }}
+              to={databaseRoute}
               className="transition-colors hover:text-accent"
             >
               {databaseDisplayName}
@@ -378,12 +385,7 @@ export function DatabaseChangelogDetailPage({
           <li>
             <RouterLink
               to={{
-                name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-                params: {
-                  projectId,
-                  instanceId,
-                  databaseName,
-                },
+                ...databaseRoute,
                 hash: "#changelog",
               }}
               className="transition-colors hover:text-accent"

--- a/frontend/src/routes/project/DatabaseRevisionDetailPage.test.tsx
+++ b/frontend/src/routes/project/DatabaseRevisionDetailPage.test.tsx
@@ -74,6 +74,21 @@ vi.mock("./database-detail/useProjectDatabaseDetail", () => ({
   useProjectDatabaseDetail: mocks.useProjectDatabaseDetail,
 }));
 
+vi.mock("@/utils", () => ({
+  autoDatabaseRoute: (database: { name: string; project: string }) => {
+    const parent = database.name.split("/databases/")[0];
+    return {
+      name: mocks.routeNames.databaseDetail,
+      params: {
+        projectId: database.project.split("/").at(-1),
+        instanceId: parent.split("/instances/").at(-1),
+        databaseName: database.name.split("/databases/").at(-1),
+      },
+      query: { parent },
+    };
+  },
+}));
+
 vi.mock("@/utils/v1/database", () => ({
   extractDatabaseResourceName: mocks.extractDatabaseResourceName,
 }));
@@ -180,10 +195,11 @@ describe("DatabaseRevisionDetailPage", () => {
   test("builds the revision name from the resolved database detail", async () => {
     mocks.useProjectDatabaseDetail.mockReturnValue({
       database: {
-        name: "instances/inst1/databases/db-from-hook",
+        name: "projects/proj1/instances/inst1/databases/db-from-hook",
         project: "projects/proj1",
       },
-      databaseName: "instances/inst1/databases/db-from-hook",
+      databaseName:
+        "projects/proj1/instances/inst1/databases/db-from-hook",
       loading: false,
       ready: true,
       allowAlterSchema: true,
@@ -195,6 +211,9 @@ describe("DatabaseRevisionDetailPage", () => {
         instanceId: "inst1",
         databaseName: "db-from-prop",
         revisionId: "7",
+        routeQuery: {
+          parent: "projects/proj1/instances/inst1",
+        },
       })
     );
 
@@ -206,19 +225,19 @@ describe("DatabaseRevisionDetailPage", () => {
     });
 
     expect(mocks.useProjectDatabaseDetail).toHaveBeenCalledWith({
+      parent: "projects/proj1/instances/inst1",
       projectId: "proj1",
       instanceId: "inst1",
       databaseName: "db-from-prop",
-      routeName: mocks.routeNames.databaseRevisionDetail,
-      revisionId: "7",
     });
     expect(mocks.RevisionDetailPanel).toHaveBeenCalled();
     expect(mocks.RevisionDetailPanel.mock.calls[0]?.[0]).toEqual({
-      revisionName: "instances/inst1/databases/db-from-hook/revisions/7",
+      revisionName:
+        "projects/proj1/instances/inst1/databases/db-from-hook/revisions/7",
     });
 
     expect(container.textContent).toContain(
-      "instances/inst1/databases/db-from-hook/revisions/7"
+      "projects/proj1/instances/inst1/databases/db-from-hook/revisions/7"
     );
 
     const clickBreadcrumb = async (label: string) => {
@@ -247,8 +266,9 @@ describe("DatabaseRevisionDetailPage", () => {
       params: {
         projectId: "proj1",
         instanceId: "inst1",
-        databaseName: "db-from-prop",
+        databaseName: "db-from-hook",
       },
+      query: { parent: "projects/proj1/instances/inst1" },
     });
 
     await clickBreadcrumb("database.revision.self");
@@ -257,9 +277,10 @@ describe("DatabaseRevisionDetailPage", () => {
       params: {
         projectId: "proj1",
         instanceId: "inst1",
-        databaseName: "db-from-prop",
+        databaseName: "db-from-hook",
       },
       hash: "#revision",
+      query: { parent: "projects/proj1/instances/inst1" },
     });
 
     const databaseBreadcrumb = Array.from(container.querySelectorAll("a")).find(

--- a/frontend/src/routes/project/DatabaseRevisionDetailPage.tsx
+++ b/frontend/src/routes/project/DatabaseRevisionDetailPage.tsx
@@ -1,12 +1,9 @@
 import { LoaderCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import {
-  PROJECT_V1_ROUTE_DATABASE_DETAIL,
-  PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
-  PROJECT_V1_ROUTE_DATABASES,
-} from "@/app/router/handles";
+import { PROJECT_V1_ROUTE_DATABASES } from "@/app/router/handles";
 import { RouterLink } from "@/components/RouterLink";
 import { RevisionDetailPanel } from "@/components/revision";
+import { autoDatabaseRoute } from "@/utils";
 import { useProjectDatabaseDetail } from "./database-detail/useProjectDatabaseDetail";
 
 export function DatabaseRevisionDetailPage({
@@ -14,21 +11,45 @@ export function DatabaseRevisionDetailPage({
   instanceId,
   databaseName,
   revisionId,
+  routeQuery,
 }: {
   projectId: string;
   instanceId: string;
   databaseName: string;
   revisionId: string;
+  routeQuery?: Record<string, string | undefined>;
 }) {
   const { t } = useTranslation();
+  const parent = routeQuery?.parent ?? `instances/${instanceId}`;
+  const databaseRouteQuery = { ...routeQuery, parent };
   const detail = useProjectDatabaseDetail({
+    parent,
     projectId,
     instanceId,
     databaseName,
-    routeName: PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
-    revisionId,
   });
   const revisionName = `${detail.databaseName}/revisions/${revisionId}`;
+
+  if (detail.loading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <LoaderCircle className="h-4 w-4 animate-spin text-control-light" />
+      </div>
+    );
+  }
+
+  if (!detail.ready) {
+    return null;
+  }
+
+  const baseDatabaseRoute = autoDatabaseRoute(detail.database);
+  const databaseRoute = {
+    ...baseDatabaseRoute,
+    query: {
+      ...databaseRouteQuery,
+      ...baseDatabaseRoute.query,
+    },
+  };
 
   return (
     <div className="flex min-h-full flex-col gap-y-4 p-4">
@@ -48,14 +69,7 @@ export function DatabaseRevisionDetailPage({
           <li aria-hidden="true">/</li>
           <li>
             <RouterLink
-              to={{
-                name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-                params: {
-                  projectId,
-                  instanceId,
-                  databaseName,
-                },
-              }}
+              to={databaseRoute}
               className="transition-colors hover:text-accent"
             >
               {databaseName}
@@ -65,12 +79,7 @@ export function DatabaseRevisionDetailPage({
           <li>
             <RouterLink
               to={{
-                name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-                params: {
-                  projectId,
-                  instanceId,
-                  databaseName,
-                },
+                ...databaseRoute,
                 hash: "#revision",
               }}
               className="transition-colors hover:text-accent"
@@ -83,13 +92,7 @@ export function DatabaseRevisionDetailPage({
         </ol>
       </nav>
 
-      {detail.loading ? (
-        <div className="flex items-center justify-center py-10">
-          <LoaderCircle className="h-4 w-4 animate-spin text-control-light" />
-        </div>
-      ) : (
-        <RevisionDetailPanel revisionName={revisionName} />
-      )}
+      <RevisionDetailPanel revisionName={revisionName} />
     </div>
   );
 }

--- a/frontend/src/routes/project/ProjectAccessGrantsPage.tsx
+++ b/frontend/src/routes/project/ProjectAccessGrantsPage.tsx
@@ -122,7 +122,7 @@ function getValueFromScopes(params: SearchParams, id: string): string {
 }
 
 function mapDatabase(db: Database) {
-  const { database: dbName } = extractDatabaseResourceName(db.name);
+  const { databaseName: dbName } = extractDatabaseResourceName(db.name);
   const inst = db.instanceResource;
   const envId = (db.effectiveEnvironment ?? db.environment ?? "")
     .split("/")

--- a/frontend/src/routes/project/ProjectDatabaseDetailPage.test.tsx
+++ b/frontend/src/routes/project/ProjectDatabaseDetailPage.test.tsx
@@ -610,8 +610,8 @@ describe("ProjectDatabaseDetailPage", () => {
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
-        hash: `#${PROJECT_DATABASE_DETAIL_TAB_REVISION}`,
-        query: { foo: "bar", page: "2" },
+        routeHash: `#${PROJECT_DATABASE_DETAIL_TAB_REVISION}`,
+        routeQuery: { foo: "bar", page: "2" },
       })
     );
 
@@ -704,7 +704,7 @@ describe("ProjectDatabaseDetailPage", () => {
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
-        hash: "#not-a-real-tab",
+        routeHash: "#not-a-real-tab",
       })
     );
 
@@ -754,7 +754,7 @@ describe("ProjectDatabaseDetailPage", () => {
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
-        query: { foo: "bar" },
+        routeQuery: { foo: "bar" },
       })
     );
 
@@ -890,7 +890,7 @@ describe("ProjectDatabaseDetailPage", () => {
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
-        hash: "#changelog",
+        routeHash: "#changelog",
       })
     );
 
@@ -930,7 +930,7 @@ describe("ProjectDatabaseDetailPage", () => {
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
-        hash: "#changelog",
+        routeHash: "#changelog",
       })
     );
 
@@ -970,7 +970,7 @@ describe("ProjectDatabaseDetailPage", () => {
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
-        hash: "#revision",
+        routeHash: "#revision",
       })
     );
 
@@ -1010,7 +1010,7 @@ describe("ProjectDatabaseDetailPage", () => {
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
-        hash: "#catalog",
+        routeHash: "#catalog",
       })
     );
 
@@ -1145,8 +1145,8 @@ describe("ProjectDatabaseDetailPage", () => {
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
-        hash: `#${PROJECT_DATABASE_DETAIL_TAB_REVISION}`,
-        query: { foo: "bar", page: "2" },
+        routeHash: `#${PROJECT_DATABASE_DETAIL_TAB_REVISION}`,
+        routeQuery: { foo: "bar", page: "2" },
       })
     );
 

--- a/frontend/src/routes/project/ProjectDatabaseDetailPage.test.tsx
+++ b/frontend/src/routes/project/ProjectDatabaseDetailPage.test.tsx
@@ -623,11 +623,10 @@ describe("ProjectDatabaseDetailPage", () => {
     });
 
     expect(mocks.useProjectDatabaseDetail).toHaveBeenCalledWith({
+      parent: "instances/inst1",
       projectId: "proj1",
       instanceId: "inst1",
       databaseName: "db1",
-      hash: `#${PROJECT_DATABASE_DETAIL_TAB_REVISION}`,
-      query: { foo: "bar", page: "2" },
     });
     expect(container.querySelector('[data-testid="tabs"]')).not.toBeNull();
     expect(
@@ -668,7 +667,7 @@ describe("ProjectDatabaseDetailPage", () => {
         databaseName: "db1",
       },
       hash: "#changelog",
-      query: { foo: "bar", page: "2" },
+      query: { foo: "bar", page: "2", parent: "instances/inst1" },
     });
     expect(
       container
@@ -793,7 +792,7 @@ describe("ProjectDatabaseDetailPage", () => {
         databaseName: "db1",
       },
       hash: `#${PROJECT_DATABASE_DETAIL_TAB_SETTING}`,
-      query: { foo: "bar" },
+      query: { foo: "bar", parent: "instances/inst1" },
     });
 
     unmount();
@@ -1197,7 +1196,7 @@ describe("ProjectDatabaseDetailPage", () => {
         databaseName: "db1",
       },
       hash: `#${PROJECT_DATABASE_DETAIL_TAB_REVISION}`,
-      query: { foo: "bar", page: "2" },
+      query: { foo: "bar", page: "2", parent: "instances/inst1" },
     });
 
     unmount();

--- a/frontend/src/routes/project/ProjectDatabaseDetailPage.tsx
+++ b/frontend/src/routes/project/ProjectDatabaseDetailPage.tsx
@@ -1,10 +1,9 @@
 import { create } from "@bufbuild/protobuf";
 import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import { LoaderCircle } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { router } from "@/app/router";
-import { PROJECT_V1_ROUTE_DATABASE_DETAIL } from "@/app/router/handles";
 import { ComponentPermissionGuard } from "@/components/ComponentPermissionGuard";
 import { TransferProjectSheet } from "@/components/database";
 import { Alert } from "@/components/ui/alert";
@@ -18,7 +17,7 @@ import {
   DatabaseSchema$,
   UpdateDatabaseRequestSchema,
 } from "@/types/proto-es/v1/database_service_pb";
-import { getDatabaseProject } from "@/utils";
+import { autoDatabaseRoute, getDatabaseProject } from "@/utils";
 import { DatabaseDetailActions } from "./database-detail/DatabaseDetailActions";
 import { DatabaseDetailHeader } from "./database-detail/DatabaseDetailHeader";
 import { DatabaseCatalogPanel } from "./database-detail/panels/DatabaseCatalogPanel";
@@ -37,57 +36,38 @@ import {
 } from "./database-detail/tabs";
 import { useProjectDatabaseDetail } from "./database-detail/useProjectDatabaseDetail";
 
-const buildDatabaseDetailRoute = (
-  database: {
-    name: string;
-    project: string;
-  },
-  options?: {
-    hash?: string;
-    query?: Record<string, string | undefined>;
-  }
-) => {
-  const databaseMatches = database.name.match(
-    /(?:^|\/)instances\/(?<instanceId>[^/]+)\/databases\/(?<databaseName>[^/]+)(?:$|\/)/
-  );
-  const projectMatches = database.project.match(
-    /(?:^|\/)projects\/(?<projectId>[^/]+)(?:$|\/)/
-  );
-
-  return {
-    name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-    params: {
-      projectId: projectMatches?.groups?.projectId ?? "",
-      instanceId: databaseMatches?.groups?.instanceId ?? "",
-      databaseName: databaseMatches?.groups?.databaseName ?? "",
-    },
-    hash: options?.hash,
-    query: options?.query,
-  };
-};
-
 export interface ProjectDatabaseDetailPageProps {
   projectId: string;
   instanceId: string;
   databaseName: string;
   hash?: string;
   query?: Record<string, string | undefined>;
+  routeHash?: string;
+  routeQuery?: Record<string, string | undefined>;
 }
 
 export function ProjectDatabaseDetailPage({
   projectId,
   instanceId,
   databaseName,
-  hash,
-  query,
+  hash: hashProp,
+  query: queryProp,
+  routeHash,
+  routeQuery,
 }: ProjectDatabaseDetailPageProps) {
   const { t } = useTranslation();
+  const hash = routeHash ?? hashProp;
+  const query = routeQuery ?? queryProp;
+  const parent = query?.parent ?? `instances/${instanceId}`;
+  const databaseRouteQuery = useMemo(
+    () => ({ ...query, parent }),
+    [parent, query]
+  );
   const detail = useProjectDatabaseDetail({
+    parent,
     projectId,
     instanceId,
     databaseName,
-    hash,
-    query,
   });
   const [selectedTab, setSelectedTab] = useState<ProjectDatabaseDetailTab>(() =>
     parseProjectDatabaseDetailTabHash(hash)
@@ -104,18 +84,17 @@ export function ProjectDatabaseDetailPage({
 
       const nextTab = parseProjectDatabaseDetailTabHash(tab);
       setSelectedTab(nextTab);
+      const databaseRoute = autoDatabaseRoute(detail.database);
       void router.replace({
-        name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-        params: {
-          projectId,
-          instanceId,
-          databaseName,
-        },
+        ...databaseRoute,
         hash: `#${nextTab}`,
-        query: query ?? {},
+        query: {
+          ...databaseRouteQuery,
+          ...databaseRoute.query,
+        },
       });
     },
-    [databaseName, instanceId, projectId, query]
+    [databaseRouteQuery, detail.database]
   );
 
   useEffect(() => {
@@ -158,12 +137,15 @@ export function ProjectDatabaseDetailPage({
           title: t("database.successfully-transferred-databases"),
         });
         setShowTransferDrawer(false);
-        void router.replace(
-          buildDatabaseDetailRoute(updatedDatabase, {
-            hash: `#${selectedTab}`,
-            query: query ?? {},
-          })
-        );
+        const databaseRoute = autoDatabaseRoute(updatedDatabase);
+        void router.replace({
+          ...databaseRoute,
+          hash: `#${selectedTab}`,
+          query: {
+            ...databaseRouteQuery,
+            ...databaseRoute.query,
+          },
+        });
       } catch {
         pushNotification({
           module: "bytebase",
@@ -172,7 +154,7 @@ export function ProjectDatabaseDetailPage({
         });
       }
     },
-    [detail.database, query, selectedTab, t]
+    [databaseRouteQuery, detail.database, selectedTab, t]
   );
 
   if (!detail.ready) {

--- a/frontend/src/routes/project/ProjectDatabaseDetailPage.tsx
+++ b/frontend/src/routes/project/ProjectDatabaseDetailPage.tsx
@@ -40,8 +40,6 @@ export interface ProjectDatabaseDetailPageProps {
   projectId: string;
   instanceId: string;
   databaseName: string;
-  hash?: string;
-  query?: Record<string, string | undefined>;
   routeHash?: string;
   routeQuery?: Record<string, string | undefined>;
 }
@@ -50,14 +48,10 @@ export function ProjectDatabaseDetailPage({
   projectId,
   instanceId,
   databaseName,
-  hash: hashProp,
-  query: queryProp,
-  routeHash,
-  routeQuery,
+  routeHash: hash,
+  routeQuery: query,
 }: ProjectDatabaseDetailPageProps) {
   const { t } = useTranslation();
-  const hash = routeHash ?? hashProp;
-  const query = routeQuery ?? queryProp;
   const parent = query?.parent ?? `instances/${instanceId}`;
   const databaseRouteQuery = useMemo(
     () => ({ ...query, parent }),

--- a/frontend/src/routes/project/ProjectDatabasesPage.test.tsx
+++ b/frontend/src/routes/project/ProjectDatabasesPage.test.tsx
@@ -8,7 +8,7 @@ import { preCreateIssue } from "@/lib/plan/issue";
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
 const mocks = vi.hoisted(() => ({
-  visibleDatabases: [] as { name: string }[],
+  visibleDatabases: [] as { name: string; project?: string }[],
   databasesByName: {} as Record<string, { name: string }>,
   instancesByName: {} as Record<string, { name: string; title: string }>,
   routerCurrentName: "workspace.project.database",
@@ -516,9 +516,14 @@ describe("ProjectDatabasesPage", () => {
     vi.useRealTimers();
   });
 
-  test("shows next action after redirected instance databases finish syncing", async () => {
+  test("opens a synced project instance database in SQL Editor", async () => {
     mocks.routerCurrentQuery = { syncingInstance: "prod" };
-    mocks.visibleDatabases = [{ name: "instances/prod/databases/app" }];
+    mocks.visibleDatabases = [
+      {
+        name: "projects/demo/instances/prod/databases/app",
+        project: "projects/demo",
+      },
+    ];
     const container = document.createElement("div");
     const root = createRoot(container);
 
@@ -561,7 +566,7 @@ describe("ProjectDatabasesPage", () => {
     });
 
     expect(preCreateIssue).toHaveBeenCalledWith("projects/demo", [
-      "instances/prod/databases/app",
+      "projects/demo/instances/prod/databases/app",
     ]);
 
     const sqlEditorButton = Array.from(

--- a/frontend/src/routes/project/ProjectDatabasesPage.tsx
+++ b/frontend/src/routes/project/ProjectDatabasesPage.tsx
@@ -9,7 +9,6 @@ import { router, useCurrentRoute } from "@/app/router";
 import {
   PROJECT_V1_ROUTE_DATABASES,
   PROJECT_V1_ROUTE_INSTANCE_CREATE,
-  SQL_EDITOR_DATABASE_MODULE,
 } from "@/app/router/handles";
 import { markListScrollRestorationEntry } from "@/app/router/NavigationScrollRestoration";
 import {
@@ -72,8 +71,8 @@ import {
 } from "@/types/proto-es/v1/database_service_pb";
 import { unknownDatabase } from "@/types/v1/database";
 import {
+  autoSQLEditorDatabaseRoute,
   engineNameV1,
-  extractDatabaseResourceName,
   extractInstanceResourceName,
   getDefaultPagination,
   hasProjectPermissionV2,
@@ -539,18 +538,8 @@ export function ProjectDatabasesPage({ projectId }: { projectId: string }) {
         resource: projectName,
       })
     );
-    const { instanceName, databaseName } = extractDatabaseResourceName(
-      firstDatabase.name
-    );
-    router.push({
-      name: SQL_EDITOR_DATABASE_MODULE,
-      params: {
-        project: projectId,
-        instance: instanceName,
-        database: databaseName,
-      },
-    });
-  }, [projectId, projectName, visibleDatabases]);
+    router.push(autoSQLEditorDatabaseRoute(firstDatabase));
+  }, [projectName, visibleDatabases]);
 
   useProductIntro({
     id: CONNECT_DATABASE_PRODUCT_INTRO,

--- a/frontend/src/routes/project/ProjectMaskingExemptionPage.tsx
+++ b/frontend/src/routes/project/ProjectMaskingExemptionPage.tsx
@@ -274,7 +274,7 @@ export function ProjectMaskingExemptionPage({
         filter: keyword ? { query: keyword } : undefined,
       });
       return result.databases.map((db) => {
-        const { database: dbName } = extractDatabaseResourceName(db.name);
+        const { databaseName: dbName } = extractDatabaseResourceName(db.name);
         return {
           value: db.name,
           keywords: [dbName, db.name],

--- a/frontend/src/routes/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/routes/project/ProjectSyncSchemaPage.tsx
@@ -70,7 +70,8 @@ import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { DiffSchemaRequestSchema } from "@/types/proto-es/v1/database_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import {
-  databaseV1Url,
+  autoDatabaseRoute,
+  databaseV1UrlWithSuffix,
   engineNameV1,
   extractChangelogUID,
   extractDatabaseResourceName,
@@ -1037,14 +1038,19 @@ function SourceSchemaInfo({
 
   const gotoDatabase = useCallback(() => {
     if (isValidDatabaseName(databaseFromChangelog.name)) {
-      window.open(databaseV1Url(databaseFromChangelog));
+      window.open(
+        router.resolve(autoDatabaseRoute(databaseFromChangelog)).href
+      );
     }
   }, [databaseFromChangelog]);
 
   const gotoChangelog = useCallback(() => {
     if (isValidChangelogName(changelogSourceSchema?.changelogName || "")) {
       window.open(
-        `${databaseV1Url(databaseFromChangelog)}/changelogs/${changelogUID}`
+        databaseV1UrlWithSuffix(
+          databaseFromChangelog,
+          `/changelogs/${changelogUID}`
+        )
       );
     }
   }, [databaseFromChangelog, changelogUID, changelogSourceSchema]);

--- a/frontend/src/routes/project/ProjectSyncSchemaPage.tsx
+++ b/frontend/src/routes/project/ProjectSyncSchemaPage.tsx
@@ -70,8 +70,8 @@ import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { DiffSchemaRequestSchema } from "@/types/proto-es/v1/database_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
 import {
+  autoDatabaseChangelogRoute,
   autoDatabaseRoute,
-  databaseV1UrlWithSuffix,
   engineNameV1,
   extractChangelogUID,
   extractDatabaseResourceName,
@@ -1047,10 +1047,9 @@ function SourceSchemaInfo({
   const gotoChangelog = useCallback(() => {
     if (isValidChangelogName(changelogSourceSchema?.changelogName || "")) {
       window.open(
-        databaseV1UrlWithSuffix(
-          databaseFromChangelog,
-          `/changelogs/${changelogUID}`
-        )
+        router.resolve(
+          autoDatabaseChangelogRoute(databaseFromChangelog, changelogUID ?? "")
+        ).href
       );
     }
   }, [databaseFromChangelog, changelogUID, changelogSourceSchema]);

--- a/frontend/src/routes/project/database-detail/DatabaseSQLEditorButton.tsx
+++ b/frontend/src/routes/project/database-detail/DatabaseSQLEditorButton.tsx
@@ -2,25 +2,10 @@ import { SquareTerminal } from "lucide-react";
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { router } from "@/app/router";
-import { SQL_EDITOR_DATABASE_MODULE } from "@/app/router/handles";
 import { useAppStore } from "@/stores/app";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import { defaultProject, isDefaultProject } from "@/types/v1/project";
-
-const extractDatabaseParts = (resource: string) => {
-  const matches = resource.match(
-    /(?:^|\/)instances\/(?<instanceName>[^/]+)\/databases\/(?<databaseName>[^/]+)(?:$|\/)/
-  );
-  return {
-    instanceName: matches?.groups?.instanceName ?? "",
-    databaseName: matches?.groups?.databaseName ?? "",
-  };
-};
-
-const extractProjectId = (resource: string) => {
-  const matches = resource.match(/(?:^|\/)projects\/([^/]+)(?:$|\/)/);
-  return matches?.[1] ?? "";
-};
+import { autoSQLEditorDatabaseRoute } from "@/utils";
 
 export function DatabaseSQLEditorButton({
   database,
@@ -57,15 +42,7 @@ export function DatabaseSQLEditorButton({
       }
     }
 
-    const { instanceName, databaseName } = extractDatabaseParts(database.name);
-    const route = router.resolve({
-      name: SQL_EDITOR_DATABASE_MODULE,
-      params: {
-        project: extractProjectId(database.project),
-        instance: instanceName,
-        database: databaseName,
-      },
-    });
+    const route = router.resolve(autoSQLEditorDatabaseRoute(database));
 
     if (router.currentRoute.value.name?.toString().startsWith("sql-editor")) {
       void router.push(route);

--- a/frontend/src/routes/project/database-detail/catalog/SensitiveColumnTable.tsx
+++ b/frontend/src/routes/project/database-detail/catalog/SensitiveColumnTable.tsx
@@ -199,6 +199,7 @@ export function SensitiveColumnTable({
           ) : (
             columnList.map((item) => {
               const key = itemKey(item);
+              const databaseRoute = autoDatabaseRoute(database);
               const isChecked = checkedKeySet.has(key);
               const semanticTypeDisabled =
                 !canEdit || !!item.disableSemanticType;
@@ -223,8 +224,9 @@ export function SensitiveColumnTable({
                     <RouterLink
                       className="normal-link"
                       to={{
-                        ...autoDatabaseRoute(database),
+                        ...databaseRoute,
                         query: {
+                          ...databaseRoute.query,
                           schema: item.schema,
                           table: item.table,
                         },

--- a/frontend/src/routes/project/database-detail/useProjectDatabaseDetail.test.tsx
+++ b/frontend/src/routes/project/database-detail/useProjectDatabaseDetail.test.tsx
@@ -53,7 +53,9 @@ vi.mock("@/app/router", async (importOriginal) => ({
   router: { replace: mocks.replace },
 }));
 
-vi.mock("@/stores", () => ({}));
+vi.mock("@/stores", () => ({
+  environmentNamePrefix: "environments/",
+}));
 
 // Build the `databasesByName` cache the hook subscribes to from the mocked
 // `getDatabaseByName` return value, keyed by its `name`.
@@ -82,6 +84,18 @@ vi.mock("@/stores/app", () => {
 });
 
 vi.mock("@/utils", () => ({
+  autoDatabaseRoute: (database: { name: string; project: string }) => {
+    const parent = database.name.split("/databases/")[0];
+    return {
+      name: mocks.routeNames.databaseDetail,
+      params: {
+        projectId: database.project.split("/").at(-1),
+        instanceId: parent.split("/instances/").at(-1),
+        databaseName: database.name.split("/databases/").at(-1),
+      },
+      query: { parent },
+    };
+  },
   getInstanceResource: mocks.getInstanceResource,
   instanceV1HasAlterSchema: mocks.instanceV1HasAlterSchema,
 }));
@@ -186,6 +200,88 @@ afterEach(() => {
 });
 
 describe("useProjectDatabaseDetail", () => {
+  test("loads a project instance database by its nested resource name", async () => {
+    const database = {
+      name: "projects/proj1/instances/inst1/databases/db1",
+      project: "projects/proj1",
+    };
+    mocks.getDatabaseByName.mockReturnValue(database);
+    mocks.getOrFetchDatabaseByName.mockResolvedValue(database);
+    mocks.getOrFetchDatabaseMetadata.mockResolvedValue({});
+
+    let latest: ReturnType<typeof useProjectDatabaseDetail> | undefined;
+
+    const { render, unmount } = renderIntoContainer(
+      createElement(HookProbe, {
+        parent: "projects/proj1/instances/inst1",
+        projectId: "proj1",
+        instanceId: "inst1",
+        databaseName: "db1",
+        onValue: (value) => {
+          latest = value;
+        },
+      })
+    );
+
+    act(() => {
+      render();
+    });
+    await waitFor(() => latest?.ready === true);
+
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenCalledWith(
+      "projects/proj1/instances/inst1/databases/db1"
+    );
+    expect(mocks.getOrFetchDatabaseMetadata).toHaveBeenCalledWith({
+      database: "projects/proj1/instances/inst1/databases/db1",
+      silent: true,
+    });
+    expect(latest?.databaseName).toBe(
+      "projects/proj1/instances/inst1/databases/db1"
+    );
+    expect(mocks.replace).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  test("loads the database from the explicit parent on a direct visit", async () => {
+    const database = {
+      name: "projects/proj1/instances/inst1/databases/db1",
+      project: "projects/proj1",
+    };
+    mocks.getDatabaseByName.mockReturnValue(undefined);
+    mocks.getOrFetchDatabaseByName.mockImplementation(async () => {
+      mocks.getDatabaseByName.mockReturnValue(database);
+      return database;
+    });
+    mocks.getOrFetchDatabaseMetadata.mockResolvedValue({});
+
+    let latest: ReturnType<typeof useProjectDatabaseDetail> | undefined;
+
+    const { render, unmount } = renderIntoContainer(
+      createElement(HookProbe, {
+        parent: "projects/proj1/instances/inst1",
+        projectId: "proj1",
+        instanceId: "inst1",
+        databaseName: "db1",
+        onValue: (value) => {
+          latest = value;
+        },
+      })
+    );
+
+    act(() => {
+      render();
+    });
+    await waitFor(() => latest?.ready === true);
+
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenCalledOnce();
+    expect(mocks.getOrFetchDatabaseByName).toHaveBeenCalledWith(database.name);
+    expect(latest?.databaseName).toBe(database.name);
+    expect(mocks.replace).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
   test("loads the database and warms metadata", async () => {
     const database = {
       name: "instances/inst1/databases/db1",
@@ -199,6 +295,7 @@ describe("useProjectDatabaseDetail", () => {
 
     const { render, unmount } = renderIntoContainer(
       createElement(HookProbe, {
+        parent: "instances/inst1",
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
@@ -243,6 +340,7 @@ describe("useProjectDatabaseDetail", () => {
 
     const { render, unmount } = renderIntoContainer(
       createElement(HookProbe, {
+        parent: "instances/inst1",
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
@@ -265,22 +363,18 @@ describe("useProjectDatabaseDetail", () => {
 
   test("redirects to the canonical project route", async () => {
     const database = {
-      name: "instances/inst1/databases/db1",
+      name: "projects/proj2/instances/inst1/databases/db1",
       project: "projects/proj2",
     };
     mocks.getDatabaseByName.mockReturnValue(database);
     mocks.getOrFetchDatabaseByName.mockResolvedValue(database);
     mocks.getOrFetchDatabaseMetadata.mockResolvedValue({});
-
     const { render, unmount } = renderIntoContainer(
       createElement(HookProbe, {
+        parent: "projects/proj2/instances/inst1",
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
-        routeName: mocks.routeNames.databaseRevisionDetail,
-        revisionId: "123",
-        hash: "#revision",
-        query: { foo: "bar" },
         onValue: () => {},
       })
     );
@@ -291,80 +385,14 @@ describe("useProjectDatabaseDetail", () => {
     await waitFor(() => mocks.replace.mock.calls.length > 0);
 
     expect(mocks.replace).toHaveBeenCalledWith({
-      name: mocks.routeNames.databaseRevisionDetail,
+      name: mocks.routeNames.databaseDetail,
       params: {
         projectId: "proj2",
         instanceId: "inst1",
         databaseName: "db1",
-        revisionId: "123",
       },
-      hash: "#revision",
-      query: { foo: "bar" },
+      query: { parent: "projects/proj2/instances/inst1" },
     });
-
-    unmount();
-  });
-
-  test("does not refetch database detail when only hash or query changes", async () => {
-    const database = {
-      name: "instances/inst1/databases/db1",
-      project: "projects/proj1",
-    };
-    mocks.getDatabaseByName.mockReturnValue(database);
-    mocks.getOrFetchDatabaseByName.mockResolvedValue(database);
-    mocks.getOrFetchDatabaseMetadata.mockResolvedValue({});
-
-    let latest: ReturnType<typeof useProjectDatabaseDetail> | undefined;
-
-    const initialElement = createElement(HookProbe, {
-      projectId: "proj1",
-      instanceId: "inst1",
-      databaseName: "db1",
-      hash: "#overview",
-      query: { schema: "public" },
-      onValue: (value) => {
-        latest = value;
-      },
-    });
-    const { render, unmount } = renderIntoContainer(initialElement);
-
-    act(() => {
-      render();
-    });
-    await waitFor(() => mocks.getOrFetchDatabaseByName.mock.calls.length > 0);
-    await waitFor(() => mocks.getOrFetchDatabaseMetadata.mock.calls.length > 0);
-    await Promise.resolve();
-    await Promise.resolve();
-
-    const initialDatabaseFetchCount =
-      mocks.getOrFetchDatabaseByName.mock.calls.length;
-    const initialMetadataFetchCount =
-      mocks.getOrFetchDatabaseMetadata.mock.calls.length;
-
-    act(() => {
-      render(
-        createElement(HookProbe, {
-          projectId: "proj1",
-          instanceId: "inst1",
-          databaseName: "db1",
-          hash: "#revision",
-          query: { schema: "archive" },
-          onValue: (value) => {
-            latest = value;
-          },
-        })
-      );
-    });
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(mocks.getOrFetchDatabaseByName).toHaveBeenCalledTimes(
-      initialDatabaseFetchCount
-    );
-    expect(mocks.getOrFetchDatabaseMetadata).toHaveBeenCalledTimes(
-      initialMetadataFetchCount
-    );
-    expect(latest?.databaseName).toBe("instances/inst1/databases/db1");
 
     unmount();
   });

--- a/frontend/src/routes/project/database-detail/useProjectDatabaseDetail.ts
+++ b/frontend/src/routes/project/database-detail/useProjectDatabaseDetail.ts
@@ -1,42 +1,33 @@
 import { useEffect, useMemo, useState } from "react";
 import { router } from "@/app/router";
-import {
-  PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL,
-  PROJECT_V1_ROUTE_DATABASE_DETAIL,
-  PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
-} from "@/app/router/handles";
 import { useAppStore } from "@/stores/app";
 import { unknownDatabase } from "@/types/v1/database";
 import { isDefaultProject } from "@/types/v1/project";
-import { getInstanceResource, instanceV1HasAlterSchema } from "@/utils";
+import {
+  autoDatabaseRoute,
+  getInstanceResource,
+  instanceV1HasAlterSchema,
+} from "@/utils";
 import { extractProjectResourceName } from "@/utils/v1/project";
 
 export interface UseProjectDatabaseDetailOptions {
+  parent: string;
   projectId: string;
   instanceId: string;
   databaseName: string;
-  routeName?: string;
-  hash?: string;
-  query?: Record<string, string | undefined>;
-  changelogId?: string;
-  revisionId?: string;
 }
 
 export function useProjectDatabaseDetail({
+  parent,
   projectId,
   instanceId,
   databaseName,
-  routeName,
-  hash,
-  query,
-  changelogId,
-  revisionId,
 }: UseProjectDatabaseDetailOptions) {
   const getOrFetchDatabaseMetadata = useAppStore(
     (s) => s.getOrFetchDatabaseMetadata
   );
   const databasesByName = useAppStore((s) => s.databasesByName);
-  const fullDatabaseName = `instances/${instanceId}/databases/${databaseName}`;
+  const fullDatabaseName = `${parent}/databases/${databaseName}`;
   const database = useMemo(
     () => databasesByName[fullDatabaseName] ?? unknownDatabase(),
     [databasesByName, fullDatabaseName]
@@ -62,24 +53,7 @@ export function useProjectDatabaseDetail({
 
         const canonicalProjectId = extractProjectResourceName(db.project);
         if (canonicalProjectId !== projectId) {
-          const name =
-            routeName === PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL
-              ? PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL
-              : routeName === PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL
-                ? PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL
-                : PROJECT_V1_ROUTE_DATABASE_DETAIL;
-          void router.replace({
-            name,
-            params: {
-              projectId: canonicalProjectId,
-              instanceId,
-              databaseName,
-              ...(changelogId ? { changelogId } : {}),
-              ...(revisionId ? { revisionId } : {}),
-            },
-            hash,
-            query,
-          });
+          void router.replace(autoDatabaseRoute(db));
         }
       })
       .finally(() => {
@@ -91,16 +65,7 @@ export function useProjectDatabaseDetail({
     return () => {
       cancelled = true;
     };
-  }, [
-    changelogId,
-    databaseName,
-    getOrFetchDatabaseMetadata,
-    fullDatabaseName,
-    instanceId,
-    projectId,
-    revisionId,
-    routeName,
-  ]);
+  }, [fullDatabaseName, getOrFetchDatabaseMetadata, projectId]);
 
   const allowAlterSchema = useMemo(() => {
     return database

--- a/frontend/src/routes/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
+++ b/frontend/src/routes/project/issue-detail/components/IssueDetailDatabaseCreateView.tsx
@@ -17,7 +17,7 @@ import type { Plan_CreateDatabaseConfig } from "@/types/proto-es/v1/plan_service
 import { Task_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { unknownInstance } from "@/types/v1/instance";
 import {
-  databaseV1Url,
+  autoDatabaseRoute,
   extractCoreDatabaseInfoFromDatabaseCreateTask,
   extractDatabaseResourceName,
 } from "@/utils";
@@ -152,7 +152,7 @@ export function IssueDetailDatabaseCreateView() {
               <>
                 <RouterLink
                   className="normal-link"
-                  to={databaseV1Url(createdDatabase)}
+                  to={autoDatabaseRoute(createdDatabase)}
                 >
                   {
                     extractDatabaseResourceName(createdDatabase.name)

--- a/frontend/src/routes/workspace/InstanceDatabaseRedirectPage.tsx
+++ b/frontend/src/routes/workspace/InstanceDatabaseRedirectPage.tsx
@@ -1,17 +1,14 @@
 import { useEffect } from "react";
 import { router } from "@/app/router";
-import {
-  INSTANCE_ROUTE_DETAIL,
-  PROJECT_V1_ROUTE_DATABASE_DETAIL,
-} from "@/app/router/handles";
+import { INSTANCE_ROUTE_DETAIL } from "@/app/router/handles";
 import {
   databaseNamePrefix,
-  getProjectName,
   instanceNamePrefix,
   isValidProjectName,
 } from "@/lib/resourceName";
 import { pushNotification } from "@/stores";
 import { getOrFetchDatabaseByName } from "@/stores/app/databaseAccess";
+import { autoDatabaseRoute } from "@/utils";
 
 export function InstanceDatabaseRedirectPage({
   instanceId,
@@ -32,14 +29,7 @@ export function InstanceDatabaseRedirectPage({
           return;
         }
         if (isValidProjectName(database.project)) {
-          void router.replace({
-            name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
-            params: {
-              projectId: getProjectName(database.project),
-              instanceId,
-              databaseName,
-            },
-          });
+          void router.replace(autoDatabaseRoute(database));
           return;
         }
         pushNotification({

--- a/frontend/src/stores/app/index.test.ts
+++ b/frontend/src/stores/app/index.test.ts
@@ -136,6 +136,8 @@ const mocks = vi.hoisted(() => ({
   listChangelogs: vi.fn(),
   getChangelog: vi.fn(),
   getDatabaseMetadata: vi.fn(),
+  getDatabaseCatalog: vi.fn(),
+  updateDatabaseCatalog: vi.fn(),
   getDatabaseGroup: vi.fn(),
   listDatabaseGroups: vi.fn(),
   getSheet: vi.fn(),
@@ -226,6 +228,10 @@ vi.mock("@/api", () => ({
     batchGetDatabases: mocks.batchGetDatabases,
     listDatabases: mocks.listDatabases,
     getDatabaseMetadata: mocks.getDatabaseMetadata,
+  },
+  databaseCatalogServiceClientConnect: {
+    getDatabaseCatalog: mocks.getDatabaseCatalog,
+    updateDatabaseCatalog: mocks.updateDatabaseCatalog,
   },
   databaseGroupServiceClientConnect: {
     getDatabaseGroup: mocks.getDatabaseGroup,
@@ -2348,6 +2354,99 @@ describe("useAppStore", () => {
     });
 
     expect(mocks.getDatabaseMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  test("keeps project-instance metadata requests and caches isolated", async () => {
+    const { DatabaseMetadataSchema } = await import(
+      "@/types/proto-es/v1/database_service_pb"
+    );
+    const databaseA = "projects/a/instances/shared/databases/db";
+    const databaseB = "projects/b/instances/shared/databases/db";
+    mocks.getDatabaseMetadata.mockImplementation(async ({ name }) =>
+      createProto(DatabaseMetadataSchema, { name })
+    );
+    const store = createAppStore();
+
+    await Promise.all([
+      store.getState().getOrFetchDatabaseMetadata({ database: databaseA }),
+      store.getState().getOrFetchDatabaseMetadata({ database: databaseB }),
+    ]);
+
+    expect(
+      mocks.getDatabaseMetadata.mock.calls.map(([request]) => request.name)
+    ).toEqual([`${databaseA}/metadata`, `${databaseB}/metadata`]);
+    expect(store.getState().getCachedDatabaseMetadata(databaseA)?.name).toBe(
+      `${databaseA}/metadata`
+    );
+    expect(store.getState().getCachedDatabaseMetadata(databaseB)?.name).toBe(
+      `${databaseB}/metadata`
+    );
+
+    store.getState().removeDatabaseMetadataCache(databaseA);
+
+    expect(
+      store.getState().getCachedDatabaseMetadata(databaseA)
+    ).toBeUndefined();
+    expect(store.getState().getCachedDatabaseMetadata(databaseB)?.name).toBe(
+      `${databaseB}/metadata`
+    );
+  });
+
+  test("keeps project-instance catalog requests and caches isolated", async () => {
+    const { DatabaseCatalogSchema } = await import(
+      "@/types/proto-es/v1/database_catalog_service_pb"
+    );
+    const databaseA = "projects/a/instances/shared/databases/db";
+    const databaseB = "projects/b/instances/shared/databases/db";
+    mocks.getDatabaseCatalog.mockImplementation(async ({ name }) =>
+      createProto(DatabaseCatalogSchema, { name })
+    );
+    const store = createAppStore();
+
+    await Promise.all([
+      store.getState().getOrFetchDatabaseCatalog({ database: databaseA }),
+      store.getState().getOrFetchDatabaseCatalog({ database: databaseB }),
+    ]);
+
+    expect(
+      mocks.getDatabaseCatalog.mock.calls.map(([request]) => request.name)
+    ).toEqual([`${databaseA}/catalog`, `${databaseB}/catalog`]);
+    expect(store.getState().getDatabaseCatalog(databaseA).name).toBe(
+      `${databaseA}/catalog`
+    );
+    expect(store.getState().getDatabaseCatalog(databaseB).name).toBe(
+      `${databaseB}/catalog`
+    );
+  });
+
+  test("loads project-instance metadata when updating its catalog", async () => {
+    const { DatabaseCatalogSchema } = await import(
+      "@/types/proto-es/v1/database_catalog_service_pb"
+    );
+    const { DatabaseMetadataSchema } = await import(
+      "@/types/proto-es/v1/database_service_pb"
+    );
+    const database = "projects/a/instances/shared/databases/db";
+    const catalog = createProto(DatabaseCatalogSchema, {
+      name: `${database}/catalog`,
+    });
+    mocks.getDatabaseMetadata.mockResolvedValue(
+      createProto(DatabaseMetadataSchema, { name: `${database}/metadata` })
+    );
+    mocks.updateDatabaseCatalog.mockResolvedValue(catalog);
+    const store = createAppStore();
+
+    await store.getState().updateDatabaseCatalog(catalog);
+
+    expect(mocks.getDatabaseMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({ name: `${database}/metadata` }),
+      expect.anything()
+    );
+    expect(mocks.updateDatabaseCatalog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        catalog: expect.objectContaining({ name: `${database}/catalog` }),
+      })
+    );
   });
 
   describe("getDBGroupByName / getOrFetchDBGroupByName cache semantics", () => {

--- a/frontend/src/utils/auto-route.test.ts
+++ b/frontend/src/utils/auto-route.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { PROJECT_V1_ROUTE_DATABASE_DETAIL } from "@/app/router/handles";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { autoDatabaseRoute } from "./auto-route";
+
+describe("autoDatabaseRoute", () => {
+  test("preserves the canonical project instance parent", () => {
+    const database = {
+      name: "projects/proj1/instances/inst1/databases/db1",
+      project: "projects/proj1",
+    } as Database;
+
+    expect(autoDatabaseRoute(database)).toEqual({
+      name: PROJECT_V1_ROUTE_DATABASE_DETAIL,
+      params: {
+        projectId: "proj1",
+        instanceId: "inst1",
+        databaseName: "db1",
+      },
+      query: {
+        parent: "projects/proj1/instances/inst1",
+      },
+    });
+  });
+});

--- a/frontend/src/utils/auto-route.test.ts
+++ b/frontend/src/utils/auto-route.test.ts
@@ -3,12 +3,14 @@ import {
   PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL,
   PROJECT_V1_ROUTE_DATABASE_DETAIL,
   PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
+  SQL_EDITOR_DATABASE_MODULE,
 } from "@/app/router/handles";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import {
   autoDatabaseChangelogRoute,
   autoDatabaseRevisionRoute,
   autoDatabaseRoute,
+  autoSQLEditorDatabaseRoute,
 } from "./auto-route";
 
 describe("autoDatabaseRoute", () => {
@@ -67,6 +69,24 @@ describe("autoDatabaseRoute", () => {
       },
       query: {
         parent: "projects/proj1/instances/inst1",
+      },
+    });
+  });
+});
+
+describe("autoSQLEditorDatabaseRoute", () => {
+  test("builds the route without encoding the instance parent", () => {
+    const database = {
+      name: "projects/proj1/instances/inst1/databases/db1",
+      project: "projects/proj1",
+    } as Database;
+
+    expect(autoSQLEditorDatabaseRoute(database)).toEqual({
+      name: SQL_EDITOR_DATABASE_MODULE,
+      params: {
+        project: "proj1",
+        instance: "inst1",
+        database: "db1",
       },
     });
   });

--- a/frontend/src/utils/auto-route.test.ts
+++ b/frontend/src/utils/auto-route.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, test } from "vitest";
-import { PROJECT_V1_ROUTE_DATABASE_DETAIL } from "@/app/router/handles";
+import {
+  PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL,
+  PROJECT_V1_ROUTE_DATABASE_DETAIL,
+  PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
+} from "@/app/router/handles";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
-import { autoDatabaseRoute } from "./auto-route";
+import {
+  autoDatabaseChangelogRoute,
+  autoDatabaseRevisionRoute,
+  autoDatabaseRoute,
+} from "./auto-route";
 
 describe("autoDatabaseRoute", () => {
   test("preserves the canonical project instance parent", () => {
@@ -16,6 +24,46 @@ describe("autoDatabaseRoute", () => {
         projectId: "proj1",
         instanceId: "inst1",
         databaseName: "db1",
+      },
+      query: {
+        parent: "projects/proj1/instances/inst1",
+      },
+    });
+  });
+
+  test("builds a changelog route from the canonical database route", () => {
+    const database = {
+      name: "projects/proj1/instances/inst1/databases/db1",
+      project: "projects/proj1",
+    } as Database;
+
+    expect(autoDatabaseChangelogRoute(database, "42")).toEqual({
+      name: PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL,
+      params: {
+        projectId: "proj1",
+        instanceId: "inst1",
+        databaseName: "db1",
+        changelogId: "42",
+      },
+      query: {
+        parent: "projects/proj1/instances/inst1",
+      },
+    });
+  });
+
+  test("builds a revision route from the canonical database route", () => {
+    const database = {
+      name: "projects/proj1/instances/inst1/databases/db1",
+      project: "projects/proj1",
+    } as Database;
+
+    expect(autoDatabaseRevisionRoute(database, "7")).toEqual({
+      name: PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
+      params: {
+        projectId: "proj1",
+        instanceId: "inst1",
+        databaseName: "db1",
+        revisionId: "7",
       },
       query: {
         parent: "projects/proj1/instances/inst1",

--- a/frontend/src/utils/auto-route.ts
+++ b/frontend/src/utils/auto-route.ts
@@ -1,22 +1,24 @@
 import {
+  PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL,
   PROJECT_V1_ROUTE_DATABASE_DETAIL,
+  PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
   PROJECT_V1_ROUTE_DATABASES,
   SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
 } from "@/app/router/handles";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
-import {
-  extractDatabaseParentResourceName,
-  extractDatabaseResourceName,
-  extractProjectResourceName,
-} from "./v1";
+import { extractDatabaseResourceName } from "./v1/database";
+import { extractProjectResourceName } from "./v1/project";
 
 export const autoDatabaseRoute = (database: Database) => {
   const name = PROJECT_V1_ROUTE_DATABASE_DETAIL;
 
   const projectId = extractProjectResourceName(database.project);
-  const { instanceName: instanceId, databaseName } =
-    extractDatabaseResourceName(database.name);
+  const {
+    parent,
+    instanceName: instanceId,
+    databaseName,
+  } = extractDatabaseResourceName(database.name);
   return {
     name,
     params: {
@@ -25,7 +27,37 @@ export const autoDatabaseRoute = (database: Database) => {
       databaseName,
     },
     query: {
-      parent: extractDatabaseParentResourceName(database.name),
+      parent,
+    },
+  };
+};
+
+export const autoDatabaseChangelogRoute = (
+  database: Database,
+  changelogId: string
+) => {
+  const route = autoDatabaseRoute(database);
+  return {
+    ...route,
+    name: PROJECT_V1_ROUTE_DATABASE_CHANGELOG_DETAIL,
+    params: {
+      ...route.params,
+      changelogId,
+    },
+  };
+};
+
+export const autoDatabaseRevisionRoute = (
+  database: Database,
+  revisionId: string
+) => {
+  const route = autoDatabaseRoute(database);
+  return {
+    ...route,
+    name: PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
+    params: {
+      ...route.params,
+      revisionId,
     },
   };
 };

--- a/frontend/src/utils/auto-route.ts
+++ b/frontend/src/utils/auto-route.ts
@@ -4,6 +4,7 @@ import {
   PROJECT_V1_ROUTE_DATABASE_REVISION_DETAIL,
   PROJECT_V1_ROUTE_DATABASES,
   SETTING_ROUTE_WORKSPACE_SUBSCRIPTION,
+  SQL_EDITOR_DATABASE_MODULE,
 } from "@/app/router/handles";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
@@ -15,7 +16,7 @@ export const autoDatabaseRoute = (database: Database) => {
 
   const projectId = extractProjectResourceName(database.project);
   const {
-    parent,
+    instance,
     instanceName: instanceId,
     databaseName,
   } = extractDatabaseResourceName(database.name);
@@ -27,7 +28,7 @@ export const autoDatabaseRoute = (database: Database) => {
       databaseName,
     },
     query: {
-      parent,
+      parent: instance,
     },
   };
 };
@@ -58,6 +59,22 @@ export const autoDatabaseRevisionRoute = (
     params: {
       ...route.params,
       revisionId,
+    },
+  };
+};
+
+export const autoSQLEditorDatabaseRoute = (
+  database: Pick<Database, "name" | "project">
+) => {
+  const { instanceName, databaseName } = extractDatabaseResourceName(
+    database.name
+  );
+  return {
+    name: SQL_EDITOR_DATABASE_MODULE,
+    params: {
+      project: extractProjectResourceName(database.project),
+      instance: instanceName,
+      database: databaseName,
     },
   };
 };

--- a/frontend/src/utils/auto-route.ts
+++ b/frontend/src/utils/auto-route.ts
@@ -5,7 +5,11 @@ import {
 } from "@/app/router/handles";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
 import type { Project } from "@/types/proto-es/v1/project_service_pb";
-import { extractDatabaseResourceName, extractProjectResourceName } from "./v1";
+import {
+  extractDatabaseParentResourceName,
+  extractDatabaseResourceName,
+  extractProjectResourceName,
+} from "./v1";
 
 export const autoDatabaseRoute = (database: Database) => {
   const name = PROJECT_V1_ROUTE_DATABASE_DETAIL;
@@ -19,6 +23,9 @@ export const autoDatabaseRoute = (database: Database) => {
       projectId,
       instanceId,
       databaseName,
+    },
+    query: {
+      parent: extractDatabaseParentResourceName(database.name),
     },
   };
 };

--- a/frontend/src/utils/v1/changelog.ts
+++ b/frontend/src/utils/v1/changelog.ts
@@ -1,10 +1,11 @@
 import { create } from "@bufbuild/protobuf";
+import { router } from "@/app/router";
 import { getDatabaseByName } from "@/stores/app/databaseAccess";
 import { UNKNOWN_ID } from "@/types";
 import type { Changelog } from "@/types/proto-es/v1/changelog_service_pb";
 import { ChangelogSchema } from "@/types/proto-es/v1/changelog_service_pb";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
-import { databaseV1UrlWithSuffix } from "./database";
+import { autoDatabaseChangelogRoute } from "../auto-route";
 
 export const extractChangelogUID = (name: string) => {
   const pattern = /(?:^|\/)changelogs\/([^/]+)(?:$|\/)/;
@@ -36,10 +37,9 @@ export const changelogLink = (changelog: Changelog): string => {
     changelog.name
   );
   const composedDatabase = getDatabaseByName(databaseName);
-  return databaseV1UrlWithSuffix(
-    composedDatabase,
-    `/changelogs/${changelogUID}`
-  );
+  return router.resolve(
+    autoDatabaseChangelogRoute(composedDatabase, changelogUID)
+  ).href;
 };
 
 export const mockLatestChangelog = (

--- a/frontend/src/utils/v1/changelog.ts
+++ b/frontend/src/utils/v1/changelog.ts
@@ -4,7 +4,7 @@ import { UNKNOWN_ID } from "@/types";
 import type { Changelog } from "@/types/proto-es/v1/changelog_service_pb";
 import { ChangelogSchema } from "@/types/proto-es/v1/changelog_service_pb";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
-import { databaseV1Url, extractDatabaseResourceName } from "./database";
+import { databaseV1UrlWithSuffix } from "./database";
 
 export const extractChangelogUID = (name: string) => {
   const pattern = /(?:^|\/)changelogs\/([^/]+)(?:$|\/)/;
@@ -32,11 +32,13 @@ export const isValidChangelogName = (name: string | undefined) => {
 };
 
 export const changelogLink = (changelog: Changelog): string => {
-  const { changelogUID } = extractDatabaseNameAndChangelogUID(changelog.name);
-  const { database } = extractDatabaseResourceName(changelog.name);
-  const composedDatabase = getDatabaseByName(database);
-  return [databaseV1Url(composedDatabase), "changelogs", changelogUID].join(
-    "/"
+  const { changelogUID, databaseName } = extractDatabaseNameAndChangelogUID(
+    changelog.name
+  );
+  const composedDatabase = getDatabaseByName(databaseName);
+  return databaseV1UrlWithSuffix(
+    composedDatabase,
+    `/changelogs/${changelogUID}`
   );
 };
 

--- a/frontend/src/utils/v1/database.test.ts
+++ b/frontend/src/utils/v1/database.test.ts
@@ -9,8 +9,8 @@ describe("extractDatabaseResourceName", () => {
   } as Database;
 
   test("extracts the canonical database parent with the resource parts", () => {
-    expect(extractDatabaseResourceName(database.name)).toMatchObject({
-      parent: "projects/proj1/instances/inst1",
+    expect(extractDatabaseResourceName(database.name)).toEqual({
+      instance: "projects/proj1/instances/inst1",
       database: "projects/proj1/instances/inst1/databases/db1",
       instanceName: "inst1",
       databaseName: "db1",
@@ -20,8 +20,8 @@ describe("extractDatabaseResourceName", () => {
   test("extracts a workspace instance parent", () => {
     expect(
       extractDatabaseResourceName("instances/inst1/databases/db1")
-    ).toMatchObject({
-      parent: "instances/inst1",
+    ).toEqual({
+      instance: "instances/inst1",
       database: "instances/inst1/databases/db1",
       instanceName: "inst1",
       databaseName: "db1",

--- a/frontend/src/utils/v1/database.test.ts
+++ b/frontend/src/utils/v1/database.test.ts
@@ -1,16 +1,28 @@
 import { describe, expect, test } from "vitest";
 import type { Database } from "@/types/proto-es/v1/database_service_pb";
-import { databaseV1UrlWithSuffix } from "./database";
+import { extractDatabaseResourceName } from "./database";
 
-describe("databaseV1UrlWithSuffix", () => {
+describe("extractDatabaseResourceName", () => {
   const database = {
     name: "projects/proj1/instances/inst1/databases/db1",
     project: "projects/proj1",
   } as Database;
 
-  test("places descendant paths before the parent query", () => {
-    expect(databaseV1UrlWithSuffix(database, "/revisions/7")).toBe(
-      "/projects/proj1/instances/inst1/databases/db1/revisions/7?parent=projects%2Fproj1%2Finstances%2Finst1"
-    );
+  test("extracts the canonical database parent with the resource parts", () => {
+    expect(extractDatabaseResourceName(database.name)).toMatchObject({
+      parent: "projects/proj1/instances/inst1",
+      instanceName: "inst1",
+      databaseName: "db1",
+    });
+  });
+
+  test("extracts a workspace instance parent", () => {
+    expect(
+      extractDatabaseResourceName("instances/inst1/databases/db1")
+    ).toMatchObject({
+      parent: "instances/inst1",
+      instanceName: "inst1",
+      databaseName: "db1",
+    });
   });
 });

--- a/frontend/src/utils/v1/database.test.ts
+++ b/frontend/src/utils/v1/database.test.ts
@@ -11,6 +11,7 @@ describe("extractDatabaseResourceName", () => {
   test("extracts the canonical database parent with the resource parts", () => {
     expect(extractDatabaseResourceName(database.name)).toMatchObject({
       parent: "projects/proj1/instances/inst1",
+      database: "projects/proj1/instances/inst1/databases/db1",
       instanceName: "inst1",
       databaseName: "db1",
     });
@@ -21,6 +22,7 @@ describe("extractDatabaseResourceName", () => {
       extractDatabaseResourceName("instances/inst1/databases/db1")
     ).toMatchObject({
       parent: "instances/inst1",
+      database: "instances/inst1/databases/db1",
       instanceName: "inst1",
       databaseName: "db1",
     });

--- a/frontend/src/utils/v1/database.test.ts
+++ b/frontend/src/utils/v1/database.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import type { Database } from "@/types/proto-es/v1/database_service_pb";
+import { databaseV1UrlWithSuffix } from "./database";
+
+describe("databaseV1UrlWithSuffix", () => {
+  const database = {
+    name: "projects/proj1/instances/inst1/databases/db1",
+    project: "projects/proj1",
+  } as Database;
+
+  test("places descendant paths before the parent query", () => {
+    expect(databaseV1UrlWithSuffix(database, "/revisions/7")).toBe(
+      "/projects/proj1/instances/inst1/databases/db1/revisions/7?parent=projects%2Fproj1%2Finstances%2Finst1"
+    );
+  });
+});

--- a/frontend/src/utils/v1/database.ts
+++ b/frontend/src/utils/v1/database.ts
@@ -30,7 +30,7 @@ export const extractDatabaseResourceName = (
   parent: string;
   // instance full name
   instance: string;
-  // database full name
+  // database full name preserving its project parent
   database: string;
   databaseName: string;
   instanceName: string;
@@ -40,15 +40,18 @@ export const extractDatabaseResourceName = (
   const matches = resource.match(pattern);
 
   const {
-    parent = "",
+    matchedParent = "",
     databaseName = String(UNKNOWN_ID),
     instanceName = String(UNKNOWN_ID),
   } = matches?.groups ?? {};
+  const instance = `${instanceNamePrefix}${instanceName}`;
+  const parent = matchedParent ?? instance;
+  const database = `${parent}/${databaseNamePrefix}${databaseName}`;
   return {
     parent,
-    instance: `${instanceNamePrefix}${instanceName}`,
+    instance,
     instanceName,
-    database: `${instanceNamePrefix}${instanceName}/${databaseNamePrefix}${databaseName}`,
+    database,
     databaseName,
   };
 };

--- a/frontend/src/utils/v1/database.ts
+++ b/frontend/src/utils/v1/database.ts
@@ -19,15 +19,13 @@ import { appStoreUtilBridge } from "@/utils/app-store-bridge";
 import { hasWorkspacePermissionV2 } from "../iam";
 import { checkQuerierPermission } from "./iam";
 
-// Extracts the database resource parts while preserving the complete parent.
-// For example, "projects/p/instances/i/databases/d" has parent
-// "projects/p/instances/i", while "instances/i/databases/d" has parent
+// Extracts database resource parts while preserving the canonical instance.
+// For example, "projects/p/instances/i/databases/d" has instance
+// "projects/p/instances/i", while "instances/i/databases/d" has instance
 // "instances/i".
 export const extractDatabaseResourceName = (
   resource: string
 ): {
-  // database parent preserving its full scope
-  parent: string;
   // instance full name
   instance: string;
   // database full name preserving its project parent
@@ -40,15 +38,14 @@ export const extractDatabaseResourceName = (
   const matches = resource.match(pattern);
 
   const {
-    matchedParent = "",
+    parent: matchedParent,
     databaseName = String(UNKNOWN_ID),
     instanceName = String(UNKNOWN_ID),
   } = matches?.groups ?? {};
-  const instance = `${instanceNamePrefix}${instanceName}`;
-  const parent = matchedParent ?? instance;
-  const database = `${parent}/${databaseNamePrefix}${databaseName}`;
+  const workspaceInstance = `${instanceNamePrefix}${instanceName}`;
+  const instance = matchedParent || workspaceInstance;
+  const database = `${instance}/${databaseNamePrefix}${databaseName}`;
   return {
-    parent,
     instance,
     instanceName,
     database,

--- a/frontend/src/utils/v1/database.ts
+++ b/frontend/src/utils/v1/database.ts
@@ -18,27 +18,16 @@ import { type Environment, unknownEnvironment } from "@/types/v1/environment";
 import { appStoreUtilBridge } from "@/utils/app-store-bridge";
 import { hasWorkspacePermissionV2 } from "../iam";
 import { checkQuerierPermission } from "./iam";
-import { extractProjectResourceName } from "./project";
 
-export const databaseV1UrlWithSuffix = (db: Database, suffix: string) => {
-  return databaseV1UrlWithProject(db.project, db.name, suffix);
-};
-
-const databaseV1UrlWithProject = (
-  project: string,
-  database: string,
-  suffix = ""
-) => {
-  const projectId = extractProjectResourceName(project);
-  const { databaseName, instanceName } = extractDatabaseResourceName(database);
-  const parent = extractDatabaseParentResourceName(database);
-
-  return `/projects/${encodeURIComponent(projectId)}/${instanceNamePrefix}${encodeURIComponent(instanceName)}/${databaseNamePrefix}${encodeURIComponent(databaseName)}${suffix}?parent=${encodeURIComponent(parent)}`;
-};
-
+// Extracts the database resource parts while preserving the complete parent.
+// For example, "projects/p/instances/i/databases/d" has parent
+// "projects/p/instances/i", while "instances/i/databases/d" has parent
+// "instances/i".
 export const extractDatabaseResourceName = (
   resource: string
 ): {
+  // database parent preserving its full scope
+  parent: string;
   // instance full name
   instance: string;
   // database full name
@@ -47,28 +36,21 @@ export const extractDatabaseResourceName = (
   instanceName: string;
 } => {
   const pattern =
-    /(?:^|\/)instances\/(?<instanceName>[^/]+)\/databases\/(?<databaseName>[^/]+)(?:$|\/)/;
+    /(?:^|\/)(?<parent>(?:projects\/[^/]+\/)?instances\/(?<instanceName>[^/]+))\/databases\/(?<databaseName>[^/]+)(?:$|\/)/;
   const matches = resource.match(pattern);
 
   const {
+    parent = "",
     databaseName = String(UNKNOWN_ID),
     instanceName = String(UNKNOWN_ID),
   } = matches?.groups ?? {};
   return {
+    parent,
     instance: `${instanceNamePrefix}${instanceName}`,
     instanceName,
     database: `${instanceNamePrefix}${instanceName}/${databaseNamePrefix}${databaseName}`,
     databaseName,
   };
-};
-
-// Extracts the database parent while preserving its full scope.
-// For example, "projects/p/instances/i/databases/d" returns
-// "projects/p/instances/i".
-export const extractDatabaseParentResourceName = (resource: string): string => {
-  const marker = "/databases/";
-  const index = resource.indexOf(marker);
-  return index < 0 ? "" : resource.slice(0, index);
 };
 
 // isDatabaseV1Queryable checks if database allowed to query in SQL Editor.

--- a/frontend/src/utils/v1/database.ts
+++ b/frontend/src/utils/v1/database.ts
@@ -20,15 +20,20 @@ import { hasWorkspacePermissionV2 } from "../iam";
 import { checkQuerierPermission } from "./iam";
 import { extractProjectResourceName } from "./project";
 
-export const databaseV1Url = (db: Database) => {
-  return databaseV1UrlWithProject(db.project, db.name);
+export const databaseV1UrlWithSuffix = (db: Database, suffix: string) => {
+  return databaseV1UrlWithProject(db.project, db.name, suffix);
 };
 
-const databaseV1UrlWithProject = (project: string, database: string) => {
+const databaseV1UrlWithProject = (
+  project: string,
+  database: string,
+  suffix = ""
+) => {
   const projectId = extractProjectResourceName(project);
   const { databaseName, instanceName } = extractDatabaseResourceName(database);
+  const parent = extractDatabaseParentResourceName(database);
 
-  return `/projects/${encodeURIComponent(projectId)}/${instanceNamePrefix}${encodeURIComponent(instanceName)}/${databaseNamePrefix}${encodeURIComponent(databaseName)}`;
+  return `/projects/${encodeURIComponent(projectId)}/${instanceNamePrefix}${encodeURIComponent(instanceName)}/${databaseNamePrefix}${encodeURIComponent(databaseName)}${suffix}?parent=${encodeURIComponent(parent)}`;
 };
 
 export const extractDatabaseResourceName = (
@@ -55,6 +60,15 @@ export const extractDatabaseResourceName = (
     database: `${instanceNamePrefix}${instanceName}/${databaseNamePrefix}${databaseName}`,
     databaseName,
   };
+};
+
+// Extracts the database parent while preserving its full scope.
+// For example, "projects/p/instances/i/databases/d" returns
+// "projects/p/instances/i".
+export const extractDatabaseParentResourceName = (resource: string): string => {
+  const marker = "/databases/";
+  const index = resource.indexOf(marker);
+  return index < 0 ? "" : resource.slice(0, index);
 };
 
 // isDatabaseV1Queryable checks if database allowed to query in SQL Editor.

--- a/frontend/src/utils/v1/revision.ts
+++ b/frontend/src/utils/v1/revision.ts
@@ -2,7 +2,7 @@ import i18n from "@/lib/i18n";
 import { getDatabaseByName } from "@/stores/app/databaseAccess";
 import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
 import { Revision_Type } from "@/types/proto-es/v1/revision_service_pb";
-import { databaseV1Url, extractDatabaseResourceName } from "./database";
+import { databaseV1UrlWithSuffix } from "./database";
 
 export const extractRevisionUID = (name: string): string => {
   const pattern = /(?:^|\/)revisions\/([^/]+)(?:$|\/)/;
@@ -15,9 +15,8 @@ export const revisionLink = (revision: Revision): string => {
   if (parts.length !== 2) {
     return "";
   }
-  const { database } = extractDatabaseResourceName(revision.name);
-  const composedDatabase = getDatabaseByName(database);
-  return `${databaseV1Url(composedDatabase)}/revisions/${parts[1]}`;
+  const composedDatabase = getDatabaseByName(parts[0]);
+  return databaseV1UrlWithSuffix(composedDatabase, `/revisions/${parts[1]}`);
 };
 
 export const getRevisionType = (type: Revision_Type): string => {

--- a/frontend/src/utils/v1/revision.ts
+++ b/frontend/src/utils/v1/revision.ts
@@ -1,8 +1,9 @@
+import { router } from "@/app/router";
 import i18n from "@/lib/i18n";
 import { getDatabaseByName } from "@/stores/app/databaseAccess";
 import type { Revision } from "@/types/proto-es/v1/revision_service_pb";
 import { Revision_Type } from "@/types/proto-es/v1/revision_service_pb";
-import { databaseV1UrlWithSuffix } from "./database";
+import { autoDatabaseRevisionRoute } from "../auto-route";
 
 export const extractRevisionUID = (name: string): string => {
   const pattern = /(?:^|\/)revisions\/([^/]+)(?:$|\/)/;
@@ -16,7 +17,8 @@ export const revisionLink = (revision: Revision): string => {
     return "";
   }
   const composedDatabase = getDatabaseByName(parts[0]);
-  return databaseV1UrlWithSuffix(composedDatabase, `/revisions/${parts[1]}`);
+  return router.resolve(autoDatabaseRevisionRoute(composedDatabase, parts[1]))
+    .href;
 };
 
 export const getRevisionType = (type: Revision_Type): string => {


### PR DESCRIPTION
## Problem

Databases in Bytebase have a fully-qualified resource name like `projects/{project}/instances/{instance}/databases/{database}`. The frontend was **stripping the project prefix** when parsing these names, using `instances/{instance}` as the instance parent instead of preserving `projects/{project}/instances/{instance}`.

Since instance IDs are **globally unique** (they are the primary key of the `instance` table), this wasn't causing cross-project data leakage. But it did cause:

- **Cache misses** — `databasesByName` is keyed by full resource name. A lookup with `instances/{instance}/databases/{db}` wouldn't match a database cached under `projects/{project}/instances/{instance}/databases/{db}`, triggering unnecessary re-fetches.
- **Inconsistent resource name usage** — Some code paths used the workspace form, others the project form, with no central place enforcing consistency.
- **Ad-hoc route building** — Regex-based route URL construction was copy-pasted across ~15 files, each with its own (sometimes inconsistent) logic.

---

## Fix — 4 Layers

### 1. `extractDatabaseResourceName` preserves the project prefix in the instance parent

**`frontend/src/utils/v1/database.ts`** — The regex now captures the optional `projects/{id}/` prefix and includes it in the returned `instance` and `database` fields:

| Input | `instance` (before) | `instance` (after) |
|---|---|---|
| `instances/i/databases/d` | `instances/i` | `instances/i` |
| `projects/p/instances/i/databases/d` | `instances/i` | `projects/p/instances/i` |

The full parent is threaded through routes as `query.parent`, ensuring cache lookups use the same fully-qualified name the API returns.

### 2. Centralized `auto-route` utilities replace ad-hoc regex-based URL building

**New: `frontend/src/utils/auto-route.ts`** (+59) with 4 functions:

| Function | Purpose |
|---|---|
| `autoDatabaseRoute(database)` | Canonical database detail route with `parent` query |
| `autoDatabaseChangelogRoute(database, id)` | Extends for changelog detail |
| `autoDatabaseRevisionRoute(database, id)` | Extends for revision detail |
| `autoSQLEditorDatabaseRoute(database)` | SQL Editor database route |

Every consumer that previously hand-rolled route objects now uses these functions:

- **Route pages:** `ProjectDatabaseDetailPage`, `DatabaseChangelogDetailPage`, `DatabaseRevisionDetailPage`
- **SQL Editor:** `SQLEditorRouteShell`, `ConnectionPane/actions`, `SchemaPane/actions`
- **Other pages:** `ProjectDatabasesPage`, `DatabaseSQLEditorButton`, `InstanceDatabaseRedirectPage`, `ProjectSyncSchemaPage`, `WorkspaceSetupGuide`
- **Utility helpers:** `changelog.ts`, `revision.ts`

### 3. Robust fallback resolution

**`frontend/src/modules/sql-editor/components/SQLEditorRouteShell.tsx`** — When `getOrFetchDatabaseByName` fails with the workspace-scoped path (`instances/{id}/databases/{name}`), it retries with the project-scoped path (`projects/{pid}/instances/{id}/databases/{name}`). This handles bookmarked URLs where the project context is known from the route but wasn't encoded in the database name.

**`frontend/src/modules/agent/logic/context.ts`** — Same fallback pattern for agent route context extraction.

**`frontend/src/routes/project/database-detail/useProjectDatabaseDetail.ts`** — Simplified from 5+ params (`routeName`, `changelogId`, `revisionId`, `hash`, `query`) down to just `parent`. Redirects through `autoDatabaseRoute(db)` when a database's canonical project differs from the URL.

### 4. Backend: purge descendant caches on instance delete

**`backend/store/instance.go`** — `DeleteInstance` now also removes:

- **`databaseCache`** entries (workspace-scoped & unscoped keys)
- **`dbSchemaCache`** entries (instance-prefixed keys)

Previously, deleting an instance would only clear the instance cache, leaving stale database and schema cache entries that could be served for a different project reusing the same instance ID.

**New test: `backend/store/instance_purge_cache_test.go`** (+82) verifies:

1. Database and schema caches are cleared after deletion
2. A new database with the same instance ID but **different project** doesn't hit stale cache
3. Schema cache stays cleared even after database is re-inserted under a new project
