### PR TITLE
fix(rollout): scope BatchCancelTaskRuns to the authorized stage (T18a)

### DIFF
--- a/backend/api/v1/rollout_service.go
+++ b/backend/api/v1/rollout_service.go
@@ -1080,14 +1080,18 @@ func (s *RolloutService) BatchCancelTaskRuns(ctx context.Context, req *connect.R
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to find issue"))
 	}
 
+	// Require every task run to name the parent's stage so the single permission
+	// check below covers the whole batch.
+	var taskRunIDs []int64
 	for _, taskRun := range request.TaskRuns {
-		_, _, taskRunStageID, _, _, err := common.GetProjectIDPlanIDStageIDTaskIDTaskRunID(taskRun)
+		_, _, taskRunStageID, _, taskRunID, err := common.GetProjectIDPlanIDStageIDTaskIDTaskRunID(taskRun)
 		if err != nil {
 			return nil, connect.NewError(connect.CodeInvalidArgument, err)
 		}
 		if taskRunStageID != stageID {
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("task run %v is not in the specified stage %v", taskRun, stageID))
 		}
+		taskRunIDs = append(taskRunIDs, taskRunID)
 	}
 
 	user, ok := GetUserFromContext(ctx)
@@ -1104,22 +1108,29 @@ func (s *RolloutService) BatchCancelTaskRuns(ctx context.Context, req *connect.R
 		return nil, connect.NewError(connect.CodePermissionDenied, errors.New("Not allowed to cancel tasks"))
 	}
 
-	var taskRunIDs []int64
-	for _, taskRun := range request.TaskRuns {
-		_, _, _, _, taskRunID, err := common.GetProjectIDPlanIDStageIDTaskIDTaskRunID(taskRun)
-		if err != nil {
-			return nil, connect.NewError(connect.CodeInvalidArgument, err)
-		}
-		taskRunIDs = append(taskRunIDs, taskRunID)
-	}
-
+	// Confine the lookup to the plan and environment just authorized: the stage in
+	// the request names is caller-supplied, so without this an ID from another
+	// environment or plan in the same project would resolve and be canceled on
+	// permission granted elsewhere. Reject rather than drop an out-of-scope ID —
+	// the cancel below is driven by the requested IDs.
 	taskRuns, err := s.store.ListTaskRuns(ctx, &store.FindTaskRunMessage{
-		Workspace: common.GetWorkspaceIDFromContext(ctx),
-		ProjectID: projectID,
-		UIDs:      &taskRunIDs,
+		Workspace:   common.GetWorkspaceIDFromContext(ctx),
+		ProjectID:   projectID,
+		PlanUID:     &planID,
+		Environment: &environment,
+		UIDs:        &taskRunIDs,
 	})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, errors.Wrapf(err, "failed to list task runs"))
