### PR TITLE
fix(mysql): stop downloading the RDS CA bundle on every connection

### DIFF
--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -220,28 +220,36 @@ func cachedRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
 	if pool := rdsCertPool.Load(); pool != nil {
 		return pool, nil
 	}
-	// Collapse a cold-start burst into one download. singleflight does not retain
-	// the error, so a failed fetch is retried by the next caller.
-	v, err, _ := rdsCertGroup.Do("", func() (any, error) {
+	// Collapse a cold-start burst into one download. The shared fetch does not
+	// inherit any one caller's context, so the caller that starts it cannot
+	// cancel it for everybody else; each caller waits on its own context below.
+	ch := rdsCertGroup.DoChan("", func() (any, error) {
 		// Double check after entering singleflight.
 		if pool := rdsCertPool.Load(); pool != nil {
 			return pool, nil
 		}
-		pool, err := getRDSCertPool(ctx)
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), rdsCertFetchTimeout)
+		defer cancel()
+		pool, err := getRDSCertPool(fetchCtx)
 		if err != nil {
 			return nil, err
 		}
 		rdsCertPool.Store(pool)
 		return pool, nil
 	})
-	if err != nil {
-		return nil, err
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case res := <-ch:
+		if res.Err != nil {
+			return nil, res.Err
+		}
+		pool, ok := res.Val.(*x509.CertPool)
+		if !ok {
+			return nil, errors.Errorf("unexpected RDS cert pool type %T", res.Val)
+		}
+		return pool, nil
 	}
-	pool, ok := v.(*x509.CertPool)
-	if !ok {
-		return nil, errors.Errorf("unexpected RDS cert pool type %T", v)
-	}
-	return pool, nil
 }
 
 // rdsRootCAs prefers an operator-supplied CA, so a deployment can serve RDS IAM

