### PR TITLE
fix(advisor/pg): make TABLE_REQUIRE_PK ignore unrelated ALTER TABLE

### DIFF
--- a/backend/plugin/advisor/pg/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk.go
@@ -3,6 +3,7 @@ package pg
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/bytebase/omni/pg/ast"
 
@@ -23,10 +24,12 @@ func init() {
 
 // TableRequirePKAdvisor is the advisor checking table requires PK.
 //
-// The rule only guards the net change of a batch: a table created in the batch
-// must end with a PRIMARY KEY, and a table that had a PRIMARY KEY before the
-// batch must still have one afterwards. ALTER TABLE on a pre-existing table
-// without a PRIMARY KEY is out of scope so unrelated changes are not blocked.
+// The rule guards the net change of a batch by comparing the metadata before
+// and after the walkthrough: a table created in the batch must end with a
+// PRIMARY KEY, and a table that had one must still have one. Pre-existing
+// tables without a PRIMARY KEY are out of scope, so unrelated changes to them
+// are not blocked. Name resolution (search_path, SET ROLE, drops) is left to
+// the walkthrough; statements are only tracked to attribute the advice.
 type TableRequirePKAdvisor struct {
 }
 
@@ -44,15 +47,7 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 		},
 		originalMetadata: checkCtx.OriginalMetadata,
 		finalMetadata:    checkCtx.FinalMetadata,
-		searchPath:       []string{"public"},
 		tableMentions:    make(map[string]*tableMention),
-	}
-	if checkCtx.OriginalMetadata != nil {
-		// Resolve $user against SessionUser so unqualified names land in the
-		// same schema the walkthrough uses when building FinalMetadata.
-		if sp := checkCtx.OriginalMetadata.GetSearchPathForCurrentUser(checkCtx.SessionUser); len(sp) > 0 {
-			rule.searchPath = sp
-		}
 	}
 
 	// Manually iterate statements instead of using RunOmniRules because
@@ -77,17 +72,19 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 type tableMention struct {
 	startLine int
 	text      string
+	// created is set when the batch contains a CREATE TABLE for this name.
+	created bool
 }
 
 type tableRequirePKRule struct {
 	OmniBaseRule
 	originalMetadata *model.DatabaseMetadata
 	finalMetadata    *model.DatabaseMetadata
-	// searchPath resolves unqualified table names; never empty.
-	searchPath []string
 
-	// Track last mention of each table
-	tableMentions map[string]*tableMention // key: "schema.table", value: last mention info
+	// tableMentions records the last CREATE/ALTER TABLE per name for advice
+	// attribution. The key is "schema.table" with the schema as written, so an
+	// unqualified name is keyed ".table".
+	tableMentions map[string]*tableMention
 }
 
 // Name returns the rule name.
