### PR TITLE
fix(api): scope DiffSchema and UpdateDatabaseCatalog to the named resource's project

### DIFF
--- a/backend/api/v1/acl.go
+++ b/backend/api/v1/acl.go
@@ -627,6 +627,12 @@ func getResourceFromRequest(ctx context.Context, request any, method string) ([]
 		}
 	default:
 	}
+	if r, ok := request.(*v1pb.UpdateDatabaseCatalogRequest); ok {
+		// The catalog is in `catalog`, not the `database_catalog` the Update
+		// convention below derives from the method name. Without this it
+		// resolves nothing and falls back to workspace scope.
+		return []string{r.GetCatalog().GetName()}, nil
+	}
 	if r, ok := request.(*v1pb.UpdateInstanceRequest); ok && r.AllowMissing && r.Instance != nil {
 		if projectID, _, err := common.GetProjectIDInstanceID(r.Instance.Name); err == nil {
 			// The instance does not exist yet, so authorize the implicit creation

--- a/backend/api/v1/acl_test.go
+++ b/backend/api/v1/acl_test.go
@@ -172,6 +172,16 @@ func TestGetResourceRoute(t *testing.T) {
 			parts: []string{"instances", "instance-a", "databases", "app", "schema"},
 			want:  resourceRoute{"instances", "databases", "schema"},
 		},
+		{
+			name:  "project database catalog",
+			parts: []string{"projects", "project-a", "instances", "instance-a", "databases", "app", "catalog"},
+			want:  resourceRoute{"projects", "instances", "databases"},
+		},
+		{
+			name:  "workspace database catalog",
+			parts: []string{"instances", "instance-a", "databases", "app", "catalog"},
+			want:  resourceRoute{"instances", "databases", "catalog"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -201,6 +211,7 @@ func TestFindResourceResolver(t *testing.T) {
 		{name: "workspace instance role", route: resourceRoute{"instances", "roles"}, wantRoute: resourceRoute{"instances"}, wantExists: true},
 		{name: "workspace database revision", route: resourceRoute{"instances", "databases", "revisions"}, wantRoute: resourceRoute{"instances", "databases"}, wantExists: true},
 		{name: "workspace database schema", route: resourceRoute{"instances", "databases", "schema"}, wantRoute: resourceRoute{"instances", "databases"}, wantExists: true},
+		{name: "workspace database catalog", route: resourceRoute{"instances", "databases", "catalog"}, wantRoute: resourceRoute{"instances", "databases"}, wantExists: true},
 		{name: "ordinary project descendant", route: resourceRoute{"projects", "issues"}, wantRoute: resourceRoute{"projects"}, wantExists: true},
 		{name: "unknown root", route: resourceRoute{"unknowns"}, wantExists: false},
 	}
@@ -595,6 +606,28 @@ func TestGetResourceFromRequest(t *testing.T) {
 			request: &v1pb.MoveMySavedQueriesRequest{Parent: "projects/hello"},
 			method:  "/bytebase.v1.SavedQueryService/MoveMySavedQueries",
 			want:    []string{"projects/hello"},
+		},
+		{
+			// The field is `catalog`, not the `database_catalog` the Update
+			// convention derives -- so this must not fall back to "", which
+			// would check the permission against the workspace instead of the
+			// named database's project.
+			request: &v1pb.UpdateDatabaseCatalogRequest{
+				Catalog: &v1pb.DatabaseCatalog{
+					Name: "instances/hello/databases/world/catalog",
+				},
+			},
+			method: "/bytebase.v1.DatabaseCatalogService/UpdateDatabaseCatalog",
+			want:   []string{"instances/hello/databases/world/catalog"},
+		},
+		{
+			request: &v1pb.UpdateDatabaseCatalogRequest{
+				Catalog: &v1pb.DatabaseCatalog{
+					Name: "projects/hello/instances/world/databases/db/catalog",
+				},
+			},
+			method: "/bytebase.v1.DatabaseCatalogService/UpdateDatabaseCatalog",
+			want:   []string{"projects/hello/instances/world/databases/db/catalog"},
 		},
 	}
 

--- a/backend/api/v1/database_diff_schema_project_test.go
+++ b/backend/api/v1/database_diff_schema_project_test.go
@@ -1,0 +1,149 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+// The ACL interceptor authorizes request.name only, so the handler confines the
+// changelog target to the source's project. One container, since the fixture is
+// the expensive part.
+func TestDiffSchemaTargetProject(t *testing.T) {
+	ctx, stores, instanceID, changelogByDatabase := setupDiffSchemaProjectTest(t)
+	service := NewDatabaseService(stores, nil, nil, nil, nil)
+
+	// Databases without a changelog still get a well-formed name, so a
+	// rejection is about the project and not about a malformed one.
+	changelogOn := func(databaseName string) string {
+		changelogID, ok := changelogByDatabase[databaseName]
+		if !ok {
+			changelogID = "1"
+		}
+		return common.FormatChangelog(instanceID, databaseName, changelogID)
+	}
+	diffAgainstChangelog := func(sourceName, changelogName string) (string, error) {
+		response, err := service.DiffSchema(ctx, connect.NewRequest(&v1pb.DiffSchemaRequest{
+			Name:   sourceName,
+			Target: &v1pb.DiffSchemaRequest_Changelog{Changelog: changelogName},
+		}))
+		if err != nil {
+			return "", err
+		}
+		return response.Msg.Diff, nil
+	}
+
+	t.Run("same project diffs", func(t *testing.T) {
+		// The diff must actually run: a gate that rejected everything would
+		// still satisfy the negative cases below.
+		diff, err := diffAgainstChangelog(common.FormatDatabase(instanceID, "app-a"), changelogOn("app-a"))
+		require.NoError(t, err)
+		require.Empty(t, diff)
+	})
+
+	t.Run("changelog source resolves to its database", func(t *testing.T) {
+		// request.name may itself be a changelog.
+		diff, err := diffAgainstChangelog(changelogOn("app-a"), changelogOn("app-a"))
+		require.NoError(t, err)
+		require.Empty(t, diff)
+	})
+
+	t.Run("foreign project is rejected", func(t *testing.T) {
+		// app-b's changelog is real, so without the gate this succeeds and
+		// returns another project's schema.
+		_, err := diffAgainstChangelog(common.FormatDatabase(instanceID, "app-a"), changelogOn("app-b"))
+		require.Error(t, err)
+		require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+		require.NotContains(t, err.Error(), "project-b")
+
+		// Indistinguishable from a database that does not exist, or the error
+		// itself answers the question.
+		_, missing := diffAgainstChangelog(common.FormatDatabase(instanceID, "app-a"), changelogOn("no-such-db"))
+		require.Equal(t, connect.CodeOf(err), connect.CodeOf(missing))
+	})
+
+	t.Run("schema target skips the gate", func(t *testing.T) {
+		// One-resource requests must not reach the gate at all.
+		response, err := service.DiffSchema(ctx, connect.NewRequest(&v1pb.DiffSchemaRequest{
+			Name:   common.FormatDatabase(instanceID, "app-a"),
+			Target: &v1pb.DiffSchemaRequest_Schema{Schema: ""},
+		}))
+		require.NoError(t, err)
+		require.Empty(t, response.Msg.Diff)
+	})
+}
+
+func setupDiffSchemaProjectTest(t *testing.T) (context.Context, *store.Store, string, map[string]string) {
+	t.Helper()
+	ctx := context.WithValue(context.Background(), common.WorkspaceIDContextKey, "default")
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+	db := container.GetDB()
+	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO project (resource_id, workspace, name) VALUES
+			('project-a', 'default', 'Project A'),
+			('project-b', 'default', 'Project B');
+	`)
+	require.NoError(t, err)
+
+	pgURL := fmt.Sprintf("host=%s port=%s user=postgres password=root-password database=postgres", container.GetHost(), container.GetPort())
+	stores, err := store.New(ctx, pgURL, false)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, stores.Close()) })
+
+	// A workspace-level instance whose databases sit in different projects: the
+	// shape that lets one name reach across a project boundary.
+	instanceID := "shared-instance"
+	_, err = stores.CreateInstance(ctx, &store.InstanceMessage{
+		ResourceID: instanceID,
+		Workspace:  "default",
+		Metadata: &storepb.Instance{
+			Engine: storepb.Engine_POSTGRES,
+			DataSources: []*storepb.DataSource{{
+				Id:   "admin",
+				Type: storepb.DataSourceType_ADMIN,
+			}},
+		},
+	})
+	require.NoError(t, err)
+
+	for databaseName, projectID := range map[string]string{"app-a": "project-a", "app-b": "project-b"} {
+		_, err = stores.UpsertDatabase(ctx, &store.DatabaseMessage{
+			InstanceID:   instanceID,
+			DatabaseName: databaseName,
+			ProjectID:    projectID,
+			Metadata:     &storepb.DatabaseMetadata{},
+		})
+		require.NoError(t, err)
+		require.NoError(t, stores.UpsertDBSchema(ctx, instanceID, databaseName,
+			&storepb.DatabaseSchemaMetadata{Name: databaseName}, &storepb.DatabaseConfig{}, nil))
+	}
+
+	// The foreign changelog must exist, or the cross-project case would fail
+	// for the wrong reason and still pass.
+	changelogByDatabase := map[string]string{}
+	for _, databaseName := range []string{"app-a", "app-b"} {
+		changelogID, err := stores.CreateChangelog(ctx, &store.ChangelogMessage{
+			InstanceID:   instanceID,
+			DatabaseName: databaseName,
+			Payload:      &storepb.ChangelogPayload{},
+			Status:       store.ChangelogStatusDone,
+		})
+		require.NoError(t, err)
+		changelogByDatabase[databaseName] = changelogID
+	}
+
+	return ctx, stores, instanceID, changelogByDatabase
+}

--- a/backend/api/v1/database_diff_schema_project_test.go
+++ b/backend/api/v1/database_diff_schema_project_test.go
@@ -72,6 +72,24 @@ func TestDiffSchemaTargetProject(t *testing.T) {
 		require.Equal(t, connect.CodeOf(err), connect.CodeOf(missing))
 	})
 
+	t.Run("foreign changelog id under an owned database is rejected", func(t *testing.T) {
+		// Changelog ids are globally unique, so the path's database name alone
+		// does not establish which changelog it addresses. Same error as an id
+		// that does not exist, which is what the pre-existing not-found path
+		// already returns.
+		_, err := diffAgainstChangelog(
+			common.FormatDatabase(instanceID, "app-a"),
+			common.FormatChangelog(instanceID, "app-a", changelogByDatabase["app-b"]),
+		)
+		require.Error(t, err)
+
+		_, missing := diffAgainstChangelog(
+			common.FormatDatabase(instanceID, "app-a"),
+			common.FormatChangelog(instanceID, "app-a", "999999"),
+		)
+		require.Equal(t, connect.CodeOf(missing), connect.CodeOf(err))
+	})
+
 	t.Run("schema target skips the gate", func(t *testing.T) {
 		// One-resource requests must not reach the gate at all.
 		response, err := service.DiffSchema(ctx, connect.NewRequest(&v1pb.DiffSchemaRequest{

--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -1035,8 +1035,9 @@ func (s *DatabaseService) getSourceDBMetadata(ctx context.Context, request *v1pb
 		}
 
 		changelog, err := s.store.GetChangelog(ctx, &store.FindChangelogMessage{
-			InstanceID: instanceID,
-			ResourceID: &changelogID,
+			InstanceID:   instanceID,
+			DatabaseName: &databaseID,
+			ResourceID:   &changelogID,
 		})
 		if err != nil {
 			return nil, err
@@ -1117,8 +1118,9 @@ func (s *DatabaseService) getTargetDBMetadata(ctx context.Context, request *v1pb
 		}
 
 		changelog, err := s.store.GetChangelog(ctx, &store.FindChangelogMessage{
-			InstanceID: instanceID,
-			ResourceID: &changelogID,
+			InstanceID:   instanceID,
+			DatabaseName: &databaseID,
+			ResourceID:   &changelogID,
 		})
 		if err != nil {
 			return nil, err

--- a/backend/api/v1/database_service.go
+++ b/backend/api/v1/database_service.go
@@ -787,6 +787,10 @@ func (s *DatabaseService) GetDatabaseSDLSchema(ctx context.Context, req *connect
 
 // DiffSchema diff the database schema.
 func (s *DatabaseService) DiffSchema(ctx context.Context, req *connect.Request[v1pb.DiffSchemaRequest]) (*connect.Response[v1pb.DiffSchemaResponse], error) {
+	if err := s.validateDiffSchemaTargetProject(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	engine, err := s.getParserEngine(ctx, req.Msg)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get parser engine"))
@@ -879,6 +883,56 @@ func (s *DatabaseService) DiffMetadata(ctx context.Context, req *connect.Request
 	return connect.NewResponse(&v1pb.DiffMetadataResponse{
 		Diff: migrationSQL,
 	}), nil
+}
+
+// validateDiffSchemaTargetProject confines the changelog target to the source's
+// project. The ACL interceptor authorizes request.name only, so nothing else
+// checks the changelog.
+func (s *DatabaseService) validateDiffSchemaTargetProject(ctx context.Context, request *v1pb.DiffSchemaRequest) error {
+	changelog := request.GetChangelog()
+	if changelog == "" {
+		return nil
+	}
+	source, err := s.getDiffSchemaDatabase(ctx, request.GetName())
+	if err != nil {
+		return err
+	}
+	if source == nil {
+		return connect.NewError(connect.CodeNotFound, errors.Errorf("database %q not found", request.GetName()))
+	}
+	target, err := s.getDiffSchemaDatabase(ctx, changelog)
+	if err != nil {
+		return err
+	}
+	// One error for both: a distinct one would confirm what lives in a project
+	// the caller cannot see.
+	if target == nil || target.ProjectID != source.ProjectID {
+		return connect.NewError(connect.CodeNotFound, errors.Errorf("changelog %q not found", changelog))
+	}
+	return nil
+}
+
+// getDiffSchemaDatabase resolves the database behind a DiffSchema name, which
+// may name a database or one of its changelogs. Returns nil, not an error, when
+// the database does not exist.
+func (s *DatabaseService) getDiffSchemaDatabase(ctx context.Context, name string) (*store.DatabaseMessage, error) {
+	// Not a "changelogs/" substring test: an instance or project may be named
+	// `changelogs`. Segment counts make exactly one form parse.
+	_, instanceID, databaseName, _, err := common.GetDatabaseChangelogResourceName(name)
+	if err != nil {
+		if _, instanceID, databaseName, err = common.GetDatabaseResourceName(name); err != nil {
+			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Wrapf(err, "failed to parse %q", name))
+		}
+	}
+	database, err := s.store.GetDatabase(ctx, &store.FindDatabaseMessage{
+		Workspace:    common.GetWorkspaceIDFromContext(ctx),
+		InstanceID:   &instanceID,
+		DatabaseName: &databaseName,
+	})
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to get database %q", name))
+	}
+	return database, nil
 }
 
 // shouldDiffSchemaViaSDL reports whether a raw-schema-text DiffSchema target should take the

--- a/docs/design/v1-api-audit-2026-08.md
+++ b/docs/design/v1-api-audit-2026-08.md
@@ -10,7 +10,6 @@ noted. Fixed findings are removed and listed at the end.
 
 | | Problem | Severity |
 |---|---|---|
-| T2 | Schema diff reads a second database without checking permission on it | HIGH |
 | T15 | Rotating a leaked cloud credential can silently do nothing | HIGH |
 | T13 | "Waiting for my approval" can show an empty page with a live Load More | HIGH |
 | T14 | Paging through issues across projects skips some and repeats others | HIGH |
@@ -26,19 +25,26 @@ noted. Fixed findings are removed and listed at the end.
 
 ## Doing more than you're allowed
 
-### T2 · The permission check only looks at one resource per request — HIGH
+### The one-resource ACL rule, and what it still costs
 
-The ACL interceptor authorizes exactly one resource name per request: `parent`, else `name`, else
-`resource`, else `project`. Any *second* resource named in the body is invisible to it.
+`getResourceFromSingleRequest` authorizes exactly one resource name per request, picked by field-name
+convention: `parent`, else `name`, else `resource`, else `project`, else — for `Create`/`Update`/
+`Remove`/`Test` — the nested `<snake_case(resource)>.name`. Nothing else in the body is visible to it.
+`acl.go:735-795`
 
-One live case: `DiffSchema` takes both a database and a changelog, and the changelog can belong to a
-different project. Only the first is checked, so a caller can read schema out of a project they have
-no access to. Every other known case is closed inside the handler; this is the last one, and the
-parked patch `04` fixes it.
+A sweep of all 216 v1 RPCs found 24 whose body names a resource the interceptor never authorizes.
+Twenty-two are closed downstream: `CreatePlan`/`UpdatePlan`, the three `Release` RPCs,
+`BatchCreateRevisions`, `CreateAccessGrant`, the `SavedQuery` writes, `CreateIssue`,
+`UpdateIssueComment`, `TestWebhook` and `GetQueryHistory` each compare the second resource's project
+to the authorized one; `BatchRunTasks`, `BatchSkipTasks` and `CreateRollout` re-derive it from the
+parent instead of trusting the name; `UpdateDatabase`/`BatchUpdateDatabases` are special-cased in the
+interceptor itself. `DiffSchema` was the one live gap and is now closed the same way.
 
-The real fix is the general one — teach the interceptor to collect *every* annotated resource field,
-so the next second-resource field doesn't reopen the hole. `acl.go:735-753`,
-`database_service.go:1051-1082`
+The convention can also miss the *only* resource: `UpdateDatabaseCatalog` names its target in
+`catalog`, not the `database_catalog` the method suffix derives, so it resolved nothing and every
+call was authorized against the workspace. Both are fixed and listed at the end. Neither fix
+generalizes — the next request field that departs from the convention arrives unchecked, silently,
+and only a sweep like this one finds it.
 
 ### T18a · Test-environment rights can cancel a production migration — MED
 
@@ -204,10 +210,13 @@ constraints.
 
 ## What I'd do, in order
 
-1. **Fix the ACL class, not the instance (T2).** Teach the interceptor to collect every annotated
-   resource field, then annotate `DiffSchema`. Otherwise the next second-resource field reopens it.
-2. **Make credential rotation fail loudly (T15).** A security operation that returns 200 and does
+1. **Make credential rotation fail loudly (T15).** A security operation that returns 200 and does
    nothing is worse than one that errors.
+2. **Make the extractor's misses loud.** A `Create`/`Update` request whose conventional field is
+   absent still degrades silently to a workspace check — `UpdateDatabaseCatalog` sat that way until
+   it was found by sweep, not by failure. Rejecting it at startup, the same shape as the
+   `AUTH_METHOD_UNSPECIFIED` gate below, turns the next `catalog`-style field name into a build
+   failure instead of a silent scope change.
 3. **Fail closed on auth annotations, and put api-linter in CI.** Reject
    `AUTH_METHOD_UNSPECIFIED` at startup; make a `permission` on a CUSTOM RPC either enforced or a
    build error, since 15 are decorative. None of Tier 5 was visible to `buf lint`'s BASIC profile,
@@ -221,6 +230,8 @@ constraints.
 |---|---|
 | T1, T3 | Fixed earlier in the session |
 | T2 (INPUT_ONLY) | Read-path fix |
+| T2 `DiffSchema` | `DiffSchema` rejects a changelog target owned by another project before any read, matching how every other second-resource handler closes it. Not the general interceptor change: the resource the caller names must simply belong to the project they were authorized on, which is also the only thing a cross-project diff could have meant. A missing target and a foreign one return the same error, so neither confirms what lives in the other project. Accepted with it: the class stays latent — a future second-resource field still arrives unchecked |
+| T19 `UpdateDatabaseCatalog` | The interceptor now reads `catalog.name`, so the permission is checked against the named database's project instead of the workspace — the route resolver already drops the trailing `/catalog`. Strictly additive: workspace holders are unaffected and Project Owner, whose role carries `bb.databaseCatalogs.update`, is no longer denied. Separate and still open: `bb.databaseCatalogs.create` does not exist, so the `allow_missing` secondary check denies every caller. Dead rather than harmful — no UI sets the flag and the RPC is MCP-`EXCLUDED` |
 | T5, T6 | [#21143](https://github.com/bytebase/bytebase/pull/21143) — `sheet_blob_ref` gives sheets per-project ownership; `BatchCreateRevisions` rejects foreign-project provenance without echoing the hash |
 | T7 | [#21102](https://github.com/bytebase/bytebase/pull/21102) — every `CheckRelease` target validated against the parent project before any schema read (its error codes still leak existence — T18c-iii) |
 | T8 `CreateWorksheet` | [#21169](https://github.com/bytebase/bytebase/pull/21169) — `CreateSavedQuery` is now IAM-enforced; Workspace Member holds no saved-query permission, and new queries start creator-private |
@@ -236,6 +247,6 @@ is free on Bytebase's own key, so no customer budget is at risk and abuse is our
 problem. Self-hosted, the admin supplies the org's key when enabling it, so org-wide use by members
 is the intended model. The missing per-user rate limit and audit are accepted with that disposition.
 
-The three patches from earlier in the session (`SearchProjects` proto comment, `SearchProjects`
-pagination, `DiffSchema` ACL) remain parked and still apply — none landed independently, and all
-three targets are still present at HEAD.
+Two patches from earlier in the session (`SearchProjects` proto comment, `SearchProjects` pagination)
+remain parked and still apply — neither landed independently, and both targets are still present at
+HEAD. The third, `DiffSchema` ACL, is superseded by the same-project fix above.


### PR DESCRIPTION
## What

The ACL interceptor authorizes exactly **one** resource name per request, picked by field-name convention: `parent`, else `name`, else `resource`, else `project`, else — for `Create`/`Update`/`Remove`/`Test` — the nested `<snake_case(resource)>.name`. Anything else in the request body is invisible to it. Two v1 methods paid for that, in opposite directions.

**`DiffSchema` (T2)** names both a database and a changelog, and the changelog may belong to another project. Only the database was authorized, so a caller could read schema out of a project they hold no permission on. The handler now confines the changelog target to the source's project before any read.

Naming the database is not enough on its own: changelog ids are globally unique, and both changelog reads fetched by `(instance, id)` without the database, so a foreign id could ride under a database the caller owns and return that project's schema through its sync history. Both lookups are now scoped by `DatabaseName`, matching `ChangelogService.GetChangelog`. (Caught in review by Codex.)

**`UpdateDatabaseCatalog` (T19)** carries its target as `catalog.name`, but the convention derives `database_catalog` from the method suffix, finds no such field, and falls back to workspace scope. `bb.databaseCatalogs.update` was checked against the workspace no matter which database was named — and a Project Owner, whose role carries that permission, was denied. The interceptor now reads `catalog.name`; the route resolver already drops the trailing `/catalog`.

## Why these two

A sweep of all 216 v1 RPCs found 24 whose body names a resource the interceptor never authorizes. The other 22 are already closed downstream — `CreatePlan`/`UpdatePlan`, the three `Release` RPCs, `BatchCreateRevisions`, `CreateAccessGrant`, the `SavedQuery` writes, `CreateIssue`, `UpdateIssueComment`, `TestWebhook` and `GetQueryHistory` compare the second resource's project to the authorized one; `BatchRunTasks`, `BatchSkipTasks` and `CreateRollout` re-derive it from the parent; `UpdateDatabase`/`BatchUpdateDatabases` are special-cased in the interceptor itself.

These fixes are deliberately local rather than a general interceptor change: the resource a caller names must belong to the project they were authorized on, which is also the only thing a cross-project diff could have meant. The class stays latent — see *Follow-ups*.

## Breaking Changes

1. **`DiffSchema` rejects a cross-project changelog target** (`NOT_FOUND`). This is the vulnerability; any caller relying on it was reading another project's schema.
2. **`DiffSchema` rejects a soft-deleted database or an archived instance** (`NOT_FOUND`), where it previously succeeded. The new gate resolves databases with the default `ShowDeleted`, matching every sibling project-ownership check (`validateSpecs`, `validateAccessGrantTargets`, `CheckRelease`). `GetDBSchema` has no deleted filter, so these diffs did work before.
3. **`UpdateDatabaseCatalog` authorization moves from workspace scope to the named database's project.** Strictly additive: `CheckPermission` consults the workspace policy first, so Workspace Admin and DBA are unaffected, and Project Owner stops being denied. No one loses access.

## Testing

`backend/api/v1/database_diff_schema_project_test.go` — one Postgres container, four subtests: a same-project diff that actually runs, a changelog used as `request.name`, the cross-project rejection (no project leak, and indistinguishable from a nonexistent database), and a `schema` target confirming the gate is a no-op on one-resource requests.

`acl_test.go` — both name forms in `TestGetResourceFromRequest`, plus catalog cases in `TestGetResourceRoute` and `TestFindResourceResolver` pinning the route truncation the fix relies on.

Both fixes were mutation-tested. Disabling the `DiffSchema` gate makes the cross-project request **succeed and return another project's schema** (`An error is expected but got nil`); disabling the ACL case makes the extractor resolve `[""]`, the workspace fallback.

`./backend/api/v1` full suite green, `golangci-lint` 0 issues, server builds.

## Follow-ups (not in this PR)

- **The class stays latent.** The next request field that departs from the naming convention arrives unchecked and silent. The durable fix is a startup gate rejecting a `Create`/`Update` whose conventional field is absent — same shape as the `AUTH_METHOD_UNSPECIFIED` gate.
- **`bb.databaseCatalogs.create` does not exist**, so `UpdateDatabaseCatalog(allow_missing=true)` denies every caller via the secondary check. Dead rather than harmful: no UI sets the flag and the RPC is MCP-`EXCLUDED`. Fixing it means deciding which roles get a new permission.
- **A changelog that isn't found returns `CodeInternal`,** because `getTargetDBMetadata` returns a plain error that `DiffSchema` wraps as Internal. Pre-existing — a nonexistent id in your own database already 500s. That sameness is what keeps the rejection above from being an oracle, and the test asserts both cases return the identical code.
- **`strings.Contains(name, ChangelogPrefix)`** at `database_service.go:1022`, `:1041`, `:1228` misparses a database whose instance or project is named `changelogs`. Pre-existing; the new gate parses by segment count instead, so it is stricter than the read paths, never looser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