--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -227,7 +227,7 @@ func cachedRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
 func rdsRootCAs(ctx context.Context, dataSource *storepb.DataSource) (*x509.CertPool, error) {
 	if ca := dataSource.GetSslCa(); ca != "" {
 		pool := x509.NewCertPool()
-		if ok := pool.AppendCertsFromPEM([]byte(ca)); !ok {
+		if !pool.AppendCertsFromPEM([]byte(ca)) {
 			return nil, errors.Errorf("failed to parse ssl_ca certificates")
 		}
 		return pool, nil
@@ -240,7 +240,7 @@ func rdsRootCAs(ctx context.Context, dataSource *storepb.DataSource) (*x509.Cert
 func rdsTLSConfig(ctx context.Context, dataSource *storepb.DataSource) (*tls.Config, error) {
 	if !dataSource.GetVerifyTlsCertificate() {
 		// No verifier runs in this mode, so a root pool would never be consulted.
-		return &tls.Config{InsecureSkipVerify: true}, nil
+		return &tls.Config{InsecureSkipVerify: true}, nil // NOSONAR(go:S4830,go:S5527) operator disabled verification (verify_tls_certificate=false)
 	}
 	rootCertPool, err := rdsRootCAs(ctx, dataSource)
 	if err != nil {
@@ -248,7 +248,7 @@ func rdsTLSConfig(ctx context.Context, dataSource *storepb.DataSource) (*tls.Con
 	}
 	return &tls.Config{
 		RootCAs:               rootCertPool,
-		InsecureSkipVerify:    true, // superseded by VerifyPeerCertificate below
+		InsecureSkipVerify:    true, // NOSONAR(go:S4830) superseded by VerifyPeerCertificate below
 		VerifyPeerCertificate: util.CreateCertificateVerifier(rootCertPool, dataSource.GetHost()),
 	}, nil
 }

--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/bytebase/bytebase/backend/common"
@@ -169,6 +170,9 @@ const maxRDSCertBundleSize int64 = 4 << 20
 // rdsCertPool caches the downloaded bundle for the process lifetime.
 var rdsCertPool atomic.Pointer[x509.CertPool]
 
+// rdsCertGroup collapses concurrent cold-start downloads into one request.
+var rdsCertGroup singleflight.Group
+
 // getRDSCertPool downloads and returns the RDS CA certificate pool.
 // AWS RDS connection with IAM require TLS connection.
 //
@@ -210,17 +214,33 @@ func getRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
 	return rootCertPool, nil
 }
 
-// cachedRDSCertPool caches the AWS RDS CA bundle for the process lifetime.
-// Concurrent first callers may each download, but only successes are cached, so a transient failure can still recover.
+// cachedRDSCertPool returns the AWS RDS CA bundle, downloading it once per
+// process. Only successes are cached, so a transient failure can still recover.
 func cachedRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
 	if pool := rdsCertPool.Load(); pool != nil {
 		return pool, nil
 	}
-	pool, err := getRDSCertPool(ctx)
+	// Collapse a cold-start burst into one download. singleflight does not retain
+	// the error, so a failed fetch is retried by the next caller.
+	v, err, _ := rdsCertGroup.Do("", func() (any, error) {
+		// Double check after entering singleflight.
+		if pool := rdsCertPool.Load(); pool != nil {
+			return pool, nil
+		}
+		pool, err := getRDSCertPool(ctx)
+		if err != nil {
+			return nil, err
+		}
+		rdsCertPool.Store(pool)
+		return pool, nil
+	})
 	if err != nil {
 		return nil, err
 	}
-	rdsCertPool.Store(pool)
+	pool, ok := v.(*x509.CertPool)
+	if !ok {
+		return nil, errors.Errorf("unexpected RDS cert pool type %T", v)
+	}
 	return pool, nil
 }
 

--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -246,9 +246,9 @@ func rdsTLSConfig(ctx context.Context, dataSource *storepb.DataSource) (*tls.Con
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get RDS cert pool")
 	}
-	return &tls.Config{
+	return &tls.Config{ // NOSONAR(go:S4830) VerifyPeerCertificate below verifies chain and hostname
 		RootCAs:               rootCertPool,
-		InsecureSkipVerify:    true, // NOSONAR(go:S4830) superseded by VerifyPeerCertificate below
+		InsecureSkipVerify:    true, // superseded by VerifyPeerCertificate below
 		VerifyPeerCertificate: util.CreateCertificateVerifier(rootCertPool, dataSource.GetHost()),
 	}, nil
 }

--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
@@ -154,6 +155,16 @@ func (d *Driver) getMySQLConnection(connCfg db.ConnectionConfig) (string, error)
 	return fmt.Sprintf("%s:%s@%s(%s:%s)/%s?%s", connCfg.DataSource.Username, connCfg.Password, protocol, connCfg.DataSource.Host, connCfg.DataSource.Port, connCfg.ConnectionContext.DatabaseName, strings.Join(params, "&")), nil
 }
 
+// rdsCertBundleURL is a variable so tests can point it at a local server.
+var rdsCertBundleURL = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem"
+
+// rdsCertFetchTimeout bounds the download so a stalled fetch cannot hold a
+// connection attempt open indefinitely.
+const rdsCertFetchTimeout = 30 * time.Second
+
+// rdsCertPool caches the downloaded bundle for the process lifetime.
+var rdsCertPool atomic.Pointer[x509.CertPool]
+
 // getRDSCertPool downloads and returns the RDS CA certificate pool.
 // AWS RDS connection with IAM require TLS connection.
 //
@@ -161,17 +172,23 @@ func (d *Driver) getMySQLConnection(connCfg db.ConnectionConfig) (string, error)
 // https://github.com/aws/aws-sdk-go/issues/1248
 // https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/mysql-ssl-connections.html
 func getRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rdsCertBundleURL, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to build request for rds cert")
 	}
 
-	client := &http.Client{}
+	client := &http.Client{Timeout: rdsCertFetchTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
+
+	// Without this an error page would reach AppendCertsFromPEM and surface as
+	// "failed to parse RDS CA certificates", hiding the real cause.
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("failed to download RDS CA certificates: %s", resp.Status)
+	}
 
 	pem, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -188,6 +205,52 @@ func getRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
 	}
 
 	return rootCertPool, nil
