### PR TITLE
docs(design): combined dev box and CI runner on GCP

### DIFF
--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -512,6 +512,11 @@ systemctl is-active --quiet google-cloud-ops-agent \
   || { curl -sSo /tmp/ops.sh --retry 3 https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh && bash /tmp/ops.sh --also-install; } \
   || logger -t devbox-startup "WARN: Ops Agent install failed; no memory or swap metrics"   # retried next boot
 
+# One outcome check before any runner is advertised. Covers a failed package
+# install, a dockerd that would not start, and a daemon.json it rejects -- all of
+# which otherwise register three healthy-looking runners that fail every job.
+docker info &>/dev/null || { logger -t devbox-startup "FATAL: docker unusable"; exit 1; }
+
 systemctl daemon-reload
 systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3
 ```

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -462,6 +462,9 @@ Environment=XDG_CACHE_HOME=/scratch/%i/cache GOMODCACHE=/scratch/%i/cache/go-mod
 ExecStartPre=+/usr/local/sbin/install-runner %i
 ExecStartPre=/usr/local/sbin/register-runner %i /scratch/%i/runner /scratch/%i/work
 ExecStart=/scratch/%i/runner/run.sh
+# install-runner fetches ~200 MB and waits on the apt lock, which the 90s default
+# would kill -- and the retry restarts the download from zero.
+TimeoutStartSec=600
 Restart=always
 # Registration failure retries forever; at 5s x3 runners that would burn the API quota.
 RestartSec=30

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -388,7 +388,8 @@ mountpoint -q /var/lib/containerd || mount --bind /scratch/containerd /var/lib/c
 # disabled from here on: only this script starts Docker, so a reboot no longer brings
 # it up on the boot disk before the script has run.
 systemctl unmask docker.socket docker containerd 2>/dev/null
-systemctl disable docker.socket docker containerd 2>/dev/null
+systemctl disable docker.socket docker containerd 2>/dev/null \
+  || logger -t devbox-startup "WARN: docker autostart still enabled; the mask covers the next boot"
 systemctl daemon-reload && systemctl restart containerd docker || fatal "docker would not start"
 docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
   || fatal "docker not on Local SSD"   # daemon.json unwritten or rejected: dockerd starts fine on the boot disk

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -347,7 +347,8 @@ echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unat
 PKGS="docker.io cron systemd-oomd build-essential"
 # Unconditional: a preemption during any dpkg work -- an unattended upgrade of some
 # unrelated package -- blocks every later apt call, including installdependencies.sh.
-dpkg --configure -a 2>/dev/null
+dpkg --configure -a 2>/dev/null \
+  || { logger -t devbox-startup "FATAL: dpkg wedged; apt is unusable"; exit 1; }
 # Count 'install ok installed', not dpkg -s: a preemption mid-apt leaves packages
 # unpacked but unconfigured, which dpkg -s still reports as success.
 [[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -347,8 +347,10 @@ echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unat
 PKGS="docker.io cron systemd-oomd build-essential"
 # Unconditional: a preemption during any dpkg work -- an unattended upgrade of some
 # unrelated package -- blocks every later apt call, including installdependencies.sh.
-dpkg --configure -a 2>/dev/null \
-  || { logger -t devbox-startup "FATAL: dpkg wedged; apt is unusable"; exit 1; }
+# DPkg::Lock::Timeout is apt configuration and dpkg does not honour it, so wait here
+# instead: unattended-upgrades holds the lock at boot, which is not a wedged dpkg.
+for _ in $(seq 60); do dpkg --configure -a 2>/dev/null && { DPKG_OK=1; break; }; sleep 5; done
+[[ -n "${DPKG_OK:-}" ]] || { logger -t devbox-startup "FATAL: dpkg wedged; apt is unusable"; exit 1; }
 # Count 'install ok installed', not dpkg -s: a preemption mid-apt leaves packages
 # unpacked but unconfigured, which dpkg -s still reports as success.
 [[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -511,11 +511,15 @@ find /tmp -mindepth 1 -delete 2>/dev/null   # /tmp is on scratch; nothing is usi
 docker ps -q | xargs -r docker rm -f >/dev/null 2>&1   # idle, so a running container is orphaned
 docker system prune -af --volumes >/dev/null 2>&1
 docker volume prune -af >/dev/null 2>&1   # system prune takes anonymous volumes only
-for d in /scratch/*/; do
-  u=${d%/}; u=${u##*/}; id "$u" &>/dev/null || continue
-  rm -rf "$d"{cache,home,work}   # runner/ stays: it holds the install and its stamp
+# On scratch only the fixed entries and each account's runner/ install survive. The
+# rest -- whatever was written, wherever -- is by definition disposable.
+for e in /scratch/*; do
+  u=${e##*/}
+  case $u in tmp|docker|containerd|swapfile|lost+found) continue;; esac
+  id "$u" &>/dev/null || { rm -rf "$e"; continue; }   # not an account: dumped at the top level
+  find "$e" -mindepth 1 -maxdepth 1 ! -name runner -exec rm -rf {} +   # runner/ holds the install and its stamp
   for x in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do
-    install -d -o "$u" -g "$u" "/scratch/$u$x"   # recreate: symlinks must not dangle
+    install -d -o "$u" -g "$u" "$e$x"   # recreate: symlinks must not dangle
   done
 done
 logger -t cache-gc "cleaned -> $(used)%"

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -84,9 +84,11 @@ Org-owned tokens may need an org admin to approve the request.
 Developers already have access: the developer group holds Editor on the project,
 which covers OS Login with `sudo` and acting as the service account.
 
-**2. Everything else.**
+**2. Everything else.** Run as a project Owner: it sets IAM policy on the project and
+on the secret, which Editor cannot do. It stops at the first failed step.
 
 ```bash
+set -e
 PROJECT=bytebase-dev
 ZONE=northamerica-northeast2-a
 SA=devbox@${PROJECT}.iam.gserviceaccount.com

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -384,8 +384,11 @@ printf '[Service]\nExecStartPost=/bin/chmod 666 /var/run/docker.sock\n' > /etc/s
 mountpoint -q /var/lib/containerd || mount --bind /scratch/containerd /var/lib/containerd \
   || fatal "containerd store not on Local SSD"
 # Masked until here: an active docker.socket cannot spawn a masked service, so nothing
-# can start dockerd on the boot disk between the stop above and this restart.
+# can start dockerd on the boot disk between the stop above and this restart. And
+# disabled from here on: only this script starts Docker, so a reboot no longer brings
+# it up on the boot disk before the script has run.
 systemctl unmask docker.socket docker containerd 2>/dev/null
+systemctl disable docker.socket docker containerd 2>/dev/null
 systemctl daemon-reload && systemctl restart containerd docker || fatal "docker would not start"
 docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
   || fatal "docker not on Local SSD"   # daemon.json unwritten or rejected: dockerd starts fine on the boot disk
@@ -515,6 +518,7 @@ for d in /scratch/*/; do
   done
 done
 logger -t cache-gc "cleaned -> $(used)%"
+[[ $(used) -lt $HIGH ]] || logger -t cache-gc "WARN: still $(used)% after cleaning; a docker prune may have failed"
 EOF
 chmod +x /usr/local/sbin/cache-gc
 # PATH first: cron's default omits /usr/sbin, and a missing `ss` would make idle() look true.

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -337,7 +337,7 @@ stop_docker() {
   fi
 }
 stop_docker   # before anything that can block or exit
-systemctl mask docker.socket docker containerd 2>/dev/null   # postinst must not start them
+systemctl mask --now docker.socket docker containerd 2>/dev/null   # --now: also stops one a postinst already queued
 # Latest runner release, falling back to a known-good pin if the lookup fails. Every
 # boot uses this: the runner lives on scratch and is re-fetched, never updated in place.
 RUNNER_VERSION=$(curl -sf --retry 3 --max-time 30 https://api.github.com/repos/actions/runner/releases/latest | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null || echo 2.336.0)
@@ -348,10 +348,12 @@ echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unat
 PKGS="docker.io cron systemd-oomd build-essential"
 # Unconditional: a preemption during any dpkg work -- an unattended upgrade of some
 # unrelated package -- blocks every later apt call, including installdependencies.sh.
-# DPkg::Lock::Timeout is apt configuration and dpkg does not honour it, so wait here
-# instead: unattended-upgrades holds the lock at boot, which is not a wedged dpkg.
-for _ in $(seq 60); do dpkg --configure -a 2>/dev/null && { DPKG_OK=1; break; }; sleep 5; done
-[[ -n "${DPKG_OK:-}" ]] || { logger -t devbox-startup "FATAL: dpkg wedged; apt is unusable"; exit 1; }
+# One dpkg pass clears an interrupted transaction; its result is ignored on purpose.
+# Deps missing from an unpack cut short are apt's to install, not dpkg's, and a lock
+# held by unattended-upgrades means nothing to clear -- apt waits for that lock.
+dpkg --configure -a 2>/dev/null || true
+apt-get -y -qq --fix-broken install \
+  || { logger -t devbox-startup "FATAL: apt cannot repair the package state"; exit 1; }
 # Count 'install ok installed', not dpkg -s: a preemption mid-apt leaves packages
 # unpacked but unconfigured, which dpkg -s still reports as success.
 [[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \
@@ -526,6 +528,7 @@ idle() { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state establish
 if ! idle && [[ $(used) -lt $CRITICAL ]]; then logger -t cache-gc "deferred: busy at $(used)%"; exit 0; fi
 logger -t cache-gc "cleaning: $(used)% used"
 find /tmp -mindepth 1 -delete 2>/dev/null   # /tmp is on scratch; nothing is using it
+docker ps -q | xargs -r docker rm -f >/dev/null 2>&1   # idle, so a running container is orphaned
 docker system prune -af --volumes >/dev/null 2>&1
 docker volume prune -af >/dev/null 2>&1   # system prune takes anonymous volumes only
 for d in /scratch/*/; do

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -525,6 +525,7 @@ idle() { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state establish
 [[ $(used) -ge $HIGH ]] || exit 0
 if ! idle && [[ $(used) -lt $CRITICAL ]]; then logger -t cache-gc "deferred: busy at $(used)%"; exit 0; fi
 logger -t cache-gc "cleaning: $(used)% used"
+find /tmp -mindepth 1 -delete 2>/dev/null   # /tmp is on scratch; nothing is using it
 docker system prune -af --volumes >/dev/null 2>&1
 docker volume prune -af >/dev/null 2>&1   # system prune takes anonymous volumes only
 for d in /scratch/*/; do

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -339,7 +339,7 @@ PKGS="docker.io cron systemd-oomd build-essential"
 # Count 'install ok installed', not dpkg -s: a preemption mid-apt leaves packages
 # unpacked but unconfigured, which dpkg -s still reports as success.
 [[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \
-  || { apt-get update -qq && apt-get install -y -qq $PKGS; } \
+  || { dpkg --configure -a; apt-get update -qq && apt-get install -y -qq $PKGS; } \
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
 systemctl stop docker.socket docker 2>/dev/null   # again: docker.io's postinst starts it
 

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -526,6 +526,7 @@ idle() { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state establish
 if ! idle && [[ $(used) -lt $CRITICAL ]]; then logger -t cache-gc "deferred: busy at $(used)%"; exit 0; fi
 logger -t cache-gc "cleaning: $(used)% used"
 docker system prune -af --volumes >/dev/null 2>&1
+docker volume prune -af >/dev/null 2>&1   # system prune takes anonymous volumes only
 for d in /scratch/*/; do
   u=${d%/}; u=${u##*/}; id "$u" &>/dev/null || continue
   rm -rf "$d"{cache,home,work}   # runner/ stays: it holds the install and its stamp

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -337,6 +337,7 @@ export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
 dpkg -s docker.io cron systemd-oomd build-essential &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron systemd-oomd build-essential; } \
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
+systemctl stop docker.socket docker 2>/dev/null   # again: docker.io's postinst starts it
 
 # ---------- (a) disk layout ----------
 mkdir -p /scratch
@@ -565,9 +566,11 @@ not give org-wide runners.
 
 **A Cloud Run service minting JIT configs** — it would keep the PAT off the box
 entirely, but it is too much infrastructure for a dev box. The accepted cost: any CI
-job can read the PAT from the metadata server, and an org-wide runner credential has
-org-wide reach by definition. It is bounded by a token expiry, and by alerting on any
-runner not named `devbox-*`.
+job can read the PAT from the metadata server, register its own runner, and keep
+taking org jobs until that registration is deleted. Neither obvious bound actually
+binds -- a runner credential outlives the PAT that created it, and a rogue host picks
+its own `--name`, so alerting on names outside `devbox-*` catches mistakes rather than
+an attacker. Removing a registration is the control; the alert is a convenience.
 
 **Rootless Docker** — the socket is world-accessible, which is how an OS Login account
 the script cannot name gets Docker. That is root-equivalent, and accepted. Be clear

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -511,7 +511,9 @@ find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 -exec rm -rf {} +
 accounts() { for d in /scratch/*/; do u=${d%/}; u=${u##*/}; id "$u" &>/dev/null && echo "$u"; done; }
 used()  { df -P /scratch | awk 'NR==2 {print $5+0}'; }
 halt_() { [[ $(used) -le $LOW ]] && { logger -t cache-gc "$1 -> $(used)%"; exit 0; }; }
-drop()  { for u in $(accounts); do p=/scratch/$u/cache/$1; rm -rf "$p"; install -d -o "$u" -g "$u" "$p"; done; }   # recreate: symlinks must not dangle
+mk()    { for d in "" /go-mod /npm /pnpm; do install -d -o "$1" -g "$1" "/scratch/$1/cache$d"; done; }   # recreate: symlinks must not dangle
+drop()  { for u in $(accounts); do rm -rf "/scratch/$u/cache/$1"; mk "$u"; done; }
+wipe()  { for u in $(accounts); do rm -rf "/scratch/$u/cache";    mk "$u"; done; }   # Playwright, pip, yarn and anything else under XDG_CACHE_HOME
 idle()  { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state established '( sport = :22 )')" ]]; }
 
 [[ $(used) -ge $HIGH ]] || exit 0
@@ -528,7 +530,7 @@ docker builder prune -af >/dev/null 2>&1;                   halt_ "build cache"
 drop pnpm; drop npm;                                         halt_ "package stores"
 docker image prune -af --filter until=168h >/dev/null 2>&1;  halt_ "stale images"
 drop go-mod;                                                 halt_ "modcache"
-drop go-build
+wipe   # everything left under XDG_CACHE_HOME, go-build included
 logger -t cache-gc "full clean -> $(used)%"
 EOF
 chmod +x /usr/local/sbin/cache-gc

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -342,6 +342,9 @@ PKGS="docker.io cron systemd-oomd build-essential"
   || { dpkg --configure -a; apt-get update -qq && apt-get install -y -qq $PKGS; } \
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
 systemctl stop docker.socket docker 2>/dev/null   # again: docker.io's postinst starts it
+# Confirm it actually stopped: mounting over a live data root is the failure the two
+# stops exist to prevent, and a stuck unit would walk straight into it.
+pgrep -x dockerd >/dev/null && { logger -t devbox-startup "FATAL: dockerd would not stop"; exit 1; }
 
 # ---------- (a) disk layout ----------
 mkdir -p /scratch

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -366,7 +366,8 @@ if [[ "$(blkid -s TYPE -o value /scratch/swapfile 2>/dev/null)" != swap ]]; then
   rm -f /scratch/swapfile
   fallocate -l 8G /scratch/swapfile && chmod 600 /scratch/swapfile && mkswap /scratch/swapfile >/dev/null
 fi
