### PR TITLE
fix(tidb): sync fails on TiDB Cloud version strings (BYT-10062)

### DIFF
--- a/backend/plugin/db/tidb/sync.go
+++ b/backend/plugin/db/tidb/sync.go
@@ -333,16 +333,8 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 	}
 
 	// Query check constraint info.
-	// information_schema.CHECK_CONSTRAINTS was added in TiDB v7.4.0. Gate on the TiDB
-	// version rather than the MySQL compatibility prefix: TiDB reports 8.0.11 (also since
-	// v7.4.0, before which it reported 5.7.25), but MySQL itself only added that table in
-	// 8.0.16, so reading the prefix as a MySQL version understates what TiDB supports.
 	checkMap := make(map[db.TableKey][]*storepb.CheckConstraintMetadata)
-	hasCheckConstraints, err := tidbVersionAtLeast(version, "7.4.0")
-	if err != nil {
-		return nil, err
-	}
-	if hasCheckConstraints {
+	if supportsCheckConstraintTable(version) {
 		checkMap, err = d.getCheckConstraintList(ctx, d.databaseName)
 		if err != nil {
 			return nil, err
@@ -837,21 +829,39 @@ func (d *Driver) getCheckConstraintList(ctx context.Context, databaseName string
 	return checkMap, nil
 }
 
-// tidbVersionAtLeast checks if a TiDB version string (e.g., "v7.4.0") is
-// greater than or equal to the given threshold (e.g., "7.4.0"). TiDB Cloud
-// calendar versions (e.g., "CLOUD.202603.4") carry no upstream semver to compare,
-// but every TiDB Cloud release postdates the versions gated here, so they satisfy
-// any threshold.
-func tidbVersionAtLeast(version, threshold string) (bool, error) {
-	if isCloudVersion(version) {
-		return true, nil
+var (
+	// TiDB Self-Managed and TiDB Cloud Starter report the upstream semver, e.g.
+	// "8.0.11-TiDB-v8.5.0" and "8.0.11-TiDB-v7.5.2-serverless".
+	tidbSemverRegex = regexp.MustCompile(`v\d+\.\d+\.\d+`)
+	// TiDB Cloud reports a calendar version carrying no upstream semver, e.g.
+	// "8.0.11-TiDB-CLOUD.202603.4".
+	tidbCloudVersionRegex = regexp.MustCompile(`CLOUD\.\d+\.\d+`)
+)
+
+// supportsCheckConstraintTable reports whether the server exposes
+// information_schema.CHECK_CONSTRAINTS, which TiDB added in v7.4.0. rawVersion is the
+// verbatim VERSION() output, carrying both a MySQL compatibility version and the TiDB
+// version.
+//
+// Gate on the TiDB half, not the MySQL prefix: TiDB reports the 8.0.11 prefix from v7.4.0
+// onward (5.7.25 before that), but MySQL itself only added the table in 8.0.16, so
+// reading that prefix as a real MySQL version understates what TiDB supports. TiDB Cloud
+// reports a calendar version in place of the semver, and every TiDB Cloud release
+// postdates v7.4.0.
+//
+// A string carrying no recognizable TiDB version — a custom server-version, say — counts
+// as unsupported, so sync omits check constraints instead of failing outright.
+func supportsCheckConstraintTable(rawVersion string) bool {
+	loc := tidbSemverRegex.FindStringIndex(rawVersion)
+	if loc == nil {
+		return tidbCloudVersionRegex.MatchString(rawVersion)
 	}
-	v := strings.TrimPrefix(version, "v")
-	semVersion, err := semver.Make(v)
+	// Skip the leading "v" that semver.Make does not accept.
+	semVersion, err := semver.Make(rawVersion[loc[0]+1 : loc[1]])
 	if err != nil {
-		return false, errors.Wrapf(err, "failed to parse TiDB version %q", version)
+		return false
 	}
-	return semVersion.GE(semver.MustParse(threshold)), nil
+	return semVersion.GE(semver.MustParse("7.4.0"))
 }
 
 func stripSingleQuote(s string) string {

--- a/backend/plugin/db/tidb/sync.go
+++ b/backend/plugin/db/tidb/sync.go
@@ -835,8 +835,14 @@ func (d *Driver) getCheckConstraintList(ctx context.Context, databaseName string
 }
 
 // tidbVersionAtLeast checks if a TiDB version string (e.g., "v7.4.0") is
-// greater than or equal to the given threshold (e.g., "7.4.0").
+// greater than or equal to the given threshold (e.g., "7.4.0"). TiDB Cloud
+// calendar versions (e.g., "CLOUD.202603.4") carry no upstream semver to compare,
+// but every TiDB Cloud release postdates the versions gated here, so they satisfy
+// any threshold.
 func tidbVersionAtLeast(version, threshold string) (bool, error) {
+	if isCloudVersion(version) {
+		return true, nil
+	}
 	v := strings.TrimPrefix(version, "v")
 	semVersion, err := semver.Make(v)
 	if err != nil {

--- a/backend/plugin/db/tidb/sync.go
+++ b/backend/plugin/db/tidb/sync.go
@@ -830,38 +830,42 @@ func (d *Driver) getCheckConstraintList(ctx context.Context, databaseName string
 }
 
 var (
-	// TiDB Self-Managed and TiDB Cloud Starter report the upstream semver, e.g.
-	// "8.0.11-TiDB-v8.5.0" and "8.0.11-TiDB-v7.5.2-serverless".
+	// The TiDB version within a VERSION() string, e.g. "8.0.11-TiDB-v8.5.0" and
+	// "8.0.11-TiDB-v7.5.2-serverless".
 	tidbSemverRegex = regexp.MustCompile(`v\d+\.\d+\.\d+`)
-	// TiDB Cloud reports a calendar version carrying no upstream semver, e.g.
-	// "8.0.11-TiDB-CLOUD.202603.4".
-	tidbCloudVersionRegex = regexp.MustCompile(`CLOUD\.\d+\.\d+`)
+	// The leading MySQL compatibility version every TiDB build reports.
+	mysqlCompatVersionRegex = regexp.MustCompile(`^\d+\.\d+\.\d+`)
 )
 
 // supportsCheckConstraintTable reports whether the server exposes
 // information_schema.CHECK_CONSTRAINTS, which TiDB added in v7.4.0. rawVersion is the
-// verbatim VERSION() output, carrying both a MySQL compatibility version and the TiDB
-// version.
+// verbatim VERSION() output, carrying a MySQL compatibility version and, usually, the
+// TiDB version: "8.0.11-TiDB-v8.5.0".
 //
-// Gate on the TiDB half, not the MySQL prefix: TiDB reports the 8.0.11 prefix from v7.4.0
-// onward (5.7.25 before that), but MySQL itself only added the table in 8.0.16, so
-// reading that prefix as a real MySQL version understates what TiDB supports. TiDB Cloud
-// reports a calendar version in place of the semver, and every TiDB Cloud release
-// postdates v7.4.0.
+// The TiDB version decides whenever it is readable. When it is not — TiDB Cloud reports a
+// calendar version ("8.0.11-TiDB-CLOUD.202603.4"), and a custom server-version can drop it
+// altogether — fall back to the MySQL prefix, which marks the same boundary: TiDB moved
+// that prefix from 5.7.25 to 8.0.11 in v7.4.0, the very release that added the table.
 //
-// A string carrying no recognizable TiDB version — a custom server-version, say — counts
-// as unsupported, so sync omits check constraints instead of failing outright.
+// Do not read the prefix as a real MySQL version. MySQL added the table in 8.0.16, so
+// comparing against that would answer false for every TiDB build, all of which report
+// 8.0.11.
 func supportsCheckConstraintTable(rawVersion string) bool {
-	loc := tidbSemverRegex.FindStringIndex(rawVersion)
-	if loc == nil {
-		return tidbCloudVersionRegex.MatchString(rawVersion)
+	if loc := tidbSemverRegex.FindStringIndex(rawVersion); loc != nil {
+		// Skip the leading "v" that semver.Make does not accept.
+		if tidbVersion, err := semver.Make(rawVersion[loc[0]+1 : loc[1]]); err == nil {
+			return tidbVersion.GE(semver.MustParse("7.4.0"))
+		}
 	}
-	// Skip the leading "v" that semver.Make does not accept.
-	semVersion, err := semver.Make(rawVersion[loc[0]+1 : loc[1]])
+	loc := mysqlCompatVersionRegex.FindStringIndex(rawVersion)
+	if loc == nil {
+		return false
+	}
+	mysqlVersion, err := semver.Make(rawVersion[loc[0]:loc[1]])
 	if err != nil {
 		return false
 	}
-	return semVersion.GE(semver.MustParse("7.4.0"))
+	return mysqlVersion.GE(semver.MustParse("8.0.0"))
 }
 
 func stripSingleQuote(s string) string {

--- a/backend/plugin/db/tidb/sync.go
+++ b/backend/plugin/db/tidb/sync.go
@@ -333,7 +333,10 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 	}
 
 	// Query check constraint info.
-	// information_schema.CHECK_CONSTRAINTS was added in TiDB v7.4.0.
+	// information_schema.CHECK_CONSTRAINTS was added in TiDB v7.4.0. Gate on the TiDB
+	// version rather than the MySQL compatibility prefix: TiDB reports 8.0.11 (also since
+	// v7.4.0, before which it reported 5.7.25), but MySQL itself only added that table in
+	// 8.0.16, so reading the prefix as a MySQL version understates what TiDB supports.
 	checkMap := make(map[db.TableKey][]*storepb.CheckConstraintMetadata)
 	hasCheckConstraints, err := tidbVersionAtLeast(version, "7.4.0")
 	if err != nil {

--- a/backend/plugin/db/tidb/sync_test.go
+++ b/backend/plugin/db/tidb/sync_test.go
@@ -304,21 +304,29 @@ func TestSupportsCheckConstraintTable(t *testing.T) {
 		want    bool
 	}{
 		// information_schema.CHECK_CONSTRAINTS landed in TiDB v7.4.0, the same release
-		// that moved the reported MySQL prefix from 5.7.25 to 8.0.11.
+		// that moved the reported MySQL prefix from 5.7.25 to 8.0.11. The TiDB version
+		// decides whenever it is readable.
 		{version: "5.7.25-TiDB-v7.1.1", want: false},
 		{version: "5.7.25-TiDB-v7.2.0", want: false},
 		{version: "5.7.25-TiDB-v7.3.0", want: false},
 		{version: "8.0.11-TiDB-v7.4.0", want: true},
 		{version: "8.0.11-TiDB-v8.5.0", want: true},
 		{version: "8.0.11-TiDB-v7.5.2-serverless", want: true},
-		// TiDB Cloud reports a calendar version carrying no upstream semver.
+		// No readable TiDB version, so the MySQL prefix decides. TiDB Cloud reports a
+		// calendar version; a custom server-version can drop the TiDB half entirely.
 		{version: "8.0.11-TiDB-CLOUD.202603.4", want: true},
-		// The MySQL prefix alone must not decide the gate: MySQL added the table in
-		// 8.0.16, so treating 8.0.11 as a real MySQL version would answer false here.
-		{version: "8.0.11", want: false},
-		// A custom server-version carries no recognizable TiDB version.
+		{version: "5.7.25-TiDB-CLOUD.202603.4", want: false},
+		{version: "8.0.11", want: true},
 		{version: "5.7.25", want: false},
+		// A future prefix bump must not regress.
+		{version: "8.4.0-TiDB-CLOUD.202701.1", want: true},
+		// The TiDB version wins over the prefix when both are readable.
+		{version: "8.0.11-TiDB-v7.3.0", want: false},
+		// MySQL added the table in 8.0.16; comparing the prefix against that would
+		// answer false for every TiDB build, all of which report 8.0.11.
+		{version: "8.0.11-TiDB-CLOUD.202512.1", want: true},
 		{version: "", want: false},
+		{version: "not-a-version", want: false},
 	}
 
 	for _, tc := range tests {

--- a/backend/plugin/db/tidb/sync_test.go
+++ b/backend/plugin/db/tidb/sync_test.go
@@ -297,3 +297,33 @@ func TestStripSingleQuote(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportsCheckConstraintTable(t *testing.T) {
+	tests := []struct {
+		version string
+		want    bool
+	}{
+		// information_schema.CHECK_CONSTRAINTS landed in TiDB v7.4.0, the same release
+		// that moved the reported MySQL prefix from 5.7.25 to 8.0.11.
+		{version: "5.7.25-TiDB-v7.1.1", want: false},
+		{version: "5.7.25-TiDB-v7.2.0", want: false},
+		{version: "5.7.25-TiDB-v7.3.0", want: false},
+		{version: "8.0.11-TiDB-v7.4.0", want: true},
+		{version: "8.0.11-TiDB-v8.5.0", want: true},
+		{version: "8.0.11-TiDB-v7.5.2-serverless", want: true},
+		// TiDB Cloud reports a calendar version carrying no upstream semver.
+		{version: "8.0.11-TiDB-CLOUD.202603.4", want: true},
+		// The MySQL prefix alone must not decide the gate: MySQL added the table in
+		// 8.0.16, so treating 8.0.11 as a real MySQL version would answer false here.
+		{version: "8.0.11", want: false},
+		// A custom server-version carries no recognizable TiDB version.
+		{version: "5.7.25", want: false},
+		{version: "", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.version, func(t *testing.T) {
+			require.Equal(t, tc.want, supportsCheckConstraintTable(tc.version))
+		})
+	}
+}

--- a/backend/plugin/db/tidb/tidb.go
+++ b/backend/plugin/db/tidb/tidb.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
-	"regexp"
 	"strings"
 	"time"
 
@@ -155,7 +154,10 @@ func (d *Driver) GetDB() *sql.DB {
 	return d.db
 }
 
-// getVersion gets the version.
+// getVersion returns the verbatim VERSION() output, e.g. "8.0.11-TiDB-v8.5.0". It is
+// stored and displayed as-is; callers that gate behavior on a version parse it
+// themselves, so a version string we do not recognize costs a feature rather than the
+// whole sync.
 func (d *Driver) getVersion(ctx context.Context) (string, error) {
 	query := "SELECT VERSION()"
 	var version string
@@ -166,32 +168,7 @@ func (d *Driver) getVersion(ctx context.Context) (string, error) {
 		return "", util.FormatErrorWithQuery(err, query)
 	}
 
-	return parseVersion(version)
-}
-
-var (
-	// TiDB Self-Managed and TiDB Cloud Starter report the upstream semver, e.g.
-	// "8.0.11-TiDB-v8.5.0" and "8.0.11-TiDB-v7.5.2-serverless".
-	tidbSemverRegex = regexp.MustCompile(`v\d+\.\d+\.\d+`)
-	// TiDB Cloud reports a calendar version carrying no upstream semver, e.g.
-	// "8.0.11-TiDB-CLOUD.202603.4".
-	tidbCloudVersionRegex = regexp.MustCompile(`CLOUD\.\d+\.\d+`)
-)
-
-func parseVersion(version string) (string, error) {
-	if loc := tidbSemverRegex.FindStringIndex(version); loc != nil {
-		return version[loc[0]:loc[1]], nil
-	}
-	if loc := tidbCloudVersionRegex.FindStringIndex(version); loc != nil {
-		return version[loc[0]:loc[1]], nil
-	}
-	return "", errors.Errorf("failed to parse version %q", version)
-}
-
-// isCloudVersion reports whether a version returned by parseVersion is a TiDB Cloud
-// calendar version, e.g. "CLOUD.202603.4".
-func isCloudVersion(version string) bool {
-	return strings.HasPrefix(version, "CLOUD.")
+	return version, nil
 }
 
 func buildExecuteCommands(statement string) ([]base.Statement, error) {

--- a/backend/plugin/db/tidb/tidb.go
+++ b/backend/plugin/db/tidb/tidb.go
@@ -169,12 +169,29 @@ func (d *Driver) getVersion(ctx context.Context) (string, error) {
 	return parseVersion(version)
 }
 
+var (
+	// TiDB Self-Managed and TiDB Cloud Starter report the upstream semver, e.g.
+	// "8.0.11-TiDB-v8.5.0" and "8.0.11-TiDB-v7.5.2-serverless".
+	tidbSemverRegex = regexp.MustCompile(`v\d+\.\d+\.\d+`)
+	// TiDB Cloud reports a calendar version carrying no upstream semver, e.g.
+	// "8.0.11-TiDB-CLOUD.202603.4".
+	tidbCloudVersionRegex = regexp.MustCompile(`CLOUD\.\d+\.\d+`)
+)
+
 func parseVersion(version string) (string, error) {
-	// Examples: 8.0.11-TiDB-v8.5.0, 8.0.11-TiDB-v7.5.2-serverless.
-	if loc := regexp.MustCompile(`v\d+\.\d+\.\d+`).FindStringIndex(version); loc != nil {
+	if loc := tidbSemverRegex.FindStringIndex(version); loc != nil {
+		return version[loc[0]:loc[1]], nil
+	}
+	if loc := tidbCloudVersionRegex.FindStringIndex(version); loc != nil {
 		return version[loc[0]:loc[1]], nil
 	}
 	return "", errors.Errorf("failed to parse version %q", version)
+}
+
+// isCloudVersion reports whether a version returned by parseVersion is a TiDB Cloud
+// calendar version, e.g. "CLOUD.202603.4".
+func isCloudVersion(version string) bool {
+	return strings.HasPrefix(version, "CLOUD.")
 }
 
 func buildExecuteCommands(statement string) ([]base.Statement, error) {

--- a/backend/plugin/db/tidb/tidb_test.go
+++ b/backend/plugin/db/tidb/tidb_test.go
@@ -57,6 +57,7 @@ func TestParseVersion(t *testing.T) {
 	tests := []struct {
 		version string
 		want    string
+		wantErr bool
 	}{
 		{
 			version: "8.0.11-TiDB-v8.5.0",
@@ -66,12 +67,25 @@ func TestParseVersion(t *testing.T) {
 			version: "8.0.11-TiDB-v7.5.2-serverless",
 			want:    "v7.5.2",
 		},
+		{
+			// TiDB Cloud reports a calendar version carrying no upstream semver.
+			version: "8.0.11-TiDB-CLOUD.202603.4",
+			want:    "CLOUD.202603.4",
+		},
+		{
+			version: "8.0.11",
+			wantErr: true,
+		},
 	}
 
 	a := require.New(t)
 	for _, tc := range tests {
 		version, err := parseVersion(tc.version)
-		a.NoError(err)
+		if tc.wantErr {
+			a.Error(err, "version=%s", tc.version)
+			continue
+		}
+		a.NoError(err, "version=%s", tc.version)
 		a.Equal(tc.want, version)
 	}
 }
@@ -89,6 +103,8 @@ func TestTiDBVersionAtLeast(t *testing.T) {
 		{version: "v7.5.2", threshold: "7.4.0", want: true},
 		{version: "v8.0.0", threshold: "7.4.0", want: true},
 		{version: "v8.5.0", threshold: "7.4.0", want: true},
+		// TiDB Cloud calendar versions postdate every semver gated here.
+		{version: "CLOUD.202603.4", threshold: "7.4.0", want: true},
 	}
 
 	a := require.New(t)

--- a/backend/plugin/db/tidb/tidb_test.go
+++ b/backend/plugin/db/tidb/tidb_test.go
@@ -53,68 +53,6 @@ func TestGetTiDBConnectionRejectsAllowAllFiles(t *testing.T) {
 	require.Contains(t, err.Error(), "allowAllFiles")
 }
 
-func TestParseVersion(t *testing.T) {
-	tests := []struct {
-		version string
-		want    string
-		wantErr bool
-	}{
-		{
-			version: "8.0.11-TiDB-v8.5.0",
-			want:    "v8.5.0",
-		},
-		{
-			version: "8.0.11-TiDB-v7.5.2-serverless",
-			want:    "v7.5.2",
-		},
-		{
-			// TiDB Cloud reports a calendar version carrying no upstream semver.
-			version: "8.0.11-TiDB-CLOUD.202603.4",
-			want:    "CLOUD.202603.4",
-		},
-		{
-			version: "8.0.11",
-			wantErr: true,
-		},
-	}
-
-	a := require.New(t)
-	for _, tc := range tests {
-		version, err := parseVersion(tc.version)
-		if tc.wantErr {
-			a.Error(err, "version=%s", tc.version)
-			continue
-		}
-		a.NoError(err, "version=%s", tc.version)
-		a.Equal(tc.want, version)
-	}
-}
-
-func TestTiDBVersionAtLeast(t *testing.T) {
-	tests := []struct {
-		version   string
-		threshold string
-		want      bool
-	}{
-		{version: "v7.1.1", threshold: "7.4.0", want: false},
-		{version: "v7.2.0", threshold: "7.4.0", want: false},
-		{version: "v7.3.0", threshold: "7.4.0", want: false},
-		{version: "v7.4.0", threshold: "7.4.0", want: true},
-		{version: "v7.5.2", threshold: "7.4.0", want: true},
-		{version: "v8.0.0", threshold: "7.4.0", want: true},
-		{version: "v8.5.0", threshold: "7.4.0", want: true},
-		// TiDB Cloud calendar versions postdate every semver gated here.
-		{version: "CLOUD.202603.4", threshold: "7.4.0", want: true},
-	}
-
-	a := require.New(t)
-	for _, tc := range tests {
-		got, err := tidbVersionAtLeast(tc.version, tc.threshold)
-		a.NoError(err)
-		a.Equal(tc.want, got, "version=%s threshold=%s", tc.version, tc.threshold)
-	}
-}
-
 func TestBuildExecuteCommandsNormalizesDelimiter(t *testing.T) {
 	statement := "DELIMITER //\nCREATE PROCEDURE p()\nBEGIN\n  SELECT 1;\nEND//\nDELIMITER ;\n"
 


### PR DESCRIPTION
## What broke

TiDB Cloud reports a calendar version carrying no upstream semver:

```
8.0.11-TiDB-CLOUD.202603.4
```

`parseVersion` only matched `v\d+\.\d+\.\d+`. That string contains no lowercase `v` at all, so the parse returned an error — and because `getVersion` is the first call in both `SyncInstance` and `SyncDBSchema`, the error aborted the **entire instance and schema sync** for every TiDB Cloud instance.

## Root cause

The version was parsed on the way to storage, before anything knew whether a caller actually needed it parsed. In fact only one caller did: a single feature gate deciding whether to read `information_schema.CHECK_CONSTRAINTS`. Everything else — `InstanceMetadata.Version`, `EngineVersion` in the v1 API, the instance panel — just displays the string.

So an unparseable version cost the whole sync to protect one boolean.

## The change

**1. `getVersion` returns `VERSION()` verbatim.** Nothing parses on the display path, so an unrecognized format can no longer fail a sync.

**2. Parsing happens only at the gate.** `parseVersion`, `isCloudVersion`, and `tidbVersionAtLeast` collapse into one function answering the caller's actual question:

```go
func supportsCheckConstraintTable(rawVersion string) bool
```

**3. The gate reads two signals.** The TiDB version decides whenever it is readable; otherwise the MySQL compatibility prefix does. These mark the same boundary *by construction*: TiDB moved that prefix from `5.7.25` to `8.0.11` in v7.4.0 — the very release that added the table.

That fallback is what makes this robust rather than a patch. `8.0.11-TiDB-CLOUD.202603.4` now passes on its `8.0.11` prefix, not on a pattern matching this particular calendar format, so a future change to that format cannot reintroduce the same bug. A custom `server-version` that hides the TiDB half is covered by the same path.

### Two thresholds worth reviewing

- The prefix is compared against **8.0.0**, not MySQL's real **8.0.16** where `CHECK_CONSTRAINTS` was added upstream. Every TiDB build reports `8.0.11`, so the stricter threshold would answer `false` for all of them and silently drop every check constraint.
- The TiDB threshold stays **7.4.0**, not 7.2.0. TiDB v7.2.0 added CHECK constraint *support*, but the `information_schema` table itself landed in v7.4.0.

## Breaking Changes

**`EngineVersion` changes format for TiDB instances.** It now reports the full `VERSION()` output rather than a trimmed fragment:

| Before | After |
|---|---|
| `v8.5.0` | `8.0.11-TiDB-v8.5.0` |
| (sync failed) | `8.0.11-TiDB-CLOUD.202603.4` |

Existing instances pick this up on their next sync. It is visible in the instance detail panel and in the `EngineVersion` field of the v1 API, so an integration parsing that field for TiDB engines would see a different string.

I verified nothing in this codebase compares it: the frontend's two `allowGhostForDatabase` helpers gate on `Engine.MYSQL`/`Engine.MARIADB` only, and the SDL migration paths that do semver-parse a stored version (`mysqlVersionFor`) are registered for `POSTGRES`/`COCKROACHDB`/`MYSQL`, not `TIDB`.

Labeling this conservatively — happy to drop the label if maintainers read it as additive.

## Known gap

A server reporting an `8.0+` prefix while actually running TiDB < 7.4.0 — someone spoofing `server-version` on an old cluster — will attempt the query and fail the sync when the table is absent. This needs both an old cluster (v7.4.0 shipped Oct 2023) and a spoofed prefix. Closing it would mean swallowing errors from `getCheckConstraintList`, which would also mask genuine failures like permission errors, so I left it deliberate rather than silent.

## Testing

`TestSupportsCheckConstraintTable` covers 15 cases: the pre-7.4.0 range, the 7.4.0 boundary, serverless, the cloud string, a future prefix bump, precedence (`8.0.11-TiDB-v7.3.0 → false`, the TiDB version wins over the prefix), the reverse fallback (`5.7.25-TiDB-CLOUD.202603.4 → false`), and unparseable input.

- `gofmt` clean; `go vet` clean
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go` succeeds
- `golangci-lint` v2.12.2 (matching this repo's pinned CI version): **lint-neutral** — the only findings in the package are 5 pre-existing `revive` `unhandled-error` reports on `strings.Builder.WriteString` in `tidb_test.go`, which reproduce identically on `origin/main` (at lines 114–119; removing two obsolete tests shifted them to 68–73). My diff touches none of those lines.
- Package tests pass except `TestExecuteCreateIndexInTransaction` and `TestExecutePreparedStatementFlowWithCreateIndexString`, which fail on `rootless Docker not found` in this environment before any code runs.

I could not reproduce the change against a live TiDB Cloud Essential instance — the cloud version string here came from the issue report, not from a connection I made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ER5VNBb5ceCk3BQrFggHeo)_