### PR TITLE
fix(masking): refuse a query whose relation has no synced columns

### DIFF
--- a/backend/api/v1/query_result_masker.go
+++ b/backend/api/v1/query_result_masker.go
@@ -86,7 +86,14 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		// just Results (SELECT output) to catch cases like:
 		//   SELECT name FROM t WHERE CAST(masked_col AS int) > 5
 		if results[i].Error != "" && len(results[i].Rows) == 0 {
-			if i < len(spans) && spans[i] != nil && s.spanTouchesMaskedColumns(ctx, m, instance, user, spans[i]) {
+			// spanTouchesMaskedColumns looks for a column carrying a policy, so on
+			// a snapshot that describes no columns it finds nothing and reads that
+			// as "nothing sensitive here". The error text can quote a column value,
+			// so redact whenever the relation is unresolved, without asking a
+			// question the snapshot cannot answer.
+			if i < len(spans) && spans[i] != nil &&
+				(maskingBlockedByUnresolvedColumns(spans[i], instance) ||
+					s.spanTouchesMaskedColumns(ctx, m, instance, user, spans[i])) {
 				results[i].Error = "Query execution failed. Error details are hidden because the query references columns with data masking policies."
 			}
 			continue

--- a/backend/api/v1/query_result_masker.go
+++ b/backend/api/v1/query_result_masker.go
@@ -69,13 +69,15 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		// here means a fresh sync still could not describe the relation.
 		//
 		// A table that legitimately has no columns (PostgreSQL allows
-		// CREATE TABLE t()) is stored exactly like a degraded one, so it is
-		// refused too. The snapshot cannot tell the two apart, and refusing a
-		// relation that can hold no data is the cheaper error than returning an
-		// unmaskable one.
-		if results[i].Error == "" && spans[i].UnresolvedColumnsError != nil &&
-			common.EngineSupportMasking(instance.Metadata.GetEngine()) {
-			return errors.Errorf("masking error: %v; sync the database to restore it", spans[i].UnresolvedColumnsError)
+		// CREATE TABLE t()) is stored exactly like a degraded one and is refused
+		// too. Such a table still holds rows and still conveys cardinality
+		// through count(*), joins and existence tests, so this is a real refusal
+		// rather than a free one — but the snapshot cannot tell the two apart,
+		// and refusing is the safe side of that ambiguity.
+		if results[i].Error == "" && maskingBlockedByUnresolvedColumns(spans[i], instance) {
+			return errors.Errorf(
+				"masking cannot be applied: %v; the schema was re-synced and still reports none, so the query was not returned",
+				spans[i].UnresolvedColumnsError)
 		}
 		// Skip masking for error result, but redact the error message if the
 		// statement touches masked columns — database errors can contain
@@ -97,6 +99,22 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 	}
 
 	return nil
+}
+
+// maskingBlockedByUnresolvedColumns reports whether masking cannot be evaluated
+// for this span because the stored snapshot does not describe a relation the
+// query reads.
+//
+// Both the re-sync trigger in queryRetry and the refusal above key on this one
+// predicate. They were written separately and drifted apart twice, so this is
+// deliberately the only definition: a re-sync that fires where the refusal will
+// not is wasted work on the request path, and a refusal that fires where the
+// re-sync did not never gives a stale snapshot its chance to recover.
+func maskingBlockedByUnresolvedColumns(span *parserbase.QuerySpan, instance *store.InstanceMessage) bool {
+	if span == nil || span.UnresolvedColumnsError == nil || instance == nil {
+		return false
+	}
+	return common.EngineSupportMasking(instance.Metadata.GetEngine())
 }
 
 // spanTouchesMaskedColumns checks whether any column referenced anywhere in

--- a/backend/api/v1/query_result_masker.go
+++ b/backend/api/v1/query_result_masker.go
@@ -67,7 +67,14 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		// back unmasked data with no indication that masking was skipped.
 		// queryRetry re-syncs and rebuilds the span before this runs, so reaching
 		// here means a fresh sync still could not describe the relation.
+		//
+		// The driver's own column list settles the one ambiguous case: a table
+		// that legitimately has no columns (PostgreSQL allows CREATE TABLE t())
+		// is stored exactly like a degraded one, but selecting from it returns
+		// no columns and therefore no data to leak. Only refuse once the driver
+		// has handed back columns the snapshot cannot account for.
 		if results[i].Error == "" && spans[i].UnresolvedColumnsError != nil &&
+			len(results[i].ColumnNames) > 0 &&
 			common.EngineSupportMasking(instance.Metadata.GetEngine()) {
 			return errors.Errorf("masking error: %v; sync the database to restore it", spans[i].UnresolvedColumnsError)
 		}

--- a/backend/api/v1/query_result_masker.go
+++ b/backend/api/v1/query_result_masker.go
@@ -68,13 +68,20 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		// queryRetry re-syncs and rebuilds the span before this runs, so reaching
 		// here means a fresh sync still could not describe the relation.
 		//
+		// This is deliberately not conditioned on the result being clean. A
+		// driver can return rows AND an error together — exceeding
+		// MaximumSQLResultSize sets Error on the rows collected so far — and
+		// those partial rows are as unmaskable as a whole result. Refusing
+		// before the branches below also means an unresolved span never reaches
+		// the client carrying a structured driver error.
+		//
 		// A table that legitimately has no columns (PostgreSQL allows
 		// CREATE TABLE t()) is stored exactly like a degraded one and is refused
 		// too. Such a table still holds rows and still conveys cardinality
 		// through count(*), joins and existence tests, so this is a real refusal
 		// rather than a free one — but the snapshot cannot tell the two apart,
 		// and refusing is the safe side of that ambiguity.
-		if results[i].Error == "" && maskingBlockedByUnresolvedColumns(spans[i], instance) {
+		if maskingBlockedByUnresolvedColumns(spans[i], instance) {
 			return errors.Errorf(
 				"masking cannot be applied: %v; the schema was re-synced and still reports none, so the query was not returned",
 				spans[i].UnresolvedColumnsError)
@@ -86,15 +93,13 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		// just Results (SELECT output) to catch cases like:
 		//   SELECT name FROM t WHERE CAST(masked_col AS int) > 5
 		if results[i].Error != "" && len(results[i].Rows) == 0 {
-			// spanTouchesMaskedColumns looks for a column carrying a policy, so on
-			// a snapshot that describes no columns it finds nothing and reads that
-			// as "nothing sensitive here". The error text can quote a column value,
-			// so redact whenever the relation is unresolved, without asking a
-			// question the snapshot cannot answer.
-			if i < len(spans) && spans[i] != nil &&
-				(maskingBlockedByUnresolvedColumns(spans[i], instance) ||
-					s.spanTouchesMaskedColumns(ctx, m, instance, user, spans[i])) {
+			if i < len(spans) && spans[i] != nil && s.spanTouchesMaskedColumns(ctx, m, instance, user, spans[i]) {
 				results[i].Error = "Query execution failed. Error details are hidden because the query references columns with data masking policies."
+				// Error is not the only place the value travels. A driver also
+				// fills the structured error — for PostgreSQL that is message,
+				// detail, hint and where — and those reach the client verbatim.
+				// Redacting one and leaving the other redacts nothing.
+				results[i].DetailedError = nil
 			}
 			continue
 		}

--- a/backend/api/v1/query_result_masker.go
+++ b/backend/api/v1/query_result_masker.go
@@ -68,13 +68,12 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		// queryRetry re-syncs and rebuilds the span before this runs, so reaching
 		// here means a fresh sync still could not describe the relation.
 		//
-		// The driver's own column list settles the one ambiguous case: a table
-		// that legitimately has no columns (PostgreSQL allows CREATE TABLE t())
-		// is stored exactly like a degraded one, but selecting from it returns
-		// no columns and therefore no data to leak. Only refuse once the driver
-		// has handed back columns the snapshot cannot account for.
+		// A table that legitimately has no columns (PostgreSQL allows
+		// CREATE TABLE t()) is stored exactly like a degraded one, so it is
+		// refused too. The snapshot cannot tell the two apart, and refusing a
+		// relation that can hold no data is the cheaper error than returning an
+		// unmaskable one.
 		if results[i].Error == "" && spans[i].UnresolvedColumnsError != nil &&
-			len(results[i].ColumnNames) > 0 &&
 			common.EngineSupportMasking(instance.Metadata.GetEngine()) {
 			return errors.Errorf("masking error: %v; sync the database to restore it", spans[i].UnresolvedColumnsError)
 		}

--- a/backend/api/v1/query_result_masker.go
+++ b/backend/api/v1/query_result_masker.go
@@ -61,6 +61,16 @@ func (s *QueryResultMasker) MaskResults(ctx context.Context, spans []*parserbase
 		if results[i].Error == "" && spans[i].NotFoundError != nil {
 			return errors.Errorf("masking error: %v", spans[i].NotFoundError)
 		}
+		// The span read a relation whose columns the stored snapshot does not
+		// describe, so its lineage is knowingly incomplete and no masking policy
+		// can be evaluated against those columns. Returning the rows would hand
+		// back unmasked data with no indication that masking was skipped.
+		// queryRetry re-syncs and rebuilds the span before this runs, so reaching
+		// here means a fresh sync still could not describe the relation.
+		if results[i].Error == "" && spans[i].UnresolvedColumnsError != nil &&
+			common.EngineSupportMasking(instance.Metadata.GetEngine()) {
+			return errors.Errorf("masking error: %v; sync the database to restore it", spans[i].UnresolvedColumnsError)
+		}
 		// Skip masking for error result, but redact the error message if the
 		// statement touches masked columns — database errors can contain
 		// actual column values (e.g. "invalid input syntax for type integer: '<value>'").

--- a/backend/api/v1/query_result_masker_test.go
+++ b/backend/api/v1/query_result_masker_test.go
@@ -88,6 +88,28 @@ func TestMaskingBlockedByUnresolvedColumns(t *testing.T) {
 	}
 }
 
+// TestUnresolvedSpanDrivesErrorRedaction pins that an unresolved relation is
+// enough on its own to redact a database error.
+//
+// The other half of that condition, spanTouchesMaskedColumns, looks for a
+// column carrying a policy — and on a snapshot describing no columns it finds
+// none and reports false. Read literally that is "nothing sensitive here",
+// which is exactly wrong: the snapshot could not answer the question. Database
+// errors quote column values (an integer cast of a text column returns the
+// value in the message), so the unresolved signal has to redact by itself.
+func TestUnresolvedSpanDrivesErrorRedaction(t *testing.T) {
+	// The predicate the redaction path consults for the unresolved case is the
+	// same one the refusal uses, so an unresolved span on a masking engine
+	// redacts without needing any column-level lineage.
+	require.True(t, maskingBlockedByUnresolvedColumns(unresolvedSpan(), instanceOn(storepb.Engine_POSTGRES)),
+		"an unresolved relation must redact the error on its own")
+
+	// A span with no unresolved relation falls through to the lineage check,
+	// which is the pre-existing behavior and must not change.
+	require.False(t, maskingBlockedByUnresolvedColumns(&parserbase.QuerySpan{Type: parserbase.Select}, instanceOn(storepb.Engine_POSTGRES)),
+		"a healthy span must still be judged by its column lineage, not redacted wholesale")
+}
+
 // TestMaskingEnginesAgreeWithSignalProducers records which masking-capable
 // engines actually produce the unresolved-columns signal today. Only the
 // PostgreSQL extractor sets it, so every other masking engine still returns

--- a/backend/api/v1/query_result_masker_test.go
+++ b/backend/api/v1/query_result_masker_test.go
@@ -110,6 +110,30 @@ func TestUnresolvedSpanDrivesErrorRedaction(t *testing.T) {
 		"a healthy span must still be judged by its column lineage, not redacted wholesale")
 }
 
+// TestMaskingBlockedIgnoresResultShape pins that the refusal decision cannot
+// depend on what the result looks like.
+//
+// The predicate takes no *v1pb.QueryResult at all, and that is the point. An
+// earlier revision gated the refusal on `results[i].Error == ""`, which let two
+// shapes through: a driver can return rows AND an error together — exceeding
+// MaximumSQLResultSize sets Error on the rows collected so far
+// (backend/plugin/db/util/driverutil.go) — and the error-redaction branch below
+// it only handles results with no rows, so those partial rows were transmitted
+// with no maskers at all.
+//
+// If someone re-adds a result condition at the call site, this test will not
+// catch it — MaskResults needs a *store.Store to run. What this pins is that
+// the decision itself has no way to see a result.
+func TestMaskingBlockedIgnoresResultShape(t *testing.T) {
+	span := unresolvedSpan()
+	instance := instanceOn(storepb.Engine_POSTGRES)
+	// Same answer regardless of how the statement turned out, because the
+	// question is about the snapshot, not the outcome.
+	require.True(t, maskingBlockedByUnresolvedColumns(span, instance))
+	require.True(t, maskingBlockedByUnresolvedColumns(span, instance),
+		"the decision is a pure function of span and instance")
+}
+
 // TestMaskingEnginesAgreeWithSignalProducers records which masking-capable
 // engines actually produce the unresolved-columns signal today. Only the
 // PostgreSQL extractor sets it, so every other masking engine still returns

--- a/backend/api/v1/query_result_masker_test.go
+++ b/backend/api/v1/query_result_masker_test.go
@@ -1,0 +1,117 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	parserbase "github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func instanceOn(engine storepb.Engine) *store.InstanceMessage {
+	return &store.InstanceMessage{
+		ResourceID: "inst",
+		Metadata:   &storepb.Instance{Engine: engine},
+	}
+}
+
+func unresolvedSpan() *parserbase.QuerySpan {
+	return &parserbase.QuerySpan{
+		Type: parserbase.Select,
+		UnresolvedColumnsError: &parserbase.UnresolvedColumnsError{
+			Relations: []parserbase.ColumnResource{
+				{Database: "db", Schema: "public", Table: "t"},
+			},
+		},
+	}
+}
+
+// TestMaskingBlockedByUnresolvedColumns pins the single predicate behind both
+// the re-sync trigger in queryRetry and the refusal in MaskResults.
+//
+// These two conditions were originally written out separately and drifted apart
+// twice during review: once when only one of them gained the engine check, and
+// once when only the other gained a result-shape check. Each divergence is a
+// real defect — a re-sync that fires where the refusal will not burns a full
+// schema sync on the request path for nothing, and a refusal that fires where
+// the re-sync did not denies a query that one sync would have repaired. Routing
+// both through this function is what makes them agree; this test is what keeps
+// the function honest.
+func TestMaskingBlockedByUnresolvedColumns(t *testing.T) {
+	testCases := []struct {
+		name     string
+		span     *parserbase.QuerySpan
+		instance *store.InstanceMessage
+		want     bool
+	}{
+		{
+			name:     "unresolved columns on a masking engine blocks",
+			span:     unresolvedSpan(),
+			instance: instanceOn(storepb.Engine_POSTGRES),
+			want:     true,
+		},
+		{
+			// CockroachDB shares the PostgreSQL span extractor, so it receives the
+			// signal, but it never masks. Acting on it would sync per query and
+			// then refuse nothing.
+			name:     "engine that never masks does not block",
+			span:     unresolvedSpan(),
+			instance: instanceOn(storepb.Engine_COCKROACHDB),
+			want:     false,
+		},
+		{
+			name:     "resolved span does not block",
+			span:     &parserbase.QuerySpan{Type: parserbase.Select},
+			instance: instanceOn(storepb.Engine_POSTGRES),
+			want:     false,
+		},
+		{
+			name:     "nil span does not block",
+			span:     nil,
+			instance: instanceOn(storepb.Engine_POSTGRES),
+			want:     false,
+		},
+		{
+			name:     "nil instance does not block",
+			span:     unresolvedSpan(),
+			instance: nil,
+			want:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, maskingBlockedByUnresolvedColumns(tc.span, tc.instance))
+		})
+	}
+}
+
+// TestMaskingEnginesAgreeWithSignalProducers records which masking-capable
+// engines actually produce the unresolved-columns signal today. Only the
+// PostgreSQL extractor sets it, so every other masking engine still returns
+// unmasked rows against a snapshot with no column metadata.
+//
+// This is a scope marker, not a passing grade: when another engine gains the
+// signal, add it here so the remaining gap stays visible instead of being
+// inferred from the absence of a test.
+func TestMaskingEnginesAgreeWithSignalProducers(t *testing.T) {
+	// The pg extractor is registered for both of these; only POSTGRES masks.
+	require.True(t, maskingBlockedByUnresolvedColumns(unresolvedSpan(), instanceOn(storepb.Engine_POSTGRES)),
+		"PostgreSQL both produces the signal and masks, so it must act on it")
+	require.False(t, maskingBlockedByUnresolvedColumns(unresolvedSpan(), instanceOn(storepb.Engine_COCKROACHDB)),
+		"CockroachDB produces the signal but never masks, so acting on it is pure cost")
+
+	// Masking engines whose extractors do not set the signal yet. They would
+	// block if they ever did, which is the intended direction of travel.
+	for _, engine := range []storepb.Engine{
+		storepb.Engine_MYSQL,
+		storepb.Engine_ORACLE,
+		storepb.Engine_MSSQL,
+		storepb.Engine_REDSHIFT,
+	} {
+		require.True(t, maskingBlockedByUnresolvedColumns(unresolvedSpan(), instanceOn(engine)),
+			"%s masks, so it must act on the signal once its extractor sets one", engine)
+	}
+}

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -748,10 +748,28 @@ func queryRetry(
 		if r.Error != "" {
 			continue
 		}
-		if i < len(spans) && spans[i].NotFoundError != nil {
+		if i >= len(spans) {
+			continue
+		}
+		if spans[i].NotFoundError != nil {
 			for k := range spans[i].SourceColumns {
 				slog.Debug("database metadata need to sync", slog.String("instance", instance.ResourceID), slog.String("database", k.Database), slog.String("schema", k.Schema), slog.String("table", k.Table), slog.String("column", k.Column))
 				syncDatabaseMap[k.Database] = true
+			}
+		}
+		// A relation whose columns the snapshot cannot describe blocks masking.
+		// Re-sync it once before deciding the condition is real: the usual cause
+		// is a sync that ran while the connecting role lacked privileges, which a
+		// fresh sync repairs. The databases come from the signal itself rather
+		// than from SourceColumns, so the target survives even when column
+		// resolution produced no entries.
+		if maskingEnabled && spans[i].UnresolvedColumnsError != nil {
+			for _, dbName := range spans[i].UnresolvedColumnsError.Databases() {
+				slog.Debug("database metadata need to sync: unresolved columns",
+					slog.String("instance", instance.ResourceID),
+					slog.String("database", dbName),
+					slog.String("detail", spans[i].UnresolvedColumnsError.Error()))
+				syncDatabaseMap[dbName] = true
 			}
 		}
 	}

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -745,17 +745,8 @@ func queryRetry(
 
 	syncDatabaseMap := make(map[string]bool)
 	for i, r := range results {
-		if r.Error != "" {
-			continue
-		}
 		if i >= len(spans) {
 			continue
-		}
-		if spans[i].NotFoundError != nil {
-			for k := range spans[i].SourceColumns {
-				slog.Debug("database metadata need to sync", slog.String("instance", instance.ResourceID), slog.String("database", k.Database), slog.String("schema", k.Schema), slog.String("table", k.Table), slog.String("column", k.Column))
-				syncDatabaseMap[k.Database] = true
-			}
 		}
 		// A relation whose columns the snapshot cannot describe blocks masking.
 		// Re-sync it once before deciding the condition is real: the usual cause
@@ -763,6 +754,12 @@ func queryRetry(
 		// fresh sync repairs. The databases come from the signal itself rather
 		// than from SourceColumns, so the target survives even when column
 		// resolution produced no entries.
+		//
+		// This runs before the error skip below, because MaskResults refuses on
+		// this condition whatever the result shape. A size-limited result carries
+		// rows and an error together, so skipping it here would refuse a stale
+		// snapshot without ever giving it the one sync that repairs it — the
+		// re-sync and the refusal have to agree on when they fire.
 		if maskingEnabled && maskingBlockedByUnresolvedColumns(spans[i], instance) {
 			for _, dbName := range spans[i].UnresolvedColumnsError.Databases() {
 				slog.Debug("database metadata need to sync: unresolved columns",
@@ -770,6 +767,15 @@ func queryRetry(
 					slog.String("database", dbName),
 					slog.String("detail", spans[i].UnresolvedColumnsError.Error()))
 				syncDatabaseMap[dbName] = true
+			}
+		}
+		if r.Error != "" {
+			continue
+		}
+		if spans[i].NotFoundError != nil {
+			for k := range spans[i].SourceColumns {
+				slog.Debug("database metadata need to sync", slog.String("instance", instance.ResourceID), slog.String("database", k.Database), slog.String("schema", k.Schema), slog.String("table", k.Table), slog.String("column", k.Column))
+				syncDatabaseMap[k.Database] = true
 			}
 		}
 	}

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -763,7 +763,8 @@ func queryRetry(
 		// fresh sync repairs. The databases come from the signal itself rather
 		// than from SourceColumns, so the target survives even when column
 		// resolution produced no entries.
-		if maskingEnabled && spans[i].UnresolvedColumnsError != nil {
+		if maskingEnabled && spans[i].UnresolvedColumnsError != nil &&
+			common.EngineSupportMasking(instance.Metadata.GetEngine()) {
 			for _, dbName := range spans[i].UnresolvedColumnsError.Databases() {
 				slog.Debug("database metadata need to sync: unresolved columns",
 					slog.String("instance", instance.ResourceID),

--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -763,8 +763,7 @@ func queryRetry(
 		// fresh sync repairs. The databases come from the signal itself rather
 		// than from SourceColumns, so the target survives even when column
 		// resolution produced no entries.
-		if maskingEnabled && spans[i].UnresolvedColumnsError != nil &&
-			common.EngineSupportMasking(instance.Metadata.GetEngine()) {
+		if maskingEnabled && maskingBlockedByUnresolvedColumns(spans[i], instance) {
 			for _, dbName := range spans[i].UnresolvedColumnsError.Databases() {
 				slog.Debug("database metadata need to sync: unresolved columns",
 					slog.String("instance", instance.ResourceID),

--- a/backend/plugin/parser/base/span.go
+++ b/backend/plugin/parser/base/span.go
@@ -2,6 +2,7 @@ package base
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -73,6 +74,52 @@ type QuerySpan struct {
 	ElasticsearchAnalysis     *ElasticsearchAnalysis
 	NotFoundError             error
 	FunctionNotSupportedError error
+	// UnresolvedColumnsError is set when the query reads a relation whose
+	// columns the stored schema snapshot does not describe, so this span's
+	// lineage is knowingly incomplete. Masking is column-granular, so a
+	// consumer that masks must treat this as "cannot evaluate" rather than
+	// "nothing to mask" — see MaskResults. Consumers that do not mask can
+	// ignore it; the span is otherwise usable.
+	UnresolvedColumnsError *UnresolvedColumnsError
+}
+
+// UnresolvedColumnsError names the relations a query reads whose columns the
+// stored schema snapshot does not describe. A schema sync that ran while the
+// connecting role lacked privileges is the usual cause: the relation is still
+// listed, but with no columns under it.
+type UnresolvedColumnsError struct {
+	// Relations are the unresolved relations, each with an empty Column field.
+	Relations []ColumnResource
+}
+
+func (e *UnresolvedColumnsError) Error() string {
+	names := make([]string, 0, len(e.Relations))
+	for _, r := range e.Relations {
+		switch {
+		case r.Schema != "":
+			names = append(names, fmt.Sprintf("%s.%s", r.Schema, r.Table))
+		default:
+			names = append(names, r.Table)
+		}
+	}
+	slices.Sort(names)
+	return fmt.Sprintf("the synced schema describes no columns for %s", strings.Join(names, ", "))
+}
+
+// Databases returns the distinct databases holding the unresolved relations, so
+// a caller can re-sync exactly those before deciding the condition is real.
+func (e *UnresolvedColumnsError) Databases() []string {
+	seen := make(map[string]bool, len(e.Relations))
+	var out []string
+	for _, r := range e.Relations {
+		if r.Database == "" || seen[r.Database] {
+			continue
+		}
+		seen[r.Database] = true
+		out = append(out, r.Database)
+	}
+	slices.Sort(out)
+	return out
 }
 
 // QuerySpanResult is the result column of a query span.

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -193,14 +193,18 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 // SELECT * simply yields no results at all, which is indistinguishable from a
 // query that legitimately projects nothing.
 //
-// Tables and views are both checked: the syncer fills a view's column list
-// from the same map as a table's, so an empty one means the same thing.
-// Materialized views are excluded because their metadata carries no column
-// list at all, making an empty one uninformative.
+// Tables, views and foreign tables are all checked: the syncer fills each
+// column list from the same map, so an empty one means the same thing for
+// every one of them. Materialized views are excluded because their metadata
+// carries no column list at all, making an empty one uninformative.
 //
 // A relation the snapshot does not carry at all is not reported. Column
 // resolution drops it upstream, so it never reaches this set; that shape is
 // still unmasked and is tracked separately.
+//
+// On PostgreSQL a current sync cannot produce this state: #20581 moved the
+// column query to pg_catalog so privileges no longer hide columns. What
+// reaches it is a snapshot written before that fix and never re-synced.
 func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet) []base.ColumnResource {
 	seen := make(map[base.ColumnResource]bool, len(accesses))
 	var unresolved []base.ColumnResource
@@ -215,32 +219,39 @@ func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceCol
 			continue
 		}
 		seen[relation] = true
-
-		meta, err := e.getDatabaseMetadata(relation.Database)
-		if err != nil || meta == nil {
-			// A database we cannot read is not evidence about this relation.
-			continue
-		}
-		schema := meta.GetSchemaMetadata(relation.Schema)
-		if schema == nil {
-			continue
-		}
-		if table := schema.GetTable(relation.Table); table != nil {
-			if len(table.GetProto().GetColumns()) == 0 {
-				unresolved = append(unresolved, relation)
-			}
-			continue
-		}
-		// A view carries a column list too, filled from the same map as a
-		// table's, so a view with none is degraded the same way. Reading a
-		// masked base table through one must not slip past.
-		if view := schema.GetView(relation.Table); view != nil {
-			if len(view.GetColumns()) == 0 {
-				unresolved = append(unresolved, relation)
-			}
+		if e.relationHasNoSyncedColumns(relation) {
+			unresolved = append(unresolved, relation)
 		}
 	}
 	return unresolved
+}
+
+// relationHasNoSyncedColumns reports whether the snapshot carries the relation
+// with an empty column list. It answers false for anything it cannot judge:
+// a database or schema it cannot read, and any object kind that does not carry
+// a column list of its own.
+func (e *omniQuerySpanExtractor) relationHasNoSyncedColumns(relation base.ColumnResource) bool {
+	meta, err := e.getDatabaseMetadata(relation.Database)
+	if err != nil || meta == nil {
+		// A database we cannot read is not evidence about this relation.
+		return false
+	}
+	schema := meta.GetSchemaMetadata(relation.Schema)
+	if schema == nil {
+		return false
+	}
+	// Tables, views and foreign tables all take their column list from the same
+	// map in the syncer, so an empty one means the same thing for each.
+	if table := schema.GetTable(relation.Table); table != nil {
+		return len(table.GetProto().GetColumns()) == 0
+	}
+	if view := schema.GetView(relation.Table); view != nil {
+		return len(view.GetColumns()) == 0
+	}
+	if external := schema.GetExternalTable(relation.Table); external != nil {
+		return len(external.GetProto().GetColumns()) == 0
+	}
+	return false
 }
 
 // unresolvedColumnsError builds the span signal for accesses whose columns the

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -208,7 +208,7 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 // On PostgreSQL a current sync cannot produce this state: #20581 moved the
 // column query to pg_catalog so privileges no longer hide columns. What
 // reaches it is a snapshot written before that fix and never re-synced.
-func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet, cteNames map[string]bool) []base.ColumnResource {
+func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet, cteNames, qualified map[string]bool) []base.ColumnResource {
 	seen := make(map[base.ColumnResource]bool, len(accesses))
 	var unresolved []base.ColumnResource
 	for access := range accesses {
@@ -224,9 +224,11 @@ func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceCol
 		seen[relation] = true
 		// ExtractAccessTables walks every RangeVar without tracking CTE scope, so
 		// a reference to a CTE that shares a table's name arrives here resolved to
-		// that table. Such a query never reads the table and resolves entirely
-		// from the CTE, so refusing it would be a false positive.
-		if cteNames[strings.ToLower(relation.Table)] {
+		// that table. Skip it only when nothing in the statement names the table
+		// with a schema: PostgreSQL does not let a CTE shadow a qualified name, so
+		// a qualified mention is a genuine read no matter what the CTEs are called.
+		lower := strings.ToLower(relation.Table)
+		if cteNames[lower] && !qualified[lower] {
 			continue
 		}
 		if e.relationHasNoSyncedColumns(relation) {
@@ -267,7 +269,7 @@ func (e *omniQuerySpanExtractor) relationHasNoSyncedColumns(relation base.Column
 // unresolvedColumnsError builds the span signal for accesses whose columns the
 // snapshot cannot describe, or nil when every accessed table resolves.
 func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet, selStmt *ast.SelectStmt) *base.UnresolvedColumnsError {
-	unresolved := e.findUnresolvedRelations(accesses, collectCTENames(selStmt))
+	unresolved := e.findUnresolvedRelations(accesses, collectCTENames(selStmt), collectQualifiedTableNames(selStmt))
 	if len(unresolved) == 0 {
 		return nil
 	}
@@ -1389,10 +1391,10 @@ func collectColumnRefNames(node ast.Node) []string {
 // a WITH can sit inside a derived table, a scalar subquery, or a branch of a
 // set operation, and a name bound in any of those shadows just as effectively.
 //
-// Names are collected without regard to the scope they are visible in. Naming
-// one too many leaves a genuinely degraded table sharing a CTE's name
-// unchecked in that statement; naming one too few refuses a query that reads
-// no table at all. The first is the quieter failure.
+// Names are collected without regard to the scope they are visible in, so a
+// CTE bound in one branch suppresses an unqualified reference in another. A
+// schema-qualified reference is never suppressed — see
+// collectQualifiedTableNames — so a genuine read still reaches the check.
 func collectCTENames(selStmt *ast.SelectStmt) map[string]bool {
 	names := make(map[string]bool)
 	if selStmt == nil {
@@ -1401,6 +1403,27 @@ func collectCTENames(selStmt *ast.SelectStmt) map[string]bool {
 	ast.Inspect(selStmt, func(node ast.Node) bool {
 		if cte, ok := node.(*ast.CommonTableExpr); ok {
 			names[strings.ToLower(cte.Ctename)] = true
+		}
+		return true
+	})
+	return names
+}
+
+// collectQualifiedTableNames returns the lowercased base names of every table
+// reference in the statement that carries a schema, anywhere in the tree.
+//
+// A CTE cannot shadow a schema-qualified reference in PostgreSQL, so a name
+// that appears qualified somewhere is being read as a real table there, whatever
+// the statement's CTEs are called. Excluding it as a CTE name would drop a
+// genuine read.
+func collectQualifiedTableNames(selStmt *ast.SelectStmt) map[string]bool {
+	names := make(map[string]bool)
+	if selStmt == nil {
+		return names
+	}
+	ast.Inspect(selStmt, func(node ast.Node) bool {
+		if rv, ok := node.(*ast.RangeVar); ok && rv.Schemaname != "" && rv.Relname != "" {
+			names[strings.ToLower(rv.Relname)] = true
 		}
 		return true
 	})

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -182,7 +182,6 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 	return "", 0, 0
 }
 
-// getQuerySpan extracts the query span for the given SQL statement.
 // findUnresolvedRelations reports the relations in accesses whose columns the
 // stored snapshot does not describe. It reads the snapshot directly rather than
 // inspecting the analyzer's output, so it says the same thing regardless of
@@ -254,6 +253,7 @@ func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColu
 	return &base.UnresolvedColumnsError{Relations: unresolved}
 }
 
+// getQuerySpan extracts the query span for the given SQL statement.
 func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) (*base.QuerySpan, error) {
 	e.ctx = ctx
 

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -198,9 +198,12 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 // every one of them. Materialized views are excluded because their metadata
 // carries no column list at all, making an empty one uninformative.
 //
-// A relation the snapshot does not carry at all is not reported. Column
-// resolution drops it upstream, so it never reaches this set; that shape is
-// still unmasked and is tracked separately.
+// Two shapes are known not to reach this set, so they stay unmasked and are
+// tracked separately rather than silently assumed covered:
+//   - a relation the snapshot does not carry at all, which column resolution
+//     drops upstream.
+//   - a relation read only inside a SQL-language function body, whose accesses
+//     the body analysis does not surface (BYT-10075).
 //
 // On PostgreSQL a current sync cannot produce this state: #20581 moved the
 // column query to pg_catalog so privileges no longer hide columns. What
@@ -1377,34 +1380,30 @@ func collectColumnRefNames(node ast.Node) []string {
 	return names
 }
 
-// collectCTENames returns every name bound by a WITH clause in the statement,
-// lowercased. A CTE name shadows an unqualified reference to a physical table
-// of the same name, and the access-table walk does not model that scope.
+// collectCTENames returns every name bound by a WITH clause anywhere in the
+// statement, lowercased. A CTE name shadows an unqualified reference to a
+// physical table of the same name, and the access-table walk does not model
+// that scope, so a CTE reference arrives resolved to the table.
 //
-// Nested WITH clauses inside CTE bodies are included. The cost of naming one
-// too many is that a genuinely degraded table sharing a CTE's name goes
-// unchecked in that statement; the cost of naming one too few is refusing a
-// query that reads no table at all.
+// The walk is over the whole tree rather than the top-level WITH clause alone:
+// a WITH can sit inside a derived table, a scalar subquery, or a branch of a
+// set operation, and a name bound in any of those shadows just as effectively.
+//
+// Names are collected without regard to the scope they are visible in. Naming
+// one too many leaves a genuinely degraded table sharing a CTE's name
+// unchecked in that statement; naming one too few refuses a query that reads
+// no table at all. The first is the quieter failure.
 func collectCTENames(selStmt *ast.SelectStmt) map[string]bool {
 	names := make(map[string]bool)
-	var walk func(*ast.SelectStmt, int)
-	walk = func(sel *ast.SelectStmt, depth int) {
-		// Guard against a malformed tree looping; real queries nest shallowly.
-		if sel == nil || sel.WithClause == nil || depth > 32 {
-			return
-		}
-		for _, item := range sel.WithClause.Ctes.Items {
-			cte, ok := item.(*ast.CommonTableExpr)
-			if !ok {
-				continue
-			}
-			names[strings.ToLower(cte.Ctename)] = true
-			if body, ok := cte.Ctequery.(*ast.SelectStmt); ok {
-				walk(body, depth+1)
-			}
-		}
+	if selStmt == nil {
+		return names
 	}
-	walk(selStmt, 0)
+	ast.Inspect(selStmt, func(node ast.Node) bool {
+		if cte, ok := node.(*ast.CommonTableExpr); ok {
+			names[strings.ToLower(cte.Ctename)] = true
+		}
+		return true
+	})
 	return names
 }
 

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -98,67 +98,6 @@ func (e *omniQuerySpanExtractor) getDatabaseMetadata(database string) (*model.Da
 //
 // The DDL render + batch-parse path used before this refactor is deleted: BYT-9215 and
 // BYT-9261 are unreachable by construction here.
-// findUnresolvedRelations reports the relations in accesses whose columns the
-// stored snapshot does not describe. It reads the snapshot directly rather than
-// inspecting the analyzer's output, so it says the same thing regardless of
-// which lineage path produced the span.
-//
-// A relation the snapshot lists with no columns is the state a schema sync
-// leaves behind when the connecting role lost its privileges. Column-granular
-// masking cannot be evaluated against it, and no other span field records that:
-// SELECT * simply yields no results at all, which is indistinguishable from a
-// query that legitimately projects nothing.
-//
-// Views and materialized views are excluded: their columns come from a
-// definition rather than a column list, so an empty column list is normal for
-// them and says nothing about the snapshot's health.
-func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet) []base.ColumnResource {
-	seen := make(map[base.ColumnResource]bool, len(accesses))
-	var unresolved []base.ColumnResource
-	for access := range accesses {
-		relation := base.ColumnResource{
-			Server:   access.Server,
-			Database: access.Database,
-			Schema:   access.Schema,
-			Table:    access.Table,
-		}
-		if relation.Table == "" || seen[relation] {
-			continue
-		}
-		seen[relation] = true
-
-		meta, err := e.getDatabaseMetadata(relation.Database)
-		if err != nil || meta == nil {
-			// A database we cannot read is not evidence about this relation.
-			continue
-		}
-		schema := meta.GetSchemaMetadata(relation.Schema)
-		if schema == nil {
-			continue
-		}
-		table := schema.GetTable(relation.Table)
-		if table == nil {
-			// Not a table: a view, materialized view, function, or an object the
-			// snapshot never carried. Out of scope here.
-			continue
-		}
-		if len(table.GetProto().GetColumns()) == 0 {
-			unresolved = append(unresolved, relation)
-		}
-	}
-	return unresolved
-}
-
-// unresolvedColumnsError builds the span signal for accesses whose columns the
-// snapshot cannot describe, or nil when every accessed table resolves.
-func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet) *base.UnresolvedColumnsError {
-	unresolved := e.findUnresolvedRelations(accesses)
-	if len(unresolved) == 0 {
-		return nil
-	}
-	return &base.UnresolvedColumnsError{Relations: unresolved}
-}
-
 func (e *omniQuerySpanExtractor) initCatalog() error {
 	meta, err := e.getDatabaseMetadata(e.defaultDatabase)
 	if err != nil {
@@ -244,6 +183,77 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 }
 
 // getQuerySpan extracts the query span for the given SQL statement.
+// findUnresolvedRelations reports the relations in accesses whose columns the
+// stored snapshot does not describe. It reads the snapshot directly rather than
+// inspecting the analyzer's output, so it says the same thing regardless of
+// which lineage path produced the span.
+//
+// A relation the snapshot lists with no columns is the state a schema sync
+// leaves behind when the connecting role lost its privileges. Column-granular
+// masking cannot be evaluated against it, and no other span field records that:
+// SELECT * simply yields no results at all, which is indistinguishable from a
+// query that legitimately projects nothing.
+//
+// Tables and views are both checked: the syncer fills a view's column list
+// from the same map as a table's, so an empty one means the same thing.
+// Materialized views are excluded because their metadata carries no column
+// list at all, making an empty one uninformative.
+//
+// A relation the snapshot does not carry at all is not reported. Column
+// resolution drops it upstream, so it never reaches this set; that shape is
+// still unmasked and is tracked separately.
+func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet) []base.ColumnResource {
+	seen := make(map[base.ColumnResource]bool, len(accesses))
+	var unresolved []base.ColumnResource
+	for access := range accesses {
+		relation := base.ColumnResource{
+			Server:   access.Server,
+			Database: access.Database,
+			Schema:   access.Schema,
+			Table:    access.Table,
+		}
+		if relation.Table == "" || seen[relation] {
+			continue
+		}
+		seen[relation] = true
+
+		meta, err := e.getDatabaseMetadata(relation.Database)
+		if err != nil || meta == nil {
+			// A database we cannot read is not evidence about this relation.
+			continue
+		}
+		schema := meta.GetSchemaMetadata(relation.Schema)
+		if schema == nil {
+			continue
+		}
+		if table := schema.GetTable(relation.Table); table != nil {
+			if len(table.GetProto().GetColumns()) == 0 {
+				unresolved = append(unresolved, relation)
+			}
+			continue
+		}
+		// A view carries a column list too, filled from the same map as a
+		// table's, so a view with none is degraded the same way. Reading a
+		// masked base table through one must not slip past.
+		if view := schema.GetView(relation.Table); view != nil {
+			if len(view.GetColumns()) == 0 {
+				unresolved = append(unresolved, relation)
+			}
+		}
+	}
+	return unresolved
+}
+
+// unresolvedColumnsError builds the span signal for accesses whose columns the
+// snapshot cannot describe, or nil when every accessed table resolves.
+func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet) *base.UnresolvedColumnsError {
+	unresolved := e.findUnresolvedRelations(accesses)
+	if len(unresolved) == 0 {
+		return nil
+	}
+	return &base.UnresolvedColumnsError{Relations: unresolved}
+}
+
 func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) (*base.QuerySpan, error) {
 	e.ctx = ctx
 

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -98,6 +98,67 @@ func (e *omniQuerySpanExtractor) getDatabaseMetadata(database string) (*model.Da
 //
 // The DDL render + batch-parse path used before this refactor is deleted: BYT-9215 and
 // BYT-9261 are unreachable by construction here.
+// findUnresolvedRelations reports the relations in accesses whose columns the
+// stored snapshot does not describe. It reads the snapshot directly rather than
+// inspecting the analyzer's output, so it says the same thing regardless of
+// which lineage path produced the span.
+//
+// A relation the snapshot lists with no columns is the state a schema sync
+// leaves behind when the connecting role lost its privileges. Column-granular
+// masking cannot be evaluated against it, and no other span field records that:
+// SELECT * simply yields no results at all, which is indistinguishable from a
+// query that legitimately projects nothing.
+//
+// Views and materialized views are excluded: their columns come from a
+// definition rather than a column list, so an empty column list is normal for
+// them and says nothing about the snapshot's health.
+func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet) []base.ColumnResource {
+	seen := make(map[base.ColumnResource]bool, len(accesses))
+	var unresolved []base.ColumnResource
+	for access := range accesses {
+		relation := base.ColumnResource{
+			Server:   access.Server,
+			Database: access.Database,
+			Schema:   access.Schema,
+			Table:    access.Table,
+		}
+		if relation.Table == "" || seen[relation] {
+			continue
+		}
+		seen[relation] = true
+
+		meta, err := e.getDatabaseMetadata(relation.Database)
+		if err != nil || meta == nil {
+			// A database we cannot read is not evidence about this relation.
+			continue
+		}
+		schema := meta.GetSchemaMetadata(relation.Schema)
+		if schema == nil {
+			continue
+		}
+		table := schema.GetTable(relation.Table)
+		if table == nil {
+			// Not a table: a view, materialized view, function, or an object the
+			// snapshot never carried. Out of scope here.
+			continue
+		}
+		if len(table.GetProto().GetColumns()) == 0 {
+			unresolved = append(unresolved, relation)
+		}
+	}
+	return unresolved
+}
+
+// unresolvedColumnsError builds the span signal for accesses whose columns the
+// snapshot cannot describe, or nil when every accessed table resolves.
+func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet) *base.UnresolvedColumnsError {
+	unresolved := e.findUnresolvedRelations(accesses)
+	if len(unresolved) == 0 {
+		return nil
+	}
+	return &base.UnresolvedColumnsError{Relations: unresolved}
+}
+
 func (e *omniQuerySpanExtractor) initCatalog() error {
 	meta, err := e.getDatabaseMetadata(e.defaultDatabase)
 	if err != nil {
@@ -276,18 +337,20 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 		// used as table sources: SELECT * FROM func()).
 		if results := e.tryUserFuncTableSource(selStmt, accessesMap); results != nil {
 			return &base.QuerySpan{
-				Type:          base.Select,
-				SourceColumns: accessesMap,
-				Results:       results,
+				Type:                   base.Select,
+				SourceColumns:          accessesMap,
+				Results:                results,
+				UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap),
 			}, nil
 		}
 		// Fail-open: return access tables with best-effort column names and lineage
 		// when analysis fails (e.g., unsupported built-in functions).
 		return &base.QuerySpan{
-			Type:             base.Select,
-			SourceColumns:    accessesMap,
-			Results:          e.extractFallbackColumns(selStmt),
-			PredicateColumns: e.funcPredicateColumns,
+			Type:                   base.Select,
+			SourceColumns:          accessesMap,
+			Results:                e.extractFallbackColumns(selStmt),
+			PredicateColumns:       e.funcPredicateColumns,
+			UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap),
 		}, nil
 	}
 
@@ -302,10 +365,11 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 	}
 
 	return &base.QuerySpan{
-		Type:             base.Select,
-		SourceColumns:    accessesMap,
-		PredicateColumns: e.funcPredicateColumns,
-		Results:          results,
+		Type:                   base.Select,
+		SourceColumns:          accessesMap,
+		PredicateColumns:       e.funcPredicateColumns,
+		Results:                results,
+		UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap),
 	}, nil
 }
 

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -205,7 +205,7 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 // On PostgreSQL a current sync cannot produce this state: #20581 moved the
 // column query to pg_catalog so privileges no longer hide columns. What
 // reaches it is a snapshot written before that fix and never re-synced.
-func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet) []base.ColumnResource {
+func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet, cteNames map[string]bool) []base.ColumnResource {
 	seen := make(map[base.ColumnResource]bool, len(accesses))
 	var unresolved []base.ColumnResource
 	for access := range accesses {
@@ -219,6 +219,13 @@ func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceCol
 			continue
 		}
 		seen[relation] = true
+		// ExtractAccessTables walks every RangeVar without tracking CTE scope, so
+		// a reference to a CTE that shares a table's name arrives here resolved to
+		// that table. Such a query never reads the table and resolves entirely
+		// from the CTE, so refusing it would be a false positive.
+		if cteNames[strings.ToLower(relation.Table)] {
+			continue
+		}
 		if e.relationHasNoSyncedColumns(relation) {
 			unresolved = append(unresolved, relation)
 		}
@@ -256,8 +263,8 @@ func (e *omniQuerySpanExtractor) relationHasNoSyncedColumns(relation base.Column
 
 // unresolvedColumnsError builds the span signal for accesses whose columns the
 // snapshot cannot describe, or nil when every accessed table resolves.
-func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet) *base.UnresolvedColumnsError {
-	unresolved := e.findUnresolvedRelations(accesses)
+func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet, selStmt *ast.SelectStmt) *base.UnresolvedColumnsError {
+	unresolved := e.findUnresolvedRelations(accesses, collectCTENames(selStmt))
 	if len(unresolved) == 0 {
 		return nil
 	}
@@ -361,7 +368,7 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 				Type:                   base.Select,
 				SourceColumns:          accessesMap,
 				Results:                results,
-				UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap),
+				UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap, selStmt),
 			}, nil
 		}
 		// Fail-open: return access tables with best-effort column names and lineage
@@ -371,7 +378,7 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 			SourceColumns:          accessesMap,
 			Results:                e.extractFallbackColumns(selStmt),
 			PredicateColumns:       e.funcPredicateColumns,
-			UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap),
+			UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap, selStmt),
 		}, nil
 	}
 
@@ -390,7 +397,7 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 		SourceColumns:          accessesMap,
 		PredicateColumns:       e.funcPredicateColumns,
 		Results:                results,
-		UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap),
+		UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap, selStmt),
 	}, nil
 }
 
@@ -1367,6 +1374,37 @@ func collectColumnRefNames(node ast.Node) []string {
 		names = append(names, collectColumnRefNames(v.Arg)...)
 	default:
 	}
+	return names
+}
+
+// collectCTENames returns every name bound by a WITH clause in the statement,
+// lowercased. A CTE name shadows an unqualified reference to a physical table
+// of the same name, and the access-table walk does not model that scope.
+//
+// Nested WITH clauses inside CTE bodies are included. The cost of naming one
+// too many is that a genuinely degraded table sharing a CTE's name goes
+// unchecked in that statement; the cost of naming one too few is refusing a
+// query that reads no table at all.
+func collectCTENames(selStmt *ast.SelectStmt) map[string]bool {
+	names := make(map[string]bool)
+	var walk func(*ast.SelectStmt, int)
+	walk = func(sel *ast.SelectStmt, depth int) {
+		// Guard against a malformed tree looping; real queries nest shallowly.
+		if sel == nil || sel.WithClause == nil || depth > 32 {
+			return
+		}
+		for _, item := range sel.WithClause.Ctes.Items {
+			cte, ok := item.(*ast.CommonTableExpr)
+			if !ok {
+				continue
+			}
+			names[strings.ToLower(cte.Ctename)] = true
+			if body, ok := cte.Ctequery.(*ast.SelectStmt); ok {
+				walk(body, depth+1)
+			}
+		}
+	}
+	walk(selStmt, 0)
 	return names
 }
 

