### PR TITLE
feat(comment): make general comments plain and anchored comments threads

### DIFF
--- a/backend/api/v1/issue_service_test.go
+++ b/backend/api/v1/issue_service_test.go
@@ -73,23 +73,30 @@ func TestListIssueCommentsExcludesReplies(t *testing.T) {
 	_, issue := createIssueServiceApprovalIssue(ctx, t, stores)
 	parent := common.FormatIssue(issue.ProjectID, issue.UID)
 
-	created, err := service.CreateIssueComment(ctx, connect.NewRequest(&v1pb.CreateIssueCommentRequest{
-		Parent: parent,
-		IssueComment: &v1pb.IssueComment{
+	// Only an anchored comment starts a thread, and v1 cannot set the anchor
+	// yet, so the root is created through the store.
+	root, err := stores.CreateIssueComments(ctx, "users/root@example.com", &store.IssueCommentMessage{
+		ProjectID: issue.ProjectID,
+		IssueUID:  issue.UID,
+		Payload: &storepb.IssueCommentPayload{
 			Comment: "root",
+			StatementAnchor: &storepb.IssueCommentPayload_StatementAnchor{
+				SpecId:        "spec-1",
+				SheetSha256:   "0be1f01d6ee8e6f6c6a2ce9b418ba10ea9d16c9b9bfae5548b8fa0e26c04a5e0",
+				StartPosition: &storepb.Position{Line: 1},
+				EndPosition:   &storepb.Position{Line: 1},
+			},
 		},
-	}))
-	require.NoError(t, err)
-
-	_, _, rootID, err := common.GetProjectIDIssueUIDIssueCommentID(created.Msg.Name)
+	})
 	require.NoError(t, err)
 	_, err = stores.CreateIssueCommentReply(ctx, "users/reply@example.com", &store.IssueCommentMessage{
 		ProjectID: issue.ProjectID,
 		IssueUID:  issue.UID,
-		ParentID:  &rootID,
+		ParentID:  &root.ResourceID,
 		Payload:   &storepb.IssueCommentPayload{Comment: "reply body"},
 	})
 	require.NoError(t, err)
+	rootName := fmt.Sprintf("%s/%s%s", parent, common.IssueCommentNamePrefix, root.ResourceID)
 
 	resp, err := service.ListIssueComments(ctx, connect.NewRequest(&v1pb.ListIssueCommentsRequest{
 		Parent: parent,
@@ -100,7 +107,7 @@ func TestListIssueCommentsExcludesReplies(t *testing.T) {
 		require.NotEqual(t, "reply body", comment.Comment, "replies must not appear in the activity timeline")
 		names = append(names, comment.Name)
 	}
-	require.Contains(t, names, created.Msg.Name, "the thread root stays in the timeline")
+	require.Contains(t, names, rootName, "the thread root stays in the timeline")
 }
 
 func TestDraftLabelUpdateConflictsWithConcurrentSubmission(t *testing.T) {

--- a/backend/migrator/migration/3.23/0001##issue_comment_thread.sql
+++ b/backend/migrator/migration/3.23/0001##issue_comment_thread.sql
@@ -3,25 +3,15 @@ ALTER TABLE issue_comment
     -- The root comment of this reply's thread; NULL on root comments and
     -- events. A reply references the root directly, never another reply.
     ADD COLUMN parent_id text REFERENCES issue_comment(resource_id),
-    -- OPEN/RESOLVED on root comments; NULL on replies and events.
+    -- OPEN/RESOLVED on thread roots, the comments with a statement anchor;
+    -- NULL on plain comments, replies, and events.
     ADD COLUMN thread_state text CHECK (thread_state IN ('OPEN', 'RESOLVED'));
 
 -- FK referencing side and reply reads. Partial: most rows have no parent.
 CREATE INDEX idx_issue_comment_parent_id ON issue_comment(parent_id)
     WHERE parent_id IS NOT NULL;
 
--- Every valid legacy Comment becomes an OPEN thread root. Protojson omits an
--- empty comment, so both {} and {"comment": ""} are Comments. Event, hybrid,
--- legacy Event-key, and malformed payloads stay outside threads.
-UPDATE issue_comment
-SET thread_state = 'OPEN'
-WHERE CASE WHEN jsonb_typeof(payload) = 'object'
-           THEN payload - 'comment' = '{}'::jsonb
-                AND (NOT (payload ? 'comment') OR jsonb_typeof(payload -> 'comment') = 'string')
-           ELSE false END;
-
--- Built after the backfill: the UPDATE would otherwise maintain it per row.
+-- No backfill: legacy comments have no statement anchor, so they stay plain
+-- comments outside threads.
 CREATE INDEX idx_issue_comment_open_thread ON issue_comment(project, issue_id)
     WHERE thread_state = 'OPEN';
-
-ANALYZE issue_comment;

--- a/backend/migrator/migration/LATEST.sql
+++ b/backend/migrator/migration/LATEST.sql
@@ -369,7 +369,8 @@ CREATE TABLE issue_comment (
     -- The root comment of this reply's thread; NULL on root comments and
     -- events. A reply references the root directly, never another reply.
     parent_id text REFERENCES issue_comment(resource_id),
-    -- OPEN/RESOLVED on root comments; NULL on replies and events.
+    -- OPEN/RESOLVED on thread roots, the comments with a statement anchor;
+    -- NULL on plain comments, replies, and events.
     thread_state text CHECK (thread_state IN ('OPEN', 'RESOLVED')),
     PRIMARY KEY (resource_id),
     FOREIGN KEY (project, issue_id) REFERENCES issue(project, id)

--- a/backend/migrator/migrator_test.go
+++ b/backend/migrator/migrator_test.go
@@ -61,32 +61,14 @@ func TestMigration3_23_1_IssueCommentThreads(t *testing.T) {
 	_, err = db.ExecContext(ctx, string(migration))
 	require.NoError(t, err)
 
-	wantOpen := map[string]bool{
-		"comment-only":    true,
-		"empty-comment":   true,
-		"empty-object":    true,
-		"hybrid":          false,
-		"event-only":      false,
-		"legacy-event":    false,
-		"numeric-comment": false,
-		"null-comment":    false,
-		"scalar":          false,
-	}
-	rows, err := db.QueryContext(ctx, `SELECT resource_id, thread_state = 'OPEN' FROM issue_comment`)
-	require.NoError(t, err)
-	defer rows.Close()
-	seen := 0
-	for rows.Next() {
-		var id string
-		var open *bool
-		require.NoError(t, rows.Scan(&id, &open))
-		want, ok := wantOpen[id]
-		require.True(t, ok, "unexpected row %s", id)
-		require.Equal(t, want, open != nil && *open, "thread classification for %s", id)
-		seen++
-	}
-	require.NoError(t, rows.Err())
-	require.Equal(t, len(wantOpen), seen)
+	// Legacy comments have no statement anchor, so none becomes a thread root.
+	var rowCount, stateless int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*), count(*) FILTER (WHERE parent_id IS NULL AND thread_state IS NULL)
+		FROM issue_comment
+	`).Scan(&rowCount, &stateless))
+	require.Equal(t, 9, rowCount)
+	require.Equal(t, rowCount, stateless, "the migration must not classify any legacy row as a thread root")
 
 	var indexes int
 	require.NoError(t, db.QueryRowContext(ctx, `

--- a/backend/store/issue_comment.go
+++ b/backend/store/issue_comment.go
@@ -15,8 +15,9 @@ import (
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
 
-// ThreadState is the resolvable state carried by a thread's root comment.
-// Events and replies have no state (NULL thread_state).
+// ThreadState is the resolvable state carried by a thread's root comment: a
+// comment created with a statement anchor. Plain comments, events, and
+// replies have no state (NULL thread_state).
 type ThreadState string
 
 const (
@@ -35,7 +36,8 @@ type IssueCommentMessage struct {
 	// ParentID names the thread's root comment on a reply; nil on root
 	// comments and events.
 	ParentID *string
-	// ThreadState is set on thread roots; nil on replies and events.
+	// ThreadState is set on thread roots; nil on plain comments, replies,
+	// and events.
 	ThreadState *ThreadState
 }
 
@@ -252,7 +254,7 @@ func (s *Store) CreateIssueComments(ctx context.Context, creator string, creates
 			return nil, common.Errorf(common.Invalid, "replies must be created through CreateIssueCommentReply")
 		}
 		if create.ThreadState != nil {
-			return nil, common.Errorf(common.Invalid, "thread state is derived on create; a new root starts OPEN")
+			return nil, common.Errorf(common.Invalid, "thread state is derived on create; an anchored root starts OPEN")
 		}
 		if err := validateIssueCommentPayload(create.Payload); err != nil {
 			return nil, err
@@ -264,8 +266,10 @@ func (s *Store) CreateIssueComments(ctx context.Context, creator string, creates
 		projectIDs = append(projectIDs, create.ProjectID)
 		issueIDs = append(issueIDs, create.IssueUID)
 		payloads = append(payloads, payload)
-		// Event-less writes are roots. Event and hybrid rows remain outside threads.
-		threadRoots = append(threadRoots, create.Payload.GetEvent() == nil)
+		// An anchored comment starts a thread; validateIssueCommentPayload
+		// already rejects an anchor on an event. Plain comments, events, and
+		// hybrid rows remain outside threads.
+		threadRoots = append(threadRoots, create.Payload.GetStatementAnchor() != nil)
 	}
 
 	// Use UNNEST to insert all comments in one query.
@@ -320,9 +324,9 @@ func (s *Store) CreateIssueComments(ctx context.Context, creator string, creates
 // CreateIssueCommentReply creates a reply in the thread rooted at
 // create.ParentID and returns it with ResourceID, CreatedAt, and UpdatedAt
 // filled in. The insert-select pins every reply invariant in one statement:
-// the parent is a root comment (thread_state set, so never an event or a
-// reply) in the same project and issue, and replying never changes the
-// thread state. Like CreateIssueComments, it requires only the referenced
+// the parent is a thread root (thread_state set, so never a plain comment,
+// an event, or a reply) in the same project and issue, and replying never
+// changes the thread state. Like CreateIssueComments, it requires only the referenced
 // rows to exist, regardless of project lifecycle.
 func (s *Store) CreateIssueCommentReply(ctx context.Context, creator string, create *IssueCommentMessage) (*IssueCommentMessage, error) {
 	if create.ParentID == nil {
@@ -387,7 +391,7 @@ func (s *Store) replyTargetError(ctx context.Context, create *IssueCommentMessag
 		// concurrent write landed between the insert and this diagnosis.
 		return common.Errorf(common.Conflict, "comment %s changed concurrently; retry the reply", *create.ParentID)
 	default:
-		// Events, hybrid comment+event rows, and unclassified legacy rows
+		// Plain comments, events, hybrid comment+event rows, and legacy rows
 		// all carry NULL thread_state.
 		return common.Errorf(common.Invalid, "comment %s is not a thread root and cannot be replied to", *create.ParentID)
 	}
@@ -418,10 +422,11 @@ func (s *Store) UpdateIssueComment(ctx context.Context, patch *UpdateIssueCommen
 	if patch.ThreadState != nil {
 		q.And("thread_state IS NOT NULL")
 	}
-	// Text edits apply to rows that already render text: roots, replies, and
-	// hybrid event+comment rows — never to pure events.
+	// Text edits apply to rows that already render text: thread roots,
+	// replies, hybrid event+comment rows, and plain comments (protojson omits
+	// an empty comment, so a contentless one is {}) — never to pure events.
 	if patch.Comment != nil {
-		q.And("(payload ?? 'comment' OR thread_state IS NOT NULL OR parent_id IS NOT NULL)")
+		q.And("(payload ?? 'comment' OR payload = '{}'::jsonb OR thread_state IS NOT NULL OR parent_id IS NOT NULL)")
 	}
 
 	query, args, err := q.ToSQL()

--- a/backend/store/issue_comment_thread_test.go
+++ b/backend/store/issue_comment_thread_test.go
@@ -76,6 +76,16 @@ func TestIssueCommentThreads(t *testing.T) {
 	require.NotNil(t, root.ThreadState)
 	require.Equal(t, store.ThreadStateOpen, *root.ThreadState)
 
+	// An unanchored comment is a plain comment: no thread state, no replies.
+	plain, err := stores.CreateIssueComments(ctx, creator, &store.IssueCommentMessage{
+		ProjectID: projectID,
+		IssueUID:  issueUID,
+		Payload:   &storepb.IssueCommentPayload{Comment: "plain"},
+	})
+	require.NoError(t, err)
+	require.Nil(t, plain.ParentID)
+	require.Nil(t, plain.ThreadState, "an unanchored comment is not a thread root")
+
 	event, err := stores.CreateIssueComments(ctx, creator, &store.IssueCommentMessage{
 		ProjectID: projectID,
 		IssueUID:  issueUID,
@@ -121,6 +131,14 @@ func TestIssueCommentThreads(t *testing.T) {
 		Payload:   &storepb.IssueCommentPayload{Comment: "on event"},
 	})
 	require.Equal(t, common.Invalid, common.ErrorCode(err), "events cannot be replied to")
+
+	_, err = stores.CreateIssueCommentReply(ctx, creator, &store.IssueCommentMessage{
+		ProjectID: projectID,
+		IssueUID:  issueUID,
+		ParentID:  &plain.ResourceID,
+		Payload:   &storepb.IssueCommentPayload{Comment: "on plain"},
+	})
+	require.Equal(t, common.Invalid, common.ErrorCode(err), "plain comments cannot be replied to")
 
 	missing := "no-such-comment"
 	_, err = stores.CreateIssueCommentReply(ctx, creator, &store.IssueCommentMessage{
@@ -218,7 +236,7 @@ func TestIssueCommentThreads(t *testing.T) {
 		IssueUID:  &uid,
 	})
 	require.NoError(t, err)
-	require.Len(t, all, 3, "unfiltered list returns roots, events, and replies")
+	require.Len(t, all, 4, "unfiltered list returns roots, plain comments, events, and replies")
 
 	topLevel, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
 		ProjectID:    projectID,
@@ -226,7 +244,7 @@ func TestIssueCommentThreads(t *testing.T) {
 		TopLevelOnly: true,
 	})
 	require.NoError(t, err)
-	require.Len(t, topLevel, 2, "timeline entries are the root and the event")
+	require.Len(t, topLevel, 3, "timeline entries are the root, the plain comment, and the event")
 	for _, comment := range topLevel {
 		require.Nil(t, comment.ParentID)
 	}
@@ -356,6 +374,18 @@ func TestIssueCommentThreads(t *testing.T) {
 		ThreadState: &resolved,
 	})
 	require.Equal(t, common.NotFound, common.ErrorCode(err), "events carry no thread state")
+	err = stores.UpdateIssueComment(ctx, &store.UpdateIssueCommentMessage{
+		ProjectID:   projectID,
+		ResourceID:  plain.ResourceID,
+		ThreadState: &resolved,
+	})
+	require.Equal(t, common.NotFound, common.ErrorCode(err), "plain comments carry no thread state")
+	plainEdit := "plain (edited)"
+	require.NoError(t, stores.UpdateIssueComment(ctx, &store.UpdateIssueCommentMessage{
+		ProjectID:  projectID,
+		ResourceID: plain.ResourceID,
+		Comment:    &plainEdit,
+	}), "plain comments stay editable")
 
 	open := store.ThreadStateOpen
 	require.NoError(t, stores.UpdateIssueComment(ctx, &store.UpdateIssueCommentMessage{

--- a/backend/store/pagination_integration_test.go
+++ b/backend/store/pagination_integration_test.go
@@ -185,7 +185,7 @@ func TestIssueCommentBatchKeepsInsertionOrder(t *testing.T) {
 		SELECT count(*) FROM issue_comment
 		WHERE project = $1 AND issue_id = $2 AND thread_state = 'OPEN'
 	`, projectID, issueUID).Scan(&openRoots))
-	require.Equal(t, len(want), openRoots, "new comment-only rows must be OPEN roots")
+	require.Equal(t, 0, openRoots, "unanchored comments are plain comments, not thread roots")
 
 	_, err = stores.CreateIssueComments(ctx, "users/comment@example.com",
 		&store.IssueCommentMessage{
@@ -224,11 +224,11 @@ func TestIssueCommentBatchKeepsInsertionOrder(t *testing.T) {
 	`, projectID, issueUID).Scan(&eventsOutsideThreads))
 	require.Equal(t, 2, eventsOutsideThreads, "event and hybrid rows must stay outside threads")
 
-	var emptyRoots int
+	var emptyPlain int
 	require.NoError(t, db.QueryRowContext(ctx, `
 		SELECT count(*) FROM issue_comment
 		WHERE project = $1 AND issue_id = $2
-		  AND payload = '{}'::jsonb AND thread_state = 'OPEN'
-	`, projectID, issueUID).Scan(&emptyRoots))
-	require.Equal(t, 1, emptyRoots, "an event-less payload is still a root comment")
+		  AND payload = '{}'::jsonb AND parent_id IS NULL AND thread_state IS NULL
+	`, projectID, issueUID).Scan(&emptyPlain))
+	require.Equal(t, 1, emptyPlain, "an event-less, unanchored payload is a plain comment")
 }


### PR DESCRIPTION
## What

Only a root comment created with a statement anchor is a thread root (`thread_state = 'OPEN'`). An unanchored comment from the Review Activity composer stays a plain comment: no thread state, no replies, not resolvable — the same as today.

- Migration 3.23.1 (unreleased): backfill `UPDATE` removed in place, so no legacy comment becomes a thread root. Column comments updated in the migration and `LATEST.sql`.
- Store: `CreateIssueComments` sets `OPEN` when the payload carries a statement anchor instead of when it lacks an event. `UpdateIssueComment` also accepts a `{}` payload for text edits so a contentless plain comment stays editable.
- Tests: migration test asserts every legacy row stays stateless; store thread test adds a plain comment that has no state, rejects replies and resolve, and stays editable; pagination test asserts unanchored rows are plain; the v1 reply-exclusion test creates its anchored root through the store since v1 cannot set the anchor yet.

## Why

Follows GitHub, where conversation comments stay plain and only review comments are resolvable threads. `OPEN` then means unresolved review feedback, so unresolved counts and a future Approval gate need no exclusions, and existing comments do not change meaning on upgrade. A GitLab-style "Start thread" option can be added later: the schema does not tie `thread_state` to the anchor.

Design: [Plan Review Comment and Thread Model](https://docs.google.com/document/d/1nKJjF3YdMt_h65D6viVGmtW7XZJU8Bt_GX1X80lgBC4/edit), Thread Model alternative "Every Root Comment Is a Thread".

## Testing

- `go test ./backend/migrator/ -run 'TestLatestVersion|TestMigration3_23_1_IssueCommentThreads|TestVersionUnique'`
- `go test ./backend/store/ -run 'TestIssueCommentThreads|TestPaginationStabilityAcrossProjects'`
- `go test ./backend/api/v1/ -run TestListIssueCommentsExcludesReplies`
- `golangci-lint run` on the touched packages: 0 issues; full server build passes.

Not breaking: 3.23 has not shipped (latest tag 3.22.0), and `issue_comment` has a single-column primary key with every touched predicate already scoped by `project`.

BYT-9955
