### PR TITLE
feat(comment): add flat reply threads to issue comments

### DIFF
--- a/backend/api/v1/issue_service.go
+++ b/backend/api/v1/issue_service.go
@@ -1351,6 +1351,9 @@ func (s *IssueService) UpdateIssueComment(ctx context.Context, req *connect.Requ
 	for _, path := range req.Msg.UpdateMask.Paths {
 		switch path {
 		case "comment":
+			if req.Msg.IssueComment.Comment == "" {
+				return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf("issue comment is empty"))
+			}
 			update.Comment = &req.Msg.IssueComment.Comment
 		default:
 			return nil, connect.NewError(connect.CodeInvalidArgument, errors.Errorf(`unsupport update_mask: "%s"`, path))

--- a/backend/api/v1/issue_service_test.go
+++ b/backend/api/v1/issue_service_test.go
@@ -29,6 +29,40 @@ import (
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
 )
 
+func TestUpdateIssueCommentRejectsEmptyComment(t *testing.T) {
+	ctx := issueServiceTestContext()
+	stores := setupIssueServiceTestStore(ctx, t)
+	service := newIssueServiceForTest(t, stores)
+	_, issue := createIssueServiceApprovalIssue(ctx, t, stores)
+	parent := common.FormatIssue(issue.ProjectID, issue.UID)
+
+	created, err := service.CreateIssueComment(ctx, connect.NewRequest(&v1pb.CreateIssueCommentRequest{
+		Parent: parent,
+		IssueComment: &v1pb.IssueComment{
+			Comment: "keep me",
+		},
+	}))
+	require.NoError(t, err)
+
+	_, err = service.UpdateIssueComment(ctx, connect.NewRequest(&v1pb.UpdateIssueCommentRequest{
+		Parent: parent,
+		IssueComment: &v1pb.IssueComment{
+			Name:    created.Msg.Name,
+			Comment: "",
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"comment"}},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
+		ProjectID: issue.ProjectID,
+		IssueUID:  &issue.UID,
+	})
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	require.Equal(t, "keep me", comments[0].Payload.GetComment())
+}
+
 func TestDraftLabelUpdateConflictsWithConcurrentSubmission(t *testing.T) {
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)

--- a/backend/migrator/migration/3.23/0001##issue_comment_thread.sql
+++ b/backend/migrator/migration/3.23/0001##issue_comment_thread.sql
@@ -1,0 +1,27 @@
+-- Add flat reply threads to issue comments.
+ALTER TABLE issue_comment
+    -- The root comment of this reply's thread; NULL on root comments and
+    -- events. A reply references the root directly, never another reply.
+    ADD COLUMN parent_id text REFERENCES issue_comment(resource_id),
+    -- OPEN/RESOLVED on root comments; NULL on replies and events.
+    ADD COLUMN thread_state text CHECK (thread_state IN ('OPEN', 'RESOLVED'));
+
+-- FK referencing side and reply reads. Partial: most rows have no parent.
+CREATE INDEX idx_issue_comment_parent_id ON issue_comment(parent_id)
+    WHERE parent_id IS NOT NULL;
+
+-- Every valid legacy Comment becomes an OPEN thread root. Protojson omits an
+-- empty comment, so both {} and {"comment": ""} are Comments. Event, hybrid,
+-- legacy Event-key, and malformed payloads stay outside threads.
+UPDATE issue_comment
+SET thread_state = 'OPEN'
+WHERE CASE WHEN jsonb_typeof(payload) = 'object'
+           THEN payload - 'comment' = '{}'::jsonb
+                AND (NOT (payload ? 'comment') OR jsonb_typeof(payload -> 'comment') = 'string')
+           ELSE false END;
+
+-- Built after the backfill: the UPDATE would otherwise maintain it per row.
+CREATE INDEX idx_issue_comment_open_thread ON issue_comment(project, issue_id)
+    WHERE thread_state = 'OPEN';
+
+ANALYZE issue_comment;

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -364,12 +364,21 @@ CREATE TABLE issue_comment (
     issue_id integer NOT NULL,
     -- Stored as IssueCommentPayload (proto/store/store/issue_comment.proto)
     payload jsonb NOT NULL DEFAULT '{}',
+    -- The root comment of this reply's thread; NULL on root comments and
+    -- events. A reply references the root directly, never another reply.
+    parent_id text REFERENCES issue_comment(resource_id),
+    -- OPEN/RESOLVED on root comments; NULL on replies and events.
+    thread_state text CHECK (thread_state IN ('OPEN', 'RESOLVED')),
     PRIMARY KEY (resource_id),
     FOREIGN KEY (project, issue_id) REFERENCES issue(project, id)
 );
 
 CREATE INDEX idx_issue_comment_issue_id ON issue_comment(project, issue_id);
 CREATE UNIQUE INDEX idx_issue_comment_unique_resource_id ON issue_comment(resource_id);
+CREATE INDEX idx_issue_comment_parent_id ON issue_comment(parent_id)
+    WHERE parent_id IS NOT NULL;
+CREATE INDEX idx_issue_comment_open_thread ON issue_comment(project, issue_id)
+    WHERE thread_state = 'OPEN';
 
 -- SQL Review V2 run status slot: one row per (issue, reviewer type), reset in
 -- place on re-run (created_at = now() on reset — the row is the current run,

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -21,8 +21,101 @@ import (
 func TestLatestVersion(t *testing.T) {
 	files, err := getSortedVersionedFiles()
 	require.NoError(t, err)
-	require.Equal(t, semver.MustParse("3.23.0"), *files[len(files)-1].version)
-	require.Equal(t, "migration/3.23/0000##review_run.sql", files[len(files)-1].path)
+	require.Equal(t, semver.MustParse("3.23.1"), *files[len(files)-1].version)
+	require.Equal(t, "migration/3.23/0001##issue_comment_thread.sql", files[len(files)-1].path)
+}
+
+func TestMigration3_23_1_IssueCommentThreads(t *testing.T) {
+	ctx := context.Background()
+	container := testcontainer.GetTestPgContainer(ctx, t)
+	t.Cleanup(func() { container.Close(ctx) })
+
+	db := container.GetDB()
+
+	// Minimal pre-3.23.1 shape of issue_comment.
+	setup := `
+		CREATE TABLE issue_comment (
+			resource_id text NOT NULL,
+			project text NOT NULL DEFAULT 'p1',
+			issue_id integer NOT NULL DEFAULT 101,
+			payload jsonb NOT NULL DEFAULT '{}'
+		);
+		CREATE UNIQUE INDEX idx_issue_comment_unique_resource_id ON issue_comment(resource_id);
+		ALTER TABLE issue_comment ADD PRIMARY KEY (resource_id);
+		INSERT INTO issue_comment (resource_id, payload) VALUES
+			('comment-only', '{"comment": "hello"}'),
+			('empty-comment', '{"comment": ""}'),
+			('empty-object', '{}'),
+			('hybrid', '{"comment": "approved", "approval": {}}'),
+			('event-only', '{"issueUpdate": {"toTitle": "t"}}'),
+			('legacy-event', '{"planSpecUpdate": {}}'),
+			('numeric-comment', '{"comment": 123}'),
+			('null-comment', '{"comment": null}'),
+			('scalar', '"comment"');
+	`
+	_, err := db.ExecContext(ctx, setup)
+	require.NoError(t, err)
+
+	migration, err := migrationFS.ReadFile("migration/3.23/0001##issue_comment_thread.sql")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, string(migration))
+	require.NoError(t, err)
+
+	wantOpen := map[string]bool{
+		"comment-only":    true,
+		"empty-comment":   true,
+		"empty-object":    true,
+		"hybrid":          false,
+		"event-only":      false,
+		"legacy-event":    false,
+		"numeric-comment": false,
+		"null-comment":    false,
+		"scalar":          false,
+	}
+	rows, err := db.QueryContext(ctx, `SELECT resource_id, thread_state = 'OPEN' FROM issue_comment`)
+	require.NoError(t, err)
+	defer rows.Close()
+	seen := 0
+	for rows.Next() {
+		var id string
+		var open *bool
+		require.NoError(t, rows.Scan(&id, &open))
+		want, ok := wantOpen[id]
+		require.True(t, ok, "unexpected row %s", id)
+		require.Equal(t, want, open != nil && *open, "thread classification for %s", id)
+		seen++
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, len(wantOpen), seen)
+
+	var indexes int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*) FROM pg_indexes
+		WHERE indexname IN ('idx_issue_comment_parent_id', 'idx_issue_comment_open_thread')
+	`).Scan(&indexes))
+	require.Equal(t, 2, indexes)
+
+	// On upgraded databases the explicit-column FK binds the pre-existing
+	// duplicate unique index, not the primary key (this fixture recreates
+	// that index order). Accepted for now; the deferred cleanup that drops
+	// idx_issue_comment_unique_resource_id must swap the FK dependency and
+	// flip this assertion to issue_comment_pkey.
+	var referencedIndex string
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT referenced_index.relname
+		FROM pg_constraint
+		JOIN pg_class AS referenced_index ON referenced_index.oid = pg_constraint.conindid
+		WHERE pg_constraint.conname = 'issue_comment_parent_id_fkey'
+		  AND pg_constraint.conrelid = 'issue_comment'::regclass
+	`).Scan(&referencedIndex))
+	require.Equal(t, "idx_issue_comment_unique_resource_id", referencedIndex)
+
+	_, err = db.ExecContext(ctx, `INSERT INTO issue_comment (resource_id, payload, parent_id) VALUES ('reply', '{"comment": "re"}', 'comment-only')`)
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, `INSERT INTO issue_comment (resource_id, payload, parent_id) VALUES ('orphan', '{"comment": "re"}', 'missing')`)
+	require.Error(t, err, "parent_id must reference an existing comment")
+	_, err = db.ExecContext(ctx, `UPDATE issue_comment SET thread_state = 'INVALID' WHERE resource_id = 'comment-only'`)
+	require.Error(t, err, "thread_state must reject unknown values")
 }
 
 func TestVersionUnique(t *testing.T) {

--- a/backend/store/issue_comment.go
+++ b/backend/store/issue_comment.go
@@ -127,7 +127,8 @@ func (s *Store) ListIssueComment(ctx context.Context, find *FindIssueCommentMess
 	return issueComments, nil
 }
 
-// CreateIssueComments creates one or more issue comments.
+// CreateIssueComments creates one or more root comments or events.
+// Reply creation is not supported by this writer yet.
 // For a single comment, it returns the created comment with UID, CreatedAt, and UpdatedAt filled in.
 // For multiple comments, it performs a batch insert and returns nil.
 func (s *Store) CreateIssueComments(ctx context.Context, creator string, creates ...*IssueCommentMessage) (*IssueCommentMessage, error) {
@@ -139,6 +140,7 @@ func (s *Store) CreateIssueComments(ctx context.Context, creator string, creates
 	projectIDs := make([]string, 0, len(creates))
 	issueIDs := make([]int64, 0, len(creates))
 	payloads := make([][]byte, 0, len(creates))
+	threadRoots := make([]bool, 0, len(creates))
 	for _, create := range creates {
 		payload, err := protojson.Marshal(create.Payload)
 		if err != nil {
@@ -147,6 +149,9 @@ func (s *Store) CreateIssueComments(ctx context.Context, creator string, creates
 		projectIDs = append(projectIDs, create.ProjectID)
 		issueIDs = append(issueIDs, create.IssueUID)
 		payloads = append(payloads, payload)
+		// Current event-less writes are roots. Event and hybrid rows remain
+		// outside threads; replies will additionally require parent_id handling.
+		threadRoots = append(threadRoots, create.Payload.GetEvent() == nil)
 	}
 
 	// Use UNNEST to insert all comments in one query.
@@ -158,12 +163,12 @@ func (s *Store) CreateIssueComments(ctx context.Context, creator string, creates
 	// ordinal keeps the batch in insertion order and makes created_at unique
 	// within it, at a cost of microseconds.
 	q := qb.Q().Space(`
-		INSERT INTO issue_comment (creator, project, issue_id, payload, created_at, updated_at)
-		SELECT ?, c.project, c.issue_id, c.payload, t.at, t.at
-		FROM unnest(?::TEXT[], ?::INT[], ?::JSONB[])
-		     WITH ORDINALITY AS c(project, issue_id, payload, ordinality),
+		INSERT INTO issue_comment (creator, project, issue_id, payload, thread_state, created_at, updated_at)
+		SELECT ?, c.project, c.issue_id, c.payload, CASE WHEN c.is_thread_root THEN 'OPEN' END, t.at, t.at
+		FROM unnest(?::TEXT[], ?::INT[], ?::JSONB[], ?::BOOLEAN[])
+		     WITH ORDINALITY AS c(project, issue_id, payload, is_thread_root, ordinality),
 		     LATERAL (SELECT now() + ((c.ordinality - 1) * interval '1 microsecond')) AS t(at)
-	`, creator, projectIDs, issueIDs, payloads)
+	`, creator, projectIDs, issueIDs, payloads, threadRoots)
 
 	// For single comment, use RETURNING to get the created comment details.
 	if len(creates) == 1 {

--- a/backend/store/pagination_integration_test.go
+++ b/backend/store/pagination_integration_test.go
@@ -179,4 +179,56 @@ func TestIssueCommentBatchKeepsInsertionOrder(t *testing.T) {
 		order = append(order, comment.Payload.Comment)
 	}
 	require.Equal(t, want, order, "a batch of issue comments must read back in insertion order")
+
+	var openRoots int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*) FROM issue_comment
+		WHERE project = $1 AND issue_id = $2 AND thread_state = 'OPEN'
+	`, projectID, issueUID).Scan(&openRoots))
+	require.Equal(t, len(want), openRoots, "new comment-only rows must be OPEN roots")
+
+	_, err = stores.CreateIssueComments(ctx, "users/comment@example.com",
+		&store.IssueCommentMessage{
+			ProjectID: projectID,
+			IssueUID:  issueUID,
+			Payload: &storepb.IssueCommentPayload{
+				Event: &storepb.IssueCommentPayload_IssueUpdate_{
+					IssueUpdate: &storepb.IssueCommentPayload_IssueUpdate{},
+				},
+			},
+		},
+		&store.IssueCommentMessage{
+			ProjectID: projectID,
+			IssueUID:  issueUID,
+			Payload: &storepb.IssueCommentPayload{
+				Comment: "approved",
+				Event: &storepb.IssueCommentPayload_Approval_{
+					Approval: &storepb.IssueCommentPayload_Approval{},
+				},
+			},
+		},
+		&store.IssueCommentMessage{
+			ProjectID: projectID,
+			IssueUID:  issueUID,
+			Payload:   &storepb.IssueCommentPayload{},
+		},
+	)
+	require.NoError(t, err)
+
+	var eventsOutsideThreads int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*) FROM issue_comment
+		WHERE project = $1 AND issue_id = $2
+		  AND (payload ? 'issueUpdate' OR payload ? 'approval')
+		  AND thread_state IS NULL
+	`, projectID, issueUID).Scan(&eventsOutsideThreads))
+	require.Equal(t, 2, eventsOutsideThreads, "event and hybrid rows must stay outside threads")
+
+	var emptyRoots int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*) FROM issue_comment
+		WHERE project = $1 AND issue_id = $2
+		  AND payload = '{}'::jsonb AND thread_state = 'OPEN'
+	`, projectID, issueUID).Scan(&emptyRoots))
+	require.Equal(t, 1, emptyRoots, "an event-less payload is still a root comment")
 }


