### PR TITLE
docs: timestamp display — work queues vs history views

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -76,6 +76,14 @@ _Avoid_: Plan, rollout, issue
 The recorded history of a database migration after execution. It is evidence that a change ran, not the proposed change itself.
 _Avoid_: Change request, release
 
+**Work Queue Surface**:
+A list surface read to decide what needs attention now, such as the issue, plan, and release lists. The primary time question on a work queue is freshness.
+_Avoid_: History view, feed, dashboard
+
+**History View Surface**:
+A surface read as a record of what already happened, such as the audit log, database changelog, revisions, and task-run history. The primary time question on a history view is exactly when something happened.
+_Avoid_: Work queue, activity feed
+
 **Composite Type**:
 A PostgreSQL-family standalone named row type (`CREATE TYPE x AS (...)`, `pg_type.typtype = 'c'` excluding table row types). Distinct from enums, domains, ranges, Oracle object types, and SQL Server table/alias types — each is its own concept with its own name.
 _Avoid_: UDT, user-defined type, custom type, object type

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -170,9 +170,10 @@ Where operational times are displayed today:
 | Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute, interpolated into `t("project.members.expires-at", …)` | No timezone, no seconds — and a plain-string context: gets the full-precision string per the corollary (a `Trans`-slot refactor is the alternative if minute display is wanted) |
 | Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None today. Under D5, the JSX-rendered sites adopt the operational mode; the string-interpolated ones (subscription banner via `BannersWrapper.tsx`, `SampleExpirationAlert.tsx`) keep full precision — plain-string corollary |
 
-Fixes under D5: the scheduled pill and the three bare-format expirations converge on the
-operational format — absolute date-time + timezone at minute precision ("Sep 15, 2026, 9:00 AM
-GMT+8"); relative age can move to the tooltip.
+Fixes under D5: the scheduled pill, the masking exemption expiration, and the role-grant
+expiration converge on the operational format — absolute date-time + timezone at minute precision
+("Sep 15, 2026, 9:00 AM GMT+8"), relative age movable to the tooltip. The member expiration
+preview is i18n-interpolated and keeps a full-precision string instead (plain-string corollary).
 
 ## Current absolute-time display inventory
 

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -160,7 +160,8 @@ Where operational times are displayed today:
 | Surface | File | Today | Gap |
 |---|---|---|---|
 | Scheduled rollout pill | `routes/project/plan-detail/components/deploy/DeployTaskHeader.tsx` (task pinned to a run time) | `HumanizeTs` — relative ("in 7 hours"), tz only in tooltip | **The BYT-10023 display gap**: the one surface showing when a rollout will fire hides the timezone question entirely |
-| Task-run waiting message | `frontend/src/lib/taskRun.ts` ("enqueued, will run at …") | `formatAbsoluteDateTime` | None — already absolute + tz (seconds drop under D5's minute precision) |
+| Task-run waiting message | `frontend/src/lib/taskRun.ts` ("enqueued, will run at …") | `formatAbsoluteDateTime` interpolated into a plain i18n string | None — a plain-string context cannot host a tooltip, so it keeps the full-precision form (invariant corollary below); seconds do **not** drop here |
+| SQL-editor access grant item, <24h remaining | `modules/sql-editor/components/AccessGrantItem.tsx` | Duration only ("expires in 3h20m"); the absolute value is discarded, no tooltip | Relative-only operational display — needs the D6 tooltip carrying the full absolute + timezone |
 | Masking exemption expiration | `routes/project/ProjectMaskingExemptionPage.tsx` | dayjs `YYYY-MM-DD HH:mm` | No timezone, no seconds, not locale-aware |
 | Role-grant expiration detail | `routes/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx` | dayjs `LLL` | No timezone |
 | Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute | No timezone, no seconds |
@@ -254,6 +255,10 @@ tooltip.
   and the six already-absolute ones adopt the same mode (open item 4), which is what makes the
   sub-minute preset tails recoverable. **Invariant: a reduced timestamp without a full-precision
   tooltip is a bug** — bare formatter calls are reserved for full-precision strings and exports.
+  Corollary: a plain-string context that cannot host a tooltip — the i18n-interpolated task-run
+  waiting message, exports, document titles — must embed the full-precision string, never the
+  reduced one. The SQL-editor access grant item's <24h branch ("expires in 3h20m") is a relative
+  operational display and adopts the same tooltip treatment as the pill.
 - Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
   `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -108,9 +108,12 @@ the SQL-editor access-grant drawer), so a minute display floors the enforced cut
 seconds — in the safe direction: the value never expires earlier than displayed, and the full
 value stays in the tooltip (D6). Accepting D5 means accepting that bounded under-report;
 alternatives are retaining seconds for expiration values, or normalizing preset writes to the
-minute (a write-path change, out of scope for this display-only design). Driven by BYT-10023 —
-see Operational times below. Proposed, pending confirmation; the time *pickers* that write these
-values are explicitly deferred.
+minute (a write-path change, out of scope for this display-only design). Scope note: the rule targets **wall-clock renderings** — the timezone trap it guards against
+cannot occur in a pure remaining-duration display ("expires in 3h20m"), which is
+timezone-unambiguous by construction and stays permitted for short horizons, provided the D6
+tooltip carries the full absolute + timezone. Driven by BYT-10023 — see Operational times below.
+Proposed, pending confirmation; the time *pickers* that write these values are explicitly
+deferred.
 
 **D6 — Full date-time tooltip on every reduced display.**
 Any timestamp that does not show the full form — relative, date-only after the switch, or the
@@ -168,7 +171,7 @@ Where operational times are displayed today:
 |---|---|---|---|
 | Scheduled rollout pill | `routes/project/plan-detail/components/deploy/DeployTaskHeader.tsx` (task pinned to a run time) | `HumanizeTs` — relative ("in 7 hours"), tz only in tooltip | **The BYT-10023 display gap**: the one surface showing when a rollout will fire hides the timezone question entirely |
 | Task-run waiting message | `frontend/src/lib/taskRun.ts` ("enqueued, will run at …") | `formatAbsoluteDateTime` interpolated into a plain i18n string | None — a plain-string context cannot host a tooltip, so it keeps the full-precision form (invariant corollary below); seconds do **not** drop here |
-| SQL-editor access grant item, <24h remaining | `modules/sql-editor/components/AccessGrantItem.tsx` | Duration only ("expires in 3h20m"); the absolute value is discarded, no tooltip | Relative-only operational display — needs the D6 tooltip carrying the full absolute + timezone |
+| SQL-editor access grant item, <24h remaining | `modules/sql-editor/components/AccessGrantItem.tsx` | Duration only ("expires in 3h20m"); the absolute value is discarded, no tooltip | The visible duration is permitted under D5's wall-clock scope note (a countdown is timezone-unambiguous); the gap is the missing D6 tooltip with the full absolute + timezone |
 | Access-grant expiration, issue detail | `routes/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx` (renders the helper's string in JSX) | `formatAbsoluteDateTime` via `getAccessGrantExpirationText` | None today. Under D5: JSX context — adopts the operational mode with its D6 tooltip |
 | Masking exemption expiration | `routes/project/ProjectMaskingExemptionPage.tsx` | dayjs `YYYY-MM-DD HH:mm` | No timezone, no seconds, not locale-aware |
 | Role-grant expiration detail | `routes/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx` | dayjs `LLL` | No timezone |

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -302,9 +302,16 @@ tooltip.
   output actually changes. This matches GitHub's `relative-time` element, which schedules its own
   updates at the next boundary. The dividing line is time-variance, not mode: absolute labels
   (compact/datetime/operational) never change with time and skip the subscription, while every
-  time-varying display subscribes — the relative buckets, and countdown/status consumers such as
-  the SQL-editor access-grant item, whose remaining duration, 24-hour display transition, and
-  expired state otherwise go stale on a long-mounted editor.
+  time-varying display subscribes — the relative buckets, and every countdown/status consumer
+  that derives `isExpired`/remaining-time state from render-time `Date.now()`: the SQL-editor
+  access-grant item (duration, 24-hour display transition, expired state), the masking exemption
+  rows (`ExemptionGrantSection`), `SampleExpirationAlert`, and the subscription banner's
+  time-dependent store selectors. Two components already run private timers for exactly this
+  (`PlanDetailMeta` at 60s, `DatabaseQueryContext` at 1s) and consolidate onto the shared clock
+  (`InactiveRemindModal`'s 1s timer is a session-idle mechanism, not a timestamp display — out of
+  scope). Implementation checklist: sweep render-time `Date.now()` in display components — every
+  hit either subscribes to the shared clock or records why it need not (e.g. values evaluated at
+  interaction time inside action panels).
 - Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
   `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
@@ -314,8 +321,10 @@ tooltip.
   (e.g. 9:00:47) asserting the visible label renders minute + timezone and the tooltip carries the
   full seconds + timezone, plus the countdown carve-out (a <24h grant renders the remaining
   duration with that same full tooltip), a fake-timer test advancing a mounted component across a
-  relative bucket boundary and across the 30-day cutoff, and a fake-timer transition test for the
-  access-grant countdown (duration ticks → 24-hour display boundary → expired state).
+  relative bucket boundary and across the 30-day cutoff, a fake-timer transition test for the
+  access-grant countdown (duration ticks → 24-hour display boundary → expired state), and
+  fake-timer expiration-status flips for the masking exemption row, the sample-expiration alert,
+  and the subscription banner.
 
 ## What does not change
 

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -131,7 +131,7 @@ Every current `HumanizeTs` call site, classified under the principle:
 |---|---|---|---|
 | Issue list | `components/IssueTable.tsx` | Work queue | 30d switch |
 | Plan list | `routes/project/ProjectPlanDashboardPage.tsx` | Work queue | 30d switch |
-| Release list / detail meta | `routes/project/ProjectReleaseDashboardPage.tsx`, `ProjectReleaseDetailPage.tsx` | Work queue / meta | 30d switch |
+| Release list / detail meta | `routes/project/ProjectReleaseDashboardPage.tsx`, `ProjectReleaseDetailPage.tsx`, `components/release/ReleaseInfoCard.tsx` (fixed string today — adopts `HumanizeTs`) | Work queue / meta | 30d switch |
 | Issue comments & activity | `components/issue-activity/IssueCommentActivity.tsx`, `routes/project/issue-detail/components/IssueDetailCommentList.tsx` | Feed | 30d switch |
 | Review timeline / rejection banner | `routes/project/plan-detail/components/review/ReviewActivityTimeline.tsx`, `ReviewRejectionBanner.tsx` | Feed | 30d switch |
 | Plan detail "created" | `routes/project/plan-detail/components/PlanDetailMeta.tsx` | Meta | 30d switch |
@@ -181,7 +181,9 @@ For reference, absolute timestamps already appear in the product in three incons
    scheduled-time messages, SQL editor result panel, Monaco heartbeat, agent chat tooltip.
 2. **Fixed dayjs strings** — time but no timezone, not locale-aware: masking exemption
    (`YYYY-MM-DD HH:mm`), role-grant details (`LLL`), SQL editor query-history rows and tab titles
-   (`YYYY-MM-DD HH:mm:ss` via `titleOfQueryHistory` in `HistoryPane.tsx`).
+   (`YYYY-MM-DD HH:mm:ss` — `titleOfQueryHistory` in `HistoryPane.tsx`, plus an independently
+   built deep-link tab title in `SQLEditorRouteShell.tsx`), and embedded release metadata
+   (`components/release/ReleaseInfoCard.tsx`, `YYYY-MM-DD HH:mm:ss`).
 3. **Ad-hoc `toLocaleDateString`** with hour/minute — no seconds, no timezone: the members-page
    expiration preview.
 
@@ -251,7 +253,9 @@ tooltip.
   `formatCompactDateTime` helper in `datetime.ts` — date + hh:mm, locale-aware). One canonical
   component, modes matching the principle one-to-one; the audit log can keep its direct call.
   `titleOfQueryHistory` in `HistoryPane.tsx` splits: the row display adopts the compact mode with
-  its D6 tooltip, while the tab title — a plain-string context — keeps a full-precision string.
+  its D6 tooltip, while both tab-title paths — `titleOfQueryHistory` and the independently built
+  deep-link title in `SQLEditorRouteShell.tsx` — keep a full-precision string (plain-string
+  corollary). `ReleaseInfoCard.tsx` swaps its fixed string for `HumanizeTs` (queue mode).
 - Operational times render through the shared component, never as bare strings: `HumanizeTs` gains
   `mode="operational"` (`formatOperationalDateTime` in the cell, D6 tooltip carrying the full
   enforced value with seconds). The scheduled pill in `DeployTaskHeader.tsx` switches mode rather

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -117,7 +117,9 @@ tooltip. This is the universal escape hatch that keeps every reduced cell recove
 **D7 (proposed) — History views carry two precision tiers.**
 *A history row orients; a history record testifies.* Full precision (seconds + timezone,
 `formatAbsoluteDateTime`) where the time itself is the evidence: the audit log — exportable, and
-the export must match the screen — and single-record detail views. Compact precision (date +
+the export must preserve the same instant at no less precision than the screen (the export writes
+RFC 3339 UTC while the screen shows browser-local time; equivalence means instant + precision,
+not string identity) — and single-record detail views. Compact precision (date +
 hh:mm, no seconds, no timezone) where rows are scanned to locate a record inside one resource's
 history: the embedded lists, where width is contended and D6 keeps full precision one hover away.
 Objective divider: **exportable-as-evidence or a detail view → full; scannable embedded list →
@@ -342,8 +344,9 @@ D6 (full date-time tooltip on every reduced display). Still open:
    (write-path change, out of scope here).
 3. Scheduled rollout pill shows the operational format inline ("Sep 15, 2026, 9:00 AM GMT+8");
    relative age moves to the tooltip.
-4. The three bare-format expiration displays (masking exemption, role-grant details, member
-   preview) are normalized to the operational format in this effort. Alternative: file as
-   follow-up cleanup.
+4. The bare-format expiration displays are fixed in this effort rather than filed as follow-up
+   cleanup: masking exemption and role-grant details adopt the operational mode; the member
+   preview — an i18n-interpolated string — gets the full-precision string per the corollary
+   (or the `Trans`-slot refactor if minute display is preferred there).
 5. Tooltip on *full* cells may show the relative age (inverse tooltip). Alternative: repeat the
    full string (GitHub parity).

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -297,7 +297,11 @@ tooltip.
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
   `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
   `ProjectPlanDashboardPage.test.tsx`, `DatabaseChangelogTable.test.tsx`, …). New behavior gets new
-  tests: threshold boundary (29d/31d), same-year vs cross-year, zh locale, history-view mode.
+  tests: threshold boundary (29d/31d), same-year vs cross-year, zh locale, history-view tiers, and
+  the operational contract — a component test using an expiration with a sub-minute tail
+  (e.g. 9:00:47) asserting the visible label renders minute + timezone and the tooltip carries the
+  full seconds + timezone, plus the countdown carve-out (a <24h grant renders the remaining
+  duration with that same full tooltip).
 
 ## What does not change
 

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -296,8 +296,11 @@ tooltip.
 - Staleness: `HumanizeTs` evaluates `Date.now()` only during render, so a long-mounted page shows
   "5 minutes ago" indefinitely and a row can sit on the wrong side of the 30-day cutoff until an
   unrelated render. With buckets formalized, the component subscribes to one shared module-level
-  coarse clock (~30–60s tick); a subscriber re-renders only when its formatted output actually
-  changes. This matches GitHub's `relative-time` element, which schedules its own updates.
+  clock with adaptive cadence: second-level ticks while any subscriber's label still changes at
+  sub-minute granularity (the "now" and seconds buckets), dropping to a coarse ~30–60s tick once
+  every subscriber is in minute-or-older buckets; a subscriber re-renders only when its formatted
+  output actually changes. This matches GitHub's `relative-time` element, which schedules its own
+  updates at the next boundary.
   Absolute modes (compact/datetime/operational) never change with time and skip the subscription.
 - Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -165,7 +165,7 @@ Where operational times are displayed today:
 | SQL-editor access grant item, <24h remaining | `modules/sql-editor/components/AccessGrantItem.tsx` | Duration only ("expires in 3h20m"); the absolute value is discarded, no tooltip | Relative-only operational display — needs the D6 tooltip carrying the full absolute + timezone |
 | Masking exemption expiration | `routes/project/ProjectMaskingExemptionPage.tsx` | dayjs `YYYY-MM-DD HH:mm` | No timezone, no seconds, not locale-aware |
 | Role-grant expiration detail | `routes/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx` | dayjs `LLL` | No timezone |
-| Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute | No timezone, no seconds |
+| Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute, interpolated into `t("project.members.expires-at", …)` | No timezone, no seconds — and a plain-string context: gets the full-precision string per the corollary (a `Trans`-slot refactor is the alternative if minute display is wanted) |
 | Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None today. Under D5, the JSX-rendered sites adopt the operational mode; the string-interpolated ones (subscription banner via `BannersWrapper.tsx`, `SampleExpirationAlert.tsx`) keep full precision — plain-string corollary |
 
 Fixes under D5: the scheduled pill and the three bare-format expirations converge on the
@@ -236,6 +236,12 @@ their list views render relative. D4 makes each list agree with its own detail v
 - **Compact** = date + hh:mm, locale-aware: "Aug 26, 2026, 2:03 PM" / zh "2026年8月26日 14:03"
   (~21 characters). Seconds and timezone stay one hover away per D6.
 
+**Task-run log entries** (`components/task-run-log/model.ts::formatTime` — `HH:mm:ss.SSS`,
+embedded in changelog detail and task-run views) keep their time-only millisecond format: log
+lines are dense by design and the parent run header carries the full date. They are still reduced
+displays, so each entry gains the D6 tooltip with the full date-time — which also covers a run
+crossing midnight.
+
 **Operational times** (scheduled rollouts, expirations): a new `formatOperationalDateTime` helper
 in `datetime.ts` — date + hh:mm + short timezone, locale-aware: "Sep 15, 2026, 9:00 AM GMT+8" / zh
 "2026年9月15日 09:00 GMT+8". The timezone lives in the visible string — not only in the tooltip,
@@ -261,10 +267,12 @@ tooltip.
 - Operational times render through the shared component, never as bare strings: `HumanizeTs` gains
   `mode="operational"` (`formatOperationalDateTime` in the cell, D6 tooltip carrying the full
   enforced value with seconds). The scheduled pill in `DeployTaskHeader.tsx` switches mode rather
-  than dropping the component — its tooltip survives; the three bare-format expiration call sites
-  and, of the six already-absolute ones, the JSX-rendered sites adopt the same mode (open item 4),
-  which is what makes the sub-minute preset tails recoverable. The string-interpolated sites
-  (subscription banner, sample-expiration alert) keep the full-precision string per the corollary. **Invariant: a reduced timestamp without a full-precision
+  than dropping the component — its tooltip survives; of the three bare-format expiration call
+  sites, masking exemption and role-grant details adopt the same mode (open item 4), which is what
+  makes the sub-minute preset tails recoverable, while the member preset preview is itself
+  i18n-interpolated and keeps a full-precision string per the corollary. Of the six
+  already-absolute sites, the JSX-rendered ones adopt the mode; the string-interpolated ones
+  (subscription banner, sample-expiration alert) keep the full-precision string. **Invariant: a reduced timestamp without a full-precision
   tooltip is a bug** — bare formatter calls are reserved for full-precision strings and exports.
   Corollary: a plain-string context that cannot host a tooltip — the i18n-interpolated task-run
   waiting message, exports, document titles — must embed the full-precision string, never the

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -293,6 +293,12 @@ tooltip.
   waiting message, exports, document titles — must embed the full-precision string, never the
   reduced one. The SQL-editor access grant item's <24h branch ("expires in 3h20m") is a relative
   operational display and adopts the same tooltip treatment as the pill.
+- Staleness: `HumanizeTs` evaluates `Date.now()` only during render, so a long-mounted page shows
+  "5 minutes ago" indefinitely and a row can sit on the wrong side of the 30-day cutoff until an
+  unrelated render. With buckets formalized, the component subscribes to one shared module-level
+  coarse clock (~30–60s tick); a subscriber re-renders only when its formatted output actually
+  changes. This matches GitHub's `relative-time` element, which schedules its own updates.
+  Absolute modes (compact/datetime/operational) never change with time and skip the subscription.
 - Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
   `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
@@ -301,7 +307,8 @@ tooltip.
   the operational contract — a component test using an expiration with a sub-minute tail
   (e.g. 9:00:47) asserting the visible label renders minute + timezone and the tooltip carries the
   full seconds + timezone, plus the countdown carve-out (a <24h grant renders the remaining
-  duration with that same full tooltip).
+  duration with that same full tooltip), and a fake-timer test advancing a mounted component
+  across a relative bucket boundary and across the 30-day cutoff.
 
 ## What does not change
 

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -96,11 +96,26 @@ GitHub behavior).
 The history views — database changelog, revision table, task-run history — flip to **absolute
 date-time always**, consistent with the audit log. They are records of execution, not queues.
 