--- a/backend/plugin/parser/pg/query_span_omni.go
+++ b/backend/plugin/parser/pg/query_span_omni.go
@@ -205,10 +205,15 @@ func findDollarQuotedBody(definition string) (tag string, bodyStart int, bodyEnd
 //   - a relation read only inside a SQL-language function body, whose accesses
 //     the body analysis does not surface (BYT-10075).
 //
+// scope is the analyzer's scope resolution for this statement, used to drop the
+// accesses that name a CTE rather than a table. It is nil when the analyzer
+// failed and produced no query to read; every access is then checked. See
+// unresolvedColumnsError.
+//
 // On PostgreSQL a current sync cannot produce this state: #20581 moved the
 // column query to pg_catalog so privileges no longer hide columns. What
 // reaches it is a snapshot written before that fix and never re-synced.
-func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet, cteNames, qualified map[string]bool) []base.ColumnResource {
+func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceColumnSet, scope *analyzedScope) []base.ColumnResource {
 	seen := make(map[base.ColumnResource]bool, len(accesses))
 	var unresolved []base.ColumnResource
 	for access := range accesses {
@@ -224,11 +229,9 @@ func (e *omniQuerySpanExtractor) findUnresolvedRelations(accesses base.SourceCol
 		seen[relation] = true
 		// ExtractAccessTables walks every RangeVar without tracking CTE scope, so
 		// a reference to a CTE that shares a table's name arrives here resolved to
-		// that table. Skip it only when nothing in the statement names the table
-		// with a schema: PostgreSQL does not let a CTE shadow a qualified name, so
-		// a qualified mention is a genuine read no matter what the CTEs are called.
-		lower := strings.ToLower(relation.Table)
-		if cteNames[lower] && !qualified[lower] {
+		// that table. The analyzer already did that scope resolution, so ask it
+		// which names are relations the statement really reads.
+		if !scope.reads(relation.Schema, relation.Table) {
 			continue
 		}
 		if e.relationHasNoSyncedColumns(relation) {
@@ -268,12 +271,42 @@ func (e *omniQuerySpanExtractor) relationHasNoSyncedColumns(relation base.Column
 
 // unresolvedColumnsError builds the span signal for accesses whose columns the
 // snapshot cannot describe, or nil when every accessed table resolves.
-func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet, selStmt *ast.SelectStmt) *base.UnresolvedColumnsError {
-	unresolved := e.findUnresolvedRelations(accesses, collectCTENames(selStmt), collectQualifiedTableNames(selStmt))
+//
+// scope is the analyzer's scope resolution, which says which of the accesses
+// name a relation the statement really reads. Pass nil when there is none.
+func (e *omniQuerySpanExtractor) unresolvedColumnsError(accesses base.SourceColumnSet, scope *analyzedScope) *base.UnresolvedColumnsError {
+	unresolved := e.findUnresolvedRelations(accesses, scope)
 	if len(unresolved) == 0 {
 		return nil
 	}
 	return &base.UnresolvedColumnsError{Relations: unresolved}
+}
+
+// analyzedScopeOf reads the analyzer's scope resolution for query and widens it
+// with the relations the function body analysis surfaced.
+//
+// Those reads are real and they reach accessesMap, but they happen inside a
+// function body that the top-level analyzed query does not contain, so the walk
+// over that query cannot find them. Dropping them would stop checking a table a
+// PL/pgSQL body reads.
+func (e *omniQuerySpanExtractor) analyzedScopeOf(query *catalog.Query, selStmt *ast.SelectStmt) *analyzedScope {
+	scope := collectAnalyzedScope(e.cat, query)
+	for access := range e.funcSourceColumns {
+		scope.relations.add(access.Schema, access.Table)
+	}
+	// Floor the analyzer's answer with the parse tree's schema-qualified names.
+	// A CTE cannot shadow a qualified reference, so every one of these is a real
+	// read no matter what the walk found. This is a second, independent oracle
+	// for the same question, and it covers the positions the analyzed tree drops
+	// outright — an aggregate's FILTER and ORDER BY subqueries reach neither
+	// catalog.AggExpr nor therefore the walk.
+	ast.Inspect(selStmt, func(node ast.Node) bool {
+		if rv, ok := node.(*ast.RangeVar); ok && rv.Schemaname != "" && rv.Relname != "" {
+			scope.relations.add(rv.Schemaname, rv.Relname)
+		}
+		return true
+	})
+	return scope
 }
 
 // getQuerySpan extracts the query span for the given SQL statement.
@@ -365,6 +398,14 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 		// gate behavior — the fallback below always runs on analyzer errors.
 		e.lastFallbackReason = classifyAnalyzeError(err)
 
+		// Both returns below pass a nil scope: analysis failed, so there is no
+		// scope resolution to consult and every access is checked. The accesses
+		// that name a CTE rather than a table stay in, which can refuse a query
+		// that reads only a CTE named like a degraded relation. That is the safe
+		// direction for a masking guard, and the alternative — the name-based
+		// shadowing heuristic this replaced — drops a real read whenever any CTE
+		// anywhere in the statement shares an unqualified relation's name.
+		//
 		// Before falling back, try to handle user-defined table-returning functions
 		// that omni's AnalyzeSelectStmt can't resolve (e.g., RETURNS TABLE functions
 		// used as table sources: SELECT * FROM func()).
@@ -373,7 +414,7 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 				Type:                   base.Select,
 				SourceColumns:          accessesMap,
 				Results:                results,
-				UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap, selStmt),
+				UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap, nil),
 			}, nil
 		}
 		// Fail-open: return access tables with best-effort column names and lineage
@@ -383,7 +424,7 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 			SourceColumns:          accessesMap,
 			Results:                e.extractFallbackColumns(selStmt),
 			PredicateColumns:       e.funcPredicateColumns,
-			UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap, selStmt),
+			UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap, nil),
 		}, nil
 	}
 
