### PR TITLE
feat(mcp): serve what each MCP capability mode contains, resolved live (P1b 1b-5b)

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -7766,6 +7766,52 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bytebase.v1.IamPolicy'
+  /bytebase.v1.WorkspaceService/GetMCPInfo:
+    post:
+      tags:
+        - bytebase.v1.WorkspaceService
+      summary: |-
+        Gets what MCP (Model Context Protocol) does in this workspace: the
+         capability ceiling in force, what each ceiling serves, and the per-engine
+         facts a read-only session depends on. The workspace is resolved from the
+         authenticated session.
+      description: |-
+        Served to MCP sessions. An agent asking what it may do here is the point:
+         the response says nothing a session's own denials do not already say, one
+         refusal at a time, and knowing it up front is what stops the agent
+         planning work the ceiling was never going to serve.
+
+         Permissions required: None (authentication required)
+      operationId: bytebase.v1.WorkspaceService.GetMCPInfo
+      parameters:
+        - name: Connect-Protocol-Version
+          in: header
+          required: true
+          schema:
+            $ref: '#/components/schemas/connect-protocol-version'
+        - name: Connect-Timeout-Ms
+          in: header
+          schema:
+            $ref: '#/components/schemas/connect-timeout-header'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/bytebase.v1.GetMCPInfoRequest'
+        required: true
+      responses:
+        default:
+          description: Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/connect.error'
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bytebase.v1.MCPInfo'
   /bytebase.v1.WorkspaceService/GetWorkspace:
     post:
       tags:
@@ -12292,6 +12338,10 @@ components:
           description: If set to true, bypass cache and fetch the latest data.
       title: GetIssueRequest
       additionalProperties: false
+    bytebase.v1.GetMCPInfoRequest:
+      type: object
+      title: GetMCPInfoRequest
+      additionalProperties: false
     bytebase.v1.GetPaymentInfoRequest:
       type: object
       title: GetPaymentInfoRequest
@@ -14991,6 +15041,21 @@ components:
       title: LogoutRequest
       additionalProperties: false
       description: Request to logout current user session.
+    bytebase.v1.MCPCapabilityMode:
+      type: object
+      properties:
+        capability:
+          title: capability
+          $ref: '#/components/schemas/bytebase.v1.MCPSetting.Capability'
+        servedClasses:
+          type: array
+          items:
+            $ref: '#/components/schemas/bytebase.v1.MCPMethodClass'
+          title: served_classes
+          description: Empty means the ceiling serves nothing, which is what DISABLED is.
+      title: MCPCapabilityMode
+      additionalProperties: false
+      description: MCPCapabilityMode is one ceiling and the method classes it serves.
     bytebase.v1.MCPDelegation:
       type: object
       properties:
@@ -15063,6 +15128,159 @@ components:
          that contradicts its class. Neither is expressible now, and the one check
          left — the reason belongs to the class it is used on — is a table the gate
          already keeps for the wording.
+    bytebase.v1.MCPEngineEnforcement:
+      type: object
+      properties:
+        engine:
+          title: engine
+          $ref: '#/components/schemas/bytebase.v1.Engine'
+        readOnlyDepth:
+          title: read_only_depth
+          $ref: '#/components/schemas/bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth'
+        masking:
+          title: masking
+          $ref: '#/components/schemas/bytebase.v1.MCPEngineEnforcement.Masking'
+        note:
+          type: string
+          title: note
+          description: |-
+            Where the answers above are the floor rather than the whole story. Empty
+             for most engines.
+      title: MCPEngineEnforcement
+      additionalProperties: false
+      description: |-
+        MCPEngineEnforcement is what the read-only ceiling and the masking toggle
+         reach on one database engine.
+    bytebase.v1.MCPEngineEnforcement.Masking:
+      type: string
+      title: Masking
+      enum:
+        - MASKING_UNSPECIFIED
+        - NONE
+        - COLUMN
+        - DOCUMENT
+      description: |-
+        How Bytebase masks results on this engine, which is what decides whether
+         ignoring masking exemptions changes anything here.
+    bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth:
+      type: string
+      title: ReadOnlyDepth
+      enum:
+        - READ_ONLY_DEPTH_UNSPECIFIED
+        - UNSUPPORTED
+        - STATEMENT
+        - STATEMENT_AND_SESSION
+      description: How much of a read-only ceiling this engine can be held to.
+    bytebase.v1.MCPInfo:
+      type: object
+      properties:
+        workspace:
+          type: string
+          title: workspace
+          description: |-
+            The workspace this describes. Format: workspaces/{workspace}. Not this
+             message's own resource name — MCPInfo is not a named resource and there is
+             nothing to get it by.
+        capability:
+          title: capability
+          description: |-
+            The ceiling in force for this workspace. A workspace that never configured
+             MCP resolves to READ_WRITE.
+          $ref: '#/components/schemas/bytebase.v1.MCPSetting.Capability'
+        modes:
+          type: array
+          items:
+            $ref: '#/components/schemas/bytebase.v1.MCPCapabilityMode'
+          title: modes
+          description: |-
+            What each ceiling serves, including the one in force, so an admin can
+             compare the choices rather than only read the current answer.
+        methods:
+          type: array
+          items:
+            $ref: '#/components/schemas/bytebase.v1.MCPMethod'
+          title: methods
+          description: |-
+            Every API method some ceiling serves. A mode serves a method when the
+             method's class is one of that mode's served_classes, which is the ceiling
+             rule the gate evaluates. Methods no ceiling serves are absent.
+
+             Being listed is necessary, not sufficient. The caller still needs the
+             permission, and two further rules narrow what a served method does: a
+             handful of methods are refused on the shape of the request (an issue that
+             would grant a permission, a rollout that skips approval), and under
+             READ_ONLY every statement SQLService/Query runs must classify as a read.
+        engines:
+          type: array
+          items:
+            $ref: '#/components/schemas/bytebase.v1.MCPEngineEnforcement'
+          title: engines
+          description: |-
+            What a read-only session and the masking toggle actually reach, per engine.
+             Both are engine-conditional in ways the ceiling alone does not show.
+        ignoreMaskingExemptions:
+          type: boolean
+          title: ignore_masking_exemptions
+          description: |-
+            Whether this workspace stops applying the caller's own unmasking
+             provisioning to MCP requests. It decides which branch of each engine's
+             masking state a caller is in, and no other API tells an MCP session:
+             SettingService/GetSetting is served by no ceiling.
+        dataMaskingAvailable:
+          type: boolean
+          title: data_masking_available
+          description: |-
+            Whether data masking is licensed for this workspace. When false nothing is
+             masked whatever an engine supports, so the masking states below describe a
+             mechanism that does not run. Licensing can also be set per instance, so a
+             true here is the workspace answer, not a promise about every instance.
+      title: MCPInfo
+      additionalProperties: false
+      description: |-
+        MCPInfo is what MCP does in this workspace: the ceiling in force, what each
+         ceiling serves, and the per-engine facts a read-only session depends on.
+
+         Everything here is resolved when the request is served, never from a stored
+         copy: the method list comes off the compiled API descriptors and the engine
+         answers off the code that enforces them, so a build whose rules changed
+         cannot describe the rules of the build before it.
+    bytebase.v1.MCPMethod:
+      type: object
+      properties:
+        method:
+          type: string
+          title: method
+          description: |-
+            The method as an audit entry names it, so a denial can be found by it.
+             Example: /bytebase.v1.SQLService/Query
+        operationId:
+          type: string
+          title: operation_id
+          description: |-
+            The same method as call_api takes it.
+             Example: bytebase.v1.SQLService.Query
+        class:
+          title: class
+          $ref: '#/components/schemas/bytebase.v1.MCPMethodClass'
+        permission:
+          type: string
+          title: permission
+          description: |-
+            The IAM permission the method declares. The ceiling never grants: a session
+             may call a served method only where the person it acts for could.
+
+             Empty means the method declares no permission, which is NOT the same as
+             needing none — a method that authorizes inside its handler declares nothing
+             here. auth_method says which case an empty value is.
+        authMethod:
+          title: auth_method
+          description: |-
+            How the method authorizes. IAM means the permission above is the whole
+             rule; CUSTOM means the handler decides and the permission field is silent.
+          $ref: '#/components/schemas/bytebase.v1.AuthMethod'
+      title: MCPMethod
+      additionalProperties: false
+      description: MCPMethod is one API method an MCP session can reach, and what decides it.
     bytebase.v1.MCPMethodClass:
       type: string
       title: MCPMethodClass