-**D5 (proposed) — Operational times: absolute with explicit timezone, always.**
-Scheduled rollout times and expirations render `formatAbsoluteDateTime` (which carries the short
-timezone name) in the visible string, not just the tooltip. Driven by BYT-10023 — see Operational
-times below. Proposed, pending confirmation; the time *pickers* that write these values are
-explicitly deferred.
+**D5 (proposed) — Operational times: absolute with explicit timezone, minute precision.**
+Scheduled rollout times and expirations render the absolute date-time with the short timezone name
+in the visible string, not just the tooltip: "Sep 15, 2026, 9:00 AM GMT+8". No seconds — the
+pickers write minute precision, so a seconds field would always read ":00". Driven by BYT-10023 —
+see Operational times below. Proposed, pending confirmation; the time *pickers* that write these
+values are explicitly deferred.
+
+**D6 — Full date-time tooltip on every reduced display.**
+Any timestamp that does not show the full form — relative, date-only after the switch, or the
+compact history tier — carries the full absolute date-time with seconds and timezone in its
+tooltip. This is the universal escape hatch that keeps every reduced cell recoverable.
+
+**D7 (proposed) — History views carry two precision tiers.**
+*A history row orients; a history record testifies.* Full precision (seconds + timezone,
+`formatAbsoluteDateTime`) where the time itself is the evidence: the audit log — exportable, and
+the export must match the screen — and single-record detail views. Compact precision (date +
+hh:mm, no seconds, no timezone) where rows are scanned to locate a record inside one resource's
+history: the embedded lists, where width is contended and D6 keeps full precision one hover away.
+Objective divider: **exportable-as-evidence or a detail view → full; scannable embedded list →
+compact.**
 
 ## Surface classification
 
@@ -118,9 +133,9 @@ Every current `HumanizeTs` call site, classified under the principle:
 | **Scheduled rollout pill** | `DeployTaskHeader.tsx` (task pinned to a run time) | **Operational** | **Absolute + timezone** |
 | Schema sync status | `modules/sql-editor/components/SchemaPane/SyncSchemaButton.tsx`, `routes/project/ProjectSyncSchemaPage.tsx`, `components/database/DatabaseOverviewInfo.tsx` | Freshness | 30d switch |
 | Agent chat | `modules/agent/components/AgentWindow.tsx` | Feed | 30d switch |
-| **Database changelog** | `routes/project/database-detail/changelog/DatabaseChangelogTable.tsx` | **History view** | **Absolute date-time always** |
-| **Database revisions** | `routes/project/database-detail/revision/DatabaseRevisionTable.tsx` | **History view** | **Absolute date-time always** |
-| **Task-run history** | `routes/project/plan-detail/components/deploy/DeployTaskRunHistorySheet.tsx`, `routes/project/issue-detail/components/IssueDetailTaskRunTable.tsx` | **History view** | **Absolute date-time always** |
+| **Database changelog** | `routes/project/database-detail/changelog/DatabaseChangelogTable.tsx` | **History view** | **Absolute always — compact tier (D7)** |
+| **Database revisions** | `routes/project/database-detail/revision/DatabaseRevisionTable.tsx` | **History view** | **Absolute always — compact tier (D7)** |
+| **Task-run history** | `routes/project/plan-detail/components/deploy/DeployTaskRunHistorySheet.tsx`, `routes/project/issue-detail/components/IssueDetailTaskRunTable.tsx` | **History view** | **Absolute always — compact tier (D7)** |
 | Audit log | `components/AuditLogTable.tsx` | History view | Already absolute — unchanged |
 
 ## Operational times (BYT-10023)