@@ -397,12 +438,14 @@ func (e *omniQuerySpanExtractor) getQuerySpan(ctx context.Context, stmt string) 
 		accessesMap[col] = true
 	}
 
+	// Analysis succeeded, so the analyzer's scope resolution is available and
+	// decides which accesses are relation reads.
 	return &base.QuerySpan{
 		Type:                   base.Select,
 		SourceColumns:          accessesMap,
 		PredicateColumns:       e.funcPredicateColumns,
 		Results:                results,
-		UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap, selStmt),
+		UnresolvedColumnsError: e.unresolvedColumnsError(accessesMap, e.analyzedScopeOf(query, selStmt)),
 	}, nil
 }
 
@@ -1379,54 +1422,6 @@ func collectColumnRefNames(node ast.Node) []string {
 		names = append(names, collectColumnRefNames(v.Arg)...)
 	default:
 	}
-	return names
-}
-
-// collectCTENames returns every name bound by a WITH clause anywhere in the
-// statement, lowercased. A CTE name shadows an unqualified reference to a
-// physical table of the same name, and the access-table walk does not model
-// that scope, so a CTE reference arrives resolved to the table.
-//
-// The walk is over the whole tree rather than the top-level WITH clause alone:
-// a WITH can sit inside a derived table, a scalar subquery, or a branch of a
-// set operation, and a name bound in any of those shadows just as effectively.
-//
-// Names are collected without regard to the scope they are visible in, so a
-// CTE bound in one branch suppresses an unqualified reference in another. A
-// schema-qualified reference is never suppressed — see
-// collectQualifiedTableNames — so a genuine read still reaches the check.
-func collectCTENames(selStmt *ast.SelectStmt) map[string]bool {
-	names := make(map[string]bool)
-	if selStmt == nil {
-		return names
-	}
-	ast.Inspect(selStmt, func(node ast.Node) bool {
-		if cte, ok := node.(*ast.CommonTableExpr); ok {
-			names[strings.ToLower(cte.Ctename)] = true
-		}
-		return true
-	})
-	return names
-}
-
-// collectQualifiedTableNames returns the lowercased base names of every table
-// reference in the statement that carries a schema, anywhere in the tree.
-//
-// A CTE cannot shadow a schema-qualified reference in PostgreSQL, so a name
-// that appears qualified somewhere is being read as a real table there, whatever
-// the statement's CTEs are called. Excluding it as a CTE name would drop a
-// genuine read.
-func collectQualifiedTableNames(selStmt *ast.SelectStmt) map[string]bool {
-	names := make(map[string]bool)
-	if selStmt == nil {
-		return names
-	}
-	ast.Inspect(selStmt, func(node ast.Node) bool {
-		if rv, ok := node.(*ast.RangeVar); ok && rv.Schemaname != "" && rv.Relname != "" {
-			names[strings.ToLower(rv.Relname)] = true
-		}
-		return true
-	})
 	return names
 }
 

