### PR TITLE
fix(devbox): make runner re-registration survive a service restart

### DIFF
--- a/scripts/devbox/startup.sh
+++ b/scripts/devbox/startup.sh
@@ -168,7 +168,12 @@ TOKEN=$(curl -sfX POST -H "Authorization: Bearer $PAT" -H "Accept: application/v
   "https://api.github.com/orgs/${ORG}/actions/runners/registration-token" \
   | python3 -c 'import sys,json; print(json.load(sys.stdin)["token"])')
 cd "/scratch/$1/runner"
-rm -f .runner .credentials .credentials_rsakey   # config.sh refuses to overwrite an existing config
+# config.sh refuses to run over an existing config, and --replace only settles a name
+# collision on GitHub's side, not this check. Glob both families rather than naming
+# files: 2.337.0 migrated its config and left a .runner_migrated marker no name list
+# knew to clear, which turned every service restart into a 30s crash loop. A glob
+# cannot rot the same way. Nothing else in the tree starts with either prefix.
+rm -f .runner* .credentials*
 ./config.sh --unattended --replace --url "https://github.com/${ORG}" --token "$TOKEN" \
   --name "$(hostname -s)-$1" --work "/scratch/$1/work"   # host-qualified name: never collides with another box
 EOF


### PR DESCRIPTION
## What happened

At 06:21 UTC today `unattended-upgrades` (`apt-daily-upgrade.service`) restarted the four `actions-runner@` units on `devbox`. None of them came back. The whole self-hosted CI fleet was offline for ~45 minutes, all four units crash-looping every 30 seconds on:

```
Cannot configure the runner because it is already configured.
To reconfigure the runner, run 'config.cmd remove' or './config.sh remove' first.
```

## Why

`register-runner` cleared a hand-written list of config markers before calling `config.sh`:

```
rm -f .runner .credentials .credentials_rsakey
```

At 01:56 UTC the runner agent (v2.337.0) migrated its own config format and wrote a **new** marker, `.runner_migrated`. It isn't on that list, so `config.sh` still saw a configured runner and exited 1. That's an `ExecStartPre`, so the unit failed, `Restart=always` fired, and it looped forever.

The runners kept working for the 4.5 hours between the migration and the restart, because the marker only matters at re-registration. Any restart after 01:56 was unrecoverable.

`--replace` does not help here — it settles a *name collision on GitHub's side*, never the local "already configured" check.

## The fix

```diff
-rm -f .runner .credentials .credentials_rsakey
+rm -f .runner* .credentials*
```

A glob rather than an appended name, because the name list is precisely what rotted: it will break again the next time the runner invents a marker, and it breaks silently — as a 30-second crash loop, hours or days after the change that caused it. Nothing else in the runner tree starts with either prefix.

This also drops `.credentials_rsakey`, which has never existed. The real file is `.credentials_rsaparams`, so that `rm` has always been a no-op — the same class of bug, already latent.

## Testing

Applied end to end on the live box, not just committed:

- Confirmed the VM's `startup-script` metadata was byte-identical to the repo file first (no drift to clobber)
- Pushed the edited file via `add-metadata --metadata-from-file` and diffed the readback — matches
- **Rebooted the guest**, not stop/start: a stop discards the Local SSD, and `/scratch` came through intact at 88 G, so no runner re-download
- Startup script exited status 0; all four runners registered and reached `Listening for Jobs` one second later, `NRestarts=0`
- **Regression test:** ran `systemctl restart actions-runner@runner4` — the exact action that caused the outage — and it re-registered cleanly and returned to `Listening for Jobs`

## Not addressed here

`unattended-upgrades` still restarts these units on its nightly run. This fix makes that *survivable*, but a restart mid-job still kills that job — it killed a `golangci-lint` job on #21341 while I was testing. Excluding the units from the apt service sweep is a separate decision and a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)