### PR TITLE
refactor: drop duplicate query data policy fetch in Query()

### DIFF
--- a/backend/api/v1/sql_service.go
+++ b/backend/api/v1/sql_service.go
@@ -347,14 +347,14 @@ func (s *SQLService) Query(ctx context.Context, req *connect.Request[v1pb.QueryR
 		}
 	}
 
-	queryDataPolicy := getEffectiveQueryDataPolicy(
+	queryRestriction := getEffectiveQueryDataPolicy(
 		ctx,
 		s.store,
 		s.licenseService,
-		0,
+		request.Limit,
 		database.ProjectID,
 	)
-	resolvedDataSourceID, err := resolveDataSourceID(ctx, instance, request.DataSourceId, statement, queryDataPolicy.AllowAdminDataSource)
+	resolvedDataSourceID, err := resolveDataSourceID(ctx, instance, request.DataSourceId, statement, queryRestriction.AllowAdminDataSource)
 	if err != nil {
 		return nil, err
 	}
@@ -384,13 +384,6 @@ func (s *SQLService) Query(ctx context.Context, req *connect.Request[v1pb.QueryR
 	}
 
 	startTime := time.Now()
-	queryRestriction := getEffectiveQueryDataPolicy(
-		ctx,
-		s.store,
-		s.licenseService,
-		request.Limit,
-		database.ProjectID,
-	)
 	queryContext := db.QueryContext{
 		Explain:              request.Explain,
 		Limit:                int(queryRestriction.MaximumResultRows),


### PR DESCRIPTION
## What

`SQLService.Query()` called `getEffectiveQueryDataPolicy` twice against the same workspace and project. This collapses them into one call.

- The first call (`limit=0`) was added by #20390 and only ever read `.AllowAdminDataSource`, to decide whether an auto-resolved DML query may use the admin data source.
- The second call (`limit=request.Limit`) fed `MaximumResultRows` / `MaximumResultSize` / `MaxQueryTimeoutInSeconds` into `db.QueryContext`.

## Why it's safe

The `limit` argument only clamps `MaximumResultRows` — it never touches `AllowAdminDataSource`, which comes straight off the workspace policy. So both calls already returned the same value for the only field the first call site read.

Verified before collapsing:

1. `resolveDataSourceID` takes the flag as a `bool` by value, so it cannot observe the clamped row limit later.
2. Nothing between the two old call sites mutates the policy or `request.Limit` — only `resolveDataSourceID`, `checkAndGetDataSourceQueriable`, `GetDataSourceDriver`, and `sqlDB.Conn`, all reads.
3. Full usage audit: `queryDataPolicy` was read exactly once (`.AllowAdminDataSource`); no other consumer depended on either struct.

One intentional behavior change: the fetch now sits above `startTime := time.Now()`, so the policy read is no longer included in the `"query finished"` / `"request finished"` debug durations. The read is policy-cache-backed, so this is microseconds — it makes the logged number marginally more accurate, not less.

No API, proto, schema, or permission-logic change. Not a breaking change.

## Testing

- `golangci-lint run --allow-parallel-runners` — 0 issues
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go` — OK
- `go test -count=1 ./backend/api/v1/...` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)