### PR TITLE
feat(store): record when session and grant rows are issued

### DIFF
--- a/backend/migrator/migration/3.22/0014##token_row_created_at.sql
+++ b/backend/migrator/migration/3.22/0014##token_row_created_at.sql
@@ -1,0 +1,25 @@
+-- Record when each session and grant row was issued.
+--
+-- The three token tables carry an expiry but no issue time, so nothing can
+-- order a row against anything that happened to the account after it was
+-- handed out. Existing rows default to migration time, which is the earliest
+-- issue time consistent with their still being here.
+ALTER TABLE web_refresh_token ADD COLUMN created_at timestamptz NOT NULL DEFAULT now();
+ALTER TABLE oauth2_authorization_code ADD COLUMN created_at timestamptz NOT NULL DEFAULT now();
+ALTER TABLE oauth2_refresh_token ADD COLUMN created_at timestamptz NOT NULL DEFAULT now();
+
+-- Index the two foreign keys these tables carry. PostgreSQL indexes the
+-- referenced side of a foreign key, never the referencing side, so both
+-- cascades below are sequential scans over the whole table until they are.
+--
+-- user_email references principal(email) ON UPDATE CASCADE: every account
+-- email change rewrites the rows keyed on it. web_refresh_token already has
+-- this index; these two are catching up.
+CREATE INDEX idx_oauth2_authorization_code_user_email ON oauth2_authorization_code(user_email);
+CREATE INDEX idx_oauth2_refresh_token_user_email ON oauth2_refresh_token(user_email);
+
+-- client_id references oauth2_client(client_id) ON DELETE CASCADE, and the
+-- data cleaner deletes stale clients in bulk on a schedule. It answers no
+-- query on its own — every lookup pairs it with the primary key.
+CREATE INDEX idx_oauth2_authorization_code_client_id ON oauth2_authorization_code(client_id);
+CREATE INDEX idx_oauth2_refresh_token_client_id ON oauth2_refresh_token(client_id);

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -689,7 +689,9 @@ CREATE TABLE oauth2_authorization_code (
     -- access token's workspace_id claim.
     workspace text REFERENCES workspace(resource_id),
     config jsonb NOT NULL,
-    expires_at timestamptz NOT NULL
+    expires_at timestamptz NOT NULL,
+    -- When the row was issued.
+    created_at timestamptz NOT NULL DEFAULT now()
 );
 
 CREATE TABLE oauth2_refresh_token (
@@ -703,11 +705,21 @@ CREATE TABLE oauth2_refresh_token (
     -- consented resource and scope, inherited from the authorization code and
     -- carried forward unchanged by every refresh.
     config jsonb NOT NULL DEFAULT '{}',
-    expires_at timestamptz NOT NULL
+    expires_at timestamptz NOT NULL,
+    -- When the row was issued.
+    created_at timestamptz NOT NULL DEFAULT now()
 );
 
 CREATE INDEX idx_oauth2_authorization_code_expires_at ON oauth2_authorization_code(expires_at);
 CREATE INDEX idx_oauth2_refresh_token_expires_at ON oauth2_refresh_token(expires_at);
+-- Referencing columns of the two foreign keys these tables carry: PostgreSQL
+-- indexes only the referenced side, so without these the ON UPDATE CASCADE
+-- from principal(email) and the ON DELETE CASCADE from oauth2_client are
+-- sequential scans.
+CREATE INDEX idx_oauth2_authorization_code_user_email ON oauth2_authorization_code(user_email);
+CREATE INDEX idx_oauth2_refresh_token_user_email ON oauth2_refresh_token(user_email);
+CREATE INDEX idx_oauth2_authorization_code_client_id ON oauth2_authorization_code(client_id);
+CREATE INDEX idx_oauth2_refresh_token_client_id ON oauth2_refresh_token(client_id);
 CREATE INDEX idx_oauth2_client_last_active_at ON oauth2_client(last_active_at);
 CREATE INDEX idx_oauth2_client_workspace ON oauth2_client(workspace);
 
@@ -715,7 +727,9 @@ CREATE INDEX idx_oauth2_client_workspace ON oauth2_client(workspace);
 CREATE TABLE web_refresh_token (
     token_hash  TEXT PRIMARY KEY,
     user_email  TEXT NOT NULL REFERENCES principal(email) ON UPDATE CASCADE,
-    expires_at  TIMESTAMPTZ NOT NULL
+    expires_at  TIMESTAMPTZ NOT NULL,
+    -- When the row was issued.
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE INDEX idx_web_refresh_token_user_email ON web_refresh_token(user_email);

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -21,8 +21,8 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.22.13"), *files[len(files)-1].version)
-	require.Equal(t, "migration/3.22/0013##sample_instance_setup.sql", files[len(files)-1].path)
+	require.Equal(t, semver.MustParse("3.22.14"), *files[len(files)-1].version)
+	require.Equal(t, "migration/3.22/0014##token_row_created_at.sql", files[len(files)-1].path)
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/backend/store/oauth2_authorization_code.go
+++ b/backend/store/oauth2_authorization_code.go
@@ -25,6 +25,9 @@ type OAuth2AuthorizationCodeMessage struct {
 	Workspace string
 	Config    *storepb.OAuth2AuthorizationCodeConfig
 	ExpiresAt time.Time
+	// CreatedAt is when the code was issued, filled in by the database.
+	// Ignored on create.
+	CreatedAt time.Time
 }
 
 func (s *Store) CreateOAuth2AuthorizationCode(ctx context.Context, create *OAuth2AuthorizationCodeMessage) (*OAuth2AuthorizationCodeMessage, error) {
@@ -56,7 +59,7 @@ func (s *Store) CreateOAuth2AuthorizationCode(ctx context.Context, create *OAuth
 
 func (s *Store) GetOAuth2AuthorizationCode(ctx context.Context, clientID, code string) (*OAuth2AuthorizationCodeMessage, error) {
 	q := qb.Q().Space(`
-		SELECT code, client_id, user_email, workspace, config, expires_at
+		SELECT code, client_id, user_email, workspace, config, expires_at, created_at
 		FROM oauth2_authorization_code
 		WHERE code = ? AND client_id = ?
 	`, code, clientID)
@@ -70,7 +73,7 @@ func (s *Store) GetOAuth2AuthorizationCode(ctx context.Context, clientID, code s
 	var workspace sql.NullString
 	var configBytes []byte
 	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan( // NOSONAR: query is parameterized via qb.Query
-		&msg.Code, &msg.ClientID, &msg.UserEmail, &workspace, &configBytes, &msg.ExpiresAt,
+		&msg.Code, &msg.ClientID, &msg.UserEmail, &workspace, &configBytes, &msg.ExpiresAt, &msg.CreatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil

--- a/backend/store/oauth2_refresh_token.go
+++ b/backend/store/oauth2_refresh_token.go
@@ -27,6 +27,9 @@ type OAuth2RefreshTokenMessage struct {
 	// never widens a grant. Empty for tokens created before the 3.22.1 migration.
 	Config    *storepb.OAuth2RefreshTokenConfig
 	ExpiresAt time.Time
+	// CreatedAt is when the grant was issued, filled in by the database.
+	// Ignored on create.
+	CreatedAt time.Time
 }
 
 func (s *Store) CreateOAuth2RefreshToken(ctx context.Context, create *OAuth2RefreshTokenMessage) (*OAuth2RefreshTokenMessage, error) {
@@ -58,7 +61,7 @@ func (s *Store) CreateOAuth2RefreshToken(ctx context.Context, create *OAuth2Refr
 
 func (s *Store) GetOAuth2RefreshToken(ctx context.Context, clientID, tokenHash string) (*OAuth2RefreshTokenMessage, error) {
 	q := qb.Q().Space(`
-		SELECT token_hash, client_id, user_email, workspace, config, expires_at
+		SELECT token_hash, client_id, user_email, workspace, config, expires_at, created_at
 		FROM oauth2_refresh_token
 		WHERE token_hash = ? AND client_id = ?
 	`, tokenHash, clientID)
@@ -72,7 +75,7 @@ func (s *Store) GetOAuth2RefreshToken(ctx context.Context, clientID, tokenHash s
 	var workspace sql.NullString
 	var configBytes []byte
 	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(
-		&msg.TokenHash, &msg.ClientID, &msg.UserEmail, &workspace, &configBytes, &msg.ExpiresAt,
+		&msg.TokenHash, &msg.ClientID, &msg.UserEmail, &workspace, &configBytes, &msg.ExpiresAt, &msg.CreatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil

--- a/backend/store/web_refresh_token.go
+++ b/backend/store/web_refresh_token.go
@@ -14,6 +14,9 @@ type WebRefreshTokenMessage struct {
 	TokenHash string
 	UserEmail string
 	ExpiresAt time.Time
+	// CreatedAt is when the session was issued, filled in by the database.
+	// Ignored on create.
+	CreatedAt time.Time
 }
 
 func (s *Store) CreateWebRefreshToken(ctx context.Context, create *WebRefreshTokenMessage) error {
@@ -35,7 +38,7 @@ func (s *Store) CreateWebRefreshToken(ctx context.Context, create *WebRefreshTok
 
 func (s *Store) GetWebRefreshToken(ctx context.Context, tokenHash string) (*WebRefreshTokenMessage, error) {
 	q := qb.Q().Space(`
-		SELECT token_hash, user_email, expires_at
+		SELECT token_hash, user_email, expires_at, created_at
 		FROM web_refresh_token
 		WHERE token_hash = ?
 	`, tokenHash)
@@ -47,7 +50,7 @@ func (s *Store) GetWebRefreshToken(ctx context.Context, tokenHash string) (*WebR
 
 	msg := &WebRefreshTokenMessage{}
 	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(
-		&msg.TokenHash, &msg.UserEmail, &msg.ExpiresAt,
+		&msg.TokenHash, &msg.UserEmail, &msg.ExpiresAt, &msg.CreatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
@@ -63,7 +66,7 @@ func (s *Store) GetAndDeleteWebRefreshToken(ctx context.Context, tokenHash strin
 	q := qb.Q().Space(`
 		DELETE FROM web_refresh_token
 		WHERE token_hash = ?
-		RETURNING token_hash, user_email, expires_at
+		RETURNING token_hash, user_email, expires_at, created_at
 	`, tokenHash)
 
 	query, args, err := q.ToSQL()
@@ -73,7 +76,7 @@ func (s *Store) GetAndDeleteWebRefreshToken(ctx context.Context, tokenHash strin
 
 	msg := &WebRefreshTokenMessage{}
 	if err := s.GetDB().QueryRowContext(ctx, query, args...).Scan(
-		&msg.TokenHash, &msg.UserEmail, &msg.ExpiresAt,
+		&msg.TokenHash, &msg.UserEmail, &msg.ExpiresAt, &msg.CreatedAt,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil


### PR DESCRIPTION
## What

Adds `created_at` to the three token tables — `web_refresh_token`, `oauth2_authorization_code`, `oauth2_refresh_token` — and reads it back through the store layer. Also indexes the referencing side of the two foreign keys those tables carry.

Migration `3.22/0014##token_row_created_at.sql`.

## Why

**The column.** These tables record when a row *expires* but not when it was *issued*. That is a gap for anyone debugging an account: "when was this session handed out?" is currently unanswerable, and `expires_at` only implies it if you also know the refresh duration in force at issue time, which is per-workspace and can change. It also lets an account-level event be ordered against the rows that existed when it happened. Existing rows default to migration time, the earliest issue time consistent with their still being here.

**The indexes.** PostgreSQL indexes the referenced side of a foreign key, never the referencing side, so both cascades on these tables are sequential scans until they are indexed:

- `user_email` references `principal(email) ON UPDATE CASCADE` — every account email change rewrites the rows keyed on it. `web_refresh_token` already had this index; the two OAuth tables are catching up.
- `client_id` references `oauth2_client(client_id) ON DELETE CASCADE`, and the data cleaner deletes stale clients in bulk on a schedule. It answers no query on its own — every lookup pairs it with the primary key — so this is purely cascade support.

## Testing

`go test ./backend/migrator/` (including `TestLatestVersion`) and `./backend/store/` pass; `golangci-lint run` reports 0 issues. Nothing reads `created_at` for a decision yet, so there is nothing behavioral here to assert beyond the schema itself.

## Note

Split out of the re-authentication work in `docs/design/reauthenticate-credential-changes.md` so the schema can land and be reviewed on its own. The follow-up PR consumes `created_at` as a backstop at token-consume time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)