### PR TITLE
perf(tests): close idle connections before shutting the server down

### DIFF
--- a/backend/tests/tests.go
+++ b/backend/tests/tests.go
@@ -347,6 +347,11 @@ func (ctl *controller) waitForHealthz(ctx context.Context) error {
 // Close closes long running resources.
 func (ctl *controller) Close(ctx context.Context) error {
 	var e error
+	// Drop the client's idle HTTP/2 connection before shutting the server down.
+	// Otherwise httpServer.Shutdown waits out the idle connection, ~1s per test.
+	if ctl.client != nil {
+		ctl.client.CloseIdleConnections()
+	}
 	if ctl.server != nil {
 		if err := ctl.server.Shutdown(ctx); err != nil {
 			e = multierr.Append(e, err)

--- a/docs/design/backend-test-execution-time.md
+++ b/docs/design/backend-test-execution-time.md
@@ -1,5 +1,7 @@
 # Backend test execution time
 
+Status: in progress
+
 ## Scope
 
 Cut the execution time of `go test ./backend/...`. It takes 14–19.5 minutes in
@@ -90,7 +92,7 @@ cost inside a package that runs 3.7× parallel, and effort 1's saving sits insid
 effort 4's, so they do not simply add. Together they should take it from 635 s
 of wall clock to roughly 330 s.
 
-### 1. Close idle connections before shutting the server down
+### [✓] 1. Close idle connections before shutting the server down
 
 **Three lines.** `httpServer.Shutdown` burns 1036 ms on every one of the 207
 boots. It is waiting out an idle HTTP/2 connection that nobody will reuse: the
@@ -112,6 +114,13 @@ to 676 ms. Across 207 boots that is ~217 s.
 That 217 s is part of effort 4's total, not on top of it. This goes first only
 because it is three lines and needs no restructuring, and it stops mattering
 once effort 4 collapses the boot count.
+
+**What it bought.** Over 5 cycles the shutdown went from 1058 ms to **1 ms**
+and the boot-and-shutdown cycle from 1720 ms to **691 ms**, as projected. A
+package-isolated `go test ./backend/tests/` — not the full-suite figure above —
+went from **679 s to 611 s** across its 233 boots: 227 s off the summed test
+time, compressed 3.3× by the package's own parallelism. Measure the efforts
+below against 611 s.
 
 ### 2. One shared container per package, then turn parallelism on
 


### PR DESCRIPTION
Effort 1 of [`docs/design/backend-test-execution-time.md`](https://github.com/bytebase/bytebase/blob/main/docs/design/backend-test-execution-time.md).

## What changed

Three lines in `controller.Close` (`backend/tests/tests.go`): close the test client's idle connections before `server.Shutdown`.

## Why

Every test in `backend/tests` boots a server and tears it down through `controller.Close`, and `httpServer.Shutdown` was burning ~1 s of each teardown waiting out the test client's idle HTTP/2 connection — one nobody was going to reuse, because the client's `http2.Transport` is never closed. The server's own runners exit in 0 ms.

Order matters: the idle connection has to go *before* `server.Shutdown`, or `httpServer.Shutdown` still waits it out.

## Measured

Micro — 6 boot/shutdown cycles through `StartServerWithExternalPg` + `Close` (first dropped as warmup, mean of 5), on a 20 vCPU box:

| | boot | shutdown | cycle |
| --- | ---: | ---: | ---: |
| before | 661 ms | 1058 ms | 1720 ms |
| after | 690 ms | **1 ms** | **691 ms** |

Macro — full `go test -count=1 ./backend/tests/`, build cache warmed outside the timer, runs sequential on an otherwise idle box:

| | wall | package `Elapsed` | Σ top-level test time |
| --- | ---: | ---: | ---: |
| before | 679.1 s | 671.1 s | 2428.8 s |
| after | **610.7 s** | 603.0 s | 2201.7 s |
| | **−68.3 s (−10.1%)** | −68.1 s | −227.1 s |

Both passes: exit 0, zero failures, 329 tests, and **233 server boots each** — identical work. 233 × 1.029 s ≈ 240 s of serial fixture time removed, landing at 68 s of wall clock; that ~3.3× compression is the package's own parallelism, matching the 3.7× factor the design doc measured. 169 of 209 top-level tests improved; the rest is MySQL-container scheduling noise (tests that queue behind 10 s container starts).

## For the reviewer

- `backend/tests` has exactly one boot helper, one `Close`, and one `server.Shutdown` call site, so this covers every path in the package.
- `http2.Transport` does implement `CloseIdleConnections` (x/net v0.57.0, `http2/transport_common.go:237`), so `http.Client`'s delegation is not a silent no-op.
- Not a breaking change: test harness and docs only, nothing in the shipped binary.
- Pre-PR checklist — sections 2, 4, 5 and 6 skip (no store query, no transaction, no version metadata). Section 3 applies because the diff touches `backend/tests/`: no SQL or store method is added or modified, and all 27 `TestCollision*`/`TestClaim*` tests pass on the patched code as part of the full-package run above. `gofmt` clean, `golangci-lint` (v2.12.2, matching CI) introduces no new findings, build OK.

The doc is updated to mark effort 1 done and to record 611 s as the fresh baseline for efforts 3–5, which target the same package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)