### PR TITLE
chore: demo gofmt violation for golangci lint

### DIFF
--- a/backend/common/retry.go
+++ b/backend/common/retry.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// Just choose an empirical timeout value. The default 15 minutes seems too long.
-	timeout         = 5 * time.Minute
+	timeout = 5 * time.Minute
 	initialInterval = 5 * time.Second
 )
 


### PR DESCRIPTION
Intentionally introduces a gofmt formatting violation in `backend/common/retry.go` (misaligned const block) to demonstrate golangci-lint CI failures.

Expected CI lint failure:

```
backend/common/retry.go:13:1: File is not properly formatted (goimports)
```

This PR is a demo and should not be merged.