### PR TITLE
fix(rollout): show the engine's error on a failed task run

### DIFF
--- a/backend/plugin/db/bigquery/bigquery.go
+++ b/backend/plugin/db/bigquery/bigquery.go
@@ -102,21 +102,39 @@ func (*Driver) GetDB() *sql.DB {
 }
 
 // Execute executes a SQL statement.
-func (d *Driver) Execute(ctx context.Context, statement string, _ db.ExecuteOptions) (int64, error) {
+func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteOptions) (int64, error) {
 	q := d.client.Query(statement)
 	q.DefaultDatasetID = d.databaseName
+
+	// BigQuery submits the whole sheet as one query job, so the task run log
+	// carries one command spanning the entire statement, as snowflake does.
+	// Without these the log holds only the surrounding sync entries and the
+	// engine's error reaches no reader.
+	opts.LogCommandExecute(&storepb.Range{Start: 0, End: int32(len(statement))}, statement)
+
 	job, err := q.Run(ctx)
 	if err != nil {
+		opts.LogCommandResponse(0, nil, err.Error())
 		return 0, err
 	}
 	status, err := job.Wait(ctx)
 	if err != nil {
+		opts.LogCommandResponse(0, nil, err.Error())
 		return 0, err
 	}
 	if err := status.Err(); err != nil {
+		opts.LogCommandResponse(0, nil, err.Error())
 		return 0, err
 	}
-	return 0, nil
+
+	// NumDMLAffectedRows is 0 for DDL and for a multi-statement script, whose
+	// parent job reports statementType SCRIPT and carries no row count.
+	var affectedRows int64
+	if stats, ok := status.Statistics.Details.(*bigquery.QueryStatistics); ok {
+		affectedRows = stats.NumDMLAffectedRows
+	}
+	opts.LogCommandResponse(affectedRows, nil, "")
+	return affectedRows, nil
 }
 
 // QueryConn queries a SQL statement in a given connection.

