### PR TITLE
perf(tests): share one Postgres across backend/store

### DIFF
--- a/backend/api/v1/audit_log_converter_test.go
+++ b/backend/api/v1/audit_log_converter_test.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+// The resource name is built from the payload's parent, not the row's
+// workspace. Split out of the retention test that moved to backend/store.
+func TestConvertToAuditLogsNamesRowsByPayloadParent(t *testing.T) {
+	logs := convertToAuditLogs([]*store.AuditLog{
+		{ResourceID: "after-cutoff", CreatedAt: time.Unix(2, 0), Payload: &storepb.AuditLog{Parent: "projects/project-a"}},
+		{ResourceID: "at-cutoff", CreatedAt: time.Unix(1, 0), Payload: &storepb.AuditLog{Parent: "projects/project-a"}},
+	})
+
+	var names []string
+	for _, l := range logs {
+		names = append(names, l.Name)
+	}
+	require.Equal(t, []string{
+		"projects/project-a/auditLogs/after-cutoff",
+		"projects/project-a/auditLogs/at-cutoff",
+	}, names)
+}

--- a/backend/api/v1/issue_service_test.go
+++ b/backend/api/v1/issue_service_test.go
@@ -2,12 +2,9 @@ package v1
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 	"slices"
-	"sync"
 	"testing"
-	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
@@ -110,107 +107,6 @@ func TestListIssueCommentsExcludesReplies(t *testing.T) {
 	require.Contains(t, names, rootName, "the thread root stays in the timeline")
 }
 
