### PR TITLE
fix(wif): keep a typed subject, and open an identity with no declared provider

### DIFF
--- a/frontend/src/components/CreateWorkloadIdentitySheet.test.tsx
+++ b/frontend/src/components/CreateWorkloadIdentitySheet.test.tsx
@@ -2,6 +2,7 @@ import { create } from "@bufbuild/protobuf";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import type { WorkloadIdentity } from "@/types/proto-es/v1/workload_identity_service_pb";
 import {
   WorkloadIdentityConfig_ProviderType,
   WorkloadIdentityConfigSchema,
@@ -77,22 +78,14 @@ vi.mock("@/stores", () => ({
   pushNotification: vi.fn(),
 }));
 
-vi.mock("@/utils", () => ({
-  getWorkloadIdentityProviderText: (provider: number) =>
-    provider === 1 ? "GitLab" : "GitHub Actions",
+// The real parser and resolver, so the tests see exactly what the form does
+// with a stored subject. Only the permission checks are stubbed.
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual<typeof import("@/utils/workloadIdentity")>(
+    "@/utils/workloadIdentity"
+  )),
   hasProjectPermissionV2: () => true,
   hasWorkspacePermissionV2: () => true,
-  parseWorkloadIdentitySubjectPattern: (workloadIdentity: {
-    workloadIdentityConfig?: { subjectPattern: string };
-  }) => {
-    if (
-      workloadIdentity.workloadIdentityConfig?.subjectPattern ===
-      "project_path:group/project:environment:production"
-    ) {
-      return { owner: "group", repo: "project", branch: "" };
-    }
-    return undefined;
-  },
 }));
 
 describe("CreateWorkloadIdentitySheet", () => {
@@ -533,5 +526,154 @@ describe("CreateWorkloadIdentitySheet", () => {
     act(() => {
       root.unmount();
     });
+  });
+
+  // Both bugs below reproduce on main. #21309 skips the first run of the
+  // fields-to-pattern effect, which covers opening the sheet; it does not
+  // cover a subject typed after any derived field is edited.
+  const editableIdentity = (
+    providerType: WorkloadIdentityConfig_ProviderType,
+    subjectPattern: string
+  ) =>
+    create(WorkloadIdentitySchema, {
+      name: "workloadIdentities/ci@workload.bytebase.com",
+      email: "ci@workload.bytebase.com",
+      title: "CI deploy",
+      workloadIdentityConfig: create(WorkloadIdentityConfigSchema, {
+        providerType,
+        issuerUrl: "https://token.actions.githubusercontent.com",
+        allowedAudiences: ["bytebase"],
+        subjectPattern,
+      }),
+    });
+
+  const renderSheet = (workloadIdentity?: WorkloadIdentity) => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <CreateWorkloadIdentitySheet
+          open
+          workloadIdentity={workloadIdentity}
+          onClose={() => undefined}
+          onCreated={() => undefined}
+          onUpdated={() => undefined}
+        />
+      );
+    });
+    return { container, root };
+  };
+
+  const inputFor = (container: HTMLElement, label: string) =>
+    Array.from(container.querySelectorAll('[data-slot="form-field"]'))
+      .find((field) => field.textContent?.includes(label))
+      ?.querySelector("input") as HTMLInputElement;
+
+  const type = (input: HTMLInputElement, value: string) =>
+    act(() => {
+      Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value"
+      )?.set?.call(input, value);
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+  const openAdvanced = (container: HTMLElement) =>
+    act(() => {
+      Array.from(container.querySelectorAll("button"))
+        .find((button) =>
+          button.textContent?.includes(
+            "settings.members.workload-identity-advanced"
+          )
+        )
+        ?.click();
+    });
+
+  test("keeps a subject pattern typed after a field edit", async () => {
+    const identity = editableIdentity(
+      WorkloadIdentityConfig_ProviderType.GITHUB,
+      "repo:acme-corp/deploy:ref:refs/heads/main"
+    );
+    mocks.store.updateWorkloadIdentity.mockResolvedValue(identity);
+    const { container, root } = renderSheet(identity);
+
+    type(inputFor(container, "settings.members.workload-identity-owner"), "acme-two");
+    openAdvanced(container);
+    const pinned = "repo:acme-two/deploy:environment:production";
+    type(inputFor(container, "settings.members.workload-identity-subject"), pinned);
+
+    expect(
+      inputFor(container, "settings.members.workload-identity-subject").value
+    ).toBe(pinned);
+
+    const update = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "common.update"
+    );
+    await act(async () => {
+      update?.click();
+    });
+    expect(
+      mocks.store.updateWorkloadIdentity.mock.calls[0]?.[0]
+        ?.workloadIdentityConfig?.subjectPattern
+    ).toBe(pinned);
+
+    act(() => root.unmount());
+  });
+
+  test("opens an identity that never declared a provider", async () => {
+    const identity = editableIdentity(
+      WorkloadIdentityConfig_ProviderType.PROVIDER_TYPE_UNSPECIFIED,
+      "repo:acme-corp/deploy:ref:refs/heads/main"
+    );
+    mocks.store.updateWorkloadIdentity.mockResolvedValue(identity);
+    const { container, root } = renderSheet(identity);
+
+    // The subject names the provider, so the fields parse and the form is
+    // usable; reading the stored enum leaves owner empty and Update dead.
+    expect(
+      inputFor(container, "settings.members.workload-identity-owner").value
+    ).toBe("acme-corp");
+
+    type(inputFor(container, "common.name"), "CI deploy renamed");
+    const update = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "common.update"
+    );
+    expect(update?.hasAttribute("disabled")).toBe(false);
+    await act(async () => {
+      update?.click();
+    });
+
+    const sent =
+      mocks.store.updateWorkloadIdentity.mock.calls[0]?.[0]
+        ?.workloadIdentityConfig;
+    expect(sent?.subjectPattern).toBe("repo:acme-corp/deploy:ref:refs/heads/main");
+    // provider_type is required on write now, so the save must name one.
+    expect(sent?.providerType).toBe(WorkloadIdentityConfig_ProviderType.GITHUB);
+
+    act(() => root.unmount());
+  });
+
+  test("recomputes the subject pattern from every derived control", () => {
+    const { container, root } = renderSheet(
+      editableIdentity(
+        WorkloadIdentityConfig_ProviderType.GITHUB,
+        "repo:acme-corp/deploy:ref:refs/heads/main"
+      )
+    );
+    openAdvanced(container);
+    const subject = () =>
+      inputFor(container, "settings.members.workload-identity-subject").value;
+
+    type(inputFor(container, "settings.members.workload-identity-owner"), "acme-two");
+    expect(subject()).toBe("repo:acme-two/deploy:ref:refs/heads/main");
+
+    type(inputFor(container, "settings.members.workload-identity-repo"), "release");
+    expect(subject()).toBe("repo:acme-two/release:ref:refs/heads/main");
+
+    type(inputFor(container, "settings.members.workload-identity-branch"), "dev");
+    expect(subject()).toBe("repo:acme-two/release:ref:refs/heads/dev");
+
+    act(() => root.unmount());
   });
 });

