### PR TITLE
fix(schemasync): use transaction advisory lock

### DIFF
--- a/backend/runner/schemasync/syncer.go
+++ b/backend/runner/schemasync/syncer.go
@@ -4,6 +4,7 @@ package schemasync
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -121,7 +122,24 @@ func (s *Syncer) trySyncAll(ctx context.Context) {
 		}
 	}()
 
-	lock, acquired, err := store.TryAdvisoryLock(ctx, s.store.GetDB(), store.AdvisoryLockKeySchemaSyncer)
+	tx, err := s.store.GetDB().BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("Failed to begin schema syncer transaction", log.BBError(err))
+		return
+	}
+	defer func() {
+		if err := tx.Rollback(); err != nil && !errors.Is(err, sql.ErrTxDone) {
+			result = productmetrics.ResultFailure
+			slog.Error("Failed to rollback schema syncer transaction", log.BBError(err))
+		}
+	}()
+
+	if _, err := tx.ExecContext(ctx, "SET LOCAL idle_in_transaction_session_timeout = 0"); err != nil {
+		slog.Error("Failed to configure schema syncer transaction", log.BBError(err))
+		return
+	}
+
+	acquired, err := store.TryAdvisoryXactLock(ctx, tx, store.AdvisoryLockKeySchemaSyncer)
 	if err != nil {
 		slog.Error("Failed to acquire schema syncer advisory lock", log.BBError(err))
 		return
@@ -131,12 +149,6 @@ func (s *Syncer) trySyncAll(ctx context.Context) {
 		result = productmetrics.ResultSkipped
 		return
 	}
-	defer func() {
-		if err := lock.Release(); err != nil {
-			result = productmetrics.ResultFailure
-			slog.Error("Failed to release schema syncer advisory lock", log.BBError(err))
-		}
-	}()
 
 	wp := pool.New().WithMaxGoroutines(MaximumOutstanding)
 	var syncFailed atomic.Bool

--- a/backend/runner/schemasync/syncer_test.go
+++ b/backend/runner/schemasync/syncer_test.go
@@ -27,11 +27,6 @@ func TestSyncCyclesRecordEmptySuccess(t *testing.T) {
 
 	syncer.trySyncAll(ctx)
 	require.NoError(t, syncer.syncQueuedDatabases(ctx))
-	lock, acquired, err := store.TryAdvisoryLock(ctx, stores.GetDB(), store.AdvisoryLockKeySchemaSyncer)
-	require.NoError(t, err)
-	require.True(t, acquired)
-	syncer.trySyncAll(ctx)
-	require.NoError(t, lock.Release())
 	panicSyncer := &Syncer{productMetrics: metrics}
 	panicSyncer.trySyncAll(ctx)
 	require.Error(t, panicSyncer.syncQueuedDatabases(ctx))
@@ -39,7 +34,45 @@ func TestSyncCyclesRecordEmptySuccess(t *testing.T) {
 	require.Equal(t, uint64(1), runnerRunCount(t, metrics, productmetrics.RunnerDatabaseSync, productmetrics.ResultSuccess))
 	require.Equal(t, uint64(1), runnerRunCount(t, metrics, productmetrics.RunnerInstanceSync, productmetrics.ResultFailure))
 	require.Equal(t, uint64(1), runnerRunCount(t, metrics, productmetrics.RunnerDatabaseSync, productmetrics.ResultFailure))
+}
+
+func TestTrySyncAllSkipsWhenAdvisoryLockHeld(t *testing.T) {
+	ctx := context.Background()
+	stores := setupSyncerStore(ctx, t)
+	metrics := productmetrics.New(nil, nil)
+	syncer := NewSyncer(stores, nil, nil, metrics)
+
+	lockTx, err := stores.GetDB().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, lockTx.Rollback())
+	}()
+	acquired, err := store.TryAdvisoryXactLock(ctx, lockTx, store.AdvisoryLockKeySchemaSyncer)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	syncer.trySyncAll(ctx)
 	require.Equal(t, uint64(1), runnerRunCount(t, metrics, productmetrics.RunnerInstanceSync, productmetrics.ResultSkipped))
+	require.Zero(t, runnerRunCount(t, metrics, productmetrics.RunnerInstanceSync, productmetrics.ResultSuccess))
+}
+
+func TestTrySyncAllReleasesAdvisoryLockAfterRollback(t *testing.T) {
+	ctx := context.Background()
+	stores := setupSyncerStore(ctx, t)
+	metrics := productmetrics.New(nil, nil)
+	syncer := NewSyncer(stores, nil, nil, metrics)
+
+	syncer.trySyncAll(ctx)
+	require.Equal(t, uint64(1), runnerRunCount(t, metrics, productmetrics.RunnerInstanceSync, productmetrics.ResultSuccess))
+
+	tx, err := stores.GetDB().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, tx.Rollback())
+	}()
+	acquired, err := store.TryAdvisoryXactLock(ctx, tx, store.AdvisoryLockKeySchemaSyncer)
+	require.NoError(t, err)
+	require.True(t, acquired)
 }
 
 func TestSyncInstancePanicRecordsFailure(t *testing.T) {


### PR DESCRIPTION
## Summary

- replace the schema syncer session-level advisory lock with a transaction-scoped lock compatible with PgBouncer transaction pooling
- disable idle-in-transaction timeout locally for the guard transaction and release the lock through rollback
- add coverage for contention, skipped cycles, and automatic lock release

## Testing

- `go test -count=1 ./backend/runner/schemasync`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `git diff --check`
- `golangci-lint run --allow-parallel-runners` (reports pre-existing repository-wide revive findings outside the changed files; no changed-path findings)