+}
+
+// cachedRDSCertPool returns the AWS RDS CA bundle, downloading it at most once
+// per process. Only successes are cached, so a transient network failure can
+// recover instead of poisoning every later connection.
+func cachedRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
+	if pool := rdsCertPool.Load(); pool != nil {
+		return pool, nil
+	}
+	pool, err := getRDSCertPool(ctx)
+	if err != nil {
+		return nil, err
+	}
+	rdsCertPool.Store(pool)
+	return pool, nil
+}
+
+// rdsRootCAs prefers an operator-supplied CA, so a deployment can serve RDS IAM
+// connections without any outbound network access.
+func rdsRootCAs(ctx context.Context, dataSource *storepb.DataSource) (*x509.CertPool, error) {
+	if ca := dataSource.GetSslCa(); ca != "" {
+		pool := x509.NewCertPool()
+		if ok := pool.AppendCertsFromPEM([]byte(ca)); !ok {
+			return nil, errors.Errorf("failed to parse ssl_ca certificates")
+		}
+		return pool, nil
+	}
+	return cachedRDSCertPool(ctx)
+}
+
+// rdsTLSConfig builds the TLS config for an RDS IAM connection. IAM auth always
+// requires TLS, so this always returns a config.
+func rdsTLSConfig(ctx context.Context, dataSource *storepb.DataSource) (*tls.Config, error) {
+	if !dataSource.GetVerifyTlsCertificate() {
+		// No verifier runs in this mode, so a root pool would never be consulted.
+		return &tls.Config{InsecureSkipVerify: true}, nil
+	}
+	rootCertPool, err := rdsRootCAs(ctx, dataSource)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get RDS cert pool")
+	}
+	return &tls.Config{
+		RootCAs:               rootCertPool,
+		InsecureSkipVerify:    true, // superseded by VerifyPeerCertificate below
+		VerifyPeerCertificate: util.CreateCertificateVerifier(rootCertPool, dataSource.GetHost()),
+	}, nil
 }
 
 // getRDSConnection returns the connection string with IAM for AWS RDS.
@@ -213,30 +276,13 @@ func (d *Driver) getRDSConnection(ctx context.Context, connCfg db.ConnectionConf
 		return "", errors.Wrap(err, "failed to create authentication token")
 	}
 
-	// Get RDS CA certificate pool
-	rootCertPool, err := getRDSCertPool(ctx)
+	tlsConfig, err := rdsTLSConfig(ctx, connCfg.DataSource)
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get RDS cert pool")
+		return "", err
 	}
 
 	// Create TLS config with unique name for this connection
 	tlsKey := uuid.NewString()
-
-	var tlsConfig *tls.Config
-	if connCfg.DataSource.GetVerifyTlsCertificate() {
-		// Secure config with certificate verification
-		tlsConfig = &tls.Config{
-			RootCAs:            rootCertPool,
-			InsecureSkipVerify: true, // We use custom verification
-		}
-		tlsConfig.VerifyPeerCertificate = util.CreateCertificateVerifier(rootCertPool, connCfg.DataSource.Host)
-	} else {
-		// Backward compatible config without verification
-		tlsConfig = &tls.Config{
-			RootCAs:            rootCertPool,
-			InsecureSkipVerify: true,
-		}
-	}
 
 	// Register the TLS config with unique name
 	if err := mysql.RegisterTLSConfig(tlsKey, tlsConfig); err != nil {

--- a/backend/plugin/db/mysql/mysql.go
+++ b/backend/plugin/db/mysql/mysql.go
@@ -156,11 +156,15 @@ func (d *Driver) getMySQLConnection(connCfg db.ConnectionConfig) (string, error)
 }
 
 // rdsCertBundleURL is a variable so tests can point it at a local server.
-var rdsCertBundleURL = "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem"
+var rdsCertBundleURL = "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
 
 // rdsCertFetchTimeout bounds the download so a stalled fetch cannot hold a
 // connection attempt open indefinitely.
 const rdsCertFetchTimeout = 30 * time.Second
+
+// maxRDSCertBundleSize bounds the downloaded bundle so a misbehaving endpoint
+// cannot stream unbounded data into memory (the real global bundle is ~165 KB).
+const maxRDSCertBundleSize int64 = 4 << 20
 
 // rdsCertPool caches the downloaded bundle for the process lifetime.
 var rdsCertPool atomic.Pointer[x509.CertPool]
@@ -190,13 +194,12 @@ func getRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
 		return nil, errors.Errorf("failed to download RDS CA certificates: %s", resp.Status)
 	}
 
-	pem, err := io.ReadAll(resp.Body)
+	pem, err := io.ReadAll(io.LimitReader(resp.Body, maxRDSCertBundleSize+1))
 	if err != nil {
 		return nil, err
 	}
-
-	if err := resp.Body.Close(); err != nil {
-		return nil, errors.Wrapf(err, "failed to close response")
+	if int64(len(pem)) > maxRDSCertBundleSize {
+		return nil, errors.Errorf("RDS CA bundle exceeds %d bytes", maxRDSCertBundleSize)
 	}
 
 	rootCertPool := x509.NewCertPool()
@@ -207,9 +210,8 @@ func getRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
 	return rootCertPool, nil
 }
 
