### PR TITLE
fix(bigquery): handle NULL ordinal_position during schema sync

### DIFF
--- a/backend/plugin/db/bigquery/sync.go
+++ b/backend/plugin/db/bigquery/sync.go
@@ -36,7 +36,7 @@ func (d *Driver) SyncInstance(ctx context.Context) (*db.InstanceMetadata, error)
 type columnRow struct {
 	TableName       string              `bigquery:"table_name"`
 	ColumnName      string              `bigquery:"column_name"`
-	OrdinalPosition int32               `bigquery:"ordinal_position"`
+	OrdinalPosition bigquery.NullInt64  `bigquery:"ordinal_position"`
 	IsNullable      string              `bigquery:"is_nullable"`
 	DataType        string              `bigquery:"data_type"`
 	CollationName   bigquery.NullString `bigquery:"collation_name"`
@@ -78,7 +78,7 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 
 		column := &storepb.ColumnMetadata{
 			Name:     row.ColumnName,
-			Position: row.OrdinalPosition,
+			Position: int32(row.OrdinalPosition.Int64),
 			Nullable: nullableBool,
 			Type:     row.DataType,
 		}

--- a/backend/plugin/db/bigquery/sync.go
+++ b/backend/plugin/db/bigquery/sync.go
@@ -57,7 +57,9 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 			data_type,
 			collation_name,
 			column_default
-		FROM %s.INFORMATION_SCHEMA.COLUMNS ORDER BY table_name, ordinal_position;`, d.databaseName))
+		FROM %s.INFORMATION_SCHEMA.COLUMNS
+		WHERE is_hidden = 'NO'
+		ORDER BY table_name, ordinal_position;`, d.databaseName))
 	it, err := q.Read(ctx)
 	if err != nil {
 		return nil, err
@@ -70,6 +72,10 @@ func (d *Driver) SyncDBSchema(ctx context.Context) (*storepb.DatabaseSchemaMetad
 		}
 		if err != nil {
 			return nil, err
+		}
+		// Pseudo columns such as _PARTITIONTIME/_PARTITIONDATE have NULL ordinal_position.
+		if !row.OrdinalPosition.Valid {
+			continue
 		}
 		nullableBool, err := util.ConvertYesNo(row.IsNullable)
 		if err != nil {


### PR DESCRIPTION
## Summary

Fixes #21217

BigQuery schema sync can fail when `INFORMATION_SCHEMA.COLUMNS.ordinal_position` is `NULL`.

The BigQuery Go client refuses to assign a SQL `NULL` into a non-nullable Go `int32` field, which aborts `SyncDBSchema` for the whole database.

Per BigQuery docs, `ordinal_position` is `NULL` for pseudo columns such as `_PARTITIONTIME` / `_PARTITIONDATE` (also marked `is_hidden = 'YES'`). This PR:

1. Scans `ordinal_position` as `bigquery.NullInt64` so NULL values do not fail the iterator.
2. Filters `WHERE is_hidden = 'NO'` and skips rows with invalid ordinals, so pseudo columns are not stored as normal user columns with `Position: 0`.

## Problem

### Symptom

Database Overview shows **Sync failed** with an error similar to:

```text
failed to sync database schema for database "<name>":
bigquery: NULL cannot be assigned to field `OrdinalPosition` of type int32
```

### Root cause

In `backend/plugin/db/bigquery/sync.go`, column metadata was scanned into a non-nullable `int32`. BigQuery returns NULL `ordinal_position` for hidden/system pseudo columns, which caused the entire sync to fail.

## Solution

- Use `bigquery.NullInt64` for `OrdinalPosition` (BigQuery Go client has no `NullInt32`; INTEGER is INT64).
- Exclude hidden pseudo columns via `WHERE is_hidden = 'NO'`.
- Skip any remaining rows where `!OrdinalPosition.Valid`.
- Cast valid values with `int32(row.OrdinalPosition.Int64)` into `ColumnMetadata.Position`.

## Changes

| File | Change |
|------|--------|
| `backend/plugin/db/bigquery/sync.go` | `NullInt64` scan; filter/skip pseudo columns; cast valid ordinal to `int32` |

## Test plan

- [x] Build backend successfully.
- [x] Sync a BigQuery database that previously failed with the `OrdinalPosition` / `int32` NULL error (e.g. ingestion-time partitioned tables).
- [x] Confirm Overview **Sync status** becomes **OK**.
- [x] Confirm pseudo columns like `_PARTITIONTIME` / `_PARTITIONDATE` are **not** listed as normal table columns.
- [x] Confirm regular columns still sync with correct positions.
- [x] Spot-check a non-partitioned BigQuery database (no regression).

## Impact

- **Scope:** BigQuery schema sync only (`SyncDBSchema` column metadata path).
- **Risk:** Low. Isolated metadata sync fix; no API or UI changes.
- **User-facing:** Unblocks schema sync for BigQuery databases with NULL `ordinal_position`, without treating pseudo columns as user columns.