### PR DESCRIPTION
## What

Migration 3.23.1 adds flat reply threads to `issue_comment`:

- `parent_id` — self-FK to the thread's root comment; NULL on root comments and events.
- `thread_state` — OPEN/RESOLVED on root comments; NULL on replies and events.
- Partial indexes `idx_issue_comment_parent_id` (FK referencing side, reply reads) and `idx_issue_comment_open_thread` (open-thread lookups), plus `ANALYZE` after the backfill.
- Backfill: every valid legacy Comment row becomes an OPEN thread root; event, hybrid, legacy event-key, and malformed payloads stay outside threads. The predicate is positive and scalar-safe — real payloads still carry keys from removed or renamed proto fields (e.g. `planSpecUpdate`) that a blocklist of current event keys would misclassify.
- `CreateIssueComments` writes `thread_state='OPEN'` for event-less payloads so new comments match the backfill; reply creation is not supported yet.
- `UpdateIssueComment` now rejects empty comment text, matching `CreateIssueComment` (previously an empty update stored `{"comment": ""}`).

Part of BYT-9955.

## Why

The Plan Review comment/thread design keeps Comments and Events in the single `issue_comment` model; a thread is a root comment plus flat direct replies, with the root comment owning the OPEN/RESOLVED state. This PR lands the database layer; the store/API thread surface follows separately.

## Notes

- The migration is strictly additive. Dropping the redundant `idx_issue_comment_unique_resource_id` (which the new FK binds on upgraded databases) is deferred to a follow-up PR; the migration test pins the interim binding and documents what that cleanup must flip.
- Behavior tightening: `UpdateIssueComment` with an empty comment now returns InvalidArgument.

## Testing

- `TestMigration3_23_1_IssueCommentThreads` executes the embedded migration file against a fixture reproducing the upgraded-install index order, covering nine payload classes plus FK and CHECK behavior.
- `TestIssueCommentBatchKeepsInsertionOrder` extended to pin writer classification (event and hybrid rows stay outside threads; event-less rows become OPEN roots).
- `TestUpdateIssueCommentRejectsEmptyComment` pins the new guard and that the original comment survives.
- Full-repo lint, build, the collision suite (`^(TestClaim|TestCollision)`), and a fresh-install boot (`LATEST.sql` stamps 3.23.1) verified locally.