-// cachedRDSCertPool returns the AWS RDS CA bundle, downloading it at most once
-// per process. Only successes are cached, so a transient network failure can
-// recover instead of poisoning every later connection.
+// cachedRDSCertPool caches the AWS RDS CA bundle for the process lifetime.
+// Concurrent first callers may each download, but only successes are cached, so a transient failure can still recover.
 func cachedRDSCertPool(ctx context.Context) (*x509.CertPool, error) {
 	if pool := rdsCertPool.Load(); pool != nil {
 		return pool, nil

--- a/backend/plugin/db/mysql/mysql_test.go
+++ b/backend/plugin/db/mysql/mysql_test.go
@@ -406,3 +406,75 @@ func TestRDSCertPoolCollapsesConcurrentDownloads(t *testing.T) {
 	}
 	require.Equal(t, int32(1), requests.Load())
 }
+
+func TestRDSCertPoolWaiterObservesItsOwnCancellation(t *testing.T) {
+	ca := selfSignedCAPEM(t)
+	release := make(chan struct{})
+	inFlight := make(chan struct{}, 1)
+	serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
+		inFlight <- struct{}{}
+		<-release
+		_, _ = w.Write([]byte(ca))
+	})
+	// Registered after serveRDSCertBundle so this runs before its server.Close,
+	// which would otherwise wait forever on the blocked handler.
+	t.Cleanup(func() { close(release) })
+
+	dataSource := &storepb.DataSource{Host: "db.example.com", VerifyTlsCertificate: true}
+	// Leader occupies the flight and stays blocked in the handler.
+	go func() {
+		_, _ = cachedRDSCertPool(context.Background())
+	}()
+	<-inFlight
+
+	// The waiter joins the in-flight download, then gives up on its own context.
+	ctx, cancel := context.WithCancel(context.Background())
+	waiterDone := make(chan error, 1)
+	go func() {
+		_, err := rdsTLSConfig(ctx, dataSource)
+		waiterDone <- err
+	}()
+	cancel()
+
+	select {
+	case err := <-waiterDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "canceled waiter blocked on the shared download")
+	}
+}
+
+func TestRDSCertPoolLeaderCancellationDoesNotFailWaiter(t *testing.T) {
+	ca := selfSignedCAPEM(t)
+	release := make(chan struct{})
+	inFlight := make(chan struct{}, 1)
+	serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
+		inFlight <- struct{}{}
+		<-release
+		_, _ = w.Write([]byte(ca))
+	})
+
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	go func() {
+		_, _ = cachedRDSCertPool(leaderCtx)
+	}()
+	<-inFlight
+
+	// A second caller with a live context is waiting on the same flight.
+	waiterDone := make(chan error, 1)
+	go func() {
+		_, err := cachedRDSCertPool(context.Background())
+		waiterDone <- err
+	}()
+
+	// The leader walks away; the shared fetch must still complete for the waiter.
+	cancelLeader()
+	close(release)
+
+	select {
+	case err := <-waiterDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "waiter never completed after leader cancellation")
+	}
+}