+	}
+	foundTaskRunIDs := make(map[int64]bool, len(taskRuns))
+	for _, taskRun := range taskRuns {
+		foundTaskRunIDs[taskRun.ID] = true
+	}
+	for _, taskRunID := range taskRunIDs {
+		if !foundTaskRunIDs[taskRunID] {
+			return nil, connect.NewError(connect.CodeNotFound, errors.Errorf("task run %v not found in stage %v", taskRunID, stageID))
+		}
 	}
 
 	for _, taskRun := range taskRuns {

--- a/backend/tests/task_run_cancel_scope_test.go
+++ b/backend/tests/task_run_cancel_scope_test.go
@@ -1,0 +1,146 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+)
+
+// TestBatchCancelTaskRuns_RejectsTaskRunFromAnotherStage pins T18a.
+//
+// BatchCancelTaskRuns authorizes the caller against the stage named in the
+// request, and the stage segment of a task run name is caller-supplied. It must
+// therefore confine the task runs it acts on to that stage; otherwise cancel
+// rights in one environment reach a task run in another environment of the same
+// project — test-environment rights killing a production migration.
+func TestBatchCancelTaskRuns_RejectsTaskRunFromAnotherStage(t *testing.T) {
+	a := require.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	ctl := &controller{}
+	ctx, err := ctl.StartServerWithExternalPg(ctx)
+	a.NoError(err)
+	defer ctl.Close(ctx)
+
+	testEnvironment, err := ctl.getEnvironment(ctx, "test")
+	a.NoError(err)
+
+	pgContainer, err := provisionPgInstance(ctx, t)
+	a.NoError(err)
+	instanceResp, err := ctl.instanceServiceClient.CreateInstance(ctx, connect.NewRequest(&v1pb.CreateInstanceRequest{
+		InstanceId: generateRandomString("instance"),
+		Instance: &v1pb.Instance{
+			Title:       "testInstanceCancelScope",
+			Engine:      v1pb.Engine_POSTGRES,
+			Environment: new("environments/prod"),
+			Activation:  true,
+			DataSources: []*v1pb.DataSource{pgContainer.adminDataSource()},
+		},
+	}))
+	a.NoError(err)
+	instance := instanceResp.Msg
+
+	// One database per environment, so the rollout gets a test stage and a prod stage.
+	const prodDatabase, testDatabase = "cancelScopeProdDb", "cancelScopeTestDb"
+	a.NoError(ctl.createDatabase(ctx, ctl.project, instance, nil /* environment */, prodDatabase, ""))
+	a.NoError(ctl.createDatabase(ctx, ctl.project, instance, testEnvironment, testDatabase, ""))
+
+	sheetResp, err := ctl.sheetServiceClient.CreateSheet(ctx, connect.NewRequest(&v1pb.CreateSheetRequest{
+		Parent: ctl.project.Name,
+		Sheet:  &v1pb.Sheet{Content: []byte("SELECT 1;")},
+	}))
+	a.NoError(err)
+
+	planResp, err := ctl.planServiceClient.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+		Parent: ctl.project.Name,
+		Plan: &v1pb.Plan{Specs: []*v1pb.Plan_Spec{{
+			Id: uuid.NewString(),
+			Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+				ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{
+					Targets: []string{
+						fmt.Sprintf("%s/databases/%s", instance.Name, testDatabase),
+						fmt.Sprintf("%s/databases/%s", instance.Name, prodDatabase),
+					},
+					Sheet: sheetResp.Msg.Name,
+				},
+			},
+		}}},
+	}))
+	a.NoError(err)
+
+	rolloutResp, err := ctl.rolloutServiceClient.CreateRollout(ctx, connect.NewRequest(&v1pb.CreateRolloutRequest{
+		Parent: planResp.Msg.Name,
+	}))
+	a.NoError(err)
+
+	stageByID := map[string]*v1pb.Stage{}
+	for _, stage := range rolloutResp.Msg.Stages {
+		stageByID[stage.Id] = stage
+	}
+	testStage, ok := stageByID["test"]
+	a.True(ok, "rollout should have a test stage")
+	prodStage, ok := stageByID["prod"]
+	a.True(ok, "rollout should have a prod stage")
+
+	// Park a task run in each stage. A run time in the future leaves them PENDING,
+	// which is cancelable, without executing anything.
+	runTime := timestamppb.New(time.Now().Add(time.Hour))
+	for _, stage := range []*v1pb.Stage{testStage, prodStage} {
+		var taskNames []string
+		for _, task := range stage.Tasks {
+			taskNames = append(taskNames, task.Name)
+		}
+		a.NotEmpty(taskNames, "stage %s should have tasks", stage.Id)
+		_, err = ctl.rolloutServiceClient.BatchRunTasks(ctx, connect.NewRequest(&v1pb.BatchRunTasksRequest{
+			Parent:  stage.Name,
+			Tasks:   taskNames,
+			RunTime: runTime,
+		}))
+		a.NoError(err)
+	}
+
+	prodTaskRun := onlyTaskRunInStage(ctx, a, ctl, prodStage)
+	a.Equal(v1pb.TaskRun_PENDING, prodTaskRun.Status)
+
+	// The attack: address the prod task run as though it lived in the test stage.
+	// Only the stage segment changes; the task run ID still resolves in the project.
+	spoofed := testStage.Name + strings.TrimPrefix(prodTaskRun.Name, prodStage.Name)
+	a.NotEqual(prodTaskRun.Name, spoofed, "spoofed name should differ from the real one")
+
+	_, err = ctl.rolloutServiceClient.BatchCancelTaskRuns(ctx, connect.NewRequest(&v1pb.BatchCancelTaskRunsRequest{
+		Parent:   testStage.Name + "/tasks/-",
+		TaskRuns: []string{spoofed},
+	}))
+	a.Error(err, "canceling a prod task run through the test stage must be rejected")
+	a.Equal(connect.CodeNotFound, connect.CodeOf(err))
+
+	a.Equal(v1pb.TaskRun_PENDING, onlyTaskRunInStage(ctx, a, ctl, prodStage).Status,
+		"the prod task run must survive the rejected cancel")
+
+	// The legitimate path still works: the test stage can cancel its own task run.
+	testTaskRun := onlyTaskRunInStage(ctx, a, ctl, testStage)
+	_, err = ctl.rolloutServiceClient.BatchCancelTaskRuns(ctx, connect.NewRequest(&v1pb.BatchCancelTaskRunsRequest{
+		Parent:   testStage.Name + "/tasks/-",
+		TaskRuns: []string{testTaskRun.Name},
+	}))
+	a.NoError(err)
+	a.Equal(v1pb.TaskRun_CANCELED, onlyTaskRunInStage(ctx, a, ctl, testStage).Status)
+}
+
+func onlyTaskRunInStage(ctx context.Context, a *require.Assertions, ctl *controller, stage *v1pb.Stage) *v1pb.TaskRun {
+	resp, err := ctl.rolloutServiceClient.ListTaskRuns(ctx, connect.NewRequest(&v1pb.ListTaskRunsRequest{
+		Parent: stage.Name + "/tasks/-",
+	}))
+	a.NoError(err)
+	a.Len(resp.Msg.TaskRuns, 1, "stage %s should have exactly one task run", stage.Id)
+	return resp.Msg.TaskRuns[0]
+}


