### PR TITLE
fix(pg): stop materializing inherited partition child indexes in sync metadata

### DIFF
--- a/backend/plugin/db/pg/sync.go
+++ b/backend/plugin/db/pg/sync.go
@@ -729,7 +729,7 @@ func getTablePartitions(txn *sql.Tx, indexMap map[db.TableKey][]*storepb.IndexMe
 			Name:               tableName,
 			Expression:         partKeyDef,
 			Value:              relPartBound,
-			Indexes:            indexMap[key],
+			Indexes:            localIndexes(indexMap[key]),
 			CheckConstraints:   checksMap[key],
 			ExcludeConstraints: excludesMap[key],
 		}
@@ -750,6 +750,16 @@ func getTablePartitions(txn *sql.Tx, indexMap map[db.TableKey][]*storepb.IndexMe
 	}
 
 	return result, nil
+}
+
+func localIndexes(indexes []*storepb.IndexMetadata) []*storepb.IndexMetadata {
+	var result []*storepb.IndexMetadata
+	for _, index := range indexes {
+		if index.ParentIndexName == "" {
+			result = append(result, index)
+		}
+	}
+	return result
 }
 
 var listIndexInheritanceQuery = `

--- a/backend/plugin/db/pg/sync.go
+++ b/backend/plugin/db/pg/sync.go
@@ -755,7 +755,7 @@ func getTablePartitions(txn *sql.Tx, indexMap map[db.TableKey][]*storepb.IndexMe
 func localIndexes(indexes []*storepb.IndexMetadata) []*storepb.IndexMetadata {
 	var result []*storepb.IndexMetadata
 	for _, index := range indexes {
-		if index.ParentIndexName == "" {
+		if index.ParentIndexName == "" || index.Comment != "" {
 			result = append(result, index)
 		}
 	}

--- a/backend/plugin/db/pg/sync_partition_index_test.go
+++ b/backend/plugin/db/pg/sync_partition_index_test.go
@@ -1,0 +1,113 @@
+package pg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/db"
+)
+
+const partitionIndexSetupSQL = `
+CREATE TABLE accounts (
+    tenant text NOT NULL,
+    id integer NOT NULL,
+    email text,
+    PRIMARY KEY (tenant, id)
+) PARTITION BY LIST (tenant);
+CREATE TABLE accounts_t1 PARTITION OF accounts FOR VALUES IN ('t1');
+CREATE TABLE accounts_t2 PARTITION OF accounts FOR VALUES IN ('t2') PARTITION BY RANGE (id);
+CREATE TABLE accounts_t2_a PARTITION OF accounts_t2 FOR VALUES FROM (0) TO (100);
+CREATE INDEX accounts_email_idx ON accounts (email);
+CREATE INDEX accounts_t1_local_idx ON accounts_t1 (email, id);
+CREATE INDEX accounts_t2_local_idx ON accounts_t2 (id, email);
+`
+
+// TestSyncPartitionIndexesOmitInheritedClones verifies that synced partition
+// metadata keeps locally-created indexes but not clones propagated from a
+// parent partitioned index.
+func TestSyncPartitionIndexesOmitInheritedClones(t *testing.T) {
+	ctx := context.Background()
+
+	pgContainer := testcontainer.GetTestPgContainer(ctx, t)
+	defer pgContainer.Close(ctx)
+
+	pgDB := pgContainer.GetDB()
+	require.NoError(t, pgDB.Ping())
+
+	_, err := pgDB.Exec(partitionIndexSetupSQL)
+	require.NoError(t, err)
+
+	driver := &Driver{}
+	config := db.ConnectionConfig{
+		DataSource: &storepb.DataSource{
+			Type:     storepb.DataSourceType_ADMIN,
+			Username: "postgres",
+			Host:     pgContainer.GetHost(),
+			Port:     pgContainer.GetPort(),
+			Database: "postgres",
+		},
+		Password: "root-password",
+		ConnectionContext: db.ConnectionContext{
+			EngineVersion: "16.0",
+			DatabaseName:  "postgres",
+		},
+	}
+
+	openedDriver, err := driver.Open(ctx, storepb.Engine_POSTGRES, config)
+	require.NoError(t, err)
+	defer openedDriver.Close(ctx)
+
+	pgDriver, ok := openedDriver.(*Driver)
+	require.True(t, ok)
+
+	metadata, err := pgDriver.SyncDBSchema(ctx)
+	require.NoError(t, err)
+
+	var publicSchema *storepb.SchemaMetadata
+	for _, schema := range metadata.Schemas {
+		if schema.Name == "public" {
+			publicSchema = schema
+			break
+		}
+	}
+	require.NotNil(t, publicSchema, "public schema not found in synced metadata")
+
+	var accounts *storepb.TableMetadata
+	for _, table := range publicSchema.Tables {
+		if table.Name == "accounts" {
+			accounts = table
+			break
+		}
+	}
+	require.NotNil(t, accounts, "accounts table not found in synced metadata")
+
+	require.ElementsMatch(t, []string{"accounts_pkey", "accounts_email_idx"}, indexNames(accounts.Indexes))
+
+	partitions := make(map[string]*storepb.TablePartitionMetadata)
+	for _, partition := range accounts.Partitions {
+		partitions[partition.Name] = partition
+	}
+	require.Len(t, partitions, 2)
+	require.Contains(t, partitions, "accounts_t1")
+	require.Contains(t, partitions, "accounts_t2")
+
+	require.ElementsMatch(t, []string{"accounts_t1_local_idx"}, indexNames(partitions["accounts_t1"].Indexes))
+	require.ElementsMatch(t, []string{"accounts_t2_local_idx"}, indexNames(partitions["accounts_t2"].Indexes))
+
+	require.Len(t, partitions["accounts_t2"].Subpartitions, 1)
+	subpartition := partitions["accounts_t2"].Subpartitions[0]
+	require.Equal(t, "accounts_t2_a", subpartition.Name)
+	require.Empty(t, indexNames(subpartition.Indexes))
+}
+
+func indexNames(indexes []*storepb.IndexMetadata) []string {
+	names := make([]string, 0, len(indexes))
+	for _, index := range indexes {
+		names = append(names, index.Name)
+	}
+	return names
+}

--- a/backend/plugin/db/pg/sync_partition_index_test.go
+++ b/backend/plugin/db/pg/sync_partition_index_test.go
@@ -24,11 +24,12 @@ CREATE TABLE accounts_t2_a PARTITION OF accounts_t2 FOR VALUES FROM (0) TO (100)
 CREATE INDEX accounts_email_idx ON accounts (email);
 CREATE INDEX accounts_t1_local_idx ON accounts_t1 (email, id);
 CREATE INDEX accounts_t2_local_idx ON accounts_t2 (id, email);
+COMMENT ON INDEX accounts_t1_email_idx IS 'clone comment';
 `
 
 // TestSyncPartitionIndexesOmitInheritedClones verifies that synced partition