--- a/backend/plugin/db/mysql/mysql_test.go
+++ b/backend/plugin/db/mysql/mysql_test.go
@@ -411,6 +411,11 @@ func TestRDSCertPoolWaiterObservesItsOwnCancellation(t *testing.T) {
 	ca := selfSignedCAPEM(t)
 	release := make(chan struct{})
 	inFlight := make(chan struct{}, 1)
+	var leader sync.WaitGroup
+	// Registered before serveRDSCertBundle, so it runs last: the leader must finish
+	// before the helper resets rdsCertPool, or it re-stores this test's pool
+	// afterwards and a later cache test never contacts its own server.
+	t.Cleanup(leader.Wait)
 	serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
 		inFlight <- struct{}{}
 		<-release
@@ -422,7 +427,9 @@ func TestRDSCertPoolWaiterObservesItsOwnCancellation(t *testing.T) {
 
 	dataSource := &storepb.DataSource{Host: "db.example.com", VerifyTlsCertificate: true}
 	// Leader occupies the flight and stays blocked in the handler.
+	leader.Add(1)
 	go func() {
+		defer leader.Done()
 		_, _ = cachedRDSCertPool(context.Background())
 	}()
 	<-inFlight
@@ -430,7 +437,9 @@ func TestRDSCertPoolWaiterObservesItsOwnCancellation(t *testing.T) {
 	// The waiter joins the in-flight download, then gives up on its own context.
 	ctx, cancel := context.WithCancel(context.Background())
 	waiterDone := make(chan error, 1)
+	leader.Add(1)
 	go func() {
+		defer leader.Done()
 		_, err := rdsTLSConfig(ctx, dataSource)
 		waiterDone <- err
 	}()
@@ -448,6 +457,10 @@ func TestRDSCertPoolLeaderCancellationDoesNotFailWaiter(t *testing.T) {
 	ca := selfSignedCAPEM(t)
 	release := make(chan struct{})
 	inFlight := make(chan struct{}, 1)
+	var leader sync.WaitGroup
+	// See the note in TestRDSCertPoolWaiterObservesItsOwnCancellation: this runs
+	// last, so no background store lands after the cache reset.
+	t.Cleanup(leader.Wait)
 	serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
 		inFlight <- struct{}{}
 		<-release
@@ -455,14 +468,18 @@ func TestRDSCertPoolLeaderCancellationDoesNotFailWaiter(t *testing.T) {
 	})
 
 	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leader.Add(1)
 	go func() {
+		defer leader.Done()
 		_, _ = cachedRDSCertPool(leaderCtx)
 	}()
 	<-inFlight
 
 	// A second caller with a live context is waiting on the same flight.
 	waiterDone := make(chan error, 1)
+	leader.Add(1)
 	go func() {
+		defer leader.Done()
 		_, err := cachedRDSCertPool(context.Background())
 		waiterDone <- err
 	}()

--- a/backend/plugin/db/mysql/mysql_test.go
+++ b/backend/plugin/db/mysql/mysql_test.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/bytebase/bytebase/backend/common"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/db/util"
 )
 
 func TestValidateMySQLExtraConnectionParameters(t *testing.T) {
@@ -292,4 +294,74 @@ func TestRDSCertPoolReportsHTTPStatus(t *testing.T) {
 func TestRDSRootCAsRejectsUnparseableSslCa(t *testing.T) {
 	_, err := rdsRootCAs(context.Background(), &storepb.DataSource{SslCa: "not a certificate"})
 	require.ErrorContains(t, err, "ssl_ca")
+}
+
+func TestRDSCertPoolRejectsOversizedResponse(t *testing.T) {
+	serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(bytes.Repeat([]byte("x"), int(maxRDSCertBundleSize)+1024))
+	})
+	_, err := getRDSCertPool(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds")
+}
+
+func TestCreateCertificateVerifierValidatesChainAndHostname(t *testing.T) {
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	rootTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "bytebase-test-root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	require.NoError(t, err)
+	rootCert, err := x509.ParseCertificate(rootDER)
+	require.NoError(t, err)
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(rootCert)
+
+	foreignKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	foreignTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{CommonName: "bytebase-test-foreign-root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	foreignDER, err := x509.CreateCertificate(rand.Reader, foreignTemplate, foreignTemplate, &foreignKey.PublicKey, foreignKey)
+	require.NoError(t, err)
+	foreignCert, err := x509.ParseCertificate(foreignDER)
+	require.NoError(t, err)
+
+	// leafFor returns a DER-encoded leaf signed by parent, valid for dnsName.
+	leafFor := func(parent *x509.Certificate, parentKey *ecdsa.PrivateKey, dnsName string) []byte {
+		leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		leaf := &x509.Certificate{
+			SerialNumber: big.NewInt(100),
+			Subject:      pkix.Name{CommonName: dnsName},
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			DNSNames:     []string{dnsName},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, leaf, parent, &leafKey.PublicKey, parentKey)
+		require.NoError(t, err)
+		return der
+	}
+
+	const host = "db.example.com"
+	verifier := util.CreateCertificateVerifier(rootPool, host)
+
+	require.NoError(t, verifier([][]byte{leafFor(rootCert, rootKey, host)}, nil))
+	require.Error(t, verifier([][]byte{leafFor(rootCert, rootKey, "other.example.com")}, nil))
+	require.Error(t, verifier([][]byte{leafFor(foreignCert, foreignKey, host)}, nil))
 }

--- a/backend/plugin/db/mysql/mysql_test.go
+++ b/backend/plugin/db/mysql/mysql_test.go
@@ -1,12 +1,25 @@
 package mysql
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/bytebase/bytebase/backend/common"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
 
 func TestValidateMySQLExtraConnectionParameters(t *testing.T) {
@@ -151,4 +164,132 @@ func TestBuildExecuteCommandsDoesNotNormalizeDelimiterForLargeSheet(t *testing.T
 	require.NoError(t, err)
 	require.Len(t, commands, 1)
 	require.Equal(t, statement, commands[0].Text)
+}
+
+// selfSignedCAPEM builds a throwaway CA so the tests can assert that a supplied
+// ssl_ca is parsed and that a served bundle is cached, without shipping a
+// certificate that eventually expires.
+func selfSignedCAPEM(t *testing.T) string {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "bytebase-test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}))
+}
+
+// serveRDSCertBundle points rdsCertBundleURL at a local server and returns the
+// request counter, so a test can assert that no download happened at all.
+func serveRDSCertBundle(t *testing.T, handler http.HandlerFunc) *atomic.Int32 {
+	t.Helper()
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	previousURL := rdsCertBundleURL
+	rdsCertBundleURL = server.URL
+	rdsCertPool.Store(nil)
+	t.Cleanup(func() {
+		rdsCertBundleURL = previousURL
+		rdsCertPool.Store(nil)
+	})
+	return &requests
+}
+
+func TestRDSTLSConfigSkipsDownloadWhenVerificationDisabled(t *testing.T) {
+	ca := selfSignedCAPEM(t)
+	requests := serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(ca))
+	})
+
+	cfg, err := rdsTLSConfig(context.Background(), &storepb.DataSource{
+		Host:                 "db.example.com",
+		VerifyTlsCertificate: false,
+	})
+	require.NoError(t, err)
+	require.True(t, cfg.InsecureSkipVerify)
+	require.Nil(t, cfg.RootCAs)
+	require.Nil(t, cfg.VerifyPeerCertificate)
+	require.Equal(t, int32(0), requests.Load())
+}
+
+func TestRDSTLSConfigSkipsDownloadWhenSslCaConfigured(t *testing.T) {
+	ca := selfSignedCAPEM(t)
+	requests := serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(ca))
+	})
+
+	cfg, err := rdsTLSConfig(context.Background(), &storepb.DataSource{
+		Host:                 "db.example.com",
+		VerifyTlsCertificate: true,
+		SslCa:                ca,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, cfg.RootCAs)
+	require.NotNil(t, cfg.VerifyPeerCertificate)
+	require.Equal(t, int32(0), requests.Load())
+}
+
+func TestRDSTLSConfigDownloadsBundleOnlyOnce(t *testing.T) {
+	ca := selfSignedCAPEM(t)
+	requests := serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(ca))
+	})
+
+	dataSource := &storepb.DataSource{Host: "db.example.com", VerifyTlsCertificate: true}
+	for range 5 {
+		cfg, err := rdsTLSConfig(context.Background(), dataSource)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.RootCAs)
+	}
+	require.Equal(t, int32(1), requests.Load())
+}
+
+func TestRDSCertPoolDoesNotCacheFailures(t *testing.T) {
+	ca := selfSignedCAPEM(t)
+	var fail atomic.Bool
+	fail.Store(true)
+	requests := serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
+		if fail.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(ca))
+	})
+
+	_, err := cachedRDSCertPool(context.Background())
+	require.Error(t, err)
+
+	fail.Store(false)
+	pool, err := cachedRDSCertPool(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, pool)
+	require.Equal(t, int32(2), requests.Load())
+}
+
+func TestRDSCertPoolReportsHTTPStatus(t *testing.T) {
+	serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("<Error>AccessDenied</Error>"))
+	})
+
+	_, err := getRDSCertPool(context.Background())
+	require.ErrorContains(t, err, "403")
+}
+
+func TestRDSRootCAsRejectsUnparseableSslCa(t *testing.T) {
+	_, err := rdsRootCAs(context.Background(), &storepb.DataSource{SslCa: "not a certificate"})
+	require.ErrorContains(t, err, "ssl_ca")
 }