--- a/frontend/src/components/CreateWorkloadIdentitySheet.tsx
+++ b/frontend/src/components/CreateWorkloadIdentitySheet.tsx
@@ -1,7 +1,7 @@
 import { create } from "@bufbuild/protobuf";
 import { FieldMaskSchema } from "@bufbuild/protobuf/wkt";
 import { ChevronDown, ChevronUp, PlusIcon, XIcon } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { RoleSelect } from "@/components/RoleSelect";
 import { Button } from "@/components/ui/button";
@@ -43,6 +43,7 @@ import {
   hasProjectPermissionV2,
   hasWorkspacePermissionV2,
   parseWorkloadIdentitySubjectPattern,
+  resolveWorkloadIdentityProviderType,
 } from "@/utils";
 
 type RefType = "branch" | "tag" | "all";
@@ -170,9 +171,13 @@ function WorkloadIdentityForm({
         : undefined,
     []
   );
+  // Resolved, not read raw: an identity written before provider_type was
+  // required may carry PROVIDER_TYPE_UNSPECIFIED, which names no platform and
+  // parses no subject.
   const initialProviderType =
-    workloadIdentity?.workloadIdentityConfig?.providerType ??
-    WorkloadIdentityConfig_ProviderType.GITHUB;
+    resolveWorkloadIdentityProviderType(
+      workloadIdentity?.workloadIdentityConfig
+    ) ?? WorkloadIdentityConfig_ProviderType.GITHUB;
   const initialIssuerUrl =
     workloadIdentity?.workloadIdentityConfig?.issuerUrl ??
     PLATFORM_PRESETS[initialProviderType]?.issuerUrl ??
@@ -224,58 +229,69 @@ function WorkloadIdentityForm({
   const [roles, setRoles] = useState<string[]>([]);
   const [isRequesting, setIsRequesting] = useState(false);
 
-  const isUpdatingFromPatternRef = useRef(false);
-  const isUpdatingFromFieldsRef = useRef(false);
-  const didInitializeSubjectFieldsRef = useRef(false);
   const isGenericOIDC =
     providerType === WorkloadIdentityConfig_ProviderType.OIDC;
 
-  useEffect(() => {
-    if (!didInitializeSubjectFieldsRef.current) {
-      didInitializeSubjectFieldsRef.current = true;
-      return;
-    }
-    if (isGenericOIDC || isUpdatingFromPatternRef.current) return;
-    isUpdatingFromFieldsRef.current = true;
+  // The subject pattern and the owner/repository/branch fields derive from
+  // each other, and each edit resolves in the handler that made it. An effect
+  // pair cannot: the guards it needs are set and cleared inside one
+  // synchronous effect body, so the sibling effect never observes them, and a
+  // subject typed in Advanced is overwritten by the recompute that the next
+  // render schedules. The GitHub arm of computeSubjectPattern cannot express a
+  // subject pinned to a tag, an environment or a pull request, so that
+  // recompute widens the binding to "repo:<owner>/<repo>:*".
+  const applyDerivedFields = (patch: {
+    providerType?: WorkloadIdentityConfig_ProviderType;
+    owner?: string;
+    repo?: string;
+    branch?: string;
+    refType?: RefType;
+  }) => {
+    if (patch.providerType !== undefined) setProviderType(patch.providerType);
+    if (patch.owner !== undefined) setOwner(patch.owner);
+    if (patch.repo !== undefined) setRepo(patch.repo);
+    if (patch.branch !== undefined) setBranch(patch.branch);
+    if (patch.refType !== undefined) setRefType(patch.refType);
     setSubjectPattern(
-      computeSubjectPattern(providerType, owner, repo, branch, refType)
+      computeSubjectPattern(
+        patch.providerType ?? providerType,
+        patch.owner ?? owner,
+        patch.repo ?? repo,
+        patch.branch ?? branch,
+        patch.refType ?? refType
+      )
     );
-    isUpdatingFromFieldsRef.current = false;
-  }, [owner, repo, branch, providerType, refType, isGenericOIDC]);
+  };
 
-  useEffect(() => {
-    if (isGenericOIDC || isUpdatingFromFieldsRef.current) return;
+  const handleSubjectPatternChange = (value: string) => {
+    setSubjectPattern(value);
     const parsed = parseWorkloadIdentitySubjectPattern({
-      workloadIdentityConfig: {
-        subjectPattern,
-        providerType,
-      },
+      workloadIdentityConfig: { subjectPattern: value, providerType },
     });
-    if (parsed) {
-      isUpdatingFromPatternRef.current = true;
-      setOwner(parsed.owner);
-      setRepo(parsed.repo);
-      setBranch(parsed.branch);
-      if ("refType" in parsed && parsed.refType) {
-        setRefType(parsed.refType);
-      }
-      isUpdatingFromPatternRef.current = false;
+    if (!parsed) return;
+    setOwner(parsed.owner);
+    setRepo(parsed.repo);
+    setBranch(parsed.branch);
+    if ("refType" in parsed && parsed.refType) {
+      setRefType(parsed.refType);
     }
-  }, [subjectPattern, providerType, isGenericOIDC]);
+  };
 
   const handlePlatformChange = (value: WorkloadIdentityConfig_ProviderType) => {
-    setProviderType(value);
     const preset = PLATFORM_PRESETS[value];
     if (preset) {
       setIssuerUrl(preset.issuerUrl);
       setAudiences([preset.audience]);
       setJwksUrl("");
-    } else {
-      setIssuerUrl("");
-      setJwksUrl("");
-      setAudiences([""]);
-      setSubjectPattern("");
+      applyDerivedFields({ providerType: value, refType: "all", branch: "" });
+      return;
     }
+    // Generic OIDC composes nothing: its subject is typed, not derived.
+    setProviderType(value);
+    setIssuerUrl("");
+    setJwksUrl("");
+    setAudiences([""]);
+    setSubjectPattern("");
     setRefType("all");
     setBranch("");
   };
@@ -641,7 +657,7 @@ function WorkloadIdentityForm({
             >
               <Input
                 value={owner}
-                onChange={(e) => setOwner(e.target.value)}
+                onChange={(e) => applyDerivedFields({ owner: e.target.value })}
                 placeholder={isGitLab ? "my-group" : "my-org"}
                 maxLength={200}
                 autoComplete="off"
@@ -669,7 +685,7 @@ function WorkloadIdentityForm({
             >
               <Input
                 value={repo}
-                onChange={(e) => setRepo(e.target.value)}
+                onChange={(e) => applyDerivedFields({ repo: e.target.value })}
                 placeholder={isGitLab ? "my-project" : "my-repo"}
                 maxLength={200}
                 autoComplete="off"
@@ -691,7 +707,8 @@ function WorkloadIdentityForm({
               <Select
                 value={refType}
                 onValueChange={(value) => {
-                  if (value !== null) setRefType(value as RefType);
+                  if (value !== null)
+                    applyDerivedFields({ refType: value as RefType });
                 }}
               >
                 <SelectTrigger className="w-full">
@@ -742,7 +759,7 @@ function WorkloadIdentityForm({
             >
               <Input
                 value={branch}
-                onChange={(e) => setBranch(e.target.value)}
+                onChange={(e) => applyDerivedFields({ branch: e.target.value })}
                 placeholder={isTagRefType ? "v1.0.0" : "main"}
                 maxLength={200}
                 autoComplete="off"
@@ -845,7 +862,7 @@ function WorkloadIdentityForm({
               >
                 <Input
                   value={subjectPattern}
-                  onChange={(e) => setSubjectPattern(e.target.value)}
+                  onChange={(e) => handleSubjectPatternChange(e.target.value)}
                   maxLength={500}
                   autoComplete="off"
                 />

--- a/frontend/src/routes/project/ProjectGitOpsPage.tsx
+++ b/frontend/src/routes/project/ProjectGitOpsPage.tsx
@@ -25,6 +25,7 @@ import {
   getWorkloadIdentityProviderText,
   hasProjectPermissionV2,
   parseWorkloadIdentitySubjectPattern,
+  resolveWorkloadIdentityProviderType,
 } from "@/utils";
 import { WorkloadIdentitySelect } from "./WorkloadIdentitySelect";
 
@@ -87,21 +88,24 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
   }, [selectedIdentityName, fetchWorkloadIdentity]);
 
   const selectedConfig = selectedIdentity?.workloadIdentityConfig;
+  // Resolved, not read raw: the subject parser below resolves an unspecified
+  // provider from the subject prefix, so a page reading the stored enum would
+  // render this identity's repository under a "provider does not match" alert
+  // naming no provider.
+  const selectedProviderType =
+    resolveWorkloadIdentityProviderType(selectedConfig) ??
+    WorkloadIdentityConfig_ProviderType.PROVIDER_TYPE_UNSPECIFIED;
 
   // Sync active tab with selected identity provider
   useEffect(() => {
-    if (
-      selectedConfig?.providerType ===
-      WorkloadIdentityConfig_ProviderType.GITLAB
-    ) {
+    if (selectedProviderType === WorkloadIdentityConfig_ProviderType.GITLAB) {
       setActiveTab("gitlab");
     } else if (
-      selectedConfig?.providerType ===
-      WorkloadIdentityConfig_ProviderType.GITHUB
+      selectedProviderType === WorkloadIdentityConfig_ProviderType.GITHUB
     ) {
       setActiveTab("github");
     }
-  }, [selectedConfig?.providerType]);
+  }, [selectedProviderType]);
 
   const parsedSubject = useMemo(() => {
     if (!selectedIdentity) return undefined;
@@ -111,17 +115,16 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
   const repoUrl = useMemo(() => {
     const parsed = parsedSubject;
     if (!parsed?.owner || !parsed.repo) return "";
-    const providerType = selectedConfig?.providerType;
-    if (providerType === WorkloadIdentityConfig_ProviderType.GITHUB) {
+    if (selectedProviderType === WorkloadIdentityConfig_ProviderType.GITHUB) {
       return `https://github.com/${parsed.owner}/${parsed.repo}`;
     }
-    if (providerType === WorkloadIdentityConfig_ProviderType.GITLAB) {
+    if (selectedProviderType === WorkloadIdentityConfig_ProviderType.GITLAB) {
       const issuer = selectedConfig?.issuerUrl ?? "https://gitlab.com";
       const base = issuer.replace(/\/$/, "");
       return `${base}/${parsed.owner}/${parsed.repo}`;
     }
     return "";
-  }, [parsedSubject, selectedConfig]);
+  }, [parsedSubject, selectedConfig, selectedProviderType]);
 
   const branch = parsedSubject?.branch || "main";
 
@@ -225,11 +228,11 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
   const providerMismatchGithub =
     selectedConfig &&
     activeTab === "github" &&
-    selectedConfig.providerType !== WorkloadIdentityConfig_ProviderType.GITHUB;
+    selectedProviderType !== WorkloadIdentityConfig_ProviderType.GITHUB;
   const providerMismatchGitlab =
     selectedConfig &&
     activeTab === "gitlab" &&
-    selectedConfig.providerType !== WorkloadIdentityConfig_ProviderType.GITLAB;
+    selectedProviderType !== WorkloadIdentityConfig_ProviderType.GITLAB;
 
   return (
     <ProjectPageLayout className="gap-y-1">
@@ -435,7 +438,7 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
                 className="mb-3"
                 description={t("gitops.workflow.provider-not-match", {
                   provider: getWorkloadIdentityProviderText(
-                    selectedConfig!.providerType,
+                    selectedProviderType,
                     t("settings.members.workload-identity-generic-oidc")
                   ),
                 })}
@@ -484,7 +487,7 @@ export function ProjectGitOpsPage({ projectId }: { projectId: string }) {
                 className="mb-3"
                 description={t("gitops.workflow.provider-not-match", {
                   provider: getWorkloadIdentityProviderText(
-                    selectedConfig!.providerType,
+                    selectedProviderType,
                     t("settings.members.workload-identity-generic-oidc")
                   ),
                 })}

--- a/frontend/src/utils/workloadIdentity.test.ts
+++ b/frontend/src/utils/workloadIdentity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+import { WorkloadIdentityConfig_ProviderType } from "@/types/proto-es/v1/workload_identity_service_pb";
+import {
+  parseWorkloadIdentitySubjectPattern,
+  resolveWorkloadIdentityProviderType,
+} from "./workloadIdentity";
+
+const { GITHUB, GITLAB, PROVIDER_TYPE_UNSPECIFIED } =
+  WorkloadIdentityConfig_ProviderType;
+
+describe("resolveWorkloadIdentityProviderType", () => {
+  test("returns a declared provider unchanged", () => {
+    expect(
+      resolveWorkloadIdentityProviderType({
+        providerType: GITLAB,
+        subjectPattern: "repo:acme-corp/*",
+      })
+    ).toBe(GITLAB);
+  });
+
+  // provider_type is optional and identities created through the API often
+  // omit it. Leaving those unresolved seeds the edit form with an unspecified
+  // provider, which recomputes an empty subject pattern on mount and locks the
+  // operator out of the identity.
+  test("infers the provider from the subject when none was declared", () => {
+    expect(
+      resolveWorkloadIdentityProviderType({
+        providerType: PROVIDER_TYPE_UNSPECIFIED,
+        subjectPattern: "repo:acme-corp/deploy:ref:refs/heads/main",
+      })
+    ).toBe(GITHUB);
+    expect(
+      resolveWorkloadIdentityProviderType({
+        providerType: PROVIDER_TYPE_UNSPECIFIED,
+        subjectPattern: "project_path:grp/proj:*",
+      })
+    ).toBe(GITLAB);
+  });
+
+  test("returns undefined when the subject names no provider", () => {
+    expect(
+      resolveWorkloadIdentityProviderType({
+        providerType: PROVIDER_TYPE_UNSPECIFIED,
+        subjectPattern: "custom:whatever",
+      })
+    ).toBeUndefined();
+    expect(resolveWorkloadIdentityProviderType(undefined)).toBeUndefined();
+  });
+});
+
+describe("parseWorkloadIdentitySubjectPattern", () => {
+  // The parser and the form's initial provider must agree, so both read the
+  // same resolution.
+  test("parses an identity that never declared a provider", () => {
+    expect(
+      parseWorkloadIdentitySubjectPattern({
+        workloadIdentityConfig: {
+          providerType: PROVIDER_TYPE_UNSPECIFIED,
+          subjectPattern: "repo:acme-corp/deploy:ref:refs/heads/main",
+        },
+      })
+    ).toEqual({ owner: "acme-corp", repo: "deploy", branch: "main" });
+  });
+});

--- a/frontend/src/utils/workloadIdentity.ts
+++ b/frontend/src/utils/workloadIdentity.ts
@@ -1,5 +1,29 @@
 import { WorkloadIdentityConfig_ProviderType } from "@/types/proto-es/v1/workload_identity_service_pb";
 
+// provider_type is optional in storage and identities written before it was
+// required may carry PROVIDER_TYPE_UNSPECIFIED. Every reader that needs a
+// provider for such an identity resolves it here, or two readers disagree
+// about the same record.
+export const resolveWorkloadIdentityProviderType = (config?: {
+  subjectPattern: string;
+  providerType: WorkloadIdentityConfig_ProviderType;
+}): WorkloadIdentityConfig_ProviderType | undefined => {
+  if (!config) return undefined;
+  if (
+    config.providerType !==
+    WorkloadIdentityConfig_ProviderType.PROVIDER_TYPE_UNSPECIFIED
+  ) {
+    return config.providerType;
+  }
+  if (config.subjectPattern.startsWith("repo:")) {
+    return WorkloadIdentityConfig_ProviderType.GITHUB;
+  }
+  if (config.subjectPattern.startsWith("project_path:")) {
+    return WorkloadIdentityConfig_ProviderType.GITLAB;
+  }
+  return undefined;
+};
+
 // Parse subject pattern and extract owner/repo/branch/refType
 export const parseWorkloadIdentitySubjectPattern = (wi: {
   workloadIdentityConfig?: {
@@ -16,7 +40,9 @@ export const parseWorkloadIdentitySubjectPattern = (wi: {
     return;
   }
 
-  const providerType = wi.workloadIdentityConfig.providerType;
+  const providerType = resolveWorkloadIdentityProviderType(
+    wi.workloadIdentityConfig
+  );
   switch (providerType) {
     case WorkloadIdentityConfig_ProviderType.GITHUB: {
       const match = /^repo:([^/]+)\/(.*)$/.exec(pattern);


### PR DESCRIPTION
Two edit-sheet bugs, both reproducible on `main` after #21309. Split out of #21262, which drives operators into this sheet.

## What is wrong

**A subject typed by hand is overwritten.** The subject pattern and the owner, repository and branch fields derive from each other through a pair of effects. #21309 skips the first run of the fields-to-pattern effect, which covers opening the sheet. It does not cover the rest: the two re-entrancy refs meant to hold the pair apart never fire, because each is set and cleared inside one synchronous effect body while the sibling effect runs in a later commit.

So after any owner, repository or branch edit, a subject typed in Advanced Settings is overwritten on the next render. Typing `repo:acme/deploy:environment:production` leaves `repo:acme/deploy:*` in the field, and the next save persists that widening. Measured against `main`, not inferred.

**An identity that never declared a provider cannot be opened.** `provider_type` is optional in storage, so a row written before #21309 made it required may carry `PROVIDER_TYPE_UNSPECIFIED`. The sheet seeded a blank platform and a subject the parser could not read, so owner stayed empty and Update stayed disabled. That sheet is the only way to repair such a row.

## What changes

Derivation happens in the handler that made the edit. Editing a field recomputes the pattern; editing the pattern re-reads the fields. That removes both effects, both re-entrancy refs and the mount guard, and it makes a typed subject authoritative for the same reason a stored one is: the fields cannot express it. Generic OIDC is unaffected, since its subject was never composed from fields.

The provider is resolved from the subject's own prefix in one helper. Every reader that needs a provider for such an identity resolves through it, the GitOps page included. That page's subject parser already recognized these identities, while its tab sync, repository link and provider-mismatch alert read the stored enum, so it rendered the identity's repository under an alert naming no provider.

Saving a configuration change on such an identity writes the resolved provider back.

## Testing

The sheet tests mount the real parser and resolver rather than the stub, so the six tests already in the file exercise the shipped parser too. Two new tests fail on `main`, one per bug. A third pins that every derived control still recomputes the pattern.

Local gates: `pnpm --dir frontend fix / check / type-check / test` (4075 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2LgXzMpFrqeUYHiPw7Ji9

