### PR TITLE
test(schema): share one container per engine package

### DIFF
--- a/backend/plugin/schema/mssql/generate_migration_testcontainer_test.go
+++ b/backend/plugin/schema/mssql/generate_migration_testcontainer_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 	"github.com/bytebase/bytebase/backend/store/model"
@@ -33,8 +32,7 @@ func TestGenerateMigrationWithTestcontainer(t *testing.T) {
 	ctx := context.Background()
 
 	// Start shared MSSQL container for all subtests
-	container := testcontainer.GetTestMSSQLContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedMSSQLContainer(t)
 
 	// Test cases with various schema changes
 	testCases := []struct {

--- a/backend/plugin/schema/mssql/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/mssql/get_database_definition_testcontainer_test.go
@@ -9,7 +9,6 @@ import (
 	_ "github.com/microsoft/go-mssqldb"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
@@ -17,8 +16,7 @@ import (
 //nolint:tparallel
 func TestGetDatabaseDefinitionWithTestcontainer(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestMSSQLContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedMSSQLContainer(t)
 
 	testCases := []struct {
 		name      string

--- a/backend/plugin/schema/mssql/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/mssql/get_database_definition_testcontainer_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	_ "github.com/microsoft/go-mssqldb"
 	"github.com/stretchr/testify/require"
 
@@ -395,7 +396,7 @@ GO
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel() // Safe to parallelize - shared container, unique databases per test
 			// Use test name for database name - each test case has a unique name
-			databaseName := fmt.Sprintf("test_%s", strings.ReplaceAll(tc.name, " ", "_"))
+			databaseName := fmt.Sprintf("test_%s_%s", strings.ReplaceAll(tc.name, " ", "_"), strings.ReplaceAll(uuid.New().String(), "-", "_"))
 
 			// Create test database using container's master connection
 			_, err := container.GetDB().Exec(fmt.Sprintf("CREATE DATABASE [%s]", databaseName))
@@ -419,7 +420,7 @@ GO
 			require.NotEmpty(t, definitionX)
 
 			// Step 3: Create a new database and run the definition X
-			newDatabaseName := fmt.Sprintf("test_copy_%s", strings.ReplaceAll(tc.name, " ", "_"))
+			newDatabaseName := fmt.Sprintf("copy_%s", databaseName)
 
 			// Create new database using container's master connection
 			_, err = container.GetDB().Exec(fmt.Sprintf("CREATE DATABASE [%s]", newDatabaseName))

--- a/backend/plugin/schema/mssql/get_database_metadata_testcontainer_test.go
+++ b/backend/plugin/schema/mssql/get_database_metadata_testcontainer_test.go
@@ -9,15 +9,13 @@ import (
 	_ "github.com/microsoft/go-mssqldb"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
 
 //nolint:tparallel
 func TestGetDatabaseMetadataWithTestcontainer(t *testing.T) {
 	ctx := context.Background()
-	container := testcontainer.GetTestMSSQLContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedMSSQLContainer(t)
 
 	testCases := []struct {
 		name     string

--- a/backend/plugin/schema/mssql/get_database_metadata_testcontainer_test.go
+++ b/backend/plugin/schema/mssql/get_database_metadata_testcontainer_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	_ "github.com/microsoft/go-mssqldb"
 	"github.com/stretchr/testify/require"
 
@@ -644,7 +645,7 @@ GO
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel() // Safe to parallelize - shared container, unique databases per test
-			databaseName := fmt.Sprintf("test_%s", strings.ReplaceAll(tc.name, " ", "_"))
+			databaseName := fmt.Sprintf("test_%s_%s", strings.ReplaceAll(tc.name, " ", "_"), strings.ReplaceAll(uuid.New().String(), "-", "_"))
 
 			// Create test database using container's master connection
 			_, err := container.GetDB().Exec(fmt.Sprintf("CREATE DATABASE [%s]", databaseName))

--- a/backend/plugin/schema/mssql/main_test.go
+++ b/backend/plugin/schema/mssql/main_test.go
@@ -1,0 +1,50 @@
+package mssql
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+)
+
+// The package shares one SQL Server container, started on first use.
+//
+// Sharing it is worth a container start, and this package took three of them.
+// Starting it lazily is what keeps that saving from turning into a tax on the
+// tests that need no engine at all, which would otherwise pay for a container
+// they never open.
+var (
+	mssqlOnce      sync.Once
+	mssqlContainer *testcontainer.Container
+	mssqlErr       error
+)
+
+func TestMain(m *testing.M) {
+	defer func() {
+		if mssqlContainer != nil {
+			mssqlContainer.Close(context.Background())
+		}
+	}()
+	m.Run()
+}
+
+// sharedMSSQLContainer returns the package's SQL Server container, starting it on
+// the first call. Tests keep isolating themselves with a per-test database,
+// which is what makes one container enough.
+func sharedMSSQLContainer(t *testing.T) *testcontainer.Container {
+	t.Helper()
+
+	mssqlOnce.Do(func() {
+		container, err := testcontainer.GetMSSQLContainer(context.Background())
+		if err != nil {
+			mssqlErr = err
+			return
+		}
+		mssqlContainer = container
+	})
+	if mssqlErr != nil {
+		t.Fatalf("failed to start the shared SQL Server container: %v", mssqlErr)
+	}
+	return mssqlContainer
+}

--- a/backend/plugin/schema/mysql/generate_migration_testcontainer_test.go
+++ b/backend/plugin/schema/mysql/generate_migration_testcontainer_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
@@ -33,9 +32,7 @@ func TestGenerateMigrationWithTestcontainer(t *testing.T) {
 	ctx := context.Background()
 
 	// Start shared MySQL container for all subtests
-	container, err := testcontainer.GetTestMySQLContainer(ctx)
-	require.NoError(t, err)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedMySQLContainer(t)
 
 	// Test cases with various schema changes
 	testCases := []struct {
@@ -1695,7 +1692,7 @@ CREATE TABLE some_table (
 			// Step 1: Initialize the database schema and get schema result A
 			// Create a unique test database for parallel execution
 			testDBName := fmt.Sprintf("test_%s", strings.ReplaceAll(uuid.New().String(), "-", "_"))
-			_, err = container.GetDB().Exec(fmt.Sprintf("CREATE DATABASE `%s`", testDBName))
+			_, err := container.GetDB().Exec(fmt.Sprintf("CREATE DATABASE `%s`", testDBName))
 			require.NoError(t, err)
 
 			// Create MySQL driver for this test's database

--- a/backend/plugin/schema/mysql/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/mysql/get_database_definition_testcontainer_test.go
@@ -425,9 +425,12 @@ func TestGetDatabaseDefinitionWithConnectedDeps(t *testing.T) {
 		t.Skip("Skipping MySQL testcontainer test in short mode")
 	}
 
+	// Unique per run: TestMain keeps one container for the whole package, so a
+	// fixed name collides with itself under go test -count=2.
+	databaseName := fmt.Sprintf("test_complex_deps_%s", strings.ReplaceAll(uuid.New().String(), "-", "_"))
+
 	const (
-		databaseName = "test_complex_deps"
-		originalDDL  = `
+		originalDDL = `
 CREATE TABLE department (
 	id INT PRIMARY KEY AUTO_INCREMENT,
 	name VARCHAR(100) NOT NULL,

--- a/backend/plugin/schema/mysql/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/mysql/get_database_definition_testcontainer_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
@@ -28,9 +27,7 @@ func TestGetDatabaseDefinition(t *testing.T) {
 	ctx := context.Background()
 
 	// Start shared MySQL container for all subtests
-	container, err := testcontainer.GetTestMySQLContainer(ctx)
-	require.NoError(t, err)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedMySQLContainer(t)
 
 	type testCase struct {
 		description string
@@ -470,12 +467,10 @@ CREATE TABLE project_member (
 	ctx := context.Background()
 
 	// Start MySQL container
-	container, err := testcontainer.GetTestMySQLContainer(ctx)
-	require.NoError(t, err)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedMySQLContainer(t)
 
 	// Create test database
-	_, err = container.GetDB().Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", databaseName))
+	_, err := container.GetDB().Exec(fmt.Sprintf("CREATE DATABASE IF NOT EXISTS `%s`", databaseName))
 	require.NoError(t, err)
 
 	// Step 1: Initialize the database schema

--- a/backend/plugin/schema/mysql/get_database_metadata_testcontainer_test.go
+++ b/backend/plugin/schema/mysql/get_database_metadata_testcontainer_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/db"
 )
@@ -24,9 +23,7 @@ func TestGetDatabaseMetadataWithTestcontainer(t *testing.T) {
 	ctx := context.Background()
 
 	// Start shared MySQL container for all subtests
-	container, err := testcontainer.GetTestMySQLContainer(ctx)
-	require.NoError(t, err)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedMySQLContainer(t)
 
 	// Test cases with various MySQL features
 	testCases := []struct {

--- a/backend/plugin/schema/mysql/main_test.go
+++ b/backend/plugin/schema/mysql/main_test.go
@@ -1,0 +1,50 @@
+package mysql
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+)
+
+// The package shares one MySQL container, started on first use.
+//
+// Sharing it is worth a container start, and this package took three of them.
+// Starting it lazily is what keeps that saving from turning into a tax on the
+// tests that need no engine at all, which would otherwise pay for a container
+// they never open.
+var (
+	mysqlOnce      sync.Once
+	mysqlContainer *testcontainer.Container
+	mysqlErr       error
+)
+
+func TestMain(m *testing.M) {
+	defer func() {
+		if mysqlContainer != nil {
+			mysqlContainer.Close(context.Background())
+		}
+	}()
+	m.Run()
+}
+
+// sharedMySQLContainer returns the package's MySQL container, starting it on
+// the first call. Tests keep isolating themselves with a per-test database,
+// which is what makes one container enough.
+func sharedMySQLContainer(t *testing.T) *testcontainer.Container {
+	t.Helper()
+
+	mysqlOnce.Do(func() {
+		container, err := testcontainer.GetTestMySQLContainer(context.Background())
+		if err != nil {
+			mysqlErr = err
+			return
+		}
+		mysqlContainer = container
+	})
+	if mysqlErr != nil {
+		t.Fatalf("failed to start the shared MySQL container: %v", mysqlErr)
+	}
+	return mysqlContainer
+}

--- a/backend/plugin/schema/pg/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_testcontainer_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
@@ -431,7 +431,7 @@ CREATE TABLE cities (
 			t.Parallel()
 
 			// Create first database with original DDL using unique name
-			dbNameA := fmt.Sprintf("test_a_%s_%d", strings.ReplaceAll(tc.name, "-", "_"), time.Now().UnixNano()%1000000)
+			dbNameA := fmt.Sprintf("test_a_%s", strings.ReplaceAll(uuid.New().String(), "-", "_"))
 			_, err := pgContainer.GetDB().Exec(fmt.Sprintf("CREATE DATABASE %s", dbNameA))
 			require.NoError(t, err)
 
@@ -454,7 +454,7 @@ CREATE TABLE cities (
 			require.NotEmpty(t, generatedDDL, "generated DDL should not be empty")
 
 			// Create second database and apply generated DDL using unique name
-			dbNameB := fmt.Sprintf("test_b_%s_%d", strings.ReplaceAll(tc.name, "-", "_"), time.Now().UnixNano()%1000000)
+			dbNameB := fmt.Sprintf("test_b_%s", strings.ReplaceAll(uuid.New().String(), "-", "_"))
 			_, err = pgContainer.GetDB().Exec(fmt.Sprintf("CREATE DATABASE %s", dbNameB))
 			require.NoError(t, err)
 
@@ -914,7 +914,7 @@ func TestSyncCompositeTypesWithTestcontainer(t *testing.T) {
 
 	pgContainer := sharedPgContainer(t)
 
-	dbName := fmt.Sprintf("test_sync_composite_%d", time.Now().UnixNano()%1000000)
+	dbName := fmt.Sprintf("test_sync_composite_%s", strings.ReplaceAll(uuid.New().String(), "-", "_"))
 	_, err := pgContainer.GetDB().Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))
 	require.NoError(t, err)
 

--- a/backend/plugin/schema/pg/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/pg/get_database_definition_testcontainer_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
@@ -23,8 +22,7 @@ func TestGetDatabaseDefinitionWithTestcontainer(t *testing.T) {
 	ctx := context.Background()
 
 	// Get PostgreSQL container from testcontainer.go
-	pgContainer := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { pgContainer.Close(ctx) })
+	pgContainer := sharedPgContainer(t)
 
 	// Test cases with various PostgreSQL features
 	testCases := []struct {
@@ -914,8 +912,7 @@ func compareEnumsDef(t *testing.T, enumsA, enumsB []*storepb.EnumTypeMetadata) {
 func TestSyncCompositeTypesWithTestcontainer(t *testing.T) {
 	ctx := context.Background()
 
-	pgContainer := testcontainer.GetTestPgContainer(ctx, t)
-	t.Cleanup(func() { pgContainer.Close(ctx) })
+	pgContainer := sharedPgContainer(t)
 
 	dbName := fmt.Sprintf("test_sync_composite_%d", time.Now().UnixNano()%1000000)
 	_, err := pgContainer.GetDB().Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))

--- a/backend/plugin/schema/pg/main_test.go
+++ b/backend/plugin/schema/pg/main_test.go
@@ -1,0 +1,50 @@
+package pg
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+)
+
+// The package shares one PostgreSQL container, started on first use.
+//
+// Sharing it is worth a container start, and this package took two of them.
+// Starting it lazily is what keeps that saving from turning into a tax on the
+// tests that need no engine at all, which would otherwise pay for a container
+// they never open.
+var (
+	pgOnce      sync.Once
+	pgContainer *testcontainer.Container
+	pgErr       error
+)
+
+func TestMain(m *testing.M) {
+	defer func() {
+		if pgContainer != nil {
+			pgContainer.Close(context.Background())
+		}
+	}()
+	m.Run()
+}
+
+// sharedPgContainer returns the package's PostgreSQL container, starting it on
+// the first call. Tests keep isolating themselves with a per-test database,
+// which is what makes one container enough.
+func sharedPgContainer(t *testing.T) *testcontainer.Container {
+	t.Helper()
+
+	pgOnce.Do(func() {
+		container, err := testcontainer.GetPgContainer(context.Background())
+		if err != nil {
+			pgErr = err
+			return
+		}
+		pgContainer = container
+	})
+	if pgErr != nil {
+		t.Fatalf("failed to start the shared PostgreSQL container: %v", pgErr)
+	}
+	return pgContainer
+}

--- a/backend/plugin/schema/tidb/generate_migration_testcontainer_test.go
+++ b/backend/plugin/schema/tidb/generate_migration_testcontainer_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 	"github.com/bytebase/bytebase/backend/store/model"
@@ -30,8 +29,7 @@ func TestGenerateMigrationWithTestcontainer(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	container := testcontainer.GetTestTiDBContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedTiDBContainer(t)
 
 	// Test cases with various schema changes
 	testCases := []struct {

--- a/backend/plugin/schema/tidb/get_database_definition_testcontainer_test.go
+++ b/backend/plugin/schema/tidb/get_database_definition_testcontainer_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 	"github.com/bytebase/bytebase/backend/plugin/schema"
 )
@@ -26,8 +25,7 @@ func TestGetDatabaseDefinition(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	container := testcontainer.GetTestTiDBContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedTiDBContainer(t)
 
 	type testCase struct {
 		description string
@@ -244,8 +242,7 @@ func TestGetDatabaseDefinitionWithConnectedDeps(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	container := testcontainer.GetTestTiDBContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedTiDBContainer(t)
 
 	// Create unique test database using UUID
 	testDB := fmt.Sprintf("test_%s", strings.ReplaceAll(uuid.New().String(), "-", "_"))

--- a/backend/plugin/schema/tidb/get_database_metadata_testcontainer_test.go
+++ b/backend/plugin/schema/tidb/get_database_metadata_testcontainer_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
-	"github.com/bytebase/bytebase/backend/common/testcontainer"
 	storepb "github.com/bytebase/bytebase/backend/generated-go/store"
 )
 
@@ -23,8 +22,7 @@ func TestGetDatabaseMetadataWithTestcontainer(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	container := testcontainer.GetTestTiDBContainer(ctx, t)
-	t.Cleanup(func() { container.Close(ctx) })
+	container := sharedTiDBContainer(t)
 
 	// Test cases with various TiDB features
 	testCases := []struct {

--- a/backend/plugin/schema/tidb/main_test.go
+++ b/backend/plugin/schema/tidb/main_test.go
@@ -1,0 +1,50 @@
+package tidb
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/bytebase/bytebase/backend/common/testcontainer"
+)
+
+// The package shares one TiDB container, started on first use.
+//
+// Sharing it is worth a container start, and this package took four of them.
+// Starting it lazily is what keeps that saving from turning into a tax on the
+// tests that need no engine at all, which would otherwise pay for a container
+// they never open.
+var (
+	tidbOnce      sync.Once
+	tidbContainer *testcontainer.Container
+	tidbErr       error
+)
+
+func TestMain(m *testing.M) {
+	defer func() {
+		if tidbContainer != nil {
+			tidbContainer.Close(context.Background())
+		}
+	}()
+	m.Run()
+}
+
+// sharedTiDBContainer returns the package's TiDB container, starting it on
+// the first call. Tests keep isolating themselves with a per-test database,
+// which is what makes one container enough.
+func sharedTiDBContainer(t *testing.T) *testcontainer.Container {
+	t.Helper()
+
+	tidbOnce.Do(func() {
+		container, err := testcontainer.GetTiDBContainer(context.Background())
+		if err != nil {
+			tidbErr = err
+			return
+		}
+		tidbContainer = container
+	})
+	if tidbErr != nil {
+		t.Fatalf("failed to start the shared TiDB container: %v", tidbErr)
+	}
+	return tidbContainer
+}


### PR DESCRIPTION
## What

`pg`, `mysql`, `tidb` and `mssql` each started a container **per top-level test** — 2, 3, 4 and 3 of them, **12 in all**. A MySQL start is around 10 s and a Postgres one around 4 s, so most of these packages' wall clock was fixtures rather than assertions: `mysql` spent **41.4 s of wall on 25.5 s of subtest work**.

Each package gets a `TestMain` shaped like [`backend/store/main_test.go`](backend/store/main_test.go) — defer the close, bare `m.Run` — with the same **lazy start** the `oracle` package uses. Most of these packages is pure: mssql's yaml migration goldens, pg's SDL and regression tests, the walk-through cases. An eager start would have made every one of those pay for a container it never opens.

One container is enough because the tests already isolate themselves with a per-test database — by UUID everywhere except one pg case that uses a nanosecond suffix.

## Measured, not assumed

Container counts come from diffing `docker ps -a` across a run:

| Package | Containers before | After | Wall before | After |
|---|---:|---:|---:|---:|
| mssql | 3 | **1** | 39.4 s | 32.1 s |
| mysql | 3 | **1** | 41.4 s | 14.6 s |
| tidb | 4 | **1** | 7.7 s | 9.1 s |
| pg | 2 | **1** | 6.4 s | 8.3 s |
| **total** | **12** | **4** | **94.9 s** | **64.1 s** |

Two honesty notes on that table. This host had **unrelated postgres containers appearing and disappearing** during the combined run, so the combined census over-counted; pg was re-measured on its own and creates exactly one. And the same contention is the likely reason tidb and pg read slightly *higher* after — both are small enough that noise dominates. **The container counts are exact; the wall times are indicative.**

## One regression the review caught

Holding the container open breaks `go test -count=2`: a fresh container used to guarantee a clean instance per repetition, so fixed database names were safe. Five names had to become unique — mysql's `test_complex_deps` const, two mssql names derived from the test case name, and `test_copy_<case>`, which running `-count=2` found and the review had not named. pg's two `UnixNano()%1000000` suffixes went to UUIDs in the same pass: they didn't fail, but sharing a container is the first thing that makes collisions possible *between* tests rather than only within one.

`go test -count=2 -p=4` now passes for all four packages.

## Testing

- `go test ./backend/plugin/schema/{pg,mysql,tidb,mssql}/` — all pass, no failures
- `golangci-lint run ./backend/plugin/schema/...` — 0 issues
- `gofmt`, `go vet` clean
- `go build` of the server binary

Test files only — sections 2–6 of the pre-PR checklist skip.

## Not included, and why

The same survey looked at whether the rest of the Oracle work generalizes. Mostly it does not:

- **Golden conversion** (replacing container round-trips with recorded fixtures, as [#21344](https://github.com/bytebase/bytebase/pull/21344) did for Oracle) is only worth it for **mssql**, whose `generate_migration` test is 268 s of subtest work. mysql, tidb and pg are 25 s, 27 s and 6 s — their cost was the container starts this PR removes, not DDL.
- **Missing `GetSchemaString` registrations** ([#21348](https://github.com/bytebase/bytebase/pull/21348)) turned out to be Oracle-specific. The frontend only ever requests `TABLE` and `VIEW`, and pg, mysql, tidb and mssql all register both. The one remaining gap is **Redshift**, which is in `supportGetStringSchema` but registers only `GetDatabaseDefinition` — already filed on #21348.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
