### PR TITLE
fix(schema/oracle): serve the single-object definitions GetSchemaString asks for

### DIFF
--- a/backend/plugin/schema/oracle/generate_migration_record_test.go
+++ b/backend/plugin/schema/oracle/generate_migration_record_test.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
@@ -57,8 +56,7 @@ var oracleGeneratedName = regexp.MustCompile(`ISEQ\$\$_[0-9]+|SYS_C[0-9]+`)
 func TestRecordGenerateMigrationFixtures(t *testing.T) {
 	ctx := context.Background()
 
-	container := testcontainer.GetTestOracleContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedOracleContainer(t)
 	systemDB := container.GetDB()
 
 	require.NoError(t, os.MkdirAll(generateMigrationFixtureDir, 0o755))

--- a/backend/plugin/schema/oracle/get_database_definition.go
+++ b/backend/plugin/schema/oracle/get_database_definition.go
@@ -305,14 +305,7 @@ func writeTable(buf *strings.Builder, table *storepb.TableMetadata) error {
 		}
 	}
 
-	// Write triggers for this table
-	for _, trigger := range table.Triggers {
-		if err := writeTrigger(buf, trigger); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return writeTriggers(buf, table.Triggers)
 }
 
 func writeIndex(buf *strings.Builder, table string, index *storepb.IndexMetadata) error {
@@ -710,7 +703,10 @@ func writeView(buf *strings.Builder, view *storepb.ViewMetadata) error {
 	if _, err := buf.WriteString("\n\n"); err != nil {
 		return err
 	}
-	return nil
+
+	// An INSTEAD OF trigger carries the view's DML behavior, so it belongs with
+	// the view the way writeTable emits a table's triggers.
+	return writeTriggers(buf, view.Triggers)
 }
 
 // writeMaterializedView writes a CREATE MATERIALIZED VIEW statement
@@ -735,7 +731,8 @@ func writeMaterializedView(buf *strings.Builder, view *storepb.MaterializedViewM
 	if _, err := buf.WriteString("\n\n"); err != nil {
 		return err
 	}
-	return nil
+
+	return writeTriggers(buf, view.Triggers)
 }
 
 // writeFunction writes a CREATE FUNCTION statement
@@ -780,6 +777,16 @@ func writeProcedure(buf *strings.Builder, procedure *storepb.ProcedureMetadata) 
 	}
 	if _, err := buf.WriteString("\n\n"); err != nil {
 		return err
+	}
+	return nil
+}
+
+// writeTriggers writes the CREATE TRIGGER statements owned by a table or view.
+func writeTriggers(buf *strings.Builder, triggers []*storepb.TriggerMetadata) error {
+	for _, trigger := range triggers {
+		if err := writeTrigger(buf, trigger); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/backend/plugin/schema/oracle/get_database_definition.go
+++ b/backend/plugin/schema/oracle/get_database_definition.go
@@ -689,32 +689,14 @@ func writeView(buf *strings.Builder, view *storepb.ViewMetadata) error {
 	if _, err := buf.WriteString(view.Name); err != nil {
 		return err
 	}
-	if _, err := buf.WriteString(`"`); err != nil {
-		return err
-	}
-	// ALL_VIEWS.TEXT is only the query, so a view declared as
-	// CREATE VIEW V (RENAMED) AS SELECT BASE ... loses its aliases unless the
-	// synced column names are written back out. Naming them changes nothing for
-	// a view that never had an explicit list.
-	if len(view.Columns) > 0 {
-		if _, err := buf.WriteString(` (`); err != nil {
-			return err
-		}
-		for i, column := range view.Columns {
-			if i > 0 {
-				if _, err := buf.WriteString(`, `); err != nil {
-					return err
-				}
-			}
-			if _, err := buf.WriteString(`"` + column.Name + `"`); err != nil {
-				return err
-			}
-		}
-		if _, err := buf.WriteString(`)`); err != nil {
-			return err
-		}
-	}
-	if _, err := buf.WriteString(` AS `); err != nil {
+	// The synced column names are deliberately not written back as an explicit
+	// list. They would restore the aliases of CREATE VIEW V (RENAMED) AS SELECT
+	// BASE ..., which ALL_VIEWS.TEXT does not carry, but getTableColumns drops
+	// invisible columns (COLUMN_ID IS NULL, sync.go:485) while the query keeps
+	// their expressions -- so a view with an invisible column would get fewer
+	// names than output columns and fail with ORA-01730. Losing an alias beats
+	// emitting DDL that cannot run.
+	if _, err := buf.WriteString(`" AS `); err != nil {
 		return err
 	}
 	if _, err := buf.WriteString(view.Definition); err != nil {

--- a/backend/plugin/schema/oracle/get_database_definition.go
+++ b/backend/plugin/schema/oracle/get_database_definition.go
@@ -8,9 +8,17 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
 
+// Oracle registers no schema definition: a schema is a user, one per database,
+// so GetDatabaseDefinition below already renders it. GetSchemaString's SCHEMA
+// case therefore stays unsupported here, as it is for MSSQL, MySQL and TiDB.
 func init() {
 	schema.RegisterGetDatabaseDefinition(storepb.Engine_ORACLE, GetDatabaseDefinition)
 	schema.RegisterGetTableDefinition(storepb.Engine_ORACLE, GetTableDefinition)
+	schema.RegisterGetViewDefinition(storepb.Engine_ORACLE, GetViewDefinition)
+	schema.RegisterGetMaterializedViewDefinition(storepb.Engine_ORACLE, GetMaterializedViewDefinition)
+	schema.RegisterGetFunctionDefinition(storepb.Engine_ORACLE, GetFunctionDefinition)
+	schema.RegisterGetProcedureDefinition(storepb.Engine_ORACLE, GetProcedureDefinition)
+	schema.RegisterGetSequenceDefinition(storepb.Engine_ORACLE, GetSequenceDefinition)
 }
 
 func GetDatabaseDefinition(_ schema.GetDefinitionContext, to *storepb.DatabaseSchemaMetadata) (string, error) {
@@ -171,6 +179,62 @@ func GetDatabaseDefinition(_ schema.GetDefinitionContext, to *storepb.DatabaseSc
 func GetTableDefinition(_ string, table *storepb.TableMetadata, _ []*storepb.SequenceMetadata) (string, error) {
 	var buf strings.Builder
 	if err := writeTable(&buf, table); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// The single-object definitions below all ignore the schema argument: Oracle has
+// one schema per database and the writers emit unqualified names, matching
+// GetTableDefinition and the whole-database output.
+
+func GetViewDefinition(_ string, view *storepb.ViewMetadata) (string, error) {
+	var buf strings.Builder
+	if err := writeView(&buf, view); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func GetMaterializedViewDefinition(_ string, view *storepb.MaterializedViewMetadata) (string, error) {
+	var buf strings.Builder
+	if err := writeMaterializedView(&buf, view); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func GetFunctionDefinition(_ string, function *storepb.FunctionMetadata) (string, error) {
+	var buf strings.Builder
+	if err := writeFunction(&buf, function); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+func GetProcedureDefinition(_ string, procedure *storepb.ProcedureMetadata) (string, error) {
+	var buf strings.Builder
+	if err := writeProcedure(&buf, procedure); err != nil {
+		return "", err
+	}
+
+	return buf.String(), nil
+}
+
+// GetSequenceDefinition skips the sequences Oracle creates for identity columns,
+// the way the whole-database output does: they belong to their table's DDL and
+// cannot be created independently.
+func GetSequenceDefinition(_ string, sequence *storepb.SequenceMetadata) (string, error) {
+	if strings.HasPrefix(sequence.Name, "ISEQ$$_") {
+		return "", nil
+	}
+
+	var buf strings.Builder
+	if err := writeSequence(&buf, sequence); err != nil {
 		return "", err
 	}
 

--- a/backend/plugin/schema/oracle/get_database_definition.go
+++ b/backend/plugin/schema/oracle/get_database_definition.go
@@ -8,9 +8,17 @@ import (
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
 
-// Oracle registers no schema definition: a schema is a user, one per database,
-// so GetDatabaseDefinition below already renders it. GetSchemaString's SCHEMA
-// case therefore stays unsupported here, as it is for MSSQL, MySQL and TiDB.
+// Two of GetSchemaString's object types are deliberately left unregistered.
+//
+// SCHEMA: an Oracle schema is a user, one per database, so its definition is the
+// database definition GetDatabaseDefinition already renders. Only pg registers a
+// schema definition; MSSQL, MySQL and TiDB have real schemas and do not.
+//
+// SEQUENCE: getSequences in backend/plugin/db/oracle/sync.go selects only
+// SEQUENCE_NAME, so synced sequences carry no Start, Increment, MaxValue or
+// Cycle. Rendering one would emit a bare CREATE SEQUENCE that silently drops the
+// real increment and bounds. Registering it has to wait for the sync to read
+// those columns.
 func init() {
 	schema.RegisterGetDatabaseDefinition(storepb.Engine_ORACLE, GetDatabaseDefinition)
 	schema.RegisterGetTableDefinition(storepb.Engine_ORACLE, GetTableDefinition)
@@ -18,7 +26,6 @@ func init() {
 	schema.RegisterGetMaterializedViewDefinition(storepb.Engine_ORACLE, GetMaterializedViewDefinition)
 	schema.RegisterGetFunctionDefinition(storepb.Engine_ORACLE, GetFunctionDefinition)
 	schema.RegisterGetProcedureDefinition(storepb.Engine_ORACLE, GetProcedureDefinition)
-	schema.RegisterGetSequenceDefinition(storepb.Engine_ORACLE, GetSequenceDefinition)
 }
 
 func GetDatabaseDefinition(_ schema.GetDefinitionContext, to *storepb.DatabaseSchemaMetadata) (string, error) {
@@ -219,22 +226,6 @@ func GetFunctionDefinition(_ string, function *storepb.FunctionMetadata) (string
 func GetProcedureDefinition(_ string, procedure *storepb.ProcedureMetadata) (string, error) {
 	var buf strings.Builder
 	if err := writeProcedure(&buf, procedure); err != nil {
-		return "", err
-	}
-
-	return buf.String(), nil
-}
-
-// GetSequenceDefinition skips the sequences Oracle creates for identity columns,
-// the way the whole-database output does: they belong to their table's DDL and
-// cannot be created independently.
-func GetSequenceDefinition(_ string, sequence *storepb.SequenceMetadata) (string, error) {
-	if strings.HasPrefix(sequence.Name, "ISEQ$$_") {
-		return "", nil
-	}
-
-	var buf strings.Builder
-	if err := writeSequence(&buf, sequence); err != nil {
 		return "", err
 	}
 

--- a/backend/plugin/schema/oracle/get_database_definition.go
+++ b/backend/plugin/schema/oracle/get_database_definition.go
@@ -689,7 +689,32 @@ func writeView(buf *strings.Builder, view *storepb.ViewMetadata) error {
 	if _, err := buf.WriteString(view.Name); err != nil {
 		return err
 	}
-	if _, err := buf.WriteString(`" AS `); err != nil {
+	if _, err := buf.WriteString(`"`); err != nil {
+		return err
+	}
+	// ALL_VIEWS.TEXT is only the query, so a view declared as
+	// CREATE VIEW V (RENAMED) AS SELECT BASE ... loses its aliases unless the
+	// synced column names are written back out. Naming them changes nothing for
+	// a view that never had an explicit list.
+	if len(view.Columns) > 0 {
+		if _, err := buf.WriteString(` (`); err != nil {
+			return err
+		}
+		for i, column := range view.Columns {
+			if i > 0 {
+				if _, err := buf.WriteString(`, `); err != nil {
+					return err
+				}
+			}
+			if _, err := buf.WriteString(`"` + column.Name + `"`); err != nil {
+				return err
+			}
+		}
+		if _, err := buf.WriteString(`)`); err != nil {
+			return err
+		}
+	}
+	if _, err := buf.WriteString(` AS `); err != nil {
 		return err
 	}
 	if _, err := buf.WriteString(view.Definition); err != nil {

--- a/backend/plugin/schema/oracle/get_database_definition_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_test.go
@@ -112,91 +112,84 @@ func TestGetTableDefinition(t *testing.T) {
 }
 
 // TestGetObjectDefinition covers the single-object definitions GetSchemaString
-// serves. Metadata shapes are taken from what Oracle actually reports: view and
-// materialized-view definitions are a bare SELECT, routine definitions start at
-// FUNCTION/PROCEDURE with no CREATE, and sequences carry attributes rather than
-// text.
+// serves. The metadata is shaped the way Oracle reports it: view and
+// materialized-view definitions are a bare SELECT, and routine definitions
+// start at FUNCTION/PROCEDURE with no CREATE of their own.
 func TestGetObjectDefinition(t *testing.T) {
-	t.Parallel()
-
-	t.Run("view", func(t *testing.T) {
-		t.Parallel()
-		got, err := GetViewDefinition("", &storepb.ViewMetadata{
-			Name:       "DEPT_EMPLOYEE_COUNT",
-			Definition: "SELECT D.ID AS DEPT_ID, COUNT(E.ID) AS EMP_COUNT\nFROM DEPARTMENTS D",
-		})
-		require.NoError(t, err)
-		require.Equal(t, `CREATE VIEW "DEPT_EMPLOYEE_COUNT" AS SELECT D.ID AS DEPT_ID, COUNT(E.ID) AS EMP_COUNT
+	tests := []struct {
+		name string
+		get  func() (string, error)
+		want string
+	}{
+		{
+			name: "view",
+			get: func() (string, error) {
+				return GetViewDefinition("", &storepb.ViewMetadata{
+					Name:       "DEPT_EMPLOYEE_COUNT",
+					Definition: "SELECT D.ID AS DEPT_ID, COUNT(E.ID) AS EMP_COUNT\nFROM DEPARTMENTS D",
+				})
+			},
+			want: `CREATE VIEW "DEPT_EMPLOYEE_COUNT" AS SELECT D.ID AS DEPT_ID, COUNT(E.ID) AS EMP_COUNT
 FROM DEPARTMENTS D;
 
-`, got)
-	})
+`,
+		},
+		{
+			name: "materialized view",
+			get: func() (string, error) {
+				return GetMaterializedViewDefinition("", &storepb.MaterializedViewMetadata{
+					Name:       "PRODUCT_STATS",
+					Definition: "SELECT PRODUCT_ID, COUNT(*) AS ORDER_COUNT FROM ORDERS GROUP BY PRODUCT_ID",
+				})
+			},
+			want: `CREATE MATERIALIZED VIEW "PRODUCT_STATS" AS SELECT PRODUCT_ID, COUNT(*) AS ORDER_COUNT FROM ORDERS GROUP BY PRODUCT_ID;
 
-	t.Run("materialized view", func(t *testing.T) {
-		t.Parallel()
-		got, err := GetMaterializedViewDefinition("", &storepb.MaterializedViewMetadata{
-			Name:       "PRODUCT_STATS",
-			Definition: "SELECT PRODUCT_ID, COUNT(*) AS ORDER_COUNT FROM ORDERS GROUP BY PRODUCT_ID",
-		})
-		require.NoError(t, err)
-		require.Equal(t, `CREATE MATERIALIZED VIEW "PRODUCT_STATS" AS SELECT PRODUCT_ID, COUNT(*) AS ORDER_COUNT FROM ORDERS GROUP BY PRODUCT_ID;
-
-`, got)
-	})
-
-	t.Run("function gains the CREATE OR REPLACE prefix", func(t *testing.T) {
-		t.Parallel()
-		got, err := GetFunctionDefinition("", &storepb.FunctionMetadata{
-			Name:       "CALCULATE_DISCOUNT",
-			Definition: "FUNCTION CALCULATE_DISCOUNT(AMOUNT NUMBER)\nRETURN NUMBER\nIS\nBEGIN\n    RETURN AMOUNT * 0.1;\nEND;",
-		})
-		require.NoError(t, err)
-		require.Equal(t, `CREATE OR REPLACE FUNCTION CALCULATE_DISCOUNT(AMOUNT NUMBER)
+`,
+		},
+		{
+			// ALL_SOURCE hands back the body starting at FUNCTION, so the
+			// CREATE OR REPLACE prefix has to be supplied here.
+			name: "function gains the CREATE OR REPLACE prefix",
+			get: func() (string, error) {
+				return GetFunctionDefinition("", &storepb.FunctionMetadata{
+					Name:       "CALCULATE_DISCOUNT",
+					Definition: "FUNCTION CALCULATE_DISCOUNT(AMOUNT NUMBER)\nRETURN NUMBER\nIS\nBEGIN\n    RETURN AMOUNT * 0.1;\nEND;",
+				})
+			},
+			want: `CREATE OR REPLACE FUNCTION CALCULATE_DISCOUNT(AMOUNT NUMBER)
 RETURN NUMBER
 IS
 BEGIN
     RETURN AMOUNT * 0.1;
 END;
 
-`, got)
-	})
-
-	t.Run("procedure gains the CREATE OR REPLACE prefix", func(t *testing.T) {
-		t.Parallel()
-		got, err := GetProcedureDefinition("", &storepb.ProcedureMetadata{
-			Name:       "LOG_AUDIT",
-			Definition: "PROCEDURE LOG_AUDIT(P_TABLE_NAME VARCHAR2)\nIS\nBEGIN\n    NULL;\nEND;",
-		})
-		require.NoError(t, err)
-		require.Equal(t, `CREATE OR REPLACE PROCEDURE LOG_AUDIT(P_TABLE_NAME VARCHAR2)
+`,
+		},
+		{
+			name: "procedure gains the CREATE OR REPLACE prefix",
+			get: func() (string, error) {
+				return GetProcedureDefinition("", &storepb.ProcedureMetadata{
+					Name:       "LOG_AUDIT",
+					Definition: "PROCEDURE LOG_AUDIT(P_TABLE_NAME VARCHAR2)\nIS\nBEGIN\n    NULL;\nEND;",
+				})
+			},
+			want: `CREATE OR REPLACE PROCEDURE LOG_AUDIT(P_TABLE_NAME VARCHAR2)
 IS
 BEGIN
     NULL;
 END;
 
-`, got)
-	})
+`,
+		},
+	}
 
-	t.Run("sequence", func(t *testing.T) {
-		t.Parallel()
-		got, err := GetSequenceDefinition("", &storepb.SequenceMetadata{
-			Name:      "ORDER_SEQ",
-			Start:     "100",
-			Increment: "2",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.get()
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
-		require.NoError(t, err)
-		require.Equal(t, "CREATE SEQUENCE \"ORDER_SEQ\" START WITH 100 INCREMENT BY 2;\n\n", got)
-	})
-
-	// Oracle creates these for identity columns. They belong to their table's
-	// DDL and cannot be created on their own, so the whole-database output skips
-	// them and so does this.
-	t.Run("identity-column sequence is skipped", func(t *testing.T) {
-		t.Parallel()
-		got, err := GetSequenceDefinition("", &storepb.SequenceMetadata{Name: "ISEQ$$_73349"})
-		require.NoError(t, err)
-		require.Empty(t, got)
-	})
+	}
 }
 
 // TestObjectDefinitionsRegisteredForOracle goes through the schema registry
@@ -206,26 +199,39 @@ END;
 // supportGetStringSchema on the frontend lists ORACLE and offers "view schema
 // text" on views.
 func TestObjectDefinitionsRegisteredForOracle(t *testing.T) {
-	t.Parallel()
-
-	view := &storepb.ViewMetadata{Name: "V", Definition: "SELECT 1 FROM DUAL"}
-	materializedView := &storepb.MaterializedViewMetadata{Name: "MV", Definition: "SELECT 1 FROM DUAL"}
-	function := &storepb.FunctionMetadata{Name: "F", Definition: "FUNCTION F RETURN NUMBER IS BEGIN RETURN 1; END;"}
-	procedure := &storepb.ProcedureMetadata{Name: "P", Definition: "PROCEDURE P IS BEGIN NULL; END;"}
-	sequence := &storepb.SequenceMetadata{Name: "S", Start: "1"}
-
-	for name, get := range map[string]func() (string, error){
-		"view": func() (string, error) { return schema.GetViewDefinition(storepb.Engine_ORACLE, "", view) },
-		"materializedView": func() (string, error) {
-			return schema.GetMaterializedViewDefinition(storepb.Engine_ORACLE, "", materializedView)
+	tests := []struct {
+		name string
+		get  func() (string, error)
+	}{
+		{
+			name: "view",
+			get: func() (string, error) {
+				return schema.GetViewDefinition(storepb.Engine_ORACLE, "", &storepb.ViewMetadata{Name: "V", Definition: "SELECT 1 FROM DUAL"})
+			},
 		},
-		"function":  func() (string, error) { return schema.GetFunctionDefinition(storepb.Engine_ORACLE, "", function) },
-		"procedure": func() (string, error) { return schema.GetProcedureDefinition(storepb.Engine_ORACLE, "", procedure) },
-		"sequence":  func() (string, error) { return schema.GetSequenceDefinition(storepb.Engine_ORACLE, "", sequence) },
-	} {
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-			got, err := get()
+		{
+			name: "materialized view",
+			get: func() (string, error) {
+				return schema.GetMaterializedViewDefinition(storepb.Engine_ORACLE, "", &storepb.MaterializedViewMetadata{Name: "MV", Definition: "SELECT 1 FROM DUAL"})
+			},
+		},
+		{
+			name: "function",
+			get: func() (string, error) {
+				return schema.GetFunctionDefinition(storepb.Engine_ORACLE, "", &storepb.FunctionMetadata{Name: "F", Definition: "FUNCTION F RETURN NUMBER IS BEGIN RETURN 1; END;"})
+			},
+		},
+		{
+			name: "procedure",
+			get: func() (string, error) {
+				return schema.GetProcedureDefinition(storepb.Engine_ORACLE, "", &storepb.ProcedureMetadata{Name: "P", Definition: "PROCEDURE P IS BEGIN NULL; END;"})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.get()
 			require.NoError(t, err)
 			require.NotEmpty(t, got)
 		})

--- a/backend/plugin/schema/oracle/get_database_definition_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_test.go
@@ -182,25 +182,6 @@ END;
 `,
 		},
 		{
-			// ALL_VIEWS.TEXT carries only the query, so the aliases from
-			// CREATE VIEW V (RENAMED_ID, ...) survive solely in view.Columns.
-			name: "view keeps its explicit column aliases",
-			get: func() (string, error) {
-				return GetViewDefinition("", &storepb.ViewMetadata{
-					Name:       "ALIASED_VIEW",
-					Definition: "SELECT BASE_ID, BASE_LABEL\nFROM SOURCE_DATA",
-					Columns: []*storepb.ColumnMetadata{
-						{Name: "RENAMED_ID", Type: "NUMBER"},
-						{Name: "RENAMED_LABEL", Type: "VARCHAR2(50 BYTE)"},
-					},
-				})
-			},
-			want: `CREATE VIEW "ALIASED_VIEW" ("RENAMED_ID", "RENAMED_LABEL") AS SELECT BASE_ID, BASE_LABEL
-FROM SOURCE_DATA;
-
-`,
-		},
-		{
 			// An INSTEAD OF trigger carries the view's DML behavior. Dropping it
 			// would hand back schema text that recreates the view read-only.
 			// The body shape is constructTriggerBody's in the Oracle sync: it

--- a/backend/plugin/schema/oracle/get_database_definition_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_test.go
@@ -181,6 +181,35 @@ END;
 
 `,
 		},
+		{
+			// An INSTEAD OF trigger carries the view's DML behavior. Dropping it
+			// would hand back schema text that recreates the view read-only.
+			// The body shape is constructTriggerBody's in the Oracle sync: it
+			// prepends CREATE OR REPLACE TRIGGER to ALL_TRIGGERS.DESCRIPTION.
+			name: "view keeps its INSTEAD OF trigger",
+			get: func() (string, error) {
+				return GetViewDefinition("", &storepb.ViewMetadata{
+					Name:       "EMPLOYEE_VIEW",
+					Definition: "SELECT EMP_ID, EMAIL FROM EMPLOYEES",
+					Triggers: []*storepb.TriggerMetadata{
+						{
+							Name: "EMPLOYEE_VIEW_INSERT_TRG",
+							Body: "CREATE OR REPLACE TRIGGER EMPLOYEE_VIEW_INSERT_TRG\nINSTEAD OF INSERT ON EMPLOYEE_VIEW\nFOR EACH ROW\nBEGIN\n    NULL;\nEND;",
+						},
+					},
+				})
+			},
+			want: `CREATE VIEW "EMPLOYEE_VIEW" AS SELECT EMP_ID, EMAIL FROM EMPLOYEES;
+
+CREATE OR REPLACE TRIGGER EMPLOYEE_VIEW_INSERT_TRG
+INSTEAD OF INSERT ON EMPLOYEE_VIEW
+FOR EACH ROW
+BEGIN
+    NULL;
+END;
+
+`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/plugin/schema/oracle/get_database_definition_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
+	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
 
 func TestGetTableDefinition(t *testing.T) {
@@ -106,6 +107,127 @@ func TestGetTableDefinition(t *testing.T) {
 			got, err := GetTableDefinition("", tt.table, nil)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestGetObjectDefinition covers the single-object definitions GetSchemaString
+// serves. Metadata shapes are taken from what Oracle actually reports: view and
+// materialized-view definitions are a bare SELECT, routine definitions start at
+// FUNCTION/PROCEDURE with no CREATE, and sequences carry attributes rather than
+// text.
+func TestGetObjectDefinition(t *testing.T) {
+	t.Parallel()
+
+	t.Run("view", func(t *testing.T) {
+		t.Parallel()
+		got, err := GetViewDefinition("", &storepb.ViewMetadata{
+			Name:       "DEPT_EMPLOYEE_COUNT",
+			Definition: "SELECT D.ID AS DEPT_ID, COUNT(E.ID) AS EMP_COUNT\nFROM DEPARTMENTS D",
+		})
+		require.NoError(t, err)
+		require.Equal(t, `CREATE VIEW "DEPT_EMPLOYEE_COUNT" AS SELECT D.ID AS DEPT_ID, COUNT(E.ID) AS EMP_COUNT
+FROM DEPARTMENTS D;
+
+`, got)
+	})
+
+	t.Run("materialized view", func(t *testing.T) {
+		t.Parallel()
+		got, err := GetMaterializedViewDefinition("", &storepb.MaterializedViewMetadata{
+			Name:       "PRODUCT_STATS",
+			Definition: "SELECT PRODUCT_ID, COUNT(*) AS ORDER_COUNT FROM ORDERS GROUP BY PRODUCT_ID",
+		})
+		require.NoError(t, err)
+		require.Equal(t, `CREATE MATERIALIZED VIEW "PRODUCT_STATS" AS SELECT PRODUCT_ID, COUNT(*) AS ORDER_COUNT FROM ORDERS GROUP BY PRODUCT_ID;
+
+`, got)
+	})
+
+	t.Run("function gains the CREATE OR REPLACE prefix", func(t *testing.T) {
+		t.Parallel()
+		got, err := GetFunctionDefinition("", &storepb.FunctionMetadata{
+			Name:       "CALCULATE_DISCOUNT",
+			Definition: "FUNCTION CALCULATE_DISCOUNT(AMOUNT NUMBER)\nRETURN NUMBER\nIS\nBEGIN\n    RETURN AMOUNT * 0.1;\nEND;",
+		})
+		require.NoError(t, err)
+		require.Equal(t, `CREATE OR REPLACE FUNCTION CALCULATE_DISCOUNT(AMOUNT NUMBER)
+RETURN NUMBER
+IS
+BEGIN
+    RETURN AMOUNT * 0.1;
+END;
+
+`, got)
+	})
+
+	t.Run("procedure gains the CREATE OR REPLACE prefix", func(t *testing.T) {
+		t.Parallel()
+		got, err := GetProcedureDefinition("", &storepb.ProcedureMetadata{
+			Name:       "LOG_AUDIT",
+			Definition: "PROCEDURE LOG_AUDIT(P_TABLE_NAME VARCHAR2)\nIS\nBEGIN\n    NULL;\nEND;",
+		})
+		require.NoError(t, err)
+		require.Equal(t, `CREATE OR REPLACE PROCEDURE LOG_AUDIT(P_TABLE_NAME VARCHAR2)
+IS
+BEGIN
+    NULL;
+END;
+
+`, got)
+	})
+
+	t.Run("sequence", func(t *testing.T) {
+		t.Parallel()
+		got, err := GetSequenceDefinition("", &storepb.SequenceMetadata{
+			Name:      "ORDER_SEQ",
+			Start:     "100",
+			Increment: "2",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "CREATE SEQUENCE \"ORDER_SEQ\" START WITH 100 INCREMENT BY 2;\n\n", got)
+	})
+
+	// Oracle creates these for identity columns. They belong to their table's
+	// DDL and cannot be created on their own, so the whole-database output skips
+	// them and so does this.
+	t.Run("identity-column sequence is skipped", func(t *testing.T) {
+		t.Parallel()
+		got, err := GetSequenceDefinition("", &storepb.SequenceMetadata{Name: "ISEQ$$_73349"})
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+}
+
+// TestObjectDefinitionsRegisteredForOracle goes through the schema registry
+// rather than calling the functions directly, because the registry lookup is
+// what was missing: GetSchemaString served only DATABASE and TABLE for Oracle
+// and returned "engine ORACLE is not supported" for the rest, while
+// supportGetStringSchema on the frontend lists ORACLE and offers "view schema
+// text" on views.
+func TestObjectDefinitionsRegisteredForOracle(t *testing.T) {
+	t.Parallel()
+
+	view := &storepb.ViewMetadata{Name: "V", Definition: "SELECT 1 FROM DUAL"}
+	materializedView := &storepb.MaterializedViewMetadata{Name: "MV", Definition: "SELECT 1 FROM DUAL"}
+	function := &storepb.FunctionMetadata{Name: "F", Definition: "FUNCTION F RETURN NUMBER IS BEGIN RETURN 1; END;"}
+	procedure := &storepb.ProcedureMetadata{Name: "P", Definition: "PROCEDURE P IS BEGIN NULL; END;"}
+	sequence := &storepb.SequenceMetadata{Name: "S", Start: "1"}
+
+	for name, get := range map[string]func() (string, error){
+		"view": func() (string, error) { return schema.GetViewDefinition(storepb.Engine_ORACLE, "", view) },
+		"materializedView": func() (string, error) {
+			return schema.GetMaterializedViewDefinition(storepb.Engine_ORACLE, "", materializedView)
+		},
+		"function":  func() (string, error) { return schema.GetFunctionDefinition(storepb.Engine_ORACLE, "", function) },
+		"procedure": func() (string, error) { return schema.GetProcedureDefinition(storepb.Engine_ORACLE, "", procedure) },
+		"sequence":  func() (string, error) { return schema.GetSequenceDefinition(storepb.Engine_ORACLE, "", sequence) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := get()
+			require.NoError(t, err)
+			require.NotEmpty(t, got)
 		})
 	}
 }

--- a/backend/plugin/schema/oracle/get_database_definition_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_test.go
@@ -182,6 +182,25 @@ END;
 `,
 		},
 		{
+			// ALL_VIEWS.TEXT carries only the query, so the aliases from
+			// CREATE VIEW V (RENAMED_ID, ...) survive solely in view.Columns.
+			name: "view keeps its explicit column aliases",
+			get: func() (string, error) {
+				return GetViewDefinition("", &storepb.ViewMetadata{
+					Name:       "ALIASED_VIEW",
+					Definition: "SELECT BASE_ID, BASE_LABEL\nFROM SOURCE_DATA",
+					Columns: []*storepb.ColumnMetadata{
+						{Name: "RENAMED_ID", Type: "NUMBER"},
+						{Name: "RENAMED_LABEL", Type: "VARCHAR2(50 BYTE)"},
+					},
+				})
+			},
+			want: `CREATE VIEW "ALIASED_VIEW" ("RENAMED_ID", "RENAMED_LABEL") AS SELECT BASE_ID, BASE_LABEL
+FROM SOURCE_DATA;
+
+`,
+		},
+		{
 			// An INSTEAD OF trigger carries the view's DML behavior. Dropping it
 			// would hand back schema text that recreates the view read-only.
 			// The body shape is constructTriggerBody's in the Oracle sync: it

--- a/backend/plugin/schema/oracle/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_testcontainer_test.go
@@ -85,20 +85,6 @@ END;
 `,
 			description: "A view whose INSTEAD OF trigger must survive the definition round trip",
 		},
-		{
-			name: "view_with_explicit_column_aliases",
-			initialSchema: `
-CREATE TABLE SOURCE_DATA (
-    BASE_ID NUMBER PRIMARY KEY,
-    BASE_LABEL VARCHAR2(50)
-);
-
-CREATE VIEW ALIASED_VIEW (RENAMED_ID, RENAMED_LABEL) AS
-SELECT BASE_ID, BASE_LABEL
-FROM SOURCE_DATA;
-`,
-			description: "A view declared with an explicit column list, which ALL_VIEWS.TEXT does not carry",
-		},
 	}
 
 	for _, tc := range testCases {

--- a/backend/plugin/schema/oracle/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_testcontainer_test.go
@@ -66,6 +66,28 @@ CREATE INDEX IDX_EMP_NAME ON EMPLOYEES(NAME);
 `,
 			description: "Basic tables with primary keys, foreign keys, unique constraints, check constraints, and indexes",
 		},
+		{
+			name: "view_with_instead_of_trigger",
+			initialSchema: `
+CREATE TABLE EMPLOYEES (
+    EMP_ID NUMBER PRIMARY KEY,
+    EMAIL VARCHAR2(100)
+);
+
+CREATE VIEW EMPLOYEE_VIEW AS
+SELECT EMP_ID, EMAIL
+FROM EMPLOYEES;
+
+CREATE OR REPLACE TRIGGER EMPLOYEE_VIEW_INSERT_TRG
+INSTEAD OF INSERT ON EMPLOYEE_VIEW
+FOR EACH ROW
+BEGIN
+    INSERT INTO EMPLOYEES (EMP_ID, EMAIL) VALUES (:NEW.EMP_ID, :NEW.EMAIL);
+END;
+/
+`,
+			description: "A view whose INSTEAD OF trigger must survive the definition round trip",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -144,6 +166,20 @@ CREATE INDEX IDX_EMP_NAME ON EMPLOYEES(NAME);
 // normalizeOracleMetadata handles Oracle-specific normalization for metadata comparison
 func normalizeOracleMetadata(metadata *storepb.DatabaseSchemaMetadata) {
 	for _, schema := range metadata.Schemas {
+		// A view's dependency columns record their owning Oracle user, and this
+		// test recreates the schema under a second user by construction, so the
+		// two can never match.
+		for _, view := range schema.Views {
+			for _, dependency := range view.DependencyColumns {
+				dependency.Schema = ""
+			}
+		}
+		for _, view := range schema.MaterializedViews {
+			for _, dependency := range view.DependencyColumns {
+				dependency.Schema = ""
+			}
+		}
+
 		for _, table := range schema.Tables {
 			for _, column := range table.Columns {
 				// Normalize system-generated sequence references in default expressions

--- a/backend/plugin/schema/oracle/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_testcontainer_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
@@ -28,9 +27,7 @@ func TestGetDatabaseDefinitionWithTestcontainer(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Get Oracle container from testcontainer utility
-	container := testcontainer.GetTestOracleContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedOracleContainer(t)
 
 	// Get SYSTEM database connection for user management
 	systemDB := container.GetDB()

--- a/backend/plugin/schema/oracle/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/oracle/get_database_definition_testcontainer_test.go
@@ -88,6 +88,20 @@ END;
 `,
 			description: "A view whose INSTEAD OF trigger must survive the definition round trip",
 		},
+		{
+			name: "view_with_explicit_column_aliases",
+			initialSchema: `
+CREATE TABLE SOURCE_DATA (
+    BASE_ID NUMBER PRIMARY KEY,
+    BASE_LABEL VARCHAR2(50)
+);
+
+CREATE VIEW ALIASED_VIEW (RENAMED_ID, RENAMED_LABEL) AS
+SELECT BASE_ID, BASE_LABEL
+FROM SOURCE_DATA;
+`,
+			description: "A view declared with an explicit column list, which ALL_VIEWS.TEXT does not carry",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/backend/plugin/schema/oracle/get_database_metadata_test.go
+++ b/backend/plugin/schema/oracle/get_database_metadata_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 )
@@ -744,9 +743,7 @@ COMMENT ON COLUMN ORDER_LINE_ITEMS.FULFILLMENT_STATUS IS 'Status: PENDING, PICKE
 func TestGetDatabaseMetadataWithTestcontainer(t *testing.T) {
 	ctx := context.Background()
 
-	// Start Oracle container
-	container := testcontainer.GetTestOracleContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedOracleContainer(t)
 
 	host := container.GetHost()
 	port := container.GetPort()

--- a/backend/plugin/schema/oracle/main_test.go
+++ b/backend/plugin/schema/oracle/main_test.go
@@ -1,0 +1,52 @@
+package oracle
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+)
+
+// The package shares one Oracle container, started on first use.
+//
+// Sharing it is worth a container start: the metadata and definition tests took
+// one each, and an Oracle Free start is around 12 s. Starting it lazily is what
+// keeps that saving from turning into a tax on everything else -- the
+// generate-migration goldens, the omni parser cases and the topological-order
+// cases need no engine at all, and a package-wide eager start would have made
+// `go test -run TestGenerateMigration` pay 12 s for a container it never opens.
+var (
+	oracleOnce      sync.Once
+	oracleContainer *testcontainer.Container
+	oracleErr       error
+)
+
+func TestMain(m *testing.M) {
+	defer func() {
+		if oracleContainer != nil {
+			oracleContainer.Close(context.Background())
+		}
+	}()
+	m.Run()
+}
+
+// sharedOracleContainer returns the package's Oracle container, starting it on
+// the first call. Tests keep isolating themselves with a per-test Oracle user,
+// which is what makes one container enough.
+func sharedOracleContainer(t *testing.T) *testcontainer.Container {
+	t.Helper()
+
+	oracleOnce.Do(func() {
+		container, err := testcontainer.GetOracleContainer(context.Background())
+		if err != nil {
+			oracleErr = err
+			return
+		}
+		oracleContainer = container
+	})
+	if oracleErr != nil {
+		t.Fatalf("failed to start the shared Oracle container: %v", oracleErr)
+	}
+	return oracleContainer
+}


### PR DESCRIPTION
## The bug

`GetSchemaString` switches over nine object types. Oracle registered handlers for **three** — unspecified, `DATABASE` and `TABLE` — so `SCHEMA`, `VIEW`, `MATERIALIZED_VIEW`, `FUNCTION`, `PROCEDURE` and `SEQUENCE` all fell through to the registry's `engine ORACLE is not supported`.

That was reachable from the product, not just the API. [`instance.ts:441`](frontend/src/utils/v1/instance.ts#L441) `supportGetStringSchema` lists `ORACLE`, and [`SchemaPane/actions.tsx:503`](frontend/src/modules/sql-editor/components/SchemaPane/actions.tsx#L503) puts a "view schema text" item on **views** whenever it returns true. So right-clicking a view on an Oracle instance in the SQL editor offered an action the backend could not serve. Every other engine in that list — MYSQL, OCEANBASE, POSTGRES, TIDB, CLICKHOUSE, MSSQL — registers `GetViewDefinition`.

## The fix

Four registrations and four wrappers: `VIEW`, `MATERIALIZED_VIEW`, `FUNCTION`, `PROCEDURE`, over the `write*` helpers the whole-database output already used. Oracle goes from **3 of 9** object types to **7 of 9**.

## Two fidelity bugs found while making views servable

Review surfaced two ways the generated view DDL was lossy. Both are fixed in the **writers**, not the wrappers, because the whole-database definition — and therefore the raw dump recorded on every Oracle sync — was losing them too:

**`INSTEAD OF` triggers were dropped.** `writeTable` has always emitted a table's triggers; `writeView` and `writeMaterializedView` never did, so schema text recreated the view read-only. Fixed in the writers via a shared `writeTriggers` helper, and proved against a real Oracle: `TestGetDatabaseDefinitionWithTestcontainer` gained a `view_with_instead_of_trigger` fixture that failed before and round-trips now.

A second fix in this area — writing the synced column names back as an explicit list, to restore the aliases of `CREATE VIEW V (RENAMED_ID) AS SELECT BASE_ID ...` — was **added and then reverted**. `getTableColumns` drops invisible columns while the query keeps their expressions, so a view with one gets fewer names than output columns. Probed on a real Oracle: `CREATE VIEW V1 (A, B INVISIBLE) AS SELECT A, B FROM T` is accepted, sync reports one column against a two-expression query, and the generated DDL would fail with ORA-01730. Nothing in the metadata distinguishes that from a view that simply has one column, so there is no guard to write. Losing an alias beats emitting DDL that cannot run.

## Two object types deliberately left unregistered

**`SEQUENCE`.** `getSequences` ([sync.go:1198](backend/plugin/db/oracle/sync.go#L1198)) selects only `SEQUENCE_NAME`, so a synced `SequenceMetadata` carries no `Start`, `Increment`, `MaxValue` or `Cycle`. Rendering one would emit `CREATE SEQUENCE "ORDER_SEQ";` for a sequence that really starts at 1000 and increments by 5 — DDL that looks right, runs, and quietly changes behavior. Registering it waits on the sync reading those columns.

**`SCHEMA`.** An Oracle schema is a user, one per database, so its definition *is* the database definition `DATABASE` already serves. Only pg registers `GetSchemaDefinition`; MSSQL, MySQL and TiDB have real schemas and don't.

## Also: one Oracle container for the package

The metadata and definition tests each started their own Oracle, and the fixture recorder a third under its build tag — about 12 s per start. A `TestMain` now owns one, shaped like `backend/store/main_test.go` but **started lazily**, because most of this package needs no engine and an eager start would make `go test -run TestGenerateMigration` pay 12 s for a container it never opens. That path still runs in 2.1 s.

Measured: polling docker through a full run saw exactly one distinct Oracle container id, max one concurrent, where there had been two. **Package 68.8 s → 58.2 s.** The tagged recorder was re-run on the shared container and reproduced its fixture byte-for-byte.

## Not a breaking change

These paths returned an error before; they now return content. Nothing removed or renamed. The dump changes are strictly additive fidelity — DDL that was lossy no longer is.

## Testing

Written to match the file they live in: `TestGetTableDefinition` above them uses a slice of cases with a plain `t.Run` loop and no `t.Parallel`, as does mysql's `get_database_definition_test.go`.

- `TestGetObjectDefinition` pins the rendering, with metadata shaped the way Oracle reports it — bare `SELECT` for views, `FUNCTION`/`PROCEDURE` with no `CREATE` prefix for routines, and trigger bodies in `constructTriggerBody`'s form
- `TestObjectDefinitionsRegisteredForOracle` goes through the `schema` registry, because **the registry lookup is where the bug was** — a direct-call test passes against the broken code
- `go test ./backend/plugin/schema/oracle/` — pass; `./backend/api/v1/` `TestAuditRedact`/`TestMCPGate` — pass
- `gofmt`, `go vet`, `golangci-lint` clean under both the default and `oracle_record` build tags
- `go build` of the server binary

Sections 3–6 of the pre-PR checklist skip: no `backend/store/`, `backend/migrator/`, `backend/tests/`, proto, or schema changes.

## Correction

An earlier revision of this description said the root `AGENTS.md` requires sharing one container per package via `TestMain`. It does not — `AGENTS.md` says nothing about containers. That rule is effort 2 of [`docs/design/backend-test-execution-time.md`](docs/design/backend-test-execution-time.md), scoped to the serial Postgres packages. The change above applies that pattern rather than fixing a stated violation.

## Follow-ups, filed not fixed

- **Identifier escaping.** `get_database_definition.go` quotes identifiers by concatenation in 22 places with no escaping helper, so a column named `A"B` yields invalid DDL — the table breaks before any view does. Needs a helper applied across this file and `generate_migration.go`, which quotes independently.
- **Materialized view options.** `MaterializedViewMetadata` has no refresh or build fields at all, so `REFRESH FAST ON COMMIT` is lost at sync time for `DATABASE`, the raw dump and `DiffMigration` alike. Needs proto plus driver work.
- **View column aliases and invisible columns.** `ALL_VIEWS.TEXT` carries only the query, and `getTableColumns` filters invisible columns out, so explicit aliases are lost and cannot be restored from the metadata as it stands. Needs invisible columns represented in the model.
- **Disabled triggers.** `getTriggers` does not select `ALL_TRIGGERS.STATUS` and `TriggerMetadata` has no field for it, so a disabled trigger is recreated enabled — already true for table triggers, which `writeTable` has always emitted. Needs the column in the sync, a field on the proto, and `ALTER TRIGGER ... DISABLE` in `writeTrigger`; fixes tables and views together.
- **Redshift.** `Engine.REDSHIFT` is also in `supportGetStringSchema`, and [`schema/redshift`](backend/plugin/schema/redshift/get_database_definition.go) registers only `GetDatabaseDefinition` — same bug on views, but its `writeViews` operates over the whole database and would need extracting first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

