### PR TITLE
fix(redis): classify RedisJSON and other module read commands as read-only

### DIFF
--- a/backend/plugin/parser/redis/query.go
+++ b/backend/plugin/parser/redis/query.go
@@ -10,6 +10,16 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
 
+// readCommands holds the core Redis commands that the server flags "readonly"
+// in its own command table. Redis has no read-only transaction or connection
+// mode, so the SQL Editor read-only gate has to classify by command name.
+//
+// TestReadCommandsMatchServerFlags diffs this map against
+// testdata/core_readonly_commands.txt, a snapshot of `COMMAND INFO` from the
+// pinned Redis in that file's header. Regenerate the snapshot when bumping the
+// pinned version; the test then reports every newly shipped read command.
+// Commands left out on purpose live in that test's knownExclusions, with the
+// reason.
 var readCommands = map[string]bool{
 	"bitcount":             true,
 	"bitfield_ro":          true,
@@ -28,15 +38,19 @@ var readCommands = map[string]bool{
 	"geosearch":            true,
 	"getbit":               true,
 	"hexists":              true,
+	"hexpiretime":          true,
 	"hget":                 true,
 	"hgetall":              true,
 	"hkeys":                true,
 	"hmget":                true,
 	"hlen":                 true,
+	"hpexpiretime":         true,
+	"hpttl":                true,
 	"hrandfield":           true,
 	"hscan":                true,
 	"hvals":                true,
 	"hstrlen":              true,
+	"httl":                 true,
 	"keys":                 true,
 	"lcs":                  true,
 	"lindex":               true,
@@ -53,7 +67,6 @@ var readCommands = map[string]bool{
 	"sscan":                true,
 	"scard":                true,
 	"sdiff":                true,
-	"select":               true,
 	"smismember":           true,
 	"sismember":            true,
 	"sinter":               true,
@@ -110,6 +123,85 @@ var doubleNameReadCommands = map[string]map[string]bool{
 	},
 }
 
+// moduleReadCommands holds the read-only commands of the Redis Stack modules.
+// Module commands namespace with a dot inside a single token ("JSON.GET"), so
+// they cannot go through doubleNameReadCommands, which expects the subcommand
+// as a second token ("XINFO STREAM").
+//
+// The server's "readonly" flag means "does not write the keyspace", not "has no
+// side effects", so it is not enough on its own here. RediSearch flags
+// FT.ALIASADD, FT.DICTADD, FT.DICTDEL, FT.CONFIG and FT.CURSOR readonly even
+// though they mutate index or config state, and RedisBloom flags CF.COMPACT
+// readonly even though it rewrites the filter. Those stay out. So do the
+// modules' internal cluster commands.
+var moduleReadCommands = map[string]bool{
+	// RedisJSON.
+	"json.arrindex": true,
+	"json.arrlen":   true,
+	"json.debug":    true,
+	"json.get":      true,
+	"json.mget":     true,
+	"json.objkeys":  true,
+	"json.objlen":   true,
+	"json.resp":     true,
+	"json.strlen":   true,
+	"json.type":     true,
+
+	// RedisTimeSeries.
+	"ts.get":        true,
+	"ts.info":       true,
+	"ts.mget":       true,
+	"ts.mrange":     true,
+	"ts.mrevrange":  true,
+	"ts.queryindex": true,
+	"ts.range":      true,
+	"ts.revrange":   true,
+
+	// RedisBloom: Bloom filter, Cuckoo filter, Count-Min sketch, Top-K,
+	// t-digest. The scandump commands stay out: they page through internal
+	// chunks for replication, not for reading data.
+	"bf.card":              true,
+	"bf.exists":            true,
+	"bf.info":              true,
+	"bf.mexists":           true,
+	"cf.count":             true,
+	"cf.exists":            true,
+	"cf.info":              true,
+	"cf.mexists":           true,
+	"cms.info":             true,
+	"cms.query":            true,
+	"topk.info":            true,
+	"topk.list":            true,
+	"topk.query":           true,
+	"tdigest.byrank":       true,
+	"tdigest.byrevrank":    true,
+	"tdigest.cdf":          true,
+	"tdigest.info":         true,
+	"tdigest.max":          true,
+	"tdigest.min":          true,
+	"tdigest.quantile":     true,
+	"tdigest.rank":         true,
+	"tdigest.revrank":      true,
+	"tdigest.trimmed_mean": true,
+
+	// RediSearch. FT.AGGREGATE with WITHCURSOR leaves a server-side cursor
+	// behind, and FT.CURSOR is not allowed here, so such a cursor is only
+	// reclaimed when it times out.
+	"ft.aggregate":  true,
+	"ft.dictdump":   true,
+	"ft.explain":    true,
+	"ft.get":        true,
+	"ft.info":       true,
+	"ft.mget":       true,
+	"ft.profile":    true,
+	"ft.search":     true,
+	"ft.spellcheck": true,
+	"ft.sugget":     true,
+	"ft.suglen":     true,
+	"ft.syndump":    true,
+	"ft.tagvals":    true,
+}
+
 func init() {
 	base.RegisterQueryValidator(storepb.Engine_REDIS, validateQuery)
 }
@@ -136,7 +228,7 @@ func isReadCommand(fields []string) bool {
 		return false
 	}
 	command := strings.ToLower(fields[0])
-	if _, ok := readCommands[command]; ok {
+	if readCommands[command] || moduleReadCommands[command] {
 		return true
 	}
 	if doubleNameReadCommands[command] != nil && len(fields) > 1 {

--- a/backend/plugin/parser/redis/query_test.go
+++ b/backend/plugin/parser/redis/query_test.go
@@ -1,8 +1,12 @@
 package redis
 
 import (
+	"os"
+	"slices"
+	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,6 +32,93 @@ func TestValidateQuery(t *testing.T) {
 			valid:     true,
 			allQuery:  true,
 		},
+		// RedisJSON reads. The command namespaces with a dot inside one token,
+		// so it can only match readCommands/moduleReadCommands, never the
+		// container-subcommand fallback.
+		{
+			statement: "JSON.GET doc",
+			valid:     true,
+			allQuery:  true,
+		},
+		{
+			statement: "json.get doc $.name",
+			valid:     true,
+			allQuery:  true,
+		},
+		{
+			statement: "JSON.DEBUG MEMORY doc",
+			valid:     true,
+			allQuery:  true,
+		},
+		{
+			statement: `JSON.SET doc $ {"a":1}`,
+			valid:     false,
+			allQuery:  false,
+		},
+		{
+			statement: "JSON.DEL doc $.a",
+			valid:     false,
+			allQuery:  false,
+		},
+		// Other Redis Stack modules.
+		{
+			statement: "FT.SEARCH idx *",
+			valid:     true,
+			allQuery:  true,
+		},
+		{
+			statement: "TS.GET series",
+			valid:     true,
+			allQuery:  true,
+		},
+		{
+			statement: "BF.EXISTS filter item",
+			valid:     true,
+			allQuery:  true,
+		},
+		// FT.DICTADD mutates a dictionary even though Redis flags it readonly.
+		{
+			statement: "FT.DICTADD dict term",
+			valid:     false,
+			allQuery:  false,
+		},
+		// Core read commands added in Redis 7.4.
+		{
+			statement: "HTTL h FIELDS 1 f",
+			valid:     true,
+			allQuery:  true,
+		},
+		// Read-only script mode only blocks commands flagged "write", so Lua
+		// still reaches SELECT and the readonly-flagged module commands that
+		// mutate state. See knownExclusions in
+		// TestReadCommandsMatchServerFlags.
+		{
+			statement: "EVAL_RO \"return redis.call('GET','k')\" 0",
+			valid:     false,
+			allQuery:  false,
+		},
+		{
+			statement: "EVALSHA_RO abc 0",
+			valid:     false,
+			allQuery:  false,
+		},
+		{
+			statement: "FCALL_RO fn 0",
+			valid:     false,
+			allQuery:  false,
+		},
+		// SELECT switches the connection to another logical database, so a
+		// later read escapes the database the request was authorized against.
+		{
+			statement: "select 3",
+			valid:     false,
+			allQuery:  false,
+		},
+		{
+			statement: "select 3\nkeys *",
+			valid:     false,
+			allQuery:  false,
+		},
 	}
 
 	for _, test := range tests {
@@ -36,8 +127,98 @@ func TestValidateQuery(t *testing.T) {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
-			require.Equal(t, test.valid, gotValid)
-			require.Equal(t, test.allQuery, gotAllQuery)
+			require.Equal(t, test.valid, gotValid, test.statement)
+			require.Equal(t, test.allQuery, gotAllQuery, test.statement)
 		}
+	}
+}
+
+// TestReadCommandsMatchServerFlags diffs the core allowlist against a snapshot
+// of the flags Redis reports for itself, so a Redis upgrade that ships new read
+// commands fails here instead of reaching a customer. See the snapshot header
+// for how to regenerate it.
+func TestReadCommandsMatchServerFlags(t *testing.T) {
+	// knownExclusions holds commands Redis flags "readonly" that Bytebase
+	// deliberately keeps out of the gate. Every entry needs a reason: the flag
+	// means "does not write the keyspace", not "has no side effects".
+	//
+	// SELECT is not listed. Redis does not flag it readonly, so the reverse
+	// check below is what keeps it out of the allowlist.
+	knownExclusions := map[string]string{
+		// Read-only script mode only rejects commands flagged "write", so a
+		// script still reaches SELECT and every readonly-flagged module command
+		// that mutates state. Verified on redis-stack-server 7.4.7: running
+		// EVAL_RO "redis.call('SELECT',1); return redis.call('GET','marker')"
+		// against database 0 returns database 1's value, and a no-writes
+		// function called through FCALL_RO both crosses databases and adds a
+		// RediSearch dictionary term via FT.DICTADD.
+		"eval_ro":    "Lua reaches SELECT and readonly-flagged mutating module commands",
+		"evalsha_ro": "same as eval_ro",
+		"fcall_ro":   "same as eval_ro, through a no-writes function",
+	}
+
+	content, err := os.ReadFile("testdata/core_readonly_commands.txt")
+	require.NoError(t, err)
+
+	serverReadOnly := map[string]bool{}
+	for line := range strings.SplitSeq(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		serverReadOnly[line] = true
+	}
+	require.NotEmpty(t, serverReadOnly, "snapshot has no commands")
+
+	allowed := map[string]bool{}
+	for command := range readCommands {
+		allowed[command] = true
+	}
+	for container, subcommands := range doubleNameReadCommands {
+		for subcommand := range subcommands {
+			allowed[container+" "+subcommand] = true
+		}
+	}
+
+	var rejected []string
+	for command := range serverReadOnly {
+		if allowed[command] {
+			continue
+		}
+		if _, ok := knownExclusions[command]; ok {
+			continue
+		}
+		rejected = append(rejected, command)
+	}
+	slices.Sort(rejected)
+	// assert, not require: a run that breaks both directions must report both.
+	assert.Emptyf(t, rejected,
+		"Redis flags these commands readonly but the gate rejects them: %v. "+
+			"Add each to readCommands or doubleNameReadCommands, or to knownExclusions with a reason.",
+		rejected)
+
+	var unflagged []string
+	for command := range allowed {
+		if !serverReadOnly[command] {
+			unflagged = append(unflagged, command)
+		}
+	}
+	slices.Sort(unflagged)
+	assert.Emptyf(t, unflagged,
+		"the gate accepts these but Redis does not flag them readonly: %v. "+
+			"Either the name is wrong, or the command has side effects and must be removed.",
+		unflagged)
+}
+
+// TestModuleReadCommandsWellFormed guards the module allowlist, which has no
+// snapshot because module presence varies per instance. A key that is not a
+// lowercase dotted name can never match, since isReadCommand lowercases the
+// first token and module commands carry the dot inside it.
+func TestModuleReadCommandsWellFormed(t *testing.T) {
+	require.NotEmpty(t, moduleReadCommands)
+	for command := range moduleReadCommands {
+		require.Equal(t, strings.ToLower(command), command, "module command must be lowercase")
+		require.Contains(t, command, ".", "module command must be dot-namespaced")
+		require.False(t, readCommands[command], "module command duplicated in readCommands: %s", command)
 	}
 }

--- a/backend/plugin/parser/redis/testdata/core_readonly_commands.txt
+++ b/backend/plugin/parser/redis/testdata/core_readonly_commands.txt
@@ -1,0 +1,111 @@
+# Core Redis commands that the server flags "readonly" in its own command table.
+#
+# Source: redis_version 7.4.7, from
+#   redis/redis-stack-server@sha256:798ab84d9f266936b034ab11c4d04a2b8e4b441884c5aa7d17ac951eefdf742a
+# Pinned by digest on purpose: the "latest" tag moves, so it would not name the
+# version this snapshot was taken from.
+#
+# Generated with:
+#   docker run -d --rm --name redis-oracle -p 6399:6379 \
+#     redis/redis-stack-server@sha256:798ab84d9f266936b034ab11c4d04a2b8e4b441884c5aa7d17ac951eefdf742a
+#   # then, per top-level entry of `COMMAND INFO` and each of its subcommands,
+#   # keep the name when its flags contain "readonly"; module commands (a dot in
+#   # the name) are excluded because module presence varies per instance.
+#
+# Container subcommands appear as "<container> <subcommand>".
+# Regenerate when bumping the pinned version. TestReadCommandsMatchServerFlags
+# then reports every read command Redis has shipped since.
+bitcount
+bitfield_ro
+bitpos
+dbsize
+dump
+eval_ro
+evalsha_ro
+exists
+expiretime
+fcall_ro
+geodist
+geohash
+geopos
+georadius_ro
+georadiusbymember_ro
+geosearch
+get
+getbit
+getrange
+hexists
+hexpiretime
+hget
+hgetall
+hkeys
+hlen
+hmget
+hpexpiretime
+hpttl
+hrandfield
+hscan
+hstrlen
+httl
+hvals
+keys
+lcs
+lindex
+llen
+lolwut
+lpos
+lrange
+memory usage
+mget
+object encoding
+object freq
+object idletime
+object refcount
+pexpiretime
+pfcount
+pttl
+randomkey
+scan
+scard
+sdiff
+sinter
+sintercard
+sismember
+smembers
+smismember
+sort_ro
+srandmember
+sscan
+strlen
+substr
+sunion
+touch
+ttl
+type
+xinfo consumers
+xinfo groups
+xinfo stream
+xlen
+xpending
+xrange
+xread
+xrevrange
+zcard
+zcount
+zdiff
+zinter
+zintercard
+zlexcount
+zmscore
+zrandmember
+zrange
+zrangebylex
+zrangebyscore
+zrank
+zrevrange
+zrevrangebylex
+zrevrangebyscore
+zrevrank
+zscan
+zscore
+zunion


### PR DESCRIPTION
## Problem

Kraken cannot run read-only RedisJSON commands in the SQL Editor. `JSON.GET <key>` is rejected with `invalid_argument: Support read-only command statements only` before it reaches Redis.

The read-only gate classifies a Redis statement by looking its first word up in a hand-written map (`backend/plugin/parser/redis/query.go`). The map only ever covered core Redis, so **every** module command was treated as a write, not just RedisJSON.

The container-command fallback could not cover it either. It expects the subcommand as a *second token* (`XINFO STREAM`), while module commands namespace with a dot *inside one token* (`JSON.GET`). That is why `XINFO STREAM` works and `JSON.GET` cannot.

The same `readOnly` bit feeds five consumers, so the misclassification was never only an error message: the Query gate, the Export gate, JIT access-grant matching (`preCheckAccess`, `access_grant_service`), and read-only-vs-admin data-source routing (`requiresAdminDataSource`). Fixing the map corrects all five.

## Changes

- **`moduleReadCommands`** — 54 read commands across RedisJSON, RedisTimeSeries, RedisBloom and RediSearch.
- **4 core read commands** the map had drifted past: `HTTL`, `HPTTL`, `HEXPIRETIME`, `HPEXPIRETIME` (Redis 7.4).
- **`SELECT` removed.** The driver pins the connection to the DB index from the request, then pipelines every line onto that one connection, so `select 3` followed by a read escaped the database the request was authorized against. Verified: `CLIENT INFO` reports `db=3`, and a probe write lands in db3.
- **`TestReadCommandsMatchServerFlags`** — diffs the core map against `testdata/core_readonly_commands.txt`, a snapshot of the server's own `COMMAND INFO` `readonly` flags, pinned by image digest. A Redis upgrade that ships new read commands now fails in CI instead of reaching a customer.

## The list is curated, not generated — on purpose

The server's `readonly` flag means "does not write the keyspace", not "has no side effects". Confirmed on the live server: `FT.ALIASADD`, `FT.DICTADD`, `FT.DICTDEL`, `FT.CONFIG`, `FT.CURSOR`, `CF.COMPACT` and `BF.SCANDUMP` are all flagged `readonly` while mutating index, dictionary, config or filter state. They stay out, as do the modules' internal cluster commands.

## Security finding caught while pre-reviewing this branch

An earlier revision of this PR also added `EVAL_RO`, `EVALSHA_RO` and `FCALL_RO`, because the server flags them `readonly`. That was wrong, and it would have reopened the hole the `SELECT` removal closes.

Read-only script mode rejects only commands flagged `write`. Lua still reaches `SELECT` and every readonly-flagged module command that mutates state. Verified on redis-stack-server 7.4.7, run against database 0:

```
EVAL_RO "redis.call('SELECT',1); return redis.call('GET','marker')" 0
  -> db1-secret          (database 0 holds db0-secret)

EVAL_RO "return redis.call('FT.DICTADD','d1','term')" 0
  -> 1                   FT.DICTDUMP d1 -> term
EVAL_RO "return redis.call('FT.ALIASADD','al','idx')" 0
  -> OK                  FT.INFO al resolves
EVAL_RO "return redis.call('FT.CONFIG','SET','TIMEOUT','1')" 0
  -> OK                  server config changed from a "read-only" script

FCALL_RO on a no-writes function
  -> db1-secret, and FT.DICTDUMP d2 -> viafcall
```

All three are now recorded in the guard's `knownExclusions` with that reason, so the test does not flag them as a gap and the next person does not re-add them.

## Verification

Ground truth throughout is a live `redis-stack-server` 7.4.7 (ReJSON 2.8.9, RediSearch 2.10.20, RedisTimeSeries 1.12.6, RedisBloom 2.8.16), not documentation.

- All 54 module entries confirmed to exist on the server **and** carry the `readonly` flag.
- Drift guard proven RED in **both** directions, and proven to report both in a single run (it uses `assert`, not `require`, so the first failure does not mask the second).
- Driven end to end through the real registered validator, `base.ValidateSQLForEditor(Engine_REDIS, …)`: every RedisJSON read now passes; `JSON.SET`, `JSON.DEL`, `select 1`, `SWAPDB`, `MOVE`, `COPY`, `EVAL_RO`, `EVALSHA_RO`, `FCALL_RO` all rejected.
- Rendering checked, since it decides whether this actually helps: replaying the driver's own `shlex.Split` -> `p.Do` -> `getResultRow` path on RESP2 and RESP3, `JSON.GET doc` returns its JSON verbatim and JSONPath filters survive `shlex` intact.
- `gofmt`, `go vet`, `golangci-lint` clean; package tests pass.

## Deliberately out of scope

- **Introspection commands** a user would expect in an editor but Redis does not flag `readonly`: `PING`, `INFO`, `COMMAND INFO`, `CONFIG GET`, `OBJECT HELP`, `SCRIPT EXISTS`, `FUNCTION LIST`. Allowing them needs a separate documented "safe extras" set, since they fail the guard's reverse check by design.
- **`FT.CURSOR`.** `FT.AGGREGATE … WITHCURSOR` can therefore leave a cursor that is only reclaimed on timeout. Adding `"ft.cursor": {"read": true}` to `doubleNameReadCommands` would work mechanically, but supporting `READ` without `DEL` seemed worse than supporting neither. Happy to fold it in if you disagree.
- **`FT._LIST`, `BF.SCANDUMP`, `CF.SCANDUMP`, `BF.DEBUG`, `CF.DEBUG`** — read-only but internal or replication-oriented.
- Two adjacent defects in `redis.go`, unrelated to this bug and left alone: `shlex` does not honour `redis-cli` escape sequences (`NEWLINE "\n"` arrives as a literal `n`), and `results[i].Statement = lines[i]` mislabels results when the statement contains a blank line.

## Note on process

The `pr-prereview` subagent lenses could not run — 29 agents across four attempts, every one failing on API 529. I ran the security, tests, claims and hygiene probes by hand instead; the `EVAL_RO` finding above came out of that pass. No peer-reviewer prediction rows were logged, since the predictors never executed and logging an empty result would have recorded a pass that did not happen.

Fixes BYT-10072