### PR DESCRIPTION
## What

`BatchCancelTaskRuns` checked the caller's permission against the stage named in the request, then resolved task runs by project and ID alone.

The stage segment of a task run name is caller-supplied, and the only stage check compared it to the parent's stage — both halves coming from the request body. Those names proved that the caller's strings agreed with each other; they proved nothing about the rows. `ListTaskRuns` then filtered on `Workspace` + `ProjectID` + `UIDs`, with no environment or plan predicate.

So cancel rights in one environment reached any cancelable task run in the project. A caller holding rollout-policy roles in `test` could send `parent = projects/P/plans/1/rollout/stages/test/tasks/-` with a task run name whose stage segment says `test` but whose ID belongs to a running production migration: the name check passes, permission is evaluated against `test`, and the ID resolves by project.

The RPC is `auth_method = CUSTOM`, so the interceptor is not a second gate (`acl.go:252-254` returns early for non-IAM methods) — the handler is the only gate.

This is T18a in `docs/design/v1-api-audit-2026-08.md`.

## Why it matters

For a PENDING or AVAILABLE row this flips it to CANCELED. For a RUNNING row the store UPDATE does not apply — it covers only PENDING/AVAILABLE — but the handler invokes the executor's `context.CancelFunc` and broadcasts `CANCEL_TASK_RUN` to every replica, aborting an in-flight migration mid-statement.

The gap is wider than the environment axis: with no plan predicate, the IDs could also belong to a different plan or issue in the same project. It does stay project-scoped — both the store UPDATE and the cancel-func key are project-qualified — so it never crossed projects.

## The fix

Confine the lookup to the plan and environment just authorized, and reject an ID that does not resolve within that scope rather than letting it fall through. Rejecting matters: the cancel is driven by the requested IDs, so adding the filter alone would have left a filtered-out ID still being canceled.

`Environment` and `PlanUID` already exist on `FindTaskRunMessage` and ride the `LEFT JOIN task` the query already performs, so this adds no round trips — the handler makes the same number of database calls as before. `task` carries `idx_task_plan_id_environment ON task(project, plan_id, environment)`, an exact prefix match for the two added predicates.

`BatchSkipTasks` derives its environment from the task rows for the same reason, so this brings the sibling in line. I deliberately did not copy its shape of looping the permission check once per distinct environment: the pre-existing name-consistency loop already forces a single stage per batch, so one check provably suffices, and `canUserCancelEnvironmentTaskRun` is the expensive call in this handler.

Also merges the two duplicate parse loops over `request.TaskRuns`, which is where most of the deletion comes from.

## Behavior change

Two request shapes that previously returned 200 now return an error:

- a task run ID outside the parent's stage or plan → `NotFound` (previously canceled — the bug)
- a task run ID that does not exist → `NotFound` (previously silently ignored)

Neither is reachable from the shipped callers. The rollout action panels and `cancelRollout` in `action/command/rollout.go` both group task runs by the stage the server reported, so every name they send already matches its parent.

I did not treat this as a breaking change: no legitimate caller changes behavior, and it restores correctness on a scoping predicate. Flagging it here so reviewers can decide otherwise.

## Testing

`backend/tests/task_run_cancel_scope_test.go` builds a two-stage rollout (one database per environment), parks a PENDING task run in each, addresses the prod task run under the test stage, and asserts `NotFound` plus the prod run surviving unchanged. It also asserts that the legitimate same-stage cancel still succeeds, so the fix cannot pass by being uniformly strict.

Verified locally:

- `gofmt` and `go vet ./backend/api/v1/ ./backend/tests/` clean
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go` passes
- `go test ./backend/api/v1/` — 88 failures, all 88 from `rootless Docker not found`; identical set before and after the change

Not verified locally — needs CI:

- **`golangci-lint` could not run.** The binary in this environment is built against Go 1.25 and refuses the repo's Go 1.26.5 target, so the lint gate is unmet locally.
- **The new test has not been executed.** `backend/tests` needs Docker (testcontainers) plus an external Postgres, neither available in this environment. It compiles and vets clean, but CI is its first real run.

Pre-PR checklist: §3 (composite-PK) is skippable since no `backend/store/` file changed, but verified regardless — the lookup identifies rows by the full `task_run` primary key `(project, id)` and joins `task` on its full primary key, with the two added predicates as further restrictions, so the change strictly narrows. §4 and §5 skipped (no store transaction, no version metadata). §8 needs no update: `sonar.test.inclusions` already matches `backend/tests/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tp2a2PixUBLjLkqHaZE9wK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tp2a2PixUBLjLkqHaZE9wK)_