--- a/backend/plugin/db/mysql/mysql_test.go
+++ b/backend/plugin/db/mysql/mysql_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -364,4 +365,44 @@ func TestCreateCertificateVerifierValidatesChainAndHostname(t *testing.T) {
 	require.NoError(t, verifier([][]byte{leafFor(rootCert, rootKey, host)}, nil))
 	require.Error(t, verifier([][]byte{leafFor(rootCert, rootKey, "other.example.com")}, nil))
 	require.Error(t, verifier([][]byte{leafFor(foreignCert, foreignKey, host)}, nil))
+}
+
+func TestRDSCertPoolCollapsesConcurrentDownloads(t *testing.T) {
+	const callers = 32
+	ca := selfSignedCAPEM(t)
+	// release blocks the first response until every caller is inside the fetch,
+	// so a per-caller download cannot pass by finishing before the others start.
+	release := make(chan struct{})
+	requests := serveRDSCertBundle(t, func(w http.ResponseWriter, _ *http.Request) {
+		<-release
+		_, _ = w.Write([]byte(ca))
+	})
+
+	dataSource := &storepb.DataSource{Host: "db.example.com", VerifyTlsCertificate: true}
+	var ready, done sync.WaitGroup
+	ready.Add(callers)
+	done.Add(callers)
+	pools := make([]*x509.CertPool, callers)
+	errs := make([]error, callers)
+	for i := range callers {
+		go func() {
+			defer done.Done()
+			ready.Done()
+			cfg, err := rdsTLSConfig(context.Background(), dataSource)
+			errs[i] = err
+			if err == nil {
+				pools[i] = cfg.RootCAs
+			}
+		}()
+	}
+	ready.Wait()
+	close(release)
+	done.Wait()
+
+	for i := range callers {
+		require.NoError(t, errs[i])
+		require.NotNil(t, pools[i])
+		require.Same(t, pools[0], pools[i])
+	}
+	require.Equal(t, int32(1), requests.Load())
 }


