### PR TITLE
feat(metrics): restrict endpoint to loopback by default

### DIFF
--- a/backend/bin/server/cmd/profile.go
+++ b/backend/bin/server/cmd/profile.go
@@ -16,6 +16,7 @@ func getBaseProfile(dataDir string) *config.Profile {
 		DatastorePort:              flags.port + 2, // Using flags.port + 2 as our datastore port.
 		HA:                         flags.ha,
 		SaaS:                       flags.saas,
+		MetricsRemoteAccess:        flags.metricsRemoteAccess,
 		Debug:                      flags.debug,
 		IsDocker:                   isDocker(),
 		DataDir:                    dataDir,

--- a/backend/bin/server/cmd/recovery_test.go
+++ b/backend/bin/server/cmd/recovery_test.go
@@ -33,6 +33,7 @@ func TestResolveProfileUsesServerDataConfiguration(t *testing.T) {
 	flags.dataDir = "metadata"
 	flags.port = 9090
 	flags.ha = true
+	flags.metricsRemoteAccess = true
 	t.Setenv("PG_URL", "postgres://bytebase.example/metadata")
 
 	profile, err := resolveProfile()
@@ -43,6 +44,7 @@ func TestResolveProfileUsesServerDataConfiguration(t *testing.T) {
 	require.Equal(t, 9090, profile.Port)
 	require.Equal(t, 9092, profile.DatastorePort)
 	require.True(t, profile.HA)
+	require.True(t, profile.MetricsRemoteAccess)
 	require.Equal(t, "postgres://bytebase.example/metadata", profile.PgURL)
 }
 

--- a/backend/bin/server/cmd/root.go
+++ b/backend/bin/server/cmd/root.go
@@ -58,12 +58,13 @@ ________________________________________________________________________________
 var (
 	flags struct {
 		// Used for Bytebase command line config
-		port        int
-		externalURL string
-		dataDir     string
-		ha          bool
-		saas        bool
-		debug       bool
+		port                int
+		externalURL         string
+		dataDir             string
+		ha                  bool
+		saas                bool
+		metricsRemoteAccess bool
+		debug               bool
 		// output logs in json format
 		enableJSONLogging bool
 		// memoryProfileThreshold is the threshold of memory usage in bytes to trigger a memory profile.
@@ -106,6 +107,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flags.dataDir, "data", defaultDataDir, "not recommended for production. Directory where Bytebase stores data if PG_URL is not specified. If relative path is supplied, then the path is relative to the directory where Bytebase is under")
 	rootCmd.PersistentFlags().BoolVar(&flags.ha, "ha", false, "run in HA mode")
 	rootCmd.PersistentFlags().BoolVar(&flags.saas, "saas", false, "run in SaaS mode")
+	rootCmd.PersistentFlags().BoolVar(&flags.metricsRemoteAccess, "metrics-remote-access", false, "allow remote clients to access /metrics; enable only when protected by a gateway, firewall, or NetworkPolicy")
 	rootCmd.PersistentFlags().BoolVar(&flags.debug, "debug", false, "enable debug level log")
 	rootCmd.PersistentFlags().BoolVar(&flags.enableJSONLogging, "enable-json-logging", false, "enable output logs in bytebase in json format")
 	rootCmd.PersistentFlags().Uint64Var(&flags.memoryProfileThreshold, "memory-profile-threshold", 0, "the threshold of memory usage in bytes to trigger a memory profile")

--- a/backend/component/config/profile.go
+++ b/backend/component/config/profile.go
@@ -21,6 +21,8 @@ type Profile struct {
 	Port int
 	// When we are running in SaaS mode, some features are not allowed to edit by users.
 	SaaS bool
+	// MetricsRemoteAccess allows non-loopback clients to scrape /metrics.
+	MetricsRemoteAccess bool
 	// Stripe configuration for SaaS subscription purchase. Only used when SaaS is true.
 	StripeAPISecret     string
 	StripeWebhookSecret string

--- a/backend/server/echo_routes.go
+++ b/backend/server/echo_routes.go
@@ -95,10 +95,6 @@ func configureEchoRouters(
 }
 
 func registerMetricsRoute(e *echo.Echo, profile *config.Profile, productMetrics *productmetrics.ProductMetrics) {
-	if profile.SaaS {
-		return
-	}
-
 	// Prometheus metrics - use custom registry to avoid duplicate registration in tests
 	registry := prometheus.NewRegistry()
 	e.Use(echoprometheus.NewMiddlewareWithConfig(echoprometheus.MiddlewareConfig{
@@ -123,7 +119,7 @@ func registerMetricsRoute(e *echo.Echo, profile *config.Profile, productMetrics 
 	// for self-instrumentation; pass the Gatherers fold as the gather
 	// source. Both observability surfaces preserved.
 	registry.MustRegister(productMetrics)
-	e.GET("/metrics", echo.WrapHandler(newMetricsHandler(registry)))
+	e.GET("/metrics", echo.WrapHandler(metricsAccessHandler(profile.MetricsRemoteAccess, newMetricsHandler(registry))))
 }
 
 func recoverMiddleware(next echo.HandlerFunc) echo.HandlerFunc {

--- a/backend/server/echo_routes_test.go
+++ b/backend/server/echo_routes_test.go
@@ -72,42 +72,34 @@ func TestSecurityHeadersMiddleware_SaaSAllowsPostHogHosts(t *testing.T) {
 	}
 }
 
-func TestMetricsRouteDisabledInSaaS(t *testing.T) {
+func TestMetricsRouteSaaSParity(t *testing.T) {
 	tests := []struct {
-		name       string
-		saas       bool
-		wantStatus int
+		name string
+		saas bool
 	}{
 		{
-			name:       "self-host exposes metrics",
-			saas:       false,
-			wantStatus: http.StatusOK,
+			name: "self-host exposes metrics",
+			saas: false,
 		},
 		{
-			name:       "SaaS does not expose metrics",
-			saas:       true,
-			wantStatus: http.StatusNotFound,
+			name: "SaaS exposes metrics",
+			saas: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			e := echo.New()
-			if tt.saas {
-				registerMetricsRoute(e, &config.Profile{SaaS: true}, nil)
-			} else {
-				// Self-host: use a real store and license service so the
-				// product-level license gauges are registered and collected.
-				_, st, licenseService := newMetricsTestEcho(t)
-				registerMetricsRoute(e, &config.Profile{SaaS: false}, productmetrics.New(st, licenseService))
-			}
+			_, st, licenseService := newMetricsTestEcho(t)
+			registerMetricsRoute(e, &config.Profile{SaaS: tt.saas}, productmetrics.New(st, licenseService))
 
 			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			req.RemoteAddr = "127.0.0.1:12345"
 			rec := httptest.NewRecorder()
 			e.ServeHTTP(rec, req)
 
-			if rec.Code != tt.wantStatus {
-				t.Fatalf("GET /metrics status = %d, want %d", rec.Code, tt.wantStatus)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("GET /metrics status = %d, want %d", rec.Code, http.StatusOK)
 			}
 		})
 	}

--- a/backend/server/metrics.go
+++ b/backend/server/metrics.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"net"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -17,4 +18,22 @@ func newMetricsHandler(registry *prometheus.Registry) http.Handler {
 			promhttp.HandlerOpts{ErrorHandling: promhttp.HTTPErrorOnError},
 		),
 	)
+}
+
+func metricsAccessHandler(remoteAccess bool, next http.Handler) http.Handler {
+	if remoteAccess {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		if addr := net.ParseIP(host); addr == nil || !addr.IsLoopback() {
+			http.NotFound(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }

--- a/backend/server/metrics_test.go
+++ b/backend/server/metrics_test.go
@@ -66,6 +66,7 @@ func newMetricsTestEchoWithCollector(t *testing.T) (*echo.Echo, *store.Store, *e
 func scrapeMetrics(t *testing.T, e *echo.Echo, wantStatus int) string {
 	t.Helper()
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
 	rec := httptest.NewRecorder()
 	e.ServeHTTP(rec, req)
 	require.Equal(t, wantStatus, rec.Code, rec.Body.String())
@@ -197,6 +198,7 @@ func TestMetricsEventsAreServerLocal(t *testing.T) {
 		wg.Go(func() {
 			metrics1.RecordRunnerRun(productmetrics.RunnerPlanCheck, productmetrics.ResultSuccess, time.Millisecond)
 			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			req.RemoteAddr = "127.0.0.1:12345"
 			rec := httptest.NewRecorder()
 			e1.ServeHTTP(rec, req)
 			if rec.Code != http.StatusOK {
@@ -212,6 +214,7 @@ func TestMetricsEventsAreServerLocal(t *testing.T) {
 
 	format := expfmt.NewFormat(expfmt.TypeProtoDelim)
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("Accept", string(format))
 	rec := httptest.NewRecorder()
 	e1.ServeHTTP(rec, req)
@@ -231,6 +234,90 @@ func TestMetricsEventsAreServerLocal(t *testing.T) {
 		}
 	}
 	require.True(t, foundNative)
+}
+
+func TestMetricsAccessHandler(t *testing.T) {
+	tests := []struct {
+		name         string
+		remoteAccess bool
+		remoteAddr   string
+		forwardedFor string
+		forwarded    string
+		wantStatus   int
+		wantCalls    int
+	}{
+		{
+			name:       "IPv4 loopback",
+			remoteAddr: "127.0.0.1:12345",
+			wantStatus: http.StatusNoContent,
+			wantCalls:  1,
+		},
+		{
+			name:       "IPv6 loopback",
+			remoteAddr: "[::1]:12345",
+			wantStatus: http.StatusNoContent,
+			wantCalls:  1,
+		},
+		{
+			name:       "IPv4-mapped IPv6 loopback",
+			remoteAddr: "[::ffff:127.0.0.1]:12345",
+			wantStatus: http.StatusNoContent,
+			wantCalls:  1,
+		},
+		{
+			name:       "remote IPv4",
+			remoteAddr: "192.0.2.1:12345",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "remote IPv6",
+			remoteAddr: "[2001:db8::1]:12345",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "empty remote address",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "malformed remote address",
+			remoteAddr: "not-an-address",
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:         "spoofed forwarding headers",
+			remoteAddr:   "192.0.2.1:12345",
+			forwardedFor: "127.0.0.1",
+			forwarded:    "for=127.0.0.1",
+			wantStatus:   http.StatusNotFound,
+		},
+		{
+			name:         "remote access bypasses peer parsing",
+			remoteAccess: true,
+			remoteAddr:   "not-an-address",
+			wantStatus:   http.StatusNoContent,
+			wantCalls:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := 0
+			handler := metricsAccessHandler(tt.remoteAccess, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				calls++
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+			req.RemoteAddr = tt.remoteAddr
+			req.Header.Set("X-Forwarded-For", tt.forwardedFor)
+			req.Header.Set("Forwarded", tt.forwarded)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+
+			require.Equal(t, tt.wantStatus, rec.Code)
+			require.Equal(t, tt.wantCalls, calls, "collection handler calls")
+		})
+	}
 }
 
 func metricTextLine(body, name string) string {

--- a/backend/server/server.go
+++ b/backend/server/server.go
@@ -218,10 +218,7 @@ func NewServer(ctx context.Context, profile *config.Profile) (*Server, error) {
 	// Configure echo server.
 	s.echoServer = echo.New()
 
-	var productMetrics *productmetrics.ProductMetrics
-	if !profile.SaaS {
-		productMetrics = productmetrics.New(stores, s.licenseService)
-	}
+	productMetrics := productmetrics.New(stores, s.licenseService)
 	s.schemaSyncer = schemasync.NewSyncer(stores, s.dbFactory, s.licenseService, productMetrics)
 	if profile.SaaS {
 		s.sampleProjectManager = configureSampleProjectManager(


### PR DESCRIPTION
## Summary

- restrict `/metrics` to actual IPv4 or IPv6 loopback peers by default
- add `--metrics-remote-access` as an explicit deployment-network escape hatch
- expose the same metrics behavior in SaaS and self-hosted deployments
- reject unauthorized scrapes before Prometheus collection and metadata queries

## Breaking Changes

Remote scrapers that connect directly to the Bytebase application listener now receive `404 Not Found` by default. Run an authenticated reverse proxy on the same host or Pod so it connects to Bytebase over loopback. As a temporary compatibility measure, `--metrics-remote-access` restores remote access but delegates all authorization to the deployment network.

## Testing

- `go test -v -count=1 ./backend/server -run "^(TestMetrics|TestCollisionMetrics)"`
- `go test -v -count=1 ./backend/bin/server/cmd -run "^TestResolveProfileUsesServerDataConfiguration$"`
- `golangci-lint run --allow-parallel-runners --new-from-rev=origin/main`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

Repository-wide lint also runs but currently reports pre-existing `revive` violations outside this diff.

Linear: [BYT-10114](https://linear.app/bytebase/issue/BYT-10114/implementation-auth-for-metrics-endpoint)