### PR TITLE
feat(ghost): expose metadata lock check bypass

### DIFF
--- a/backend/common/audit.go
+++ b/backend/common/audit.go
@@ -1,3 +1,4 @@
+//nolint:revive
 package common
 
 import (

--- a/backend/component/ghost/config.go
+++ b/backend/component/ghost/config.go
@@ -34,6 +34,7 @@ var defaultConfig = struct {
 	attemptInstantDDL                   bool
 	allowedRunningOnMaster              bool
 	concurrentCountTableRows            bool
+	skipMetadataLockCheck               bool
 	timestampOldTable                   bool
 	hooksStatusIntervalSec              int64
 	heartbeatIntervalMilliseconds       int64
@@ -50,6 +51,7 @@ var defaultConfig = struct {
 	attemptInstantDDL:                   true,  // attempt-instant-ddl
 	allowedRunningOnMaster:              true,  // allow-on-master
 	concurrentCountTableRows:            true,  // concurrent-rowcount
+	skipMetadataLockCheck:               false, // skip-metadata-lock-check
 	timestampOldTable:                   false, // doesn't have a gh-ost cli flag counterpart
 	hooksStatusIntervalSec:              60,    // hooks-status-interval
 	heartbeatIntervalMilliseconds:       100,   // heartbeat-interval-millis
@@ -80,6 +82,7 @@ type UserFlags struct {
 	throttleControlReplicas       *string
 	attemptInstantDDL             *bool
 	assumeMasterHost              *bool // use datasource host if true
+	skipMetadataLockCheck         *bool
 }
 
 var knownKeys = map[string]bool{
@@ -98,6 +101,7 @@ var knownKeys = map[string]bool{
 	"throttle-control-replicas":        true,
 	"attempt-instant-ddl":              true,
 	"assume-master-host":               true,
+	"skip-metadata-lock-check":         true,
 }
 
 func GetUserFlags(flags map[string]string) (*UserFlags, error) {
@@ -212,6 +216,13 @@ func GetUserFlags(flags map[string]string) (*UserFlags, error) {
 		}
 		f.assumeMasterHost = &assumeMasterHost
 	}
+	if v, ok := flags["skip-metadata-lock-check"]; ok {
+		skipMetadataLockCheck, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to convert skip-metadata-lock-check %q to bool", v)
+		}
+		f.skipMetadataLockCheck = &skipMetadataLockCheck
+	}
 	return f, nil
 }
 
@@ -276,6 +287,7 @@ func NewMigrationContext(ctx context.Context, taskID int64, database *store.Data
 	migrationContext.AttemptInstantDDL = defaultConfig.attemptInstantDDL
 	migrationContext.AllowedRunningOnMaster = defaultConfig.allowedRunningOnMaster
 	migrationContext.ConcurrentCountTableRows = defaultConfig.concurrentCountTableRows
+	migrationContext.SkipMetadataLockCheck = defaultConfig.skipMetadataLockCheck
 	migrationContext.HooksStatusIntervalSec = defaultConfig.hooksStatusIntervalSec
 	migrationContext.CutOverType = ghostbase.CutOverAtomic
 	migrationContext.ThrottleHTTPIntervalMillis = defaultConfig.throttleHTTPIntervalMillis
@@ -390,6 +402,9 @@ func NewMigrationContext(ctx context.Context, taskID int64, database *store.Data
 		if dataSource.GetPort() != "" {
 			migrationContext.AssumeMasterHostname += ":" + dataSource.GetPort()
 		}
+	}
+	if v := userFlags.skipMetadataLockCheck; v != nil {
+		migrationContext.SkipMetadataLockCheck = *v
 	}
 	// Uses specified port. GCP, Aliyun, Azure are equivalent here.
 	migrationContext.GoogleCloudPlatform = true

--- a/backend/component/ghost/config_test.go
+++ b/backend/component/ghost/config_test.go
@@ -97,6 +97,43 @@ func TestNewMigrationContextTrimsTrailingSemicolon(t *testing.T) {
 	}
 }
 
+func TestNewMigrationContextSkipMetadataLockCheck(t *testing.T) {
+	ctx := context.Background()
+	database := &store.DatabaseMessage{DatabaseName: "ghostdb"}
+	dataSource := &storepb.DataSource{
+		Host:               "127.0.0.1",
+		Port:               "3306",
+		Username:           "root",
+		AuthenticationType: storepb.DataSource_PASSWORD,
+	}
+
+	testCases := []struct {
+		name  string
+		flags map[string]string
+		want  bool
+	}{
+		{
+			name: "disabled by default",
+			want: false,
+		},
+		{
+			name: "enabled by user flag",
+			flags: map[string]string{
+				"skip-metadata-lock-check": "true",
+			},
+			want: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			migrationContext, cleanup, err := NewMigrationContext(ctx, 1, database, dataSource, "t", "_suffix", "ALTER TABLE t ADD COLUMN c INT", false, tc.flags, 0)
+			require.NoError(t, err)
+			t.Cleanup(cleanup)
+			require.Equal(t, tc.want, migrationContext.SkipMetadataLockCheck)
+		})
+	}
+}
+
 func TestNewMigrationContextWritesTLSMaterialToTempFiles(t *testing.T) {
 	certPEM, keyPEM := generateSelfSignedPEM(t)
 

--- a/backend/component/ghost/manifest_test.go
+++ b/backend/component/ghost/manifest_test.go
@@ -57,6 +57,7 @@ func TestFrontendFlagManifestInSync(t *testing.T) {
 		"default-retries":                  strconv.FormatInt(defaultConfig.defaultNumRetries, 10),
 		"cut-over-lock-timeout-seconds":    strconv.FormatInt(defaultConfig.cutoverLockTimeoutSeconds, 10),
 		"exponential-backoff-max-interval": strconv.FormatInt(defaultConfig.exponentialBackoffMaxInterval, 10),
+		"skip-metadata-lock-check":         strconv.FormatBool(defaultConfig.skipMetadataLockCheck),
 	}
 	for _, f := range manifest {
 		want, ok := backendDefaults[f.Key]

--- a/frontend/src/components/ghost/GhostFlagsButton.test.tsx
+++ b/frontend/src/components/ghost/GhostFlagsButton.test.tsx
@@ -100,6 +100,33 @@ describe("GhostFlagsForm", () => {
     toggleFlag(container, "allow-on-master");
     expect(onChange).toHaveBeenCalledWith({ "allow-on-master": "false" });
   });
+
+  test("shows the metadata lock risk only when the skip check is enabled", () => {
+    const { rerender } = render(
+      <GhostFlagsForm value={{}} onChange={vi.fn()} />
+    );
+    expect(
+      screen.queryByTestId("skip-metadata-lock-check-risk")
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <GhostFlagsForm
+        value={{ "skip-metadata-lock-check": "true" }}
+        onChange={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByTestId("skip-metadata-lock-check-risk")
+    ).toHaveTextContent("plan.ghost.skip-metadata-lock-check-risk");
+    expect(
+      screen.getByRole("link", {
+        name: "plan.ghost.skip-metadata-lock-check-why",
+      })
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/github/gh-ost/pull/1536"
+    );
+  });
 });
 
 describe("GhostFlagsButton", () => {

--- a/frontend/src/components/ghost/GhostFlagsButton.test.tsx
+++ b/frontend/src/components/ghost/GhostFlagsButton.test.tsx
@@ -127,27 +127,6 @@ describe("GhostFlagsForm", () => {
       "https://github.com/github/gh-ost/pull/1536"
     );
   });
-
-  test.each(["1", "t", "T", "true", "TRUE", "True"])(
-    "shows the metadata lock risk for accepted true value %s",
-    (value) => {
-      const { container } = render(
-        <GhostFlagsForm
-          value={{ "skip-metadata-lock-check": value }}
-          onChange={vi.fn()}
-        />
-      );
-
-      expect(
-        container
-          .querySelector('[data-flag="skip-metadata-lock-check"]')
-          ?.querySelector('[role="switch"]')
-      ).toBeChecked();
-      expect(
-        screen.getByTestId("skip-metadata-lock-check-risk")
-      ).toBeInTheDocument();
-    }
-  );
 });
 
 describe("GhostFlagsButton", () => {

--- a/frontend/src/components/ghost/GhostFlagsButton.test.tsx
+++ b/frontend/src/components/ghost/GhostFlagsButton.test.tsx
@@ -127,6 +127,27 @@ describe("GhostFlagsForm", () => {
       "https://github.com/github/gh-ost/pull/1536"
     );
   });
+
+  test.each(["1", "t", "T", "true", "TRUE", "True"])(
+    "shows the metadata lock risk for accepted true value %s",
+    (value) => {
+      const { container } = render(
+        <GhostFlagsForm
+          value={{ "skip-metadata-lock-check": value }}
+          onChange={vi.fn()}
+        />
+      );
+
+      expect(
+        container
+          .querySelector('[data-flag="skip-metadata-lock-check"]')
+          ?.querySelector('[role="switch"]')
+      ).toBeChecked();
+      expect(
+        screen.getByTestId("skip-metadata-lock-check-risk")
+      ).toBeInTheDocument();
+    }
+  );
 });
 
 describe("GhostFlagsButton", () => {

--- a/frontend/src/components/ghost/GhostFlagsForm.tsx
+++ b/frontend/src/components/ghost/GhostFlagsForm.tsx
@@ -1,3 +1,5 @@
+import { TriangleAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
@@ -15,6 +17,8 @@ interface GhostFlagsFormProps {
  * map (only non-default overrides); the parent decides when to persist it.
  */
 export function GhostFlagsForm({ value, onChange }: GhostFlagsFormProps) {
+  const { t } = useTranslation();
+
   return (
     <div className="flex flex-col gap-y-3">
       {GHOST_PARAMETERS.map((param) => (
@@ -23,6 +27,14 @@ export function GhostFlagsForm({ value, onChange }: GhostFlagsFormProps) {
           param={param}
           value={value}
           onChange={onChange}
+          riskCaption={
+            param.key === "skip-metadata-lock-check"
+              ? {
+                  text: t("plan.ghost.skip-metadata-lock-check-risk"),
+                  link: t("plan.ghost.skip-metadata-lock-check-why"),
+                }
+              : undefined
+          }
         />
       ))}
     </div>
@@ -33,55 +45,71 @@ function GhostFlagRow({
   param,
   value,
   onChange,
+  riskCaption,
 }: {
   param: GhostParameter;
   value: Record<string, string>;
   onChange: (next: Record<string, string>) => void;
+  riskCaption?: { text: string; link: string };
 }) {
   const current = value[param.key];
+  const isEnabled =
+    current !== undefined ? current === "true" : param.default === "true";
   const set = (raw: string | number | boolean | null | undefined) =>
     onChange(withFlag(value, param, raw));
 
   return (
-    <div
-      data-flag={param.key}
-      className="flex min-h-7 items-center justify-between gap-x-4"
-    >
-      <span
-        className="truncate font-mono text-sm text-control"
-        title={param.key}
-      >
-        {param.key}
-      </span>
-      {param.type === "bool" ? (
-        <Switch
-          size="sm"
-          checked={
-            current !== undefined
-              ? current === "true"
-              : param.default === "true"
-          }
-          onCheckedChange={(checked) => set(checked)}
-        />
-      ) : param.type === "string" ? (
-        <Input
-          size="sm"
-          className="w-48"
-          aria-label={param.key}
-          placeholder={param.default || param.key}
-          value={current ?? ""}
-          onChange={(e) => set(e.target.value)}
-        />
-      ) : (
-        <NumberInput
-          size="sm"
-          className="w-48"
-          aria-label={param.key}
-          placeholder={param.default}
-          value={current !== undefined ? Number(current) : null}
-          step={param.type === "float" ? 0.1 : 1}
-          onValueChange={(v) => set(v)}
-        />
+    <div data-flag={param.key} className="flex flex-col gap-y-1">
+      <div className="flex min-h-7 items-center justify-between gap-x-4">
+        <span
+          className="truncate font-mono text-sm text-control"
+          title={param.key}
+        >
+          {param.key}
+        </span>
+        {param.type === "bool" ? (
+          <Switch
+            size="sm"
+            checked={isEnabled}
+            onCheckedChange={(checked) => set(checked)}
+          />
+        ) : param.type === "string" ? (
+          <Input
+            size="sm"
+            className="w-48"
+            aria-label={param.key}
+            placeholder={param.default || param.key}
+            value={current ?? ""}
+            onChange={(e) => set(e.target.value)}
+          />
+        ) : (
+          <NumberInput
+            size="sm"
+            className="w-48"
+            aria-label={param.key}
+            placeholder={param.default}
+            value={current !== undefined ? Number(current) : null}
+            step={param.type === "float" ? 0.1 : 1}
+            onValueChange={(v) => set(v)}
+          />
+        )}
+      </div>
+      {riskCaption && isEnabled && (
+        <div
+          data-testid="skip-metadata-lock-check-risk"
+          className="flex items-center gap-x-1 text-xs text-warning"
+        >
+          <TriangleAlert className="size-3.5 shrink-0" />
+          <span>{riskCaption.text}</span>
+          <a
+            href="https://github.com/github/gh-ost/pull/1536"
+            target="_blank"
+            rel="noreferrer"
+            className="shrink-0 text-warning hover:underline"
+          >
+            {riskCaption.link}
+          </a>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/components/ghost/GhostFlagsForm.tsx
+++ b/frontend/src/components/ghost/GhostFlagsForm.tsx
@@ -1,5 +1,6 @@
-import { TriangleAlert } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { Alert } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/number-input";
 import { Switch } from "@/components/ui/switch";
@@ -54,7 +55,7 @@ function GhostFlagRow({
 }) {
   const current = value[param.key];
   const isEnabled =
-    current !== undefined ? current === "true" : param.default === "true";
+    param.type === "bool" && isBooleanFlagEnabled(current, param.default);
   const set = (raw: string | number | boolean | null | undefined) =>
     onChange(withFlag(value, param, raw));
 
@@ -95,22 +96,31 @@ function GhostFlagRow({
         )}
       </div>
       {riskCaption && isEnabled && (
-        <div
+        <Alert
+          appearance="caption"
+          variant="warning"
           data-testid="skip-metadata-lock-check-risk"
-          className="flex items-center gap-x-1 text-xs text-warning"
         >
-          <TriangleAlert className="size-3.5 shrink-0" />
-          <span>{riskCaption.text}</span>
-          <a
-            href="https://github.com/github/gh-ost/pull/1536"
-            target="_blank"
-            rel="noreferrer"
-            className="shrink-0 text-warning hover:underline"
-          >
-            {riskCaption.link}
-          </a>
-        </div>
+          <span>
+            {riskCaption.text}{" "}
+            <a
+              href="https://github.com/github/gh-ost/pull/1536"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-x-1 text-warning underline"
+            >
+              {riskCaption.link}
+              <ExternalLink className="size-3" />
+            </a>
+          </span>
+        </Alert>
       )}
     </div>
   );
+}
+
+const TRUE_BOOLEAN_VALUES = new Set(["1", "t", "T", "true", "TRUE", "True"]);
+
+function isBooleanFlagEnabled(value: string | undefined, defaultValue: string) {
+  return TRUE_BOOLEAN_VALUES.has(value ?? defaultValue);
 }

--- a/frontend/src/components/ghost/GhostFlagsForm.tsx
+++ b/frontend/src/components/ghost/GhostFlagsForm.tsx
@@ -55,7 +55,7 @@ function GhostFlagRow({
 }) {
   const current = value[param.key];
   const isEnabled =
-    param.type === "bool" && isBooleanFlagEnabled(current, param.default);
+    param.type === "bool" && (current ?? param.default) === "true";
   const set = (raw: string | number | boolean | null | undefined) =>
     onChange(withFlag(value, param, raw));
 
@@ -117,10 +117,4 @@ function GhostFlagRow({
       )}
     </div>
   );
-}
-
-const TRUE_BOOLEAN_VALUES = new Set(["1", "t", "T", "true", "TRUE", "True"]);
-
-function isBooleanFlagEnabled(value: string | undefined, defaultValue: string) {
-  return TRUE_BOOLEAN_VALUES.has(value ?? defaultValue);
 }

--- a/frontend/src/components/ghost/flags.json
+++ b/frontend/src/components/ghost/flags.json
@@ -11,6 +11,7 @@
   { "key": "throttle-control-replicas", "type": "string", "default": "" },
   { "key": "allow-on-master", "type": "bool", "default": "true" },
   { "key": "attempt-instant-ddl", "type": "bool", "default": "true" },
+  { "key": "skip-metadata-lock-check", "type": "bool", "default": "false" },
   { "key": "switch-to-rbr", "type": "bool", "default": "false" },
   { "key": "assume-rbr", "type": "bool", "default": "false" },
   { "key": "assume-master-host", "type": "bool", "default": "false" }

--- a/frontend/src/components/ui/alert.test.tsx
+++ b/frontend/src/components/ui/alert.test.tsx
@@ -46,6 +46,21 @@ describe("Alert", () => {
     unmount();
   });
 
+  test("renders a compact caption alert", () => {
+    const { container, unmount } = renderIntoContainer(
+      createElement(Alert, { appearance: "caption", variant: "warning" }, "Risk")
+    );
+
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.className).toContain("text-xs");
+    expect(alert?.className).toContain("border-0");
+    expect(alert?.querySelector("svg")?.getAttribute("class")).toContain(
+      "size-3.5"
+    );
+
+    unmount();
+  });
+
   test("only exports the alert primitive", () => {
     expect("AlertTitle" in alertModule).toBe(false);
     expect("AlertDescription" in alertModule).toBe(false);

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -20,23 +20,34 @@ const alertVariants = cva(
         warning: "border-warning/40 bg-warning/10 text-warning",
         error: "border-error/40 bg-error/10 text-error",
       },
+      appearance: {
+        default: "",
+        caption:
+          "gap-x-1 rounded-none border-0 bg-transparent p-0 text-xs leading-4 shadow-none",
+      },
     },
     defaultVariants: {
       variant: "info",
+      appearance: "default",
     },
   }
 );
 
-const alertIconVariants = cva("mt-0.5 size-5 shrink-0", {
+const alertIconVariants = cva("shrink-0", {
   variants: {
     variant: {
       info: "text-info",
       warning: "text-warning",
       error: "text-error",
     },
+    appearance: {
+      default: "mt-0.5 size-5",
+      caption: "size-3.5",
+    },
   },
   defaultVariants: {
     variant: "info",
+    appearance: "default",
   },
 });
 
@@ -55,6 +66,7 @@ type AlertProps = Omit<ComponentProps<"div">, "title"> &
   };
 
 function Alert({
+  appearance = "default",
   className,
   variant = "info",
   showIcon = true,
@@ -70,10 +82,12 @@ function Alert({
   return (
     <div
       role="alert"
-      className={cn(alertVariants({ variant, className }))}
+      className={cn(alertVariants({ appearance, variant, className }))}
       {...props}
     >
-      {showIcon && <Icon className={alertIconVariants({ variant })} />}
+      {showIcon && (
+        <Icon className={alertIconVariants({ appearance, variant })} />
+      )}
       <div className="min-w-0 flex-1">
         {hasStructuredContent ? (
           <>

--- a/frontend/src/locales/en-US.json
+++ b/frontend/src/locales/en-US.json
@@ -1655,7 +1655,9 @@
       "configure": "Configure",
       "parameters": "gh-ost parameters",
       "requirements-not-met": "Ghost requirements not met: {{databases}}",
-      "reset-to-defaults": "Reset to defaults"
+      "reset-to-defaults": "Reset to defaults",
+      "skip-metadata-lock-check-risk": "Skipping this check can cause lost writes during cut-over.",
+      "skip-metadata-lock-check-why": "Why?"
     },
     "go-to-plan-page": "Go to plan page",
     "initial-sql-storage-failed": "Unable to temporarily save the SQL. Clear some browser storage and try again.",

--- a/frontend/src/locales/es-ES.json
+++ b/frontend/src/locales/es-ES.json
@@ -1655,7 +1655,9 @@
       "configure": "Configurar",
       "parameters": "Parámetros de gh-ost",
       "requirements-not-met": "Los requisitos de Ghost no se cumplen para: {{databases}}",
-      "reset-to-defaults": "Restablecer valores predeterminados"
+      "reset-to-defaults": "Restablecer valores predeterminados",
+      "skip-metadata-lock-check-risk": "Omitir esta comprobación puede provocar la pérdida de escrituras durante el corte.",
+      "skip-metadata-lock-check-why": "¿Por qué?"
     },
     "go-to-plan-page": "Ir a la página del plan",
     "initial-sql-storage-failed": "No se pudo guardar temporalmente el SQL. Libera espacio de almacenamiento del navegador e inténtalo de nuevo.",

--- a/frontend/src/locales/ja-JP.json
+++ b/frontend/src/locales/ja-JP.json
@@ -1655,7 +1655,9 @@
       "configure": "設定",
       "parameters": "gh-ost パラメータ",
       "requirements-not-met": "次のデータベースは Ghost の要件を満たしていません: {{databases}}",
-      "reset-to-defaults": "デフォルトに戻す"
+      "reset-to-defaults": "デフォルトに戻す",
+      "skip-metadata-lock-check-risk": "このチェックをスキップすると、カットオーバー時に書き込みが失われる可能性があります。",
+      "skip-metadata-lock-check-why": "理由"
     },
     "go-to-plan-page": "プランページへ移動",
     "initial-sql-storage-failed": "SQL を一時保存できませんでした。ブラウザーのストレージを空けて、もう一度お試しください。",

--- a/frontend/src/locales/vi-VN.json
+++ b/frontend/src/locales/vi-VN.json
@@ -1655,7 +1655,9 @@
       "configure": "Cấu hình",
       "parameters": "Tham số gh-ost",
       "requirements-not-met": "Các cơ sở dữ liệu sau không đáp ứng yêu cầu Ghost: {{databases}}",
-      "reset-to-defaults": "Đặt lại về mặc định"
+      "reset-to-defaults": "Đặt lại về mặc định",
+      "skip-metadata-lock-check-risk": "Bỏ qua bước kiểm tra này có thể làm mất các thao tác ghi trong quá trình cut-over.",
+      "skip-metadata-lock-check-why": "Tại sao?"
     },
     "go-to-plan-page": "Đi tới trang kế hoạch",
     "initial-sql-storage-failed": "Không thể lưu tạm thời SQL. Hãy giải phóng dung lượng lưu trữ của trình duyệt rồi thử lại.",

--- a/frontend/src/locales/zh-CN.json
+++ b/frontend/src/locales/zh-CN.json
@@ -1655,7 +1655,9 @@
       "configure": "配置",
       "parameters": "gh-ost 参数",
       "requirements-not-met": "以下数据库不满足 Ghost 要求：{{databases}}",
-      "reset-to-defaults": "重置为默认值"
+      "reset-to-defaults": "重置为默认值",
+      "skip-metadata-lock-check-risk": "跳过此检查可能导致切换期间的写入丢失。",
+      "skip-metadata-lock-check-why": "为什么？"
     },
     "go-to-plan-page": "前往计划页面",
     "initial-sql-storage-failed": "无法临时保存 SQL。请清理部分浏览器存储空间后重试。",


### PR DESCRIPTION
## Summary

- support the gh-ost `--skip-metadata-lock-check` option while keeping it disabled by default
- expose the option in the gh-ost configuration UI
- warn that enabling it can cause lost writes during cut-over and link to the upstream rationale
- keep the frontend flag manifest synchronized with backend defaults

## Testing

- `go test -count=1 ./backend/component/ghost`
- `go build -ldflags "-w -s" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`
- `pnpm --dir frontend check`
- `pnpm --dir frontend type-check`
- `pnpm --dir frontend test` (3,999 tests)
- focused gh-ost UI tests (15 tests)

Linear: https://linear.app/bytebase/issue/BYT-10162/expose-gh-ost-metadata-lock-instrument-check-as-a-bytebase-native-pre