### PR TITLE
fix: expose AWS credentials for DynamoDB instances and assume role in the driver

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -711,6 +711,39 @@ func (s *InstanceService) validateIAMCredentialForSaaS(dataSource *storepb.DataS
 		)
 	}
 
+	// An IAM extension whose fields are all empty behaves exactly like the
+	// default credential chain at connect time (the host's own cloud
+	// identity), so reject it for the same reason.
+	return validateIAMCredentialNotEmpty(dataSource)
+}
+
+func validateIAMCredentialNotEmpty(dataSource *storepb.DataSource) error {
+	switch {
+	case dataSource.GetAwsCredential() != nil:
+		awsCredential := dataSource.GetAwsCredential()
+		if awsCredential.GetAccessKeyId() == "" && awsCredential.GetRoleArn() == "" {
+			return connect.NewError(
+				connect.CodeInvalidArgument,
+				errors.New("AWS credential requires an access key ID or a role ARN in SaaS mode"),
+			)
+		}
+	case dataSource.GetGcpCredential() != nil:
+		if dataSource.GetGcpCredential().GetContent() == "" {
+			return connect.NewError(
+				connect.CodeInvalidArgument,
+				errors.New("GCP credential content is required in SaaS mode"),
+			)
+		}
+	case dataSource.GetAzureCredential() != nil:
+		azureCredential := dataSource.GetAzureCredential()
+		if azureCredential.GetTenantId() == "" || azureCredential.GetClientId() == "" || azureCredential.GetClientSecret() == "" {
+			return connect.NewError(
+				connect.CodeInvalidArgument,
+				errors.New("Azure credential requires tenant ID, client ID, and client secret in SaaS mode"),
+			)
+		}
+	default:
+	}
 	return nil
 }
 