@@ -99,103 +96,40 @@ func (*tableRequirePKRule) Name() string {
 func (r *tableRequirePKRule) OnStatement(node ast.Node) {
 	switch n := node.(type) {
 	case *ast.CreateStmt:
-		r.handleCreateStmt(n)
+		r.recordMention(n.Relation, true)
 	case *ast.AlterTableStmt:
-		r.handleAlterTableStmt(n)
-	case *ast.DropStmt:
-		r.handleDropStmt(n)
+		r.recordMention(n.Relation, false)
 	default:
 	}
 }
 
-// handleCreateStmt records CREATE TABLE statements.
-func (r *tableRequirePKRule) handleCreateStmt(n *ast.CreateStmt) {
-	tableName := omniTableName(n.Relation)
+func (r *tableRequirePKRule) recordMention(rv *ast.RangeVar, created bool) {
+	tableName := omniTableName(rv)
 	if tableName == "" {
 		return
 	}
-	schema := r.resolveSchema(n.Relation.Schemaname, tableName)
-
-	key := fmt.Sprintf("%s.%s", schema, tableName)
-	r.tableMentions[key] = &tableMention{
-		startLine: int(r.ContentStartLine()) + r.BaseLine,
-		text:      r.TrimmedStmtText(),
-	}
-}
-
-// handleAlterTableStmt records ALTER TABLE statements on tables that had a
-// PRIMARY KEY before this batch. Tables created in this batch are already
-// tracked by handleCreateStmt.
-func (r *tableRequirePKRule) handleAlterTableStmt(n *ast.AlterTableStmt) {
-	tableName := omniTableName(n.Relation)
-	if tableName == "" {
-		return
-	}
-	schema := r.resolveSchema(n.Relation.Schemaname, tableName)
-
-	key := fmt.Sprintf("%s.%s", schema, tableName)
-	if _, tracked := r.tableMentions[key]; !tracked {
-		if table := r.originalTable(schema, tableName); table == nil || table.GetPrimaryKey() == nil {
-			return
-		}
+	key := mentionKey(rv.Schemaname, tableName)
+	if prev := r.tableMentions[key]; prev != nil && prev.created {
+		created = true
 	}
 	r.tableMentions[key] = &tableMention{
 		startLine: int(r.ContentStartLine()) + r.BaseLine,
 		text:      r.TrimmedStmtText(),
+		created:   created,
 	}
 }
 
-// handleDropStmt handles DROP TABLE - remove from tracking.
-func (r *tableRequirePKRule) handleDropStmt(n *ast.DropStmt) {
-	if n.RemoveType != int(ast.OBJECT_TABLE) {
-		return
-	}
-
-	if n.Objects == nil {
-		return
-	}
-	for _, item := range n.Objects.Items {
-		list, ok := item.(*ast.List)
-		if !ok {
-			continue
-		}
-		var parts []string
-		for _, nameItem := range list.Items {
-			if s, ok := nameItem.(*ast.String); ok {
-				parts = append(parts, s.Str)
-			}
-		}
-		var schema, tableName string
-		switch len(parts) {
-		case 1:
-			tableName = parts[0]
-		case 2:
-			schema, tableName = parts[0], parts[1]
-		default:
-			continue
-		}
-		delete(r.tableMentions, fmt.Sprintf("%s.%s", r.resolveSchema(schema, tableName), tableName))
-	}
+func mentionKey(schema, table string) string {
+	return schema + "." + table
 }
 
-// resolveSchema mirrors PostgreSQL name resolution. A qualified name is taken
-// as-is. An unqualified name maps to the first search_path schema that already
-// holds the table, either created earlier in this batch or present in the
-// original metadata; otherwise to the first search_path schema, which is
-// where CREATE TABLE places a new table.
-func (r *tableRequirePKRule) resolveSchema(schema, tableName string) string {
-	if schema != "" {
-		return schema
+// mentionFor returns the mention for a table in the final metadata, trying
+// the qualified name first and then the unqualified one.
+func (r *tableRequirePKRule) mentionFor(schema, table string) *tableMention {
+	if m := r.tableMentions[mentionKey(schema, table)]; m != nil {
+		return m
 	}
-	for _, candidate := range r.searchPath {
-		if _, ok := r.tableMentions[fmt.Sprintf("%s.%s", candidate, tableName)]; ok {
-			return candidate
-		}
-		if r.originalTable(candidate, tableName) != nil {
-			return candidate
-		}
-	}
-	return r.searchPath[0]
+	return r.tableMentions[mentionKey("", table)]
 }
 
 // originalTable returns the table from the metadata before this batch, or nil.
@@ -206,47 +140,57 @@ func (r *tableRequirePKRule) originalTable(schemaName, tableName string) *model.
 	return r.originalMetadata.GetSchemaMetadata(schemaName).GetTable(tableName)
 }
 
-// validateFinalState checks all mentioned tables against FinalMetadata for PRIMARY KEY.
+// validateFinalState flags tables that end the batch without a PRIMARY KEY and
+// either were created by the batch or had a PRIMARY KEY before it.
 func (r *tableRequirePKRule) validateFinalState() {
-	for tableKey, mention := range r.tableMentions {
-		schemaName, tableName := parseTableKey(tableKey)
-
+	if r.finalMetadata == nil {
+		return
+	}
+	schemaNames := r.finalMetadata.ListSchemaNames()
+	slices.Sort(schemaNames)
+	for _, schemaName := range schemaNames {
 		schema := r.finalMetadata.GetSchemaMetadata(schemaName)
-		var hasPK bool
-		if schema != nil {
-			table := schema.GetTable(tableName)
-			if table != nil {
-				hasPK = table.GetPrimaryKey() != nil
+		tableNames := schema.ListTableNames()
+		slices.Sort(tableNames)
+		for _, tableName := range tableNames {
+			if schema.GetTable(tableName).GetPrimaryKey() != nil {
+				continue
 			}
-		}
-
-		if !hasPK {
-			content := fmt.Sprintf("Table %q.%q requires PRIMARY KEY", schemaName, tableName)
-
-			if mention.text != "" {
-				content = fmt.Sprintf("%s, related statement: %q", content, mention.text)
+			mention := r.mentionFor(schemaName, tableName)
+			original := r.originalTable(schemaName, tableName)
+			switch {
+			case original == nil:
+				// New in this batch: only tables the batch created are in scope.
+				if mention == nil || !mention.created {
+					continue
+				}
+			case original.GetPrimaryKey() == nil:
+				// Pre-existing table without a PRIMARY KEY is out of scope.
+				continue
+			default:
 			}
-
-			r.AddAdviceAbsolute(&storepb.Advice{
-				Status:  r.Level,
-				Code:    code.TableNoPK.Int32(),
-				Title:   r.Title,
-				Content: content,
-				StartPosition: &storepb.Position{
-					Line:   int32(mention.startLine),
-					Column: 0,
-				},
-			})
+			r.addAdvice(schemaName, tableName, mention)
 		}
 	}
 }
 
-// parseTableKey splits "schema.table" into schema and table name.
-func parseTableKey(key string) (string, string) {
-	for i := 0; i < len(key); i++ {
-		if key[i] == '.' {
-			return key[:i], key[i+1:]
+func (r *tableRequirePKRule) addAdvice(schemaName, tableName string, mention *tableMention) {
+	content := fmt.Sprintf("Table %q.%q requires PRIMARY KEY", schemaName, tableName)
+	line := 0
+	if mention != nil {
+		line = mention.startLine
+		if mention.text != "" {
+			content = fmt.Sprintf("%s, related statement: %q", content, mention.text)
 		}
 	}
-	return "public", key
+	r.AddAdviceAbsolute(&storepb.Advice{
+		Status:  r.Level,
+		Code:    code.TableNoPK.Int32(),
+		Title:   r.Title,
+		Content: content,
+		StartPosition: &storepb.Position{
+			Line:   int32(line),
+			Column: 0,
+		},
+	})
 }

--- a/backend/plugin/advisor/pg/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk.go
@@ -77,6 +77,8 @@ type tableMention struct {
 	created bool
 	// dropped is set when the batch contains a DROP TABLE for this name.
 	dropped bool
+	// renamedFrom is the name the table had before the batch renamed it.
+	renamedFrom string
 }
 
 type tableRequirePKRule struct {
@@ -84,9 +86,10 @@ type tableRequirePKRule struct {
 	originalMetadata *model.DatabaseMetadata
 	finalMetadata    *model.DatabaseMetadata
 
-	// tableMentions tracks, per table name, what the batch did to the table
-	// and the last CREATE/ALTER statement for advice attribution. Keys ignore
-	// schema qualification; the final metadata supplies the schema.
+	// tableMentions tracks what the batch did to each table and the last
+	// CREATE/ALTER statement for advice attribution. Keys are "schema.table"
+	// with the schema as written, so an unqualified name is keyed ".table";
+	// validation merges the qualified and unqualified entries of a table.
 	tableMentions map[string]*tableMention
 }
 
@@ -99,59 +102,124 @@ func (*tableRequirePKRule) Name() string {
 func (r *tableRequirePKRule) OnStatement(node ast.Node) {
 	switch n := node.(type) {
 	case *ast.CreateStmt:
-		if m := r.recordMention(omniTableName(n.Relation)); m != nil {
+		if m := r.recordMention(n.Relation); m != nil {
 			m.created = true
 		}
 	case *ast.AlterTableStmt:
-		r.recordMention(omniTableName(n.Relation))
+		r.recordMention(n.Relation)
 	case *ast.DropStmt:
-		if n.RemoveType != int(ast.OBJECT_TABLE) {
+		if n.RemoveType != int(ast.OBJECT_TABLE) || n.Objects == nil {
 			return
 		}
-		for _, obj := range omniDropObjects(n) {
-			r.mention(obj[1]).dropped = true
+		for _, item := range n.Objects.Items {
+			if schema, tableName, ok := dropObjectName(item); ok {
+				r.mention(schema, tableName).dropped = true
+			}
 		}
 	case *ast.RenameStmt:
 		if n.RenameType != ast.OBJECT_TABLE || n.Relation == nil {
 			return
 		}
-		r.renameMention(n.Relation.Relname, n.Newname)
+		r.renameMention(n.Relation, n.Newname)
 	default:
 	}
 }
 
-func (r *tableRequirePKRule) mention(tableName string) *tableMention {
-	m := r.tableMentions[tableName]
+// dropObjectName splits a DROP TABLE object into schema (empty when
+// unqualified) and table name.
+func dropObjectName(item ast.Node) (string, string, bool) {
+	list, ok := item.(*ast.List)
+	if !ok {
+		return "", "", false
+	}
+	var parts []string
+	for _, nameItem := range list.Items {
+		if s, ok := nameItem.(*ast.String); ok {
+			parts = append(parts, s.Str)
+		}
+	}
+	switch len(parts) {
+	case 1:
+		return "", parts[0], true
+	case 2:
+		return parts[0], parts[1], true
+	default:
+		return "", "", false
+	}
+}
+
+func mentionKey(schema, tableName string) string {
+	return schema + "." + tableName
+}
+
+func (r *tableRequirePKRule) mention(schema, tableName string) *tableMention {
+	key := mentionKey(schema, tableName)
+	m := r.tableMentions[key]
 	if m == nil {
 		m = &tableMention{}
-		r.tableMentions[tableName] = m
+		r.tableMentions[key] = m
 	}
 	return m
 }
 
 // recordMention points the table's advice attribution at the current statement.
-func (r *tableRequirePKRule) recordMention(tableName string) *tableMention {
+func (r *tableRequirePKRule) recordMention(rv *ast.RangeVar) *tableMention {
+	tableName := omniTableName(rv)
 	if tableName == "" {
 		return nil
 	}
-	m := r.mention(tableName)
+	m := r.mention(rv.Schemaname, tableName)
 	m.startLine = int(r.ContentStartLine()) + r.BaseLine
 	m.text = r.TrimmedStmtText()
 	return m
 }
 
-// renameMention carries the batch state of oldName over to newName.
-func (r *tableRequirePKRule) renameMention(oldName, newName string) {
+// renameMention carries the batch state of rv over to newName and remembers
+// the pre-batch name so the original metadata can still be found.
+func (r *tableRequirePKRule) renameMention(rv *ast.RangeVar, newName string) {
+	oldName := omniTableName(rv)
 	if oldName == "" || newName == "" {
 		return
 	}
-	old := r.tableMentions[oldName]
-	delete(r.tableMentions, oldName)
-	m := r.recordMention(newName)
+	oldKey := mentionKey(rv.Schemaname, oldName)
+	old := r.tableMentions[oldKey]
+	delete(r.tableMentions, oldKey)
+
+	m := r.mention(rv.Schemaname, newName)
+	m.startLine = int(r.ContentStartLine()) + r.BaseLine
+	m.text = r.TrimmedStmtText()
+	m.renamedFrom = oldName
 	if old != nil {
 		m.created = m.created || old.created
 		m.dropped = m.dropped || old.dropped
+		if old.renamedFrom != "" {
+			m.renamedFrom = old.renamedFrom
+		}
 	}
+}
+
+// mentionFor merges the qualified and unqualified entries of a table, taking
+// the attribution from the later statement.
+func (r *tableRequirePKRule) mentionFor(schema, tableName string) *tableMention {
+	q := r.tableMentions[mentionKey(schema, tableName)]
+	u := r.tableMentions[mentionKey("", tableName)]
+	switch {
+	case q == nil:
+		return u
+	case u == nil:
+		return q
+	default:
+	}
+	m := *q
+	if u.startLine > q.startLine {
+		m.startLine, m.text = u.startLine, u.text
+	}
+	m.created = q.created || u.created
+	m.dropped = q.dropped || u.dropped
+	if m.renamedFrom == "" {
+		m.renamedFrom = u.renamedFrom
+	}
+	return &m
 }
 
 // originalTable returns the table from the metadata before this batch, or nil.
@@ -178,8 +246,11 @@ func (r *tableRequirePKRule) validateFinalState() {
 			if schema.GetTable(tableName).GetPrimaryKey() != nil {
 				continue
 			}
-			mention := r.tableMentions[tableName]
+			mention := r.mentionFor(schemaName, tableName)
 			original := r.originalTable(schemaName, tableName)
+			if original == nil && mention != nil && mention.renamedFrom != "" {
+				original = r.originalTable(schemaName, mention.renamedFrom)
+			}
 			switch {
 			case original == nil:
 				// New in this batch: only tables the batch created are in scope.

--- a/backend/plugin/advisor/pg/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk.go
@@ -22,6 +22,11 @@ func init() {
 }
 
 // TableRequirePKAdvisor is the advisor checking table requires PK.
+//
+// The rule only guards the net change of a batch: a table created in the batch
+// must end with a PRIMARY KEY, and a table that had a PRIMARY KEY before the
+// batch must still have one afterwards. ALTER TABLE on a pre-existing table
+// without a PRIMARY KEY is out of scope so unrelated changes are not blocked.
 type TableRequirePKAdvisor struct {
 }
 
@@ -37,8 +42,9 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 			Level: level,
 			Title: checkCtx.Rule.Type.String(),
 		},
-		finalMetadata: checkCtx.FinalMetadata,
-		tableMentions: make(map[string]*tableMention),
+		originalMetadata: checkCtx.OriginalMetadata,
+		finalMetadata:    checkCtx.FinalMetadata,
+		tableMentions:    make(map[string]*tableMention),
 	}
 
 	// Manually iterate statements instead of using RunOmniRules because
@@ -67,7 +73,8 @@ type tableMention struct {
 
 type tableRequirePKRule struct {
 	OmniBaseRule
-	finalMetadata *model.DatabaseMetadata
+	originalMetadata *model.DatabaseMetadata
+	finalMetadata    *model.DatabaseMetadata
 
 	// Track last mention of each table
 	tableMentions map[string]*tableMention // key: "schema.table", value: last mention info
@@ -106,7 +113,9 @@ func (r *tableRequirePKRule) handleCreateStmt(n *ast.CreateStmt) {
 	}
 }
 
-// handleAlterTableStmt records ALTER TABLE statements.
+// handleAlterTableStmt records ALTER TABLE statements on tables that had a
+// PRIMARY KEY before this batch. Tables created in this batch are already
+// tracked by handleCreateStmt.
 func (r *tableRequirePKRule) handleAlterTableStmt(n *ast.AlterTableStmt) {
 	tableName := omniTableName(n.Relation)
 	if tableName == "" {
@@ -115,6 +124,9 @@ func (r *tableRequirePKRule) handleAlterTableStmt(n *ast.AlterTableStmt) {
 	schema := omniSchemaName(n.Relation)
 
 	key := fmt.Sprintf("%s.%s", schema, tableName)
+	if _, tracked := r.tableMentions[key]; !tracked && !r.originalTableHasPK(schema, tableName) {
+		return
+	}
 	r.tableMentions[key] = &tableMention{
 		startLine: int(r.ContentStartLine()) + r.BaseLine,
 		text:      r.TrimmedStmtText(),
@@ -131,6 +143,15 @@ func (r *tableRequirePKRule) handleDropStmt(n *ast.DropStmt) {
 		key := fmt.Sprintf("%s.%s", obj[0], obj[1])
 		delete(r.tableMentions, key)
 	}
+}
+
+// originalTableHasPK reports whether the table had a PRIMARY KEY before this batch.
+func (r *tableRequirePKRule) originalTableHasPK(schemaName, tableName string) bool {
+	if r.originalMetadata == nil {
+		return false
+	}
+	table := r.originalMetadata.GetSchemaMetadata(schemaName).GetTable(tableName)
+	return table != nil && table.GetPrimaryKey() != nil
 }
 
 // validateFinalState checks all mentioned tables against FinalMetadata for PRIMARY KEY.

--- a/backend/plugin/advisor/pg/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk.go
@@ -29,7 +29,8 @@ func init() {
 // PRIMARY KEY, and a table that had one must still have one. Pre-existing
 // tables without a PRIMARY KEY are out of scope, so unrelated changes to them
 // are not blocked. Name resolution (search_path, SET ROLE, drops) is left to
-// the walkthrough; statements are only tracked to attribute the advice.
+// the walkthrough; statements are only tracked to tell created tables from
+// pre-existing ones and to attribute the advice.
 type TableRequirePKAdvisor struct {
 }
 
@@ -74,6 +75,8 @@ type tableMention struct {
 	text      string
 	// created is set when the batch contains a CREATE TABLE for this name.
 	created bool
+	// dropped is set when the batch contains a DROP TABLE for this name.
+	dropped bool
 }
 
 type tableRequirePKRule struct {
@@ -81,9 +84,9 @@ type tableRequirePKRule struct {
 	originalMetadata *model.DatabaseMetadata
 	finalMetadata    *model.DatabaseMetadata
 
-	// tableMentions records the last CREATE/ALTER TABLE per name for advice
-	// attribution. The key is "schema.table" with the schema as written, so an
-	// unqualified name is keyed ".table".
+	// tableMentions tracks, per table name, what the batch did to the table
+	// and the last CREATE/ALTER statement for advice attribution. Keys ignore
+	// schema qualification; the final metadata supplies the schema.
 	tableMentions map[string]*tableMention
 }
 
@@ -96,40 +99,59 @@ func (*tableRequirePKRule) Name() string {
 func (r *tableRequirePKRule) OnStatement(node ast.Node) {
 	switch n := node.(type) {
 	case *ast.CreateStmt:
-		r.recordMention(n.Relation, true)
+		if m := r.recordMention(omniTableName(n.Relation)); m != nil {
+			m.created = true
+		}
 	case *ast.AlterTableStmt:
-		r.recordMention(n.Relation, false)
+		r.recordMention(omniTableName(n.Relation))
+	case *ast.DropStmt:
+		if n.RemoveType != int(ast.OBJECT_TABLE) {
+			return
+		}
+		for _, obj := range omniDropObjects(n) {
+			r.mention(obj[1]).dropped = true
+		}
+	case *ast.RenameStmt:
+		if n.RenameType != ast.OBJECT_TABLE || n.Relation == nil {
+			return
+		}
+		r.renameMention(n.Relation.Relname, n.Newname)
 	default:
 	}
 }
 
-func (r *tableRequirePKRule) recordMention(rv *ast.RangeVar, created bool) {
-	tableName := omniTableName(rv)
+func (r *tableRequirePKRule) mention(tableName string) *tableMention {
+	m := r.tableMentions[tableName]
+	if m == nil {
+		m = &tableMention{}
+		r.tableMentions[tableName] = m
+	}
+	return m
+}
+
+// recordMention points the table's advice attribution at the current statement.
+func (r *tableRequirePKRule) recordMention(tableName string) *tableMention {
 	if tableName == "" {
+		return nil
+	}
+	m := r.mention(tableName)
+	m.startLine = int(r.ContentStartLine()) + r.BaseLine
+	m.text = r.TrimmedStmtText()
+	return m
+}
+
+// renameMention carries the batch state of oldName over to newName.
+func (r *tableRequirePKRule) renameMention(oldName, newName string) {
+	if oldName == "" || newName == "" {
 		return
 	}
-	key := mentionKey(rv.Schemaname, tableName)
-	if prev := r.tableMentions[key]; prev != nil && prev.created {
-		created = true
+	old := r.tableMentions[oldName]
+	delete(r.tableMentions, oldName)
+	m := r.recordMention(newName)
+	if old != nil {
+		m.created = m.created || old.created
+		m.dropped = m.dropped || old.dropped
 	}
-	r.tableMentions[key] = &tableMention{
-		startLine: int(r.ContentStartLine()) + r.BaseLine,
-		text:      r.TrimmedStmtText(),
-		created:   created,
-	}
-}
-
-func mentionKey(schema, table string) string {
-	return schema + "." + table
-}
-
-// mentionFor returns the mention for a table in the final metadata, trying
-// the qualified name first and then the unqualified one.
-func (r *tableRequirePKRule) mentionFor(schema, table string) *tableMention {
-	if m := r.tableMentions[mentionKey(schema, table)]; m != nil {
-		return m
-	}
-	return r.tableMentions[mentionKey("", table)]
 }
 
 // originalTable returns the table from the metadata before this batch, or nil.
@@ -156,7 +178,7 @@ func (r *tableRequirePKRule) validateFinalState() {
 			if schema.GetTable(tableName).GetPrimaryKey() != nil {
 				continue
 			}
-			mention := r.mentionFor(schemaName, tableName)
+			mention := r.tableMentions[tableName]
 			original := r.originalTable(schemaName, tableName)
 			switch {
 			case original == nil:
@@ -165,8 +187,11 @@ func (r *tableRequirePKRule) validateFinalState() {
 					continue
 				}
 			case original.GetPrimaryKey() == nil:
-				// Pre-existing table without a PRIMARY KEY is out of scope.
-				continue
+				// A pre-existing table without a PRIMARY KEY is out of scope
+				// unless the batch dropped and recreated it.
+				if mention == nil || !mention.created || !mention.dropped {
+					continue
+				}
 			default:
 			}
 			r.addAdvice(schemaName, tableName, mention)

--- a/backend/plugin/advisor/pg/advisor_table_require_pk.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk.go
@@ -44,7 +44,15 @@ func (*TableRequirePKAdvisor) Check(_ context.Context, checkCtx advisor.Context)
 		},
 		originalMetadata: checkCtx.OriginalMetadata,
 		finalMetadata:    checkCtx.FinalMetadata,
+		searchPath:       []string{"public"},
 		tableMentions:    make(map[string]*tableMention),
+	}
+	if checkCtx.OriginalMetadata != nil {
+		// Resolve $user against SessionUser so unqualified names land in the
+		// same schema the walkthrough uses when building FinalMetadata.
+		if sp := checkCtx.OriginalMetadata.GetSearchPathForCurrentUser(checkCtx.SessionUser); len(sp) > 0 {
+			rule.searchPath = sp
+		}
 	}
 
 	// Manually iterate statements instead of using RunOmniRules because
@@ -75,6 +83,8 @@ type tableRequirePKRule struct {
 	OmniBaseRule
 	originalMetadata *model.DatabaseMetadata
 	finalMetadata    *model.DatabaseMetadata
+	// searchPath resolves unqualified table names; never empty.
+	searchPath []string
 
 	// Track last mention of each table
 	tableMentions map[string]*tableMention // key: "schema.table", value: last mention info
@@ -104,7 +114,7 @@ func (r *tableRequirePKRule) handleCreateStmt(n *ast.CreateStmt) {
 	if tableName == "" {
 		return
 	}
-	schema := omniSchemaName(n.Relation)
+	schema := r.resolveSchema(n.Relation.Schemaname, tableName)
 
 	key := fmt.Sprintf("%s.%s", schema, tableName)
 	r.tableMentions[key] = &tableMention{
@@ -121,11 +131,13 @@ func (r *tableRequirePKRule) handleAlterTableStmt(n *ast.AlterTableStmt) {
 	if tableName == "" {
 		return
 	}
-	schema := omniSchemaName(n.Relation)
+	schema := r.resolveSchema(n.Relation.Schemaname, tableName)
 
 	key := fmt.Sprintf("%s.%s", schema, tableName)
-	if _, tracked := r.tableMentions[key]; !tracked && !r.originalTableHasPK(schema, tableName) {
-		return
+	if _, tracked := r.tableMentions[key]; !tracked {
+		if table := r.originalTable(schema, tableName); table == nil || table.GetPrimaryKey() == nil {
+			return
+		}
 	}
 	r.tableMentions[key] = &tableMention{
 		startLine: int(r.ContentStartLine()) + r.BaseLine,
@@ -139,19 +151,59 @@ func (r *tableRequirePKRule) handleDropStmt(n *ast.DropStmt) {
 		return
 	}
 
-	for _, obj := range omniDropObjects(n) {
-		key := fmt.Sprintf("%s.%s", obj[0], obj[1])
-		delete(r.tableMentions, key)
+	if n.Objects == nil {
+		return
+	}
+	for _, item := range n.Objects.Items {
+		list, ok := item.(*ast.List)
+		if !ok {
+			continue
+		}
+		var parts []string
+		for _, nameItem := range list.Items {
+			if s, ok := nameItem.(*ast.String); ok {
+				parts = append(parts, s.Str)
+			}
+		}
+		var schema, tableName string
+		switch len(parts) {
+		case 1:
+			tableName = parts[0]
+		case 2:
+			schema, tableName = parts[0], parts[1]
+		default:
+			continue
+		}
+		delete(r.tableMentions, fmt.Sprintf("%s.%s", r.resolveSchema(schema, tableName), tableName))
 	}
 }
 
-// originalTableHasPK reports whether the table had a PRIMARY KEY before this batch.
-func (r *tableRequirePKRule) originalTableHasPK(schemaName, tableName string) bool {
-	if r.originalMetadata == nil {
-		return false
+// resolveSchema mirrors PostgreSQL name resolution. A qualified name is taken
+// as-is. An unqualified name maps to the first search_path schema that already
+// holds the table, either created earlier in this batch or present in the
+// original metadata; otherwise to the first search_path schema, which is
+// where CREATE TABLE places a new table.
+func (r *tableRequirePKRule) resolveSchema(schema, tableName string) string {
+	if schema != "" {
+		return schema
 	}
-	table := r.originalMetadata.GetSchemaMetadata(schemaName).GetTable(tableName)
-	return table != nil && table.GetPrimaryKey() != nil
+	for _, candidate := range r.searchPath {
+		if _, ok := r.tableMentions[fmt.Sprintf("%s.%s", candidate, tableName)]; ok {
+			return candidate
+		}
+		if r.originalTable(candidate, tableName) != nil {
+			return candidate
+		}
+	}
+	return r.searchPath[0]
+}
+
+// originalTable returns the table from the metadata before this batch, or nil.
+func (r *tableRequirePKRule) originalTable(schemaName, tableName string) *model.TableMetadata {
+	if r.originalMetadata == nil {
+		return nil
+	}
+	return r.originalMetadata.GetSchemaMetadata(schemaName).GetTable(tableName)
 }
 
 // validateFinalState checks all mentioned tables against FinalMetadata for PRIMARY KEY.

--- a/backend/plugin/advisor/pg/advisor_table_require_pk_test.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk_test.go
@@ -18,7 +18,7 @@ import (
 // resolution: the configured search_path, in-batch SET search_path, and drops
 // that change which same-named table an unqualified name refers to.
 // with_pk and without_pk live only in app_schema; shadow exists in both
-// schemas, with a PK only in public.
+// schemas, with a PK only in public; legacy exists in both without a PK.
 func TestTableRequirePKSearchPath(t *testing.T) {
 	dbSchema := &storepb.DatabaseSchemaMetadata{
 		Name:       "test",
@@ -34,6 +34,10 @@ func TestTableRequirePKSearchPath(t *testing.T) {
 							{Name: "shadow_pkey", Expressions: []string{"id"}, Unique: true, Primary: true},
 						},
 					},
+					{
+						Name:    "legacy",
+						Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer"}},
+					},
 				},
 			},
 			{
@@ -41,6 +45,10 @@ func TestTableRequirePKSearchPath(t *testing.T) {
 				Tables: []*storepb.TableMetadata{
 					{
 						Name:    "shadow",
+						Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer"}},
+					},
+					{
+						Name:    "legacy",
 						Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer"}},
 					},
 					{
@@ -111,6 +119,11 @@ func TestTableRequirePKSearchPath(t *testing.T) {
 		{
 			name: "unrelated ALTER on same-named table without PK in first schema",
 			stmt: "ALTER TABLE shadow ADD COLUMN note TEXT;",
+		},
+		{
+			name:        "qualified drop and recreate does not touch same-named legacy table elsewhere",
+			stmt:        "DROP TABLE app_schema.legacy; CREATE TABLE app_schema.legacy(id INT);",
+			wantContent: `Table "app_schema"."legacy" requires PRIMARY KEY`,
 		},
 	}
 

--- a/backend/plugin/advisor/pg/advisor_table_require_pk_test.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk_test.go
@@ -14,18 +14,35 @@ import (
 	"github.com/bytebase/bytebase/backend/store/model"
 )
 
-// TestTableRequirePKSearchPath proves unqualified names resolve through the
-// database search_path, matching the walkthrough that builds FinalMetadata.
-// Both tables live only in app_schema; public is empty.
+// TestTableRequirePKSearchPath proves the rule follows the walkthrough's name
+// resolution: the configured search_path, in-batch SET search_path, and drops
+// that change which same-named table an unqualified name refers to.
+// with_pk and without_pk live only in app_schema; shadow exists in both
+// schemas, with a PK only in public.
 func TestTableRequirePKSearchPath(t *testing.T) {
 	dbSchema := &storepb.DatabaseSchemaMetadata{
 		Name:       "test",
 		SearchPath: "app_schema, public",
 		Schemas: []*storepb.SchemaMetadata{
-			{Name: "public"},
+			{
+				Name: "public",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name:    "shadow",
+						Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer"}},
+						Indexes: []*storepb.IndexMetadata{
+							{Name: "shadow_pkey", Expressions: []string{"id"}, Unique: true, Primary: true},
+						},
+					},
+				},
+			},
 			{
 				Name: "app_schema",
 				Tables: []*storepb.TableMetadata{
+					{
+						Name:    "shadow",
+						Columns: []*storepb.ColumnMetadata{{Name: "id", Type: "integer"}},
+					},
 					{
 						Name: "with_pk",
 						Columns: []*storepb.ColumnMetadata{
@@ -49,6 +66,7 @@ func TestTableRequirePKSearchPath(t *testing.T) {
 
 	tests := []struct {
 		name        string
+		searchPath  string // overrides the fixture search_path when set
 		stmt        string
 		wantContent string // empty means no advice
 	}{
@@ -79,6 +97,21 @@ func TestTableRequirePKSearchPath(t *testing.T) {
 			name: "create then drop unqualified table in same batch",
 			stmt: "CREATE TABLE fresh(id INT); DROP TABLE fresh;",
 		},
+		{
+			name:        "in-batch SET search_path redirects unqualified name",
+			searchPath:  "public",
+			stmt:        "SET search_path TO app_schema, public; ALTER TABLE with_pk DROP CONSTRAINT with_pk_pkey;",
+			wantContent: `Table "app_schema"."with_pk" requires PRIMARY KEY`,
+		},
+		{
+			name:        "in-batch drop changes which same-named table is altered",
+			stmt:        "DROP TABLE app_schema.shadow; ALTER TABLE shadow DROP CONSTRAINT shadow_pkey;",
+			wantContent: `Table "public"."shadow" requires PRIMARY KEY`,
+		},
+		{
+			name: "unrelated ALTER on same-named table without PK in first schema",
+			stmt: "ALTER TABLE shadow ADD COLUMN note TEXT;",
+		},
 	}
 
 	rule := &storepb.SQLReviewRule{
@@ -90,7 +123,10 @@ func TestTableRequirePKSearchPath(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			original, ok := proto.Clone(dbSchema).(*storepb.DatabaseSchemaMetadata)
 			require.True(t, ok)
-			final, ok := proto.Clone(dbSchema).(*storepb.DatabaseSchemaMetadata)
+			if tc.searchPath != "" {
+				original.SearchPath = tc.searchPath
+			}
+			final, ok := proto.Clone(original).(*storepb.DatabaseSchemaMetadata)
 			require.True(t, ok)
 			checkCtx := advisor.Context{
 				DBType:           storepb.Engine_POSTGRES,

--- a/backend/plugin/advisor/pg/advisor_table_require_pk_test.go
+++ b/backend/plugin/advisor/pg/advisor_table_require_pk_test.go
@@ -1,0 +1,121 @@
+package pg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/bytebase/bytebase/backend/component/sheet"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/advisor"
+	"github.com/bytebase/bytebase/backend/plugin/advisor/code"
+	"github.com/bytebase/bytebase/backend/store/model"
+)
+
+// TestTableRequirePKSearchPath proves unqualified names resolve through the
+// database search_path, matching the walkthrough that builds FinalMetadata.
+// Both tables live only in app_schema; public is empty.
+func TestTableRequirePKSearchPath(t *testing.T) {
+	dbSchema := &storepb.DatabaseSchemaMetadata{
+		Name:       "test",
+		SearchPath: "app_schema, public",
+		Schemas: []*storepb.SchemaMetadata{
+			{Name: "public"},
+			{
+				Name: "app_schema",
+				Tables: []*storepb.TableMetadata{
+					{
+						Name: "with_pk",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+							{Name: "name", Type: "text"},
+						},
+						Indexes: []*storepb.IndexMetadata{
+							{Name: "with_pk_pkey", Expressions: []string{"id"}, Unique: true, Primary: true},
+						},
+					},
+					{
+						Name: "without_pk",
+						Columns: []*storepb.ColumnMetadata{
+							{Name: "id", Type: "integer"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		stmt        string
+		wantContent string // empty means no advice
+	}{
+		{
+			name:        "drop PK on unqualified table in non-public schema",
+			stmt:        "ALTER TABLE with_pk DROP CONSTRAINT with_pk_pkey;",
+			wantContent: `Table "app_schema"."with_pk" requires PRIMARY KEY`,
+		},
+		{
+			name:        "drop PK column on unqualified table in non-public schema",
+			stmt:        "ALTER TABLE with_pk DROP COLUMN id;",
+			wantContent: `Table "app_schema"."with_pk" requires PRIMARY KEY`,
+		},
+		{
+			name: "unrelated ALTER on unqualified table with PK",
+			stmt: "ALTER TABLE with_pk ADD COLUMN note TEXT;",
+		},
+		{
+			name: "unrelated ALTER on unqualified table without PK",
+			stmt: "ALTER TABLE without_pk ADD COLUMN note TEXT;",
+		},
+		{
+			name:        "create unqualified table lands in first search_path schema",
+			stmt:        "CREATE TABLE fresh(id INT);",
+			wantContent: `Table "app_schema"."fresh" requires PRIMARY KEY`,
+		},
+		{
+			name: "create then drop unqualified table in same batch",
+			stmt: "CREATE TABLE fresh(id INT); DROP TABLE fresh;",
+		},
+	}
+
+	rule := &storepb.SQLReviewRule{
+		Type:   storepb.SQLReviewRule_TABLE_REQUIRE_PK,
+		Level:  storepb.SQLReviewRule_WARNING,
+		Engine: storepb.Engine_POSTGRES,
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			original, ok := proto.Clone(dbSchema).(*storepb.DatabaseSchemaMetadata)
+			require.True(t, ok)
+			final, ok := proto.Clone(dbSchema).(*storepb.DatabaseSchemaMetadata)
+			require.True(t, ok)
+			checkCtx := advisor.Context{
+				DBType:           storepb.Engine_POSTGRES,
+				OriginalMetadata: model.NewDatabaseMetadata(original, nil, nil, storepb.Engine_POSTGRES, true),
+				FinalMetadata:    model.NewDatabaseMetadata(final, nil, nil, storepb.Engine_POSTGRES, true),
+				CurrentDatabase:  "test",
+				DBSchema:         dbSchema,
+				NoAppendBuiltin:  true,
+			}
+
+			advice, err := advisor.SQLReviewCheck(context.Background(), sheet.NewManager(), tc.stmt, []*storepb.SQLReviewRule{rule}, checkCtx)
+			require.NoError(t, err)
+
+			var got []*storepb.Advice
+			for _, a := range advice {
+				if a.Code == code.TableNoPK.Int32() {
+					got = append(got, a)
+				}
+			}
+			if tc.wantContent == "" {
+				require.Empty(t, got)
+				return
+			}
+			require.Len(t, got, 1)
+			require.Contains(t, got[0].Content, tc.wantContent)
+		})
+	}
+}

--- a/backend/plugin/advisor/pg/test/table_require_pk.yaml
+++ b/backend/plugin/advisor/pg/test/table_require_pk.yaml
@@ -74,3 +74,22 @@
         line: 3
         column: 0
       endposition: null
+- statement: ALTER TABLE no_index_table ADD COLUMN note TEXT
+  changeType: 1
+- statement: ALTER TABLE no_index_table DROP COLUMN col_b
+  changeType: 1
+- statement: ALTER TABLE no_index_table ALTER COLUMN col_a TYPE bigint
+  changeType: 1
+- statement: |-
+    CREATE TABLE audit_log(id INT, payload TEXT);
+    ALTER TABLE audit_log ADD COLUMN note TEXT;
+  changeType: 1
+  want:
+    - status: 2
+      code: 601
+      title: TABLE_REQUIRE_PK
+      content: 'Table "public"."audit_log" requires PRIMARY KEY, related statement: "ALTER TABLE audit_log ADD COLUMN note TEXT"'
+      startposition:
+        line: 2
+        column: 0
+      endposition: null

--- a/backend/plugin/advisor/pg/test/table_require_pk.yaml
+++ b/backend/plugin/advisor/pg/test/table_require_pk.yaml
@@ -131,3 +131,51 @@
     ALTER TABLE tech_book DROP CONSTRAINT old_pk;
     ALTER TABLE tech_book ADD PRIMARY KEY (id);
   changeType: 1
+- statement: |-
+    DROP TABLE no_index_table;
+    CREATE TABLE no_index_table(id INT);
+  changeType: 1
+  want:
+    - status: 2
+      code: 601
+      title: TABLE_REQUIRE_PK
+      content: 'Table "public"."no_index_table" requires PRIMARY KEY, related statement: "CREATE TABLE no_index_table(id INT)"'
+      startposition:
+        line: 2
+        column: 0
+      endposition: null
+- statement: CREATE TABLE IF NOT EXISTS no_index_table(id INT)
+  changeType: 1
+- statement: |-
+    CREATE TABLE t(id INT);
+    ALTER TABLE t RENAME TO u;
+  changeType: 1
+  want:
+    - status: 2
+      code: 601
+      title: TABLE_REQUIRE_PK
+      content: 'Table "public"."u" requires PRIMARY KEY, related statement: "ALTER TABLE t RENAME TO u"'
+      startposition:
+        line: 2
+        column: 0
+      endposition: null
+- statement: |-
+    CREATE TABLE t(id INT);
+    ALTER TABLE t RENAME TO u;
+    ALTER TABLE u ADD PRIMARY KEY (id);
+  changeType: 1
+- statement: ALTER TABLE no_index_table RENAME TO legacy_renamed
+  changeType: 1
+- statement: |-
+    CREATE TABLE t(id INT);
+    ALTER TABLE public.t ADD COLUMN note TEXT;
+  changeType: 1
+  want:
+    - status: 2
+      code: 601
+      title: TABLE_REQUIRE_PK
+      content: 'Table "public"."t" requires PRIMARY KEY, related statement: "ALTER TABLE public.t ADD COLUMN note TEXT"'
+      startposition:
+        line: 2
+        column: 0
+      endposition: null

--- a/backend/plugin/advisor/pg/test/table_require_pk.yaml
+++ b/backend/plugin/advisor/pg/test/table_require_pk.yaml
@@ -179,3 +179,20 @@
         line: 2
         column: 0
       endposition: null
+- statement: |-
+    ALTER TABLE public.tech_book RENAME TO tb;
+    ALTER TABLE public.tb DROP CONSTRAINT old_pk;
+  changeType: 1
+  want:
+    - status: 2
+      code: 601
+      title: TABLE_REQUIRE_PK
+      content: 'Table "public"."tb" requires PRIMARY KEY, related statement: "ALTER TABLE public.tb DROP CONSTRAINT old_pk"'
+      startposition:
+        line: 2
+        column: 0
+      endposition: null
+- statement: |-
+    ALTER TABLE tech_book RENAME TO tb;
+    ALTER TABLE tb ADD COLUMN note TEXT;
+  changeType: 1

--- a/backend/plugin/advisor/pg/test/table_require_pk.yaml
+++ b/backend/plugin/advisor/pg/test/table_require_pk.yaml
@@ -93,3 +93,41 @@
         line: 2
         column: 0
       endposition: null
+- statement: ALTER TABLE public.no_index_table ADD COLUMN x INT
+  changeType: 1
+- statement: ALTER TABLE tech_book ADD COLUMN x INT
+  changeType: 1
+- statement: ALTER TABLE public.tech_book DROP CONSTRAINT old_pk
+  changeType: 1
+  want:
+    - status: 2
+      code: 601
+      title: TABLE_REQUIRE_PK
+      content: 'Table "public"."tech_book" requires PRIMARY KEY, related statement: "ALTER TABLE public.tech_book DROP CONSTRAINT old_pk"'
+      startposition:
+        line: 1
+        column: 0
+      endposition: null
+- statement: |-
+    DROP TABLE tech_book;
+    CREATE TABLE tech_book(id INT, name TEXT);
+  changeType: 1
+  want:
+    - status: 2
+      code: 601
+      title: TABLE_REQUIRE_PK
+      content: 'Table "public"."tech_book" requires PRIMARY KEY, related statement: "CREATE TABLE tech_book(id INT, name TEXT)"'
+      startposition:
+        line: 2
+        column: 0
+      endposition: null
+- statement: ALTER TABLE ghost_table ADD COLUMN x INT
+  changeType: 1
+- statement: |-
+    ALTER TABLE no_index_table ADD PRIMARY KEY (col_a);
+    ALTER TABLE no_index_table DROP CONSTRAINT no_index_table_pkey;
+  changeType: 1
+- statement: |-
+    ALTER TABLE tech_book DROP CONSTRAINT old_pk;
+    ALTER TABLE tech_book ADD PRIMARY KEY (id);
+  changeType: 1


### PR DESCRIPTION
## Summary

Fixes [BYT-10169](https://linear.app/bytebase/issue/BYT-10169/make-table-require-pk-ignore-unrelated-postgresql-alter-table).

The PostgreSQL `TABLE_REQUIRE_PK` advisor recorded every `ALTER TABLE` target and checked its final metadata for a primary key. An unrelated change to a pre-existing table without a PK, such as `ALTER TABLE existing_table ADD COLUMN note TEXT`, therefore emitted code 601. MySQL/MariaDB/OceanBase, TiDB, Oracle, SQL Server, and Snowflake only track creates and PK-affecting ALTER operations, so PostgreSQL users were blocked from unrelated changes to legacy tables.

## Change

The rule now guards only the net change of a batch, decided by comparing `OriginalMetadata` with the `FinalMetadata` the walkthrough produces:

- A table that ends the batch without a primary key is flagged when it had one before the batch (PK constraint dropped, PK column dropped, dropped and recreated without PK, renamed and then stripped of its PK).
- A table that is new in the final metadata is flagged only when the batch created it (a `CREATE TABLE` under that name, followed through `ALTER TABLE ... RENAME TO`) and it ends without a primary key.
- A pre-existing table without a primary key is out of scope unless the batch both dropped and recreated it. Unrelated ALTERs, renames, and `CREATE TABLE IF NOT EXISTS` on such a table are no longer flagged.

Name resolution is left to the walkthrough. The advisor no longer resolves schemas itself, so `search_path`, `$user`, in-batch `SET search_path` / `SET ROLE`, and drops that change which same-named table an unqualified name refers to are all handled by the same code that builds `FinalMetadata`. Statements are tracked per table, keyed by the schema as written, only to tell created tables from pre-existing ones and to attribute the advice line and related statement text.

Known gaps, accepted for this PR. All of them need table identity from the walkthrough (an OID-level before/after mapping) and are left for a follow-up:

- An unqualified drop-and-recreate under a non-public `search_path` can still collide with a same-named legacy table without a PK in another schema.
- `ALTER TABLE ... SET SCHEMA` is not followed, so a PK table moved and then stripped of its PK is not flagged.
- A new table created with a qualified name and renamed with an unqualified one (or vice versa) loses its created state at the rename.

## Test

- `backend/plugin/advisor/pg/test/table_require_pk.yaml`: `ADD COLUMN`, `DROP COLUMN`, and `ALTER COLUMN TYPE` on a pre-existing table without a PK no longer emit 601; a table created then altered (unqualified or qualified) in the same batch still does; drop-and-recreate of a legacy table flags while `CREATE TABLE IF NOT EXISTS` on it does not; create-then-rename flags under the new name and clears once the PK is added; renaming a legacy table stays quiet; renaming a PK table and then dropping the PK flags under the new name; schema-qualified names, a table absent from the catalog, and add-then-drop PK within a batch. Existing cases unchanged.
- `TestTableRequirePKSearchPath`: with `search_path = app_schema, public`, dropping the PK or a PK column on an unqualified table is flagged under `app_schema`, unrelated ALTERs are not, an unqualified `CREATE TABLE` is attributed to `app_schema`, an in-batch `SET search_path` redirecting an unqualified `ALTER` is still caught, dropping one of two same-named tables before altering the other is attributed to the surviving table, and a qualified drop-and-recreate does not flag a same-named legacy table in another schema.
- `go test ./backend/plugin/advisor/pg/` passes; `golangci-lint` reports 0 issues; backend build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