--- a/backend/plugin/parser/pg/query_span_omni_relations.go
+++ b/backend/plugin/parser/pg/query_span_omni_relations.go
@@ -1,0 +1,346 @@
+package pg
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/bytebase/omni/pg/catalog"
+)
+
+// relationRef identifies a relation by schema and name, both lowercased.
+//
+// Case is folded on both sides of every comparison. A lookup that misses on
+// letter case would drop a genuine read from the unresolved-columns check,
+// which is the fail-open direction; folding can only keep an extra access,
+// which at worst refuses a query.
+//
+// An empty schema is a wildcard that matches any schema for that name. It is
+// used only when the analyzer bound a relation whose schema could not be
+// recovered from the catalog.
+type relationRef struct {
+	schema string
+	table  string
+}
+
+// relationSet is a set of relations a query reads.
+type relationSet map[relationRef]bool
+
+func (s relationSet) add(schema, table string) {
+	if table == "" {
+		return
+	}
+	s[relationRef{schema: strings.ToLower(schema), table: strings.ToLower(table)}] = true
+}
+
+func (s relationSet) has(schema, table string) bool {
+	name := strings.ToLower(table)
+	return s[relationRef{schema: strings.ToLower(schema), table: name}] || s[relationRef{table: name}]
+}
+
+// analyzedScope is what omni's scope resolution says a statement reads.
+//
+// The omni analyzer resolves every table reference against the CTEs in scope
+// at that point, which is the one thing a name-based walk of the parse tree
+// cannot do: a non-recursive CTE's own name is not visible inside its own body,
+// WITH RECURSIVE makes it visible, an earlier sibling CTE is visible to a later
+// one, and an inner WITH shadows an outer one. So `WITH t AS (SELECT * FROM t)
+// SELECT * FROM t` reads the physical t once, in the CTE body, and the two
+// other mentions of t are the CTE.
+//
+// The scope is built by walking the analyzed query, not the parse tree.
+type analyzedScope struct {
+	// relations holds every range table entry the analyzer bound to a real
+	// relation, anywhere in the query.
+	relations relationSet
+	// cteNames holds every name a WITH clause binds, anywhere in the query.
+	// It is not the decision — relations is — it bounds what a gap in the walk
+	// can cost. See reads.
+	cteNames map[string]bool
+	// unknownExpr records that the walk met an expression type it does not
+	// handle, so it cannot claim to have found every subquery. See reads.
+	unknownExpr bool
+}
+
+// reads reports whether a table the access-table walk found is a relation this
+// statement really reads.
+//
+// A nil scope means the caller has no analyzer output to consult and wants
+// every access checked.
+//
+// The relation set decides: a name the analyzer bound to a real relation is a
+// read, whatever else shares that name. The CTE-name set only limits the blast
+// radius of a walk that misses a node type: an access is dropped only on
+// positive evidence that the analyzer bound its name as a CTE. A missed node
+// then costs a refused query (false positive) rather than an unchecked read
+// (fail-open), and costs even that only when a CTE shares the name.
+func (s *analyzedScope) reads(schema, table string) bool {
+	if s == nil {
+		return true
+	}
+	if s.unknownExpr {
+		// The walk met a type it does not understand, so its evidence about what
+		// this statement reads is incomplete. Check every access rather than
+		// trust a walk that may have stepped over a subquery. On a healthy
+		// snapshot this changes nothing; on a degraded one it refuses, which is
+		// the direction this signal exists to fail in.
+		return true
+	}
+	if s.relations.has(schema, table) {
+		return true
+	}
+	return !s.cteNames[strings.ToLower(table)]
+}
+
+// scopeCollector walks an analyzed query and fills an analyzedScope.
+//
+// Every position that can hold a nested *catalog.Query is reached: the range
+// table (subqueries and function arguments), the CTE list, both branches of a
+// set operation, and every expression position that can hold a SubLinkExpr —
+// the target list, the join tree's WHERE and ON conditions, HAVING, LIMIT,
+// OFFSET, and window frame offsets.
+//
+// GROUP BY, ORDER BY and DISTINCT ON hold no expressions of their own: omni
+// models them as *catalog.SortGroupClause, an index into the target list, so
+// walking the target list covers them.
+//
+// A view's body is deliberately not expanded. A view is itself the relation the
+// query reads, and the snapshot describes its columns directly; expanding it
+// would widen the signal to relations the access-table walk never reports.
+type scopeCollector struct {
+	cat     *catalog.Catalog
+	scope   *analyzedScope
+	visited map[*catalog.Query]bool
+}
+
+// collectAnalyzedScope returns what the analyzer resolved q to read.
+func collectAnalyzedScope(cat *catalog.Catalog, q *catalog.Query) *analyzedScope {
+	c := &scopeCollector{
+		cat: cat,
+		scope: &analyzedScope{
+			relations: make(relationSet),
+			cteNames:  make(map[string]bool),
+		},
+		visited: make(map[*catalog.Query]bool),
+	}
+	c.walkQuery(q)
+	return c.scope
+}
+
+func (c *scopeCollector) walkQuery(q *catalog.Query) {
+	// A recursive CTE's query refers to itself, so the walk needs a cycle guard.
+	if q == nil || c.visited[q] {
+		return
+	}
+	c.visited[q] = true
+
+	c.walkCTEList(q.CTEList)
+	c.walkRangeTable(q.RangeTable)
+	c.walkJoinTree(q.JoinTree)
+	c.walkTargetList(q.TargetList)
+	c.walkWindowClause(q.WindowClause)
+	c.walkExpr(q.HavingQual)
+	c.walkExpr(q.LimitCount)
+	c.walkExpr(q.LimitOffset)
+	c.walkQuery(q.LArg)
+	c.walkQuery(q.RArg)
+}
+
+func (c *scopeCollector) walkCTEList(list []*catalog.CommonTableExprQ) {
+	for _, cte := range list {
+		if cte == nil {
+			continue
+		}
+		if cte.Name != "" {
+			c.scope.cteNames[strings.ToLower(cte.Name)] = true
+		}
+		c.walkQuery(cte.Query)
+	}
+}
+
+func (c *scopeCollector) walkRangeTable(rangeTable []*catalog.RangeTableEntry) {
+	for _, rte := range rangeTable {
+		c.walkRangeTableEntry(rte)
+	}
+}
+
+func (c *scopeCollector) walkRangeTableEntry(rte *catalog.RangeTableEntry) {
+	if rte == nil {
+		return
+	}
+	switch rte.Kind {
+	case catalog.RTERelation:
+		c.collectRelation(rte)
+		c.walkTablesample(rte.Tablesample)
+	case catalog.RTESubquery:
+		c.walkQuery(rte.Subquery)
+	case catalog.RTEFunction:
+		c.walkExprs(rte.FuncExprs)
+	case catalog.RTECTE:
+		// The CTE body is walked from the CTE list that binds it, which is this
+		// query's or an enclosing one's — both are on the walk.
+	case catalog.RTEJoin:
+		// A join entry carries no relation of its own; its inputs are separate
+		// range table entries.
+	default:
+	}
+}
+
+// collectRelation records the relation an RTERelation entry is bound to.
+//
+// The entry's SchemaName is only what the statement wrote, so it is empty for
+// an unqualified reference. The catalog holds the schema the analyzer actually
+// resolved the OID to, which is what the access-table walk reports too.
+// walkTablesample walks a TABLESAMPLE clause. Its arguments and REPEATABLE seed
+// are ordinary expressions and can hold a subquery.
+func (c *scopeCollector) walkTablesample(ts *catalog.TablesampleClauseQ) {
+	if ts == nil {
+		return
+	}
+	c.walkExprs(ts.Args)
+	c.walkExpr(ts.Repeatable)
+}
+
+func (c *scopeCollector) collectRelation(rte *catalog.RangeTableEntry) {
+	schema := rte.SchemaName
+	if c.cat != nil {
+		if rel := c.cat.GetRelationByOID(rte.RelOID); rel != nil && rel.Schema != nil {
+			schema = rel.Schema.Name
+		}
+	}
+	c.scope.relations.add(schema, rte.RelName)
+}
+
+func (c *scopeCollector) walkJoinTree(tree *catalog.JoinTree) {
+	if tree == nil {
+		return
+	}
+	for _, node := range tree.FromList {
+		c.walkJoinNode(node)
+	}
+	c.walkExpr(tree.Quals)
+}
+
+// walkJoinNode descends a join expression for its ON condition. The other
+// JoinNode implementation, *catalog.RangeTableRef, is an index into the range
+// table, which walkRangeTable covers in full.
+func (c *scopeCollector) walkJoinNode(node catalog.JoinNode) {
+	join, ok := node.(*catalog.JoinExprNode)
+	if !ok || join == nil {
+		return
+	}
+	c.walkJoinNode(join.Left)
+	c.walkJoinNode(join.Right)
+	c.walkExpr(join.Quals)
+}
+
+func (c *scopeCollector) walkTargetList(list []*catalog.TargetEntry) {
+	for _, entry := range list {
+		if entry == nil {
+			continue
+		}
+		c.walkExpr(entry.Expr)
+	}
+}
+
+func (c *scopeCollector) walkWindowClause(list []*catalog.WindowClauseQ) {
+	for _, window := range list {
+		if window == nil {
+			continue
+		}
+		c.walkExpr(window.StartOffset)
+		c.walkExpr(window.EndOffset)
+	}
+}
+
+func (c *scopeCollector) walkExprs(exprs []catalog.AnalyzedExpr) {
+	for _, expr := range exprs {
+		c.walkExpr(expr)
+	}
+}
+
+// walkExpr descends every child expression, and every subquery a SubLinkExpr
+// carries.
+//
+// The type switch names the expression types that can carry a subquery in the
+// pinned omni. It is NOT assumed exhaustive: omni adds types, and an earlier
+// revision of this file enumerated them against a stale module directory and
+// silently stopped checking ten statement shapes. Check the real list with
+//
+//	go list -m github.com/bytebase/omni
+//	grep -rh 'func (.*) exprType() uint32' "$(go list -m -f '{{.Dir}}' github.com/bytebase/omni)"/pg/catalog/*.go
+//
+// The default arm marks the scope incomplete rather than trusting this list.
+func (c *scopeCollector) walkExpr(expr catalog.AnalyzedExpr) {
+	switch e := expr.(type) {
+	case *catalog.SubLinkExpr:
+		c.walkExpr(e.TestExpr)
+		c.walkQuery(e.SubQuery)
+	case *catalog.FuncCallExpr:
+		c.walkExprs(e.Args)
+	case *catalog.AggExpr:
+		c.walkExprs(e.Args)
+	case *catalog.WindowFuncExpr:
+		c.walkExprs(e.Args)
+		c.walkExpr(e.AggFilter)
+	case *catalog.OpExpr:
+		c.walkExpr(e.Left)
+		c.walkExpr(e.Right)
+	case *catalog.DistinctExprQ:
+		c.walkExpr(e.Left)
+		c.walkExpr(e.Right)
+	case *catalog.ScalarArrayOpExpr:
+		c.walkExpr(e.Left)
+		c.walkExpr(e.Right)
+	case *catalog.CaseExprQ:
+		c.walkCaseExpr(e)
+	case *catalog.BoolExprQ:
+		c.walkExprs(e.Args)
+	case *catalog.CoalesceExprQ:
+		c.walkExprs(e.Args)
+	case *catalog.NullIfExprQ:
+		c.walkExprs(e.Args)
+	case *catalog.MinMaxExprQ:
+		c.walkExprs(e.Args)
+	case *catalog.ArrayExprQ:
+		c.walkExprs(e.Elements)
+	case *catalog.RowExprQ:
+		c.walkExprs(e.Args)
+	case *catalog.RelabelExpr:
+		c.walkExpr(e.Arg)
+	case *catalog.CoerceViaIOExpr:
+		c.walkExpr(e.Arg)
+	case *catalog.CollateExprQ:
+		c.walkExpr(e.Arg)
+	case *catalog.NullTestExpr:
+		c.walkExpr(e.Arg)
+	case *catalog.BooleanTestExpr:
+		c.walkExpr(e.Arg)
+	case *catalog.FieldSelectExprQ:
+		c.walkExpr(e.Arg)
+	case *catalog.VarExpr, *catalog.ConstExpr, *catalog.SQLValueFuncExpr,
+		*catalog.CoerceToDomainValueExpr:
+		// Leaves: a column reference, a constant, CURRENT_DATE and friends, and
+		// the VALUE keyword of a domain constraint carry no child expression.
+	case nil:
+	default:
+		// An expression type omni added after this switch was written. If it can
+		// carry a subquery, the reads inside it are no longer checked, so say so
+		// rather than dropping them in silence.
+		c.scope.unknownExpr = true
+		slog.Debug("unhandled analyzed expression type in the relation walk",
+			slog.String("type", fmt.Sprintf("%T", expr)))
+	}
+}
+
+func (c *scopeCollector) walkCaseExpr(e *catalog.CaseExprQ) {
+	c.walkExpr(e.Arg)
+	for _, when := range e.When {
+		if when == nil {
+			continue
+		}
+		c.walkExpr(when.Condition)
+		c.walkExpr(when.Result)
+	}
+	c.walkExpr(e.Default)
+}

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -200,6 +200,14 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 		require.Nil(t, span.UnresolvedColumnsError)
 	})
 
