### PR TITLE
fix(audit): redact batch instance updates and the IAM credential oneof

### DIFF
--- a/backend/api/v1/audit.go
+++ b/backend/api/v1/audit.go
@@ -591,6 +591,12 @@ func getRequestString(request any) (string, error) {
 			r = proto.CloneOf(r)
 			r.Instance = redactInstance(r.Instance)
 			return r
+		case *v1pb.BatchUpdateInstancesRequest:
+			r = proto.CloneOf(r)
+			for _, ur := range r.Requests {
+				ur.Instance = redactInstance(ur.Instance)
+			}
+			return r
 		case *v1pb.AddDataSourceRequest:
 			r = proto.CloneOf(r)
 			r.DataSource = redactDataSource(r.DataSource)
@@ -695,6 +701,12 @@ func getResponseString(response any) (string, error) {
 			n := &v1pb.BatchCreateSheetsResponse{}
 			for _, sheet := range r.Sheets {
 				n.Sheets = append(n.Sheets, redactSheet(sheet))
+			}
+			return n
+		case *v1pb.BatchUpdateInstancesResponse:
+			n := &v1pb.BatchUpdateInstancesResponse{}
+			for _, instance := range r.Instances {
+				n.Instances = append(n.Instances, redactInstance(instance))
 			}
 			return n
 		default:
@@ -1046,11 +1058,11 @@ func redactInstance(i *v1pb.Instance) *v1pb.Instance {
 }
 
 func redactDataSource(d *v1pb.DataSource) *v1pb.DataSource {
-	// Clone the datasource to avoid modifying the original
-	cloned, ok := proto.Clone(d).(*v1pb.DataSource)
-	if !ok {
-		return d
+	if d == nil {
+		return nil
 	}
+	// Clone the datasource to avoid modifying the original
+	cloned := proto.CloneOf(d)
 	if cloned.Password != "" {
 		cloned.Password = maskedString
 	}
@@ -1081,6 +1093,10 @@ func redactDataSource(d *v1pb.DataSource) *v1pb.DataSource {
 	if cloned.AuthenticationPrivateKey != "" {
 		cloned.AuthenticationPrivateKey = maskedString
 	}
+	if cloned.AuthenticationPrivateKeyPassphrase != "" {
+		cloned.AuthenticationPrivateKeyPassphrase = maskedString
+	}
+	redactIAMExtension(cloned)
 	if cloned.ExternalSecret != nil {
 		cloned.ExternalSecret = new(v1pb.DataSourceExternalSecret)
 	}
@@ -1094,6 +1110,46 @@ func redactDataSource(d *v1pb.DataSource) *v1pb.DataSource {
 		cloned.MasterPassword = maskedString
 	}
 	return cloned
+}
+
+// redactIAMExtension strips the IAM credential while keeping the variant that
+// was set, so the row still records which credential type the caller supplied.
+// It keys off the oneof rather than authentication_type, which a request is
+// free to leave unset or contradict.
+//
+// What survives mirrors the read path (instance_service_converter.go): the
+// Azure tenant and client IDs name the principal and are not INPUT_ONLY, so
+// they stay; every AWSCredential field is, including the role ARN, so none
+// does; and the GCP content is a whole service-account key.
+//
+// Keeping the ARN was considered — it names a principal rather than
+// authenticating as one, and the row could then answer which role a data
+// source was pointed at. It is dropped anyway, because "no INPUT_ONLY field
+// survives redaction" is an invariant a descriptor walk can check forever
+// (TestAuditRedactsEveryInputOnlyDataSourceField), and a hand-kept exception
+// list is the drift this function exists to stop.
+func redactIAMExtension(d *v1pb.DataSource) {
+	switch extension := d.GetIamExtension().(type) {
+	case *v1pb.DataSource_AzureCredential_:
+		d.IamExtension = &v1pb.DataSource_AzureCredential_{
+			AzureCredential: &v1pb.DataSource_AzureCredential{
+				TenantId: extension.AzureCredential.GetTenantId(),
+				ClientId: extension.AzureCredential.GetClientId(),
+			},
+		}
+	case *v1pb.DataSource_AwsCredential:
+		d.IamExtension = &v1pb.DataSource_AwsCredential{
+			AwsCredential: &v1pb.DataSource_AWSCredential{},
+		}
+	case *v1pb.DataSource_GcpCredential:
+		d.IamExtension = &v1pb.DataSource_GcpCredential{
+			GcpCredential: &v1pb.DataSource_GCPCredential{},
+		}
+	default:
+		// A variant added to the oneof after this function was written is
+		// dropped whole rather than logged. Unset lands here too and stays nil.
+		d.IamExtension = nil
+	}
 }
 
 func redactAdminExecuteResponse(r *v1pb.AdminExecuteResponse) *v1pb.AdminExecuteResponse {

--- a/backend/api/v1/audit_redaction_test.go
+++ b/backend/api/v1/audit_redaction_test.go
@@ -2,9 +2,15 @@ package v1
 
 import (
 	"encoding/base64"
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
 
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 )
@@ -86,6 +92,16 @@ func TestAuditResponseRedactsCredentials(t *testing.T) {
 				NextPageToken: "next-page-token",
 			},
 		},
+		{
+			// The single-instance response is redacted as defense in depth even
+			// though the converter blanks these on reads; its batch twin gets
+			// the same treatment rather than the default arm.
+			name: "batch instance update response",
+			response: &v1pb.BatchUpdateInstancesResponse{Instances: []*v1pb.Instance{{
+				Name:        "instances/instance-a",
+				DataSources: []*v1pb.DataSource{dataSourceWithEverySecret()},
+			}}},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := getResponseString(tt.response)
@@ -96,7 +112,329 @@ func TestAuditResponseRedactsCredentials(t *testing.T) {
 	}
 }
 
+// dataSourceWithEverySecret is the readable fixture: every secret redactDataSource
+// masks today, on one data source, so a case reads as the request a caller sends.
+// It is a hand-kept list and cannot see a field added later —
+// TestAuditRedactsEveryInputOnlyDataSourceField is the net that can.
+func dataSourceWithEverySecret() *v1pb.DataSource {
+	return &v1pb.DataSource{
+		Id:                                 "admin",
+		Type:                               v1pb.DataSourceType_ADMIN,
+		Username:                           "bytebase",
+		Host:                               "db.example.com",
+		Password:                           secretSentinel,
+		SslCa:                              secretSentinel,
+		SslCaPath:                          secretSentinel,
+		SslCert:                            secretSentinel,
+		SslCertPath:                        secretSentinel,
+		SslKey:                             secretSentinel,
+		SslKeyPath:                         secretSentinel,
+		SshPassword:                        secretSentinel,
+		SshPrivateKey:                      secretSentinel,
+		AuthenticationPrivateKey:           secretSentinel,
+		AuthenticationPrivateKeyPassphrase: secretSentinel,
+		MasterPassword:                     secretSentinel,
+		ExternalSecret: &v1pb.DataSourceExternalSecret{
+			AuthOption: &v1pb.DataSourceExternalSecret_Token{Token: secretSentinel},
+		},
+		SaslConfig: &v1pb.SASLConfig{Mechanism: &v1pb.SASLConfig_KrbConfig{
+			KrbConfig: &v1pb.KerberosConfig{Keytab: []byte(secretSentinel)},
+		}},
+		IamExtension: &v1pb.DataSource_GcpCredential{
+			GcpCredential: &v1pb.DataSource_GCPCredential{Content: secretSentinel},
+		},
+	}
+}
+
+// assertDataSourceIntact checks the fields a redactor rewrites rather than
+// clears, then returns the password for the caller's own comparison.
+func assertDataSourceIntact(t *testing.T, d *v1pb.DataSource) string {
+	t.Helper()
+	require.Equal(t, secretSentinel, d.GetAuthenticationPrivateKeyPassphrase(), "redaction mutated the passphrase")
+	require.Equal(t, secretSentinel, d.GetGcpCredential().GetContent(), "redaction mutated the IAM credential")
+	require.Equal(t, secretSentinel, string(d.GetSaslConfig().GetKrbConfig().GetKeytab()), "redaction mutated the keytab")
+	return d.GetPassword()
+}
+
+// fillInputOnlyFields sets every INPUT_ONLY string and bytes field reachable
+// from m to the sentinel, singular or repeated. Each oneof takes its arm-th
+// variant, so calling this for every arm up to maxOneofArms covers every branch
+// of every oneof declared alongside its siblings.
+//
+// This reads the same annotation the read path is pinned against
+// (assertNoInputOnlyValues), so a credential added to the proto lands in the
+// fixture without anyone remembering to add it here. Two shapes it cannot build:
+// a map, and a oneof nested inside another oneof's arm, which one global arm
+// counter only ever constructs on one value. Neither is silent — inputOnlyLeaves
+// counts both, so a fill that cannot reach one fails the test rather than
+// quietly asking less of the redactor.
+func fillInputOnlyFields(m protoreflect.Message, arm int, onPath map[protoreflect.FullName]bool) {
+	descriptor := m.Descriptor()
+	if onPath[descriptor.FullName()] {
+		return
+	}
+	onPath[descriptor.FullName()] = true
+	defer delete(onPath, descriptor.FullName())
+
+	skip := map[protoreflect.FieldNumber]bool{}
+	for i := 0; i < descriptor.Oneofs().Len(); i++ {
+		oneof := descriptor.Oneofs().Get(i)
+		if oneof.IsSynthetic() {
+			continue
+		}
+		for j := 0; j < oneof.Fields().Len(); j++ {
+			skip[oneof.Fields().Get(j).Number()] = true
+		}
+		fillOneField(m, oneof.Fields().Get(arm%oneof.Fields().Len()), arm, onPath)
+	}
+	for i := 0; i < descriptor.Fields().Len(); i++ {
+		if field := descriptor.Fields().Get(i); !skip[field.Number()] {
+			fillOneField(m, field, arm, onPath)
+		}
+	}
+}
+
+func fillOneField(m protoreflect.Message, field protoreflect.FieldDescriptor, arm int, onPath map[protoreflect.FullName]bool) {
+	if field.IsMap() {
+		return
+	}
+	if field.Kind() == protoreflect.MessageKind {
+		if field.IsList() {
+			list := m.Mutable(field).List()
+			element := list.NewElement()
+			fillInputOnlyFields(element.Message(), arm, onPath)
+			list.Append(element)
+			return
+		}
+		fillInputOnlyFields(m.Mutable(field).Message(), arm, onPath)
+		return
+	}
+	if !isInputOnly(field) {
+		return
+	}
+	var value protoreflect.Value
+	switch field.Kind() {
+	case protoreflect.StringKind:
+		value = protoreflect.ValueOfString(secretSentinel)
+	case protoreflect.BytesKind:
+		value = protoreflect.ValueOfBytes([]byte(secretSentinel))
+	default:
+		return
+	}
+	if field.IsList() {
+		m.Mutable(field).List().Append(value)
+		return
+	}
+	m.Set(field, value)
+}
+
+// maxOneofArms returns the widest non-synthetic oneof reachable from the
+// descriptor. Driving the arm loop off this rather than off a literal is the
+// point: a fourth iam_extension variant raises the bound by declaring itself.
+func maxOneofArms(descriptor protoreflect.MessageDescriptor, onPath map[protoreflect.FullName]bool) int {
+	if onPath[descriptor.FullName()] {
+		return 0
+	}
+	onPath[descriptor.FullName()] = true
+	defer delete(onPath, descriptor.FullName())
+
+	widest := 1
+	for i := 0; i < descriptor.Oneofs().Len(); i++ {
+		if oneof := descriptor.Oneofs().Get(i); !oneof.IsSynthetic() {
+			widest = max(widest, oneof.Fields().Len())
+		}
+	}
+	for i := 0; i < descriptor.Fields().Len(); i++ {
+		if field := descriptor.Fields().Get(i); field.Kind() == protoreflect.MessageKind && !field.IsMap() {
+			widest = max(widest, maxOneofArms(field.Message(), onPath))
+		}
+	}
+	return widest
+}
+
+// inputOnlyLeaves is the yardstick: every INPUT_ONLY scalar reachable from the
+// descriptor, down every arm of every oneof at once and through map values. The
+// fill can only take one arm per pass and cannot build a map at all, so the
+// union over passes has to equal this — which is what makes a fill that quietly
+// reaches less than it claims fail instead of pass. Every other assertion in the
+// test is negative, and a field nobody populated passes them all.
+//
+// Counting what the fill cannot yet build is deliberate. DataSource already
+// carries a map (extra_connection_parameters); the day one like it is declared
+// INPUT_ONLY, this fails and names it, rather than the gap staying a comment.
+func inputOnlyLeaves(descriptor protoreflect.MessageDescriptor, prefix string, onPath map[protoreflect.FullName]bool) []string {
+	if onPath[descriptor.FullName()] {
+		return nil
+	}
+	onPath[descriptor.FullName()] = true
+	defer delete(onPath, descriptor.FullName())
+
+	var paths []string
+	for i := 0; i < descriptor.Fields().Len(); i++ {
+		field := descriptor.Fields().Get(i)
+		path := fmt.Sprintf("%s.%s", prefix, field.Name())
+		switch {
+		case field.IsMap():
+			if isInputOnly(field) {
+				paths = append(paths, path)
+			}
+			if field.MapValue().Kind() == protoreflect.MessageKind {
+				paths = append(paths, inputOnlyLeaves(field.MapValue().Message(), path, onPath)...)
+			}
+		case field.Kind() == protoreflect.MessageKind:
+			paths = append(paths, inputOnlyLeaves(field.Message(), path, onPath)...)
+		case isInputOnly(field):
+			paths = append(paths, path)
+		default:
+		}
+	}
+	return paths
+}
+
+// sentinelPaths reports which fields the fill actually reached.
+func sentinelPaths(m protoreflect.Message, prefix string) []string {
+	var paths []string
+	m.Range(func(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+		path := fmt.Sprintf("%s.%s", prefix, field.Name())
+		switch {
+		case field.IsMap():
+		case field.Kind() == protoreflect.MessageKind && field.IsList():
+			for i := range value.List().Len() {
+				paths = append(paths, sentinelPaths(value.List().Get(i).Message(), path)...)
+			}
+		case field.Kind() == protoreflect.MessageKind:
+			paths = append(paths, sentinelPaths(value.Message(), path)...)
+		case field.IsList():
+			for i := range value.List().Len() {
+				if isSentinel(field, value.List().Get(i)) {
+					paths = append(paths, path)
+					break
+				}
+			}
+		default:
+			if isSentinel(field, value) {
+				paths = append(paths, path)
+			}
+		}
+		return true
+	})
+	return paths
+}
+
+func isSentinel(field protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+	switch field.Kind() {
+	case protoreflect.StringKind:
+		return value.String() == secretSentinel
+	case protoreflect.BytesKind:
+		return string(value.Bytes()) == secretSentinel
+	default:
+		return false
+	}
+}
+
+func isInputOnly(field protoreflect.FieldDescriptor) bool {
+	options, ok := field.Options().(*descriptorpb.FieldOptions)
+	if !ok || options == nil {
+		return false
+	}
+	behaviors, ok := proto.GetExtension(options, annotations.E_FieldBehavior).([]annotations.FieldBehavior)
+	return ok && slices.Contains(behaviors, annotations.FieldBehavior_INPUT_ONLY)
+}
+
+// A hand-kept fixture cannot fail for a credential nobody added to it. This one
+// is derived from the proto instead: every INPUT_ONLY field on a DataSource,
+// every arm of every oneof under it, on each request that carries one. A new
+// credential field, or a fourth iam_extension variant, is covered on the day it
+// is declared rather than on the day someone notices the audit row.
+func TestAuditRedactsEveryInputOnlyDataSourceField(t *testing.T) {
+	dataSource := (&v1pb.DataSource{}).ProtoReflect().Descriptor()
+	reached := map[string]bool{}
+	for arm := range maxOneofArms(dataSource, map[protoreflect.FullName]bool{}) {
+		filled := &v1pb.DataSource{}
+		fillInputOnlyFields(filled.ProtoReflect(), arm, map[protoreflect.FullName]bool{})
+		for _, path := range sentinelPaths(filled.ProtoReflect(), "dataSource") {
+			reached[path] = true
+		}
+
+		for _, tt := range []struct {
+			name    string
+			request any
+		}{
+			{"create instance", &v1pb.CreateInstanceRequest{Instance: &v1pb.Instance{
+				DataSources: []*v1pb.DataSource{filled},
+			}}},
+			{"update instance", &v1pb.UpdateInstanceRequest{Instance: &v1pb.Instance{
+				DataSources: []*v1pb.DataSource{filled},
+			}}},
+			{"batch update instances", &v1pb.BatchUpdateInstancesRequest{
+				Requests: []*v1pb.UpdateInstanceRequest{{Instance: &v1pb.Instance{
+					DataSources: []*v1pb.DataSource{filled},
+				}}},
+			}},
+			{"add data source", &v1pb.AddDataSourceRequest{DataSource: filled}},
+			{"update data source", &v1pb.UpdateDataSourceRequest{DataSource: filled}},
+			{"remove data source", &v1pb.RemoveDataSourceRequest{DataSource: filled}},
+		} {
+			t.Run(fmt.Sprintf("%s/oneof arm %d", tt.name, arm), func(t *testing.T) {
+				got, err := getRequestString(tt.request)
+				require.NoError(t, err)
+				require.NotContains(t, got, secretSentinel, "credential written to the audit log")
+				require.NotContains(t, got, encodedSecretSentinel, "encoded credential written to the audit log")
+			})
+		}
+
+		t.Run(fmt.Sprintf("redacted message/oneof arm %d", arm), func(t *testing.T) {
+			// The string check above only catches what the fixture happened to
+			// populate. This one holds the whole annotation: nothing declared
+			// INPUT_ONLY may carry a value after redaction.
+			assertNoInputOnlyValues(t, redactDataSource(filled).ProtoReflect(), "dataSource")
+		})
+	}
+
+	// The positive half. Everything above is an assertion that something is
+	// absent, which a field the fill never populated passes for free — so under-
+	// coverage would read as success. This one fails instead.
+	t.Run("the fill reaches every INPUT_ONLY field", func(t *testing.T) {
+		var missed []string
+		for _, path := range inputOnlyLeaves(dataSource, "dataSource", map[protoreflect.FullName]bool{}) {
+			if !reached[path] {
+				missed = append(missed, path)
+			}
+		}
+		require.Empty(t, missed, "never populated, so the redaction assertions above say nothing about them")
+	})
+}
+
+// A rejected request is audited too, so every redactor runs on messages the
+// handler was about to refuse. redactDataSource used to read through the nil
+// data source in one of these and panic the interceptor.
+func TestAuditRedactionSurvivesAnIncompleteRequest(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		request any
+	}{
+		{"add data source without one", &v1pb.AddDataSourceRequest{Name: "instances/instance-a"}},
+		{"update data source without one", &v1pb.UpdateDataSourceRequest{Name: "instances/instance-a"}},
+		{"remove data source without one", &v1pb.RemoveDataSourceRequest{Name: "instances/instance-a"}},
+		{"create instance without one", &v1pb.CreateInstanceRequest{InstanceId: "instance-a"}},
+		{"update instance without one", &v1pb.UpdateInstanceRequest{}},
+		{"batch update instances without any", &v1pb.BatchUpdateInstancesRequest{
+			Requests: []*v1pb.UpdateInstanceRequest{{}},
+		}},
+		{"instance carrying an empty data source", &v1pb.UpdateInstanceRequest{Instance: &v1pb.Instance{
+			DataSources: []*v1pb.DataSource{{}},
+		}}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getRequestString(tt.request)
+			require.NoError(t, err)
+			require.NotEmpty(t, got, "a rejected request still gets a row")
+		})
+	}
+}
+
 func TestAuditRequestRedactsCredentials(t *testing.T) {
+	batchParent := "projects/project-a"
 	settingRequest := func(v *v1pb.SettingValue) *v1pb.UpdateSettingRequest {
 		return &v1pb.UpdateSettingRequest{Setting: &v1pb.Setting{Value: v}}
 	}
@@ -155,6 +493,46 @@ func TestAuditRequestRedactsCredentials(t *testing.T) {
 		{"saved query SQL", &v1pb.CreateSavedQueryRequest{SavedQuery: &v1pb.SavedQuery{
 			Content: []byte(secretSentinel),
 		}}},
+		// The data-source secrets are INPUT_ONLY, so a write request is the only
+		// place they appear — which is exactly what an audit row records.
+		{"instance data source secrets", &v1pb.UpdateInstanceRequest{Instance: &v1pb.Instance{
+			Name:        "instances/instance-a",
+			DataSources: []*v1pb.DataSource{dataSourceWithEverySecret()},
+		}}},
+		{"batch instance data source secrets", &v1pb.BatchUpdateInstancesRequest{
+			Parent: &batchParent,
+			Requests: []*v1pb.UpdateInstanceRequest{nil, {Instance: &v1pb.Instance{
+				Name:        "instances/instance-a",
+				DataSources: []*v1pb.DataSource{dataSourceWithEverySecret()},
+			}}},
+		}},
+		{"created instance data source secrets", &v1pb.CreateInstanceRequest{
+			InstanceId: "instance-a",
+			Instance:   &v1pb.Instance{DataSources: []*v1pb.DataSource{dataSourceWithEverySecret()}},
+		}},
+		{"added data source secrets", &v1pb.AddDataSourceRequest{
+			Name:       "instances/instance-a",
+			DataSource: dataSourceWithEverySecret(),
+		}},
+		{"updated data source secrets", &v1pb.UpdateDataSourceRequest{
+			Name:       "instances/instance-a",
+			DataSource: dataSourceWithEverySecret(),
+		}},
+		{"removed data source secrets", &v1pb.RemoveDataSourceRequest{
+			Name:       "instances/instance-a",
+			DataSource: dataSourceWithEverySecret(),
+		}},
+		{"azure iam client secret", &v1pb.AddDataSourceRequest{DataSource: &v1pb.DataSource{
+			IamExtension: &v1pb.DataSource_AzureCredential_{AzureCredential: &v1pb.DataSource_AzureCredential{
+				TenantId: "tenant-a", ClientId: "client-a", ClientSecret: secretSentinel,
+			}},
+		}}},
+		{"aws iam access keys", &v1pb.AddDataSourceRequest{DataSource: &v1pb.DataSource{
+			IamExtension: &v1pb.DataSource_AwsCredential{AwsCredential: &v1pb.DataSource_AWSCredential{
+				AccessKeyId: secretSentinel, SecretAccessKey: secretSentinel, SessionToken: secretSentinel,
+				RoleArn: secretSentinel, ExternalId: secretSentinel,
+			}},
+		}}},
 		{"password reset code and password", &v1pb.ResetPasswordRequest{
 			Email:       "user@example.com",
 			Code:        secretSentinel,
@@ -185,6 +563,7 @@ func TestAuditRequestRedactsCredentials(t *testing.T) {
 }
 
 func TestSensitiveOutboundAuditMetadata(t *testing.T) {
+	batchParent := "projects/project-a"
 	for _, tt := range []struct {
 		name     string
 		value    any
@@ -195,6 +574,37 @@ func TestSensitiveOutboundAuditMetadata(t *testing.T) {
 			name:  "webhook request retains identifiers",
 			value: &v1pb.AddWebhookRequest{Project: "projects/project-a", Webhook: &v1pb.Webhook{Name: "projects/project-a/webhooks/webhook-a", Title: "Webhook A", Url: secretSentinel}},
 			want:  []string{"projects/project-a", "projects/project-a/webhooks/webhook-a", "Webhook A"},
+		},
+		{
+			// The row has to stay useful: which instances were retargeted, and
+			// which kind of IAM credential was supplied.
+			name: "batch instance update retains targets and credential type",
+			value: &v1pb.BatchUpdateInstancesRequest{
+				Parent: &batchParent,
+				Requests: []*v1pb.UpdateInstanceRequest{{Instance: &v1pb.Instance{
+					Name:        "instances/instance-a",
+					DataSources: []*v1pb.DataSource{dataSourceWithEverySecret()},
+				}}},
+			},
+			want: []string{"projects/project-a", "instances/instance-a", "db.example.com", "gcpCredential"},
+		},
+		{
+			name: "azure iam credential retains the principal it names",
+			value: &v1pb.AddDataSourceRequest{DataSource: &v1pb.DataSource{
+				IamExtension: &v1pb.DataSource_AzureCredential_{AzureCredential: &v1pb.DataSource_AzureCredential{
+					TenantId: "tenant-a", ClientId: "client-a", ClientSecret: secretSentinel,
+				}},
+			}},
+			want: []string{"azureCredential", "tenant-a", "client-a"},
+		},
+		{
+			name: "aws iam credential records that one was supplied",
+			value: &v1pb.AddDataSourceRequest{DataSource: &v1pb.DataSource{
+				IamExtension: &v1pb.DataSource_AwsCredential{AwsCredential: &v1pb.DataSource_AWSCredential{
+					AccessKeyId: secretSentinel, SecretAccessKey: secretSentinel,
+				}},
+			}},
+			want: []string{"awsCredential"},
 		},
 		{
 			name:     "audit export retains page token",
@@ -264,19 +674,25 @@ func TestAuditRedactionDoesNotMutateInput(t *testing.T) {
 	}{
 		{
 			name: "create instance request",
-			request: &v1pb.CreateInstanceRequest{Instance: &v1pb.Instance{DataSources: []*v1pb.DataSource{{
-				Password: secretSentinel,
-			}}}},
+			request: &v1pb.CreateInstanceRequest{Instance: &v1pb.Instance{
+				DataSources: []*v1pb.DataSource{dataSourceWithEverySecret()},
+			}},
 		},
 		{
 			name: "update instance request",
-			request: &v1pb.UpdateInstanceRequest{Instance: &v1pb.Instance{DataSources: []*v1pb.DataSource{{
-				Password: secretSentinel,
-			}}}},
+			request: &v1pb.UpdateInstanceRequest{Instance: &v1pb.Instance{
+				DataSources: []*v1pb.DataSource{dataSourceWithEverySecret()},
+			}},
 		},
-		{name: "add data source request", request: &v1pb.AddDataSourceRequest{DataSource: &v1pb.DataSource{Password: secretSentinel}}},
-		{name: "update data source request", request: &v1pb.UpdateDataSourceRequest{DataSource: &v1pb.DataSource{Password: secretSentinel}}},
-		{name: "remove data source request", request: &v1pb.RemoveDataSourceRequest{DataSource: &v1pb.DataSource{Password: secretSentinel}}},
+		{
+			name: "batch update instances request",
+			request: &v1pb.BatchUpdateInstancesRequest{Requests: []*v1pb.UpdateInstanceRequest{{
+				Instance: &v1pb.Instance{DataSources: []*v1pb.DataSource{dataSourceWithEverySecret()}},
+			}}},
+		},
+		{name: "add data source request", request: &v1pb.AddDataSourceRequest{DataSource: dataSourceWithEverySecret()}},
+		{name: "update data source request", request: &v1pb.UpdateDataSourceRequest{DataSource: dataSourceWithEverySecret()}},
+		{name: "remove data source request", request: &v1pb.RemoveDataSourceRequest{DataSource: dataSourceWithEverySecret()}},
 		{name: "create release request", request: &v1pb.CreateReleaseRequest{Release: &v1pb.Release{Files: []*v1pb.Release_File{{Statement: []byte(secretSentinel)}}}}},
 		{name: "update release request", request: &v1pb.UpdateReleaseRequest{Release: &v1pb.Release{Files: []*v1pb.Release_File{{Statement: []byte(secretSentinel)}}}}},
 		{name: "create saved query request", request: &v1pb.CreateSavedQueryRequest{SavedQuery: &v1pb.SavedQuery{Content: []byte(secretSentinel)}}},
@@ -288,15 +704,17 @@ func TestAuditRedactionDoesNotMutateInput(t *testing.T) {
 			var sensitiveValue string
 			switch request := tt.request.(type) {
 			case *v1pb.CreateInstanceRequest:
-				sensitiveValue = request.GetInstance().GetDataSources()[0].GetPassword()
+				sensitiveValue = assertDataSourceIntact(t, request.GetInstance().GetDataSources()[0])
 			case *v1pb.UpdateInstanceRequest:
-				sensitiveValue = request.GetInstance().GetDataSources()[0].GetPassword()
+				sensitiveValue = assertDataSourceIntact(t, request.GetInstance().GetDataSources()[0])
+			case *v1pb.BatchUpdateInstancesRequest:
+				sensitiveValue = assertDataSourceIntact(t, request.GetRequests()[0].GetInstance().GetDataSources()[0])
 			case *v1pb.AddDataSourceRequest:
-				sensitiveValue = request.GetDataSource().GetPassword()
+				sensitiveValue = assertDataSourceIntact(t, request.GetDataSource())
 			case *v1pb.UpdateDataSourceRequest:
-				sensitiveValue = request.GetDataSource().GetPassword()
+				sensitiveValue = assertDataSourceIntact(t, request.GetDataSource())
 			case *v1pb.RemoveDataSourceRequest:
-				sensitiveValue = request.GetDataSource().GetPassword()
+				sensitiveValue = assertDataSourceIntact(t, request.GetDataSource())
 			case *v1pb.CreateReleaseRequest:
 				sensitiveValue = string(request.GetRelease().GetFiles()[0].GetStatement())
 			case *v1pb.UpdateReleaseRequest:

--- a/backend/api/v1/mcp_forbidden.go
+++ b/backend/api/v1/mcp_forbidden.go
@@ -116,17 +116,24 @@ var mcpForbiddenReasons = map[v1pb.MCPForbiddenReason]string{
 	v1pb.MCPForbiddenReason_MINTS_CREDENTIAL_FOR_OTHERS: "it hands someone control of a principal other than the caller, which revoking this session would not take back",
 
 	// SettingService/UpdateSetting, refused for the boundary it rewrites
-	// rather than for any credential it hands out. Two mask paths carry it:
+	// rather than for any credential it hands out. Three mask paths carry it:
 	// value.workspace_profile.mcp_capability IS the MCP ceiling, so a session
-	// that reaches it is not bounded by it; and value.email.smtp keeps the
+	// that reaches it is not bounded by it; value.email.smtp keeps the
 	// stored password when the request omits it while accepting a new host,
 	// which hands over the relay resolvePreLoginEmailSetting reads to mail
-	// password resets and login codes. TestEmailSetting is the one-shot
-	// version of the second; this is the persisting one. The same method also
-	// writes the SSO domain allowlist and the sign-in switches.
+	// password resets and login codes; and value.ai.endpoint does the same to
+	// the AI key it never names — the stored api_key survives the mask, and the
+	// next AIService/Chat puts it in an auth header to the host just written
+	// (ai_service.go). SaaS refuses AI writes outright (setting_service.go), so
+	// that third one is a self-hosted vector, and the key it carries out is
+	// whatever the operator configured — GEMINI_API_KEY, where it is set, seeds
+	// one key into every workspace created after it (getAdditionalWorkspaceSettings).
+	// TestEmailSetting is the one-shot version of the second; this is the
+	// persisting one. The same method also writes the SSO domain allowlist and
+	// the sign-in switches.
 	//
 	// Classification is per method, so this refuses the whole RPC — including
-	// the settings that have nothing to do with either path. Splitting the
+	// the settings that have nothing to do with any of them. Splitting the
 	// handler so ordinary configuration stays reachable to an agent is the
 	// follow-up (BOT-53); disallowing first is the deliberate order.
 	v1pb.MCPForbiddenReason_REWRITES_SESSION_BOUNDARY: "it rewrites the workspace settings that bound this session, including the switch meant to contain it",

--- a/backend/generated-go/v1/annotation.pb.go
+++ b/backend/generated-go/v1/annotation.pb.go
@@ -170,9 +170,10 @@ const (
 	// gets delivered.
 	MCPForbiddenReason_MINTS_CREDENTIAL_FOR_OTHERS MCPForbiddenReason = 6
 	// Rewrites the workspace configuration that governs the session making the
-	// call — the MCP switch itself, the sign-in and SSO settings, and the mail
-	// relay that carries credential resets. A session that can widen its own
-	// ceiling is not bounded by it.
+	// call — the MCP switch itself, the sign-in and SSO settings, the mail
+	// relay that carries credential resets, and the AI endpoint the stored API
+	// key is sent to. A session that can widen its own ceiling is not bounded
+	// by it.
 	MCPForbiddenReason_REWRITES_SESSION_BOUNDARY MCPForbiddenReason = 7
 )
 

--- a/frontend/src/types/proto-es/v1/annotation_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/annotation_pb.d.ts
@@ -159,9 +159,10 @@ export enum MCPForbiddenReason {
 
   /**
    * Rewrites the workspace configuration that governs the session making the
-   * call — the MCP switch itself, the sign-in and SSO settings, and the mail
-   * relay that carries credential resets. A session that can widen its own
-   * ceiling is not bounded by it.
+   * call — the MCP switch itself, the sign-in and SSO settings, the mail
+   * relay that carries credential resets, and the AI endpoint the stored API
+   * key is sent to. A session that can widen its own ceiling is not bounded
+   * by it.
    *
    * @generated from enum value: REWRITES_SESSION_BOUNDARY = 7;
    */

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -820,7 +820,7 @@ reader trusts — so a method changing what it does changes its reason here.
 | ENDS_SESSION | 4 | Destroys the human&#39;s own login session. |
 | ENDS_MEMBERSHIP | 5 | Destroys the caller&#39;s own workspace membership and mints a plain workspace token on the way out. |
 | MINTS_CREDENTIAL_FOR_OTHERS | 6 | Leaves someone holding a principal the caller is not — by issuing its credential, carrying an existing one out to a host the caller named, choosing what will later be trusted to mint one, or redirecting where one gets delivered. |
-| REWRITES_SESSION_BOUNDARY | 7 | Rewrites the workspace configuration that governs the session making the call — the MCP switch itself, the sign-in and SSO settings, and the mail relay that carries credential resets. A session that can widen its own ceiling is not bounded by it. |
+| REWRITES_SESSION_BOUNDARY | 7 | Rewrites the workspace configuration that governs the session making the call — the MCP switch itself, the sign-in and SSO settings, the mail relay that carries credential resets, and the AI endpoint the stored API key is sent to. A session that can widen its own ceiling is not bounded by it. |
 
 
 

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -2928,7 +2928,7 @@
                 <li>
                   <a href="#bytebase.v1.ExportVCSProviderUsersResponse"><span class="badge">M</span>ExportVCSProviderUsersResponse</a>
                 </li>
-
+              
                 <li>
                   <a href="#bytebase.v1.GetPaymentInfoRequest"><span class="badge">M</span>GetPaymentInfoRequest</a>
                 </li>
@@ -3237,9 +3237,10 @@ gets delivered.</p></td>
                 <td>REWRITES_SESSION_BOUNDARY</td>
                 <td>7</td>
                 <td><p>Rewrites the workspace configuration that governs the session making the
-call — the MCP switch itself, the sign-in and SSO settings, and the mail
-relay that carries credential resets. A session that can widen its own
-ceiling is not bounded by it.</p></td>
+call — the MCP switch itself, the sign-in and SSO settings, the mail
+relay that carries credential resets, and the AI endpoint the stored API
+key is sent to. A session that can widen its own ceiling is not bounded
+by it.</p></td>
               </tr>
             
           </tbody>
@@ -33239,27 +33240,27 @@ Required. </p></td>
         <h3 id="bytebase.v1.ExportVCSProviderUsersResponse">ExportVCSProviderUsersResponse</h3>
         <p></p>
 
-
+        
           <table class="field-table">
             <thead>
               <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
             </thead>
             <tbody>
-
+              
                 <tr>
                   <td>content</td>
                   <td><a href="#bytes">bytes</a></td>
                   <td></td>
                   <td><p> </p></td>
                 </tr>
-
+              
             </tbody>
           </table>
 
+          
 
-
-
-
+        
+      
         <h3 id="bytebase.v1.GetPaymentInfoRequest">GetPaymentInfoRequest</h3>
         <p></p>
 

--- a/proto/v1/v1/annotation.proto
+++ b/proto/v1/v1/annotation.proto
@@ -83,8 +83,9 @@ enum MCPForbiddenReason {
   // gets delivered.
   MINTS_CREDENTIAL_FOR_OTHERS = 6;
   // Rewrites the workspace configuration that governs the session making the
-  // call — the MCP switch itself, the sign-in and SSO settings, and the mail
-  // relay that carries credential resets. A session that can widen its own
-  // ceiling is not bounded by it.
+  // call — the MCP switch itself, the sign-in and SSO settings, the mail
+  // relay that carries credential resets, and the AI endpoint the stored API
+  // key is sent to. A session that can widen its own ceiling is not bounded
+  // by it.
   REWRITES_SESSION_BOUNDARY = 7;
 }


### PR DESCRIPTION
Three holes in what an audit row records, all on the instance write path.

## BatchUpdateInstances was never redacted

`getRequestString` switches on the concrete request type and had no case for
`BatchUpdateInstancesRequest`, so the request fell through to the default branch
and `protojson.Marshal` wrote every data-source secret in the batch verbatim.
The handler fans the batch out to `UpdateInstance` in process, so the inner
`UpdateInstanceRequest` never re-enters the audit interceptor — no redacted row
existed anywhere. This is not MCP-specific and not gated on anything: it leaked
for every caller on every call. The response side gets the same case, as its
`BatchCreateSheetsResponse` twin already has.

## redactDataSource skipped two secrets

The whole `iam_extension` oneof — `azure_credential`, `aws_credential` and
`gcp_credential`, whose `GCPCredential.content` is a full service-account key —
and `authentication_private_key_passphrase`. Every leaf secret here is
`INPUT_ONLY`, so a write request is the only place it appears, which is exactly
what an audit row records. This one bit on all six instance write paths, not
just the batch.

The oneof keeps its variant instead of being cleared, so the row still records
which credential type was supplied. What survives mirrors the read path
(`instance_service_converter.go`): the Azure tenant and client IDs name the
principal and are not `INPUT_ONLY`, so they stay. A variant added later is
dropped whole rather than logged.

Keeping the AWS `role_arn` was considered — it names a principal rather than
authenticating as one. It is dropped anyway, because "no `INPUT_ONLY` field
survives redaction" is an invariant a descriptor walk can check forever, and a
hand-kept exception list is the drift this change exists to stop.

## redactDataSource also panicked on a nil data source

It was the one redactor without a nil guard, behind a `proto.Clone(d).(*T)`
assertion that cannot fail for a typed nil and so never caught what it looked
like it was guarding. A rejected `AddDataSource` with no `data_source` is
audited like any other failure, so any caller could crash the interceptor:

```go
getRequestString(&v1pb.AddDataSourceRequest{Name: "instances/foo"})
// panic: runtime error: invalid memory address or nil pointer dereference
```

## The FORBIDDEN reason now names the AI-endpoint retarget

`update_mask=["value.ai.endpoint"]` keeps the stored `api_key` and repoints it,
so the next `AIService/Chat` puts that key in an auth header to a host the caller
just wrote. SaaS refuses AI setting writes outright (`setting_service.go:370`),
so it is a self-hosted vector, and the comment says so. BOT-53 will read this
text to decide what must stay forbidden when `UpdateSetting` is split; an
unnamed vector is one that gets reopened. Comment only — no classification,
interceptor or method-list change.

## Sweep

Walked every message in the compiled `bytebase.v1` descriptor set for a
transitive `Instance` or `DataSource`, then joined against each RPC's audit
annotation. Eight audited request messages carry one. Five were already covered,
`BatchUpdateInstancesRequest` is fixed here, and two are left alone:

- `UpdateDatabaseRequest` and `BatchUpdateDatabasesRequest` reach a `DataSource`
  through `Database.instance_resource`, which is `OUTPUT_ONLY` — the write path
  ignores it and the read path never fills in secrets, so a caller can only echo
  strings it already knows into its own audit row. `Instance.roles[].password`
  is the same shape. Caller self-echo, not server-side disclosure — but the same
  missing-case shape, and a real leak the day either field stops being
  output-only.
- `ListInstanceDatabaseRequest` carries an `Instance` but has no audit
  annotation, so no row is ever written.

## Testing

The redaction tests are now derived from the proto rather than hand-listed.
`TestAuditRedactsEveryInputOnlyDataSourceField` fills every `INPUT_ONLY` field
reachable from a `DataSource`, every arm of every oneof, and runs it through all
six write paths. The arm count comes from the descriptor, not a literal, so a
fourth `iam_extension` variant is covered on the day it is declared.

Because every redaction assertion is negative, a field nobody populated passes
for free — so the test also carries a positive pin: the set of fields the fill
actually reaches must equal the set the descriptor says exists. Under-coverage
fails and names the paths instead of reading as success.

RED evidence, with the batch case removed:

```
"{"parent":"projects/project-a","requests":[{},{"instance":{"name":"instances/instance-a",
"dataSources":[{...,"password":"s3cr3t-sentinel-value",...,
"gcpCredential":{"content":"s3cr3t-sentinel-value"},...}]}}]}"
should not contain "s3cr3t-sentinel-value"
```

With the `iam_extension` and passphrase masking removed: six cases fail,
including `AddDataSource`, `UpdateDataSource`, `CreateInstance` and
`UpdateInstance` — the single-instance leak that bites today.

Each new test was mutation-checked: dropping `redactIAMExtension`, dropping the
passphrase mask, masking only the external-secret token, restoring the
unguarded `redactDataSource`, dropping the batch response case, cutting the
oneof arm bound, and stopping the nested-message recursion each turn the suite
red.

`TestSensitiveOutboundAuditMetadata` asserts the row keeps what makes it useful:
the instance names, the host, `gcpCredential` / `awsCredential` /
`azureCredential` as the variant marker, and the Azure principal IDs.

Gates: gofmt, `go vet`, golangci-lint clean, `buf format` / `lint` / `generate`,
`go test ./backend/api/v1/...`, `go test ./backend/tests -run '^TestMCP'` (18
pass), server build.

BOT-55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