--- a/backend/api/mcp/openapi_index.go
+++ b/backend/api/mcp/openapi_index.go
@@ -75,7 +75,7 @@ type OpenAPIIndex struct {
 	// hiddenEndpoints holds every endpoint no MCP capability ceiling serves —
 	// FORBIDDEN and EXCLUDED alike — resolvable through byOperation so a
 	// direct call still gets the gate's actionable denial, but reachable by no
-	// discovery path. That is 121 of the 209 classified RPCs, and 13 services
+	// discovery path. That is 114 of the 211 classified RPCs, and 13 services
 	// whose every method is refused leave Services() entirely.
 	hiddenEndpoints []EndpointInfo
 	byOperation     map[string]*EndpointInfo

--- a/backend/api/mcp/server.go
+++ b/backend/api/mcp/server.go
@@ -136,6 +136,12 @@ func newServerWithStore(stores serverStore, profile *config.Profile, secret stri
 }
 
 // registerTools registers all MCP tools.
+//
+// The list is not filtered by the workspace's ceiling (BOT-89), and cannot be:
+// the SDK builds it once at session start while the ceiling is read per
+// request, so a filtered list would be a promise made under whatever the
+// ceiling was at connect time and would go stale the moment an admin changed
+// it. Revisit only if the SDK grows a way to revise a live session's tool list.
 func (s *Server) registerTools() {
 	s.registerSearchTool()
 	s.registerCallTool()

--- a/backend/api/mcp/tool_change.go
+++ b/backend/api/mcp/tool_change.go
@@ -151,7 +151,8 @@ propose_database_change(database="app", sql="UPDATE orders SET status='shipped' 
 - Plan checks run automatically; results included in response when available.
 - Requires bb.sheets.create, bb.plans.create, bb.issues.create permissions.
 - If createRollout=true but policy gates aren't satisfied, returns success with rolloutCreated=false and a reason.
-- Masked data: a masked column reads back as "******". That is a placeholder, not a value anything holds. Any change containing it is refused, because writing it back would overwrite the real value. Ask a human to make the change in the Bytebase console instead.`
+- Masked data: a masked column reads back as "******". That is a placeholder, not a value anything holds. Any change containing it is refused, because writing it back would overwrite the real value. Ask a human to make the change in the Bytebase console instead.
+- Workspace ceiling: the workspace's MCP policy decides whether changes are served at all, and under a read-only ceiling this tool is refused before anything is created. Read it with call_api(operationId="bytebase.v1.WorkspaceService.GetMCPInfo") before planning a change.`
 
 func (s *Server) registerChangeTool() {
 	mcp.AddTool(s.mcpServer, &mcp.Tool{

--- a/backend/api/mcp/tool_query.go
+++ b/backend/api/mcp/tool_query.go
@@ -58,7 +58,8 @@ query_database(database="employee_db", statement="SELECT * FROM users LIMIT 10")
 query_database(database="employee", instance="prod-pg", statement="SELECT count(*) FROM orders")
 
 **Notes:**
-- Masked data: a masked column reads back as "******". That is a placeholder, not a value anything holds, so never write it back and never filter on it. Any statement containing it is refused.`
+- Masked data: a masked column reads back as "******". That is a placeholder, not a value anything holds, so never write it back and never filter on it. Any statement containing it is refused.
+- Workspace ceiling: the workspace's MCP policy decides what is served here, and under a read-only ceiling any statement that is not a read is refused whole. Read it with call_api(operationId="bytebase.v1.WorkspaceService.GetMCPInfo") — it also reports how deeply read-only is enforced on each engine.`
 
 func (s *Server) registerQueryTool() {
 	mcp.AddTool(s.mcpServer, &mcp.Tool{

--- a/backend/api/v1/mcp_info.go
+++ b/backend/api/v1/mcp_info.go
@@ -1,0 +1,252 @@
+package v1
+
+import (
+	"cmp"
+	"context"
+	"log/slog"
+	"slices"
+	"strings"
+
+	"connectrpc.com/connect"
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"github.com/bytebase/bytebase/backend/api/auth"
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/log"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	parserbase "github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+// GetMCPInfo reports what MCP does in this workspace.
+//
+// Everything is resolved when the request is served. The method list comes off
+// the compiled descriptors — the same place the gate reads a method's class —
+// and the engine answers off the code that enforces them, so this cannot
+// describe rules the build does not run. A stored list would drift silently:
+// the first sign would be an admin acting on a mode that no longer means what
+// the page said.
+func (s *WorkspaceService) GetMCPInfo(ctx context.Context, _ *connect.Request[v1pb.GetMCPInfoRequest]) (*connect.Response[v1pb.MCPInfo], error) {
+	workspaceID := common.GetWorkspaceIDFromContext(ctx)
+	if workspaceID == "" {
+		return nil, connect.NewError(connect.CodeInternal, errors.New("no workspace on the request"))
+	}
+	settings, err := s.mcpSettingsForInfo(ctx, workspaceID)
+	// Every verdict is decided here, not only the read failures. DISABLED is
+	// the one refusing ceiling this still answers under, deliberately: an admin
+	// looking at a workspace with MCP off is exactly who needs to see what the
+	// other modes contain. A ceiling this build does not serve is different —
+	// reporting it as "in force" would describe a state the build does not run,
+	// beside a modes list with no row for it.
+	switch verdict := auth.ClassifyMCPCeiling(settings.Capability, err); verdict {
+	case auth.MCPCeilingServes, auth.MCPCeilingDisabled:
+	case auth.MCPCeilingUnreadable:
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(
+			"this workspace's stored MCP capability ceiling is not one this build understands. "+
+				"Ask a workspace admin to set the MCP ceiling again in the workspace settings"))
+	case auth.MCPCeilingUnserved:
+		return nil, connect.NewError(connect.CodeFailedPrecondition, errors.New(
+			"this workspace's stored MCP capability ceiling is not one this build serves. "+
+				"Ask a workspace admin to set the MCP ceiling to a supported value in the workspace settings"))
+	default:
+		// The store error stays in the log. This method is served to MCP
+		// sessions and the tool layer renders a connect message into what the
+		// model reads, so a driver error text would leave the metadata
+		// database's shape in an agent's context.
+		slog.Error("failed to read the MCP setting", slog.String("workspace", workspaceID), log.BBError(err))
+		return nil, connect.NewError(connect.CodeUnavailable, errors.New(
+			"the MCP setting could not be read; retry shortly"))
+	}
+
+	return connect.NewResponse(&v1pb.MCPInfo{
+		Workspace:               common.FormatWorkspace(workspaceID),
+		Capability:              convertToV1MCPCapability(settings.Capability),
+		Modes:                   mcpCapabilityModes(),
+		Methods:                 mcpServedMethods(protoregistry.GlobalFiles),
+		Engines:                 mcpEngineEnforcement(),
+		IgnoreMaskingExemptions: settings.IgnoreMaskingExemptions,
+		DataMaskingAvailable:    s.licenseService.IsFeatureEnabled(ctx, workspaceID, v1pb.PlanFeature_FEATURE_DATA_MASKING) == nil,
+	}), nil
+}
+
+// mcpSettingsForInfo returns the MCP settings this request is answered from.
+//
+// On the internal MCP chain the gate already resolved them and stamped them on
+// the context; reading again could answer with a ceiling the request was not
+// admitted under, which is the rule mcp_gate.go states and the clamp and the
+// masking check both follow. Off that chain — the console, an admin opening the
+// settings page — nothing is stamped and the store is read.
+func (s *WorkspaceService) mcpSettingsForInfo(ctx context.Context, workspaceID string) (store.MCPSettings, error) {
+	if settings, ok := mcpSettingsFromContext(ctx); ok {
+		return settings, nil
+	}
+	return s.store.GetMCPSettingsUncached(ctx, workspaceID)
+}
+
+// mcpCapabilityModes renders the serving table the gate evaluates, one row per
+// ceiling. It reads mcpServingClasses rather than restating it, so a mode that
+// starts or stops serving a class cannot leave this stale.
+func mcpCapabilityModes() []*v1pb.MCPCapabilityMode {
+	modes := make([]*v1pb.MCPCapabilityMode, 0, len(mcpServingClasses))
+	for capability, served := range mcpServingClasses {
+		modes = append(modes, &v1pb.MCPCapabilityMode{
+			Capability: convertToV1MCPCapability(capability),
+			// Cloned: the response must not hand out the slice the gate
+			// evaluates against on every request.
+			ServedClasses: slices.Clone(served),
+		})
+	}
+	slices.SortFunc(modes, func(a, b *v1pb.MCPCapabilityMode) int { return cmp.Compare(a.Capability, b.Capability) })
+	return modes
+}
+
+// fileRanger is the descriptor set to resolve classifications from.
+// *protoregistry.Files satisfies it; a test supplies its own, which is what
+// lets "the response follows the descriptors" be shown rather than asserted.
+type fileRanger interface {
+	RangeFiles(func(protoreflect.FileDescriptor) bool)
+}
+
+// mcpServedMethods reads every bytebase.v1 RPC's classification off the
+// descriptors and returns the ones some ceiling serves, sorted by procedure.
+//
+// Methods no ceiling serves are left out: the response answers "what can be
+// done here", and an agent handed the refused list would have to be told
+// separately that those entries are not offers.
+func mcpServedMethods(files fileRanger) []*v1pb.MCPMethod {
+	var methods []*v1pb.MCPMethod
+	files.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+		if fd.Package() != "bytebase.v1" {
+			return true
+		}
+		services := fd.Services()
+		for i := range services.Len() {
+			sd := services.Get(i)
+			descriptors := sd.Methods()
+			for j := range descriptors.Len() {
+				md := descriptors.Get(j)
+				options, ok := md.Options().(*descriptorpb.MethodOptions)
+				if !ok {
+					continue
+				}
+				class, ok := proto.GetExtension(options, v1pb.E_McpMethodClass).(v1pb.MCPMethodClass)
+				if !ok {
+					// A malformed annotation is not a classification. CI
+					// rejects one, and no ceiling serves what it resolves to.
+					continue
+				}
+				if auth.MCPClassIsRefused(class) {
+					continue
+				}
+				method := &v1pb.MCPMethod{
+					Method:      "/" + string(sd.FullName()) + "/" + string(md.Name()),
+					OperationId: string(sd.FullName()) + "." + string(md.Name()),
+					Class:       class,
+				}
+				if permission, ok := proto.GetExtension(options, v1pb.E_Permission).(string); ok {
+					method.Permission = permission
+				}
+				if authMethod, ok := proto.GetExtension(options, v1pb.E_AuthMethod).(v1pb.AuthMethod); ok {
+					method.AuthMethod = authMethod
+				}
+				methods = append(methods, method)
+			}
+		}
+		return true
+	})
+	slices.SortFunc(methods, func(a, b *v1pb.MCPMethod) int { return strings.Compare(a.Method, b.Method) })
+	return methods
+}
+
+// mcpEngineEnforcement answers, per engine, how deep a read-only ceiling goes
+// and whether masking reaches anything — the two facts the ceiling alone does
+// not show. Every engine the build knows appears, in declaration order.
+func mcpEngineEnforcement() []*v1pb.MCPEngineEnforcement {
+	values := storepb.Engine(0).Descriptor().Values()
+	engines := make([]*v1pb.MCPEngineEnforcement, 0, values.Len())
+	for i := range values.Len() {
+		engine := storepb.Engine(values.Get(i).Number())
+		if engine == storepb.Engine_ENGINE_UNSPECIFIED {
+			continue
+		}
+		engines = append(engines, &v1pb.MCPEngineEnforcement{
+			Engine:        convertToEngine(engine),
+			ReadOnlyDepth: mcpReadOnlyDepth(engine),
+			Masking:       mcpMaskingSupport(engine),
+			Note:          mcpEngineNote(engine),
+		})
+	}
+	return engines
+}
+
+// mcpReadOnlyDepth reports how much of a read-only ceiling this engine can be
+// held to.
+//
+// The classifier half is asked, not mirrored: parserbase.HasQueryValidator is
+// the same registry the clamp consults, so an engine that gains or loses a
+// validator moves here on the same commit.
+func mcpReadOnlyDepth(engine storepb.Engine) v1pb.MCPEngineEnforcement_ReadOnlyDepth {
+	if !parserbase.HasQueryValidator(engine) {
+		return v1pb.MCPEngineEnforcement_UNSUPPORTED
+	}
+	if readOnlyDriverSession(engine) {
+		return v1pb.MCPEngineEnforcement_STATEMENT_AND_SESSION
+	}
+	return v1pb.MCPEngineEnforcement_STATEMENT
+}
+
+// readOnlyDriverSession reports whether this engine's driver always turns
+// ConnectionContext.ReadOnly into a read-only database session, by setting
+// default_transaction_read_only on the connection it opens. Two always do:
+// postgres and cockroachdb. Redshift does too, but only outside a datashare
+// database, which cannot run a read-only transaction — that is per database,
+// off its metadata, and this answer is per engine, so redshift is reported at
+// its floor and its note carries the rest (plugin/db/pg, /cockroachdb,
+// /redshift).
+//
+// It mirrors the drivers rather than asking them, because a driver reports this
+// by acting on a flag when a connection is opened and no connection exists
+// here. A driver that starts honoring the flag without a row here understates
+// its own depth, which is the safe way for this to be wrong.
+func readOnlyDriverSession(engine storepb.Engine) bool {
+	switch engine {
+	case storepb.Engine_POSTGRES, storepb.Engine_COCKROACHDB:
+		return true
+	default:
+		return false
+	}
+}
+
+// mcpMaskingSupport reports how Bytebase masks results on this engine, which is
+// what decides whether ignoring masking exemptions changes anything.
+//
+// Document first, because that is the order the query path checks them
+// (sql_service.go): an engine with a document masker never reaches the column
+// masker. Exemptions are a column-masking mechanism — the document masker's
+// interface carries neither the user nor their exemptions — so on a document
+// engine the toggle has nothing to suppress (BOT-95).
+func mcpMaskingSupport(engine storepb.Engine) v1pb.MCPEngineEnforcement_Masking {
+	switch {
+	case getDocumentMasker(engine) != nil:
+		return v1pb.MCPEngineEnforcement_DOCUMENT
+	case common.EngineSupportMasking(engine):
+		return v1pb.MCPEngineEnforcement_COLUMN
+	default:
+		return v1pb.MCPEngineEnforcement_NONE
+	}
+}
+
+// mcpEngineNote carries the cases where a per-engine answer is the floor rather
+// than the whole story.
+func mcpEngineNote(engine storepb.Engine) string {
+	if engine == storepb.Engine_REDSHIFT {
+		return "Outside a datashare database the driver also opens the session read-only. " +
+			"A datashare database cannot run a read-only transaction, so there it is statement classification alone."
+	}
+	return ""
+}

--- a/backend/api/v1/mcp_info_test.go
+++ b/backend/api/v1/mcp_info_test.go
@@ -1,0 +1,440 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+
+	"github.com/bytebase/bytebase/backend/api/auth"
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/component/config"
+	"github.com/bytebase/bytebase/backend/enterprise"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/migrator"
+	parserbase "github.com/bytebase/bytebase/backend/plugin/parser/base"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+// TestMCPInfoResolvesMethodsLive shows that the served-method list follows the
+// descriptors rather than any copy of them: the same resolver, run over two
+// descriptor sets differing only in one method's mcp_method_class annotation,
+// answers differently.
+//
+// This is the property the API exists for. A stored or hand-kept list would
+// pass every assertion below on the day it was written and drift silently
+// afterwards, and the first sign would be an admin choosing a mode from a page
+// that described the build before this one.
+func TestMCPInfoResolvesMethodsLive(t *testing.T) {
+	asRead := mcpServedMethods(descriptorsClassifying(t, v1pb.MCPMethodClass_READ))
+	require.Len(t, asRead, 1)
+	require.Equal(t, "/bytebase.v1.LiveResolutionService/Probe", asRead[0].Method)
+	require.Equal(t, v1pb.MCPMethodClass_READ, asRead[0].Class)
+	require.Equal(t, "bb.probes.get", asRead[0].Permission)
+
+	asWrite := mcpServedMethods(descriptorsClassifying(t, v1pb.MCPMethodClass_WRITE))
+	require.Len(t, asWrite, 1)
+	require.Equal(t, v1pb.MCPMethodClass_WRITE, asWrite[0].Class,
+		"the response must move when the annotation moves")
+
+	// A refused class leaves the method out entirely: the response answers what
+	// can be done, so a refused entry would read as an offer.
+	for _, class := range []v1pb.MCPMethodClass{
+		v1pb.MCPMethodClass_FORBIDDEN,
+		v1pb.MCPMethodClass_EXCLUDED,
+		v1pb.MCPMethodClass_MCP_METHOD_CLASS_UNSPECIFIED,
+	} {
+		require.Empty(t, mcpServedMethods(descriptorsClassifying(t, class)),
+			"%v is served by no ceiling", class)
+	}
+}
+
+// descriptorsClassifying builds a descriptor set holding one bytebase.v1
+// service with one method carrying the given classification. The file is
+// compiled the same way the real ones are, so the resolver reads a real
+// annotation off a real descriptor, not a stand-in for one.
+func descriptorsClassifying(t *testing.T, class v1pb.MCPMethodClass) *protoregistry.Files {
+	t.Helper()
+
+	options := &descriptorpb.MethodOptions{}
+	proto.SetExtension(options, v1pb.E_McpMethodClass, class)
+	proto.SetExtension(options, v1pb.E_Permission, "bb.probes.get")
+	if class == v1pb.MCPMethodClass_FORBIDDEN || class == v1pb.MCPMethodClass_EXCLUDED {
+		// The build's own lint requires a reason on a refused method; keep the
+		// synthetic file consistent with that rule.
+		proto.SetExtension(options, v1pb.E_McpDenialReason, v1pb.MCPDenialReason_ADMINISTERS_THE_WORKSPACE)
+	}
+
+	probe := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("test/live_resolution.proto"),
+		Package: proto.String("bytebase.v1"),
+		Syntax:  proto.String("proto3"),
+		Dependency: []string{
+			"v1/annotation.proto",
+		},
+		MessageType: []*descriptorpb.DescriptorProto{
+			{Name: proto.String("ProbeRequest")},
+			{Name: proto.String("ProbeResponse")},
+		},
+		Service: []*descriptorpb.ServiceDescriptorProto{{
+			Name: proto.String("LiveResolutionService"),
+			Method: []*descriptorpb.MethodDescriptorProto{{
+				Name:       proto.String("Probe"),
+				InputType:  proto.String(".bytebase.v1.ProbeRequest"),
+				OutputType: proto.String(".bytebase.v1.ProbeResponse"),
+				Options:    options,
+			}},
+		}},
+	}
+
+	set := &descriptorpb.FileDescriptorSet{File: append(fileAndDependencies(t, "v1/annotation.proto"), probe)}
+	files, err := protodesc.NewFiles(set)
+	require.NoError(t, err)
+	return files
+}
+
+// fileAndDependencies returns the given compiled file and everything it imports,
+// dependencies first, as descriptor protos.
+func fileAndDependencies(t *testing.T, path string) []*descriptorpb.FileDescriptorProto {
+	t.Helper()
+	seen := map[string]bool{}
+	var out []*descriptorpb.FileDescriptorProto
+	var walk func(fd protoreflect.FileDescriptor)
+	walk = func(fd protoreflect.FileDescriptor) {
+		if seen[fd.Path()] {
+			return
+		}
+		seen[fd.Path()] = true
+		imports := fd.Imports()
+		for i := range imports.Len() {
+			walk(imports.Get(i).FileDescriptor)
+		}
+		out = append(out, protodesc.ToFileDescriptorProto(fd))
+	}
+	fd, err := protoregistry.GlobalFiles.FindFileByPath(path)
+	require.NoError(t, err)
+	walk(fd)
+	return out
+}
+
+// TestMCPInfoServedMethodsMatchTheServingTable holds the real response against
+// the gate's own serving table: every method it lists must be one some ceiling
+// serves, and every method the annotations classify as served must be listed.
+func TestMCPInfoServedMethodsMatchTheServingTable(t *testing.T) {
+	methods := mcpServedMethods(protoregistry.GlobalFiles)
+	require.NotEmpty(t, methods)
+
+	listed := map[string]v1pb.MCPMethodClass{}
+	for _, m := range methods {
+		require.False(t, auth.MCPClassIsRefused(m.Class),
+			"%s is %v, which no ceiling serves, so it must not be advertised", m.Method, m.Class)
+		listed[m.Method] = m.Class
+	}
+
+	byMethod := map[string]*v1pb.MCPMethod{}
+	for _, m := range methods {
+		byMethod[m.Method] = m
+	}
+	for _, row := range mcpClassificationsFromDescriptors(t) {
+		if auth.MCPClassIsRefused(row.class) {
+			require.NotContains(t, listed, row.procedure)
+			continue
+		}
+		require.Equal(t, row.class, listed[row.procedure],
+			"%s is classified %v and must be listed as such", row.procedure, row.class)
+		// The permission is the part an agent acts on to predict a denial, so
+		// it is checked on every real method, not only on a synthetic one.
+		require.Equal(t, row.permission, byMethod[row.procedure].Permission,
+			"%s must report the permission its descriptor declares", row.procedure)
+	}
+
+	// The order is the response's contract: protoregistry's RangeFiles order is
+	// unspecified, so without the sort the list would flap between requests.
+	for range 4 {
+		next := mcpServedMethods(protoregistry.GlobalFiles)
+		require.Len(t, next, len(methods))
+		for i := range methods {
+			require.Equal(t, methods[i].Method, next[i].Method, "method order must be stable")
+		}
+	}
+}
+
+// TestMCPInfoModesMatchTheServingTable pins that the modes the response
+// describes are the gate's, not a second copy of them.
+func TestMCPInfoModesMatchTheServingTable(t *testing.T) {
+	modes := mcpCapabilityModes()
+	require.Len(t, modes, len(mcpServingClasses))
+
+	got := map[storepb.MCPSetting_Capability][]v1pb.MCPMethodClass{}
+	for _, mode := range modes {
+		capability := convertToStoreMCPCapability(mode.Capability)
+		_, known := mcpServingClasses[capability]
+		require.True(t, known, "%v is not a ceiling the gate decides about", mode.Capability)
+		got[capability] = mode.ServedClasses
+	}
+
+	// Spelled out rather than compared against the table, so flipping what a
+	// mode serves fails here instead of agreeing with itself.
+	require.Empty(t, got[storepb.MCPSetting_DISABLED])
+	require.Equal(t, []v1pb.MCPMethodClass{v1pb.MCPMethodClass_READ}, got[storepb.MCPSetting_READ_ONLY])
+	require.Equal(t,
+		[]v1pb.MCPMethodClass{v1pb.MCPMethodClass_READ, v1pb.MCPMethodClass_WRITE},
+		got[storepb.MCPSetting_READ_WRITE])
+
+	// And not the gate's own slice: a response that aliases the serving table
+	// lets anything downstream write into the ceiling.
+	for _, mode := range modes {
+		served := mcpServingClasses[convertToStoreMCPCapability(mode.Capability)]
+		if len(served) > 0 && len(mode.ServedClasses) > 0 {
+			require.NotSame(t, &served[0], &mode.ServedClasses[0],
+				"%v hands out the table the gate evaluates", mode.Capability)
+		}
+	}
+
+	// The order is the response's contract: Go randomizes map iteration, so
+	// without the sort every request would return a different one.
+	for range 8 {
+		next := mcpCapabilityModes()
+		require.Len(t, next, len(modes))
+		for i := range modes {
+			require.Equal(t, modes[i].Capability, next[i].Capability, "mode order must be stable")
+		}
+	}
+}
+
+// TestMCPInfoReadOnlyDepthMirrorsTheDrivers holds the reported depth against
+// the two things that decide it.
+//
+// The classifier half is asked, not mirrored: HasQueryValidator is the registry
+// the clamp itself consults, so an engine gaining or losing a validator moves
+// here on the same commit and this test follows it.
+//
+// The session half cannot be asked — a driver reports it by acting on a flag
+// when a connection opens, and none exists here — so readOnlyDriverSession
+// mirrors the drivers by hand. What this pins is that mcpReadOnlyDepth reports
+// that table faithfully, NOT that the table matches the drivers: a fourth
+// driver that starts honoring the flag leaves both unchanged and this green.
+// Nothing in a unit test can catch that; the safe direction is that an
+// unmirrored driver understates its own depth rather than overstating it.
+func TestMCPInfoReadOnlyDepthMirrorsTheDrivers(t *testing.T) {
+	// readOnlyDriverSession's table, restated so an unmirrored edit to it fails.
+	sessionDepth := map[storepb.Engine]bool{
+		storepb.Engine_POSTGRES:    true,
+		storepb.Engine_COCKROACHDB: true,
+	}
+
+	values := storepb.Engine(0).Descriptor().Values()
+	for i := range values.Len() {
+		engine := storepb.Engine(values.Get(i).Number())
+		if engine == storepb.Engine_ENGINE_UNSPECIFIED {
+			continue
+		}
+		got := mcpReadOnlyDepth(engine)
+		switch {
+		case !parserbase.HasQueryValidator(engine):
+			require.Equal(t, v1pb.MCPEngineEnforcement_UNSUPPORTED, got,
+				"%v has no read-only classifier, so a read-only session is refused every statement", engine)
+		case sessionDepth[engine]:
+			require.Equal(t, v1pb.MCPEngineEnforcement_STATEMENT_AND_SESSION, got, "%v", engine)
+		default:
+			require.Equal(t, v1pb.MCPEngineEnforcement_STATEMENT, got, "%v", engine)
+		}
+	}
+
+	require.NotEmpty(t, mcpEngineNote(storepb.Engine_REDSHIFT),
+		"redshift's floor is only honest with the datashare exception said out loud")
+}
+
+// TestMCPInfoMaskingMirrorsTheMaskers holds the three masking states against
+// the two functions the query path branches on.
+//
+// It does not pin the branch ORDER, and cannot: it also pins that the two
+// predicates are disjoint, which is what makes the order unobservable. That
+// disjointness is the real invariant — an engine in both sets would make
+// document-first the only correct order, and the assertion below is what would
+// catch one appearing.
+//
+// The third state is the one worth having: a document engine masks, so it is
+// not "no masking", but the document masker's interface carries neither the
+// user nor their exemptions, so ignoring exemptions changes nothing there
+// (BOT-95). Collapsing it into either neighbour would overclaim.
+func TestMCPInfoMaskingMirrorsTheMaskers(t *testing.T) {
+	values := storepb.Engine(0).Descriptor().Values()
+	var column, document, none int
+	for i := range values.Len() {
+		engine := storepb.Engine(values.Get(i).Number())
+		if engine == storepb.Engine_ENGINE_UNSPECIFIED {
+			continue
+		}
+		got := mcpMaskingSupport(engine)
+		switch {
+		case getDocumentMasker(engine) != nil:
+			require.Equal(t, v1pb.MCPEngineEnforcement_DOCUMENT, got, "%v", engine)
+			require.False(t, common.EngineSupportMasking(engine),
+				"%v routes to the document masker, so the column masker is never reached", engine)
+			document++
+		case common.EngineSupportMasking(engine):
+			require.Equal(t, v1pb.MCPEngineEnforcement_COLUMN, got, "%v", engine)
+			column++
+		default:
+			require.Equal(t, v1pb.MCPEngineEnforcement_NONE, got, "%v", engine)
+			none++
+		}
+	}
+	require.Equal(t, 3, document, "cosmosdb, mongodb, elasticsearch")
+	require.NotZero(t, column)
+	require.NotZero(t, none)
+}
+
+// TestMCPInfoCoversEveryEngine pins that the response leaves no engine out: an
+// admin choosing read-only must not have to guess about the one engine the
+// table skipped.
+func TestMCPInfoCoversEveryEngine(t *testing.T) {
+	engines := mcpEngineEnforcement()
+	values := storepb.Engine(0).Descriptor().Values()
+	require.Len(t, engines, values.Len()-1, "every engine but the unspecified zero value")
+
+	seen := map[v1pb.Engine]bool{}
+	for _, e := range engines {
+		require.NotEqual(t, v1pb.Engine_ENGINE_UNSPECIFIED, e.Engine,
+			"an engine the v1 converter does not know would report as unspecified")
+		require.False(t, seen[e.Engine], "%v listed twice", e.Engine)
+		seen[e.Engine] = true
+	}
+}
+
+// TestGetMCPInfoHandler drives the RPC itself, which the helper tests above
+// cannot: they each hand mcpServedMethods a descriptor source, so nothing they
+// assert pins that the handler passes the real registry rather than a cached or
+// stored set — the one property this API exists to guarantee. They also leave
+// every error branch unexercised.
+func TestGetMCPInfoHandler(t *testing.T) {
+	ctx := context.Background()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+	require.NoError(t, migrator.MigrateSchema(ctx, container.GetDB()))
+
+	pgURL := fmt.Sprintf("host=%s port=%s user=postgres password=root-password database=postgres",
+		container.GetHost(), container.GetPort())
+	stores, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stores.Close()) })
+
+	licenseService, err := enterprise.NewLicenseService(common.ReleaseModeDev, stores, false, "")
+	require.NoError(t, err)
+	service := NewWorkspaceService(stores, nil, &config.Profile{}, licenseService, nil)
+
+	const workspaceID = "mcp-info-handler"
+	_, err = stores.CreateWorkspace(ctx, &store.WorkspaceMessage{
+		ResourceID: workspaceID,
+		Payload:    &storepb.WorkspacePayload{Title: "MCP info handler"},
+	}, "admin@example.com")
+	require.NoError(t, err)
+
+	get := func(ctx context.Context) (*v1pb.MCPInfo, error) {
+		resp, err := service.GetMCPInfo(ctx, connect.NewRequest(&v1pb.GetMCPInfoRequest{}))
+		if err != nil {
+			return nil, err
+		}
+		return resp.Msg, nil
+	}
+	workspaceCtx := func() context.Context {
+		return context.WithValue(ctx, common.WorkspaceIDContextKey, workspaceID)
+	}
+	setCeiling := func(t *testing.T, value string) {
+		t.Helper()
+		_, err := container.GetDB().ExecContext(ctx, `
+			INSERT INTO setting (name, workspace, value) VALUES ('MCP', $1, $2)
+			ON CONFLICT (workspace, name) DO UPDATE SET value = EXCLUDED.value`,
+			workspaceID, value)
+		require.NoError(t, err)
+	}
+
+	t.Run("a workspace that never configured MCP", func(t *testing.T) {
+		info, err := get(workspaceCtx())
+		require.NoError(t, err)
+		require.Equal(t, "workspaces/"+workspaceID, info.Workspace)
+		require.Equal(t, v1pb.MCPSetting_READ_WRITE, info.Capability)
+		require.False(t, info.IgnoreMaskingExemptions)
+
+		// The list is the live registry's, not a fixture: every entry must be a
+		// method this build actually compiled, and the count must match what
+		// the descriptors classify as served right now.
+		require.Equal(t, len(mcpServedMethods(protoregistry.GlobalFiles)), len(info.Methods))
+		byMethod := map[string]*v1pb.MCPMethod{}
+		for _, m := range info.Methods {
+			byMethod[m.Method] = m
+		}
+		query := byMethod["/bytebase.v1.SQLService/Query"]
+		require.NotNil(t, query, "the handler must resolve from the compiled descriptors")
+		require.Equal(t, "bytebase.v1.SQLService.Query", query.OperationId)
+		require.NotContains(t, byMethod, "/bytebase.v1.AuthService/Login",
+			"a FORBIDDEN method must never be advertised as reachable")
+
+		require.Len(t, info.Modes, 3)
+		require.NotEmpty(t, info.Engines)
+	})
+
+	t.Run("the toggle reaches the response", func(t *testing.T) {
+		setCeiling(t, `{"capability":"READ_ONLY","ignoreMaskingExemptions":true}`)
+		info, err := get(workspaceCtx())
+		require.NoError(t, err)
+		require.Equal(t, v1pb.MCPSetting_READ_ONLY, info.Capability)
+		require.True(t, info.IgnoreMaskingExemptions,
+			"every masking state is written in terms of this, so withholding it leaves the table unusable")
+	})
+
+	t.Run("a disabled workspace is still answered", func(t *testing.T) {
+		setCeiling(t, `{"capability":"DISABLED"}`)
+		info, err := get(workspaceCtx())
+		require.NoError(t, err)
+		require.Equal(t, v1pb.MCPSetting_DISABLED, info.Capability)
+		require.NotEmpty(t, info.Modes,
+			"an admin with MCP off is exactly who needs to see what the other modes contain")
+	})
+
+	t.Run("a ceiling this build cannot read fails closed", func(t *testing.T) {
+		setCeiling(t, `{"capability":"READ_ONLYY"}`)
+		_, err := get(workspaceCtx())
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		require.Contains(t, err.Error(), "not one this build understands")
+	})
+
+	t.Run("a ceiling this build does not serve fails closed", func(t *testing.T) {
+		// The reserved 2, or a value a newer release wrote. It parses, so
+		// nothing but the verdict catches it.
+		setCeiling(t, `{"capability":2}`)
+		_, err := get(workspaceCtx())
+		require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+		require.Contains(t, err.Error(), "not one this build serves")
+	})
+
+	t.Run("the gate's resolution wins over a second read", func(t *testing.T) {
+		// The stored ceiling still says DISABLED below; the gate admitted this
+		// request under READ_ONLY. Answering from the store would report a
+		// ceiling the request was not admitted under.
+		setCeiling(t, `{"capability":"DISABLED"}`)
+		stamped := withMCPSettings(workspaceCtx(), store.MCPSettings{
+			Capability:              storepb.MCPSetting_READ_ONLY,
+			IgnoreMaskingExemptions: true,
+		})
+		info, err := get(stamped)
+		require.NoError(t, err)
+		require.Equal(t, v1pb.MCPSetting_READ_ONLY, info.Capability)
+		require.True(t, info.IgnoreMaskingExemptions)
+	})
+
+	t.Run("no workspace on the request", func(t *testing.T) {
+		_, err := get(ctx)
+		require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+	})
+}

--- a/backend/api/v1/setting_service_converter.go
+++ b/backend/api/v1/setting_service_converter.go
@@ -384,12 +384,18 @@ func convertToStoreMCPCapability(c v1pb.MCPSetting_Capability) storepb.MCPSettin
 	return storepb.MCPSetting_Capability(c)
 }
 
+// convertToV1MCPCapability crosses the two Capability enums the other way, by
+// number. Same pin.
+func convertToV1MCPCapability(c storepb.MCPSetting_Capability) v1pb.MCPSetting_Capability {
+	return v1pb.MCPSetting_Capability(c)
+}
+
 func convertToMCPSetting(s *storepb.MCPSetting) *v1pb.MCPSetting {
 	if s == nil {
 		return nil
 	}
 	return &v1pb.MCPSetting{
-		Capability:              v1pb.MCPSetting_Capability(s.Capability),
+		Capability:              convertToV1MCPCapability(s.Capability),
 		IgnoreMaskingExemptions: s.IgnoreMaskingExemptions,
 	}
 }

--- a/backend/api/v1/testdata/mcp_method_classification.md
+++ b/backend/api/v1/testdata/mcp_method_classification.md
@@ -16,12 +16,12 @@ served by no ceiling.
 
 | Class | Methods | Meaning |
 |---|---|---|
-| READ | 56 | served to a read-only session and above |
+| READ | 57 | served to a read-only session and above |
 | WRITE | 40 | served to a read-write session only |
 | EXCLUDED | 86 | served by no ceiling this phase ships |
 | FORBIDDEN | 28 | never served, whatever the ceiling |
 | MCP_METHOD_CLASS_UNSPECIFIED | 0 | unclassified — CI rejects this, and the gate refuses it |
-| **total** | **210** | |
+| **total** | **211** | |
 
 | Method | Class | Reason | Permission |
 |---|---|---|---|
@@ -229,6 +229,7 @@ served by no ceiling.
 | WorkloadIdentityService/UpdateWorkloadIdentity | FORBIDDEN | MINTS_CREDENTIAL_FOR_OTHERS | bb.workloadIdentities.update |
 | WorkspaceService/DeleteWorkspace | FORBIDDEN | ENDS_MEMBERSHIP | bb.workspaces.delete |
 | WorkspaceService/GetIamPolicy | EXCLUDED | ADMINISTERS_THE_WORKSPACE | bb.workspaces.getIamPolicy |
+| WorkspaceService/GetMCPInfo | READ | — | — |
 | WorkspaceService/GetWorkspace | READ | — | — |
 | WorkspaceService/LeaveWorkspace | FORBIDDEN | ENDS_MEMBERSHIP | — |
 | WorkspaceService/ListWorkspaces | READ | — | — |

--- a/backend/generated-go/v1/v1connect/workspace_service.connect.go
+++ b/backend/generated-go/v1/v1connect/workspace_service.connect.go
@@ -54,6 +54,9 @@ const (
 	// WorkspaceServiceSetIamPolicyProcedure is the fully-qualified name of the WorkspaceService's
 	// SetIamPolicy RPC.
 	WorkspaceServiceSetIamPolicyProcedure = "/bytebase.v1.WorkspaceService/SetIamPolicy"
+	// WorkspaceServiceGetMCPInfoProcedure is the fully-qualified name of the WorkspaceService's
+	// GetMCPInfo RPC.
+	WorkspaceServiceGetMCPInfoProcedure = "/bytebase.v1.WorkspaceService/GetMCPInfo"
 	// WorkspaceServiceRotateDirectorySyncTokenProcedure is the fully-qualified name of the
 	// WorkspaceService's RotateDirectorySyncToken RPC.
 	WorkspaceServiceRotateDirectorySyncTokenProcedure = "/bytebase.v1.WorkspaceService/RotateDirectorySyncToken"
@@ -85,6 +88,18 @@ type WorkspaceServiceClient interface {
 	// Sets IAM policy for the workspace.
 	// Permissions required: bb.workspaces.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
+	// Gets what MCP (Model Context Protocol) does in this workspace: the
+	// capability ceiling in force, what each ceiling serves, and the per-engine
+	// facts a read-only session depends on. The workspace is resolved from the
+	// authenticated session.
+	//
+	// Served to MCP sessions. An agent asking what it may do here is the point:
+	// the response says nothing a session's own denials do not already say, one
+	// refusal at a time, and knowing it up front is what stops the agent
+	// planning work the ceiling was never going to serve.
+	//
+	// Permissions required: None (authentication required)
+	GetMCPInfo(context.Context, *connect.Request[v1.GetMCPInfoRequest]) (*connect.Response[v1.MCPInfo], error)
 	// Mints a new directory sync (SCIM) token, immediately invalidating the
 	// previous one. The plaintext token is returned exactly once and cannot be
 	// retrieved afterwards; only its hash is stored. Callers that lose it must
@@ -146,6 +161,12 @@ func NewWorkspaceServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(workspaceServiceMethods.ByName("SetIamPolicy")),
 			connect.WithClientOptions(opts...),
 		),
+		getMCPInfo: connect.NewClient[v1.GetMCPInfoRequest, v1.MCPInfo](
+			httpClient,
+			baseURL+WorkspaceServiceGetMCPInfoProcedure,
+			connect.WithSchema(workspaceServiceMethods.ByName("GetMCPInfo")),
+			connect.WithClientOptions(opts...),
+		),
 		rotateDirectorySyncToken: connect.NewClient[v1.RotateDirectorySyncTokenRequest, v1.RotateDirectorySyncTokenResponse](
 			httpClient,
 			baseURL+WorkspaceServiceRotateDirectorySyncTokenProcedure,
@@ -164,6 +185,7 @@ type workspaceServiceClient struct {
 	deleteWorkspace          *connect.Client[v1.DeleteWorkspaceRequest, v1.LoginResponse]
 	leaveWorkspace           *connect.Client[v1.LeaveWorkspaceRequest, v1.LoginResponse]
 	setIamPolicy             *connect.Client[v1.SetIamPolicyRequest, v1.IamPolicy]
+	getMCPInfo               *connect.Client[v1.GetMCPInfoRequest, v1.MCPInfo]
 	rotateDirectorySyncToken *connect.Client[v1.RotateDirectorySyncTokenRequest, v1.RotateDirectorySyncTokenResponse]
 }
 
@@ -202,6 +224,11 @@ func (c *workspaceServiceClient) SetIamPolicy(ctx context.Context, req *connect.
 	return c.setIamPolicy.CallUnary(ctx, req)
 }
 
+// GetMCPInfo calls bytebase.v1.WorkspaceService.GetMCPInfo.
+func (c *workspaceServiceClient) GetMCPInfo(ctx context.Context, req *connect.Request[v1.GetMCPInfoRequest]) (*connect.Response[v1.MCPInfo], error) {
+	return c.getMCPInfo.CallUnary(ctx, req)
+}
+
 // RotateDirectorySyncToken calls bytebase.v1.WorkspaceService.RotateDirectorySyncToken.
 func (c *workspaceServiceClient) RotateDirectorySyncToken(ctx context.Context, req *connect.Request[v1.RotateDirectorySyncTokenRequest]) (*connect.Response[v1.RotateDirectorySyncTokenResponse], error) {
 	return c.rotateDirectorySyncToken.CallUnary(ctx, req)
@@ -233,6 +260,18 @@ type WorkspaceServiceHandler interface {
 	// Sets IAM policy for the workspace.
 	// Permissions required: bb.workspaces.setIamPolicy
 	SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error)
+	// Gets what MCP (Model Context Protocol) does in this workspace: the
+	// capability ceiling in force, what each ceiling serves, and the per-engine
+	// facts a read-only session depends on. The workspace is resolved from the
+	// authenticated session.
+	//
+	// Served to MCP sessions. An agent asking what it may do here is the point:
+	// the response says nothing a session's own denials do not already say, one
+	// refusal at a time, and knowing it up front is what stops the agent
+	// planning work the ceiling was never going to serve.
+	//
+	// Permissions required: None (authentication required)
+	GetMCPInfo(context.Context, *connect.Request[v1.GetMCPInfoRequest]) (*connect.Response[v1.MCPInfo], error)
 	// Mints a new directory sync (SCIM) token, immediately invalidating the
 	// previous one. The plaintext token is returned exactly once and cannot be
 	// retrieved afterwards; only its hash is stored. Callers that lose it must
@@ -290,6 +329,12 @@ func NewWorkspaceServiceHandler(svc WorkspaceServiceHandler, opts ...connect.Han
 		connect.WithSchema(workspaceServiceMethods.ByName("SetIamPolicy")),
 		connect.WithHandlerOptions(opts...),
 	)
+	workspaceServiceGetMCPInfoHandler := connect.NewUnaryHandler(
+		WorkspaceServiceGetMCPInfoProcedure,
+		svc.GetMCPInfo,
+		connect.WithSchema(workspaceServiceMethods.ByName("GetMCPInfo")),
+		connect.WithHandlerOptions(opts...),
+	)
 	workspaceServiceRotateDirectorySyncTokenHandler := connect.NewUnaryHandler(
 		WorkspaceServiceRotateDirectorySyncTokenProcedure,
 		svc.RotateDirectorySyncToken,
@@ -312,6 +357,8 @@ func NewWorkspaceServiceHandler(svc WorkspaceServiceHandler, opts ...connect.Han
 			workspaceServiceLeaveWorkspaceHandler.ServeHTTP(w, r)
 		case WorkspaceServiceSetIamPolicyProcedure:
 			workspaceServiceSetIamPolicyHandler.ServeHTTP(w, r)
+		case WorkspaceServiceGetMCPInfoProcedure:
+			workspaceServiceGetMCPInfoHandler.ServeHTTP(w, r)
 		case WorkspaceServiceRotateDirectorySyncTokenProcedure:
 			workspaceServiceRotateDirectorySyncTokenHandler.ServeHTTP(w, r)
 		default:
@@ -349,6 +396,10 @@ func (UnimplementedWorkspaceServiceHandler) LeaveWorkspace(context.Context, *con
 
 func (UnimplementedWorkspaceServiceHandler) SetIamPolicy(context.Context, *connect.Request[v1.SetIamPolicyRequest]) (*connect.Response[v1.IamPolicy], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bytebase.v1.WorkspaceService.SetIamPolicy is not implemented"))
+}
+
+func (UnimplementedWorkspaceServiceHandler) GetMCPInfo(context.Context, *connect.Request[v1.GetMCPInfoRequest]) (*connect.Response[v1.MCPInfo], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("bytebase.v1.WorkspaceService.GetMCPInfo is not implemented"))
 }
 
 func (UnimplementedWorkspaceServiceHandler) RotateDirectorySyncToken(context.Context, *connect.Request[v1.RotateDirectorySyncTokenRequest]) (*connect.Response[v1.RotateDirectorySyncTokenResponse], error) {

--- a/backend/generated-go/v1/workspace_service.pb.go
+++ b/backend/generated-go/v1/workspace_service.pb.go
@@ -23,6 +23,506 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// How much of a read-only ceiling this engine can be held to.
+type MCPEngineEnforcement_ReadOnlyDepth int32
+
+const (
+	MCPEngineEnforcement_READ_ONLY_DEPTH_UNSPECIFIED MCPEngineEnforcement_ReadOnlyDepth = 0
+	// Bytebase has no read-only classifier for this engine, so a read-only
+	// session is refused every statement on it, including a plain SELECT.
+	MCPEngineEnforcement_UNSUPPORTED MCPEngineEnforcement_ReadOnlyDepth = 1
+	// Every statement is classified before it runs and a request holding one
+	// that is not a read is refused whole. Nothing below that: the driver does
+	// not open a read-only database session, except where the note says
+	// otherwise.
+	MCPEngineEnforcement_STATEMENT MCPEngineEnforcement_ReadOnlyDepth = 2
+	// Statement classification, and the driver opens the database session
+	// read-only as well, so the engine refuses most writes the classifier
+	// missed. Not a proof: a statement that classifies as a read can still call
+	// a function that switches the session setting back off.
+	MCPEngineEnforcement_STATEMENT_AND_SESSION MCPEngineEnforcement_ReadOnlyDepth = 3
+)
+
+// Enum value maps for MCPEngineEnforcement_ReadOnlyDepth.
+var (
+	MCPEngineEnforcement_ReadOnlyDepth_name = map[int32]string{
+		0: "READ_ONLY_DEPTH_UNSPECIFIED",
+		1: "UNSUPPORTED",
+		2: "STATEMENT",
+		3: "STATEMENT_AND_SESSION",
+	}
+	MCPEngineEnforcement_ReadOnlyDepth_value = map[string]int32{
+		"READ_ONLY_DEPTH_UNSPECIFIED": 0,
+		"UNSUPPORTED":                 1,
+		"STATEMENT":                   2,
+		"STATEMENT_AND_SESSION":       3,
+	}
+)
+
+func (x MCPEngineEnforcement_ReadOnlyDepth) Enum() *MCPEngineEnforcement_ReadOnlyDepth {
+	p := new(MCPEngineEnforcement_ReadOnlyDepth)
+	*p = x
+	return p
+}
+
+func (x MCPEngineEnforcement_ReadOnlyDepth) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (MCPEngineEnforcement_ReadOnlyDepth) Descriptor() protoreflect.EnumDescriptor {
+	return file_v1_workspace_service_proto_enumTypes[0].Descriptor()
+}
+
+func (MCPEngineEnforcement_ReadOnlyDepth) Type() protoreflect.EnumType {
+	return &file_v1_workspace_service_proto_enumTypes[0]
+}
+
+func (x MCPEngineEnforcement_ReadOnlyDepth) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use MCPEngineEnforcement_ReadOnlyDepth.Descriptor instead.
+func (MCPEngineEnforcement_ReadOnlyDepth) EnumDescriptor() ([]byte, []int) {
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{4, 0}
+}
+
+// How Bytebase masks results on this engine, which is what decides whether
+// ignoring masking exemptions changes anything here.
+type MCPEngineEnforcement_Masking int32
+
+const (
+	MCPEngineEnforcement_MASKING_UNSPECIFIED MCPEngineEnforcement_Masking = 0
+	// Bytebase does not mask on this engine. Nothing narrows what a session
+	// reads, and ignoring masking exemptions does nothing.
+	MCPEngineEnforcement_NONE MCPEngineEnforcement_Masking = 1
+	// Column masking. A masking policy substitutes values in query results,
+	// and the exemptions granted to the caller are what let them see the real
+	// value — which is what ignoring exemptions suppresses.
+	MCPEngineEnforcement_COLUMN MCPEngineEnforcement_Masking = 2
+	// Document masking. Results are masked, but exemptions are never consulted
+	// on this path, so ignoring them changes nothing here either.
+	MCPEngineEnforcement_DOCUMENT MCPEngineEnforcement_Masking = 3
+)
+
+// Enum value maps for MCPEngineEnforcement_Masking.
+var (
+	MCPEngineEnforcement_Masking_name = map[int32]string{
+		0: "MASKING_UNSPECIFIED",
+		1: "NONE",
+		2: "COLUMN",
+		3: "DOCUMENT",
+	}
+	MCPEngineEnforcement_Masking_value = map[string]int32{
+		"MASKING_UNSPECIFIED": 0,
+		"NONE":                1,
+		"COLUMN":              2,
+		"DOCUMENT":            3,
+	}
+)
+
+func (x MCPEngineEnforcement_Masking) Enum() *MCPEngineEnforcement_Masking {
+	p := new(MCPEngineEnforcement_Masking)
+	*p = x
+	return p
+}
+
+func (x MCPEngineEnforcement_Masking) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (MCPEngineEnforcement_Masking) Descriptor() protoreflect.EnumDescriptor {
+	return file_v1_workspace_service_proto_enumTypes[1].Descriptor()
+}
+
+func (MCPEngineEnforcement_Masking) Type() protoreflect.EnumType {
+	return &file_v1_workspace_service_proto_enumTypes[1]
+}
+
+func (x MCPEngineEnforcement_Masking) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use MCPEngineEnforcement_Masking.Descriptor instead.
+func (MCPEngineEnforcement_Masking) EnumDescriptor() ([]byte, []int) {
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{4, 1}
+}
+
+type GetMCPInfoRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetMCPInfoRequest) Reset() {
+	*x = GetMCPInfoRequest{}
+	mi := &file_v1_workspace_service_proto_msgTypes[0]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetMCPInfoRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetMCPInfoRequest) ProtoMessage() {}
+
+func (x *GetMCPInfoRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_workspace_service_proto_msgTypes[0]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetMCPInfoRequest.ProtoReflect.Descriptor instead.
+func (*GetMCPInfoRequest) Descriptor() ([]byte, []int) {
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{0}
+}
+
+// MCPInfo is what MCP does in this workspace: the ceiling in force, what each
+// ceiling serves, and the per-engine facts a read-only session depends on.
+//
+// Everything here is resolved when the request is served, never from a stored
+// copy: the method list comes off the compiled API descriptors and the engine
+// answers off the code that enforces them, so a build whose rules changed
+// cannot describe the rules of the build before it.
+type MCPInfo struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The workspace this describes. Format: workspaces/{workspace}. Not this
+	// message's own resource name — MCPInfo is not a named resource and there is
+	// nothing to get it by.
+	Workspace string `protobuf:"bytes,1,opt,name=workspace,proto3" json:"workspace,omitempty"`
+	// The ceiling in force for this workspace. A workspace that never configured
+	// MCP resolves to READ_WRITE.
+	Capability MCPSetting_Capability `protobuf:"varint,2,opt,name=capability,proto3,enum=bytebase.v1.MCPSetting_Capability" json:"capability,omitempty"`
+	// What each ceiling serves, including the one in force, so an admin can
+	// compare the choices rather than only read the current answer.
+	Modes []*MCPCapabilityMode `protobuf:"bytes,3,rep,name=modes,proto3" json:"modes,omitempty"`
+	// Every API method some ceiling serves. A mode serves a method when the
+	// method's class is one of that mode's served_classes, which is the ceiling
+	// rule the gate evaluates. Methods no ceiling serves are absent.
+	//
+	// Being listed is necessary, not sufficient. The caller still needs the
+	// permission, and two further rules narrow what a served method does: a
+	// handful of methods are refused on the shape of the request (an issue that
+	// would grant a permission, a rollout that skips approval), and under
+	// READ_ONLY every statement SQLService/Query runs must classify as a read.
+	Methods []*MCPMethod `protobuf:"bytes,4,rep,name=methods,proto3" json:"methods,omitempty"`
+	// What a read-only session and the masking toggle actually reach, per engine.
+	// Both are engine-conditional in ways the ceiling alone does not show.
+	Engines []*MCPEngineEnforcement `protobuf:"bytes,5,rep,name=engines,proto3" json:"engines,omitempty"`
+	// Whether this workspace stops applying the caller's own unmasking
+	// provisioning to MCP requests. It decides which branch of each engine's
+	// masking state a caller is in, and no other API tells an MCP session:
+	// SettingService/GetSetting is served by no ceiling.
+	IgnoreMaskingExemptions bool `protobuf:"varint,6,opt,name=ignore_masking_exemptions,json=ignoreMaskingExemptions,proto3" json:"ignore_masking_exemptions,omitempty"`
+	// Whether data masking is licensed for this workspace. When false nothing is
+	// masked whatever an engine supports, so the masking states below describe a
+	// mechanism that does not run. Licensing can also be set per instance, so a
+	// true here is the workspace answer, not a promise about every instance.
+	DataMaskingAvailable bool `protobuf:"varint,7,opt,name=data_masking_available,json=dataMaskingAvailable,proto3" json:"data_masking_available,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *MCPInfo) Reset() {
+	*x = MCPInfo{}
+	mi := &file_v1_workspace_service_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MCPInfo) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MCPInfo) ProtoMessage() {}
+
+func (x *MCPInfo) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_workspace_service_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MCPInfo.ProtoReflect.Descriptor instead.
+func (*MCPInfo) Descriptor() ([]byte, []int) {
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *MCPInfo) GetWorkspace() string {
+	if x != nil {
+		return x.Workspace
+	}
+	return ""
+}
+
+func (x *MCPInfo) GetCapability() MCPSetting_Capability {
+	if x != nil {
+		return x.Capability
+	}
+	return MCPSetting_CAPABILITY_UNSPECIFIED
+}
+
+func (x *MCPInfo) GetModes() []*MCPCapabilityMode {
+	if x != nil {
+		return x.Modes
+	}
+	return nil
+}
+
+func (x *MCPInfo) GetMethods() []*MCPMethod {
+	if x != nil {
+		return x.Methods
+	}
+	return nil
+}
+
+func (x *MCPInfo) GetEngines() []*MCPEngineEnforcement {
+	if x != nil {
+		return x.Engines
+	}
+	return nil
+}
+
+func (x *MCPInfo) GetIgnoreMaskingExemptions() bool {
+	if x != nil {
+		return x.IgnoreMaskingExemptions
+	}
+	return false
+}
+
+func (x *MCPInfo) GetDataMaskingAvailable() bool {
+	if x != nil {
+		return x.DataMaskingAvailable
+	}
+	return false
+}
+
+// MCPCapabilityMode is one ceiling and the method classes it serves.
+type MCPCapabilityMode struct {
+	state      protoimpl.MessageState `protogen:"open.v1"`
+	Capability MCPSetting_Capability  `protobuf:"varint,1,opt,name=capability,proto3,enum=bytebase.v1.MCPSetting_Capability" json:"capability,omitempty"`
+	// Empty means the ceiling serves nothing, which is what DISABLED is.
+	ServedClasses []MCPMethodClass `protobuf:"varint,2,rep,packed,name=served_classes,json=servedClasses,proto3,enum=bytebase.v1.MCPMethodClass" json:"served_classes,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MCPCapabilityMode) Reset() {
+	*x = MCPCapabilityMode{}
+	mi := &file_v1_workspace_service_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MCPCapabilityMode) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MCPCapabilityMode) ProtoMessage() {}
+
+func (x *MCPCapabilityMode) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_workspace_service_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MCPCapabilityMode.ProtoReflect.Descriptor instead.
+func (*MCPCapabilityMode) Descriptor() ([]byte, []int) {
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *MCPCapabilityMode) GetCapability() MCPSetting_Capability {
+	if x != nil {
+		return x.Capability
+	}
+	return MCPSetting_CAPABILITY_UNSPECIFIED
+}
+
+func (x *MCPCapabilityMode) GetServedClasses() []MCPMethodClass {
+	if x != nil {
+		return x.ServedClasses
+	}
+	return nil
+}
+
+// MCPMethod is one API method an MCP session can reach, and what decides it.
+type MCPMethod struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The method as an audit entry names it, so a denial can be found by it.
+	// Example: /bytebase.v1.SQLService/Query
+	Method string `protobuf:"bytes,1,opt,name=method,proto3" json:"method,omitempty"`
+	// The same method as call_api takes it.
+	// Example: bytebase.v1.SQLService.Query
+	OperationId string         `protobuf:"bytes,4,opt,name=operation_id,json=operationId,proto3" json:"operation_id,omitempty"`
+	Class       MCPMethodClass `protobuf:"varint,2,opt,name=class,proto3,enum=bytebase.v1.MCPMethodClass" json:"class,omitempty"`
+	// The IAM permission the method declares. The ceiling never grants: a session
+	// may call a served method only where the person it acts for could.
+	//
+	// Empty means the method declares no permission, which is NOT the same as
+	// needing none — a method that authorizes inside its handler declares nothing
+	// here. auth_method says which case an empty value is.
+	Permission string `protobuf:"bytes,3,opt,name=permission,proto3" json:"permission,omitempty"`
+	// How the method authorizes. IAM means the permission above is the whole
+	// rule; CUSTOM means the handler decides and the permission field is silent.
+	AuthMethod    AuthMethod `protobuf:"varint,5,opt,name=auth_method,json=authMethod,proto3,enum=bytebase.v1.AuthMethod" json:"auth_method,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MCPMethod) Reset() {
+	*x = MCPMethod{}
+	mi := &file_v1_workspace_service_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MCPMethod) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MCPMethod) ProtoMessage() {}
+
+func (x *MCPMethod) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_workspace_service_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MCPMethod.ProtoReflect.Descriptor instead.
+func (*MCPMethod) Descriptor() ([]byte, []int) {
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *MCPMethod) GetMethod() string {
+	if x != nil {
+		return x.Method
+	}
+	return ""
+}
+
+func (x *MCPMethod) GetOperationId() string {
+	if x != nil {
+		return x.OperationId
+	}
+	return ""
+}
+
+func (x *MCPMethod) GetClass() MCPMethodClass {
+	if x != nil {
+		return x.Class
+	}
+	return MCPMethodClass_MCP_METHOD_CLASS_UNSPECIFIED
+}
+
+func (x *MCPMethod) GetPermission() string {
+	if x != nil {
+		return x.Permission
+	}
+	return ""
+}
+
+func (x *MCPMethod) GetAuthMethod() AuthMethod {
+	if x != nil {
+		return x.AuthMethod
+	}
+	return AuthMethod_AUTH_METHOD_UNSPECIFIED
+}
+
+// MCPEngineEnforcement is what the read-only ceiling and the masking toggle
+// reach on one database engine.
+type MCPEngineEnforcement struct {
+	state         protoimpl.MessageState             `protogen:"open.v1"`
+	Engine        Engine                             `protobuf:"varint,1,opt,name=engine,proto3,enum=bytebase.v1.Engine" json:"engine,omitempty"`
+	ReadOnlyDepth MCPEngineEnforcement_ReadOnlyDepth `protobuf:"varint,2,opt,name=read_only_depth,json=readOnlyDepth,proto3,enum=bytebase.v1.MCPEngineEnforcement_ReadOnlyDepth" json:"read_only_depth,omitempty"`
+	Masking       MCPEngineEnforcement_Masking       `protobuf:"varint,3,opt,name=masking,proto3,enum=bytebase.v1.MCPEngineEnforcement_Masking" json:"masking,omitempty"`
+	// Where the answers above are the floor rather than the whole story. Empty
+	// for most engines.
+	Note          string `protobuf:"bytes,4,opt,name=note,proto3" json:"note,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MCPEngineEnforcement) Reset() {
+	*x = MCPEngineEnforcement{}
+	mi := &file_v1_workspace_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MCPEngineEnforcement) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MCPEngineEnforcement) ProtoMessage() {}
+
+func (x *MCPEngineEnforcement) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_workspace_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MCPEngineEnforcement.ProtoReflect.Descriptor instead.
+func (*MCPEngineEnforcement) Descriptor() ([]byte, []int) {
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *MCPEngineEnforcement) GetEngine() Engine {
+	if x != nil {
+		return x.Engine
+	}
+	return Engine_ENGINE_UNSPECIFIED
+}
+
+func (x *MCPEngineEnforcement) GetReadOnlyDepth() MCPEngineEnforcement_ReadOnlyDepth {
+	if x != nil {
+		return x.ReadOnlyDepth
+	}
+	return MCPEngineEnforcement_READ_ONLY_DEPTH_UNSPECIFIED
+}
+
+func (x *MCPEngineEnforcement) GetMasking() MCPEngineEnforcement_Masking {
+	if x != nil {
+		return x.Masking
+	}
+	return MCPEngineEnforcement_MASKING_UNSPECIFIED
+}
+
+func (x *MCPEngineEnforcement) GetNote() string {
+	if x != nil {
+		return x.Note
+	}
+	return ""
+}
+
 type RotateDirectorySyncTokenRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The workspace whose directory sync token is rotated.
@@ -34,7 +534,7 @@ type RotateDirectorySyncTokenRequest struct {
 
 func (x *RotateDirectorySyncTokenRequest) Reset() {
 	*x = RotateDirectorySyncTokenRequest{}
-	mi := &file_v1_workspace_service_proto_msgTypes[0]
+	mi := &file_v1_workspace_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -46,7 +546,7 @@ func (x *RotateDirectorySyncTokenRequest) String() string {
 func (*RotateDirectorySyncTokenRequest) ProtoMessage() {}
 
 func (x *RotateDirectorySyncTokenRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_workspace_service_proto_msgTypes[0]
+	mi := &file_v1_workspace_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59,7 +559,7 @@ func (x *RotateDirectorySyncTokenRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotateDirectorySyncTokenRequest.ProtoReflect.Descriptor instead.
 func (*RotateDirectorySyncTokenRequest) Descriptor() ([]byte, []int) {
-	return file_v1_workspace_service_proto_rawDescGZIP(), []int{0}
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *RotateDirectorySyncTokenRequest) GetName() string {
@@ -79,7 +579,7 @@ type RotateDirectorySyncTokenResponse struct {
 
 func (x *RotateDirectorySyncTokenResponse) Reset() {
 	*x = RotateDirectorySyncTokenResponse{}
-	mi := &file_v1_workspace_service_proto_msgTypes[1]
+	mi := &file_v1_workspace_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -91,7 +591,7 @@ func (x *RotateDirectorySyncTokenResponse) String() string {
 func (*RotateDirectorySyncTokenResponse) ProtoMessage() {}
 
 func (x *RotateDirectorySyncTokenResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_workspace_service_proto_msgTypes[1]
+	mi := &file_v1_workspace_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -104,7 +604,7 @@ func (x *RotateDirectorySyncTokenResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RotateDirectorySyncTokenResponse.ProtoReflect.Descriptor instead.
 func (*RotateDirectorySyncTokenResponse) Descriptor() ([]byte, []int) {
-	return file_v1_workspace_service_proto_rawDescGZIP(), []int{1}
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *RotateDirectorySyncTokenResponse) GetToken() string {
@@ -122,7 +622,7 @@ type ListWorkspacesRequest struct {
 
 func (x *ListWorkspacesRequest) Reset() {
 	*x = ListWorkspacesRequest{}
-	mi := &file_v1_workspace_service_proto_msgTypes[2]
+	mi := &file_v1_workspace_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -134,7 +634,7 @@ func (x *ListWorkspacesRequest) String() string {
 func (*ListWorkspacesRequest) ProtoMessage() {}
 
 func (x *ListWorkspacesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_workspace_service_proto_msgTypes[2]
+	mi := &file_v1_workspace_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -147,7 +647,7 @@ func (x *ListWorkspacesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacesRequest.ProtoReflect.Descriptor instead.
 func (*ListWorkspacesRequest) Descriptor() ([]byte, []int) {
-	return file_v1_workspace_service_proto_rawDescGZIP(), []int{2}
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{7}
 }
 
 type ListWorkspacesResponse struct {
@@ -159,7 +659,7 @@ type ListWorkspacesResponse struct {
 
 func (x *ListWorkspacesResponse) Reset() {
 	*x = ListWorkspacesResponse{}
-	mi := &file_v1_workspace_service_proto_msgTypes[3]
+	mi := &file_v1_workspace_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -171,7 +671,7 @@ func (x *ListWorkspacesResponse) String() string {
 func (*ListWorkspacesResponse) ProtoMessage() {}
 
 func (x *ListWorkspacesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_workspace_service_proto_msgTypes[3]
+	mi := &file_v1_workspace_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -184,7 +684,7 @@ func (x *ListWorkspacesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListWorkspacesResponse.ProtoReflect.Descriptor instead.
 func (*ListWorkspacesResponse) Descriptor() ([]byte, []int) {
-	return file_v1_workspace_service_proto_rawDescGZIP(), []int{3}
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ListWorkspacesResponse) GetWorkspaces() []*Workspace {
@@ -205,7 +705,7 @@ type GetWorkspaceRequest struct {
 
 func (x *GetWorkspaceRequest) Reset() {
 	*x = GetWorkspaceRequest{}
-	mi := &file_v1_workspace_service_proto_msgTypes[4]
+	mi := &file_v1_workspace_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -217,7 +717,7 @@ func (x *GetWorkspaceRequest) String() string {
 func (*GetWorkspaceRequest) ProtoMessage() {}
 
 func (x *GetWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_workspace_service_proto_msgTypes[4]
+	mi := &file_v1_workspace_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -230,7 +730,7 @@ func (x *GetWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*GetWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_v1_workspace_service_proto_rawDescGZIP(), []int{4}
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetWorkspaceRequest) GetName() string {
@@ -253,7 +753,7 @@ type Workspace struct {
 
 func (x *Workspace) Reset() {
 	*x = Workspace{}
-	mi := &file_v1_workspace_service_proto_msgTypes[5]
+	mi := &file_v1_workspace_service_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -265,7 +765,7 @@ func (x *Workspace) String() string {
 func (*Workspace) ProtoMessage() {}
 
 func (x *Workspace) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_workspace_service_proto_msgTypes[5]
+	mi := &file_v1_workspace_service_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -278,7 +778,7 @@ func (x *Workspace) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Workspace.ProtoReflect.Descriptor instead.
 func (*Workspace) Descriptor() ([]byte, []int) {
-	return file_v1_workspace_service_proto_rawDescGZIP(), []int{5}
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *Workspace) GetName() string {
@@ -312,7 +812,7 @@ type DeleteWorkspaceRequest struct {
 
 func (x *DeleteWorkspaceRequest) Reset() {
 	*x = DeleteWorkspaceRequest{}
-	mi := &file_v1_workspace_service_proto_msgTypes[6]
+	mi := &file_v1_workspace_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -324,7 +824,7 @@ func (x *DeleteWorkspaceRequest) String() string {
 func (*DeleteWorkspaceRequest) ProtoMessage() {}
 
 func (x *DeleteWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_workspace_service_proto_msgTypes[6]
+	mi := &file_v1_workspace_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -337,7 +837,7 @@ func (x *DeleteWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*DeleteWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_v1_workspace_service_proto_rawDescGZIP(), []int{6}
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DeleteWorkspaceRequest) GetName() string {
@@ -357,7 +857,7 @@ type UpdateWorkspaceRequest struct {
 
 func (x *UpdateWorkspaceRequest) Reset() {
 	*x = UpdateWorkspaceRequest{}
-	mi := &file_v1_workspace_service_proto_msgTypes[7]
+	mi := &file_v1_workspace_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -369,7 +869,7 @@ func (x *UpdateWorkspaceRequest) String() string {
 func (*UpdateWorkspaceRequest) ProtoMessage() {}
 
 func (x *UpdateWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_workspace_service_proto_msgTypes[7]
+	mi := &file_v1_workspace_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -382,7 +882,7 @@ func (x *UpdateWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*UpdateWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_v1_workspace_service_proto_rawDescGZIP(), []int{7}
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *UpdateWorkspaceRequest) GetWorkspace() *Workspace {
@@ -409,7 +909,7 @@ type LeaveWorkspaceRequest struct {
 
 func (x *LeaveWorkspaceRequest) Reset() {
 	*x = LeaveWorkspaceRequest{}
-	mi := &file_v1_workspace_service_proto_msgTypes[8]
+	mi := &file_v1_workspace_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -421,7 +921,7 @@ func (x *LeaveWorkspaceRequest) String() string {
 func (*LeaveWorkspaceRequest) ProtoMessage() {}
 
 func (x *LeaveWorkspaceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_workspace_service_proto_msgTypes[8]
+	mi := &file_v1_workspace_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -434,7 +934,7 @@ func (x *LeaveWorkspaceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LeaveWorkspaceRequest.ProtoReflect.Descriptor instead.
 func (*LeaveWorkspaceRequest) Descriptor() ([]byte, []int) {
-	return file_v1_workspace_service_proto_rawDescGZIP(), []int{8}
+	return file_v1_workspace_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *LeaveWorkspaceRequest) GetName() string {
@@ -448,7 +948,48 @@ var File_v1_workspace_service_proto protoreflect.FileDescriptor
 
 const file_v1_workspace_service_proto_rawDesc = "" +
 	"\n" +
-	"\x1av1/workspace_service.proto\x12\vbytebase.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x17google/api/client.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a\x19google/api/resource.proto\x1a google/protobuf/field_mask.proto\x1a\x13v1/annotation.proto\x1a\x15v1/auth_service.proto\x1a\x13v1/iam_policy.proto\"U\n" +
+	"\x1av1/workspace_service.proto\x12\vbytebase.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x17google/api/client.proto\x1a\x1fgoogle/api/field_behavior.proto\x1a\x19google/api/resource.proto\x1a google/protobuf/field_mask.proto\x1a\x13v1/annotation.proto\x1a\x15v1/auth_service.proto\x1a\x0fv1/common.proto\x1a\x13v1/iam_policy.proto\x1a\x18v1/setting_service.proto\"\x13\n" +
+	"\x11GetMCPInfoRequest\"\xa5\x03\n" +
+	"\aMCPInfo\x12!\n" +
+	"\tworkspace\x18\x01 \x01(\tB\x03\xe0A\x03R\tworkspace\x12G\n" +
+	"\n" +
+	"capability\x18\x02 \x01(\x0e2\".bytebase.v1.MCPSetting.CapabilityB\x03\xe0A\x03R\n" +
+	"capability\x129\n" +
+	"\x05modes\x18\x03 \x03(\v2\x1e.bytebase.v1.MCPCapabilityModeB\x03\xe0A\x03R\x05modes\x125\n" +
+	"\amethods\x18\x04 \x03(\v2\x16.bytebase.v1.MCPMethodB\x03\xe0A\x03R\amethods\x12@\n" +
+	"\aengines\x18\x05 \x03(\v2!.bytebase.v1.MCPEngineEnforcementB\x03\xe0A\x03R\aengines\x12?\n" +
+	"\x19ignore_masking_exemptions\x18\x06 \x01(\bB\x03\xe0A\x03R\x17ignoreMaskingExemptions\x129\n" +
+	"\x16data_masking_available\x18\a \x01(\bB\x03\xe0A\x03R\x14dataMaskingAvailable\"\x9b\x01\n" +
+	"\x11MCPCapabilityMode\x12B\n" +
+	"\n" +
+	"capability\x18\x01 \x01(\x0e2\".bytebase.v1.MCPSetting.CapabilityR\n" +
+	"capability\x12B\n" +
+	"\x0eserved_classes\x18\x02 \x03(\x0e2\x1b.bytebase.v1.MCPMethodClassR\rservedClasses\"\xd3\x01\n" +
+	"\tMCPMethod\x12\x16\n" +
+	"\x06method\x18\x01 \x01(\tR\x06method\x12!\n" +
+	"\foperation_id\x18\x04 \x01(\tR\voperationId\x121\n" +
+	"\x05class\x18\x02 \x01(\x0e2\x1b.bytebase.v1.MCPMethodClassR\x05class\x12\x1e\n" +
+	"\n" +
+	"permission\x18\x03 \x01(\tR\n" +
+	"permission\x128\n" +
+	"\vauth_method\x18\x05 \x01(\x0e2\x17.bytebase.v1.AuthMethodR\n" +
+	"authMethod\"\xaa\x03\n" +
+	"\x14MCPEngineEnforcement\x12+\n" +
+	"\x06engine\x18\x01 \x01(\x0e2\x13.bytebase.v1.EngineR\x06engine\x12W\n" +
+	"\x0fread_only_depth\x18\x02 \x01(\x0e2/.bytebase.v1.MCPEngineEnforcement.ReadOnlyDepthR\rreadOnlyDepth\x12C\n" +
+	"\amasking\x18\x03 \x01(\x0e2).bytebase.v1.MCPEngineEnforcement.MaskingR\amasking\x12\x12\n" +
+	"\x04note\x18\x04 \x01(\tR\x04note\"k\n" +
+	"\rReadOnlyDepth\x12\x1f\n" +
+	"\x1bREAD_ONLY_DEPTH_UNSPECIFIED\x10\x00\x12\x0f\n" +
+	"\vUNSUPPORTED\x10\x01\x12\r\n" +
+	"\tSTATEMENT\x10\x02\x12\x19\n" +
+	"\x15STATEMENT_AND_SESSION\x10\x03\"F\n" +
+	"\aMasking\x12\x17\n" +
+	"\x13MASKING_UNSPECIFIED\x10\x00\x12\b\n" +
+	"\x04NONE\x10\x01\x12\n" +
+	"\n" +
+	"\x06COLUMN\x10\x02\x12\f\n" +
+	"\bDOCUMENT\x10\x03\"U\n" +
 	"\x1fRotateDirectorySyncTokenRequest\x122\n" +
 	"\x04name\x18\x01 \x01(\tB\x1e\xe0A\x02\xfaA\x18\n" +
 	"\x16bytebase.com/WorkspaceR\x04name\"=\n" +
@@ -472,8 +1013,7 @@ const file_v1_workspace_service_proto_rawDesc = "" +
 	"\vupdate_mask\x18\x02 \x01(\v2\x1a.google.protobuf.FieldMaskR\n" +
 	"updateMask\"0\n" +
 	"\x15LeaveWorkspaceRequest\x12\x17\n" +
-	"\x04name\x18\x01 \x01(\tB\x03\xe0A\x02R\x04name2\x9f\n" +
-	"\n" +
+	"\x04name\x18\x01 \x01(\tB\x03\xe0A\x02R\x04name2\x80\v\n" +
 	"\x10WorkspaceService\x12q\n" +
 	"\fGetWorkspace\x12 .bytebase.v1.GetWorkspaceRequest\x1a\x16.bytebase.v1.Workspace\"'\x80\xea0\x01\xa0\xea0\x01\x82\xd3\xe4\x93\x02\x19\x12\x17/v1/{name=workspaces/*}\x12y\n" +
 	"\x0eListWorkspaces\x12\".bytebase.v1.ListWorkspacesRequest\x1a#.bytebase.v1.ListWorkspacesResponse\"\x1e\x90\xea0\x02\xa0\xea0\x01\x82\xd3\xe4\x93\x02\x10\x12\x0e/v1/workspaces\x12\xa4\x01\n" +
@@ -481,7 +1021,9 @@ const file_v1_workspace_service_proto_rawDesc = "" +
 	"\fGetIamPolicy\x12 .bytebase.v1.GetIamPolicyRequest\x1a\x16.bytebase.v1.IamPolicy\"Z\x8a\xea0\x1abb.workspaces.getIamPolicy\x90\xea0\x01\xa0\xea0\x04\xa8\xea0\t\x82\xd3\xe4\x93\x02*\x12(/v1/{resource=workspaces/*}:getIamPolicy\x12\x9b\x01\n" +
 	"\x0fDeleteWorkspace\x12#.bytebase.v1.DeleteWorkspaceRequest\x1a\x1a.bytebase.v1.LoginResponse\"G\x8a\xea0\x14bb.workspaces.delete\x90\xea0\x01\x98\xea0\x01\xa0\xea0\x03\xa8\xea0\x05\x82\xd3\xe4\x93\x02\x19*\x17/v1/{name=workspaces/*}\x12\x8a\x01\n" +
 	"\x0eLeaveWorkspace\x12\".bytebase.v1.LeaveWorkspaceRequest\x1a\x1a.bytebase.v1.LoginResponse\"8\x90\xea0\x02\x98\xea0\x01\xa0\xea0\x03\xa8\xea0\x05\x82\xd3\xe4\x93\x02\":\x01*\"\x1d/v1/{name=workspaces/*}:leave\x12\xab\x01\n" +
-	"\fSetIamPolicy\x12 .bytebase.v1.SetIamPolicyRequest\x1a\x16.bytebase.v1.IamPolicy\"a\x8a\xea0\x1abb.workspaces.setIamPolicy\x90\xea0\x01\x98\xea0\x01\xa0\xea0\x04\xa8\xea0\t\x82\xd3\xe4\x93\x02-:\x01*\"(/v1/{resource=workspaces/*}:setIamPolicy\x12\xf5\x01\n" +
+	"\fSetIamPolicy\x12 .bytebase.v1.SetIamPolicyRequest\x1a\x16.bytebase.v1.IamPolicy\"a\x8a\xea0\x1abb.workspaces.setIamPolicy\x90\xea0\x01\x98\xea0\x01\xa0\xea0\x04\xa8\xea0\t\x82\xd3\xe4\x93\x02-:\x01*\"(/v1/{resource=workspaces/*}:setIamPolicy\x12_\n" +
+	"\n" +
+	"GetMCPInfo\x12\x1e.bytebase.v1.GetMCPInfoRequest\x1a\x14.bytebase.v1.MCPInfo\"\x1b\xdaA\x00\xa0\xea0\x01\x82\xd3\xe4\x93\x02\x0e\x12\f/v1/mcp/info\x12\xf5\x01\n" +
 	"\x18RotateDirectorySyncToken\x12,.bytebase.v1.RotateDirectorySyncTokenRequest\x1a-.bytebase.v1.RotateDirectorySyncTokenResponse\"|\xdaA\x04name\x8a\xea0&bb.workspaces.rotateDirectorySyncToken\x90\xea0\x01\x98\xea0\x01\xa0\xea0\x03\xa8\xea0\x06\x82\xd3\xe4\x93\x025:\x01*\"0/v1/{name=workspaces/*}:rotateDirectorySyncTokenB\xab\x01\n" +
 	"\x0fcom.bytebase.v1B\x15WorkspaceServiceProtoP\x01Z4github.com/bytebase/bytebase/backend/generated-go/v1\xa2\x02\x03BXX\xaa\x02\vBytebase.V1\xca\x02\vBytebase\\V1\xe2\x02\x17Bytebase\\V1\\GPBMetadata\xea\x02\fBytebase::V1b\x06proto3"
 
@@ -497,48 +1039,73 @@ func file_v1_workspace_service_proto_rawDescGZIP() []byte {
 	return file_v1_workspace_service_proto_rawDescData
 }
 
-var file_v1_workspace_service_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_v1_workspace_service_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_v1_workspace_service_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
 var file_v1_workspace_service_proto_goTypes = []any{
-	(*RotateDirectorySyncTokenRequest)(nil),  // 0: bytebase.v1.RotateDirectorySyncTokenRequest
-	(*RotateDirectorySyncTokenResponse)(nil), // 1: bytebase.v1.RotateDirectorySyncTokenResponse
-	(*ListWorkspacesRequest)(nil),            // 2: bytebase.v1.ListWorkspacesRequest
-	(*ListWorkspacesResponse)(nil),           // 3: bytebase.v1.ListWorkspacesResponse
-	(*GetWorkspaceRequest)(nil),              // 4: bytebase.v1.GetWorkspaceRequest
-	(*Workspace)(nil),                        // 5: bytebase.v1.Workspace
-	(*DeleteWorkspaceRequest)(nil),           // 6: bytebase.v1.DeleteWorkspaceRequest
-	(*UpdateWorkspaceRequest)(nil),           // 7: bytebase.v1.UpdateWorkspaceRequest
-	(*LeaveWorkspaceRequest)(nil),            // 8: bytebase.v1.LeaveWorkspaceRequest
-	(*fieldmaskpb.FieldMask)(nil),            // 9: google.protobuf.FieldMask
-	(*GetIamPolicyRequest)(nil),              // 10: bytebase.v1.GetIamPolicyRequest
-	(*SetIamPolicyRequest)(nil),              // 11: bytebase.v1.SetIamPolicyRequest
-	(*IamPolicy)(nil),                        // 12: bytebase.v1.IamPolicy
-	(*LoginResponse)(nil),                    // 13: bytebase.v1.LoginResponse
+	(MCPEngineEnforcement_ReadOnlyDepth)(0),  // 0: bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth
+	(MCPEngineEnforcement_Masking)(0),        // 1: bytebase.v1.MCPEngineEnforcement.Masking
+	(*GetMCPInfoRequest)(nil),                // 2: bytebase.v1.GetMCPInfoRequest
+	(*MCPInfo)(nil),                          // 3: bytebase.v1.MCPInfo
+	(*MCPCapabilityMode)(nil),                // 4: bytebase.v1.MCPCapabilityMode
+	(*MCPMethod)(nil),                        // 5: bytebase.v1.MCPMethod
+	(*MCPEngineEnforcement)(nil),             // 6: bytebase.v1.MCPEngineEnforcement
+	(*RotateDirectorySyncTokenRequest)(nil),  // 7: bytebase.v1.RotateDirectorySyncTokenRequest
+	(*RotateDirectorySyncTokenResponse)(nil), // 8: bytebase.v1.RotateDirectorySyncTokenResponse
+	(*ListWorkspacesRequest)(nil),            // 9: bytebase.v1.ListWorkspacesRequest
+	(*ListWorkspacesResponse)(nil),           // 10: bytebase.v1.ListWorkspacesResponse
+	(*GetWorkspaceRequest)(nil),              // 11: bytebase.v1.GetWorkspaceRequest
+	(*Workspace)(nil),                        // 12: bytebase.v1.Workspace
+	(*DeleteWorkspaceRequest)(nil),           // 13: bytebase.v1.DeleteWorkspaceRequest
+	(*UpdateWorkspaceRequest)(nil),           // 14: bytebase.v1.UpdateWorkspaceRequest
+	(*LeaveWorkspaceRequest)(nil),            // 15: bytebase.v1.LeaveWorkspaceRequest
+	(MCPSetting_Capability)(0),               // 16: bytebase.v1.MCPSetting.Capability
+	(MCPMethodClass)(0),                      // 17: bytebase.v1.MCPMethodClass
+	(AuthMethod)(0),                          // 18: bytebase.v1.AuthMethod
+	(Engine)(0),                              // 19: bytebase.v1.Engine
+	(*fieldmaskpb.FieldMask)(nil),            // 20: google.protobuf.FieldMask
+	(*GetIamPolicyRequest)(nil),              // 21: bytebase.v1.GetIamPolicyRequest
+	(*SetIamPolicyRequest)(nil),              // 22: bytebase.v1.SetIamPolicyRequest
+	(*IamPolicy)(nil),                        // 23: bytebase.v1.IamPolicy
+	(*LoginResponse)(nil),                    // 24: bytebase.v1.LoginResponse
 }
 var file_v1_workspace_service_proto_depIdxs = []int32{
-	5,  // 0: bytebase.v1.ListWorkspacesResponse.workspaces:type_name -> bytebase.v1.Workspace
-	5,  // 1: bytebase.v1.UpdateWorkspaceRequest.workspace:type_name -> bytebase.v1.Workspace
-	9,  // 2: bytebase.v1.UpdateWorkspaceRequest.update_mask:type_name -> google.protobuf.FieldMask
-	4,  // 3: bytebase.v1.WorkspaceService.GetWorkspace:input_type -> bytebase.v1.GetWorkspaceRequest
-	2,  // 4: bytebase.v1.WorkspaceService.ListWorkspaces:input_type -> bytebase.v1.ListWorkspacesRequest
-	7,  // 5: bytebase.v1.WorkspaceService.UpdateWorkspace:input_type -> bytebase.v1.UpdateWorkspaceRequest
-	10, // 6: bytebase.v1.WorkspaceService.GetIamPolicy:input_type -> bytebase.v1.GetIamPolicyRequest
-	6,  // 7: bytebase.v1.WorkspaceService.DeleteWorkspace:input_type -> bytebase.v1.DeleteWorkspaceRequest
-	8,  // 8: bytebase.v1.WorkspaceService.LeaveWorkspace:input_type -> bytebase.v1.LeaveWorkspaceRequest
-	11, // 9: bytebase.v1.WorkspaceService.SetIamPolicy:input_type -> bytebase.v1.SetIamPolicyRequest
-	0,  // 10: bytebase.v1.WorkspaceService.RotateDirectorySyncToken:input_type -> bytebase.v1.RotateDirectorySyncTokenRequest
-	5,  // 11: bytebase.v1.WorkspaceService.GetWorkspace:output_type -> bytebase.v1.Workspace
-	3,  // 12: bytebase.v1.WorkspaceService.ListWorkspaces:output_type -> bytebase.v1.ListWorkspacesResponse
-	5,  // 13: bytebase.v1.WorkspaceService.UpdateWorkspace:output_type -> bytebase.v1.Workspace
-	12, // 14: bytebase.v1.WorkspaceService.GetIamPolicy:output_type -> bytebase.v1.IamPolicy
-	13, // 15: bytebase.v1.WorkspaceService.DeleteWorkspace:output_type -> bytebase.v1.LoginResponse
-	13, // 16: bytebase.v1.WorkspaceService.LeaveWorkspace:output_type -> bytebase.v1.LoginResponse
-	12, // 17: bytebase.v1.WorkspaceService.SetIamPolicy:output_type -> bytebase.v1.IamPolicy
-	1,  // 18: bytebase.v1.WorkspaceService.RotateDirectorySyncToken:output_type -> bytebase.v1.RotateDirectorySyncTokenResponse
-	11, // [11:19] is the sub-list for method output_type
-	3,  // [3:11] is the sub-list for method input_type
-	3,  // [3:3] is the sub-list for extension type_name
-	3,  // [3:3] is the sub-list for extension extendee
-	0,  // [0:3] is the sub-list for field type_name
+	16, // 0: bytebase.v1.MCPInfo.capability:type_name -> bytebase.v1.MCPSetting.Capability
+	4,  // 1: bytebase.v1.MCPInfo.modes:type_name -> bytebase.v1.MCPCapabilityMode
+	5,  // 2: bytebase.v1.MCPInfo.methods:type_name -> bytebase.v1.MCPMethod
+	6,  // 3: bytebase.v1.MCPInfo.engines:type_name -> bytebase.v1.MCPEngineEnforcement
+	16, // 4: bytebase.v1.MCPCapabilityMode.capability:type_name -> bytebase.v1.MCPSetting.Capability
+	17, // 5: bytebase.v1.MCPCapabilityMode.served_classes:type_name -> bytebase.v1.MCPMethodClass
+	17, // 6: bytebase.v1.MCPMethod.class:type_name -> bytebase.v1.MCPMethodClass
+	18, // 7: bytebase.v1.MCPMethod.auth_method:type_name -> bytebase.v1.AuthMethod
+	19, // 8: bytebase.v1.MCPEngineEnforcement.engine:type_name -> bytebase.v1.Engine
+	0,  // 9: bytebase.v1.MCPEngineEnforcement.read_only_depth:type_name -> bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth
+	1,  // 10: bytebase.v1.MCPEngineEnforcement.masking:type_name -> bytebase.v1.MCPEngineEnforcement.Masking
+	12, // 11: bytebase.v1.ListWorkspacesResponse.workspaces:type_name -> bytebase.v1.Workspace
+	12, // 12: bytebase.v1.UpdateWorkspaceRequest.workspace:type_name -> bytebase.v1.Workspace
+	20, // 13: bytebase.v1.UpdateWorkspaceRequest.update_mask:type_name -> google.protobuf.FieldMask
+	11, // 14: bytebase.v1.WorkspaceService.GetWorkspace:input_type -> bytebase.v1.GetWorkspaceRequest
+	9,  // 15: bytebase.v1.WorkspaceService.ListWorkspaces:input_type -> bytebase.v1.ListWorkspacesRequest
+	14, // 16: bytebase.v1.WorkspaceService.UpdateWorkspace:input_type -> bytebase.v1.UpdateWorkspaceRequest
+	21, // 17: bytebase.v1.WorkspaceService.GetIamPolicy:input_type -> bytebase.v1.GetIamPolicyRequest
+	13, // 18: bytebase.v1.WorkspaceService.DeleteWorkspace:input_type -> bytebase.v1.DeleteWorkspaceRequest
+	15, // 19: bytebase.v1.WorkspaceService.LeaveWorkspace:input_type -> bytebase.v1.LeaveWorkspaceRequest
+	22, // 20: bytebase.v1.WorkspaceService.SetIamPolicy:input_type -> bytebase.v1.SetIamPolicyRequest
+	2,  // 21: bytebase.v1.WorkspaceService.GetMCPInfo:input_type -> bytebase.v1.GetMCPInfoRequest
+	7,  // 22: bytebase.v1.WorkspaceService.RotateDirectorySyncToken:input_type -> bytebase.v1.RotateDirectorySyncTokenRequest
+	12, // 23: bytebase.v1.WorkspaceService.GetWorkspace:output_type -> bytebase.v1.Workspace
+	10, // 24: bytebase.v1.WorkspaceService.ListWorkspaces:output_type -> bytebase.v1.ListWorkspacesResponse
+	12, // 25: bytebase.v1.WorkspaceService.UpdateWorkspace:output_type -> bytebase.v1.Workspace
+	23, // 26: bytebase.v1.WorkspaceService.GetIamPolicy:output_type -> bytebase.v1.IamPolicy
+	24, // 27: bytebase.v1.WorkspaceService.DeleteWorkspace:output_type -> bytebase.v1.LoginResponse
+	24, // 28: bytebase.v1.WorkspaceService.LeaveWorkspace:output_type -> bytebase.v1.LoginResponse
+	23, // 29: bytebase.v1.WorkspaceService.SetIamPolicy:output_type -> bytebase.v1.IamPolicy
+	3,  // 30: bytebase.v1.WorkspaceService.GetMCPInfo:output_type -> bytebase.v1.MCPInfo
+	8,  // 31: bytebase.v1.WorkspaceService.RotateDirectorySyncToken:output_type -> bytebase.v1.RotateDirectorySyncTokenResponse
+	23, // [23:32] is the sub-list for method output_type
+	14, // [14:23] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_v1_workspace_service_proto_init() }
@@ -548,19 +1115,22 @@ func file_v1_workspace_service_proto_init() {
 	}
 	file_v1_annotation_proto_init()
 	file_v1_auth_service_proto_init()
+	file_v1_common_proto_init()
 	file_v1_iam_policy_proto_init()
+	file_v1_setting_service_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_workspace_service_proto_rawDesc), len(file_v1_workspace_service_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   9,
+			NumEnums:      2,
+			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_v1_workspace_service_proto_goTypes,
 		DependencyIndexes: file_v1_workspace_service_proto_depIdxs,
+		EnumInfos:         file_v1_workspace_service_proto_enumTypes,
 		MessageInfos:      file_v1_workspace_service_proto_msgTypes,
 	}.Build()
 	File_v1_workspace_service_proto = out.File

--- a/backend/generated-go/v1/workspace_service.pb.gw.go
+++ b/backend/generated-go/v1/workspace_service.pb.gw.go
@@ -308,6 +308,27 @@ func local_request_WorkspaceService_SetIamPolicy_0(ctx context.Context, marshale
 	return msg, metadata, err
 }
 
+func request_WorkspaceService_GetMCPInfo_0(ctx context.Context, marshaler runtime.Marshaler, client WorkspaceServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetMCPInfoRequest
+		metadata runtime.ServerMetadata
+	)
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.GetMCPInfo(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_WorkspaceService_GetMCPInfo_0(ctx context.Context, marshaler runtime.Marshaler, server WorkspaceServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq GetMCPInfoRequest
+		metadata runtime.ServerMetadata
+	)
+	msg, err := server.GetMCPInfo(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_WorkspaceService_RotateDirectorySyncToken_0(ctx context.Context, marshaler runtime.Marshaler, client WorkspaceServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq RotateDirectorySyncTokenRequest
@@ -499,6 +520,26 @@ func RegisterWorkspaceServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_WorkspaceService_SetIamPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_WorkspaceService_GetMCPInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/bytebase.v1.WorkspaceService/GetMCPInfo", runtime.WithHTTPPathPattern("/v1/mcp/info"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_WorkspaceService_GetMCPInfo_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_WorkspaceService_GetMCPInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_WorkspaceService_RotateDirectorySyncToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -678,6 +719,23 @@ func RegisterWorkspaceServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_WorkspaceService_SetIamPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodGet, pattern_WorkspaceService_GetMCPInfo_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/bytebase.v1.WorkspaceService/GetMCPInfo", runtime.WithHTTPPathPattern("/v1/mcp/info"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_WorkspaceService_GetMCPInfo_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_WorkspaceService_GetMCPInfo_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodPost, pattern_WorkspaceService_RotateDirectorySyncToken_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -706,6 +764,7 @@ var (
 	pattern_WorkspaceService_DeleteWorkspace_0          = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 2, 5, 2}, []string{"v1", "workspaces", "name"}, ""))
 	pattern_WorkspaceService_LeaveWorkspace_0           = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 2, 5, 2}, []string{"v1", "workspaces", "name"}, "leave"))
 	pattern_WorkspaceService_SetIamPolicy_0             = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 2, 5, 2}, []string{"v1", "workspaces", "resource"}, "setIamPolicy"))
+	pattern_WorkspaceService_GetMCPInfo_0               = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "mcp", "info"}, ""))
 	pattern_WorkspaceService_RotateDirectorySyncToken_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 2, 5, 2}, []string{"v1", "workspaces", "name"}, "rotateDirectorySyncToken"))
 )
 
@@ -717,5 +776,6 @@ var (
 	forward_WorkspaceService_DeleteWorkspace_0          = runtime.ForwardResponseMessage
 	forward_WorkspaceService_LeaveWorkspace_0           = runtime.ForwardResponseMessage
 	forward_WorkspaceService_SetIamPolicy_0             = runtime.ForwardResponseMessage
+	forward_WorkspaceService_GetMCPInfo_0               = runtime.ForwardResponseMessage
 	forward_WorkspaceService_RotateDirectorySyncToken_0 = runtime.ForwardResponseMessage
 )

--- a/backend/generated-go/v1/workspace_service_equal.pb.go
+++ b/backend/generated-go/v1/workspace_service_equal.pb.go
@@ -8,6 +8,130 @@ import (
 	fieldmaskpb "google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
+func (x *GetMCPInfoRequest) Equal(y *GetMCPInfoRequest) bool {
+	if x == y {
+		return true
+	}
+	if x == nil || y == nil {
+		return x == nil && y == nil
+	}
+	return true
+}
+
+func (x *MCPInfo) Equal(y *MCPInfo) bool {
+	if x == y {
+		return true
+	}
+	if x == nil || y == nil {
+		return x == nil && y == nil
+	}
+	if x.Workspace != y.Workspace {
+		return false
+	}
+	if x.Capability != y.Capability {
+		return false
+	}
+	if len(x.Modes) != len(y.Modes) {
+		return false
+	}
+	for i := 0; i < len(x.Modes); i++ {
+		if !x.Modes[i].Equal(y.Modes[i]) {
+			return false
+		}
+	}
+	if len(x.Methods) != len(y.Methods) {
+		return false
+	}
+	for i := 0; i < len(x.Methods); i++ {
+		if !x.Methods[i].Equal(y.Methods[i]) {
+			return false
+		}
+	}
+	if len(x.Engines) != len(y.Engines) {
+		return false
+	}
+	for i := 0; i < len(x.Engines); i++ {
+		if !x.Engines[i].Equal(y.Engines[i]) {
+			return false
+		}
+	}
+	if x.IgnoreMaskingExemptions != y.IgnoreMaskingExemptions {
+		return false
+	}
+	if x.DataMaskingAvailable != y.DataMaskingAvailable {
+		return false
+	}
+	return true
+}
+
+func (x *MCPCapabilityMode) Equal(y *MCPCapabilityMode) bool {
+	if x == y {
+		return true
+	}
+	if x == nil || y == nil {
+		return x == nil && y == nil
+	}
+	if x.Capability != y.Capability {
+		return false
+	}
+	if len(x.ServedClasses) != len(y.ServedClasses) {
+		return false
+	}
+	for i := 0; i < len(x.ServedClasses); i++ {
+		if x.ServedClasses[i] != y.ServedClasses[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func (x *MCPMethod) Equal(y *MCPMethod) bool {
+	if x == y {
+		return true
+	}
+	if x == nil || y == nil {
+		return x == nil && y == nil
+	}
+	if x.Method != y.Method {
+		return false
+	}
+	if x.OperationId != y.OperationId {
+		return false
+	}
+	if x.Class != y.Class {
+		return false
+	}
+	if x.Permission != y.Permission {
+		return false
+	}
+	if x.AuthMethod != y.AuthMethod {
+		return false
+	}
+	return true
+}
+
+func (x *MCPEngineEnforcement) Equal(y *MCPEngineEnforcement) bool {
+	if x == y {
+		return true
+	}
+	if x == nil || y == nil {
+		return x == nil && y == nil
+	}
+	if x.Engine != y.Engine {
+		return false
+	}
+	if x.ReadOnlyDepth != y.ReadOnlyDepth {
+		return false
+	}
+	if x.Masking != y.Masking {
+		return false
+	}
+	if x.Note != y.Note {
+		return false
+	}
+	return true
+}
+
 func (x *RotateDirectorySyncTokenRequest) Equal(y *RotateDirectorySyncTokenRequest) bool {
 	if x == y {
 		return true

--- a/backend/generated-go/v1/workspace_service_grpc.pb.go
+++ b/backend/generated-go/v1/workspace_service_grpc.pb.go
@@ -26,6 +26,7 @@ const (
 	WorkspaceService_DeleteWorkspace_FullMethodName          = "/bytebase.v1.WorkspaceService/DeleteWorkspace"
 	WorkspaceService_LeaveWorkspace_FullMethodName           = "/bytebase.v1.WorkspaceService/LeaveWorkspace"
 	WorkspaceService_SetIamPolicy_FullMethodName             = "/bytebase.v1.WorkspaceService/SetIamPolicy"
+	WorkspaceService_GetMCPInfo_FullMethodName               = "/bytebase.v1.WorkspaceService/GetMCPInfo"
 	WorkspaceService_RotateDirectorySyncToken_FullMethodName = "/bytebase.v1.WorkspaceService/RotateDirectorySyncToken"
 )
 
@@ -59,6 +60,18 @@ type WorkspaceServiceClient interface {
 	// Sets IAM policy for the workspace.
 	// Permissions required: bb.workspaces.setIamPolicy
 	SetIamPolicy(ctx context.Context, in *SetIamPolicyRequest, opts ...grpc.CallOption) (*IamPolicy, error)
+	// Gets what MCP (Model Context Protocol) does in this workspace: the
+	// capability ceiling in force, what each ceiling serves, and the per-engine
+	// facts a read-only session depends on. The workspace is resolved from the
+	// authenticated session.
+	//
+	// Served to MCP sessions. An agent asking what it may do here is the point:
+	// the response says nothing a session's own denials do not already say, one
+	// refusal at a time, and knowing it up front is what stops the agent
+	// planning work the ceiling was never going to serve.
+	//
+	// Permissions required: None (authentication required)
+	GetMCPInfo(ctx context.Context, in *GetMCPInfoRequest, opts ...grpc.CallOption) (*MCPInfo, error)
 	// Mints a new directory sync (SCIM) token, immediately invalidating the
 	// previous one. The plaintext token is returned exactly once and cannot be
 	// retrieved afterwards; only its hash is stored. Callers that lose it must
@@ -145,6 +158,16 @@ func (c *workspaceServiceClient) SetIamPolicy(ctx context.Context, in *SetIamPol
 	return out, nil
 }
 
+func (c *workspaceServiceClient) GetMCPInfo(ctx context.Context, in *GetMCPInfoRequest, opts ...grpc.CallOption) (*MCPInfo, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(MCPInfo)
+	err := c.cc.Invoke(ctx, WorkspaceService_GetMCPInfo_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *workspaceServiceClient) RotateDirectorySyncToken(ctx context.Context, in *RotateDirectorySyncTokenRequest, opts ...grpc.CallOption) (*RotateDirectorySyncTokenResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(RotateDirectorySyncTokenResponse)
@@ -185,6 +208,18 @@ type WorkspaceServiceServer interface {
 	// Sets IAM policy for the workspace.
 	// Permissions required: bb.workspaces.setIamPolicy
 	SetIamPolicy(context.Context, *SetIamPolicyRequest) (*IamPolicy, error)
+	// Gets what MCP (Model Context Protocol) does in this workspace: the
+	// capability ceiling in force, what each ceiling serves, and the per-engine
+	// facts a read-only session depends on. The workspace is resolved from the
+	// authenticated session.
+	//
+	// Served to MCP sessions. An agent asking what it may do here is the point:
+	// the response says nothing a session's own denials do not already say, one
+	// refusal at a time, and knowing it up front is what stops the agent
+	// planning work the ceiling was never going to serve.
+	//
+	// Permissions required: None (authentication required)
+	GetMCPInfo(context.Context, *GetMCPInfoRequest) (*MCPInfo, error)
 	// Mints a new directory sync (SCIM) token, immediately invalidating the
 	// previous one. The plaintext token is returned exactly once and cannot be
 	// retrieved afterwards; only its hash is stored. Callers that lose it must
@@ -221,6 +256,9 @@ func (UnimplementedWorkspaceServiceServer) LeaveWorkspace(context.Context, *Leav
 }
 func (UnimplementedWorkspaceServiceServer) SetIamPolicy(context.Context, *SetIamPolicyRequest) (*IamPolicy, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetIamPolicy not implemented")
+}
+func (UnimplementedWorkspaceServiceServer) GetMCPInfo(context.Context, *GetMCPInfoRequest) (*MCPInfo, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetMCPInfo not implemented")
 }
 func (UnimplementedWorkspaceServiceServer) RotateDirectorySyncToken(context.Context, *RotateDirectorySyncTokenRequest) (*RotateDirectorySyncTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RotateDirectorySyncToken not implemented")
@@ -372,6 +410,24 @@ func _WorkspaceService_SetIamPolicy_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _WorkspaceService_GetMCPInfo_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetMCPInfoRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(WorkspaceServiceServer).GetMCPInfo(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: WorkspaceService_GetMCPInfo_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(WorkspaceServiceServer).GetMCPInfo(ctx, req.(*GetMCPInfoRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _WorkspaceService_RotateDirectorySyncToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(RotateDirectorySyncTokenRequest)
 	if err := dec(in); err != nil {
@@ -424,6 +480,10 @@ var WorkspaceService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetIamPolicy",
 			Handler:    _WorkspaceService_SetIamPolicy_Handler,
+		},
+		{
+			MethodName: "GetMCPInfo",
+			Handler:    _WorkspaceService_GetMCPInfo_Handler,
 		},
 		{
 			MethodName: "RotateDirectorySyncToken",

--- a/frontend/src/types/proto-es/v1/workspace_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/workspace_service_pb.d.ts
@@ -2,8 +2,11 @@
 // @generated from file v1/workspace_service.proto (package bytebase.v1, syntax proto3)
 /* eslint-disable */
 
-import type { GenFile, GenMessage, GenService } from "@bufbuild/protobuf/codegenv2";
+import type { GenEnum, GenFile, GenMessage, GenService } from "@bufbuild/protobuf/codegenv2";
 import type { Message } from "@bufbuild/protobuf";
+import type { MCPSetting_Capability } from "./setting_service_pb";
+import type { AuthMethod, MCPMethodClass } from "./annotation_pb";
+import type { Engine } from "./common_pb";
 import type { FieldMask } from "@bufbuild/protobuf/wkt";
 import type { GetIamPolicyRequestSchema, IamPolicySchema, SetIamPolicyRequestSchema } from "./iam_policy_pb";
 import type { LoginResponseSchema } from "./auth_service_pb";
@@ -12,6 +15,309 @@ import type { LoginResponseSchema } from "./auth_service_pb";
  * Describes the file v1/workspace_service.proto.
  */
 export declare const file_v1_workspace_service: GenFile;
+
+/**
+ * @generated from message bytebase.v1.GetMCPInfoRequest
+ */
+export declare type GetMCPInfoRequest = Message<"bytebase.v1.GetMCPInfoRequest"> & {
+};
+
+/**
+ * Describes the message bytebase.v1.GetMCPInfoRequest.
+ * Use `create(GetMCPInfoRequestSchema)` to create a new message.
+ */
+export declare const GetMCPInfoRequestSchema: GenMessage<GetMCPInfoRequest>;
+
+/**
+ * MCPInfo is what MCP does in this workspace: the ceiling in force, what each
+ * ceiling serves, and the per-engine facts a read-only session depends on.
+ *
+ * Everything here is resolved when the request is served, never from a stored
+ * copy: the method list comes off the compiled API descriptors and the engine
+ * answers off the code that enforces them, so a build whose rules changed
+ * cannot describe the rules of the build before it.
+ *
+ * @generated from message bytebase.v1.MCPInfo
+ */
+export declare type MCPInfo = Message<"bytebase.v1.MCPInfo"> & {
+  /**
+   * The workspace this describes. Format: workspaces/{workspace}. Not this
+   * message's own resource name — MCPInfo is not a named resource and there is
+   * nothing to get it by.
+   *
+   * @generated from field: string workspace = 1;
+   */
+  workspace: string;
+
+  /**
+   * The ceiling in force for this workspace. A workspace that never configured
+   * MCP resolves to READ_WRITE.
+   *
+   * @generated from field: bytebase.v1.MCPSetting.Capability capability = 2;
+   */
+  capability: MCPSetting_Capability;
+
+  /**
+   * What each ceiling serves, including the one in force, so an admin can
+   * compare the choices rather than only read the current answer.
+   *
+   * @generated from field: repeated bytebase.v1.MCPCapabilityMode modes = 3;
+   */
+  modes: MCPCapabilityMode[];
+
+  /**
+   * Every API method some ceiling serves. A mode serves a method when the
+   * method's class is one of that mode's served_classes, which is the ceiling
+   * rule the gate evaluates. Methods no ceiling serves are absent.
+   *
+   * Being listed is necessary, not sufficient. The caller still needs the
+   * permission, and two further rules narrow what a served method does: a
+   * handful of methods are refused on the shape of the request (an issue that
+   * would grant a permission, a rollout that skips approval), and under
+   * READ_ONLY every statement SQLService/Query runs must classify as a read.
+   *
+   * @generated from field: repeated bytebase.v1.MCPMethod methods = 4;
+   */
+  methods: MCPMethod[];
+
+  /**
+   * What a read-only session and the masking toggle actually reach, per engine.
+   * Both are engine-conditional in ways the ceiling alone does not show.
+   *
+   * @generated from field: repeated bytebase.v1.MCPEngineEnforcement engines = 5;
+   */
+  engines: MCPEngineEnforcement[];
+
+  /**
+   * Whether this workspace stops applying the caller's own unmasking
+   * provisioning to MCP requests. It decides which branch of each engine's
+   * masking state a caller is in, and no other API tells an MCP session:
+   * SettingService/GetSetting is served by no ceiling.
+   *
+   * @generated from field: bool ignore_masking_exemptions = 6;
+   */
+  ignoreMaskingExemptions: boolean;
+
+  /**
+   * Whether data masking is licensed for this workspace. When false nothing is
+   * masked whatever an engine supports, so the masking states below describe a
+   * mechanism that does not run. Licensing can also be set per instance, so a
+   * true here is the workspace answer, not a promise about every instance.
+   *
+   * @generated from field: bool data_masking_available = 7;
+   */
+  dataMaskingAvailable: boolean;
+};
+
+/**
+ * Describes the message bytebase.v1.MCPInfo.
+ * Use `create(MCPInfoSchema)` to create a new message.
+ */
+export declare const MCPInfoSchema: GenMessage<MCPInfo>;
+
+/**
+ * MCPCapabilityMode is one ceiling and the method classes it serves.
+ *
+ * @generated from message bytebase.v1.MCPCapabilityMode
+ */
+export declare type MCPCapabilityMode = Message<"bytebase.v1.MCPCapabilityMode"> & {
+  /**
+   * @generated from field: bytebase.v1.MCPSetting.Capability capability = 1;
+   */
+  capability: MCPSetting_Capability;
+
+  /**
+   * Empty means the ceiling serves nothing, which is what DISABLED is.
+   *
+   * @generated from field: repeated bytebase.v1.MCPMethodClass served_classes = 2;
+   */
+  servedClasses: MCPMethodClass[];
+};
+
+/**
+ * Describes the message bytebase.v1.MCPCapabilityMode.
+ * Use `create(MCPCapabilityModeSchema)` to create a new message.
+ */
+export declare const MCPCapabilityModeSchema: GenMessage<MCPCapabilityMode>;
+
+/**
+ * MCPMethod is one API method an MCP session can reach, and what decides it.
+ *
+ * @generated from message bytebase.v1.MCPMethod
+ */
+export declare type MCPMethod = Message<"bytebase.v1.MCPMethod"> & {
+  /**
+   * The method as an audit entry names it, so a denial can be found by it.
+   * Example: /bytebase.v1.SQLService/Query
+   *
+   * @generated from field: string method = 1;
+   */
+  method: string;
+
+  /**
+   * The same method as call_api takes it.
+   * Example: bytebase.v1.SQLService.Query
+   *
+   * @generated from field: string operation_id = 4;
+   */
+  operationId: string;
+
+  /**
+   * @generated from field: bytebase.v1.MCPMethodClass class = 2;
+   */
+  class: MCPMethodClass;
+
+  /**
+   * The IAM permission the method declares. The ceiling never grants: a session
+   * may call a served method only where the person it acts for could.
+   *
+   * Empty means the method declares no permission, which is NOT the same as
+   * needing none — a method that authorizes inside its handler declares nothing
+   * here. auth_method says which case an empty value is.
+   *
+   * @generated from field: string permission = 3;
+   */
+  permission: string;
+
+  /**
+   * How the method authorizes. IAM means the permission above is the whole
+   * rule; CUSTOM means the handler decides and the permission field is silent.
+   *
+   * @generated from field: bytebase.v1.AuthMethod auth_method = 5;
+   */
+  authMethod: AuthMethod;
+};
+
+/**
+ * Describes the message bytebase.v1.MCPMethod.
+ * Use `create(MCPMethodSchema)` to create a new message.
+ */
+export declare const MCPMethodSchema: GenMessage<MCPMethod>;
+
+/**
+ * MCPEngineEnforcement is what the read-only ceiling and the masking toggle
+ * reach on one database engine.
+ *
+ * @generated from message bytebase.v1.MCPEngineEnforcement
+ */
+export declare type MCPEngineEnforcement = Message<"bytebase.v1.MCPEngineEnforcement"> & {
+  /**
+   * @generated from field: bytebase.v1.Engine engine = 1;
+   */
+  engine: Engine;
+
+  /**
+   * @generated from field: bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth read_only_depth = 2;
+   */
+  readOnlyDepth: MCPEngineEnforcement_ReadOnlyDepth;
+
+  /**
+   * @generated from field: bytebase.v1.MCPEngineEnforcement.Masking masking = 3;
+   */
+  masking: MCPEngineEnforcement_Masking;
+
+  /**
+   * Where the answers above are the floor rather than the whole story. Empty
+   * for most engines.
+   *
+   * @generated from field: string note = 4;
+   */
+  note: string;
+};
+
+/**
+ * Describes the message bytebase.v1.MCPEngineEnforcement.
+ * Use `create(MCPEngineEnforcementSchema)` to create a new message.
+ */
+export declare const MCPEngineEnforcementSchema: GenMessage<MCPEngineEnforcement>;
+
+/**
+ * How much of a read-only ceiling this engine can be held to.
+ *
+ * @generated from enum bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth
+ */
+export enum MCPEngineEnforcement_ReadOnlyDepth {
+  /**
+   * @generated from enum value: READ_ONLY_DEPTH_UNSPECIFIED = 0;
+   */
+  READ_ONLY_DEPTH_UNSPECIFIED = 0,
+
+  /**
+   * Bytebase has no read-only classifier for this engine, so a read-only
+   * session is refused every statement on it, including a plain SELECT.
+   *
+   * @generated from enum value: UNSUPPORTED = 1;
+   */
+  UNSUPPORTED = 1,
+
+  /**
+   * Every statement is classified before it runs and a request holding one
+   * that is not a read is refused whole. Nothing below that: the driver does
+   * not open a read-only database session, except where the note says
+   * otherwise.
+   *
+   * @generated from enum value: STATEMENT = 2;
+   */
+  STATEMENT = 2,
+
+  /**
+   * Statement classification, and the driver opens the database session
+   * read-only as well, so the engine refuses most writes the classifier
+   * missed. Not a proof: a statement that classifies as a read can still call
+   * a function that switches the session setting back off.
+   *
+   * @generated from enum value: STATEMENT_AND_SESSION = 3;
+   */
+  STATEMENT_AND_SESSION = 3,
+}
+
+/**
+ * Describes the enum bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth.
+ */
+export declare const MCPEngineEnforcement_ReadOnlyDepthSchema: GenEnum<MCPEngineEnforcement_ReadOnlyDepth>;
+
+/**
+ * How Bytebase masks results on this engine, which is what decides whether
+ * ignoring masking exemptions changes anything here.
+ *
+ * @generated from enum bytebase.v1.MCPEngineEnforcement.Masking
+ */
+export enum MCPEngineEnforcement_Masking {
+  /**
+   * @generated from enum value: MASKING_UNSPECIFIED = 0;
+   */
+  MASKING_UNSPECIFIED = 0,
+
+  /**
+   * Bytebase does not mask on this engine. Nothing narrows what a session
+   * reads, and ignoring masking exemptions does nothing.
+   *
+   * @generated from enum value: NONE = 1;
+   */
+  NONE = 1,
+
+  /**
+   * Column masking. A masking policy substitutes values in query results,
+   * and the exemptions granted to the caller are what let them see the real
+   * value — which is what ignoring exemptions suppresses.
+   *
+   * @generated from enum value: COLUMN = 2;
+   */
+  COLUMN = 2,
+
+  /**
+   * Document masking. Results are masked, but exemptions are never consulted
+   * on this path, so ignoring them changes nothing here either.
+   *
+   * @generated from enum value: DOCUMENT = 3;
+   */
+  DOCUMENT = 3,
+}
+
+/**
+ * Describes the enum bytebase.v1.MCPEngineEnforcement.Masking.
+ */
+export declare const MCPEngineEnforcement_MaskingSchema: GenEnum<MCPEngineEnforcement_Masking>;
 
 /**
  * @generated from message bytebase.v1.RotateDirectorySyncTokenRequest
@@ -269,6 +575,26 @@ export declare const WorkspaceService: GenService<{
     methodKind: "unary";
     input: typeof SetIamPolicyRequestSchema;
     output: typeof IamPolicySchema;
+  },
+  /**
+   * Gets what MCP (Model Context Protocol) does in this workspace: the
+   * capability ceiling in force, what each ceiling serves, and the per-engine
+   * facts a read-only session depends on. The workspace is resolved from the
+   * authenticated session.
+   *
+   * Served to MCP sessions. An agent asking what it may do here is the point:
+   * the response says nothing a session's own denials do not already say, one
+   * refusal at a time, and knowing it up front is what stops the agent
+   * planning work the ceiling was never going to serve.
+   *
+   * Permissions required: None (authentication required)
+   *
+   * @generated from rpc bytebase.v1.WorkspaceService.GetMCPInfo
+   */
+  getMCPInfo: {
+    methodKind: "unary";
+    input: typeof GetMCPInfoRequestSchema;
+    output: typeof MCPInfoSchema;
   },
   /**
    * Mints a new directory sync (SCIM) token, immediately invalidating the

--- a/frontend/src/types/proto-es/v1/workspace_service_pb.js
+++ b/frontend/src/types/proto-es/v1/workspace_service_pb.js
@@ -2,7 +2,7 @@
 // @generated from file v1/workspace_service.proto (package bytebase.v1, syntax proto3)
 /* eslint-disable */
 
-import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv2";
+import { enumDesc, fileDesc, messageDesc, serviceDesc, tsEnum } from "@bufbuild/protobuf/codegenv2";
 import { file_google_api_annotations } from "../google/api/annotations_pb";
 import { file_google_api_client } from "../google/api/client_pb";
 import { file_google_api_field_behavior } from "../google/api/field_behavior_pb";
@@ -10,76 +10,142 @@ import { file_google_api_resource } from "../google/api/resource_pb";
 import { file_google_protobuf_field_mask } from "@bufbuild/protobuf/wkt";
 import { file_v1_annotation } from "./annotation_pb";
 import { file_v1_auth_service } from "./auth_service_pb";
+import { file_v1_common } from "./common_pb";
 import { file_v1_iam_policy } from "./iam_policy_pb";
+import { file_v1_setting_service } from "./setting_service_pb";
 
 /**
  * Describes the file v1/workspace_service.proto.
  */
 export const file_v1_workspace_service = /*@__PURE__*/
-  fileDesc("Chp2MS93b3Jrc3BhY2Vfc2VydmljZS5wcm90bxILYnl0ZWJhc2UudjEiTwofUm90YXRlRGlyZWN0b3J5U3luY1Rva2VuUmVxdWVzdBIsCgRuYW1lGAEgASgJQh7gQQL6QRgKFmJ5dGViYXNlLmNvbS9Xb3Jrc3BhY2UiNgogUm90YXRlRGlyZWN0b3J5U3luY1Rva2VuUmVzcG9uc2USEgoFdG9rZW4YASABKAlCA+BBAyIXChVMaXN0V29ya3NwYWNlc1JlcXVlc3QiRAoWTGlzdFdvcmtzcGFjZXNSZXNwb25zZRIqCgp3b3Jrc3BhY2VzGAEgAygLMhYuYnl0ZWJhc2UudjEuV29ya3NwYWNlIiMKE0dldFdvcmtzcGFjZVJlcXVlc3QSDAoEbmFtZRgBIAEoCSI2CglXb3Jrc3BhY2USDAoEbmFtZRgBIAEoCRINCgV0aXRsZRgCIAEoCRIMCgRsb2dvGAMgASgJIisKFkRlbGV0ZVdvcmtzcGFjZVJlcXVlc3QSEQoEbmFtZRgBIAEoCUID4EECInkKFlVwZGF0ZVdvcmtzcGFjZVJlcXVlc3QSLgoJd29ya3NwYWNlGAEgASgLMhYuYnl0ZWJhc2UudjEuV29ya3NwYWNlQgPgQQISLwoLdXBkYXRlX21hc2sYAiABKAsyGi5nb29nbGUucHJvdG9idWYuRmllbGRNYXNrIioKFUxlYXZlV29ya3NwYWNlUmVxdWVzdBIRCgRuYW1lGAEgASgJQgPgQQIynwoKEFdvcmtzcGFjZVNlcnZpY2UScQoMR2V0V29ya3NwYWNlEiAuYnl0ZWJhc2UudjEuR2V0V29ya3NwYWNlUmVxdWVzdBoWLmJ5dGViYXNlLnYxLldvcmtzcGFjZSIngOowAaDqMAGC0+STAhkSFy92MS97bmFtZT13b3Jrc3BhY2VzLyp9EnkKDkxpc3RXb3Jrc3BhY2VzEiIuYnl0ZWJhc2UudjEuTGlzdFdvcmtzcGFjZXNSZXF1ZXN0GiMuYnl0ZWJhc2UudjEuTGlzdFdvcmtzcGFjZXNSZXNwb25zZSIekOowAqDqMAGC0+STAhASDi92MS93b3Jrc3BhY2VzEqQBCg9VcGRhdGVXb3Jrc3BhY2USIy5ieXRlYmFzZS52MS5VcGRhdGVXb3Jrc3BhY2VSZXF1ZXN0GhYuYnl0ZWJhc2UudjEuV29ya3NwYWNlIlSK6jAUYmIud29ya3NwYWNlcy51cGRhdGWQ6jABmOowAaDqMASo6jAJgtPkkwImOgEqMiEvdjEve3dvcmtzcGFjZS5uYW1lPXdvcmtzcGFjZXMvKn0SpAEKDEdldElhbVBvbGljeRIgLmJ5dGViYXNlLnYxLkdldElhbVBvbGljeVJlcXVlc3QaFi5ieXRlYmFzZS52MS5JYW1Qb2xpY3kiWorqMBpiYi53b3Jrc3BhY2VzLmdldElhbVBvbGljeZDqMAGg6jAEqOowCYLT5JMCKhIoL3YxL3tyZXNvdXJjZT13b3Jrc3BhY2VzLyp9OmdldElhbVBvbGljeRKbAQoPRGVsZXRlV29ya3NwYWNlEiMuYnl0ZWJhc2UudjEuRGVsZXRlV29ya3NwYWNlUmVxdWVzdBoaLmJ5dGViYXNlLnYxLkxvZ2luUmVzcG9uc2UiR4rqMBRiYi53b3Jrc3BhY2VzLmRlbGV0ZZDqMAGY6jABoOowA6jqMAWC0+STAhkqFy92MS97bmFtZT13b3Jrc3BhY2VzLyp9EooBCg5MZWF2ZVdvcmtzcGFjZRIiLmJ5dGViYXNlLnYxLkxlYXZlV29ya3NwYWNlUmVxdWVzdBoaLmJ5dGViYXNlLnYxLkxvZ2luUmVzcG9uc2UiOJDqMAKY6jABoOowA6jqMAWC0+STAiI6ASoiHS92MS97bmFtZT13b3Jrc3BhY2VzLyp9OmxlYXZlEqsBCgxTZXRJYW1Qb2xpY3kSIC5ieXRlYmFzZS52MS5TZXRJYW1Qb2xpY3lSZXF1ZXN0GhYuYnl0ZWJhc2UudjEuSWFtUG9saWN5ImGK6jAaYmIud29ya3NwYWNlcy5zZXRJYW1Qb2xpY3mQ6jABmOowAaDqMASo6jAJgtPkkwItOgEqIigvdjEve3Jlc291cmNlPXdvcmtzcGFjZXMvKn06c2V0SWFtUG9saWN5EvUBChhSb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW4SLC5ieXRlYmFzZS52MS5Sb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW5SZXF1ZXN0Gi0uYnl0ZWJhc2UudjEuUm90YXRlRGlyZWN0b3J5U3luY1Rva2VuUmVzcG9uc2UifNpBBG5hbWWK6jAmYmIud29ya3NwYWNlcy5yb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW6Q6jABmOowAaDqMAOo6jAGgtPkkwI1OgEqIjAvdjEve25hbWU9d29ya3NwYWNlcy8qfTpyb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW5CqwEKD2NvbS5ieXRlYmFzZS52MUIVV29ya3NwYWNlU2VydmljZVByb3RvUAFaNGdpdGh1Yi5jb20vYnl0ZWJhc2UvYnl0ZWJhc2UvYmFja2VuZC9nZW5lcmF0ZWQtZ28vdjGiAgNCWFiqAgtCeXRlYmFzZS5WMcoCC0J5dGViYXNlXFYx4gIXQnl0ZWJhc2VcVjFcR1BCTWV0YWRhdGHqAgxCeXRlYmFzZTo6VjFiBnByb3RvMw", [file_google_api_annotations, file_google_api_client, file_google_api_field_behavior, file_google_api_resource, file_google_protobuf_field_mask, file_v1_annotation, file_v1_auth_service, file_v1_iam_policy]);
+  fileDesc("Chp2MS93b3Jrc3BhY2Vfc2VydmljZS5wcm90bxILYnl0ZWJhc2UudjEiEwoRR2V0TUNQSW5mb1JlcXVlc3QixgIKB01DUEluZm8SFgoJd29ya3NwYWNlGAEgASgJQgPgQQMSOwoKY2FwYWJpbGl0eRgCIAEoDjIiLmJ5dGViYXNlLnYxLk1DUFNldHRpbmcuQ2FwYWJpbGl0eUID4EEDEjIKBW1vZGVzGAMgAygLMh4uYnl0ZWJhc2UudjEuTUNQQ2FwYWJpbGl0eU1vZGVCA+BBAxIsCgdtZXRob2RzGAQgAygLMhYuYnl0ZWJhc2UudjEuTUNQTWV0aG9kQgPgQQMSNwoHZW5naW5lcxgFIAMoCzIhLmJ5dGViYXNlLnYxLk1DUEVuZ2luZUVuZm9yY2VtZW50QgPgQQMSJgoZaWdub3JlX21hc2tpbmdfZXhlbXB0aW9ucxgGIAEoCEID4EEDEiMKFmRhdGFfbWFza2luZ19hdmFpbGFibGUYByABKAhCA+BBAyKAAQoRTUNQQ2FwYWJpbGl0eU1vZGUSNgoKY2FwYWJpbGl0eRgBIAEoDjIiLmJ5dGViYXNlLnYxLk1DUFNldHRpbmcuQ2FwYWJpbGl0eRIzCg5zZXJ2ZWRfY2xhc3NlcxgCIAMoDjIbLmJ5dGViYXNlLnYxLk1DUE1ldGhvZENsYXNzIp8BCglNQ1BNZXRob2QSDgoGbWV0aG9kGAEgASgJEhQKDG9wZXJhdGlvbl9pZBgEIAEoCRIqCgVjbGFzcxgCIAEoDjIbLmJ5dGViYXNlLnYxLk1DUE1ldGhvZENsYXNzEhIKCnBlcm1pc3Npb24YAyABKAkSLAoLYXV0aF9tZXRob2QYBSABKA4yFy5ieXRlYmFzZS52MS5BdXRoTWV0aG9kIoQDChRNQ1BFbmdpbmVFbmZvcmNlbWVudBIjCgZlbmdpbmUYASABKA4yEy5ieXRlYmFzZS52MS5FbmdpbmUSSAoPcmVhZF9vbmx5X2RlcHRoGAIgASgOMi8uYnl0ZWJhc2UudjEuTUNQRW5naW5lRW5mb3JjZW1lbnQuUmVhZE9ubHlEZXB0aBI6CgdtYXNraW5nGAMgASgOMikuYnl0ZWJhc2UudjEuTUNQRW5naW5lRW5mb3JjZW1lbnQuTWFza2luZxIMCgRub3RlGAQgASgJImsKDVJlYWRPbmx5RGVwdGgSHwobUkVBRF9PTkxZX0RFUFRIX1VOU1BFQ0lGSUVEEAASDwoLVU5TVVBQT1JURUQQARINCglTVEFURU1FTlQQAhIZChVTVEFURU1FTlRfQU5EX1NFU1NJT04QAyJGCgdNYXNraW5nEhcKE01BU0tJTkdfVU5TUEVDSUZJRUQQABIICgROT05FEAESCgoGQ09MVU1OEAISDAoIRE9DVU1FTlQQAyJPCh9Sb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW5SZXF1ZXN0EiwKBG5hbWUYASABKAlCHuBBAvpBGAoWYnl0ZWJhc2UuY29tL1dvcmtzcGFjZSI2CiBSb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW5SZXNwb25zZRISCgV0b2tlbhgBIAEoCUID4EEDIhcKFUxpc3RXb3Jrc3BhY2VzUmVxdWVzdCJEChZMaXN0V29ya3NwYWNlc1Jlc3BvbnNlEioKCndvcmtzcGFjZXMYASADKAsyFi5ieXRlYmFzZS52MS5Xb3Jrc3BhY2UiIwoTR2V0V29ya3NwYWNlUmVxdWVzdBIMCgRuYW1lGAEgASgJIjYKCVdvcmtzcGFjZRIMCgRuYW1lGAEgASgJEg0KBXRpdGxlGAIgASgJEgwKBGxvZ28YAyABKAkiKwoWRGVsZXRlV29ya3NwYWNlUmVxdWVzdBIRCgRuYW1lGAEgASgJQgPgQQIieQoWVXBkYXRlV29ya3NwYWNlUmVxdWVzdBIuCgl3b3Jrc3BhY2UYASABKAsyFi5ieXRlYmFzZS52MS5Xb3Jrc3BhY2VCA+BBAhIvCgt1cGRhdGVfbWFzaxgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5GaWVsZE1hc2siKgoVTGVhdmVXb3Jrc3BhY2VSZXF1ZXN0EhEKBG5hbWUYASABKAlCA+BBAjKACwoQV29ya3NwYWNlU2VydmljZRJxCgxHZXRXb3Jrc3BhY2USIC5ieXRlYmFzZS52MS5HZXRXb3Jrc3BhY2VSZXF1ZXN0GhYuYnl0ZWJhc2UudjEuV29ya3NwYWNlIieA6jABoOowAYLT5JMCGRIXL3YxL3tuYW1lPXdvcmtzcGFjZXMvKn0SeQoOTGlzdFdvcmtzcGFjZXMSIi5ieXRlYmFzZS52MS5MaXN0V29ya3NwYWNlc1JlcXVlc3QaIy5ieXRlYmFzZS52MS5MaXN0V29ya3NwYWNlc1Jlc3BvbnNlIh6Q6jACoOowAYLT5JMCEBIOL3YxL3dvcmtzcGFjZXMSpAEKD1VwZGF0ZVdvcmtzcGFjZRIjLmJ5dGViYXNlLnYxLlVwZGF0ZVdvcmtzcGFjZVJlcXVlc3QaFi5ieXRlYmFzZS52MS5Xb3Jrc3BhY2UiVIrqMBRiYi53b3Jrc3BhY2VzLnVwZGF0ZZDqMAGY6jABoOowBKjqMAmC0+STAiY6ASoyIS92MS97d29ya3NwYWNlLm5hbWU9d29ya3NwYWNlcy8qfRKkAQoMR2V0SWFtUG9saWN5EiAuYnl0ZWJhc2UudjEuR2V0SWFtUG9saWN5UmVxdWVzdBoWLmJ5dGViYXNlLnYxLklhbVBvbGljeSJaiuowGmJiLndvcmtzcGFjZXMuZ2V0SWFtUG9saWN5kOowAaDqMASo6jAJgtPkkwIqEigvdjEve3Jlc291cmNlPXdvcmtzcGFjZXMvKn06Z2V0SWFtUG9saWN5EpsBCg9EZWxldGVXb3Jrc3BhY2USIy5ieXRlYmFzZS52MS5EZWxldGVXb3Jrc3BhY2VSZXF1ZXN0GhouYnl0ZWJhc2UudjEuTG9naW5SZXNwb25zZSJHiuowFGJiLndvcmtzcGFjZXMuZGVsZXRlkOowAZjqMAGg6jADqOowBYLT5JMCGSoXL3YxL3tuYW1lPXdvcmtzcGFjZXMvKn0SigEKDkxlYXZlV29ya3NwYWNlEiIuYnl0ZWJhc2UudjEuTGVhdmVXb3Jrc3BhY2VSZXF1ZXN0GhouYnl0ZWJhc2UudjEuTG9naW5SZXNwb25zZSI4kOowApjqMAGg6jADqOowBYLT5JMCIjoBKiIdL3YxL3tuYW1lPXdvcmtzcGFjZXMvKn06bGVhdmUSqwEKDFNldElhbVBvbGljeRIgLmJ5dGViYXNlLnYxLlNldElhbVBvbGljeVJlcXVlc3QaFi5ieXRlYmFzZS52MS5JYW1Qb2xpY3kiYYrqMBpiYi53b3Jrc3BhY2VzLnNldElhbVBvbGljeZDqMAGY6jABoOowBKjqMAmC0+STAi06ASoiKC92MS97cmVzb3VyY2U9d29ya3NwYWNlcy8qfTpzZXRJYW1Qb2xpY3kSXwoKR2V0TUNQSW5mbxIeLmJ5dGViYXNlLnYxLkdldE1DUEluZm9SZXF1ZXN0GhQuYnl0ZWJhc2UudjEuTUNQSW5mbyIb2kEAoOowAYLT5JMCDhIML3YxL21jcC9pbmZvEvUBChhSb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW4SLC5ieXRlYmFzZS52MS5Sb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW5SZXF1ZXN0Gi0uYnl0ZWJhc2UudjEuUm90YXRlRGlyZWN0b3J5U3luY1Rva2VuUmVzcG9uc2UifNpBBG5hbWWK6jAmYmIud29ya3NwYWNlcy5yb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW6Q6jABmOowAaDqMAOo6jAGgtPkkwI1OgEqIjAvdjEve25hbWU9d29ya3NwYWNlcy8qfTpyb3RhdGVEaXJlY3RvcnlTeW5jVG9rZW5CqwEKD2NvbS5ieXRlYmFzZS52MUIVV29ya3NwYWNlU2VydmljZVByb3RvUAFaNGdpdGh1Yi5jb20vYnl0ZWJhc2UvYnl0ZWJhc2UvYmFja2VuZC9nZW5lcmF0ZWQtZ28vdjGiAgNCWFiqAgtCeXRlYmFzZS5WMcoCC0J5dGViYXNlXFYx4gIXQnl0ZWJhc2VcVjFcR1BCTWV0YWRhdGHqAgxCeXRlYmFzZTo6VjFiBnByb3RvMw", [file_google_api_annotations, file_google_api_client, file_google_api_field_behavior, file_google_api_resource, file_google_protobuf_field_mask, file_v1_annotation, file_v1_auth_service, file_v1_common, file_v1_iam_policy, file_v1_setting_service]);
+
+/**
+ * Describes the message bytebase.v1.GetMCPInfoRequest.
+ * Use `create(GetMCPInfoRequestSchema)` to create a new message.
+ */
+export const GetMCPInfoRequestSchema = /*@__PURE__*/
+  messageDesc(file_v1_workspace_service, 0);
+
+/**
+ * Describes the message bytebase.v1.MCPInfo.
+ * Use `create(MCPInfoSchema)` to create a new message.
+ */
+export const MCPInfoSchema = /*@__PURE__*/
+  messageDesc(file_v1_workspace_service, 1);
+
+/**
+ * Describes the message bytebase.v1.MCPCapabilityMode.
+ * Use `create(MCPCapabilityModeSchema)` to create a new message.
+ */
+export const MCPCapabilityModeSchema = /*@__PURE__*/
+  messageDesc(file_v1_workspace_service, 2);
+
+/**
+ * Describes the message bytebase.v1.MCPMethod.
+ * Use `create(MCPMethodSchema)` to create a new message.
+ */
+export const MCPMethodSchema = /*@__PURE__*/
+  messageDesc(file_v1_workspace_service, 3);
+
+/**
+ * Describes the message bytebase.v1.MCPEngineEnforcement.
+ * Use `create(MCPEngineEnforcementSchema)` to create a new message.
+ */
+export const MCPEngineEnforcementSchema = /*@__PURE__*/
+  messageDesc(file_v1_workspace_service, 4);
+
+/**
+ * Describes the enum bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth.
+ */
+export const MCPEngineEnforcement_ReadOnlyDepthSchema = /*@__PURE__*/
+  enumDesc(file_v1_workspace_service, 4, 0);
+
+/**
+ * How much of a read-only ceiling this engine can be held to.
+ *
+ * @generated from enum bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth
+ */
+export const MCPEngineEnforcement_ReadOnlyDepth = /*@__PURE__*/
+  tsEnum(MCPEngineEnforcement_ReadOnlyDepthSchema);
+
+/**
+ * Describes the enum bytebase.v1.MCPEngineEnforcement.Masking.
+ */
+export const MCPEngineEnforcement_MaskingSchema = /*@__PURE__*/
+  enumDesc(file_v1_workspace_service, 4, 1);
+
+/**
+ * How Bytebase masks results on this engine, which is what decides whether
+ * ignoring masking exemptions changes anything here.
+ *
+ * @generated from enum bytebase.v1.MCPEngineEnforcement.Masking
+ */
+export const MCPEngineEnforcement_Masking = /*@__PURE__*/
+  tsEnum(MCPEngineEnforcement_MaskingSchema);
 
 /**
  * Describes the message bytebase.v1.RotateDirectorySyncTokenRequest.
  * Use `create(RotateDirectorySyncTokenRequestSchema)` to create a new message.
  */
 export const RotateDirectorySyncTokenRequestSchema = /*@__PURE__*/
-  messageDesc(file_v1_workspace_service, 0);
+  messageDesc(file_v1_workspace_service, 5);
 
 /**
  * Describes the message bytebase.v1.RotateDirectorySyncTokenResponse.
  * Use `create(RotateDirectorySyncTokenResponseSchema)` to create a new message.
  */
 export const RotateDirectorySyncTokenResponseSchema = /*@__PURE__*/
-  messageDesc(file_v1_workspace_service, 1);
+  messageDesc(file_v1_workspace_service, 6);
 
 /**
  * Describes the message bytebase.v1.ListWorkspacesRequest.
  * Use `create(ListWorkspacesRequestSchema)` to create a new message.
  */
 export const ListWorkspacesRequestSchema = /*@__PURE__*/
-  messageDesc(file_v1_workspace_service, 2);
+  messageDesc(file_v1_workspace_service, 7);
 
 /**
  * Describes the message bytebase.v1.ListWorkspacesResponse.
  * Use `create(ListWorkspacesResponseSchema)` to create a new message.
  */
 export const ListWorkspacesResponseSchema = /*@__PURE__*/
-  messageDesc(file_v1_workspace_service, 3);
+  messageDesc(file_v1_workspace_service, 8);
 
 /**
  * Describes the message bytebase.v1.GetWorkspaceRequest.
  * Use `create(GetWorkspaceRequestSchema)` to create a new message.
  */
 export const GetWorkspaceRequestSchema = /*@__PURE__*/
-  messageDesc(file_v1_workspace_service, 4);
+  messageDesc(file_v1_workspace_service, 9);
 
 /**
  * Describes the message bytebase.v1.Workspace.
  * Use `create(WorkspaceSchema)` to create a new message.
  */
 export const WorkspaceSchema = /*@__PURE__*/
-  messageDesc(file_v1_workspace_service, 5);
+  messageDesc(file_v1_workspace_service, 10);
 
 /**
  * Describes the message bytebase.v1.DeleteWorkspaceRequest.
  * Use `create(DeleteWorkspaceRequestSchema)` to create a new message.
  */
 export const DeleteWorkspaceRequestSchema = /*@__PURE__*/
-  messageDesc(file_v1_workspace_service, 6);
+  messageDesc(file_v1_workspace_service, 11);
 
 /**
  * Describes the message bytebase.v1.UpdateWorkspaceRequest.
  * Use `create(UpdateWorkspaceRequestSchema)` to create a new message.
  */
 export const UpdateWorkspaceRequestSchema = /*@__PURE__*/
-  messageDesc(file_v1_workspace_service, 7);
+  messageDesc(file_v1_workspace_service, 12);
 
 /**
  * Describes the message bytebase.v1.LeaveWorkspaceRequest.
  * Use `create(LeaveWorkspaceRequestSchema)` to create a new message.
  */
 export const LeaveWorkspaceRequestSchema = /*@__PURE__*/
-  messageDesc(file_v1_workspace_service, 8);
+  messageDesc(file_v1_workspace_service, 13);
 
 /**
  * WorkspaceService manages workspace-level operations and profile.

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -5443,6 +5443,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/bytebase.v1.BatchUpdateInstancesResponse'
+  /v1/mcp/info:
+    get:
+      tags:
+        - WorkspaceService
+      summary: |-
+        Gets what MCP (Model Context Protocol) does in this workspace: the
+         capability ceiling in force, what each ceiling serves, and the per-engine
+         facts a read-only session depends on. The workspace is resolved from the
+         authenticated session.
+      description: |-
+        Served to MCP sessions. An agent asking what it may do here is the point:
+         the response says nothing a session's own denials do not already say, one
+         refusal at a time, and knowing it up front is what stops the agent
+         planning work the ceiling was never going to serve.
+
+         Permissions required: None (authentication required)
+      operationId: WorkspaceService_GetMCPInfo
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bytebase.v1.MCPInfo'
   /v1/projects:
     get:
       tags:
@@ -23176,6 +23200,10 @@ components:
       required:
         - name
       additionalProperties: false
+    bytebase.v1.GetMCPInfoRequest:
+      type: object
+      title: GetMCPInfoRequest
+      additionalProperties: false
     bytebase.v1.GetPaymentInfoRequest:
       type: object
       title: GetPaymentInfoRequest
@@ -25970,6 +25998,21 @@ components:
       title: LogoutRequest
       additionalProperties: false
       description: Request to logout current user session.
+    bytebase.v1.MCPCapabilityMode:
+      type: object
+      properties:
+        capability:
+          title: capability
+          $ref: '#/components/schemas/bytebase.v1.MCPSetting.Capability'
+        servedClasses:
+          type: array
+          items:
+            $ref: '#/components/schemas/bytebase.v1.MCPMethodClass'
+          title: served_classes
+          description: Empty means the ceiling serves nothing, which is what DISABLED is.
+      title: MCPCapabilityMode
+      additionalProperties: false
+      description: MCPCapabilityMode is one ceiling and the method classes it serves.
     bytebase.v1.MCPDelegation:
       type: object
       properties:
@@ -26042,6 +26085,166 @@ components:
          that contradicts its class. Neither is expressible now, and the one check
          left — the reason belongs to the class it is used on — is a table the gate
          already keeps for the wording.
+    bytebase.v1.MCPEngineEnforcement:
+      type: object
+      properties:
+        engine:
+          title: engine
+          $ref: '#/components/schemas/bytebase.v1.Engine'
+        readOnlyDepth:
+          title: read_only_depth
+          $ref: '#/components/schemas/bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth'
+        masking:
+          title: masking
+          $ref: '#/components/schemas/bytebase.v1.MCPEngineEnforcement.Masking'
+        note:
+          type: string
+          title: note
+          description: |-
+            Where the answers above are the floor rather than the whole story. Empty
+             for most engines.
+      title: MCPEngineEnforcement
+      additionalProperties: false
+      description: |-
+        MCPEngineEnforcement is what the read-only ceiling and the masking toggle
+         reach on one database engine.
+    bytebase.v1.MCPEngineEnforcement.Masking:
+      type: string
+      title: Masking
+      enum:
+        - MASKING_UNSPECIFIED
+        - NONE
+        - COLUMN
+        - DOCUMENT
+      description: |-
+        How Bytebase masks results on this engine, which is what decides whether
+         ignoring masking exemptions changes anything here.
+    bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth:
+      type: string
+      title: ReadOnlyDepth
+      enum:
+        - READ_ONLY_DEPTH_UNSPECIFIED
+        - UNSUPPORTED
+        - STATEMENT
+        - STATEMENT_AND_SESSION
+      description: How much of a read-only ceiling this engine can be held to.
+    bytebase.v1.MCPInfo:
+      type: object
+      properties:
+        workspace:
+          type: string
+          title: workspace
+          description: |-
+            The workspace this describes. Format: workspaces/{workspace}. Not this
+             message's own resource name — MCPInfo is not a named resource and there is
+             nothing to get it by.
+          readOnly: true
+        capability:
+          title: capability
+          description: |-
+            The ceiling in force for this workspace. A workspace that never configured
+             MCP resolves to READ_WRITE.
+          readOnly: true
+          $ref: '#/components/schemas/bytebase.v1.MCPSetting.Capability'
+        modes:
+          type: array
+          items:
+            $ref: '#/components/schemas/bytebase.v1.MCPCapabilityMode'
+          title: modes
+          description: |-
+            What each ceiling serves, including the one in force, so an admin can
+             compare the choices rather than only read the current answer.
+          readOnly: true
+        methods:
+          type: array
+          items:
+            $ref: '#/components/schemas/bytebase.v1.MCPMethod'
+          title: methods
+          description: |-
+            Every API method some ceiling serves. A mode serves a method when the
+             method's class is one of that mode's served_classes, which is the ceiling
+             rule the gate evaluates. Methods no ceiling serves are absent.
+
+             Being listed is necessary, not sufficient. The caller still needs the
+             permission, and two further rules narrow what a served method does: a
+             handful of methods are refused on the shape of the request (an issue that
+             would grant a permission, a rollout that skips approval), and under
+             READ_ONLY every statement SQLService/Query runs must classify as a read.
+          readOnly: true
+        engines:
+          type: array
+          items:
+            $ref: '#/components/schemas/bytebase.v1.MCPEngineEnforcement'
+          title: engines
+          description: |-
+            What a read-only session and the masking toggle actually reach, per engine.
+             Both are engine-conditional in ways the ceiling alone does not show.
+          readOnly: true
+        ignoreMaskingExemptions:
+          type: boolean
+          title: ignore_masking_exemptions
+          description: |-
+            Whether this workspace stops applying the caller's own unmasking
+             provisioning to MCP requests. It decides which branch of each engine's
+             masking state a caller is in, and no other API tells an MCP session:
+             SettingService/GetSetting is served by no ceiling.
+          readOnly: true
+        dataMaskingAvailable:
+          type: boolean
+          title: data_masking_available
+          description: |-
+            Whether data masking is licensed for this workspace. When false nothing is
+             masked whatever an engine supports, so the masking states below describe a
+             mechanism that does not run. Licensing can also be set per instance, so a
+             true here is the workspace answer, not a promise about every instance.
+          readOnly: true
+      title: MCPInfo
+      additionalProperties: false
+      description: |-
+        MCPInfo is what MCP does in this workspace: the ceiling in force, what each
+         ceiling serves, and the per-engine facts a read-only session depends on.
+
+         Everything here is resolved when the request is served, never from a stored
+         copy: the method list comes off the compiled API descriptors and the engine
+         answers off the code that enforces them, so a build whose rules changed
+         cannot describe the rules of the build before it.
+    bytebase.v1.MCPMethod:
+      type: object
+      properties:
+        method:
+          type: string
+          title: method
+          description: |-
+            The method as an audit entry names it, so a denial can be found by it.
+             Example: /bytebase.v1.SQLService/Query
+        operationId:
+          type: string
+          title: operation_id
+          description: |-
+            The same method as call_api takes it.
+             Example: bytebase.v1.SQLService.Query
+        class:
+          title: class
+          $ref: '#/components/schemas/bytebase.v1.MCPMethodClass'
+        permission:
+          type: string
+          title: permission
+          description: |-
+            The IAM permission the method declares. The ceiling never grants: a session
+             may call a served method only where the person it acts for could.
+
+             Empty means the method declares no permission, which is NOT the same as
+             needing none — a method that authorizes inside its handler declares nothing
+             here. auth_method says which case an empty value is.
+        authMethod:
+          title: auth_method
+          description: |-
+            How the method authorizes. IAM means the permission above is the whole
+             rule; CUSTOM means the handler decides and the permission field is silent.
+          $ref: '#/components/schemas/bytebase.v1.AuthMethod'
+      title: MCPMethod
+      additionalProperties: false
+      description: MCPMethod is one API method an MCP session can reach, and what decides it.
     bytebase.v1.MCPMethodClass:
       type: string
       title: MCPMethodClass

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -775,14 +775,22 @@
   
 - [v1/workspace_service.proto](#v1_workspace_service-proto)
     - [DeleteWorkspaceRequest](#bytebase-v1-DeleteWorkspaceRequest)
+    - [GetMCPInfoRequest](#bytebase-v1-GetMCPInfoRequest)
     - [GetWorkspaceRequest](#bytebase-v1-GetWorkspaceRequest)
     - [LeaveWorkspaceRequest](#bytebase-v1-LeaveWorkspaceRequest)
     - [ListWorkspacesRequest](#bytebase-v1-ListWorkspacesRequest)
     - [ListWorkspacesResponse](#bytebase-v1-ListWorkspacesResponse)
+    - [MCPCapabilityMode](#bytebase-v1-MCPCapabilityMode)
+    - [MCPEngineEnforcement](#bytebase-v1-MCPEngineEnforcement)
+    - [MCPInfo](#bytebase-v1-MCPInfo)
+    - [MCPMethod](#bytebase-v1-MCPMethod)
     - [RotateDirectorySyncTokenRequest](#bytebase-v1-RotateDirectorySyncTokenRequest)
     - [RotateDirectorySyncTokenResponse](#bytebase-v1-RotateDirectorySyncTokenResponse)
     - [UpdateWorkspaceRequest](#bytebase-v1-UpdateWorkspaceRequest)
     - [Workspace](#bytebase-v1-Workspace)
+  
+    - [MCPEngineEnforcement.Masking](#bytebase-v1-MCPEngineEnforcement-Masking)
+    - [MCPEngineEnforcement.ReadOnlyDepth](#bytebase-v1-MCPEngineEnforcement-ReadOnlyDepth)
   
     - [WorkspaceService](#bytebase-v1-WorkspaceService)
   
@@ -12520,6 +12528,16 @@ WorkloadIdentityService manages workload identities for external CI/CD integrati
 
 
 
+<a name="bytebase-v1-GetMCPInfoRequest"></a>
+
+### GetMCPInfoRequest
+
+
+
+
+
+
+
 <a name="bytebase-v1-GetWorkspaceRequest"></a>
 
 ### GetWorkspaceRequest
@@ -12569,6 +12587,91 @@ WorkloadIdentityService manages workload identities for external CI/CD integrati
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | workspaces | [Workspace](#bytebase-v1-Workspace) | repeated |  |
+
+
+
+
+
+
+<a name="bytebase-v1-MCPCapabilityMode"></a>
+
+### MCPCapabilityMode
+MCPCapabilityMode is one ceiling and the method classes it serves.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| capability | [MCPSetting.Capability](#bytebase-v1-MCPSetting-Capability) |  |  |
+| served_classes | [MCPMethodClass](#bytebase-v1-MCPMethodClass) | repeated | Empty means the ceiling serves nothing, which is what DISABLED is. |
+
+
+
+
+
+
+<a name="bytebase-v1-MCPEngineEnforcement"></a>
+
+### MCPEngineEnforcement
+MCPEngineEnforcement is what the read-only ceiling and the masking toggle
+reach on one database engine.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| engine | [Engine](#bytebase-v1-Engine) |  |  |
+| read_only_depth | [MCPEngineEnforcement.ReadOnlyDepth](#bytebase-v1-MCPEngineEnforcement-ReadOnlyDepth) |  |  |
+| masking | [MCPEngineEnforcement.Masking](#bytebase-v1-MCPEngineEnforcement-Masking) |  |  |
+| note | [string](#string) |  | Where the answers above are the floor rather than the whole story. Empty for most engines. |
+
+
+
+
+
+
+<a name="bytebase-v1-MCPInfo"></a>
+
+### MCPInfo
+MCPInfo is what MCP does in this workspace: the ceiling in force, what each
+ceiling serves, and the per-engine facts a read-only session depends on.
+
+Everything here is resolved when the request is served, never from a stored
+copy: the method list comes off the compiled API descriptors and the engine
+answers off the code that enforces them, so a build whose rules changed
+cannot describe the rules of the build before it.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| workspace | [string](#string) |  | The workspace this describes. Format: workspaces/{workspace}. Not this message&#39;s own resource name — MCPInfo is not a named resource and there is nothing to get it by. |
+| capability | [MCPSetting.Capability](#bytebase-v1-MCPSetting-Capability) |  | The ceiling in force for this workspace. A workspace that never configured MCP resolves to READ_WRITE. |
+| modes | [MCPCapabilityMode](#bytebase-v1-MCPCapabilityMode) | repeated | What each ceiling serves, including the one in force, so an admin can compare the choices rather than only read the current answer. |
+| methods | [MCPMethod](#bytebase-v1-MCPMethod) | repeated | Every API method some ceiling serves. A mode serves a method when the method&#39;s class is one of that mode&#39;s served_classes, which is the ceiling rule the gate evaluates. Methods no ceiling serves are absent.
+
+Being listed is necessary, not sufficient. The caller still needs the permission, and two further rules narrow what a served method does: a handful of methods are refused on the shape of the request (an issue that would grant a permission, a rollout that skips approval), and under READ_ONLY every statement SQLService/Query runs must classify as a read. |
+| engines | [MCPEngineEnforcement](#bytebase-v1-MCPEngineEnforcement) | repeated | What a read-only session and the masking toggle actually reach, per engine. Both are engine-conditional in ways the ceiling alone does not show. |
+| ignore_masking_exemptions | [bool](#bool) |  | Whether this workspace stops applying the caller&#39;s own unmasking provisioning to MCP requests. It decides which branch of each engine&#39;s masking state a caller is in, and no other API tells an MCP session: SettingService/GetSetting is served by no ceiling. |
+| data_masking_available | [bool](#bool) |  | Whether data masking is licensed for this workspace. When false nothing is masked whatever an engine supports, so the masking states below describe a mechanism that does not run. Licensing can also be set per instance, so a true here is the workspace answer, not a promise about every instance. |
+
+
+
+
+
+
+<a name="bytebase-v1-MCPMethod"></a>
+
+### MCPMethod
+MCPMethod is one API method an MCP session can reach, and what decides it.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| method | [string](#string) |  | The method as an audit entry names it, so a denial can be found by it. Example: /bytebase.v1.SQLService/Query |
+| operation_id | [string](#string) |  | The same method as call_api takes it. Example: bytebase.v1.SQLService.Query |
+| class | [MCPMethodClass](#bytebase-v1-MCPMethodClass) |  |  |
+| permission | [string](#string) |  | The IAM permission the method declares. The ceiling never grants: a session may call a served method only where the person it acts for could.
+
+Empty means the method declares no permission, which is NOT the same as needing none — a method that authorizes inside its handler declares nothing here. auth_method says which case an empty value is. |
+| auth_method | [AuthMethod](#bytebase-v1-AuthMethod) |  | How the method authorizes. IAM means the permission above is the whole rule; CUSTOM means the handler decides and the permission field is silent. |
 
 
 
@@ -12639,6 +12742,35 @@ WorkloadIdentityService manages workload identities for external CI/CD integrati
 
  
 
+
+<a name="bytebase-v1-MCPEngineEnforcement-Masking"></a>
+
+### MCPEngineEnforcement.Masking
+How Bytebase masks results on this engine, which is what decides whether
+ignoring masking exemptions changes anything here.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| MASKING_UNSPECIFIED | 0 |  |
+| NONE | 1 | Bytebase does not mask on this engine. Nothing narrows what a session reads, and ignoring masking exemptions does nothing. |
+| COLUMN | 2 | Column masking. A masking policy substitutes values in query results, and the exemptions granted to the caller are what let them see the real value — which is what ignoring exemptions suppresses. |
+| DOCUMENT | 3 | Document masking. Results are masked, but exemptions are never consulted on this path, so ignoring them changes nothing here either. |
+
+
+
+<a name="bytebase-v1-MCPEngineEnforcement-ReadOnlyDepth"></a>
+
+### MCPEngineEnforcement.ReadOnlyDepth
+How much of a read-only ceiling this engine can be held to.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| READ_ONLY_DEPTH_UNSPECIFIED | 0 |  |
+| UNSUPPORTED | 1 | Bytebase has no read-only classifier for this engine, so a read-only session is refused every statement on it, including a plain SELECT. |
+| STATEMENT | 2 | Every statement is classified before it runs and a request holding one that is not a read is refused whole. Nothing below that: the driver does not open a read-only database session, except where the note says otherwise. |
+| STATEMENT_AND_SESSION | 3 | Statement classification, and the driver opens the database session read-only as well, so the engine refuses most writes the classifier missed. Not a proof: a statement that classifies as a read can still call a function that switches the session setting back off. |
+
+
  
 
  
@@ -12658,6 +12790,11 @@ WorkspaceService manages workspace-level operations and profile.
 | DeleteWorkspace | [DeleteWorkspaceRequest](#bytebase-v1-DeleteWorkspaceRequest) | [LoginResponse](#bytebase-v1-LoginResponse) | Deletes a workspace. SaaS only. Cancels any active subscription and soft-deletes the workspace so all associated data becomes inaccessible. Requires workspace admin permission. |
 | LeaveWorkspace | [LeaveWorkspaceRequest](#bytebase-v1-LeaveWorkspaceRequest) | [LoginResponse](#bytebase-v1-LoginResponse) | Removes the calling user from a workspace and switches to the next available workspace. Available to any workspace member. Fails if the caller is the last workspace admin. |
 | SetIamPolicy | [SetIamPolicyRequest](#bytebase-v1-SetIamPolicyRequest) | [IamPolicy](#bytebase-v1-IamPolicy) | Sets IAM policy for the workspace. Permissions required: bb.workspaces.setIamPolicy |
+| GetMCPInfo | [GetMCPInfoRequest](#bytebase-v1-GetMCPInfoRequest) | [MCPInfo](#bytebase-v1-MCPInfo) | Gets what MCP (Model Context Protocol) does in this workspace: the capability ceiling in force, what each ceiling serves, and the per-engine facts a read-only session depends on. The workspace is resolved from the authenticated session.
+
+Served to MCP sessions. An agent asking what it may do here is the point: the response says nothing a session&#39;s own denials do not already say, one refusal at a time, and knowing it up front is what stops the agent planning work the ceiling was never going to serve.
+
+Permissions required: None (authentication required) |
 | RotateDirectorySyncToken | [RotateDirectorySyncTokenRequest](#bytebase-v1-RotateDirectorySyncTokenRequest) | [RotateDirectorySyncTokenResponse](#bytebase-v1-RotateDirectorySyncTokenResponse) | Mints a new directory sync (SCIM) token, immediately invalidating the previous one. The plaintext token is returned exactly once and cannot be retrieved afterwards; only its hash is stored. Callers that lose it must rotate again and update their identity provider. Permissions required: bb.workspaces.rotateDirectorySyncToken |
 
  

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -3128,6 +3128,10 @@
                 </li>
               
                 <li>
+                  <a href="#bytebase.v1.GetMCPInfoRequest"><span class="badge">M</span>GetMCPInfoRequest</a>
+                </li>
+              
+                <li>
                   <a href="#bytebase.v1.GetWorkspaceRequest"><span class="badge">M</span>GetWorkspaceRequest</a>
                 </li>
               
@@ -3141,6 +3145,22 @@
               
                 <li>
                   <a href="#bytebase.v1.ListWorkspacesResponse"><span class="badge">M</span>ListWorkspacesResponse</a>
+                </li>
+              
+                <li>
+                  <a href="#bytebase.v1.MCPCapabilityMode"><span class="badge">M</span>MCPCapabilityMode</a>
+                </li>
+              
+                <li>
+                  <a href="#bytebase.v1.MCPEngineEnforcement"><span class="badge">M</span>MCPEngineEnforcement</a>
+                </li>
+              
+                <li>
+                  <a href="#bytebase.v1.MCPInfo"><span class="badge">M</span>MCPInfo</a>
+                </li>
+              
+                <li>
+                  <a href="#bytebase.v1.MCPMethod"><span class="badge">M</span>MCPMethod</a>
                 </li>
               
                 <li>
@@ -3159,6 +3179,14 @@
                   <a href="#bytebase.v1.Workspace"><span class="badge">M</span>Workspace</a>
                 </li>
               
+              
+                <li>
+                  <a href="#bytebase.v1.MCPEngineEnforcement.Masking"><span class="badge">E</span>MCPEngineEnforcement.Masking</a>
+                </li>
+              
+                <li>
+                  <a href="#bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth"><span class="badge">E</span>MCPEngineEnforcement.ReadOnlyDepth</a>
+                </li>
               
               
               
@@ -35617,6 +35645,13 @@ Permissions required: bb.workloadIdentities.undelete</p></td>
 
         
       
+        <h3 id="bytebase.v1.GetMCPInfoRequest">GetMCPInfoRequest</h3>
+        <p></p>
+
+        
+
+        
+      
         <h3 id="bytebase.v1.GetWorkspaceRequest">GetWorkspaceRequest</h3>
         <p></p>
 
@@ -35688,6 +35723,228 @@ Use &#34;workspaces/-&#34; to get the current/default workspace. </p></td>
                   <td><a href="#bytebase.v1.Workspace">Workspace</a></td>
                   <td>repeated</td>
                   <td><p> </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="bytebase.v1.MCPCapabilityMode">MCPCapabilityMode</h3>
+        <p>MCPCapabilityMode is one ceiling and the method classes it serves.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>capability</td>
+                  <td><a href="#bytebase.v1.MCPSetting.Capability">MCPSetting.Capability</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>served_classes</td>
+                  <td><a href="#bytebase.v1.MCPMethodClass">MCPMethodClass</a></td>
+                  <td>repeated</td>
+                  <td><p>Empty means the ceiling serves nothing, which is what DISABLED is. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="bytebase.v1.MCPEngineEnforcement">MCPEngineEnforcement</h3>
+        <p>MCPEngineEnforcement is what the read-only ceiling and the masking toggle</p><p>reach on one database engine.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>engine</td>
+                  <td><a href="#bytebase.v1.Engine">Engine</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>read_only_depth</td>
+                  <td><a href="#bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth">MCPEngineEnforcement.ReadOnlyDepth</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>masking</td>
+                  <td><a href="#bytebase.v1.MCPEngineEnforcement.Masking">MCPEngineEnforcement.Masking</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>note</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Where the answers above are the floor rather than the whole story. Empty
+for most engines. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="bytebase.v1.MCPInfo">MCPInfo</h3>
+        <p>MCPInfo is what MCP does in this workspace: the ceiling in force, what each</p><p>ceiling serves, and the per-engine facts a read-only session depends on.</p><p>Everything here is resolved when the request is served, never from a stored</p><p>copy: the method list comes off the compiled API descriptors and the engine</p><p>answers off the code that enforces them, so a build whose rules changed</p><p>cannot describe the rules of the build before it.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>workspace</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The workspace this describes. Format: workspaces/{workspace}. Not this
+message&#39;s own resource name — MCPInfo is not a named resource and there is
+nothing to get it by. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>capability</td>
+                  <td><a href="#bytebase.v1.MCPSetting.Capability">MCPSetting.Capability</a></td>
+                  <td></td>
+                  <td><p>The ceiling in force for this workspace. A workspace that never configured
+MCP resolves to READ_WRITE. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>modes</td>
+                  <td><a href="#bytebase.v1.MCPCapabilityMode">MCPCapabilityMode</a></td>
+                  <td>repeated</td>
+                  <td><p>What each ceiling serves, including the one in force, so an admin can
+compare the choices rather than only read the current answer. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>methods</td>
+                  <td><a href="#bytebase.v1.MCPMethod">MCPMethod</a></td>
+                  <td>repeated</td>
+                  <td><p>Every API method some ceiling serves. A mode serves a method when the
+method&#39;s class is one of that mode&#39;s served_classes, which is the ceiling
+rule the gate evaluates. Methods no ceiling serves are absent.
+
+Being listed is necessary, not sufficient. The caller still needs the
+permission, and two further rules narrow what a served method does: a
+handful of methods are refused on the shape of the request (an issue that
+would grant a permission, a rollout that skips approval), and under
+READ_ONLY every statement SQLService/Query runs must classify as a read. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>engines</td>
+                  <td><a href="#bytebase.v1.MCPEngineEnforcement">MCPEngineEnforcement</a></td>
+                  <td>repeated</td>
+                  <td><p>What a read-only session and the masking toggle actually reach, per engine.
+Both are engine-conditional in ways the ceiling alone does not show. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>ignore_masking_exemptions</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>Whether this workspace stops applying the caller&#39;s own unmasking
+provisioning to MCP requests. It decides which branch of each engine&#39;s
+masking state a caller is in, and no other API tells an MCP session:
+SettingService/GetSetting is served by no ceiling. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>data_masking_available</td>
+                  <td><a href="#bool">bool</a></td>
+                  <td></td>
+                  <td><p>Whether data masking is licensed for this workspace. When false nothing is
+masked whatever an engine supports, so the masking states below describe a
+mechanism that does not run. Licensing can also be set per instance, so a
+true here is the workspace answer, not a promise about every instance. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+        <h3 id="bytebase.v1.MCPMethod">MCPMethod</h3>
+        <p>MCPMethod is one API method an MCP session can reach, and what decides it.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>method</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The method as an audit entry names it, so a denial can be found by it.
+Example: /bytebase.v1.SQLService/Query </p></td>
+                </tr>
+              
+                <tr>
+                  <td>operation_id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The same method as call_api takes it.
+Example: bytebase.v1.SQLService.Query </p></td>
+                </tr>
+              
+                <tr>
+                  <td>class</td>
+                  <td><a href="#bytebase.v1.MCPMethodClass">MCPMethodClass</a></td>
+                  <td></td>
+                  <td><p> </p></td>
+                </tr>
+              
+                <tr>
+                  <td>permission</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The IAM permission the method declares. The ceiling never grants: a session
+may call a served method only where the person it acts for could.
+
+Empty means the method declares no permission, which is NOT the same as
+needing none — a method that authorizes inside its handler declares nothing
+here. auth_method says which case an empty value is. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>auth_method</td>
+                  <td><a href="#bytebase.v1.AuthMethod">AuthMethod</a></td>
+                  <td></td>
+                  <td><p>How the method authorizes. IAM means the permission above is the whole
+rule; CUSTOM means the handler decides and the permission field is silent. </p></td>
                 </tr>
               
             </tbody>
@@ -35817,6 +36074,87 @@ Format: workspaces/{workspace} </p></td>
       
 
       
+        <h3 id="bytebase.v1.MCPEngineEnforcement.Masking">MCPEngineEnforcement.Masking</h3>
+        <p>How Bytebase masks results on this engine, which is what decides whether</p><p>ignoring masking exemptions changes anything here.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>MASKING_UNSPECIFIED</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>NONE</td>
+                <td>1</td>
+                <td><p>Bytebase does not mask on this engine. Nothing narrows what a session
+reads, and ignoring masking exemptions does nothing.</p></td>
+              </tr>
+            
+              <tr>
+                <td>COLUMN</td>
+                <td>2</td>
+                <td><p>Column masking. A masking policy substitutes values in query results,
+and the exemptions granted to the caller are what let them see the real
+value — which is what ignoring exemptions suppresses.</p></td>
+              </tr>
+            
+              <tr>
+                <td>DOCUMENT</td>
+                <td>3</td>
+                <td><p>Document masking. Results are masked, but exemptions are never consulted
+on this path, so ignoring them changes nothing here either.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
+        <h3 id="bytebase.v1.MCPEngineEnforcement.ReadOnlyDepth">MCPEngineEnforcement.ReadOnlyDepth</h3>
+        <p>How much of a read-only ceiling this engine can be held to.</p>
+        <table class="enum-table">
+          <thead>
+            <tr><td>Name</td><td>Number</td><td>Description</td></tr>
+          </thead>
+          <tbody>
+            
+              <tr>
+                <td>READ_ONLY_DEPTH_UNSPECIFIED</td>
+                <td>0</td>
+                <td><p></p></td>
+              </tr>
+            
+              <tr>
+                <td>UNSUPPORTED</td>
+                <td>1</td>
+                <td><p>Bytebase has no read-only classifier for this engine, so a read-only
+session is refused every statement on it, including a plain SELECT.</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATEMENT</td>
+                <td>2</td>
+                <td><p>Every statement is classified before it runs and a request holding one
+that is not a read is refused whole. Nothing below that: the driver does
+not open a read-only database session, except where the note says
+otherwise.</p></td>
+              </tr>
+            
+              <tr>
+                <td>STATEMENT_AND_SESSION</td>
+                <td>3</td>
+                <td><p>Statement classification, and the driver opens the database session
+read-only as well, so the engine refuses most writes the classifier
+missed. Not a proof: a statement that classifies as a read can still call
+a function that switches the session setting back off.</p></td>
+              </tr>
+            
+          </tbody>
+        </table>
+      
 
       
 
@@ -35886,6 +36224,23 @@ caller is the last workspace admin.</p></td>
                 <td><a href="#bytebase.v1.IamPolicy">IamPolicy</a></td>
                 <td><p>Sets IAM policy for the workspace.
 Permissions required: bb.workspaces.setIamPolicy</p></td>
+              </tr>
+            
+              <tr>
+                <td>GetMCPInfo</td>
+                <td><a href="#bytebase.v1.GetMCPInfoRequest">GetMCPInfoRequest</a></td>
+                <td><a href="#bytebase.v1.MCPInfo">MCPInfo</a></td>
+                <td><p>Gets what MCP (Model Context Protocol) does in this workspace: the
+capability ceiling in force, what each ceiling serves, and the per-engine
+facts a read-only session depends on. The workspace is resolved from the
+authenticated session.
+
+Served to MCP sessions. An agent asking what it may do here is the point:
+the response says nothing a session&#39;s own denials do not already say, one
+refusal at a time, and knowing it up front is what stops the agent
+planning work the ceiling was never going to serve.
+
+Permissions required: None (authentication required)</p></td>
               </tr>
             
               <tr>
@@ -35984,6 +36339,16 @@ Permissions required: bb.workspaces.rotateDirectorySyncToken</p></td>
                 <td>POST</td>
                 <td>/v1/{resource=workspaces/*}:setIamPolicy</td>
                 <td>*</td>
+              </tr>
+              
+            
+              
+              
+              <tr>
+                <td>GetMCPInfo</td>
+                <td>GET</td>
+                <td>/v1/mcp/info</td>
+                <td></td>
               </tr>
               
             

--- a/proto/v1/v1/workspace_service.proto
+++ b/proto/v1/v1/workspace_service.proto
@@ -9,7 +9,9 @@ import "google/api/resource.proto";
 import "google/protobuf/field_mask.proto";
 import "v1/annotation.proto";
 import "v1/auth_service.proto";
+import "v1/common.proto";
 import "v1/iam_policy.proto";
+import "v1/setting_service.proto";
 
 option go_package = "github.com/bytebase/bytebase/backend/generated-go/v1";
 
@@ -96,6 +98,23 @@ service WorkspaceService {
     option (bytebase.v1.mcp_denial_reason) = ADMINISTERS_THE_WORKSPACE;
   }
 
+  // Gets what MCP (Model Context Protocol) does in this workspace: the
+  // capability ceiling in force, what each ceiling serves, and the per-engine
+  // facts a read-only session depends on. The workspace is resolved from the
+  // authenticated session.
+  //
+  // Served to MCP sessions. An agent asking what it may do here is the point:
+  // the response says nothing a session's own denials do not already say, one
+  // refusal at a time, and knowing it up front is what stops the agent
+  // planning work the ceiling was never going to serve.
+  //
+  // Permissions required: None (authentication required)
+  rpc GetMCPInfo(GetMCPInfoRequest) returns (MCPInfo) {
+    option (google.api.http) = {get: "/v1/mcp/info"};
+    option (google.api.method_signature) = "";
+    option (bytebase.v1.mcp_method_class) = READ;
+  }
+
   // Mints a new directory sync (SCIM) token, immediately invalidating the
   // previous one. The plaintext token is returned exactly once and cannot be
   // retrieved afterwards; only its hash is stored. Callers that lose it must
@@ -113,6 +132,144 @@ service WorkspaceService {
     option (bytebase.v1.mcp_method_class) = FORBIDDEN;
     option (bytebase.v1.mcp_denial_reason) = MINTS_CREDENTIAL_FOR_OTHERS;
   }
+}
+
+message GetMCPInfoRequest {}
+
+// MCPInfo is what MCP does in this workspace: the ceiling in force, what each
+// ceiling serves, and the per-engine facts a read-only session depends on.
+//
+// Everything here is resolved when the request is served, never from a stored
+// copy: the method list comes off the compiled API descriptors and the engine
+// answers off the code that enforces them, so a build whose rules changed
+// cannot describe the rules of the build before it.
+message MCPInfo {
+  // The workspace this describes. Format: workspaces/{workspace}. Not this
+  // message's own resource name — MCPInfo is not a named resource and there is
+  // nothing to get it by.
+  string workspace = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // The ceiling in force for this workspace. A workspace that never configured
+  // MCP resolves to READ_WRITE.
+  MCPSetting.Capability capability = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // What each ceiling serves, including the one in force, so an admin can
+  // compare the choices rather than only read the current answer.
+  repeated MCPCapabilityMode modes = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Every API method some ceiling serves. A mode serves a method when the
+  // method's class is one of that mode's served_classes, which is the ceiling
+  // rule the gate evaluates. Methods no ceiling serves are absent.
+  //
+  // Being listed is necessary, not sufficient. The caller still needs the
+  // permission, and two further rules narrow what a served method does: a
+  // handful of methods are refused on the shape of the request (an issue that
+  // would grant a permission, a rollout that skips approval), and under
+  // READ_ONLY every statement SQLService/Query runs must classify as a read.
+  repeated MCPMethod methods = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // What a read-only session and the masking toggle actually reach, per engine.
+  // Both are engine-conditional in ways the ceiling alone does not show.
+  repeated MCPEngineEnforcement engines = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Whether this workspace stops applying the caller's own unmasking
+  // provisioning to MCP requests. It decides which branch of each engine's
+  // masking state a caller is in, and no other API tells an MCP session:
+  // SettingService/GetSetting is served by no ceiling.
+  bool ignore_masking_exemptions = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+  // Whether data masking is licensed for this workspace. When false nothing is
+  // masked whatever an engine supports, so the masking states below describe a
+  // mechanism that does not run. Licensing can also be set per instance, so a
+  // true here is the workspace answer, not a promise about every instance.
+  bool data_masking_available = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+
+// MCPCapabilityMode is one ceiling and the method classes it serves.
+message MCPCapabilityMode {
+  MCPSetting.Capability capability = 1;
+
+  // Empty means the ceiling serves nothing, which is what DISABLED is.
+  repeated MCPMethodClass served_classes = 2;
+}
+
+// MCPMethod is one API method an MCP session can reach, and what decides it.
+message MCPMethod {
+  // The method as an audit entry names it, so a denial can be found by it.
+  // Example: /bytebase.v1.SQLService/Query
+  string method = 1;
+
+  // The same method as call_api takes it.
+  // Example: bytebase.v1.SQLService.Query
+  string operation_id = 4;
+
+  MCPMethodClass class = 2;
+
+  // The IAM permission the method declares. The ceiling never grants: a session
+  // may call a served method only where the person it acts for could.
+  //
+  // Empty means the method declares no permission, which is NOT the same as
+  // needing none — a method that authorizes inside its handler declares nothing
+  // here. auth_method says which case an empty value is.
+  string permission = 3;
+
+  // How the method authorizes. IAM means the permission above is the whole
+  // rule; CUSTOM means the handler decides and the permission field is silent.
+  AuthMethod auth_method = 5;
+}
+
+// MCPEngineEnforcement is what the read-only ceiling and the masking toggle
+// reach on one database engine.
+message MCPEngineEnforcement {
+  // How much of a read-only ceiling this engine can be held to.
+  enum ReadOnlyDepth {
+    READ_ONLY_DEPTH_UNSPECIFIED = 0;
+
+    // Bytebase has no read-only classifier for this engine, so a read-only
+    // session is refused every statement on it, including a plain SELECT.
+    UNSUPPORTED = 1;
+
+    // Every statement is classified before it runs and a request holding one
+    // that is not a read is refused whole. Nothing below that: the driver does
+    // not open a read-only database session, except where the note says
+    // otherwise.
+    STATEMENT = 2;
+
+    // Statement classification, and the driver opens the database session
+    // read-only as well, so the engine refuses most writes the classifier
+    // missed. Not a proof: a statement that classifies as a read can still call
+    // a function that switches the session setting back off.
+    STATEMENT_AND_SESSION = 3;
+  }
+
+  // How Bytebase masks results on this engine, which is what decides whether
+  // ignoring masking exemptions changes anything here.
+  enum Masking {
+    MASKING_UNSPECIFIED = 0;
+
+    // Bytebase does not mask on this engine. Nothing narrows what a session
+    // reads, and ignoring masking exemptions does nothing.
+    NONE = 1;
+
+    // Column masking. A masking policy substitutes values in query results,
+    // and the exemptions granted to the caller are what let them see the real
+    // value — which is what ignoring exemptions suppresses.
+    COLUMN = 2;
+
+    // Document masking. Results are masked, but exemptions are never consulted
+    // on this path, so ignoring them changes nothing here either.
+    DOCUMENT = 3;
+  }
+
+  Engine engine = 1;
+
+  ReadOnlyDepth read_only_depth = 2;
+
+  Masking masking = 3;
+
+  // Where the answers above are the floor rather than the whole story. Empty
+  // for most engines.
+  string note = 4;
 }
 
 message RotateDirectorySyncTokenRequest {


### PR DESCRIPTION
`WorkspaceService.GetMCPInfo` answers "what can be done here": the MCP capability ceiling in force, what each ceiling serves, and the two per-engine facts the ceiling alone does not show.

P1b 1b-5b, stacked on #21221 — **review that first**; this PR's diff is only the delta on top of it. Spec: `plans/2026-08-07-mcp-p1b-spec.md` §1b-5(b) and (d). Closes the option-2 and option-3 halves of BOT-89.

## Everything resolves when the request is served

The method list comes off the compiled descriptors — the same place the gate reads a method's class — and the mode rows read `mcpServingClasses`, the gate's own serving table, rather than a copy of it.

A stored list would pass its tests the day it was written and drift silently after. The first sign would be an admin choosing a mode from a page describing the build before this one.

`TestMCPInfoResolvesMethodsLive` runs the same resolver over two descriptor sets that differ only in one method's `mcp_method_class` annotation, and shows the answer move. It compiles a synthetic `bytebase.v1` file, so the resolver reads a real annotation off a real descriptor, not a stand-in.

## The two engine tables

Both were dropped when 1b-3 removed the per-query `read_only_enforcement` field, for the reason ecmadao gave: no consumer. This is the consumer.

**Read-only depth, three states.** An engine with no read-only classifier refuses a read-only session every statement, including `SELECT 1`. An engine with one gets statement classification. Two drivers always open the database session read-only as well, so the engine refuses most writes the classifier missed — not a proof, since a statement that classifies as a read can still call a function that switches the setting back off (BOT-88), and the enum says so.

The classifier half is *asked* — `parserbase.HasQueryValidator`, the registry the clamp itself consults — so it cannot drift. The driver half is *mirrored*, because a driver reports this by acting on a flag when a connection opens and none exists here. A driver that starts honoring the flag without a row here understates its own depth, which is the safe direction; no unit test can catch that, and the test comment says so rather than claiming otherwise.

Redshift is reported at its floor. Its driver does open the session read-only, but not on a datashare database, and datashare is per *database* while this answer is per *engine*. The engine's note says so, and `STATEMENT` is worded as a floor rather than as a claim about what a driver can do.

**Masking, three states — the BOT-95 shape.** Column masking, where the caller's exemptions are what `ignore_masking_exemptions` suppresses. Document masking, where results are masked but the masker's interface carries neither the user nor their exemptions, so the toggle changes nothing. And no masking at all.

Collapsing the middle state into either neighbour would overclaim: "masked" reads as "the toggle works here", "unmasked" reads as "nothing is masked". Both are wrong for Mongo, Elasticsearch and CosmosDB. The test pins that the two predicates are disjoint, which is the real invariant — an engine in both sets would make document-first the only correct order.

## BOT-89

**Option 2 is done.** `propose_database_change` and `query_database` each say the workspace ceiling decides what is served, and name this API.

**Option 1 is deliberately not done, and the reason is in the source** at `registerTools`. The ceiling is read per request; the MCP SDK builds the tool list once at session start. A filtered list is a promise made under whatever the ceiling was at connect time, and a session outliving an admin's change would advertise the wrong answer with no way to correct it. The denial is per request and cannot go stale. Revisit only if the SDK grows a way to revise a live session's tool list.

## What the response carries

`workspace`, the ceiling in force, `ignore_masking_exemptions`, `data_masking_available`, the per-mode served classes, the served methods, and the per-engine tables.

The masking toggle is in there because every `Masking` value is documented by what ignoring exemptions does under it — a caller told the mechanism per engine and never the state cannot use the table, and no other API tells an MCP session (`SettingService/GetSetting` is served by no ceiling). `data_masking_available` is there because masking is licensed: without the feature nothing masks whatever an engine supports, so reporting `COLUMN` alone overstates in the direction that matters. Licensing can also be per instance, and the field says so.

Each method carries both spellings of its name: `method` as an audit entry names it (`/bytebase.v1.SQLService/Query`), so a denial can be found by it, and `operation_id` as `call_api` takes it (`bytebase.v1.SQLService.Query`). One is the correlation key, the other is what an agent can actually invoke.

`permission` reports what the method *declares*. Empty is not "needs none" — 19 served methods authorize inside their handler and declare nothing — so `auth_method` rides along to say which case an empty value is.

## Failing closed

`auth.ClassifyMCPCeiling` decides every verdict here, not only the read failures. A stored ceiling this build cannot read, or one it parses but serves nothing under (the reserved `2`, or a value a newer release wrote), is refused rather than reported as "in force" beside a modes list containing no row for it.

`DISABLED` is the one refusing ceiling this still answers under, deliberately: an admin looking at a workspace with MCP off is exactly who needs to see what the other modes contain.

On an MCP session the answer comes from the settings the gate already stamped on the request, not a second read — the rule `mcp_gate.go` states and the clamp and the masking check both follow, so the response cannot report a ceiling the request was not admitted under.

## Shape decisions, flagged for veto

**Home: `WorkspaceService`.** It is already MCP-visible (`GetWorkspace` and `ListWorkspaces` are READ), workspace-scoped by construction, and its handler already holds the store. `SettingService` was rejected: all four of its RPCs are refused to MCP, so it appears in no MCP discovery index today, and adding one READ method would make `GetSetting` and `UpdateSetting` read as reachable when they are not.

**Empty request message.** No workspace field — the workspace comes from the authenticated session. That removes a cross-tenant read by construction, and keeps `TestLintDenialRequestsAreReviewedForRedaction` silent, which any field but `name` or `parent` would not. AIP would prefer a singleton `name`; the deviation is deliberate.

**Classified `READ`, no permission.** An agent asking what it may do here is the point. The 1b-6 member summary shows the current ceiling to members, and the method classification is already public in the descriptors and the OpenAPI, so gating this on `bb.settings.get` — held only by admin and DBA — would lock out both the member page and most MCP sessions. The widening against `SettingService/GetSetting` is real and deliberate. **Flagged for veto.**

**One source of truth per fact.** `modes[]` carries each ceiling's served classes; `methods[]` carries each served method's class, permission and auth method. A mode serves a method when the method's class is in that mode's `served_classes` — the ceiling rule the gate evaluates. Doing that join server-side would let the response describe a ceiling the gate does not enforce. The cost is that the 1b-6 drawer does a set-membership test over 97 rows.

Being listed is necessary, not sufficient, and the field says so: two further rules narrow what a served method does — a handful are refused on the shape of the request, and under `READ_ONLY` every statement `Query` runs must classify as a read.

**Refused methods are omitted.** The response answers what can be done; a `FORBIDDEN` entry in a list an agent reads would need separately explaining as not an offer.

## Tests

- `TestMCPInfoResolvesMethodsLive` — the live-resolution proof above.
- `TestMCPInfoServedMethodsMatchTheServingTable` — the real response against `mcpClassificationsFromDescriptors`, both directions.
- `TestMCPInfoModesMatchTheServingTable` — the modes are the gate's, not a second copy.
- `TestMCPInfoReadOnlyDepthMirrorsTheDrivers` / `TestMCPInfoMaskingMirrorsTheMaskers` — each table against the code that decides it, with the mirror-don't-ask rationale inline.
- `TestMCPInfoCoversEveryEngine` — no engine omitted, none reporting an unspecified answer.
- `TestGetMCPInfoHandler` — the RPC itself against a real store: live resolution at its only call site, the toggle reaching the response, `DISABLED` answered, unreadable and unserved failing closed, the gate's stamped resolution winning over a second read, and the empty-workspace guard.
- 1b-1 lint green; `testdata/mcp_method_classification.md` regenerated (READ 56 → 57, total 210 → 211).

Pre-review changed a lot here. It found that the handler had no test at all — every assertion ran against the helpers, so nothing pinned that the RPC passes the real registry, which is the property the whole design rests on. It found `ignore_masking_exemptions` read and dropped, the unserved verdict computed and thrown away, the raw store error handed to a caller whose tool layer renders it into a model's context, `method` emitted in a form `call_api` rejects, and `STATEMENT` documented as "this engine's driver cannot open one" while the Redshift note in the same response says it does. It also found three assertions that could not fail — `require.Equal(served, mode.ServedClasses)` compared a slice with itself, because the response aliased the gate's own serving table.

## Not here

No UI beyond the two tool-description sentences — 1b-6 owns `/settings/mcp`, the mode drawer and the consent page. No export columns (BOT-45). No gate, clamp, masking or setting changes.

## Gates

`buf format` / `buf lint` / `buf generate` · `gofmt` · `go vet` · `golangci-lint` clean · full backend build · `go test ./backend/...`. Frontend is untouched by hand; the generated `proto-es` TS moves with the new messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
