### PR TITLE
feat(ai): use Gemini 3.7 Flash for SaaS

### DIFF
--- a/backend/api/v1/auth_service.go
+++ b/backend/api/v1/auth_service.go
@@ -1231,7 +1231,7 @@ func (*AuthService) getAdditionalWorkspaceSettings() []store.AdditionalSetting {
 				Provider: storepb.AISetting_GEMINI,
 				ApiKey:   geminiAPIKey,
 				Endpoint: "https://generativelanguage.googleapis.com/v1beta",
-				Model:    "gemini-2.5-pro",
+				Model:    "gemini-3.7-flash",
 			},
 		})
 	}


### PR DESCRIPTION
## Summary

Update newly provisioned Bytebase SaaS workspaces to use `gemini-3.7-flash` instead of `gemini-2.5-pro`.

## Testing

Not run per request.