### PR TITLE
fix: name the right RPC in DeleteUser/UndeleteUser SaaS guards

### DIFF
--- a/backend/api/v1/user_service.go
+++ b/backend/api/v1/user_service.go
@@ -499,7 +499,7 @@ func (s *UserService) UpdateUser(ctx context.Context, request *connect.Request[v
 // DeleteUser deletes a user.
 func (s *UserService) DeleteUser(ctx context.Context, request *connect.Request[v1pb.DeleteUserRequest]) (*connect.Response[emptypb.Empty], error) {
 	if s.profile.SaaS {
-		return nil, connect.NewError(connect.CodeUnimplemented, errors.Errorf("CreateUser is not available in SaaS mode, add users via workspace IAM policy instead"))
+		return nil, connect.NewError(connect.CodeUnimplemented, errors.Errorf("DeleteUser is not available in SaaS mode, remove users from the workspace IAM policy instead"))
 	}
 
 	callerUser, ok := GetUserFromContext(ctx)
@@ -586,7 +586,7 @@ func (s *UserService) hasExtraWorkspaceAdmin(ctx context.Context, policy *storep
 // UndeleteUser undeletes a user.
 func (s *UserService) UndeleteUser(ctx context.Context, request *connect.Request[v1pb.UndeleteUserRequest]) (*connect.Response[v1pb.User], error) {
 	if s.profile.SaaS {
-		return nil, connect.NewError(connect.CodeUnimplemented, errors.Errorf("CreateUser is not available in SaaS mode, add users via workspace IAM policy instead"))
+		return nil, connect.NewError(connect.CodeUnimplemented, errors.Errorf("UndeleteUser is not available in SaaS mode, add users back to the workspace IAM policy instead"))
 	}
 
 	callerUser, ok := GetUserFromContext(ctx)


### PR DESCRIPTION
## What

`DeleteUser` and `UndeleteUser` both open with a SaaS-mode guard whose error message was copy-pasted from `CreateUser`:

```
CreateUser is not available in SaaS mode, add users via workspace IAM policy instead
```

So an admin deactivating or restoring a user on SaaS got an error about a different RPC, pointing at guidance that didn't match what they were trying to do. Each message now names its own operation and the corresponding IAM policy action:

| RPC | Message |
|---|---|
| `DeleteUser` | `DeleteUser is not available in SaaS mode, remove users from the workspace IAM policy instead` |
| `UndeleteUser` | `UndeleteUser is not available in SaaS mode, add users back to the workspace IAM policy instead` |

Text only — same code path, same `CodeUnimplemented`, same guard conditions.

## Testing

- No test asserted on the old string. `CodeUnimplemented` appears in zero test files, and the two Go tests touching these RPCs (`backend/tests/user_test.go`, `backend/tests/login_audit_test.go`) never exercise the SaaS branch.
- `golangci-lint run --allow-parallel-runners` → 0 issues; `gofmt -l` clean.
- `go test -count=1 ./backend/api/v1/` passes.
- Full server build passes.

## Follow-up

`UpdateEmail` ([user_service.go:642](https://github.com/bytebase/bytebase/blob/claude/awesome-euclid-e0872c/backend/api/v1/user_service.go#L642)) has the same copy-pasted `CreateUser` message. Left out of this PR because the right SaaS guidance for an email change isn't obvious — identity provider, workspace IAM policy, or not supported at all. Happy to fix in a follow-up once that's settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)