### PR DESCRIPTION
## What

`getRDSConnection` calls `getRDSCertPool` on **every** connection, which is an uncached HTTPS `GET` to `s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem`. This PR makes that download happen once per process, skips it entirely when it cannot be used, and lets a configured `ssl_ca` replace it.

Present on `main` and in every released version I checked (3.19.0, 3.20.1, 3.21.1).

The bundle URL is also stale: every CA in `rds-combined-ca-bundle.pem` expired by 2025-06-01, so `verify_tls_certificate=true` without `ssl_ca` cached a pool that could never verify a modern RDS instance. This PR swaps to AWS's current `https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem`.

## Why

Applying a migration to 32 sharded databases opens 32 connections at once, so the rollout issued 32 concurrent downloads of the same file. Any one of them failing failed that task.

We hit this in production against Aurora MySQL with `AWS_RDS_IAM`. Roughly 40% of task runs failed with:

```
failed to get RDS cert pool: Get "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem": net/http: TLS handshake timeout
```

The same schema migration landed on 29, then 29, then 29, then 31 of 32 shard databases across four attempts before converging. Measured from inside the pod, the stall was ~10.5s in the TLS handshake against `http.DefaultTransport`'s 10s `TLSHandshakeTimeout` — so about half of a concurrent burst crossed the limit. Serial requests from the same pod completed in ~85ms.

There is a second, configuration-independent problem. When `verify_tls_certificate` is false, the downloaded pool is placed in:

```go
tls.Config{RootCAs: rootCertPool, InsecureSkipVerify: true}
```

with no `VerifyPeerCertificate`. The pool is never consulted, so in that configuration the download is pure overhead that can only add failures.

That is the configuration we run: with `verify_tls_certificate: true` our IAM schema sync against Aurora MySQL failed with `x509: certificate signed by unknown authority`, so we disabled verification — and then still paid a download per connection for a pool that is discarded. Change 2 below is what would let us turn verification back on without depending on the network.

## Changes

1. **Skip the download when `verify_tls_certificate` is false.** Behaviour-preserving: with `InsecureSkipVerify: true` and no verifier, `RootCAs` had no effect. Now the config is built without touching the network.

2. **Honour `ssl_ca` when `verify_tls_certificate` is true.** `util.GetTLSConfig` already does this for the password path (`backend/plugin/db/util/ssl.go`); the IAM path ignored `ssl_ca` completely. With this, an operator can serve RDS IAM connections with no outbound network access at all. `ssl_ca_path` needs no handling here — `util.HasTLSPath` shows paths are resolved to inline PEM earlier in the pipeline.

   The system pool is deliberately *not* used as a fallback, since RDS certificates chain to Amazon RDS CAs that are not in the system store — which is why the bundle is fetched in the first place.

