### PR TITLE
fix(test): align the Redis clamp denial reason with its classifier

### DIFF
--- a/backend/api/v1/mcp_sql_clamp_test.go
+++ b/backend/api/v1/mcp_sql_clamp_test.go
@@ -305,11 +305,16 @@ func TestMCPClampRefusesWhatItCannotShowIsARead(t *testing.T) {
 		{
 			// Redis SELECT switches the connection's logical database, so the
 			// GET after it reads a database the caller did not ask for.
+			//
+			// Refused as not-a-read rather than as a read returning no data:
+			// Redis does not flag SELECT readonly, so isReadCommand rejects it
+			// outright (#21196). Which of the two reasons fires is the
+			// classifier's business; that it is refused at all is this test's.
 			name:      "Redis SELECT switches the logical database",
 			engine:    storepb.Engine_REDIS,
 			statement: "SELECT 1\nGET secret",
 			refused:   true,
-			reason:    "returns no data",
+			reason:    "is not a read",
 		},
 		{
 			name:      "an unseparated batch is refused rather than read on its first statement",


### PR DESCRIPTION
`go-tests` is red on `main`. `TestMCPClampRefusesWhatItCannotShowIsARead/Redis_SELECT_switches_the_logical_database` expects the refusal to read `returns no data`, but it now reads `is not a read`.

## Why

#21196 stopped treating Redis `SELECT` as a read command — its own test says *"SELECT is not listed. Redis does not flag it readonly"*. So `ValidateSQLForEditor` now returns `(readOnly=false, allQuery=false)`, and `refuseNonReadOnlyStatement` takes its **not-a-read** arm instead of its **returns-no-data** arm. The clamp test was still asserting the old string.

Confirmed by calling the validator directly:

```
"SELECT 1"             readOnly=false allQuery=false
"SELECT 1\nGET secret" readOnly=false allQuery=false
"GET k"                readOnly=true  allQuery=true
```

## Why the assertion is what changes, not the classifier

The statement is still refused, and more firmly than before: *not a read* is a stronger classification than *reads but returns no data*. Nothing about what an MCP session may run has changed — only which of the two denial strings the clamp emits. The subtest's point is that a Redis `SELECT` ahead of a `GET` is refused, because it repoints the connection at a logical database the caller never named; which arm reports that is the classifier's business.

## Testing

- `go test ./backend/api/v1/ -count=1` — full package passes (314s).
- `go test ./backend/plugin/parser/redis/ -count=1` — passes.
- `golangci-lint run --allow-parallel-runners --disable staticcheck ./backend/api/v1/...` — 0 issues.

## Note for #21196

`backend/plugin/parser/redis/query.go:223-227` is now unreachable:

```go
if !isReadCommand(fields) {
    return false, false, nil
}
// SELECT switches the connection's logical database, so a later command
// runs somewhere the caller did not name.
if strings.EqualFold(fields[0], "select") {
    returnsData = false
}
```

`isReadCommand` already rejects `SELECT` at the guard above, so the branch can never run. Harmless behaviorally, but it reads as though `SELECT` were deliberately handled as a read that returns no data, which is no longer how it is classified. Left alone here to keep this fix to the red test — worth a follow-up in the parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)