### PR TITLE
fix(frontend): keep session polling from redirecting to 403

### DIFF
--- a/frontend/src/app/AuthGate.test.tsx
+++ b/frontend/src/app/AuthGate.test.tsx
@@ -286,6 +286,7 @@ describe("AuthGate", () => {
     });
 
     expect(mocks.fetchCurrentUser).toHaveBeenCalledTimes(1);
+    expect(mocks.fetchCurrentUser).toHaveBeenCalledWith(true);
     expect(mocks.fetchWorkspaceIamPolicy).toHaveBeenCalledTimes(1);
     expect(mocks.fetchWorkspaceIamPolicy).toHaveBeenCalledWith(true);
     expect(mocks.listRoles).toHaveBeenCalledTimes(1);

--- a/frontend/src/app/AuthGate.tsx
+++ b/frontend/src/app/AuthGate.tsx
@@ -102,7 +102,7 @@ export function AuthGate({ children }: { children: ReactNode }) {
       if (!store.isLoggedIn() || store.unauthenticatedOccurred) return;
       if (isAuthRoute || isPublicRoute) return;
       void (async () => {
-        const user = await store.fetchCurrentUser();
+        const user = await store.fetchCurrentUser(true);
         if (!user || !store.isLoggedIn() || store.unauthenticatedOccurred) {
           return;
         }

--- a/frontend/src/stores/app/auth.ts
+++ b/frontend/src/stores/app/auth.ts
@@ -2,7 +2,7 @@ import { create } from "@bufbuild/protobuf";
 import { Code, createContextValues } from "@connectrpc/connect";
 import { uniqueId } from "lodash-es";
 import { authServiceClientConnect, userServiceClientConnect } from "@/api";
-import { ignoredCodesContextKey } from "@/api/context-key";
+import { ignoredCodesContextKey, silentContextKey } from "@/api/context-key";
 import {
   AUTH_MFA_MODULE,
   AUTH_PASSWORD_RESET_MODULE,
@@ -144,9 +144,12 @@ export const createAuthSlice: AppSliceCreator<AuthSlice> = (set, get) => ({
 
   // Force re-fetch (mirrors the Pinia `fetchCurrentUser`, which always hits
   // the server — login/signup need the fresh authenticated user).
-  fetchCurrentUser: async () => {
+  fetchCurrentUser: async (silent = false) => {
     try {
-      const fresh = await userServiceClientConnect.getCurrentUser({});
+      const fresh = await userServiceClientConnect.getCurrentUser(
+        {},
+        { contextValues: createContextValues().set(silentContextKey, silent) }
+      );
       const user = keepMfaEnrollment(fresh, get().currentUser);
       set({ currentUser: user, currentUserName: user.name });
       return user;

--- a/frontend/src/stores/app/index.test.ts
+++ b/frontend/src/stores/app/index.test.ts
@@ -507,6 +507,17 @@ describe("useAppStore", () => {
     expect(store.getState().isLoggedIn()).toBe(true);
   });
 
+  test("fetches the current user silently when requested", async () => {
+    mocks.getCurrentUser.mockResolvedValue(user);
+    const store = createAppStore();
+
+    await store.getState().fetchCurrentUser(true);
+
+    expect(
+      mocks.getCurrentUser.mock.calls[0][1]?.contextValues.get(silentContextKey)
+    ).toBe(true);
+  });
+
   // The MFA enrollment secrets ride out only on the UpdateUser response that
   // mints them; the read the session revalidation makes no longer carries them.
   // That revalidation fires every five minutes, which is the whole enrollment

--- a/frontend/src/stores/app/types.ts
+++ b/frontend/src/stores/app/types.ts
@@ -199,7 +199,7 @@ export type AuthSlice = {
   requireResetPassword: () => boolean;
   setRequireResetPassword: (value: boolean) => void;
   setUnauthenticatedOccurred: (value: boolean) => void;
-  fetchCurrentUser: () => Promise<User | undefined>;
+  fetchCurrentUser: (silent?: boolean) => Promise<User | undefined>;
   login: (params: {
     request: LoginRequest;
     redirect?: boolean;


### PR DESCRIPTION
## What changed

- Mark the periodic `GetCurrentUser` request from `AuthGate` as silent.
- Forward the silent context through `fetchCurrentUser`.
- Keep login and signup requests non-silent by default.
- Add regression tests for the store and polling path.

## Why

`AuthGate` periodically revalidates the current session. A background
`PermissionDenied` response could reach the global authentication interceptor
and redirect an active SQL Editor to `/403`.

Silent polling still refreshes expired tokens and triggers the in-place
session-expired sign-in flow when refresh fails, but it no longer navigates away
from the current page or emits background error notifications.

Follow-up for [BYT-9972](https://linear.app/bytebase/issue/BYT-9972/sql-editor-redirects-to-recursive-403-after-session-or-network-change).