-func TestDraftLabelUpdateConflictsWithConcurrentSubmission(t *testing.T) {
-	ctx := issueServiceTestContext()
-	stores := setupIssueServiceTestStore(ctx, t)
-	service := newIssueServiceForTest(t, stores)
-	draft := createReadyDraftForUpdateTest(ctx, t, stores, service, "label submission race")
-
-	tx, err := stores.GetDB().BeginTx(ctx, nil)
-	require.NoError(t, err)
-	defer tx.Rollback()
-	var lockedUID int64
-	require.NoError(t, tx.QueryRowContext(ctx, `
-		SELECT id FROM issue
-		WHERE project = $1 AND id = $2
-		FOR UPDATE`, draft.ProjectID, draft.UID).Scan(&lockedUID))
-
-	updateResult := make(chan error, 1)
-	go func() {
-		_, err := service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
-			Issue: &v1pb.Issue{
-				Name: common.FormatIssue(draft.ProjectID, draft.UID), Labels: []string{"environment:staging"},
-			},
-			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"labels"}},
-		}))
-		updateResult <- err
-	}()
-	waitForTransactionBlock(ctx, t, stores.GetDB(), tx)
-	_, err = tx.ExecContext(ctx, `
-		UPDATE issue
-		SET payload = payload || jsonb_build_object('draft', false)
-		WHERE project = $1 AND id = $2`, draft.ProjectID, draft.UID)
-	require.NoError(t, err)
-	require.NoError(t, tx.Commit())
-
-	select {
-	case err := <-updateResult:
-		require.Equal(t, connect.CodeAborted, connect.CodeOf(err))
-	case <-time.After(5 * time.Second):
-		t.Fatal("draft label update did not return")
-	}
-	stored := getIssueForTest(ctx, t, stores, draft.UID)
-	require.False(t, stored.Payload.GetDraft())
-	require.Equal(t, []string{"team:database"}, stored.Payload.GetLabels())
-	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
-		ProjectID: draft.ProjectID, IssueUID: &draft.UID,
-	})
-	require.NoError(t, err)
-	require.Empty(t, comments)
-	require.Empty(t, service.bus.ApprovalCheckChan)
-}
-
-func TestConcurrentSubmissionWithLabelsWritesOneAuditComment(t *testing.T) {
-	ctx := issueServiceTestContext()
-	stores := setupIssueServiceTestStore(ctx, t)
-	service := newIssueServiceForTest(t, stores)
-	draft := createReadyDraftForUpdateTest(ctx, t, stores, service, "concurrent labels")
-
-	type outcome struct {
-		response *connect.Response[v1pb.Issue]
-		err      error
-	}
-	start := make(chan struct{})
-	results := make(chan outcome, 2)
-	var wg sync.WaitGroup
-	for range 2 {
-		wg.Go(func() {
-			<-start
-			response, err := service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
-				Issue: &v1pb.Issue{
-					Name: common.FormatIssue(draft.ProjectID, draft.UID), Labels: []string{"environment:prod"},
-				},
-				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"labels", "draft"}},
-			}))
-			results <- outcome{response: response, err: err}
-		})
-	}
-	close(start)
-	wg.Wait()
-	close(results)
-	for result := range results {
-		require.NoError(t, result.err)
-		require.False(t, result.response.Msg.GetDraft())
-	}
-	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
-		ProjectID: draft.ProjectID, IssueUID: &draft.UID,
-	})
-	require.NoError(t, err)
-	var labelUpdates, submissions int
-	for _, comment := range comments {
-		switch comment.Payload.Event.(type) {
-		case *storepb.IssueCommentPayload_IssueUpdate_:
-			labelUpdates++
-		case *storepb.IssueCommentPayload_ReviewSubmission_:
-			submissions++
-		default:
-		}
-	}
-	require.Equal(t, 1, labelUpdates)
-	require.Equal(t, 1, submissions)
-	require.Len(t, service.bus.ApprovalCheckChan, 1)
-}
-
 func TestUpdateIssueLabelsResetsApprovalBeforeRollout(t *testing.T) {
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)
@@ -263,118 +159,6 @@ func TestUpdateIssueLabelsDoesNotResetApprovalAfterRollout(t *testing.T) {
 	require.True(t, got.Payload.GetApproval().GetApprovalFindingDone())
 	require.EqualValues(t, 2, got.Payload.GetApproval().GetApprovalInputVersion())
 	require.Len(t, service.bus.ApprovalCheckChan, 0)
-}
-
-func TestConcurrentIdenticalLabelUpdatesCreateOneAuditComment(t *testing.T) {
-	ctx := issueServiceTestContext()
-	stores := setupIssueServiceTestStore(ctx, t)
-	service := newIssueServiceForTest(t, stores)
-	_, issue := createIssueServiceApprovalIssue(ctx, t, stores)
-
-	for i := range 10 {
-		labels := []string{fmt.Sprintf("iteration:%d", i)}
-		start := make(chan struct{})
-		errs := make(chan error, 2)
-		var wg sync.WaitGroup
-		for range 2 {
-			wg.Go(func() {
-				<-start
-				_, err := service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
-					Issue: &v1pb.Issue{
-						Name:   common.FormatIssue(issue.ProjectID, issue.UID),
-						Labels: labels,
-					},
-					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"labels"}},
-				}))
-				errs <- err
-			})
-		}
-		close(start)
-		wg.Wait()
-		close(errs)
-		for err := range errs {
-			require.NoError(t, err)
-		}
-	}
-
-	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
-		ProjectID: "project-a",
-		IssueUID:  &issue.UID,
-	})
-	require.NoError(t, err)
-	require.Len(t, comments, 10)
-}
-
-func TestConcurrentIdenticalTitleUpdatesCreateOneAuditComment(t *testing.T) {
-	ctx := issueServiceTestContext()
-	stores := setupIssueServiceTestStore(ctx, t)
-	service := newIssueServiceForTest(t, stores)
-	_, issue := createIssueServiceApprovalIssue(ctx, t, stores)
-	start := make(chan struct{})
-	errs := make(chan error, 2)
-	var wg sync.WaitGroup
-	for range 2 {
-		wg.Go(func() {
-			<-start
-			_, err := service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
-				Issue: &v1pb.Issue{
-					Name:  common.FormatIssue(issue.ProjectID, issue.UID),
-					Title: "renamed issue",
-				},
-				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"title"}},
-			}))
-			errs <- err
-		})
-	}
-	close(start)
-	wg.Wait()
-	close(errs)
-	for err := range errs {
-		require.NoError(t, err)
-	}
-
-	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
-		ProjectID: issue.ProjectID,
-		IssueUID:  &issue.UID,
-	})
-	require.NoError(t, err)
-	require.Len(t, comments, 1)
-	update := comments[0].Payload.GetIssueUpdate()
-	require.Equal(t, "issue-a", update.GetFromTitle())
-	require.Equal(t, "renamed issue", update.GetToTitle())
-}
-
-func TestMixedIssuePatchRollsBackWhenLabelsFail(t *testing.T) {
-	ctx := issueServiceTestContext()
-	stores := setupIssueServiceTestStore(ctx, t)
-	service := newIssueServiceForTest(t, stores)
-	_, issue := createIssueServiceApprovalIssue(ctx, t, stores)
-	_, err := stores.GetDB().ExecContext(ctx, `
-		ALTER TABLE issue ADD CONSTRAINT reject_atomic_test_label
-		CHECK (NOT COALESCE(payload->'labels' ? 'reject', false))`)
-	require.NoError(t, err)
-
-	_, err = service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
-		Issue: &v1pb.Issue{
-			Name:        common.FormatIssue(issue.ProjectID, issue.UID),
-			Title:       "renamed issue",
-			Description: "updated description",
-			Labels:      []string{"reject"},
-		},
-		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"title", "description", "labels"}},
-	}))
-	require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
-
-	got := getIssueForTest(ctx, t, stores, issue.UID)
-	require.Equal(t, "issue-a", got.Title)
-	require.Empty(t, got.Description)
-	require.Equal(t, []string{"environment:prod"}, got.Payload.GetLabels())
-	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
-		ProjectID: issue.ProjectID,
-		IssueUID:  &issue.UID,
-	})
-	require.NoError(t, err)
-	require.Empty(t, comments)
 }
 
 func TestMixedIssuePatchCommitsWithAuditComments(t *testing.T) {
@@ -608,81 +392,6 @@ func TestCreateRolloutAndPendingTasksRejectsPersistedDraftWithStaleIssueSnapshot
 	gotIssue := getIssueForTest(ctx, t, stores, draft.UID)
 	require.Equal(t, storepb.Issue_OPEN, gotIssue.Status)
 	require.True(t, gotIssue.Payload.GetDraft())
-}
-
-func TestCreateDraftAndRolloutAreSerialized(t *testing.T) {
-	ctx := issueServiceTestContext()
-	stores := setupIssueServiceTestStore(ctx, t)
-	service := newIssueServiceForTest(t, stores)
-
-	for i := range 10 {
-		t.Run(fmt.Sprintf("attempt-%d", i), func(t *testing.T) {
-			plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
-				ProjectID: "project-a",
-				Name:      "draft rollout race",
-				Config: &storepb.PlanConfig{
-					Specs: []*storepb.PlanConfig_Spec{{
-						Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
-							ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
-								SheetSha256: "sheet",
-							},
-						},
-					}},
-				},
-			}, "creator@example.com")
-			require.NoError(t, err)
-
-			start := make(chan struct{})
-			draftResult := make(chan error, 1)
-			rolloutResult := make(chan error, 1)
-			go func() {
-				<-start
-				_, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
-					Parent: "projects/project-a",
-					Issue: &v1pb.Issue{
-						Type:  v1pb.Issue_DATABASE_CHANGE,
-						Plan:  common.FormatPlan("project-a", plan.UID),
-						Draft: true,
-					},
-				}))
-				draftResult <- err
-			}()
-			go func() {
-				<-start
-				rolloutResult <- CreateRolloutAndPendingTasks(ctx, stores, "creator@example.com", plan, nil, &store.ProjectMessage{
-					ResourceID: "project-a",
-					Setting:    &storepb.Project{RequireIssueApproval: false},
-				}, []*store.TaskMessage{})
-			}()
-			close(start)
-			draftErr := <-draftResult
-			rolloutErr := <-rolloutResult
-
-			require.NotEqual(t, draftErr == nil, rolloutErr == nil)
-			if draftErr == nil {
-				require.ErrorIs(t, rolloutErr, errDraftIssueNotSubmitted)
-			} else {
-				require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(draftErr))
-				require.NoError(t, rolloutErr)
-			}
-
-			gotPlan, err := stores.GetPlan(ctx, &store.FindPlanMessage{
-				ProjectID: "project-a",
-				UID:       &plan.UID,
-			})
-			require.NoError(t, err)
-			linkedIssue, err := stores.GetIssue(ctx, &store.FindIssueMessage{
-				ProjectIDs: []string{"project-a"},
-				PlanUID:    &plan.UID,
-			})
-			require.NoError(t, err)
-			require.NotEqual(t, gotPlan.Config.GetHasRollout(), linkedIssue != nil)
-			if linkedIssue != nil {
-				require.True(t, linkedIssue.Payload.GetDraft())
-				require.Equal(t, storepb.Issue_OPEN, linkedIssue.Status)
-			}
-		})
-	}
 }
 
 func TestCreateDraftIssueRejectedAfterRollout(t *testing.T) {
@@ -990,131 +699,6 @@ func TestCreateDraftIssue(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	require.True(t, createDatabaseDraft.Msg.GetDraft())
-}
-
-func TestCreateDraftIssueIsIdempotent(t *testing.T) {
-	ctx := issueServiceTestContext()
-	stores := setupIssueServiceTestStore(ctx, t)
-	b, err := bus.New()
-	require.NoError(t, err)
-	service := NewIssueService(stores, nil, b, nil, nil)
-
-	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
-		ProjectID: "project-a",
-		Name:      "idempotent draft plan",
-		Config: &storepb.PlanConfig{
-			Specs: []*storepb.PlanConfig_Spec{
-				{
-					Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
-						ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
-							SheetSha256: "sheet",
-						},
-					},
-				},
-			},
-		},
-	}, "creator@example.com")
-	require.NoError(t, err)
-
-	first, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
-		Parent: "projects/project-a",
-		Issue: &v1pb.Issue{
-			Title:       "original title",
-			Description: "original description",
-			Type:        v1pb.Issue_DATABASE_CHANGE,
-			Plan:        common.FormatPlan("project-a", plan.UID),
-			Labels:      []string{"original"},
-			Draft:       true,
-		},
-	}))
-	require.NoError(t, err)
-
-	second, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
-		Parent: "projects/project-a",
-		Issue: &v1pb.Issue{
-			Title:       "replacement title",
-			Description: "replacement description",
-			Type:        v1pb.Issue_DATABASE_CHANGE,
-			Plan:        common.FormatPlan("project-a", plan.UID),
-			Labels:      []string{"replacement"},
-			Draft:       true,
-		},
-	}))
-	require.NoError(t, err)
-	require.Equal(t, first.Msg, second.Msg)
-	require.Empty(t, b.ApprovalCheckChan)
-
-	issues, err := stores.ListIssues(ctx, &store.FindIssueMessage{
-		ProjectIDs: []string{"project-a"},
-		PlanUID:    &plan.UID,
-	})
-	require.NoError(t, err)
-	require.Len(t, issues, 1)
-	require.Equal(t, plan.Name, issues[0].Title)
-	require.Equal(t, plan.Description, issues[0].Description)
-	require.Equal(t, []string{"original"}, issues[0].Payload.GetLabels())
-
-	concurrentPlan, err := stores.CreatePlan(ctx, &store.PlanMessage{
-		ProjectID: "project-a",
-		Name:      "concurrent draft plan",
-		Config: &storepb.PlanConfig{
-			Specs: []*storepb.PlanConfig_Spec{
-				{
-					Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
-						ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
-							SheetSha256: "sheet",
-						},
-					},
-				},
-			},
-		},
-	}, "creator@example.com")
-	require.NoError(t, err)
-
-	type createResult struct {
-		response *connect.Response[v1pb.Issue]
-		err      error
-	}
-	start := make(chan struct{})
-	results := make(chan createResult, 2)
-	var waitGroup sync.WaitGroup
-	for _, title := range []string{"first concurrent title", "second concurrent title"} {
-		waitGroup.Add(1)
-		go func() {
-			defer waitGroup.Done()
-			<-start
-			response, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
-				Parent: "projects/project-a",
-				Issue: &v1pb.Issue{
-					Title: title,
-					Type:  v1pb.Issue_DATABASE_CHANGE,
-					Plan:  common.FormatPlan("project-a", concurrentPlan.UID),
-					Draft: true,
-				},
-			}))
-			results <- createResult{response: response, err: err}
-		}()
-	}
-	close(start)
-	waitGroup.Wait()
-	close(results)
-
-	var concurrentIssueName string
-	for result := range results {
-		require.NoError(t, result.err)
-		require.NotNil(t, result.response)
-		if concurrentIssueName == "" {
-			concurrentIssueName = result.response.Msg.GetName()
-		} else {
-			require.Equal(t, concurrentIssueName, result.response.Msg.GetName())
-		}
-	}
-	concurrentIssues, err := stores.ListIssues(ctx, &store.FindIssueMessage{
-		ProjectIDs: []string{"project-a"},
-		PlanUID:    &concurrentPlan.UID,
-	})
-	require.NoError(t, err)
-	require.Len(t, concurrentIssues, 1)
 }
 
 func TestCreateDraftIssueDoesNotExposeAnotherCreatorsDraft(t *testing.T) {
@@ -1465,6 +1049,10 @@ func TestIssueListsHideDraftIssues(t *testing.T) {
 	require.True(t, direct.Msg.GetDraft())
 }
 
+// The fixture helpers below are duplicated in
+// backend/store/issue_service_concurrency_test.go, which needs its own copies
+// for the concurrency tests that moved there. Change both together: nothing
+// catches a divergence. The duplication ends when the tests here move to a fake.
 func issueNames(issues []*v1pb.Issue) []string {
 	names := make([]string, 0, len(issues))
 	for _, issue := range issues {
@@ -1655,74 +1243,6 @@ func getIssueForTest(ctx context.Context, t *testing.T, stores *store.Store, iss
 	return got
 }
 
-func createReadyDraftForUpdateTest(
-	ctx context.Context,
-	t *testing.T,
-	stores *store.Store,
-	service *IssueService,
-	title string,
-) *store.IssueMessage {
-	t.Helper()
-	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
-		ProjectID: "project-a", Name: title,
-		Config: &storepb.PlanConfig{Specs: []*storepb.PlanConfig_Spec{{
-			Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
-				ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
-					Targets: []string{"instances/prod/databases/app"}, SheetSha256: "sheet",
-				},
-			},
-		}}},
-	}, "creator@example.com")
-	require.NoError(t, err)
-	response, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
-		Parent: "projects/project-a",
-		Issue: &v1pb.Issue{
-			Type: v1pb.Issue_DATABASE_CHANGE, Plan: common.FormatPlan("project-a", plan.UID),
-			Labels: []string{"team:database"}, Draft: true,
-		},
-	}))
-	require.NoError(t, err)
-	_, issueUID, err := common.GetProjectIDIssueUID(response.Msg.GetName())
-	require.NoError(t, err)
-	created, err := stores.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
-		ProjectID: plan.ProjectID, PlanUID: plan.UID,
-		Result: &storepb.PlanCheckRunResult{ApprovalInputVersion: plan.Config.GetApprovalInputVersion()},
-	})
-	require.NoError(t, err)
-	require.True(t, created)
-	run, err := stores.GetPlanCheckRun(ctx, plan.ProjectID, plan.UID)
-	require.NoError(t, err)
-	require.NoError(t, stores.UpdatePlanCheckRun(ctx, plan.ProjectID, store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
-		ApprovalInputVersion: plan.Config.GetApprovalInputVersion(),
-		Results: []*storepb.PlanCheckRunResult_Result{{
-			Type: storepb.PlanCheckType_PLAN_CHECK_TYPE_STATEMENT_ADVISE, Status: storepb.Advice_SUCCESS,
-		}},
-	}, run.UID))
-	return getIssueForTest(ctx, t, stores, issueUID)
-}
-
-func waitForTransactionBlock(ctx context.Context, t *testing.T, db *sql.DB, tx *sql.Tx) {
-	t.Helper()
-	var blockerPID int
-	require.NoError(t, tx.QueryRowContext(ctx, "SELECT pg_backend_pid()").Scan(&blockerPID))
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		var waiting int
-		require.NoError(t, db.QueryRowContext(ctx, `
-			SELECT count(*)
-			FROM pg_stat_activity AS activity
-			WHERE activity.pid <> pg_backend_pid()
-			  AND $1 = ANY(pg_blocking_pids(activity.pid))`, blockerPID).Scan(&waiting))
-		if waiting >= 1 {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("timed out waiting for a session blocked by transaction PID %d", blockerPID)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-}
-
 func createIssueWithApproval(ctx context.Context, t *testing.T, stores *store.Store, title string, approval *storepb.IssuePayloadApproval) *store.IssueMessage {
 	t.Helper()
 
@@ -1761,56 +1281,6 @@ func issueApprover(status storepb.IssuePayloadApproval_Approver_Status) *storepb
 // page after the store had already cut it and minted the page token, so
 // filtering the default My Issues view answered with an empty page and a live
 // next page token underneath it.
-func TestIssueApprovalFiltersRunBeforePaging(t *testing.T) {
-	ctx := issueServiceTestContext()
-	stores := setupIssueServiceTestStore(ctx, t)
-	service := newIssueServiceForTest(t, stores)
-
-	// Created first, so the default id DESC ordering puts it behind both
-	// non-matching issues. With page size 1 the pre-fix code read the two
-	// non-matching rows, minted a token, and then dropped every row it had.
-	waiting := createIssueWithApproval(ctx, t, stores, "waiting on the caller", &storepb.IssuePayloadApproval{
-		ApprovalTemplate:    approvalTemplateWithRoles("roles/workspaceAdmin"),
-		ApprovalFindingDone: true,
-	})
-	createIssueWithApproval(ctx, t, stores, "already approved", &storepb.IssuePayloadApproval{
-		ApprovalTemplate:    approvalTemplateWithRoles("roles/workspaceAdmin"),
-		Approvers:           []*storepb.IssuePayloadApproval_Approver{issueApprover(storepb.IssuePayloadApproval_Approver_APPROVED)},
-		ApprovalFindingDone: true,
-	})
-	// The caller holds roles/workspaceAdmin, not roles/projectOwner, so this one
-	// is pending but waiting on somebody else.
-	createIssueWithApproval(ctx, t, stores, "waiting on another role", &storepb.IssuePayloadApproval{
-		ApprovalTemplate:    approvalTemplateWithRoles("roles/projectOwner"),
-		ApprovalFindingDone: true,
-	})
-
-	const filter = `approval_status == "PENDING" && current_approver == "users/creator@example.com"`
-	want := []string{common.FormatIssue("project-a", waiting.UID)}
-
-	list, err := service.ListIssues(ctx, connect.NewRequest(&v1pb.ListIssuesRequest{
-		Parent:   "projects/project-a",
-		Filter:   filter,
-		PageSize: 1,
-	}))
-	require.NoError(t, err)
-	require.Equal(t, want, issueNames(list.Msg.Issues))
-	require.Empty(t, list.Msg.GetNextPageToken())
-
-	search, err := service.SearchIssues(ctx, connect.NewRequest(&v1pb.SearchIssuesRequest{
-		Parent:   "projects/project-a",
-		Filter:   filter,
-		PageSize: 1,
-	}))
-	require.NoError(t, err)
-	require.Equal(t, want, issueNames(search.Msg.Issues))
-	require.Empty(t, search.Msg.GetNextPageToken())
-}
-
-// TestIssueApprovalStatusFilterMatchesConverter pins the SQL derivation of
-// approval_status to computeApprovalStatus. They are two implementations of one
-// rule, and the SQL side has to read an absent JSON key as a zero value because
-// payloads are written with a bare protojson.Marshal.
 func TestIssueApprovalStatusFilterMatchesConverter(t *testing.T) {
 	ctx := issueServiceTestContext()
 	stores := setupIssueServiceTestStore(ctx, t)

--- a/backend/store/advisory_lock_test.go
+++ b/backend/store/advisory_lock_test.go
@@ -6,16 +6,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
 func TestTryAdvisoryXactLockWithStringKeyScopesByKey(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-
-	db := container.GetDB()
+	db, _, _ := newTestDB(t)
 	tx1, err := db.BeginTx(ctx, nil)
 	require.NoError(t, err)
 	defer tx1.Rollback()

--- a/backend/store/audit_log_mcp_filter_test.go
+++ b/backend/store/audit_log_mcp_filter_test.go
@@ -2,14 +2,11 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
@@ -28,20 +25,9 @@ import (
 // rather than a query.
 func TestSearchAuditLogsMCPFilters(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, _ := newTestDB(t)
 
 	_, err := db.ExecContext(ctx, `INSERT INTO workspace (resource_id) VALUES ('ws-test')`)
-	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
 	require.NoError(t, err)
 
 	rows := []*storepb.AuditLog{

--- a/backend/store/audit_log_retention_test.go
+++ b/backend/store/audit_log_retention_test.go
@@ -1,4 +1,4 @@
-package v1
+package store_test
 
 import (
 	"context"
@@ -14,12 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 
+	apiv1 "github.com/bytebase/bytebase/backend/api/v1"
 	"github.com/bytebase/bytebase/backend/common"
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	"github.com/bytebase/bytebase/backend/enterprise"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -36,13 +35,9 @@ const (
 //   - ENTERPRISE: unlimited retention, so rows older than the cutoff remain
 //     visible.
 //
-// The license service is constructed normally (NewLicenseService with the
-// embedded dev public key) and then given a test-only RSA keypair so the test
-// can mint a license for each plan. The license is stored in the SYSTEM
-// setting and loaded through the real subscription path, so the feature gate,
-// retention cutoff, filter application, and SQL execution are all exercised.
-// The keypair swap uses the same reflect/unsafe access to the unexported
-// config field as backend/tests/sql_query_data_source_test.go.
+// The license is minted with a test keypair and stored through the real
+// subscription path, so the feature gate, retention cutoff, filter application
+// and SQL execution are all exercised.
 func TestAuditLogRetentionFilteringEndToEnd(t *testing.T) {
 	ctx, stores, licenseService := setupAuditLogRetentionTest(t)
 
@@ -52,7 +47,7 @@ func TestAuditLogRetentionFilteringEndToEnd(t *testing.T) {
 	seedAuditLog(ctx, t, stores, "old-log", oldLogTime)
 	seedAuditLog(ctx, t, stores, "new-log", newLogTime)
 
-	service := NewAuditLogService(stores, licenseService)
+	service := apiv1.NewAuditLogService(stores, licenseService)
 
 	t.Run("FREE plan has no audit log access", func(t *testing.T) {
 		setAuditLogLicense(ctx, t, stores, licenseService, v1pb.PlanType_FREE)
@@ -97,10 +92,8 @@ func TestAuditLogRetentionFilteringEndToEnd(t *testing.T) {
 }
 
 // TestAuditLogRetentionFilterIncludesExactCutoffRow pins the >= boundary of
-// ApplyRetentionFilter against real PostgreSQL rows: a row created exactly at
-// the cutoff is retained and a row one microsecond earlier is dropped. This
-// exercises the same filter wiring SearchAuditLogs uses (ApplyRetentionFilter
-// feeding store.SearchAuditLogs) with a fixed, deterministic cutoff.
+// ApplyRetentionFilter against real rows: a row created exactly at the cutoff
+// is retained and a row one microsecond earlier is dropped.
 func TestAuditLogRetentionFilterIncludesExactCutoffRow(t *testing.T) {
 	ctx, stores, _ := setupAuditLogRetentionTest(t)
 
@@ -120,33 +113,15 @@ func TestAuditLogRetentionFilterIncludesExactCutoffRow(t *testing.T) {
 		resourceIDs = append(resourceIDs, l.ResourceID)
 	}
 	require.Equal(t, []string{"after-cutoff", "at-cutoff"}, resourceIDs)
-
-	var names []string
-	for _, l := range convertToAuditLogs(logs) {
-		names = append(names, l.Name)
-	}
-	require.Equal(t, []string{
-		fmt.Sprintf("%s/%s%s", testAuditLogParent, common.AuditLogPrefix, "after-cutoff"),
-		fmt.Sprintf("%s/%s%s", testAuditLogParent, common.AuditLogPrefix, "at-cutoff"),
-	}, names)
 }
 
 func setupAuditLogRetentionTest(t *testing.T) (context.Context, *store.Store, *enterprise.LicenseService) {
 	t.Helper()
 	ctx := context.WithValue(context.Background(), common.WorkspaceIDContextKey, testAuditLogWorkspace)
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	_, stores, _ := newTestDB(t)
 
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
-	_, err := db.ExecContext(ctx, `INSERT INTO workspace (resource_id) VALUES ('default')`)
+	_, err := stores.GetDB().ExecContext(ctx, `INSERT INTO workspace (resource_id) VALUES ('default')`)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf("host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort())
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
 
 	// The SYSTEM setting must exist before UpdateLicense can write the license.
 	_, err = stores.UpsertSetting(ctx, &store.SettingMessage{
@@ -162,11 +137,10 @@ func setupAuditLogRetentionTest(t *testing.T) (context.Context, *store.Store, *e
 	return ctx, stores, licenseService
 }
 
-// installTestLicenseKeypair replaces the license service's embedded dev public
-// key with a test-only RSA keypair so the test can mint a license for any
-// plan. The private key matching the embedded dev public key is not checked
-// in, and the LicenseService config field is unexported, so this uses the same
-// reflect/unsafe access as backend/tests/sql_query_data_source_test.go.
+// installTestLicenseKeypair replaces the embedded dev public key with a
+// test-only keypair so the test can mint a license for any plan. The matching
+// private key is not checked in and the config field is unexported, hence the
+// reflect/unsafe access.
 func installTestLicenseKeypair(t *testing.T, licenseService *enterprise.LicenseService) {
 	t.Helper()
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -179,10 +153,8 @@ func installTestLicenseKeypair(t *testing.T, licenseService *enterprise.LicenseS
 	config.PublicKey = &privateKey.PublicKey
 }
 
-// setAuditLogLicense signs a license for the given plan with the test keypair,
-// stores it through the real subscription setting, and invalidates the
-// subscription cache so the next SearchAuditLogs call reloads it from the
-// database.
+// setAuditLogLicense signs a license for the plan, stores it through the real
+// subscription setting, and drops the cache so the next call reloads it.
 func setAuditLogLicense(ctx context.Context, t *testing.T, stores *store.Store, licenseService *enterprise.LicenseService, plan v1pb.PlanType) {
 	t.Helper()
 	token, err := licenseService.CreateLicense(&enterprise.LicenseParams{
@@ -196,8 +168,7 @@ func setAuditLogLicense(ctx context.Context, t *testing.T, stores *store.Store, 
 	licenseService.InvalidateCache(testAuditLogWorkspace)
 }
 
-// seedAuditLog inserts an audit_log row directly with a controlled created_at
-// and a canonical project-scoped payload.
+// seedAuditLog inserts a row directly with a controlled created_at.
 func seedAuditLog(ctx context.Context, t *testing.T, stores *store.Store, resourceID string, createdAt time.Time) {
 	t.Helper()
 	payload, err := protojson.Marshal(&storepb.AuditLog{

--- a/backend/store/instance_project_test.go
+++ b/backend/store/instance_project_test.go
@@ -3,15 +3,12 @@ package store_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -19,10 +16,7 @@ func newInstanceProjectFixture(t *testing.T) (context.Context, *sql.DB, *store.S
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(context.Background()) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, _ := newTestDB(t)
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('default');
 		INSERT INTO project (resource_id, workspace, name, deleted) VALUES
@@ -31,13 +25,6 @@ func newInstanceProjectFixture(t *testing.T) (context.Context, *sql.DB, *store.S
 			('deleted-project', 'default', 'Deleted Project', TRUE);
 	`)
 	require.NoError(t, err)
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	return ctx, db, s
 }
 

--- a/backend/store/issue_comment_thread_test.go
+++ b/backend/store/issue_comment_thread_test.go
@@ -2,15 +2,12 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/bytebase/bytebase/backend/common"
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
@@ -30,10 +27,7 @@ func TestIssueCommentThreads(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, stores, _ := newTestDB(t)
 
 	_, err := db.ExecContext(ctx,
 		`INSERT INTO workspace (resource_id) VALUES ($1)`, workspaceID)
@@ -51,14 +45,6 @@ func TestIssueCommentThreads(t *testing.T) {
 			id, projectID, creator)
 		require.NoError(t, err)
 	}
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
 
 	anchor := &storepb.IssueCommentPayload_StatementAnchor{
 		SpecId:        "spec-1",

--- a/backend/store/issue_list_filter_integration_test.go
+++ b/backend/store/issue_list_filter_integration_test.go
@@ -2,14 +2,11 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
@@ -25,24 +22,13 @@ import (
 //     "<", excluding an issue at the exact boundary.
 func TestIssueListFilterEdgeCases(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, stores, _ := newTestDB(t)
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('default');
 		INSERT INTO principal (name, email, password_hash) VALUES ('c', 'c@example.com', 'x');
 		INSERT INTO project (resource_id, workspace, name) VALUES ('p1', 'default', 'P1'), ('p2', 'default', 'P2');
 	`)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
 
 	createIn := func(projectID, title string, approval *storepb.IssuePayloadApproval) *store.IssueMessage {
 		plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
@@ -104,24 +90,13 @@ func TestIssueListFilterEdgeCases(t *testing.T) {
 // assertion in this file and fails this one.
 func TestIssueListNextApproverIsProjectScoped(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, stores, _ := newTestDB(t)
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('default');
 		INSERT INTO principal (name, email, password_hash) VALUES ('c', 'c@example.com', 'x');
 		INSERT INTO project (resource_id, workspace, name) VALUES ('p1', 'default', 'P1'), ('p2', 'default', 'P2');
 	`)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
 
 	waiting := &storepb.IssuePayloadApproval{
 		ApprovalTemplate:    &storepb.ApprovalTemplate{Flow: &storepb.ApprovalFlow{Roles: []string{"roles/projectOwner"}}},

--- a/backend/store/issue_service_concurrency_test.go
+++ b/backend/store/issue_service_concurrency_test.go
@@ -1,0 +1,718 @@
+package store_test
+
+// Concurrency, transaction and pagination tests for the issue service. They
+// assert SQL behavior — serialization, rollback, claim ordering, page
+// boundaries — so they live here rather than in backend/api/v1, which may not
+// hold a real metadata Postgres.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	apiv1 "github.com/bytebase/bytebase/backend/api/v1"
+	"github.com/bytebase/bytebase/backend/common"
+	"github.com/bytebase/bytebase/backend/component/bus"
+	"github.com/bytebase/bytebase/backend/component/iam"
+	"github.com/bytebase/bytebase/backend/component/webhook"
+	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+func TestDraftLabelUpdateConflictsWithConcurrentSubmission(t *testing.T) {
+	ctx := issueServiceTestContext()
+	stores := setupIssueServiceTestStore(ctx, t)
+	service, issueBus := newIssueServiceForTest(t, stores)
+	draft := createReadyDraftForUpdateTest(ctx, t, stores, service, "label submission race")
+
+	tx, err := stores.GetDB().BeginTx(ctx, nil)
+	require.NoError(t, err)
+	defer tx.Rollback()
+	var lockedUID int64
+	require.NoError(t, tx.QueryRowContext(ctx, `
+		SELECT id FROM issue
+		WHERE project = $1 AND id = $2
+		FOR UPDATE`, draft.ProjectID, draft.UID).Scan(&lockedUID))
+
+	updateResult := make(chan error, 1)
+	go func() {
+		_, err := service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
+			Issue: &v1pb.Issue{
+				Name: common.FormatIssue(draft.ProjectID, draft.UID), Labels: []string{"environment:staging"},
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"labels"}},
+		}))
+		updateResult <- err
+	}()
+	waitForTransactionBlock(ctx, t, stores.GetDB(), tx)
+	_, err = tx.ExecContext(ctx, `
+		UPDATE issue
+		SET payload = payload || jsonb_build_object('draft', false)
+		WHERE project = $1 AND id = $2`, draft.ProjectID, draft.UID)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	select {
+	case err := <-updateResult:
+		require.Equal(t, connect.CodeAborted, connect.CodeOf(err))
+	case <-time.After(5 * time.Second):
+		t.Fatal("draft label update did not return")
+	}
+	stored := getIssueForTest(ctx, t, stores, draft.UID)
+	require.False(t, stored.Payload.GetDraft())
+	require.Equal(t, []string{"team:database"}, stored.Payload.GetLabels())
+	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
+		ProjectID: draft.ProjectID, IssueUID: &draft.UID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, comments)
+	require.Empty(t, issueBus.ApprovalCheckChan)
+}
+
+func TestConcurrentSubmissionWithLabelsWritesOneAuditComment(t *testing.T) {
+	ctx := issueServiceTestContext()
+	stores := setupIssueServiceTestStore(ctx, t)
+	service, issueBus := newIssueServiceForTest(t, stores)
+	draft := createReadyDraftForUpdateTest(ctx, t, stores, service, "concurrent labels")
+
+	type outcome struct {
+		response *connect.Response[v1pb.Issue]
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan outcome, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			<-start
+			response, err := service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
+				Issue: &v1pb.Issue{
+					Name: common.FormatIssue(draft.ProjectID, draft.UID), Labels: []string{"environment:prod"},
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"labels", "draft"}},
+			}))
+			results <- outcome{response: response, err: err}
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+	for result := range results {
+		require.NoError(t, result.err)
+		require.False(t, result.response.Msg.GetDraft())
+	}
+	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
+		ProjectID: draft.ProjectID, IssueUID: &draft.UID,
+	})
+	require.NoError(t, err)
+	var labelUpdates, submissions int
+	for _, comment := range comments {
+		switch comment.Payload.Event.(type) {
+		case *storepb.IssueCommentPayload_IssueUpdate_:
+			labelUpdates++
+		case *storepb.IssueCommentPayload_ReviewSubmission_:
+			submissions++
+		default:
+		}
+	}
+	require.Equal(t, 1, labelUpdates)
+	require.Equal(t, 1, submissions)
+	require.Len(t, issueBus.ApprovalCheckChan, 1)
+}
+
+func TestConcurrentIdenticalLabelUpdatesCreateOneAuditComment(t *testing.T) {
+	ctx := issueServiceTestContext()
+	stores := setupIssueServiceTestStore(ctx, t)
+	service, _ := newIssueServiceForTest(t, stores)
+	_, issue := createIssueServiceApprovalIssue(ctx, t, stores)
+
+	for i := range 10 {
+		labels := []string{fmt.Sprintf("iteration:%d", i)}
+		start := make(chan struct{})
+		errs := make(chan error, 2)
+		var wg sync.WaitGroup
+		for range 2 {
+			wg.Go(func() {
+				<-start
+				_, err := service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
+					Issue: &v1pb.Issue{
+						Name:   common.FormatIssue(issue.ProjectID, issue.UID),
+						Labels: labels,
+					},
+					UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"labels"}},
+				}))
+				errs <- err
+			})
+		}
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
+	}
+
+	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
+		ProjectID: "project-a",
+		IssueUID:  &issue.UID,
+	})
+	require.NoError(t, err)
+	require.Len(t, comments, 10)
+}
+
+func TestConcurrentIdenticalTitleUpdatesCreateOneAuditComment(t *testing.T) {
+	ctx := issueServiceTestContext()
+	stores := setupIssueServiceTestStore(ctx, t)
+	service, _ := newIssueServiceForTest(t, stores)
+	_, issue := createIssueServiceApprovalIssue(ctx, t, stores)
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for range 2 {
+		wg.Go(func() {
+			<-start
+			_, err := service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
+				Issue: &v1pb.Issue{
+					Name:  common.FormatIssue(issue.ProjectID, issue.UID),
+					Title: "renamed issue",
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"title"}},
+			}))
+			errs <- err
+		})
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
+		ProjectID: issue.ProjectID,
+		IssueUID:  &issue.UID,
+	})
+	require.NoError(t, err)
+	require.Len(t, comments, 1)
+	update := comments[0].Payload.GetIssueUpdate()
+	require.Equal(t, "issue-a", update.GetFromTitle())
+	require.Equal(t, "renamed issue", update.GetToTitle())
+}
+
+func TestMixedIssuePatchRollsBackWhenLabelsFail(t *testing.T) {
+	ctx := issueServiceTestContext()
+	stores := setupIssueServiceTestStore(ctx, t)
+	service, _ := newIssueServiceForTest(t, stores)
+	_, issue := createIssueServiceApprovalIssue(ctx, t, stores)
+	_, err := stores.GetDB().ExecContext(ctx, `
+		ALTER TABLE issue ADD CONSTRAINT reject_atomic_test_label
+		CHECK (NOT COALESCE(payload->'labels' ? 'reject', false))`)
+	require.NoError(t, err)
+
+	_, err = service.UpdateIssue(ctx, connect.NewRequest(&v1pb.UpdateIssueRequest{
+		Issue: &v1pb.Issue{
+			Name:        common.FormatIssue(issue.ProjectID, issue.UID),
+			Title:       "renamed issue",
+			Description: "updated description",
+			Labels:      []string{"reject"},
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"title", "description", "labels"}},
+	}))
+	require.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+
+	got := getIssueForTest(ctx, t, stores, issue.UID)
+	require.Equal(t, "issue-a", got.Title)
+	require.Empty(t, got.Description)
+	require.Equal(t, []string{"environment:prod"}, got.Payload.GetLabels())
+	comments, err := stores.ListIssueComment(ctx, &store.FindIssueCommentMessage{
+		ProjectID: issue.ProjectID,
+		IssueUID:  &issue.UID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, comments)
+}
+
+func TestCreateDraftAndRolloutAreSerialized(t *testing.T) {
+	ctx := issueServiceTestContext()
+	stores := setupIssueServiceTestStore(ctx, t)
+	service, _ := newIssueServiceForTest(t, stores)
+
+	for i := range 10 {
+		t.Run(fmt.Sprintf("attempt-%d", i), func(t *testing.T) {
+			plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+				ProjectID: "project-a",
+				Name:      "draft rollout race",
+				Config: &storepb.PlanConfig{
+					Specs: []*storepb.PlanConfig_Spec{{
+						Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+							ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+								SheetSha256: "sheet",
+							},
+						},
+					}},
+				},
+			}, "creator@example.com")
+			require.NoError(t, err)
+
+			start := make(chan struct{})
+			draftResult := make(chan error, 1)
+			rolloutResult := make(chan error, 1)
+			go func() {
+				<-start
+				_, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+					Parent: "projects/project-a",
+					Issue: &v1pb.Issue{
+						Type:  v1pb.Issue_DATABASE_CHANGE,
+						Plan:  common.FormatPlan("project-a", plan.UID),
+						Draft: true,
+					},
+				}))
+				draftResult <- err
+			}()
+			go func() {
+				<-start
+				rolloutResult <- apiv1.CreateRolloutAndPendingTasks(ctx, stores, "creator@example.com", plan, nil, &store.ProjectMessage{
+					ResourceID: "project-a",
+					Setting:    &storepb.Project{RequireIssueApproval: false},
+				}, []*store.TaskMessage{})
+			}()
+			close(start)
+			draftErr := <-draftResult
+			rolloutErr := <-rolloutResult
+
+			require.NotEqual(t, draftErr == nil, rolloutErr == nil)
+			if draftErr == nil {
+				require.True(t, apiv1.IsDraftIssueNotSubmittedError(rolloutErr))
+			} else {
+				require.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(draftErr))
+				require.NoError(t, rolloutErr)
+			}
+
+			gotPlan, err := stores.GetPlan(ctx, &store.FindPlanMessage{
+				ProjectID: "project-a",
+				UID:       &plan.UID,
+			})
+			require.NoError(t, err)
+			linkedIssue, err := stores.GetIssue(ctx, &store.FindIssueMessage{
+				ProjectIDs: []string{"project-a"},
+				PlanUID:    &plan.UID,
+			})
+			require.NoError(t, err)
+			require.NotEqual(t, gotPlan.Config.GetHasRollout(), linkedIssue != nil)
+			if linkedIssue != nil {
+				require.True(t, linkedIssue.Payload.GetDraft())
+				require.Equal(t, storepb.Issue_OPEN, linkedIssue.Status)
+			}
+		})
+	}
+}
+
+func TestCreateDraftIssueIsIdempotent(t *testing.T) {
+	ctx := issueServiceTestContext()
+	stores := setupIssueServiceTestStore(ctx, t)
+	b, err := bus.New()
+	require.NoError(t, err)
+	service := apiv1.NewIssueService(stores, nil, b, nil, nil)
+
+	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      "idempotent draft plan",
+		Config: &storepb.PlanConfig{
+			Specs: []*storepb.PlanConfig_Spec{
+				{
+					Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+							SheetSha256: "sheet",
+						},
+					},
+				},
+			},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	first, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+		Parent: "projects/project-a",
+		Issue: &v1pb.Issue{
+			Title:       "original title",
+			Description: "original description",
+			Type:        v1pb.Issue_DATABASE_CHANGE,
+			Plan:        common.FormatPlan("project-a", plan.UID),
+			Labels:      []string{"original"},
+			Draft:       true,
+		},
+	}))
+	require.NoError(t, err)
+
+	second, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+		Parent: "projects/project-a",
+		Issue: &v1pb.Issue{
+			Title:       "replacement title",
+			Description: "replacement description",
+			Type:        v1pb.Issue_DATABASE_CHANGE,
+			Plan:        common.FormatPlan("project-a", plan.UID),
+			Labels:      []string{"replacement"},
+			Draft:       true,
+		},
+	}))
+	require.NoError(t, err)
+	require.Equal(t, first.Msg, second.Msg)
+	require.Empty(t, b.ApprovalCheckChan)
+
+	issues, err := stores.ListIssues(ctx, &store.FindIssueMessage{
+		ProjectIDs: []string{"project-a"},
+		PlanUID:    &plan.UID,
+	})
+	require.NoError(t, err)
+	require.Len(t, issues, 1)
+	require.Equal(t, plan.Name, issues[0].Title)
+	require.Equal(t, plan.Description, issues[0].Description)
+	require.Equal(t, []string{"original"}, issues[0].Payload.GetLabels())
+
+	concurrentPlan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      "concurrent draft plan",
+		Config: &storepb.PlanConfig{
+			Specs: []*storepb.PlanConfig_Spec{
+				{
+					Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+							SheetSha256: "sheet",
+						},
+					},
+				},
+			},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	type createResult struct {
+		response *connect.Response[v1pb.Issue]
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan createResult, 2)
+	var waitGroup sync.WaitGroup
+	for _, title := range []string{"first concurrent title", "second concurrent title"} {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			response, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+				Parent: "projects/project-a",
+				Issue: &v1pb.Issue{
+					Title: title,
+					Type:  v1pb.Issue_DATABASE_CHANGE,
+					Plan:  common.FormatPlan("project-a", concurrentPlan.UID),
+					Draft: true,
+				},
+			}))
+			results <- createResult{response: response, err: err}
+		}()
+	}
+	close(start)
+	waitGroup.Wait()
+	close(results)
+
+	var concurrentIssueName string
+	for result := range results {
+		require.NoError(t, result.err)
+		require.NotNil(t, result.response)
+		if concurrentIssueName == "" {
+			concurrentIssueName = result.response.Msg.GetName()
+		} else {
+			require.Equal(t, concurrentIssueName, result.response.Msg.GetName())
+		}
+	}
+	concurrentIssues, err := stores.ListIssues(ctx, &store.FindIssueMessage{
+		ProjectIDs: []string{"project-a"},
+		PlanUID:    &concurrentPlan.UID,
+	})
+	require.NoError(t, err)
+	require.Len(t, concurrentIssues, 1)
+}
+
+func TestIssueApprovalFiltersRunBeforePaging(t *testing.T) {
+	ctx := issueServiceTestContext()
+	stores := setupIssueServiceTestStore(ctx, t)
+	service, _ := newIssueServiceForTest(t, stores)
+
+	// Created first, so the default id DESC ordering puts it behind both
+	// non-matching issues. With page size 1 the pre-fix code read the two
+	// non-matching rows, minted a token, and then dropped every row it had.
+	waiting := createIssueWithApproval(ctx, t, stores, "waiting on the caller", &storepb.IssuePayloadApproval{
+		ApprovalTemplate:    approvalTemplateWithRoles("roles/workspaceAdmin"),
+		ApprovalFindingDone: true,
+	})
+	createIssueWithApproval(ctx, t, stores, "already approved", &storepb.IssuePayloadApproval{
+		ApprovalTemplate:    approvalTemplateWithRoles("roles/workspaceAdmin"),
+		Approvers:           []*storepb.IssuePayloadApproval_Approver{issueApprover(storepb.IssuePayloadApproval_Approver_APPROVED)},
+		ApprovalFindingDone: true,
+	})
+	// The caller holds roles/workspaceAdmin, not roles/projectOwner, so this one
+	// is pending but waiting on somebody else.
+	createIssueWithApproval(ctx, t, stores, "waiting on another role", &storepb.IssuePayloadApproval{
+		ApprovalTemplate:    approvalTemplateWithRoles("roles/projectOwner"),
+		ApprovalFindingDone: true,
+	})
+
+	const filter = `approval_status == "PENDING" && current_approver == "users/creator@example.com"`
+	want := []string{common.FormatIssue("project-a", waiting.UID)}
+
+	list, err := service.ListIssues(ctx, connect.NewRequest(&v1pb.ListIssuesRequest{
+		Parent:   "projects/project-a",
+		Filter:   filter,
+		PageSize: 1,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, want, issueNames(list.Msg.Issues))
+	require.Empty(t, list.Msg.GetNextPageToken())
+
+	search, err := service.SearchIssues(ctx, connect.NewRequest(&v1pb.SearchIssuesRequest{
+		Parent:   "projects/project-a",
+		Filter:   filter,
+		PageSize: 1,
+	}))
+	require.NoError(t, err)
+	require.Equal(t, want, issueNames(search.Msg.Issues))
+	require.Empty(t, search.Msg.GetNextPageToken())
+}
+
+// The fixture helpers below are duplicated from
+// backend/api/v1/issue_service_test.go, which keeps its own copies for the
+// issue tests that stay there. Change both together: nothing catches a
+// divergence, and these tests would keep passing against a stale fixture.
+// The duplication ends when those tests move to a fake.
+// TestIssueApprovalStatusFilterMatchesConverter pins the SQL derivation of
+// approval_status to computeApprovalStatus. They are two implementations of one
+// rule, and the SQL side has to read an absent JSON key as a zero value because
+// payloads are written with a bare protojson.Marshal.
+func issueNames(issues []*v1pb.Issue) []string {
+	names := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		names = append(names, issue.GetName())
+	}
+	return names
+}
+
+func setupIssueServiceTestStore(ctx context.Context, t *testing.T) *store.Store {
+	t.Helper()
+
+	db, stores, _ := newTestDB(t)
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO workspace (resource_id) VALUES ('default');
+		INSERT INTO principal (name, email, password_hash) VALUES ('creator', 'creator@example.com', 'unused');
+		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
+	`)
+	require.NoError(t, err)
+
+	// SearchIssues authorizes the caller itself (CUSTOM auth), so the test
+	// principal needs a role carrying bb.issues.get.
+	_, err = stores.PatchWorkspaceIamPolicy(ctx, &store.PatchIamPolicyMessage{
+		Workspace: "default",
+		Member:    common.FormatUserEmail("creator@example.com"),
+		Roles:     []string{"roles/workspaceAdmin"},
+	})
+	require.NoError(t, err)
+	return stores
+}
+
+func issueServiceTestContext() context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, common.WorkspaceIDContextKey, "default")
+	ctx = context.WithValue(ctx, common.UserContextKey, &store.UserMessage{
+		Email: "creator@example.com",
+		Name:  "creator",
+	})
+	return ctx
+}
+
+// newIssueServiceForTest also returns the bus it built: the service keeps it
+// unexported, and two tests assert on what the handler published.
+func newIssueServiceForTest(t *testing.T, stores *store.Store) (*apiv1.IssueService, *bus.Bus) {
+	t.Helper()
+
+	b, err := bus.New()
+	require.NoError(t, err)
+	iamManager, err := iam.NewManager(stores, nil, false)
+	require.NoError(t, err)
+	return apiv1.NewIssueService(stores, webhook.NewManager(stores, nil), b, nil, iamManager), b
+}
+
+func createIssueServiceApprovalIssue(ctx context.Context, t *testing.T, stores *store.Store) (*store.PlanMessage, *store.IssueMessage) {
+	t.Helper()
+
+	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID:   "project-a",
+		Name:        "plan-a",
+		Description: "",
+		Config: &storepb.PlanConfig{
+			ApprovalInputVersion: 2,
+			Specs: []*storepb.PlanConfig_Spec{
+				{
+					Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+						ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+							Targets: []string{"instances/prod/databases/app"},
+						},
+					},
+				},
+			},
+		},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	issue, err := stores.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        "issue-a",
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Description:  "",
+		Payload: &storepb.Issue{
+			Labels: []string{"environment:prod"},
+			Approval: &storepb.IssuePayloadApproval{
+				ApprovalTemplate: &storepb.ApprovalTemplate{
+					Flow:  &storepb.ApprovalFlow{Roles: []string{"roles/projectOwner"}},
+					Title: "manual approval",
+				},
+				Approvers: []*storepb.IssuePayloadApproval_Approver{
+					{
+						Status:    storepb.IssuePayloadApproval_Approver_APPROVED,
+						Principal: common.FormatUserEmail("creator@example.com"),
+					},
+				},
+				ApprovalFindingDone:  true,
+				ApprovalInputVersion: 2,
+			},
+		},
+		PlanUID: &plan.UID,
+	})
+	require.NoError(t, err)
+	return plan, issue
+}
+
+func getIssueForTest(ctx context.Context, t *testing.T, stores *store.Store, issueUID int64) *store.IssueMessage {
+	t.Helper()
+
+	got, err := stores.GetIssue(ctx, &store.FindIssueMessage{
+		ProjectIDs: []string{"project-a"},
+		UID:        &issueUID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	return got
+}
+
+func createReadyDraftForUpdateTest(
+	ctx context.Context,
+	t *testing.T,
+	stores *store.Store,
+	service *apiv1.IssueService,
+	title string,
+) *store.IssueMessage {
+	t.Helper()
+	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a", Name: title,
+		Config: &storepb.PlanConfig{Specs: []*storepb.PlanConfig_Spec{{
+			Config: &storepb.PlanConfig_Spec_ChangeDatabaseConfig{
+				ChangeDatabaseConfig: &storepb.PlanConfig_ChangeDatabaseConfig{
+					Targets: []string{"instances/prod/databases/app"}, SheetSha256: "sheet",
+				},
+			},
+		}}},
+	}, "creator@example.com")
+	require.NoError(t, err)
+	response, err := service.CreateIssue(ctx, connect.NewRequest(&v1pb.CreateIssueRequest{
+		Parent: "projects/project-a",
+		Issue: &v1pb.Issue{
+			Type: v1pb.Issue_DATABASE_CHANGE, Plan: common.FormatPlan("project-a", plan.UID),
+			Labels: []string{"team:database"}, Draft: true,
+		},
+	}))
+	require.NoError(t, err)
+	_, issueUID, err := common.GetProjectIDIssueUID(response.Msg.GetName())
+	require.NoError(t, err)
+	created, err := stores.CreatePlanCheckRun(ctx, &store.PlanCheckRunMessage{
+		ProjectID: plan.ProjectID, PlanUID: plan.UID,
+		Result: &storepb.PlanCheckRunResult{ApprovalInputVersion: plan.Config.GetApprovalInputVersion()},
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+	run, err := stores.GetPlanCheckRun(ctx, plan.ProjectID, plan.UID)
+	require.NoError(t, err)
+	require.NoError(t, stores.UpdatePlanCheckRun(ctx, plan.ProjectID, store.PlanCheckRunStatusDone, &storepb.PlanCheckRunResult{
+		ApprovalInputVersion: plan.Config.GetApprovalInputVersion(),
+		Results: []*storepb.PlanCheckRunResult_Result{{
+			Type: storepb.PlanCheckType_PLAN_CHECK_TYPE_STATEMENT_ADVISE, Status: storepb.Advice_SUCCESS,
+		}},
+	}, run.UID))
+	return getIssueForTest(ctx, t, stores, issueUID)
+}
+
+func waitForTransactionBlock(ctx context.Context, t *testing.T, db *sql.DB, tx *sql.Tx) {
+	t.Helper()
+	var blockerPID int
+	require.NoError(t, tx.QueryRowContext(ctx, "SELECT pg_backend_pid()").Scan(&blockerPID))
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var waiting int
+		require.NoError(t, db.QueryRowContext(ctx, `
+			SELECT count(*)
+			FROM pg_stat_activity AS activity
+			WHERE activity.pid <> pg_backend_pid()
+			  AND $1 = ANY(pg_blocking_pids(activity.pid))`, blockerPID).Scan(&waiting))
+		if waiting >= 1 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for a session blocked by transaction PID %d", blockerPID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func createIssueWithApproval(ctx context.Context, t *testing.T, stores *store.Store, title string, approval *storepb.IssuePayloadApproval) *store.IssueMessage {
+	t.Helper()
+
+	plan, err := stores.CreatePlan(ctx, &store.PlanMessage{
+		ProjectID: "project-a",
+		Name:      title + " plan",
+		Config:    &storepb.PlanConfig{},
+	}, "creator@example.com")
+	require.NoError(t, err)
+
+	issue, err := stores.CreateIssue(ctx, &store.IssueMessage{
+		ProjectID:    "project-a",
+		CreatorEmail: "creator@example.com",
+		Title:        title,
+		Type:         storepb.Issue_DATABASE_CHANGE,
+		Payload:      &storepb.Issue{Approval: approval},
+		PlanUID:      &plan.UID,
+	})
+	require.NoError(t, err)
+	return issue
+}
+
+func approvalTemplateWithRoles(roles ...string) *storepb.ApprovalTemplate {
+	return &storepb.ApprovalTemplate{Flow: &storepb.ApprovalFlow{Roles: roles}}
+}
+
+func issueApprover(status storepb.IssuePayloadApproval_Approver_Status) *storepb.IssuePayloadApproval_Approver {
+	return &storepb.IssuePayloadApproval_Approver{
+		Status:    status,
+		Principal: common.FormatUserEmail("creator@example.com"),
+	}
+}
+
+// TestIssueApprovalFiltersRunBeforePaging is the regression lock for audit
+// finding T13: approval_status and current_approver used to be applied to the
+// page after the store had already cut it and minted the page token, so
+// filtering the default My Issues view answered with an empty page and a live
+// next page token underneath it.

--- a/backend/store/lock_order_test.go
+++ b/backend/store/lock_order_test.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -27,10 +25,7 @@ func newStorePostgresFixture(t *testing.T, seedSQL string) *storePostgresFixture
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(context.Background()) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, url := newTestDB(t)
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('default');
@@ -39,15 +34,7 @@ func newStorePostgresFixture(t *testing.T, seedSQL string) *storePostgresFixture
 	`+seedSQL)
 	require.NoError(t, err)
 
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
-
-	return &storePostgresFixture{ctx: ctx, db: db, store: s, pgURL: pgURL}
+	return &storePostgresFixture{ctx: ctx, db: db, store: s, pgURL: url}
 }
 
 const maintenanceLockWait = 10 * time.Second

--- a/backend/store/login_attempt_test.go
+++ b/backend/store/login_attempt_test.go
@@ -2,7 +2,6 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -10,10 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
-	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
 )
@@ -25,19 +21,7 @@ import (
 // forgets after D of quiet, and success deletes the row.
 func TestLoginAttemptClaim(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	db, s, _ := newTestDB(t)
 
 	const window = 10 * time.Minute
 
@@ -209,19 +193,7 @@ func TestLoginAttemptClaim(t *testing.T) {
 // the lockout, under the window rule EMAIL_CODE_SEND selects.
 func TestSendBudgetClaim(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
+	db, s, _ := newTestDB(t)
 
 	const window = time.Hour
 	const kind = storepb.LoginAttemptKind_EMAIL_CODE_SEND

--- a/backend/store/main_test.go
+++ b/backend/store/main_test.go
@@ -1,0 +1,85 @@
+package store_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+	"github.com/bytebase/bytebase/backend/migrator"
+	"github.com/bytebase/bytebase/backend/store"
+)
+
+const templateDatabase = "bbtest_template"
+
+var (
+	pgHost, pgPort string
+	adminDB        *sql.DB
+	databaseSeq    atomic.Int64
+)
+
+// TestMain starts one Postgres for the package and migrates a template
+// database once. Tests copy the template instead of starting a container:
+// a copy costs 44ms against 4.3s.
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	container, err := testcontainer.GetPgContainer(ctx)
+	if err != nil {
+		panic(err)
+	}
+	defer container.Close(ctx)
+
+	pgHost, pgPort = container.GetHost(), container.GetPort()
+	adminDB = container.GetDB()
+	if err := migrateTemplate(ctx); err != nil {
+		panic(err)
+	}
+	m.Run()
+}
+
+func migrateTemplate(ctx context.Context) error {
+	if _, err := adminDB.ExecContext(ctx, "CREATE DATABASE "+templateDatabase); err != nil {
+		return err
+	}
+	db, err := sql.Open("pgx", fmt.Sprintf(
+		"host=%s port=%s user=postgres password=root-password database=%s",
+		pgHost, pgPort, templateDatabase))
+	if err != nil {
+		return err
+	}
+	if err := migrator.MigrateSchema(ctx, db); err != nil {
+		_ = db.Close()
+		return err
+	}
+	// TEMPLATE refuses to copy a database that still has a session attached.
+	return db.Close()
+}
+
+// newTestDB gives the test its own migrated database: a raw handle for seeding,
+// a Store for the code under test, and the URL for tests that open their own
+// connections. The copies are not dropped; the container takes them with it.
+func newTestDB(t *testing.T) (*sql.DB, *store.Store, string) {
+	t.Helper()
+	ctx := context.Background()
+	name := fmt.Sprintf("bbtest_%d", databaseSeq.Add(1))
+	_, err := adminDB.ExecContext(ctx,
+		fmt.Sprintf("CREATE DATABASE %s TEMPLATE %s", name, templateDatabase))
+	require.NoError(t, err)
+
+	url := fmt.Sprintf("host=%s port=%s user=postgres password=root-password database=%s",
+		pgHost, pgPort, name)
+	db, err := sql.Open("pgx", url)
+	require.NoError(t, err)
+	s, err := store.New(ctx, url, false)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, s.Close())
+		require.NoError(t, db.Close())
+	})
+	return db, s, url
+}

--- a/backend/store/oauth2_consume_test.go
+++ b/backend/store/oauth2_consume_test.go
@@ -2,16 +2,13 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
@@ -24,11 +21,7 @@ import (
 // and a second sequential redemption must observe consumed=false.
 func TestOAuth2AtomicConsume(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, _ := newTestDB(t)
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('ws-test');
@@ -36,13 +29,6 @@ func TestOAuth2AtomicConsume(t *testing.T) {
 		INSERT INTO oauth2_client (client_id, workspace, client_secret_hash, config)
 		VALUES ('client-A', NULL, 'unused-hash', '{}'::jsonb);
 	`)
-	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
 	require.NoError(t, err)
 
 	t.Run("authorization code is single-use", func(t *testing.T) {

--- a/backend/store/oauth2_workspace_test.go
+++ b/backend/store/oauth2_workspace_test.go
@@ -2,15 +2,12 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
@@ -32,11 +29,7 @@ import (
 //     singleton can take over.
 func TestOAuth2WorkspaceBinding(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, _ := newTestDB(t)
 
 	// Seed the minimal fixtures needed by the FK constraints on the OAuth2
 	// tables: a workspace and a principal.
@@ -46,13 +39,6 @@ func TestOAuth2WorkspaceBinding(t *testing.T) {
 		INSERT INTO oauth2_client (client_id, workspace, client_secret_hash, config)
 		VALUES ('client-A', NULL, 'unused-hash', '{}'::jsonb);
 	`)
-	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
 	require.NoError(t, err)
 
 	t.Run("auth code round-trips workspace bound at consent time", func(t *testing.T) {

--- a/backend/store/pagination_integration_test.go
+++ b/backend/store/pagination_integration_test.go
@@ -8,9 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
@@ -33,24 +31,13 @@ func TestPaginationStabilityAcrossProjects(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, stores, _ := newTestDB(t)
 
 	projectIDs := make([]string, 0, projectCount)
 	for i := range projectCount {
 		projectIDs = append(projectIDs, fmt.Sprintf("pagination-p%d", i))
 	}
 	seedTiedIssues(ctx, t, db, workspaceID, projectIDs, perProject)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
 
 	// Walk the list the way the API does: a fresh LIMIT/OFFSET query per page.
 	seen := map[string]int{}
@@ -122,10 +109,7 @@ func seedTiedIssues(ctx context.Context, t *testing.T, db *sql.DB, workspaceID s
 // changed", permanently, for that issue.
 func TestIssueCommentBatchKeepsInsertionOrder(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, stores, _ := newTestDB(t)
 
 	const (
 		workspaceID = "comment-ws"
@@ -146,14 +130,6 @@ func TestIssueCommentBatchKeepsInsertionOrder(t *testing.T) {
 		VALUES ($1, $2, 'users/comment@example.com', 'issue', 'OPEN', 'DATABASE_CHANGE', '')`,
 		issueUID, projectID)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
 
 	want := []string{"title", "description", "labels", "status", "assignee"}
 	creates := make([]*store.IssueCommentMessage, 0, len(want))

--- a/backend/store/plan_check_run_test.go
+++ b/backend/store/plan_check_run_test.go
@@ -2,14 +2,11 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
@@ -644,11 +641,7 @@ func TestFailStalePlanCheckRunsPreservesApprovalInputVersion(t *testing.T) {
 func setupPlanCheckRunVersionStore(ctx context.Context, t *testing.T) *store.Store {
 	t.Helper()
 
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, _ := newTestDB(t)
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('default');
@@ -656,14 +649,6 @@ func setupPlanCheckRunVersionStore(ctx context.Context, t *testing.T) *store.Sto
 		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
 	`)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	return s
 }
 

--- a/backend/store/policy_project_iam_test.go
+++ b/backend/store/policy_project_iam_test.go
@@ -8,9 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/bytebase/bytebase/backend/common"
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
@@ -24,10 +22,7 @@ import (
 // policy type, whose payload would then be unmarshalled as an IamPolicy.
 func TestListProjectIamPoliciesIsScoped(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, stores, _ := newTestDB(t)
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('ws-a'), ('ws-b');
 		INSERT INTO project (resource_id, workspace, name) VALUES
@@ -37,14 +32,6 @@ func TestListProjectIamPoliciesIsScoped(t *testing.T) {
 			('other-workspace', 'ws-b', 'Other workspace');
 	`)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
 
 	iamPayload := func(role string) string {
 		return fmt.Sprintf(`{"bindings":[{"role":%q,"members":["users/c@example.com"]}]}`, role)

--- a/backend/store/project_purge_cache_test.go
+++ b/backend/store/project_purge_cache_test.go
@@ -30,6 +30,7 @@ func newProjectPurgeCacheFixture(t *testing.T) (context.Context, *sql.DB, *store
 
 	s, err := store.New(ctx, url, true)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	return ctx, db, s
 }
 

--- a/backend/store/project_purge_cache_test.go
+++ b/backend/store/project_purge_cache_test.go
@@ -3,14 +3,11 @@ package store_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -21,10 +18,7 @@ func newProjectPurgeCacheFixture(t *testing.T) (context.Context, *sql.DB, *store
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(context.Background()) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, _, url := newTestDB(t)
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('default');
 		INSERT INTO project (resource_id, workspace, name, deleted) VALUES
@@ -33,13 +27,9 @@ func newProjectPurgeCacheFixture(t *testing.T) (context.Context, *sql.DB, *store
 			('project-b', 'default', 'Project B', FALSE);
 	`)
 	require.NoError(t, err)
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, true)
+
+	s, err := store.New(ctx, url, true)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
 	return ctx, db, s
 }
 

--- a/backend/store/sample_instance_test.go
+++ b/backend/store/sample_instance_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -17,10 +15,7 @@ func newSampleInstanceFixture(t *testing.T) (context.Context, *store.Store) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(context.Background()) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, stores, _ := newTestDB(t)
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES
 			('workspace-a'), ('workspace-b'), ('workspace-c'), ('workspace-d');
@@ -31,13 +26,6 @@ func newSampleInstanceFixture(t *testing.T) (context.Context, *store.Store) {
 			('project-workspace-d', 'workspace-d', 'Project D');
 	`)
 	require.NoError(t, err)
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
 	return ctx, stores
 }
 

--- a/backend/store/setting_atomic_test.go
+++ b/backend/store/setting_atomic_test.go
@@ -35,6 +35,7 @@ func newSettingAtomicFixtureWithCache(t *testing.T, enableCache bool) (context.C
 	require.NoError(t, err)
 	s, err := store.New(ctx, url, enableCache)
 	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
 	_, err = s.UpsertSetting(ctx, &store.SettingMessage{
 		Name:      storepb.SettingName_WORKSPACE_PROFILE,

--- a/backend/store/setting_atomic_test.go
+++ b/backend/store/setting_atomic_test.go
@@ -3,7 +3,6 @@ package store_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -13,9 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -32,21 +29,12 @@ func newSettingAtomicFixtureWithCache(t *testing.T, enableCache bool) (context.C
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(context.Background()) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, _, url := newTestDB(t)
 
 	_, err := db.ExecContext(ctx, `INSERT INTO workspace (resource_id) VALUES ('default');`)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, enableCache)
+	s, err := store.New(ctx, url, enableCache)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
 	_, err = s.UpsertSetting(ctx, &store.SettingMessage{
 		Name:      storepb.SettingName_WORKSPACE_PROFILE,

--- a/backend/store/task_run_batch_test.go
+++ b/backend/store/task_run_batch_test.go
@@ -2,15 +2,12 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/bytebase/bytebase/backend/common"
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -18,10 +15,7 @@ func TestCreatePendingTaskRunsRejectsMultipleProjects(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(context.Background()) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, _ := newTestDB(t)
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('default');
@@ -37,14 +31,6 @@ func TestCreatePendingTaskRunsRejectsMultipleProjects(t *testing.T) {
 			(101, 'project-b', 101, 'instance-a', 'DATABASE_SCHEMA_UPDATE');
 	`)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
 	err = s.CreatePendingTaskRuns(ctx, "creator@example.com",
 		&store.TaskRunMessage{ProjectID: "project-a", TaskUID: 101},

--- a/backend/store/task_run_claim_test.go
+++ b/backend/store/task_run_claim_test.go
@@ -3,15 +3,10 @@ package store_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
-	"github.com/bytebase/bytebase/backend/migrator"
-	"github.com/bytebase/bytebase/backend/store"
 )
 
 func TestClaimAvailableTaskRunsSkipsDeletedProjects(t *testing.T) {
@@ -100,10 +95,7 @@ func newTaskRunClaimFixture(t *testing.T, seedSQL string) *storePostgresFixture 
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	t.Cleanup(cancel)
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(context.Background()) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, _ := newTestDB(t)
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('default');
@@ -111,14 +103,6 @@ func newTaskRunClaimFixture(t *testing.T, seedSQL string) *storePostgresFixture 
 		INSERT INTO project (resource_id, workspace, name) VALUES ('project-a', 'default', 'Project A');
 	`+seedSQL)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
 	return &storePostgresFixture{ctx: ctx, db: db, store: s}
 }

--- a/backend/store/task_run_pagination_test.go
+++ b/backend/store/task_run_pagination_test.go
@@ -8,8 +8,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 )
 
@@ -21,10 +19,7 @@ func TestListTaskRunsPagination(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(context.Background()) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, _ := newTestDB(t)
 
 	_, err := db.ExecContext(ctx, `
 		INSERT INTO workspace (resource_id) VALUES ('default');
@@ -46,14 +41,6 @@ func TestListTaskRunsPagination(t *testing.T) {
 			(102, 'project-b', 101, 1, 'DONE');
 	`)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
 	planUID := int64(101)
 	ids := func(taskRuns []*store.TaskRunMessage) []string {

--- a/backend/store/vcs_provider_user_test.go
+++ b/backend/store/vcs_provider_user_test.go
@@ -3,16 +3,13 @@ package store_test
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	v1pb "github.com/bytebase/bytebase/backend/generated-go/v1"
-	"github.com/bytebase/bytebase/backend/migrator"
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
 	"github.com/bytebase/bytebase/backend/store"
 )
@@ -245,22 +242,10 @@ func TestDeleteExpiredVCSProviderUsers(t *testing.T) {
 func setupVCSProviderUserStore(ctx context.Context, t *testing.T) (*store.Store, *sql.DB) {
 	t.Helper()
 
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
+	db, s, _ := newTestDB(t)
 
 	_, err := db.ExecContext(ctx, `INSERT INTO workspace (resource_id) VALUES ('default')`)
 	require.NoError(t, err)
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	s, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, s.Close()) })
 
 	return s, db
 }

--- a/backend/store/workspace_test.go
+++ b/backend/store/workspace_test.go
@@ -2,7 +2,6 @@ package store_test
 
 import (
 	"context"
-	"fmt"
 	"slices"
 	"testing"
 
@@ -11,9 +10,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/bytebase/bytebase/backend/common"
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
-	"github.com/bytebase/bytebase/backend/migrator"
 	"github.com/bytebase/bytebase/backend/store"
 
 	_ "github.com/bytebase/bytebase/backend/plugin/db/pg"
@@ -21,21 +18,10 @@ import (
 
 func TestCreateWorkspaceInitializesDefaults(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
+	_, stores, _ := newTestDB(t)
 
 	const workspaceID = "workspace-defaults"
-	_, err = stores.CreateWorkspace(ctx, &store.WorkspaceMessage{
+	_, err := stores.CreateWorkspace(ctx, &store.WorkspaceMessage{
 		ResourceID: workspaceID,
 		AdditionalSettings: []store.AdditionalSetting{{
 			Name:    storepb.SettingName_AI,
@@ -86,18 +72,7 @@ func TestCreateWorkspaceInitializesDefaults(t *testing.T) {
 
 func TestListWorkspacesByEmailEvaluatesBindingConditions(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
-	db := container.GetDB()
-	require.NoError(t, migrator.MigrateSchema(ctx, db))
-
-	pgURL := fmt.Sprintf(
-		"host=%s port=%s user=postgres password=root-password database=postgres",
-		container.GetHost(), container.GetPort(),
-	)
-	stores, err := store.New(ctx, pgURL, false)
-	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, stores.Close()) })
+	db, stores, _ := newTestDB(t)
 
 	const email = "member@example.com"
 	activeCondition := `request.time < timestamp("2099-01-01T00:00:00Z")`

--- a/docs/design/backend-test-execution-time.md
+++ b/docs/design/backend-test-execution-time.md
@@ -125,7 +125,7 @@ went from **679 s to 611 s** across its 233 boots: 227 s off the summed test
 time, compressed 3.3× by the package's own parallelism. Measure the efforts
 below against 611 s.
 
-### 2. One shared container per package, then turn parallelism on
+### [✓ step 1, store] 2. One shared container per package, then turn parallelism on
 
 **459 s of wall clock, 390 s of it container starts.** `store` starts 90
 containers, and because it runs serially that cost is its wall clock almost
@@ -161,6 +161,25 @@ ordering coupling.
 
 Step 1 alone takes `store` from 459 s to roughly 75 s. Step 2 should take it
 below that; what remains is real work across 128 tests.
+
+**What it bought, measured on one Mac, same tests both sides.** `backend/store`
+went from **382.95 s to 12.0 s** — 90 container starts down to 1, and 20 files
+off `GetTestPgContainer`. `main_test.go` holds the whole mechanism in one
+helper: `newTestDB` returns a raw handle for seeding, a Store for the code under
+test, and the URL for tests that open their own connections, all on a database
+copied from the template.
+
+The copies are never dropped, deliberately. They are physical — 140 tests hold
+roughly 1.3 GB — but they live inside the package's own container, which
+`TestMain` terminates on the way out, so the space comes back with it. Dropping
+each database costs about 54 ms, or 7 s across the package, to reclaim disk that
+is already reclaimed.
+
+**Step 2 is not done.** Nothing calls `t.Parallel()` yet, so this is step 1
+alone. Two things that would have blocked it are already checked: Postgres
+advisory locks are per-database, so the lock and claim tests cannot reach each
+other across per-test databases, and eight concurrent
+`CREATE DATABASE … TEMPLATE` from one template all succeed.
 
 ### 3. Pool the provisioned Postgres instances
 
@@ -258,11 +277,11 @@ Three keep their engine. Each needs a comment saying why:
 
 ### 6. Seams instead of containers
 
-**912 s of wall clock, 680 s of it container starts.** AGENTS.md confines a real
-metadata Postgres to `store` and `tests`. `api/v1`, `component/review` and
-`migrator` are not on that list and start 157 containers between them.
-`backend/api/mcp` is the proof this is livable: 168 tests in 39.5 s, 16 of its
-18 files containerless.
+**822 s of wall clock, 611 s of it container starts**, after `migrator` was
+settled by deletion below. AGENTS.md confines a real metadata Postgres to
+`store` and `tests`; `api/v1` and `component/review` are not on that list and
+start 141 containers between them. `backend/api/mcp` is the proof this is
+livable: 168 tests in 39.5 s, 16 of its 18 files containerless.
 
 Effort 2 declined a fake store on two grounds, and both fail here. `api/v1` is
 not testing its API — `mcp_info_test.go` calls `service.GetMCPInfo` as a Go
@@ -272,19 +291,48 @@ calls 181, but `api/mcp` needed five (`serverStore`, faked in 62 lines) and
 `mcp_gate.go` needed one (`mcpSettingsReader`). Interfaces go beside the handler
 that reads them, never over the store.
 
-Fourteen files in `api/v1` start containers, ~90 tests. Read from names, not
-bodies — verify the back two rows:
+Fourteen files in `api/v1` start containers, 90 tests, classified from their
+bodies:
 
 | Disposition | Tests | Shape |
 | --- | ---: | --- |
-| Move to `backend/store` | ~20 | `Test*Claims`, concurrent-update and serialization, `TestMixedIssuePatchRollsBackWhenLabelsFail`, retention filter boundaries, `TestIssueApprovalFiltersRunBeforePaging` |
-| Pure function over plain data | ~40 | canonical-name tests, the four `TestCheckRelease*`, converters |
-| Narrow interface and a fake | ~30 | `TestGetMCPInfoHandler`, the list-and-hide tests, `TestApproveIssueFailsClosedWhenIAMLookupFails` |
+| Move to `backend/store` | 18 | the 7 lockout and claims tests, 6 concurrency and transaction tests, 2 retention-filter boundaries, `TestIssueApprovalFiltersRunBeforePaging` |
+| Replace with a fake | 66 | canonical-name assertions through real services, the list-and-hide tests, validation rejections, `TestGetMCPInfoHandler`, `TestApproveIssueFailsClosedWhenIAMLookupFails` |
+| Pure function over plain data | 6 | `TestExtractDomain`, `TestLDAPLoginIdentity`, the MFA temp-token shapes |
 
-`component/review` splits the same way:
-`TestApplyApprovalTemplateAndCreatePlanCheckRunDoNotDeadlock` is lock ordering
-and moves to `store`; the CEL, template-matching and target-unfolding tests are
-pure functions already, wearing a container for the package's sake.
+The last two rows are one boundary, not two: a fake test becomes a pure one as
+soon as its decide-half is extracted, so 66 is a ceiling on the fakes and 6 a
+floor on the pure functions.
+
+The rest of `backend/api` adds 14, all fakes — `oauth2` 6, `mcp` 5, `auth` 2,
+`lsp` 1. `oauth2`'s consent-ceiling tests seed five workspaces and their MCP
+settings in raw SQL to exercise one ceiling read each. The 6 pure tests need no
+work: verified by call closure, none reaches a container.
+
+**Outside `api/`, seven more packages hold a metadata Postgres**, 73 tests
+between them, classified the same way by call closure:
+
+| Package | → `store` | → fake |
+| --- | ---: | ---: |
+| `component/review` | 12 | 29 |
+| `runner/schemasync` | 5 | 2 |
+| `runner/taskrun` | 5 | 4 |
+| `runner/plancheck` | 1 | 5 |
+| `server` | 2 | 2 |
+| `component/recovery` | 0 | 5 |
+| `enterprise` | 0 | 1 |
+
+`component/review`'s 12 are the largest store-bound group anywhere — approval
+lock ordering, concurrent approvals, staleness races — and share helpers with
+their own 29, so fakes-first applies there too. `runner/schemasync`'s five hold
+`AdvisoryLockKeySchemaSyncer` in a live transaction, which nothing but Postgres
+can do. `plugin/db/*` and `plugin/schema/*` are out of scope: target engines,
+not metadata, and effort 7's business.
+
+Two places already have the right shape: 39 of `backend/store`'s 140 tests never
+touch a database (the CEL-to-SQL builders assert generated SQL rather than
+executing it), and 52 tests across the seven packages above are already
+container-free.
 
 Prefer the middle row: a handler is fetch, decide, convert, and only the fetch
 needs a store.
@@ -304,6 +352,30 @@ than one per test.
 **Every fake needs a contract test** — one table run against both the fake and
 the real store — or effort 2's objection is right. Since none of these packages
 may hold a container, that suite lives in `backend/store`. No `mockgen`, no SQLite.
+
+**Fakes before moves.** The 18 do not move first, because their helpers are
+shared with the tests that stay: 9 of the 11 helpers the 8 issue tests need are
+also used by the 27 `issue_service_test.go` tests bound for fakes, so moving now
+would duplicate them across two packages. Converting the 27 first lets those
+helpers diverge naturally, and the 8 then move with helpers of their own. The
+exception is a file whose tests all move — `audit_log_service_test.go` had two
+tests and four file-local helpers, so it moved whole (**done**: now
+`backend/store/audit_log_retention_test.go`, 0.14 s and 0.11 s against 4.3 s
+each before). Its one unexported dependency, `convertToAuditLogs`, stayed behind
+as a pure converter test with no database.
+
+**Done anyway, duplication accepted.** The 8 issue tests moved to
+`backend/store/issue_service_concurrency_test.go` with copies of the 9 shared
+helpers; `api/v1` keeps its own for the 27 that stay, which get rewritten against
+a fake regardless. All 8 run in 0.04–0.07 s against 4.3 s. Two snags, neither
+needing a production change: they asserted on `IssueService.bus`, unexported, so
+the helper now returns the bus it built; and `errDraftIssueNotSubmitted` is
+unexported, but `IsDraftIssueNotSubmittedError` sits exported beside it.
+
+Five of the 18 call unexported `api/v1` methods — `getAndVerifyUser`,
+`verifyEmailCode`, `completeMFALogin`, `getOrCreateUserWithIDP` — and cannot
+move without exporting them. `TestLoginAttemptRetentionOutlivesLockouts` is not
+a database test at all; it compares two constants.
 
 Convert `mcp_info_test.go` first — `mcpSettingsReader` exists and the test is 60
 lines — and measure before doing the rest. Server boots go the same way:


### PR DESCRIPTION
## What

`go test ./backend/store/` took **382.95s**, because 90 of its tests each started their own Postgres container at 4.3s a piece. This gives the package a `TestMain` that starts one container and migrates a template database once; each test then copies that template for 44ms.

Same tests, same machine: **382.95s → 12.0s.**

It also moves ten tests out of `backend/api/v1`, which under the AGENTS.md rule may not hold a real metadata Postgres.

## The helper

One function covers every call site:

```go
func newTestDB(t *testing.T) (*sql.DB, *store.Store, string)
```

A raw handle for seeding, a Store for the code under test, and the URL for the few tests that open their own connections — all on the test's own database. Call sites read `db, s, _ := newTestDB(t)`, `_, s, _ :=`, and so on.

The copies are deliberately **not** dropped. They live in the package's own container, which `TestMain` terminates on the way out, so the space returns with it; dropping each database costs 54ms (7s across the package) to reclaim disk that is already reclaimed.

## The moved tests

Ten tests whose subject is SQL behaviour move to `backend/store` and are deleted from `backend/api/v1`:

- `audit_log_service_test.go` → `backend/store/audit_log_retention_test.go` (2 tests; the whole file moved, since all its helpers were file-local)
- 8 issue concurrency / transaction / pagination tests → `backend/store/issue_service_concurrency_test.go`

Assertions are unchanged — verified by body-level diff. Two things could not follow, neither needing a production change:

- `convertToAuditLogs` is unexported, so its name-formatting assertion stays in `backend/api/v1` as a pure converter test with no database.
- The tests asserted on `IssueService.bus`, an unexported field. The helper now returns the bus it builds, which the test constructed anyway.

## Known tradeoff

Nine fixture helpers are duplicated between the two packages. Both copies carry a comment saying so. The duplication ends when the 27 issue tests still in `backend/api/v1` are converted to fakes and the copies diverge on purpose. This is recorded in the design doc.

## Testing

- `backend/store`: 140 tests, 12.0s, all passing (baseline measured at 382.95s in a worktree at `main`, same machine)
- `backend/api/v1`: passing
- `backend/tests` collision suite (`^(TestClaim|TestCollision)`): passing, 69.3s
- `golangci-lint run`: 0 issues; `go build ./...` and `go vet ./backend/...` clean
- Server binary builds

Three things checked empirically because the change moves tests from one Postgres cluster each to a shared one:

- **`m.Run()` without `os.Exit` still propagates failure** — verified with a deliberate `t.Fatal` probe (exit code 1). Had this been wrong, every failure would report green.
- **Advisory locks are per-database** — a session holding a key in one database does not block another, and correctly blocks a second attempt in the same one. The lock and claim tests stay isolated.
- **Eight concurrent `CREATE DATABASE … TEMPLATE` from one template all succeed** — so adding `t.Parallel()` (step 2, not in this PR) is safe.

## Pre-PR checklist

- Breaking change: N/A — test files and one design doc only
- Composite-PK query safety: no query or store method added or modified; collision tests run and passing
- Pagination ordering / transaction lock ordering: N/A — no query or transaction changed
- Lint, format, test and build gates: passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
