### PR TITLE
refactor(store): put review_run's primary-key columns first

### DIFF
--- a/backend/migrator/migration/3.23/0000##review_run.sql
+++ b/backend/migrator/migration/3.23/0000##review_run.sql
@@ -3,14 +3,14 @@
 -- not the slot's history). Results live in issue comments; the run carries
 -- none. No standalone id on purpose: nothing may durably reference a run.
 CREATE TABLE review_run (
-    created_at timestamptz NOT NULL DEFAULT now(),
-    updated_at timestamptz NOT NULL DEFAULT now(),
     project text NOT NULL REFERENCES project(resource_id),
     issue_id bigint NOT NULL,
     -- Reviewer type: 'RULE' (standard rules) or 'GUIDELINE' (natural-language
     -- guidelines, performed by AI). No CHECK on purpose: the reviewer-id space
     -- is open.
     type text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
     -- Attempt number of the current run, 0-based like task_run.attempt.
     -- Bumped on every slot reset (issue created / SQL updated / manual
     -- re-run); it counts triggers, not completed executions. The completion

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -376,14 +376,14 @@ CREATE UNIQUE INDEX idx_issue_comment_unique_resource_id ON issue_comment(resour
 -- not the slot's history). Results live in issue comments; the run carries
 -- none. No standalone id on purpose: nothing may durably reference a run.
 CREATE TABLE review_run (
-    created_at timestamptz NOT NULL DEFAULT now(),
-    updated_at timestamptz NOT NULL DEFAULT now(),
     project text NOT NULL REFERENCES project(resource_id),
     issue_id bigint NOT NULL,
     -- Reviewer type: 'RULE' (standard rules) or 'GUIDELINE' (natural-language
     -- guidelines, performed by AI). No CHECK on purpose: the reviewer-id space
     -- is open.
     type text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
     -- Attempt number of the current run, 0-based like task_run.attempt.
     -- Bumped on every slot reset (issue created / SQL updated / manual
     -- re-run); it counts triggers, not completed executions. The completion


### PR DESCRIPTION
## What

Column-order polish on the `review_run` table added in #21271: lead with the primary-key columns `(project, issue_id, type)`, then `created_at`/`updated_at`, then the rest. Applied identically to the `3.23/0000` migration and `LATEST.sql`. No semantic change — constraints, indexes, defaults, and comments are untouched.

## Why

Matches the newer-table style where the primary key leads the definition (`plan_webhook_delivery`, `login_attempt`), so the key structure is readable at a glance.

## In-place migration edit

`3.23/0000##review_run.sql` is edited in place rather than adding a follow-up migration: 3.23 is unreleased and the migrator records only applied versions (no script hash), so fresh installs and 3.22.x upgrades both produce the new order. Environments that already applied the previous file from main keep the old column order — a cosmetic-only divergence with no functional effect (no `SELECT *` or positional access on this table).

## Testing

- Full `LATEST.sql` applies cleanly on PostgreSQL 17; `\d review_run` shows the new order with PK and both partial indexes intact.
- `TestLatestVersion` / `TestVersionUnique` pass (file path and version unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)