### PR TITLE
fix(store): prevent stale project cache publication

### DIFF
--- a/backend/store/project.go
+++ b/backend/store/project.go
@@ -101,14 +101,19 @@ func (s *Store) GetProject(ctx context.Context, find *FindProjectMessage) (*Proj
 	if len(projects) > 1 {
 		return nil, &common.Error{Code: common.Conflict, Err: errors.Errorf("found %d projects with filter %+v, expect 1", len(projects), find)}
 	}
-	project := projects[0]
-
-	s.storeProjectCache(project)
-	return project, nil
+	return projects[0], nil
 }
 
 // ListProjects lists all projects.
 func (s *Store) ListProjects(ctx context.Context, find *FindProjectMessage) ([]*ProjectMessage, error) {
+	if s.enableCache {
+		// Keep the database read and cache publication ordered with project
+		// invalidation. Otherwise this query can read the pre-update row and
+		// repopulate it after UpdateProjects has already removed the old entry.
+		s.projectPublishMu.Lock()
+		defer s.projectPublishMu.Unlock()
+	}
+
 	q := qb.Q().Space("SELECT resource_id, workspace, name, setting, deleted FROM project WHERE workspace = ?", find.Workspace)
 	if filterQ := find.FilterQ; filterQ != nil {
 		q.And("?", filterQ)
@@ -193,7 +198,7 @@ func (s *Store) ListProjects(ctx context.Context, find *FindProjectMessage) ([]*
 	}
 
 	for _, project := range projectMessages {
-		s.storeProjectCache(project)
+		s.projectCache.Add(project.ResourceID, project)
 	}
 	return projectMessages, nil
 }
@@ -323,12 +328,9 @@ func (s *Store) UpdateProjects(ctx context.Context, patches ...*UpdateProjectMes
 	}
 
 	// The second eviction: see the comment above. Project settings gate
-	// authorization — AllowLastPlanEditorApproval decides who may approve — so a
-	// stale entry reads as a revoked permission still being granted. One
-	// narrower window survives both evictions: a reader whose row read began
-	// before the commit and whose cache fill lands after this line. Closing it
-	// needs the cache to track a generation per key, which is more machinery
-	// than the exposure warrants.
+	// authorization, so stale entries could preserve revoked permissions. The
+	// publication mutex ensures a pre-update read cannot refill the cache after
+	// this eviction.
 	for _, patch := range patches {
 		s.removeProjectCache(patch.ResourceID)
 	}
@@ -337,10 +339,14 @@ func (s *Store) UpdateProjects(ctx context.Context, patches ...*UpdateProjectMes
 }
 
 func (s *Store) storeProjectCache(project *ProjectMessage) {
+	s.projectPublishMu.Lock()
+	defer s.projectPublishMu.Unlock()
 	s.projectCache.Add(project.ResourceID, project)
 }
 
 func (s *Store) removeProjectCache(resourceID string) {
+	s.projectPublishMu.Lock()
+	defer s.projectPublishMu.Unlock()
 	s.projectCache.Remove(resourceID)
 }
 
@@ -456,7 +462,7 @@ func (s *Store) removeProjectDescendantCaches(keys *projectDescendantCacheKeys, 
 		s.dbSchemaCache.Remove(getDBSchemaCacheKey(key.instanceID, key.databaseName))
 	}
 	for _, projectID := range projectIDs {
-		s.projectCache.Remove(projectID)
+		s.removeProjectCache(projectID)
 	}
 }
 

--- a/backend/store/runner_queries.go
+++ b/backend/store/runner_queries.go
@@ -23,6 +23,15 @@ func (s *Store) GetProjectByResourceID(ctx context.Context, resourceID string) (
 	if v, ok := s.projectCache.Get(resourceID); ok && s.enableCache {
 		return v, nil
 	}
+	if s.enableCache {
+		// Keep the database read and cache publication ordered with project
+		// invalidation for the same reason as ListProjects.
+		s.projectPublishMu.Lock()
+		defer s.projectPublishMu.Unlock()
+		if v, ok := s.projectCache.Get(resourceID); ok {
+			return v, nil
+		}
+	}
 
 	q := qb.Q().Space("SELECT resource_id, workspace, name, setting, deleted FROM project WHERE resource_id = ?", resourceID)
 	query, args, err := q.ToSQL()
@@ -49,7 +58,7 @@ func (s *Store) GetProjectByResourceID(ctx context.Context, resourceID string) (
 		return nil, err
 	}
 	project.Setting = setting
-	s.storeProjectCache(&project)
+	s.projectCache.Add(project.ResourceID, &project)
 	return &project, nil
 }
 

