### PR TITLE
fix(approval): harden last plan editor lifecycle policy

### DIFF
--- a/backend/api/v1/plan_service_test.go
+++ b/backend/api/v1/plan_service_test.go
@@ -7,9 +7,11 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/bytebase/bytebase/backend/common"
 	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/component/bus"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 	"github.com/bytebase/bytebase/backend/migrator"
@@ -88,6 +90,84 @@ func TestPlanServiceListPlansHidesMalformedUIPlans(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	require.Equal(t, oldMalformed.Name, gotMalformed.Msg.Title)
+}
+
+func TestPlanServiceCreatePlanRecordsAuthenticatedPrincipalAsLastEditor(t *testing.T) {
+	stores := setupPlanServiceTestStore(context.Background(), t)
+	eventBus, err := bus.New()
+	require.NoError(t, err)
+	service := NewPlanService(stores, eventBus, nil, nil, nil)
+
+	for _, test := range []struct {
+		name          string
+		email         string
+		principalType storepb.PrincipalType
+	}{
+		{name: "service account", email: "automation@service.bytebase.com", principalType: storepb.PrincipalType_SERVICE_ACCOUNT},
+		{name: "workload identity", email: "deployment@workload.bytebase.com", principalType: storepb.PrincipalType_WORKLOAD_IDENTITY},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), common.WorkspaceIDContextKey, "default")
+			ctx = context.WithValue(ctx, common.UserContextKey, &store.UserMessage{
+				Email: test.email,
+				Name:  test.name,
+				Type:  test.principalType,
+			})
+
+			created, err := service.CreatePlan(ctx, connect.NewRequest(&v1pb.CreatePlanRequest{
+				Parent: "projects/project-a",
+				Plan: &v1pb.Plan{
+					Title: test.name,
+					Specs: []*v1pb.Plan_Spec{{
+						Id: "create-" + test.principalType.String(),
+						Config: &v1pb.Plan_Spec_CreateDatabaseConfig{
+							CreateDatabaseConfig: &v1pb.Plan_CreateDatabaseConfig{},
+						},
+					}},
+				},
+			}))
+			require.NoError(t, err)
+			require.Equal(t, common.FormatUserEmail(test.email), created.Msg.LastPlanEditor)
+		})
+	}
+}
+
+func TestPlanServiceReleaseBackedPlanKeepsCreatorAsLastEditor(t *testing.T) {
+	ctx := context.WithValue(context.Background(), common.WorkspaceIDContextKey, "default")
+	ctx = context.WithValue(ctx, common.UserContextKey, &store.UserMessage{Email: "creator@example.com", Name: "creator"})
+	stores := setupPlanServiceTestStore(ctx, t)
+	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      "release-backed",
+		Config: &storepb.PlanConfig{Specs: []*storepb.PlanConfig_Spec{{
+			Id: "release",
+			Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+				ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{Release: "projects/project-a/releases/release-a"},
+			},
+		}}},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	require.Equal(t, "creator@example.com", *plan.LastPlanEditor)
+
+	service := NewPlanService(stores, nil, nil, nil, nil)
+	_, err = service.UpdatePlan(ctx, connect.NewRequest(&v1pb.UpdatePlanRequest{
+		Plan: &v1pb.Plan{
+			Name: common.FormatPlan(plan.ProjectID, plan.UID),
+			Specs: []*v1pb.Plan_Spec{{
+				Id: "replacement",
+				Config: &v1pb.Plan_Spec_ChangeDatabaseConfig{
+					ChangeDatabaseConfig: &v1pb.Plan_ChangeDatabaseConfig{},
+				},
+			}},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"specs"}},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.ErrorContains(t, err, "created from a release")
+
+	got, err := stores.GetPlan(ctx, &store.FindPlanMessage{ProjectID: plan.ProjectID, UID: &plan.UID})
+	require.NoError(t, err)
+	require.Equal(t, "creator@example.com", *got.LastPlanEditor)
 }
 
 func TestPlanServiceListPlansIncludesIssueStatus(t *testing.T) {

--- a/backend/component/review/evaluator.go
+++ b/backend/component/review/evaluator.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"maps"
 	"math"
+	"strings"
 	"sync"
 
 	"github.com/google/cel-go/cel"
@@ -1288,6 +1289,22 @@ func NotifyApprovalRequested(ctx context.Context, stores *store.Store, webhookMa
 	if err != nil {
 		slog.Warn("failed to get approvers", log.BBError(err))
 		approvers = []webhook.User{} // Continue with empty list
+	}
+	if !project.Setting.GetAllowLastPlanEditorApproval() && issue.Type == storepb.Issue_DATABASE_CHANGE && issue.PlanUID != nil {
+		plan, err := stores.GetPlan(ctx, &store.FindPlanMessage{ProjectID: issue.ProjectID, UID: issue.PlanUID})
+		if err != nil {
+			slog.Warn("failed to get plan for approval notification", log.BBError(err))
+		} else if plan == nil {
+			slog.Warn("plan not found for approval notification", slog.Int64("plan_uid", *issue.PlanUID))
+		} else {
+			eligibleApprovers := approvers[:0]
+			for _, approver := range approvers {
+				if !strings.EqualFold(approver.Email, effectiveLastPlanEditor(plan)) {
+					eligibleApprovers = append(eligibleApprovers, approver)
+				}
+			}
+			approvers = eligibleApprovers
+		}
 	}
 
 	// Trigger ISSUE_APPROVAL_REQUESTED webhook

--- a/backend/component/review/plan.go
+++ b/backend/component/review/plan.go
@@ -94,6 +94,9 @@ func (w *Workflow) UpdatePlan(ctx context.Context, input UpdatePlanInput) (*Upda
 	if input.Specs != nil && plan.Config.GetHasRollout() {
 		return nil, workflowError(ErrorFailedPrecondition, "cannot update specs for plan that has a rollout")
 	}
+	if w.beforePlanMutation != nil {
+		w.beforePlanMutation()
+	}
 
 	oldSpecs := plan.Config.GetSpecs()
 	updatedConfig := proto.CloneOf(plan.Config)

--- a/backend/component/review/workflow.go
+++ b/backend/component/review/workflow.go
@@ -160,11 +160,12 @@ type IssueResult struct {
 
 // Workflow owns transactional Bytebase Issue and Plan review transitions.
 type Workflow struct {
-	store             *store.Store
-	beforeCommit      func()
-	beforePlanCommit  func()
-	beforeSubmit      func()
-	beforeCreateDraft func()
+	store              *store.Store
+	beforeCommit       func()
+	beforePlanCommit   func()
+	beforePlanMutation func()
+	beforeSubmit       func()
+	beforeCreateDraft  func()
 }
 
 // NewWorkflow creates a review workflow.
@@ -346,11 +347,7 @@ func (w *Workflow) applyReviewAction(ctx context.Context, project *store.Project
 			return nil, workflowError(ErrorPermissionDenied, "cannot %s because self-approval is not allowed for this project", verb)
 		}
 		if input.Action == ActionApprove && !project.Setting.GetAllowLastPlanEditorApproval() && plan != nil {
-			lastPlanEditor := plan.Creator
-			if plan.LastPlanEditor != nil {
-				lastPlanEditor = *plan.LastPlanEditor
-			}
-			if lastPlanEditor == input.Actor.Email {
+			if effectiveLastPlanEditor(plan) == input.Actor.Email {
 				return nil, workflowError(ErrorFailedPrecondition, "cannot approve because the user is the last Plan editor")
 			}
 		}
@@ -395,6 +392,13 @@ func (w *Workflow) applyReviewAction(ctx context.Context, project *store.Project
 	default:
 		return nil, workflowError(ErrorInvalidAction, "unsupported review action")
 	}
+}
+
+func effectiveLastPlanEditor(plan *store.PlanMessage) string {
+	if plan.LastPlanEditor != nil {
+		return *plan.LastPlanEditor
+	}
+	return plan.Creator
 }
 
 func (w *Workflow) canReview(ctx context.Context, project *store.ProjectMessage, user *store.UserMessage, role string) bool {

--- a/backend/component/review/workflow_test.go
+++ b/backend/component/review/workflow_test.go
@@ -201,6 +201,177 @@ func TestLastPlanEditorApproval(t *testing.T) {
 	}
 }
 
+func TestReviewIssueEvaluatesPolicyForEachApprovalStep(t *testing.T) {
+	ctx := context.Background()
+	stores := setupWorkflowStore(ctx, t)
+	for _, email := range []string{"reviewer@example.com", "reviewer2@example.com"} {
+		_, err := stores.PatchWorkspaceIamPolicy(ctx, &store.PatchIamPolicyMessage{
+			Workspace: "default",
+			Member:    common.FormatUserEmail(email),
+			Roles:     []string{"roles/projectOwner"},
+		})
+		require.NoError(t, err)
+	}
+	plan, issue := createPendingDatabaseChangeApproval(ctx, t, stores, []string{"roles/projectOwner", "roles/projectOwner"})
+	workflow := NewWorkflow(stores)
+	lastPlanEditor := "reviewer@example.com"
+	_, err := workflow.UpdatePlan(ctx, UpdatePlanInput{
+		Workspace:      "default",
+		ProjectID:      "project-a",
+		PlanUID:        plan.UID,
+		LastPlanEditor: &lastPlanEditor,
+	})
+	require.NoError(t, err)
+
+	_, err = workflow.ReviewIssue(ctx, IssueInput{
+		Workspace: "default",
+		ProjectID: "project-a",
+		IssueUID:  issue.UID,
+		Actor:     &store.UserMessage{Email: lastPlanEditor},
+		Action:    ActionApprove,
+	})
+	var workflowErr *Error
+	require.ErrorAs(t, err, &workflowErr)
+	require.Equal(t, ErrorFailedPrecondition, workflowErr.Code)
+
+	first, err := workflow.ReviewIssue(ctx, IssueInput{
+		Workspace: "default",
+		ProjectID: "project-a",
+		IssueUID:  issue.UID,
+		Actor:     &store.UserMessage{Email: "reviewer2@example.com"},
+		Action:    ActionApprove,
+	})
+	require.NoError(t, err)
+	require.False(t, first.Approved)
+
+	_, err = workflow.ReviewIssue(ctx, IssueInput{
+		Workspace: "default",
+		ProjectID: "project-a",
+		IssueUID:  issue.UID,
+		Actor:     &store.UserMessage{Email: lastPlanEditor},
+		Action:    ActionApprove,
+	})
+	require.ErrorAs(t, err, &workflowErr)
+	require.Equal(t, ErrorFailedPrecondition, workflowErr.Code)
+
+	second, err := workflow.ReviewIssue(ctx, IssueInput{
+		Workspace: "default",
+		ProjectID: "project-a",
+		IssueUID:  issue.UID,
+		Actor:     &store.UserMessage{Email: "reviewer2@example.com"},
+		Action:    ActionApprove,
+	})
+	require.NoError(t, err)
+	require.True(t, second.Approved)
+}
+
+func TestPlanSpecsUpdateResetsApprovalAndChangesLastPlanEditor(t *testing.T) {
+	ctx := context.Background()
+	stores := setupWorkflowStore(ctx, t)
+	for _, email := range []string{"reviewer@example.com", "reviewer2@example.com"} {
+		_, err := stores.PatchWorkspaceIamPolicy(ctx, &store.PatchIamPolicyMessage{
+			Workspace: "default",
+			Member:    common.FormatUserEmail(email),
+			Roles:     []string{"roles/projectOwner"},
+		})
+		require.NoError(t, err)
+	}
+	plan, issue := createPendingDatabaseChangeApproval(ctx, t, stores, []string{"roles/projectOwner", "roles/projectOwner"})
+	workflow := NewWorkflow(stores)
+
+	first, err := workflow.ReviewIssue(ctx, IssueInput{
+		Workspace: "default",
+		ProjectID: "project-a",
+		IssueUID:  issue.UID,
+		Actor:     &store.UserMessage{Email: "reviewer@example.com"},
+		Action:    ActionApprove,
+	})
+	require.NoError(t, err)
+	require.False(t, first.Approved)
+
+	newEditor := "reviewer2@example.com"
+	updated, err := workflow.UpdatePlanSpecs(ctx, UpdatePlanSpecsInput{
+		Workspace:      "default",
+		ProjectID:      "project-a",
+		PlanUID:        plan.UID,
+		Specs:          proto.CloneOf(plan.Config).GetSpecs(),
+		LastPlanEditor: &newEditor,
+	})
+	require.NoError(t, err)
+	require.True(t, updated.ApprovalReset)
+	require.Empty(t, updated.Events)
+	require.NotNil(t, updated.Plan.LastPlanEditor)
+	require.Equal(t, newEditor, *updated.Plan.LastPlanEditor)
+	require.Empty(t, updated.Issue.Payload.GetApproval().GetApprovers())
+	require.False(t, updated.Issue.Payload.GetApproval().GetApprovalFindingDone())
+
+	_, err = stores.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
+		PayloadUpsert: &storepb.Issue{Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: updated.Plan.Config.GetApprovalInputVersion(),
+			ApprovalTemplate:     &storepb.ApprovalTemplate{Flow: &storepb.ApprovalFlow{Roles: []string{"roles/projectOwner", "roles/projectOwner"}}},
+		}},
+	})
+	require.NoError(t, err)
+
+	priorEditor, err := workflow.ReviewIssue(ctx, IssueInput{
+		Workspace: "default",
+		ProjectID: "project-a",
+		IssueUID:  issue.UID,
+		Actor:     &store.UserMessage{Email: "reviewer@example.com"},
+		Action:    ActionApprove,
+	})
+	require.NoError(t, err)
+	require.False(t, priorEditor.Approved)
+
+	_, err = workflow.ReviewIssue(ctx, IssueInput{
+		Workspace: "default",
+		ProjectID: "project-a",
+		IssueUID:  issue.UID,
+		Actor:     &store.UserMessage{Email: newEditor},
+		Action:    ActionApprove,
+	})
+	var workflowErr *Error
+	require.ErrorAs(t, err, &workflowErr)
+	require.Equal(t, ErrorFailedPrecondition, workflowErr.Code)
+}
+
+func TestPlanlessGrantApprovalsDoNotRequireAPlan(t *testing.T) {
+	ctx := context.Background()
+	stores := setupWorkflowStore(ctx, t)
+	_, err := stores.PatchWorkspaceIamPolicy(ctx, &store.PatchIamPolicyMessage{
+		Workspace: "default",
+		Member:    common.FormatUserEmail("reviewer@example.com"),
+		Roles:     []string{"roles/projectOwner"},
+	})
+	require.NoError(t, err)
+
+	for _, issueType := range []storepb.Issue_Type{storepb.Issue_ROLE_GRANT, storepb.Issue_ACCESS_GRANT} {
+		issue, err := stores.CreateIssue(ctx, &store.IssueMessage{
+			ProjectID:    "project-a",
+			CreatorEmail: "creator@example.com",
+			Title:        issueType.String(),
+			Type:         issueType,
+			Payload: &storepb.Issue{Approval: &storepb.IssuePayloadApproval{
+				ApprovalFindingDone: true,
+				ApprovalTemplate:    &storepb.ApprovalTemplate{Flow: &storepb.ApprovalFlow{Roles: []string{"roles/projectOwner"}}},
+			}},
+		})
+		require.NoError(t, err)
+
+		result, err := NewWorkflow(stores).ReviewIssue(ctx, IssueInput{
+			Workspace: "default",
+			ProjectID: "project-a",
+			IssueUID:  issue.UID,
+			Actor:     &store.UserMessage{Email: "reviewer@example.com"},
+			Action:    ActionApprove,
+		})
+		require.NoError(t, err)
+		require.True(t, result.Approved)
+		require.Contains(t, result.Events, CompleteAccessRequestEvent{})
+	}
+}
+
 func TestReviewIssueConcurrentApprovalsHaveOneWinner(t *testing.T) {
 	ctx := context.Background()
 	stores := setupWorkflowStore(ctx, t)
@@ -313,6 +484,106 @@ func TestPlanUpdateMakesPendingApprovalActionStale(t *testing.T) {
 	require.Equal(t, ErrorConflict, workflowErr.Code)
 	require.False(t, planResult.Issue.Payload.GetApproval().GetApprovalFindingDone())
 	require.EqualValues(t, 3, planResult.Issue.Payload.GetApproval().GetApprovalInputVersion())
+}
+
+func TestApprovalStartedDuringPlanUpdateCannotUseStaleEditorState(t *testing.T) {
+	ctx := context.Background()
+	stores := setupWorkflowStore(ctx, t)
+	_, err := stores.PatchWorkspaceIamPolicy(ctx, &store.PatchIamPolicyMessage{
+		Workspace: "default",
+		Member:    common.FormatUserEmail("reviewer@example.com"),
+		Roles:     []string{"roles/projectOwner"},
+	})
+	require.NoError(t, err)
+	plan, issue := createPendingDatabaseChangeApproval(ctx, t, stores, []string{"roles/projectOwner"})
+	workflow := NewWorkflow(stores)
+	planLocked := make(chan struct{})
+	releasePlan := make(chan struct{})
+	approvalProposed := make(chan struct{})
+	workflow.beforePlanMutation = func() {
+		close(planLocked)
+		<-releasePlan
+	}
+	workflow.beforeCommit = func() {
+		close(approvalProposed)
+	}
+
+	newEditor := "reviewer@example.com"
+	type planOutcome struct {
+		result *UpdatePlanSpecsResult
+		err    error
+	}
+	planDone := make(chan planOutcome, 1)
+	go func() {
+		result, err := workflow.UpdatePlanSpecs(ctx, UpdatePlanSpecsInput{
+			Workspace:      "default",
+			ProjectID:      "project-a",
+			PlanUID:        plan.UID,
+			Specs:          []*storepb.PlanConfig_Spec{{Id: "new"}},
+			LastPlanEditor: &newEditor,
+		})
+		planDone <- planOutcome{result: result, err: err}
+	}()
+	select {
+	case <-planLocked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Plan update did not acquire its workflow locks")
+	}
+
+	approvalDone := make(chan error, 1)
+	go func() {
+		_, err := workflow.ReviewIssue(ctx, IssueInput{
+			Workspace: "default",
+			ProjectID: "project-a",
+			IssueUID:  issue.UID,
+			Actor:     &store.UserMessage{Email: newEditor},
+			Action:    ActionApprove,
+		})
+		approvalDone <- err
+	}()
+	select {
+	case <-approvalProposed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("approval did not reach the commit seam")
+	}
+	close(releasePlan)
+
+	var updated *UpdatePlanSpecsResult
+	select {
+	case outcome := <-planDone:
+		require.NoError(t, outcome.err)
+		updated = outcome.result
+		require.True(t, updated.ApprovalReset)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Plan update deadlocked with approval")
+	}
+	select {
+	case err := <-approvalDone:
+		var workflowErr *Error
+		require.ErrorAs(t, err, &workflowErr)
+		require.Equal(t, ErrorConflict, workflowErr.Code)
+	case <-time.After(5 * time.Second):
+		t.Fatal("approval deadlocked with Plan update")
+	}
+
+	_, err = stores.UpdateIssue(ctx, issue.ProjectID, issue.UID, &store.UpdateIssueMessage{
+		PayloadUpsert: &storepb.Issue{Approval: &storepb.IssuePayloadApproval{
+			ApprovalFindingDone:  true,
+			ApprovalInputVersion: updated.Plan.Config.GetApprovalInputVersion(),
+			ApprovalTemplate:     &storepb.ApprovalTemplate{Flow: &storepb.ApprovalFlow{Roles: []string{"roles/projectOwner"}}},
+		}},
+	})
+	require.NoError(t, err)
+	_, err = NewWorkflow(stores).ReviewIssue(ctx, IssueInput{
+		Workspace: "default",
+		ProjectID: "project-a",
+		IssueUID:  issue.UID,
+		Actor:     &store.UserMessage{Email: newEditor},
+		Action:    ActionApprove,
+	})
+	var workflowErr *Error
+	require.ErrorAs(t, err, &workflowErr)
+	require.Equal(t, ErrorFailedPrecondition, workflowErr.Code)
 }
 
 func TestUpdatePlanResetsLinkedIssueApprovalAtomically(t *testing.T) {

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -162,6 +162,15 @@ func TestMigration3_23_2BackfillsLastPlanEditorApproval(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, enabled)
 	}
+	_, err = db.ExecContext(ctx, "UPDATE project SET deleted = false WHERE resource_id = 'deleted'")
+	require.NoError(t, err)
+	var restoredEnabled bool
+	err = db.QueryRowContext(ctx, `
+		SELECT (setting->>'allowLastPlanEditorApproval')::boolean
+		FROM project
+		WHERE resource_id = 'deleted' AND NOT deleted`).Scan(&restoredEnabled)
+	require.NoError(t, err)
+	require.True(t, restoredEnabled)
 	var nullable string
 	require.NoError(t, db.QueryRowContext(ctx, `
 		SELECT is_nullable

--- a/backend/tests/plan_update_test.go
+++ b/backend/tests/plan_update_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	"github.com/bytebase/bytebase/backend/common"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
 )
 
@@ -224,6 +225,24 @@ func TestPlanLastEditorAttributionAndApproval(t *testing.T) {
 
 	issue := createIssueForPlan(f.ctx, t, f.ctl, f.ctl.project, updated, "last plan editor approval")
 	waitForIssuePending(f.ctx, t, f.ctl, issue)
+
+	withImpersonation(f.ctx, t, f.ctl, editor, func() {
+		_, err := f.ctl.issueServiceClient.ApproveIssue(f.ctx, connect.NewRequest(&v1pb.ApproveIssueRequest{Name: issue.Name}))
+		a.Error(err)
+		a.Equal(connect.CodeFailedPrecondition, connect.CodeOf(err))
+	})
+
+	renamedEmail := "renamed-" + editor.Email
+	renamed, err := f.ctl.userServiceClient.UpdateEmail(f.ctx, connect.NewRequest(&v1pb.UpdateEmailRequest{
+		Name:  common.FormatUserEmail(editor.Email),
+		Email: renamedEmail,
+	}))
+	a.NoError(err)
+	a.Equal(renamedEmail, renamed.Msg.Email)
+	editor.Email = renamedEmail
+	gotPlan, err := f.ctl.planServiceClient.GetPlan(f.ctx, connect.NewRequest(&v1pb.GetPlanRequest{Name: updated.Name}))
+	a.NoError(err)
+	a.Equal(common.FormatUserEmail(renamedEmail), gotPlan.Msg.LastPlanEditor)
 
 	withImpersonation(f.ctx, t, f.ctl, editor, func() {
 		_, err := f.ctl.issueServiceClient.ApproveIssue(f.ctx, connect.NewRequest(&v1pb.ApproveIssueRequest{Name: issue.Name}))

--- a/backend/tests/webhook_test.go
+++ b/backend/tests/webhook_test.go
@@ -16,6 +16,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
@@ -717,6 +718,109 @@ func TestWebhookIntegration(t *testing.T) {
 		waitForIssuePending(ctx, t, ctl, issue)
 
 		waitForWebhookCount(t, collector, project.Name, "Approval required", 1)
+	})
+
+	t.Run("IssueApprovalRequested_ExcludesLastPlanEditor", func(t *testing.T) {
+		project := ctl.createTestProject(ctx, t, "bot121-last-editor")
+		require.NoError(t, ctl.createDatabase(ctx, project, instance, nil, "bot121_last_editor_db", ""))
+		_, err := ctl.projectServiceClient.UpdateProject(ctx, connect.NewRequest(&v1pb.UpdateProjectRequest{
+			Project: &v1pb.Project{
+				Name:                        project.Name,
+				AllowLastPlanEditorApproval: false,
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"allow_last_plan_editor_approval"}},
+		}))
+		require.NoError(t, err)
+
+		clearWorkspaceApprovalRules(ctx, t, ctl)
+		installWorkspaceApprovalRule(ctx, t, ctl, project, []string{"roles/projectOwner"})
+		editor := provisionApprover(ctx, t, ctl, project, "webhook-last-editor", "roles/projectOwner")
+		other := provisionApprover(ctx, t, ctl, project, "webhook-other", "roles/projectOwner")
+		for _, user := range []struct {
+			email string
+			phone string
+		}{
+			{editor.Email, "+8613800000001"},
+			{other.Email, "+8613800000002"},
+		} {
+			_, err := ctl.userServiceClient.UpdateUser(ctx, connect.NewRequest(&v1pb.UpdateUserRequest{
+				User:       &v1pb.User{Name: "users/" + user.email, Phone: user.phone},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"phone"}},
+			}))
+			require.NoError(t, err)
+		}
+
+		plan := createPlanWithSpecs(ctx, t, ctl, project, []taskSpec{
+			{seedPassingSheet(ctx, t, ctl, project), dbTargetName(instance, "bot121_last_editor_db")},
+		})
+		withImpersonation(ctx, t, ctl, editor, func() {
+			resp, err := ctl.planServiceClient.UpdatePlan(ctx, connect.NewRequest(&v1pb.UpdatePlanRequest{
+				Plan:       &v1pb.Plan{Name: plan.Name, Specs: plan.Specs},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"specs"}},
+			}))
+			require.NoError(t, err)
+			plan = resp.Msg
+		})
+
+		dingtalkCollector := &webhookCollector{}
+		dingtalkServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := dingtalkCollector.addRequest(r); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"errcode":0}`))
+		}))
+		defer dingtalkServer.Close()
+		webhookplugin.TestOnlyAllowedDomains[storepb.WebhookType_DINGTALK] = []string{"127.0.0.1", "localhost", "[::1]"}
+		t.Cleanup(func() {
+			delete(webhookplugin.TestOnlyAllowedDomains, storepb.WebhookType_DINGTALK)
+		})
+		_, err = ctl.projectServiceClient.AddWebhook(ctx, connect.NewRequest(&v1pb.AddWebhookRequest{
+			Project: project.Name,
+			Webhook: &v1pb.Webhook{
+				Type:              v1pb.WebhookType_DINGTALK,
+				Title:             "last-editor-recipient-test",
+				Url:               dingtalkServer.URL,
+				NotificationTypes: []v1pb.Activity_Type{v1pb.Activity_ISSUE_APPROVAL_REQUESTED},
+			},
+		}))
+		require.NoError(t, err)
+
+		issue := createIssueForPlan(ctx, t, ctl, project, plan, "last editor webhook recipients")
+		waitForIssuePending(ctx, t, ctl, issue)
+		require.Eventually(t, func() bool {
+			return len(dingtalkCollector.getRequests()) == 1
+		}, webhookWaitTimeout, 100*time.Millisecond)
+
+		var payload struct {
+			Markdown struct {
+				Text string `json:"text"`
+			} `json:"markdown"`
+		}
+		require.NoError(t, json.Unmarshal(dingtalkCollector.getRequests()[0].Body, &payload))
+		require.NotContains(t, payload.Markdown.Text, "@13800000001")
+		require.Contains(t, payload.Markdown.Text, "@13800000002")
+
+		dingtalkCollector.reset()
+		_, err = ctl.issueServiceClient.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+			Parent: project.Name,
+			Issue: &v1pb.Issue{
+				Title: "planless webhook recipients",
+				Type:  v1pb.Issue_ROLE_GRANT,
+				RoleGrant: &v1pb.RoleGrant{
+					Role: "roles/projectDeveloper",
+					User: "users/" + editor.Email,
+				},
+			},
+		}))
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			return len(dingtalkCollector.getRequests()) == 1
+		}, webhookWaitTimeout, 100*time.Millisecond)
+		require.NoError(t, json.Unmarshal(dingtalkCollector.getRequests()[0].Body, &payload))
+		require.Contains(t, payload.Markdown.Text, "@13800000001")
+		require.Contains(t, payload.Markdown.Text, "@13800000002")
 	})
 
 	t.Run("IssueApprovalRequested_NotFiredWhenUnused", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- exclude the effective last plan editor from approval-request notifications while preserving recipients on lookup failures
- enforce the policy across multi-step approvals, plan mutations, identity renames, and both plan-update/approval lock orders
- add lifecycle coverage for service and workload identities, planless grants, release-backed plans, migrations, and project-key collisions

## Breaking Changes

When Last Plan Editor approval is disabled, approval-request notifications no longer include the effective last plan editor. This aligns notification recipients with the existing approval authorization policy; webhook schemas and event names are unchanged.

## Testing

- focused API, workflow, webhook, migration, attribution, and concurrency tests
- collision and claim regression suite
- server build
- full suite attempted once; backend/api/v1 and backend/tests reached the default 10-minute package timeout under broad parallel execution, while their focused affected tests pass
- golangci-lint reports 46 unrelated pre-existing revive findings; no findings are in modified code

Linear: https://linear.app/bytebase/issue/BOT-121