-swapon /scratch/swapfile 2>/dev/null || true          # no-op if already active
+swapon /scratch/swapfile 2>/dev/null                  # fails harmlessly if already active
+swapon --show=NAME --noheadings | grep -q . || logger -t devbox-startup "WARN: no swap active"
 sysctl -qw vm.swappiness=10
 systemctl enable --now systemd-oomd || logger -t devbox-startup "WARN: systemd-oomd inert"
 # On the slice, not the runner unit: Docker gives each container its own scope under

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -337,6 +337,7 @@ fatal() {
 # previous boot's dockerd is already up with its data root on the boot disk, and
 # mounting over it would leave it writing there unseen. Masked, apt cannot restart it.
 systemctl mask --now docker.socket docker containerd 2>/dev/null
+! pgrep -x 'dockerd|containerd' >/dev/null || fatal "docker would not stop"   # a process stuck in I/O survives SIGKILL
 
 # ---------- packages ----------
 export DEBIAN_FRONTEND=noninteractive

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -156,7 +156,7 @@ is rebuilt. Anything on the boot disk is guarded, so it is not redone.
 
 Two kinds of account use the box, and they need opposite things from it.
 
-**Runner accounts** are `gha`, `ghb` and `ghc`. The script creates them, `nologin`,
+**Runner accounts** are `runner1`, `runner2` and `runner3`. The script creates them, `nologin`,
 one per job slot. Nothing of theirs is worth keeping: software, work trees and caches
 all sit on Local SSD, and the `/home` that `useradd` creates goes unused. They are
 disposable, and are disposed of on every stop.
@@ -320,7 +320,7 @@ printf '[Service]\nExecStartPost=/bin/chmod 666 /var/run/docker.sock\n' > /etc/s
 systemctl daemon-reload && systemctl restart docker
 
 # ---------- (b) accounts and cache paths ----------
-for u in gha ghb ghc; do
+for u in runner1 runner2 runner3; do
   id "$u" &>/dev/null || useradd -m -s /usr/sbin/nologin "$u"
   usermod -aG docker "$u"
   mkdir -p "/scratch/$u/cache" "/scratch/$u/work"
@@ -347,7 +347,7 @@ EOF
 # The runner is stateless, so it lives on scratch and is re-fetched each boot: one
 # download, extracted per account, always the version resolved above.
 curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" -o /tmp/runner.tar.gz
-for u in gha ghb ghc; do
+for u in runner1 runner2 runner3; do
   install -d -o "$u" -g "$u" "/scratch/$u/runner"
   tar xzf /tmp/runner.tar.gz -C "/scratch/$u/runner"
   chown -R "$u:$u" "/scratch/$u/runner"
@@ -355,7 +355,7 @@ done
 rm -f /tmp/runner.tar.gz
 # Its system packages land on the boot disk and persist, so this runs once per rebuild.
 [[ -f /var/lib/devbox-runner-deps ]] || \
-  { /scratch/gha/runner/bin/installdependencies.sh >/dev/null && touch /var/lib/devbox-runner-deps; }
+  { /scratch/runner1/runner/bin/installdependencies.sh >/dev/null && touch /var/lib/devbox-runner-deps; }
 
 cat > /usr/local/sbin/register-runner <<'EOF'
 #!/bin/bash
@@ -390,7 +390,8 @@ Environment=XDG_CACHE_HOME=/scratch/%i/cache GOMODCACHE=/scratch/%i/cache/go-mod
 ExecStartPre=/usr/local/sbin/register-runner %i /scratch/%i/runner /scratch/%i/work
 ExecStart=/scratch/%i/runner/run.sh
 Restart=always
-RestartSec=30   # registration failure retries forever; 5s x3 runners would burn the API quota
+# Registration failure retries forever; at 5s x3 runners that would burn the API quota.
+RestartSec=30
 ManagedOOMMemoryPressure=kill
 EOF
 
@@ -435,7 +436,7 @@ printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 
 systemctl is-active --quiet google-cloud-ops-agent || { curl -sSo /tmp/ops.sh --retry 3 https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh && bash /tmp/ops.sh --also-install; }
 
 systemctl daemon-reload
-systemctl restart actions-runner@gha actions-runner@ghb actions-runner@ghc
+systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3
 ```
 
 ## 3. Considered

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -263,9 +263,12 @@ and `node_modules` — which is right for anything inside a working copy.
 
 ### c. GitHub runners
 
-Three accounts, three job slots, one systemd template. That is one slot per
-self-hosted workflow that fires on a pull request. A fourth is one more name in the
-script's account list.
+Three accounts, three job slots, one systemd template. A pull request touching both
+backend and frontend schedules five self-hosted jobs -- one each from `backend-tests`,
+`golangci-lint` and `test_link`, two from `frontend-tests` -- so two of them queue,
+before counting any other repository in the org. That is deliberate: jobs queue, they
+do not fail, and 20 vCPU split five ways is thin. A fourth or fifth slot is one more
+name in the script's account list if the wait proves worse than the contention.
 
 The runner is stateless, so it lives on scratch and is re-fetched each boot: one
 ~200 MB download, extracted per account. That costs seconds of boot time. In return
@@ -328,8 +331,11 @@ DEV=$(ls /dev/disk/by-id/google-local-* 2>/dev/null | head -1)
 if [[ -n "$DEV" ]] && ! mountpoint -q /scratch; then
   # A stop discards Local SSD; a reboot does not. Format only when there is no filesystem.
   [[ -n "$(blkid -s TYPE -o value "$DEV")" ]] || mkfs.ext4 -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "$DEV"
-  mount -o noatime,discard "$DEV" /scratch || logger -t devbox-startup "WARN: /scratch mount failed; scratch is on the boot disk"
+  mount -o noatime,discard "$DEV" /scratch
 fi
+# Everything below assumes /scratch is the Local SSD. Falling back to the boot disk
+# would put swap, Docker, work trees and caches on the 100 GB disk that holds /home.
+mountpoint -q /scratch || { logger -t devbox-startup "FATAL: no Local SSD at /scratch"; exit 1; }
 chmod 1777 /scratch                                   # OS Login accounts create their own subtree
 mkdir -p /scratch/tmp && chmod 1777 /scratch/tmp
 # Bind unless /tmp already *is* /scratch/tmp: `mountpoint` would also be true for a
@@ -341,6 +347,10 @@ fi
 swapon /scratch/swapfile 2>/dev/null || true          # no-op if already active
 sysctl -qw vm.swappiness=10
 systemctl enable --now systemd-oomd 2>/dev/null || true
+# On the slice, not the runner unit: Docker gives each container its own scope under
+# system.slice, so a unit-scoped policy would never see the containers under test.
+mkdir -p /etc/systemd/system/system.slice.d
+printf '[Slice]\nManagedOOMMemoryPressure=kill\n' > /etc/systemd/system/system.slice.d/oomd.conf
 
 # Docker on Local SSD with log rotation. The socket is opened to every account: OS
 # Login users appear on first connect and cannot be pre-added to the docker group.
@@ -380,6 +390,7 @@ EOF
 # ---------- (c) GitHub runners ----------
 # The runner is stateless, so it lives on scratch and is re-fetched each boot: one
 # download, extracted per account, always the version resolved above.
+echo "$RUNNER_VERSION" > /etc/devbox-runner-version   # register-runner re-reads this to self-heal
 curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" -o /tmp/runner.tar.gz
 for u in runner1 runner2 runner3; do
   install -d -o "$u" -g "$u" "/scratch/$u/runner"
@@ -406,6 +417,12 @@ TOKEN=$(curl -sfX POST -H "Authorization: Bearer $PAT" -H "Accept: application/v
   "https://api.github.com/orgs/${ORG}/actions/runners/registration-token" \
   | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
 cd "$DIR"
+# systemd retries this unit forever, so re-fetch if the boot-time download failed. A
+# transient network error then heals itself instead of killing the slot until reboot.
+if [[ ! -x ./config.sh ]]; then
+  V=$(< /etc/devbox-runner-version)
+  curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v$V/actions-runner-linux-x64-$V.tar.gz" | tar xz
+fi
 rm -f .runner .credentials .credentials_rsakey   # config.sh refuses to overwrite an existing config
 ./config.sh --unattended --replace --url "https://github.com/${ORG}" --token "$TOKEN" \
   --name "$(hostname -s)-$NAME" --work "$WORK"   # host-qualified name: never collides with another box
@@ -426,7 +443,6 @@ ExecStart=/scratch/%i/runner/run.sh
 Restart=always
 # Registration failure retries forever; at 5s x3 runners that would burn the API quota.
 RestartSec=30
-ManagedOOMMemoryPressure=kill
 EOF
 
 # ---------- (d) cache cleanup ----------

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -217,10 +217,12 @@ The `monitoring.metricWriter` role puts both in Cloud Monitoring, as
 `memory/percent_used` and `swap/percent_used`. Sustained swap above zero means 32 GB
 is too little.
 
-Toolchains are not installed here. An agent session installs its own with `sudo`, to
+Go and Node are not installed here. An agent session installs its own with `sudo`, to
 `/usr/local/go` and `/usr/local/node`, which `/etc/environment` puts on the `PATH` of
-every session, non-login included. CI jobs
-bring their own through `setup-go` and `setup-node`.
+every session, non-login included. CI jobs bring their own through `setup-go` and
+`setup-node`. The C toolchain is the exception and is a prerequisite: neither action
+installs one, and Go defaults to `CGO_ENABLED=1`, so dependencies carrying cgo files
+fail to build without it.
 
 ### b. Cache paths
 
@@ -333,7 +335,7 @@ RUNNER_VERSION=$(curl -sf --retry 3 https://api.github.com/repos/actions/runner/
 # ---------- packages: the Ubuntu image ships neither ----------
 export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
-dpkg -s docker.io cron systemd-oomd &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron systemd-oomd; } \
+dpkg -s docker.io cron systemd-oomd build-essential &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron systemd-oomd build-essential; } \
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
 
 # ---------- (a) disk layout ----------

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -304,13 +304,14 @@ The Go build cache dominates. On a comparable box it was 59% of all disk used. G
 evicts by age with no size cap, so five days of CI output is about 55 GB per account,
 and it regrows after any cleanup.
 
-Eviction fires at 85% and cleans down to 70%. Cleaning to exactly the trigger would
-re-trigger immediately. Tiers escalate by rebuild cost, and the destructive ones wait
-for an idle box.
+Eviction fires at 85% and deletes the lot: every cache, every home and work tree, and
+everything Docker holds. No tiers and no filters. Deciding what to spare would mean
+ranking rebuild costs against each other, and re-pulling an image or a module cache
+costs minutes where a full disk fails every job on the box.
 
-The idle check is a sample, not a lock, so a job starting mid-sweep can still lose a
-cache it was using. Accepted: it only happens above 85%, and a failed job is retryable
-where a full disk is not.
+It waits for an idle box, except above 95% where a failing disk is worse than a failed
+job. The idle check is a sample, not a lock, so a job starting mid-sweep can still lose
+what it was using. Accepted on the same grounds.
 
 It runs on a schedule, not at boot. A boot-time check cannot fire on a box that stays
 up for days, and Local SSD survives a guest *reboot*. It is discarded only on stop or
@@ -512,41 +513,27 @@ EOF
 # ---------- (d) cache cleanup ----------
 cat > /usr/local/sbin/cache-gc <<'EOF'
 #!/bin/bash
-# Every 30 min. Leaked go-build sandboxes are swept unconditionally. Caches are evicted
-# only at 85% used, down to 70%, in order of rebuild cost; the destructive tiers wait
-# for an idle box unless ENOSPC is imminent. Removal is by path as root -- no toolchain.
+# Every 30 min. Leaked go-build sandboxes are swept always. Above 85% used, wait for an
+# idle box -- unless it is nearly full -- then delete everything disposable. It all
+# rebuilds on the next job; a full disk does not.
 set -uo pipefail
-HIGH=85 LOW=70 CRITICAL=95
+HIGH=85 CRITICAL=95
 find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 -exec rm -rf {} +
-accounts() { for d in /scratch/*/; do u=${d%/}; u=${u##*/}; id "$u" &>/dev/null && echo "$u"; done; }
-used()  { df -P /scratch | awk 'NR==2 {print $5+0}'; }
-halt_() { [[ $(used) -le $LOW ]] && { logger -t cache-gc "$1 -> $(used)%"; exit 0; }; }
-mk()    { for d in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do install -d -o "$1" -g "$1" "/scratch/$1$d"; done; }   # recreate: symlinks must not dangle
-drop()  { for u in $(accounts); do rm -rf "/scratch/$u/cache/$1"; mk "$u"; done; }
-# Everything the account owns except runner/, which holds the install and its marker.
-wipe()  { for u in $(accounts); do rm -rf "/scratch/$u"/{cache,home,work}; mk "$u"; done; }
-idle()  { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state established '( sport = :22 )')" ]]; }
+used() { df -P /scratch | awk 'NR==2 {print $5+0}'; }
+idle() { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state established '( sport = :22 )')" ]]; }
 
 [[ $(used) -ge $HIGH ]] || exit 0
-logger -t cache-gc "start: $(used)% used"
-# Safe while jobs run. 24h, not 1h: a job can stop a container and restart it later,
-# so the window has to exceed any job's lifetime rather than merely look idle.
-docker container prune -f --filter until=24h >/dev/null 2>&1
-docker image prune -f --filter until=24h >/dev/null 2>&1
-halt_ "docker garbage"
-for u in $(accounts); do find "/scratch/$u/cache/go-build" -type f -mmin +2880 -delete 2>/dev/null; done
-halt_ "go-build >2d"
-# Destructive from here.
 if ! idle && [[ $(used) -lt $CRITICAL ]]; then logger -t cache-gc "deferred: busy at $(used)%"; exit 0; fi
-docker container prune -f >/dev/null 2>&1
-docker volume prune -af >/dev/null 2>&1;                     halt_ "containers and volumes"
-docker builder prune -af >/dev/null 2>&1;                   halt_ "build cache"
-drop pnpm; drop npm;                                         halt_ "package stores"
-docker image prune -af --filter until=168h >/dev/null 2>&1;  halt_ "stale images"
-drop go-mod;                                                 halt_ "modcache"
-docker image prune -af >/dev/null 2>&1   # the last tier keeps nothing: recent images too
-wipe   # the rest of XDG_CACHE_HOME, plus disposable homes and work trees
-logger -t cache-gc "full clean -> $(used)%"
+logger -t cache-gc "cleaning: $(used)% used"
+docker system prune -af --volumes >/dev/null 2>&1
+for d in /scratch/*/; do
+  u=${d%/}; u=${u##*/}; id "$u" &>/dev/null || continue
+  rm -rf "$d"{cache,home,work}   # runner/ stays: it holds the install and its stamp
+  for x in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do
+    install -d -o "$u" -g "$u" "/scratch/$u$x"   # recreate: symlinks must not dangle
+  done
+done
+logger -t cache-gc "cleaned -> $(used)%"
 EOF
 chmod +x /usr/local/sbin/cache-gc
 # PATH first: cron's default omits /usr/sbin, and a missing `ss` would make idle()

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -448,13 +448,16 @@ cat > /usr/local/sbin/install-runner <<'EOF'
 # <account>. Root, from the unit. Re-runs whole on every retry, deps included.
 set -euo pipefail
 DIR=/scratch/$1/runner
-[[ -f $DIR/.installed ]] && exit 0   # written last, so a failed dep step is retried
 V=$(< /etc/devbox-runner-version)
+# Stamped with the version and written last: a reboot keeps scratch, so a bare marker
+# would pin the old release, and an unstamped one would skip a failed dep step.
+[[ "$(cat "$DIR/.installed" 2>/dev/null)" == "$V" ]] && exit 0
+rm -rf "$DIR"   # clean tree: extracting over an old release leaves its files behind
 install -d -o "$1" -g "$1" "$DIR"
 curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v$V/actions-runner-linux-x64-$V.tar.gz" | tar xz -C "$DIR"
 chown -R "$1:$1" "$DIR"
 "$DIR"/bin/installdependencies.sh >/dev/null   # apt is a no-op once satisfied
-touch "$DIR/.installed"
+echo "$V" > "$DIR/.installed"
 EOF
 chmod +x /usr/local/sbin/install-runner
 

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -345,10 +345,13 @@ RUNNER_VERSION=$(curl -sf --retry 3 --max-time 30 https://api.github.com/repos/a
 export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
 PKGS="docker.io cron systemd-oomd build-essential"
+# Unconditional: a preemption during any dpkg work -- an unattended upgrade of some
+# unrelated package -- blocks every later apt call, including installdependencies.sh.
+dpkg --configure -a 2>/dev/null
 # Count 'install ok installed', not dpkg -s: a preemption mid-apt leaves packages
 # unpacked but unconfigured, which dpkg -s still reports as success.
 [[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \
-  || { dpkg --configure -a; apt-get update -qq && apt-get install -y -qq $PKGS; } \
+  || { apt-get update -qq && apt-get install -y -qq $PKGS; } \
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
 systemctl unmask docker.socket docker containerd 2>/dev/null
 stop_docker   # belt and braces once unmasked

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -322,6 +322,10 @@ preemption.
 # must not abandon the boot; `journalctl -t devbox-startup` shows the exit status.
 set -uo pipefail
 trap 'logger -t devbox-startup "exited: status $?"' EXIT
+# First, before anything that can block or exit. daemon.json persists, so a previous
+# boot's dockerd is already up with data-root=/scratch/docker -- on the boot disk
+# until (a) mounts over it. Absent on a first boot. Restarted in (a).
+systemctl stop docker.socket docker 2>/dev/null
 # Latest runner release, falling back to a known-good pin if the lookup fails. Every
 # boot uses this: the runner lives on scratch and is re-fetched, never updated in place.
 RUNNER_VERSION=$(curl -sf --retry 3 https://api.github.com/repos/actions/runner/releases/latest | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null || echo 2.336.0)
@@ -329,10 +333,6 @@ RUNNER_VERSION=$(curl -sf --retry 3 https://api.github.com/repos/actions/runner/
 # ---------- packages: the Ubuntu image ships neither ----------
 export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
-# Docker down first. daemon.json persists, so a previous boot's dockerd is already up
-# with data-root=/scratch/docker -- on the boot disk until (a) mounts over it, and
-# still writing there through anything slow or fatal below. Absent on a first boot.
-systemctl stop docker.socket docker 2>/dev/null
 dpkg -s docker.io cron systemd-oomd &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron systemd-oomd; } \
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
 

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -329,7 +329,6 @@ fatal() {
 # mounting over it would leave it writing there unseen. Masked, nothing can restart it
 # -- not apt's postinst, not a connection to a still-listening socket -- until (a) is done.
 systemctl mask --now docker.socket docker containerd 2>/dev/null
-! pgrep -x 'dockerd|containerd' >/dev/null || fatal "docker would not stop"   # a process stuck in I/O survives SIGKILL
 
 # ---------- packages ----------
 export DEBIAN_FRONTEND=noninteractive
@@ -489,7 +488,7 @@ cat > /usr/local/sbin/cache-gc <<'EOF'
 set -uo pipefail
 mountpoint -q /scratch || exit 0   # cron outlives a stop; before (a) has mounted, there is nothing to clean
 HIGH=85 CRITICAL=95
-find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 ! -exec mountpoint -q {} \; -exec rm -rf --one-file-system {} +
+find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 -exec rm -rf {} +
 used() { df -P /scratch | awk 'NR==2 {print $5+0}'; }
 # Load catches detached work -- tmux, nohup, a container -- that holds neither an SSH
 # session nor a Runner.Worker. On 20 vCPU, anything actually working exceeds 2.
@@ -499,26 +498,16 @@ idle() { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state establish
 [[ $(used) -ge $HIGH ]] || exit 0
 if ! idle && [[ $(used) -lt $CRITICAL ]]; then logger -t cache-gc "deferred: busy at $(used)%"; exit 0; fi
 logger -t cache-gc "cleaning: $(used)% used"
-find /tmp -xdev -mindepth 1 -delete 2>/dev/null   # /tmp is on scratch; -xdev: never into a mount left beneath it
+rm -rf /tmp/* /tmp/.[!.]*   # /tmp is on scratch; the box is idle
 docker ps -q | xargs -r docker rm -f >/dev/null 2>&1   # idle, so a running container is orphaned
 docker system prune -af --volumes >/dev/null 2>&1
-docker volume prune -af >/dev/null 2>&1   # system prune takes anonymous volumes only
-# On scratch only the fixed entries and each account's runner/ install survive. The
-# rest -- whatever was written, wherever -- is by definition disposable.
-shopt -s dotglob   # a /scratch/.something must not hide from the glob
-for e in /scratch/*; do
-  u=${e##*/}
-  case $u in tmp|docker|containerd|swapfile|lost+found) continue;; esac
-  mountpoint -q "$e" && continue   # not ours, whatever it is: never delete through a mount
-  if ! id "$u" &>/dev/null || [[ ! -d $e ]]; then rm -rf --one-file-system "$e"; continue; fi   # dumped at the top level
-  case $u in runner[1-9]) keep=(! -path "$e/runner" ! -path "$e/runner/*");; *) keep=(-true);; esac   # only a CI account's runner/ holds an install
-  find "$e" -mindepth 1 -xdev "${keep[@]}" -delete 2>/dev/null   # -delete cannot cross into, or remove, a foreign mount
-  for x in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do
-    mountpoint -q "$e$x" || mountpoint -q "$e${x%/*}" || install -d -o "$u" -g "$u" "$e$x"   # recreate: symlinks must not dangle; never touch a mount or anything under one
-  done
+# Everything on scratch is disposable except the runner installs, which are large and
+# would otherwise be re-downloaded on the next boot.
+rm -rf /scratch/*/cache /scratch/*/home /scratch/*/work
+for u in runner1 runner2 runner3; do
+  install -d -o "$u" -g "$u" /scratch/$u/{cache,home,work}   # the units need them; a profile remakes an interactive account's
 done
 logger -t cache-gc "cleaned -> $(used)%"
-[[ $(used) -lt $HIGH ]] || logger -t cache-gc "WARN: still $(used)% after cleaning; a docker prune may have failed"
 EOF
 chmod +x /usr/local/sbin/cache-gc
 # PATH first: cron's default omits /usr/sbin, and a missing `ss` would make idle() look true.

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -522,9 +522,10 @@ idle()  { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state establis
 
 [[ $(used) -ge $HIGH ]] || exit 0
 logger -t cache-gc "start: $(used)% used"
-# Safe while jobs run: only things idle >1h, and Go's content-addressed build cache.
-docker container prune -f --filter until=1h >/dev/null 2>&1
-docker image prune -f --filter until=1h >/dev/null 2>&1
+# Safe while jobs run. 24h, not 1h: a job can stop a container and restart it later,
+# so the window has to exceed any job's lifetime rather than merely look idle.
+docker container prune -f --filter until=24h >/dev/null 2>&1
+docker image prune -f --filter until=24h >/dev/null 2>&1
 halt_ "docker garbage"
 for u in $(accounts); do find "/scratch/$u/cache/go-build" -type f -mmin +2880 -delete 2>/dev/null; done
 halt_ "go-build >2d"

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -487,6 +487,7 @@ cat > /usr/local/sbin/cache-gc <<'EOF'
 # idle box -- unless it is nearly full -- then delete everything disposable. It all
 # rebuilds on the next job; a full disk does not.
 set -uo pipefail
+mountpoint -q /scratch || exit 0   # cron outlives a stop; before (a) has mounted, there is nothing to clean
 HIGH=85 CRITICAL=95
 find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 ! -exec mountpoint -q {} \; -exec rm -rf --one-file-system {} +
 used() { df -P /scratch | awk 'NR==2 {print $5+0}'; }
@@ -513,7 +514,7 @@ for e in /scratch/*; do
   case $u in runner[1-9]) keep=(! -path "$e/runner" ! -path "$e/runner/*");; *) keep=(-true);; esac   # only a CI account's runner/ holds an install
   find "$e" -mindepth 1 -xdev "${keep[@]}" -delete 2>/dev/null   # -delete cannot cross into, or remove, a foreign mount
   for x in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do
-    mountpoint -q "$e$x" || install -d -o "$u" -g "$u" "$e$x"   # recreate: symlinks must not dangle; never chown a mount
+    mountpoint -q "$e$x" || mountpoint -q "$e${x%/*}" || install -d -o "$u" -g "$u" "$e$x"   # recreate: symlinks must not dangle; never touch a mount or anything under one
   done
 done
 logger -t cache-gc "cleaned -> $(used)%"

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -23,8 +23,9 @@ it hosts three self-hosted GitHub Actions runners for the whole org.
    CPU and disk. The Ops Agent reports the rest, so RAM is sized from measurement
    instead of a guess.
 7. **Usable as a desktop agent's SSH environment.** One SSH config entry is enough.
-   OS Login manages keys through IAM, and there is no static IP or bastion. An account
-   that first appears at connect time can run Docker and has `sudo`.
+   A reserved address keeps that entry valid across preemptions. OS Login manages
+   keys through IAM, with no bastion. An account that first appears at connect time
+   can run Docker and has `sudo`.
 
 ## 1. Machine spec and cost
 
@@ -36,10 +37,10 @@ it hosts three self-hosted GitHub Actions runners for the whole org.
 | Image | `ubuntu-2404-lts-amd64` |
 | Boot disk | 100 GB pd-balanced, `--no-boot-disk-auto-delete` |
 | Scratch | 375 GB Local SSD (NVMe) |
-| External IP | ephemeral; carries all egress, and inbound SSH |
+| External IP | reserved; carries all egress, and inbound SSH |
 | Inbound | SSH only, via the VPC default rule; no tag, no custom rules |
 | Service account | dedicated; reads one secret, writes metrics and logs, nothing else |
-| Availability | always on; preemption stops it, the start workflow restarts it |
+| Availability | always on; preemption stops it, the start workflow restarts it within its polling interval |
 
 | Component | Rate | $/mo |
 |---|---|---|
@@ -47,7 +48,7 @@ it hosts three self-hosted GitHub Actions runners for the whole org.
 | 32 GiB RAM (N2) | $0.000441 / GiB-hr | $10.30 |
 | 375 GB Local SSD | $0.052800 / GB-mo | $19.80 |
 | 100 GB pd-balanced | $0.110 / GB-mo | $11.00 |
-| External IP (Spot) | $0.0025 / hr | $1.82 |
+| Reserved external IP | $0.0025 / hr | $1.82 |
 | **Total** | | **$90.96** |
 
 Catalog prices, 2026-09-01. vCPU and RAM are changeable on a stopped instance with
@@ -113,8 +114,13 @@ for r in monitoring.metricWriter logging.logWriter; do
     --member="serviceAccount:${SA}" --role=roles/$r
 done
 
+# A reserved address. An ephemeral one is released when the instance stops, so every
+# preemption would hand the box a new IP and strand the generated SSH entry.
+gcloud compute addresses create devbox --project=$PROJECT --region=${ZONE%-*}
+
 # The instance.
 gcloud compute instances create devbox --project=$PROJECT --zone=$ZONE \
+  --address=devbox \
   --machine-type=n2-custom-20-32768 \
   --provisioning-model=SPOT --instance-termination-action=STOP \
   --image-family=ubuntu-2404-lts-amd64 --image-project=ubuntu-os-cloud \
@@ -138,6 +144,11 @@ Repoint its instance name and zone at this one, in two places each, as the last 
 of cutover. Do it earlier and it stops restarting the box it serves today. Until then,
 start this one by hand.
 
+Raise its cadence at the same time. It runs at three fixed hours, so a preemption just
+after one of them leaves the box stopped for up to fifteen -- which is not "always on"
+for either the dev box or CI. Every fifteen minutes bounds the outage at fifteen
+minutes, and starting a running instance is a no-op.
+
 ### Connect
 
 Run `gcloud compute config-ssh` once. It writes the `~/.ssh/config` entries, and this
@@ -145,6 +156,12 @@ box's alias is `devbox.northamerica-northeast2-a.bytebase-dev`. Desktop agents t
 that alias as their SSH host: Claude Desktop under **Add SSH connection**, Codex in
 its SSH environment. Each developer gets their own account and home, created by OS
 Login on first connect.
+
+Log in once interactively before pointing an agent at a new account. The cache links
+in (b) are made by the profile, and a non-login `bash -c` does not read one -- so an
+account whose very first session is an agent command would write that session's caches
+to the boot disk. After that first login the links exist and every later session
+follows them, non-login included.
 
 ## 2. Startup script
 
@@ -184,8 +201,8 @@ fast OOM kill. With swap, the box thrashes until the job timeout. So there is 8 
 `systemd-oomd` kills a runaway job before either happens.
 
 The `monitoring.metricWriter` role puts both in Cloud Monitoring, as
-`memory/percent_used` and `swap/percent_usage`. The suffixes differ. Sustained swap
-above zero means 32 GB is too little.
+`memory/percent_used` and `swap/percent_used`. Sustained swap above zero means 32 GB
+is too little.
 
 Toolchains are not installed here. An agent session installs its own with `sudo`, to
 `/usr/local/go` and `/usr/local/node`, which the profile puts on every `PATH`. CI jobs

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -1,0 +1,492 @@
+# Combined Dev Box and CI Runner on GCP
+
+One Spot VM with two jobs. It is the SSH target that agentic coding tools drive, and
+it hosts three self-hosted GitHub Actions runners for the whole org.
+
+## Goals
+
+1. **The cheapest VM that still performs.** Spot, N2 or N2D, 20 vCPU. Sized for
+   parallel Go builds and Docker-backed tests. Re-priced per region and family before
+   any rebuild.
+2. **One startup script, so the box is close to stateless.** Everything on the box is
+   produced by that script. Only `/home` and a shared toolchain in `/usr/local` are
+   yours to manage; nothing else is set up by hand.
+3. **GitHub Actions runners that set themselves up.** Three org-level slots. Each
+   re-registers at boot from a secret, so there is no registration state to preserve.
+4. **A clear split between Local SSD and the persistent disk.** Local SSD holds what
+   can be discarded: caches, Docker, temp files, swap. The boot disk holds repos and
+   uncommitted work. It can be lost too, so push your branches.
+5. **Cache cleanup that will not break a running job.** Leaked temp files are swept
+   always. Caches are evicted only under disk pressure, cheapest to rebuild first.
+   The one exception is a disk about to fill, which would fail every job anyway.
+6. **Guest memory and swap visible in Cloud Monitoring.** The hypervisor reports only
+   CPU and disk. The Ops Agent reports the rest, so RAM is sized from measurement
+   instead of a guess.
+7. **Usable as a desktop agent's SSH environment.** One SSH config entry is enough.
+   OS Login manages keys through IAM, and there is no static IP or bastion. An account
+   that first appears at connect time can run Docker and has `sudo`.
+
+## 1. Machine spec and cost
+
+| Property | Value |
+|---|---|
+| Project / zone | `bytebase-dev` / `northamerica-northeast2-a` (Toronto) |
+| Machine type | `n2-custom-20-32768` — 20 vCPU, 32 GB |
+| Provisioning | `SPOT`, `instanceTerminationAction=STOP` |
+| Image | `ubuntu-2404-lts-amd64` |
+| Boot disk | 100 GB pd-balanced, `--no-boot-disk-auto-delete` |
+| Scratch | 375 GB Local SSD (NVMe) |
+| External IP | ephemeral; carries all egress, and inbound SSH |
+| Inbound | SSH only, via the VPC default rule; no tag, no custom rules |
+| Service account | dedicated; reads one secret, writes metrics and logs, nothing else |
+| Availability | always on; preemption stops it, the start workflow restarts it |
+
+| Component | Rate | $/mo |
+|---|---|---|
+| 20 vCPU (N2) | $0.003290 / vCPU-hr | $48.03 |
+| 32 GiB RAM (N2) | $0.000441 / GiB-hr | $10.30 |
+| 375 GB Local SSD | $0.052800 / GB-mo | $19.80 |
+| 100 GB pd-balanced | $0.110 / GB-mo | $11.00 |
+| External IP (Spot) | $0.0025 / hr | $1.82 |
+| **Total** | | **$90.96** |
+
+Catalog prices, 2026-09-01. vCPU and RAM are changeable on a stopped instance with
+`set-machine-type`; Local SSD capacity is fixed at creation.
+
+### Re-checking the region
+
+Spot prices are set per family *per region*, and they drift. Re-check before any
+rebuild.
+
+Price the whole VM, not just the CPU. Keep only regions that can actually run the
+family: the catalog prices N1 in 14 regions that cannot run it. Prefer N2 or N2D,
+whichever is cheaper, and use N1 only when both are far more expensive.
+
+Moving is delete and recreate. Push any work in `/home` first; the startup script
+rebuilds the rest.
+
+### Create
+
+**1. GitHub PAT.** Fine-grained tokens cannot be created from an API, so this part is
+manual — at `github.com/settings/personal-access-tokens/new`:
+
+| Field | Value |
+|---|---|
+| Resource owner | `bytebase` (the org, not your account) |
+| Expiration | set one; rotation should be forced, not remembered |
+| Repository access | Public repositories (read-only) |
+| Organization permissions → **Self-hosted runners** | **Read and write** |
+| Repository permissions | none |
+
+Org-owned tokens may need an org admin to approve the request.
+
+Separately, grant yourself `roles/compute.osAdminLogin` on the project. That gives
+your OS Login account `sudo`. The script cannot grant it, because the account does not
+exist until you first connect.
+
+**2. Everything else.**
+
+```bash
+PROJECT=bytebase-dev
+ZONE=northamerica-northeast2-a
+SA=devbox@${PROJECT}.iam.gserviceaccount.com
+
+gcloud services enable secretmanager.googleapis.com --project=$PROJECT
+
+# Service account; its roles are granted below, nothing more.
+gcloud iam service-accounts create devbox --project=$PROJECT \
+  --display-name="devbox: dev host and CI runners"
+
+# The PAT, readable by that service account and nothing else.
+read -rsp 'GitHub PAT: ' GH_PAT && echo
+printf '%s' "$GH_PAT" | gcloud secrets create gh-runner-pat \
+  --project=$PROJECT --replication-policy=automatic --data-file=-
+unset GH_PAT
+
+gcloud secrets add-iam-policy-binding gh-runner-pat --project=$PROJECT \
+  --member="serviceAccount:${SA}" --role=roles/secretmanager.secretAccessor
+
+# Metrics and logs from the Ops Agent. Without these the agent gets 403s and goal 6
+# is silently unmet -- a scope is not a role.
+for r in monitoring.metricWriter logging.logWriter; do
+  gcloud projects add-iam-policy-binding $PROJECT \
+    --member="serviceAccount:${SA}" --role=roles/$r
+done
+
+# The instance.
+gcloud compute instances create devbox --project=$PROJECT --zone=$ZONE \
+  --machine-type=n2-custom-20-32768 \
+  --provisioning-model=SPOT --instance-termination-action=STOP \
+  --image-family=ubuntu-2404-lts-amd64 --image-project=ubuntu-os-cloud \
+  --boot-disk-size=100GB --boot-disk-type=pd-balanced --no-boot-disk-auto-delete \
+  --local-ssd=interface=NVME \
+  --service-account=$SA --scopes=cloud-platform \
+  --metadata=enable-oslogin=TRUE \
+  --metadata-from-file=startup-script=./startup.sh
+```
+
+The `cloud-platform` scope resolves to the intersection with the account's roles: one
+secret, metrics, logs. The scope is not the boundary. The IAM bindings are.
+
+There is no flag day. Runners register at the organization under the automatic
+`self-hosted` label, with host-qualified names. So this box only adds capacity
+alongside any existing runner, and you can delete the old one whenever.
+
+One step does have to happen in order. A preemption stops the instance, and
+`.github/workflows/start-runner-vm.yml` already restarts a runner box on a schedule.
+Repoint its instance name and zone at this one, in two places each, as the last step
+of cutover. Do it earlier and it stops restarting the box it serves today. Until then,
+start this one by hand.
+
+### Connect
+
+Run `gcloud compute config-ssh` once. It writes the `~/.ssh/config` entries, and this
+box's alias is `devbox.northamerica-northeast2-a.bytebase-dev`. Desktop agents take
+that alias as their SSH host: Claude Desktop under **Add SSH connection**, Codex in
+its SSH environment. Each developer gets their own account and home, created by OS
+Login on first connect.
+
+## 2. Startup script
+
+Saved as `startup.sh` and passed to the create command above. It runs as root on every
+boot and is idempotent. Local SSD is discarded on every stop, so anything living there
+is rebuilt. Anything on the boot disk is guarded, so it is not redone.
+
+### a. Disk layout
+
+Two kinds of account use the box, and they need opposite things from it.
+
+**Runner accounts** are `gha`, `ghb` and `ghc`. The script creates them, `nologin`,
+one per job slot. Nothing of theirs is worth keeping: software, work trees and caches
+all sit on Local SSD, and the `/home` that `useradd` creates goes unused. They are
+disposable, and are disposed of on every stop.
+
+**Interactive accounts** arrive through OS Login on first connect. Their `/home/<u>`
+is the only durable state on the box: repos, uncommitted changes, agent CLI state,
+`~/.ssh`. Nothing backs it up and nothing collects it. Push your branches, and keep an
+eye on the boot disk.
+
+| | Runner account | Interactive account |
+|---|---|---|
+| Created by | the startup script | OS Login, on first connect |
+| Boot disk | an unused `/home/<u>` | `/home/<u>` — **the only durable state** |
+| Local SSD | `/scratch/<u>/runner`, `/work`, `/cache` | `/scratch/<u>/cache` |
+| Cache wiring | `Environment=` in the systemd unit | `/etc/profile.d` symlinks the default paths onto scratch |
+| Lost on a rebuild | nothing | uncommitted work |
+
+Local SSD also carries Docker's `data-root`, the swapfile and `/tmp`. Container
+startup and database `fsync` are the heaviest I/O on this box. Docker starts before
+the script runs, so the script points it at Local SSD and restarts it.
+
+**Swap causes hangs; it does not prevent them.** Without swap, exhausting RAM is a
+fast OOM kill. With swap, the box thrashes until the job timeout. So there is 8 GB at
+`vm.swappiness=10`: enough to evict cold pages, too little to sustain a thrash. And
+`systemd-oomd` kills a runaway job before either happens.
+
+The `monitoring.metricWriter` role puts both in Cloud Monitoring, as
+`memory/percent_used` and `swap/percent_usage`. The suffixes differ. Sustained swap
+above zero means 32 GB is too little.
+
+Toolchains are not installed here. An agent session installs its own with `sudo`, to
+`/usr/local/go` and `/usr/local/node`, which the profile puts on every `PATH`. CI jobs
+bring their own through `setup-go` and `setup-node`.
+
+### b. Cache paths
+
+Four paths carry every cache. `XDG_CACHE_HOME` relocates the Go **build** cache,
+Playwright, yarn and pip. Three others ignore it: the Go **module** cache sits under
+`GOPATH`, npm uses `~/.npm`, and pnpm's store is under `XDG_DATA_HOME`. `TMPDIR` is
+unset, because `/tmp` is bind-mounted onto Local SSD and catches every process.
+
+The paths are per-account. Go writes module-cache files read-only, so one shared
+`GOMODCACHE` becomes a permissions problem.
+
+**Runner accounts** get them from `Environment=` in the unit. systemd owns a service's
+environment, so the setting always applies. A GitHub Actions `run:` step is a
+non-login shell and would never read a profile.
+
+**Interactive accounts** cannot be named in a unit. Instead `/etc/profile.d/devbox.sh`
+runs on every login and replaces each tool's default cache location with a symlink
+onto scratch:
+
+```
+~/.cache             ->  /scratch/<u>/cache
+~/go/pkg/mod         ->  /scratch/<u>/cache/go-mod
+~/.npm               ->  /scratch/<u>/cache/npm
+~/.local/share/pnpm  ->  /scratch/<u>/cache/pnpm
+```
+
+It creates the target directory first, then the link, and skips anything that is
+already a link. Nothing configures Go, npm or pnpm. They write to the paths they
+always use, and the filesystem sends those writes to Local SSD.
+
+Symlinks rather than variables. A variable's reach depends on how the SSH client
+invokes the shell. Some tools ignore `XDG_CACHE_HOME` anyway. And a missed variable
+fails *silently* onto the boot disk, while a dangling symlink fails loudly. The
+targets are recreated on every login, because a symlink on the durable disk pointing
+into the disposable one must be re-pointed after each wipe.
+
+Nothing outside the box needs to know any of this. `/tmp` and the default cache paths
+already resolve to Local SSD, so `AGENTS.md` stays environment-agnostic. Only output
+written *into* the repo tree follows the repo onto the boot disk — `./bytebase-build/`
+and `node_modules` — which is right for anything inside a working copy.
+
+### c. GitHub runners
+
+Three accounts, three job slots, one systemd template. That is one slot per
+self-hosted workflow that fires on a pull request. A fourth is one more name in the
+script's account list.
+
+The runner is stateless, so it lives on scratch and is re-fetched each boot: one
+~200 MB download, extracted per account. That costs seconds of boot time. In return
+the boot disk holds nothing of the runner's, and every start runs the version resolved
+at the top of the script. Only its system packages persist, guarded by a marker file
+so `apt` runs once per rebuild.
+
+`register-runner` reads the PAT from Secret Manager over the REST API, since the
+Ubuntu images ship no `gcloud`. It exchanges the PAT for a registration token and
+configures the runner. It deletes `.runner` and `.credentials` first, because
+`config.sh` refuses to run over an existing config. `--replace` then takes the
+server-side entry of the same name. Names are host-qualified, so two boxes never claim
+each other's.
+
+Re-registering rather than preserving credentials means the runner holds no identity
+on disk. Wipe the boot disk and the same service account brings back the same three
+runners. Registration is derived state, like `/scratch`.
+
+The units carry no `[Install]` section. The script starts them rather than enabling
+them, so they cannot race ahead of the scratch mount.
+
+### d. Cache cleanup
+
+Two problems, handled differently. **Garbage** is leaked `go-build*` sandboxes from
+cancelled or OOM-killed builds, and it is swept on every run. **Caches** are evicted
+only under disk pressure, because they are what make builds fast.
+
+The Go build cache dominates. On a comparable box it was 59% of all disk used. Go
+evicts by age with no size cap, so five days of CI output is about 55 GB per account,
+and it regrows after any cleanup.
+
+Eviction fires at 85% and cleans down to 70%. Cleaning to exactly the trigger would
+re-trigger immediately. Tiers escalate by rebuild cost, and the destructive ones wait
+for an idle box.
+
+It runs on a schedule, not at boot. A boot-time check cannot fire on a box that stays
+up for days, and Local SSD survives a guest *reboot*. It is discarded only on stop or
+preemption.
+
+### startup.sh
+
+```bash
+#!/bin/bash
+# GCE startup-script: root, every boot, idempotent. No `set -e` -- one failed step
+# must not abandon the boot; `journalctl -t devbox-startup` shows the exit status.
+set -uo pipefail
+trap 'logger -t devbox-startup "exited: status $?"' EXIT
+# Latest runner release, falling back to a known-good pin if the lookup fails. Every
+# boot uses this: the runner lives on scratch and is re-fetched, never updated in place.
+RUNNER_VERSION=$(curl -sf --retry 3 https://api.github.com/repos/actions/runner/releases/latest | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null || echo 2.336.0)
+
+# ---------- packages: the Ubuntu image ships neither ----------
+export DEBIAN_FRONTEND=noninteractive
+echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
+dpkg -s docker.io cron &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron; }   # any missing -> install
+
+# ---------- (a) disk layout ----------
+mkdir -p /scratch
+DEV=$(ls /dev/disk/by-id/google-local-* 2>/dev/null | head -1)
+if [[ -n "$DEV" ]] && ! mountpoint -q /scratch; then
+  # A stop discards Local SSD; a reboot does not. Format only when there is no filesystem.
+  [[ -n "$(blkid -s TYPE -o value "$DEV")" ]] || mkfs.ext4 -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "$DEV"
+  mount -o noatime,discard "$DEV" /scratch || logger -t devbox-startup "WARN: /scratch mount failed; scratch is on the boot disk"
+fi
+chmod 1777 /scratch                                   # OS Login accounts create their own subtree
+mkdir -p /scratch/tmp && chmod 1777 /scratch/tmp
+# Bind unless /tmp already *is* /scratch/tmp: `mountpoint` would also be true for a
+# tmpfs /tmp, which would silently leave temp files in RAM.
+[ "$(stat -c '%d:%i' /tmp)" = "$(stat -c '%d:%i' /scratch/tmp)" ] || mount --bind /scratch/tmp /tmp
+if [[ ! -f /scratch/swapfile ]]; then
+  fallocate -l 8G /scratch/swapfile && chmod 600 /scratch/swapfile && mkswap /scratch/swapfile >/dev/null
+fi
+swapon /scratch/swapfile 2>/dev/null || true          # no-op if already active
+sysctl -qw vm.swappiness=10
+systemctl enable --now systemd-oomd 2>/dev/null || true
+
+# Docker on Local SSD with log rotation. The socket is opened to every account: OS
+# Login users appear on first connect and cannot be pre-added to the docker group.
+mkdir -p /scratch/docker /etc/systemd/system/docker.service.d
+echo '{"data-root":"/scratch/docker","log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"3"}}' > /etc/docker/daemon.json
+printf '[Service]\nExecStartPost=/bin/chmod 666 /var/run/docker.sock\n' > /etc/systemd/system/docker.service.d/socket.conf
+systemctl daemon-reload && systemctl restart docker
+
+# ---------- (b) accounts and cache paths ----------
+for u in gha ghb ghc; do
+  id "$u" &>/dev/null || useradd -m -s /usr/sbin/nologin "$u"
+  usermod -aG docker "$u"
+  mkdir -p "/scratch/$u/cache" "/scratch/$u/work"
+  chown "$u:$u" "/scratch/$u" "/scratch/$u/cache" "/scratch/$u/work"   # not -R: contents are the user's own
+done
+
+# Interactive accounts appear on first OS Login connect, so the profile provisions them:
+# each tool's default cache path is symlinked onto scratch. Symlinks, not variables, so
+# an agent's `bash -c` -- which never sources a profile -- lands there too.
+cat > /etc/profile.d/devbox.sh <<'EOF'
+export PATH=/usr/local/go/bin:/usr/local/node/bin:$PATH   # the shared toolchain location; install once with sudo
+u=$(id -un); c=/scratch/$u/cache
+if [ -d /scratch ] && [ -n "$u" ] && [ -n "${HOME:-}" ] && mkdir -p "$c" 2>/dev/null; then
+  for pair in "$HOME/.cache:$c" "$HOME/go/pkg/mod:$c/go-mod" "$HOME/.npm:$c/npm" "$HOME/.local/share/pnpm:$c/pnpm"; do
+    link=${pair%%:*}; target=${pair#*:}
+    mkdir -p "$target"   # every login: scratch targets vanish on preemption, the symlink in HOME does not
+    [ -L "$link" ] || { mkdir -p "$(dirname "$link")" && rm -rf "$link" && ln -s "$target" "$link"; }
+  done 2>/dev/null
+fi
+unset u c pair link target
+EOF
+
+# ---------- (c) GitHub runners ----------
+# The runner is stateless, so it lives on scratch and is re-fetched each boot: one
+# download, extracted per account, always the version resolved above.
+curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" -o /tmp/runner.tar.gz
+for u in gha ghb ghc; do
+  install -d -o "$u" -g "$u" "/scratch/$u/runner"
+  tar xzf /tmp/runner.tar.gz -C "/scratch/$u/runner"
+  chown -R "$u:$u" "/scratch/$u/runner"
+done
+rm -f /tmp/runner.tar.gz
+# Its system packages land on the boot disk and persist, so this runs once per rebuild.
+[[ -f /var/lib/devbox-runner-deps ]] || \
+  { /scratch/gha/runner/bin/installdependencies.sh >/dev/null && touch /var/lib/devbox-runner-deps; }
+
+cat > /usr/local/sbin/register-runner <<'EOF'
+#!/bin/bash
+# <account> <install-dir> <work-dir>. Runs as the account, every boot.
+set -euo pipefail
+NAME=$1 DIR=$2 WORK=$3 ORG=bytebase
+md() { curl -sf -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/$1"; }
+PROJECT=$(md project/project-id)
+ACCESS=$(md instance/service-accounts/default/token | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
+PAT=$(curl -sf -H "Authorization: Bearer $ACCESS" \
+  "https://secretmanager.googleapis.com/v1/projects/${PROJECT}/secrets/gh-runner-pat/versions/latest:access" \
+  | python3 -c 'import sys,base64,json; print(base64.b64decode(json.load(sys.stdin)["payload"]["data"]).decode())')
+TOKEN=$(curl -sfX POST -H "Authorization: Bearer $PAT" -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/orgs/${ORG}/actions/runners/registration-token" \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
+cd "$DIR"
+rm -f .runner .credentials .credentials_rsakey   # config.sh refuses to overwrite an existing config
+./config.sh --unattended --replace --url "https://github.com/${ORG}" --token "$TOKEN" \
+  --name "$(hostname -s)-$NAME" --work "$WORK"   # host-qualified name: never collides with another box
+EOF
+chmod +x /usr/local/sbin/register-runner
+
+cat > /etc/systemd/system/actions-runner@.service <<'EOF'
+[Unit]
+Description=GitHub Actions runner (%i)
+Wants=network-online.target
+After=network-online.target docker.service
+[Service]
+User=%i
+WorkingDirectory=/scratch/%i/runner
+Environment=XDG_CACHE_HOME=/scratch/%i/cache GOMODCACHE=/scratch/%i/cache/go-mod npm_config_cache=/scratch/%i/cache/npm PNPM_CONFIG_STORE_DIR=/scratch/%i/cache/pnpm
+ExecStartPre=/usr/local/sbin/register-runner %i /scratch/%i/runner /scratch/%i/work
+ExecStart=/scratch/%i/runner/run.sh
+Restart=always
+RestartSec=30   # registration failure retries forever; 5s x3 runners would burn the API quota
+ManagedOOMMemoryPressure=kill
+EOF
+
+# ---------- (d) cache cleanup ----------
+cat > /usr/local/sbin/cache-gc <<'EOF'
+#!/bin/bash
+# Every 30 min. Leaked go-build sandboxes are swept unconditionally. Caches are evicted
+# only at 85% used, down to 70%, in order of rebuild cost; the destructive tiers wait
+# for an idle box unless ENOSPC is imminent. Removal is by path as root -- no toolchain.
+set -uo pipefail
+HIGH=85 LOW=70 CRITICAL=95
+find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 -exec rm -rf {} +
+accounts() { for d in /scratch/*/; do u=${d%/}; u=${u##*/}; id "$u" &>/dev/null && echo "$u"; done; }
+used()  { df -P /scratch | awk 'NR==2 {print $5+0}'; }
+halt_() { [[ $(used) -le $LOW ]] && { logger -t cache-gc "$1 -> $(used)%"; exit 0; }; }
+drop()  { for u in $(accounts); do p=/scratch/$u/cache/$1; rm -rf "$p"; install -d -o "$u" -g "$u" "$p"; done; }   # recreate: symlinks must not dangle
+idle()  { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state established '( sport = :22 )')" ]]; }
+
+[[ $(used) -ge $HIGH ]] || exit 0
+logger -t cache-gc "start: $(used)% used"
+# Safe while jobs run: only things idle >1h, and Go's content-addressed build cache.
+docker container prune -f --filter until=1h >/dev/null 2>&1
+docker image prune -f --filter until=1h >/dev/null 2>&1
+halt_ "docker garbage"
+for u in $(accounts); do find "/scratch/$u/cache/go-build" -type f -mmin +2880 -delete 2>/dev/null; done
+halt_ "go-build >2d"
+# Destructive from here.
+if ! idle && [[ $(used) -lt $CRITICAL ]]; then logger -t cache-gc "deferred: busy at $(used)%"; exit 0; fi
+docker builder prune -af >/dev/null 2>&1;                   halt_ "build cache"
+drop pnpm; drop npm;                                         halt_ "package stores"
+docker image prune -af --filter until=168h >/dev/null 2>&1;  halt_ "stale images"
+drop go-mod;                                                 halt_ "modcache"
+drop go-build
+logger -t cache-gc "full clean -> $(used)%"
+EOF
+chmod +x /usr/local/sbin/cache-gc
+# PATH first: cron's default omits /usr/sbin, and a missing `ss` would make idle()
+# look true and let the destructive tiers run during a live job.
+printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 * * * * root /usr/local/sbin/cache-gc\n' > /etc/cron.d/devbox
+
+# Guest memory and swap are invisible without the Ops Agent.
+systemctl is-active --quiet google-cloud-ops-agent || { curl -sSo /tmp/ops.sh --retry 3 https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh && bash /tmp/ops.sh --also-install; }
+
+systemctl daemon-reload
+systemctl restart actions-runner@gha actions-runner@ghb actions-runner@ghc
+```
+
+## 3. Considered
+
+**N2D** — its guaranteed Milan silicon avoids N2's Cascade-Lake-or-Ice-Lake lottery,
+but no region prices it close to Toronto N2. Spot rates are set per family *per
+region*, so there is no cheap region, only cheap region-and-family pairs.
+
+**Arm (C4A, T2A)** — not every testcontainer image ships arm64, and
+`mcr.microsoft.com/mssql/server` is one that does not. It is also not the saving it
+looks like: Arm has no custom shapes, so the nearest fit costs more for fewer cores.
+
+**48 GB or 64 GB RAM** — a comparable box runs two runner slots in 16 GB plus swap
+without an OOM kill, so 32 GB already doubles what has sufficed. Machine type is a
+stopped-instance change, so erring low costs one restart.
+
+**On-demand instead of Spot** — about 2.5x per hour. Reversible on a stopped instance
+with `set-scheduling`.
+
+**Two machines instead of one** — cheaper for the same work, because a combined box
+stays up for the union of both duty cycles at the sum of both sizes. Consolidation was
+chosen for operational simplicity.
+
+**750 GB Local SSD** — another $19.80/mo, against a projected 49% use of 375 GB. Local
+SSD is the one capacity fixed at creation, so it is the first thing to revisit if that
+projection is wrong.
+
+**A firewall rule and network tag** — the default VPC leaves several ports open to
+`0.0.0.0/0`, but nothing here listens on them. Tags can be added to a running instance,
+so a rule can follow later.
+
+**Repository-level runner registration** — it would bound a stolen credential to one
+repo, but its endpoints need the far broader *Administration* permission, and it would
+not give org-wide runners.
+
+**A Cloud Run service minting JIT configs** — it would keep the PAT off the box
+entirely, but it is too much infrastructure for a dev box. The accepted cost: any CI
+job can read the PAT from the metadata server, and an org-wide runner credential has
+org-wide reach by definition. It is bounded by a token expiry, and by alerting on any
+runner not named `devbox-*`.
+
+**Rootless Docker** — the socket is world-accessible, which is how an OS Login account
+the script cannot name gets Docker. That is root-equivalent, and accepted: the box
+holds only pushable work and an expiring PAT.
+
+**Pinning Ice Lake** — deferred. `cpuPlatform` after each restart shows what Toronto
+hands out. A pin, or a different region, is a stop-and-start away.
+
+## Reference
+
+- Local SSD: https://cloud.google.com/compute/docs/disks/local-ssd
+- Self-hosted runners: https://docs.github.com/en/actions/hosting-your-own-runners
+- Fine-grained PAT permissions: https://docs.github.com/en/rest/authentication/permissions-required-for-fine-grained-personal-access-tokens
+- CPU platforms: https://cloud.google.com/compute/docs/cpu-platforms

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -517,8 +517,9 @@ shopt -s dotglob   # a /scratch/.something must not hide from the glob
 for e in /scratch/*; do
   u=${e##*/}
   case $u in tmp|docker|containerd|swapfile|lost+found) continue;; esac
-  id "$u" &>/dev/null || { rm -rf "$e"; continue; }   # not an account: dumped at the top level
-  find "$e" -mindepth 1 -maxdepth 1 ! -name runner -exec rm -rf {} +   # runner/ holds the install and its stamp
+  id "$u" &>/dev/null || { rm -rf --one-file-system "$e"; continue; }   # not an account: dumped at the top level
+  case $u in runner[1-9]) keep='! -name runner';; *) keep=;; esac   # only a CI account's runner/ holds an install
+  find "$e" -mindepth 1 -maxdepth 1 -xdev $keep -exec rm -rf --one-file-system {} +   # never into a foreign mount
   for x in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do
     install -d -o "$u" -g "$u" "$e$x"   # recreate: symlinks must not dangle
   done

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -329,12 +329,14 @@ trap 'logger -t devbox-startup "exited: status $?"' EXIT
 # over a live data root is what this prevents, so a stop that did not take is fatal.
 # The socket counts: left active it reactivates dockerd on the next connection.
 stop_docker() {
-  systemctl stop docker.socket docker 2>/dev/null   # absent on a first boot
-  if pgrep -x dockerd >/dev/null || systemctl is-active --quiet docker.socket; then
+  systemctl stop docker.socket docker containerd 2>/dev/null   # absent on a first boot
+  if pgrep -x dockerd >/dev/null || pgrep -x containerd >/dev/null \
+     || systemctl is-active --quiet docker.socket; then
     logger -t devbox-startup "FATAL: docker would not stop"; exit 1
   fi
 }
 stop_docker   # before anything that can block or exit
+systemctl mask docker.socket docker containerd 2>/dev/null   # postinst must not start them
 # Latest runner release, falling back to a known-good pin if the lookup fails. Every
 # boot uses this: the runner lives on scratch and is re-fetched, never updated in place.
 RUNNER_VERSION=$(curl -sf --retry 3 --max-time 30 https://api.github.com/repos/actions/runner/releases/latest | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null || echo 2.336.0)
@@ -348,7 +350,8 @@ PKGS="docker.io cron systemd-oomd build-essential"
 [[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \
   || { dpkg --configure -a; apt-get update -qq && apt-get install -y -qq $PKGS; } \
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
-stop_docker   # again: docker.io's postinst starts it
+systemctl unmask docker.socket docker containerd 2>/dev/null
+stop_docker   # belt and braces once unmasked
 
 # ---------- (a) disk layout ----------
 mkdir -p /scratch
@@ -387,7 +390,12 @@ printf '[Slice]\nManagedOOMMemoryPressure=kill\n' > /etc/systemd/system/system.s
 mkdir -p /scratch/docker /etc/systemd/system/docker.service.d
 echo '{"data-root":"/scratch/docker","log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"3"}}' > /etc/docker/daemon.json
 printf '[Service]\nExecStartPost=/bin/chmod 666 /var/run/docker.sock\n' > /etc/systemd/system/docker.service.d/socket.conf
-systemctl daemon-reload && systemctl restart docker
+# Engine 29 defaults to the containerd image store, and data-root does not cover it:
+# images and snapshots live under containerd's own root. Bind it rather than edit
+# containerd's TOML, so there is no config format or default to track.
+mkdir -p /scratch/containerd /var/lib/containerd
+mountpoint -q /var/lib/containerd || mount --bind /scratch/containerd /var/lib/containerd
+systemctl daemon-reload && systemctl restart containerd docker
 
 # ---------- (b) accounts and cache paths ----------
 for u in runner1 runner2 runner3; do
@@ -535,6 +543,8 @@ printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 
 # runners that fail every job, or quietly fill the disk holding /home.
 docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
   || { logger -t devbox-startup "FATAL: docker unusable or not on Local SSD"; exit 1; }
+mountpoint -q /var/lib/containerd \
+  || { logger -t devbox-startup "FATAL: containerd images not on Local SSD"; exit 1; }
 
 systemctl daemon-reload
 systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -538,6 +538,8 @@ for u in $(accounts); do find "/scratch/$u/cache/go-build" -type f -mmin +2880 -
 halt_ "go-build >2d"
 # Destructive from here.
 if ! idle && [[ $(used) -lt $CRITICAL ]]; then logger -t cache-gc "deferred: busy at $(used)%"; exit 0; fi
+docker container prune -f >/dev/null 2>&1
+docker volume prune -af >/dev/null 2>&1;                     halt_ "containers and volumes"
 docker builder prune -af >/dev/null 2>&1;                   halt_ "build cache"
 drop pnpm; drop npm;                                         halt_ "package stores"
 docker image prune -af --filter until=168h >/dev/null 2>&1;  halt_ "stale images"

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -306,6 +306,10 @@ Eviction fires at 85% and cleans down to 70%. Cleaning to exactly the trigger wo
 re-trigger immediately. Tiers escalate by rebuild cost, and the destructive ones wait
 for an idle box.
 
+The idle check is a sample, not a lock, so a job starting mid-sweep can still lose a
+cache it was using. Accepted: it only happens above 85%, and a failed job is retryable
+where a full disk is not.
+
 It runs on a schedule, not at boot. A boot-time check cannot fire on a box that stays
 up for days, and Local SSD survives a guest *reboot*. It is discarded only on stop or
 preemption.
@@ -325,8 +329,8 @@ RUNNER_VERSION=$(curl -sf --retry 3 https://api.github.com/repos/actions/runner/
 # ---------- packages: the Ubuntu image ships neither ----------
 export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
-dpkg -s docker.io cron &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron; } \
-  || { logger -t devbox-startup "FATAL: docker/cron install failed"; exit 1; }   # never advertise a runner that cannot run Docker
+dpkg -s docker.io cron systemd-oomd &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron systemd-oomd; } \
+  || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }   # never advertise a runner that cannot run Docker
 
 # ---------- (a) disk layout ----------
 mkdir -p /scratch
@@ -351,7 +355,7 @@ if [[ ! -f /scratch/swapfile ]]; then
 fi
 swapon /scratch/swapfile 2>/dev/null || true          # no-op if already active
 sysctl -qw vm.swappiness=10
-systemctl enable --now systemd-oomd 2>/dev/null || true
+systemctl enable --now systemd-oomd || logger -t devbox-startup "WARN: systemd-oomd inert"
 # On the slice, not the runner unit: Docker gives each container its own scope under
 # system.slice, so a unit-scoped policy would never see the containers under test.
 mkdir -p /etc/systemd/system/system.slice.d
@@ -545,8 +549,10 @@ org-wide reach by definition. It is bounded by a token expiry, and by alerting o
 runner not named `devbox-*`.
 
 **Rootless Docker** — the socket is world-accessible, which is how an OS Login account
-the script cannot name gets Docker. That is root-equivalent, and accepted: the box
-holds only pushable work and an expiring PAT.
+the script cannot name gets Docker. That is root-equivalent, and accepted. Be clear
+what that accepts: CI runs pull-request code with the same reach, so a job can read or
+change any `/home` on the box -- uncommitted work, agent CLI state, `~/.ssh`. Treat
+this as a shared machine and keep nothing on it you would not put on one.
 
 **Pinning Ice Lake** — deferred. `cpuPlatform` after each restart shows what Toronto
 hands out. A pin, or a different region, is a stop-and-start away.

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -162,7 +162,7 @@ minutes, and starting a running instance is a no-op.
 
 ### Connect
 
-Run `gcloud compute config-ssh` once. It writes the `~/.ssh/config` entries, and this
+Run `gcloud compute config-ssh --project=bytebase-dev` once. It writes the `~/.ssh/config` entries, and this
 box's alias is `devbox.northamerica-northeast2-a.bytebase-dev`. Desktop agents take
 that alias as their SSH host: Claude Desktop under **Add SSH connection**, Codex in
 its SSH environment. Each developer gets their own account and home, created by OS
@@ -507,7 +507,7 @@ idle() { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state establish
 [[ $(used) -ge $HIGH ]] || exit 0
 if ! idle && [[ $(used) -lt $CRITICAL ]]; then logger -t cache-gc "deferred: busy at $(used)%"; exit 0; fi
 logger -t cache-gc "cleaning: $(used)% used"
-find /tmp -mindepth 1 -delete 2>/dev/null   # /tmp is on scratch; nothing is using it
+find /tmp -xdev -mindepth 1 -delete 2>/dev/null   # /tmp is on scratch; -xdev: never into a mount left beneath it
 docker ps -q | xargs -r docker rm -f >/dev/null 2>&1   # idle, so a running container is orphaned
 docker system prune -af --volumes >/dev/null 2>&1
 docker volume prune -af >/dev/null 2>&1   # system prune takes anonymous volumes only

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -511,9 +511,10 @@ find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 -exec rm -rf {} +
 accounts() { for d in /scratch/*/; do u=${d%/}; u=${u##*/}; id "$u" &>/dev/null && echo "$u"; done; }
 used()  { df -P /scratch | awk 'NR==2 {print $5+0}'; }
 halt_() { [[ $(used) -le $LOW ]] && { logger -t cache-gc "$1 -> $(used)%"; exit 0; }; }
-mk()    { for d in "" /go-mod /npm /pnpm; do install -d -o "$1" -g "$1" "/scratch/$1/cache$d"; done; }   # recreate: symlinks must not dangle
+mk()    { for d in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do install -d -o "$1" -g "$1" "/scratch/$1$d"; done; }   # recreate: symlinks must not dangle
 drop()  { for u in $(accounts); do rm -rf "/scratch/$u/cache/$1"; mk "$u"; done; }
-wipe()  { for u in $(accounts); do rm -rf "/scratch/$u/cache";    mk "$u"; done; }   # Playwright, pip, yarn and anything else under XDG_CACHE_HOME
+# Everything the account owns except runner/, which holds the install and its marker.
+wipe()  { for u in $(accounts); do rm -rf "/scratch/$u"/{cache,home,work}; mk "$u"; done; }
 idle()  { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state established '( sport = :22 )')" ]]; }
 
 [[ $(used) -ge $HIGH ]] || exit 0
@@ -530,7 +531,7 @@ docker builder prune -af >/dev/null 2>&1;                   halt_ "build cache"
 drop pnpm; drop npm;                                         halt_ "package stores"
 docker image prune -af --filter until=168h >/dev/null 2>&1;  halt_ "stale images"
 drop go-mod;                                                 halt_ "modcache"
-wipe   # everything left under XDG_CACHE_HOME, go-build included
+wipe   # the rest of XDG_CACHE_HOME, plus disposable homes and work trees
 logger -t cache-gc "full clean -> $(used)%"
 EOF
 chmod +x /usr/local/sbin/cache-gc

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -325,7 +325,8 @@ RUNNER_VERSION=$(curl -sf --retry 3 https://api.github.com/repos/actions/runner/
 # ---------- packages: the Ubuntu image ships neither ----------
 export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
-dpkg -s docker.io cron &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron; }   # any missing -> install
+dpkg -s docker.io cron &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron; } \
+  || { logger -t devbox-startup "FATAL: docker/cron install failed"; exit 1; }   # never advertise a runner that cannot run Docker
 
 # ---------- (a) disk layout ----------
 mkdir -p /scratch
@@ -339,7 +340,7 @@ fi
 # would put swap, Docker, work trees and caches on the 100 GB disk that holds /home.
 # Stop Docker too: daemon.json persists on the boot disk and points data-root at
 # /scratch, and Docker starts before this script runs.
-mountpoint -q /scratch || { logger -t devbox-startup "FATAL: no Local SSD at /scratch"; systemctl stop docker; exit 1; }
+mountpoint -q /scratch || { logger -t devbox-startup "FATAL: no Local SSD at /scratch"; systemctl stop docker.socket docker; exit 1; }
 chmod 1777 /scratch                                   # OS Login accounts create their own subtree
 mkdir -p /scratch/tmp && chmod 1777 /scratch/tmp
 # Bind unless /tmp already *is* /scratch/tmp: `mountpoint` would also be true for a
@@ -367,8 +368,10 @@ systemctl daemon-reload && systemctl restart docker
 for u in runner1 runner2 runner3; do
   id "$u" &>/dev/null || useradd -m -s /usr/sbin/nologin "$u"
   usermod -aG docker "$u"
-  mkdir -p "/scratch/$u/cache" "/scratch/$u/work"
-  chown "$u:$u" "/scratch/$u" "/scratch/$u/cache" "/scratch/$u/work"   # not -R: contents are the user's own
+  # runner/ too: systemd applies WorkingDirectory before ExecStartPre runs, so the
+  # unit would fail on CHDIR before install-runner could create it.
+  mkdir -p "/scratch/$u"/{cache,work,runner}
+  chown "$u:$u" "/scratch/$u" "/scratch/$u"/{cache,work,runner}   # not -R: contents are the user's own
 done
 
 # Interactive accounts appear on first OS Login connect, so the profile provisions them:
@@ -410,12 +413,13 @@ cat > /usr/local/sbin/install-runner <<'EOF'
 # <account>. Root, from the unit. Re-runs whole on every retry, deps included.
 set -euo pipefail
 DIR=/scratch/$1/runner
-[[ -x $DIR/config.sh ]] && exit 0
+[[ -f $DIR/.installed ]] && exit 0   # written last, so a failed dep step is retried
 V=$(< /etc/devbox-runner-version)
 install -d -o "$1" -g "$1" "$DIR"
 curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v$V/actions-runner-linux-x64-$V.tar.gz" | tar xz -C "$DIR"
 chown -R "$1:$1" "$DIR"
 "$DIR"/bin/installdependencies.sh >/dev/null   # apt is a no-op once satisfied
+touch "$DIR/.installed"
 EOF
 chmod +x /usr/local/sbin/install-runner
 

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -172,8 +172,9 @@ Log in once interactively before pointing an agent at a new account. The cache l
 in (b) are made by the profile, and a non-login `bash -c` does not read one -- so an
 account whose very first session is an agent command would write that session's caches
 to the boot disk. After that first login the links exist and every later session
-follows them, non-login included. `PATH` needs no such step: it comes from
-`/etc/environment`, which every session reads.
+follows them, non-login included -- and the startup script remakes the targets on
+every boot, so a preemption does not repeat the exercise. `PATH` needs no such step
+at all: it comes from `/etc/environment`, which every session reads.
 
 ## 2. Startup script
 
@@ -270,11 +271,12 @@ before counting any other repository in the org. That is deliberate: jobs queue,
 do not fail, and 20 vCPU split five ways is thin. A fourth or fifth slot is one more
 name in the script's account list if the wait proves worse than the contention.
 
-The runner is stateless, so it lives on scratch and is re-fetched each boot: one
-~200 MB download, extracted per account. That costs seconds of boot time. In return
-the boot disk holds nothing of the runner's, and every start runs the version resolved
-at the top of the script. Only its system packages persist, guarded by a marker file
-so `apt` runs once per rebuild.
+The runner is stateless, so it lives on scratch and is installed by the unit rather
+than by the startup script: an `ExecStartPre` runs `install-runner` as root, before
+the account registers. systemd retries that step, so a failed download heals itself
+instead of leaving the slot dead until someone reboots the box. Each account fetches
+its own ~200 MB copy, which costs seconds. In return the boot disk holds nothing of
+the runner's, and every start runs the version resolved at boot.
 
 `register-runner` reads the PAT from Secret Manager over the REST API, since the
 Ubuntu images ship no `gcloud`. It exchanges the PAT for a registration token and
@@ -335,7 +337,9 @@ if [[ -n "$DEV" ]] && ! mountpoint -q /scratch; then
 fi
 # Everything below assumes /scratch is the Local SSD. Falling back to the boot disk
 # would put swap, Docker, work trees and caches on the 100 GB disk that holds /home.
-mountpoint -q /scratch || { logger -t devbox-startup "FATAL: no Local SSD at /scratch"; exit 1; }
+# Stop Docker too: daemon.json persists on the boot disk and points data-root at
+# /scratch, and Docker starts before this script runs.
+mountpoint -q /scratch || { logger -t devbox-startup "FATAL: no Local SSD at /scratch"; systemctl stop docker; exit 1; }
 chmod 1777 /scratch                                   # OS Login accounts create their own subtree
 mkdir -p /scratch/tmp && chmod 1777 /scratch/tmp
 # Bind unless /tmp already *is* /scratch/tmp: `mountpoint` would also be true for a
@@ -387,20 +391,33 @@ fi
 unset u c pair link target
 EOF
 
-# ---------- (c) GitHub runners ----------
-# The runner is stateless, so it lives on scratch and is re-fetched each boot: one
-# download, extracted per account, always the version resolved above.
-echo "$RUNNER_VERSION" > /etc/devbox-runner-version   # register-runner re-reads this to self-heal
-curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" -o /tmp/runner.tar.gz
-for u in runner1 runner2 runner3; do
-  install -d -o "$u" -g "$u" "/scratch/$u/runner"
-  tar xzf /tmp/runner.tar.gz -C "/scratch/$u/runner"
-  chown -R "$u:$u" "/scratch/$u/runner"
+# Accounts that already exist keep their symlinks in /home across a stop, but the
+# scratch targets those point at are gone. Remake them, so only a brand-new account
+# still needs a first interactive login.
+for h in /home/*; do
+  u=${h##*/}; id "$u" &>/dev/null || continue
+  for d in "" /go-mod /npm /pnpm; do install -d -o "$u" -g "$u" "/scratch/$u/cache$d"; done
 done
-rm -f /tmp/runner.tar.gz
-# Its system packages land on the boot disk and persist, so this runs once per rebuild.
-[[ -f /var/lib/devbox-runner-deps ]] || \
-  { /scratch/runner1/runner/bin/installdependencies.sh >/dev/null && touch /var/lib/devbox-runner-deps; }
+
+# ---------- (c) GitHub runners ----------
+# The runner is stateless, so it lives on scratch and is installed from the unit
+# rather than from here. systemd retries that step forever, so a failed download
+# heals itself; doing it at boot gave a fresh VM no second chance.
+echo "$RUNNER_VERSION" > /etc/devbox-runner-version
+
+cat > /usr/local/sbin/install-runner <<'EOF'
+#!/bin/bash
+# <account>. Root, from the unit. Re-runs whole on every retry, deps included.
+set -euo pipefail
+DIR=/scratch/$1/runner
+[[ -x $DIR/config.sh ]] && exit 0
+V=$(< /etc/devbox-runner-version)
+install -d -o "$1" -g "$1" "$DIR"
+curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v$V/actions-runner-linux-x64-$V.tar.gz" | tar xz -C "$DIR"
+chown -R "$1:$1" "$DIR"
+"$DIR"/bin/installdependencies.sh >/dev/null   # apt is a no-op once satisfied
+EOF
+chmod +x /usr/local/sbin/install-runner
 
 cat > /usr/local/sbin/register-runner <<'EOF'
 #!/bin/bash
@@ -417,12 +434,6 @@ TOKEN=$(curl -sfX POST -H "Authorization: Bearer $PAT" -H "Accept: application/v
   "https://api.github.com/orgs/${ORG}/actions/runners/registration-token" \
   | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
 cd "$DIR"
-# systemd retries this unit forever, so re-fetch if the boot-time download failed. A
-# transient network error then heals itself instead of killing the slot until reboot.
-if [[ ! -x ./config.sh ]]; then
-  V=$(< /etc/devbox-runner-version)
-  curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v$V/actions-runner-linux-x64-$V.tar.gz" | tar xz
-fi
 rm -f .runner .credentials .credentials_rsakey   # config.sh refuses to overwrite an existing config
 ./config.sh --unattended --replace --url "https://github.com/${ORG}" --token "$TOKEN" \
   --name "$(hostname -s)-$NAME" --work "$WORK"   # host-qualified name: never collides with another box
@@ -438,6 +449,7 @@ After=network-online.target docker.service
 User=%i
 WorkingDirectory=/scratch/%i/runner
 Environment=XDG_CACHE_HOME=/scratch/%i/cache GOMODCACHE=/scratch/%i/cache/go-mod npm_config_cache=/scratch/%i/cache/npm PNPM_CONFIG_STORE_DIR=/scratch/%i/cache/pnpm
+ExecStartPre=+/usr/local/sbin/install-runner %i
 ExecStartPre=/usr/local/sbin/register-runner %i /scratch/%i/runner /scratch/%i/work
 ExecStart=/scratch/%i/runner/run.sh
 Restart=always

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -511,10 +511,13 @@ chmod +x /usr/local/sbin/cache-gc
 # look true and let the destructive tiers run during a live job.
 printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 * * * * root /usr/local/sbin/cache-gc\n' > /etc/cron.d/devbox
 
-# One outcome check before any runner is advertised. Covers a failed package
-# install, a dockerd that would not start, and a daemon.json it rejects -- all of
-# which otherwise register three healthy-looking runners that fail every job.
-docker info &>/dev/null || { logger -t devbox-startup "FATAL: docker unusable"; exit 1; }
+# One outcome check before any runner is advertised. An unset or unreadable
+# DockerRootDir catches a failed package install, a dockerd that would not start and a
+# daemon.json it rejected; requiring /scratch also catches one that was never written,
+# which starts dockerd cleanly on the boot disk. Otherwise: three healthy-looking
+# runners that fail every job, or quietly fill the disk holding /home.
+docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
+  || { logger -t devbox-startup "FATAL: docker unusable or not on Local SSD"; exit 1; }
 
 systemctl daemon-reload
 systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -509,11 +509,6 @@ chmod +x /usr/local/sbin/cache-gc
 # look true and let the destructive tiers run during a live job.
 printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 * * * * root /usr/local/sbin/cache-gc\n' > /etc/cron.d/devbox
 
-# Guest memory and swap are invisible without the Ops Agent.
-systemctl is-active --quiet google-cloud-ops-agent \
-  || { curl -sSo /tmp/ops.sh --retry 3 https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh && bash /tmp/ops.sh --also-install; } \
-  || logger -t devbox-startup "WARN: Ops Agent install failed; no memory or swap metrics"   # retried next boot
-
 # One outcome check before any runner is advertised. Covers a failed package
 # install, a dockerd that would not start, and a daemon.json it rejects -- all of
 # which otherwise register three healthy-looking runners that fail every job.
@@ -521,6 +516,13 @@ docker info &>/dev/null || { logger -t devbox-startup "FATAL: docker unusable"; 
 
 systemctl daemon-reload
 systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3
+
+# Last, and time-bounded: guest memory and swap are invisible without the Ops Agent,
+# but it is observability. A stall here must not hold up CI capacity.
+systemctl is-active --quiet google-cloud-ops-agent \
+  || { curl -sS --retry 3 --max-time 120 -o /tmp/ops.sh https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh \
+       && timeout 300 bash /tmp/ops.sh --also-install; } \
+  || logger -t devbox-startup "WARN: Ops Agent install failed; no memory or swap metrics"   # retried next boot
 ```
 
 ## 3. Considered

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -508,7 +508,9 @@ chmod +x /usr/local/sbin/cache-gc
 printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 * * * * root /usr/local/sbin/cache-gc\n' > /etc/cron.d/devbox
 
 # Guest memory and swap are invisible without the Ops Agent.
-systemctl is-active --quiet google-cloud-ops-agent || { curl -sSo /tmp/ops.sh --retry 3 https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh && bash /tmp/ops.sh --also-install; }
+systemctl is-active --quiet google-cloud-ops-agent \
+  || { curl -sSo /tmp/ops.sh --retry 3 https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh && bash /tmp/ops.sh --also-install; } \
+  || logger -t devbox-startup "WARN: Ops Agent install failed; no memory or swap metrics"   # retried next boot
 
 systemctl daemon-reload
 systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -349,7 +349,9 @@ chmod 1777 /scratch                                   # OS Login accounts create
 mkdir -p /scratch/tmp && chmod 1777 /scratch/tmp
 # Bind unless /tmp already *is* /scratch/tmp: `mountpoint` would also be true for a
 # tmpfs /tmp, which would silently leave temp files in RAM.
-[ "$(stat -c '%d:%i' /tmp)" = "$(stat -c '%d:%i' /scratch/tmp)" ] || mount --bind /scratch/tmp /tmp
+[ "$(stat -c '%d:%i' /tmp)" = "$(stat -c '%d:%i' /scratch/tmp)" ] \
+  || mount --bind /scratch/tmp /tmp \
+  || { logger -t devbox-startup "FATAL: /tmp not on Local SSD"; systemctl stop docker.socket docker; exit 1; }
 if [[ ! -f /scratch/swapfile ]]; then
   fallocate -l 8G /scratch/swapfile && chmod 600 /scratch/swapfile && mkswap /scratch/swapfile >/dev/null
 fi
@@ -388,7 +390,7 @@ echo 'PATH="/usr/local/go/bin:/usr/local/node/bin:/usr/local/sbin:/usr/local/bin
 
 cat > /etc/profile.d/devbox.sh <<'EOF'
 u=$(id -un); c=/scratch/$u/cache
-if [ -d /scratch ] && [ -n "$u" ] && [ -n "${HOME:-}" ] && mkdir -p "$c" 2>/dev/null; then
+if mountpoint -q /scratch && [ -n "$u" ] && [ -n "${HOME:-}" ] && mkdir -p "$c" 2>/dev/null; then
   for pair in "$HOME/.cache:$c" "$HOME/go/pkg/mod:$c/go-mod" "$HOME/.npm:$c/npm" "$HOME/.local/share/pnpm:$c/pnpm"; do
     link=${pair%%:*}; target=${pair#*:}
     mkdir -p "$target"   # every login: scratch targets vanish on preemption, the symlink in HOME does not

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -513,6 +513,7 @@ docker system prune -af --volumes >/dev/null 2>&1
 docker volume prune -af >/dev/null 2>&1   # system prune takes anonymous volumes only
 # On scratch only the fixed entries and each account's runner/ install survive. The
 # rest -- whatever was written, wherever -- is by definition disposable.
+shopt -s dotglob   # a /scratch/.something must not hide from the glob
 for e in /scratch/*; do
   u=${e##*/}
   case $u in tmp|docker|containerd|swapfile|lost+found) continue;; esac

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -91,7 +91,8 @@ PROJECT=bytebase-dev
 ZONE=northamerica-northeast2-a
 SA=devbox@${PROJECT}.iam.gserviceaccount.com
 
-gcloud services enable secretmanager.googleapis.com --project=$PROJECT
+gcloud services enable secretmanager.googleapis.com oslogin.googleapis.com \
+  --project=$PROJECT
 
 # Service account; its roles are granted below, nothing more.
 gcloud iam service-accounts create devbox --project=$PROJECT \
@@ -171,7 +172,8 @@ Log in once interactively before pointing an agent at a new account. The cache l
 in (b) are made by the profile, and a non-login `bash -c` does not read one -- so an
 account whose very first session is an agent command would write that session's caches
 to the boot disk. After that first login the links exist and every later session
-follows them, non-login included.
+follows them, non-login included. `PATH` needs no such step: it comes from
+`/etc/environment`, which every session reads.
 
 ## 2. Startup script
 
@@ -215,7 +217,8 @@ The `monitoring.metricWriter` role puts both in Cloud Monitoring, as
 is too little.
 
 Toolchains are not installed here. An agent session installs its own with `sudo`, to
-`/usr/local/go` and `/usr/local/node`, which the profile puts on every `PATH`. CI jobs
+`/usr/local/go` and `/usr/local/node`, which `/etc/environment` puts on the `PATH` of
+every session, non-login included. CI jobs
 bring their own through `setup-go` and `setup-node`.
 
 ### b. Cache paths
@@ -357,8 +360,12 @@ done
 # Interactive accounts appear on first OS Login connect, so the profile provisions them:
 # each tool's default cache path is symlinked onto scratch. Symlinks, not variables, so
 # an agent's `bash -c` -- which never sources a profile -- lands there too.
+# PATH for every SSH session. pam_env reads this file, so an agent's non-login
+# `bash -c` -- which reads no profile -- still finds the shared toolchain. Unlike the
+# cache symlinks below, a PATH set in a profile would not outlive the login shell.
+echo 'PATH="/usr/local/go/bin:/usr/local/node/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' > /etc/environment
+
 cat > /etc/profile.d/devbox.sh <<'EOF'
-export PATH=/usr/local/go/bin:/usr/local/node/bin:$PATH   # the shared toolchain location; install once with sudo
 u=$(id -un); c=/scratch/$u/cache
 if [ -d /scratch ] && [ -n "$u" ] && [ -n "${HOME:-}" ] && mkdir -p "$c" 2>/dev/null; then
   for pair in "$HOME/.cache:$c" "$HOME/go/pkg/mod:$c/go-mod" "$HOME/.npm:$c/npm" "$HOME/.local/share/pnpm:$c/pnpm"; do

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -335,7 +335,11 @@ RUNNER_VERSION=$(curl -sf --retry 3 --max-time 30 https://api.github.com/repos/a
 # ---------- packages: the Ubuntu image ships neither ----------
 export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
-dpkg -s docker.io cron systemd-oomd build-essential &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron systemd-oomd build-essential; } \
+PKGS="docker.io cron systemd-oomd build-essential"
+# Count 'install ok installed', not dpkg -s: a preemption mid-apt leaves packages
+# unpacked but unconfigured, which dpkg -s still reports as success.
+[[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \
+  || { apt-get update -qq && apt-get install -y -qq $PKGS; } \
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
 systemctl stop docker.socket docker 2>/dev/null   # again: docker.io's postinst starts it
 

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -81,9 +81,8 @@ manual — at `github.com/settings/personal-access-tokens/new`:
 
 Org-owned tokens may need an org admin to approve the request.
 
-Separately, grant yourself `roles/compute.osAdminLogin` on the project. That gives
-your OS Login account `sudo`. The script cannot grant it, because the account does not
-exist until you first connect.
+Developer access is granted below rather than by the script, because an OS Login
+account does not exist until its owner first connects.
 
 **2. Everything else.**
 
@@ -117,6 +116,17 @@ done
 # A reserved address. An ephemeral one is released when the instance stops, so every
 # preemption would hand the box a new IP and strand the generated SSH entry.
 gcloud compute addresses create devbox --project=$PROJECT --region=${ZONE%-*}
+
+# Each developer who will SSH in. OS Login checks both: osAdminLogin gives the
+# account `sudo`, and because the VM has a service account attached, connecting also
+# requires permission to act as it -- without that, OS Login refuses the connection
+# before it ever creates the account.
+for DEV in you@bytebase.com; do
+  gcloud projects add-iam-policy-binding $PROJECT \
+    --member="user:$DEV" --role=roles/compute.osAdminLogin
+  gcloud iam service-accounts add-iam-policy-binding $SA --project=$PROJECT \
+    --member="user:$DEV" --role=roles/iam.serviceAccountUser
+done
 
 # The instance.
 gcloud compute instances create devbox --project=$PROJECT --zone=$ZONE \

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -325,6 +325,15 @@ preemption.
 # must not abandon the boot; `journalctl -t devbox-startup` shows the exit status.
 set -uo pipefail
 trap 'logger -t devbox-startup "exited: status $?"' EXIT
+# A fatal exit powers the box off rather than leaving it RUNNING with no runners,
+# which the start workflow would never touch. Off, it is restarted and retried on the
+# workflow's next tick; a transient DNS or mirror failure heals itself, a persistent
+# one shows as a box that keeps stopping. Five minutes keeps SSH usable first.
+fatal() {
+  logger -t devbox-startup "FATAL: $1"
+  systemctl stop docker.socket docker containerd 2>/dev/null
+  shutdown -h +5 "devbox-startup: $1"; exit 1
+}
 # daemon.json persists, so a previous boot's dockerd is already up with
 # data-root=/scratch/docker -- on the boot disk until (a) mounts over it. Mounting
 # over a live data root is what this prevents, so a stop that did not take is fatal.
@@ -332,9 +341,7 @@ trap 'logger -t devbox-startup "exited: status $?"' EXIT
 stop_docker() {
   systemctl stop docker.socket docker containerd 2>/dev/null   # absent on a first boot
   if pgrep -x dockerd >/dev/null || pgrep -x containerd >/dev/null \
-     || systemctl is-active --quiet docker.socket; then
-    logger -t devbox-startup "FATAL: docker would not stop"; exit 1
-  fi
+     || systemctl is-active --quiet docker.socket; then fatal "docker would not stop"; fi
 }
 stop_docker   # before anything that can block or exit
 systemctl mask --now docker.socket docker containerd 2>/dev/null   # --now: also stops one a postinst already queued
@@ -353,12 +360,12 @@ PKGS="docker.io cron systemd-oomd build-essential"
 # held by unattended-upgrades means nothing to clear -- apt waits for that lock.
 dpkg --configure -a 2>/dev/null || true
 apt-get -y -qq --fix-broken install \
-  || { logger -t devbox-startup "FATAL: apt cannot repair the package state"; exit 1; }
+  || fatal "apt cannot repair the package state"
 # Count 'install ok installed', not dpkg -s: a preemption mid-apt leaves packages
 # unpacked but unconfigured, which dpkg -s still reports as success.
 [[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \
   || { apt-get update -qq && apt-get install -y -qq $PKGS; } \
-  || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
+  || fatal "prerequisite install failed"
 systemctl unmask docker.socket docker containerd 2>/dev/null
 stop_docker   # belt and braces once unmasked
 
@@ -372,14 +379,14 @@ if [[ -n "$DEV" ]] && ! mountpoint -q /scratch; then
 fi
 # Everything below assumes /scratch is the Local SSD. Falling back to the boot disk
 # would put swap, Docker, work trees and caches on the 100 GB disk that holds /home.
-mountpoint -q /scratch || { logger -t devbox-startup "FATAL: no Local SSD at /scratch"; exit 1; }
+mountpoint -q /scratch || fatal "no Local SSD at /scratch"
 chmod 1777 /scratch                                   # OS Login accounts create their own subtree
 mkdir -p /scratch/tmp && chmod 1777 /scratch/tmp
 # Bind unless /tmp already *is* /scratch/tmp: `mountpoint` would also be true for a
 # tmpfs /tmp, which would silently leave temp files in RAM.
 [ "$(stat -c '%d:%i' /tmp)" = "$(stat -c '%d:%i' /scratch/tmp)" ] \
   || mount --bind /scratch/tmp /tmp \
-  || { logger -t devbox-startup "FATAL: /tmp not on Local SSD"; exit 1; }
+  || fatal "/tmp not on Local SSD"
 # blkid, not -f: a partly written file satisfies -f and swapon then rejects it.
 if [[ "$(blkid -s TYPE -o value /scratch/swapfile 2>/dev/null)" != swap ]]; then
   rm -f /scratch/swapfile
@@ -404,7 +411,7 @@ printf '[Service]\nExecStartPost=/bin/chmod 666 /var/run/docker.sock\n' > /etc/s
 # containerd's TOML, so there is no config format or default to track.
 mkdir -p /scratch/containerd /var/lib/containerd
 mountpoint -q /var/lib/containerd || mount --bind /scratch/containerd /var/lib/containerd \
-  || { logger -t devbox-startup "FATAL: containerd store not on Local SSD"; exit 1; }
+  || fatal "containerd store not on Local SSD"
 systemctl daemon-reload && systemctl restart containerd docker
 
 # ---------- (b) accounts and cache paths ----------
@@ -522,7 +529,10 @@ set -uo pipefail
 HIGH=85 CRITICAL=95
 find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 -exec rm -rf {} +
 used() { df -P /scratch | awk 'NR==2 {print $5+0}'; }
-idle() { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state established '( sport = :22 )')" ]]; }
+# Load catches detached work -- tmux, nohup, a container -- that holds neither an SSH
+# session nor a Runner.Worker. On 20 vCPU, anything actually working exceeds 2.
+idle() { ! pgrep -f Runner.Worker >/dev/null && [[ -z "$(ss -Htn state established '( sport = :22 )')" ]] \
+         && (( $(cut -d. -f1 /proc/loadavg) < 2 )); }
 
 [[ $(used) -ge $HIGH ]] || exit 0
 if ! idle && [[ $(used) -lt $CRITICAL ]]; then logger -t cache-gc "deferred: busy at $(used)%"; exit 0; fi
@@ -551,7 +561,7 @@ printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 
 # which starts dockerd cleanly on the boot disk. Otherwise: three healthy-looking
 # runners that fail every job, or quietly fill the disk holding /home.
 docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
-  || { logger -t devbox-startup "FATAL: docker unusable or not on Local SSD"; stop_docker; exit 1; }
+  || fatal "docker unusable or not on Local SSD"
 
 systemctl daemon-reload
 systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -329,14 +329,14 @@ RUNNER_VERSION=$(curl -sf --retry 3 https://api.github.com/repos/actions/runner/
 # ---------- packages: the Ubuntu image ships neither ----------
 export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
+# Docker down first. daemon.json persists, so a previous boot's dockerd is already up
+# with data-root=/scratch/docker -- on the boot disk until (a) mounts over it, and
+# still writing there through anything slow or fatal below. Absent on a first boot.
+systemctl stop docker.socket docker 2>/dev/null
 dpkg -s docker.io cron systemd-oomd &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron systemd-oomd; } \
-  || { logger -t devbox-startup "FATAL: prerequisite install failed"; systemctl stop docker.socket docker; exit 1; }
+  || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
 
 # ---------- (a) disk layout ----------
-# Before /scratch changes shape: daemon.json persists, so dockerd is already up with
-# data-root=/scratch/docker. Mounting over an open data root leaves it writing to the
-# covered boot-disk tree, invisible under the mount. Restarted below.
-systemctl stop docker.socket docker
 mkdir -p /scratch
 DEV=$(ls /dev/disk/by-id/google-local-* 2>/dev/null | head -1)
 if [[ -n "$DEV" ]] && ! mountpoint -q /scratch; then

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -548,7 +548,7 @@ printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 
 # which starts dockerd cleanly on the boot disk. Otherwise: three healthy-looking
 # runners that fail every job, or quietly fill the disk holding /home.
 docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
-  || { logger -t devbox-startup "FATAL: docker unusable or not on Local SSD"; exit 1; }
+  || { logger -t devbox-startup "FATAL: docker unusable or not on Local SSD"; stop_docker; exit 1; }
 
 systemctl daemon-reload
 systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -333,6 +333,10 @@ dpkg -s docker.io cron systemd-oomd &>/dev/null || { apt-get update -qq && apt-g
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; systemctl stop docker.socket docker; exit 1; }
 
 # ---------- (a) disk layout ----------
+# Before /scratch changes shape: daemon.json persists, so dockerd is already up with
+# data-root=/scratch/docker. Mounting over an open data root leaves it writing to the
+# covered boot-disk tree, invisible under the mount. Restarted below.
+systemctl stop docker.socket docker
 mkdir -p /scratch
 DEV=$(ls /dev/disk/by-id/google-local-* 2>/dev/null | head -1)
 if [[ -n "$DEV" ]] && ! mountpoint -q /scratch; then
@@ -342,16 +346,14 @@ if [[ -n "$DEV" ]] && ! mountpoint -q /scratch; then
 fi
 # Everything below assumes /scratch is the Local SSD. Falling back to the boot disk
 # would put swap, Docker, work trees and caches on the 100 GB disk that holds /home.
-# Stop Docker too: daemon.json persists on the boot disk and points data-root at
-# /scratch, and Docker starts before this script runs.
-mountpoint -q /scratch || { logger -t devbox-startup "FATAL: no Local SSD at /scratch"; systemctl stop docker.socket docker; exit 1; }
+mountpoint -q /scratch || { logger -t devbox-startup "FATAL: no Local SSD at /scratch"; exit 1; }
 chmod 1777 /scratch                                   # OS Login accounts create their own subtree
 mkdir -p /scratch/tmp && chmod 1777 /scratch/tmp
 # Bind unless /tmp already *is* /scratch/tmp: `mountpoint` would also be true for a
 # tmpfs /tmp, which would silently leave temp files in RAM.
 [ "$(stat -c '%d:%i' /tmp)" = "$(stat -c '%d:%i' /scratch/tmp)" ] \
   || mount --bind /scratch/tmp /tmp \
-  || { logger -t devbox-startup "FATAL: /tmp not on Local SSD"; systemctl stop docker.socket docker; exit 1; }
+  || { logger -t devbox-startup "FATAL: /tmp not on Local SSD"; exit 1; }
 if [[ ! -f /scratch/swapfile ]]; then
   fallocate -l 8G /scratch/swapfile && chmod 600 /scratch/swapfile && mkswap /scratch/swapfile >/dev/null
 fi

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -92,7 +92,7 @@ ZONE=northamerica-northeast2-a
 SA=devbox@${PROJECT}.iam.gserviceaccount.com
 
 gcloud services enable secretmanager.googleapis.com oslogin.googleapis.com \
-  --project=$PROJECT
+  monitoring.googleapis.com logging.googleapis.com --project=$PROJECT
 
 # Service account; its roles are granted below, nothing more.
 gcloud iam service-accounts create devbox --project=$PROJECT \
@@ -330,7 +330,7 @@ trap 'logger -t devbox-startup "exited: status $?"' EXIT
 systemctl stop docker.socket docker 2>/dev/null
 # Latest runner release, falling back to a known-good pin if the lookup fails. Every
 # boot uses this: the runner lives on scratch and is re-fetched, never updated in place.
-RUNNER_VERSION=$(curl -sf --retry 3 https://api.github.com/repos/actions/runner/releases/latest | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null || echo 2.336.0)
+RUNNER_VERSION=$(curl -sf --retry 3 --max-time 30 https://api.github.com/repos/actions/runner/releases/latest | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null || echo 2.336.0)
 
 # ---------- packages: the Ubuntu image ships neither ----------
 export DEBIAN_FRONTEND=noninteractive

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -517,8 +517,9 @@ shopt -s dotglob   # a /scratch/.something must not hide from the glob
 for e in /scratch/*; do
   u=${e##*/}
   case $u in tmp|docker|containerd|swapfile|lost+found) continue;; esac
-  id "$u" &>/dev/null || { mountpoint -q "$e" || rm -rf --one-file-system "$e"; continue; }   # not an account: dumped at the top level
-  case $u in runner[1-9]) keep=(! -path "$e/runner" ! -path "$e/runner/*");; *) keep=();; esac   # only a CI account's runner/ holds an install
+  mountpoint -q "$e" && continue   # not ours, whatever it is: never delete through a mount
+  if ! id "$u" &>/dev/null || [[ ! -d $e ]]; then rm -rf --one-file-system "$e"; continue; fi   # dumped at the top level
+  case $u in runner[1-9]) keep=(! -path "$e/runner" ! -path "$e/runner/*");; *) keep=(-true);; esac   # only a CI account's runner/ holds an install
   find "$e" -mindepth 1 -xdev "${keep[@]}" -delete 2>/dev/null   # -delete cannot cross into, or remove, a foreign mount
   for x in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do
     install -d -o "$u" -g "$u" "$e$x"   # recreate: symlinks must not dangle

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -544,6 +544,7 @@ docker builder prune -af >/dev/null 2>&1;                   halt_ "build cache"
 drop pnpm; drop npm;                                         halt_ "package stores"
 docker image prune -af --filter until=168h >/dev/null 2>&1;  halt_ "stale images"
 drop go-mod;                                                 halt_ "modcache"
+docker image prune -af >/dev/null 2>&1   # the last tier keeps nothing: recent images too
 wipe   # the rest of XDG_CACHE_HOME, plus disposable homes and work trees
 logger -t cache-gc "full clean -> $(used)%"
 EOF

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -522,7 +522,7 @@ for e in /scratch/*; do
   case $u in runner[1-9]) keep=(! -path "$e/runner" ! -path "$e/runner/*");; *) keep=(-true);; esac   # only a CI account's runner/ holds an install
   find "$e" -mindepth 1 -xdev "${keep[@]}" -delete 2>/dev/null   # -delete cannot cross into, or remove, a foreign mount
   for x in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do
-    install -d -o "$u" -g "$u" "$e$x"   # recreate: symlinks must not dangle
+    mountpoint -q "$e$x" || install -d -o "$u" -g "$u" "$e$x"   # recreate: symlinks must not dangle; never chown a mount
   done
 done
 logger -t cache-gc "cleaned -> $(used)%"

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -278,7 +278,7 @@ than by the startup script: an `ExecStartPre` runs `install-runner` as root, bef
 the account registers. systemd retries that step, so a failed download heals itself
 instead of leaving the slot dead until someone reboots the box. Each account fetches
 its own ~200 MB copy, which costs seconds. In return the boot disk holds nothing of
-the runner's, and every start runs the version resolved at boot.
+the runner's, and each start installs the latest release.
 
 `register-runner` reads the PAT from Secret Manager over the REST API, since the
 Ubuntu images ship no `gcloud`. It exchanges the PAT for a registration token and
@@ -321,53 +321,31 @@ preemption.
 
 ```bash
 #!/bin/bash
-# GCE startup-script: root, every boot, idempotent. No `set -e` -- one failed step
-# must not abandon the boot; `journalctl -t devbox-startup` shows the exit status.
+# GCE startup-script: root, every boot, idempotent. No `set -e`: a failed step must
+# not abandon the boot; `journalctl -t devbox-startup` has the exit status.
 set -uo pipefail
 trap 'logger -t devbox-startup "exited: status $?"' EXIT
-# A fatal exit powers the box off rather than leaving it RUNNING with no runners,
-# which the start workflow would never touch. Off, it is restarted and retried on the
-# workflow's next tick; a transient DNS or mirror failure heals itself, a persistent
-# one shows as a box that keeps stopping. Five minutes keeps SSH usable first.
+# A fatal exit powers the box off. Left RUNNING with no runners, the start workflow
+# would never touch it; off, it is restarted and this script retried on the
+# workflow's next tick. Five minutes keeps SSH usable for the journal or /home first.
 fatal() {
-  logger -t devbox-startup "FATAL: $1"
-  systemctl stop docker.socket docker containerd 2>/dev/null
+  logger -t devbox-startup "FATAL: $1"; systemctl stop docker.socket docker containerd 2>/dev/null
   shutdown -h +5 "devbox-startup: $1"; exit 1
 }
-# daemon.json persists, so a previous boot's dockerd is already up with
-# data-root=/scratch/docker -- on the boot disk until (a) mounts over it. Mounting
-# over a live data root is what this prevents, so a stop that did not take is fatal.
-# The socket counts: left active it reactivates dockerd on the next connection.
-stop_docker() {
-  systemctl stop docker.socket docker containerd 2>/dev/null   # absent on a first boot
-  if pgrep -x dockerd >/dev/null || pgrep -x containerd >/dev/null \
-     || systemctl is-active --quiet docker.socket; then fatal "docker would not stop"; fi
-}
-stop_docker   # before anything that can block or exit
-systemctl mask --now docker.socket docker containerd 2>/dev/null   # --now: also stops one a postinst already queued
-# Latest runner release, falling back to a known-good pin if the lookup fails. Every
-# boot uses this: the runner lives on scratch and is re-fetched, never updated in place.
-RUNNER_VERSION=$(curl -sf --retry 3 --max-time 30 https://api.github.com/repos/actions/runner/releases/latest | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null || echo 2.336.0)
 
-# ---------- packages: the Ubuntu image ships neither ----------
+# Docker down and masked until (a) has mounted /scratch. daemon.json persists, so the
+# previous boot's dockerd is already up with its data root on the boot disk, and
+# mounting over it would leave it writing there unseen. Masked, apt cannot restart it.
+systemctl mask --now docker.socket docker containerd 2>/dev/null
+
+# ---------- packages ----------
 export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
-PKGS="docker.io cron systemd-oomd build-essential"
-# Unconditional: a preemption during any dpkg work -- an unattended upgrade of some
-# unrelated package -- blocks every later apt call, including installdependencies.sh.
-# One dpkg pass clears an interrupted transaction; its result is ignored on purpose.
-# Deps missing from an unpack cut short are apt's to install, not dpkg's, and a lock
-# held by unattended-upgrades means nothing to clear -- apt waits for that lock.
-dpkg --configure -a 2>/dev/null || true
-apt-get -y -qq --fix-broken install \
-  || fatal "apt cannot repair the package state"
-# Count 'install ok installed', not dpkg -s: a preemption mid-apt leaves packages
-# unpacked but unconfigured, which dpkg -s still reports as success.
-[[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \
-  || { apt-get update -qq && apt-get install -y -qq $PKGS; } \
+PKGS="docker.io cron systemd-oomd build-essential"   # build-essential: Go defaults to CGO_ENABLED=1
+dpkg --configure -a 2>/dev/null || true   # clears a transaction a preemption cut short; apt repairs the rest
+apt-get -y -qq -f install $PKGS 2>/dev/null || { apt-get update -qq && apt-get -y -qq -f install $PKGS; } \
   || fatal "prerequisite install failed"
 systemctl unmask docker.socket docker containerd 2>/dev/null
-stop_docker   # belt and braces once unmasked
 
 # ---------- (a) disk layout ----------
 mkdir -p /scratch
@@ -377,112 +355,96 @@ if [[ -n "$DEV" ]] && ! mountpoint -q /scratch; then
   [[ -n "$(blkid -s TYPE -o value "$DEV")" ]] || mkfs.ext4 -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard "$DEV"
   mount -o noatime,discard "$DEV" /scratch
 fi
-# Everything below assumes /scratch is the Local SSD. Falling back to the boot disk
-# would put swap, Docker, work trees and caches on the 100 GB disk that holds /home.
+# Everything below assumes it. Falling back to the boot disk would put swap, Docker,
+# work trees and caches on the 100 GB disk that holds /home.
 mountpoint -q /scratch || fatal "no Local SSD at /scratch"
 chmod 1777 /scratch                                   # OS Login accounts create their own subtree
 mkdir -p /scratch/tmp && chmod 1777 /scratch/tmp
-# Bind unless /tmp already *is* /scratch/tmp: `mountpoint` would also be true for a
-# tmpfs /tmp, which would silently leave temp files in RAM.
-[ "$(stat -c '%d:%i' /tmp)" = "$(stat -c '%d:%i' /scratch/tmp)" ] \
-  || mount --bind /scratch/tmp /tmp \
+# Compare inodes, not `mountpoint`: a tmpfs /tmp is a mountpoint too, and would leave temp files in RAM.
+[ "$(stat -c '%d:%i' /tmp)" = "$(stat -c '%d:%i' /scratch/tmp)" ] || mount --bind /scratch/tmp /tmp \
   || fatal "/tmp not on Local SSD"
-# blkid, not -f: a partly written file satisfies -f and swapon then rejects it.
-if [[ "$(blkid -s TYPE -o value /scratch/swapfile 2>/dev/null)" != swap ]]; then
-  rm -f /scratch/swapfile
-  fallocate -l 8G /scratch/swapfile && chmod 600 /scratch/swapfile && mkswap /scratch/swapfile >/dev/null
-fi
-swapon /scratch/swapfile 2>/dev/null                  # fails harmlessly if already active
-swapon --show=NAME --noheadings | grep -q . || logger -t devbox-startup "WARN: no swap active"
+swapon --show=NAME --noheadings | grep -q /scratch/swapfile \
+  || { rm -f /scratch/swapfile && fallocate -l 8G /scratch/swapfile && chmod 600 /scratch/swapfile \
+       && mkswap /scratch/swapfile >/dev/null && swapon /scratch/swapfile; } \
+  || logger -t devbox-startup "WARN: no swap active"
 sysctl -qw vm.swappiness=10
 systemctl enable --now systemd-oomd || logger -t devbox-startup "WARN: systemd-oomd inert"
-# On the slice, not the runner unit: Docker gives each container its own scope under
-# system.slice, so a unit-scoped policy would never see the containers under test.
+# On the slice: containers get their own scopes under system.slice, not under the runner unit.
 mkdir -p /etc/systemd/system/system.slice.d
 printf '[Slice]\nManagedOOMMemoryPressure=kill\n' > /etc/systemd/system/system.slice.d/oomd.conf
 
 # Docker on Local SSD with log rotation. The socket is opened to every account: OS
 # Login users appear on first connect and cannot be pre-added to the docker group.
-mkdir -p /scratch/docker /etc/systemd/system/docker.service.d
+mkdir -p /scratch/docker /scratch/containerd /var/lib/containerd /etc/systemd/system/docker.service.d
 echo '{"data-root":"/scratch/docker","log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"3"}}' > /etc/docker/daemon.json
 printf '[Service]\nExecStartPost=/bin/chmod 666 /var/run/docker.sock\n' > /etc/systemd/system/docker.service.d/socket.conf
-# Engine 29 defaults to the containerd image store, and data-root does not cover it:
-# images and snapshots live under containerd's own root. Bind it rather than edit
-# containerd's TOML, so there is no config format or default to track.
-mkdir -p /scratch/containerd /var/lib/containerd
+# Engine 29 keeps images in containerd's own store, which data-root does not cover. A
+# bind needs no containerd config to track.
 mountpoint -q /var/lib/containerd || mount --bind /scratch/containerd /var/lib/containerd \
   || fatal "containerd store not on Local SSD"
-systemctl daemon-reload && systemctl restart containerd docker
+systemctl daemon-reload && systemctl restart containerd docker || fatal "docker would not start"
+docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
+  || fatal "docker not on Local SSD"   # daemon.json unwritten or rejected: dockerd starts fine on the boot disk
 
 # ---------- (b) accounts and cache paths ----------
 for u in runner1 runner2 runner3; do
-  # Home on scratch, not /home: whatever a job writes home-relative that the cache
-  # variables do not cover is disposable too, and the GC only looks at /scratch.
+  # Home on scratch: whatever a job writes home-relative is disposable too.
   id "$u" &>/dev/null || useradd -M -d "/scratch/$u/home" -s /usr/sbin/nologin "$u"
-  usermod -aG docker "$u"
-  # runner/ too: systemd applies WorkingDirectory before ExecStartPre runs, so the
-  # unit would fail on CHDIR before install-runner could create it.
+  # runner/ up front: systemd applies WorkingDirectory before ExecStartPre could create it.
   mkdir -p "/scratch/$u"/{cache,work,runner,home}
   chown "$u:$u" "/scratch/$u" "/scratch/$u"/{cache,work,runner,home}   # not -R: contents are the user's own
 done
 
-# Interactive accounts appear on first OS Login connect, so the profile provisions them:
-# each tool's default cache path is symlinked onto scratch. Symlinks, not variables, so
-# an agent's `bash -c` -- which never sources a profile -- lands there too.
-# PATH for every SSH session. pam_env reads this file, so an agent's non-login
-# `bash -c` -- which reads no profile -- still finds the shared toolchain. Unlike the
-# cache symlinks below, a PATH set in a profile would not outlive the login shell.
+# Interactive accounts appear at first OS Login connect, so the profile provisions them:
+# each tool's default cache path becomes a symlink onto scratch. Symlinks, not variables,
+# so an agent's `bash -c` -- which sources no profile -- lands there too. PATH goes in
+# /etc/environment for the same reason: pam_env applies it to every session.
 echo 'PATH="/usr/local/go/bin:/usr/local/node/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' > /etc/environment
-
 cat > /etc/profile.d/devbox.sh <<'EOF'
 u=$(id -un); c=/scratch/$u/cache
 if mountpoint -q /scratch && [ -n "$u" ] && [ -n "${HOME:-}" ] && mkdir -p "$c" 2>/dev/null; then
   for pair in "$HOME/.cache:$c" "$HOME/go/pkg/mod:$c/go-mod" "$HOME/.npm:$c/npm" "$HOME/.local/share/pnpm:$c/pnpm"; do
     link=${pair%%:*}; target=${pair#*:}
-    mkdir -p "$target"   # every login: scratch targets vanish on preemption, the symlink in HOME does not
+    mkdir -p "$target"   # every login: scratch targets vanish on a stop, the symlink in HOME does not
     [ -L "$link" ] || { mkdir -p "$(dirname "$link")" && rm -rf "$link" && ln -s "$target" "$link"; }
   done 2>/dev/null
 fi
 unset u c pair link target
 EOF
-
-# Accounts that already exist keep their symlinks in /home across a stop, but the
-# scratch targets those point at are gone. Remake them, so only a brand-new account
-# still needs a first interactive login.
+# Existing accounts keep their symlinks across a stop but not the targets. Remake them,
+# so only a brand-new account needs a first interactive login.
 for h in /home/*; do
   u=${h##*/}; id "$u" &>/dev/null || continue
   for d in "" /go-mod /npm /pnpm; do install -d -o "$u" -g "$u" "/scratch/$u/cache$d"; done
 done
 
 # ---------- (c) GitHub runners ----------
-# The runner is stateless, so it lives on scratch and is installed from the unit
-# rather than from here. systemd retries that step forever, so a failed download
-# heals itself; doing it at boot gave a fresh VM no second chance.
-echo "$RUNNER_VERSION" > /etc/devbox-runner-version
-
+# Stateless, so it lives on scratch and is installed from the unit rather than from
+# here: systemd retries that step forever, so a failed download heals itself.
 cat > /usr/local/sbin/install-runner <<'EOF'
 #!/bin/bash
 # <account>. Root, from the unit. Re-runs whole on every retry, deps included.
 set -euo pipefail
 DIR=/scratch/$1/runner
-V=$(< /etc/devbox-runner-version)
-# Stamped with the version and written last: a reboot keeps scratch, so a bare marker
-# would pin the old release, and an unstamped one would skip a failed dep step.
+# Latest release; if the lookup fails, keep what is installed, or fall back to a pin.
+V=$(curl -sf --retry 3 --max-time 30 https://api.github.com/repos/actions/runner/releases/latest \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null) \
+  || V=$(cat "$DIR/.installed" 2>/dev/null || echo 2.336.0)
+# Version-stamped and written last: a reboot keeps scratch, so a bare marker would pin
+# the old release, and an unstamped one would skip a failed dep step.
 [[ "$(cat "$DIR/.installed" 2>/dev/null)" == "$V" ]] && exit 0
-rm -rf "$DIR"   # clean tree: extracting over an old release leaves its files behind
-install -d -o "$1" -g "$1" "$DIR"
+rm -rf "$DIR" && install -d -o "$1" -g "$1" "$DIR"   # clean tree: an old release's files must not linger
 curl -fsSL --retry 3 "https://github.com/actions/runner/releases/download/v$V/actions-runner-linux-x64-$V.tar.gz" | tar xz -C "$DIR"
 chown -R "$1:$1" "$DIR"
 "$DIR"/bin/installdependencies.sh >/dev/null   # apt is a no-op once satisfied
 echo "$V" > "$DIR/.installed"
 EOF
-chmod +x /usr/local/sbin/install-runner
 
 cat > /usr/local/sbin/register-runner <<'EOF'
 #!/bin/bash
-# <account> <install-dir> <work-dir>. Runs as the account, every boot.
+# <account>. Runs as the account, every boot.
 set -euo pipefail
-NAME=$1 DIR=$2 WORK=$3 ORG=bytebase
+ORG=bytebase
 md() { curl -sf -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/$1"; }
 PROJECT=$(md project/project-id)
 ACCESS=$(md instance/service-accounts/default/token | python3 -c 'import sys,json; print(json.load(sys.stdin)["access_token"])')
@@ -492,12 +454,12 @@ PAT=$(curl -sf -H "Authorization: Bearer $ACCESS" \
 TOKEN=$(curl -sfX POST -H "Authorization: Bearer $PAT" -H "Accept: application/vnd.github+json" \
   "https://api.github.com/orgs/${ORG}/actions/runners/registration-token" \
   | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
-cd "$DIR"
+cd "/scratch/$1/runner"
 rm -f .runner .credentials .credentials_rsakey   # config.sh refuses to overwrite an existing config
 ./config.sh --unattended --replace --url "https://github.com/${ORG}" --token "$TOKEN" \
-  --name "$(hostname -s)-$NAME" --work "$WORK"   # host-qualified name: never collides with another box
+  --name "$(hostname -s)-$1" --work "/scratch/$1/work"   # host-qualified name: never collides with another box
 EOF
-chmod +x /usr/local/sbin/register-runner
+chmod +x /usr/local/sbin/install-runner /usr/local/sbin/register-runner
 
 cat > /etc/systemd/system/actions-runner@.service <<'EOF'
 [Unit]
@@ -509,10 +471,10 @@ User=%i
 WorkingDirectory=/scratch/%i/runner
 Environment=XDG_CACHE_HOME=/scratch/%i/cache GOMODCACHE=/scratch/%i/cache/go-mod npm_config_cache=/scratch/%i/cache/npm PNPM_CONFIG_STORE_DIR=/scratch/%i/cache/pnpm
 ExecStartPre=+/usr/local/sbin/install-runner %i
-ExecStartPre=/usr/local/sbin/register-runner %i /scratch/%i/runner /scratch/%i/work
+ExecStartPre=/usr/local/sbin/register-runner %i
 ExecStart=/scratch/%i/runner/run.sh
-# install-runner fetches ~200 MB and waits on the apt lock, which the 90s default
-# would kill -- and the retry restarts the download from zero.
+# install-runner fetches ~200 MB and may wait on the apt lock; the 90s default would
+# kill it, and the retry restarts the download from zero.
 TimeoutStartSec=600
 Restart=always
 # Registration failure retries forever; at 5s x3 runners that would burn the API quota.
@@ -551,27 +513,17 @@ done
 logger -t cache-gc "cleaned -> $(used)%"
 EOF
 chmod +x /usr/local/sbin/cache-gc
-# PATH first: cron's default omits /usr/sbin, and a missing `ss` would make idle()
-# look true and let the destructive tiers run during a live job.
+# PATH first: cron's default omits /usr/sbin, and a missing `ss` would make idle() look true.
 printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 * * * * root /usr/local/sbin/cache-gc\n' > /etc/cron.d/devbox
 
-# One outcome check before any runner is advertised. An unset or unreadable
-# DockerRootDir catches a failed package install, a dockerd that would not start and a
-# daemon.json it rejected; requiring /scratch also catches one that was never written,
-# which starts dockerd cleanly on the boot disk. Otherwise: three healthy-looking
-# runners that fail every job, or quietly fill the disk holding /home.
-docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
-  || fatal "docker unusable or not on Local SSD"
-
 systemctl daemon-reload
-systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3
+systemctl restart actions-runner@{runner1,runner2,runner3}
 
-# Last, and time-bounded: guest memory and swap are invisible without the Ops Agent,
-# but it is observability. A stall here must not hold up CI capacity.
+# Last and time-bounded: observability must not hold up CI capacity.
 systemctl is-active --quiet google-cloud-ops-agent \
   || { curl -sS --retry 3 --max-time 120 -o /tmp/ops.sh https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh \
        && timeout 300 bash /tmp/ops.sh --also-install; } \
-  || logger -t devbox-startup "WARN: Ops Agent install failed; no memory or swap metrics"   # retried next boot
+  || logger -t devbox-startup "WARN: Ops Agent install failed; no memory or swap metrics"
 ```
 
 ## 3. Considered

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -400,7 +400,8 @@ printf '[Service]\nExecStartPost=/bin/chmod 666 /var/run/docker.sock\n' > /etc/s
 # images and snapshots live under containerd's own root. Bind it rather than edit
 # containerd's TOML, so there is no config format or default to track.
 mkdir -p /scratch/containerd /var/lib/containerd
-mountpoint -q /var/lib/containerd || mount --bind /scratch/containerd /var/lib/containerd
+mountpoint -q /var/lib/containerd || mount --bind /scratch/containerd /var/lib/containerd \
+  || { logger -t devbox-startup "FATAL: containerd store not on Local SSD"; exit 1; }
 systemctl daemon-reload && systemctl restart containerd docker
 
 # ---------- (b) accounts and cache paths ----------
@@ -556,8 +557,6 @@ printf 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\n*/30 
 # runners that fail every job, or quietly fill the disk holding /home.
 docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
   || { logger -t devbox-startup "FATAL: docker unusable or not on Local SSD"; exit 1; }
-mountpoint -q /var/lib/containerd \
-  || { logger -t devbox-startup "FATAL: containerd images not on Local SSD"; exit 1; }
 
 systemctl daemon-reload
 systemctl restart actions-runner@runner1 actions-runner@runner2 actions-runner@runner3

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -335,7 +335,8 @@ fatal() {
 
 # Docker down and masked until (a) has mounted /scratch. daemon.json persists, so the
 # previous boot's dockerd is already up with its data root on the boot disk, and
-# mounting over it would leave it writing there unseen. Masked, apt cannot restart it.
+# mounting over it would leave it writing there unseen. Masked, nothing can restart it
+# -- not apt's postinst, not a connection to a still-listening socket -- until (a) is done.
 systemctl mask --now docker.socket docker containerd 2>/dev/null
 ! pgrep -x 'dockerd|containerd' >/dev/null || fatal "docker would not stop"   # a process stuck in I/O survives SIGKILL
 
@@ -346,7 +347,6 @@ PKGS="docker.io cron systemd-oomd build-essential"   # build-essential: Go defau
 dpkg --configure -a 2>/dev/null || true   # clears a transaction a preemption cut short; apt repairs the rest
 apt-get -y -qq -f install $PKGS 2>/dev/null || { apt-get update -qq && apt-get -y -qq -f install $PKGS; } \
   || fatal "prerequisite install failed"
-systemctl unmask docker.socket docker containerd 2>/dev/null
 
 # ---------- (a) disk layout ----------
 mkdir -p /scratch
@@ -383,6 +383,9 @@ printf '[Service]\nExecStartPost=/bin/chmod 666 /var/run/docker.sock\n' > /etc/s
 # bind needs no containerd config to track.
 mountpoint -q /var/lib/containerd || mount --bind /scratch/containerd /var/lib/containerd \
   || fatal "containerd store not on Local SSD"
+# Masked until here: an active docker.socket cannot spawn a masked service, so nothing
+# can start dockerd on the boot disk between the stop above and this restart.
+systemctl unmask docker.socket docker containerd 2>/dev/null
 systemctl daemon-reload && systemctl restart containerd docker || fatal "docker would not start"
 docker info --format '{{.DockerRootDir}}' 2>/dev/null | grep -q '^/scratch/' \
   || fatal "docker not on Local SSD"   # daemon.json unwritten or rejected: dockerd starts fine on the boot disk

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -81,8 +81,8 @@ manual — at `github.com/settings/personal-access-tokens/new`:
 
 Org-owned tokens may need an org admin to approve the request.
 
-Developer access is granted below rather than by the script, because an OS Login
-account does not exist until its owner first connects.
+Developers already have access: the developer group holds Editor on the project,
+which covers OS Login with `sudo` and acting as the service account.
 
 **2. Everything else.**
 
@@ -117,17 +117,6 @@ done
 # A reserved address. An ephemeral one is released when the instance stops, so every
 # preemption would hand the box a new IP and strand the generated SSH entry.
 gcloud compute addresses create devbox --project=$PROJECT --region=${ZONE%-*}
-
-# Each developer who will SSH in. OS Login checks both: osAdminLogin gives the
-# account `sudo`, and because the VM has a service account attached, connecting also
-# requires permission to act as it -- without that, OS Login refuses the connection
-# before it ever creates the account.
-for DEV in you@bytebase.com; do
-  gcloud projects add-iam-policy-binding $PROJECT \
-    --member="user:$DEV" --role=roles/compute.osAdminLogin
-  gcloud iam service-accounts add-iam-policy-binding $SA --project=$PROJECT \
-    --member="user:$DEV" --role=roles/iam.serviceAccountUser
-done
 
 # The instance.
 gcloud compute instances create devbox --project=$PROJECT --zone=$ZONE \

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -188,7 +188,7 @@ Two kinds of account use the box, and they need opposite things from it.
 
 **Runner accounts** are `runner1`, `runner2` and `runner3`. The script creates them, `nologin`,
 one per job slot. Nothing of theirs is worth keeping: software, work trees and caches
-all sit on Local SSD, and the `/home` that `useradd` creates goes unused. They are
+all sit on Local SSD, and their home directories are on it too. They are
 disposable, and are disposed of on every stop.
 
 **Interactive accounts** arrive through OS Login on first connect. Their `/home/<u>`
@@ -357,7 +357,9 @@ mkdir -p /scratch/tmp && chmod 1777 /scratch/tmp
 [ "$(stat -c '%d:%i' /tmp)" = "$(stat -c '%d:%i' /scratch/tmp)" ] \
   || mount --bind /scratch/tmp /tmp \
   || { logger -t devbox-startup "FATAL: /tmp not on Local SSD"; exit 1; }
-if [[ ! -f /scratch/swapfile ]]; then
+# blkid, not -f: a partly written file satisfies -f and swapon then rejects it.
+if [[ "$(blkid -s TYPE -o value /scratch/swapfile 2>/dev/null)" != swap ]]; then
+  rm -f /scratch/swapfile
   fallocate -l 8G /scratch/swapfile && chmod 600 /scratch/swapfile && mkswap /scratch/swapfile >/dev/null
 fi
 swapon /scratch/swapfile 2>/dev/null || true          # no-op if already active
@@ -377,12 +379,14 @@ systemctl daemon-reload && systemctl restart docker
 
 # ---------- (b) accounts and cache paths ----------
 for u in runner1 runner2 runner3; do
-  id "$u" &>/dev/null || useradd -m -s /usr/sbin/nologin "$u"
+  # Home on scratch, not /home: whatever a job writes home-relative that the cache
+  # variables do not cover is disposable too, and the GC only looks at /scratch.
+  id "$u" &>/dev/null || useradd -M -d "/scratch/$u/home" -s /usr/sbin/nologin "$u"
   usermod -aG docker "$u"
   # runner/ too: systemd applies WorkingDirectory before ExecStartPre runs, so the
   # unit would fail on CHDIR before install-runner could create it.
-  mkdir -p "/scratch/$u"/{cache,work,runner}
-  chown "$u:$u" "/scratch/$u" "/scratch/$u"/{cache,work,runner}   # not -R: contents are the user's own
+  mkdir -p "/scratch/$u"/{cache,work,runner,home}
+  chown "$u:$u" "/scratch/$u" "/scratch/$u"/{cache,work,runner,home}   # not -R: contents are the user's own
 done
 
 # Interactive accounts appear on first OS Login connect, so the profile provisions them:

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -497,7 +497,7 @@ cat > /usr/local/sbin/cache-gc <<'EOF'
 # rebuilds on the next job; a full disk does not.
 set -uo pipefail
 HIGH=85 CRITICAL=95
-find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 -exec rm -rf {} +
+find /tmp -maxdepth 1 -name 'go-build*' -type d -mmin +1440 ! -exec mountpoint -q {} \; -exec rm -rf --one-file-system {} +
 used() { df -P /scratch | awk 'NR==2 {print $5+0}'; }
 # Load catches detached work -- tmux, nohup, a container -- that holds neither an SSH
 # session nor a Runner.Worker. On 20 vCPU, anything actually working exceeds 2.
@@ -517,9 +517,9 @@ shopt -s dotglob   # a /scratch/.something must not hide from the glob
 for e in /scratch/*; do
   u=${e##*/}
   case $u in tmp|docker|containerd|swapfile|lost+found) continue;; esac
-  id "$u" &>/dev/null || { rm -rf --one-file-system "$e"; continue; }   # not an account: dumped at the top level
-  case $u in runner[1-9]) keep='! -name runner';; *) keep=;; esac   # only a CI account's runner/ holds an install
-  find "$e" -mindepth 1 -maxdepth 1 -xdev $keep -exec rm -rf --one-file-system {} +   # never into a foreign mount
+  id "$u" &>/dev/null || { mountpoint -q "$e" || rm -rf --one-file-system "$e"; continue; }   # not an account: dumped at the top level
+  case $u in runner[1-9]) keep=(! -path "$e/runner" ! -path "$e/runner/*");; *) keep=();; esac   # only a CI account's runner/ holds an install
+  find "$e" -mindepth 1 -xdev "${keep[@]}" -delete 2>/dev/null   # -delete cannot cross into, or remove, a foreign mount
   for x in /cache /cache/go-mod /cache/npm /cache/pnpm /home /work; do
     install -d -o "$u" -g "$u" "$e$x"   # recreate: symlinks must not dangle
   done

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -324,10 +324,17 @@ preemption.
 # must not abandon the boot; `journalctl -t devbox-startup` shows the exit status.
 set -uo pipefail
 trap 'logger -t devbox-startup "exited: status $?"' EXIT
-# First, before anything that can block or exit. daemon.json persists, so a previous
-# boot's dockerd is already up with data-root=/scratch/docker -- on the boot disk
-# until (a) mounts over it. Absent on a first boot. Restarted in (a).
-systemctl stop docker.socket docker 2>/dev/null
+# daemon.json persists, so a previous boot's dockerd is already up with
+# data-root=/scratch/docker -- on the boot disk until (a) mounts over it. Mounting
+# over a live data root is what this prevents, so a stop that did not take is fatal.
+# The socket counts: left active it reactivates dockerd on the next connection.
+stop_docker() {
+  systemctl stop docker.socket docker 2>/dev/null   # absent on a first boot
+  if pgrep -x dockerd >/dev/null || systemctl is-active --quiet docker.socket; then
+    logger -t devbox-startup "FATAL: docker would not stop"; exit 1
+  fi
+}
+stop_docker   # before anything that can block or exit
 # Latest runner release, falling back to a known-good pin if the lookup fails. Every
 # boot uses this: the runner lives on scratch and is re-fetched, never updated in place.
 RUNNER_VERSION=$(curl -sf --retry 3 --max-time 30 https://api.github.com/repos/actions/runner/releases/latest | python3 -c 'import sys,json; print(json.load(sys.stdin)["tag_name"].lstrip("v"))' 2>/dev/null || echo 2.336.0)
@@ -341,10 +348,7 @@ PKGS="docker.io cron systemd-oomd build-essential"
 [[ $(dpkg-query -W -f='${Status}\n' $PKGS 2>/dev/null | grep -c '^install ok installed$') -eq $(wc -w <<<"$PKGS") ]] \
   || { dpkg --configure -a; apt-get update -qq && apt-get install -y -qq $PKGS; } \
   || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }
-systemctl stop docker.socket docker 2>/dev/null   # again: docker.io's postinst starts it
-# Confirm it actually stopped: mounting over a live data root is the failure the two
-# stops exist to prevent, and a stuck unit would walk straight into it.
-pgrep -x dockerd >/dev/null && { logger -t devbox-startup "FATAL: dockerd would not stop"; exit 1; }
+stop_docker   # again: docker.io's postinst starts it
 
 # ---------- (a) disk layout ----------
 mkdir -p /scratch

--- a/docs/design/devbox-and-ci-runner.md
+++ b/docs/design/devbox-and-ci-runner.md
@@ -330,7 +330,7 @@ RUNNER_VERSION=$(curl -sf --retry 3 https://api.github.com/repos/actions/runner/
 export DEBIAN_FRONTEND=noninteractive
 echo 'DPkg::Lock::Timeout "300";' > /etc/apt/apt.conf.d/99-lock-timeout   # unattended-upgrades holds the lock at boot
 dpkg -s docker.io cron systemd-oomd &>/dev/null || { apt-get update -qq && apt-get install -y -qq docker.io cron systemd-oomd; } \
-  || { logger -t devbox-startup "FATAL: prerequisite install failed"; exit 1; }   # never advertise a runner that cannot run Docker
+  || { logger -t devbox-startup "FATAL: prerequisite install failed"; systemctl stop docker.socket docker; exit 1; }
 
 # ---------- (a) disk layout ----------
 mkdir -p /scratch


### PR DESCRIPTION
Design doc only — no code or infrastructure changes. Nothing is provisioned by merging this.

## What

Consolidates the agent SSH dev box and the org's three self-hosted GitHub Actions runners onto a single GCP Spot VM, replacing separate machines.

| | |
|---|---|
| Machine | `n2-custom-20-32768` (20 vCPU, 32 GB), Spot, `instanceTerminationAction=STOP` |
| Zone | `northamerica-northeast2-a` |
| Disks | 100 GB pd-balanced boot (`--no-boot-disk-auto-delete`) + 375 GB Local SSD |
| Cost | ~$91/mo |

## Why these numbers

RAM was sized from measurement, not a guess. Ops Agent metrics on the existing runner VM showed CI is CPU-bound well before it is RAM-bound, so the custom shape trades RAM for vCPU rather than taking a standard 20-vCPU machine with far more RAM than the workload uses.

Region and family were priced across 43 regions through the Cloud Billing Catalog API, for the whole VM rather than vCPU alone. Both should be re-checked before any rebuild — the box is close to stateless, so moving it is just deleting and recreating it.

## Design shape

- **One idempotent startup script provisions everything.** Nothing is set up by hand, so a rebuild is reproducible and there is no drift to explain later.
- **The disk split is the load-bearing rule.** Local SSD holds only what can be discarded (caches, Docker data-root, `/tmp`, swap). The boot disk holds repos and uncommitted work — and can be lost too, so branches must be pushed.
- **Runners re-register at every boot** from a secret in Secret Manager, read via the metadata-server token. No registration state has to survive a preemption.
- **Cache GC evicts only under disk pressure**, cheapest-to-rebuild first, and defers its destructive tiers while a job is running. The single exception is a disk about to fill, which would fail every job anyway.

## For reviewers

The startup script is embedded in the doc and is the part worth reading closely — the design lives in it more than in the prose. Two things there are deliberate and easy to misread as mistakes:

- `RestartSec=30`, not 5. `register-runner` is an `ExecStartPre`, so a bad IAM binding or missing secret fails on every attempt and `Restart=always` loops forever. At 5s across three runners that is ~2160 GitHub API calls/hour against a 5000/hour limit — enough that the quota would block recovery even after the config was fixed. systemd's default `StartLimitBurst` does not stop it, because 5s spacing never fills the 10s window.
- `/tmp` is bound on a device+inode comparison rather than `mountpoint -q`. `mountpoint` is true for *any* mount, including a tmpfs `/tmp`, which would silently leave temp files in RAM on a 32 GB box.

`PNPM_CONFIG_STORE_DIR` is also intentional and not a typo for `PNPM_STORE_DIR` — the latter is not a pnpm variable at all (verified against pnpm 11.24.0: the string does not appear in pnpm's bundle, and `npm_config_store_dir` is ignored too). Using it would have silently put the CI pnpm store on the boot disk, outside the GC's reach.

## Cutover note

`.github/workflows/start-runner-vm.yml` already starts a runner VM on a schedule and hardcodes a name and zone in two places each. Repointing it is the **last** step of cutover, not part of this PR.

## Testing

Not deployed. Every embedded script was checked with `bash -n` (and the profile fragment additionally with `dash -n`, since it is sourced by `/bin/sh`), cache paths were cross-checked so that every directory written by a runner or an interactive account is also collected by the GC, and pricing was pulled from the live Billing Catalog API rather than published list prices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)