### PR TITLE
fix: use latest schema snapshot for changelog diff

### DIFF
--- a/backend/api/mcp/gen/openapi.yaml
+++ b/backend/api/mcp/gen/openapi.yaml
@@ -13951,12 +13951,13 @@ components:
 
              Supported filter:
              - status: the changelog status, support "==" operation. check Changelog.Status for available values.
-             - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
+             - has_schema_snapshot: filters to changelogs with a schema snapshot; only "has_schema_snapshot == true" is supported.
+             - create_time: the changelog create time in RFC 3339 format, supports ">=", "<=", or "<" operator.
 
              Example:
              status == "DONE"
-             status == "FAILED" && type == "SDL"
-             create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
+             status == "FAILED"
+             has_schema_snapshot == true && create_time < "2024-01-02T00:00:00Z"
       title: ListChangelogsRequest
       additionalProperties: false
     bytebase.v1.ListChangelogsResponse:

--- a/backend/api/v1/changelog_service.go
+++ b/backend/api/v1/changelog_service.go
@@ -60,35 +60,49 @@ func parseChangelogFilter(filter string, find *store.FindChangelogMessage) error
 				}
 			case celoperators.Equals:
 				variable, value := getVariableAndValueFromExpr(expr)
-				strValue, ok := value.(string)
-				if !ok {
-					return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unexpected string but found %q", value))
-				}
 				switch variable {
 				case "status":
+					strValue, ok := value.(string)
+					if !ok {
+						return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unexpected string but found %q", value))
+					}
 					v1Status := v1pb.Changelog_Status_value[strValue]
 					storeStatus := convertToChangelogStoreStatus(v1pb.Changelog_Status(v1Status))
 					find.Status = &storeStatus
+				case "has_schema_snapshot":
+					hasSchemaSnapshot, ok := value.(bool)
+					if !ok {
+						return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unexpected bool but found %q", value))
+					}
+					if !hasSchemaSnapshot {
+						return connect.NewError(connect.CodeInvalidArgument, errors.Errorf(`"has_schema_snapshot" only supports true`))
+					}
+					find.HasSyncHistory = true
 				default:
 					return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unsupport variable %v", variable))
 				}
-			case celoperators.GreaterEquals, celoperators.LessEquals:
+			case celoperators.GreaterEquals, celoperators.LessEquals, celoperators.Less:
 				variable, rawValue := getVariableAndValueFromExpr(expr)
 				value, ok := rawValue.(string)
 				if !ok {
 					return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("expect string, got %T, hint: filter literals should be string", rawValue))
 				}
 				if variable != "create_time" {
-					return connect.NewError(connect.CodeInvalidArgument, errors.Errorf(`">=" and "<=" are only supported for "create_time"`))
+					return connect.NewError(connect.CodeInvalidArgument, errors.Errorf(`">=", "<=", and "<" are only supported for "create_time"`))
 				}
 				t, err := time.Parse(time.RFC3339, value)
 				if err != nil {
 					return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("failed to parse time %v, error: %v", value, err))
 				}