--- a/backend/store/store.go
+++ b/backend/store/store.go
@@ -30,6 +30,9 @@ type Store struct {
 	policyCache    *lru.Cache[string, *PolicyMessage]
 	settingCache   *lru.Cache[string, *SettingMessage]
 
+	// projectPublishMu prevents a cache fill that read an old database snapshot
+	// from publishing after a concurrent project update invalidates the cache.
+	projectPublishMu sync.Mutex
 	// settingPublishMu serializes all setting cache publications (writer
 	// republishes, cache-miss fills, invalidations). Publishers re-read the
 	// row under the mutex, so whichever publishes last publishes current

--- a/backend/tests/plan_update_test.go
+++ b/backend/tests/plan_update_test.go
@@ -154,7 +154,7 @@ func TestPlanLastEditorAttributionAndApproval(t *testing.T) {
 	a.NoError(err)
 	a.False(newProject.Msg.AllowLastPlanEditorApproval)
 	a.Equal("users/demo@example.com", f.plan.LastPlanEditor)
-	_, err = f.ctl.projectServiceClient.UpdateProject(f.ctx, connect.NewRequest(&v1pb.UpdateProjectRequest{
+	projectResp, err := f.ctl.projectServiceClient.UpdateProject(f.ctx, connect.NewRequest(&v1pb.UpdateProjectRequest{
 		Project: &v1pb.Project{
 			Name:                        f.ctl.project.Name,
 			AllowSelfApproval:           false,
@@ -163,6 +163,7 @@ func TestPlanLastEditorAttributionAndApproval(t *testing.T) {
 		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"allow_self_approval", "allow_last_plan_editor_approval"}},
 	}))
 	a.NoError(err)
+	a.False(projectResp.Msg.AllowLastPlanEditorApproval)
 
 	installWorkspaceApprovalRule(f.ctx, t, f.ctl, f.ctl.project, []string{"roles/projectOwner"})
 	editor := provisionApprover(f.ctx, t, f.ctl, f.ctl.project, "last-plan-editor", "roles/projectOwner")
@@ -232,7 +233,7 @@ func TestPlanLastEditorAttributionAndApproval(t *testing.T) {
 		a.NoError(err)
 	})
 
-	projectResp, err := f.ctl.projectServiceClient.UpdateProject(f.ctx, connect.NewRequest(&v1pb.UpdateProjectRequest{
+	projectResp, err = f.ctl.projectServiceClient.UpdateProject(f.ctx, connect.NewRequest(&v1pb.UpdateProjectRequest{
 		Project: &v1pb.Project{
 			Name:                        f.ctl.project.Name,
 			AllowLastPlanEditorApproval: true,


### PR DESCRIPTION
## Summary

- serialize project cache fills with project cache invalidation
- invalidate project entries after updates so an in-flight reader cannot retain a pre-update snapshot
- assert the last-plan-editor approval setting is observable immediately after updating it

This fixes `TestPlanLastEditorAttributionAndApproval`, which could intermittently allow the last plan editor to approve because a background runner republished the previous project setting after `UpdateProjects` invalidated the cache.

## Testing

- `golangci-lint run --allow-parallel-runners`
- `go test -run '^$' ./backend/store ./backend/component/review ./backend/api/v1`
- `go test -c -o /tmp/bytebase-backend-tests.test ./backend/tests`
- `go build -ldflags \"-w -s\" -p=16 -o ./bytebase-build/bytebase ./backend/bin/server/main.go`

The targeted integration test requires Docker; this orb has no Docker daemon, so it was compiled but not executed locally. The failure was confirmed from GitHub Actions logs before the fix.