### PR TITLE
fix: keep sample project instances outside activation quota

### DIFF
--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -503,7 +503,7 @@ func (s *InstanceService) PrepareSampleProjectInstance(ctx context.Context, req 
 	return connect.NewResponse(s.convertToV1Instance(ctx, result.Instance)), nil
 }
 
-func (s *InstanceService) sampleProjectInstanceCreatePolicy(ctx context.Context, workspaceID string) (sampleprojectinstance.CreatePolicyResult, error) {
+func (s *InstanceService) sampleProjectInstanceCreatePolicy(ctx context.Context, _ string) (sampleprojectinstance.CreatePolicyResult, error) {
 	if err := s.instanceCountGuard(ctx); err != nil {
 		if connect.CodeOf(err) == connect.CodeResourceExhausted {
 			return sampleprojectinstance.CreatePolicyResult{DeniedReason: transportNeutralError(err)}, nil

--- a/backend/api/v1/instance_service.go
+++ b/backend/api/v1/instance_service.go
@@ -510,12 +510,6 @@ func (s *InstanceService) sampleProjectInstanceCreatePolicy(ctx context.Context,
 		}
 		return sampleprojectinstance.CreatePolicyResult{}, transportNeutralError(err)
 	}
-	if err := s.checkActivationLimit(ctx, workspaceID, true); err != nil {
-		if connect.CodeOf(err) == connect.CodeResourceExhausted {
-			return sampleprojectinstance.CreatePolicyResult{DeniedReason: transportNeutralError(err)}, nil
-		}
-		return sampleprojectinstance.CreatePolicyResult{}, transportNeutralError(err)
-	}
 	return sampleprojectinstance.CreatePolicyResult{}, nil
 }
 

--- a/backend/api/v1/instance_service_test.go
+++ b/backend/api/v1/instance_service_test.go
@@ -92,6 +92,18 @@ func TestSampleProjectInstanceCreatePolicyMapsCapacityDenial(t *testing.T) {
 	require.Equal(t, connect.CodeUnknown, connect.CodeOf(policy.DeniedReason))
 }
 
+func TestSampleProjectInstanceCreatePolicyDoesNotConsumeActivationQuota(t *testing.T) {
+	ctx, stores, _, _, _ := setupProjectInstanceLifecycleAPITest(t)
+	service := &InstanceService{
+		store:          stores,
+		profile:        &config.Profile{SaaS: true},
+		licenseService: &instanceLicenseServiceStub{instanceLimit: 10, activatedInstanceLimit: 0},
+	}
+	policy, err := service.sampleProjectInstanceCreatePolicy(ctx, common.GetWorkspaceIDFromContext(ctx))
+	require.NoError(t, err)
+	require.Nil(t, policy.DeniedReason)
+}
+
 func TestTransportNeutralErrorRemovesConnectType(t *testing.T) {
 	neutral := transportNeutralError(connect.NewError(connect.CodeResourceExhausted, errors.New("instance limit reached")))
 	var connectErr *connect.Error

--- a/backend/api/v1/sample_project_instance_integration_test.go
+++ b/backend/api/v1/sample_project_instance_integration_test.go
@@ -48,7 +48,10 @@ func TestPrepareSampleProjectInstanceLifecycle(t *testing.T) {
 	require.Equal(t, "Sample Project Instance", prepared.Msg.Title)
 	require.Equal(t, v1pb.Engine_POSTGRES, prepared.Msg.Engine)
 	require.Equal(t, "environments/test", prepared.Msg.GetEnvironment())
-	require.True(t, prepared.Msg.Activation)
+	require.False(t, prepared.Msg.Activation)
+	activatedInstanceCount, err := fixture.store.GetActivatedInstanceCount(ctx, fixture.workspaceID)
+	require.NoError(t, err)
+	require.Zero(t, activatedInstanceCount)
 
 	record := fixture.sampleRecord(ctx, t)
 	allocation := fixture.allocation(ctx, t)
@@ -309,7 +312,7 @@ func newSampleProjectInstanceFixture(t *testing.T, clock func() time.Time) (cont
 		service: &InstanceService{
 			store:                stores,
 			profile:              &config.Profile{SaaS: true},
-			licenseService:       &instanceLicenseServiceStub{instanceLimit: 10, activatedInstanceLimit: 10},
+			licenseService:       &instanceLicenseServiceStub{instanceLimit: 10, activatedInstanceLimit: 0},
 			dbFactory:            dbFactory,
 			schemaSyncer:         syncer,
 			sampleProjectManager: manager,
@@ -504,7 +507,7 @@ func (f *sampleProjectInstanceFixture) createPartialReservation(
 		Metadata: &storepb.Instance{
 			Title:      "Sample Project Instance",
 			Engine:     storepb.Engine_POSTGRES,
-			Activation: true,
+			Activation: false,
 			DataSources: []*storepb.DataSource{
 				config.AdminDataSource,
 			},

--- a/backend/component/sampleprojectinstance/metadata.go
+++ b/backend/component/sampleprojectinstance/metadata.go
@@ -49,7 +49,7 @@ func (m *Manager) lookupMetadata(
 	return state, nil
 }
 
-// createMetadata persists the activated, project-scoped PostgreSQL Instance through
+// createMetadata persists the inactive, project-scoped PostgreSQL Instance through
 // Store.CreateInstance so credential obfuscation remains centralized.
 func (m *Manager) createMetadata(ctx context.Context, registration registration) (*store.InstanceMessage, error) {
 	return m.store.CreateInstance(ctx, &store.InstanceMessage{
@@ -60,7 +60,7 @@ func (m *Manager) createMetadata(ctx context.Context, registration registration)
 		Metadata: &storepb.Instance{
 			Title:       registration.Title,
 			Engine:      registration.Engine,
-			Activation:  true,
+			Activation:  false,
 			DataSources: []*storepb.DataSource{registration.AdminDataSource},
 			SyncDatabases: &storepb.SyncDatabases{
 				Databases: registration.SyncDatabaseNames,

--- a/backend/component/sampleprojectinstance/metadata_test.go
+++ b/backend/component/sampleprojectinstance/metadata_test.go
@@ -37,7 +37,7 @@ func TestManagerMetadataCreatesAndLooksUpScopedSampleProjectInstance(t *testing.
 		SyncDatabaseNames: []string{allocation.Database},
 	})
 	require.NoError(t, err)
-	require.True(t, instance.Metadata.GetActivation())
+	require.False(t, instance.Metadata.GetActivation())
 	require.Equal(t, allocation.Password, instance.Metadata.GetDataSources()[0].GetPassword())
 
 	state, err := manager.lookupMetadata(ctx, allocation, "sample-instance", "workspace-a", "project-a")


### PR DESCRIPTION
## Summary

- enforce the normal workspace instance-count quota when preparing a Sample Project Instance
- store Sample Project Instances as inactive so Free workspaces do not consume their zero activated-instance allowance
- cover the Free 10/0 quota configuration and verify sample preparation leaves the activated count unchanged

## Testing

- `go test -v -count=1 ./backend/api/v1 -run "^(TestSampleProjectInstanceCreatePolicyDoesNotConsumeActivationQuota|TestSampleProjectInstanceCreatePolicyMapsCapacityDenial|TestTransportNeutralErrorRemovesConnectType)$" -timeout 5m`
- `go test -v -count=1 ./backend/component/sampleprojectinstance -run "^TestManagerMetadataCreatesAndLooksUpScopedSampleProjectInstance$" -timeout 5m`
- full lint, build, and test suite deferred to CI