### PR TITLE
chore: bump omni to the strict doris/starrocks parsers (BYT-10084/10085)

### DIFF
--- a/backend/plugin/db/starrocks/query.go
+++ b/backend/plugin/db/starrocks/query.go
@@ -121,13 +121,20 @@ func getStatementWithResultLimitInline(statement string, limitCount int) (string
 	case *ast.SetOpStmt:
 		return rewriteSetOpLimit(statement, stmt, limitCount)
 	case *ast.ParenSelect:
-		switch inner := stmt.Sel.(type) {
-		case *ast.SelectStmt:
-			return rewriteSelectLimit(statement, inner, limitCount)
-		case *ast.SetOpStmt:
-			return rewriteSetOpLimit(statement, inner, limitCount)
+		// The wrapper itself may carry the trailing clauses —
+		// (SELECT 1) LIMIT 900000 attaches the LIMIT to the ParenSelect,
+		// not the inner query — so the wrapper is where the cap applies.
+		if stmt.Limit != nil {
+			return rewriteExistingLimit(statement, stmt.Limit, limitCount)
 		}
-		return statement, nil
+		// No wrapper LIMIT: append one at the wrapper level, which covers
+		// any paren nesting depth — ((SELECT 1)) LIMIT n and
+		// (SELECT 1) ORDER BY 1 LIMIT n are engine-valid — instead of
+		// unwrapping and missing deeper layers.
+		if hasUnparsedTail(statement, stmt.Loc.End) {
+			return "", errors.New("statement has unparsed tail content")
+		}
+		return statement[:stmt.Loc.End] + fmt.Sprintf(" LIMIT %d", limitCount) + statement[stmt.Loc.End:], nil
 	default:
 		return statement, nil
 	}
@@ -169,26 +176,32 @@ func hasUnparsedTail(sql string, locEnd int) bool {
 	return false
 }
 
-func rewriteSelectLimit(sql string, stmt *ast.SelectStmt, limitCount int) (string, error) {
-	if stmt.Limit != nil {
-		limitLoc := literalLoc(stmt.Limit)
-		if limitLoc.Start < 0 {
-			return "", errors.New("cannot rewrite non-constant LIMIT expression")
-		}
+// rewriteExistingLimit caps an already-present LIMIT clause: keep it when it
+// is a constant no larger than limitCount, replace the count otherwise.
+func rewriteExistingLimit(sql string, limitNode ast.Node, limitCount int) (string, error) {
+	limitLoc := literalLoc(limitNode)
+	if limitLoc.Start < 0 {
+		return "", errors.New("cannot rewrite non-constant LIMIT expression")
+	}
 
-		if countStart, countEnd, ok := findCommaLimitCount(sql, limitLoc); ok {
-			existingCount, _ := strconv.Atoi(sql[countStart:countEnd])
-			if existingCount > 0 && existingCount <= limitCount {
-				return sql, nil
-			}
-			return sql[:countStart] + fmt.Sprintf("%d", limitCount) + sql[countEnd:], nil
-		}
-
-		existingLimit := extractLimitValue(stmt.Limit)
-		if existingLimit >= 0 && existingLimit <= limitCount {
+	if countStart, countEnd, ok := findCommaLimitCount(sql, limitLoc); ok {
+		existingCount, _ := strconv.Atoi(sql[countStart:countEnd])
+		if existingCount > 0 && existingCount <= limitCount {
 			return sql, nil
 		}
-		return sql[:limitLoc.Start] + fmt.Sprintf("%d", limitCount) + sql[limitLoc.End:], nil
+		return sql[:countStart] + fmt.Sprintf("%d", limitCount) + sql[countEnd:], nil
+	}
+
+	existingLimit := extractLimitValue(limitNode)
+	if existingLimit >= 0 && existingLimit <= limitCount {
+		return sql, nil
+	}
+	return sql[:limitLoc.Start] + fmt.Sprintf("%d", limitCount) + sql[limitLoc.End:], nil
+}
+
+func rewriteSelectLimit(sql string, stmt *ast.SelectStmt, limitCount int) (string, error) {
+	if stmt.Limit != nil {
+		return rewriteExistingLimit(sql, stmt.Limit, limitCount)
 	}
 
 	if stmt.Into != nil {
@@ -202,24 +215,7 @@ func rewriteSelectLimit(sql string, stmt *ast.SelectStmt, limitCount int) (strin
 
 func rewriteSetOpLimit(sql string, stmt *ast.SetOpStmt, limitCount int) (string, error) {
 	if stmt.Limit != nil {
-		limitLoc := literalLoc(stmt.Limit)
-		if limitLoc.Start < 0 {
-			return "", errors.New("cannot rewrite non-constant LIMIT expression")
-		}
-
-		if countStart, countEnd, ok := findCommaLimitCount(sql, limitLoc); ok {
-			existingCount, _ := strconv.Atoi(sql[countStart:countEnd])
-			if existingCount > 0 && existingCount <= limitCount {
-				return sql, nil
-			}
-			return sql[:countStart] + fmt.Sprintf("%d", limitCount) + sql[countEnd:], nil
-		}
-
-		existingLimit := extractLimitValue(stmt.Limit)
-		if existingLimit >= 0 && existingLimit <= limitCount {
-			return sql, nil
-		}
-		return sql[:limitLoc.Start] + fmt.Sprintf("%d", limitCount) + sql[limitLoc.End:], nil
+		return rewriteExistingLimit(sql, stmt.Limit, limitCount)
 	}
 	if hasUnparsedTail(sql, stmt.Loc.End) {
 		return "", errors.New("statement has unparsed tail content")

--- a/backend/plugin/db/starrocks/query_test.go
+++ b/backend/plugin/db/starrocks/query_test.go
@@ -223,6 +223,44 @@ func TestGetStatementWithResultLimit(t *testing.T) {
 			count: 10,
 			want:  "SELECT * FROM (SELECT * FROM person /* c */ LATERAL VIEW EXPLODE(ARRAY(30, 60)) tableName AS c_age) result LIMIT 10;",
 		},
+		// Parenthesized queries: the LIMIT lands on (or caps at) the wrapper,
+		// covering any nesting depth.
+		{
+			stmt:  "(SELECT * FROM t)",
+			count: 10,
+			want:  "(SELECT * FROM t) LIMIT 10",
+		},
+		{
+			stmt:  "((SELECT * FROM large_table))",
+			count: 10,
+			want:  "((SELECT * FROM large_table)) LIMIT 10",
+		},
+		{
+			stmt:  "(((SELECT * FROM t)))",
+			count: 10,
+			want:  "(((SELECT * FROM t))) LIMIT 10",
+		},
+		{
+			stmt:  "(SELECT * FROM t) ORDER BY 1",
+			count: 10,
+			want:  "(SELECT * FROM t) ORDER BY 1 LIMIT 10",
+		},
+		// The wrapper's own LIMIT is the one that caps.
+		{
+			stmt:  "(SELECT * FROM t) LIMIT 1000000",
+			count: 10,
+			want:  "(SELECT * FROM t) LIMIT 10",
+		},
+		{
+			stmt:  "(SELECT * FROM t) LIMIT 5",
+			count: 10,
+			want:  "(SELECT * FROM t) LIMIT 5",
+		},
+		{
+			stmt:  "((SELECT * FROM t)) ORDER BY 1 LIMIT 0,1000000",
+			count: 10,
+			want:  "((SELECT * FROM t)) ORDER BY 1 LIMIT 0,10",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/backend/plugin/parser/doris/query.go
+++ b/backend/plugin/parser/doris/query.go
@@ -94,9 +94,13 @@ func isReadOnlyAST(node ast.Node) bool {
 // legitimately wrap (SELECT family or DML). DDL inside EXPLAIN is rejected:
 // Doris only supports EXPLAIN on query and DML statements.
 func isExplainableInner(node ast.Node) bool {
-	switch node.(type) {
+	switch n := node.(type) {
 	case *ast.SelectStmt, *ast.SetOpStmt:
 		return true
+	case *ast.GroupedQuery:
+		// EXPLAIN (SELECT 1 LIMIT 1) LIMIT 2 — engine-verified accept;
+		// classify by the wrapped query.
+		return isExplainableInner(n.Query)
 	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt,
 		*ast.MergeStmt, *ast.TruncateTableStmt:
 		return true

--- a/backend/plugin/parser/doris/query.go
+++ b/backend/plugin/parser/doris/query.go
@@ -63,6 +63,10 @@ func isReadOnlyAST(node ast.Node) bool {
 	switch n := node.(type) {
 	case *ast.SelectStmt, *ast.SetOpStmt:
 		return true
+	case *ast.GroupedQuery:
+		// A repeated trailing clause group or a parenthesized WITH group —
+		// (SELECT 1 LIMIT 1) LIMIT 2 — wraps a query; classify by the query.
+		return isReadOnlyAST(n.Query)
 	case *ast.ShowStmt:
 		// Reject bare `SHOW` (Type is empty when the parser took the stub path
 		// without seeing a recognised variant keyword).

--- a/backend/plugin/parser/doris/query_span_fail_closed_test.go
+++ b/backend/plugin/parser/doris/query_span_fail_closed_test.go
@@ -1,0 +1,35 @@
+package doris
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestQuerySpanFailClosed pins the BYT-10085 contract at the bytebase layer:
+// a statement the parser cannot fully consume must FAIL the span extraction,
+// not return an empty span. Before strict parsing, "SELECT a FROM secret
+// xx yy" silently truncated to "SELECT a FROM secret" upstream and variants
+// with a junked FROM clause could yield zero AccessTables — masking and
+// table-level ACL checks then saw nothing to protect.
+func TestQuerySpanFailClosed(t *testing.T) {
+	a := require.New(t)
+	q := newQuerySpanExtractor("db1", base.GetQuerySpanContext{}, false)
+
+	_, err := q.getQuerySpan(context.Background(), "SELECT a FROM secret xx yy zz")
+	a.Error(err, "trailing junk must fail the span, not truncate silently")
+
+	// The newly accepted paren/grouped shapes still extract their reads.
+	span, err := q.getQuerySpan(context.Background(), "(SELECT a FROM secret) LIMIT 1")
+	a.NoError(err)
+	a.True(span.SourceColumns[base.ColumnResource{Database: "db1", Table: "secret"}],
+		"paren query must report its table read")
+
+	span, err = q.getQuerySpan(context.Background(), "(SELECT a FROM secret ORDER BY 1) ORDER BY 1")
+	a.NoError(err)
+	a.True(span.SourceColumns[base.ColumnResource{Database: "db1", Table: "secret"}],
+		"grouped query must report its table read")
+}

--- a/backend/plugin/parser/doris/query_test.go
+++ b/backend/plugin/parser/doris/query_test.go
@@ -171,6 +171,31 @@ func TestValidateQuery(t *testing.T) {
 			valid:       true,
 			description: "CONVERT and BINARY forms are read-only",
 		},
+		{
+			statement:   "(SELECT 1) LIMIT 1",
+			valid:       true,
+			description: "Parenthesized query with trailing LIMIT is read-only",
+		},
+		{
+			statement:   "(SELECT 1 LIMIT 1) LIMIT 2",
+			valid:       true,
+			description: "GroupedQuery wrapper (repeated clause groups) is read-only",
+		},
+		{
+			statement:   "SELECT 1 LIMIT 5 ORDER BY 1",
+			valid:       true,
+			description: "Engine-lenient clause order wraps in GroupedQuery, still read-only",
+		},
+		{
+			statement:   "(WITH c AS (SELECT 1) SELECT * FROM c)",
+			valid:       true,
+			description: "Parenthesized WITH group (CTE scope boundary) is read-only",
+		},
+		{
+			statement:   "SELECT 1 UNION (SELECT 2) LIMIT 5",
+			valid:       true,
+			description: "Set operation with parenthesized operand and trailing LIMIT is read-only",
+		},
 	}
 
 	for _, tc := range tests {
@@ -228,6 +253,13 @@ func TestValidateQuery(t *testing.T) {
 			// EXPLAIN over DDL is not a real read-only operation.
 			statement:   "EXPLAIN DROP TABLE t",
 			description: "EXPLAIN over DDL must be rejected",
+		},
+		{
+			// Strict parsing (BYT-10085): a valid prefix followed by junk no
+			// longer silently truncates — it is a syntax error. Before the
+			// fix this parsed as `SELECT a FROM t` and ran.
+			statement:   "SELECT a FROM t xx yy zz",
+			description: "Trailing junk after a valid prefix must be rejected",
 		},
 	}
 	for _, tc := range rejectCases {

--- a/backend/plugin/parser/doris/query_test.go
+++ b/backend/plugin/parser/doris/query_test.go
@@ -196,6 +196,16 @@ func TestValidateQuery(t *testing.T) {
 			valid:       true,
 			description: "Set operation with parenthesized operand and trailing LIMIT is read-only",
 		},
+		{
+			statement:   "EXPLAIN (SELECT 1)",
+			valid:       true,
+			description: "EXPLAIN over a parenthesized query is read-only",
+		},
+		{
+			statement:   "EXPLAIN (SELECT 1 LIMIT 1) LIMIT 2",
+			valid:       true,
+			description: "EXPLAIN over a grouped query is read-only",
+		},
 	}
 
 	for _, tc := range tests {

--- a/backend/plugin/parser/doris/query_type.go
+++ b/backend/plugin/parser/doris/query_type.go
@@ -77,6 +77,10 @@ func astQueryType(node ast.Node) (analysis.QueryType, bool) {
 	switch n := node.(type) {
 	case *ast.SelectStmt, *ast.SetOpStmt:
 		return analysis.QueryTypeSelect, true
+	case *ast.GroupedQuery:
+		// A repeated trailing clause group or a parenthesized WITH group
+		// wraps a query; classify by the wrapped query.
+		return astQueryType(n.Query)
 	case *ast.ShowStmt,
 		*ast.ShowRoutineLoadStmt, *ast.ShowRoutineLoadTaskStmt,
 		*ast.ShowJobStmt, *ast.ShowJobTaskStmt,

--- a/backend/plugin/parser/doris/query_type_test.go
+++ b/backend/plugin/parser/doris/query_type_test.go
@@ -39,6 +39,18 @@ func TestGetQueryType(t *testing.T) {
 			want:      base.SelectInfoSchema,
 		},
 		{
+			statement: "(SELECT * FROM users)",
+			want:      base.Select,
+		},
+		{
+			statement: "(SELECT 1 LIMIT 1) LIMIT 2",
+			want:      base.Select,
+		},
+		{
+			statement: "(SELECT * FROM users) ORDER BY 1 LIMIT 5",
+			want:      base.Select,
+		},
+		{
 			statement: "SHOW TABLES",
 			want:      base.SelectInfoSchema,
 		},

--- a/backend/plugin/parser/starrocks/query.go
+++ b/backend/plugin/parser/starrocks/query.go
@@ -57,6 +57,10 @@ func isReadOnlyAST(node ast.Node) bool {
 		return n.Into == nil
 	case *ast.SetOpStmt:
 		return !setOpWritesOutfile(n)
+	case *ast.ParenSelect:
+		// (SELECT ...) at the top level — classify by the inner query so the
+		// INTO OUTFILE gate still applies inside the parens.
+		return isReadOnlyAST(n.Sel)
 	case *ast.ShowStmt:
 		// Reject bare `SHOW` (Type is empty when the parser took the stub path
 		// without seeing a recognised variant keyword).
@@ -102,6 +106,10 @@ func setOpWritesOutfile(node ast.Node) bool {
 		return n.Into != nil
 	case *ast.SetOpStmt:
 		return setOpWritesOutfile(n.Left) || setOpWritesOutfile(n.Right)
+	case *ast.ParenSelect:
+		// A parenthesized arm — SELECT 1 UNION (SELECT ... INTO OUTFILE ...) —
+		// must not slip the export gate.
+		return setOpWritesOutfile(n.Sel)
 	default:
 		return false
 	}

--- a/backend/plugin/parser/starrocks/query.go
+++ b/backend/plugin/parser/starrocks/query.go
@@ -88,9 +88,13 @@ func isReadOnlyAST(node ast.Node) bool {
 // legitimately wrap (SELECT family or DML). DDL inside EXPLAIN is rejected:
 // Doris only supports EXPLAIN on query and DML statements.
 func isExplainableInner(node ast.Node) bool {
-	switch node.(type) {
+	switch n := node.(type) {
 	case *ast.SelectStmt, *ast.SetOpStmt:
 		return true
+	case *ast.ParenSelect:
+		// EXPLAIN (SELECT ...) / EXPLAIN ((SELECT ...)) — engine-verified
+		// accepts; classify by the wrapped query.
+		return isExplainableInner(n.Sel)
 	case *ast.InsertStmt, *ast.UpdateStmt, *ast.DeleteStmt,
 		*ast.MergeStmt, *ast.TruncateTableStmt:
 		return true

--- a/backend/plugin/parser/starrocks/query_span_fail_closed_test.go
+++ b/backend/plugin/parser/starrocks/query_span_fail_closed_test.go
@@ -1,0 +1,35 @@
+package starrocks
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/plugin/parser/base"
+)
+
+// TestQuerySpanFailClosed pins the BYT-10085 contract at the bytebase layer:
+// a statement the parser cannot fully consume must FAIL the span extraction,
+// not return an empty span. Before strict parsing, "SELECT a FROM secret
+// xx yy" silently truncated to "SELECT a FROM secret" upstream and variants
+// with a junked FROM clause could yield zero AccessTables — masking and
+// table-level ACL checks then saw nothing to protect.
+func TestQuerySpanFailClosed(t *testing.T) {
+	a := require.New(t)
+	q := newQuerySpanExtractor("db1", base.GetQuerySpanContext{}, false)
+
+	_, err := q.getQuerySpan(context.Background(), "SELECT a FROM secret xx yy zz")
+	a.Error(err, "trailing junk must fail the span, not truncate silently")
+
+	// The newly accepted paren/grouped shapes still extract their reads.
+	span, err := q.getQuerySpan(context.Background(), "(SELECT a FROM secret) LIMIT 1")
+	a.NoError(err)
+	a.True(span.SourceColumns[base.ColumnResource{Database: "db1", Table: "secret"}],
+		"paren query must report its table read")
+
+	span, err = q.getQuerySpan(context.Background(), "(SELECT a FROM secret ORDER BY 1) ORDER BY 1")
+	a.NoError(err)
+	a.True(span.SourceColumns[base.ColumnResource{Database: "db1", Table: "secret"}],
+		"grouped query must report its table read")
+}

--- a/backend/plugin/parser/starrocks/query_test.go
+++ b/backend/plugin/parser/starrocks/query_test.go
@@ -133,6 +133,16 @@ func TestValidateQuery(t *testing.T) {
 			description: "INTO OUTFILE inside nested parens must not slip the export gate",
 		},
 		{
+			statement:   "EXPLAIN (SELECT 1)",
+			valid:       true,
+			description: "EXPLAIN over a parenthesized query is read-only",
+		},
+		{
+			statement:   "EXPLAIN ((SELECT 1))",
+			valid:       true,
+			description: "EXPLAIN over nested parens is read-only",
+		},
+		{
 			statement:   "SELECT EXTRACT(YEAR FROM MONTHS_ADD(NOW(), -1))",
 			valid:       true,
 			description: "EXTRACT(unit FROM expr) is read-only",

--- a/backend/plugin/parser/starrocks/query_test.go
+++ b/backend/plugin/parser/starrocks/query_test.go
@@ -108,6 +108,31 @@ func TestValidateQuery(t *testing.T) {
 			description: "CTE-prefixed SELECT is read-only",
 		},
 		{
+			statement:   "((SELECT 1))",
+			valid:       true,
+			description: "Nested parenthesized SELECT is read-only",
+		},
+		{
+			statement:   "(SELECT 1) LIMIT 5",
+			valid:       true,
+			description: "Parenthesized SELECT with trailing LIMIT is read-only",
+		},
+		{
+			statement:   "(WITH c AS (SELECT 1) SELECT * FROM c)",
+			valid:       true,
+			description: "Parenthesized WITH query is read-only",
+		},
+		{
+			statement:   `SELECT 1 UNION (SELECT a FROM t INTO OUTFILE "s3://b/x")`,
+			valid:       false,
+			description: "INTO OUTFILE inside a parenthesized set-op arm must not slip the export gate",
+		},
+		{
+			statement:   `((SELECT a FROM t INTO OUTFILE "s3://b/x"))`,
+			valid:       false,
+			description: "INTO OUTFILE inside nested parens must not slip the export gate",
+		},
+		{
 			statement:   "SELECT EXTRACT(YEAR FROM MONTHS_ADD(NOW(), -1))",
 			valid:       true,
 			description: "EXTRACT(unit FROM expr) is read-only",
@@ -189,6 +214,9 @@ func TestValidateQuery(t *testing.T) {
 	// Cases that must fail validation — either because they're not read-only
 	// or because they don't parse. Both shapes flow through the same code
 	// path and must be rejected (either via valid=false or err!=nil).
+	//
+	// The trailing-junk case pins strict parsing (BYT-10085): before the fix
+	// "SELECT a FROM t xx yy zz" silently truncated to its valid prefix.
 	rejectCases := []struct {
 		statement   string
 		description string
@@ -232,6 +260,10 @@ func TestValidateQuery(t *testing.T) {
 			// EXPLAIN over DDL is not a real read-only operation.
 			statement:   "EXPLAIN DROP TABLE t",
 			description: "EXPLAIN over DDL must be rejected",
+		},
+		{
+			statement:   "SELECT a FROM t xx yy zz",
+			description: "Trailing junk after a valid prefix must be rejected",
 		},
 	}
 	for _, tc := range rejectCases {

--- a/backend/plugin/parser/starrocks/query_type.go
+++ b/backend/plugin/parser/starrocks/query_type.go
@@ -77,6 +77,10 @@ func astQueryType(node ast.Node) (analysis.QueryType, bool) {
 	switch n := node.(type) {
 	case *ast.SelectStmt, *ast.SetOpStmt:
 		return analysis.QueryTypeSelect, true
+	case *ast.ParenSelect:
+		// (SELECT ...) at the top level wraps a query; classify by the
+		// wrapped query.
+		return astQueryType(n.Sel)
 	case *ast.ShowStmt,
 		*ast.ShowRoutineLoadStmt, *ast.ShowRoutineLoadTaskStmt,
 		*ast.ShowJobStmt, *ast.ShowJobTaskStmt,

--- a/backend/plugin/parser/starrocks/query_type_test.go
+++ b/backend/plugin/parser/starrocks/query_type_test.go
@@ -35,6 +35,14 @@ func TestGetQueryType(t *testing.T) {
 			want:      base.DDL,
 		},
 		{
+			statement: "((SELECT * FROM users))",
+			want:      base.Select,
+		},
+		{
+			statement: "(SELECT * FROM users) LIMIT 5",
+			want:      base.Select,
+		},
+		{
 			statement: "SHOW DATABASES",
 			want:      base.SelectInfoSchema,
 		},

--- a/backend/plugin/parser/starrocks/starrocks_test.go
+++ b/backend/plugin/parser/starrocks/starrocks_test.go
@@ -12,7 +12,12 @@ func TestStarRocksSQLParser(t *testing.T) {
 		errorMessage string
 	}{
 		{
-			statement: "SELECT * FROM person LATERAL VIEW EXPLODE(ARRAY(30, 60)) tableName AS c_age;",
+			// StarRocks has no Hive-style LATERAL VIEW (its lateral form is
+			// `, [LATERAL] unnest(...)`) — container-verified engine reject.
+			// The old parser only "accepted" this by silently truncating at
+			// LATERAL (BYT-10085); strict parsing reports it like the engine.
+			statement:    "SELECT * FROM person LATERAL VIEW EXPLODE(ARRAY(30, 60)) tableName AS c_age;",
+			errorMessage: "syntax error at or near LATERAL",
 		},
 		{
 			statement: "SELECT * FROM schema1.t1 JOIN schema2.t2 ON t1.c1 = t2.c1",

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735
 	github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0
-	github.com/bytebase/omni v0.0.0-20260820081141-f107d677cca3
+	github.com/bytebase/omni v0.0.0-20260828034652-044f516d401c
 	github.com/caarlos0/env/v11 v11.4.1
 	github.com/cenkalti/backoff/v7 v7.0.0
 	github.com/cockroachdb/cockroachdb-parser v0.25.2

--- a/go.sum
+++ b/go.sum
@@ -250,8 +250,8 @@ github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735 h1:v8y6mXeHmYVsdM
 github.com/bytebase/gomongo v0.0.0-20260730033313-67ba6e249735/go.mod h1:vTHjcvfn8Pmf65WjnV1ytTCYyC7xNhFjrniv4YWvtA8=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0 h1:bJ8NSf2K+pccl5m/wuu97fiYjDwpJH6IzURAq/3XA2U=
 github.com/bytebase/lsp-protocol v0.0.0-20250324071136-1586d0c10ff0/go.mod h1:BEWMfiZtqshdmulKJcIsWb45MUaEvDO4CROcgi8dfFg=
-github.com/bytebase/omni v0.0.0-20260820081141-f107d677cca3 h1:gbpLT03nnD5xVfy22UzoxUMaN5ymmcXoYx3ghgYNNO8=
-github.com/bytebase/omni v0.0.0-20260820081141-f107d677cca3/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
+github.com/bytebase/omni v0.0.0-20260828034652-044f516d401c h1:Plc8vW5rGPaqRXyn+oNt72HmLMaY7E6HWkFmeS7QmA0=
+github.com/bytebase/omni v0.0.0-20260828034652-044f516d401c/go.mod h1:Gp5RN3FM07f9/FFOTZCeu8duTAIMeuinkjjBCrs2Dw4=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767 h1:YuR5G3LcxpO5ScSTA+Kdirxg9RW4TRc/v1t7N2Hfmbw=
 github.com/bytebase/pgx/v5 v5.0.0-20250212161523-96ff8aed8767/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsbsfGQ=
 github.com/bytebase/pkcs8 v0.0.0-20240612095628-fcd0a7484c94 h1:6PNsuNmSqCuR8Z616uQLzDIvujWCFsKzeVc3ECmVubk=


### PR DESCRIPTION
## What

Bumps omni from the #400-era pin to current main (044f516d), bringing in the doris/starrocks trailing-token swallow fix series (bytebase/omni#401–#403, #406) plus the Oracle constraint_state support (bytebase/omni#399 was already included upstream of the old pin's successor).

**Why it matters**: with the old pin, a statement like `SELECT a FROM secret xx yy zz` silently truncated to its valid prefix and *ran*, and malformed statements could yield empty query spans — past masking and table-level ACL checks. Strict `Parse` now reports such input as a syntax error, and `GetQuerySpan` fails closed. The whole enforcement chain (span extractor → `base.GetQuerySpan` → `queryRetry`) propagates the error, so the query is refused before execution.

## bytebase-side adjustments

- **doris**: handle the new `ast.GroupedQuery` wrapper (repeated trailing clause groups, parenthesized WITH scope boundaries) in the read-only validator and the AST query-type classifier — `(SELECT 1 LIMIT 1) LIMIT 2` stays a read-only SELECT.
- **starrocks**: handle top-level `ast.ParenSelect` (statement-level parenthesized queries are newly accepted) in the same two places, and recurse through parenthesized set-op arms in the INTO OUTFILE export gate — `SELECT 1 UNION (SELECT ... INTO OUTFILE "s3://...")` must not pass as read-only (this was a live bypass).
- **starrocks**: flip the LATERAL VIEW smoke test to expect a syntax error — StarRocks 3.4.10 has no Hive-style LATERAL VIEW (container-verified); the old parser only "accepted" it by silently truncating at `LATERAL`. Doris LATERAL VIEW is engine-valid and now actually parsed (bytebase/omni#406) instead of being truncated out of lineage.
- New `query_span_fail_closed_test.go` on both engines pins the contract: trailing junk fails the span extraction, and the newly accepted paren/grouped shapes still report their table reads.

## Verification

- `backend/plugin/parser/doris`, `backend/plugin/parser/starrocks`, `backend/plugin/db/starrocks` suites green.
- `backend/api/v1` MCP read-only clamp tests green.
- Full `./backend/...` build green.
- Every engine-behavior claim above was verified against live Doris 3.1.4 / StarRocks 3.4.10 containers on the omni side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)