### PR TITLE
fix(parser/doris): unblock read-only Doris queries in SQL Editor (BYT-10070)

### DIFF
--- a/backend/plugin/parser/doris/query_test.go
+++ b/backend/plugin/parser/doris/query_test.go
@@ -107,6 +107,70 @@ func TestValidateQuery(t *testing.T) {
 			valid:       true,
 			description: "CTE-prefixed SELECT is read-only",
 		},
+		{
+			statement:   "SELECT EXTRACT(YEAR FROM MONTHS_ADD(NOW(), -1))",
+			valid:       true,
+			description: "EXTRACT(unit FROM expr) is read-only",
+		},
+		{
+			statement: `SELECT EXTRACT(
+  YEAR
+  FROM
+    MONTHS_ADD(NOW(), -1)
+)`,
+			valid:       true,
+			description: "Multi-line EXTRACT is read-only",
+		},
+		{
+			statement:   "WITH c AS (SELECT EXTRACT(MONTH FROM created_at) m FROM t) SELECT * FROM c",
+			valid:       true,
+			description: "EXTRACT inside a CTE body is read-only",
+		},
+		{
+			statement:   "SELECT TRIM(s), LEFT(s, 2), RIGHT(s, 2), IF(a, 1, 2) FROM t",
+			valid:       true,
+			description: "Reserved keywords used as function names are read-only",
+		},
+		{
+			statement:   "SELECT DATABASE()",
+			valid:       true,
+			description: "DATABASE() is read-only",
+		},
+		{
+			statement:   "SELECT CURRENT_TIMESTAMP(3)",
+			valid:       true,
+			description: "Datetime function with precision is read-only",
+		},
+		{
+			statement:   "SELECT @@version_comment, @@session.query_timeout, @uservar",
+			valid:       true,
+			description: "Session and user variables are read-only",
+		},
+		{
+			statement:   "SELECT [1, 2, 3], {'a': 1}, x'1f', b'101'",
+			valid:       true,
+			description: "Array, map, hex and bit literals are read-only",
+		},
+		{
+			statement:   "SELECT array_map(x -> x + 1, arr) FROM t",
+			valid:       true,
+			description: "Lambda in a higher-order array function is read-only",
+		},
+		{
+			statement:   "SELECT /*+ SET_VAR(query_timeout = 100) */ a FROM t",
+			valid:       true,
+			description: "Statement with an optimizer hint is read-only",
+		},
+		{
+			statement:   "SELECT a, SUM(b) FROM t GROUP BY CUBE(a)",
+			valid:       true,
+			description: "GROUP BY CUBE is read-only",
+		},
+		{
+			statement:   "SELECT CONVERT(s USING utf8), CONVERT(s, SIGNED), BINARY s FROM t",
+			valid:       true,
+			description: "CONVERT and BINARY forms are read-only",
+		},
 	}
 
 	for _, tc := range tests {
@@ -137,6 +201,10 @@ func TestValidateQuery(t *testing.T) {
 		{
 			statement:   "WITH c AS (SELECT 1) DELETE FROM t",
 			description: "CTE-prefixed DELETE must be rejected",
+		},
+		{
+			statement:   "WITH c AS (SELECT 1) INSERT INTO t SELECT * FROM c",
+			description: "CTE-prefixed INSERT must be rejected",
 		},
 		{
 			statement:   "SELECT a > (select max(a) from t1) FROM",

--- a/backend/plugin/parser/starrocks/query_test.go
+++ b/backend/plugin/parser/starrocks/query_test.go
@@ -107,6 +107,70 @@ func TestValidateQuery(t *testing.T) {
 			valid:       true,
 			description: "CTE-prefixed SELECT is read-only",
 		},
+		{
+			statement:   "SELECT EXTRACT(YEAR FROM MONTHS_ADD(NOW(), -1))",
+			valid:       true,
+			description: "EXTRACT(unit FROM expr) is read-only",
+		},
+		{
+			statement: `SELECT EXTRACT(
+  YEAR
+  FROM
+    MONTHS_ADD(NOW(), -1)
+)`,
+			valid:       true,
+			description: "Multi-line EXTRACT is read-only",
+		},
+		{
+			statement:   "WITH c AS (SELECT EXTRACT(MONTH FROM created_at) m FROM t) SELECT * FROM c",
+			valid:       true,
+			description: "EXTRACT inside a CTE body is read-only",
+		},
+		{
+			statement:   "SELECT TRIM(s), LEFT(s, 2), RIGHT(s, 2), IF(a, 1, 2) FROM t",
+			valid:       true,
+			description: "Reserved keywords used as function names are read-only",
+		},
+		{
+			statement:   "SELECT DATABASE()",
+			valid:       true,
+			description: "DATABASE() is read-only",
+		},
+		{
+			statement:   "SELECT CURRENT_TIMESTAMP(3)",
+			valid:       true,
+			description: "Datetime function with precision is read-only",
+		},
+		{
+			statement:   "SELECT @@version_comment, @@session.query_timeout, @uservar",
+			valid:       true,
+			description: "Session and user variables are read-only",
+		},
+		{
+			statement:   "SELECT [1, 2, 3], {'a': 1}, x'1f', b'101'",
+			valid:       true,
+			description: "Array, map, hex and bit literals are read-only",
+		},
+		{
+			statement:   "SELECT array_map(x -> x + 1, arr) FROM t",
+			valid:       true,
+			description: "Lambda in a higher-order array function is read-only",
+		},
+		{
+			statement:   "SELECT /*+ SET_VAR(query_timeout = 100) */ a FROM t",
+			valid:       true,
+			description: "Statement with an optimizer hint is read-only",
+		},
+		{
+			statement:   "SELECT a, SUM(b) FROM t GROUP BY CUBE(a)",
+			valid:       true,
+			description: "GROUP BY CUBE is read-only",
+		},
+		{
+			statement:   "SELECT CONVERT(s USING utf8), CONVERT(s, SIGNED), BINARY s FROM t",
+			valid:       true,
+			description: "CONVERT and BINARY forms are read-only",
+		},
 	}
 
 	for _, tc := range tests {
@@ -137,6 +201,10 @@ func TestValidateQuery(t *testing.T) {
 		{
 			statement:   "WITH c AS (SELECT 1) DELETE FROM t",
 			description: "CTE-prefixed DELETE must be rejected",
+		},
+		{
+			statement:   "WITH c AS (SELECT 1) INSERT INTO t SELECT * FROM c",
+			description: "CTE-prefixed INSERT must be rejected",
 		},
 		{
 			statement:   "SELECT a > (select max(a) from t1) FROM",

--- a/backend/plugin/parser/starrocks/query_test.go
+++ b/backend/plugin/parser/starrocks/query_test.go
@@ -147,7 +147,9 @@ func TestValidateQuery(t *testing.T) {
 			description: "Session and user variables are read-only",
 		},
 		{
-			statement:   "SELECT [1, 2, 3], {'a': 1}, x'1f', b'101'",
+			// StarRocks requires the MAP prefix on a map constructor; a bare
+			// {...} is not a literal there.
+			statement:   "SELECT [1, 2, 3], map{'a': 1}, x'1f', b'101'",
 			valid:       true,
 			description: "Array, map, hex and bit literals are read-only",
 		},
@@ -167,7 +169,9 @@ func TestValidateQuery(t *testing.T) {
 			description: "GROUP BY CUBE is read-only",
 		},
 		{
-			statement:   "SELECT CONVERT(s USING utf8), CONVERT(s, SIGNED), BINARY s FROM t",
+			// StarRocks has no USING charset clause; CONVERT(x, type) and the
+			// BINARY operator are both accepted.
+			statement:   "SELECT CONVERT(s, SIGNED), BINARY s FROM t",
 			valid:       true,
 			description: "CONVERT and BINARY forms are read-only",
 		},

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260820065957-85eec94e0c11
+	github.com/bytebase/omni v0.0.0-20260820073230-a3778c31eacb
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260820073230-a3778c31eacb
+	github.com/bytebase/omni v0.0.0-20260820081141-f107d677cca3
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260817095119-ad01165bf7db
+	github.com/bytebase/omni v0.0.0-20260820065957-85eec94e0c11
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735 h1:v8y6mXeHmYVsdM
 github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735/go.mod h1:vTHjcvfn8Pmf65WjnV1ytTCYyC7xNhFjrniv4YWvtA8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260820065957-85eec94e0c11 h1:pNIntMVvLW/vi9BK9VA00BRbA2SBun2t791yyN0ucXA=
-github.com/bytebase/omni v0.0.0-20260820065957-85eec94e0c11/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260820073230-a3778c31eacb h1:ucQtBAKSTYffEXbFfv8Tw8Kqn9F8z3fHq1h6DGrHsXU=
+github.com/bytebase/omni v0.0.0-20260820073230-a3778c31eacb/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735 h1:v8y6mXeHmYVsdM
 github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735/go.mod h1:vTHjcvfn8Pmf65WjnV1ytTCYyC7xNhFjrniv4YWvtA8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260817095119-ad01165bf7db h1:K2pZNwZi1YfwYrhWrkYjBUBLiWa/0ugIPc1Zd2tDxDQ=
-github.com/bytebase/omni v0.0.0-20260817095119-ad01165bf7db/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260820065957-85eec94e0c11 h1:pNIntMVvLW/vi9BK9VA00BRbA2SBun2t791yyN0ucXA=
+github.com/bytebase/omni v0.0.0-20260820065957-85eec94e0c11/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735 h1:v8y6mXeHmYVsdM
 github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735/go.mod h1:vTHjcvfn8Pmf65WjnV1ytTCYyC7xNhFjrniv4YWvtA8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260820073230-a3778c31eacb h1:ucQtBAKSTYffEXbFfv8Tw8Kqn9F8z3fHq1h6DGrHsXU=
-github.com/bytebase/omni v0.0.0-20260820073230-a3778c31eacb/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260820081141-f107d677cca3 h1:gbpLT03nnD5xVfy22UzoxUMaN5ymmcXoYx3ghgYNNO8=
+github.com/bytebase/omni v0.0.0-20260820081141-f107d677cca3/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
Fixes [BYT-10070](https://linear.app/bytebase/issue/BYT-10070/fix-doris-sql-editor-rejection-of-read-only-extract-queries).

Depends on [bytebase/omni#400](https://github.com/bytebase/omni/pull/400), **merged** as `f107d677`; `go.mod` is pinned to that commit on `main`.

## What changed

CG Tech could not run a valid read-only Doris query in SQL Editor. The omni Doris parser has no production for `EXTRACT(unit FROM expr)`, so `validateQuery` failed the whole statement and the editor blocked it before it reached the database. A differential sweep — every parser rejection re-run through a live Doris — found nine more classes with the same shape.

This PR bumps `github.com/bytebase/omni` to pick up the parser fix and adds regression coverage in the read-only query validator for each form.

## One correction to the issue

The issue reports the customer-facing error as `Support read-only command statements only`. That is **not** what this query produces on any 3.18.1+ build — a parse failure returns a `*base.SyntaxError`, which `validateQueryRequest` surfaces as `[invalid_argument] syntax error at or near EXTRACT`. The read-only message only fires when parsing *succeeds* and the AST is not a read-only shape, e.g. a `SET` or `USE` prefix in the same editor tab:

| statement | result |
|---|---|
| the attached CG Tech query | `syntax error at or near EXTRACT` |
| `SET enable_profile = true;\nSELECT 1;` | **`Support read-only command statements only`** |
| `USE game_dws;\nSELECT 1;` | same |

So the screenshot and the attached SQL are most likely different executions. Worth asking CG Tech for the exact tab contents — if they prepend a `SET`, that is a second, separate bug. The issue's acceptance criterion "parser failures surface a precise syntax error instead of claiming the statement is non-read-only" is already satisfied today.

## Regression window

`3.18.1` and later. The ANTLR parser this replaced accepted the query; I confirmed that by running the customer's SQL through the pre-omni validator at `91cb65600e^`.

## Test plan

New cases in `TestValidateQuery` for both `doris` and `starrocks`, each asserting the form passes read-only validation:

- `EXTRACT(YEAR FROM MONTHS_ADD(NOW(), -1))`, multi-line, and inside a CTE body
- `TRIM(s)`, `LEFT(s,2)`, `RIGHT(s,2)`, `IF(a,1,2)`, `DATABASE()`
- `CURRENT_TIMESTAMP(3)`
- `@@version_comment`, `@@session.query_timeout`, `@uservar`
- `[1,2,3]`, `{'a':1}`, `x'1f'`, `b'101'`
- `array_map(x -> x + 1, arr)`
- `/*+ SET_VAR(query_timeout = 100) */`
- `GROUP BY CUBE(a)`
- `CONVERT(s USING utf8)`, `CONVERT(s, SIGNED)`, `BINARY s`

Verified these fail without the omni bump and pass with it. The reject arm is unchanged and still holds — CTE-prefixed `INSERT`/`UPDATE`/`DELETE`, bare `SHOW`/`DESCRIBE`/`EXPLAIN`, and `EXPLAIN` over DDL — with a new CTE-prefixed `INSERT` case added.

Upstream, the parser change is verified against a **live Apache Doris 3.1.4 container**: a 50-case conformance matrix, 0 mismatches. That matrix also has a negative arm, because the Apache Doris ANTLR grammar accepts six forms the shipping engine rejects (`SUBSTRING(x FROM n)`, `TRIM(BOTH .. FROM ..)`, `POSITION(x IN y)`, quantified `= ANY/> ALL/= SOME`); those are deliberately still rejected.

Locally: package tests pass, `golangci-lint` 0 issues, server binary builds.

## Not breaking

The change is permissive-only. Every statement rejected as a write before is still rejected; nothing that previously executed stops working.

## Known gaps

- `VALUES (1,2),(3,4)` as a standalone query still fails. It needs a new statement node upstream *and* a matching case in `isReadOnlyAST` here, or the editor flips from "syntax error" to "not read-only".
- StarRocks conformance is now verified against a live StarRocks 3.4.10 (43 cases, 0 mismatches). It turned out **not** to be interchangeable with Doris — five constructs differ (precision args on nilary datetime functions, bare `{'a':1}` map literals, `(x) -> …` lambdas, and `USING charset` on both `CONVERT` and `CHAR`), so `starrocks/query_test.go` here is deliberately no longer a copy of the Doris one. Details in omni#400.

## Follow-up found along the way

`SELECT ... INTO OUTFILE 's3://…'` currently **passes** the Doris read-only gate, exporting result sets to object storage around Bytebase's export policy, row limits, masking and export audit. Unrelated to this fix; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