-				if functionName == celoperators.GreaterEquals {
+				switch functionName {
+				case celoperators.GreaterEquals:
 					find.CreatedAtAfter = &t
-				} else {
+				case celoperators.LessEquals:
 					find.CreatedAtBefore = &t
+				case celoperators.Less:
+					find.CreatedAtStrictlyBefore = &t
+				default:
+					return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unexpected function %v", functionName))
 				}
 			default:
 				return connect.NewError(connect.CodeInvalidArgument, errors.Errorf("unexpected function %v", functionName))

--- a/backend/api/v1/changelog_service_test.go
+++ b/backend/api/v1/changelog_service_test.go
@@ -11,13 +11,15 @@ import (
 
 func TestParseChangelogFilter(t *testing.T) {
 	tests := []struct {
-		name        string
-		filter      string
-		wantStatus  *store.ChangelogStatus
-		wantAfter   *time.Time
-		wantBefore  *time.Time
-		wantErr     bool
-		errContains string
+		name               string
+		filter             string
+		wantStatus         *store.ChangelogStatus
+		wantAfter          *time.Time
+		wantBefore         *time.Time
+		wantStrictBefore   *time.Time
+		wantSchemaSnapshot bool
+		wantErr            bool
+		errContains        string
 	}{
 		{
 			name:   "empty filter",
@@ -37,6 +39,12 @@ func TestParseChangelogFilter(t *testing.T) {
 			name:       "create_time less than or equal",
 			filter:     `create_time <= "2024-12-31T23:59:59Z"`,
 			wantBefore: ptr(mustParseTime(t, "2024-12-31T23:59:59Z")),
+		},
+		{
+			name:               "schema snapshot before create time",
+			filter:             `has_schema_snapshot == true && create_time < "2024-12-31T23:59:59.123456789Z"`,
+			wantSchemaSnapshot: true,
+			wantStrictBefore:   ptr(mustParseTime(t, "2024-12-31T23:59:59.123456789Z")),
 		},
 		{
 			name:       "create_time range",
@@ -60,7 +68,7 @@ func TestParseChangelogFilter(t *testing.T) {
 			name:        "time comparison on wrong field",
 			filter:      `status >= "2024-01-01T00:00:00Z"`,
 			wantErr:     true,
-			errContains: `">=" and "<=" are only supported for "create_time"`,
+			errContains: `">=", "<=", and "<" are only supported for "create_time"`,
 		},
 		{
 			name:        "unsupported variable",
@@ -102,6 +110,11 @@ func TestParseChangelogFilter(t *testing.T) {
 				require.NotNil(t, find.CreatedAtBefore)
 				require.Equal(t, *tt.wantBefore, *find.CreatedAtBefore)
 			}
+			if tt.wantStrictBefore != nil {
+				require.NotNil(t, find.CreatedAtStrictlyBefore)
+				require.Equal(t, *tt.wantStrictBefore, *find.CreatedAtStrictlyBefore)
+			}
+			require.Equal(t, tt.wantSchemaSnapshot, find.HasSyncHistory)
 		})
 	}
 }

--- a/backend/generated-go/v1/changelog_service.pb.go
+++ b/backend/generated-go/v1/changelog_service.pb.go
@@ -147,12 +147,13 @@ type ListChangelogsRequest struct {
 	//
 	// Supported filter:
 	// - status: the changelog status, support "==" operation. check Changelog.Status for available values.
-	// - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
+	// - has_schema_snapshot: filters to changelogs with a schema snapshot; only "has_schema_snapshot == true" is supported.
+	// - create_time: the changelog create time in RFC 3339 format, supports ">=", "<=", or "<" operator.
 	//
 	// Example:
 	// status == "DONE"
-	// status == "FAILED" && type == "SDL"
-	// create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
+	// status == "FAILED"
+	// has_schema_snapshot == true && create_time < "2024-01-02T00:00:00Z"
 	Filter        string `protobuf:"bytes,5,opt,name=filter,proto3" json:"filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/backend/store/changelog.go
+++ b/backend/store/changelog.go
@@ -44,9 +44,10 @@ type FindChangelogMessage struct {
 	ResourceID   *string
 	DatabaseName *string
 
-	Status          *ChangelogStatus
-	CreatedAtBefore *time.Time
-	CreatedAtAfter  *time.Time
+	Status                  *ChangelogStatus
+	CreatedAtBefore         *time.Time
+	CreatedAtAfter          *time.Time
+	CreatedAtStrictlyBefore *time.Time
 
 	Limit  *int
 	Offset *int
@@ -137,7 +138,7 @@ func (s *Store) UpdateChangelog(ctx context.Context, update *UpdateChangelogMess
 	return nil
 }
 
-func (s *Store) ListChangelogs(ctx context.Context, find *FindChangelogMessage) ([]*ChangelogMessage, error) {
+func buildListChangelogsQuery(find *FindChangelogMessage) (string, []any, error) {
 	// Avoid SQL-level string functions (e.g. LEFT()) on raw_dump — the column may
 	// contain invalid UTF-8 from TiDB/OceanBase schema syncs (SQLSTATE 22021).
 	// BASIC view skips the column entirely; FULL view fetches it and sanitizes in Go.
@@ -187,8 +188,11 @@ func (s *Store) ListChangelogs(ctx context.Context, find *FindChangelogMessage) 
 	if v := find.CreatedAtAfter; v != nil {
 		q.And("changelog.created_at >= ?", *v)
 	}
+	if v := find.CreatedAtStrictlyBefore; v != nil {
+		q.And("changelog.created_at < ?", *v)
+	}
 
-	q.Space("ORDER BY changelog.created_at DESC")
+	q.Space("ORDER BY changelog.created_at DESC, changelog.resource_id DESC")
 	if v := find.Limit; v != nil {
 		q.Space("LIMIT ?", *v)
 	}
@@ -196,7 +200,11 @@ func (s *Store) ListChangelogs(ctx context.Context, find *FindChangelogMessage) 
 		q.Space("OFFSET ?", *v)
 	}
 
-	query, args, err := q.ToSQL()
+	return q.ToSQL()
+}
+
+func (s *Store) ListChangelogs(ctx context.Context, find *FindChangelogMessage) ([]*ChangelogMessage, error) {
+	query, args, err := buildListChangelogsQuery(find)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to build sql")
 	}

--- a/backend/store/changelog_test.go
+++ b/backend/store/changelog_test.go
@@ -1,1 +1,29 @@
 package store
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildListChangelogsQuerySchemaSnapshotBefore(t *testing.T) {
+	before, err := time.Parse(time.RFC3339Nano, "2024-12-31T23:59:59.123456789Z")
+	require.NoError(t, err)
+	database := "db"
+	limit := 1
+
+	query, args, err := buildListChangelogsQuery(&FindChangelogMessage{
+		InstanceID:              "instance",
+		DatabaseName:            &database,
+		HasSyncHistory:          true,
+		CreatedAtStrictlyBefore: &before,
+		Limit:                   &limit,
+	})
+	require.NoError(t, err)
+	require.Contains(t, strings.Join(strings.Fields(query), " "), "changelog.sync_history IS NOT NULL")
+	require.Contains(t, strings.Join(strings.Fields(query), " "), "changelog.created_at < $3")
+	require.Contains(t, strings.Join(strings.Fields(query), " "), "ORDER BY changelog.created_at DESC, changelog.resource_id DESC LIMIT $4")
+	require.Equal(t, []any{"instance", "db", before, 1}, args)
+}

--- a/frontend/src/stores/app/changelog.ts
+++ b/frontend/src/stores/app/changelog.ts
@@ -1,4 +1,5 @@
-import { create as createProto } from "@bufbuild/protobuf";
+import { create as createProto, toJson } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
 import { changelogServiceClientConnect } from "@/api";
 import { UNKNOWN_ID } from "@/types";
 import {
@@ -189,21 +190,21 @@ export const createChangelogSlice: AppSliceCreator<ChangelogSlice> = (
       return undefined;
     }
 
-    const { changelogs } = await get().listChangelogs({
-      parent: database,
-      pageSize: 1000,
-      view: ChangelogView.BASIC,
-    });
-    const index = changelogs.findIndex(
-      (changelog) => extractChangelogUID(changelog.name) === currentUid
-    );
-    if (index < 0 || index === changelogs.length - 1) {
-      return undefined;
-    }
-    return get().getOrFetchChangelogByName(
-      changelogs[index + 1].name,
+    const current = await get().getOrFetchChangelogByName(
+      name,
       ChangelogView.FULL
     );
+    if (!current?.createTime) {
+      return undefined;
+    }
+    const createTime = toJson(TimestampSchema, current.createTime);
+    const { changelogs } = await get().listChangelogs({
+      parent: database,
+      pageSize: 1,
+      view: ChangelogView.FULL,
+      filter: `has_schema_snapshot == true && create_time < "${createTime}"`,
+    });
+    return changelogs[0];
   },
 });
 

--- a/frontend/src/stores/app/index.test.ts
+++ b/frontend/src/stores/app/index.test.ts
@@ -1,4 +1,5 @@
 import { create as createProto } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { silentContextKey } from "@/api/context-key";
 import { isValidDatabaseGroupName, UNKNOWN_PROJECT_NAME } from "@/types";
@@ -437,6 +438,11 @@ const changelogA = createProto(ChangelogSchema, {
 const changelogB = createProto(ChangelogSchema, {
   name: "instances/i1/databases/db1/changelogs/2",
   schema: "full",
+});
+
+const changelogCreateTime = createProto(TimestampSchema, {
+  seconds: 1735689599n,
+  nanos: 123456789,
 });
 
 const webhookA = createProto(WebhookSchema, {
@@ -1441,6 +1447,37 @@ describe("useAppStore", () => {
         `${changelogA.name}|${ChangelogView.BASIC}`
       ]
     ).toBeUndefined();
+  });
+
+  test("fetches the latest prior changelog with a schema snapshot", async () => {
+    const current = createProto(ChangelogSchema, {
+      ...changelogA,
+      createTime: changelogCreateTime,
+    });
+    mocks.getChangelog.mockResolvedValue(current);
+    mocks.listChangelogs.mockResolvedValue({ changelogs: [changelogB] });
+    const store = createAppStore();
+
+    const previous = await store
+      .getState()
+      .fetchPreviousChangelog(current.name);
+
+    expect(previous).toBe(changelogB);
+    expect(mocks.getChangelog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: current.name,
+        view: ChangelogView.FULL,
+      })
+    );
+    expect(mocks.listChangelogs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        parent: "instances/i1/databases/db1",
+        pageSize: 1,
+        view: ChangelogView.FULL,
+        filter:
+          'has_schema_snapshot == true && create_time < "2024-12-31T23:59:59.123456789Z"',
+      })
+    );
   });
 
   test("project webhook operations call through and lookup by id", async () => {

--- a/frontend/src/types/proto-es/v1/changelog_service_pb.d.ts
+++ b/frontend/src/types/proto-es/v1/changelog_service_pb.d.ts
@@ -54,12 +54,13 @@ export declare type ListChangelogsRequest = Message<"bytebase.v1.ListChangelogsR
    *
    * Supported filter:
    * - status: the changelog status, support "==" operation. check Changelog.Status for available values.
-   * - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
+   * - has_schema_snapshot: filters to changelogs with a schema snapshot; only "has_schema_snapshot == true" is supported.
+   * - create_time: the changelog create time in RFC 3339 format, supports ">=", "<=", or "<" operator.
    *
    * Example:
    * status == "DONE"
-   * status == "FAILED" && type == "SDL"
-   * create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
+   * status == "FAILED"
+   * has_schema_snapshot == true && create_time < "2024-01-02T00:00:00Z"
    *
    * @generated from field: string filter = 5;
    */

--- a/proto/gen/grpc-doc/openapi.yaml
+++ b/proto/gen/grpc-doc/openapi.yaml
@@ -2691,12 +2691,13 @@ paths:
 
              Supported filter:
              - status: the changelog status, support "==" operation. check Changelog.Status for available values.
-             - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
+             - has_schema_snapshot: filters to changelogs with a schema snapshot; only "has_schema_snapshot == true" is supported.
+             - create_time: the changelog create time in RFC 3339 format, supports ">=", "<=", or "<" operator.
 
              Example:
              status == "DONE"
-             status == "FAILED" && type == "SDL"
-             create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
+             status == "FAILED"
+             has_schema_snapshot == true && create_time < "2024-01-02T00:00:00Z"
           schema:
             type: string
             title: filter
@@ -7830,12 +7831,13 @@ paths:
 
              Supported filter:
              - status: the changelog status, support "==" operation. check Changelog.Status for available values.
-             - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
+             - has_schema_snapshot: filters to changelogs with a schema snapshot; only "has_schema_snapshot == true" is supported.
+             - create_time: the changelog create time in RFC 3339 format, supports ">=", "<=", or "<" operator.
 
              Example:
              status == "DONE"
-             status == "FAILED" && type == "SDL"
-             create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
+             status == "FAILED"
+             has_schema_snapshot == true && create_time < "2024-01-02T00:00:00Z"
           schema:
             type: string
             title: filter
@@ -25014,12 +25016,13 @@ components:
 
              Supported filter:
              - status: the changelog status, support "==" operation. check Changelog.Status for available values.
-             - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
+             - has_schema_snapshot: filters to changelogs with a schema snapshot; only "has_schema_snapshot == true" is supported.
+             - create_time: the changelog create time in RFC 3339 format, supports ">=", "<=", or "<" operator.
 
              Example:
              status == "DONE"
-             status == "FAILED" && type == "SDL"
-             create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
+             status == "FAILED"
+             has_schema_snapshot == true && create_time < "2024-01-02T00:00:00Z"
       title: ListChangelogsRequest
       required:
         - parent

--- a/proto/gen/grpc-doc/v1/README.md
+++ b/proto/gen/grpc-doc/v1/README.md
@@ -6251,9 +6251,9 @@ When paginating, all other parameters provided must match the call that provided
 | view | [ChangelogView](#bytebase-v1-ChangelogView) |  |  |
 | filter | [string](#string) |  | Filter is used to filter changelogs returned in the list. The syntax and semantics of CEL are documented at https://github.com/google/cel-spec
 
-Supported filter: - status: the changelog status, support &#34;==&#34; operation. check Changelog.Status for available values. - create_time: the changelog create time in &#34;2006-01-02T15:04:05Z07:00&#34; format, support &#34;&gt;=&#34; or &#34;&lt;=&#34; operator.
+Supported filter: - status: the changelog status, support &#34;==&#34; operation. check Changelog.Status for available values. - has_schema_snapshot: filters to changelogs with a schema snapshot; only &#34;has_schema_snapshot == true&#34; is supported. - create_time: the changelog create time in RFC 3339 format, supports &#34;&gt;=&#34;, &#34;&lt;=&#34;, or &#34;&lt;&#34; operator.
 
-Example: status == &#34;DONE&#34; status == &#34;FAILED&#34; &amp;&amp; type == &#34;SDL&#34; create_time &gt;= &#34;2024-01-01T00:00:00Z&#34; &amp;&amp; create_time &lt;= &#34;2024-01-02T00:00:00Z&#34; |
+Example: status == &#34;DONE&#34; status == &#34;FAILED&#34; has_schema_snapshot == true &amp;&amp; create_time &lt; &#34;2024-01-02T00:00:00Z&#34; |
 
 
 

--- a/proto/gen/grpc-doc/v1/index.html
+++ b/proto/gen/grpc-doc/v1/index.html
@@ -17831,12 +17831,13 @@ The syntax and semantics of CEL are documented at https://github.com/google/cel-
 
 Supported filter:
 - status: the changelog status, support &#34;==&#34; operation. check Changelog.Status for available values.
-- create_time: the changelog create time in &#34;2006-01-02T15:04:05Z07:00&#34; format, support &#34;&gt;=&#34; or &#34;&lt;=&#34; operator.
+- has_schema_snapshot: filters to changelogs with a schema snapshot; only &#34;has_schema_snapshot == true&#34; is supported.
+- create_time: the changelog create time in RFC 3339 format, supports &#34;&gt;=&#34;, &#34;&lt;=&#34;, or &#34;&lt;&#34; operator.
 
 Example:
 status == &#34;DONE&#34;
-status == &#34;FAILED&#34; &amp;&amp; type == &#34;SDL&#34;
-create_time &gt;= &#34;2024-01-01T00:00:00Z&#34; &amp;&amp; create_time &lt;= &#34;2024-01-02T00:00:00Z&#34; </p></td>
+status == &#34;FAILED&#34;
+has_schema_snapshot == true &amp;&amp; create_time &lt; &#34;2024-01-02T00:00:00Z&#34; </p></td>
                 </tr>
               
             </tbody>

--- a/proto/v1/v1/changelog_service.proto
+++ b/proto/v1/v1/changelog_service.proto
@@ -75,12 +75,13 @@ message ListChangelogsRequest {
   //
   // Supported filter:
   // - status: the changelog status, support "==" operation. check Changelog.Status for available values.
-  // - create_time: the changelog create time in "2006-01-02T15:04:05Z07:00" format, support ">=" or "<=" operator.
+  // - has_schema_snapshot: filters to changelogs with a schema snapshot; only "has_schema_snapshot == true" is supported.
+  // - create_time: the changelog create time in RFC 3339 format, supports ">=", "<=", or "<" operator.
   //
   // Example:
   // status == "DONE"
-  // status == "FAILED" && type == "SDL"
-  // create_time >= "2024-01-01T00:00:00Z" && create_time <= "2024-01-02T00:00:00Z"
+  // status == "FAILED"
+  // has_schema_snapshot == true && create_time < "2024-01-02T00:00:00Z"
   string filter = 5;
 }
 


### PR DESCRIPTION
## Summary

- expose changelog filters for schema snapshots and strict creation-time bounds
- resolve schema diffs against the latest prior schema-bearing changelog
- preserve protobuf timestamp precision and avoid scanning up to 1,000 changelogs
- add backend parser/query and frontend regression coverage

## Root cause

Data-only changes and rollbacks intentionally do not create schema snapshots. The frontend selected the immediately preceding changelog, so the next schema change compared its complete schema against an empty dump.

Fixes [BYT-10146](https://linear.app/bytebase/issue/BYT-10146/schema-diff-broken-after-upgrading-to-3220).

## Testing

- go test ./backend/api/v1 -run ^TestParseChangelogFilter$ -count=1
- go test ./backend/store -run ^TestBuildListChangelogsQuerySchemaSnapshotBefore$ -count=1
- pnpm --dir frontend test: 3,838 tests passed
- pnpm --dir frontend check
- pnpm --dir frontend type-check
- buf format -w proto
- buf lint proto
- buf generate
- go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go
- git diff --check

golangci-lint was run and reports only existing generated-code, repository-baseline, and stale cross-worktree findings outside the changed files.