### PR TITLE
chore: bump omni for Oracle constraint_state support (BYT-10010)

### DIFF
--- a/backend/plugin/parser/plsql/byt10010_e2e_test.go
+++ b/backend/plugin/parser/plsql/byt10010_e2e_test.go
@@ -1,0 +1,56 @@
+package plsql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestDiagnoseBYT10010CustomerStatement verifies the MBBank statement from
+// BYT-10010 passes SQL Review diagnosis end to end after the omni
+// constraint_state fix.
+func TestDiagnoseBYT10010CustomerStatement(t *testing.T) {
+	stmt := `CREATE TABLE DATA.RC_FT_ADJ_CONFIG
+(
+    RC_FT_ADJ_CODE        VARCHAR2(250) NOT NULL,
+    RC_CODE               VARCHAR2(150),
+    DATE_REPORT           DATE,
+    IS_CHECK              VARCHAR2(255),
+    IS_ACTION             VARCHAR2(255),
+    CREATE_DATE           DATE DEFAULT SYSDATE NOT NULL,
+    CREATE_USER           VARCHAR2(50) DEFAULT 'ETL_USER',
+    UPDATE_DATE           DATE DEFAULT SYSDATE,
+    UPDATE_USER           VARCHAR2(50) DEFAULT 'ETL_USER',
+    TYPE                  VARCHAR2(50),
+    RC_FT_ADJ_STATUS      VARCHAR2(255),
+    PARENT_RC_FT_ADJ_CODE VARCHAR2(250),
+    E_STATUS              NUMBER,
+
+    CONSTRAINT PK_RC_FT_ADJ_CONFIG
+        PRIMARY KEY (RC_FT_ADJ_CODE, CREATE_DATE) USING INDEX LOCAL
+)
+PARTITION BY RANGE (CREATE_DATE)
+INTERVAL (NUMTOYMINTERVAL(1, 'MONTH'))
+(
+    PARTITION P202607
+        VALUES LESS THAN (DATE '2026-07-01')
+)`
+	diags, err := Diagnose(context.Background(), base.DiagnoseContext{}, stmt)
+	if err != nil {
+		t.Fatalf("Diagnose returned error: %v", err)
+	}
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics, got %d: %+v", len(diags), diags)
+	}
+
+	// DBMS_METADATA-style variant with NOT NULL ENABLE and USING INDEX attributes.
+	stmt2 := `CREATE TABLE "S"."T" ("A" NUMBER(*,0) NOT NULL ENABLE, CONSTRAINT "PK_T" PRIMARY KEY ("A") USING INDEX PCTFREE 10 INITRANS 2 MAXTRANS 255 COMPUTE STATISTICS TABLESPACE "USERS" ENABLE) PCTFREE 10 PCTUSED 40 INITRANS 1 MAXTRANS 255 TABLESPACE "USERS"`
+	diags2, err := Diagnose(context.Background(), base.DiagnoseContext{}, stmt2)
+	if err != nil {
+		t.Fatalf("Diagnose returned error: %v", err)
+	}
+	if len(diags2) != 0 {
+		t.Fatalf("expected no diagnostics for DBMS_METADATA style, got %+v", diags2)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260730024920-8e82223f7635
+	github.com/bytebase/omni v0.0.0-20260817095119-ad01165bf7db
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735 h1:v8y6mXeHmYVsdM
 github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735/go.mod h1:vTHjcvfn8Pmf65WjnV1ytTCYyC7xNhFjrniv4YWvtA8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260730024920-8e82223f7635 h1:JBDU5vAImt6qBPy4bUDgWhuuc2NQzR6WTMtKRL51YjE=
-github.com/bytebase/omni v0.0.0-20260730024920-8e82223f7635/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260817095119-ad01165bf7db h1:K2pZNwZi1YfwYrhWrkYjBUBLiWa/0ugIPc1Zd2tDxDQ=
+github.com/bytebase/omni v0.0.0-20260817095119-ad01165bf7db/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
Picks up [bytebase/omni#399](https://github.com/bytebase/omni/pull/399): full Oracle `constraint_state` support, engine-verified against Oracle 23ai (39/40 statement-level agreement). Fixes [BYT-10010](https://linear.app/bytebase/issue/BYT-10010/sql-review-rejects-valid-oracle-using-index-local-table-constraint) — MBBank's `PRIMARY KEY (...) USING INDEX LOCAL` partitioned DDL rejected by SQL Review since 3.19.0.

## Adaptation audit (beyond the bump)

- **Compilation**: no changes needed — new AST fields (`TableConstraint.UsingIndexLocal`/`Tablespace`, `ColumnConstraint` equivalents, `CreateViewStmt.Constraints`) are additive.
- **Schema extraction**: `extractTableConstraint` consumes `AlterTableCmd.Constraint` only on `AT_ADD_CONSTRAINT`; the newly populated nodes on `AT_MODIFY_CONSTRAINT` are ignored there, so no phantom constraints.
- **Advisors**: statements that previously failed at parse (`NOT NULL ENABLE`, `USING INDEX ...`) now reach the rules, so `table.require-pk` / `column.no-null` etc. produce correct results on DBMS_METADATA-style DDL automatically. No rule reads the new fields yet; wiring local-index semantics into `IndexMetadata` is deferred to a separate issue per the BYT-10010 discussion.
- **Tests**: `parser/plsql`, `advisor/oracle`, `schema/oracle` all pass unmodified; added an end-to-end `Diagnose` regression test for the customer statement and the DBMS_METADATA shape.

After merge: cherry-pick to 3.21.x for MBBank (regression window 3.19.0–3.21.x).

🤖 Generated with [Claude Code](https://claude.com/claude-code)