### PR TITLE
test(api): inventory audit payloads, not the store row (BYT-10090)

### DIFF
--- a/backend/api/v1/audit_redact_inventory_test.go
+++ b/backend/api/v1/audit_redact_inventory_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	spb "google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
@@ -33,11 +34,15 @@ import (
 // since those reach the row without passing marshalAuditPayload — which is why
 // the registry is enforced at its call sites for this list to mean anything.
 //
-// The bytebase.store entries are not a layering slip: storepb.AuditLog IS the
-// audit row, protojson-marshaled into audit_log.payload by store.CreateAuditLog
-// and printed by logAuditToStdout. RequestMetadata and MCPDelegation are there
-// because createAuditLog assigns them directly, so nothing else would look at
-// them — and RequestMetadata.caller_supplied_user_agent is caller-controlled.
+// The roots are the payloads createAuditLog marshals onto the row — request,
+// response, status, service_data — and not the row itself. storepb.AuditLog's
+// own columns, its RequestMetadata and its MCPDelegation are assigned in Go
+// from headers and verified grant state and are reviewed there; the annotation
+// is no remedy for them, since bytebase.store does not import bytebase.v1 and
+// marshalAuditPayload never sees them, so a line here would record a decision
+// that had only one branch. TestLintAuditAnyFieldsAreRegistered does walk the
+// row, because its remedy — registering what an Any may pack — is the live
+// enforcement for the row's own service_data.
 
 // TestLintAuditPayloadInventory fails when a string or bytes field joins or
 // leaves the audited surface without anyone deciding what the audit row may
@@ -126,9 +131,9 @@ func auditRecordedScalarFields(t *testing.T) []string {
 		return true
 	})
 
-	// The audit row itself: service_data, status.details, request_metadata and
-	// mcp_delegation never pass an entry point.
-	walk((&storepb.AuditLog{}).ProtoReflect().Descriptor())
+	// The status a failed RPC leaves on the row. The v1 read API happens to
+	// reach it too; it is a root of its own so the list does not rest on that.
+	walk((&spb.Status{}).ProtoReflect().Descriptor())
 
 	// Every registered Any type. These reach the row packed, so no descriptor
 	// walk finds them: registering a type is what pulls its fields in here.
@@ -199,22 +204,8 @@ func inventoryFieldExists(entry string) bool {
 // is; DataSource.AzureCredential's tenant_id and client_id name the principal
 // rather than authenticate as it; google.protobuf.Any.type_url and value are
 // the envelope of a packed message whose own fields come in through
-// auditAnyRegistry. AuditLog.request and .response are the redacted payloads
-// themselves, kept because the rule is every scalar on the row with no
-// exceptions — a new column lands here and forces a decision.
+// auditAnyRegistry.
 var auditRecordedFields = []string{
-	"bytebase.store.AuditLog.method",
-	"bytebase.store.AuditLog.parent",
-	"bytebase.store.AuditLog.request",
-	"bytebase.store.AuditLog.resource",
-	"bytebase.store.AuditLog.response",
-	"bytebase.store.AuditLog.user",
-	"bytebase.store.MCPDelegation.client_id",
-	"bytebase.store.MCPDelegation.correlation_id",
-	"bytebase.store.MCPDelegation.resource",
-	"bytebase.store.MCPDelegation.scope",
-	"bytebase.store.RequestMetadata.caller_ip",
-	"bytebase.store.RequestMetadata.caller_supplied_user_agent",
 	"bytebase.v1.AIChatResponse.content",
 	"bytebase.v1.AIChatToolCall.arguments",
 	"bytebase.v1.AIChatToolCall.id",


### PR DESCRIPTION
## What

`TestLintAuditPayloadInventory` walked `storepb.AuditLog` as a root, which put 12 `bytebase.store.*` lines into `auditRecordedFields` — the row's own columns plus every field of `RequestMetadata` and `MCPDelegation`. This re-roots the walk on what `createAuditLog` actually marshals onto the row and drops those lines.

- Roots are now the v1 request/response surface, `google.rpc.Status`, and the registered Any types — not the store row.
- `google.rpc.Status` becomes an explicit root. It was previously reached only because the v1 read API (`v1.AuditLog.status`) happens to echo it; annotating that field OMIT would have silently dropped `Status.message` from the inventory even though the interceptor still writes it via `redactAuditStatus`.
- The 12 `bytebase.store.*` entries are removed; the header comment now states the boundary, and a stale sentence above the list ("every scalar on the row… a new column lands here") is gone.

## Why

The test's remedy for an undecided field is "annotate it with `bytebase.v1.audit_behavior` or list it." For store fields the first branch does not exist: `proto/store` does not import `bytebase.v1`, and `marshalAuditPayload` never runs on the row's own sub-messages anyway. So those 12 lines could only ever record a decision that had one branch. The row's own columns, `RequestMetadata`, and `MCPDelegation` are assigned in Go from headers and verified grant state, and are reviewed there.

## Reviewer notes

- `TestLintAuditAnyFieldsAreRegistered` deliberately still walks the store row. Its remedy — registering packed types in `auditAnyRegistry` — is keyed by field and *is* the live enforcement for `bytebase.store.AuditLog.service_data`, so that guard is real and unchanged.
- `TestAuditRowNeedsNoRedactionBeyondTheAnyPayloads` is unchanged and keeps the note that `caller_supplied_user_agent` is caller-controlled.
- Trade-off: a new string copied onto `MCPDelegation` from grant state no longer trips a test. That is a deliberate edit to `proto/store/store/audit_log.proto` plus `mcpDelegationFromAuthContext`, which is where review belongs.

## Testing

- Applied the re-rooting first and ran the lint alone: it reported exactly the 12 store entries as unreachable and nothing newly undecided, confirming nothing else was reached solely through the row. Then removed the lines.
- `go test ./backend/api/v1/ -run Audit` passes; the three lint tests pass individually.
- `gofmt`, `go vet`, and `golangci-lint --disable=staticcheck` clean; server build OK.
- Full `golangci-lint` panics locally in staticcheck v0.8.0-rc.1's `nilness` analyzer over the third-party `sentry` package — reproduced identically on a clean `main`, so it is a local toolchain issue, not this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