+	t.Run("a CTE inside a derived table also shadows", func(t *testing.T) {
+		// A WITH clause can sit anywhere a SELECT can, so the name collector
+		// walks the whole tree rather than the top-level WITH alone.
+		span := spanFor(t, "SELECT * FROM (WITH t AS (SELECT 1 AS n) SELECT * FROM t) q", degradedSchema())
+		require.Nil(t, span.UnresolvedColumnsError,
+			"a CTE bound inside a subquery shadows the physical table just as a top-level one does")
+	})
+
 	t.Run("known gap: a qualified read is skipped when a CTE shares the name", func(t *testing.T) {
 		// PostgreSQL does not let a CTE shadow a schema-qualified name, so this
 		// statement really does read the degraded public.t. Excluding by name

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/bytebase/omni/pg/ast"
+
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/parser/base"
 )
@@ -47,11 +49,17 @@ func healthySchema() *storepb.DatabaseSchemaMetadata {
 // current PostgreSQL sync reads pg_catalog and cannot produce this, but a
 // snapshot written by an older version and never re-synced still carries it.
 func degradedSchema() *storepb.DatabaseSchemaMetadata {
+	return degradedSchemaNamed("t")
+}
+
+// degradedSchemaNamed is degradedSchema with the column-less table under a
+// chosen name, for statements that also bind a CTE of that name.
+func degradedSchemaNamed(table string) *storepb.DatabaseSchemaMetadata {
 	return &storepb.DatabaseSchemaMetadata{
 		Name: "db",
 		Schemas: []*storepb.SchemaMetadata{{
 			Name:   "public",
-			Tables: []*storepb.TableMetadata{{Name: "t"}},
+			Tables: []*storepb.TableMetadata{{Name: table}},
 		}},
 	}
 }
@@ -95,6 +103,31 @@ func spanFor(t *testing.T, statement string, metadata *storepb.DatabaseSchemaMet
 	return span
 }
 
+// analyzerResolves reports whether omni's analyzer resolved the statement.
+//
+// It is what puts a span on the path that consults the analyzer's scope. A
+// statement the analyzer rejects takes the fallback path, which checks every
+// access and would make a coverage assertion pass without the walk over the
+// analyzed query being involved at all.
+func analyzerResolves(t *testing.T, statement string, metadata *storepb.DatabaseSchemaMetadata) bool {
+	t.Helper()
+	getter, lister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{metadata})
+	extractor := newOmniQuerySpanExtractor(metadata.Name, []string{"public"}, base.GetQuerySpanContext{
+		InstanceID:              "inst",
+		GetDatabaseMetadataFunc: getter,
+		ListDatabaseNamesFunc:   lister,
+	})
+	extractor.ctx = context.Background()
+	statements, err := ParsePg(statement)
+	require.NoError(t, err)
+	require.Len(t, statements, 1)
+	selStmt, ok := statements[0].AST.(*ast.SelectStmt)
+	require.True(t, ok)
+	require.NoError(t, extractor.initCatalog())
+	_, err = extractor.cat.AnalyzeSelectStmt(selStmt)
+	return err == nil
+}
+
 // TestUnresolvedColumnsSignalFiresOnDegradedSnapshot covers the reported bug: a
 // table synced with no columns yields a span whose lineage cannot support
 // masking. Every one of these shapes returned unmasked rows before the signal
@@ -102,6 +135,9 @@ func spanFor(t *testing.T, statement string, metadata *storepb.DatabaseSchemaMet
 func TestUnresolvedColumnsSignalFiresOnDegradedSnapshot(t *testing.T) {
 	statements := []string{
 		"SELECT * FROM public.t",
+		// The analyzer rejects the four shapes below — the degraded table has no
+		// column to bind email, id or ssn to — so they exercise the fallback path,
+		// which has no scope resolution to consult and checks every access.
 		"SELECT email FROM public.t",
 		"SELECT t.email FROM public.t",
 		"SELECT * FROM public.t WHERE email = 'x'",
@@ -188,7 +224,8 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 	t.Run("a CTE shadowing a degraded table is not a read of it", func(t *testing.T) {
 		// ExtractAccessTables resolves the unqualified `t` to public.t without
 		// modelling CTE scope, so the access set names a table this query never
-		// reads. The query resolves entirely from the CTE.
+		// reads. The query resolves entirely from the CTE, and the analyzer's
+		// range table says so: it holds a CTE reference, not a relation.
 		span := spanFor(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM t", degradedSchema())
 		require.Nil(t, span.UnresolvedColumnsError,
 			"a query that reads only a CTE must not be refused for a same-named table")
@@ -201,17 +238,43 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 	})
 
 	t.Run("a CTE inside a derived table also shadows", func(t *testing.T) {
-		// A WITH clause can sit anywhere a SELECT can, so the name collector
-		// walks the whole tree rather than the top-level WITH alone.
+		// A WITH clause can sit anywhere a SELECT can, so the walk covers every
+		// nested query rather than the top-level one alone.
 		span := spanFor(t, "SELECT * FROM (WITH t AS (SELECT 1 AS n) SELECT * FROM t) q", degradedSchema())
 		require.Nil(t, span.UnresolvedColumnsError,
 			"a CTE bound inside a subquery shadows the physical table just as a top-level one does")
 	})
 
+	t.Run("a non-recursive CTE reading its own name reads the table", func(t *testing.T) {
+		// This is the case name-based shadowing cannot express, and the reason
+		// the check reads the analyzer's range table instead. A non-recursive
+		// CTE's own name is not visible inside its own body, so the inner `t` is
+		// the physical public.t — verified on PostgreSQL 17, where this statement
+		// returns the table's row. The outer `t` is the CTE.
+		require.True(t, analyzerResolves(t, "WITH t AS (SELECT * FROM t) SELECT * FROM t", degradedSchema()),
+			"the analyzer resolves this statement, so the scope walk decides it")
+		span := spanFor(t, "WITH t AS (SELECT * FROM t) SELECT * FROM t", degradedSchema())
+		require.NotNil(t, span.UnresolvedColumnsError,
+			"the CTE body reads the degraded table, so masking cannot be evaluated")
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
+	})
+
+	t.Run("a recursive CTE reading its own name reads the CTE", func(t *testing.T) {
+		// WITH RECURSIVE is the opposite binding: the name is visible inside the
+		// body, so the self-reference is the CTE and no table is read.
+		span := spanFor(t,
+			"WITH RECURSIVE t AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM t WHERE n < 3) SELECT * FROM t",
+			degradedSchema())
+		require.Nil(t, span.UnresolvedColumnsError,
+			"a recursive self-reference is the CTE, not the same-named table")
+	})
+
 	t.Run("a qualified read is still checked when a CTE shares the name", func(t *testing.T) {
 		// PostgreSQL does not let a CTE shadow a schema-qualified name, so this
 		// statement really does read the degraded public.t. Excluding by name
-		// alone would have dropped it; the qualified-reference set keeps it.
+		// alone would have dropped it; the analyzer binds it as a relation.
+		require.True(t, analyzerResolves(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM public.t", degradedSchema()),
+			"the analyzer resolves this statement, so the scope walk decides it")
 		span := spanFor(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM public.t", degradedSchema())
 		require.NotNil(t, span.UnresolvedColumnsError,
 			"a schema-qualified read is never shadowed by a CTE of the same name")
@@ -219,9 +282,13 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 	})
 
 	t.Run("a statement reading both the CTE and the qualified table is checked", func(t *testing.T) {
-		span := spanFor(t,
-			"WITH t AS (SELECT 1 AS n) SELECT * FROM t UNION ALL SELECT * FROM public.t",
-			degradedSchema())
+		// The arms project different column counts, so the analyzer rejects the
+		// statement. This is the fallback path, which has no scope to consult and
+		// checks every access — including the ones a CTE shares a name with.
+		const statement = "WITH t AS (SELECT 1 AS n) SELECT * FROM t UNION ALL SELECT * FROM public.t"
+		require.False(t, analyzerResolves(t, statement, degradedSchema()),
+			"the analyzer rejects the mismatched set operation, which is what puts this on the fallback path")
+		span := spanFor(t, statement, degradedSchema())
 		require.NotNil(t, span.UnresolvedColumnsError,
 			"the qualified arm is a genuine read regardless of the CTE arm")
 	})
@@ -241,4 +308,127 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.o")
 		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
 	})
+}
+
+// TestUnresolvedColumnsSignalReachesEveryReadPosition is the completeness guard
+// for the walk over the analyzed query.
+//
+// Every statement here binds a CTE named t and reads the degraded public.t in
+// one position. The CTE name alone would drop the access, so the signal fires
+// only if the walk reaches that position. A position the walk misses stops
+// checking the reads inside it, which lets a query the snapshot cannot mask run
+// unmasked — so this list is the one that must grow when omni grows a new node.
+func TestUnresolvedColumnsSignalReachesEveryReadPosition(t *testing.T) {
+	const cte = "WITH t AS (SELECT 1 AS n) "
+	statements := []string{
+		// Range table.
+		"SELECT * FROM public.t",
+		"SELECT * FROM (SELECT count(*) FROM public.t) s",
+		"SELECT * FROM t, LATERAL (SELECT count(*) FROM public.t) s",
+		"SELECT * FROM (WITH u AS (SELECT count(*) AS n FROM public.t) SELECT * FROM u) s",
+		// Target list, through each expression node that can carry a subquery.
+		"SELECT (SELECT count(*) FROM public.t) FROM t",
+		"SELECT COALESCE((SELECT count(*) FROM public.t), 0) FROM t",
+		"SELECT CASE WHEN true THEN (SELECT count(*) FROM public.t) ELSE 0 END FROM t",
+		"SELECT CASE (SELECT count(*) FROM public.t) WHEN 1 THEN 1 ELSE 0 END FROM t",
+		"SELECT ARRAY[(SELECT count(*) FROM public.t)] FROM t",
+		"SELECT ROW((SELECT count(*) FROM public.t)) FROM t",
+		"SELECT NULLIF((SELECT count(*) FROM public.t), 0) FROM t",
+		"SELECT GREATEST((SELECT count(*) FROM public.t), 0) FROM t",
+		"SELECT ((SELECT count(*) FROM public.t))::text FROM t",
+		"SELECT (SELECT count(*) FROM public.t) IS NULL FROM t",
+		"SELECT (SELECT count(*) FROM public.t) IS NOT TRUE FROM t",
+		"SELECT (SELECT count(*) FROM public.t) IS DISTINCT FROM 1 FROM t",
+		"SELECT n = ANY (SELECT count(*) FROM public.t) FROM t",
+		"SELECT n IN (SELECT count(*) FROM public.t) FROM t",
+		"SELECT abs((SELECT count(*) FROM public.t)) FROM t",
+		"SELECT sum((SELECT count(*) FROM public.t)) FROM t",
+		"SELECT n + (SELECT count(*) FROM public.t) FROM t",
+		"SELECT EXISTS (SELECT 1 FROM public.t) FROM t",
+		// Clauses that hold expressions of their own.
+		"SELECT n FROM t WHERE n > (SELECT count(*) FROM public.t)",
+		"SELECT t.n FROM t JOIN t t2 ON t.n > (SELECT count(*) FROM public.t)",
+		"SELECT n FROM t GROUP BY n HAVING count(*) > (SELECT count(*) FROM public.t)",
+		"SELECT n FROM t LIMIT (SELECT count(*) FROM public.t)",
+		"SELECT n FROM t OFFSET (SELECT count(*) FROM public.t)",
+		"SELECT sum(n) OVER (ORDER BY n ROWS BETWEEN (SELECT count(*) FROM public.t) PRECEDING AND CURRENT ROW) FROM t",
+		"SELECT count(*) FILTER (WHERE n > (SELECT count(*) FROM public.t)) OVER () FROM t",
+		// GROUP BY, ORDER BY and DISTINCT ON carry no expression of their own:
+		// omni moves them into the target list as hidden entries.
+		"SELECT n FROM t GROUP BY (SELECT count(*) FROM public.t), n",
+		"SELECT n FROM t ORDER BY (SELECT count(*) FROM public.t)",
+		"SELECT DISTINCT ON ((SELECT count(*) FROM public.t)) n FROM t",
+		// Set operation branches.
+		"SELECT n FROM t UNION ALL SELECT count(*) FROM public.t",
+		"SELECT n FROM t EXCEPT SELECT count(*) FROM public.t",
+	}
+	for _, statement := range statements {
+		t.Run(statement, func(t *testing.T) {
+			require.True(t, analyzerResolves(t, cte+statement, degradedSchema()),
+				"the analyzer must resolve this statement, or the fallback path would carry the test")
+			span := spanFor(t, cte+statement, degradedSchema())
+			require.NotNil(t, span.UnresolvedColumnsError,
+				"a read of the degraded table in this position must still be checked")
+			require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
+		})
+	}
+}
+
+// TestUnresolvedColumnsSignalSurvivesUnwalkedExpressions covers the shapes that
+// hide a read inside an expression the analyzed-query walk does not reach.
+//
+// Each statement wraps a subquery over the degraded relation in an expression
+// node, and names a CTE after that relation so the walk's CTE evidence would
+// otherwise drop the access. An earlier revision returned unmasked rows for
+// every one of these: it enumerated catalog.AnalyzedExpr against a stale module
+// directory, so twenty-two live types fell through to a default arm that only
+// logged. Two defenses close them — the schema-qualified names the parse tree
+// carries, which no CTE can shadow, and a default arm that marks the walk's
+// evidence incomplete instead of trusting it.
+//
+// Every case asserts the analyzer resolved the statement, so none of them can
+// pass by falling back to the unfiltered path.
+func TestUnresolvedColumnsSignalSurvivesUnwalkedExpressions(t *testing.T) {
+	const cte = "WITH d AS (SELECT 1 AS id) "
+	statements := map[string]string{
+		"array subscript":    cte + "SELECT (ARRAY[1,2,3])[(SELECT count(*)::int FROM public.d)]",
+		"row comparison":     cte + "SELECT 1 WHERE (1, 1) < ((SELECT count(*)::int FROM public.d), 5)",
+		"xml constructor":    cte + "SELECT xmlelement(name e, (SELECT count(*) FROM public.d))",
+		"json constructor":   cte + "SELECT json_array((SELECT count(*) FROM public.d))",
+		"json is predicate":  cte + "SELECT 1 WHERE (SELECT count(*)::text FROM public.d) IS JSON",
+		"aggregate filter":   cte + "SELECT count(*) FILTER (WHERE EXISTS (SELECT 1 FROM public.d))",
+		"aggregate order by": cte + "SELECT string_agg('x', ',' ORDER BY (SELECT count(*) FROM public.d))",
+		"tablesample arg":    cte + "SELECT 1 FROM public.d TABLESAMPLE BERNOULLI ((SELECT 1.0::float8))",
+	}
+	for name, statement := range statements {
+		t.Run(name, func(t *testing.T) {
+			span := spanFor(t, statement, degradedSchemaNamed("d"))
+			require.NotNil(t, span.UnresolvedColumnsError,
+				"a read of the degraded relation inside this expression must still be seen")
+		})
+	}
+}
+
+// TestUnresolvedColumnsSignalNotCoveredShapes pins the reads this signal cannot
+// see, so the boundary is a recorded decision rather than something a reviewer
+// rediscovers.
+//
+// These are not walk gaps. ExtractAccessTables never reports the relation at
+// all, so it is absent from span.SourceColumns too — the access-level fix
+// belongs upstream and is tracked in BYT-10076. Until then a query shaped like
+// this returns unmasked rows against a degraded snapshot.
+func TestUnresolvedColumnsSignalNotCoveredShapes(t *testing.T) {
+	notCovered := map[string]string{
+		"subquery in a FROM-clause function argument": "SELECT * FROM generate_series(1, (SELECT count(*)::int FROM public.d))",
+		"subquery inside a VALUES list":               "SELECT * FROM (VALUES ((SELECT count(*) FROM public.d))) v(x)",
+	}
+	for name, statement := range notCovered {
+		t.Run(name, func(t *testing.T) {
+			span := spanFor(t, statement, degradedSchemaNamed("d"))
+			require.Empty(t, span.SourceColumns,
+				"the premise of this gap is that the access set is empty; if this fails the gap may have been closed upstream")
+			require.Nil(t, span.UnresolvedColumnsError,
+				"documented gap: no access reported, so nothing to check (BYT-10076)")
+		})
+	}
 }

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -208,14 +208,22 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 			"a CTE bound inside a subquery shadows the physical table just as a top-level one does")
 	})
 
-	t.Run("known gap: a qualified read is skipped when a CTE shares the name", func(t *testing.T) {
+	t.Run("a qualified read is still checked when a CTE shares the name", func(t *testing.T) {
 		// PostgreSQL does not let a CTE shadow a schema-qualified name, so this
 		// statement really does read the degraded public.t. Excluding by name
-		// alone cannot see that, so the read goes unchecked. Pinned so the gap
-		// is visible; closing it needs CTE scope in ExtractAccessTables.
+		// alone would have dropped it; the qualified-reference set keeps it.
 		span := spanFor(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM public.t", degradedSchema())
-		require.Nil(t, span.UnresolvedColumnsError,
-			"documented limitation of excluding CTE names without scope tracking")
+		require.NotNil(t, span.UnresolvedColumnsError,
+			"a schema-qualified read is never shadowed by a CTE of the same name")
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
+	})
+
+	t.Run("a statement reading both the CTE and the qualified table is checked", func(t *testing.T) {
+		span := spanFor(t,
+			"WITH t AS (SELECT 1 AS n) SELECT * FROM t UNION ALL SELECT * FROM public.t",
+			degradedSchema())
+		require.NotNil(t, span.UnresolvedColumnsError,
+			"the qualified arm is a genuine read regardless of the CTE arm")
 	})
 
 	t.Run("materialized view without columns is not a degraded table", func(t *testing.T) {

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -42,8 +42,10 @@ func healthySchema() *storepb.DatabaseSchemaMetadata {
 	}
 }
 
-// degradedSchema is what a sync leaves behind when the connecting role lost its
-// privileges: the table is still listed, with no columns under it.
+// degradedSchema is what a pre-#20581 sync left behind when the connecting role
+// lost its privileges: the table is still listed, with no columns under it. A
+// current PostgreSQL sync reads pg_catalog and cannot produce this, but a
+// snapshot written by an older version and never re-synced still carries it.
 func degradedSchema() *storepb.DatabaseSchemaMetadata {
 	return &storepb.DatabaseSchemaMetadata{
 		Name: "db",
@@ -54,9 +56,10 @@ func degradedSchema() *storepb.DatabaseSchemaMetadata {
 	}
 }
 
-// degradedViewSchema is the same degradation reaching a view: the syncer fills
-// a view's column list from the same map as a table's, so a privilege-degraded
-// sync empties both.
+// degradedViewSchema is the same degradation reaching a view. The syncer fills
+// a view's column list from the same map as a table's, so a snapshot written
+// before #20581 — when the column query still ran through information_schema
+// and privileges could hide rows — empties both.
 func degradedViewSchema() *storepb.DatabaseSchemaMetadata {
 	return &storepb.DatabaseSchemaMetadata{
 		Name: "db",
@@ -166,6 +169,20 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 		require.NotNil(t, span.UnresolvedColumnsError,
 			"a view with no synced columns hides its base table's masking just as a table does")
 		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.v")
+	})
+
+	t.Run("a foreign table stripped of its columns is unresolved", func(t *testing.T) {
+		metadata := &storepb.DatabaseSchemaMetadata{
+			Name: "db",
+			Schemas: []*storepb.SchemaMetadata{{
+				Name:           "public",
+				ExternalTables: []*storepb.ExternalTableMetadata{{Name: "ft"}},
+			}},
+		}
+		span := spanFor(t, "SELECT * FROM public.ft", metadata)
+		require.NotNil(t, span.UnresolvedColumnsError,
+			"foreign tables take their columns from the same sync map as tables and views")
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.ft")
 	})
 
 	t.Run("materialized view without columns is not a degraded table", func(t *testing.T) {

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -54,6 +54,20 @@ func degradedSchema() *storepb.DatabaseSchemaMetadata {
 	}
 }
 
+// degradedViewSchema is the same degradation reaching a view: the syncer fills
+// a view's column list from the same map as a table's, so a privilege-degraded
+// sync empties both.
+func degradedViewSchema() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name:   "public",
+			Tables: []*storepb.TableMetadata{{Name: "t"}},
+			Views:  []*storepb.ViewMetadata{{Name: "v", Definition: "SELECT id, email FROM public.t"}},
+		}},
+	}
+}
+
 // partialSchema keeps some of the table's columns. Same-arity drift like this is
 // out of scope for the unresolved-columns signal; see the masking follow-up.
 func partialSchema() *storepb.DatabaseSchemaMetadata {
@@ -145,6 +159,13 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 		span := spanFor(t, "SELECT * FROM public.t", partialSchema())
 		require.Nil(t, span.UnresolvedColumnsError,
 			"a table with some columns resolves; same-arity drift needs the catalog-comparison follow-up")
+	})
+
+	t.Run("a view stripped of its columns is unresolved", func(t *testing.T) {
+		span := spanFor(t, "SELECT * FROM public.v", degradedViewSchema())
+		require.NotNil(t, span.UnresolvedColumnsError,
+			"a view with no synced columns hides its base table's masking just as a table does")
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.v")
 	})
 
 	t.Run("materialized view without columns is not a degraded table", func(t *testing.T) {

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -1,0 +1,165 @@
+package pg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+func column(name, typ string) *storepb.ColumnMetadata {
+	return &storepb.ColumnMetadata{Name: name, Type: typ}
+}
+
+// healthySchema mirrors a fully synced database: two tables with columns, a
+// view, and a materialized view with the dependency columns real sync records.
+func healthySchema() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name: "public",
+			Tables: []*storepb.TableMetadata{
+				{Name: "t", Columns: []*storepb.ColumnMetadata{column("id", "int4"), column("email", "text"), column("ssn", "text")}},
+				{Name: "o", Columns: []*storepb.ColumnMetadata{column("id", "int4"), column("amt", "numeric")}},
+			},
+			Views: []*storepb.ViewMetadata{{
+				Name:       "v",
+				Definition: "SELECT id, email FROM public.t",
+				Columns:    []*storepb.ColumnMetadata{column("id", "int4"), column("email", "text")},
+			}},
+			MaterializedViews: []*storepb.MaterializedViewMetadata{{
+				Name:       "mv",
+				Definition: "SELECT id, ssn FROM public.t",
+				DependencyColumns: []*storepb.DependencyColumn{
+					{Schema: "public", Table: "t", Column: "id"},
+					{Schema: "public", Table: "t", Column: "ssn"},
+				},
+			}},
+		}},
+	}
+}
+
+// degradedSchema is what a sync leaves behind when the connecting role lost its
+// privileges: the table is still listed, with no columns under it.
+func degradedSchema() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name:   "public",
+			Tables: []*storepb.TableMetadata{{Name: "t"}},
+		}},
+	}
+}
+
+// partialSchema keeps some of the table's columns. Same-arity drift like this is
+// out of scope for the unresolved-columns signal; see the masking follow-up.
+func partialSchema() *storepb.DatabaseSchemaMetadata {
+	return &storepb.DatabaseSchemaMetadata{
+		Name: "db",
+		Schemas: []*storepb.SchemaMetadata{{
+			Name:   "public",
+			Tables: []*storepb.TableMetadata{{Name: "t", Columns: []*storepb.ColumnMetadata{column("email", "text"), column("ssn", "text")}}},
+		}},
+	}
+}
+
+func spanFor(t *testing.T, statement string, metadata *storepb.DatabaseSchemaMetadata) *base.QuerySpan {
+	t.Helper()
+	getter, lister := buildMockDatabaseMetadataGetter([]*storepb.DatabaseSchemaMetadata{metadata})
+	span, err := GetQuerySpan(context.Background(), base.GetQuerySpanContext{
+		InstanceID:              "inst",
+		GetDatabaseMetadataFunc: getter,
+		ListDatabaseNamesFunc:   lister,
+	}, base.Statement{Text: statement}, metadata.Name, "", false)
+	require.NoError(t, err)
+	return span
+}
+
+// TestUnresolvedColumnsSignalFiresOnDegradedSnapshot covers the reported bug: a
+// table synced with no columns yields a span whose lineage cannot support
+// masking. Every one of these shapes returned unmasked rows before the signal
+// existed, and none of them sets NotFoundError, so nothing else marks them.
+func TestUnresolvedColumnsSignalFiresOnDegradedSnapshot(t *testing.T) {
+	statements := []string{
+		"SELECT * FROM public.t",
+		"SELECT email FROM public.t",
+		"SELECT t.email FROM public.t",
+		"SELECT * FROM public.t WHERE email = 'x'",
+		"SELECT id, email FROM public.t ORDER BY ssn",
+		"WITH c AS (SELECT * FROM public.t) SELECT * FROM c",
+	}
+	for _, statement := range statements {
+		t.Run(statement, func(t *testing.T) {
+			span := spanFor(t, statement, degradedSchema())
+			require.NotNil(t, span.UnresolvedColumnsError,
+				"a table with no synced columns must mark the span as unresolvable")
+			require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
+			require.Equal(t, []string{"db"}, span.UnresolvedColumnsError.Databases(),
+				"the re-sync target must survive even when column resolution produced nothing")
+		})
+	}
+}
+
+// TestUnresolvedColumnsSignalQuietOnHealthySnapshot is the false-positive guard.
+// Enforcement refuses the query, so every shape here would become a broken
+// query. The join, expression-fallback, and EXPLAIN cases are the ones that
+// defeated an earlier arity-based version of this check.
+func TestUnresolvedColumnsSignalQuietOnHealthySnapshot(t *testing.T) {
+	statements := []string{
+		"SELECT * FROM public.t",
+		"SELECT email FROM public.t",
+		"SELECT * FROM public.t NATURAL JOIN public.o",
+		"SELECT * FROM public.t JOIN public.o USING (id)",
+		"SELECT * FROM public.t LEFT JOIN public.o ON t.id = o.id",
+		"SELECT *, md5(email) FROM public.t",
+		"SELECT * FROM public.v",
+		"SELECT * FROM public.mv",
+		"WITH c AS (SELECT * FROM public.t) SELECT * FROM c",
+		"SELECT * FROM public.t UNION ALL SELECT * FROM public.t",
+		"SELECT DISTINCT ON (id) * FROM public.t",
+		"SELECT count(*) FROM public.t",
+		"SELECT 1",
+		"SELECT * FROM generate_series(1, 3)",
+		"EXPLAIN SELECT * FROM public.t",
+		"EXPLAIN ANALYZE SELECT * FROM public.t",
+		"-- plan\nEXPLAIN ANALYZE SELECT * FROM public.t",
+		"SHOW search_path",
+		"SET search_path TO public",
+	}
+	for _, statement := range statements {
+		t.Run(statement, func(t *testing.T) {
+			span := spanFor(t, statement, healthySchema())
+			require.Nil(t, span.UnresolvedColumnsError,
+				"a fully synced snapshot must never mark a span unresolvable")
+		})
+	}
+}
+
+// TestUnresolvedColumnsSignalScope pins what this signal deliberately does not
+// cover, so a later change does not silently widen or narrow it.
+func TestUnresolvedColumnsSignalScope(t *testing.T) {
+	t.Run("partial column loss is out of scope", func(t *testing.T) {
+		span := spanFor(t, "SELECT * FROM public.t", partialSchema())
+		require.Nil(t, span.UnresolvedColumnsError,
+			"a table with some columns resolves; same-arity drift needs the catalog-comparison follow-up")
+	})
+
+	t.Run("materialized view without columns is not a degraded table", func(t *testing.T) {
+		// MaterializedViewMetadata has no column list by design, so an empty one
+		// says nothing about snapshot health.
+		span := spanFor(t, "SELECT * FROM public.mv", healthySchema())
+		require.Nil(t, span.UnresolvedColumnsError)
+	})
+
+	t.Run("error names every unresolved relation", func(t *testing.T) {
+		metadata := degradedSchema()
+		metadata.Schemas[0].Tables = append(metadata.Schemas[0].Tables, &storepb.TableMetadata{Name: "o"})
+		span := spanFor(t, "SELECT * FROM public.t, public.o", metadata)
+		require.NotNil(t, span.UnresolvedColumnsError)
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.o")
+		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.t")
+	})
+}