3. **Cache the bundle for the process lifetime**, successes only, via `atomic.Pointer`, with the cache miss wrapped in a `singleflight` group (`DoChan`) so a cold-start burst collapses into one download. Each caller selects on its own context, so a canceled caller returns immediately instead of blocking on the shared fetch, and the fetch itself runs under `context.WithoutCancel` with its own timeout so the caller that starts it cannot cancel it for everybody else. A failed download is not cached — `singleflight` does not retain the error, so the next caller retries. `sync.OnceValues` would have cached the error and permanently broken every subsequent RDS IAM connection for the process. `singleflight` matches the existing thundering-herd guard in `backend/enterprise/license.go`; `golang.org/x/sync` is already a direct dependency. `sync.OnceValues` would have cached the error and permanently broken every subsequent RDS IAM connection for the process — worth avoiding given the failure mode above.

Three smaller fixes in the same function:

- Bound the download with `http.Client{Timeout: 30s}`. It previously relied only on the caller's context.
- Bound the response body with `io.LimitReader` (4 MiB; the real bundle is ~165 KB) so a misbehaving endpoint cannot stream unbounded data, and dropped the redundant explicit `resp.Body.Close` (the `defer` handles it).
- Report a non-200 status directly. Previously an error page body reached `AppendCertsFromPEM` and surfaced as `failed to parse RDS CA certificates`, hiding the real cause.

## Testing

Eleven new tests in `backend/plugin/db/mysql/mysql_test.go`, using `httptest` with `rdsCertBundleURL` pointed at a local server and a request counter, so "no download happened" is asserted rather than inferred:

- verification disabled → zero requests, `RootCAs` nil, no verifier
- verification enabled with `ssl_ca` set → zero requests, pool present
- verification enabled without `ssl_ca` → exactly one request across five calls
- a failed download is not cached (fail then succeed → two requests, success returned)
- a 403 response is reported as a status error, not a parse error
- an unparseable `ssl_ca` is rejected
- an oversized response is rejected with a size error, not a parse error
- `util.CreateCertificateVerifier` is pinned directly: it accepts a valid chain+hostname and rejects a wrong hostname and an untrusted chain
- 32 concurrent cold-start callers, held inside the fetch by a barrier, produce exactly one request and share one pool
- a canceled waiter returns `context.Canceled` instead of blocking on the shared download
- a waiter still completes when the caller that started the shared fetch cancels

Verified they fail against the previous behaviour: reverting `rdsTLSConfig` to always fetch turns three of them red, including the once-only test at 5 requests instead of 1. Dropping the `singleflight` group turns the concurrent test red at 32 requests with 32 distinct pools, and reverting to `singleflight.Do` turns both context tests red (the canceled waiter blocks, the waiter inherits the leader's cancellation).

```
go test -count=3 -race ./backend/plugin/db/mysql/    ok (no data race)
go test -count=1 ./backend/plugin/db/mysql/          ok
golangci-lint run --allow-parallel-runners ./backend/plugin/db/mysql/...   0 issues
gofmt -l backend/plugin/db/mysql/                    clean
go build ./backend/plugin/db/mysql/                  ok
go vet ./backend/plugin/db/mysql/                    ok
```

## Notes for review

- **Cache lifetime.** The bundle is now cached until the process restarts. AWS rotates these CAs rarely and restarts are routine, so this seemed the simplest correct choice — but if you would rather have bounded staleness, a TTL is a small addition and I am happy to add one.
- **Not marked breaking, but one behaviour change to confirm.** No API, schema, proto, or configuration surface changes. The `verify_tls_certificate: false` path is behaviour-identical. The one visible change: on the IAM path, `ssl_ca` was previously ignored (the downloaded AWS bundle verified the chain), and with this PR it is honoured — when `verify_tls_certificate: true` and `ssl_ca` is set, the connection verifies against `ssl_ca` only and the AWS bundle is not fetched. An existing IAM datasource configured with `verify_tls_certificate: true` and an `ssl_ca` that is not the instance's actual CA chain will start failing IAM connections after upgrade. This is intentional and matches the password path (`util.GetTLSConfig`), but it is a trust-anchor switch for that config combination, so I am calling it out for review.
- Only `backend/plugin/db/mysql/` is touched, so the composite-PK and transaction-lock-ordering sections of the pre-PR checklist do not apply.