@@ -145,8 +160,9 @@ Where operational times are displayed today:
 | Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute | No timezone, no seconds |
 | Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None — already absolute + tz |
 
-Fixes under D5: the scheduled pill renders `formatAbsoluteDateTime` (relative age can move to the
-tooltip), and the three bare-format expirations converge on `formatAbsoluteDateTime`.
+Fixes under D5: the scheduled pill and the three bare-format expirations converge on the
+operational format — absolute date-time + timezone at minute precision ("Sep 15, 2026, 9:00 AM
+GMT+8"); relative age can move to the tooltip.
 
 ## Current absolute-time display inventory
 
@@ -190,10 +206,22 @@ their list views render relative. D4 makes each list agree with its own detail v
 - All strings locale-aware via `Intl` with the active i18n locale — no hardcoded formats, no new
   locale keys needed.
 
-**History views** (changelog, revisions, task-run history): absolute date-time always, using the
-audit log's exact format (`formatAbsoluteDateTime`): "Aug 26, 2026, 2:03:22 PM GMT+8" — seconds
-included, which is where the exact-time ask lands fully. Tooltip retained (GitHub also tooltips its
-absolute dates); it may additionally show the relative age — see defaults below.
+**History views**: absolute always; precision comes in two tiers under D7 (assignment proposed):
+
+| History-view occurrence | Space | Tier |
+|---|---|---|
+| Audit log (workspace + project pages) | Dedicated page, exportable | **Full** — keep as is |
+| Changelog detail page | Detail view | **Full** — keep as is |
+| Revision detail panel | Detail view | **Full** — keep as is |
+| Database changelog list | Full-width table | Compact |
+| Database revision list | Full-width table | Compact |
+| Task-run history sheet | 704px sheet — the space-constrained case | Compact |
+| Issue-detail task-run table | Embedded table | Compact |
+
+- **Full** = `formatAbsoluteDateTime`: "Aug 26, 2026, 2:03:22 PM GMT+8" / zh
+  "2026年8月26日 14:03:22 GMT+8" (~30 characters).
+- **Compact** = date + hh:mm, locale-aware: "Aug 26, 2026, 2:03 PM" / zh "2026年8月26日 14:03"
+  (~21 characters). Seconds and timezone stay one hover away per D6.
 
 **Operational times** (scheduled rollouts, expirations): `formatAbsoluteDateTime`, with the
 timezone in the visible string — not only in the tooltip, because the reader is about to act on
@@ -206,10 +234,10 @@ hours") may accompany it in the tooltip.
   in `frontend/src/utils/util.ts` (30-day switch) + `RELATIVE_THRESHOLD_MS` and
   `formatAbsoluteDate` in `frontend/src/utils/datetime.ts`. Consolidate into `datetime.ts`; delete
   the dead `humanizeTs`/`humanizeDate` pair in `util.ts` / `utils/v1/common.ts`.
-- History views either call `formatAbsoluteDateTime` directly (as `AuditLogTable.tsx` does today)
-  or `HumanizeTs` gains a `mode="absolute"` prop so the tooltip/i18n-resubscribe behavior stays
-  shared. Prefer the prop — one canonical component, two declared modes, matching the principle
-  one-to-one.
+- History views use a `mode` prop on `HumanizeTs` so the tooltip/i18n-resubscribe behavior stays
+  shared: `mode="datetime"` (full, existing `formatAbsoluteDateTime`) and `mode="compact"` (a new
+  `formatCompactDateTime` helper in `datetime.ts` — date + hh:mm, locale-aware). One canonical
+  component, modes matching the principle one-to-one; the audit log can keep its direct call.
 - Operational times: the scheduled pill in `DeployTaskHeader.tsx` swaps `HumanizeTs` for the
   absolute string; the three bare-format expiration call sites converge on
   `formatAbsoluteDateTime` (default 6).
@@ -241,17 +269,20 @@ hours") may accompany it in the tooltip.
   part of the complaint survives. Mitigation: tooltip; escalation path if it recurs is lowering the
   threshold (D3) or a GitLab-style preference (D1 rejected-for-now).
 
-## Defaults awaiting veto
+## Open items awaiting ruling
 
-1. History-view cells keep the timezone suffix ("GMT+8"), matching the audit log. Alternative: move
-   tz to tooltip for density.
-2. Tooltip on absolute cells shows the full date-time (GitHub parity). Alternative: show the
-   relative age instead (inverse tooltip).
-3. Release list classified as work queue (switch), not history.
-4. Comment/activity timelines classified as feed (switch) even on closed issues.
-5. Scheduled rollout pill shows the full `formatAbsoluteDateTime` string inline (wide, but the
-   pill only appears while a schedule is pending). Alternative: date + hh:mm + tz, seconds in
-   tooltip.
-6. The three bare-format expiration displays (masking exemption, role-grant details, member
-   preview) are normalized to `formatAbsoluteDateTime` in this effort. Alternative: file as
+Confirmed since the first draft: release list = work queue; comment/activity timelines = feed;
+D6 (full date-time tooltip on every reduced display). Still open:
+
+1. **D7 tier assignment/format** — compact (date + hh:mm) vs full for the embedded history lists.
+   Mockups of both options exist for the changelog table and the 704px task-run sheet;
+   recommendation is compact per the orient/testify principle.
+2. **D5 precision refinement** — operational times at minute precision (no seconds), since the
+   pickers write minutes. Alternative: full seconds for uniformity with the full history tier.
+3. Scheduled rollout pill shows the operational format inline ("Sep 15, 2026, 9:00 AM GMT+8");
+   relative age moves to the tooltip.
+4. The three bare-format expiration displays (masking exemption, role-grant details, member
+   preview) are normalized to the operational format in this effort. Alternative: file as
    follow-up cleanup.
+5. Tooltip on *full* cells may show the relative age (inverse tooltip). Alternative: repeat the
+   full string (GitHub parity).

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -4,7 +4,10 @@ Relative timestamps ("x days ago") hide exactly the precision an audit reading n
 ([BYT-10140](https://linear.app/bytebase/issue/BYT-10140)). The rule this doc lands on: **a surface
 is either a work queue or a history view, and that classification decides its time display** — work
 queues get GitHub-style relative time with a 30-day cap, history views get absolute date-time
-always. Frontend display only; no backend, no API, no stored preference.
+always. A third kind of time is future-pointing — scheduled rollouts and expirations
+([BYT-10023](https://linear.app/bytebase/issue/BYT-10023)) — and renders absolute with an explicit
+timezone. Frontend display only; no backend, no API, no stored preference. Time *input* (the
+schedule and expiration pickers) is explicitly out of scope for now.
 
 ## Problem
 
@@ -30,6 +33,14 @@ audit request.
 
 Surfaces that are neither literally a queue nor a record (activity feeds, "created N ago" meta,
 sync freshness, agent chat) are freshness-first readings and follow the work-queue rendering.
+
+The queue/history split covers *record* timestamps — times of things that already happened. A
+**future-pointing time** is a third kind:
+
+- **Operational time** — a scheduled rollout or an expiration, read in order to *act*: "exactly
+  when will this fire or lapse". Display: absolute date-time **with an explicit timezone**, never
+  relative-only. Relative wording ("in 7 hours") hides that the timezone question even exists;
+  see the incident evidence under Operational times below.
 
 ## Research — how other products display timestamps
 
@@ -85,6 +96,12 @@ GitHub behavior).
 The history views — database changelog, revision table, task-run history — flip to **absolute
 date-time always**, consistent with the audit log. They are records of execution, not queues.
 
+**D5 (proposed) — Operational times: absolute with explicit timezone, always.**
+Scheduled rollout times and expirations render `formatAbsoluteDateTime` (which carries the short
+timezone name) in the visible string, not just the tooltip. Driven by BYT-10023 — see Operational
+times below. Proposed, pending confirmation; the time *pickers* that write these values are
+explicitly deferred.
+
 ## Surface classification
 
 Every current `HumanizeTs` call site, classified under the principle:
@@ -97,13 +114,60 @@ Every current `HumanizeTs` call site, classified under the principle:
 | Issue comments & activity | `components/issue-activity/IssueCommentActivity.tsx`, `routes/project/issue-detail/components/IssueDetailCommentList.tsx` | Feed | 30d switch |
 | Review timeline / rejection banner | `routes/project/plan-detail/components/review/ReviewActivityTimeline.tsx`, `ReviewRejectionBanner.tsx` | Feed | 30d switch |
 | Plan detail "created" | `routes/project/plan-detail/components/PlanDetailMeta.tsx` | Meta | 30d switch |
-| Deploy current status | `routes/project/plan-detail/components/deploy/DeployTaskHeader.tsx`, `DeployLatestTaskRunInfo.tsx` | Freshness | 30d switch |
+| Deploy current status (latest-run times) | `routes/project/plan-detail/components/deploy/DeployTaskHeader.tsx`, `DeployLatestTaskRunInfo.tsx` | Freshness | 30d switch |
+| **Scheduled rollout pill** | `DeployTaskHeader.tsx` (task pinned to a run time) | **Operational** | **Absolute + timezone** |
 | Schema sync status | `modules/sql-editor/components/SchemaPane/SyncSchemaButton.tsx`, `routes/project/ProjectSyncSchemaPage.tsx`, `components/database/DatabaseOverviewInfo.tsx` | Freshness | 30d switch |
 | Agent chat | `modules/agent/components/AgentWindow.tsx` | Feed | 30d switch |
 | **Database changelog** | `routes/project/database-detail/changelog/DatabaseChangelogTable.tsx` | **History view** | **Absolute date-time always** |
 | **Database revisions** | `routes/project/database-detail/revision/DatabaseRevisionTable.tsx` | **History view** | **Absolute date-time always** |
 | **Task-run history** | `routes/project/plan-detail/components/deploy/DeployTaskRunHistorySheet.tsx`, `routes/project/issue-detail/components/IssueDetailTaskRunTable.tsx` | **History view** | **Absolute date-time always** |
 | Audit log | `components/AuditLogTable.tsx` | History view | Already absolute — unchanged |
+
+## Operational times (BYT-10023)
+
+The incident that motivates the third class: a customer scheduling a production rollout for that
+night asked which timezone the schedule uses. Nobody on their side could tell from the product;
+their two guesses — UTC+0 and the server's timezone — were both wrong (it is the operator's
+*browser* timezone), and acting on the UTC+0 guess would have fired the rollout seven hours early,
+mid-business-day. The product behavior is correct; the defect is that no visible surface says which
+timezone applies. The docs side was fixed in
+[bytebase.com#125](https://github.com/bytebase/bytebase.com/pull/125); this doc covers the display
+side. The picker itself (input side) is deliberately not designed here.
+
+Where operational times are displayed today:
+
+| Surface | File | Today | Gap |
+|---|---|---|---|
+| Scheduled rollout pill | `routes/project/plan-detail/components/deploy/DeployTaskHeader.tsx` (task pinned to a run time) | `HumanizeTs` — relative ("in 7 hours"), tz only in tooltip | **The BYT-10023 display gap**: the one surface showing when a rollout will fire hides the timezone question entirely |
+| Task-run waiting message | `frontend/src/lib/taskRun.ts` ("enqueued, will run at …") | `formatAbsoluteDateTime` | None — already absolute + tz |
+| Masking exemption expiration | `routes/project/ProjectMaskingExemptionPage.tsx` | dayjs `YYYY-MM-DD HH:mm` | No timezone, no seconds, not locale-aware |
+| Role-grant expiration detail | `routes/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx` | dayjs `LLL` | No timezone |
+| Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute | No timezone, no seconds |
+| Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None — already absolute + tz |
+
+Fixes under D5: the scheduled pill renders `formatAbsoluteDateTime` (relative age can move to the
+tooltip), and the three bare-format expirations converge on `formatAbsoluteDateTime`.
+
+## Current absolute-time display inventory
+
+For reference, absolute timestamps already appear in the product in three inconsistent families:
+
+1. **`formatAbsoluteDateTime`** — locale-aware, seconds + short timezone ("GMT+8"). The dominant
+   family: audit log, changelog detail page, revision detail panel, access grants, members
+   expiration table, IAM remind dialog, sample-expiration alert, subscription expiry, task-run
+   scheduled-time messages, SQL editor result panel, Monaco heartbeat, agent chat tooltip.
+2. **Fixed dayjs strings** — time but no timezone, not locale-aware: masking exemption
+   (`YYYY-MM-DD HH:mm`), role-grant details (`LLL`), SQL editor tab titles (`YYYY-MM-DD HH:mm:ss`).
+3. **Ad-hoc `toLocaleDateString`** with hour/minute — no seconds, no timezone: the members-page
+   expiration preview.
+
+Two half-built versions of this design already exist as dead code: the unused `humanizeTs()`
+30-day switch in `utils/util.ts`, and the never-passed `format="absolute"` branch of the date cell
+in `IssueDetailTaskRunTable.tsx`. Both are evidence the need was felt before; both get subsumed.
+
+Notably, the product's current pattern is *relative in the list, absolute in the detail* — the
+changelog detail page and revision detail panel already render `formatAbsoluteDateTime` while
+their list views render relative. D4 makes each list agree with its own detail view.
 
 ## Rendering specification
 
@@ -131,6 +195,11 @@ audit log's exact format (`formatAbsoluteDateTime`): "Aug 26, 2026, 2:03:22 PM G
 included, which is where the exact-time ask lands fully. Tooltip retained (GitHub also tooltips its
 absolute dates); it may additionally show the relative age — see defaults below.
 
+**Operational times** (scheduled rollouts, expirations): `formatAbsoluteDateTime`, with the
+timezone in the visible string — not only in the tooltip, because the reader is about to act on
+the value and must not have to discover that a timezone question exists. Relative age ("in 7
+hours") may accompany it in the tooltip.
+
 ## Implementation shape
 
 - `HumanizeTs` adopts the switching behavior. The logic already exists as dead code: `humanizeTs()`
@@ -141,6 +210,9 @@ absolute dates); it may additionally show the relative age — see defaults belo
   or `HumanizeTs` gains a `mode="absolute"` prop so the tooltip/i18n-resubscribe behavior stays
   shared. Prefer the prop — one canonical component, two declared modes, matching the principle
   one-to-one.
+- Operational times: the scheduled pill in `DeployTaskHeader.tsx` swaps `HumanizeTs` for the
+  absolute string; the three bare-format expiration call sites converge on
+  `formatAbsoluteDateTime` (default 6).
 - Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
   `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
@@ -154,6 +226,9 @@ absolute dates); it may additionally show the relative age — see defaults belo
 - No user or workspace preference (revisit only if a customer asks for the opposite default —
   GitLab's model is the known shape for that).
 - No backend or proto change.
+- The time *pickers* (schedule rollout, expiration inputs — `datetime-local` fields writing browser
+  local time): BYT-10023's input side. Deferred to its own design; the docs-side fix already landed
+  in bytebase.com#125.
 
 ## Customer outcome check
 
@@ -174,3 +249,9 @@ absolute dates); it may additionally show the relative age — see defaults belo
    relative age instead (inverse tooltip).
 3. Release list classified as work queue (switch), not history.
 4. Comment/activity timelines classified as feed (switch) even on closed issues.
+5. Scheduled rollout pill shows the full `formatAbsoluteDateTime` string inline (wide, but the
+   pill only appears while a schedule is pending). Alternative: date + hh:mm + tz, seconds in
+   tooltip.
+6. The three bare-format expiration displays (masking exemption, role-grant details, member
+   preview) are normalized to `formatAbsoluteDateTime` in this effort. Alternative: file as
+   follow-up cleanup.

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -98,8 +98,14 @@ date-time always**, consistent with the audit log. They are records of execution
 
 **D5 (proposed) — Operational times: absolute with explicit timezone, minute precision.**
 Scheduled rollout times and expirations render the absolute date-time with the short timezone name
-in the visible string, not just the tooltip: "Sep 15, 2026, 9:00 AM GMT+8". No seconds — the
-pickers write minute precision, so a seconds field would always read ":00". Driven by BYT-10023 —
+in the visible string, not just the tooltip: "Sep 15, 2026, 9:00 AM GMT+8". Precision caveat:
+minute-granular input covers only the `datetime-local` pickers. Day/second-count presets write
+`now() + offset` with real sub-minute tails (`computeExpirationTimestamp` in `MembersPage.tsx`,
+the SQL-editor access-grant drawer), so a minute display floors the enforced cutoff by up to 59
+seconds — in the safe direction: the value never expires earlier than displayed, and the full
+value stays in the tooltip (D6). Accepting D5 means accepting that bounded under-report;
+alternatives are retaining seconds for expiration values, or normalizing preset writes to the
+minute (a write-path change, out of scope for this display-only design). Driven by BYT-10023 —
 see Operational times below. Proposed, pending confirmation; the time *pickers* that write these
 values are explicitly deferred.
 
@@ -285,8 +291,11 @@ D6 (full date-time tooltip on every reduced display). Still open:
 1. **D7 tier assignment/format** — compact (date + hh:mm) vs full for the embedded history lists.
    Mockups of both options exist for the changelog table and the 704px task-run sheet;
    recommendation is compact per the orient/testify principle.
-2. **D5 precision refinement** — operational times at minute precision (no seconds), since the
-   pickers write minutes. Alternative: full seconds for uniformity with the full history tier.
+2. **D5 precision refinement** — operational times at minute precision (no seconds). Pickers
+   write minutes, but day/second-count presets write `now() + offset` with sub-minute tails, so
+   minute display floors the enforced cutoff by ≤59s (safe direction; full value in the tooltip).
+   Alternatives: full seconds for expiration values, or normalizing preset writes to the minute
+   (write-path change, out of scope here).
 3. Scheduled rollout pill shows the operational format inline ("Sep 15, 2026, 9:00 AM GMT+8");
    relative age moves to the tooltip.
 4. The three bare-format expiration displays (masking exemption, role-grant details, member

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -11,11 +11,14 @@ schedule and expiration pickers) is explicitly out of scope for now.
 
 ## Problem
 
-Every timestamp outside the audit log renders through the shared `HumanizeTs` component
-(`frontend/src/components/HumanizeTs.tsx`), which is **relative-forever**: "45 seconds ago" → "12
+The product's canonical timestamp component, `HumanizeTs`
+(`frontend/src/components/HumanizeTs.tsx`), is **relative-forever**: "45 seconds ago" → "12
 minutes ago" → "7 hours ago" → "N days ago" with no upper cap. A year-old issue reads "365 days
-ago". The absolute time exists only in a hover tooltip, recoverable one row at a time. The audit
-log is the sole exception — it renders absolute date-time always.
+ago". The absolute time exists only in a hover tooltip, recoverable one row at a time. It backs
+the issue list, the plan list, and a dozen other surfaces. The rest of the product is a patchwork
+rather than a counter-model: the audit log and a few detail views render full absolute date-times,
+while several surfaces hand-roll fixed, non-locale strings — the inventories below map every call
+site.
 
 For someone reviewing historical tickets, relative wording past a certain age carries no usable
 information: it cannot be correlated with an incident window, a changelog entry, or an external
@@ -142,6 +145,7 @@ Every current `HumanizeTs` call site, classified under the principle:
 | Schema sync status | `modules/sql-editor/components/SchemaPane/SyncSchemaButton.tsx`, `routes/project/ProjectSyncSchemaPage.tsx`, `components/database/DatabaseOverviewInfo.tsx` | Freshness | 30d switch |
 | Agent chat | `modules/agent/components/AgentWindow.tsx` | Feed | 30d switch |
 | Plan-check run time | `components/plan-check/PlanCheckSection.tsx` (bare `toLocaleString()` today — adopts `HumanizeTs`) | Freshness | 30d switch |
+| Access-grant creation time | `routes/project/ProjectAccessGrantsPage.tsx` (`AccessGrantRow`; full absolute today — adopts `HumanizeTs`). Creation meta on a management roster; the grant's operational fact is its *expiration*, which stays operational mode | Work queue / meta | 30d switch |
 | **Database changelog** | `routes/project/database-detail/changelog/DatabaseChangelogTable.tsx` | **History view** | **Absolute always — compact tier (D7)** |
 | **Database revisions** | `routes/project/database-detail/revision/DatabaseRevisionTable.tsx` | **History view** | **Absolute always — compact tier (D7)** |
 | **Task-run history** | `routes/project/plan-detail/components/deploy/DeployTaskRunHistorySheet.tsx`, `routes/project/issue-detail/components/IssueDetailTaskRunTable.tsx` | **History view** | **Absolute always — compact tier (D7)** |

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -247,10 +247,13 @@ tooltip.
   shared: `mode="datetime"` (full, existing `formatAbsoluteDateTime`) and `mode="compact"` (a new
   `formatCompactDateTime` helper in `datetime.ts` — date + hh:mm, locale-aware). One canonical
   component, modes matching the principle one-to-one; the audit log can keep its direct call.
-- Operational times: the scheduled pill in `DeployTaskHeader.tsx` swaps `HumanizeTs` for the
-  operational string; the three bare-format expiration call sites converge on
-  `formatOperationalDateTime` (open item 4). The six expiration surfaces already on
-  `formatAbsoluteDateTime` move to the same helper, dropping their always-`:00` seconds.
+- Operational times render through the shared component, never as bare strings: `HumanizeTs` gains
+  `mode="operational"` (`formatOperationalDateTime` in the cell, D6 tooltip carrying the full
+  enforced value with seconds). The scheduled pill in `DeployTaskHeader.tsx` switches mode rather
+  than dropping the component — its tooltip survives; the three bare-format expiration call sites
+  and the six already-absolute ones adopt the same mode (open item 4), which is what makes the
+  sub-minute preset tails recoverable. **Invariant: a reduced timestamp without a full-precision
+  tooltip is a bug** — bare formatter calls are reserved for full-precision strings and exports.
 - Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
   `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
@@ -260,6 +263,9 @@ tooltip.
 ## What does not change
 
 - The audit log (already correct).
+- Duration display (`humanizeDurationV1` — elapsed times like "4.2s" on task runs and query
+  results). Durations are elapsed quantities, not timestamps: they carry no calendar, timezone, or
+  precision question, so this design leaves them untouched.
 - Relative wording under 30 days.
 - No user or workspace preference (revisit only if a customer asks for the opposite default —
   GitLab's model is the known shape for that).

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -139,6 +139,7 @@ Every current `HumanizeTs` call site, classified under the principle:
 | **Scheduled rollout pill** | `DeployTaskHeader.tsx` (task pinned to a run time) | **Operational** | **Absolute + timezone** |
 | Schema sync status | `modules/sql-editor/components/SchemaPane/SyncSchemaButton.tsx`, `routes/project/ProjectSyncSchemaPage.tsx`, `components/database/DatabaseOverviewInfo.tsx` | Freshness | 30d switch |
 | Agent chat | `modules/agent/components/AgentWindow.tsx` | Feed | 30d switch |
+| Plan-check run time | `components/plan-check/PlanCheckSection.tsx` (bare `toLocaleString()` today — adopts `HumanizeTs`) | Freshness | 30d switch |
 | **Database changelog** | `routes/project/database-detail/changelog/DatabaseChangelogTable.tsx` | **History view** | **Absolute always — compact tier (D7)** |
 | **Database revisions** | `routes/project/database-detail/revision/DatabaseRevisionTable.tsx` | **History view** | **Absolute always — compact tier (D7)** |
 | **Task-run history** | `routes/project/plan-detail/components/deploy/DeployTaskRunHistorySheet.tsx`, `routes/project/issue-detail/components/IssueDetailTaskRunTable.tsx` | **History view** | **Absolute always — compact tier (D7)** |
@@ -184,8 +185,9 @@ For reference, absolute timestamps already appear in the product in three incons
    (`YYYY-MM-DD HH:mm:ss` — `titleOfQueryHistory` in `HistoryPane.tsx`, plus an independently
    built deep-link tab title in `SQLEditorRouteShell.tsx`), and embedded release metadata
    (`components/release/ReleaseInfoCard.tsx`, `YYYY-MM-DD HH:mm:ss`).
-3. **Ad-hoc `toLocaleDateString`** with hour/minute — no seconds, no timezone: the members-page
-   expiration preview.
+3. **Ad-hoc `toLocale*`** — the members-page expiration preview (`toLocaleDateString` with
+   hour/minute — no seconds, no timezone) and the plan-check run time (bare `toLocaleString()` in
+   `PlanCheckSection.tsx` — locale default, no tooltip).
 
 Two half-built versions of this design already exist as dead code: the unused `humanizeTs()`
 30-day switch in `utils/util.ts`, and the never-passed `format="absolute"` branch of the date cell
@@ -280,6 +282,20 @@ tooltip.
 - Duration display (`humanizeDurationV1` — elapsed times like "4.2s" on task runs and query
   results). Durations are elapsed quantities, not timestamps: they carry no calendar, timezone, or
   precision question, so this design leaves them untouched.
+- Four further classes of date-formatting call sites are out of scope by kind, closing the
+  inventory — every `dayjs`/`Intl`/`toLocale*` call site under `frontend/src` now has a
+  disposition in this doc (a display class, a corollary context, or one of these):
+  - **SQL result cell values** (`utils/v1/sql.ts`): rendering of the database's own timestamp
+    data, with microsecond precision and stored offsets — data fidelity, never subject to UI
+    display tiers.
+  - **Generated content embedding times**: issue titles (`utils/v1/issue/issue.ts` — already
+    carries a UTC offset) and CEL request descriptions (`utils/issue/cel.ts`) are written into
+    resources at creation; reformatting them is a data change, not a display change.
+  - **Export/download filenames** (`DataExportButton.tsx`, SQL-editor result exports,
+    `SubscriptionPage.tsx`): filesystem-safe fixed format.
+  - **Picker value echoes and API wire strings**: `date-time-picker`, `TimeRangePicker`,
+    `expiration-picker` render the input's own value (deferred with the pickers);
+    `stores/app/issue.ts`/`plan.ts` and the audit-log filter emit ISO strings to the API.
 - Relative wording under 30 days.
 - No user or workspace preference (revisit only if a customer asks for the opposite default —
   GitLab's model is the known shape for that).

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -154,11 +154,11 @@ Where operational times are displayed today:
 | Surface | File | Today | Gap |
 |---|---|---|---|
 | Scheduled rollout pill | `routes/project/plan-detail/components/deploy/DeployTaskHeader.tsx` (task pinned to a run time) | `HumanizeTs` — relative ("in 7 hours"), tz only in tooltip | **The BYT-10023 display gap**: the one surface showing when a rollout will fire hides the timezone question entirely |
-| Task-run waiting message | `frontend/src/lib/taskRun.ts` ("enqueued, will run at …") | `formatAbsoluteDateTime` | None — already absolute + tz |
+| Task-run waiting message | `frontend/src/lib/taskRun.ts` ("enqueued, will run at …") | `formatAbsoluteDateTime` | None — already absolute + tz (seconds drop under D5's minute precision) |
 | Masking exemption expiration | `routes/project/ProjectMaskingExemptionPage.tsx` | dayjs `YYYY-MM-DD HH:mm` | No timezone, no seconds, not locale-aware |
 | Role-grant expiration detail | `routes/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx` | dayjs `LLL` | No timezone |
 | Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute | No timezone, no seconds |
-| Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None — already absolute + tz |
+| Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None — already absolute + tz (seconds drop under D5's minute precision) |
 
 Fixes under D5: the scheduled pill and the three bare-format expirations converge on the
 operational format — absolute date-time + timezone at minute precision ("Sep 15, 2026, 9:00 AM
@@ -223,10 +223,13 @@ their list views render relative. D4 makes each list agree with its own detail v
 - **Compact** = date + hh:mm, locale-aware: "Aug 26, 2026, 2:03 PM" / zh "2026年8月26日 14:03"
   (~21 characters). Seconds and timezone stay one hover away per D6.
 
-**Operational times** (scheduled rollouts, expirations): `formatAbsoluteDateTime`, with the
-timezone in the visible string — not only in the tooltip, because the reader is about to act on
-the value and must not have to discover that a timezone question exists. Relative age ("in 7
-hours") may accompany it in the tooltip.
+**Operational times** (scheduled rollouts, expirations): a new `formatOperationalDateTime` helper
+in `datetime.ts` — date + hh:mm + short timezone, locale-aware: "Sep 15, 2026, 9:00 AM GMT+8" / zh
+"2026年9月15日 09:00 GMT+8". The timezone lives in the visible string — not only in the tooltip,
+because the reader is about to act on the value and must not have to discover that a timezone
+question exists. No seconds per D5 (`formatAbsoluteDateTime` is the alternative if D5's
+minute-precision refinement is rejected). Relative age ("in 7 hours") may accompany it in the
+tooltip.
 
 ## Implementation shape
 
@@ -239,8 +242,9 @@ hours") may accompany it in the tooltip.
   `formatCompactDateTime` helper in `datetime.ts` — date + hh:mm, locale-aware). One canonical
   component, modes matching the principle one-to-one; the audit log can keep its direct call.
 - Operational times: the scheduled pill in `DeployTaskHeader.tsx` swaps `HumanizeTs` for the
-  absolute string; the three bare-format expiration call sites converge on
-  `formatAbsoluteDateTime` (default 6).
+  operational string; the three bare-format expiration call sites converge on
+  `formatOperationalDateTime` (open item 4). The six expiration surfaces already on
+  `formatAbsoluteDateTime` move to the same helper, dropping their always-`:00` seconds.
 - Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
   `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
@@ -262,8 +266,12 @@ hours") may accompany it in the tooltip.
 
 - Historical tickets (> 30 days): issue list shows the real date — complaint resolved for genuinely
   old history.
-- Changelog / revisions / task-run history: full date-time with seconds by default — the
-  year-month-day-hour-minute-second ask fully satisfied on the record surfaces.
+- Changelog / revisions / task-run history: absolute date-time to the minute by default (compact
+  tier, D7); seconds and timezone one hover away (D6). Full seconds remain the default on the
+  evidence surfaces — the audit log and the changelog/revision detail views — so the
+  year-month-day-hour-minute-second ask is met to the minute on record lists and fully on record
+  details. If the customer pushes back specifically on visible seconds, the escalation is flipping
+  those lists to the full tier — a one-line D7 assignment change, no model change.
 - Queue rows 1–29 days old: still "x days ago" (D1/D3 trade-off, accepted because these are queue
   readings). **Risk**: if the reported "ticket history" reading includes *recent* issue-list rows,
   part of the complaint survives. Mitigation: tooltip; escalation path if it recurs is lowering the

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -165,6 +165,7 @@ Where operational times are displayed today:
 | Scheduled rollout pill | `routes/project/plan-detail/components/deploy/DeployTaskHeader.tsx` (task pinned to a run time) | `HumanizeTs` — relative ("in 7 hours"), tz only in tooltip | **The BYT-10023 display gap**: the one surface showing when a rollout will fire hides the timezone question entirely |
 | Task-run waiting message | `frontend/src/lib/taskRun.ts` ("enqueued, will run at …") | `formatAbsoluteDateTime` interpolated into a plain i18n string | None — a plain-string context cannot host a tooltip, so it keeps the full-precision form (invariant corollary below); seconds do **not** drop here |
 | SQL-editor access grant item, <24h remaining | `modules/sql-editor/components/AccessGrantItem.tsx` | Duration only ("expires in 3h20m"); the absolute value is discarded, no tooltip | Relative-only operational display — needs the D6 tooltip carrying the full absolute + timezone |
+| Access-grant expiration, issue detail | `routes/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx` (renders the helper's string in JSX) | `formatAbsoluteDateTime` via `getAccessGrantExpirationText` | None today. Under D5: JSX context — adopts the operational mode with its D6 tooltip |
 | Masking exemption expiration | `routes/project/ProjectMaskingExemptionPage.tsx` | dayjs `YYYY-MM-DD HH:mm` | No timezone, no seconds, not locale-aware |
 | Role-grant expiration detail | `routes/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx` | dayjs `LLL` | No timezone |
 | Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute, interpolated into `t("project.members.expires-at", …)` | No timezone, no seconds — and a plain-string context: gets the full-precision string per the corollary (a `Trans`-slot refactor is the alternative if minute display is wanted) |
@@ -275,7 +276,11 @@ tooltip.
   makes the sub-minute preset tails recoverable, while the member preset preview is itself
   i18n-interpolated and keeps a full-precision string per the corollary. Of the six
   already-absolute sites, the JSX-rendered ones adopt the mode; the string-interpolated ones
-  (subscription banner, sample-expiration alert) keep the full-precision string. **Invariant: a reduced timestamp without a full-precision
+  (subscription banner, sample-expiration alert) keep the full-precision string.
+  `getAccessGrantExpirationText` itself stays a full-precision string builder — its output also
+  lands in string concatenations — while its JSX consumers (`AccessGrantItem.tsx`,
+  `ProjectAccessGrantsPage.tsx`, `IssueDetailAccessGrantDetails.tsx`) render the shared component
+  in operational mode instead of the helper's string. **Invariant: a reduced timestamp without a full-precision
   tooltip is a bug** — bare formatter calls are reserved for full-precision strings and exports.
   Corollary: a plain-string context that cannot host a tooltip — the i18n-interpolated task-run
   waiting message, exports, document titles — must embed the full-precision string, never the

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -300,8 +300,11 @@ tooltip.
   sub-minute granularity (the "now" and seconds buckets), dropping to a coarse ~30–60s tick once
   every subscriber is in minute-or-older buckets; a subscriber re-renders only when its formatted
   output actually changes. This matches GitHub's `relative-time` element, which schedules its own
-  updates at the next boundary.
-  Absolute modes (compact/datetime/operational) never change with time and skip the subscription.
+  updates at the next boundary. The dividing line is time-variance, not mode: absolute labels
+  (compact/datetime/operational) never change with time and skip the subscription, while every
+  time-varying display subscribes — the relative buckets, and countdown/status consumers such as
+  the SQL-editor access-grant item, whose remaining duration, 24-hour display transition, and
+  expired state otherwise go stale on a long-mounted editor.
 - Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
   `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
@@ -310,8 +313,9 @@ tooltip.
   the operational contract — a component test using an expiration with a sub-minute tail
   (e.g. 9:00:47) asserting the visible label renders minute + timezone and the tooltip carries the
   full seconds + timezone, plus the countdown carve-out (a <24h grant renders the remaining
-  duration with that same full tooltip), and a fake-timer test advancing a mounted component
-  across a relative bucket boundary and across the 30-day cutoff.
+  duration with that same full tooltip), a fake-timer test advancing a mounted component across a
+  relative bucket boundary and across the 30-day cutoff, and a fake-timer transition test for the
+  access-grant countdown (duration ticks → 24-hour display boundary → expired state).
 
 ## What does not change
 

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -295,23 +295,14 @@ tooltip.
   operational display and adopts the same tooltip treatment as the pill.
 - Staleness: `HumanizeTs` evaluates `Date.now()` only during render, so a long-mounted page shows
   "5 minutes ago" indefinitely and a row can sit on the wrong side of the 30-day cutoff until an
-  unrelated render. With buckets formalized, the component subscribes to one shared module-level
-  clock with adaptive cadence: second-level ticks while any subscriber's label still changes at
-  sub-minute granularity (the "now" and seconds buckets), dropping to a coarse ~30–60s tick once
-  every subscriber is in minute-or-older buckets; a subscriber re-renders only when its formatted
-  output actually changes. This matches GitHub's `relative-time` element, which schedules its own
-  updates at the next boundary. The dividing line is time-variance, not mode: absolute labels
-  (compact/datetime/operational) never change with time and skip the subscription, while every
-  time-varying display subscribes — the relative buckets, and every countdown/status consumer
-  that derives `isExpired`/remaining-time state from render-time `Date.now()`: the SQL-editor
-  access-grant item (duration, 24-hour display transition, expired state), the masking exemption
-  rows (`ExemptionGrantSection`), `SampleExpirationAlert`, and the subscription banner's
-  time-dependent store selectors. Two components already run private timers for exactly this
-  (`PlanDetailMeta` at 60s, `DatabaseQueryContext` at 1s) and consolidate onto the shared clock
-  (`InactiveRemindModal`'s 1s timer is a session-idle mechanism, not a timestamp display — out of
-  scope). Implementation checklist: sweep render-time `Date.now()` in display components — every
-  hit either subscribes to the shared clock or records why it need not (e.g. values evaluated at
-  interaction time inside action panels).
+  unrelated render. Design requirement: **no time-varying display may go stale while mounted** —
+  relative buckets, countdowns, and `isExpired`/remaining-state derivations must track the
+  passage of time, and displays that never change with time must not pay for a refresh
+  subscription. The mechanism (a shared clock, its cadence, which components subscribe —
+  including consolidating the ad-hoc per-component timers that already exist) is the
+  implementation PR's design space, guarded there by a sweep of render-time `Date.now()` in
+  display components and fake-timer tests. GitHub's `relative-time` element, which schedules its
+  own updates at the next boundary, is the reference behavior.
 - Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
   relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
   `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
@@ -320,11 +311,9 @@ tooltip.
   the operational contract — a component test using an expiration with a sub-minute tail
   (e.g. 9:00:47) asserting the visible label renders minute + timezone and the tooltip carries the
   full seconds + timezone, plus the countdown carve-out (a <24h grant renders the remaining
-  duration with that same full tooltip), a fake-timer test advancing a mounted component across a
-  relative bucket boundary and across the 30-day cutoff, a fake-timer transition test for the
-  access-grant countdown (duration ticks → 24-hour display boundary → expired state), and
-  fake-timer expiration-status flips for the masking exemption row, the sample-expiration alert,
-  and the subscription banner.
+  duration with that same full tooltip), and fake-timer staleness tests: a mounted component
+  crossing a relative bucket boundary and the 30-day cutoff, plus representative
+  countdown-to-expired transitions.
 
 ## What does not change
 

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -1,0 +1,176 @@
+# Timestamp display — work queues vs history views
+
+Relative timestamps ("x days ago") hide exactly the precision an audit reading needs
+([BYT-10140](https://linear.app/bytebase/issue/BYT-10140)). The rule this doc lands on: **a surface
+is either a work queue or a history view, and that classification decides its time display** — work
+queues get GitHub-style relative time with a 30-day cap, history views get absolute date-time
+always. Frontend display only; no backend, no API, no stored preference.
+
+## Problem
+
+Every timestamp outside the audit log renders through the shared `HumanizeTs` component
+(`frontend/src/components/HumanizeTs.tsx`), which is **relative-forever**: "45 seconds ago" → "12
+minutes ago" → "7 hours ago" → "N days ago" with no upper cap. A year-old issue reads "365 days
+ago". The absolute time exists only in a hover tooltip, recoverable one row at a time. The audit
+log is the sole exception — it renders absolute date-time always.
+
+For someone reviewing historical tickets, relative wording past a certain age carries no usable
+information: it cannot be correlated with an incident window, a changelog entry, or an external
+audit request.
+
+## Principle
+
+> **A surface is either a work queue or a history view, and that classification decides its time
+> display.**
+
+- **Work queue** — read to decide *what needs attention now*. The primary time question is
+  **freshness**. Display: GitHub-style relative time with a 30-day cap, then absolute date.
+- **History view** — read as a *record of what already happened*. The primary time question is
+  **exactly when**. Display: absolute date-time, always.
+
+Surfaces that are neither literally a queue nor a record (activity feeds, "created N ago" meta,
+sync freshness, agent chat) are freshness-first readings and follow the work-queue rendering.
+
+## Research — how other products display timestamps
+
+How to read this table: "Default display" is what a list row shows without interaction; "Switch" is
+any built-in age-based change of format; "Escape hatch" is how a user recovers the other form. Rows
+marked ✔ were verified against primary sources on 2026-08-26; unmarked rows are from product
+knowledge and worth spot-checking before citing externally.
+
+| Product / surface | Surface kind | Default display | Switch | Escape hatch | User setting |
+|---|---|---|---|---|---|
+| **GitHub** issues/PRs/commits ✔ | Work queue / feed | Relative ("3 days ago") | At **30 days** → absolute **date only** ("on Apr 1, 2014"; same-year drops the year) | Tooltip: full date-time | None |
+| **GitLab** ✔ | Work queue / feed | Relative everywhere | None | Tooltip | Per-user "Use relative times" (uncheck → absolute everywhere) + 12/24-hour format |
+| **Linear** issue list | Work queue | Compact relative ("3d") | None | Tooltip | None |
+| **Jira** issue views | Work queue | Relative for recent | Absolute for older items | Tooltip | None |
+| **Slack** messages | Feed | Contextual ("Today at 2:31 PM") | Older days show the date | Hover | 12/24-hour |
+| **Sentry** issue stream | Queue/feed | Relative age | None in stream; detail view is absolute | Detail page | None |
+| **Stripe Dashboard** payments | History / audit table | Absolute ("Jul 3, 2:35 PM") | — | — | None |
+| **AWS CloudTrail** | Audit log | Absolute, uniform column | — | — | UTC/local |
+| **Datadog** logs | Record/observability | Absolute (ms precision) | — | — | Timezone |
+
+**Pattern**: mature products do not pick one global convention — they pick **per reading mode**.
+Queues and feeds are relative (GitHub adds the 30-day age cap); records and audit tables are
+absolute, uniform, and column-scannable. GitLab is the outlier that solves it with a user
+preference — and its *default* is still relative, so an audit-reading user must discover the
+toggle. Our principle matches the industry split; we get both halves right by default instead of
+shipping a setting.
+
+Note the original request (absolute *always*, with seconds) is stronger than GitHub's pattern. The
+resolution below satisfies it on history views; on work queues it is intentionally traded for
+queue scanability (D1).
+
+## Decisions
+
+**D1 — Mechanism: GitHub-style age switch on queues, not absolute-always, not a preference.**
+The issue list is a work queue, and the plan list is becoming one. Freshness is the dominant
+question there, so relative time under a cap is correct. Rejected: absolute-always on queues (kills
+freshness reading); GitLab-style user preference (settings machinery, wrong default for whoever
+hasn't toggled); doing nothing (the complaint is real — "365 days ago" is information-free).
+
+**D2 — Absolute form after the switch: date only (GitHub parity).**
+"Jul 12, 2026"; same-year rows drop the year ("Jul 12"). Time-of-day stays in the tooltip.
+Prioritizes queue density; accepts that on queue surfaces the exact-to-the-second ask is met only
+via hover (it is met fully on history views, where that reading actually lives).
+
+**D3 — Threshold: 30 days (GitHub parity).**
+Matches GitHub exactly and matches the existing `RELATIVE_THRESHOLD_MS = 30d` constant.
+Consequence accepted: queue rows aged 1–29 days still read "x days ago". Rejected: 24-hour and
+7-day thresholds (would kill the complained-about string sooner, but diverge from the familiar
+GitHub behavior).
+
+**D4 — Scope: switch everywhere + history-view carve-out.**
+`HumanizeTs` itself gains the 30-day switch, so every freshness-first surface behaves GitHub-style.
+The history views — database changelog, revision table, task-run history — flip to **absolute
+date-time always**, consistent with the audit log. They are records of execution, not queues.
+
+## Surface classification
+
+Every current `HumanizeTs` call site, classified under the principle:
+
+| Surface | File | Class | New display |
+|---|---|---|---|
+| Issue list | `components/IssueTable.tsx` | Work queue | 30d switch |
+| Plan list | `routes/project/ProjectPlanDashboardPage.tsx` | Work queue | 30d switch |
+| Release list / detail meta | `routes/project/ProjectReleaseDashboardPage.tsx`, `ProjectReleaseDetailPage.tsx` | Work queue / meta | 30d switch |
+| Issue comments & activity | `components/issue-activity/IssueCommentActivity.tsx`, `routes/project/issue-detail/components/IssueDetailCommentList.tsx` | Feed | 30d switch |
+| Review timeline / rejection banner | `routes/project/plan-detail/components/review/ReviewActivityTimeline.tsx`, `ReviewRejectionBanner.tsx` | Feed | 30d switch |
+| Plan detail "created" | `routes/project/plan-detail/components/PlanDetailMeta.tsx` | Meta | 30d switch |
+| Deploy current status | `routes/project/plan-detail/components/deploy/DeployTaskHeader.tsx`, `DeployLatestTaskRunInfo.tsx` | Freshness | 30d switch |
+| Schema sync status | `modules/sql-editor/components/SchemaPane/SyncSchemaButton.tsx`, `routes/project/ProjectSyncSchemaPage.tsx`, `components/database/DatabaseOverviewInfo.tsx` | Freshness | 30d switch |
+| Agent chat | `modules/agent/components/AgentWindow.tsx` | Feed | 30d switch |
+| **Database changelog** | `routes/project/database-detail/changelog/DatabaseChangelogTable.tsx` | **History view** | **Absolute date-time always** |
+| **Database revisions** | `routes/project/database-detail/revision/DatabaseRevisionTable.tsx` | **History view** | **Absolute date-time always** |
+| **Task-run history** | `routes/project/plan-detail/components/deploy/DeployTaskRunHistorySheet.tsx`, `routes/project/issue-detail/components/IssueDetailTaskRunTable.tsx` | **History view** | **Absolute date-time always** |
+| Audit log | `components/AuditLogTable.tsx` | History view | Already absolute — unchanged |
+
+## Rendering specification
+
+**Work-queue / freshness surfaces** (via `HumanizeTs`, which gains the switch):
+
+| Row age | Rendered | Example (en) | Example (zh) |
+|---|---|---|---|
+| < 10 s | "now" | now | 现在 |
+| < 1 min | relative seconds | 45 seconds ago | 45秒钟前 |
+| < 1 h | relative minutes | 12 minutes ago | 12分钟前 |
+| < 24 h | relative hours | 7 hours ago | 7小时前 |
+| < 30 d | relative days | 6 days ago | 6天前 |
+| ≥ 30 d, same year | absolute date, no year | Jul 12 | 7月12日 |
+| ≥ 30 d, other year | absolute date with year | Jul 12, 2025 | 2025年7月12日 |
+
+- Tooltip (both forms, unchanged contract): full absolute date-time with seconds and timezone —
+  "Aug 26, 2026, 2:03:22 PM GMT+8" / zh "2026年8月26日 14:03:22 GMT+8".
+- Future timestamps mirror on |age| (`Intl.RelativeTimeFormat` already signs correctly; the ≥30d
+  branch shows the date).
+- All strings locale-aware via `Intl` with the active i18n locale — no hardcoded formats, no new
+  locale keys needed.
+
+**History views** (changelog, revisions, task-run history): absolute date-time always, using the
+audit log's exact format (`formatAbsoluteDateTime`): "Aug 26, 2026, 2:03:22 PM GMT+8" — seconds
+included, which is where the exact-time ask lands fully. Tooltip retained (GitHub also tooltips its
+absolute dates); it may additionally show the relative age — see defaults below.
+
+## Implementation shape
+
+- `HumanizeTs` adopts the switching behavior. The logic already exists as dead code: `humanizeTs()`
+  in `frontend/src/utils/util.ts` (30-day switch) + `RELATIVE_THRESHOLD_MS` and
+  `formatAbsoluteDate` in `frontend/src/utils/datetime.ts`. Consolidate into `datetime.ts`; delete
+  the dead `humanizeTs`/`humanizeDate` pair in `util.ts` / `utils/v1/common.ts`.
+- History views either call `formatAbsoluteDateTime` directly (as `AuditLogTable.tsx` does today)
+  or `HumanizeTs` gains a `mode="absolute"` prop so the tooltip/i18n-resubscribe behavior stays
+  shared. Prefer the prop — one canonical component, two declared modes, matching the principle
+  one-to-one.
+- Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
+  relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
+  `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
+  `ProjectPlanDashboardPage.test.tsx`, `DatabaseChangelogTable.test.tsx`, …). New behavior gets new
+  tests: threshold boundary (29d/31d), same-year vs cross-year, zh locale, history-view mode.
+
+## What does not change
+
+- The audit log (already correct).
+- Relative wording under 30 days.
+- No user or workspace preference (revisit only if a customer asks for the opposite default —
+  GitLab's model is the known shape for that).
+- No backend or proto change.
+
+## Customer outcome check
+
+- Historical tickets (> 30 days): issue list shows the real date — complaint resolved for genuinely
+  old history.
+- Changelog / revisions / task-run history: full date-time with seconds by default — the
+  year-month-day-hour-minute-second ask fully satisfied on the record surfaces.
+- Queue rows 1–29 days old: still "x days ago" (D1/D3 trade-off, accepted because these are queue
+  readings). **Risk**: if the reported "ticket history" reading includes *recent* issue-list rows,
+  part of the complaint survives. Mitigation: tooltip; escalation path if it recurs is lowering the
+  threshold (D3) or a GitLab-style preference (D1 rejected-for-now).
+
+## Defaults awaiting veto
+
+1. History-view cells keep the timezone suffix ("GMT+8"), matching the audit log. Alternative: move
+   tz to tooltip for density.
+2. Tooltip on absolute cells shows the full date-time (GitHub parity). Alternative: show the
+   relative age instead (inverse tooltip).
+3. Release list classified as work queue (switch), not history.
+4. Comment/activity timelines classified as feed (switch) even on closed issues.

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -100,25 +100,22 @@ The history views — database changelog, revision table, task-run history — f
 date-time always**, consistent with the audit log. They are records of execution, not queues.
 
 **D5 (proposed) — Operational times: absolute with explicit timezone, minute precision.**
-Scheduled rollout times and expirations render the absolute date-time with the short timezone name
-in the visible string, not just the tooltip: "Sep 15, 2026, 9:00 AM GMT+8". Precision caveat:
-minute-granular input covers only the `datetime-local` pickers. Day/second-count presets write
-`now() + offset` with real sub-minute tails (`computeExpirationTimestamp` in `MembersPage.tsx`,
-the SQL-editor access-grant drawer), so a minute display floors the enforced cutoff by up to 59
-seconds — in the safe direction: the value never expires earlier than displayed, and the full
-value stays in the tooltip (D6). Accepting D5 means accepting that bounded under-report;
-alternatives are retaining seconds for expiration values, or normalizing preset writes to the
-minute (a write-path change, out of scope for this display-only design). Scope note: the rule targets **wall-clock renderings** — the timezone trap it guards against
-cannot occur in a pure remaining-duration display ("expires in 3h20m"), which is
-timezone-unambiguous by construction and stays permitted for short horizons, provided the D6
-tooltip carries the full absolute + timezone. Driven by BYT-10023 — see Operational times below.
-Proposed, pending confirmation; the time *pickers* that write these values are explicitly
-deferred.
+Wall-clock renderings of scheduled rollouts and expirations show the absolute date-time with the
+short timezone name in the visible string: "Sep 15, 2026, 9:00 AM GMT+8". Two refinements from
+review: (a) preset-written expirations (`now() + N days`) carry real sub-minute tails, so a
+minute display floors the enforced cutoff by ≤59s — in the safe direction, exact value in the D6
+tooltip; alternatives are keeping seconds for expirations or normalizing preset writes (a
+write-path change, out of scope). (b) The rule targets wall-clock strings only — a pure countdown
+("expires in 3h20m") cannot be misread across timezones and stays permitted with the D6 tooltip.
+Driven by BYT-10023 — see Operational times below. Proposed, pending confirmation; the pickers
+that write these values are deferred.
 
 **D6 — Full date-time tooltip on every reduced display.**
 Any timestamp that does not show the full form — relative, date-only after the switch, or the
 compact history tier — carries the full absolute date-time with seconds and timezone in its
-tooltip. This is the universal escape hatch that keeps every reduced cell recoverable.
+tooltip. This is the universal escape hatch that keeps every reduced cell recoverable. Corollary:
+a context that cannot host a tooltip — i18n-interpolated strings, exports, titles — carries the
+full-precision string itself.
 
 **D7 (proposed) — History views carry two precision tiers.**
 *A history row orients; a history record testifies.* Full precision (seconds + timezone,
@@ -170,13 +167,13 @@ Where operational times are displayed today:
 | Surface | File | Today | Gap |
 |---|---|---|---|
 | Scheduled rollout pill | `routes/project/plan-detail/components/deploy/DeployTaskHeader.tsx` (task pinned to a run time) | `HumanizeTs` — relative ("in 7 hours"), tz only in tooltip | **The BYT-10023 display gap**: the one surface showing when a rollout will fire hides the timezone question entirely |
-| Task-run waiting message | `frontend/src/lib/taskRun.ts` ("enqueued, will run at …") | `formatAbsoluteDateTime` interpolated into a plain i18n string | None — a plain-string context cannot host a tooltip, so it keeps the full-precision form (invariant corollary below); seconds do **not** drop here |
-| SQL-editor access grant item, <24h remaining | `modules/sql-editor/components/AccessGrantItem.tsx` | Duration only ("expires in 3h20m"); the absolute value is discarded, no tooltip | The visible duration is permitted under D5's wall-clock scope note (a countdown is timezone-unambiguous); the gap is the missing D6 tooltip with the full absolute + timezone |
-| Access-grant expiration, issue detail | `routes/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx` (renders the helper's string in JSX) | `formatAbsoluteDateTime` via `getAccessGrantExpirationText` | None today. Under D5: JSX context — adopts the operational mode with its D6 tooltip |
+| Task-run waiting message | `frontend/src/lib/taskRun.ts` ("enqueued, will run at …") | `formatAbsoluteDateTime` in an i18n string | None — plain-string context, keeps full precision (D6 corollary) |
+| SQL-editor access grant item, <24h remaining | `modules/sql-editor/components/AccessGrantItem.tsx` | Duration only ("expires in 3h20m"), no tooltip | Countdown stays (D5 scope note); add the D6 tooltip |
+| Access-grant expiration, issue detail | `routes/project/issue-detail/components/IssueDetailAccessGrantDetails.tsx` | `formatAbsoluteDateTime` via `getAccessGrantExpirationText`, in JSX | None today; adopts operational mode under D5 |
 | Masking exemption expiration | `routes/project/ProjectMaskingExemptionPage.tsx` | dayjs `YYYY-MM-DD HH:mm` | No timezone, no seconds, not locale-aware |
 | Role-grant expiration detail | `routes/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx` | dayjs `LLL` | No timezone |
-| Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute, interpolated into `t("project.members.expires-at", …)` | No timezone, no seconds — and a plain-string context: gets the full-precision string per the corollary (a `Trans`-slot refactor is the alternative if minute display is wanted) |
-| Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None today. Under D5, the JSX-rendered sites adopt the operational mode; the string-interpolated ones (subscription banner via `BannersWrapper.tsx`, `SampleExpirationAlert.tsx`) keep full precision — plain-string corollary |
+| Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute in an i18n string | No tz/seconds; plain-string context → full-precision string (D6 corollary) |
+| Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None today; under D5, JSX sites adopt operational mode, string-interpolated ones (banner, sample alert) keep full precision (D6 corollary) |
 
 Fixes under D5: the scheduled pill, the masking exemption expiration, and the role-grant
 expiration converge on the operational format — absolute date-time + timezone at minute precision
@@ -247,101 +244,51 @@ their list views render relative. D4 makes each list agree with its own detail v
 - **Compact** = date + hh:mm, locale-aware: "Aug 26, 2026, 2:03 PM" / zh "2026年8月26日 14:03"
   (~21 characters). Seconds and timezone stay one hover away per D6.
 
-**Task-run log entries** (`components/task-run-log/model.ts::formatTime` — `HH:mm:ss.SSS`,
-embedded in changelog detail and task-run views) keep their time-only millisecond format: log
-lines are dense by design and the parent run header carries the full date. They are still reduced
-displays, so each entry gains the D6 tooltip with the full date-time — which also covers a run
-crossing midnight.
+**Task-run log entries** (`task-run-log/model.ts::formatTime`, `HH:mm:ss.SSS`): keep the dense
+time-only format — the parent run header carries the date — plus the D6 tooltip with the full
+date-time (which also covers a run crossing midnight).
 
-**Operational times** (scheduled rollouts, expirations): a new `formatOperationalDateTime` helper
-in `datetime.ts` — date + hh:mm + short timezone, locale-aware: "Sep 15, 2026, 9:00 AM GMT+8" / zh
-"2026年9月15日 09:00 GMT+8". The timezone lives in the visible string — not only in the tooltip,
-because the reader is about to act on the value and must not have to discover that a timezone
-question exists. No seconds per D5 (`formatAbsoluteDateTime` is the alternative if D5's
-minute-precision refinement is rejected). Relative age ("in 7 hours") may accompany it in the
-tooltip.
+**Operational times** (scheduled rollouts, expirations): `formatOperationalDateTime` — date +
+hh:mm + short timezone, locale-aware: "Sep 15, 2026, 9:00 AM GMT+8" / zh "2026年9月15日 09:00
+GMT+8". The timezone lives in the visible string because the reader is about to act on the value;
+no seconds per D5. Relative age may accompany it in the tooltip.
 
 ## Implementation shape
 
-- `HumanizeTs` adopts the switching behavior. The logic already exists as dead code: `humanizeTs()`
-  in `frontend/src/utils/util.ts` (30-day switch) + `RELATIVE_THRESHOLD_MS` and
-  `formatAbsoluteDate` in `frontend/src/utils/datetime.ts`. Consolidate into `datetime.ts`; delete
-  the dead `humanizeTs`/`humanizeDate` pair in `util.ts` / `utils/v1/common.ts`.
-- History views use a `mode` prop on `HumanizeTs` so the tooltip/i18n-resubscribe behavior stays
-  shared: `mode="datetime"` (full, existing `formatAbsoluteDateTime`) and `mode="compact"` (a new
-  `formatCompactDateTime` helper in `datetime.ts` — date + hh:mm, locale-aware). One canonical
-  component, modes matching the principle one-to-one; the audit log can keep its direct call.
-  `titleOfQueryHistory` in `HistoryPane.tsx` splits: the row display adopts the compact mode with
-  its D6 tooltip, while both tab-title paths — `titleOfQueryHistory` and the independently built
-  deep-link title in `SQLEditorRouteShell.tsx` — keep a full-precision string (plain-string
-  corollary). `ReleaseInfoCard.tsx` swaps its fixed string for `HumanizeTs` (queue mode).
-- Operational times render through the shared component, never as bare strings: `HumanizeTs` gains
-  `mode="operational"` (`formatOperationalDateTime` in the cell, D6 tooltip carrying the full
-  enforced value with seconds). The scheduled pill in `DeployTaskHeader.tsx` switches mode rather
-  than dropping the component — its tooltip survives; of the three bare-format expiration call
-  sites, masking exemption and role-grant details adopt the same mode (open item 4), which is what
-  makes the sub-minute preset tails recoverable, while the member preset preview is itself
-  i18n-interpolated and keeps a full-precision string per the corollary. Of the six
-  already-absolute sites, the JSX-rendered ones adopt the mode; the string-interpolated ones
-  (subscription banner, sample-expiration alert) keep the full-precision string.
-  `getAccessGrantExpirationText` itself stays a full-precision string builder — its output also
-  lands in string concatenations — while its JSX consumers (`AccessGrantItem.tsx`,
-  `ProjectAccessGrantsPage.tsx`, `IssueDetailAccessGrantDetails.tsx`) render the shared component
-  in operational mode instead of the helper's string. **Invariant: a reduced timestamp without a full-precision
-  tooltip is a bug** — bare formatter calls are reserved for full-precision strings and exports.
-  Corollary: a plain-string context that cannot host a tooltip — the i18n-interpolated task-run
-  waiting message, exports, document titles — must embed the full-precision string, never the
-  reduced one. The SQL-editor access grant item's <24h branch ("expires in 3h20m") is a relative
-  operational display and adopts the same tooltip treatment as the pill.
-- Staleness: `HumanizeTs` evaluates `Date.now()` only during render, so a long-mounted page shows
-  "5 minutes ago" indefinitely and a row can sit on the wrong side of the 30-day cutoff until an
-  unrelated render. Design requirement: **no time-varying display may go stale while mounted** —
-  relative buckets, countdowns, and `isExpired`/remaining-state derivations must track the
-  passage of time, and displays that never change with time must not pay for a refresh
-  subscription. The mechanism (a shared clock, its cadence, which components subscribe —
-  including consolidating the ad-hoc per-component timers that already exist) is the
-  implementation PR's design space, guarded there by a sweep of render-time `Date.now()` in
-  display components and fake-timer tests. GitHub's `relative-time` element, which schedules its
-  own updates at the next boundary, is the reference behavior.
-- Tests: update `HumanizeTs.test.tsx` for the switch; sweep the `*.test.tsx` files that assert
-  relative strings (`PlanDetailMeta.test.tsx`, `SchemaPane.test.tsx`,
-  `DeployTaskRunHistorySheet.test.tsx`, `IssueCommentActivity.test.tsx`,
-  `ProjectPlanDashboardPage.test.tsx`, `DatabaseChangelogTable.test.tsx`, …). New behavior gets new
-  tests: threshold boundary (29d/31d), same-year vs cross-year, zh locale, history-view tiers, and
-  the operational contract — a component test using an expiration with a sub-minute tail
-  (e.g. 9:00:47) asserting the visible label renders minute + timezone and the tooltip carries the
-  full seconds + timezone, plus the countdown carve-out (a <24h grant renders the remaining
-  duration with that same full tooltip), and fake-timer staleness tests: a mounted component
-  crossing a relative bucket boundary and the 30-day cutoff, plus representative
-  countdown-to-expired transitions.
+- `HumanizeTs` gains the 30-day switch (the logic exists as dead code — `humanizeTs()` in
+  `util.ts`, `RELATIVE_THRESHOLD_MS`/`formatAbsoluteDate` in `datetime.ts`; consolidate there,
+  delete the dead pair) plus three absolute modes, each with the D6 tooltip built in:
+  `compact` (new `formatCompactDateTime`), `datetime` (existing `formatAbsoluteDateTime`), and
+  `operational` (new `formatOperationalDateTime`).
+- Per-site work is the inventory tables above: each listed call site adopts its class's mode;
+  plain-string contexts keep full-precision strings per the D6 corollary. A helper that feeds
+  both JSX and string contexts stays a full-precision string builder — its JSX consumers render
+  the component instead.
+- Staleness: no time-varying display (relative buckets, countdowns, `isExpired` derivations) may
+  go stale while mounted; displays that never change with time pay nothing. The mechanism —
+  shared clock, cadence, subscribers, consolidating today's ad-hoc per-component timers — is the
+  implementation PR's design space, guarded by a render-time `Date.now()` sweep and fake-timer
+  tests. GitHub's `relative-time` element, which schedules updates at the next boundary, is the
+  reference behavior.
+- Tests: threshold boundary (29d/31d), year handling, zh locale, the three modes, the operational
+  label/tooltip contract on a sub-minute-tail expiration, the <24h countdown carve-out, and
+  fake-timer staleness; update the existing `*.test.tsx` files that assert relative strings.
 
 ## What does not change
 
 - The audit log (already correct).
-- Duration display (`humanizeDurationV1` — elapsed times like "4.2s" on task runs and query
-  results). Durations are elapsed quantities, not timestamps: they carry no calendar, timezone, or
-  precision question, so this design leaves them untouched.
-- Four further classes of date-formatting call sites are out of scope by kind, closing the
-  inventory — every `dayjs`/`Intl`/`toLocale*` call site under `frontend/src` now has a
-  disposition in this doc (a display class, a corollary context, or one of these):
-  - **SQL result cell values** (`utils/v1/sql.ts`): rendering of the database's own timestamp
-    data, with microsecond precision and stored offsets — data fidelity, never subject to UI
-    display tiers.
-  - **Generated content embedding times**: issue titles (`utils/v1/issue/issue.ts` — already
-    carries a UTC offset) and CEL request descriptions (`utils/issue/cel.ts`) are written into
-    resources at creation; reformatting them is a data change, not a display change.
-  - **Export/download filenames** (`DataExportButton.tsx`, SQL-editor result exports,
-    `SubscriptionPage.tsx`): filesystem-safe fixed format.
-  - **Picker value echoes and API wire strings**: `date-time-picker`, `TimeRangePicker`,
-    `expiration-picker` render the input's own value (deferred with the pickers);
-    `stores/app/issue.ts`/`plan.ts` and the audit-log filter emit ISO strings to the API.
+- Duration display (`humanizeDurationV1`, "4.2s"): durations are elapsed quantities with no
+  calendar or timezone question.
 - Relative wording under 30 days.
-- No user or workspace preference (revisit only if a customer asks for the opposite default —
-  GitLab's model is the known shape for that).
+- No user or workspace preference (GitLab's model is the known shape if a customer ever asks).
 - No backend or proto change.
-- The time *pickers* (schedule rollout, expiration inputs — `datetime-local` fields writing browser
-  local time): BYT-10023's input side. Deferred to its own design; the docs-side fix already landed
-  in bytebase.com#125.
+- The time *pickers*: BYT-10023's input side, deferred to its own design (docs-side fix already in
+  bytebase.com#125).
+- Out of scope by kind — with these, every `dayjs`/`Intl`/`toLocale*` call site under
+  `frontend/src` has a disposition in this doc: SQL result cell values (`utils/v1/sql.ts` — the
+  database's own data), generated content embedding times (issue titles, CEL descriptions —
+  reformatting them is a data change), export/download filenames, and picker value echoes / API
+  wire strings.
 
 ## Customer outcome check
 

--- a/docs/design/timestamp-display.md
+++ b/docs/design/timestamp-display.md
@@ -165,7 +165,7 @@ Where operational times are displayed today:
 | Masking exemption expiration | `routes/project/ProjectMaskingExemptionPage.tsx` | dayjs `YYYY-MM-DD HH:mm` | No timezone, no seconds, not locale-aware |
 | Role-grant expiration detail | `routes/project/issue-detail/components/IssueDetailRoleGrantDetails.tsx` | dayjs `LLL` | No timezone |
 | Member expiration preview | `routes/workspace/MembersPage.tsx` (`formatExpirationDate`) | `toLocaleDateString` + hour/minute | No timezone, no seconds |
-| Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None — already absolute + tz (seconds drop under D5's minute precision) |
+| Member expiration table, access grants, IAM remind dialog, sample expiration, subscription expiry | `MembersPage.tsx`, `ProjectAccessGrantsPage.tsx`, `utils/accessGrant.ts`, `IAMRemindDialog.tsx`, `SampleExpirationAlert.tsx`, `stores/app/workspace.ts` | `formatAbsoluteDateTime` | None today. Under D5, the JSX-rendered sites adopt the operational mode; the string-interpolated ones (subscription banner via `BannersWrapper.tsx`, `SampleExpirationAlert.tsx`) keep full precision — plain-string corollary |
 
 Fixes under D5: the scheduled pill and the three bare-format expirations converge on the
 operational format — absolute date-time + timezone at minute precision ("Sep 15, 2026, 9:00 AM
@@ -180,7 +180,8 @@ For reference, absolute timestamps already appear in the product in three incons
    expiration table, IAM remind dialog, sample-expiration alert, subscription expiry, task-run
    scheduled-time messages, SQL editor result panel, Monaco heartbeat, agent chat tooltip.
 2. **Fixed dayjs strings** — time but no timezone, not locale-aware: masking exemption
-   (`YYYY-MM-DD HH:mm`), role-grant details (`LLL`), SQL editor tab titles (`YYYY-MM-DD HH:mm:ss`).
+   (`YYYY-MM-DD HH:mm`), role-grant details (`LLL`), SQL editor query-history rows and tab titles
+   (`YYYY-MM-DD HH:mm:ss` via `titleOfQueryHistory` in `HistoryPane.tsx`).
 3. **Ad-hoc `toLocaleDateString`** with hour/minute — no seconds, no timezone: the members-page
    expiration preview.
 
@@ -224,6 +225,7 @@ their list views render relative. D4 makes each list agree with its own detail v
 | Database revision list | Full-width table | Compact |
 | Task-run history sheet | 704px sheet — the space-constrained case | Compact |
 | Issue-detail task-run table | Embedded table | Compact |
+| SQL editor query history rows (`HistoryPane.tsx`) | Narrow side-pane list; today a fixed non-locale `YYYY-MM-DD HH:mm:ss` | Compact |
 
 - **Full** = `formatAbsoluteDateTime`: "Aug 26, 2026, 2:03:22 PM GMT+8" / zh
   "2026年8月26日 14:03:22 GMT+8" (~30 characters).
@@ -248,12 +250,15 @@ tooltip.
   shared: `mode="datetime"` (full, existing `formatAbsoluteDateTime`) and `mode="compact"` (a new
   `formatCompactDateTime` helper in `datetime.ts` — date + hh:mm, locale-aware). One canonical
   component, modes matching the principle one-to-one; the audit log can keep its direct call.
+  `titleOfQueryHistory` in `HistoryPane.tsx` splits: the row display adopts the compact mode with
+  its D6 tooltip, while the tab title — a plain-string context — keeps a full-precision string.
 - Operational times render through the shared component, never as bare strings: `HumanizeTs` gains
   `mode="operational"` (`formatOperationalDateTime` in the cell, D6 tooltip carrying the full
   enforced value with seconds). The scheduled pill in `DeployTaskHeader.tsx` switches mode rather
   than dropping the component — its tooltip survives; the three bare-format expiration call sites
-  and the six already-absolute ones adopt the same mode (open item 4), which is what makes the
-  sub-minute preset tails recoverable. **Invariant: a reduced timestamp without a full-precision
+  and, of the six already-absolute ones, the JSX-rendered sites adopt the same mode (open item 4),
+  which is what makes the sub-minute preset tails recoverable. The string-interpolated sites
+  (subscription banner, sample-expiration alert) keep the full-precision string per the corollary. **Invariant: a reduced timestamp without a full-precision
   tooltip is a bug** — bare formatter calls are reserved for full-precision strings and exports.
   Corollary: a plain-string context that cannot host a tooltip — the i18n-interpolated task-run
   waiting message, exports, document titles — must embed the full-precision string, never the


### PR DESCRIPTION
Design doc only — no implementation. D1–D4 and D6 are decided; D5 and D7 (and the doc's "Open items awaiting ruling" section) are marked proposed — reviewer input welcome on those.

Resolves the display question behind [BYT-10140](https://linear.app/bytebase/issue/BYT-10140/issue-history-show-absolute-date-time-by-default-instead-of-x-days-ago) (relative "x days ago" hides exactly the precision an audit reading needs; the shared `HumanizeTs` component renders relative-forever on every surface except the audit log) and the display side of [BYT-10023](https://linear.app/bytebase/issue/BYT-10023/scheduled-rollout-neither-the-ui-nor-the-docs-state-which-timezone-the) (the scheduled-rollout time never states its timezone anywhere visible).

## The principle

**A surface is either a work queue or a history view, and that classification decides its time display.** Future-pointing times are a third kind.

- **Work queues** (issue list, plan list, release list, feeds, sync/meta): GitHub parity — relative under 30 days, then absolute date only ("Jul 12"; year added cross-year), full date-time in the tooltip. The switching logic already exists as dead code (`humanizeTs()` + `RELATIVE_THRESHOLD_MS`); the implementation is wiring it into `HumanizeTs`.
- **History views**: absolute always, in two precision tiers (D7): full seconds + timezone where the time is evidence — the audit log (its export must match the screen) and single-record detail views, which already render this today — and compact date + hh:mm on the scannable embedded lists (changelog, revisions, task-run history). *A history row orients; a history record testifies.*
- **Operational times** (scheduled rollouts, expirations): absolute with an **explicit timezone in the visible string**, minute precision — relative wording ("in 7 hours") hides that a timezone question even exists, which is how BYT-10023 nearly fired a production rollout seven hours early. Time *pickers* (the input side) are explicitly deferred.

Every reduced display — relative, date-only, or compact — carries the full date-time + timezone tooltip (D6).

## Why not the alternatives

- Absolute-always on queues kills the freshness reading a queue exists for.
- A GitLab-style user preference is settings machinery with a wrong default for whoever hasn't toggled it.
- GitHub-style *everywhere* leaves history views hover-per-row for exact times — the original complaint.

The research section surveys 9 products (GitHub and GitLab verified against primary sources; Linear, Jira, Slack, Sentry, Stripe, CloudTrail, Datadog from product knowledge): mature products consistently split by reading mode — queues/feeds relative, records/audit absolute — rather than picking one global convention.

The doc also inventories the three inconsistent absolute-time families already in the product (locale-aware w/ tz, fixed dayjs strings w/o tz, ad-hoc `toLocaleDateString`) and the two dead half-implementations of this exact design, and adds **Work Queue Surface** / **History View Surface** to the CONTEXT.md glossary.

## Testing

Doc-only change; no code paths affected. The doc's implementation section lists the test plan for the follow-up PR (threshold boundary, same-year vs cross-year, zh locale, history-view tiers, operational-time formats, plus the existing tests that assert relative strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)