### PR TITLE
fix(frontend): land EDITOR-mode workspaces on the SQL Editor after re-auth

### DIFF
--- a/frontend/src/app/router/guard.test.ts
+++ b/frontend/src/app/router/guard.test.ts
@@ -1,5 +1,6 @@
 import { matchRoutes, RouterContextProvider } from "react-router";
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { DatabaseChangeMode } from "@/types/proto-es/v1/setting_service_pb";
 
 // Configurable fake session, controlled per test.
 const session = {
@@ -10,6 +11,8 @@ const session = {
   hasTwoFa: false,
   isSaaSMode: false,
   currentUser: undefined as { mfaEnabled: boolean } | undefined,
+  // Mirrors the store default: PIPELINE until the workspace profile loads.
+  databaseChangeMode: DatabaseChangeMode.PIPELINE,
 };
 
 const resets = {
@@ -28,6 +31,9 @@ vi.mock("@/stores/app", () => ({
       hasFeature: () => session.hasTwoFa,
       isSaaSMode: () => session.isSaaSMode,
       currentUser: session.currentUser,
+      appFeatures: {
+        "bb.feature.database-change-mode": session.databaseChangeMode,
+      },
       ...resets,
     }),
   },
@@ -46,7 +52,10 @@ import {
   AUTH_SIGNIN_MODULE,
   AUTH_SIGNUP_MODULE,
   PROJECT_V1_ROUTE_DASHBOARD,
+  SQL_EDITOR_HOME_MODULE,
+  WORKSPACE_ROOT_MODULE,
   WORKSPACE_ROUTE_404,
+  WORKSPACE_ROUTE_LANDING,
 } from "./handles";
 import { setRouteNameIndex } from "./navigation";
 import { routes } from "./routes";
@@ -59,6 +68,7 @@ beforeEach(() => {
   session.hasTwoFa = false;
   session.isSaaSMode = false;
   session.currentUser = undefined;
+  session.databaseChangeMode = DatabaseChangeMode.PIPELINE;
   vi.clearAllMocks();
   setRouteNameIndex(
     new Map<string, string>([
@@ -66,6 +76,8 @@ beforeEach(() => {
       [AUTH_2FA_SETUP_MODULE, "/auth/2fa-setup"],
       [AUTH_PASSWORD_RESET_MODULE, "/auth/password-reset"],
       [WORKSPACE_ROUTE_404, "/404"],
+      [SQL_EDITOR_HOME_MODULE, "/sql-editor"],
+      [WORKSPACE_ROUTE_LANDING, "/landing"],
     ])
   );
 });
@@ -100,6 +112,24 @@ async function runCatchAllLoader(path: string): Promise<Response> {
 describe("rootGuard", () => {
   test("error page is allowed directly", () => {
     expect(run(WORKSPACE_ROUTE_404, "/404")).toBeNull();
+  });
+
+  test("root sends an EDITOR workspace to the SQL Editor", () => {
+    session.isLoggedIn = true;
+    session.databaseChangeMode = DatabaseChangeMode.EDITOR;
+
+    expect(location(run(WORKSPACE_ROOT_MODULE, "/"))).toBe("/sql-editor");
+  });
+
+  // Documents why `login()` must load the workspace profile before it
+  // navigates: this guard cannot tell "not loaded" from "PIPELINE", and the
+  // last-visit fallback ignores /sql-editor, so an EDITOR workspace whose
+  // profile is still unloaded lands here instead of the editor.
+  test("root falls back to landing while the workspace profile is unloaded", () => {
+    session.isLoggedIn = true;
+    session.databaseChangeMode = DatabaseChangeMode.PIPELINE;
+
+    expect(location(run(WORKSPACE_ROOT_MODULE, "/"))).toBe("/landing");
   });
 
   test("logged-out user on an unknown URL matched by the 404 catch-all is redirected to signin", () => {

--- a/frontend/src/app/router/guard.ts
+++ b/frontend/src/app/router/guard.ts
@@ -95,8 +95,13 @@ const ALLOWED_ROUTE_PATTERNS = [
 //   - EDITOR change-mode workspaces go to the SQL Editor home
 //   - otherwise the user's last meaningful visit, if any
 //   - falling back to the landing page
-// `loadWorkspaceProfile()` is awaited before the router mounts (see main.ts),
-// so `appFeatures` is populated by the time this runs.
+// `appFeatures` must already hold the workspace profile when this runs. Two
+// callers guarantee that: `main.ts` awaits `loadWorkspaceProfile()` before
+// mounting when the boot already had a session, and `login()` awaits it before
+// navigating when the boot did not. A signed-out boot cannot read the profile
+// (the setting is authenticated-only), so any future auth path that navigates
+// here must load it first or EDITOR workspaces silently fall through to the
+// landing page.
 function resolveRootRedirect(
   store: ReturnType<typeof useAppStore.getState>
 ): string {

--- a/frontend/src/app/router/guard.ts
+++ b/frontend/src/app/router/guard.ts
@@ -95,12 +95,14 @@ const ALLOWED_ROUTE_PATTERNS = [
 //   - EDITOR change-mode workspaces go to the SQL Editor home
 //   - otherwise the user's last meaningful visit, if any
 //   - falling back to the landing page
-// This is the single owner of "where does '/' go". It reads `appFeatures`, so
-// every caller that navigates to "/" must have loaded the workspace profile
-// first. A signed-out boot cannot load it (the setting is authenticated-only),
-// so the auth paths load it themselves before they navigate; miss that and an
-// EDITOR workspace silently falls through to the landing page. The loader must
-// resolve synchronously (see AppRoot), so it cannot fetch the profile itself.
+// Resolves "/" for the auth paths, which navigate here rather than deciding
+// themselves. It reads `appFeatures`, so every caller that navigates to "/"
+// must have loaded the workspace profile first. A signed-out boot cannot load
+// it (the setting is authenticated-only), so `login()` and `signup()` load it
+// before they navigate; miss that and an EDITOR workspace silently falls
+// through to the landing page. The loader must resolve synchronously (see
+// AppRoot), so it cannot fetch the profile itself. `SetupPage.homePath` still
+// keeps its own copy of the EDITOR rule; folding it in here is a follow-up.
 function resolveRootRedirect(
   store: ReturnType<typeof useAppStore.getState>
 ): string {

--- a/frontend/src/app/router/guard.ts
+++ b/frontend/src/app/router/guard.ts
@@ -95,13 +95,12 @@ const ALLOWED_ROUTE_PATTERNS = [
 //   - EDITOR change-mode workspaces go to the SQL Editor home
 //   - otherwise the user's last meaningful visit, if any
 //   - falling back to the landing page
-// `appFeatures` must already hold the workspace profile when this runs. Two
-// callers guarantee that: `main.ts` awaits `loadWorkspaceProfile()` before
-// mounting when the boot already had a session, and `login()` awaits it before
-// navigating when the boot did not. A signed-out boot cannot read the profile
-// (the setting is authenticated-only), so any future auth path that navigates
-// here must load it first or EDITOR workspaces silently fall through to the
-// landing page.
+// This is the single owner of "where does '/' go". It reads `appFeatures`, so
+// every caller that navigates to "/" must have loaded the workspace profile
+// first. A signed-out boot cannot load it (the setting is authenticated-only),
+// so the auth paths load it themselves before they navigate; miss that and an
+// EDITOR workspace silently falls through to the landing page. The loader must
+// resolve synchronously (see AppRoot), so it cannot fetch the profile itself.
 function resolveRootRedirect(
   store: ReturnType<typeof useAppStore.getState>
 ): string {

--- a/frontend/src/app/router/guard.ts
+++ b/frontend/src/app/router/guard.ts
@@ -95,8 +95,8 @@ const ALLOWED_ROUTE_PATTERNS = [
 //   - EDITOR change-mode workspaces go to the SQL Editor home
 //   - otherwise the user's last meaningful visit, if any
 //   - falling back to the landing page
-// Resolves "/", which has no page of its own. It reads `appFeatures`, so every
-// caller that navigates here must have loaded the workspace profile first:
+// It reads `appFeatures`, so every caller that navigates here must have loaded
+// the workspace profile first:
 // `main.ts` awaits it before mounting when the boot already had a session, and
 // `login()`/`signup()` await it before navigating when it did not (a signed-out
 // boot cannot load it, the setting is authenticated-only). Miss that and an

--- a/frontend/src/app/router/guard.ts
+++ b/frontend/src/app/router/guard.ts
@@ -95,14 +95,15 @@ const ALLOWED_ROUTE_PATTERNS = [
 //   - EDITOR change-mode workspaces go to the SQL Editor home
 //   - otherwise the user's last meaningful visit, if any
 //   - falling back to the landing page
-// Resolves "/" for the auth paths, which navigate here rather than deciding
-// themselves. It reads `appFeatures`, so every caller that navigates to "/"
-// must have loaded the workspace profile first. A signed-out boot cannot load
-// it (the setting is authenticated-only), so `login()` and `signup()` load it
-// before they navigate; miss that and an EDITOR workspace silently falls
-// through to the landing page. The loader must resolve synchronously (see
-// AppRoot), so it cannot fetch the profile itself. `SetupPage.homePath` still
-// keeps its own copy of the EDITOR rule; folding it in here is a follow-up.
+// Resolves "/", which has no page of its own. It reads `appFeatures`, so every
+// caller that navigates here must have loaded the workspace profile first:
+// `main.ts` awaits it before mounting when the boot already had a session, and
+// `login()`/`signup()` await it before navigating when it did not (a signed-out
+// boot cannot load it, the setting is authenticated-only). Miss that and an
+// EDITOR workspace silently falls through to the landing page. This loader
+// resolves synchronously (see AppRoot), so it does not fetch the profile
+// itself. `SetupPage.homePath` still keeps its own copy of the EDITOR rule;
+// folding it in here is a follow-up.
 function resolveRootRedirect(
   store: ReturnType<typeof useAppStore.getState>
 ): string {

--- a/frontend/src/app/router/routes.test.tsx
+++ b/frontend/src/app/router/routes.test.tsx
@@ -69,6 +69,21 @@ function collectBareLeaves(
   return bare;
 }
 
+describe("workspace root", () => {
+  // The redirect for "/" is decided by `rootGuard` in the index route's loader,
+  // not by a static <Navigate>. `login()` and `signup()` rely on that seam:
+  // they navigate to "/" and expect the guard to resolve the real destination.
+  // Lose the loader and an EDITOR workspace silently lands on the landing page,
+  // which is the customer bug this guards.
+  it("matches an index route carrying a loader", () => {
+    const matched = matchRoutes(routes, "/");
+    const leaf = matched?.at(-1)?.route;
+
+    expect(leaf).toBeDefined();
+    expect(typeof leaf?.loader).toBe("function");
+  });
+});
+
 describe("react route table reachability", () => {
   it("every leaf route renders something or redirects (no blank-body bare leaves)", () => {
     expect(collectBareLeaves(routes)).toEqual([]);

--- a/frontend/src/stores/app/auth.ts
+++ b/frontend/src/stores/app/auth.ts
@@ -9,7 +9,6 @@ import {
   AUTH_PROFILE_SETUP_MODULE,
   AUTH_SIGNIN_MODULE,
   SETUP_MODULE,
-  SQL_EDITOR_HOME_MODULE,
 } from "@/app/router/handles";
 import {
   navigateByName,
@@ -21,7 +20,6 @@ import {
   SendEmailLoginCodeRequestSchema,
   SignupRequestSchema,
 } from "@/types/proto-es/v1/auth_service_pb";
-import { DatabaseChangeMode } from "@/types/proto-es/v1/setting_service_pb";
 import type { User } from "@/types/proto-es/v1/user_service_pb";
 import { UNKNOWN_USER_NAME } from "@/types/v1/user";
 import { storageKeyResetPassword } from "@/utils/storage-keys";
@@ -146,7 +144,7 @@ export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
     const redirectQuery = new URLSearchParams(window.location.search).get(
       "redirect"
     );
-    let nextPage = redirectUrl ?? (redirectQuery || "/");
+    const nextPage = redirectUrl ?? (redirectQuery || "/");
     if (resp.mfaTempToken) {
       set({ unauthenticatedOccurred: false });
       navigateByName(AUTH_MFA_MODULE, {
@@ -165,24 +163,16 @@ export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
     await get().fetchServerInfo(user?.workspace);
     // Re-fetch the current workspace now that we're authenticated.
     await get().loadWorkspace();
-    // The workspace profile is only fetchable once authenticated, so a boot
-    // that started signed out left `appFeatures` at its PIPELINE default.
-    // Load it before anything reads the change mode below — `rootGuard`'s
-    // `resolveRootRedirect` reads the same store right after we navigate.
+    // `rootGuard` decides where "/" goes, and it reads the workspace change
+    // mode from this store. The profile is only fetchable once authenticated,
+    // so a boot that started signed out left `appFeatures` at its PIPELINE
+    // default and an EDITOR workspace would fall through to the landing page.
     // `force` because a previous user's profile must not survive a re-auth.
     await get().loadWorkspaceProfile(true);
 
     // After user login, reset the auth session key.
     set({ authSessionKey: uniqueId() });
 
-    if (
-      redirectUrl === undefined &&
-      !redirectQuery &&
-      get().appFeatures["bb.feature.database-change-mode"] ===
-        DatabaseChangeMode.EDITOR
-    ) {
-      nextPage = resolvePath(SQL_EDITOR_HOME_MODULE);
-    }
     if (resp.requireResetPassword) {
       navigateByName(AUTH_PASSWORD_RESET_MODULE, {
         query: { redirect: nextPage },
@@ -218,6 +208,9 @@ export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
     }
 
     await get().fetchServerInfo(user?.workspace);
+    // See `login()`. Loaded above the onboarding branch because `SetupPage`
+    // reads the change mode too, and its skip button navigates to "/".
+    await get().loadWorkspaceProfile(true);
     set({ authSessionKey: uniqueId() });
 
     if (get().enableOnboarding()) {
@@ -225,20 +218,10 @@ export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
       return;
     }
 
-    // See `login()`: `appFeatures` is still at its default until the profile
-    // is loaded, and signup boots signed out by definition.
-    await get().loadWorkspaceProfile(true);
-
-    const getRedirectQuery = () =>
-      new URLSearchParams(window.location.search).get("redirect");
-    let nextPage = getRedirectQuery() || "/";
-    if (
-      get().appFeatures["bb.feature.database-change-mode"] ===
-      DatabaseChangeMode.EDITOR
-    ) {
-      nextPage = resolvePath(SQL_EDITOR_HOME_MODULE);
-    }
-    navigateToPath(nextPage, { replace: true });
+    const redirectQuery = new URLSearchParams(window.location.search).get(
+      "redirect"
+    );
+    navigateToPath(redirectQuery || "/", { replace: true });
   },
 
   logout: async () => {

--- a/frontend/src/stores/app/auth.ts
+++ b/frontend/src/stores/app/auth.ts
@@ -165,6 +165,12 @@ export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
     await get().fetchServerInfo(user?.workspace);
     // Re-fetch the current workspace now that we're authenticated.
     await get().loadWorkspace();
+    // The workspace profile is only fetchable once authenticated, so a boot
+    // that started signed out left `appFeatures` at its PIPELINE default.
+    // Load it before anything reads the change mode below — `rootGuard`'s
+    // `resolveRootRedirect` reads the same store right after we navigate.
+    // `force` because a previous user's profile must not survive a re-auth.
+    await get().loadWorkspaceProfile(true);
 
     // After user login, reset the auth session key.
     set({ authSessionKey: uniqueId() });
@@ -218,6 +224,10 @@ export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
       navigateByName(SETUP_MODULE, { replace: true });
       return;
     }
+
+    // See `login()`: `appFeatures` is still at its default until the profile
+    // is loaded, and signup boots signed out by definition.
+    await get().loadWorkspaceProfile(true);
 
     const getRedirectQuery = () =>
       new URLSearchParams(window.location.search).get("redirect");

--- a/frontend/src/stores/app/index.test.ts
+++ b/frontend/src/stores/app/index.test.ts
@@ -450,8 +450,10 @@ const timestampSeconds = (seconds: number) => ({
 beforeEach(() => {
   vi.clearAllMocks();
   // Tests here stub `location`; without this the stub leaks into every test
-  // declared after it, with only the keys that test happened to supply.
+  // declared after it, with only the keys that test happened to supply. The
+  // unstub is blanket, so re-install the localStorage mock it also removes.
   vi.unstubAllGlobals();
+  vi.stubGlobal("localStorage", mocks.localStorage);
   localStorage.clear();
 });
 

--- a/frontend/src/stores/app/index.test.ts
+++ b/frontend/src/stores/app/index.test.ts
@@ -101,6 +101,7 @@ const mocks = vi.hoisted(() => ({
       return serialized ? `${base}?${serialized}` : base;
     }
   ),
+  signup: vi.fn(),
   getActuatorInfo: vi.fn(),
   getWorkspace: vi.fn(),
   updateWorkspace: vi.fn(),
@@ -192,6 +193,7 @@ vi.mock("@/api", () => ({
   authServiceClientConnect: {
     login: mocks.login,
     logout: mocks.logout,
+    signup: mocks.signup,
   },
   projectServiceClientConnect: {
     getProject: mocks.getProject,
@@ -585,7 +587,47 @@ describe("useAppStore", () => {
     expect(
       store.getState().appFeatures["bb.feature.database-change-mode"]
     ).toBe(DatabaseChangeMode.EDITOR);
-    expect(mocks.navigateToPath).toHaveBeenCalledWith("/sql-editor", {
+    // `rootGuard` owns the "/" policy and turns this into the SQL Editor; see
+    // the root-redirect tests in app/router/guard.test.ts. What `login()` owes
+    // it is a loaded profile, asserted above.
+    expect(mocks.navigateToPath).toHaveBeenCalledWith("/", { replace: true });
+  });
+
+  // Regression guard: `signup()` used to override the destination with the SQL
+  // Editor whenever the mode read EDITOR, with no check for an explicit
+  // redirect. That branch was dead (signup always boots signed out, so the mode
+  // was never EDITOR) until the profile load made it live, which would have
+  // silently dropped deep links.
+  test("signup keeps an explicit redirect in an EDITOR workspace", async () => {
+    vi.stubGlobal("location", { search: "?redirect=%2Fprojects%2Ffoo" });
+    mocks.signup.mockResolvedValue({});
+    mocks.getCurrentUser.mockResolvedValue(user);
+    // activeUserCount > 1 so `enableOnboarding()` is false and signup navigates.
+    mocks.getActuatorInfo.mockResolvedValue({
+      workspace: user.workspace,
+      activeUserCount: 2,
+    });
+    mocks.getSetting.mockResolvedValue(
+      createProto(SettingSchema, {
+        value: createProto(SettingValueSchema, {
+          value: {
+            case: "workspaceProfile",
+            value: createProto(WorkspaceProfileSettingSchema, {
+              databaseChangeMode: DatabaseChangeMode.EDITOR,
+            }),
+          },
+        }),
+      })
+    );
+    const store = createAppStore();
+
+    await store.getState().signup({
+      email: user.email,
+      name: "Test",
+      password: "secret",
+    } as never);
+
+    expect(mocks.navigateToPath).toHaveBeenCalledWith("/projects/foo", {
       replace: true,
     });
   });

--- a/frontend/src/stores/app/index.test.ts
+++ b/frontend/src/stores/app/index.test.ts
@@ -527,13 +527,21 @@ describe("useAppStore", () => {
     mocks.getCurrentUser.mockResolvedValue(user);
     mocks.getActuatorInfo.mockResolvedValue({ workspace: user.workspace });
     mocks.getWorkspace.mockResolvedValue({ name: user.workspace });
+    // `login()` loads the profile itself, so EDITOR mode comes from the server
+    // rather than a seeded `appFeatures`.
+    mocks.getSetting.mockResolvedValue(
+      createProto(SettingSchema, {
+        value: createProto(SettingValueSchema, {
+          value: {
+            case: "workspaceProfile",
+            value: createProto(WorkspaceProfileSettingSchema, {
+              databaseChangeMode: DatabaseChangeMode.EDITOR,
+            }),
+          },
+        }),
+      })
+    );
     const store = createAppStore();
-    store.setState({
-      appFeatures: {
-        ...store.getState().appFeatures,
-        "bb.feature.database-change-mode": DatabaseChangeMode.EDITOR,
-      },
-    });
 
     await store.getState().login({
       request: { email: user.email, password: "secret" } as never,
@@ -541,6 +549,43 @@ describe("useAppStore", () => {
     });
 
     expect(mocks.navigateToPath).toHaveBeenCalledWith(redirectUrl, {
+      replace: true,
+    });
+  });
+
+  // Regression guard (customer report): signing in from the bare root left
+  // `appFeatures` at its PIPELINE default, because a signed-out boot never
+  // fetches the workspace profile and `login()` did not fetch it either. The
+  // EDITOR branch below then failed and the user landed on the workspace
+  // landing page instead of the SQL Editor. Note this test seeds no
+  // `appFeatures` — the profile must come from the server during `login()`.
+  test("login loads the workspace profile before choosing the next page", async () => {
+    mocks.login.mockResolvedValue({ requireResetPassword: false });
+    mocks.getCurrentUser.mockResolvedValue(user);
+    mocks.getActuatorInfo.mockResolvedValue({ workspace: user.workspace });
+    mocks.getWorkspace.mockResolvedValue({ name: user.workspace });
+    mocks.getSetting.mockResolvedValue(
+      createProto(SettingSchema, {
+        value: createProto(SettingValueSchema, {
+          value: {
+            case: "workspaceProfile",
+            value: createProto(WorkspaceProfileSettingSchema, {
+              databaseChangeMode: DatabaseChangeMode.EDITOR,
+            }),
+          },
+        }),
+      })
+    );
+    const store = createAppStore();
+
+    await store.getState().login({
+      request: { email: user.email, password: "secret" } as never,
+    });
+
+    expect(
+      store.getState().appFeatures["bb.feature.database-change-mode"]
+    ).toBe(DatabaseChangeMode.EDITOR);
+    expect(mocks.navigateToPath).toHaveBeenCalledWith("/sql-editor", {
       replace: true,
     });
   });

--- a/frontend/src/stores/app/index.test.ts
+++ b/frontend/src/stores/app/index.test.ts
@@ -449,6 +449,9 @@ const timestampSeconds = (seconds: number) => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Tests here stub `location`; without this the stub leaks into every test
+  // declared after it, with only the keys that test happened to supply.
+  vi.unstubAllGlobals();
   localStorage.clear();
 });
 
@@ -605,7 +608,7 @@ describe("useAppStore", () => {
     // activeUserCount > 1 so `enableOnboarding()` is false and signup navigates.
     mocks.getActuatorInfo.mockResolvedValue({
       workspace: user.workspace,
-      activeUserCount: 2,
+      activatedUserCount: 2,
     });
     mocks.getSetting.mockResolvedValue(
       createProto(SettingSchema, {
@@ -630,6 +633,43 @@ describe("useAppStore", () => {
     expect(mocks.navigateToPath).toHaveBeenCalledWith("/projects/foo", {
       replace: true,
     });
+  });
+
+  // Guards signup's own `loadWorkspaceProfile` call. The explicit-redirect test
+  // above returns before `rootGuard` is consulted, so it passes with or without
+  // the load; this one pins that a no-redirect signup hands the guard a loaded
+  // profile, which is what sends an EDITOR workspace to the SQL Editor.
+  test("signup loads the workspace profile before choosing the next page", async () => {
+    mocks.signup.mockResolvedValue({});
+    mocks.getCurrentUser.mockResolvedValue(user);
+    mocks.getActuatorInfo.mockResolvedValue({
+      workspace: user.workspace,
+      activatedUserCount: 2,
+    });
+    mocks.getSetting.mockResolvedValue(
+      createProto(SettingSchema, {
+        value: createProto(SettingValueSchema, {
+          value: {
+            case: "workspaceProfile",
+            value: createProto(WorkspaceProfileSettingSchema, {
+              databaseChangeMode: DatabaseChangeMode.EDITOR,
+            }),
+          },
+        }),
+      })
+    );
+    const store = createAppStore();
+
+    await store.getState().signup({
+      email: user.email,
+      name: "Test",
+      password: "secret",
+    } as never);
+
+    expect(
+      store.getState().appFeatures["bb.feature.database-change-mode"]
+    ).toBe(DatabaseChangeMode.EDITOR);
+    expect(mocks.navigateToPath).toHaveBeenCalledWith("/", { replace: true });
   });
 
   test("lists groups and populates the group cache", async () => {


### PR DESCRIPTION
Fixes BYT-10056. Customer-reported (Lucid), on 3.20.0.

> We have Bytebase configured to land on the SQL Editor page, but when I re-auth it always redirects me to the workspace instead.

## The bug

`appFeatures` is only populated by `loadWorkspaceProfile()`, and `main.ts` calls that at bootstrap **only when a session already exists**. A sign-in boots signed out, so the profile is never fetched (the setting is authenticated-only and 401s). `login()` refreshed the user, server info and workspace list but not the profile, so both the EDITOR check in `login()` and the one in `rootGuard`'s `resolveRootRedirect()` read the hard-coded `PIPELINE` default. `resolveRootRedirect` then fell through to the landing page, because the last-visit fallback deliberately ignores `/sql-editor` paths.

Regression from **3.19.0** (`f75589919e`), which replaced the reactive Vue `DummyRootView` watcher with a one-shot router-loader read. The branch logic was ported faithfully; the timing was not. Still present through 3.21.0, so upgrading does not help.

## The fix

Load the workspace profile in `login()` and `signup()` before anything reads the change mode. Authentication is the first moment the setting is readable.

Then delete both store-level EDITOR branches and navigate to `"/"`, letting `resolveRootRedirect()` resolve it. It already owns "where does `/` go"; the branches were copies of that policy that disagreed with each other and with the guard. They only fired when the destination was already `"/"`, so this is behavior-preserving. `auth.ts` is 17 lines shorter.

That divergence was not cosmetic: `signup()`'s copy had no redirect check, and it had been dead only because signup boots signed out. Loading the profile would have woken it up and started dropping deep links.

## Verification

Live, against a running instance with `databaseChangeMode = EDITOR`, via an isolated-Chrome Playwright repro. Before, signing in from the bare root landed on `/landing`, with the profile arriving 21ms **after** the redirect was decided. After, both the bare root and a `/sql-editor` deep link land on the SQL Editor.

Tests, all mutation-verified (each fails when the code it covers is removed):
- `login()` hands `rootGuard` a loaded profile and navigates to `"/"`
- `signup()` does the same, and keeps an explicit `?redirect`
- `rootGuard` sends EDITOR to the SQL Editor, and falls back to landing while the profile is unloaded (the bug, documented)
- matching `"/"` yields a route with a loader (the seam the fix depends on)

The root-redirect path had no coverage at all before this.

Full suite: 440 files / 3532 tests.

## Known follow-ups (not in this PR)

- `SetupPage.homePath` keeps a third copy of the EDITOR rule and omits the last-visit branch. Folding it in changes onboarding behavior for a PIPELINE user with a meaningful last visit, so it wants its own tests.
- `loadWorkspaceProfile`'s bare `.catch()` swallows a failed `GetSetting`, leaving `PIPELINE`. A custom role lacking `bb.settings.getWorkspaceProfile` therefore breaks even a normal authenticated load.
- `SigninPage` passes `query.redirect` to `openWindowForSSO` instead of the `redirectUrl` prop, so the session-expired modal's SSO button drops `currentPath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)