--- a/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
+++ b/backend/plugin/parser/pg/query_span_unresolved_columns_test.go
@@ -185,6 +185,31 @@ func TestUnresolvedColumnsSignalScope(t *testing.T) {
 		require.Contains(t, span.UnresolvedColumnsError.Error(), "public.ft")
 	})
 
+	t.Run("a CTE shadowing a degraded table is not a read of it", func(t *testing.T) {
+		// ExtractAccessTables resolves the unqualified `t` to public.t without
+		// modelling CTE scope, so the access set names a table this query never
+		// reads. The query resolves entirely from the CTE.
+		span := spanFor(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM t", degradedSchema())
+		require.Nil(t, span.UnresolvedColumnsError,
+			"a query that reads only a CTE must not be refused for a same-named table")
+		require.Len(t, span.Results, 1, "the CTE resolved, so the span has real lineage")
+	})
+
+	t.Run("a CTE nested inside another CTE also shadows", func(t *testing.T) {
+		span := spanFor(t, "WITH outer_q AS (WITH t AS (SELECT 1 AS n) SELECT * FROM t) SELECT * FROM outer_q", degradedSchema())
+		require.Nil(t, span.UnresolvedColumnsError)
+	})
+
+	t.Run("known gap: a qualified read is skipped when a CTE shares the name", func(t *testing.T) {
+		// PostgreSQL does not let a CTE shadow a schema-qualified name, so this
+		// statement really does read the degraded public.t. Excluding by name
+		// alone cannot see that, so the read goes unchecked. Pinned so the gap
+		// is visible; closing it needs CTE scope in ExtractAccessTables.
+		span := spanFor(t, "WITH t AS (SELECT 1 AS n) SELECT * FROM public.t", degradedSchema())
+		require.Nil(t, span.UnresolvedColumnsError,
+			"documented limitation of excluding CTE names without scope tracking")
+	})
+
 	t.Run("materialized view without columns is not a degraded table", func(t *testing.T) {
 		// MaterializedViewMetadata has no column list by design, so an empty one
 		// says nothing about snapshot health.


### PR DESCRIPTION
Closes the masking fail-open reported by WealthNavi in BYT-10073.

## The problem

A schema sync that ran while the connecting role lacked privileges leaves a relation listed with **no columns under it**. Column-granular masking cannot be evaluated against that snapshot, but nothing said so: `SELECT *` simply produced a span with no results — indistinguishable from a query that projects nothing — and the PostgreSQL extractor never sets `NotFoundError`. The rows came back **raw**, with no error, no log, and no masking indicator.

The customer changed the role of their Bytebase DB user, saw "No Data" for a schema's columns, and got the whole schema back unmasked. Pressing **Sync Database** restored masking with no reconfiguration, which is the tell: their semantic types were never lost, only unreachable.

Export shares the same masker, so the exposure includes downloaded files.

## The fix

`QuerySpan` gains `UnresolvedColumnsError`, naming the relations a query reads whose columns the stored snapshot does not describe. The PostgreSQL extractor computes it **from the snapshot directly** rather than from analyzer output, so it reports the same condition on all three lineage paths — normal, expression fallback, and table-returning function.

Enforcement reuses the machinery already built for `NotFoundError`:

1. `queryRetry` re-syncs the databases the signal names and rebuilds the span. A merely stale snapshot repairs itself here.
2. `MaskResults` refuses only if a fresh sync still cannot describe the relation.

Re-sync targets come from the signal rather than from `SourceColumns`, so they survive when column resolution produced no entries at all. Both gates route through one predicate, `maskingBlockedByUnresolvedColumns` — they were written separately at first and drifted apart twice during review.

Tables, views, and foreign tables are all checked: the syncer fills each column list from the same map. Materialized views are excluded because their metadata carries no column list at all.

## Why not an arity check

The first attempt compared span result count against the driver's column count. Pre-review killed it, and rightly: arity is wrong in **both** directions on healthy metadata. `NATURAL JOIN` over-counts (span 5, driver 4, verified on live PostgreSQL); Doris and StarRocks always under-count; omni's expression fallback under-counts. It would have become an endless SQL-shape allowlist. A semantic signal says what it means.

## Verification

Against a live PostgreSQL and through the real span registry:

- Fires on every degraded shape — `SELECT *`, named columns, qualified columns, predicate-only, `ORDER BY`, CTEs, degraded views, degraded foreign tables.
- Silent on 19 healthy shapes, including every one that defeated the arity guard: `NATURAL JOIN`, `JOIN USING`, expression fallback, views, materialized views, unions, `DISTINCT ON`, set-returning functions, `EXPLAIN`, `EXPLAIN ANALYZE`, a comment-prefixed `EXPLAIN ANALYZE`, `SHOW`, `information_schema`, `SET`.
- The degraded tests go **RED** with the signal disabled.

## Trade-offs, stated

**A legally column-less table is refused.** `CREATE TABLE t()` is stored identically to a degraded one and the snapshot cannot separate them. Such a table still holds rows and conveys cardinality — verified: three `INSERT ... DEFAULT VALUES` gives `count(*) = 3` and a self-join of 9 — so this is a real refusal, not a free one. Refusing is the safe side of an ambiguity that has no clean discriminator.

**A permanent condition re-syncs per query.** Unthrottled, on the request path. Not introduced here — the `NotFoundError` arm above has always behaved this way, and the new arm matches it deliberately. Tracked as BYT-10074.

## Deliberately out of scope

- **Absent relations.** A relation missing from the snapshot entirely is dropped upstream before this check, so it stays unmasked. Documented at the function, not silently left.
- **Other engines.** Only the PostgreSQL extractor sets the signal. MySQL, Oracle, SQL Server, Redshift and the rest keep the fail-open; a test records which engines would act on it once their extractors set one.
- **Stale-but-plausible snapshots.** A renamed or swapped column resolves against the wrong name and raises nothing. That needs catalog-versus-metadata comparison plus a policy lookup that does not route through the metadata tree — the follow-up in BYT-10073.

## Testing

`gofmt`, `golangci-lint` (0 issues), `go vet`, and the `backend/api/v1`, `backend/plugin/parser/pg`, `backend/plugin/parser/base` suites all pass. New tests derive spans from real SQL rather than hand-built structs.

Ran through the pre-review battery plus three recheck rounds; two of the round-three findings were defects the earlier fixes introduced, both corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