--- a/backend/plugin/db/bigquery/bigquery.go
+++ b/backend/plugin/db/bigquery/bigquery.go
@@ -130,11 +130,23 @@ func (d *Driver) Execute(ctx context.Context, statement string, opts db.ExecuteO
 	// NumDMLAffectedRows is 0 for DDL and for a multi-statement script, whose
 	// parent job reports statementType SCRIPT and carries no row count.
 	var affectedRows int64
-	if stats, ok := status.Statistics.Details.(*bigquery.QueryStatistics); ok {
+	if stats, ok := statisticsOf(status); ok {
 		affectedRows = stats.NumDMLAffectedRows
 	}
 	opts.LogCommandResponse(affectedRows, nil, "")
 	return affectedRows, nil
+}
+
+// statisticsOf returns the query statistics of a finished job.
+// JobStatus.Statistics is nil when the jobs.get response carried no statistics
+// block (Job.setStatistics returns early on that), so the Details assertion
+// alone dereferences nil.
+func statisticsOf(status *bigquery.JobStatus) (*bigquery.QueryStatistics, bool) {
+	if status.Statistics == nil {
+		return nil, false
+	}
+	stats, ok := status.Statistics.Details.(*bigquery.QueryStatistics)
+	return stats, ok
 }
 
 // QueryConn queries a SQL statement in a given connection.
@@ -218,12 +230,11 @@ func (d *Driver) QueryConn(ctx context.Context, _ *sql.Conn, statement string, q
 			if err := status.Err(); err != nil {
 				return nil, err
 			}
-			switch r := status.Statistics.Details.(type) {
-			case *bigquery.QueryStatistics:
-				return util.BuildAffectedRowsResult(r.NumDMLAffectedRows, nil), nil
-			default:
+			stats, ok := statisticsOf(status)
+			if !ok {
 				return nil, errors.New("invalid status statistics detail type")
 			}
+			return util.BuildAffectedRowsResult(stats.NumDMLAffectedRows, nil), nil
 		}()
 		stop := false
 		if err != nil {
@@ -300,7 +311,7 @@ func (d *Driver) dryRunQuery(ctx context.Context, statement string, queryContext
 			Latency:   durationpb.New(time.Since(startTime)),
 		}
 
-		if stats, ok := status.Statistics.Details.(*bigquery.QueryStatistics); ok {
+		if stats, ok := statisticsOf(status); ok {
 			bytesProcessed := stats.TotalBytesProcessed
 
 			// Format output similar to bq CLI

--- a/frontend/src/routes/project/plan-detail/components/deploy/DeployLatestTaskRunInfo.tsx
+++ b/frontend/src/routes/project/plan-detail/components/deploy/DeployLatestTaskRunInfo.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from "react-i18next";
 import { HumanizeTs } from "@/components/HumanizeTs";
 import { TaskRunStatusIcon } from "@/components/TaskRunStatusIcon";
 import { TaskRunLogViewer } from "@/components/task-run-log";
-import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { executorEmailOfTaskRun } from "@/lib/taskRun";
@@ -15,6 +14,7 @@ import type { TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
 import { TaskRun_Status } from "@/types/proto-es/v1/rollout_service_pb";
 import { stringifyTaskRunStatus } from "@/utils/v1/issue/rollout";
 import { PlanDetailTaskRunSession } from "../PlanDetailTaskRunSession";
+import { TaskRunErrorAlert } from "./TaskRunErrorAlert";
 
 const STATUS_LABEL_CLASS: Partial<Record<TaskRun_Status, string>> = {
   [TaskRun_Status.RUNNING]: "text-info",
@@ -103,22 +103,7 @@ export function DeployLatestTaskRunInfo({
         )}
       </div>
 
-      {/* The engine's error, which the log below cannot be relied on to carry:
-          cassandra, databricks, elasticsearch, hive, redis, spanner and
-          starrocks never write a command-response entry, so for them the log
-          holds only the surrounding sync steps and the failure reads as
-          "Database Sync ✓ Completed" with no cause anywhere. */}
-      {taskRun.status === TaskRun_Status.FAILED && taskRun.detail && (
-        <Alert
-          variant="error"
-          title={t("common.error")}
-          description={
-            <span className="whitespace-pre-wrap break-words font-mono text-xs">
-              {taskRun.detail}
-            </span>
-          }
-        />
-      )}
+      <TaskRunErrorAlert taskRun={taskRun} />
 
       {/* Status is part of the key on purpose: a status flip (RUNNING→DONE)
           remounts the viewer for a fresh disclosure state on the new phase.

--- a/frontend/src/routes/project/plan-detail/components/deploy/DeployLatestTaskRunInfo.tsx
+++ b/frontend/src/routes/project/plan-detail/components/deploy/DeployLatestTaskRunInfo.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { HumanizeTs } from "@/components/HumanizeTs";
 import { TaskRunStatusIcon } from "@/components/TaskRunStatusIcon";
 import { TaskRunLogViewer } from "@/components/task-run-log";
+import { Alert } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Tooltip } from "@/components/ui/tooltip";
 import { executorEmailOfTaskRun } from "@/lib/taskRun";
@@ -101,6 +102,23 @@ export function DeployLatestTaskRunInfo({
           </span>
         )}
       </div>
+
+      {/* The engine's error, which the log below cannot be relied on to carry:
+          cassandra, databricks, elasticsearch, hive, redis, spanner and
+          starrocks never write a command-response entry, so for them the log
+          holds only the surrounding sync steps and the failure reads as
+          "Database Sync ✓ Completed" with no cause anywhere. */}
+      {taskRun.status === TaskRun_Status.FAILED && taskRun.detail && (
+        <Alert
+          variant="error"
+          title={t("common.error")}
+          description={
+            <span className="whitespace-pre-wrap break-words font-mono text-xs">
+              {taskRun.detail}
+            </span>
+          }
+        />
+      )}
 
       {/* Status is part of the key on purpose: a status flip (RUNNING→DONE)
           remounts the viewer for a fresh disclosure state on the new phase.

--- a/frontend/src/routes/project/plan-detail/components/deploy/DeployTaskRunHistorySheet.tsx
+++ b/frontend/src/routes/project/plan-detail/components/deploy/DeployTaskRunHistorySheet.tsx
@@ -20,6 +20,7 @@ import {
 } from "@/lib/taskRun";
 import { getTimeForPbTimestampProtoEs } from "@/types";
 import type { TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
+import { TaskRunErrorAlert } from "./TaskRunErrorAlert";
 
 // With this many runs or more, only the newest run starts expanded; older
 // runs collapse to header rows. Keeps the sheet scannable and avoids fetching
@@ -154,7 +155,8 @@ function TaskRunHistoryItem({
         </span>
       </button>
       {isExpanded && (
-        <div className="border-t p-3">
+        <div className="flex flex-col gap-2 border-t p-3">
+          <TaskRunErrorAlert taskRun={taskRun} />
           {/* Status is part of the key (as in the latest-run panel): a
               RUNNING -> DONE flip remounts the viewer so useTaskRunLogData's
               unmount cleanup invalidates the in-flight RUNNING log request,

--- a/frontend/src/routes/project/plan-detail/components/deploy/TaskRunErrorAlert.tsx
+++ b/frontend/src/routes/project/plan-detail/components/deploy/TaskRunErrorAlert.tsx
@@ -11,7 +11,7 @@ import { TaskRun_Status } from "@/types/proto-es/v1/rollout_service_pb";
 //
 // The log loads asynchronously, so gating this on the log's contents would
 // flip the alert after first paint.
-export function TaskRunErrorAlert({ taskRun }: { taskRun: TaskRun }) {
+export function TaskRunErrorAlert({ taskRun }: Readonly<{ taskRun: TaskRun }>) {
   const { t } = useTranslation();
 
   if (taskRun.status !== TaskRun_Status.FAILED || !taskRun.detail) {

--- a/frontend/src/routes/project/plan-detail/components/deploy/TaskRunErrorAlert.tsx
+++ b/frontend/src/routes/project/plan-detail/components/deploy/TaskRunErrorAlert.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from "react-i18next";
+import { Alert } from "@/components/ui/alert";
+import type { TaskRun } from "@/types/proto-es/v1/rollout_service_pb";
+import { TaskRun_Status } from "@/types/proto-es/v1/rollout_service_pb";
+
+// The engine's error for a failed run. The task run log below it cannot be
+// relied on to carry the cause: several drivers (cassandra, databricks,
+// elasticsearch, hive, redis, spanner and starrocks among them) never write a
+// command-response entry, so their logs hold only the surrounding sync steps
+// and a failure reads as "Database Sync Completed" with no cause anywhere.
+//
+// The log loads asynchronously, so gating this on the log's contents would
+// flip the alert after first paint.
+export function TaskRunErrorAlert({ taskRun }: { taskRun: TaskRun }) {
+  const { t } = useTranslation();
+
+  if (taskRun.status !== TaskRun_Status.FAILED || !taskRun.detail) {
+    return null;
+  }
+
+  return (
+    <Alert
+      variant="error"
+      title={t("common.error")}
+      description={
+        <span className="whitespace-pre-wrap break-words font-mono text-xs">
+          {taskRun.detail}
+        </span>
+      }
+    />
+  );
+}


### PR DESCRIPTION
Closes BOT-116. Follow-up to BYT-10132.

## What happened

A BigQuery deploy failed and the reporter could only find out why by reading the server's Docker log. The issue page showed a failed task whose entire content was:

```
Latest · ✗ Failed · 2 hours ago · users/ · 4.8s
  Database Sync   3.3s
  1  16:45:11.591  ✓ Completed
```

Their statement was wrong — the table had no `created_at` column — but nothing in the product said so. Reproduced end to end against a live BigQuery instance.

## Two independent causes

**The BigQuery driver discarded `db.ExecuteOptions`.** It took the parameter as `_`, so it never called `CreateTaskRunLog` and the task run log held only the surrounding sync steps. It now logs one command spanning the whole statement plus a response carrying the engine's error and `NumDMLAffectedRows`, mirroring the snowflake driver, which likewise submits a single job for the whole statement.

**`TaskRun.detail` was rendered nowhere.** It carried the same error for every engine and the API returned it; no component read it. A failed run now shows it.

The second is not redundant with the first. Several drivers — cassandra, databricks, elasticsearch, hive, redis, spanner and starrocks among them — also write no command-response entry, so for them the log can never carry the cause. The alert renders whenever the run failed rather than only when the log lacks an error of its own, because the log loads asynchronously and that condition would flip after first paint.

Both the latest-run panel and the task-run history sheet render it through one `TaskRunErrorAlert`, so they cannot drift. The history sheet's header comment already claimed *"the expanded body shows the full error"* as its reason for hiding the collapsed teaser when expanded; that is now true rather than aspirational.

## Also fixed here

`status.Statistics` is nil whenever the `jobs.get` response carried no statistics block — `Job.setStatistics` returns early on that (`cloud.google.com/go/bigquery@v1.79.0` `job.go:1259`) — and a `, ok` on the `Details` assertion guards the type, not the pointer. All three dereference sites in the file now go through `statisticsOf`, including the two in `QueryConn` and `dryRunQuery` that predate this branch. Without it a migration that actually applied could panic, which the task executor recovers into a failed task with no changelog: the inverse of the bug this fixes.

## Not fixed here

The other seven drivers still take `db.ExecuteOptions` as `_`, so their task run logs keep reading as a clean "Database Sync Completed" for a failed deploy even though the alert now carries the cause. That sweep belongs in its own change; this one closes the reporter's path.

## Testing

Measured against a live BigQuery instance, through the registered driver with an `ExecuteOptions` that captures log entries:

| | before | after |
|---|---|---|
| failing `INSERT` | 0 log entries | `COMMAND_EXECUTE` + `COMMAND_RESPONSE`, error `googleapi: Error 400: Column created_at is not present in table users_nocreated` |
| succeeding `INSERT` | `affectedRows=0` | `affectedRows=1` |

And in the real UI, on the same failed task and the same backend:

```
before:  Latest · ✗ Failed · 2.7s
           Database Sync ✓ Completed
after:   Latest · ✗ Failed · 2.7s
           ⚠ Error
           googleapi: Error 400: Column created_at is not present in table
           users_nocreated at [2:21], invalidQuery
           Database Sync ✓ Completed
```

Gates: `gofmt`, `go vet ./backend/...`, `golangci-lint` (0 issues), `go build ./...`, `go test ./backend/plugin/db/...`, and frontend `fix`/`check`/`type-check`/`test` (468 files, 3819 tests).