@@ -1347,6 +1380,12 @@ func (s *InstanceService) UpdateDataSource(ctx context.Context, req *connect.Req
 	normalizeGCPDataSources(instance.Metadata.GetEngine(), []*storepb.DataSource{dataSource})
 	if err := validateAndSanitizeDataSourceTLS(dataSource); err != nil {
 		return nil, connect.NewError(connect.CodeInvalidArgument, err)
+	}
+	// Validate the merged result so untouched stored credentials keep passing:
+	// the create-path SaaS checks never run for updates, which would otherwise
+	// let an update strip an IAM credential down to the default chain.
+	if err := s.validateIAMCredentialForSaaS(dataSource); err != nil {
+		return nil, err
 	}
 
 	if err := s.checkInstanceDataSources(ctx, instance, metadata.GetDataSources()); err != nil {

--- a/backend/api/v1/instance_service_test.go
+++ b/backend/api/v1/instance_service_test.go
@@ -15,6 +15,114 @@ import (
 	"github.com/bytebase/bytebase/backend/store"
 )
 
+func TestValidateIAMCredentialForSaaS(t *testing.T) {
+	saas := &InstanceService{profile: &config.Profile{SaaS: true}}
+	selfHosted := &InstanceService{profile: &config.Profile{SaaS: false}}
+
+	awsDS := func(credential *storepb.DataSource_AWSCredential) *storepb.DataSource {
+		ds := &storepb.DataSource{AuthenticationType: storepb.DataSource_AWS_RDS_IAM}
+		if credential != nil {
+			ds.IamExtension = &storepb.DataSource_AwsCredential{AwsCredential: credential}
+		}
+		return ds
+	}
+
+	testCases := []struct {
+		name    string
+		service *InstanceService
+		ds      *storepb.DataSource
+		wantErr bool
+	}{
+		{
+			name:    "saas rejects nil iam extension",
+			service: saas,
+			ds:      awsDS(nil),
+			wantErr: true,
+		},
+		{
+			// An all-empty credential behaves exactly like the default chain
+			// at connect time: the host's own AWS identity.
+			name:    "saas rejects empty aws credential",
+			service: saas,
+			ds:      awsDS(&storepb.DataSource_AWSCredential{}),
+			wantErr: true,
+		},
+		{
+			name:    "saas accepts aws access key",
+			service: saas,
+			ds:      awsDS(&storepb.DataSource_AWSCredential{AccessKeyId: "AKIAIOSFODNN7EXAMPLE", SecretAccessKey: "secret"}),
+			wantErr: false,
+		},
+		{
+			// Role-only is the legitimate SaaS cross-account pattern: the
+			// tenant's role trusts the host identity as the base principal.
+			name:    "saas accepts aws role arn without keys",
+			service: saas,
+			ds:      awsDS(&storepb.DataSource_AWSCredential{RoleArn: "arn:aws:iam::123456789012:role/tenant"}),
+			wantErr: false,
+		},
+		{
+			name:    "saas rejects empty gcp credential",
+			service: saas,
+			ds: &storepb.DataSource{
+				AuthenticationType: storepb.DataSource_GOOGLE_CLOUD_SQL_IAM,
+				IamExtension:       &storepb.DataSource_GcpCredential{GcpCredential: &storepb.DataSource_GCPCredential{}},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "saas accepts gcp credential content",
+			service: saas,
+			ds: &storepb.DataSource{
+				AuthenticationType: storepb.DataSource_GOOGLE_CLOUD_SQL_IAM,
+				IamExtension:       &storepb.DataSource_GcpCredential{GcpCredential: &storepb.DataSource_GCPCredential{Content: `{"type":"service_account"}`}},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "saas rejects incomplete azure credential",
+			service: saas,
+			ds: &storepb.DataSource{
+				AuthenticationType: storepb.DataSource_AZURE_IAM,
+				IamExtension:       &storepb.DataSource_AzureCredential_{AzureCredential: &storepb.DataSource_AzureCredential{TenantId: "tenant"}},
+			},
+			wantErr: true,
+		},
+		{
+			name:    "saas accepts complete azure credential",
+			service: saas,
+			ds: &storepb.DataSource{
+				AuthenticationType: storepb.DataSource_AZURE_IAM,
+				IamExtension:       &storepb.DataSource_AzureCredential_{AzureCredential: &storepb.DataSource_AzureCredential{TenantId: "tenant", ClientId: "client", ClientSecret: "secret"}},
+			},
+			wantErr: false,
+		},
+		{
+			name:    "saas ignores password authentication",
+			service: saas,
+			ds:      &storepb.DataSource{AuthenticationType: storepb.DataSource_PASSWORD},
+			wantErr: false,
+		},
+		{
+			// Self-hosted deployments may use the default credential chain.
+			name:    "self-hosted accepts empty aws credential",
+			service: selfHosted,
+			ds:      awsDS(&storepb.DataSource_AWSCredential{}),
+			wantErr: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.service.validateIAMCredentialForSaaS(tc.ds)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateExtraConnectionParametersRejectsTiDBAllowAllFiles(t *testing.T) {
 	err := validateExtraConnectionParameters(storepb.Engine_TIDB, map[string]string{
 		"allowAllFiles": "true",

--- a/backend/plugin/db/dynamodb/dynamodb.go
+++ b/backend/plugin/db/dynamodb/dynamodb.go
@@ -54,6 +54,9 @@ func (d *Driver) Open(ctx context.Context, _ storepb.Engine, conf db.ConnectionC
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load AWS config")
 	}
+	if err := util.AssumeRoleIfNeeded(ctx, &cfg, conf.ConnectionContext, conf.DataSource.GetAwsCredential()); err != nil {
+		return nil, err
+	}
 	d.awsConfig = cfg
 
 	var optFns []func(*dynamodb.Options)

--- a/backend/plugin/db/dynamodb/dynamodb_test.go
+++ b/backend/plugin/db/dynamodb/dynamodb_test.go
@@ -1,9 +1,12 @@
 package dynamodb
 
 import (
+	"context"
+	"strings"
 	"testing"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/db"
 )
 
 func TestDynamoDBEndpoint(t *testing.T) {
@@ -54,5 +57,58 @@ func TestDynamoDBEndpoint(t *testing.T) {
 				t.Errorf("dynamoDBEndpoint() = %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// setHermeticAWSEnv pins base credentials and points STS at an unroutable local
+// endpoint so Open never reaches real AWS: an attempted AssumeRole fails fast
+// and deterministically instead of depending on ambient credentials or network.
+func setHermeticAWSEnv(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_ENDPOINT_URL_STS", "http://127.0.0.1:1")
+}
+
+func TestOpenAssumesRoleWhenRoleArnSet(t *testing.T) {
+	setHermeticAWSEnv(t)
+
+	d := newDriver()
+	_, err := d.Open(context.Background(), storepb.Engine_DYNAMODB, db.ConnectionConfig{
+		ConnectionContext: db.ConnectionContext{InstanceID: "dynamodb-test"},
+		DataSource: &storepb.DataSource{
+			Region: "us-east-1",
+			IamExtension: &storepb.DataSource_AwsCredential{
+				AwsCredential: &storepb.DataSource_AWSCredential{
+					RoleArn: "arn:aws:iam::123456789012:role/bytebase-test-role",
+				},
+			},
+		},
+	})
+	if err == nil {
+		t.Fatal("Open() = nil error; want an assume-role failure, meaning role_arn was ignored")
+	}
+	if !strings.Contains(err.Error(), "failed to assume role") {
+		t.Errorf("Open() error = %q, want it to mention the assume-role attempt", err.Error())
+	}
+}
+
+func TestOpenWithoutRoleArnSkipsAssumeRole(t *testing.T) {
+	setHermeticAWSEnv(t)
+
+	d := newDriver()
+	if _, err := d.Open(context.Background(), storepb.Engine_DYNAMODB, db.ConnectionConfig{
+		ConnectionContext: db.ConnectionContext{InstanceID: "dynamodb-test"},
+		DataSource: &storepb.DataSource{
+			Region: "us-east-1",
+			IamExtension: &storepb.DataSource_AwsCredential{
+				AwsCredential: &storepb.DataSource_AWSCredential{
+					AccessKeyId:     "AKIAIOSFODNN7EXAMPLE",
+					SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Open() error = %v, want nil when no role_arn is set", err)
 	}
 }

--- a/backend/plugin/db/dynamodb/dynamodb_test.go
+++ b/backend/plugin/db/dynamodb/dynamodb_test.go
@@ -2,6 +2,7 @@ package dynamodb
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -68,6 +69,16 @@ func setHermeticAWSEnv(t *testing.T) {
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
 	t.Setenv("AWS_SESSION_TOKEN", "")
 	t.Setenv("AWS_ENDPOINT_URL_STS", "http://127.0.0.1:1")
+	// Single attempt: the SDK's default retryer would otherwise retry the
+	// refused connection with backoff, slowing the failure to several seconds.
+	t.Setenv("AWS_MAX_ATTEMPTS", "1")
+	// Shield the tests from ambient AWS configuration on the host: a set
+	// AWS_PROFILE or shared config file would otherwise leak into
+	// config.LoadDefaultConfig.
+	t.Setenv("AWS_PROFILE", "")
+	missing := filepath.Join(t.TempDir(), "nonexistent")
+	t.Setenv("AWS_CONFIG_FILE", missing)
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", missing)
 }
 
 func TestOpenAssumesRoleWhenRoleArnSet(t *testing.T) {

--- a/backend/plugin/db/util/aws.go
+++ b/backend/plugin/db/util/aws.go
@@ -45,8 +45,10 @@ func AssumeRoleIfNeeded(ctx context.Context, awsCfg *aws.Config, connectionCtx d
 			}
 		})
 
-	// Update config with assumed role credentials
-	awsCfg.Credentials = assumeRoleProvider
+	// Update config with assumed role credentials. The cache refreshes the
+	// temporary credentials before expiry instead of calling STS AssumeRole on
+	// every AWS API request.
+	awsCfg.Credentials = aws.NewCredentialsCache(assumeRoleProvider)
 
 	// Test credentials retrieval and provide context-specific error messages
 	_, err := awsCfg.Credentials.Retrieve(ctx)

--- a/frontend/src/components/instance/DataSourceForm.tsx
+++ b/frontend/src/components/instance/DataSourceForm.tsx
@@ -272,6 +272,27 @@ export function DataSourceForm({
     }
   }, [basicInfo.engine, t]);
 
+  // DynamoDB always authenticates with AWS IAM, but data sources created
+  // before the form exposed credentials still carry PASSWORD. Render those in
+  // the AWS IAM mode and stamp the real authentication type only when a
+  // credential field is edited, so opening an old instance stays pristine.
+  const dynamoDBDataSource = useMemo(
+    () => ({
+      ...dataSource,
+      authenticationType: DataSource_AuthenticationType.AWS_RDS_IAM,
+    }),
+    [dataSource]
+  );
+  const updateDynamoDB = useCallback(
+    (updates: Partial<EditDataSource>) => {
+      update({
+        authenticationType: DataSource_AuthenticationType.AWS_RDS_IAM,
+        ...updates,
+      });
+    },
+    [update]
+  );
+
   const extraConnectionParamsList = useMemo(() => {
     const params = dataSource.extraConnectionParameters || {};
     return Object.entries(params).map(([key, value]) => ({ key, value }));
@@ -874,23 +895,12 @@ export function DataSourceForm({
 
               {/* AWS Region */}
               {isAwsIAM && (
-                <FormField
-                  className="sm:col-span-3 sm:col-start-1"
-                  title={
-                    <>
-                      {t("instance.database-region")}{" "}
-                      <span className="text-error">*</span>
-                    </>
-                  }
-                >
-                  <Input
-                    value={dataSource.region ?? ""}
-                    className="w-full"
-                    disabled={!allowEdit}
-                    placeholder="database region, for example, us-east-1"
-                    onChange={(e) => update({ region: e.target.value })}
-                  />
-                </FormField>
+                <AwsRegionField
+                  region={dataSource.region ?? ""}
+                  required
+                  allowEdit={allowEdit}
+                  onChange={(region) => update({ region })}
+                />
               )}
 
               {/* Password / External Secret */}
@@ -1673,6 +1683,24 @@ export function DataSourceForm({
             </>
           )}
 
+          {/* DynamoDB AWS IAM credentials */}
+          {basicInfo.engine === Engine.DYNAMODB && (
+            <>
+              <CredentialSourceForm
+                dataSource={dynamoDBDataSource}
+                engine={basicInfo.engine}
+                allowEdit={allowEdit}
+                onDataSourceChange={updateDynamoDB}
+              />
+              <AwsRegionField
+                region={dataSource.region ?? ""}
+                required={dataSource.iamExtension?.case === "awsCredential"}
+                allowEdit={allowEdit}
+                onChange={(region) => updateDynamoDB({ region })}
+              />
+            </>
+          )}
+
           {/* Oracle SID/Service Name */}
           {basicInfo.engine === Engine.ORACLE && (
             <OracleSIDServiceNameInput
@@ -2144,5 +2172,38 @@ function OracleSIDServiceNameInput({
         }}
       />
     </div>
+  );
+}
+
+function AwsRegionField({
+  region,
+  required,
+  allowEdit,
+  onChange,
+}: Readonly<{
+  region: string;
+  required: boolean;
+  allowEdit: boolean;
+  onChange: (region: string) => void;
+}>) {
+  const { t } = useTranslation();
+  return (
+    <FormField
+      className="sm:col-span-3 sm:col-start-1"
+      title={
+        <>
+          {t("instance.database-region")}
+          {required && <span className="text-error"> *</span>}
+        </>
+      }
+    >
+      <Input
+        value={region}
+        className="w-full"
+        disabled={!allowEdit}
+        placeholder="database region, for example, us-east-1"
+        onChange={(e) => onChange(e.target.value)}
+      />
+    </FormField>
   );
 }

--- a/frontend/src/components/instance/DataSourceForm.tsx
+++ b/frontend/src/components/instance/DataSourceForm.tsx
@@ -276,6 +276,9 @@ export function DataSourceForm({
   // before the form exposed credentials still carry PASSWORD. Render those in
   // the AWS IAM mode and stamp the real authentication type only when a
   // credential field is edited, so opening an old instance stays pristine.
+  // (In SaaS mode the shared CredentialSourceForm instead forces
+  // specific-credential mode on open — the policy every IAM engine inherits
+  // there, since the default credential chain is the host's own identity.)
   const dynamoDBDataSource = useMemo(
     () => ({
       ...dataSource,
@@ -2201,7 +2204,7 @@ function AwsRegionField({
         value={region}
         className="w-full"
         disabled={!allowEdit}
-        placeholder="database region, for example, us-east-1"
+        placeholder={t("instance.database-region-placeholder")}
         onChange={(e) => onChange(e.target.value)}
       />
     </FormField>

--- a/frontend/src/components/instance/DataSourceSection.tsx
+++ b/frontend/src/components/instance/DataSourceSection.tsx
@@ -106,9 +106,12 @@ export function DataSourceSection({
     [setDataSourceEditState]
   );
 
-  // DynamoDB has a single admin data source: no read-only tabs or tips.
+  // DynamoDB normally has a single admin data source, so the read-only
+  // tabs/tips are hidden — unless a read-only data source already exists
+  // (creatable via the API), which must stay reachable.
   const showDataSourceTabs =
-    !isCreating && basicInfo.engine !== Engine.DYNAMODB;
+    !isCreating &&
+    (basicInfo.engine !== Engine.DYNAMODB || hasReadOnlyDataSource);
 
   // Show RO tips when not creating and no RO data source
   const showROTips = showDataSourceTabs && !hasReadOnlyDataSource;

--- a/frontend/src/components/instance/DataSourceSection.tsx
+++ b/frontend/src/components/instance/DataSourceSection.tsx
@@ -106,8 +106,12 @@ export function DataSourceSection({
     [setDataSourceEditState]
   );
 
+  // DynamoDB has a single admin data source: no read-only tabs or tips.
+  const showDataSourceTabs =
+    !isCreating && basicInfo.engine !== Engine.DYNAMODB;
+
   // Show RO tips when not creating and no RO data source
-  const showROTips = !isCreating && !hasReadOnlyDataSource;
+  const showROTips = showDataSourceTabs && !hasReadOnlyDataSource;
 
   return (
     <>
@@ -132,7 +136,7 @@ export function DataSourceSection({
 
       <div className="mt-2 gap-y-2 gap-x-4 border-none">
         {/* Data source tabs */}
-        {!isCreating && (
+        {showDataSourceTabs && (
           <div className="mb-4 flex items-center gap-x-2 border-b border-block-border">
             <button
               type="button"

--- a/frontend/src/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/components/instance/InstanceFormBody.tsx
@@ -950,8 +950,18 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
           if (ds.type !== DataSourceType.ADMIN) return ds;
           const updated = { ...ds };
           switch (engine) {
-            case Engine.SNOWFLAKE:
+            case Engine.SNOWFLAKE: {
+              if (
+                updated.host === "127.0.0.1" ||
+                updated.host === "host.docker.internal"
+              ) {
+                updated.host = "";
+              }
+              break;
+            }
             case Engine.DYNAMODB: {
+              updated.authenticationType =
+                DataSource_AuthenticationType.AWS_RDS_IAM;
               if (
                 updated.host === "127.0.0.1" ||
                 updated.host === "host.docker.internal"
@@ -1736,13 +1746,10 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
           </div>
 
           {/* Credentials (auth method, username, password) */}
+          <DataSourceSection hideOptions onOpenInfoPanel={onOpenInfoPanel} />
+
           {basicInfo.engine !== Engine.DYNAMODB && (
             <>
-              <DataSourceSection
-                hideOptions
-                onOpenInfoPanel={onOpenInfoPanel}
-              />
-
               <div className="mt-6">
                 <SyncDatabases
                   isCreating={isCreating}

--- a/frontend/src/components/instance/InstanceFormBody.tsx
+++ b/frontend/src/components/instance/InstanceFormBody.tsx
@@ -696,6 +696,14 @@ interface InstanceFormBodyProps {
   onOpenInfoPanel?: (section: InfoSection) => void;
 }
 
+// Engines without a host field (or with a non-local default) drop the local
+// development placeholder host when the user switches to them.
+const clearLocalPlaceholderHost = (ds: EditDataSource) => {
+  if (ds.host === "127.0.0.1" || ds.host === "host.docker.internal") {
+    ds.host = "";
+  }
+};
+
 export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
   const { t } = useTranslation();
   const ctx = useInstanceFormContext();
@@ -951,35 +959,20 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
           const updated = { ...ds };
           switch (engine) {
             case Engine.SNOWFLAKE: {
-              if (
-                updated.host === "127.0.0.1" ||
-                updated.host === "host.docker.internal"
-              ) {
-                updated.host = "";
-              }
+              clearLocalPlaceholderHost(updated);
               break;
             }
             case Engine.DYNAMODB: {
               updated.authenticationType =
                 DataSource_AuthenticationType.AWS_RDS_IAM;
-              if (
-                updated.host === "127.0.0.1" ||
-                updated.host === "host.docker.internal"
-              ) {
-                updated.host = "";
-              }
+              clearLocalPlaceholderHost(updated);
               break;
             }
             case Engine.SPANNER:
             case Engine.BIGQUERY: {
               updated.authenticationType =
                 DataSource_AuthenticationType.GOOGLE_CLOUD_SQL_IAM;
-              if (
-                updated.host === "127.0.0.1" ||
-                updated.host === "host.docker.internal"
-              ) {
-                updated.host = "";
-              }
+              clearLocalPlaceholderHost(updated);
               break;
             }
             case Engine.COSMOSDB: {
@@ -1749,21 +1742,17 @@ export function InstanceFormBody({ onOpenInfoPanel }: InstanceFormBodyProps) {
           <DataSourceSection hideOptions onOpenInfoPanel={onOpenInfoPanel} />
 
           {basicInfo.engine !== Engine.DYNAMODB && (
-            <>
-              <div className="mt-6">
-                <SyncDatabases
-                  isCreating={isCreating}
-                  showLabel
-                  allowEdit={
-                    isCreating ? allowEdit && !!allowCreate : allowEdit
-                  }
-                  projectName={parent}
-                  onOpenInfoPanel={onOpenInfoPanel}
-                  syncDatabases={basicInfo.syncDatabases}
-                  onSyncDatabasesChange={handleChangeSyncDatabases}
-                />
-              </div>
-            </>
+            <div className="mt-6">
+              <SyncDatabases
+                isCreating={isCreating}
+                showLabel
+                allowEdit={isCreating ? allowEdit && !!allowCreate : allowEdit}
+                projectName={parent}
+                onOpenInfoPanel={onOpenInfoPanel}
+                syncDatabases={basicInfo.syncDatabases}
+                onSyncDatabasesChange={handleChangeSyncDatabases}
+              />
+            </div>
           )}
         </div>
 

--- a/frontend/src/components/instance/InstanceFormContext.test.tsx
+++ b/frontend/src/components/instance/InstanceFormContext.test.tsx
@@ -5,6 +5,8 @@ import { createRoot } from "react-dom/client";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { Engine, State } from "@/types/proto-es/v1/common_pb";
 import {
+  DataSource_AuthenticationType,
+  DataSource_AWSCredentialSchema,
   DataSourceSchema,
   DataSourceType,
   InstanceSchema,
@@ -12,6 +14,7 @@ import {
 import { ProjectSchema } from "@/types/proto-es/v1/project_service_pb";
 import { PlanFeature } from "@/types/proto-es/v1/subscription_service_pb";
 import { unknownInstance } from "@/types/v1/instance";
+import { wrapEditDataSource } from "./common";
 import {
   InstanceFormProvider,
   useInstanceFormContext,
@@ -373,5 +376,87 @@ describe("InstanceFormProvider", () => {
     ).toBeNull();
 
     harness.unmount();
+  });
+
+  describe("checkDataSource AWS region requirement", () => {
+    const awsDataSource = (region: string, withCredential: boolean) => {
+      const ds = wrapEditDataSource(
+        create(DataSourceSchema, {
+          id: "admin",
+          type: DataSourceType.ADMIN,
+          authenticationType: DataSource_AuthenticationType.AWS_RDS_IAM,
+          region,
+        })
+      );
+      if (withCredential) {
+        ds.iamExtension = {
+          case: "awsCredential",
+          value: create(DataSource_AWSCredentialSchema, {}),
+        };
+      }
+      return ds;
+    };
+
+    const CheckDataSourceProbe = () => {
+      const ctx = useInstanceFormContext();
+      return (
+        <div
+          data-credential-no-region={String(
+            ctx.checkDataSource([awsDataSource("", true)])
+          )}
+          data-credential-with-region={String(
+            ctx.checkDataSource([awsDataSource("us-east-1", true)])
+          )}
+          data-default-chain-no-region={String(
+            ctx.checkDataSource([awsDataSource("", false)])
+          )}
+        />
+      );
+    };
+
+    const instanceOfEngine = (engine: Engine) =>
+      create(InstanceSchema, {
+        name: "instances/aws-check",
+        title: "AWS check",
+        engine,
+        environment: "environments/prod",
+        dataSources: [
+          create(DataSourceSchema, { id: "admin", type: DataSourceType.ADMIN }),
+        ],
+      });
+
+    test("DynamoDB requires a region only with a specific credential", async () => {
+      const harness = renderIntoContainer();
+
+      await harness.render(
+        <InstanceFormProvider instance={instanceOfEngine(Engine.DYNAMODB)}>
+          <CheckDataSourceProbe />
+        </InstanceFormProvider>
+      );
+
+      const probe = harness.container.firstElementChild as HTMLElement;
+      expect(probe.dataset.credentialNoRegion).toBe("false");
+      expect(probe.dataset.credentialWithRegion).toBe("true");
+      expect(probe.dataset.defaultChainNoRegion).toBe("true");
+
+      harness.unmount();
+    });
+
+    test("other engines require a region for AWS IAM even on the default credential chain", async () => {
+      const harness = renderIntoContainer();
+
+      await harness.render(
+        <InstanceFormProvider instance={instanceOfEngine(Engine.POSTGRES)}>
+          <CheckDataSourceProbe />
+        </InstanceFormProvider>
+      );
+
+      const probe = harness.container.firstElementChild as HTMLElement;
+      expect(probe.dataset.credentialNoRegion).toBe("false");
+      expect(probe.dataset.credentialWithRegion).toBe("true");
+      expect(probe.dataset.defaultChainNoRegion).toBe("false");
+
+      harness.unmount();
+    });
   });
 });

--- a/frontend/src/components/instance/InstanceFormContext.tsx
+++ b/frontend/src/components/instance/InstanceFormContext.tsx
@@ -290,6 +290,12 @@ export function InstanceFormProvider({
         if (
           ds.authenticationType === DataSource_AuthenticationType.AWS_RDS_IAM
         ) {
+          // DynamoDB can run on the deployment's default credential chain,
+          // where the region may also come from the environment. A specific
+          // credential must pin its region.
+          if (basicInfo.engine === Engine.DYNAMODB) {
+            return ds.iamExtension?.case !== "awsCredential" || !!ds.region;
+          }
           return !!ds.region;
         }
         if (basicInfo.engine === Engine.ORACLE) {

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1037,6 +1037,7 @@
     },
     "create-gcp-credentials": "To create credentials, see",
     "database-region": "Database Region",
+    "database-region-placeholder": "database region, for example, us-east-1",
     "default-role": "Default role",
     "delete-active-confirmation": "Instance \"{{name}}\" is active. Bytebase will archive it first, then permanently delete it. This action cannot be undone. Type the instance ID \"{{id}}\" to confirm.",
     "delete-confirmation": "This will permanently delete instance \"{{name}}\". This action cannot be undone. Type the instance ID \"{{id}}\" to confirm.",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1037,6 +1037,7 @@
     },
     "create-gcp-credentials": "Para crear credenciales, consulte",
     "database-region": "Región de la base de datos",
+    "database-region-placeholder": "región de la base de datos, por ejemplo us-east-1",
     "default-role": "Rol predeterminado",
     "delete-active-confirmation": "La instancia \"{{name}}\" está activa. Bytebase la archivará primero y luego la eliminará permanentemente. Esta acción no se puede deshacer. Escribe el ID de la instancia \"{{id}}\" para confirmar.",
     "delete-confirmation": "Esto eliminará permanentemente la instancia \"{{name}}\". Esta acción no se puede deshacer. Escribe el ID de la instancia \"{{id}}\" para confirmar.",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1037,6 +1037,7 @@
     },
     "create-gcp-credentials": "認証情報の作成方法については、を参照してください",
     "database-region": "データベース領域",
+    "database-region-placeholder": "データベースのリージョン（例: us-east-1）",
     "default-role": "デフォルトロール",
     "delete-active-confirmation": "インスタンス「{{name}}」はアクティブです。Bytebase はまずアーカイブしてから完全に削除します。この操作は元に戻せません。確認するにはインスタンス ID「{{id}}」を入力してください。",
     "delete-confirmation": "インスタンス「{{name}}」を完全に削除します。この操作は元に戻せません。確認するにはインスタンス ID「{{id}}」を入力してください。",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1037,6 +1037,7 @@
     },
     "create-gcp-credentials": "Để tạo thông tin xác thực, xem",
     "database-region": "Khu vực cơ sở dữ liệu",
+    "database-region-placeholder": "khu vực cơ sở dữ liệu, ví dụ us-east-1",
     "default-role": "Vai trò mặc định",
     "delete-active-confirmation": "Instance \"{{name}}\" đang hoạt động. Bytebase sẽ lưu trữ instance này trước, sau đó xóa vĩnh viễn. Không thể hoàn tác hành động này. Nhập ID instance \"{{id}}\" để xác nhận.",
     "delete-confirmation": "Thao tác này sẽ xóa vĩnh viễn instance \"{{name}}\". Không thể hoàn tác hành động này. Nhập ID instance \"{{id}}\" để xác nhận.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1037,6 +1037,7 @@
     },
     "create-gcp-credentials": "创建凭据的方法见",
     "database-region": "数据库区域",
+    "database-region-placeholder": "数据库区域，例如 us-east-1",
     "default-role": "默认角色",
     "delete-active-confirmation": "实例“{{name}}”当前处于活动状态。Bytebase 将先归档该实例，然后永久删除它。此操作无法撤销。请输入实例 ID “{{id}}” 以确认。",
     "delete-confirmation": "这将永久删除实例“{{name}}”。此操作无法撤销。请输入实例 ID “{{id}}” 以确认。",


### PR DESCRIPTION
Closes BYT-10051 (customer: multi-account DynamoDB via per-instance credentials).

## Problem

DynamoDB instances could only use the deployment's ambient AWS identity:

- The driver loaded per-datasource region + static keys (`util.GetAWSConnectionConfig`, since #18789) but never called `util.AssumeRoleIfNeeded` — a stored `role_arn`/`external_id` was **silently ignored**, so per-instance cross-account role assumption did not work even via API/Terraform.
- The instance form hid the whole credential section for DynamoDB, so none of this was configurable from the UI (unlike RDS MySQL/Postgres and Elasticsearch).

## Change

**Backend**
- `Open` in the DynamoDB driver now calls `util.AssumeRoleIfNeeded`, mirroring the Elasticsearch driver.
- `util.AssumeRoleIfNeeded` wraps the assume-role provider in `aws.NewCredentialsCache` (the documented `stscreds` usage): temporary credentials are cached and refreshed before expiry instead of one STS AssumeRole round-trip per AWS API request. This also benefits the existing Elasticsearch/RDS IAM callers and makes the 1h session duration meaningful.

**Frontend**
- The DynamoDB form renders the AWS IAM credential section: credential source (default chain / specific credential), access keys, Role ARN, External ID, and Region — all reusing the existing `CredentialSourceForm`.
- New DynamoDB data sources are created with `AWS_RDS_IAM` authentication (same pattern as Spanner/BigQuery/CosmosDB forcing their IAM modes). The Snowflake arm was split out of the previously shared engine-switch case purely so only DynamoDB receives the stamp (no Snowflake behavior change).
- Legacy DynamoDB data sources (created before this change, still `PASSWORD`) render in the AWS IAM mode without being mutated; the real authentication type is stamped only when a credential field is edited, so opening an old instance does not dirty the form. In SaaS mode the shared form instead forces specific-credential on open — the policy every IAM engine inherits there.
- Region is required only with a specific credential; on the default chain it stays optional (the environment can provide it), preserving existing setups.
- The Admin/read-only data source tabs stay hidden for DynamoDB (single admin data source) **unless** a read-only data source already exists via the API — then the tabs render so it stays reachable.

## Upgrade note

DynamoDB data sources that already carry a `role_arn` (settable via API/Terraform, previously inert) start **enforcing** it after this change: the role must actually be assumable by the base credentials. Validate with Test Connection after upgrading.

## Verification

- **Unit (RED→GREEN)**: hermetic driver tests (fake env credentials, STS pointed at an unroutable endpoint, single-attempt retry, immune to ambient `AWS_PROFILE`/shared config) prove `Open` attempts AssumeRole when `role_arn` is set and skips STS when it is not. Frontend unit tests cover the DynamoDB region-requirement branch of `checkDataSource` with a non-DynamoDB contrast.
- **Live E2E against real AWS STS + DynamoDB**: test role with an `sts:ExternalId` trust condition; through the running app, Test Connection **succeeded** with the correct external ID and **failed** with the driver's typed error on a wrong one (`failed to assume role ...: access denied (external ID configured: wrong-external-id)`) — the discriminator that the role is really assumed, since the pre-fix driver silently succeeded on base credentials. Instance sync produced the `{account-id}-{region}` pseudo-database and listed the test table under the assumed role's permissions.
- **Legacy compat**: an API-created `PASSWORD`-auth DynamoDB instance renders with Default credential source, optional region, and no forced state change.

## Known follow-up (pre-existing, all AWS IAM engines)

Editing one field of a stored AWS credential replaces the whole credential with the form's blanked read-back, silently erasing the stored key pair — tracked in BOT-51; not specific to DynamoDB and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)