### PR TITLE
fix: remove 80-char truncation of executed statement in changelog viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ scripts/azure-marketplace/*.backup
 # superpowers brainstorm sessions (visual companion mockups)
 .superpowers/
 .gocache/
+.pnpm-store/
+
+# Reasonix tool cache
+.reasonix/

--- a/frontend/src/components/task-run-log/model.ts
+++ b/frontend/src/components/task-run-log/model.ts
@@ -319,10 +319,7 @@ const getCommandExecuteDetail = (
       : undefined);
   if (!statement) return "-";
 
-  const normalized = statement.trim().replace(/\s+/g, " ");
-  return normalized.length > 80
-    ? `${normalized.substring(0, 80)}...`
-    : normalized;
+  return statement.trim().replace(/\s+/g, " ");
 };
 
 const getTransactionControlDetail = (


### PR DESCRIPTION
fix: remove 80-char truncation of executed statement in changelog viewer

Fixes #21318

Problem:

When using SDL (Schema Definition Language), the executed statement in the changelog detail page is truncated to 80 characters with "..." appended. 
SDL statements are typically very long (e.g., full CREATE TABLE), making them unreadable.

Root Cause:

getCommandExecuteDetail in frontend/src/components/task-run-log/model.ts hardcodes a 80-character truncation.

Fix:

Removed the truncation entirely. The statement is now rendered in full, and CSS (break-words, overflow: auto) handles long text naturally.

Verification:

- pnpm check passed
- 474 test files, 3855 test cases all passed

### Screenshots

After fix - changelog detail page showing the full statement:
<img width="2100" height="492" alt="image" src="https://github.com/user-attachments/assets/471e10ba-fe57-4dc9-a3ca-9b3d04c7ae90" />
