### PR TITLE
fix(action): support project instance targets

### DIFF
--- a/action/README.md
+++ b/action/README.md
@@ -58,7 +58,8 @@ These flags apply to the main `bytebase-action` command and its subcommands (`ch
     -   Used when `--plan` is not specified for the `rollout` command.
     -   Can specify a database group or individual databases.
     -   Formats:
-        -   Database: `instances/{instance}/databases/{database}`
+        -   Workspace-instance database: `instances/{instance}/databases/{database}`
+        -   Project-instance database: `projects/{project}/instances/{instance}/databases/{database}`
         -   Database Group: `projects/{project}/databaseGroups/{databaseGroup}`
     -   Default: `instances/test-sample-instance/databases/hr_test,instances/prod-sample-instance/databases/hr_prod`
 

--- a/action/command/root.go
+++ b/action/command/root.go
@@ -34,7 +34,7 @@ func NewRootCommand(w *world.World) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&w.AccessToken, "access-token", "", "Bytebase access token (alternative to service account auth, e.g. from workload identity exchange)")
 	cmd.PersistentFlags().Var(newCustomHeaderFlag(&w.CustomHeaders, &w.CustomHeaderError), "custom-header", "Custom HTTP header for Bytebase API requests, in 'Name: value' format. Can be specified multiple times")
 	cmd.PersistentFlags().StringVar(&w.Project, "project", "projects/hr", "Bytebase project")
-	cmd.PersistentFlags().StringSliceVar(&w.Targets, "targets", []string{"instances/test-sample-instance/databases/hr_test", "instances/prod-sample-instance/databases/hr_prod"}, "Bytebase targets. Either one or more databases or a single databaseGroup")
+	cmd.PersistentFlags().StringSliceVar(&w.Targets, "targets", []string{"instances/test-sample-instance/databases/hr_test", "instances/prod-sample-instance/databases/hr_prod"}, "Bytebase targets: one or more workspace or project-instance databases, or a single project database group")
 	cmd.PersistentFlags().StringVar(&w.FilePattern, "file-pattern", "", "File pattern to glob migration files")
 	cmd.PersistentFlags().BoolVar(&w.Declarative, "declarative", false, "Whether to use declarative mode. (experimental)")
 

--- a/action/command/root_test.go
+++ b/action/command/root_test.go
@@ -1,6 +1,7 @@
 package command
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"log/slog"
@@ -118,6 +119,20 @@ func TestCheckVersionCompatibility(t *testing.T) {
 			require.Contains(t, err.Error(), tt.wantError)
 		})
 	}
+}
+
+func TestRootTargetsHelp(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	cmd := NewRootCommand(&world.World{})
+	cmd.SetArgs([]string{"--help"})
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	require.NoError(t, cmd.Execute())
+	require.Contains(t, output.String(), "workspace or project-instance databases")
+	require.Contains(t, output.String(), "single project database group")
 }
 
 func TestRecommendedActionTag(t *testing.T) {

--- a/action/command/validation/flags.go
+++ b/action/command/validation/flags.go
@@ -71,14 +71,14 @@ func validateTargets(targets []string) error {
 		} else if _, _, err := common.GetProjectIDDatabaseGroupID(target); err == nil {
 			databaseGroupTarget++
 		} else {
-			return errors.Errorf("invalid target format, must be instances/{instance}/databases/{database} or projects/{project}/databaseGroups/{databaseGroup}")
+			return errors.Errorf("invalid target format %q; must be instances/{instance}/databases/{database}, projects/{project}/instances/{instance}/databases/{database}, or projects/{project}/databaseGroups/{databaseGroup}", target)
 		}
 	}
 	if databaseTarget > 0 && databaseGroupTarget > 0 {
-		return errors.Errorf("targets must be either databases or databaseGroups")
+		return errors.Errorf("targets must be either database targets or a database group target")
 	}
 	if databaseGroupTarget > 1 {
-		return errors.Errorf("targets must be a single databaseGroup")
+		return errors.Errorf("targets must contain a single database group target")
 	}
 	return nil
 }

--- a/action/command/validation/flags_test.go
+++ b/action/command/validation/flags_test.go
@@ -1,0 +1,67 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTargets(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		targets []string
+		wantErr string
+	}{
+		{
+			name: "workspace database targets",
+			targets: []string{
+				"instances/test/databases/hr_test",
+				"instances/prod/databases/hr_prod",
+			},
+		},
+		{
+			name: "project instance database targets",
+			targets: []string{
+				"projects/hr/instances/test/databases/hr_test",
+				"projects/hr/instances/prod/databases/hr_prod",
+			},
+		},
+		{
+			name: "mixed workspace and project instance database targets",
+			targets: []string{
+				"instances/test/databases/hr_test",
+				"projects/hr/instances/prod/databases/hr_prod",
+			},
+		},
+		{
+			name:    "database target and database group",
+			targets: []string{"projects/hr/instances/test/databases/hr_test", "projects/hr/databaseGroups/all"},
+			wantErr: "either database targets or a database group target",
+		},
+		{
+			name:    "multiple database groups",
+			targets: []string{"projects/hr/databaseGroups/one", "projects/hr/databaseGroups/two"},
+			wantErr: "single database group target",
+		},
+		{
+			name:    "malformed project instance target",
+			targets: []string{"projects/hr/instances//databases/hr_test"},
+			wantErr: "invalid target format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateTargets(tt.targets)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorContains(t, err, tt.wantErr)
+		})
+	}
+}

--- a/action/common/resource_name.go
+++ b/action/common/resource_name.go
@@ -26,12 +26,16 @@ func GetProjectIDDatabaseGroupID(name string) (string, string, error) {
 
 // GetInstanceDatabaseID returns the instance ID and database ID from a resource name.
 func GetInstanceDatabaseID(name string) (string, string, error) {
-	// the instance request should be instances/{instance-id}/databases/{database-id}
-	tokens, err := GetNameParentTokens(name, InstanceNamePrefix, DatabaseIDPrefix)
+	// Database targets can refer to either a workspace instance or a project instance.
+	if tokens, err := GetNameParentTokens(name, InstanceNamePrefix, DatabaseIDPrefix); err == nil {
+		return tokens[0], tokens[1], nil
+	}
+
+	tokens, err := GetNameParentTokens(name, ProjectNamePrefix, InstanceNamePrefix, DatabaseIDPrefix)
 	if err != nil {
 		return "", "", err
 	}
-	return tokens[0], tokens[1], nil
+	return tokens[1], tokens[2], nil
 }
 
 // GetNameParentTokens returns the tokens from a resource name.
@@ -45,6 +49,9 @@ func GetNameParentTokens(name string, tokenPrefixes ...string) ([]string, error)
 	for i, tokenPrefix := range tokenPrefixes {
 		if fmt.Sprintf("%s/", parts[2*i]) != tokenPrefix {
 			return nil, errors.Errorf("invalid prefix %q in request %q", tokenPrefix, name)
+		}
+		if parts[2*i+1] == "" {
+			return nil, errors.Errorf("empty token for prefix %q in request %q", tokenPrefix, name)
 		}
 		tokens = append(tokens, parts[2*i+1])
 	}

--- a/action/common/resource_name_test.go
+++ b/action/common/resource_name_test.go
@@ -1,0 +1,71 @@
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/action/common"
+)
+
+func TestGetInstanceDatabaseID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		target     string
+		instanceID string
+		databaseID string
+		wantErr    bool
+	}{
+		{
+			name:       "workspace instance",
+			target:     "instances/test/databases/hr",
+			instanceID: "test",
+			databaseID: "hr",
+		},
+		{
+			name:       "project instance",
+			target:     "projects/hr/instances/test/databases/hr",
+			instanceID: "test",
+			databaseID: "hr",
+		},
+		{
+			name:    "missing project instance ID",
+			target:  "projects/hr/instances//databases/hr",
+			wantErr: true,
+		},
+		{
+			name:    "missing database ID",
+			target:  "instances/test/databases/",
+			wantErr: true,
+		},
+		{
+			name:    "project database group",
+			target:  "projects/hr/databaseGroups/all",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			instanceID, databaseID, err := common.GetInstanceDatabaseID(tt.target)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.instanceID, instanceID)
+			require.Equal(t, tt.databaseID, databaseID)
+		})
+	}
+}
+
+func TestGetNameParentTokensRejectsEmptyTokens(t *testing.T) {
+	t.Parallel()
+
+	_, err := common.GetNameParentTokens("projects//databaseGroups/all", common.ProjectNamePrefix, common.DatabaseGroupNamePrefix)
+	require.Error(t, err)
+}

--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -9737,6 +9737,7 @@ components:
              Format:
              projects/{project}/databaseGroups/{databaseGroup}
              instances/{instance}/databases/{database}
+             projects/{project}/instances/{instance}/databases/{database}
         customRules:
           type: string
           title: custom_rules
@@ -9787,7 +9788,8 @@ components:
           title: target
           description: |-
             The target that the check is performed on.
-             Should be a database. Format: instances/{instance}/databases/{database}
+             Should be a database.
+             Format: instances/{instance}/databases/{database} or projects/{project}/instances/{instance}/databases/{database}
         advices:
           type: array
           items:

--- a/backend/generated-go/v1/release_service.pb.go
+++ b/backend/generated-go/v1/release_service.pb.go
@@ -506,6 +506,7 @@ type CheckReleaseRequest struct {
 	// Format:
 	// projects/{project}/databaseGroups/{databaseGroup}
 	// instances/{instance}/databases/{database}
+	// projects/{project}/instances/{instance}/databases/{database}
 	Targets []string `protobuf:"bytes,3,rep,name=targets,proto3" json:"targets,omitempty"`
 	// Custom linting rules in natural language for AI-powered validation.
 	// Each rule should be a clear statement describing the desired schema constraint.
@@ -919,7 +920,8 @@ type CheckReleaseResponse_CheckResult struct {
 	// The file path that is being checked.
 	File string `protobuf:"bytes,1,opt,name=file,proto3" json:"file,omitempty"`
 	// The target that the check is performed on.
-	// Should be a database. Format: instances/{instance}/databases/{database}
+	// Should be a database.
+	// Format: instances/{instance}/databases/{database} or projects/{project}/instances/{instance}/databases/{database}
 	Target string `protobuf:"bytes,2,opt,name=target,proto3" json:"target,omitempty"`
 	// The list of advice for the file and the target.
 	Advices []*Advice `protobuf:"bytes,3,rep,name=advices,proto3" json:"advices,omitempty"`

--- a/frontend/src/routes/project/ProjectGitOpsPage.tsx
+++ b/frontend/src/routes/project/ProjectGitOpsPage.tsx
@@ -148,7 +148,8 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
   }, [targetTab, selectedDatabaseGroupName, selectedDatabaseNames]);
 
   const targetsPlaceholder =
-    targetsString || "instances/{instance}/databases/{database}";
+    targetsString ||
+    `projects/${projectId}/instances/{instance}/databases/{database}`;
   const runsOn = useSelfhostRunner ? "self-hosted" : "ubuntu-latest";
 
   const handleTargetTabChange = (tab: "GROUP" | "DATABASE") => {

--- a/frontend/src/types/proto-es/v1/release_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/release_service_pb.d.ts
@@ -247,6 +247,7 @@ export declare type CheckReleaseRequest = Message<"bytebase.v1.CheckReleaseReque
    * Format:
    * projects/{project}/databaseGroups/{databaseGroup}
    * instances/{instance}/databases/{database}
+   * projects/{project}/instances/{instance}/databases/{database}
    *
    * @generated from field: repeated string targets = 3;
    */
@@ -355,7 +356,8 @@ export declare type CheckReleaseResponse_CheckResult = Message<"bytebase.v1.Chec
 
   /**
    * The target that the check is performed on.
-   * Should be a database. Format: instances/{instance}/databases/{database}
+   * Should be a database.
+   * Format: instances/{instance}/databases/{database} or projects/{project}/instances/{instance}/databases/{database}
    *
    * @generated from field: string target = 2;
    */

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -13642,6 +13642,7 @@ paths:
                      Format:
                      projects/{project}/databaseGroups/{databaseGroup}
                      instances/{instance}/databases/{database}
+                     projects/{project}/instances/{instance}/databases/{database}
                 customRules:
                   type: string
                   title: custom_rules
@@ -20438,6 +20439,7 @@ components:
              Format:
              projects/{project}/databaseGroups/{databaseGroup}
              instances/{instance}/databases/{database}
+             projects/{project}/instances/{instance}/databases/{database}
         customRules:
           type: string
           title: custom_rules
@@ -20491,7 +20493,8 @@ components:
           title: target
           description: |-
             The target that the check is performed on.
-             Should be a database. Format: instances/{instance}/databases/{database}
+             Should be a database.
+             Format: instances/{instance}/databases/{database} or projects/{project}/instances/{instance}/databases/{database}
         advices:
           type: array
           items:

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -10176,7 +10176,7 @@ ProjectService manages projects that group databases and changes.
 | ----- | ---- | ----- | ----------- |
 | parent | [string](#string) |  | Format: projects/{project} |
 | release | [Release](#bytebase-v1-Release) |  | The release to check. |
-| targets | [string](#string) | repeated | The targets to dry-run the release. Can be database or databaseGroup. Format: projects/{project}/databaseGroups/{databaseGroup} instances/{instance}/databases/{database} |
+| targets | [string](#string) | repeated | The targets to dry-run the release. Can be database or databaseGroup. Format: projects/{project}/databaseGroups/{databaseGroup} instances/{instance}/databases/{database} projects/{project}/instances/{instance}/databases/{database} |
 | custom_rules | [string](#string) |  | Custom linting rules in natural language for AI-powered validation. Each rule should be a clear statement describing the desired schema constraint. Example: &#34;All tables must have a primary key&#34; Example: &#34;VARCHAR columns should specify a maximum length&#34; |
 | vcs_user | [VCSUser](#bytebase-v1-VCSUser) |  | The non-bot VCS pull request or merge request creator observed by bytebase-release. If absent, Bytebase skips VCS user tracking and VCS user limit enforcement. |
 
@@ -10211,7 +10211,7 @@ Check result for a single release file on a target database.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | file | [string](#string) |  | The file path that is being checked. |
-| target | [string](#string) |  | The target that the check is performed on. Should be a database. Format: instances/{instance}/databases/{database} |
+| target | [string](#string) |  | The target that the check is performed on. Should be a database. Format: instances/{instance}/databases/{database} or projects/{project}/instances/{instance}/databases/{database} |
 | advices | [Advice](#bytebase-v1-Advice) | repeated | The list of advice for the file and the target. |
 | affected_rows | [int64](#int64) |  | The count of affected rows of the statement on the target. |
 | risk_level | [RiskLevel](#bytebase-v1-RiskLevel) |  | The risk level of the statement on the target. |

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -29048,7 +29048,8 @@ Permissions required: bb.projects.update</p></td>
 Can be database or databaseGroup.
 Format:
 projects/{project}/databaseGroups/{databaseGroup}
-instances/{instance}/databases/{database} </p></td>
+instances/{instance}/databases/{database}
+projects/{project}/instances/{instance}/databases/{database} </p></td>
                 </tr>
               
                 <tr>
@@ -29136,7 +29137,8 @@ If absent, Bytebase skips VCS user tracking and VCS user limit enforcement. </p>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>The target that the check is performed on.
-Should be a database. Format: instances/{instance}/databases/{database} </p></td>
+Should be a database.
+Format: instances/{instance}/databases/{database} or projects/{project}/instances/{instance}/databases/{database} </p></td>
                 </tr>
               
                 <tr>

--- a/proto/v1/v1/release_service.proto
+++ b/proto/v1/v1/release_service.proto
@@ -223,6 +223,7 @@ message CheckReleaseRequest {
   // Format:
   // projects/{project}/databaseGroups/{databaseGroup}
   // instances/{instance}/databases/{database}
+  // projects/{project}/instances/{instance}/databases/{database}
   repeated string targets = 3;
 
   // Custom linting rules in natural language for AI-powered validation.
@@ -250,7 +251,8 @@ message CheckReleaseResponse {
     string file = 1;
 
     // The target that the check is performed on.
-    // Should be a database. Format: instances/{instance}/databases/{database}
+    // Should be a database.
+    // Format: instances/{instance}/databases/{database} or projects/{project}/instances/{instance}/databases/{database}
     string target = 2;
 
     // The list of advice for the file and the target.


### PR DESCRIPTION
## Summary

- accept canonical `projects/{project}/instances/{instance}/databases/{database}` targets in `bytebase-action`
- preserve workspace-instance and database-group target behavior, with regression coverage for malformed and mixed targets
- align GitOps workflow guidance, API comments, and generated protobuf/OpenAPI artifacts

Addresses [discussion #21240](https://github.com/bytebase/bytebase/discussions/21240).

## Testing

- `go test ./action/...`
- `golangci-lint run --allow-parallel-runners --new-from-rev=HEAD`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `buf lint proto`
- `buf generate`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test`