-// metadata keeps locally-created indexes but not clones propagated from a
-// parent partitioned index.
+// metadata keeps locally-created indexes and commented clones, but not plain
+// clones propagated from a parent partitioned index.
 func TestSyncPartitionIndexesOmitInheritedClones(t *testing.T) {
 	ctx := context.Background()
 
@@ -95,8 +96,16 @@ func TestSyncPartitionIndexesOmitInheritedClones(t *testing.T) {
 	require.Contains(t, partitions, "accounts_t1")
 	require.Contains(t, partitions, "accounts_t2")
 
-	require.ElementsMatch(t, []string{"accounts_t1_local_idx"}, indexNames(partitions["accounts_t1"].Indexes))
+	require.ElementsMatch(t, []string{"accounts_t1_local_idx", "accounts_t1_email_idx"}, indexNames(partitions["accounts_t1"].Indexes))
 	require.ElementsMatch(t, []string{"accounts_t2_local_idx"}, indexNames(partitions["accounts_t2"].Indexes))
+
+	for _, index := range partitions["accounts_t1"].Indexes {
+		if index.Name == "accounts_t1_email_idx" {
+			require.Equal(t, "clone comment", index.Comment)
+			require.Equal(t, "public", index.ParentIndexSchema)
+			require.Equal(t, "accounts_email_idx", index.ParentIndexName)
+		}
+	}
 
 	require.Len(t, partitions["accounts_t2"].Subpartitions, 1)
 	subpartition := partitions["accounts_t2"].Subpartitions[0]

--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -2052,7 +2052,7 @@ func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequ
 	// Construct Primary Key.
 	for _, index := range table.Indexes {
 		if index.Primary {
-			if err := writePrimaryKey(out, schema, table.Name, index); err != nil {
+			if err := writePrimaryKey(out, schema, table.Name, index, len(table.Partitions) == 0 || hasRecordedAttachedChild(table.Partitions, schema, index.Name)); err != nil {
 				return err
 			}
 		}
@@ -2068,7 +2068,7 @@ func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequ
 	// Construct Unique Key.
 	for _, index := range table.Indexes {
 		if index.Unique && !index.Primary && index.IsConstraint {
-			if err := writeUniqueKey(out, schema, table.Name, index); err != nil {
+			if err := writeUniqueKey(out, schema, table.Name, index, len(table.Partitions) == 0 || hasRecordedAttachedChild(table.Partitions, schema, index.Name)); err != nil {
 				return err
 			}
 		}
@@ -2084,7 +2084,7 @@ func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequ
 	// Construct Index.
 	for _, index := range table.Indexes {
 		if !index.Primary && !index.IsConstraint {
-			if err := writeIndex(out, schema, table.Name, index, len(table.Partitions) > 0); err != nil {
+			if err := writeIndex(out, schema, table.Name, index, len(table.Partitions) > 0 && hasRecordedAttachedChild(table.Partitions, schema, index.Name)); err != nil {
 				return err
 			}
 		}
@@ -2219,6 +2219,17 @@ func writeAttachPartitionIndex(out io.Writer, schema string, partition *storepb.
 	return nil
 }
 
+func hasRecordedAttachedChild(partitions []*storepb.TablePartitionMetadata, parentSchema, parentIndex string) bool {
+	for _, partition := range partitions {
+		for _, index := range partition.Indexes {
+			if index.ParentIndexSchema == parentSchema && index.ParentIndexName == parentIndex {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func writeAttachIndex(out io.Writer, schema string, index *storepb.IndexMetadata) error {
 	if len(index.ParentIndexName) == 0 || len(index.ParentIndexSchema) == 0 {
 		return nil
@@ -2255,7 +2266,7 @@ func writeAttachIndex(out io.Writer, schema string, index *storepb.IndexMetadata
 func writePartitionIndex(out io.Writer, schema string, partition *storepb.TablePartitionMetadata) error {
 	for _, index := range partition.Indexes {
 		if !index.IsConstraint && !index.Primary {
-			if err := writeIndex(out, schema, partition.Name, index, len(partition.Subpartitions) > 0); err != nil {
+			if err := writeIndex(out, schema, partition.Name, index, len(partition.Subpartitions) > 0 && hasRecordedAttachedChild(partition.Subpartitions, schema, index.Name)); err != nil {
 				return err
 			}
 		}
@@ -2351,7 +2362,7 @@ func writeIndexComment(out io.Writer, schema string, index *storepb.IndexMetadat
 func writePartitionUniqueKey(out io.Writer, schema string, partition *storepb.TablePartitionMetadata) error {
 	for _, index := range partition.Indexes {
 		if index.Unique && !index.Primary && index.IsConstraint {
-			if err := writeUniqueKey(out, schema, partition.Name, index); err != nil {
+			if err := writeUniqueKey(out, schema, partition.Name, index, len(partition.Subpartitions) == 0 || hasRecordedAttachedChild(partition.Subpartitions, schema, index.Name)); err != nil {
 				return err
 			}
 		}
@@ -2365,8 +2376,12 @@ func writePartitionUniqueKey(out io.Writer, schema string, partition *storepb.Ta
 	return nil
 }
 
-func writeUniqueKey(out io.Writer, schema string, table string, index *storepb.IndexMetadata) error {
-	if _, err := io.WriteString(out, `ALTER TABLE ONLY "`); err != nil {
+func writeUniqueKey(out io.Writer, schema string, table string, index *storepb.IndexMetadata, useOnly bool) error {
+	alterTable := `ALTER TABLE ONLY "`
+	if !useOnly {
+		alterTable = `ALTER TABLE "`
+	}
+	if _, err := io.WriteString(out, alterTable); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(out, schema); err != nil {
@@ -2413,7 +2428,7 @@ func writeUniqueKey(out io.Writer, schema string, table string, index *storepb.I
 func writePartitionPrimaryKey(out io.Writer, schema string, partition *storepb.TablePartitionMetadata) error {
 	for _, index := range partition.Indexes {
 		if index.Primary {
-			if err := writePrimaryKey(out, schema, partition.Name, index); err != nil {
+			if err := writePrimaryKey(out, schema, partition.Name, index, len(partition.Subpartitions) == 0 || hasRecordedAttachedChild(partition.Subpartitions, schema, index.Name)); err != nil {
 				return err
 			}
 		}
@@ -2427,8 +2442,12 @@ func writePartitionPrimaryKey(out io.Writer, schema string, partition *storepb.T
 	return nil
 }
 
-func writePrimaryKey(out io.Writer, schema string, table string, index *storepb.IndexMetadata) error {
-	if _, err := io.WriteString(out, `ALTER TABLE ONLY "`); err != nil {
+func writePrimaryKey(out io.Writer, schema string, table string, index *storepb.IndexMetadata, useOnly bool) error {
+	alterTable := `ALTER TABLE ONLY "`
+	if !useOnly {
+		alterTable = `ALTER TABLE "`
+	}
+	if _, err := io.WriteString(out, alterTable); err != nil {
 		return err
 	}
 	if _, err := io.WriteString(out, schema); err != nil {
@@ -3595,7 +3614,7 @@ func writeIndexesSDL(out io.Writer, schemaName string, table *storepb.TableMetad
 			continue
 		}
 
-		if err := writeIndexSDL(out, schemaName, table.Name, index, len(table.Partitions) > 0); err != nil {
+		if err := writeIndexSDL(out, schemaName, table.Name, index, len(table.Partitions) > 0 && hasRecordedAttachedChild(table.Partitions, schemaName, index.Name)); err != nil {
 			return err
 		}
 

--- a/backend/plugin/schema/pg/get_database_definition.go
+++ b/backend/plugin/schema/pg/get_database_definition.go
@@ -2049,15 +2049,6 @@ func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequ
 		}
 	}
 
-	// Construct Primary Key.
-	for _, index := range table.Indexes {
-		if index.Primary {
-			if err := writePrimaryKey(out, schema, table.Name, index, len(table.Partitions) == 0 || hasRecordedAttachedChild(table.Partitions, schema, index.Name)); err != nil {
-				return err
-			}
-		}
-	}
-
 	// Construct Partition table primary key.
 	for _, partition := range table.Partitions {
 		if err := writePartitionPrimaryKey(out, schema, partition); err != nil {
@@ -2065,10 +2056,10 @@ func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequ
 		}
 	}
 
-	// Construct Unique Key.
+	// Construct Primary Key.
 	for _, index := range table.Indexes {
-		if index.Unique && !index.Primary && index.IsConstraint {
-			if err := writeUniqueKey(out, schema, table.Name, index, len(table.Partitions) == 0 || hasRecordedAttachedChild(table.Partitions, schema, index.Name)); err != nil {
+		if index.Primary {
+			if err := writePrimaryKey(out, schema, table.Name, index, len(table.Partitions) == 0 || allPartitionsRecordAttachedChild(table.Partitions, schema, index.Name)); err != nil {
 				return err
 			}
 		}
@@ -2081,10 +2072,10 @@ func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequ
 		}
 	}
 
-	// Construct Index.
+	// Construct Unique Key.
 	for _, index := range table.Indexes {
-		if !index.Primary && !index.IsConstraint {
-			if err := writeIndex(out, schema, table.Name, index, len(table.Partitions) > 0 && hasRecordedAttachedChild(table.Partitions, schema, index.Name)); err != nil {
+		if index.Unique && !index.Primary && index.IsConstraint {
+			if err := writeUniqueKey(out, schema, table.Name, index, len(table.Partitions) == 0 || allPartitionsRecordAttachedChild(table.Partitions, schema, index.Name)); err != nil {
 				return err
 			}
 		}
@@ -2094,6 +2085,15 @@ func writeTable(out io.Writer, schema string, table *storepb.TableMetadata, sequ
 	for _, partition := range table.Partitions {
 		if err := writePartitionIndex(out, schema, partition); err != nil {
 			return err
+		}
+	}
+
+	// Construct Index.
+	for _, index := range table.Indexes {
+		if !index.Primary && !index.IsConstraint {
+			if err := writeIndex(out, schema, table.Name, index, allPartitionsRecordAttachedChild(table.Partitions, schema, index.Name)); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -2219,15 +2219,23 @@ func writeAttachPartitionIndex(out io.Writer, schema string, partition *storepb.
 	return nil
 }
 
-func hasRecordedAttachedChild(partitions []*storepb.TablePartitionMetadata, parentSchema, parentIndex string) bool {
+func allPartitionsRecordAttachedChild(partitions []*storepb.TablePartitionMetadata, parentSchema, parentIndex string) bool {
+	if len(partitions) == 0 {
+		return false
+	}
 	for _, partition := range partitions {
+		found := false
 		for _, index := range partition.Indexes {
 			if index.ParentIndexSchema == parentSchema && index.ParentIndexName == parentIndex {
-				return true
+				found = true
+				break
 			}
 		}
+		if !found {
+			return false
+		}
 	}
-	return false
+	return true
 }
 
 func writeAttachIndex(out io.Writer, schema string, index *storepb.IndexMetadata) error {
@@ -2264,17 +2272,17 @@ func writeAttachIndex(out io.Writer, schema string, index *storepb.IndexMetadata
 }
 
 func writePartitionIndex(out io.Writer, schema string, partition *storepb.TablePartitionMetadata) error {
-	for _, index := range partition.Indexes {
-		if !index.IsConstraint && !index.Primary {
-			if err := writeIndex(out, schema, partition.Name, index, len(partition.Subpartitions) > 0 && hasRecordedAttachedChild(partition.Subpartitions, schema, index.Name)); err != nil {
-				return err
-			}
-		}
-	}
-
 	for _, subpartition := range partition.Subpartitions {
 		if err := writePartitionIndex(out, schema, subpartition); err != nil {
 			return err
+		}
+	}
+
+	for _, index := range partition.Indexes {
+		if !index.IsConstraint && !index.Primary {
+			if err := writeIndex(out, schema, partition.Name, index, allPartitionsRecordAttachedChild(partition.Subpartitions, schema, index.Name)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -2360,17 +2368,17 @@ func writeIndexComment(out io.Writer, schema string, index *storepb.IndexMetadat
 }
 
 func writePartitionUniqueKey(out io.Writer, schema string, partition *storepb.TablePartitionMetadata) error {
-	for _, index := range partition.Indexes {
-		if index.Unique && !index.Primary && index.IsConstraint {
-			if err := writeUniqueKey(out, schema, partition.Name, index, len(partition.Subpartitions) == 0 || hasRecordedAttachedChild(partition.Subpartitions, schema, index.Name)); err != nil {
-				return err
-			}
-		}
-	}
-
 	for _, subpartition := range partition.Subpartitions {
 		if err := writePartitionUniqueKey(out, schema, subpartition); err != nil {
 			return err
+		}
+	}
+
+	for _, index := range partition.Indexes {
+		if index.Unique && !index.Primary && index.IsConstraint {
+			if err := writeUniqueKey(out, schema, partition.Name, index, len(partition.Subpartitions) == 0 || allPartitionsRecordAttachedChild(partition.Subpartitions, schema, index.Name)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -2426,17 +2434,17 @@ func writeUniqueKey(out io.Writer, schema string, table string, index *storepb.I
 }
 
 func writePartitionPrimaryKey(out io.Writer, schema string, partition *storepb.TablePartitionMetadata) error {
-	for _, index := range partition.Indexes {
-		if index.Primary {
-			if err := writePrimaryKey(out, schema, partition.Name, index, len(partition.Subpartitions) == 0 || hasRecordedAttachedChild(partition.Subpartitions, schema, index.Name)); err != nil {
-				return err
-			}
-		}
-	}
-
 	for _, subpartition := range partition.Subpartitions {
 		if err := writePartitionPrimaryKey(out, schema, subpartition); err != nil {
 			return err
+		}
+	}
+
+	for _, index := range partition.Indexes {
+		if index.Primary {
+			if err := writePrimaryKey(out, schema, partition.Name, index, len(partition.Subpartitions) == 0 || allPartitionsRecordAttachedChild(partition.Subpartitions, schema, index.Name)); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -3614,7 +3622,7 @@ func writeIndexesSDL(out io.Writer, schemaName string, table *storepb.TableMetad
 			continue
 		}
 
-		if err := writeIndexSDL(out, schemaName, table.Name, index, len(table.Partitions) > 0 && hasRecordedAttachedChild(table.Partitions, schemaName, index.Name)); err != nil {
+		if err := writeIndexSDL(out, schemaName, table.Name, index, allPartitionsRecordAttachedChild(table.Partitions, schemaName, index.Name)); err != nil {
 			return err
 		}
 

--- a/backend/plugin/schema/pg/metadata_migration.go
+++ b/backend/plugin/schema/pg/metadata_migration.go
@@ -1645,7 +1645,7 @@ func writeTableForMetadataMigration(out *strings.Builder, schemaName string, tab
 	}
 	for _, index := range table.GetIndexes() {
 		if index.GetPrimary() {
-			if err := writePrimaryKey(out, schemaName, table.GetName(), index); err != nil {
+			if err := writePrimaryKey(out, schemaName, table.GetName(), index, len(table.GetPartitions()) == 0 || hasRecordedAttachedChild(table.GetPartitions(), schemaName, index.GetName())); err != nil {
 				return err
 			}
 		}
@@ -1657,7 +1657,7 @@ func writeTableForMetadataMigration(out *strings.Builder, schemaName string, tab
 	}
 	for _, index := range table.GetIndexes() {
 		if index.GetUnique() && !index.GetPrimary() && index.GetIsConstraint() {
-			if err := writeUniqueKey(out, schemaName, table.GetName(), index); err != nil {
+			if err := writeUniqueKey(out, schemaName, table.GetName(), index, len(table.GetPartitions()) == 0 || hasRecordedAttachedChild(table.GetPartitions(), schemaName, index.GetName())); err != nil {
 				return err
 			}
 		}
@@ -1669,7 +1669,7 @@ func writeTableForMetadataMigration(out *strings.Builder, schemaName string, tab
 	}
 	for _, index := range table.GetIndexes() {
 		if !index.GetPrimary() && !index.GetIsConstraint() {
-			if err := writeCreateRegularIndex(out, schemaName, table.GetName(), index, len(table.GetPartitions()) > 0); err != nil {
+			if err := writeCreateRegularIndex(out, schemaName, table.GetName(), index, len(table.GetPartitions()) > 0 && hasRecordedAttachedChild(table.GetPartitions(), schemaName, index.GetName())); err != nil {
 				return err
 			}
 		}
@@ -1762,7 +1762,7 @@ func writeCreatePartitionDiff(out *strings.Builder, schemaName, tableName string
 func writePartitionIndexForMetadataMigration(out *strings.Builder, schemaName string, partition *storepb.TablePartitionMetadata) error {
 	for _, index := range partition.GetIndexes() {
 		if !index.GetIsConstraint() && !index.GetPrimary() {
-			if err := writeCreateRegularIndex(out, schemaName, partition.GetName(), index, len(partition.GetSubpartitions()) > 0); err != nil {
+			if err := writeCreateRegularIndex(out, schemaName, partition.GetName(), index, len(partition.GetSubpartitions()) > 0 && hasRecordedAttachedChild(partition.GetSubpartitions(), schemaName, index.GetName())); err != nil {
 				return err
 			}
 		}
@@ -1793,14 +1793,14 @@ func writeAlterTableDiff(out *strings.Builder, tableDiff *schema.TableDiff) erro
 	}
 	for _, primaryKeyDiff := range tableDiff.PrimaryKeyChanges {
 		if primaryKeyDiff.Action == schema.MetadataDiffActionCreate || primaryKeyDiff.Action == schema.MetadataDiffActionAlter {
-			if err := writePrimaryKey(out, tableDiff.SchemaName, tableDiff.TableName, primaryKeyDiff.NewPrimaryKey); err != nil {
+			if err := writePrimaryKey(out, tableDiff.SchemaName, tableDiff.TableName, primaryKeyDiff.NewPrimaryKey, true); err != nil {
 				return err
 			}
 		}
 	}
 	for _, uniqueConstraintDiff := range tableDiff.UniqueConstraintChanges {
 		if uniqueConstraintDiff.Action == schema.MetadataDiffActionCreate || uniqueConstraintDiff.Action == schema.MetadataDiffActionAlter {
-			if err := writeUniqueKey(out, tableDiff.SchemaName, tableDiff.TableName, uniqueConstraintDiff.NewUniqueConstraint); err != nil {
+			if err := writeUniqueKey(out, tableDiff.SchemaName, tableDiff.TableName, uniqueConstraintDiff.NewUniqueConstraint, true); err != nil {
 				return err
 			}
 		}
@@ -2050,16 +2050,16 @@ func writeCreateIndexDiff(out *strings.Builder, schemaName, tableName string, in
 	}
 	switch {
 	case index.GetPrimary():
-		return writePrimaryKey(out, schemaName, tableName, index)
+		return writePrimaryKey(out, schemaName, tableName, index, true)
 	case index.GetUnique() && index.GetIsConstraint():
-		return writeUniqueKey(out, schemaName, tableName, index)
+		return writeUniqueKey(out, schemaName, tableName, index, true)
 	default:
 		return writeCreateRegularIndex(out, schemaName, tableName, index, false)
 	}
 }
 
 func writeCreateRegularIndex(out *strings.Builder, schemaName, tableName string, index *storepb.IndexMetadata, useOnlyClause bool) error {
-	if index.GetDefinition() != "" {
+	if index.GetDefinition() != "" && (useOnlyClause || !strings.Contains(index.GetDefinition(), " ON ONLY ")) {
 		if err := writeDefinitionStatement(out, index.GetDefinition()); err != nil {
 			return err
 		}

--- a/backend/plugin/schema/pg/metadata_migration.go
+++ b/backend/plugin/schema/pg/metadata_migration.go
@@ -1643,21 +1643,14 @@ func writeTableForMetadataMigration(out *strings.Builder, schemaName string, tab
 			return err
 		}
 	}
-	for _, index := range table.GetIndexes() {
-		if index.GetPrimary() {
-			if err := writePrimaryKey(out, schemaName, table.GetName(), index, len(table.GetPartitions()) == 0 || hasRecordedAttachedChild(table.GetPartitions(), schemaName, index.GetName())); err != nil {
-				return err
-			}
-		}
-	}
 	for _, partition := range table.GetPartitions() {
 		if err := writePartitionPrimaryKey(out, schemaName, partition); err != nil {
 			return err
 		}
 	}
 	for _, index := range table.GetIndexes() {
-		if index.GetUnique() && !index.GetPrimary() && index.GetIsConstraint() {
-			if err := writeUniqueKey(out, schemaName, table.GetName(), index, len(table.GetPartitions()) == 0 || hasRecordedAttachedChild(table.GetPartitions(), schemaName, index.GetName())); err != nil {
+		if index.GetPrimary() {
+			if err := writePrimaryKey(out, schemaName, table.GetName(), index, len(table.GetPartitions()) == 0 || allPartitionsRecordAttachedChild(table.GetPartitions(), schemaName, index.GetName())); err != nil {
 				return err
 			}
 		}
@@ -1668,8 +1661,8 @@ func writeTableForMetadataMigration(out *strings.Builder, schemaName string, tab
 		}
 	}
 	for _, index := range table.GetIndexes() {
-		if !index.GetPrimary() && !index.GetIsConstraint() {
-			if err := writeCreateRegularIndex(out, schemaName, table.GetName(), index, len(table.GetPartitions()) > 0 && hasRecordedAttachedChild(table.GetPartitions(), schemaName, index.GetName())); err != nil {
+		if index.GetUnique() && !index.GetPrimary() && index.GetIsConstraint() {
+			if err := writeUniqueKey(out, schemaName, table.GetName(), index, len(table.GetPartitions()) == 0 || allPartitionsRecordAttachedChild(table.GetPartitions(), schemaName, index.GetName())); err != nil {
 				return err
 			}
 		}
@@ -1677,6 +1670,13 @@ func writeTableForMetadataMigration(out *strings.Builder, schemaName string, tab
 	for _, partition := range table.GetPartitions() {
 		if err := writePartitionIndexForMetadataMigration(out, schemaName, partition); err != nil {
 			return err
+		}
+	}
+	for _, index := range table.GetIndexes() {
+		if !index.GetPrimary() && !index.GetIsConstraint() {
+			if err := writeCreateRegularIndex(out, schemaName, table.GetName(), index, allPartitionsRecordAttachedChild(table.GetPartitions(), schemaName, index.GetName())); err != nil {
+				return err
+			}
 		}
 	}
 	for _, partition := range table.GetPartitions() {
@@ -1760,16 +1760,16 @@ func writeCreatePartitionDiff(out *strings.Builder, schemaName, tableName string
 }
 
 func writePartitionIndexForMetadataMigration(out *strings.Builder, schemaName string, partition *storepb.TablePartitionMetadata) error {
-	for _, index := range partition.GetIndexes() {
-		if !index.GetIsConstraint() && !index.GetPrimary() {
-			if err := writeCreateRegularIndex(out, schemaName, partition.GetName(), index, len(partition.GetSubpartitions()) > 0 && hasRecordedAttachedChild(partition.GetSubpartitions(), schemaName, index.GetName())); err != nil {
-				return err
-			}
-		}
-	}
 	for _, subpartition := range partition.GetSubpartitions() {
 		if err := writePartitionIndexForMetadataMigration(out, schemaName, subpartition); err != nil {
 			return err
+		}
+	}
+	for _, index := range partition.GetIndexes() {
+		if !index.GetIsConstraint() && !index.GetPrimary() {
+			if err := writeCreateRegularIndex(out, schemaName, partition.GetName(), index, allPartitionsRecordAttachedChild(partition.GetSubpartitions(), schemaName, index.GetName())); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/backend/plugin/schema/pg/partition_index_definition_testcontainer_test.go
+++ b/backend/plugin/schema/pg/partition_index_definition_testcontainer_test.go
@@ -1,0 +1,136 @@
+package pg
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
+)
+
+const partitionIndexRoundTripDDL = `
+CREATE TABLE accounts (
+    tenant text NOT NULL,
+    id integer NOT NULL,
+    email text,
+    PRIMARY KEY (tenant, id)
+) PARTITION BY LIST (tenant);
+CREATE TABLE accounts_t1 PARTITION OF accounts FOR VALUES IN ('t1');
+CREATE TABLE accounts_t2 PARTITION OF accounts FOR VALUES IN ('t2') PARTITION BY RANGE (id);
+CREATE TABLE accounts_t2_a PARTITION OF accounts_t2 FOR VALUES FROM (0) TO (100);
+CREATE INDEX accounts_email_idx ON accounts (email);
+CREATE INDEX accounts_t1_local_idx ON accounts_t1 (email, id);
+CREATE INDEX accounts_t2_local_idx ON accounts_t2 (id, email);
+`
+
+// TestGetDatabaseDefinitionPartitionIndexRoundTrip verifies that the generated
+// definition of a partitioned table with indexes restores to a database where
+// every index is valid and every partition carries its indexes.
+func TestGetDatabaseDefinitionPartitionIndexRoundTrip(t *testing.T) {
+	ctx := context.Background()
+
+	pgContainer := testcontainer.GetTestPgContainer(ctx, t)
+	defer pgContainer.Close(ctx)
+
+	pgDB := pgContainer.GetDB()
+	require.NoError(t, pgDB.Ping())
+
+	dbNameA := fmt.Sprintf("part_idx_a_%d", time.Now().UnixNano()%1000000)
+	_, err := pgDB.Exec(fmt.Sprintf("CREATE DATABASE %s", dbNameA))
+	require.NoError(t, err)
+
+	driverA, err := createPgDriver(ctx, pgContainer.GetHost(), pgContainer.GetPort(), dbNameA)
+	require.NoError(t, err)
+	defer driverA.Close(ctx)
+
+	_, err = driverA.GetDB().ExecContext(ctx, partitionIndexRoundTripDDL)
+	require.NoError(t, err)
+
+	metadataA, err := driverA.SyncDBSchema(ctx)
+	require.NoError(t, err)
+
+	generatedDDL, err := GetDatabaseDefinition(schema.GetDefinitionContext{}, metadataA)
+	require.NoError(t, err)
+
+	dbNameB := fmt.Sprintf("part_idx_b_%d", time.Now().UnixNano()%1000000)
+	_, err = pgDB.Exec(fmt.Sprintf("CREATE DATABASE %s", dbNameB))
+	require.NoError(t, err)
+
+	driverB, err := createPgDriver(ctx, pgContainer.GetHost(), pgContainer.GetPort(), dbNameB)
+	require.NoError(t, err)
+	defer driverB.Close(ctx)
+
+	_, err = driverB.GetDB().ExecContext(ctx, generatedDDL)
+	require.NoError(t, err, "failed to execute generated DDL: %s", generatedDDL)
+
+	dbB := driverB.GetDB()
+
+	var invalidCount int
+	require.NoError(t, dbB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pg_index WHERE NOT indisvalid`).Scan(&invalidCount))
+	require.Zero(t, invalidCount, "restored database has invalid indexes; generated DDL:\n%s", generatedDDL)
+
+	var indexInheritanceEdges int
+	require.NoError(t, dbB.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM pg_inherits i JOIN pg_class c ON c.oid = i.inhrelid WHERE c.relkind IN ('i', 'I')`).Scan(&indexInheritanceEdges))
+	require.Equal(t, 7, indexInheritanceEdges, "generated DDL:\n%s", generatedDDL)
+
+	for _, indexName := range []string{"accounts_pkey", "accounts_email_idx", "accounts_t1_local_idx", "accounts_t2_local_idx"} {
+		var exists bool
+		require.NoError(t, dbB.QueryRowContext(ctx,
+			`SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = $1 AND relkind IN ('i', 'I'))`, indexName).Scan(&exists))
+		require.True(t, exists, "index %s missing from restored database; generated DDL:\n%s", indexName, generatedDDL)
+	}
+}
+
+// TestGetDatabaseDefinitionLegacyPartitionIndexMetadata pins the pg_dump-style
+// output for metadata rows that still record inherited partition child indexes.
+func TestGetDatabaseDefinitionLegacyPartitionIndexMetadata(t *testing.T) {
+	meta := &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name: "public",
+			Tables: []*storepb.TableMetadata{{
+				Name: "accounts",
+				Columns: []*storepb.ColumnMetadata{
+					{Name: "tenant", Type: "text", Nullable: false},
+					{Name: "email", Type: "text", Nullable: true},
+				},
+				Indexes: []*storepb.IndexMetadata{{
+					Name:        "accounts_email_idx",
+					Type:        "btree",
+					Expressions: []string{"email"},
+					Definition:  "CREATE INDEX accounts_email_idx ON ONLY public.accounts USING btree (email);",
+				}},
+				Partitions: []*storepb.TablePartitionMetadata{{
+					Name:       "accounts_t1",
+					Type:       storepb.TablePartitionMetadata_LIST,
+					Expression: "LIST (tenant)",
+					Value:      "FOR VALUES IN ('t1')",
+					Indexes: []*storepb.IndexMetadata{{
+						Name:              "accounts_t1_email_idx",
+						Type:              "btree",
+						Expressions:       []string{"email"},
+						Definition:        "CREATE INDEX accounts_t1_email_idx ON public.accounts_t1 USING btree (email);",
+						ParentIndexSchema: "public",
+						ParentIndexName:   "accounts_email_idx",
+					}},
+				}},
+			}},
+		}},
+	}
+
+	ddl, err := GetDatabaseDefinition(schema.GetDefinitionContext{}, meta)
+	require.NoError(t, err)
+
+	require.Contains(t, ddl, `CREATE INDEX "accounts_email_idx" ON ONLY "public"."accounts"`)
+	require.Contains(t, ddl, `CREATE INDEX "accounts_t1_email_idx" ON "public"."accounts_t1"`)
+	require.Contains(t, ddl, `ALTER INDEX "public"."accounts_email_idx" ATTACH PARTITION "public"."accounts_t1_email_idx";`)
+	require.False(t, strings.Contains(ddl, `ON ONLY "public"."accounts_t1"`), "partition without subpartitions must not use ON ONLY; got:\n%s", ddl)
+}

--- a/backend/plugin/schema/pg/partition_index_definition_testcontainer_test.go
+++ b/backend/plugin/schema/pg/partition_index_definition_testcontainer_test.go
@@ -24,9 +24,11 @@ CREATE TABLE accounts (
 CREATE TABLE accounts_t1 PARTITION OF accounts FOR VALUES IN ('t1');
 CREATE TABLE accounts_t2 PARTITION OF accounts FOR VALUES IN ('t2') PARTITION BY RANGE (id);
 CREATE TABLE accounts_t2_a PARTITION OF accounts_t2 FOR VALUES FROM (0) TO (100);
+CREATE INDEX accounts_t1_email_idx ON accounts_t1 (id);
 CREATE INDEX accounts_email_idx ON accounts (email);
 CREATE INDEX accounts_t1_local_idx ON accounts_t1 (email, id);
 CREATE INDEX accounts_t2_local_idx ON accounts_t2 (id, email);
+COMMENT ON INDEX accounts_t1_email_idx1 IS 'inherited clone comment';
 `
 
 // TestGetDatabaseDefinitionPartitionIndexRoundTrip verifies that the generated
@@ -81,12 +83,22 @@ func TestGetDatabaseDefinitionPartitionIndexRoundTrip(t *testing.T) {
 		`SELECT COUNT(*) FROM pg_inherits i JOIN pg_class c ON c.oid = i.inhrelid WHERE c.relkind IN ('i', 'I')`).Scan(&indexInheritanceEdges))
 	require.Equal(t, 7, indexInheritanceEdges, "generated DDL:\n%s", generatedDDL)
 
-	for _, indexName := range []string{"accounts_pkey", "accounts_email_idx", "accounts_t1_local_idx", "accounts_t2_local_idx"} {
+	for _, indexName := range []string{"accounts_pkey", "accounts_email_idx", "accounts_t1_email_idx", "accounts_t1_email_idx1", "accounts_t1_local_idx", "accounts_t2_local_idx"} {
 		var exists bool
 		require.NoError(t, dbB.QueryRowContext(ctx,
 			`SELECT EXISTS (SELECT 1 FROM pg_class WHERE relname = $1 AND relkind IN ('i', 'I'))`, indexName).Scan(&exists))
 		require.True(t, exists, "index %s missing from restored database; generated DDL:\n%s", indexName, generatedDDL)
 	}
+
+	var localDef string
+	require.NoError(t, dbB.QueryRowContext(ctx,
+		`SELECT pg_get_indexdef(oid) FROM pg_class WHERE relname = 'accounts_t1_email_idx'`).Scan(&localDef))
+	require.Contains(t, localDef, "(id)", "generated DDL:\n%s", generatedDDL)
+
+	var cloneComment string
+	require.NoError(t, dbB.QueryRowContext(ctx,
+		`SELECT COALESCE(obj_description(oid), '') FROM pg_class WHERE relname = 'accounts_t1_email_idx1'`).Scan(&cloneComment))
+	require.Equal(t, "inherited clone comment", cloneComment, "generated DDL:\n%s", generatedDDL)
 }
 
 // TestGetDatabaseDefinitionLegacyPartitionIndexMetadata pins the pg_dump-style
@@ -133,4 +145,8 @@ func TestGetDatabaseDefinitionLegacyPartitionIndexMetadata(t *testing.T) {
 	require.Contains(t, ddl, `CREATE INDEX "accounts_t1_email_idx" ON "public"."accounts_t1"`)
 	require.Contains(t, ddl, `ALTER INDEX "public"."accounts_email_idx" ATTACH PARTITION "public"."accounts_t1_email_idx";`)
 	require.False(t, strings.Contains(ddl, `ON ONLY "public"."accounts_t1"`), "partition without subpartitions must not use ON ONLY; got:\n%s", ddl)
+	require.Less(t,
+		strings.Index(ddl, `CREATE INDEX "accounts_t1_email_idx"`),
+		strings.Index(ddl, `CREATE INDEX "accounts_email_idx"`),
+		"partition index must be written before parent index; got:\n%s", ddl)
 }


### PR DESCRIPTION
## Problem

PostgreSQL automatically clones every index of a partitioned table onto each partition. `getTablePartitions` stores those clones in full under `TablePartitionMetadata.Indexes`, so `db_schema.metadata` grows as `partitions × indexes` with no added information — and that document sits on the SQL editor query path (`GetQuerySpan → GetSearchPath`).

Measured on a production database (~20 tables, LIST-partitioned into 106 per-tenant partitions, 12–13 indexes each), before/after this PR under identical conditions:

| Metric | before | after |
|---|---|---|
| `db_schema.metadata` | 72 MB | 2.4 MB (**−96.7%**) |
| one table's `partitions` block | 3,433,099 B | 87,159 B |
| parent `columns` / `indexes` | — | byte-identical |
| SQL editor `SELECT ... LIMIT 10` end-to-end | ~27 s | **< 3 s** |
| PostgreSQL-side duration | ~0.3 s | ~0.3 s |

## Fix

- **Sync** (`backend/plugin/db/pg/sync.go`): partitions keep only locally-created indexes. The discriminator is catalog-derived — `pg_inherits` marks propagated clones with a non-empty `parent_index_name` (`listIndexInheritanceQuery`). Clones carrying a user comment are kept so `COMMENT ON INDEX` survives.
- **Emitters** (`backend/plugin/schema/pg/get_database_definition.go`, `metadata_migration.go`): the pg_dump-style `ON ONLY` + child `CREATE INDEX` + `ATTACH PARTITION` shape is kept only when every partition still records an attached child (i.e. legacy metadata). Otherwise the cascading form is emitted (`CREATE INDEX ON parent`, `ALTER TABLE parent ADD CONSTRAINT ...`) and PostgreSQL propagates the index itself. Partition-level statements are written before parent-level ones (deepest first), so the cascade attaches pre-created children instead of claiming their names — verified on PG16, including that re-`ATTACH` of an attached child is a no-op.

The query-span model never read partition indexes, and the metadata differ ignores them (`partitionsEqual`), so neither is affected; metadata synced before this change keeps producing its current statements.

## Behavior changes

- Fresh syncs list only locally-created indexes (plus commented clones) on partition children.
- Definitions for freshly-synced partitioned tables use the cascading form; auto-generated child index names match PostgreSQL's usual `<partition>_<cols>_idx`. An uncommented clone that was manually renamed is no longer reproduced under its custom name.

## Testing

Three new tests, each written first and watched fail: a sync testcontainer test (clones filtered at every level, locals and commented clones kept), a restore round-trip asserting against the restored catalog (`pg_index`/`pg_inherits`: no INVALID index, all inheritance edges present, name-collision fixture, comment preserved), and a legacy-metadata output pin. Full `backend/plugin/db/pg` and `backend/plugin/schema/pg` suites pass; `golangci-lint` reports no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
