### PR TITLE
chore: remove unused Prettier configs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "useTabs": false,
-  "tabWidth": 2,
-  "singleQuote": false,
-  "trailingComma": "es5",
-  "printWidth": 80
-}

--- a/frontend/src/locales/.prettierrc
+++ b/frontend/src/locales/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "useTabs": false,
-  "tabWidth": 2,
-  "singleQuote": false,
-  "trailingComma": "es5",
-  "printWidth": 80
-}


### PR DESCRIPTION
## Summary

- remove the stale root Prettier configuration
- remove the duplicate locale-specific Prettier configuration
- rely on the existing Biome formatter configuration

## Testing

- Not run (configuration-only deletion; Prettier is absent from scripts and dependencies)